### PR TITLE
chore: implement/sync url filter params for templates

### DIFF
--- a/apps/web/app/(landing)/templates/page.tsx
+++ b/apps/web/app/(landing)/templates/page.tsx
@@ -15,24 +15,16 @@ import { Input } from "@/components/ui/input";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { ExternalLink, VenetianMask } from "lucide-react";
 import Link from "next/link";
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { Framework, Language, templates } from "./data";
-
-const schema = z.object({
-  search: z.string().optional(),
-  frameworks: z.array(z.string()),
-  languages: z.array(z.string()),
-});
+import { TemplatesFormValues, getDefaulTemplatesFormValues, schema, updateUrl } from "@/lib/templates-form";
 
 export default function Templates() {
-  const form = useForm<z.infer<typeof schema>>({
+  const form = useForm<TemplatesFormValues>({
     resolver: zodResolver(schema),
-    defaultValues: {
-      frameworks: [],
-      languages: [],
-    },
+    defaultValues: getDefaulTemplatesFormValues(),
     reValidateMode: "onChange",
   });
 
@@ -56,6 +48,11 @@ export default function Templates() {
   }, {} as Record<Framework, number>);
 
   const fields = form.watch();
+
+  useEffect(() => {
+    updateUrl(fields);
+  }, [fields])
+  
   const filteredTemplates = useMemo(
     () =>
       Object.entries(templates).reduce((acc, [id, template]) => {

--- a/apps/web/lib/templates-form.ts
+++ b/apps/web/lib/templates-form.ts
@@ -1,0 +1,91 @@
+import { z } from "zod";
+import { isBrowser } from "./utils";
+
+/**
+* Form values for the templates page.
+*/
+export const schema = z.object({
+  search: z.string().optional(),
+  frameworks: z.array(z.string()),
+  languages: z.array(z.string()),
+});
+
+/**
+ * Infer the type from the schema.
+ */
+export type TemplatesFormValues = z.infer<typeof schema>;
+
+/**
+ * Get default form values from URL query params.
+ */
+export const getDefaulTemplatesFormValues = () => {
+  if (!isBrowser) {
+    return {
+      search: undefined,
+      frameworks: [],
+      languages: [],
+    };
+  }
+
+  const searchParams = new URLSearchParams(window.location.search);
+  
+  const search = searchParams.get("search");
+  const frameworks = searchParams.getAll("framework");
+  const languages = searchParams.getAll("language");
+
+  return {
+    search: search || undefined,
+    frameworks: frameworks.length > 0 ? frameworks : [],
+    languages: languages.length > 0 ? languages : [],
+  };
+}
+
+
+/**
+ * Update URL query params from form values.
+ */
+export const updateUrl = (values: TemplatesFormValues) => {
+  const searchParams = new URLSearchParams(window.location.search);
+
+  if (values.search) {
+    searchParams.set("search", values.search);
+  } else {
+    searchParams.delete("search");
+  }
+
+  if (values.frameworks) {
+    searchParams.delete("framework");
+    values.frameworks.forEach((framework) => {
+      searchParams.append("framework", framework);
+    });
+  } else {
+    searchParams.delete("framework");
+  }
+
+  if (values.languages) {
+    searchParams.delete("language");
+    values.languages.forEach((language) => {
+      searchParams.append("language", language);
+    });
+  } else {
+    searchParams.delete("language");
+  }
+
+  createUrl(searchParams);
+}
+
+/**
+ * Create a new URL with the given search params.
+ */
+const createUrl = (searchParams: URLSearchParams) => {
+  const newUrl = searchParams.toString() ? `${window.location.pathname}?${searchParams.toString()}` : window.location.pathname;
+
+  window.history.replaceState({
+    ...window.history.state,
+    as: newUrl,
+    url: newUrl,
+  },
+  "",
+  newUrl)  
+}
+

--- a/apps/web/lib/utils.ts
+++ b/apps/web/lib/utils.ts
@@ -48,3 +48,5 @@ export function cumulative(
     };
   });
 }
+
+export const isBrowser = typeof window !== "undefined";


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation

## Description

Implement URL filter parameters in the templates page, similar to Vercel Templates (for example), check "After this PR" to see the result in unkey.

<img width="1145" alt="Screenshot 2023-10-03 at 10 21 40" src="https://github.com/unkeyed/unkey/assets/53876147/308e4066-1ad4-4e1e-b30b-7794fe123c83">

### Before this PR

N/A

### After this PR
<img width="1145" alt="image" src="https://github.com/unkeyed/unkey/assets/53876147/7fd6e93b-4ae0-4578-832b-47832765cae5">

### Related Issue (optional)

<!--- Please link to the issue here: -->
