### PR TITLE
chore: remove link checker from autofix, rely on Mintlify GH app only

### DIFF
--- a/.github/workflows/autofix.ci.yaml
+++ b/.github/workflows/autofix.ci.yaml
@@ -64,14 +64,3 @@ jobs:
           CI: 1
 
       - uses: autofix-ci/action@635ffb0c9798bd160680f18fd73371e355b85f27 # v1.3.2
-
-  lint_docs:
-    name: Docs
-    if: ((github.event.pull_request.draft == false || github.event_name != 'pull_request') && needs.detect_changes.result == 'success' && needs.detect_changes.outputs.docs == 'true')
-    needs: [detect_changes]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
-      - name: Lint main docs
-        run: npx mintlify@latest broken-links
-        working-directory: apps/docs


### PR DESCRIPTION
## What does this PR do?

Removes the link checker from autofix and rely on the Mintlify GH app only

Fixes #4337 


## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

1. Checkout this branch
2. Create a new branch from this branch with a doc change (apps/doc)
3. Confirm that the Mintlify App checks run, and the autofix check does not

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary
