### PR TITLE
fix: fall back to loading the workspace id from cache/db

### DIFF
--- a/apps/api/src/pkg/cache/index.ts
+++ b/apps/api/src/pkg/cache/index.ts
@@ -75,6 +75,10 @@ export function initCache(c: Context<HonoEnv>, metrics: Metrics): C<CacheNamespa
     auditLogBucketByWorkspaceIdAndName: new Namespace<
       CacheNamespaces["auditLogBucketByWorkspaceIdAndName"]
     >(c.executionCtx, defaultOpts),
+    workspaceIdByRootKeyHash: new Namespace<CacheNamespaces["workspaceIdByRootKeyHash"]>(
+      c.executionCtx,
+      defaultOpts,
+    ),
   });
 }
 

--- a/apps/api/src/pkg/cache/namespaces.ts
+++ b/apps/api/src/pkg/cache/namespaces.ts
@@ -68,6 +68,7 @@ export type CacheNamespaces = {
   auditLogBucketByWorkspaceIdAndName: {
     id: string;
   };
+  workspaceIdByRootKeyHash: string | null;
 };
 
 export type CacheNamespace = keyof CacheNamespaces;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced workspace identification mechanism in metrics middleware
	- Added new cache namespace for workspace ID retrieval by root key hash

- **Improvements**
	- Implemented more robust method for fetching workspace identifiers
	- Updated metrics handling to support dynamic workspace ID extraction

<!-- end of auto-generated comment: release notes by coderabbit.ai -->