### PR TITLE
fix: docs generator paths

### DIFF
--- a/docs/product/docs.json
+++ b/docs/product/docs.json
@@ -6,7 +6,13 @@
     "primary": "#999999"
   },
   "contextual": {
-    "options": ["copy", "view", "chatgpt", "claude", "perplexity"]
+    "options": [
+      "copy",
+      "view",
+      "chatgpt",
+      "claude",
+      "perplexity"
+    ]
   },
   "favicon": "/unkey.png",
   "fonts": {
@@ -55,7 +61,11 @@
         "groups": [
           {
             "group": "Getting Started",
-            "pages": ["introduction", "quickstart/quickstart", "glossary"]
+            "pages": [
+              "introduction",
+              "quickstart/quickstart",
+              "glossary"
+            ]
           },
           {
             "group": "Framework Guides",
@@ -197,7 +207,10 @@
           {
             "group": "Audit Logs",
             "icon": "scroll",
-            "pages": ["audit-log/introduction", "audit-log/types"]
+            "pages": [
+              "audit-log/introduction",
+              "audit-log/types"
+            ]
           },
           {
             "group": "Security",
@@ -236,7 +249,10 @@
           {
             "group": "Migrations",
             "icon": "arrows-rotate",
-            "pages": ["migrations/introduction", "migrations/keys"]
+            "pages": [
+              "migrations/introduction",
+              "migrations/keys"
+            ]
           },
           {
             "group": "Errors",
@@ -410,11 +426,17 @@
               },
               {
                 "group": "Go",
-                "pages": ["libraries/go/overview", "libraries/go/api"]
+                "pages": [
+                  "libraries/go/overview",
+                  "libraries/go/api"
+                ]
               },
               {
                 "group": "Python",
-                "pages": ["libraries/py/overview", "libraries/py/api"]
+                "pages": [
+                  "libraries/py/overview",
+                  "libraries/py/api"
+                ]
               }
             ]
           },
@@ -423,7 +445,9 @@
             "pages": [
               {
                 "group": "Nuxt",
-                "pages": ["libraries/nuxt/overview"]
+                "pages": [
+                  "libraries/nuxt/overview"
+                ]
               }
             ]
           }

--- a/pkg/codes/generate.go
+++ b/pkg/codes/generate.go
@@ -221,7 +221,10 @@ func processCategory(f *os.File, systemName, domainName, categoryName, domain st
 		}
 
 		// Write the constant
-		f.WriteString(fmt.Sprintf("\t%s URN = \"%s\"\n", constName, codeStr))
+		_, err := fmt.Fprintf(f, "\t%s URN = \"%s\"\n", constName, codeStr)
+		if err != nil {
+			panic(err)
+		}
 
 		// Store error code info for MDX generation
 		errorCodes = append(errorCodes, ErrorCodeInfo{
@@ -238,7 +241,7 @@ func processCategory(f *os.File, systemName, domainName, categoryName, domain st
 // generateMissingMDXFiles creates MDX documentation files for error codes that don't have them
 func generateMissingMDXFiles(errorCodes []ErrorCodeInfo) error {
 	// Get the base docs directory path (relative to this file)
-	baseDocsPath := filepath.Join("..", "..", "..", "apps", "docs", "errors")
+	baseDocsPath := filepath.Join("..", "..", "..", "docs", "product", "errors")
 
 	created := 0
 	skipped := 0
@@ -304,7 +307,7 @@ description: "%s"
 
 // removeObsoleteMDXFiles deletes MDX files that don't have corresponding error codes
 func removeObsoleteMDXFiles(errorCodes []ErrorCodeInfo) error {
-	baseDocsPath := filepath.Join("..", "..", "..", "apps", "docs", "errors")
+	baseDocsPath := filepath.Join("..", "..", "..", "docs", "product", "errors")
 
 	// Build a set of valid file paths from error codes
 	validPaths := make(map[string]bool)
@@ -370,7 +373,7 @@ func removeObsoleteMDXFiles(errorCodes []ErrorCodeInfo) error {
 
 // updateDocsJSON updates the docs.json navigation to include all error pages
 func updateDocsJSON(errorCodes []ErrorCodeInfo) error {
-	docsJSONPath := filepath.Join("..", "..", "web", "apps", "docs", "docs.json")
+	docsJSONPath := filepath.Join("..", "..", "docs", "product", "docs.json")
 
 	// Read existing docs.json
 	data, err := os.ReadFile(docsJSONPath)


### PR DESCRIPTION
## What does this PR do?

Migrates documentation structure from `apps/docs` to `docs/product` directory. Updates file paths in the error code generation system to point to the new documentation location and reformats JSON arrays in the docs configuration for better readability.

Fixes # (issue)

_If there is not an issue for this, please create one first. This is used to tracking purposes and also helps us understand why this PR exists_

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Verify that error code generation still works correctly with the new paths
- Confirm that documentation files are created in the correct `docs/product/errors` directory
- Test that the docs.json file is properly updated at the new location
- Ensure all documentation links and references still function properly

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary