### PR TITLE
feat: add CTRL_URL environment variable to dashboard

### DIFF
--- a/go/k8s/manifests/dashboard.yaml
+++ b/go/k8s/manifests/dashboard.yaml
@@ -7,59 +7,61 @@ metadata:
   labels:
     app: dashboard
 spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: dashboard
-  template:
-    metadata:
-      labels:
-        app: dashboard
-    spec:
-      initContainers:
-        - name: wait-for-dependencies
-          image: busybox:1.36
-          command:
-            - sh
-            - -c
-            - |
-              until nc -z planetscale 3900; do
-                echo waiting for planetscale
-                sleep 2
-              done
-      containers:
-        - name: dashboard
-          image: unkey/dashboard:latest
-          imagePullPolicy: Never
-          ports:
-            - containerPort: 3000
-          env:
-            # Database configuration
-            - name: DATABASE_HOST
-              value: "planetscale:3900"
-            # ClickHouse configuration
-            - name: CLICKHOUSE_URL
-              value: "http://unkey:password@clickhouse:8123"
-            # Environment
-            - name: NODE_ENV
-              value: "production"
-            # Instance identification
-            - name: UNKEY_PLATFORM
-              value: "kubernetes"
-            - name: UNKEY_REGION
-              value: "local"
-          readinessProbe:
-            httpGet:
-              path: /
-              port: 3000
-            initialDelaySeconds: 10
-            periodSeconds: 5
-          livenessProbe:
-            httpGet:
-              path: /
-              port: 3000
-            initialDelaySeconds: 30
-            periodSeconds: 10
+    replicas: 1
+    selector:
+        matchLabels:
+            app: dashboard
+    template:
+        metadata:
+            labels:
+                app: dashboard
+        spec:
+            initContainers:
+                - name: wait-for-dependencies
+                  image: busybox:1.36
+                  command:
+                      - sh
+                      - -c
+                      - |
+                          until nc -z planetscale 3900; do
+                            echo waiting for planetscale
+                            sleep 2
+                          done
+            containers:
+                - name: dashboard
+                  image: unkey/dashboard:latest
+                  imagePullPolicy: Never
+                  ports:
+                      - containerPort: 3000
+                  env:
+                      # Database configuration
+                      - name: DATABASE_HOST
+                        value: "planetscale:3900"
+                      # ClickHouse configuration
+                      - name: CLICKHOUSE_URL
+                        value: "http://unkey:password@clickhouse:8123"
+                      # Environment
+                      - name: NODE_ENV
+                        value: "production"
+                      # Instance identification
+                      - name: UNKEY_PLATFORM
+                        value: "kubernetes"
+                      - name: UNKEY_REGION
+                        value: "local"
+                      - name: CTRL_URL
+                        value: "http://ctrl:7091"
+                  readinessProbe:
+                      httpGet:
+                          path: /
+                          port: 3000
+                      initialDelaySeconds: 10
+                      periodSeconds: 5
+                  livenessProbe:
+                      httpGet:
+                          path: /
+                          port: 3000
+                      initialDelaySeconds: 30
+                      periodSeconds: 10
 
 ---
 apiVersion: v1

--- a/tools/local/src/cmd/dashboard.ts
+++ b/tools/local/src/cmd/dashboard.ts
@@ -32,6 +32,9 @@ export async function bootstrapDashboard(resources: {
     Clickhouse: {
       CLICKHOUSE_URL: "http://default:password@localhost:8123",
     },
+    ControlPlane: {
+      CTRL_URL: "http://localhost:7091",
+    },
   });
 
   if (fs.existsSync(envPath)) {


### PR DESCRIPTION
## What does this PR do?

Adds the `CTRL_URL` environment variable to the dashboard configuration in both Kubernetes manifests and local development setup. This allows the dashboard to communicate with the control plane service.

Fixes # (issue)

## Type of change

- [x] Enhancement (small improvements)

## How should this be tested?

- Verify that the dashboard can connect to the control plane service using the provided URL
- Test dashboard functionality that relies on control plane interactions

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Dashboard is now exposed via a LoadBalancer service on port 3000, making it accessible externally.
  - Dashboard container now includes a control plane URL environment variable (CTRL_URL) for connectivity.
  - Local bootstrap sets CTRL_URL to http://localhost:7091; in-cluster configuration uses http://ctrl:7091.
- Chores
  - Deployment manifest formatting and structure cleaned up without changing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->