### PR TITLE
Potential fix for code scanning alert no. 112: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Deploy
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/unkeyed/unkey/security/code-scanning/112](https://github.com/unkeyed/unkey/security/code-scanning/112)

The best way to fix this issue is to add an explicit `permissions` block to the root of the workflow file. This block will apply to all jobs unless overridden in individual jobs. Based on the provided code, most jobs likely only require `contents: read`, while those interacting with pull requests (if any) might need additional permissions. This fix adheres to the principle of least privilege.

Steps for implementation:
1. Add a `permissions` block at the root of the workflow file, specifying `contents: read` for general operations.
2. If specific jobs require additional access (e.g., `pull-requests: write`), override the permissions within those jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
