### PR TITLE
fix: prevent SSRF via openapi_spec_path authority confusion

### DIFF
--- a/svc/ctrl/worker/openapi/BUILD.bazel
+++ b/svc/ctrl/worker/openapi/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "openapi",
@@ -16,5 +16,15 @@ go_library(
         "//pkg/logger",
         "//pkg/uid",
         "@com_github_restatedev_sdk_go//:sdk-go",
+    ],
+)
+
+go_test(
+    name = "openapi_test",
+    size = "small",
+    srcs = ["scrape_handler_test.go"],
+    embed = [":openapi"],
+    deps = [
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/svc/ctrl/worker/openapi/scrape_handler.go
+++ b/svc/ctrl/worker/openapi/scrape_handler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -78,7 +79,12 @@ func (s *Service) ScrapeSpec(ctx restate.Context, req *hydrav1.ScrapeSpecRequest
 	// is not trusted inside the cluster, so reach the pod directly via plain HTTP.
 	// Production: use HTTPS with the public FQDN.
 	isLocal := strings.HasSuffix(fqdn, ".unkey.local")
-	var specURL string
+	parsedSpecPath, err := validateSpecPath(specPath)
+	if err != nil {
+		return nil, fault.Wrap(err, fault.Public("Failed to fetch OpenAPI spec."))
+	}
+
+	var baseURL *url.URL
 	if isLocal {
 		instances, instErr := restate.Run(ctx, func(runCtx restate.RunContext) ([]db.Instance, error) {
 			return db.Query.FindInstancesByDeploymentId(runCtx, s.db.RO(), deploymentID)
@@ -99,10 +105,12 @@ func (s *Service) ScrapeSpec(ctx restate.Context, req *hydrav1.ScrapeSpecRequest
 			return &hydrav1.ScrapeSpecResponse{}, nil
 		}
 
-		specURL = fmt.Sprintf("http://%s%s", instanceAddr, specPath)
+		baseURL = &url.URL{Scheme: "http", Host: instanceAddr}
 	} else {
-		specURL = fmt.Sprintf("https://%s%s", fqdn, specPath)
+		baseURL = &url.URL{Scheme: "https", Host: fqdn}
 	}
+
+	specURL := baseURL.ResolveReference(parsedSpecPath).String()
 
 	logger.Info("scraping openapi spec", "deployment_id", deploymentID, "fqdn", fqdn, "path", specPath, "url", specURL)
 
@@ -164,4 +172,28 @@ func (s *Service) ScrapeSpec(ctx restate.Context, req *hydrav1.ScrapeSpecRequest
 
 	logger.Info("openapi spec scraped and persisted", "deployment_id", deploymentID)
 	return &hydrav1.ScrapeSpecResponse{}, nil
+}
+
+// validateSpecPath checks that path is a clean, absolute path suitable for resolving
+// against a trusted base URL. It rejects values containing a scheme, host, or userinfo
+// to prevent authority-confusion SSRF where a payload like "@attacker/path" would cause
+// the constructed URL to target an attacker-controlled host instead of the trusted one.
+func validateSpecPath(path string) (*url.URL, error) {
+	parsed, err := url.Parse(path)
+	if err != nil {
+		return nil, fmt.Errorf("malformed openapi spec path: %w", err)
+	}
+	if parsed.IsAbs() {
+		return nil, fmt.Errorf("openapi spec path must not contain a scheme: %q", path)
+	}
+	if parsed.Host != "" {
+		return nil, fmt.Errorf("openapi spec path must not contain a host: %q", path)
+	}
+	if parsed.User != nil {
+		return nil, fmt.Errorf("openapi spec path must not contain userinfo: %q", path)
+	}
+	if !strings.HasPrefix(parsed.Path, "/") {
+		return nil, fmt.Errorf("openapi spec path must be absolute (start with /): %q", path)
+	}
+	return parsed, nil
 }

--- a/svc/ctrl/worker/openapi/scrape_handler_test.go
+++ b/svc/ctrl/worker/openapi/scrape_handler_test.go
@@ -1,0 +1,47 @@
+package openapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateSpecPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		wantErr bool
+	}{
+		{name: "valid simple path", path: "/openapi.json", wantErr: false},
+		{name: "valid nested path", path: "/api/v1/openapi.json", wantErr: false},
+		{name: "valid path with query", path: "/openapi.json?format=yaml", wantErr: false},
+
+		// Authority-confusion SSRF payloads.
+		{name: "at-sign authority confusion", path: "@attacker.com/openapi.json", wantErr: true},
+		{name: "at-sign with port", path: "@127.0.0.1:8080/openapi.json", wantErr: true},
+
+		// Scheme-based payloads.
+		{name: "absolute URL with https", path: "https://attacker.com/openapi.json", wantErr: true},
+		{name: "absolute URL with http", path: "http://attacker.com/openapi.json", wantErr: true},
+
+		// Authority reference payloads.
+		{name: "double-slash authority", path: "//attacker.com/openapi.json", wantErr: true},
+
+		// Relative paths (no leading slash).
+		{name: "relative path", path: "openapi.json", wantErr: true},
+		{name: "empty string", path: "", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parsed, err := validateSpecPath(tt.path)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Nil(t, parsed)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, parsed)
+		})
+	}
+}

--- a/web/apps/dashboard/lib/trpc/routers/deploy/environment-settings/runtime/update-openapi-spec-path.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/environment-settings/runtime/update-openapi-spec-path.ts
@@ -8,7 +8,14 @@ export const updateOpenapiSpecPath = workspaceProcedure
   .input(
     z.object({
       environmentId: z.string(),
-      openapiSpecPath: z.string().max(512).nullable(),
+      openapiSpecPath: z
+        .string()
+        .max(512)
+        .refine(
+          (value) => value.startsWith("/") && !value.startsWith("//"),
+          "OpenAPI spec path must start with a single '/'",
+        )
+        .nullable(),
     }),
   )
   .mutation(async ({ ctx, input }) => {


### PR DESCRIPTION
## Summary

- The `openapi_spec_path` field accepted any string up to 512 chars and the scraper concatenated it into a request URL with `fmt.Sprintf`. A payload like `@attacker.com/path` causes Go's URL parser to treat the trusted FQDN as userinfo and the attacker host as the actual target, giving any workspace user with runtime-settings access an SSRF primitive from the control-plane worker.
- Validates the path in the tRPC mutation (`startsWith("/")`, not `//`) so malformed values are rejected at the entry point.
- Validates again in `ScrapeSpec` via the new `validateSpecPath` helper (DB values are untrusted) and builds the final URL with `url.URL` + `ResolveReference`, making authority confusion structurally impossible.
- Adds table-driven unit tests covering valid paths and the attack vectors: `@host`, `//host`, `http://host`, relative paths, empty string.

## Test plan

- [ ] `make build`
- [ ] `make test` 
- [ ] Manually verify the dashboard form rejects `@attacker.com/openapi.json` with the new validation message
