### PR TITLE
ci: Potential fix for code scanning alert no. 68: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test_agent_local.yaml
+++ b/.github/workflows/test_agent_local.yaml
@@ -2,6 +2,9 @@ name: Test Agent Local
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   test_agent_local:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/unkeyed/unkey/security/code-scanning/68](https://github.com/unkeyed/unkey/security/code-scanning/68)

To resolve the issue, add a `permissions` block at the root level of the workflow or within the `test_agent_local` job. The block should specify the least privileges required for this workflow. Based on the actions and steps in the workflow, `contents: read` is sufficient for tasks like checking out the repository and building/testing the code. No write permissions appear necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
