### PR TITLE
ci: Potential fix for code scanning alert no. 46: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/job_deploy_api_production.yaml
+++ b/.github/workflows/job_deploy_api_production.yaml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   deploy:
+    permissions:
+      contents: read
+      deployments: write
     environment: Production
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/unkeyed/unkey/security/code-scanning/46](https://github.com/unkeyed/unkey/security/code-scanning/46)

The fix involves adding a `permissions` key to the workflow file to explicitly define the minimum privileges required for the `GITHUB_TOKEN`. Based on the actions and steps used in the workflow, the following permissions are required:
- `contents: read`: Needed for the `actions/checkout@v4` step to access the repository's code.
- `deployments: write`: Needed for the `wrangler deploy` command to deploy the application.

The `permissions` key can be added at the root of the workflow (applies to all jobs) or specifically to the `deploy` job. Here, we will apply it to the `deploy` job as it ensures the least privilege principle is followed more granularly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
