### PR TITLE
fix: correct url for settings page

### DIFF
--- a/apps/dashboard/app/(app)/semantic-cache/[gatewayId]/layout.tsx
+++ b/apps/dashboard/app/(app)/semantic-cache/[gatewayId]/layout.tsx
@@ -17,7 +17,7 @@ export default async function SemanticCacheLayout({
     },
     {
       label: "Settings",
-      href: `/semantic-cache/${params.gatewayId}/settings`,
+      href: "/semantic-cache/settings",
       segment: "settings",
     },
   ];


### PR DESCRIPTION
Correct URL for semantic cache settings page