### PR TITLE
fix: log verifications to the owning workspace

### DIFF
--- a/go/internal/services/keys/verifier.go
+++ b/go/internal/services/keys/verifier.go
@@ -115,7 +115,7 @@ func (k *KeyVerifier) Verify(ctx context.Context, opts ...VerifyOption) error {
 func (k *KeyVerifier) log() {
 	k.clickhouse.BufferKeyVerification(schema.KeyVerificationRequestV1{
 		RequestID:   k.session.RequestID(),
-		WorkspaceID: k.session.AuthorizedWorkspaceID(),
+		WorkspaceID: k.Key.WorkspaceID,
 		Time:        time.Now().UnixMilli(),
 		Region:      "",
 		Outcome:     string(k.Status),


### PR DESCRIPTION
## What does this PR do?

Fix the workspace ID used in key verification logging. The PR changes the source of the workspace ID from `k.session.AuthorizedWorkspaceID()` to `k.Key.WorkspaceID` in the `log()` method of the `KeyVerifier` struct.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Verify that key verification logs now correctly show the workspace ID associated with the key rather than the authorized workspace ID from the session
- Test key verification with different workspace IDs to ensure the correct ID is being logged

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved accuracy of workspace identification in key verification logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->