### PR TITLE
fix: `@unkey/api` extracted types and small performance improvements

### DIFF
--- a/packages/api/src/client.ts
+++ b/packages/api/src/client.ts
@@ -1,88 +1,337 @@
-import { UnkeyError } from "./errors";
+import type { ErrorResponse } from "./errors";
 
-export type UnkeyOptions = (
-  | {
-      token?: never;
-
-      /**
-       * The root key from unkey.dev.
-       *
-       * You can create/manage your root keys here:
-       * https://unkey.dev/app/settings/root-keys
-       */
-      rootKey: string;
-    }
-  | {
-      /**
-       * The workspace key from unkey.dev
-       *
-       * @deprecated Use `rootKey`
-       */
-      token: string;
-      rootKey?: never;
-    }
-) & {
+type UnkeyRootKeyOptions = {
+  /**
+   * The root key from unkey.dev.
+   *
+   * You can create/manage your root keys here:
+   * https://unkey.dev/app/settings/root-keys
+   */
+  rootKey: string;
+};
+type UnkeyTokenOptions = {
+  /**
+   * The workspace key from unkey.dev
+   *
+   * @deprecated Use `rootKey`
+   */
+  token: string;
+};
+type UnkeyBaseOptions = {
   /**
    * @default https://api.unkey.dev
    */
   baseUrl?: string;
-
   /**
    * Retry on network errors
    */
-  retry?: {
-    /**
-     * How many attempts should be made
-     * The maximum number of requests will be `attempts + 1`
-     * `0` means no retries
-     *
-     * @default 5
-     */
-    attempts?: number;
-    /**
-     * Return how many milliseconds to wait until the next attempt is made
-     *
-     * @default `(retryCount) => Math.round(Math.exp(retryCount) * 10)),`
-     */
-    backoff?: (retryCount: number) => number;
-  };
+  retry?: Partial<Retry>;
   /**
    * Customize the `fetch` cache behaviour
    */
   cache?: RequestCache;
-  // some change
 };
 
+export type UnkeyOptions = (UnkeyRootKeyOptions | UnkeyTokenOptions) &
+  UnkeyBaseOptions;
+
+type Backoff = (retryCount: number) => number;
+type Retry = {
+  /**
+   * How many attempts should be made
+   * The maximum number of requests will be `attempts + 1`
+   * `0` means no retries
+   *
+   * @default 5
+   */
+  attempts: number;
+  /**
+   * Return how many milliseconds to wait until the next attempt is made
+   *
+   * @default `(retryCount) => Math.round(Math.exp(retryCount) * 10)),`
+   */
+  backoff: Backoff;
+};
+type RateLimit = {
+  type: "fast" | "consistent";
+  /**
+   * The total amount of burstable requests.
+   */
+  limit: number;
+
+  /**
+   * How many tokens to refill during each refillInterval
+   */
+  refillRate: number;
+
+  /**
+   * Determines the speed at which tokens are refilled.
+   * In milliseconds.
+   */
+  refillInterval: number;
+};
+type RateLimitResult = {
+  /**
+   * The maximum number of requests for bursting.
+   */
+  limit: number;
+
+  /**
+   * How many requests are remaining until `reset`
+   */
+  remaining: number;
+
+  /**
+   * Unix timestamp in millisecond when the ratelimit is refilled.
+   */
+  reset: number;
+};
+type MetaRecord<T = unknown> = {
+  /**
+   * This is a place for dynamic meta data, anything that feels useful for you should go here
+   *
+   * Example:
+   *
+   * ```json
+   * {
+   *   "billingTier":"PRO",
+   *   "trialEnds": "2023-06-16T17:16:37.161Z"
+   * }
+   * ```
+   */
+  meta?: T;
+};
+
+type CreateKeyPayload = {
+  /**
+   * Provide a name to this key if you want for later reference
+   */
+  name?: string;
+  /**
+   * Choose an API where this key should be created.
+   */
+  apiId: string;
+  /**
+   * To make it easier for your users to understand which product an api key belongs to, you can add prefix them.
+   *
+   * For example Stripe famously prefixes their customer ids with cus_ or their api keys with sk_live_.
+   *
+   * The underscore is automtically added if you are defining a prefix, for example: "prefix": "abc" will result in a key like abc_xxxxxxxxx
+   */
+  prefix?: string;
+
+  /**
+   * The bytelength used to generate your key determines its entropy as well as its length. Higher is better, but keys become longer and more annoying to handle.
+   *
+   * The default is 16 bytes, or 2128 possible combinations
+   */
+  byteLength?: number;
+  /**
+   * Your user’s Id. This will provide a link between Unkey and your customer record.
+   *
+   * When validating a key, we will return this back to you, so you can clearly identify your user from their api key.
+   */
+  ownerId?: string;
+  /**
+   * You can auto expire keys by providing a unix timestamp in milliseconds.
+   *
+   * Once keys expire they will automatically be deleted and are no longer valid.
+   */
+  expires?: number;
+
+  /**
+   * Unkey comes with per-key ratelimiting out of the box.
+   *
+   * @see https://unkey.dev/docs/features/ratelimiting
+   */
+  ratelimit?: RateLimit;
+
+  /**
+   * Unkey allows you to set/update usage limits on individual keys
+   *
+   * @see https://unkey.dev/docs/features/remaining
+   */
+  remaining?: number;
+} & MetaRecord;
+type UpdateKeyPayload = {
+  /**
+   * The id of the key to update.
+   */
+  keyId: string;
+  /**
+   * Update the name
+   */
+  name?: string | null;
+
+  /**
+   * Update the owner id
+   */
+  ownerId?: string | null;
+  /**
+   * Update the expiration time, Unix timstamp in milliseconds
+   *
+   *
+   */
+  expires?: number | null;
+
+  /**
+   * Update the ratelimit
+   *
+   * @see https://unkey.dev/docs/features/ratelimiting
+   */
+  ratelimit?: RateLimit | null;
+
+  /**
+   * Update the remaining verifications.
+   *
+   * @see https://unkey.dev/docs/features/remaining
+   */
+  remaining?: number | null;
+} & MetaRecord;
+export type VerifyKeyPayload = {
+  /**
+   * The key to verify
+   */
+  key: string;
+
+  /**
+   * The api id to verify against
+   *
+   * This will be required soon.
+   */
+  apiId?: string;
+};
+type VerifyKeyResult = {
+  /**
+   * Whether or not this key is valid and has passed the ratelimit. If false you should not grant access to whatever the user is requesting
+   */
+  valid: boolean;
+
+  /**
+   * If you have set an ownerId on this key it is returned here. You can use this to clearly authenticate a user in your system.
+   */
+  ownerId?: string;
+
+  /**
+   *  Unix timestamp in milliseconds when this key expires
+   * Only available when the key automatically expires
+   */
+  expires?: number;
+
+  /**
+   * How many verifications are remaining after the current request.
+   */
+  remaining?: number;
+
+  /**
+   * Ratelimit data if the key is ratelimited.
+   */
+  ratelimit?: RateLimitResult;
+
+  /**
+   * Machine readable code that explains why a key is invalid or could not be verified
+   */
+  code?: "NOT_FOUND" | "FORBIDDEN" | "RATELIMITED" | "KEY_USAGE_EXCEEDED";
+} & MetaRecord;
+type RevokeKeyPayload = { keyId: string };
+type KeysResult = { key: string; keyId: string };
+
+type ApiIdRecord = {
+  /**
+   * The global unique identifier of your api.
+   */
+  apiId: string;
+};
+type Key = {
+  id: string;
+  apiId: string;
+  ownerId?: string;
+  workspaceId: string;
+  start: string;
+  createdAt: number;
+  name?: string;
+  expires?: number;
+  remaining?: number;
+  ratelimit?: RateLimit;
+} & MetaRecord;
+type CreateApiPayload = {
+  /**
+   * A name for you to identify your API.
+   */
+  name: string;
+};
+type GetApiResult = { id: string; name: string; workspaceId: string };
+type ListKeysPayload = ApiIdRecord & {
+  /**
+   * Limit the number of returned keys, the maximum is 100.
+   *
+   * @default 100
+   */
+  limit?: number;
+
+  /**
+   * Specify an offset for pagination.
+   * @example:
+   * An offset of 4 will skip the first 4 keys and return keys starting at the 5th position.
+   *
+   * @default 0
+   */
+  offset?: number;
+
+  /**
+   * If provided, this will only return keys where the ownerId matches.
+   */
+  ownerId?: string;
+};
+type ListKeysResult = {
+  keys: Key[];
+  total: number;
+};
+
+type CreateRootKeyPayload = {
+  /**
+   * Provide a name to this key if you want for later reference
+   */
+  name?: string;
+
+  /**
+   * You can auto expire keys by providing a unix timestamp in milliseconds.
+   *
+   * Once keys expire they will automatically be deleted and are no longer valid.
+   */
+  expires?: number;
+
+  // Used to create root keys from the frontend, please ignore
+  forWorkspaceId: string;
+};
+type DeleteRootKeyPayload = {
+  /**
+   *  Used to create root keys from the frontend, please ignore
+   */
+  keyId: string;
+};
+
+type SuccessResult<R> = Record<"result", R>;
+type Result<R> = SuccessResult<R> | ErrorResponse;
+type ApiCall<P = unknown, R = unknown> = (payload: P) => Promise<Result<R>>;
 type ApiRequest = {
   path: string[];
-  method: "GET" | "POST" | "PUT" | "DELETE";
-  body?: unknown;
   query?: Record<string, string>;
-};
-
-type Result<R> =
-  | {
-      result: R;
-      error?: never;
-    }
-  | {
-      result?: never;
-      error: UnkeyError;
-    };
+} & (
+  | { method: "GET" } // GET requests do not have a body
+  | { method: "POST" | "PUT" | "DELETE"; body?: any }
+);
 
 export class Unkey {
   public readonly baseUrl: string;
   private readonly rootKey: string;
   private readonly cache?: RequestCache;
 
-  public readonly retry: {
-    attempts: number;
-    backoff: (retryCount: number) => number;
-  };
+  public readonly retry: Retry;
 
-  constructor(opts: UnkeyOptions) {
+  public constructor(opts: UnkeyOptions) {
     this.baseUrl = opts.baseUrl ?? "https://api.unkey.dev";
-    this.rootKey = opts.rootKey ?? opts.token;
+    this.rootKey = "rootKey" in opts ? opts.rootKey : opts.token;
 
     this.cache = opts.cache;
     /**
@@ -97,478 +346,183 @@ export class Unkey {
     this.retry = {
       attempts: opts.retry?.attempts ?? 5,
       backoff: opts.retry?.backoff ?? ((n) => Math.round(Math.exp(n) * 10)),
-    };
+    } satisfies Retry;
   }
 
-  private async fetch<TResult>(req: ApiRequest): Promise<Result<TResult>> {
+  private async fetch<TResult = unknown>(
+    req: ApiRequest,
+  ): Promise<Result<TResult>> {
     let res: Response | null = null;
     let err: Error | null = null;
+
+    const url = new URL(req.path.join("/"), this.baseUrl);
+
+    if (req.query) {
+      for (const [k, v] of Object.entries(req.query)) {
+        url.searchParams.set(k, v);
+      }
+    }
+
     for (let i = 0; i <= this.retry.attempts; i++) {
-      const url = new URL(`${this.baseUrl}/${req.path.join("/")}`);
-      if (req.query) {
-        for (const [k, v] of Object.entries(req.query)) {
-          url.searchParams.set(k, v);
+      try {
+        const body =
+          req.method === "GET" || !req.body
+            ? undefined
+            : JSON.stringify(req.body);
+
+        res = await fetch(url, {
+          method: req.method,
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${this.rootKey}`,
+          },
+          cache: this.cache,
+          body,
+        });
+
+        if (res.ok) {
+          return { result: await res.json() } as SuccessResult<TResult>;
         }
+      } catch (e) {
+        err = e as Error;
+        res = null; // set `res` to `null`
       }
-      res = await fetch(url, {
-        method: req.method,
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${this.rootKey}`,
-        },
-        cache: this.cache,
-        body: JSON.stringify(req.body),
-      }).catch((e: Error) => {
-        err = e;
-        return null; // set `res` to `null`
-      });
-      if (res?.ok) {
-        return { result: (await res.json()) as TResult };
+
+      // no need to wait after last attempt failed
+      if (i < this.retry.attempts) {
+        const backoff = this.retry.backoff(i);
+        console.debug(
+          "attempt %d of %d to reach %s failed, retrying in %d ms: %s",
+          i + 1,
+          this.retry.attempts + 1,
+          url,
+          backoff,
+          err?.message,
+        );
+        await new Promise<void>((r) => setTimeout(r, backoff));
+      } else {
+        console.debug(
+          "attempt %d of %d to reach %s failed, giving up: %s",
+          i + 1,
+          this.retry.attempts + 1,
+          url,
+          err?.message,
+        );
       }
-      const backoff = this.retry.backoff(i);
-      console.debug(
-        "attempt %d of %d to reach %s failed, retrying in %d ms: %s",
-        i + 1,
-        this.retry.attempts + 1,
-        url,
-        backoff,
-        // @ts-ignore I don't understand why `err` is `never`
-        err?.message,
-      );
-      await new Promise((r) => setTimeout(r, backoff));
     }
 
     if (res) {
-      return { error: (await res.json()) as UnkeyError };
+      return { error: await res.json() } as ErrorResponse;
     }
 
     return {
       error: {
         code: "FETCH_ERROR",
-        // @ts-ignore I don't understand why `err` is `never`
         message: err?.message ?? "No response",
         docs: "https://developer.mozilla.org/en-US/docs/Web/API/fetch",
         requestId: "N/A",
       },
-    };
+    } satisfies ErrorResponse;
   }
 
-  public get keys() {
+  public get keys(): {
+    create: ApiCall<CreateKeyPayload, KeysResult>;
+    update: ApiCall<UpdateKeyPayload, KeysResult>;
+    verify: ApiCall<VerifyKeyPayload, VerifyKeyResult>;
+    revoke: ApiCall<RevokeKeyPayload, void>;
+  } {
     return {
-      create: async (req: {
-        /**
-         * Provide a name to this key if you want for later reference
-         */
-        name?: string;
-        /**
-         * Choose an API where this key should be created.
-         */
-        apiId: string;
-        /**
-         * To make it easier for your users to understand which product an api key belongs to, you can add prefix them.
-         *
-         * For example Stripe famously prefixes their customer ids with cus_ or their api keys with sk_live_.
-         *
-         * The underscore is automtically added if you are defining a prefix, for example: "prefix": "abc" will result in a key like abc_xxxxxxxxx
-         */
-        prefix?: string;
-
-        /**
-         * The bytelength used to generate your key determines its entropy as well as its length. Higher is better, but keys become longer and more annoying to handle.
-         *
-         * The default is 16 bytes, or 2128 possible combinations
-         */
-        byteLength?: number;
-        /**
-         * Your user’s Id. This will provide a link between Unkey and your customer record.
-         *
-         * When validating a key, we will return this back to you, so you can clearly identify your user from their api key.
-         */
-        ownerId?: string;
-        /**
-         * This is a place for dynamic meta data, anything that feels useful for you should go here
-         *
-         * Example:
-         *
-         * ```json
-         * {
-         *   "billingTier":"PRO",
-         *   "trialEnds": "2023-06-16T17:16:37.161Z"
-         * }
-         * ```
-         */
-        meta?: unknown;
-        /**
-         * You can auto expire keys by providing a unix timestamp in milliseconds.
-         *
-         * Once keys expire they will automatically be deleted and are no longer valid.
-         */
-        expires?: number;
-
-        /**
-         * Unkey comes with per-key ratelimiting out of the box.
-         *
-         * @see https://unkey.dev/docs/features/ratelimiting
-         */
-        ratelimit?: {
-          type: "fast" | "consistent";
-          /**
-           * The total amount of burstable requests.
-           */
-          limit: number;
-
-          /**
-           * How many tokens to refill during each refillInterval
-           */
-          refillRate: number;
-
-          /**
-           * Determines the speed at which tokens are refilled.
-           * In milliseconds.
-           */
-          refillInterval: number;
-        };
-
-        /**
-         * Unkey allows you to set/update usage limits on individual keys
-         *
-         * @see https://unkey.dev/docs/features/remaining
-         */
-        remaining?: number;
-      }): Promise<Result<{ key: string; keyId: string }>> => {
-        return await this.fetch<{ key: string; keyId: string }>({
+      create: async (payload) =>
+        this.fetch({
           path: ["v1", "keys"],
           method: "POST",
-          body: req,
-        });
-      },
-      update: async (req: {
-        /**
-         * The id of the key to update.
-         */
-        keyId: string;
-        /**
-         * Update the name
-         */
-        name?: string | null;
-
-        /**
-         * Update the owner id
-         */
-        ownerId?: string | null;
-        /**
-         * This is a place for dynamic meta data, anything that feels useful for you should go here
-         *
-         * Example:
-         *
-         * ```json
-         * {
-         *   "billingTier":"PRO",
-         *   "trialEnds": "2023-06-16T17:16:37.161Z"
-         * }
-         * ```
-         */
-        meta?: unknown | null;
-        /**
-         * Update the expiration time, Unix timstamp in milliseconds
-         *
-         *
-         */
-        expires?: number | null;
-
-        /**
-         * Update the ratelimit
-         *
-         * @see https://unkey.dev/docs/features/ratelimiting
-         */
-        ratelimit?: {
-          type: "fast" | "consistent";
-          /**
-           * The total amount of burstable requests.
-           */
-          limit: number;
-
-          /**
-           * How many tokens to refill during each refillInterval
-           */
-          refillRate: number;
-
-          /**
-           * Determines the speed at which tokens are refilled.
-           * In milliseconds.
-           */
-          refillInterval: number;
-        } | null;
-
-        /**
-         * Update the remaining verifications.
-         *
-         * @see https://unkey.dev/docs/features/remaining
-         */
-        remaining?: number | null;
-      }): Promise<Result<{ key: string; keyId: string }>> => {
-        return await this.fetch<{ key: string; keyId: string }>({
-          path: ["v1", "keys", req.keyId],
+          body: payload,
+        }),
+      update: async (payload) =>
+        this.fetch({
+          path: ["v1", "keys", payload.keyId],
           method: "PUT",
-          body: req,
-        });
-      },
-      verify: async (req: {
-        /**
-         * The key to verify
-         */
-        key: string;
-
-        /**
-         * The api id to verify against
-         *
-         * This will be required soon.
-         */
-        apiId?: string;
-      }): Promise<
-        Result<{
-          /**
-           * Whether or not this key is valid and has passed the ratelimit. If false you should not grant access to whatever the user is requesting
-           */
-          valid: boolean;
-
-          /**
-           * If you have set an ownerId on this key it is returned here. You can use this to clearly authenticate a user in your system.
-           */
-          ownerId?: string;
-
-          /**
-           * This is the meta data you have set when creating the key.
-           *
-           * Example:
-           *
-           * ```json
-           * {
-           *   "billingTier":"PRO",
-           *   "trialEnds": "2023-06-16T17:16:37.161Z"
-           * }
-           * ```
-           */
-          meta?: unknown;
-
-          /**
-           *  Unix timestamp in milliseconds when this key expires
-           * Only available when the key automatically expires
-           */
-          expires?: number;
-
-          /**
-           * How many verifications are remaining after the current request.
-           */
-          remaining?: number;
-
-          /**
-           * Ratelimit data if the key is ratelimited.
-           */
-          ratelimit?: {
-            /**
-             * The maximum number of requests for bursting.
-             */
-            limit: number;
-
-            /**
-             * How many requests are remaining until `reset`
-             */
-            remaining: number;
-
-            /**
-             * Unix timestamp in millisecond when the ratelimit is refilled.
-             */
-            reset: number;
-          };
-
-          /**
-           * Machine readable code that explains why a key is invalid or could not be verified
-           */
-          code?: "NOT_FOUND" | "FORBIDDEN" | "RATELIMITED" | "KEY_USAGE_EXCEEDED";
-        }>
-      > => {
-        return await this.fetch<{
-          valid: boolean;
-          ownerId?: string;
-          meta?: unknown;
-        }>({
+          body: payload,
+        }),
+      verify: async (payload) =>
+        this.fetch({
           path: ["v1", "keys", "verify"],
           method: "POST",
-          body: req,
-        });
-      },
-      revoke: async (req: { keyId: string }): Promise<Result<void>> => {
-        return await this.fetch<void>({
-          path: ["v1", "keys", req.keyId],
+          body: payload,
+        }),
+      revoke: async (payload) =>
+        this.fetch({
+          path: ["v1", "keys", payload.keyId],
           method: "DELETE",
-        });
-      },
+        }),
     };
   }
 
-  public get apis() {
+  public get apis(): {
+    create: ApiCall<CreateApiPayload, ApiIdRecord>;
+    remove: ApiCall<ApiIdRecord, ApiIdRecord>;
+    get: ApiCall<ApiIdRecord, GetApiResult>;
+    listKeys: ApiCall<ListKeysPayload, ListKeysResult>;
+  } {
     return {
-      create: async (req: {
-        /**
-         * A name for you to identify your API.
-         */
-        name: string;
-      }): Promise<
-        Result<{
-          /**
-           * The global unique identifier of your api.
-           * You'll need this for other api requests.
-           */
-          apiId: string;
-        }>
-      > => {
-        return await this.fetch({
+      create: async (payload) =>
+        this.fetch({
           path: ["v1", "apis.createApi"],
           method: "POST",
-          body: req,
-        });
-      },
-      remove: async (req: {
-        /**
-         * The global unique identifier of your api.
-         * You'll need this for other api requests.
-         */
-        apiId: string;
-      }): Promise<
-        Result<{
-          /**
-           * The global unique identifier of your api.
-           * You'll need this for other api requests.
-           */
-          apiId: string;
-        }>
-      > => {
-        return await this.fetch({
+          body: payload,
+        }),
+      remove: async (payload) =>
+        this.fetch({
           path: ["v1", "apis.removeApi"],
           method: "POST",
-          body: req,
-        });
-      },
-      get: async (req: {
-        /**
-         * The api id
-         */
-        apiId: string;
-      }): Promise<Result<{ id: string; name: string; workspaceId: string }>> => {
-        return await this.fetch({
-          path: ["v1", "apis", req.apiId],
+          body: payload,
+        }),
+      get: async (payload) =>
+        this.fetch({
+          path: ["v1", "apis", payload.apiId],
           method: "GET",
-        });
-      },
-
-      listKeys: async (req: {
-        /**
-         * The api id
-         */
-        apiId: string;
-
-        /**
-         * Limit the number of returned keys, the maximum is 100.
-         *
-         * @default 100
-         */
-        limit?: number;
-
-        /**
-         * Specify an offset for pagination.
-         * @example:
-         * An offset of 4 will skip the first 4 keys and return keys starting at the 5th position.
-         *
-         * @default 0
-         */
-        offset?: number;
-
-        /**
-         * If provided, this will only return keys where the ownerId matches.
-         */
-        ownerId?: string;
-      }): Promise<
-        Result<{
-          keys: {
-            id: string;
-            apiId: string;
-            ownerId?: string;
-            workspaceId: string;
-            start: string;
-            createdAt: number;
-            name?: string;
-            expires?: number;
-            remaining?: number;
-            meta?: unknown;
-            ratelimit?: {
-              type: "fast" | "consistent";
-              limit: number;
-              refillRate: number;
-              refillInterval: number;
-            };
-          }[];
-          total: number;
-        }>
-      > => {
+        }),
+      listKeys: async (payload) => {
         const query: Record<string, string> = {};
-        if (typeof req.limit !== "undefined") {
-          query.limit = req.limit.toString();
+        if (typeof payload.limit !== "undefined") {
+          query.limit = payload.limit.toString();
         }
-        if (typeof req.offset !== "undefined") {
-          query.offset = req.offset.toString();
+        if (typeof payload.offset !== "undefined") {
+          query.offset = payload.offset.toString();
         }
-        if (typeof req.ownerId !== "undefined") {
-          query.ownerId = req.ownerId;
+        if (typeof payload.ownerId !== "undefined") {
+          query.ownerId = payload.ownerId;
         }
 
-        return await this.fetch({
-          path: ["v1", "apis", req.apiId, "keys"],
+        return this.fetch({
+          path: ["v1", "apis", payload.apiId, "keys"],
           method: "GET",
           query,
         });
       },
     };
   }
+
   /**
    * Must be authenticated via app token
    */
-  public get _internal() {
+  public get _internal(): {
+    createRootKey: ApiCall<CreateRootKeyPayload, KeysResult>;
+    deleteRootKey: ApiCall<DeleteRootKeyPayload, void>;
+  } {
     return {
-      createRootKey: async (req: {
-        /**
-         * Provide a name to this key if you want for later reference
-         */
-        name?: string;
-
-        /**
-         * You can auto expire keys by providing a unix timestamp in milliseconds.
-         *
-         * Once keys expire they will automatically be deleted and are no longer valid.
-         */
-        expires?: number;
-
-        // Used to create root keys from the frontend, please ignore
-        forWorkspaceId: string;
-      }): Promise<Result<{ key: string; keyId: string }>> => {
-        return await this.fetch<{ key: string; keyId: string }>({
+      createRootKey: async (payload) =>
+        this.fetch({
           path: ["v1", "internal", "rootkeys"],
           method: "POST",
-          body: req,
-        });
-      },
-      deleteRootKey: async (req: {
-        /**
-         *  Used to create root keys from the frontend, please ignore
-         */
-        keyId: string;
-      }): Promise<Result<void>> => {
-        return await this.fetch<void>({
+          body: payload,
+        }),
+      deleteRootKey: async (payload) =>
+        this.fetch({
           path: ["v1", "internal.removeRootKey"],
           method: "POST",
-          body: req,
-        });
-      },
+          body: payload,
+        }),
     };
   }
 }

--- a/packages/api/src/verify.ts
+++ b/packages/api/src/verify.ts
@@ -1,4 +1,4 @@
-import { Unkey } from "./client";
+import { Unkey, type VerifyKeyPayload } from "./client";
 
 /**
  * Verify a key
@@ -21,7 +21,7 @@ import { Unkey } from "./client";
  * console.log(result)
  * ```
  */
-export function verifyKey(req: string | { key: string; apiId: string }) {
+export function verifyKey(req: string | VerifyKeyPayload) {
   // yes this is empty to make typescript happy but we don't need a token for verifying keys
   // it's not the cleanest but it works for now :)
   const unkey = new Unkey({ token: "public" });

--- a/packages/hono/src/index.ts
+++ b/packages/hono/src/index.ts
@@ -1,22 +1,8 @@
-import { UnkeyError, verifyKey } from "@unkey/api";
+import { type VerifyKeyResult, type UnkeyError, verifyKey } from "@unkey/api";
 import type { Context, MiddlewareHandler } from "hono";
 import { HTTPException } from "hono/http-exception";
 
-export type UnkeyContext = {
-  valid: boolean;
-  ownerId?: string | undefined;
-  meta?: unknown;
-  expires?: number | undefined;
-  remaining?: number | undefined;
-  ratelimit?:
-    | {
-        limit: number;
-        remaining: number;
-        reset: number;
-      }
-    | undefined;
-  code?: "NOT_FOUND" | "RATELIMITED" | "FORBIDDEN" | "KEY_USAGE_EXCEEDED" | undefined;
-};
+export type UnkeyContext = VerifyKeyResult;
 
 export type UnkeyConfig<TContext = Context> = {
   /**

--- a/packages/nextjs/src/index.ts
+++ b/packages/nextjs/src/index.ts
@@ -1,4 +1,4 @@
-import { type UnkeyError, verifyKey } from "@unkey/api";
+import { type VerifyKeyResult, type UnkeyError, verifyKey } from "@unkey/api";
 import { type NextFetchEvent, NextRequest, NextResponse } from "next/server";
 
 export type WithUnkeyConfig = {
@@ -34,21 +34,7 @@ export type WithUnkeyConfig = {
   onError?: (req: NextRequest, err: UnkeyError) => NextResponse | Promise<NextResponse>;
 };
 
-export type UnkeyContext = {
-  valid: boolean;
-  ownerId?: string | undefined;
-  meta?: unknown;
-  expires?: number | undefined;
-  remaining?: number | undefined;
-  ratelimit?:
-    | {
-        limit: number;
-        remaining: number;
-        reset: number;
-      }
-    | undefined;
-  code?: "NOT_FOUND" | "RATELIMITED" | "FORBIDDEN" | "KEY_USAGE_EXCEEDED" | undefined;
-};
+export type UnkeyContext = VerifyKeyResult;
 
 export type NextRequestWithUnkeyContext = NextRequest & { unkey: UnkeyContext };
 

--- a/packages/nuxt/src/runtime/server/types.d.ts
+++ b/packages/nuxt/src/runtime/server/types.d.ts
@@ -1,7 +1,7 @@
-import type { Unkey } from "@unkey/api";
+import type { Result, VerifyKeyResult } from "@unkey/api";
 
 declare module "h3" {
   interface H3EventContext {
-    unkey?: Awaited<ReturnType<Unkey["keys"]["verify"]>>;
+    unkey?: Awaited<Result<VerifyKeyResult>>;
   }
 }


### PR DESCRIPTION
- extracted inlined types in own definitions for reusability and readability
- fixed and removed `@ts-ignore`
- moved url creation in fetch method outside the loop
- skip waiting backoff after last attempt failed
- removed `return await this.fetch(...)` in favour of direct `return this.fetch(...)`. Since we don't handle it in `try-catch` there is no need to create another intermediate promise

## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation

## Description

<!--- Describe your changes in detail -->

### A picture tells a thousand words (if any)

### Before this PR

{Please add a screenshot here}

### After this PR

{Please add a screenshot here}

### Related Issue (optional)

<!--- Please link to the issue here: -->
