### PR TITLE
KEY-132 feat: add name to key creations, key update and key table

### DIFF
--- a/apps/web/app/(authenticated)/(app)/app/apis/[apiId]/create-key.tsx
+++ b/apps/web/app/(authenticated)/(app)/app/apis/[apiId]/create-key.tsx
@@ -35,6 +35,7 @@ const formSchema = z.object({
   bytes: z.coerce.number().positive(),
   prefix: z.string().max(8).optional(),
   ownerId: z.string().optional(),
+  name: z.string().optional(),
   meta: z.record(z.unknown()).optional(),
   remaining: z.coerce.number().positive().optional(),
   expires: z
@@ -182,12 +183,12 @@ export const CreateKey: React.FC<Props> = ({ apiId }) => {
               <h2 className="mb-2 text-2xl">Create a new Key</h2>
               <Form {...form}>
                 <form className="max-w-6xl mx-auto" onSubmit={form.handleSubmit(onSubmit)}>
-                  <div className="flex gap-4 justify-evenly">
+                  <div className="flex flex-col md:flex-row gap-4 justify-evenly">
                     <FormField
                       control={form.control}
                       name="prefix"
                       render={({ field }) => (
-                        <FormItem>
+                        <FormItem className="w-full md:w-1/4">
                           <FormLabel>Prefix</FormLabel>
                           <FormControl>
                             <Input {...field} />
@@ -206,7 +207,7 @@ export const CreateKey: React.FC<Props> = ({ apiId }) => {
                       name="bytes"
                       rules={{ required: true }}
                       render={({ field }) => (
-                        <FormItem>
+                        <FormItem className="w-full md:w-1/4">
                           <FormLabel>Bytes</FormLabel>
                           <FormControl>
                             <Input type="number" {...field} />
@@ -221,7 +222,7 @@ export const CreateKey: React.FC<Props> = ({ apiId }) => {
                       control={form.control}
                       name="ownerId"
                       render={({ field }) => (
-                        <FormItem>
+                        <FormItem className="w-full md:w-1/4">
                           <FormLabel>Owner</FormLabel>
                           <FormControl>
                             <Input {...field} />
@@ -229,6 +230,22 @@ export const CreateKey: React.FC<Props> = ({ apiId }) => {
                           <FormDescription>
                             This is the id of the user or workspace in your system, so you can
                             identify users from an API key.
+                          </FormDescription>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                    <FormField
+                      control={form.control}
+                      name="name"
+                      render={({ field }) => (
+                        <FormItem className="w-full md:w-1/4">
+                          <FormLabel>Name</FormLabel>
+                          <FormControl>
+                            <Input {...field} />
+                          </FormControl>
+                          <FormDescription>
+                            To make it easier to identify a particular key, you can provide a name.
                           </FormDescription>
                           <FormMessage />
                         </FormItem>
@@ -345,7 +362,7 @@ export const CreateKey: React.FC<Props> = ({ apiId }) => {
                                           e.target.value = prettier;
                                           field.onChange(JSON.parse(e.target.value));
                                           form.clearErrors("meta");
-                                        } catch (_e) {}
+                                        } catch (_e) { }
                                       }}
                                       onChange={(e) => {
                                         try {

--- a/apps/web/app/(authenticated)/(app)/app/apis/[apiId]/create-key.tsx
+++ b/apps/web/app/(authenticated)/(app)/app/apis/[apiId]/create-key.tsx
@@ -362,7 +362,7 @@ export const CreateKey: React.FC<Props> = ({ apiId }) => {
                                           e.target.value = prettier;
                                           field.onChange(JSON.parse(e.target.value));
                                           form.clearErrors("meta");
-                                        } catch (_e) { }
+                                        } catch (_e) {}
                                       }}
                                       onChange={(e) => {
                                         try {

--- a/apps/web/app/(authenticated)/(app)/app/keys/[keyId]/settings/actions.ts
+++ b/apps/web/app/(authenticated)/(app)/app/keys/[keyId]/settings/actions.ts
@@ -205,5 +205,5 @@ export const updateKeyName = serverAction({
       .where(eq(schema.keys.id, input.keyId));
 
     revalidatePath(`/apps/keys/${input.keyId}`);
-  }
+  },
 });

--- a/apps/web/app/(authenticated)/(app)/app/keys/[keyId]/settings/actions.ts
+++ b/apps/web/app/(authenticated)/(app)/app/keys/[keyId]/settings/actions.ts
@@ -180,3 +180,30 @@ export const updateMetadata = serverAction({
     revalidatePath(`/apps/keys/${input.keyId}`);
   },
 });
+
+export const updateKeyName = serverAction({
+  input: z.object({
+    keyId: z.string(),
+    name: z.string().nullish(),
+  }),
+  handler: async ({ input, ctx }) => {
+    const key = await db.query.keys.findFirst({
+      where: eq(schema.keys.id, input.keyId),
+      with: {
+        workspace: true,
+      },
+    });
+    if (!key || key.workspace.tenantId !== ctx.tenantId) {
+      throw new Error("key not found");
+    }
+
+    await db
+      .update(schema.keys)
+      .set({
+        name: input.name ?? null,
+      })
+      .where(eq(schema.keys.id, input.keyId));
+
+    revalidatePath(`/apps/keys/${input.keyId}`);
+  }
+});

--- a/apps/web/app/(authenticated)/(app)/app/keys/[keyId]/settings/page.tsx
+++ b/apps/web/app/(authenticated)/(app)/app/keys/[keyId]/settings/page.tsx
@@ -7,9 +7,9 @@ import { notFound } from "next/navigation";
 import { DeleteKey } from "./delete-key";
 import { UpdateKeyExpiration } from "./update-key-expiration";
 import { UpdateKeyMetadata } from "./update-key-metadata";
+import { UpdateKeyName } from "./update-key-name";
 import { UpdateKeyRatelimit } from "./update-key-ratelimit";
 import { UpdateKeyRemaining } from "./update-key-remaining";
-import { UpdateKeyName } from "./update-key-name";
 export const revalidate = 0;
 
 type Props = {

--- a/apps/web/app/(authenticated)/(app)/app/keys/[keyId]/settings/page.tsx
+++ b/apps/web/app/(authenticated)/(app)/app/keys/[keyId]/settings/page.tsx
@@ -9,6 +9,7 @@ import { UpdateKeyExpiration } from "./update-key-expiration";
 import { UpdateKeyMetadata } from "./update-key-metadata";
 import { UpdateKeyRatelimit } from "./update-key-ratelimit";
 import { UpdateKeyRemaining } from "./update-key-remaining";
+import { UpdateKeyName } from "./update-key-name";
 export const revalidate = 0;
 
 type Props = {
@@ -36,6 +37,7 @@ export default async function SettingsPage(props: Props) {
       <UpdateKeyRatelimit apiKey={key} />
       <UpdateKeyExpiration apiKey={key} />
       <UpdateKeyMetadata apiKey={key} />
+      <UpdateKeyName apiKey={key} />
       <Card>
         <CardHeader>
           <CardTitle>Key ID</CardTitle>

--- a/apps/web/app/(authenticated)/(app)/app/keys/[keyId]/settings/update-key-name.tsx
+++ b/apps/web/app/(authenticated)/(app)/app/keys/[keyId]/settings/update-key-name.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { Button } from "@/components/ui/button";
-import React, { useState } from "react";
+import React from "react";
 import { experimental_useFormStatus as useFormStatus } from "react-dom";
 
 import { Loading } from "@/components/dashboard/loading";
@@ -50,7 +50,7 @@ export const UpdateKeyName: React.FC<Props> = ({ apiKey }) => {
         <CardHeader>
           <CardTitle>Name</CardTitle>
           <CardDescription>
-          To make it easier to identify a particular key, you can provide a name.
+            To make it easier to identify a particular key, you can provide a name.
           </CardDescription>
         </CardHeader>
         <CardContent className="flex justify-between item-center">

--- a/apps/web/app/(authenticated)/(app)/app/keys/[keyId]/settings/update-key-name.tsx
+++ b/apps/web/app/(authenticated)/(app)/app/keys/[keyId]/settings/update-key-name.tsx
@@ -54,13 +54,13 @@ export const UpdateKeyName: React.FC<Props> = ({ apiKey }) => {
           </CardDescription>
         </CardHeader>
         <CardContent className="flex justify-between item-center">
-          <div className={cn("flex flex-col space-y-2")}>
+          <div className={cn("flex flex-col space-y-2 w-full ")}>
             <input type="hidden" name="keyId" value={apiKey.id} />
-            <Label htmlFor="remaining">Remaining</Label>
+            <Label htmlFor="remaining">Name</Label>
             <Input
               type="string"
               name="name"
-              className="max-w-sm"
+              className="max-w-sm h-8"
               defaultValue={apiKey.name ?? ""}
               autoComplete="off"
             />

--- a/apps/web/app/(authenticated)/(app)/app/keys/[keyId]/settings/update-key-name.tsx
+++ b/apps/web/app/(authenticated)/(app)/app/keys/[keyId]/settings/update-key-name.tsx
@@ -1,0 +1,77 @@
+"use client";
+import { Button } from "@/components/ui/button";
+import React, { useState } from "react";
+import { experimental_useFormStatus as useFormStatus } from "react-dom";
+
+import { Loading } from "@/components/dashboard/loading";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useToast } from "@/components/ui/use-toast";
+import { cn } from "@/lib/utils";
+import { updateKeyName } from "./actions";
+type Props = {
+  apiKey: {
+    id: string;
+    workspaceId: string;
+    name: string | null;
+  };
+};
+
+export const UpdateKeyName: React.FC<Props> = ({ apiKey }) => {
+  const { toast } = useToast();
+  const { pending } = useFormStatus();
+  return (
+    <form
+      action={async (formData: FormData) => {
+        const res = await updateKeyName(formData);
+        if (res.error) {
+          toast({
+            title: "Error",
+            description: res.error,
+            variant: "alert",
+          });
+          return;
+        }
+        toast({
+          title: "Success",
+          description: "Remaining uses updated",
+        });
+      }}
+    >
+      <Card>
+        <CardHeader>
+          <CardTitle>Name</CardTitle>
+          <CardDescription>
+          To make it easier to identify a particular key, you can provide a name.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex justify-between item-center">
+          <div className={cn("flex flex-col space-y-2")}>
+            <input type="hidden" name="keyId" value={apiKey.id} />
+            <Label htmlFor="remaining">Remaining</Label>
+            <Input
+              type="string"
+              name="name"
+              className="max-w-sm"
+              defaultValue={apiKey.name ?? ""}
+              autoComplete="off"
+            />
+          </div>
+        </CardContent>
+        <CardFooter className="justify-between">
+          <Button variant={pending ? "disabled" : "primary"} type="submit" disabled={pending}>
+            {pending ? <Loading /> : "Save"}
+          </Button>
+        </CardFooter>
+      </Card>
+    </form>
+  );
+};

--- a/apps/web/components/dashboard/api-key-table/index.tsx
+++ b/apps/web/components/dashboard/api-key-table/index.tsx
@@ -35,6 +35,7 @@ type Column = {
   createdAt: Date;
   expires: Date | null;
   ownerId: string | null;
+  name: string | null;
   ratelimitType: string | null;
   ratelimitLimit: number | null;
   ratelimitRefillRate: number | null;
@@ -145,6 +146,16 @@ export const ApiKeyTable: React.FC<Props> = ({ data }) => {
       cell: ({ row }) =>
         row.original.ownerId ? (
           <Badge variant="secondary">{row.original.ownerId}</Badge>
+        ) : (
+          <Minus className="w-4 h-4 text-gray-300" />
+        ),
+    },
+    {
+      accessorKey: "name",
+      header: "Name",
+      cell: ({ row }) =>
+        row.original.name ? (
+          <Badge variant="secondary">{row.original.name}</Badge>
         ) : (
           <Minus className="w-4 h-4 text-gray-300" />
         ),

--- a/apps/web/lib/trpc/routers/key.ts
+++ b/apps/web/lib/trpc/routers/key.ts
@@ -17,7 +17,7 @@ export const keyRouter = t.router({
         meta: z.record(z.unknown()).optional(),
         remaining: z.number().int().positive().optional(),
         expires: z.number().int().nullish(), // unix timestamp in milliseconds
-
+        name: z.string().optional(),
         ratelimit: z
           .object({
             type: z.enum(["consistent", "fast"]),
@@ -47,6 +47,7 @@ export const keyRouter = t.router({
 
       const { error, result } = await unkeyScoped(newRootKey.result.key).keys.create({
         apiId: input.apiId,
+        name: input.name ?? undefined,
         prefix: input.prefix,
         byteLength: input.bytesLength,
         ownerId: input.ownerId ?? undefined,


### PR DESCRIPTION

## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [ ] 🐛 Bug fix
- [X ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation

## Description

This adds the ability to add a name to key creation, to key update and the key table. Allowing users to identify a key quickly.

### A picture tells a thousand words (if any)

### Before this PR

Table: 
![image](https://github.com/unkeyed/unkey/assets/45409975/4f4ef0b6-1c3a-4ac1-af80-f832abd1a4cd)

Key creation: 
![image](https://github.com/unkeyed/unkey/assets/45409975/a30d9e7f-7f96-4e97-b306-580caaa1f151)

Key Update:

![image](https://github.com/unkeyed/unkey/assets/45409975/c5e914a7-be12-44a2-a5f6-4356c230a721)


### After this PR

Table: 
![image](https://github.com/unkeyed/unkey/assets/45409975/3b523bc2-1fdd-4161-8929-eff2be14b316)

Creation: 
![image](https://github.com/unkeyed/unkey/assets/45409975/1131bd59-46ce-4a16-b84b-936138ecdc01)

Updates: 
![image](https://github.com/unkeyed/unkey/assets/45409975/6631d798-b258-4cc6-8d4a-3a08cddf9569)


### Related Issue (optional)

<!--- Please link to the issue here: -->
