### PR TITLE
Add docker compose with MySql service

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -4,7 +4,7 @@ There are a few 3rd party services that are required to run the app:
 
 Required
 
-- [Planetscale](https://planetscale.com?ref=unkey): Database
+- [Planetscale](https://planetscale.com?ref=unkey) or Local MySQL (can be spun up using Docker Compose in the project's root directory): Database
 - [Clerk](https://clerk.com?ref=unkey): Authentication
 
 Optional
@@ -37,6 +37,15 @@ Push the database schema to Planetscale:
 cd internal/db
 DRIZZLE_DATABASE_URL='mysql://{user}:{password}@{host}/{db}?ssl={"rejectUnauthorized":true}' pnpm drizzle-kit push:mysql
 ```
+
+If you're using a local MySQL database, use this command instead:
+
+```
+cd internal/db
+DRIZZLE_DATABASE_URL='mysql://user:password@localhost:3306/unkey' pnpm drizzle-kit push:mysql
+```
+
+Note: If you're utilizing a local database, remember to update the credentials in the environment files with the database credentials from the docker-compose.yml file.
 
 ### 2. Tinybird (Optional)
 

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,6 +1,6 @@
 # Auth
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=
-CLERK_SECRET_KEY=D
+CLERK_SECRET_KEY=
 # Skip these for development, they are only needed for production
 NEXT_PUBLIC_CLERK_SIGN_IN_URL=
 NEXT_PUBLIC_CLERK_SIGN_UP_URL=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3.8'
+
+services:
+  database:
+    container_name: database
+    image: mysql:latest
+    environment:
+      MYSQL_DATABASE: unkey
+      MYSQL_USER: user
+      MYSQL_PASSWORD: password
+      MYSQL_ROOT_PASSWORD: password
+    ports:
+      - 3306:3306
+    volumes:
+      - unkey-db:/var/lib/mysql
+
+volumes:
+  unkey-db:


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation

## Description
**Add Docker compose file**
<!--- Describe your changes in detail -->
- Add a docker-compose.yml file with the MySql service.
- Allow usage of both local MySQL and Planetscale.
- Update the documentation to include instructions for pushing the schema to the local database in Docker.

### Related Issue (optional)

<!--- Please link to the issue here: -->
[Allow using local mysql as well as planetscale](https://github.com/unkeyed/unkey/issues/490)
