### PR TITLE
fix: replace time.Sleep with proper synchronization in krane tests

### DIFF
--- a/svc/krane/internal/reconciler/refresh_current_deployments_test.go
+++ b/svc/krane/internal/reconciler/refresh_current_deployments_test.go
@@ -359,6 +359,8 @@ func TestRefreshCurrentDeployments_HandlesMissingDeploymentID(t *testing.T) {
 		return getDesiredCalls.Load() >= 1
 	}, 2*time.Second, 50*time.Millisecond, "expected only replicaset with ID to be processed")
 
-	time.Sleep(200 * time.Millisecond)
+	require.Never(t, func() bool {
+		return getDesiredCalls.Load() > 1
+	}, 200*time.Millisecond, 20*time.Millisecond, "only one replicaset should be processed (the one with ID)")
 	require.Equal(t, int32(1), getDesiredCalls.Load(), "only one replicaset should be processed (the one with ID)")
 }

--- a/svc/krane/internal/reconciler/refresh_current_sentinels_test.go
+++ b/svc/krane/internal/reconciler/refresh_current_sentinels_test.go
@@ -359,6 +359,8 @@ func TestRefreshCurrentSentinels_HandlesMissingSentinelID(t *testing.T) {
 		return getDesiredCalls.Load() >= 1
 	}, 2*time.Second, 50*time.Millisecond, "expected only deployment with ID to be processed")
 
-	time.Sleep(200 * time.Millisecond)
+	require.Never(t, func() bool {
+		return getDesiredCalls.Load() > 1
+	}, 200*time.Millisecond, 20*time.Millisecond, "only one deployment should be processed (the one with ID)")
 	require.Equal(t, int32(1), getDesiredCalls.Load(), "only one deployment should be processed (the one with ID)")
 }

--- a/svc/krane/internal/reconciler/watch_current_deployments_test.go
+++ b/svc/krane/internal/reconciler/watch_current_deployments_test.go
@@ -203,8 +203,6 @@ func TestWatchCurrentDeployments_ChannelClosure(t *testing.T) {
 	require.NoError(t, err)
 
 	fakeWatch.Stop()
-
-	time.Sleep(100 * time.Millisecond)
 }
 
 func TestWatchCurrentDeployments_ContextCancellation(t *testing.T) {
@@ -228,8 +226,6 @@ func TestWatchCurrentDeployments_ContextCancellation(t *testing.T) {
 	require.NoError(t, err)
 
 	cancel()
-
-	time.Sleep(100 * time.Millisecond)
 }
 
 func TestWatchCurrentDeployments_WithPods(t *testing.T) {

--- a/svc/krane/internal/reconciler/watch_current_sentinels_test.go
+++ b/svc/krane/internal/reconciler/watch_current_sentinels_test.go
@@ -195,8 +195,6 @@ func TestWatchCurrentSentinels_ChannelClosure(t *testing.T) {
 	require.NoError(t, err)
 
 	fakeWatch.Stop()
-
-	time.Sleep(100 * time.Millisecond)
 }
 
 func TestWatchCurrentSentinels_ContextCancellation(t *testing.T) {
@@ -220,8 +218,6 @@ func TestWatchCurrentSentinels_ContextCancellation(t *testing.T) {
 	require.NoError(t, err)
 
 	cancel()
-
-	time.Sleep(100 * time.Millisecond)
 }
 
 func TestWatchCurrentSentinels_MultipleEvents(t *testing.T) {


### PR DESCRIPTION
## Summary
Remove flaky time.Sleep() calls from krane test files and replace with proper synchronization patterns.

## Changes
- **watch_current_deployments_test.go**: Remove unnecessary time.Sleep calls in ChannelClosure and ContextCancellation tests - these sleeps had no assertions afterward
- **watch_current_sentinels_test.go**: Same fix for ChannelClosure and ContextCancellation tests
- **refresh_current_deployments_test.go**: Replace time.Sleep with require.Never to verify stability
- **refresh_current_sentinels_test.go**: Replace time.Sleep with require.Never to verify stability

## Testing
- bazel test //svc/krane/... passes
- All modified tests continue to pass

Closes ENG-2383