### PR TITLE
fix: panic when caling api with root key for disabled workspace

### DIFF
--- a/go/apps/api/integration/root_keys/root_keys_test.go
+++ b/go/apps/api/integration/root_keys/root_keys_test.go
@@ -1,0 +1,418 @@
+//go:build integration
+
+package root_keys
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/go/apps/api/integration"
+	handler "github.com/unkeyed/unkey/go/apps/api/routes/v2_keys_verify_key"
+	"github.com/unkeyed/unkey/go/pkg/db"
+	"github.com/unkeyed/unkey/go/pkg/hash"
+	"github.com/unkeyed/unkey/go/pkg/testutil"
+	"github.com/unkeyed/unkey/go/pkg/testutil/seed"
+	"github.com/unkeyed/unkey/go/pkg/uid"
+)
+
+// TestGetRootKey_Valid tests that a valid root key works correctly
+func TestGetRootKey_Valid(t *testing.T) {
+	testutil.SkipUnlessIntegration(t)
+
+	ctx := context.Background()
+	h := integration.New(t, integration.Config{NumNodes: 1})
+
+	workspace := h.Resources().UserWorkspace
+	rootKey := h.Seed.CreateRootKey(ctx, workspace.ID, "api.*.verify_key")
+
+	api := h.Seed.CreateAPI(ctx, seed.CreateApiRequest{
+		WorkspaceID: workspace.ID,
+	})
+
+	keyResponse := h.Seed.CreateKey(ctx, seed.CreateKeyRequest{
+		WorkspaceID: workspace.ID,
+		KeyAuthID:   api.KeyAuthID.String,
+	})
+
+	req := handler.Request{Key: keyResponse.Key}
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}
+
+	lb := integration.NewLoadbalancer(h)
+	res, err := integration.CallRandomNode[handler.Request, handler.Response](
+		lb, "POST", "/v2/keys.verifyKey", headers, req)
+
+	require.NoError(t, err)
+	require.Equal(t, 200, res.Status)
+	require.True(t, res.Body.Data.Valid)
+}
+
+// TestGetRootKey_NotFound tests that a non-existent root key returns proper error
+func TestGetRootKey_NotFound(t *testing.T) {
+	testutil.SkipUnlessIntegration(t)
+
+	ctx := context.Background()
+	h := integration.New(t, integration.Config{NumNodes: 1})
+
+	workspace := h.Resources().UserWorkspace
+	fakeRootKey := uid.New("test_fake_root_key")
+
+	api := h.Seed.CreateAPI(ctx, seed.CreateApiRequest{
+		WorkspaceID: workspace.ID,
+	})
+
+	keyResponse := h.Seed.CreateKey(ctx, seed.CreateKeyRequest{
+		WorkspaceID: workspace.ID,
+		KeyAuthID:   api.KeyAuthID.String,
+	})
+
+	req := handler.Request{Key: keyResponse.Key}
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", fakeRootKey)},
+	}
+
+	lb := integration.NewLoadbalancer(h)
+	res, err := integration.CallRandomNode[handler.Request, handler.Response](lb, "POST", "/v2/keys.verifyKey", headers, req)
+
+	require.NoError(t, err)
+	require.Equal(t, 401, res.Status, "should return 401 for non-existent root key")
+}
+
+// TestGetRootKey_Disabled tests that a disabled root key returns proper error
+func TestGetRootKey_Disabled(t *testing.T) {
+	testutil.SkipUnlessIntegration(t)
+
+	ctx := context.Background()
+	h := integration.New(t, integration.Config{NumNodes: 1})
+
+	workspace := h.Resources().UserWorkspace
+	rootKey := h.Seed.CreateRootKey(ctx, workspace.ID, "api.*.verify_key")
+
+	// Disable the root key
+	keyHash := hash.Sha256(rootKey)
+	keyRow, err := db.Query.FindKeyForVerification(ctx, h.DB.RO(), keyHash)
+	require.NoError(t, err)
+
+	err = db.Query.UpdateKey(ctx, h.DB.RW(), db.UpdateKeyParams{
+		ID:               keyRow.ID,
+		EnabledSpecified: 1,
+		Enabled:          sql.NullBool{Bool: false, Valid: true},
+		Now:              sql.NullInt64{Int64: time.Now().UnixMilli(), Valid: true},
+	})
+	require.NoError(t, err)
+
+	api := h.Seed.CreateAPI(ctx, seed.CreateApiRequest{
+		WorkspaceID: workspace.ID,
+	})
+
+	keyResponse := h.Seed.CreateKey(ctx, seed.CreateKeyRequest{
+		WorkspaceID: workspace.ID,
+		KeyAuthID:   api.KeyAuthID.String,
+	})
+
+	req := handler.Request{Key: keyResponse.Key}
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}
+
+	lb := integration.NewLoadbalancer(h)
+	res, err := integration.CallRandomNode[handler.Request, handler.Response](
+		lb, "POST", "/v2/keys.verifyKey", headers, req)
+
+	require.NoError(t, err)
+	require.Equal(t, 403, res.Status, "should return 403 for disabled root key")
+}
+
+// TestGetRootKey_Expired tests that an expired root key returns proper error
+func TestGetRootKey_Expired(t *testing.T) {
+	testutil.SkipUnlessIntegration(t)
+
+	ctx := context.Background()
+	h := integration.New(t, integration.Config{NumNodes: 1})
+
+	workspace := h.Resources().UserWorkspace
+	rootWorkspace := h.Resources().RootWorkspace
+	rootKeyring := h.Resources().RootKeyring
+
+	// Create an expired root key
+	expiredTime := time.Now().Add(-1 * time.Hour)
+	rootKeyResponse := h.Seed.CreateKey(ctx, seed.CreateKeyRequest{
+		WorkspaceID:    rootWorkspace.ID,
+		KeyAuthID:      rootKeyring.ID,
+		ForWorkspaceID: &workspace.ID,
+		Expires:        &expiredTime,
+	})
+	rootKey := rootKeyResponse.Key
+
+	api := h.Seed.CreateAPI(ctx, seed.CreateApiRequest{
+		WorkspaceID: workspace.ID,
+	})
+
+	keyResponse := h.Seed.CreateKey(ctx, seed.CreateKeyRequest{
+		WorkspaceID: workspace.ID,
+		KeyAuthID:   api.KeyAuthID.String,
+	})
+
+	req := handler.Request{Key: keyResponse.Key}
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}
+
+	lb := integration.NewLoadbalancer(h)
+	res, err := integration.CallRandomNode[handler.Request, handler.Response](
+		lb, "POST", "/v2/keys.verifyKey", headers, req)
+
+	require.NoError(t, err)
+	require.Equal(t, 403, res.Status, "should return 403 for expired root key")
+}
+
+// TestGetRootKey_TargetWorkspaceDisabled tests that a root key for a disabled workspace returns proper error
+func TestGetRootKey_TargetWorkspaceDisabled(t *testing.T) {
+	testutil.SkipUnlessIntegration(t)
+
+	ctx := context.Background()
+	h := integration.New(t, integration.Config{NumNodes: 1})
+
+	workspace := h.Resources().UserWorkspace
+	rootKey := h.Seed.CreateRootKey(ctx, workspace.ID, "api.*.verify_key")
+
+	api := h.Seed.CreateAPI(ctx, seed.CreateApiRequest{
+		WorkspaceID: workspace.ID,
+	})
+
+	keyResponse := h.Seed.CreateKey(ctx, seed.CreateKeyRequest{
+		WorkspaceID: workspace.ID,
+		KeyAuthID:   api.KeyAuthID.String,
+	})
+
+	// Disable the target workspace
+	_, err := db.Query.UpdateWorkspaceEnabled(ctx, h.DB.RW(), db.UpdateWorkspaceEnabledParams{
+		ID:      workspace.ID,
+		Enabled: false,
+	})
+	require.NoError(t, err)
+
+	req := handler.Request{Key: keyResponse.Key}
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}
+
+	lb := integration.NewLoadbalancer(h)
+	res, err := integration.CallRandomNode[handler.Request, handler.Response](lb, "POST", "/v2/keys.verifyKey", headers, req)
+
+	require.NoError(t, err)
+	require.Equal(t, 403, res.Status, "should return 403 for disabled target workspace")
+}
+
+// TestGetRootKey_RootWorkspaceDisabled tests that a root key whose owning workspace is disabled returns proper error
+func TestGetRootKey_RootWorkspaceDisabled(t *testing.T) {
+	testutil.SkipUnlessIntegration(t)
+
+	ctx := context.Background()
+	h := integration.New(t, integration.Config{NumNodes: 1})
+
+	workspace := h.Resources().UserWorkspace
+	rootWorkspace := h.Resources().RootWorkspace
+	rootKey := h.Seed.CreateRootKey(ctx, workspace.ID, "api.*.verify_key")
+
+	// Disable the root workspace (the one that owns the root key)
+	_, err := db.Query.UpdateWorkspaceEnabled(ctx, h.DB.RW(), db.UpdateWorkspaceEnabledParams{
+		ID:      rootWorkspace.ID,
+		Enabled: false,
+	})
+	require.NoError(t, err)
+
+	api := h.Seed.CreateAPI(ctx, seed.CreateApiRequest{
+		WorkspaceID: workspace.ID,
+	})
+
+	keyResponse := h.Seed.CreateKey(ctx, seed.CreateKeyRequest{
+		WorkspaceID: workspace.ID,
+		KeyAuthID:   api.KeyAuthID.String,
+	})
+
+	req := handler.Request{Key: keyResponse.Key}
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}
+
+	lb := integration.NewLoadbalancer(h)
+	res, err := integration.CallRandomNode[handler.Request, handler.Response](
+		lb, "POST", "/v2/keys.verifyKey", headers, req)
+
+	require.NoError(t, err)
+	require.Equal(t, 403, res.Status, "should return 403 for disabled root workspace")
+}
+
+// TestGetRootKey_WorkspaceNotFound tests that a root key pointing to a non-existent workspace returns proper error
+func TestGetRootKey_WorkspaceNotFound(t *testing.T) {
+	testutil.SkipUnlessIntegration(t)
+
+	ctx := context.Background()
+	h := integration.New(t, integration.Config{NumNodes: 1})
+
+	rootWorkspace := h.Resources().RootWorkspace
+	rootKeyring := h.Resources().RootKeyring
+	nonExistentWorkspaceID := uid.New("ws_nonexistent")
+
+	// Create a root key pointing to a non-existent workspace
+	rootKeyResponse := h.Seed.CreateKey(ctx, seed.CreateKeyRequest{
+		WorkspaceID:    rootWorkspace.ID,
+		KeyAuthID:      rootKeyring.ID,
+		ForWorkspaceID: &nonExistentWorkspaceID,
+	})
+	rootKey := rootKeyResponse.Key
+
+	workspace := h.Resources().UserWorkspace
+	api := h.Seed.CreateAPI(ctx, seed.CreateApiRequest{
+		WorkspaceID: workspace.ID,
+	})
+
+	keyResponse := h.Seed.CreateKey(ctx, seed.CreateKeyRequest{
+		WorkspaceID: workspace.ID,
+		KeyAuthID:   api.KeyAuthID.String,
+	})
+
+	req := handler.Request{Key: keyResponse.Key}
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}
+
+	lb := integration.NewLoadbalancer(h)
+	res, err := integration.CallRandomNode[handler.Request, handler.Response](
+		lb, "POST", "/v2/keys.verifyKey", headers, req)
+
+	require.NoError(t, err)
+	require.Equal(t, 404, res.Status, "should return 404 for non-existent target workspace")
+}
+
+// TestGetRootKey_MissingBearer tests that missing Authorization header returns proper error
+func TestGetRootKey_MissingBearer(t *testing.T) {
+	testutil.SkipUnlessIntegration(t)
+
+	ctx := context.Background()
+	h := integration.New(t, integration.Config{NumNodes: 1})
+
+	workspace := h.Resources().UserWorkspace
+	api := h.Seed.CreateAPI(ctx, seed.CreateApiRequest{
+		WorkspaceID: workspace.ID,
+	})
+
+	keyResponse := h.Seed.CreateKey(ctx, seed.CreateKeyRequest{
+		WorkspaceID: workspace.ID,
+		KeyAuthID:   api.KeyAuthID.String,
+	})
+
+	req := handler.Request{Key: keyResponse.Key}
+	headers := http.Header{
+		"Content-Type": {"application/json"},
+		// No Authorization header
+	}
+
+	lb := integration.NewLoadbalancer(h)
+	res, err := integration.CallRandomNode[handler.Request, handler.Response](
+		lb, "POST", "/v2/keys.verifyKey", headers, req)
+
+	require.NoError(t, err)
+	require.Equal(t, 400, res.Status, "should return 400 for missing authorization header")
+}
+
+// TestGetRootKey_Deleted tests that a soft-deleted root key returns proper error
+func TestGetRootKey_Deleted(t *testing.T) {
+	testutil.SkipUnlessIntegration(t)
+
+	ctx := context.Background()
+	h := integration.New(t, integration.Config{NumNodes: 1})
+
+	workspace := h.Resources().UserWorkspace
+	rootKey := h.Seed.CreateRootKey(ctx, workspace.ID, "api.*.verify_key")
+
+	// Soft delete the root key
+	keyHash := hash.Sha256(rootKey)
+	keyRow, err := db.Query.FindKeyForVerification(ctx, h.DB.RO(), keyHash)
+	require.NoError(t, err)
+
+	err = db.Query.SoftDeleteKeyByID(ctx, h.DB.RW(), db.SoftDeleteKeyByIDParams{
+		ID:  keyRow.ID,
+		Now: sql.NullInt64{Int64: time.Now().UnixMilli(), Valid: true},
+	})
+	require.NoError(t, err)
+
+	api := h.Seed.CreateAPI(ctx, seed.CreateApiRequest{
+		WorkspaceID: workspace.ID,
+	})
+
+	keyResponse := h.Seed.CreateKey(ctx, seed.CreateKeyRequest{
+		WorkspaceID: workspace.ID,
+		KeyAuthID:   api.KeyAuthID.String,
+	})
+
+	req := handler.Request{Key: keyResponse.Key}
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}
+
+	lb := integration.NewLoadbalancer(h)
+	res, err := integration.CallRandomNode[handler.Request, handler.Response](
+		lb, "POST", "/v2/keys.verifyKey", headers, req)
+
+	require.NoError(t, err)
+	require.Equal(t, 401, res.Status, "should return 401 for non-existent root key")
+}
+
+// TestGetRootKey_InsufficientPermissions tests that a root key without required permissions returns proper error
+func TestGetRootKey_InsufficientPermissions(t *testing.T) {
+	testutil.SkipUnlessIntegration(t)
+
+	ctx := context.Background()
+	h := integration.New(t, integration.Config{NumNodes: 1})
+
+	workspace := h.Resources().UserWorkspace
+	// Create root key without the required ratelimit permission
+	rootKey := h.Seed.CreateRootKey(ctx, workspace.ID, "api.*.create_key")
+
+	// Try to use ratelimit endpoint which requires ratelimit.*.create_namespace permission
+	type RatelimitRequest struct {
+		Namespace  string `json:"namespace"`
+		Identifier string `json:"identifier"`
+		Limit      int    `json:"limit"`
+		Duration   int64  `json:"duration"`
+	}
+
+	type RatelimitResponse struct {
+		Success bool `json:"success"`
+	}
+
+	req := RatelimitRequest{
+		Namespace:  "test",
+		Identifier: "test-id",
+		Limit:      10,
+		Duration:   60000,
+	}
+
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}
+
+	lb := integration.NewLoadbalancer(h)
+	res, err := integration.CallRandomNode[RatelimitRequest, RatelimitResponse](
+		lb, "POST", "/v2/ratelimit.limit", headers, req)
+
+	require.NoError(t, err)
+	require.Equal(t, 403, res.Status, "should return 403 for insufficient permissions")
+}

--- a/go/cmd/ctrl/main.go
+++ b/go/cmd/ctrl/main.go
@@ -36,8 +36,6 @@ var Cmd = &cli.Command{
 			cli.Required(), cli.EnvVar("UNKEY_DATABASE_PRIMARY")),
 		cli.String("database-partition", "MySQL connection string for partition database. Required for all deployments. Example: user:pass@host:3306/partition_002?parseTime=true",
 			cli.Required(), cli.EnvVar("UNKEY_DATABASE_PARTITION")),
-		cli.String("database-hydra", "MySQL connection string for hydra database. Required for all deployments. Example: user:pass@host:3306/hydra?parseTime=true",
-			cli.Required(), cli.EnvVar("UNKEY_DATABASE_HYDRA")),
 
 		// Observability
 		cli.Bool("otel", "Enable OpenTelemetry tracing and metrics",

--- a/go/internal/services/keys/get.go
+++ b/go/internal/services/keys/get.go
@@ -109,11 +109,22 @@ func (s *service) Get(ctx context.Context, sess *zen.Session, rawKey string) (*K
 
 	if !key.WorkspaceEnabled || (key.ForWorkspaceEnabled.Valid && !key.ForWorkspaceEnabled.Bool) {
 		// nolint:exhaustruct
-		return &KeyVerifier{
-			Status:  StatusWorkspaceDisabled,
-			message: "workspace is disabled",
-			region:  s.region,
-		}, emptyLog, nil
+		kv := &KeyVerifier{
+			Status:                StatusWorkspaceDisabled,
+			message:               "workspace is disabled",
+			session:               sess,
+			rBAC:                  s.rbac,
+			region:                s.region,
+			logger:                s.logger,
+			clickhouse:            s.clickhouse,
+			rateLimiter:           s.raterLimiter,
+			usageLimiter:          s.usageLimiter,
+			AuthorizedWorkspaceID: key.WorkspaceID,
+			isRootKey:             key.ForWorkspaceID.Valid,
+			Key:                   key,
+		}
+
+		return kv, kv.log, nil
 	}
 
 	// The DB returns this in array format and an empty array if not found

--- a/go/internal/services/keys/get.go
+++ b/go/internal/services/keys/get.go
@@ -107,15 +107,13 @@ func (s *service) Get(ctx context.Context, sess *zen.Session, rawKey string) (*K
 		}, emptyLog, nil
 	}
 
-	kv := &KeyVerifier{
-		Status:  StatusWorkspaceDisabled,
-		message: "workspace is disabled",
-		region:  s.region,
-	}
-
 	if !key.WorkspaceEnabled || (key.ForWorkspaceEnabled.Valid && !key.ForWorkspaceEnabled.Bool) {
 		// nolint:exhaustruct
-		return kv, kv.log, nil
+		return &KeyVerifier{
+			Status:  StatusWorkspaceDisabled,
+			message: "workspace is disabled",
+			region:  s.region,
+		}, emptyLog, nil
 	}
 
 	// The DB returns this in array format and an empty array if not found
@@ -170,7 +168,7 @@ func (s *service) Get(ctx context.Context, sess *zen.Session, rawKey string) (*K
 		}
 	}
 
-	kv = &KeyVerifier{
+	kv := &KeyVerifier{
 		Key:                   key,
 		clickhouse:            s.clickhouse,
 		rateLimiter:           s.raterLimiter,

--- a/go/internal/services/keys/status.go
+++ b/go/internal/services/keys/status.go
@@ -84,6 +84,7 @@ func (k *KeyVerifier) ToFault() error {
 		if message == "" {
 			message = "Insufficient permissions to access this resource."
 		}
+
 		return fault.New("insufficient permissions",
 			fault.Code(codes.Auth.Authorization.InsufficientPermissions.URN()),
 			fault.Internal(message),

--- a/go/pkg/testutil/seed/seed.go
+++ b/go/pkg/testutil/seed/seed.go
@@ -186,15 +186,16 @@ func (s *Seeder) CreateRootKey(ctx context.Context, workspaceID string, permissi
 }
 
 type CreateKeyRequest struct {
-	Disabled    bool
-	WorkspaceID string
-	KeyAuthID   string
-	Remaining   *int32
-	IdentityID  *string
-	Meta        *string
-	Expires     *time.Time
-	Name        *string
-	Deleted     bool
+	Disabled       bool
+	WorkspaceID    string
+	KeyAuthID      string
+	Remaining      *int32
+	IdentityID     *string
+	Meta           *string
+	Expires        *time.Time
+	Name           *string
+	Deleted        bool
+	ForWorkspaceID *string // For creating root keys that target a specific workspace
 
 	Recoverable bool
 
@@ -228,7 +229,7 @@ func (s *Seeder) CreateKey(ctx context.Context, req CreateKeyRequest) CreateKeyR
 		Enabled:           !req.Disabled,
 		Start:             start,
 		Name:              sql.NullString{String: ptr.SafeDeref(req.Name, "test-key"), Valid: true},
-		ForWorkspaceID:    sql.NullString{String: "", Valid: false},
+		ForWorkspaceID:    sql.NullString{String: ptr.SafeDeref(req.ForWorkspaceID, ""), Valid: req.ForWorkspaceID != nil},
 		Meta:              sql.NullString{String: ptr.SafeDeref(req.Meta, ""), Valid: req.Meta != nil},
 		IdentityID:        sql.NullString{String: ptr.SafeDeref(req.IdentityID, ""), Valid: req.IdentityID != nil},
 		Expires:           sql.NullTime{Time: ptr.SafeDeref(req.Expires, time.Time{}), Valid: req.Expires != nil},


### PR DESCRIPTION
## What does this PR do?

Fixes #4082 

When using an API key for a disabled workspace we shall not panic anymore, + adds tests for all root key statuses

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

Create Root Key, in your local db set enabled to 0 for your workspace

Call any API you should get a nice error message saying the workspace is disabled.

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary
