### PR TITLE
feat: allow / in permission queries

### DIFF
--- a/go/pkg/rbac/lexer.go
+++ b/go/pkg/rbac/lexer.go
@@ -182,17 +182,18 @@ func (l *lexer) readIdentifier() string {
 //   - Hyphens (-) for kebab-case identifiers
 //   - Colons (:) for namespace separation (e.g., "system:admin")
 //   - Asterisks (*) for literal permission names (e.g., "api.*")
+//   - Forward slashes (/) for path-like permission names (e.g., "/api/v1/xxx")
 //
 // Note: The asterisk (*) character is treated as a literal character in permission
 // names, NOT as a wildcard pattern. For example, "api.*" matches only the exact
 // permission "api.*", not "api.read" or "api.write".
 //
-// This character set matches the regex: /^[a-zA-Z0-9_:\-\.\*]+$/
+// This character set matches the regex: /^[a-zA-Z0-9_:\-\.\*\/]+$/
 //
 // Characters like spaces, parentheses, and operators are not allowed in
 // permission identifiers and will terminate identifier parsing.
 func isValidPermissionChar(ch byte) bool {
-	return unicode.IsLetter(rune(ch)) || unicode.IsDigit(rune(ch)) || ch == '.' || ch == '_' || ch == '-' || ch == '*' || ch == ':'
+	return unicode.IsLetter(rune(ch)) || unicode.IsDigit(rune(ch)) || ch == '.' || ch == '_' || ch == '-' || ch == '*' || ch == ':' || ch == '/'
 }
 
 // nextToken extracts and returns the next token from the input stream.
@@ -252,7 +253,7 @@ func (l *lexer) nextToken() token {
 			err := fault.New(
 				fmt.Sprintf("invalid character '%c' at position %d in query", char, pos),
 				fault.Code(codes.User.BadRequest.PermissionsQuerySyntaxError.URN()),
-				fault.Public(fmt.Sprintf("Invalid character '%c' found in query at position %d. Only letters, numbers, dots, underscores, hyphens, and parentheses are allowed.", char, pos)),
+				fault.Public(fmt.Sprintf("Invalid character '%c' found in query at position %d. Only letters, numbers, dots, underscores, hyphens, slashes, colons, asterisks, and parentheses are allowed.", char, pos)),
 			)
 
 			tok = token{

--- a/go/pkg/rbac/lexer_test.go
+++ b/go/pkg/rbac/lexer_test.go
@@ -282,6 +282,14 @@ func TestLexer_PermissionFormats(t *testing.T) {
 				{typ: eof, value: "", pos: 28},
 			},
 		},
+		{
+			name:  "Permission with slash",
+			input: "api/v1.read_key",
+			expected: []token{
+				{typ: permission, value: "api/v1.read_key", pos: 0},
+				{typ: eof, value: "", pos: 15},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/go/pkg/rbac/rbac.go
+++ b/go/pkg/rbac/rbac.go
@@ -139,7 +139,7 @@ func formatPermissions(permissions []string) []string {
 // ParseQuery parses a SQL-like permission query string and returns a PermissionQuery.
 //
 // Supported syntax:
-//   - Permissions: alphanumeric characters, dots, underscores, hyphens, colons, asterisks (e.g., "api.key1.read_key", "system:admin", "api.*")
+//   - Permissions: alphanumeric characters, dots, underscores, hyphens, colons, asterisks, forward slashes (e.g., "api.key1.read_key", "system:admin", "api.*", "/api/v1/xxx")
 //   - Operators: AND, OR (case-insensitive)
 //   - Grouping: parentheses ()
 //   - Precedence: AND has higher precedence than OR
@@ -151,6 +151,7 @@ func formatPermissions(permissions []string) []string {
 // Examples:
 //   - "api.key1.read_key"
 //   - "api.*" (matches only the literal permission "api.*")
+//   - "/api/v1/xxx" (path-like permission names)
 //   - "perm1 AND perm2"
 //   - "perm1 OR perm2 AND perm3" (parsed as "perm1 OR (perm2 AND perm3)")
 //   - "(perm1 OR perm2) AND perm3"


### PR DESCRIPTION
## What does this PR do?

Add support for forward slashes in permission names to enable path-like permission formats (e.g., "/api/v1/xxx"). This enhances the flexibility of the RBAC system by allowing more expressive permission naming patterns.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Test parsing permissions with forward slashes (e.g., "/api/v1/resource")
- Verify that the lexer correctly tokenizes path-like permission names
- Test complex permission queries that include path-like permissions with other operators

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [x] Ran `make fmt` on `/go` directory
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [x] Updated the Unkey Docs if changes were necessary