### PR TITLE
refactor: force dismiss redeploy banner

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/env-vars/deployment-env-vars.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/env-vars/deployment-env-vars.tsx
@@ -3,7 +3,6 @@
 import { useState } from "react";
 import { useProjectData } from "../data-provider";
 import { useOptionalProjectLayout } from "../layout-provider";
-import { PendingRedeployBanner } from "../settings/pending-redeploy-banner";
 import { AddEnvVarExpandable } from "./components/add/add-env-var-expandable";
 import { EnvVarsList } from "./components/list/env-vars-list";
 import { EnvVarsHeader } from "./components/toolbar/env-vars-header";
@@ -48,7 +47,6 @@ export function DeploymentEnvVars() {
           sortBy={sortBy}
         />
       </div>
-      <PendingRedeployBanner />
     </>
   );
 }

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/page.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/page.tsx
@@ -5,8 +5,6 @@ import { SettingsShell } from "@unkey/ui";
 import { DeleteProject } from "./components/delete-project";
 import { DeploymentSettings } from "./deployment-settings";
 import { EnvironmentSettingsProvider } from "./environment-provider";
-import { PendingRedeployBanner } from "./pending-redeploy-banner";
-
 export default function SettingsPage() {
   const { bypass } = usePreventLeave();
 
@@ -21,7 +19,6 @@ export default function SettingsPage() {
         </div>
         <DeploymentSettings onBeforeNavigate={bypass} />
       </SettingsShell>
-      <PendingRedeployBanner />
       <DeleteProject />
     </EnvironmentSettingsProvider>
   );

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/components/pending-redeploy-banner.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/components/pending-redeploy-banner.tsx
@@ -2,26 +2,31 @@
 
 import { useWorkspaceNavigation } from "@/hooks/use-workspace-navigation";
 import { queryClient } from "@/lib/collections/client";
-import { useSettingsHasSaved } from "@/lib/collections/deploy/environment-settings";
+import {
+  dismissSettingsBanner,
+  useSettingsBannerVisible,
+} from "@/lib/collections/deploy/environment-settings";
 import { trpc } from "@/lib/trpc/client";
+import { cn } from "@/lib/utils";
 import { Hammer2, XMark } from "@unkey/icons";
 import { Button, toast } from "@unkey/ui";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
-import { GlowIcon } from "../../components/glow-icon";
-import { useProjectData } from "../data-provider";
+import { useEffect } from "react";
+import { useProjectData } from "../(overview)/data-provider";
+import { GlowIcon } from "../components/glow-icon";
 
 export function PendingRedeployBanner() {
-  const [dismissed, setDismissed] = useState(false);
   const { project, deployments, projectId } = useProjectData();
   const router = useRouter();
   const workspace = useWorkspaceNavigation();
-  const hasSaved = useSettingsHasSaved();
-  const visible = hasSaved && !dismissed;
+  const visible = useSettingsBannerVisible();
+  const currentDeploymentId = project?.currentDeploymentId;
 
-  const currentDeployment = project?.currentDeploymentId
-    ? deployments.find((d) => d.id === project.currentDeploymentId)
+  const currentDeployment = currentDeploymentId
+    ? deployments.find((d) => d.id === currentDeploymentId)
     : undefined;
+
+  const show = visible && !!currentDeployment;
 
   const redeploy = trpc.deploy.deployment.redeploy.useMutation({
     onSuccess: async (data) => {
@@ -38,16 +43,32 @@ export function PendingRedeployBanner() {
     },
   });
 
-  if (!visible || !currentDeployment) {
-    return null;
-  }
+  useEffect(
+    function getDismissedAutomatically() {
+      if (!visible || !currentDeploymentId) {
+        return;
+      }
+      const timer = setTimeout(() => dismissSettingsBanner(), 10_000);
+      return () => {
+        clearTimeout(timer);
+      };
+    },
+    [visible, currentDeploymentId],
+  );
 
   return (
-    <div className="fixed top-6 right-6 z-50 animate-fade-slide-in">
+    <div
+      aria-hidden={!show}
+      inert={!show || undefined}
+      className={cn(
+        "fixed top-6 right-6 z-50 transition-[transform,opacity] duration-300 ease-out",
+        show ? "translate-x-0 opacity-100" : "translate-x-[calc(100%+24px)] opacity-0",
+      )}
+    >
       <div className="relative flex items-start gap-4 rounded-xl border border-gray-4 bg-gray-1 p-4 shadow-lg w-100">
         <button
           type="button"
-          onClick={() => setDismissed(true)}
+          onClick={() => dismissSettingsBanner()}
           className="absolute top-3 right-3 text-gray-9 hover:text-gray-11 transition-colors cursor-pointer"
           aria-label="Dismiss"
         >
@@ -55,7 +76,7 @@ export function PendingRedeployBanner() {
         </button>
 
         <GlowIcon
-          icon={<Hammer2 iconSize="sm-medium" className="size-[18px]" />}
+          icon={<Hammer2 iconSize="sm-medium" className="size-4.5" />}
           className="w-9 h-9 shrink-0"
         />
 
@@ -73,7 +94,9 @@ export function PendingRedeployBanner() {
             disabled={redeploy.isLoading}
             loading={redeploy.isLoading}
             onClick={() => {
-              redeploy.mutate({ deploymentId: currentDeployment.id });
+              if (currentDeployment) {
+                redeploy.mutate({ deploymentId: currentDeployment.id });
+              }
             }}
           >
             Redeploy

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/layout.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/layout.tsx
@@ -4,6 +4,7 @@ import { ProjectDataProvider, useProjectData } from "./(overview)/data-provider"
 import { ProjectDetailsExpandable } from "./(overview)/details/project-details-expandables";
 import { ProjectLayoutContext } from "./(overview)/layout-provider";
 import { ProjectNavigation } from "./(overview)/navigations/project-navigation";
+import { PendingRedeployBanner } from "./components/pending-redeploy-banner";
 
 export default function ProjectLayoutWrapper({ children }: PropsWithChildren) {
   return <ProjectLayout>{children}</ProjectLayout>;
@@ -47,6 +48,7 @@ const ProjectLayoutInner = ({ children }: PropsWithChildren) => {
             onClose={() => setIsDetailsOpen(false)}
           />
         </div>
+        <PendingRedeployBanner />
       </div>
     </ProjectLayoutContext.Provider>
   );

--- a/web/apps/dashboard/lib/collections/deploy/environment-settings.ts
+++ b/web/apps/dashboard/lib/collections/deploy/environment-settings.ts
@@ -321,6 +321,7 @@ async function dispatchSettingsMutations(
 const saveStore = {
   pendingSaves: 0,
   savedCount: 0,
+  dismissedAtCount: 0,
   listeners: new Set<() => void>(),
   notify() {
     for (const cb of this.listeners) {
@@ -332,6 +333,10 @@ const saveStore = {
     return () => {
       this.listeners.delete(cb);
     };
+  },
+  dismiss() {
+    this.dismissedAtCount = this.savedCount;
+    this.notify();
   },
 };
 
@@ -360,10 +365,15 @@ export function useSettingsIsSaving(): boolean {
   );
 }
 
-/** Returns true once at least one settings save has completed in this session. */
-export function useSettingsHasSaved(): boolean {
+/** Returns true when there are saves the user hasn't dismissed yet. Survives navigation. */
+export function useSettingsBannerVisible(): boolean {
   return useSyncExternalStore(
     (cb) => saveStore.subscribe(cb),
-    () => saveStore.savedCount > 0,
+    () => saveStore.savedCount > saveStore.dismissedAtCount,
   );
+}
+
+/** Dismisses the pending-redeploy banner until a new save occurs. */
+export function dismissSettingsBanner(): void {
+  saveStore.dismiss();
 }


### PR DESCRIPTION
## What does this PR do?

This PR force dismisses redeploy banner also moves it to project layout so it only has one instance all the time and can be accessed everywhere within projects.

https://github.com/user-attachments/assets/2f144eae-722a-4d1e-a41b-aa649cb1fb1a

