### PR TITLE
fix: use localstorage for product switcher on /[slug]

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/page.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/page.tsx
@@ -1,15 +1,21 @@
 "use client";
-import { useWorkspaceNavigation } from "@/hooks/use-workspace-navigation";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
+import {
+  PRODUCT_HOME_ROUTES,
+  useProductSelection,
+} from "@/hooks/use-product-selection";
+import { useWorkspaceNavigation } from "@/hooks/use-workspace-navigation";
 
 export default function WorkspacePage() {
   const router = useRouter();
   const workspace = useWorkspaceNavigation();
 
+  const { product } = useProductSelection();
+
   useEffect(() => {
-    router.replace(`/${workspace.slug}/apis`);
-  }, [router, workspace.slug]);
+    router.replace(`/${workspace.slug}/${PRODUCT_HOME_ROUTES[product]}`);
+  }, [router, workspace.slug, product]);
 
   return null;
 }

--- a/web/apps/dashboard/hooks/use-product-selection.ts
+++ b/web/apps/dashboard/hooks/use-product-selection.ts
@@ -10,7 +10,7 @@ export const STORAGE_KEY = "selected-product";
 export const DEFAULT_PRODUCT: Product = "api-management";
 export const STORAGE_EVENT = "product-selection-changed";
 
-const PRODUCT_HOME_ROUTES: Record<Product, string> = {
+export const PRODUCT_HOME_ROUTES: Record<Product, string> = {
   "api-management": "apis",
   deploy: "projects",
 };


### PR DESCRIPTION
## What does this PR do?

Replace hardcoded `/apis` redirect with dynamic product-based routing in workspace navigation. The workspace page now redirects users to the appropriate home route based on their selected product (either "apis" for API management or "projects" for deploy).

Fixes #5192

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Navigate to a workspace page and verify it redirects to `/apis` when API management product is selected
- Switch to deploy product and verify workspace page redirects to `/projects`
- Test that the redirect works correctly for different workspace slugs

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary