### PR TITLE
Potential fix for code scanning alert no. 60: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/job_test_api_staging.yaml
+++ b/.github/workflows/job_test_api_staging.yaml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: API Test Staging
 on:
   workflow_call:


### PR DESCRIPTION
Potential fix for [https://github.com/unkeyed/unkey/security/code-scanning/60](https://github.com/unkeyed/unkey/security/code-scanning/60)

To address this issue, we need to add an explicit `permissions` block to the workflow or job to restrict the permissions of the `GITHUB_TOKEN`. Since we are performing actions like checking out the code and running tests, we can start with minimal permissions, such as `contents: read`. If additional permissions are required (e.g., for writing pull request comments), they can be added as needed.

The `permissions` block should be added just below the `jobs:` key or at the root of the workflow to apply globally. In this case, since no explicit job-specific permissions are mentioned, adding the permissions globally at the workflow level is recommended.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
