### PR TITLE
feat: add more cloudflare ratelimits

### DIFF
--- a/apps/api/src/pkg/env.ts
+++ b/apps/api/src/pkg/env.ts
@@ -48,7 +48,10 @@ export const zEnv = z.object({
     }),
   RL_10_60s: cloudflareRatelimiter,
   RL_30_60s: cloudflareRatelimiter,
+  RL_50_60s: cloudflareRatelimiter,
   RL_200_60s: cloudflareRatelimiter,
+  RL_600_60s: cloudflareRatelimiter,
+  RL_1_10s: cloudflareRatelimiter,
   RL_500_10s: cloudflareRatelimiter,
   RL_200_10s: cloudflareRatelimiter,
 });

--- a/apps/api/src/pkg/hono/app.ts
+++ b/apps/api/src/pkg/hono/app.ts
@@ -57,6 +57,7 @@ export function newApp() {
     bearerFormat: "root key",
     type: "http",
     scheme: "bearer",
+    "x-speakeasy-example": "UNKEY_ROOT_KEY",
   });
   return app;
 }

--- a/apps/api/src/pkg/ratelimit/client.ts
+++ b/apps/api/src/pkg/ratelimit/client.ts
@@ -86,7 +86,13 @@ export class AgentRatelimiter implements RateLimiter {
             success: res.success,
             source: "cloudflare",
           });
-          return Ok({ pass: res.success, reset: -1, current: -1, remaining: -1, triggered: null });
+          return Ok({
+            pass: res.success,
+            reset: -1,
+            current: -1,
+            remaining: -1,
+            triggered: res.success ? null : req.name,
+          });
         }
       }
     } catch (err) {

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -55,10 +55,33 @@ namespace_id = "99003060"
 simple = { limit = 30, period = 60}
 
 [[unsafe.bindings]]
+name = "RL_50_60s"
+type = "ratelimit"
+namespace_id = "99005060"
+simple = { limit = 50, period = 60}
+
+
+[[unsafe.bindings]]
 name = "RL_200_60s"
 type = "ratelimit"
 namespace_id = "990020060"
 simple = { limit = 200, period = 60}
+
+
+[[unsafe.bindings]]
+name = "RL_600_60s"
+type = "ratelimit"
+namespace_id = "990060060"
+simple = { limit = 600, period = 60}
+
+
+
+[[unsafe.bindings]]
+name = "RL_1_10s"
+type = "ratelimit"
+namespace_id = "9900110"
+simple = { limit = 1, period = 10}
+
 
 [[unsafe.bindings]]
 name = "RL_500_10s"
@@ -120,10 +143,31 @@ namespace_id = "99003060"
 simple = { limit = 30, period = 60}
 
 [[env.preview.unsafe.bindings]]
+name = "RL_50_60s"
+type = "ratelimit"
+namespace_id = "99005060"
+simple = { limit = 50, period = 60}
+
+
+[[env.preview.unsafe.bindings]]
 name = "RL_200_60s"
 type = "ratelimit"
 namespace_id = "990020060"
 simple = { limit = 200, period = 60}
+
+[[env.preview.unsafe.bindings]]
+name = "RL_600_60s"
+type = "ratelimit"
+namespace_id = "990060060"
+simple = { limit = 600, period = 60}
+
+
+[[env.canary.unsafe.bindings]]
+name = "RL_1_10s"
+type = "ratelimit"
+namespace_id = "9900110"
+simple = { limit = 1, period = 10}
+
 
 [[env.preview.unsafe.bindings]]
 name = "RL_500_10s"
@@ -179,10 +223,31 @@ namespace_id = "99003060"
 simple = { limit = 30, period = 60}
 
 [[env.canary.unsafe.bindings]]
+name = "RL_50_60s"
+type = "ratelimit"
+namespace_id = "99005060"
+simple = { limit = 50, period = 60}
+
+
+[[env.canary.unsafe.bindings]]
 name = "RL_200_60s"
 type = "ratelimit"
 namespace_id = "990020060"
 simple = { limit = 200, period = 60}
+
+[[env.canary.unsafe.bindings]]
+name = "RL_600_60s"
+type = "ratelimit"
+namespace_id = "990060060"
+simple = { limit = 600, period = 60}
+
+
+[[env.canary.unsafe.bindings]]
+name = "RL_1_10s"
+type = "ratelimit"
+namespace_id = "9900110"
+simple = { limit = 1, period = 10}
+
 
 [[env.canary.unsafe.bindings]]
 name = "RL_500_10s"
@@ -240,11 +305,32 @@ type = "ratelimit"
 namespace_id = "99003060"
 simple = { limit = 30, period = 60}
 
+
+[[env.production.unsafe.bindings]]
+name = "RL_50_60s"
+type = "ratelimit"
+namespace_id = "99005060"
+simple = { limit = 50, period = 60}
+
 [[env.production.unsafe.bindings]]
 name = "RL_200_60s"
 type = "ratelimit"
 namespace_id = "990020060"
 simple = { limit = 200, period = 60}
+
+[[env.production.unsafe.bindings]]
+name = "RL_600_60s"
+type = "ratelimit"
+namespace_id = "990060060"
+simple = { limit = 600, period = 60}
+
+
+[[env.production.unsafe.bindings]]
+name = "RL_1_10s"
+type = "ratelimit"
+namespace_id = "9900110"
+simple = { limit = 1, period = 10}
+
 
 [[env.production.unsafe.bindings]]
 name = "RL_500_10s"

--- a/packages/api/src/openapi.d.ts
+++ b/packages/api/src/openapi.d.ts
@@ -358,13 +358,14 @@ export interface components {
       /**
        * @description Unkey allows you to refill remaining verifications on a key on a regular interval.
        * @example {
-       *   "interval": "daily",
-       *   "amount": 10
+       *   "interval": "monthly",
+       *   "amount": 10,
+       *   "refillDay": 10
        * }
        */
       refill?: {
         /**
-         * @description Determines the rate at which verifications will be refilled.
+         * @description Determines the rate at which verifications will be refilled. When 'daily' is set for 'interval' 'refillDay' will be set to null.
          * @example daily
          * @enum {string}
          */
@@ -374,6 +375,12 @@ export interface components {
          * @example 100
          */
         amount: number;
+        /**
+         * @description The day verifications will refill each month, when interval is set to 'monthly'. Value is not zero-indexed making 1 the first day of the month. If left blank it will default to the first day of the month. When 'daily' is set for 'interval' 'refillDay' will be set to null.
+         * @default 1
+         * @example 15
+         */
+        refillDay?: number | null;
         /**
          * @description The unix timestamp in miliseconds when the key was last refilled.
          * @example 100
@@ -1057,8 +1064,9 @@ export interface operations {
           /**
            * @description Unkey enables you to refill verifications for each key at regular intervals.
            * @example {
-           *   "interval": "daily",
-           *   "amount": 100
+           *   "interval": "monthly",
+           *   "amount": 100,
+           *   "refillDay": 15
            * }
            */
           refill?: {
@@ -1069,6 +1077,11 @@ export interface operations {
             interval: "daily" | "monthly";
             /** @description The number of verifications to refill for each occurrence is determined individually for each key. */
             amount: number;
+            /**
+             * @description The day of the month, when we will refill the remaining verifications. To refill on the 15th of each month, set 'refillDay': 15.
+             *                     If the day does not exist, for example you specified the 30th and it's february, we will refill them on the last day of the month instead.
+             */
+            refillDay?: number;
           };
           /**
            * @description Unkey comes with per-key fixed-window ratelimiting out of the box.
@@ -1365,6 +1378,8 @@ export interface operations {
             interval: "daily" | "monthly";
             /** @description The amount of verifications to refill for each occurrence is determined individually for each key. */
             amount: number;
+            /** @description The day verifications will refill each month, when interval is set to 'monthly' */
+            refillDay?: number;
           } | null;
           /**
            * @description Set if key is enabled or disabled. If disabled, the key cannot be used to verify.
@@ -2765,6 +2780,8 @@ export interface operations {
             interval: "daily" | "monthly";
             /** @description The number of verifications to refill for each occurrence is determined individually for each key. */
             amount: number;
+            /** @description The day verifications will refill each month, when interval is set to 'monthly' */
+            refillDay?: number;
           };
           /**
            * @description Unkey comes with per-key ratelimiting out of the box.
@@ -2977,6 +2994,8 @@ export interface operations {
               interval: "daily" | "monthly";
               /** @description The number of verifications to refill for each occurrence is determined individually for each key. */
               amount: number;
+              /** @description The day verifications will refill each month, when interval is set to 'monthly' */
+              refillDay?: number;
             };
             /**
              * @description Unkey comes with per-key fixed-window ratelimiting out of the box.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced new rate limiting configurations: `RL_50_60s`, `RL_600_60s`, and `RL_1_10s`, enhancing control over request limits.
	- Added example value for bearer authentication in OpenAPI documentation.

- **Improvements**
	- Enhanced response clarity for rate limit triggers in the agent rate limiter.
	- Updated key management functionality with a new optional `refillDay` field for refill scheduling.

- **Deprecations**
	- Marked `deprecated.verifyKey` operation as deprecated to streamline key verification processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->