### PR TITLE
fix: preserver client ip

### DIFF
--- a/svc/frontline/services/proxy/director.go
+++ b/svc/frontline/services/proxy/director.go
@@ -29,6 +29,7 @@ func (s *service) makeSentinelDirector(sess *zen.Session, deploymentID string, s
 		})
 
 		req.Header.Set(HeaderForwardedProto, "https")
+		req.Header.Set("X-Forwarded-For", sess.Location())
 
 		// We always want to override the deployment id, even if the client send it.
 		req.Header.Set(HeaderDeploymentID, deploymentID)


### PR DESCRIPTION
## What does this PR do?

Adds the `X-Forwarded-For` header to the sentinel director proxy requests, setting it to the session location to properly track the original client IP address through the proxy chain.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Test that proxied requests include the `X-Forwarded-For` header with the correct session location
- Verify that downstream services can properly identify the original client IP address

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary