### PR TITLE
ci: Potential fix for code scanning alert no. 32: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/job_build_agent_image.yaml
+++ b/.github/workflows/job_build_agent_image.yaml
@@ -6,8 +6,8 @@ on:
         required: true
         description: "github registrytoken"
 
-
-
+permissions:
+  contents: read
 
 jobs:
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/unkeyed/unkey/security/code-scanning/32](https://github.com/unkeyed/unkey/security/code-scanning/32)

To fix the issue, we need to add a `permissions` block to explicitly define the minimal permissions required for the workflow. Based on the actions used in the workflow, the workflow primarily interacts with repository contents (e.g., checking out code) and builds/pushes Docker images. Therefore, `contents: read` is sufficient for the `GITHUB_TOKEN`. Add this `permissions` block at the root of the workflow file for clarity and consistency.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
