### PR TITLE
fix(chproxy): Update reader interval to 60s

### DIFF
--- a/apps/chproxy/config.go
+++ b/apps/chproxy/config.go
@@ -29,7 +29,7 @@ func LoadConfig() (*Config, error) {
 		ListenerPort:      "7123",
 		LogDebug:          false,
 		ServiceName:       "chproxy",
-		ServiceVersion:    "1.3.1",
+		ServiceVersion:    "1.3.2",
 		TraceMaxBatchSize: 512,
 		TraceSampleRate:   0.25, // Sample 25%
 	}

--- a/apps/chproxy/otel.go
+++ b/apps/chproxy/otel.go
@@ -76,7 +76,7 @@ func setupTelemetry(ctx context.Context, config *Config) (*TelemetryConfig, func
 		sdkmetric.WithReader(
 			sdkmetric.NewPeriodicReader(
 				metricExporter,
-				sdkmetric.WithInterval(10*time.Second),
+				sdkmetric.WithInterval(60*time.Second),
 			),
 		),
 	)


### PR DESCRIPTION
This will decrease the DPM rate on the Grafana Cloud side.
