### PR TITLE
fix(api): Disable otel rpc server attributes

### DIFF
--- a/go/internal/services/ratelimit/peers.go
+++ b/go/internal/services/ratelimit/peers.go
@@ -87,7 +87,10 @@ func (s *service) newPeer(ctx context.Context, key string) (peer, error) {
 		rpcAddr = "http://" + rpcAddr
 	}
 
-	interceptor, err := otelconnect.NewInterceptor(otelconnect.WithTracerProvider(tracing.GetGlobalTraceProvider()))
+	interceptor, err := otelconnect.NewInterceptor(
+		otelconnect.WithTracerProvider(tracing.GetGlobalTraceProvider()),
+		otelconnect.WithoutServerPeerAttributes(),
+	)
 	if err != nil {
 		s.logger.Error("failed to create interceptor", "error", err.Error())
 		return peer{}, err

--- a/go/pkg/rpc/rpc.go
+++ b/go/pkg/rpc/rpc.go
@@ -54,7 +54,9 @@ func New(config Config) (*Server, error) {
 	}
 
 	interceptor, err := otelconnect.NewInterceptor(
-		otelconnect.WithTracerProvider(tracing.GetGlobalTraceProvider()), otelconnect.WithTrustRemote(),
+		otelconnect.WithTracerProvider(tracing.GetGlobalTraceProvider()),
+		otelconnect.WithTrustRemote(),
+		otelconnect.WithoutServerPeerAttributes(),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
By default OpenTelemetry RPC includes peer ports and names which increase metric cardinality by a significant amount. Setting the option WithoutServerPeerAttributes() on the interceptor removes those attributes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the system's telemetry configuration to exclude specific server connection attributes, ensuring more focused and precise performance data.
	- Enhanced monitoring capabilities while maintaining robust error logging, resulting in clearer operational insights.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->