### PR TITLE
fix: replace time.Sleep with require.Eventually in counter tests

### DIFF
--- a/pkg/counter/BUILD.bazel
+++ b/pkg/counter/BUILD.bazel
@@ -26,6 +26,7 @@ go_test(
         "//pkg/dockertest",
         "//pkg/otel/logging",
         "//pkg/uid",
+        "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],
 )


### PR DESCRIPTION
## Summary
Remove flaky time.Sleep() call from pkg/counter tests testing Redis TTL expiration.

## Changes
- **redis_test.go**: Replace 2-second sleep with require.EventuallyWithT polling until key expires
- **BUILD.bazel**: Add testify/assert dependency for EventuallyWithT

## Why this approach
Fixed sleeps are flaky because Redis expiration isn't guaranteed to be observed exactly at the TTL boundary. Polling with require.EventuallyWithT matches the actual behavior being tested (eventual expiry) while enforcing an upper bound via timeout.

## Testing
- go test ./pkg/counter/... passes

Closes ENG-2384