### PR TITLE
feat: log streaming body

### DIFF
--- a/pkg/zen/BUILD.bazel
+++ b/pkg/zen/BUILD.bazel
@@ -49,6 +49,7 @@ go_test(
     size = "small",
     srcs = [
         "auth_test.go",
+        "limited_writer_test.go",
         "middleware_metrics_test.go",
         "middleware_timeout_test.go",
         "redact_test.go",

--- a/pkg/zen/limited_writer_test.go
+++ b/pkg/zen/limited_writer_test.go
@@ -1,0 +1,49 @@
+package zen
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLimitedWriter_CapsAtLimit(t *testing.T) {
+	var buf bytes.Buffer
+	lw := &LimitedWriter{W: &buf, N: 10}
+
+	n, err := lw.Write([]byte("hello world!")) // 12 bytes
+	require.NoError(t, err)
+	require.Equal(t, 12, n, "should report all bytes as written to avoid short-write errors")
+	require.Equal(t, "hello worl", buf.String(), "should only capture first 10 bytes")
+}
+
+func TestLimitedWriter_ExactLimit(t *testing.T) {
+	var buf bytes.Buffer
+	lw := &LimitedWriter{W: &buf, N: 5}
+
+	n, err := lw.Write([]byte("hello"))
+	require.NoError(t, err)
+	require.Equal(t, 5, n)
+	require.Equal(t, "hello", buf.String())
+}
+
+func TestLimitedWriter_MultipleWrites(t *testing.T) {
+	var buf bytes.Buffer
+	lw := &LimitedWriter{W: &buf, N: 8}
+
+	_, _ = lw.Write([]byte("aaa"))  // 3 written, 5 remaining
+	_, _ = lw.Write([]byte("bbb"))  // 3 written, 2 remaining
+	_, _ = lw.Write([]byte("cccc")) // only 2 captured, rest discarded
+
+	require.Equal(t, "aaabbbcc", buf.String())
+}
+
+func TestLimitedWriter_ZeroLimit(t *testing.T) {
+	var buf bytes.Buffer
+	lw := &LimitedWriter{W: &buf, N: 0}
+
+	n, err := lw.Write([]byte("anything"))
+	require.NoError(t, err)
+	require.Equal(t, 8, n, "should report all bytes as written")
+	require.Empty(t, buf.String(), "should capture nothing")
+}

--- a/pkg/zen/session.go
+++ b/pkg/zen/session.go
@@ -74,7 +74,7 @@ func (s *Session) Init(w http.ResponseWriter, r *http.Request, maxBodySize int64
 	// For gRPC/streaming requests, skip body buffering — the body is a stream
 	// that must be forwarded incrementally. Buffering would deadlock because the
 	// client waits for a response before sending more frames.
-	if isStreamingContentType(r.Header.Get("Content-Type")) {
+	if IsStreamingContentType(r.Header.Get("Content-Type")) {
 		s.requestBody = nil
 	} else {
 		// Read and cache the request body so metrics middleware can access it even on early errors.
@@ -514,9 +514,42 @@ func (s *Session) Send(status int, body []byte) error {
 	return s.send(status, body)
 }
 
-// isStreamingContentType returns true for content types that use streaming
+// SetResponseBody allows proxy handlers to feed a captured response body back
+// into the session so zen middleware (WithLogging, WithMetrics) can log it.
+// This is necessary for proxied responses where the body is written directly
+// to the ResponseWriter, bypassing Session.send().
+func (s *Session) SetResponseBody(body []byte) {
+	s.responseBody = body
+}
+
+// MaxBodyCapture is the maximum number of bytes captured from streaming
+// request/response bodies for logging. Anything beyond this is silently dropped.
+const MaxBodyCapture = 1 << 20 // 1 MiB
+
+// LimitedWriter wraps an io.Writer and stops writing after N bytes.
+// Excess bytes are silently discarded — no error is returned so the
+// TeeReader (and therefore the stream) is never interrupted.
+type LimitedWriter struct {
+	W io.Writer
+	N int64
+}
+
+func (lw *LimitedWriter) Write(p []byte) (int, error) {
+	total := len(p)
+	if lw.N <= 0 {
+		return total, nil
+	}
+	if int64(len(p)) > lw.N {
+		p = p[:lw.N]
+	}
+	n, err := lw.W.Write(p)
+	lw.N -= int64(n)
+	return total, err
+}
+
+// IsStreamingContentType returns true for content types that use streaming
 // and must not have their body buffered (gRPC, Connect streaming).
-func isStreamingContentType(ct string) bool {
+func IsStreamingContentType(ct string) bool {
 	return strings.HasPrefix(ct, "application/grpc") ||
 		strings.HasPrefix(ct, "application/connect+")
 }

--- a/svc/ctrl/integration/seed/seed.go
+++ b/svc/ctrl/integration/seed/seed.go
@@ -772,3 +772,71 @@ func (s *Seeder) CreatePermission(ctx context.Context, req CreatePermissionReque
 		UpdatedAtM:  sql.NullInt64{Valid: false, Int64: 0},
 	}
 }
+
+type CreateRegionRequest struct {
+	Name     string
+	Platform string
+}
+
+func (s *Seeder) CreateRegion(ctx context.Context, req CreateRegionRequest) db.Region {
+	id := uid.New(uid.RegionPrefix)
+
+	err := db.Query.UpsertRegion(ctx, s.DB.RW(), db.UpsertRegionParams{
+		ID:       id,
+		Name:     req.Name,
+		Platform: req.Platform,
+	})
+	require.NoError(s.t, err)
+
+	region, err := db.Query.FindRegionByNameAndPlatform(ctx, s.DB.RO(), db.FindRegionByNameAndPlatformParams{
+		Name:     req.Name,
+		Platform: req.Platform,
+	})
+	require.NoError(s.t, err)
+
+	return region
+}
+
+type CreateInstanceRequest struct {
+	DeploymentID string
+	WorkspaceID  string
+	ProjectID    string
+	AppID        string
+	RegionID     string
+	Address      string
+}
+
+func (s *Seeder) CreateInstance(ctx context.Context, req CreateInstanceRequest) db.Instance {
+	id := uid.New("inst")
+
+	err := db.Query.UpsertInstance(ctx, s.DB.RW(), db.UpsertInstanceParams{
+		ID:            id,
+		DeploymentID:  req.DeploymentID,
+		WorkspaceID:   req.WorkspaceID,
+		ProjectID:     req.ProjectID,
+		AppID:         req.AppID,
+		RegionID:      req.RegionID,
+		K8sName:       uid.New("k8s"),
+		Address:       req.Address,
+		CpuMillicores: 100,
+		MemoryMib:     128,
+		Status:        db.InstancesStatusRunning,
+	})
+	require.NoError(s.t, err)
+
+	return db.Instance{
+		Pk:            0,
+		ID:            id,
+		DeploymentID:  req.DeploymentID,
+		WorkspaceID:   req.WorkspaceID,
+		ProjectID:     req.ProjectID,
+		AppID:         req.AppID,
+		RegionID:      req.RegionID,
+		K8sName:       "",
+		Address:       req.Address,
+		CpuMillicores: 100,
+		MemoryMib:     128,
+		StorageMib:    0,
+		Status:        db.InstancesStatusRunning,
+	}
+}

--- a/svc/frontline/services/proxy/forward.go
+++ b/svc/frontline/services/proxy/forward.go
@@ -59,6 +59,8 @@ func (s *service) forward(ctx context.Context, sess *zen.Session, cfg forwardCon
 		})
 	}()
 
+	var responseBuf bytes.Buffer
+
 	wrapper := zen.NewErrorCapturingWriter(sess.ResponseWriter())
 
 	var backendStart time.Time
@@ -108,9 +110,17 @@ func (s *service) forward(ctx context.Context, sess *zen.Session, cfg forwardCon
 				},
 			})
 
-			if source != "sentinel" {
-				return nil
-			}
+			// Capture response body for logging via TeeReader.
+				// Streaming: bytes flow to the client while accumulating in responseBuf.
+				// Non-streaming: the proxy buffers internally, same result.
+				if resp.Body != nil {
+					responseBuf.Reset()
+					resp.Body = io.NopCloser(io.TeeReader(resp.Body, &zen.LimitedWriter{W: &responseBuf, N: zen.MaxBodyCapture}))
+				}
+
+				if source != "sentinel" {
+					return nil
+				}
 
 			if sentinelTime := resp.Header.Get(timing.HeaderName); sentinelTime != "" {
 				sess.ResponseWriter().Header().Add(timing.HeaderName, sentinelTime)
@@ -160,6 +170,11 @@ func (s *service) forward(ctx context.Context, sess *zen.Session, cfg forwardCon
 
 	// Proxy the request with the middleware context (carries timeout deadline)
 	proxy.ServeHTTP(wrapper, sess.Request().WithContext(ctx))
+
+	// Feed captured response body back into the session for zen middleware logging.
+	if responseBuf.Len() > 0 {
+		sess.SetResponseBody(responseBuf.Bytes())
+	}
 
 	// If error was captured, return it to middleware for consistent error handling
 	if err := wrapper.Error(); err != nil {

--- a/svc/sentinel/routes/proxy/BUILD.bazel
+++ b/svc/sentinel/routes/proxy/BUILD.bazel
@@ -29,10 +29,19 @@ go_library(
 
 go_test(
     name = "proxy_test",
-    srcs = ["transport_test.go"],
+    srcs = [
+        "handler_test.go",
+        "transport_test.go",
+    ],
     embed = [":proxy"],
     deps = [
+        "//pkg/clock",
         "//pkg/db",
+        "//pkg/dockertest",
+        "//pkg/uid",
+        "//pkg/zen",
+        "//svc/ctrl/integration/seed",
+        "//svc/sentinel/services/router",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/svc/sentinel/routes/proxy/handler.go
+++ b/svc/sentinel/routes/proxy/handler.go
@@ -92,11 +92,17 @@ func (h *Handler) Handle(ctx context.Context, sess *zen.Session) error {
 		}
 	}
 
-	// For gRPC/streaming, don't buffer the body — pass it through as a stream.
-	var requestBody []byte
 	streaming := strings.HasPrefix(req.Header.Get("Content-Type"), "application/grpc") ||
 		strings.HasPrefix(req.Header.Get("Content-Type"), "application/connect+")
-	if req.Body != nil && !streaming {
+
+	// Capture the request body for logging.
+	// Streaming: TeeReader passes bytes through to the upstream while capturing a copy.
+	// Non-streaming: read the full body upfront so we can fail fast on unreadable bodies.
+	var requestBuf bytes.Buffer
+	var requestBody []byte
+	if req.Body != nil && streaming {
+		req.Body = io.NopCloser(io.TeeReader(req.Body, &zen.LimitedWriter{W: &requestBuf, N: zen.MaxBodyCapture}))
+	} else if req.Body != nil {
 		requestBody, err = io.ReadAll(req.Body)
 		if err != nil {
 			return fault.Wrap(err,
@@ -136,6 +142,11 @@ func (h *Handler) Handle(ctx context.Context, sess *zen.Session) error {
 		)
 	}
 
+	// Buffer to capture streaming response body via TeeReader.
+	// Bytes are written here as they stream through to the client,
+	// so the full body is available for logging after proxy.ServeHTTP returns.
+	var responseBuf bytes.Buffer
+
 	wrapper := zen.NewErrorCapturingWriter(sess.ResponseWriter())
 	// nolint:exhaustruct
 	proxy := &httputil.ReverseProxy{
@@ -162,29 +173,26 @@ func (h *Handler) Handle(ctx context.Context, sess *zen.Session) error {
 		Transport: transport,
 		ModifyResponse: func(resp *http.Response) error {
 			if tracking != nil {
-				tracking.InstanceEnd = h.Clock.Now()
 				tracking.ResponseStatus = int32(resp.StatusCode)
 				tracking.ResponseHeaders = resp.Header
 
-				// Record upstream metrics
+				// Record time-to-first-byte metrics (InstanceEnd is set after the
+				// full stream completes in the post-proxy block below).
+				ttfb := h.Clock.Now()
 				statusClass := upstreamStatusClass(resp.StatusCode)
 				upstreamResponseTotal.WithLabelValues(statusClass).Inc()
 				if !tracking.InstanceStart.IsZero() {
-					upstreamDuration.WithLabelValues(statusClass).Observe(tracking.InstanceEnd.Sub(tracking.InstanceStart).Seconds())
+					upstreamDuration.WithLabelValues(statusClass).Observe(ttfb.Sub(tracking.InstanceStart).Seconds())
 				}
 
-				// Capture response body for logging (skip for streaming — would buffer the entire stream)
-				if resp.Body != nil && !streaming {
-					responseBody, err := io.ReadAll(resp.Body)
-					if err != nil {
-						return fault.Wrap(err,
-							fault.Code(codes.Sentinel.Proxy.BadGateway.URN()),
-							fault.Internal("failed to read response body for logging"),
-							fault.Public("Failed to process backend response"),
-						)
-					}
-					tracking.ResponseBody = responseBody
-					resp.Body = io.NopCloser(bytes.NewReader(responseBody))
+				// Capture response body for logging.
+				// Always use TeeReader — bytes flow through to the client while
+				// accumulating in responseBuf (capped at MaxBodyCapture).
+				// This avoids buffering the entire body (which blocks streaming)
+				// and removes the need to detect streaming via Content-Type.
+				if resp.Body != nil {
+					responseBuf.Reset()
+					resp.Body = io.NopCloser(io.TeeReader(resp.Body, &zen.LimitedWriter{W: &responseBuf, N: zen.MaxBodyCapture}))
 				}
 			}
 
@@ -214,8 +222,6 @@ func (h *Handler) Handle(ctx context.Context, sess *zen.Session) error {
 		},
 		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
 			if tracking != nil {
-				tracking.InstanceEnd = h.Clock.Now()
-
 				sentinelDuration := h.Clock.Now().Sub(tracking.StartTime)
 				timing.Write(sess.ResponseWriter(), timing.Entry{
 					Name:     "sentinel",
@@ -244,5 +250,28 @@ func (h *Handler) Handle(ctx context.Context, sess *zen.Session) error {
 	}
 
 	proxy.ServeHTTP(wrapper, req)
+
+	// Mark the true end of the instance interaction (includes full stream duration).
+	if tracking != nil {
+		tracking.InstanceEnd = h.Clock.Now()
+	}
+
+	// TeeReaders have now accumulated the full bodies for any streaming direction.
+	if tracking != nil {
+		if streaming && requestBuf.Len() > 0 {
+			tracking.RequestBody = requestBuf.Bytes()
+		}
+		if responseBuf.Len() > 0 {
+			tracking.ResponseBody = responseBuf.Bytes()
+		}
+	}
+
+	// Feed the captured response body back into the session so zen middleware
+	// (WithLogging, WithMetrics) can log it — the proxy writes directly to
+	// the ResponseWriter, bypassing Session.send().
+	if tracking != nil && len(tracking.ResponseBody) > 0 {
+		sess.SetResponseBody(tracking.ResponseBody)
+	}
+
 	return wrapper.Error()
 }

--- a/svc/sentinel/routes/proxy/handler_test.go
+++ b/svc/sentinel/routes/proxy/handler_test.go
@@ -1,0 +1,263 @@
+package handler
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/clock"
+	"github.com/unkeyed/unkey/pkg/db"
+	"github.com/unkeyed/unkey/pkg/dockertest"
+	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/pkg/zen"
+	"github.com/unkeyed/unkey/svc/ctrl/integration/seed"
+	"github.com/unkeyed/unkey/svc/sentinel/services/router"
+)
+
+const (
+	testPlatform = "test"
+	testRegion   = "test-region"
+)
+
+// setupHandler creates a real router service backed by MySQL and returns a
+// Handler wired to the given upstream address.
+func setupHandler(t *testing.T, upstreamAddr string) (*Handler, string) {
+	t.Helper()
+
+	mysqlCfg := dockertest.MySQL(t)
+	clk := clock.New()
+
+	database, err := db.New(db.Config{
+		PrimaryDSN:  mysqlCfg.DSN,
+		ReadOnlyDSN: "",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = database.Close() })
+
+	ctx := context.Background()
+	s := seed.New(t, database, nil)
+	ws := s.CreateWorkspace(ctx)
+
+	project := s.CreateProject(ctx, seed.CreateProjectRequest{
+		ID:          uid.New("prj"),
+		WorkspaceID: ws.ID,
+		Name:        "test-project",
+		Slug:        uid.New("slug"),
+	})
+
+	app := s.CreateApp(ctx, seed.CreateAppRequest{
+		ID:            uid.New("app"),
+		WorkspaceID:   ws.ID,
+		ProjectID:     project.ID,
+		Name:          "default",
+		Slug:          "default",
+		DefaultBranch: "main",
+	})
+
+	env := s.CreateEnvironment(ctx, seed.CreateEnvironmentRequest{
+		ID:          uid.New("env"),
+		WorkspaceID: ws.ID,
+		ProjectID:   project.ID,
+		AppID:       app.ID,
+		Slug:        "production",
+	})
+
+	deployment := s.CreateDeployment(ctx, seed.CreateDeploymentRequest{
+		WorkspaceID:   ws.ID,
+		ProjectID:     project.ID,
+		AppID:         app.ID,
+		EnvironmentID: env.ID,
+		Status:        db.DeploymentsStatusReady,
+	})
+
+	region := s.CreateRegion(ctx, seed.CreateRegionRequest{
+		Name:     testRegion,
+		Platform: testPlatform,
+	})
+
+	s.CreateInstance(ctx, seed.CreateInstanceRequest{
+		DeploymentID: deployment.ID,
+		WorkspaceID:  ws.ID,
+		ProjectID:    project.ID,
+		AppID:        app.ID,
+		RegionID:     region.ID,
+		Address:      upstreamAddr,
+	})
+
+	routerSvc, err := router.New(router.Config{
+		DB:            database,
+		Clock:         clk,
+		EnvironmentID: env.ID,
+		Platform:      testPlatform,
+		Region:        testRegion,
+		Broadcaster:   nil,
+		NodeID:        "test-node",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = routerSvc.Close() })
+
+	// nolint:exhaustruct
+	h := &Handler{
+		RouterService: routerSvc,
+		Clock:         clk,
+		Transports:    NewTransportRegistry(),
+		SentinelID:    "sentinel_test",
+		Region:        testRegion,
+		Engine:        nil,
+	}
+
+	return h, deployment.ID
+}
+
+// proxyStreaming sends a streaming (gRPC content-type) request through the
+// handler and returns the tracking result.
+func proxyStreaming(t *testing.T, h *Handler, deploymentID string, requestBody string) (*SentinelRequestTracking, []byte) {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodPost, "/some/path", strings.NewReader(requestBody))
+	req.Header.Set("Content-Type", "application/grpc")
+	req.Header.Set("X-Deployment-Id", deploymentID)
+
+	w := httptest.NewRecorder()
+	sess := &zen.Session{}
+	err := sess.Init(w, req, 0)
+	require.NoError(t, err)
+
+	tracking := &SentinelRequestTracking{
+		StartTime: time.Now(),
+	}
+	ctx := WithSentinelTracking(context.Background(), tracking)
+
+	err = h.Handle(ctx, sess)
+	require.NoError(t, err)
+
+	resp := w.Result()
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	return tracking, body
+}
+
+func TestHandler_StreamingBodyCapture(t *testing.T) {
+	chunks := []string{"chunk1\n", "chunk2\n", "chunk3\n"}
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reqBody, _ := io.ReadAll(r.Body)
+		_ = r.Body.Close()
+
+		w.Header().Set("Content-Type", "application/grpc")
+		w.WriteHeader(http.StatusOK)
+
+		flusher, ok := w.(http.Flusher)
+		require.True(t, ok)
+
+		for _, chunk := range chunks {
+			_, _ = fmt.Fprint(w, chunk)
+			flusher.Flush()
+		}
+		_, _ = fmt.Fprintf(w, "req:%s", reqBody)
+		flusher.Flush()
+	}))
+	defer upstream.Close()
+
+	h, deploymentID := setupHandler(t, strings.TrimPrefix(upstream.URL, "http://"))
+
+	requestBody := "streaming request payload"
+	tracking, respBody := proxyStreaming(t, h, deploymentID, requestBody)
+
+	for _, chunk := range chunks {
+		require.Contains(t, string(respBody), chunk, "client should have received chunk")
+	}
+	require.Contains(t, string(respBody), "req:"+requestBody, "upstream should have received the request body")
+
+	require.NotEmpty(t, tracking.RequestBody, "streaming request body should be captured")
+	require.Equal(t, requestBody, string(tracking.RequestBody))
+
+	require.NotEmpty(t, tracking.ResponseBody, "streaming response body should be captured")
+	require.Contains(t, string(tracking.ResponseBody), "chunk1")
+	require.Contains(t, string(tracking.ResponseBody), "chunk3")
+}
+
+// TestHandler_ServerStreamBodyCapture verifies that a non-streaming request
+// with a streaming *response* (server-stream) still captures the response body
+// via TeeReader based on the response Content-Type.
+func TestHandler_ServerStreamBodyCapture(t *testing.T) {
+	chunks := []string{"chunk1\n", "chunk2\n", "chunk3\n"}
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.ReadAll(r.Body)
+		_ = r.Body.Close()
+
+		// Response is streaming (Connect), but request was application/json
+		w.Header().Set("Content-Type", "application/connect+proto")
+		w.WriteHeader(http.StatusOK)
+
+		flusher, ok := w.(http.Flusher)
+		require.True(t, ok)
+
+		for _, chunk := range chunks {
+			_, _ = fmt.Fprint(w, chunk)
+			flusher.Flush()
+		}
+	}))
+	defer upstream.Close()
+
+	h, deploymentID := setupHandler(t, strings.TrimPrefix(upstream.URL, "http://"))
+
+	// Send a normal JSON request — NOT application/grpc
+	req := httptest.NewRequest(http.MethodPost, "/some/path", strings.NewReader(`{"msg":"hello"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Deployment-Id", deploymentID)
+
+	w := httptest.NewRecorder()
+	sess := &zen.Session{}
+	err := sess.Init(w, req, 0)
+	require.NoError(t, err)
+
+	tracking := &SentinelRequestTracking{StartTime: time.Now()}
+	ctx := WithSentinelTracking(context.Background(), tracking)
+
+	err = h.Handle(ctx, sess)
+	require.NoError(t, err)
+
+	resp := w.Result()
+	defer func() { _ = resp.Body.Close() }()
+	respBody, _ := io.ReadAll(resp.Body)
+
+	for _, chunk := range chunks {
+		require.Contains(t, string(respBody), chunk, "client should have received chunk")
+	}
+
+	require.NotEmpty(t, tracking.ResponseBody, "server-stream response body should be captured via TeeReader")
+	require.Contains(t, string(tracking.ResponseBody), "chunk1")
+	require.Contains(t, string(tracking.ResponseBody), "chunk3")
+}
+
+func TestHandler_StreamingBodyCapture_RespectsLimit(t *testing.T) {
+	bigChunk := strings.Repeat("X", zen.MaxBodyCapture+1024)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Drain the request body so the TeeReader captures it.
+		_, _ = io.ReadAll(r.Body)
+		_ = r.Body.Close()
+		w.Header().Set("Content-Type", "application/grpc")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, bigChunk)
+	}))
+	defer upstream.Close()
+
+	h, deploymentID := setupHandler(t, strings.TrimPrefix(upstream.URL, "http://"))
+
+	tracking, respBody := proxyStreaming(t, h, deploymentID, bigChunk)
+
+	require.Len(t, respBody, len(bigChunk), "client must receive the full response even though logging is capped")
+	require.Len(t, tracking.RequestBody, zen.MaxBodyCapture, "request body capture should be capped")
+	require.Len(t, tracking.ResponseBody, zen.MaxBodyCapture, "response body capture should be capped")
+}


### PR DESCRIPTION
## What does this PR do?

Adds streaming request/response body capture for logging in the proxy handlers. 

Previously, streaming requests (gRPC, Connect) had their bodies skipped entirely to avoid buffering issues. This change uses `TeeReader` with a `LimitedWriter` to capture up to 1 MiB of streaming body content for logging purposes while allowing the stream to flow through uninterrupted.

The implementation includes:
- A new `LimitedWriter` that caps captured bytes at a configurable limit (1 MiB) and silently discards excess data
- Modified proxy handlers in both frontline and sentinel to use `TeeReader` for streaming body capture
- A new `SetResponseBody` method on `Session` to allow proxy handlers to feed captured response bodies back for middleware logging
- Exported `IsStreamingContentType` function for reuse across services
- Added seeder methods for creating regions and instances in integration tests

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Run the new `TestLimitedWriter_*` tests to verify the limited writer behavior
- Run the new `TestHandler_StreamingBodyCapture` test to verify streaming request/response body capture
- Run the `TestHandler_ServerStreamBodyCapture` test to verify server-only streaming scenarios
- Run the `TestHandler_StreamingBodyCapture_RespectsLimit` test to verify the 1 MiB capture limit is enforced
- Test with actual gRPC/Connect streaming requests to ensure bodies are captured in logs without affecting stream performance

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [x] Ran `make fmt` on `/go` directory
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary