### PR TITLE
KEY-247 feat(desktop-sidebar): added hover to sidebad api links

### DIFF
--- a/apps/web/app/(authenticated)/(app)/app/desktop-sidebar.tsx
+++ b/apps/web/app/(authenticated)/(app)/app/desktop-sidebar.tsx
@@ -72,9 +72,9 @@ export const DesktopSidebar: React.FC<Props> = ({ workspace, className }) => {
             <h3 className="text-xs font-semibold leading-6 text-content">Your APIs</h3>
             <ul className="mt-2 -mx-2 space-y-1">
               {workspace.apis.map((api) => (
-                <Tooltip>
-                  <TooltipTrigger className="w-full overflow-hidden text-ellipsis">
-                    <li key={api.id}>
+                <li key={api.id}>
+                  <Tooltip>
+                    <TooltipTrigger className="w-full overflow-hidden text-ellipsis">
                       <NavLink
                         item={{
                           icon: Code,
@@ -83,12 +83,10 @@ export const DesktopSidebar: React.FC<Props> = ({ workspace, className }) => {
                           active: segments.includes(api.id),
                         }}
                       />
-                    </li>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <li key={api.id}>{api.name}</li>
-                  </TooltipContent>
-                </Tooltip>
+                    </TooltipTrigger>
+                    <TooltipContent>{api.name}</TooltipContent>
+                  </Tooltip>
+                </li>
               ))}
             </ul>
           </li>

--- a/apps/web/app/(authenticated)/(app)/app/desktop-sidebar.tsx
+++ b/apps/web/app/(authenticated)/(app)/app/desktop-sidebar.tsx
@@ -1,4 +1,6 @@
 "use client";
+import { Tooltip, TooltipContent } from "@/components/ui/tooltip";
+import { TooltipTrigger } from "@/components/ui/tooltip";
 import type { Workspace } from "@/lib/db";
 import { cn } from "@/lib/utils";
 import { BookOpen, Code, LucideIcon, Settings } from "lucide-react";
@@ -48,7 +50,9 @@ export const DesktopSidebar: React.FC<Props> = ({ workspace, className }) => {
   ];
 
   return (
-    <aside className={cn("fixed  h-screen  inset-y-0 flex w-64 flex-col px-6 gap-y-5", className)}>
+    <aside
+      className={cn("fixed  h-screen  inset-y-0 flex w-64 flex-col px-6 gap-y-5 z-10", className)}
+    >
       <div className="flex items-center h-16 mt-4">
         <WorkspaceSwitcher />
       </div>
@@ -68,16 +72,23 @@ export const DesktopSidebar: React.FC<Props> = ({ workspace, className }) => {
             <h3 className="text-xs font-semibold leading-6 text-content">Your APIs</h3>
             <ul className="mt-2 -mx-2 space-y-1">
               {workspace.apis.map((api) => (
-                <li key={api.id}>
-                  <NavLink
-                    item={{
-                      icon: Code,
-                      href: `/app/apis/${api.id}`,
-                      label: api.name,
-                      active: segments.includes(api.id),
-                    }}
-                  />
-                </li>
+                <Tooltip>
+                  <TooltipTrigger className="w-full overflow-hidden text-ellipsis">
+                    <li key={api.id}>
+                      <NavLink
+                        item={{
+                          icon: Code,
+                          href: `/app/apis/${api.id}`,
+                          label: api.name,
+                          active: segments.includes(api.id),
+                        }}
+                      />
+                    </li>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <li key={api.id}>{api.name}</li>
+                  </TooltipContent>
+                </Tooltip>
               ))}
             </ul>
           </li>


### PR DESCRIPTION
Added hover tooltips to api navigation in sidebar

KEY-247

## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [ ] 🐛 Bug fix
- [X] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation

## Description

Added hover tooltip to API nav links in sidebar

### A picture tells a thousand words (if any)

### Before this PR

{Please add a screenshot here}

### After this PR

{Please add a screenshot here}

### Related Issue (optional)

<!--- Please link to the issue here: -->
