### PR TITLE
feat: add ClickHouse schema for container resource metering

### DIFF
--- a/pkg/clickhouse/schema/025_container_resources_raw_v1.sql
+++ b/pkg/clickhouse/schema/025_container_resources_raw_v1.sql
@@ -1,0 +1,31 @@
+CREATE TABLE container_resources_raw_v1 (
+  -- unix milli
+  time Int64 CODEC(Delta, LZ4),
+  workspace_id String CODEC(ZSTD(1)),
+  project_id String CODEC(ZSTD(1)),
+  app_id String CODEC(ZSTD(1)),
+  environment_id String CODEC(ZSTD(1)),
+  deployment_id String CODEC(ZSTD(1)),
+  instance_id String CODEC(ZSTD(1)),
+  region LowCardinality(String),
+  platform LowCardinality(String),
+  -- Actual usage (from kubelet)
+  cpu_millicores Float64 CODEC(ZSTD(1)),
+  memory_working_set_bytes Int64 CODEC(Delta, LZ4),
+  -- Allocated resources (from pod spec)
+  cpu_request_millicores Int32 CODEC(Delta, LZ4),
+  cpu_limit_millicores Int32 CODEC(Delta, LZ4),
+  memory_request_bytes Int64 CODEC(Delta, LZ4),
+  memory_limit_bytes Int64 CODEC(Delta, LZ4),
+  -- Network egress (delta since last sample)
+  network_tx_bytes Int64 CODEC(Delta, LZ4),
+  -- Public egress only (non-RFC1918 destinations, from Cilium Hubble)
+  network_tx_bytes_public Int64 CODEC(Delta, LZ4),
+  INDEX idx_workspace_id (workspace_id) TYPE bloom_filter(0.001) GRANULARITY 1,
+  INDEX idx_app_id (app_id) TYPE bloom_filter(0.001) GRANULARITY 1,
+  INDEX idx_deployment_id (deployment_id) TYPE bloom_filter(0.001) GRANULARITY 1
+) ENGINE = MergeTree()
+ORDER BY (workspace_id, app_id, deployment_id, time)
+PARTITION BY toDate(fromUnixTimestamp64Milli(time))
+TTL toDateTime(fromUnixTimestamp64Milli(time)) + toIntervalDay(90)
+SETTINGS index_granularity = 8192, non_replicated_deduplication_window = 10000;

--- a/pkg/clickhouse/schema/026_deployment_lifecycle_events_v1.sql
+++ b/pkg/clickhouse/schema/026_deployment_lifecycle_events_v1.sql
@@ -1,0 +1,24 @@
+CREATE TABLE deployment_lifecycle_events_v1 (
+  -- unix milli (ms-precise)
+  time Int64 CODEC(Delta, LZ4),
+  workspace_id String CODEC(ZSTD(1)),
+  project_id String CODEC(ZSTD(1)),
+  app_id String CODEC(ZSTD(1)),
+  environment_id String CODEC(ZSTD(1)),
+  deployment_id String CODEC(ZSTD(1)),
+  region LowCardinality(String),
+  platform LowCardinality(String),
+  -- "started", "stopped", "scaled"
+  event LowCardinality(String),
+  replicas Int32 CODEC(Delta, LZ4),
+  -- Per-replica resource limits at this moment
+  cpu_limit_millicores Int32 CODEC(Delta, LZ4),
+  memory_limit_bytes Int64 CODEC(Delta, LZ4),
+  INDEX idx_workspace_id (workspace_id) TYPE bloom_filter(0.001) GRANULARITY 1,
+  INDEX idx_app_id (app_id) TYPE bloom_filter(0.001) GRANULARITY 1,
+  INDEX idx_deployment_id (deployment_id) TYPE bloom_filter(0.001) GRANULARITY 1
+) ENGINE = MergeTree()
+ORDER BY (workspace_id, app_id, deployment_id, time)
+PARTITION BY toDate(fromUnixTimestamp64Milli(time))
+TTL toDateTime(fromUnixTimestamp64Milli(time)) + toIntervalDay(365)
+SETTINGS index_granularity = 8192, non_replicated_deduplication_window = 10000;

--- a/pkg/clickhouse/schema/027_container_resources_per_minute_v1.sql
+++ b/pkg/clickhouse/schema/027_container_resources_per_minute_v1.sql
@@ -1,0 +1,45 @@
+CREATE TABLE container_resources_per_minute_v1 (
+  time DateTime,
+  workspace_id String,
+  project_id String,
+  app_id String,
+  environment_id String,
+  deployment_id String,
+  cpu_millicores_sum SimpleAggregateFunction(sum, Float64),
+  memory_bytes_max SimpleAggregateFunction(max, Int64),
+  memory_bytes_sum SimpleAggregateFunction(sum, Float64),
+  cpu_limit_millicores_max SimpleAggregateFunction(max, Int32),
+  memory_limit_bytes_max SimpleAggregateFunction(max, Int64),
+  network_tx_bytes_sum SimpleAggregateFunction(sum, Int64),
+  network_tx_bytes_public_sum SimpleAggregateFunction(sum, Int64),
+  sample_count SimpleAggregateFunction(sum, Int64)
+) ENGINE = AggregatingMergeTree()
+ORDER BY (workspace_id, app_id, deployment_id, time)
+PARTITION BY toStartOfDay(time)
+TTL time + INTERVAL 30 DAY DELETE;
+
+CREATE MATERIALIZED VIEW container_resources_per_minute_mv_v1
+TO container_resources_per_minute_v1 AS
+SELECT
+  toStartOfMinute(fromUnixTimestamp64Milli(time)) AS time,
+  workspace_id,
+  project_id,
+  app_id,
+  environment_id,
+  deployment_id,
+  sum(cpu_millicores) AS cpu_millicores_sum,
+  max(memory_working_set_bytes) AS memory_bytes_max,
+  sum(toFloat64(memory_working_set_bytes)) AS memory_bytes_sum,
+  max(cpu_limit_millicores) AS cpu_limit_millicores_max,
+  max(memory_limit_bytes) AS memory_limit_bytes_max,
+  sum(network_tx_bytes) AS network_tx_bytes_sum,
+  sum(network_tx_bytes_public) AS network_tx_bytes_public_sum,
+  count() AS sample_count
+FROM container_resources_raw_v1
+GROUP BY
+  time,
+  workspace_id,
+  project_id,
+  app_id,
+  environment_id,
+  deployment_id;

--- a/pkg/clickhouse/schema/028_container_resources_per_hour_v1.sql
+++ b/pkg/clickhouse/schema/028_container_resources_per_hour_v1.sql
@@ -1,0 +1,45 @@
+CREATE TABLE container_resources_per_hour_v1 (
+  time DateTime,
+  workspace_id String,
+  project_id String,
+  app_id String,
+  environment_id String,
+  deployment_id String,
+  cpu_millicores_sum SimpleAggregateFunction(sum, Float64),
+  memory_bytes_max SimpleAggregateFunction(max, Int64),
+  memory_bytes_sum SimpleAggregateFunction(sum, Float64),
+  cpu_limit_millicores_max SimpleAggregateFunction(max, Int32),
+  memory_limit_bytes_max SimpleAggregateFunction(max, Int64),
+  network_tx_bytes_sum SimpleAggregateFunction(sum, Int64),
+  network_tx_bytes_public_sum SimpleAggregateFunction(sum, Int64),
+  sample_count SimpleAggregateFunction(sum, Int64)
+) ENGINE = AggregatingMergeTree()
+ORDER BY (workspace_id, app_id, deployment_id, time)
+PARTITION BY toStartOfDay(time)
+TTL time + INTERVAL 90 DAY DELETE;
+
+CREATE MATERIALIZED VIEW container_resources_per_hour_mv_v1
+TO container_resources_per_hour_v1 AS
+SELECT
+  toStartOfHour(time) AS time,
+  workspace_id,
+  project_id,
+  app_id,
+  environment_id,
+  deployment_id,
+  sum(cpu_millicores_sum) AS cpu_millicores_sum,
+  max(memory_bytes_max) AS memory_bytes_max,
+  sum(memory_bytes_sum) AS memory_bytes_sum,
+  max(cpu_limit_millicores_max) AS cpu_limit_millicores_max,
+  max(memory_limit_bytes_max) AS memory_limit_bytes_max,
+  sum(network_tx_bytes_sum) AS network_tx_bytes_sum,
+  sum(network_tx_bytes_public_sum) AS network_tx_bytes_public_sum,
+  sum(sample_count) AS sample_count
+FROM container_resources_per_minute_v1
+GROUP BY
+  time,
+  workspace_id,
+  project_id,
+  app_id,
+  environment_id,
+  deployment_id;

--- a/pkg/clickhouse/schema/029_container_resources_per_day_v1.sql
+++ b/pkg/clickhouse/schema/029_container_resources_per_day_v1.sql
@@ -1,0 +1,44 @@
+CREATE TABLE container_resources_per_day_v1 (
+  time Date,
+  workspace_id String,
+  project_id String,
+  app_id String,
+  environment_id String,
+  deployment_id String,
+  cpu_millicores_sum SimpleAggregateFunction(sum, Float64),
+  memory_bytes_max SimpleAggregateFunction(max, Int64),
+  memory_bytes_sum SimpleAggregateFunction(sum, Float64),
+  cpu_limit_millicores_max SimpleAggregateFunction(max, Int32),
+  memory_limit_bytes_max SimpleAggregateFunction(max, Int64),
+  network_tx_bytes_sum SimpleAggregateFunction(sum, Int64),
+  network_tx_bytes_public_sum SimpleAggregateFunction(sum, Int64),
+  sample_count SimpleAggregateFunction(sum, Int64)
+) ENGINE = AggregatingMergeTree()
+ORDER BY (workspace_id, app_id, deployment_id, time)
+TTL time + INTERVAL 365 DAY DELETE;
+
+CREATE MATERIALIZED VIEW container_resources_per_day_mv_v1
+TO container_resources_per_day_v1 AS
+SELECT
+  toStartOfDay(time) AS time,
+  workspace_id,
+  project_id,
+  app_id,
+  environment_id,
+  deployment_id,
+  sum(cpu_millicores_sum) AS cpu_millicores_sum,
+  max(memory_bytes_max) AS memory_bytes_max,
+  sum(memory_bytes_sum) AS memory_bytes_sum,
+  max(cpu_limit_millicores_max) AS cpu_limit_millicores_max,
+  max(memory_limit_bytes_max) AS memory_limit_bytes_max,
+  sum(network_tx_bytes_sum) AS network_tx_bytes_sum,
+  sum(network_tx_bytes_public_sum) AS network_tx_bytes_public_sum,
+  sum(sample_count) AS sample_count
+FROM container_resources_per_hour_v1
+GROUP BY
+  time,
+  workspace_id,
+  project_id,
+  app_id,
+  environment_id,
+  deployment_id;

--- a/pkg/clickhouse/schema/030_container_resources_per_month_v1.sql
+++ b/pkg/clickhouse/schema/030_container_resources_per_month_v1.sql
@@ -1,0 +1,43 @@
+CREATE TABLE container_resources_per_month_v1 (
+  time Date,
+  workspace_id String,
+  project_id String,
+  app_id String,
+  environment_id String,
+  deployment_id String,
+  cpu_millicores_sum SimpleAggregateFunction(sum, Float64),
+  memory_bytes_max SimpleAggregateFunction(max, Int64),
+  memory_bytes_sum SimpleAggregateFunction(sum, Float64),
+  cpu_limit_millicores_max SimpleAggregateFunction(max, Int32),
+  memory_limit_bytes_max SimpleAggregateFunction(max, Int64),
+  network_tx_bytes_sum SimpleAggregateFunction(sum, Int64),
+  network_tx_bytes_public_sum SimpleAggregateFunction(sum, Int64),
+  sample_count SimpleAggregateFunction(sum, Int64)
+) ENGINE = AggregatingMergeTree()
+ORDER BY (workspace_id, app_id, deployment_id, time);
+
+CREATE MATERIALIZED VIEW container_resources_per_month_mv_v1
+TO container_resources_per_month_v1 AS
+SELECT
+  toStartOfMonth(time) AS time,
+  workspace_id,
+  project_id,
+  app_id,
+  environment_id,
+  deployment_id,
+  sum(cpu_millicores_sum) AS cpu_millicores_sum,
+  max(memory_bytes_max) AS memory_bytes_max,
+  sum(memory_bytes_sum) AS memory_bytes_sum,
+  max(cpu_limit_millicores_max) AS cpu_limit_millicores_max,
+  max(memory_limit_bytes_max) AS memory_limit_bytes_max,
+  sum(network_tx_bytes_sum) AS network_tx_bytes_sum,
+  sum(network_tx_bytes_public_sum) AS network_tx_bytes_public_sum,
+  sum(sample_count) AS sample_count
+FROM container_resources_per_day_v1
+GROUP BY
+  time,
+  workspace_id,
+  project_id,
+  app_id,
+  environment_id,
+  deployment_id;

--- a/pkg/clickhouse/schema/types.go
+++ b/pkg/clickhouse/schema/types.go
@@ -123,6 +123,45 @@ type BuildStepLogV1 struct {
 	Message      string `ch:"message" json:"message"`
 }
 
+// ContainerResource represents the v1 container resource usage raw table structure.
+// This tracks per-instance CPU, memory, and network usage for billing.
+type ContainerResource struct {
+	Time                  int64   `ch:"time" json:"time"`
+	WorkspaceID           string  `ch:"workspace_id" json:"workspace_id"`
+	ProjectID             string  `ch:"project_id" json:"project_id"`
+	AppID                 string  `ch:"app_id" json:"app_id"`
+	EnvironmentID         string  `ch:"environment_id" json:"environment_id"`
+	DeploymentID          string  `ch:"deployment_id" json:"deployment_id"`
+	InstanceID            string  `ch:"instance_id" json:"instance_id"`
+	Region                string  `ch:"region" json:"region"`
+	Platform              string  `ch:"platform" json:"platform"`
+	CPUMillicores         float64 `ch:"cpu_millicores" json:"cpu_millicores"`
+	MemoryWorkingSetBytes int64   `ch:"memory_working_set_bytes" json:"memory_working_set_bytes"`
+	CPURequestMillicores  int32   `ch:"cpu_request_millicores" json:"cpu_request_millicores"`
+	CPULimitMillicores    int32   `ch:"cpu_limit_millicores" json:"cpu_limit_millicores"`
+	MemoryRequestBytes    int64   `ch:"memory_request_bytes" json:"memory_request_bytes"`
+	MemoryLimitBytes      int64   `ch:"memory_limit_bytes" json:"memory_limit_bytes"`
+	NetworkTxBytes        int64   `ch:"network_tx_bytes" json:"network_tx_bytes"`
+	NetworkTxBytesPublic  int64   `ch:"network_tx_bytes_public" json:"network_tx_bytes_public"`
+}
+
+// DeploymentLifecycleEvent represents the v1 deployment lifecycle events table structure.
+// This tracks when deployments start, stop, or scale with ms-precise timestamps for billing.
+type DeploymentLifecycleEvent struct {
+	Time               int64  `ch:"time" json:"time"`
+	WorkspaceID        string `ch:"workspace_id" json:"workspace_id"`
+	ProjectID          string `ch:"project_id" json:"project_id"`
+	AppID              string `ch:"app_id" json:"app_id"`
+	EnvironmentID      string `ch:"environment_id" json:"environment_id"`
+	DeploymentID       string `ch:"deployment_id" json:"deployment_id"`
+	Region             string `ch:"region" json:"region"`
+	Platform           string `ch:"platform" json:"platform"`
+	Event              string `ch:"event" json:"event"`
+	Replicas           int32  `ch:"replicas" json:"replicas"`
+	CPULimitMillicores int32  `ch:"cpu_limit_millicores" json:"cpu_limit_millicores"`
+	MemoryLimitBytes   int64  `ch:"memory_limit_bytes" json:"memory_limit_bytes"`
+}
+
 // SentinelRequest represents the v1 sentinel request raw table structure.
 // This tracks requests routed through sentinel proxy to deployment instances
 // with deployment routing, performance breakdown, and error categorization.


### PR DESCRIPTION
## What does this PR do?

Adds ClickHouse schema for container resource monitoring and deployment lifecycle tracking. Creates a raw data table for container resource usage metrics (CPU, memory, network) and deployment events (started, stopped, scaled), along with pre-aggregated tables for minute, hour, day, and month intervals with automatic materialized views for efficient querying.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Verify ClickHouse schema migrations apply successfully
- Test inserting container resource data into the raw table
- Test inserting deployment lifecycle events
- Verify materialized views automatically aggregate data correctly
- Test querying aggregated tables at different time intervals
- Verify TTL policies are working as expected

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary