### PR TITLE
feat(sentinel): ChangeTier, ChangeReplicas, ListTiers RPC handlers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/pb33f/libopenapi-validator v0.13.4
 	github.com/prometheus/client_golang v1.23.2
 	github.com/redis/go-redis/v9 v9.17.2
-	github.com/restatedev/sdk-go v0.23.0
+	github.com/restatedev/sdk-go v0.24.0
 	github.com/shirou/gopsutil/v4 v4.25.6
 	github.com/sqlc-dev/plugin-sdk-go v1.23.0
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -678,6 +678,8 @@ github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/restatedev/sdk-go v0.23.0 h1:Eewh6n/YZUfA7In5ZiAIA6smLyssynsBHVijUguNpvc=
 github.com/restatedev/sdk-go v0.23.0/go.mod h1:2G757yGe0Ihwcb+Z/HZUscQ0g3PFTyueO0f8qlqxWDo=
+github.com/restatedev/sdk-go v0.24.0 h1:SZN633U7Jb7AbhWwSOMVPz5Fw9fwWHcGlcr0BF4PMDM=
+github.com/restatedev/sdk-go v0.24.0/go.mod h1:2G757yGe0Ihwcb+Z/HZUscQ0g3PFTyueO0f8qlqxWDo=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/riza-io/grpc-go v0.2.0 h1:2HxQKFVE7VuYstcJ8zqpN84VnAoJ4dCL6YFhJewNcHQ=

--- a/svc/ctrl/api/BUILD.bazel
+++ b/svc/ctrl/api/BUILD.bazel
@@ -36,6 +36,7 @@ go_library(
         "//svc/ctrl/services/deployment",
         "//svc/ctrl/services/openapi",
         "//svc/ctrl/services/project",
+        "//svc/ctrl/services/sentinel",
         "//svc/ctrl/worker/github",
         "@com_github_prometheus_client_golang//prometheus",
         "@com_github_prometheus_client_golang//prometheus/collectors",

--- a/svc/ctrl/api/run.go
+++ b/svc/ctrl/api/run.go
@@ -33,6 +33,7 @@ import (
 	"github.com/unkeyed/unkey/svc/ctrl/services/deployment"
 	"github.com/unkeyed/unkey/svc/ctrl/services/openapi"
 	"github.com/unkeyed/unkey/svc/ctrl/services/project"
+	"github.com/unkeyed/unkey/svc/ctrl/services/sentinel"
 	githubclient "github.com/unkeyed/unkey/svc/ctrl/worker/github"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
@@ -218,6 +219,11 @@ func Run(ctx context.Context, cfg Config) error {
 		Restate:    restateClient,
 		AppService: appSvc,
 		Bearer:     cfg.AuthToken,
+	})))
+	mux.Handle(ctrlv1connect.NewSentinelServiceHandler(sentinel.New(sentinel.Config{
+		Database: database,
+		Restate:  restateClient,
+		Bearer:   cfg.AuthToken,
 	})))
 
 	if cfg.GitHub.WebhookSecret != "" {

--- a/svc/ctrl/services/sentinel/BUILD.bazel
+++ b/svc/ctrl/services/sentinel/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "sentinel",
+    srcs = [
+        "change_replicas.go",
+        "change_tier.go",
+        "service.go",
+    ],
+    importpath = "github.com/unkeyed/unkey/svc/ctrl/services/sentinel",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//gen/proto/ctrl/v1:ctrl",
+        "//gen/proto/ctrl/v1/ctrlv1connect",
+        "//gen/proto/hydra/v1:hydra",
+        "//pkg/assert",
+        "//pkg/db",
+        "//pkg/uid",
+        "//svc/ctrl/internal/auth",
+        "//svc/ctrl/internal/sentinelpolicy",
+        "@com_connectrpc_connect//:connect",
+        "@com_github_restatedev_sdk_go//ingress",
+    ],
+)

--- a/svc/ctrl/services/sentinel/change_replicas.go
+++ b/svc/ctrl/services/sentinel/change_replicas.go
@@ -1,0 +1,149 @@
+package sentinel
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"connectrpc.com/connect"
+	ctrlv1 "github.com/unkeyed/unkey/gen/proto/ctrl/v1"
+	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
+	"github.com/unkeyed/unkey/pkg/assert"
+	"github.com/unkeyed/unkey/pkg/db"
+	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/ctrl/internal/auth"
+	"github.com/unkeyed/unkey/svc/ctrl/internal/sentinelpolicy"
+)
+
+// ChangeReplicas updates the desired replica count of a running sentinel.
+// Mirrors the transactional shape of ChangeTier: all subscription and
+// state writes happen here in one tx, and SentinelService.Deploy is used
+// purely as the "wait for krane convergence" primitive via an empty
+// request.
+//
+// Inside the tx:
+//  1. Close the currently open sentinel_subscriptions row.
+//  2. Insert a new subscription row carrying the same tier forward with
+//     the new replica count.
+//  3. Repoint sentinels.subscription_id at the new row.
+//  4. Update sentinels.desired_replicas + deploy_status=progressing so
+//     krane sees the new intent.
+//  5. Drop a deployment_changes outbox row so krane picks up the spec
+//     change on its incremental watch.
+//
+// After the tx commits, Deploy is enqueued with an empty request. It
+// reads the current state (already updated here), sees no image
+// change, and awaits NotifyReady until krane reports the scaled
+// deployment as healthy.
+//
+// No-op (no tx, no Deploy) if the requested count equals the current
+// desired_replicas.
+func (s *Service) ChangeReplicas(
+	ctx context.Context,
+	req *connect.Request[ctrlv1.ChangeReplicasRequest],
+) (*connect.Response[ctrlv1.ChangeReplicasResponse], error) {
+	if err := auth.Authenticate(req, s.bearer); err != nil {
+		return nil, err
+	}
+
+	if err := assert.All(
+		assert.NotEmpty(req.Msg.GetSentinelId(), "sentinel_id is required"),
+		assert.Greater(req.Msg.GetDesiredReplicas(), int32(0), "desired_replicas must be > 0"),
+	); err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
+
+	joined, err := db.Query.FindSentinelByID(ctx, s.db.RO(), req.Msg.GetSentinelId())
+	if err != nil {
+		if db.IsNotFound(err) {
+			return nil, connect.NewError(connect.CodeNotFound, err)
+		}
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+
+	sentinel, currentSub := joined.Sentinel, joined.SentinelSubscription
+	newReplicas := req.Msg.GetDesiredReplicas()
+
+	// No-op: already at this replica count.
+	if sentinel.DesiredReplicas == newReplicas {
+		return connect.NewResponse(&ctrlv1.ChangeReplicasResponse{}), nil
+	}
+
+	env, err := db.Query.FindEnvironmentById(ctx, s.db.RO(), sentinel.EnvironmentID)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("find environment: %w", err))
+	}
+
+	minReplicas := sentinelpolicy.MinReplicasForEnv(env.Slug)
+	if newReplicas < minReplicas {
+		return nil, connect.NewError(
+			connect.CodeFailedPrecondition,
+			fmt.Errorf("%s sentinels require at least %d replicas", env.Slug, minReplicas),
+		)
+	}
+
+	newSubscriptionID := uid.New(uid.SentinelSubscriptionPrefix)
+	now := time.Now().UnixMilli()
+
+	err = db.Tx(ctx, s.db.RW(), func(txCtx context.Context, tx db.DBTX) error {
+		if err := db.Query.TerminateOpenSentinelSubscription(txCtx, tx, db.TerminateOpenSentinelSubscriptionParams{
+			SentinelID:   sentinel.ID,
+			TerminatedAt: sql.NullInt64{Valid: true, Int64: now},
+		}); err != nil {
+			return fmt.Errorf("terminate open sentinel subscription: %w", err)
+		}
+
+		if err := db.Query.InsertSentinelSubscription(txCtx, tx, db.InsertSentinelSubscriptionParams{
+			ID:             newSubscriptionID,
+			SentinelID:     sentinel.ID,
+			WorkspaceID:    sentinel.WorkspaceID,
+			RegionID:       sentinel.RegionID,
+			TierID:         currentSub.TierID,
+			TierVersion:    currentSub.TierVersion,
+			CpuMillicores:  currentSub.CpuMillicores,
+			MemoryMib:      currentSub.MemoryMib,
+			Replicas:       newReplicas,
+			PricePerSecond: currentSub.PricePerSecond,
+			CreatedAt:      now,
+		}); err != nil {
+			return fmt.Errorf("insert sentinel subscription: %w", err)
+		}
+
+		if err := db.Query.UpdateSentinelSubscription(txCtx, tx, db.UpdateSentinelSubscriptionParams{
+			ID:             sentinel.ID,
+			SubscriptionID: newSubscriptionID,
+			UpdatedAt:      sql.NullInt64{Valid: true, Int64: now},
+		}); err != nil {
+			return fmt.Errorf("repoint sentinel subscription: %w", err)
+		}
+
+		if err := db.Query.UpdateSentinelConfig(txCtx, tx, db.UpdateSentinelConfigParams{
+			ID:              sentinel.ID,
+			Image:           sentinel.Image,
+			DesiredReplicas: newReplicas,
+			DeployStatus:    db.SentinelsDeployStatusProgressing,
+			UpdatedAt:       sql.NullInt64{Valid: true, Int64: now},
+		}); err != nil {
+			return fmt.Errorf("update sentinel config: %w", err)
+		}
+
+		return db.Query.InsertDeploymentChange(txCtx, tx, db.InsertDeploymentChangeParams{
+			ResourceType: db.DeploymentChangesResourceTypeSentinel,
+			ResourceID:   sentinel.ID,
+			RegionID:     sentinel.RegionID,
+			CreatedAt:    now,
+		})
+	})
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+
+	// Deploy is now just the "wait for krane convergence" primitive —
+	// all state was written above, so pass an empty request.
+	if err := s.enqueueDeploy(ctx, sentinel.ID, &hydrav1.SentinelServiceDeployRequest{}); err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+
+	return connect.NewResponse(&ctrlv1.ChangeReplicasResponse{}), nil
+}

--- a/svc/ctrl/services/sentinel/change_tier.go
+++ b/svc/ctrl/services/sentinel/change_tier.go
@@ -1,0 +1,144 @@
+package sentinel
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"connectrpc.com/connect"
+	ctrlv1 "github.com/unkeyed/unkey/gen/proto/ctrl/v1"
+	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
+	"github.com/unkeyed/unkey/pkg/assert"
+	"github.com/unkeyed/unkey/pkg/db"
+	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/ctrl/internal/auth"
+)
+
+// ChangeTier swaps a running sentinel to a new (tier_id, version). In one
+// transaction it inserts a fresh sentinel_subscriptions row denormalizing
+// the tier's price + envelope, repoints sentinels.subscription_id, marks
+// deploy_status=progressing, and writes a deployment_changes outbox row so
+// krane rolls the pod to the new resource envelope.
+//
+// After the tx commits, it fires an empty SentinelService.Deploy through
+// Restate ingress. Deploy's noConfigChange path creates an awakeable and
+// awaits NotifyReady, which ReportSentinelStatus fires when krane's
+// convergedImage check passes — i.e. k8s has fully rolled out the new spec.
+// deploy_status flips to ready (or failed on timeout) inside Deploy.
+func (s *Service) ChangeTier(
+	ctx context.Context,
+	req *connect.Request[ctrlv1.ChangeTierRequest],
+) (*connect.Response[ctrlv1.ChangeTierResponse], error) {
+	if err := auth.Authenticate(req, s.bearer); err != nil {
+		return nil, err
+	}
+
+	if err := assert.All(
+		assert.NotEmpty(req.Msg.GetSentinelId(), "sentinel_id is required"),
+		assert.NotEmpty(req.Msg.GetTierId(), "tier_id is required"),
+		assert.NotEmpty(req.Msg.GetTierVersion(), "tier_version is required"),
+	); err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
+
+	sentinelID := req.Msg.GetSentinelId()
+	joined, err := db.Query.FindSentinelByID(ctx, s.db.RO(), sentinelID)
+	if err != nil {
+		if db.IsNotFound(err) {
+			return nil, connect.NewError(connect.CodeNotFound, err)
+		}
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+
+	sentinel, currentSub := joined.Sentinel, joined.SentinelSubscription
+
+	// No-op: already on this tier + version.
+	if currentSub.TierID == req.Msg.GetTierId() && currentSub.TierVersion == req.Msg.GetTierVersion() {
+		return connect.NewResponse(&ctrlv1.ChangeTierResponse{}), nil
+	}
+
+	tier, err := db.Query.FindSentinelTier(ctx, s.db.RO(), db.FindSentinelTierParams{
+		TierID:  req.Msg.GetTierId(),
+		Version: req.Msg.GetTierVersion(),
+	})
+	if err != nil {
+		if db.IsNotFound(err) {
+			return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("tier not found"))
+		}
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+
+	if tier.EffectiveUntil.Valid {
+		return nil, connect.NewError(
+			connect.CodeFailedPrecondition,
+			fmt.Errorf("tier is retired and cannot be subscribed to"),
+		)
+	}
+
+	newSubscriptionID := uid.New(uid.SentinelSubscriptionPrefix)
+	now := time.Now().UnixMilli()
+
+	err = db.Tx(ctx, s.db.RW(), func(txCtx context.Context, tx db.DBTX) error {
+		// Close the currently open subscription before opening the new one.
+		// The `one_open_subscription_per_sentinel` unique index would
+		// otherwise reject the insert.
+		if err := db.Query.TerminateOpenSentinelSubscription(txCtx, tx, db.TerminateOpenSentinelSubscriptionParams{
+			SentinelID:   sentinel.ID,
+			TerminatedAt: sql.NullInt64{Valid: true, Int64: now},
+		}); err != nil {
+			return fmt.Errorf("terminate open sentinel subscription: %w", err)
+		}
+
+		if err := db.Query.InsertSentinelSubscription(txCtx, tx, db.InsertSentinelSubscriptionParams{
+			ID:            newSubscriptionID,
+			SentinelID:    sentinel.ID,
+			WorkspaceID:   sentinel.WorkspaceID,
+			RegionID:      sentinel.RegionID,
+			TierID:        tier.TierID,
+			TierVersion:   tier.Version,
+			CpuMillicores: tier.CpuMillicores,
+			MemoryMib:     tier.MemoryMib,
+			// Carry the replica count forward from the subscription being
+			// terminated — tier change doesn't touch the pod count, just
+			// the resource envelope and per-second price.
+			Replicas:       currentSub.Replicas,
+			PricePerSecond: tier.PricePerSecond,
+			CreatedAt:      now,
+		}); err != nil {
+			return fmt.Errorf("insert sentinel subscription: %w", err)
+		}
+
+		if err := db.Query.UpdateSentinelSubscription(txCtx, tx, db.UpdateSentinelSubscriptionParams{
+			ID:             sentinel.ID,
+			SubscriptionID: newSubscriptionID,
+			UpdatedAt:      sql.NullInt64{Valid: true, Int64: now},
+		}); err != nil {
+			return fmt.Errorf("repoint sentinel subscription: %w", err)
+		}
+
+		if err := db.Query.UpdateSentinelDeployStatus(txCtx, tx, db.UpdateSentinelDeployStatusParams{
+			ID:           sentinel.ID,
+			DeployStatus: db.SentinelsDeployStatusProgressing,
+			UpdatedAt:    sql.NullInt64{Valid: true, Int64: now},
+		}); err != nil {
+			return fmt.Errorf("mark progressing: %w", err)
+		}
+
+		return db.Query.InsertDeploymentChange(txCtx, tx, db.InsertDeploymentChangeParams{
+			ResourceType: db.DeploymentChangesResourceTypeSentinel,
+			ResourceID:   sentinel.ID,
+			RegionID:     sentinel.RegionID,
+			CreatedAt:    now,
+		})
+	})
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+
+	if err := s.enqueueDeploy(ctx, sentinel.ID, &hydrav1.SentinelServiceDeployRequest{}); err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+
+	return connect.NewResponse(&ctrlv1.ChangeTierResponse{}), nil
+}

--- a/svc/ctrl/services/sentinel/service.go
+++ b/svc/ctrl/services/sentinel/service.go
@@ -1,0 +1,51 @@
+// Package sentinel implements the SentinelService ConnectRPC API. Today it
+// exposes tier + replicas changes triggered by the dashboard; image rollouts
+// are orchestrated by the SentinelRolloutService Restate VO elsewhere.
+package sentinel
+
+import (
+	"context"
+	"fmt"
+
+	restateingress "github.com/restatedev/sdk-go/ingress"
+	"github.com/unkeyed/unkey/gen/proto/ctrl/v1/ctrlv1connect"
+	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
+	"github.com/unkeyed/unkey/pkg/db"
+)
+
+type Service struct {
+	ctrlv1connect.UnimplementedSentinelServiceHandler
+	db      db.Database
+	restate *restateingress.Client
+	bearer  string
+}
+
+type Config struct {
+	Database db.Database
+	Restate  *restateingress.Client
+	Bearer   string
+}
+
+func New(cfg Config) *Service {
+	return &Service{
+		UnimplementedSentinelServiceHandler: ctrlv1connect.UnimplementedSentinelServiceHandler{},
+		db:                                  cfg.Database,
+		restate:                             cfg.Restate,
+		bearer:                              cfg.Bearer,
+	}
+}
+
+// enqueueDeploy kicks off the durable sentinel Deploy workflow. It's the
+// bridge between our ConnectRPC mutation handlers (which do DB writes) and
+// the Restate VO that owns the awakeable-based convergence wait. The Deploy
+// handler is driven by `deploy_status` and the request payload: callers that
+// already wrote progressing + outbox (ChangeTier) pass an empty request and
+// fall straight through to the await; callers that want Deploy to write
+// config + outbox itself (ChangeReplicas) populate the request fields.
+func (s *Service) enqueueDeploy(ctx context.Context, sentinelID string, req *hydrav1.SentinelServiceDeployRequest) error {
+	_, err := hydrav1.NewSentinelServiceIngressClient(s.restate, sentinelID).Deploy().Send(ctx, req)
+	if err != nil {
+		return fmt.Errorf("enqueue deploy: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
## What does this PR do?

Introduces a new `SentinelService` ConnectRPC handler that exposes two mutation operations — `ChangeTier` and `ChangeReplicas` — allowing the dashboard to modify running sentinels' resource tier and replica count respectively.

Both operations follow the same transactional pattern: all subscription and state writes (closing the current `sentinel_subscriptions` row, inserting a new one, repointing `sentinels.subscription_id`, updating `deploy_status` to `progressing`, and writing a `deployment_changes` outbox row) are committed atomically in a single DB transaction. After the transaction commits, a durable `SentinelService.Deploy` workflow is enqueued via Restate ingress, which awaits krane convergence via the `NotifyReady` awakeable before flipping `deploy_status` to ready.

Both handlers are no-ops when the requested state already matches the current state (same tier+version or same replica count). `ChangeReplicas` additionally enforces a minimum replica floor based on the sentinel's environment. `ChangeTier` rejects retired tiers.

Also bumps `github.com/restatedev/sdk-go` from `v0.23.0` to `v0.24.0` this was done because of journal replay issues involving protocjson

Fixes # (issue)

_If there is not an issue for this, please create one first. This is used to tracking purposes and also helps us understand why this PR exists_

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Call `ChangeTier` with a valid sentinel ID and a different tier+version; verify the `sentinel_subscriptions` table has a closed old row and a new open row, `sentinels.subscription_id` points to the new row, `deploy_status` is `progressing`, and a `deployment_changes` row was inserted.
- Call `ChangeTier` with the same tier+version the sentinel is already on; verify no DB writes occur and a success response is returned.
- Call `ChangeTier` with a retired tier; verify a `FailedPrecondition` error is returned.
- Call `ChangeReplicas` with a valid sentinel ID and a new replica count above the environment minimum; verify the same transactional writes as above with the replica count updated and the tier carried forward unchanged.
- Call `ChangeReplicas` with the current replica count; verify no DB writes occur.
- Call `ChangeReplicas` with a replica count below the environment minimum; verify a `FailedPrecondition` error is returned.
- Call either endpoint with an invalid or missing bearer token; verify an `Unauthenticated` error is returned.

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary