### PR TITLE
fix: dont require approval for main pushes

### DIFF
--- a/svc/ctrl/worker/githubwebhook/handle_push.go
+++ b/svc/ctrl/worker/githubwebhook/handle_push.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"os"
-	"strings"
 	"time"
 
 	restate "github.com/restatedev/sdk-go"
@@ -192,15 +191,24 @@ func (s *Service) HandlePush(ctx restate.ObjectContext, req *hydrav1.HandlePushR
 }
 
 // requiresApproval determines whether a push needs manual approval.
-// Bot accounts (ending in [bot]) and repo collaborators are auto-approved.
+// Fork PRs always require approval. Non-fork pushes are auto-approved because
+// GitHub already enforces write access — if someone can push to the repo, they
+// are authorized.
 //
-// Set FORCE_DEPLOYMENT_APPROVAL=true to bypass collaborator checks and always
-// require approval. This is useful for testing the approval flow locally.
+// Set FORCE_DEPLOYMENT_APPROVAL=true to require approval for all pushes.
+// This is useful for testing the approval flow locally.
 func (s *Service) requiresApproval(
-	ctx restate.ObjectContext,
+	_ restate.ObjectContext,
 	req *hydrav1.HandlePushRequest,
-	repo db.GithubRepoConnection,
+	_ db.GithubRepoConnection,
 ) bool {
+	if os.Getenv("FORCE_DEPLOYMENT_APPROVAL") == "true" {
+		logger.Info("FORCE_DEPLOYMENT_APPROVAL is set, requiring approval",
+			"sender", req.GetSenderLogin(),
+		)
+		return true
+	}
+
 	// Fork PRs always require approval — external code must never auto-deploy.
 	if req.GetIsForkPr() {
 		logger.Info("fork PR deployment requires approval",
@@ -209,43 +217,9 @@ func (s *Service) requiresApproval(
 		return true
 	}
 
-	if os.Getenv("FORCE_DEPLOYMENT_APPROVAL") == "true" {
-		logger.Info("FORCE_DEPLOYMENT_APPROVAL is set, requiring approval",
-			"sender", req.GetSenderLogin(),
-		)
-		return true
-	}
-
-	senderLogin := req.GetSenderLogin()
-
-	// Bot accounts are trusted (GitHub controls the [bot] suffix)
-	if strings.HasSuffix(senderLogin, "[bot]") {
-		return false
-	}
-
-	// No sender info — fail closed, require approval
-	if senderLogin == "" {
-		logger.Info("no sender login in push event, requiring approval")
-		return true
-	}
-
-	isCollaborator, err := restate.Run(ctx, func(_ restate.RunContext) (bool, error) {
-		return s.github.IsCollaborator(
-			repo.InstallationID,
-			req.GetRepositoryFullName(),
-			senderLogin,
-		)
-	}, restate.WithName("check collaborator status"), restate.WithMaxRetryDuration(30*time.Second))
-	if err != nil {
-		// Fail closed: treat errors as non-collaborator to prevent bypassing protection.
-		logger.Error("failed to check collaborator status, blocking deployment",
-			"sender", senderLogin,
-			"error", err,
-		)
-		return true
-	}
-
-	return !isCollaborator
+	// Non-fork pushes: GitHub already verified the pusher has write access to
+	// the repo, so there is no reason to gate the deployment behind approval.
+	return false
 }
 
 // insertDeploymentRecord creates a deployment and its initial queued step in a single transaction.


### PR DESCRIPTION
## What does this PR do?

Simplifies the deployment approval logic for GitHub webhook push events. Previously, the system checked if the sender was a bot account or repository collaborator to determine auto-approval. Now, the logic is streamlined: fork PRs always require approval (since external code should never auto-deploy), while non-fork pushes are auto-approved because GitHub already enforces write access verification.

This removes the collaborator status check and bot account detection, relying instead on GitHub's existing access controls. The `FORCE_DEPLOYMENT_APPROVAL` environment variable is preserved for testing purposes.

Fixes # (issue)

## Type of change

- [x] Enhancement (small improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Test fork PR deployments still require approval
- Test non-fork pushes are auto-approved
- Test `FORCE_DEPLOYMENT_APPROVAL=true` forces approval for all pushes
- Verify no collaborator API calls are made during push handling

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary