### PR TITLE
chore: update docs for cronjob and alerts

### DIFF
--- a/docs/engineering/infra/deployments/cronjobs.mdx
+++ b/docs/engineering/infra/deployments/cronjobs.mdx
@@ -66,6 +66,7 @@ If Restate sees the same idempotency key twice, it deduplicates — pick a granu
 | `cert-renewal`     | `0 3 * * *`     | Renews certificates expiring within 30 days |
 | `key-refill`       | `0 0 * * *`     | Refills API key pools                     |
 | `scale-down-idle`  | `0 * * * *` / `*/15 * * * *` | Scales down idle preview deployments (hourly staging, every 15min prod) |
+| `key-last-used-sync` | `* * * * *`   | Syncs `lastUsedAt` timestamps from ClickHouse to MySQL every minute ([details](/architecture/services/control-plane/worker/workflows/key-last-used-sync)) |
 
 ## Runtime details
 

--- a/docs/engineering/infra/observability/alerting.mdx
+++ b/docs/engineering/infra/observability/alerting.mdx
@@ -46,11 +46,31 @@ If you're not sure, start with `warning`. It's easy to promote to `critical` lat
 | Alert | Severity | What it catches | File |
 |-------|----------|----------------|------|
 | PodNotRunning | critical | Pod stuck in `CrashLoopBackOff`, `ImagePullBackOff`, etc. for 5m | `observability/templates/prometheus-alerts.yaml` |
-| FrontlineErrorRateHigh | critical | 5xx error rate > 5% for 2m | `observability/templates/prometheus-alerts-frontline.yaml` |
-| FrontlineP99LatencyHigh | critical | P99 latency > 2.5s for 5m | `observability/templates/prometheus-alerts-frontline.yaml` |
+| **Frontline** | | | |
+| FrontlinePlatformErrorRateHigh | warning | Platform (our) error rate > 2% for 2m — excludes customer/user errors | `observability/templates/prometheus-alerts-frontline.yaml` |
+| FrontlineRoutingErrorsHigh | warning | Sustained routing errors > 0.5/s for 2m | `observability/templates/prometheus-alerts-frontline.yaml` |
+| FrontlineProxyConnectionFailures | warning | Connection failures (timeout, refused, reset, DNS) > 5% for 2m | `observability/templates/prometheus-alerts-frontline.yaml` |
+| FrontlineSentinel5xxRate | warning | Sentinel-sourced 5xx > 5% for 2m (sentinel itself is broken) | `observability/templates/prometheus-alerts-frontline.yaml` |
+| FrontlineP99LatencyHigh | warning | P99 latency > 2.5s for 5m | `observability/templates/prometheus-alerts-frontline.yaml` |
 | FrontlineP95LatencyHigh | warning | P95 latency > 1s for 5m | `observability/templates/prometheus-alerts-frontline.yaml` |
+| FrontlineRoutingLatencyHigh | warning | Routing P99 > 1.5s for 5m | `observability/templates/prometheus-alerts-frontline.yaml` |
+| FrontlineBackendLatencyHigh | warning | Backend P99 > 5s for 5m | `observability/templates/prometheus-alerts-frontline.yaml` |
 | FrontlineHighActiveRequests | warning | Active requests > 100 for 2m | `observability/templates/prometheus-alerts-frontline.yaml` |
+| FrontlineExcessiveHops | warning | P99 cross-region hops >= 2 for 5m | `observability/templates/prometheus-alerts-frontline.yaml` |
 | FrontlineGoroutineLeak | warning | Goroutines > 1000 for 10m | `observability/templates/prometheus-alerts-frontline.yaml` |
+| **Sentinel** | | | |
+| SentinelPlatformErrorRateHigh | warning | Platform (our) error rate > 2% for 2m — excludes customer/user errors | `observability/templates/prometheus-alerts-sentinel.yaml` |
+| SentinelProxyErrorsHigh | warning | Proxy errors > 1/s for 2m (excl. client cancellations) | `observability/templates/prometheus-alerts-sentinel.yaml` |
+| SentinelEngineEvaluationErrors | warning | Policy engine error rate > 1% for 3m | `observability/templates/prometheus-alerts-sentinel.yaml` |
+| SentinelRoutingFailures | warning | Deployment/instance routing failures > 0.5/s for 3m | `observability/templates/prometheus-alerts-sentinel.yaml` |
+| SentinelP99LatencyHigh | warning | P99 latency > 2.5s for 5m | `observability/templates/prometheus-alerts-sentinel.yaml` |
+| SentinelP95LatencyHigh | warning | P95 latency > 1s for 5m | `observability/templates/prometheus-alerts-sentinel.yaml` |
+| SentinelEngineEvaluationLatencyHigh | warning | Policy eval P99 > 1.5s for 5m | `observability/templates/prometheus-alerts-sentinel.yaml` |
+| SentinelRoutingLatencyHigh | warning | Routing P99 > 1.5s for 5m | `observability/templates/prometheus-alerts-sentinel.yaml` |
+| SentinelUpstreamLatencyHigh | warning | Upstream P99 > 10s for 5m | `observability/templates/prometheus-alerts-sentinel.yaml` |
+| SentinelHighActiveRequests | warning | Active requests > 100 for 2m | `observability/templates/prometheus-alerts-sentinel.yaml` |
+| SentinelNoRunningInstancesSustained | warning | No running instances > 0.5/s for 5m | `observability/templates/prometheus-alerts-sentinel.yaml` |
+| SentinelGoroutineLeak | warning | Goroutines > 1000 for 10m | `observability/templates/prometheus-alerts-sentinel.yaml` |
 
 ### kube-prometheus-stack built-ins
 


### PR DESCRIPTION
## What does this PR do?

Adds documentation for the new `key-last-used-sync` cronjob that runs every minute to sync `lastUsedAt` timestamps from ClickHouse to MySQL. Also expands the alerting documentation with comprehensive Frontline and Sentinel monitoring alerts, including platform error rates, latency thresholds, routing failures, and resource leak detection.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How should this be tested?

- Verify the cronjob documentation accurately reflects the actual deployment configuration
- Confirm the alerting table matches the actual Prometheus alert definitions in the referenced YAML files
- Test that the link to the key-last-used-sync workflow details resolves correctly

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [x] Ran `make fmt` on `/go` directory
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [x] Updated the Unkey Docs if changes were necessary