### PR TITLE
fix: resolve N+1 deploy.domain.list calls on project overview

### DIFF
--- a/pkg/mysql/schema/frontline_routes.sql
+++ b/pkg/mysql/schema/frontline_routes.sql
@@ -14,6 +14,8 @@ CREATE TABLE `frontline_routes` (
 	CONSTRAINT `frontline_routes_fully_qualified_domain_name_unique` UNIQUE(`fully_qualified_domain_name`)
 );
 
+CREATE INDEX `project_id_idx` ON `frontline_routes` (`project_id`);
+
 CREATE INDEX `environment_id_idx` ON `frontline_routes` (`environment_id`);
 
 CREATE INDEX `deployment_id_idx` ON `frontline_routes` (`deployment_id`);

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/data-provider.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/data-provider.tsx
@@ -84,14 +84,18 @@ export const ProjectDataProvider = ({
         .orderBy(({ domain }) => domain.createdAt, "desc"),
     [projectId],
   );
-  // refetch domains only when current deployment actually changes (not on initial mount)
+  // refetch domains only when current deployment actually changes (not on initial mount/hydration)
   const prevDeploymentIdRef = useRef(project?.currentDeploymentId);
+  const mountedRef = useRef(false);
+  useEffect(() => {
+    mountedRef.current = true;
+  }, []);
   useEffect(() => {
     const currentId = project?.currentDeploymentId;
-    if (currentId && prevDeploymentIdRef.current !== currentId) {
-      prevDeploymentIdRef.current = currentId;
+    if (mountedRef.current && currentId && prevDeploymentIdRef.current !== currentId) {
       collection.domains.utils.refetch();
     }
+    prevDeploymentIdRef.current = currentId;
   }, [project?.currentDeploymentId]);
 
   const environmentsQuery = useLiveQuery(

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/data-provider.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/data-provider.tsx
@@ -8,7 +8,14 @@ import type { Environment } from "@/lib/collections/deploy/environments";
 import type { Project } from "@/lib/collections/deploy/projects";
 import { eq, useLiveQuery } from "@tanstack/react-db";
 import { useParams } from "next/navigation";
-import { type PropsWithChildren, createContext, useContext, useEffect, useMemo } from "react";
+import {
+  type PropsWithChildren,
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+} from "react";
 
 type ProjectDataContextType = {
   projectId: string;
@@ -77,9 +84,12 @@ export const ProjectDataProvider = ({
         .orderBy(({ domain }) => domain.createdAt, "desc"),
     [projectId],
   );
-  // refetch domains when current deployment changes
+  // refetch domains only when current deployment actually changes (not on initial mount)
+  const prevDeploymentIdRef = useRef(project?.currentDeploymentId);
   useEffect(() => {
-    if (project?.currentDeploymentId) {
+    const currentId = project?.currentDeploymentId;
+    if (currentId && prevDeploymentIdRef.current !== currentId) {
+      prevDeploymentIdRef.current = currentId;
       collection.domains.utils.refetch();
     }
   }, [project?.currentDeploymentId]);

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/components/active-deployment-card/components/skeleton.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/components/active-deployment-card/components/skeleton.tsx
@@ -56,13 +56,9 @@ export function ActiveDeploymentCardSkeleton() {
             </div>
           </div>
           <div className="flex items-center gap-1.5" aria-hidden="true">
-            <span className="text-xs text-grayA-9">
-              Requests
-            </span>
+            <span className="text-xs text-grayA-9">Requests</span>
             <span className="text-grayA-6">|</span>
-            <span className="text-xs text-grayA-9">
-              Logs
-            </span>
+            <span className="text-xs text-grayA-9">Logs</span>
             <span className="inline-flex items-center justify-center size-7">
               <ChevronDown
                 className={cn("text-grayA-9 size-3! transition-transform duration-200")}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/components/active-deployment-card/components/skeleton.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/components/active-deployment-card/components/skeleton.tsx
@@ -1,5 +1,5 @@
 import { ChevronDown, CircleCheck, CodeBranch, CodeCommit, FolderCloud } from "@unkey/icons";
-import { Badge, Button, Card } from "@unkey/ui";
+import { Badge, Card } from "@unkey/ui";
 import { cn } from "@unkey/ui/src/lib/utils";
 import { StatusIndicator } from "../../../components/status-indicator";
 
@@ -55,19 +55,19 @@ export function ActiveDeploymentCardSkeleton() {
               <div className="h-2 w-24 bg-grayA-4 rounded-sm" />
             </div>
           </div>
-          <div className="flex items-center gap-1.5">
-            <button className="text-xs text-grayA-9" type="button" disabled>
+          <div className="flex items-center gap-1.5" aria-hidden="true">
+            <span className="text-xs text-grayA-9">
               Requests
-            </button>
+            </span>
             <span className="text-grayA-6">|</span>
-            <button className="text-xs text-grayA-9" type="button" disabled>
+            <span className="text-xs text-grayA-9">
               Logs
-            </button>
-            <Button size="icon" variant="ghost" disabled aria-hidden="true" tabIndex={-1}>
+            </span>
+            <span className="inline-flex items-center justify-center size-7">
               <ChevronDown
                 className={cn("text-grayA-9 size-3! transition-transform duration-200")}
               />
-            </Button>
+            </span>
           </div>
         </div>
       </div>

--- a/web/internal/db/src/schema/frontline_routes.ts
+++ b/web/internal/db/src/schema/frontline_routes.ts
@@ -37,6 +37,7 @@ export const frontlineRoutes = mysqlTable(
     ...lifecycleDates,
   },
   (table) => [
+    index("project_id_idx").on(table.projectId),
     index("environment_id_idx").on(table.environmentId),
     index("deployment_id_idx").on(table.deploymentId),
     index("fqdn_environment_deployment_idx").on(


### PR DESCRIPTION
## What does this PR do?

Fixes the N+1 issue on `deploy.domain.list` where the tRPC endpoint was called multiple times in a single batched request on the project overview page.

**Root causes:**
1. The `useEffect` in `data-provider.tsx` called `collection.domains.utils.refetch()` on every mount when `currentDeploymentId` was truthy, duplicating the fetch already triggered by `useLiveQuery`. Now tracks the previous value via a ref and only refetches when the deployment ID actually changes.
2. The `frontline_routes` table was missing a `project_id` index. The lateral join in the Drizzle-generated query filters on `project_id` but had no index, causing a full table scan.

**Side quest:** Replaced `<button disabled aria-hidden="true">` elements with `<span>` in the active deployment card skeleton. Disabled buttons with `aria-hidden="true"` violate a11y rules (focusable elements must not be aria-hidden). Since these are decorative skeleton placeholders, `<span>` is the correct element.

Fixes #5806 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

**N+1 fix:**
1. Open the project overview page (`/projects/[projectId]`) in the dashboard
2. Open browser DevTools → Network tab and filter by `trpc`
3. Verify that `deploy.domain.list` appears only once in the batched tRPC request on initial page load (previously appeared 4 times)
4. Navigate away and back to the project page — confirm still only 1 call
5. Trigger a promotion or rollback — confirm domains refetch correctly after the mutation completes and domain data displays correctly in the promotion/rollback dialogs

**a11y fix:**
1. Navigate to a project overview page while a deployment is loading (or throttle network in DevTools)
2. Verify the skeleton card renders correctly with "Requests", "Logs" text and chevron icon
3. Run Biome lint — confirm no `aria-hidden` on focusable element warnings

## ⚠️ Migration Required

This PR adds a `project_id` index to the `frontline_routes` table. After merging:

1. Run `make generate-sql` to regenerate `pkg/mysql/schema/frontline_routes.sql`
2. Apply the following to all database environments:

```sql
CREATE INDEX `project_id_idx` ON `frontline_routes` (`project_id`);
```

This is a non-blocking, additive index so its safe to apply without downtime.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary
