### PR TITLE
fix: Pentest remediation  

### DIFF
--- a/apps/dashboard/lib/trpc/routers/org/getInvitationList.ts
+++ b/apps/dashboard/lib/trpc/routers/org/getInvitationList.ts
@@ -7,8 +7,14 @@ export const getInvitationList = t.procedure
   .use(requireUser)
   .use(requireOrgAdmin)
   .input(z.string())
-  .query(async ({ input: orgId }) => {
+  .query(async ({ ctx, input: orgId }) => {
     try {
+      if (orgId !== ctx.workspace?.orgId) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Invalid organization ID",
+        });
+      }
       return await authProvider.getInvitationList(orgId);
     } catch (error) {
       console.error("Error retrieving organization member list:", error);

--- a/apps/dashboard/lib/trpc/routers/org/inviteMember.ts
+++ b/apps/dashboard/lib/trpc/routers/org/inviteMember.ts
@@ -13,8 +13,14 @@ export const inviteMember = t.procedure
       role: z.enum(["basic_member", "admin"]),
     }),
   )
-  .mutation(async ({ input }) => {
+  .mutation(async ({ ctx, input }) => {
     try {
+      if (input.orgId !== ctx.workspace?.orgId) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Invalid organization ID",
+        });
+      }
       return await authProvider.inviteMember({
         email: input.email,
         role: input.role,

--- a/apps/dashboard/lib/trpc/routers/org/removeMembership.ts
+++ b/apps/dashboard/lib/trpc/routers/org/removeMembership.ts
@@ -12,8 +12,14 @@ export const removeMembership = t.procedure
       orgId: z.string(), // needed for the requireOrgAdmin middleware
     }),
   )
-  .mutation(async ({ input }) => {
+  .mutation(async ({ ctx, input }) => {
     try {
+      if (input.orgId !== ctx.workspace?.orgId) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Invalid organization ID",
+        });
+      }
       return await authProvider.removeMembership(input.membershipId);
     } catch (error) {
       throw new TRPCError({

--- a/apps/dashboard/lib/trpc/routers/org/revokeInvitation.ts
+++ b/apps/dashboard/lib/trpc/routers/org/revokeInvitation.ts
@@ -12,8 +12,14 @@ export const revokeInvitation = t.procedure
       orgId: z.string(), // needed for the requireOrgAdmin middleware
     }),
   )
-  .mutation(async ({ input }) => {
+  .mutation(async ({ ctx, input }) => {
     try {
+      if (input.orgId !== ctx.workspace?.orgId) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Invalid organization ID",
+        });
+      }
       return await authProvider.revokeOrgInvitation(input.invitationId);
     } catch (error) {
       throw new TRPCError({

--- a/apps/dashboard/lib/trpc/routers/org/updateMembership.ts
+++ b/apps/dashboard/lib/trpc/routers/org/updateMembership.ts
@@ -13,8 +13,14 @@ export const updateMembership = t.procedure
       role: z.string(),
     }),
   )
-  .mutation(async ({ input }) => {
+  .mutation(async ({ ctx, input }) => {
     try {
+      if (input.orgId !== ctx.workspace?.orgId) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Invalid organization ID",
+        });
+      }
       return await authProvider.updateMembership({
         membershipId: input.membershipId,
         role: input.role,

--- a/apps/dashboard/lib/trpc/routers/workspace/changeName.ts
+++ b/apps/dashboard/lib/trpc/routers/workspace/changeName.ts
@@ -17,6 +17,12 @@ export const changeWorkspaceName = t.procedure
     }),
   )
   .mutation(async ({ ctx, input }) => {
+    if (input.workspaceId !== ctx.workspace.id) {
+      throw new TRPCError({
+        code: "BAD_REQUEST",
+        message: "Invalid workspace ID",
+      });
+    }
     await db
       .transaction(async (tx) => {
         await tx

--- a/apps/dashboard/next.config.js
+++ b/apps/dashboard/next.config.js
@@ -13,6 +13,7 @@ const nextConfig = {
   experimental: {
     esmExternals: "loose",
   },
+  poweredByHeader: false,
   webpack: (config) => {
     config.cache = Object.freeze({
       type: "memory",


### PR DESCRIPTION
Adds CRUD checks to certain tRPC routes to make sure the current user is able to do the action.

## What does this PR do?

During a pen test, we found a couple items where if a user was smart enough to figure out the 1E18 combination for an organization they could potentially update a different org. 

This addresses:

1. Workspace name updates
2. Invites to orgs
3. Revoking invites
4. Updating roles.
5. Removes powered by Next.js


Fixes # (issue)

*If there is not an issue for this, please create one first. This is used to tracking purposes and also helps use understand why this PR exists*

<!-- If there isn't an issue for this PR, please re-review our Contributing Guide and create an issue -->

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Try updating a workspace name that you know the ws_id of by using the network payload
- Try inviting a new member to a team you know the org_id of by using the network payload
- Try revoking an invite to an org you aren't logged into but know the org_id
- Try upgrading to an admin without knowing the org_id
- Look for the powered by header

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [X] Filled out the "How to test" section in this PR
- [X] Read [Contributing Guide](./CONTRIBUTING.md)
- [X] Self-reviewed my own code
- [X] Commented on my code in hard-to-understand areas
- [X] Ran `pnpm build`
- [X] Ran `pnpm fmt`
- [X] Checked for warnings, there are none
- [X] Removed all `console.logs`
- [X] Merged the latest changes from main onto my branch with `git pull origin main`
- [X] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary
