### PR TITLE
fix: use v3 verification aggregation tables in keys overview

### DIFF
--- a/web/internal/clickhouse/src/keys/keys.ts
+++ b/web/internal/clickhouse/src/keys/keys.ts
@@ -302,7 +302,7 @@ export function getKeysOverviewLogs(ch: Querier) {
               toInt64(toUnixTimestamp(time) * 1000) as time,
               '' as request_id,
               tags
-          FROM default.key_verifications_per_hour_v2
+          FROM default.key_verifications_per_hour_v3
           WHERE workspace_id = {workspaceId: String}
               AND key_space_id = {keyspaceId: String}
               AND time BETWEEN toDateTime(fromUnixTimestamp64Milli({startTime: UInt64}))
@@ -342,7 +342,7 @@ WITH
           h.key_id,
           h.outcome,
           toUInt64(sum(h.count)) as count
-      FROM default.key_verifications_per_hour_v2 h
+      FROM default.key_verifications_per_hour_v3 h
       INNER JOIN top_keys t ON h.key_id = t.key_id
       WHERE h.workspace_id = {workspaceId: String}
           AND h.key_space_id = {keyspaceId: String}


### PR DESCRIPTION
## What does this PR do?

Updates ClickHouse queries to use the `key_verifications_per_hour_v3` table instead of `key_verifications_per_hour_v2` in the keys overview functionality. This change affects two queries that retrieve key verification logs and aggregate verification counts by outcome.

Fixes # (issue)

_If there is not an issue for this, please create one first. This is used to tracking purposes and also helps us understand why this PR exists_

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Verify that key verification logs are still displayed correctly in the keys overview
- Confirm that key verification counts and outcomes are properly aggregated
- Test that the queries execute successfully against the v3 table schema

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary