### PR TITLE
feat: add slug to v1/listPermissions and v1/getPermission

### DIFF
--- a/apps/api/src/routes/v1_permissions_getPermission.happy.test.ts
+++ b/apps/api/src/routes/v1_permissions_getPermission.happy.test.ts
@@ -29,5 +29,6 @@ test("return the role", async (t) => {
   expect(res.status, `expected 200, received: ${JSON.stringify(res, null, 2)}`).toBe(200);
   expect(res.body.id).toEqual(permission.id);
   expect(res.body.name).toEqual(permission.name);
+  expect(res.body.slug).toEqual(permission.slug);
   expect(res.body.description).toBeUndefined();
 });

--- a/apps/api/src/routes/v1_permissions_getPermission.ts
+++ b/apps/api/src/routes/v1_permissions_getPermission.ts
@@ -35,9 +35,9 @@ const route = createRoute({
               example: "domain.record.manager",
             }),
             slug: z.string().openapi({
-                description: "The slug of the permission",
-                example: "domain-record-manager",
-              }),
+              description: "The slug of the permission",
+              example: "domain-record-manager",
+            }),
             description: z.string().optional().openapi({
               description:
                 "The description of what this permission does. This is just for your team, your users will not see this.",

--- a/apps/api/src/routes/v1_permissions_getPermission.ts
+++ b/apps/api/src/routes/v1_permissions_getPermission.ts
@@ -34,6 +34,10 @@ const route = createRoute({
               description: "The name of the permission.",
               example: "domain.record.manager",
             }),
+            slug: z.string().openapi({
+                description: "The slug of the permission",
+                example: "domain-record-manager",
+              }),
             description: z.string().optional().openapi({
               description:
                 "The description of what this permission does. This is just for your team, your users will not see this.",
@@ -75,6 +79,7 @@ export const registerV1PermissionsGetPermission = (app: App) =>
     return c.json({
       id: permission.id,
       name: permission.name,
+      slug: permission.slug,
       description: permission.description ?? undefined,
     });
   });

--- a/apps/api/src/routes/v1_permissions_listPermissions.happy.test.ts
+++ b/apps/api/src/routes/v1_permissions_listPermissions.happy.test.ts
@@ -30,5 +30,6 @@ test("return all permissions", async (t) => {
   expect(res.body.length).toBe(1);
   expect(res.body[0].id).toEqual(permission.id);
   expect(res.body[0].name).toEqual(permission.name);
+  expect(res.body[0].slug).toEqual(permission.slug);
   expect(res.body[0].description).toBeUndefined();
 });

--- a/apps/api/src/routes/v1_permissions_listPermissions.ts
+++ b/apps/api/src/routes/v1_permissions_listPermissions.ts
@@ -27,6 +27,10 @@ const route = createRoute({
                 description: "The name of the permission.",
                 example: "domain.record.manager",
               }),
+              slug: z.string().openapi({
+                description: "The slug of the permission",
+                example: "domain-record-manager",
+              }),
               description: z.string().optional().openapi({
                 description:
                   "The description of what this permission does. This is just for your team, your users will not see this.",
@@ -62,6 +66,7 @@ export const registerV1PermissionsListPermissions = (app: App) =>
       permissions.map((p) => ({
         id: p.id,
         name: p.name,
+        slug: p.slug,
         description: p.description ?? undefined,
       })),
     );


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3452 

<!-- If there isn't an issue for this PR, please re-review our Contributing Guide and create an issue -->

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Automated tests included

Test 1
1. Get / v1 / permissions.listPermissions
2. Slug value for each permission is returned.

Test 2
1. Get / v1 / permissions.getPermissions
2. Slug value for specific permission is returned.

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new field, `slug`, to the API responses for permission details and permission lists. This field is now visible in the returned data and documented in the API schema.

* **Tests**
  * Updated tests to verify the presence and correctness of the new `slug` field in API responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->