### PR TITLE
chore: utility script to move environments to meta

### DIFF
--- a/tools/migrate/environment-migrate.ts
+++ b/tools/migrate/environment-migrate.ts
@@ -1,0 +1,56 @@
+import { eq, mysqlDrizzle, schema } from "@unkey/db";
+import mysql from "mysql2/promise";
+
+async function main() {
+  const conn = await mysql.createConnection(
+    `mysql://${process.env.DATABASE_USERNAME}:${process.env.DATABASE_PASSWORD}@${process.env.DATABASE_HOST}:3306/unkey?ssl={} `,
+  );
+
+  await conn.ping();
+  const db = mysqlDrizzle(conn, { schema, mode: "default" });
+
+  let cursor = "";
+  do {
+    const keys = await db.query.keys.findMany({
+      where: (table, { isNotNull, gt, eq, and }) =>
+        and(
+          gt(table.id, cursor),
+          eq(table.workspaceId, "ws_39g5eLLQTX8bVdbsGK9Dke"),
+          isNotNull(table.environment),
+        ),
+      limit: 1000,
+      orderBy: (table, { asc }) => asc(table.id),
+    });
+
+    cursor = keys.at(-1)?.id ?? "";
+    console.info({ cursor, keys: keys.length });
+
+    if (keys.length === 0) {
+      break;
+    }
+
+    for (const key of keys) {
+      if (!key.environment) {
+        continue;
+      }
+
+      console.log(JSON.stringify(key));
+
+      const meta = key.meta ? JSON.parse(key.meta) : {};
+      if (meta.environment) {
+        console.error(`Key ${key.id} has environment ${meta.environment}`);
+        continue;
+      }
+
+      meta.environment = key.environment;
+
+      const newMeta = JSON.stringify(meta);
+
+      await db.update(schema.keys).set({ meta: newMeta }).where(eq(schema.keys.id, key.id));
+    }
+  } while (cursor);
+  await conn.end();
+  console.info("Migration completed. Keys Changed");
+}
+
+main();


### PR DESCRIPTION
## What does this PR do?

This PR adds a migration script to move environment data from the `environment` field to the `meta.environment` field for keys in a specific workspace. The script:

1. Connects to the MySQL database
2. Queries keys in batches of 1000 from workspace "ws_39g5eLLQTX8bVdbsGK9Dke" that have an environment value
3. For each key, checks if meta.environment already exists
4. If not, adds the environment value to the meta JSON object
5. Updates the key record with the new meta data

Fixes # (issue)

## Type of change

- [x] Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

- Run the migration script against a test database to verify it correctly moves environment data to meta.environment
- Verify that keys in the specified workspace have their environment values properly migrated to meta.environment
- Check that no data is lost during the migration process

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues