### PR TITLE
feat(endpoint): add new endpoint for billing verifications per hour

### DIFF
--- a/internal/tinybird/endpoints/endpoint__billing_verifications_per_hour__v1.pipe
+++ b/internal/tinybird/endpoints/endpoint__billing_verifications_per_hour__v1.pipe
@@ -1,0 +1,10 @@
+VERSION 1
+
+NODE endpoint
+SQL >
+    %
+    SELECT workspaceId, verifications, time
+    FROM mv__verifications_per_workspace_per_hour__v1
+    where time > {{ Int64(since, 0) }}
+
+


### PR DESCRIPTION
This commit adds a new endpoint for retrieving billing verifications per hour. The endpoint is implemented as a Tinybird pipe and uses SQL to query the `mv__verifications_per_workspace_per_hour__v1` materialized view. The query selects the `workspaceId`, `verifications`, and `time` columns from the view, filtering the results based on a provided `since` parameter.
