### PR TITLE
fix: handle non-Date expiration values in dialog reopening

### DIFF
--- a/apps/dashboard/app/(app)/apis/[apiId]/_components/create-key/components/expiration-setup.tsx
+++ b/apps/dashboard/app/(app)/apis/[apiId]/_components/create-key/components/expiration-setup.tsx
@@ -115,12 +115,15 @@ export const ExpirationSetup = ({
   };
 
   const getInitialTimeValues = () => {
-    // If we have a current expiry date, use it, otherwise use minimum valid date
-    const initialDate = currentExpiryDate || minValidDate;
+    // Safely convert currentExpiryDate to Date object, fallback to minValidDate
+    const initialDate = currentExpiryDate ? new Date(currentExpiryDate) : minValidDate;
+
+    // If conversion failed, use minValidDate
+    const safeInitialDate = Number.isNaN(initialDate.getTime()) ? minValidDate : initialDate;
 
     return {
-      startTime: initialDate.getTime(),
-      endTime: undefined, // Not needed for single date mode
+      startTime: safeInitialDate.getTime(),
+      endTime: undefined,
       since: undefined,
     };
   };


### PR DESCRIPTION
## What does this PR do?

- Convert currentExpiryDate to proper Date object before calling getTime()
- Add fallback to minValidDate when Date conversion fails
- Prevents TypeError when dialog is opened/closed/reopened for same key
- Handles cases where form serialization converts Date to string/timestamp

Fixes issue where reopening expiration dialog would crash with: "TypeError: initialDate.getTime is not a function"

Fixes #3787 

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Create a key and add expiration 
- Open Edit expiration and close and reopen the dialog a few times.

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [X] Filled out the "How to test" section in this PR
- [X] Read [Contributing Guide](./CONTRIBUTING.md)
- [X] Self-reviewed my own code
- [X] Commented on my code in hard-to-understand areas
- [X] Ran `pnpm build`
- [X] Ran `pnpm fmt`
- [X] Checked for warnings, there are none
- [X] Removed all `console.logs`
- [X] Merged the latest changes from main onto my branch with `git pull origin main`
- [X] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary
