### PR TITLE
fix: don't set ratelimitAsync to null when updating a key

### DIFF
--- a/apps/api/src/routes/v1_keys_updateKey.happy.test.ts
+++ b/apps/api/src/routes/v1_keys_updateKey.happy.test.ts
@@ -382,7 +382,7 @@ test.only("update ratelimit should not disable it", async (t) => {
       ratelimit: {
         async: true,
         limit: 5,
-        refillInterval: 5000,
+        duration: 5000,
       },
     },
   });
@@ -412,6 +412,6 @@ test.only("update ratelimit should not disable it", async (t) => {
   expect(verify.status, `expected 200, received: ${JSON.stringify(verify)}`).toBe(200);
   expect(verify.body.ratelimit).toBeDefined();
   expect(verify.body.ratelimit!.limit).toBe(5);
-  expect(verify.body.ratelimit!.remaining).toBeDefined();
-  expect(verify.body.ratelimit!.reset).toBeDefined();
+  expect(verify.body.ratelimit!.remaining).toBe(4);
+  expect(verify.body.ratelimit!.reset).toBeGreaterThan(Date.now());
 });

--- a/apps/api/src/routes/v1_keys_updateKey.happy.test.ts
+++ b/apps/api/src/routes/v1_keys_updateKey.happy.test.ts
@@ -346,7 +346,7 @@ test("omit enabled update", async (t) => {
   expect(found?.enabled).toEqual(true);
 });
 
