### PR TITLE
fix: handle multiple ratelimit responses from agent correctly

### DIFF
--- a/apps/api/src/integration/sdk/verify_with_ratelimit.test.ts
+++ b/apps/api/src/integration/sdk/verify_with_ratelimit.test.ts
@@ -1,0 +1,54 @@
+import { IntegrationHarness } from "@/pkg/testutil/integration-harness";
+import { Unkey } from "@unkey/api/src/index"; // use unbundled raw esm typescript
+import { schema } from "@unkey/db";
+import { newId } from "@unkey/id";
+import { expect, test } from "vitest";
+
+test("1 per 10 seconds", async (t) => {
+  const h = await IntegrationHarness.init(t);
+
+  const root = await h.createRootKey([`api.${h.resources.userApi.id}.create_key`]);
+
+  await h.db.primary.insert(schema.roles).values({
+    id: newId("test"),
+    workspaceId: h.resources.userWorkspace.id,
+    name: "role",
+  });
+
+  const sdk = new Unkey({
+    baseUrl: h.baseUrl,
+    rootKey: root.key,
+  });
+
+  const { result: key, error: createKeyError } = await sdk.keys.create({
+    apiId: h.resources.userApi.id,
+    ownerId: "ownerId",
+    roles: ["role"],
+    ratelimit: {
+      limit: 1,
+      duration: 10000,
+      async: false,
+    },
+  });
+  expect(createKeyError).toBeUndefined();
+  expect(key).toBeDefined();
+
+  const { result: firstVerify, error: firstVerifyError } = await sdk.keys.verify({
+    apiId: h.resources.userApi.id,
+    key: key!.key,
+    ratelimit: {
+      cost: 1,
+    },
+  });
+  expect(firstVerifyError).toBeUndefined();
+  expect(firstVerify).toBeDefined();
+  expect(firstVerify!.code).toBe("VALID");
+
+  const { result: secondVerify, error: secondVerifyError } = await sdk.keys.verify({
+    apiId: h.resources.userApi.id,
+    key: key!.key,
+  });
+  expect(secondVerifyError).toBeUndefined();
+  expect(secondVerify).toBeDefined();
+  expect(secondVerify!.code).toBe("RATE_LIMITED");
+});

--- a/apps/api/src/pkg/keys/service.ts
+++ b/apps/api/src/pkg/keys/service.ts
@@ -470,7 +470,6 @@ export class KeyService {
 
       return Err(new MissingRatelimitError(r.name));
     }
-    console.warn(JSON.stringify({ req, ratelimits }, null, 2));
 
     const [pass, ratelimit] = await this.ratelimit(c, data.key, ratelimits);
     if (!pass) {

--- a/apps/api/src/pkg/ratelimit/client.ts
+++ b/apps/api/src/pkg/ratelimit/client.ts
@@ -94,9 +94,15 @@ export class DurableRateLimiter implements RateLimiter {
   ): Promise<Result<RatelimitResponse, RatelimitError>> {
     const res = await Promise.all(req.map((r) => this.limit(c, r)));
     for (const r of res) {
-      if (!r.val?.current) {
+      if (r.err) {
         return r;
       }
+      if (!r.val.pass) {
+        return r;
+      }
+    }
+    if (res.length > 0) {
+      return Ok(res[0].val!);
     }
 
     return Ok({ current: -1, pass: true, reset: -1 });


### PR DESCRIPTION
<sub><a href="https://huly.app/guest/unkey?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjgzMTZiZTJhNmFiOWVlZjU1OWFiYTYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctamFtZXMtdW5rZXktNjY2YWYwNzktNjliNzJiMzYyNi05ZGM2MGUiLCJwcm9kdWN0SWQiOiIifQ.IgIToH_nU293fQctHgdzCLKkoOBZjwhi41vqEoFZNKI">Huly&reg;: <b>ENG-1835</b></a></sub>