### PR TITLE
feat(dashboard): add cancel deployment action

### DIFF
--- a/svc/ctrl/worker/deploy/queue_gate.go
+++ b/svc/ctrl/worker/deploy/queue_gate.go
@@ -12,17 +12,20 @@ import (
 	"github.com/unkeyed/unkey/pkg/logger"
 )
 
-// skipIfSuperseded marks the current deployment as skipped and returns
+// skipIfSuperseded marks the current deployment as superseded and returns
 // (true, nil) when a newer deployment for the same (app, environment, branch)
 // has already been queued. Rapid pushes to the same branch only build the
-// latest commit.
+// latest commit. `skipped` is reserved for "watch paths didn't match", so
+// supersession uses its own status here.
 //
 // Returns (false, nil) when the deployment should proceed normally, or
 // (false, err) if the dedup query or status update fails.
 //
-// The check is race-free because Deploy is keyed by app_id — when this
-// handler runs, any subsequent deploys for the same app are already queued
-// in the Restate VO inbox.
+// This catches the race where the proactive dedup in
+// services/deployment.create_deployment didn't manage to cancel the older
+// sibling before it started running (e.g. invocation_id hadn't been
+// persisted yet). The workflow self-checks at the top so it can bow out
+// before acquiring a build slot.
 func (w *Workflow) skipIfSuperseded(
 	ctx restate.ObjectContext,
 	deployment db.Deployment,
@@ -43,7 +46,7 @@ func (w *Workflow) skipIfSuperseded(
 		return false, nil
 	}
 
-	logger.Info("skipping superseded deployment",
+	logger.Info("self-superseding deployment",
 		"deployment_id", deployment.ID,
 		"app_id", deployment.AppID,
 		"branch", deployment.GitBranch.String,
@@ -53,7 +56,7 @@ func (w *Workflow) skipIfSuperseded(
 		now := sql.NullInt64{Valid: true, Int64: time.Now().UnixMilli()}
 		if updErr := db.Query.UpdateDeploymentStatus(runCtx, w.db.RW(), db.UpdateDeploymentStatusParams{
 			ID:        deployment.ID,
-			Status:    db.DeploymentsStatusSkipped,
+			Status:    db.DeploymentsStatusSuperseded,
 			UpdatedAt: now,
 		}); updErr != nil {
 			return updErr
@@ -64,8 +67,8 @@ func (w *Workflow) skipIfSuperseded(
 			EndedAt:      now,
 			Error:        sql.NullString{Valid: true, String: "superseded by newer commit"},
 		})
-	}, restate.WithName("mark deployment skipped")); err != nil {
-		return false, fault.Wrap(err, fault.Public("Failed to mark deployment as skipped."))
+	}, restate.WithName("mark deployment superseded")); err != nil {
+		return false, fault.Wrap(err, fault.Public("Failed to mark deployment as superseded."))
 	}
 
 	return true, nil

--- a/svc/ctrl/worker/run.go
+++ b/svc/ctrl/worker/run.go
@@ -229,15 +229,17 @@ func Run(ctx context.Context, cfg Config) error {
 		AllowUnauthenticatedDeployments: cfg.GitHub.AllowUnauthenticatedDeployments,
 		DashboardURL:                    cfg.DashboardURL,
 	}),
-		// Retry with exponential backoff: 30s → 1m → 2m → 4m → 5m (capped),
-		// 10 attempts (~30 min total). A deploy that can't make progress
-		// after 10 retries (e.g. persistent MySQL EOF, Depot outage) should
-		// fail rather than stay stuck for hours.
+		// Retry with exponential backoff: 2s → 4s → 8s → 16s → 30s (capped),
+		// 15 attempts (~5 min total). Short backoffs keep the worst-case
+		// cancel latency low — a user-initiated cancel only lands at the
+		// next attempt boundary, so longer intervals make cancels feel
+		// stuck. 5 minutes total is enough for transient blips; persistent
+		// failures should surface fast rather than retry for half an hour.
 		restate.WithInvocationRetryPolicy(
-			restate.WithInitialInterval(30*time.Second),
+			restate.WithInitialInterval(2*time.Second),
 			restate.WithExponentiationFactor(2.0),
-			restate.WithMaxInterval(5*time.Minute),
-			restate.WithMaxAttempts(10),
+			restate.WithMaxInterval(30*time.Second),
+			restate.WithMaxAttempts(15),
 			restate.KillOnMaxAttempts(),
 		),
 	))

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/(deployment-progress)/deployment-cancelled.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/(deployment-progress)/deployment-cancelled.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import type { Deployment } from "@/lib/collections/deploy/deployments";
+import { Ban, CloudUp, Earth, Hammer2, LayerFront, Pulse, Sparkle3 } from "@unkey/icons";
+import { Button, SettingCardGroup } from "@unkey/ui";
+import { useState } from "react";
+import { RedeployDialog } from "../../components/table/components/actions/redeploy-dialog";
+import type { StepsData } from "./deployment-progress";
+import { DeploymentStep } from "./deployment-step";
+
+const STEP_ORDER: Array<{
+  key: keyof NonNullable<StepsData>;
+  icon: React.ReactNode;
+  title: string;
+}> = [
+  {
+    key: "queued",
+    icon: <LayerFront iconSize="sm-medium" className="size-[18px]" />,
+    title: "Deployment Queued",
+  },
+  {
+    key: "starting",
+    icon: <Pulse iconSize="sm-medium" className="size-[18px]" />,
+    title: "Deployment Starting",
+  },
+  {
+    key: "building",
+    icon: <Hammer2 iconSize="sm-medium" className="size-[18px]" />,
+    title: "Building Image",
+  },
+  {
+    key: "deploying",
+    icon: <CloudUp iconSize="sm-medium" className="size-[18px]" />,
+    title: "Deploying Containers",
+  },
+  {
+    key: "network",
+    icon: <Earth iconSize="sm-medium" className="size-[18px]" />,
+    title: "Assigning Domains",
+  },
+  {
+    key: "finalizing",
+    icon: <Sparkle3 iconSize="sm-medium" className="size-[18px]" />,
+    title: "Deployment Finalizing",
+  },
+];
+
+type StopReason = "cancelled" | "superseded";
+
+type DeploymentCancelledProps = {
+  deployment: Deployment;
+  stepsData?: StepsData;
+  reason: StopReason;
+};
+
+const COPY: Record<StopReason, { step: string; title: string; description: string }> = {
+  cancelled: {
+    step: "Cancelled",
+    title: "Deployment cancelled",
+    description: "You aborted this deployment. Redeploy to try again.",
+  },
+  superseded: {
+    step: "Superseded",
+    title: "Deployment superseded",
+    description: "A newer commit on this branch replaced this deployment.",
+  },
+};
+
+export function DeploymentCancelled({ deployment, stepsData, reason }: DeploymentCancelledProps) {
+  const [redeployOpen, setRedeployOpen] = useState(false);
+  const copy = COPY[reason];
+
+  // Find the first step that has an error and isn't completed -- that's
+  // the step that was actively running when the deployment was stopped.
+  const stoppedKey = STEP_ORDER.find(
+    ({ key }) => stepsData?.[key]?.error && !stepsData?.[key]?.completed,
+  )?.key;
+
+  return (
+    <div className="flex flex-col gap-5">
+      <SettingCardGroup>
+        {STEP_ORDER.map(({ key, icon, title }) => {
+          const step = stepsData?.[key];
+          const isStoppedHere = key === stoppedKey;
+
+          // Every step in the cancelled view shows the same description so
+          // the page reads as a single intent: this deployment was stopped.
+          // Steps that finished before the cancel keep their duration so
+          // you can still see how far it got.
+          return (
+            <DeploymentStep
+              key={key}
+              icon={icon}
+              title={title}
+              description={copy.step}
+              duration={step?.duration ?? undefined}
+              status="skipped"
+              statusIcon={
+                isStoppedHere ? <Ban className="text-gray-9" iconSize="md-regular" /> : undefined
+              }
+            />
+          );
+        })}
+      </SettingCardGroup>
+
+      <div className="border border-grayA-4 bg-grayA-2 rounded-[14px] p-4 flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <div className="flex flex-col gap-0.5">
+            <span className="text-sm font-medium text-gray-12">{copy.title}</span>
+            <span className="text-xs text-gray-11">{copy.description}</span>
+          </div>
+        </div>
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={() => setRedeployOpen(true)}
+          className="px-3 shrink-0"
+        >
+          Redeploy
+        </Button>
+      </div>
+
+      <RedeployDialog
+        isOpen={redeployOpen}
+        onClose={() => setRedeployOpen(false)}
+        selectedDeployment={deployment}
+      />
+    </div>
+  );
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/(deployment-progress)/deployment-info.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/(deployment-progress)/deployment-info.tsx
@@ -1,11 +1,15 @@
 "use client";
 
 import type { DeploymentStatus } from "@/lib/collections";
-import { Cloud } from "@unkey/icons";
+import { Ban, Cloud } from "@unkey/icons";
+import { Button } from "@unkey/ui";
+import { useState } from "react";
 import { ActiveDeploymentCard } from "../../../../components/active-deployment-card";
 import { DeploymentStatusBadge } from "../../../../components/deployment-status-badge";
 import { Section, SectionHeader } from "../../../../components/section";
 import { useProjectData } from "../../../data-provider";
+import { CancelDialog } from "../../components/table/components/actions/cancel-dialog";
+import { isCancellableDeploymentStatus } from "../../components/table/components/actions/deployment-action-eligibility";
 import { useDeployment } from "../layout-provider";
 
 type DeploymentInfoProps = {
@@ -17,6 +21,11 @@ export function DeploymentInfo({ title = "Deployment", statusOverride }: Deploym
   const { deployment } = useDeployment();
   const { project, environments } = useProjectData();
   const deploymentStatus = statusOverride ?? deployment.status;
+  // Track "the cancel mutation already succeeded for this view" so the
+  // button hides immediately even if the live query hasn't caught up yet.
+  const [cancelled, setCancelled] = useState(false);
+  const canCancel = isCancellableDeploymentStatus(deploymentStatus) && !cancelled;
+  const [cancelOpen, setCancelOpen] = useState(false);
 
   const isCurrent = project?.currentDeploymentId === deployment.id;
   const isRolledBack = isCurrent && (project?.isRolledBack ?? false);
@@ -24,7 +33,23 @@ export function DeploymentInfo({ title = "Deployment", statusOverride }: Deploym
 
   return (
     <Section>
-      <SectionHeader icon={<Cloud iconSize="md-regular" className="text-gray-9" />} title={title} />
+      <SectionHeader
+        icon={<Cloud iconSize="md-regular" className="text-gray-9" />}
+        title={title}
+        rightAction={
+          canCancel ? (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setCancelOpen(true)}
+              className="h-7 px-2 text-gray-11 hover:text-gray-12"
+            >
+              <Ban iconSize="sm-regular" />
+              Cancel deployment
+            </Button>
+          ) : undefined
+        }
+      />
       <ActiveDeploymentCard
         deploymentId={deployment.id}
         isCurrent={isCurrent}
@@ -32,6 +57,14 @@ export function DeploymentInfo({ title = "Deployment", statusOverride }: Deploym
         environmentSlug={environment?.slug}
         statusBadge={<DeploymentStatusBadge status={deploymentStatus} />}
       />
+      {canCancel && (
+        <CancelDialog
+          isOpen={cancelOpen}
+          onClose={() => setCancelOpen(false)}
+          onCancelled={() => setCancelled(true)}
+          deployment={deployment}
+        />
+      )}
     </Section>
   );
 }

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/(deployment-progress)/failed-deployment-banner.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/(deployment-progress)/failed-deployment-banner.tsx
@@ -25,6 +25,9 @@ function isSettingsRelatedError(error: string): boolean {
 
 export type StepEntry = { error: string | null } | null | undefined;
 
+// Note: user-cancelled deployments are routed to DeploymentCancelled in
+// page.tsx before this banner is rendered, so we don't need special-case
+// handling for the "Cancelled by user" marker here.
 export function FailedDeploymentBanner({
   steps,
   settingsUrl,

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/page.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/page.tsx
@@ -8,6 +8,7 @@ import { ProjectContentWrapper } from "../../../components/project-content-wrapp
 import { useProjectData } from "../../data-provider";
 import { DeploymentApproval } from "./(deployment-progress)/deployment-approval";
 import { DeploymentBuild } from "./(deployment-progress)/deployment-build";
+import { DeploymentCancelled } from "./(deployment-progress)/deployment-cancelled";
 import { DeploymentInfo } from "./(deployment-progress)/deployment-info";
 import { DeploymentProgress } from "./(deployment-progress)/deployment-progress";
 import { DeploymentSkipped } from "./(deployment-progress)/deployment-skipped";
@@ -23,14 +24,19 @@ export default function DeploymentOverview() {
 
   const ready = deployment.status === "ready";
   const skipped = deployment.status === "skipped";
+  const superseded = deployment.status === "superseded";
+  const cancelled = deployment.status === "cancelled";
   const awaitingApproval = deployment.status === "awaiting_approval";
+  // Steps don't change until the user authorizes (awaiting_approval) or
+  // until the deployment reaches a true terminal state — no point polling.
+  const stepsAreStable = ready || skipped || superseded || cancelled || awaitingApproval;
 
   const stepsQuery = trpc.deploy.deployment.steps.useQuery(
     { deploymentId: deployment.id },
     {
-      refetchInterval: ready || skipped || awaitingApproval ? false : 1_000,
+      refetchInterval: stepsAreStable ? false : 1_000,
       refetchOnWindowFocus: false,
-      enabled: !skipped,
+      enabled: !skipped && !superseded && !cancelled,
     },
   );
 
@@ -64,6 +70,24 @@ export default function DeploymentOverview() {
     .with("skipped", () => (
       <div key="skipped" className="animate-fade-slide-in">
         <DeploymentSkipped />
+      </div>
+    ))
+    .with("superseded", () => (
+      <div key="superseded" className="animate-fade-slide-in">
+        <DeploymentCancelled
+          deployment={deployment}
+          stepsData={stepsQuery.data}
+          reason="superseded"
+        />
+      </div>
+    ))
+    .with("cancelled", () => (
+      <div key="cancelled" className="animate-fade-slide-in">
+        <DeploymentCancelled
+          deployment={deployment}
+          stepsData={stepsQuery.data}
+          reason="cancelled"
+        />
       </div>
     ))
     .with("ready", () => (

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/components/table/components/actions/cancel-dialog.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/components/table/components/actions/cancel-dialog.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { type Deployment, collection } from "@/lib/collections";
+import { trpc } from "@/lib/trpc/client";
+import { Button, DialogContainer, toast } from "@unkey/ui";
+import { DeploymentCard } from "./components/deployment-card";
+
+type CancelDialogProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  // Optional: fired once the cancel mutation succeeds. Lets the parent
+  // hide the cancel-trigger button optimistically before the live query
+  // observes the status change.
+  onCancelled?: () => void;
+  deployment: Deployment;
+};
+
+export const CancelDialog = ({ isOpen, onClose, onCancelled, deployment }: CancelDialogProps) => {
+  const utils = trpc.useUtils();
+
+  const cancel = trpc.deploy.deployment.cancel.useMutation({
+    onSuccess: () => {
+      utils.invalidate();
+      toast.success("Deployment cancelled", {
+        description: `Cancelled deployment ${deployment.id}`,
+      });
+      try {
+        collection.deployments.utils.refetch();
+      } catch (error) {
+        console.error("Refetch error:", error);
+      }
+      onCancelled?.();
+      onClose();
+    },
+    onError: (error) => {
+      toast.error("Cancel failed", {
+        description: error.message,
+      });
+    },
+  });
+
+  const handleCancel = async () => {
+    await cancel
+      .mutateAsync({
+        deploymentId: deployment.id,
+      })
+      .catch((error) => {
+        console.error("Cancel error:", error);
+      });
+  };
+
+  return (
+    <DialogContainer
+      isOpen={isOpen}
+      onOpenChange={onClose}
+      title="Cancel deployment"
+      subTitle="This will permanently stop the current build. To deploy again, you'll need to trigger a new deployment."
+      footer={
+        <Button
+          variant="destructive"
+          size="xlg"
+          onClick={handleCancel}
+          disabled={cancel.isLoading}
+          loading={cancel.isLoading}
+          className="w-full rounded-lg"
+        >
+          Cancel deployment
+        </Button>
+      }
+    >
+      <DeploymentCard deployment={deployment} isCurrent={false} />
+    </DialogContainer>
+  );
+};

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/components/table/components/actions/components/deployment-card.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/components/table/components/actions/components/deployment-card.tsx
@@ -1,4 +1,3 @@
-import { StatusIndicator } from "@/app/(app)/[workspaceSlug]/projects/[projectId]/components/status-indicator";
 import type { Deployment } from "@/lib/collections";
 import { shortenId } from "@/lib/shorten-id";
 import { CodeBranch, CodeCommit } from "@unkey/icons";
@@ -7,29 +6,23 @@ import { Badge } from "@unkey/ui";
 type DeploymentCardProps = {
   deployment: Deployment;
   isCurrent: boolean;
-  showSignal?: boolean;
 };
 
-export const DeploymentCard = ({ deployment, isCurrent, showSignal }: DeploymentCardProps) => (
+export const DeploymentCard = ({ deployment, isCurrent }: DeploymentCardProps) => (
   <div className="bg-white dark:bg-black border border-grayA-4 rounded-[14px] p-4 relative">
     <div className="flex items-center justify-between">
-      <div className="flex items-center gap-3">
-        <StatusIndicator withSignal={showSignal} />
-        <div>
-          <div className="flex items-center gap-2">
-            <span className="text-xs text-accent-12 font-mono">
-              {`${deployment.id.slice(0, 3)}...${deployment.id.slice(-4)}`}
-            </span>
-            <Badge
-              variant={isCurrent ? "success" : "primary"}
-              className={`px-1.5 capitalize ${isCurrent ? "text-successA-11" : "text-grayA-11"}`}
-            >
-              {isCurrent ? "Current" : deployment.status}
-            </Badge>
-          </div>
-          <div className="text-xs text-grayA-9">
-            {deployment.gitCommitMessage || `${isCurrent ? "Current active" : "Target"} deployment`}
-          </div>
+      <div>
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-accent-12 font-semibold font-mono">{deployment.id}</span>
+          <Badge
+            variant={isCurrent ? "success" : "primary"}
+            className={`px-1.5 capitalize ${isCurrent ? "text-successA-11" : "text-grayA-11"}`}
+          >
+            {isCurrent ? "Current" : deployment.status}
+          </Badge>
+        </div>
+        <div className="text-xs text-grayA-9">
+          {deployment.gitCommitMessage || `${isCurrent ? "Current active" : "Target"} deployment`}
         </div>
       </div>
       <div className="flex gap-1.5">
@@ -37,10 +30,12 @@ export const DeploymentCard = ({ deployment, isCurrent, showSignal }: Deployment
           <CodeBranch iconSize="sm-regular" className="shrink-0 text-gray-12" />
           <span className="truncate">{deployment.gitBranch}</span>
         </div>
-        <div className="flex items-center gap-1.5 px-2 py-1 bg-gray-3 rounded-md text-xs text-grayA-11">
-          <CodeCommit iconSize="sm-regular" className="shrink-0 text-gray-12" />
-          <span>{shortenId(deployment.gitCommitSha ?? "")}</span>
-        </div>
+        {deployment.gitCommitSha && (
+          <div className="flex items-center gap-1.5 px-2 py-1 bg-gray-3 rounded-md text-xs text-grayA-11">
+            <CodeCommit iconSize="sm-regular" className="shrink-0 text-gray-12" />
+            <span>{shortenId(deployment.gitCommitSha)}</span>
+          </div>
+        )}
       </div>
     </div>
   </div>

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/components/table/components/actions/components/deployment-section.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/components/table/components/actions/components/deployment-section.tsx
@@ -1,25 +1,15 @@
 import type { Deployment } from "@/lib/collections";
-import { CircleInfo } from "@unkey/icons";
 import { DeploymentCard } from "./deployment-card";
 
 type DeploymentSectionProps = {
   title: string;
   deployment: Deployment;
   isCurrent: boolean;
-  showSignal?: boolean;
 };
 
-export const DeploymentSection = ({
-  title,
-  deployment,
-  isCurrent,
-  showSignal,
-}: DeploymentSectionProps) => (
+export const DeploymentSection = ({ title, deployment, isCurrent }: DeploymentSectionProps) => (
   <div className="flex flex-col gap-2">
-    <div className="flex items-center gap-2">
-      <h3 className="text-[13px] text-grayA-11">{title}</h3>
-      <CircleInfo iconSize="sm-regular" className="text-gray-9" />
-    </div>
-    <DeploymentCard deployment={deployment} isCurrent={isCurrent} showSignal={showSignal} />
+    <h3 className="text-[13px] text-grayA-11">{title}</h3>
+    <DeploymentCard deployment={deployment} isCurrent={isCurrent} />
   </div>
 );

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/components/table/components/actions/deployment-action-eligibility.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/components/table/components/actions/deployment-action-eligibility.ts
@@ -11,7 +11,29 @@ type DeploymentActionEligibility = {
   canRollback: boolean;
   canPromote: boolean;
   canRedeploy: boolean;
+  canCancel: boolean;
 };
+
+// Non-terminal statuses where a cancel is meaningful: the Restate workflow
+// is still running, so we can abort it. Terminal statuses (ready, failed,
+// skipped, stopped) are rejected by the backend anyway.
+const CANCELLABLE_STATUSES: DeploymentStatus[] = [
+  "pending",
+  "starting",
+  "building",
+  "deploying",
+  "network",
+  "finalizing",
+  "awaiting_approval",
+];
+
+// isCancellableDeploymentStatus reports whether a deployment is still in
+// flight and can therefore be cancelled. Exported so UI elements outside
+// the table action popover (e.g. the header button on the deployment
+// detail page) can share the same rule.
+export function isCancellableDeploymentStatus(status: DeploymentStatus): boolean {
+  return CANCELLABLE_STATUSES.includes(status);
+}
 
 export function getDeploymentActionEligibility(
   ctx: DeploymentActionContext,
@@ -26,8 +48,15 @@ export function getDeploymentActionEligibility(
   const canRollback = isProduction && isActionable && hasCurrent && !isCurrent;
   // Promote: same as rollback, but also allowed on the current deployment when rolled back.
   const canPromote = isProduction && isActionable && hasCurrent && (!isCurrent || ctx.isRolledBack);
-  // Redeploy: available for ready, idle, or failed deployments regardless of environment
-  const canRedeploy = isActionable || status === "stopped" || status === "failed";
+  // Redeploy: available for ready, idle, failed, or superseded deployments
+  const canRedeploy =
+    isActionable ||
+    status === "stopped" ||
+    status === "failed" ||
+    status === "superseded" ||
+    status === "cancelled";
+  // Cancel: available for any in-flight deployment.
+  const canCancel = isCancellableDeploymentStatus(status);
 
-  return { canRollback, canPromote, canRedeploy };
+  return { canRollback, canPromote, canRedeploy, canCancel };
 }

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/components/table/components/actions/deployment-list-table-action.popover.constants.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/components/table/components/actions/deployment-list-table-action.popover.constants.tsx
@@ -3,9 +3,10 @@ import { useProjectData } from "@/app/(app)/[workspaceSlug]/projects/[projectId]
 import { type MenuItem, TableActionPopover } from "@/components/logs/table-action.popover";
 import { useWorkspaceNavigation } from "@/hooks/use-workspace-navigation";
 import type { Deployment, Environment } from "@/lib/collections";
-import { ArrowDottedRotateAnticlockwise, ChevronUp, Hammer2, Layers3 } from "@unkey/icons";
+import { ArrowDottedRotateAnticlockwise, Ban, ChevronUp, Hammer2, Layers3 } from "@unkey/icons";
 import { useRouter } from "next/navigation";
 import { useMemo } from "react";
+import { CancelDialog } from "./cancel-dialog";
 import { getDeploymentActionEligibility } from "./deployment-action-eligibility";
 import { PromotionDialog } from "./promotion-dialog";
 import { RedeployDialog } from "./redeploy-dialog";
@@ -31,7 +32,7 @@ export const DeploymentListTableActions = ({
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: its okay
   const menuItems = useMemo((): MenuItem[] => {
-    const { canRollback, canPromote, canRedeploy } = getDeploymentActionEligibility({
+    const { canRollback, canPromote, canRedeploy, canCancel } = getDeploymentActionEligibility({
       selectedDeployment,
       currentDeploymentId,
       isRolledBack,
@@ -77,6 +78,13 @@ export const DeploymentListTableActions = ({
         ActionComponent: (props) => (
           <RedeployDialog {...props} selectedDeployment={selectedDeployment} />
         ),
+      },
+      {
+        id: "cancel",
+        label: "Cancel deployment",
+        icon: <Ban iconSize="md-regular" />,
+        disabled: !canCancel,
+        ActionComponent: (props) => <CancelDialog {...props} deployment={selectedDeployment} />,
       },
       {
         id: "sentinel-logs",

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/components/table/components/actions/promotion-dialog.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/components/table/components/actions/promotion-dialog.tsx
@@ -89,7 +89,6 @@ export const PromotionDialog = ({
           title="Current Deployment"
           deployment={currentDeployment}
           isCurrent={true}
-          showSignal={true}
         />
         <DomainsSection domains={domains.data} />
         <DeploymentSection

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/components/table/components/actions/rollback-dialog.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/components/table/components/actions/rollback-dialog.tsx
@@ -91,7 +91,6 @@ export const RollbackDialog = ({
           title="Current Deployment"
           deployment={currentDeployment}
           isCurrent={true}
-          showSignal={true}
         />
         <DomainsSection domains={domains.data} />
         <DeploymentSection

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/navigations/project-navigation.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/navigations/project-navigation.tsx
@@ -201,12 +201,7 @@ export const ProjectNavigation = ({
     return (
       <Navbar>
         <Navbar.Breadcrumbs icon={<Cube />}>
-          <Navbar.Breadcrumbs.Link
-            href={basePath}
-            noop={false}
-            active={false}
-            isLast={false}
-          >
+          <Navbar.Breadcrumbs.Link href={basePath} noop={false} active={false} isLast={false}>
             Projects
           </Navbar.Breadcrumbs.Link>
         </Navbar.Breadcrumbs>

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/components/section.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/components/section.tsx
@@ -1,10 +1,24 @@
 import type { ReactNode } from "react";
 
-export function SectionHeader({ icon, title }: { icon: ReactNode; title: string }) {
+export function SectionHeader({
+  icon,
+  title,
+  rightAction,
+}: {
+  icon: ReactNode;
+  title: string;
+  // Optional slot rendered right-aligned in the header, used for
+  // per-section actions (e.g. "Cancel deployment" on the deployment
+  // detail page while a build is in flight).
+  rightAction?: ReactNode;
+}) {
   return (
-    <div className="flex items-center gap-2.5 mb-4 px-2">
-      {icon}
-      <div className="text-accent-12 font-medium text-[13px] leading-4">{title}</div>
+    <div className="flex items-center justify-between gap-2.5 mb-4 px-2">
+      <div className="flex items-center gap-2.5 min-w-0">
+        {icon}
+        <div className="text-accent-12 font-medium text-[13px] leading-4">{title}</div>
+      </div>
+      {rightAction}
     </div>
   );
 }

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/ratelimits/[namespaceId]/logs/components/table/logs-table.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/ratelimits/[namespaceId]/logs/components/table/logs-table.tsx
@@ -281,6 +281,4 @@ function msToSeconds(ms: number) {
   return `${seconds}s`;
 }
 
-const EnrichmentSkeleton = () => (
-  <div className="h-4 w-16 bg-accent-3 rounded-sm animate-pulse" />
-);
+const EnrichmentSkeleton = () => <div className="h-4 w-16 bg-accent-3 rounded-sm animate-pulse" />;

--- a/web/apps/dashboard/components/navigation/navbar.tsx
+++ b/web/apps/dashboard/components/navigation/navbar.tsx
@@ -62,13 +62,7 @@ const BreadcrumbsLink = React.forwardRef<HTMLAnchorElement, LinkProps>(
   ({ children, href, className, active, isLast, noop, ...props }, ref) => (
     <li className="flex items-center gap-3">
       {noop ? (
-        <span
-          className={cn(
-            "text-sm",
-            active ? "text-accent-12" : "text-accent-10",
-            className,
-          )}
-        >
+        <span className={cn("text-sm", active ? "text-accent-12" : "text-accent-10", className)}>
           {children}
         </span>
       ) : (

--- a/web/apps/dashboard/lib/trpc/routers/deploy/deployment/cancel.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/deployment/cancel.ts
@@ -1,0 +1,87 @@
+import { DeployService } from "@/gen/proto/ctrl/v1/deployment_pb";
+import { insertAuditLogs } from "@/lib/audit";
+import { createCtrlClient } from "@/lib/ctrl-client";
+import { db } from "@/lib/db";
+import { ratelimit, withRatelimit, workspaceProcedure } from "@/lib/trpc/trpc";
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+
+// Deployments in these statuses are terminal — cancelling them is a no-op
+// at the backend, so we reject from the UI upfront to avoid noise in the
+// audit log.
+const TERMINAL_STATUSES = new Set(["ready", "failed", "skipped", "stopped"]);
+
+export const cancelDeployment = workspaceProcedure
+  .use(withRatelimit(ratelimit.update))
+  .input(
+    z.object({
+      deploymentId: z.string().min(1, "Deployment ID is required"),
+    }),
+  )
+  .mutation(async ({ input, ctx }) => {
+    const deployment = await db.query.deployments.findFirst({
+      where: (table, { eq, and }) =>
+        and(eq(table.id, input.deploymentId), eq(table.workspaceId, ctx.workspace.id)),
+      columns: {
+        id: true,
+        status: true,
+        projectId: true,
+      },
+      with: {
+        project: {
+          columns: {
+            name: true,
+          },
+        },
+      },
+    });
+
+    if (!deployment) {
+      throw new TRPCError({
+        code: "NOT_FOUND",
+        message: "Deployment not found or access denied",
+      });
+    }
+
+    if (TERMINAL_STATUSES.has(deployment.status)) {
+      throw new TRPCError({
+        code: "PRECONDITION_FAILED",
+        message: `Deployment is already ${deployment.status}`,
+      });
+    }
+
+    const ctrl = createCtrlClient(DeployService);
+
+    try {
+      await ctrl.cancelDeployment({
+        deploymentId: input.deploymentId,
+      });
+
+      await insertAuditLogs(db, {
+        workspaceId: ctx.workspace.id,
+        actor: { type: "user", id: ctx.user.id },
+        event: "deployment.cancel",
+        description: `Cancelled deployment ${input.deploymentId} for ${deployment.project.name}`,
+        resources: [
+          {
+            type: "deployment",
+            id: deployment.id,
+            name: deployment.project.name,
+          },
+        ],
+        context: ctx.audit,
+      });
+
+      return {};
+    } catch (error) {
+      if (error instanceof TRPCError) {
+        throw error;
+      }
+
+      console.error("Cancel deployment request failed:", error);
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: "Failed to cancel deployment",
+      });
+    }
+  });

--- a/web/apps/dashboard/lib/trpc/routers/index.ts
+++ b/web/apps/dashboard/lib/trpc/routers/index.ts
@@ -42,6 +42,7 @@ import { listCustomDomains } from "./deploy/custom-domains/list";
 import { retryVerification } from "./deploy/custom-domains/retry";
 import { authorizeDeployment } from "./deploy/deployment/authorize";
 import { getDeploymentBuildSteps } from "./deploy/deployment/build-steps";
+import { cancelDeployment } from "./deploy/deployment/cancel";
 import { createDeploy } from "./deploy/deployment/create-deploy";
 import { getDeploymentSteps } from "./deploy/deployment/deployment-steps";
 import { getById as getDeploymentById } from "./deploy/deployment/getById";
@@ -492,6 +493,7 @@ export const router = t.router({
       redeploy,
       create: createDeploy,
       authorize: authorizeDeployment,
+      cancel: cancelDeployment,
     }),
     sentinelLogs: t.router({
       query: querySentinelLogs,

--- a/web/internal/schema/src/auditlog.ts
+++ b/web/internal/schema/src/auditlog.ts
@@ -61,6 +61,7 @@ export const unkeyAuditLogEvents = z.enum([
   "deployment.redeploy",
   "deployment.create",
   "deployment.authorize",
+  "deployment.cancel",
 ]);
 
 export const auditLogSchemaV1 = z.object({


### PR DESCRIPTION
## What does this PR do?

Adds deployment cancellation functionality to the dashboard, allowing users to cancel in-flight deployments and properly handle cancelled/superseded deployment states.

### Key Features:
- **Cancel Button**: Added cancel deployment button to deployment detail pages for in-flight deployments
- **Cancellation Dialog**: New dialog component for confirming deployment cancellation with proper error handling
- **Cancelled Deployment View**: Dedicated UI component (`DeploymentCancelled`) for displaying cancelled and superseded deployments with appropriate messaging
- **Backend Integration**: New tRPC endpoint for cancelling deployments with audit logging and proper status validation
- **Superseded Status**: Added support for "superseded" deployment status handling

### UI Improvements:
- Enhanced section headers to support right-aligned action buttons
- Updated deployment info component with cancel button for eligible deployments
- Improved deployment detail button styling and positioning
- Added proper routing logic to show cancelled/superseded deployments instead of failed deployment banner
- Added cancellation eligibility checks to prevent cancelling terminal deployments

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Start a deployment and verify the cancel button appears in the deployment header
- Click cancel button and confirm the cancellation dialog appears with proper deployment information
- Cancel a deployment and verify it shows the cancelled state with appropriate messaging and redeploy option
- Test that superseded deployments show the superseded view instead of failed banner
- Verify cancelled deployments are properly distinguished from actual failures in the UI
- Test that terminal deployments (ready, failed, etc.) do not show cancel buttons
- Confirm audit logs are created when deployments are cancelled
- Test the cancel action from the deployment table actions popover

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary