### PR TITLE
chore: Remove extra prop and loading of workspace 

### DIFF
--- a/apps/dashboard/app/(app)/settings/root-keys/[keyId]/update-root-key-name.tsx
+++ b/apps/dashboard/app/(app)/settings/root-keys/[keyId]/update-root-key-name.tsx
@@ -9,13 +9,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import {
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-  FormMessage,
-} from "@/components/ui/form";
+import { Form, FormControl, FormField, FormItem, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { toast } from "@/components/ui/toaster";
@@ -76,8 +70,7 @@ export const UpdateRootKeyName: React.FC<Props> = ({ apiKey }) => {
           <CardHeader>
             <CardTitle>Name</CardTitle>
             <CardDescription>
-              Give your root key a name. This is optional and not customer
-              facing.
+              Give your root key a name. This is optional and not customer facing.
             </CardDescription>
           </CardHeader>
           <CardContent className="flex justify-between item-center">
@@ -90,12 +83,7 @@ export const UpdateRootKeyName: React.FC<Props> = ({ apiKey }) => {
                 render={({ field }) => (
                   <FormItem>
                     <FormControl>
-                      <Input
-                        {...field}
-                        type="string"
-                        className="h-8 max-w-sm"
-                        autoComplete="off"
-                      />
+                      <Input {...field} type="string" className="h-8 max-w-sm" autoComplete="off" />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -104,10 +92,7 @@ export const UpdateRootKeyName: React.FC<Props> = ({ apiKey }) => {
             </div>
           </CardContent>
           <CardFooter className="justify-end">
-            <Button
-              disabled={updateName.isLoading || !form.formState.isValid}
-              type="submit"
-            >
+            <Button disabled={updateName.isLoading || !form.formState.isValid} type="submit">
               {updateName.isLoading ? <Loading /> : "Save"}
             </Button>
           </CardFooter>

--- a/apps/dashboard/app/(app)/settings/root-keys/[keyId]/update-root-key-name.tsx
+++ b/apps/dashboard/app/(app)/settings/root-keys/[keyId]/update-root-key-name.tsx
@@ -9,7 +9,13 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { Form, FormControl, FormField, FormItem, FormMessage } from "@/components/ui/form";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormMessage,
+} from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { toast } from "@/components/ui/toaster";
@@ -30,7 +36,6 @@ const formSchema = z.object({
 type Props = {
   apiKey: {
     id: string;
-    workspaceId: string;
     name: string | null;
   };
 };
@@ -71,7 +76,8 @@ export const UpdateRootKeyName: React.FC<Props> = ({ apiKey }) => {
           <CardHeader>
             <CardTitle>Name</CardTitle>
             <CardDescription>
-              Give your root key a name. This is optional and not customer facing.
+              Give your root key a name. This is optional and not customer
+              facing.
             </CardDescription>
           </CardHeader>
           <CardContent className="flex justify-between item-center">
@@ -84,7 +90,12 @@ export const UpdateRootKeyName: React.FC<Props> = ({ apiKey }) => {
                 render={({ field }) => (
                   <FormItem>
                     <FormControl>
-                      <Input {...field} type="string" className="h-8 max-w-sm" autoComplete="off" />
+                      <Input
+                        {...field}
+                        type="string"
+                        className="h-8 max-w-sm"
+                        autoComplete="off"
+                      />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -93,7 +104,10 @@ export const UpdateRootKeyName: React.FC<Props> = ({ apiKey }) => {
             </div>
           </CardContent>
           <CardFooter className="justify-end">
-            <Button disabled={updateName.isLoading || !form.formState.isValid} type="submit">
+            <Button
+              disabled={updateName.isLoading || !form.formState.isValid}
+              type="submit"
+            >
               {updateName.isLoading ? <Loading /> : "Save"}
             </Button>
           </CardFooter>

--- a/apps/dashboard/lib/trpc/routers/key/updateRootKeyName.ts
+++ b/apps/dashboard/lib/trpc/routers/key/updateRootKeyName.ts
@@ -16,7 +16,7 @@ export const updateRootKeyName = t.procedure
   .mutation(async ({ input, ctx }) => {
     const key = await db.query.keys.findFirst({
       where: (table, { eq, isNull, and }) =>
-        and(eq(table.id, input.keyId), isNull(table.deletedAt))
+        and(eq(table.id, input.keyId), isNull(table.deletedAt)),
     });
 
     const workspace = await db.query.workspaces.findFirst({

--- a/apps/dashboard/lib/trpc/routers/key/updateRootKeyName.ts
+++ b/apps/dashboard/lib/trpc/routers/key/updateRootKeyName.ts
@@ -16,10 +16,7 @@ export const updateRootKeyName = t.procedure
   .mutation(async ({ input, ctx }) => {
     const key = await db.query.keys.findFirst({
       where: (table, { eq, isNull, and }) =>
-        and(eq(table.id, input.keyId), isNull(table.deletedAt)),
-      with: {
-        workspace: true,
-      },
+        and(eq(table.id, input.keyId), isNull(table.deletedAt))
     });
 
     const workspace = await db.query.workspaces.findFirst({


### PR DESCRIPTION
Removes extra prop and the loading of workspace I missed during a code review. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified component functionality by removing the `workspaceId` requirement from the root key update process.
  
- **Bug Fixes**
	- Improved efficiency in fetching key data by eliminating unnecessary workspace context from the update procedure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->