### PR TITLE
fix: make GH actons run on non draft only

### DIFF
--- a/.github/workflows/apply-issue-labels-to-pr.yml
+++ b/.github/workflows/apply-issue-labels-to-pr.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   label_on_pr:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/autofix.ci.yaml
+++ b/.github/workflows/autofix.ci.yaml
@@ -8,6 +8,7 @@ permissions:
 
 jobs:
   autofix:
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -26,6 +27,7 @@ jobs:
       - uses: autofix-ci/action@ff86a557419858bb967097bfc916833f5647fa8c
   lint_docs:
     name: Docs
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -13,27 +13,29 @@ permissions:
   contents: read
 jobs:
   detect_changes:
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     uses: ./.github/workflows/job_detect_changes.yaml
 
   test_packages:
     name: Test Packages
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     uses: ./.github/workflows/job_test_unit.yaml
 
   build:
     name: Build
-    if: needs.detect_changes.outputs.api == 'true'
+    if: (github.event.pull_request.draft == false || github.event_name != 'pull_request') && needs.detect_changes.outputs.api == 'true'
     needs: [detect_changes]
     uses: ./.github/workflows/build.yaml
 
   test_api:
     name: Test API
-    if: needs.detect_changes.outputs.api == 'true'
+    if: (github.event.pull_request.draft == false || github.event_name != 'pull_request') && needs.detect_changes.outputs.api == 'true'
     needs: [detect_changes]
     uses: ./.github/workflows/job_test_api_local.yaml
 
   test_agent_local:
     name: Test Agent Local
-    if: needs.detect_changes.outputs.agent == 'true'
+    if: (github.event.pull_request.draft == false || github.event_name != 'pull_request') && needs.detect_changes.outputs.agent == 'true'
     needs: [detect_changes]
     uses: ./.github/workflows/job_test_agent_local.yaml
   # test_agent_integration:
@@ -60,6 +62,6 @@ jobs:
 
   test_go_api_local:
     name: Test Go API Local
-    if: needs.detect_changes.outputs.api == 'true'
+    if: (github.event.pull_request.draft == false || github.event_name != 'pull_request') && needs.detect_changes.outputs.api == 'true'
     needs: [detect_changes]
     uses: ./.github/workflows/job_test_go_api_local.yaml

--- a/.github/workflows/semantic-pull-requests.yaml
+++ b/.github/workflows/semantic-pull-requests.yaml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   validate-pr:
     name: PR title
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v5


### PR DESCRIPTION
**What does this PR do?**

Fixes # (issue)

_If there is not an issue for this, please create one first. This is used to tracking purposes and also helps use understand why this PR exists_

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How should this be tested?**

- Test A
- Test B

**Checklist**

**Required**

- [ ] Filled out the "How to test" section in this PR
- [ ] Read Contributing Guide
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

**Appreciated**

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary

**Summary by CodeRabbit**

- **Chores**- Updated GitHub Actions workflows to prevent certain jobs from running on draft pull requests, improving workflow efficiency and reducing unnecessary checks during early PR stages.