### PR TITLE
fix: correct module name for gha-fetch-digest

### DIFF
--- a/tools/gha-fetch-digest/go.mod
+++ b/tools/gha-fetch-digest/go.mod
@@ -1,6 +1,6 @@
-module github.com/unkey/tools/gha-fetch-digest
+module github.com/unkeyed/unkey/tools/gha-fetch-digest
 
-go 1.25.0
+go 1.25.1
 
 require (
 	github.com/google/go-github/v63 v63.0.0


### PR DESCRIPTION
- forgot the unkeyed/ in the module name
- update to go 1.25.1

## What does this PR do?

This should hopefully enable it to be called by `go install` or `go run`.