### PR TITLE
fix(billing): show correct tier for declined payment statuses

### DIFF
--- a/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/client.tsx
+++ b/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/client.tsx
@@ -68,7 +68,7 @@ export const Client: React.FC = () => {
   const subscription = billingInfo.subscription;
   const currentProductId = billingInfo.currentProductId;
 
-  const allowUpdate = subscription && ["active", "trialing"].includes(subscription.status);
+  // const allowUpdate = subscription && ["active", "trialing"].includes(subscription.status);
 
   const hasPaidSubscription = Boolean(
     subscription &&
@@ -77,7 +77,9 @@ export const Client: React.FC = () => {
   );
   const isFreeTier = !hasPaidSubscription;
   const allowCancel = subscription && subscription.status === "active" && !subscription.cancelAt;
-  const currentProduct = hasPaidSubscription ? products.find((p) => p.id === currentProductId) : undefined;
+  const currentProduct = hasPaidSubscription
+    ? products.find((p) => p.id === currentProductId)
+    : undefined;
 
   return (
     <div>


### PR DESCRIPTION
## What does this PR do?
Closes #4447
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

 When a user's payment declines, the UI incorrectly shows the user as on the Free tier. Users on a paid/billing tier should continue to see their
  billing tier while payment retries are in progress. The Free tier label should only be shown if the user is actually on the Free tier.

Fixes # (issue)
Updated the billing tier detection logic to treat  payment statuses (past_due) as paid subscriptions for UI purposes:
  1. Updated isFreeTier logic to use hasPaidSubscription instead of checking subscription status directly:



_If there is not an issue for this, please create one first. This is used to tracking purposes and also helps us understand why this PR exists_

<!-- If there isn't an issue for this PR, please re-review our Contributing Guide and create an issue -->

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Test A
- Test B

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x]  Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary
