### PR TITLE
feat: Added a new Go stdlib authenication template at `oss.gg/7_create_a_template.md`

### DIFF
--- a/oss.gg/7_create_a_template.md
+++ b/oss.gg/7_create_a_template.md
@@ -39,4 +39,5 @@ Your turn 👇
 » 10-October-2024 by Harsh Bhat [FastAPI Unkey Boilerplate](https://github.com/harshsbhat/unkey-fastapi-boilerplate)
 » 11-October-2024 by Prabin Subedi [Starter template for Unkey Route protection in Hono Webframework in Cloudflare workers](https://github.com/prabincankod/hono-unkey-cflare)
 » 12-October-2024 by Nazar Poshtarenko [Next.js Unkey Pay-as-you-Go Starter Kit](https://github.com/unrenamed/unkey-nextjs-pay-as-you-go)
+» 15-October-2024 by Diwas Rimal [API key authentication with Go stdlib](https://github.com/diwasrimal/unkey-go-stdlib-auth.git)
 ---


### PR DESCRIPTION
## What does this PR do?

Fixes #2429

Added a Go stdlib template  for peforming API authentication using Unkey API keys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a side quest for creating templates using the Unkey framework to build APIs.
	- Included requirements for submissions, such as open-source licensing and a README.md file.
	- Expanded the list of existing submissions with a new entry for an API key authentication template using Go's standard library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->