### PR TITLE
fix: key-296 stopped general button from being cutoff

### DIFF
--- a/apps/web/components/dashboard/navbar.tsx
+++ b/apps/web/components/dashboard/navbar.tsx
@@ -17,14 +17,14 @@ export const Navbar: React.FC<React.PropsWithChildren<Props>> = ({ navigation, c
 
   return (
     <nav className={cn("sticky top-0 bg-background z-20", className)}>
-      <div className="flex overflow-x-auto items-center w-full">
+      <div className="flex overflow-x-auto items-center w-full pl-1">
         <ul className="flex flex-row gap-4">
           {navigation.map(({ label, href, segment }) => {
             const active = segment === selectedSegment;
             return (
               <li
                 key={label}
-                className={cn("flex shrink-0 list-none border-b-2 border-transparent p-2 ", {
+                className={cn("flex shrink-0 list-none border-b-2 border-transparent p-2", {
                   "border-primary ": active,
                 })}
               >
@@ -44,7 +44,7 @@ export const Navbar: React.FC<React.PropsWithChildren<Props>> = ({ navigation, c
           })}
         </ul>
       </div>
-      <Separator />
+      <Separator className="ml-1" />
     </nav>
   );
 };


### PR DESCRIPTION
Added padding to navbar to stop buttong cutoff

key-296

## What does this PR do?

Fix bug cutting off button in navbar in settings

Fixes # (issue)

*If there is not an issue for this, please create one first. This is used to tracking purposes and also helps use understand why this PR exists*

<!-- If there isn't an issue for this PR, please re-review our Contributing Guide and create an issue -->

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

check if fix looks right and causes no ui issues

- Test A
- Test B

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary
