### PR TITLE
fix: avatar misalignment

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/components/table/deployments-list.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/components/table/deployments-list.tsx
@@ -170,14 +170,19 @@ export const DeploymentsList = () => {
                 </div>
                 <div className="min-w-0">
                   <div className="flex items-center gap-1.5 font-mono text-[13px]">
-                    <span className="truncate text-accent-12 max-w-25" title={deployment.gitBranch}>{deployment.gitBranch}</span>
+                    <span className="truncate text-accent-12 max-w-25" title={deployment.gitBranch}>
+                      {deployment.gitBranch}
+                    </span>
                     <span className="text-gray-6 shrink-0">·</span>
                     <span className="text-gray-9 shrink-0">
                       {deployment.gitCommitSha?.slice(0, 7)}
                     </span>
                   </div>
                   {deployment.gitCommitMessage ? (
-                    <div className="truncate text-xs text-gray-9 max-w-50" title={deployment.gitCommitMessage}>
+                    <div
+                      className="truncate text-xs text-gray-9 max-w-50"
+                      title={deployment.gitCommitMessage}
+                    >
                       {deployment.gitCommitMessage}
                     </div>
                   ) : null}


### PR DESCRIPTION
## What does this PR do?

Fixes avatar misalignment when commit message or branch is too long.

Before:
<img width="1606" height="220" alt="image" src="https://github.com/user-attachments/assets/882d494f-5cf7-41c0-9a0b-1d3382669e3d" />


After:
<img width="1609" height="206" alt="image" src="https://github.com/user-attachments/assets/97b76e17-23e3-4f2c-8384-c3932f125b34" />
