### PR TITLE
fix: show skipped deployment as skipped in overview

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/(deployment-progress)/skipped-deployment-view.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/(deployment-progress)/skipped-deployment-view.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { Ban, Github } from "@unkey/icons";
+import { Button } from "@unkey/ui";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { useProjectData } from "../../../data-provider";
+
+export function SkippedDeploymentView() {
+  const { projectId } = useProjectData();
+  const params = useParams();
+  const workspaceSlug = params.workspaceSlug as string;
+
+  return (
+    <div className="flex flex-col items-center gap-8 py-12 animate-fade-slide-in">
+      {/* Flow diagram */}
+      <div className="flex items-center gap-0">
+        {/* GitHub circle */}
+        <div className="size-12 rounded-full border border-gray-6 bg-gray-2 flex items-center justify-center">
+          <Github iconSize="xl-regular" className="text-gray-12" />
+        </div>
+
+        {/* Dashed line */}
+        <div className="w-12 border-t border-dashed border-gray-6" />
+
+        {/* Skip circle */}
+        <div className="size-12 rounded-full border border-gray-6 bg-gray-2 flex items-center justify-center">
+          <Ban iconSize="xl-regular" className="text-gray-9" />
+        </div>
+      </div>
+
+      {/* Title and description */}
+      <div className="flex flex-col items-center gap-2 max-w-md text-center">
+        <h2 className="text-lg font-semibold text-gray-12">Deployment Skipped</h2>
+        <p className="text-sm text-gray-9">
+          No changed files matched the configured watch paths. This deployment was automatically
+          skipped.
+        </p>
+      </div>
+
+      {/* Settings link */}
+      <Link href={`/${workspaceSlug}/projects/${projectId}/settings`}>
+        <Button variant="ghost" size="sm">
+          Configure Watch Paths
+        </Button>
+      </Link>
+    </div>
+  );
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/deployment-utils.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/deployment-utils.ts
@@ -10,6 +10,7 @@ const DEPLOYMENT_STATUSES: ReadonlySet<string> = new Set<DeploymentStatus>([
   "finalizing",
   "ready",
   "failed",
+  "skipped",
 ]);
 
 function isDeploymentStatus(value: string): value is DeploymentStatus {

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/page.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/page.tsx
@@ -6,6 +6,7 @@ import { ProjectContentWrapper } from "../../../components/project-content-wrapp
 import { useProjectData } from "../../data-provider";
 import { DeploymentInfo } from "./(deployment-progress)/deployment-info";
 import { DeploymentProgress } from "./(deployment-progress)/deployment-progress";
+import { SkippedDeploymentView } from "./(deployment-progress)/skipped-deployment-view";
 import { DeploymentNetworkSection } from "./(overview)/components/sections/deployment-network-section";
 import { deriveStatusFromSteps } from "./deployment-utils";
 import { useDeployment } from "./layout-provider";
@@ -15,15 +16,20 @@ export default function DeploymentOverview() {
   const { refetchDomains } = useProjectData();
 
   const ready = deployment.status === "ready";
+  const skipped = deployment.status === "skipped";
 
   const stepsQuery = trpc.deploy.deployment.steps.useQuery(
     { deploymentId: deployment.id },
-    { refetchInterval: ready ? false : 1_000, refetchOnWindowFocus: false },
+    {
+      refetchInterval: ready || skipped ? false : 1_000,
+      refetchOnWindowFocus: false,
+      enabled: !skipped,
+    },
   );
 
   const derivedStatus = useMemo(
-    () => deriveStatusFromSteps(stepsQuery.data, deployment.status),
-    [stepsQuery.data, deployment.status],
+    () => (skipped ? "skipped" as const : deriveStatusFromSteps(stepsQuery.data, deployment.status)),
+    [stepsQuery.data, deployment.status, skipped],
   );
 
   useEffect(() => {
@@ -36,7 +42,11 @@ export default function DeploymentOverview() {
   return (
     <ProjectContentWrapper centered>
       <DeploymentInfo statusOverride={derivedStatus} />
-      {ready ? (
+      {skipped ? (
+        <div key="skipped" className="animate-fade-slide-in">
+          <SkippedDeploymentView />
+        </div>
+      ) : ready ? (
         <div key="ready" className="flex flex-col gap-5 animate-fade-slide-in">
           <DeploymentDomainsCard />
           <DeploymentNetworkSection />


### PR DESCRIPTION
## What does this PR do?

Adds support for displaying skipped deployments in the dashboard. When a deployment is skipped due to no changed files matching the configured watch paths, users now see a dedicated view with a visual flow diagram showing GitHub → Skip, along with an explanation and a link to configure watch paths.

The implementation includes:
- New `SkippedDeploymentView` component with visual indicators and user guidance
- Added "skipped" status to the deployment status validation
- Updated deployment page logic to handle skipped deployments by disabling step queries and showing the appropriate view
- Conditional rendering based on deployment status with proper animations

![image.png](https://app.graphite.com/user-attachments/assets/f980b5f1-ca2e-4854-95e6-61fa3362859e.png)

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Create a deployment that gets skipped due to watch path configuration
- Navigate to the deployment page and verify the skipped deployment view displays correctly
- Verify the "Configure Watch Paths" button links to the correct settings page
- Test that the visual flow diagram renders properly with GitHub and Ban icons
- Confirm that step queries are disabled for skipped deployments to avoid unnecessary API calls

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary