### PR TITLE
Potential fix for code scanning alert no. 107: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/job_deploy_api_canary.yaml
+++ b/.github/workflows/job_deploy_api_canary.yaml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Deploy API Canary
 on:
   workflow_call:


### PR DESCRIPTION
Potential fix for [https://github.com/unkeyed/unkey/security/code-scanning/107](https://github.com/unkeyed/unkey/security/code-scanning/107)

To resolve the issue, we must add a `permissions` block to the workflow at the root level or within the `deploy` job. This block will explicitly define the required permissions for the `GITHUB_TOKEN`. Based on the workflow's operations, the `contents: read` permission is sufficient since there are no write operations or repository modifications.

Changes:
- Add a `permissions` key at the root of the workflow to apply permissions globally to all jobs.
- Set `contents: read` in the `permissions` block to limit access to only what is necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
