### PR TITLE
refactor(ui): insufficient padding in codeblock components

### DIFF
--- a/apps/www/components/template/codeblock.tsx
+++ b/apps/www/components/template/codeblock.tsx
@@ -61,6 +61,7 @@ export function CodeBlock(props: any) {
                     {line.map((token, key) => (
                       <span key={` ${key}-${token}`} {...getTokenProps({ token })} />
                     ))}
+                    <span className="pl-6"></span>
                   </div>
                 );
               })}


### PR DESCRIPTION
## What does this PR do?

Adds padding in the right side of the codeblock component

Fixes #2298

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

Before 
![before](https://github.com/user-attachments/assets/3ddcb32b-7ca5-4806-8f68-47f03e83e32e)

After
![after](https://github.com/user-attachments/assets/5604b242-35a0-4729-8106-720b5ee8dc5c)


## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced spacing in the rendered output of code blocks for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->