### PR TITLE
feat: adds filter to templates page

### DIFF
--- a/apps/landing/app/globals.css
+++ b/apps/landing/app/globals.css
@@ -483,3 +483,13 @@ li > p {
     top: -130px;
   }
 }
+
+.placeholder-parallelogram {
+  width: 60%;
+  height: 100%;
+  opacity: 0.98;
+  transform: skew(-30deg); 
+  background-position: 52%;
+  background-size: 600px 600px;
+  background-repeat: no-repeat;
+}

--- a/apps/landing/app/templates/client.tsx
+++ b/apps/landing/app/templates/client.tsx
@@ -20,6 +20,7 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@/components/ui/accordion";
+import { FrostedGlassFilter } from "@/components/ui/image-glass-filter";
 import { MeteorLinesAngular } from "@/components/ui/meteorLines";
 import { Separator } from "@/components/ui/separator";
 import {
@@ -332,13 +333,15 @@ export function TemplatesClient() {
               >
                 <div className="relative w-full">
                   {template.image ? (
-                    <Image
-                      src={template.image}
-                      alt=""
-                      width={800}
-                      height={400}
-                      className="aspect-[16/9] w-full  bg-gray-100 object-cover  sm:aspect-[2/1] "
-                    />
+                    <FrostedGlassFilter>
+                      <Image
+                        src={template.image}
+                        alt=""
+                        width={800}
+                        height={400}
+                        className="aspect-[16/9] w-full  bg-gray-100 object-cover  sm:aspect-[2/1] "
+                      />
+                    </FrostedGlassFilter>
                   ) : (
                     <div className="flex items-center justify-center w-full h-full">
                       <VenetianMask className="w-8 h-8 text-white/60" />

--- a/apps/landing/components/ui/image-glass-filter.tsx
+++ b/apps/landing/components/ui/image-glass-filter.tsx
@@ -1,0 +1,8 @@
+export function FrostedGlassFilter({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="relative overflow-hidden">
+      <div className="absolute top-0 right-[-60px] backdrop-blur-xl placeholder-parallelogram" />
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
Adds the filter overlay to images on the templates page. Doesn't add it to the blog page, since we don't have our final blog header images yet.