### PR TITLE
feat: show user's email

### DIFF
--- a/apps/dashboard/components/navigation/sidebar/user-button.tsx
+++ b/apps/dashboard/components/navigation/sidebar/user-button.tsx
@@ -65,6 +65,15 @@ export const UserButton: React.FC<UserButtonProps> = ({
         </div>
       </DropdownMenuTrigger>
       <DropdownMenuContent side="bottom" className="flex w-min-44 flex-col gap-2" align="start">
+        <DropdownMenuItem>
+          <span
+            title={user?.email}
+            className="text-accent-11 text-xs overflow-hidden text-ellipsis max-w-44"
+          >
+            {user?.email}
+          </span>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
         <DropdownMenuGroup className="w-full">
           <DropdownMenuLabel>Theme</DropdownMenuLabel>
           <Tabs value={theme} onValueChange={setTheme}>
@@ -82,6 +91,7 @@ export const UserButton: React.FC<UserButtonProps> = ({
           </Tabs>
         </DropdownMenuGroup>
         <DropdownMenuSeparator />
+
         <DropdownMenuGroup className="w-full">
           <DropdownMenuItem
             asChild

--- a/apps/dashboard/components/navigation/sidebar/user-button.tsx
+++ b/apps/dashboard/components/navigation/sidebar/user-button.tsx
@@ -65,15 +65,19 @@ export const UserButton: React.FC<UserButtonProps> = ({
         </div>
       </DropdownMenuTrigger>
       <DropdownMenuContent side="bottom" className="flex w-min-44 flex-col gap-2" align="start">
-        <DropdownMenuItem>
-          <span
-            title={user?.email}
-            className="text-accent-11 text-xs overflow-hidden text-ellipsis max-w-44"
-          >
-            {user?.email}
-          </span>
-        </DropdownMenuItem>
-        <DropdownMenuSeparator />
+        {user?.email && (
+          <>
+            <DropdownMenuLabel className="font-normal p-0">
+              <span
+                title={user.email}
+                className="text-accent-11 text-xs truncate max-w-44"
+              >
+                {user.email}
+              </span>
+            </DropdownMenuLabel>
+            <DropdownMenuSeparator />
+          </>
+        )}
         <DropdownMenuGroup className="w-full">
           <DropdownMenuLabel>Theme</DropdownMenuLabel>
           <Tabs value={theme} onValueChange={setTheme}>

--- a/apps/dashboard/components/navigation/sidebar/user-button.tsx
+++ b/apps/dashboard/components/navigation/sidebar/user-button.tsx
@@ -68,10 +68,7 @@ export const UserButton: React.FC<UserButtonProps> = ({
         {user?.email && (
           <>
             <DropdownMenuLabel className="font-normal p-0">
-              <span
-                title={user.email}
-                className="text-accent-11 text-xs truncate max-w-44"
-              >
+              <span title={user.email} className="text-accent-11 text-xs truncate max-w-44">
                 {user.email}
               </span>
             </DropdownMenuLabel>

--- a/apps/dashboard/components/navigation/sidebar/user-button.tsx
+++ b/apps/dashboard/components/navigation/sidebar/user-button.tsx
@@ -67,7 +67,7 @@ export const UserButton: React.FC<UserButtonProps> = ({
       <DropdownMenuContent side="bottom" className="flex w-min-44 flex-col gap-2" align="start">
         {user?.email && (
           <>
-            <DropdownMenuLabel className="font-normal p-0">
+            <DropdownMenuLabel className="font-normal">
               <span title={user.email} className="text-accent-11 text-xs truncate max-w-44">
                 {user.email}
               </span>


### PR DESCRIPTION
## What does this PR do?

A user couldn't find out what email account they're using. We would only show this if they had subscibed and looked at the team page.
This adds a small display in the dropdown menu of the user button component. The email is shown at the top of the dropdown with text ellipsis for overflow handling and a tooltip for viewing the full email when hovering.


![CleanShot 2025-09-24 at 23.42.20@2x.png](https://app.graphite.dev/user-attachments/assets/8fe4606a-c5c6-4fa7-85bb-2f7d82731239.png)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (small improvements)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Open the user dropdown menu and verify the user's email appears at the top
- Test with various email lengths to ensure text ellipsis works correctly
- Hover over truncated emails to confirm the full email appears in the tooltip

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary