### PR TITLE
fix: do not use the name as environment

### DIFF
--- a/apps/dashboard/app/(app)/apis/[apiId]/_components/create-key/create-key.utils.ts
+++ b/apps/dashboard/app/(app)/apis/[apiId]/_components/create-key/create-key.utils.ts
@@ -23,7 +23,7 @@ export const formValuesToApiInput = (formValues: FormValues, keyAuthId: string):
     identityId: formValues.identityId || null,
     name: formValues.name === "" ? undefined : formValues.name,
     enabled: true,
-    environment: formValues.environment === "" ? undefined : formValues.name,
+    environment: formValues.environment === "" ? undefined : formValues.environment,
     meta:
       formValues.metadata?.enabled && formValues.metadata.data
         ? JSON.parse(formValues.metadata.data)


### PR DESCRIPTION
## What does this PR do?

Fixes a bug in the API key creation form where the environment value was incorrectly being set to the name value instead of empty.

Fixes #(issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Create a new API key with an environment value
- Verify that the environment value is correctly saved and not overwritten with the name value

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the assignment of the environment field to ensure it accurately reflects the selected form value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->