### PR TITLE
feat(ctrl): default slack webhook + richer rollout messages

### DIFF
--- a/docs/engineering/architecture/services/control-plane/worker/configuration.mdx
+++ b/docs/engineering/architecture/services/control-plane/worker/configuration.mdx
@@ -106,6 +106,7 @@ GitHub configuration is optional and can be omitted for local development.
 | `heartbeat.quota_check_url` | string | Checkly heartbeat for quota checks.
 | `heartbeat.key_refill_url` | string | Checkly heartbeat for key refills.
 | `slack.quota_check_webhook_url` | string | Slack webhook for quota alerts.
+| `slack.sentinel_rollout_webhook_url` | string | Slack webhook used by `SentinelRolloutService` to post rollout progress.
 
 ## Example
 
@@ -173,4 +174,5 @@ key_refill_url = "${UNKEY_KEY_REFILL_HEARTBEAT_URL}"
 
 [slack]
 quota_check_webhook_url = "${UNKEY_QUOTA_CHECK_SLACK_WEBHOOK_URL}"
+sentinel_rollout_webhook_url = "${UNKEY_SENTINEL_ROLLOUT_SLACK_WEBHOOK_URL}"
 ```

--- a/docs/engineering/infra/deployments/sentinel-rollout.mdx
+++ b/docs/engineering/infra/deployments/sentinel-rollout.mdx
@@ -12,7 +12,8 @@ This doc is the operator-facing recipe: how to actually start, monitor, and unst
 - The target image exists in `ghcr.io/unkeyed/sentinel` and passed CI.
 - You have a kubeconfig for the prod control-plane cluster.
 - You have the Restate ingress bearer token from the `restate-cloud-credentials` secret (AWS Secrets Manager).
-- A Slack webhook URL (optional but strongly recommended in prod — it's the only progress stream you'll get without tailing logs).
+
+The Slack channel for rollout progress is configured server-side via [`slack.sentinel_rollout_webhook_url`](/architecture/services/control-plane/worker/configuration#heartbeat-and-slack) — there's nothing to pass per-rollout.
 
 Export the ingress URL and token for the rest of this doc:
 
@@ -28,8 +29,7 @@ curl -X POST "$RESTATE_URL/hydra.v1.SentinelRolloutService/singleton/Rollout" \
   -H "Authorization: Bearer $RESTATE_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
-    "image": "ghcr.io/unkeyed/sentinel:v1.2.3",
-    "slack_webhook_url": "https://hooks.slack.com/services/..."
+    "image": "ghcr.io/unkeyed/sentinel:v1.2.3"
   }'
 ```
 
@@ -50,11 +50,10 @@ If you'd rather click than curl, the Restate Cloud UI exposes every handler as a
 5. Fill in the JSON body:
    ```json
    {
-     "image": "ghcr.io/unkeyed/sentinel:v1.2.3",
-     "slack_webhook_url": "https://hooks.slack.com/services/..."
+     "image": "ghcr.io/unkeyed/sentinel:v1.2.3"
    }
    ```
-   Add `"wave_percentages": [10, 100]` if you want to override the defaults.
+   Add `"wave_percentages": [10, 100]` to override the default waves.
 6. Hit **Send** (blocks until `completed`/`paused`) or **Send async** (fire-and-forget — watch Slack).
 
 For `Resume`, `Cancel`, and `RollbackAll`, use the same flow: pick the handler on `SentinelRolloutService`, key `singleton`, empty `{}` body.
@@ -119,6 +118,5 @@ Fans `SentinelService.Deploy` back to each sentinel's previous image (captured a
 ## Tips
 
 - **Test on staging first.** The same RPCs exist on the staging control-plane — use the staging ingress URL and always run a full rollout there before prod.
-- **Don't skip the Slack webhook in prod.** If you `/send` the rollout and forget to pass it, your only progress signal is worker logs.
 - **Custom waves for emergencies.** Rolling back a bad image via a fresh rollout of the last-known-good tag is often faster than `RollbackAll` if most sentinels are already on the bad image — but think about what `previousImages` will capture before you do it.
 - **The `singleton` key is intentional.** Don't try to run two rollouts at once by varying the key — clients always address `singleton`.

--- a/gen/proto/hydra/v1/sentinel.pb.go
+++ b/gen/proto/hydra/v1/sentinel.pb.go
@@ -325,8 +325,6 @@ type SentinelRolloutServiceRolloutRequest struct {
 	Image string                 `protobuf:"bytes,1,opt,name=image,proto3" json:"image,omitempty"`
 	// Custom wave percentages. Defaults to [1, 5, 25, 50, 100].
 	WavePercentages []int32 `protobuf:"varint,2,rep,packed,name=wave_percentages,json=wavePercentages,proto3" json:"wave_percentages,omitempty"`
-	// Slack webhook URL for rollout notifications.
-	SlackWebhookUrl string `protobuf:"bytes,3,opt,name=slack_webhook_url,json=slackWebhookUrl,proto3" json:"slack_webhook_url,omitempty"`
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
@@ -373,13 +371,6 @@ func (x *SentinelRolloutServiceRolloutRequest) GetWavePercentages() []int32 {
 		return x.WavePercentages
 	}
 	return nil
-}
-
-func (x *SentinelRolloutServiceRolloutRequest) GetSlackWebhookUrl() string {
-	if x != nil {
-		return x.SlackWebhookUrl
-	}
-	return ""
 }
 
 type SentinelRolloutServiceRolloutResponse struct {
@@ -672,11 +663,10 @@ const file_hydra_v1_sentinel_proto_rawDesc = "" +
 	"\x1dSentinelServiceDeployResponse\x126\n" +
 	"\x06status\x18\x01 \x01(\x0e2\x1e.hydra.v1.SentinelDeployStatusR\x06status\"#\n" +
 	"!SentinelServiceNotifyReadyRequest\"$\n" +
-	"\"SentinelServiceNotifyReadyResponse\"\x93\x01\n" +
+	"\"SentinelServiceNotifyReadyResponse\"g\n" +
 	"$SentinelRolloutServiceRolloutRequest\x12\x14\n" +
 	"\x05image\x18\x01 \x01(\tR\x05image\x12)\n" +
-	"\x10wave_percentages\x18\x02 \x03(\x05R\x0fwavePercentages\x12*\n" +
-	"\x11slack_webhook_url\x18\x03 \x01(\tR\x0fslackWebhookUrl\"]\n" +
+	"\x10wave_percentages\x18\x02 \x03(\x05R\x0fwavePercentages\"]\n" +
 	"%SentinelRolloutServiceRolloutResponse\x124\n" +
 	"\x05state\x18\x01 \x01(\x0e2\x1e.hydra.v1.SentinelRolloutStateR\x05state\"%\n" +
 	"#SentinelRolloutServiceResumeRequest\"\\\n" +

--- a/svc/ctrl/proto/hydra/v1/sentinel.proto
+++ b/svc/ctrl/proto/hydra/v1/sentinel.proto
@@ -83,8 +83,6 @@ message SentinelRolloutServiceRolloutRequest {
   string image = 1;
   // Custom wave percentages. Defaults to [1, 5, 25, 50, 100].
   repeated int32 wave_percentages = 2;
-  // Slack webhook URL for rollout notifications.
-  string slack_webhook_url = 3;
 }
 
 message SentinelRolloutServiceRolloutResponse {

--- a/svc/ctrl/worker/config.go
+++ b/svc/ctrl/worker/config.go
@@ -185,6 +185,11 @@ type SlackConfig struct {
 	// When set, Slack notifications are sent when workspaces exceed their quota.
 	// Optional - if empty, no Slack notifications are sent.
 	QuotaCheckWebhookURL string `toml:"quota_check_webhook_url"`
+
+	// SentinelRolloutWebhookURL is the Slack webhook URL used by the
+	// SentinelRolloutService to post progress for fleet-wide image rollouts.
+	// Optional - if empty, no Slack notifications are sent.
+	SentinelRolloutWebhookURL string `toml:"sentinel_rollout_webhook_url"`
 }
 
 // Config holds the complete configuration for the Restate worker service.

--- a/svc/ctrl/worker/run.go
+++ b/svc/ctrl/worker/run.go
@@ -320,7 +320,8 @@ func Run(ctx context.Context, cfg Config) error {
 	})))
 
 	restateSrv.Bind(hydrav1.NewSentinelRolloutServiceServer(workersentinel.NewRolloutService(workersentinel.RolloutConfig{
-		DB: database,
+		DB:              database,
+		SlackWebhookURL: cfg.Slack.SentinelRolloutWebhookURL,
 	})))
 
 	// Initialize domain cache for ACME providers

