### PR TITLE
fix(ctrl): fixes showing wrong metadata

### DIFF
--- a/svc/ctrl/api/github_webhook.go
+++ b/svc/ctrl/api/github_webhook.go
@@ -207,7 +207,12 @@ func (s *GitHubWebhook) handlePullRequest(ctx context.Context, w http.ResponseWr
 		sendOpts = append(sendOpts, restate.WithIdempotencyKey(deliveryID))
 	}
 
-	authorHandle := pr.User.Login
+	authorHandle := payload.Sender.Login
+	authorAvatar := payload.Sender.AvatarURL
+	if authorAvatar == "" {
+		authorAvatar = fmt.Sprintf("https://github.com/%s.png", authorHandle)
+	}
+
 	_, err := client.HandlePush().Send(ctx, &hydrav1.HandlePushRequest{
 		InstallationId:         payload.Installation.ID,
 		RepositoryId:           baseRepo.ID,
@@ -216,7 +221,7 @@ func (s *GitHubWebhook) handlePullRequest(ctx context.Context, w http.ResponseWr
 		After:                  pr.Head.SHA,
 		CommitMessage:          pr.Title,
 		CommitAuthorHandle:     authorHandle,
-		CommitAuthorAvatarUrl:  fmt.Sprintf("https://github.com/%s.png", authorHandle),
+		CommitAuthorAvatarUrl:  authorAvatar,
 		CommitTimestamp:        time.Now().UnixMilli(),
 		DeliveryId:             deliveryID,
 		SenderLogin:            payload.Sender.Login,

--- a/svc/ctrl/api/github_webhook.go
+++ b/svc/ctrl/api/github_webhook.go
@@ -57,7 +57,6 @@ func (s *GitHubWebhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxWebhookBodySize))
-
 	if err != nil {
 		logger.Warn("GitHub webhook rejected: failed to read body", "error", err)
 		http.Error(w, "failed to read body", http.StatusBadRequest)
@@ -89,7 +88,6 @@ func (s *GitHubWebhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		logger.Info("Unhandled event type", "event", event)
 		w.WriteHeader(http.StatusOK)
 	}
-
 }
 
 // handlePush parses the push payload, extracts commit metadata, and sends
@@ -278,26 +276,18 @@ func extractGitCommitInfo(payload *pushPayload) githubclient.CommitInfo {
 		return githubclient.CommitInfoFromRaw("", "", "", "", "")
 	}
 
-	// Use the first commit's author as the originator (PR creator).
-	// For a merged PR, head_commit is the merge commit whose author is the
-	// merger; commits[0] is the original PR work commit whose author is the
-	// PR creator. For a direct push, commits[0] == head_commit so this is
-	// equivalent.
-	authorCommit := headCommit
-	if len(payload.Commits) > 0 {
-		authorCommit = &payload.Commits[0]
-	}
+	authorHandle := payload.Sender.Login
+	authorAvatar := payload.Sender.AvatarURL
 
-	authorHandle := authorCommit.Author.Username
-	if authorHandle == "" {
-		authorHandle = authorCommit.Author.Name
+	if authorAvatar == "" {
+		authorAvatar = fmt.Sprintf("https://github.com/%s.png", authorHandle)
 	}
 
 	return githubclient.CommitInfoFromRaw(
 		headCommit.ID,
 		headCommit.Message,
 		authorHandle,
-		fmt.Sprintf("https://github.com/%s.png", authorHandle),
+		authorAvatar,
 		headCommit.Timestamp,
 	)
 }

--- a/svc/ctrl/api/github_webhook.go
+++ b/svc/ctrl/api/github_webhook.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -210,7 +211,7 @@ func (s *GitHubWebhook) handlePullRequest(ctx context.Context, w http.ResponseWr
 	authorHandle := payload.Sender.Login
 	authorAvatar := payload.Sender.AvatarURL
 	if authorAvatar == "" {
-		authorAvatar = fmt.Sprintf("https://github.com/%s.png", authorHandle)
+		authorAvatar = fmt.Sprintf("https://github.com/%s.png", url.PathEscape(authorHandle))
 	}
 
 	_, err := client.HandlePush().Send(ctx, &hydrav1.HandlePushRequest{
@@ -285,7 +286,7 @@ func extractGitCommitInfo(payload *pushPayload) githubclient.CommitInfo {
 	authorAvatar := payload.Sender.AvatarURL
 
 	if authorAvatar == "" {
-		authorAvatar = fmt.Sprintf("https://github.com/%s.png", authorHandle)
+		authorAvatar = fmt.Sprintf("https://github.com/%s.png", url.PathEscape(authorHandle))
 	}
 
 	return githubclient.CommitInfoFromRaw(

--- a/svc/ctrl/api/github_webhook_integration_test.go
+++ b/svc/ctrl/api/github_webhook_integration_test.go
@@ -48,8 +48,8 @@ func TestGitHubWebhook_Push_TriggersHandlePush(t *testing.T) {
 		require.Equal(t, "main", req.GetBranch())
 		require.Equal(t, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", req.GetAfter())
 		require.Equal(t, "Merge pull request #1 from pr-creator/feat", req.GetCommitMessage())
-		require.Equal(t, "pr-creator", req.GetCommitAuthorHandle())
-		require.Equal(t, "https://github.com/pr-creator.png", req.GetCommitAuthorAvatarUrl())
+		require.Equal(t, "merger", req.GetCommitAuthorHandle())
+		require.Equal(t, "https://avatar", req.GetCommitAuthorAvatarUrl())
 		require.NotZero(t, req.GetCommitTimestamp())
 	case <-time.After(10 * time.Second):
 		t.Fatal("expected HandlePush invocation")

--- a/svc/ctrl/worker/github/BUILD.bazel
+++ b/svc/ctrl/worker/github/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "github",
@@ -19,4 +19,11 @@ go_library(
         "//pkg/jwt",
         "//pkg/logger",
     ],
+)
+
+go_test(
+    name = "github_test",
+    srcs = ["client_test.go"],
+    embed = [":github"],
+    deps = ["@com_github_stretchr_testify//require"],
 )

--- a/svc/ctrl/worker/github/client.go
+++ b/svc/ctrl/worker/github/client.go
@@ -221,7 +221,7 @@ func (c *Client) GetBranchHeadCommit(installationID int64, repo string, branch s
 		commit.SHA,
 		commit.Commit.Message,
 		commit.Commit.Author.Name,
-		fmt.Sprintf("https://github.com/%s.png", commit.Commit.Author.Name),
+		fmt.Sprintf("https://github.com/%s.png", url.PathEscape(commit.Commit.Author.Name)),
 		commit.Commit.Author.Date,
 	)
 

--- a/svc/ctrl/worker/github/client.go
+++ b/svc/ctrl/worker/github/client.go
@@ -217,15 +217,13 @@ func (c *Client) GetBranchHeadCommit(installationID int64, repo string, branch s
 	// verified GitHub account. If two users share the same unconfigured email
 	// (e.g. sean@seans-MacBook-Pro.local), it resolves to the wrong user.
 	// Use raw git metadata instead to bypass this.
-	info := CommitInfoFromRaw(
+	return CommitInfoFromRaw(
 		commit.SHA,
 		commit.Commit.Message,
 		commit.Commit.Author.Name,
 		fmt.Sprintf("https://github.com/%s.png", url.PathEscape(commit.Commit.Author.Name)),
 		commit.Commit.Author.Date,
-	)
-
-	return info, nil
+	), nil
 }
 
 // GetBranchHeadCommitPublic retrieves the HEAD commit of a branch using the
@@ -241,8 +239,8 @@ func (c *Client) GetBranchHeadCommitPublic(repo string, branch string) (CommitIn
 	return CommitInfoFromRaw(
 		commit.SHA,
 		commit.Commit.Message,
-		commit.Author.Login,
-		commit.Author.AvatarURL,
+		commit.Commit.Author.Name,
+		fmt.Sprintf("https://github.com/%s.png", url.PathEscape(commit.Commit.Author.Name)),
 		commit.Commit.Author.Date,
 	), nil
 }
@@ -264,8 +262,8 @@ func (c *Client) GetCommitBySHA(installationID int64, repo string, sha string) (
 	return CommitInfoFromRaw(
 		commit.SHA,
 		commit.Commit.Message,
-		commit.Author.Login,
-		commit.Author.AvatarURL,
+		commit.Commit.Author.Name,
+		fmt.Sprintf("https://github.com/%s.png", url.PathEscape(commit.Commit.Author.Name)),
 		commit.Commit.Author.Date,
 	), nil
 }

--- a/svc/ctrl/worker/github/client.go
+++ b/svc/ctrl/worker/github/client.go
@@ -34,6 +34,7 @@ type ghCommitDetail struct {
 
 type ghCommitAuthor struct {
 	Date string `json:"date"`
+	Name string `json:"name"`
 }
 
 type ghUser struct {
@@ -203,16 +204,28 @@ func (c *Client) GetBranchHeadCommit(installationID int64, repo string, branch s
 
 	commit, err := request[ghCommitResponse](c.httpClient, http.MethodGet, apiURL, headers, nil, http.StatusOK)
 	if err != nil {
+		logger.Error("failed to fetch branch head commit",
+			"installation_id", installationID,
+			"repo", repo,
+			"branch", branch,
+			"url", apiURL,
+			"err", err,
+		)
 		return CommitInfo{}, err
 	}
-
-	return CommitInfoFromRaw(
+	// GitHub resolves commit.Author.Login by matching the git author email to a
+	// verified GitHub account. If two users share the same unconfigured email
+	// (e.g. sean@seans-MacBook-Pro.local), it resolves to the wrong user.
+	// Use raw git metadata instead to bypass this.
+	info := CommitInfoFromRaw(
 		commit.SHA,
 		commit.Commit.Message,
-		commit.Author.Login,
-		commit.Author.AvatarURL,
+		commit.Commit.Author.Name,
+		fmt.Sprintf("https://github.com/%s.png", commit.Commit.Author.Name),
 		commit.Commit.Author.Date,
-	), nil
+	)
+
+	return info, nil
 }
 
 // GetBranchHeadCommitPublic retrieves the HEAD commit of a branch using the

--- a/svc/ctrl/worker/github/client.go
+++ b/svc/ctrl/worker/github/client.go
@@ -3,6 +3,7 @@ package github
 import (
 	"context"
 	"crypto/hmac"
+	"crypto/md5"
 	"crypto/sha256"
 	"crypto/subtle"
 	"fmt"
@@ -28,13 +29,19 @@ type ghCommitResponse struct {
 }
 
 type ghCommitDetail struct {
-	Message string         `json:"message"`
-	Author  ghCommitAuthor `json:"author"`
+	Message      string               `json:"message"`
+	Author       ghCommitAuthor       `json:"author"`
+	Verification ghCommitVerification `json:"verification"`
+}
+
+type ghCommitVerification struct {
+	Verified bool `json:"verified"`
 }
 
 type ghCommitAuthor struct {
-	Date string `json:"date"`
-	Name string `json:"name"`
+	Date  string `json:"date"`
+	Name  string `json:"name"`
+	Email string `json:"email"`
 }
 
 type ghUser struct {
@@ -78,6 +85,7 @@ type collaboratorKey struct {
 // token retrieval for repository-level operations. It is safe for concurrent use.
 type Client struct {
 	config            ClientConfig
+	baseURL           string
 	httpClient        *http.Client
 	signer            jwt.Signer[jwt.RegisteredClaims]
 	tokenCache        cache.Cache[int64, InstallationToken]
@@ -116,6 +124,7 @@ func NewClient(config ClientConfig) (*Client, error) {
 
 	return &Client{
 		config:            config,
+		baseURL:           "https://api.github.com",
 		httpClient:        &http.Client{Timeout: 30 * time.Second},
 		signer:            signer,
 		tokenCache:        tokenCache,
@@ -200,7 +209,7 @@ func (c *Client) GetBranchHeadCommit(installationID int64, repo string, branch s
 		return CommitInfo{}, fault.Wrap(err, fault.Internal("failed to get installation token for branch head lookup"))
 	}
 
-	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/commits/%s", repo, url.PathEscape(branch))
+	apiURL := fmt.Sprintf("%s/repos/%s/commits/%s", c.baseURL, repo, url.PathEscape(branch))
 
 	commit, err := request[ghCommitResponse](c.httpClient, http.MethodGet, apiURL, headers, nil, http.StatusOK)
 	if err != nil {
@@ -213,36 +222,23 @@ func (c *Client) GetBranchHeadCommit(installationID int64, repo string, branch s
 		)
 		return CommitInfo{}, err
 	}
-	// GitHub resolves commit.Author.Login by matching the git author email to a
-	// verified GitHub account. If two users share the same unconfigured email
-	// (e.g. sean@seans-MacBook-Pro.local), it resolves to the wrong user.
-	// Use raw git metadata instead to bypass this.
-	return CommitInfoFromRaw(
-		commit.SHA,
-		commit.Commit.Message,
-		commit.Commit.Author.Name,
-		fmt.Sprintf("https://github.com/%s.png", url.PathEscape(commit.Commit.Author.Name)),
-		commit.Commit.Author.Date,
-	), nil
+
+	handle, avatarURL := resolveCommitAuthor(commit)
+	return CommitInfoFromRaw(commit.SHA, commit.Commit.Message, handle, avatarURL, commit.Commit.Author.Date), nil
 }
 
 // GetBranchHeadCommitPublic retrieves the HEAD commit of a branch using the
 // public GitHub API without authentication. Only works for public repositories.
 func (c *Client) GetBranchHeadCommitPublic(repo string, branch string) (CommitInfo, error) {
-	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/commits/%s", repo, url.PathEscape(branch))
+	apiURL := fmt.Sprintf("%s/repos/%s/commits/%s", c.baseURL, repo, url.PathEscape(branch))
 
 	commit, err := request[ghCommitResponse](c.httpClient, http.MethodGet, apiURL, githubHeaders(""), nil, http.StatusOK)
 	if err != nil {
 		return CommitInfo{}, err
 	}
 
-	return CommitInfoFromRaw(
-		commit.SHA,
-		commit.Commit.Message,
-		commit.Commit.Author.Name,
-		fmt.Sprintf("https://github.com/%s.png", url.PathEscape(commit.Commit.Author.Name)),
-		commit.Commit.Author.Date,
-	), nil
+	handle, avatarURL := resolveCommitAuthor(commit)
+	return CommitInfoFromRaw(commit.SHA, commit.Commit.Message, handle, avatarURL, commit.Commit.Author.Date), nil
 }
 
 // GetCommitBySHA retrieves commit metadata for a specific SHA.
@@ -252,20 +248,29 @@ func (c *Client) GetCommitBySHA(installationID int64, repo string, sha string) (
 		return CommitInfo{}, fault.Wrap(err, fault.Internal("failed to get installation token for commit lookup"))
 	}
 
-	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/commits/%s", repo, url.PathEscape(sha))
+	apiURL := fmt.Sprintf("%s/repos/%s/commits/%s", c.baseURL, repo, url.PathEscape(sha))
 
 	commit, err := request[ghCommitResponse](c.httpClient, http.MethodGet, apiURL, headers, nil, http.StatusOK)
 	if err != nil {
 		return CommitInfo{}, err
 	}
 
-	return CommitInfoFromRaw(
-		commit.SHA,
-		commit.Commit.Message,
-		commit.Commit.Author.Name,
-		fmt.Sprintf("https://github.com/%s.png", url.PathEscape(commit.Commit.Author.Name)),
-		commit.Commit.Author.Date,
-	), nil
+	handle, avatarURL := resolveCommitAuthor(commit)
+	return CommitInfoFromRaw(commit.SHA, commit.Commit.Message, handle, avatarURL, commit.Commit.Author.Date), nil
+}
+
+// resolveCommitAuthor picks the best author handle and avatar from a GitHub
+// commit response. When the commit is verified, GitHub's resolved user is
+// trustworthy. Otherwise we fall back to raw git metadata because GitHub's
+// email-based resolution can map to the wrong account.
+func resolveCommitAuthor(commit ghCommitResponse) (handle string, avatarURL string) {
+	if commit.Commit.Verification.Verified && commit.Author.Login != "" {
+		return commit.Author.Login, commit.Author.AvatarURL
+	}
+	name := commit.Commit.Author.Name
+	email := strings.ToLower(strings.TrimSpace(commit.Commit.Author.Email))
+	hash := fmt.Sprintf("%x", md5.Sum([]byte(email)))
+	return name, fmt.Sprintf("https://www.gravatar.com/avatar/%s?d=identicon", hash)
 }
 
 // CommitInfoFromRaw constructs a CommitInfo, truncating the message to the
@@ -324,7 +329,7 @@ func (c *Client) CreateDeployment(installationID int64, repo string, ref string,
 		return 0, err
 	}
 
-	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/deployments", repo)
+	apiURL := fmt.Sprintf("%s/repos/%s/deployments", c.baseURL, repo)
 
 	result, err := request[ghDeploymentResponse](c.httpClient, http.MethodPost, apiURL, headers, map[string]interface{}{
 		"ref":                    ref,
@@ -349,7 +354,7 @@ func (c *Client) CreateDeploymentStatus(installationID int64, repo string, deplo
 		return err
 	}
 
-	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/deployments/%d/statuses", repo, deploymentID)
+	apiURL := fmt.Sprintf("%s/repos/%s/deployments/%d/statuses", c.baseURL, repo, deploymentID)
 
 	payload := map[string]interface{}{
 		"state":         state,
@@ -375,7 +380,7 @@ func (c *Client) CreateCommitStatus(installationID int64, repo string, sha strin
 		return err
 	}
 
-	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/statuses/%s", repo, url.PathEscape(sha))
+	apiURL := fmt.Sprintf("%s/repos/%s/statuses/%s", c.baseURL, repo, url.PathEscape(sha))
 
 	return doRequest(c.httpClient, http.MethodPost, apiURL, headers, map[string]string{
 		"state":       state,
@@ -403,7 +408,7 @@ func (c *Client) ListCommitFiles(installationID int64, repo string, sha string) 
 		return nil, err
 	}
 
-	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/commits/%s", repo, url.PathEscape(sha))
+	apiURL := fmt.Sprintf("%s/repos/%s/commits/%s", c.baseURL, repo, url.PathEscape(sha))
 
 	commit, err := request[ghCommitWithFiles](c.httpClient, http.MethodGet, apiURL, headers, nil, http.StatusOK)
 	if err != nil {
@@ -436,8 +441,8 @@ func (c *Client) FindPullRequestForBranch(installationID int64, repo string, bra
 		return 0, err
 	}
 
-	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/pulls?state=open&head=%s:%s&per_page=1",
-		repo, strings.Split(repo, "/")[0], url.PathEscape(branch))
+	apiURL := fmt.Sprintf("%s/repos/%s/pulls?state=open&head=%s:%s&per_page=1",
+		c.baseURL, repo, strings.Split(repo, "/")[0], url.PathEscape(branch))
 
 	prs, err := request[[]ghPullRequest](c.httpClient, http.MethodGet, apiURL, headers, nil, http.StatusOK)
 	if err != nil {
@@ -457,7 +462,7 @@ func (c *Client) CreateIssueComment(installationID int64, repo string, prNumber 
 		return 0, err
 	}
 
-	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/issues/%d/comments", repo, prNumber)
+	apiURL := fmt.Sprintf("%s/repos/%s/issues/%d/comments", c.baseURL, repo, prNumber)
 
 	comment, err := request[ghIssueComment](c.httpClient, http.MethodPost, apiURL, headers, map[string]string{
 		"body": body,
@@ -475,7 +480,7 @@ func (c *Client) UpdateIssueComment(installationID int64, repo string, commentID
 		return err
 	}
 
-	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/issues/comments/%d", repo, commentID)
+	apiURL := fmt.Sprintf("%s/repos/%s/issues/comments/%d", c.baseURL, repo, commentID)
 
 	return doRequest(c.httpClient, http.MethodPatch, apiURL, headers, map[string]string{
 		"body": body,
@@ -491,7 +496,7 @@ func (c *Client) FindBotComment(installationID int64, repo string, prNumber int,
 	}
 
 	// Paginate through comments looking for our marker (most recent first)
-	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/issues/%d/comments?per_page=100&direction=desc", repo, prNumber)
+	apiURL := fmt.Sprintf("%s/repos/%s/issues/%d/comments?per_page=100&direction=desc", c.baseURL, repo, prNumber)
 
 	comments, err := request[[]ghIssueComment](c.httpClient, http.MethodGet, apiURL, headers, nil, http.StatusOK)
 	if err != nil {
@@ -520,7 +525,7 @@ func (c *Client) IsCollaborator(installationID int64, repo string, username stri
 				return false, err
 			}
 
-			apiURL := fmt.Sprintf("https://api.github.com/repos/%s/collaborators/%s", repo, url.PathEscape(username))
+			apiURL := fmt.Sprintf("%s/repos/%s/collaborators/%s", c.baseURL, repo, url.PathEscape(username))
 
 			return statusCheck(c.httpClient, http.MethodGet, apiURL, headers, http.StatusNoContent)
 		},

--- a/svc/ctrl/worker/github/client_test.go
+++ b/svc/ctrl/worker/github/client_test.go
@@ -1,0 +1,106 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveCommitAuthor(t *testing.T) {
+	tests := []struct {
+		name              string
+		commit            ghCommitResponse
+		expectedHandle    string
+		expectedAvatarURL string
+	}{
+		{
+			name: "unverified commit with misconfigured email falls back to git metadata",
+			commit: ghCommitResponse{
+				SHA: "aaa1111111111111111111111111111111111111",
+				Commit: ghCommitDetail{
+					Message: "fix: update config",
+					Author: ghCommitAuthor{
+						Name:  "alice",
+						Email: "alice@alices-MacBook-Pro.local",
+						Date:  "2026-04-22T13:09:45Z",
+					},
+					Verification: ghCommitVerification{Verified: false},
+				},
+				Author: ghUser{
+					Login:     "wronguser",
+					AvatarURL: "https://avatars.githubusercontent.com/u/99999?v=4",
+				},
+			},
+			expectedHandle:    "alice",
+			expectedAvatarURL: "https://www.gravatar.com/avatar/b91be39b212b63b1fac5e8041f01ae89?d=identicon",
+		},
+		{
+			name: "verified commit uses GitHub resolved author",
+			commit: ghCommitResponse{
+				SHA: "bbb2222222222222222222222222222222222222",
+				Commit: ghCommitDetail{
+					Message: "Update README.md",
+					Author: ghCommitAuthor{
+						Name:  "Alice",
+						Email: "alice@example.com",
+						Date:  "2026-04-22T13:50:03Z",
+					},
+					Verification: ghCommitVerification{Verified: true},
+				},
+				Author: ghUser{
+					Login:     "alice-gh",
+					AvatarURL: "https://avatars.githubusercontent.com/u/12345?v=4",
+				},
+			},
+			expectedHandle:    "alice-gh",
+			expectedAvatarURL: "https://avatars.githubusercontent.com/u/12345?v=4",
+		},
+		{
+			name: "verified commit from local with proper config uses GitHub resolved author",
+			commit: ghCommitResponse{
+				SHA: "ccc3333333333333333333333333333333333333",
+				Commit: ghCommitDetail{
+					Message: "feat: add endpoint",
+					Author: ghCommitAuthor{
+						Name:  "bob",
+						Email: "bob@company.com",
+						Date:  "2026-04-22T13:51:08Z",
+					},
+					Verification: ghCommitVerification{Verified: true},
+				},
+				Author: ghUser{
+					Login:     "bob-dev",
+					AvatarURL: "https://avatars.githubusercontent.com/u/67890?v=4",
+				},
+			},
+			expectedHandle:    "bob-dev",
+			expectedAvatarURL: "https://avatars.githubusercontent.com/u/67890?v=4",
+		},
+		{
+			name: "verified commit but empty GitHub login falls back to gravatar",
+			commit: ghCommitResponse{
+				SHA: "ddd4444444444444444444444444444444444444",
+				Commit: ghCommitDetail{
+					Message: "chore: cleanup",
+					Author: ghCommitAuthor{
+						Name:  "bob",
+						Email: "bob@localhost",
+						Date:  "2026-04-22T15:00:00Z",
+					},
+					Verification: ghCommitVerification{Verified: true},
+				},
+				Author: ghUser{},
+			},
+			expectedHandle:    "bob",
+			expectedAvatarURL: "https://www.gravatar.com/avatar/a1d4544a85858c1d7562c5659166af24?d=identicon",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handle, avatarURL := resolveCommitAuthor(tt.commit)
+			require.Equal(t, tt.expectedHandle, handle)
+			require.Equal(t, tt.expectedAvatarURL, avatarURL)
+		})
+	}
+}

--- a/web/apps/dashboard/components/api-requests-table/components/key-identifier-column.tsx
+++ b/web/apps/dashboard/components/api-requests-table/components/key-identifier-column.tsx
@@ -69,9 +69,7 @@ export const KeyIdentifierColumn = ({ log, apiId, onNavigate }: KeyIdentifierCol
 
       onNavigate?.();
 
-      router.push(
-        `/${workspace.slug}/apis/${apiId}/keys/${keyAuthId}/${log.key_id}`,
-      );
+      router.push(`/${workspace.slug}/apis/${apiId}/keys/${keyAuthId}/${log.key_id}`);
     },
     [apiId, log.key_id, keyAuthId, canNavigate, onNavigate, router, workspace.slug],
   );

--- a/web/apps/dashboard/lib/trpc/routers/deploy/domains/list.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/domains/list.ts
@@ -30,7 +30,10 @@ export const listDomains = workspaceProcedure
         and(eq(projects.id, frontlineRoutes.projectId), eq(projects.workspaceId, ctx.workspace.id)),
       )
       .where(
-        and(eq(frontlineRoutes.projectId, input.projectId), eq(projects.workspaceId, ctx.workspace.id)),
+        and(
+          eq(frontlineRoutes.projectId, input.projectId),
+          eq(projects.workspaceId, ctx.workspace.id),
+        ),
       )
       .orderBy(desc(frontlineRoutes.updatedAt))
       .limit(500)


### PR DESCRIPTION
## What does this PR do?

GH resolves `commit.Author.Login` by matching the git author email to a verified GH account. If two users share the same unconfigured local email (like sean@seans-MacBook-Pro.local), the API returns the wrong user's metadata. This PR uses raw git metadata instead, which bypasses email-based resolution entirely. And uses head commits author.

Also, for GH webhooks we now use "Sender" as our primary metadata source. What we did before was fragile because in some cases commits array was missing. This is safer and makes more sense because we show who actually did the action.

<img width="1285" height="271" alt="Screenshot 2026-04-22 at 13 52 26" src="https://github.com/user-attachments/assets/7c55b095-27ee-4854-a1bc-66364a8ba078" />
