### PR TITLE
fix: overflow issue in value cell env-var page

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/env-vars/components/list/env-var-base-row.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/env-vars/components/list/env-var-base-row.tsx
@@ -78,7 +78,7 @@ export function EnvVarBaseRow({
         </div>
         <div className="flex-4 min-w-0 py-3.5 flex items-center">{nameCell}</div>
         <div className="flex-4 min-w-0 py-3.5 flex items-center pr-3">{valueCell}</div>
-        <div className="flex-2 min-w-0 py-3.5 flex items-center pr-3">
+        <div className="w-45 shrink-0 py-3.5 flex items-center pr-3">
           <TimestampBadge value={timestamp} />
         </div>
         <div

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/env-vars/components/list/env-var-value-cell.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/env-vars/components/list/env-var-value-cell.tsx
@@ -118,7 +118,7 @@ export const EnvVarValueCell = memo(function EnvVarValueCell({
           <button
             type="button"
             onClick={handleCopy}
-            className="font-mono max-w-90 bg-gray-3 px-1.5 py-0.5 truncate text-[13px] text-accent-12 cursor-pointer transition-colors min-w-0 rounded-md h-5.5"
+            className="font-mono bg-gray-3 px-1.5 py-0.5 truncate text-[13px] text-accent-12 cursor-pointer transition-colors min-w-0 rounded-md h-5.5 max-w-70"
           >
             {decryptedValue}
           </button>


### PR DESCRIPTION
## What does this PR do?

Fixes #5606  overflow issue in env-var page value column.

<img width="1156" height="812" alt="Screenshot 2026-04-06 at 12 46 10" src="https://github.com/user-attachments/assets/416f5080-7952-4af0-b878-d2bcd71955bc" />
