### PR TITLE
fix: deploy CLI and docs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ permissions:
 concurrency: release
 jobs:
   goreleaser:
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -44,7 +44,6 @@ use_repo(
     "com_github_moby_buildkit",
     "com_github_oapi_codegen_nullable",
     "com_github_oapi_codegen_oapi_codegen_v2",
-    "com_github_oapi_codegen_runtime",
     "com_github_oasdiff_oasdiff",
     "com_github_opencontainers_go_digest",
     "com_github_pb33f_libopenapi",

--- a/cmd/deploy/BUILD.bazel
+++ b/cmd/deploy/BUILD.bazel
@@ -15,7 +15,6 @@ go_library(
         "//pkg/otel/logging",
         "@com_github_unkeyed_sdks_api_go_v2//:go",
         "@com_github_unkeyed_sdks_api_go_v2//models/components",
-        "@com_github_unkeyed_sdks_api_go_v2//models/operations",
         "@org_golang_x_text//cases",
         "@org_golang_x_text//language",
     ],

--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,6 @@ require (
 	github.com/moby/buildkit v0.26.3
 	github.com/nishanths/exhaustive v0.12.0
 	github.com/oapi-codegen/nullable v1.1.0
-	github.com/oapi-codegen/runtime v1.1.2
 	github.com/oasdiff/oasdiff v1.11.8
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/pb33f/libopenapi v0.31.2
@@ -72,7 +71,7 @@ require (
 	github.com/spiffe/go-spiffe/v2 v2.6.0
 	github.com/sqlc-dev/plugin-sdk-go v1.23.0
 	github.com/stretchr/testify v1.11.1
-	github.com/unkeyed/sdks/api/go/v2 v2.5.0
+	github.com/unkeyed/sdks/api/go/v2 v2.6.0
 	go.opentelemetry.io/contrib/bridges/otelslog v0.14.0
 	go.opentelemetry.io/contrib/bridges/prometheus v0.64.0
 	go.opentelemetry.io/contrib/processors/minsev v0.12.0
@@ -133,7 +132,6 @@ require (
 	github.com/TwiN/go-color v1.4.1 // indirect
 	github.com/andybalholm/brotli v1.2.0 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
-	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.4 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.17 // indirect

--- a/go.sum
+++ b/go.sum
@@ -91,7 +91,6 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Microsoft/hcsshim v0.14.0-rc.1 h1:qAPXKwGOkVn8LlqgBN8GS0bxZ83hOJpcjxzmlQKxKsQ=
 github.com/Microsoft/hcsshim v0.14.0-rc.1/go.mod h1:hTKFGbnDtQb1wHiOWv4v0eN+7boSWAHyK/tNAaYZL0c=
-github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
 github.com/TwiN/go-color v1.4.1 h1:mqG0P/KBgHKVqmtL5ye7K0/Gr4l6hTksPgTgMk3mUzc=
 github.com/TwiN/go-color v1.4.1/go.mod h1:WcPf/jtiW95WBIsEeY1Lc/b8aaWoiqQpu5cf8WFxu+s=
 github.com/anchore/go-struct-converter v0.0.0-20221118182256-c68fdcfa2092 h1:aM1rlcoLz8y5B2r4tTLMiVTrMtpfY0O8EScKJxaSaEc=
@@ -100,8 +99,6 @@ github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwTo
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
 github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
-github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
-github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/aws/aws-sdk-go-v2 v1.41.1 h1:ABlyEARCDLN034NhxlRUSZr4l71mh+T5KAeGh6cerhU=
@@ -161,8 +158,6 @@ github.com/bitly/go-simplejson v0.5.1 h1:xgwPbetQScXt1gh9BmoJ6j9JMr3TElvuIyjR8pg
 github.com/bitly/go-simplejson v0.5.1/go.mod h1:YOPVLzCfwK14b4Sff3oP1AmGhI9T9Vsg84etUnlyp+Q=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
-github.com/bmatcuk/doublestar v1.1.1 h1:YroD6BJCZBYx06yYFEWvUuKVWQn3vLLQAVmDmvTSaiQ=
-github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
 github.com/bmatcuk/doublestar/v4 v4.9.1 h1:X8jg9rRZmJd4yRy7ZeNDRnM+T3ZfHv15JiBJ/avrEXE=
 github.com/bmatcuk/doublestar/v4 v4.9.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/brianvoe/gofakeit/v6 v6.28.0 h1:Xib46XXuQfmlLS2EXRuJpqcw8St6qSZz75OUo0tgAW4=
@@ -446,7 +441,6 @@ github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8Hm
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.13-0.20220915233716-71ac16282d12 h1:9Nu54bhS/H/Kgo2/7xNSUuC5G28VR8ljfrLKU2G4IjU=
 github.com/json-iterator/go v1.1.13-0.20220915233716-71ac16282d12/go.mod h1:TBzl5BIHNXfS9+C35ZyJaklL7mLDbgUkcgXzSLa8Tk0=
-github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d/go.mod h1:2PavIy+JPciBPrBUjwbNvtwB6RQlve+hkpll6QSNmOE=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/errcheck v1.9.0 h1:9xt1zI9EBfcYBvdU1nVrzMzzUPUtPKs9bVSIM3TAb3M=
 github.com/kisielk/errcheck v1.9.0/go.mod h1:kQxWMMVZgIkDq7U8xtG/n2juOjbLgZtedi0D+/VL/i8=
@@ -538,8 +532,6 @@ github.com/oapi-codegen/nullable v1.1.0 h1:eAh8JVc5430VtYVnq00Hrbpag9PFRGWLjxR1/
 github.com/oapi-codegen/nullable v1.1.0/go.mod h1:KUZ3vUzkmEKY90ksAmit2+5juDIhIZhfDl+0PwOQlFY=
 github.com/oapi-codegen/oapi-codegen/v2 v2.5.1 h1:5vHNY1uuPBRBWqB2Dp0G7YB03phxLQZupZTIZaeorjc=
 github.com/oapi-codegen/oapi-codegen/v2 v2.5.1/go.mod h1:ro0npU1BWkcGpCgGD9QwPp44l5OIZ94tB3eabnT7DjQ=
-github.com/oapi-codegen/runtime v1.1.2 h1:P2+CubHq8fO4Q6fV1tqDBZHCwpVpvPg7oKiYzQgXIyI=
-github.com/oapi-codegen/runtime v1.1.2/go.mod h1:SK9X900oXmPWilYR5/WKPzt3Kqxn/uS/+lbpREv+eCg=
 github.com/oasdiff/oasdiff v1.11.8 h1:3LalSR0yYVM5sAYNInlIG4TVckLCJBkgjcnst2GKWVg=
 github.com/oasdiff/oasdiff v1.11.8/go.mod h1:YtP/1VnQo8FCdSWGJ11a98HFgLnFvUffH//FTDuEpls=
 github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037 h1:G7ERwszslrBzRxj//JalHPu/3yz+De2J+4aLtSRlHiY=
@@ -690,7 +682,6 @@ github.com/spf13/viper v1.21.0 h1:x5S+0EU27Lbphp4UKm1C+1oQO+rKx36vfCoaVebLFSU=
 github.com/spf13/viper v1.21.0/go.mod h1:P0lhsswPGWD/1lZJ9ny3fYnVqxiegrlNrEmgLjbTCAY=
 github.com/spiffe/go-spiffe/v2 v2.6.0 h1:l+DolpxNWYgruGQVV0xsfeya3CsC7m8iBzDnMpsbLuo=
 github.com/spiffe/go-spiffe/v2 v2.6.0/go.mod h1:gm2SeUoMZEtpnzPNs2Csc0D/gX33k1xIx7lEzqblHEs=
-github.com/spkg/bom v0.0.0-20160624110644-59b7046e48ad/go.mod h1:qLr4V1qq6nMqFKkMo8ZTx3f+BZEkzsRUY10Xsm2mwU0=
 github.com/spyzhov/ajson v0.8.0 h1:sFXyMbi4Y/BKjrsfkUZHSjA2JM1184enheSjjoT/zCc=
 github.com/spyzhov/ajson v0.8.0/go.mod h1:63V+CGM6f1Bu/p4nLIN8885ojBdt88TbLoSFzyqMuVA=
 github.com/sqlc-dev/plugin-sdk-go v1.23.0 h1:iSeJhnXPlbDXlbzUEebw/DxsGzE9rdDJArl8Hvt0RMM=
@@ -743,8 +734,8 @@ github.com/tonistiigi/vt100 v0.0.0-20240514184818-90bafcd6abab h1:H6aJ0yKQ0gF49Q
 github.com/tonistiigi/vt100 v0.0.0-20240514184818-90bafcd6abab/go.mod h1:ulncasL3N9uLrVann0m+CDlJKWsIAP34MPcOJF6VRvc=
 github.com/ugorji/go/codec v1.2.11 h1:BMaWp1Bb6fHwEtbplGBGJ498wD+LKlNSl25MjdZY4dU=
 github.com/ugorji/go/codec v1.2.11/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
-github.com/unkeyed/sdks/api/go/v2 v2.5.0 h1:b+V+WxrDKA1bbtFJ7NljrNPi2WKf7b8Dhx55A0rA9qw=
-github.com/unkeyed/sdks/api/go/v2 v2.5.0/go.mod h1:1eT/d35dAxF/Ncbg9jrDSuw9CHo/qKzGPppo0gABOU4=
+github.com/unkeyed/sdks/api/go/v2 v2.6.0 h1:xJwxkst+vCyUODKF1OYiUtWGJ4rQZVZH3YRlDplKxi8=
+github.com/unkeyed/sdks/api/go/v2 v2.6.0/go.mod h1:1eT/d35dAxF/Ncbg9jrDSuw9CHo/qKzGPppo0gABOU4=
 github.com/vbatts/tar-split v0.12.2 h1:w/Y6tjxpeiFMR47yzZPlPj/FcPLpXbTUi/9H7d3CPa4=
 github.com/vbatts/tar-split v0.12.2/go.mod h1:eF6B6i6ftWQcDqEn3/iGFRFRo8cBIMSJVOpnNdfTMFA=
 github.com/vishvananda/netlink v1.3.1 h1:3AEMt62VKqz90r0tmNhog0r/PpWKmrEShJU0wJW6bV0=

--- a/web/apps/engineering/content/docs/architecture/services/ctrl/build.mdx
+++ b/web/apps/engineering/content/docs/architecture/services/ctrl/build.mdx
@@ -5,91 +5,159 @@ description: Container image building for customer deployments
 
 import { Mermaid } from "@/app/components/mermaid"
 
+The build system supports two deployment paths: GitHub-triggered builds and CLI deployments with pre-built images.
 
-When a customer deploys their application, the following process occurs:
+## GitHub-Triggered Builds
 
-The CLI first requests a deployment from the control plane, which returns a presigned S3 URL. The CLI packages the source code into a tarball and uploads it directly to S3, bypassing the control plane for efficient transfer. Once uploaded, the CLI triggers the build by sending the S3 path to the control plane.
+When a customer pushes to a GitHub repository connected to their Unkey project, the following process occurs:
 
-The control plane retrieves or creates a dedicated Depot project for the customer, then initiates a build with Depot. Depot provisions an isolated BuildKit machine, downloads the build context from S3, executes the Docker build, and pushes the resulting image to its registry. The image name is returned to the control plane.
+GitHub sends a webhook to the control plane, which validates the signature and maps the repository to an Unkey project. The control plane creates a deployment record and triggers the deploy workflow.
 
-With the built image ready, the control plane instructs Krane to create a deployment with specified resources (replicas, CPU, memory). Krane creates the necessary Kubernetes resources (StatefulSet and Service) and K8s begins scheduling pods.
+The deploy workflow uses BuildKit's native git context support to build directly from GitHub. BuildKit fetches the repository at the specified commit SHA, authenticated via a GitHub App installation token. This eliminates the need for intermediate storage (S3) and provides efficient builds with automatic layer caching through Depot.
 
-The control plane polls Krane every second (for up to 5 minutes) to check instance status. As instances become ready, their details are registered in the database. Once all instances are running, the control plane attempts to scrape an OpenAPI specification from the deployed service.
+Depot provisions an isolated BuildKit machine, fetches the repository directly from GitHub, executes the Docker build, and pushes the resulting image to its registry. The image name is returned to the control plane.
 
-Finally, the control plane calls the RoutingService to atomically assign domains and create sentinel configurations, and marks the deployment as ready in the database. Meanwhile, the CLI continuously polls the control plane every 2 seconds to check the deployment status until it becomes ready.
+With the built image ready, the control plane creates deployment topologies for target regions. Krane agents pull these changes and create the necessary Kubernetes resources. The control plane polls for instance readiness, registers instances in the database, and finally assigns domains via the routing service.
 
 <Mermaid chart={`sequenceDiagram
     autonumber
-    participant CLI
+    participant GH as GitHub
     participant Ctrl as Ctrl Plane
-    participant S3
     participant Depot
+    participant GitHub as GitHub API
     participant Krane
     participant K8s as Kubernetes
     participant DB as Database
     
-    CLI->>Ctrl: Create Deployment
-    Ctrl->>CLI: Presigned S3 upload URL
-    CLI->>S3: PUT tar file directly
-    S3->>CLI: Upload complete
+    GH->>Ctrl: Push Webhook
+    Ctrl->>DB: Create Deployment (status: pending)
+    Ctrl->>Ctrl: Trigger Deploy Workflow
     
-    CLI->>Ctrl: CreateBuild(s3_path)
+    Ctrl->>GitHub: Get Installation Token
+    GitHub->>Ctrl: Token (1 hour TTL)
+    
     Ctrl->>Depot: Get/Create Depot Project
     Depot->>Ctrl: Project ID
-    Ctrl->>Depot: Create Build
-    Depot->>Ctrl: Build ID
+    Ctrl->>Depot: Create Build with Git Context
     
-    Depot->>S3: Download build context
+    Depot->>GitHub: Fetch repo at commit SHA
     Depot->>Depot: Execute Docker build & push to registry
     Depot->>Ctrl: Image name & build ID
     
-    Ctrl->>Krane: CreateDeployment(image, replicas, resources)
+    Ctrl->>DB: Update deployment image
+    Ctrl->>DB: Create deployment topologies
+    
+    Krane->>Ctrl: Pull deployment changes
     Krane->>K8s: Create StatefulSet & Service
     K8s->>K8s: Schedule & start pods
     
     loop Poll until ready (max 5 min)
-        Ctrl->>Krane: GetDeployment()
-        Krane->>K8s: AppsV1.StatefulSets.Get
-        K8s->>Krane: Instances: [{id, addr, status}]
+        Ctrl->>Krane: Check deployment status
         Krane->>Ctrl: Instances: [{id, addr, status}]
-        Ctrl->>DB: Upsert VM records
+        Ctrl->>DB: Upsert instance records
     end
     
-    K8s->>K8s: Pods running
+    Ctrl->>K8s: HTTP GET /openapi.yaml
+    K8s->>Ctrl: OpenAPI spec (optional)
+    
+    Ctrl->>Ctrl: AssignFrontlineRoutes (RoutingService)
+    Ctrl->>DB: Update deployment status: READY
+`} />
+
+## CLI Deployments (Pre-built Images)
+
+For CLI deployments, customers provide pre-built Docker images directly. This bypasses the build system entirely:
+
+<Mermaid chart={`sequenceDiagram
+    autonumber
+    participant CLI
+    participant API
+    participant Ctrl as Ctrl Plane
+    participant Krane
+    participant K8s as Kubernetes
+    participant DB as Database
+    
+    CLI->>API: CreateDeployment(dockerImage)
+    API->>DB: Create Deployment (status: pending)
+    API->>Ctrl: Trigger Deploy Workflow
+    
+    Ctrl->>DB: Create deployment topologies
+    
+    Krane->>Ctrl: Pull deployment changes
+    Krane->>K8s: Create StatefulSet & Service
+    K8s->>K8s: Schedule & start pods
+    
+    loop Poll until ready (max 5 min)
+        Ctrl->>Krane: Check deployment status
+        Krane->>Ctrl: Instances: [{id, addr, status}]
+        Ctrl->>DB: Upsert instance records
+    end
     
     Ctrl->>K8s: HTTP GET /openapi.yaml
-    K8s->>Ctrl: OpenAPI spec
+    K8s->>Ctrl: OpenAPI spec (optional)
     
-    Ctrl->>Ctrl: AssignFrontlineRoutes (RoutingService)<br/>- Update frontline routes<br/>- Point to new deployment
-    
+    Ctrl->>Ctrl: AssignFrontlineRoutes (RoutingService)
     Ctrl->>DB: Update deployment status: READY
     
     loop CLI polls every 2s
-        CLI->>Ctrl: GetDeployment()
-        Ctrl->>CLI: Deployment status
+        CLI->>API: GetDeployment()
+        API->>CLI: Deployment status
     end
     
     CLI->>CLI: Status = READY, deployment complete
 `} />
 
-## Build Backends
+## Build Backend: Depot
 
-We support two build backends, configurable via the `BUILD_BACKEND` environment variable.
+Depot.dev provides isolated, cached, and high-performance container builds:
 
-### Depot (Production)
+- **Fast builds**: Persistent layer caching across builds
+- **Isolated environments**: Each customer project gets its own cache
+- **No local Docker daemon**: Builds run on remote BuildKit machines
+- **Multi-architecture support**: Build for both amd64 and arm64
+- **Native git context**: BuildKit fetches repositories directly from GitHub
+- **Built-in registry**: Images pushed directly to Depot's registry
 
-Depot.dev provides isolated, cached, and high-performance container builds. Builds are fast thanks to persistent layer caching across builds. Each customer project gets an isolated build environment with its own cache. No local Docker daemon is required since builds run on remote BuildKit machines. Multi-architecture support allows building for both amd64 and arm64. Registry integration is built-in, pushing images directly to Depot's registry after the build completes.
+**Location:** `svc/ctrl/worker/deploy/build.go`
 
-**Location:** `go/apps/ctrl/services/build/backend/depot/`
+## GitHub Authentication
 
-### Docker (Local Development)
+For private repositories, BuildKit authenticates using GitHub App installation tokens:
 
-The Docker backend uses standard Docker builds for local testing. It connects to the local Docker daemon and builds images on the host machine. This backend is simpler to set up for development but lacks the caching and isolation benefits of Depot.
+1. The control plane creates a JWT signed with the GitHub App's private key
+2. Exchanges the JWT for an installation token via GitHub API
+3. Passes the token to BuildKit via the `GIT_AUTH_TOKEN.github.com` secret
+4. BuildKit uses the token for HTTPS authentication when fetching the repository
 
-**Location:** `go/apps/ctrl/services/build/backend/docker/`
+Installation tokens are short-lived (~1 hour) and scoped to repositories where the GitHub App is installed.
 
-## Storage
+**Location:** `svc/ctrl/worker/github/client.go`
 
-Build contexts are stored in S3-compatible storage. The upload process gives customers presigned URLs to directly upload their build context, bypassing the control plane for efficient transfer. During the build, Depot receives presigned download URLs to fetch the context from S3. Build contexts are retained for the lifecycle of the deployment, allowing rebuilds and rollbacks when needed.
+## Depot Project Management
 
-**Location:** `go/apps/ctrl/services/build/storage/s3.go`
+Each Unkey project gets a corresponding Depot project for caching:
+
+```go
+func (w *Workflow) getOrCreateDepotProject(ctx context.Context, unkeyProjectID string) (string, error) {
+    project, _ := db.Query.FindProjectById(ctx, w.db.RO(), unkeyProjectID)
+    
+    if project.DepotProjectID.Valid {
+        return project.DepotProjectID.String, nil
+    }
+    
+    // Create new Depot project with cache policy
+    createResp, _ := projectClient.CreateProject(ctx, connect.NewRequest(&corev1.CreateProjectRequest{
+        Name:     fmt.Sprintf("unkey-%s", unkeyProjectID),
+        RegionId: w.depotConfig.ProjectRegion,
+        CachePolicy: &corev1.CachePolicy{
+            KeepGb:   50,
+            KeepDays: 14,
+        },
+    }))
+    
+    // Store Depot project ID in database for future builds
+    db.Query.UpdateProjectDepotID(ctx, w.db.RW(), ...)
+    
+    return createResp.Msg.GetProject().GetProjectId(), nil
+}
+```

--- a/web/apps/engineering/content/docs/architecture/services/ctrl/index.mdx
+++ b/web/apps/engineering/content/docs/architecture/services/ctrl/index.mdx
@@ -43,9 +43,11 @@ When resources are created, updated, or deleted, the deploy workflow updates the
 
 ### Build Service
 
-The build service manages container image building for customer deployments. It supports two backends: Depot for production deployments, which provides remote BuildKit with persistent layer caching for fast rebuilds, and Docker for local development, which uses standard Docker builds on the local machine.
+The build service manages container image building for customer deployments through Depot, which provides remote BuildKit with persistent layer caching for fast rebuilds.
 
-The service provides two key operations. `GenerateUploadURL` returns a presigned S3 URL where the CLI can upload a tarball of the build context. `CreateBuild` then builds a Docker image from that uploaded source, coordinating with either Depot or Docker depending on configuration.
+For GitHub-connected repositories, builds are triggered automatically via webhooks. BuildKit fetches the repository directly from GitHub using its native git context support, authenticated via GitHub App installation tokens. This eliminates the need for intermediate storage and provides efficient builds with automatic layer caching.
+
+For CLI deployments, users provide pre-built Docker images directly, bypassing the build service entirely.
 
 [Read detailed Build System docs →](./build)
 

--- a/web/apps/engineering/content/docs/architecture/workflows/deployment-workflow-pull-based.mdx
+++ b/web/apps/engineering/content/docs/architecture/workflows/deployment-workflow-pull-based.mdx
@@ -128,9 +128,12 @@ func (w *Workflow) Deploy(ctx restate.ObjectContext, req *hydrav1.DeployRequest)
         return db.Query.FindDeploymentById(stepCtx, w.db.RW(), req.GetDeploymentId())
     })
     
-    // 2. Build Docker image if needed
-    if req.GetBuildContextPath() != "" {
-        dockerImage = w.buildImage(ctx, req)
+    // 2. Build Docker image if needed (git source) or use pre-built image
+    switch source := req.Source.(type) {
+    case *hydrav1.DeployRequest_Git:
+        dockerImage = w.buildDockerImageFromGit(ctx, source.Git)
+    case *hydrav1.DeployRequest_DockerImage:
+        dockerImage = source.DockerImage.Image
     }
     
     // 3. Create deployment topology for target regions

--- a/web/apps/engineering/content/docs/cli/deploy/index.mdx
+++ b/web/apps/engineering/content/docs/cli/deploy/index.mdx
@@ -1,122 +1,59 @@
 ---
 title: "Deploy"
-description: "Deploy a new version or initialize configuration"
+description: "Deploy a pre-built Docker image to Unkey infrastructure"
 ---
-Build and deploy a new version of your application, or initialize configuration.
 
-The deploy command handles the complete deployment lifecycle: from building Docker images to deploying them on Unkey's infrastructure. It automatically detects your Git context, builds containers, and manages the deployment process with real-time status updates.
+Deploy a pre-built Docker image to Unkey infrastructure.
 
-## Initialization Mode
-
-Use --init to create a configuration template file. This generates an unkey.json file with your project settings, making future deployments simpler and more consistent across environments.
+The deploy command handles the deployment lifecycle: from creating a deployment to monitoring its status until it's ready. It automatically detects your Git context for metadata.
 
 ## Deployment Process
 
-1. Load configuration from unkey.json or flags
-2. Build Docker image from your application
-3. Push image to container registry
-4. Create deployment version on Unkey platform
-5. Monitor deployment status until active
+1. Create deployment with pre-built Docker image
+2. Monitor deployment status until active
 
 ## Command Syntax
 
 ```bash
-unkey deploy [flags]
+unkey deploy <docker-image> [flags]
 ```
 
 ## Examples
 
-### Initialize new project configuration
+### Deploy a Docker image
 
 ```bash
-unkey deploy --init
+unkey deploy ghcr.io/user/app:v1.0.0 --project-id=proj_123
 ```
 
-### Initialize with custom location
+### Deploy to production environment
 
 ```bash
-unkey deploy --init --config=./my-project
+unkey deploy myregistry.io/app:latest --project-id=proj_123 --env=production
 ```
 
-### Force overwrite existing configuration
+### Deploy with keyspace authentication
 
 ```bash
-unkey deploy --init --force
+unkey deploy ghcr.io/user/app:v1.0.0 --project-id=proj_123 --keyspace-id=ks_abc123
 ```
 
-### Standard deployment (uses ./unkey.json)
+### Deploy with custom branch metadata
 
 ```bash
-unkey deploy
+unkey deploy ghcr.io/user/app:v1.0.0 --project-id=proj_123 --branch=feature-branch
 ```
 
-### Deploy from specific config directory
+## Arguments
 
-```bash
-unkey deploy --config=./production
-```
-
-### Override workspace from config file
-
-```bash
-unkey deploy --workspace-id=ws_production_123
-```
-
-### Deploy with custom build context
-
-```bash
-unkey deploy --context=./api
-```
-
-### Local development (build only, no push)
-
-```bash
-unkey deploy --skip-push
-```
-
-### Deploy pre-built image
-
-```bash
-unkey deploy --docker-image=ghcr.io/user/app:v1.0.0
-```
-
-### Verbose output for debugging
-
-```bash
-unkey deploy --verbose
-```
+| Argument | Description |
+|----------|-------------|
+| `<docker-image>` | Docker image reference to deploy (required). Example: `ghcr.io/user/app:v1.0.0` |
 
 ## Flags
 
-<Callout type="info" title="--config">
-Directory containing unkey.json config file
-
-- **Type:** string
-</Callout>
-
-<Callout type="info" title="--init">
-Initialize configuration file in the specified directory
-
-- **Type:** boolean
-- **Default:** `false`
-</Callout>
-
-<Callout type="info" title="--force">
-Force overwrite existing configuration file when using --init
-
-- **Type:** boolean
-- **Default:** `false`
-</Callout>
-
-<Callout type="info" title="--workspace-id">
-Workspace ID
-
-- **Type:** string
-- **Environment:** `UNKEY_WORKSPACE_ID`
-</Callout>
-
 <Callout type="info" title="--project-id">
-Project ID
+Project ID (required)
 
 - **Type:** string
 - **Environment:** `UNKEY_PROJECT_ID`
@@ -129,44 +66,18 @@ Keyspace ID for API key authentication
 - **Environment:** `UNKEY_KEYSPACE_ID`
 </Callout>
 
-<Callout type="info" title="--context">
-Build context path
-
-- **Type:** string
-</Callout>
-
 <Callout type="info" title="--branch">
-Git branch
+Git branch metadata
 
 - **Type:** string
-- **Default:** `"main"`
-</Callout>
-
-<Callout type="info" title="--docker-image">
-Pre-built docker image
-
-- **Type:** string
-</Callout>
-
-<Callout type="info" title="--dockerfile">
-Path to Dockerfile
-
-- **Type:** string
-- **Default:** `"Dockerfile"`
+- **Default:** `"main"` (auto-detected from git if available)
 </Callout>
 
 <Callout type="info" title="--commit">
-Git commit SHA
+Git commit SHA metadata
 
 - **Type:** string
-</Callout>
-
-<Callout type="info" title="--registry">
-Container registry
-
-- **Type:** string
-- **Default:** `"ghcr.io/unkeyed/deploy"`
-- **Environment:** `UNKEY_REGISTRY`
+- **Default:** auto-detected from git if available
 </Callout>
 
 <Callout type="info" title="--env">
@@ -176,44 +87,16 @@ Environment slug to deploy to
 - **Default:** `"preview"`
 </Callout>
 
-<Callout type="info" title="--skip-push">
-Skip pushing to registry (for local testing)
-
-- **Type:** boolean
-- **Default:** `false`
-</Callout>
-
-<Callout type="info" title="--verbose">
-Show detailed output for build and deployment operations
-
-- **Type:** boolean
-- **Default:** `false`
-</Callout>
-
-<Callout type="info" title="--linux">
-Build Docker image for linux/amd64 platform (for deployment to cloud clusters)
-
-- **Type:** boolean
-- **Default:** `false`
-</Callout>
-
-<Callout type="info" title="--control-plane-url">
-Control plane URL
+<Callout type="info" title="--root-key">
+Root key for authentication
 
 - **Type:** string
-- **Default:** `"http://localhost:7091"`
+- **Environment:** `UNKEY_ROOT_KEY`
 </Callout>
 
-<Callout type="info" title="--auth-token">
-Control plane auth token
+<Callout type="info" title="--api-base-url">
+API base URL (for local testing)
 
 - **Type:** string
-- **Default:** `"ctrl-secret-token"`
-</Callout>
-
-<Callout type="info" title="--api-key">
-API key for ctrl service authentication
-
-- **Type:** string
-- **Environment:** `API_KEY`
+- **Environment:** `UNKEY_API_BASE_URL`
 </Callout>


### PR DESCRIPTION
## Summary
- simplify deploy CLI to accept a pre-built Docker image as a positional argument
- remove build-context upload and dockerfile flags; CLI now only creates deployments and polls status
- refresh control-plane and deployment docs to reflect the image-based flow

## Usage
- build/push your image to a registry, then:
  - `unkey deploy <image> --project-id=proj_xxx --env=production`

## Testing
- not run (docs/config changes)
