### PR TITLE
fix: invalidate repo tree on repo installation

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/build-settings/github-settings/github-connected.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/build-settings/github-settings/github-connected.tsx
@@ -18,6 +18,7 @@ export const GitHubConnected = ({
     onSuccess: async () => {
       toast.success("Repository disconnected");
       await utils.github.getInstallations.invalidate();
+      await utils.github.getRepoTree.invalidate();
     },
     onError: (error) => {
       toast.error(error.message);

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/build-settings/github-settings/github-no-repo.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/build-settings/github-settings/github-no-repo.tsx
@@ -29,6 +29,7 @@ export const GitHubNoRepo = ({
     onSuccess: async () => {
       toast.success("Repository connected");
       await utils.github.getInstallations.invalidate();
+      await utils.github.getRepoTree.invalidate();
     },
     onError: (error) => {
       toast.error(error.message);

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/new/steps/select-repo/index.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/new/steps/select-repo/index.tsx
@@ -35,6 +35,7 @@ export const SelectRepo = ({
   const selectRepoMutation = trpc.github.selectRepository.useMutation({
     onSuccess: async (_data, variables) => {
       trpcUtils.github.getInstallations.invalidate();
+      trpcUtils.github.getRepoTree.invalidate();
       const name =
         variables.repositoryFullName.length > 40
           ? `${variables.repositoryFullName.slice(0, 37)}...`


### PR DESCRIPTION
## What does this PR do?

Adds cache invalidation for `github.getRepoTree` query when connecting or disconnecting GitHub repositories to ensure the repository tree data stays synchronized with the current connection state.

The changes add `await utils.github.getRepoTree.invalidate()` calls in three locations:
- When disconnecting a repository in GitHub settings
- When connecting a repository in GitHub settings  
- When selecting a repository during project creation

Fixes # (issue)

_If there is not an issue for this, please create one first. This is used to tracking purposes and also helps us understand why this PR exists_

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Connect a GitHub repository and verify the repository tree updates immediately
- Disconnect a GitHub repository and verify the repository tree clears/updates appropriately
- Create a new project and select a repository, ensuring the tree data reflects the selection

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary