### PR TITLE
fix: handle ignored errors in test files

### DIFF
--- a/pkg/array/map_test.go
+++ b/pkg/array/map_test.go
@@ -23,7 +23,8 @@ func TestMap(t *testing.T) {
 	t.Run("maps string slice to int slice", func(t *testing.T) {
 		input := []string{"10", "20", "30", "40"}
 		result := Map(input, func(s string) int {
-			n, _ := strconv.Atoi(s)
+			n, err := strconv.Atoi(s)
+			require.NoError(t, err)
 			return n
 		})
 
@@ -261,7 +262,10 @@ func ExampleMap_structTransformation() {
 func ExampleMap_typeConversion() {
 	strings := []string{"10", "20", "30"}
 	numbers := Map(strings, func(s string) int {
-		n, _ := strconv.Atoi(s)
+		n, err := strconv.Atoi(s)
+		if err != nil {
+			panic(err)
+		}
 		return n
 	})
 

--- a/pkg/batchrand/batchrand_test.go
+++ b/pkg/batchrand/batchrand_test.go
@@ -175,7 +175,8 @@ func TestRace(t *testing.T) {
 			defer wg.Done()
 			for j := 0; j < iterations; j++ {
 				buf := make([]byte, 16)
-				_ = batchrand.Read(buf)
+				err := batchrand.Read(buf)
+				require.NoError(t, err)
 			}
 		}()
 	}
@@ -189,7 +190,8 @@ func BenchmarkRead(b *testing.B) {
 		b.ReportAllocs()
 		buf := make([]byte, 12)
 		for i := 0; i < b.N; i++ {
-			_ = batchrand.Read(buf)
+			err := batchrand.Read(buf)
+			require.NoError(b, err)
 		}
 	})
 
@@ -197,7 +199,8 @@ func BenchmarkRead(b *testing.B) {
 		b.ReportAllocs()
 		buf := make([]byte, 12)
 		for i := 0; i < b.N; i++ {
-			_, _ = rand.Read(buf)
+			_, err := rand.Read(buf)
+			require.NoError(b, err)
 		}
 	})
 }
@@ -209,7 +212,10 @@ func BenchmarkReadParallel(b *testing.B) {
 		b.RunParallel(func(pb *testing.PB) {
 			buf := make([]byte, 12)
 			for pb.Next() {
-				_ = batchrand.Read(buf)
+				err := batchrand.Read(buf)
+				if err != nil {
+					b.Fatal(err)
+				}
 			}
 		})
 	})
@@ -219,7 +225,10 @@ func BenchmarkReadParallel(b *testing.B) {
 		b.RunParallel(func(pb *testing.PB) {
 			buf := make([]byte, 12)
 			for pb.Next() {
-				_, _ = rand.Read(buf)
+				_, err := rand.Read(buf)
+				if err != nil {
+					b.Fatal(err)
+				}
 			}
 		})
 	})
@@ -234,7 +243,8 @@ func BenchmarkReadSizes(b *testing.B) {
 			b.ReportAllocs()
 			buf := make([]byte, size)
 			for i := 0; i < b.N; i++ {
-				_ = batchrand.Read(buf)
+				err := batchrand.Read(buf)
+				require.NoError(b, err)
 			}
 		})
 	}

--- a/pkg/db/key_data_test.go
+++ b/pkg/db/key_data_test.go
@@ -151,10 +151,12 @@ func TestToKeyData_WithIdentity(t *testing.T) {
 func TestToKeyData_WithJSONFields(t *testing.T) {
 	t.Run("with valid JSON arrays", func(t *testing.T) {
 		roles := []RoleInfo{{Name: "admin"}, {Name: "user"}}
-		rolesJSON, _ := json.Marshal(roles)
+		rolesJSON, err := json.Marshal(roles)
+		require.NoError(t, err)
 
 		permissions := []PermissionInfo{{Slug: "read"}, {Slug: "write"}}
-		permissionsJSON, _ := json.Marshal(permissions)
+		permissionsJSON, err := json.Marshal(permissions)
+		require.NoError(t, err)
 
 		ratelimits := []RatelimitInfo{
 			{
@@ -172,7 +174,8 @@ func TestToKeyData_WithJSONFields(t *testing.T) {
 				AutoApply: false,
 			},
 		}
-		ratelimitsJSON, _ := json.Marshal(ratelimits)
+		ratelimitsJSON, err := json.Marshal(ratelimits)
+		require.NoError(t, err)
 
 		row := FindLiveKeyByHashRow{
 			ID:              "key-with-json",


### PR DESCRIPTION
## Summary
Replace blank identifier error handling with proper require.NoError assertions in test files across pkg/array, pkg/batchrand, and pkg/db.

### Changes
- **pkg/array/map_test.go**: Replace `n, _ := strconv.Atoi(s)` with proper error handling using `require.NoError` (in tests) and `panic(err)` (in examples)
- **pkg/batchrand/batchrand_test.go**: Replace `_ = batchrand.Read(buf)` and `_, _ = rand.Read(buf)` with proper error handling using `require.NoError` and `b.Fatal(err)`
- **pkg/db/key_data_test.go**: Replace `rolesJSON, _ := json.Marshal(roles)` patterns with proper `require.NoError` assertions

Closes ENG-2363