### PR TITLE
fix: update `remaining` drizzle schema for keys

### DIFF
--- a/internal/db/src/schema/keys.ts
+++ b/internal/db/src/schema/keys.ts
@@ -51,7 +51,7 @@ export const keys = mysqlTable(
     /**
      * You can limit the amount of times a key can be verified before it becomes invalid
      */
-    remainingRequests: int("remaining_requests"),
+    remaining: int("remaining_requests"),
 
     ratelimitType: text("ratelimit_type", { enum: ["consistent", "fast"] }),
     ratelimitLimit: int("ratelimit_limit"), // max size of the bucket


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation

## Description
We have a column `remaining_requests` in keys but in code, we use `remaining` as the better option in terms of code but drizzle in the background converts remaining to `remaining_requests`. But there was a mismatch in the `key` in the drizzle schema for `keys`. 
