### PR TITLE
ci: run all go tests in one action to reduce installs due to ratelimits

### DIFF
--- a/.github/workflows/job_test_go_api_local.yaml
+++ b/.github/workflows/job_test_go_api_local.yaml
@@ -7,10 +7,6 @@ jobs:
     name: Test (Shard ${{ matrix.shard }})
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    strategy:
-      matrix:
-        shard: ["1/8", "2/8", "3/8", "4/8", "5/8", "6/8", "7/8", "8/8"]
-      fail-fast: true
     steps:
       - uses: actions/checkout@v4
 
@@ -24,7 +20,7 @@ jobs:
         run: make up
         working-directory: go
       - name: Test
-        run: go test -shuffle=on -timeout=60m $(go run ./scripts/shard-test ${{ matrix.shard }})
+        run: make test-full
         working-directory: go
         env:
           INTEGRATION_TEST: true


### PR DESCRIPTION
## What does this PR do?

Simplifies the Go API testing workflow by removing the test sharding strategy and replacing the test command with `make test-full`. This change eliminates the matrix configuration that previously split tests into 8 shards, streamlining the CI process.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Run the GitHub workflow to ensure tests execute properly with the new configuration
- Verify that `make test-full` runs all tests correctly in the Go directory

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary