### PR TITLE
test: use current time to work with ttls

### DIFF
--- a/apps/api/src/routes/v1_analytics_getVerifications.happy.test.ts
+++ b/apps/api/src/routes/v1_analytics_getVerifications.happy.test.ts
@@ -1151,7 +1151,7 @@ test("grouping by tags", { timeout: 120_000 }, async (t) => {
     h.createKey(),
   ]);
 
-  const now = new Date("2023-01-07T00:00:00Z").getTime();
+  const now = Date.now();
 
   const tags = [["a", "b"], ["a"], [], ["b", "c"]];
 


### PR DESCRIPTION
## What does this PR do?

Updates the test case in `v1_analytics_getVerifications.happy.test.ts` to use the current timestamp (`Date.now()`) instead of a hardcoded date from January 2023. This ensures the test uses current time values rather than relying on a static date and failing due to clickhouse TTL based evictions.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

- Run the analytics verification tests to ensure they pass with the updated timestamp
- Verify that the test behavior remains consistent with the dynamic timestamp

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [x] Ran `make fmt` on `/go` directory
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues