### PR TITLE
docs: Add doc on how to manage AWS users/groups

### DIFF
--- a/apps/engineering/content/infrastructure/aws/user-group-management.mdx
+++ b/apps/engineering/content/infrastructure/aws/user-group-management.mdx
@@ -1,0 +1,11 @@
+---
+title: User and Group management
+description: How to manage users and groups in AWS IAM Identity Center
+---
+import { Step, Steps } from 'fumadocs-ui/components/steps';
+
+SCIM, which automagically provisions users does only that. It does not handle synchronization of groups or group membership. There's a tool from the awslabs github org called ssosync that is usually how you handle synchronizing from Google Workspace to IAM Identity Center. The secure way to handle service accounts in GCP is using Workload Identity Federation which as of this writing, is unsupported because the `ssosync` app expects specific user credentials hard-coded from a file. There are a couple of PRs on that repo to implement it but progress seems to have stalled since end of last year. To faciliate mapping Workspace users to IAM Identity Center users, there is a script in `unkeyed/infra/contrib` to facilitate that.
+```bash
+ AWS_PROFILE=unkey-root-admin AWS_REGION=us-east-1 bash unkeyed/infra/contrib/add-aws-user-to-aws-group.sh [username]
+```
+Where `[username]` is the `@unkey.com` user you're adding. The script can accept a secondary argument if for example you're adding someone to the `aws-administrators` group.

--- a/apps/engineering/content/infrastructure/aws/user-group-management.mdx
+++ b/apps/engineering/content/infrastructure/aws/user-group-management.mdx
@@ -2,10 +2,39 @@
 title: User and Group management
 description: How to manage users and groups in AWS IAM Identity Center
 ---
-import { Step, Steps } from 'fumadocs-ui/components/steps';
 
-SCIM, which automagically provisions users does only that. It does not handle synchronization of groups or group membership. There's a tool from the awslabs github org called ssosync that is usually how you handle synchronizing from Google Workspace to IAM Identity Center. The secure way to handle service accounts in GCP is using Workload Identity Federation which as of this writing, is unsupported because the `ssosync` app expects specific user credentials hard-coded from a file. There are a couple of PRs on that repo to implement it but progress seems to have stalled since end of last year. To faciliate mapping Workspace users to IAM Identity Center users, there is a script in `unkeyed/infra/contrib` to facilitate that.
+# SCIM Limitations
+
+SCIM, which automagically provisions users, does only that. It does not handle synchronization of groups or group membership.
+
+# Current Solution
+
+There's a tool from the AWS Labs GitHub organization called `ssosync` that typically handles synchronization from Google Workspace to IAM Identity Center. However, it currently has limitations:
+
+- The secure way to handle service accounts in GCP is using Workload Identity Federation, which, as of this writing, is unsupported
+- The `ssosync` app expects specific user credentials hard-coded from a file
+- There are a couple of PRs on that repo to implement it, but progress seems to have stalled since the end of last year
+
+To facilitate mapping Workspace users to IAM Identity Center users, we provide a script in `unkeyed/infra/contrib`.
+
+## Usage
+
+### Basic Usage
 ```bash
- AWS_PROFILE=unkey-root-admin AWS_REGION=us-east-1 bash unkeyed/infra/contrib/add-aws-user-to-aws-group.sh [username]
+AWS_PROFILE=unkey-root-admin \
+AWS_REGION=us-east-1 \
+bash unkeyed/infra/contrib/add-aws-user-to-aws-group.sh [username]
 ```
-Where `[username]` is the `@unkey.com` user you're adding. The script can accept a secondary argument if for example you're adding someone to the `aws-administrators` group.
+
+Where `[username]` is the `@unkey.com` user you're adding (e.g., `john.doe@unkey.com`)
+
+### Adding to a Specific Group
+```bash
+AWS_PROFILE=unkey-root-admin \
+AWS_REGION=us-east-1 \
+bash unkeyed/infra/contrib/add-aws-user-to-aws-group.sh john.doe@unkey.com aws-administrators
+```
+
+#### Available groups:
+- `aws-administrators`: Full administrative access
+- `aws-users`: Non-administrative access


### PR DESCRIPTION
- Until SSOSync works with Google's Workload Identity Federation we'll manage users/groups manually as there shouldn't be too many changes.

- [x] Updated the Unkey Docs if changes were necessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Introduced a new guide on managing users and groups within AWS IAM Identity Center.
  - The guide outlines limitations of SCIM in user provisioning and references the `ssosync` tool for synchronizing users.
  - Includes a script for mapping Google Workspace users to IAM Identity Center users with example commands for adding users to AWS groups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->