### PR TITLE
fix(dashboard): skip deployments skeleton when cached data is available

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/components/deployments-card-list.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/components/deployments-card-list.tsx
@@ -14,7 +14,7 @@ export function DeploymentsCardList() {
   const currentDeploymentId = project?.currentDeploymentId;
   const workspace = useWorkspaceNavigation();
 
-  if (deployments.isLoading) {
+  if (deployments.isLoading && !deployments.data) {
     return <DeploymentsSkeleton />;
   }
 


### PR DESCRIPTION
## What does this PR do?

- Guard the deployments list skeleton on `!deployments.data` so filter clicks no longer flash a 7-second skeleton over data that is already correct client-side.

Fixes DES-27

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Open a project's deployments page, wait for the list to load, then toggle any status filter (e.g. Ready). The list updates immediately instead of showing the skeleton until the next 5s poll completes.