### PR TITLE
fix: Reduce the workspace switcher size to be max-96

### DIFF
--- a/web/apps/dashboard/components/navigation/sidebar/team-switcher.tsx
+++ b/web/apps/dashboard/components/navigation/sidebar/team-switcher.tsx
@@ -9,7 +9,6 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { useSidebar } from "@/components/ui/sidebar";
 import { setLastUsedOrgCookie, setSessionCookie } from "@/lib/auth/cookies";
 import { trpc } from "@/lib/trpc/client";
@@ -150,7 +149,7 @@ export const WorkspaceSwitcher: React.FC = () => {
     >
       <DropdownMenuLabel>Workspaces</DropdownMenuLabel>
       <DropdownMenuGroup>
-        <ScrollArea className="h-96">
+        <div className="max-h-96 overflow-y-auto">
           {filteredOrgs.map((membership) => (
             <DropdownMenuItem
               key={membership.id}
@@ -175,7 +174,7 @@ export const WorkspaceSwitcher: React.FC = () => {
               )}
             </DropdownMenuItem>
           ))}
-        </ScrollArea>
+        </div>
         <DropdownMenuSeparator />
         <DropdownMenuItem asChild>
           <Link href="/new" className="flex items-center">


### PR DESCRIPTION
## What does this PR do?

This PR removes the h-96 by default because it is dumb when a use has a single workspace to take up 96 units of space. 

one:
<img width="616" height="537" alt="Screenshot 2026-03-13 at 10 30 36 AM" src="https://github.com/user-attachments/assets/716a10ba-6f22-4f05-8c93-10eb42f6626f" />

Many: 
<img width="616" height="575" alt="Screenshot 2026-03-13 at 10 30 59 AM" src="https://github.com/user-attachments/assets/60474859-8560-4fe6-86e0-9a63fcab30d1" />

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [X] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

Have a workspace with a single workspace. 

Have many workspaces and see how it looks. 

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [X] Filled out the "How to test" section in this PR
- [X] Read [Contributing Guide](./CONTRIBUTING.md)
- [X] Self-reviewed my own code
- [X] Commented on my code in hard-to-understand areas
- [X] Ran `pnpm build`
- [X] Ran `pnpm fmt`
- [X] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [X] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary
