### PR TITLE
chore: update cli to use latest unkey sdk

### DIFF
--- a/cmd/deploy/control_plane.go
+++ b/cmd/deploy/control_plane.go
@@ -73,7 +73,8 @@ func (c *ControlPlaneClient) CreateDeployment(ctx context.Context, dockerImage s
 	}
 
 	reqBody := components.V2DeployCreateDeploymentRequestBody{
-		ProjectID:       c.opts.ProjectID,
+		Project:         c.opts.Project,
+		App:             c.opts.App,
 		Branch:          c.opts.Branch,
 		EnvironmentSlug: c.opts.Environment,
 		DockerImage:     dockerImage,

--- a/cmd/deploy/main.go
+++ b/cmd/deploy/main.go
@@ -22,7 +22,8 @@ const (
 
 // DeployOptions contains all configuration for deployment
 type DeployOptions struct {
-	ProjectID   string
+	Project     string
+	App         string
 	KeyspaceID  string
 	DockerImage string
 	Branch      string
@@ -34,14 +35,15 @@ type DeployOptions struct {
 
 var DeployFlags = []cli.Flag{
 	// Required flags
-	cli.String("project-id", "Project ID", cli.EnvVar("UNKEY_PROJECT_ID")),
+	cli.String("project", "Project slug", cli.Required(), cli.EnvVar("UNKEY_PROJECT")),
+	cli.String("app", "App slug within the project", cli.EnvVar("UNKEY_APP"), cli.Default("default")),
 	// Optional flags with defaults
 	cli.String("keyspace-id", "Keyspace ID for API key authentication", cli.EnvVar("UNKEY_KEYSPACE_ID")),
 	cli.String("branch", "Git branch", cli.Default(DefaultBranch)),
 	cli.String("commit", "Git commit SHA"),
 	cli.String("env", "Environment slug to deploy to", cli.Default(DefaultEnvironment)),
 	// Authentication flag
-	cli.String("root-key", "Root key for authentication", cli.EnvVar("UNKEY_ROOT_KEY")),
+	cli.String("root-key", "Root key for authentication", cli.Required(), cli.EnvVar("UNKEY_ROOT_KEY")),
 	// API configuration
 	cli.String("api-base-url", "API base URL for local testing", cli.EnvVar("UNKEY_API_BASE_URL")),
 }
@@ -69,8 +71,8 @@ DEPLOYMENT PROCESS:
 2. Monitor deployment status until active
 
 EXAMPLES:
-unkey deploy ghcr.io/user/app:v1.0.0 --project-id=proj_123
-unkey deploy myregistry.io/app:latest --project-id=proj_123 --env=production`,
+unkey deploy ghcr.io/user/app:v1.0.0 --project=my-project
+unkey deploy myregistry.io/app:latest --project=my-project --app=api --env=production`,
 	Flags:  DeployFlags,
 	Action: DeployAction,
 }
@@ -82,13 +84,9 @@ func DeployAction(ctx context.Context, cmd *cli.Command) error {
 	}
 	dockerImage := args[0]
 
-	projectID := cmd.String("project-id")
-	if projectID == "" {
-		return fmt.Errorf("project ID is required (use --project-id flag or UNKEY_PROJECT_ID env var)")
-	}
-
 	opts := DeployOptions{
-		ProjectID:   projectID,
+		Project:     cmd.String("project"),
+		App:         cmd.String("app"),
 		KeyspaceID:  cmd.String("keyspace-id"),
 		DockerImage: dockerImage,
 		Branch:      cmd.String("branch"),

--- a/go.mod
+++ b/go.mod
@@ -71,7 +71,7 @@ require (
 	github.com/spiffe/go-spiffe/v2 v2.6.0
 	github.com/sqlc-dev/plugin-sdk-go v1.23.0
 	github.com/stretchr/testify v1.11.1
-	github.com/unkeyed/sdks/api/go/v2 v2.6.0
+	github.com/unkeyed/sdks/api/go/v2 v2.6.1
 	go.opentelemetry.io/contrib/bridges/otelslog v0.14.0
 	go.opentelemetry.io/contrib/bridges/prometheus v0.64.0
 	go.opentelemetry.io/contrib/processors/minsev v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -835,6 +835,8 @@ github.com/ugorji/go/codec v1.2.11 h1:BMaWp1Bb6fHwEtbplGBGJ498wD+LKlNSl25MjdZY4d
 github.com/ugorji/go/codec v1.2.11/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
 github.com/unkeyed/sdks/api/go/v2 v2.6.0 h1:xJwxkst+vCyUODKF1OYiUtWGJ4rQZVZH3YRlDplKxi8=
 github.com/unkeyed/sdks/api/go/v2 v2.6.0/go.mod h1:1eT/d35dAxF/Ncbg9jrDSuw9CHo/qKzGPppo0gABOU4=
+github.com/unkeyed/sdks/api/go/v2 v2.6.1 h1:Sz4Rv4fhh7ByCTIcJ7orK+2ZOMyoXLsAV6t+q4B+Gck=
+github.com/unkeyed/sdks/api/go/v2 v2.6.1/go.mod h1:1eT/d35dAxF/Ncbg9jrDSuw9CHo/qKzGPppo0gABOU4=
 github.com/vbatts/tar-split v0.12.2 h1:w/Y6tjxpeiFMR47yzZPlPj/FcPLpXbTUi/9H7d3CPa4=
 github.com/vbatts/tar-split v0.12.2/go.mod h1:eF6B6i6ftWQcDqEn3/iGFRFRo8cBIMSJVOpnNdfTMFA=
 github.com/vishvananda/netlink v1.3.1 h1:3AEMt62VKqz90r0tmNhog0r/PpWKmrEShJU0wJW6bV0=


### PR DESCRIPTION
## What does this PR do?

Refactors the deploy command to use project and app slugs instead of project ID. Changes the `--project-id` flag to `--project` (now required) and adds a new `--app` flag with a default value of "default". Updates the API request body structure to include both project and app fields. Also makes the `--root-key` flag required and updates the SDK dependency to v2.6.1.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Test deploying with the new `--project` flag instead of `--project-id`
- Test deploying with the new `--app` flag (both with explicit value and default)
- Verify that the `--root-key` flag is now required
- Test that the API request includes both project and app fields

running `go run . deploy --project=local-api --app=default --root-key=<ROOT_KEY> --api-base-url=http://localhost:7070 --env=preview nginx:latest` should deploy...

just set the port to 80 in the db for this to actually work.

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary