### PR TITLE
fix: update remainingRequests schema

### DIFF
--- a/apps/api/src/pkg/usagelimit/client.ts
+++ b/apps/api/src/pkg/usagelimit/client.ts
@@ -13,7 +13,7 @@ export async function durableUsageLimit(
   namespace: DurableObjectNamespace,
   key: Key,
 ): Promise<UsageLimit> {
-  if (key.remainingRequests === null) {
+  if (key.remaining === null) {
     return { valid: true };
   }
 
@@ -44,7 +44,7 @@ export async function durableUsageLimit(
 /**
  * revalidateUsage will ask the durable object to revalidate by loading the key from the database.
  *
- * Use this after updating the key's remainingRequests manually.
+ * Use this after updating the key's remaining manually.
  */
 export async function revalidateUsage(
   namespace: DurableObjectNamespace,

--- a/apps/api/src/pkg/usagelimit/durable_object.ts
+++ b/apps/api/src/pkg/usagelimit/durable_object.ts
@@ -57,32 +57,32 @@ export class DurableObjectUsagelimiter {
           });
         }
 
-        if (this.key.remainingRequests === null) {
+        if (this.key.remaining === null) {
           this.logger.warn("key does not have remaining requests enabled", { key: this.key });
           return Response.json({
             valid: true,
           });
         }
 
-        if (this.key.remainingRequests <= 0) {
+        if (this.key.remaining <= 0) {
           return Response.json({
             valid: false,
             remaining: 0,
           });
         }
 
-        this.key.remainingRequests = Math.max(0, this.key.remainingRequests - 1);
+        this.key.remaining = Math.max(0, this.key.remaining - 1);
 
         this.state.waitUntil(
           this.db
             .update(schema.keys)
-            .set({ remainingRequests: sql`${schema.keys.remainingRequests}-1` })
+            .set({ remaining: sql`${schema.keys.remaining}-1` })
             .where(eq(schema.keys.id, this.key.id)),
         );
 
         return Response.json({
           valid: true,
-          remaining: this.key.remainingRequests,
+          remaining: this.key.remaining,
         });
       }
     }

--- a/apps/api/src/routes/v1_keys_createKey.ts
+++ b/apps/api/src/routes/v1_keys_createKey.ts
@@ -217,7 +217,7 @@ export const registerV1KeysCreateKey = (app: App) =>
       ratelimitRefillRate: req.ratelimit?.refillRate,
       ratelimitRefillInterval: req.ratelimit?.refillInterval,
       ratelimitType: req.ratelimit?.type,
-      remainingRequests: req.remaining,
+      remaining: req.remaining,
       totalUses: 0,
       deletedAt: null,
     });

--- a/apps/api/src/routes/v1_keys_getKey.ts
+++ b/apps/api/src/routes/v1_keys_getKey.ts
@@ -89,6 +89,6 @@ export const registerV1KeysGetKey = (app: App) =>
       meta: data.key.meta ?? undefined,
       createdAt: data.key.createdAt.getTime() ?? undefined,
       expiresAt: data.key.expires?.getTime() ?? undefined,
-      remaining: data.key.remainingRequests ?? undefined,
+      remaining: data.key.remaining ?? undefined,
     });
   });

--- a/apps/api/src/routes/v1_keys_updateRemaining.ts
+++ b/apps/api/src/routes/v1_keys_updateRemaining.ts
@@ -96,7 +96,7 @@ export const registerV1KeysUpdateRemaining = (app: App) =>
 
     switch (req.op) {
       case "increment": {
-        if (key.remainingRequests === null) {
+        if (key.remaining === null) {
           throw new UnkeyApiError({
             code: "BAD_REQUEST",
             message:
@@ -112,12 +112,12 @@ export const registerV1KeysUpdateRemaining = (app: App) =>
         await db
           .update(schema.keys)
           .set({
-            remainingRequests: sql`remaining_requests + ${req.value}`,
+            remaining: sql`remaining_requests + ${req.value}`,
           })
           .where(eq(schema.keys.id, req.keyId));
       }
       case "decrement": {
-        if (key.remainingRequests === null) {
+        if (key.remaining === null) {
           throw new UnkeyApiError({
             code: "BAD_REQUEST",
             message:
@@ -133,14 +133,14 @@ export const registerV1KeysUpdateRemaining = (app: App) =>
         await db
           .update(schema.keys)
           .set({
-            remainingRequests: sql`remaining_requests - ${req.value}`,
+            remaining: sql`remaining_requests - ${req.value}`,
           })
           .where(eq(schema.keys.id, req.keyId));
       }
       case "set": {
         db.update(schema.keys)
           .set({
-            remainingRequests: req.value,
+            remaining: req.value,
           })
           .where(eq(schema.keys.id, req.keyId));
       }
@@ -158,6 +158,6 @@ export const registerV1KeysUpdateRemaining = (app: App) =>
     }
 
     return c.jsonT({
-      remaining: keyAfterUpdate.remainingRequests,
+      remaining: keyAfterUpdate.remaining,
     });
   });

--- a/apps/web/app/(authenticated)/(app)/app/keys/[keyId]/page.tsx
+++ b/apps/web/app/(authenticated)/(app)/app/keys/[keyId]/page.tsx
@@ -96,9 +96,7 @@ export default async function KeyPage(props: { params: { keyId: string } }) {
           />
           <Stat
             label="Remaining"
-            value={
-              typeof key.remainingRequests === "number" ? fmt(key.remainingRequests) : <Minus />
-            }
+            value={typeof key.remaining === "number" ? fmt(key.remaining) : <Minus />}
           />
           <Stat
             label="Last Used"

--- a/apps/web/app/(authenticated)/(app)/app/keys/[keyId]/settings/update-key-remaining.tsx
+++ b/apps/web/app/(authenticated)/(app)/app/keys/[keyId]/settings/update-key-remaining.tsx
@@ -20,14 +20,14 @@ type Props = {
   apiKey: {
     id: string;
     workspaceId: string;
-    remainingRequests: number | null;
+    remaining: number | null;
   };
 };
 
 export const UpdateKeyRemaining: React.FC<Props> = ({ apiKey }) => {
   const { toast } = useToast();
 
-  const [enabled, setEnabled] = useState(apiKey.remainingRequests !== null);
+  const [enabled, setEnabled] = useState(apiKey.remaining !== null);
   return (
     <form
       action={async (formData: FormData) => {
@@ -65,7 +65,7 @@ export const UpdateKeyRemaining: React.FC<Props> = ({ apiKey }) => {
               min={0}
               name="remaining"
               className="max-w-sm"
-              defaultValue={apiKey.remainingRequests ?? ""}
+              defaultValue={apiKey.remaining ?? ""}
               autoComplete="off"
             />
           </div>

--- a/apps/web/app/(authenticated)/(app)/app/settings/root-keys/[keyId]/page.tsx
+++ b/apps/web/app/(authenticated)/(app)/app/settings/root-keys/[keyId]/page.tsx
@@ -105,9 +105,7 @@ export default async function Page(props: { params: { keyId: string } }) {
           />
           <Stat
             label="Remaining"
-            value={
-              typeof key.remainingRequests === "number" ? fmt(key.remainingRequests) : <Minus />
-            }
+            value={typeof key.remaining === "number" ? fmt(key.remaining) : <Minus />}
           />
           <Stat
             label="LastUsed"

--- a/apps/web/components/dashboard/api-key-table/index.tsx
+++ b/apps/web/components/dashboard/api-key-table/index.tsx
@@ -40,7 +40,7 @@ type Column = {
   ratelimitLimit: number | null;
   ratelimitRefillRate: number | null;
   ratelimitRefillInterval: number | null;
-  remainingRequests: number | null;
+  remaining: number | null;
 };
 
 type Props = {
@@ -148,11 +148,11 @@ export const ApiKeyTable: React.FC<Props> = ({ data }) => {
         ),
     },
     {
-      accessorKey: "remainingRequests",
+      accessorKey: "remaining",
       header: "Remaining",
       cell: ({ row }) =>
-        row.original.remainingRequests ? (
-          <span>{row.original.remainingRequests.toLocaleString()}</span>
+        row.original.remaining ? (
+          <span>{row.original.remaining.toLocaleString()}</span>
         ) : (
           <Minus className="w-4 h-4 text-gray-300" />
         ),

--- a/apps/web/components/dashboard/root-key-table/index.tsx
+++ b/apps/web/components/dashboard/root-key-table/index.tsx
@@ -40,7 +40,7 @@ type Column = {
   ratelimitLimit: number | null;
   ratelimitRefillRate: number | null;
   ratelimitRefillInterval: number | null;
-  remainingRequests: number | null;
+  remaining: number | null;
 };
 
 type Props = {
@@ -135,11 +135,11 @@ export const RootKeyTable: React.FC<Props> = ({ data }) => {
         ),
     },
     {
-      accessorKey: "remainingRequests",
+      accessorKey: "remaining",
       header: "Remaining",
       cell: ({ row }) =>
-        row.original.remainingRequests ? (
-          <span>{row.original.remainingRequests.toLocaleString()}</span>
+        row.original.remaining ? (
+          <span>{row.original.remaining.toLocaleString()}</span>
         ) : (
           <Minus className="w-4 h-4 text-gray-300" />
         ),

--- a/internal/db/src/schema/keys.ts
+++ b/internal/db/src/schema/keys.ts
@@ -51,7 +51,7 @@ export const keys = mysqlTable(
     /**
      * You can limit the amount of times a key can be verified before it becomes invalid
      */
-    remainingRequests: int("remaining_requests"),
+    remaining: int("remaining_requests"),
 
     ratelimitType: text("ratelimit_type", { enum: ["consistent", "fast"] }),
     ratelimitLimit: int("ratelimit_limit"), // max size of the bucket


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation

## Description
Changing `remainingRequests` to `remaining`.

Currently, users send `remaining` to update their remaining requests that they have and we need to convert that to `remainingRequests` for Drizzle to make sense, making a slight issue and a point of bugs in the future. 

We have 2 options:
1. Either update the client/user to send `remaingingRequests` in the API request body
2. We update the code to use `remaining` rather than `remaingingRequests`

This is the code for **Solution 2**.
