### PR TITLE
fix: root-keys ch unknown query param issue

### DIFF
--- a/apps/dashboard/app/(app)/settings/root-keys/[keyId]/page-layout.tsx
+++ b/apps/dashboard/app/(app)/settings/root-keys/[keyId]/page-layout.tsx
@@ -54,7 +54,7 @@ const LastUsed: React.FC<{
   keyId: string;
 }> = async ({ workspaceId, keySpaceId, keyId }) => {
   const lastUsed = await clickhouse.verifications
-    .latest({ workspaceId, keySpaceId, keyId })
+    .latest({ workspaceId, keySpaceId, keyId, limit: 1 })
     .then((res) => res.val?.at(0)?.time ?? 0);
 
   return (


### PR DESCRIPTION
## What does this PR do?

The root keys detail page was throwing a ClickHouse database error whenever someone tried to view key verification history. The problem was that our query expected a limit parameter but we weren't always providing one, causing the database to reject the request. Page will be refactored soon so its okay to leave it as magic number for now, we just need the latest verification.

<!-- If there isn't an issue for this PR, please re-review our Contributing Guide and create an issue -->

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Go to /root-keys/[id]
- Verify that its not throwing that error below:
```sh
}
ClickHouseError: Substitution `limit` is not set.
    at parseError (webpack-internal:///(rsc)/../../node_modules/.pnpm/@clickhouse+client-common@1.11.1/node_modules/@clickhouse/client-common/dist/error/parse_error.js:35:16)
    at WebConnection.request (webpack-internal:///(rsc)/../../node_modules/.pnpm/@clickhouse+client-web@1.11.1/node_modules/@clickhouse/client-web/dist/connection/web_connection.js:156:70)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async WebConnection.query (webpack-internal:///(rsc)/../../node_modules/.pnpm/@clickhouse+client-web@1.11.1/node_modules/@clickhouse/client-web/dist/connection/web_connection.js:41:26)
    at async WebClickHouseClientImpl.query (webpack-internal:///(rsc)/../../node_modules/.pnpm/@clickhouse+client-common@1.11.1/node_modules/@clickhouse/client-common/dist/client.js:81:56)
    at async eval (webpack-internal:///(rsc)/../../internal/clickhouse/src/client/client.ts:34:29)
    at async LastUsed (webpack-internal:///(rsc)/./app/(app)/settings/root-keys/[keyId]/page-layout.tsx:138:22) {
  code: '456',
  type: 'UNKNOWN_QUERY_PARAMETER'
}
```

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of the "Last Used" information in the settings by ensuring only the most recent verification entry is displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->