### PR TITLE
fix: making pnpm local command to exit if db migration fails

### DIFF
--- a/deployment/docker-compose.yaml
+++ b/deployment/docker-compose.yaml
@@ -15,6 +15,8 @@ services:
       - 3306:3306
     volumes:
       - mysql:/var/lib/mysql
+    storage_opt:
+      size: 760M
   planetscale:
     container_name: planetscale
     image: ghcr.io/mattrobenolt/ps-http-sim:latest

--- a/deployment/docker-compose.yaml
+++ b/deployment/docker-compose.yaml
@@ -15,8 +15,6 @@ services:
       - 3306:3306
     volumes:
       - mysql:/var/lib/mysql
-    storage_opt:
-      size: 760M
   planetscale:
     container_name: planetscale
     image: ghcr.io/mattrobenolt/ps-http-sim:latest

--- a/tools/local/src/db.ts
+++ b/tools/local/src/db.ts
@@ -30,6 +30,8 @@ export async function prepareDatabase(url?: string): Promise<{
         },
 
         cwd,
+      }, (error, stdout, stderr) => {
+          console.error(`stdout: ${stdout}`);
       });
       p.on("exit", (code) => {
         if (code === 0) {


### PR DESCRIPTION
## What does this PR do?
This PR makes the `pnpm local` command exit if the database migrations are unsuccessful
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #2854 (issue)

<!-- If there isn't an issue for this PR, please re-review our Contributing Guide and create an issue -->

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?
I found it really tricky to mimic the mysql disk is full message. so what I just did is make the migration fail by adding:
```ts
 plan: mysqlEnum("plan", ["free", "pro", "enterprise"]).default("invalid_value"),
```
on line 40 of https://github.com/unkeyed/unkey/blob/main/internal/db/src/schema/workspaces.ts

After doing this, run `pnpm local` and the command should fail at the migration step. before it would fail at the seed step without saying what went wrong
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated the MySQL container configuration to enforce a storage limit of 760MB.
- **Bug Fixes**
  - Enhanced error reporting during database migrations to deliver clearer feedback when issues occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->