### PR TITLE
feat: make entire deployment table row clickable

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/components/table/deployments-list.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/components/table/deployments-list.tsx
@@ -182,15 +182,8 @@ export const DeploymentsList = () => {
         headerClassName: "hidden 2xl:table-cell",
         cellClassName: "hidden 2xl:table-cell",
         render: ({ deployment }) => {
-          const isSelected = deployment.id === selectedDeployment?.deployment.id;
           const iconContainer = (
-            <div
-              className={cn(
-                "size-5 rounded flex items-center justify-center cursor-pointer border border-grayA-3 transition-all duration-100",
-                "bg-grayA-3",
-                isSelected && "bg-grayA-5",
-              )}
-            >
+            <div className="size-5 rounded flex items-center justify-center cursor-pointer border border-grayA-3 transition-all duration-100 bg-grayA-3">
               <CodeBranch iconSize="sm-regular" className="text-gray-12" />
             </div>
           );
@@ -276,7 +269,7 @@ export const DeploymentsList = () => {
         },
       },
     ];
-  }, [selectedDeploymentId, project]);
+  }, [project]);
 
   return (
     <VirtualTable
@@ -291,15 +284,9 @@ export const DeploymentsList = () => {
       onRowMouseEnter={(item) => {
         router.prefetch(getDeploymentHref(item.deployment.id));
       }}
-      selectedItem={selectedDeployment}
       keyExtractor={(deployment) => deployment.id}
       rowClassName={(deployment) =>
-        getRowClassName(
-          deployment,
-          selectedDeployment?.deployment.id ?? null,
-          liveDeploymentId ?? null,
-          project?.isRolledBack ?? false,
-        )
+        getRowClassName(deployment, liveDeploymentId ?? null, project?.isRolledBack ?? false)
       }
       emptyState={
         <div className="w-full flex justify-center items-center h-full">

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/components/table/utils/get-row-class.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/components/table/utils/get-row-class.ts
@@ -5,10 +5,8 @@ import { cn } from "@/lib/utils";
 export type StatusStyle = {
   base: string;
   hover: string;
-  selected: string;
   badge: {
     default: string;
-    selected: string;
   };
   focusRing: string;
 };
@@ -16,10 +14,8 @@ export type StatusStyle = {
 export const STATUS_STYLES = {
   base: "text-grayA-9",
   hover: "hover:text-accent-11 dark:hover:text-accent-12 hover:bg-grayA-2",
-  selected: "text-accent-12 bg-grayA-2 hover:text-accent-12",
   badge: {
     default: "bg-grayA-3 text-grayA-11 group-hover:bg-grayA-5 border-transparent",
-    selected: "bg-grayA-5 text-grayA-12 hover:bg-grayA-5 border-grayA-3",
   },
   focusRing: "focus:ring-accent-7",
 };
@@ -27,7 +23,6 @@ export const STATUS_STYLES = {
 export const FAILED_STATUS_STYLES = {
   base: "text-grayA-9 bg-error-2",
   hover: "hover:text-grayA-11 hover:bg-error-2",
-  selected: "text-grayA-12 bg-error-3 hover:bg-error-3",
   badge: {
     default: "bg-grayA-3 text-grayA-11 group-hover:bg-grayA-5 border-transparent",
     selected: "bg-grayA-5 text-grayA-12 hover:bg-grayA-5 border-grayA-3",
@@ -38,7 +33,6 @@ export const FAILED_STATUS_STYLES = {
 export const ROLLED_BACK_STYLES = {
   base: "text-grayA-9 bg-warning-2",
   hover: "hover:text-grayA-11 hover:bg-warning-4",
-  selected: "text-grayA-12 bg-warning-5 hover:bg-warning-6",
   badge: {
     default: "bg-grayA-3 text-grayA-11 group-hover:bg-grayA-5 border-transparent",
     selected: "bg-grayA-5 text-grayA-12 hover:bg-grayA-5 border-grayA-3",
@@ -48,7 +42,6 @@ export const ROLLED_BACK_STYLES = {
 
 export const getRowClassName = (
   { deployment }: { deployment: Deployment; environment: Environment },
-  selectedDeploymentId: string | null,
   liveDeploymentId: string | null,
   isRolledBack: boolean,
 ) => {
@@ -59,8 +52,6 @@ export const getRowClassName = (
     : isRolledBack && liveDeploymentId === deployment.id
       ? ROLLED_BACK_STYLES
       : STATUS_STYLES;
-  const isSelected =
-    typeof selectedDeploymentId !== "undefined" && deployment.id === selectedDeploymentId;
 
   return cn(
     style.base,
@@ -68,6 +59,5 @@ export const getRowClassName = (
     "group rounded",
     "focus:outline-none focus:ring-1 focus:ring-opacity-40",
     style.focusRing,
-    isSelected && style.selected,
   );
 };


### PR DESCRIPTION
## What
Make the entire row in the deployments table clickable to navigate to the deployment detail page, not just the ID link in the first column.

## How
- Use existing `onRowClick` to `router.push()` to the deployment detail page
- Use existing `onRowMouseEnter` to `router.prefetch()` the route on hover
- Remove the old `Link` in the first column (no longer needed since the whole row navigates)
- Clean up unused imports (`Loading`, `Link`) and state (`navigatingId`)