### PR TITLE
docs: add doc comments to pkg/circuitbreaker exports

### DIFF
--- a/pkg/circuitbreaker/errors.go
+++ b/pkg/circuitbreaker/errors.go
@@ -3,14 +3,24 @@ package circuitbreaker
 import "errors"
 
 var (
-	ErrTripped         = errors.New("circuit breaker is open")
+	// ErrTripped is returned when the circuit breaker is in the [Open] state and
+	// is rejecting requests to protect the downstream service. Callers should
+	// implement fallback logic or return an appropriate error to their clients.
+	ErrTripped = errors.New("circuit breaker is open")
+
+	// ErrTooManyRequests is returned when the circuit breaker is in the [HalfOpen]
+	// state and has already allowed the maximum number of probe requests through.
+	// The caller should wait for the current probe requests to complete before
+	// retrying.
 	ErrTooManyRequests = errors.New("too many requests during half open state")
 )
 
+// IsErrTripped reports whether err is or wraps [ErrTripped].
 func IsErrTripped(err error) bool {
 	return errors.Is(err, ErrTripped)
 }
 
+// IsErrTooManyRequests reports whether err is or wraps [ErrTooManyRequests].
 func IsErrTooManyRequests(err error) bool {
 	return errors.Is(err, ErrTooManyRequests)
 }

--- a/pkg/circuitbreaker/interface.go
+++ b/pkg/circuitbreaker/interface.go
@@ -4,20 +4,35 @@ import (
 	"context"
 )
 
+// State represents the current state of a circuit breaker. The circuit breaker
+// transitions between states based on the success or failure of requests:
+// [Closed] -> [Open] -> [HalfOpen] -> [Closed] (or back to [Open] on failure).
 type State string
 
 var (
-	// Open state means the circuit breaker is open and requests are not allowed
-	// to pass through
+	// Open indicates the circuit breaker is tripped and rejecting all requests
+	// without calling the downstream service. The circuit remains open until
+	// the timeout period elapses, after which it transitions to [HalfOpen].
 	Open State = "open"
-	// HalfOpen state means the circuit breaker is in a state of testing the
-	// upstream service to see if it has recovered
+
+	// HalfOpen indicates the circuit breaker is testing whether the downstream
+	// service has recovered. A limited number of probe requests are allowed
+	// through. If they succeed, the circuit transitions to [Closed]; if any
+	// fail, it returns to [Open].
 	HalfOpen State = "halfopen"
-	// Closed state means the circuit breaker is allowing requests to pass
-	// through to the upstream service
+
+	// Closed indicates the circuit breaker is operating normally and allowing
+	// all requests through to the downstream service. If failures exceed the
+	// trip threshold within a cyclic period, the circuit transitions to [Open].
 	Closed State = "closed"
 )
 
+// CircuitBreaker wraps operations that call downstream services and provides
+// automatic failure detection and recovery. When failures exceed a threshold,
+// the circuit "opens" to fail fast and reduce load on the struggling service.
 type CircuitBreaker[Res any] interface {
+	// Do executes the provided function if the circuit is closed or allows a
+	// probe request in half-open state. Returns [ErrTripped] if the circuit is
+	// open, or [ErrTooManyRequests] if the half-open probe limit is exceeded.
 	Do(ctx context.Context, fn func(context.Context) (Res, error)) (Res, error)
 }


### PR DESCRIPTION
## Summary

Adds doc comments to exported symbols in `pkg/circuitbreaker/`:

- `State` type and constants (`Open`, `HalfOpen`, `Closed`)
- `CircuitBreaker` interface
- `CB` struct and `New` constructor
- All option functions (`WithMaxRequests`, `WithCyclicPeriod`, etc.)
- Error variables (`ErrTripped`, `ErrTooManyRequests`) and helper functions

Closes ENG-2393