### PR TITLE
fix: prevent github webhook fetching wrong author info

### DIFF
--- a/svc/ctrl/api/github_webhook.go
+++ b/svc/ctrl/api/github_webhook.go
@@ -183,16 +183,26 @@ func extractGitCommitInfo(payload *pushPayload) githubclient.CommitInfo {
 		return githubclient.CommitInfoFromRaw("", "", "", "", "")
 	}
 
-	authorHandle := headCommit.Author.Username
+	// Use the first commit's author as the originator (PR creator).
+	// For a merged PR, head_commit is the merge commit whose author is the
+	// merger; commits[0] is the original PR work commit whose author is the
+	// PR creator. For a direct push, commits[0] == head_commit so this is
+	// equivalent.
+	authorCommit := headCommit
+	if len(payload.Commits) > 0 {
+		authorCommit = &payload.Commits[0]
+	}
+
+	authorHandle := authorCommit.Author.Username
 	if authorHandle == "" {
-		authorHandle = headCommit.Author.Name
+		authorHandle = authorCommit.Author.Name
 	}
 
 	return githubclient.CommitInfoFromRaw(
 		headCommit.ID,
 		headCommit.Message,
 		authorHandle,
-		payload.Sender.AvatarURL,
+		fmt.Sprintf("https://github.com/%s.png", authorHandle),
 		headCommit.Timestamp,
 	)
 }

--- a/svc/ctrl/api/github_webhook_integration_test.go
+++ b/svc/ctrl/api/github_webhook_integration_test.go
@@ -47,9 +47,9 @@ func TestGitHubWebhook_Push_TriggersHandlePush(t *testing.T) {
 		require.Equal(t, testRepoFullName, req.GetRepositoryFullName())
 		require.Equal(t, "main", req.GetBranch())
 		require.Equal(t, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", req.GetAfter())
-		require.Equal(t, "hello", req.GetCommitMessage())
-		require.Equal(t, "u", req.GetCommitAuthorHandle())
-		require.Equal(t, "https://avatar", req.GetCommitAuthorAvatarUrl())
+		require.Equal(t, "Merge pull request #1 from pr-creator/feat", req.GetCommitMessage())
+		require.Equal(t, "pr-creator", req.GetCommitAuthorHandle())
+		require.Equal(t, "https://github.com/pr-creator.png", req.GetCommitAuthorAvatarUrl())
 		require.NotZero(t, req.GetCommitTimestamp())
 	case <-time.After(10 * time.Second):
 		t.Fatal("expected HandlePush invocation")
@@ -106,20 +106,26 @@ func sendWebhook(url string, body []byte, secret string) (*http.Response, error)
 }
 
 func newTestPushPayload(repoFullName string, fork bool) pushPayload {
-	commit := pushCommit{
-		ID:        "c1",
-		Message:   "hello\nworld",
+	prCommit := pushCommit{
+		ID:        "c0",
+		Message:   "feat: original PR work",
 		Timestamp: "2024-01-01T00:00:00Z",
-		Author:    pushCommitAuthor{Name: "n", Username: "u"},
+		Author:    pushCommitAuthor{Name: "pr-creator", Username: "pr-creator"},
+	}
+	mergeCommit := pushCommit{
+		ID:        "c1",
+		Message:   "Merge pull request #1 from pr-creator/feat\n\nfeat: original PR work",
+		Timestamp: "2024-01-01T00:01:00Z",
+		Author:    pushCommitAuthor{Name: "merger", Username: "merger"},
 	}
 	return pushPayload{
 		Ref:          "refs/heads/main",
 		After:        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 		Installation: pushInstallation{ID: 101},
 		Repository:   pushRepository{ID: 202, FullName: repoFullName, Fork: fork},
-		Commits:      []pushCommit{commit},
-		HeadCommit:   &commit,
-		Sender:       pushSender{Login: "u", AvatarURL: "https://avatar"},
+		Commits:      []pushCommit{prCommit, mergeCommit},
+		HeadCommit:   &mergeCommit,
+		Sender:       pushSender{Login: "merger", AvatarURL: "https://avatar"},
 	}
 }
 

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/components/table/deployments-list.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/components/table/deployments-list.tsx
@@ -169,12 +169,18 @@ export const DeploymentsList = () => {
                   <CodeBranch iconSize="sm-regular" className="text-gray-12" />
                 </div>
                 <div className="min-w-0">
-                  <div className="font-mono truncate text-[13px] text-accent-12">
-                    {deployment.gitBranch}
+                  <div className="flex items-center gap-1.5 font-mono text-[13px]">
+                    <span className="truncate text-accent-12">{deployment.gitBranch}</span>
+                    <span className="text-gray-6 shrink-0">·</span>
+                    <span className="text-gray-9 shrink-0">
+                      {deployment.gitCommitSha?.slice(0, 7)}
+                    </span>
                   </div>
-                  <div className="font-mono text-xs text-gray-9">
-                    {deployment.gitCommitSha?.slice(0, 7)}
-                  </div>
+                  {deployment.gitCommitMessage ? (
+                    <div className="truncate text-xs text-gray-9 max-w-[200px]">
+                      {deployment.gitCommitMessage}
+                    </div>
+                  ) : null}
                 </div>
               </div>
               <div className="flex items-center gap-2">


### PR DESCRIPTION
## What does this PR do?

This PR fixes the issue of not getting the correct author handler thus author avatar. Also adds `git_message_info` to deployment list table. Without this fix if someone else merges the PR instead of author his names will be on the deployment list.

