### PR TITLE
chore: comment out key creation vault encr

### DIFF
--- a/apps/dashboard/lib/trpc/routers/key/create.ts
+++ b/apps/dashboard/lib/trpc/routers/key/create.ts
@@ -1,17 +1,15 @@
 import { createKeyInputSchema } from "@/app/(app)/apis/[apiId]/_components/create-key/create-key.schema";
 import { insertAuditLogs } from "@/lib/audit";
 import { db, schema } from "@/lib/db";
-import { env } from "@/lib/env";
-import { Vault } from "@/lib/vault";
 import { TRPCError } from "@trpc/server";
 import { newId } from "@unkey/id";
 import { newKey } from "@unkey/keys";
 import { requireUser, requireWorkspace, t } from "../../trpc";
 
-const vault = new Vault({
-  baseUrl: env().AGENT_URL,
-  token: env().AGENT_TOKEN,
-});
+// const vault = new Vault({
+//   baseUrl: env().AGENT_URL,
+//   token: env().AGENT_TOKEN,
+// });
 
 export const createKey = t.procedure
   .use(requireUser)
@@ -70,21 +68,22 @@ export const createKey = t.procedure
           environment: input.environment,
         });
 
-        if (keyAuth.storeEncryptedKeys) {
-          const { encrypted, keyId: encryptionKeyId } = await vault.encrypt({
-            keyring: ctx.workspace.id,
-            data: key,
-          });
-
-          await tx.insert(schema.encryptedKeys).values({
-            encrypted,
-            encryptionKeyId,
-            keyId,
-            workspaceId: ctx.workspace.id,
-            createdAt: Date.now(),
-            updatedAt: null,
-          });
-        }
+        //FIXME: We'll add this back once we figure out the aws Vault timeout
+        // if (keyAuth.storeEncryptedKeys) {
+        //   const { encrypted, keyId: encryptionKeyId } = await vault.encrypt({
+        //     keyring: ctx.workspace.id,
+        //     data: key,
+        //   });
+        //
+        //   await tx.insert(schema.encryptedKeys).values({
+        //     encrypted,
+        //     encryptionKeyId,
+        //     keyId,
+        //     workspaceId: ctx.workspace.id,
+        //     createdAt: Date.now(),
+        //     updatedAt: null,
+        //   });
+        // }
 
         if (input.ratelimit?.length) {
           await tx.insert(schema.ratelimits).values(


### PR DESCRIPTION
## What does this PR do?

This PR disables key creation encryption due to AWS Vault timeout. We'll re-enable it back once we figure it out.

Fixes # (issue)

*If there is not an issue for this, please create one first. This is used to tracking purposes and also helps use understand why this PR exists*

<!-- If there isn't an issue for this PR, please re-review our Contributing Guide and create an issue -->

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Nothing to test

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Disabled Vault-based encryption and storage for keys due to an ongoing AWS Vault timeout issue. Key creation and storage continue without encryption for now.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->