### PR TITLE
feat: create identities from external id when migrating keys

### DIFF
--- a/apps/api/src/routes/v1_migrations_createKey.happy.test.ts
+++ b/apps/api/src/routes/v1_migrations_createKey.happy.test.ts
@@ -187,6 +187,101 @@ describe("with prefix", () => {
   });
 });
 
+describe("with externalId", () => {
+  describe("when identity does not exist", () => {
+    test("should create an identity", async (t) => {
+      const h = await IntegrationHarness.init(t);
+      const root = await h.createRootKey([`api.${h.resources.userApi.id}.create_key`]);
+      const hash = await sha256(randomUUID());
+
+      const externalId = newId("test")
+
+      const res = await h.post<V1MigrationsCreateKeysRequest, V1MigrationsCreateKeysResponse>({
+        url: "/v1/migrations.createKeys",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${root.key}`,
+        },
+        body: [
+          {
+            hash: {
+              value: hash,
+              variant: "sha256_base64",
+            },
+            apiId: h.resources.userApi.id,
+            enabled: true,
+            externalId: externalId
+          },
+        ],
+      });
+
+      expect(res.status, `expected 200, received: ${JSON.stringify(res, null, 2)}`).toBe(200);
+
+      const key = await h.db.primary.query.keys.findFirst({
+        where: (table, { eq }) => eq(table.id, res.body.keyIds[0]),
+        with: {
+          identity: true
+        }
+      });
+      expect(key).toBeDefined();
+
+      expect(key!.identity).toBeDefined()
+      expect(key!.identity!.externalId).toEqual(externalId)
+
+    });
+  })
+  describe("when identity does not exist", () => {
+    test("should create an identity", async (t) => {
+      const h = await IntegrationHarness.init(t);
+      const root = await h.createRootKey([`api.${h.resources.userApi.id}.create_key`]);
+      const hash = await sha256(randomUUID());
+
+      const externalId = newId("test")
+      const identity = {
+        id: newId("test"),
+        workspaceId: h.resources.userWorkspace.id,
+        externalId,
+
+      }
+      await h.db.primary.insert(schema.identities).values(identity)
+
+
+      const res = await h.post<V1MigrationsCreateKeysRequest, V1MigrationsCreateKeysResponse>({
+        url: "/v1/migrations.createKeys",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${root.key}`,
+        },
+        body: [
+          {
+            hash: {
+              value: hash,
+              variant: "sha256_base64",
+            },
+            apiId: h.resources.userApi.id,
+            enabled: true,
+            externalId: externalId
+          },
+        ],
+      });
+
+      expect(res.status, `expected 200, received: ${JSON.stringify(res, null, 2)}`).toBe(200);
+
+      const key = await h.db.primary.query.keys.findFirst({
+        where: (table, { eq }) => eq(table.id, res.body.keyIds[0]),
+        with: {
+          identity: true
+        }
+      });
+      expect(key).toBeDefined();
+
+      expect(key!.identity).toBeDefined()
+      expect(key!.identity!.id).toEqual(identity.id)
+
+    });
+  })
+});
+
 describe("roles", () => {
   test("connects the specified roles", async (t) => {
     const h = await IntegrationHarness.init(t);

--- a/apps/api/src/routes/v1_migrations_createKey.happy.test.ts
+++ b/apps/api/src/routes/v1_migrations_createKey.happy.test.ts
@@ -194,7 +194,7 @@ describe("with externalId", () => {
       const root = await h.createRootKey([`api.${h.resources.userApi.id}.create_key`]);
       const hash = await sha256(randomUUID());
 
-      const externalId = newId("test")
+      const externalId = newId("test");
 
       const res = await h.post<V1MigrationsCreateKeysRequest, V1MigrationsCreateKeysResponse>({
         url: "/v1/migrations.createKeys",
@@ -210,7 +210,7 @@ describe("with externalId", () => {
             },
             apiId: h.resources.userApi.id,
             enabled: true,
-            externalId: externalId
+            externalId: externalId,
           },
         ],
       });
@@ -220,31 +220,28 @@ describe("with externalId", () => {
       const key = await h.db.primary.query.keys.findFirst({
         where: (table, { eq }) => eq(table.id, res.body.keyIds[0]),
         with: {
-          identity: true
-        }
+          identity: true,
+        },
       });
       expect(key).toBeDefined();
 
-      expect(key!.identity).toBeDefined()
-      expect(key!.identity!.externalId).toEqual(externalId)
-
+      expect(key!.identity).toBeDefined();
+      expect(key!.identity!.externalId).toEqual(externalId);
     });
-  })
+  });
   describe("when identity does not exist", () => {
     test("should create an identity", async (t) => {
       const h = await IntegrationHarness.init(t);
       const root = await h.createRootKey([`api.${h.resources.userApi.id}.create_key`]);
       const hash = await sha256(randomUUID());
 
-      const externalId = newId("test")
+      const externalId = newId("test");
       const identity = {
         id: newId("test"),
         workspaceId: h.resources.userWorkspace.id,
         externalId,
-
-      }
-      await h.db.primary.insert(schema.identities).values(identity)
-
+      };
+      await h.db.primary.insert(schema.identities).values(identity);
 
       const res = await h.post<V1MigrationsCreateKeysRequest, V1MigrationsCreateKeysResponse>({
         url: "/v1/migrations.createKeys",
@@ -260,7 +257,7 @@ describe("with externalId", () => {
             },
             apiId: h.resources.userApi.id,
             enabled: true,
-            externalId: externalId
+            externalId: externalId,
           },
         ],
       });
@@ -270,16 +267,15 @@ describe("with externalId", () => {
       const key = await h.db.primary.query.keys.findFirst({
         where: (table, { eq }) => eq(table.id, res.body.keyIds[0]),
         with: {
-          identity: true
-        }
+          identity: true,
+        },
       });
       expect(key).toBeDefined();
 
-      expect(key!.identity).toBeDefined()
-      expect(key!.identity!.id).toEqual(identity.id)
-
+      expect(key!.identity).toBeDefined();
+      expect(key!.identity!.id).toEqual(identity.id);
     });
-  })
+  });
 });
 
 describe("roles", () => {

--- a/apps/api/src/routes/v1_migrations_createKey.happy.test.ts
+++ b/apps/api/src/routes/v1_migrations_createKey.happy.test.ts
@@ -229,8 +229,8 @@ describe("with externalId", () => {
       expect(key!.identity!.externalId).toEqual(externalId);
     });
   });
-  describe("when identity does not exist", () => {
-    test("should create an identity", async (t) => {
+  describe("when identity does exist", () => {
+    test("should link the identity", async (t) => {
       const h = await IntegrationHarness.init(t);
       const root = await h.createRootKey([`api.${h.resources.userApi.id}.create_key`]);
       const hash = await sha256(randomUUID());

--- a/apps/api/src/routes/v1_migrations_createKey.ts
+++ b/apps/api/src/routes/v1_migrations_createKey.ts
@@ -6,7 +6,7 @@ import { rootKeyAuth } from "@/pkg/auth/root_key";
 import { UnkeyApiError, openApiErrorResponses } from "@/pkg/errors";
 import { retry } from "@/pkg/util/retry";
 import { DatabaseError } from "@planetscale/database";
-import { type EncryptedKey, type Key, type KeyPermission, type KeyRole, schema } from "@unkey/db";
+import { type EncryptedKey, Identity, type Key, type KeyPermission, type KeyRole, schema } from "@unkey/db";
 import { sha256 } from "@unkey/hash";
 import { newId } from "@unkey/id";
 import { buildUnkeyQuery } from "@unkey/rbac";
@@ -71,9 +71,17 @@ The underscore is automatically added if you are defining a prefix, for example:
                   .string()
                   .optional()
                   .openapi({
+                    description: "Deprecated, use `externalId`",
+                    example: "team_123",
+                    deprecated: true
+                  }),
+                externalId: z
+                  .string()
+                  .optional()
+                  .openapi({
                     description: `Your user’s Id. This will provide a link between Unkey and your customer record.
 When validating a key, we will return this back to you, so you can clearly identify your user from their api key.`,
-                    example: "team_123",
+                    example: "user_123",
                   }),
                 meta: z
                   .record(z.unknown())
@@ -304,6 +312,15 @@ export const registerV1MigrationsCreateKeys = (app: App) =>
       }
     }
 
+
+
+
+
+
+
+
+
+    const createIdentities: Array<Identity> = []
     const keys: Array<Key> = [];
     const encryptedKeys: Array<EncryptedKey> = [];
     const roleConnections: Array<KeyRole> = [];
@@ -350,7 +367,7 @@ export const registerV1MigrationsCreateKeys = (app: App) =>
           return (
             (await db.readonly.query.apis.findFirst({
               where: (table, { eq, and, isNull }) =>
-                and(eq(table.id, key.apiId), isNull(table.deletedAt)),
+                and(eq(table.workspaceId, authorizedWorkspaceId), eq(table.id, key.apiId), isNull(table.deletedAt)),
               with: {
                 keyAuth: true,
               },
@@ -397,6 +414,44 @@ export const registerV1MigrationsCreateKeys = (app: App) =>
             message: "when interval is set to 'daily', 'refillDay' must be null.",
           });
         }
+
+
+        let identityId: string | null = null;
+        if (key.externalId) {
+
+          const identity = await cache.identityByExternalId.swr(key.externalId, async (externalId) => {
+            return await db.readonly.query.identities.findFirst({
+              where: (table, { eq, and }) =>
+                and(eq(table.workspaceId, authorizedWorkspaceId), eq(table.externalId, externalId)),
+
+            })
+
+          })
+          if (identity.err) {
+            throw new UnkeyApiError({
+              code: "INTERNAL_SERVER_ERROR",
+              message: `unable to load identity: ${identity.err.message}`,
+            });
+          }
+          if (identity.val) {
+            identityId = identity.val.id
+          } else {
+            identityId = newId("identity")
+            createIdentities.push({
+              id: identityId,
+              externalId: key.externalId,
+              workspaceId: authorizedWorkspaceId,
+              createdAt: Date.now(),
+              updatedAt: null,
+              meta: null,
+              environment: "default"
+            })
+          }
+
+        }
+
+
+
         /**
          * Set up an api for production
          */
@@ -410,7 +465,7 @@ export const registerV1MigrationsCreateKeys = (app: App) =>
           hash: hash,
           start: key.start ?? key.plaintext?.slice(0, 4) ?? "",
           ownerId: key.ownerId ?? null,
-          identityId: null,
+          identityId,
           meta: key.meta ? JSON.stringify(key.meta) : null,
           workspaceId: authorizedWorkspaceId,
           forWorkspaceId: null,
@@ -478,6 +533,16 @@ export const registerV1MigrationsCreateKeys = (app: App) =>
     );
 
     await db.primary.transaction(async (tx) => {
+      if (createIdentities.length > 0) {
+        await tx.insert(schema.identities).values(createIdentities).onDuplicateKeyUpdate({ set: { updatedAt: Date.now() } }).catch((e) => {
+          logger.error("unable to create identities", {
+            error: e.message
+          })
+          throw new UnkeyApiError({ code: "INTERNAL_SERVER_ERROR", message: "unable to create identities" })
+        })
+      }
+
+
       if (keys.length > 0) {
         await tx
           .insert(schema.keys)


### PR DESCRIPTION
- **feat: allow externalId when migrating keys**
- **style: fmt**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for external ID in the key creation process.
	- Enhanced identity management with more flexible user identification.

- **Improvements**
	- Updated request schema to support optional `externalId`.
	- Deprecated `ownerId` field in favor of a more robust identification method.

- **Bug Fixes**
	- Improved handling of identity creation and association during key generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->