### PR TITLE
docs: add doc comments to internal/services/usagelimiter exports

### DIFF
--- a/internal/services/usagelimiter/interface.go
+++ b/internal/services/usagelimiter/interface.go
@@ -4,23 +4,39 @@ import (
 	"context"
 )
 
+// Service defines the interface for usage limiting operations. It enforces
+// credit-based rate limits on API keys by tracking and decrementing available
+// credits. Implementations may use direct database queries or distributed
+// Redis counters for higher performance.
 type Service interface {
-	// If the given keyId has exceeded its usage limit, an error is returned.
+	// Limit checks whether the given key has sufficient credits to cover the
+	// requested cost and, if so, decrements the credits atomically. Returns a
+	// [UsageResponse] indicating whether the request is valid and how many
+	// credits remain.
 	Limit(ctx context.Context, req UsageRequest) (UsageResponse, error)
 
-	// Invalidate removes the cached limit for the given keyId.
+	// Invalidate removes the cached limit for the given keyId, forcing the
+	// next [Limit] call to reload from the database.
 	Invalidate(ctx context.Context, keyId string) error
 
-	// Close gracefully shuts down the usage limiter service.
+	// Close gracefully shuts down the usage limiter service, draining any
+	// pending replay operations before returning.
 	Close() error
 }
 
+// UsageRequest represents a request to check and decrement usage credits
+// for an API key. The Cost field specifies how many credits this operation
+// should consume.
 type UsageRequest struct {
 	KeyId string
 	Cost  int32
 }
 
+// UsageResponse represents the result of a usage limit check. Valid indicates
+// whether the key has sufficient credits for the requested operation.
+// Remaining reports the number of credits left after the operation, or -1
+// if the key has no limit configured.
 type UsageResponse struct {
 	Valid     bool
-	Remaining int32 // Remaining usage for the keyId -1 indicates no limit
+	Remaining int32
 }


### PR DESCRIPTION
## Summary

Adds doc comments to exported symbols in `internal/services/usagelimiter/`:

- `Service` interface - Documents the credit-based rate limiting contract
- `UsageRequest` type - Documents the request structure for usage checks
- `UsageResponse` type - Documents the response structure and sentinel values

Closes ENG-2388