### PR TITLE
fix: make rate limits bento card more opaque

### DIFF
--- a/apps/landing/components/rate-limits-bento.tsx
+++ b/apps/landing/components/rate-limits-bento.tsx
@@ -1,6 +1,6 @@
 export function RateLimitsBento() {
   return (
-    <div className="w-full xl:mt-5 relative border-[.75px] h-[520px] rounded-[32px] border-[#ffffff]/10 flex overflow-x-hidden rate-limits-background-gradient">
+    <div className="w-full xl:mt-5 relative border-[.75px] h-[520px] rounded-[32px] border-[#ffffff]/10 flex overflow-x-hidden rate-limits-background-gradient bg-gradient-to-t backdrop-blur-[1px] from-black/20 via-black/20 via-20% to-transparent">
       <RateLimits />
       <RateLimitsText />
     </div>


### PR DESCRIPTION
bef

![CleanShot 2024-04-19 at 14 21 22@2x](https://github.com/unkeyed/unkey/assets/10366880/8d764178-0821-4cb4-9eb1-a39f2bfe10f5)

after

![CleanShot 2024-04-19 at 14 21 16@2x](https://github.com/unkeyed/unkey/assets/10366880/00c41cb9-a6be-4ae3-9ff6-c451dda45b60)
