### PR TITLE
fix: port scroll issue

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/runtime-settings/port-settings.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/runtime-settings/port-settings.tsx
@@ -54,6 +54,10 @@ export const Port = () => {
       <FormInput
         required
         type="number"
+        onWheelCapture={(e) => {
+          //@ts-expect-error there is no other way to prevent scroll here
+          e.target.blur();
+        }}
         className="w-[480px]"
         label="Port"
         description="Port your application listens on. Changes apply on next deploy."

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/shared/setting-description.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/shared/setting-description.tsx
@@ -6,7 +6,7 @@ type SettingDescriptionProps = {
 
 export const SettingDescription: React.FC<SettingDescriptionProps> = ({ children }) => {
   return (
-    <div className="text-[13px] leading-5 mt-1">
+    <div className="text-[13px] leading-5 mt-1 max-w-[480px]">
       <output className="text-gray-9 flex gap-2 items-start">
         <CircleInfo iconSize="md-medium" className="shrink-0 mt-[3px]" aria-hidden="true" />
         <span className="flex-1 text-gray-10">{children}</span>


### PR DESCRIPTION
## What does this PR do?

This PR prevents scroll for number input for Port setting. Otherwise it hijacks scroll and changes port without users noticing. Also fixes small long text issue in slider description.