### PR TITLE
chore: lower default cache retention

### DIFF
--- a/svc/ctrl/worker/deploy/build.go
+++ b/svc/ctrl/worker/deploy/build.go
@@ -37,11 +37,11 @@ import (
 const (
 	// defaultCacheKeepGB is the maximum cache size in gigabytes for new Depot
 	// projects. Depot evicts least-recently-used cache entries when exceeded.
-	defaultCacheKeepGB = 50
+	defaultCacheKeepGB = 25
 
 	// defaultCacheKeepDays is the maximum age in days for cached build layers.
 	// Layers older than this are evicted regardless of cache size.
-	defaultCacheKeepDays = 14
+	defaultCacheKeepDays = 7
 )
 
 // knownBuildError maps a BuildKit error pattern to a user-friendly message.


### PR DESCRIPTION
## What does this PR do?

Reduces the default Depot build cache limits for new projects. The maximum cache size has been halved from 50GB to 25GB, and the maximum cache retention period has been reduced from 14 days to 7 days.

Fixes # (issue)

_If there is not an issue for this, please create one first. This is used to tracking purposes and also helps us understand why this PR exists_

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Verify that new Depot projects are created with a 25GB cache limit instead of 50GB
- Verify that cached build layers older than 7 days are evicted correctly

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary