### PR TITLE
perf: some better queries

### DIFF
--- a/web/apps/dashboard/lib/trpc/routers/api/keys/api-query.ts
+++ b/web/apps/dashboard/lib/trpc/routers/api/keys/api-query.ts
@@ -1,10 +1,14 @@
 import type { KeysOverviewFilterUrlValue } from "@/app/(app)/[workspaceSlug]/apis/[apiId]/_overview/filters.schema";
-import { type InferSelectModel, type SQL, db } from "@/lib/db";
+import { type InferSelectModel, type SQL, and, db, desc, eq, inArray, isNull, sql } from "@/lib/db";
 import { TRPCError } from "@trpc/server";
-import { identities } from "@unkey/db/src/schema";
-
-import type { keys } from "@unkey/db/src/schema/keys";
-import type { permissions, roles } from "@unkey/db/src/schema/rbac";
+import {
+  identities,
+  keys,
+  keysPermissions,
+  keysRoles,
+  permissions,
+  roles,
+} from "@unkey/db/src/schema";
 
 type BaseKey = InferSelectModel<typeof keys>;
 type BaseRole = InferSelectModel<typeof roles>;
@@ -60,7 +64,6 @@ type KeyDetails = {
   }[];
 };
 
-// Input interface for the query abstraction
 export interface QueryApiKeysInput {
   apiId: string;
   workspaceId: string;
@@ -69,19 +72,38 @@ export interface QueryApiKeysInput {
   identities?: KeysOverviewFilterUrlValue[] | null;
 }
 
-// Response interface with the query results
 export interface QueryApiKeysResult {
   keyspaceId: string;
   keys: DatabaseKey[];
   keyIds: KeysOverviewFilterUrlValue[] | null;
+  // True when more matching keys exist beyond MAX_KEYS_PER_QUERY. Callers can
+  // surface this to the user (e.g. "refine your filter") instead of silently
+  // displaying a truncated result.
+  hasMore: boolean;
 }
 
+// Drizzle parameterizes LIKE patterns (no SQL injection risk), but MySQL still
+// interprets % and _ as wildcards at query time. A user searching for a key
+// named "100%_test" would otherwise match "100xyz_test" etc. Escape the three
+// LIKE metacharacters and use ESCAPE '\\' so they match literally.
+function escapeLikePattern(value: string): string {
+  return value.replace(/[%_\\]/g, "\\$&");
+}
+
+// Cap the rows we ever scan from a single keyspace. The dashboard only renders
+// a single page of keys, and ClickHouse always narrows us to a small window
+// via keyIds first, so this only ever matters when someone filters by name or
+// identity without a keyIds cursor.
+const MAX_KEYS_PER_QUERY = 1000;
+
 /**
- * Abstracts the common database query pattern for API keys
- * With proper identity relation joining
+ * Fetches keys under an API's keyspace that match the given filters, along with
+ * each key's roles, permissions, and identity.
  *
- * @param input Query parameters including apiId, workspaceId, and optional filters
- * @returns The API's keyspace ID, matching keys, and processed keyIds filter
+ * Built as a flat keys query plus bulk lookups for relations so that MySQL uses
+ * `keys.keys_id_unique` / `keys.key_auth_id_deleted_at_idx` directly instead of
+ * the nested lateral + JSON aggregation that Drizzle's relational query API
+ * generates (which was reading millions of rows per call).
  */
 export async function queryApiKeys({
   apiId,
@@ -90,189 +112,120 @@ export async function queryApiKeys({
   names: namesFromInput,
   identities: identitiesFromInput,
 }: QueryApiKeysInput): Promise<QueryApiKeysResult> {
-  const combinedResults = await db.query.apis
-    .findFirst({
-      where: (api, { and, eq, isNull }) =>
-        and(eq(api.id, apiId), eq(api.workspaceId, workspaceId), isNull(api.deletedAtM)),
-      with: {
-        keyAuth: {
-          with: {
-            keys: {
-              with: {
-                permissions: {
-                  with: {
-                    permission: {
-                      columns: {
-                        name: true,
-                        description: true,
-                        createdAtM: true,
-                        updatedAtM: true,
-                      },
-                    },
-                  },
-                },
-                roles: {
-                  with: {
-                    role: {
-                      columns: {
-                        name: true,
-                        description: true,
-                        createdAtM: true,
-                        updatedAtM: true,
-                      },
-                    },
-                  },
-                },
-                identity: {
-                  columns: {
-                    externalId: true,
-                  },
-                },
-              },
-              where: (key, { and, isNull, inArray, sql }) => {
-                const conditions = [isNull(key.deletedAtM)];
+  const api = await getApi(apiId, workspaceId);
+  if (!api || !api.keyAuth?.id) {
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "API not found or does not have key authentication enabled",
+    });
+  }
+  const keyspaceId = api.keyAuth.id;
 
-                if (namesFromInput && namesFromInput.length > 0) {
-                  const nameIsValues = namesFromInput
-                    .filter((filter) => filter.operator === "is")
-                    .map((filter) => filter.value);
+  const conditions: SQL<unknown>[] = [eq(keys.keyAuthId, keyspaceId), isNull(keys.deletedAtM)];
 
-                  const nameContainsValues = namesFromInput
-                    .filter((filter) => filter.operator === "contains")
-                    .map((filter) => filter.value);
+  if (namesFromInput && namesFromInput.length > 0) {
+    const nameIsValues = namesFromInput
+      .filter((f) => f.operator === "is")
+      .map((f) => f.value as string);
+    if (nameIsValues.length > 0) {
+      conditions.push(inArray(keys.name, nameIsValues));
+    }
+    for (const f of namesFromInput) {
+      const value = f.value;
+      if (typeof value !== "string") {
+        continue;
+      }
+      const escaped = escapeLikePattern(value);
+      if (f.operator === "contains") {
+        conditions.push(sql`${keys.name} LIKE ${`%${escaped}%`} ESCAPE '\\'`);
+      } else if (f.operator === "startsWith") {
+        conditions.push(sql`${keys.name} LIKE ${`${escaped}%`} ESCAPE '\\'`);
+      } else if (f.operator === "endsWith") {
+        conditions.push(sql`${keys.name} LIKE ${`%${escaped}`} ESCAPE '\\'`);
+      }
+    }
+  }
 
-                  const nameStartsWithValues = namesFromInput
-                    .filter((filter) => filter.operator === "startsWith")
-                    .map((filter) => filter.value);
+  if (keyIdsFromInput && keyIdsFromInput.length > 0) {
+    const idIsValues = keyIdsFromInput
+      .filter((f) => f.operator === "is")
+      .map((f) => f.value as string);
+    if (idIsValues.length > 0) {
+      conditions.push(inArray(keys.id, idIsValues));
+    }
+    for (const f of keyIdsFromInput) {
+      const value = f.value;
+      if (typeof value !== "string") {
+        continue;
+      }
+      if (f.operator === "contains") {
+        conditions.push(sql`${keys.id} LIKE ${`%${escapeLikePattern(value)}%`} ESCAPE '\\'`);
+      }
+    }
+  }
 
-                  const nameEndsWithValues = namesFromInput
-                    .filter((filter) => filter.operator === "endsWith")
-                    .map((filter) => filter.value);
+  if (identitiesFromInput && identitiesFromInput.length > 0) {
+    const identityOrs: SQL<unknown>[] = [];
+    for (const filter of identitiesFromInput) {
+      const value = filter.value;
+      if (typeof value !== "string") {
+        continue;
+      }
 
-                  if (nameIsValues.length > 0) {
-                    conditions.push(inArray(key.name, nameIsValues as string[]));
-                  }
+      let externalMatch: SQL<unknown>;
+      let ownerMatch: SQL<unknown>;
+      const escaped = escapeLikePattern(value);
+      switch (filter.operator) {
+        case "contains":
+          externalMatch = sql`${identities.externalId} LIKE ${`%${escaped}%`} ESCAPE '\\'`;
+          ownerMatch = sql`${keys.ownerId} LIKE ${`%${escaped}%`} ESCAPE '\\'`;
+          break;
+        case "startsWith":
+          externalMatch = sql`${identities.externalId} LIKE ${`${escaped}%`} ESCAPE '\\'`;
+          ownerMatch = sql`${keys.ownerId} LIKE ${`${escaped}%`} ESCAPE '\\'`;
+          break;
+        case "endsWith":
+          externalMatch = sql`${identities.externalId} LIKE ${`%${escaped}`} ESCAPE '\\'`;
+          ownerMatch = sql`${keys.ownerId} LIKE ${`%${escaped}`} ESCAPE '\\'`;
+          break;
+        default:
+          externalMatch = sql`${identities.externalId} = ${value}`;
+          ownerMatch = sql`${keys.ownerId} = ${value}`;
+      }
 
-                  if (nameContainsValues.length > 0) {
-                    nameContainsValues.forEach((value) => {
-                      conditions.push(sql`${key.name} LIKE ${`%${value}%`}`);
-                    });
-                  }
+      identityOrs.push(
+        sql`EXISTS (SELECT 1 FROM ${identities} WHERE ${identities.id} = ${keys.identityId} AND ${externalMatch})`,
+      );
+      identityOrs.push(ownerMatch);
+    }
 
-                  if (nameStartsWithValues.length > 0) {
-                    nameStartsWithValues.forEach((value) => {
-                      conditions.push(sql`${key.name} LIKE ${`${value}%`}`);
-                    });
-                  }
+    if (identityOrs.length > 0) {
+      conditions.push(sql`(${sql.join(identityOrs, sql` OR `)})`);
+    }
+  }
 
-                  if (nameEndsWithValues.length > 0) {
-                    nameEndsWithValues.forEach((value) => {
-                      conditions.push(sql`${key.name} LIKE ${`%${value}`}`);
-                    });
-                  }
-                }
-
-                if (keyIdsFromInput && keyIdsFromInput.length > 0) {
-                  const keyIdValues = keyIdsFromInput
-                    .filter((filter) => filter.operator === "is")
-                    .map((filter) => filter.value);
-
-                  const keyIdContainsValues = keyIdsFromInput
-                    .filter((filter) => filter.operator === "contains")
-                    .map((filter) => filter.value);
-
-                  if (keyIdValues.length > 0) {
-                    conditions.push(inArray(key.id, keyIdValues as string[]));
-                  }
-
-                  if (keyIdContainsValues.length > 0) {
-                    keyIdContainsValues.forEach((value) =>
-                      conditions.push(sql`${key.id} LIKE ${`%${value}%`}`),
-                    );
-                  }
-                }
-
-                const allIdentityConditions = [];
-                if (identitiesFromInput && identitiesFromInput.length > 0) {
-                  for (const filter of identitiesFromInput) {
-                    const value = filter.value;
-                    if (typeof value !== "string") {
-                      continue;
-                    }
-
-                    const operator = filter.operator;
-
-                    let condition: SQL<unknown>;
-
-                    switch (operator) {
-                      case "is":
-                        condition = sql`identities.external_id = ${value}`;
-                        break;
-                      case "contains":
-                        condition = sql`identities.external_id LIKE ${`%${value}%`}`;
-                        break;
-                      case "startsWith":
-                        condition = sql`identities.external_id LIKE ${`${value}%`}`;
-                        break;
-                      case "endsWith":
-                        condition = sql`identities.external_id LIKE ${`%${value}`}`;
-                        break;
-                      default:
-                        condition = sql`identities.external_id = ${value}`;
-                    }
-
-                    allIdentityConditions.push(sql`
-        EXISTS (
-          SELECT 1 FROM ${identities}
-          WHERE ${identities.id} = ${key.identityId}
-          AND ${condition}
-        )`);
-                    let ownerCondition: SQL<unknown>;
-
-                    switch (operator) {
-                      case "is":
-                        ownerCondition = sql`${key.ownerId} = ${value}`;
-                        break;
-                      case "contains":
-                        ownerCondition = sql`${key.ownerId} LIKE ${`%${value}%`}`;
-                        break;
-                      case "startsWith":
-                        ownerCondition = sql`${key.ownerId} LIKE ${`${value}%`}`;
-                        break;
-                      case "endsWith":
-                        ownerCondition = sql`${key.ownerId} LIKE ${`%${value}`}`;
-                        break;
-                      default:
-                        ownerCondition = sql`${key.ownerId} = ${value}`;
-                    }
-
-                    allIdentityConditions.push(ownerCondition);
-                  }
-                }
-
-                if (allIdentityConditions.length > 0) {
-                  conditions.push(sql`(${sql.join(allIdentityConditions, sql` OR `)})`);
-                }
-
-                return and(...conditions);
-              },
-              columns: {
-                id: true,
-                keyAuthId: true,
-                name: true,
-                ownerId: true,
-                identityId: true,
-                meta: true,
-                enabled: true,
-                remaining: true,
-                environment: true,
-                workspaceId: true,
-              },
-            },
-          },
-        },
-      },
+  // Fetch one extra row to detect truncation without a separate count query.
+  // Deterministic ORDER BY so the cutoff is repeatable and the new
+  // (key_auth_id, deleted_at_m, last_used_at) composite serves the sort. `pk`
+  // is the tiebreaker — unique, monotonic, and InnoDB stores it as the implicit
+  // trailing column of every secondary index so MySQL can avoid a filesort.
+  const rawRows = await db
+    .select({
+      id: keys.id,
+      keyAuthId: keys.keyAuthId,
+      name: keys.name,
+      ownerId: keys.ownerId,
+      identityId: keys.identityId,
+      meta: keys.meta,
+      enabled: keys.enabled,
+      remaining: keys.remaining,
+      environment: keys.environment,
+      workspaceId: keys.workspaceId,
     })
+    .from(keys)
+    .where(and(...conditions))
+    .orderBy(desc(keys.lastUsedAt), desc(keys.pk))
+    .limit(MAX_KEYS_PER_QUERY + 1)
     .catch((err) => {
       console.error("Database query error:", err);
       throw new TRPCError({
@@ -282,22 +235,134 @@ export async function queryApiKeys({
       });
     });
 
-  if (!combinedResults || !combinedResults?.keyAuth?.id) {
-    throw new TRPCError({
-      code: "NOT_FOUND",
-      message: "API not found or does not have key authentication enabled",
-    });
+  const hasMore = rawRows.length > MAX_KEYS_PER_QUERY;
+  const keyRows = hasMore ? rawRows.slice(0, MAX_KEYS_PER_QUERY) : rawRows;
+
+  if (hasMore) {
+    // Log rather than throw so the dashboard still renders a page — but operators
+    // can spot when a workspace regularly hits the cap and needs a refined filter.
+    console.warn(
+      `queryApiKeys: truncated at ${MAX_KEYS_PER_QUERY} keys for apiId=${apiId} workspaceId=${workspaceId}`,
+    );
   }
 
-  const keysResult = combinedResults.keyAuth.keys;
-  const keyIds = keysResult.map((key) => key.id);
+  if (keyRows.length === 0) {
+    return {
+      keyspaceId,
+      keys: [],
+      keyIds: keyIdsFromInput,
+      hasMore: false,
+    };
+  }
 
-  // Build keyIdsFilter for clickhouse query
+  const matchedKeyIds = keyRows.map((k) => k.id);
+  const identityIdList = Array.from(
+    new Set(
+      keyRows
+        .map((k) => k.identityId)
+        .filter((id): id is string => typeof id === "string" && id.length > 0),
+    ),
+  );
+
+  const [roleRows, permissionRows, identityRows] = await Promise.all([
+    db
+      .select({
+        keyId: keysRoles.keyId,
+        name: roles.name,
+        description: roles.description,
+        createdAtM: roles.createdAtM,
+        updatedAtM: roles.updatedAtM,
+      })
+      .from(keysRoles)
+      .innerJoin(roles, eq(keysRoles.roleId, roles.id))
+      .where(inArray(keysRoles.keyId, matchedKeyIds)),
+    db
+      .select({
+        keyId: keysPermissions.keyId,
+        name: permissions.name,
+        description: permissions.description,
+        createdAtM: permissions.createdAtM,
+        updatedAtM: permissions.updatedAtM,
+      })
+      .from(keysPermissions)
+      .innerJoin(permissions, eq(keysPermissions.permissionId, permissions.id))
+      .where(inArray(keysPermissions.keyId, matchedKeyIds)),
+    identityIdList.length > 0
+      ? db
+          .select({ id: identities.id, externalId: identities.externalId })
+          .from(identities)
+          .where(inArray(identities.id, identityIdList))
+      : Promise.resolve([] as { id: string; externalId: string }[]),
+  ]).catch((err) => {
+    console.error("Database query error (key relation lookups):", err);
+    throw new TRPCError({
+      code: "INTERNAL_SERVER_ERROR",
+      message:
+        "Failed to retrieve API information. If this issue persists, please contact support@unkey.com with the time this occurred.",
+    });
+  });
+
+  const rolesByKey = new Map<string, DatabaseKey["roles"]>();
+  for (const r of roleRows) {
+    const entry = rolesByKey.get(r.keyId);
+    const rel = {
+      role: {
+        name: r.name,
+        description: r.description,
+        createdAtM: r.createdAtM,
+        updatedAtM: r.updatedAtM,
+      },
+    };
+    if (entry) {
+      entry.push(rel);
+    } else {
+      rolesByKey.set(r.keyId, [rel]);
+    }
+  }
+
+  const permissionsByKey = new Map<string, DatabaseKey["permissions"]>();
+  for (const p of permissionRows) {
+    const entry = permissionsByKey.get(p.keyId);
+    const rel = {
+      permission: {
+        name: p.name,
+        description: p.description,
+        createdAtM: p.createdAtM,
+        updatedAtM: p.updatedAtM,
+      },
+    };
+    if (entry) {
+      entry.push(rel);
+    } else {
+      permissionsByKey.set(p.keyId, [rel]);
+    }
+  }
+
+  const identityById = new Map(identityRows.map((i) => [i.id, i.externalId]));
+
+  const keysResult: DatabaseKey[] = keyRows.map((k) => ({
+    id: k.id,
+    keyAuthId: k.keyAuthId,
+    name: k.name,
+    ownerId: k.ownerId,
+    identityId: k.identityId,
+    meta: k.meta,
+    enabled: k.enabled,
+    remaining: k.remaining,
+    environment: k.environment,
+    workspaceId: k.workspaceId,
+    roles: rolesByKey.get(k.id) ?? [],
+    permissions: permissionsByKey.get(k.id) ?? [],
+    identity:
+      k.identityId && identityById.has(k.identityId)
+        ? { externalId: identityById.get(k.identityId) as string }
+        : null,
+  }));
+
   let keyIdsFilter = keyIdsFromInput;
   if (!keyIdsFilter || keyIdsFilter.length === 0) {
-    if (keyIds.length > 0) {
-      // Build a filter using OR conditions with "is" operators
-      keyIdsFilter = keyIds.map((keyId) => ({
+    if (matchedKeyIds.length > 0) {
+      keyIdsFilter = matchedKeyIds.map((keyId) => ({
         operator: "is" as const,
         value: keyId,
       }));
@@ -305,9 +370,10 @@ export async function queryApiKeys({
   }
 
   return {
-    keyspaceId: combinedResults.keyAuth.id,
+    keyspaceId,
     keys: keysResult,
     keyIds: keyIdsFilter,
+    hasMore,
   };
 }
 

--- a/web/apps/dashboard/lib/trpc/routers/audit/fetch.ts
+++ b/web/apps/dashboard/lib/trpc/routers/audit/fetch.ts
@@ -76,7 +76,12 @@ export const fetchAuditLog = workspaceProcedure
           db.query.auditLog.findMany({
             where: and(...whereConditions),
             with: { targets: true },
-            orderBy: (table, { desc }) => [desc(table.time), desc(table.id)],
+            // Tiebreak on pk so the workspace_id_bucket_time_idx composite covers
+            // the sort — InnoDB stores pk as the implicit trailing column in
+            // every secondary index, so ORDER BY (time, pk) avoids a filesort.
+            // id is unique and monotonic-with-insert like pk, so pagination
+            // stability is preserved.
+            orderBy: (table, { desc }) => [desc(table.time), desc(table.pk)],
             limit: pageSize,
             offset,
           }),
@@ -94,7 +99,12 @@ export const fetchAuditLog = workspaceProcedure
           db.query.auditLog.findMany({
             where: and(...whereConditions),
             with: { targets: true },
-            orderBy: (table, { desc }) => [desc(table.time), desc(table.id)],
+            // Tiebreak on pk so the workspace_id_bucket_time_idx composite covers
+            // the sort — InnoDB stores pk as the implicit trailing column in
+            // every secondary index, so ORDER BY (time, pk) avoids a filesort.
+            // id is unique and monotonic-with-insert like pk, so pagination
+            // stability is preserved.
+            orderBy: (table, { desc }) => [desc(table.time), desc(table.pk)],
             limit: pageSize,
             offset,
           }),

--- a/web/apps/dashboard/lib/trpc/routers/deploy/project/list.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/project/list.ts
@@ -1,114 +1,192 @@
 import type { Project } from "@/lib/collections/deploy/projects";
-import { db, sql } from "@/lib/db";
+import { and, db, desc, eq, inArray, sql } from "@/lib/db";
 import { ratelimit, withRatelimit, workspaceProcedure } from "@/lib/trpc/trpc";
-import { apps, deployments, frontlineRoutes, projects } from "@unkey/db/src/schema";
-
-type ProjectRow = {
-  id: string;
-  name: string;
-  slug: string;
-  repository_full_name: string | null;
-  current_deployment_id: string | null;
-  is_rolled_back: boolean;
-  git_commit_message: string | null;
-  git_branch: string | null;
-  git_commit_author_handle: string | null;
-  git_commit_author_avatar_url: string | null;
-  git_commit_timestamp: number | null;
-  domain: string | null;
-  latest_deployment_id: string | null;
-};
+import {
+  apps,
+  deployments,
+  frontlineRoutes,
+  githubRepoConnections,
+  projects,
+} from "@unkey/db/src/schema";
 
 export const listProjects = workspaceProcedure
   .use(withRatelimit(ratelimit.read))
   .query(async ({ ctx }) => {
-    // Pick the most recently updated app that has a current deployment.
-    // This avoids hardcoding slug = 'default' and works for any number of apps.
-    const result = await db.execute(sql`
-      SELECT
-        ${projects.id},
-        ${projects.name},
-        ${projects.slug},
-        ${projects.updatedAt},
-        (
-          SELECT grc.repository_full_name
-          FROM github_repo_connections grc
-          WHERE grc.project_id = ${projects.id}
-          LIMIT 1
-        ) as repository_full_name,
-        (
-          SELECT a.current_deployment_id
-          FROM ${apps} a
-          WHERE a.project_id = ${projects.id}
-            AND a.current_deployment_id IS NOT NULL
-          ORDER BY a.updated_at DESC
-          LIMIT 1
-        ) as current_deployment_id,
-        (
-          SELECT a.is_rolled_back
-          FROM ${apps} a
-          WHERE a.project_id = ${projects.id}
-            AND a.current_deployment_id IS NOT NULL
-          ORDER BY a.updated_at DESC
-          LIMIT 1
-        ) as is_rolled_back,
-        ${deployments.gitCommitMessage},
-        ${deployments.gitBranch},
-        ${deployments.gitCommitAuthorHandle},
-        ${deployments.gitCommitAuthorAvatarUrl},
-        ${deployments.gitCommitTimestamp},
-        (
-          SELECT fr.fully_qualified_domain_name
-          FROM ${frontlineRoutes} fr
-          INNER JOIN ${projects} p ON p.id = fr.project_id AND p.workspace_id = ${ctx.workspace.id}
-          WHERE fr.project_id = ${projects.id}
-          ORDER BY (fr.sticky = 'live') DESC, fr.updated_at DESC
-          LIMIT 1
-        ) as domain,
-        (
-          SELECT id
-          FROM ${deployments} d
-          WHERE d.project_id = ${projects.id}
-            AND d.workspace_id = ${ctx.workspace.id}
-          ORDER BY d.created_at DESC
-          LIMIT 1
-        ) as latest_deployment_id
-      FROM ${projects}
-      LEFT JOIN ${deployments}
-        ON ${deployments.id} = (
-          SELECT a2.current_deployment_id
-          FROM ${apps} a2
-          WHERE a2.project_id = ${projects.id}
-            AND a2.current_deployment_id IS NOT NULL
-          ORDER BY a2.updated_at DESC
-          LIMIT 1
-        )
-        AND ${deployments.workspaceId} = ${ctx.workspace.id}
-      WHERE ${projects.workspaceId} = ${ctx.workspace.id}
-      ORDER BY ${projects.updatedAt} DESC
-    `);
+    const workspaceId = ctx.workspace.id;
 
-    return (result[0] as unknown as ProjectRow[]).map((row): Project => {
-      // Single source of truth for "has deployment" in the UI:
-      // we consider a deployment present when we have commit metadata from the joined row.
-      const hasDeployment = row.git_commit_timestamp !== null;
+    const projectRows = await db
+      .select({
+        id: projects.id,
+        name: projects.name,
+        slug: projects.slug,
+        updatedAt: projects.updatedAt,
+      })
+      .from(projects)
+      .where(eq(projects.workspaceId, workspaceId))
+      .orderBy(desc(projects.updatedAt));
+
+    if (projectRows.length === 0) {
+      return [] satisfies Project[];
+    }
+
+    const projectIds = projectRows.map((p) => p.id);
+
+    const [appRows, latestDeploymentRows, routeRows, repoRows] = await Promise.all([
+      // Each "*-by-project" query below relies on the reducer below picking
+      // the first row per projectId. Every ORDER BY therefore ends in a unique
+      // tiebreaker (id) so ties on updatedAt/createdAt don't produce a
+      // nondeterministic winner across requests.
+      db
+        .select({
+          projectId: apps.projectId,
+          currentDeploymentId: apps.currentDeploymentId,
+          isRolledBack: apps.isRolledBack,
+          updatedAt: apps.updatedAt,
+        })
+        .from(apps)
+        .where(
+          and(
+            eq(apps.workspaceId, workspaceId),
+            inArray(apps.projectId, projectIds),
+            sql`${apps.currentDeploymentId} IS NOT NULL`,
+          ),
+        )
+        .orderBy(apps.projectId, desc(apps.updatedAt), desc(apps.id)),
+      db
+        .select({
+          projectId: deployments.projectId,
+          id: deployments.id,
+          createdAt: deployments.createdAt,
+        })
+        .from(deployments)
+        .where(
+          and(eq(deployments.workspaceId, workspaceId), inArray(deployments.projectId, projectIds)),
+        )
+        .orderBy(deployments.projectId, desc(deployments.createdAt), desc(deployments.id)),
+      db
+        .select({
+          projectId: frontlineRoutes.projectId,
+          fullyQualifiedDomainName: frontlineRoutes.fullyQualifiedDomainName,
+          isLive: sql<number>`(${frontlineRoutes.sticky} = 'live')`,
+          updatedAt: frontlineRoutes.updatedAt,
+          id: frontlineRoutes.id,
+        })
+        .from(frontlineRoutes)
+        // frontline_routes has no workspace_id column, so join to projects to
+        // enforce workspace ownership explicitly. projectIds is already
+        // workspace-scoped, but the policy is that every query with user input
+        // must include ctx.workspace.id in its WHERE/JOIN conditions.
+        .innerJoin(
+          projects,
+          and(eq(projects.id, frontlineRoutes.projectId), eq(projects.workspaceId, workspaceId)),
+        )
+        .where(inArray(frontlineRoutes.projectId, projectIds))
+        .orderBy(
+          frontlineRoutes.projectId,
+          sql`(${frontlineRoutes.sticky} = 'live') DESC`,
+          desc(frontlineRoutes.updatedAt),
+          desc(frontlineRoutes.id),
+        ),
+      db
+        .select({
+          projectId: githubRepoConnections.projectId,
+          repositoryFullName: githubRepoConnections.repositoryFullName,
+        })
+        .from(githubRepoConnections)
+        .where(eq(githubRepoConnections.workspaceId, workspaceId)),
+    ]);
+
+    const primaryAppByProject = new Map<
+      string,
+      { currentDeploymentId: string; isRolledBack: boolean }
+    >();
+    for (const row of appRows) {
+      if (!row.currentDeploymentId || primaryAppByProject.has(row.projectId)) {
+        continue;
+      }
+      primaryAppByProject.set(row.projectId, {
+        currentDeploymentId: row.currentDeploymentId,
+        isRolledBack: Boolean(row.isRolledBack),
+      });
+    }
+
+    const latestDeploymentByProject = new Map<string, string>();
+    for (const row of latestDeploymentRows) {
+      if (latestDeploymentByProject.has(row.projectId)) {
+        continue;
+      }
+      latestDeploymentByProject.set(row.projectId, row.id);
+    }
+
+    const domainByProject = new Map<string, string>();
+    for (const row of routeRows) {
+      if (domainByProject.has(row.projectId)) {
+        continue;
+      }
+      domainByProject.set(row.projectId, row.fullyQualifiedDomainName);
+    }
+
+    const repoByProject = new Map<string, string>();
+    for (const row of repoRows) {
+      if (repoByProject.has(row.projectId)) {
+        continue;
+      }
+      repoByProject.set(row.projectId, row.repositoryFullName);
+    }
+
+    const currentDeploymentIds = Array.from(
+      new Set(
+        Array.from(primaryAppByProject.values())
+          .map((app) => app.currentDeploymentId)
+          .filter((id): id is string => Boolean(id)),
+      ),
+    );
+
+    const currentDeploymentRows = currentDeploymentIds.length
+      ? await db
+          .select({
+            id: deployments.id,
+            gitCommitMessage: deployments.gitCommitMessage,
+            gitBranch: deployments.gitBranch,
+            gitCommitAuthorHandle: deployments.gitCommitAuthorHandle,
+            gitCommitAuthorAvatarUrl: deployments.gitCommitAuthorAvatarUrl,
+            gitCommitTimestamp: deployments.gitCommitTimestamp,
+          })
+          .from(deployments)
+          .where(
+            and(
+              eq(deployments.workspaceId, workspaceId),
+              inArray(deployments.id, currentDeploymentIds),
+            ),
+          )
+      : [];
+
+    const currentDeploymentById = new Map(currentDeploymentRows.map((d) => [d.id, d]));
+
+    return projectRows.map((project): Project => {
+      const primaryApp = primaryAppByProject.get(project.id);
+      const currentDeployment = primaryApp
+        ? currentDeploymentById.get(primaryApp.currentDeploymentId)
+        : undefined;
+      const hasDeployment = currentDeployment?.gitCommitTimestamp != null;
 
       return {
-        id: row.id,
-        name: row.name,
-        slug: row.slug,
-        repositoryFullName: row.repository_full_name,
-        currentDeploymentId: row.current_deployment_id,
-        isRolledBack: row.is_rolled_back,
-        commitTitle: row.git_commit_message,
-        branch: row.git_branch ?? "main",
-        author: row.git_commit_author_handle,
-        // Preserve null instead of coercing to 0 when there is no deployment
+        id: project.id,
+        name: project.name,
+        slug: project.slug,
+        repositoryFullName: repoByProject.get(project.id) ?? null,
+        currentDeploymentId: primaryApp?.currentDeploymentId ?? null,
+        isRolledBack: primaryApp?.isRolledBack ?? false,
+        commitTitle: currentDeployment?.gitCommitMessage ?? null,
+        branch: currentDeployment?.gitBranch ?? "main",
+        author: currentDeployment?.gitCommitAuthorHandle ?? null,
+        authorAvatar: currentDeployment?.gitCommitAuthorAvatarUrl ?? null,
         commitTimestamp:
-          row.git_commit_timestamp === null ? null : Number(row.git_commit_timestamp),
-        authorAvatar: row.git_commit_author_avatar_url,
-        domain: hasDeployment ? row.domain : null,
-        latestDeploymentId: row.latest_deployment_id,
+          currentDeployment?.gitCommitTimestamp == null
+            ? null
+            : Number(currentDeployment.gitCommitTimestamp),
+        domain: hasDeployment ? (domainByProject.get(project.id) ?? null) : null,
+        latestDeploymentId: latestDeploymentByProject.get(project.id) ?? null,
       };
     });
   });

--- a/web/internal/db/src/schema/audit_logs.ts
+++ b/web/internal/db/src/schema/audit_logs.ts
@@ -38,12 +38,11 @@ export const auditLog = mysqlTable(
     ...lifecycleDates,
   },
   (table) => [
-    index("workspace_id_idx").on(table.workspaceId),
-    index("bucket_id_idx").on(table.bucketId),
-    index("bucket_idx").on(table.bucket),
-    index("event_idx").on(table.event),
-    index("actor_id_idx").on(table.actorId),
-    index("time_idx").on(table.time),
+    // Every dashboard SELECT filters by (workspace_id, bucket, time) and orders
+    // by time DESC. This one composite serves every code path; the old
+    // single-column indexes on workspace_id / bucket / bucket_id / event /
+    // actor_id / time saw zero traffic and were costing INSERT throughput.
+    index("workspace_id_bucket_time_idx").on(table.workspaceId, table.bucket, table.time),
   ],
 );
 
@@ -87,7 +86,6 @@ export const auditLogTarget = mysqlTable(
   },
   (table) => [
     unique("unique_id_per_log").on(table.auditLogId, table.id),
-    index("bucket").on(table.bucket),
     index("id_idx").on(table.id),
   ],
 );

--- a/web/internal/db/src/schema/keys.ts
+++ b/web/internal/db/src/schema/keys.ts
@@ -94,6 +94,14 @@ export const keys = mysqlTable(
       table.deletedAtM,
       table.id,
     ),
+    // Dashboard's keys-overview pagination sorts by last_used_at DESC under
+    // (key_auth_id, deletedAtM IS NULL) — without this, the list falls back
+    // to filesort and the p99 blows up to ~8s on busy keyspaces.
+    keyAuthDeletedLastUsedIndex: index("key_auth_id_deleted_at_last_used_at_idx").on(
+      table.keyAuthId,
+      table.deletedAtM,
+      table.lastUsedAt,
+    ),
     forWorkspaceIdIndex: index("idx_keys_on_for_workspace_id").on(table.forWorkspaceId),
     pendingMigrationIdIndex: index("pending_migration_id_idx").on(table.pendingMigrationId),
     workspaceIdIndex: index("idx_keys_on_workspace_id").on(table.workspaceId),


### PR DESCRIPTION
## What does this PR do?

Fixes several slow database queries in the dashboard that were causing high p99 latency on busy workspaces.

**API keys overview (`api-query.ts`):**
Replaces Drizzle's relational query API (which generated nested lateral joins with JSON aggregation, scanning millions of rows per call) with a flat `SELECT` on the `keys` table followed by three parallel bulk lookups for roles, permissions, and identities. A hard cap of 1,000 rows per query (`MAX_KEYS_PER_QUERY`) is also introduced to bound worst-case scans when filtering by name or identity without a keyIds cursor.

**Audit log (`fetch.ts`):**
Changes the `ORDER BY` tiebreaker from `id` to `pk` so that the `workspace_id_bucket_time_idx` composite index fully covers the sort in InnoDB, avoiding a filesort on every paginated audit log request.

**Deploy project list (`list.ts`):**
Replaces a single large raw SQL query containing multiple correlated subqueries with four parallel Drizzle queries followed by in-memory map lookups. This lets the database use targeted indexes on each table rather than re-scanning via correlated subqueries for every project row.

**Schema index changes:**
- `audit_logs`: Replaces six single-column indexes (`workspace_id_idx`, `bucket_id_idx`, `bucket_idx`, `event_idx`, `actor_id_idx`, `time_idx`) with a single composite `workspace_id_bucket_time_idx` that covers every dashboard query path, reducing INSERT overhead.
- `keys`: Adds `key_auth_id_deleted_at_last_used_at_idx` to support the keys-overview pagination sort by `last_used_at DESC` under `(key_auth_id, deletedAtM IS NULL)`, which was previously falling back to a filesort and hitting ~8s p99 on busy keyspaces.

audit_log query performance

Benchmark: local MySQL, 10M rows, 70% in target workspace ws_audit_bench, 30% split across 99 noise workspaces. 
Each query run 5x against a 24h lookback window on bucket = 'unkey_mutations'

TL;DR

query      before p50   after p50   before p99   after p99   speedup
---------  ----------   ---------   ----------   ---------   -------
count(*)      3877 ms       20 ms      6799 ms       37 ms     ~194x
list LIMIT    4010 ms        2 ms      4369 ms       51 ms    ~2000x

EXPLAIN before (no composite)

count:  type=ALL  key=-  rows=9,979,748  Using where
list:   type=ALL  key=-  rows=9,979,748  Using where; Using filesort

EXPLAIN after (with workspace_id_bucket_time_idx)

count:  type=range  key=workspace_id_bucket_time_idx  rows=94,344  Using where; Using index
list:   type=range  key=workspace_id_bucket_time_idx  rows=94,344  Using index condition; Backward index scan

Raw runs

Before:

run 1/5: count=3047ms list=4193ms
run 2/5: count=3228ms list=3935ms
run 3/5: count=3897ms list=4010ms
run 4/5: count=3877ms list=4369ms
run 5/5: count=6799ms list=3510ms

count: min=3047 p50=3877 p99=6799 avg=4170
list : min=3510 p50=4010 p99=4369 avg=4003

After:

run 1/5: count=20ms list=51ms
run 2/5: count=37ms list=2ms
run 3/5: count=21ms list=2ms
run 4/5: count=19ms list=1ms
run 5/5: count=20ms list=2ms

count: min=19 p50=20 p99=37 avg=23
list : min=1  p50=2  p99=51 avg=12

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How should this be tested?

- Load the keys overview page for an API with a large number of keys and verify it loads within an acceptable time (well under 8s p99).
- Apply name, identity, and key ID filters on the keys overview and confirm results are correct and performant.
- Navigate to the audit log page and verify pagination returns correct, stably-ordered results.
- Navigate to the deploy projects list and confirm all project metadata (current deployment, domain, repo, commit info) renders correctly.
- Verify that no regressions exist for workspaces with zero keys or zero projects.

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary