### PR TITLE
fix: remove readonly storage mentions

### DIFF
--- a/docs/product/builds/dockerfile-prompt.mdx
+++ b/docs/product/builds/dockerfile-prompt.mdx
@@ -7,7 +7,7 @@ import DeployBeta from "/snippets/deploy-beta.mdx";
 
 <DeployBeta />
 
-If you're not comfortable writing a Dockerfile from scratch, hand the prompt below to a coding agent. It tells the agent to first inspect your repository and then produce a Dockerfile plus a `.dockerignore` that respect Unkey Deploy's runtime constraints (reading `PORT`, handling `SIGTERM`, a read-only root filesystem, build secrets via mount).
+If you're not comfortable writing a Dockerfile from scratch, hand the prompt below to a coding agent. It tells the agent to first inspect your repository and then produce a Dockerfile plus a `.dockerignore` that respect Unkey Deploy's runtime constraints (reading `PORT`, handling `SIGTERM`, build secrets via mount).
 
 ## How to use it
 
@@ -66,12 +66,10 @@ them.
 2. Handle `SIGTERM` for graceful shutdown. Use the exec form for `CMD`
    (for example `CMD ["node", "dist/index.js"]`) so the app process is PID 1
    and receives signals directly instead of a shell swallowing them.
-3. The root filesystem is read-only at runtime. The only writable paths are:
-   - `/tmp`: small, memory-backed scratch space.
+3. Scratch and ephemeral storage:
+   - `/tmp`: small, memory-backed scratch space, always available.
    - `/data`: available only if ephemeral storage is configured. The mount
      path is exposed in the `UNKEY_EPHEMERAL_DISK_PATH` env var.
-   If the app or a library writes cache, lock, or socket files, point it at
-   `/tmp`. Do not write to `/app` or anywhere else.
 4. Build-time secrets come from a mounted file, never `ARG` or `ENV`. If the
    build needs secrets (private package tokens, codegen against a real DB
    URL), consume them like this:
@@ -95,8 +93,7 @@ them.
   of the source. Reordering kills the cache.
 - Prefer slim or distroless base images when the runtime is compatible.
 - Run as a non-root user (`USER node`, `USER nobody`, or a dedicated user
-  you create). The read-only FS already blocks most damage; non-root is
-  cheap extra defense.
+  you create). Non-root is cheap extra defense.
 - One foreground process. No supervisord, no `&`, no wrapper shell scripts
   that background the app.
 
@@ -166,7 +163,7 @@ Produce:
 
 After the agent finishes, skim the result for these specifics:
 
-The `CMD` instruction uses the exec form (JSON array, not a bare string), so your app receives `SIGTERM` directly when Unkey drains an instance. Any `RUN` step that needs a secret uses the `--mount=type=secret,id=env,target=/run/secrets/.env` pattern rather than `ARG` or `ENV`. Nothing in the `Dockerfile` or `.dockerignore` references a writable path other than `/tmp` or `/data`. The base image is pinned to a specific version and your final stage is slim enough that it doesn't carry the whole build toolchain.
+The `CMD` instruction uses the exec form (JSON array, not a bare string), so your app receives `SIGTERM` directly when Unkey drains an instance. Any `RUN` step that needs a secret uses the `--mount=type=secret,id=env,target=/run/secrets/.env` pattern rather than `ARG` or `ENV`. The base image is pinned to a specific version and your final stage is slim enough that it doesn't carry the whole build toolchain.
 
 If any of those are wrong, ask the agent to fix them directly. The prompt is short enough to tweak and re-run if your project has an unusual shape.
 

--- a/docs/product/platform/apps/settings.mdx
+++ b/docs/product/platform/apps/settings.mdx
@@ -113,7 +113,7 @@ Memory allocation for each instance. Available options:
 
 ### Storage
 
-Two dedicated storage locations are available to your instance:
+Two writable storage locations are available to your instance:
 
 | Path | Description | Always available |
 | --- | --- | --- |

--- a/docs/product/platform/apps/settings.mdx
+++ b/docs/product/platform/apps/settings.mdx
@@ -113,9 +113,7 @@ Memory allocation for each instance. Available options:
 
 ### Storage
 
-Instances run with a **read-only root filesystem**. Your application cannot write to arbitrary paths inside the container. This hardens the runtime against unintended or malicious file writes.
-
-Two writable locations are available:
+Two dedicated storage locations are available to your instance:
 
 | Path | Description | Always available |
 | --- | --- | --- |

--- a/docs/product/platform/instances/overview.mdx
+++ b/docs/product/platform/instances/overview.mdx
@@ -49,7 +49,7 @@ Configure limits in **Settings > Runtime settings**:
 - Memory: 256 MiB to 4 GiB (default 256 MiB, billed on allocation)
 - Storage: None to 10 GiB ephemeral disk (default none, mounted at `/data`)
 
-Instances run with a read-only root filesystem. A writable `/tmp` directory backed by memory is always available for scratch files. For larger temporary storage needs, configure [ephemeral storage](/platform/apps/settings#ephemeral-storage) to attach a dedicated disk volume per instance.
+A `/tmp` directory backed by memory is always available for scratch files. For larger temporary storage needs, configure [ephemeral storage](/platform/apps/settings#ephemeral-storage) to attach a dedicated disk volume per instance.
 
 All instances in a deployment share the same resource configuration. Changing these values takes effect on the next deployment.
 


### PR DESCRIPTION
## What does this PR do?

Removes references to the read-only root filesystem constraint from the Unkey Deploy documentation. This includes removing the mention of the read-only filesystem from the Dockerfile prompt guide, the app settings storage section, and the instances overview page. The `/tmp` and `/data` storage locations are still documented, but no longer framed in the context of a read-only root filesystem restriction.

Fixes # (issue)

_If there is not an issue for this, please create one first. This is used to tracking purposes and also helps us understand why this PR exists_

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How should this be tested?

- Review the updated pages (`dockerfile-prompt.mdx`, `settings.mdx`, `instances/overview.mdx`) to confirm all references to a read-only root filesystem have been removed.
- Verify that the `/tmp` and `/data` storage descriptions remain accurate and consistent across all three pages.

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [x] Updated the Unkey Docs if changes were necessary