### PR TITLE
fix: always return the raw llm response

### DIFF
--- a/apps/semantic-cache/src/pkg/util/index.ts
+++ b/apps/semantic-cache/src/pkg/util/index.ts
@@ -21,18 +21,6 @@ export async function createCompletionChunk(content: string, stop = false) {
   };
 }
 
-export function OpenAIResponse(content: string) {
-  return {
-    choices: [
-      {
-        message: {
-          content,
-        },
-      },
-    ],
-  };
-}
-
 /**
  * Extracts the word enclosed in double quotes from the given chunk.
  *


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced response handling by caching the entire chat completion object as JSON, allowing for richer data retrieval.
  
- **Bug Fixes**
	- Simplified response management, improving performance and clarity in data processing.

- **Refactor**
	- Removed the `OpenAIResponse` function to streamline response handling, indicating a shift in approach to managing OpenAI responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->