### PR TITLE
fix: actually limit disk on pod

### DIFF
--- a/svc/krane/internal/deployment/apply.go
+++ b/svc/krane/internal/deployment/apply.go
@@ -127,12 +127,14 @@ func (c *Controller) ApplyDeployment(ctx context.Context, req *ctrlv1.ApplyDeplo
 		}},
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse(fmt.Sprintf("%dm", max(req.GetCpuMillicores()/resourceRequestFraction, 1))),
-				corev1.ResourceMemory: resource.MustParse(fmt.Sprintf("%dMi", max(req.GetMemoryMib()/resourceRequestFraction, 1))),
+				corev1.ResourceCPU:              resource.MustParse(fmt.Sprintf("%dm", max(req.GetCpuMillicores()/resourceRequestFraction, 1))),
+				corev1.ResourceMemory:           resource.MustParse(fmt.Sprintf("%dMi", max(req.GetMemoryMib()/resourceRequestFraction, 1))),
+				corev1.ResourceEphemeralStorage: resource.MustParse(fmt.Sprintf("%dMi", max(defaultContainerEphemeralStorageMib/resourceRequestFraction, 1))),
 			},
 			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse(fmt.Sprintf("%dm", req.GetCpuMillicores())),
-				corev1.ResourceMemory: resource.MustParse(fmt.Sprintf("%dMi", req.GetMemoryMib())),
+				corev1.ResourceCPU:              resource.MustParse(fmt.Sprintf("%dm", req.GetCpuMillicores())),
+				corev1.ResourceMemory:           resource.MustParse(fmt.Sprintf("%dMi", req.GetMemoryMib())),
+				corev1.ResourceEphemeralStorage: resource.MustParse(fmt.Sprintf("%dMi", defaultContainerEphemeralStorageMib)),
 			},
 		},
 	}

--- a/svc/krane/internal/deployment/consts.go
+++ b/svc/krane/internal/deployment/consts.go
@@ -19,6 +19,14 @@ const (
 	// Requests determine scheduling; limits cap actual usage.
 	resourceRequestFraction = 4 // requests = limits / 4
 
+	// defaultContainerEphemeralStorageMib caps writes to a container's rootfs
+	// (overlayfs writable layer, container logs, unmounted emptyDirs). Without
+	// this, a single pod could fill the node's 50Gi EBS root volume and trigger
+	// disk-pressure eviction of neighbors. Users who need more scratch space
+	// should configure an EphemeralStorage volume, which mounts at /data and is
+	// accounted separately from the rootfs.
+	defaultContainerEphemeralStorageMib = 128
+
 	// defaultCPUTargetUtilization is the average CPU utilization percentage (0-100)
 	// used when no autoscaling policy is attached. When average pod CPU exceeds
 	// this percentage of their requested CPU, the HPA adds replicas.


### PR DESCRIPTION
## What does this PR do?

Adds ephemeral storage resource requests and limits to containers deployed via `ApplyDeployment`. A new constant `defaultContainerEphemeralStorageMib` (128 MiB) is introduced to cap writes to a container's rootfs (overlayfs writable layer, container logs, unmounted emptyDirs).

Without this limit, a single pod could fill the node's EBS root volume and trigger disk-pressure eviction of neighboring pods. Users who need more scratch space should configure an `EphemeralStorage` volume, which mounts at `/data` and is accounted separately from the rootfs.

Fixes # (issue)

_If there is not an issue for this, please create one first. This is used to tracking purposes and also helps us understand why this PR exists_

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Deploy a pod via `ApplyDeployment` and confirm the resulting pod spec includes ephemeral storage requests of `32Mi` (128 / 4) and a limit of `128Mi`
- Verify that a container writing beyond 128 MiB to its rootfs is evicted rather than impacting neighboring pods on the node
- Confirm that pods using a separately configured `EphemeralStorage` volume at `/data` are unaffected by this limit

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary