### PR TITLE
fix: wait for cillium policy until CRDs are ready

### DIFF
--- a/dev/Tiltfile
+++ b/dev/Tiltfile
@@ -65,7 +65,7 @@ EOF
 
 local_resource(
   'cilium-policies',
-  'until kubectl apply -f k8s/manifests/cilium-policies.yaml 2>/dev/null; do echo "Waiting for Cilium CRDs..."; sleep 2; done',
+  'kubectl apply -f k8s/manifests/cilium-policies.yaml',
   labels=['setup'],
 )
 

--- a/dev/cluster.yaml
+++ b/dev/cluster.yaml
@@ -11,5 +11,6 @@ minikube:
     - "--docker-opt=containerd=/var/run/containerd/containerd.sock"
     - "--cni=cilium"
     - "--addons=gvisor,metrics-server"
+    - "--wait=all"
 registry: ctlptl-registry
 kubernetesVersion: v1.34.0


### PR DESCRIPTION
## What does this PR do?

ctlptl apply starts minikube with --wait=all, which blocks until all system pods are ready