### PR TITLE
fix(dashboard): remove broken Delete project menu item

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/_components/list/project-actions.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/_components/list/project-actions.tsx
@@ -2,7 +2,7 @@
 
 import { type MenuItem, TableActionPopover } from "@/components/logs/table-action.popover";
 import { useWorkspace } from "@/providers/workspace-provider";
-import { Clone, Cloud, Gear, Heart, Layers3, Trash } from "@unkey/icons";
+import { Clone, Cloud, Gear, Heart, Layers3 } from "@unkey/icons";
 
 import { toast } from "@unkey/ui";
 import type { AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime";
@@ -74,15 +74,6 @@ const getProjectActionItems = (
       id: "project-settings",
       label: "Project settings",
       icon: <Gear iconSize="md-medium" />,
-      onClick: () => {
-        router.push(`/${workspaceSlug}/projects/${projectId}/settings`);
-      },
-      divider: true,
-    },
-    {
-      id: "delete-project",
-      label: "Delete project",
-      icon: <Trash iconSize="md-medium" />,
       onClick: () => {
         router.push(`/${workspaceSlug}/projects/${projectId}/settings`);
       },


### PR DESCRIPTION
## Summary
- The **Delete project** action in a project's overflow menu routed to the settings page instead of starting a deletion.
- Remove the menu entry (and its now-unused `Trash` icon import). The working delete form on the project settings page is untouched.

Closes #5830

## Test plan
- [ ] Open a project's overflow menu in the projects list and confirm the **Delete project** entry is gone.
- [ ] Remaining entries (Add favorite, Copy project ID, View requests, View deployments, Project settings) still render and navigate correctly.
- [ ] Project settings page still exposes a working delete flow.