### PR TITLE
fix: align single code block with the buttons

### DIFF
--- a/apps/www/components/blog/blog-code-block.tsx
+++ b/apps/www/components/blog/blog-code-block.tsx
@@ -99,7 +99,7 @@ export function BlogCodeBlockSingle({ className, children }: any) {
   }
   return (
     <div className={cn(CN_BLOG_CODE_BLOCK, className, "p-4")}>
-      <div className="flex flex-row items-center justify-center gap-4">
+      <div className="flex flex-row items-center justify-between gap-4">
         <SyntaxHighlighter
           language={block.className.replace(/language-/, "")}
           style={darkTheme}

--- a/apps/www/components/blog/blog-code-block.tsx
+++ b/apps/www/components/blog/blog-code-block.tsx
@@ -98,26 +98,28 @@ export function BlogCodeBlockSingle({ className, children }: any) {
     element.click();
   }
   return (
-    <div className={cn(CN_BLOG_CODE_BLOCK, className, "pl-4 pb-4")}>
-      <div className="flex flex-row justify-end gap-4 mt-2 mr-4 border-white/10 ">
-        <CopyButton value={copyData} />
-        <button
-          type="button"
-          aria-label="Download code"
-          className="p-0 m-0 align-top bg-transparent"
-          onClick={handleDownload}
+    <div className={cn(CN_BLOG_CODE_BLOCK, className, "p-4")}>
+      <div className="flex flex-row items-center justify-center gap-4">
+        <SyntaxHighlighter
+          language={block.className.replace(/language-/, "")}
+          style={darkTheme}
+          showLineNumbers={true}
+          highlighter={"hljs"}
         >
-          <BlogCodeDownload />
-        </button>
+          {block.children.trim()}
+        </SyntaxHighlighter>
+        <div className="flex gap-2 border-white/10 ">
+          <CopyButton value={copyData} />
+          <button
+            type="button"
+            aria-label="Download code"
+            className="p-0 m-0 align-top bg-transparent"
+            onClick={handleDownload}
+          >
+            <BlogCodeDownload />
+          </button>
+        </div>
       </div>
-      <SyntaxHighlighter
-        language={block.className.replace(/language-/, "")}
-        style={darkTheme}
-        showLineNumbers={true}
-        highlighter={"hljs"}
-      >
-        {block.children.trim()}
-      </SyntaxHighlighter>
     </div>
   );
 }

--- a/apps/www/components/blog/blog-code-block.tsx
+++ b/apps/www/components/blog/blog-code-block.tsx
@@ -97,9 +97,27 @@ export function BlogCodeBlockSingle({ className, children }: any) {
     document.body.appendChild(element); // Required for this to work in FireFox
     element.click();
   }
+
+  const isSingleLine = (block.children.match(/\n/g) || []).length < 2;
+
   return (
-    <div className={cn(CN_BLOG_CODE_BLOCK, className, "p-4")}>
-      <div className="flex flex-row items-center justify-between gap-4">
+    <div className={cn(CN_BLOG_CODE_BLOCK, className, `${isSingleLine ? "p-4" : "pl-4 pb-4"}`)}>
+      <div className="flex flex-row justify-end gap-4 mt-2 mr-4 border-white/10">
+        {!isSingleLine && (
+          <>
+            <CopyButton value={copyData} />
+            <button
+              type="button"
+              aria-label="Download code"
+              className="p-0 m-0 align-top bg-transparent"
+              onClick={handleDownload}
+            >
+              <BlogCodeDownload />
+            </button>
+          </>
+        )}
+      </div>
+      <div className={`flex ${isSingleLine ? "items-center justify-between" : ""}`}>
         <SyntaxHighlighter
           language={block.className.replace(/language-/, "")}
           style={darkTheme}
@@ -108,17 +126,20 @@ export function BlogCodeBlockSingle({ className, children }: any) {
         >
           {block.children.trim()}
         </SyntaxHighlighter>
-        <div className="flex gap-2 border-white/10 ">
-          <CopyButton value={copyData} />
-          <button
-            type="button"
-            aria-label="Download code"
-            className="p-0 m-0 align-top bg-transparent"
-            onClick={handleDownload}
-          >
-            <BlogCodeDownload />
-          </button>
-        </div>
+
+        {isSingleLine && (
+          <div className={cn("flex gap-4 border-white/10")}>
+            <CopyButton value={copyData} />
+            <button
+              type="button"
+              aria-label="Download code"
+              className="p-0 m-0 align-top bg-transparent"
+              onClick={handleDownload}
+            >
+              <BlogCodeDownload />
+            </button>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/apps/www/components/blog/suggested-blogs.tsx
+++ b/apps/www/components/blog/suggested-blogs.tsx
@@ -19,8 +19,8 @@ export function SuggestedBlogs({ className, currentPostSlug }: BlogListProps): J
   return (
     <div>
       {posts.map((post) => (
-        <div className={cn("flex flex-col w-full mt-8 prose", className)}>
-          <Link href={post.url} key={post.url}>
+        <div key={post.url} className={cn("flex flex-col w-full mt-8 prose", className)}>
+          <Link href={post.url}>
             <div className="flex w-full">
               <div className="flex flex-col gap-2">
                 <Frame size="sm">


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Updated styles to align the single line code block with the buttons.

Fixes #2148

Before:
![image](https://github.com/user-attachments/assets/5da74e51-577c-4c41-8673-4747239b8f1b)

After:
![image](https://github.com/user-attachments/assets/9ca7abac-73f8-49e8-99f3-ba065ff9bd3e)


<!-- *If there is not an issue for this, please create one first. This is used to tracking purposes and also helps use understand why this PR exists* -->

<!-- If there isn't an issue for this PR, please re-review our Contributing Guide and create an issue -->

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Visit the [blog](https://www.unkey.com/blog/fixing-serverless-with-a-vps) the single line code block should be vertically center aligned with the buttons.


## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved layout and organization of the code block component in the blog.
	- Enhanced visual alignment of code display and action buttons.
	- Introduced conditional rendering for code blocks based on content length.
	- Added a key prop to enhance rendering efficiency in the suggested blogs component.

- **Bug Fixes**
	- Streamlined structure for the download button and copy functionality.

- **Documentation**
	- Added a new README file for the "@unkey/api" package to enhance user understanding and usability.

- **Refactor**
	- Restructured JSX layout for better maintainability and clarity.
	- Updated API definitions for improved clarity and consistency in error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->