### PR TITLE
Potential fix for code scanning alert no. 27: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,6 +3,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: deploy
   cancel-in-progress: false


### PR DESCRIPTION
Potential fix for [https://github.com/unkeyed/unkey/security/code-scanning/27](https://github.com/unkeyed/unkey/security/code-scanning/27)

To address the issue, explicit permissions should be added to the workflow. This involves introducing a `permissions` block at the root level of the workflow to apply default permissions to all jobs or adding individual `permissions` blocks to jobs that require specific access. The permissions should be set to the minimal level required, such as `contents: read` for read-only access, and additional write permissions only for specific actions.

For this workflow, the following permissions are recommended:
- `contents: read` for general access to repository contents.
- Write permissions for specific actions such as pull requests or issues, if applicable.

Changes will be made to `.github/workflows/deploy.yaml` to define permissions for the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow configuration to set repository permissions for improved security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->