### PR TITLE
chore(dashboard/button): add opacity-50 to disabled button

### DIFF
--- a/apps/dashboard/components/ui/button.tsx
+++ b/apps/dashboard/components/ui/button.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center rounded-md font-medium text-sm max-sm:text-xs transition-colors focus-visible:outline-none gap-2 disabled:pointer-events-none	 duration-200 whitespace-nowrap",
+  "inline-flex items-center justify-center rounded-md font-medium text-sm max-sm:text-xs transition-colors focus-visible:outline-none gap-2 disabled:pointer-events-none disabled:opacity-50 duration-200 whitespace-nowrap",
   {
     variants: {
       variant: {


### PR DESCRIPTION
## Before
The button only had `pointer-events-none` applied to the `disabled:` modifier
![CleanShot 2024-07-15 at 08 49 39@2x](https://github.com/user-attachments/assets/f7749812-0eec-4f38-9e9a-a6afff123806)

## After
Added `opacity-50` to disabled modifier
![CleanShot 2024-07-15 at 08 49 33@2x](https://github.com/user-attachments/assets/4b2fb0ed-12b1-4503-8f4f-0072744d4b64)
