### PR TITLE
ci: Potential fix for code scanning alert no. 109: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/job_deploy_workflows.yaml
+++ b/.github/workflows/job_deploy_workflows.yaml
@@ -1,4 +1,6 @@
 name: Deploy Workflows Production
+permissions:
+  contents: read
 on:
   workflow_call:
     secrets:


### PR DESCRIPTION
Potential fix for [https://github.com/unkeyed/unkey/security/code-scanning/109](https://github.com/unkeyed/unkey/security/code-scanning/109)

To fix the issue, we will add a `permissions` block at the root of the workflow. This block will define the minimal permissions required for the workflow to function correctly. Based on the workflow's steps:
- The `contents: read` permission is needed for the `actions/checkout` step to read the repository's contents.
- No other permissions appear to be required for the `GITHUB_TOKEN`.

The `permissions` block will be added after the `name` field (line 1) to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
