### PR TITLE
project nav

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/components/table/components/actions/deployment-list-table-action.popover.constants.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/components/table/components/actions/deployment-list-table-action.popover.constants.tsx
@@ -1,16 +1,9 @@
 "use client";
 import { useProjectData } from "@/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/data-provider";
-import {
-  type MenuItem,
-  TableActionPopover,
-} from "@/components/logs/table-action.popover";
+import { type MenuItem, TableActionPopover } from "@/components/logs/table-action.popover";
 import { useWorkspaceNavigation } from "@/hooks/use-workspace-navigation";
 import type { Deployment, Environment } from "@/lib/collections";
-import {
-  ArrowDottedRotateAnticlockwise,
-  ChevronUp,
-  Layers3,
-} from "@unkey/icons";
+import { ArrowDottedRotateAnticlockwise, ChevronUp, Layers3 } from "@unkey/icons";
 import { useRouter } from "next/navigation";
 import { useMemo } from "react";
 import { PromotionDialog } from "./promotion-dialog";

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/navigations/use-breadcrumb-config.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/navigations/use-breadcrumb-config.ts
@@ -2,7 +2,6 @@
 
 import type { Navbar } from "@/components/navigation/navbar";
 import { shortenId } from "@/lib/shorten-id";
-import { useWorkspace } from "@/providers/workspace-provider";
 import { useParams, useSelectedLayoutSegments } from "next/navigation";
 import type { ComponentPropsWithoutRef } from "react";
 
@@ -14,9 +13,7 @@ export type QuickNavItem = {
   disabledTooltip?: string;
 };
 
-export type BreadcrumbItem = ComponentPropsWithoutRef<
-  typeof Navbar.Breadcrumbs.Link
-> & {
+export type BreadcrumbItem = ComponentPropsWithoutRef<typeof Navbar.Breadcrumbs.Link> & {
   /** Unique identifier for the breadcrumb item */
   id: string;
   /** Internal: determines if this breadcrumb should be rendered */
@@ -91,8 +88,7 @@ export const useBreadcrumbConfig = ({
   ];
 
   // Determine active subpage based on segment
-  const activeSubPage =
-    subPages.find((p) => p.segment === currentSegment) || subPages[0];
+  const activeSubPage = subPages.find((p) => p.segment === currentSegment) || subPages[0];
   const isOnDeploymentDetail = Boolean(deploymentId);
 
   // Build breadcrumbs declaratively
@@ -132,9 +128,7 @@ export const useBreadcrumbConfig = ({
     {
       id: "subpage",
       children: isOnDeploymentDetail ? "Deployments" : activeSubPage.label,
-      href: isOnDeploymentDetail
-        ? `${basePath}/${projectId}/deployments`
-        : activeSubPage.href,
+      href: isOnDeploymentDetail ? `${basePath}/${projectId}/deployments` : activeSubPage.href,
       shouldRender: true,
       active: !isOnDeploymentDetail, // Active if not on detail page
       isLast: !isOnDeploymentDetail, // Last if not on detail page


### PR DESCRIPTION
- **fix: cleanup project side nav**
- **chore: remove most nested sidebar stuff**
- **revert: log nav**


THis flattens the sidebar nav, we only do one row per project now, nothing nested

pages on a project can be accessed in the breadcrumbs

<img width="1840" height="1132" alt="CleanShot 2026-02-12 at 14 45 16@2x" src="https://github.com/user-attachments/assets/ae70f1d5-b8c8-4513-aa22-f03aa4fdc86e" />

