### PR TITLE
fix(builds): invalidate build cache when project variables change

### DIFF
--- a/docs/product/builds/dockerfile-prompt.mdx
+++ b/docs/product/builds/dockerfile-prompt.mdx
@@ -70,16 +70,22 @@ them.
    - `/tmp`: small, memory-backed scratch space, always available.
    - `/data`: available only if ephemeral storage is configured. The mount
      path is exposed in the `UNKEY_EPHEMERAL_DISK_PATH` env var.
-4. Build-time secrets come from a mounted file, never `ARG` or `ENV`. If the
-   build needs secrets (private package tokens, codegen against a real DB
-   URL), consume them like this:
+4. Build-time secrets come from a mounted file, never `ARG` or `ENV` for
+   the values themselves. If the build needs secrets (private package
+   tokens, codegen against a real DB URL), consume them like this:
 
-   RUN --mount=type=secret,id=env,target=/run/secrets/.env \
+   ARG UNKEY_SECRETS_ID
+   RUN --mount=type=secret,id=${UNKEY_SECRETS_ID},target=/run/secrets/.env \
        set -a && . /run/secrets/.env && set +a && \
        <your build command>
 
-   `ARG` and `ENV` values are visible in `docker history` and leak into the
-   final image. Don't use them for secrets.
+   `UNKEY_SECRETS_ID` is a build argument Unkey injects. Declare
+   `ARG UNKEY_SECRETS_ID` in every stage that mounts the secret; ARG
+   values are not inherited across stages.
+
+   `ARG` and `ENV` values for actual secret content are visible in
+   `docker history` and leak into the final image. Don't use them that
+   way.
 
 ## Step 3: Apply these best practices
 
@@ -163,7 +169,7 @@ Produce:
 
 After the agent finishes, skim the result for these specifics:
 
-The `CMD` instruction uses the exec form (JSON array, not a bare string), so your app receives `SIGTERM` directly when Unkey drains an instance. Any `RUN` step that needs a secret uses the `--mount=type=secret,id=env,target=/run/secrets/.env` pattern rather than `ARG` or `ENV`. The base image is pinned to a specific version and your final stage is slim enough that it doesn't carry the whole build toolchain.
+The `CMD` instruction uses the exec form (JSON array, not a bare string), so your app receives `SIGTERM` directly when Unkey drains an instance. Any `RUN` step that needs a secret uses the `--mount=type=secret,id=${UNKEY_SECRETS_ID},target=/run/secrets/.env` pattern with `ARG UNKEY_SECRETS_ID` declared in the same stage, rather than `ARG` or `ENV` for the values themselves. The base image is pinned to a specific version and your final stage is slim enough that it doesn't carry the whole build toolchain.
 
 If any of those are wrong, ask the agent to fix them directly. The prompt is short enough to tweak and re-run if your project has an unusual shape.
 

--- a/docs/product/builds/overview.mdx
+++ b/docs/product/builds/overview.mdx
@@ -43,19 +43,20 @@ See [App settings](/platform/apps/settings#build-settings) for the full referenc
 
 Some builds need access to environment variables during the build step, for example to install private packages or generate code. All [variables](/platform/variables/overview) configured for the environment are available as Docker build secrets.
 
-Unkey mounts all your variables as a `.env` file at `/run/secrets/.env` inside the build container. To use them, add a `--mount=type=secret` flag to the `RUN` step that needs them. Copy the mount flag exactly as shown, the `id` and `target` values are set by Unkey.
+Unkey mounts all your variables as a `.env` file at `/run/secrets/.env` inside the build container. To use them, add a `--mount=type=secret` flag to the `RUN` step that needs them. Unkey exposes a build argument called `UNKEY_SECRETS_ID` that you reference as the mount's `id` (see [Variable changes and the build cache](#variable-changes-and-the-build-cache)).
 
 Here's a complete example for a Node.js app that needs environment variables during the build step:
 
 ```dockerfile Dockerfile
 FROM node:lts-alpine AS builder
+ARG UNKEY_SECRETS_ID
 
 WORKDIR /app
 COPY . .
 RUN npm install
 
 # Mount the secrets file and load variables into the shell
-RUN --mount=type=secret,id=env,target=/run/secrets/.env \
+RUN --mount=type=secret,id=${UNKEY_SECRETS_ID},target=/run/secrets/.env \
     set -a && . /run/secrets/.env && set +a && \
     pnpm build
 
@@ -64,6 +65,8 @@ WORKDIR /app
 COPY --from=builder /app .
 CMD ["node", "dist/index.js"]
 ```
+
+Declare `ARG UNKEY_SECRETS_ID` inside every stage that mounts the secret. ARG values aren't inherited across stages, so each `FROM ... AS <stage>` that consumes variables needs its own declaration.
 
 The secrets file uses standard `.env` syntax, one variable per line:
 
@@ -83,6 +86,10 @@ How you consume the file depends on your toolchain:
 ### Why secret mounts instead of ARG or ENV?
 
 Docker's `ARG` and `ENV` instructions are stored in the image layer history. Anyone with access to the image can extract them with `docker history` or `docker inspect`. Secret mounts avoid this problem: the file is available only during the `RUN` step and is never written to a layer.
+
+### Variable changes and the build cache
+
+`UNKEY_SECRETS_ID` is a hash of your project's variables. When you write `id=${UNKEY_SECRETS_ID}` on the mount line, BuildKit's cache key for that `RUN` includes the id, so any variable change produces a new id and a fresh execution of that step and everything after it in the same stage. Steps before the secret mount (base image pulls, dependency installs) keep caching normally.
 
 ## Build infrastructure
 

--- a/svc/ctrl/worker/deploy/build.go
+++ b/svc/ctrl/worker/deploy/build.go
@@ -349,17 +349,26 @@ func (w *Workflow) buildSolverOptions(
 	if err != nil {
 		return client.SolveOpt{}, fmt.Errorf("invalid environment variables: %w", err)
 	}
-	if envFile != nil {
-		sessionAttachables = append(sessionAttachables, secretsprovider.FromMap(map[string][]byte{"env": envFile}))
-	}
 
 	frontendAttrs := map[string]string{
 		"platform": platform,
 		"context":  contextURL,
 		"filename": dockerfilePath,
 	}
-	if h := hashEnvVars(envVars); h != "" {
+	if envFile != nil {
+		// Publish the same content under the stable "env" id (legacy) and the
+		// env-hash as a second id. Dockerfiles that reference
+		// id=${UNKEY_SECRETS_ID} see the mount declaration change when env
+		// content changes, which is what invalidates BuildKit's RUN cache
+		// key. id=env stays available so unmigrated Dockerfiles keep building
+		// during the rollout.
+		h := hashEnvVars(envVars)
+		sessionAttachables = append(sessionAttachables, secretsprovider.FromMap(map[string][]byte{
+			"env": envFile,
+			h:     envFile,
+		}))
 		frontendAttrs["label:org.unkey.env-hash"] = h
+		frontendAttrs["build-arg:UNKEY_SECRETS_ID"] = h
 	}
 
 	return client.SolveOpt{
@@ -393,17 +402,22 @@ func (w *Workflow) buildGitSolverOptions(
 	if err != nil {
 		return client.SolveOpt{}, fmt.Errorf("invalid environment variables: %w", err)
 	}
-	if envFile != nil {
-		secrets["env"] = envFile
-	}
 
 	frontendAttrs := map[string]string{
 		"platform": platform,
 		"context":  gitContextURL,
 		"filename": dockerfilePath,
 	}
-	if h := hashEnvVars(envVars); h != "" {
+	if envFile != nil {
+		// See buildSolverOptions for the dual-id rationale: legacy "env" keeps
+		// unmigrated Dockerfiles working, the hash-id lets the mount
+		// declaration vary with env content so BuildKit invalidates the
+		// secret-consuming RUN when a variable changes.
+		h := hashEnvVars(envVars)
+		secrets["env"] = envFile
+		secrets[h] = envFile
 		frontendAttrs["label:org.unkey.env-hash"] = h
+		frontendAttrs["build-arg:UNKEY_SECRETS_ID"] = h
 	}
 
 	return client.SolveOpt{

--- a/svc/kitchensink/BUILD.bazel
+++ b/svc/kitchensink/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/unkeyed/unkey/svc/kitchensink",
     visibility = ["//visibility:private"],
     deps = [
+        "//svc/kitchensink/buildinfo",
         "//svc/kitchensink/echo",
         "//svc/kitchensink/env",
         "//svc/kitchensink/headers",
@@ -22,4 +23,7 @@ go_binary(
     name = "kitchensink",
     embed = [":kitchensink_lib"],
     visibility = ["//visibility:public"],
+    x_defs = {
+        "github.com/unkeyed/unkey/svc/kitchensink/buildinfo.Version": "bazel",
+    },
 )

--- a/svc/kitchensink/Dockerfile
+++ b/svc/kitchensink/Dockerfile
@@ -12,7 +12,16 @@ RUN go mod download
 
 COPY svc/kitchensink ./svc/kitchensink
 
-RUN CGO_ENABLED=0 GOOS=linux go build -o /kitchensink ./svc/kitchensink
+# Unkey mounts project variables as a .env file at /run/secrets/.env
+# during build. VERSION is sourced from that file and baked into
+# buildinfo.Version via -ldflags -X, then served at GET /buildinfo.
+# The file is absent for local `docker build` runs — we guard with -f so
+# it still works outside the Unkey builder.
+RUN --mount=type=secret,id=env,target=/run/secrets/.env \
+    if [ -f /run/secrets/.env ]; then set -a && . /run/secrets/.env && set +a; fi && \
+    CGO_ENABLED=0 GOOS=linux go build \
+      -ldflags "-X 'github.com/unkeyed/unkey/svc/kitchensink/buildinfo.Version=${VERSION:-unset}'" \
+      -o /kitchensink ./svc/kitchensink
 
 FROM gcr.io/distroless/static-debian12
 

--- a/svc/kitchensink/Dockerfile
+++ b/svc/kitchensink/Dockerfile
@@ -5,6 +5,10 @@
 
 FROM golang:1.25-alpine AS builder
 
+# UNKEY_SECRETS_ID is supplied by the Unkey builder as a hash of the
+# project's variables.
+ARG UNKEY_SECRETS_ID
+
 WORKDIR /src
 
 COPY go.mod go.sum ./
@@ -12,12 +16,10 @@ RUN go mod download
 
 COPY svc/kitchensink ./svc/kitchensink
 
-# Unkey mounts project variables as a .env file at /run/secrets/.env
-# during build. VERSION is sourced from that file and baked into
-# buildinfo.Version via -ldflags -X, then served at GET /buildinfo.
-# The file is absent for local `docker build` runs — we guard with -f so
-# it still works outside the Unkey builder.
-RUN --mount=type=secret,id=env,target=/run/secrets/.env \
+# VERSION is sourced from the mounted .env file and baked into
+# buildinfo.Version via -ldflags -X, then served at GET /buildinfo. The
+# -f guard keeps local builds working when no secret is mounted.
+RUN --mount=type=secret,id=${UNKEY_SECRETS_ID},target=/run/secrets/.env \
     if [ -f /run/secrets/.env ]; then set -a && . /run/secrets/.env && set +a; fi && \
     CGO_ENABLED=0 GOOS=linux go build \
       -ldflags "-X 'github.com/unkeyed/unkey/svc/kitchensink/buildinfo.Version=${VERSION:-unset}'" \

--- a/svc/kitchensink/README.md
+++ b/svc/kitchensink/README.md
@@ -33,6 +33,7 @@ svc/kitchensink/
 ├── main.go       — wires method+path → handler
 ├── hello/        — GET /hello, smoke test
 ├── env/          — GET /env, process environment
+├── buildinfo/    — GET /buildinfo, value injected via -ldflags -X
 ├── principal/    — GET /principal, decodes X-Unkey-Principal
 ├── headers/      — GET /headers, echoes request headers
 ├── echo/         — POST /echo, echoes body verbatim

--- a/svc/kitchensink/buildinfo/BUILD.bazel
+++ b/svc/kitchensink/buildinfo/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "buildinfo",
+    srcs = ["handler.go"],
+    importpath = "github.com/unkeyed/unkey/svc/kitchensink/buildinfo",
+    visibility = ["//visibility:public"],
+    deps = ["//svc/kitchensink/internal/httpx"],
+)

--- a/svc/kitchensink/buildinfo/handler.go
+++ b/svc/kitchensink/buildinfo/handler.go
@@ -1,0 +1,31 @@
+// Package buildinfo exposes a string injected at link time. It verifies
+// that release pipelines can bake values (version, commit SHA,
+// timestamps) into the binary and read them back at runtime.
+//
+// Contrast with the env probe: env reads the process environment at
+// request time; buildinfo reads a constant the linker wrote into the
+// binary. The pipeline contract being exercised here is "build-time
+// variable → ldflags -X → package var", not "runtime env → os.Getenv".
+// In the Unkey builder the value originates from the project variables
+// mounted at /run/secrets/.env during the build; see the Dockerfile.
+package buildinfo
+
+import (
+	"net/http"
+
+	"github.com/unkeyed/unkey/svc/kitchensink/internal/httpx"
+)
+
+// Version is overwritten at link time. Override with:
+//
+//	go build -ldflags "-X 'github.com/unkeyed/unkey/svc/kitchensink/buildinfo.Version=<value>'"
+//
+// In Bazel the same wiring lives in x_defs on the kitchensink go_binary.
+// "unset" is the sentinel returned when no override was passed, so the
+// probe still serves a response during local `go run` sessions.
+var Version = "unset"
+
+// Handler returns the build-time Version as JSON. Registered by main.go.
+func Handler(w http.ResponseWriter, r *http.Request) {
+	httpx.JSON(w, http.StatusOK, map[string]string{"version": Version})
+}

--- a/svc/kitchensink/main.go
+++ b/svc/kitchensink/main.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/unkeyed/unkey/svc/kitchensink/buildinfo"
 	"github.com/unkeyed/unkey/svc/kitchensink/echo"
 	"github.com/unkeyed/unkey/svc/kitchensink/env"
 	"github.com/unkeyed/unkey/svc/kitchensink/headers"
@@ -39,6 +40,7 @@ var routes = []route{
 	{"GET /", "This page — lists every registered route.", index.Handler},
 	{"GET /hello", "Smoke test — returns 'hello, world'.", hello.Handler},
 	{"GET /env", "Process environment as JSON. Filter with ?prefix=.", env.Handler},
+	{"GET /buildinfo", "Returns the build-time Version injected via -ldflags -X.", buildinfo.Handler},
 	{"GET /principal", "Decodes X-Unkey-Principal and returns it.", principal.Handler},
 	{"GET /headers", "Incoming request headers as JSON.", headers.Handler},
 	{"POST /echo", "Returns the request body verbatim.", echo.Handler},


### PR DESCRIPTION
## Summary

- BuildKit excludes secret content from RUN cache keys, so a secret mount with a fixed id cache-hits on subsequent builds and re-bakes stale values into the image.
- Worker now publishes the env secret under a second id derived from `hashEnvVars(envVars)` and exposes that hash as the `UNKEY_SECRETS_ID` build argument.
- Dockerfiles that write `id=${UNKEY_SECRETS_ID}` get a fresh cache key on every variable change, so the secret-consuming step and everything after it in that stage re-runs with the new values.
- Docs (`builds/overview.mdx` and `builds/dockerfile-prompt.mdx`) updated to show the pattern.

## Customer-facing change

```dockerfile
FROM node:lts-alpine AS builder
ARG UNKEY_SECRETS_ID

RUN --mount=type=secret,id=${UNKEY_SECRETS_ID},target=/run/secrets/.env \
    set -a && . /run/secrets/.env && set +a && \
    pnpm build
```

`ARG UNKEY_SECRETS_ID` is needed in every stage that mounts the secret; ARG values don't cross stages.

## Test plan

- [ ] Build an app with a fixed source, deploy with `FOO=1`, curl an endpoint that echoes `FOO`, see `1`.
- [ ] Change `FOO` to `2` in project variables, redeploy without touching code, curl again, see `2`.
- [ ] Confirm the secret-consuming RUN re-executes in the build logs for the second build (not a cache hit).
- [ ] Confirm steps before the secret mount (base image, dependency installs) still cache hit.