### PR TITLE
fix: low credits flag

### DIFF
--- a/apps/dashboard/app/(app)/apis/[apiId]/keys/[keyAuthId]/_components/components/table/components/status-cell/use-key-status.ts
+++ b/apps/dashboard/app/(app)/apis/[apiId]/keys/[keyAuthId]/_components/components/table/components/status-cell/use-key-status.ts
@@ -8,7 +8,7 @@ import { STATUS_DEFINITIONS, type StatusInfo } from "./constants";
 
 const RATE_LIMIT_THRESHOLD_PERCENT = 0.1; // 10%
 const VALIDATION_ISSUE_THRESHOLD_PERCENT = 0.1; // 10%
-const LOW_CREDITS_THRESHOLD_ABSOLUTE = 100;
+const LOW_CREDITS_THRESHOLD_ABSOLUTE = 0;
 const LOW_CREDITS_THRESHOLD_REFILL_PERCENT = 0.1; // 10%
 const EXPIRY_THRESHOLD_HOURS = 24;
 
@@ -118,7 +118,7 @@ export const useKeyStatus = (keyAuthId: string, keyData: KeyDetails): UseKeyStat
     const remaining = keyData.key.credits.remaining;
     const refillAmount = keyData.key.credits.refillAmount;
     const isLowOnCredits =
-      (remaining != null && remaining < LOW_CREDITS_THRESHOLD_ABSOLUTE) ||
+      (remaining != null && remaining === LOW_CREDITS_THRESHOLD_ABSOLUTE) ||
       (refillAmount &&
         remaining != null &&
         refillAmount > 0 &&


### PR DESCRIPTION
## What does this PR do?

Low credits flag will now only be displayed in two specific scenarios: 
1) when credits reach exactly zero for keys without refills, or when credits fall below 10% of the refill amount for keys with refills.


## Type of change

<!-- Please mark the relevant points by using [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Test A
- Test B

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the criteria for flagging keys as low on credits. Keys are now only flagged when credits are completely depleted, instead of when they fall below a fixed threshold.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->