### PR TITLE
fix: tentants should be member and org needs org checks

### DIFF
--- a/web/apps/dashboard/lib/trpc/trpc.ts
+++ b/web/apps/dashboard/lib/trpc/trpc.ts
@@ -198,7 +198,10 @@ const requireUser = t.middleware(({ next, ctx }) => {
   return next({
     ctx: {
       user: ctx.user,
-      tenant: ctx.tenant ?? { id: ctx.user.id, role: "owner" },
+      // Default to "member" role when tenant context is missing to prevent
+      // unintended privilege escalation. Previously defaulted to "owner" which
+      // could grant admin-level access to users without a proper org assignment.
+      tenant: ctx.tenant ?? { id: ctx.user.id, role: "member" },
     },
   });
 });
@@ -273,6 +276,17 @@ export const requireOrgAdmin = t.middleware(async ({ next, ctx, rawInput }) => {
       message: "Organization ID is required",
     });
   }
+
+  // Verify the requested orgId matches the caller's tenant to prevent
+  // cross-organization privilege escalation. Without this check, an admin
+  // in Org A could pass Org B's ID and the role check alone would pass.
+  if (orgId !== ctx.tenant?.id) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "You do not have access to this organization.",
+    });
+  }
+
   try {
     const isAdmin = ctx.tenant?.role === "admin";
 

--- a/web/apps/dashboard/lib/trpc/trpc.ts
+++ b/web/apps/dashboard/lib/trpc/trpc.ts
@@ -198,9 +198,6 @@ const requireUser = t.middleware(({ next, ctx }) => {
   return next({
     ctx: {
       user: ctx.user,
-      // Default to "member" role when tenant context is missing to prevent
-      // unintended privilege escalation. Previously defaulted to "owner" which
-      // could grant admin-level access to users without a proper org assignment.
       tenant: ctx.tenant ?? { id: ctx.user.id, role: "member" },
     },
   });


### PR DESCRIPTION
## What does this PR do?

This makes the fallback on tenants go to member and also check if the admin actually belongs to the org.

Fixes # (issue)

_If there is not an issue for this, please create one first. This is used to tracking purposes and also helps us understand why this PR exists_

<!-- If there isn't an issue for this PR, please re-review our Contributing Guide and create an issue -->

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Test A
- Test B

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [X] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [X] Ran `pnpm build`
- [X] Ran `pnpm fmt`
- [X] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary
