### PR TITLE
fix: broken deployment page

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/layout-provider.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/layout-provider.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { LoadingState } from "@/components/loading-state";
 import type { Deployment } from "@/lib/collections/deploy/deployments";
 import { useParams } from "next/navigation";
 import { createContext, useContext } from "react";
@@ -19,10 +20,13 @@ export const DeploymentLayoutProvider = ({ children }: { children: React.ReactNo
     throw new Error("DeploymentLayoutProvider must be used within a deployment route");
   }
 
-  const { getDeploymentById } = useProjectData();
+  const { getDeploymentById, isDeploymentsLoading } = useProjectData();
   const deployment = getDeploymentById(deploymentId);
 
   if (!deployment) {
+    if (isDeploymentsLoading) {
+      return <LoadingState message="Loading deployment..." />;
+    }
     throw new Error(`Deployment not found: ${deploymentId}`);
   }
 

--- a/web/apps/dashboard/app/(app)/layout.tsx
+++ b/web/apps/dashboard/app/(app)/layout.tsx
@@ -4,8 +4,9 @@ import { AppSidebar } from "@/components/navigation/sidebar/app-sidebar";
 import { SidebarMobile } from "@/components/navigation/sidebar/sidebar-mobile";
 import { SidebarProvider } from "@/components/ui/sidebar";
 
+import { LoadingState } from "@/components/loading-state";
 import { useWorkspace } from "@/providers/workspace-provider";
-import { Empty, Loading } from "@unkey/ui";
+import { Empty } from "@unkey/ui";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
@@ -13,19 +14,6 @@ import { QueryTimeProvider } from "../../providers/query-time-provider";
 
 interface LayoutProps {
   children: React.ReactNode;
-}
-
-function LoadingState({ message = "Loading..." }: { message?: string }) {
-  return (
-    <div className="h-[100dvh] relative flex flex-col overflow-hidden bg-white dark:bg-base-12 lg:flex-row">
-      <div className="flex items-center justify-center w-full h-full">
-        <div className="flex flex-col items-center gap-4">
-          <Loading size={24} />
-          <p className="text-sm text-gray-600 dark:text-gray-400">{message}</p>
-        </div>
-      </div>
-    </div>
-  );
 }
 
 export default function Layout({ children }: LayoutProps) {

--- a/web/apps/dashboard/components/loading-state.tsx
+++ b/web/apps/dashboard/components/loading-state.tsx
@@ -1,0 +1,14 @@
+import { Loading } from "@unkey/ui";
+
+export function LoadingState({ message = "Loading..." }: { message?: string }) {
+  return (
+    <div className="h-[100dvh] relative flex flex-col overflow-hidden bg-white dark:bg-base-12 lg:flex-row">
+      <div className="flex items-center justify-center w-full h-full">
+        <div className="flex flex-col items-center gap-4">
+          <Loading size={24} />
+          <p className="text-sm text-gray-600 dark:text-gray-400">{message}</p>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What does this PR do?

When navigating from the deployment list to a deployment ID page, it doesn't fail because the data is already in memory. However, refreshing on the deployment ID page would fail due to the `throw Error()` we had there. This PR fixes that issue.

## How should this be tested?

- Make deployment
- Open your deployment list page
- Select deployment, it should work fine
- Refresh on that deployment and it shouldn't fail anymore.
- Try the same steps in prod and it will fail 
 


