### PR TITLE
fix: missing workspace id in query

### DIFF
--- a/apps/api/src/routes/v1_analytics_getVerifications.ts
+++ b/apps/api/src/routes/v1_analytics_getVerifications.ts
@@ -355,13 +355,13 @@ STEP INTERVAL 1 MONTH`,
     if (filters.externalId) {
       const { val: identity, err: getIdentityError } = await cache.identityByExternalId.swr(
         `${auth.authorizedWorkspaceId}:${filters.externalId}`,
-        async (externalId: string) => {
+        async () => {
           return (
             (await db.readonly.query.identities.findFirst({
               where: (table, { and, eq }) =>
                 and(
                   eq(table.workspaceId, auth.authorizedWorkspaceId),
-                  eq(table.externalId, externalId),
+                  eq(table.externalId, filters.externalId!),
                 ),
             })) ?? null
           );

--- a/apps/api/src/routes/v1_analytics_getVerifications.ts
+++ b/apps/api/src/routes/v1_analytics_getVerifications.ts
@@ -358,7 +358,11 @@ STEP INTERVAL 1 MONTH`,
         async (externalId: string) => {
           return (
             (await db.readonly.query.identities.findFirst({
-              where: (table, { eq }) => eq(table.externalId, externalId),
+              where: (table, { and, eq }) =>
+                and(
+                  eq(table.workspaceId, auth.authorizedWorkspaceId),
+                  eq(table.externalId, externalId),
+                ),
             })) ?? null
           );
         },

--- a/apps/api/src/routes/v1_analytics_getVerifications.ts
+++ b/apps/api/src/routes/v1_analytics_getVerifications.ts
@@ -354,7 +354,7 @@ STEP INTERVAL 1 MONTH`,
 
     if (filters.externalId) {
       const { val: identity, err: getIdentityError } = await cache.identityByExternalId.swr(
-        filters.externalId,
+        `${auth.authorizedWorkspaceId}:${filters.externalId}`,
         async (externalId: string) => {
           return (
             (await db.readonly.query.identities.findFirst({

--- a/apps/api/src/routes/v1_apis_listKeys.ts
+++ b/apps/api/src/routes/v1_apis_listKeys.ts
@@ -140,7 +140,7 @@ export const registerV1ApisListKeys = (app: App) =>
 
     let identity: Identity | undefined = undefined;
     if (externalId) {
-      const { val, err } = await cache.identityByExternalId.swr(externalId, async () => {
+      const { val, err } = await cache.identityByExternalId.swr(`${auth.authorizedWorkspaceId}:${externalId}`, async () => {
         return db.readonly.query.identities.findFirst({
           where: (table, { and, eq }) =>
             and(

--- a/apps/api/src/routes/v1_migrations_createKey.ts
+++ b/apps/api/src/routes/v1_migrations_createKey.ts
@@ -422,7 +422,7 @@ export const registerV1MigrationsCreateKeys = (app: App) =>
         let identityId: string | null = null;
         if (key.externalId) {
           const identity = await cache.identityByExternalId.swr(
-            key.externalId,
+            `${authorizedWorkspaceId}:${key.externalId}`,
             async (externalId) => {
               return await db.readonly.query.identities.findFirst({
                 where: (table, { eq, and }) =>

--- a/apps/api/src/routes/v1_migrations_createKey.ts
+++ b/apps/api/src/routes/v1_migrations_createKey.ts
@@ -423,12 +423,12 @@ export const registerV1MigrationsCreateKeys = (app: App) =>
         if (key.externalId) {
           const identity = await cache.identityByExternalId.swr(
             `${authorizedWorkspaceId}:${key.externalId}`,
-            async (externalId) => {
+            async () => {
               return await db.readonly.query.identities.findFirst({
                 where: (table, { eq, and }) =>
                   and(
                     eq(table.workspaceId, authorizedWorkspaceId),
-                    eq(table.externalId, externalId),
+                    eq(table.externalId, key.externalId!),
                   ),
               });
             },


### PR DESCRIPTION
## What does this PR do?

Fixes a planetscale insight where we are only querying with the externalid which is not indexed so its slow.

Instead we are now searching with the rootKeys workspaceid.

I also adjusted the cache keys to be scoped to the workspace.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

Run the tests.

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary
