### PR TITLE
fix: use the identityId as ratelimit identifier

### DIFF
--- a/apps/api/src/pkg/keys/service.ts
+++ b/apps/api/src/pkg/keys/service.ts
@@ -87,6 +87,7 @@ type ValidResponse = {
 type VerifyKeyResult = NotFoundResponse | InvalidResponse | ValidResponse;
 
 type RatelimitRequest = {
+  identity: string;
   name: string;
   cost?: number;
   limit?: number;
@@ -131,7 +132,7 @@ export class KeyService {
       apiId?: string;
       permissionQuery?: PermissionQuery;
       ratelimit?: { cost?: number };
-      ratelimits?: Array<RatelimitRequest>;
+      ratelimits?: Array<Omit<RatelimitRequest, "identity">>;
     },
   ): Promise<
     Result<
@@ -212,7 +213,7 @@ export class KeyService {
       apiId?: string;
       permissionQuery?: PermissionQuery;
       ratelimit?: { cost?: number };
-      ratelimits?: Array<RatelimitRequest>;
+      ratelimits?: Array<Omit<RatelimitRequest, "identity">>;
     },
   ): Promise<
     Result<
@@ -452,6 +453,7 @@ export class KeyService {
       data.key.ratelimitLimit !== null
     ) {
       ratelimits.default = {
+        identity: data.identity?.id ?? data.key.id,
         name: "default",
         cost: req.ratelimit?.cost ?? 1,
         limit: data.key.ratelimitLimit,
@@ -461,6 +463,7 @@ export class KeyService {
     for (const r of req.ratelimits ?? []) {
       if (typeof r.limit !== "undefined" && typeof r.duration !== "undefined") {
         ratelimits[r.name] = {
+          identity: data.identity?.id ?? data.key.id,
           name: r.name,
           cost: r.cost ?? 1,
           limit: r.limit,
@@ -472,6 +475,7 @@ export class KeyService {
       const configured = data.ratelimits[r.name];
       if (configured) {
         ratelimits[configured.name] = {
+          identity: data.identity?.id ?? data.key.id,
           name: configured.name,
           cost: r.cost ?? 1,
           limit: configured.limit,
@@ -555,7 +559,7 @@ export class KeyService {
         name: r.name,
         async: !!key.ratelimitAsync,
         workspaceId: key.workspaceId,
-        identifier: key.id,
+        identifier: r.identity,
         cost: r.cost,
         interval: r.duration,
         limit: r.limit,

--- a/apps/api/src/pkg/testutil/harness.ts
+++ b/apps/api/src/pkg/testutil/harness.ts
@@ -114,7 +114,8 @@ export abstract class Harness {
   }
 
   public async createKey(opts?: {
-    roles: {
+    identityId?: string;
+    roles?: {
       name: string;
       permissions?: string[];
     }[];
@@ -127,6 +128,7 @@ export abstract class Harness {
     const keyId = newId("test");
     await this.db.primary.insert(schema.keys).values({
       id: keyId,
+      identityId: opts?.identityId,
       keyAuthId: this.resources.userKeyAuth.id,
       hash,
       start: key.slice(0, 8),

--- a/apps/api/src/routes/v1_keys_verifyKey.multilimit.test.ts
+++ b/apps/api/src/routes/v1_keys_verifyKey.multilimit.test.ts
@@ -139,6 +139,130 @@ describe("without identities", () => {
 });
 
 describe("with identity", () => {
+  describe("with multiple keys per identity", async () => {
+    test("ratelimit is shared across many keys", async (t) => {
+      const h = await IntegrationHarness.init(t);
+
+      const identityId = newId("test");
+      await h.db.primary.insert(schema.identities).values({
+        id: identityId,
+        externalId: "test",
+        environment: "test",
+        workspaceId: h.resources.userWorkspace.id,
+      });
+
+      await h.db.primary.insert(schema.ratelimits).values({
+        id: newId("test"),
+        identityId,
+        limit: 100,
+        duration: 60_0000,
+        name: "100per10m",
+        workspaceId: h.resources.userWorkspace.id,
+      });
+
+      const keys = await Promise.all(
+        new Array(20).fill(null).map((_) => h.createKey({ identityId })),
+      );
+
+      const total = 1000;
+      let pass = 0;
+
+      for (let i = 0; i < total; i++) {
+        const key = keys[Math.floor(Math.random() * keys.length)];
+
+        const res = await h.post<V1KeysVerifyKeyRequest, V1KeysVerifyKeyResponse>({
+          url: "/v1/keys.verifyKey",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: {
+            key: key.key,
+            apiId: h.resources.userApi.id,
+            ratelimits: [
+              {
+                name: "100per10m",
+              },
+            ],
+          },
+        });
+        expect(res.status, `received: ${JSON.stringify(res, null, 2)}`).toBe(200);
+        if (res.body.code === "VALID") {
+          pass += 1;
+        }
+      }
+
+      expect(pass).toBeGreaterThanOrEqual(100);
+      expect(pass).toBeLessThanOrEqual(200);
+    });
+    test("a second key is rejected", async (t) => {
+      const h = await IntegrationHarness.init(t);
+
+      const identityId = newId("test");
+      await h.db.primary.insert(schema.identities).values({
+        id: identityId,
+        externalId: "test",
+        environment: "test",
+        workspaceId: h.resources.userWorkspace.id,
+      });
+
+      await h.db.primary.insert(schema.ratelimits).values({
+        id: newId("test"),
+        identityId,
+        limit: 10,
+        duration: 60_000,
+        name: "10per60s",
+        workspaceId: h.resources.userWorkspace.id,
+      });
+
+      const key1 = await h.createKey({ identityId });
+      const key2 = await h.createKey({ identityId });
+
+      /**
+       * Exhaust the limit by calling the first key over and over
+       */
+      while (true) {
+        const res = await h.post<V1KeysVerifyKeyRequest, V1KeysVerifyKeyResponse>({
+          url: "/v1/keys.verifyKey",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: {
+            key: key1.key,
+            apiId: h.resources.userApi.id,
+            ratelimits: [
+              {
+                name: "10per60s",
+              },
+            ],
+          },
+        });
+
+        expect(res.status, `received: ${JSON.stringify(res, null, 2)}`).toBe(200);
+        if (res.body.code === "RATE_LIMITED") {
+          break;
+        }
+      }
+
+      const res = await h.post<V1KeysVerifyKeyRequest, V1KeysVerifyKeyResponse>({
+        url: "/v1/keys.verifyKey",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: {
+          key: key2.key,
+          apiId: h.resources.userApi.id,
+          ratelimits: [
+            {
+              name: "10per60s",
+            },
+          ],
+        },
+      });
+      expect(res.status, `received: ${JSON.stringify(res, null, 2)}`).toBe(200);
+      expect(res.body.code).toEqual("RATE_LIMITED");
+    });
+  });
+
   describe("with ratelimits on key and identity", () => {
     test("ratelimits on key should take precedence and pass", async (t) => {
       const h = await IntegrationHarness.init(t);


### PR DESCRIPTION
In order to share ratelimits across keys for a single identity, we need to use the identityId as ratelimit identifier instead of the keyId