### PR TITLE
fix: watch path overfill

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/build-settings/watch-paths-settings.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/build-settings/watch-paths-settings.tsx
@@ -16,7 +16,7 @@ import { SettingDescription } from "../shared/setting-description";
 const watchPathsSchema = z.object({
   paths: z.array(
     z.object({
-      value: z.string().min(1, "Pattern cannot be empty"),
+      value: z.string(),
     }),
   ),
 });
@@ -45,6 +45,7 @@ export const WatchPaths = () => {
     handleSubmit,
     formState: { isValid, isSubmitting, errors },
     control,
+    reset,
   } = useForm<WatchPathsForm>({
     resolver: zodResolver(watchPathsSchema),
     mode: "onChange",
@@ -91,9 +92,20 @@ export const WatchPaths = () => {
     updateAllEnvironments((draft) => {
       draft.watchPaths = watchPaths;
     });
+    reset({ paths: toFormPaths(watchPaths) });
   };
 
-  const displayValue = defaultPaths.length > 0 ? defaultPaths.join(", ") : "All files (no filter)";
+  const displayValue =
+    defaultPaths.length > 0 ? (
+      <span className="flex items-center gap-1 truncate">
+        <span className="truncate">{defaultPaths[0]}</span>
+        {defaultPaths.length > 1 && (
+          <span className="shrink-0 text-gray-9">+{defaultPaths.length - 1}</span>
+        )}
+      </span>
+    ) : (
+      "All files (no filter)"
+    );
 
   return (
     <FormSettingCard

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/shared/selected-config.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/shared/selected-config.tsx
@@ -11,7 +11,7 @@ export const SelectedConfig = ({ label, className = "" }: SelectedConfigProps) =
     <Badge
       variant="secondary"
       className={cn(
-        "px-3 py-2 text-gray-11 text-[13px] border-grayA-4 bg-transparent hover:bg-grayA-3 cursor-default hover:text-gray-12 rounded-md focus:hover:bg-transparent h-7",
+        "px-3 py-2 text-gray-11 text-[13px] border-grayA-4 bg-transparent hover:bg-grayA-3 cursor-default hover:text-gray-12 rounded-md focus:hover:bg-transparent h-7 max-w-full overflow-hidden",
         className,
       )}
     >


### PR DESCRIPTION
## What does this PR do?

This PR improves the watch paths settings UI by removing the empty pattern validation requirement, adding form reset functionality after successful updates, and enhancing the display of multiple watch paths with a truncated view that shows the first path plus a count indicator for additional paths.

The changes also add overflow handling to the selected config badge component to prevent layout issues with long content.

![image.png](https://app.graphite.com/user-attachments/assets/c4752d6e-fa9a-42e4-b1fa-ccf9dc9347ae.png)

Fixes #5381

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Navigate to project settings > build settings > watch paths
- Add multiple watch paths and verify the display shows the first path with a "+N" indicator
- Test that empty patterns are now allowed in the form
- Verify that the form resets properly after saving changes
- Check that long path names don't break the layout

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary