### PR TITLE
chore: remove limit from bucket keys

### DIFF
--- a/internal/services/ratelimit/bucket.go
+++ b/internal/services/ratelimit/bucket.go
@@ -8,18 +8,16 @@ import (
 	"github.com/unkeyed/unkey/internal/services/ratelimit/metrics"
 )
 
-// bucket maintains rate limit state for a specific identifier+limit+duration combination.
+// bucket maintains rate limit state for a specific identifier+duration combination.
 // It stores a sliding window of request counts and manages the lifecycle of these windows.
 //
-// Each bucket is uniquely identified by a triplet of:
+// Each bucket is uniquely identified by a pair of:
 //   - identifier: The rate limit subject (user ID, API key, etc)
-//   - limit: Maximum requests allowed in the duration
 //   - duration: Time window for the rate limit
 //
 // Example Usage:
 //
 //	b := &bucket{
-//	    limit:    100,
 //	    duration: time.Minute,
 //	    windows:  make(map[int64]window),
 //	}
@@ -36,9 +34,6 @@ type bucket struct {
 
 	// identifier is the rate limit subject (user ID, API key, etc)
 	identifier string
-
-	// limit is the maximum number of requests allowed per duration
-	limit int64
 
 	// duration is the time window for this rate limit
 	duration time.Duration
@@ -58,14 +53,12 @@ func (b *bucket) key() bucketKey {
 	return bucketKey{
 		name:       b.name,
 		identifier: b.identifier,
-		limit:      b.limit,
 		duration:   b.duration,
 	}
 }
 
 // bucketKey uniquely identifies a rate limit bucket by combining the
-// identifier, limit, and duration. This ensures separate tracking when
-// the same identifier has different rate limit configurations.
+// identifier and duration.
 //
 // Thread Safety:
 //   - Immutable after creation
@@ -75,7 +68,6 @@ func (b *bucket) key() bucketKey {
 //
 //	key := bucketKey{
 //	    identifier: "user-123",
-//	    limit:      100,
 //	    duration:   time.Minute,
 //	}
 //	bucketID := key.toString()
@@ -86,15 +78,12 @@ type bucketKey struct {
 	// identifier is the rate limit subject (user ID, API key, etc)
 	identifier string
 
-	// limit is the maximum requests allowed in the duration
-	limit int64
-
 	// duration is the time window for the rate limit
 	duration time.Duration
 }
 
 func (b bucketKey) toString() string {
-	return fmt.Sprintf("%s-%s-%d-%d", b.name, b.identifier, b.limit, b.duration.Milliseconds())
+	return fmt.Sprintf("%s-%s-%d", b.name, b.identifier, b.duration.Milliseconds())
 }
 
 // getOrCreateBucket retrieves a rate limiting bucket for the given key.
@@ -102,7 +91,6 @@ func (b bucketKey) toString() string {
 //
 // The bucket is uniquely identified by the combination of:
 // - identifier: the client identifier being rate limited
-// - limit: the maximum number of allowed requests
 // - duration: the time window for applying the limit
 //
 // This function is thread-safe and can be called concurrently.
@@ -120,7 +108,6 @@ func (s *service) getOrCreateBucket(key bucketKey) (*bucket, bool) {
 			mu:          sync.RWMutex{},
 			name:        key.name,
 			identifier:  key.identifier,
-			limit:       key.limit,
 			duration:    key.duration,
 			windows:     make(map[int64]*window),
 			strictUntil: time.Time{},

--- a/internal/services/ratelimit/interface.go
+++ b/internal/services/ratelimit/interface.go
@@ -64,8 +64,8 @@ type RatelimitRequest struct {
 	//   - An IP address
 	//   - Any other unique identifier that needs rate limiting
 	//
-	// Must be non-empty. The same identifier with different Limit/Duration
-	// combinations will be treated as separate rate limits.
+	// Must be non-empty. The same identifier with different Duration
+	// values will be treated as separate rate limits.
 	Identifier string
 
 	// Limit specifies the maximum number of tokens allowed within the Duration.

--- a/internal/services/ratelimit/replay.go
+++ b/internal/services/ratelimit/replay.go
@@ -67,7 +67,6 @@ func (s *service) syncWithOrigin(ctx context.Context, req RatelimitRequest) erro
 	key := bucketKey{
 		name:       req.Name,
 		identifier: req.Identifier,
-		limit:      req.Limit,
 		duration:   req.Duration,
 	}
 

--- a/internal/services/ratelimit/service.go
+++ b/internal/services/ratelimit/service.go
@@ -180,7 +180,7 @@ func (s *service) RatelimitMany(ctx context.Context, reqs []RatelimitRequest) ([
 	// Build and sort keys first (before getting buckets)
 	reqsWithKeys := make([]reqWithKey, len(reqs))
 	for i, req := range reqs {
-		key := bucketKey{req.Name, req.Identifier, req.Limit, req.Duration}
+		key := bucketKey{name: req.Name, identifier: req.Identifier, duration: req.Duration}
 		reqsWithKeys[i] = reqWithKey{
 			req:   req,
 			key:   key,
@@ -280,7 +280,7 @@ func (s *service) Ratelimit(ctx context.Context, req RatelimitRequest) (Ratelimi
 		return RatelimitResponse{}, err
 	}
 
-	key := bucketKey{req.Name, req.Identifier, req.Limit, req.Duration}
+	key := bucketKey{name: req.Name, identifier: req.Identifier, duration: req.Duration}
 	span.SetAttributes(attribute.String("key", key.toString()))
 	b, _ := s.getOrCreateBucket(key)
 	b.mu.Lock()


### PR DESCRIPTION
The intended behavior is for a user to be able send different `limit`
rqeuests and reuse the same counter.

fixes ENG-2636
