### PR TITLE
ci: Potential fix for code scanning alert no. 53: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/job_test_agent_local.yaml
+++ b/.github/workflows/job_test_agent_local.yaml
@@ -1,7 +1,8 @@
+permissions:
+  contents: read
 name: Test Agent Local
 on:
   workflow_call:
-
 jobs:
   test_agent_local:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/unkeyed/unkey/security/code-scanning/53](https://github.com/unkeyed/unkey/security/code-scanning/53)

To address the issue, the `permissions` key should be added to the workflow file. The permissions block should assign the least privileges necessary for the workflow's tasks. Since the workflow involves checking out code and possibly interacting with repository contents during the install step, the `contents: read` permission is sufficient. Write permissions are not required based on the provided steps.

The `permissions` block should be added at the top level of the workflow file to apply to all jobs in the workflow. This ensures consistency and avoids the need to define permissions for individual jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
