### PR TITLE
fix(dashboard): hide log section copy button when content is empty

### DIFF
--- a/web/apps/dashboard/components/logs/details/log-details/components/log-section.tsx
+++ b/web/apps/dashboard/components/logs/details/log-details/components/log-section.tsx
@@ -9,6 +9,8 @@ export const LogSection = ({
   details: LogSectionDetails;
   title: string;
 }) => {
+  const copyValue = getFormattedContent(details);
+
   return (
     <div className="flex flex-col gap-1 mt-[16px] px-4">
       <div className="border bg-gray-2 border-gray-4 rounded-[10px] relative group">
@@ -37,13 +39,15 @@ export const LogSection = ({
               : details}
           </pre>
         </div>
-        <CopyButton
-          value={getFormattedContent(details)}
-          shape="square"
-          variant="outline"
-          className="absolute bottom-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity rounded-md p-4 bg-gray-2 hover:bg-gray-2 size-2"
-          aria-label="Copy content"
-        />
+        {copyValue && (
+          <CopyButton
+            value={copyValue}
+            shape="square"
+            variant="outline"
+            className="absolute bottom-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity rounded-md p-4 bg-gray-2 hover:bg-gray-2 size-2"
+            aria-label="Copy content"
+          />
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- Closes #5462
- The deploy logs detail panel rendered a copy-to-clipboard button for every `LogSection`, but `getFormattedContent` returns `""` when `details` is a React node (which is what the "Log Information" and "Deployment Info" sections pass). Result: clicking the button copied nothing.
- Now the `CopyButton` only renders when there is actual text to copy. The "Attributes" section (which passes a JSON string) continues to have a working copy button.

## Test plan

- [ ] Open a deployment logs view, select a log, and confirm the "Log Information" and "Deployment Info" sections no longer show a copy button on hover.
- [ ] Confirm the "Attributes" section still shows the copy button and copies the JSON payload.