### PR TITLE
fix: Icon alignment when creating a root key

### DIFF
--- a/apps/dashboard/app/(app)/settings/root-keys/new/client.tsx
+++ b/apps/dashboard/app/(app)/settings/root-keys/new/client.tsx
@@ -190,7 +190,7 @@ export const Client: React.FC<Props> = ({ apis }) => {
           <p className="mt-2 text-sm font-medium text-center text-gray-700 ">
             Try creating a new api key for your users:
           </p>
-          <Code className="flex flex-col items-start justify-between gap-2 w-full text-xs">
+          <Code className="flex flex-col items-start gap-2 w-full text-xs">
             <div className="w-full shrink-0 flex items-center justify-end gap-2">
               <VisibleButton isVisible={showKeyInSnippet} setIsVisible={setShowKeyInSnippet} />
               <CopyButton value={snippet} />

--- a/apps/dashboard/app/(app)/settings/root-keys/new/client.tsx
+++ b/apps/dashboard/app/(app)/settings/root-keys/new/client.tsx
@@ -196,7 +196,7 @@ export const Client: React.FC<Props> = ({ apis }) => {
               <CopyButton value={snippet} />
             </div>
             <div className="text-wrap">
-              {showKeyInSnippet ? snippet : snippet.replace(key.data?.key ?? "", maskedKey)}    
+              {showKeyInSnippet ? snippet : snippet.replace(key.data?.key ?? "", maskedKey)}
             </div>
           </Code>
           <DialogClose asChild>

--- a/apps/dashboard/app/(app)/settings/root-keys/new/client.tsx
+++ b/apps/dashboard/app/(app)/settings/root-keys/new/client.tsx
@@ -92,7 +92,7 @@ export const Client: React.FC<Props> = ({ apis }) => {
         <CardContent>
           <div className="flex flex-col gap-4">
             {Object.entries(workspacePermissions).map(([category, allPermissions]) => (
-              <div className="flex flex-col gap-2">
+              <div key={`workspace-${category}`} className="flex flex-col gap-2">
                 <span className="font-medium">{category}</span>{" "}
                 <div className="flex flex-col gap-1">
                   {Object.entries(allPermissions).map(([action, { description, permission }]) => (
@@ -112,7 +112,7 @@ export const Client: React.FC<Props> = ({ apis }) => {
         </CardContent>
       </Card>
       {apis.map((api) => (
-        <Card>
+        <Card key={api.id}>
           <CardHeader>
             <CardTitle>{api.name}</CardTitle>
             <CardDescription>
@@ -124,7 +124,7 @@ export const Client: React.FC<Props> = ({ apis }) => {
             <div className="flex flex-col gap-4">
               {Object.entries(apiPermissions(api.id)).map(([category, roles]) => {
                 return (
-                  <div className="flex flex-col gap-2">
+                  <div key={`api-${category}`} className="flex flex-col gap-2">
                     <span className="font-medium">{category}</span>
                     <div className="flex flex-col gap-1">
                       {Object.entries(roles).map(([action, { description, permission }]) => {
@@ -180,7 +180,7 @@ export const Client: React.FC<Props> = ({ apis }) => {
 
             <Code className="flex items-center justify-between gap-4 my-8 ph-no-capture">
               {showKey ? key.data?.key : maskedKey}
-              <div className="flex items-center justify-between gap-4 ">
+              <div className="flex items-center justify-between gap-2">
                 <VisibleButton isVisible={showKey} setIsVisible={setShowKey} />
                 <CopyButton value={key.data?.key ?? ""} />
               </div>
@@ -190,11 +190,13 @@ export const Client: React.FC<Props> = ({ apis }) => {
           <p className="mt-2 text-sm font-medium text-center text-gray-700 ">
             Try creating a new api key for your users:
           </p>
-          <Code className="flex items-center justify-between gap-4 pt-10 my-8 text-xs">
-            {showKeyInSnippet ? snippet : snippet.replace(key.data?.key ?? "", maskedKey)}
-            <div className="relative -top-8 right-[88px] flex items-start justify-between gap-4">
+          <Code className="flex flex-col items-start justify-between gap-2 w-full text-xs">
+            <div className="w-full shrink-0 flex items-center justify-end gap-2">
               <VisibleButton isVisible={showKeyInSnippet} setIsVisible={setShowKeyInSnippet} />
               <CopyButton value={snippet} />
+            </div>
+            <div className="text-wrap">
+              {showKeyInSnippet ? snippet : snippet.replace(key.data?.key ?? "", maskedKey)}    
             </div>
           </Code>
           <DialogClose asChild>


### PR DESCRIPTION
## What does this PR do?

It fixes the icon alignment when creating a root key. It also fixes some react warnings related to missing `key`.

Fixes #2054 

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

Just follow the steps to reproduce posted in the issue #2054 

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary

### Before
![2054-before](https://github.com/user-attachments/assets/1f379bf9-a5ca-4aea-abdb-cc1a3a59d2ce)

### After
![2054-after](https://github.com/user-attachments/assets/409b105b-c558-4d3d-9815-653745217a50)

