### PR TITLE
docs: fix outdated API in pkg/prometheus/server.go

### DIFF
--- a/pkg/prometheus/server.go
+++ b/pkg/prometheus/server.go
@@ -50,7 +50,7 @@ type Config struct {
 // Example usage:
 //
 //	// Create a dedicated metrics server
-//	logger := logging.NewLogger()
+//	logger := logging.New()
 //	server, err := prometheus.New(prometheus.Config{
 //	    Logger: logger,
 //	})


### PR DESCRIPTION
## Summary
Fixed documentation that referenced the outdated logging.NewLogger() API, updated to use logging.New().

Closes ENG-2355