### PR TITLE
fix: Use long blob versus blob text

### DIFF
--- a/go/pkg/db/schema.sql
+++ b/go/pkg/db/schema.sql
@@ -335,7 +335,7 @@ CREATE TABLE `deployments` (
 	`git_commit_author_avatar_url` varchar(512),
 	`git_commit_timestamp` bigint,
 	`runtime_config` json NOT NULL,
-	`openapi_spec` text,
+	`openapi_spec` longblob,
 	`status` enum('pending','building','deploying','network','ready','failed') NOT NULL DEFAULT 'pending',
 	`created_at` bigint NOT NULL,
 	`updated_at` bigint,
@@ -418,3 +418,4 @@ CREATE INDEX `project_idx` ON `domains` (`project_id`);
 CREATE INDEX `deployment_idx` ON `domains` (`deployment_id`);
 CREATE INDEX `workspace_idx` ON `acme_challenges` (`workspace_id`);
 CREATE INDEX `status_idx` ON `acme_challenges` (`status`);
+

--- a/go/pkg/partition/db/schema.sql
+++ b/go/pkg/partition/db/schema.sql
@@ -12,7 +12,7 @@ CREATE TABLE gateways (
   `workspace_id` varchar(255) NOT NULL,
   `deployment_id` varchar(255) NOT NULL,
   `hostname` varchar(255) NOT NULL,
-  `config` blob NOT NULL,   -- Protobuf with all configuration including deployment_id, workspace_id
+  `config` longblob NOT NULL,   -- Protobuf with all configuration including deployment_id, workspace_id
   PRIMARY KEY (`id`),
   UNIQUE KEY `gateways_pk` (`hostname`),
   INDEX idx_deployment_id (deployment_id)

--- a/internal/db/src/schema/deployments.ts
+++ b/internal/db/src/schema/deployments.ts
@@ -4,6 +4,7 @@ import { deploymentSteps } from "./deployment_steps";
 import { environments } from "./environments";
 import { projects } from "./projects";
 import { lifecycleDates } from "./util/lifecycle_dates";
+import { longblob } from "./util/longblob";
 import { workspaces } from "./workspaces";
 
 export const deployments = mysqlTable(
@@ -38,7 +39,7 @@ export const deployments = mysqlTable(
       .notNull(),
 
     // OpenAPI specification
-    openapiSpec: text("openapi_spec"),
+    openapiSpec: longblob("openapi_spec"),
 
     // Deployment status
     status: mysqlEnum("status", ["pending", "building", "deploying", "network", "ready", "failed"])

--- a/internal/db/src/schema/util/longblob.ts
+++ b/internal/db/src/schema/util/longblob.ts
@@ -1,0 +1,28 @@
+import { customType } from "drizzle-orm/mysql-core";
+
+/**
+ * Custom longblob type for MySQL in Drizzle ORM
+ *
+ * Usage:
+ * ```typescript
+ * import { longblob } from "./util/longblob";
+ *
+ * export const myTable = mysqlTable("my_table", {
+ *   data: longblob("data"),
+ * });
+ * ```
+ */
+export const longblob = customType<{
+  data: string | null;
+  driverData: string | null;
+}>({
+  dataType() {
+    return "longblob";
+  },
+  toDriver(value: string | null): string | null {
+    return value;
+  },
+  fromDriver(value: string | null): string | null {
+    return value;
+  },
+});


### PR DESCRIPTION
This adds the ability to use longblob versus text / blob so we can store openapi specs that are larger

## What does this PR do?

This adds the ability to use longblob versus text / blob so we can store openapi specs that are larger
<!-- If there isn't an issue for this PR, please re-review our Contributing Guide and create an issue -->

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Test A
- Test B

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary
