### PR TITLE
fix: use UPDATE for existing ratelimits to eliminate deadlocks (ENG-2679)

### DIFF
--- a/svc/api/routes/v2_identities_update_identity/200_test.go
+++ b/svc/api/routes/v2_identities_update_identity/200_test.go
@@ -349,3 +349,119 @@ func TestUpdateIdentityConcurrentRatelimits(t *testing.T) {
 	})
 	require.NoError(t, err)
 }
+
+type testIdentity struct {
+	id         string
+	externalID string
+}
+
+// TestBulkIdentityUpdateDeadlock reproduces a production 5xx spike caused by
+// many identity updates for DIFFERENT identities hitting the API concurrently.
+// INSERT ... ON DUPLICATE KEY UPDATE on the ratelimits table causes gap-lock
+// contention on unique_name_per_identity_idx, leading to MySQL deadlocks (1213).
+//
+// The existing TestUpdateIdentityConcurrentRatelimits only tests concurrent
+// updates to the SAME identity, which the FOR UPDATE lock serializes. This test
+// hits the cross-identity failure mode.
+func TestBulkIdentityUpdateDeadlock(t *testing.T) {
+	t.Parallel()
+
+	h := testutil.NewHarness(t)
+	ctx := context.Background()
+
+	route := &handler.Handler{
+		DB:        h.DB,
+		Keys:      h.Keys,
+		Auditlogs: h.Auditlogs,
+	}
+
+	h.Register(route)
+
+	rootKey := h.CreateRootKey(h.Resources().UserWorkspace.ID, "identity.*.create_identity", "identity.*.update_identity")
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}
+
+	workspaceID := h.Resources().UserWorkspace.ID
+	numIdentities := 50
+	rlNames := []string{"rl_a", "rl_b", "rl_c", "rl_d", "rl_e"}
+
+	// Create many distinct identities, each with several ratelimits already
+	// attached, so the concurrent update phase hits the upsert path.
+	identities := make([]testIdentity, numIdentities)
+	for i := range numIdentities {
+		id := uid.New(uid.IdentityPrefix)
+		externalID := fmt.Sprintf("deadlock_test_%d_%s", i, uid.New("test"))
+		err := db.Query.InsertIdentity(ctx, h.DB.RW(), db.InsertIdentityParams{
+			ID:          id,
+			ExternalID:  externalID,
+			WorkspaceID: workspaceID,
+			Environment: "default",
+			CreatedAt:   time.Now().UnixMilli(),
+			Meta:        []byte("{}"),
+		})
+		require.NoError(t, err)
+
+		seedRL := make([]db.InsertIdentityRatelimitParams, len(rlNames))
+		for j, name := range rlNames {
+			seedRL[j] = db.InsertIdentityRatelimitParams{
+				ID:          uid.New(uid.RatelimitPrefix),
+				WorkspaceID: workspaceID,
+				IdentityID:  sql.NullString{String: id, Valid: true},
+				Name:        name,
+				Limit:       100,
+				Duration:    60000,
+				CreatedAt:   time.Now().UnixMilli(),
+				AutoApply:   true,
+			}
+		}
+		err = db.BulkQuery.InsertIdentityRatelimits(ctx, h.DB.RW(), seedRL)
+		require.NoError(t, err)
+
+		identities[i] = testIdentity{id: id, externalID: externalID}
+	}
+
+	// Warm up the validator cache with one request.
+	warmupRL := make([]openapi.RatelimitRequest, len(rlNames))
+	for j, name := range rlNames {
+		warmupRL[j] = openapi.RatelimitRequest{Name: name, Limit: 999, Duration: 60000, AutoApply: true}
+	}
+	warmup := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{
+		Identity:   identities[0].externalID,
+		Ratelimits: &warmupRL,
+	})
+	require.Equal(t, 200, warmup.Status, "warmup request should succeed")
+
+	// Fire off concurrent updates for ALL identities at once, multiple rounds.
+	// A single round may succeed via retries; repeated rounds exhaust them.
+	for round := range 3 {
+		g := errgroup.Group{}
+		for i, ident := range identities {
+			g.Go(func() error {
+				ratelimits := make([]openapi.RatelimitRequest, len(rlNames))
+				for j, name := range rlNames {
+					ratelimits[j] = openapi.RatelimitRequest{
+						Name:      name,
+						Limit:     int64(100 + round*1000 + i),
+						Duration:  60000,
+						AutoApply: true,
+					}
+				}
+				req := handler.Request{
+					Identity:   ident.externalID,
+					Ratelimits: &ratelimits,
+				}
+				res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, req)
+				if res.Status != 200 {
+					body, _ := json.Marshal(res.Body)
+					return fmt.Errorf("round %d identity %s: unexpected status %d: %s", round, ident.externalID, res.Status, string(body))
+				}
+				return nil
+			})
+		}
+
+		err := g.Wait()
+		require.NoError(t, err, "round %d: all concurrent identity updates should succeed without deadlock", round)
+	}
+}

--- a/svc/api/routes/v2_identities_update_identity/handler.go
+++ b/svc/api/routes/v2_identities_update_identity/handler.go
@@ -258,23 +258,32 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			}
 
 			rateLimitsToInsert := make([]db.InsertIdentityRatelimitParams, 0)
-			// Update existing ratelimits or create new ones
+			// Update existing ratelimits via UPDATE by ID (row locks only), and
+			// INSERT only truly new rows. This avoids gap-lock contention from
+			// INSERT ... ON DUPLICATE KEY UPDATE that deadlocks under concurrent
+			// bulk identity updates.
 			for name, newRL := range newRatelimitMap {
 				existingRL, exists := existingRatelimitMap[name]
 
 				var ratelimitID string
 				if exists {
 					ratelimitID = existingRL.ID
-					rateLimitsToInsert = append(rateLimitsToInsert, db.InsertIdentityRatelimitParams{
-						ID:          existingRL.ID,
-						WorkspaceID: auth.AuthorizedWorkspaceID,
-						IdentityID:  sql.NullString{String: identityRow.ID, Valid: true},
-						Name:        newRL.Name,
-						Limit:       int32(newRL.Limit), // nolint:gosec
-						Duration:    newRL.Duration,
-						AutoApply:   newRL.AutoApply,
-						CreatedAt:   time.Now().UnixMilli(),
+
+					err = db.Query.UpdateRatelimit(ctx, tx, db.UpdateRatelimitParams{
+						ID:        existingRL.ID,
+						Name:      newRL.Name,
+						Limit:     int32(newRL.Limit), // nolint:gosec
+						Duration:  newRL.Duration,
+						AutoApply: newRL.AutoApply,
 					})
+					if err != nil {
+						// nolint:exhaustruct
+						return txResult{}, fault.Wrap(err,
+							fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
+							fault.Internal("database failed to update ratelimit"),
+							fault.Public("Failed to update ratelimit"),
+						)
+					}
 
 					auditLogs = append(auditLogs, auditlog.AuditLog{
 						WorkspaceID: auth.AuthorizedWorkspaceID,


### PR DESCRIPTION
## What does this PR do?

Fixes MySQL deadlock errors occurring during concurrent bulk identity updates by replacing `INSERT ... ON DUPLICATE KEY UPDATE` with separate `UPDATE` and `INSERT` operations for ratelimits.

The deadlock was caused by gap-lock contention on the `unique_name_per_identity_idx` index when multiple identity updates happened simultaneously for different identities. The new approach uses row-level locks via `UPDATE` for existing ratelimits and only performs `INSERT` for truly new records.

Adds a comprehensive test `TestBulkIdentityUpdateDeadlock` that reproduces the production failure scenario by concurrently updating 50 different identities across multiple rounds, simulating the customer usage pattern that triggered the original issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Run the new `TestBulkIdentityUpdateDeadlock` test to verify concurrent bulk updates no longer deadlock
- Run existing `TestUpdateIdentityConcurrentRatelimits` test to ensure single identity concurrent updates still work
- Verify that ratelimit updates and inserts function correctly in both concurrent and sequential scenarios

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary