### PR TITLE
fix: removed animation for slide in

### DIFF
--- a/web/internal/ui/src/components/dialog/dialog.tsx
+++ b/web/internal/ui/src/components/dialog/dialog.tsx
@@ -70,7 +70,7 @@ const DialogContent = React.forwardRef<
         <DialogPrimitive.Content
           ref={ref}
           className={cn(
-            "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+            "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg",
             className,
           )}
           onKeyDown={(e) => {


### PR DESCRIPTION
## What does this PR do?

  Remove the four slide-in/slide-out translation classes. The fade + zoom animation (fade-in-0, zoom-in-95, etc.) is sufficient and animates correctly from the already-centered position.

  No other dialog-type components are affected — dropdowns, popovers, tooltips, and sheets all use data-[side=...] directional variants or small fixed-pixel offsets on non-centered elements,  neither of which have this conflict.

Fixes # (issue)
ENG-2538

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

  1. Open any dialog in the dashboard (e.g. create API key, delete key, any confirmation modal).
  2. Before fix: the dialog slides in from the left edge of the screen on open, and exits to the left on close.
  3. After fix: the dialog fades in and scales up from the center of the viewport, and fades out + scales down on close. No lateral movement.
  4. Verify other overlay components are unaffected: open a dropdown menu, tooltip, popover, and sheet — their directional animations should still behave correctly.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [x] Ran `make fmt` on `/go` directory
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary
