### PR TITLE
ci: Potential fix for code scanning alert no. 52: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/job_deploy_logdrain_production.yaml
+++ b/.github/workflows/job_deploy_logdrain_production.yaml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   deploy:
+    permissions:
+      contents: read
+      deployments: write
     environment: Production
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/unkeyed/unkey/security/code-scanning/52](https://github.com/unkeyed/unkey/security/code-scanning/52)

The best way to fix this issue is to add a `permissions` key at the job or workflow level to explicitly define the required permissions. Since the workflow involves tasks like checking out code, installing dependencies, building, and deploying, the minimal permissions needed include `contents: read` (to read repository contents) and potentially other specific permissions, such as `deployments: write` if required for deployment. 

The fix involves editing `.github/workflows/job_deploy_logdrain_production.yaml` to include a `permissions` block at the workflow or job level. This block will specify the least privileges required for the deployment process.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
