### PR TITLE
fix: rename S3Url to S3URL in vault

### DIFF
--- a/cmd/vault/main.go
+++ b/cmd/vault/main.go
@@ -53,7 +53,7 @@ func action(ctx context.Context, cmd *cli.Command) error {
 		// Basic configuration
 		HttpPort:          cmd.RequireInt("http-port"),
 		InstanceID:        cmd.RequireString("instance-id"),
-		S3Url:             cmd.RequireString("s3-url"),
+		S3URL:             cmd.RequireString("s3-url"),
 		S3Bucket:          cmd.RequireString("s3-bucket"),
 		S3AccessKeyID:     cmd.RequireString("s3-access-key-id"),
 		S3AccessKeySecret: cmd.RequireString("s3-access-key-secret"),

--- a/svc/vault/config.go
+++ b/svc/vault/config.go
@@ -11,8 +11,8 @@ type Config struct {
 
 	// S3Bucket is the bucket to store secrets in
 	S3Bucket string
-	// S3Url is the url to store secrets in
-	S3Url string
+	// S3URL is the url to store secrets in
+	S3URL string
 	// S3AccessKeyID is the access key id to use for s3
 	S3AccessKeyID string
 	// S3AccessKeySecret is the access key secret to use for s3
@@ -32,7 +32,7 @@ func (c Config) Validate() error {
 		assert.NotEmpty(c.InstanceID, "instanceID must not be empty"),
 		assert.Greater(c.HttpPort, 0, "httpPort must be greater than 0"),
 		assert.NotEmpty(c.S3Bucket, "s3Bucket must not be empty"),
-		assert.NotEmpty(c.S3Url, "s3Url must not be empty"),
+		assert.NotEmpty(c.S3URL, "s3Url must not be empty"),
 		assert.NotEmpty(c.S3AccessKeyID, "s3AccessKeyID must not be empty"),
 		assert.NotEmpty(c.S3AccessKeySecret, "s3AccessKeySecret must not be empty"),
 		assert.NotEmpty(c.MasterKeys, "masterKeys must not be empty"),

--- a/svc/vault/run.go
+++ b/svc/vault/run.go
@@ -31,7 +31,7 @@ func Run(ctx context.Context, cfg Config) error {
 	// Create the connect handler
 	mux := http.NewServeMux()
 	s3, err := storage.NewS3(storage.S3Config{
-		S3URL:             cfg.S3Url,
+		S3URL:             cfg.S3URL,
 		S3Bucket:          cfg.S3Bucket,
 		S3AccessKeyID:     cfg.S3AccessKeyID,
 		S3AccessKeySecret: cfg.S3AccessKeySecret,


### PR DESCRIPTION
## Summary

Renamed `S3Url` to `S3URL` in svc/vault to follow Go naming conventions for initialisms.

Closes ENG-2345