### PR TITLE
refactor(docs): remove explicit types in onError function parameters in hono.mdx

### DIFF
--- a/apps/docs/libraries/ts/hono.mdx
+++ b/apps/docs/libraries/ts/hono.mdx
@@ -127,7 +127,7 @@ The handler will be called with the context and the error.
 app.use(
   "*",
   unkey({
-    onError: (c: Context, err: UnkeyError) => {
+    onError: (c, err) => {
       // handle error
       return c.text("unauthorized", 401);
     },


### PR DESCRIPTION
<sub><a href="https://huly.app/guest/unkey?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjdmZjc5MDJhNmFiOWVlZjU1OTVhYzYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctamFtZXMtdW5rZXktNjY2YWYwNzktNjliNzJiMzYyNi05ZGM2MGUiLCJwcm9kdWN0SWQiOiIifQ.9PmoaQhCFc1AWgiIK2o1y24zk0QcBQgkpUcpERhjqUc">Huly&reg;: <b>ENG-1824</b></a></sub>