### PR TITLE
fix: validate s3 config

### DIFF
--- a/go/apps/api/config.go
+++ b/go/apps/api/config.go
@@ -3,6 +3,7 @@ package api
 import (
 	"net"
 
+	"github.com/unkeyed/unkey/go/pkg/assert"
 	"github.com/unkeyed/unkey/go/pkg/clock"
 	"github.com/unkeyed/unkey/go/pkg/tls"
 )
@@ -11,7 +12,7 @@ type S3Config struct {
 	URL             string
 	Bucket          string
 	AccessKeyID     string
-	SecretAccessKey string
+	AccessKeySecret string
 }
 
 type Config struct {
@@ -82,5 +83,18 @@ type Config struct {
 func (c Config) Validate() error {
 	// TLS configuration is validated when it's created from files
 	// Other validations may be added here in the future
+
+	if c.VaultS3 != nil {
+		err := assert.All(
+			assert.NotEmpty(c.VaultS3.URL, "vault s3 url is empty"),
+			assert.NotEmpty(c.VaultS3.Bucket, "vault s3 bucket is empty"),
+			assert.NotEmpty(c.VaultS3.AccessKeyID, "vault s3 access key id is empty"),
+			assert.NotEmpty(c.VaultS3.AccessKeySecret, "vault s3 secret access key is empty"),
+		)
+		if err != nil {
+			return err
+		}
+
+	}
 	return nil
 }

--- a/go/apps/api/run.go
+++ b/go/apps/api/run.go
@@ -195,7 +195,7 @@ func Run(ctx context.Context, cfg Config) error {
 			S3URL:             cfg.VaultS3.URL,
 			S3Bucket:          cfg.VaultS3.Bucket,
 			S3AccessKeyID:     cfg.VaultS3.AccessKeyID,
-			S3AccessKeySecret: cfg.VaultS3.SecretAccessKey,
+			S3AccessKeySecret: cfg.VaultS3.AccessKeySecret,
 		})
 		if err != nil {
 			return fmt.Errorf("unable to create vault storage: %w", err)

--- a/go/cmd/api/main.go
+++ b/go/cmd/api/main.go
@@ -106,7 +106,7 @@ func action(ctx context.Context, cmd *cli.Command) error {
 			URL:             cmd.String("vault-s3-url"),
 			Bucket:          cmd.String("vault-s3-bucket"),
 			AccessKeyID:     cmd.String("vault-s3-access-key-id"),
-			SecretAccessKey: cmd.String("vault-s3-access-key-secret"),
+			AccessKeySecret: cmd.String("vault-s3-access-key-secret"),
 		}
 	}
 

--- a/go/go.mod
+++ b/go/go.mod
@@ -6,9 +6,9 @@ require (
 	connectrpc.com/connect v1.18.1
 	github.com/ClickHouse/clickhouse-go/v2 v2.35.0
 	github.com/aws/aws-sdk-go-v2 v1.36.5
-	github.com/aws/aws-sdk-go-v2/config v1.29.17
-	github.com/aws/aws-sdk-go-v2/credentials v1.17.70
-	github.com/aws/aws-sdk-go-v2/service/s3 v1.82.0
+	github.com/aws/aws-sdk-go-v2/config v1.29.6
+	github.com/aws/aws-sdk-go-v2/credentials v1.17.59
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.76.1
 	github.com/btcsuite/btcutil v1.0.2
 	github.com/getkin/kin-openapi v0.132.0
 	github.com/go-redis/redis/v8 v8.11.5

--- a/go/go.sum
+++ b/go/go.sum
@@ -24,10 +24,10 @@ github.com/aws/aws-sdk-go-v2 v1.36.5 h1:0OF9RiEMEdDdZEMqF9MRjevyxAQcf6gY+E7vwBIL
 github.com/aws/aws-sdk-go-v2 v1.36.5/go.mod h1:EYrzvCCN9CMUTa5+6lf6MM4tq3Zjp8UhSGR/cBsjai0=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.11 h1:12SpdwU8Djs+YGklkinSSlcrPyj3H4VifVsKf78KbwA=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.11/go.mod h1:dd+Lkp6YmMryke+qxW/VnKyhMBDTYP41Q2Bb+6gNZgY=
-github.com/aws/aws-sdk-go-v2/config v1.29.17 h1:jSuiQ5jEe4SAMH6lLRMY9OVC+TqJLP5655pBGjmnjr0=
-github.com/aws/aws-sdk-go-v2/config v1.29.17/go.mod h1:9P4wwACpbeXs9Pm9w1QTh6BwWwJjwYvJ1iCt5QbCXh8=
-github.com/aws/aws-sdk-go-v2/credentials v1.17.70 h1:ONnH5CM16RTXRkS8Z1qg7/s2eDOhHhaXVd72mmyv4/0=
-github.com/aws/aws-sdk-go-v2/credentials v1.17.70/go.mod h1:M+lWhhmomVGgtuPOhO85u4pEa3SmssPTdcYpP/5J/xc=
+github.com/aws/aws-sdk-go-v2/config v1.29.6 h1:fqgqEKK5HaZVWLQoLiC9Q+xDlSp+1LYidp6ybGE2OGg=
+github.com/aws/aws-sdk-go-v2/config v1.29.6/go.mod h1:Ft+WLODzDQmCTHDvqAH1JfC2xxbZ0MxpZAcJqmE1LTQ=
+github.com/aws/aws-sdk-go-v2/credentials v1.17.59 h1:9btwmrt//Q6JcSdgJOLI98sdr5p7tssS9yAsGe8aKP4=
+github.com/aws/aws-sdk-go-v2/credentials v1.17.59/go.mod h1:NM8fM6ovI3zak23UISdWidyZuI1ghNe2xjzUZAyT+08=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.32 h1:KAXP9JSHO1vKGCr5f4O6WmlVKLFFXgWYAGoJosorxzU=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.32/go.mod h1:h4Sg6FQdexC1yYG9RDnOvLbW1a/P986++/Y/a+GyEM8=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.36 h1:SsytQyTMHMDPspp+spo7XwXTP44aJZZAC7fBV2C5+5s=
@@ -46,8 +46,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.17 h1:t0E6FzRE
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.17/go.mod h1:ygpklyoaypuyDvOM5ujWGrYWpAK3h7ugnmKCU/76Ys4=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.18.17 h1:qcLWgdhq45sDM9na4cvXax9dyLitn8EYBRl8Ak4XtG4=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.18.17/go.mod h1:M+jkjBFZ2J6DJrjMv2+vkBbuht6kxJYtJiwoVgX4p4U=
-github.com/aws/aws-sdk-go-v2/service/s3 v1.82.0 h1:JubM8CGDDFaAOmBrd8CRYNr49ZNgEAiLwGwgNMdS0nw=
-github.com/aws/aws-sdk-go-v2/service/s3 v1.82.0/go.mod h1:kUklwasNoCn5YpyAqC/97r6dzTA1SRKJfKq16SXeoDU=
+github.com/aws/aws-sdk-go-v2/service/s3 v1.76.1 h1:d4ZG8mELlLeUWFBMCqPtRfEP3J6aQgg/KTC9jLSlkMs=
+github.com/aws/aws-sdk-go-v2/service/s3 v1.76.1/go.mod h1:uZoEIR6PzGOZEjgAZE4hfYfsqK2zOHhq68JLKEvvXj4=
 github.com/aws/aws-sdk-go-v2/service/sso v1.25.5 h1:AIRJ3lfb2w/1/8wOOSqYb9fUKGwQbtysJ2H1MofRUPg=
 github.com/aws/aws-sdk-go-v2/service/sso v1.25.5/go.mod h1:b7SiVprpU+iGazDUqvRSLf5XmCdn+JtT1on7uNL6Ipc=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.30.3 h1:BpOxT3yhLwSJ77qIY3DoHAQjZsc4HEGfMCE4NGy3uFg=


### PR DESCRIPTION
## What does this PR do?

Renames `SecretAccessKey` to `AccessKeySecret` in the S3Config struct for consistency across the codebase. This change affects multiple files where the field is referenced. Also adds validation for the S3 vault configuration to ensure all required fields are present.

Additionally, downgrades AWS SDK dependencies to specific versions:
- aws-sdk-go-v2/config from 1.29.17 to 1.29.6
- aws-sdk-go-v2/credentials from 1.17.70 to 1.17.59
- aws-sdk-go-v2/service/s3 from 1.82.0 to 1.76.1

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

- Test S3 vault configuration with the renamed `AccessKeySecret` field
- Verify that validation correctly identifies missing S3 configuration values
- Confirm AWS SDK functionality works with the downgraded versions

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the S3 secret access key field name in configuration and setup processes to ensure proper handling of credentials.

* **Chores**
  * Updated validation to check all required S3 configuration fields.
  * Downgraded AWS SDK dependencies to earlier versions for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->