### PR TITLE
added button to go to the key overview page after key creation

### DIFF
--- a/apps/dashboard/app/(app)/keys/[keyAuthId]/new/client.tsx
+++ b/apps/dashboard/app/(app)/keys/[keyAuthId]/new/client.tsx
@@ -260,13 +260,18 @@ export const CreateKey: React.FC<Props> = ({ keyAuthId }) => {
               </AlertDescription>
             </Alert>
 
-            <Code className="flex items-center justify-between w-full gap-4 my-8 ph-no-capture max-sm:text-xs sm:overflow-hidden">
-              <pre>{showKey ? key.data.key : maskedKey}</pre>
-              <div className="flex items-start justify-between gap-4 max-sm:absolute max-sm:right-11">
-                <VisibleButton isVisible={showKey} setIsVisible={setShowKey} />
-                <CopyButton value={key.data.key} />
-              </div>
-            </Code>
+            <div className="flex flex-col w-full gap-4 my-8 ph-no-capture max-sm:text-xs sm:overflow-hidden">
+              <Link href={`/keys/${keyAuthId}/${key.data.keyId}`}>
+                <Button variant={"secondary"}>View key details</Button>
+              </Link>
+              <Code className="flex items-center justify-between w-full gap-4 ph-no-capture max-sm:text-xs sm:overflow-hidden">
+                <pre>{showKey ? key.data.key : maskedKey}</pre>
+                <div className="flex items-start justify-between gap-4 max-sm:absolute max-sm:right-11">
+                  <VisibleButton isVisible={showKey} setIsVisible={setShowKey} />
+                  <CopyButton value={key.data.key} />
+                </div>
+              </Code>
+            </div>
           </div>
 
           <p className="my-2 font-medium text-center text-gray-700 ">Try verifying it:</p>


### PR DESCRIPTION
## What does this PR do?

Adds a "View key details" button after a key has been created.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How should this be tested?

Create Key ⇾ Click the "View key details" button and the key overview page should open.

https://github.com/unkeyed/unkey/assets/41112852/f08b25bc-b30b-49c8-8b34-688320d62014



