### PR TITLE
fix: preview on first branch and find without proj id

### DIFF
--- a/pkg/db/app_environment_variables_list_for_connections.sql_generated.go
+++ b/pkg/db/app_environment_variables_list_for_connections.sql_generated.go
@@ -18,6 +18,7 @@ INNER JOIN github_repo_connections gc ON gc.app_id = a.id
 WHERE gc.installation_id = ?
   AND gc.repository_id = ?
   AND e.slug = CASE
+    WHEN CAST(? AS SIGNED) = 1 THEN 'preview'
     WHEN ? = COALESCE(NULLIF(a.default_branch, ''), 'main')
     THEN 'production'
     ELSE 'preview'
@@ -27,6 +28,7 @@ WHERE gc.installation_id = ?
 type ListEnvVarsForRepoConnectionsParams struct {
 	InstallationID int64  `db:"installation_id"`
 	RepositoryID   int64  `db:"repository_id"`
+	IsForkPr       int64  `db:"is_fork_pr"`
 	Branch         string `db:"branch"`
 }
 
@@ -46,12 +48,18 @@ type ListEnvVarsForRepoConnectionsRow struct {
 //	WHERE gc.installation_id = ?
 //	  AND gc.repository_id = ?
 //	  AND e.slug = CASE
+//	    WHEN CAST(? AS SIGNED) = 1 THEN 'preview'
 //	    WHEN ? = COALESCE(NULLIF(a.default_branch, ''), 'main')
 //	    THEN 'production'
 //	    ELSE 'preview'
 //	  END
 func (q *Queries) ListEnvVarsForRepoConnections(ctx context.Context, db DBTX, arg ListEnvVarsForRepoConnectionsParams) ([]ListEnvVarsForRepoConnectionsRow, error) {
-	rows, err := db.QueryContext(ctx, listEnvVarsForRepoConnections, arg.InstallationID, arg.RepositoryID, arg.Branch)
+	rows, err := db.QueryContext(ctx, listEnvVarsForRepoConnections,
+		arg.InstallationID,
+		arg.RepositoryID,
+		arg.IsForkPr,
+		arg.Branch,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/db/querier_generated.go
+++ b/pkg/db/querier_generated.go
@@ -2216,6 +2216,7 @@ type Querier interface {
 	//  WHERE gc.installation_id = ?
 	//    AND gc.repository_id = ?
 	//    AND e.slug = CASE
+	//      WHEN CAST(? AS SIGNED) = 1 THEN 'preview'
 	//      WHEN ? = COALESCE(NULLIF(a.default_branch, ''), 'main')
 	//      THEN 'production'
 	//      ELSE 'preview'

--- a/pkg/db/queries/app_environment_variables_list_for_connections.sql
+++ b/pkg/db/queries/app_environment_variables_list_for_connections.sql
@@ -7,6 +7,7 @@ INNER JOIN github_repo_connections gc ON gc.app_id = a.id
 WHERE gc.installation_id = sqlc.arg(installation_id)
   AND gc.repository_id = sqlc.arg(repository_id)
   AND e.slug = CASE
+    WHEN CAST(sqlc.arg(is_fork_pr) AS SIGNED) = 1 THEN 'preview'
     WHEN sqlc.arg(branch) = COALESCE(NULLIF(a.default_branch, ''), 'main')
     THEN 'production'
     ELSE 'preview'

--- a/svc/ctrl/api/github_webhook.go
+++ b/svc/ctrl/api/github_webhook.go
@@ -103,14 +103,13 @@ func (s *GitHubWebhook) handlePush(ctx context.Context, w http.ResponseWriter, b
 		return
 	}
 
-	// Branch deletions and restorations don't need deployments.
-	// Deleted branches have no code to build; restored branches are
-	// just re-created refs pointing at an existing commit.
-	if payload.Deleted || payload.Created {
-		logger.Info("Ignoring branch delete/restore push",
+	// Deleted branches have no code to build — `after` is all zeros and there
+	// is nothing to deploy. `created: true` is NOT skipped: GitHub sets it on
+	// every first push of a new branch (e.g. `git push -u origin feature`),
+	// which is the main way preview deployments get triggered.
+	if payload.Deleted {
+		logger.Info("Ignoring branch delete push",
 			"ref", payload.Ref,
-			"deleted", payload.Deleted,
-			"created", payload.Created,
 		)
 		w.WriteHeader(http.StatusOK)
 		return

--- a/svc/ctrl/api/github_webhook_integration_test.go
+++ b/svc/ctrl/api/github_webhook_integration_test.go
@@ -99,12 +99,14 @@ func TestGitHubWebhook_Push_IgnoresDeletedBranch(t *testing.T) {
 	}
 }
 
-func TestGitHubWebhook_Push_IgnoresRestoredBranch(t *testing.T) {
+func TestGitHubWebhook_Push_ProcessesCreatedBranch(t *testing.T) {
 	pushRequests := make(chan *hydrav1.HandlePushRequest, 1)
 	harness := newWebhookHarness(t, webhookHarnessConfig{
 		Services: []restate.ServiceDefinition{hydrav1.NewGitHubWebhookServiceServer(&mockGitHubWebhookService{requests: pushRequests})},
 	})
 
+	// GitHub sets `created: true` on the first push of a new branch, which is
+	// the main way preview deployments get triggered.
 	payload := newTestPushPayload(testRepoFullName, false)
 	payload.Created = true
 
@@ -115,8 +117,8 @@ func TestGitHubWebhook_Push_IgnoresRestoredBranch(t *testing.T) {
 
 	select {
 	case <-pushRequests:
-		t.Fatal("unexpected HandlePush invocation for restored branch")
-	case <-time.After(1 * time.Second):
+	case <-time.After(10 * time.Second):
+		t.Fatal("expected HandlePush invocation for newly created branch")
 	}
 }
 

--- a/svc/ctrl/worker/githubwebhook/handle_push.go
+++ b/svc/ctrl/worker/githubwebhook/handle_push.go
@@ -62,6 +62,7 @@ func (s *Service) HandlePush(ctx restate.ObjectContext, req *hydrav1.HandlePushR
 			InstallationID: req.GetInstallationId(),
 			RepositoryID:   req.GetRepositoryId(),
 			Branch:         branch,
+			IsForkPr:       boolToInt64(req.GetIsForkPr()),
 		})
 	}, restate.WithName("list env vars"))
 	if err != nil {
@@ -70,15 +71,19 @@ func (s *Service) HandlePush(ctx restate.ObjectContext, req *hydrav1.HandlePushR
 
 	envVarsByApp := groupEnvVarsByApp(allEnvVars)
 
-	// Fork PRs come through the pull_request webhook which doesn't include
-	// per-commit file lists. Fetch changed files from the commit API so
-	// watch path matching works correctly instead of seeing an empty list.
+	// Webhook payloads don't always include per-commit file lists:
+	//   - Fork PRs come through the pull_request webhook which has no commits.
+	//   - Created-branch pushes pointing at an already-reachable commit arrive
+	//     with an empty commits array.
+	// When files aren't available, fetch from the GitHub API so watch-path
+	// matching doesn't skip deploys for lack of a diff.
 	changedFiles := req.GetChangedFiles()
-	if req.GetIsForkPr() && req.GetAfter() != "" && !s.allowUnauthenticatedDeployments {
-		logger.Info("fetching commit files for fork PR",
+	if len(changedFiles) == 0 && req.GetAfter() != "" && !s.allowUnauthenticatedDeployments {
+		logger.Info("fetching commit files from GitHub",
 			"commit_sha", req.GetAfter(),
 			"repo", req.GetRepositoryFullName(),
 			"installation_id", req.GetInstallationId(),
+			"is_fork_pr", req.GetIsForkPr(),
 		)
 		files, filesErr := restate.Run(ctx, func(_ restate.RunContext) ([]string, error) {
 			return s.github.ListCommitFiles(
@@ -93,7 +98,7 @@ func (s *Service) HandlePush(ctx restate.ObjectContext, req *hydrav1.HandlePushR
 				"error", filesErr,
 			)
 		} else {
-			logger.Info("fetched commit files for fork PR",
+			logger.Info("fetched commit files",
 				"commit_sha", req.GetAfter(),
 				"changed_files", files,
 			)
@@ -130,7 +135,11 @@ func (s *Service) HandlePush(ctx restate.ObjectContext, req *hydrav1.HandlePushR
 			continue
 		}
 
-		needsApproval := !s.allowUnauthenticatedDeployments && s.requiresApproval(ctx, req, repo)
+		// Approval decision is independent of allowUnauthenticatedDeployments:
+		// the flag only controls whether we reach out to GitHub (e.g. to post
+		// the "awaiting authorization" commit status — see blockDeploymentForApproval).
+		// Fork PRs run external code and must always be gated, even in dev.
+		needsApproval := s.requiresApproval(ctx, req, repo)
 
 		status := db.DeploymentsStatusPending
 		if needsApproval {


### PR DESCRIPTION
## What does this PR do?

Fixes two issues related to GitHub webhook push handling and fork PR deployments.

First, the webhook was incorrectly skipping all branch creation events (`created: true`), which prevented preview deployments from being triggered when developers pushed a new branch for the first time (e.g. `git push -u origin feature`). The `created` condition has been removed from the early return guard so that newly created branches proceed through the deployment pipeline. Only deleted branches (where `after` is all zeros and there is nothing to build) are now skipped.

Second, fork PRs were not being consistently gated for approval. The `allowUnauthenticatedDeployments` flag was incorrectly short-circuiting the approval check, meaning fork PRs — which run external code — could bypass the approval gate in development environments. The approval decision is now always evaluated independently of that flag, ensuring fork PRs are always gated regardless of environment.

Additionally, the environment variable lookup query now accepts an `is_fork_pr` parameter so that fork PR builds are always resolved to the `preview` environment slug rather than potentially matching `production` based on branch name.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Create a new branch and push it to GitHub for the first time (`git push -u origin feature-branch`) and verify that a preview deployment is triggered
- Delete a branch and verify that the webhook still ignores the deletion event with no deployment triggered
- Open a fork PR and verify that it is always routed to the `preview` environment and requires approval, even when `allowUnauthenticatedDeployments` is enabled
- Verify that non-fork PRs targeting the default branch still resolve to the `production` environment

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary