### PR TITLE
ci: Potential fix for code scanning alert no. 49: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/job_deploy_api_enterprise.yaml
+++ b/.github/workflows/job_deploy_api_enterprise.yaml
@@ -1,4 +1,6 @@
 name: Deploy API Enterprise
+permissions:
+  contents: read
 on:
   workflow_call:
     secrets:


### PR DESCRIPTION
Potential fix for [https://github.com/unkeyed/unkey/security/code-scanning/49](https://github.com/unkeyed/unkey/security/code-scanning/49)

To fix the issue, we need to add a `permissions` block to the workflow. This block should explicitly define the least privileges required for the workflow to function correctly. Based on the workflow's operations, the `contents: read` permission is sufficient for the `GITHUB_TOKEN` used in the `install` step. No other permissions appear to be required.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or specifically to the `deploy` job. In this case, adding it at the root level is more concise and ensures consistency across all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
