### PR TITLE
fix: resync handled err log

### DIFF
--- a/svc/krane/internal/cilium/resync.go
+++ b/svc/krane/internal/cilium/resync.go
@@ -53,8 +53,8 @@ func (c *Controller) runResyncLoop(ctx context.Context) {
 							K8SName:      policy.GetName(),
 						}); err != nil {
 							logger.Error("unable to delete cilium network policy", "error", err.Error(), "policy_id", policyID)
-							continue
 						}
+						continue
 					}
 
 					logger.Error("unable to get desired cilium network policy state", "error", err.Error(), "policy_id", policyID)


### PR DESCRIPTION
## What does this PR do?

Fixes the control flow in the Cilium network policy resync loop to ensure the loop continues to the next iteration regardless of whether the policy deletion succeeds or fails. Previously, the `continue` statement was only executed when the deletion failed, causing the loop to proceed with additional error handling when deletion succeeded.

Fixes #5082

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Test the Cilium network policy resync loop with policies that fail to get desired state
- Verify that both successful and failed policy deletions properly continue to the next iteration
- Ensure no additional error handling is executed after successful policy deletion

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary