### PR TITLE
test: check if clickhouse verification inserts fails

### DIFF
--- a/apps/api/src/routes/v1_analytics_getVerifications.happy.test.ts
+++ b/apps/api/src/routes/v1_analytics_getVerifications.happy.test.ts
@@ -79,6 +79,7 @@ describe.each([
     })({
       workspaceId: h.resources.userWorkspace.id,
     });
+    expect(inserted.err).toEqual(undefined);
     expect(inserted.val!.at(0)?.count).toEqual(verifications.length);
 
     const root = await h.createRootKey(["api.*.read_api"]);

--- a/apps/api/src/routes/v1_analytics_getVerifications.happy.test.ts
+++ b/apps/api/src/routes/v1_analytics_getVerifications.happy.test.ts
@@ -68,7 +68,8 @@ describe.each([
       keys: Array.from({ length: 3 }).map(() => ({ keyId: newId("test") })),
     });
 
-    await h.ch.verifications.insert(verifications);
+    const insert = await h.ch.verifications.insert(verifications);
+    expect(insert.err).toEqual(undefined);
 
     const inserted = await h.ch.querier.query({
       query:


### PR DESCRIPTION
## What does this PR do?

Based on #2839, a check is added to the verification test to see if the insert fails.
Hoping this gives a more explicit error message 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?
Running the test `pnpm vitest run -c vitest.integration.ts analytics_getVerifications.happy.test --bail=1`

## Checklist

### Required

- [X] Filled out the "How to test" section in this PR
- [X] Read [Contributing Guide](./CONTRIBUTING.md)
- [X] Self-reviewed my own code
- [X] Commented on my code in hard-to-understand areas
- [X] Ran `pnpm build`
- [X] Ran `pnpm fmt`
- [X] Checked for warnings, there are none
- [X] Removed all `console.logs`
- [X] Merged the latest changes from main onto my branch with `git pull origin main`
- [X] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Enhanced test robustness by adding explicit error checking during database verification insertion
	- Improved verification of database operation success before proceeding with assertions
	- Maintained focus on analytics verification scenarios with no structural changes to tests
<!-- end of auto-generated comment: release notes by coderabbit.ai -->