### PR TITLE
fix: use less expensive prometheus labels

### DIFF
--- a/go/internal/services/keys/verifier.go
+++ b/go/internal/services/keys/verifier.go
@@ -2,7 +2,6 @@ package keys
 
 import (
 	"context"
-	"strconv"
 	"time"
 
 	"github.com/unkeyed/unkey/go/internal/services/ratelimit"
@@ -116,12 +115,13 @@ func (k *KeyVerifier) Verify(ctx context.Context, opts ...VerifyOption) error {
 		Tags:        config.tags,
 	})
 
+	keyType := "key"
+	if k.isRootKey {
+		keyType = "root_key"
+	}
 	// Emit Prometheus metrics for key verification
 	metrics.KeyVerificationsTotal.WithLabelValues(
-		k.AuthorizedWorkspaceID, // workspaceId
-		k.Key.ApiID,             // apiId
-		k.Key.ID,                // keyId
-		strconv.FormatBool(k.Status == StatusValid), // valid
+		keyType,
 		string(k.Status), // code
 	).Inc()
 

--- a/go/pkg/prometheus/metrics/keys.go
+++ b/go/pkg/prometheus/metrics/keys.go
@@ -11,11 +11,12 @@ import (
 )
 
 var (
-	// KeyVerificationsTotal tracks the number of key verifications handled, labeled by some data.
+	// KeyVerificationsTotal tracks the number of key verifications handled, labeled by type and outcome.
+	// The type should be either "root_key" or "key"
 	// Use this counter to monitor API traffic patterns and error rates.
 	//
 	// Example usage:
-	//   metrics.KeyVerificationsTotal.WithLabelValues("ws_1234", "api_5678", "key_abcd", "true", "VALID").Inc()
+	//   metrics.KeyVerificationsTotal.WithLabelValues("root_key", "VALID").Inc()
 	KeyVerificationsTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Subsystem:   "key",
@@ -23,7 +24,7 @@ var (
 			Help:        "Total number of Key verifications processed.",
 			ConstLabels: constLabels,
 		},
-		[]string{"workspaceId", "apiId", "keyId", "valid", "code"},
+		[]string{"type", "code"},
 	)
 
 	// KeyCreditsSpentTotal tracks the total credits spent by keys, labeled by workspace ID, key ID, and identity ID.


### PR DESCRIPTION
This replaces the high-cardinality labels with just a key_type and outcome

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified Prometheus metrics for key verifications by reducing the number of labels and updating label names and documentation. The metrics now use only "type" and "code" as labels, making monitoring and analysis more straightforward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->