### PR TITLE
docs: fix wrong function name in pkg/debug/doc.go

### DIFF
--- a/pkg/debug/doc.go
+++ b/pkg/debug/doc.go
@@ -33,7 +33,7 @@
 //	    status = "FRESH"
 //	}
 //
-//	debug.RecordCacheState(ctx, "ApiByID", status, latency)
+//	debug.RecordCacheHit(ctx, "ApiByID", status, latency)
 //
 //	// Results in HTTP header:
 //	// X-Unkey-Debug-Cache: ApiByID:1.25ms:FRESH


### PR DESCRIPTION
## Summary

Updated doc comment example to call the correct function name `RecordCacheHit` instead of the non-existent `RecordCacheState`.

Closes ENG-2370