### PR TITLE
fix: wrong workspace for perms

### DIFF
--- a/apps/dashboard/lib/trpc/routers/key/updateRootKeyPermissions.ts
+++ b/apps/dashboard/lib/trpc/routers/key/updateRootKeyPermissions.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
 import { requireUser, requireWorkspace, t } from "../../trpc";
 
 import { insertAuditLogs } from "@/lib/audit";
+import { env } from "@/lib/env";
 import { upsertPermissions } from "../rbac";
 
 /**
@@ -70,7 +71,7 @@ export const updateRootKeyPermissions = t.procedure
 
         // Upsert new permissions
         const { permissions: upsertedPermissions, auditLogs: createPermissionLogs } =
-          await upsertPermissions(ctx, ctx.workspace.id, input.permissions);
+          await upsertPermissions(ctx, env().UNKEY_WORKSPACE_ID, input.permissions);
 
         auditLogs.push(...createPermissionLogs);
 


### PR DESCRIPTION
## What does this PR do?

When creating new permissions for root keys we need to use the unkey workspace ID and not the users workspace ID

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

Create new permissions e.g api.api_123.verify_key and check if they are created in the ws_local_root workspace 
Then update the root key to add new permissions that have to be created first and check that they also get created there too.

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary
