### PR TITLE
fix(redis.go): handle nil values in members list fix(redis.go): log error when failing to cast value to string

### DIFF
--- a/apps/agent/pkg/membership/redis.go
+++ b/apps/agent/pkg/membership/redis.go
@@ -167,8 +167,13 @@ func (m *membership) Members() ([]Member, error) {
 		return nil, fmt.Errorf("failed to get members: %w", err)
 	}
 	for _, val := range values {
+		if val == nil {
+			m.logger.Warn().Msg("nil value found in members")
+			continue
+		}
 		str, ok := val.(string)
 		if !ok {
+			m.logger.Error().Interface("val", val).Msg("failed to cast value to string")
 			return nil, fmt.Errorf("failed to cast value to string")
 		}
 		var member Member

--- a/apps/agent/pkg/ring/ring.go
+++ b/apps/agent/pkg/ring/ring.go
@@ -158,8 +158,6 @@ func (r *Ring[T]) FindNodes(key string, n int) ([]Node[T], error) {
 	if err != nil {
 		return nil, err
 	}
-	r.logger.Info().Str("key", key).Str("token", token).Msg("finding nodes for key")
-
 	tokenIndex := sort.Search(len(r.tokens), func(i int) bool {
 		return r.tokens[i].token >= token
 	})

--- a/apps/agent/services/ratelimit/ratelimit.go
+++ b/apps/agent/services/ratelimit/ratelimit.go
@@ -9,8 +9,6 @@ import (
 
 func (s *service) Ratelimit(ctx context.Context, req *ratelimitv1.RatelimitRequest) (*ratelimitv1.RatelimitResponse, error) {
 
-	s.logger.Warn().Interface("req", req).Msg("ratelimit request")
-
 	res := s.ratelimiter.Take(ratelimit.RatelimitRequest{
 		Identifier:     req.Identifier,
 		Max:            req.Limit,


### PR DESCRIPTION
<sub><a href="https://huly.app/guest/unkey?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjdkN2ExOTJhNmFiOWVlZjU1ODAwMWUiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctamFtZXMtdW5rZXktNjY2YWYwNzktNjliNzJiMzYyNi05ZGM2MGUiLCJwcm9kdWN0SWQiOiIifQ.iGw3CUFdQNEH-6KR_SkIEjz_SLkF5fq1mpUW0ZKN4l0">Huly&reg;: <b>ENG-1811</b></a></sub>