### PR TITLE
fix: allow env-var grouping

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/env-vars/components/env-var-item-row.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/env-vars/components/env-var-item-row.tsx
@@ -1,0 +1,133 @@
+import { ChartActivity2 } from "@unkey/icons";
+import { Badge, TimestampInfo } from "@unkey/ui";
+import { EnvVarActionMenu } from "./env-var-action-menu";
+import { EnvVarEditRow } from "./env-var-edit-row";
+import { EnvVarNameCell } from "./env-var-name-cell";
+import { EnvVarValueCell } from "./env-var-value-cell";
+
+export type EnvVarItem = {
+  id: string;
+  key: string;
+  environmentId: string;
+  environmentName: string;
+  type: "writeonly" | "recoverable";
+  updatedAt: number;
+  note: string | null | undefined;
+};
+
+export type DisplayRow =
+  | { kind: "single"; item: EnvVarItem }
+  | {
+      kind: "group";
+      key: string;
+      items: EnvVarItem[];
+      latestUpdatedAt: number;
+      hasWriteonly: boolean;
+    };
+
+type EnvVarItemRowProps = {
+  item: EnvVarItem;
+  searchQuery: string;
+  isEditing: boolean;
+  onEdit: () => void;
+  onCloseEdit: () => void;
+};
+
+export function EnvVarItemRow({
+  item,
+  searchQuery,
+  isEditing,
+  onEdit,
+  onCloseEdit,
+}: EnvVarItemRowProps) {
+  return (
+    <div>
+      <div className="group flex items-center hover:bg-grayA-2 transition-colors">
+        <div className="flex-3 min-w-0 py-3.5 flex items-center">
+          <EnvVarNameCell
+            envVarId={item.id}
+            variableKey={item.key}
+            environmentName={item.environmentName}
+            note={item.note}
+            searchQuery={searchQuery}
+            type={item.type}
+          />
+        </div>
+        <div className="flex-4 min-w-0 py-3.5 flex items-center pr-3">
+          <EnvVarValueCell envVarId={item.id} type={item.type} />
+        </div>
+        <div className="flex-2 min-w-0 py-3.5 flex items-center pr-3">
+          <TimestampBadge value={item.updatedAt} />
+        </div>
+        <div className="w-12 shrink-0 py-3.5 pr-3 flex items-center justify-end">
+          <EnvVarActionMenu
+            envVarId={item.id}
+            variableKey={item.key}
+            type={item.type}
+            onEdit={onEdit}
+          />
+        </div>
+      </div>
+      {isEditing && (
+        <div className="grid animate-expand-down overflow-hidden">
+          <div className="min-h-0">
+            <EnvVarEditRow
+              environmentId={item.environmentId}
+              envVarId={item.id}
+              variableKey={item.key}
+              type={item.type}
+              note={item.note ?? null}
+              onClose={onCloseEdit}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function TimestampBadge({ value }: { value: number }) {
+  return (
+    <Badge className="px-1.5 rounded-md flex gap-2 items-center h-5.5 border-none bg-grayA-3 text-grayA-11 truncate">
+      <ChartActivity2 iconSize="sm-regular" className="shrink-0" />
+      <TimestampInfo displayType="relative" value={value} className="truncate" />
+    </Badge>
+  );
+}
+
+export function rowKey(r: DisplayRow): string {
+  return r.kind === "group" ? r.key : r.item.key;
+}
+
+export function rowTime(r: DisplayRow): number {
+  return r.kind === "group" ? r.latestUpdatedAt : r.item.updatedAt;
+}
+
+export function groupByKey(items: EnvVarItem[]): DisplayRow[] {
+  const groups = new Map<string, EnvVarItem[]>();
+  for (const item of items) {
+    const existing = groups.get(item.key);
+    if (existing) {
+      existing.push(item);
+    } else {
+      groups.set(item.key, [item]);
+    }
+  }
+
+  const rows: DisplayRow[] = [];
+  for (const [key, group] of groups) {
+    if (group.length === 1) {
+      rows.push({ kind: "single", item: group[0] });
+    } else {
+      group.sort((a, b) => a.environmentName.localeCompare(b.environmentName));
+      rows.push({
+        kind: "group",
+        key,
+        items: group,
+        latestUpdatedAt: Math.max(...group.map((i) => i.updatedAt)),
+        hasWriteonly: group.some((i) => i.type === "writeonly"),
+      });
+    }
+  }
+  return rows;
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/env-vars/components/env-var-row.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/env-vars/components/env-var-row.tsx
@@ -29,6 +29,7 @@ export const EnvVarRow = ({ index, isOnly, register, onRemove, errors }: EnvVarR
           label="Value"
           className="flex-1 [&_input]:font-mono"
           placeholder="value"
+          error={fieldErrors?.value?.message}
           {...register(`envVars.${index}.value`)}
         />
         {!isOnly && (

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/env-vars/components/env-vars-list.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/env-vars/components/env-vars-list.tsx
@@ -3,16 +3,21 @@
 import { collection } from "@/lib/collections";
 import type { Environment } from "@/lib/collections/deploy/environments";
 import { eq, useLiveQuery } from "@tanstack/react-db";
-import { ChartActivity2 } from "@unkey/icons";
-import { Badge, TimestampInfo } from "@unkey/ui";
-import { useCallback, useDeferredValue, useMemo, useState } from "react";
-import { EnvVarActionMenu } from "./env-var-action-menu";
-import { EnvVarEditRow } from "./env-var-edit-row";
-import { EnvVarNameCell } from "./env-var-name-cell";
-import { EnvVarValueCell } from "./env-var-value-cell";
+import { Badge } from "@unkey/ui";
+import { useCallback, useDeferredValue, useEffect, useMemo, useState } from "react";
+import {
+  type DisplayRow,
+  type EnvVarItem,
+  EnvVarItemRow,
+  TimestampBadge,
+  groupByKey,
+  rowKey,
+  rowTime,
+} from "./env-var-item-row";
 import { EnvVarsEmpty } from "./env-vars-empty";
 import { EnvVarsSkeleton } from "./env-vars-skeleton";
 import type { EnvironmentFilter, SortOption } from "./env-vars-toolbar";
+import { HighlightMatch } from "./highlight-match";
 
 type EnvVarsListProps = {
   projectId: string;
@@ -30,125 +35,183 @@ export function EnvVarsList({
   sortBy,
 }: EnvVarsListProps) {
   const [editingId, setEditingId] = useState<string | null>(null);
+  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
   const closeEdit = useCallback(() => setEditingId(null), []);
   const deferredQuery = useDeferredValue(searchQuery);
+
+  const toggleGroup = useCallback((key: string) => {
+    setExpandedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  }, []);
 
   const { data: envVarData, isLoading } = useLiveQuery(
     (q) => q.from({ v: collection.envVars }).where(({ v }) => eq(v.projectId, projectId)),
     [projectId],
   );
 
-  const envMap = useMemo(() => {
-    const map = new Map<string, string>();
-    for (const env of environments) {
-      map.set(env.id, env.slug);
-    }
-    return map;
-  }, [environments]);
-
-  const indexedVars = useMemo(() => {
+  const displayRows = useMemo((): DisplayRow[] => {
     if (!envVarData) {
       return [];
     }
-    return envVarData.map((v) => ({
-      id: v.id,
-      key: v.key,
-      keyLower: v.key.toLowerCase(),
-      type: v.type,
-      environmentId: v.environmentId,
-      updatedAt: v.updatedAt,
-      note: v.description,
-    }));
-  }, [envVarData]);
 
-  const filteredData = useMemo(() => {
     const query = deferredQuery.toLowerCase();
 
-    const result = [];
-    for (const v of indexedVars) {
-      if (query && !v.keyLower.includes(query)) {
+    const filtered: EnvVarItem[] = [];
+    for (const v of envVarData) {
+      if (query && !v.key.toLowerCase().includes(query)) {
         continue;
       }
       if (environmentFilter !== "all" && v.environmentId !== environmentFilter) {
         continue;
       }
-      result.push({
+      filtered.push({
         id: v.id,
         key: v.key,
         environmentId: v.environmentId,
-        environmentName: envMap.get(v.environmentId) ?? "Unknown",
+        environmentName: environments.find((e) => e.id === v.environmentId)?.slug ?? "Unknown",
         type: v.type,
         updatedAt: v.updatedAt,
-        note: v.note,
+        note: v.description,
       });
     }
 
+    // When filtering by a specific environment, each var is a standalone row.
+    // When viewing all environments, group vars that share the same key.
+    const rows =
+      environmentFilter !== "all"
+        ? filtered.map((item): DisplayRow => ({ kind: "single", item }))
+        : groupByKey(filtered);
+
+    // Sort rows by name or most recently updated
     if (sortBy === "name-asc") {
-      result.sort((a, b) => a.key.localeCompare(b.key));
+      rows.sort((a, b) => rowKey(a).localeCompare(rowKey(b)));
     } else {
-      result.sort((a, b) => b.updatedAt - a.updatedAt);
+      rows.sort((a, b) => rowTime(b) - rowTime(a));
     }
 
-    return result;
-  }, [indexedVars, envMap, deferredQuery, environmentFilter, sortBy]);
+    return rows;
+  }, [envVarData, environments, deferredQuery, environmentFilter, sortBy]);
+
+  useCloseEditOnGroupCollapse(displayRows, expandedGroups, editingId, setEditingId);
 
   if (isLoading) {
     return <EnvVarsSkeleton />;
   }
 
-  if (filteredData.length === 0) {
+  if (displayRows.length === 0) {
     return <EnvVarsEmpty searchQuery={searchQuery} />;
   }
 
   return (
     <div className="border border-grayA-4 rounded-[14px] overflow-hidden divide-y divide-grayA-4">
-      {filteredData.map((item) => (
-        <div key={item.id}>
-          <div className="group flex items-center hover:bg-grayA-2 transition-colors">
-            <div className="flex-3 min-w-0 py-3.5 flex items-center">
-              <EnvVarNameCell
-                envVarId={item.id}
-                variableKey={item.key}
-                environmentName={item.environmentName}
-                note={item.note}
-                searchQuery={deferredQuery}
-                type={item.type}
-              />
-            </div>
-            <div className="flex-4 min-w-0 py-3.5 flex items-center pr-3">
-              <EnvVarValueCell envVarId={item.id} type={item.type} />
-            </div>
-            <div className="flex-2 min-w-0 py-3.5 flex items-center pr-3">
-              <Badge className="px-1.5 rounded-md flex gap-2 items-center h-5.5 border-none bg-grayA-3 text-grayA-11 truncate">
-                <ChartActivity2 iconSize="sm-regular" className="shrink-0" />
-                <TimestampInfo displayType="relative" value={item.updatedAt} className="truncate" />
-              </Badge>
-            </div>
-            <div className="w-12 shrink-0 py-3.5 pr-3 flex items-center justify-end">
-              <EnvVarActionMenu
-                envVarId={item.id}
-                variableKey={item.key}
-                type={item.type}
-                onEdit={() => setEditingId(item.id)}
-              />
-            </div>
-          </div>
-          {editingId === item.id && (
-            <div className="grid animate-expand-down overflow-hidden">
-              <div className="min-h-0">
-                <EnvVarEditRow
-                  environmentId={item.environmentId}
-                  envVarId={item.id}
-                  variableKey={item.key}
-                  type={item.type}
-                  note={item.note ?? null}
-                  onClose={closeEdit}
-                />
+      {displayRows.map((row) => {
+        if (row.kind === "single") {
+          const item = row.item;
+          return (
+            <EnvVarItemRow
+              key={item.id}
+              item={item}
+              searchQuery={deferredQuery}
+              isEditing={editingId === item.id}
+              onEdit={() => setEditingId(item.id)}
+              onCloseEdit={closeEdit}
+            />
+          );
+        }
+
+        // Group row
+        const isExpanded = expandedGroups.has(row.key);
+        return (
+          <div key={`group-${row.key}`}>
+            <div
+              //biome-ignore lint/a11y/useSemanticElements: its okay
+              role="button"
+              tabIndex={0}
+              onClick={() => toggleGroup(row.key)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  toggleGroup(row.key);
+                }
+              }}
+              className="group flex items-center hover:bg-grayA-2 transition-colors cursor-pointer"
+            >
+              <div className="flex-3 min-w-0 py-3.5 flex items-center">
+                <div className="flex items-center px-4">
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-1.5">
+                      <span className="font-mono font-medium text-[13px] text-accent-12 truncate leading-4 max-w-[250px]">
+                        <HighlightMatch text={row.key} query={deferredQuery} />
+                      </span>
+                      {row.hasWriteonly && (
+                        <Badge
+                          className="px-1.5 py-0 rounded-md h-5 text-[11px] font-medium pointer-events-none"
+                          variant="warning"
+                        >
+                          Sensitive
+                        </Badge>
+                      )}
+                    </div>
+                    <div className="text-[13px] mt-1 text-gray-10 capitalize">All Environments</div>
+                  </div>
+                </div>
               </div>
+              <div className="flex-4 min-w-0 py-3.5 flex items-center pr-3">
+                <span className="text-[13px] text-gray-9 group-hover:text-gray-11 transition-colors pl-2">
+                  {row.items.length} values ›
+                </span>
+              </div>
+              <div className="flex-2 min-w-0 py-3.5 flex items-center pr-3">
+                <TimestampBadge value={row.latestUpdatedAt} />
+              </div>
+              <div className="w-12 shrink-0 py-3.5 pr-3" />
             </div>
-          )}
-        </div>
-      ))}
+            {/* Expanded sub-rows */}
+            {isExpanded && (
+              <div className="divide-y divide-grayA-3 bg-grayA-2 border-t border-grayA-4">
+                {row.items.map((item) => (
+                  <EnvVarItemRow
+                    key={item.id}
+                    item={item}
+                    searchQuery={deferredQuery}
+                    isEditing={editingId === item.id}
+                    onEdit={() => setEditingId(item.id)}
+                    onCloseEdit={closeEdit}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        );
+      })}
     </div>
   );
+}
+
+function useCloseEditOnGroupCollapse(
+  displayRows: DisplayRow[],
+  expandedGroups: Set<string>,
+  editingId: string | null,
+  setEditingId: (id: string | null) => void,
+) {
+  useEffect(() => {
+    if (editingId === null) {
+      return;
+    }
+    for (const row of displayRows) {
+      if (row.kind === "group" && !expandedGroups.has(row.key)) {
+        if (row.items.some((i) => i.id === editingId)) {
+          setEditingId(null);
+          break;
+        }
+      }
+    }
+  }, [expandedGroups, displayRows, editingId, setEditingId]);
 }

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/env-vars/components/schema.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/env-vars/components/schema.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 export const envVarEntrySchema = z.object({
   key: z.string().trim().min(1, "Variable name is required"),
-  value: z.string(),
+  value: z.string().min(1, "Variable value is required"),
   description: z.string().optional(),
 });
 


### PR DESCRIPTION
## What does this PR do?

This PR allows us to group env-vars when there are identical keys across multiple environments, collapsing them into expandable rows to reduce clutter.

https://github.com/user-attachments/assets/b90a7704-b642-4540-aaf9-ec059e237a56

