### PR TITLE
chore: Minimum byte length should be consistent

### DIFF
--- a/apps/dashboard/app/(app)/apis/[apiId]/keys/[keyAuthId]/new/validation.ts
+++ b/apps/dashboard/app/(app)/apis/[apiId]/keys/[keyAuthId]/new/validation.ts
@@ -10,6 +10,7 @@ export const formSchema = z.object({
             : defaultError,
       }),
     })
+    .min(16)
     .default(16),
   prefix: z
     .string()

--- a/apps/dashboard/app/(app)/apis/[apiId]/settings/default-bytes.tsx
+++ b/apps/dashboard/app/(app)/apis/[apiId]/settings/default-bytes.tsx
@@ -21,7 +21,7 @@ const formSchema = z.object({
   keyAuthId: z.string(),
   defaultBytes: z
     .number()
-    .min(8, "Byte size needs to be at least 8")
+    .min(16, "Byte size needs to be at least 16")
     .max(255, "Byte size cannot exceed 255")
     .optional(),
 });

--- a/apps/dashboard/lib/trpc/routers/api/setDefaultBytes.ts
+++ b/apps/dashboard/lib/trpc/routers/api/setDefaultBytes.ts
@@ -11,7 +11,7 @@ export const setDefaultApiBytes = t.procedure
     z.object({
       defaultBytes: z
         .number()
-        .min(8, "Byte size needs to be at least 8")
+        .min(16, "Byte size needs to be at least 16")
         .max(255, "Byte size cannot exceed 255")
         .optional(),
       keyAuthId: z.string(),

--- a/apps/dashboard/lib/trpc/routers/key/create.ts
+++ b/apps/dashboard/lib/trpc/routers/key/create.ts
@@ -11,7 +11,7 @@ export const createKey = t.procedure
   .input(
     z.object({
       prefix: z.string().optional(),
-      bytes: z.number().int().gte(1).default(16),
+      bytes: z.number().int().gte(16).default(16),
       keyAuthId: z.string(),
       ownerId: z.string().nullish(),
       meta: z.record(z.unknown()).optional(),


### PR DESCRIPTION
## What does this PR do?

The minimum byte length for keys is 8 on the dashboard and 16 on the API. This PR makes sure that it is consistent on both API and Dashboard by making it 16 on the dashboard.

Fixes #2564


<!-- If there isn't an issue for this PR, please re-review our Contributing Guide and create an issue -->

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Test A
- Test B

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes  
  - Enhanced input validation for numeric byte fields across dashboard forms and APIs. Users now must enter a value of at least 16 for key and default byte settings, ensuring more robust and consistent input handling while keeping error messaging unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->