### PR TITLE
perf(www): add next bundle analyzer

### DIFF
--- a/apps/www/next.config.js
+++ b/apps/www/next.config.js
@@ -1,6 +1,7 @@
 const { withContentlayer } = require("next-contentlayer");
-/** @type {import('next').NextConfig} */
+const withBundleAnalyzer = require("@next/bundle-analyzer")();
 
+/** @type {import('next').NextConfig} */
 const nextConfig = {
   pageExtensions: ["tsx", "mdx", "ts", "js"],
   reactStrictMode: true,
@@ -46,4 +47,11 @@ const nextConfig = {
   ],
 };
 
-module.exports = withContentlayer(nextConfig);
+let finalNextConfig = nextConfig;
+finalNextConfig = withContentlayer(finalNextConfig);
+
+if (process.env.ANALYZE === "true") {
+  finalNextConfig = withBundleAnalyzer(finalNextConfig);
+}
+
+module.exports = finalNextConfig;

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "analyze:build": "ANALYZE=true next build",
     "start": "next start",
     "lint": "next lint"
   },
@@ -12,6 +13,7 @@
     "@chronark/zod-bird": "^0.3.7",
     "@faker-js/faker": "^8.4.1",
     "@hookform/resolvers": "^3.3.4",
+    "@next/bundle-analyzer": "^14.2.3",
     "@planetscale/database": "^1.11.0",
     "@radix-ui/react-accordion": "^1.1.2",
     "@radix-ui/react-avatar": "^1.0.3",


### PR DESCRIPTION
This PR just adds an `pnpm analyze:build` command so that we can visualize bundles like this

![CleanShot 2024-05-01 at 16 36 13@2x](https://github.com/unkeyed/unkey/assets/10366880/5a3d01e3-c16a-414f-9ed7-2cb74d46266d)
