### PR TITLE
docs: fix wrong function name in pkg/debug/doc.go

### DIFF
--- a/pkg/debug/doc.go
+++ b/pkg/debug/doc.go
@@ -33,7 +33,7 @@
 //	    status = "FRESH"
 //	}
 //
-//	debug.RecordCacheState(ctx, "ApiByID", status, latency)
+//	debug.RecordCacheHit(ctx, "ApiByID", status, latency)
 //
 //	// Results in HTTP header:
 //	// X-Unkey-Debug-Cache: ApiByID:1.25ms:FRESH


### PR DESCRIPTION
## Summary
Fixed documentation that called the wrong function name in the example. The doc comment in `pkg/debug/doc.go` referenced `debug.RecordCacheState` but the actual function is named `RecordCacheHit`.

Closes ENG-2370