### PR TITLE
fix: member role shouldn't be able to change others role

### DIFF
--- a/apps/web/app/(authenticated)/(app)/app/settings/team/page.tsx
+++ b/apps/web/app/(authenticated)/(app)/app/settings/team/page.tsx
@@ -265,7 +265,9 @@ const RoleSwitcher: React.FC<{
     }
   }
 
-  if (!membership) return null;
+  if (!membership) {
+    return null;
+  }
 
   if (membership.role === "admin") {
     return (

--- a/apps/web/app/(authenticated)/(app)/app/settings/team/page.tsx
+++ b/apps/web/app/(authenticated)/(app)/app/settings/team/page.tsx
@@ -62,19 +62,24 @@ export default function TeamPage() {
   type Tab = "members" | "invitations";
   const [tab, setTab] = useState<Tab>("members");
 
-  const actions: React.ReactNode[] = [
-    <Select value={tab} onValueChange={(value: Tab) => setTab(value)}>
-      <SelectTrigger className="w-[180px]">
-        <SelectValue />
-      </SelectTrigger>
-      <SelectContent>
-        <SelectGroup>
-          <SelectItem value="members">Members</SelectItem>
-          <SelectItem value="invitations">Invitations</SelectItem>
-        </SelectGroup>
-      </SelectContent>
-    </Select>,
-  ];
+  const actions: React.ReactNode[] = [];
+
+  if (isAdmin) {
+    actions.push(
+      <Select value={tab} onValueChange={(value: Tab) => setTab(value)}>
+        <SelectTrigger className="w-[180px]">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectGroup>
+            <SelectItem value="members">Members</SelectItem>
+            <SelectItem value="invitations">Invitations</SelectItem>
+          </SelectGroup>
+        </SelectContent>
+      </Select>,
+    );
+  }
+
   if (isAdmin) {
     actions.push(<InviteButton />);
   }

--- a/apps/web/app/(authenticated)/(app)/app/settings/team/page.tsx
+++ b/apps/web/app/(authenticated)/(app)/app/settings/team/page.tsx
@@ -227,10 +227,12 @@ const Invitations: React.FC = () => {
   );
 };
 
-const RoleSwitcher: React.FC<{ member: { id: string; role: Member["role"] } }> = ({ member }) => {
+const RoleSwitcher: React.FC<{
+  member: { id: string; role: Member["role"] };
+}> = ({ member }) => {
   const [role, setRole] = useState(member.role);
   const [isLoading, setLoading] = useState(false);
-  const { organization } = useOrganization();
+  const { organization, membership } = useOrganization();
   const { toast } = useToast();
   const { userId } = useAuth();
   async function updateRole(role: Member["role"]) {
@@ -258,25 +260,31 @@ const RoleSwitcher: React.FC<{ member: { id: string; role: Member["role"] } }> =
     }
   }
 
-  return (
-    <Select
-      value={role}
-      disabled={member.id === userId}
-      onValueChange={async (value: Member["role"]) => {
-        updateRole(value);
-      }}
-    >
-      <SelectTrigger className="w-[180px]">
-        {isLoading ? <Loading /> : <SelectValue />}
-      </SelectTrigger>
-      <SelectContent>
-        <SelectGroup>
-          <SelectItem value="admin">Admin</SelectItem>
-          <SelectItem value="basic_member">Member</SelectItem>
-        </SelectGroup>
-      </SelectContent>
-    </Select>
-  );
+  if (!membership) return null;
+
+  if (membership.role === "admin") {
+    return (
+      <Select
+        value={role}
+        disabled={member.id === userId}
+        onValueChange={async (value: Member["role"]) => {
+          updateRole(value);
+        }}
+      >
+        <SelectTrigger className="w-[180px]">
+          {isLoading ? <Loading /> : <SelectValue />}
+        </SelectTrigger>
+        <SelectContent>
+          <SelectGroup>
+            <SelectItem value="admin">Admin</SelectItem>
+            <SelectItem value="basic_member">Member</SelectItem>
+          </SelectGroup>
+        </SelectContent>
+      </Select>
+    );
+  }
+
+  return <span className="text-content">{role === "admin" ? "Admin" : "Member"}</span>;
 };
 
 const StatusBadge: React.FC<{ status: "pending" | "accepted" | "revoked" }> = ({ status }) => {


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation

## Description

User with role "Member" shouldn't be able to change other user's role in Settings->Team page.

### Before this PR

User with role "Member" could change other's role:


![image](https://github.com/unkeyed/unkey/assets/59637626/cebcb66e-237a-43e5-940e-46372597a220)


### After this PR

Fixed now:

![image](https://github.com/unkeyed/unkey/assets/59637626/55c13f63-1553-4085-b427-0b7834a80377)

### Related Issue (optional)

https://github.com/unkeyed/unkey/issues/549
