### PR TITLE
fix: allow containers to access host in orbstack

### DIFF
--- a/pkg/dockertest/docker.go
+++ b/pkg/dockertest/docker.go
@@ -199,6 +199,12 @@ func startContainer(t *testing.T, cfg containerConfig) *Container {
 			PortBindings: portBindings,
 			AutoRemove:   false, // We handle removal in t.Cleanup
 			Tmpfs:        cfg.Tmpfs,
+			// Ensure host.docker.internal resolves inside containers.
+			// Docker Desktop adds this automatically, but alternative runtimes
+			// like OrbStack do not. Without it, containers that need to call
+			// back to host-bound test servers (e.g. Restate → worker handler)
+			// fail with DNS resolution errors.
+			ExtraHosts: []string{"host.docker.internal:host-gateway"},
 		},
 		nil, // NetworkingConfig
 		nil, // Platform


### PR DESCRIPTION
## What does this PR do?

Adds `host.docker.internal:host-gateway` to the ExtraHosts configuration for Docker containers in the test framework. This ensures that `host.docker.internal` resolves correctly inside containers across different Docker runtimes.

Docker Desktop automatically provides this hostname mapping, but alternative runtimes like OrbStack do not. Without this configuration, containers that need to communicate with host-bound test servers (such as Restate calling back to worker handlers) fail with DNS resolution errors.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Run tests that involve containers communicating with host services using alternative Docker runtimes like OrbStack
- Verify that `host.docker.internal` resolves correctly inside test containers
- Ensure existing tests continue to pass with Docker Desktop

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary