### PR TITLE
feat: switch customer workloads from ReplicaSets to Deployments

### DIFF
--- a/svc/krane/internal/deployment/DEPLOYMENTS_OVER_REPLICASETS.md
+++ b/svc/krane/internal/deployment/DEPLOYMENTS_OVER_REPLICASETS.md
@@ -1,0 +1,35 @@
+# Why Deployments over ReplicaSets for customer workloads
+
+## The problem with ReplicaSets
+
+ReplicaSets don't roll pods when the pod template changes. They only ensure the desired replica count is met — if the template changes on an existing RS, running pods keep the old spec indefinitely.
+
+This meant that infra-level changes — env var overrides, resource defaults, security settings, runtime class updates — would **not take effect** on existing customer workloads until the customer triggered a new deploy. Each user redeploy created a new deployment ID (and therefore a new RS), so the issue was masked during normal deploys. But any change we made to the pod template from our side was silently ignored for all running workloads.
+
+## Why Deployments fix this
+
+A Kubernetes Deployment owns ReplicaSets and performs rolling updates automatically when the pod template changes. When we update the Deployment spec (e.g. change a resource limit, add an env var override, update the runtime class), the Deployment controller:
+
+1. Creates a new RS with the updated template
+2. Scales up the new RS while scaling down the old one
+3. Respects the rolling update strategy (`MaxUnavailable: 0, MaxSurge: 1`) for zero-downtime transitions
+
+This gives us the ability to push infra-level changes to all running workloads without requiring customers to redeploy.
+
+## Rolling update strategy
+
+We use `MaxUnavailable: 0, MaxSurge: 1`:
+
+- **MaxUnavailable: 0** — never take down a running pod before its replacement is ready. This ensures zero downtime during rolls.
+- **MaxSurge: 1** — allow at most 1 extra pod above the desired count during the roll. This keeps resource usage bounded while still making progress.
+
+## Migration path
+
+Existing ReplicaSets from the previous controller are cleaned up automatically:
+
+- The resync loop identifies orphan RS (those with krane labels but no ownerReferences, meaning they weren't created by a Deployment) and deletes them.
+- New Deployments are created with the same name and labels, so the transition is seamless from the control plane's perspective.
+
+## Sentinels already use this pattern
+
+The sentinel controller already uses Deployments. This change aligns customer workloads with the same pattern, reducing the number of K8s resource types we need to reason about.

--- a/svc/krane/internal/deployment/actual_state_report.go
+++ b/svc/krane/internal/deployment/actual_state_report.go
@@ -11,11 +11,11 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 )
 
-// runActualStateReportLoop starts a Kubernetes watch for deployment ReplicaSets
+// runActualStateReportLoop starts a Kubernetes watch for Deployments
 // and reports actual state changes back to the control plane in real-time.
 //
 // The watch filters for resources with the "managed-by: krane" and "component: deployment"
-// labels, ignoring resources created by other controllers. When a ReplicaSet is added
+// labels, ignoring resources created by other controllers. When a Deployment is added
 // or modified, the method calls [Controller.buildDeploymentStatus] to query pod state
 // and reports via [Controller.reportDeploymentStatus]. Deletions are reported directly
 // so the control plane can remove the deployment from its routing tables.
@@ -24,7 +24,7 @@ import (
 // errors are logged but the goroutine continues processing events. The watch runs
 // until the context is cancelled.
 func (c *Controller) runActualStateReportLoop(ctx context.Context) error {
-	w, err := c.clientSet.AppsV1().ReplicaSets("").Watch(ctx, metav1.ListOptions{
+	w, err := c.clientSet.AppsV1().Deployments("").Watch(ctx, metav1.ListOptions{
 		LabelSelector: labels.New().
 			ManagedByKrane().
 			ComponentDeployment().
@@ -41,12 +41,12 @@ func (c *Controller) runActualStateReportLoop(ctx context.Context) error {
 				logger.Error("error watching deployment", "event", event.Object)
 			case watch.Bookmark:
 			case watch.Added, watch.Modified:
-				replicaset, ok := event.Object.(*appsv1.ReplicaSet)
+				dep, ok := event.Object.(*appsv1.Deployment)
 				if !ok {
-					logger.Error("unable to cast object to replicaset")
+					logger.Error("unable to cast object to deployment")
 					continue
 				}
-				status, err := c.buildDeploymentStatus(ctx, replicaset)
+				status, err := c.buildDeploymentStatus(ctx, dep)
 				if err != nil {
 					logger.Error("unable to build status", "error", err.Error())
 					continue
@@ -57,15 +57,15 @@ func (c *Controller) runActualStateReportLoop(ctx context.Context) error {
 					continue
 				}
 			case watch.Deleted:
-				replicaset, ok := event.Object.(*appsv1.ReplicaSet)
+				dep, ok := event.Object.(*appsv1.Deployment)
 				if !ok {
-					logger.Error("unable to cast object to replicaset")
+					logger.Error("unable to cast object to deployment")
 					continue
 				}
 				err := c.reportDeploymentStatus(ctx, &ctrlv1.ReportDeploymentStatusRequest{
 					Change: &ctrlv1.ReportDeploymentStatusRequest_Delete_{
 						Delete: &ctrlv1.ReportDeploymentStatusRequest_Delete{
-							K8SName: replicaset.Name,
+							K8SName: dep.Name,
 						},
 					},
 				})

--- a/svc/krane/internal/deployment/apply.go
+++ b/svc/krane/internal/deployment/apply.go
@@ -20,12 +20,17 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-// ApplyDeployment creates or updates a user workload as a Kubernetes ReplicaSet.
+// ApplyDeployment creates or updates a user workload as a Kubernetes Deployment.
 //
-// The method uses server-side apply to create or update the ReplicaSet, enabling
+// The method uses server-side apply to create or update the Deployment, enabling
 // concurrent modifications from different sources without conflicts. After applying,
 // it queries the resulting pods and reports their addresses and status to the control
 // plane so the routing layer knows where to send traffic.
+//
+// Using Deployments instead of ReplicaSets gives us rolling updates: when the pod
+// template changes (env overrides, resource defaults, security settings), pods are
+// automatically rolled without requiring a user redeploy. The rolling update strategy
+// uses MaxUnavailable=0, MaxSurge=1 to ensure zero-downtime updates.
 //
 // ApplyDeployment validates all required fields and returns an error if any are missing
 // or invalid: WorkspaceId, ProjectId, EnvironmentId, DeploymentId, K8sNamespace, K8sName,
@@ -73,8 +78,8 @@ func (c *Controller) ApplyDeployment(ctx context.Context, req *ctrlv1.ApplyDeplo
 		return fmt.Errorf("failed to decrypt secrets: %w", err)
 	}
 
-	// Determine secret and SA names upfront so the RS pod spec can reference them.
-	// The actual resources are created after the RS so we can set ownerReferences.
+	// Determine secret and SA names upfront so the Deployment pod spec can reference them.
+	// The actual resources are created after the Deployment so we can set ownerReferences.
 	secretName := ""
 	saName := ""
 	if len(plaintext) > 0 {
@@ -184,22 +189,29 @@ func (c *Controller) ApplyDeployment(ctx context.Context, req *ctrlv1.ApplyDeplo
 		podSpec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: registryPullSecretName}}
 	}
 
-	desired := &appsv1.ReplicaSet{
+	desired := &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps/v1",
-			Kind:       "ReplicaSet",
+			Kind:       "Deployment",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      req.GetK8SName(),
 			Namespace: req.GetK8SNamespace(),
 			Labels:    usedLabels,
 		},
-		Spec: appsv1.ReplicaSetSpec{
+		Spec: appsv1.DeploymentSpec{
 			Replicas: ptr.P(req.GetReplicas()),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: labels.New().DeploymentID(req.GetDeploymentId()),
 			},
 			MinReadySeconds: 30,
+			Strategy: appsv1.DeploymentStrategy{
+				Type: appsv1.RollingUpdateDeploymentStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateDeployment{
+					MaxUnavailable: &intstr.IntOrString{Type: intstr.Int, IntVal: 0, StrVal: ""},
+					MaxSurge:       &intstr.IntOrString{Type: intstr.Int, IntVal: 1, StrVal: ""},
+				},
+			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: fmt.Sprintf("%s-", req.GetK8SName()),
@@ -210,27 +222,27 @@ func (c *Controller) ApplyDeployment(ctx context.Context, req *ctrlv1.ApplyDeplo
 		},
 	}
 
-	client := c.clientSet.AppsV1().ReplicaSets(req.GetK8SNamespace())
+	client := c.clientSet.AppsV1().Deployments(req.GetK8SNamespace())
 
 	patch, err := json.Marshal(desired)
 	if err != nil {
-		return fmt.Errorf("failed to marshal replicaset: %w", err)
+		return fmt.Errorf("failed to marshal deployment: %w", err)
 	}
 
-	// Apply the ReplicaSet first so we get its UID for ownerReferences.
+	// Apply the Deployment first so we get its UID for ownerReferences.
 	// Pods will retry until the secret/SA exist (created immediately after).
 	applied, err := client.Patch(ctx, req.GetK8SName(), types.ApplyPatchType, patch, metav1.PatchOptions{
 		FieldManager: fieldManagerKrane,
 	})
 	if err != nil {
-		return fmt.Errorf("failed to apply replicaset: %w", err)
+		return fmt.Errorf("failed to apply deployment: %w", err)
 	}
 
 	// Create owned resources (Secret, SA, Role, RoleBinding) with ownerReferences
-	// so K8s garbage-collects them when the ReplicaSet is deleted.
+	// so K8s garbage-collects them when the Deployment is deleted.
 	ownerRef := metav1.OwnerReference{
 		APIVersion:         "apps/v1",
-		Kind:               "ReplicaSet",
+		Kind:               "Deployment",
 		Name:               applied.Name,
 		UID:                applied.UID,
 		Controller:         ptr.P(true),

--- a/svc/krane/internal/deployment/controller.go
+++ b/svc/krane/internal/deployment/controller.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-// Controller manages deployment ReplicaSets in a Kubernetes cluster by maintaining
+// Controller manages Deployments in a Kubernetes cluster by maintaining
 // bidirectional state synchronization with the control plane.
 //
 // The controller receives desired state via the WatchDeployments stream and reports
@@ -40,7 +40,7 @@ type Controller struct {
 // operations, while Cluster provides the control plane RPC client for state
 // synchronization. Region determines which deployments this controller manages.
 type Config struct {
-	// ClientSet provides typed Kubernetes API access for ReplicaSet and Pod operations.
+	// ClientSet provides typed Kubernetes API access for Deployment and Pod operations.
 	ClientSet kubernetes.Interface
 
 	// DynamicClient provides unstructured Kubernetes API access for CiliumNetworkPolicy

--- a/svc/krane/internal/deployment/delete.go
+++ b/svc/krane/internal/deployment/delete.go
@@ -9,7 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// DeleteDeployment removes a user workload's ReplicaSet from the cluster.
+// DeleteDeployment removes a user workload's Deployment from the cluster.
 // Owned resources (Secret, ServiceAccount, Role, RoleBinding) are garbage-collected
 // automatically by K8s via ownerReferences.
 //
@@ -22,7 +22,7 @@ func (c *Controller) DeleteDeployment(ctx context.Context, req *ctrlv1.DeleteDep
 		"name", req.GetK8SName(),
 	)
 
-	err := c.clientSet.AppsV1().ReplicaSets(req.GetK8SNamespace()).Delete(ctx, req.GetK8SName(), metav1.DeleteOptions{})
+	err := c.clientSet.AppsV1().Deployments(req.GetK8SNamespace()).Delete(ctx, req.GetK8SName(), metav1.DeleteOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}

--- a/svc/krane/internal/deployment/rbac.go
+++ b/svc/krane/internal/deployment/rbac.go
@@ -15,7 +15,7 @@ import (
 
 // ensureDeploymentRBAC creates a ServiceAccount, Role, and RoleBinding for the
 // deployment. The Role only allows reading the specific deployment secret.
-// All resources are owned by the ReplicaSet via ownerRef for automatic GC.
+// All resources are owned by the Deployment via ownerRef for automatic GC.
 func (c *Controller) ensureDeploymentRBAC(ctx context.Context, namespace, deploymentID, secretName string, ownerRef metav1.OwnerReference) error {
 	sanitized := sanitizeForK8s(deploymentID)
 	saName := fmt.Sprintf("deploy-%s", sanitized)

--- a/svc/krane/internal/deployment/resync.go
+++ b/svc/krane/internal/deployment/resync.go
@@ -12,27 +12,30 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// runResyncLoop periodically reconciles all deployment ReplicaSets with their
-// desired state from the control plane.
+// runResyncLoop periodically reconciles all Deployments with their desired state
+// from the control plane.
 //
 // The loop runs every minute as a consistency safety net. While
 // [Controller.runActualStateReportLoop] handles real-time Kubernetes events and
 // [Controller.runDesiredStateApplyLoop] handles streaming updates, both can miss
 // events during network partitions, controller restarts, or watch buffer overflows.
 // This resync loop guarantees eventual consistency by querying the control plane
-// for each existing ReplicaSet and applying any drift.
+// for each existing Deployment and applying any drift.
 //
-// The loop paginates through all krane-managed deployment ReplicaSets across all
-// namespaces, calling GetDesiredDeploymentState for each and applying or deleting
-// as directed. Errors are logged but don't stop the loop from processing remaining
-// ReplicaSets.
+// The loop paginates through all krane-managed Deployments across all namespaces,
+// calling GetDesiredDeploymentState for each and applying or deleting as directed.
+// Errors are logged but don't stop the loop from processing remaining Deployments.
+//
+// After reconciling Deployments, the loop cleans up orphan ReplicaSets that were
+// created by the previous ReplicaSet-based controller and are not owned by any
+// Deployment.
 func (c *Controller) runResyncLoop(ctx context.Context) {
 	repeat.Every(1*time.Minute, func() {
 		logger.Info("running periodic resync")
 
 		cursor := ""
 		for {
-			replicaSets, err := c.clientSet.AppsV1().ReplicaSets("").List(ctx, metav1.ListOptions{
+			deployments, err := c.clientSet.AppsV1().Deployments("").List(ctx, metav1.ListOptions{
 				LabelSelector: labels.New().
 					ManagedByKrane().
 					ComponentDeployment().
@@ -40,14 +43,14 @@ func (c *Controller) runResyncLoop(ctx context.Context) {
 				Continue: cursor,
 			})
 			if err != nil {
-				logger.Error("unable to list replicaSets", "error", err.Error())
+				logger.Error("unable to list deployments", "error", err.Error())
 				return
 			}
 
-			for _, replicaSet := range replicaSets.Items {
-				deploymentID, ok := labels.GetDeploymentID(replicaSet.Labels)
+			for _, dep := range deployments.Items {
+				deploymentID, ok := labels.GetDeploymentID(dep.Labels)
 				if !ok {
-					logger.Error("unable to get deployment ID", "replicaSet", replicaSet.Name)
+					logger.Error("unable to get deployment ID", "deployment", dep.Name)
 					continue
 				}
 
@@ -57,8 +60,8 @@ func (c *Controller) runResyncLoop(ctx context.Context) {
 				if err != nil {
 					if connect.CodeOf(err) == connect.CodeNotFound {
 						if err := c.DeleteDeployment(ctx, &ctrlv1.DeleteDeployment{
-							K8SNamespace: replicaSet.GetNamespace(),
-							K8SName:      replicaSet.GetName(),
+							K8SNamespace: dep.GetNamespace(),
+							K8SName:      dep.GetName(),
 						}); err != nil {
 							logger.Error("unable to delete deployment", "error", err.Error(), "deployment_id", deploymentID)
 							continue
@@ -81,10 +84,50 @@ func (c *Controller) runResyncLoop(ctx context.Context) {
 				}
 			}
 
-			cursor = replicaSets.Continue
+			cursor = deployments.Continue
 			if cursor == "" {
 				break
 			}
 		}
+
+		// Clean up orphan ReplicaSets from the previous controller that are not
+		// owned by a Deployment. These are standalone RS with krane labels.
+		c.cleanupOrphanReplicaSets(ctx)
 	})
+}
+
+// cleanupOrphanReplicaSets deletes standalone ReplicaSets with krane labels that
+// have no ownerReferences (i.e. not managed by a Deployment). These are leftovers
+// from before we switched customer workloads from ReplicaSets to Deployments.
+func (c *Controller) cleanupOrphanReplicaSets(ctx context.Context) {
+	cursor := ""
+	for {
+		rsList, err := c.clientSet.AppsV1().ReplicaSets("").List(ctx, metav1.ListOptions{
+			LabelSelector: labels.New().
+				ManagedByKrane().
+				ComponentDeployment().
+				ToString(),
+			Continue: cursor,
+		})
+		if err != nil {
+			logger.Error("unable to list orphan replicasets", "error", err.Error())
+			return
+		}
+
+		for _, rs := range rsList.Items {
+			// Skip RS owned by a Deployment (created by the new controller)
+			if len(rs.OwnerReferences) > 0 {
+				continue
+			}
+			logger.Info("deleting orphan replicaset", "namespace", rs.Namespace, "name", rs.Name)
+			if err := c.clientSet.AppsV1().ReplicaSets(rs.Namespace).Delete(ctx, rs.Name, metav1.DeleteOptions{}); err != nil {
+				logger.Error("unable to delete orphan replicaset", "error", err.Error(), "name", rs.Name)
+			}
+		}
+
+		cursor = rsList.Continue
+		if cursor == "" {
+			break
+		}
+	}
 }

--- a/svc/krane/internal/deployment/secrets.go
+++ b/svc/krane/internal/deployment/secrets.go
@@ -57,7 +57,7 @@ func sanitizeForK8s(id string) string {
 
 // ensureDeploymentSecret creates or updates a K8s Secret containing the plaintext
 // environment variables for the deployment. Uses server-side apply for idempotency.
-// The ownerRef ties the secret's lifecycle to the ReplicaSet for automatic GC.
+// The ownerRef ties the secret's lifecycle to the Deployment for automatic GC.
 func (c *Controller) ensureDeploymentSecret(ctx context.Context, namespace, deploymentID string, envVars map[string]string, ownerRef metav1.OwnerReference) error {
 	secretName := deploymentSecretName(deploymentID)
 

--- a/svc/krane/internal/deployment/state.go
+++ b/svc/krane/internal/deployment/state.go
@@ -11,7 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// buildDeploymentStatus queries the pods belonging to a ReplicaSet and builds a
+// buildDeploymentStatus queries the pods belonging to a Deployment and builds a
 // status report for the control plane.
 //
 // The report includes each pod's cluster-local DNS address, CPU and memory limits,
@@ -22,29 +22,29 @@ import (
 // Pod phase is mapped to instance status: Running pods with all containers ready
 // become STATUS_RUNNING, Pending pods become STATUS_PENDING, and Failed pods or
 // Running pods with unready containers become STATUS_FAILED.
-func (c *Controller) buildDeploymentStatus(ctx context.Context, replicaset *appsv1.ReplicaSet) (*ctrlv1.ReportDeploymentStatusRequest, error) {
-	selector, err := metav1.LabelSelectorAsSelector(replicaset.Spec.Selector)
+func (c *Controller) buildDeploymentStatus(ctx context.Context, dep *appsv1.Deployment) (*ctrlv1.ReportDeploymentStatusRequest, error) {
+	selector, err := metav1.LabelSelectorAsSelector(dep.Spec.Selector)
 	if err != nil {
 		return nil, err
 	}
 
-	pods, err := c.clientSet.CoreV1().Pods(replicaset.Namespace).List(ctx, metav1.ListOptions{
+	pods, err := c.clientSet.CoreV1().Pods(dep.Namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: selector.String(),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list pods: %w", err)
 	}
 
-	// Read the port from the ReplicaSet's container spec
+	// Read the port from the Deployment's container spec
 	containerPort := int32(8080)
-	if containers := replicaset.Spec.Template.Spec.Containers; len(containers) > 0 {
+	if containers := dep.Spec.Template.Spec.Containers; len(containers) > 0 {
 		if ports := containers[0].Ports; len(ports) > 0 {
 			containerPort = ports[0].ContainerPort
 		}
 	}
 
 	update := &ctrlv1.ReportDeploymentStatusRequest_Update{
-		K8SName:   replicaset.Name,
+		K8SName:   dep.Name,
 		Instances: make([]*ctrlv1.ReportDeploymentStatusRequest_Update_Instance, 0, len(pods.Items)),
 	}
 


### PR DESCRIPTION
## What does this PR do?

Migrates customer workloads from ReplicaSets to Deployments to enable automatic rolling updates when infrastructure-level changes are made to pod templates.

Previously, ReplicaSets would not roll pods when the pod template changed, meaning infrastructure updates like environment variable overrides, resource defaults, security settings, or runtime class updates would not take effect on existing workloads until customers manually redeployed. This change allows the platform to push infrastructure changes to all running workloads without requiring customer action.

The migration includes:
- Switching from ReplicaSet to Deployment resources with rolling update strategy (`MaxUnavailable: 0, MaxSurge: 1`)
- Adding automatic cleanup of orphaned ReplicaSets from the previous controller
- Updating all watch loops, status reporting, and CRUD operations to work with Deployments
- Adding comprehensive documentation explaining the rationale for this architectural change

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Deploy a workload and verify it creates a Deployment instead of a ReplicaSet
- Modify the pod template (e.g., add environment variables) and verify pods are automatically rolled
- Confirm zero-downtime rolling updates with the configured strategy
- Test that orphaned ReplicaSets from previous deployments are cleaned up during resync
- Verify status reporting and watch loops work correctly with Deployments

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary