### PR TITLE
fix: spacing issues caused by warning icon

### DIFF
--- a/apps/dashboard/app/(app)/apis/[apiId]/_overview/components/table/components/override-indicator.tsx
+++ b/apps/dashboard/app/(app)/apis/[apiId]/_overview/components/table/components/override-indicator.tsx
@@ -18,13 +18,13 @@ type KeyIdentifierColumnProps = {
 const getWarningIcon = (severity: string) => {
   switch (severity) {
     case "high":
-      return <TriangleWarning2 className="text-error-11" />;
+      return <TriangleWarning2 className="text-error-11" size="md-regular" />;
     case "moderate":
-      return <TriangleWarning2 className="text-orange-11" />;
+      return <TriangleWarning2 className="text-orange-11" size="md-regular" />;
     case "low":
-      return <TriangleWarning2 className="text-warning-11" />;
+      return <TriangleWarning2 className="text-warning-11" size="md-regular" />;
     default:
-      return <TriangleWarning2 className="invisible" />;
+      return <TriangleWarning2 className="invisible" size="md-regular" />;
   }
 };
 

--- a/apps/dashboard/app/(app)/apis/[apiId]/_overview/components/table/logs-table.tsx
+++ b/apps/dashboard/app/(app)/apis/[apiId]/_overview/components/table/logs-table.tsx
@@ -34,7 +34,7 @@ export const KeysOverviewLogsTable = ({ apiId, setSelectedLog, log: selectedLog 
         key: "key_id",
         header: "ID",
         width: "15%",
-        headerClassName: "pl-11",
+        headerClassName: "pl-12",
         render: (log) => (
           <KeyIdentifierColumn log={log} apiId={apiId} onNavigate={() => setSelectedLog(null)} />
         ),

--- a/apps/dashboard/app/(app)/logs/components/table/logs-table.tsx
+++ b/apps/dashboard/app/(app)/logs/components/table/logs-table.tsx
@@ -82,6 +82,7 @@ const getSelectedClassName = (log: Log, isSelected: boolean) => {
 
 const WarningIcon = ({ status }: { status: number }) => (
   <TriangleWarning2
+    size="md-regular"
     className={cn(
       WARNING_ICON_STYLES.base,
       status < 300 && "invisible",

--- a/apps/dashboard/app/(app)/ratelimits/[namespaceId]/_overview/components/table/components/override-indicator.tsx
+++ b/apps/dashboard/app/(app)/ratelimits/[namespaceId]/_overview/components/table/components/override-indicator.tsx
@@ -40,8 +40,8 @@ export const IdentifierColumn = ({ log }: IdentifierColumnProps) => {
           </div>
         }
       >
-        <div className={cn(hasMoreBlocked ? "block" : "invisible")}>
-          <TriangleWarning2 />
+        <div className={cn(hasMoreBlocked ? "flex items-center flex-shrink-0" : "invisible")}>
+          <TriangleWarning2 size="md-regular" />
         </div>
       </InfoTooltip>
       <div className="flex gap-3 items-center">

--- a/apps/dashboard/app/(app)/ratelimits/[namespaceId]/_overview/components/table/logs-table.tsx
+++ b/apps/dashboard/app/(app)/ratelimits/[namespaceId]/_overview/components/table/logs-table.tsx
@@ -35,8 +35,8 @@ export const RatelimitOverviewLogsTable = ({
       {
         key: "identifier",
         header: "Identifier",
-        width: "7.5%",
-        headerClassName: "pl-11",
+        width: "20%",
+        headerClassName: "pl-12",
         render: (log) => {
           return (
             <div className="flex gap-3 items-center group/identifier">
@@ -52,7 +52,7 @@ export const RatelimitOverviewLogsTable = ({
       {
         key: "passed",
         header: "Passed",
-        width: "7.5%",
+        width: "20%",
         sort: {
           direction: getSortDirection("passed"),
           sortable: true,
@@ -85,7 +85,7 @@ export const RatelimitOverviewLogsTable = ({
       {
         key: "blocked",
         header: "Blocked",
-        width: "7.5%",
+        width: "20%",
         sort: {
           direction: getSortDirection("blocked"),
           sortable: true,
@@ -168,7 +168,7 @@ export const RatelimitOverviewLogsTable = ({
       {
         key: "lastRequest",
         header: "Last Request",
-        width: "7.5%",
+        width: "20%",
         sort: {
           direction: getSortDirection("time"),
           sortable: true,
@@ -189,15 +189,13 @@ export const RatelimitOverviewLogsTable = ({
       {
         key: "actions",
         header: "",
-        width: "7.5%",
+        width: "auto",
         render: (log) => (
-          <div className="text-end">
-            <LogsTableAction
-              overrideDetails={log.override}
-              identifier={log.identifier}
-              namespaceId={namespaceId}
-            />
-          </div>
+          <LogsTableAction
+            overrideDetails={log.override}
+            identifier={log.identifier}
+            namespaceId={namespaceId}
+          />
         ),
       },
     ];


### PR DESCRIPTION
## What does this PR do?

This PR fixes spacing issues caused by `<TriangleWarning2 />` icon. We recently fixed definition of this icon and that caused some visual regressions in our UIs. This PR fixes all these issues.

Fixes # (issue)

*If there is not an issue for this, please create one first. This is used to tracking purposes and also helps use understand why this PR exists*

<!-- If there isn't an issue for this PR, please re-review our Contributing Guide and create an issue -->

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Test A
- Test B

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR
- [x] Updated the Unkey Docs if changes were necessary

## PROD:
<img width="492" alt="image" src="https://github.com/user-attachments/assets/32efb0ff-0a78-464a-a70d-0b3467fb8e3b" />

## PREVIEW:
<img width="470" alt="image" src="https://github.com/user-attachments/assets/e517cc90-c1ca-4241-8cfe-3edd5c737f7a" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Standardized the size of warning icons across multiple tables for a consistent appearance.
  - Improved alignment and layout of warning icons in rate limit overview tables.
  - Adjusted column widths and padding in logs and rate limit tables for better readability and spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->