### PR TITLE
fix: eng-950-landing-decrease-line-height-of-editor

### DIFF
--- a/apps/landing/components/analytics/analytics-bento.tsx
+++ b/apps/landing/components/analytics/analytics-bento.tsx
@@ -59,7 +59,7 @@ export function AnalyticsBento() {
 
   return (
     <div className="relative flex justify-center w-full">
-      <div className="absolute top-14 z-50">
+      <div className="absolute z-50 top-14">
         <PrimaryButton
           label="Show API code"
           IconLeft={Wand2}
@@ -665,7 +665,7 @@ export function Editor({
         return (
           <pre
             key={codeBlock} // Use codeBlock as a key to trigger animations on change
-            className="leading-8"
+            className="leading-6"
           >
             {tokens.map((line, i) => {
               const lineNumber = i + 1;
@@ -673,7 +673,7 @@ export function Editor({
               return (
                 // biome-ignore lint/suspicious/noArrayIndexKey: I got nothing better right now
                 <div key={`${line}-${i}`} {...getLineProps({ line })}>
-                  <span className="line-number select-none">{paddedLineGutter}</span>
+                  <span className="select-none line-number">{paddedLineGutter}</span>
                   {line.map((token, key) => (
                     <span key={`${key}-${token}`} {...getTokenProps({ token })} />
                   ))}


### PR DESCRIPTION
changed from leading-8 to leading-6 

before:
![CleanShot 2024-04-19 at 14 35 06@2x](https://github.com/unkeyed/unkey/assets/18246773/3929ddff-0ef8-41a8-bce8-9083e546f8e2)

after:
![CleanShot 2024-04-19 at 14 34 08@2x](https://github.com/unkeyed/unkey/assets/18246773/7c3e69fb-402a-46f5-ade7-c0479d357d52)
