### PR TITLE
fix: skip test_ apis when calculating key counts

### DIFF
--- a/apps/workflows/src/workflows/count_keys_per_keyspace.ts
+++ b/apps/workflows/src/workflows/count_keys_per_keyspace.ts
@@ -24,10 +24,11 @@ export class CountKeys extends WorkflowEntrypoint<Env, Params> {
 
     const keySpaces = await step.do("fetch outdated keyspaces", async () =>
       db.query.keyAuth.findMany({
-        where: (table, { or, and, isNull, lt }) =>
+        where: (table, { or, and, isNull, lt, not, like }) =>
           and(
             isNull(table.deletedAtM),
             or(isNull(table.sizeLastUpdatedAt), lt(table.sizeLastUpdatedAt, now - 600_000)),
+            not(like(table.id, "test_%")),
           ),
         orderBy: (table, { asc }) => asc(table.sizeLastUpdatedAt),
         limit: 200,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Keyspaces with IDs starting with "test_" are now excluded from the outdated keyspaces results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->