### PR TITLE
feat: upstream protocol UI in dashboard

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/runtime-settings/upstream-protocol.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/runtime-settings/upstream-protocol.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Connections } from "@unkey/icons";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@unkey/ui";
+import { Controller, useForm, useWatch } from "react-hook-form";
+import { z } from "zod";
+import { useEnvironmentSettings } from "../../environment-provider";
+import { useUpdateAllEnvironments } from "../../hooks/use-update-all-environments";
+import { SettingField } from "../shared/form-blocks";
+import { FormSettingCard, resolveSaveState } from "../shared/form-setting-card";
+
+const PROTOCOLS = [
+  { value: "http1", label: "HTTP/1.1" },
+  { value: "h2c", label: "HTTP/2 (h2c)" },
+] as const;
+
+const schema = z.object({
+  upstreamProtocol: z.enum(["http1", "h2c"]),
+});
+
+const displayLabel = (value: string) => PROTOCOLS.find((p) => p.value === value)?.label ?? value;
+
+export const UpstreamProtocol = () => {
+  const { settings, variant } = useEnvironmentSettings();
+  const { upstreamProtocol: defaultValue } = settings;
+  const updateAllEnvironments = useUpdateAllEnvironments();
+
+  const {
+    control,
+    handleSubmit,
+    formState: { isValid, isSubmitting },
+  } = useForm<z.infer<typeof schema>>({
+    resolver: zodResolver(schema),
+    mode: "onChange",
+    defaultValues: { upstreamProtocol: defaultValue },
+  });
+
+  const currentProtocol = useWatch({ control, name: "upstreamProtocol" });
+
+  const saveState = resolveSaveState([
+    [isSubmitting, { status: "saving" }],
+    [!isValid, { status: "disabled" }],
+    [currentProtocol === defaultValue, { status: "disabled", reason: "No changes to save" }],
+  ]);
+
+  const onSubmit = async (values: z.infer<typeof schema>) => {
+    updateAllEnvironments((draft) => {
+      draft.upstreamProtocol = values.upstreamProtocol;
+    });
+  };
+
+  return (
+    <FormSettingCard
+      icon={<Connections className="text-gray-12" iconSize="xl-medium" />}
+      title="Upstream Protocol"
+      description={
+        <>
+          Protocol used to connect to your application. If you don&apos;t know what this is, use
+          HTTP/1.1.{" "}
+          <a
+            href="https://www.unkey.com/docs/platform/apps/settings#upstream-protocol"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline text-accent-11"
+          >
+            Learn more
+          </a>
+          .
+        </>
+      }
+      displayValue={displayLabel(defaultValue)}
+      onSubmit={handleSubmit(onSubmit)}
+      saveState={saveState}
+      autoSave={variant === "onboarding"}
+    >
+      <SettingField>
+        <Controller
+          control={control}
+          name="upstreamProtocol"
+          render={({ field }) => (
+            <Select value={field.value} onValueChange={field.onChange}>
+              <SelectTrigger>
+                <SelectValue placeholder="Select protocol" />
+              </SelectTrigger>
+              <SelectContent>
+                {PROTOCOLS.map((protocol) => (
+                  <SelectItem
+                    key={protocol.value}
+                    value={protocol.value}
+                    className="focus:bg-gray-3"
+                  >
+                    {protocol.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+        />
+      </SettingField>
+    </FormSettingCard>
+  );
+};

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/shared/form-setting-card.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/shared/form-setting-card.tsx
@@ -6,7 +6,7 @@ import { SelectedConfig } from "./selected-config";
 type EditableSettingCardProps = {
   icon: React.ReactNode;
   title: string;
-  description: string;
+  description: React.ReactNode;
   border?: SettingCardBorder;
 
   displayValue: React.ReactNode;

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/deployment-settings.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/deployment-settings.tsx
@@ -14,6 +14,7 @@ import { Instances } from "./components/runtime-settings/instances";
 import { Memory } from "./components/runtime-settings/memory";
 import { Port } from "./components/runtime-settings/port-settings";
 import { Regions } from "./components/runtime-settings/regions";
+import { UpstreamProtocol } from "./components/runtime-settings/upstream-protocol";
 
 import { CustomDomains } from "./components/advanced-settings/custom-domains";
 
@@ -70,6 +71,7 @@ export const DeploymentSettings = ({
         <SettingCardGroup>
           <CustomDomains />
           <OpenapiSpecPath />
+          <UpstreamProtocol />
         </SettingCardGroup>
       </SettingsGroup>
       <SettingsGroup

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/new/steps/configure-deployment/environment-inner.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/new/steps/configure-deployment/environment-inner.tsx
@@ -99,6 +99,7 @@ function useInitializeSettings(
       healthcheck: null,
       regions: availableRegions.map((r) => ({ id: r.id, name: r.name, replicas: 1 })),
       shutdownSignal: d.shutdownSignal,
+      upstreamProtocol: d.upstreamProtocol,
       sentinelConfig: undefined,
       openapiSpecPath: null,
     };
@@ -115,6 +116,7 @@ function useInitializeSettings(
       healthcheck: null,
       regions: [],
       shutdownSignal: "",
+      upstreamProtocol: "http1",
       sentinelConfig: undefined,
       openapiSpecPath: null,
     };

--- a/web/apps/dashboard/lib/collections/deploy/environment-settings.ts
+++ b/web/apps/dashboard/lib/collections/deploy/environment-settings.ts
@@ -46,6 +46,7 @@ const schema = z.object({
   healthcheck: healthcheckSchema,
   regions: z.array(z.object({ id: z.string(), name: z.string(), replicas: z.number().int() })),
   shutdownSignal: z.string(),
+  upstreamProtocol: z.enum(["http1", "h2c"]).default("http1"),
   sentinelConfig: sentinelConfigSchema,
   openapiSpecPath: z.string().nullable().default(null),
 });
@@ -112,6 +113,7 @@ export const ENVIRONMENT_SETTINGS_DEFAULTS = {
   cpuMillicores: 250,
   memoryMib: 256,
   shutdownSignal: "SIGTERM",
+  upstreamProtocol: "http1",
 } as const;
 
 type SettingsResponse = Awaited<ReturnType<typeof trpcClient.deploy.environmentSettings.get.query>>;
@@ -149,6 +151,7 @@ function flattenSettingsResponse(
         replicas: r.replicas,
       })),
     shutdownSignal: d.shutdownSignal,
+    upstreamProtocol: (runtime?.upstreamProtocol as "http1" | "h2c") ?? d.upstreamProtocol,
     sentinelConfig: runtime?.sentinelConfig,
     openapiSpecPath: runtime?.openapiSpecPath ?? null,
   };
@@ -271,6 +274,15 @@ export function buildSettingsMutations(
       trpcClient.deploy.environmentSettings.sentinel.updateMiddleware.mutate({
         environmentId,
         keyspaceIds: extractKeyspaceIds(modified.sentinelConfig),
+      }),
+    );
+  }
+
+  if (modified.upstreamProtocol !== original.upstreamProtocol) {
+    mutations.push(
+      trpcClient.deploy.environmentSettings.runtime.updateUpstreamProtocol.mutate({
+        environmentId,
+        upstreamProtocol: modified.upstreamProtocol,
       }),
     );
   }

--- a/web/apps/dashboard/lib/trpc/routers/deploy/environment-settings/runtime/update-upstream-protocol.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/environment-settings/runtime/update-upstream-protocol.ts
@@ -1,0 +1,40 @@
+import { and, db, eq } from "@/lib/db";
+import { TRPCError } from "@trpc/server";
+import { appRuntimeSettings, environments } from "@unkey/db/src/schema";
+import { z } from "zod";
+import { workspaceProcedure } from "../../../../trpc";
+
+export const updateUpstreamProtocol = workspaceProcedure
+  .input(
+    z.object({
+      environmentId: z.string(),
+      upstreamProtocol: z.enum(["http1", "h2c"]),
+    }),
+  )
+  .mutation(async ({ ctx, input }) => {
+    const env = await db.query.environments.findFirst({
+      where: and(
+        eq(environments.id, input.environmentId),
+        eq(environments.workspaceId, ctx.workspace.id),
+      ),
+      columns: { appId: true },
+    });
+    if (!env) {
+      throw new TRPCError({ code: "NOT_FOUND", message: "Environment not found" });
+    }
+
+    await db
+      .insert(appRuntimeSettings)
+      .values({
+        workspaceId: ctx.workspace.id,
+        appId: env.appId,
+        environmentId: input.environmentId,
+        upstreamProtocol: input.upstreamProtocol,
+        sentinelConfig: "{}",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      })
+      .onDuplicateKeyUpdate({
+        set: { upstreamProtocol: input.upstreamProtocol, updatedAt: Date.now() },
+      });
+  });

--- a/web/apps/dashboard/lib/trpc/routers/index.ts
+++ b/web/apps/dashboard/lib/trpc/routers/index.ts
@@ -72,6 +72,7 @@ import { updateMemory } from "./deploy/environment-settings/runtime/update-memor
 import { updateOpenapiSpecPath } from "./deploy/environment-settings/runtime/update-openapi-spec-path";
 import { updatePort } from "./deploy/environment-settings/runtime/update-port";
 import { updateRegions } from "./deploy/environment-settings/runtime/update-regions";
+import { updateUpstreamProtocol } from "./deploy/environment-settings/runtime/update-upstream-protocol";
 import { updateMiddleware } from "./deploy/environment-settings/sentinel/update-middleware";
 import { getDeploymentLatency } from "./deploy/metrics/get-deployment-latency";
 import { getDeploymentLatencyTimeseries } from "./deploy/metrics/get-deployment-latency-timeseries";
@@ -425,6 +426,7 @@ export const router = t.router({
         updateRegions,
         updateInstances,
         updateOpenapiSpecPath,
+        updateUpstreamProtocol,
       }),
       build: t.router({
         updateDockerfile,


### PR DESCRIPTION
## What does this PR do?

Adds upstream protocol configuration support to the deployment settings, allowing users to select between HTTP/1.1 and HTTP/2 (h2c) protocols for connecting to their applications.

This change introduces a new `UpstreamProtocol` component in the runtime settings section with a dropdown selector for protocol options. The feature includes form validation, auto-save functionality for onboarding flows, and proper state management through the existing environment settings infrastructure.

![CleanShot 2026-04-03 at 17.11.19.png](https://app.graphite.com/user-attachments/assets/817fd944-21bc-4aa6-b94a-e5283eb6ca7d.png)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Navigate to project deployment settings and verify the new "Upstream Protocol" setting appears in the runtime settings section
- Test switching between HTTP/1.1 and HTTP/2 (h2c) options and confirm the selection is saved
- Verify the setting displays correctly during project onboarding flow with auto-save enabled
- Confirm the default value of "http1" is properly set for new environments

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary