### PR TITLE
feat: cancel subscriptions at the end of the period

### DIFF
--- a/apps/dashboard/app/(app)/settings/billing/client.tsx
+++ b/apps/dashboard/app/(app)/settings/billing/client.tsx
@@ -128,10 +128,11 @@ export const Client: React.FC<Props> = (props) => {
                   {props.subscription ? (
                     <Confirm
                       title={`${i > selectedProductIndex ? "Upgrade" : "Downgrade"} to ${p.name}`}
-                      description={`Changing to ${p.name
-                        } updates your request quota to ${formatNumber(
-                          p.quota.requestsPerMonth,
-                        )} per month immediately.`}
+                      description={`Changing to ${
+                        p.name
+                      } updates your request quota to ${formatNumber(
+                        p.quota.requestsPerMonth,
+                      )} per month immediately.`}
                       onConfirm={async () =>
                         updateSubscription.mutateAsync({
                           oldProductId: props.currentProductId!,
@@ -147,10 +148,11 @@ export const Client: React.FC<Props> = (props) => {
                   ) : (
                     <Confirm
                       title={`Upgrade to ${p.name}`}
-                      description={`Changing to ${p.name
-                        } updates your request quota to ${formatNumber(
-                          p.quota.requestsPerMonth,
-                        )} per month immediately.`}
+                      description={`Changing to ${
+                        p.name
+                      } updates your request quota to ${formatNumber(
+                        p.quota.requestsPerMonth,
+                      )} per month immediately.`}
                       onConfirm={() => createSubscription.mutateAsync({ productId: p.id })}
                       fineprint={
                         props.hasPreviousSubscriptions
@@ -239,7 +241,7 @@ const FreeTierAlert: React.FC = () => {
   );
 };
 
-const CancelAlert: React.FC<{ cancelAt?: number; }> = (props) => {
+const CancelAlert: React.FC<{ cancelAt?: number }> = (props) => {
   const router = useRouter();
   const uncancelSubscription = trpc.stripe.uncancelSubscription.useMutation({
     onSuccess: () => {

--- a/apps/dashboard/app/(app)/settings/billing/client.tsx
+++ b/apps/dashboard/app/(app)/settings/billing/client.tsx
@@ -25,6 +25,7 @@ type Props = {
     id: string;
     status: Stripe.Subscription.Status;
     trialUntil?: number;
+    cancelAt?: number;
   };
   currentProductId?: string;
   products: Array<{
@@ -72,7 +73,9 @@ export const Client: React.FC<Props> = (props) => {
   const allowUpdate =
     props.subscription && ["active", "trialing"].includes(props.subscription.status);
   const allowCancel =
-    props.subscription && ["active", "trialing"].includes(props.subscription.status);
+    props.subscription &&
+    ["active", "trialing"].includes(props.subscription.status) &&
+    !props.subscription.cancelAt;
   const isFreeTier =
     !props.subscription || !["active", "trialing"].includes(props.subscription.status);
   const selectedProductIndex = allowUpdate
@@ -88,6 +91,7 @@ export const Client: React.FC<Props> = (props) => {
         />
       ) : null}
 
+      <CancelAlert cancelAt={props.subscription?.cancelAt} />
       {isFreeTier ? <FreeTierAlert /> : null}
       <Usage current={props.usage.current} max={props.usage.max} />
 
@@ -124,11 +128,10 @@ export const Client: React.FC<Props> = (props) => {
                   {props.subscription ? (
                     <Confirm
                       title={`${i > selectedProductIndex ? "Upgrade" : "Downgrade"} to ${p.name}`}
-                      description={`Changing to ${
-                        p.name
-                      } updates your request quota to ${formatNumber(
-                        p.quota.requestsPerMonth,
-                      )} per month immediately.`}
+                      description={`Changing to ${p.name
+                        } updates your request quota to ${formatNumber(
+                          p.quota.requestsPerMonth,
+                        )} per month immediately.`}
                       onConfirm={async () =>
                         updateSubscription.mutateAsync({
                           oldProductId: props.currentProductId!,
@@ -144,11 +147,10 @@ export const Client: React.FC<Props> = (props) => {
                   ) : (
                     <Confirm
                       title={`Upgrade to ${p.name}`}
-                      description={`Changing to ${
-                        p.name
-                      } updates your request quota to ${formatNumber(
-                        p.quota.requestsPerMonth,
-                      )} per month immediately.`}
+                      description={`Changing to ${p.name
+                        } updates your request quota to ${formatNumber(
+                          p.quota.requestsPerMonth,
+                        )} per month immediately.`}
                       onConfirm={() => createSubscription.mutateAsync({ productId: p.id })}
                       fineprint={
                         props.hasPreviousSubscriptions
@@ -205,7 +207,7 @@ export const Client: React.FC<Props> = (props) => {
             <div className="w-full flex justify-end">
               <Confirm
                 title="Cancel plan"
-                description="Canceling your plan will immediately downgrade your workspace to the free tier. Prorated credits are applied to your account and you can resume the subscription any time."
+                description="Canceling your plan will downgrade your workspace to the free tier at the end of the current period. You can resume your subscription until then."
                 onConfirm={() => cancelSubscription.mutateAsync()}
                 trigger={(onClick) => (
                   <Button variant="outline" color="danger" size="lg" onClick={onClick}>
@@ -237,6 +239,48 @@ const FreeTierAlert: React.FC = () => {
   );
 };
 
+const CancelAlert: React.FC<{ cancelAt?: number; }> = (props) => {
+  const router = useRouter();
+  const uncancelSubscription = trpc.stripe.uncancelSubscription.useMutation({
+    onSuccess: () => {
+      router.refresh();
+      toast.info("Subscription resumed");
+    },
+    onError: (err) => {
+      toast.error(err.message);
+    },
+  });
+
+  if (!props.cancelAt) {
+    return null;
+  }
+  return (
+    <SettingCard
+      title="Cancellation scheduled"
+      description={
+        <p>
+          Your subscription ends in
+          <span className="text-accent-12"> {ms(props.cancelAt - Date.now(), { long: true })}</span>{" "}
+          on <span className="text-accent-12">{new Date(props.cancelAt).toLocaleDateString()}</span>
+          .
+        </p>
+      }
+      border="both"
+      className="border-warning-7 bg-warning-2"
+    >
+      <div className="flex w-full justify-end">
+        <Button
+          variant="primary"
+          loading={uncancelSubscription.isLoading}
+          disabled={uncancelSubscription.isLoading}
+          onClick={() => uncancelSubscription.mutate()}
+        >
+          Resubscribe
+        </Button>
+      </div>
+    </SettingCard>
+  );
+};
 const SusbcriptionStatus: React.FC<{ status: Stripe.Subscription.Status; trialUntil?: number }> = (
   props,
 ) => {

--- a/apps/dashboard/app/(app)/settings/billing/page.tsx
+++ b/apps/dashboard/app/(app)/settings/billing/page.tsx
@@ -174,6 +174,7 @@ export default async function BillingPage() {
               id: subscription.id,
               status: subscription.status,
               trialUntil: subscription.trial_end ? subscription.trial_end * 1000 : undefined,
+              cancelAt: subscription.cancel_at ? subscription.cancel_at * 1000 : undefined,
             }
           : undefined
       }

--- a/apps/dashboard/app/api/webhooks/stripe/route.ts
+++ b/apps/dashboard/app/api/webhooks/stripe/route.ts
@@ -1,0 +1,92 @@
+import { insertAuditLogs } from "@/lib/audit";
+import { type Quotas, db, eq, schema } from "@/lib/db";
+import { stripeEnv } from "@/lib/env";
+import Stripe from "stripe";
+
+export const runtime = "nodejs";
+
+export const POST = async (req: Request): Promise<Response> => {
+  const signature = req.headers.get("stripe-signature");
+  if (!signature) {
+    throw new Error("Signature missing");
+  }
+
+  const e = stripeEnv();
+
+  if (!e) {
+    throw new Error("stripe env variables are not set up");
+  }
+
+  const stripe = new Stripe(stripeEnv()!.STRIPE_SECRET_KEY, {
+    apiVersion: "2023-10-16",
+    typescript: true,
+  });
+
+  const event = stripe.webhooks.constructEvent(
+    await req.text(),
+    signature,
+    e.STRIPE_WEBHOOK_SECRET,
+  );
+
+  switch (event.type) {
+    case "customer.subscription.deleted": {
+      const sub = event.data.object as Stripe.Subscription;
+
+      const ws = await db.query.workspaces.findFirst({
+        where: (table, { and, eq, isNull }) =>
+          and(eq(table.stripeSubscriptionId, sub.id), isNull(table.deletedAtM)),
+        with: {
+          auditLogBuckets: {
+            where: (table, { eq }) => eq(table.name, "unkey_mutations"),
+          },
+        },
+      });
+      if (!ws) {
+        throw new Error("workspace does not exist");
+      }
+      await db
+        .update(schema.workspaces)
+        .set({
+          stripeSubscriptionId: null,
+        })
+        .where(eq(schema.workspaces.id, ws.id));
+
+      const freeTierQuotas: Omit<Quotas, "workspaceId"> = {
+        requestsPerMonth: 150_000,
+        logsRetentionDays: 7,
+        auditLogsRetentionDays: 30,
+        team: false,
+      };
+      await db
+        .insert(schema.quotas)
+        .values({
+          workspaceId: ws.id,
+          ...freeTierQuotas,
+        })
+        .onDuplicateKeyUpdate({
+          set: freeTierQuotas,
+        });
+
+      await insertAuditLogs(db, ws.auditLogBuckets[0].id, {
+        workspaceId: ws.id,
+        actor: {
+          type: "system",
+          id: "stripe",
+        },
+        event: "workspace.update",
+        description: "Cancelled subscription.",
+        resources: [],
+        context: {
+          location: "",
+          userAgent: undefined,
+        },
+      });
+      break;
+    }
+
+    default:
+      console.error("Incoming stripe event, that should not be received", event.type);
+      break;
+  }
+  return new Response("OK");
+};

--- a/apps/dashboard/lib/audit.ts
+++ b/apps/dashboard/lib/audit.ts
@@ -57,7 +57,7 @@ export type UnkeyAuditLog = {
   event: z.infer<typeof unkeyAuditLogEvents>;
   description: string;
   actor: {
-    type: "user" | "key";
+    type: "user" | "key" | "system";
     name?: string;
     id: string;
     meta?: Record<string, string | number | boolean | null>;

--- a/apps/dashboard/lib/env.ts
+++ b/apps/dashboard/lib/env.ts
@@ -63,6 +63,7 @@ const stripeSchema = z.object({
   STRIPE_SECRET_KEY: z.string(),
   // The product ids, comma separated, from lowest to highest pro plan
   STRIPE_PRODUCT_IDS_PRO: z.string().transform((s) => s.split(",")),
+  STRIPE_WEBHOOK_SECRET: z.string(),
 });
 
 const stripeParsed = stripeSchema.safeParse(process.env);

--- a/apps/dashboard/lib/trpc/routers/index.ts
+++ b/apps/dashboard/lib/trpc/routers/index.ts
@@ -53,6 +53,7 @@ import { updatePermission } from "./rbac/updatePermission";
 import { updateRole } from "./rbac/updateRole";
 import { cancelSubscription } from "./stripe/cancelSubscription";
 import { createSubscription } from "./stripe/createSubscription";
+import { uncancelSubscription } from "./stripe/uncancelSubscription";
 import { updateSubscription } from "./stripe/updateSubscription";
 import { vercelRouter } from "./vercel";
 import { changeWorkspaceName } from "./workspace/changeName";
@@ -105,6 +106,7 @@ export const router = t.router({
     createSubscription,
     updateSubscription,
     cancelSubscription,
+    uncancelSubscription,
   }),
   vercel: vercelRouter,
   plain: t.router({

--- a/apps/dashboard/lib/trpc/routers/stripe/uncancelSubscription.ts
+++ b/apps/dashboard/lib/trpc/routers/stripe/uncancelSubscription.ts
@@ -2,7 +2,7 @@ import { stripeEnv } from "@/lib/env";
 import { TRPCError } from "@trpc/server";
 import Stripe from "stripe";
 import { auth, t } from "../../trpc";
-export const cancelSubscription = t.procedure.use(auth).mutation(async ({ ctx }) => {
+export const uncancelSubscription = t.procedure.use(auth).mutation(async ({ ctx }) => {
   const e = stripeEnv();
   if (!e) {
     throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Stripe is not set up" });
@@ -27,6 +27,6 @@ export const cancelSubscription = t.procedure.use(auth).mutation(async ({ ctx })
   }
 
   await stripe.subscriptions.update(ctx.workspace.stripeSubscriptionId, {
-    cancel_at_period_end: true,
+    cancel_at_period_end: false,
   });
 });

--- a/apps/dashboard/lib/trpc/routers/stripe/updateSubscription.ts
+++ b/apps/dashboard/lib/trpc/routers/stripe/updateSubscription.ts
@@ -78,6 +78,12 @@ export const updateSubscription = t.procedure
       proration_behavior: "always_invoice",
     });
 
+    if (sub.cancel_at) {
+      await stripe.subscriptions.update(sub.id, {
+        cancel_at_period_end: false,
+      });
+    }
+
     await db
       .update(schema.workspaces)
       .set({

--- a/go/api/openapi.json
+++ b/go/api/openapi.json
@@ -50,13 +50,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "requestId",
-          "detail",
-          "status",
-          "title",
-          "type"
-        ]
+        "required": ["requestId", "detail", "status", "title", "type"]
       },
       "NotFoundError": {
         "$ref": "#/components/schemas/BaseError"
@@ -86,9 +80,7 @@
                 "type": "array"
               }
             },
-            "required": [
-              "errors"
-            ]
+            "required": ["errors"]
           }
         ]
       },
@@ -112,10 +104,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "message",
-          "location"
-        ]
+        "required": ["message", "location"]
       },
       "V2LivenessResponseBody": {
         "additionalProperties": false,
@@ -126,9 +115,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "message"
-        ],
+        "required": ["message"],
         "type": "object"
       },
       "V2RatelimitSetOverrideRequestBody": {
@@ -164,11 +151,7 @@
             "minimum": 0
           }
         },
-        "required": [
-          "identifier",
-          "limit",
-          "duration"
-        ],
+        "required": ["identifier", "limit", "duration"],
         "type": "object"
       },
       "V2RatelimitSetOverrideResponseBody": {
@@ -179,9 +162,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "overrideId"
-        ],
+        "required": ["overrideId"],
         "type": "object"
       },
       "V2RatelimitGetOverrideRequestBody": {
@@ -207,9 +188,7 @@
             "maxLength": 255
           }
         },
-        "required": [
-          "identifier"
-        ],
+        "required": ["identifier"],
         "type": "object"
       },
       "V2RatelimitGetOverrideResponseBody": {
@@ -246,13 +225,7 @@
             "minimum": 0
           }
         },
-        "required": [
-          "namespaceId",
-          "overrideId",
-          "duration",
-          "identifier",
-          "limit"
-        ],
+        "required": ["namespaceId", "overrideId", "duration", "identifier", "limit"],
         "type": "object"
       },
       "V2RatelimitLimitRequestBody": {
@@ -290,12 +263,7 @@
             "minimum": 1
           }
         },
-        "required": [
-          "namespace",
-          "identifier",
-          "limit",
-          "duration"
-        ],
+        "required": ["namespace", "identifier", "limit", "duration"],
         "type": "object"
       },
       "V2RatelimitLimitResponseBody": {
@@ -325,12 +293,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "limit",
-          "remaining",
-          "reset",
-          "success"
-        ],
+        "required": ["limit", "remaining", "reset", "success"],
         "type": "object"
       },
       "V2RatelimitDeleteOverrideRequestBody": {
@@ -356,9 +319,7 @@
             "maxLength": 255
           }
         },
-        "required": [
-          "identifier"
-        ],
+        "required": ["identifier"],
         "type": "object"
       },
       "V2RatelimitDeleteOverrideResponseBody": {
@@ -443,9 +404,7 @@
             "description": "Error"
           }
         },
-        "tags": [
-          "ratelimit"
-        ]
+        "tags": ["ratelimit"]
       }
     },
     "/v2/ratelimit.setOverride": {
@@ -523,16 +482,12 @@
             "description": "Error"
           }
         },
-        "tags": [
-          "ratelimit"
-        ]
+        "tags": ["ratelimit"]
       }
     },
     "/v2/ratelimit.getOverride": {
       "post": {
-        "tags": [
-          "ratelimit"
-        ],
+        "tags": ["ratelimit"],
         "operationId": "v2.ratelimit.getOverride",
         "requestBody": {
           "content": {
@@ -610,9 +565,7 @@
     },
     "/v2/ratelimit.deleteOverride": {
       "post": {
-        "tags": [
-          "ratelimit"
-        ],
+        "tags": ["ratelimit"],
         "operationId": "v2.ratelimit.deleteOverride",
         "requestBody": {
           "content": {
@@ -725,9 +678,7 @@
           }
         },
         "summary": "Liveness check",
-        "tags": [
-          "liveness"
-        ]
+        "tags": ["liveness"]
       }
     }
   }

--- a/tools/migrate/migrate_subscription.ts
+++ b/tools/migrate/migrate_subscription.ts
@@ -14,7 +14,7 @@ async function main() {
   await conn.ping();
   const db = mysqlDrizzle(conn, { schema, mode: "default" });
 
-  const workspaceId = "ws_39g5eLLQTX8bVdbsGK9Dke";
+  const workspaceId = "ws_wB4SmWrYkhSbWE2rH61S6gMseWw";
   const productId = "prod_Rtu3rLbjwprz7p";
 
   const workspace = await db.query.workspaces.findFirst({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a billing alert that shows when a cancellation is scheduled, including a countdown and an option to resume the subscription.
	- Introduced functionality for users to reverse their subscription cancellation before the current period ends.

- **Refactor**
	- Updated cancellation processing so that subscriptions are set to cancel at period end rather than immediately, with confirmation messaging now clarifying the timing of the downgrade.
	- Enhanced subscription management logic to handle cancellation states more effectively.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->