### PR TITLE
fix(dashboard/root-keys): push to a different route instead of refreshing the same one, right after creating a root key

### DIFF
--- a/apps/dashboard/app/(app)/settings/root-keys/new/client.tsx
+++ b/apps/dashboard/app/(app)/settings/root-keys/new/client.tsx
@@ -166,7 +166,7 @@ export const Client: React.FC<Props> = ({ apis }) => {
             key.reset();
             setSelectedPermissions([]);
             setName("");
-            router.refresh();
+            router.push("/settings/root-keys");
           }
         }}
       >


### PR DESCRIPTION
This PR makes sure the user is redirected to the root key listing page right after successfully creating a new root key.

The previous behavior was an issue because it only refreshed the `settings/root-keys/new` route which is the same creation form as the user just had submitted. In other words, the user would remain in the same root key creation form/submission  page, even after successfully submitting the form.

Before
https://github.com/user-attachments/assets/1a58b67d-9fb0-429c-b222-819994419671

After
https://github.com/user-attachments/assets/16ff2cbe-dfb7-479e-a654-4c137b51e932

