### PR TITLE
fix: dev seed script using wrong region id

### DIFF
--- a/cmd/dev/seed/local.go
+++ b/cmd/dev/seed/local.go
@@ -243,6 +243,17 @@ func seedLocal(ctx context.Context, cmd *cli.Command) error {
 			return fmt.Errorf("failed to create region: %w", err)
 		}
 
+		// The upsert is a no-op on duplicate (name, platform), so the existing row keeps
+		// its original ID. We must read back the actual ID to use in regional settings.
+		existingRegion, err := db.Query.FindRegionByPlatformAndName(ctx, tx, db.FindRegionByPlatformAndNameParams{
+			Platform: "dev",
+			Name:     "local",
+		})
+		if err != nil {
+			return fmt.Errorf("failed to find region after upsert: %w", err)
+		}
+		regionID = existingRegion.ID
+
 		// Create regional settings so deployments work without manually saving each environment
 		err = db.BulkQuery.UpsertAppRegionalSettings(ctx, tx, []db.UpsertAppRegionalSettingsParams{
 			{


### PR DESCRIPTION
## What does this PR do?

Fixes an issue in the local seeding process where the region ID was not being properly retrieved after upserting a region. The upsert operation is a no-op when a region with the same name and platform already exists, which means the original ID is preserved. This change adds a query to fetch the actual region ID after the upsert operation to ensure the correct ID is used when creating regional settings.

Fixes # (issue)

_If there is not an issue for this, please create one first. This is used to tracking purposes and also helps us understand why this PR exists_

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Run the local seeding command multiple times to ensure it works correctly on both initial runs and subsequent runs
- Verify that regional settings are created with the correct region ID
- Test that deployments work properly after seeding

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary