### PR TITLE
fix: cap dashboard min ratelimtit interval

### DIFF
--- a/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/_components/create-key/create-key.schema.ts
+++ b/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/_components/create-key/create-key.schema.ts
@@ -116,6 +116,7 @@ export const refillSchema = z.discriminatedUnion("interval", [
     refillDay: z.undefined().optional(),
   }),
 ]);
+
 export const ratelimitItemSchema = z.object({
   id: z.string().nullish(), // Will be used only for updating case
   name: z
@@ -128,7 +129,7 @@ export const ratelimitItemSchema = z.object({
         message: issue.code === "invalid_type" ? "Duration must be greater than 0" : defaultError,
       }),
     })
-    .positive({ message: "Refill interval must be greater than 0" }),
+    .min(1000, { message: "Refill interval must be at least 1 second (1000ms)" }),
   limit: z.coerce
     .number({
       errorMap: (issue, { defaultError }) => ({


### PR DESCRIPTION
## What does this PR do?
Fixes #4493

We cannot allow ratelimits durations less than a second.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

Create a key locally and use a duration less than 1second in ms. it should error 

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [X] Filled out the "How to test" section in this PR
- [X] Read [Contributing Guide](./CONTRIBUTING.md)
- [X] Self-reviewed my own code
- [X] Commented on my code in hard-to-understand areas
- [X] Ran `pnpm build`
- [X] Ran `pnpm fmt`
- [X] Ran `make fmt` on `/go` directory
- [X] Checked for warnings, there are none
- [X] Removed all `console.logs`
- [X] Merged the latest changes from main onto my branch with `git pull origin main`
- [X] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary
