### PR TITLE
feat: implement environment-aware cookie security

### DIFF
--- a/apps/dashboard/app/(app)/api/auth/refresh/route.ts
+++ b/apps/dashboard/app/(app)/api/auth/refresh/route.ts
@@ -1,3 +1,4 @@
+import { shouldUseSecureCookies } from "@/lib/auth/cookie-security";
 import { setCookie } from "@/lib/auth/cookies";
 import { auth } from "@/lib/auth/server";
 import { UNKEY_SESSION_COOKIE } from "@/lib/auth/types";
@@ -19,7 +20,7 @@ export async function POST(request: Request) {
       value: newToken,
       options: {
         httpOnly: true,
-        secure: true,
+        secure: shouldUseSecureCookies(),
         sameSite: "lax",
         path: "/",
         maxAge: Math.floor((expiresAt.getTime() - Date.now()) / 1000), // Convert to seconds

--- a/apps/dashboard/app/new/hooks/use-workspace-step.tsx
+++ b/apps/dashboard/app/new/hooks/use-workspace-step.tsx
@@ -1,3 +1,4 @@
+import { shouldUseSecureCookies } from "@/lib/auth/cookie-security";
 import { setCookie } from "@/lib/auth/cookies";
 import { UNKEY_SESSION_COOKIE } from "@/lib/auth/types";
 import { trpc } from "@/lib/trpc/client";
@@ -53,7 +54,7 @@ export const useWorkspaceStep = (): OnboardingStep => {
         value: sessionData.token,
         options: {
           httpOnly: true,
-          secure: true,
+          secure: shouldUseSecureCookies(),
           sameSite: "strict",
           path: "/",
           maxAge: Math.floor((sessionData.expiresAt.getTime() - Date.now()) / 1000),

--- a/apps/dashboard/lib/auth/cookie-security.ts
+++ b/apps/dashboard/lib/auth/cookie-security.ts
@@ -1,0 +1,54 @@
+import { env } from "@/lib/env";
+
+/**
+ * Cookie Security Utilities
+ *
+ * This module handles environment-aware cookie security settings to resolve
+ * Safari's restriction on secure cookies over HTTP connections.
+ *
+ * PROBLEM:
+ * Safari browsers don't allow setting cookies with the `secure` flag when
+ * running over HTTP (like localhost during development). This causes cookie
+ * operations to fail silently in development environments.
+ *
+ * SOLUTION:
+ * - Use `secure: true` in production (HTTPS)
+ * - Use `secure: false` in development/preview (HTTP/localhost)
+ *
+ * This approach maintains security in production while allowing development
+ * to work seamlessly across all browsers, including Safari.
+ */
+
+/**
+ * Determines if cookies should be secure based on the environment.
+ *
+ * @returns true if cookies should be secure (production), false otherwise (development/preview)
+ */
+export function shouldUseSecureCookies(): boolean {
+  const environment = env();
+  return environment.VERCEL_ENV === "production";
+}
+
+/**
+ * Get default cookie options with environment-appropriate security settings
+ */
+export function getDefaultCookieOptions() {
+  return {
+    httpOnly: true,
+    secure: shouldUseSecureCookies(),
+    sameSite: "strict" as const,
+    path: "/",
+  };
+}
+
+/**
+ * Get cookie options for authentication flows (typically uses "lax" sameSite for OAuth)
+ */
+export function getAuthCookieOptions() {
+  return {
+    httpOnly: true,
+    secure: shouldUseSecureCookies(),
+    sameSite: "lax" as const,
+    path: "/",
+  };
+}

--- a/apps/dashboard/lib/auth/cookies.ts
+++ b/apps/dashboard/lib/auth/cookies.ts
@@ -2,6 +2,7 @@
 
 import { cookies } from "next/headers";
 import type { NextRequest, NextResponse } from "next/server";
+import { getDefaultCookieOptions, shouldUseSecureCookies } from "./cookie-security";
 import { UNKEY_SESSION_COOKIE } from "./types";
 
 export interface CookieOptions {
@@ -71,7 +72,7 @@ export async function updateCookie(
       value: value,
       options: {
         httpOnly: true,
-        secure: true,
+        secure: shouldUseSecureCookies(),
         sameSite: "strict",
       },
     });
@@ -113,7 +114,7 @@ export async function setSessionCookie(params: {
     value: token,
     options: {
       httpOnly: true,
-      secure: true,
+      secure: shouldUseSecureCookies(),
       sameSite: "strict",
       path: "/",
       maxAge: Math.floor((expiresAt.getTime() - Date.now()) / 1000),
@@ -125,12 +126,7 @@ export async function getCookieOptionsAsString(
   options: Partial<CookieOptions> = {},
 ): Promise<string> {
   // Set defaults if not provided
-  const defaultOptions: CookieOptions = {
-    httpOnly: true,
-    secure: true,
-    sameSite: "strict",
-    path: "/",
-  };
+  const defaultOptions: CookieOptions = getDefaultCookieOptions();
 
   // Merge defaults with provided options
   const mergedOptions = { ...defaultOptions, ...options };

--- a/apps/dashboard/lib/auth/local.ts
+++ b/apps/dashboard/lib/auth/local.ts
@@ -1,4 +1,5 @@
 import { BaseAuthProvider } from "./base-provider";
+import { shouldUseSecureCookies } from "./cookie-security";
 import { getCookie } from "./cookies";
 import {
   type AuthenticatedUser,
@@ -147,7 +148,10 @@ export class LocalAuthProvider extends BaseAuthProvider {
   }
 
   // Organization Management
-  async createTenant(params: { name: string; userId: string }): Promise<string> {
+  async createTenant(params: {
+    name: string;
+    userId: string;
+  }): Promise<string> {
     const { name, userId } = params;
     if (!name || !userId) {
       throw new Error("Organization name and userId are required.");
@@ -389,7 +393,7 @@ export class LocalAuthProvider extends BaseAuthProvider {
           name: UNKEY_SESSION_COOKIE,
           value: `local_session_${Date.now()}`,
           options: {
-            secure: true,
+            secure: shouldUseSecureCookies(),
             httpOnly: true,
             sameSite: "lax",
             path: "/",
@@ -413,7 +417,7 @@ export class LocalAuthProvider extends BaseAuthProvider {
           name: UNKEY_SESSION_COOKIE,
           value: `local_session_${Date.now()}`,
           options: {
-            secure: true,
+            secure: shouldUseSecureCookies(),
             httpOnly: true,
             sameSite: "lax",
             path: "/",
@@ -437,7 +441,7 @@ export class LocalAuthProvider extends BaseAuthProvider {
           name: UNKEY_SESSION_COOKIE,
           value: `local_session_${Date.now()}`,
           options: {
-            secure: true,
+            secure: shouldUseSecureCookies(),
             httpOnly: true,
             sameSite: "lax",
             path: "/",
@@ -467,7 +471,7 @@ export class LocalAuthProvider extends BaseAuthProvider {
           name: UNKEY_SESSION_COOKIE,
           value: `local_session_${Date.now()}`,
           options: {
-            secure: true,
+            secure: shouldUseSecureCookies(),
             httpOnly: true,
             sameSite: "lax",
           },

--- a/apps/dashboard/lib/auth/tests/cookie-security.test.ts
+++ b/apps/dashboard/lib/auth/tests/cookie-security.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getAuthCookieOptions,
+  getDefaultCookieOptions,
+  shouldUseSecureCookies,
+} from "./cookie-security";
+
+// Mock the env module
+vi.mock("@/lib/env", () => ({
+  env: vi.fn(),
+}));
+
+import { env } from "@/lib/env";
+
+const mockEnv = vi.mocked(env);
+
+describe("cookie-security", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("shouldUseSecureCookies", () => {
+    it("should return true for production environment", () => {
+      mockEnv.mockReturnValue({
+        VERCEL_ENV: "production",
+      } as any);
+
+      expect(shouldUseSecureCookies()).toBe(true);
+    });
+
+    it("should return false for development environment", () => {
+      mockEnv.mockReturnValue({
+        VERCEL_ENV: "development",
+      } as any);
+
+      expect(shouldUseSecureCookies()).toBe(false);
+    });
+
+    it("should return false for preview environment", () => {
+      mockEnv.mockReturnValue({
+        VERCEL_ENV: "preview",
+      } as any);
+
+      expect(shouldUseSecureCookies()).toBe(false);
+    });
+  });
+
+  describe("getDefaultCookieOptions", () => {
+    it("should return secure options for production", () => {
+      mockEnv.mockReturnValue({
+        VERCEL_ENV: "production",
+      } as any);
+
+      const options = getDefaultCookieOptions();
+
+      expect(options).toEqual({
+        httpOnly: true,
+        secure: true,
+        sameSite: "strict",
+        path: "/",
+      });
+    });
+
+    it("should return non-secure options for development", () => {
+      mockEnv.mockReturnValue({
+        VERCEL_ENV: "development",
+      } as any);
+
+      const options = getDefaultCookieOptions();
+
+      expect(options).toEqual({
+        httpOnly: true,
+        secure: false,
+        sameSite: "strict",
+        path: "/",
+      });
+    });
+  });
+
+  describe("getAuthCookieOptions", () => {
+    it("should return secure options with lax sameSite for production", () => {
+      mockEnv.mockReturnValue({
+        VERCEL_ENV: "production",
+      } as any);
+
+      const options = getAuthCookieOptions();
+
+      expect(options).toEqual({
+        httpOnly: true,
+        secure: true,
+        sameSite: "lax",
+        path: "/",
+      });
+    });
+
+    it("should return non-secure options with lax sameSite for development", () => {
+      mockEnv.mockReturnValue({
+        VERCEL_ENV: "development",
+      } as any);
+
+      const options = getAuthCookieOptions();
+
+      expect(options).toEqual({
+        httpOnly: true,
+        secure: false,
+        sameSite: "lax",
+        path: "/",
+      });
+    });
+  });
+});

--- a/apps/dashboard/lib/auth/workos.ts
+++ b/apps/dashboard/lib/auth/workos.ts
@@ -6,6 +6,7 @@ import {
 } from "@workos-inc/node";
 import { getBaseUrl } from "../utils";
 import { BaseAuthProvider } from "./base-provider";
+import { shouldUseSecureCookies } from "./cookie-security";
 import { getCookie } from "./cookies";
 import { getAuth } from "./get-auth";
 import {
@@ -639,7 +640,7 @@ export class WorkOSAuthProvider extends BaseAuthProvider {
             name: UNKEY_SESSION_COOKIE,
             value: sealedSession,
             options: {
-              secure: true,
+              secure: shouldUseSecureCookies(),
               httpOnly: true,
               sameSite: "lax",
             },
@@ -662,7 +663,7 @@ export class WorkOSAuthProvider extends BaseAuthProvider {
               name: PENDING_SESSION_COOKIE,
               value: authError.rawData.pending_authentication_token,
               options: {
-                secure: true,
+                secure: shouldUseSecureCookies(),
                 httpOnly: true,
                 sameSite: "lax",
               },
@@ -704,7 +705,7 @@ export class WorkOSAuthProvider extends BaseAuthProvider {
             name: UNKEY_SESSION_COOKIE,
             value: sealedSession,
             options: {
-              secure: true,
+              secure: shouldUseSecureCookies(),
               httpOnly: true,
               sameSite: "lax",
             },
@@ -729,7 +730,7 @@ export class WorkOSAuthProvider extends BaseAuthProvider {
               name: PENDING_SESSION_COOKIE,
               value: authError.rawData.pending_authentication_token,
               options: {
-                secure: true,
+                secure: shouldUseSecureCookies(),
                 httpOnly: true,
                 sameSite: "lax",
               },
@@ -769,7 +770,7 @@ export class WorkOSAuthProvider extends BaseAuthProvider {
             name: UNKEY_SESSION_COOKIE,
             value: sealedSession,
             options: {
-              secure: true,
+              secure: shouldUseSecureCookies(),
               httpOnly: true,
               sameSite: "lax",
             },
@@ -851,7 +852,7 @@ export class WorkOSAuthProvider extends BaseAuthProvider {
             name: UNKEY_SESSION_COOKIE,
             value: sealedSession,
             options: {
-              secure: true,
+              secure: shouldUseSecureCookies(),
               httpOnly: true,
               sameSite: "lax",
             },
@@ -873,7 +874,7 @@ export class WorkOSAuthProvider extends BaseAuthProvider {
               name: PENDING_SESSION_COOKIE,
               value: authError.rawData.pending_authentication_token,
               options: {
-                secure: true,
+                secure: shouldUseSecureCookies(),
                 httpOnly: true,
                 sameSite: "lax",
                 maxAge: 60, // user has 60 seconds to select an org before the cookie expires
@@ -900,7 +901,7 @@ export class WorkOSAuthProvider extends BaseAuthProvider {
               name: PENDING_SESSION_COOKIE,
               value: authError.rawData.pending_authentication_token,
               options: {
-                secure: true,
+                secure: shouldUseSecureCookies(),
                 httpOnly: true,
                 sameSite: "lax",
                 maxAge: 60 * 10, // user has 10 mins seconds to verify their email before the cookie expires


### PR DESCRIPTION
## What does this PR do?

Safari browsers don't allow setting cookies with the `secure` flag when running
over HTTP connections (like localhost:3000 during development), causing cookie
operations to fail silently in development environments.

This commit implements a comprehensive solution that:
- Uses secure cookies (secure: true) in production environments (HTTPS)
- Uses non-secure cookies (secure: false) in development/preview (HTTP/localhost)
- Maintains security in production while ensuring Safari compatibility in development

## Changes Made

### Core Implementation
- **NEW**: `lib/auth/cookie-security.ts` - Centralized cookie security utilities
  - `shouldUseSecureCookies()` - Environment-based security determination
  - `getDefaultCookieOptions()` - Default cookie options with env-aware security
  - `getAuthCookieOptions()` - Auth-specific options (lax sameSite for OAuth)

### Updated Cookie Usage
- **MODIFIED**: `lib/auth/cookies.ts` - Updated main cookie utilities to use new security logic
- **MODIFIED**: `app/(app)/api/auth/refresh/route.ts` - Auth refresh endpoint
- **MODIFIED**: `app/new/hooks/use-workspace-step.tsx` - Workspace creation flow
- **MODIFIED**: `lib/auth/local.ts` - Local authentication provider (5 locations)
- **MODIFIED**: `lib/auth/workos.ts` - WorkOS authentication provider (8 locations)

### Testing
- **NEW**: `lib/auth/cookie-security.test.ts` - Test coverage for all scenarios 🤮 

## Environment Logic
```typescript
// Production (Vercel, HTTPS) - Secure cookies
VERCEL_ENV === "production" → secure: true

// Development/Preview (localhost, HTTP) - Non-secure cookies
VERCEL_ENV !== "production" → secure: false
```
<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?


- Run locally and test Safari + Chrome and make sure you can select an org.
- Run Preview URL with Safari + Chrome and make sure you can select an org.



## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [X] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [X] Self-reviewed my own code
- [X] Commented on my code in hard-to-understand areas
- [X] Ran `pnpm build`
- [X] Ran `pnpm fmt`
- [X] Checked for warnings, there are none
- [X] Removed all `console.logs`
- [X] Merged the latest changes from main onto my branch with `git pull origin main`
- [X] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary
