### PR TITLE
chore: Workflows run when they should

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -26,13 +26,20 @@ jobs:
       FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
       AXIOM_TOKEN: ${{ secrets.AXIOM_TOKEN }}
 
+  changes:
+    uses: ./.github/workflows/job_changes.yaml
+
   api_local_test:
     name: Test API
+    needs: [changes]
+    if: needs.changes.outputs.api == 'true'
     uses: ./.github/workflows/job_test_api_local.yaml
 
   api_preview_deployment:
     needs:
+      - changes
       - api_local_test
+    if: always() && (needs.changes.outputs.api != 'true' || needs.api_local_test.result == 'success')
     uses: ./.github/workflows/job_deploy_api_staging.yaml
     secrets:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -61,8 +68,10 @@ jobs:
 
   api_canary_deployment:
     needs:
+      - changes
       - api_local_test
       - api_preview_test
+    if: always() && (needs.changes.outputs.api != 'true' || needs.api_local_test.result == 'success')
     uses: ./.github/workflows/job_deploy_api_canary.yaml
     secrets:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -161,7 +170,9 @@ jobs:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
   workflows_deployment:
     needs:
+      - changes
       - api_local_test
+    if: always() && (needs.changes.outputs.api != 'true' || needs.api_local_test.result == 'success')
     uses: ./.github/workflows/job_deploy_workflows.yaml
     secrets:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -175,12 +186,9 @@ jobs:
     secrets:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 
-  changes:
-    uses: ./.github/workflows/job_changes.yaml
-
 
   clickhouse_migration_preview:
-    if: needs.changes.outputs.clickhouse == 'true'
+    if: needs.changes.outputs.clickhouse == 'true' && (needs.changes.outputs.api != 'true' || needs.api_local_test.result == 'success')
     needs:
       - changes
       - api_local_test

--- a/.github/workflows/job_changes.yaml
+++ b/.github/workflows/job_changes.yaml
@@ -1,14 +1,21 @@
 name: Changes
 on:
   workflow_call:
-
-
-
+    outputs:
+      clickhouse:
+        description: "Whether ClickHouse schema has changed"
+        value: ${{ jobs.build.outputs.clickhouse }}
+      api:
+        description: "Whether API code has changed"
+        value: ${{ jobs.build.outputs.api }}
 
 jobs:
   build:
     name: Build Agent
     runs-on: ubuntu-latest
+    outputs:
+      clickhouse: ${{ steps.changes.outputs.clickhouse }}
+      api: ${{ steps.changes.outputs.api }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -17,3 +24,5 @@ jobs:
           filters: |
             clickhouse:
               - 'internal/clickhouse/schema/**'
+            api:
+              - 'apps/api/**'


### PR DESCRIPTION
## What does this PR do?

Makes API testing run when we make changes to the API versus all the time. 

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

Workflows run automatically so we can test it via GH actions.

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [X] Filled out the "How to test" section in this PR
- [X] Read [Contributing Guide](./CONTRIBUTING.md)
- [X] Self-reviewed my own code
- [X] Commented on my code in hard-to-understand areas
- [X] Ran `pnpm build`
- [X] Ran `pnpm fmt`
- [X] Checked for warnings, there are none
- [X] Removed all `console.logs`
- [X] Merged the latest changes from main onto my branch with `git pull origin main`
- [X] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary
