### PR TITLE
chore(landing): hide badge above hero

### DIFF
--- a/apps/www/app/hero/hero-main-section.tsx
+++ b/apps/www/app/hero/hero-main-section.tsx
@@ -6,13 +6,13 @@ import { ArrowRight, BookOpen, ChevronRight, LogIn } from "lucide-react";
 export function HeroMainSection() {
   return (
     <div className="relative flex flex-col items-center text-center xl:text-left xl:items-start">
-      <Link href="/accelerate" target="">
+      {/* <Link href="/accelerate" target="">
         <RainbowDarkButton
           className="mb-6"
           label="Launch Week: June 24-29"
           IconRight={ArrowRight}
         />
-      </Link>
+      </Link> */}
       <h1 className="bg-gradient-to-br text-pretty text-transparent bg-gradient-stop bg-clip-text from-white via-white via-30% to-white/30 max-w-sm sm:max-w-none xl:max-w-lg font-medium text-[32px] leading-none sm:text-[56px] md:text-[64px] xl:text-[64px] tracking-tighter">
         Build better APIs faster
       </h1>


### PR DESCRIPTION
For now, we don't have any badge/update to show in the Hero section, therefore hiding it temporarily.

Before
![CleanShot 2024-07-15 at 06 38 57@2x](https://github.com/user-attachments/assets/838948b0-90af-468a-9261-a8f789f21f76)

After
![CleanShot 2024-07-15 at 06 39 01@2x](https://github.com/user-attachments/assets/9bbcec16-f2fe-4485-9afe-89fac92ce50e)
