### PR TITLE
KEY-248 fix(copybutton icon): changed the icon that shows on click to copy keys

### DIFF
--- a/apps/web/components/dashboard/copy-button.tsx
+++ b/apps/web/components/dashboard/copy-button.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 
 import { cn } from "@/lib/utils";
-import { Check, Copy } from "lucide-react";
+import { Copy, CopyCheck } from "lucide-react";
 
 interface CopyButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
   value: string;
@@ -39,7 +39,7 @@ export function CopyButton({ value, className, src, ...props }: CopyButtonProps)
       {...props}
     >
       <span className="sr-only">Copy</span>
-      {hasCopied ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
+      {hasCopied ? <CopyCheck className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
     </button>
   );
 }


### PR DESCRIPTION
Changed the icon that shows on click to verify copy has worked

KEY-248

## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation

## Description

Changed icon for copy button when clicked

### A picture tells a thousand words (if any)

### Before this PR

{Please add a screenshot here}

### After this PR

{Please add a screenshot here}

### Related Issue (optional)

<!--- Please link to the issue here: -->
