### PR TITLE
docs: fix doc drift in pkg/sim/simulation.go

### DIFF
--- a/pkg/sim/simulation.go
+++ b/pkg/sim/simulation.go
@@ -34,13 +34,12 @@ type Simulation[State any] struct {
 type apply[S any] func(*Simulation[S]) *Simulation[S]
 
 // New creates a new simulation for property-based testing.
-// It initializes the simulation with the provided testing instance and
+// It initializes the simulation with the provided seed and
 // applies any configuration functions provided.
 //
 // Example:
 //
-//	sim := sim.New[MyState](t,
-//	    sim.WithSeed(12345),
+//	sim := sim.New[MyState](sim.NewSeed(),
 //	    sim.WithSteps(1000000),
 //	    sim.WithState(func(rng *rand.Rand) *MyState {
 //	        // Initialize state with random values


### PR DESCRIPTION
## Summary
Fixed documentation that referenced a testing parameter (t) that doesn't exist in the actual function signature.

Closes ENG-2353