### PR TITLE
feat(sentinel): migrate Sentinel service to file-based TOML config

### DIFF
--- a/cmd/sentinel/BUILD.bazel
+++ b/cmd/sentinel/BUILD.bazel
@@ -7,7 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/cli",
-        "//pkg/uid",
+        "//pkg/config",
         "//svc/sentinel",
     ],
 )

--- a/cmd/sentinel/main.go
+++ b/cmd/sentinel/main.go
@@ -2,10 +2,9 @@ package sentinel
 
 import (
 	"context"
-	"time"
 
 	"github.com/unkeyed/unkey/pkg/cli"
-	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/pkg/config"
 	"github.com/unkeyed/unkey/svc/sentinel"
 )
 
@@ -19,72 +18,17 @@ var Cmd = &cli.Command{
 	Name:        "sentinel",
 	Usage:       "Run the Unkey Sentinel server (deployment proxy)",
 	Flags: []cli.Flag{
-		// Server Configuration
-		cli.Int("http-port", "HTTP port for the Sentinel server to listen on. Default: 8080",
-			cli.Default(8080), cli.EnvVar("UNKEY_HTTP_PORT")),
-
-		// Instance Identification
-		cli.String("sentinel-id", "Unique identifier for this sentinel instance. Auto-generated if not provided.",
-			cli.Default(uid.New("sentinel", 4)), cli.EnvVar("UNKEY_SENTINEL_ID")),
-
-		cli.String("workspace-id", "Workspace ID this sentinel serves. Required.",
-			cli.Required(), cli.EnvVar("UNKEY_WORKSPACE_ID")),
-
-		cli.String("environment-id", "Environment ID this sentinel serves (handles all deployments in this environment). Required.",
-			cli.Required(), cli.EnvVar("UNKEY_ENVIRONMENT_ID")),
-
-		cli.String("region", "Geographic region identifier. Used for logging. Default: unknown",
-			cli.Default("unknown"), cli.EnvVar("UNKEY_REGION")),
-
-		// Database Configuration
-		cli.String("database-primary", "MySQL connection string for primary database. Required.",
-			cli.Required(), cli.EnvVar("UNKEY_DATABASE_PRIMARY")),
-
-		cli.String("database-replica", "MySQL connection string for read-replica.",
-			cli.EnvVar("UNKEY_DATABASE_REPLICA")),
-
-		cli.String("clickhouse-url", "ClickHouse connection string. Optional.",
-			cli.EnvVar("UNKEY_CLICKHOUSE_URL")),
-
-		// Observability
-		cli.Bool("otel", "Enable OpenTelemetry tracing and metrics",
-			cli.EnvVar("UNKEY_OTEL")),
-		cli.Float("otel-trace-sampling-rate", "Sampling rate for OpenTelemetry traces (0.0-1.0). Default: 0.25",
-			cli.Default(0.25), cli.EnvVar("UNKEY_OTEL_TRACE_SAMPLING_RATE")),
-		cli.Int("prometheus-port", "Enable Prometheus /metrics endpoint on specified port. Set to 0 to disable.", cli.EnvVar("UNKEY_PROMETHEUS_PORT")),
-
-		// Logging Sampler Configuration
-		cli.Float("log-sample-rate", "Baseline probability (0.0-1.0) of emitting log events. Default: 1.0",
-			cli.Default(1.0), cli.EnvVar("UNKEY_LOG_SAMPLE_RATE")),
-		cli.Duration("log-slow-threshold", "Duration threshold for slow event sampling. Default: 1s",
-			cli.Default(time.Second), cli.EnvVar("UNKEY_LOG_SLOW_THRESHOLD")),
+		cli.String("config", "Path to a TOML config file",
+			cli.Default("unkey.toml"), cli.EnvVar("UNKEY_CONFIG")),
 	},
 	Action: action,
 }
 
 func action(ctx context.Context, cmd *cli.Command) error {
-	return sentinel.Run(ctx, sentinel.Config{
-		// Instance identification
-		SentinelID:    cmd.String("sentinel-id"),
-		WorkspaceID:   cmd.String("workspace-id"),
-		EnvironmentID: cmd.String("environment-id"),
-		Region:        cmd.String("region"),
+	cfg, err := config.Load[sentinel.Config](cmd.String("config"))
+	if err != nil {
+		return cli.Exit("Failed to load config: "+err.Error(), 1)
+	}
 
-		// HTTP configuration
-		HttpPort: cmd.Int("http-port"),
-
-		// Database configuration
-		DatabasePrimary:         cmd.String("database-primary"),
-		DatabaseReadonlyReplica: cmd.String("database-replica"),
-		ClickhouseURL:           cmd.String("clickhouse-url"),
-
-		// Observability
-		OtelEnabled:           cmd.Bool("otel"),
-		OtelTraceSamplingRate: cmd.Float("otel-trace-sampling-rate"),
-		PrometheusPort:        cmd.Int("prometheus-port"),
-
-		// Logging sampler configuration
-		LogSampleRate:    cmd.Float("log-sample-rate"),
-		LogSlowThreshold: cmd.Duration("log-slow-threshold"),
-	})
+	return sentinel.Run(ctx, cfg)
 }

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -63,7 +63,7 @@ services:
     deploy:
       replicas: 3
       endpoint_mode: vip
-    command: ["run", "api"]
+    command: ["run", "api", "--config", "/etc/unkey/api.toml"]
     build:
       context: ../
       dockerfile: ./Dockerfile
@@ -80,22 +80,8 @@ services:
         condition: service_started
       ctrl-api:
         condition: service_started
-    environment:
-      UNKEY_HTTP_PORT: 7070
-      UNKEY_REDIS_URL: "redis://redis:6379"
-      UNKEY_DATABASE_PRIMARY: "unkey:password@tcp(mysql:3306)/unkey?parseTime=true"
-      UNKEY_CLICKHOUSE_URL: "clickhouse://default:password@clickhouse:9000?secure=false&skip_verify=true"
-      UNKEY_CHPROXY_AUTH_TOKEN: "chproxy-test-token-123"
-      UNKEY_OTEL: false
-      UNKEY_VAULT_URL: "http://vault:8060"
-      UNKEY_VAULT_TOKEN: "vault-test-token-123"
-      UNKEY_KAFKA_BROKERS: "kafka:9092"
-      UNKEY_CLICKHOUSE_ANALYTICS_URL: "http://clickhouse:8123/default"
-      UNKEY_CTRL_URL: "http://ctrl-api:7091"
-      UNKEY_CTRL_TOKEN: "your-local-dev-key"
-      UNKEY_PPROF_ENABLED: "true"
-      UNKEY_PPROF_USERNAME: "admin"
-      UNKEY_PPROF_PASSWORD: "password"
+    volumes:
+      - ./config/api.toml:/etc/unkey/api.toml:ro
 
   redis:
     networks:
@@ -126,20 +112,14 @@ services:
     build:
       context: ../
       dockerfile: Dockerfile
-    command: ["run", "vault"]
+    command: ["run", "vault", "--config", "/etc/unkey/vault.toml"]
     ports:
       - "8060:8060"
     depends_on:
       s3:
         condition: service_healthy
-    environment:
-      UNKEY_HTTP_PORT: "8060"
-      UNKEY_S3_URL: "http://s3:3902"
-      UNKEY_S3_BUCKET: "vault"
-      UNKEY_S3_ACCESS_KEY_ID: "minio_root_user"
-      UNKEY_S3_ACCESS_KEY_SECRET: "minio_root_password"
-      UNKEY_MASTER_KEYS: "Ch9rZWtfMmdqMFBJdVhac1NSa0ZhNE5mOWlLSnBHenFPENTt7an5MRogENt9Si6wms4pQ2XIvqNSIgNpaBenJmXgcInhu6Nfv2U="
-      UNKEY_BEARER_TOKEN: "vault-test-token-123"
+    volumes:
+      - ./config/vault.toml:/etc/unkey/vault.toml:ro
     healthcheck:
       test: ["CMD", "/unkey", "healthcheck", "http://localhost:8060/health/live"]
       timeout: 10s
@@ -210,29 +190,17 @@ services:
       args:
         VERSION: "latest"
     container_name: krane
-    command: ["run", "krane"]
+    command: ["run", "krane", "--config", "/etc/unkey/krane.toml"]
     ports:
       - "8070:8070"
     volumes:
       # Mount Docker socket for Docker backend support
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./config/krane.toml:/etc/unkey/krane.toml:ro
     depends_on:
       vault:
         condition: service_healthy
     environment:
-      # Server configuration
-      UNKEY_REGION: "local.dev" # currently required to receive filtered events from ctrl
-      UNKEY_CONTROL_PLANE_URL: "http://ctrl-api:7091"
-      UNKEY_CONTROL_PLANE_BEARER: "your-local-dev-key"
-
-      # Backend configuration - use Docker backend for development
-      UNKEY_KRANE_BACKEND: "docker"
-      UNKEY_DOCKER_SOCKET: "/var/run/docker.sock"
-
-      # Vault configuration for secrets decryption
-      UNKEY_VAULT_URL: "http://vault:8060"
-      UNKEY_VAULT_TOKEN: "vault-test-token-123"
-
       UNKEY_REGISTRY_URL: "${UNKEY_REGISTRY_URL:-}"
       UNKEY_REGISTRY_USERNAME: "${UNKEY_REGISTRY_USERNAME:-}"
       UNKEY_REGISTRY_PASSWORD: "${UNKEY_REGISTRY_PASSWORD:-}"
@@ -266,7 +234,7 @@ services:
       args:
         VERSION: "latest"
     container_name: ctrl-api
-    command: ["run", "ctrl", "api"]
+    command: ["run", "ctrl", "api", "--config", "/etc/unkey/ctrl-api.toml"]
     ports:
       - "7091:7091"
     depends_on:
@@ -282,30 +250,10 @@ services:
       clickhouse:
         condition: service_healthy
         required: true
+    volumes:
+      - ./config/ctrl-api.toml:/etc/unkey/ctrl-api.toml:ro
     environment:
-      UNKEY_DATABASE_PRIMARY: "unkey:password@tcp(mysql:3306)/unkey?parseTime=true&interpolateParams=true"
-
-      # Control plane configuration
-      UNKEY_HTTP_PORT: "7091"
-
-      # Restate configuration (ctrl api only needs ingress client, not server)
-      UNKEY_RESTATE_INGRESS_URL: "http://restate:8080"
-      UNKEY_RESTATE_ADMIN_URL: "http://restate:9070"
-      UNKEY_RESTATE_API_KEY: ""
-
-      # Build configuration (for presigned URLs)
-      UNKEY_BUILD_S3_URL: "${UNKEY_BUILD_S3_URL:-http://s3:3902}"
-      UNKEY_BUILD_S3_EXTERNAL_URL: "${UNKEY_BUILD_S3_EXTERNAL_URL:-http://localhost:3902}"
-      UNKEY_BUILD_S3_BUCKET: "build-contexts"
-      UNKEY_BUILD_S3_ACCESS_KEY_ID: "${UNKEY_BUILD_S3_ACCESS_KEY_ID:-minio_root_user}"
-      UNKEY_BUILD_S3_ACCESS_KEY_SECRET: "${UNKEY_BUILD_S3_ACCESS_KEY_SECRET:-minio_root_password}"
-
-      # API key for simple authentication
-      UNKEY_AUTH_TOKEN: "your-local-dev-key"
-
-      # Certificate bootstrap
-      UNKEY_DEFAULT_DOMAIN: "unkey.local"
-      UNKEY_CNAME_DOMAIN: "unkey.local"
+      UNKEY_GITHUB_APP_WEBHOOK_SECRET: "${UNKEY_GITHUB_APP_WEBHOOK_SECRET:-}"
 
   ctrl-worker:
     networks:
@@ -316,7 +264,7 @@ services:
       args:
         VERSION: "latest"
     container_name: ctrl-worker
-    command: ["run", "ctrl", "worker"]
+    command: ["run", "ctrl", "worker", "--config", "/etc/unkey/ctrl-worker.toml"]
     env_file:
       - .env.depot
     ports:
@@ -345,42 +293,7 @@ services:
         required: true
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-    environment:
-      UNKEY_DATABASE_PRIMARY: "unkey:password@tcp(mysql:3306)/unkey?parseTime=true&interpolateParams=true"
-
-      # Domain configuration (used by deploy and routing services)
-      UNKEY_DEFAULT_DOMAIN: "unkey.local"
-      UNKEY_CNAME_DOMAIN: "unkey.local"
-
-      # Restate configuration
-      UNKEY_RESTATE_ADMIN_URL: "http://restate:9070"
-      UNKEY_RESTATE_HTTP_PORT: "9080"
-      UNKEY_RESTATE_REGISTER_AS: "http://ctrl-worker:9080"
-
-      # Vault service for secret encryption
-      UNKEY_VAULT_URL: "http://vault:8060"
-      UNKEY_VAULT_TOKEN: "vault-test-token-123"
-
-      # Build configuration (loaded from .env.depot)
-      UNKEY_BUILD_S3_BUCKET: "build-contexts"
-
-      # Build configuration
-      UNKEY_BUILD_PLATFORM: "linux/amd64"
-
-      # Registry configuration (UNKEY_REGISTRY_PASSWORD loaded from .env.depot)
-      UNKEY_REGISTRY_URL: "registry.depot.dev"
-      UNKEY_REGISTRY_USERNAME: "x-token"
-
-      # Depot-specific configuration
-      UNKEY_DEPOT_API_URL: "https://api.depot.dev"
-      UNKEY_DEPOT_PROJECT_REGION: "us-east-1"
-
-      # ClickHouse
-      UNKEY_CLICKHOUSE_URL: "clickhouse://default:password@clickhouse:9000?secure=false&skip_verify=true"
-      UNKEY_CLICKHOUSE_ADMIN_URL: "clickhouse://unkey_user_admin:C57RqT5EPZBqCJkMxN9mEZZEzMPcw9yBlwhIizk99t7kx6uLi9rYmtWObsXzdl@clickhouse:9000?secure=false&skip_verify=true"
-
-      # Sentinel image for deployments
-      UNKEY_SENTINEL_IMAGE: "unkey/sentinel:latest"
+      - ./config/ctrl-worker.toml:/etc/unkey/ctrl-worker.toml:ro
 
   otel:
     networks:

--- a/pkg/db/deployment_topology_update_desired_status.sql_generated.go
+++ b/pkg/db/deployment_topology_update_desired_status.sql_generated.go
@@ -31,6 +31,12 @@ type UpdateDeploymentTopologyDesiredStatusParams struct {
 //	SET desired_status = ?, version = ?, updated_at = ?
 //	WHERE deployment_id = ? AND region = ?
 func (q *Queries) UpdateDeploymentTopologyDesiredStatus(ctx context.Context, db DBTX, arg UpdateDeploymentTopologyDesiredStatusParams) error {
-	_, err := db.ExecContext(ctx, updateDeploymentTopologyDesiredStatus, arg.DesiredStatus, arg.Version, arg.UpdatedAt, arg.DeploymentID, arg.Region)
+	_, err := db.ExecContext(ctx, updateDeploymentTopologyDesiredStatus,
+		arg.DesiredStatus,
+		arg.Version,
+		arg.UpdatedAt,
+		arg.DeploymentID,
+		arg.Region,
+	)
 	return err
 }

--- a/pkg/db/querier_generated.go
+++ b/pkg/db/querier_generated.go
@@ -2412,13 +2412,6 @@ type Querier interface {
 	//  SET desired_state = ?, updated_at = ?
 	//  WHERE id = ?
 	UpdateDeploymentDesiredState(ctx context.Context, db DBTX, arg UpdateDeploymentDesiredStateParams) error
-	//UpdateDeploymentTopologyDesiredStatus updates the desired_status and version of a topology entry.
-	// A new version is required so that WatchDeployments picks up the change.
-	//
-	//  UPDATE `deployment_topology`
-	//  SET desired_status = ?, version = ?, updated_at = ?
-	//  WHERE deployment_id = ? AND region = ?
-	UpdateDeploymentTopologyDesiredStatus(ctx context.Context, db DBTX, arg UpdateDeploymentTopologyDesiredStatusParams) error
 	//UpdateDeploymentImage
 	//
 	//  UPDATE deployments
@@ -2437,6 +2430,13 @@ type Querier interface {
 	//  SET status = ?, updated_at = ?
 	//  WHERE id = ?
 	UpdateDeploymentStatus(ctx context.Context, db DBTX, arg UpdateDeploymentStatusParams) error
+	// UpdateDeploymentTopologyDesiredStatus updates the desired_status and version of a topology entry.
+	// A new version is required so that WatchDeployments picks up the change.
+	//
+	//  UPDATE `deployment_topology`
+	//  SET desired_status = ?, version = ?, updated_at = ?
+	//  WHERE deployment_id = ? AND region = ?
+	UpdateDeploymentTopologyDesiredStatus(ctx context.Context, db DBTX, arg UpdateDeploymentTopologyDesiredStatusParams) error
 	//UpdateFrontlineRouteDeploymentId
 	//
 	//  UPDATE frontline_routes

--- a/svc/sentinel/BUILD.bazel
+++ b/svc/sentinel/BUILD.bazel
@@ -9,9 +9,9 @@ go_library(
     importpath = "github.com/unkeyed/unkey/svc/sentinel",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/assert",
         "//pkg/clickhouse",
         "//pkg/clock",
+        "//pkg/config",
         "//pkg/db",
         "//pkg/logger",
         "//pkg/otel",

--- a/svc/sentinel/config.go
+++ b/svc/sentinel/config.go
@@ -3,53 +3,68 @@ package sentinel
 import (
 	"fmt"
 	"slices"
-	"time"
 
-	"github.com/unkeyed/unkey/pkg/assert"
+	"github.com/unkeyed/unkey/pkg/config"
 )
 
-type Config struct {
-	SentinelID string
-
-	WorkspaceID string
-
-	// EnvironmentID identifies which environment this sentinel serves
-	// A single environment may have multiple deployments, and this sentinel
-	// handles all of them based on the deployment ID passed in each request
-	EnvironmentID string
-
-	Region string
-
-	HttpPort int
-
-	DatabasePrimary         string
-	DatabaseReadonlyReplica string
-
-	ClickhouseURL string
-
-	OtelEnabled           bool
-	OtelTraceSamplingRate float64
-	PrometheusPort        int
-
-	// --- Logging sampler configuration ---
-
-	// LogSampleRate is the baseline probability (0.0-1.0) of emitting log events.
-	LogSampleRate float64
-
-	// LogSlowThreshold defines what duration qualifies as "slow" for sampling.
-	LogSlowThreshold time.Duration
+// ClickHouseConfig configures connections to ClickHouse for analytics storage.
+// When URL is empty, a no-op analytics backend is used.
+type ClickHouseConfig struct {
+	// URL is the ClickHouse connection string.
+	// Example: "clickhouse://default:password@clickhouse:9000?secure=false&skip_verify=true"
+	URL string `toml:"url"`
 }
 
-func (c Config) Validate() error {
-	err := assert.All(
-		assert.NotEmpty(c.WorkspaceID, "workspace ID is required"),
-		assert.NotEmpty(c.EnvironmentID, "environment ID is required"),
-	)
+// Config holds the complete configuration for the Sentinel server. It is
+// designed to be loaded from a TOML file using [config.Load]:
+//
+//	cfg, err := config.Load[sentinel.Config]("/etc/unkey/sentinel.toml")
+//
+// Environment variables are expanded in file values using ${VAR} or
+// ${VAR:-default} syntax before parsing. Struct tag defaults are applied to
+// any field left at its zero value after parsing, and validation runs
+// automatically via [Config.Validate].
+type Config struct {
+	// SentinelID identifies this particular sentinel instance. Used in log
+	// attribution and request tracing.
+	SentinelID string `toml:"sentinel_id"`
 
-	if err != nil {
-		return err
-	}
+	// WorkspaceID is the workspace this sentinel serves.
+	WorkspaceID string `toml:"workspace_id" config:"required,nonempty"`
 
+	// EnvironmentID identifies which environment this sentinel serves.
+	// A single environment may have multiple deployments, and this sentinel
+	// handles all of them based on the deployment ID passed in each request.
+	EnvironmentID string `toml:"environment_id" config:"required,nonempty"`
+
+	// Region is the geographic region identifier (e.g. "us-east-1.aws").
+	// Included in structured logs and used for routing decisions.
+	Region string `toml:"region" config:"required,oneof=local.dev|us-east-1.aws|us-east-2.aws|us-west-1.aws|us-west-2.aws|eu-central-1.aws"`
+
+	// HttpPort is the TCP port the sentinel server binds to.
+	HttpPort int `toml:"http_port" config:"default=8080,min=1,max=65535"`
+
+	// PrometheusPort starts a Prometheus /metrics HTTP endpoint on the
+	// specified port. Set to 0 (the default) to disable the endpoint entirely.
+	PrometheusPort int `toml:"prometheus_port"`
+
+	// Database configures MySQL connections. See [config.DatabaseConfig].
+	Database config.DatabaseConfig `toml:"database"`
+
+	// ClickHouse configures analytics storage. See [ClickHouseConfig].
+	ClickHouse ClickHouseConfig `toml:"clickhouse"`
+
+	// Otel configures OpenTelemetry export. See [config.OtelConfig].
+	Otel config.OtelConfig `toml:"otel"`
+
+	// Logging configures log sampling. See [config.LoggingConfig].
+	Logging config.LoggingConfig `toml:"logging"`
+}
+
+// Validate checks cross-field constraints that cannot be expressed through
+// struct tags alone. It implements [config.Validator] so that [config.Load]
+// calls it automatically after tag-level validation.
+func (c *Config) Validate() error {
 	validRegions := []string{
 		"local.dev",
 		"us-east-1.aws",
@@ -61,7 +76,6 @@ func (c Config) Validate() error {
 
 	if !slices.Contains(validRegions, c.Region) {
 		return fmt.Errorf("invalid region: %s, must be one of %v", c.Region, validRegions)
-
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

Migrates the Sentinel sidecar from `UNKEY_*` environment variables to a structured TOML config file loaded via `pkg/config`. This is the final service migration in the config stack.

## What changed

- **`svc/sentinel/config.go`**: Rewritten with tagged Config struct — ClickHouse, logging, database, otel
- **`svc/sentinel/run.go`**: Updated to read from new config struct fields
- **`cmd/sentinel/main.go`**: Accepts `--config` flag to load TOML file
- **`dev/docker-compose.yaml`**: Updated all migrated services — replaces env var blocks with TOML config volume mounts (api, vault, krane, ctrl-api, ctrl-worker)
- **`pkg/db/`**: Minor formatting fix in generated code

## docker-compose.yaml changes

This PR includes the docker-compose updates for **all** services migrated across the stack:
- `api`: env vars → `./config/api.toml:/etc/unkey/api.toml:ro`
- `vault`: env vars → `./config/vault.toml:/etc/unkey/vault.toml:ro`
- `krane`: env vars → `./config/krane.toml:/etc/unkey/krane.toml:ro`
- `ctrl-api`: env vars → `./config/ctrl-api.toml:/etc/unkey/ctrl-api.toml:ro`
- `ctrl-worker`: env vars → `./config/ctrl-worker.toml:/etc/unkey/ctrl-worker.toml:ro`

## Stack

**PR 8/8** — final PR in the config migration stack. Depends on #5051.

1. `pkg/config` (#5045)
2. `svc/api` (#5046)
3. `svc/vault` (#5047)
4. `svc/ctrl` (#5048)
5. `svc/krane` (#5049)
6. `svc/frontline` (#5050)
7. `svc/preflight` (#5051)
8. **→ `svc/sentinel` (this PR)**