### PR TITLE
fix: charts and logs data count

### DIFF
--- a/apps/dashboard/app/(app)/apis/[apiId]/_overview/components/charts/bar-chart/hooks/use-fetch-timeseries.ts
+++ b/apps/dashboard/app/(app)/apis/[apiId]/_overview/components/charts/bar-chart/hooks/use-fetch-timeseries.ts
@@ -1,5 +1,5 @@
 import { formatTimestampForChart } from "@/components/logs/chart/utils/format-timestamp";
-import { TIMESERIES_DATA_WINDOW } from "@/components/logs/constants";
+import { HISTORICAL_DATA_WINDOW } from "@/components/logs/constants";
 import { trpc } from "@/lib/trpc/client";
 import { KEY_VERIFICATION_OUTCOMES } from "@unkey/clickhouse/src/keys/keys";
 import { useMemo } from "react";
@@ -13,7 +13,7 @@ export const useFetchVerificationTimeseries = (apiId: string | null) => {
 
   const queryParams = useMemo(() => {
     const params: KeysOverviewQueryTimeseriesPayload = {
-      startTime: dateNow - TIMESERIES_DATA_WINDOW * 24,
+      startTime: dateNow - HISTORICAL_DATA_WINDOW,
       endTime: dateNow,
       keyIds: { filters: [] },
       outcomes: { filters: [] },

--- a/apps/dashboard/app/(app)/apis/[apiId]/_overview/components/charts/line-chart/hooks/use-fetch-timeseries.ts
+++ b/apps/dashboard/app/(app)/apis/[apiId]/_overview/components/charts/line-chart/hooks/use-fetch-timeseries.ts
@@ -1,5 +1,5 @@
 import { formatTimestampForChart } from "@/components/logs/chart/utils/format-timestamp";
-import { TIMESERIES_DATA_WINDOW } from "@/components/logs/constants";
+import { HISTORICAL_DATA_WINDOW } from "@/components/logs/constants";
 import { trpc } from "@/lib/trpc/client";
 import { KEY_VERIFICATION_OUTCOMES } from "@unkey/clickhouse/src/keys/keys";
 import { useMemo } from "react";
@@ -13,7 +13,7 @@ export const useFetchActiveKeysTimeseries = (apiId: string | null) => {
 
   const queryParams = useMemo(() => {
     const params: KeysOverviewQueryTimeseriesPayload = {
-      startTime: dateNow - TIMESERIES_DATA_WINDOW * 24,
+      startTime: dateNow - HISTORICAL_DATA_WINDOW,
       endTime: dateNow,
       keyIds: { filters: [] },
       outcomes: { filters: [] },

--- a/apps/dashboard/app/(app)/logs/components/charts/hooks/use-fetch-timeseries.ts
+++ b/apps/dashboard/app/(app)/logs/components/charts/hooks/use-fetch-timeseries.ts
@@ -1,5 +1,5 @@
 import { formatTimestampForChart } from "@/components/logs/chart/utils/format-timestamp";
-import { TIMESERIES_DATA_WINDOW } from "@/components/logs/constants";
+import { HISTORICAL_DATA_WINDOW } from "@/components/logs/constants";
 import { trpc } from "@/lib/trpc/client";
 import { useMemo } from "react";
 import type { z } from "zod";
@@ -12,7 +12,7 @@ export const useFetchTimeseries = () => {
   const dateNow = useMemo(() => Date.now(), []);
   const queryParams = useMemo(() => {
     const params: z.infer<typeof queryTimeseriesPayload> = {
-      startTime: dateNow - TIMESERIES_DATA_WINDOW,
+      startTime: dateNow - HISTORICAL_DATA_WINDOW,
       endTime: dateNow,
       host: { filters: [] },
       method: { filters: [] },

--- a/apps/dashboard/app/(app)/ratelimits/[namespaceId]/_overview/components/charts/bar-chart/hooks/use-fetch-timeseries.ts
+++ b/apps/dashboard/app/(app)/ratelimits/[namespaceId]/_overview/components/charts/bar-chart/hooks/use-fetch-timeseries.ts
@@ -1,5 +1,5 @@
 import { formatTimestampForChart } from "@/components/logs/chart/utils/format-timestamp";
-import { TIMESERIES_DATA_WINDOW } from "@/components/logs/constants";
+import { HISTORICAL_DATA_WINDOW } from "@/components/logs/constants";
 import { trpc } from "@/lib/trpc/client";
 import { useQueryTime } from "@/providers/query-time-provider";
 import { useMemo } from "react";
@@ -13,7 +13,7 @@ export const useFetchRatelimitOverviewTimeseries = (namespaceId: string) => {
   const queryParams = useMemo(() => {
     const params: RatelimitOverviewQueryTimeseriesPayload = {
       namespaceId,
-      startTime: timestamp - TIMESERIES_DATA_WINDOW,
+      startTime: timestamp - HISTORICAL_DATA_WINDOW,
       endTime: timestamp,
       identifiers: { filters: [] },
       since: "",

--- a/apps/dashboard/app/(app)/ratelimits/[namespaceId]/logs/components/charts/hooks/use-fetch-timeseries.ts
+++ b/apps/dashboard/app/(app)/ratelimits/[namespaceId]/logs/components/charts/hooks/use-fetch-timeseries.ts
@@ -1,5 +1,5 @@
 import { formatTimestampForChart } from "@/components/logs/chart/utils/format-timestamp";
-import { TIMESERIES_DATA_WINDOW } from "@/components/logs/constants";
+import { HISTORICAL_DATA_WINDOW } from "@/components/logs/constants";
 import { trpc } from "@/lib/trpc/client";
 import { useQueryTime } from "@/providers/query-time-provider";
 import { useMemo } from "react";
@@ -13,7 +13,7 @@ export const useFetchRatelimitTimeseries = (namespaceId: string) => {
   const queryParams = useMemo(() => {
     const params: RatelimitQueryTimeseriesPayload = {
       namespaceId,
-      startTime: timestamp - TIMESERIES_DATA_WINDOW,
+      startTime: timestamp - HISTORICAL_DATA_WINDOW,
       endTime: timestamp,
       identifiers: { filters: [] },
       since: "",


### PR DESCRIPTION

## What does this PR do?

This will prevent charts and logs showing the different data. Previously, logs and charts were using different intervals for the default fetch. Reason was to show more data on the chart, but that gives the wrong impression to users.

Fixes # (issue)

Chart and log counts will add up.
<!-- If there isn't an issue for this PR, please re-review our Contributing Guide and create an issue -->

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Use your seed to generate 1000 data for the metric you wanna check(ratelimits, apis, logs) and check default chart and log count if they add up. It's working.

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary

### BEFORE
![image](https://github.com/user-attachments/assets/024ed4b5-d79a-4677-90f0-445f8f06625b)

### AFTER
<img width="1217" alt="image" src="https://github.com/user-attachments/assets/0b3b94c8-8f91-4445-bbd4-78667f108f5f" />

Active keys counts are already showing min-max for selected interval. It shouldn't be `0-5`.
