### PR TITLE
chore: remove redundant index

### DIFF
--- a/pkg/db/schema.sql
+++ b/pkg/db/schema.sql
@@ -805,7 +805,6 @@ CREATE INDEX `workspace_idx` ON `deployment_steps` (`workspace_id`);
 CREATE INDEX `workspace_idx` ON `deployment_topology` (`workspace_id`);
 CREATE INDEX `status_idx` ON `deployment_topology` (`desired_status`);
 CREATE INDEX `domain_idx` ON `acme_users` (`workspace_id`);
-CREATE INDEX `workspace_idx` ON `custom_domains` (`workspace_id`);
 CREATE INDEX `project_idx` ON `custom_domains` (`project_id`);
 CREATE INDEX `verification_status_idx` ON `custom_domains` (`verification_status`);
 CREATE INDEX `workspace_idx` ON `acme_challenges` (`workspace_id`);

--- a/pkg/mysql/schema.sql
+++ b/pkg/mysql/schema.sql
@@ -805,7 +805,6 @@ CREATE INDEX `workspace_idx` ON `deployment_steps` (`workspace_id`);
 CREATE INDEX `workspace_idx` ON `deployment_topology` (`workspace_id`);
 CREATE INDEX `status_idx` ON `deployment_topology` (`desired_status`);
 CREATE INDEX `domain_idx` ON `acme_users` (`workspace_id`);
-CREATE INDEX `workspace_idx` ON `custom_domains` (`workspace_id`);
 CREATE INDEX `project_idx` ON `custom_domains` (`project_id`);
 CREATE INDEX `verification_status_idx` ON `custom_domains` (`verification_status`);
 CREATE INDEX `workspace_idx` ON `acme_challenges` (`workspace_id`);

--- a/web/internal/db/src/schema/custom_domains.ts
+++ b/web/internal/db/src/schema/custom_domains.ts
@@ -51,7 +51,6 @@ export const customDomains = mysqlTable(
     ...lifecycleDates,
   },
   (table) => [
-    index("workspace_idx").on(table.workspaceId),
     index("project_idx").on(table.projectId),
     index("verification_status_idx").on(table.verificationStatus),
     uniqueIndex("unique_domain_workspace_idx").on(table.workspaceId, table.domain),


### PR DESCRIPTION
## What does this PR do?

Removes the redundant `workspace_idx` index on the `custom_domains` table. This index was unnecessary since there is already a unique composite index `unique_domain_workspace_idx` that includes `workspaceId` as the first column, which can serve the same query optimization purposes.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Verify that queries filtering by `workspace_id` on the `custom_domains` table still perform efficiently
- Run database migration to ensure the index is properly removed
- Test custom domain functionality to ensure no performance regression

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary