### PR TITLE
Fix incorrect error code and reference link for UNAUTHORIZED error

### DIFF
--- a/apps/docs/api-reference/errors/code/UNAUTHORIZED.mdx
+++ b/apps/docs/api-reference/errors/code/UNAUTHORIZED.mdx
@@ -1,6 +1,6 @@
 ---
 title: UNAUTHORIZED
-openapi-schema: ErrInternalServerError
+openapi-schema: ErrUnauthorized
 ---
 
 ## Problem


### PR DESCRIPTION
## What does this PR do?

This PR fixes the incorrect error code and reference link in the example for the UNAUTHORIZED error code within the documentation. The example previously displayed INTERNAL_SERVER_ERROR as the code and its corresponding documentation link. These have now been corrected to reflect the proper UNAUTHORIZED error code and the correct documentation link.

Fixes #2226 

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [X] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

1. Verify that the UNAUTHORIZED error code is now displayed correctly in [Docs -> API Reference -> Errors -> UNAUTHORIZED](https://www.unkey.com/docs/api-reference/errors/code/UNAUTHORIZED).
2. Ensure the documentation link provided for the UNAUTHORIZED error code now points to the correct reference.


## Checklist

### Required

- [X] Filled out the "How to test" section in this PR
- [X] Read [Contributing Guide](./CONTRIBUTING.md)
- [X] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [X] Ran `pnpm build`
- [X] Ran `pnpm fmt`
- [X] Checked for warnings, there are none
- [X] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [X] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [X] Updated the Unkey Docs if changes were necessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the `openapi-schema` value for the `UNAUTHORIZED` error to reflect a more accurate categorization of authorization failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->