### PR TITLE
docs: Add infrastructure section

### DIFF
--- a/apps/engineering/app/infrastructure/[[...slug]]/page.tsx
+++ b/apps/engineering/app/infrastructure/[[...slug]]/page.tsx
@@ -1,0 +1,73 @@
+import { infrastructureSource } from "@/app/source";
+import defaultMdxComponents from "fumadocs-ui/mdx";
+import {
+  DocsBody,
+  DocsDescription,
+  DocsPage,
+  DocsTitle,
+} from "fumadocs-ui/page";
+import type { Metadata } from "next";
+
+import { getGithubLastEdit } from "fumadocs-core/server";
+import { notFound } from "next/navigation";
+
+export default async function Page(props: {
+  params: Promise<{ slug?: string[] }>;
+}) {
+  const params = await props.params;
+  const page = infrastructureSource.getPage(params.slug);
+
+  if (!page) {
+    notFound();
+  }
+
+  const MDX = page.data.body;
+
+  return (
+    <DocsPage
+      toc={page.data.toc}
+      full={page.data.full}
+      tableOfContent={{
+        style: "clerk",
+        single: true,
+      }}
+      lastUpdate={
+        (await getGithubLastEdit({
+          owner: "unkeyed",
+          repo: "unkey",
+          path: `apps/engineering/content/infrastructure/${page.file.path}`,
+        })) ?? undefined
+      }
+    >
+      <DocsTitle>{page.data.title}</DocsTitle>
+
+      <DocsDescription className="text-sm">
+        {page.data.description}
+      </DocsDescription>
+
+      <DocsBody className="font-mono text-sm">
+        <MDX components={{ ...defaultMdxComponents }} />
+      </DocsBody>
+    </DocsPage>
+  );
+}
+
+export async function generateStaticParams() {
+  return infrastructureSource.generateParams();
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug?: string[] }>;
+}) {
+  const page = infrastructureSource.getPage((await params).slug);
+  if (!page) {
+    notFound();
+  }
+
+  return {
+    title: page.data.title,
+    description: page.data.description,
+  } satisfies Metadata;
+}

--- a/apps/engineering/app/infrastructure/[[...slug]]/page.tsx
+++ b/apps/engineering/app/infrastructure/[[...slug]]/page.tsx
@@ -1,11 +1,6 @@
 import { infrastructureSource } from "@/app/source";
 import defaultMdxComponents from "fumadocs-ui/mdx";
-import {
-  DocsBody,
-  DocsDescription,
-  DocsPage,
-  DocsTitle,
-} from "fumadocs-ui/page";
+import { DocsBody, DocsDescription, DocsPage, DocsTitle } from "fumadocs-ui/page";
 import type { Metadata } from "next";
 
 import { getGithubLastEdit } from "fumadocs-core/server";
@@ -41,9 +36,7 @@ export default async function Page(props: {
     >
       <DocsTitle>{page.data.title}</DocsTitle>
 
-      <DocsDescription className="text-sm">
-        {page.data.description}
-      </DocsDescription>
+      <DocsDescription className="text-sm">{page.data.description}</DocsDescription>
 
       <DocsBody className="font-mono text-sm">
         <MDX components={{ ...defaultMdxComponents }} />

--- a/apps/engineering/app/infrastructure/layout.tsx
+++ b/apps/engineering/app/infrastructure/layout.tsx
@@ -1,0 +1,14 @@
+import { infrastructureSource } from "@/app/source";
+import { DocsLayout } from "fumadocs-ui/layouts/notebook";
+import type { ReactNode } from "react";
+import { baseOptions } from "../layout.config";
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return (
+    <div className="font-mono">
+      <DocsLayout tree={infrastructureSource.pageTree} {...baseOptions}>
+        {children}
+      </DocsLayout>
+    </div>
+  );
+}

--- a/apps/engineering/app/layout.config.tsx
+++ b/apps/engineering/app/layout.config.tsx
@@ -31,6 +31,11 @@ export const baseOptions: HomeLayoutProps = {
       active: "nested-url",
     },
     {
+      text: "Infrastructure",
+      url: "/infrastructure",
+      active: "nested-url",
+    },
+    {
       text: "RFCs",
       url: "/rfcs",
       active: "nested-url",

--- a/apps/engineering/app/source.ts
+++ b/apps/engineering/app/source.ts
@@ -1,6 +1,16 @@
-import { architecture, company, components, contributing, docs, meta, rfcs } from "@/.source";
+import {
+  architecture,
+  company,
+  components,
+  contributing,
+  docs,
+  infrastructure,
+  meta,
+  rfcs,
+} from "@/.source";
 import { loader } from "fumadocs-core/source";
 import { createMDXSource } from "fumadocs-mdx";
+import { createMDX } from "fumadocs-mdx/next";
 
 export const source = loader({
   baseUrl: "/docs",
@@ -29,4 +39,9 @@ export const contributingSource = loader({
 export const architectureSource = loader({
   baseUrl: "/architecture",
   source: createMDXSource(architecture, []),
+});
+
+export const infrastructureSource = loader({
+  baseUrl: "/infrastructure",
+  source: createMDXSource(infrastructure, []),
 });

--- a/apps/engineering/app/source.ts
+++ b/apps/engineering/app/source.ts
@@ -10,7 +10,6 @@ import {
 } from "@/.source";
 import { loader } from "fumadocs-core/source";
 import { createMDXSource } from "fumadocs-mdx";
-import { createMDX } from "fumadocs-mdx/next";
 
 export const source = loader({
   baseUrl: "/docs",

--- a/apps/engineering/content/infrastructure/aws/google-idp.mdx
+++ b/apps/engineering/content/infrastructure/aws/google-idp.mdx
@@ -1,0 +1,4 @@
+---
+title: Google as an Identity Provider for AWS
+description: Efficient details for setting up Google Workspace to be an IdP for AWS
+---

--- a/apps/engineering/content/infrastructure/aws/index.mdx
+++ b/apps/engineering/content/infrastructure/aws/index.mdx
@@ -1,0 +1,4 @@
+---
+title: AWS
+description: How to setup AWS infrastructure
+---

--- a/apps/engineering/content/infrastructure/index.mdx
+++ b/apps/engineering/content/infrastructure/index.mdx
@@ -1,0 +1,7 @@
+---
+title: Overview
+description: Information on setting up infrastructure for Unkey
+---
+## Supported clouds
+
+AWS

--- a/apps/engineering/content/infrastructure/meta.json
+++ b/apps/engineering/content/infrastructure/meta.json
@@ -1,0 +1,6 @@
+{
+  "title": "Infrastructure",
+  "description": "Setting up infrastructure for Unkey",
+  "root": false,
+  "pages": ["aws"]
+}

--- a/apps/engineering/source.config.ts
+++ b/apps/engineering/source.config.ts
@@ -40,6 +40,12 @@ export const architecture = defineCollections({
   type: "doc",
 });
 
+export const infrastructure = defineCollections({
+  dir: "content/infrastructure",
+  schema: frontmatterSchema.extend({}),
+  type: "doc",
+});
+
 export default defineConfig({
   lastModifiedTime: "git",
 });


### PR DESCRIPTION
## What does this PR do?

- This lays the foundation for documentation on how we build infrastructure in support of Unkey
- Adds AWS directory

### Appreciated

- [x] Updated the Unkey Docs if changes were necessary 😉 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Launched an enhanced infrastructure documentation section that dynamically loads content and auto-generates metadata, ensuring a seamless browsing experience.
  - Introduced a refined layout with improved navigation, including a dedicated "Infrastructure" link.

- **Documentation**
  - Added new guides and overviews covering AWS setup and integrating Google as an Identity Provider, providing clear, comprehensive instructions for users.
  - Included an overview for setting up infrastructure for Unkey, detailing supported cloud platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->