### PR TITLE
fix: use normal port ranges

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/runtime-settings/port-settings.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/runtime-settings/port-settings.tsx
@@ -8,7 +8,7 @@ import { useEnvironmentSettings } from "../../environment-provider";
 import { FormSettingCard, resolveSaveState } from "../shared/form-setting-card";
 
 const portSchema = z.object({
-  port: z.number().int().min(2000).max(54000),
+  port: z.number().int().min(1).max(65535),
 });
 
 export const Port = () => {
@@ -57,8 +57,8 @@ export const Port = () => {
         label="Port"
         description="Port your application listens on. Changes apply on next deploy."
         placeholder="8080"
-        min={2000}
-        max={54000}
+        min={1}
+        max={65535}
         error={errors.port?.message}
         variant={errors.port ? "error" : "default"}
         {...register("port", { valueAsNumber: true })}


### PR DESCRIPTION
## What does this PR do?

Expands the port range validation for runtime settings to allow the full valid TCP port range (1-65535) instead of the previously restricted range (2000-54000). This change affects both the schema validation and the form input constraints.

Fixes # (issue)

_If there is not an issue for this, please create one first. This is used to tracking purposes and also helps us understand why this PR exists_

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Test that port values from 1-65535 are now accepted in the port settings form
- Test that port values outside this range (0, 65536+) are properly rejected
- Verify that the form validation displays appropriate error messages for invalid ports
- Test that existing port configurations within the old range (2000-54000) continue to work

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary