### PR TITLE
feat: build process style and restructure

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/(overview)/components/sections/deployment-domains-section.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/(overview)/components/sections/deployment-domains-section.tsx
@@ -4,11 +4,7 @@ import { eq, useLiveQuery } from "@tanstack/react-db";
 import { Earth } from "@unkey/icons";
 import { useParams } from "next/navigation";
 import { Section, SectionHeader } from "../../../../../../components/section";
-import {
-  DomainRow,
-  DomainRowEmpty,
-  DomainRowSkeleton,
-} from "../../../../../details/domain-row";
+import { DomainRow, DomainRowEmpty, DomainRowSkeleton } from "../../../../../details/domain-row";
 import { useProject } from "../../../../../layout-provider";
 
 export function DeploymentDomainsSection() {
@@ -39,10 +35,7 @@ export function DeploymentDomainsSection() {
           </>
         ) : (domains?.length ?? 0) > 0 ? (
           domains?.map((domain) => (
-            <DomainRow
-              key={domain.id}
-              domain={domain.fullyQualifiedDomainName}
-            />
+            <DomainRow key={domain.id} domain={domain.fullyQualifiedDomainName} />
           ))
         ) : (
           <DomainRowEmpty />

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/(overview)/components/sections/deployment-network-section.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/(overview)/components/sections/deployment-network-section.tsx
@@ -12,17 +12,17 @@ import { useDeploymentRps } from "../../hooks/use-deployment-rps";
 import { MetricCard } from "../metrics/metric-card";
 
 export function DeploymentNetworkSection() {
-  const [latencyPercentile, setLatencyPercentile] =
-    useState<keyof typeof PERCENTILE_VALUES>("p50");
+  const [latencyPercentile, setLatencyPercentile] = useState<keyof typeof PERCENTILE_VALUES>("p50");
 
   const params = useParams();
   const deploymentId = params?.deploymentId as string;
   const projectId = params?.projectId as string;
 
-  const { currentRps, timeseries: rpsTimeseries } =
-    useDeploymentRps(deploymentId);
-  const { currentLatency, timeseries: latencyTimeseries } =
-    useDeploymentLatency(deploymentId, latencyPercentile);
+  const { currentRps, timeseries: rpsTimeseries } = useDeploymentRps(deploymentId);
+  const { currentLatency, timeseries: latencyTimeseries } = useDeploymentLatency(
+    deploymentId,
+    latencyPercentile,
+  );
 
   return (
     <Section>
@@ -32,10 +32,7 @@ export function DeploymentNetworkSection() {
       />
       <div className="flex gap-2 flex-col">
         <Card className="rounded-[14px] flex justify-between flex-col overflow-hidden border-gray-4 h-[600px] gap-2">
-          <DeploymentNetworkView
-            projectId={projectId}
-            deploymentId={deploymentId}
-          />
+          <DeploymentNetworkView projectId={projectId} deploymentId={deploymentId} />
         </Card>
         <div className="flex gap-2">
           <MetricCard
@@ -43,9 +40,7 @@ export function DeploymentNetworkSection() {
             metricType="latency"
             currentValue={currentLatency}
             percentile={latencyPercentile}
-            onPercentileChange={(value) =>
-              setLatencyPercentile(value as typeof latencyPercentile)
-            }
+            onPercentileChange={(value) => setLatencyPercentile(value as typeof latencyPercentile)}
             chartData={{
               data: latencyTimeseries,
               dataKey: "y",

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/(overview)/components/table/build-step-logs-expanded.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/(overview)/components/table/build-step-logs-expanded.tsx
@@ -1,14 +1,9 @@
-import { CopyButton, TimestampInfo } from "@unkey/ui";
-import { format } from "date-fns";
+import { TimestampInfo } from "@unkey/ui";
 import type { BuildStepRow } from "./columns/build-steps";
 
 export function BuildStepLogsExpanded({ step }: { step: BuildStepRow }) {
   if (!step.logs || step.logs.length === 0) {
-    return (
-      <div className="px-8 py-4 text-sm text-gray-9">
-        No logs available for this step
-      </div>
-    );
+    return <div className="px-8 py-4 text-sm text-gray-9">No logs available for this step</div>;
   }
 
   return (

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/(overview)/components/table/columns/build-steps.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/(overview)/components/table/columns/build-steps.tsx
@@ -1,12 +1,9 @@
 import type { Column } from "@/components/virtual-table/types";
 import { cn } from "@/lib/utils";
 import { formatLatency } from "@/lib/utils/metric-formatters";
-import type {
-  BuildStep,
-  BuildStepLog,
-} from "@unkey/clickhouse/src/build-steps";
-import { Bolt, TriangleWarning, CaretRight } from "@unkey/icons";
-import { TimestampInfo, InfoTooltip } from "@unkey/ui";
+import type { BuildStep, BuildStepLog } from "@unkey/clickhouse/src/build-steps";
+import { Bolt, CaretRight, TriangleWarning } from "@unkey/icons";
+import { InfoTooltip, TimestampInfo } from "@unkey/ui";
 
 export type BuildStepRow = BuildStep & {
   logs?: Omit<BuildStepLog, "step_id">[];

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/(overview)/components/table/deployment-build-steps-table.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/(overview)/components/table/deployment-build-steps-table.tsx
@@ -3,7 +3,7 @@
 import { VirtualTable } from "@/components/virtual-table/index";
 import { BookBookmark } from "@unkey/icons";
 import { Button, Empty } from "@unkey/ui";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { BuildStepLogsExpanded } from "./build-step-logs-expanded";
 import { buildStepsColumns } from "./columns/build-steps";
 import { useDeploymentBuildStepsQuery } from "./hooks/use-deployment-build-steps-query";
@@ -11,9 +11,7 @@ import { getBuildStepRowClass } from "./utils/get-build-step-row-class";
 
 export const DeploymentBuildStepsTable = () => {
   const { steps, isLoading } = useDeploymentBuildStepsQuery();
-  const [expandedIds, setExpandedIds] = useState<Set<string | number>>(
-    new Set(),
-  );
+  const [expandedIds, setExpandedIds] = useState<Set<string | number>>(new Set());
 
   // Enrich steps with expansion state for chevron rendering
   const enrichedSteps = steps.map((step) => ({
@@ -39,8 +37,8 @@ export const DeploymentBuildStepsTable = () => {
             <Empty.Icon className="w-auto" />
             <Empty.Title>Build Steps</Empty.Title>
             <Empty.Description className="text-left">
-              No build steps found for this deployment. Build steps will appear
-              here once the deployment starts building.
+              No build steps found for this deployment. Build steps will appear here once the
+              deployment starts building.
             </Empty.Description>
             <Empty.Actions className="mt-4 justify-start">
               <a

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/page.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/page.tsx
@@ -1,17 +1,17 @@
 "use client";
 
 import { eq, useLiveQuery } from "@tanstack/react-db";
+import { Cube } from "@unkey/icons";
+import { Card } from "@unkey/ui";
+import { useParams } from "next/navigation";
 import { ProjectContentWrapper } from "../../../components/project-content-wrapper";
+import { Section, SectionHeader } from "../../../components/section";
 import { useProject } from "../../layout-provider";
 import { DeploymentDomainsSection } from "./(overview)/components/sections/deployment-domains-section";
 import { DeploymentInfoSection } from "./(overview)/components/sections/deployment-info-section";
 import { DeploymentLogsSection } from "./(overview)/components/sections/deployment-logs-section";
 import { DeploymentNetworkSection } from "./(overview)/components/sections/deployment-network-section";
-import { useParams } from "next/navigation";
-import { Card } from "@unkey/ui";
 import { DeploymentBuildStepsTable } from "./(overview)/components/table/deployment-build-steps-table";
-import { Section, SectionHeader } from "../../../components/section";
-import { Cube } from "@unkey/icons";
 
 export default function DeploymentOverview() {
   const { collections } = useProject();

--- a/web/apps/dashboard/components/virtual-table/index.tsx
+++ b/web/apps/dashboard/components/virtual-table/index.tsx
@@ -1,10 +1,5 @@
 import { cn } from "@/lib/utils";
-import {
-  CaretDown,
-  CaretExpandY,
-  CaretUp,
-  CircleCaretRight,
-} from "@unkey/icons";
+import { CaretDown, CaretExpandY, CaretUp, CircleCaretRight } from "@unkey/icons";
 import { useIsMobile } from "@unkey/ui";
 import {
   Fragment,
@@ -21,12 +16,7 @@ import { DEFAULT_CONFIG } from "./constants";
 import { useTableData } from "./hooks/useTableData";
 import { useTableHeight } from "./hooks/useTableHeight";
 import { useVirtualData } from "./hooks/useVirtualData";
-import type {
-  Column,
-  SeparatorItem,
-  SortDirection,
-  VirtualTableProps,
-} from "./types";
+import type { Column, SeparatorItem, SortDirection, VirtualTableProps } from "./types";
 
 const MOBILE_TABLE_HEIGHT = 400;
 
@@ -88,19 +78,13 @@ export const VirtualTable = forwardRef<VirtualTableRef, VirtualTableProps<any>>(
     // Merge configs, allowing specific overrides
     const config = { ...DEFAULT_CONFIG, ...userConfig };
     const isGridLayout = config.layoutMode === "grid";
-    const parentRef = useRef<HTMLDivElement>(
-      null,
-    ) as React.RefObject<HTMLDivElement>;
-    const containerRef = useRef<HTMLDivElement>(
-      null,
-    ) as React.RefObject<HTMLDivElement>;
+    const parentRef = useRef<HTMLDivElement>(null) as React.RefObject<HTMLDivElement>;
+    const containerRef = useRef<HTMLDivElement>(null) as React.RefObject<HTMLDivElement>;
     // Default to false (desktop) to prevent hydration mismatches
     const isMobile = useIsMobile({ defaultValue: false });
 
     // Track expansion state internally if not controlled
-    const [internalExpandedIds, setInternalExpandedIds] = useState<
-      Set<string | number>
-    >(new Set());
+    const [internalExpandedIds, setInternalExpandedIds] = useState<Set<string | number>>(new Set());
     const expandedIds = controlledExpandedIds ?? internalExpandedIds;
 
     // Toggle expansion
@@ -138,9 +122,7 @@ export const VirtualTable = forwardRef<VirtualTableRef, VirtualTableProps<any>>(
         const typedItem = item as TTableData;
         const id = String(keyExtractor(typedItem));
         const isExpanded = expandedIds.has(id);
-        return isExpanded
-          ? config.rowHeight + expandedRowHeight
-          : config.rowHeight;
+        return isExpanded ? config.rowHeight + expandedRowHeight : config.rowHeight;
       };
     }, [
       renderExpanded,
@@ -210,9 +192,7 @@ export const VirtualTable = forwardRef<VirtualTableRef, VirtualTableProps<any>>(
                       column.cellClassName,
                     )}
                   >
-                    <div className="truncate text-accent-12">
-                      {column.header}
-                    </div>
+                    <div className="truncate text-accent-12">{column.header}</div>
                   </th>
                 ))}
               </tr>
@@ -224,9 +204,7 @@ export const VirtualTable = forwardRef<VirtualTableRef, VirtualTableProps<any>>(
             </thead>
           </table>
           {emptyState ? (
-            <div className="flex-1 flex items-center justify-center">
-              {emptyState}
-            </div>
+            <div className="flex-1 flex items-center justify-center">{emptyState}</div>
           ) : (
             <EmptyState />
           )}
@@ -239,11 +217,7 @@ export const VirtualTable = forwardRef<VirtualTableRef, VirtualTableProps<any>>(
         <div
           ref={parentRef}
           className={containerClassName}
-          style={
-            isMobile
-              ? { height: MOBILE_TABLE_HEIGHT }
-              : { height: `${fixedHeight}px` }
-          }
+          style={isMobile ? { height: MOBILE_TABLE_HEIGHT } : { height: `${fixedHeight}px` }}
         >
           <table className={tableClassName}>
             <colgroup>
@@ -293,9 +267,7 @@ export const VirtualTable = forwardRef<VirtualTableRef, VirtualTableProps<any>>(
                     return (
                       <tr
                         key={`skeleton-${virtualRow.key}`}
-                        className={cn(
-                          config.rowBorders && "border-b border-gray-4",
-                        )}
+                        className={cn(config.rowBorders && "border-b border-gray-4")}
                         style={{ height: `${config.rowHeight}px` }}
                       >
                         {renderSkeletonRow({
@@ -308,16 +280,11 @@ export const VirtualTable = forwardRef<VirtualTableRef, VirtualTableProps<any>>(
                   return (
                     <tr
                       key={`skeleton-${virtualRow.key}`}
-                      className={cn(
-                        config.rowBorders && "border-b border-gray-4",
-                      )}
+                      className={cn(config.rowBorders && "border-b border-gray-4")}
                       style={{ height: `${config.rowHeight}px` }}
                     >
                       {columns.map((column) => (
-                        <td
-                          key={column.key}
-                          className={cn("pr-4", column.cellClassName)}
-                        >
+                        <td key={column.key} className={cn("pr-4", column.cellClassName)}>
                           <div className="h-4 bg-accent-3 rounded animate-pulse" />
                         </td>
                       ))}
@@ -334,10 +301,7 @@ export const VirtualTable = forwardRef<VirtualTableRef, VirtualTableProps<any>>(
                 if (separator.isSeparator) {
                   return (
                     <Fragment key={`row-group-${virtualRow.key}`}>
-                      <tr
-                        key={`spacer-${virtualRow.key}`}
-                        style={{ height: "4px" }}
-                      />
+                      <tr key={`spacer-${virtualRow.key}`} style={{ height: "4px" }} />
                       <tr key={`content-${virtualRow.key}`}>
                         <td colSpan={columns.length} className="p-0">
                           <div className="h-[26px] bg-info-2 font-mono text-xs text-info-11 rounded-md flex items-center gap-3 px-2">
@@ -380,8 +344,7 @@ export const VirtualTable = forwardRef<VirtualTableRef, VirtualTableProps<any>>(
                           if (event.key === "Escape") {
                             event.preventDefault();
                             onRowClick?.(null);
-                            const activeElement =
-                              document.activeElement as HTMLElement;
+                            const activeElement = document.activeElement as HTMLElement;
                             activeElement?.blur();
                           }
                           if (event.key === "ArrowDown" || event.key === "j") {
@@ -458,8 +421,7 @@ export const VirtualTable = forwardRef<VirtualTableRef, VirtualTableProps<any>>(
                         if (event.key === "Escape") {
                           event.preventDefault();
                           onRowClick?.(null);
-                          const activeElement =
-                            document.activeElement as HTMLElement;
+                          const activeElement = document.activeElement as HTMLElement;
                           activeElement?.blur();
                         }
                         if (event.key === "ArrowDown" || event.key === "j") {
@@ -519,9 +481,8 @@ export const VirtualTable = forwardRef<VirtualTableRef, VirtualTableProps<any>>(
                 style={{
                   height: `${
                     virtualizer.getTotalSize() -
-                    (virtualizer.getVirtualItems()[
-                      virtualizer.getVirtualItems().length - 1
-                    ]?.end || 0)
+                    (virtualizer.getVirtualItems()[virtualizer.getVirtualItems().length - 1]?.end ||
+                      0)
                   }px`,
                 }}
               />
@@ -560,11 +521,7 @@ function HeaderCell<T>({ column }: { column: Column<T> }) {
       return;
     }
 
-    const nextDirection = direction
-      ? direction === "asc"
-        ? "desc"
-        : null
-      : "asc";
+    const nextDirection = direction ? (direction === "asc" ? "desc" : null) : "asc";
 
     onSort(nextDirection);
   };

--- a/web/internal/ui/src/components/timestamp-info.tsx
+++ b/web/internal/ui/src/components/timestamp-info.tsx
@@ -124,12 +124,7 @@ const TimestampInfo: React.FC<{
         className="flex items-center hover:bg-gray-3 text-left cursor-pointer w-full px-5 py-2"
       >
         <span className="w-32 text-left truncate text-accent-9">{label}</span>
-        <span
-          className={cn(
-            "ml-2 text-xs text-accent-12",
-            copied ? "text-success-11" : "",
-          )}
-        >
+        <span className={cn("ml-2 text-xs text-accent-12", copied ? "text-success-11" : "")}>
           {copied ? "Copied!" : value}
         </span>
       </span>
@@ -142,17 +137,12 @@ const TimestampInfo: React.FC<{
         // If external trigger is provided, use a span and the external trigger
         <>
           <TooltipTrigger asChild>
-            <span className={cn("text-xs", className)}>
-              {getDisplayValue()}
-            </span>
+            <span className={cn("text-xs", className)}>{getDisplayValue()}</span>
           </TooltipTrigger>
         </>
       ) : (
         // Otherwise use the internal trigger ref for the button
-        <TooltipTrigger
-          ref={internalTriggerRef}
-          className={cn("text-xs", className)}
-        >
+        <TooltipTrigger ref={internalTriggerRef} className={cn("text-xs", className)}>
           <span>{getDisplayValue()}</span>
         </TooltipTrigger>
       )}


### PR DESCRIPTION
I don't care if this code makes it to prod as is or at all, this is an idea of my vision and I am sure you want some code done differently. Tell me or fix it :D


During builds we only display buildlogs, and not the unpopulated domains/network sections.
https://unkey.slack.com/archives/C05SYU6P2DC/p1770751597886379


This also restyles the build logs 
before:
<img width="1980" height="1486" alt="image" src="https://github.com/user-attachments/assets/44b246d6-7e46-4f68-971d-792ddc62ebc9" />

after:
<img width="1280" height="1332" alt="image" src="https://github.com/user-attachments/assets/fc5d9aee-a05f-4a23-9cae-568713c191f3" />
