### PR TITLE
feat: move deployments from replicaset to k8s deployment

### DIFF
--- a/svc/krane/internal/deployment/apply.go
+++ b/svc/krane/internal/deployment/apply.go
@@ -21,10 +21,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-// ApplyDeployment creates or updates a user workload as a Kubernetes ReplicaSet
+// ApplyDeployment creates or updates a user workload as a Kubernetes Deployment
 // with an associated HorizontalPodAutoscaler (HPA).
 //
-// The method uses server-side apply to create or update the ReplicaSet.
+// The method uses server-side apply to create or update the Deployment.
 // spec.replicas is omitted so the HPA owns the replica count. The HPA's
 // minReplicas determines the minimum capacity; users should set this high
 // enough to handle traffic during rollouts.
@@ -186,21 +186,29 @@ func (c *Controller) ApplyDeployment(ctx context.Context, req *ctrlv1.ApplyDeplo
 
 	podSpec.ImagePullSecrets = c.imagePullSecrets
 
-	desired := &appsv1.ReplicaSet{
+	desired := &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps/v1",
-			Kind:       "ReplicaSet",
+			Kind:       "Deployment",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      req.GetK8SName(),
 			Namespace: req.GetK8SNamespace(),
 			Labels:    usedLabels,
 		},
-		Spec: appsv1.ReplicaSetSpec{
+		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: labels.New().DeploymentID(req.GetDeploymentId()),
 			},
-			MinReadySeconds: 30,
+			MinReadySeconds:      30,
+			RevisionHistoryLimit: ptr.P(int32(0)),
+			Strategy: appsv1.DeploymentStrategy{
+				Type: appsv1.RollingUpdateDeploymentStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateDeployment{
+					MaxUnavailable: ptr.P(intstr.FromInt(0)),
+					MaxSurge:       ptr.P(intstr.FromInt(1)),
+				},
+			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: fmt.Sprintf("%s-", req.GetK8SName()),
@@ -211,10 +219,10 @@ func (c *Controller) ApplyDeployment(ctx context.Context, req *ctrlv1.ApplyDeplo
 		},
 	}
 
-	// Create the Secret and ServiceAccount before the ReplicaSet so they
+	// Create the Secret and ServiceAccount before the Deployment so they
 	// exist by the time pods are scheduled. This prevents the
 	// "serviceaccount not found" race condition. We patch ownerReferences
-	// onto them after the RS is created so K8s still garbage-collects them.
+	// onto them after the Deployment is created so K8s still garbage-collects them.
 	if hasSecrets {
 		if err := c.ensureDeploymentSecret(ctx, req.GetK8SNamespace(), req.GetDeploymentId(), plaintext); err != nil {
 			return fmt.Errorf("failed to ensure deployment secret: %w", err)
@@ -224,26 +232,26 @@ func (c *Controller) ApplyDeployment(ctx context.Context, req *ctrlv1.ApplyDeplo
 		}
 	}
 
-	client := c.clientSet.AppsV1().ReplicaSets(req.GetK8SNamespace())
+	client := c.clientSet.AppsV1().Deployments(req.GetK8SNamespace())
 
 	patch, err := json.Marshal(desired)
 	if err != nil {
-		return fmt.Errorf("failed to marshal replicaset: %w", err)
+		return fmt.Errorf("failed to marshal deployment: %w", err)
 	}
 
 	applied, err := client.Patch(ctx, req.GetK8SName(), types.ApplyPatchType, patch, metav1.PatchOptions{
 		FieldManager: fieldManagerKrane,
 	})
 	if err != nil {
-		return fmt.Errorf("failed to apply replicaset: %w", err)
+		return fmt.Errorf("failed to apply deployment: %w", err)
 	}
 
 	// Patch ownerReferences onto the Secret and SA so K8s garbage-collects
-	// them when the ReplicaSet is deleted.
+	// them when the Deployment is deleted.
 	if hasSecrets {
 		ownerRef := metav1.OwnerReference{
 			APIVersion:         "apps/v1",
-			Kind:               "ReplicaSet",
+			Kind:               "Deployment",
 			Name:               applied.Name,
 			UID:                applied.UID,
 			Controller:         ptr.P(true),
@@ -310,9 +318,9 @@ func unmarshalHealthcheck(data []byte) *dbtype.Healthcheck {
 }
 
 // ensureHPAExists creates or updates a HorizontalPodAutoscaler that scales the
-// deployment's ReplicaSet using the autoscaling policy from the control plane.
-// The HPA is owned by the ReplicaSet for automatic garbage collection.
-func (c *Controller) ensureHPAExists(ctx context.Context, req *ctrlv1.ApplyDeployment, rs *appsv1.ReplicaSet) error {
+// Deployment using the autoscaling policy from the control plane.
+// The HPA is owned by the Deployment for automatic garbage collection.
+func (c *Controller) ensureHPAExists(ctx context.Context, req *ctrlv1.ApplyDeployment, deploy *appsv1.Deployment) error {
 	client := c.clientSet.AutoscalingV2().HorizontalPodAutoscalers(req.GetK8SNamespace())
 
 	policy := req.GetAutoscaling()
@@ -378,9 +386,9 @@ func (c *Controller) ensureHPAExists(ctx context.Context, req *ctrlv1.ApplyDeplo
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion:         "apps/v1",
-					Kind:               "ReplicaSet",
-					Name:               rs.Name,
-					UID:                rs.UID,
+					Kind:               "Deployment",
+					Name:               deploy.Name,
+					UID:                deploy.UID,
 					Controller:         ptr.P(true),
 					BlockOwnerDeletion: ptr.P(true),
 				},
@@ -390,7 +398,7 @@ func (c *Controller) ensureHPAExists(ctx context.Context, req *ctrlv1.ApplyDeplo
 		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
 			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 				APIVersion: "apps/v1",
-				Kind:       "ReplicaSet",
+				Kind:       "Deployment",
 				Name:       req.GetK8SName(),
 			},
 			MinReplicas: ptr.P(minReplicas),

--- a/svc/krane/internal/deployment/controller.go
+++ b/svc/krane/internal/deployment/controller.go
@@ -17,7 +17,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-// Controller manages deployment ReplicaSets in a Kubernetes cluster by maintaining
+// Controller manages user workload Deployments in a Kubernetes cluster by maintaining
 // bidirectional state synchronization with the control plane.
 //
 // The controller receives desired state via the WatchDeployments stream and reports
@@ -40,9 +40,9 @@ type Controller struct {
 	platform         string
 	versionLastSeen  uint64
 
-	// fingerprints tracks the most recently reported state per ReplicaSet
+	// fingerprints tracks the most recently reported state per Deployment
 	// so we can skip redundant reports during resync. Entries auto-expire
-	// via the cache's TTL, preventing unbounded growth from deleted RSs.
+	// via the cache's TTL, preventing unbounded growth from deleted Deployments.
 	fingerprints cache.Cache[string, string]
 }
 
@@ -52,7 +52,7 @@ type Controller struct {
 // operations, while Cluster provides the control plane RPC client for state
 // synchronization. Region determines which deployments this controller manages.
 type Config struct {
-	// ClientSet provides typed Kubernetes API access for ReplicaSet and Pod operations.
+	// ClientSet provides typed Kubernetes API access for Deployment and Pod operations.
 	ClientSet kubernetes.Interface
 
 	// DynamicClient provides unstructured Kubernetes API access for CiliumNetworkPolicy

--- a/svc/krane/internal/deployment/delete.go
+++ b/svc/krane/internal/deployment/delete.go
@@ -9,9 +9,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// DeleteDeployment removes a user workload's ReplicaSet from the cluster.
+// DeleteDeployment removes a user workload's Deployment from the cluster.
 // Owned resources (Secret, ServiceAccount, Role, RoleBinding) are garbage-collected
-// automatically by K8s via ownerReferences.
+// automatically by K8s via ownerReferences. The child ReplicaSet and its pods are
+// cascade-deleted by Kubernetes.
 //
 // Not-found errors are ignored since the desired end state (resource gone) is
 // already achieved. After deletion, the method reports the deletion to the control
@@ -22,7 +23,7 @@ func (c *Controller) DeleteDeployment(ctx context.Context, req *ctrlv1.DeleteDep
 		"name", req.GetK8SName(),
 	)
 
-	err := c.clientSet.AppsV1().ReplicaSets(req.GetK8SNamespace()).Delete(ctx, req.GetK8SName(), metav1.DeleteOptions{})
+	err := c.clientSet.AppsV1().Deployments(req.GetK8SNamespace()).Delete(ctx, req.GetK8SName(), metav1.DeleteOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}

--- a/svc/krane/internal/deployment/doc.go
+++ b/svc/krane/internal/deployment/doc.go
@@ -1,4 +1,4 @@
-// Package deployment manages user workload ReplicaSets in Kubernetes as part of
+// Package deployment manages user workload Deployments in Kubernetes as part of
 // krane's split control loop architecture.
 //
 // The package provides [Controller], which operates independently from the sentinel
@@ -16,13 +16,13 @@
 //
 // [Controller.runPodWatchLoop] watches Kubernetes for pod changes and reports actual
 // state back to the control plane via ReportDeploymentStatus. Watching pods directly
-// (rather than ReplicaSets) means IP assignments and readiness changes are reported
-// immediately without waiting for the RS status to roll up.
+// (rather than Deployments) means IP assignments and readiness changes are reported
+// immediately without waiting for the Deployment status to roll up.
 //
 // [Controller.runResyncLoop] runs every minute as a consistency safety net. While the
 // other loops handle real-time events, they can miss updates during network partitions,
 // controller restarts, or buffer overflows. The resync loop queries the control plane
-// for each existing ReplicaSet and applies any drift.
+// for each existing Deployment and applies any drift.
 //
 // # Security
 //

--- a/svc/krane/internal/deployment/pod_watch.go
+++ b/svc/krane/internal/deployment/pod_watch.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/svc/krane/pkg/labels"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
@@ -16,8 +17,9 @@ import (
 // to the control plane in real-time.
 //
 // The watch filters for pods with "managed-by: krane" and "component: deployment"
-// labels. On any pod event it finds the owning ReplicaSet, rebuilds the full
-// deployment status, and reports it (deduplicated via fingerprinting).
+// labels. On any pod event it finds the owning Deployment (via the intermediate
+// ReplicaSet), rebuilds the full deployment status, and reports it (deduplicated
+// via fingerprinting).
 //
 // The initial watch must succeed for the controller to start. After that the
 // goroutine automatically reconnects with jittered backoff (1-5s) when the
@@ -90,26 +92,37 @@ func (c *Controller) drainPodWatch(ctx context.Context, w watch.Interface) {
 
 			rs, err := c.clientSet.AppsV1().ReplicaSets(pod.Namespace).Get(ctx, rsName, metav1.GetOptions{})
 			if err != nil {
-				// RS already deleted — resync loop handles orphan cleanup.
 				logger.Info("pod watch: replicaset not found, skipping", "pod", pod.Name, "replicaSet", rsName, "error", err.Error())
 				continue
 			}
 
-			status, err := c.buildDeploymentStatus(ctx, rs)
+			deployName := owningDeployment(rs)
+			if deployName == "" {
+				logger.Info("pod watch: replicaset has no owning deployment, skipping", "pod", pod.Name, "replicaSet", rsName)
+				continue
+			}
+
+			deploy, err := c.clientSet.AppsV1().Deployments(pod.Namespace).Get(ctx, deployName, metav1.GetOptions{})
 			if err != nil {
-				logger.Error("pod watch: unable to build status", "error", err.Error(), "replicaSet", rsName)
+				logger.Info("pod watch: deployment not found, skipping", "pod", pod.Name, "deployment", deployName, "error", err.Error())
+				continue
+			}
+
+			status, err := c.buildDeploymentStatus(ctx, deploy)
+			if err != nil {
+				logger.Error("pod watch: unable to build status", "error", err.Error(), "deployment", deployName)
 				continue
 			}
 
 			reported, err := c.reportIfChanged(ctx, status)
 			if err != nil {
-				logger.Error("pod watch: unable to report status", "error", err.Error(), "replicaSet", rsName)
+				logger.Error("pod watch: unable to report status", "error", err.Error(), "deployment", deployName)
 				continue
 			}
 			if reported {
-				logger.Info("pod watch: reported changed status", "replicaSet", rsName, "pod", pod.Name, "instances", len(status.GetUpdate().GetInstances()))
+				logger.Info("pod watch: reported changed status", "deployment", deployName, "pod", pod.Name, "instances", len(status.GetUpdate().GetInstances()))
 			} else {
-				logger.Info("pod watch: status unchanged, skipped report", "replicaSet", rsName, "pod", pod.Name)
+				logger.Info("pod watch: status unchanged, skipped report", "deployment", deployName, "pod", pod.Name)
 			}
 		}
 	}
@@ -120,6 +133,17 @@ func (c *Controller) drainPodWatch(ctx context.Context, w watch.Interface) {
 func owningReplicaSet(pod *corev1.Pod) string {
 	for _, ref := range pod.OwnerReferences {
 		if ref.Kind == "ReplicaSet" && ref.Controller != nil && *ref.Controller {
+			return ref.Name
+		}
+	}
+	return ""
+}
+
+// owningDeployment returns the name of the Deployment that owns this ReplicaSet,
+// or empty string if no controller owner reference with Kind "Deployment" exists.
+func owningDeployment(rs *appsv1.ReplicaSet) string {
+	for _, ref := range rs.OwnerReferences {
+		if ref.Kind == "Deployment" && ref.Controller != nil && *ref.Controller {
 			return ref.Name
 		}
 	}

--- a/svc/krane/internal/deployment/rbac.go
+++ b/svc/krane/internal/deployment/rbac.go
@@ -16,7 +16,7 @@ import (
 // ensureDeploymentServiceAccount creates a ServiceAccount for the deployment.
 // The SA is referenced by podSpec.ServiceAccountName so the pod doesn't use the
 // namespace default. automountServiceAccountToken is false — no API access is needed.
-// The SA is owned by the ReplicaSet via ownerRef for automatic GC.
+// The SA is owned by the Deployment via ownerRef for automatic GC.
 func (c *Controller) ensureDeploymentServiceAccount(ctx context.Context, namespace, deploymentID string) error {
 	saName := deploymentResourcePrefix(deploymentID)
 	commonLabels := labels.New().DeploymentID(deploymentID).ManagedByKrane()
@@ -38,7 +38,7 @@ func (c *Controller) ensureDeploymentServiceAccount(ctx context.Context, namespa
 }
 
 // patchOwnerRef patches the ownerReferences on the Secret and ServiceAccount
-// for the given resource name so they are garbage-collected with the ReplicaSet.
+// for the given resource name so they are garbage-collected with the Deployment.
 func (c *Controller) patchOwnerRef(ctx context.Context, namespace, name string, ownerRef metav1.OwnerReference) error {
 	ownerPatch, err := json.Marshal(map[string]any{
 		"metadata": map[string]any{

--- a/svc/krane/internal/deployment/resync.go
+++ b/svc/krane/internal/deployment/resync.go
@@ -12,27 +12,26 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// runResyncLoop periodically reconciles all deployment ReplicaSets with their
-// desired state from the control plane.
+// runResyncLoop periodically reconciles all Deployments with their desired state
+// from the control plane.
 //
 // The loop runs every minute as a consistency safety net. While
 // [Controller.runPodWatchLoop] handles real-time Kubernetes events and
 // [Controller.runDesiredStateApplyLoop] handles streaming updates, both can miss
 // events during network partitions, controller restarts, or watch buffer overflows.
 // This resync loop guarantees eventual consistency by querying the control plane
-// for each existing ReplicaSet and applying any drift.
+// for each existing Deployment and applying any drift.
 //
-// The loop paginates through all krane-managed deployment ReplicaSets across all
-// namespaces, calling GetDesiredDeploymentState for each and applying or deleting
-// as directed. Errors are logged but don't stop the loop from processing remaining
-// ReplicaSets.
+// The loop paginates through all krane-managed Deployments across all namespaces,
+// calling GetDesiredDeploymentState for each and applying or deleting as directed.
+// Errors are logged but don't stop the loop from processing remaining Deployments.
 func (c *Controller) runResyncLoop(ctx context.Context) {
 	repeat.Every(1*time.Minute, func() {
 		logger.Info("running periodic resync")
 
 		cursor := ""
 		for {
-			replicaSets, err := c.clientSet.AppsV1().ReplicaSets("").List(ctx, metav1.ListOptions{
+			deployments, err := c.clientSet.AppsV1().Deployments("").List(ctx, metav1.ListOptions{
 				LabelSelector: labels.New().
 					ManagedByKrane().
 					ComponentDeployment().
@@ -40,26 +39,26 @@ func (c *Controller) runResyncLoop(ctx context.Context) {
 				Continue: cursor,
 			})
 			if err != nil {
-				logger.Error("unable to list replicaSets", "error", err.Error())
+				logger.Error("unable to list deployments", "error", err.Error())
 				return
 			}
 
-			for _, replicaSet := range replicaSets.Items {
+			for _, deployment := range deployments.Items {
 				// Report actual state back to the control plane if it differs
 				// from the last report. This catches pods that were skipped
 				// earlier (e.g. no IP yet) or watch events that were missed.
-				status, buildErr := c.buildDeploymentStatus(ctx, &replicaSet)
+				status, buildErr := c.buildDeploymentStatus(ctx, &deployment)
 				if buildErr != nil {
-					logger.Error("resync: unable to build deployment status", "error", buildErr.Error(), "replicaSet", replicaSet.Name)
+					logger.Error("resync: unable to build deployment status", "error", buildErr.Error(), "deployment", deployment.Name)
 				} else if reported, reportErr := c.reportIfChanged(ctx, status); reportErr != nil {
-					logger.Error("resync: unable to report deployment status", "error", reportErr.Error(), "replicaSet", replicaSet.Name)
+					logger.Error("resync: unable to report deployment status", "error", reportErr.Error(), "deployment", deployment.Name)
 				} else if reported {
-					logger.Info("resync: reported changed deployment status", "replicaSet", replicaSet.Name)
+					logger.Info("resync: reported changed deployment status", "deployment", deployment.Name)
 				}
 
-				deploymentID, ok := labels.GetDeploymentID(replicaSet.Labels)
+				deploymentID, ok := labels.GetDeploymentID(deployment.Labels)
 				if !ok {
-					logger.Error("unable to get deployment ID", "replicaSet", replicaSet.Name)
+					logger.Error("unable to get deployment ID", "deployment", deployment.Name)
 					continue
 				}
 
@@ -69,8 +68,8 @@ func (c *Controller) runResyncLoop(ctx context.Context) {
 				if err != nil {
 					if connect.CodeOf(err) == connect.CodeNotFound {
 						if err := c.DeleteDeployment(ctx, &ctrlv1.DeleteDeployment{
-							K8SNamespace: replicaSet.GetNamespace(),
-							K8SName:      replicaSet.GetName(),
+							K8SNamespace: deployment.GetNamespace(),
+							K8SName:      deployment.GetName(),
 						}); err != nil {
 							logger.Error("unable to delete deployment", "error", err.Error(), "deployment_id", deploymentID)
 							continue
@@ -93,7 +92,7 @@ func (c *Controller) runResyncLoop(ctx context.Context) {
 				}
 			}
 
-			cursor = replicaSets.Continue
+			cursor = deployments.Continue
 			if cursor == "" {
 				break
 			}

--- a/svc/krane/internal/deployment/secrets.go
+++ b/svc/krane/internal/deployment/secrets.go
@@ -57,7 +57,7 @@ func deploymentResourcePrefix(deploymentID string) string {
 
 // ensureDeploymentSecret creates or updates a K8s Secret containing the plaintext
 // environment variables for the deployment. Uses server-side apply for idempotency.
-// The ownerRef ties the secret's lifecycle to the ReplicaSet for automatic GC.
+// The ownerRef ties the secret's lifecycle to the Deployment for automatic GC.
 func (c *Controller) ensureDeploymentSecret(ctx context.Context, namespace, deploymentID string, envVars map[string]string) error {
 	secretName := deploymentResourcePrefix(deploymentID)
 

--- a/svc/krane/internal/deployment/state.go
+++ b/svc/krane/internal/deployment/state.go
@@ -11,7 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// buildDeploymentStatus queries the pods belonging to a ReplicaSet and builds a
+// buildDeploymentStatus queries the pods belonging to a Deployment and builds a
 // status report for the control plane.
 //
 // The report includes each pod's cluster-local DNS address, CPU and memory limits,
@@ -22,29 +22,29 @@ import (
 // Pod phase is mapped to instance status: Running pods with all containers ready
 // become STATUS_RUNNING, Pending pods become STATUS_PENDING, and Failed pods or
 // Running pods with unready containers become STATUS_FAILED.
-func (c *Controller) buildDeploymentStatus(ctx context.Context, replicaset *appsv1.ReplicaSet) (*ctrlv1.ReportDeploymentStatusRequest, error) {
-	selector, err := metav1.LabelSelectorAsSelector(replicaset.Spec.Selector)
+func (c *Controller) buildDeploymentStatus(ctx context.Context, deploy *appsv1.Deployment) (*ctrlv1.ReportDeploymentStatusRequest, error) {
+	selector, err := metav1.LabelSelectorAsSelector(deploy.Spec.Selector)
 	if err != nil {
 		return nil, err
 	}
 
-	pods, err := c.clientSet.CoreV1().Pods(replicaset.Namespace).List(ctx, metav1.ListOptions{
+	pods, err := c.clientSet.CoreV1().Pods(deploy.Namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: selector.String(),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list pods: %w", err)
 	}
 
-	// Read the port from the ReplicaSet's container spec
+	// Read the port from the Deployment's container spec
 	containerPort := int32(8080)
-	if containers := replicaset.Spec.Template.Spec.Containers; len(containers) > 0 {
+	if containers := deploy.Spec.Template.Spec.Containers; len(containers) > 0 {
 		if ports := containers[0].Ports; len(ports) > 0 {
 			containerPort = ports[0].ContainerPort
 		}
 	}
 
 	update := &ctrlv1.ReportDeploymentStatusRequest_Update{
-		K8SName:   replicaset.Name,
+		K8SName:   deploy.Name,
 		Instances: make([]*ctrlv1.ReportDeploymentStatusRequest_Update_Instance, 0, len(pods.Items)),
 	}
 


### PR DESCRIPTION
## What does this PR do?

Migrates user workload management from Kubernetes ReplicaSets to Deployments in the krane deployment controller. This change provides better rollout capabilities and aligns with standard Kubernetes practices for managing stateless applications.

The migration includes:
- Replacing ReplicaSet creation with Deployment resources
- Adding deployment strategy configuration with rolling updates (maxUnavailable: 0, maxSurge: 1)
- Setting revision history limit to 0 to minimize storage overhead
- Updating HorizontalPodAutoscaler to target Deployments instead of ReplicaSets
- Modifying pod watch logic to traverse the ownership chain from Pod → ReplicaSet → Deployment
- Updating all comments and documentation to reflect the new architecture

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Deploy a workload and verify it creates a Deployment instead of a ReplicaSet
- Test autoscaling behavior to ensure HPA correctly targets the Deployment
- Verify pod watch functionality reports status changes correctly through the Pod → ReplicaSet → Deployment ownership chain
- Test deployment deletion and confirm cascade deletion of child ReplicaSets and pods
- Validate resync loop correctly processes Deployments instead of ReplicaSets

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary