### PR TITLE
fix: `@unkey/client` types

### DIFF
--- a/.changeset/soft-spies-walk.md
+++ b/.changeset/soft-spies-walk.md
@@ -1,0 +1,5 @@
+---
+"@unkey/api": patch
+---
+
+Fix `@unkey/client` types

--- a/packages/api/src/client.ts
+++ b/packages/api/src/client.ts
@@ -123,7 +123,7 @@ export class Unkey {
         return null; // set `res` to `null`
       });
       if (res?.ok) {
-        return { result: await res.json() };
+        return { result: (await res.json()) as TResult };
       }
       const backoff = this.retry.backoff(i);
       console.debug(
@@ -139,7 +139,7 @@ export class Unkey {
     }
 
     if (res) {
-      return { error: await res.json() };
+      return { error: (await res.json()) as UnkeyError };
     }
 
     return {


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation


Add typecasts to prevent `tsc` complaining about incorrect types.

### Before this PR
```console
client.ts:126:9 - error TS2322: Type '{ result: Awaited<TResult> | undefined; }' is not assignable to type 'Result<TResult>'.
  Type '{ result: Awaited<TResult> | undefined; }' is not assignable to type '{ result: TResult; error?: undefined; }'.
    Types of property 'result' are incompatible.
      Type 'Awaited<TResult> | undefined' is not assignable to type 'TResult'.
        'TResult' could be instantiated with an arbitrary type which could be unrelated to 'Awaited<TResult> | undefined'.

126         return { result: await res.json() };
            ~~~~~~

client.ts:142:7 - error TS2322: Type '{ error: UnkeyError | undefined; }' is not assignable to type 'Result<TResult>'.
  Property 'result' is missing in type '{ error: UnkeyError | undefined; }' but required in type '{ result: TResult; error?: undefined; }'.

142       return { error: await res.json() };
          ~~~~~~

  client.ts:65:7
    65       result: R;
             ~~~~~~
    'result' is declared here.
```

### After this PR
```console
<no error>
```