### PR TITLE
chore(landing/changelog): make the tagged text the same font-size as blog does

### DIFF
--- a/apps/www/components/changelog/changelog-grid-item.tsx
+++ b/apps/www/components/changelog/changelog-grid-item.tsx
@@ -49,7 +49,12 @@ export async function ChangelogGridItem({ className, changelog }: Props) {
           <Image src={changelog.image.toString()} alt={changelog.title} width={1100} height={860} />
         </Frame>
       )}
-      <div className="w-full flex flex-col gap-12 prose-thead:border-none">
+      <div
+        className={cn(
+          "w-full flex flex-col gap-12 prose-thead:border-none",
+          "prose-sm md:prose-md prose-strong:text-white/90 prose-code:text-white/80 prose-code:bg-white/10 prose-code:px-2 prose-code:py-1 prose-code:border-white/20 prose-code:rounded-md prose-pre:p-0 prose-pre:m-0 prose-pre:leading-6",
+        )}
+      >
         <MDX code={changelog.body.code} />
         <XShareButton
           className="my-2"


### PR DESCRIPTION
Making the Changelog `code` the same as Blog is doing

Before

![CleanShot 2024-07-15 at 06 09 34@2x](https://github.com/user-attachments/assets/a7aefc8e-5a70-4ac0-a46a-2070e7246830)

After

![CleanShot 2024-07-15 at 06 09 50@2x](https://github.com/user-attachments/assets/9612e510-b2ea-4062-a3a3-f1b4d92051cf)
