### PR TITLE
fix(dashboard): revoke WorkOS session on logout

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/sentinel-policies/components/add-panel/forms/summary-helpers.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/sentinel-policies/components/add-panel/forms/summary-helpers.tsx
@@ -7,7 +7,10 @@ export const Strong = ({ children, className }: { children: ReactNode; className
 
 export const Sep = () => <span className="text-gray-9 mx-1.5">·</span>;
 
-export const DocsLink = ({ href, children = "Read more" }: { href: string; children?: ReactNode }) => (
+export const DocsLink = ({
+  href,
+  children = "Read more",
+}: { href: string; children?: ReactNode }) => (
   <a href={href} target="_blank" rel="noopener noreferrer">
     <span className="font-medium text-gray-12 underline underline-offset-2 decoration-grayA-6 hover:decoration-gray-12 transition-colors decoration-dotted">
       {children}

--- a/web/apps/dashboard/lib/auth/base-provider.ts
+++ b/web/apps/dashboard/lib/auth/base-provider.ts
@@ -113,6 +113,14 @@ export abstract class BaseAuthProvider {
   abstract getSignOutUrl(): Promise<string | null>;
 
   /**
+   * Revokes a session so it can no longer be refreshed or authenticated,
+   * even if the sealed cookie is replayed.
+   *
+   * @param sessionToken - The sealed session token to revoke
+   */
+  abstract revokeSession(sessionToken: string): Promise<void>;
+
+  /**
    * Completes the organization selection process during authentication.
    *
    * @param params - Parameters containing the selected organization ID and pending auth token

--- a/web/apps/dashboard/lib/auth/local.ts
+++ b/web/apps/dashboard/lib/auth/local.ts
@@ -467,6 +467,10 @@ export class LocalAuthProvider extends BaseAuthProvider {
     return "/auth/sign-in";
   }
 
+  async revokeSession(_sessionToken: string): Promise<void> {
+    // No-op: local provider has no server-side session to revoke.
+  }
+
   // OAuth Methods
   signInViaOAuth(options: SignInViaOAuthOptions): string {
     return options.redirectUrlComplete;

--- a/web/apps/dashboard/lib/auth/utils.ts
+++ b/web/apps/dashboard/lib/auth/utils.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { redirect } from "next/navigation";
-import { deleteCookie } from "./cookies";
+import { deleteCookie, getCookie } from "./cookies";
 import { auth } from "./server";
 import { UNKEY_SESSION_COOKIE } from "./types";
 
@@ -23,7 +23,10 @@ export async function requireEmailMatch(params: {
 
 // Sign Out
 export async function signOut(): Promise<void> {
-  //const signOutUrl = await auth.getSignOutUrl();
+  const sessionToken = await getCookie(UNKEY_SESSION_COOKIE);
+  if (sessionToken) {
+    await auth.revokeSession(sessionToken);
+  }
   await deleteCookie(UNKEY_SESSION_COOKIE);
   redirect("/auth/sign-in");
 }

--- a/web/apps/dashboard/lib/auth/workos.ts
+++ b/web/apps/dashboard/lib/auth/workos.ts
@@ -903,6 +903,30 @@ export class WorkOSAuthProvider extends BaseAuthProvider {
     }
   }
 
+  async revokeSession(sessionToken: string): Promise<void> {
+    if (!sessionToken) {
+      return;
+    }
+
+    try {
+      const session = this.provider.userManagement.loadSealedSession({
+        sessionData: sessionToken,
+        cookiePassword: this.cookiePassword,
+      });
+
+      const authResult = await session.authenticate();
+      if (!authResult.authenticated) {
+        return;
+      }
+
+      await this.provider.userManagement.revokeSession({
+        sessionId: authResult.sessionId,
+      });
+    } catch (_error) {
+      // Swallow revoke failures so logout can always complete client-side.
+    }
+  }
+
   // OAuth Methods
   signInViaOAuth(options: SignInViaOAuthOptions): string {
     const { provider, redirectUrlComplete } = options;


### PR DESCRIPTION
## What does this PR do?

  ## Summary
Previously, signing out of the dashboard only cleared the local session cookie — the underlying WorkOS session stayed active on the server. That meant a leaked or exfiltrated session cookie could still be replayed after a user hit "Sign out", which is not what users reasonably expect from logout.

This change wires up proper server-side revocation. `signOut` now reads the session cookie, calls a new `auth.revokeSession(token)` before deleting the cookie, and then redirects to `/auth/sign-in`. The WorkOS provider implements `revokeSession` by loading the sealed session, authenticating it to extract the `sessionId`, and calling `userManagement.revokeSession`; errors are swallowed so the client-side logout always completes even if the token is already expired or the API call fails. The local auth provider implements it as a no-op since it has no server-side session to revoke.

Fixes # (issue)

_If there is not an issue for this, please create one first. This is used to tracking purposes and also helps us understand why this PR exists_

<!-- If there isn't an issue for this PR, please re-review our Contributing Guide and create an issue -->

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

  ## Test plan
  - [ ] Sign in via WorkOS, sign out, confirm session appears revoked in the WorkOS dashboard in the staging environment

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [X] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary
