### PR TITLE
fix(dashboard): show skeleton instead of empty card

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/components/deployments-card-list.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/components/deployments-card-list.tsx
@@ -14,11 +14,11 @@ export function DeploymentsCardList() {
   const currentDeploymentId = project?.currentDeploymentId;
   const workspace = useWorkspaceNavigation();
 
-  if (deployments.isLoading && !deployments.data) {
+  if (deployments.isLoading) {
     return <DeploymentsSkeleton />;
   }
 
-  if (!deployments.data || deployments.data.length === 0) {
+  if (deployments.data.length === 0) {
     return (
       <div className="border border-grayA-4 rounded-[14px] overflow-hidden">
         <div className="w-full flex justify-center items-center py-16 px-4">

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/components/deployments-skeleton.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/components/deployments-skeleton.tsx
@@ -10,23 +10,24 @@ export function DeploymentsSkeleton() {
         <div key={i} className="flex flex-col md:flex-row md:items-center px-4 py-3 gap-3 md:gap-0">
           {/* Identity + Status */}
           <div className="flex items-center justify-between md:contents">
-            <div className="md:w-[25%] md:shrink-0 flex flex-col gap-2 min-w-0">
+            <div className="md:w-[20%] md:shrink-0 flex flex-col gap-1 min-w-0">
               <div className="h-[14px] w-20 bg-grayA-3 rounded-sm animate-pulse" />
               <div className="h-3 w-16 bg-grayA-3 rounded-sm animate-pulse" />
             </div>
-            <div className="md:w-[15%] md:shrink-0">
+            <div className="md:w-[20%] md:shrink-0">
               <div className="h-5.5 w-20 bg-grayA-3 rounded-md animate-pulse" />
             </div>
           </div>
 
           {/* Source */}
-          <div className="md:w-[30%] md:shrink-0 flex flex-col gap-2 min-w-0">
-            <div className="flex items-center gap-2">
+          <div className="md:w-[30%] md:shrink-0 flex flex-col gap-1 min-w-0">
+            <div className="flex items-center gap-2 min-w-0">
               <div className="size-4 bg-grayA-3 rounded animate-pulse shrink-0" />
               <div className="h-[14px] w-20 bg-grayA-3 rounded-sm animate-pulse" />
               <div className="h-[14px] w-14 bg-grayA-3 rounded-sm animate-pulse" />
             </div>
-            <div className="pl-6">
+            <div className="flex items-center gap-2 min-w-0">
+              <div className="size-4 bg-grayA-3 rounded animate-pulse shrink-0" />
               <div className="h-3 w-32 bg-grayA-3 rounded-sm animate-pulse" />
             </div>
           </div>


### PR DESCRIPTION
## What does this PR do?

This PR shows the skeleton instead of empty card and adjust the skeletons for new styling.

https://github.com/user-attachments/assets/3118f095-ef5c-46dd-8d2d-0c642f08454e

