### PR TITLE
fix: prevent dockerfile detect warning appear when its not missing

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/build-settings/dockerfile-settings.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/build-settings/dockerfile-settings.tsx
@@ -32,7 +32,7 @@ export const Dockerfile = () => {
     defaultValues: { dockerfile: defaultValue },
   });
 
-  const currentDockerfile = useWatch({ control, name: "dockerfile" });
+  const currentDockerfile = useWatch({ control, name: "dockerfile", defaultValue });
 
   const validation = validateDockerfilePath(currentDockerfile, dockerContext);
   const caseMatch =

--- a/web/apps/dashboard/lib/collections/deploy/environment-settings.ts
+++ b/web/apps/dashboard/lib/collections/deploy/environment-settings.ts
@@ -122,8 +122,8 @@ function flattenSettingsResponse(
 ): EnvironmentSettings {
   return {
     environmentId,
-    dockerfile: build?.dockerfile ?? "Dockerfile",
-    dockerContext: build?.dockerContext ?? ".",
+    dockerfile: build?.dockerfile || "Dockerfile",
+    dockerContext: build?.dockerContext || ".",
     watchPaths: build?.watchPaths ?? [],
     port: runtime?.port ?? 8080,
     cpuMillicores: runtime?.cpuMillicores ?? 256,


### PR DESCRIPTION
## What does this PR do?

Before that it was like this even if there was a valid dockerfile
<img width="1088" height="941" alt="Screenshot 2026-03-23 at 13 31 11" src="https://github.com/user-attachments/assets/9fb351b7-2d3f-4d3b-a726-bf58b9be843b" />
