### PR TITLE
feat: define protos for kranes gateway management

### DIFF
--- a/go/proto/krane/v1/gateway.proto
+++ b/go/proto/krane/v1/gateway.proto
@@ -1,0 +1,72 @@
+syntax = "proto3";
+
+package krane.v1;
+
+option go_package = "github.com/unkeyed/unkey/go/gen/proto/krane/v1;kranev1";
+
+service GatewayService {
+  // CreateGateway
+  rpc CreateGateway(CreateGatewayRequest) returns (CreateGatewayResponse);
+
+  // GetGateway
+  rpc GetGateway(GetGatewayRequest) returns (GetGatewayResponse);
+
+  // DeleteGateway
+  rpc DeleteGateway(DeleteGatewayRequest) returns (DeleteGatewayResponse);
+}
+
+message GatewayRequest {
+  string namespace = 1;
+  string workspace_id = 2;
+  string gateway_id = 3;
+
+  string image = 4;
+
+  uint32 replicas = 5;
+  uint32 cpu_millicores = 6;
+  uint64 memory_size_mib = 7;
+}
+
+message CreateGatewayRequest {
+  GatewayRequest gateway = 1;
+}
+
+message CreateGatewayResponse {
+  GatewayStatus status = 1;
+}
+
+message UpdateGatewayRequest {
+  GatewayRequest gateway = 1;
+}
+message UpdateGatewayResponse {
+  repeated string pod_ids = 1;
+}
+
+message DeleteGatewayRequest {
+  string namespace = 1;
+  string gateway_id = 2;
+}
+
+message DeleteGatewayResponse {}
+
+message GetGatewayRequest {
+  string namespace = 1;
+  string gateway_id = 2;
+}
+
+message GetGatewayResponse {
+  repeated GatewayInstance instances = 2;
+}
+
+enum GatewayStatus {
+  GATEWAY_STATUS_UNSPECIFIED = 0;
+  GATEWAY_STATUS_PENDING = 1; // Gateway request accepted, container/pod creation in progress
+  GATEWAY_STATUS_RUNNING = 2; // Container/pod is running and healthy
+  GATEWAY_STATUS_TERMINATING = 3; // Container/pod is being terminated
+}
+
+message GatewayInstance {
+  string id = 1;
+  string address = 2;
+  GatewayStatus status = 3;
+}


### PR DESCRIPTION
## What does this PR do?

Adds a new protobuf definition for the Krane Gateway Service. This includes:

- Service definition with CreateGateway, GetGateway, and DeleteGateway RPCs
- Message definitions for gateway requests and responses
- Gateway status enum to track deployment states (pending, running, terminating)
- Instance representation with ID, address, and status

Fixes # (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How should this be tested?

- Verify the protobuf compiles correctly
- Check that the generated Go code matches the expected interface
- Ensure the service definition aligns with the planned Gateway implementation

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [x] Ran `make fmt` on `/go` directory
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues