### PR TITLE
fix: scope cache keys to a workspace to prevent leaking of data

### DIFF
--- a/go/apps/api/routes/register.go
+++ b/go/apps/api/routes/register.go
@@ -73,13 +73,13 @@ func Register(srv *zen.Server, svc *Services) {
 	srv.RegisterRoute(
 		defaultMiddlewares,
 		&v2RatelimitLimit.Handler{
-			Logger:                        svc.Logger,
-			DB:                            svc.Database,
-			Keys:                          svc.Keys,
-			ClickHouse:                    svc.ClickHouse,
-			Ratelimit:                     svc.Ratelimit,
-			RatelimitNamespaceByNameCache: svc.Caches.RatelimitNamespaceByName,
-			TestMode:                      srv.Flags().TestMode,
+			Logger:                  svc.Logger,
+			DB:                      svc.Database,
+			Keys:                    svc.Keys,
+			ClickHouse:              svc.ClickHouse,
+			Ratelimit:               svc.Ratelimit,
+			RatelimitNamespaceCache: svc.Caches.RatelimitNamespace,
+			TestMode:                srv.Flags().TestMode,
 		},
 	)
 
@@ -87,11 +87,11 @@ func Register(srv *zen.Server, svc *Services) {
 	srv.RegisterRoute(
 		defaultMiddlewares,
 		&v2RatelimitSetOverride.Handler{
-			Logger:                        svc.Logger,
-			DB:                            svc.Database,
-			Keys:                          svc.Keys,
-			Auditlogs:                     svc.Auditlogs,
-			RatelimitNamespaceByNameCache: svc.Caches.RatelimitNamespaceByName,
+			Logger:                  svc.Logger,
+			DB:                      svc.Database,
+			Keys:                    svc.Keys,
+			Auditlogs:               svc.Auditlogs,
+			RatelimitNamespaceCache: svc.Caches.RatelimitNamespace,
 		},
 	)
 
@@ -99,10 +99,10 @@ func Register(srv *zen.Server, svc *Services) {
 	srv.RegisterRoute(
 		defaultMiddlewares,
 		&v2RatelimitGetOverride.Handler{
-			Logger:                        svc.Logger,
-			DB:                            svc.Database,
-			Keys:                          svc.Keys,
-			RatelimitNamespaceByNameCache: svc.Caches.RatelimitNamespaceByName,
+			Logger:                  svc.Logger,
+			DB:                      svc.Database,
+			Keys:                    svc.Keys,
+			RatelimitNamespaceCache: svc.Caches.RatelimitNamespace,
 		},
 	)
 
@@ -110,11 +110,11 @@ func Register(srv *zen.Server, svc *Services) {
 	srv.RegisterRoute(
 		defaultMiddlewares,
 		&v2RatelimitDeleteOverride.Handler{
-			Logger:                        svc.Logger,
-			DB:                            svc.Database,
-			Keys:                          svc.Keys,
-			Auditlogs:                     svc.Auditlogs,
-			RatelimitNamespaceByNameCache: svc.Caches.RatelimitNamespaceByName,
+			Logger:                  svc.Logger,
+			DB:                      svc.Database,
+			Keys:                    svc.Keys,
+			Auditlogs:               svc.Auditlogs,
+			RatelimitNamespaceCache: svc.Caches.RatelimitNamespace,
 		},
 	)
 

--- a/go/apps/api/routes/v2_ratelimit_delete_override/200_test.go
+++ b/go/apps/api/routes/v2_ratelimit_delete_override/200_test.go
@@ -44,11 +44,11 @@ func TestDeleteOverrideSuccessfully(t *testing.T) {
 	require.NoError(t, err)
 
 	route := &handler.Handler{
-		DB:                            h.DB,
-		Keys:                          h.Keys,
-		Logger:                        h.Logger,
-		Auditlogs:                     h.Auditlogs,
-		RatelimitNamespaceByNameCache: h.Caches.RatelimitNamespaceByName,
+		DB:                      h.DB,
+		Keys:                    h.Keys,
+		Logger:                  h.Logger,
+		Auditlogs:               h.Auditlogs,
+		RatelimitNamespaceCache: h.Caches.RatelimitNamespace,
 	}
 
 	h.Register(route)

--- a/go/apps/api/routes/v2_ratelimit_delete_override/400_test.go
+++ b/go/apps/api/routes/v2_ratelimit_delete_override/400_test.go
@@ -18,10 +18,10 @@ func TestBadRequests(t *testing.T) {
 
 	rootKey := h.CreateRootKey(h.Resources().UserWorkspace.ID)
 	route := &handler.Handler{
-		DB:                            h.DB,
-		Keys:                          h.Keys,
-		Logger:                        h.Logger,
-		RatelimitNamespaceByNameCache: h.Caches.RatelimitNamespaceByName,
+		DB:                      h.DB,
+		Keys:                    h.Keys,
+		Logger:                  h.Logger,
+		RatelimitNamespaceCache: h.Caches.RatelimitNamespace,
 	}
 
 	h.Register(route)

--- a/go/apps/api/routes/v2_ratelimit_delete_override/401_test.go
+++ b/go/apps/api/routes/v2_ratelimit_delete_override/401_test.go
@@ -14,11 +14,11 @@ func TestUnauthorizedAccess(t *testing.T) {
 	h := testutil.NewHarness(t)
 
 	route := &handler.Handler{
-		DB:                            h.DB,
-		Keys:                          h.Keys,
-		Logger:                        h.Logger,
-		Auditlogs:                     h.Auditlogs,
-		RatelimitNamespaceByNameCache: h.Caches.RatelimitNamespaceByName,
+		DB:                      h.DB,
+		Keys:                    h.Keys,
+		Logger:                  h.Logger,
+		Auditlogs:               h.Auditlogs,
+		RatelimitNamespaceCache: h.Caches.RatelimitNamespace,
 	}
 
 	h.Register(route)

--- a/go/apps/api/routes/v2_ratelimit_delete_override/403_test.go
+++ b/go/apps/api/routes/v2_ratelimit_delete_override/403_test.go
@@ -45,11 +45,11 @@ func TestWorkspacePermissions(t *testing.T) {
 	require.NoError(t, err)
 
 	route := &handler.Handler{
-		DB:                            h.DB,
-		Keys:                          h.Keys,
-		Logger:                        h.Logger,
-		Auditlogs:                     h.Auditlogs,
-		RatelimitNamespaceByNameCache: h.Caches.RatelimitNamespaceByName,
+		DB:                      h.DB,
+		Keys:                    h.Keys,
+		Logger:                  h.Logger,
+		Auditlogs:               h.Auditlogs,
+		RatelimitNamespaceCache: h.Caches.RatelimitNamespace,
 	}
 
 	h.Register(route)

--- a/go/apps/api/routes/v2_ratelimit_delete_override/404_test.go
+++ b/go/apps/api/routes/v2_ratelimit_delete_override/404_test.go
@@ -31,11 +31,11 @@ func TestNotFound(t *testing.T) {
 	require.NoError(t, err)
 
 	route := &handler.Handler{
-		DB:                            h.DB,
-		Keys:                          h.Keys,
-		Logger:                        h.Logger,
-		Auditlogs:                     h.Auditlogs,
-		RatelimitNamespaceByNameCache: h.Caches.RatelimitNamespaceByName,
+		DB:                      h.DB,
+		Keys:                    h.Keys,
+		Logger:                  h.Logger,
+		Auditlogs:               h.Auditlogs,
+		RatelimitNamespaceCache: h.Caches.RatelimitNamespace,
 	}
 
 	h.Register(route)

--- a/go/apps/api/routes/v2_ratelimit_get_override/200_test.go
+++ b/go/apps/api/routes/v2_ratelimit_get_override/200_test.go
@@ -47,10 +47,10 @@ func TestGetOverrideSuccessfully(t *testing.T) {
 	require.NoError(t, err)
 
 	route := &handler.Handler{
-		DB:                            h.DB,
-		Keys:                          h.Keys,
-		Logger:                        h.Logger,
-		RatelimitNamespaceByNameCache: h.Caches.RatelimitNamespaceByName,
+		DB:                      h.DB,
+		Keys:                    h.Keys,
+		Logger:                  h.Logger,
+		RatelimitNamespaceCache: h.Caches.RatelimitNamespace,
 	}
 
 	h.Register(route)

--- a/go/apps/api/routes/v2_ratelimit_get_override/400_test.go
+++ b/go/apps/api/routes/v2_ratelimit_get_override/400_test.go
@@ -19,10 +19,10 @@ func TestBadRequests(t *testing.T) {
 
 	rootKey := h.CreateRootKey(h.Resources().UserWorkspace.ID)
 	route := &handler.Handler{
-		DB:                            h.DB,
-		Keys:                          h.Keys,
-		Logger:                        h.Logger,
-		RatelimitNamespaceByNameCache: h.Caches.RatelimitNamespaceByName,
+		DB:                      h.DB,
+		Keys:                    h.Keys,
+		Logger:                  h.Logger,
+		RatelimitNamespaceCache: h.Caches.RatelimitNamespace,
 	}
 
 	h.Register(route)

--- a/go/apps/api/routes/v2_ratelimit_get_override/401_test.go
+++ b/go/apps/api/routes/v2_ratelimit_get_override/401_test.go
@@ -14,10 +14,10 @@ func TestUnauthorizedAccess(t *testing.T) {
 	h := testutil.NewHarness(t)
 
 	route := &handler.Handler{
-		DB:                            h.DB,
-		Keys:                          h.Keys,
-		Logger:                        h.Logger,
-		RatelimitNamespaceByNameCache: h.Caches.RatelimitNamespaceByName,
+		DB:                      h.DB,
+		Keys:                    h.Keys,
+		Logger:                  h.Logger,
+		RatelimitNamespaceCache: h.Caches.RatelimitNamespace,
 	}
 
 	h.Register(route)

--- a/go/apps/api/routes/v2_ratelimit_get_override/403_test.go
+++ b/go/apps/api/routes/v2_ratelimit_get_override/403_test.go
@@ -45,10 +45,10 @@ func TestWorkspacePermissions(t *testing.T) {
 	require.NoError(t, err)
 
 	route := &handler.Handler{
-		DB:                            h.DB,
-		Keys:                          h.Keys,
-		Logger:                        h.Logger,
-		RatelimitNamespaceByNameCache: h.Caches.RatelimitNamespaceByName,
+		DB:                      h.DB,
+		Keys:                    h.Keys,
+		Logger:                  h.Logger,
+		RatelimitNamespaceCache: h.Caches.RatelimitNamespace,
 	}
 
 	h.Register(route)

--- a/go/apps/api/routes/v2_ratelimit_get_override/404_test.go
+++ b/go/apps/api/routes/v2_ratelimit_get_override/404_test.go
@@ -31,10 +31,10 @@ func TestOverrideNotFound(t *testing.T) {
 	require.NoError(t, err)
 
 	route := &handler.Handler{
-		DB:                            h.DB,
-		Keys:                          h.Keys,
-		Logger:                        h.Logger,
-		RatelimitNamespaceByNameCache: h.Caches.RatelimitNamespaceByName,
+		DB:                      h.DB,
+		Keys:                    h.Keys,
+		Logger:                  h.Logger,
+		RatelimitNamespaceCache: h.Caches.RatelimitNamespace,
 	}
 
 	h.Register(route)

--- a/go/apps/api/routes/v2_ratelimit_get_override/handler.go
+++ b/go/apps/api/routes/v2_ratelimit_get_override/handler.go
@@ -26,10 +26,10 @@ type Response = openapi.V2RatelimitGetOverrideResponseBody
 // Handler implements zen.Route interface for the v2 ratelimit get override endpoint
 type Handler struct {
 	// Services as public fields
-	Logger                        logging.Logger
-	DB                            db.Database
-	Keys                          keys.KeyService
-	RatelimitNamespaceByNameCache cache.Cache[string, db.FindRatelimitNamespace]
+	Logger                  logging.Logger
+	DB                      db.Database
+	Keys                    keys.KeyService
+	RatelimitNamespaceCache cache.Cache[cache.ScopedKey, db.FindRatelimitNamespace]
 }
 
 // Method returns the HTTP method this route responds to

--- a/go/apps/api/routes/v2_ratelimit_limit/200_test.go
+++ b/go/apps/api/routes/v2_ratelimit_limit/200_test.go
@@ -22,12 +22,12 @@ func TestLimitSuccessfully(t *testing.T) {
 	h := testutil.NewHarness(t)
 
 	route := &handler.Handler{
-		DB:                            h.DB,
-		Keys:                          h.Keys,
-		Logger:                        h.Logger,
-		ClickHouse:                    h.ClickHouse,
-		Ratelimit:                     h.Ratelimit,
-		RatelimitNamespaceByNameCache: h.Caches.RatelimitNamespaceByName,
+		DB:                      h.DB,
+		Keys:                    h.Keys,
+		Logger:                  h.Logger,
+		ClickHouse:              h.ClickHouse,
+		Ratelimit:               h.Ratelimit,
+		RatelimitNamespaceCache: h.Caches.RatelimitNamespace,
 	}
 
 	h.Register(route)

--- a/go/apps/api/routes/v2_ratelimit_limit/400_test.go
+++ b/go/apps/api/routes/v2_ratelimit_limit/400_test.go
@@ -20,11 +20,11 @@ func TestBadRequests(t *testing.T) {
 	h := testutil.NewHarness(t)
 
 	route := &handler.Handler{
-		DB:                            h.DB,
-		Keys:                          h.Keys,
-		Logger:                        h.Logger,
-		Ratelimit:                     h.Ratelimit,
-		RatelimitNamespaceByNameCache: h.Caches.RatelimitNamespaceByName,
+		DB:                      h.DB,
+		Keys:                    h.Keys,
+		Logger:                  h.Logger,
+		Ratelimit:               h.Ratelimit,
+		RatelimitNamespaceCache: h.Caches.RatelimitNamespace,
 	}
 
 	h.Register(route)

--- a/go/apps/api/routes/v2_ratelimit_limit/401_test.go
+++ b/go/apps/api/routes/v2_ratelimit_limit/401_test.go
@@ -13,11 +13,11 @@ func TestUnauthorizedAccess(t *testing.T) {
 	h := testutil.NewHarness(t)
 
 	route := &handler.Handler{
-		DB:                            h.DB,
-		Keys:                          h.Keys,
-		Logger:                        h.Logger,
-		Ratelimit:                     h.Ratelimit,
-		RatelimitNamespaceByNameCache: h.Caches.RatelimitNamespaceByName,
+		DB:                      h.DB,
+		Keys:                    h.Keys,
+		Logger:                  h.Logger,
+		Ratelimit:               h.Ratelimit,
+		RatelimitNamespaceCache: h.Caches.RatelimitNamespace,
 	}
 
 	h.Register(route)

--- a/go/apps/api/routes/v2_ratelimit_limit/403_test.go
+++ b/go/apps/api/routes/v2_ratelimit_limit/403_test.go
@@ -31,11 +31,11 @@ func TestWorkspacePermissions(t *testing.T) {
 	require.NoError(t, err)
 
 	route := &handler.Handler{
-		DB:                            h.DB,
-		Keys:                          h.Keys,
-		Logger:                        h.Logger,
-		Ratelimit:                     h.Ratelimit,
-		RatelimitNamespaceByNameCache: h.Caches.RatelimitNamespaceByName,
+		DB:                      h.DB,
+		Keys:                    h.Keys,
+		Logger:                  h.Logger,
+		Ratelimit:               h.Ratelimit,
+		RatelimitNamespaceCache: h.Caches.RatelimitNamespace,
 	}
 
 	h.Register(route)

--- a/go/apps/api/routes/v2_ratelimit_limit/404_test.go
+++ b/go/apps/api/routes/v2_ratelimit_limit/404_test.go
@@ -20,11 +20,11 @@ func TestNamespaceNotFound(t *testing.T) {
 	h := testutil.NewHarness(t)
 
 	route := &handler.Handler{
-		DB:                            h.DB,
-		Keys:                          h.Keys,
-		Logger:                        h.Logger,
-		Ratelimit:                     h.Ratelimit,
-		RatelimitNamespaceByNameCache: h.Caches.RatelimitNamespaceByName,
+		DB:                      h.DB,
+		Keys:                    h.Keys,
+		Logger:                  h.Logger,
+		Ratelimit:               h.Ratelimit,
+		RatelimitNamespaceCache: h.Caches.RatelimitNamespace,
 	}
 
 	h.Register(route)

--- a/go/apps/api/routes/v2_ratelimit_limit/accuracy_test.go
+++ b/go/apps/api/routes/v2_ratelimit_limit/accuracy_test.go
@@ -57,12 +57,12 @@ func TestRateLimitAccuracy(t *testing.T) {
 									h := testutil.NewHarness(t)
 
 									route := &handler.Handler{
-										DB:                            h.DB,
-										Keys:                          h.Keys,
-										Logger:                        h.Logger,
-										ClickHouse:                    h.ClickHouse,
-										Ratelimit:                     h.Ratelimit,
-										RatelimitNamespaceByNameCache: h.Caches.RatelimitNamespaceByName,
+										DB:                      h.DB,
+										Keys:                    h.Keys,
+										Logger:                  h.Logger,
+										ClickHouse:              h.ClickHouse,
+										Ratelimit:               h.Ratelimit,
+										RatelimitNamespaceCache: h.Caches.RatelimitNamespace,
 									}
 									h.Register(route)
 									ctx := context.Background()

--- a/go/apps/api/routes/v2_ratelimit_set_override/200_test.go
+++ b/go/apps/api/routes/v2_ratelimit_set_override/200_test.go
@@ -30,11 +30,11 @@ func TestSetOverrideSuccessfully(t *testing.T) {
 	require.NoError(t, err)
 
 	route := &handler.Handler{
-		DB:                            h.DB,
-		Keys:                          h.Keys,
-		Logger:                        h.Logger,
-		Auditlogs:                     h.Auditlogs,
-		RatelimitNamespaceByNameCache: h.Caches.RatelimitNamespaceByName,
+		DB:                      h.DB,
+		Keys:                    h.Keys,
+		Logger:                  h.Logger,
+		Auditlogs:               h.Auditlogs,
+		RatelimitNamespaceCache: h.Caches.RatelimitNamespace,
 	}
 
 	h.Register(route)

--- a/go/apps/api/routes/v2_ratelimit_set_override/400_test.go
+++ b/go/apps/api/routes/v2_ratelimit_set_override/400_test.go
@@ -18,10 +18,10 @@ func TestBadRequests(t *testing.T) {
 
 	rootKey := h.CreateRootKey(h.Resources().UserWorkspace.ID, "ratelimit.*.set_override")
 	route := &handler.Handler{
-		DB:                            h.DB,
-		Keys:                          h.Keys,
-		Logger:                        h.Logger,
-		RatelimitNamespaceByNameCache: h.Caches.RatelimitNamespaceByName,
+		DB:                      h.DB,
+		Keys:                    h.Keys,
+		Logger:                  h.Logger,
+		RatelimitNamespaceCache: h.Caches.RatelimitNamespace,
 	}
 
 	h.Register(route)

--- a/go/apps/api/routes/v2_ratelimit_set_override/401_test.go
+++ b/go/apps/api/routes/v2_ratelimit_set_override/401_test.go
@@ -14,11 +14,11 @@ func TestUnauthorizedAccess(t *testing.T) {
 	h := testutil.NewHarness(t)
 
 	route := &handler.Handler{
-		DB:                            h.DB,
-		Keys:                          h.Keys,
-		Logger:                        h.Logger,
-		Auditlogs:                     h.Auditlogs,
-		RatelimitNamespaceByNameCache: h.Caches.RatelimitNamespaceByName,
+		DB:                      h.DB,
+		Keys:                    h.Keys,
+		Logger:                  h.Logger,
+		Auditlogs:               h.Auditlogs,
+		RatelimitNamespaceCache: h.Caches.RatelimitNamespace,
 	}
 
 	h.Register(route)

--- a/go/apps/api/routes/v2_ratelimit_set_override/403_test.go
+++ b/go/apps/api/routes/v2_ratelimit_set_override/403_test.go
@@ -31,11 +31,11 @@ func TestWorkspacePermissions(t *testing.T) {
 	require.NoError(t, err)
 
 	route := &handler.Handler{
-		DB:                            h.DB,
-		Keys:                          h.Keys,
-		Logger:                        h.Logger,
-		Auditlogs:                     h.Auditlogs,
-		RatelimitNamespaceByNameCache: h.Caches.RatelimitNamespaceByName,
+		DB:                      h.DB,
+		Keys:                    h.Keys,
+		Logger:                  h.Logger,
+		Auditlogs:               h.Auditlogs,
+		RatelimitNamespaceCache: h.Caches.RatelimitNamespace,
 	}
 
 	h.Register(route)

--- a/go/apps/api/routes/v2_ratelimit_set_override/404_test.go
+++ b/go/apps/api/routes/v2_ratelimit_set_override/404_test.go
@@ -15,11 +15,11 @@ func TestNamespaceNotFound(t *testing.T) {
 	h := testutil.NewHarness(t)
 
 	route := &handler.Handler{
-		DB:                            h.DB,
-		Keys:                          h.Keys,
-		Logger:                        h.Logger,
-		Auditlogs:                     h.Auditlogs,
-		RatelimitNamespaceByNameCache: h.Caches.RatelimitNamespaceByName,
+		DB:                      h.DB,
+		Keys:                    h.Keys,
+		Logger:                  h.Logger,
+		Auditlogs:               h.Auditlogs,
+		RatelimitNamespaceCache: h.Caches.RatelimitNamespace,
 	}
 
 	h.Register(route)

--- a/go/pkg/cache/cache.go
+++ b/go/pkg/cache/cache.go
@@ -153,10 +153,10 @@ func (c *cache[K, V]) get(_ context.Context, key K) (swrEntry[V], bool) {
 	return v, ok
 }
 
-func (c *cache[K, V]) Remove(ctx context.Context, key K) {
-
-	c.otter.Delete(key)
-
+func (c *cache[K, V]) Remove(ctx context.Context, keys ...K) {
+	for _, key := range keys {
+		c.otter.Delete(key)
+	}
 }
 
 func (c *cache[K, V]) Dump(ctx context.Context) ([]byte, error) {

--- a/go/pkg/cache/interface.go
+++ b/go/pkg/cache/interface.go
@@ -15,8 +15,9 @@ type Cache[K comparable, V any] interface {
 	// Sets the given key to null, indicating that the value does not exist in the origin.
 	SetNull(ctx context.Context, key K)
 
-	// Removes the key from the cache.
-	Remove(ctx context.Context, key K)
+	// Remove removes one or more keys from the cache.
+	// Multiple keys can be provided for efficient bulk removal.
+	Remove(ctx context.Context, keys ...K)
 
 	SWR(ctx context.Context, key K, refreshFromOrigin func(ctx context.Context) (V, error), op func(error) Op) (value V, err error)
 

--- a/go/pkg/cache/middleware/tracing.go
+++ b/go/pkg/cache/middleware/tracing.go
@@ -44,13 +44,15 @@ func (mw *tracingMiddleware[K, V]) SetNull(ctx context.Context, key K) {
 	mw.next.SetNull(ctx, key)
 
 }
-func (mw *tracingMiddleware[K, V]) Remove(ctx context.Context, key K) {
+func (mw *tracingMiddleware[K, V]) Remove(ctx context.Context, keys ...K) {
 	ctx, span := tracing.Start(ctx, "cache.Remove")
 	defer span.End()
-	span.SetAttributes(attribute.String("key", fmt.Sprintf("%+v", key)))
+	span.SetAttributes(
+		attribute.String("keys", fmt.Sprintf("%+v", keys)),
+		attribute.Int("count", len(keys)),
+	)
 
-	mw.next.Remove(ctx, key)
-
+	mw.next.Remove(ctx, keys...)
 }
 
 func (mw *tracingMiddleware[K, V]) Dump(ctx context.Context) ([]byte, error) {

--- a/go/pkg/cache/noop.go
+++ b/go/pkg/cache/noop.go
@@ -13,7 +13,7 @@ func (c *noopCache[K, V]) Get(ctx context.Context, key K) (value V, hit CacheHit
 func (c *noopCache[K, V]) Set(ctx context.Context, key K, value V) {}
 func (c *noopCache[K, V]) SetNull(ctx context.Context, key K)      {}
 
-func (c *noopCache[K, V]) Remove(ctx context.Context, key K) {}
+func (c *noopCache[K, V]) Remove(ctx context.Context, keys ...K) {}
 
 func (c *noopCache[K, V]) Dump(ctx context.Context) ([]byte, error) {
 	return []byte{}, nil

--- a/go/pkg/cache/scoped_key.go
+++ b/go/pkg/cache/scoped_key.go
@@ -1,0 +1,57 @@
+package cache
+
+// ScopedKey represents a cache key that is scoped to a specific workspace.
+//
+// This type is designed for caching data where keys are only unique within
+// a workspace context, rather than being globally unique. For example, a user
+// might create a ratelimit namespace called "api-calls" which is unique within
+// their workspace but could exist in multiple workspaces.
+//
+// The ScopedKey ensures cache isolation between workspaces by combining the
+// workspace ID with the resource key, preventing cache collisions and data
+// leakage between different workspaces.
+//
+// # Usage
+//
+// Use ScopedKey when caching data that is workspace-specific:
+//
+//	// Cache a ratelimit namespace by name
+//	key := cache.ScopedKey{
+//		WorkspaceID: "ws_123",
+//		Key:         "api-calls",
+//	}
+//
+//	// Cache by ID (still workspace-scoped for consistency)
+//	key := cache.ScopedKey{
+//		WorkspaceID: "ws_123",
+//		Key:         "ns_456",
+//	}
+//
+//	// Cache any workspace-scoped resource
+//	key := cache.ScopedKey{
+//		WorkspaceID: "ws_123",
+//		Key:         "some-resource-identifier",
+//	}
+//
+// # Design Rationale
+//
+// We chose this approach over concatenating strings because it provides type
+// safety and makes the workspace scoping explicit in the API. It also allows
+// for future extension if additional scoping dimensions are needed.
+//
+// The generic Key field can hold any string identifier (names, IDs, slugs, etc.)
+// while maintaining consistent workspace isolation across all cache usage patterns.
+type ScopedKey struct {
+	// WorkspaceID is the unique identifier for the workspace that owns this resource.
+	// This ensures that cache keys are isolated between different workspaces,
+	// preventing accidental data leakage or cache collisions.
+	WorkspaceID string
+
+	// Key is the identifier for the resource within the workspace.
+	// This can be a user-provided name, system-generated ID, slug, or any other
+	// string identifier that uniquely identifies the resource within the workspace.
+	//
+	// The key is only guaranteed to be unique within the workspace context.
+	// Different workspaces may have resources with the same key value.
+	Key string
+}


### PR DESCRIPTION
## What does this PR do?

Refactors the ratelimit namespace cache to use a more robust scoped key approach. This change replaces the previous `RatelimitNamespaceByNameCache` with a new `RatelimitNamespaceCache` that uses a `ScopedKey` type to properly isolate cached data between workspaces.

The new implementation:
- Introduces a `ScopedKey` type that combines workspace ID with resource keys
- Updates all ratelimit handlers to use the new cache interface
- Improves cache invalidation by supporting removal of multiple keys at once
- Ensures proper workspace isolation for cached ratelimit namespace data

Fixes # (issue)

## Type of change

- [x] Chore (refactoring code, technical debt, workflow improvements)
- [x] Enhancement (small improvements)

## How should this be tested?

- Test all ratelimit API endpoints to ensure they work correctly with the new cache implementation
- Verify that cache isolation works properly between workspaces
- Check that cache invalidation works when setting or deleting overrides

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new cache key type to improve workspace-level isolation for cached resources.

* **Refactor**
  * Updated cache keying for rate limit namespace operations to use workspace-scoped keys instead of simple strings.
  * Improved cache invalidation logic to support removal of multiple entries at once.
  * Renamed and updated cache-related fields and methods to reflect new keying strategy.

* **Tests**
  * Updated test setups to use the new cache field names and keying approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->