### PR TITLE
chore: make layout metadata more typestrict

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,3 +1,5 @@
+import type React from "react";
+import type {Metadata} from "next";
 import "@/styles/tailwind/tailwind.css";
 import { Inter } from "next/font/google";
 import localFont from "next/font/local";
@@ -11,6 +13,7 @@ const pangea = localFont({
   src: "../public/fonts/PangeaAfrikanTrial-Medium.woff2",
   variable: "--font-pangea",
 });
+
 export const metadata = {
   metadataBase: new URL("https://unkey.dev"),
   title: "Open Source API Key Management",
@@ -20,12 +23,12 @@ export const metadata = {
     description: "Accelerate your API development",
     url: "https://unkey.dev",
     siteName: "unkey.dev",
-    image: "https://unkey.dev/og.png",
+    images: ["https://unkey.dev/og.png"],
   },
   twitter: {
     title: "Unkey",
     card: "summary_large_image",
-    image: "https://unkey.dev/og.png",
+    images: ["https://unkey.dev/og.png"],
   },
   robots: {
     index: true,
@@ -40,7 +43,7 @@ export const metadata = {
       "max-snippet": -1,
     },
   },
-};
+} satisfies Metadata;
 
 export default function RootLayout({
   children,

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,8 +1,8 @@
-import type React from "react";
-import type {Metadata} from "next";
 import "@/styles/tailwind/tailwind.css";
+import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import localFont from "next/font/local";
+import type React from "react";
 
 const inter = Inter({
   subsets: ["latin"],


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation

## Description

<!--- Describe your changes in detail -->

When reviewing the code for Unkey, I noticed that my IDE (Webstorm) was throwing an error on `metadata` due to a key mismatch from `image` to `images`. This PR fixes this issue but imports the types and applies them using `satisfies` to ensure these errors won't be reintroduced.

### A picture tells a thousand words (if any)

### Before this PR

<img width="741" alt="A TypeScript error" src="https://github.com/unkeyed/unkey/assets/9100169/38124e16-fcbc-4ba4-8a6a-782df73358bf">


### After this PR

<img width="363" alt="No TypeScript error" src="https://github.com/unkeyed/unkey/assets/9100169/3c95bbed-6fa2-41c6-acec-20f4e7a2570d">
