### PR TITLE
Potential fix for code scanning alert no. 108: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/job_deploy_api_staging.yaml
+++ b/.github/workflows/job_deploy_api_staging.yaml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Deploy API Staging
 on:
   workflow_call:


### PR DESCRIPTION
Potential fix for [https://github.com/unkeyed/unkey/security/code-scanning/108](https://github.com/unkeyed/unkey/security/code-scanning/108)

To fix this issue:
1. Add a `permissions` key at the root of the workflow or within the `deploy` job to explicitly define the least privileges required.
2. The `contents: read` permission is sufficient for checking out the repository. No other permissions are required for this workflow since the token is not used for write operations (e.g., updating pull requests or creating issues).
3. Apply the `permissions` block at the root level so all jobs inherit it, or restrict permissions specifically for the `deploy` job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
