### PR TITLE
fix: set a maxURLLength for trpc batches

### DIFF
--- a/apps/dashboard/app/react-query-provider.tsx
+++ b/apps/dashboard/app/react-query-provider.tsx
@@ -30,6 +30,7 @@ export const ReactQueryProvider: React.FC<PropsWithChildren> = ({ children }) =>
       links: [
         httpBatchLink({
           url: `${getBaseUrl()}/api/trpc`,
+          maxURLLength: 500, // We ran into issues on vercel with long URLs of 1000 characters or more
         }),
       ],
     }),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Limited URL length to 500 characters to prevent issues with excessively long URLs on hosting platforms like Vercel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->