### PR TITLE
fix: A user can collapse/expand APIs when creating a new root key

### DIFF
--- a/apps/dashboard/app/(app)/settings/root-keys/new/client.tsx
+++ b/apps/dashboard/app/(app)/settings/root-keys/new/client.tsx
@@ -24,7 +24,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { trpc } from "@/lib/trpc/client";
 import type { UnkeyPermission } from "@unkey/rbac";
 import { useRouter } from "next/navigation";
-import { AwaitedReactNode, JSXElementConstructor, ReactElement, ReactNode, ReactPortal, useState } from "react";
+import { useState } from "react";
 import { apiPermissions, workspacePermissions } from "../[keyId]/permissions/permissions";
 import { ChevronRight } from "lucide-react";
 type Props = {

--- a/apps/dashboard/app/(app)/settings/root-keys/new/client.tsx
+++ b/apps/dashboard/app/(app)/settings/root-keys/new/client.tsx
@@ -24,7 +24,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { trpc } from "@/lib/trpc/client";
 import type { UnkeyPermission } from "@unkey/rbac";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { AwaitedReactNode, JSXElementConstructor, ReactElement, ReactNode, ReactPortal, useState } from "react";
 import { apiPermissions, workspacePermissions } from "../[keyId]/permissions/permissions";
 import { ChevronRight } from "lucide-react";
 type Props = {
@@ -40,7 +40,7 @@ export const Client: React.FC<Props> = ({ apis }) => {
   const [selectedPermissions, setSelectedPermissions] = useState<UnkeyPermission[]>([]);
 
   const key = trpc.rootKey.create.useMutation({
-    onError(err) {
+    onError(err: { message: string }) {
       console.error(err);
       toast.error(err.message);
     },
@@ -66,19 +66,21 @@ export const Client: React.FC<Props> = ({ apis }) => {
       return prevPermissions.filter((r) => r !== permission);
     });
   };
-  
+
   type CardStates = {
     [key: string]: boolean;
-  }
+  };
 
   const initialCardStates: CardStates = {};
-  apis.map((api) => { initialCardStates[api.id] = false; });
+  apis.map((api) => {
+    initialCardStates[api.id] = false;
+  });
   const [cardStatesMap, setCardStatesMap] = useState(initialCardStates);
 
   const toggleCard = (apiId: string) => {
-    setCardStatesMap(prevStates => ({
+    setCardStatesMap((prevStates) => ({
       ...prevStates,
-      [apiId]: !prevStates[apiId]
+      [apiId]: !prevStates[apiId],
     }));
   };
 
@@ -150,32 +152,39 @@ export const Client: React.FC<Props> = ({ apis }) => {
       </Card>
       {apis.map((api) => (
         <Collapsible
-          key={api.id} 
-          open={cardStatesMap[api.id]} 
+          key={api.id}
+          open={cardStatesMap[api.id]}
           onOpenChange={() => {
-            toggleCard(api.id)
-        }}>
+            toggleCard(api.id);
+          }}
+        >
           <Card>
-              <CardHeader>
-                <CollapsibleTrigger 
-                  className="flex items-center justify-between transition-all [&[data-state=open]>svg]:rotate-90 pb-6"
-                  aria-controls={api.id}
-                  aria-expanded={cardStatesMap[api.id]}>
-                  <CardTitle className="break-all">{api.name}</CardTitle>
-                  <ChevronRight className="w-4 h-4 transition-transform duration-200" aria-hidden="true" />
-                </CollapsibleTrigger>
-                <CollapsibleContent id={api.id}>
+            <CardHeader>
+              <CollapsibleTrigger
+                className="flex items-center justify-between transition-all [&[data-state=open]>svg]:rotate-90 pb-6"
+                aria-controls={api.id}
+                aria-expanded={cardStatesMap[api.id]}
+              >
+                <CardTitle className="break-all">{api.name}</CardTitle>
+                <ChevronRight
+                  className="w-4 h-4 transition-transform duration-200"
+                  aria-hidden="true"
+                />
+              </CollapsibleTrigger>
+              <CollapsibleContent id={api.id}>
                 <CardDescription>
                   Permissions scoped to this API. Enabling these roles only grants access to this
                   specific API.
                 </CardDescription>
-                </CollapsibleContent>
+              </CollapsibleContent>
             </CardHeader>
             <CollapsibleContent>
               <CardContent>
                 <div className="flex flex-col gap-4">
                   {Object.entries(apiPermissions(api.id)).map(([category, roles]) => {
-                    const allPermissionNames = Object.values(roles).map(({ permission }) => permission);
+                    const allPermissionNames = Object.values(roles).map(
+                      ({ permission }) => permission,
+                    );
                     const isAllSelected = allPermissionNames.every((permission) =>
                       selectedPermissions.includes(permission),
                     );

--- a/apps/dashboard/app/(app)/settings/root-keys/new/client.tsx
+++ b/apps/dashboard/app/(app)/settings/root-keys/new/client.tsx
@@ -8,6 +8,7 @@ import { Code } from "@/components/ui/code";
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import {
   Dialog,
   DialogClose,
@@ -16,17 +17,16 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { toast } from "@/components/ui/toaster";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { trpc } from "@/lib/trpc/client";
 import type { UnkeyPermission } from "@unkey/rbac";
+import { ChevronRight } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { apiPermissions, workspacePermissions } from "../[keyId]/permissions/permissions";
-import { ChevronRight } from "lucide-react";
 type Props = {
   apis: {
     id: string;

--- a/apps/dashboard/app/(app)/settings/root-keys/new/client.tsx
+++ b/apps/dashboard/app/(app)/settings/root-keys/new/client.tsx
@@ -72,7 +72,7 @@ export const Client: React.FC<Props> = ({ apis }) => {
   };
 
   const initialCardStates: CardStates = {};
-  apis.map((api) => {
+  apis.forEach((api) => {
     initialCardStates[api.id] = false;
   });
   const [cardStatesMap, setCardStatesMap] = useState(initialCardStates);
@@ -161,13 +161,13 @@ export const Client: React.FC<Props> = ({ apis }) => {
           <Card>
             <CardHeader>
               <CollapsibleTrigger
-                className="flex items-center justify-between transition-all [&[data-state=open]>svg]:rotate-90 pb-6"
+                className="flex items-center justify-between transition-all pb-6"
                 aria-controls={api.id}
                 aria-expanded={cardStatesMap[api.id]}
               >
                 <CardTitle className="break-all">{api.name}</CardTitle>
                 <ChevronRight
-                  className="w-4 h-4 transition-transform duration-200"
+                  className="w-4 h-4 transition-transform duration-200 data-[state=open]:rotate-90"
                   aria-hidden="true"
                 />
               </CollapsibleTrigger>

--- a/apps/dashboard/app/(app)/settings/root-keys/new/client.tsx
+++ b/apps/dashboard/app/(app)/settings/root-keys/new/client.tsx
@@ -161,13 +161,13 @@ export const Client: React.FC<Props> = ({ apis }) => {
           <Card>
             <CardHeader>
               <CollapsibleTrigger
-                className="flex items-center justify-between transition-all pb-6"
+                className="flex items-center justify-between transition-all pb-6 [&[data-state=open]>svg]:rotate-90"
                 aria-controls={api.id}
                 aria-expanded={cardStatesMap[api.id]}
               >
                 <CardTitle className="break-all">{api.name}</CardTitle>
                 <ChevronRight
-                  className="w-4 h-4 transition-transform duration-200 data-[state=open]:rotate-90"
+                  className="w-4 h-4 transition-transform duration-200"
                   aria-hidden="true"
                 />
               </CollapsibleTrigger>

--- a/apps/dashboard/app/(app)/settings/root-keys/new/client.tsx
+++ b/apps/dashboard/app/(app)/settings/root-keys/new/client.tsx
@@ -26,6 +26,7 @@ import type { UnkeyPermission } from "@unkey/rbac";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { apiPermissions, workspacePermissions } from "../[keyId]/permissions/permissions";
+import { ChevronRight } from "lucide-react";
 type Props = {
   apis: {
     id: string;
@@ -156,10 +157,14 @@ export const Client: React.FC<Props> = ({ apis }) => {
         }}>
           <Card>
               <CardHeader>
-                <CollapsibleTrigger asChild>
-                  <CardTitle className="pb-6">{api.name}</CardTitle>
+                <CollapsibleTrigger 
+                  className="flex items-center justify-between transition-all [&[data-state=open]>svg]:rotate-90 pb-6"
+                  aria-controls={api.id}
+                  aria-expanded={cardStatesMap[api.id]}>
+                  <CardTitle className="break-all">{api.name}</CardTitle>
+                  <ChevronRight className="w-4 h-4 transition-transform duration-200" aria-hidden="true" />
                 </CollapsibleTrigger>
-                <CollapsibleContent>
+                <CollapsibleContent id={api.id}>
                 <CardDescription>
                   Permissions scoped to this API. Enabling these roles only grants access to this
                   specific API.

--- a/apps/dashboard/app/(app)/settings/root-keys/new/client.tsx
+++ b/apps/dashboard/app/(app)/settings/root-keys/new/client.tsx
@@ -16,6 +16,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { toast } from "@/components/ui/toaster";
@@ -63,6 +64,21 @@ export const Client: React.FC<Props> = ({ apis }) => {
       }
       return prevPermissions.filter((r) => r !== permission);
     });
+  };
+  
+  type CardStates = {
+    [key: string]: boolean;
+  }
+
+  const initialCardStates: CardStates = {};
+  apis.map((api) => { initialCardStates[api.id] = false; });
+  const [cardStatesMap, setCardStatesMap] = useState(initialCardStates);
+
+  const toggleCard = (apiId: string) => {
+    setCardStatesMap(prevStates => ({
+      ...prevStates,
+      [apiId]: !prevStates[apiId]
+    }));
   };
 
   return (
@@ -132,56 +148,69 @@ export const Client: React.FC<Props> = ({ apis }) => {
         </CardContent>
       </Card>
       {apis.map((api) => (
-        <Card key={api.id}>
-          <CardHeader>
-            <CardTitle>{api.name}</CardTitle>
-            <CardDescription>
-              Permissions scoped to this API. Enabling these roles only grants access to this
-              specific API.
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="flex flex-col gap-4">
-              {Object.entries(apiPermissions(api.id)).map(([category, roles]) => {
-                const allPermissionNames = Object.values(roles).map(({ permission }) => permission);
-                const isAllSelected = allPermissionNames.every((permission) =>
-                  selectedPermissions.includes(permission),
-                );
+        <Collapsible
+          key={api.id} 
+          open={cardStatesMap[api.id]} 
+          onOpenChange={() => {
+            toggleCard(api.id)
+        }}>
+          <Card>
+              <CardHeader>
+                <CollapsibleTrigger asChild>
+                  <CardTitle className="pb-6">{api.name}</CardTitle>
+                </CollapsibleTrigger>
+                <CollapsibleContent>
+                <CardDescription>
+                  Permissions scoped to this API. Enabling these roles only grants access to this
+                  specific API.
+                </CardDescription>
+                </CollapsibleContent>
+            </CardHeader>
+            <CollapsibleContent>
+              <CardContent>
+                <div className="flex flex-col gap-4">
+                  {Object.entries(apiPermissions(api.id)).map(([category, roles]) => {
+                    const allPermissionNames = Object.values(roles).map(({ permission }) => permission);
+                    const isAllSelected = allPermissionNames.every((permission) =>
+                      selectedPermissions.includes(permission),
+                    );
 
-                return (
-                  <div key={`api-${category}`} className="flex flex-col gap-2">
-                    <div className="flex flex-col">
-                      <PermissionToggle
-                        permissionName={`selectAll-${category}`}
-                        label={<span className="text-base font-bold">{category}</span>}
-                        description={`Select all for ${category} permissions for this API`}
-                        checked={isAllSelected}
-                        setChecked={(isChecked) => {
-                          allPermissionNames.forEach((permission) => {
-                            handleSetChecked(permission, isChecked);
-                          });
-                        }}
-                      />
-                    </div>
+                    return (
+                      <div key={`api-${category}`} className="flex flex-col gap-2">
+                        <div className="flex flex-col">
+                          <PermissionToggle
+                            permissionName={`selectAll-${category}`}
+                            label={<span className="text-base font-bold">{category}</span>}
+                            description={`Select all for ${category} permissions for this API`}
+                            checked={isAllSelected}
+                            setChecked={(isChecked) => {
+                              allPermissionNames.forEach((permission) => {
+                                handleSetChecked(permission, isChecked);
+                              });
+                            }}
+                          />
+                        </div>
 
-                    <div className="flex flex-col gap-1">
-                      {Object.entries(roles).map(([action, { description, permission }]) => (
-                        <PermissionToggle
-                          key={action}
-                          permissionName={permission}
-                          label={action}
-                          description={description}
-                          checked={selectedPermissions.includes(permission)}
-                          setChecked={(isChecked) => handleSetChecked(permission, isChecked)}
-                        />
-                      ))}
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          </CardContent>
-        </Card>
+                        <div className="flex flex-col gap-1">
+                          {Object.entries(roles).map(([action, { description, permission }]) => (
+                            <PermissionToggle
+                              key={action}
+                              permissionName={permission}
+                              label={action}
+                              description={description}
+                              checked={selectedPermissions.includes(permission)}
+                              setChecked={(isChecked) => handleSetChecked(permission, isChecked)}
+                            />
+                          ))}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </CardContent>
+            </CollapsibleContent>
+          </Card>
+        </Collapsible>
       ))}
       <Button
         onClick={() => {


### PR DESCRIPTION
## What does this PR do?

Currently when a user creates a new root key, we show all the APIs by default. This PR converts those APIs cards into Collapsible cards, default collapsed. The user can expand each API card to add permissions if necessary. 

![Screenshot 2024-09-23 at 12 54 47 PM](https://github.com/user-attachments/assets/6028743e-0e6f-4efb-bc9b-a8be2331e46d)
![Screenshot 2024-09-23 at 12 55 03 PM](https://github.com/user-attachments/assets/77fc79cf-3527-44be-9a9c-0311ca3969ef)
![Screenshot 2024-09-23 at 12 55 14 PM](https://github.com/user-attachments/assets/6c5961c3-b5de-4b4b-a439-69b71c421f48)


Fixes #1980 

*If there is not an issue for this, please create one first. This is used to tracking purposes and also helps use understand why this PR exists*

<!-- If there isn't an issue for this PR, please re-review our Contributing Guide and create an issue -->

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Manual testing. 

1. Log into Unkey
2. Ensure that you have at least 1 API created
3. Go to Settings > Root Keys > Create New Root Key
4. Observe that API card is collapsed. On title click, the card expands. Additional cards can independently expand/collapse. 

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a collapsible UI component for displaying API permissions in the Client component.
	- Each API card now features a collapsible trigger, allowing users to expand or collapse content related to API permissions.

- **Improvements**
	- Enhanced the layout of API cards to a dynamic collapsible structure for better user interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->