### PR TITLE
fix: update keys to allow 16

### DIFF
--- a/apps/dashboard/app/(app)/apis/[apiId]/_components/create-key/components/general-setup.tsx
+++ b/apps/dashboard/app/(app)/apis/[apiId]/_components/create-key/components/general-setup.tsx
@@ -29,7 +29,7 @@ export const GeneralSetup = () => {
         className="[&_input:first-of-type]:h-[36px]"
         label="Prefix"
         placeholder="Enter prefix"
-        maxLength={8}
+        maxLength={16}
         description="Prefix to distinguish between different APIs (we'll add the underscore)."
         error={errors.prefix?.message}
         optional

--- a/apps/dashboard/app/(app)/apis/[apiId]/_components/create-key/create-key.schema.ts
+++ b/apps/dashboard/app/(app)/apis/[apiId]/_components/create-key/create-key.schema.ts
@@ -25,7 +25,7 @@ export const createConditionalSchema = <
 // Basic schemas
 export const keyPrefixSchema = z
   .string()
-  .max(8, { message: "Prefixes cannot be longer than 8 characters" })
+  .max(16, { message: "Prefixes cannot be longer than 16 characters" })
   .trim()
   .refine((prefix) => !prefix.includes(" "), {
     message: "Prefixes cannot contain spaces",

--- a/apps/dashboard/lib/zod-helper.ts
+++ b/apps/dashboard/lib/zod-helper.ts
@@ -9,7 +9,7 @@ export const formSchema = z.object({
   }),
   prefix: z
     .string()
-    .max(8, { message: "Please limit the prefix to under 8 characters." })
+    .max(16, { message: "Please limit the prefix to under 16 characters." })
     .optional(),
   ownerId: z.string().optional(),
   name: z.string().optional(),


### PR DESCRIPTION
## What does this PR do?

Allows 16 characters in the UI to match the API

Fixes #3839 

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Create a key and make sure you can create one with 16 length.

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [X] Filled out the "How to test" section in this PR
- [X] Read [Contributing Guide](./CONTRIBUTING.md)
- [X] Self-reviewed my own code
- [X] Commented on my code in hard-to-understand areas
- [X] Ran `pnpm build`
- [X] Ran `pnpm fmt`
- [X] Checked for warnings, there are none
- [X] Removed all `console.logs`
- [X] Merged the latest changes from main onto my branch with `git pull origin main`
- [X] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased maximum API key prefix length from 8 to 16 characters in the create-key flow.
  * Updated form validation and error messages to reflect the new limit.
  * Adjusted input field constraints to accept longer prefixes.
  * Ensured consistent enforcement of the 16-character limit across the create-key UI and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->