### PR TITLE
fix: do 30sec credits ttl instead of 60

### DIFF
--- a/go/apps/api/run.go
+++ b/go/apps/api/run.go
@@ -183,7 +183,7 @@ func Run(ctx context.Context, cfg Config) error {
 		Logger:  logger,
 		DB:      db,
 		Counter: ctr,
-		TTL:     60 * time.Second,
+		TTL:     30 * time.Second,
 	})
 	if err != nil {
 		return fmt.Errorf("unable to create usage limiter service: %w", err)

--- a/go/internal/services/usagelimiter/redis.go
+++ b/go/internal/services/usagelimiter/redis.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	defaultTTL           = 10 * time.Minute
+	defaultTTL           = 30 * time.Second
 	defaultReplayWorkers = 8
 )
 

--- a/go/pkg/testutil/http.go
+++ b/go/pkg/testutil/http.go
@@ -118,7 +118,7 @@ func NewHarness(t *testing.T) *Harness {
 		Logger:  logger,
 		DB:      db,
 		Counter: ctr,
-		TTL:     60 * time.Second,
+		TTL:     30 * time.Second,
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
## What does this PR do?

Credits should have 30 secs ttl but they don't atm so now they do

*If there is not an issue for this, please create one first. This is used to tracking purposes and also helps use understand why this PR exists*

<!-- If there isn't an issue for this PR, please re-review our Contributing Guide and create an issue -->

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Test A
- Test B

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced the default usage limit window to 30 seconds (down from 60s/10m), leading to faster counter expiration and more responsive quota feedback across the app and API.
* **Tests**
  * Updated test harness to reflect the new 30-second TTL for usage limiting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->