### PR TITLE
chore: Unkey PDF Viewer template [SIDE QUEST]

### DIFF
--- a/apps/www/app/templates/data.ts
+++ b/apps/www/app/templates/data.ts
@@ -48,6 +48,18 @@ export type Template = {
 };
 
 export const templates: Record<string, Template> = {
+  "pdf-view": {
+    title: "Protecting Digital Content Access",
+    description:
+      "Leverage Unkey’s short-lived keys to grant temporary access to digital content (e.g., e-books, videos, or streams), expiring after a set duration.",
+    authors: ["unrenamed"],
+    repository: "https://github.com/unrenamed/unkey-pdf-view",
+    image: "/images/templates/pdf-view.png",
+    readmeUrl:
+      "https://raw.githubusercontent.com/unrenamed/unkey-pdf-view/refs/heads/main/README.md",
+    language: "Typescript",
+    framework: "Next.js",
+  },
   "flask-rbac": {
     title: "Flask middleware with RBAC",
     description: "Protect your Flask API with Unkey",

--- a/oss.gg/7_create_a_template.md
+++ b/oss.gg/7_create_a_template.md
@@ -3,6 +3,7 @@
 Record yourself going through the setup of Unkey for the first time and provide feedback. Depending on how much feedback you provide, we’ll assign 150 or 300 points.
 Create a minimal starter template to showcase how you can use Unkey with a particular framework. For example [Ratelimit your Next.js routes](https://www.unkey.com/templates/ratelimit-nextjs) or [Middleware for golang’s echo framework](https://www.unkey.com/templates/echo-middleware).
 Requirements:
+
 - No duplicates, please check [unkey.com/templates](https://www.unkey.com/templates) first
 - Must be open source, either committed to [github.com/unkeyed/examples](https://github.com/unkeyed/examples) or to your own GitHub account.
 - Must be MIT licensed
@@ -27,4 +28,7 @@ Your turn 👇
 ////////////////////////////
 
 » 04-October-2024 by Harsh Bhat [Flask RBAC route protection using unkey](https://github.com/harshsbhat/unkey-flask.git)
+
+» 04-October-2024 by Nazar Poshtarenko [Time-Sensitive API Keys for Digital Content Access](https://github.com/unrenamed/unkey-pdf-view.git)
+
 ---


### PR DESCRIPTION
## What does this PR do?

Adds a demo app showcasing time-limited access to specific PDF pages, restricting full downloads. Example of protecting digital content with temporary access using Unkey SDK.  https://github.com/unrenamed/unkey-pdf-view


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated template creation guidelines for the Unkey framework, including new requirements for checking duplicates, open-source commitment, and licensing.
	- Added two new example projects with links to their GitHub repositories.
	- Retained requirement for a README.md file with a quickstart guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->