### PR TITLE
Potential fix for code scanning alert no. 115: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/job_test_go_api_local.yaml
+++ b/.github/workflows/job_test_go_api_local.yaml
@@ -1,6 +1,8 @@
 name: Test Go API Local
 on:
   workflow_call:
+permissions:
+  contents: read
 
 jobs:
   tests:


### PR DESCRIPTION
Potential fix for [https://github.com/unkeyed/unkey/security/code-scanning/115](https://github.com/unkeyed/unkey/security/code-scanning/115)

To fix the issue, an explicit `permissions` block will be added to the workflow. Since the workflow uses `actions/checkout` and performs installation and testing steps, it likely needs `contents: read` permission to read the repository contents. No write permissions are explicitly required based on the provided code, so the permissions block will restrict access to the minimum necessary.

The `permissions` block will be added at the root workflow level to apply to all jobs, as no job-specific permissions are evident in the current workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
