### PR TITLE
fix: key all deployments by workspace id

### DIFF
--- a/svc/ctrl/services/deployment/create_deployment.go
+++ b/svc/ctrl/services/deployment/create_deployment.go
@@ -42,8 +42,8 @@ type dockerSourceInfo struct {
 // apps deploy HEAD of their default branch, non-git apps reuse the live
 // deployment's Docker image.
 //
-// The workflow runs asynchronously keyed by project ID, so only one deployment
-// per project executes at a time. Returns the deployment ID and initial status.
+// The workflow runs asynchronously keyed by workspace ID, so only one deployment
+// per workspace executes at a time during beta. Returns the deployment ID and initial status.
 func (s *Service) CreateDeployment(
 	ctx context.Context,
 	req *connect.Request[ctrlv1.CreateDeploymentRequest],
@@ -273,8 +273,8 @@ func (s *Service) CreateDeployment(
 		"environment", env.Environment.ID,
 	)
 
-	// Send deployment request asynchronously, keyed by project ID
-	invocation, err := s.deploymentClient(project.ID).
+	// Send deployment request asynchronously, keyed by workspace ID
+	invocation, err := s.deploymentClient(workspaceID).
 		Deploy().
 		Send(ctx, deployReq)
 	if err != nil {

--- a/svc/ctrl/services/deployment/promote.go
+++ b/svc/ctrl/services/deployment/promote.go
@@ -15,13 +15,13 @@ import (
 // This is typically used after a rollback to restore the original deployment, or
 // to switch traffic to a new deployment that was previously in a preview state.
 // The workflow runs synchronously (blocking until complete) and is keyed by
-// app ID to prevent concurrent promotion operations on the same app.
+// workspace ID to prevent concurrent promotion operations on the same workspace.
 func (s *Service) Promote(ctx context.Context, req *connect.Request[ctrlv1.PromoteRequest]) (*connect.Response[ctrlv1.PromoteResponse], error) {
 	logger.Info("initiating promotion via Restate",
 		"target", req.Msg.GetTargetDeploymentId(),
 	)
 
-	// Get target deployment to determine app ID for keying
+	// Get target deployment to determine workspace ID for keying
 	targetDeployment, err := db.Query.FindDeploymentById(ctx, s.db.RO(), req.Msg.GetTargetDeploymentId())
 	if err != nil {
 		if db.IsNotFound(err) {
@@ -34,9 +34,9 @@ func (s *Service) Promote(ctx context.Context, req *connect.Request[ctrlv1.Promo
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to get deployment: %w", err))
 	}
 
-	// Call the Restate workflow using project ID as the key
-	// This ensures only one operation per project can run at a time
-	_, err = s.deploymentClient(targetDeployment.ProjectID).
+	// Call the Restate workflow using workspace ID as the key
+	// This ensures only one operation per workspace can run at a time during beta
+	_, err = s.deploymentClient(targetDeployment.WorkspaceID).
 		Promote().
 		Request(ctx, &hydrav1.PromoteRequest{
 			TargetDeploymentId: req.Msg.GetTargetDeploymentId(),

--- a/svc/ctrl/services/deployment/rollback.go
+++ b/svc/ctrl/services/deployment/rollback.go
@@ -15,14 +15,14 @@ import (
 // deployment via a Restate workflow. This is typically called from the dashboard
 // when a deployment needs to be reverted. The workflow runs synchronously
 // (blocking until complete) and is keyed by app ID to prevent concurrent
-// rollback operations on the same app.
+// rollback operations on the same workspace.
 func (s *Service) Rollback(ctx context.Context, req *connect.Request[ctrlv1.RollbackRequest]) (*connect.Response[ctrlv1.RollbackResponse], error) {
 	logger.Info("initiating rollback via Restate",
 		"source", req.Msg.GetSourceDeploymentId(),
 		"target", req.Msg.GetTargetDeploymentId(),
 	)
 
-	// Get source deployment to determine app ID for keying
+	// Get source deployment to determine workspace ID for keying
 	sourceDeployment, err := db.Query.FindDeploymentById(ctx, s.db.RO(), req.Msg.GetSourceDeploymentId())
 	if err != nil {
 		if db.IsNotFound(err) {
@@ -35,9 +35,9 @@ func (s *Service) Rollback(ctx context.Context, req *connect.Request[ctrlv1.Roll
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to get deployment: %w", err))
 	}
 
-	// Call the Restate workflow using project ID as the key
-	// This ensures only one rollback per project can run at a time
-	_, err = s.deploymentClient(sourceDeployment.ProjectID).
+	// Call the Restate workflow using workspace ID as the key
+	// This ensures only one rollback per workspace can run at a time during beta
+	_, err = s.deploymentClient(sourceDeployment.WorkspaceID).
 		Rollback().
 		Request(ctx, &hydrav1.RollbackRequest{
 			SourceDeploymentId: req.Msg.GetSourceDeploymentId(),

--- a/svc/ctrl/services/deployment/service.go
+++ b/svc/ctrl/services/deployment/service.go
@@ -17,9 +17,9 @@ type Service struct {
 }
 
 // deploymentClient creates a typed Restate ingress client for the DeployService
-// keyed by the given project ID to ensure only one operation per project runs at a time.
-func (s *Service) deploymentClient(projectID string) hydrav1.DeployServiceIngressClient {
-	return hydrav1.NewDeployServiceIngressClient(s.restate, projectID)
+// keyed by workspace ID to run 1 concurrent build per workspace during beta.
+func (s *Service) deploymentClient(workspaceID string) hydrav1.DeployServiceIngressClient {
+	return hydrav1.NewDeployServiceIngressClient(s.restate, workspaceID)
 }
 
 // Config holds the configuration for creating a new [Service].


### PR DESCRIPTION
## What does this PR do?

Changes deployment workflow concurrency control from project-based to workspace-based keying. This modifies the Restate workflow client to use workspace ID instead of project ID for deployment, promotion, and rollback operations, limiting concurrent operations to one per workspace during the beta period.

The change affects:
- Deployment creation workflow keying
- Promotion operation concurrency control  
- Rollback operation concurrency control
- Client initialization logic

Fixes # (issue)

_If there is not an issue for this, please create one first. This is used to tracking purposes and also helps us understand why this PR exists_

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Verify deployment operations are properly keyed by workspace ID
- Test that concurrent deployments within the same workspace are serialized
- Confirm promotion and rollback operations respect workspace-level concurrency limits
- Validate that operations across different workspaces can run concurrently

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary