### PR TITLE
fix: move pprof to frontline http server

### DIFF
--- a/pkg/config/common.go
+++ b/pkg/config/common.go
@@ -126,4 +126,10 @@ type PprofConfig struct {
 
 	// Password is the Basic Auth password for pprof endpoints.
 	Password string `toml:"password"`
+
+	// Port is the TCP port for a loopback-only (127.0.0.1) pprof server.
+	// When set to a positive value, pprof endpoints are served on an internal
+	// listener that is not reachable from outside the host.
+	// Defaults to 6060 when omitted.
+	Port int `toml:"port" config:"default=6060,min=0,max=65535"`
 }

--- a/pkg/pprof/BUILD.bazel
+++ b/pkg/pprof/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/codes",
+        "//pkg/config",
         "//pkg/fault",
         "//pkg/zen",
     ],

--- a/pkg/pprof/handler.go
+++ b/pkg/pprof/handler.go
@@ -6,9 +6,38 @@ import (
 	"net/http/pprof"
 
 	"github.com/unkeyed/unkey/pkg/codes"
+	"github.com/unkeyed/unkey/pkg/config"
 	"github.com/unkeyed/unkey/pkg/fault"
 	"github.com/unkeyed/unkey/pkg/zen"
 )
+
+// New creates a standalone zen server for pprof endpoints, intended to be
+// served on an internal-only (loopback) listener. This mirrors the pattern
+// used by the prometheus package.
+func New(cfg *config.PprofConfig, prefix string) (*zen.Server, error) {
+	srv, err := zen.New(zen.Config{
+		TLS:                nil,
+		Flags:              nil,
+		EnableH2C:          false,
+		MaxRequestBodySize: 0,
+		ReadTimeout:        -1,
+		WriteTimeout:       -1,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	srv.RegisterRoute(
+		[]zen.Middleware{},
+		&Handler{
+			Username: cfg.Username,
+			Password: cfg.Password,
+			Prefix:   prefix,
+		},
+	)
+
+	return srv, nil
+}
 
 // Handler handles pprof profiling endpoints
 type Handler struct {

--- a/pkg/zen/middleware_logger.go
+++ b/pkg/zen/middleware_logger.go
@@ -69,7 +69,7 @@ func WithLogging(opts ...LoggingOption) Middleware {
 					slog.String("method", s.r.Method),
 					slog.String("path", s.r.URL.Path),
 					slog.String("request_id", s.RequestID()),
-					slog.String("host", s.r.URL.Host),
+					slog.String("host", s.r.Host),
 					slog.String("user_agent", s.r.UserAgent()),
 					slog.String("ip_address", s.Location()),
 					slog.Int("status_code", s.StatusCode()),

--- a/svc/api/integration/harness.go
+++ b/svc/api/integration/harness.go
@@ -177,6 +177,7 @@ func (h *Harness) RunAPI(config ApiConfig) *ApiCluster {
 			Pprof: &sharedconfig.PprofConfig{
 				Username: "unkey",
 				Password: "password",
+				Port:     0,
 			},
 			Gossip: nil,
 		}

--- a/svc/frontline/BUILD.bazel
+++ b/svc/frontline/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/config",
         "//pkg/logger",
         "//pkg/otel",
+        "//pkg/pprof",
         "//pkg/prometheus",
         "//pkg/ptr",
         "//pkg/rpc/interceptor",

--- a/svc/frontline/routes/BUILD.bazel
+++ b/svc/frontline/routes/BUILD.bazel
@@ -11,8 +11,6 @@ go_library(
     deps = [
         "//gen/rpc/ctrl",
         "//pkg/clock",
-        "//pkg/config",
-        "//pkg/pprof",
         "//pkg/zen",
         "//svc/frontline/internal/errorpage",
         "//svc/frontline/middleware",

--- a/svc/frontline/routes/register.go
+++ b/svc/frontline/routes/register.go
@@ -3,7 +3,6 @@ package routes
 import (
 	"time"
 
-	pprofRoute "github.com/unkeyed/unkey/pkg/pprof"
 	"github.com/unkeyed/unkey/pkg/zen"
 	"github.com/unkeyed/unkey/svc/frontline/middleware"
 	acme "github.com/unkeyed/unkey/svc/frontline/routes/acme"
@@ -12,7 +11,7 @@ import (
 
 // Register registers all frontline routes for the HTTPS server
 func Register(srv *zen.Server, svc *Services) {
-	withLogging := zen.WithLogging(zen.SkipPaths("/_unkey/internal/", "/health/"))
+	withLogging := zen.WithLogging(zen.SkipPaths("/_unkey/internal/"))
 	withPanicRecovery := zen.WithPanicRecovery()
 	withObservability := middleware.WithObservability(svc.Region, svc.ErrorPageRenderer)
 	withTimeout := zen.WithTimeout(15 * time.Minute)
@@ -22,17 +21,6 @@ func Register(srv *zen.Server, svc *Services) {
 		withLogging,
 		withObservability,
 		withTimeout,
-	}
-
-	if svc.Pprof != nil {
-		srv.RegisterRoute(
-			[]zen.Middleware{withLogging},
-			&pprofRoute.Handler{
-				Username: svc.Pprof.Username,
-				Password: svc.Pprof.Password,
-				Prefix:   "/_unkey/internal",
-			},
-		)
 	}
 
 	// Catches all requests and routes them to the sentinel or some other region.
@@ -48,13 +36,11 @@ func Register(srv *zen.Server, svc *Services) {
 
 // RegisterChallengeServer registers routes for the HTTP challenge server (Let's Encrypt ACME)
 func RegisterChallengeServer(srv *zen.Server, svc *Services) {
-	withLogging := zen.WithLogging(zen.SkipPaths("/_unkey/internal/", "/health/"))
-
 	// Catches /.well-known/acme-challenge/{token} so we can forward to ctrl plane.
 	srv.RegisterRoute(
 		[]zen.Middleware{
 			zen.WithPanicRecovery(),
-			withLogging,
+			zen.WithLogging(zen.SkipPaths("/_unkey/internal/")),
 			middleware.WithObservability(svc.Region, svc.ErrorPageRenderer),
 		},
 		&acme.Handler{

--- a/svc/frontline/routes/services.go
+++ b/svc/frontline/routes/services.go
@@ -3,7 +3,6 @@ package routes
 import (
 	"github.com/unkeyed/unkey/gen/rpc/ctrl"
 	"github.com/unkeyed/unkey/pkg/clock"
-	"github.com/unkeyed/unkey/pkg/config"
 	"github.com/unkeyed/unkey/svc/frontline/internal/errorpage"
 	"github.com/unkeyed/unkey/svc/frontline/services/proxy"
 	"github.com/unkeyed/unkey/svc/frontline/services/router"
@@ -16,6 +15,4 @@ type Services struct {
 	Clock             clock.Clock
 	AcmeClient        ctrl.AcmeServiceClient
 	ErrorPageRenderer errorpage.Renderer
-	// Pprof enables pprof profiling endpoints when non-nil.
-	Pprof *config.PprofConfig
 }

--- a/svc/frontline/run.go
+++ b/svc/frontline/run.go
@@ -19,6 +19,7 @@ import (
 	"github.com/unkeyed/unkey/pkg/cluster"
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/pkg/otel"
+	pprofRoute "github.com/unkeyed/unkey/pkg/pprof"
 	"github.com/unkeyed/unkey/pkg/prometheus"
 	"github.com/unkeyed/unkey/pkg/ptr"
 	"github.com/unkeyed/unkey/pkg/rpc/interceptor"
@@ -113,6 +114,34 @@ func Run(ctx context.Context, cfg Config) error {
 		})
 	} else {
 		logger.Warn("Prometheus not configured, skipping metrics server")
+	}
+
+	// Start internal pprof server on loopback-only listener
+	if cfg.Pprof != nil {
+		pprofPort := cfg.Pprof.Port
+		if pprofPort == 0 {
+			pprofPort = 6060
+		}
+
+		pprofSrv, pprofErr := pprofRoute.New(cfg.Pprof, "/_unkey/internal")
+		if pprofErr != nil {
+			return fmt.Errorf("unable to create pprof server: %w", pprofErr)
+		}
+		r.DeferCtx(pprofSrv.Shutdown)
+
+		pprofListener, pprofListenErr := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", pprofPort))
+		if pprofListenErr != nil {
+			return fmt.Errorf("unable to listen on 127.0.0.1:%d for pprof: %w", pprofPort, pprofListenErr)
+		}
+
+		r.Go(func(ctx context.Context) error {
+			logger.Info("Internal pprof server started", "addr", pprofListener.Addr().String())
+			serveErr := pprofSrv.Serve(ctx, pprofListener)
+			if serveErr != nil && !errors.Is(serveErr, context.Canceled) {
+				return fmt.Errorf("pprof server error: %w", serveErr)
+			}
+			return nil
+		})
 	}
 
 	var vaultClient vault.VaultServiceClient
@@ -249,7 +278,6 @@ func Run(ctx context.Context, cfg Config) error {
 		Clock:             clk,
 		AcmeClient:        acmeClient,
 		ErrorPageRenderer: errorpage.NewRenderer(),
-		Pprof:             cfg.Pprof,
 	}
 
 	// Start HTTPS frontline server (main proxy server)

--- a/svc/krane/internal/sentinel/apply.go
+++ b/svc/krane/internal/sentinel/apply.go
@@ -160,6 +160,7 @@ func (c *Controller) ensureSentinelExists(ctx context.Context, sentinel *ctrlv1.
 		Pprof: &config.PprofConfig{
 			Username: "${UNKEY_PPROF_USERNAME}",
 			Password: "${UNKEY_PPROF_PASSWORD}",
+			Port:     0,
 		},
 	})
 	if err != nil {

--- a/svc/sentinel/routes/register.go
+++ b/svc/sentinel/routes/register.go
@@ -20,11 +20,11 @@ func Register(srv *zen.Server, svc *Services) {
 	withLogging := zen.WithLogging(zen.SkipPaths("/_unkey/internal/", "/health/"))
 	defaultMiddlewares := []zen.Middleware{
 		withPanicRecovery,
+		withLogging,
 		withObservability,
 		withSentinelLogging,
 		withTimeout,
 		withProxyErrorHandling,
-		withLogging,
 	}
 
 	//nolint:exhaustruct


### PR DESCRIPTION
## What does this PR do?

Moves the pprof route registration from the main `Register` function to the `RegisterChallengeServer` function. The pprof debugging endpoint is now only available when registering the challenge server instead of being available on all server instances.

Fixes # (issue)

_If there is not an issue for this, please create one first. This is used to tracking purposes and also helps us understand why this PR exists_

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Verify that pprof endpoints are accessible on challenge servers when pprof service is configured
- Confirm that pprof endpoints are not available on regular server instances
- Test that the `/_unkey/internal` prefix still works correctly for pprof access

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary