### PR TITLE
chore: use larger batches

### DIFF
--- a/go/pkg/clickhouse/client.go
+++ b/go/pkg/clickhouse/client.go
@@ -98,8 +98,8 @@ func New(config Config) (*clickhouse, error) {
 		requests: batch.New(batch.Config[schema.ApiRequestV1]{
 			Name:          "api_requests",
 			Drop:          true,
-			BatchSize:     10000,
-			BufferSize:    100000,
+			BatchSize:     50_000,
+			BufferSize:    200_000,
 			FlushInterval: 5 * time.Second,
 			Consumers:     2,
 			Flush: func(ctx context.Context, rows []schema.ApiRequestV1) {
@@ -117,8 +117,8 @@ func New(config Config) (*clickhouse, error) {
 			batch.Config[schema.KeyVerificationRequestV1]{
 				Name:          "key_verifications",
 				Drop:          true,
-				BatchSize:     10000,
-				BufferSize:    100000,
+				BatchSize:     50_000,
+				BufferSize:    200_000,
 				FlushInterval: 5 * time.Second,
 				Consumers:     2,
 				Flush: func(ctx context.Context, rows []schema.KeyVerificationRequestV1) {
@@ -136,8 +136,8 @@ func New(config Config) (*clickhouse, error) {
 			batch.Config[schema.RatelimitRequestV1]{
 				Name:          "ratelimits",
 				Drop:          true,
-				BatchSize:     10000,
-				BufferSize:    100000,
+				BatchSize:     50_000,
+				BufferSize:    200_000,
 				FlushInterval: 5 * time.Second,
 				Consumers:     2,
 				Flush: func(ctx context.Context, rows []schema.RatelimitRequestV1) {


### PR DESCRIPTION
## What does this PR do?

Increases the batch size and buffer size for ClickHouse clients to improve data processing efficiency. The PR updates the configuration for three batch processors:
- `api_requests`: Increases batch size from 10,000 to 50,000 and buffer size from 100,000 to 200,000
- `key_verifications`: Increases batch size from 10,000 to 50,000 and buffer size from 100,000 to 200,000
- `ratelimits`: Increases batch size from 10,000 to 50,000 and buffer size from 100,000 to 200,000

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [x] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Monitor ClickHouse performance metrics after deployment to ensure the increased batch and buffer sizes improve throughput
- Verify that no data loss occurs during high-load scenarios
- Check that memory usage remains within acceptable limits with the increased buffer sizes

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues