### PR TITLE
fix: add missing category for root key trpc query

### DIFF
--- a/web/apps/dashboard/lib/trpc/routers/settings/root-keys/query.ts
+++ b/web/apps/dashboard/lib/trpc/routers/settings/root-keys/query.ts
@@ -260,6 +260,9 @@ function categorizePermissions(permissions: PermissionResponse[]) {
       case "identity":
         category = "Identities";
         break;
+      case "project":
+        category = "Projects";
+        break;
       default:
         category = "Other";
         console.warn(`Unknown permission identifier: ${identifier}`);


### PR DESCRIPTION
## What does this PR do?

settings root key trpc query did not list projects as a possible category and marked it as other. Added projects to the switch statement to remedy console warnings


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- root key table, Create root key side sheet and dialog works as before. No console warning is shown

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [x] Ran `make fmt` on `/go` directory
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary
