### PR TITLE
fix: enable card correctly

### DIFF
--- a/apps/dashboard/app/(app)/apis/[apiId]/keys/[keyAuthId]/[keyId]/settings/update-key-remaining.tsx
+++ b/apps/dashboard/app/(app)/apis/[apiId]/keys/[keyAuthId]/[keyId]/settings/update-key-remaining.tsx
@@ -67,7 +67,7 @@ export const UpdateKeyRemaining: React.FC<Props> = ({ apiKey }) => {
     delayError: 100,
     defaultValues: {
       keyId: apiKey.id,
-      limitEnabled: Boolean(apiKey.refillAmount),
+      limitEnabled: Boolean(apiKey.remaining) || Boolean(apiKey.refillAmount),
       remaining: apiKey.remaining ? apiKey.remaining : undefined,
       refill: {
         amount: apiKey.refillAmount ? apiKey.refillAmount : undefined,


### PR DESCRIPTION
the card was disabled when the remaining reached 0,
which is a perfectly fine state, as long as the refill
is configured to be greater than 0 as well


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved key limit settings logic to more accurately reflect API key remaining and refill configurations.
	- Enhanced form initialization to better handle key limit states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->