### PR TITLE
fix: use only time as cursos

### DIFF
--- a/apps/dashboard/app/auth/layout.tsx
+++ b/apps/dashboard/app/auth/layout.tsx
@@ -109,11 +109,21 @@ export default async function AuthenticatedLayout({
           <div className="flex items-center justify-center ">
             <p className="p-4 text-xs text-center text-white/50 text-balance">
               By continuing, you agree to Unkey's{" "}
-              <Link className="underline" href="https://www.unkey.com/policies/terms" target="_blank" rel="noopener noreferrer">
+              <Link
+                className="underline"
+                href="https://www.unkey.com/policies/terms"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
                 Terms of Service
               </Link>{" "}
               and{" "}
-              <Link className="underline" href="https://www.unkey.com/policies/privacy" target="_blank" rel="noopener noreferrer">
+              <Link
+                className="underline"
+                href="https://www.unkey.com/policies/privacy"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
                 Privacy Policy
               </Link>
               , and to receive periodic emails with updates.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Refined the presentation of legal link elements in the authentication view. The links for terms and privacy display as before without affecting functionality.

- **Refactor**
  - Streamlined audit log pagination and ordering for a more intuitive, chronologically aligned log display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->