--- a/svc/ctrl/worker/sentinel/rollout_cancel.go
+++ b/svc/ctrl/worker/sentinel/rollout_cancel.go
@@ -34,13 +34,14 @@ func (s *RolloutService) Cancel(
 	logger.Info("sentinel rollout cancelled", "image", state.Image,
 		"succeeded", len(state.SucceededIDs), "failed", len(state.FailedIDs))
 
+	elapsed := durationMs(nowMs(ctx) - state.StartedAtMs)
 	notifySlack(
 		ctx,
 		state.SlackWebhookURL,
 		"Rollout cancelled",
-		fmt.Sprintf("Rollout of `%s` cancelled. %d sentinels on new image, %d failed.",
-			state.Image,
-			len(state.SucceededIDs),
+		fmt.Sprintf("Rollout of `%s` cancelled after %s. %d/%d sentinels on the new image, %d failed.",
+			state.Image, elapsed,
+			len(state.SucceededIDs), state.TotalSentinels,
 			len(state.FailedIDs),
 		),
 	)

--- a/svc/ctrl/worker/sentinel/rollout_notify.go
+++ b/svc/ctrl/worker/sentinel/rollout_notify.go
@@ -2,11 +2,46 @@ package sentinel
 
 import (
 	"fmt"
+	"strings"
+	"time"
 
 	restate "github.com/restatedev/sdk-go"
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/slack"
 )
+
+// nowMs captures wall-clock time deterministically inside a restate.Run so
+// replays produce the same timestamp.
+func nowMs(ctx restate.ObjectContext) int64 {
+	ts, err := restate.Run(ctx, func(_ restate.RunContext) (int64, error) {
+		return time.Now().UnixMilli(), nil
+	}, restate.WithName("now"))
+	if err != nil {
+		logger.Error("failed to capture timestamp, falling back to local clock", "error", err)
+		return time.Now().UnixMilli()
+	}
+	return ts
+}
+
+// durationMs wraps a unix-ms delta in a time.Duration so call sites can
+// format it directly via `%s` — time.Duration.String() already renders
+// values like "1h32m0s".
+func durationMs(ms int64) time.Duration {
+	return time.Duration(ms) * time.Millisecond
+}
+
+// truncateIDs returns a comma-separated list of up to maxShow IDs with a
+// trailing "(+N more)" if truncated. Useful for surfacing failing sentinels
+// without flooding a Slack message.
+func truncateIDs(ids []string, maxShow int) string {
+	if len(ids) == 0 {
+		return ""
+	}
+	if len(ids) <= maxShow {
+		return "`" + strings.Join(ids, "`, `") + "`"
+	}
+	return "`" + strings.Join(ids[:maxShow], "`, `") + "` (+" + fmt.Sprintf("%d more", len(ids)-maxShow) + ")"
+}
 
 // notifySlack sends a notification if a webhook URL is configured in the
 // rollout state. Errors are logged but do not fail the rollout.

--- a/svc/ctrl/worker/sentinel/rollout_resume.go
+++ b/svc/ctrl/worker/sentinel/rollout_resume.go
@@ -27,11 +27,14 @@ func (s *RolloutService) Resume(
 	restate.Set(ctx, stateKeyRollout, state)
 
 	logger.Info("resuming sentinel rollout", "image", state.Image, "wave", state.CurrentWave)
+	elapsed := durationMs(nowMs(ctx) - state.StartedAtMs)
 	notifySlack(
 		ctx,
 		state.SlackWebhookURL,
 		"Rollout resumed",
-		fmt.Sprintf("Resuming from wave %d/%d.", state.CurrentWave+1, len(state.Waves)),
+		fmt.Sprintf("Skipping the failed wave, continuing from wave %d/%d. Elapsed since start: %s. Progress: %d/%d, %d failed.",
+			state.CurrentWave+1, len(state.Waves), elapsed,
+			len(state.SucceededIDs), state.TotalSentinels, len(state.FailedIDs)),
 	)
 
 	resp, err := s.executeWaves(ctx, state)

--- a/svc/ctrl/worker/sentinel/rollout_rollback_all.go
+++ b/svc/ctrl/worker/sentinel/rollout_rollback_all.go
@@ -38,11 +38,13 @@ func (s *RolloutService) RollbackAll(
 	restate.Set(ctx, stateKeyRollout, state)
 
 	logger.Info("rolling back all sentinels", "count", len(state.SucceededIDs))
+	rollbackStartedAt := nowMs(ctx)
 	notifySlack(
 		ctx,
 		state.SlackWebhookURL,
-		"Rollout rolling back",
-		fmt.Sprintf("Reverting %d sentinels to their previous images.", len(state.SucceededIDs)),
+		"Rollback started",
+		fmt.Sprintf("Reverting *%d sentinels* to their previous images. Rollout `%s` ran for %s before rollback.",
+			len(state.SucceededIDs), state.Image, durationMs(rollbackStartedAt-state.StartedAtMs)),
 	)
 
 	// Fan out Deploy calls to revert each sentinel to its previous image.
@@ -72,9 +74,11 @@ func (s *RolloutService) RollbackAll(
 	state.State = stateCancelled
 	restate.Set(ctx, stateKeyRollout, state)
 
-	logger.Info("rollback completed", "reverted", reverted, "total", len(state.SucceededIDs))
+	rollbackDuration := durationMs(nowMs(ctx) - rollbackStartedAt)
+	logger.Info("rollback completed", "reverted", reverted, "total", len(state.SucceededIDs), "duration", rollbackDuration)
 	notifySlack(ctx, state.SlackWebhookURL, "Rollback completed",
-		fmt.Sprintf("Reverted %d/%d sentinels to their previous images.", reverted, len(state.SucceededIDs)))
+		fmt.Sprintf("Reverted *%d/%d* sentinels to their previous images in %s.",
+			reverted, len(state.SucceededIDs), rollbackDuration))
 
 	return &hydrav1.SentinelRolloutServiceRollbackAllResponse{Reverted: reverted}, nil
 }

--- a/svc/ctrl/worker/sentinel/rollout_rollout.go
+++ b/svc/ctrl/worker/sentinel/rollout_rollout.go
@@ -89,17 +89,20 @@ func (s *RolloutService) Rollout(
 
 	waves := computeWaves(sentinelIDs, wavePercentages)
 
+	startedAt := nowMs(ctx)
 	state := &rolloutState{
 		State:           stateInProgress,
 		Image:           req.GetImage(),
 		PreviousImages:  previousImages,
-		SlackWebhookURL: req.GetSlackWebhookUrl(),
+		SlackWebhookURL: s.slackWebhookURL,
 		WavePercentages: wavePercentages,
 		Waves:           waves,
 		CurrentWave:     0,
 		SucceededIDs:    []string{},
 		FailedIDs:       []string{},
 		TotalSentinels:  len(sentinelIDs),
+		StartedAtMs:     startedAt,
+		WaveStartedAtMs: 0,
 	}
 	restate.Set(ctx, stateKeyRollout, state)
 
@@ -109,7 +112,8 @@ func (s *RolloutService) Rollout(
 		"waves", len(waves),
 	)
 	notifySlack(ctx, state.SlackWebhookURL, "Sentinel rollout started",
-		fmt.Sprintf("Rolling out `%s` to %d sentinels in %d waves.", req.GetImage(), len(sentinelIDs), len(waves)))
+		fmt.Sprintf("Rolling out `%s` to *%d sentinels* across *%d waves* (`%v`%%).",
+			req.GetImage(), len(sentinelIDs), len(waves), wavePercentages))
 
 	return s.executeWaves(ctx, state)
 }
@@ -123,11 +127,14 @@ func (s *RolloutService) executeWaves(
 	for i := state.CurrentWave; i < len(state.Waves); i++ {
 		wave := state.Waves[i]
 		state.CurrentWave = i
+		state.WaveStartedAtMs = nowMs(ctx)
 		restate.Set(ctx, stateKeyRollout, state)
 
 		logger.Info("starting wave", "wave", i, "sentinels", len(wave))
-		notifySlack(ctx, state.SlackWebhookURL, "Wave started",
-			fmt.Sprintf("Wave %d/%d: deploying to %d sentinels.", i+1, len(state.Waves), len(wave)))
+		notifySlack(ctx, state.SlackWebhookURL, fmt.Sprintf("Wave %d/%d started", i+1, len(state.Waves)),
+			fmt.Sprintf("Deploying `%s` to *%d sentinels* in this wave. Progress: %d/%d (%d%%).",
+				state.Image, len(wave), len(state.SucceededIDs), state.TotalSentinels,
+				percent(len(state.SucceededIDs), state.TotalSentinels)))
 
 		// Fan out Deploy calls for all sentinels in this wave.
 		type deployFuture = restate.ResponseFuture[*hydrav1.SentinelServiceDeployResponse]
@@ -139,46 +146,63 @@ func (s *RolloutService) executeWaves(
 		}
 
 		// Collect results.
-		waveFailed := false
+		var waveFailures []string
 		for j, fut := range futures {
 			resp, err := fut.Response()
 			if err != nil {
 				state.FailedIDs = append(state.FailedIDs, wave[j])
-				waveFailed = true
+				waveFailures = append(waveFailures, wave[j])
 				logger.Error("sentinel deploy error", "sentinel_id", wave[j], "error", err)
 				continue
 			}
 			if resp.GetStatus() != hydrav1.SentinelDeployStatus_SENTINEL_DEPLOY_STATUS_READY {
 				state.FailedIDs = append(state.FailedIDs, wave[j])
-				waveFailed = true
+				waveFailures = append(waveFailures, wave[j])
 				logger.Warn("sentinel deploy failed", "sentinel_id", wave[j], "status", resp.GetStatus())
 			} else {
 				state.SucceededIDs = append(state.SucceededIDs, wave[j])
 			}
 		}
 
-		if waveFailed {
+		waveDuration := durationMs(nowMs(ctx) - state.WaveStartedAtMs)
+
+		if len(waveFailures) > 0 {
 			state.State = statePaused
 			restate.Set(ctx, stateKeyRollout, state)
-			notifySlack(ctx, state.SlackWebhookURL, "Rollout paused",
-				fmt.Sprintf("Wave %d/%d had failures. %d succeeded, %d failed. Investigate and call Resume or RollbackAll.",
-					i+1, len(state.Waves), len(state.SucceededIDs), len(state.FailedIDs)))
+			notifySlack(ctx, state.SlackWebhookURL, fmt.Sprintf("Rollout paused after wave %d/%d", i+1, len(state.Waves)),
+				fmt.Sprintf("*%d failed*, %d succeeded in this wave (took %s).\nFailing sentinels: %s\nTotal so far: %d/%d succeeded, %d failed.\nCall `Resume` to continue, `Cancel` to stop, or `RollbackAll` to revert.",
+					len(waveFailures), len(wave)-len(waveFailures), waveDuration,
+					truncateIDs(waveFailures, 5),
+					len(state.SucceededIDs), state.TotalSentinels, len(state.FailedIDs)))
 			return &hydrav1.SentinelRolloutServiceRolloutResponse{
 				State: hydrav1.SentinelRolloutState_SENTINEL_ROLLOUT_STATE_PAUSED,
 			}, nil
 		}
 
-		notifySlack(ctx, state.SlackWebhookURL, "Wave completed",
-			fmt.Sprintf("Wave %d/%d complete. %d/%d sentinels updated.", i+1, len(state.Waves), len(state.SucceededIDs), state.TotalSentinels))
+		notifySlack(ctx, state.SlackWebhookURL, fmt.Sprintf("Wave %d/%d completed", i+1, len(state.Waves)),
+			fmt.Sprintf("%d sentinels updated in %s. Progress: %d/%d (%d%%).",
+				len(wave), waveDuration,
+				len(state.SucceededIDs), state.TotalSentinels,
+				percent(len(state.SucceededIDs), state.TotalSentinels)))
 	}
 
 	state.State = stateCompleted
 	restate.Set(ctx, stateKeyRollout, state)
+	total := durationMs(nowMs(ctx) - state.StartedAtMs)
 	notifySlack(ctx, state.SlackWebhookURL, "Rollout completed",
-		fmt.Sprintf("All %d sentinels updated to `%s`.", state.TotalSentinels, state.Image))
+		fmt.Sprintf("All *%d sentinels* updated to `%s` in %s across %d waves.",
+			state.TotalSentinels, state.Image, total, len(state.Waves)))
 
-	logger.Info("sentinel rollout completed", "image", state.Image, "sentinels", state.TotalSentinels)
+	logger.Info("sentinel rollout completed", "image", state.Image, "sentinels", state.TotalSentinels, "duration", total)
 	return &hydrav1.SentinelRolloutServiceRolloutResponse{
 		State: hydrav1.SentinelRolloutState_SENTINEL_ROLLOUT_STATE_COMPLETED,
 	}, nil
+}
+
+// percent returns floor(100 * n / total), guarding against div-by-zero.
+func percent(n, total int) int {
+	if total == 0 {
+		return 0
+	}
+	return n * 100 / total
 }

--- a/svc/ctrl/worker/sentinel/rollout_service.go
+++ b/svc/ctrl/worker/sentinel/rollout_service.go
@@ -9,7 +9,8 @@ import (
 // for orchestrating progressive sentinel image rollouts across the fleet.
 type RolloutService struct {
 	hydrav1.UnimplementedSentinelRolloutServiceServer
-	db db.Database
+	db              db.Database
+	slackWebhookURL string
 }
 
 var _ hydrav1.SentinelRolloutServiceServer = (*RolloutService)(nil)
@@ -17,12 +18,17 @@ var _ hydrav1.SentinelRolloutServiceServer = (*RolloutService)(nil)
 // RolloutConfig holds the configuration for the sentinel rollout service.
 type RolloutConfig struct {
 	DB db.Database
+
+	// SlackWebhookURL is the webhook used to post rollout progress.
+	// Optional - if empty, no Slack notifications are sent.
+	SlackWebhookURL string
 }
 
 // NewRolloutService creates a new sentinel rollout service.
 func NewRolloutService(cfg RolloutConfig) *RolloutService {
 	return &RolloutService{
 		UnimplementedSentinelRolloutServiceServer: hydrav1.UnimplementedSentinelRolloutServiceServer{},
-		db: cfg.DB,
+		db:              cfg.DB,
+		slackWebhookURL: cfg.SlackWebhookURL,
 	}
 }

--- a/svc/ctrl/worker/sentinel/rollout_state.go
+++ b/svc/ctrl/worker/sentinel/rollout_state.go
@@ -18,6 +18,11 @@ type rolloutState struct {
 	SucceededIDs    []string          `json:"succeededIds"`
 	FailedIDs       []string          `json:"failedIds"`
 	TotalSentinels  int               `json:"totalSentinels"`
+
+	// StartedAtMs is the unix-ms timestamp when Rollout was first invoked.
+	StartedAtMs int64 `json:"startedAtMs,omitempty"`
+	// WaveStartedAtMs is the unix-ms timestamp when the current wave started.
+	WaveStartedAtMs int64 `json:"waveStartedAtMs,omitempty"`
 }
 
 const (


### PR DESCRIPTION
## What does this PR do?

Moves Slack webhook configuration for sentinel rollouts from per-request parameters to server-side configuration. The Slack webhook URL is now configured via the `slack.sentinel_rollout_webhook_url` setting in the worker configuration instead of being passed with each rollout request.

Additionally enhances rollout notifications with more detailed progress information including:
- Elapsed time tracking for rollouts, waves, and rollbacks
- Progress percentages and detailed status updates
- Better formatting of failed sentinel IDs with truncation
- More informative messages for wave completion, failures, and rollback operations

## Type of change

- [x] Enhancement (small improvements)
- [x] This change requires a documentation update

## How should this be tested?

- Test sentinel rollout operations with the new server-side Slack configuration
- Verify that rollout progress notifications include timing and progress information
- Test rollout pause/resume/cancel/rollback scenarios to ensure proper Slack notifications
- Confirm that the API no longer requires `slack_webhook_url` in rollout requests

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [x] Ran `make fmt` on `/go` directory
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [x] Updated the Unkey Docs if changes were necessary