### PR TITLE
fix: speakeasy ignore directive is ignored if it's a string

### DIFF
--- a/go/apps/api/openapi/openapi-generated.yaml
+++ b/go/apps/api/openapi/openapi-generated.yaml
@@ -3074,7 +3074,7 @@ paths:
             tags:
                 - chproxy
             x-excluded: true
-            x-speakeasy-ignore: "true"
+            x-speakeasy-ignore: true
     /_internal/chproxy/ratelimits:
         post:
             description: |-
@@ -3112,7 +3112,7 @@ paths:
             tags:
                 - chproxy
             x-excluded: true
-            x-speakeasy-ignore: "true"
+            x-speakeasy-ignore: true
     /_internal/chproxy/verifications:
         post:
             description: |-
@@ -3150,7 +3150,7 @@ paths:
             tags:
                 - chproxy
             x-excluded: true
-            x-speakeasy-ignore: "true"
+            x-speakeasy-ignore: true
     /v2/apis.createApi:
         post:
             description: |
@@ -4869,7 +4869,7 @@ paths:
             tags:
                 - liveness
             x-excluded: true
-            x-speakeasy-ignore: "true"
+            x-speakeasy-ignore: true
     /v2/permissions.createPermission:
         post:
             description: |

--- a/go/apps/api/openapi/spec/paths/chproxy/metrics/index.yaml
+++ b/go/apps/api/openapi/spec/paths/chproxy/metrics/index.yaml
@@ -1,5 +1,5 @@
 post:
-  x-speakeasy-ignore: "true"
+  x-speakeasy-ignore: true
   x-excluded: true
   tags:
     - chproxy

--- a/go/apps/api/openapi/spec/paths/chproxy/ratelimits/index.yaml
+++ b/go/apps/api/openapi/spec/paths/chproxy/ratelimits/index.yaml
@@ -1,5 +1,5 @@
 post:
-  x-speakeasy-ignore: "true"
+  x-speakeasy-ignore: true
   x-excluded: true
   tags:
     - chproxy

--- a/go/apps/api/openapi/spec/paths/chproxy/verifications/index.yaml
+++ b/go/apps/api/openapi/spec/paths/chproxy/verifications/index.yaml
@@ -1,5 +1,5 @@
 post:
-  x-speakeasy-ignore: "true"
+  x-speakeasy-ignore: true
   x-excluded: true
   tags:
     - chproxy

--- a/go/apps/api/openapi/spec/paths/v2/liveness/index.yaml
+++ b/go/apps/api/openapi/spec/paths/v2/liveness/index.yaml
@@ -1,5 +1,5 @@
 get:
-  x-speakeasy-ignore: "true"
+  x-speakeasy-ignore: true
   x-excluded: true
   tags:
     - liveness


### PR DESCRIPTION
## What does this PR do?

Removes unnecessary quotes around boolean values in the `x-speakeasy-ignore` property across multiple OpenAPI specification files. This change standardizes the format of boolean values in the API specification by changing `"true"` to `true`.

Fixes # (issue)

## Type of change

- [x] Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

- Verify that the OpenAPI spec still validates correctly
- Ensure that the Speakeasy SDK generation works as expected with the updated format

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Merged the latest changes from main onto my branch with `git pull origin main`