### PR TITLE
chore: Show semantic cache in sidebar

### DIFF
--- a/apps/dashboard/app/(app)/desktop-sidebar.tsx
+++ b/apps/dashboard/app/(app)/desktop-sidebar.tsx
@@ -119,7 +119,6 @@ export const DesktopSidebar: React.FC<Props> = ({ workspace, className }) => {
       href: "/semantic-cache",
       label: "Semantic Cache",
       active: segments.at(0) === "semantic-cache",
-      hidden: process.env.NODE_ENV === "production",
     },
   ].filter((n) => !n.hidden);
 


### PR DESCRIPTION
Unhide the semantic cache tab

<sub><a href="https://huly.app/guest/unkey?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjdjMWQ5ZjJhNmFiOWVlZjU1N2I3YmQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctamFtZXMtdW5rZXktNjY2YWYwNzktNjliNzJiMzYyNi05ZGM2MGUiLCJwcm9kdWN0SWQiOiIifQ.bviqQh33Agk4B8FkfzSwemY8pHSGeeyok24cXAWAE0w">Huly&reg;: <b>ENG-1803</b></a></sub>