### PR TITLE
fix: show verification code in logs when using v2

### DIFF
--- a/apps/dashboard/app/(app)/[workspaceSlug]/logs/components/table/logs-table.tsx
+++ b/apps/dashboard/app/(app)/[workspaceSlug]/logs/components/table/logs-table.tsx
@@ -173,8 +173,7 @@ export const LogsTable = () => {
                 isSelected ? style.badge.selected : style.badge.default,
               )}
             >
-              {log.response_status}{" "}
-              {code ? `| ${code}` : ""}
+              {log.response_status} {code ? `| ${code}` : ""}
             </Badge>
           );
         },

--- a/apps/dashboard/app/(app)/[workspaceSlug]/logs/utils.ts
+++ b/apps/dashboard/app/(app)/[workspaceSlug]/logs/utils.ts
@@ -18,10 +18,10 @@ type V1ResponseBody = {
 };
 
 type V2ResponseBody = {
-    data: V1ResponseBody
-}
+  data: V1ResponseBody;
+};
 
-export type ResponseBody = V1ResponseBody | V2ResponseBody
+export type ResponseBody = V1ResponseBody | V2ResponseBody;
 
 export const extractResponseField = <K extends keyof V1ResponseBody>(
   log: Log | RatelimitLog,
@@ -36,7 +36,7 @@ export const extractResponseField = <K extends keyof V1ResponseBody>(
     const parsedBody = JSON.parse(log.response_body) as ResponseBody;
 
     // Check if it's v2 (nested under data)
-    if ('data' in parsedBody) {
+    if ("data" in parsedBody) {
       return parsedBody.data[fieldName];
     }
 


### PR DESCRIPTION
## What does this PR do?

Fixes #3719

<img width="1210" height="123" alt="CleanShot 2025-11-04 at 20 04 11" src="https://github.com/user-attachments/assets/a9e835b0-0517-4fe6-96c2-d6d9157f8b59" />
<img width="1252" height="199" alt="CleanShot 2025-11-04 at 20 04 24" src="https://github.com/user-attachments/assets/91ab8cab-e690-4272-9f76-70f5dce4fcd3" />


## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

Go into the logs page and look at verification requests from v1 and v2.

Make sure both of them show the status code. 

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [X] Filled out the "How to test" section in this PR
- [X] Read [Contributing Guide](./CONTRIBUTING.md)
- [X] Self-reviewed my own code
- [X] Commented on my code in hard-to-understand areas
- [X] Ran `pnpm build`
- [X] Ran `pnpm fmt`
- [X] Ran `make fmt` on `/go` directory
- [X] Checked for warnings, there are none
- [X] Removed all `console.logs`
- [X] Merged the latest changes from main onto my branch with `git pull origin main`
- [X] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary
