### PR TITLE
fix: deduplicate custom domains

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/components/domain-priority.test.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/components/domain-priority.test.ts
@@ -32,6 +32,8 @@ function makeCustomDomain(overrides: Partial<CustomDomain> = {}): CustomDomain {
     checkAttempts: 0,
     lastCheckedAt: null,
     verificationError: null,
+    domainConnectProvider: null,
+    domainConnectUrl: null,
     createdAt: 0,
     updatedAt: null,
     ...overrides,
@@ -195,6 +197,27 @@ describe("getDomainPriority", () => {
       }
     });
   }
+
+  test("verified custom domain deduplicates matching platform domain", () => {
+    const result = getDomainPriority({
+      ...baseCtx,
+      domains: [
+        makeDomain({
+          id: "d-custom-route",
+          fullyQualifiedDomainName: "custom.example.com",
+          sticky: "live",
+        }),
+        makeDomain({ id: "d-a", fullyQualifiedDomainName: "a.example.com" }),
+      ],
+      customDomains: [
+        makeCustomDomain({ id: "cd-1", domain: "custom.example.com" }),
+      ],
+    });
+
+    expect(result.all).toHaveLength(2);
+    expect(result.all.map((d) => d.id)).toEqual(["cd-1", "d-a"]);
+    expect(result.primary?.id).toBe("cd-1");
+  });
 
   test("all order: custom → sticky live → sticky branch → rest alphabetically", () => {
     const result = getDomainPriority({

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/components/domain-priority.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/components/domain-priority.ts
@@ -42,7 +42,11 @@ export function getDomainPriority(ctx: DomainPriorityContext): DomainPriorityRes
       customDomain: cd,
     }));
 
+  // Exclude platform domains that match a verified custom domain to avoid duplicates
+  const customHostnames = new Set(customDisplayDomains.map((cd) => cd.hostname));
+
   const platformDisplayDomains: ReadonlyArray<DisplayDomain> = [...ctx.domains]
+    .filter((d) => !customHostnames.has(d.fullyQualifiedDomainName))
     .sort((a, b) => a.fullyQualifiedDomainName.localeCompare(b.fullyQualifiedDomainName))
     .map((d) => ({
       source: "platform" as const,

--- a/web/apps/dashboard/lib/collections/deploy/custom-domains.ts
+++ b/web/apps/dashboard/lib/collections/deploy/custom-domains.ts
@@ -4,6 +4,7 @@ import { createCollection } from "@tanstack/react-db";
 import { toast } from "@unkey/ui";
 import { z } from "zod";
 import { queryClient, trpcClient } from "../client";
+import { domains } from "./domains";
 import { parseProjectIdFromWhere, validateProjectIdInQuery } from "./utils";
 
 const verificationStatusSchema = z.enum(["pending", "verifying", "verified", "failed"]);
@@ -92,6 +93,7 @@ export const customDomains = createCollection<CustomDomain, string>(
       });
 
       await mutation;
+      await customDomains.utils.refetch();
     },
     onDelete: async ({ transaction }) => {
       const original = transaction.mutations[0].original;
@@ -111,6 +113,7 @@ export const customDomains = createCollection<CustomDomain, string>(
       });
 
       await deleteMutation;
+      await domains.utils.refetch();
     },
   }),
 );


### PR DESCRIPTION
## What does this PR do?

Prevents duplicate domains from appearing in the domain list when a verified custom domain matches an existing platform domain. The domain priority logic now filters out platform domains that have the same hostname as verified custom domains, ensuring each unique domain appears only once in the interface.

Added test coverage to verify the deduplication behavior and included cache invalidation to keep domain lists synchronized when custom domains are created or deleted.

Fixes #5318

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Create a custom domain that matches an existing platform domain hostname
- Verify that only the custom domain appears in the domain list, not both
- Test that domain list updates correctly when custom domains are added or removed
- Run the new test case that validates deduplication behavior

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary