### PR TITLE
fix: add initialDimensions to all ResponsiveContainer chart instances

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/network/unkey-flow/components/overlay/node-details-panel/components/chart/components/logs-chart-empty.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/network/unkey-flow/components/overlay/node-details-panel/components/chart/components/logs-chart-empty.tsx
@@ -21,8 +21,7 @@ export const LogsChartEmpty = ({ config, height }: LogsChartEmptyProps) => {
         height={height}
         className="border-b border-grayA-4"
         width="100%"
-        minHeight={1}
-        minWidth={1}
+        initialDimension={{ width: 1, height: 1 }}
       >
         <BarChart
           data={placeholderData}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/network/unkey-flow/components/overlay/node-details-panel/components/chart/components/logs-chart-empty.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/network/unkey-flow/components/overlay/node-details-panel/components/chart/components/logs-chart-empty.tsx
@@ -17,7 +17,13 @@ export const LogsChartEmpty = ({ config, height }: LogsChartEmptyProps) => {
 
   return (
     <div className="w-full relative">
-      <ResponsiveContainer height={height} className="border-b border-grayA-4" width="100%">
+      <ResponsiveContainer
+        height={height}
+        className="border-b border-grayA-4"
+        width="100%"
+        minHeight={1}
+        minWidth={1}
+      >
         <BarChart
           data={placeholderData}
           margin={{ top: 0, right: 0, bottom: 0, left: 0 }}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/network/unkey-flow/components/overlay/node-details-panel/components/chart/components/logs-chart-error.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/network/unkey-flow/components/overlay/node-details-panel/components/chart/components/logs-chart-error.tsx
@@ -3,7 +3,13 @@ import { ResponsiveContainer } from "recharts";
 export const LogsChartError = () => {
   return (
     <div className="w-full relative">
-      <ResponsiveContainer height={50} className="border-b border-grayA-4" width="100%">
+      <ResponsiveContainer
+        height={50}
+        className="border-b border-grayA-4"
+        width="100%"
+        minHeight={1}
+        minWidth={1}
+      >
         <div className="flex-1 flex items-center justify-center h-full">
           <div className="flex flex-col items-center gap-2">
             <span className="text-sm text-accent-9">Could not retrieve logs</span>

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/network/unkey-flow/components/overlay/node-details-panel/components/chart/components/logs-chart-error.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/network/unkey-flow/components/overlay/node-details-panel/components/chart/components/logs-chart-error.tsx
@@ -7,8 +7,7 @@ export const LogsChartError = () => {
         height={50}
         className="border-b border-grayA-4"
         width="100%"
-        minHeight={1}
-        minWidth={1}
+        initialDimension={{ width: 1, height: 1 }}
       >
         <div className="flex-1 flex items-center justify-center h-full">
           <div className="flex flex-col items-center gap-2">

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/network/unkey-flow/components/overlay/node-details-panel/components/chart/components/logs-chart-loading.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/network/unkey-flow/components/overlay/node-details-panel/components/chart/components/logs-chart-loading.tsx
@@ -15,7 +15,13 @@ export const LogsChartLoading = () => {
 
   return (
     <div className="w-full relative">
-      <ResponsiveContainer height={50} className="border-b border-grayA-4" width="100%">
+      <ResponsiveContainer
+        height={50}
+        className="border-b border-grayA-4"
+        width="100%"
+        minHeight={1}
+        minWidth={1}
+      >
         <BarChart margin={{ top: 0, right: -20, bottom: 0, left: -20 }} barGap={0} data={mockData}>
           <YAxis domain={[0, 1.2]} hide />
           <Bar dataKey="success" fill="hsl(var(--accent-3))" isAnimationActive={false} />

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/network/unkey-flow/components/overlay/node-details-panel/components/chart/components/logs-chart-loading.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/network/unkey-flow/components/overlay/node-details-panel/components/chart/components/logs-chart-loading.tsx
@@ -19,8 +19,7 @@ export const LogsChartLoading = () => {
         height={50}
         className="border-b border-grayA-4"
         width="100%"
-        minHeight={1}
-        minWidth={1}
+        initialDimension={{ width: 1, height: 1 }}
       >
         <BarChart margin={{ top: 0, right: -20, bottom: 0, left: -20 }} barGap={0} data={mockData}>
           <YAxis domain={[0, 1.2]} hide />

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/components/domain-priority.test.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/components/domain-priority.test.ts
@@ -209,9 +209,7 @@ describe("getDomainPriority", () => {
         }),
         makeDomain({ id: "d-a", fullyQualifiedDomainName: "a.example.com" }),
       ],
-      customDomains: [
-        makeCustomDomain({ id: "cd-1", domain: "custom.example.com" }),
-      ],
+      customDomains: [makeCustomDomain({ id: "cd-1", domain: "custom.example.com" })],
     });
 
     expect(result.all).toHaveLength(2);

--- a/web/apps/dashboard/components/logs/chart/chart-states/chart-loading.tsx
+++ b/web/apps/dashboard/components/logs/chart/chart-states/chart-loading.tsx
@@ -75,7 +75,7 @@ export const ChartLoading = ({
     return (
       <div className={cn("flex flex-col h-full animate-pulse", className)}>
         <div className="flex-1 min-h-0">
-          <ResponsiveContainer width="100%" height="100%" minHeight={1} minWidth={1}>
+          <ResponsiveContainer width="100%" height="100%" initialDimension={{ width: 1, height: 1 }}>
             <BarChart data={mockData} margin={{ top: 0, right: 0, bottom: 0, left: 0 }}>
               <YAxis domain={[0, 1]} hide />
               <Bar
@@ -113,8 +113,7 @@ export const ChartLoading = ({
           height={height}
           className="border-b border-gray-4"
           width="100%"
-          minHeight={1}
-          minWidth={1}
+          initialDimension={{ width: 1, height: 1 }}
         >
           <BarChart
             margin={{ top: 0, right: -20, bottom: 0, left: -20 }}
@@ -138,7 +137,7 @@ export const ChartLoading = ({
   return (
     <div className={cn("flex flex-col h-full animate-pulse", className)}>
       <div className="flex-1 min-h-0">
-        <ResponsiveContainer width="100%" height="100%" minHeight={1} minWidth={1}>
+        <ResponsiveContainer width="100%" height="100%" initialDimension={{ width: 1, height: 1 }}>
           <BarChart data={mockData} margin={{ top: 0, right: 0, bottom: 0, left: 0 }}>
             <YAxis domain={[0, 1]} hide />
             <Bar dataKey="success" fill="hsl(var(--accent-3))" isAnimationActive={false} />
@@ -283,7 +282,7 @@ function FullChartLoader({
 
       {/* Chart area */}
       <div className="flex-1 min-h-0">
-        <ResponsiveContainer width="100%" height="100%" minHeight={1} minWidth={1}>
+        <ResponsiveContainer width="100%" height="100%" initialDimension={{ width: 1, height: 1 }}>
           <AreaChart data={mockData} margin={{ top: 0, right: 0, bottom: 0, left: 0 }}>
             <defs>
               {labelsWithDefaults.metrics.map((metric) => (

--- a/web/apps/dashboard/components/logs/chart/chart-states/chart-loading.tsx
+++ b/web/apps/dashboard/components/logs/chart/chart-states/chart-loading.tsx
@@ -75,7 +75,7 @@ export const ChartLoading = ({
     return (
       <div className={cn("flex flex-col h-full animate-pulse", className)}>
         <div className="flex-1 min-h-0">
-          <ResponsiveContainer width="100%" height="100%">
+          <ResponsiveContainer width="100%" height="100%" minHeight={1} minWidth={1}>
             <BarChart data={mockData} margin={{ top: 0, right: 0, bottom: 0, left: 0 }}>
               <YAxis domain={[0, 1]} hide />
               <Bar
@@ -109,7 +109,13 @@ export const ChartLoading = ({
             </div>
           ))}
         </div>
-        <ResponsiveContainer height={height} className="border-b border-gray-4" width="100%">
+        <ResponsiveContainer
+          height={height}
+          className="border-b border-gray-4"
+          width="100%"
+          minHeight={1}
+          minWidth={1}
+        >
           <BarChart
             margin={{ top: 0, right: -20, bottom: 0, left: -20 }}
             barGap={0}
@@ -132,7 +138,7 @@ export const ChartLoading = ({
   return (
     <div className={cn("flex flex-col h-full animate-pulse", className)}>
       <div className="flex-1 min-h-0">
-        <ResponsiveContainer width="100%" height="100%">
+        <ResponsiveContainer width="100%" height="100%" minHeight={1} minWidth={1}>
           <BarChart data={mockData} margin={{ top: 0, right: 0, bottom: 0, left: 0 }}>
             <YAxis domain={[0, 1]} hide />
             <Bar dataKey="success" fill="hsl(var(--accent-3))" isAnimationActive={false} />
@@ -277,7 +283,7 @@ function FullChartLoader({
 
       {/* Chart area */}
       <div className="flex-1 min-h-0">
-        <ResponsiveContainer width="100%" height="100%">
+        <ResponsiveContainer width="100%" height="100%" minHeight={1} minWidth={1}>
           <AreaChart data={mockData} margin={{ top: 0, right: 0, bottom: 0, left: 0 }}>
             <defs>
               {labelsWithDefaults.metrics.map((metric) => (

--- a/web/apps/dashboard/components/logs/overview-charts/overview-bar-chart-loader.tsx
+++ b/web/apps/dashboard/components/logs/overview-charts/overview-bar-chart-loader.tsx
@@ -55,7 +55,7 @@ export const OverviewChartLoader = ({
       </div>
       {/* Chart area */}
       <div className="flex-1 min-h-0">
-        <ResponsiveContainer width="100%" height="100%" minHeight={1} minWidth={1}>
+        <ResponsiveContainer width="100%" height="100%" initialDimension={{ width: 1, height: 1 }}>
           <BarChart data={mockData} margin={{ top: 0, right: 0, bottom: 0, left: 0 }}>
             <YAxis domain={[0, 1]} hide />
             <Bar

--- a/web/apps/dashboard/components/logs/overview-charts/overview-bar-chart-loader.tsx
+++ b/web/apps/dashboard/components/logs/overview-charts/overview-bar-chart-loader.tsx
@@ -55,7 +55,7 @@ export const OverviewChartLoader = ({
       </div>
       {/* Chart area */}
       <div className="flex-1 min-h-0">
-        <ResponsiveContainer width="100%" height="100%">
+        <ResponsiveContainer width="100%" height="100%" minHeight={1} minWidth={1}>
           <BarChart data={mockData} margin={{ top: 0, right: 0, bottom: 0, left: 0 }}>
             <YAxis domain={[0, 1]} hide />
             <Bar

--- a/web/apps/dashboard/components/ui/chart.tsx
+++ b/web/apps/dashboard/components/ui/chart.tsx
@@ -57,7 +57,9 @@ const ChartContainer = React.forwardRef<
         {...props}
       >
         <ChartStyle id={chartId} config={config} />
-        <RechartsPrimitive.ResponsiveContainer>{children}</RechartsPrimitive.ResponsiveContainer>
+        <RechartsPrimitive.ResponsiveContainer minHeight={1} minWidth={1}>
+          {children}
+        </RechartsPrimitive.ResponsiveContainer>
       </div>
     </ChartContext.Provider>
   );

--- a/web/apps/dashboard/components/ui/chart.tsx
+++ b/web/apps/dashboard/components/ui/chart.tsx
@@ -57,7 +57,7 @@ const ChartContainer = React.forwardRef<
         {...props}
       >
         <ChartStyle id={chartId} config={config} />
-        <RechartsPrimitive.ResponsiveContainer minHeight={1} minWidth={1}>
+        <RechartsPrimitive.ResponsiveContainer initialDimension={{ width: 1, height: 1 }}>
           {children}
         </RechartsPrimitive.ResponsiveContainer>
       </div>


### PR DESCRIPTION
## What does this PR do?

Fixes the recurring Sentry error: "The width(-1) and height(-1) of chart should be greater than 0" from Recharts.

The error fires when `ResponsiveContainer` renders inside a parent container that hasn't been laid out yet (0 computed dimensions). This happens during initial render of loading states, rapid tab switching, or when flex containers with `flex-1 min-h-0` haven't resolved their height.

This fix initializes responsive containers with  initialDimensions greater than their default of -1/-1

<img width="686" height="399" alt="Screenshot 2026-04-10 at 10 37 26 AM" src="https://github.com/user-attachments/assets/830eca8b-3683-447e-9961-59a2228ea52d" />

Fixes #5702 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Start the dashboard locally with `pnpm --dir=web dev`
- Open browser DevTools Console and filter for "should be greater than 0"
- Navigate to the API overview page (`/apis/[apiId]`) — charts with loading states should render without console warnings
- Navigate to the logs page — the timeseries bar chart loading state should render without warnings
- Rapidly switch between time ranges while charts are loading to trigger re-renders during layout
- Resize the browser to very small dimensions while charts are visible
- Inspect a chart's parent div (the one with `flex-1 min-h-0`), temporarily set `height: 0` via DevTools — no console warning should appear
- Navigate to a deployment's network view (`/projects/[projectId]/deployments/[deploymentId]/network`) and verify chart loading/empty/error states render cleanly
- After deploy: monitor Sentry for the "width(-1) and height(-1)" error — it should stop appearing

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary
