### PR TITLE
fix: update copy to remove mention of analytics deletion

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/keys/[keyAuthId]/_components/components/table/components/actions/components/delete-key.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/keys/[keyAuthId]/_components/components/table/components/actions/components/delete-key.tsx
@@ -118,8 +118,7 @@ export const DeleteKey = ({ keyDetails, isOpen, onClose }: DeleteKeyProps) => {
               </div>
               <div className="text-error-12 text-[13px] leading-6">
                 <span className="font-medium">Warning:</span> deleting this key will remove all
-                associated data and metadata. This action cannot be undone. Any verification,
-                tracking, and historical usage tied to this key will be permanently lost.
+                associated data and metadata. This action cannot be undone.
               </div>
             </div>
             <Controller
@@ -133,7 +132,7 @@ export const DeleteKey = ({ keyDetails, isOpen, onClose }: DeleteKeyProps) => {
                   size="lg"
                   checked={field.value}
                   onCheckedChange={field.onChange}
-                  label="I understand this will permanently delete the key and all its associated data"
+                  label="I understand this will permanently delete the key and its associated metadata"
                   error={errors.confirmDeletion?.message}
                 />
               )}
@@ -147,7 +146,7 @@ export const DeleteKey = ({ keyDetails, isOpen, onClose }: DeleteKeyProps) => {
         onConfirm={performKeyDeletion}
         triggerRef={deleteButtonRef}
         title="Confirm key deletion"
-        description="This action is irreversible. All data associated with this key will be permanently deleted."
+        description="This action is irreversible. Metadata and ratelimits associated with this key will be permanently deleted."
         confirmButtonText="Delete key"
         cancelButtonText="Cancel"
         variant="danger"


### PR DESCRIPTION
## What does this PR do?

Updated the key deletion warning copy to accurately reflect what data is actually deleted. The previous warning incorrectly stated that analytics and historical usage would be permanently lost, but analytics data is NOT deleted when a key is removed.

Changes:
- Removed misleading claims about "verification, tracking, and historical usage" being lost
- Updated warning to specify "metadata and ratelimits" which are actually deleted
- Updated all three warning instances: main warning box, checkbox label, and confirm popover

Fixes #4515 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Navigate to a workspace → API → Keys → Select a key
- Click the delete action
- Verify the warning message now says "deleting this key will remove all associated metadata and ratelimits" instead of mentioning analytics/historical usage
- Verify the checkbox label says "metadata" instead of "all its associated data"
- Click the delete button and verify the confirm popover says "Metadata and ratelimits associated with this key will be permanently deleted"

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas (N/A - copy changes only)
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory 
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary
