### PR TITLE
fix: feedback

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/network/unkey-flow/components/nodes/status/status-indicator.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/network/unkey-flow/components/nodes/status/status-indicator.tsx
@@ -57,15 +57,15 @@ export function StatusIndicator({
       position={{ align: "center", side: "top", sideOffset: 5 }}
     >
       <div
-        className="border bg-gray-1 border-grayA-3 h-full rounded-lg w-8 transition-shadow hover:ring-1 hover:ring-gray-7 duration-200 ease-out cursor-pointer overflow-hidden"
+        className="border bg-gray-1 border-grayA-3 h-full rounded-lg w-6.5 transition-shadow hover:ring-1 hover:ring-gray-7 duration-200 ease-out cursor-pointer overflow-hidden"
         style={{
           boxShadow: glowBoxShadow,
         }}
       >
-        <div className="h-6 border-b border-grayA-3 flex justify-end items-start pt-1.5 pr-1.5">
+        <div className="h-6 border-b border-grayA-3 flex justify-center items-center">
           <StatusDot healthStatus={healthStatus} />
         </div>
-        <div className="h-5 bg-grayA-2 pl-1 pt-[3px]">{icon}</div>
+        <div className="h-5 bg-grayA-2 flex items-center w-full justify-center">{icon}</div>
       </div>
     </InfoTooltip>
   );

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/components/deployment-domains-card.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/components/deployment-domains-card.tsx
@@ -144,7 +144,7 @@ export function DeploymentDomainsCard({
                           href={d.url}
                           target="_blank"
                           rel="noopener noreferrer"
-                          className="transition-all hover:underline decoration-dashed underline-offset-2 max-w-[250px] truncate font-medium text-xs"
+                          className="transition-all hover:underline decoration-dashed underline-offset-2 w-[250px] max-w-[250px] truncate font-medium text-xs"
                         >
                           {d.hostname}
                         </a>


### PR DESCRIPTION
## What does this PR do?

- Makes status pill centered 
- Makes sure Show URL's copy buttons always on the right side of the popover

Fixes some of the feedback we received today.
<img width="422" height="214" alt="Screenshot 2026-03-13 at 18 40 08" src="https://github.com/user-attachments/assets/16fd61eb-ceaa-472f-ad62-aed0e4143d08" />
<img width="389" height="284" alt="Screenshot 2026-03-13 at 18 40 10" src="https://github.com/user-attachments/assets/6dd12143-88bd-46e1-80c3-6536f1c835cb" />
