### PR TITLE
feat: docker support for the api

### DIFF
--- a/apps/api/.dockerignore
+++ b/apps/api/.dockerignore
@@ -1,0 +1,2 @@
+.dev.vars
+node_modules

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,0 +1,27 @@
+FROM --platform=linux/amd64 node:lts AS compile
+
+WORKDIR /app
+RUN npm install -g workerd pnpm
+
+COPY pnpm-lock.yaml ./
+RUN pnpm fetch
+
+
+COPY . .
+
+
+
+
+RUN pnpm install --offline -r
+
+WORKDIR /app/apps/api
+RUN pnpm wrangler deploy --outdir=dist --dry-run
+
+RUN pnpm workerd compile ./workerd.capnp > unkey
+
+
+FROM --platform=linux/amd64 ubuntu:latest
+COPY --from=compile /app/apps/api/unkey /usr/bin/unkey
+
+EXPOSE 8787
+CMD ["unkey"]

--- a/apps/api/docker-compose.yaml
+++ b/apps/api/docker-compose.yaml
@@ -1,0 +1,50 @@
+version: "3.8"
+
+services:
+  unkey:
+    platform: linux/amd64
+    build:
+      context: ../..
+      dockerfile: ./apps/api/Dockerfile
+    environment:
+      DATABASE_HOST: psproxy:3900
+      DATABASE_USERNAME: leave_empty
+      DATABASE_PASSWORD: leave_empty
+    ports:
+      - "8787:8787"
+    depends_on:
+      - psproxy
+
+
+  mysql:
+    platform: linux/amd64
+    build:
+      context: ../..
+      dockerfile: ./apps/api/Dockerfile.mysql
+    restart: always
+    environment:
+      MYSQL_DATABASE: unkey
+      MYSQL_ROOT_HOST: "%"
+      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+    command:
+      [
+        "--max_connections=1000",
+        "--default-authentication-plugin=mysql_native_password",
+      ]
+    ports:
+      - 3306:3306
+ 
+  psproxy:
+    image: ghcr.io/mattrobenolt/ps-http-sim:v0.0.3
+    command:
+      [
+        "-mysql-no-pass",
+        "-listen-port=3900",
+        "-mysql-dbname=unkey",
+        "-mysql-addr=psproxy",
+      ]
+    depends_on:
+      - mysql
+    ports:
+      - 3900:3900
+  

--- a/apps/api/workerd.capnp
+++ b/apps/api/workerd.capnp
@@ -1,0 +1,41 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const config :Workerd.Config = (
+  services = [
+    (name = "main", worker = .mainWorker),
+
+  ],
+
+  sockets = [
+    # Serve HTTP on port 8787.
+    ( name = "http",
+      address = "*:8787",
+      http = (),
+      service = "main"
+    ),
+  ]
+);
+
+const mainWorker :Workerd.Worker = (
+modules = [
+    (name = "worker", esModule = embed "dist/worker.js")
+  ],
+
+  durableObjectNamespaces = [
+    (className = "DO_RATELIMIT", uniqueKey = "ratelimit"),
+    (className = "DO_USAGELIMIT", uniqueKey = "usagelimit"),
+  ],
+    durableObjectStorage = (inMemory = void),
+
+bindings = [
+    (name = "DO_RATELIMIT", durableObjectNamespace = "DO_RATELIMIT"),
+    (name = "DO_USAGELIMIT", durableObjectNamespace = "DO_USAGELIMIT"),
+    ( name = "DATABASE_HOST", fromEnvironment= "DATABASE_HOST"),
+    ( name = "DATABASE_USERNAME", fromEnvironment= "DATABASE_USERNAME"),
+    ( name = "DATABASE_PASSWORD", fromEnvironment= "DATABASE_PASSWORD"),
+  ],
+
+  compatibilityDate = "2023-02-28",
+  # Learn more about compatibility dates at:
+  # https://developers.cloudflare.com/workers/platform/compatibility-dates/
+);


### PR DESCRIPTION
1. run `docker compose up` in the root
2. cd internal/db
3. DRIZZLE_DATABASE_URL='mysql://user:pass@localhost:3306/unkey' pnpm drizzle-kit push:mysql
4. continue with step 6 from https://unkey.dev/docs/contributing/getting-started
