### PR TITLE
feat: double Click on Root Key start should redirect to settings

### DIFF
--- a/apps/dashboard/components/dashboard/root-key-table/index.tsx
+++ b/apps/dashboard/components/dashboard/root-key-table/index.tsx
@@ -93,7 +93,7 @@ export const RootKeyTable: React.FC<Props> = ({ data }) => {
         <Tooltip>
           <TooltipTrigger>
           <Badge
-              onDoubleClick={() => {
+              onClick={() => {
                 router.push(`/settings/root-keys/${row.original.id}`);
               }}
               variant="secondary"

--- a/apps/dashboard/components/dashboard/root-key-table/index.tsx
+++ b/apps/dashboard/components/dashboard/root-key-table/index.tsx
@@ -92,7 +92,14 @@ export const RootKeyTable: React.FC<Props> = ({ data }) => {
       cell: ({ row }) => (
         <Tooltip>
           <TooltipTrigger>
-            <Badge variant="secondary">{row.getValue("start")}...</Badge>
+          <Badge
+              onDoubleClick={() => {
+                router.push(`/settings/root-keys/${row.original.id}`);
+              }}
+              variant="secondary"
+            >
+              {row.getValue("start")}...
+            </Badge>
           </TooltipTrigger>
           <TooltipContent>
             This is the first part of the key to visually match it. We don't store the full key for

--- a/apps/dashboard/components/dashboard/root-key-table/index.tsx
+++ b/apps/dashboard/components/dashboard/root-key-table/index.tsx
@@ -92,14 +92,9 @@ export const RootKeyTable: React.FC<Props> = ({ data }) => {
       cell: ({ row }) => (
         <Tooltip>
           <TooltipTrigger>
-          <Badge
-              onClick={() => {
-                router.push(`/settings/root-keys/${row.original.id}`);
-              }}
-              variant="secondary"
-            >
-              {row.getValue("start")}...
-            </Badge>
+            <Link href={`/settings/root-keys/${row.original.id}`}>
+              <Badge variant="secondary">{row.getValue("start")}...</Badge>
+            </Link>
           </TooltipTrigger>
           <TooltipContent>
             This is the first part of the key to visually match it. We don't store the full key for


### PR DESCRIPTION
## What does this PR do?

On double click of the root key start, it redirects the user to the settings instead of having the user to click on 3 dots and then select the details to view the settings

https://www.loom.com/share/5432908be4ae44c9a93139e27ce7fe5f?sid=41ce8430-0c68-4dfe-b87b-6052d4afe2b0 

Fixes #1937

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

Go to the root key in settings and then double-click on the start of the root key that is shown

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ x] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary
