### PR TITLE
fix: run in correct folder

### DIFF
--- a/apps/dashboard/Dockerfile
+++ b/apps/dashboard/Dockerfile
@@ -51,5 +51,5 @@ ENV HOSTNAME="0.0.0.0"
 ENV PORT=3000
 EXPOSE 3000
 
-# Run in development mode for now
-CMD ["pnpm","start", "--hostname", "0.0.0.0"]
+# Run in production mode
+CMD ["pnpm", "--filter", "@unkey/dashboard", "start"]


### PR DESCRIPTION
## What does this PR do?

Updates the dashboard Dockerfile to run in production mode instead of development mode. The command has been changed from `pnpm start --hostname 0.0.0.0` to `pnpm --filter @unkey/dashboard start`.

## Type of change

- [x] Enhancement (small improvements)

## How should this be tested?

- Build the dashboard Docker image and verify it starts correctly in production mode
- Confirm the dashboard application is accessible on port 3000

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [x] Ran `make fmt` on `/go` directory
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues