### PR TITLE
fix: retry hubble ui

### DIFF
--- a/dev/Tiltfile
+++ b/dev/Tiltfile
@@ -78,7 +78,7 @@ local_resource(
 
 local_resource(
   'hubble-ui',
-  serve_cmd='kubectl port-forward -n kube-system svc/hubble-ui 12000:80',
+  serve_cmd='while true; do kubectl wait --for=condition=ready pod -l k8s-app=hubble-ui -n kube-system --timeout=120s && kubectl port-forward -n kube-system svc/hubble-ui 12000:80; echo "port-forward exited, retrying in 5s..."; sleep 5; done',
   resource_deps=['hubble'],
   labels=['observability'],
   links=['http://localhost:12000'],


### PR DESCRIPTION
## What does this PR do?

Adds retries to the hubble ui which sometimes gets stuck on first `make dev` load

_If there is not an issue for this, please create one first. This is used to tracking purposes and also helps us understand why this PR exists_

<!-- If there isn't an issue for this PR, please re-review our Contributing Guide and create an issue -->

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

Run `make dev` a few times hubble ui shouldnt err out

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary
