### PR TITLE
chore(landing/editor): remove user-select for line numbers

### DIFF
--- a/apps/landing/components/analytics/analytics-bento.tsx
+++ b/apps/landing/components/analytics/analytics-bento.tsx
@@ -682,7 +682,7 @@ export function Editor({
           {tokens.map((line, i) => (
             // biome-ignore lint/suspicious/noArrayIndexKey: I got nothing better right now
             <div key={`${line}-${i}`} {...getLineProps({ line })}>
-              <span className="line-number">{i + 1}</span>
+              <span className="line-number select-none">{i + 1}</span>
               {line.map((token, key) => (
                 <span key={`${key}-${token}`} {...getTokenProps({ token })} />
               ))}


### PR DESCRIPTION
I was going through my first Unkey experience from 0 to deploy and at some point I could not properly copy the code snippet in the landing page when not clicking on the dedicated "copy" button.

This PR brings a UX improvement to the code editor through a temporary solution, which applies `user-select:none` (not ideal).

https://github.com/unkeyed/unkey/assets/10366880/b64ba0ee-51bc-444d-b537-aa6d0fc97279

---

Ideally, the line numbers should live in a different column inside of the code editor, all parallel to that line's code. That way we won't need to apply `user-select:none` anymore.

The code editor should eventually the ability to edit code, otherwise it may be better to rename it to code viewer.

