### PR TITLE
fix: otel prom

### DIFF
--- a/dev/Tiltfile
+++ b/dev/Tiltfile
@@ -170,6 +170,17 @@ k8s_resource('s3', port_forwards=['3902:3902', '3903:3903'], resource_deps=[], l
 k8s_yaml('k8s/manifests/restate.yaml')
 k8s_resource('restate', port_forwards=['8080:8080', '9070:9070'], resource_deps=[], labels=['database'])
 
+# Observability (Prometheus + OTEL Collector w/ Grafana)
+k8s_yaml('k8s/manifests/observability.yaml')
+k8s_resource('prometheus', resource_deps=[], labels=['observability'])
+k8s_resource(
+  'otel-collector',
+  port_forwards=['4000:3000'],
+  resource_deps=[],
+  labels=['observability'],
+  links=['http://localhost:4000'],
+)
+
 # Restate CronJobs (scheduled tasks that call Restate handlers)
 k8s_yaml(helm('k8s/charts/restate-cronjobs'))
 k8s_resource('restate-key-last-used-sync', resource_deps=['restate', 'ctrl-worker'], labels=['unkey'])

--- a/dev/k8s/manifests/api.yaml
+++ b/dev/k8s/manifests/api.yaml
@@ -13,7 +13,6 @@ data:
     http_port = 7070
     redis_url = "redis://redis:6379"
     test_mode = false
-    prometheus_port = 0
     max_request_body_size = 10485760
 
     [database]
@@ -35,6 +34,13 @@ data:
     [control]
     url = "http://ctrl-api:7091"
     token = "your-local-dev-key"
+
+    [observability.tracing]
+    sample_rate = 1.0
+
+    [observability.logging]
+    sample_rate = 1.0
+    slow_threshold = "1s"
 
 ---
 apiVersion: apps/v1
@@ -59,6 +65,9 @@ spec:
           image: unkey/go:latest
           args: ["run", "api", "--config", "/etc/unkey/unkey.toml"]
           imagePullPolicy: Never # Use local images
+          env:
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "http://otel-collector:4318"
           ports:
             - containerPort: 7070
             - containerPort: 7946

--- a/dev/k8s/manifests/observability.yaml
+++ b/dev/k8s/manifests/observability.yaml
@@ -95,6 +95,12 @@ spec:
             - containerPort: 3000 # Grafana
             - containerPort: 4317 # OTLP gRPC
             - containerPort: 4318 # OTLP HTTP
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: 3000
+            initialDelaySeconds: 15
+            periodSeconds: 10
 
 ---
 apiVersion: v1

--- a/pkg/otel/BUILD.bazel
+++ b/pkg/otel/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//pkg/logger",
         "//pkg/otel/tracing",
         "//pkg/version",
+        "@com_github_prometheus_client_golang//prometheus",
         "@com_github_shirou_gopsutil_v4//cpu",
         "@com_github_shirou_gopsutil_v4//mem",
         "@io_opentelemetry_go_contrib_bridges_otelslog//:otelslog",

--- a/pkg/otel/grafana.go
+++ b/pkg/otel/grafana.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	promclient "github.com/prometheus/client_golang/prometheus"
 	"github.com/shirou/gopsutil/v4/cpu"
 	"github.com/shirou/gopsutil/v4/mem"
 	"github.com/unkeyed/unkey/pkg/logger"
@@ -53,6 +54,12 @@ type Config struct {
 	//
 	// As long as the sampling rate is greater than 0.0, all errors will be sampled.
 	TraceSampleRate float64
+
+	// PrometheusGatherer is the prometheus registry to gather metrics from when
+	// bridging prometheus metrics into OTLP. If nil, the default prometheus
+	// registry is used (which is almost certainly wrong when lazy metrics register
+	// to a custom registry).
+	PrometheusGatherer promclient.Gatherer
 }
 
 // InitGrafana initializes the global tracer and metric providers for OpenTelemetry,
@@ -177,7 +184,11 @@ func InitGrafana(ctx context.Context, config Config) (func(ctx context.Context) 
 		return nil, fmt.Errorf("failed to create metric exporter: %w", err)
 	}
 
-	bridge := prometheus.NewMetricProducer()
+	var bridgeOpts []prometheus.Option
+	if config.PrometheusGatherer != nil {
+		bridgeOpts = append(bridgeOpts, prometheus.WithGatherer(config.PrometheusGatherer))
+	}
+	bridge := prometheus.NewMetricProducer(bridgeOpts...)
 
 	reader := metricsdk.NewPeriodicReader(metricExporter, metricsdk.WithProducer(bridge), metricsdk.WithInterval(60*time.Second))
 

--- a/svc/api/run.go
+++ b/svc/api/run.go
@@ -75,15 +75,22 @@ func Run(ctx context.Context, cfg Config) error {
 
 	clk := clock.New()
 
+	reg := promclient.NewRegistry()
+	reg.MustRegister(collectors.NewGoCollector())
+	//nolint:exhaustruct
+	reg.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
+	lazy.SetRegistry(reg)
+
 	// This is a little ugly, but the best we can do to resolve the circular dependency until we rework the logger.
 	var shutdownGrafana func(context.Context) error
 	if cfg.Observability.Tracing != nil {
 		shutdownGrafana, err = otel.InitGrafana(ctx, otel.Config{
-			Application:     "api",
-			Version:         version.Version,
-			InstanceID:      cfg.InstanceID,
-			CloudRegion:     cfg.Region,
-			TraceSampleRate: cfg.Observability.Tracing.SampleRate,
+			Application:        "api",
+			Version:            version.Version,
+			InstanceID:         cfg.InstanceID,
+			CloudRegion:        cfg.Region,
+			TraceSampleRate:    cfg.Observability.Tracing.SampleRate,
+			PrometheusGatherer: reg,
 		})
 		if err != nil {
 			return fmt.Errorf("unable to init grafana: %w", err)
@@ -94,12 +101,6 @@ func Run(ctx context.Context, cfg Config) error {
 	defer r.Recover()
 
 	r.DeferCtx(shutdownGrafana)
-
-	reg := promclient.NewRegistry()
-	reg.MustRegister(collectors.NewGoCollector())
-	//nolint:exhaustruct
-	reg.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
-	lazy.SetRegistry(reg)
 
 	database, err := db.New(db.Config{
 		PrimaryDSN:  cfg.Database.Primary,

--- a/svc/ctrl/api/run.go
+++ b/svc/ctrl/api/run.go
@@ -64,11 +64,12 @@ func Run(ctx context.Context, cfg Config) error {
 	var shutdownGrafana func(context.Context) error
 	if cfg.Observability.Tracing != nil {
 		shutdownGrafana, err = otel.InitGrafana(ctx, otel.Config{
-			Application:     "ctrl",
-			Version:         pkgversion.Version,
-			InstanceID:      cfg.InstanceID,
-			CloudRegion:     cfg.Region,
-			TraceSampleRate: cfg.Observability.Tracing.SampleRate,
+			Application:        "ctrl",
+			Version:            pkgversion.Version,
+			InstanceID:         cfg.InstanceID,
+			CloudRegion:        cfg.Region,
+			TraceSampleRate:    cfg.Observability.Tracing.SampleRate,
+			PrometheusGatherer: nil,
 		})
 		if err != nil {
 			return fmt.Errorf("unable to init grafana: %w", err)

--- a/svc/ctrl/worker/run.go
+++ b/svc/ctrl/worker/run.go
@@ -86,11 +86,12 @@ func Run(ctx context.Context, cfg Config) error {
 	var err error
 	if cfg.Observability.Tracing != nil {
 		shutdownGrafana, err = otel.InitGrafana(ctx, otel.Config{
-			Application:     "worker",
-			Version:         version.Version,
-			InstanceID:      cfg.InstanceID,
-			CloudRegion:     cfg.Region,
-			TraceSampleRate: cfg.Observability.Tracing.SampleRate,
+			Application:        "worker",
+			Version:            version.Version,
+			InstanceID:         cfg.InstanceID,
+			CloudRegion:        cfg.Region,
+			TraceSampleRate:    cfg.Observability.Tracing.SampleRate,
+			PrometheusGatherer: nil,
 		})
 		if err != nil {
 			return fmt.Errorf("unable to init grafana: %w", err)

--- a/svc/frontline/run.go
+++ b/svc/frontline/run.go
@@ -64,11 +64,12 @@ func Run(ctx context.Context, cfg Config) error {
 	var shutdownGrafana func(context.Context) error
 	if cfg.Observability.Tracing != nil {
 		shutdownGrafana, err = otel.InitGrafana(ctx, otel.Config{
-			Application:     "frontline",
-			Version:         version.Version,
-			InstanceID:      cfg.InstanceID,
-			CloudRegion:     cfg.Region,
-			TraceSampleRate: cfg.Observability.Tracing.SampleRate,
+			Application:        "frontline",
+			Version:            version.Version,
+			InstanceID:         cfg.InstanceID,
+			CloudRegion:        cfg.Region,
+			TraceSampleRate:    cfg.Observability.Tracing.SampleRate,
+			PrometheusGatherer: nil,
 		})
 		if err != nil {
 			return fmt.Errorf("unable to init grafana: %w", err)

--- a/svc/krane/run.go
+++ b/svc/krane/run.go
@@ -57,11 +57,12 @@ func Run(ctx context.Context, cfg Config) error {
 	var shutdownGrafana func(context.Context) error
 	if cfg.Observability.Tracing != nil {
 		shutdownGrafana, err = otel.InitGrafana(ctx, otel.Config{
-			Application:     "krane",
-			Version:         pkgversion.Version,
-			InstanceID:      cfg.InstanceID,
-			CloudRegion:     cfg.Region,
-			TraceSampleRate: cfg.Observability.Tracing.SampleRate,
+			Application:        "krane",
+			Version:            pkgversion.Version,
+			InstanceID:         cfg.InstanceID,
+			CloudRegion:        cfg.Region,
+			TraceSampleRate:    cfg.Observability.Tracing.SampleRate,
+			PrometheusGatherer: nil,
 		})
 		if err != nil {
 			return fmt.Errorf("unable to init grafana: %w", err)

--- a/svc/sentinel/run.go
+++ b/svc/sentinel/run.go
@@ -59,11 +59,12 @@ func Run(ctx context.Context, cfg Config) error {
 	var shutdownGrafana func(context.Context) error
 	if cfg.Observability.Tracing != nil {
 		shutdownGrafana, err = otel.InitGrafana(ctx, otel.Config{
-			Application:     "sentinel",
-			Version:         version.Version,
-			InstanceID:      cfg.SentinelID,
-			CloudRegion:     cfg.Region,
-			TraceSampleRate: cfg.Observability.Tracing.SampleRate,
+			Application:        "sentinel",
+			Version:            version.Version,
+			InstanceID:         cfg.SentinelID,
+			CloudRegion:        cfg.Region,
+			TraceSampleRate:    cfg.Observability.Tracing.SampleRate,
+			PrometheusGatherer: nil,
 		})
 		if err != nil {
 			return fmt.Errorf("unable to init grafana: %w", err)

--- a/svc/vault/run.go
+++ b/svc/vault/run.go
@@ -38,11 +38,12 @@ func Run(ctx context.Context, cfg Config) error {
 	var shutdownGrafana func(context.Context) error
 	if cfg.Observability.Tracing != nil {
 		shutdownGrafana, err = otel.InitGrafana(ctx, otel.Config{
-			Application:     "vault",
-			Version:         version.Version,
-			InstanceID:      cfg.InstanceID,
-			CloudRegion:     cfg.Region,
-			TraceSampleRate: cfg.Observability.Tracing.SampleRate,
+			Application:        "vault",
+			Version:            version.Version,
+			InstanceID:         cfg.InstanceID,
+			CloudRegion:        cfg.Region,
+			TraceSampleRate:    cfg.Observability.Tracing.SampleRate,
+			PrometheusGatherer: nil,
 		})
 		if err != nil {
 			return fmt.Errorf("unable to init grafana: %w", err)


### PR DESCRIPTION
## What does this PR do?

Adds configurable Prometheus registry support to OpenTelemetry metrics bridging. The `PrometheusGatherer` field is added to the OTEL configuration to allow specifying a custom Prometheus registry instead of using the default global registry. This ensures that lazy metrics registered to custom registries are properly bridged to OTLP.

The Prometheus registry initialization is moved before the Grafana OTEL initialization across all services (api, ctrl, frontline, krane, sentinel, vault) to ensure the custom registry is available when configuring the metrics bridge.

Fixes # (issue)

## Type of change

- [x] Enhancement (small improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Verify that Prometheus metrics are properly exported to OTLP endpoints
- Test that custom registry metrics appear in observability dashboards
- Confirm that lazy metrics registered to the custom registry are bridged correctly

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary