### PR TITLE
fix: raise the http timeouts

### DIFF
--- a/apps/agent/pkg/connect/ratelimit.go
+++ b/apps/agent/pkg/connect/ratelimit.go
@@ -15,6 +15,8 @@ import (
 	"github.com/unkeyed/unkey/apps/agent/services/ratelimit"
 )
 
+var _ ratelimitv1connect.RatelimitServiceHandler = (*ratelimitServer)(nil)
+
 type ratelimitServer struct {
 	svc       ratelimit.Service
 	logger    logging.Logger

--- a/apps/agent/pkg/connect/service.go
+++ b/apps/agent/pkg/connect/service.go
@@ -137,14 +137,14 @@ func (s *Server) Listen(addr string) error {
 	// > like http.ListenAndServe, http.ListenAndServeTLS and http.Serve are unfit for public Internet
 	// > servers.
 	// >
-	// > hose functions leave the Timeouts to their default off value, with no way of enabling them,
+	// > Those functions leave the Timeouts to their default off value, with no way of enabling them,
 	// > so if you use them you'll soon be leaking connections and run out of file descriptors. I've
 	// > made this mistake at least half a dozen times.
 	// >
 	// > Instead, create a http.Server instance with ReadTimeout and WriteTimeout and use its
 	// > corresponding methods, like in the example a few paragraphs above.
-	srv.ReadTimeout = 5 * time.Second
-	srv.WriteTimeout = 10 * time.Second
+	srv.ReadTimeout = 10 * time.Second
+	srv.WriteTimeout = 20 * time.Second
 
 	s.logger.Info().Str("addr", addr).Msg("listening")
 	go func() {

--- a/apps/agent/services/ratelimit/pushpull.go
+++ b/apps/agent/services/ratelimit/pushpull.go
@@ -25,7 +25,6 @@ func (s *service) PushPull(ctx context.Context, req *ratelimitv1.PushPullRequest
 			Current:    r.Current,
 		}
 	}
-	s.logger.Debug().Interface("req", req).Interface("res", res).Msg("ratelimit")
 
 	return res, nil
 


### PR DESCRIPTION
I have a feeling this is preventing bufconnect to write the response sometimes, causing empty unary responses.
This could be the reason why our ratelimiting is flaky right now.
