### PR TITLE
remove regex for permissions

### DIFF
--- a/go/apps/api/openapi/spec/paths/v2/keys/verifyKey/V2KeysVerifyKeyRequestBody.yaml
+++ b/go/apps/api/openapi/spec/paths/v2/keys/verifyKey/V2KeysVerifyKeyRequestBody.yaml
@@ -47,8 +47,7 @@ properties:
   permissions:
     type: string
     minLength: 1
-    maxLength: 1000 # Allow for complex permission queries
-    pattern: "^[a-zA-Z0-9_.()\\s-]+$"
+    maxLength: 1000
     description: |
       Checks if the key has the specified permission(s) using a query syntax.
       Supports single permissions, logical operators (AND, OR), and parentheses for grouping.


### PR DESCRIPTION
## What does this PR do?

Removes regex pattern for the permissions. 

It didnt match `v1.leaderboard.getAccountLeaderboard OR api.*` which should be a valid permission query as we allow thoe permission names.

The permission parser itself takes care of making sure this is a valid query anyways.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [] Chore (refactoring code, technical debt, workflow improvements)
- [] Enhancement (small improvements)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Test A
- Test B

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary
