### PR TITLE
fix(stripe webhook): stripe webhook by using a non empty string

### DIFF
--- a/apps/web/pages/api/v1/stripe/webhooks.ts
+++ b/apps/web/pages/api/v1/stripe/webhooks.ts
@@ -190,7 +190,7 @@ async function getUsers(tenantId: string): Promise<{ id: string; email: string; 
       }
       return {
         id: user.id,
-        name: user.firstName ?? user.username ?? "",
+        name: user.firstName ?? user.username ?? "there",
         email,
       };
     }),


### PR DESCRIPTION

## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation

## Description

This should now allow a the trial email to be sent if the user doesn't have a name or have a username but inserting there. An empty string "" seems to break the flow completely. So we replaced it with there

### A picture tells a thousand words (if any)

### Before this PR

{Please add a screenshot here}

### After this PR

{Please add a screenshot here}

### Related Issue (optional)

No issue but, related to alerting.
