### PR TITLE
refactor: allow changing repo without disconnect

### DIFF
--- a/svc/krane/internal/cilium/resync.go
+++ b/svc/krane/internal/cilium/resync.go
@@ -6,10 +6,10 @@ import (
 
 	"connectrpc.com/connect"
 	ctrlv1 "github.com/unkeyed/unkey/gen/proto/ctrl/v1"
+	"github.com/unkeyed/unkey/pkg/conc"
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/pkg/repeat"
 	"github.com/unkeyed/unkey/svc/krane/pkg/labels"
-	"github.com/unkeyed/unkey/pkg/conc"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 

--- a/svc/krane/internal/deployment/pod_watch.go
+++ b/svc/krane/internal/deployment/pod_watch.go
@@ -5,9 +5,9 @@ import (
 	"math/rand/v2"
 	"time"
 
+	"github.com/unkeyed/unkey/pkg/conc"
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/svc/krane/pkg/labels"
-	"github.com/unkeyed/unkey/pkg/conc"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"

--- a/svc/krane/internal/deployment/resync.go
+++ b/svc/krane/internal/deployment/resync.go
@@ -6,10 +6,10 @@ import (
 
 	"connectrpc.com/connect"
 	ctrlv1 "github.com/unkeyed/unkey/gen/proto/ctrl/v1"
+	"github.com/unkeyed/unkey/pkg/conc"
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/pkg/repeat"
 	"github.com/unkeyed/unkey/svc/krane/pkg/labels"
-	"github.com/unkeyed/unkey/pkg/conc"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/svc/krane/internal/sentinel/actual_state_report.go
+++ b/svc/krane/internal/sentinel/actual_state_report.go
@@ -4,9 +4,9 @@ import (
 	"context"
 
 	ctrlv1 "github.com/unkeyed/unkey/gen/proto/ctrl/v1"
+	"github.com/unkeyed/unkey/pkg/conc"
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/svc/krane/pkg/labels"
-	"github.com/unkeyed/unkey/pkg/conc"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"

--- a/svc/krane/internal/sentinel/resync.go
+++ b/svc/krane/internal/sentinel/resync.go
@@ -6,10 +6,10 @@ import (
 
 	"connectrpc.com/connect"
 	ctrlv1 "github.com/unkeyed/unkey/gen/proto/ctrl/v1"
+	"github.com/unkeyed/unkey/pkg/conc"
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/pkg/repeat"
 	"github.com/unkeyed/unkey/svc/krane/pkg/labels"
-	"github.com/unkeyed/unkey/pkg/conc"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/(deployment-progress)/deployment-progress.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/(deployment-progress)/deployment-progress.tsx
@@ -189,9 +189,6 @@ export function DeploymentProgress({ stepsData }: { stepsData?: StepsData }) {
               </div>
             ) : null
           }
-          defaultExpanded={
-            Boolean(deploying && !deploying.endedAt) || deployingStep.status === "error"
-          }
         />
         <DeploymentStep
           icon={<Earth iconSize="sm-medium" className="size-[18px]" />}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/build-settings/github-settings/github-connected.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/build-settings/github-settings/github-connected.tsx
@@ -1,14 +1,17 @@
+import { Combobox } from "@/components/ui/combobox";
 import { trpc } from "@/lib/trpc/client";
-import { Button, InfoTooltip, toast } from "@unkey/ui";
-import { SelectedConfig } from "../../shared/selected-config";
-import { GitHubSettingCard, ManageGitHubAppLink, RepoNameLabel } from "./shared";
+import { toast } from "@unkey/ui";
+import { useMemo } from "react";
+import { ComboboxSkeleton, GitHubSettingCard, ManageGitHubAppLink, RepoNameLabel } from "./shared";
 
 export const GitHubConnected = ({
+  projectId,
   appId,
   installUrl,
   repoFullName,
   onBeforeNavigate,
 }: {
+  projectId: string;
   appId: string;
   installUrl: string;
   repoFullName: string;
@@ -16,9 +19,30 @@ export const GitHubConnected = ({
 }) => {
   const utils = trpc.useUtils();
 
-  const disconnectRepoMutation = trpc.github.disconnectRepo.useMutation({
+  const { data: reposData, isLoading: isLoadingRepos } = trpc.github.listRepositories.useQuery(
+    { projectId },
+    { refetchOnWindowFocus: false },
+  );
+
+  const repoOptions = useMemo(
+    () =>
+      (reposData?.repositories ?? []).map((repo) => ({
+        value: `${repo.installationId}:${repo.id}`,
+        label: <RepoNameLabel fullName={repo.fullName} />,
+        searchValue: repo.fullName,
+        selectedLabel: <RepoNameLabel fullName={repo.fullName} />,
+      })),
+    [reposData?.repositories],
+  );
+
+  const selectedValue = useMemo(() => {
+    const match = reposData?.repositories.find((r) => r.fullName === repoFullName);
+    return match ? `${match.installationId}:${match.id}` : "";
+  }, [reposData?.repositories, repoFullName]);
+
+  const selectRepoMutation = trpc.github.selectRepository.useMutation({
     onSuccess: async () => {
-      toast.success("Repository disconnected");
+      toast.success("Repository connected");
       await utils.github.getInstallations.invalidate();
       await utils.github.getRepoTree.invalidate();
     },
@@ -27,17 +51,19 @@ export const GitHubConnected = ({
     },
   });
 
-  const collapsed = (
-    <InfoTooltip
-      content="Connected repository. Expand to disconnect or manage settings."
-      variant="inverted"
-      position={{
-        side: "top",
-      }}
-    >
-      <SelectedConfig label={<RepoNameLabel fullName={repoFullName} />} />
-    </InfoTooltip>
-  );
+  const handleSelectRepository = (value: string) => {
+    const repo = reposData?.repositories.find((r) => `${r.installationId}:${r.id}` === value);
+    if (!repo) {
+      return;
+    }
+    selectRepoMutation.mutate({
+      projectId,
+      appId,
+      repositoryId: repo.id,
+      repositoryFullName: repo.fullName,
+      installationId: repo.installationId,
+    });
+  };
 
   const expandable = (
     <div className="px-6 py-4 flex flex-col gap-3 bg-grayA-2 rounded-b-xl">
@@ -45,20 +71,9 @@ export const GitHubConnected = ({
         Pushes to this repository will trigger deployments.
       </span>
       <div className="flex items-center gap-5 pt-1">
-        <div onClick={(e) => e.stopPropagation()} onKeyDown={(e) => e.stopPropagation()}>
-          <Button
-            className="px-3 rounded-lg"
-            variant="primary"
-            color="danger"
-            onClick={() => disconnectRepoMutation.mutate({ appId })}
-            loading={disconnectRepoMutation.isLoading}
-          >
-            Disconnect
-          </Button>
-        </div>
         <ManageGitHubAppLink
           installUrl={installUrl}
-          variant="outline"
+          variant="primary"
           text={<span>Manage GitHub</span>}
           onBeforeNavigate={onBeforeNavigate}
         />
@@ -68,7 +83,21 @@ export const GitHubConnected = ({
 
   return (
     <GitHubSettingCard expandable={expandable} chevronState="interactive">
-      {collapsed}
+      <div onClick={(e) => e.stopPropagation()} onKeyDown={(e) => e.stopPropagation()}>
+        {isLoadingRepos ? (
+          <ComboboxSkeleton />
+        ) : (
+          <Combobox
+            className="w-[200px] text-left h-7 border-grayA-4"
+            options={repoOptions}
+            value={selectedValue}
+            onSelect={handleSelectRepository}
+            placeholder={<span className="text-left w-full">Select a repository...</span>}
+            searchPlaceholder="Filter repositories..."
+            disabled={selectRepoMutation.isLoading}
+          />
+        )}
+      </div>
     </GitHubSettingCard>
   );
 };

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/build-settings/github-settings/github-no-repo.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/build-settings/github-settings/github-no-repo.tsx
@@ -70,7 +70,7 @@ export const GitHubNoRepo = ({
         <ComboboxSkeleton />
       ) : repoOptions.length ? (
         <Combobox
-          className="w-[200px] text-left min-h-8 border-grayA-4"
+          className="w-[200px] text-left h-7 border-grayA-4"
           options={repoOptions}
           value={selectedRepo}
           onSelect={handleSelectRepository}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/build-settings/github-settings/index.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/build-settings/github-settings/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { trpc } from "@/lib/trpc/client";
+import { match } from "@unkey/match";
 import { useProjectData } from "../../../../data-provider";
 import { SelectedConfig } from "../../shared/selected-config";
 import { GitHubConnected } from "./github-connected";
@@ -55,50 +56,47 @@ export const GitHub = ({ readOnly = false, onBeforeNavigate }: GitHubProps) => {
     return { status: "no-repo", appId, installUrl };
   })();
 
-  switch (connectionState.status) {
-    case "loading":
-      return (
-        <GitHubSettingCard chevronState="disabled">
-          <ComboboxSkeleton />
-        </GitHubSettingCard>
-      );
-    // No-app means user haven't connected an app to unkey yet
-    case "no-app":
-      return (
-        <GitHubSettingCard chevronState="disabled">
-          <ManageGitHubAppLink
-            installUrl={connectionState.installUrl}
-            variant="outline"
-            className="px-2.5 py-3 text-gray-12 font-medium text-[13px] bg-grayA-2 shadow-md hover:bg-grayA-3"
-            onBeforeNavigate={onBeforeNavigate}
-          />
-        </GitHubSettingCard>
-      );
-    // User connected to unkey, but haven't selected a repo yet
-    case "no-repo":
-      return (
-        <GitHubNoRepo
-          projectId={projectId}
-          appId={connectionState.appId}
-          installUrl={connectionState.installUrl}
+  return match(connectionState)
+    .with({ status: "loading" }, () => (
+      <GitHubSettingCard chevronState="disabled">
+        <ComboboxSkeleton />
+      </GitHubSettingCard>
+    ))
+    .with({ status: "no-app" }, ({ installUrl: url }) => (
+      <GitHubSettingCard chevronState="disabled">
+        <ManageGitHubAppLink
+          installUrl={url}
+          variant="outline"
+          className="px-2.5 py-3 text-gray-12 font-medium text-[13px] hover:bg-grayA-2"
           onBeforeNavigate={onBeforeNavigate}
         />
-      );
-    case "connected":
+      </GitHubSettingCard>
+    ))
+    .with({ status: "no-repo" }, ({ appId, installUrl: url }) => (
+      <GitHubNoRepo
+        projectId={projectId}
+        appId={appId}
+        installUrl={url}
+        onBeforeNavigate={onBeforeNavigate}
+      />
+    ))
+    .with({ status: "connected" }, ({ appId, repoFullName, installUrl: url }) => {
       if (readOnly) {
         return (
           <GitHubSettingCard chevronState="disabled">
-            <SelectedConfig label={<RepoNameLabel fullName={connectionState.repoFullName} />} />
+            <SelectedConfig label={<RepoNameLabel fullName={repoFullName} />} />
           </GitHubSettingCard>
         );
       }
       return (
         <GitHubConnected
-          appId={connectionState.appId}
-          installUrl={connectionState.installUrl}
-          repoFullName={connectionState.repoFullName}
+          projectId={projectId}
+          appId={appId}
+          installUrl={url}
+          repoFullName={repoFullName}
           onBeforeNavigate={onBeforeNavigate}
         />
       );
-  }
+    })
+    .exhaustive();
 };

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/build-settings/github-settings/shared.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/build-settings/github-settings/shared.tsx
@@ -25,7 +25,7 @@ export const GitHubSettingCard = ({
 );
 
 export const ComboboxSkeleton = () => (
-  <div className="w-[185px] h-8 rounded-lg border border-gray-5 bg-gray-2 flex items-center justify-between px-3 py-2">
+  <div className="w-[185px] h-7 rounded-lg border border-gray-5 bg-gray-2 flex items-center justify-between px-3 py-2">
     <div className="flex gap-1.5 items-center">
       <div className="h-3.5 w-16 bg-grayA-3 rounded animate-pulse" />
       <div className="h-3.5 w-24 bg-grayA-3 rounded animate-pulse" />
@@ -47,13 +47,13 @@ export const RepoNameLabel = ({ fullName }: { fullName: string }) => {
 
 export const ManageGitHubAppLink = ({
   installUrl,
-  variant = "ghost",
-  className = "-ml-3 px-3 py-2 rounded-lg",
+  variant = "primary",
+  className = "px-3 py-2 rounded-md",
   text = "Manage Github App",
   onBeforeNavigate,
 }: {
   installUrl: string;
-  variant?: "outline" | "ghost";
+  variant?: "outline" | "ghost" | "primary";
   className?: string;
   text?: React.ReactNode;
   onBeforeNavigate?: () => void;
@@ -61,7 +61,7 @@ export const ManageGitHubAppLink = ({
   <Button variant={variant} className={className}>
     <a
       href={installUrl}
-      className="text-sm text-gray-12"
+      className="text-sm"
       target="_blank"
       rel="noopener noreferrer"
       onClick={onBeforeNavigate}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/delete-project.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/delete-project.tsx
@@ -4,7 +4,7 @@ import { collection } from "@/lib/collections";
 import { useWorkspace } from "@/providers/workspace-provider";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { TriangleWarning2 } from "@unkey/icons";
-import { Button, DialogContainer, Input, SettingsDangerZone, SettingsZoneRow } from "@unkey/ui";
+import { Button, DialogContainer, Input, SettingsZoneRow } from "@unkey/ui";
 
 import { useRouter } from "next/navigation";
 import { useState } from "react";
@@ -49,18 +49,14 @@ export function DeleteProject() {
 
   return (
     <>
-      <div className="w-225 mx-auto mt-10 mb-14">
-        <SettingsDangerZone>
-          <SettingsZoneRow
-            title="Delete this project"
-            description="Once you delete a project, there is no going back. Please be certain."
-            action={{
-              label: "Delete this project",
-              onClick: () => setIsDialogOpen(true),
-            }}
-          />
-        </SettingsDangerZone>
-      </div>
+      <SettingsZoneRow
+        title="Delete this project"
+        description="Once you delete a project, there is no going back. Please be certain."
+        action={{
+          label: "Delete this project",
+          onClick: () => setIsDialogOpen(true),
+        }}
+      />
 
       <DialogContainer
         isOpen={isDialogOpen}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/disconnect-github.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/disconnect-github.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { trpc } from "@/lib/trpc/client";
+import { SettingsZoneRow, toast } from "@unkey/ui";
+import { useProjectData } from "../../data-provider";
+
+export function DisconnectGitHub() {
+  const { projectId } = useProjectData();
+  const utils = trpc.useUtils();
+
+  const { data } = trpc.github.getInstallations.useQuery({ projectId }, { staleTime: 0 });
+
+  const appId = data?.appId;
+  const isConnected = Boolean(data?.repoConnection?.repositoryFullName);
+
+  const disconnectRepoMutation = trpc.github.disconnectRepo.useMutation({
+    onSuccess: async () => {
+      toast.success("Repository disconnected");
+      await utils.github.getInstallations.invalidate();
+      await utils.github.getRepoTree.invalidate();
+    },
+    onError: (error) => {
+      toast.error(error.message);
+    },
+  });
+
+  if (!isConnected || !appId) {
+    return null;
+  }
+
+  return (
+    <SettingsZoneRow
+      title="Disconnect repository"
+      description="Deployments will no longer be triggered by pushes to this repository."
+      action={{
+        label: "Disconnect repository",
+        onClick: () => disconnectRepoMutation.mutate({ appId }),
+        loading: disconnectRepoMutation.isLoading,
+      }}
+    />
+  );
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/page.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { usePreventLeave } from "@/hooks/use-prevent-leave";
-import { SettingsShell } from "@unkey/ui";
+import { SettingsDangerZone, SettingsShell } from "@unkey/ui";
 import { DeleteProject } from "./components/delete-project";
+import { DisconnectGitHub } from "./components/disconnect-github";
 import { DeploymentSettings } from "./deployment-settings";
 import { EnvironmentSettingsProvider } from "./environment-provider";
 export default function SettingsPage() {
@@ -19,7 +20,12 @@ export default function SettingsPage() {
         </div>
         <DeploymentSettings onBeforeNavigate={bypass} />
       </SettingsShell>
-      <DeleteProject />
+      <div className="w-225 mx-auto mt-10 mb-14">
+        <SettingsDangerZone>
+          <DisconnectGitHub />
+          <DeleteProject />
+        </SettingsDangerZone>
+      </div>
     </EnvironmentSettingsProvider>
   );
 }


### PR DESCRIPTION
## What does this PR do?

Fixes #5749.  

- Runs `fmt` for unformatted go code.
- Moves disconnect to Danger zone. We didn't do it initally coz we didn't have danger zone before.

<img width="1000" height="339" alt="Screenshot 2026-04-14 at 17 22 38" src="https://github.com/user-attachments/assets/cb08d623-5002-4e3e-b44e-f73a53b94bf8" />
<img width="1196" height="431" alt="Screenshot 2026-04-14 at 17 22 42" src="https://github.com/user-attachments/assets/eef448f3-6280-481c-b2fb-0f6d913ddb87" />


## Test
You can try to disconnect, try to select new repo while connected to another