### PR TITLE
refactor(ui): Insufficient padding in code block component on /templates page

### DIFF
--- a/apps/www/components/template/codeblock.tsx
+++ b/apps/www/components/template/codeblock.tsx
@@ -45,7 +45,7 @@ export function CodeBlock(props: any) {
       <Highlight theme={darkTheme} code={block} language={language[0].replace(/language-/, "")}>
         {({ tokens, getLineProps, getTokenProps }) => {
           return (
-            <pre className="pt-0 pb-5 mt-0 overflow-x-auto leading-7 bg-transparent border-none rounded-none">
+            <pre className="pt-0 pb-5 mt-0 overflow-x-auto leading-7 bg-transparent border-none rounded-none mr-[1.7vmax]">
               {tokens.map((line, i) => {
                 // if the last line is empty, don't render it
                 if (i === tokens.length - 1 && line[0].empty === true) {


### PR DESCRIPTION
## It fixes the padding problem of "templates/rust-rocket"

I have fixed the padding problem on template page in rust-rocket api.

Fixes #2312


## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [x] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

1) Visit https://www.unkey.com/templates/rust-rocket
2) Scroll down to the steps with code blocks containing large code snippets


### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

![image](https://github.com/user-attachments/assets/bf55d62e-9872-4096-8e6c-8ac986be0376)
![image](https://github.com/user-attachments/assets/1d9673d2-88b7-4609-ab5c-777fbffb0642)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the `CodeBlock` component to include a right margin for improved layout and spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->