### PR TITLE
perf: tweak batching

### DIFF
--- a/go/pkg/clickhouse/client.go
+++ b/go/pkg/clickhouse/client.go
@@ -101,8 +101,8 @@ func New(config Config) (*clickhouse, error) {
 			Drop:          true,
 			BatchSize:     10000,
 			BufferSize:    100000,
-			FlushInterval: time.Second,
-			Consumers:     4,
+			FlushInterval: 5 * time.Second,
+			Consumers:     2,
 			Flush: func(ctx context.Context, rows []schema.ApiRequestV1) {
 				table := "metrics.raw_api_requests_v1"
 				err := flush(ctx, conn, table, rows)
@@ -120,8 +120,8 @@ func New(config Config) (*clickhouse, error) {
 				Drop:          true,
 				BatchSize:     10000,
 				BufferSize:    100000,
-				FlushInterval: time.Second,
-				Consumers:     4,
+				FlushInterval: 5 * time.Second,
+				Consumers:     2,
 				Flush: func(ctx context.Context, rows []schema.KeyVerificationRequestV1) {
 					table := "verifications.raw_key_verifications_v1"
 					err := flush(ctx, conn, table, rows)
@@ -139,8 +139,8 @@ func New(config Config) (*clickhouse, error) {
 				Drop:          true,
 				BatchSize:     10000,
 				BufferSize:    100000,
-				FlushInterval: time.Second,
-				Consumers:     8,
+				FlushInterval: 5 * time.Second,
+				Consumers:     2,
 				Flush: func(ctx context.Context, rows []schema.RatelimitRequestV1) {
 					table := "ratelimits.raw_ratelimits_v1"
 					err := flush(ctx, conn, table, rows)


### PR DESCRIPTION
## What does this PR do?

Adjusts ClickHouse client configuration to optimize performance by:
- Increasing the flush interval from 1 second to 5 seconds for all data streams
- Reducing the number of consumers from 4 to 2 for API requests and key verification requests
- Reducing the number of consumers from 8 to 2 for rate limit requests

These changes aim to reduce the frequency of database writes and decrease resource consumption while maintaining adequate throughput.

Fixes #(issue)

## Type of change

- [x] Enhancement (small improvements)
- [x] Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

- Monitor ClickHouse performance metrics before and after deployment to verify reduced write frequency
- Verify that data is still being properly written to the database with the new flush interval
- Check system resource utilization to confirm reduced CPU/memory usage from fewer consumer threads

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated batch processing settings to adjust flush intervals and the number of concurrent consumers, which may affect the responsiveness and throughput of certain background operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->