### PR TITLE
fix(datepicker for new keys): blocked ability to select previous date…

### DIFF
--- a/apps/web/app/(authenticated)/(app)/app/apis/[apiId]/create-key.tsx
+++ b/apps/web/app/(authenticated)/(app)/app/apis/[apiId]/create-key.tsx
@@ -403,6 +403,7 @@ export const CreateKey: React.FC<Props> = ({ apiId }) => {
                                   <FormLabel>Expiry Date</FormLabel>
                                   <FormControl>
                                     <Input
+                                      min={new Date().toISOString().slice(0, -8)}
                                       type="datetime-local"
                                       {...field}
                                       value={field.value?.toLocaleString()}

--- a/apps/web/app/(authenticated)/(app)/app/apis/[apiId]/create-key.tsx
+++ b/apps/web/app/(authenticated)/(app)/app/apis/[apiId]/create-key.tsx
@@ -412,7 +412,8 @@ export const CreateKey: React.FC<Props> = ({ apiId }) => {
                                       min={getDatePlusTwoMinutes()}
                                       type="datetime-local"
                                       {...field}
-                                      value={getDatePlusTwoMinutes()}
+                                      defaultValue={getDatePlusTwoMinutes()}
+                                      value={field.value?.toLocaleString()}
                                     />
                                   </FormControl>
                                   <FormDescription>

--- a/apps/web/app/(authenticated)/(app)/app/apis/[apiId]/create-key.tsx
+++ b/apps/web/app/(authenticated)/(app)/app/apis/[apiId]/create-key.tsx
@@ -139,6 +139,12 @@ export const CreateKey: React.FC<Props> = ({ apiId }) => {
       : "*".repeat(split.at(0)?.length ?? 0);
   const [showKey, setShowKey] = useState(false);
   const [showKeyInSnippet, setShowKeyInSnippet] = useState(false);
+
+  function getDatePlusTwoMinutes(): string {
+    const now = new Date();
+    const futureDate = new Date(now.getTime() + 2 * 60000);
+    return futureDate.toISOString().slice(0, -8);
+  }
   return (
     <>
       {key.data ? (
@@ -403,10 +409,10 @@ export const CreateKey: React.FC<Props> = ({ apiId }) => {
                                   <FormLabel>Expiry Date</FormLabel>
                                   <FormControl>
                                     <Input
-                                      min={new Date().toISOString().slice(0, -8)}
+                                      min={getDatePlusTwoMinutes()}
                                       type="datetime-local"
                                       {...field}
-                                      value={field.value?.toLocaleString()}
+                                      value={getDatePlusTwoMinutes()}
                                     />
                                   </FormControl>
                                   <FormDescription>


### PR DESCRIPTION
… in date picker for expiration

added min date to datepicker input

## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation

## Description

Set min date for date input

### A picture tells a thousand words (if any)

### Before this PR

{Please add a screenshot here}

### After this PR


### Related Issue (optional)

<!--- Please link to the issue here: -->
