### PR TITLE
fix: allow me some more ports

### DIFF
--- a/web/apps/dashboard/lib/trpc/routers/deploy/environment-settings/runtime/update-port.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/environment-settings/runtime/update-port.ts
@@ -8,7 +8,7 @@ export const updatePort = workspaceProcedure
   .input(
     z.object({
       environmentId: z.string(),
-      port: z.number().int().min(2000).max(54000),
+      port: z.number().int().min(1).max(65535),
     }),
   )
   .mutation(async ({ ctx, input }) => {


### PR DESCRIPTION
## What does this PR do?

Expands the allowed port range for environment runtime settings from 2000-54000 to the full valid port range of 1-65535.

Fixes # (issue)

_If there is not an issue for this, please create one first. This is used to tracking purposes and also helps us understand why this PR exists_

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Test updating environment port with values below 2000 (e.g., 80, 443, 1000)
- Test updating environment port with values above 54000 (e.g., 60000, 65535)
- Verify that ports outside the valid range (0, 65536+) are still rejected

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary