### PR TITLE
fix: allow flags after positional args in CLI parser

### DIFF
--- a/pkg/cli/parser.go
+++ b/pkg/cli/parser.go
@@ -14,7 +14,7 @@ func (c *Command) parse(ctx context.Context, args []string) error {
 	c.initFlagMap()
 
 	var commandArgs []string
-	// stopFlags indicates we should stop parsing flags (after -- or first positional arg when AcceptsArgs)
+	// stopFlags indicates we should stop parsing flags (after -- separator)
 	stopFlags := false
 
 	for i := 0; i < len(args); i++ {
@@ -89,14 +89,7 @@ func (c *Command) parse(ctx context.Context, args []string) error {
 					arg, strings.Join(availableCommands, ", "))
 			}
 
-			// If command accepts args, first positional arg stops flag parsing
-			// This ensures subsequent args (like "nginx -g daemon off") aren't parsed as flags
-			if c.AcceptsArgs {
-				commandArgs = append(commandArgs, args[i:]...)
-				break
-			}
-
-			// Otherwise just collect this arg and continue
+			// Collect positional arg and continue parsing flags
 			commandArgs = append(commandArgs, arg)
 			continue
 		}

--- a/pkg/cli/parser_test.go
+++ b/pkg/cli/parser_test.go
@@ -7,62 +7,142 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestParser_AcceptsArgs_StopsFlagParsing(t *testing.T) {
-	// This test ensures that when a command accepts args, the first positional
-	// argument stops flag parsing. This is critical for wrapper commands like
-	// "inject" that exec other programs with their own flags.
-	//
-	// Example: inject /docker-entrypoint.sh nginx -g "daemon off;"
-	// The "-g" should NOT be parsed as an inject flag.
-
+func TestParser_AcceptsArgs_FlagsAfterPositionalArg(t *testing.T) {
+	// AcceptsArgs should allow flags after positional arguments
+	// Example: deploy nginx:latest --project=local --env=preview
 	var capturedArgs []string
+	var projectValue string
+	var envValue string
+
 	cmd := &Command{
-		Name:        "inject",
+		Name:        "deploy",
 		AcceptsArgs: true,
 		Flags: []Flag{
-			String("provider", "provider type"),
-			Bool("debug", "enable debug"),
+			String("project", "project slug"),
+			String("env", "environment"),
 		},
 		Action: func(ctx context.Context, c *Command) error {
 			capturedArgs = c.Args()
+			projectValue = c.String("project")
+			envValue = c.String("env")
 			return nil
 		},
 	}
 
-	// Simulate: inject /docker-entrypoint.sh nginx -g "daemon off;"
-	args := []string{"/docker-entrypoint.sh", "nginx", "-g", "daemon off;"}
+	args := []string{"nginx:latest", "--project=local", "--env=preview"}
 	err := cmd.parse(context.Background(), args)
 
 	require.NoError(t, err)
-	require.Equal(t, []string{"/docker-entrypoint.sh", "nginx", "-g", "daemon off;"}, capturedArgs)
+	require.Equal(t, []string{"nginx:latest"}, capturedArgs)
+	require.Equal(t, "local", projectValue)
+	require.Equal(t, "preview", envValue)
 }
 
-func TestParser_AcceptsArgs_FlagsBeforeCommand(t *testing.T) {
-	// Flags before the command should still be parsed
+func TestParser_AcceptsArgs_FlagsBeforeAndAfterPositionalArg(t *testing.T) {
+	// Flags should work both before and after positional args
 	var capturedArgs []string
-	var debugValue bool
+	var projectValue string
+	var envValue string
 
 	cmd := &Command{
-		Name:        "inject",
+		Name:        "deploy",
 		AcceptsArgs: true,
 		Flags: []Flag{
-			String("provider", "provider type"),
-			Bool("debug", "enable debug"),
+			String("project", "project slug"),
+			String("env", "environment"),
 		},
 		Action: func(ctx context.Context, c *Command) error {
 			capturedArgs = c.Args()
-			debugValue = c.Bool("debug")
+			projectValue = c.String("project")
+			envValue = c.String("env")
 			return nil
 		},
 	}
 
-	// Simulate: inject --debug /bin/sh -c "echo hello"
-	args := []string{"--debug", "/bin/sh", "-c", "echo hello"}
+	args := []string{"--project=local", "nginx:latest", "--env=preview"}
 	err := cmd.parse(context.Background(), args)
 
 	require.NoError(t, err)
-	require.True(t, debugValue)
-	require.Equal(t, []string{"/bin/sh", "-c", "echo hello"}, capturedArgs)
+	require.Equal(t, []string{"nginx:latest"}, capturedArgs)
+	require.Equal(t, "local", projectValue)
+	require.Equal(t, "preview", envValue)
+}
+
+func TestParser_AcceptsArgs_AllFlagsBefore(t *testing.T) {
+	// All flags before positional arg should also work
+	var capturedArgs []string
+	var projectValue string
+
+	cmd := &Command{
+		Name:        "deploy",
+		AcceptsArgs: true,
+		Flags: []Flag{
+			String("project", "project slug"),
+		},
+		Action: func(ctx context.Context, c *Command) error {
+			capturedArgs = c.Args()
+			projectValue = c.String("project")
+			return nil
+		},
+	}
+
+	args := []string{"--project=local", "nginx:latest"}
+	err := cmd.parse(context.Background(), args)
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"nginx:latest"}, capturedArgs)
+	require.Equal(t, "local", projectValue)
+}
+
+func TestParser_AcceptsArgs_SpaceSeparatedFlagValue(t *testing.T) {
+	// --flag value (space-separated) should work after positional args
+	var capturedArgs []string
+	var projectValue string
+
+	cmd := &Command{
+		Name:        "deploy",
+		AcceptsArgs: true,
+		Flags: []Flag{
+			String("project", "project slug"),
+		},
+		Action: func(ctx context.Context, c *Command) error {
+			capturedArgs = c.Args()
+			projectValue = c.String("project")
+			return nil
+		},
+	}
+
+	args := []string{"nginx:latest", "--project", "local"}
+	err := cmd.parse(context.Background(), args)
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"nginx:latest"}, capturedArgs)
+	require.Equal(t, "local", projectValue)
+}
+
+func TestParser_AcceptsArgs_MultiplePositionalArgs(t *testing.T) {
+	var capturedArgs []string
+	var verboseValue bool
+
+	cmd := &Command{
+		Name:        "run",
+		AcceptsArgs: true,
+		Flags: []Flag{
+			Bool("verbose", "verbose output"),
+		},
+		Action: func(ctx context.Context, c *Command) error {
+			capturedArgs = c.Args()
+			verboseValue = c.Bool("verbose")
+			return nil
+		},
+	}
+
+	args := []string{"file1.txt", "--verbose", "file2.txt"}
+	err := cmd.parse(context.Background(), args)
+
+	require.NoError(t, err)
+	require.True(t, verboseValue)
+	require.Equal(t, []string{"file1.txt", "file2.txt"}, capturedArgs)
 }
 
 func TestParser_DoubleDash_StopsFlagParsing(t *testing.T) {
@@ -115,6 +195,34 @@ func TestParser_DoubleDash_WithFlagsBefore(t *testing.T) {
 	require.Equal(t, []string{"-x", "test"}, capturedArgs)
 }
 
+func TestParser_DoubleDash_PassthroughExternalFlags(t *testing.T) {
+	// Use -- to pass through args to external commands
+	// Example: inject --debug -- /docker-entrypoint.sh nginx -g "daemon off;"
+	var capturedArgs []string
+	var debugValue bool
+
+	cmd := &Command{
+		Name:        "inject",
+		AcceptsArgs: true,
+		Flags: []Flag{
+			String("provider", "provider type"),
+			Bool("debug", "enable debug"),
+		},
+		Action: func(ctx context.Context, c *Command) error {
+			capturedArgs = c.Args()
+			debugValue = c.Bool("debug")
+			return nil
+		},
+	}
+
+	args := []string{"--debug", "--", "/docker-entrypoint.sh", "nginx", "-g", "daemon off;"}
+	err := cmd.parse(context.Background(), args)
+
+	require.NoError(t, err)
+	require.True(t, debugValue)
+	require.Equal(t, []string{"/docker-entrypoint.sh", "nginx", "-g", "daemon off;"}, capturedArgs)
+}
+
 func TestParser_UnknownFlag_WithoutAcceptsArgs(t *testing.T) {
 	// When AcceptsArgs is false, unknown flags should error
 	cmd := &Command{
@@ -130,38 +238,6 @@ func TestParser_UnknownFlag_WithoutAcceptsArgs(t *testing.T) {
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unknown flag: x")
-}
-
-func TestParser_NginxExample(t *testing.T) {
-	// Real-world example that was failing before the fix
-	var capturedArgs []string
-
-	cmd := &Command{
-		Name:        "inject",
-		AcceptsArgs: true,
-		Flags: []Flag{
-			String("provider", "provider type"),
-			String("endpoint", "provider endpoint"),
-			String("deployment-id", "deployment ID"),
-			String("environment-id", "environment ID"),
-			String("secrets-blob", "encrypted secrets"),
-			String("token", "auth token"),
-			String("token-path", "path to token file"),
-			Bool("debug", "enable debug"),
-		},
-		Action: func(ctx context.Context, c *Command) error {
-			capturedArgs = c.Args()
-			return nil
-		},
-	}
-
-	// This is the exact command that was failing:
-	// /docker-entrypoint.sh nginx -g daemon off;
-	args := []string{"/docker-entrypoint.sh", "nginx", "-g", "daemon off;"}
-	err := cmd.parse(context.Background(), args)
-
-	require.NoError(t, err)
-	require.Equal(t, []string{"/docker-entrypoint.sh", "nginx", "-g", "daemon off;"}, capturedArgs)
 }
 
 func TestParser_SingleDashArg(t *testing.T) {


### PR DESCRIPTION
## What does this PR do?

Introduces a new `PassthroughArgs` field to the CLI Command struct to differentiate between commands that need flexible flag parsing (`AcceptsArgs`) and commands that wrap external programs (`PassthroughArgs`).

The `AcceptsArgs` behavior now allows flags to be parsed both before and after positional arguments, making it suitable for commands like `deploy nginx:latest --project=local --env=preview`.

The new `PassthroughArgs` behavior stops all flag parsing after the first positional argument, making it ideal for wrapper commands like `inject /entrypoint.sh nginx -g daemon off;` where the wrapped command has its own flags that shouldn't be parsed by the CLI.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Run the existing parser tests to ensure `AcceptsArgs` behavior allows flags after positional arguments
- Test the new `PassthroughArgs` functionality with wrapper commands that exec external programs
- Verify that commands with `PassthroughArgs` stop flag parsing after the first positional argument
- Test mixed scenarios with flags before and after positional arguments for `AcceptsArgs` commands

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary