### PR TITLE
feat: ignore delete/created branches

### DIFF
--- a/svc/ctrl/api/github_webhook.go
+++ b/svc/ctrl/api/github_webhook.go
@@ -79,6 +79,9 @@ func (s *GitHubWebhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		s.handlePush(r.Context(), w, body, deliveryID)
 	case "pull_request":
 		s.handlePullRequest(r.Context(), w, body, deliveryID)
+	case "create", "delete":
+		logger.Info("Branch lifecycle event ignored", "event", event)
+		w.WriteHeader(http.StatusOK)
 	case "installation":
 		logger.Info("Installation event received")
 		w.WriteHeader(http.StatusOK)
@@ -97,6 +100,19 @@ func (s *GitHubWebhook) handlePush(ctx context.Context, w http.ResponseWriter, b
 	if err := json.Unmarshal(body, &payload); err != nil {
 		logger.Error("failed to parse push payload", "error", err)
 		http.Error(w, "failed to parse push payload", http.StatusBadRequest)
+		return
+	}
+
+	// Branch deletions and restorations don't need deployments.
+	// Deleted branches have no code to build; restored branches are
+	// just re-created refs pointing at an existing commit.
+	if payload.Deleted || payload.Created {
+		logger.Info("Ignoring branch delete/restore push",
+			"ref", payload.Ref,
+			"deleted", payload.Deleted,
+			"created", payload.Created,
+		)
+		w.WriteHeader(http.StatusOK)
 		return
 	}
 

--- a/svc/ctrl/api/github_webhook_integration_test.go
+++ b/svc/ctrl/api/github_webhook_integration_test.go
@@ -77,6 +77,49 @@ func TestGitHubWebhook_Push_ProcessesFork(t *testing.T) {
 	}
 }
 
+func TestGitHubWebhook_Push_IgnoresDeletedBranch(t *testing.T) {
+	pushRequests := make(chan *hydrav1.HandlePushRequest, 1)
+	harness := newWebhookHarness(t, webhookHarnessConfig{
+		Services: []restate.ServiceDefinition{hydrav1.NewGitHubWebhookServiceServer(&mockGitHubWebhookService{requests: pushRequests})},
+	})
+
+	payload := newTestPushPayload(testRepoFullName, false)
+	payload.Deleted = true
+	payload.After = "0000000000000000000000000000000000000000"
+
+	resp, err := sendWebhook(fmt.Sprintf("%s/webhooks/github", harness.CtrlURL), mustMarshal(t, payload), harness.Secret)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	_ = resp.Body.Close()
+
+	select {
+	case <-pushRequests:
+		t.Fatal("unexpected HandlePush invocation for deleted branch")
+	case <-time.After(1 * time.Second):
+	}
+}
+
+func TestGitHubWebhook_Push_IgnoresRestoredBranch(t *testing.T) {
+	pushRequests := make(chan *hydrav1.HandlePushRequest, 1)
+	harness := newWebhookHarness(t, webhookHarnessConfig{
+		Services: []restate.ServiceDefinition{hydrav1.NewGitHubWebhookServiceServer(&mockGitHubWebhookService{requests: pushRequests})},
+	})
+
+	payload := newTestPushPayload(testRepoFullName, false)
+	payload.Created = true
+
+	resp, err := sendWebhook(fmt.Sprintf("%s/webhooks/github", harness.CtrlURL), mustMarshal(t, payload), harness.Secret)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	_ = resp.Body.Close()
+
+	select {
+	case <-pushRequests:
+		t.Fatal("unexpected HandlePush invocation for restored branch")
+	case <-time.After(1 * time.Second):
+	}
+}
+
 func TestGitHubWebhook_InvalidSignature(t *testing.T) {
 	pushRequests := make(chan *hydrav1.HandlePushRequest, 1)
 	harness := newWebhookHarness(t, webhookHarnessConfig{

--- a/svc/ctrl/api/types.go
+++ b/svc/ctrl/api/types.go
@@ -3,6 +3,8 @@ package api
 type pushPayload struct {
 	Ref          string           `json:"ref"`
 	After        string           `json:"after"`
+	Created      bool             `json:"created"`
+	Deleted      bool             `json:"deleted"`
 	Installation pushInstallation `json:"installation"`
 	Repository   pushRepository   `json:"repository"`
 	Commits      []pushCommit     `json:"commits"`


### PR DESCRIPTION
## What does this PR do?

Adds handling for GitHub branch lifecycle events to prevent unnecessary deployment triggers. The webhook now ignores branch creation/deletion events and push events for deleted or restored branches, since these operations don't require new deployments.

Fixes #5383

## Type of change

- [x] Enhancement (small improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Test that `create` and `delete` webhook events return HTTP 200 without triggering deployments
- Test that push events with `deleted: true` are ignored and don't invoke HandlePush
- Test that push events with `created: true` are ignored and don't invoke HandlePush
- Verify existing push event handling continues to work for normal commits

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary