### PR TITLE
fix: apply sentinel with metric/trace config

### DIFF
--- a/svc/krane/internal/sentinel/apply.go
+++ b/svc/krane/internal/sentinel/apply.go
@@ -149,8 +149,12 @@ func (c *Controller) ensureSentinelExists(ctx context.Context, sentinel *ctrlv1.
 				SampleRate:    1.0,
 				SlowThreshold: time.Second,
 			},
-			Tracing: nil,
-			Metrics: nil,
+			Tracing: &config.TracingConfig{
+				SampleRate: 0.25,
+			},
+			Metrics: &config.MetricsConfig{
+				PrometheusPort: MetricsPort,
+			},
 		},
 		Gossip: nil,
 		Pprof: &config.PprofConfig{
@@ -258,6 +262,7 @@ func (c *Controller) ensureSentinelExists(ctx context.Context, sentinel *ctrlv1.
 							{ContainerPort: SentinelPort, Name: "sentinel"},
 							{ContainerPort: GossipLANPort, Name: "gossip-lan", Protocol: corev1.ProtocolTCP},
 							{ContainerPort: GossipLANPort, Name: "gossip-lan-udp", Protocol: corev1.ProtocolUDP},
+							{ContainerPort: MetricsPort, Name: "metrics"},
 						},
 
 						LivenessProbe: &corev1.Probe{

--- a/svc/krane/internal/sentinel/consts.go
+++ b/svc/krane/internal/sentinel/consts.go
@@ -12,6 +12,9 @@ const (
 	// GossipLANPort is the port used for gossip protocol LAN communication between sentinel pods.
 	GossipLANPort = 7946
 
+	// MetricsPort is the port for Prometheus metrics.
+	MetricsPort = 9090
+
 	// SentinelNodeClass is the node class for sentinel workloads.
 	SentinelNodeClass = "sentinel"
 


### PR DESCRIPTION
## What does this PR do?

Enables metrics collection for sentinel pods by configuring Prometheus metrics on port 9090. This change adds tracing configuration with a 25% sample rate and exposes a metrics endpoint through the container port configuration.

Fixes # (issue)

_If there is not an issue for this, please create one first. This is used to tracking purposes and also helps us understand why this PR exists_

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Deploy a sentinel pod and verify the metrics port 9090 is exposed
- Confirm Prometheus can scrape metrics from the /metrics endpoint
- Validate tracing is working with the configured 25% sample rate

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary