### PR TITLE
fix(codeowners): unblock web reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-* @perkinsjr @chronark @mcstepp @MichaelUnkey @ogzhanolguncu @flo4604 @imeyer
-web @dave-hawkins
+* @dave-hawkins @perkinsjr @chronark @mcstepp @MichaelUnkey @ogzhanolguncu @flo4604 @imeyer


### PR DESCRIPTION
## Summary

The bare `web` pattern added in #5801 matches everything under `web/` (gitignore semantics), and CODEOWNERS uses last-match-wins, so dave-hawkins became the **sole** required CODEOWNER for any `web/**` file. PRs touching web files (e.g. #5794) couldn't satisfy required-review even with two approvals from people on the `*` line.

Anchors to `/web/` and lists the existing owners alongside dave so any of them can approve web changes.

## Test plan

- [ ] Re-check #5794 mergeability after merge