### PR TITLE
docs: only require host:port

### DIFF
--- a/apps/engineering/content/architecture/services/api/config.mdx
+++ b/apps/engineering/content/architecture/services/api/config.mdx
@@ -146,13 +146,12 @@ These options configure analytics storage and observability for the Unkey API.
 <Property name="--otel-otlp-endpoint | UNKEY_OTEL_OTLP_ENDPOINT" type="string" required={false}>
   OpenTelemetry collector endpoint for metrics, traces, and logs. When provided, the Unkey API will send telemetry data (metrics, traces, and logs) to this endpoint using the OTLP protocol.
 
-  The endpoint should be an OpenTelemetry collector capable of receiving OTLP data. The implementation is currently configured for Grafana Cloud integration but is compatible with any OTLP-compliant collector.
-
+  This should be specified as a host and optional port without scheme or path. The implementation is configured for HTTP protocol by default.
 
   **Examples:**
-  - `--otel-otlp-endpoint=http://localhost:4317` - Local collector
-  - `--otel-otlp-endpoint=https://otlp.grafana-cloud.example.com` - Grafana Cloud
-  - `--otel-otlp-endpoint=https://api.honeycomb.io:443` - Honeycomb.io
+  - `--otel-otlp-endpoint=localhost:4317` - Local collector
+  - `--otel-otlp-endpoint=otlp-gateway-prod-us-east-0.grafana.net:443` - Grafana Cloud
+  - `--otel-otlp-endpoint=api.honeycomb.io:443` - Honeycomb.io
 </Property>
 
 <Property name="--color | UNKEY_COLOR" type="boolean" defaultValue={false} required={false}>

--- a/go/cmd/api/main.go
+++ b/go/cmd/api/main.go
@@ -327,6 +327,8 @@ Examples:
 		&cli.StringFlag{
 			Name: "otel-otlp-endpoint",
 			Usage: `OpenTelemetry collector endpoint for metrics, traces, and logs.
+Specified as host:port (without scheme or path)
+
 When provided, the Unkey API will send telemetry data (metrics, traces, and logs)
 to this endpoint using the OTLP protocol. This enables comprehensive observability
 for production deployments.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the API configuration and command-line usage guides for the OpenTelemetry collector endpoint.
	- Clarified that the endpoint should be formatted as a host with an optional port, omitting any scheme or path.
	- Revised examples for local collectors and cloud integrations to enhance clarity and consistency for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->