### PR TITLE
fix: Jolt-testing API insufficent prems 

### DIFF
--- a/apps/api/src/pkg/errors/http.ts
+++ b/apps/api/src/pkg/errors/http.ts
@@ -39,6 +39,10 @@ export function errorSchemaFactory(code: z.ZodEnum<any>) {
         description: "Please always include the requestId in your error report",
         example: "req_1234",
       }),
+      missingPermissions: z.array(z.string()).optional().openapi({
+        description: "The list of missing permissions when code is INSUFFICIENT_PERMISSIONS",
+        example: ["perm1", "perm2"],
+      }),
     }),
   });
 }

--- a/apps/api/src/pkg/errors/openapi_responses.ts
+++ b/apps/api/src/pkg/errors/openapi_responses.ts
@@ -44,6 +44,12 @@ export const openApiErrorResponses = {
       "application/json": {
         schema: errorSchemaFactory(z.enum(["CONFLICT"])).openapi("ErrConflict"),
       },
+          {
+            missingPermissions: z.array(z.string()).optional().openapi({
+              description: "The list of missing permissions",
+              example: ["perm1", "perm2"],
+            }),
+          }),
     },
   },
   429: {

--- a/apps/api/src/pkg/keys/service.ts
+++ b/apps/api/src/pkg/keys/service.ts
@@ -45,6 +45,7 @@ type InvalidResponse = {
   };
   remaining?: number;
   permissions: string[];
+  missingPermissions?: string[];
 };
 
 type ValidResponse = {
@@ -370,6 +371,7 @@ export class KeyService {
           valid: false,
           code: "INSUFFICIENT_PERMISSIONS",
           permissions: data.permissions,
+          missingPermissions: rbacResp.val.missingPermissions,
         });
       }
     }

--- a/apps/api/src/pkg/testutil/common-tests.ts
+++ b/apps/api/src/pkg/testutil/common-tests.ts
@@ -132,6 +132,9 @@ export function runCommonRouteTests<TReq>(config: {
               code: "INSUFFICIENT_PERMISSIONS",
               docs: "https://unkey.dev/docs/api-reference/errors/code/INSUFFICIENT_PERMISSIONS",
               message: "unauthorized",
+              missingPermissions: [
+                "api.*.read_api",
+              ],
             },
           });
         });

--- a/apps/docs/api-reference/errors/code/BAD_REQUEST.mdx
+++ b/apps/docs/api-reference/errors/code/BAD_REQUEST.mdx
@@ -12,3 +12,5 @@ The request is malformed, either missing required fields, using wrong datatypes,
 Check the request by debugging or logging it and making sure it's correct.
 
 If that doesn't help, ask for help on [Discord](https://unkey.com/discord)
+
+When the error code is `INSUFFICIENT_PERMISSIONS`, the error message will now include the missing permissions in the format: "missing permissions: [\"perm1\", \"perm2\"]".

--- a/apps/docs/api-reference/errors/introduction.mdx
+++ b/apps/docs/api-reference/errors/introduction.mdx
@@ -14,6 +14,7 @@ The Unkey API returns machine readable error codes to quickly identify the type 
     message: "We were unable to authorize your request. Either your key was missing, malformed or does not have the required permissions.",
     docs: "https://unkey.api/docs/api-reference/errors/code/BAD_REQUEST",
     requestId: "req_1234567890"
+    missingPermissions: ["perm1", "perm2"]
   }
 }
 

--- a/apps/docs/api-reference/keys/verify.mdx
+++ b/apps/docs/api-reference/keys/verify.mdx
@@ -8,3 +8,5 @@ openapi: post /v1/keys.verifyKey
 | Date        | Changes             |
 |-------------|---------------------|
 | Dec 06 2023 | Introduced endpoint |
+| Dec 07 2023 | Enhanced error response to include `missingPermissions` field with missing permission names |
+

--- a/packages/api/src/errors.ts
+++ b/packages/api/src/errors.ts
@@ -3,3 +3,4 @@ import type { paths } from "./openapi";
 // this is what a json body response looks like
 export type ErrorResponse =
   paths["/v1/liveness"]["get"]["responses"]["500"]["content"]["application/json"];
+    missingPermissions?: string[];

--- a/packages/api/src/openapi.d.ts
+++ b/packages/api/src/openapi.d.ts
@@ -218,6 +218,14 @@ export interface components {
          */
         requestId: string;
       };
+      error: {
+        missingPermissions?: {
+          /**
+           * @description The list of missing permissions when code is INSUFFICIENT_PERMISSIONS
+           */
+          permissions: string[];
+        };
+      };
     };
     Key: {
       /**


### PR DESCRIPTION
Task Description:

### Is your feature request related to a problem? Please describe.

When a key is missing permissions, we only return the error

```json
{
  "code": "INSUFFICIENT_PERMISSIONS",
  "message": "unauthorized"
}
```

This makes it really hard to understand which permissions are missing and act accordingly.

### Describe the solution

Return a list of unsufficient permissions to the client. I'm not sure yet if this needs to be machine readable or if this would be enough:

```json
{
  "code": "INSUFFICIENT_PERMISSIONS",
  "message": "missing permissions: [ \"perm1\", \"perm2\" ]"
}
```

### Describe alternatives you have considered (if any)

making it machine-readable would also benefit us directly as we can build better assertions in our tests

Jolt's Explanation:
To return a list of insufficient permissions when a key is missing permissions during verification:

1. Update the `InvalidResponse` type in `apps/api/src/pkg/keys/service.ts` to include a new `missingPermissions` field that is an array of strings.
2. In the `_verifyKey` method of `KeyService` class, when the RBAC evaluation fails due to insufficient permissions, populate the `missingPermissions` field with the missing permission names.
3. Update the error response schema in `apps/api/src/pkg/errors/http.ts` and `apps/api/src/pkg/errors/openapi_responses.ts` to include the `missingPermissions` field.
4. Update the error response type in `packages/api/src/errors.ts` and `packages/api/src/openapi.d.ts` to include the `missingPermissions` field.
5. Update the `verifyKey` method in `packages/api/src/verify.ts` to return the `missingPermissions` in the error response.
6. Update the relevant test cases in `apps/api/src/pkg/testutil/common-tests.ts` to check for the presence of `missingPermissions` field in the error response.
7. Update the API documentation in `apps/docs/api-reference/errors/introduction.mdx`, `apps/docs/api-reference/errors/code/BAD_REQUEST.mdx`, and `apps/docs/api-reference/keys/verify.mdx` to mention the new `missingPermissions` field in the error response.

Files to be changed:

* apps/api/src/pkg/keys/service.ts
* apps/api/src/pkg/errors/http.ts
* apps/api/src/pkg/errors/openapi_responses.ts
* apps/api/src/pkg/testutil/common-tests.ts
* packages/api/src/errors.ts
* packages/api/src/openapi.d.ts
* packages/api/src/verify.ts
* apps/docs/api-reference/errors/introduction.mdx
* apps/docs/api-reference/errors/code/BAD_REQUEST.mdx
* apps/docs/api-reference/keys/verify.mdx

No new packages need to be added. The existing code structure and patterns will be followed to implement the feature.

## What does this PR do?

Fixes # (issue)

*If there is not an issue for this, please create one first. This is used to tracking purposes and also helps use understand why this PR exists*

## Type of change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] Chore (refactoring code, technical debt, workflow improvements)
* [ ] Enhancement (small improvements)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## How should this be tested?

* Test A
* Test B

## Checklist

### Required

* [ ] Filled out the "How to test" section in this PR
* [ ] Read [Contributing Guide](./CONTRIBUTING.md)
* [ ] Self-reviewed my own code
* [ ] Commented on my code in hard-to-understand areas
* [ ] Ran `pnpm build`
* [ ] Ran `pnpm fmt`
* [ ] Checked for warnings, there are none
* [ ] Removed all `console.logs`
* [ ] Merged the latest changes from main onto my branch with `git pull origin main`
* [ ] My changes don't cause any responsiveness issues

### Appreciated

* [ ] If a UI change was made: Added a screen recording or screenshots to this PR
* [ ] Updated the Unkey Docs if changes were necessary