### PR TITLE
ci: Potential fix for code scanning alert no. 61: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/job_test_unit.yaml
+++ b/.github/workflows/job_test_unit.yaml
@@ -1,6 +1,8 @@
 name: Unit Tests
 on:
   workflow_call:
+permissions:
+  contents: read
 jobs:
   test:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/unkeyed/unkey/security/code-scanning/61](https://github.com/unkeyed/unkey/security/code-scanning/61)

To resolve the issue, we will add a `permissions` block to the workflow. This block will explicitly specify the minimum permissions required for the workflow to function correctly. Based on the workflow's usage of `actions/checkout` and `secrets.GITHUB_TOKEN`, the workflow needs access to the repository contents (`contents: read`). Since there is no evidence of other actions requiring elevated permissions (e.g., write access), the minimal permission `contents: read` will suffice.

The `permissions` block will be added at the workflow level (root level) to apply to all jobs in the workflow. This ensures uniform permission restrictions across all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
