### PR TITLE
fix: reset input fields in API delete dialog after reopening

### DIFF
--- a/apps/dashboard/app/(app)/apis/[apiId]/settings/delete-api.tsx
+++ b/apps/dashboard/app/(app)/apis/[apiId]/settings/delete-api.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { Button } from "@/components/ui/button";
 import type React from "react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { Card, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -83,6 +83,13 @@ export const DeleteApi: React.FC<Props> = ({ api, keys }) => {
   async function onSubmit(_values: z.infer<typeof formSchema>) {
     deleteApi.mutate({ apiId: api.id });
   }
+
+  // useEffect to reset form fields when dialog is closed
+  useEffect(() => {
+    if (!open) {
+      form.reset(); // Reset form when the dialog is closed
+    }
+  }, [open, form.reset]); // Run this whenever `open` changes
 
   return (
     <>

--- a/apps/dashboard/app/(app)/apis/[apiId]/settings/delete-api.tsx
+++ b/apps/dashboard/app/(app)/apis/[apiId]/settings/delete-api.tsx
@@ -1,14 +1,8 @@
 "use client";
-import { Button } from "@/components/ui/button";
-import type React from "react";
-import { useEffect, useState } from "react";
-
-import { Card, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
-import { toast } from "@/components/ui/toaster";
-
 import { Loading } from "@/components/dashboard/loading";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Card, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   Dialog,
   DialogContent,
@@ -25,13 +19,16 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { toast } from "@/components/ui/toaster";
 import { trpc } from "@/lib/trpc/client";
+import { cn } from "@/lib/utils";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter } from "next/navigation";
+import type React from "react";
+import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
-
-import { cn } from "@/lib/utils";
 import { revalidate } from "./actions";
 
 type Props = {
@@ -84,7 +81,7 @@ export const DeleteApi: React.FC<Props> = ({ api, keys }) => {
     deleteApi.mutate({ apiId: api.id });
   }
 
-  function handleDialogOpenChange(newState:boolean){
+  function handleDialogOpenChange(newState: boolean) {
     setOpen(newState);
     form.reset();
   }

--- a/apps/dashboard/app/(app)/apis/[apiId]/settings/delete-api.tsx
+++ b/apps/dashboard/app/(app)/apis/[apiId]/settings/delete-api.tsx
@@ -84,12 +84,10 @@ export const DeleteApi: React.FC<Props> = ({ api, keys }) => {
     deleteApi.mutate({ apiId: api.id });
   }
 
-  // useEffect to reset form fields when dialog is closed
-  useEffect(() => {
-    if (!open) {
-      form.reset(); // Reset form when the dialog is closed
-    }
-  }, [open, form.reset]); // Run this whenever `open` changes
+  function handleDialogOpenChange(newState:boolean){
+    setOpen(newState);
+    form.reset();
+  }
 
   return (
     <>
@@ -123,7 +121,7 @@ export const DeleteApi: React.FC<Props> = ({ api, keys }) => {
           ) : null}
         </CardFooter>
       </Card>
-      <Dialog open={open} onOpenChange={(o) => setOpen(o)}>
+      <Dialog open={open} onOpenChange={handleDialogOpenChange}>
         <DialogContent className="border-alert">
           <DialogHeader>
             <DialogTitle>Delete API</DialogTitle>


### PR DESCRIPTION
## What does this PR do?

This PR fixes the issue where form fields in the "API Delete" dialog do not reset upon reopening. Previously, input values persisted after the dialog was closed and reopened. Now, the form fields are properly reset to their default state when the dialog is opened again.


Fixes #2296 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

1. Navigate to Dashboard -> APIs -> Select any API -> API Settings -> Click on Delete API.
2. Open the Delete API dialog, enter data in the input fields, close the dialog, and then reopen it.
3. Verify that the input fields are reset to their default (empty) state on reopening.

## Checklist

### Required

- [X] Filled out the "How to test" section in this PR
- [X] Read [Contributing Guide](./CONTRIBUTING.md)
- [X] Self-reviewed my own code
- [X] Commented on my code in hard-to-understand areas
- [X] Ran `pnpm build`
- [X] Ran `pnpm fmt`
- [X] Checked for warnings, there are none
- [X] Removed all `console.logs`
- [X] Merged the latest changes from main onto my branch with `git pull origin main`
- [X] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced user experience by resetting form fields in the Delete API dialog when closed.

- **Bug Fixes**
	- Improved functionality to clear inputs, preventing potential user errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->