### PR TITLE
fix: apply success filter

### DIFF
--- a/apps/dashboard/app/(app)/ratelimits/[namespaceId]/logs/page.tsx
+++ b/apps/dashboard/app/(app)/ratelimits/[namespaceId]/logs/page.tsx
@@ -81,7 +81,7 @@ export default async function AuditPage(props: Props) {
             {namespace.name}
           </Navbar.Breadcrumbs.Link>
           <Navbar.Breadcrumbs.Link href={`/ratelimits/${props.params.namespaceId}/logs`} active>
-            Logs{" "}
+            Logs
           </Navbar.Breadcrumbs.Link>
         </Navbar.Breadcrumbs>
         <Navbar.Actions>
@@ -150,7 +150,7 @@ const AuditLogTable: React.FC<{
     country: selected.country.length > 0 ? selected.country : undefined,
     ipAddress: selected.ipAddress.length > 0 ? selected.ipAddress : undefined,
 
-    success: selected.success ?? undefined,
+    passed: selected.success ?? undefined,
   };
   const logs = await clickhouse.ratelimits.logs(query).then((res) => res.val!);
 


### PR DESCRIPTION
the filter was piped through as 'success' but our clickhouse query
expected 'passed'


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated rate limit logs query to correctly filter and display log entries
	- Improved query construction for more accurate log retrieval

- **Refactor**
	- Streamlined the rate limit logs query logic
	- Enhanced query parameter handling for better performance and readability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->