### PR TITLE
chore: slow down inserts

### DIFF
--- a/go/pkg/clickhouse/client.go
+++ b/go/pkg/clickhouse/client.go
@@ -109,7 +109,7 @@ func New(config Config) (*clickhouse, error) {
 			Drop:          true,
 			BatchSize:     50_000,
 			BufferSize:    200_000,
-			FlushInterval: 5 * time.Second,
+			FlushInterval: 60 * time.Second,
 			Consumers:     2,
 			Flush: func(ctx context.Context, rows []schema.ApiRequest) {
 				table := "default.api_requests_raw_v2"
@@ -129,7 +129,7 @@ func New(config Config) (*clickhouse, error) {
 				Drop:          true,
 				BatchSize:     50_000,
 				BufferSize:    200_000,
-				FlushInterval: 5 * time.Second,
+				FlushInterval: 60 * time.Second,
 				Consumers:     2,
 				Flush: func(ctx context.Context, rows []schema.KeyVerification) {
 					table := "default.key_verifications_raw_v2"
@@ -150,7 +150,7 @@ func New(config Config) (*clickhouse, error) {
 				Drop:          true,
 				BatchSize:     50_000,
 				BufferSize:    200_000,
-				FlushInterval: 5 * time.Second,
+				FlushInterval: 60 * time.Second,
 				Consumers:     2,
 				Flush: func(ctx context.Context, rows []schema.Ratelimit) {
 					table := "default.ratelimits_raw_v2"


### PR DESCRIPTION
## What does this PR do?

Increases the `FlushInterval` for ClickHouse data processing from 5 seconds to 60 seconds across all data types (API requests, key verifications, and rate limits). This change will reduce the frequency of data flushes to ClickHouse, potentially improving performance and reducing resource usage.

Fixes # (issue)

## Type of change

- [x] Enhancement (small improvements)

## How should this be tested?

- Monitor ClickHouse performance metrics before and after the change to verify reduced load
- Verify that data is still being properly written to ClickHouse tables with the longer flush interval
- Check for any impact on data freshness in dashboards or reports that rely on this data

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [x] Ran `make fmt` on `/go` directory
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues