### PR TITLE
docs: add doc comments to pkg/proto exports

### DIFF
--- a/pkg/proto/marshal.go
+++ b/pkg/proto/marshal.go
@@ -4,10 +4,14 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+// Marshal serializes a protobuf message into its binary wire format.
+// Returns the encoded bytes or an error if the message cannot be serialized.
 func Marshal(message proto.Message) ([]byte, error) {
 	return proto.Marshal(message)
 }
 
+// Unmarshal parses a protobuf binary wire format into the given message.
+// The message must be a non-nil pointer to a proto.Message of the appropriate type.
 func Unmarshal(data []byte, message proto.Message) error {
 	return proto.Unmarshal(data, message)
 }


### PR DESCRIPTION
## Summary

Adds doc comments to exported symbols in `pkg/proto/marshal.go`:

- `Marshal` function - Documents protobuf serialization to binary wire format
- `Unmarshal` function - Documents protobuf deserialization behavior

Closes ENG-2391