### PR TITLE
Potential fix for code scanning alert no. 37: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/job_clickhouse_migration_production.yaml
+++ b/.github/workflows/job_clickhouse_migration_production.yaml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   deploy:
+    permissions:
+      contents: read
     environment: ClickHouse Production Migration
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/unkeyed/unkey/security/code-scanning/37](https://github.com/unkeyed/unkey/security/code-scanning/37)

To resolve the issue flagged by CodeQL, the workflow needs an explicit `permissions` block that specifies the minimal required privileges for the `GITHUB_TOKEN`. Based on the workflow's operations (e.g., checking out code, installing dependencies, and running migrations), the `contents: read` permission is likely sufficient, as there is no evidence of operations requiring write access. This block should be added at the root of the workflow or within the specific `deploy` job to confine permissions to its scope.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
