### PR TITLE
fix: replace time.Sleep with proper synchronization in cache/clustering tests

### DIFF
--- a/pkg/cache/clustering/dispatcher.go
+++ b/pkg/cache/clustering/dispatcher.go
@@ -34,7 +34,7 @@ type InvalidationDispatcher struct {
 // events to registered caches.
 //
 // Returns an error if topic or logger is nil - use NewNoopDispatcher() if clustering is disabled.
-func NewInvalidationDispatcher(topic *eventstream.Topic[*cachev1.CacheInvalidationEvent], logger logging.Logger) (*InvalidationDispatcher, error) {
+func NewInvalidationDispatcher(topic *eventstream.Topic[*cachev1.CacheInvalidationEvent], logger logging.Logger, opts ...eventstream.ConsumerOption) (*InvalidationDispatcher, error) {
 	err := assert.All(
 		assert.NotNil(topic, "topic is required for InvalidationDispatcher - use NewNoopDispatcher() if clustering is disabled"),
 		assert.NotNil(logger, "logger is required for InvalidationDispatcher"),
@@ -50,7 +50,7 @@ func NewInvalidationDispatcher(topic *eventstream.Topic[*cachev1.CacheInvalidati
 		logger:   logger,
 	}
 
-	d.consumer = topic.NewConsumer()
+	d.consumer = topic.NewConsumer(opts...)
 	d.consumer.Consume(context.Background(), d.handleEvent)
 
 	return d, nil


### PR DESCRIPTION
## Summary
Remove flaky 5-second time.Sleep() calls from cache/clustering tests.

## Changes
- Removed `time.Sleep(5 * time.Second)` from all three test files:
  - `e2e_test.go`
  - `consume_events_test.go`
  - `produce_events_test.go`
- Used `eventstream.WithStartFromBeginning()` for consumers to read from topic start
- Added producer warmup with `require.Eventually` to handle Kafka metadata propagation delay
- Extended `NewInvalidationDispatcher` to accept `ConsumerOption` variadic args
- Increased `require.Eventually` timeouts to 30 seconds for reliability

## Why this approach
Fixed sleeps for Kafka consumer/producer startup are flaky and slow tests unnecessarily. The new approach:
1. Uses `WithStartFromBeginning()` so consumers can read events produced before they started
2. Uses `require.Eventually` to retry producer calls until Kafka metadata is propagated
3. Relies on `require.Eventually` with generous timeouts for event propagation

## Testing
- `bazel test //pkg/cache/clustering:clustering_test` passes
- `bazel build //...` passes
- `make fmt` passes

Closes ENG-2400