### PR TITLE
allow longer timeouts

### DIFF
--- a/svc/frontline/run.go
+++ b/svc/frontline/run.go
@@ -8,7 +8,6 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
-	"time"
 
 	"connectrpc.com/connect"
 	"github.com/unkeyed/unkey/gen/proto/ctrl/v1/ctrlv1connect"
@@ -215,12 +214,9 @@ func Run(ctx context.Context, cfg Config) error {
 	// Start HTTPS frontline server (main proxy server)
 	if cfg.HttpsPort > 0 {
 		httpsSrv, httpsErr := zen.New(zen.Config{
-			TLS: tlsConfig,
-			// Use longer timeouts for proxy operations
-			// WriteTimeout must be longer than the transport's ResponseHeaderTimeout (30s)
-			// so that transport timeouts can be caught and handled properly in ErrorHandler
-			ReadTimeout:        30 * time.Second,
-			WriteTimeout:       60 * time.Second,
+			TLS:                tlsConfig,
+			ReadTimeout:        0,
+			WriteTimeout:       0,
 			Flags:              nil,
 			EnableH2C:          false,
 			MaxRequestBodySize: 0,

--- a/svc/frontline/services/proxy/interface.go
+++ b/svc/frontline/services/proxy/interface.go
@@ -51,9 +51,6 @@ type Config struct {
 	// TLSHandshakeTimeout is the maximum amount of time a TLS handshake will take.
 	TLSHandshakeTimeout time.Duration
 
-	// ResponseHeaderTimeout is the maximum amount of time to wait for response headers.
-	ResponseHeaderTimeout time.Duration
-
 	// Transport allows passing a shared HTTP transport for connection pooling
 	// If nil, a new transport will be created with the other config values
 	Transport *http.Transport

--- a/svc/frontline/services/proxy/service.go
+++ b/svc/frontline/services/proxy/service.go
@@ -55,7 +55,6 @@ func New(cfg Config) (*service, error) {
 			IdleConnTimeout:       90 * time.Second,
 			TLSHandshakeTimeout:   10 * time.Second,
 			ExpectContinueTimeout: 1 * time.Second,
-			ResponseHeaderTimeout: 40 * time.Second, // Longer than sentinel timeout (30s) to receive its error response
 			// Enable TLS session resumption for faster cross-region forwarding
 			TLSClientConfig: &tls.Config{
 				MinVersion:         tls.VersionTLS12,
@@ -75,9 +74,6 @@ func New(cfg Config) (*service, error) {
 			transport.TLSHandshakeTimeout = cfg.TLSHandshakeTimeout
 		}
 
-		if cfg.ResponseHeaderTimeout > 0 {
-			transport.ResponseHeaderTimeout = cfg.ResponseHeaderTimeout
-		}
 	}
 
 	// Create h2c transport for HTTP/2 cleartext connections to sentinel

--- a/svc/sentinel/routes/register.go
+++ b/svc/sentinel/routes/register.go
@@ -17,15 +17,12 @@ func Register(srv *zen.Server, svc *Services) {
 	withSentinelLogging := middleware.WithSentinelLogging(svc.ClickHouse, svc.Clock, svc.SentinelID, svc.Region)
 	withProxyErrorHandling := middleware.WithProxyErrorHandling()
 	withLogging := zen.WithLogging()
-	withTimeout := zen.WithTimeout(5 * time.Minute)
-
 	defaultMiddlewares := []zen.Middleware{
 		withPanicRecovery,
 		withObservability,
 		withSentinelLogging,
 		withProxyErrorHandling,
 		withLogging,
-		withTimeout,
 	}
 
 	srv.RegisterRoute(
@@ -39,10 +36,9 @@ func Register(srv *zen.Server, svc *Services) {
 			Timeout:   10 * time.Second,
 			KeepAlive: 30 * time.Second,
 		}).DialContext,
-		MaxIdleConns:          200,
-		MaxIdleConnsPerHost:   50,
-		IdleConnTimeout:       90 * time.Second,
-		ResponseHeaderTimeout: 30 * time.Second,
+		MaxIdleConns:        200,
+		MaxIdleConnsPerHost: 50,
+		IdleConnTimeout:     90 * time.Second,
 	}
 
 	srv.RegisterRoute(


### PR DESCRIPTION
## What does this PR do?

Removes timeout configurations from the frontline and sentinel services to prevent premature connection termination. This change:

1. Removes the `ResponseHeaderTimeout` parameter from the proxy transport configuration
2. Sets `ReadTimeout` and `WriteTimeout` to 0 (unlimited) in the HTTPS frontline server
3. Removes the global timeout middleware from sentinel routes

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Test long-running API requests to ensure they complete successfully without timeout errors
- Verify that connections are properly maintained for operations that take longer than the previous timeout values
- Test high-load scenarios to ensure connection handling remains stable

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [x] Ran `make fmt` on `/go` directory
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary