### PR TITLE
feat: openapi diff UI

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/details/project-details-expandables/sections/open-api-diff.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/details/project-details-expandables/sections/open-api-diff.tsx
@@ -1,5 +1,4 @@
 "use client";
-import type { GetOpenApiDiffResponse } from "@/gen/proto/ctrl/v1/openapi_pb";
 import { collection } from "@/lib/collections";
 import { shortenId } from "@/lib/shorten-id";
 import { trpc } from "@/lib/trpc/client";
@@ -10,7 +9,13 @@ import { useParams } from "next/navigation";
 import { type DiffStatus, StatusIndicator } from "../../../../components/status-indicator";
 import { useProjectData } from "../../../data-provider";
 
-const getDiffStatus = (data?: GetOpenApiDiffResponse): DiffStatus => {
+type OpenApiDiffData = {
+  hasBreakingChanges: boolean;
+  summary?: { diff: boolean };
+  changes: { length: number }[];
+};
+
+const getDiffStatus = (data?: OpenApiDiffData): DiffStatus => {
   if (!data) {
     return "loading";
   }
@@ -51,10 +56,9 @@ export const OpenApiDiff = () => {
       newDeploymentId: newDeployment?.id ?? "",
       oldDeploymentId: currentDeploymentId ?? "",
     },
-    { enabled: false },
+    { enabled: !!newDeployment?.id && !!currentDeploymentId },
   );
 
-  // @ts-expect-error I have no idea why this whines about type diff
   const status = getDiffStatus(diff.data);
 
   if (newDeployment && !currentDeploymentId) {

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/navigations/use-breadcrumb-config.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/navigations/use-breadcrumb-config.ts
@@ -72,6 +72,12 @@ export const useBreadcrumbConfig = ({
       href: `${basePath}/${projectId}/settings`,
       segment: "settings",
     },
+    {
+      id: "openapi-diff",
+      label: "OpenAPI Diff",
+      href: `${basePath}/${projectId}/openapi-diff`,
+      segment: "openapi-diff",
+    },
   ];
 
   // Determine active subpage based on segment

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/openapi-diff/components/client.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/openapi-diff/components/client.tsx
@@ -19,6 +19,7 @@ import {
   SelectValue,
 } from "@unkey/ui";
 import { cn } from "@unkey/ui/src/lib/utils";
+import type { BadgeProps } from "@unkey/ui";
 import type React from "react";
 import { useMemo, useState } from "react";
 
@@ -90,24 +91,14 @@ export const DiffViewerContent: React.FC<DiffViewerContentProps> = ({
     setExpandedPaths(newExpanded);
   };
 
-  const getSeverityIcon = (level: number) => {
-    if (level === 3) {
-      return <TriangleWarning iconSize="sm-regular" className="text-errorA-11" />;
-    }
-    if (level === 2) {
-      return <CircleWarning iconSize="sm-regular" className="text-warningA-11" />;
-    }
-    return <CircleInfo iconSize="sm-regular" className="text-grayA-9" />;
-  };
-
   const getSeverityColor = (level: number) => {
     if (level === 3) {
-      return "border border-error-6 bg-errorA-2";
+      return "bg-errorA-2";
     }
     if (level === 2) {
-      return "border border-warning-6 bg-warningA-2";
+      return "bg-warningA-2";
     }
-    return "border border-gray-4 bg-grayA-1";
+    return "bg-grayA-2";
   };
 
   if (!changelog || changelog.length === 0) {
@@ -136,10 +127,10 @@ export const DiffViewerContent: React.FC<DiffViewerContentProps> = ({
   return (
     <>
       {/* Stats header */}
-      <div className="px-3 pb-3">
+      <div className="px-6 pt-5 pb-4">
         <div className="flex justify-between items-center">
           <div className="flex flex-col gap-1">
-            <div className="text-accent-12 font-medium text-[13px]">API Changes</div>
+            <div className="text-grayA-12 font-medium text-[13px]">API Changes</div>
             <div className="text-grayA-9 text-xs">
               {stats.total} changes • {stats.paths.length} endpoints
             </div>
@@ -164,7 +155,7 @@ export const DiffViewerContent: React.FC<DiffViewerContentProps> = ({
       </div>
 
       {/* Filters */}
-      <div className="px-3 pb-2 flex gap-2.5 items-center">
+      <div className="px-4 pb-4 flex gap-2.5 items-center">
         <Input
           type="text"
           value={filters.searchQuery}
@@ -232,24 +223,24 @@ export const DiffViewerContent: React.FC<DiffViewerContentProps> = ({
       </div>
 
       {/* Changes list */}
-      <div className="px-3 pb-3">
+      <div className="px-4 pb-6">
         {filteredChanges.length === 0 ? (
           <div className="text-center py-8">
             <p className="text-xs text-grayA-9">No changes match filters</p>
           </div>
         ) : (
-          <div className="flex flex-col gap-1">
+          <div className="flex flex-col gap-2">
             {Object.entries(groupedChanges).map(([path, operations]) => {
               const isExpanded = expandedPaths.has(path);
               return (
                 <div
                   key={path}
-                  className="border border-gray-4 rounded-md overflow-hidden bg-white dark:bg-black"
+                  className="border border-gray-4 rounded-md overflow-hidden"
                 >
                   <button
                     type="button"
                     onClick={() => togglePathExpansion(path)}
-                    className="w-full flex items-center justify-between py-2 px-3 text-left bg-grayA-1 hover:bg-grayA-2 transition-colors"
+                    className="w-full flex items-center justify-between py-3 px-4 text-left bg-grayA-1 hover:bg-grayA-2 transition-colors cursor-pointer"
                   >
                     <div className="flex items-center gap-2.5 min-w-0 flex-1">
                       <ChevronDown
@@ -267,7 +258,7 @@ export const DiffViewerContent: React.FC<DiffViewerContentProps> = ({
                       </span>
                       <div className="flex items-center gap-1.5">
                         {Object.keys(operations).map((op) => (
-                          <Badge key={op} variant="secondary" size="sm" className="text-[10px]">
+                          <Badge key={op} variant={getMethodVariant(op)} size="sm">
                             {op}
                           </Badge>
                         ))}
@@ -275,27 +266,16 @@ export const DiffViewerContent: React.FC<DiffViewerContentProps> = ({
                     </div>
                   </button>
                   {isExpanded && (
-                    <div className="border-t border-gray-4 bg-grayA-1 animate-in slide-in-from-top-2 duration-200">
+                    <div className="animate-in slide-in-from-top-2 duration-200 px-3 pt-2 pb-3 flex flex-col gap-3">
                       {Object.entries(operations).map(([operation, changes]) => (
-                        <div
-                          key={operation}
-                          className="py-2 px-3 border-b border-gray-4 last:border-b-0"
-                        >
-                          <div className="flex items-center gap-2.5 mb-2">
-                            <Badge variant="secondary" size="sm" className="text-[10px]">
-                              {operation}
-                            </Badge>
-                          </div>
+                        <div key={operation}>
                           <div className="flex flex-col gap-1">
                             {changes.map((change, index) => (
                               <div
                                 key={`${change.id}-${index}`}
-                                className={`px-2 py-1.5 rounded-sm ${getSeverityColor(change.level)}`}
+                                className={cn("px-2 py-1.5 rounded-sm", getSeverityColor(change.level))}
                               >
                                 <div className="flex items-start gap-2.5">
-                                  <div className="shrink-0 mt-0.5">
-                                    {getSeverityIcon(change.level)}
-                                  </div>
                                   <div className="flex-1 min-w-0">
                                     <p className="text-xs text-grayA-12">{change.text}</p>
                                     <div className="mt-1 flex items-center gap-2 flex-wrap">
@@ -314,6 +294,7 @@ export const DiffViewerContent: React.FC<DiffViewerContentProps> = ({
                             ))}
                           </div>
                         </div>
+
                       ))}
                     </div>
                   )}
@@ -326,3 +307,21 @@ export const DiffViewerContent: React.FC<DiffViewerContentProps> = ({
     </>
   );
 };
+
+function getMethodVariant(method: string): BadgeProps["variant"] {
+  switch (method.toUpperCase()) {
+    case "GET":
+      return "primary";
+    case "POST":
+      return "success";
+    case "DELETE":
+      return "error";
+    case "PUT":
+    case "PATCH":
+      return "warning";
+    default:
+      return "secondary";
+  }
+}
+
+

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/openapi-diff/hooks/use-diff-deployments.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/openapi-diff/hooks/use-diff-deployments.ts
@@ -1,0 +1,33 @@
+"use client";
+
+import { collection } from "@/lib/collections";
+import { eq, useLiveQuery } from "@tanstack/react-db";
+import { useProjectData } from "../../data-provider";
+
+export const useDiffDeployments = () => {
+  const { projectId } = useProjectData();
+
+  const deployments = useLiveQuery(
+    (q) => {
+      const environments = q
+        .from({ environment: collection.environments })
+        .where(({ environment }) => eq(environment.projectId, projectId));
+
+      return q
+        .from({ deployment: collection.deployments })
+        .where(({ deployment }) => eq(deployment.projectId, projectId))
+        .rightJoin({ environment: environments }, ({ environment, deployment }) =>
+          eq(environment.id, deployment?.environmentId ?? ""),
+        )
+        .orderBy(({ deployment }) => deployment?.createdAt ?? 0, "desc")
+        .limit(100);
+    },
+    [projectId],
+  );
+
+  const data = (deployments.data ?? []).flatMap((d) =>
+    d.deployment ? [{ deployment: d.deployment, environment: d.environment }] : [],
+  );
+
+  return { deployments: data, isLoading: deployments.isLoading };
+};

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/openapi-diff/page.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/openapi-diff/page.tsx
@@ -1,18 +1,16 @@
 "use client";
 
-import { collection } from "@/lib/collections";
 import { shortenId } from "@/lib/shorten-id";
 import { trpc } from "@/lib/trpc/client";
-import { eq, useLiveQuery } from "@tanstack/react-db";
 import { ArrowRight, Magnifier } from "@unkey/icons";
 import { Loading } from "@unkey/ui";
 import { useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
-import { ProjectContentWrapper } from "../../components/project-content-wrapper";
 import { Card } from "../components/card";
 import { useProjectData } from "../data-provider";
 import { DiffViewerContent } from "./components/client";
 import { DeploymentSelect } from "./components/deployment-select";
+import { useDiffDeployments } from "./hooks/use-diff-deployments";
 
 export default function DiffPage() {
   const { projectId, project } = useProjectData();
@@ -22,24 +20,11 @@ export default function DiffPage() {
   const [selectedFromDeployment, setSelectedFromDeployment] = useState<string>("");
   const [selectedToDeployment, setSelectedToDeployment] = useState<string>("");
 
-  const deployments = useLiveQuery(
-    (q) =>
-      q
-        .from({ deployment: collection.deployments })
-        .where(({ deployment }) => eq(deployment.projectId, projectId))
-        .join({ environment: collection.environments }, ({ environment, deployment }) =>
-          eq(environment.id, deployment.environmentId),
-        )
-        .orderBy(({ deployment }) => deployment.createdAt, "desc")
-        .limit(100),
-    [projectId],
-  );
-
-  const sortedDeployments = deployments.data ?? [];
+  const { deployments: sortedDeployments, isLoading: deploymentsLoading } = useDiffDeployments();
 
   // Read from URL params and pre-select deployments
   useEffect(() => {
-    if (deployments.isLoading) {
+    if (deploymentsLoading) {
       return;
     }
 
@@ -67,7 +52,7 @@ export default function DiffPage() {
         setSelectedFromDeployment(currentDeploymentId);
       }
     }
-  }, [currentDeploymentId, sortedDeployments, deployments.isLoading, searchParams]);
+  }, [currentDeploymentId, sortedDeployments, deploymentsLoading, searchParams]);
 
   const {
     data: diffData,
@@ -79,7 +64,7 @@ export default function DiffPage() {
       newDeploymentId: selectedToDeployment,
     },
     {
-      enabled: false,
+      enabled: !!selectedFromDeployment && !!selectedToDeployment,
     },
   );
 
@@ -99,26 +84,18 @@ export default function DiffPage() {
   const showContent = selectedFromDeployment && selectedToDeployment;
 
   return (
-    <ProjectContentWrapper centered>
-      <Card className="pt-[14px] flex flex-col overflow-hidden">
-        {/* Header Section */}
-        <div className="flex w-full justify-between items-center px-[22px]">
-          <div className="flex gap-5 items-center">
-            <div className="flex flex-col gap-1">
-              <div className="text-accent-12 font-medium text-[13px]">Compare Deployments</div>
-              <div className="text-grayA-9 text-xs">View API changes between deployments</div>
-            </div>
-          </div>
-        </div>
+    <div className="w-225 flex flex-col justify-center items-center gap-6 mx-auto my-14">
+      <div className="flex flex-col gap-2 items-center">
+        <span className="font-semibold text-gray-12 leading-8 text-lg">Compare Deployments</span>
+        <span className="leading-4 text-gray-11 text-[13px]">View API changes between deployments</span>
+      </div>
 
+      <Card className="flex flex-col overflow-hidden w-full">
         {/* Deployment Selectors */}
-        <div className="bg-gray-1 rounded-b-[14px]">
-          <div className="relative h-4 flex items-center justify-center">
-            <div className="absolute top-0 left-0 right-0 h-4 border-b border-gray-4 rounded-b-[14px] bg-white dark:bg-black" />
-          </div>
-
-          <div className="py-5 px-3">
-            <div className="flex gap-3 items-center">
+        <div className="px-4 pt-6 pb-4">
+          <div className="flex gap-3">
+            <div className="flex flex-col gap-1.5 flex-1">
+              <span className="text-[11px] font-medium text-grayA-9">Baseline</span>
               <DeploymentSelect
                 value={selectedFromDeployment}
                 onValueChange={(value) => {
@@ -128,13 +105,16 @@ export default function DiffPage() {
                   }
                 }}
                 deployments={sortedDeployments}
-                isLoading={deployments.isLoading}
+                isLoading={deploymentsLoading}
                 placeholder="Select baseline..."
                 disabledDeploymentId={selectedToDeployment}
               />
+            </div>
 
-              <ArrowRight className="shrink-0 text-gray-9 size-[14px]" iconSize="sm-regular" />
+            <ArrowRight className="shrink-0 text-gray-9 size-[14px] mt-8.5" iconSize="sm-regular" />
 
+            <div className="flex flex-col gap-1.5 flex-1">
+              <span className="text-[11px] font-medium text-grayA-9">Comparison</span>
               <DeploymentSelect
                 value={selectedToDeployment}
                 onValueChange={(value) => {
@@ -144,14 +124,16 @@ export default function DiffPage() {
                   }
                 }}
                 deployments={sortedDeployments}
-                isLoading={deployments.isLoading}
+                isLoading={deploymentsLoading}
                 placeholder="Select comparison..."
                 disabledDeploymentId={selectedFromDeployment}
               />
             </div>
           </div>
+        </div>
 
-          {/* Content Area */}
+        {/* Content Area */}
+        <div className="bg-gray-1 rounded-b-[14px] border-t border-gray-4">
           {showEmptyState && (
             <div className="flex flex-col items-center gap-4 px-8 py-12 text-center">
               <div className="relative">
@@ -218,6 +200,6 @@ export default function DiffPage() {
           )}
         </div>
       </Card>
-    </ProjectContentWrapper>
+    </div>
   );
 }

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/advanced-settings/openapi-spec-path.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/advanced-settings/openapi-spec-path.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { BracketsCurly } from "@unkey/icons";
+import { FormInput } from "@unkey/ui";
+import { useEffect } from "react";
+import { useForm, useWatch } from "react-hook-form";
+import { z } from "zod";
+import { useEnvironmentSettings } from "../../environment-provider";
+import { useUpdateAllEnvironments } from "../../hooks/use-update-all-environments";
+import { FormSettingCard, resolveSaveState } from "../shared/form-setting-card";
+import { RemoveButton } from "../shared/remove-button";
+
+const openapiSpecPathSchema = z.object({
+  openapiSpecPath: z.string().max(512),
+});
+
+export const OpenapiSpecPath = () => {
+  const { settings, variant } = useEnvironmentSettings();
+  const { openapiSpecPath } = settings;
+  const updateAllEnvironments = useUpdateAllEnvironments();
+
+  const defaultValue = openapiSpecPath ?? "";
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    control,
+    formState: { isValid, isSubmitting, errors },
+  } = useForm<z.infer<typeof openapiSpecPathSchema>>({
+    resolver: zodResolver(openapiSpecPathSchema),
+    mode: "onChange",
+    defaultValues: { openapiSpecPath: defaultValue },
+  });
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: we gucci
+  useEffect(() => {
+    reset({ openapiSpecPath: defaultValue });
+  }, [defaultValue, reset]);
+
+  const current = useWatch({ control, name: "openapiSpecPath" });
+  const hasChanges = current !== defaultValue;
+
+  const saveState = resolveSaveState([
+    [isSubmitting, { status: "saving" }],
+    [!isValid, { status: "disabled" }],
+    [!hasChanges, { status: "disabled", reason: "No changes to save" }],
+  ]);
+
+  const onSubmit = (values: z.infer<typeof openapiSpecPathSchema>) => {
+    const trimmed = values.openapiSpecPath.trim();
+    updateAllEnvironments((draft) => {
+      draft.openapiSpecPath = trimmed === "" ? null : trimmed;
+    });
+  };
+
+  const handleRemove = () => {
+    updateAllEnvironments((draft) => {
+      draft.openapiSpecPath = null;
+    });
+    reset({ openapiSpecPath: "" });
+  };
+
+  return (
+    <FormSettingCard
+      icon={<BracketsCurly className="text-gray-12" iconSize="xl-medium" />}
+      title="OpenAPI Spec Path"
+      description="Path to your OpenAPI spec. Leave empty to disable scraping."
+      displayValue={
+        openapiSpecPath ? (
+          <span className="text-gray-12 text-xs">{openapiSpecPath}</span>
+        ) : null
+      }
+      onSubmit={handleSubmit(onSubmit)}
+      saveState={saveState}
+      autoSave={variant === "onboarding"}
+    >
+      <div className="flex flex-col gap-2 w-[480px]">
+        <span className="text-gray-11 text-[13px]">OpenAPI Spec Path</span>
+        <div className="relative flex items-start gap-3">
+          <FormInput
+            description="Path your deployment serves the OpenAPI spec (e.g. /openapi.yaml). Changes apply on next deploy."
+            placeholder="/openapi.yaml"
+            className="flex-1 [&_input]:font-mono"
+            error={errors.openapiSpecPath?.message}
+            variant={errors.openapiSpecPath ? "error" : "default"}
+            {...register("openapiSpecPath")}
+          />
+          {openapiSpecPath && (
+            <RemoveButton onClick={handleRemove} className="absolute -right-11 top-0" />
+          )}
+        </div>
+      </div>
+    </FormSettingCard>
+  );
+};

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/deployment-settings.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/deployment-settings.tsx
@@ -12,6 +12,7 @@ import { Cpu } from "./components/runtime-settings/cpu";
 import { Healthcheck } from "./components/runtime-settings/healthcheck";
 import { Instances } from "./components/runtime-settings/instances";
 import { Memory } from "./components/runtime-settings/memory";
+import { OpenapiSpecPath } from "./components/advanced-settings/openapi-spec-path";
 import { Port } from "./components/runtime-settings/port-settings";
 import { Regions } from "./components/runtime-settings/regions";
 
@@ -67,6 +68,7 @@ export const DeploymentSettings = ({
         <SettingCardGroup>
           <EnvVars />
           <CustomDomains />
+          <OpenapiSpecPath />
         </SettingCardGroup>
       </SettingsGroup>
       <SettingsGroup

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/environment-provider.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/environment-provider.tsx
@@ -37,6 +37,8 @@ export const EnvironmentSettingsProvider = ({ children }: PropsWithChildren) => 
     [getActiveEnvId],
   );
 
+  console.log(data)
+
   // Selected envs settings cannot but null because we apply some sane defaults to them
   const settings = data.at(0);
   if (!settings) {

--- a/web/apps/dashboard/lib/collections/deploy/domains.ts
+++ b/web/apps/dashboard/lib/collections/deploy/domains.ts
@@ -11,7 +11,7 @@ const schema = z.object({
   projectId: z.string(),
   deploymentId: z.string(),
   environmentId: z.string(),
-  sticky: z.enum(["none", "branch", "environment", "live"]),
+  sticky: z.enum(["none", "branch", "environment", "live", "deployment"]),
   createdAt: z.number(),
   updatedAt: z.number().nullable(),
 });

--- a/web/apps/dashboard/lib/collections/deploy/environment-settings.ts
+++ b/web/apps/dashboard/lib/collections/deploy/environment-settings.ts
@@ -45,6 +45,7 @@ const schema = z.object({
   regions: z.array(z.object({ id: z.string(), name: z.string(), replicas: z.number().int() })),
   shutdownSignal: z.string(),
   sentinelConfig: sentinelConfigSchema,
+  openapiSpecPath: z.string().nullable().default(null),
 });
 
 /**
@@ -133,6 +134,7 @@ function flattenSettingsResponse(
     })),
     shutdownSignal: "SIGTERM",
     sentinelConfig: runtime?.sentinelConfig,
+    openapiSpecPath: runtime?.openapiSpecPath ?? null,
   };
 }
 
@@ -244,6 +246,15 @@ export function buildSettingsMutations(
       trpcClient.deploy.environmentSettings.sentinel.updateMiddleware.mutate({
         environmentId,
         keyspaceIds: extractKeyspaceIds(modified.sentinelConfig),
+      }),
+    );
+  }
+
+  if (modified.openapiSpecPath !== original.openapiSpecPath) {
+    mutations.push(
+      trpcClient.deploy.environmentSettings.runtime.updateOpenapiSpecPath.mutate({
+        environmentId,
+        openapiSpecPath: modified.openapiSpecPath,
       }),
     );
   }

--- a/web/apps/dashboard/lib/trpc/routers/deploy/deployment/getOpenApiDiff.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/deployment/getOpenApiDiff.ts
@@ -63,6 +63,7 @@ export const getOpenApiDiff = workspaceProcedure
         oldDeploymentId: input.oldDeploymentId,
         newDeploymentId: input.newDeploymentId,
       });
+      console.log({ resp })
 
       return {
         hasBreakingChanges: resp.hasBreakingChanges,

--- a/web/apps/dashboard/lib/trpc/routers/deploy/deployment/list.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/deployment/list.ts
@@ -22,12 +22,14 @@ export const listDeployments = workspaceProcedure
           gitCommitAuthorAvatarUrl: true,
           gitCommitTimestamp: true,
           status: true,
-          openapiSpec: true,
           cpuMillicores: true,
           memoryMib: true,
           createdAt: true,
         },
         with: {
+          openapiSpec: {
+            columns: { id: true },
+          },
           instances: {
             columns: {
               id: true,

--- a/web/apps/dashboard/lib/trpc/routers/deploy/deployment/runtime-logs.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/deployment/runtime-logs.ts
@@ -34,7 +34,6 @@ export const getDeploymentRuntimeLogs = workspaceProcedure
       projectId: deployment.projectId,
       deploymentId: deployment.id,
       environmentId: deployment.environmentId,
-      appId: deployment.appId,
       limit: input.limit,
       startTime: deployment.createdAt,
       endTime: Date.now(),

--- a/web/apps/dashboard/lib/trpc/routers/deploy/environment-settings/runtime/update-openapi-spec-path.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/environment-settings/runtime/update-openapi-spec-path.ts
@@ -1,0 +1,40 @@
+import { and, db, eq } from "@/lib/db";
+import { TRPCError } from "@trpc/server";
+import { appRuntimeSettings, environments } from "@unkey/db/src/schema";
+import { z } from "zod";
+import { workspaceProcedure } from "../../../../trpc";
+
+export const updateOpenapiSpecPath = workspaceProcedure
+  .input(
+    z.object({
+      environmentId: z.string(),
+      openapiSpecPath: z.string().max(512).nullable(),
+    }),
+  )
+  .mutation(async ({ ctx, input }) => {
+    const env = await db.query.environments.findFirst({
+      where: and(
+        eq(environments.id, input.environmentId),
+        eq(environments.workspaceId, ctx.workspace.id),
+      ),
+      columns: { appId: true },
+    });
+    if (!env) {
+      throw new TRPCError({ code: "NOT_FOUND", message: "Environment not found" });
+    }
+
+    await db
+      .insert(appRuntimeSettings)
+      .values({
+        workspaceId: ctx.workspace.id,
+        appId: env.appId,
+        environmentId: input.environmentId,
+        openapiSpecPath: input.openapiSpecPath,
+        sentinelConfig: "{}",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      })
+      .onDuplicateKeyUpdate({
+        set: { openapiSpecPath: input.openapiSpecPath, updatedAt: Date.now() },
+      });
+  });

--- a/web/apps/dashboard/lib/trpc/routers/deploy/runtime-logs/query.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/runtime-logs/query.ts
@@ -14,13 +14,34 @@ export const queryRuntimeLogs = workspaceProcedure
   .input(runtimeLogsRequestSchema)
   .output(runtimeLogsResponseSchema)
   .query(async ({ ctx, input }) => {
+    const workspace = await db.query.workspaces
+      .findFirst({
+        where: (table, { and, eq, isNull }) =>
+          and(eq(table.id, ctx.workspace.id), isNull(table.deletedAtM)),
+      })
+      .catch((_err) => {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message:
+            "Failed to retrieve logs due to an error. If this issue persists, please contact support@unkey.com.",
+        });
+      });
+
+    if (!workspace) {
+      throw new TRPCError({
+        code: "NOT_FOUND",
+        message: "Workspace not found, please contact support using support@unkey.com.",
+      });
+    }
+
     const project = await db.query.projects.findFirst({
       where: (table, { and, eq }) =>
-        and(eq(table.id, input.projectId), eq(table.workspaceId, ctx.workspace.id)),
+        and(eq(table.id, input.projectId), eq(table.workspaceId, workspace.id)),
       columns: { id: true },
       with: {
         environments: {
-          columns: { id: true, appId: true },
+          columns: { id: true },
+          limit: 1,
         },
       },
     });
@@ -32,11 +53,8 @@ export const queryRuntimeLogs = workspaceProcedure
       });
     }
 
-    const environment = input.environmentId
-      ? project.environments.find((e) => e.id === input.environmentId)
-      : project.environments[0];
-
-    if (!environment) {
+    const environmentId = input.environmentId ?? project.environments[0]?.id;
+    if (!environmentId) {
       throw new TRPCError({
         code: "NOT_FOUND",
         message: "No environment found for this project",
@@ -46,11 +64,10 @@ export const queryRuntimeLogs = workspaceProcedure
     const transformedInputs = transformFilters(input);
     const { logsQuery, totalQuery } = await clickhouse.runtimeLogs.logs({
       ...transformedInputs,
-      workspaceId: ctx.workspace.id,
+      workspaceId: workspace.id,
       projectId: project.id,
       deploymentId: input.deploymentId ?? null,
-      environmentId: environment.id,
-      appId: environment.appId,
+      environmentId,
     });
 
     const [countResult, logsResult] = await Promise.all([totalQuery, logsQuery]);

--- a/web/apps/dashboard/lib/trpc/routers/deploy/runtime-logs/utils.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/runtime-logs/utils.ts
@@ -4,10 +4,7 @@ import type { RuntimeLogsRequest } from "@unkey/clickhouse/src/runtime-logs";
 
 export function transformFilters(
   params: RuntimeLogsRequestSchema,
-): Omit<
-  RuntimeLogsRequest,
-  "workspaceId" | "projectId" | "environmentId" | "deploymentId" | "appId"
-> {
+): Omit<RuntimeLogsRequest, "workspaceId" | "projectId" | "environmentId" | "deploymentId"> {
   const severity = params.severity?.filters?.map((f) => f.value) || [];
 
   let startTime = params.startTime;

--- a/web/apps/dashboard/lib/trpc/routers/index.ts
+++ b/web/apps/dashboard/lib/trpc/routers/index.ts
@@ -69,6 +69,7 @@ import { updateHealthcheck } from "./deploy/environment-settings/runtime/update-
 import { updateInstances } from "./deploy/environment-settings/runtime/update-instances";
 import { updateMemory } from "./deploy/environment-settings/runtime/update-memory";
 import { updatePort } from "./deploy/environment-settings/runtime/update-port";
+import { updateOpenapiSpecPath } from "./deploy/environment-settings/runtime/update-openapi-spec-path";
 import { updateRegions } from "./deploy/environment-settings/runtime/update-regions";
 import { updateMiddleware } from "./deploy/environment-settings/sentinel/update-middleware";
 import { getDeploymentLatency } from "./deploy/metrics/get-deployment-latency";
@@ -423,6 +424,7 @@ export const router = t.router({
         updateHealthcheck,
         updateRegions,
         updateInstances,
+        updateOpenapiSpecPath,
       }),
       build: t.router({
         updateDockerfile,

--- a/web/internal/clickhouse/src/runtime-logs.ts
+++ b/web/internal/clickhouse/src/runtime-logs.ts
@@ -8,7 +8,6 @@ export const runtimeLogsRequestSchema = z.object({
   projectId: z.string(),
   deploymentId: z.string().nullable(),
   environmentId: z.string(),
-  appId: z.string(),
   limit: z.int(),
   startTime: z.int(),
   endTime: z.int(),
@@ -40,7 +39,6 @@ export function getRuntimeLogs(ch: Querier) {
         OR deployment_id = assumeNotNull({deploymentId: Nullable(String)})
       )
       AND environment_id = {environmentId: String}
-      AND app_id = {appId: String}
       AND time BETWEEN {startTime: UInt64} AND {endTime: UInt64}
 
       AND (


### PR DESCRIPTION
## What does this PR do?

This PR enhances the OpenAPI diff functionality by improving the UI/UX, adding proper type safety, and implementing OpenAPI spec path configuration.

**Key changes:**
- Replaces generated protobuf types with local TypeScript types for better type safety
- Enables automatic query execution when both deployment IDs are available
- Adds OpenAPI spec path configuration in environment settings
- Improves the diff viewer UI with better styling, method-specific badges, and cleaner layout
- Extracts deployment fetching logic into a reusable hook
- Adds breadcrumb navigation for the OpenAPI diff page
- Removes TypeScript error suppressions and console.log statements
- Updates domain sticky options to include "deployment"
- Simplifies runtime logs queries by removing appId dependency

## Type of change

- [x] Enhancement (small improvements)
- [x] New feature (non-breaking change which adds functionality)
- [x] Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

- Navigate to a project's OpenAPI diff page and verify the improved UI renders correctly
- Test deployment comparison functionality with automatic query execution
- Verify OpenAPI spec path can be configured in environment settings
- Test that method badges display with appropriate colors (GET=primary, POST=success, DELETE=error, etc.)
- Confirm breadcrumb navigation works properly
- Test runtime logs functionality still works without appId dependency

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [x] Ran `make fmt` on `/go` directory
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary