### PR TITLE
fix: Payment fails should no longer trigger update alerts

### DIFF
--- a/apps/dashboard/lib/utils/slackAlerts.ts
+++ b/apps/dashboard/lib/utils/slackAlerts.ts
@@ -20,7 +20,7 @@ export async function alertSubscriptionCreation(
           type: "section",
           text: {
             type: "mrkdwn",
-            text: `:bugeyes: New customer ${name} signed up`,
+            text: `:bugeyes: New customer ${name || "Unknown"} signed up`,
           },
         },
         {
@@ -64,7 +64,9 @@ export async function alertSubscriptionUpdate(
   // Build the subscription change message
   let subscriptionText = `Subscription ${changeType} to the ${product} tier`;
   if (previousTier && changeType !== "updated") {
-    subscriptionText = `${name}'s subscription ${changeType} from ${previousTier} to ${product} tier, they are now paying ${price}. `;
+    subscriptionText = `${
+      name || "Unknown"
+    }'s subscription ${changeType} from ${previousTier} to ${product} tier, they are now paying ${price}. `;
   }
 
   const contactInfo = `Here is their contact information: ${email}`;
@@ -80,7 +82,7 @@ export async function alertSubscriptionUpdate(
           type: "section",
           text: {
             type: "mrkdwn",
-            text: `${emoji} ${name} ${actionText}`,
+            text: `${emoji} ${name || "Unknown"} ${actionText}`,
           },
         },
         {
@@ -126,7 +128,7 @@ export async function alertIsCancellingSubscription(
           type: "section",
           text: {
             type: "mrkdwn",
-            text: `:warning: ${name} is cancelling their subscription.`,
+            text: `:warning: ${name || "Unknown"} is cancelling their subscription.`,
           },
         },
         {
@@ -134,6 +136,45 @@ export async function alertIsCancellingSubscription(
           text: {
             type: "mrkdwn",
             text: `Subscription cancellation requested by ${email} - for ${product} at ${price} they will be moved back to the free tier, at the end of the month. We should reach out to find out why they are cancelling.`,
+          },
+        },
+      ],
+    }),
+  }).catch((err: Error) => {
+    console.error(err);
+  });
+}
+
+export async function alertPaymentFailed(
+  product: string,
+  price: string,
+  email: string,
+  name?: string,
+): Promise<void> {
+  const url = process.env.SLACK_WEBHOOK_CUSTOMERS;
+  if (!url) {
+    return;
+  }
+
+  await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      blocks: [
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: `:warning: Payment failed for ${name || "Unknown"}`,
+          },
+        },
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: `Payment for ${product} subscription at ${price} failed for ${email}. Subscription is now past due. Please reach out to customer to update payment method.`,
           },
         },
       ],
@@ -160,7 +201,7 @@ export async function alertSubscriptionCancelled(email: string, name?: string): 
           type: "section",
           text: {
             type: "mrkdwn",
-            text: `:caleb-sad: ${name} cancelled their subscription`,
+            text: `:caleb-sad: ${name || "Unknown"} cancelled their subscription`,
           },
         },
         {


### PR DESCRIPTION
## What does this PR do?

Stop payment failed from trigger updates and triggers its own alert 
Fixes # (issue)

_If there is not an issue for this, please create one first. This is used to tracking purposes and also helps us understand why this PR exists_

<!-- If there isn't an issue for this PR, please re-review our Contributing Guide and create an issue -->

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Test A
- Test B

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary