### PR TITLE
fix: save button position on api/keys/settings page

### DIFF
--- a/apps/dashboard/app/(app)/apis/[apiId]/keys/[keyAuthId]/[keyId]/settings/update-key-enabled.tsx
+++ b/apps/dashboard/app/(app)/apis/[apiId]/keys/[keyAuthId]/[keyId]/settings/update-key-enabled.tsx
@@ -99,10 +99,7 @@ export const UpdateKeyEnabled: React.FC<Props> = ({ apiKey }) => {
             </div>
           </CardContent>
           <CardFooter className="justify-end">
-            <Button
-              disabled={updateEnabled.isLoading || !form.formState.isValid}
-              type="submit"
-            >
+            <Button disabled={updateEnabled.isLoading || !form.formState.isValid} type="submit">
               {updateEnabled.isLoading ? <Loading /> : "Save"}
             </Button>
           </CardFooter>

--- a/apps/dashboard/app/(app)/apis/[apiId]/keys/[keyAuthId]/[keyId]/settings/update-key-enabled.tsx
+++ b/apps/dashboard/app/(app)/apis/[apiId]/keys/[keyAuthId]/[keyId]/settings/update-key-enabled.tsx
@@ -101,7 +101,6 @@ export const UpdateKeyEnabled: React.FC<Props> = ({ apiKey }) => {
           <CardFooter className="justify-end">
             <Button
               disabled={updateEnabled.isLoading || !form.formState.isValid}
-              className="mt-4 "
               type="submit"
             >
               {updateEnabled.isLoading ? <Loading /> : "Save"}

--- a/apps/dashboard/app/(app)/apis/[apiId]/keys/[keyAuthId]/[keyId]/settings/update-key-expiration.tsx
+++ b/apps/dashboard/app/(app)/apis/[apiId]/keys/[keyAuthId]/[keyId]/settings/update-key-expiration.tsx
@@ -146,7 +146,6 @@ export const UpdateKeyExpiration: React.FC<Props> = ({ apiKey }) => {
             />
             <Button
               disabled={changeExpiration.isLoading || !form.formState.isValid}
-              className="mt-4 "
               type="submit"
             >
               {changeExpiration.isLoading ? <Loading /> : "Save"}

--- a/apps/dashboard/app/(app)/apis/[apiId]/keys/[keyAuthId]/[keyId]/settings/update-key-expiration.tsx
+++ b/apps/dashboard/app/(app)/apis/[apiId]/keys/[keyAuthId]/[keyId]/settings/update-key-expiration.tsx
@@ -144,10 +144,7 @@ export const UpdateKeyExpiration: React.FC<Props> = ({ apiKey }) => {
                 </FormItem>
               )}
             />
-            <Button
-              disabled={changeExpiration.isLoading || !form.formState.isValid}
-              type="submit"
-            >
+            <Button disabled={changeExpiration.isLoading || !form.formState.isValid} type="submit">
               {changeExpiration.isLoading ? <Loading /> : "Save"}
             </Button>
           </CardFooter>

--- a/apps/dashboard/app/(app)/apis/[apiId]/keys/[keyAuthId]/[keyId]/settings/update-key-name.tsx
+++ b/apps/dashboard/app/(app)/apis/[apiId]/keys/[keyAuthId]/[keyId]/settings/update-key-name.tsx
@@ -95,7 +95,6 @@ export const UpdateKeyName: React.FC<Props> = ({ apiKey }) => {
           <CardFooter className="justify-end">
             <Button
               disabled={updateName.isLoading || !form.formState.isValid}
-              className="mt-4 "
               type="submit"
             >
               {updateName.isLoading ? <Loading /> : "Save"}

--- a/apps/dashboard/app/(app)/apis/[apiId]/keys/[keyAuthId]/[keyId]/settings/update-key-name.tsx
+++ b/apps/dashboard/app/(app)/apis/[apiId]/keys/[keyAuthId]/[keyId]/settings/update-key-name.tsx
@@ -93,10 +93,7 @@ export const UpdateKeyName: React.FC<Props> = ({ apiKey }) => {
             </div>
           </CardContent>
           <CardFooter className="justify-end">
-            <Button
-              disabled={updateName.isLoading || !form.formState.isValid}
-              type="submit"
-            >
+            <Button disabled={updateName.isLoading || !form.formState.isValid} type="submit">
               {updateName.isLoading ? <Loading /> : "Save"}
             </Button>
           </CardFooter>

--- a/apps/dashboard/app/(app)/apis/[apiId]/keys/[keyAuthId]/[keyId]/settings/update-key-owner-id.tsx
+++ b/apps/dashboard/app/(app)/apis/[apiId]/keys/[keyAuthId]/[keyId]/settings/update-key-owner-id.tsx
@@ -101,10 +101,7 @@ export const UpdateKeyOwnerId: React.FC<Props> = ({ apiKey }) => {
             </div>
           </CardContent>
           <CardFooter className="justify-end">
-            <Button
-              disabled={updateOwnerId.isLoading || !form.formState.isValid}
-              type="submit"
-            >
+            <Button disabled={updateOwnerId.isLoading || !form.formState.isValid} type="submit">
               {updateOwnerId.isLoading ? <Loading /> : "Save"}
             </Button>
           </CardFooter>

--- a/apps/dashboard/app/(app)/apis/[apiId]/keys/[keyAuthId]/[keyId]/settings/update-key-owner-id.tsx
+++ b/apps/dashboard/app/(app)/apis/[apiId]/keys/[keyAuthId]/[keyId]/settings/update-key-owner-id.tsx
@@ -103,7 +103,6 @@ export const UpdateKeyOwnerId: React.FC<Props> = ({ apiKey }) => {
           <CardFooter className="justify-end">
             <Button
               disabled={updateOwnerId.isLoading || !form.formState.isValid}
-              className="mt-4 "
               type="submit"
             >
               {updateOwnerId.isLoading ? <Loading /> : "Save"}

--- a/apps/dashboard/app/(app)/apis/[apiId]/keys/[keyAuthId]/[keyId]/settings/update-key-ratelimit.tsx
+++ b/apps/dashboard/app/(app)/apis/[apiId]/keys/[keyAuthId]/[keyId]/settings/update-key-ratelimit.tsx
@@ -193,7 +193,6 @@ export const UpdateKeyRatelimit: React.FC<Props> = ({ apiKey }) => {
             />
             <Button
               disabled={updateRatelimit.isLoading || !form.formState.isValid}
-              className="mt-4 "
               type="submit"
             >
               {updateRatelimit.isLoading ? <Loading /> : "Save"}

--- a/apps/dashboard/app/(app)/apis/[apiId]/keys/[keyAuthId]/[keyId]/settings/update-key-ratelimit.tsx
+++ b/apps/dashboard/app/(app)/apis/[apiId]/keys/[keyAuthId]/[keyId]/settings/update-key-ratelimit.tsx
@@ -191,10 +191,7 @@ export const UpdateKeyRatelimit: React.FC<Props> = ({ apiKey }) => {
                 </FormItem>
               )}
             />
-            <Button
-              disabled={updateRatelimit.isLoading || !form.formState.isValid}
-              type="submit"
-            >
+            <Button disabled={updateRatelimit.isLoading || !form.formState.isValid} type="submit">
               {updateRatelimit.isLoading ? <Loading /> : "Save"}
             </Button>
           </CardFooter>

--- a/apps/dashboard/app/(app)/apis/[apiId]/keys/[keyAuthId]/[keyId]/settings/update-key-remaining.tsx
+++ b/apps/dashboard/app/(app)/apis/[apiId]/keys/[keyAuthId]/[keyId]/settings/update-key-remaining.tsx
@@ -237,10 +237,7 @@ export const UpdateKeyRemaining: React.FC<Props> = ({ apiKey }) => {
                 </FormItem>
               )}
             />
-            <Button
-              disabled={updateRemaining.isLoading || !form.formState.isValid}
-              type="submit"
-            >
+            <Button disabled={updateRemaining.isLoading || !form.formState.isValid} type="submit">
               {updateRemaining.isLoading ? <Loading /> : "Save"}
             </Button>
           </CardFooter>

--- a/apps/dashboard/app/(app)/apis/[apiId]/keys/[keyAuthId]/[keyId]/settings/update-key-remaining.tsx
+++ b/apps/dashboard/app/(app)/apis/[apiId]/keys/[keyAuthId]/[keyId]/settings/update-key-remaining.tsx
@@ -239,7 +239,6 @@ export const UpdateKeyRemaining: React.FC<Props> = ({ apiKey }) => {
             />
             <Button
               disabled={updateRemaining.isLoading || !form.formState.isValid}
-              className="mt-4 "
               type="submit"
             >
               {updateRemaining.isLoading ? <Loading /> : "Save"}


### PR DESCRIPTION
## What does this PR do?

It's fixing the save button position on api/keys/settings page

Fixes #2048 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

Just follow the issue steps.

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary

### Before
![image](https://github.com/user-attachments/assets/f07b9b04-bbed-49f8-98ce-bf5976f27b60)

### After
![image](https://github.com/user-attachments/assets/f6b0c4e8-dfd0-4acf-9982-483c237bb65e)

all the cards are showing the button in the right position now.
