### PR TITLE
fix: Use correct GHCR_TOKEN for pushing container

### DIFF
--- a/.github/workflows/job_build_api_image.yaml
+++ b/.github/workflows/job_build_api_image.yaml
@@ -31,7 +31,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GHCR_TOKEN }}
 
       - name: Build and push
         uses: docker/build-push-action@v6


### PR DESCRIPTION
- GHCR_TOKEN, not GITHUB_TOKEN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the authentication method used in the deployment workflow for accessing container images. This change enhances our deployment process without affecting public functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->