### PR TITLE
fix: remove v2 aggregation tables from default allowed tables

### DIFF
--- a/pkg/clickhouse/user.go
+++ b/pkg/clickhouse/user.go
@@ -213,13 +213,9 @@ func DefaultAllowedTables() []string {
 	return []string{
 		// Key verifications
 		"default.key_verifications_raw_v2",
-		"default.key_verifications_per_minute_v2",
 		"default.key_verifications_per_minute_v3",
-		"default.key_verifications_per_hour_v2",
 		"default.key_verifications_per_hour_v3",
-		"default.key_verifications_per_day_v2",
 		"default.key_verifications_per_day_v3",
-		"default.key_verifications_per_month_v2",
 		"default.key_verifications_per_month_v3",
 	}
 }


### PR DESCRIPTION
## Summary
- Removed v2 aggregation tables (`key_verifications_per_minute_v2`, `key_verifications_per_hour_v2`, `key_verifications_per_day_v2`, `key_verifications_per_month_v2`) from `DefaultAllowedTables()` in `pkg/clickhouse/user.go`
- The analytics handler already only allows v3 tables, so the default allowed tables list should match and not include the obsolete v2 aggregation entries
- The raw table (`key_verifications_raw_v2`) is retained as it is still in use

## Test plan
- [ ] Verify analytics queries continue to work with v3 tables
- [ ] Confirm no remaining references depend on the removed v2 aggregation tables