### PR TITLE
feat:  include roles in /v1/keys.verifyKey response

### DIFF
--- a/.changeset/good-gifts-allow.md
+++ b/.changeset/good-gifts-allow.md
@@ -1,0 +1,5 @@
+---
+"api": minor
+---
+
+return roles as part of verifications

--- a/apps/api/src/pkg/keys/service.ts
+++ b/apps/api/src/pkg/keys/service.ts
@@ -82,6 +82,7 @@ type InvalidResponse = {
   };
   remaining?: number;
   permissions: string[];
+  roles: string[];
   message?: string;
 };
 
@@ -107,6 +108,7 @@ type ValidResponse = {
    */
   authorizedWorkspaceId: string;
   permissions: string[];
+  roles: string[];
 };
 type VerifyKeyResult = NotFoundResponse | InvalidResponse | ValidResponse;
 
@@ -434,6 +436,7 @@ export class KeyService {
         valid: false,
         code: "DISABLED",
         permissions: data.permissions,
+        roles: data.roles,
         message: "the key is disabled",
       });
     }
@@ -446,6 +449,7 @@ export class KeyService {
         valid: false,
         code: "FORBIDDEN",
         permissions: data.permissions,
+        roles: data.roles,
         message: `the key does not belong to ${req.apiId}`,
       });
     }
@@ -465,6 +469,7 @@ export class KeyService {
           api: data.api,
           identity: data.identity,
           permissions: data.permissions,
+          roles: data.roles,
           message: `the key has expired on ${new Date(expires).toISOString()}`,
         });
       }
@@ -481,6 +486,7 @@ export class KeyService {
           valid: false,
           code: "FORBIDDEN",
           permissions: data.permissions,
+          roles: data.roles,
         });
       }
 
@@ -493,6 +499,7 @@ export class KeyService {
           valid: false,
           code: "FORBIDDEN",
           permissions: data.permissions,
+          roles: data.roles,
         });
       }
     }
@@ -535,6 +542,7 @@ export class KeyService {
           valid: false,
           code: "INSUFFICIENT_PERMISSIONS",
           permissions: data.permissions,
+          roles: data.roles,
           message: rbacResp.val.message,
         });
       }
@@ -602,6 +610,7 @@ export class KeyService {
         code: "RATE_LIMITED",
         ratelimit,
         permissions: data.permissions,
+        roles: data.roles,
       });
     }
 
@@ -628,6 +637,7 @@ export class KeyService {
           isRootKey: !!data.key.forWorkspaceId,
           authorizedWorkspaceId: data.key.forWorkspaceId ?? data.key.workspaceId,
           permissions: data.permissions,
+          roles: data.roles,
         });
       }
     }
@@ -646,6 +656,7 @@ export class KeyService {
       isRootKey: !!data.key.forWorkspaceId,
       authorizedWorkspaceId: data.key.forWorkspaceId ?? data.key.workspaceId,
       permissions: data.permissions,
+      roles: data.roles,
     });
   }
 

--- a/apps/api/src/routes/v1_keys_verifyKey.test.ts
+++ b/apps/api/src/routes/v1_keys_verifyKey.test.ts
@@ -176,6 +176,18 @@ describe("with temporary key", () => {
         workspaceId: h.resources.userWorkspace.id,
       });
 
+      const role = {
+        id: newId("test"),
+        workspaceId: h.resources.userWorkspace.id,
+        name: "role",
+      };
+      await h.db.primary.insert(schema.roles).values(role);
+      await h.db.primary.insert(schema.keysRoles).values({
+        keyId: key.id,
+        roleId: role.id,
+        workspaceId: h.resources.userWorkspace.id,
+      });
+
       await new Promise((resolve) => setTimeout(resolve, 2500));
       const res = await h.post<V1KeysVerifyKeyRequest, V1KeysVerifyKeyResponse>({
         url: "/v1/keys.verifyKey",
@@ -196,6 +208,7 @@ describe("with temporary key", () => {
       expect(res.body.name).toBe(key.name);
       expect(res.body.ownerId).toBe(key.ownerId);
       expect(res.body.permissions).toMatchObject([permission.name]);
+      expect(res.body.roles).toMatchObject([role.name]);
     },
     { timeout: 20000 },
   );

--- a/apps/api/src/routes/v1_keys_verifyKey.ts
+++ b/apps/api/src/routes/v1_keys_verifyKey.ts
@@ -281,6 +281,13 @@ These are validation codes, the HTTP status will be 200.
                   description: "A list of all the permissions this key is connected to.",
                   example: ["dns.record.update", "dns.record.delete"],
                 }),
+              roles: z
+                .array(z.string())
+                .optional()
+                .openapi({
+                  description: "A list of all the roles this key is connected to.",
+                  example: ["admin"],
+                }),
               environment: z.string().optional().openapi({
                 description:
                   "The environment of the key, this is what what you set when you crated the key",
@@ -373,6 +380,7 @@ export const registerV1KeysVerifyKey = (app: App) =>
       ratelimit: val.ratelimit ?? undefined,
       enabled: val.key?.enabled,
       permissions: val.permissions,
+      roles: val.roles,
       environment: val.key?.environment ?? undefined,
       code: val.valid ? ("VALID" as const) : val.code,
       identity: val.identity


### PR DESCRIPTION
- **feat: return roles as part of verifications**
- **chore: changeset**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Verification responses now include a list of roles associated with each key, in addition to permissions.
- **Bug Fixes**
  - Improved test coverage to ensure roles are correctly returned by the key verification endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->