### PR TITLE
fix: one less body copy

### DIFF
--- a/svc/sentinel/middleware/logging.go
+++ b/svc/sentinel/middleware/logging.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"strings"
+	"unsafe"
 
 	"github.com/unkeyed/unkey/pkg/batch"
 	"github.com/unkeyed/unkey/pkg/clickhouse/schema"
@@ -55,10 +56,10 @@ func WithSentinelLogging(buf *batch.BatchProcessor[schema.SentinelRequest], clk 
 					QueryString:     req.URL.RawQuery,
 					QueryParams:     req.URL.Query(),
 					RequestHeaders:  formatHeaders(req.Header),
-					RequestBody:     string(tracking.RequestBody),
+					RequestBody:     unsafe.String(unsafe.SliceData(tracking.RequestBody), len(tracking.RequestBody)),
 					ResponseStatus:  tracking.ResponseStatus,
 					ResponseHeaders: formatHeaders(tracking.ResponseHeaders),
-					ResponseBody:    string(tracking.ResponseBody),
+					ResponseBody:    unsafe.String(unsafe.SliceData(tracking.ResponseBody), len(tracking.ResponseBody)),
 					UserAgent:       req.UserAgent(),
 					IPAddress:       s.Location(),
 					TotalLatency:    totalLatency,


### PR DESCRIPTION
## What does this PR do?

Optimizes string conversion in sentinel logging middleware by replacing `string()` conversions with `unsafe.String()` for request and response body fields. This eliminates unnecessary memory allocations when converting byte slices to strings for logging purposes.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Verify that sentinel logging continues to work correctly with request/response body logging
- Test with various request/response body sizes to ensure no memory corruption occurs
- Confirm that logged request and response bodies contain the expected content

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary