### PR TITLE
fix: tx traces

### DIFF
--- a/go/pkg/db/interface.go
+++ b/go/pkg/db/interface.go
@@ -32,3 +32,11 @@ type DBTX interface {
 	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
 	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
 }
+
+// DBTx represents a database transaction with commit and rollback capabilities.
+// It extends DBTX with transaction-specific methods.
+type DBTx interface {
+	DBTX
+	Commit() error
+	Rollback() error
+}

--- a/go/pkg/db/replica.go
+++ b/go/pkg/db/replica.go
@@ -151,9 +151,5 @@ func (r *Replica) Begin(ctx context.Context) (DBTx, error) {
 	}
 
 	// Wrap the transaction with tracing
-	return &TracedTx{
-		tx:   tx,
-		mode: r.mode + "_tx",
-		ctx:  ctx,
-	}, nil
+	return WrapTxWithContext(tx, r.mode+"_tx", ctx), nil
 }

--- a/go/pkg/db/replica.go
+++ b/go/pkg/db/replica.go
@@ -127,7 +127,7 @@ func (r *Replica) QueryRowContext(ctx context.Context, query string, args ...int
 
 // Begin starts a transaction and returns it.
 // This method provides a way to use the Replica in transaction-based operations.
-func (r *Replica) Begin(ctx context.Context) (*sql.Tx, error) {
+func (r *Replica) Begin(ctx context.Context) (DBTx, error) {
 	ctx, span := tracing.Start(ctx, "Begin")
 	defer span.End()
 	span.SetAttributes(attribute.String("mode", r.mode))
@@ -146,5 +146,14 @@ func (r *Replica) Begin(ctx context.Context) (*sql.Tx, error) {
 	metrics.DatabaseOperationsLatency.WithLabelValues(r.mode, "begin", status).Observe(duration)
 	metrics.DatabaseOperationsTotal.WithLabelValues(r.mode, "begin", status).Inc()
 
-	return tx, err
+	if err != nil {
+		return nil, err
+	}
+
+	// Wrap the transaction with tracing
+	return &TracedTx{
+		tx:   tx,
+		mode: r.mode + "_tx",
+		ctx:  ctx,
+	}, nil
 }

--- a/go/pkg/db/traced_tx.go
+++ b/go/pkg/db/traced_tx.go
@@ -1,0 +1,174 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/unkeyed/unkey/go/pkg/otel/tracing"
+	"github.com/unkeyed/unkey/go/pkg/prometheus/metrics"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+// WrapTx wraps a standard sql.Tx with our DBTx interface for tracing
+func WrapTx(tx *sql.Tx, mode string) DBTx {
+	return &TracedTx{
+		tx:   tx,
+		mode: mode,
+		ctx:  context.Background(),
+	}
+}
+
+// WrapTxWithContext wraps a standard sql.Tx with our DBTx interface for tracing, using the provided context
+func WrapTxWithContext(tx *sql.Tx, mode string, ctx context.Context) DBTx {
+	return &TracedTx{
+		tx:   tx,
+		mode: mode,
+		ctx:  ctx,
+	}
+}
+
+// TracedTx wraps a sql.Tx to add tracing to all database operations within a transaction
+type TracedTx struct {
+	tx   *sql.Tx
+	mode string
+	ctx  context.Context // Store the context for commit/rollback tracing
+}
+
+// Ensure TracedTx implements the DBTx interface
+var _ DBTx = (*TracedTx)(nil)
+
+// ExecContext executes a SQL statement within the transaction with tracing
+func (t *TracedTx) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
+	ctx, span := tracing.Start(ctx, "Tx.ExecContext")
+	defer span.End()
+	span.SetAttributes(
+		attribute.String("mode", t.mode),
+		attribute.String("query", query),
+	)
+
+	start := time.Now()
+	result, err := t.tx.ExecContext(ctx, query, args...)
+
+	duration := time.Since(start).Seconds()
+	status := "success"
+	if err != nil {
+		status = "error"
+	}
+
+	metrics.DatabaseOperationsLatency.WithLabelValues(t.mode, "exec", status).Observe(duration)
+	metrics.DatabaseOperationsTotal.WithLabelValues(t.mode, "exec", status).Inc()
+
+	return result, err
+}
+
+// PrepareContext prepares a SQL statement within the transaction with tracing
+func (t *TracedTx) PrepareContext(ctx context.Context, query string) (*sql.Stmt, error) {
+	ctx, span := tracing.Start(ctx, "Tx.PrepareContext")
+	defer span.End()
+	span.SetAttributes(
+		attribute.String("mode", t.mode),
+		attribute.String("query", query),
+	)
+
+	start := time.Now()
+	stmt, err := t.tx.PrepareContext(ctx, query)
+
+	duration := time.Since(start).Seconds()
+	status := "success"
+	if err != nil {
+		status = "error"
+	}
+
+	metrics.DatabaseOperationsLatency.WithLabelValues(t.mode, "prepare", status).Observe(duration)
+	metrics.DatabaseOperationsTotal.WithLabelValues(t.mode, "prepare", status).Inc()
+
+	return stmt, err
+}
+
+// QueryContext executes a SQL query within the transaction with tracing
+func (t *TracedTx) QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error) {
+	ctx, span := tracing.Start(ctx, "Tx.QueryContext")
+	defer span.End()
+	span.SetAttributes(
+		attribute.String("mode", t.mode),
+		attribute.String("query", query),
+	)
+
+	start := time.Now()
+	rows, err := t.tx.QueryContext(ctx, query, args...)
+
+	duration := time.Since(start).Seconds()
+	status := "success"
+	if err != nil {
+		status = "error"
+	}
+
+	metrics.DatabaseOperationsLatency.WithLabelValues(t.mode, "query", status).Observe(duration)
+	metrics.DatabaseOperationsTotal.WithLabelValues(t.mode, "query", status).Inc()
+
+	return rows, err
+}
+
+// QueryRowContext executes a SQL query that returns a single row within the transaction with tracing
+func (t *TracedTx) QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row {
+	ctx, span := tracing.Start(ctx, "Tx.QueryRowContext")
+	defer span.End()
+	span.SetAttributes(
+		attribute.String("mode", t.mode),
+		attribute.String("query", query),
+	)
+
+	start := time.Now()
+	row := t.tx.QueryRowContext(ctx, query, args...)
+
+	duration := time.Since(start).Seconds()
+	status := "success"
+
+	metrics.DatabaseOperationsLatency.WithLabelValues(t.mode, "query_row", status).Observe(duration)
+	metrics.DatabaseOperationsTotal.WithLabelValues(t.mode, "query_row", status).Inc()
+
+	return row
+}
+
+// Commit commits the transaction with tracing
+func (t *TracedTx) Commit() error {
+	_, span := tracing.Start(t.ctx, "Tx.Commit")
+	defer span.End()
+	span.SetAttributes(attribute.String("mode", t.mode))
+
+	start := time.Now()
+	err := t.tx.Commit()
+
+	duration := time.Since(start).Seconds()
+	status := "success"
+	if err != nil {
+		status = "error"
+	}
+
+	metrics.DatabaseOperationsLatency.WithLabelValues(t.mode, "commit", status).Observe(duration)
+	metrics.DatabaseOperationsTotal.WithLabelValues(t.mode, "commit", status).Inc()
+
+	return err
+}
+
+// Rollback rolls back the transaction with tracing
+func (t *TracedTx) Rollback() error {
+	_, span := tracing.Start(t.ctx, "Tx.Rollback")
+	defer span.End()
+	span.SetAttributes(attribute.String("mode", t.mode))
+
+	start := time.Now()
+	err := t.tx.Rollback()
+
+	duration := time.Since(start).Seconds()
+	status := "success"
+	if err != nil {
+		status = "error"
+	}
+
+	metrics.DatabaseOperationsLatency.WithLabelValues(t.mode, "rollback", status).Observe(duration)
+	metrics.DatabaseOperationsTotal.WithLabelValues(t.mode, "rollback", status).Inc()
+
+	return err
+}

--- a/go/pkg/db/traced_tx.go
+++ b/go/pkg/db/traced_tx.go
@@ -10,15 +10,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 )
 
-// WrapTx wraps a standard sql.Tx with our DBTx interface for tracing
-func WrapTx(tx *sql.Tx, mode string) DBTx {
-	return &TracedTx{
-		tx:   tx,
-		mode: mode,
-		ctx:  context.Background(),
-	}
-}
-
 // WrapTxWithContext wraps a standard sql.Tx with our DBTx interface for tracing, using the provided context
 func WrapTxWithContext(tx *sql.Tx, mode string, ctx context.Context) DBTx {
 	return &TracedTx{
@@ -83,7 +74,7 @@ func (t *TracedTx) PrepareContext(ctx context.Context, query string) (*sql.Stmt,
 	metrics.DatabaseOperationsLatency.WithLabelValues(t.mode, "prepare", status).Observe(duration)
 	metrics.DatabaseOperationsTotal.WithLabelValues(t.mode, "prepare", status).Inc()
 
-	return stmt, err
+	return stmt, err // nolint:sqlclosecheck
 }
 
 // QueryContext executes a SQL query within the transaction with tracing
@@ -107,7 +98,7 @@ func (t *TracedTx) QueryContext(ctx context.Context, query string, args ...inter
 	metrics.DatabaseOperationsLatency.WithLabelValues(t.mode, "query", status).Observe(duration)
 	metrics.DatabaseOperationsTotal.WithLabelValues(t.mode, "query", status).Inc()
 
-	return rows, err
+	return rows, err // nolint:sqlclosecheck
 }
 
 // QueryRowContext executes a SQL query that returns a single row within the transaction with tracing

--- a/go/pkg/db/tx.go
+++ b/go/pkg/db/tx.go
@@ -146,7 +146,7 @@ func TxWithResult[T any](ctx context.Context, db *Replica, fn func(context.Conte
 	return t, nil
 }
 
-// Tx executes fn within a database transaction without returning a result.
+// TxWithoutResult executes fn within a database transaction without returning a result.
 // It is a convenience wrapper around [TxWithResult] for operations that
 // only need error handling.
 //
@@ -193,9 +193,14 @@ func TxWithResult[T any](ctx context.Context, db *Replica, fn func(context.Conte
 //
 // See [TxWithResult] for detailed transaction behavior and [DBTX] for
 // available database operations.
-func Tx(ctx context.Context, db *Replica, fn func(context.Context, DBTX) error) error {
+func TxWithoutResult(ctx context.Context, db *Replica, fn func(context.Context, DBTX) error) error {
 	_, err := TxWithResult(ctx, db, func(inner context.Context, tx DBTX) (any, error) {
 		return nil, fn(inner, tx)
 	})
 	return err
+}
+
+// Tx is an alias for TxWithoutResult for backward compatibility
+func Tx(ctx context.Context, db *Replica, fn func(context.Context, DBTX) error) error {
+	return TxWithoutResult(ctx, db, fn)
 }

--- a/go/pkg/db/tx.go
+++ b/go/pkg/db/tx.go
@@ -146,7 +146,7 @@ func TxWithResult[T any](ctx context.Context, db *Replica, fn func(context.Conte
 	return t, nil
 }
 
-// TxWithoutResult executes fn within a database transaction without returning a result.
+// Tx executes fn within a database transaction without returning a result.
 // It is a convenience wrapper around [TxWithResult] for operations that
 // only need error handling.
 //
@@ -193,14 +193,9 @@ func TxWithResult[T any](ctx context.Context, db *Replica, fn func(context.Conte
 //
 // See [TxWithResult] for detailed transaction behavior and [DBTX] for
 // available database operations.
-func TxWithoutResult(ctx context.Context, db *Replica, fn func(context.Context, DBTX) error) error {
+func Tx(ctx context.Context, db *Replica, fn func(context.Context, DBTX) error) error {
 	_, err := TxWithResult(ctx, db, func(inner context.Context, tx DBTX) (any, error) {
 		return nil, fn(inner, tx)
 	})
 	return err
-}
-
-// Tx is an alias for TxWithoutResult for backward compatibility
-func Tx(ctx context.Context, db *Replica, fn func(context.Context, DBTX) error) error {
-	return TxWithoutResult(ctx, db, fn)
 }


### PR DESCRIPTION
## What does this PR do?

Fixes our databse transaction not being spanned 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [X] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

1. go into go dir
2. Set `OTEL_EXPORTER_OTLP_ENDPOINT` `export OTEL_EXPORTER_OTLP_ENDPOINT="http://127.0.0.1:4318"` for this to work please ensure the otel container from the deployment/docker-compose is running.
4. build unkey and run with always sampling `make build  && ./unkey run api --color=true --http-port="7070" --region="test" --otel-trace-sampling-rate=1.0 --otel=true --`
5. Call endpoint which uses a transaction e.g createKey
6. Check otel it should show all traces from any transaction 

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transaction-level tracing and Prometheus metrics for all DB transaction operations, providing per-operation spans and telemetry.

* **Improvements**
  * Unified, interface-based transaction handling across the app for consistent behavior.
  * Clearer error propagation when starting transactions, improving failure reporting and observability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->