### PR TITLE
fix: logdrain crashes

### DIFF
--- a/apps/logdrain/src/worker.ts
+++ b/apps/logdrain/src/worker.ts
@@ -19,10 +19,10 @@ const logsSchema = z.array(
 
             return s;
           }
-        })
+        }),
       ),
     })
-    .passthrough()
+    .passthrough(),
 );
 
 const fetchSchema = z.object({
@@ -60,10 +60,7 @@ const alarmSchema = z.object({
   ScriptTags: z.array(z.object({}).passthrough()),
 });
 
-const eventSchema = z.discriminatedUnion("EventType", [
-  fetchSchema,
-  alarmSchema,
-]);
+const eventSchema = z.discriminatedUnion("EventType", [fetchSchema, alarmSchema]);
 
 const app = new Hono<{
   Bindings: {
@@ -110,7 +107,7 @@ app.all("*", async (c) => {
         eventTime: l.EventTimestampMs,
         logdrainTime: now,
         latency: now - l.EventTimestampMs,
-      }))
+      })),
     );
 
     for (const line of lines) {


### PR DESCRIPTION
1. Cloudflare changed the logpush format slightly
2. Our logdrain worker couldn't parse it
3. we had a bug where we crashed if we couldn't parse it
4. cloudflare noticed we're crashing and just silently (WTF???) disabled the logpush


This fixes our bug and we now see logs in axiom again. 
I already deployed the logdrain.