### PR TITLE
feat: add posthog to semantic-cache

### DIFF
--- a/apps/dashboard/app/(app)/semantic-cache/[gatewayId]/settings/delete-gateway.tsx
+++ b/apps/dashboard/app/(app)/semantic-cache/[gatewayId]/settings/delete-gateway.tsx
@@ -31,6 +31,7 @@ import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
+import { PostHogEvent } from "@/providers/PostHogProvider";
 import { revalidate } from "./actions";
 
 type Props = {
@@ -56,9 +57,14 @@ export const DeleteGateway: React.FC<Props> = ({ gateway }) => {
   const router = useRouter();
 
   const deleteGateway = trpc.llmGateway.delete.useMutation({
-    async onSuccess() {
+    async onSuccess(res) {
       toast.message("Gateway Deleted", {
         description: "Your gateway has been deleted.",
+      });
+
+      PostHogEvent({
+        name: "semantic_cache_gateway_deleted",
+        properties: { id: res.id },
       });
 
       await revalidate();

--- a/apps/dashboard/app/(app)/semantic-cache/form.tsx
+++ b/apps/dashboard/app/(app)/semantic-cache/form.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/form";
 import { toast } from "@/components/ui/toaster";
 import { trpc } from "@/lib/trpc/client";
+import { PostHogEvent } from "@/providers/PostHogProvider";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
@@ -41,6 +42,10 @@ export const CreateLLMGatewayForm: React.FC<Props> = ({ defaultName }) => {
       toast.success("Gateway Created", {
         description: "Your Gateway has been created",
         duration: 10_000,
+      });
+      PostHogEvent({
+        name: "semantic_cache_gateway_created",
+        properties: { id: res.id },
       });
       router.push(`/semantic-cache/${res.id}/logs`);
     },


### PR DESCRIPTION
Adds Posthog events for creating and deleting gateways

<sub><a href="https://huly.app/guest/unkey?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjdiZTdhMjJhNmFiOWVlZjU1N2FkNzEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctamFtZXMtdW5rZXktNjY2YWYwNzktNjliNzJiMzYyNi05ZGM2MGUiLCJwcm9kdWN0SWQiOiIifQ.Sx5wSQp60mtmDGww_QzL1fp9daMwEUrXaWge0dk6cMs">Huly&reg;: <b>ENG-1799</b></a></sub>