### PR TITLE
ci: Potential fix for code scanning alert no. 78: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ghcr_retention_policy.yaml
+++ b/.github/workflows/ghcr_retention_policy.yaml
@@ -1,5 +1,8 @@
 name: Prune old images
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/unkeyed/unkey/security/code-scanning/78](https://github.com/unkeyed/unkey/security/code-scanning/78)

To address the issue, add a `permissions` key at the root of the workflow or within the specific job (`clean`) to explicitly limit the permissions of the `GITHUB_TOKEN`. Since the workflow appears to involve container management and uses a personal access token, the `contents: read` permission should be sufficient for reading repository contents, while no additional permissions should be granted unless specifically required.

Changes should be made to the `.github/workflows/ghcr_retention_policy.yaml` file:
- Insert a `permissions` block at the root level of the workflow or within the `clean` job to ensure least privilege is adhered to.
- The recommended permissions block for this workflow would be:
  ```yaml
  permissions:
    contents: read
  ```


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
