### PR TITLE
feat: return permission slugs

### DIFF
--- a/.changeset/dull-wombats-sip.md
+++ b/.changeset/dull-wombats-sip.md
@@ -1,0 +1,5 @@
+---
+"@unkey/api": minor
+---
+
+feat: return permission slugs

--- a/packages/api/src/openapi.d.ts
+++ b/packages/api/src/openapi.d.ts
@@ -3839,6 +3839,11 @@ export interface operations {
              */
             name: string;
             /**
+             * @description The slug of the permission
+             * @example domain-record-manager
+             */
+            slug: string;
+            /**
              * @description The description of what this permission does. This is just for your team, your users will not see this.
              * @example Can manage dns records
              */
@@ -3912,6 +3917,11 @@ export interface operations {
              * @example domain.record.manager
              */
             name: string;
+            /**
+             * @description The slug of the permission
+             * @example domain-record-manager
+             */
+            slug: string;
             /**
              * @description The description of what this permission does. This is just for your team, your users will not see this.
              * @example Can manage dns records


### PR DESCRIPTION
## What does this PR do?

This PR adds a new `slug` field to the permission objects in the OpenAPI specification. The slug is a hyphenated version of the permission name, for example, `domain.record.manager` becomes `domain-record-manager`. This change is marked as a minor version update for the `@unkey/api` package.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Verify that permission objects in API responses now include the `slug` field
- Check that the slug is correctly formatted as a hyphenated version of the permission name

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [x] Updated the Unkey Docs if changes were necessary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Permission details now include a "slug" field when viewing or listing permissions via the API. This provides an additional identifier for each permission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->