### PR TITLE
fix: update footer navigation to 404 for Documentation link

### DIFF
--- a/apps/web/components/landing/footer.tsx
+++ b/apps/web/components/landing/footer.tsx
@@ -5,18 +5,21 @@ import { FadeIn } from "@/components/landing/fade-in";
 import { NewsletterForm } from "@/components/landing/newsletter";
 import { socialMediaProfiles } from "@/components/landing/social-media";
 
+//Company navigation is rendered by itself so that the docs link can be added at the end.
+//The docs link needs to use the a tag instead of the Link component to avoid client side routing.
+const companyNavigation = {
+  title: "Company",
+  links: [
+    { title: "About", href: "/about" },
+    { title: "Blog", href: "/blog" },
+    { title: "Careers", href: "/careers" },
+    { title: "Changelog", href: "/changelog" },
+    { title: "Analytics", href: "https://plausible.io/unkey.dev" },
+    { title: "Source Code", href: "https://github.com/unkeyed/unkey" },
+  ],
+};
+
 const navigation = [
-  {
-    title: "Company",
-    links: [
-      { title: "About", href: "/about" },
-      { title: "Blog", href: "/blog" },
-      { title: "Careers", href: "/careers" },
-      { title: "Changelog", href: "/changelog" },
-      { title: "Analytics", href: "https://plausible.io/unkey.dev" },
-      { title: "Source Code", href: "https://github.com/unkeyed/unkey" },
-    ],
-  },
   {
     title: "Legal",
     links: [
@@ -40,6 +43,25 @@ function Navigation() {
   return (
     <nav>
       <ul className="grid grid-cols-2 gap-8 sm:grid-cols-3">
+        <li>
+          <div className="text-sm font-semibold tracking-wider font-display text-gray-950">
+            {companyNavigation.title}
+          </div>
+          <ul className="mt-4 text-sm text-gray-700">
+            {companyNavigation.links.map((link) => (
+              <li key={link.href} className="mt-4">
+                <Link href={link.href} className="transition hover:text-gray-950">
+                  {link.title}
+                </Link>
+              </li>
+            ))}
+            <li className="mt-4">
+              <a href="/docs" className="transition hover:text-gray-950">
+                Documentation
+              </a>
+            </li>
+          </ul>
+        </li>
         {navigation.map((section) => (
           <li key={section.title}>
             <div className="text-sm font-semibold tracking-wider font-display text-gray-950">
@@ -53,11 +75,6 @@ function Navigation() {
                   </Link>
                 </li>
               ))}
-              <li className="mt-4">
-                <a href="/docs" className="transition hover:text-gray-950">
-                  Documentation
-                </a>
-              </li>
             </ul>
           </li>
         ))}

--- a/apps/web/components/landing/footer.tsx
+++ b/apps/web/components/landing/footer.tsx
@@ -5,21 +5,19 @@ import { FadeIn } from "@/components/landing/fade-in";
 import { NewsletterForm } from "@/components/landing/newsletter";
 import { socialMediaProfiles } from "@/components/landing/social-media";
 
-//Company navigation is rendered by itself so that the docs link can be added at the end.
-//The docs link needs to use the a tag instead of the Link component to avoid client side routing.
-const companyNavigation = {
-  title: "Company",
-  links: [
-    { title: "About", href: "/about" },
-    { title: "Blog", href: "/blog" },
-    { title: "Careers", href: "/careers" },
-    { title: "Changelog", href: "/changelog" },
-    { title: "Analytics", href: "https://plausible.io/unkey.dev" },
-    { title: "Source Code", href: "https://github.com/unkeyed/unkey" },
-  ],
-};
-
 const navigation = [
+  {
+    title: "Company",
+    links: [
+      { title: "About", href: "/about" },
+      { title: "Blog", href: "/blog" },
+      { title: "Careers", href: "/careers" },
+      { title: "Changelog", href: "/changelog" },
+      { title: "Analytics", href: "https://plausible.io/unkey.dev" },
+      { title: "Source Code", href: "https://github.com/unkeyed/unkey" },
+      { title: "Docs", href: "https://unkey.dev/docs" },
+    ],
+  },
   {
     title: "Legal",
     links: [
@@ -43,25 +41,6 @@ function Navigation() {
   return (
     <nav>
       <ul className="grid grid-cols-2 gap-8 sm:grid-cols-3">
-        <li>
-          <div className="text-sm font-semibold tracking-wider font-display text-gray-950">
-            {companyNavigation.title}
-          </div>
-          <ul className="mt-4 text-sm text-gray-700">
-            {companyNavigation.links.map((link) => (
-              <li key={link.href} className="mt-4">
-                <Link href={link.href} className="transition hover:text-gray-950">
-                  {link.title}
-                </Link>
-              </li>
-            ))}
-            <li className="mt-4">
-              <a href="/docs" className="transition hover:text-gray-950">
-                Documentation
-              </a>
-            </li>
-          </ul>
-        </li>
         {navigation.map((section) => (
           <li key={section.title}>
             <div className="text-sm font-semibold tracking-wider font-display text-gray-950">

--- a/apps/web/components/landing/footer.tsx
+++ b/apps/web/components/landing/footer.tsx
@@ -15,7 +15,6 @@ const navigation = [
       { title: "Changelog", href: "/changelog" },
       { title: "Analytics", href: "https://plausible.io/unkey.dev" },
       { title: "Source Code", href: "https://github.com/unkeyed/unkey" },
-      { title: "Documentation", href: "/docs" },
     ],
   },
   {
@@ -54,6 +53,11 @@ function Navigation() {
                   </Link>
                 </li>
               ))}
+              <li className="mt-4">
+                <a href="/docs" className="transition hover:text-gray-950">
+                  Documentation
+                </a>
+              </li>
             </ul>
           </li>
         ))}

--- a/apps/web/components/landing/footer.tsx
+++ b/apps/web/components/landing/footer.tsx
@@ -15,7 +15,7 @@ const navigation = [
       { title: "Changelog", href: "/changelog" },
       { title: "Analytics", href: "https://plausible.io/unkey.dev" },
       { title: "Source Code", href: "https://github.com/unkeyed/unkey" },
-      { title: "Docs", href: "https://unkey.dev/docs" },
+      { title: "Documentation", href: "https://unkey.dev/docs" },
     ],
   },
   {


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation

## Description

<!--- Describe your changes in detail -->

### A picture tells a thousand words (if any)
Using client side navigation on the footer for the docs results in a 404. PR uses an `a` tag instead. 


### Before this PR
404 page when clicking on the documentation link in the footer.
<img width="1327" alt="image" src="https://github.com/unkeyed/unkey/assets/3579142/995b1b54-0798-4d27-962f-9ea336d935b6">


### After this PR

It should go the docs page.

### Related Issue (optional)

<!--- Please link to the issue here: -->
