### PR TITLE
chore: ci disable ipv6

### DIFF
--- a/.depot/workflows/autofix.ci.yaml
+++ b/.depot/workflows/autofix.ci.yaml
@@ -14,6 +14,14 @@ jobs:
     runs-on: depot-ubuntu-24.04-4
     timeout-minutes: 15
     steps:
+      - name: Disable IPv6 (workaround for proxy.golang.org resolution)
+        run: |
+          sudo sysctl -w net.ipv6.conf.all.disable_ipv6=1
+          sudo sysctl -w net.ipv6.conf.default.disable_ipv6=1
+          sudo sysctl -w net.ipv6.conf.lo.disable_ipv6=1
+          echo 'precedence ::ffff:0:0/96 100' | sudo tee -a /etc/gai.conf
+          echo 'nameserver 8.8.8.8' | sudo tee /etc/resolv.conf
+          echo 'nameserver 8.8.4.4' | sudo tee -a /etc/resolv.conf
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
       - name: Setup Node
         uses: ./.depot/actions/setup-node

--- a/.depot/workflows/job_bazel.yaml
+++ b/.depot/workflows/job_bazel.yaml
@@ -9,6 +9,14 @@ jobs:
     runs-on: depot-ubuntu-24.04-8
     timeout-minutes: 30
     steps:
+      - name: Disable IPv6 (workaround for proxy.golang.org resolution)
+        run: |
+          sudo sysctl -w net.ipv6.conf.all.disable_ipv6=1
+          sudo sysctl -w net.ipv6.conf.default.disable_ipv6=1
+          sudo sysctl -w net.ipv6.conf.lo.disable_ipv6=1
+          echo 'precedence ::ffff:0:0/96 100' | sudo tee -a /etc/gai.conf
+          echo 'nameserver 8.8.8.8' | sudo tee /etc/resolv.conf
+          echo 'nameserver 8.8.4.4' | sudo tee -a /etc/resolv.conf
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
       - uses: bazel-contrib/setup-bazel@083175551ceeceebc757ebee2127fde78840ca77 # 0.18.0
         with:
@@ -22,6 +30,7 @@ jobs:
             common --remote_cache=https://cache.depot.dev
             common --remote_header=authorization=${{ secrets.DEPOT_BAZEL_CACHE_AUTHORIZATION }}
             common --remote_local_fallback
+            common --repo_env=GODEBUG=netdns=cgo
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
         with:

--- a/.depot/workflows/release.yaml
+++ b/.depot/workflows/release.yaml
@@ -18,6 +18,14 @@ jobs:
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
+      - name: Disable IPv6 (workaround for proxy.golang.org resolution)
+        run: |
+          sudo sysctl -w net.ipv6.conf.all.disable_ipv6=1
+          sudo sysctl -w net.ipv6.conf.default.disable_ipv6=1
+          sudo sysctl -w net.ipv6.conf.lo.disable_ipv6=1
+          echo 'precedence ::ffff:0:0/96 100' | sudo tee -a /etc/gai.conf
+          echo 'nameserver 8.8.8.8' | sudo tee /etc/resolv.conf
+          echo 'nameserver 8.8.4.4' | sudo tee -a /etc/resolv.conf
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -69,6 +77,14 @@ jobs:
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
+      - name: Disable IPv6 (workaround for proxy.golang.org resolution)
+        run: |
+          sudo sysctl -w net.ipv6.conf.all.disable_ipv6=1
+          sudo sysctl -w net.ipv6.conf.default.disable_ipv6=1
+          sudo sysctl -w net.ipv6.conf.lo.disable_ipv6=1
+          echo 'precedence ::ffff:0:0/96 100' | sudo tee -a /etc/gai.conf
+          echo 'nameserver 8.8.8.8' | sudo tee /etc/resolv.conf
+          echo 'nameserver 8.8.4.4' | sudo tee -a /etc/resolv.conf
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:


### PR DESCRIPTION
## What does this PR do?

Adds IPv6 disabling step to CI workflows to resolve proxy.golang.org DNS resolution issues. This workaround prevents connectivity problems that can occur when the Go proxy service has IPv6 resolution issues on the depot-ubuntu-24.04 runners.

The change adds a step to disable IPv6 at the system level before checkout in the autofix, bazel, and release workflows.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Run the affected CI workflows and verify they complete successfully without proxy.golang.org resolution errors
- Confirm Go module downloads work properly in the bazel and release jobs
- Verify the autofix workflow can complete its Node.js setup and subsequent steps

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary