### PR TITLE
fix: exit with 1 when deployments fail

### DIFF
--- a/cmd/deploy/main.go
+++ b/cmd/deploy/main.go
@@ -123,8 +123,7 @@ func executeDeploy(ctx context.Context, opts DeployOptions) error {
 	deploymentID, err := controlPlane.CreateDeployment(ctx, opts.DockerImage)
 	if err != nil {
 		terminal.StopSpinner(errors.FormatError(err), false)
-		// Don't return error it will just double print the error without formatting
-		return nil
+		return cli.Exit("", 1)
 	}
 	terminal.StopSpinner(fmt.Sprintf("Deployment created: %s", deploymentID), true)
 

--- a/pkg/cli/command.go
+++ b/pkg/cli/command.go
@@ -324,7 +324,9 @@ var ExitFunc = os.Exit
 // Exit provides a clean way to exit with an error message and code
 // This is a convenience function that prints the message and calls os.Exit
 func Exit(message string, code int) error {
-	fmt.Println(message)
+	if message != "" {
+		fmt.Println(message)
+	}
 	ExitFunc(code)
 	return nil // unreachable but satisfies error interface
 }


### PR DESCRIPTION
a failing deployment would still exit with 0, which makes this impossible to use in CI contexts