### PR TITLE
Bug Fix: Fixed field should not allow only whitespace values issue

### DIFF
--- a/apps/dashboard/app/(app)/apis/[apiId]/keys/[keyAuthId]/new/client.tsx
+++ b/apps/dashboard/app/(app)/apis/[apiId]/keys/[keyAuthId]/new/client.tsx
@@ -187,13 +187,6 @@ export const CreateKey: React.FC<Props> = ({ apiId, keyAuthId, defaultBytes, def
 
   async function onSubmit(values: z.infer<typeof formSchema>) {
     // make sure they aren't sent to the server if they are disabled.
-
-    console.log({val: values.prefix})
-
-    if (values.prefix && values.prefix.includes(' ')) {
-      return toast.error("Default prefix cannot contain spaces.");
-    }
-
     if (!values.expireEnabled) {
       delete values.expires;
     }

--- a/apps/dashboard/app/(app)/apis/[apiId]/keys/[keyAuthId]/new/client.tsx
+++ b/apps/dashboard/app/(app)/apis/[apiId]/keys/[keyAuthId]/new/client.tsx
@@ -57,6 +57,9 @@ const formSchema = z.object({
   prefix: z
     .string()
     .max(8, { message: "Please limit the prefix to under 8 characters." })
+    .refine(prefix => !prefix.includes(' '), {
+      message: "Prefix cannot contain spaces.",
+    })
     .optional(),
   ownerId: z.string().optional(),
   name: z.string().optional(),
@@ -184,6 +187,13 @@ export const CreateKey: React.FC<Props> = ({ apiId, keyAuthId, defaultBytes, def
 
   async function onSubmit(values: z.infer<typeof formSchema>) {
     // make sure they aren't sent to the server if they are disabled.
+
+    console.log({val: values.prefix})
+
+    if (values.prefix && values.prefix.includes(' ')) {
+      return toast.error("Default prefix cannot contain spaces.");
+    }
+
     if (!values.expireEnabled) {
       delete values.expires;
     }

--- a/apps/dashboard/app/(app)/apis/[apiId]/settings/default-prefix.tsx
+++ b/apps/dashboard/app/(app)/apis/[apiId]/settings/default-prefix.tsx
@@ -54,7 +54,7 @@ export const DefaultPrefix: React.FC<Props> = ({ keyAuth }) => {
   });
   async function onSubmit(values: z.infer<typeof formSchema>) {
     if (values.defaultPrefix.includes(' ')) {
-      return toast.error("Default prefix cannot be empty or contain only spaces.");
+      return toast.error("Default prefix cannot contain spaces.");
     }
     if (values.defaultPrefix.length > 8) {
       return toast.error("Default prefix is too long, maximum length is 8 characters.");

--- a/apps/dashboard/app/(app)/apis/[apiId]/settings/default-prefix.tsx
+++ b/apps/dashboard/app/(app)/apis/[apiId]/settings/default-prefix.tsx
@@ -53,7 +53,7 @@ export const DefaultPrefix: React.FC<Props> = ({ keyAuth }) => {
     },
   });
   async function onSubmit(values: z.infer<typeof formSchema>) {
-    if (values.defaultPrefix.trim() === '') {
+    if (values.defaultPrefix.includes(' ')) {
       return toast.error("Default prefix cannot be empty or contain only spaces.");
     }
     if (values.defaultPrefix.length > 8) {

--- a/apps/dashboard/app/(app)/apis/[apiId]/settings/default-prefix.tsx
+++ b/apps/dashboard/app/(app)/apis/[apiId]/settings/default-prefix.tsx
@@ -53,6 +53,9 @@ export const DefaultPrefix: React.FC<Props> = ({ keyAuth }) => {
     },
   });
   async function onSubmit(values: z.infer<typeof formSchema>) {
+    if (values.defaultPrefix.trim() === '') {
+      return toast.error("Default prefix cannot be empty or contain only spaces.");
+    }
     if (values.defaultPrefix.length > 8) {
       return toast.error("Default prefix is too long, maximum length is 8 characters.");
     }

--- a/apps/dashboard/lib/trpc/routers/api/setDefaultPrefix.ts
+++ b/apps/dashboard/lib/trpc/routers/api/setDefaultPrefix.ts
@@ -8,7 +8,12 @@ import { rateLimitedProcedure, ratelimit } from "@/lib/trpc/ratelimitProcedure";
 export const setDefaultApiPrefix = rateLimitedProcedure(ratelimit.update)
   .input(
     z.object({
-      defaultPrefix: z.string().max(8, "Prefix can be a maximum of 8 characters"),
+      defaultPrefix: z
+        .string()
+        .max(8, "Prefix can be a maximum of 8 characters")
+        .refine(prefix => !prefix.includes(' '), {
+          message: "Default prefix cannot contain spaces.",
+        }),
       keyAuthId: z.string(),
       workspaceId: z.string(),
     }),

--- a/apps/dashboard/lib/trpc/routers/key/create.ts
+++ b/apps/dashboard/lib/trpc/routers/key/create.ts
@@ -9,7 +9,13 @@ import { z } from "zod";
 export const createKey = rateLimitedProcedure(ratelimit.create)
   .input(
     z.object({
-      prefix: z.string().optional(),
+      prefix: z
+        .string()
+        .max(8, { message: "Please limit the prefix to under 8 characters." })
+        .refine(prefix => !prefix.includes(' '), {
+          message: "Prefix cannot contain spaces.",
+        })
+        .optional(),
       bytes: z.number().int().gte(1).default(16),
       keyAuthId: z.string(),
       ownerId: z.string().nullish(),


### PR DESCRIPTION
## What does this PR do?

Added validation to check the **Default Prefix** is empty or contain whitespaces using .trim() method.

Fixes #2297

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Navigate to Dashbaord -> APIs -> Select anyone API -> API Settings
- Enter only whitespace (e.g., several spaces) in the "Default Prefix" field.
- Attempt to save the changes.
- Check if the error message is showing in bottom right corner or not

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced input validation for the default prefix field to prevent submission of empty or whitespace-only values, with error messaging for users.

- **Bug Fixes**
	- Maintained existing validation checks to ensure robust handling of default prefix submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->