### PR TITLE
fix: use v3 verification aggregation tables in keys overview

### DIFF
--- a/web/internal/clickhouse/src/keys/keys.ts
+++ b/web/internal/clickhouse/src/keys/keys.ts
@@ -302,7 +302,7 @@ export function getKeysOverviewLogs(ch: Querier) {
               toInt64(toUnixTimestamp(time) * 1000) as time,
               '' as request_id,
               tags
-          FROM default.key_verifications_per_hour_v2
+          FROM default.key_verifications_per_hour_v3
           WHERE workspace_id = {workspaceId: String}
               AND key_space_id = {keyspaceId: String}
               AND time BETWEEN toDateTime(fromUnixTimestamp64Milli({startTime: UInt64}))
@@ -342,7 +342,7 @@ WITH
           h.key_id,
           h.outcome,
           toUInt64(sum(h.count)) as count
-      FROM default.key_verifications_per_hour_v2 h
+      FROM default.key_verifications_per_hour_v3 h
       INNER JOIN top_keys t ON h.key_id = t.key_id
       WHERE h.workspace_id = {workspaceId: String}
           AND h.key_space_id = {keyspaceId: String}


### PR DESCRIPTION
## Summary

- Switches `key_verifications_per_hour_v2` to `key_verifications_per_hour_v3` in the keys overview ClickHouse queries
- The v2 table has a 30-day TTL while v3 has a 90-day TTL, meaning keys overview was missing data beyond 30 days
- v3 has the same schema (key_id, workspace_id, key_space_id, time, tags, outcome, count) but with improved partitioning and is the current standard used everywhere else

## Test plan

- [ ] Verify keys overview page loads correctly and shows verification data
- [ ] Confirm data is available for time ranges beyond 30 days