### PR TITLE
fix: basic timing attack

### DIFF
--- a/apps/engineering/mint.json
+++ b/apps/engineering/mint.json
@@ -49,7 +49,13 @@
     {
       "group": "Services",
       "icon": "vault",
-      "pages": ["services/vault"]
+      "pages": [
+        "services/vault",
+        {
+          "group": "Agent",
+          "pages": ["services/agent/profiling"]
+        }
+      ]
     },
     {
       "group": "RFCs",

--- a/apps/engineering/services/agent/profiling.mdx
+++ b/apps/engineering/services/agent/profiling.mdx
@@ -1,0 +1,47 @@
+---
+title: Profiling
+---
+
+
+The agent exposes pprof endpoints for profiling. The following endpoints are available and require basic authentication to access them:
+- `/debug/pprof/`
+- `/debug/pprof/cmdline`
+- `/debug/pprof/profile`
+- `/debug/pprof/symbol`
+- `/debug/pprof/trace`
+
+To enable profiling, set the `pprof` configuration option in the agent configuration file. The agent will then expose the pprof endpoints protected by basic authentication.
+
+```json
+{
+  "pprof": {
+    "username": "PPROF_USERNAME",
+    "password": "PPROF_PASSWORD"
+  }
+}
+```
+
+There are some helper scripts available in the agent repository to interact with the pprof endpoints. The scripts are located in the `scripts` directory.
+
+These scripts profile the machine and then open your browser to the pprof web interface. The pprof web interface allows you to analyze the profile data.
+
+## Profiling the cpu
+```bash
+cd apps/agent
+set PPROF_USERNAME=XXX
+set PPROF_PASSWORD=XXX 
+set MACHINE_ID=XXX 
+
+bash ./scripts/profile.bash
+```
+
+
+## Profiling memory
+```bash
+cd apps/agent
+set PPROF_USERNAME=XXX
+set PPROF_PASSWORD=XXX 
+set MACHINE_ID=XXX 
+
+bash ./scripts/heap.bash
+```


### PR DESCRIPTION
* **feat(mint.json): add new page for Agent profiling under Services group feat(profiling.mdx): add documentation for agent profiling endpoints and scripts**
* **fix: use sha256 to prevent timing attacks**

<sub><a href="https://huly.app/guest/unkey?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjgyOGE5OTJhNmFiOWVlZjU1OTk4OTIiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctamFtZXMtdW5rZXktNjY2YWYwNzktNjliNzJiMzYyNi05ZGM2MGUiLCJwcm9kdWN0SWQiOiIifQ.u6ItTzK0WTqGEUVz5UYM6kjfOpb9SI4KY1MtH20HPUM">Huly&reg;: <b>ENG-1828</b></a></sub>