### PR TITLE
ci: Potential fix for code scanning alert no. 56: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/job_test_api_canary.yaml
+++ b/.github/workflows/job_test_api_canary.yaml
@@ -1,4 +1,6 @@
 name: Test API Canary
+permissions:
+  contents: read
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/unkeyed/unkey/security/code-scanning/56](https://github.com/unkeyed/unkey/security/code-scanning/56)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow involves checking out code and running tests, it likely only requires `contents: read` permission. We will add this block at the root level of the workflow to apply it to all jobs. If any job requires additional permissions in the future, they can be specified individually.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
