### PR TITLE
fix: unify multiratelimit api contract

### DIFF
--- a/svc/api/openapi/gen.go
+++ b/svc/api/openapi/gen.go
@@ -2161,11 +2161,6 @@ type V2RatelimitMultiLimitCheck struct {
 	// - Understanding why limits differ from default values
 	OverrideId string `json:"overrideId,omitempty"`
 
-	// Passed Whether the request passed the rate limit check. If true, the request is allowed to proceed. If false, the request has exceeded the rate limit and should be blocked or rejected.
-	//
-	// You MUST check this field to determine if the request should proceed, as the endpoint always returns `HTTP 200` even when rate limited.
-	Passed bool `json:"passed"`
-
 	// Remaining The number of operations remaining in the current window before the rate limit is exceeded. Applications should use this value to:
 	//
 	// - Implement client-side throttling before hitting limits
@@ -2186,6 +2181,11 @@ type V2RatelimitMultiLimitCheck struct {
 	//
 	// The reset time is based on a sliding window from the first request in the current window.
 	Reset int64 `json:"reset"`
+
+	// Success Whether the request passed the rate limit check. If true, the request is allowed to proceed. If false, the request has exceeded the rate limit and should be blocked or rejected.
+	//
+	// You MUST check this field to determine if the request should proceed, as the endpoint always returns `HTTP 200` even when rate limited.
+	Success bool `json:"success"`
 }
 
 // V2RatelimitMultiLimitRequestBody Array of rate limit checks to perform
@@ -2205,10 +2205,10 @@ type V2RatelimitMultiLimitResponseData struct {
 	// Limits Array of individual rate limit check results, one for each rate limit check in the request
 	Limits []V2RatelimitMultiLimitCheck `json:"limits"`
 
-	// Passed Overall success indicator for all rate limit checks. This is true if ALL individual rate limit checks passed (all have success: true), and false if ANY check failed.
+	// Success Overall success indicator for all rate limit checks. This is true if ALL individual rate limit checks passed (all have success: true), and false if ANY check failed.
 	//
 	// Use this as a quick indicator to determine if the request should proceed.
-	Passed bool `json:"passed"`
+	Success bool `json:"success"`
 }
 
 // V2RatelimitSetOverrideRequestBody Sets a new or overwrites an existing rate limit override. Overrides allow you to apply special rate limit rules to specific identifiers, providing custom limits that differ from the default.

--- a/svc/api/openapi/openapi-generated.yaml
+++ b/svc/api/openapi/openapi-generated.yaml
@@ -3526,10 +3526,10 @@ components:
             type: object
             description: Container for multi-limit rate limit check results
             required:
-                - passed
+                - success
                 - limits
             properties:
-                passed:
+                success:
                     type: boolean
                     description: |-
                         Overall success indicator for all rate limit checks. This is true if ALL individual rate limit checks passed (all have success: true), and false if ANY check failed.
@@ -3541,72 +3541,21 @@ components:
                     items:
                         "$ref": "#/components/schemas/V2RatelimitMultiLimitCheck"
         V2RatelimitMultiLimitCheck:
-            type: object
-            properties:
-                namespace:
-                    description: |-
-                        The namespace this rate limit result corresponds to. Use this field to correlate the response with the request when checking multiple rate limits.
-                    type: string
-                identifier:
-                    description: |-
-                        The identifier this rate limit result corresponds to. Use this field to correlate the response with the request when checking multiple rate limits.
-                    type: string
-                limit:
-                    description: |-
-                        The maximum number of operations allowed within the time window. This reflects either the default limit specified in the request or an override limit if one exists for this identifier.
-
-                        This value helps clients understand their total quota for the current window.
-                    format: int64
-                    type: integer
-                remaining:
-                    description: |-
-                        The number of operations remaining in the current window before the rate limit is exceeded. Applications should use this value to:
-
-                        - Implement client-side throttling before hitting limits
-                        - Display usage information to end users
-                        - Trigger alerts when approaching limits
-                        - Adjust request patterns based on available capacity
-
-                        When this reaches zero, requests will be rejected until the window resets.
-                    format: int64
-                    type: integer
-                reset:
-                    description: |-
-                        The Unix timestamp in milliseconds when the rate limit window will reset and 'remaining' will return to 'limit'.
-
-                        This timestamp enables clients to:
-                        - Calculate and display wait times to users
-                        - Implement intelligent retry mechanisms
-                        - Schedule requests to resume after the reset
-                        - Implement exponential backoff when needed
-
-                        The reset time is based on a sliding window from the first request in the current window.
-                    format: int64
-                    type: integer
-                passed:
-                    description: |-
-                        Whether the request passed the rate limit check. If true, the request is allowed to proceed. If false, the request has exceeded the rate limit and should be blocked or rejected.
-
-                        You MUST check this field to determine if the request should proceed, as the endpoint always returns `HTTP 200` even when rate limited.
-                    type: boolean
-                overrideId:
-                    description: |-
-                        If a rate limit override was applied for this identifier, this field contains the ID of the override that was used. Empty when no override is in effect.
-
-                        This can be useful for:
-                        - Debugging which override rule was matched
-                        - Tracking the effects of specific overrides
-                        - Understanding why limits differ from default values
-                    type: string
-                    x-go-type-skip-optional-pointer: true
-                    x-go-type-skip-optional-pointer-with-omitzero: true
-            required:
-                - namespace
-                - identifier
-                - limit
-                - remaining
-                - reset
-                - passed
+            allOf:
+                - $ref: "#/components/schemas/V2RatelimitLimitResponseData"
+                - type: object
+                  properties:
+                    namespace:
+                        description: |-
+                            The namespace this rate limit result corresponds to. Use this field to correlate the response with the request when checking multiple rate limits.
+                        type: string
+                    identifier:
+                        description: |-
+                            The identifier this rate limit result corresponds to. Use this field to correlate the response with the request when checking multiple rate limits.
+                        type: string
+                  required:
+                    - namespace
+                    - identifier
         V2RatelimitSetOverrideResponseData:
             type: object
             properties:
@@ -6909,9 +6858,9 @@ paths:
             description: |
                 Check and enforce multiple rate limits in a single request for any identifiers (user IDs, IP addresses, API clients, etc.).
 
-                Use this to efficiently check multiple rate limits at once. Each rate limit check is independent and returns its own result with a top-level `passed` indicator showing if all checks succeeded.
+                Use this to efficiently check multiple rate limits at once. Each rate limit check is independent and returns its own result with a top-level `success` indicator showing if all checks succeeded.
 
-                **Response Codes**: Rate limit checks return HTTP 200 regardless of whether limits are exceeded — check the `passed` field to see if all limits passed, or the `success` field in each individual result. A 429 may be returned if the workspace exceeds its API rate limit. Other 4xx responses indicate auth, namespace existence/deletion, or validation errors (e.g., 410 Gone for deleted namespaces). 5xx responses indicate server errors.
+                **Response Codes**: Rate limit checks return HTTP 200 regardless of whether limits are exceeded — check the `success` field to see if all limits passed, or the `success` field in each individual result. A 429 may be returned if the workspace exceeds its API rate limit. Other 4xx responses indicate auth, namespace existence/deletion, or validation errors (e.g., 410 Gone for deleted namespaces). 5xx responses indicate server errors.
 
                 **Required Permissions**
 
@@ -6983,7 +6932,7 @@ paths:
                                                   remaining: 4
                                                   reset: 1714582980000
                                                   success: true
-                                            passed: true
+                                            success: true
                                         meta:
                                             requestId: req_01H9TQPP77V5E48E9SH0BG0ZQX
                                 mixedResults:
@@ -7003,7 +6952,7 @@ paths:
                                                   remaining: 0
                                                   reset: 1714583040000
                                                   success: false
-                                            passed: false
+                                            success: false
                                         meta:
                                             requestId: req_01H9TQPP77V5E48E9SH0BG0ZQY
                                 withOverride:
@@ -7024,13 +6973,13 @@ paths:
                                                   remaining: 995
                                                   reset: 1714582980000
                                                   success: true
-                                            passed: true
+                                            success: true
                                         meta:
                                             requestId: req_01H9TQPP77V5E48E9SH0BG0ZQZ
                             schema:
                                 $ref: '#/components/schemas/V2RatelimitMultiLimitResponseBody'
                     description: |
-                        All rate limit checks completed successfully. Check the `success` field in each result to determine if the corresponding request is allowed.
+                        All rate limit checks completed. Check the `success` field in each result to determine if the corresponding request is allowed.
                 "400":
                     content:
                         application/json:

--- a/svc/api/openapi/spec/paths/v2/ratelimit/multiLimit/V2RatelimitMultiLimitCheck.yaml
+++ b/svc/api/openapi/spec/paths/v2/ratelimit/multiLimit/V2RatelimitMultiLimitCheck.yaml
@@ -1,66 +1,15 @@
-type: object
-properties:
-  namespace:
-    description: |-
-      The namespace this rate limit result corresponds to. Use this field to correlate the response with the request when checking multiple rate limits.
-    type: string
-  identifier:
-    description: |-
-      The identifier this rate limit result corresponds to. Use this field to correlate the response with the request when checking multiple rate limits.
-    type: string
-  limit:
-    description: |-
-      The maximum number of operations allowed within the time window. This reflects either the default limit specified in the request or an override limit if one exists for this identifier.
-
-      This value helps clients understand their total quota for the current window.
-    format: int64
-    type: integer
-  remaining:
-    description: |-
-      The number of operations remaining in the current window before the rate limit is exceeded. Applications should use this value to:
-
-      - Implement client-side throttling before hitting limits
-      - Display usage information to end users
-      - Trigger alerts when approaching limits
-      - Adjust request patterns based on available capacity
-
-      When this reaches zero, requests will be rejected until the window resets.
-    format: int64
-    type: integer
-  reset:
-    description: |-
-      The Unix timestamp in milliseconds when the rate limit window will reset and 'remaining' will return to 'limit'.
-
-      This timestamp enables clients to:
-      - Calculate and display wait times to users
-      - Implement intelligent retry mechanisms
-      - Schedule requests to resume after the reset
-      - Implement exponential backoff when needed
-
-      The reset time is based on a sliding window from the first request in the current window.
-    format: int64
-    type: integer
-  passed:
-    description: |-
-      Whether the request passed the rate limit check. If true, the request is allowed to proceed. If false, the request has exceeded the rate limit and should be blocked or rejected.
-
-      You MUST check this field to determine if the request should proceed, as the endpoint always returns `HTTP 200` even when rate limited.
-    type: boolean
-  overrideId:
-    description: |-
-      If a rate limit override was applied for this identifier, this field contains the ID of the override that was used. Empty when no override is in effect.
-
-      This can be useful for:
-      - Debugging which override rule was matched
-      - Tracking the effects of specific overrides
-      - Understanding why limits differ from default values
-    type: string
-    x-go-type-skip-optional-pointer: true
-    x-go-type-skip-optional-pointer-with-omitzero: true
-required:
-  - namespace
-  - identifier
-  - limit
-  - remaining
-  - reset
-  - passed
+allOf:
+  - $ref: "../limit/V2RatelimitLimitResponseData.yaml"
+  - type: object
+    properties:
+      namespace:
+        description: |-
+          The namespace this rate limit result corresponds to. Use this field to correlate the response with the request when checking multiple rate limits.
+        type: string
+      identifier:
+        description: |-
+          The identifier this rate limit result corresponds to. Use this field to correlate the response with the request when checking multiple rate limits.
+        type: string
+    required:
+      - namespace
+      - identifier

--- a/svc/api/openapi/spec/paths/v2/ratelimit/multiLimit/V2RatelimitMultiLimitResponseData.yaml
+++ b/svc/api/openapi/spec/paths/v2/ratelimit/multiLimit/V2RatelimitMultiLimitResponseData.yaml
@@ -1,10 +1,10 @@
 type: object
 description: Container for multi-limit rate limit check results
 required:
-  - passed
+  - success
   - limits
 properties:
-  passed:
+  success:
     type: boolean
     description: |-
       Overall success indicator for all rate limit checks. This is true if ALL individual rate limit checks passed (all have success: true), and false if ANY check failed.

--- a/svc/api/openapi/spec/paths/v2/ratelimit/multiLimit/index.yaml
+++ b/svc/api/openapi/spec/paths/v2/ratelimit/multiLimit/index.yaml
@@ -5,9 +5,9 @@ post:
   description: |
     Check and enforce multiple rate limits in a single request for any identifiers (user IDs, IP addresses, API clients, etc.).
 
-    Use this to efficiently check multiple rate limits at once. Each rate limit check is independent and returns its own result with a top-level `passed` indicator showing if all checks succeeded.
+    Use this to efficiently check multiple rate limits at once. Each rate limit check is independent and returns its own result with a top-level `success` indicator showing if all checks succeeded.
 
-    **Response Codes**: Rate limit checks return HTTP 200 regardless of whether limits are exceeded — check the `passed` field to see if all limits passed, or the `success` field in each individual result. A 429 may be returned if the workspace exceeds its API rate limit. Other 4xx responses indicate auth, namespace existence/deletion, or validation errors (e.g., 410 Gone for deleted namespaces). 5xx responses indicate server errors.
+    **Response Codes**: Rate limit checks return HTTP 200 regardless of whether limits are exceeded — check the `success` field to see if all limits passed, or the `success` field in each individual result. A 429 may be returned if the workspace exceeds its API rate limit. Other 4xx responses indicate auth, namespace existence/deletion, or validation errors (e.g., 410 Gone for deleted namespaces). 5xx responses indicate server errors.
 
     **Required Permissions**
 
@@ -73,7 +73,7 @@ post:
                 meta:
                   requestId: req_01H9TQPP77V5E48E9SH0BG0ZQX
                 data:
-                  passed: true
+                  success: true
                   limits:
                     - namespace: api.requests
                       identifier: user_abc123
@@ -93,7 +93,7 @@ post:
                 meta:
                   requestId: req_01H9TQPP77V5E48E9SH0BG0ZQY
                 data:
-                  passed: false
+                  success: false
                   limits:
                     - namespace: auth.login
                       identifier: sha256_8f434346648f6b96df89dda901c5176b10a6d83961dd3c1ac88b59b2dc327aa4
@@ -113,7 +113,7 @@ post:
                 meta:
                   requestId: req_01H9TQPP77V5E48E9SH0BG0ZQZ
                 data:
-                  passed: true
+                  success: true
                   limits:
                     - namespace: api.light_operations
                       identifier: user_xyz789
@@ -129,7 +129,7 @@ post:
                       success: true
                       overrideId: ovr_2cGKbMxRyIzhCxo1Idjz8q
       description: |
-        All rate limit checks completed successfully. Check the `success` field in each result to determine if the corresponding request is allowed.
+        All rate limit checks completed. Check the `success` field in each result to determine if the corresponding request is allowed.
     "400":
       description: Bad request
       content:

--- a/svc/api/routes/v2_ratelimit_multi_limit/200_test.go
+++ b/svc/api/routes/v2_ratelimit_multi_limit/200_test.go
@@ -70,21 +70,21 @@ func TestLimitSuccessfully(t *testing.T) {
 		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, req)
 		require.Equal(t, 200, res.Status, "expected 200, received: %v", res.Body)
 		require.NotNil(t, res.Body)
-		require.True(t, res.Body.Data.Passed, "Overall passed should be true when all limits pass")
+		require.True(t, res.Body.Data.Success, "Overall passed should be true when all limits pass")
 		require.Len(t, res.Body.Data.Limits, 3, "Should return 3 results")
 
 		// Verify all responses
-		require.True(t, res.Body.Data.Limits[0].Passed, "Rate limit should not be exceeded on first request")
+		require.True(t, res.Body.Data.Limits[0].Success, "Rate limit should not be exceeded on first request")
 		require.Equal(t, namespaceName1, res.Body.Data.Limits[0].Namespace)
 		require.Equal(t, int64(100), res.Body.Data.Limits[0].Limit)
 		require.Equal(t, int64(99), res.Body.Data.Limits[0].Remaining)
 
-		require.True(t, res.Body.Data.Limits[1].Passed)
+		require.True(t, res.Body.Data.Limits[1].Success)
 		require.Equal(t, namespaceName2, res.Body.Data.Limits[1].Namespace)
 		require.Equal(t, int64(200), res.Body.Data.Limits[1].Limit)
 		require.Equal(t, int64(199), res.Body.Data.Limits[1].Remaining)
 
-		require.True(t, res.Body.Data.Limits[2].Passed)
+		require.True(t, res.Body.Data.Limits[2].Success)
 		require.Equal(t, namespaceName3, res.Body.Data.Limits[2].Namespace)
 		require.Equal(t, int64(300), res.Body.Data.Limits[2].Limit)
 		require.Equal(t, int64(299), res.Body.Data.Limits[2].Remaining)
@@ -144,17 +144,17 @@ func TestLimitSuccessfully(t *testing.T) {
 		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, req)
 		require.Equal(t, 200, res.Status, "expected 200, status: %d, body: %s", res.Status, res.RawBody)
 		require.NotNil(t, res.Body)
-		require.True(t, res.Body.Data.Passed, "Overall passed should be true when all limits pass")
+		require.True(t, res.Body.Data.Success, "Overall passed should be true when all limits pass")
 		require.Len(t, res.Body.Data.Limits, 2)
 
-		require.True(t, res.Body.Data.Limits[0].Passed, "Rate limit should not be exceeded on first request")
+		require.True(t, res.Body.Data.Limits[0].Success, "Rate limit should not be exceeded on first request")
 		require.Equal(t, ns1Name, res.Body.Data.Limits[0].Namespace)
 		require.Equal(t, int64(100), res.Body.Data.Limits[0].Limit)
 		require.Equal(t, int64(99), res.Body.Data.Limits[0].Remaining)
 		require.Greater(t, res.Body.Data.Limits[0].Reset, int64(0))
 		require.Empty(t, res.Body.Data.Limits[0].OverrideId, "No override should be applied")
 
-		require.True(t, res.Body.Data.Limits[1].Passed)
+		require.True(t, res.Body.Data.Limits[1].Success)
 		require.Equal(t, ns2Name, res.Body.Data.Limits[1].Namespace)
 		require.Equal(t, int64(200), res.Body.Data.Limits[1].Limit)
 		require.Equal(t, int64(199), res.Body.Data.Limits[1].Remaining)
@@ -216,7 +216,7 @@ func TestLimitSuccessfully(t *testing.T) {
 			}, 15*time.Second, 100*time.Millisecond)
 
 			require.Equal(t, identifier, row.Identifier)
-			require.Equal(t, res.Body.Data.Limits[i].Passed, row.Passed)
+			require.Equal(t, res.Body.Data.Limits[i].Success, row.Passed)
 			require.Equal(t, res.Body.Meta.RequestId, row.RequestID)
 		}
 	})
@@ -245,9 +245,9 @@ func TestLimitSuccessfully(t *testing.T) {
 		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, req)
 		require.Equal(t, 200, res.Status)
 		require.NotNil(t, res.Body)
-		require.True(t, res.Body.Data.Passed, "Overall passed should be true")
+		require.True(t, res.Body.Data.Success, "Overall passed should be true")
 		require.Len(t, res.Body.Data.Limits, 1)
-		require.True(t, res.Body.Data.Limits[0].Passed)
+		require.True(t, res.Body.Data.Limits[0].Success)
 		require.Equal(t, int64(100), res.Body.Data.Limits[0].Limit)
 		require.Equal(t, int64(95), res.Body.Data.Limits[0].Remaining) // 100 - 5
 	})
@@ -291,9 +291,9 @@ func TestLimitSuccessfully(t *testing.T) {
 		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, req)
 		require.Equal(t, 200, res.Status)
 		require.NotNil(t, res.Body)
-		require.True(t, res.Body.Data.Passed, "Overall passed should be true")
+		require.True(t, res.Body.Data.Success, "Overall passed should be true")
 		require.Len(t, res.Body.Data.Limits, 1)
-		require.True(t, res.Body.Data.Limits[0].Passed)
+		require.True(t, res.Body.Data.Limits[0].Success)
 		require.Equal(t, int64(limit), res.Body.Data.Limits[0].Limit) // Should use override limit
 		require.Equal(t, int64(199), res.Body.Data.Limits[0].Remaining)
 		require.NotNil(t, res.Body.Data.Limits[0].OverrideId)
@@ -342,11 +342,11 @@ func TestLimitSuccessfully(t *testing.T) {
 		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, req)
 		require.Equal(t, 200, res.Status)
 		require.NotNil(t, res.Body)
-		require.True(t, res.Body.Data.Passed, "Overall passed should be true")
+		require.True(t, res.Body.Data.Success, "Overall passed should be true")
 		require.Len(t, res.Body.Data.Limits, 1)
 		require.NotNil(t, res.Body.Data.Limits[0].OverrideId)
 		require.Equal(t, overrideID, res.Body.Data.Limits[0].OverrideId)
-		require.True(t, res.Body.Data.Limits[0].Passed)
+		require.True(t, res.Body.Data.Limits[0].Success)
 		require.Equal(t, int64(limit), res.Body.Data.Limits[0].Limit) // Should use override limit
 		require.Equal(t, int64(199), res.Body.Data.Limits[0].Remaining)
 		require.NotNil(t, res.Body.Data.Limits[0].OverrideId)
@@ -381,32 +381,32 @@ func TestLimitSuccessfully(t *testing.T) {
 		// First request - all should succeed
 		res1 := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, req)
 		require.Equal(t, 200, res1.Status)
-		require.True(t, res1.Body.Data.Passed, "Overall passed should be true when all limits pass")
+		require.True(t, res1.Body.Data.Success, "Overall passed should be true when all limits pass")
 		require.Len(t, res1.Body.Data.Limits, 3)
-		require.True(t, res1.Body.Data.Limits[0].Passed)
-		require.True(t, res1.Body.Data.Limits[1].Passed)
-		require.True(t, res1.Body.Data.Limits[2].Passed)
+		require.True(t, res1.Body.Data.Limits[0].Success)
+		require.True(t, res1.Body.Data.Limits[1].Success)
+		require.True(t, res1.Body.Data.Limits[2].Success)
 
 		// Second request - ns2 should fail, but ALL results should still be returned
 		res2 := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, req)
 		require.Equal(t, 200, res2.Status)
-		require.False(t, res2.Body.Data.Passed, "Overall passed should be false when any limit fails")
+		require.False(t, res2.Body.Data.Success, "Overall passed should be false when any limit fails")
 		require.Len(t, res2.Body.Data.Limits, 3, "Should return all 3 results even when one fails")
 
 		// Verify results match requests (no early exit)
 		require.Equal(t, ns1Name, res2.Body.Data.Limits[0].Namespace)
 		require.Equal(t, identifier, res2.Body.Data.Limits[0].Identifier)
-		require.True(t, res2.Body.Data.Limits[0].Passed, "ns1 should still succeed")
+		require.True(t, res2.Body.Data.Limits[0].Success, "ns1 should still succeed")
 
 		require.Equal(t, ns2Name, res2.Body.Data.Limits[1].Namespace)
 		require.Equal(t, identifier, res2.Body.Data.Limits[1].Identifier)
-		require.False(t, res2.Body.Data.Limits[1].Passed, "ns2 should fail (limit exceeded)")
+		require.False(t, res2.Body.Data.Limits[1].Success, "ns2 should fail (limit exceeded)")
 		require.Equal(t, int64(1), res2.Body.Data.Limits[1].Limit)
 		require.Equal(t, int64(0), res2.Body.Data.Limits[1].Remaining)
 
 		require.Equal(t, ns3Name, res2.Body.Data.Limits[2].Namespace)
 		require.Equal(t, identifier, res2.Body.Data.Limits[2].Identifier)
-		require.True(t, res2.Body.Data.Limits[2].Passed, "ns3 should still succeed")
+		require.True(t, res2.Body.Data.Limits[2].Success, "ns3 should still succeed")
 	})
 
 	t.Run("rate limiting with active override", func(t *testing.T) {
@@ -447,9 +447,9 @@ func TestLimitSuccessfully(t *testing.T) {
 		// First request - should succeed and use override values
 		res1 := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, req)
 		require.Equal(t, 200, res1.Status)
-		require.True(t, res1.Body.Data.Passed, "Overall passed should be true")
+		require.True(t, res1.Body.Data.Success, "Overall passed should be true")
 		require.Len(t, res1.Body.Data.Limits, 1)
-		require.True(t, res1.Body.Data.Limits[0].Passed)
+		require.True(t, res1.Body.Data.Limits[0].Success)
 		require.Equal(t, int64(overrideLimit), res1.Body.Data.Limits[0].Limit) // Should use override limit
 		require.Equal(t, int64(2), res1.Body.Data.Limits[0].Remaining)         // 3-1=2 remaining
 		require.NotNil(t, res1.Body.Data.Limits[0].OverrideId)
@@ -458,25 +458,25 @@ func TestLimitSuccessfully(t *testing.T) {
 		// Second request - should succeed
 		res2 := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, req)
 		require.Equal(t, 200, res2.Status)
-		require.True(t, res2.Body.Data.Passed, "Overall passed should be true")
+		require.True(t, res2.Body.Data.Success, "Overall passed should be true")
 		require.Len(t, res2.Body.Data.Limits, 1)
-		require.True(t, res2.Body.Data.Limits[0].Passed)
+		require.True(t, res2.Body.Data.Limits[0].Success)
 		require.Equal(t, int64(1), res2.Body.Data.Limits[0].Remaining) // 2-1=1 remaining
 
 		// Third request - should succeed but use up last remaining quota
 		res3 := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, req)
 		require.Equal(t, 200, res3.Status)
-		require.True(t, res3.Body.Data.Passed, "Overall passed should be true")
+		require.True(t, res3.Body.Data.Success, "Overall passed should be true")
 		require.Len(t, res3.Body.Data.Limits, 1)
-		require.True(t, res3.Body.Data.Limits[0].Passed)
+		require.True(t, res3.Body.Data.Limits[0].Success)
 		require.Equal(t, int64(0), res3.Body.Data.Limits[0].Remaining) // No more remaining
 
 		// Fourth request - should be rate limited
 		res4 := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, req)
 		require.Equal(t, 200, res4.Status)
-		require.False(t, res4.Body.Data.Passed, "Overall passed should be false when rate limited")
+		require.False(t, res4.Body.Data.Success, "Overall passed should be false when rate limited")
 		require.Len(t, res4.Body.Data.Limits, 1)
-		require.False(t, res4.Body.Data.Limits[0].Passed, "Request should be rate limited")
+		require.False(t, res4.Body.Data.Limits[0].Success, "Request should be rate limited")
 		require.Equal(t, int64(0), res4.Body.Data.Limits[0].Remaining)
 		require.NotNil(t, res4.Body.Data.Limits[0].OverrideId)
 		require.Equal(t, overrideID, res4.Body.Data.Limits[0].OverrideId)
@@ -528,23 +528,23 @@ func TestLimitSuccessfully(t *testing.T) {
 		// First request with custom costs
 		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, req)
 		require.Equal(t, 200, res.Status)
-		require.True(t, res.Body.Data.Passed, "Overall passed should be true when all limits pass")
+		require.True(t, res.Body.Data.Success, "Overall passed should be true when all limits pass")
 		require.Len(t, res.Body.Data.Limits, 3)
 
 		// Check ns1 - default cost of 1
-		require.True(t, res.Body.Data.Limits[0].Passed)
+		require.True(t, res.Body.Data.Limits[0].Success)
 		require.Equal(t, ns1Name, res.Body.Data.Limits[0].Namespace)
 		require.Equal(t, int64(100), res.Body.Data.Limits[0].Limit)
 		require.Equal(t, int64(99), res.Body.Data.Limits[0].Remaining) // 100 - 1
 
 		// Check ns2 - cost of 3
-		require.True(t, res.Body.Data.Limits[1].Passed)
+		require.True(t, res.Body.Data.Limits[1].Success)
 		require.Equal(t, ns2Name, res.Body.Data.Limits[1].Namespace)
 		require.Equal(t, int64(50), res.Body.Data.Limits[1].Limit)
 		require.Equal(t, int64(47), res.Body.Data.Limits[1].Remaining) // 50 - 3
 
 		// Check ns3 - cost of 10
-		require.True(t, res.Body.Data.Limits[2].Passed)
+		require.True(t, res.Body.Data.Limits[2].Success)
 		require.Equal(t, ns3Name, res.Body.Data.Limits[2].Namespace)
 		require.Equal(t, int64(200), res.Body.Data.Limits[2].Limit)
 		require.Equal(t, int64(190), res.Body.Data.Limits[2].Remaining) // 200 - 10
@@ -609,18 +609,18 @@ func TestLimitSuccessfully(t *testing.T) {
 		// First request - should use overrides
 		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, req)
 		require.Equal(t, 200, res.Status)
-		require.True(t, res.Body.Data.Passed, "Overall passed should be true when all limits pass")
+		require.True(t, res.Body.Data.Success, "Overall passed should be true when all limits pass")
 		require.Len(t, res.Body.Data.Limits, 2)
 
 		// Check ns1 - override limit of 5
-		require.True(t, res.Body.Data.Limits[0].Passed)
+		require.True(t, res.Body.Data.Limits[0].Success)
 		require.Equal(t, ns1Name, res.Body.Data.Limits[0].Namespace)
 		require.Equal(t, int64(5), res.Body.Data.Limits[0].Limit) // Override limit
 		require.Equal(t, int64(4), res.Body.Data.Limits[0].Remaining)
 		require.Equal(t, override1ID, res.Body.Data.Limits[0].OverrideId)
 
 		// Check ns2 - override limit of 3
-		require.True(t, res.Body.Data.Limits[1].Passed)
+		require.True(t, res.Body.Data.Limits[1].Success)
 		require.Equal(t, ns2Name, res.Body.Data.Limits[1].Namespace)
 		require.Equal(t, int64(3), res.Body.Data.Limits[1].Limit) // Override limit
 		require.Equal(t, int64(2), res.Body.Data.Limits[1].Remaining)

--- a/svc/api/routes/v2_ratelimit_multi_limit/handler.go
+++ b/svc/api/routes/v2_ratelimit_multi_limit/handler.go
@@ -225,7 +225,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		limits[i] = openapi.V2RatelimitMultiLimitCheck{
 			Namespace:  meta.namespaceName,
 			Identifier: meta.identifier,
-			Passed:     result.Success,
+			Success:    result.Success,
 			Limit:      meta.limit,
 			Remaining:  result.Remaining,
 			Reset:      result.Reset.UnixMilli(),
@@ -242,8 +242,8 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			RequestId: s.RequestID(),
 		},
 		Data: openapi.V2RatelimitMultiLimitResponseData{
-			Passed: allPassed,
-			Limits: limits,
+			Success: allPassed,
+			Limits:  limits,
 		},
 	})
 }


### PR DESCRIPTION
## What does this PR do?

Renames the `passed` field to `success` in the multi-limit rate limiting API for consistency across the codebase. This change affects both individual rate limit check results and the overall response indicator.

The changes include:
- Renaming `passed` to `success` in `V2RatelimitMultiLimitCheck` struct
- Renaming `passed` to `success` in `V2RatelimitMultiLimitResponseData` struct  
- Refactoring the schema definition to use `allOf` composition with the base rate limit response
- Updating OpenAPI documentation and examples to reflect the new field names
- Updating all test assertions to use the new `success` field
- Modifying the handler logic to populate the `success` field instead of `passed`

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How should this be tested?

- Run existing multi-limit rate limiting tests to ensure all functionality works with the new field names
- Verify that API responses now return `success` instead of `passed` fields
- Test that both individual limit checks and overall response indicators use the correct field names
- Validate that OpenAPI documentation reflects the updated schema

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary