### PR TITLE
svc/api: migrate from shutdown to runner package

### DIFF
--- a/svc/api/BUILD.bazel
+++ b/svc/api/BUILD.bazel
@@ -29,7 +29,7 @@ go_library(
         "//pkg/prometheus",
         "//pkg/rbac",
         "//pkg/rpc/interceptor",
-        "//pkg/shutdown",
+        "//pkg/runner",
         "//pkg/tls",
         "//pkg/vault",
         "//pkg/vault/storage",


### PR DESCRIPTION
## Summary
Migrates svc/api from `pkg/shutdown` to `pkg/runner` for lifecycle management.

## Changes
- `shutdown.New()` → `runner.New()`
- `shutdowns.Register()` → `r.Defer()`
- `shutdowns.RegisterCtx()` → `r.DeferCtx()`
- Wrap server start with `r.Go()`
- `shutdowns.WaitForSignal()` → `r.Run(ctx, runner.WithTimeout(time.Minute))`
- Use `prometheus.Serve()` for simpler prometheus setup

## Stack
- Depends on: #4826 (frontline-runner)
- Part of migration series: vault → krane → sentinel → frontline → api

## Testing
```
bazel build //svc/api:api
```