### PR TITLE
fix: refactor SQL query to order by lastUsed descending and limit to 1 result

### DIFF
--- a/internal/tinybird/pipes/endpoint__get_last_used.pipe
+++ b/internal/tinybird/pipes/endpoint__get_last_used.pipe
@@ -4,7 +4,9 @@ TOKEN "endpoint__get_last_used__v1_endpoint_read_2224" READ
 NODE mv_keys_last_used_pipe_0365_0
 SQL >
 
-    %
-    SELECT lastUsed FROM mv_keys_last_used where keyId = {{String(keyId, required=True)}}
-
-
+   %
+    SELECT lastUsed
+    FROM mv_keys_last_used
+    where keyId = {{ String(keyId, required=True) }}
+    ORDER BY lastUsed desc
+    LIMIT 1


### PR DESCRIPTION
<sub><a href="https://huly.app/guest/unkey?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjhiYjkzZDhhZTA4ZTZhZWJiY2VkOTIiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctamFtZXMtdW5rZXktNjY2YWYwNzktNjliNzJiMzYyNi05ZGM2MGUiLCJwcm9kdWN0SWQiOiIifQ.bAl--T4MtzTzPHtLr2sQve3bclZpSRT4yn2KTlwVBc8">Huly&reg;: <b>ENG-1867</b></a></sub>