### PR TITLE
chore(dashboard): remove deployments beta flag

### DIFF
--- a/cmd/dev/seed/local.go
+++ b/cmd/dev/seed/local.go
@@ -102,7 +102,7 @@ func seedLocal(ctx context.Context, cmd *cli.Command) error {
 				Slug:         slug,
 				CreatedAtM:   now,
 				Tier:         sql.NullString{String: "Free", Valid: true},
-				BetaFeatures: json.RawMessage(`{"deployments":true}`),
+				BetaFeatures: json.RawMessage(`{}`),
 			},
 			{
 				ID:           rootWorkspaceID,

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/new/page.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/new/page.tsx
@@ -1,25 +1,10 @@
 "use server";
 
 import { LoadingState } from "@/components/loading-state";
-import { getAuth } from "@/lib/auth";
-import { db } from "@/lib/db";
-import { notFound } from "next/navigation";
 import { Suspense } from "react";
 import { Onboarding } from "./index";
 
 export default async function OnboardingPage() {
-  const { orgId } = await getAuth();
-  const workspace = await db.query.workspaces.findFirst({
-    where: (table, { and, eq, isNull }) => and(eq(table.orgId, orgId), isNull(table.deletedAtM)),
-  });
-
-  if (!workspace?.betaFeatures?.deployments) {
-    // right now, we want to block all external access to deploy
-    // to make it easier to opt-in for local development, comment out the redirect
-    // and uncomment the <OptIn> component
-    //return redirect("/apis");
-    return notFound();
-  }
   return (
     <Suspense fallback={<LoadingState message="Loading projects onboarding..." />}>
       <Onboarding />

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/page.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/page.tsx
@@ -1,24 +1,9 @@
 "use server";
 import { LoadingState } from "@/components/loading-state";
-import { getAuth } from "@/lib/auth";
-import { db } from "@/lib/db";
-import { notFound } from "next/navigation";
 import { Suspense } from "react";
 import { ProjectsClient } from "./projects-client";
 
 export default async function ProjectsPage() {
-  const { orgId } = await getAuth();
-  const workspace = await db.query.workspaces.findFirst({
-    where: (table, { and, eq, isNull }) => and(eq(table.orgId, orgId), isNull(table.deletedAtM)),
-  });
-
-  if (!workspace?.betaFeatures?.deployments) {
-    // right now, we want to block all external access to deploy
-    // to make it easier to opt-in for local development, comment out the redirect
-    // and uncomment the <OptIn> component
-    //return redirect("/apis");
-    return notFound();
-  }
   return (
     <Suspense fallback={<LoadingState message="Loading projects..." />}>
       <ProjectsClient />

--- a/web/apps/dashboard/components/navigation/sidebar/app-sidebar/index.tsx
+++ b/web/apps/dashboard/components/navigation/sidebar/app-sidebar/index.tsx
@@ -120,7 +120,7 @@ export function AppSidebar({
             isCollapsed ? "justify-center" : "items-center justify-between gap-4",
           )}
         >
-          <ProductSwitcher workspace={props.workspace} currentProduct={currentProduct} />
+          <ProductSwitcher currentProduct={currentProduct} />
           {!isCollapsed && !isMobile && (
             <button type="button" onClick={toggleSidebar} aria-label="Collapse sidebar">
               <SidebarLeftHide className="text-gray-8" iconSize="xl-medium" />
@@ -138,15 +138,7 @@ export function AppSidebar({
         )}
       </div>
     ),
-    [
-      isCollapsed,
-      isMobile,
-      toggleSidebar,
-      context,
-      props.workspace,
-      currentProduct,
-      fetchedResourceName,
-    ],
+    [isCollapsed, isMobile, toggleSidebar, context, currentProduct, fetchedResourceName],
   );
 
   return (

--- a/web/apps/dashboard/components/navigation/sidebar/product-switcher.tsx
+++ b/web/apps/dashboard/components/navigation/sidebar/product-switcher.tsx
@@ -9,7 +9,6 @@ import {
 import { useSidebar } from "@/components/ui/sidebar";
 import type { Product } from "@/hooks/use-product-selection";
 import { useProductSelection } from "@/hooks/use-product-selection";
-import type { Workspace } from "@/lib/db";
 import { cn } from "@/lib/utils";
 import type { IconProps } from "@unkey/icons";
 import { Check, ChevronExpandY, CloudUp, Nodes } from "@unkey/icons";
@@ -22,18 +21,13 @@ interface ProductConfig {
   name: string;
   description: string;
   icon: React.ComponentType<IconProps>;
-  disabled: boolean;
 }
 
 interface ProductSwitcherProps {
-  workspace: Workspace;
   currentProduct: Product;
 }
 
-export const ProductSwitcher: React.FC<ProductSwitcherProps> = ({
-  workspace,
-  currentProduct: product,
-}) => {
+export const ProductSwitcher: React.FC<ProductSwitcherProps> = ({ currentProduct: product }) => {
   const { isMobile, state } = useSidebar();
   const { switchProduct } = useProductSelection();
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
@@ -47,14 +41,12 @@ export const ProductSwitcher: React.FC<ProductSwitcherProps> = ({
       name: "API Management",
       description: "Manage APIs and keys",
       icon: Nodes,
-      disabled: false,
     },
     {
       id: "deploy",
       name: "Deploy",
       description: "Deploy applications",
       icon: CloudUp,
-      disabled: !workspace.betaFeatures?.deployments,
     },
   ];
 
@@ -111,7 +103,6 @@ export const ProductSwitcher: React.FC<ProductSwitcherProps> = ({
               "flex items-center justify-between gap-2.5 p-2.5 cursor-pointer hover:bg-grayA-3",
               isSelected && "bg-grayA-2",
             )}
-            disabled={prod.disabled}
             onClick={() => {
               switchProduct(prod.id);
             }}
@@ -130,11 +121,7 @@ export const ProductSwitcher: React.FC<ProductSwitcherProps> = ({
                 >
                   {prod.name}
                 </span>
-                {prod.disabled ? (
-                  <span className="text-xs text-warning-10">In Private Beta</span>
-                ) : (
-                  <span className="text-xs text-gray-11">{prod.description}</span>
-                )}
+                <span className="text-xs text-gray-11">{prod.description}</span>
               </div>
             </div>
             {isSelected && <Check className="w-4 h-4 text-accent-11" iconSize="sm-medium" />}

--- a/web/apps/dashboard/hooks/use-navigation-context.ts
+++ b/web/apps/dashboard/hooks/use-navigation-context.ts
@@ -3,7 +3,6 @@
 import { useParams, useSelectedLayoutSegments } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 import { STORAGE_EVENT, STORAGE_KEY, getCurrentProduct } from "./use-product-selection";
-import { useWorkspaceNavigation } from "./use-workspace-navigation";
 
 export type NavigationContext =
   | { type: "product"; product: "api-management" | "deploy" }
@@ -41,7 +40,6 @@ function getParamSingle(
  * Hook to detect the current navigation context based on route params and segments.
  * Extracts resource name from URL segments when available.
  * Uses product selection state to maintain context on workspace-level routes.
- * Respects workspace feature flags - won't detect Deploy product if feature is disabled.
  *
  * Returns either:
  * - Product-level context: User is viewing a product (API Management or Deploy)
@@ -50,7 +48,6 @@ function getParamSingle(
 export function useNavigationContext(): NavigationContext {
   const segments = useSelectedLayoutSegments();
   const params = useParams();
-  const workspace = useWorkspaceNavigation();
 
   // Track localStorage changes via custom event
   const [storageVersion, setStorageVersion] = useState(0);
@@ -79,7 +76,7 @@ export function useNavigationContext(): NavigationContext {
       productSegment.startsWith("domain") ||
       productSegment.startsWith("environment-variable");
 
-    if (isDeploySegment && workspace.betaFeatures?.deployments === true) {
+    if (isDeploySegment) {
       return "deploy";
     }
 
@@ -96,7 +93,7 @@ export function useNavigationContext(): NavigationContext {
     }
 
     return null;
-  }, [segments, workspace.betaFeatures?.deployments]);
+  }, [segments]);
 
   // Update localStorage ONLY when we detect a product from the URL
   // This ensures we don't change the product context when it's ambiguous

--- a/web/apps/dashboard/lib/trpc/routers/workspace/optIntoBeta.ts
+++ b/web/apps/dashboard/lib/trpc/routers/workspace/optIntoBeta.ts
@@ -8,7 +8,7 @@ import { workspaceProcedure } from "../../trpc";
 export const optWorkspaceIntoBeta = workspaceProcedure
   .input(
     z.object({
-      feature: z.enum(["rbac", "ratelimit", "identities", "logsPage", "deployments", "portal"]),
+      feature: z.enum(["rbac", "ratelimit", "identities", "logsPage", "portal"]),
     }),
   )
   .mutation(async ({ ctx, input }) => {
@@ -19,10 +19,6 @@ export const optWorkspaceIntoBeta = workspaceProcedure
       }
       case "identities": {
         ctx.workspace.betaFeatures.identities = true;
-        break;
-      }
-      case "deployments": {
-        ctx.workspace.betaFeatures.deployments = true;
         break;
       }
       case "portal": {

--- a/web/internal/db/src/schema/workspaces.ts
+++ b/web/internal/db/src/schema/workspaces.ts
@@ -49,12 +49,6 @@ export const workspaces = mysqlTable("workspaces", {
       identities?: boolean;
 
       /**
-       * Can access /projects
-       */
-
-      deployments?: boolean;
-
-      /**
        * Can access customer billing portal
        */
       portal?: boolean;


### PR DESCRIPTION
## Summary
- Removes the `betaFeatures.deployments` gate so Deploy is available to every workspace.
- Strips the flag from the projects pages, product switcher, navigation context hook, opt-in router, workspace schema type, and local dev seed.
- No DB migration: the JSON column keeps its other fields (`rbac`, `identities`, `portal`); stale `deployments: true` values in existing rows are simply ignored.

## Out of scope
- `docs/product/snippets/deploy-beta.mdx` still says Deploy is in private beta — reused across ~20 customer docs pages, so flipping it is a separate product/marketing call.
- "During beta, X is limited…" copy in runtime settings (CPU/memory/storage/instances) describes ongoing resource caps, not the access gate.

## Test plan
- [ ] `tsc` clean on dashboard
- [ ] `biome check` clean on changed files
- [ ] `go build ./cmd/dev/seed/` clean
- [ ] Log in with a workspace that has no `betaFeatures.deployments` flag and confirm `/projects` and `/projects/new` load
- [ ] Confirm the Deploy entry in the sidebar product switcher is selectable (no "In Private Beta" label)