### PR TITLE
fix: attr overflow caused by pre tag

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/logs/components/table/runtime-log-details/index.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/logs/components/table/runtime-log-details/index.tsx
@@ -69,10 +69,7 @@ export function RuntimeLogDetails({ distanceToTop }: Props) {
         />
 
         {log.attributes && (
-          <LogSection
-            title="Attributes"
-            details={JSON.stringify(log.attributes, null, 2)}
-          />
+          <LogSection title="Attributes" details={JSON.stringify(log.attributes, null, 2)} />
         )}
       </SharedLogDetails.CustomSections>
     </SharedLogDetails>


### PR DESCRIPTION
## What does this PR do?

Fixes overflow issue of runtime logs details caused by pre tag.


Before: 
<img width="554" height="1235" alt="Screenshot 2026-03-17 at 10 31 18" src="https://github.com/user-attachments/assets/578b63da-28ec-4327-8135-a2a5f2cfa57e" />
After:
<img width="958" height="1272" alt="Screenshot 2026-03-17 at 10 31 09" src="https://github.com/user-attachments/assets/7a928b55-124b-47e6-ac58-f8935435a919" />

