### PR TITLE
feat: HMAC-based verification tokens

### DIFF
--- a/dev/config/ctrl-worker.toml
+++ b/dev/config/ctrl-worker.toml
@@ -2,6 +2,7 @@ instance_id = "ctrl-worker-dev"
 region = "local"
 default_domain = "unkey.local"
 cname_domain = "unkey.local"
+domain_signing_key = "dev-signing-key-do-not-use-in-production"
 build_platform = "linux/amd64"
 sentinel_image = "unkey/sentinel:latest"
 

--- a/pkg/db/bulk_custom_domain_insert.sql_generated.go
+++ b/pkg/db/bulk_custom_domain_insert.sql_generated.go
@@ -9,7 +9,7 @@ import (
 )
 
 // bulkInsertCustomDomain is the base query for bulk insert
-const bulkInsertCustomDomain = `INSERT INTO custom_domains ( id, workspace_id, project_id, app_id, environment_id, domain, challenge_type, verification_status, verification_token, target_cname, invocation_id, created_at ) VALUES %s`
+const bulkInsertCustomDomain = `INSERT INTO custom_domains ( id, workspace_id, project_id, app_id, environment_id, domain, challenge_type, verification_status, target_cname, invocation_id, created_at ) VALUES %s`
 
 // InsertCustomDomains performs bulk insert in a single query
 func (q *BulkQueries) InsertCustomDomains(ctx context.Context, db DBTX, args []InsertCustomDomainParams) error {
@@ -21,7 +21,7 @@ func (q *BulkQueries) InsertCustomDomains(ctx context.Context, db DBTX, args []I
 	// Build the bulk insert query
 	valueClauses := make([]string, len(args))
 	for i := range args {
-		valueClauses[i] = "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+		valueClauses[i] = "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
 	}
 
 	bulkQuery := fmt.Sprintf(bulkInsertCustomDomain, strings.Join(valueClauses, ", "))
@@ -37,7 +37,6 @@ func (q *BulkQueries) InsertCustomDomains(ctx context.Context, db DBTX, args []I
 		allArgs = append(allArgs, arg.Domain)
 		allArgs = append(allArgs, arg.ChallengeType)
 		allArgs = append(allArgs, arg.VerificationStatus)
-		allArgs = append(allArgs, arg.VerificationToken)
 		allArgs = append(allArgs, arg.TargetCname)
 		allArgs = append(allArgs, arg.InvocationID)
 		allArgs = append(allArgs, arg.CreatedAt)

--- a/pkg/db/bulk_custom_domain_upsert.sql_generated.go
+++ b/pkg/db/bulk_custom_domain_upsert.sql_generated.go
@@ -9,7 +9,7 @@ import (
 )
 
 // bulkUpsertCustomDomain is the base query for bulk insert
-const bulkUpsertCustomDomain = `INSERT INTO custom_domains ( id, workspace_id, project_id, app_id, environment_id, domain, challenge_type, verification_status, verification_token, target_cname, created_at ) VALUES %s ON DUPLICATE KEY UPDATE
+const bulkUpsertCustomDomain = `INSERT INTO custom_domains ( id, workspace_id, project_id, app_id, environment_id, domain, challenge_type, verification_status, target_cname, created_at ) VALUES %s ON DUPLICATE KEY UPDATE
     workspace_id = VALUES(workspace_id),
     project_id = VALUES(project_id),
     app_id = VALUES(app_id),
@@ -29,7 +29,7 @@ func (q *BulkQueries) UpsertCustomDomain(ctx context.Context, db DBTX, args []Up
 	// Build the bulk insert query
 	valueClauses := make([]string, len(args))
 	for i := range args {
-		valueClauses[i] = "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+		valueClauses[i] = "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
 	}
 
 	bulkQuery := fmt.Sprintf(bulkUpsertCustomDomain, strings.Join(valueClauses, ", "))
@@ -45,7 +45,6 @@ func (q *BulkQueries) UpsertCustomDomain(ctx context.Context, db DBTX, args []Up
 		allArgs = append(allArgs, arg.Domain)
 		allArgs = append(allArgs, arg.ChallengeType)
 		allArgs = append(allArgs, arg.VerificationStatus)
-		allArgs = append(allArgs, arg.VerificationToken)
 		allArgs = append(allArgs, arg.TargetCname)
 		allArgs = append(allArgs, arg.CreatedAt)
 	}

--- a/pkg/db/custom_domain_find_by_domain.sql_generated.go
+++ b/pkg/db/custom_domain_find_by_domain.sql_generated.go
@@ -10,14 +10,14 @@ import (
 )
 
 const findCustomDomainByDomain = `-- name: FindCustomDomainByDomain :one
-SELECT pk, id, workspace_id, project_id, app_id, environment_id, domain, challenge_type, verification_status, verification_token, ownership_verified, cname_verified, target_cname, last_checked_at, check_attempts, verification_error, invocation_id, created_at, updated_at
+SELECT pk, id, workspace_id, project_id, app_id, environment_id, domain, challenge_type, verification_status, ownership_verified, cname_verified, target_cname, last_checked_at, check_attempts, verification_error, invocation_id, created_at, updated_at
 FROM custom_domains
 WHERE domain = ?
 `
 
 // FindCustomDomainByDomain
 //
-//	SELECT pk, id, workspace_id, project_id, app_id, environment_id, domain, challenge_type, verification_status, verification_token, ownership_verified, cname_verified, target_cname, last_checked_at, check_attempts, verification_error, invocation_id, created_at, updated_at
+//	SELECT pk, id, workspace_id, project_id, app_id, environment_id, domain, challenge_type, verification_status, ownership_verified, cname_verified, target_cname, last_checked_at, check_attempts, verification_error, invocation_id, created_at, updated_at
 //	FROM custom_domains
 //	WHERE domain = ?
 func (q *Queries) FindCustomDomainByDomain(ctx context.Context, db DBTX, domain string) (CustomDomain, error) {
@@ -33,7 +33,6 @@ func (q *Queries) FindCustomDomainByDomain(ctx context.Context, db DBTX, domain 
 		&i.Domain,
 		&i.ChallengeType,
 		&i.VerificationStatus,
-		&i.VerificationToken,
 		&i.OwnershipVerified,
 		&i.CnameVerified,
 		&i.TargetCname,

--- a/pkg/db/custom_domain_find_by_domain_or_wildcard.sql_generated.go
+++ b/pkg/db/custom_domain_find_by_domain_or_wildcard.sql_generated.go
@@ -10,7 +10,7 @@ import (
 )
 
 const findCustomDomainByDomainOrWildcard = `-- name: FindCustomDomainByDomainOrWildcard :one
-SELECT pk, id, workspace_id, project_id, app_id, environment_id, domain, challenge_type, verification_status, verification_token, ownership_verified, cname_verified, target_cname, last_checked_at, check_attempts, verification_error, invocation_id, created_at, updated_at FROM custom_domains
+SELECT pk, id, workspace_id, project_id, app_id, environment_id, domain, challenge_type, verification_status, ownership_verified, cname_verified, target_cname, last_checked_at, check_attempts, verification_error, invocation_id, created_at, updated_at FROM custom_domains
 WHERE domain IN (?, ?)
 ORDER BY
     CASE WHEN domain = ? THEN 0 ELSE 1 END
@@ -25,7 +25,7 @@ type FindCustomDomainByDomainOrWildcardParams struct {
 
 // FindCustomDomainByDomainOrWildcard
 //
-//	SELECT pk, id, workspace_id, project_id, app_id, environment_id, domain, challenge_type, verification_status, verification_token, ownership_verified, cname_verified, target_cname, last_checked_at, check_attempts, verification_error, invocation_id, created_at, updated_at FROM custom_domains
+//	SELECT pk, id, workspace_id, project_id, app_id, environment_id, domain, challenge_type, verification_status, ownership_verified, cname_verified, target_cname, last_checked_at, check_attempts, verification_error, invocation_id, created_at, updated_at FROM custom_domains
 //	WHERE domain IN (?, ?)
 //	ORDER BY
 //	    CASE WHEN domain = ? THEN 0 ELSE 1 END
@@ -43,7 +43,6 @@ func (q *Queries) FindCustomDomainByDomainOrWildcard(ctx context.Context, db DBT
 		&i.Domain,
 		&i.ChallengeType,
 		&i.VerificationStatus,
-		&i.VerificationToken,
 		&i.OwnershipVerified,
 		&i.CnameVerified,
 		&i.TargetCname,

--- a/pkg/db/custom_domain_find_by_id.sql_generated.go
+++ b/pkg/db/custom_domain_find_by_id.sql_generated.go
@@ -10,14 +10,14 @@ import (
 )
 
 const findCustomDomainById = `-- name: FindCustomDomainById :one
-SELECT pk, id, workspace_id, project_id, app_id, environment_id, domain, challenge_type, verification_status, verification_token, ownership_verified, cname_verified, target_cname, last_checked_at, check_attempts, verification_error, invocation_id, created_at, updated_at
+SELECT pk, id, workspace_id, project_id, app_id, environment_id, domain, challenge_type, verification_status, ownership_verified, cname_verified, target_cname, last_checked_at, check_attempts, verification_error, invocation_id, created_at, updated_at
 FROM custom_domains
 WHERE id = ?
 `
 
 // FindCustomDomainById
 //
-//	SELECT pk, id, workspace_id, project_id, app_id, environment_id, domain, challenge_type, verification_status, verification_token, ownership_verified, cname_verified, target_cname, last_checked_at, check_attempts, verification_error, invocation_id, created_at, updated_at
+//	SELECT pk, id, workspace_id, project_id, app_id, environment_id, domain, challenge_type, verification_status, ownership_verified, cname_verified, target_cname, last_checked_at, check_attempts, verification_error, invocation_id, created_at, updated_at
 //	FROM custom_domains
 //	WHERE id = ?
 func (q *Queries) FindCustomDomainById(ctx context.Context, db DBTX, id string) (CustomDomain, error) {
@@ -33,7 +33,6 @@ func (q *Queries) FindCustomDomainById(ctx context.Context, db DBTX, id string) 
 		&i.Domain,
 		&i.ChallengeType,
 		&i.VerificationStatus,
-		&i.VerificationToken,
 		&i.OwnershipVerified,
 		&i.CnameVerified,
 		&i.TargetCname,

--- a/pkg/db/custom_domain_find_by_workspace_and_domain.sql_generated.go
+++ b/pkg/db/custom_domain_find_by_workspace_and_domain.sql_generated.go
@@ -10,7 +10,7 @@ import (
 )
 
 const findCustomDomainByWorkspaceAndDomain = `-- name: FindCustomDomainByWorkspaceAndDomain :one
-SELECT pk, id, workspace_id, project_id, app_id, environment_id, domain, challenge_type, verification_status, verification_token, ownership_verified, cname_verified, target_cname, last_checked_at, check_attempts, verification_error, invocation_id, created_at, updated_at FROM custom_domains
+SELECT pk, id, workspace_id, project_id, app_id, environment_id, domain, challenge_type, verification_status, ownership_verified, cname_verified, target_cname, last_checked_at, check_attempts, verification_error, invocation_id, created_at, updated_at FROM custom_domains
 WHERE workspace_id = ? AND domain = ?
 `
 
@@ -21,7 +21,7 @@ type FindCustomDomainByWorkspaceAndDomainParams struct {
 
 // FindCustomDomainByWorkspaceAndDomain
 //
-//	SELECT pk, id, workspace_id, project_id, app_id, environment_id, domain, challenge_type, verification_status, verification_token, ownership_verified, cname_verified, target_cname, last_checked_at, check_attempts, verification_error, invocation_id, created_at, updated_at FROM custom_domains
+//	SELECT pk, id, workspace_id, project_id, app_id, environment_id, domain, challenge_type, verification_status, ownership_verified, cname_verified, target_cname, last_checked_at, check_attempts, verification_error, invocation_id, created_at, updated_at FROM custom_domains
 //	WHERE workspace_id = ? AND domain = ?
 func (q *Queries) FindCustomDomainByWorkspaceAndDomain(ctx context.Context, db DBTX, arg FindCustomDomainByWorkspaceAndDomainParams) (CustomDomain, error) {
 	row := db.QueryRowContext(ctx, findCustomDomainByWorkspaceAndDomain, arg.WorkspaceID, arg.Domain)
@@ -36,7 +36,6 @@ func (q *Queries) FindCustomDomainByWorkspaceAndDomain(ctx context.Context, db D
 		&i.Domain,
 		&i.ChallengeType,
 		&i.VerificationStatus,
-		&i.VerificationToken,
 		&i.OwnershipVerified,
 		&i.CnameVerified,
 		&i.TargetCname,

--- a/pkg/db/custom_domain_find_verified_by_domain_excluding_workspace.sql_generated.go
+++ b/pkg/db/custom_domain_find_verified_by_domain_excluding_workspace.sql_generated.go
@@ -10,7 +10,7 @@ import (
 )
 
 const findVerifiedCustomDomainByDomainExcludingWorkspace = `-- name: FindVerifiedCustomDomainByDomainExcludingWorkspace :one
-SELECT pk, id, workspace_id, project_id, app_id, environment_id, domain, challenge_type, verification_status, verification_token, ownership_verified, cname_verified, target_cname, last_checked_at, check_attempts, verification_error, invocation_id, created_at, updated_at FROM custom_domains
+SELECT pk, id, workspace_id, project_id, app_id, environment_id, domain, challenge_type, verification_status, ownership_verified, cname_verified, target_cname, last_checked_at, check_attempts, verification_error, invocation_id, created_at, updated_at FROM custom_domains
 WHERE domain = ?
   AND workspace_id != ?
   AND verification_status = 'verified'
@@ -24,7 +24,7 @@ type FindVerifiedCustomDomainByDomainExcludingWorkspaceParams struct {
 
 // FindVerifiedCustomDomainByDomainExcludingWorkspace
 //
-//	SELECT pk, id, workspace_id, project_id, app_id, environment_id, domain, challenge_type, verification_status, verification_token, ownership_verified, cname_verified, target_cname, last_checked_at, check_attempts, verification_error, invocation_id, created_at, updated_at FROM custom_domains
+//	SELECT pk, id, workspace_id, project_id, app_id, environment_id, domain, challenge_type, verification_status, ownership_verified, cname_verified, target_cname, last_checked_at, check_attempts, verification_error, invocation_id, created_at, updated_at FROM custom_domains
 //	WHERE domain = ?
 //	  AND workspace_id != ?
 //	  AND verification_status = 'verified'
@@ -42,7 +42,6 @@ func (q *Queries) FindVerifiedCustomDomainByDomainExcludingWorkspace(ctx context
 		&i.Domain,
 		&i.ChallengeType,
 		&i.VerificationStatus,
-		&i.VerificationToken,
 		&i.OwnershipVerified,
 		&i.CnameVerified,
 		&i.TargetCname,

--- a/pkg/db/custom_domain_find_with_cert_by_domain.sql_generated.go
+++ b/pkg/db/custom_domain_find_with_cert_by_domain.sql_generated.go
@@ -12,7 +12,7 @@ import (
 
 const findCustomDomainWithCertByDomain = `-- name: FindCustomDomainWithCertByDomain :one
 SELECT
-    cd.pk, cd.id, cd.workspace_id, cd.project_id, cd.app_id, cd.environment_id, cd.domain, cd.challenge_type, cd.verification_status, cd.verification_token, cd.ownership_verified, cd.cname_verified, cd.target_cname, cd.last_checked_at, cd.check_attempts, cd.verification_error, cd.invocation_id, cd.created_at, cd.updated_at,
+    cd.pk, cd.id, cd.workspace_id, cd.project_id, cd.app_id, cd.environment_id, cd.domain, cd.challenge_type, cd.verification_status, cd.ownership_verified, cd.cname_verified, cd.target_cname, cd.last_checked_at, cd.check_attempts, cd.verification_error, cd.invocation_id, cd.created_at, cd.updated_at,
     c.id AS certificate_id
 FROM custom_domains cd
 LEFT JOIN certificates c ON c.hostname = cd.domain
@@ -29,7 +29,6 @@ type FindCustomDomainWithCertByDomainRow struct {
 	Domain             string                          `db:"domain"`
 	ChallengeType      CustomDomainsChallengeType      `db:"challenge_type"`
 	VerificationStatus CustomDomainsVerificationStatus `db:"verification_status"`
-	VerificationToken  string                          `db:"verification_token"`
 	OwnershipVerified  bool                            `db:"ownership_verified"`
 	CnameVerified      bool                            `db:"cname_verified"`
 	TargetCname        string                          `db:"target_cname"`
@@ -45,7 +44,7 @@ type FindCustomDomainWithCertByDomainRow struct {
 // FindCustomDomainWithCertByDomain
 //
 //	SELECT
-//	    cd.pk, cd.id, cd.workspace_id, cd.project_id, cd.app_id, cd.environment_id, cd.domain, cd.challenge_type, cd.verification_status, cd.verification_token, cd.ownership_verified, cd.cname_verified, cd.target_cname, cd.last_checked_at, cd.check_attempts, cd.verification_error, cd.invocation_id, cd.created_at, cd.updated_at,
+//	    cd.pk, cd.id, cd.workspace_id, cd.project_id, cd.app_id, cd.environment_id, cd.domain, cd.challenge_type, cd.verification_status, cd.ownership_verified, cd.cname_verified, cd.target_cname, cd.last_checked_at, cd.check_attempts, cd.verification_error, cd.invocation_id, cd.created_at, cd.updated_at,
 //	    c.id AS certificate_id
 //	FROM custom_domains cd
 //	LEFT JOIN certificates c ON c.hostname = cd.domain
@@ -63,7 +62,6 @@ func (q *Queries) FindCustomDomainWithCertByDomain(ctx context.Context, db DBTX,
 		&i.Domain,
 		&i.ChallengeType,
 		&i.VerificationStatus,
-		&i.VerificationToken,
 		&i.OwnershipVerified,
 		&i.CnameVerified,
 		&i.TargetCname,

--- a/pkg/db/custom_domain_insert.sql_generated.go
+++ b/pkg/db/custom_domain_insert.sql_generated.go
@@ -13,8 +13,8 @@ import (
 const insertCustomDomain = `-- name: InsertCustomDomain :exec
 INSERT INTO custom_domains (
     id, workspace_id, project_id, app_id, environment_id, domain,
-    challenge_type, verification_status, verification_token, target_cname, invocation_id, created_at
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    challenge_type, verification_status, target_cname, invocation_id, created_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 `
 
 type InsertCustomDomainParams struct {
@@ -26,7 +26,6 @@ type InsertCustomDomainParams struct {
 	Domain             string                          `db:"domain"`
 	ChallengeType      CustomDomainsChallengeType      `db:"challenge_type"`
 	VerificationStatus CustomDomainsVerificationStatus `db:"verification_status"`
-	VerificationToken  string                          `db:"verification_token"`
 	TargetCname        string                          `db:"target_cname"`
 	InvocationID       sql.NullString                  `db:"invocation_id"`
 	CreatedAt          int64                           `db:"created_at"`
@@ -36,8 +35,8 @@ type InsertCustomDomainParams struct {
 //
 //	INSERT INTO custom_domains (
 //	    id, workspace_id, project_id, app_id, environment_id, domain,
-//	    challenge_type, verification_status, verification_token, target_cname, invocation_id, created_at
-//	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+//	    challenge_type, verification_status, target_cname, invocation_id, created_at
+//	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 func (q *Queries) InsertCustomDomain(ctx context.Context, db DBTX, arg InsertCustomDomainParams) error {
 	_, err := db.ExecContext(ctx, insertCustomDomain,
 		arg.ID,
@@ -48,7 +47,6 @@ func (q *Queries) InsertCustomDomain(ctx context.Context, db DBTX, arg InsertCus
 		arg.Domain,
 		arg.ChallengeType,
 		arg.VerificationStatus,
-		arg.VerificationToken,
 		arg.TargetCname,
 		arg.InvocationID,
 		arg.CreatedAt,

--- a/pkg/db/custom_domain_list_by_project_id.sql_generated.go
+++ b/pkg/db/custom_domain_list_by_project_id.sql_generated.go
@@ -10,7 +10,7 @@ import (
 )
 
 const listCustomDomainsByProjectID = `-- name: ListCustomDomainsByProjectID :many
-SELECT pk, id, workspace_id, project_id, app_id, environment_id, domain, challenge_type, verification_status, verification_token, ownership_verified, cname_verified, target_cname, last_checked_at, check_attempts, verification_error, invocation_id, created_at, updated_at
+SELECT pk, id, workspace_id, project_id, app_id, environment_id, domain, challenge_type, verification_status, ownership_verified, cname_verified, target_cname, last_checked_at, check_attempts, verification_error, invocation_id, created_at, updated_at
 FROM custom_domains
 WHERE project_id = ?
 ORDER BY created_at DESC
@@ -18,7 +18,7 @@ ORDER BY created_at DESC
 
 // ListCustomDomainsByProjectID
 //
-//	SELECT pk, id, workspace_id, project_id, app_id, environment_id, domain, challenge_type, verification_status, verification_token, ownership_verified, cname_verified, target_cname, last_checked_at, check_attempts, verification_error, invocation_id, created_at, updated_at
+//	SELECT pk, id, workspace_id, project_id, app_id, environment_id, domain, challenge_type, verification_status, ownership_verified, cname_verified, target_cname, last_checked_at, check_attempts, verification_error, invocation_id, created_at, updated_at
 //	FROM custom_domains
 //	WHERE project_id = ?
 //	ORDER BY created_at DESC
@@ -41,7 +41,6 @@ func (q *Queries) ListCustomDomainsByProjectID(ctx context.Context, db DBTX, pro
 			&i.Domain,
 			&i.ChallengeType,
 			&i.VerificationStatus,
-			&i.VerificationToken,
 			&i.OwnershipVerified,
 			&i.CnameVerified,
 			&i.TargetCname,

--- a/pkg/db/custom_domain_upsert.sql_generated.go
+++ b/pkg/db/custom_domain_upsert.sql_generated.go
@@ -13,9 +13,9 @@ import (
 const upsertCustomDomain = `-- name: UpsertCustomDomain :exec
 INSERT INTO custom_domains (
     id, workspace_id, project_id, app_id, environment_id, domain,
-    challenge_type, verification_status, verification_token, target_cname, created_at
+    challenge_type, verification_status, target_cname, created_at
 )
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON DUPLICATE KEY UPDATE
     workspace_id = VALUES(workspace_id),
     project_id = VALUES(project_id),
@@ -36,7 +36,6 @@ type UpsertCustomDomainParams struct {
 	Domain             string                          `db:"domain"`
 	ChallengeType      CustomDomainsChallengeType      `db:"challenge_type"`
 	VerificationStatus CustomDomainsVerificationStatus `db:"verification_status"`
-	VerificationToken  string                          `db:"verification_token"`
 	TargetCname        string                          `db:"target_cname"`
 	CreatedAt          int64                           `db:"created_at"`
 	UpdatedAt          sql.NullInt64                   `db:"updated_at"`
@@ -46,9 +45,9 @@ type UpsertCustomDomainParams struct {
 //
 //	INSERT INTO custom_domains (
 //	    id, workspace_id, project_id, app_id, environment_id, domain,
-//	    challenge_type, verification_status, verification_token, target_cname, created_at
+//	    challenge_type, verification_status, target_cname, created_at
 //	)
-//	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+//	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 //	ON DUPLICATE KEY UPDATE
 //	    workspace_id = VALUES(workspace_id),
 //	    project_id = VALUES(project_id),
@@ -68,7 +67,6 @@ func (q *Queries) UpsertCustomDomain(ctx context.Context, db DBTX, arg UpsertCus
 		arg.Domain,
 		arg.ChallengeType,
 		arg.VerificationStatus,
-		arg.VerificationToken,
 		arg.TargetCname,
 		arg.CreatedAt,
 		arg.UpdatedAt,

--- a/pkg/db/models_generated.go
+++ b/pkg/db/models_generated.go
@@ -1139,7 +1139,6 @@ type CustomDomain struct {
 	Domain             string                          `db:"domain"`
 	ChallengeType      CustomDomainsChallengeType      `db:"challenge_type"`
 	VerificationStatus CustomDomainsVerificationStatus `db:"verification_status"`
-	VerificationToken  string                          `db:"verification_token"`
 	OwnershipVerified  bool                            `db:"ownership_verified"`
 	CnameVerified      bool                            `db:"cname_verified"`
 	TargetCname        string                          `db:"target_cname"`

--- a/pkg/db/querier_generated.go
+++ b/pkg/db/querier_generated.go
@@ -399,13 +399,13 @@ type Querier interface {
 	FindClickhouseWorkspaceSettingsByWorkspaceID(ctx context.Context, db DBTX, workspaceID string) (FindClickhouseWorkspaceSettingsByWorkspaceIDRow, error)
 	//FindCustomDomainByDomain
 	//
-	//  SELECT pk, id, workspace_id, project_id, app_id, environment_id, domain, challenge_type, verification_status, verification_token, ownership_verified, cname_verified, target_cname, last_checked_at, check_attempts, verification_error, invocation_id, created_at, updated_at
+	//  SELECT pk, id, workspace_id, project_id, app_id, environment_id, domain, challenge_type, verification_status, ownership_verified, cname_verified, target_cname, last_checked_at, check_attempts, verification_error, invocation_id, created_at, updated_at
 	//  FROM custom_domains
 	//  WHERE domain = ?
 	FindCustomDomainByDomain(ctx context.Context, db DBTX, domain string) (CustomDomain, error)
 	//FindCustomDomainByDomainOrWildcard
 	//
-	//  SELECT pk, id, workspace_id, project_id, app_id, environment_id, domain, challenge_type, verification_status, verification_token, ownership_verified, cname_verified, target_cname, last_checked_at, check_attempts, verification_error, invocation_id, created_at, updated_at FROM custom_domains
+	//  SELECT pk, id, workspace_id, project_id, app_id, environment_id, domain, challenge_type, verification_status, ownership_verified, cname_verified, target_cname, last_checked_at, check_attempts, verification_error, invocation_id, created_at, updated_at FROM custom_domains
 	//  WHERE domain IN (?, ?)
 	//  ORDER BY
 	//      CASE WHEN domain = ? THEN 0 ELSE 1 END
@@ -413,19 +413,19 @@ type Querier interface {
 	FindCustomDomainByDomainOrWildcard(ctx context.Context, db DBTX, arg FindCustomDomainByDomainOrWildcardParams) (CustomDomain, error)
 	//FindCustomDomainById
 	//
-	//  SELECT pk, id, workspace_id, project_id, app_id, environment_id, domain, challenge_type, verification_status, verification_token, ownership_verified, cname_verified, target_cname, last_checked_at, check_attempts, verification_error, invocation_id, created_at, updated_at
+	//  SELECT pk, id, workspace_id, project_id, app_id, environment_id, domain, challenge_type, verification_status, ownership_verified, cname_verified, target_cname, last_checked_at, check_attempts, verification_error, invocation_id, created_at, updated_at
 	//  FROM custom_domains
 	//  WHERE id = ?
 	FindCustomDomainById(ctx context.Context, db DBTX, id string) (CustomDomain, error)
 	//FindCustomDomainByWorkspaceAndDomain
 	//
-	//  SELECT pk, id, workspace_id, project_id, app_id, environment_id, domain, challenge_type, verification_status, verification_token, ownership_verified, cname_verified, target_cname, last_checked_at, check_attempts, verification_error, invocation_id, created_at, updated_at FROM custom_domains
+	//  SELECT pk, id, workspace_id, project_id, app_id, environment_id, domain, challenge_type, verification_status, ownership_verified, cname_verified, target_cname, last_checked_at, check_attempts, verification_error, invocation_id, created_at, updated_at FROM custom_domains
 	//  WHERE workspace_id = ? AND domain = ?
 	FindCustomDomainByWorkspaceAndDomain(ctx context.Context, db DBTX, arg FindCustomDomainByWorkspaceAndDomainParams) (CustomDomain, error)
 	//FindCustomDomainWithCertByDomain
 	//
 	//  SELECT
-	//      cd.pk, cd.id, cd.workspace_id, cd.project_id, cd.app_id, cd.environment_id, cd.domain, cd.challenge_type, cd.verification_status, cd.verification_token, cd.ownership_verified, cd.cname_verified, cd.target_cname, cd.last_checked_at, cd.check_attempts, cd.verification_error, cd.invocation_id, cd.created_at, cd.updated_at,
+	//      cd.pk, cd.id, cd.workspace_id, cd.project_id, cd.app_id, cd.environment_id, cd.domain, cd.challenge_type, cd.verification_status, cd.ownership_verified, cd.cname_verified, cd.target_cname, cd.last_checked_at, cd.check_attempts, cd.verification_error, cd.invocation_id, cd.created_at, cd.updated_at,
 	//      c.id AS certificate_id
 	//  FROM custom_domains cd
 	//  LEFT JOIN certificates c ON c.hostname = cd.domain
@@ -1270,7 +1270,7 @@ type Querier interface {
 	FindSentinelsByEnvironmentID(ctx context.Context, db DBTX, environmentID string) ([]FindSentinelsByEnvironmentIDRow, error)
 	//FindVerifiedCustomDomainByDomainExcludingWorkspace
 	//
-	//  SELECT pk, id, workspace_id, project_id, app_id, environment_id, domain, challenge_type, verification_status, verification_token, ownership_verified, cname_verified, target_cname, last_checked_at, check_attempts, verification_error, invocation_id, created_at, updated_at FROM custom_domains
+	//  SELECT pk, id, workspace_id, project_id, app_id, environment_id, domain, challenge_type, verification_status, ownership_verified, cname_verified, target_cname, last_checked_at, check_attempts, verification_error, invocation_id, created_at, updated_at FROM custom_domains
 	//  WHERE domain = ?
 	//    AND workspace_id != ?
 	//    AND verification_status = 'verified'
@@ -1528,8 +1528,8 @@ type Querier interface {
 	//
 	//  INSERT INTO custom_domains (
 	//      id, workspace_id, project_id, app_id, environment_id, domain,
-	//      challenge_type, verification_status, verification_token, target_cname, invocation_id, created_at
-	//  ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	//      challenge_type, verification_status, target_cname, invocation_id, created_at
+	//  ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	InsertCustomDomain(ctx context.Context, db DBTX, arg InsertCustomDomainParams) error
 	//InsertDeployment
 	//
@@ -2100,7 +2100,7 @@ type Querier interface {
 	ListCiliumNetworkPoliciesByRegion(ctx context.Context, db DBTX, arg ListCiliumNetworkPoliciesByRegionParams) ([]CiliumNetworkPolicy, error)
 	//ListCustomDomainsByProjectID
 	//
-	//  SELECT pk, id, workspace_id, project_id, app_id, environment_id, domain, challenge_type, verification_status, verification_token, ownership_verified, cname_verified, target_cname, last_checked_at, check_attempts, verification_error, invocation_id, created_at, updated_at
+	//  SELECT pk, id, workspace_id, project_id, app_id, environment_id, domain, challenge_type, verification_status, ownership_verified, cname_verified, target_cname, last_checked_at, check_attempts, verification_error, invocation_id, created_at, updated_at
 	//  FROM custom_domains
 	//  WHERE project_id = ?
 	//  ORDER BY created_at DESC
@@ -3129,9 +3129,9 @@ type Querier interface {
 	//
 	//  INSERT INTO custom_domains (
 	//      id, workspace_id, project_id, app_id, environment_id, domain,
-	//      challenge_type, verification_status, verification_token, target_cname, created_at
+	//      challenge_type, verification_status, target_cname, created_at
 	//  )
-	//  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	//  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	//  ON DUPLICATE KEY UPDATE
 	//      workspace_id = VALUES(workspace_id),
 	//      project_id = VALUES(project_id),

--- a/pkg/db/queries/custom_domain_insert.sql
+++ b/pkg/db/queries/custom_domain_insert.sql
@@ -1,5 +1,5 @@
 -- name: InsertCustomDomain :exec
 INSERT INTO custom_domains (
     id, workspace_id, project_id, app_id, environment_id, domain,
-    challenge_type, verification_status, verification_token, target_cname, invocation_id, created_at
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+    challenge_type, verification_status, target_cname, invocation_id, created_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);

--- a/pkg/db/queries/custom_domain_upsert.sql
+++ b/pkg/db/queries/custom_domain_upsert.sql
@@ -1,9 +1,9 @@
 -- name: UpsertCustomDomain :exec
 INSERT INTO custom_domains (
     id, workspace_id, project_id, app_id, environment_id, domain,
-    challenge_type, verification_status, verification_token, target_cname, created_at
+    challenge_type, verification_status, target_cname, created_at
 )
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON DUPLICATE KEY UPDATE
     workspace_id = VALUES(workspace_id),
     project_id = VALUES(project_id),

--- a/pkg/db/schema.sql
+++ b/pkg/db/schema.sql
@@ -592,7 +592,6 @@ CREATE TABLE `custom_domains` (
 	`domain` varchar(256) NOT NULL,
 	`challenge_type` enum('HTTP-01','DNS-01') NOT NULL,
 	`verification_status` enum('pending','verifying','verified','failed') NOT NULL DEFAULT 'pending',
-	`verification_token` varchar(64) NOT NULL,
 	`ownership_verified` boolean NOT NULL DEFAULT false,
 	`cname_verified` boolean NOT NULL DEFAULT false,
 	`target_cname` varchar(256) NOT NULL,

--- a/pkg/mysql/schema.sql
+++ b/pkg/mysql/schema.sql
@@ -592,7 +592,6 @@ CREATE TABLE `custom_domains` (
 	`domain` varchar(256) NOT NULL,
 	`challenge_type` enum('HTTP-01','DNS-01') NOT NULL,
 	`verification_status` enum('pending','verifying','verified','failed') NOT NULL DEFAULT 'pending',
-	`verification_token` varchar(64) NOT NULL,
 	`ownership_verified` boolean NOT NULL DEFAULT false,
 	`cname_verified` boolean NOT NULL DEFAULT false,
 	`target_cname` varchar(256) NOT NULL,

--- a/svc/ctrl/api/certificate.go
+++ b/svc/ctrl/api/certificate.go
@@ -83,7 +83,6 @@ func (c *certificateBootstrap) bootstrapDomain(ctx context.Context, domain strin
 		Domain:             domain,
 		ChallengeType:      db.CustomDomainsChallengeTypeDNS01,
 		VerificationStatus: db.CustomDomainsVerificationStatusVerified, // Pre-verified for infra domains
-		VerificationToken:  "",                                         // Not needed for infra domains (already verified)
 		TargetCname:        uid.DNS1035(16),                            // Unique target (not used for DNS-01 but required for uniqueness)
 		CreatedAt:          now,
 		UpdatedAt:          sql.NullInt64{Int64: now, Valid: true},

--- a/svc/ctrl/services/customdomain/service.go
+++ b/svc/ctrl/services/customdomain/service.go
@@ -78,9 +78,6 @@ func (s *Service) AddCustomDomain(
 	// Generate unique CNAME target for this domain
 	targetCname := fmt.Sprintf("%s.%s", uid.DNS1035(16), s.cnameDomain)
 
-	// Generate verification token for TXT record ownership verification
-	verificationToken := uid.Secure(24)
-
 	// Check domain doesn't already exist in this workspace
 	existing, err := db.Query.FindCustomDomainByWorkspaceAndDomain(ctx, s.db.RO(), db.FindCustomDomainByWorkspaceAndDomainParams{
 		WorkspaceID: req.Msg.GetWorkspaceId(),
@@ -106,7 +103,6 @@ func (s *Service) AddCustomDomain(
 		Domain:             domain,
 		ChallengeType:      db.CustomDomainsChallengeTypeHTTP01,
 		VerificationStatus: db.CustomDomainsVerificationStatusPending,
-		VerificationToken:  verificationToken,
 		TargetCname:        targetCname,
 		CreatedAt:          now,
 		InvocationID:       sql.NullString{String: "", Valid: false},

--- a/svc/ctrl/worker/certificate/bootstrap_infra_certs.go
+++ b/svc/ctrl/worker/certificate/bootstrap_infra_certs.go
@@ -116,7 +116,6 @@ func (s *Service) ensureInfraDomain(ctx context.Context, domain string, restate 
 			Domain:             domain,
 			ChallengeType:      db.CustomDomainsChallengeTypeDNS01,
 			VerificationStatus: db.CustomDomainsVerificationStatusVerified, // Pre-verified for infra domains
-			VerificationToken:  "",                                         // Not needed for infra domains (already verified)
 			TargetCname:        uid.DNS1035(16),                            // Unique target (not used for DNS-01 but required for uniqueness)
 			CreatedAt:          now,
 			UpdatedAt:          sql.NullInt64{Int64: now, Valid: true},

--- a/svc/ctrl/worker/config.go
+++ b/svc/ctrl/worker/config.go
@@ -225,6 +225,10 @@ type Config struct {
 	// Each custom domain gets a unique subdomain like "{random}.{CnameDomain}".
 	CnameDomain string `toml:"cname_domain" config:"required,nonempty"`
 
+	// DomainSigningKey is used to compute HMAC-based verification tokens for
+	// custom domain TXT record ownership verification.
+	DomainSigningKey string `toml:"domain_signing_key" config:"required,nonempty"`
+
 	// Database configures MySQL connections. See [config.DatabaseConfig].
 	Database config.DatabaseConfig `toml:"database"`
 

--- a/svc/ctrl/worker/customdomain/service.go
+++ b/svc/ctrl/worker/customdomain/service.go
@@ -1,6 +1,10 @@
 package customdomain
 
 import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+
 	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
 	"github.com/unkeyed/unkey/pkg/db"
 )
@@ -8,20 +12,24 @@ import (
 // Service orchestrates custom domain verification workflows.
 //
 // Service implements hydrav1.CustomDomainServiceServer with handlers for
-// verifying domain ownership via CNAME records. It uses a Restate virtual
-// object pattern keyed by domain name to ensure only one verification
+// verifying domain ownership via DNS records. It uses a Restate virtual
+// object pattern keyed by domain ID to ensure only one verification
 // workflow runs per domain at any time.
 //
 // The verification process checks that the user has added a CNAME record
-// pointing to a unique target under the configured DNS apex. Verification
-// retries every minute for approximately 24 hours before giving up.
+// pointing to a unique target under the configured DNS apex. For apex
+// domains where CNAME is not visible (CNAME flattening, ALIAS, proxy),
+// it falls back to TXT record verification using an HMAC-derived token.
 //
-// Once verified, the service triggers certificate issuance and creates
-// a frontline route so traffic can be routed to the user's deployment.
+// Verification retries every minute for approximately 24 hours before
+// giving up. Once verified, the service triggers certificate issuance
+// and creates a frontline route so traffic can be routed to the user's
+// deployment.
 type Service struct {
 	hydrav1.UnimplementedCustomDomainServiceServer
-	db          db.Database
-	cnameDomain string
+	db               db.Database
+	cnameDomain      string
+	domainSigningKey []byte
 }
 
 var _ hydrav1.CustomDomainServiceServer = (*Service)(nil)
@@ -32,10 +40,12 @@ type Config struct {
 	DB db.Database
 
 	// CnameDomain is the base domain for custom domain CNAME targets.
-	// Each custom domain gets a unique subdomain like "{random}.{CnameDomain}".
-	// For production: "unkey-dns.com"
-	// For local: "unkey.local"
 	CnameDomain string
+
+	// DomainSigningKey is used to compute HMAC-based verification tokens
+	// for TXT record ownership verification. The token is derived from the
+	// domain ID so it doesn't need to be stored in the database.
+	DomainSigningKey string
 }
 
 // New creates a [Service] with the given configuration.
@@ -44,5 +54,15 @@ func New(cfg Config) *Service {
 		UnimplementedCustomDomainServiceServer: hydrav1.UnimplementedCustomDomainServiceServer{},
 		db:                                     cfg.DB,
 		cnameDomain:                            cfg.CnameDomain,
+		domainSigningKey:                       []byte(cfg.DomainSigningKey),
 	}
+}
+
+// verificationToken computes a deterministic verification token for a domain
+// using HMAC-SHA256. The token is derived from the domain ID so it doesn't
+// need to be stored in the database.
+func (s *Service) verificationToken(domainID string) string {
+	mac := hmac.New(sha256.New, s.domainSigningKey)
+	mac.Write([]byte(domainID))
+	return hex.EncodeToString(mac.Sum(nil))[:32]
 }

--- a/svc/ctrl/worker/customdomain/verify_handler.go
+++ b/svc/ctrl/worker/customdomain/verify_handler.go
@@ -113,7 +113,7 @@ func (s *Service) VerifyDomain(
 	txtVerified := true // default: not required
 	if requiresTxt {
 		var txtErr error
-		txtVerified, txtErr = s.checkTXTRecord(dom.Domain, dom.VerificationToken)
+		txtVerified, txtErr = s.checkTXTRecord(dom.Domain, s.verificationToken(dom.ID))
 		if txtErr != nil {
 			logger.Warn("TXT check error",
 				"domain", dom.Domain,

--- a/svc/ctrl/worker/run.go
+++ b/svc/ctrl/worker/run.go
@@ -269,8 +269,9 @@ func Run(ctx context.Context, cfg Config) error {
 	})))
 
 	restateSrv.Bind(hydrav1.NewCustomDomainServiceServer(workercustomdomain.New(workercustomdomain.Config{
-		DB:          database,
-		CnameDomain: cfg.CnameDomain,
+		DB:               database,
+		CnameDomain:      cfg.CnameDomain,
+		DomainSigningKey: cfg.DomainSigningKey,
 	}),
 		// Retry every 1 minute for up to 24 hours (1440 attempts)
 		restate.WithInvocationRetryPolicy(

--- a/svc/frontline/internal/db/models_generated.go
+++ b/svc/frontline/internal/db/models_generated.go
@@ -1137,7 +1137,6 @@ type CustomDomain struct {
 	Domain             string                          `db:"domain"`
 	ChallengeType      CustomDomainsChallengeType      `db:"challenge_type"`
 	VerificationStatus CustomDomainsVerificationStatus `db:"verification_status"`
-	VerificationToken  string                          `db:"verification_token"`
 	OwnershipVerified  bool                            `db:"ownership_verified"`
 	CnameVerified      bool                            `db:"cname_verified"`
 	TargetCname        string                          `db:"target_cname"`

--- a/web/apps/dashboard/.env.example
+++ b/web/apps/dashboard/.env.example
@@ -28,6 +28,9 @@ VAULT_TOKEN=vault-test-token-123
 # ClickHouse
 CLICKHOUSE_URL=
 
+# Domain verification
+DOMAIN_SIGNING_KEY=dev-signing-key-do-not-use-in-production
+
 # Optional
 TRIGGER_API_KEY=
 NEXT_PUBLIC_TRIGGER_PUBLIC_KEY=

--- a/web/apps/dashboard/lib/env.ts
+++ b/web/apps/dashboard/lib/env.ts
@@ -41,6 +41,8 @@ export const env = () =>
       CLICKHOUSE_URL: z.string().optional(),
       OPENAI_API_KEY: z.string().optional(),
 
+      DOMAIN_SIGNING_KEY: z.string().optional(),
+
       AUTH_PROVIDER: z.enum(["workos", "local"]),
 
       WORKOS_API_KEY: z.string().optional(),

--- a/web/apps/dashboard/lib/trpc/routers/deploy/custom-domains/list.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/custom-domains/list.ts
@@ -1,7 +1,18 @@
+import { createHmac } from "node:crypto";
 import { db } from "@/lib/db";
+import { env } from "@/lib/env";
 import { ratelimit, withRatelimit, workspaceProcedure } from "@/lib/trpc/trpc";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
+
+/**
+ * Computes a deterministic verification token for a domain using HMAC-SHA256.
+ * Must match the Go implementation in svc/ctrl/worker/customdomain/service.go
+ * and svc/ctrl/services/customdomain/service.go.
+ */
+function verificationToken(domainId: string, signingKey: string): string {
+  return createHmac("sha256", signingKey).update(domainId).digest("hex").slice(0, 32);
+}
 
 export const listCustomDomains = workspaceProcedure
   .use(withRatelimit(ratelimit.read))
@@ -24,6 +35,8 @@ export const listCustomDomains = workspaceProcedure
     }
 
     try {
+      const signingKey = env().DOMAIN_SIGNING_KEY ?? "";
+
       const domains = await db.query.customDomains.findMany({
         where: (table, { eq }) => eq(table.projectId, input.projectId),
         columns: {
@@ -34,7 +47,6 @@ export const listCustomDomains = workspaceProcedure
           appId: true,
           environmentId: true,
           verificationStatus: true,
-          verificationToken: true,
           ownershipVerified: true,
           cnameVerified: true,
           targetCname: true,
@@ -55,7 +67,7 @@ export const listCustomDomains = workspaceProcedure
         appId: d.appId,
         environmentId: d.environmentId,
         verificationStatus: d.verificationStatus,
-        verificationToken: d.verificationToken,
+        verificationToken: verificationToken(d.id, signingKey),
         ownershipVerified: d.ownershipVerified,
         cnameVerified: d.cnameVerified,
         targetCname: d.targetCname,

--- a/web/internal/db/src/schema/custom_domains.ts
+++ b/web/internal/db/src/schema/custom_domains.ts
@@ -33,9 +33,6 @@ export const customDomains = mysqlTable(
 
     // Verification fields
     verificationStatus: verificationStatus.notNull().default("pending"),
-    // TXT record verification token (e.g., "abc123xyz...")
-    // User adds TXT record: _unkey.domain.com -> unkey-domain-verify=<token>
-    verificationToken: varchar("verification_token", { length: 64 }).notNull(),
     // Whether the TXT record has been verified (proves ownership)
     ownershipVerified: boolean("ownership_verified").notNull().default(false),
     // Whether the CNAME record has been verified (enables routing)


### PR DESCRIPTION
## What does this PR do?

Replaces random verification tokens with deterministic HMAC-based tokens for custom domain verification. The verification token is now computed using HMAC-SHA256 from the domain ID and a signing key, eliminating the need to store tokens in the database.

Key changes:
- Added `DomainSigningKey` configuration parameter to both API and worker services
- Modified `verification_token` database column to have a default empty string value
- Implemented `verificationToken()` method that generates deterministic tokens using HMAC-SHA256
- Updated custom domain creation to use computed tokens instead of random ones
- Modified verification workflow to compute tokens on-demand rather than reading from database

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Test custom domain creation with new HMAC-based token generation
- Verify domain verification workflow still works with computed tokens
- Test backwards compatibility with existing domains that have stored tokens
- Validate that tokens are deterministic (same domain ID produces same token)

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary