### PR TITLE
fix: sentinel pdbspec

### DIFF
--- a/svc/krane/internal/sentinel/apply.go
+++ b/svc/krane/internal/sentinel/apply.go
@@ -385,6 +385,7 @@ func (c *Controller) ensurePDBExists(ctx context.Context, sentinel *ctrlv1.Apply
 	// the majority available.
 	var pdbSpec policyv1.PodDisruptionBudgetSpec
 	if sentinel.GetReplicas() <= 1 {
+		//nolint:exhaustruct
 		pdbSpec = policyv1.PodDisruptionBudgetSpec{
 			MinAvailable: ptr.P(intstr.FromInt(1)),
 			Selector: &metav1.LabelSelector{
@@ -392,6 +393,7 @@ func (c *Controller) ensurePDBExists(ctx context.Context, sentinel *ctrlv1.Apply
 			},
 		}
 	} else {
+		//nolint:exhaustruct
 		pdbSpec = policyv1.PodDisruptionBudgetSpec{
 			MaxUnavailable: ptr.P(intstr.FromInt(1)),
 			Selector: &metav1.LabelSelector{


### PR DESCRIPTION
## What does this PR do?

Improves PodDisruptionBudget configuration for sentinel deployments by implementing replica-aware disruption policies. Single-replica sentinels now use `MinAvailable=1` to prevent eviction of the last pod during voluntary disruptions like node drains, while multi-replica sentinels use `MaxUnavailable=1` to allow rolling disruptions while maintaining majority availability.

Fixes #4873

_If there is not an issue for this, please create one first. This is used to tracking purposes and also helps us understand why this PR exists_

## Type of change

- [x] Enhancement (small improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Deploy a single-replica sentinel and verify PDB uses `MinAvailable=1`
- Deploy a multi-replica sentinel and verify PDB uses `MaxUnavailable=1`
- Test node drain scenarios to ensure single-replica sentinels are protected from eviction
- Test rolling updates on multi-replica sentinels to ensure proper disruption handling

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary