### PR TITLE
fix: properly constrain ScrollArea height in permission sheet

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/root-keys/components/dialog/components/permission-sheet.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/root-keys/components/dialog/components/permission-sheet.tsx
@@ -78,7 +78,7 @@ export const PermissionSheet = ({
           <div className="w-full h-full">
             <div className="flex flex-col h-full">
               <div
-                className={`flex flex-col ${
+                className={`flex flex-col overflow-hidden ${
                   hasNextPage ? "max-h-[calc(100%-80px)]" : "max-h-[calc(100%-40px)]"
                 }`}
               >

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/root-keys/components/dialog/components/permission-sheet.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/root-keys/components/dialog/components/permission-sheet.tsx
@@ -62,11 +62,11 @@ export const PermissionSheet = ({
         <SheetOverlay className="bg-black/30 backdrop-blur-xs" />
         <SheetContent
           disableClose={false}
-          className="flex flex-col p-0 m-0 h-full gap-0 border-l border-l-gray-4 w-[420px] bg-gray-1 dark:bg-black"
+          className="flex flex-col overflow-hidden p-0 m-0 h-full gap-0 border-l border-l-gray-4 w-[420px] bg-gray-1 dark:bg-black"
           side="right"
           overlay="transparent"
         >
-          <SheetHeader className="flex flex-row min-w-full border-b border-gray-4 gap-2 ">
+          <SheetHeader className="flex flex-row shrink-0 min-w-full border-b border-gray-4 gap-2">
             <SheetTitle className="sr-only">Select Permissions</SheetTitle>
             <SearchPermissions
               isProcessing={isProcessing}
@@ -75,71 +75,61 @@ export const PermissionSheet = ({
               onChange={handleSearchChange}
             />
           </SheetHeader>
-          <div className="w-full flex-1 min-h-0">
-            <div className="flex flex-col h-full">
-              <div
-                className={`flex flex-col overflow-hidden flex-1 min-h-0 ${
-                  hasNextPage ? "max-h-[calc(100%-80px)]" : "max-h-[calc(100%-40px)]"
-                }`}
-              >
-                <ScrollArea className="flex flex-col h-full pt-2">
-                  <div className="flex flex-col pt-0 mt-0 gap-1 pb-6">
-                    {hasNoResults ? (
-                      <p className="text-sm text-gray-10 ml-6 py-1.5 mt-1.5">
-                        {ROOT_KEY_MESSAGES.UI.NO_RESULTS}
+          <div className="flex flex-col flex-1 min-h-0 overflow-hidden">
+            <ScrollArea className="flex-1 min-h-0 pt-2">
+              <div className="flex flex-col pt-0 mt-0 gap-1 pb-6">
+                {hasNoResults ? (
+                  <p className="text-sm text-gray-10 ml-6 py-1.5 mt-1.5">
+                    {ROOT_KEY_MESSAGES.UI.NO_RESULTS}
+                  </p>
+                ) : (
+                  <>
+                    <PermissionContentList
+                      selected={selectedPermissions}
+                      searchValue={searchValue}
+                      key="workspace"
+                      type="workspace"
+                      onPermissionChange={handleWorkspacePermissionChange}
+                    />
+                    {apis.length > 0 && (
+                      <p className="text-sm text-gray-10 ml-6 py-1.5 mb-2">
+                        {ROOT_KEY_MESSAGES.UI.FROM_APIS}
                       </p>
-                    ) : (
-                      <>
-                        {/* Workspace Permissions */}
-                        <PermissionContentList
-                          selected={selectedPermissions}
-                          searchValue={searchValue}
-                          key="workspace"
-                          type="workspace"
-                          onPermissionChange={handleWorkspacePermissionChange}
-                        />
-                        {/* From APIs */}
-                        {apis.length > 0 && (
-                          <p className="text-sm text-gray-10 ml-6 py-1.5 mb-2">
-                            {ROOT_KEY_MESSAGES.UI.FROM_APIS}
-                          </p>
-                        )}
-                        {apis.map((api) => (
-                          <PermissionContentList
-                            selected={selectedPermissions}
-                            searchValue={searchValue}
-                            key={api.id}
-                            type="api"
-                            api={api}
-                            onPermissionChange={(permissions) =>
-                              handleApiPermissionChange(api.id, permissions)
-                            }
-                          />
-                        ))}
-                      </>
                     )}
-                  </div>
-                </ScrollArea>
+                    {apis.map((api) => (
+                      <PermissionContentList
+                        selected={selectedPermissions}
+                        searchValue={searchValue}
+                        key={api.id}
+                        type="api"
+                        api={api}
+                        onPermissionChange={(permissions) =>
+                          handleApiPermissionChange(api.id, permissions)
+                        }
+                      />
+                    ))}
+                  </>
+                )}
               </div>
-              <div className="sticky bottom-0 bg-background border-t border-gray-4 mt-auto">
-                {hasNextPage ? (
-                  <div className="w-full py-4">
-                    <div className="flex flex-row justify-center items-center">
-                      <Button
-                        className="mx-auto rounded-lg"
-                        size="sm"
-                        onClick={() => loadMore?.()}
-                        disabled={!hasNextPage || !loadMore}
-                        loading={isFetchingNextPage}
-                      >
-                        {ROOT_KEY_MESSAGES.UI.LOAD_MORE}
-                      </Button>
-                    </div>
-                  </div>
-                ) : undefined}
+            </ScrollArea>
+          </div>
+          {hasNextPage && (
+            <div className="shrink-0 bg-background border-t border-gray-4">
+              <div className="w-full py-4">
+                <div className="flex flex-row justify-center items-center">
+                  <Button
+                    className="mx-auto rounded-lg"
+                    size="sm"
+                    onClick={() => loadMore?.()}
+                    disabled={!hasNextPage || !loadMore}
+                    loading={isFetchingNextPage}
+                  >
+                    {ROOT_KEY_MESSAGES.UI.LOAD_MORE}
+                  </Button>
+                </div>
               </div>
             </div>
-          </div>
+          )}
         </SheetContent>
       </SheetPortal>
     </Sheet>

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/root-keys/components/dialog/components/permission-sheet.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/root-keys/components/dialog/components/permission-sheet.tsx
@@ -75,10 +75,10 @@ export const PermissionSheet = ({
               onChange={handleSearchChange}
             />
           </SheetHeader>
-          <div className="w-full h-full">
+          <div className="w-full flex-1 min-h-0">
             <div className="flex flex-col h-full">
               <div
-                className={`flex flex-col overflow-hidden ${
+                className={`flex flex-col overflow-hidden flex-1 min-h-0 ${
                   hasNextPage ? "max-h-[calc(100%-80px)]" : "max-h-[calc(100%-40px)]"
                 }`}
               >


### PR DESCRIPTION
Fixes #5105

## Problem
When a user expands enough permissions in the Root Key permission sheet, the content overflows without scrolling.

## Root Cause
The `ScrollArea` was inside wrapper divs with conflicting height properties. The height chain from `SheetContent` → `ScrollArea` was broken — the `ScrollArea` never received a bounded height because flex items default to `min-height: auto` (content size).

## Fix
Simplified to a 3-part flex column:
- **SheetContent**: `flex flex-col overflow-hidden h-full` — constrains to viewport
- **SheetHeader**: `shrink-0` — fixed header
- **Wrapper div**: `flex flex-col flex-1 min-h-0 overflow-hidden` — takes remaining space
- **ScrollArea**: `flex-1 min-h-0` — fills bounded wrapper, enables scrolling
- **Footer**: `shrink-0` (conditional) — pinned bottom

The critical piece is `min-h-0` on the flex-1 container. Without it, flex items default to `min-height: auto` (content size), preventing the ScrollArea from ever shrinking below its content height.

Apologies for the previous attempt — the initial fix only added `overflow-hidden` which didn't address the root cause.