### PR TITLE
fix: retry memberlist creation

### DIFF
--- a/pkg/cluster/bridge.go
+++ b/pkg/cluster/bridge.go
@@ -76,7 +76,7 @@ func (c *gossipCluster) promoteToBridge() {
 	seeds := c.config.WANSeeds
 	c.mu.Unlock()
 
-	backoff := 500 * time.Millisecond
+	backoff := initialBackoff
 	var wanList *memberlist.Memberlist
 
 	for {
@@ -105,7 +105,7 @@ func (c *gossipCluster) promoteToBridge() {
 	}
 
 	c.mu.Lock()
-	if c.isBridge || c.closing.Load() {
+	if c.closing.Load() {
 		c.mu.Unlock()
 		wanList.Leave(5 * time.Second)  //nolint:errcheck
 		wanList.Shutdown()              //nolint:errcheck

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -14,9 +14,14 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-// reconnectInterval is how often the background loop checks whether
-// the node is isolated and needs to re-join seeds.
-const reconnectInterval = 30 * time.Second
+const (
+	// initialBackoff is the starting delay for exponential backoff retries.
+	initialBackoff = 500 * time.Millisecond
+
+	// reconnectInterval is how often the background loop checks whether
+	// the node is isolated and needs to re-join seeds.
+	reconnectInterval = 30 * time.Second
+)
 
 // Cluster is the public interface for gossip-based cluster membership.
 type Cluster interface {
@@ -135,8 +140,7 @@ func New(cfg Config) (Cluster, error) {
 // stays connected to seeds. It handles initial join (with backoff for DNS
 // readiness) and periodic reconnection if the node becomes isolated.
 func (c *gossipCluster) maintainMembership(pool string, list func() *memberlist.Memberlist, seeds []string, onJoin func()) {
-	// Initial join with exponential backoff — DNS may not resolve immediately.
-	backoff := 500 * time.Millisecond
+	backoff := initialBackoff
 
 	for {
 		select {


### PR DESCRIPTION
## What does this PR do?

Refactors the `promoteToBridge` function to prevent blocking operations and handle socket binding failures gracefully. The function now performs memberlist creation outside of the mutex lock to avoid blocking other operations like `Broadcast`, `Members`, and `IsBridge`. Adds exponential backoff retry logic to handle cases where the previous WAN memberlist's socket hasn't been fully released by the OS after rapid demote→promote cycles.

The implementation is split into three phases:
1. Check state and capture configuration under lock
2. Create memberlist outside lock with retry mechanism
3. Re-check state and commit changes under lock

`could not set up network transport: failed to obtain an address: failed to start TCP listener on "0.0.0.0" port 7947: listen tcp 0.0.0.0:7947: bind: address already in use` 
We do this since in prod we are failing with this error atm when creating the wan.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Test rapid demote→promote cycles to verify socket binding retry logic works correctly
- Test concurrent bridge promotion attempts to ensure proper state management
- Test bridge promotion during cluster shutdown to verify graceful cleanup

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary