### PR TITLE
fix(docs): api reference for `remaining` now displays remaining usage

### DIFF
--- a/apps/docs/api-reference/keys/update.mdx
+++ b/apps/docs/api-reference/keys/update.mdx
@@ -66,9 +66,7 @@ In milliseconds
 </ParamField>
 
 <ParamField body="remaining" type="int | null">
-  Update the expire time of a key.
-
-The expire time is a unix timestamp in milliseconds.
+  Update the remaining usage of a key.
 
 </ParamField>
 


### PR DESCRIPTION
## Changes proposed

- `remaining` had the parameter field of `expires`
- this is now updated to display `remaining`'s info

## Check List (Check all the boxes which are applicable)

- [x] I have updated the documentation accordingly.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.


## Screenshots 
Add all the screenshots which support your changes