### PR TITLE
feat: dashboard resource metrics charts

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/(overview)/components/sections/deployment-network-section.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/(overview)/components/sections/deployment-network-section.tsx
@@ -30,7 +30,7 @@ export function DeploymentNetworkSection() {
       />
       <div className="flex gap-2 flex-col">
         <Card className="flex justify-between flex-col overflow-hidden h-[600px] gap-2">
-          <DeploymentNetworkView />
+          <DeploymentNetworkView showNodeDetails />
         </Card>
         <div className="flex gap-2">
           <MetricCard

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/network/deployment-network-view.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/network/deployment-network-view.tsx
@@ -51,7 +51,7 @@ export function DeploymentNetworkView({
       overlay={
         <>
           {showNodeDetails && (
-            <NodeDetailsPanel node={selectedNode} onClose={() => setSelectedNode(null)} />
+            <NodeDetailsPanel node={selectedNode} deploymentId={deployment.id} onClose={() => setSelectedNode(null)} />
           )}
 
           {showProjectDetails && <ProjectDetails />}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/network/page.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/network/page.tsx
@@ -2,5 +2,5 @@
 import { DeploymentNetworkView } from "./deployment-network-view";
 
 export default function DeploymentDetailsPage() {
-  return <DeploymentNetworkView />;
+  return <DeploymentNetworkView showNodeDetails />;
 }

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/network/unkey-flow/components/overlay/node-details-panel.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/network/unkey-flow/components/overlay/node-details-panel.tsx
@@ -13,16 +13,17 @@ import {
   isSkeletonNode,
 } from "../nodes/types";
 import { NodeDetailsPanelHeader } from "./node-details-panel/components/header";
-import { Metrics } from "./node-details-panel/components/metrics";
+import { ResourceMetrics } from "./node-details-panel/components/resource-metrics";
 import { SettingsSection } from "./node-details-panel/components/settings-row";
-import { metrics } from "./node-details-panel/constants";
 import { SentinelInstances } from "./node-details-panel/region-node/sentinel-instances";
 
 const SentinelNodeDetails = ({
   node,
+  deploymentId,
   onClose,
 }: {
   node: SentinelNode;
+  deploymentId: string;
   onClose: () => void;
 }) => {
   const { flagCode, health } = node.metadata;
@@ -50,7 +51,7 @@ const SentinelNodeDetails = ({
           health,
         }}
       />
-      <Metrics metrics={metrics} />
+      <ResourceMetrics resourceType="sentinel" resourceId={node.id} />
       <SentinelInstances instances={node.children ?? []} />
       <SettingsSection
         title="Scaling Configuration"
@@ -95,10 +96,11 @@ const SentinelNodeDetails = ({
 
 type InstanceNodeDetailsProps = {
   node: InstanceNode;
+  deploymentId: string;
   onClose: () => void;
 };
 
-const InstanceNodeDetails = ({ node, onClose }: InstanceNodeDetailsProps) => {
+const InstanceNodeDetails = ({ node, deploymentId, onClose }: InstanceNodeDetailsProps) => {
   const { health } = node.metadata;
 
   return (
@@ -118,7 +120,7 @@ const InstanceNodeDetails = ({ node, onClose }: InstanceNodeDetailsProps) => {
           health,
         }}
       />
-      <Metrics metrics={metrics} />
+      <ResourceMetrics resourceType="deployment" resourceId={deploymentId} />
       <SettingsSection
         title="Instance settings"
         settings={[
@@ -136,10 +138,11 @@ const InstanceNodeDetails = ({ node, onClose }: InstanceNodeDetailsProps) => {
 
 type Props = {
   node: DeploymentNode | null;
+  deploymentId: string;
   onClose: () => void;
 };
 
-export function NodeDetailsPanel({ node, onClose }: Props) {
+export function NodeDetailsPanel({ node, deploymentId, onClose }: Props) {
   if (!node) {
     return null;
   }
@@ -149,10 +152,10 @@ export function NodeDetailsPanel({ node, onClose }: Props) {
       return null;
     }
     if (isSentinelNode(node)) {
-      return <SentinelNodeDetails node={node} onClose={onClose} />;
+      return <SentinelNodeDetails node={node} deploymentId={deploymentId} onClose={onClose} />;
     }
     if (isInstanceNode(node)) {
-      return <InstanceNodeDetails node={node} onClose={onClose} />;
+      return <InstanceNodeDetails node={node} deploymentId={deploymentId} onClose={onClose} />;
     }
     const _exhaustive: never = node;
     return _exhaustive;

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/network/unkey-flow/components/overlay/node-details-panel/components/resource-metrics.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/network/unkey-flow/components/overlay/node-details-panel/components/resource-metrics.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { trpc } from "@/lib/trpc/client";
+import { Bolt, Focus, Grid } from "@unkey/icons";
+import { LogsTimeseriesBarChart } from "./chart";
+
+type MetricRowProps = {
+  icon: React.ReactNode;
+  label: string;
+  value: React.ReactNode;
+  data: Array<{ originalTimestamp: number; [key: string]: number }>;
+  dataKey: string;
+  color: string;
+  isLoading: boolean;
+};
+
+function MetricRow({ icon, label, value, data, dataKey, color, isLoading }: MetricRowProps) {
+  return (
+    <div className="flex flex-col gap-3 px-4 w-full mt-5">
+      <div className="flex gap-3 items-center">
+        <div className="bg-grayA-3 text-gray-12 rounded-md size-[22px] items-center flex justify-center">
+          {icon}
+        </div>
+        <span className="text-gray-11 text-xs">{label}</span>
+        <div className="ml-10">{value}</div>
+      </div>
+      <LogsTimeseriesBarChart
+        data={data}
+        config={{ [dataKey]: { label, color } }}
+        height={48}
+        isLoading={isLoading}
+        isError={false}
+      />
+    </div>
+  );
+}
+
+function toChartData(
+  points: Array<{ x: number; y: number }> | undefined,
+  dataKey: string,
+): Array<{ originalTimestamp: number; [key: string]: number }> {
+  if (!points?.length) {
+    return [];
+  }
+  return points.map((p) => ({ originalTimestamp: p.x, [dataKey]: p.y }));
+}
+
+type ResourceMetricsProps = {
+  resourceType: "deployment" | "sentinel";
+  resourceId: string;
+};
+
+export function ResourceMetrics({ resourceType, resourceId }: ResourceMetricsProps) {
+  const windowHours = 1;
+  const params = { resourceType, resourceId };
+
+  const cpu = trpc.deploy.metrics.getDeploymentCpuTimeseries.useQuery(
+    { ...params, windowHours },
+    { refetchInterval: 15_000 },
+  );
+
+  const memory = trpc.deploy.metrics.getDeploymentMemoryTimeseries.useQuery(
+    { ...params, windowHours },
+    { refetchInterval: 15_000 },
+  );
+
+  const instances = trpc.deploy.metrics.getDeploymentInstanceCountTimeseries.useQuery(
+    { ...params, windowHours },
+    { refetchInterval: 15_000 },
+  );
+
+  const summary = trpc.deploy.metrics.getDeploymentResourceSummary.useQuery(
+    params,
+    { refetchInterval: 15_000 },
+  );
+
+  const cpuValue = summary.data?.avg_cpu_millicores ?? 0;
+  const memValue = summary.data?.max_memory_bytes ?? 0;
+  const instanceCount = summary.data?.active_instances ?? 0;
+  const cpuLimit = summary.data?.avg_cpu_limit_millicores ?? 1;
+
+  return (
+    <div>
+      <div className="flex px-4 w-full">
+        <div className="flex items-center gap-3 w-full">
+          <div className="text-gray-9 text-xs whitespace-nowrap">Runtime metrics</div>
+          <div className="h-0.5 bg-grayA-3 rounded-xs flex-1 min-w-[115px]" />
+        </div>
+      </div>
+
+      <MetricRow
+        icon={<Grid iconSize="sm-regular" className="shrink-0" />}
+        label="Active instances"
+        value={
+          <span className="text-gray-12 font-medium text-[13px]">
+            {instanceCount}
+            <span className="font-normal text-grayA-10"> vm</span>
+          </span>
+        }
+        data={toChartData(instances.data as Array<{ x: number; y: number }>, "active_instances")}
+        dataKey="active_instances"
+        color="hsl(var(--error-8))"
+        isLoading={instances.isLoading}
+      />
+
+      <MetricRow
+        icon={<Bolt iconSize="sm-regular" className="shrink-0" />}
+        label="CPU usage"
+        value={
+          <span className="text-gray-12 font-medium text-[13px]">
+            {Math.round(cpuValue)}
+            <span className="font-normal text-grayA-10"> m</span>
+          </span>
+        }
+        data={toChartData(cpu.data as Array<{ x: number; y: number }>, "cpu_usage")}
+        dataKey="cpu_usage"
+        color="hsl(var(--feature-8))"
+        isLoading={cpu.isLoading}
+      />
+
+      <MetricRow
+        icon={<Focus iconSize="sm-regular" className="shrink-0" />}
+        label="Memory usage"
+        value={
+          <div className="flex gap-2.5 items-center">
+            <span className="text-gray-12 font-medium text-[13px]">
+              {formatBytes(memValue)}
+            </span>
+          </div>
+        }
+        data={toChartData(memory.data as Array<{ x: number; y: number }>, "memory_usage")}
+        dataKey="memory_usage"
+        color="hsl(var(--info-8))"
+        isLoading={memory.isLoading}
+      />
+    </div>
+  );
+}
+
+function formatBytes(bytes: number): React.ReactNode {
+  if (bytes === 0) {
+    return (
+      <>
+        0<span className="font-normal text-grayA-10"> b</span>
+      </>
+    );
+  }
+  const units = ["b", "kb", "mb", "gb"];
+  const i = Math.floor(Math.log(bytes) / Math.log(1024));
+  const value = (bytes / 1024 ** i).toFixed(i > 1 ? 1 : 0);
+  return (
+    <>
+      {value}
+      <span className="font-normal text-grayA-10"> {units[i]}</span>
+    </>
+  );
+}

--- a/web/apps/dashboard/lib/trpc/routers/deploy/metrics/get-deployment-cpu-timeseries.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/metrics/get-deployment-cpu-timeseries.ts
@@ -1,0 +1,44 @@
+import { clickhouse } from "@/lib/clickhouse";
+import { db } from "@/lib/db";
+import { ratelimit, withRatelimit, workspaceProcedure } from "@/lib/trpc/trpc";
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+
+export const getDeploymentCpuTimeseries = workspaceProcedure
+  .use(withRatelimit(ratelimit.read))
+  .input(
+    z.object({
+      resourceType: z.enum(["deployment", "sentinel"]),
+      resourceId: z.string(),
+      windowHours: z.number().int().min(1).max(168).default(6),
+    }),
+  )
+  .query(async ({ ctx, input }) => {
+    const resource = input.resourceType === "sentinel"
+      ? await db.query.sentinels.findFirst({
+          where: (table, { eq, and }) =>
+            and(eq(table.id, input.resourceId), eq(table.workspaceId, ctx.workspace.id)),
+        })
+      : await db.query.deployments.findFirst({
+          where: (table, { eq, and }) =>
+            and(eq(table.id, input.resourceId), eq(table.workspaceId, ctx.workspace.id)),
+        });
+
+    if (!resource) {
+      throw new TRPCError({ code: "NOT_FOUND", message: "Resource not found" });
+    }
+
+    const result = await clickhouse.resources.cpu.timeseries({
+      workspaceId: ctx.workspace.id,
+      resourceType: input.resourceType,
+      resourceId: input.resourceId,
+      windowHours: input.windowHours,
+    });
+
+    if (result.err) {
+      console.warn("Failed to fetch CPU timeseries", result.err);
+      return [];
+    }
+
+    return result.val;
+  });

--- a/web/apps/dashboard/lib/trpc/routers/deploy/metrics/get-deployment-instance-count-timeseries.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/metrics/get-deployment-instance-count-timeseries.ts
@@ -1,0 +1,44 @@
+import { clickhouse } from "@/lib/clickhouse";
+import { db } from "@/lib/db";
+import { ratelimit, withRatelimit, workspaceProcedure } from "@/lib/trpc/trpc";
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+
+export const getDeploymentInstanceCountTimeseries = workspaceProcedure
+  .use(withRatelimit(ratelimit.read))
+  .input(
+    z.object({
+      resourceType: z.enum(["deployment", "sentinel"]),
+      resourceId: z.string(),
+      windowHours: z.number().int().min(1).max(168).default(6),
+    }),
+  )
+  .query(async ({ ctx, input }) => {
+    const resource = input.resourceType === "sentinel"
+      ? await db.query.sentinels.findFirst({
+          where: (table, { eq, and }) =>
+            and(eq(table.id, input.resourceId), eq(table.workspaceId, ctx.workspace.id)),
+        })
+      : await db.query.deployments.findFirst({
+          where: (table, { eq, and }) =>
+            and(eq(table.id, input.resourceId), eq(table.workspaceId, ctx.workspace.id)),
+        });
+
+    if (!resource) {
+      throw new TRPCError({ code: "NOT_FOUND", message: "Resource not found" });
+    }
+
+    const result = await clickhouse.resources.instances.timeseries({
+      workspaceId: ctx.workspace.id,
+      resourceType: input.resourceType,
+      resourceId: input.resourceId,
+      windowHours: input.windowHours,
+    });
+
+    if (result.err) {
+      console.warn("Failed to fetch instance count timeseries", result.err);
+      return [];
+    }
+
+    return result.val;
+  });

--- a/web/apps/dashboard/lib/trpc/routers/deploy/metrics/get-deployment-memory-timeseries.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/metrics/get-deployment-memory-timeseries.ts
@@ -1,0 +1,44 @@
+import { clickhouse } from "@/lib/clickhouse";
+import { db } from "@/lib/db";
+import { ratelimit, withRatelimit, workspaceProcedure } from "@/lib/trpc/trpc";
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+
+export const getDeploymentMemoryTimeseries = workspaceProcedure
+  .use(withRatelimit(ratelimit.read))
+  .input(
+    z.object({
+      resourceType: z.enum(["deployment", "sentinel"]),
+      resourceId: z.string(),
+      windowHours: z.number().int().min(1).max(168).default(6),
+    }),
+  )
+  .query(async ({ ctx, input }) => {
+    const resource = input.resourceType === "sentinel"
+      ? await db.query.sentinels.findFirst({
+          where: (table, { eq, and }) =>
+            and(eq(table.id, input.resourceId), eq(table.workspaceId, ctx.workspace.id)),
+        })
+      : await db.query.deployments.findFirst({
+          where: (table, { eq, and }) =>
+            and(eq(table.id, input.resourceId), eq(table.workspaceId, ctx.workspace.id)),
+        });
+
+    if (!resource) {
+      throw new TRPCError({ code: "NOT_FOUND", message: "Resource not found" });
+    }
+
+    const result = await clickhouse.resources.memory.timeseries({
+      workspaceId: ctx.workspace.id,
+      resourceType: input.resourceType,
+      resourceId: input.resourceId,
+      windowHours: input.windowHours,
+    });
+
+    if (result.err) {
+      console.warn("Failed to fetch memory timeseries", result.err);
+      return [];
+    }
+
+    return result.val;
+  });

--- a/web/apps/dashboard/lib/trpc/routers/deploy/metrics/get-deployment-resource-summary.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/metrics/get-deployment-resource-summary.ts
@@ -1,0 +1,42 @@
+import { clickhouse } from "@/lib/clickhouse";
+import { db } from "@/lib/db";
+import { ratelimit, withRatelimit, workspaceProcedure } from "@/lib/trpc/trpc";
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+
+export const getDeploymentResourceSummary = workspaceProcedure
+  .use(withRatelimit(ratelimit.read))
+  .input(
+    z.object({
+      resourceType: z.enum(["deployment", "sentinel"]),
+      resourceId: z.string(),
+    }),
+  )
+  .query(async ({ ctx, input }) => {
+    const resource = input.resourceType === "sentinel"
+      ? await db.query.sentinels.findFirst({
+          where: (table, { eq, and }) =>
+            and(eq(table.id, input.resourceId), eq(table.workspaceId, ctx.workspace.id)),
+        })
+      : await db.query.deployments.findFirst({
+          where: (table, { eq, and }) =>
+            and(eq(table.id, input.resourceId), eq(table.workspaceId, ctx.workspace.id)),
+        });
+
+    if (!resource) {
+      throw new TRPCError({ code: "NOT_FOUND", message: "Resource not found" });
+    }
+
+    const result = await clickhouse.resources.summary({
+      workspaceId: ctx.workspace.id,
+      resourceType: input.resourceType,
+      resourceId: input.resourceId,
+    });
+
+    if (result.err) {
+      console.warn("Failed to fetch resource summary", result.err);
+      return null;
+    }
+
+    return result.val[0] ?? null;
+  });

--- a/web/apps/dashboard/lib/trpc/routers/index.ts
+++ b/web/apps/dashboard/lib/trpc/routers/index.ts
@@ -76,8 +76,12 @@ import { updateStorage } from "./deploy/environment-settings/runtime/update-stor
 import { getSentinelByEnvironment } from "./deploy/environment-settings/sentinel/get-by-environment";
 import { updateMiddleware } from "./deploy/environment-settings/sentinel/update-middleware";
 import { updateSentinelTier } from "./deploy/environment-settings/sentinel/update-tier";
+import { getDeploymentCpuTimeseries } from "./deploy/metrics/get-deployment-cpu-timeseries";
+import { getDeploymentInstanceCountTimeseries } from "./deploy/metrics/get-deployment-instance-count-timeseries";
 import { getDeploymentLatency } from "./deploy/metrics/get-deployment-latency";
 import { getDeploymentLatencyTimeseries } from "./deploy/metrics/get-deployment-latency-timeseries";
+import { getDeploymentMemoryTimeseries } from "./deploy/metrics/get-deployment-memory-timeseries";
+import { getDeploymentResourceSummary } from "./deploy/metrics/get-deployment-resource-summary";
 import { getDeploymentRps } from "./deploy/metrics/get-deployment-rps";
 import { getDeploymentRpsTimeseries } from "./deploy/metrics/get-deployment-rps-timeseries";
 import { generateDeploymentTree } from "./deploy/network/generate";
@@ -485,6 +489,10 @@ export const router = t.router({
       getDeploymentRpsTimeseries,
       getDeploymentLatency,
       getDeploymentLatencyTimeseries,
+      getDeploymentCpuTimeseries,
+      getDeploymentMemoryTimeseries,
+      getDeploymentInstanceCountTimeseries,
+      getDeploymentResourceSummary,
     }),
   }),
 });

--- a/web/internal/clickhouse/src/index.ts
+++ b/web/internal/clickhouse/src/index.ts
@@ -73,6 +73,12 @@ import {
 import { insertApiRequest } from "./requests";
 import { getRuntimeLogs } from "./runtime-logs";
 import {
+  getResourceCpuTimeseries,
+  getResourceInstanceCountTimeseries,
+  getResourceMemoryTimeseries,
+  getResourceSummary,
+} from "./resources";
+import {
   getDeploymentLatency,
   getDeploymentLatencyTimeseries,
   getDeploymentRps,
@@ -308,6 +314,14 @@ export class ClickHouse {
   public get telemetry() {
     return {
       insert: insertSDKTelemetry(this.inserter),
+    };
+  }
+  public get resources() {
+    return {
+      summary: getResourceSummary(this.querier),
+      cpu: { timeseries: getResourceCpuTimeseries(this.querier) },
+      memory: { timeseries: getResourceMemoryTimeseries(this.querier) },
+      instances: { timeseries: getResourceInstanceCountTimeseries(this.querier) },
     };
   }
   public get sentinel() {

--- a/web/internal/clickhouse/src/resources.ts
+++ b/web/internal/clickhouse/src/resources.ts
@@ -1,0 +1,126 @@
+import { z } from "zod";
+import type { Querier } from "./client";
+
+const SNAPSHOTS_TABLE = "default.instance_resource_snapshots_v1";
+const PER_MINUTE_TABLE = "default.instance_resources_per_minute_v1";
+
+const RESOURCE_FILTER = `
+  workspace_id = {workspaceId: String}
+  AND resource_type = {resourceType: String}
+  AND resource_id = {resourceId: String}`;
+
+const baseParams = z.object({
+  workspaceId: z.string(),
+  resourceType: z.enum(["deployment", "sentinel"]),
+  resourceId: z.string(),
+});
+
+const timeseriesPointSchema = z.object({
+  x: z.number().int(),
+  y: z.number(),
+});
+
+// ─────────────────────────────────────────────────────────────
+// CPU Timeseries
+// ─────────────────────────────────────────────────────────────
+
+export function getResourceCpuTimeseries(ch: Querier) {
+  return async (args: z.infer<typeof baseParams> & { windowHours: number }) => {
+    const query = ch.query({
+      query: `
+        SELECT
+          toUnixTimestamp(time) * 1000 AS x,
+          cpu_millicores_sum / greatest(sample_count, 1) AS y
+        FROM ${PER_MINUTE_TABLE}
+        WHERE ${RESOURCE_FILTER}
+          AND time >= now() - INTERVAL {windowHours: UInt8} HOUR
+        ORDER BY time ASC`,
+      params: baseParams.extend({ windowHours: z.number() }),
+      schema: timeseriesPointSchema,
+    });
+
+    return query(args);
+  };
+}
+
+// ─────────────────────────────────────────────────────────────
+// Memory Timeseries
+// ─────────────────────────────────────────────────────────────
+
+export function getResourceMemoryTimeseries(ch: Querier) {
+  return async (args: z.infer<typeof baseParams> & { windowHours: number }) => {
+    const query = ch.query({
+      query: `
+        SELECT
+          toUnixTimestamp(time) * 1000 AS x,
+          memory_bytes_max AS y
+        FROM ${PER_MINUTE_TABLE}
+        WHERE ${RESOURCE_FILTER}
+          AND time >= now() - INTERVAL {windowHours: UInt8} HOUR
+        ORDER BY time ASC`,
+      params: baseParams.extend({ windowHours: z.number() }),
+      schema: timeseriesPointSchema,
+    });
+
+    return query(args);
+  };
+}
+
+// ─────────────────────────────────────────────────────────────
+// Active Instances (replica count) Timeseries
+// ─────────────────────────────────────────────────────────────
+
+export function getResourceInstanceCountTimeseries(ch: Querier) {
+  return async (args: z.infer<typeof baseParams> & { windowHours: number }) => {
+    const query = ch.query({
+      query: `
+        SELECT
+          toUnixTimestamp(time) * 1000 AS x,
+          uniq(instance_id) AS y
+        FROM ${PER_MINUTE_TABLE}
+        WHERE ${RESOURCE_FILTER}
+          AND time >= now() - INTERVAL {windowHours: UInt8} HOUR
+        GROUP BY time
+        ORDER BY time ASC`,
+      params: baseParams.extend({ windowHours: z.number() }),
+      schema: timeseriesPointSchema,
+    });
+
+    return query(args);
+  };
+}
+
+// ─────────────────────────────────────────────────────────────
+// Current Resource Summary (latest snapshots)
+// ─────────────────────────────────────────────────────────────
+
+const resourceSummarySchema = z.object({
+  active_instances: z.number().int(),
+  avg_cpu_millicores: z.number(),
+  max_memory_bytes: z.number().int(),
+  total_egress_bytes: z.number().int(),
+  avg_cpu_limit_millicores: z.number(),
+  avg_memory_limit_bytes: z.number(),
+});
+
+export function getResourceSummary(ch: Querier) {
+  return async (args: z.infer<typeof baseParams>) => {
+    const query = ch.query({
+      query: `
+        SELECT
+          uniq(instance_id) AS active_instances,
+          avg(cpu_millicores) AS avg_cpu_millicores,
+          max(memory_bytes) AS max_memory_bytes,
+          sum(network_egress_bytes) AS total_egress_bytes,
+          avg(cpu_limit_millicores) AS avg_cpu_limit_millicores,
+          avg(memory_limit_bytes) AS avg_memory_limit_bytes
+        FROM ${SNAPSHOTS_TABLE} FINAL
+        WHERE ${RESOURCE_FILTER}
+          AND time >= now() - INTERVAL 2 MINUTE`,
+      params: baseParams,
+      schema: resourceSummarySchema,
+    });
+
+    return query(args);
+  };
+}


### PR DESCRIPTION
## What does this PR do?

Replaces static mock metrics in the deployment network view with real-time resource metrics from ClickHouse. The node details panel now displays live CPU usage, memory consumption, and active instance counts for both deployment and sentinel resources.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Navigate to a deployment's network view and click on any node to open the details panel
- Verify that CPU usage, memory usage, and active instance metrics display real data with charts
- Test both deployment and sentinel node types to ensure metrics load correctly
- Confirm that metrics auto-refresh every 15 seconds
- Check that the metrics display proper formatting (millicores for CPU, bytes for memory)

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary