### PR TITLE
docs: add doc comments to pkg/fault exports

### DIFF
--- a/pkg/fault/flatten.go
+++ b/pkg/fault/flatten.go
@@ -4,11 +4,18 @@ import (
 	"slices"
 )
 
+// Step represents a single frame in an error chain, capturing the internal
+// message and source location where the error was wrapped. Steps are ordered
+// from the root cause to the outermost wrapper when returned by [Flatten].
 type Step struct {
 	Message  string
 	Location string
 }
 
+// Flatten unwraps a chain of wrapped errors and returns each frame as a [Step].
+// The returned slice is ordered from root cause to outermost wrapper, making it
+// suitable for logging or displaying error traces. Returns an empty slice if
+// err is nil or not a wrapped error from this package.
 func Flatten(err error) []Step {
 	if err == nil {
 		return []Step{}
@@ -35,7 +42,7 @@ func Flatten(err error) []Step {
 		// Try to get the next wrapped error
 		next, ok := current.err.(*wrapped)
 		if !ok {
-			// if it's not a wrapepd error, then we don't have any more public messages
+			// if it's not a wrapped error, then we don't have any more public messages
 			// and can stop looking.
 			break
 		}

--- a/pkg/fault/wrapped.go
+++ b/pkg/fault/wrapped.go
@@ -183,7 +183,7 @@ func UserFacingMessage(err error) string {
 		// Try to get the next wrapped error
 		next, ok := current.err.(*wrapped)
 		if !ok {
-			// if it's not a wrapepd error, then we don't have any more public messages
+			// if it's not a wrapped error, then we don't have any more public messages
 			// and can stop looking.
 			break
 		}


### PR DESCRIPTION
## Summary

Adds doc comments to exported symbols in `pkg/fault/flatten.go`:

- `Step` type - Documents what a step represents in the error chain
- `Flatten` function - Documents how it unwraps nested errors into steps

Also fixes typo: `wrapepd` → `wrapped`

Closes ENG-2389