### PR TITLE
feat: report changes concurrently

### DIFF
--- a/pkg/conc/BUILD.bazel
+++ b/pkg/conc/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "conc",
+    srcs = [
+        "foreach.go",
+        "sem.go",
+    ],
+    importpath = "github.com/unkeyed/unkey/pkg/conc",
+    visibility = ["//visibility:public"],
+    deps = ["@org_golang_x_sync//semaphore"],
+)
+
+go_test(
+    name = "conc_test",
+    srcs = ["foreach_test.go"],
+    embed = [":conc"],
+)

--- a/pkg/conc/foreach.go
+++ b/pkg/conc/foreach.go
@@ -1,0 +1,24 @@
+package conc
+
+import "context"
+
+// ForEach processes items concurrently with bounded parallelism. It blocks
+// until all items have been processed. Each item is passed by pointer to avoid
+// copies of large Kubernetes structs.
+//
+// The semaphore is context-aware: if the context is cancelled, pending items
+// are skipped rather than blocking on semaphore acquisition.
+//
+//	conc.ForEach(ctx, replicaSets.Items, func(ctx context.Context, rs *appsv1.ReplicaSet) {
+//	    c.resyncReplicaSet(ctx, rs)
+//	})
+func ForEach[T any](ctx context.Context, items []T, fn func(ctx context.Context, item *T)) {
+	sem := NewSem(DefaultConcurrency)
+	for i := range items {
+		item := &items[i]
+		sem.Go(ctx, func(ctx context.Context) {
+			fn(ctx, item)
+		})
+	}
+	sem.Wait()
+}

--- a/pkg/conc/foreach_test.go
+++ b/pkg/conc/foreach_test.go
@@ -1,0 +1,65 @@
+package conc
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+)
+
+func TestForEach_ProcessesAllItems(t *testing.T) {
+	items := make([]int, 100)
+	for i := range items {
+		items[i] = i
+	}
+
+	var count atomic.Int64
+	ForEach(context.Background(), items, func(_ context.Context, item *int) {
+		count.Add(1)
+	})
+
+	if got := count.Load(); got != 100 {
+		t.Errorf("expected 100 items processed, got %d", got)
+	}
+}
+
+func TestForEach_PassesPointers(t *testing.T) {
+	items := []int{1, 2, 3}
+
+	ForEach(context.Background(), items, func(_ context.Context, item *int) {
+		*item *= 10
+	})
+
+	for i, want := range []int{10, 20, 30} {
+		if items[i] != want {
+			t.Errorf("items[%d] = %d, want %d", i, items[i], want)
+		}
+	}
+}
+
+func TestForEach_EmptySlice(t *testing.T) {
+	var items []int
+	ForEach(context.Background(), items, func(_ context.Context, item *int) {
+		t.Fatal("should not be called")
+	})
+}
+
+func TestForEach_BoundsConcurrency(t *testing.T) {
+	items := make([]int, 50)
+	var inflight atomic.Int64
+	var maxInflight atomic.Int64
+
+	ForEach(context.Background(), items, func(_ context.Context, _ *int) {
+		cur := inflight.Add(1)
+		for {
+			prev := maxInflight.Load()
+			if cur <= prev || maxInflight.CompareAndSwap(prev, cur) {
+				break
+			}
+		}
+		inflight.Add(-1)
+	})
+
+	if got := maxInflight.Load(); got > DefaultConcurrency {
+		t.Errorf("max inflight = %d, want <= %d", got, DefaultConcurrency)
+	}
+}

--- a/pkg/conc/sem.go
+++ b/pkg/conc/sem.go
@@ -1,0 +1,51 @@
+// Package conc provides bounded-concurrency helpers.
+package conc
+
+import (
+	"context"
+	"sync"
+
+	"golang.org/x/sync/semaphore"
+)
+
+// DefaultConcurrency is the maximum number of items processed in parallel.
+const DefaultConcurrency int64 = 10
+
+// Sem is a context-aware bounded-concurrency scheduler. It wraps
+// [semaphore.Weighted] with [sync.WaitGroup] so callers only provide the work
+// function.
+//
+//	sem := conc.NewSem(10)
+//	for _, item := range items {
+//	    sem.Go(ctx, func(ctx context.Context) { process(item) })
+//	}
+//	sem.Wait()
+type Sem struct {
+	sem *semaphore.Weighted
+	wg  sync.WaitGroup
+}
+
+// NewSem creates a [Sem] that allows up to n concurrent goroutines.
+func NewSem(n int64) *Sem {
+	return &Sem{
+		sem: semaphore.NewWeighted(n),
+		wg:  sync.WaitGroup{},
+	}
+}
+
+// Go acquires a semaphore slot, then runs fn in a new goroutine. If the
+// context is cancelled before a slot is available, fn is not executed.
+func (s *Sem) Go(ctx context.Context, fn func(ctx context.Context)) {
+	if err := s.sem.Acquire(ctx, 1); err != nil {
+		return
+	}
+	s.wg.Go(func() {
+		defer s.sem.Release(1)
+		fn(ctx)
+	})
+}
+
+// Wait blocks until all goroutines launched via [Sem.Go] have finished.
+func (s *Sem) Wait() {
+	s.wg.Wait()
+}

--- a/svc/krane/internal/cilium/BUILD.bazel
+++ b/svc/krane/internal/cilium/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//gen/proto/ctrl/v1:ctrl",
         "//gen/rpc/ctrl",
         "//pkg/assert",
+        "//pkg/conc",
         "//pkg/logger",
         "//pkg/repeat",
         "//svc/krane/pkg/labels",

--- a/svc/krane/internal/cilium/resync.go
+++ b/svc/krane/internal/cilium/resync.go
@@ -9,6 +9,8 @@ import (
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/pkg/repeat"
 	"github.com/unkeyed/unkey/svc/krane/pkg/labels"
+	"github.com/unkeyed/unkey/pkg/conc"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // runResyncLoop periodically reconciles all Cilium network policies with their
@@ -20,10 +22,8 @@ import (
 // This resync loop guarantees eventual consistency by querying the control plane
 // for each existing CiliumNetworkPolicy and applying any drift.
 //
-// The loop paginates through all krane-managed CiliumNetworkPolicy resources across all
-// namespaces, calling GetDesiredCiliumNetworkPolicyState for each and applying or deleting
-// as directed. Errors are logged but don't stop the loop from processing remaining
-// policies.
+// Resources are processed concurrently via [conc.ForEach] so that a slow RPC
+// for one policy does not block reconciliation of others.
 func (c *Controller) runResyncLoop(ctx context.Context) {
 	repeat.Every(1*time.Minute, func() {
 		logger.Info("running periodic resync")
@@ -36,42 +36,9 @@ func (c *Controller) runResyncLoop(ctx context.Context) {
 				return
 			}
 
-			for _, policy := range policies.Items {
-				policyID, ok := labels.GetCiliumNetworkPolicyID(policy.GetLabels())
-				if !ok {
-					logger.Error("unable to get cilium network policy id", "policy", policy.GetName())
-					continue
-				}
-
-				res, err := c.cluster.GetDesiredCiliumNetworkPolicyState(ctx, &ctrlv1.GetDesiredCiliumNetworkPolicyStateRequest{
-					CiliumNetworkPolicyId: policyID,
-				})
-				if err != nil {
-					if connect.CodeOf(err) == connect.CodeNotFound {
-						if err := c.DeleteCiliumNetworkPolicy(ctx, &ctrlv1.DeleteCiliumNetworkPolicy{
-							K8SNamespace: policy.GetNamespace(),
-							K8SName:      policy.GetName(),
-						}); err != nil {
-							logger.Error("unable to delete cilium network policy", "error", err.Error(), "policy_id", policyID)
-							continue
-						}
-					}
-
-					logger.Error("unable to get desired cilium network policy state", "error", err.Error(), "policy_id", policyID)
-					continue
-				}
-
-				switch res.GetState().(type) {
-				case *ctrlv1.CiliumNetworkPolicyState_Apply:
-					if err := c.ApplyCiliumNetworkPolicy(ctx, res.GetApply()); err != nil {
-						logger.Error("unable to apply cilium network policy", "error", err.Error(), "policy_id", policyID)
-					}
-				case *ctrlv1.CiliumNetworkPolicyState_Delete:
-					if err := c.DeleteCiliumNetworkPolicy(ctx, res.GetDelete()); err != nil {
-						logger.Error("unable to delete cilium network policy", "error", err.Error(), "policy_id", policyID)
-					}
-				}
-			}
+			conc.ForEach(ctx, policies.Items, func(ctx context.Context, policy *unstructured.Unstructured) {
+				c.resyncCiliumNetworkPolicy(ctx, policy)
+			})
 
 			cursor = policies.GetContinue()
 			if cursor == "" {
@@ -79,4 +46,44 @@ func (c *Controller) runResyncLoop(ctx context.Context) {
 			}
 		}
 	})
+}
+
+// resyncCiliumNetworkPolicy reconciles a single CiliumNetworkPolicy against the
+// control plane's desired state.
+func (c *Controller) resyncCiliumNetworkPolicy(ctx context.Context, policy *unstructured.Unstructured) {
+	policyID, ok := labels.GetCiliumNetworkPolicyID(policy.GetLabels())
+	if !ok {
+		logger.Error("unable to get cilium network policy id", "policy", policy.GetName())
+		return
+	}
+
+	res, err := c.cluster.GetDesiredCiliumNetworkPolicyState(ctx, &ctrlv1.GetDesiredCiliumNetworkPolicyStateRequest{
+		CiliumNetworkPolicyId: policyID,
+	})
+	if err != nil {
+		if connect.CodeOf(err) == connect.CodeNotFound {
+			if err := c.DeleteCiliumNetworkPolicy(ctx, &ctrlv1.DeleteCiliumNetworkPolicy{
+				K8SNamespace: policy.GetNamespace(),
+				K8SName:      policy.GetName(),
+			}); err != nil {
+				logger.Error("unable to delete cilium network policy", "error", err.Error(), "policy_id", policyID)
+			}
+
+			return
+		}
+
+		logger.Error("unable to get desired cilium network policy state", "error", err.Error(), "policy_id", policyID)
+		return
+	}
+
+	switch res.GetState().(type) {
+	case *ctrlv1.CiliumNetworkPolicyState_Apply:
+		if err := c.ApplyCiliumNetworkPolicy(ctx, res.GetApply()); err != nil {
+			logger.Error("unable to apply cilium network policy", "error", err.Error(), "policy_id", policyID)
+		}
+	case *ctrlv1.CiliumNetworkPolicyState_Delete:
+		if err := c.DeleteCiliumNetworkPolicy(ctx, res.GetDelete()); err != nil {
+			logger.Error("unable to delete cilium network policy", "error", err.Error(), "policy_id", policyID)
+		}
+	}
 }

--- a/svc/krane/internal/deployment/BUILD.bazel
+++ b/svc/krane/internal/deployment/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//pkg/assert",
         "//pkg/cache",
         "//pkg/circuitbreaker",
+        "//pkg/conc",
         "//pkg/db/types",
         "//pkg/hash",
         "//pkg/logger",

--- a/svc/krane/internal/deployment/controller.go
+++ b/svc/krane/internal/deployment/controller.go
@@ -112,14 +112,21 @@ func New(cfg Config) *Controller {
 
 // Start launches the background control loops.
 //
-// The method starts [Controller.runResyncLoop] as a background goroutine and
-// initializes [Controller.runPodWatchLoop]'s Kubernetes watch before returning.
-// Desired state is received externally via the watcher package.
-// If watch initialization fails, Start returns the error.
+// Three independent loops run concurrently:
+//   - [Controller.runActualStateResyncLoop]: periodic safety net for instance
+//     state reporting (complements the real-time pod watch).
+//   - [Controller.runDesiredStateResyncLoop]: periodic reconciliation of desired
+//     state from the control plane (complements the streaming channel).
+//   - [Controller.runPodWatchLoop]: real-time Kubernetes watch for pod events.
 //
+// The actual-state and desired-state loops are decoupled so that slow control
+// plane RPCs cannot delay instance reporting.
+//
+// If watch initialization fails, Start returns the error.
 // All loops continue until the context is cancelled or [Controller.Stop] is called.
 func (c *Controller) Start(ctx context.Context) error {
-	go c.runResyncLoop(ctx)
+	go c.runActualStateResyncLoop(ctx)
+	go c.runDesiredStateResyncLoop(ctx)
 
 	if err := c.runPodWatchLoop(ctx); err != nil {
 		return err

--- a/svc/krane/internal/deployment/pod_watch.go
+++ b/svc/krane/internal/deployment/pod_watch.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/svc/krane/pkg/labels"
+	"github.com/unkeyed/unkey/pkg/conc"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
@@ -18,6 +19,9 @@ import (
 // The watch filters for pods with "managed-by: krane" and "component: deployment"
 // labels. On any pod event it finds the owning ReplicaSet, rebuilds the full
 // deployment status, and reports it (deduplicated via fingerprinting).
+//
+// Events are processed concurrently (up to [maxPodWatchConcurrency]) so that a
+// slow RPC for one ReplicaSet does not block reporting for others.
 //
 // The initial watch must succeed for the controller to start. After that the
 // goroutine automatically reconnects with jittered backoff (1-5s) when the
@@ -67,7 +71,11 @@ func (c *Controller) watchPods(ctx context.Context) (watch.Interface, error) {
 }
 
 // drainPodWatch processes events from a pod watch until the channel closes.
+// Events are handled concurrently with bounded parallelism so that a slow
+// control plane RPC for one ReplicaSet does not delay reporting for others.
 func (c *Controller) drainPodWatch(ctx context.Context, w watch.Interface) {
+	sem := conc.NewSem(conc.DefaultConcurrency)
+
 	for event := range w.ResultChan() {
 		switch event.Type {
 		case watch.Error:
@@ -80,38 +88,48 @@ func (c *Controller) drainPodWatch(ctx context.Context, w watch.Interface) {
 				continue
 			}
 
-			logger.Info("pod watch: event received", "pod", pod.Name, "namespace", pod.Namespace, "type", event.Type, "phase", pod.Status.Phase, "ip", pod.Status.PodIP)
-
-			rsName := owningReplicaSet(pod)
-			if rsName == "" {
-				logger.Info("pod watch: pod has no owning replicaset, skipping", "pod", pod.Name)
-				continue
-			}
-
-			rs, err := c.clientSet.AppsV1().ReplicaSets(pod.Namespace).Get(ctx, rsName, metav1.GetOptions{})
-			if err != nil {
-				// RS already deleted — resync loop handles orphan cleanup.
-				logger.Info("pod watch: replicaset not found, skipping", "pod", pod.Name, "replicaSet", rsName, "error", err.Error())
-				continue
-			}
-
-			status, err := c.buildDeploymentStatus(ctx, rs)
-			if err != nil {
-				logger.Error("pod watch: unable to build status", "error", err.Error(), "replicaSet", rsName)
-				continue
-			}
-
-			reported, err := c.reportIfChanged(ctx, status)
-			if err != nil {
-				logger.Error("pod watch: unable to report status", "error", err.Error(), "replicaSet", rsName)
-				continue
-			}
-			if reported {
-				logger.Info("pod watch: reported changed status", "replicaSet", rsName, "pod", pod.Name, "instances", len(status.GetUpdate().GetInstances()))
-			} else {
-				logger.Info("pod watch: status unchanged, skipped report", "replicaSet", rsName, "pod", pod.Name)
-			}
+			sem.Go(ctx, func(ctx context.Context) {
+				c.handlePodEvent(ctx, pod, event.Type)
+			})
 		}
+	}
+
+	sem.Wait()
+}
+
+// handlePodEvent processes a single pod watch event: finds the owning
+// ReplicaSet, builds deployment status, and reports it if changed.
+func (c *Controller) handlePodEvent(ctx context.Context, pod *corev1.Pod, eventType watch.EventType) {
+	logger.Info("pod watch: event received", "pod", pod.Name, "namespace", pod.Namespace, "type", eventType, "phase", pod.Status.Phase, "ip", pod.Status.PodIP)
+
+	rsName := owningReplicaSet(pod)
+	if rsName == "" {
+		logger.Info("pod watch: pod has no owning replicaset, skipping", "pod", pod.Name)
+		return
+	}
+
+	rs, err := c.clientSet.AppsV1().ReplicaSets(pod.Namespace).Get(ctx, rsName, metav1.GetOptions{})
+	if err != nil {
+		// RS already deleted — resync loop handles orphan cleanup.
+		logger.Info("pod watch: replicaset not found, skipping", "pod", pod.Name, "replicaSet", rsName, "error", err.Error())
+		return
+	}
+
+	status, err := c.buildDeploymentStatus(ctx, rs)
+	if err != nil {
+		logger.Error("pod watch: unable to build status", "error", err.Error(), "replicaSet", rsName)
+		return
+	}
+
+	reported, err := c.reportIfChanged(ctx, status)
+	if err != nil {
+		logger.Error("pod watch: unable to report status", "error", err.Error(), "replicaSet", rsName)
+		return
+	}
+	if reported {
+		logger.Info("pod watch: reported changed status", "replicaSet", rsName, "pod", pod.Name, "instances", len(status.GetUpdate().GetInstances()))
+	} else {
+		logger.Info("pod watch: status unchanged, skipped report", "replicaSet", rsName, "pod", pod.Name)
 	}
 }
 

--- a/svc/krane/internal/deployment/resync.go
+++ b/svc/krane/internal/deployment/resync.go
@@ -9,94 +9,122 @@ import (
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/pkg/repeat"
 	"github.com/unkeyed/unkey/svc/krane/pkg/labels"
+	"github.com/unkeyed/unkey/pkg/conc"
+	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// runResyncLoop periodically reconciles all deployment ReplicaSets with their
-// desired state from the control plane.
+// runActualStateResyncLoop periodically reports actual instance state to the
+// control plane for every deployment ReplicaSet.
 //
-// The loop runs every minute as a consistency safety net. While
-// [Controller.runPodWatchLoop] handles real-time Kubernetes events and
-// [Controller.runDesiredStateApplyLoop] handles streaming updates, both can miss
-// events during network partitions, controller restarts, or watch buffer overflows.
-// This resync loop guarantees eventual consistency by querying the control plane
-// for each existing ReplicaSet and applying any drift.
+// This is a fast, lightweight safety net that complements [Controller.runPodWatchLoop].
+// The watch handles real-time events, but can miss updates during network partitions,
+// restarts, or buffer overflows. This loop catches the drift by rebuilding and
+// reporting status for every RS every 30 seconds.
 //
-// The loop paginates through all krane-managed deployment ReplicaSets across all
-// namespaces, calling GetDesiredDeploymentState for each and applying or deleting
-// as directed. Errors are logged but don't stop the loop from processing remaining
-// ReplicaSets.
-func (c *Controller) runResyncLoop(ctx context.Context) {
-	repeat.Every(1*time.Minute, func() {
-		logger.Info("running periodic resync")
-
-		cursor := ""
-		for {
-			replicaSets, err := c.clientSet.AppsV1().ReplicaSets("").List(ctx, metav1.ListOptions{
-				LabelSelector: labels.New().
-					ManagedByKrane().
-					ComponentDeployment().
-					ToString(),
-				Continue: cursor,
-			})
+// This loop does NOT fetch or apply desired state — that is handled independently
+// by [Controller.runDesiredStateResyncLoop] so that slow control plane RPCs cannot
+// delay instance reporting.
+func (c *Controller) runActualStateResyncLoop(ctx context.Context) {
+	repeat.Every(30*time.Second, func() {
+		logger.Info("running actual state resync")
+		c.forEachReplicaSet(ctx, func(ctx context.Context, rs *appsv1.ReplicaSet) {
+			status, err := c.buildDeploymentStatus(ctx, rs)
 			if err != nil {
-				logger.Error("unable to list replicaSets", "error", err.Error())
+				logger.Error("actual state resync: unable to build deployment status", "error", err.Error(), "replicaSet", rs.Name)
 				return
 			}
-
-			for _, replicaSet := range replicaSets.Items {
-				// Report actual state back to the control plane if it differs
-				// from the last report. This catches pods that were skipped
-				// earlier (e.g. no IP yet) or watch events that were missed.
-				status, buildErr := c.buildDeploymentStatus(ctx, &replicaSet)
-				if buildErr != nil {
-					logger.Error("resync: unable to build deployment status", "error", buildErr.Error(), "replicaSet", replicaSet.Name)
-				} else if reported, reportErr := c.reportIfChanged(ctx, status); reportErr != nil {
-					logger.Error("resync: unable to report deployment status", "error", reportErr.Error(), "replicaSet", replicaSet.Name)
-				} else if reported {
-					logger.Info("resync: reported changed deployment status", "replicaSet", replicaSet.Name)
-				}
-
-				deploymentID, ok := labels.GetDeploymentID(replicaSet.Labels)
-				if !ok {
-					logger.Error("unable to get deployment ID", "replicaSet", replicaSet.Name)
-					continue
-				}
-
-				res, err := c.cluster.GetDesiredDeploymentState(ctx, &ctrlv1.GetDesiredDeploymentStateRequest{
-					DeploymentId: deploymentID,
-				})
-				if err != nil {
-					if connect.CodeOf(err) == connect.CodeNotFound {
-						if err := c.DeleteDeployment(ctx, &ctrlv1.DeleteDeployment{
-							K8SNamespace: replicaSet.GetNamespace(),
-							K8SName:      replicaSet.GetName(),
-						}); err != nil {
-							logger.Error("unable to delete deployment", "error", err.Error(), "deployment_id", deploymentID)
-							continue
-						}
-					}
-
-					logger.Error("unable to get desired deployment state", "error", err.Error(), "deployment_id", deploymentID)
-					continue
-				}
-
-				switch res.GetState().(type) {
-				case *ctrlv1.DeploymentState_Apply:
-					if err := c.ApplyDeployment(ctx, res.GetApply()); err != nil {
-						logger.Error("unable to apply deployment", "error", err.Error(), "deployment_id", deploymentID)
-					}
-				case *ctrlv1.DeploymentState_Delete:
-					if err := c.DeleteDeployment(ctx, res.GetDelete()); err != nil {
-						logger.Error("unable to delete deployment", "error", err.Error(), "deployment_id", deploymentID)
-					}
-				}
+			reported, err := c.reportIfChanged(ctx, status)
+			if err != nil {
+				logger.Error("actual state resync: unable to report deployment status", "error", err.Error(), "replicaSet", rs.Name)
+				return
 			}
-
-			cursor = replicaSets.Continue
-			if cursor == "" {
-				break
+			if reported {
+				logger.Info("actual state resync: reported changed deployment status", "replicaSet", rs.Name)
 			}
-		}
+		})
 	})
+}
+
+// runDesiredStateResyncLoop periodically reconciles every deployment ReplicaSet
+// against the control plane's desired state.
+//
+// This is a consistency safety net that complements the streaming desired state
+// channel. It runs every minute, fetching the desired state for each RS and
+// applying or deleting as needed. Because this involves potentially slow RPCs
+// (GetDesiredDeploymentState), it runs independently from actual state reporting
+// so it cannot delay instance updates.
+func (c *Controller) runDesiredStateResyncLoop(ctx context.Context) {
+	repeat.Every(1*time.Minute, func() {
+		logger.Info("running desired state resync")
+		c.forEachReplicaSet(ctx, func(ctx context.Context, rs *appsv1.ReplicaSet) {
+			c.reconcileDesiredState(ctx, rs)
+		})
+	})
+}
+
+// forEachReplicaSet paginates through all krane-managed deployment ReplicaSets
+// and calls fn for each one concurrently.
+func (c *Controller) forEachReplicaSet(ctx context.Context, fn func(ctx context.Context, rs *appsv1.ReplicaSet)) {
+	cursor := ""
+	for {
+		replicaSets, err := c.clientSet.AppsV1().ReplicaSets("").List(ctx, metav1.ListOptions{
+			LabelSelector: labels.New().
+				ManagedByKrane().
+				ComponentDeployment().
+				ToString(),
+			Continue: cursor,
+		})
+		if err != nil {
+			logger.Error("unable to list replicaSets", "error", err.Error())
+			return
+		}
+
+		conc.ForEach(ctx, replicaSets.Items, fn)
+
+		cursor = replicaSets.Continue
+		if cursor == "" {
+			break
+		}
+	}
+}
+
+// reconcileDesiredState fetches the desired state for a single ReplicaSet from
+// the control plane and applies or deletes as needed.
+func (c *Controller) reconcileDesiredState(ctx context.Context, replicaSet *appsv1.ReplicaSet) {
+	deploymentID, ok := labels.GetDeploymentID(replicaSet.Labels)
+	if !ok {
+		logger.Error("unable to get deployment ID", "replicaSet", replicaSet.Name)
+		return
+	}
+
+	res, err := c.cluster.GetDesiredDeploymentState(ctx, &ctrlv1.GetDesiredDeploymentStateRequest{
+		DeploymentId: deploymentID,
+	})
+	if err != nil {
+		if connect.CodeOf(err) == connect.CodeNotFound {
+			if err := c.DeleteDeployment(ctx, &ctrlv1.DeleteDeployment{
+				K8SNamespace: replicaSet.GetNamespace(),
+				K8SName:      replicaSet.GetName(),
+			}); err != nil {
+				logger.Error("unable to delete deployment", "error", err.Error(), "deployment_id", deploymentID)
+			}
+
+			return
+		}
+
+		logger.Error("unable to get desired deployment state", "error", err.Error(), "deployment_id", deploymentID)
+		return
+	}
+
+	switch res.GetState().(type) {
+	case *ctrlv1.DeploymentState_Apply:
+		if err := c.ApplyDeployment(ctx, res.GetApply()); err != nil {
+			logger.Error("unable to apply deployment", "error", err.Error(), "deployment_id", deploymentID)
+		}
+	case *ctrlv1.DeploymentState_Delete:
+		if err := c.DeleteDeployment(ctx, res.GetDelete()); err != nil {
+			logger.Error("unable to delete deployment", "error", err.Error(), "deployment_id", deploymentID)
+		}
+	}
 }

--- a/svc/krane/internal/sentinel/BUILD.bazel
+++ b/svc/krane/internal/sentinel/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//gen/rpc/ctrl",
         "//pkg/assert",
         "//pkg/circuitbreaker",
+        "//pkg/conc",
         "//pkg/config",
         "//pkg/logger",
         "//pkg/ptr",

--- a/svc/krane/internal/sentinel/actual_state_report.go
+++ b/svc/krane/internal/sentinel/actual_state_report.go
@@ -6,6 +6,7 @@ import (
 	ctrlv1 "github.com/unkeyed/unkey/gen/proto/ctrl/v1"
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/svc/krane/pkg/labels"
+	"github.com/unkeyed/unkey/pkg/conc"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
@@ -17,6 +18,9 @@ import (
 // The watch filters for resources with the "managed-by: krane" and "component: sentinel"
 // labels. When a Deployment's available replica count changes, the method reports
 // the actual state to the control plane so it knows which sentinels are ready.
+//
+// Events are processed concurrently via [conc.Sem] so that a slow RPC for one
+// sentinel does not block reporting for others.
 func (c *Controller) runActualStateReportLoop(ctx context.Context) error {
 	w, err := c.clientSet.AppsV1().Deployments(NamespaceSentinel).Watch(ctx, metav1.ListOptions{
 		LabelSelector: labels.New().
@@ -29,6 +33,8 @@ func (c *Controller) runActualStateReportLoop(ctx context.Context) error {
 	}
 
 	go func() {
+		sem := conc.NewSem(conc.DefaultConcurrency)
+
 		for event := range w.ResultChan() {
 			switch event.Type {
 			case watch.Error:
@@ -40,48 +46,61 @@ func (c *Controller) runActualStateReportLoop(ctx context.Context) error {
 					logger.Error("unable to cast object to deployment")
 					continue
 				}
-				logger.Info("sentinel added/modified", "name", sentinel.Name)
 
-				desiredReplicas := int32(0)
-				if sentinel.Spec.Replicas != nil {
-					desiredReplicas = *sentinel.Spec.Replicas
-				}
-
-				var health ctrlv1.Health
-				if desiredReplicas == 0 {
-					health = ctrlv1.Health_HEALTH_PAUSED
-				} else if sentinel.Status.AvailableReplicas > 0 {
-					health = ctrlv1.Health_HEALTH_HEALTHY
-				} else {
-					health = ctrlv1.Health_HEALTH_UNHEALTHY
-				}
-
-				err := c.reportSentinelStatus(ctx, &ctrlv1.ReportSentinelStatusRequest{
-					K8SName:           sentinel.Name,
-					AvailableReplicas: sentinel.Status.AvailableReplicas,
-					Health:            health,
+				sem.Go(ctx, func(ctx context.Context) {
+					c.reportSentinelState(ctx, sentinel)
 				})
-				if err != nil {
-					logger.Error("error reporting sentinel status", "error", err.Error())
-				}
 			case watch.Deleted:
 				sentinel, ok := event.Object.(*appsv1.Deployment)
 				if !ok {
 					logger.Error("unable to cast object to deployment")
 					continue
 				}
-				logger.Info("sentinel deleted", "name", sentinel.Name)
-				err := c.reportSentinelStatus(ctx, &ctrlv1.ReportSentinelStatusRequest{
-					K8SName:           sentinel.Name,
-					AvailableReplicas: 0,
-					Health:            ctrlv1.Health_HEALTH_UNHEALTHY,
+
+				sem.Go(ctx, func(ctx context.Context) {
+					logger.Info("sentinel deleted", "name", sentinel.Name)
+					err := c.reportSentinelStatus(ctx, &ctrlv1.ReportSentinelStatusRequest{
+						K8SName:           sentinel.Name,
+						AvailableReplicas: 0,
+						Health:            ctrlv1.Health_HEALTH_UNHEALTHY,
+					})
+					if err != nil {
+						logger.Error("error reporting sentinel status", "error", err.Error())
+					}
 				})
-				if err != nil {
-					logger.Error("error reporting sentinel status", "error", err.Error())
-				}
 			}
 		}
+
+		sem.Wait()
 	}()
 
 	return nil
+}
+
+// reportSentinelState computes and reports the health of a sentinel Deployment.
+func (c *Controller) reportSentinelState(ctx context.Context, sentinel *appsv1.Deployment) {
+	logger.Info("sentinel added/modified", "name", sentinel.Name)
+
+	desiredReplicas := int32(0)
+	if sentinel.Spec.Replicas != nil {
+		desiredReplicas = *sentinel.Spec.Replicas
+	}
+
+	var health ctrlv1.Health
+	if desiredReplicas == 0 {
+		health = ctrlv1.Health_HEALTH_PAUSED
+	} else if sentinel.Status.AvailableReplicas > 0 {
+		health = ctrlv1.Health_HEALTH_HEALTHY
+	} else {
+		health = ctrlv1.Health_HEALTH_UNHEALTHY
+	}
+
+	err := c.reportSentinelStatus(ctx, &ctrlv1.ReportSentinelStatusRequest{
+		K8SName:           sentinel.Name,
+		AvailableReplicas: sentinel.Status.AvailableReplicas,
+		Health:            health,
+	})
+	if err != nil {
+		logger.Error("error reporting sentinel status", "error", err.Error())
+	}
 }

--- a/svc/krane/internal/sentinel/controller.go
+++ b/svc/krane/internal/sentinel/controller.go
@@ -53,18 +53,20 @@ func New(cfg Config) *Controller {
 
 // Start launches the background control loops:
 //
-//   - [Controller.runActualStateReportLoop]: Watches Kubernetes for Deployment
-//     changes and reports actual state back to the control plane.
+//   - [Controller.runActualStateReportLoop]: Real-time Kubernetes watch for
+//     Deployment changes, reports actual state back to the control plane.
+//   - [Controller.runActualStateResyncLoop]: Periodic safety net for health
+//     reporting (complements the real-time watch).
+//   - [Controller.runDesiredStateResyncLoop]: Periodic reconciliation of desired
+//     state from the control plane (complements the streaming channel).
 //
-//   - [Controller.runResyncLoop]: Periodically re-queries the control plane for
-//     each existing sentinel to ensure eventual consistency.
-//
-// Desired state is received externally via the watcher package, which calls
-// [Controller.ApplySentinel] and [Controller.DeleteSentinel] directly.
+// The actual-state and desired-state resync loops are decoupled so that slow
+// control plane RPCs cannot delay health reporting.
 //
 // All loops continue until the context is cancelled or [Controller.Stop] is called.
 func (c *Controller) Start(ctx context.Context) error {
-	go c.runResyncLoop(ctx)
+	go c.runActualStateResyncLoop(ctx)
+	go c.runDesiredStateResyncLoop(ctx)
 
 	if err := c.runActualStateReportLoop(ctx); err != nil {
 		return err

--- a/svc/krane/internal/sentinel/resync.go
+++ b/svc/krane/internal/sentinel/resync.go
@@ -9,76 +9,109 @@ import (
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/pkg/repeat"
 	"github.com/unkeyed/unkey/svc/krane/pkg/labels"
+	"github.com/unkeyed/unkey/pkg/conc"
+	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// runResyncLoop periodically reconciles all sentinel Deployments with their
-// desired state from the control plane.
+// runActualStateResyncLoop periodically reports actual sentinel health to the
+// control plane for every sentinel Deployment.
 //
-// This loop runs every minute as a consistency safety net. While
-// [Controller.runActualStateReportLoop] handles real-time K8s events and
-// [Controller.runDesiredStateApplyLoop] handles streaming updates, both can miss
-// events during network partitions, controller restarts, or buffer overflows.
-// This resync loop guarantees eventual consistency by querying the control plane
-// for each existing sentinel and applying any needed changes.
-func (c *Controller) runResyncLoop(ctx context.Context) {
-	repeat.Every(1*time.Minute, func() {
-		logger.Info("running periodic resync")
-
-		cursor := ""
-		for {
-			deployments, err := c.clientSet.AppsV1().Deployments(NamespaceSentinel).List(ctx, metav1.ListOptions{
-				LabelSelector: labels.New().
-					ManagedByKrane().
-					ComponentSentinel().
-					ToString(),
-				Continue: cursor,
-			})
-			if err != nil {
-				logger.Error("unable to list deployments", "error", err.Error())
-				return
-			}
-
-			for _, deployment := range deployments.Items {
-				sentinelID, ok := labels.GetSentinelID(deployment.Labels)
-				if !ok {
-					logger.Error("unable to get sentinel ID", "deployment", deployment.Name)
-					continue
-				}
-
-				res, err := c.cluster.GetDesiredSentinelState(ctx, &ctrlv1.GetDesiredSentinelStateRequest{
-					SentinelId: sentinelID,
-				})
-				if err != nil {
-					if connect.CodeOf(err) == connect.CodeNotFound {
-						if err := c.DeleteSentinel(ctx, &ctrlv1.DeleteSentinel{
-							K8SName: deployment.GetName(),
-						}); err != nil {
-							logger.Error("unable to delete sentinel", "error", err.Error(), "sentinel_id", sentinelID)
-							continue
-						}
-					}
-
-					logger.Error("unable to get desired sentinel state", "error", err.Error(), "sentinel_id", sentinelID)
-					continue
-				}
-
-				switch res.GetState().(type) {
-				case *ctrlv1.SentinelState_Apply:
-					if err := c.ApplySentinel(ctx, res.GetApply()); err != nil {
-						logger.Error("unable to apply sentinel", "error", err.Error(), "sentinel_id", sentinelID)
-					}
-				case *ctrlv1.SentinelState_Delete:
-					if err := c.DeleteSentinel(ctx, res.GetDelete()); err != nil {
-						logger.Error("unable to delete sentinel", "error", err.Error(), "sentinel_id", sentinelID)
-					}
-				}
-			}
-
-			cursor = deployments.Continue
-			if cursor == "" {
-				break
-			}
-		}
+// This is a lightweight safety net that complements [Controller.runActualStateReportLoop].
+// The watch handles real-time events, but can miss updates during network partitions,
+// restarts, or buffer overflows. This loop catches the drift by reporting health
+// for every sentinel every 30 seconds.
+//
+// This loop does NOT fetch or apply desired state — that is handled independently
+// by [Controller.runDesiredStateResyncLoop] so that slow control plane RPCs cannot
+// delay health reporting.
+func (c *Controller) runActualStateResyncLoop(ctx context.Context) {
+	repeat.Every(30*time.Second, func() {
+		logger.Info("running sentinel actual state resync")
+		c.forEachSentinelDeployment(ctx, func(ctx context.Context, deployment *appsv1.Deployment) {
+			c.reportSentinelState(ctx, deployment)
+		})
 	})
+}
+
+// runDesiredStateResyncLoop periodically reconciles every sentinel Deployment
+// against the control plane's desired state.
+//
+// This is a consistency safety net that complements the streaming desired state
+// channel. It runs every minute, fetching the desired state for each sentinel and
+// applying or deleting as needed. Because this involves potentially slow RPCs
+// (GetDesiredSentinelState), it runs independently from actual state reporting
+// so it cannot delay health updates.
+func (c *Controller) runDesiredStateResyncLoop(ctx context.Context) {
+	repeat.Every(1*time.Minute, func() {
+		logger.Info("running sentinel desired state resync")
+		c.forEachSentinelDeployment(ctx, func(ctx context.Context, deployment *appsv1.Deployment) {
+			c.reconcileDesiredState(ctx, deployment)
+		})
+	})
+}
+
+// forEachSentinelDeployment paginates through all krane-managed sentinel
+// Deployments and calls fn for each one concurrently.
+func (c *Controller) forEachSentinelDeployment(ctx context.Context, fn func(ctx context.Context, deployment *appsv1.Deployment)) {
+	cursor := ""
+	for {
+		deployments, err := c.clientSet.AppsV1().Deployments(NamespaceSentinel).List(ctx, metav1.ListOptions{
+			LabelSelector: labels.New().
+				ManagedByKrane().
+				ComponentSentinel().
+				ToString(),
+			Continue: cursor,
+		})
+		if err != nil {
+			logger.Error("unable to list deployments", "error", err.Error())
+			return
+		}
+
+		conc.ForEach(ctx, deployments.Items, fn)
+
+		cursor = deployments.Continue
+		if cursor == "" {
+			break
+		}
+	}
+}
+
+// reconcileDesiredState fetches the desired state for a single sentinel from
+// the control plane and applies or deletes as needed.
+func (c *Controller) reconcileDesiredState(ctx context.Context, deployment *appsv1.Deployment) {
+	sentinelID, ok := labels.GetSentinelID(deployment.Labels)
+	if !ok {
+		logger.Error("unable to get sentinel ID", "deployment", deployment.Name)
+		return
+	}
+
+	res, err := c.cluster.GetDesiredSentinelState(ctx, &ctrlv1.GetDesiredSentinelStateRequest{
+		SentinelId: sentinelID,
+	})
+	if err != nil {
+		if connect.CodeOf(err) == connect.CodeNotFound {
+			if err := c.DeleteSentinel(ctx, &ctrlv1.DeleteSentinel{
+				K8SName: deployment.GetName(),
+			}); err != nil {
+				logger.Error("unable to delete sentinel", "error", err.Error(), "sentinel_id", sentinelID)
+			}
+
+			return
+		}
+
+		logger.Error("unable to get desired sentinel state", "error", err.Error(), "sentinel_id", sentinelID)
+		return
+	}
+
+	switch res.GetState().(type) {
+	case *ctrlv1.SentinelState_Apply:
+		if err := c.ApplySentinel(ctx, res.GetApply()); err != nil {
+			logger.Error("unable to apply sentinel", "error", err.Error(), "sentinel_id", sentinelID)
+		}
+	case *ctrlv1.SentinelState_Delete:
+		if err := c.DeleteSentinel(ctx, res.GetDelete()); err != nil {
+			logger.Error("unable to delete sentinel", "error", err.Error(), "sentinel_id", sentinelID)
+		}
+	}
 }


### PR DESCRIPTION
## What does this PR do?

Introduces a new `pkg/conc` package with bounded concurrency primitives and refactors Krane controllers to process resources concurrently during resync and watch operations. This prevents slow RPCs for individual resources from blocking the processing of others.

### Key Changes

**New `pkg/conc` package:**
- `Sem`: Context-aware bounded-concurrency scheduler wrapping `semaphore.Weighted` with `sync.WaitGroup`
- `ForEach`: Processes slices concurrently with bounded parallelism (default 10)

**Cilium controller:**
- Extracts single policy reconciliation into `resyncCiliumNetworkPolicy` method
- Uses `conc.ForEach` to process policies concurrently

**Deployment controller:**
- Splits single resync loop into separate actual-state (30s) and desired-state (1m) loops
- Extracts `handlePodEvent` for concurrent pod watch processing
- Extracts `reconcileDesiredState` and adds `forEachReplicaSet` helper
- Pod watch events now processed with bounded concurrency via `conc.Sem`

**Sentinel controller:**
- Splits single resync loop into separate actual-state (30s) and desired-state (1m) loops  
- Extracts `reportSentinelState` and `reconcileDesiredState` methods
- Adds `forEachSentinelDeployment` helper using `conc.ForEach`
- Watch events processed concurrently via `conc.Sem`

The separation of actual-state and desired-state resync loops ensures that slow control plane RPCs cannot delay instance health reporting.

## Type of change

- [x] Chore (refactoring code, technical debt, workflow improvements)
- [x] Enhancement (small improvements)

## How should this be tested?

- Deploy multiple resources (deployments, network policies, sentinels) and verify resync loops complete faster
- Introduce artificial delays in control plane RPCs and confirm other resources continue processing
- Test with cancelled contexts to ensure goroutines don't leak
- Run existing integration tests to verify functional behavior is unchanged
- Monitor that actual-state reporting continues even when desired-state reconciliation is slow

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [x] Ran `make fmt` on `/go` directory
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary