### PR TITLE
ci: Potential fix for code scanning alert no. 29: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check_quotas.yml
+++ b/.github/workflows/check_quotas.yml
@@ -1,5 +1,8 @@
 name: Quota Check
 
+permissions:
+  contents: read
+
 on:
   schedule:
     - cron: "0 15 * * *"


### PR DESCRIPTION
Potential fix for [https://github.com/unkeyed/unkey/security/code-scanning/29](https://github.com/unkeyed/unkey/security/code-scanning/29)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's operations, the `contents: read` permission is sufficient, as the workflow does not appear to require write access to the repository.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or specifically to the `quota-check` job. In this case, adding it at the root level is more concise and ensures consistency across all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
