### PR TITLE
Potential fix for code scanning alert no. 36: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/job_changes.yaml
+++ b/.github/workflows/job_changes.yaml
@@ -9,6 +9,8 @@ jobs:
   build:
     name: Build Agent
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3


### PR DESCRIPTION
Potential fix for [https://github.com/unkeyed/unkey/security/code-scanning/36](https://github.com/unkeyed/unkey/security/code-scanning/36)

To resolve the issue, we need to explicitly define a `permissions` block within the relevant job or at the workflow level. This block should specify the minimal permissions required for the workflow or job to function properly. Based on the given workflow, the minimal permissions required are likely `contents: read`, as the job involves code checkout and file filtering, which do not require write access. Adding this permissions block will restrict the `GITHUB_TOKEN` to read-only access for repository contents, enhancing security.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
