### PR TITLE
docs: announce Deploy public beta and add Dockerfile AI prompt

### DIFF
--- a/docs/product/builds/dockerfile-prompt.mdx
+++ b/docs/product/builds/dockerfile-prompt.mdx
@@ -1,0 +1,182 @@
+---
+title: Generate a Dockerfile with AI
+description: "Copy this prompt into Claude Code, Cursor, Windsurf, or any coding agent to generate a Dockerfile and .dockerignore for your app or monorepo that runs correctly on Unkey Deploy."
+---
+
+import DeployBeta from "/snippets/deploy-beta.mdx";
+
+<DeployBeta />
+
+If you're not comfortable writing a Dockerfile from scratch, hand the prompt below to a coding agent. It tells the agent to first inspect your repository and then produce a Dockerfile plus a `.dockerignore` that respect Unkey Deploy's runtime constraints (reading `PORT`, handling `SIGTERM`, a read-only root filesystem, build secrets via mount).
+
+## How to use it
+
+Open your repository in your coding agent of choice (Claude Code, Cursor, Windsurf, Codex, or similar), start a fresh conversation, and paste the prompt verbatim. The agent will ask clarifying questions if anything about your project is ambiguous (for example, which app in a monorepo you're deploying) before writing any files.
+
+Once the files land in your repo, push to the branch connected to your Unkey project. Review the [Dockerfile path](/platform/apps/settings#dockerfile) and [root directory](/platform/apps/settings#root-directory) settings in your app so the build picks the right context.
+
+## The prompt
+
+````
+You're helping create a Dockerfile for an application that will be deployed on
+Unkey Deploy (https://unkey.com/docs/build-and-deploy/overview). Before writing
+anything, inspect the repository so the Dockerfile matches how the app is
+actually built and run.
+
+## Rule: never assume, always ask
+
+If anything is ambiguous, stop and ask the user. Do not guess. This includes
+(but is not limited to):
+
+- Which app in a monorepo should be deployed.
+- Which Node/Python/Go/Bun/etc. version to target if the repo doesn't pin one.
+- Which package manager to use if multiple lockfiles exist.
+- Which command starts the app, if there are several plausible scripts.
+- Which port the app listens on, if it isn't clearly set from `PORT`.
+- Whether the build needs secrets, and which ones.
+- Whether the app writes to disk at runtime, and where.
+
+Ask one question at a time. Wait for the answer, then ask the next one.
+Batching several questions into a single message makes it hard for the user
+to answer each in detail, and they often miss or skip some. A wrong
+assumption here means the build succeeds but the deploy fails, and the user
+has to debug a running container to figure out why.
+
+## Step 1: Inspect the repo
+
+Identify:
+- Language and runtime version (Node.js, Bun, Python, Go, Rust, Java, etc.).
+- Package manager and lockfile (npm, pnpm, yarn, poetry, uv, pip, cargo, go mod).
+- Build tool and output directory (next, vite, tsc, esbuild, turbo, go build,
+  cargo build, etc.).
+- The start command and the port the app listens on. Check for `process.env.PORT`,
+  `os.getenv("PORT")`, config files, or framework defaults.
+- Monorepo tooling (pnpm/npm/yarn workspaces, Turborepo, Nx, Lerna, Cargo
+  workspaces, Go workspaces). If present, ask which app we're dockerizing and
+  figure out which internal packages it depends on.
+- Any existing Dockerfile or container config to preserve intent from.
+
+## Step 2: Respect Unkey Deploy's runtime constraints
+
+These are not general Docker guidance. The image will not run correctly without
+them.
+
+1. Listen on the `PORT` environment variable (default 8080). Unkey injects
+   `PORT` at startup. Do not hardcode a port.
+2. Handle `SIGTERM` for graceful shutdown. Use the exec form for `CMD`
+   (for example `CMD ["node", "dist/index.js"]`) so the app process is PID 1
+   and receives signals directly instead of a shell swallowing them.
+3. The root filesystem is read-only at runtime. The only writable paths are:
+   - `/tmp`: small, memory-backed scratch space.
+   - `/data`: available only if ephemeral storage is configured. The mount
+     path is exposed in the `UNKEY_EPHEMERAL_DISK_PATH` env var.
+   If the app or a library writes cache, lock, or socket files, point it at
+   `/tmp`. Do not write to `/app` or anywhere else.
+4. Build-time secrets come from a mounted file, never `ARG` or `ENV`. If the
+   build needs secrets (private package tokens, codegen against a real DB
+   URL), consume them like this:
+
+   RUN --mount=type=secret,id=env,target=/run/secrets/.env \
+       set -a && . /run/secrets/.env && set +a && \
+       <your build command>
+
+   `ARG` and `ENV` values are visible in `docker history` and leak into the
+   final image. Don't use them for secrets.
+
+## Step 3: Apply these best practices
+
+- Multi-stage build: one stage for dependencies and build, a minimal final
+  stage with only the runtime artifacts. Keeps the image small and keeps
+  build tools out of production.
+- Pin the base image to a specific version (for example `node:22-alpine`,
+  not `node:latest`).
+- Cache dependency installs. Copy only the manifest files (`package.json`,
+  lockfile, `go.mod`, `Cargo.toml`, etc.) first, install, then copy the rest
+  of the source. Reordering kills the cache.
+- Prefer slim or distroless base images when the runtime is compatible.
+- Run as a non-root user (`USER node`, `USER nobody`, or a dedicated user
+  you create). The read-only FS already blocks most damage; non-root is
+  cheap extra defense.
+- One foreground process. No supervisord, no `&`, no wrapper shell scripts
+  that background the app.
+
+## Step 4: Monorepo handling
+
+If the project is a monorepo:
+- Do not assume any folder convention. Monorepos put apps under `apps/`,
+  `packages/`, `services/`, `cmd/`, or anywhere else. Read the repo's own
+  workspace config (pnpm `workspace:`, npm/yarn `workspaces`, `turbo.json`,
+  `nx.json`, `go.work`, `Cargo.toml` workspace members) to find the real
+  paths. If more than one candidate fits what the user described, ask which
+  one to deploy.
+- Ship only the target app and its workspace dependencies. Use the
+  monorepo's pruning tool: `pnpm deploy`, `turbo prune`, Nx's `build
+  --prod`, or equivalent. Do not COPY the whole monorepo into the image.
+- Place the Dockerfile next to the app you're deploying (wherever that
+  actually lives in the repo), and keep the build context at the repo root
+  so workspace packages resolve correctly.
+- In the summary, tell the user the exact **Root directory** and
+  **Dockerfile** values to set in Unkey's app settings, using the real paths
+  you used.
+
+## Step 5: Write a .dockerignore
+
+Create a `.dockerignore` next to the Dockerfile's build context. Always exclude:
+
+.git
+.gitignore
+node_modules
+.next
+dist
+build
+out
+coverage
+.env
+.env.*
+*.log
+.DS_Store
+.vscode
+.idea
+README.md
+Dockerfile
+.dockerignore
+
+Add language- and framework-specific entries based on what you found (for
+example `target/` for Rust, `__pycache__/` and `.venv/` for Python, `vendor/`
+for Go if `go mod vendor` isn't used, `.turbo/` for Turborepo). A lean build
+context makes builds faster and prevents `.env` files or other local state
+from accidentally shipping in the image.
+
+## Output
+
+Produce:
+1. A `Dockerfile` at a path that matches the repo's real layout. Do not
+   invent a folder structure. Place it next to the app you're deploying.
+2. A matching `.dockerignore` at the correct build-context root.
+3. A short note listing the exact values to configure in Unkey's app
+   settings, using the real paths you used:
+   - Root directory
+   - Dockerfile path
+   - Port (if the app doesn't listen on 8080)
+   - Start command (only if the Dockerfile's `CMD` should be overridden at
+     the platform level; usually leave this empty)
+````
+
+## What to check before deploying
+
+After the agent finishes, skim the result for these specifics:
+
+The `CMD` instruction uses the exec form (JSON array, not a bare string), so your app receives `SIGTERM` directly when Unkey drains an instance. Any `RUN` step that needs a secret uses the `--mount=type=secret,id=env,target=/run/secrets/.env` pattern rather than `ARG` or `ENV`. Nothing in the `Dockerfile` or `.dockerignore` references a writable path other than `/tmp` or `/data`. The base image is pinned to a specific version and your final stage is slim enough that it doesn't carry the whole build toolchain.
+
+If any of those are wrong, ask the agent to fix them directly. The prompt is short enough to tweak and re-run if your project has an unusual shape.
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Builds" icon="hammer" href="/builds/overview">
+    How Unkey turns your Dockerfile into a container image, including build-time secrets and caching.
+  </Card>
+  <Card title="App settings" icon="gear" href="/platform/apps/settings">
+    Configure the Dockerfile path, root directory, port, and runtime options that pair with this Dockerfile.
+  </Card>
+</CardGroup>

--- a/docs/product/builds/overview.mdx
+++ b/docs/product/builds/overview.mdx
@@ -89,7 +89,7 @@ Docker's `ARG` and `ENV` instructions are stored in the image layer history. Any
 Each build runs on a dedicated 16-CPU, 32 GB machine isolated to your project. No build shares resources with another project.
 
 <Note>
-  During the beta, builds are limited to one at a time per workspace. If multiple pushes arrive while a build is running, they queue and run sequentially. Concurrent builds are planned for a future release.
+  By default, each workspace runs one build at a time. Additional pushes queue and run as the previous build finishes. This is a soft limit; contact [support@unkey.com](mailto:support@unkey.com) if you need a higher concurrency cap.
 </Note>
 
 ## Build caching

--- a/docs/product/docs.json
+++ b/docs/product/docs.json
@@ -212,6 +212,7 @@
               "build-and-deploy/deployments",
               "build-and-deploy/github",
               "builds/overview",
+              "builds/dockerfile-prompt",
               "environments/overview",
               "build-and-deploy/regions",
               "build-and-deploy/rollbacks",

--- a/docs/product/quickstart/deploy.mdx
+++ b/docs/product/quickstart/deploy.mdx
@@ -11,7 +11,7 @@ This guide walks you through deploying an application on Unkey for the first tim
 
 ## Prerequisites
 
-- An Unkey account with Deploy beta access
+- An Unkey account
 - A GitHub repository with a Dockerfile
 
 ## Create a project

--- a/docs/product/snippets/deploy-beta.mdx
+++ b/docs/product/snippets/deploy-beta.mdx
@@ -1,5 +1,7 @@
 <Info>
-  Unkey Deploy is currently in private beta. To get access, reach out on
-  [Discord](https://unkey.com/discord) or email
-  [support@unkey.com](mailto:support@unkey.com).
+  Unkey Deploy is in public beta. To try it, open the product switcher in the
+  top-left of the dashboard and select **Deploy**. During beta, deployed
+  resources are free. We're eager for feedback, so let us know what you think
+  on [Discord](https://unkey.com/discord), [X](https://x.com/unkeydev), or
+  email [support@unkey.com](mailto:support@unkey.com).
 </Info>


### PR DESCRIPTION
## Summary

Unkey Deploy is going from private beta to public beta today. This PR updates every doc that referenced the old invite-only state, refreshes one stale runtime note, and adds a dedicated page with a copy-pasteable AI prompt to help developers who aren't comfortable writing Dockerfiles from scratch.

### Beta status: private → public

**`docs/product/snippets/deploy-beta.mdx`** — the shared snippet that every Deploy doc imports.


### New page: Generate a Dockerfile with AI

**`docs/product/builds/dockerfile-prompt.mdx`** (new) + sidebar entry in `docs/product/docs.json`.

Many developers building on Unkey aren't fluent in Dockerfiles, which turns \"push and deploy\" into \"read Docker docs for an hour first.\" This page gives them a prompt they can paste into Claude Code, Cursor, Windsurf, Codex, or any coding agent to generate a Dockerfile and `.dockerignore` tailored to their project.

What the prompt tells the agent to do:

1. **Inspect the repo first.** Detect language, runtime version, package manager, build tool, start command, port, and monorepo tooling (pnpm/npm/yarn workspaces, Turborepo, Nx, Lerna, Cargo workspaces, Go workspaces). Don't assume a folder convention like `apps/` — read the actual workspace config.
2. **Never assume, always ask.** If anything is ambiguous (which app in a monorepo, runtime version, start command, port, build secrets, disk writes), stop and ask the user. Ask **one question at a time**, not batched, so users can answer each in detail.
3. **Respect Unkey Deploy's runtime constraints**, which are listed explicitly because they aren't general Docker guidance:
   - Listen on `PORT` (injected at startup; default 8080).
   - Handle `SIGTERM` via exec-form `CMD` so the app is PID 1.
   - Root filesystem is read-only; only `/tmp` and `/data` (via `UNKEY_EPHEMERAL_DISK_PATH`) are writable.
   - Build secrets come from `--mount=type=secret,id=env,target=/run/secrets/.env`, never `ARG` or `ENV` (which leak into `docker history`).
4. **Apply Docker best practices**: multi-stage, pinned base image, manifest-first COPY for cache efficiency, slim/distroless where possible, non-root user, single foreground process.
5. **Handle monorepos correctly**: use the repo's pruning tool (`pnpm deploy`, `turbo prune`, Nx `build --prod`) to ship only the target app plus its workspace deps; keep build context at the repo root so workspace packages resolve.
6. **Emit a `.dockerignore`** with a baseline exclude list plus language/framework additions.
7. **Output the exact Unkey app-settings values** the user should configure (Root directory, Dockerfile path, Port, Command) using the real paths used.

### Proof of concept

Tested end to end on our own marketing site before landing this.

- Marketing site PR generated with this prompt: https://github.com/unkeyed/marketing-site/pull/7
- Preview deployment of that PR (running on Unkey Deploy): https://marketing-site-git-experimenting-with-docker-ai-chronark.unkey.app/
- Full agent thread showing the inspection-and-ask flow: https://ampcode.com/threads/T-019dae97-7e57-76c8-8fe9-d3bebb1ebbc8

## Test plan

- [ ] Preview docs build renders the new \`builds/dockerfile-prompt\` page in the Build & Deploy sidebar group.
- [ ] The \`<DeployBeta />\` snippet renders the new public-beta copy on every page that imports it (sample a few: build-and-deploy/overview, builds/overview, observability/logs, networking/domains, quickstart/deploy).
- [ ] Quickstart prerequisites list no longer shows \"with Deploy beta access.\"
- [ ] Build concurrency note on \`builds/overview\` reads as the new soft-limit wording.
- [ ] The prompt code block copy-pastes cleanly (nested code fences render correctly in Mintlify).