### PR TITLE
perf: add indexes to make our queries happy

### DIFF
--- a/pkg/db/key_find_for_verification.sql_generated.go
+++ b/pkg/db/key_find_for_verification.sql_generated.go
@@ -59,18 +59,24 @@ select k.id,
        coalesce(
                (select json_arrayagg(
                     json_object(
-                       'id', rl.id,
-                       'name', rl.name,
-                       'key_id', rl.key_id,
-                       'identity_id', rl.identity_id,
-                       'limit', rl.limit,
-                       'duration', rl.duration,
-                       'auto_apply', rl.auto_apply
+                       'id', id,
+                       'name', name,
+                       'key_id', key_id,
+                       'identity_id', identity_id,
+                       'limit', ` + "`" + `limit` + "`" + `,
+                       'duration', duration,
+                       'auto_apply', auto_apply
                     )
                 )
-                from ` + "`" + `ratelimits` + "`" + ` rl
-                where rl.key_id = k.id
-                   OR rl.identity_id = i.id),
+                from (
+                    select rl.id, rl.name, rl.key_id, rl.identity_id, rl.` + "`" + `limit` + "`" + `, rl.duration, rl.auto_apply
+                    from ` + "`" + `ratelimits` + "`" + ` rl
+                    where rl.key_id = k.id
+                    UNION ALL
+                    select rl.id, rl.name, rl.key_id, rl.identity_id, rl.` + "`" + `limit` + "`" + `, rl.duration, rl.auto_apply
+                    from ` + "`" + `ratelimits` + "`" + ` rl
+                    where rl.identity_id = i.id
+                ) as combined_rl),
                json_array()
        ) as ratelimits,
 
@@ -170,18 +176,24 @@ type FindKeyForVerificationRow struct {
 //	       coalesce(
 //	               (select json_arrayagg(
 //	                    json_object(
-//	                       'id', rl.id,
-//	                       'name', rl.name,
-//	                       'key_id', rl.key_id,
-//	                       'identity_id', rl.identity_id,
-//	                       'limit', rl.limit,
-//	                       'duration', rl.duration,
-//	                       'auto_apply', rl.auto_apply
+//	                       'id', id,
+//	                       'name', name,
+//	                       'key_id', key_id,
+//	                       'identity_id', identity_id,
+//	                       'limit', `limit`,
+//	                       'duration', duration,
+//	                       'auto_apply', auto_apply
 //	                    )
 //	                )
-//	                from `ratelimits` rl
-//	                where rl.key_id = k.id
-//	                   OR rl.identity_id = i.id),
+//	                from (
+//	                    select rl.id, rl.name, rl.key_id, rl.identity_id, rl.`limit`, rl.duration, rl.auto_apply
+//	                    from `ratelimits` rl
+//	                    where rl.key_id = k.id
+//	                    UNION ALL
+//	                    select rl.id, rl.name, rl.key_id, rl.identity_id, rl.`limit`, rl.duration, rl.auto_apply
+//	                    from `ratelimits` rl
+//	                    where rl.identity_id = i.id
+//	                ) as combined_rl),
 //	               json_array()
 //	       ) as ratelimits,
 //

--- a/pkg/db/key_find_live_by_hash.sql_generated.go
+++ b/pkg/db/key_find_live_by_hash.sql_generated.go
@@ -74,17 +74,24 @@ SELECT
     COALESCE(
         (SELECT JSON_ARRAYAGG(
             JSON_OBJECT(
-                'id', rl.id,
-                'name', rl.name,
-                'key_id', rl.key_id,
-                'identity_id', rl.identity_id,
-                'limit', rl.` + "`" + `limit` + "`" + `,
-                'duration', rl.duration,
-                'auto_apply', rl.auto_apply = 1
+                'id', id,
+                'name', name,
+                'key_id', key_id,
+                'identity_id', identity_id,
+                'limit', ` + "`" + `limit` + "`" + `,
+                'duration', duration,
+                'auto_apply', auto_apply = 1
             )
         )
-        FROM ratelimits rl
-        WHERE rl.key_id = k.id OR rl.identity_id = i.id),
+        FROM (
+            SELECT rl.id, rl.name, rl.key_id, rl.identity_id, rl.` + "`" + `limit` + "`" + `, rl.duration, rl.auto_apply
+            FROM ratelimits rl
+            WHERE rl.key_id = k.id
+            UNION ALL
+            SELECT rl.id, rl.name, rl.key_id, rl.identity_id, rl.` + "`" + `limit` + "`" + `, rl.duration, rl.auto_apply
+            FROM ratelimits rl
+            WHERE rl.identity_id = i.id
+        ) AS combined_rl),
         JSON_ARRAY()
     ) as ratelimits
 
@@ -207,17 +214,24 @@ type FindLiveKeyByHashRow struct {
 //	    COALESCE(
 //	        (SELECT JSON_ARRAYAGG(
 //	            JSON_OBJECT(
-//	                'id', rl.id,
-//	                'name', rl.name,
-//	                'key_id', rl.key_id,
-//	                'identity_id', rl.identity_id,
-//	                'limit', rl.`limit`,
-//	                'duration', rl.duration,
-//	                'auto_apply', rl.auto_apply = 1
+//	                'id', id,
+//	                'name', name,
+//	                'key_id', key_id,
+//	                'identity_id', identity_id,
+//	                'limit', `limit`,
+//	                'duration', duration,
+//	                'auto_apply', auto_apply = 1
 //	            )
 //	        )
-//	        FROM ratelimits rl
-//	        WHERE rl.key_id = k.id OR rl.identity_id = i.id),
+//	        FROM (
+//	            SELECT rl.id, rl.name, rl.key_id, rl.identity_id, rl.`limit`, rl.duration, rl.auto_apply
+//	            FROM ratelimits rl
+//	            WHERE rl.key_id = k.id
+//	            UNION ALL
+//	            SELECT rl.id, rl.name, rl.key_id, rl.identity_id, rl.`limit`, rl.duration, rl.auto_apply
+//	            FROM ratelimits rl
+//	            WHERE rl.identity_id = i.id
+//	        ) AS combined_rl),
 //	        JSON_ARRAY()
 //	    ) as ratelimits
 //

--- a/pkg/db/querier_generated.go
+++ b/pkg/db/querier_generated.go
@@ -731,18 +731,24 @@ type Querier interface {
 	//         coalesce(
 	//                 (select json_arrayagg(
 	//                      json_object(
-	//                         'id', rl.id,
-	//                         'name', rl.name,
-	//                         'key_id', rl.key_id,
-	//                         'identity_id', rl.identity_id,
-	//                         'limit', rl.limit,
-	//                         'duration', rl.duration,
-	//                         'auto_apply', rl.auto_apply
+	//                         'id', id,
+	//                         'name', name,
+	//                         'key_id', key_id,
+	//                         'identity_id', identity_id,
+	//                         'limit', `limit`,
+	//                         'duration', duration,
+	//                         'auto_apply', auto_apply
 	//                      )
 	//                  )
-	//                  from `ratelimits` rl
-	//                  where rl.key_id = k.id
-	//                     OR rl.identity_id = i.id),
+	//                  from (
+	//                      select rl.id, rl.name, rl.key_id, rl.identity_id, rl.`limit`, rl.duration, rl.auto_apply
+	//                      from `ratelimits` rl
+	//                      where rl.key_id = k.id
+	//                      UNION ALL
+	//                      select rl.id, rl.name, rl.key_id, rl.identity_id, rl.`limit`, rl.duration, rl.auto_apply
+	//                      from `ratelimits` rl
+	//                      where rl.identity_id = i.id
+	//                  ) as combined_rl),
 	//                 json_array()
 	//         ) as ratelimits,
 	//
@@ -872,17 +878,24 @@ type Querier interface {
 	//      COALESCE(
 	//          (SELECT JSON_ARRAYAGG(
 	//              JSON_OBJECT(
-	//                  'id', rl.id,
-	//                  'name', rl.name,
-	//                  'key_id', rl.key_id,
-	//                  'identity_id', rl.identity_id,
-	//                  'limit', rl.`limit`,
-	//                  'duration', rl.duration,
-	//                  'auto_apply', rl.auto_apply = 1
+	//                  'id', id,
+	//                  'name', name,
+	//                  'key_id', key_id,
+	//                  'identity_id', identity_id,
+	//                  'limit', `limit`,
+	//                  'duration', duration,
+	//                  'auto_apply', auto_apply = 1
 	//              )
 	//          )
-	//          FROM ratelimits rl
-	//          WHERE rl.key_id = k.id OR rl.identity_id = i.id),
+	//          FROM (
+	//              SELECT rl.id, rl.name, rl.key_id, rl.identity_id, rl.`limit`, rl.duration, rl.auto_apply
+	//              FROM ratelimits rl
+	//              WHERE rl.key_id = k.id
+	//              UNION ALL
+	//              SELECT rl.id, rl.name, rl.key_id, rl.identity_id, rl.`limit`, rl.duration, rl.auto_apply
+	//              FROM ratelimits rl
+	//              WHERE rl.identity_id = i.id
+	//          ) AS combined_rl),
 	//          JSON_ARRAY()
 	//      ) as ratelimits
 	//

--- a/pkg/db/queries/key_find_for_verification.sql
+++ b/pkg/db/queries/key_find_for_verification.sql
@@ -47,18 +47,24 @@ select k.id,
        coalesce(
                (select json_arrayagg(
                     json_object(
-                       'id', rl.id,
-                       'name', rl.name,
-                       'key_id', rl.key_id,
-                       'identity_id', rl.identity_id,
-                       'limit', rl.limit,
-                       'duration', rl.duration,
-                       'auto_apply', rl.auto_apply
+                       'id', id,
+                       'name', name,
+                       'key_id', key_id,
+                       'identity_id', identity_id,
+                       'limit', `limit`,
+                       'duration', duration,
+                       'auto_apply', auto_apply
                     )
                 )
-                from `ratelimits` rl
-                where rl.key_id = k.id
-                   OR rl.identity_id = i.id),
+                from (
+                    select rl.id, rl.name, rl.key_id, rl.identity_id, rl.`limit`, rl.duration, rl.auto_apply
+                    from `ratelimits` rl
+                    where rl.key_id = k.id
+                    UNION ALL
+                    select rl.id, rl.name, rl.key_id, rl.identity_id, rl.`limit`, rl.duration, rl.auto_apply
+                    from `ratelimits` rl
+                    where rl.identity_id = i.id
+                ) as combined_rl),
                json_array()
        ) as ratelimits,
 

--- a/pkg/db/queries/key_find_live_by_hash.sql
+++ b/pkg/db/queries/key_find_live_by_hash.sql
@@ -62,17 +62,24 @@ SELECT
     COALESCE(
         (SELECT JSON_ARRAYAGG(
             JSON_OBJECT(
-                'id', rl.id,
-                'name', rl.name,
-                'key_id', rl.key_id,
-                'identity_id', rl.identity_id,
-                'limit', rl.`limit`,
-                'duration', rl.duration,
-                'auto_apply', rl.auto_apply = 1
+                'id', id,
+                'name', name,
+                'key_id', key_id,
+                'identity_id', identity_id,
+                'limit', `limit`,
+                'duration', duration,
+                'auto_apply', auto_apply = 1
             )
         )
-        FROM ratelimits rl
-        WHERE rl.key_id = k.id OR rl.identity_id = i.id),
+        FROM (
+            SELECT rl.id, rl.name, rl.key_id, rl.identity_id, rl.`limit`, rl.duration, rl.auto_apply
+            FROM ratelimits rl
+            WHERE rl.key_id = k.id
+            UNION ALL
+            SELECT rl.id, rl.name, rl.key_id, rl.identity_id, rl.`limit`, rl.duration, rl.auto_apply
+            FROM ratelimits rl
+            WHERE rl.identity_id = i.id
+        ) AS combined_rl),
         JSON_ARRAY()
     ) as ratelimits
 

--- a/pkg/db/schema.sql
+++ b/pkg/db/schema.sql
@@ -776,12 +776,12 @@ CREATE TABLE `horizontal_autoscaling_policies` (
 
 CREATE INDEX `workspace_id_idx` ON `apis` (`workspace_id`);
 CREATE INDEX `workspace_id_idx` ON `roles` (`workspace_id`);
-CREATE INDEX `key_auth_id_deleted_at_idx` ON `keys` (`key_auth_id`,`deleted_at_m`);
+CREATE INDEX `key_auth_id_deleted_at_idx` ON `keys` (`key_auth_id`,`deleted_at_m`,`id`);
 CREATE INDEX `idx_keys_on_for_workspace_id` ON `keys` (`for_workspace_id`);
 CREATE INDEX `pending_migration_id_idx` ON `keys` (`pending_migration_id`);
 CREATE INDEX `idx_keys_on_workspace_id` ON `keys` (`workspace_id`);
 CREATE INDEX `owner_id_idx` ON `keys` (`owner_id`);
-CREATE INDEX `identity_id_idx` ON `keys` (`identity_id`);
+CREATE INDEX `identity_id_idx` ON `keys` (`identity_id`,`key_auth_id`,`id`);
 CREATE INDEX `idx_keys_refill` ON `keys` (`refill_amount`,`deleted_at_m`);
 CREATE INDEX `workspace_id_idx` ON `audit_log` (`workspace_id`);
 CREATE INDEX `bucket_id_idx` ON `audit_log` (`bucket_id`);

--- a/pkg/mysql/schema.sql
+++ b/pkg/mysql/schema.sql
@@ -776,12 +776,12 @@ CREATE TABLE `horizontal_autoscaling_policies` (
 
 CREATE INDEX `workspace_id_idx` ON `apis` (`workspace_id`);
 CREATE INDEX `workspace_id_idx` ON `roles` (`workspace_id`);
-CREATE INDEX `key_auth_id_deleted_at_idx` ON `keys` (`key_auth_id`,`deleted_at_m`);
+CREATE INDEX `key_auth_id_deleted_at_idx` ON `keys` (`key_auth_id`,`deleted_at_m`,`id`);
 CREATE INDEX `idx_keys_on_for_workspace_id` ON `keys` (`for_workspace_id`);
 CREATE INDEX `pending_migration_id_idx` ON `keys` (`pending_migration_id`);
 CREATE INDEX `idx_keys_on_workspace_id` ON `keys` (`workspace_id`);
 CREATE INDEX `owner_id_idx` ON `keys` (`owner_id`);
-CREATE INDEX `identity_id_idx` ON `keys` (`identity_id`);
+CREATE INDEX `identity_id_idx` ON `keys` (`identity_id`,`key_auth_id`,`id`);
 CREATE INDEX `idx_keys_refill` ON `keys` (`refill_amount`,`deleted_at_m`);
 CREATE INDEX `workspace_id_idx` ON `audit_log` (`workspace_id`);
 CREATE INDEX `bucket_id_idx` ON `audit_log` (`bucket_id`);

--- a/web/internal/db/src/schema/keys.ts
+++ b/web/internal/db/src/schema/keys.ts
@@ -95,12 +95,13 @@ export const keys = mysqlTable(
     keyAuthAndDeletedIndex: index("key_auth_id_deleted_at_idx").on(
       table.keyAuthId,
       table.deletedAtM,
+      table.id,
     ),
     forWorkspaceIdIndex: index("idx_keys_on_for_workspace_id").on(table.forWorkspaceId),
     pendingMigrationIdIndex: index("pending_migration_id_idx").on(table.pendingMigrationId),
     workspaceIdIndex: index("idx_keys_on_workspace_id").on(table.workspaceId),
     ownerIdIndex: index("owner_id_idx").on(table.ownerId),
-    identityIdIndex: index("identity_id_idx").on(table.identityId),
+    identityIdIndex: index("identity_id_idx").on(table.identityId, table.keyAuthId, table.id),
     refillIndex: index("idx_keys_refill").on(table.refillAmount, table.deletedAtM),
   }),
 );


### PR DESCRIPTION
## What does this PR do?

Refactors SQL queries for key lookup operations to use UNION ALL instead of OR conditions when fetching ratelimits, and adds database indexes to improve query performance.

The changes replace `WHERE rl.key_id = k.id OR rl.identity_id = i.id` with separate SELECT statements combined using UNION ALL, which allows the database to better utilize indexes. Additionally, composite indexes are added to the `keys` table to optimize lookups by `key_auth_id`, `deleted_at_m`, and `identity_id` combinations.

Fixes # (issue)

## Type of change

- [x] Enhancement (small improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Test key verification queries to ensure ratelimits are still properly retrieved
- Test key lookup by hash operations to verify functionality remains intact
- Performance test the queries to confirm improved execution times with the new indexes
- Verify that both key-level and identity-level ratelimits are correctly included in results

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary