### PR TITLE
fix: save dockerfile, root dir, port, command, and healthcheck settings to all environments

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/build-settings/dockerfile-settings.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/build-settings/dockerfile-settings.tsx
@@ -1,10 +1,10 @@
-import { collection } from "@/lib/collections";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { FileSettings } from "@unkey/icons";
 import { FormInput } from "@unkey/ui";
 import { useForm, useWatch } from "react-hook-form";
 import { z } from "zod";
 import { useEnvironmentSettings } from "../../environment-provider";
+import { useUpdateAllEnvironments } from "../../hooks/use-update-all-environments";
 import { FormSettingCard, resolveSaveState } from "../shared/form-setting-card";
 
 const dockerfileSchema = z.object({
@@ -13,7 +13,8 @@ const dockerfileSchema = z.object({
 
 export const Dockerfile = () => {
   const { settings, variant } = useEnvironmentSettings();
-  const { environmentId, dockerfile: defaultValue } = settings;
+  const { dockerfile: defaultValue } = settings;
+  const updateAllEnvironments = useUpdateAllEnvironments();
 
   const {
     register,
@@ -35,7 +36,7 @@ export const Dockerfile = () => {
   ]);
 
   const onSubmit = async (values: z.infer<typeof dockerfileSchema>) => {
-    collection.environmentSettings.update(environmentId, (draft) => {
+    updateAllEnvironments((draft) => {
       draft.dockerfile = values.dockerfile;
     });
   };

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/build-settings/root-directory-settings.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/build-settings/root-directory-settings.tsx
@@ -1,10 +1,10 @@
-import { collection } from "@/lib/collections";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { FolderLink } from "@unkey/icons";
 import { FormInput } from "@unkey/ui";
 import { useForm, useWatch } from "react-hook-form";
 import { z } from "zod";
 import { useEnvironmentSettings } from "../../environment-provider";
+import { useUpdateAllEnvironments } from "../../hooks/use-update-all-environments";
 import { FormSettingCard, resolveSaveState } from "../shared/form-setting-card";
 
 const rootDirectorySchema = z.object({
@@ -13,7 +13,8 @@ const rootDirectorySchema = z.object({
 
 export const RootDirectory = () => {
   const { settings, variant } = useEnvironmentSettings();
-  const { environmentId, dockerContext: defaultValue } = settings;
+  const { dockerContext: defaultValue } = settings;
+  const updateAllEnvironments = useUpdateAllEnvironments();
 
   const {
     register,
@@ -35,7 +36,7 @@ export const RootDirectory = () => {
   ]);
 
   const onSubmit = async (values: z.infer<typeof rootDirectorySchema>) => {
-    collection.environmentSettings.update(environmentId, (draft) => {
+    updateAllEnvironments((draft) => {
       draft.dockerContext = values.dockerContext;
     });
   };

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/runtime-settings/command.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/runtime-settings/command.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { collection } from "@/lib/collections";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { SquareTerminal } from "@unkey/icons";
 import { FormTextarea, InfoTooltip } from "@unkey/ui";
@@ -8,6 +7,7 @@ import { useEffect } from "react";
 import { useForm, useWatch } from "react-hook-form";
 import { z } from "zod";
 import { useEnvironmentSettings } from "../../environment-provider";
+import { useUpdateAllEnvironments } from "../../hooks/use-update-all-environments";
 import { FormSettingCard, resolveSaveState } from "../shared/form-setting-card";
 
 const commandSchema = z.object({
@@ -18,7 +18,8 @@ type CommandFormValues = z.infer<typeof commandSchema>;
 
 export const Command = () => {
   const { settings, variant } = useEnvironmentSettings();
-  const { command, environmentId } = settings;
+  const { command } = settings;
+  const updateAllEnvironments = useUpdateAllEnvironments();
   const defaultCommand = command.join(" ");
 
   const {
@@ -49,7 +50,7 @@ export const Command = () => {
   const onSubmit = async (values: CommandFormValues) => {
     const trimmed = values.command.trim();
     const command = trimmed === "" ? [] : trimmed.split(/\s+/).filter(Boolean);
-    collection.environmentSettings.update(environmentId, (draft) => {
+    updateAllEnvironments((draft) => {
       draft.command = command;
     });
   };

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/runtime-settings/healthcheck/index.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/runtime-settings/healthcheck/index.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { collection } from "@/lib/collections";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { ChevronDown, HeartPulse } from "@unkey/icons";
 import {
@@ -14,6 +13,7 @@ import {
 import { useEffect } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { useEnvironmentSettings } from "../../../environment-provider";
+import { useUpdateAllEnvironments } from "../../../hooks/use-update-all-environments";
 import { FormSettingCard, resolveSaveState } from "../../shared/form-setting-card";
 import { RemoveButton } from "../../shared/remove-button";
 import { MethodBadge } from "./method-badge";
@@ -22,7 +22,8 @@ import { intervalToSeconds, secondsToInterval } from "./utils";
 
 export const Healthcheck = () => {
   const { settings, variant } = useEnvironmentSettings();
-  const { healthcheck, environmentId } = settings;
+  const { healthcheck } = settings;
+  const updateAllEnvironments = useUpdateAllEnvironments();
 
   const defaultValues: HealthcheckFormValues = {
     method: healthcheck?.method ?? "GET",
@@ -48,7 +49,7 @@ export const Healthcheck = () => {
   }, [defaultValues.method, defaultValues.path, defaultValues.interval, reset]);
 
   const onSubmit = async (values: HealthcheckFormValues) => {
-    collection.environmentSettings.update(environmentId, (draft) => {
+    updateAllEnvironments((draft) => {
       draft.healthcheck =
         values.path.trim() === ""
           ? null
@@ -64,7 +65,7 @@ export const Healthcheck = () => {
   };
 
   const handleRemove = () => {
-    collection.environmentSettings.update(environmentId, (draft) => {
+    updateAllEnvironments((draft) => {
       draft.healthcheck = null;
     });
     reset({ method: "GET", path: "", interval: "" });

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/runtime-settings/port-settings.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/runtime-settings/port-settings.tsx
@@ -1,10 +1,10 @@
-import { collection } from "@/lib/collections";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { NumberInput } from "@unkey/icons";
 import { FormInput } from "@unkey/ui";
 import { useForm, useWatch } from "react-hook-form";
 import { z } from "zod";
 import { useEnvironmentSettings } from "../../environment-provider";
+import { useUpdateAllEnvironments } from "../../hooks/use-update-all-environments";
 import { FormSettingCard, resolveSaveState } from "../shared/form-setting-card";
 
 const portSchema = z.object({
@@ -13,7 +13,8 @@ const portSchema = z.object({
 
 export const Port = () => {
   const { settings, variant } = useEnvironmentSettings();
-  const { environmentId, port: defaultValue } = settings;
+  const { port: defaultValue } = settings;
+  const updateAllEnvironments = useUpdateAllEnvironments();
 
   const {
     register,
@@ -35,7 +36,7 @@ export const Port = () => {
   ]);
 
   const onSubmit = async (values: z.infer<typeof portSchema>) => {
-    collection.environmentSettings.update(environmentId, (draft) => {
+    updateAllEnvironments((draft) => {
       draft.port = values.port;
     });
   };

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/hooks/use-update-all-environments.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/hooks/use-update-all-environments.ts
@@ -1,0 +1,26 @@
+"use client";
+
+import { collection } from "@/lib/collections";
+import type { EnvironmentSettings } from "@/lib/collections/deploy/environment-settings";
+import { useCallback } from "react";
+import { useProjectData } from "../../data-provider";
+
+/**
+ * Returns a function that applies a settings mutation to every environment.
+ *
+ * Use this for settings that don't have per-environment UI (e.g. dockerfile,
+ * root directory, port, command, healthcheck) so they stay consistent across
+ * all environments.
+ */
+export function useUpdateAllEnvironments() {
+  const { environments } = useProjectData();
+
+  return useCallback(
+    (updater: (draft: EnvironmentSettings) => void) => {
+      for (const env of environments) {
+        collection.environmentSettings.update(env.id, updater);
+      }
+    },
+    [environments],
+  );
+}


### PR DESCRIPTION
## What does this PR do?

Refactors environment settings components to use a centralized `useUpdateAllEnvironments` hook instead of directly updating individual environments. This ensures that build and runtime settings (dockerfile, root directory, port, command, healthcheck) remain consistent across all environments in a project.

The changes introduce a new custom hook that applies settings mutations to every environment simultaneously, replacing the previous approach of updating settings for a single environment ID.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Test that dockerfile settings are applied to all environments when changed
- Test that root directory settings sync across all environments
- Test that port settings remain consistent across environments
- Test that command settings are updated for all environments simultaneously
- Test that healthcheck settings (including removal) apply to all environments
- Verify that the settings UI still functions correctly and shows proper save states

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary