### PR TITLE
fix: use same prefix as api

### DIFF
--- a/apps/dashboard/app/(app)/apis/[apiId]/_components/create-key/create-key.schema.ts
+++ b/apps/dashboard/app/(app)/apis/[apiId]/_components/create-key/create-key.schema.ts
@@ -32,9 +32,9 @@ export const keyPrefixSchema = z
   })
   .refine(
     (val) => {
-      return !val || /^[a-zA-Z0-9]/.test(val);
+      return !val || /^[a-zA-Z0-9_]+$/.test(val);
     },
-    { message: "Prefix must start with a letter or number" },
+    { message: "Prefix can only contain letters, numbers, and underscores" },
   )
   .optional();
 


### PR DESCRIPTION
## What does this PR do?

This updates the frontend to use the same regex as the api when creating keys, so people can't use different prefixes in one or the other.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened key prefix validation to allow only letters, numbers, and underscores, preventing unsupported characters.
  * Updated error message to clearly describe allowed characters.
  * Existing checks (trimming, no spaces, max length) remain enforced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->