-test.only("update ratelimit should not disable it", async (t) => {
+test("update ratelimit should not disable it", async (t) => {
   const h = await IntegrationHarness.init(t);
 
   const root = await h.createRootKey([

--- a/apps/api/src/routes/v1_keys_updateKey.happy.test.ts
+++ b/apps/api/src/routes/v1_keys_updateKey.happy.test.ts
@@ -6,7 +6,9 @@ import { newId } from "@unkey/id";
 import { KeyV1 } from "@unkey/keys";
 import { IntegrationHarness } from "src/pkg/testutil/integration-harness";
 
+import type { V1KeysCreateKeyRequest, V1KeysCreateKeyResponse } from "./v1_keys_createKey";
 import type { V1KeysUpdateKeyRequest, V1KeysUpdateKeyResponse } from "./v1_keys_updateKey";
+import type { V1KeysVerifyKeyRequest, V1KeysVerifyKeyResponse } from "./v1_keys_verifyKey";
 
 test("returns 200", async (t) => {
   const h = await IntegrationHarness.init(t);
@@ -342,4 +344,74 @@ test("omit enabled update", async (t) => {
   expect(found).toBeDefined();
   expect(found?.name).toEqual("test");
   expect(found?.enabled).toEqual(true);
+});
+
+test.only("update ratelimit should not disable it", async (t) => {
+  const h = await IntegrationHarness.init(t);
+
+  const root = await h.createRootKey([
+    `api.${h.resources.userApi.id}.create_key`,
+    `api.${h.resources.userApi.id}.update_key`,
+  ]);
+
+  const key = await h.post<V1KeysCreateKeyRequest, V1KeysCreateKeyResponse>({
+    url: "/v1/keys.createKey",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${root.key}`,
+    },
+    body: {
+      apiId: h.resources.userApi.id,
+      name: "my key",
+      ownerId: "team_123",
+    },
+  });
+
+  expect(key.status).toBe(200);
+
+  const update = await h.post<V1KeysUpdateKeyRequest, V1KeysUpdateKeyResponse>({
+    url: "/v1/keys.updateKey",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${root.key}`,
+    },
+    body: {
+      keyId: key.body.keyId,
+      name: "Customer X",
+      ownerId: "user_123",
+      ratelimit: {
+        async: true,
+        limit: 5,
+        refillInterval: 5000,
+      },
+    },
+  });
+
+  expect(update.status).toBe(200);
+
+  const found = await h.db.primary.query.keys.findFirst({
+    where: (table, { eq }) => eq(table.id, key.body.keyId),
+  });
+
+  expect(found).toBeDefined();
+  expect(found!.ratelimitAsync).toEqual(true);
+  expect(found!.ratelimitLimit).toEqual(5);
+  expect(found!.ratelimitDuration).toEqual(5000);
+
+  const verify = await h.post<V1KeysVerifyKeyRequest, V1KeysVerifyKeyResponse>({
+    url: "/v1/keys.verifyKey",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: {
+      apiId: h.resources.userApi.id,
+      key: key.body.key,
+    },
+  });
+
+  expect(verify.status, `expected 200, received: ${JSON.stringify(verify)}`).toBe(200);
+  expect(verify.body.ratelimit).toBeDefined();
+  expect(verify.body.ratelimit!.limit).toBe(5);
+  expect(verify.body.ratelimit!.remaining).toBeDefined();
+  expect(verify.body.ratelimit!.reset).toBeDefined();
 });

--- a/apps/api/src/routes/v1_keys_updateKey.ts
+++ b/apps/api/src/routes/v1_keys_updateKey.ts
@@ -226,9 +226,11 @@ export const registerV1KeysUpdate = (app: App) =>
           ratelimitAsync:
             req.ratelimit === null
               ? null
-              : req.ratelimit?.async ?? typeof req.ratelimit?.type === "undefined"
-                ? null
-                : req.ratelimit?.type === "fast",
+              : typeof req.ratelimit === "undefined"
+                ? undefined
+                : typeof req.ratelimit.async === "boolean"
+                  ? req.ratelimit.async
+                  : req.ratelimit?.type === "fast",
           ratelimitLimit: req.ratelimit === null ? null : req.ratelimit?.limit ?? null,
           ratelimitDuration:
             req.ratelimit === null

--- a/apps/api/src/routes/v1_keys_updateKey.ts
+++ b/apps/api/src/routes/v1_keys_updateKey.ts
@@ -54,8 +54,8 @@ const route = createRoute({
                   .optional()
                   .openapi({
                     deprecated: true,
-                    description:
-                      "Fast ratelimiting doesn't add latency, while consistent ratelimiting is more accurate.",
+                    description: `Fast ratelimiting doesn't add latency, while consistent ratelimiting is more accurate.
+Deprecated, use 'async' instead`,
                     externalDocs: {
                       description: "Learn more",
                       url: "https://unkey.dev/docs/features/ratelimiting",
@@ -67,27 +67,45 @@ const route = createRoute({
                   .optional()
                   .openapi({
                     description:
-                      "Asnyc ratelimiting doesn't add latency, while sync ratelimiting is more accurate.",
+                      "Asnyc ratelimiting doesn't add latency, while sync ratelimiting is slightly more accurate.",
                     externalDocs: {
                       description: "Learn more",
                       url: "https://unkey.dev/docs/features/ratelimiting",
                     },
                   }),
                 limit: z.number().int().min(1).openapi({
-                  description: "The total amount of burstable requests.",
+                  description: "The total amount of requests allowed in a single window.",
                 }),
 
-                refillRate: z.number().int().min(1).optional().openapi({
-                  description: "How many tokens to refill during each refillInterval.",
-                  deprecated: true,
-                }),
-                refillInterval: z.number().int().min(1).openapi({
-                  description:
-                    "Determines the speed at which tokens are refilled, in milliseconds.",
-                }),
-                duration: z.number().int().min(1).optional().openapi({
-                  description: "The duration of each ratelimit window, in milliseconds.",
-                }),
+                refillRate: z
+                  .number()
+                  .int()
+                  .min(1)
+                  .optional()
+                  .openapi({
+                    description: `How many tokens to refill during each refillInterval.
+Deprecated, use 'limit' instead.`,
+                    deprecated: true,
+                  }),
+                refillInterval: z
+                  .number()
+                  .int()
+                  .min(1)
+                  .optional()
+                  .openapi({
+                    description: `Determines the speed at which tokens are refilled, in milliseconds.
+Deprecated, use 'duration'`,
+                    deprecated: true,
+                  }),
+                duration: z
+                  .number()
+                  .int()
+                  .min(1)
+                  .optional()
+                  .openapi({
+                    description: `The duration of each ratelimit window, in milliseconds.
+This field will become required in a future version.`,
+                  }),
               })
               .nullish()
               .openapi({


### PR DESCRIPTION
<sub><a href="https://huly.app/guest/unkey?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2Njg5MGU5MjhhZTA4ZTZhZWJiY2M2NGQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctamFtZXMtdW5rZXktNjY2YWYwNzktNjliNzJiMzYyNi05ZGM2MGUiLCJwcm9kdWN0SWQiOiIifQ.86OEPVq38WKj7E9Gq7N1wUJEeRyHa7b3-xzEO8Ze8Y0">Huly&reg;: <b>ENG-1863</b></a></sub>