### PR TITLE
feat: Add build/push workflow for API image

### DIFF
--- a/.github/workflows/job_build_api_image.yaml
+++ b/.github/workflows/job_build_api_image.yaml
@@ -1,0 +1,45 @@
+name: Build and push API
+on:
+  push:
+    tags:
+      - "api/v*"
+jobs:
+  build:
+    permissions:
+      contents: read
+      packages: write
+    name: Build and push API
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        run: |
+          # Remove the 'api/' prefix from the tag to get the version
+          VERSION=${GITHUB_REF#refs/tags/api/}
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Get tags
+        run: echo "TAGS=ghcr.io/${{ github.repository }}:${VERSION}" >> $GITHUB_ENV
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to image repository
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: "{{defaultContext}}:go"
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ env.TAGS }}
+          build-args: |
+            VERSION=${{ env.VERSION }}

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -1,7 +1,5 @@
 FROM golang:1.23 AS builder
 
-
-
 WORKDIR /go/src/github.com/unkeyed/unkey/go
 COPY go.sum go.mod ./
 RUN go mod download
@@ -9,11 +7,12 @@ RUN go mod download
 COPY . .
 ARG VERSION
 ENV CGO_ENABLED=0
-RUN go build -o bin/unkey -ldflags "-X 'github.com/unkeyed/unkey/go/pkg/version.Version=${VERSION}'"  ./main.go
+RUN go build -o bin/unkey -ldflags="-X 'github.com/unkeyed/unkey/go/pkg/version.Version=${VERSION}'" ./main.go
 
 FROM gcr.io/distroless/static-debian12
-# FROM scratch
 COPY --from=builder /go/src/github.com/unkeyed/unkey/go/bin/unkey /
 
+LABEL org.opencontainers.image.source=https://github.com/unkeyed/unkey/go
+LABEL org.opencontainers.image.description="Unkey API"
 
-ENTRYPOINT  [ "/unkey"]
+ENTRYPOINT  ["/unkey"]


### PR DESCRIPTION
- Add job to build and push the API image container when a new tag is created with “api/v*”
- Update Dockerfile with LABELs for OCI

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an automated workflow that builds and deploys container images on version updates, streamlining the API’s release process.
- **Refactor**
  - Improved the build process by refining command formatting and adding descriptive metadata, ensuring consistent and clear image details.

These enhancements simplify deployments and boost operational efficiency without altering the API’s functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->