### PR TITLE
fix: use counter for cache reads

### DIFF
--- a/go/pkg/cache/cache.go
+++ b/go/pkg/cache/cache.go
@@ -101,14 +101,10 @@ func New[K comparable, V any](config Config[K, V]) (*cache[K, V], error) {
 
 func (c *cache[K, V]) registerMetrics() {
 
-	repeat.Every(10*time.Second, func() {
-
-		stats := c.otter.Stats()
+	repeat.Every(60*time.Second, func() {
 
 		metrics.CacheSize.WithLabelValues(c.resource).Set(float64(c.otter.Size()))
 		metrics.CacheCapacity.WithLabelValues(c.resource).Set(float64(c.otter.Capacity()))
-		metrics.CacheHits.WithLabelValues(c.resource).Set(float64(stats.Hits()))
-		metrics.CacheMisses.WithLabelValues(c.resource).Set(float64(stats.Misses()))
 
 	})
 
@@ -168,6 +164,7 @@ func (c *cache[K, V]) get(_ context.Context, key K) (swrEntry[V], bool) {
 	v, ok := c.otter.Get(key)
 
 	timer.ObserveDuration()
+	metrics.CacheReads.WithLabelValues(c.resource, fmt.Sprintf("%t", ok)).Inc()
 
 	return v, ok
 }

--- a/go/pkg/prometheus/metrics/cache.go
+++ b/go/pkg/prometheus/metrics/cache.go
@@ -16,29 +16,14 @@ var (
 	//
 	// Example usage:
 	//   metrics.CacheHits.WithLabelValues("user_profile").Inc()
-	//   metrics.CacheHits.WithLabelValues("user_profile").Set(float64(hitCount))
-	CacheHits = promauto.NewGaugeVec(
-		prometheus.GaugeOpts{
+	//   metrics.CacheHits.WithLabelValues("user_profile")
+	CacheReads = promauto.NewCounterVec(
+		prometheus.CounterOpts{
 			Subsystem: "cache",
-			Name:      "hits",
-			Help:      "Number of cache hits by resource type.",
+			Name:      "reads_total",
+			Help:      "Number of cache reads by resource type and hit status.",
 		},
-		[]string{"resource"},
-	)
-
-	// CacheMisses tracks the number of cache read operations that did not find the requested item,
-	// labeled by resource type. Use this to monitor cache efficiency and identify improvement opportunities.
-	//
-	// Example usage:
-	//   metrics.CacheMisses.WithLabelValues("user_profile").Inc()
-	//   metrics.CacheMisses.WithLabelValues("user_profile").Set(float64(missCount))
-	CacheMisses = promauto.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Subsystem: "cache",
-			Name:      "misses",
-			Help:      "Number of cache misses by resource type.",
-		},
-		[]string{"resource"},
+		[]string{"resource", "hit"},
 	)
 
 	// CacheWrites tracks the number of cache write operations, labeled by resource type.


### PR DESCRIPTION
## What does this PR do?

Replace the 2 gauges with a single counter because it was impossible (aka I couldn't figure out how) to calculate a percentage hit ratio from the 2 gauges.

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a unified metric to track cache reads, distinguishing between hits and misses for improved observability.

- **Refactor**
  - Consolidated separate cache hit and miss metrics into a single counter for streamlined monitoring.
  - Adjusted metric reporting intervals and reduced periodic updates to enhance performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->