### PR TITLE
fix(ui): improve Switch thumb contrast using content-subtle token

### DIFF
--- a/apps/dashboard/components/ui/switch.tsx
+++ b/apps/dashboard/components/ui/switch.tsx
@@ -20,7 +20,7 @@ const Switch = React.forwardRef<
     <SwitchPrimitives.Thumb
       className={cn(
         "pointer-events-none block h-4 w-4 rounded-full shadow-lg transition-transform data-[state=checked]:translate-x-[17px] data-[state=unchecked]:translate-x-0",
-        "data-[state=checked]:bg-secondary data-[state=unchecked]:bg-white"
+        "data-[state=checked]:bg-secondary data-[state=unchecked]:bg-content-subtle"
       )}
     />
   </SwitchPrimitives.Root>

--- a/apps/dashboard/components/ui/switch.tsx
+++ b/apps/dashboard/components/ui/switch.tsx
@@ -19,7 +19,8 @@ const Switch = React.forwardRef<
   >
     <SwitchPrimitives.Thumb
       className={cn(
-        "pointer-events-none block h-4 w-4 rounded-full  bg-secondary  shadow-lg transition-transform data-[state=checked]:translate-x-[17px] data-[state=unchecked]:translate-x-0",
+        "pointer-events-none block h-4 w-4 rounded-full shadow-lg transition-transform data-[state=checked]:translate-x-[17px] data-[state=unchecked]:translate-x-0",
+        "data-[state=checked]:bg-secondary data-[state=unchecked]:bg-white"
       )}
     />
   </SwitchPrimitives.Root>


### PR DESCRIPTION
## What does this PR do?

The switch thumb now uses bg-content-subtle (hsl(240 3.8% 46.1%)) for better visibility in both light/dark modes, aligning with existing design tokens.

Fixes # (issue)

https://github.com/unkeyed/unkey/issues/2823


## Type of change

<!-- Please mark the relevant points by using [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Manual Testing:
- ✅ Verified in light mode
- ✅ Verified in dark mode

Screenshots:
Before | After
--- | ---

## Old Dark Mode
[
<img width="1227" alt="old_dark_mode" src="https://github.com/user-attachments/assets/fb0743ad-a87c-4749-8178-5a2ca080811d" />
] |
## Updated Dark Mode
 [
<img width="1218" alt="updated_dark_mode" src="https://github.com/user-attachments/assets/0ca7d404-13d9-40b8-af2a-b1f6bc14f806" />
]

## Old Light Mode

[
<img width="1216" alt="old_light_mode" src="https://github.com/user-attachments/assets/aaea0315-b4ef-4469-91a3-81203a24f6f7" />
] | 
## Updated Light Mode
[
<img width="1212" alt="updated_light_mode" src="https://github.com/user-attachments/assets/7c72545b-c20d-4296-8224-bfe54102aac6" />
]

The comparison shows improved visibility of the thumb component while maintaining design consistency.

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR
- [x] Updated the Unkey Docs if changes were necessary
