### PR TITLE
fix: use ratelimit name to determine counter id

### DIFF
--- a/apps/api/src/pkg/ratelimit/do_client.ts
+++ b/apps/api/src/pkg/ratelimit/do_client.ts
@@ -35,7 +35,7 @@ export class DurableRateLimiter implements RateLimiter {
     const now = Date.now();
     const window = Math.floor(now / req.interval);
 
-    return [req.identifier, window, req.shard].join("::");
+    return [req.identifier, window, req.name, req.shard].join("::");
   }
 
   private setCacheMax(id: string, i: number): number {


### PR DESCRIPTION
## What does this PR do?

Adds the `name` field to the rate limiter key generation in the `DurableRateLimiter` class. This change modifies the key format from `identifier::window::shard` to `identifier::window::name::shard`.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Test that rate limiting works correctly with the new key format
- Verify that rate limits are properly isolated by name parameter
- Check that existing rate limits continue to function after the change

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary