### PR TITLE
chore: disable github action cron for staging

### DIFF
--- a/.github/workflows/restate_scheduled_tasks.yml
+++ b/.github/workflows/restate_scheduled_tasks.yml
@@ -27,7 +27,7 @@ jobs:
     if: github.event.schedule == '0 15 * * *' || github.event.inputs.task == 'all' || github.event.inputs.task == 'quota-check'
     strategy:
       matrix:
-        environment: [restate_production, restate_staging]
+        environment: [restate_production]
     environment: ${{ matrix.environment }}
     runs-on: ubuntu-latest
     steps:
@@ -51,7 +51,7 @@ jobs:
     if: github.event.schedule == '0 3 * * *' || github.event.inputs.task == 'all' || github.event.inputs.task == 'cert-renewal'
     strategy:
       matrix:
-        environment: [restate_production, restate_staging]
+        environment: [restate_production]
     environment: ${{ matrix.environment }}
     runs-on: ubuntu-latest
     steps:
@@ -71,7 +71,7 @@ jobs:
     if: github.event.schedule == '0 0 * * *' || github.event.inputs.task == 'all' || github.event.inputs.task == 'key-refill'
     strategy:
       matrix:
-        environment: [restate_production, restate_staging]
+        environment: [restate_production]
     environment: ${{ matrix.environment }}
     runs-on: ubuntu-latest
     steps:
@@ -95,7 +95,7 @@ jobs:
     if: github.event.schedule == '*/15 * * * *' || github.event.inputs.task == 'all' || github.event.inputs.task == 'scale-down-idle-deployments'
     strategy:
       matrix:
-        environment: [restate_production, restate_staging]
+        environment: [restate_production]
     environment: ${{ matrix.environment }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## What does this PR do?

Removes `restate_staging` environment from all scheduled task jobs in the GitHub workflow, leaving only `restate_production` environment to run the quota-check, cert-renewal, key-refill, and scale-down-idle-deployments tasks.

Fixes # (issue)

_If there is not an issue for this, please create one first. This is used to tracking purposes and also helps us understand why this PR exists_

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Verify that scheduled tasks only run against production environment
- Confirm that manual workflow triggers respect the environment matrix change
- Check that all four job types (quota-check, cert-renewal, key-refill, scale-down-idle-deployments) execute only in production

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary