### PR TITLE
docs: add doc comments to cmd/ exports

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -10,6 +10,8 @@ import (
 	"github.com/unkeyed/unkey/svc/api"
 )
 
+// Cmd is the api command that runs the Unkey API server for validating and managing
+// API keys, rate limiting, and analytics.
 var Cmd = &cli.Command{
 	Aliases:     []string{},
 	Description: "",

--- a/cmd/create-clickhouse-user/main.go
+++ b/cmd/create-clickhouse-user/main.go
@@ -17,6 +17,8 @@ import (
 	"github.com/unkeyed/unkey/pkg/vault/storage"
 )
 
+// Cmd is the create-clickhouse-user command that creates or updates a ClickHouse user
+// for a workspace with resource quotas, table permissions, and row-level security policies.
 var Cmd = &cli.Command{
 	Name:  "create-clickhouse-user",
 	Usage: "Create or update ClickHouse user with quotas and permissions",

--- a/cmd/ctrl/main.go
+++ b/cmd/ctrl/main.go
@@ -10,6 +10,8 @@ import (
 	"github.com/unkeyed/unkey/svc/ctrl"
 )
 
+// Cmd is the ctrl command that runs the Unkey control plane service for managing
+// infrastructure, deployments, builds, and service orchestration.
 var Cmd = &cli.Command{
 	Version:     "",
 	Commands:    []*cli.Command{},

--- a/cmd/deploy/main.go
+++ b/cmd/deploy/main.go
@@ -113,8 +113,8 @@ var DeployFlags = []cli.Flag{
 	cli.String("api-key", "API key for ctrl service authentication", cli.EnvVar("API_KEY")),
 }
 
-// WARNING: Changing the "Description" part will also affect generated MDX.
-// Cmd defines the deploy CLI command
+// Cmd is the deploy command that builds and deploys application versions to Unkey infrastructure.
+// It handles Docker image building, registry pushing, and deployment lifecycle management.
 var Cmd = &cli.Command{
 	Version:  "",
 	Commands: []*cli.Command{},

--- a/cmd/dev/main.go
+++ b/cmd/dev/main.go
@@ -5,6 +5,8 @@ import (
 	"github.com/unkeyed/unkey/pkg/cli"
 )
 
+// Cmd is the dev command that provides development tools and utilities for local testing,
+// including database seeding and other development workflows.
 var Cmd = &cli.Command{
 	Name:  "dev",
 	Usage: "All of our development tools",

--- a/cmd/dev/seed/run.go
+++ b/cmd/dev/seed/run.go
@@ -4,6 +4,8 @@ import (
 	"github.com/unkeyed/unkey/pkg/cli"
 )
 
+// Cmd is the seed command that provides subcommands for seeding test data
+// into various backends including local development, frontline, and verifications.
 var Cmd = &cli.Command{
 	Name:  "seed",
 	Usage: "Seed data for testing",

--- a/cmd/frontline/main.go
+++ b/cmd/frontline/main.go
@@ -9,6 +9,8 @@ import (
 	"github.com/unkeyed/unkey/svc/frontline"
 )
 
+// Cmd is the frontline command that runs the multi-tenant ingress server for TLS
+// termination and request routing to backend services.
 var Cmd = &cli.Command{
 	Version:     "",
 	Commands:    []*cli.Command{},

--- a/cmd/healthcheck/main.go
+++ b/cmd/healthcheck/main.go
@@ -8,6 +8,8 @@ import (
 	"github.com/unkeyed/unkey/pkg/cli"
 )
 
+// Cmd is the healthcheck command that performs an HTTP GET request to a given URL
+// and exits with code 0 if the server returns 200, otherwise exits with code 1.
 var Cmd = &cli.Command{
 	Aliases:     []string{},
 	Version:     "",

--- a/cmd/krane/main.go
+++ b/cmd/krane/main.go
@@ -8,6 +8,8 @@ import (
 	"github.com/unkeyed/unkey/svc/krane"
 )
 
+// Cmd is the krane command that runs the Kubernetes deployment service for managing
+// container lifecycles and deployments in a Kubernetes cluster.
 var Cmd = &cli.Command{
 	Version:  "",
 	Aliases:  []string{},

--- a/cmd/preflight/main.go
+++ b/cmd/preflight/main.go
@@ -7,6 +7,8 @@ import (
 	"github.com/unkeyed/unkey/svc/preflight"
 )
 
+// Cmd is the preflight command that runs the Kubernetes mutating admission webhook
+// for secrets and credentials injection into pods.
 var Cmd = &cli.Command{
 	Name:  "preflight",
 	Usage: "Run the pod mutation webhook for secrets and credentials injection",

--- a/cmd/quotacheck/main.go
+++ b/cmd/quotacheck/main.go
@@ -17,6 +17,8 @@ import (
 	"golang.org/x/text/number"
 )
 
+// Cmd is the quotacheck command that monitors workspace quota usage by querying
+// ClickHouse and sends Slack notifications when quotas are exceeded.
 var Cmd = &cli.Command{
 	Version:  "",
 	Commands: []*cli.Command{},

--- a/cmd/run/main.go
+++ b/cmd/run/main.go
@@ -14,6 +14,8 @@ import (
 	"github.com/unkeyed/unkey/pkg/cli"
 )
 
+// Cmd is the run command that serves as the parent command for running Unkey services.
+// Use 'unkey run <service>' to start a specific service such as api, ctrl, krane, or vault.
 var Cmd = &cli.Command{
 	Flags:   []cli.Flag{},
 	Version: "",

--- a/cmd/sentinel/main.go
+++ b/cmd/sentinel/main.go
@@ -8,6 +8,8 @@ import (
 	"github.com/unkeyed/unkey/svc/sentinel"
 )
 
+// Cmd is the sentinel command that runs the deployment proxy server for routing
+// requests to deployment instances within a specific environment.
 var Cmd = &cli.Command{
 	Version:     "",
 	Commands:    []*cli.Command{},

--- a/cmd/vault/main.go
+++ b/cmd/vault/main.go
@@ -8,6 +8,8 @@ import (
 	"github.com/unkeyed/unkey/svc/vault"
 )
 
+// Cmd is the vault command that runs Unkey's encryption service for secure storage
+// and retrieval of sensitive data using S3-backed storage.
 var Cmd = &cli.Command{
 	Version:     "",
 	Commands:    []*cli.Command{},

--- a/cmd/version/main.go
+++ b/cmd/version/main.go
@@ -8,6 +8,8 @@ import (
 	"github.com/unkeyed/unkey/pkg/cli"
 )
 
+// Cmd is the version command that manages API versions including listing, getting details,
+// and rolling back to previous versions.
 var Cmd = &cli.Command{
 	Version: "",
 	Flags:   []cli.Flag{},


### PR DESCRIPTION
## Summary

Adds doc comments to all exported `Cmd` variables across command packages in `cmd/`.

Each comment starts with the symbol name and explains what the command does.

Closes ENG-2385