### PR TITLE
fix: Dark Mode icon color missmatch #2781

### DIFF
--- a/internal/icons/src/icons/gauge.tsx
+++ b/internal/icons/src/icons/gauge.tsx
@@ -15,11 +15,11 @@ import type { IconProps } from "../props";
 export const Gauge: React.FC<IconProps> = (props) => {
   return (
     <svg {...props} height="18" width="18" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg">
-      <g fill="#212121">
+      <g fill="currentColor">
         <path
           d="M6,2.398c.914-.416,1.93-.648,3-.648,4.004,0,7.25,3.246,7.25,7.25s-3.246,7.25-7.25,7.25S1.75,13.004,1.75,9c0-1.07,.232-2.086,.648-3"
           fill="none"
-          stroke="#212121"
+          stroke="currentColor"
           strokeLinecap="round"
           strokeLinejoin="round"
           strokeWidth="1.5"
@@ -27,16 +27,16 @@ export const Gauge: React.FC<IconProps> = (props) => {
         <circle
           cx="9"
           cy="9"
-          fill="#212121"
+          fill="currentColor"
           r="1"
-          stroke="#212121"
+          stroke="currentColor"
           strokeLinecap="round"
           strokeLinejoin="round"
           strokeWidth="1.5"
         />
         <line
           fill="none"
-          stroke="#212121"
+          stroke="currentColor"
           strokeLinecap="round"
           strokeLinejoin="round"
           strokeWidth="1.5"

--- a/internal/icons/src/icons/gear.tsx
+++ b/internal/icons/src/icons/gear.tsx
@@ -15,10 +15,10 @@ import type { IconProps } from "../props";
 export const Gear: React.FC<IconProps> = (props) => {
   return (
     <svg {...props} height="18" width="18" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg">
-      <g fill="#212121">
+      <g fill="currentColor">
         <line
           fill="none"
-          stroke="#212121"
+          stroke="currentColor"
           strokeLinecap="round"
           strokeLinejoin="round"
           strokeWidth="1.5"
@@ -29,7 +29,7 @@ export const Gear: React.FC<IconProps> = (props) => {
         />
         <line
           fill="none"
-          stroke="#212121"
+          stroke="currentColor"
           strokeLinecap="round"
           strokeLinejoin="round"
           strokeWidth="1.5"
@@ -40,7 +40,7 @@ export const Gear: React.FC<IconProps> = (props) => {
         />
         <line
           fill="none"
-          stroke="#212121"
+          stroke="currentColor"
           strokeLinecap="round"
           strokeLinejoin="round"
           strokeWidth="1.5"
@@ -51,7 +51,7 @@ export const Gear: React.FC<IconProps> = (props) => {
         />
         <line
           fill="none"
-          stroke="#212121"
+          stroke="currentColor"
           strokeLinecap="round"
           strokeLinejoin="round"
           strokeWidth="1.5"
@@ -62,7 +62,7 @@ export const Gear: React.FC<IconProps> = (props) => {
         />
         <line
           fill="none"
-          stroke="#212121"
+          stroke="currentColor"
           strokeLinecap="round"
           strokeLinejoin="round"
           strokeWidth="1.5"
@@ -73,7 +73,7 @@ export const Gear: React.FC<IconProps> = (props) => {
         />
         <line
           fill="none"
-          stroke="#212121"
+          stroke="currentColor"
           strokeLinecap="round"
           strokeLinejoin="round"
           strokeWidth="1.5"
@@ -84,7 +84,7 @@ export const Gear: React.FC<IconProps> = (props) => {
         />
         <line
           fill="none"
-          stroke="#212121"
+          stroke="currentColor"
           strokeLinecap="round"
           strokeLinejoin="round"
           strokeWidth="1.5"
@@ -95,7 +95,7 @@ export const Gear: React.FC<IconProps> = (props) => {
         />
         <line
           fill="none"
-          stroke="#212121"
+          stroke="currentColor"
           strokeLinecap="round"
           strokeLinejoin="round"
           strokeWidth="1.5"
@@ -106,7 +106,7 @@ export const Gear: React.FC<IconProps> = (props) => {
         />
         <line
           fill="none"
-          stroke="#212121"
+          stroke="currentColor"
           strokeLinecap="round"
           strokeLinejoin="round"
           strokeWidth="1.5"
@@ -117,7 +117,7 @@ export const Gear: React.FC<IconProps> = (props) => {
         />
         <line
           fill="none"
-          stroke="#212121"
+          stroke="currentColor"
           strokeLinecap="round"
           strokeLinejoin="round"
           strokeWidth="1.5"
@@ -128,7 +128,7 @@ export const Gear: React.FC<IconProps> = (props) => {
         />
         <line
           fill="none"
-          stroke="#212121"
+          stroke="currentColor"
           strokeLinecap="round"
           strokeLinejoin="round"
           strokeWidth="1.5"
@@ -139,7 +139,7 @@ export const Gear: React.FC<IconProps> = (props) => {
         />
         <line
           fill="none"
-          stroke="#212121"
+          stroke="currentColor"
           strokeLinecap="round"
           strokeLinejoin="round"
           strokeWidth="1.5"
@@ -150,7 +150,7 @@ export const Gear: React.FC<IconProps> = (props) => {
         />
         <line
           fill="none"
-          stroke="#212121"
+          stroke="currentColor"
           strokeLinecap="round"
           strokeLinejoin="round"
           strokeWidth="1.5"
@@ -161,7 +161,7 @@ export const Gear: React.FC<IconProps> = (props) => {
         />
         <line
           fill="none"
-          stroke="#212121"
+          stroke="currentColor"
           strokeLinecap="round"
           strokeLinejoin="round"
           strokeWidth="1.5"
@@ -172,7 +172,7 @@ export const Gear: React.FC<IconProps> = (props) => {
         />
         <line
           fill="none"
-          stroke="#212121"
+          stroke="currentColor"
           strokeLinecap="round"
           strokeLinejoin="round"
           strokeWidth="1.5"
@@ -186,7 +186,7 @@ export const Gear: React.FC<IconProps> = (props) => {
           cy="9"
           fill="none"
           r="5.5"
-          stroke="#212121"
+          stroke="currentColor"
           strokeLinecap="round"
           strokeLinejoin="round"
           strokeWidth="1.5"

--- a/internal/icons/src/icons/shield-key.tsx
+++ b/internal/icons/src/icons/shield-key.tsx
@@ -15,20 +15,20 @@ import type { IconProps } from "../props";
 export const ShieldKey: React.FC<IconProps> = (props) => {
   return (
     <svg {...props} height="18" width="18" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg">
-      <g fill="#212121">
+      <g fill="currentColor">
         <circle
           cx="10"
           cy="9.25"
           fill="none"
           r="1.75"
-          stroke="#212121"
+          stroke="currentColor"
           strokeLinecap="round"
           strokeLinejoin="round"
           strokeWidth="1.5"
         />
         <line
           fill="none"
-          stroke="#212121"
+          stroke="currentColor"
           strokeLinecap="round"
           strokeLinejoin="round"
           strokeWidth="1.5"
@@ -39,7 +39,7 @@ export const ShieldKey: React.FC<IconProps> = (props) => {
         />
         <line
           fill="none"
-          stroke="#212121"
+          stroke="currentColor"
           strokeLinecap="round"
           strokeLinejoin="round"
           strokeWidth="1.5"
@@ -51,7 +51,7 @@ export const ShieldKey: React.FC<IconProps> = (props) => {
         <path
           d="M15.25,6.75v-2.27c0-.435-.281-.82-.695-.952l-5.25-1.68c-.198-.063-.411-.063-.61,0L3.445,3.528c-.414,.133-.695,.517-.695,.952v6.52c0,3.03,4.684,4.749,5.942,5.155,.203,.066,.413,.066,.616,0,.862-.279,3.334-1.175,4.804-2.686"
           fill="none"
-          stroke="#212121"
+          stroke="currentColor"
           strokeLinecap="round"
           strokeLinejoin="round"
           strokeWidth="1.5"


### PR DESCRIPTION
## What does this PR do?

At the time of dark mode icons were not seen.

Fixes #2781 

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [x] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- enable dark mode
- visit settings , authentication and rate-limiting pages


### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary

<img width="136" alt="Screenshot 2025-01-02 at 7 01 46 PM" src="https://github.com/user-attachments/assets/0c511e0c-f6fb-4db5-809f-f6e9751e1fc9" />
<img width="257" alt="Screenshot 2025-01-02 at 7 02 23 PM" src="https://github.com/user-attachments/assets/16162a32-817b-4ea2-aab1-fde4291390a2" />
<img width="175" alt="Screenshot 2025-01-02 at 7 02 56 PM" src="https://github.com/user-attachments/assets/db15cc36-0e82-476a-890d-c7de2c63c440" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated icon components (`Gauge`, `Gear`, and `ShieldKey`) to use `currentColor` for fill and stroke properties
  - Improved icon color adaptability by allowing dynamic color inheritance from parent elements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->