### PR TITLE
feat: update externalId to (dis-)connect identities

### DIFF
--- a/apps/api/src/routes/v1_identities_updateIdentity.happy.test.ts
+++ b/apps/api/src/routes/v1_identities_updateIdentity.happy.test.ts
@@ -124,6 +124,7 @@ test("sets new ratelimits", async (t) => {
     where: (table, { eq }) => eq(table.identityId, identity.id),
   });
 
+  console.log({ found })
   expect(found.length).toBe(ratelimits.length);
   for (const rl of ratelimits) {
     expect(

--- a/apps/api/src/routes/v1_identities_updateIdentity.happy.test.ts
+++ b/apps/api/src/routes/v1_identities_updateIdentity.happy.test.ts
@@ -124,7 +124,7 @@ test("sets new ratelimits", async (t) => {
     where: (table, { eq }) => eq(table.identityId, identity.id),
   });
 
-  console.log({ found })
+  console.log({ found });
   expect(found.length).toBe(ratelimits.length);
   for (const rl of ratelimits) {
     expect(

--- a/apps/api/src/routes/v1_identities_updateIdentity.ts
+++ b/apps/api/src/routes/v1_identities_updateIdentity.ts
@@ -253,7 +253,6 @@ export const registerV1IdentitiesUpdateIdentity = (app: App) =>
         /**
          * Delete undesired ratelimits
          */
-
         for (const rl of deleteRatelimits) {
           await tx.delete(schema.ratelimits).where(eq(schema.ratelimits.id, rl.id));
           auditLogs.push({

--- a/apps/api/src/routes/v1_keys_createKey.ts
+++ b/apps/api/src/routes/v1_keys_createKey.ts
@@ -569,7 +569,7 @@ async function getRoleIds(
   return roles.map((r) => r.id);
 }
 
-async function upsertIdentity(
+export async function upsertIdentity(
   db: Database,
   workspaceId: string,
   externalId: string,

--- a/apps/api/src/routes/v1_keys_updateKey.happy.test.ts
+++ b/apps/api/src/routes/v1_keys_updateKey.happy.test.ts
@@ -738,7 +738,6 @@ describe("externalId", () => {
         identity: true,
       },
     });
-    console.log(JSON.stringify({ found }, null, 2));
     expect(found).toBeDefined();
     expect(found!.identity).toBeNull();
   });

--- a/tools/local/src/cmd/dashboard.ts
+++ b/tools/local/src/cmd/dashboard.ts
@@ -57,7 +57,7 @@ which you need in to copy in the next step.`,
       AGENT_TOKEN: "agent-auth-secret",
     },
     Clickhouse: {
-      CLICKHOUSE_URL: "http://default:password@clickhouse:8123",
+      CLICKHOUSE_URL: "http://default:password@localhost:8123",
     },
   });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced `externalId` field for updating keys, replacing the deprecated `ownerId` field.
	- Enhanced identity management logic to prioritize `externalId` when connecting keys to identities.

- **Bug Fixes**
	- Improved test coverage for identity connections related to `externalId` and `ownerId`.

- **Documentation**
	- Updated OpenAPI documentation to reflect changes in the request schema and clarify the usage of `externalId` and `ownerId`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->