### PR TITLE
docs: fix corrupted example in pkg/assert/less.go

### DIFF
--- a/pkg/assert/less.go
+++ b/pkg/assert/less.go
@@ -12,7 +12,7 @@ import (
 //
 //	// Validate rate limit
 //	if err := assert.Less(requestsPerMinute, maxAllowed, "Request rate exceeds limit"); err != nil {
-//	    return fault.Wrap(err)
+//	    return err
 //	}
 func Less[T ~int | ~float64](a, b T, message ...string) error {
 	if a < b {


### PR DESCRIPTION
## Summary
Fixed corrupted/malformed example code in the Less function's doc comment.

Closes ENG-2351