### PR TITLE
ci: reuse build cache in same action

### DIFF
--- a/.github/workflows/job_bazel.yaml
+++ b/.github/workflows/job_bazel.yaml
@@ -33,7 +33,7 @@ jobs:
       # Running containers is temporary until we moved them inside of bazel,
       # at that point they are only created if they are actually needed
       - name: Start for containers
-        run: docker compose -f ./dev/docker-compose.yaml up -d --wait
+        run: docker compose -f ./dev/docker-compose.yaml up s3 clickhouse kafka mysql ctrl restate -d --wait
 
       - name: Run tests
         run: bazel test //... --test_output=errors


### PR DESCRIPTION
I suspect downloading the cache twice was making us slower than just
reusing it locally
