### PR TITLE
Self heal if organization is an orphan

### DIFF
--- a/apps/web/app/(authenticated)/(app)/new/create-workspace.tsx
+++ b/apps/web/app/(authenticated)/(app)/new/create-workspace.tsx
@@ -59,7 +59,7 @@ export const CreateWorkspace: React.FC<Props> = ({ workspaces }) => {
     onError(err) {
       toast({
         title: "Error",
-        description: `An error occured while creating your workspace: ${err.message}`,
+        description: `An error occured while creating your workspace, please contact support.`,
         variant: "alert",
       });
     },

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -54,6 +54,12 @@ export default async function (req: NextRequest, evt: NextFetchEvent) {
         !["/app/stripe", "/app/apis", "/app", "/new"].includes(req.nextUrl.pathname)
       ) {
         const workspace = await findWorkspace({ tenantId: auth.orgId });
+        // if we end up here... something is wrong with the workspace and we should redirect to the new page.
+        // this should never happen.
+        if(!workspace) {
+          console.error("Workspace not found for orgId", auth.orgId);
+          return NextResponse.redirect(new URL("/new", req.url));
+        }
         if (workspace?.plan === "free") {
           return NextResponse.redirect(new URL("/app/stripe", req.url));
         }


### PR DESCRIPTION
## Fixes Issue

This PR self heals Unkey if some how an organization is orphaned (doesn't have a workspace). We will delete the organization out of Clerk and then have them recreate a pro workspace. 

This is a rare edge case, and should be better now we don't have slugs as well. 