### PR TITLE
feat(chproxy): OTEL optimizations

### DIFF
--- a/apps/chproxy/batch.go
+++ b/apps/chproxy/batch.go
@@ -12,17 +12,14 @@ import (
 	"go.opentelemetry.io/otel/codes"
 )
 
-const (
-	MAX_BATCH_SIZE int = 10000
-)
-
 type Batch struct {
 	Rows   []string
 	Params url.Values
+	Table  string
 }
 
 func persist(ctx context.Context, batch *Batch, config *Config) error {
-	ctx, span := telemetry.Tracer.Start(ctx, "persist_batch")
+	ctx, span := telemetry.Tracer.Start(ctx, batch.Table)
 	defer span.End()
 
 	if len(batch.Rows) == 0 {
@@ -34,7 +31,6 @@ func persist(ctx context.Context, batch *Batch, config *Config) error {
 
 	span.SetAttributes(
 		attribute.Int("rows", len(batch.Rows)),
-		attribute.String("query", batch.Params.Get("query")),
 	)
 
 	u, err := url.Parse(config.ClickhouseURL)
@@ -106,12 +102,9 @@ func persist(ctx context.Context, batch *Batch, config *Config) error {
 
 	config.Logger.Info("rows persisted",
 		"count", len(batch.Rows),
-		"query", batch.Params.Get("query"))
+		"table", batch.Table)
+
 	span.SetStatus(codes.Ok, "")
-	span.SetAttributes(
-		attribute.String("result", "successfully sent to Clickhouse"),
-		attribute.Int("rows_processed", len(batch.Rows)),
-	)
 
 	return nil
 }

--- a/apps/chproxy/batch.go
+++ b/apps/chproxy/batch.go
@@ -12,6 +12,10 @@ import (
 	"go.opentelemetry.io/otel/codes"
 )
 
+const (
+	MAX_BATCH_SIZE int = 10000
+)
+
 type Batch struct {
 	Rows   []string
 	Params url.Values

--- a/apps/chproxy/buffer.go
+++ b/apps/chproxy/buffer.go
@@ -8,6 +8,10 @@ import (
 	"go.opentelemetry.io/otel/metric"
 )
 
+const (
+	MAX_BUFFER_SIZE int = 5000
+)
+
 // startBufferProcessor manages processing of data sent to Clickhouse.
 // Returns a channel that signals when all pending batches have been processed during shutdown
 func startBufferProcessor(
@@ -108,10 +112,10 @@ func startBufferProcessor(
 				buffered += len(b.Rows)
 				SetBufferSize(int64(buffered))
 
-				if buffered >= config.MaxBatchSize {
+				if buffered >= MAX_BATCH_SIZE {
 					config.Logger.Info("flushing due to max batch size",
 						"buffered_rows", buffered,
-						"max_size", config.MaxBatchSize)
+						"max_size", MAX_BATCH_SIZE)
 					flushAndReset(ctx, "max_size")
 				}
 			case <-ticker.C:

--- a/apps/chproxy/main.go
+++ b/apps/chproxy/main.go
@@ -67,13 +67,13 @@ func main() {
 	}
 
 	config.Logger.Info(fmt.Sprintf("%s starting", config.ServiceName),
-		"max_buffer_size", config.MaxBufferSize,
-		"max_batch_size", config.MaxBatchSize,
+		"max_buffer_size", MAX_BUFFER_SIZE,
+		"max_batch_size", MAX_BATCH_SIZE,
 		"flush_interval", config.FlushInterval.String())
 
 	requiredAuthorization := "Basic " + base64.StdEncoding.EncodeToString([]byte(config.BasicAuth))
 
-	buffer := make(chan *Batch, config.MaxBufferSize)
+	buffer := make(chan *Batch, MAX_BUFFER_SIZE)
 
 	// blocks until we've persisted everything and the process may stop
 	done := startBufferProcessor(ctx, buffer, config, telemetry)

--- a/apps/chproxy/main.go
+++ b/apps/chproxy/main.go
@@ -20,7 +20,8 @@ import (
 )
 
 const (
-	LOG_TICKER_SAMPLE_RATE = 10 // Only log every 10th ticker flush
+	maxBufferSize int = 50000
+	maxBatchSize  int = 10000
 )
 
 var (
@@ -67,13 +68,11 @@ func main() {
 	}
 
 	config.Logger.Info(fmt.Sprintf("%s starting", config.ServiceName),
-		"max_buffer_size", MAX_BUFFER_SIZE,
-		"max_batch_size", MAX_BATCH_SIZE,
 		"flush_interval", config.FlushInterval.String())
 
 	requiredAuthorization := "Basic " + base64.StdEncoding.EncodeToString([]byte(config.BasicAuth))
 
-	buffer := make(chan *Batch, MAX_BUFFER_SIZE)
+	buffer := make(chan *Batch, maxBufferSize)
 
 	// blocks until we've persisted everything and the process may stop
 	done := startBufferProcessor(ctx, buffer, config, telemetry)
@@ -100,12 +99,6 @@ func main() {
 
 		telemetry.Metrics.RequestCounter.Add(ctx, 1)
 
-		span.SetAttributes(
-			attribute.String("method", r.Method),
-			attribute.String("path", r.URL.Path),
-			attribute.String("remote_addr", r.RemoteAddr),
-		)
-
 		if r.Header.Get("Authorization") != requiredAuthorization {
 			telemetry.Metrics.ErrorCounter.Add(ctx, 1)
 			config.Logger.Error("invalid authorization header",
@@ -117,6 +110,12 @@ func main() {
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return
 		}
+
+		span.SetAttributes(
+			attribute.String("method", r.Method),
+			attribute.String("path", r.URL.Path),
+			attribute.String("remote_addr", r.RemoteAddr),
+		)
 
 		query := r.URL.Query().Get("query")
 		span.SetAttributes(attribute.String("query", query))
@@ -156,6 +155,7 @@ func main() {
 		buffer <- &Batch{
 			Params: params,
 			Rows:   rows,
+			Table:  strings.Split(query, " ")[2],
 		}
 
 		w.Write([]byte("ok"))


### PR DESCRIPTION
- Move configuration consts to code via MAX_BATCH_SIZE, MAX_BUFFER_SIZE
- Add trace sampling configuration via OTEL_TRACE_SAMPLE_RATE
- Default sampling of traces is 25%
- Implement trace compression
- Always sample errors
- Add batch size control for trace exports (default 512)
- Cleanup metrics shutdown calls
- Bump service version to 1.3.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced telemetry capabilities with Gzip compression for trace exports and a more flexible trace sampling strategy.
  - Added new configuration options to support improved trace diagnostics, including `TraceMaxBatchSize` and `TraceSampleRate`.
  - Defined constants for maximum batch and buffer sizes to standardize processing limits.

- **Chores**
  - Refined internal processing limits for batching and buffering to ensure more consistent performance.
  - Updated default settings, including a version bump, to streamline overall operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->