### PR TITLE
fix: use stable slices package

### DIFF
--- a/go/internal/services/keys/validation.go
+++ b/go/internal/services/keys/validation.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"slices"
+
 	"github.com/unkeyed/unkey/go/apps/api/openapi"
 	"github.com/unkeyed/unkey/go/internal/services/ratelimit"
 	"github.com/unkeyed/unkey/go/internal/services/usagelimiter"
@@ -17,7 +19,6 @@ import (
 	"github.com/unkeyed/unkey/go/pkg/prometheus/metrics"
 	"github.com/unkeyed/unkey/go/pkg/ptr"
 	"github.com/unkeyed/unkey/go/pkg/rbac"
-	"golang.org/x/exp/slices"
 )
 
 // withCredits validates that the key has sufficient usage credits and deducts the specified cost.


### PR DESCRIPTION
## What does this PR do?

Replace the deprecated `golang.org/x/exp/slices` import with the standard library `slices` package. This change updates the import to use the officially supported slices package that was moved from the experimental module to the standard library.

Fixes # (issue)

## Type of change

- [x] Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

- Verify that all existing functionality using slices operations continues to work
- Run the test suite to ensure no regressions

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues