### PR TITLE
fix: Root Key permissions not scrollable in permission sheet

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/root-keys/components/dialog/components/permission-sheet.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/root-keys/components/dialog/components/permission-sheet.tsx
@@ -78,7 +78,7 @@ export const PermissionSheet = ({
           <div className="w-full h-full">
             <div className="flex flex-col h-full">
               <div
-                className={`flex flex-col ${
+                className={`flex flex-col overflow-hidden ${
                   hasNextPage ? "max-h-[calc(100%-80px)]" : "max-h-[calc(100%-40px)]"
                 }`}
               >


### PR DESCRIPTION
## Summary

Fixes #5105

When a user expands enough permissions in the Root Key permission sheet, the content overflows the container without providing a scrollbar, making it impossible to scroll through all permissions.

## Problem

The `ScrollArea` component in `permission-sheet.tsx` relies on its parent container having a constrained height with `overflow-hidden`. The parent div used `max-h-[calc(...)]` but lacked `overflow-hidden`, so the `ScrollArea` would grow indefinitely with its content instead of becoming scrollable.

## Fix

Added `overflow-hidden` to the permissions container div in `permission-sheet.tsx`. This constrains the `ScrollArea` to the `max-h` boundary, allowing it to properly display a scrollbar when content overflows.

## Testing

1. Navigate to Root Keys settings
2. Click "Select Permissions" to open the permission sheet
3. Expand multiple permission categories
4. Verify that the permission list scrolls properly