### PR TITLE
ci: Potential fix for code scanning alert no. 59: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/job_test_api_local.yaml
+++ b/.github/workflows/job_test_api_local.yaml
@@ -1,6 +1,8 @@
 name: Test API Local
 on:
   workflow_call:
+permissions:
+  contents: read
 
 jobs:
   test:


### PR DESCRIPTION
Potential fix for [https://github.com/unkeyed/unkey/security/code-scanning/59](https://github.com/unkeyed/unkey/security/code-scanning/59)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the provided code, the workflow primarily reads repository contents and uses the `GITHUB_TOKEN` for installation purposes. Therefore, the permissions can be limited to `contents: read`.

The `permissions` block should be added at the root level of the workflow to apply to all jobs, as there is no indication that different jobs require different permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
