### PR TITLE
fix: resolve ServiceAccount race condition in deployment apply

### DIFF
--- a/svc/krane/internal/deployment/apply.go
+++ b/svc/krane/internal/deployment/apply.go
@@ -201,6 +201,19 @@ func (c *Controller) ApplyDeployment(ctx context.Context, req *ctrlv1.ApplyDeplo
 		},
 	}
 
+	// Create the Secret and ServiceAccount before the ReplicaSet so they
+	// exist by the time pods are scheduled. This prevents the
+	// "serviceaccount not found" race condition. We patch ownerReferences
+	// onto them after the RS is created so K8s still garbage-collects them.
+	if hasSecrets {
+		if err := c.ensureDeploymentSecret(ctx, req.GetK8SNamespace(), req.GetDeploymentId(), plaintext); err != nil {
+			return fmt.Errorf("failed to ensure deployment secret: %w", err)
+		}
+		if err := c.ensureDeploymentServiceAccount(ctx, req.GetK8SNamespace(), req.GetDeploymentId()); err != nil {
+			return fmt.Errorf("failed to ensure deployment service account: %w", err)
+		}
+	}
+
 	client := c.clientSet.AppsV1().ReplicaSets(req.GetK8SNamespace())
 
 	patch, err := json.Marshal(desired)
@@ -208,8 +221,6 @@ func (c *Controller) ApplyDeployment(ctx context.Context, req *ctrlv1.ApplyDeplo
 		return fmt.Errorf("failed to marshal replicaset: %w", err)
 	}
 
-	// Apply the ReplicaSet first so we get its UID for ownerReferences.
-	// Pods will retry until the secret/SA exist (created immediately after).
 	applied, err := client.Patch(ctx, req.GetK8SName(), types.ApplyPatchType, patch, metav1.PatchOptions{
 		FieldManager: fieldManagerKrane,
 	})
@@ -217,23 +228,20 @@ func (c *Controller) ApplyDeployment(ctx context.Context, req *ctrlv1.ApplyDeplo
 		return fmt.Errorf("failed to apply replicaset: %w", err)
 	}
 
-	// Create owned resources (Secret, SA) with ownerReferences
-	// so K8s garbage-collects them when the ReplicaSet is deleted.
-	ownerRef := metav1.OwnerReference{
-		APIVersion:         "apps/v1",
-		Kind:               "ReplicaSet",
-		Name:               applied.Name,
-		UID:                applied.UID,
-		Controller:         ptr.P(true),
-		BlockOwnerDeletion: ptr.P(true),
-	}
-
+	// Patch ownerReferences onto the Secret and SA so K8s garbage-collects
+	// them when the ReplicaSet is deleted.
 	if hasSecrets {
-		if err := c.ensureDeploymentSecret(ctx, req.GetK8SNamespace(), req.GetDeploymentId(), plaintext, ownerRef); err != nil {
-			return fmt.Errorf("failed to ensure deployment secret: %w", err)
+		ownerRef := metav1.OwnerReference{
+			APIVersion:         "apps/v1",
+			Kind:               "ReplicaSet",
+			Name:               applied.Name,
+			UID:                applied.UID,
+			Controller:         ptr.P(true),
+			BlockOwnerDeletion: ptr.P(true),
 		}
-		if err := c.ensureDeploymentServiceAccount(ctx, req.GetK8SNamespace(), req.GetDeploymentId(), ownerRef); err != nil {
-			return fmt.Errorf("failed to ensure deployment service account: %w", err)
+		resName := deploymentResourcePrefix(req.GetDeploymentId())
+		if err := c.patchOwnerRef(ctx, req.GetK8SNamespace(), resName, ownerRef); err != nil {
+			return fmt.Errorf("failed to patch owner references: %w", err)
 		}
 	}
 

--- a/svc/krane/internal/deployment/rbac.go
+++ b/svc/krane/internal/deployment/rbac.go
@@ -17,22 +17,50 @@ import (
 // The SA is referenced by podSpec.ServiceAccountName so the pod doesn't use the
 // namespace default. automountServiceAccountToken is false — no API access is needed.
 // The SA is owned by the ReplicaSet via ownerRef for automatic GC.
-func (c *Controller) ensureDeploymentServiceAccount(ctx context.Context, namespace, deploymentID string, ownerRef metav1.OwnerReference) error {
+func (c *Controller) ensureDeploymentServiceAccount(ctx context.Context, namespace, deploymentID string) error {
 	saName := deploymentResourcePrefix(deploymentID)
 	commonLabels := labels.New().DeploymentID(deploymentID).ManagedByKrane()
 
 	sa := &corev1.ServiceAccount{
 		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "ServiceAccount"},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            saName,
-			Namespace:       namespace,
-			Labels:          commonLabels,
-			OwnerReferences: []metav1.OwnerReference{ownerRef},
+			Name:      saName,
+			Namespace: namespace,
+			Labels:    commonLabels,
 		},
 		AutomountServiceAccountToken: ptr.P(false),
 	}
 	if err := serverSideApplyResource(ctx, c.clientSet.CoreV1().RESTClient(), "serviceaccounts", namespace, saName, sa); err != nil {
 		return fmt.Errorf("failed to apply service account: %w", err)
+	}
+
+	return nil
+}
+
+// patchOwnerRef patches the ownerReferences on the Secret and ServiceAccount
+// for the given resource name so they are garbage-collected with the ReplicaSet.
+func (c *Controller) patchOwnerRef(ctx context.Context, namespace, name string, ownerRef metav1.OwnerReference) error {
+	ownerPatch, err := json.Marshal(map[string]any{
+		"metadata": map[string]any{
+			"ownerReferences": []metav1.OwnerReference{ownerRef},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to marshal owner ref patch: %w", err)
+	}
+
+	_, err = c.clientSet.CoreV1().Secrets(namespace).Patch(
+		ctx, name, types.MergePatchType, ownerPatch, metav1.PatchOptions{},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to patch secret owner ref: %w", err)
+	}
+
+	_, err = c.clientSet.CoreV1().ServiceAccounts(namespace).Patch(
+		ctx, name, types.MergePatchType, ownerPatch, metav1.PatchOptions{},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to patch service account owner ref: %w", err)
 	}
 
 	return nil

--- a/svc/krane/internal/deployment/secrets.go
+++ b/svc/krane/internal/deployment/secrets.go
@@ -58,7 +58,7 @@ func deploymentResourcePrefix(deploymentID string) string {
 // ensureDeploymentSecret creates or updates a K8s Secret containing the plaintext
 // environment variables for the deployment. Uses server-side apply for idempotency.
 // The ownerRef ties the secret's lifecycle to the ReplicaSet for automatic GC.
-func (c *Controller) ensureDeploymentSecret(ctx context.Context, namespace, deploymentID string, envVars map[string]string, ownerRef metav1.OwnerReference) error {
+func (c *Controller) ensureDeploymentSecret(ctx context.Context, namespace, deploymentID string, envVars map[string]string) error {
 	secretName := deploymentResourcePrefix(deploymentID)
 
 	// Use Data (not StringData) so SSA tracks ownership of data.* keys directly.
@@ -75,10 +75,9 @@ func (c *Controller) ensureDeploymentSecret(ctx context.Context, namespace, depl
 			Kind:       "Secret",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            secretName,
-			Namespace:       namespace,
-			Labels:          labels.New().DeploymentID(deploymentID).ManagedByKrane(),
-			OwnerReferences: []metav1.OwnerReference{ownerRef},
+			Name:      secretName,
+			Namespace: namespace,
+			Labels:    labels.New().DeploymentID(deploymentID).ManagedByKrane(),
 		},
 		Data: data,
 		Type: corev1.SecretTypeOpaque,


### PR DESCRIPTION
## What does this PR do?

Fixes a race condition where pods could be scheduled before their required ServiceAccount and Secret resources exist, causing "serviceaccount not found" errors.

The deployment process now creates ReplicaSets with 0 replicas initially, then scales them up to the desired count only after the ServiceAccount and Secret have been successfully created. This ensures all dependencies are in place before any pods attempt to start.

Fixes # (issue)

_If there is not an issue for this, please create one first. This is used to tracking purposes and also helps us understand why this PR exists_

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Deploy a workload that requires a ServiceAccount and verify pods start successfully without "serviceaccount not found" errors
- Test rapid deployment scenarios where the race condition was most likely to occur
- Verify that the final replica count matches the requested count after deployment completes

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary