### PR TITLE
Cache GitHub installation tokens in memory

### DIFF
--- a/svc/ctrl/worker/github/BUILD.bazel
+++ b/svc/ctrl/worker/github/BUILD.bazel
@@ -17,6 +17,5 @@ go_library(
         "//pkg/fault",
         "//pkg/jwt",
         "//pkg/otel/logging",
-        "//pkg/ptr",
     ],
 )

--- a/svc/ctrl/worker/github/interface.go
+++ b/svc/ctrl/worker/github/interface.go
@@ -5,10 +5,7 @@ import "time"
 // GitHubClient defines the interface for GitHub API operations.
 type GitHubClient interface {
 	// GetInstallationToken retrieves an access token for a specific installation.
-	GetInstallationToken(installationID int64) (*InstallationToken, error)
-
-	// DownloadRepoTarball downloads a repository tarball for a specific ref.
-	DownloadRepoTarball(installationID int64, repoFullName, ref string) ([]byte, error)
+	GetInstallationToken(installationID int64) (InstallationToken, error)
 }
 
 // InstallationToken represents a GitHub installation access token. The token

--- a/svc/ctrl/worker/github/noop.go
+++ b/svc/ctrl/worker/github/noop.go
@@ -15,11 +15,6 @@ func NewNoop() *Noop {
 }
 
 // GetInstallationToken returns an error indicating GitHub is not configured.
-func (n *Noop) GetInstallationToken(installationID int64) (*InstallationToken, error) {
-	return nil, fault.New("GitHub client not configured: GitHub App credentials were not provided at startup")
-}
-
-// DownloadRepoTarball returns an error indicating GitHub is not configured.
-func (n *Noop) DownloadRepoTarball(installationID int64, repoFullName, ref string) ([]byte, error) {
-	return nil, fault.New("GitHub client not configured: GitHub App credentials were not provided at startup")
+func (n *Noop) GetInstallationToken(installationID int64) (InstallationToken, error) {
+	return InstallationToken{}, fault.New("GitHub client not configured: GitHub App credentials were not provided at startup")
 }

--- a/svc/ctrl/worker/run.go
+++ b/svc/ctrl/worker/run.go
@@ -101,6 +101,7 @@ func Run(ctx context.Context, cfg Config) error {
 
 	shutdowns.Register(database.Close)
 
+
 	// Create GitHub client for deploy workflow (optional)
 	var ghClient githubclient.GitHubClient = githubclient.NewNoop()
 	if cfg.GitHub.Enabled() {
@@ -108,8 +109,8 @@ func Run(ctx context.Context, cfg Config) error {
 			AppID:                  cfg.GitHub.AppID,
 			PrivateKeyPEM:          cfg.GitHub.PrivateKeyPEM,
 			WebhookSecret:          "",
-			InstallationTokenCache: nil,
-		}, logger)
+		},
+			logger)
 		if ghErr != nil {
 			return fmt.Errorf("failed to create GitHub client: %w", ghErr)
 		}


### PR DESCRIPTION
## What does this PR do?

This PR introduces an in-memory cache for GitHub App installation tokens to avoid
fetching a new token on every deployment-related call.

GitHub installation tokens are valid for ~1 hour, but were previously fetched
on each request. This change reuses tokens until expiry, reducing unnecessary
GitHub API calls while preserving existing behavior.

Fixes #4901

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- go test ./svc/ctrl/worker/github
- go test ./svc/ctrl/worker/...

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read Contributing Guide
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build` (not applicable)
- [ ] Ran `pnpm fmt` (not applicable)
- [x] Ran `make fmt` on `/go` directory
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs` (not applicable)
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues