### PR TITLE
fix: Format pagination numbers in log footers

### DIFF
--- a/apps/dashboard/app/(app)/apis/[apiId]/keys/[keyAuthId]/[keyId]/components/table/logs-table.tsx
+++ b/apps/dashboard/app/(app)/apis/[apiId]/keys/[keyAuthId]/[keyId]/components/table/logs-table.tsx
@@ -16,7 +16,14 @@ import {
   TimeClock,
   TriangleWarning2,
 } from "@unkey/icons";
-import { Badge, Button, CopyButton, Empty, InfoTooltip, TimestampInfo } from "@unkey/ui";
+import {
+  Badge,
+  Button,
+  CopyButton,
+  Empty,
+  InfoTooltip,
+  TimestampInfo,
+} from "@unkey/ui";
 import { useCallback, useState } from "react";
 import { useKeyDetailsLogsContext } from "../../context/logs";
 import { StatusBadge } from "./components/status-badge";
@@ -149,7 +156,9 @@ const getStatusType = (outcome: LogOutcomeType): keyof typeof STATUS_STYLES => {
   }
 };
 
-export const categorizeSeverity = (outcome: string): keyof typeof STATUS_STYLES => {
+export const categorizeSeverity = (
+  outcome: string
+): keyof typeof STATUS_STYLES => {
   switch (outcome) {
     case "VALID":
       return "success";
@@ -179,17 +188,32 @@ type Props = {
   onLogSelect: (log: KeyDetailsLog | null) => void;
 };
 
-export const KeyDetailsLogsTable = ({ keyspaceId, keyId, selectedLog, onLogSelect }: Props) => {
+export const KeyDetailsLogsTable = ({
+  keyspaceId,
+  keyId,
+  selectedLog,
+  onLogSelect,
+}: Props) => {
   const { isLive } = useKeyDetailsLogsContext();
-  const { realtimeLogs, historicalLogs, isLoading, isLoadingMore, loadMore, hasMore, totalCount } =
-    useKeyDetailsLogsQuery({
-      keyId,
-      keyspaceId,
-      startPolling: isLive,
-      pollIntervalMs: 2000,
-    });
+  const {
+    realtimeLogs,
+    historicalLogs,
+    isLoading,
+    isLoadingMore,
+    loadMore,
+    hasMore,
+    totalCount,
+  } = useKeyDetailsLogsQuery({
+    keyId,
+    keyspaceId,
+    startPolling: isLive,
+    pollIntervalMs: 2000,
+  });
 
-  const getRowClassName = (log: KeyDetailsLog, selected: KeyDetailsLog | null) => {
+  const getRowClassName = (
+    log: KeyDetailsLog,
+    selected: KeyDetailsLog | null
+  ) => {
     const style = getStatusStyle(log);
     const isSelected = selected?.request_id === log.request_id;
 
@@ -199,7 +223,7 @@ export const KeyDetailsLogsTable = ({ keyspaceId, keyId, selectedLog, onLogSelec
       "group rounded-md cursor-pointer transition-colors",
       "focus:outline-none focus:ring-1 focus:ring-opacity-40",
       style.focusRing,
-      isSelected && style.selected,
+      isSelected && style.selected
     );
   };
 
@@ -232,7 +256,7 @@ export const KeyDetailsLogsTable = ({ keyspaceId, keyId, selectedLog, onLogSelec
         });
       }
     },
-    [hoveredLogId, utils.logs.queryLogs, timestamp],
+    [hoveredLogId, utils.logs.queryLogs, timestamp]
   );
 
   const handleRowMouseLeave = useCallback(() => {
@@ -251,7 +275,9 @@ export const KeyDetailsLogsTable = ({ keyspaceId, keyId, selectedLog, onLogSelec
             value={log.time}
             className={cn(
               "font-mono group-hover:underline decoration-dotted pl-2",
-              selectedLog && selectedLog.request_id !== log.request_id && "pointer-events-none",
+              selectedLog &&
+                selectedLog.request_id !== log.request_id &&
+                "pointer-events-none"
             )}
           />
         ),
@@ -279,8 +305,10 @@ export const KeyDetailsLogsTable = ({ keyspaceId, keyId, selectedLog, onLogSelec
                   primary={{
                     label: outcomeInfo.label,
                     color: isSelected
-                      ? STATUS_STYLES[getStatusType(outcomeInfo.type)].badge.selected
-                      : STATUS_STYLES[getStatusType(outcomeInfo.type)].badge.default,
+                      ? STATUS_STYLES[getStatusType(outcomeInfo.type)].badge
+                          .selected
+                      : STATUS_STYLES[getStatusType(outcomeInfo.type)].badge
+                          .default,
                     icon: outcomeInfo.icon,
                   }}
                 />
@@ -318,9 +346,13 @@ export const KeyDetailsLogsTable = ({ keyspaceId, keyId, selectedLog, onLogSelec
                       <div className="max-w-xs">
                         {tag.length > 60 ? (
                           <div>
-                            <div className="break-all max-w-[300px] truncate">{tag}</div>
+                            <div className="break-all max-w-[300px] truncate">
+                              {tag}
+                            </div>
                             <div className="flex items-center justify-between mt-1.5">
-                              <div className="text-xs opacity-60">({tag.length} characters)</div>
+                              <div className="text-xs opacity-60">
+                                ({tag.length} characters)
+                              </div>
                               {/* biome-ignore lint/a11y/useKeyWithClickEvents: <explanation> */}
                               <div
                                 className="pointer-events-auto"
@@ -332,7 +364,9 @@ export const KeyDetailsLogsTable = ({ keyspaceId, keyId, selectedLog, onLogSelec
                           </div>
                         ) : (
                           <div className="flex justify-between items-center gap-1.5">
-                            <div className="break-all max-w-[300px] truncate">{tag}</div>
+                            <div className="break-all max-w-[300px] truncate">
+                              {tag}
+                            </div>
                             {/* biome-ignore lint/a11y/useKeyWithClickEvents: <explanation> */}
                             <div
                               className="pointer-events-auto flex-shrink-0"
@@ -352,7 +386,7 @@ export const KeyDetailsLogsTable = ({ keyspaceId, keyId, selectedLog, onLogSelec
                         "whitespace-nowrap max-w-[150px] truncate",
                         selectedLog?.request_id === log.request_id
                           ? STATUS_STYLES.success.badge.selected
-                          : "",
+                          : ""
                       )}
                     >
                       {shortenId(tag, {
@@ -378,9 +412,13 @@ export const KeyDetailsLogsTable = ({ keyspaceId, keyId, selectedLog, onLogSelec
                         <div key={idx + tag} className="text-xs">
                           {tag.length > 60 ? (
                             <div>
-                              <div className="break-all max-w-[300px] truncate">{tag}</div>
+                              <div className="break-all max-w-[300px] truncate">
+                                {tag}
+                              </div>
                               <div className="flex items-center justify-between mt-1.5">
-                                <div className="text-xs opacity-60">({tag.length} characters)</div>
+                                <div className="text-xs opacity-60">
+                                  ({tag.length} characters)
+                                </div>
                                 {/* biome-ignore lint/a11y/useKeyWithClickEvents: <explanation> */}
                                 <div
                                   className="pointer-events-auto"
@@ -392,7 +430,9 @@ export const KeyDetailsLogsTable = ({ keyspaceId, keyId, selectedLog, onLogSelec
                             </div>
                           ) : (
                             <div className="flex justify-between items-start gap-1.5">
-                              <div className="break-all max-w-[300px] truncate">{tag}</div>
+                              <div className="break-all max-w-[300px] truncate">
+                                {tag}
+                              </div>
                               {/* biome-ignore lint/a11y/useKeyWithClickEvents: <explanation> */}
                               <div
                                 className="pointer-events-auto flex-shrink-0"
@@ -414,7 +454,7 @@ export const KeyDetailsLogsTable = ({ keyspaceId, keyId, selectedLog, onLogSelec
                       "whitespace-nowrap",
                       selectedLog?.request_id === log.request_id
                         ? STATUS_STYLES.success.badge.selected
-                        : "",
+                        : ""
                     )}
                   >
                     +{log.tags.length - 3}
@@ -449,9 +489,12 @@ export const KeyDetailsLogsTable = ({ keyspaceId, keyId, selectedLog, onLogSelec
           hide: isLoading,
           countInfoText: (
             <div className="flex gap-2">
-              <span>Showing</span> <span className="text-accent-12">{historicalLogs.length}</span>
+              <span>Showing</span>{" "}
+              <span className="text-accent-12">
+                {new Intl.NumberFormat().format(historicalLogs.length)}
+              </span>
               <span>of</span>
-              {totalCount}
+              {new Intl.NumberFormat().format(totalCount)}
               <span>requests</span>
             </div>
           ),
@@ -462,8 +505,8 @@ export const KeyDetailsLogsTable = ({ keyspaceId, keyId, selectedLog, onLogSelec
               <Empty.Icon className="w-auto" />
               <Empty.Title>Key Verification Logs</Empty.Title>
               <Empty.Description className="text-left">
-                No verification logs found for this key. When this API key is used, details about
-                each verification attempt will appear here.
+                No verification logs found for this key. When this API key is
+                used, details about each verification attempt will appear here.
               </Empty.Description>
               <Empty.Actions className="mt-4 justify-center md:justify-start">
                 <a

--- a/apps/dashboard/app/(app)/apis/[apiId]/keys/[keyAuthId]/_components/components/table/keys-list.tsx
+++ b/apps/dashboard/app/(app)/apis/[apiId]/keys/[keyAuthId]/_components/components/table/keys-list.tsx
@@ -28,7 +28,7 @@ import { getRowClassName } from "./utils/get-row-class";
 const KeysTableActionPopover = dynamic(
   () =>
     import("./components/actions/keys-table-action.popover.constants").then(
-      (mod) => mod.KeysTableActions,
+      (mod) => mod.KeysTableActions
     ),
   {
     ssr: false,
@@ -37,13 +37,16 @@ const KeysTableActionPopover = dynamic(
         type="button"
         className={cn(
           "group-data-[state=open]:bg-gray-6 group-hover:bg-gray-6 group size-5 p-0 rounded m-0 items-center flex justify-center",
-          "border border-gray-6 group-hover:border-gray-8 ring-2 ring-transparent focus-visible:ring-gray-7 focus-visible:border-gray-7",
+          "border border-gray-6 group-hover:border-gray-8 ring-2 ring-transparent focus-visible:ring-gray-7 focus-visible:border-gray-7"
         )}
       >
-        <Dots className="group-hover:text-gray-12 text-gray-11" size="sm-regular" />
+        <Dots
+          className="group-hover:text-gray-12 text-gray-11"
+          size="sm-regular"
+        />
       </button>
     ),
-  },
+  }
 );
 
 export const KeysList = ({
@@ -53,9 +56,10 @@ export const KeysList = ({
   keyspaceId: string;
   apiId: string;
 }) => {
-  const { keys, isLoading, isLoadingMore, loadMore, totalCount, hasMore } = useKeysListQuery({
-    keyAuthId: keyspaceId,
-  });
+  const { keys, isLoading, isLoadingMore, loadMore, totalCount, hasMore } =
+    useKeysListQuery({
+      keyAuthId: keyspaceId,
+    });
   const [selectedKey, setSelectedKey] = useState<KeyDetails | null>(null);
   const [navigatingKeyId, setNavigatingKeyId] = useState<string | null>(null);
   // Add state for selected keys
@@ -98,13 +102,17 @@ export const KeysList = ({
               className={cn(
                 "size-5 rounded flex items-center justify-center cursor-pointer",
                 identity ? "bg-successA-3" : "bg-grayA-3",
-                isSelected && "bg-brand-5",
+                isSelected && "bg-brand-5"
               )}
               onMouseEnter={() => setHoveredKeyId(key.id)}
               onMouseLeave={() => setHoveredKeyId(null)}
             >
               {isNavigating ? (
-                <div className={cn(identity ? "text-successA-11" : "text-grayA-11")}>
+                <div
+                  className={cn(
+                    identity ? "text-successA-11" : "text-grayA-11"
+                  )}
+                >
                   <Loading size={18} />
                 </div>
               ) : (
@@ -155,17 +163,24 @@ export const KeysList = ({
                             rel="noopener noreferrer"
                             aria-disabled={isNavigating}
                           >
-                            <span className="font-mono bg-gray-4 p-1 rounded">{identity}</span>
+                            <span className="font-mono bg-gray-4 p-1 rounded">
+                              {identity}
+                            </span>
                           </Link>
                         ) : (
-                          <span className="font-mono bg-gray-4 p-1 rounded">{identity}</span>
+                          <span className="font-mono bg-gray-4 p-1 rounded">
+                            {identity}
+                          </span>
                         )}
                       </>
                     }
                     asChild
                   >
                     {React.cloneElement(iconContainer, {
-                      className: cn(iconContainer.props.className, "cursor-pointer"),
+                      className: cn(
+                        iconContainer.props.className,
+                        "cursor-pointer"
+                      ),
                     })}
                   </InfoTooltip>
                 ) : (
@@ -205,7 +220,11 @@ export const KeysList = ({
         header: "Value",
         width: "15%",
         render: (key) => (
-          <HiddenValueCell value={key.start} title="Value" selected={selectedKey?.id === key.id} />
+          <HiddenValueCell
+            value={key.start}
+            title="Value"
+            selected={selectedKey?.id === key.id}
+          />
         ),
       },
       {
@@ -266,7 +285,7 @@ export const KeysList = ({
       selectedKeys,
       toggleSelection,
       hoveredKeyId,
-    ],
+    ]
   );
 
   const getSelectedKeysState = useCallback(() => {
@@ -330,9 +349,12 @@ export const KeysList = ({
           ),
           countInfoText: (
             <div className="flex gap-2">
-              <span>Showing</span> <span className="text-accent-12">{keys.length}</span>
+              <span>Showing</span>{" "}
+              <span className="text-accent-12">
+                {new Intl.NumberFormat().format(keys.length)}
+              </span>
               <span>of</span>
-              {totalCount}
+              {new Intl.NumberFormat().format(totalCount)}
               <span>keys</span>
             </div>
           ),
@@ -343,8 +365,8 @@ export const KeysList = ({
               <Empty.Icon className="w-auto" />
               <Empty.Title>No API Keys Found</Empty.Title>
               <Empty.Description className="text-left">
-                There are no API keys associated with this service yet. Create your first API key to
-                get started.
+                There are no API keys associated with this service yet. Create
+                your first API key to get started.
               </Empty.Description>
               <Empty.Actions className="mt-4 justify-start">
                 <a
@@ -374,7 +396,7 @@ export const KeysList = ({
               className={cn(
                 "text-xs align-middle whitespace-nowrap pr-4",
                 idx === 0 ? "pl-[18px]" : "",
-                column.key === "key" ? "py-[6px]" : "py-1",
+                column.key === "key" ? "py-[6px]" : "py-1"
               )}
               style={{ height: `${rowHeight}px` }}
             >
@@ -384,9 +406,17 @@ export const KeysList = ({
               {column.key === "last_used" && <LastUsedColumnSkeleton />}
               {column.key === "status" && <StatusColumnSkeleton />}
               {column.key === "action" && <ActionColumnSkeleton />}
-              {!["select", "key", "value", "usage", "last_used", "status", "action"].includes(
-                column.key,
-              ) && <div className="h-4 w-full bg-grayA-3 rounded animate-pulse" />}
+              {![
+                "select",
+                "key",
+                "value",
+                "usage",
+                "last_used",
+                "status",
+                "action",
+              ].includes(column.key) && (
+                <div className="h-4 w-full bg-grayA-3 rounded animate-pulse" />
+              )}
             </td>
           ))
         }

--- a/apps/dashboard/app/(app)/apis/_components/api-list-client.tsx
+++ b/apps/dashboard/app/(app)/apis/_components/api-list-client.tsx
@@ -30,7 +30,7 @@ export const ApiListClient = () => {
     { limit: DEFAULT_LIMIT },
     {
       getNextPageParam: (lastPage) => lastPage.nextCursor,
-    },
+    }
   );
 
   const allApis = useMemo(() => {
@@ -61,7 +61,11 @@ export const ApiListClient = () => {
 
   return (
     <div className="flex flex-col">
-      <ApiListControls apiList={allApis} onApiListChange={setApiList} onSearch={setIsSearching} />
+      <ApiListControls
+        apiList={allApis}
+        onApiListChange={setApiList}
+        onSearch={setIsSearching}
+      />
       <ApiListControlCloud />
 
       {isLoading ? (
@@ -81,11 +85,17 @@ export const ApiListClient = () => {
 
           <div className="flex flex-col items-center justify-center mt-8 space-y-4 pb-8">
             <div className="text-center text-sm text-accent-11">
-              Showing {apiList.length} of {apisData?.pages[0]?.total || 0} APIs
+              Showing {new Intl.NumberFormat().format(apiList.length)} of{" "}
+              {new Intl.NumberFormat().format(apisData?.pages[0]?.total || 0)}{" "}
+              APIs
             </div>
 
             {!isSearching && hasNextPage && (
-              <Button onClick={loadMore} disabled={isFetchingNextPage} size="md">
+              <Button
+                onClick={loadMore}
+                disabled={isFetchingNextPage}
+                size="md"
+              >
                 {isFetchingNextPage ? (
                   <div className="flex items-center space-x-2">
                     <div className="animate-spin h-4 w-4 border-2 border-gray-7 border-t-transparent rounded-full" />

--- a/apps/dashboard/app/(app)/apis/_components/api-list-grid.tsx
+++ b/apps/dashboard/app/(app)/apis/_components/api-list-grid.tsx
@@ -43,7 +43,8 @@ export const ApiListGrid = ({
 
       <div className="flex flex-col items-center justify-center mt-8 space-y-4 pb-8">
         <div className="text-center text-sm text-accent-11">
-          Showing {apiList.length} of {total} APIs
+          Showing {new Intl.NumberFormat().format(apiList.length)} of{" "}
+          {new Intl.NumberFormat().format(total)} APIs
         </div>
 
         {!isSearching && hasMore && (

--- a/apps/dashboard/app/(app)/authorization/permissions/components/table/permissions-list.tsx
+++ b/apps/dashboard/app/(app)/authorization/permissions/components/table/permissions-list.tsx
@@ -22,11 +22,22 @@ import { usePermissionsListQuery } from "./hooks/use-permissions-list-query";
 import { getRowClassName } from "./utils/get-row-class";
 
 export const PermissionsList = () => {
-  const { permissions, isLoading, isLoadingMore, loadMore, totalCount, hasMore } =
-    usePermissionsListQuery();
-  const [selectedPermission, setSelectedPermission] = useState<Permission | null>(null);
-  const [selectedPermissions, setSelectedPermissions] = useState<Set<string>>(new Set());
-  const [hoveredPermissionName, setHoveredPermissionName] = useState<string | null>(null);
+  const {
+    permissions,
+    isLoading,
+    isLoadingMore,
+    loadMore,
+    totalCount,
+    hasMore,
+  } = usePermissionsListQuery();
+  const [selectedPermission, setSelectedPermission] =
+    useState<Permission | null>(null);
+  const [selectedPermissions, setSelectedPermissions] = useState<Set<string>>(
+    new Set()
+  );
+  const [hoveredPermissionName, setHoveredPermissionName] = useState<
+    string | null
+  >(null);
 
   const toggleSelection = useCallback((permissionName: string) => {
     setSelectedPermissions((prevSelected) => {
@@ -56,12 +67,14 @@ export const PermissionsList = () => {
               className={cn(
                 "size-5 rounded flex items-center justify-center cursor-pointer border border-grayA-3 transition-all duration-100",
                 "bg-grayA-3",
-                isSelected && "bg-grayA-5",
+                isSelected && "bg-grayA-5"
               )}
               onMouseEnter={() => setHoveredPermissionName(permission.name)}
               onMouseLeave={() => setHoveredPermissionName(null)}
             >
-              {!isSelected && !isHovered && <Page2 size="sm-regular" className="text-gray-12" />}
+              {!isSelected && !isHovered && (
+                <Page2 size="sm-regular" className="text-gray-12" />
+              )}
               {(isSelected || isHovered) && (
                 <Checkbox
                   checked={isSelected}
@@ -106,7 +119,9 @@ export const PermissionsList = () => {
           <AssignedItemsCell
             kind="slug"
             value={permission.slug}
-            isSelected={permission.permissionId === selectedPermission?.permissionId}
+            isSelected={
+              permission.permissionId === selectedPermission?.permissionId
+            }
           />
         ),
       },
@@ -118,7 +133,9 @@ export const PermissionsList = () => {
           <AssignedItemsCell
             kind="roles"
             totalCount={permission.totalConnectedRoles}
-            isSelected={permission.permissionId === selectedPermission?.permissionId}
+            isSelected={
+              permission.permissionId === selectedPermission?.permissionId
+            }
           />
         ),
       },
@@ -130,7 +147,9 @@ export const PermissionsList = () => {
           <AssignedItemsCell
             kind="keys"
             totalCount={permission.totalConnectedKeys}
-            isSelected={permission.permissionId === selectedPermission?.permissionId}
+            isSelected={
+              permission.permissionId === selectedPermission?.permissionId
+            }
           />
         ),
       },
@@ -142,7 +161,9 @@ export const PermissionsList = () => {
           return (
             <LastUpdated
               lastUpdated={permission.lastUpdated}
-              isSelected={permission.permissionId === selectedPermission?.permissionId}
+              isSelected={
+                permission.permissionId === selectedPermission?.permissionId
+              }
             />
           );
         },
@@ -156,7 +177,12 @@ export const PermissionsList = () => {
         },
       },
     ],
-    [selectedPermissions, toggleSelection, hoveredPermissionName, selectedPermission?.permissionId],
+    [
+      selectedPermissions,
+      toggleSelection,
+      hoveredPermissionName,
+      selectedPermission?.permissionId,
+    ]
   );
 
   return (
@@ -169,7 +195,9 @@ export const PermissionsList = () => {
       onRowClick={setSelectedPermission}
       selectedItem={selectedPermission}
       keyExtractor={(permission) => permission.permissionId}
-      rowClassName={(permission) => getRowClassName(permission, selectedPermission)}
+      rowClassName={(permission) =>
+        getRowClassName(permission, selectedPermission)
+      }
       loadMoreFooterProps={{
         hide: isLoading,
         buttonText: "Load more permissions",
@@ -182,9 +210,12 @@ export const PermissionsList = () => {
         ),
         countInfoText: (
           <div className="flex gap-2">
-            <span>Showing</span> <span className="text-accent-12">{permissions.length}</span>
+            <span>Showing</span>{" "}
+            <span className="text-accent-12">
+              {new Intl.NumberFormat().format(permissions.length)}
+            </span>
             <span>of</span>
-            {totalCount}
+            {new Intl.NumberFormat().format(totalCount)}
             <span>permissions</span>
           </div>
         ),
@@ -195,8 +226,8 @@ export const PermissionsList = () => {
             <Empty.Icon className="w-auto" />
             <Empty.Title>No Permissions Found</Empty.Title>
             <Empty.Description className="text-left">
-              There are no permissions configured yet. Create your first permission to start
-              managing permissions and access control.
+              There are no permissions configured yet. Create your first
+              permission to start managing permissions and access control.
             </Empty.Description>
             <Empty.Actions className="mt-4 justify-start">
               <a
@@ -225,14 +256,16 @@ export const PermissionsList = () => {
             key={column.key}
             className={cn(
               "text-xs align-middle whitespace-nowrap",
-              column.key === "permission" ? "py-[6px]" : "py-1",
+              column.key === "permission" ? "py-[6px]" : "py-1"
             )}
             style={{ height: `${rowHeight}px` }}
           >
             {column.key === "permission" && <RoleColumnSkeleton />}
             {column.key === "slug" && <SlugColumnSkeleton />}
             {column.key === "used_in_roles" && <AssignedKeysColumnSkeleton />}
-            {column.key === "assigned_to_keys" && <AssignedToKeysColumnSkeleton />}
+            {column.key === "assigned_to_keys" && (
+              <AssignedToKeysColumnSkeleton />
+            )}
             {column.key === "last_updated" && <LastUpdatedColumnSkeleton />}
             {column.key === "action" && <ActionColumnSkeleton />}
           </td>

--- a/apps/dashboard/app/(app)/authorization/roles/components/table/roles-list.tsx
+++ b/apps/dashboard/app/(app)/authorization/roles/components/table/roles-list.tsx
@@ -22,7 +22,8 @@ import { useRolesListQuery } from "./hooks/use-roles-list-query";
 import { getRowClassName } from "./utils/get-row-class";
 
 export const RolesList = () => {
-  const { roles, isLoading, isLoadingMore, loadMore, totalCount, hasMore } = useRolesListQuery();
+  const { roles, isLoading, isLoadingMore, loadMore, totalCount, hasMore } =
+    useRolesListQuery();
   const [selectedRole, setSelectedRole] = useState<RoleBasic | null>(null);
   const [selectedRoles, setSelectedRoles] = useState<Set<string>>(new Set());
   const [hoveredRoleName, setHoveredRoleName] = useState<string | null>(null);
@@ -55,12 +56,14 @@ export const RolesList = () => {
               className={cn(
                 "size-5 rounded flex items-center justify-center cursor-pointer border border-grayA-3 transition-all duration-100",
                 "bg-grayA-3",
-                isSelected && "bg-grayA-5",
+                isSelected && "bg-grayA-5"
               )}
               onMouseEnter={() => setHoveredRoleName(role.name)}
               onMouseLeave={() => setHoveredRoleName(null)}
             >
-              {!isSelected && !isHovered && <Tag size="sm-regular" className="text-gray-12" />}
+              {!isSelected && !isHovered && (
+                <Tag size="sm-regular" className="text-gray-12" />
+              )}
               {(isSelected || isHovered) && (
                 <Checkbox
                   checked={isSelected}
@@ -143,7 +146,7 @@ export const RolesList = () => {
         },
       },
     ],
-    [selectedRoles, toggleSelection, hoveredRoleName, selectedRole?.roleId],
+    [selectedRoles, toggleSelection, hoveredRoleName, selectedRole?.roleId]
   );
 
   return (
@@ -162,13 +165,19 @@ export const RolesList = () => {
         buttonText: "Load more roles",
         hasMore,
         headerContent: (
-          <SelectionControls selectedRoles={selectedRoles} setSelectedRoles={setSelectedRoles} />
+          <SelectionControls
+            selectedRoles={selectedRoles}
+            setSelectedRoles={setSelectedRoles}
+          />
         ),
         countInfoText: (
           <div className="flex gap-2">
-            <span>Showing</span> <span className="text-accent-12">{roles.length}</span>
+            <span>Showing</span>{" "}
+            <span className="text-accent-12">
+              {new Intl.NumberFormat().format(roles.length)}
+            </span>
             <span>of</span>
-            {totalCount}
+            {new Intl.NumberFormat().format(totalCount)}
             <span>roles</span>
           </div>
         ),
@@ -179,8 +188,8 @@ export const RolesList = () => {
             <Empty.Icon className="w-auto" />
             <Empty.Title>No Roles Found</Empty.Title>
             <Empty.Description className="text-left">
-              There are no roles configured yet. Create your first role to start managing
-              permissions and access control.
+              There are no roles configured yet. Create your first role to start
+              managing permissions and access control.
             </Empty.Description>
             <Empty.Actions className="mt-4 justify-start">
               <a
@@ -209,7 +218,7 @@ export const RolesList = () => {
             key={column.key}
             className={cn(
               "text-xs align-middle whitespace-nowrap",
-              column.key === "role" ? "py-[6px]" : "py-1",
+              column.key === "role" ? "py-[6px]" : "py-1"
             )}
             style={{ height: `${rowHeight}px` }}
           >

--- a/apps/dashboard/app/(app)/logs/components/table/logs-table.tsx
+++ b/apps/dashboard/app/(app)/logs/components/table/logs-table.tsx
@@ -86,7 +86,7 @@ const WarningIcon = ({ status }: { status: number }) => (
       WARNING_ICON_STYLES.base,
       status < 300 && "invisible",
       status >= 400 && status < 500 && WARNING_ICON_STYLES.warning,
-      status >= 500 && WARNING_ICON_STYLES.error,
+      status >= 500 && WARNING_ICON_STYLES.error
     )}
   />
 );
@@ -107,17 +107,27 @@ const additionalColumns: Column<Log>[] = [
     .join(" "),
   width: "auto",
   render: (log: Log) => (
-    <div className="font-mono whitespace-nowrap truncate w-[500px]">{log[key as keyof Log]}</div>
+    <div className="font-mono whitespace-nowrap truncate w-[500px]">
+      {log[key as keyof Log]}
+    </div>
   ),
 }));
 
 export const LogsTable = () => {
-  const { displayProperties, setSelectedLog, selectedLog, isLive } = useLogsContext();
-  const { realtimeLogs, historicalLogs, isLoading, isLoadingMore, loadMore, hasMore, total } =
-    useLogsQuery({
-      startPolling: isLive,
-      pollIntervalMs: 2000,
-    });
+  const { displayProperties, setSelectedLog, selectedLog, isLive } =
+    useLogsContext();
+  const {
+    realtimeLogs,
+    historicalLogs,
+    isLoading,
+    isLoadingMore,
+    loadMore,
+    hasMore,
+    total,
+  } = useLogsQuery({
+    startPolling: isLive,
+    pollIntervalMs: 2000,
+  });
 
   const getRowClassName = (log: Log) => {
     const style = getStatusStyle(log.response_status);
@@ -131,14 +141,13 @@ export const LogsTable = () => {
       style.focusRing,
       isSelected && style.selected,
       isLive &&
-        !realtimeLogs.some((realtime) => realtime.request_id === log.request_id) && [
-          "opacity-50",
-          "hover:opacity-100",
-        ],
+        !realtimeLogs.some(
+          (realtime) => realtime.request_id === log.request_id
+        ) && ["opacity-50", "hover:opacity-100"],
       selectedLog && {
         "opacity-50 z-0": !isSelected,
         "opacity-100 z-10": isSelected,
-      },
+      }
     );
   };
   // biome-ignore lint/correctness/useExhaustiveDependencies: it's okay
@@ -153,7 +162,9 @@ export const LogsTable = () => {
             value={log.time}
             className={cn(
               "font-mono group-hover:underline decoration-dotted",
-              selectedLog && selectedLog.request_id !== log.request_id && "pointer-events-none",
+              selectedLog &&
+                selectedLog.request_id !== log.request_id &&
+                "pointer-events-none"
             )}
           />
         ),
@@ -169,11 +180,13 @@ export const LogsTable = () => {
             <Badge
               className={cn(
                 "uppercase px-[6px] rounded-md font-mono whitespace-nowrap",
-                isSelected ? style.badge.selected : style.badge.default,
+                isSelected ? style.badge.selected : style.badge.default
               )}
             >
               {log.response_status}{" "}
-              {extractResponseField(log, "code") ? `| ${extractResponseField(log, "code")}` : ""}
+              {extractResponseField(log, "code")
+                ? `| ${extractResponseField(log, "code")}`
+                : ""}
             </Badge>
           );
         },
@@ -190,7 +203,7 @@ export const LogsTable = () => {
                 "uppercase px-[6px] rounded-md font-mono whitespace-nowrap",
                 isSelected
                   ? STATUS_STYLES.success.badge.selected
-                  : STATUS_STYLES.success.badge.default,
+                  : STATUS_STYLES.success.badge.default
               )}
             >
               {log.method}
@@ -205,12 +218,13 @@ export const LogsTable = () => {
         render: (log) => <div className="font-mono pr-4">{log.path}</div>,
       },
     ],
-    [selectedLog?.request_id],
+    [selectedLog?.request_id]
   );
 
   const visibleColumns = useMemo(() => {
     const filtered = [...basicColumns, ...additionalColumns].filter(
-      (column) => isDisplayProperty(column.key) && displayProperties.has(column.key),
+      (column) =>
+        isDisplayProperty(column.key) && displayProperties.has(column.key)
     );
 
     // If we have visible columns
@@ -250,9 +264,12 @@ export const LogsTable = () => {
         hasMore,
         countInfoText: (
           <div className="flex gap-2">
-            <span>Showing</span> <span className="text-accent-12">{historicalLogs.length}</span>
+            <span>Showing</span>{" "}
+            <span className="text-accent-12">
+              {new Intl.NumberFormat().format(historicalLogs.length)}
+            </span>
             <span>of</span>
-            {total}
+            {new Intl.NumberFormat().format(total)}
             <span>requests</span>
           </div>
         ),
@@ -263,8 +280,9 @@ export const LogsTable = () => {
             <Empty.Icon className="w-auto" />
             <Empty.Title>Logs</Empty.Title>
             <Empty.Description className="text-left">
-              Keep track of all activity within your workspace. We collect all API requests, giving
-              you a clear history to find problems or debug issues.
+              Keep track of all activity within your workspace. We collect all
+              API requests, giving you a clear history to find problems or debug
+              issues.
             </Empty.Description>
             <Empty.Actions className="mt-4 justify-start">
               <a

--- a/apps/dashboard/app/(app)/projects/[projectId]/deployments/components/table/deployments-list.tsx
+++ b/apps/dashboard/app/(app)/projects/[projectId]/deployments/components/table/deployments-list.tsx
@@ -27,21 +27,28 @@ import { getRowClassName } from "./utils/get-row-class";
 
 const DeploymentListTableActions = dynamic(
   () =>
-    import("./components/actions/deployment-list-table-action.popover.constants").then(
-      (mod) => mod.DeploymentListTableActions,
-    ),
+    import(
+      "./components/actions/deployment-list-table-action.popover.constants"
+    ).then((mod) => mod.DeploymentListTableActions),
   {
     loading: () => <ActionColumnSkeleton />,
     ssr: false,
-  },
+  }
 );
 
 const COMPACT_BREAKPOINT = 1200;
 
 export const DeploymentsList = () => {
-  const { deployments, isLoading, isLoadingMore, loadMore, totalCount, hasMore } =
-    useDeploymentsListQuery();
-  const [selectedDeployment, setSelectedDeployment] = useState<Deployment | null>(null);
+  const {
+    deployments,
+    isLoading,
+    isLoadingMore,
+    loadMore,
+    totalCount,
+    hasMore,
+  } = useDeploymentsListQuery();
+  const [selectedDeployment, setSelectedDeployment] =
+    useState<Deployment | null>(null);
   const isCompactView = useIsMobile({ breakpoint: COMPACT_BREAKPOINT });
 
   const columns: Column<Deployment>[] = useMemo(() => {
@@ -58,7 +65,7 @@ export const DeploymentsList = () => {
               className={cn(
                 "size-5 rounded flex items-center justify-center cursor-pointer border border-grayA-3 transition-all duration-100",
                 "bg-grayA-3",
-                isSelected && "bg-grayA-5",
+                isSelected && "bg-grayA-5"
               )}
             >
               <Cloud size="sm-regular" className="text-gray-12" />
@@ -73,16 +80,22 @@ export const DeploymentsList = () => {
                     <div
                       className={cn(
                         "font-normal font-mono truncate leading-5 text-[13px]",
-                        "text-accent-12",
+                        "text-accent-12"
                       )}
                     >
                       {shortenId(deployment.id)}
                     </div>
-                    {deployment.environment === "production" && deployment.active && (
-                      <EnvStatusBadge variant="current" text="Current" />
-                    )}
+                    {deployment.environment === "production" &&
+                      deployment.active && (
+                        <EnvStatusBadge variant="current" text="Current" />
+                      )}
                   </div>
-                  <div className={cn("font-normal font-mono truncate text-xs mt-1", "text-gray-9")}>
+                  <div
+                    className={cn(
+                      "font-normal font-mono truncate text-xs mt-1",
+                      "text-gray-9"
+                    )}
+                  >
                     {deployment.pullRequest?.title ?? "—"}
                   </div>
                 </div>
@@ -142,7 +155,9 @@ export const DeploymentsList = () => {
                     <Cube className="text-gray-12" size="sm-regular" />
                     <div className="flex gap-1">
                       <div className="flex gap-0.5">
-                        <span className="font-semibold text-grayA-12 tabular-nums">2</span>
+                        <span className="font-semibold text-grayA-12 tabular-nums">
+                          2
+                        </span>
                         <span>CPU</span>
                       </div>
                       <span> / </span>
@@ -170,7 +185,7 @@ export const DeploymentsList = () => {
               className={cn(
                 "size-5 rounded flex items-center justify-center cursor-pointer border border-grayA-3 transition-all duration-100",
                 "bg-grayA-3",
-                isSelected && "bg-grayA-5",
+                isSelected && "bg-grayA-5"
               )}
             >
               <CodeBranch size="sm-regular" className="text-gray-12" />
@@ -185,13 +200,18 @@ export const DeploymentsList = () => {
                     <div
                       className={cn(
                         "font-normal font-mono truncate leading-5 text-[13px]",
-                        "text-accent-12",
+                        "text-accent-12"
                       )}
                     >
                       {deployment.source.branch}
                     </div>
                   </div>
-                  <div className={cn("font-normal font-mono truncate text-xs mt-1", "text-gray-9")}>
+                  <div
+                    className={cn(
+                      "font-normal font-mono truncate text-xs mt-1",
+                      "text-gray-9"
+                    )}
+                  >
                     {deployment.source.gitSha}
                   </div>
                 </div>
@@ -221,7 +241,12 @@ export const DeploymentsList = () => {
                             {deployment.author.name}
                           </span>
                         </div>
-                        <div className={cn("font-mono text-xs mt-1", "text-gray-9")}>
+                        <div
+                          className={cn(
+                            "font-mono text-xs mt-1",
+                            "text-gray-9"
+                          )}
+                        >
                           <TimestampInfo
                             value={deployment.createdAt}
                             className="font-mono text-xs text-gray-9"
@@ -289,16 +314,21 @@ export const DeploymentsList = () => {
       onRowClick={setSelectedDeployment}
       selectedItem={selectedDeployment}
       keyExtractor={(deployment) => deployment.id}
-      rowClassName={(deployment) => getRowClassName(deployment, selectedDeployment)}
+      rowClassName={(deployment) =>
+        getRowClassName(deployment, selectedDeployment)
+      }
       loadMoreFooterProps={{
         hide: isLoading,
         buttonText: "Load more deployments",
         hasMore,
         countInfoText: (
           <div className="flex gap-2">
-            <span>Showing</span> <span className="text-accent-12">{deployments.length}</span>
+            <span>Showing</span>{" "}
+            <span className="text-accent-12">
+              {new Intl.NumberFormat().format(deployments.length)}
+            </span>
             <span>of</span>
-            {totalCount}
+            {new Intl.NumberFormat().format(totalCount)}
             <span>deployments</span>
           </div>
         ),
@@ -309,8 +339,8 @@ export const DeploymentsList = () => {
             <Empty.Icon className="w-auto" />
             <Empty.Title>No Deployments Found</Empty.Title>
             <Empty.Description className="text-left">
-              There are no deployments yet. Push to your connected repository or trigger a manual
-              deployment to get started.
+              There are no deployments yet. Push to your connected repository or
+              trigger a manual deployment to get started.
             </Empty.Description>
             <Empty.Actions className="mt-4 justify-start">
               <a

--- a/apps/dashboard/app/(app)/projects/_components/list/index.tsx
+++ b/apps/dashboard/app/(app)/projects/_components/list/index.tsx
@@ -38,8 +38,8 @@ export const ProjectsList = () => {
           <Empty.Icon className="w-auto" />
           <Empty.Title>No Projects Found</Empty.Title>
           <Empty.Description className="text-left">
-            There are no projects configured yet. Create your first project to start deploying and
-            managing your applications.
+            There are no projects configured yet. Create your first project to
+            start deploying and managing your applications.
           </Empty.Description>
           <Empty.Actions className="mt-4 justify-start">
             <a
@@ -68,7 +68,8 @@ export const ProjectsList = () => {
           }}
         >
           {projects.map((project) => {
-            const primaryHostname = project.hostnames[0]?.hostname || "No domain";
+            const primaryHostname =
+              project.hostnames[0]?.hostname || "No domain";
             return (
               <ProjectCard
                 projectId={project.id}
@@ -76,7 +77,9 @@ export const ProjectsList = () => {
                 name={project.name}
                 domain={primaryHostname}
                 commitTitle="Latest deployment"
-                commitDate={new Date(project.updatedAt || project.createdAt).toLocaleDateString()}
+                commitDate={new Date(
+                  project.updatedAt || project.createdAt
+                ).toLocaleDateString()}
                 branch={project.branch || "main"}
                 author="Unknown"
                 regions={["us-east-1", "us-west-2", "ap-east-1"]}
@@ -111,9 +114,13 @@ export const ProjectsList = () => {
           countInfoText={
             <div className="flex gap-2">
               <span>Viewing</span>
-              <span className="text-accent-12">{projects.length}</span>
+              <span className="text-accent-12">
+                {new Intl.NumberFormat().format(projects.length)}
+              </span>
               <span>of</span>
-              <span className="text-grayA-12">{totalCount}</span>
+              <span className="text-grayA-12">
+                {new Intl.NumberFormat().format(totalCount)}
+              </span>
               <span>projects</span>
             </div>
           }

--- a/apps/dashboard/app/(app)/ratelimits/[namespaceId]/_overview/components/table/logs-table.tsx
+++ b/apps/dashboard/app/(app)/ratelimits/[namespaceId]/_overview/components/table/logs-table.tsx
@@ -14,7 +14,11 @@ import { LogsTableAction } from "./components/logs-actions";
 import { IdentifierColumn } from "./components/override-indicator";
 import { useRatelimitOverviewLogsQuery } from "./hooks/use-logs-query";
 import type { SortFields } from "./query-logs.schema";
-import { STATUS_STYLES, getRowClassName, getStatusStyle } from "./utils/get-row-class";
+import {
+  STATUS_STYLES,
+  getRowClassName,
+  getStatusStyle,
+} from "./utils/get-row-class";
 
 // const MAX_LATENCY = 10;
 export const RatelimitOverviewLogsTable = ({
@@ -24,10 +28,16 @@ export const RatelimitOverviewLogsTable = ({
 }) => {
   const [selectedLog, setSelectedLog] = useState<RatelimitOverviewLog>();
   const { getSortDirection, toggleSort } = useSort<SortFields>();
-  const { historicalLogs, isLoading, isLoadingMore, loadMore, hasMore, totalCount } =
-    useRatelimitOverviewLogsQuery({
-      namespaceId,
-    });
+  const {
+    historicalLogs,
+    isLoading,
+    isLoadingMore,
+    loadMore,
+    hasMore,
+    totalCount,
+  } = useRatelimitOverviewLogsQuery({
+    namespaceId,
+  });
 
   const columns = (namespaceId: string): Column<RatelimitOverviewLog>[] => {
     return [
@@ -67,7 +77,7 @@ export const RatelimitOverviewLogsTable = ({
                   "uppercase px-[6px] rounded-md font-mono whitespace-nowrap",
                   selectedLog?.request_id === log.request_id
                     ? STATUS_STYLES.success.badge.selected
-                    : STATUS_STYLES.success.badge.default,
+                    : STATUS_STYLES.success.badge.default
                 )}
                 title={`${log.passed_count.toLocaleString()} Passed requests`}
               >
@@ -101,7 +111,7 @@ export const RatelimitOverviewLogsTable = ({
                   "uppercase px-[6px] rounded-md font-mono whitespace-nowrap gap-[6px]",
                   selectedLog?.request_id === log.request_id
                     ? style.badge.selected
-                    : style.badge.default,
+                    : style.badge.default
                 )}
                 title={`${log.blocked_count.toLocaleString()} Blocked requests`}
               >
@@ -180,7 +190,9 @@ export const RatelimitOverviewLogsTable = ({
             value={log.time}
             className={cn(
               "font-mono group-hover:underline decoration-dotted",
-              selectedLog && selectedLog.request_id !== log.request_id && "pointer-events-none",
+              selectedLog &&
+                selectedLog.request_id !== log.request_id &&
+                "pointer-events-none"
             )}
           />
         ),
@@ -210,7 +222,9 @@ export const RatelimitOverviewLogsTable = ({
       onLoadMore={loadMore}
       columns={columns(namespaceId)}
       keyExtractor={(log) => log.identifier}
-      rowClassName={(rowLog) => getRowClassName(rowLog, selectedLog as RatelimitOverviewLog)}
+      rowClassName={(rowLog) =>
+        getRowClassName(rowLog, selectedLog as RatelimitOverviewLog)
+      }
       loadMoreFooterProps={{
         itemLabel: "identifiers",
         buttonText: "Load more logs",
@@ -218,8 +232,11 @@ export const RatelimitOverviewLogsTable = ({
         hide: isLoading,
         countInfoText: (
           <div className="flex gap-2">
-            <span>Showing</span> <span className="text-accent-12">{historicalLogs.length}</span>
-            <span>of {totalCount}</span>
+            <span>Showing</span>{" "}
+            <span className="text-accent-12">
+              {new Intl.NumberFormat().format(historicalLogs.length)}
+            </span>
+            <span>of {new Intl.NumberFormat().format(totalCount)}</span>
             <span>rate limit identifiers</span>
           </div>
         ),
@@ -230,8 +247,9 @@ export const RatelimitOverviewLogsTable = ({
             <Empty.Icon className="w-auto" />
             <Empty.Title>Logs</Empty.Title>
             <Empty.Description className="text-left">
-              No rate limit data to show. Once requests are made, you'll see a summary of passed and
-              blocked requests for each rate limit identifier.
+              No rate limit data to show. Once requests are made, you'll see a
+              summary of passed and blocked requests for each rate limit
+              identifier.
             </Empty.Description>
             <Empty.Actions className="mt-4 justify-start">
               <a

--- a/apps/dashboard/app/(app)/ratelimits/[namespaceId]/logs/components/table/logs-table.tsx
+++ b/apps/dashboard/app/(app)/ratelimits/[namespaceId]/logs/components/table/logs-table.tsx
@@ -63,13 +63,21 @@ const getSelectedClassName = (log: RatelimitLog, isSelected: boolean) => {
 };
 
 export const RatelimitLogsTable = () => {
-  const { setSelectedLog, selectedLog, isLive, namespaceId } = useRatelimitLogsContext();
-  const { realtimeLogs, historicalLogs, isLoading, isLoadingMore, loadMore, totalCount, hasMore } =
-    useRatelimitLogsQuery({
-      namespaceId,
-      startPolling: isLive,
-      pollIntervalMs: 2000,
-    });
+  const { setSelectedLog, selectedLog, isLive, namespaceId } =
+    useRatelimitLogsContext();
+  const {
+    realtimeLogs,
+    historicalLogs,
+    isLoading,
+    isLoadingMore,
+    loadMore,
+    totalCount,
+    hasMore,
+  } = useRatelimitLogsQuery({
+    namespaceId,
+    startPolling: isLive,
+    pollIntervalMs: 2000,
+  });
 
   const getRowClassName = (log: RatelimitLog) => {
     const style = getStatusStyle(log.status);
@@ -83,14 +91,13 @@ export const RatelimitLogsTable = () => {
       style.focusRing,
       isSelected && style.selected,
       isLive &&
-        !realtimeLogs.some((realtime) => realtime.request_id === log.request_id) && [
-          "opacity-50",
-          "hover:opacity-100",
-        ],
+        !realtimeLogs.some(
+          (realtime) => realtime.request_id === log.request_id
+        ) && ["opacity-50", "hover:opacity-100"],
       selectedLog && {
         "opacity-50 z-0": !isSelected,
         "opacity-100 z-10": isSelected,
-      },
+      }
     );
   };
 
@@ -108,7 +115,9 @@ export const RatelimitLogsTable = () => {
               value={log.time}
               className={cn(
                 "font-mono group-hover:underline decoration-dotted",
-                selectedLog && selectedLog.request_id !== log.request_id && "pointer-events-none",
+                selectedLog &&
+                  selectedLog.request_id !== log.request_id &&
+                  "pointer-events-none"
               )}
             />
           </div>
@@ -118,7 +127,11 @@ export const RatelimitLogsTable = () => {
         key: "identifier",
         header: "Identifier",
         width: "15%",
-        render: (log) => <div className="font-mono truncate mr-1 max-w-40">{log.identifier}</div>,
+        render: (log) => (
+          <div className="font-mono truncate mr-1 max-w-40">
+            {log.identifier}
+          </div>
+        ),
       },
       {
         key: "rejected",
@@ -131,7 +144,7 @@ export const RatelimitLogsTable = () => {
             <Badge
               className={cn(
                 "uppercase px-[6px] rounded-md font-mono min-w-[70px] inline-block text-center",
-                isSelected ? style.badge.selected : style.badge.default,
+                isSelected ? style.badge.selected : style.badge.default
               )}
             >
               {log.status === 0 ? "Blocked" : "Passed"}
@@ -145,7 +158,9 @@ export const RatelimitLogsTable = () => {
         width: "auto",
         render: (log) => {
           return (
-            <div className="font-mono">{safeParseJson(log.response_body)?.limit ?? "<EMPTY>"}</div>
+            <div className="font-mono">
+              {safeParseJson(log.response_body)?.limit ?? "<EMPTY>"}
+            </div>
           );
         },
       },
@@ -174,7 +189,9 @@ export const RatelimitLogsTable = () => {
                 value={safeParseJson(log.response_body)?.reset ?? "<EMPTY>"}
                 className={cn(
                   "font-mono group-hover:underline decoration-dotted",
-                  selectedLog && selectedLog.request_id !== log.request_id && "pointer-events-none",
+                  selectedLog &&
+                    selectedLog.request_id !== log.request_id &&
+                    "pointer-events-none"
                 )}
               />
             </div>
@@ -196,7 +213,7 @@ export const RatelimitLogsTable = () => {
         render: (log) => <LogsTableAction identifier={log.identifier} />,
       },
     ],
-    [selectedLog?.request_id],
+    [selectedLog?.request_id]
   );
 
   return (
@@ -218,9 +235,12 @@ export const RatelimitLogsTable = () => {
         hide: isLoading,
         countInfoText: (
           <div className="flex gap-2">
-            <span>Showing</span> <span className="text-accent-12">{historicalLogs.length}</span>
+            <span>Showing</span>{" "}
+            <span className="text-accent-12">
+              {new Intl.NumberFormat().format(historicalLogs.length)}
+            </span>
             <span>of</span>
-            {totalCount}
+            {new Intl.NumberFormat().format(totalCount)}
             <span>ratelimit requests</span>
           </div>
         ),
@@ -231,8 +251,9 @@ export const RatelimitLogsTable = () => {
             <Empty.Icon className="w-auto" />
             <Empty.Title>Logs</Empty.Title>
             <Empty.Description className="text-left">
-              No ratelimit logs yet. Once API requests start coming in, you'll see a detailed view
-              of your rate limits, including passed and blocked requests, across your API endpoints.
+              No ratelimit logs yet. Once API requests start coming in, you'll
+              see a detailed view of your rate limits, including passed and
+              blocked requests, across your API endpoints.
             </Empty.Description>
             <Empty.Actions className="mt-4 justify-start">
               <a

--- a/apps/dashboard/app/(app)/settings/root-keys/components/table/root-keys-list.tsx
+++ b/apps/dashboard/app/(app)/settings/root-keys/components/table/root-keys-list.tsx
@@ -13,7 +13,9 @@ import { useCallback, useMemo, useState } from "react";
 import { RootKeyDialog } from "../root-key/root-key-dialog";
 
 // Type guard function to check if a string is a valid UnkeyPermission
-const isUnkeyPermission = (permissionName: string): permissionName is UnkeyPermission => {
+const isUnkeyPermission = (
+  permissionName: string
+): permissionName is UnkeyPermission => {
   const result = unkeyPermissionValidation.safeParse(permissionName);
   return result.success;
 };
@@ -32,22 +34,25 @@ import { getRowClassName } from "./utils/get-row-class";
 
 const RootKeysTableActions = dynamic(
   () =>
-    import("./components/actions/root-keys-table-action.popover.constants").then(
-      (mod) => mod.RootKeysTableActions,
-    ),
+    import(
+      "./components/actions/root-keys-table-action.popover.constants"
+    ).then((mod) => mod.RootKeysTableActions),
   {
     loading: () => (
       <button
         type="button"
         className={cn(
           "group-data-[state=open]:bg-gray-6 group-hover:bg-gray-6 group size-5 p-0 rounded m-0 items-center flex justify-center",
-          "border border-gray-6 group-hover:border-gray-8 ring-2 ring-transparent focus-visible:ring-gray-7 focus-visible:border-gray-7",
+          "border border-gray-6 group-hover:border-gray-8 ring-2 ring-transparent focus-visible:ring-gray-7 focus-visible:border-gray-7"
         )}
       >
-        <Dots className="group-hover:text-gray-12 text-gray-11" size="sm-regular" />
+        <Dots
+          className="group-hover:text-gray-12 text-gray-11"
+          size="sm-regular"
+        />
       </button>
     ),
-  },
+  }
 );
 
 export const RootKeysList = () => {
@@ -75,7 +80,7 @@ export const RootKeysList = () => {
   // Memoize the row className function
   const getRowClassNameMemoized = useCallback(
     (rootKey: RootKey) => getRowClassName(rootKey, selectedRootKey),
-    [selectedRootKey],
+    [selectedRootKey]
   );
 
   // Memoize the loadMoreFooterProps to prevent unnecessary re-renders
@@ -86,14 +91,17 @@ export const RootKeysList = () => {
       hasMore,
       countInfoText: (
         <div className="flex gap-2">
-          <span>Showing</span> <span className="text-accent-12">{rootKeys.length}</span>
+          <span>Showing</span>{" "}
+          <span className="text-accent-12">
+            {new Intl.NumberFormat().format(rootKeys.length)}
+          </span>
           <span>of</span>
-          {totalCount}
+          {new Intl.NumberFormat().format(totalCount)}
           <span>root keys</span>
         </div>
       ),
     }),
-    [isLoading, hasMore, rootKeys.length, totalCount],
+    [isLoading, hasMore, rootKeys.length, totalCount]
   );
 
   // Memoize the emptyState to prevent unnecessary re-renders
@@ -104,8 +112,8 @@ export const RootKeysList = () => {
           <Empty.Icon className="w-auto" />
           <Empty.Title>No Root Keys Found</Empty.Title>
           <Empty.Description className="text-left">
-            There are no root keys configured yet. Create your first root key to start managing
-            permissions and access control.
+            There are no root keys configured yet. Create your first root key to
+            start managing permissions and access control.
           </Empty.Description>
           <Empty.Actions className="mt-4 justify-start">
             <a
@@ -123,7 +131,7 @@ export const RootKeysList = () => {
         </Empty>
       </div>
     ),
-    [],
+    []
   );
 
   // Memoize the config to prevent unnecessary re-renders
@@ -134,7 +142,7 @@ export const RootKeysList = () => {
       rowBorders: true,
       containerPadding: "px-0",
     }),
-    [],
+    []
   );
 
   // Memoize the keyExtractor to prevent unnecessary re-renders
@@ -142,13 +150,19 @@ export const RootKeysList = () => {
 
   // Memoize the renderSkeletonRow function to prevent unnecessary re-renders
   const renderSkeletonRow = useCallback(
-    ({ columns, rowHeight }: { columns: Column<RootKey>[]; rowHeight: number }) =>
+    ({
+      columns,
+      rowHeight,
+    }: {
+      columns: Column<RootKey>[];
+      rowHeight: number;
+    }) =>
       columns.map((column) => (
         <td
           key={column.key}
           className={cn(
             "text-xs align-middle whitespace-nowrap",
-            column.key === "root_key" ? "py-[6px]" : "py-1",
+            column.key === "root_key" ? "py-[6px]" : "py-1"
           )}
           style={{ height: `${rowHeight}px` }}
         >
@@ -160,7 +174,7 @@ export const RootKeysList = () => {
           {column.key === "action" && <ActionColumnSkeleton />}
         </td>
       )),
-    [],
+    []
   );
 
   // Memoize the existingKey object to prevent unnecessary re-renders
@@ -171,7 +185,9 @@ export const RootKeysList = () => {
 
     // Guard against undefined permissions and use type guard function
     const permissions = editingKey.permissions ?? [];
-    const validatedPermissions = permissions.map((p) => p.name).filter(isUnkeyPermission);
+    const validatedPermissions = permissions
+      .map((p) => p.name)
+      .filter(isUnkeyPermission);
 
     return {
       id: editingKey.id,
@@ -194,7 +210,7 @@ export const RootKeysList = () => {
               className={cn(
                 "size-5 rounded flex items-center justify-center cursor-pointer border border-grayA-3 transition-all duration-100",
                 "bg-grayA-3",
-                isSelected && "bg-grayA-5",
+                isSelected && "bg-grayA-5"
               )}
             >
               <Key2 size="sm-regular" className="text-gray-12" />
@@ -208,7 +224,9 @@ export const RootKeysList = () => {
                   <div
                     className={cn(
                       "font-medium truncate leading-4 text-[13px]",
-                      rootKey.name ? "text-accent-12" : "text-gray-9 italic font-normal",
+                      rootKey.name
+                        ? "text-accent-12"
+                        : "text-gray-9 italic font-normal"
                     )}
                   >
                     {rootKey.name ?? "Unnamed Root Key"}
@@ -227,8 +245,8 @@ export const RootKeysList = () => {
           <InfoTooltip
             content={
               <p>
-                This is the first part of the key to visually match it. We don't store the full key
-                for security reasons.
+                This is the first part of the key to visually match it. We don't
+                store the full key for security reasons.
               </p>
             }
           >
@@ -259,7 +277,9 @@ export const RootKeysList = () => {
           return (
             <TimestampInfo
               value={rootKey.createdAt}
-              className={cn("font-mono group-hover:underline decoration-dotted")}
+              className={cn(
+                "font-mono group-hover:underline decoration-dotted"
+              )}
             />
           );
         },
@@ -282,11 +302,13 @@ export const RootKeysList = () => {
         header: "",
         width: "auto",
         render: (rootKey) => {
-          return <RootKeysTableActions rootKey={rootKey} onEditKey={handleEditKey} />;
+          return (
+            <RootKeysTableActions rootKey={rootKey} onEditKey={handleEditKey} />
+          );
         },
       },
     ],
-    [selectedRootKeyId, handleEditKey],
+    [selectedRootKeyId, handleEditKey]
   );
 
   return (

--- a/apps/dashboard/components/virtual-table/components/loading-indicator.tsx
+++ b/apps/dashboard/components/virtual-table/components/loading-indicator.tsx
@@ -57,11 +57,15 @@ export const LoadMoreFooter = ({
           type="button"
           onClick={handleOpen}
           className="bg-gray-1 dark:bg-black border border-gray-6 rounded-lg shadow-lg p-3 transition-all duration-200 hover:shadow-xl hover:scale-105 group"
-          title={`${buttonText} • ${totalVisible} of ${totalCount} ${itemLabel}`}
+          title={`${buttonText} • ${new Intl.NumberFormat().format(
+            totalVisible
+          )} of ${new Intl.NumberFormat().format(totalCount)} ${itemLabel}`}
         >
           <div className="flex items-center gap-2">
             <div className="flex items-center gap-2">
-              <span className="text-[11px] text-gray-9 font-medium">{countInfoText}</span>
+              <span className="text-[11px] text-gray-9 font-medium">
+                {countInfoText}
+              </span>
             </div>
             <div className="w-px h-3 bg-gray-6" />
             <span className="text-[12px] font-medium text-gray-11 group-hover:text-gray-12 transition-colors">
@@ -114,15 +118,19 @@ export const LoadMoreFooter = ({
               animation: "fadeInUp 0.3s ease-out 0.3s both",
             }}
           >
-            {countInfoText && <div className="transition-all duration-200">{countInfoText}</div>}
+            {countInfoText && (
+              <div className="transition-all duration-200">{countInfoText}</div>
+            )}
             {!countInfoText && (
               <div className="flex gap-2 transition-all duration-200">
                 <span>Viewing</span>
                 <span className="text-accent-12 transition-colors duration-200">
-                  {totalVisible}
+                  {new Intl.NumberFormat().format(totalVisible)}
                 </span>
                 <span>of</span>
-                <span className="text-grayA-12 transition-colors duration-200">{totalCount}</span>
+                <span className="text-grayA-12 transition-colors duration-200">
+                  {new Intl.NumberFormat().format(totalCount)}
+                </span>
                 <span>{itemLabel}</span>
               </div>
             )}


### PR DESCRIPTION
### What does this PR do?

Implements proper number formatting for pagination counts in log footers across the dashboard. Large numbers like `1239436` are now displayed as `1,239,436` (or locale-appropriate formatting) making them much more readable for users.

- Applied `new Intl.NumberFormat().format(number)` to all "Showing X of Y" pagination text in:
- Main logs table
- Key details logs table  
- Ratelimit logs tables
- Virtual table loading indicator
- API lists
- Projects list
- Root keys table
- Deployments table
- Authorization roles & permissions tables

fixes #3922

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Navigate to any logs page with large numbers (>1000 entries)
- Verify pagination footer displays formatted numbers (e.g., "Showing 100 of 1,239,436 requests")
- Test across different table components (APIs, keys, logs, deployments, etc.)
- Verify numbers are formatted consistently across all pagination footers

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues