### PR TITLE
fix: move github fetching out of worker and fix redeploy copying image

### DIFF
--- a/svc/ctrl/api/config.go
+++ b/svc/ctrl/api/config.go
@@ -36,6 +36,11 @@ type GitHubConfig struct {
 	// PrivateKeyPEM is the GitHub App private key in PEM format.
 	// Required for deployment authorization (fetching branch HEAD).
 	PrivateKeyPEM string `toml:"private_key_pem"`
+
+	// AllowUnauthenticatedDeployments controls whether deployments can skip
+	// GitHub authentication. Set to true only for local development.
+	// Production should keep this false to require GitHub App authentication.
+	AllowUnauthenticatedDeployments bool `toml:"allow_unauthenticated_deployments"`
 }
 
 // DomainConnectConfig holds Domain Connect protocol configuration for

--- a/svc/ctrl/api/run.go
+++ b/svc/ctrl/api/run.go
@@ -187,11 +187,12 @@ func Run(ctx context.Context, cfg Config) error {
 
 	mux.Handle(ctrlv1connect.NewCtrlServiceHandler(ctrl.New(cfg.InstanceID, database)))
 	mux.Handle(ctrlv1connect.NewDeployServiceHandler(deployment.New(deployment.Config{
-		Database:     database,
-		Restate:      restateClient,
-		RestateAdmin: restateAdminClient,
-		GitHub:       ghClient,
-		Bearer:       cfg.AuthToken,
+		Database:                        database,
+		Restate:                         restateClient,
+		RestateAdmin:                    restateAdminClient,
+		GitHub:                          ghClient,
+		AllowUnauthenticatedDeployments: cfg.GitHub.AllowUnauthenticatedDeployments,
+		Bearer:                          cfg.AuthToken,
 	})))
 
 	mux.Handle(ctrlv1connect.NewOpenApiServiceHandler(openapi.New(openapi.Config{

--- a/svc/ctrl/services/deployment/authorize_deployment.go
+++ b/svc/ctrl/services/deployment/authorize_deployment.go
@@ -81,6 +81,11 @@ func (s *Service) AuthorizeDeployment(ctx context.Context, req *connect.Request[
 		commitSHA = deployment.GitCommitSha.String
 	}
 
+	branch := ""
+	if deployment.GitBranch.Valid {
+		branch = deployment.GitBranch.String
+	}
+
 	var prNumber int64
 	if deployment.PrNumber.Valid {
 		prNumber = deployment.PrNumber.Int64
@@ -88,6 +93,8 @@ func (s *Service) AuthorizeDeployment(ctx context.Context, req *connect.Request[
 
 	deployReq := &hydrav1.DeployRequest{
 		DeploymentId: deploymentID,
+		KeyAuthId:    nil,
+		Command:      deployment.Command,
 		Source: &hydrav1.DeployRequest_Git{
 			Git: &hydrav1.GitSource{
 				InstallationId: repoConn.InstallationID,
@@ -95,6 +102,7 @@ func (s *Service) AuthorizeDeployment(ctx context.Context, req *connect.Request[
 				CommitSha:      commitSHA,
 				ContextPath:    buildSetting.DockerContext,
 				DockerfilePath: buildSetting.Dockerfile,
+				Branch:         branch,
 				PrNumber:       prNumber,
 			},
 		},

--- a/svc/ctrl/services/deployment/create_deployment.go
+++ b/svc/ctrl/services/deployment/create_deployment.go
@@ -16,6 +16,7 @@ import (
 	"github.com/unkeyed/unkey/pkg/validation"
 	"github.com/unkeyed/unkey/svc/ctrl/dedup"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/auth"
+	githubclient "github.com/unkeyed/unkey/svc/ctrl/worker/github"
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
@@ -26,18 +27,28 @@ const (
 	maxCommitAuthorHandleLength = 256
 	// maxCommitAuthorAvatarLength limits avatar URL length.
 	maxCommitAuthorAvatarLength = 512
+	// noInstallationID is the zero value for a GitHub App installation ID.
+	// When the caller has no installation we can only fall back to the public
+	// GitHub API (and only if unauthenticated deployments are enabled).
+	noInstallationID = int64(0)
 )
+
+// commitFields holds git commit metadata used on a deployment row. Empty
+// fields mean "unknown" and are eligible to be filled from GitHub.
+type commitFields struct {
+	SHA             string
+	Branch          string
+	Message         string
+	AuthorHandle    string
+	AuthorAvatarURL string
+	Timestamp       int64
+}
 
 // dockerSourceInfo holds the Docker image and inherited git metadata from a
 // current deployment, used when redeploying a non-git project.
 type dockerSourceInfo struct {
-	commitSHA       string
-	branch          string
-	commitMessage   string
-	authorHandle    string
-	authorAvatarURL string
-	commitTimestamp int64
-	dockerImage     string
+	commitFields
+	dockerImage string
 }
 
 // CreateDeployment creates a new deployment record and initiates an async Restate
@@ -146,8 +157,6 @@ func (s *Service) CreateDeployment(
 	deploymentID := uid.New(uid.DeploymentPrefix)
 	now := time.Now().UnixMilli()
 
-	var gitCommitSha, gitBranch, gitCommitMessage, gitCommitAuthorHandle, gitCommitAuthorAvatarURL string
-	var gitCommitTimestamp int64
 	var deployReq *hydrav1.DeployRequest
 
 	// Resolve request-level overrides once so all branches can use them.
@@ -158,18 +167,35 @@ func (s *Service) CreateDeployment(
 	}
 	command := req.Msg.GetCommand()
 
-	if dockerImage := req.Msg.GetDockerImage(); dockerImage != "" {
-		// Explicit docker image (CLI, REST API)
-		gitBranch = branchFromGitCommit(req.Msg.GetGitCommit(), appWithSettings.App.DefaultBranch)
+	// Populate caller-provided commit metadata. Branch defaulting and GitHub
+	// fill-in happen later, only when we're actually building from git — we
+	// don't want to synthesize git metadata on docker-image redeploys.
+	var commit commitFields
+	gc := req.Msg.GetGitCommit()
+	explicitGit := gc != nil
+	if gc != nil {
+		commit.Branch = strings.TrimSpace(gc.GetBranch())
+		commit.SHA = gc.GetCommitSha()
+		commit.Message = trimLength(gc.GetCommitMessage(), maxCommitMessageLength)
+		commit.AuthorHandle = trimLength(strings.TrimSpace(gc.GetAuthorHandle()), maxCommitAuthorHandleLength)
+		commit.AuthorAvatarURL = trimLength(strings.TrimSpace(gc.GetAuthorAvatarUrl()), maxCommitAuthorAvatarLength)
+		commit.Timestamp = gc.GetTimestamp()
+	}
 
-		if gitCommit := req.Msg.GetGitCommit(); gitCommit != nil {
-			gitCommitSha = gitCommit.GetCommitSha()
-			gitCommitMessage = trimLength(gitCommit.GetCommitMessage(), maxCommitMessageLength)
-			gitCommitAuthorHandle = trimLength(strings.TrimSpace(gitCommit.GetAuthorHandle()), maxCommitAuthorHandleLength)
-			gitCommitAuthorAvatarURL = trimLength(strings.TrimSpace(gitCommit.GetAuthorAvatarUrl()), maxCommitAuthorAvatarLength)
-			gitCommitTimestamp = gitCommit.GetTimestamp()
-		}
+	// Look up the GitHub repo connection once. Used both to decide source type
+	// (git vs docker) and to resolve missing commit metadata synchronously.
+	repoConn, repoErr := db.Query.FindGithubRepoConnectionByAppId(ctx, s.db.RO(), app.ID)
+	hasRepoConnection := repoErr == nil
+	if repoErr != nil && !db.IsNotFound(repoErr) {
+		return nil, connect.NewError(connect.CodeInternal,
+			fmt.Errorf("failed to lookup github repo connection: %w", repoErr))
+	}
 
+	switch {
+	case req.Msg.GetDockerImage() != "":
+		// Explicit docker image (CLI, REST API): skip rebuild, redeploy as-is.
+		// Don't touch git metadata — the caller owns whatever they passed.
+		dockerImage := req.Msg.GetDockerImage()
 		logger.Info("deployment will use prebuilt image",
 			"deployment_id", deploymentID,
 			"app_id", app.ID,
@@ -185,65 +211,67 @@ func (s *Service) CreateDeployment(
 				},
 			},
 		}
-	} else {
-		// Source omitted (dashboard redeploy w/o commit SHA): auto-detect from app config
-		repoConn, repoErr := db.Query.FindGithubRepoConnectionByAppId(ctx, s.db.RO(), app.ID)
-		hasRepoConnection := repoErr == nil
-		if repoErr != nil && !db.IsNotFound(repoErr) {
-			return nil, connect.NewError(connect.CodeInternal,
-				fmt.Errorf("failed to lookup github repo connection: %w", repoErr))
+
+	case explicitGit && !hasRepoConnection:
+		// Caller asked for a specific commit, but the app has no git
+		// connection. Refuse rather than silently redeploying the current
+		// image (a different artifact than what was requested).
+		return nil, connect.NewError(connect.CodeFailedPrecondition,
+			fmt.Errorf("app %q has no GitHub repo connection; cannot deploy requested git commit", app.ID))
+
+	case hasRepoConnection:
+		// Git-connected app: fill missing commit metadata synchronously so
+		// the deployment row is complete at insert time and buildImage can
+		// run without any GitHub calls.
+		// Only default to the app's default branch when neither SHA nor branch
+		// were provided. If the caller pinned a SHA without a branch, that SHA
+		// may live on a non-default branch: defaulting would record a wrong
+		// branch alongside the right SHA.
+		if commit.SHA == "" && commit.Branch == "" {
+			commit.Branch = defaultBranch(appWithSettings.App.DefaultBranch)
+		}
+		if err := commit.fillFromGitHub(
+			s.github, repoConn.InstallationID, repoConn.RepositoryFullName,
+			s.allowUnauthenticatedDeployments,
+		); err != nil {
+			return nil, connect.NewError(connect.CodeFailedPrecondition,
+				fmt.Errorf("failed to resolve git commit metadata: %w", err))
+		}
+		deployReq = &hydrav1.DeployRequest{
+			DeploymentId: deploymentID,
+			KeyAuthId:    keyAuthID,
+			Command:      command,
+			Source: &hydrav1.DeployRequest_Git{
+				Git: &hydrav1.GitSource{
+					InstallationId: repoConn.InstallationID,
+					Repository:     repoConn.RepositoryFullName,
+					CommitSha:      commit.SHA,
+					ContextPath:    appBuildSettings.DockerContext,
+					DockerfilePath: appBuildSettings.Dockerfile,
+					Branch:         commit.Branch,
+					PrNumber:       0,
+				},
+			},
 		}
 
-		if hasRepoConnection {
-			// Has github_repo_connections row: build from git source.
-			gitBranch = branchFromGitCommit(req.Msg.GetGitCommit(), appWithSettings.App.DefaultBranch)
+	default:
+		// No docker image, no git commit, no repo connection: reuse current
+		// deployment's image.
+		dockerInfo, dockerErr := buildDockerSource(ctx, s.db, app, deploymentID)
+		if dockerErr != nil {
+			return nil, dockerErr
+		}
+		commit = dockerInfo.commitFields
 
-			if gitCommit := req.Msg.GetGitCommit(); gitCommit != nil {
-				gitCommitSha = gitCommit.GetCommitSha()
-				gitCommitMessage = trimLength(gitCommit.GetCommitMessage(), maxCommitMessageLength)
-				gitCommitAuthorHandle = trimLength(strings.TrimSpace(gitCommit.GetAuthorHandle()), maxCommitAuthorHandleLength)
-				gitCommitAuthorAvatarURL = trimLength(strings.TrimSpace(gitCommit.GetAuthorAvatarUrl()), maxCommitAuthorAvatarLength)
-				gitCommitTimestamp = gitCommit.GetTimestamp()
-			}
-
-			deployReq = &hydrav1.DeployRequest{
-				DeploymentId: deploymentID,
-				KeyAuthId:    keyAuthID,
-				Command:      command,
-				Source: &hydrav1.DeployRequest_Git{
-					Git: &hydrav1.GitSource{
-						InstallationId: repoConn.InstallationID,
-						Repository:     repoConn.RepositoryFullName,
-						CommitSha:      gitCommitSha,
-						ContextPath:    appBuildSettings.DockerContext,
-						DockerfilePath: appBuildSettings.Dockerfile,
-						Branch:         gitBranch,
-					},
+		deployReq = &hydrav1.DeployRequest{
+			DeploymentId: deploymentID,
+			KeyAuthId:    keyAuthID,
+			Command:      command,
+			Source: &hydrav1.DeployRequest_DockerImage{
+				DockerImage: &hydrav1.DockerImage{
+					Image: dockerInfo.dockerImage,
 				},
-			}
-		} else {
-			// No repo connection: redeploy the current deployment's Docker image
-			dockerInfo, dockerErr := buildDockerSource(ctx, s.db, app, deploymentID)
-			if dockerErr != nil {
-				return nil, dockerErr
-			}
-			gitCommitSha = dockerInfo.commitSHA
-			gitBranch = dockerInfo.branch
-			gitCommitMessage = dockerInfo.commitMessage
-			gitCommitAuthorHandle = dockerInfo.authorHandle
-			gitCommitAuthorAvatarURL = dockerInfo.authorAvatarURL
-			gitCommitTimestamp = dockerInfo.commitTimestamp
-
-			deployReq = &hydrav1.DeployRequest{
-				DeploymentId: deploymentID,
-				KeyAuthId:    keyAuthID,
-				Command:      command,
-				Source: &hydrav1.DeployRequest_DockerImage{
-					DockerImage: &hydrav1.DockerImage{
-						Image: dockerInfo.dockerImage,
-					},
-				},
-			}
+			},
 		}
 	}
 
@@ -261,12 +289,12 @@ func (s *Service) CreateDeployment(
 		Status:                        db.DeploymentsStatusPending,
 		CreatedAt:                     now,
 		UpdatedAt:                     sql.NullInt64{Valid: false, Int64: 0},
-		GitCommitSha:                  sql.NullString{String: gitCommitSha, Valid: gitCommitSha != ""},
-		GitBranch:                     sql.NullString{String: gitBranch, Valid: gitBranch != ""},
-		GitCommitMessage:              sql.NullString{String: gitCommitMessage, Valid: gitCommitMessage != ""},
-		GitCommitAuthorHandle:         sql.NullString{String: gitCommitAuthorHandle, Valid: gitCommitAuthorHandle != ""},
-		GitCommitAuthorAvatarUrl:      sql.NullString{String: gitCommitAuthorAvatarURL, Valid: gitCommitAuthorAvatarURL != ""},
-		GitCommitTimestamp:            sql.NullInt64{Int64: gitCommitTimestamp, Valid: gitCommitTimestamp != 0},
+		GitCommitSha:                  sql.NullString{String: commit.SHA, Valid: commit.SHA != ""},
+		GitBranch:                     sql.NullString{String: commit.Branch, Valid: commit.Branch != ""},
+		GitCommitMessage:              sql.NullString{String: commit.Message, Valid: commit.Message != ""},
+		GitCommitAuthorHandle:         sql.NullString{String: commit.AuthorHandle, Valid: commit.AuthorHandle != ""},
+		GitCommitAuthorAvatarUrl:      sql.NullString{String: commit.AuthorAvatarURL, Valid: commit.AuthorAvatarURL != ""},
+		GitCommitTimestamp:            sql.NullInt64{Int64: commit.Timestamp, Valid: commit.Timestamp != 0},
 		CpuMillicores:                 appRuntimeSettings.CpuMillicores,
 		MemoryMib:                     appRuntimeSettings.MemoryMib,
 		StorageMib:                    appRuntimeSettings.StorageMib,
@@ -335,7 +363,7 @@ func (s *Service) CreateDeployment(
 		ID:            deploymentID,
 		AppID:         app.ID,
 		EnvironmentID: env.Environment.ID,
-		GitBranch:     gitBranch,
+		GitBranch:     commit.Branch,
 		CreatedAt:     now,
 	}); cancelErr != nil {
 		logger.Error("failed to cancel superseded siblings",
@@ -350,14 +378,11 @@ func (s *Service) CreateDeployment(
 	}), nil
 }
 
-// branchFromGitCommit extracts the branch from GitCommitInfo, falling back
-// to the app's default branch or "main".
-func branchFromGitCommit(gitCommit *ctrlv1.GitCommitInfo, defaultBranch string) string {
-	if gitCommit != nil && gitCommit.GetBranch() != "" {
-		return gitCommit.GetBranch()
-	}
-	if defaultBranch != "" {
-		return defaultBranch
+// defaultBranch returns the app's configured default branch, falling back
+// to "main" when unset.
+func defaultBranch(appDefault string) string {
+	if appDefault != "" {
+		return appDefault
 	}
 	return "main"
 }
@@ -397,13 +422,15 @@ func buildDockerSource(
 		"image", currentDeployment.Image.String)
 
 	return dockerSourceInfo{
-		dockerImage:     currentDeployment.Image.String,
-		commitSHA:       currentDeployment.GitCommitSha.String,
-		branch:          currentDeployment.GitBranch.String,
-		commitMessage:   currentDeployment.GitCommitMessage.String,
-		authorHandle:    currentDeployment.GitCommitAuthorHandle.String,
-		authorAvatarURL: currentDeployment.GitCommitAuthorAvatarUrl.String,
-		commitTimestamp: currentDeployment.GitCommitTimestamp.Int64,
+		dockerImage: currentDeployment.Image.String,
+		commitFields: commitFields{
+			SHA:             currentDeployment.GitCommitSha.String,
+			Branch:          currentDeployment.GitBranch.String,
+			Message:         currentDeployment.GitCommitMessage.String,
+			AuthorHandle:    currentDeployment.GitCommitAuthorHandle.String,
+			AuthorAvatarURL: currentDeployment.GitCommitAuthorAvatarUrl.String,
+			Timestamp:       currentDeployment.GitCommitTimestamp.Int64,
+		},
 	}, nil
 }
 
@@ -414,4 +441,59 @@ func trimLength(s string, characters int) string {
 		return s[:characters]
 	}
 	return s
+}
+
+// fillFromGitHub fills any empty fields by fetching commit metadata from
+// GitHub. No-op when there's nothing worth fetching. The public (unauth)
+// path has no lookup-by-SHA, so that branch is skipped when we can't
+// authenticate (matches the previous behavior in deploy_handler.buildImage).
+func (cf *commitFields) fillFromGitHub(
+	gh githubclient.GitHubClient,
+	installationID int64,
+	repo string,
+	allowUnauth bool,
+) error {
+	// Use the authenticated GitHub path whenever a real installation is
+	// available; only fall back to the public API when unauth is explicitly
+	// enabled and we have no installation to auth with.
+	hasAuth := !allowUnauth || installationID != noInstallationID
+
+	var info githubclient.CommitInfo
+	var err error
+
+	switch {
+	case cf.SHA == "":
+		if cf.Branch == "" {
+			return nil
+		}
+		if hasAuth {
+			info, err = gh.GetBranchHeadCommit(installationID, repo, cf.Branch)
+		} else {
+			info, err = gh.GetBranchHeadCommitPublic(repo, cf.Branch)
+		}
+	case cf.Message == "" && hasAuth:
+		info, err = gh.GetCommitBySHA(installationID, repo, cf.SHA)
+	default:
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	if cf.SHA == "" {
+		cf.SHA = info.SHA
+	}
+	if cf.Message == "" {
+		cf.Message = trimLength(info.Message, maxCommitMessageLength)
+	}
+	if cf.AuthorHandle == "" {
+		cf.AuthorHandle = trimLength(strings.TrimSpace(info.AuthorHandle), maxCommitAuthorHandleLength)
+	}
+	if cf.AuthorAvatarURL == "" {
+		cf.AuthorAvatarURL = trimLength(strings.TrimSpace(info.AuthorAvatarURL), maxCommitAuthorAvatarLength)
+	}
+	if cf.Timestamp == 0 && !info.Timestamp.IsZero() {
+		cf.Timestamp = info.Timestamp.UnixMilli()
+	}
+	return nil
 }

--- a/svc/ctrl/services/deployment/get_deployment.go
+++ b/svc/ctrl/services/deployment/get_deployment.go
@@ -44,6 +44,7 @@ func (s *Service) GetDeployment(
 		WorkspaceId:              deployment.WorkspaceID,
 		ProjectId:                deployment.ProjectID,
 		EnvironmentId:            deployment.EnvironmentID,
+		AppId:                    deployment.AppID,
 		Status:                   convertDbStatusToProto(deployment.Status),
 		CreatedAt:                deployment.CreatedAt,
 		GitCommitSha:             "",

--- a/svc/ctrl/services/deployment/service.go
+++ b/svc/ctrl/services/deployment/service.go
@@ -15,12 +15,13 @@ import (
 // workflow execution to Restate.
 type Service struct {
 	ctrlv1connect.UnimplementedDeployServiceHandler
-	db           db.Database
-	restate      *restateingress.Client
-	restateAdmin *restateadmin.Client
-	github       githubclient.GitHubClient
-	bearer       string
-	dedup        *dedup.Service
+	db                              db.Database
+	restate                         *restateingress.Client
+	restateAdmin                    *restateadmin.Client
+	github                          githubclient.GitHubClient
+	allowUnauthenticatedDeployments bool
+	bearer                          string
+	dedup                           *dedup.Service
 }
 
 // deploymentClient creates a typed Restate ingress client for the DeployService
@@ -44,6 +45,9 @@ type Config struct {
 	RestateAdmin *restateadmin.Client
 	// GitHub is the client for GitHub API operations (fetching HEAD, etc.).
 	GitHub githubclient.GitHubClient
+	// AllowUnauthenticatedDeployments toggles the public GitHub API path for
+	// local development with public repositories. Production keeps this false.
+	AllowUnauthenticatedDeployments bool
 	// Bearer is the preshared token that callers must provide in the Authorization header.
 	Bearer string
 }
@@ -56,6 +60,7 @@ func New(cfg Config) *Service {
 		restate:                           cfg.Restate,
 		restateAdmin:                      cfg.RestateAdmin,
 		github:                            cfg.GitHub,
+		allowUnauthenticatedDeployments:   cfg.AllowUnauthenticatedDeployments,
 		bearer:                            cfg.Bearer,
 		dedup:                             dedup.New(cfg.Database, cfg.RestateAdmin),
 	}

--- a/svc/ctrl/worker/deploy/deploy_handler.go
+++ b/svc/ctrl/worker/deploy/deploy_handler.go
@@ -18,7 +18,6 @@ import (
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/pkg/restate/compensation"
 	"github.com/unkeyed/unkey/pkg/uid"
-	githubclient "github.com/unkeyed/unkey/svc/ctrl/worker/github"
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
@@ -398,94 +397,11 @@ func (w *Workflow) buildImage(ctx restate.ObjectContext, req *hydrav1.DeployRequ
 		dockerImage = source.DockerImage.GetImage()
 	case *hydrav1.DeployRequest_Git:
 		commitSHA := source.Git.GetCommitSha()
-
-		// Resolve branch→SHA when commit_sha is empty (e.g. CreateDeployment with
-		// a GitTarget that specifies only a branch)
-		if commitSHA == "" && source.Git.GetBranch() != "" {
-			info, resolveErr := restate.Run(ctx, func(runCtx restate.RunContext) (githubclient.CommitInfo, error) {
-				if w.allowUnauthenticatedDeployments && source.Git.GetInstallationId() == noInstallationID {
-					return w.github.GetBranchHeadCommitPublic(
-						source.Git.GetRepository(),
-						source.Git.GetBranch(),
-					)
-				}
-				return w.github.GetBranchHeadCommit(
-					source.Git.GetInstallationId(),
-					source.Git.GetRepository(),
-					source.Git.GetBranch(),
-				)
-			}, restate.WithName("resolve branch head"), restate.WithMaxRetryAttempts(runMaxAttempts))
-			if resolveErr != nil {
-				return fault.Wrap(
-					restate.TerminalError(fmt.Errorf("failed to resolve HEAD of branch %q: %w", source.Git.GetBranch(), resolveErr)),
-					fault.Public("The configured Git branch could not be resolved. Please check your branch settings."),
-				)
-			}
-			commitSHA = info.SHA
-
-			resolveErr = restate.RunVoid(ctx, func(runCtx restate.RunContext) error {
-				return db.Query.UpdateDeploymentGitMetadata(runCtx, w.db.RW(), db.UpdateDeploymentGitMetadataParams{
-					ID:                       deployment.ID,
-					GitCommitSha:             sql.NullString{String: info.SHA, Valid: true},
-					GitBranch:                sql.NullString{String: source.Git.GetBranch(), Valid: true},
-					GitCommitMessage:         sql.NullString{String: info.Message, Valid: info.Message != ""},
-					GitCommitAuthorHandle:    sql.NullString{String: info.AuthorHandle, Valid: info.AuthorHandle != ""},
-					GitCommitAuthorAvatarUrl: sql.NullString{String: info.AuthorAvatarURL, Valid: info.AuthorAvatarURL != ""},
-					GitCommitTimestamp:       sql.NullInt64{Int64: info.Timestamp.UnixMilli(), Valid: !info.Timestamp.IsZero()},
-					UpdatedAt:                sql.NullInt64{Valid: true, Int64: time.Now().UnixMilli()},
-				})
-			}, restate.WithName("update deployment git metadata"), restate.WithMaxRetryAttempts(runMaxAttempts))
-			if resolveErr != nil {
-				return fault.Wrap(
-					fmt.Errorf("failed to update deployment git metadata: %w", resolveErr),
-					fault.Public("The commit was resolved but metadata could not be saved."),
-				)
-			}
-
-			deployment.GitCommitSha = sql.NullString{String: info.SHA, Valid: true}
-			deployment.GitBranch = sql.NullString{String: source.Git.GetBranch(), Valid: true}
-			deployment.GitCommitMessage = sql.NullString{String: info.Message, Valid: info.Message != ""}
-			deployment.GitCommitAuthorHandle = sql.NullString{String: info.AuthorHandle, Valid: info.AuthorHandle != ""}
-			deployment.GitCommitAuthorAvatarUrl = sql.NullString{String: info.AuthorAvatarURL, Valid: info.AuthorAvatarURL != ""}
-			deployment.GitCommitTimestamp = sql.NullInt64{Int64: info.Timestamp.UnixMilli(), Valid: !info.Timestamp.IsZero()}
-		}
-
-		// When a SHA is known (either provided directly or just resolved from branch)
-		// but the deployment record is still missing git metadata, fetch it from GitHub.
-		hasGitHubAuth := !w.allowUnauthenticatedDeployments || source.Git.GetInstallationId() != noInstallationID
-		if commitSHA != "" && !deployment.GitCommitMessage.Valid && hasGitHubAuth {
-			info, resolveErr := restate.Run(ctx, func(runCtx restate.RunContext) (githubclient.CommitInfo, error) {
-				return w.github.GetCommitBySHA(
-					source.Git.GetInstallationId(),
-					source.Git.GetRepository(),
-					commitSHA,
-				)
-			}, restate.WithName("resolve commit metadata by sha"), restate.WithMaxRetryAttempts(runMaxAttempts))
-			if resolveErr != nil {
-				return fault.Wrap(
-					fmt.Errorf("failed to resolve metadata for commit %q: %w", commitSHA, resolveErr),
-					fault.Public("Could not retrieve commit information from GitHub."),
-				)
-			}
-
-			resolveErr = restate.RunVoid(ctx, func(runCtx restate.RunContext) error {
-				return db.Query.UpdateDeploymentGitMetadata(runCtx, w.db.RW(), db.UpdateDeploymentGitMetadataParams{
-					ID:                       deployment.ID,
-					GitCommitSha:             sql.NullString{String: info.SHA, Valid: true},
-					GitBranch:                deployment.GitBranch,
-					GitCommitMessage:         sql.NullString{String: info.Message, Valid: info.Message != ""},
-					GitCommitAuthorHandle:    sql.NullString{String: info.AuthorHandle, Valid: info.AuthorHandle != ""},
-					GitCommitAuthorAvatarUrl: sql.NullString{String: info.AuthorAvatarURL, Valid: info.AuthorAvatarURL != ""},
-					GitCommitTimestamp:       sql.NullInt64{Int64: info.Timestamp.UnixMilli(), Valid: !info.Timestamp.IsZero()},
-					UpdatedAt:                sql.NullInt64{Valid: true, Int64: time.Now().UnixMilli()},
-				})
-			}, restate.WithName("update deployment git metadata for sha"), restate.WithMaxRetryAttempts(runMaxAttempts))
-			if resolveErr != nil {
-				return fault.Wrap(
-					fmt.Errorf("failed to update deployment git metadata: %w", resolveErr),
-					fault.Public("The commit was resolved but metadata could not be saved."),
-				)
-			}
+		if commitSHA == "" {
+			return fault.Wrap(
+				restate.TerminalError(fmt.Errorf("git source missing commit SHA for deployment %q", deployment.ID)),
+				fault.Public("Deployment has no resolved commit; cannot build."),
+			)
 		}
 
 		build, err := w.buildDockerImageFromGit(ctx, gitBuildParams{

--- a/web/apps/dashboard/lib/trpc/routers/deploy/deployment/redeploy.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/deployment/redeploy.ts
@@ -45,16 +45,25 @@ export const redeploy = workspaceProcedure
         });
       }
 
+      // Source type is determined by whether the app has a GitHub repo
+      // connection, not by commit metadata on the deployment row — docker
+      // redeploys carry forward git metadata from the previous deployment
+      // and would otherwise be misclassified as git-sourced.
+      const repoConnection = await db.query.githubRepoConnections.findFirst({
+        where: (table, { eq }) => eq(table.appId, deployment.appId),
+        columns: { appId: true },
+      });
+      const isGitSourced = repoConnection != null;
+
       const result = await ctrl
         .createDeployment({
           projectId: deployment.project.id,
           appId: deployment.appId,
           environmentSlug: deployment.environment?.slug ?? "",
-          dockerImage: deployment.image ?? "",
-          ...(deployment.gitCommitSha
+          ...(isGitSourced
             ? {
                 gitCommit: {
-                  commitSha: deployment.gitCommitSha,
+                  commitSha: deployment.gitCommitSha ?? "",
                   branch: deployment.gitBranch ?? "",
                   commitMessage: deployment.gitCommitMessage ?? "",
                   authorHandle: deployment.gitCommitAuthorHandle ?? "",
@@ -62,7 +71,7 @@ export const redeploy = workspaceProcedure
                   timestamp: BigInt(deployment.gitCommitTimestamp ?? 0),
                 },
               }
-            : {}),
+            : { dockerImage: deployment.image ?? "" }),
         })
         .catch((err) => {
           console.error(err);


### PR DESCRIPTION
## What does this PR do?

Moves git commit metadata resolution (branch→SHA lookup and SHA→metadata lookup) from the async Restate worker into `CreateDeployment`, so the deployment row is fully populated at insert time rather than being backfilled mid-workflow.

Previously, `buildImage` in the Restate worker was responsible for resolving a branch to a SHA and fetching commit metadata when fields were missing. This meant the deployment row could exist in a partially-populated state until the worker ran. Now, `CreateDeployment` performs these lookups synchronously before inserting the row, using the new `commitFields.fillFromGitHub` method. The worker's `buildImage` now treats a missing commit SHA as a terminal error rather than attempting to resolve it.

A new `commitFields` struct consolidates the six git metadata fields that were previously scattered as individual variables, and `dockerSourceInfo` embeds it. The `buildDockerSource` helper and the deployment insert both use this struct.

The `AllowUnauthenticatedDeployments` config flag (previously only wired into the worker) is now also threaded into the deployment service so `fillFromGitHub` can use the public GitHub API path for local development against public repositories.

The dashboard redeploy handler is updated to correctly distinguish git-sourced deployments (those with a commit SHA or branch) from docker-image-only deployments, so that git-sourced redeployments trigger a fresh build from the same commit rather than passing a docker image reference.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [x] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Trigger a deployment for a git-connected app without providing a commit SHA (e.g. branch-only). Verify the deployment row has a fully populated SHA, message, author handle, avatar URL, and timestamp immediately after creation, before the Restate worker runs.
- Trigger a deployment for a git-connected app with a commit SHA but no message. Verify the message and author fields are populated at insert time.
- Trigger a redeploy from the dashboard for a git-sourced deployment. Verify it initiates a fresh git build rather than reusing the docker image.
- Trigger a redeploy from the dashboard for a non-git deployment (docker image only). Verify it reuses the existing docker image.
- With `allow_unauthenticated_deployments = true` in config, trigger a deployment against a public repository. Verify the public GitHub API path is used and metadata is resolved correctly.

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary