### PR TITLE
fix: update expiresAt to expires in key schema (worker)

### DIFF
--- a/apps/api/src/routes/schema.ts
+++ b/apps/api/src/routes/schema.ts
@@ -46,7 +46,7 @@ export const keySchema = z
         "The unix timestamp in milliseconds when the key was deleted. We don't delete the key outright, you can restore it later.",
       example: Date.now(),
     }),
-    expiresAt: z.number().optional().openapi({
+    expires: z.number().optional().openapi({
       description:
         "The unix timestamp in milliseconds when the key will expire. If this field is null or undefined, the key is not expiring.",
       example: Date.now(),

--- a/apps/api/src/routes/v1_keys_getKey.ts
+++ b/apps/api/src/routes/v1_keys_getKey.ts
@@ -88,7 +88,7 @@ export const registerV1KeysGetKey = (app: App) =>
       ownerId: data.key.ownerId ?? undefined,
       meta: data.key.meta ?? undefined,
       createdAt: data.key.createdAt.getTime() ?? undefined,
-      expiresAt: data.key.expires?.getTime() ?? undefined,
+      expires: data.key.expires?.getTime() ?? undefined,
       remaining: data.key.remainingRequests ?? undefined,
     });
   });

--- a/apps/api/src/routes/v1_keys_verifyKey.ts
+++ b/apps/api/src/routes/v1_keys_verifyKey.ts
@@ -74,7 +74,7 @@ A key could be invalid for a number of reasons, for example if it has expired, h
                 "The unix timestamp in milliseconds when the key was deleted. We don't delete the key outright, you can restore it later.",
               example: Date.now(),
             }),
-            expiresAt: z.number().optional().openapi({
+            expires: z.number().optional().openapi({
               description:
                 "The unix timestamp in milliseconds when the key will expire. If this field is null or undefined, the key is not expiring.",
               example: 123,
@@ -159,7 +159,7 @@ export const registerV1KeysVerifyKey = (app: App) =>
       valid: true,
       ownerId: value.ownerId,
       meta: value.meta,
-      expiresAt: value.expires,
+      expires: value.expires,
       remaining: value.remaining,
       ratelimit: value.ratelimit,
     });


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation

## Description
We currently use `expires` in the database table but the schema has `expiresAt` in the worker code. Updated the schema to use the same convention, ie: `expires`
