### PR TITLE
feat(dashboard): use "Dashboard | Unkey" as page title

### DIFF
--- a/web/apps/dashboard/app/layout.tsx
+++ b/web/apps/dashboard/app/layout.tsx
@@ -16,10 +16,10 @@ import { ThemeProvider } from "./theme-provider";
 export function generateMetadata(): Metadata {
   return {
     metadataBase: new URL("https://unkey.dev"),
-    title: "Open Source API Authentication",
+    title: "Dashboard | Unkey",
     description: "Build better APIs faster",
     openGraph: {
-      title: "Open Source API Authentication",
+      title: "Dashboard | Unkey",
       description: "Build better APIs faster ",
       url: "https://app.unkey.com",
       siteName: "app.unkey.com",


### PR DESCRIPTION
## Summary
- Replace `Open Source API Authentication` with `Dashboard | Unkey` in root metadata (title + openGraph).

Closes DES-33.

## Test plan
- [ ] Load dashboard, confirm browser tab reads `Dashboard | Unkey`.