### PR TITLE
fix: remove outdated and wrong quota check

### DIFF
--- a/apps/dashboard/app/(app)/apis/_components/api-list-client.tsx
+++ b/apps/dashboard/app/(app)/apis/_components/api-list-client.tsx
@@ -15,34 +15,11 @@ import { CreateApiButton } from "./create-api-button";
 
 export const ApiListClient = ({
   initialData,
-  unpaid,
 }: {
   initialData: ApisOverviewResponse;
-  unpaid: boolean;
 }) => {
   const [isSearching, setIsSearching] = useState<boolean>(false);
   const [apiList, setApiList] = useState<ApiOverview[]>(initialData.apiList);
-
-  if (unpaid) {
-    return (
-      <EmptyComponentSpacer>
-        <Empty className="border border-gray-6 rounded-lg bg-gray-1">
-          <Empty.Title className="text-xl">Upgrade your plan</Empty.Title>
-          <Empty.Description>
-            Team workspaces is a paid feature. Please switch to a paid plan to continue using it.
-          </Empty.Description>
-          <Empty.Actions className="mt-4 ">
-            <a href="/settings/billing" target="_blank" rel="noopener noreferrer">
-              <Button size="md">
-                <BookBookmark />
-                Subscribe
-              </Button>
-            </a>
-          </Empty.Actions>
-        </Empty>
-      </EmptyComponentSpacer>
-    );
-  }
 
   return (
     <div className="flex flex-col">

--- a/apps/dashboard/app/(app)/apis/page.tsx
+++ b/apps/dashboard/app/(app)/apis/page.tsx
@@ -29,12 +29,11 @@ export default async function ApisOverviewPage(props: Props) {
     workspaceId: workspace.id,
     limit: DEFAULT_OVERVIEW_FETCH_LIMIT,
   });
-  const unpaid = workspace.tenantId.startsWith("org_") && workspace.plan === "free";
 
   return (
     <div>
       <Navigation isNewApi={!!props.searchParams.new} apisLength={initialData.total} />
-      <ApiListClient initialData={initialData} unpaid={unpaid} />
+      <ApiListClient initialData={initialData} />
     </div>
   );
 }


### PR DESCRIPTION
we now have proper quotas, so this check is redundand.

If a workspace is disabled, there is already a warning in the root
layout to contact us.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Removed the upgrade prompt and subscription button from the API list view, so plan-related messages no longer appear.
	- Streamlined the display logic for a consistent and focused view of API controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->