### PR TITLE
fix: replace time.Sleep with proper synchronization in svc/api route tests

### DIFF
--- a/svc/api/routes/v2_keys_verify_key/200_test.go
+++ b/svc/api/routes/v2_keys_verify_key/200_test.go
@@ -75,9 +75,11 @@ func TestSuccess(t *testing.T) {
 		require.Equal(t, openapi.VALID, res.Body.Data.Code, "Key should be valid but got %s", res.Body.Data.Code)
 		require.True(t, res.Body.Data.Valid, "Key should be valid but got %t", res.Body.Data.Valid)
 
-		time.Sleep(time.Second * 3)
+		require.Eventually(t, func() bool {
+			res = testutil.CallRoute[handler.Request, handler.Response](h, route, headers, req)
+			return res.Status == 200 && res.Body != nil && res.Body.Data.Code == openapi.EXPIRED
+		}, 10*time.Second, 100*time.Millisecond, "Key should become expired")
 
-		res = testutil.CallRoute[handler.Request, handler.Response](h, route, headers, req)
 		require.Equal(t, 200, res.Status, "expected 200, received: %#v", res)
 		require.NotNil(t, res.Body)
 		require.Equal(t, openapi.EXPIRED, res.Body.Data.Code, "Key should be expired but got %s", res.Body.Data.Code)


### PR DESCRIPTION
## Summary
Remove flaky time.Sleep() calls from svc/api route tests and replace with proper synchronization patterns.

## Changes
- **v2_keys_verify_key/200_test.go**: Use `require.Eventually` to poll for key expiry instead of wall-clock sleep
- **multiple_ratelimits_overcommit_test.go**: Replace sleep with `require.Eventually` for Redis sync; remove unnecessary sleep after Clock.Tick
- **v2_analytics_get_verifications/200_test.go**: Replace time.Sleep with `require.EventuallyWithT` polling for ClickHouse data
- **v2_analytics_get_verifications/422_test.go**: Same pattern - poll until data is flushed before running query

## Testing
- `bazel test //svc/api/routes/v2_keys_verify_key:all` passes
- `bazel test //svc/api/routes/v2_analytics_get_verifications:all` passes

Closes ENG-2390