### PR TITLE
ci: Potential fix for code scanning alert no. 40: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/job_clickhouse_migration_preview.yaml
+++ b/.github/workflows/job_clickhouse_migration_preview.yaml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: ClickHouse Migration Preview
 on:
   workflow_call:


### PR DESCRIPTION
Potential fix for [https://github.com/unkeyed/unkey/security/code-scanning/40](https://github.com/unkeyed/unkey/security/code-scanning/40)

To address the issue, add a `permissions` block to the root of the workflow or directly to the `deploy` job. Since the workflow involves actions like code checkout (`actions/checkout`) and migration (`goose`), it likely requires `contents: read` for repository files and possibly no additional write permissions. Adding the `permissions` block with `contents: read` at the root of the workflow ensures that all jobs inherit the least privilege necessary, while specific jobs can override this if needed.

**Steps:**
1. Add a `permissions` block at the workflow root to set `contents: read` for all jobs by default.
2. If specific jobs need write permissions (not evident in this workflow snippet), override their permissions locally.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
