### PR TITLE
feat: slop coded one-click deploys

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/new/steps/create-project.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/new/steps/create-project.tsx
@@ -4,6 +4,7 @@ import {
   type CreateProjectRequestSchema,
   createProjectRequestSchema,
 } from "@/lib/collections/deploy/projects";
+import { slugify } from "@/lib/slugify";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { DuplicateKeyError } from "@tanstack/react-db";
 import { Button, FormInput, useStepWizard } from "@unkey/ui";
@@ -65,14 +66,7 @@ export const CreateProjectStep = ({ onProjectCreated }: CreateProjectStepProps) 
   };
 
   const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const name = e.target.value;
-    const slug = name
-      .toLowerCase()
-      .replace(/[^a-z0-9\s-]/g, "")
-      .replace(/\s+/g, "-")
-      .replace(/-+/g, "-")
-      .replace(/^-|-$/g, "");
-    setValue("slug", slug);
+    setValue("slug", slugify(e.target.value));
   };
 
   return (

--- a/web/apps/dashboard/app/(app)/integrations/github/callback/page.tsx
+++ b/web/apps/dashboard/app/(app)/integrations/github/callback/page.tsx
@@ -21,6 +21,10 @@ export default function Page() {
 
   const mutation = trpc.github.registerInstallation.useMutation({
     onSuccess: (data) => {
+      if (data.kind === "clone") {
+        router.replace(`/new/clone?${data.params}`);
+        return;
+      }
       if (data.returnTo === "settings") {
         router.replace(`/${data.workspaceSlug}/projects/${data.projectId}/settings`);
       } else {

--- a/web/apps/dashboard/app/new/clone/deploy-form.tsx
+++ b/web/apps/dashboard/app/new/clone/deploy-form.tsx
@@ -1,0 +1,269 @@
+"use client";
+
+import { trpcClient } from "@/lib/collections/client";
+import { Button, FormInput, toast } from "@unkey/ui";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useMemo, useState } from "react";
+import { type CloneParams, slugify } from "./parse-params";
+
+type DeployFormProps = {
+  workspaceSlug: string;
+  installationId: number;
+  repository: {
+    id: number;
+    fullName: string;
+    defaultBranch: string;
+    htmlUrl: string;
+  };
+  params: CloneParams;
+};
+
+export function DeployForm({ workspaceSlug, installationId, repository, params }: DeployFormProps) {
+  const router = useRouter();
+  const initialName = params.projectName ?? repository.fullName.split("/")[1] ?? "";
+
+  const [name, setName] = useState(initialName);
+  const [slug, setSlug] = useState(slugify(initialName));
+  const [branch, setBranch] = useState(params.branch ?? repository.defaultBranch);
+  const [rootDirectory, setRootDirectory] = useState(params.rootDirectory ?? "");
+  const [dockerfile, setDockerfile] = useState(params.dockerfile ?? "");
+  const [envValues, setEnvValues] = useState<Record<string, string>>(() =>
+    Object.fromEntries(params.envKeys.map((k) => [k, ""])),
+  );
+  const [slugTouched, setSlugTouched] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const errors = useMemo(
+    () => validate({ name, slug, branch, envValues, envKeys: params.envKeys }),
+    [name, slug, branch, envValues, params.envKeys],
+  );
+  const isValid = Object.keys(errors).length === 0;
+
+  const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const next = e.target.value;
+    setName(next);
+    if (!slugTouched) {
+      setSlug(slugify(next));
+    }
+  };
+
+  const handleSlugChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSlug(e.target.value);
+    setSlugTouched(true);
+  };
+
+  const handleEnvChange = (key: string, value: string) => {
+    setEnvValues((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!isValid || isSubmitting) {
+      return;
+    }
+    setIsSubmitting(true);
+    try {
+      const { id: projectId } = await trpcClient.deploy.project.create.mutate({ name, slug });
+
+      await trpcClient.github.selectRepository.mutate({
+        projectId,
+        repositoryId: repository.id,
+        repositoryFullName: repository.fullName,
+        installationId,
+        selectedBranch: branch,
+      });
+
+      const { id: environmentId } = await trpcClient.deploy.project.getEnvironmentBySlug.query({
+        projectId,
+        slug: "production",
+      });
+
+      if (rootDirectory.trim().length > 0) {
+        await trpcClient.deploy.environmentSettings.build.updateDockerContext.mutate({
+          environmentId,
+          dockerContext: rootDirectory.trim(),
+        });
+      }
+
+      if (dockerfile.trim().length > 0) {
+        await trpcClient.deploy.environmentSettings.build.updateDockerfile.mutate({
+          environmentId,
+          dockerfile: dockerfile.trim(),
+        });
+      }
+
+      const variables = Object.entries(envValues)
+        .map(([key, value]) => ({ key, value: value.trim() }))
+        .filter((v) => v.value.length > 0)
+        .map((v) => ({
+          key: v.key,
+          value: v.value,
+          type: "writeonly" as const,
+        }));
+
+      if (variables.length > 0) {
+        await trpcClient.deploy.envVar.create.mutate({ environmentId, variables });
+      }
+
+      const { deploymentId } = await trpcClient.deploy.deployment.create.mutate({
+        projectId,
+        environmentSlug: "production",
+      });
+
+      router.push(`/${workspaceSlug}/projects/${projectId}/deployments/${deploymentId}`);
+    } catch (err) {
+      const description = err instanceof Error ? err.message : "Unknown error";
+      toast.error("Failed to deploy", { description });
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-6">
+      <div className="w-full max-w-2xl">
+        <div className="mb-6 flex flex-col items-center text-center">
+          <div className="text-2xl font-medium text-gray-12 leading-7">Unkey</div>
+          <h1 className="mt-6 text-lg font-semibold text-gray-12">Deploy from GitHub</h1>
+          <p className="mt-2 text-[13px] text-gray-10">
+            You're deploying{" "}
+            <a
+              href={repository.htmlUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-medium text-gray-12 underline underline-offset-2"
+            >
+              {repository.fullName}
+            </a>{" "}
+            to workspace <span className="font-medium text-gray-12">{workspaceSlug}</span>.
+          </p>
+        </div>
+
+        <form
+          onSubmit={onSubmit}
+          className="flex flex-col gap-4 rounded-[14px] border border-grayA-5 p-5"
+        >
+          <FormInput
+            requirement="required"
+            label="Project name"
+            description="A descriptive name for your project."
+            value={name}
+            onChange={handleNameChange}
+            error={errors.name}
+            placeholder="My awesome project"
+            data-1p-ignore
+          />
+
+          <FormInput
+            requirement="required"
+            label="Slug"
+            description="URL-friendly identifier (lowercase letters, numbers, hyphens)."
+            value={slug}
+            onChange={handleSlugChange}
+            error={errors.slug}
+            placeholder="my-awesome-project"
+            data-1p-ignore
+          />
+
+          <FormInput
+            requirement="required"
+            label="Production branch"
+            description="The branch to deploy when pushes hit the production environment."
+            value={branch}
+            onChange={(e) => setBranch(e.target.value)}
+            error={errors.branch}
+            placeholder={repository.defaultBranch}
+          />
+
+          <FormInput
+            requirement="optional"
+            label="Root directory"
+            description="Build context for the Docker build. Use this for monorepos."
+            value={rootDirectory}
+            onChange={(e) => setRootDirectory(e.target.value)}
+            placeholder="."
+          />
+
+          <FormInput
+            requirement="optional"
+            label="Dockerfile"
+            description="Path to the Dockerfile, relative to the root directory."
+            value={dockerfile}
+            onChange={(e) => setDockerfile(e.target.value)}
+            placeholder="Dockerfile"
+          />
+
+          {params.envKeys.length > 0 && (
+            <div className="flex flex-col gap-2 pt-2">
+              <div className="flex flex-col gap-1">
+                <span className="text-[13px] font-medium text-gray-12">Environment variables</span>
+                {params.envDescription && (
+                  <span className="text-[12px] text-gray-10">{params.envDescription}</span>
+                )}
+                {params.envLink && (
+                  <Link
+                    href={params.envLink}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-[12px] text-gray-11 underline underline-offset-2"
+                  >
+                    Where to find these values
+                  </Link>
+                )}
+              </div>
+              {params.envKeys.map((key) => (
+                <FormInput
+                  key={key}
+                  requirement="required"
+                  label={key}
+                  value={envValues[key] ?? ""}
+                  onChange={(e) => handleEnvChange(key, e.target.value)}
+                  error={errors[`env.${key}`]}
+                  type="password"
+                />
+              ))}
+            </div>
+          )}
+
+          <Button
+            type="submit"
+            variant="primary"
+            size="xlg"
+            disabled={!isValid || isSubmitting}
+            loading={isSubmitting}
+            className="mt-2 w-full rounded-lg"
+          >
+            Deploy
+          </Button>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+function validate(args: {
+  name: string;
+  slug: string;
+  branch: string;
+  envValues: Record<string, string>;
+  envKeys: string[];
+}): Record<string, string> {
+  const errors: Record<string, string> = {};
+  if (!args.name.trim()) {
+    errors.name = "Project name is required";
+  }
+  if (!args.slug.trim()) {
+    errors.slug = "Slug is required";
+  } else if (!/^[a-z0-9-]+$/.test(args.slug)) {
+    errors.slug = "Only lowercase letters, numbers, and hyphens";
+  }
+  if (!args.branch.trim()) {
+    errors.branch = "Branch is required";
+  }
+  for (const key of args.envKeys) {
+    if (!args.envValues[key] || !args.envValues[key].trim()) {
+      errors[`env.${key}`] = "Required";
+    }
+  }
+  return errors;
+}

--- a/web/apps/dashboard/app/new/clone/install-cta.tsx
+++ b/web/apps/dashboard/app/new/clone/install-cta.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { Github, Layers3 } from "@unkey/icons";
+import { Button, Empty } from "@unkey/ui";
+import type { ParsedRepository } from "./parse-params";
+
+type InstallCtaProps = {
+  repository: ParsedRepository;
+  cloneSearch: string;
+};
+
+export function InstallCta({ repository, cloneSearch }: InstallCtaProps) {
+  const state = JSON.stringify({ returnTo: "clone", params: cloneSearch });
+  const installUrl = `https://github.com/apps/${process.env.NEXT_PUBLIC_GITHUB_APP_NAME}/installations/new?state=${encodeURIComponent(state)}`;
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-6">
+      <div className="w-full max-w-xl flex flex-col items-center">
+        <Empty>
+          <Empty.Icon>
+            <Layers3 className="size-7 text-accent-12" iconSize="xl-medium" />
+          </Empty.Icon>
+          <Empty.Title>Install the Unkey GitHub App</Empty.Title>
+          <Empty.Description>
+            We need access to{" "}
+            <a
+              href={repository.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-medium text-gray-12 underline underline-offset-2"
+            >
+              {repository.fullName}
+            </a>{" "}
+            before we can deploy it. Install the Unkey GitHub App on this repository, then you'll
+            come right back here.
+          </Empty.Description>
+          <Empty.Actions>
+            <a href={installUrl}>
+              <Button variant="primary" size="lg" className="rounded-lg">
+                <Github className="size-[18px]! shrink-0" />
+                <span className="text-[13px] font-medium">Install on GitHub</span>
+              </Button>
+            </a>
+          </Empty.Actions>
+        </Empty>
+      </div>
+    </div>
+  );
+}

--- a/web/apps/dashboard/app/new/clone/page.tsx
+++ b/web/apps/dashboard/app/new/clone/page.tsx
@@ -1,0 +1,143 @@
+import { getAuth } from "@/lib/auth/get-auth";
+import { db } from "@/lib/db";
+import { getRepository } from "@/lib/github";
+import { Empty } from "@unkey/ui";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { DeployForm } from "./deploy-form";
+import { InstallCta } from "./install-cta";
+import { type CloneParams, buildCloneSearchString, parseCloneParams } from "./parse-params";
+
+export const dynamic = "force-dynamic";
+
+type Props = {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export default async function CloneDeployPage(props: Props) {
+  const search = await props.searchParams;
+
+  const parsed = parseCloneParams(search);
+  if (!parsed.ok) {
+    return <InvalidParams message={parsed.error} />;
+  }
+  const params = parsed.params;
+  const cloneSearch = buildCloneSearchString(params);
+  const cloneHref = `/new/clone?${cloneSearch}`;
+
+  const { userId, orgId } = await getAuth();
+  if (!userId || !orgId) {
+    redirect(`/auth/sign-in?redirect=${encodeURIComponent(cloneHref)}`);
+  }
+
+  const workspace = await db.query.workspaces.findFirst({
+    where: (table, { and, eq, isNull }) => and(eq(table.orgId, orgId), isNull(table.deletedAtM)),
+    columns: { id: true, slug: true },
+    with: {
+      githubAppInstallations: {
+        columns: { installationId: true },
+      },
+    },
+  });
+
+  if (!workspace) {
+    return <OnboardingRequired cloneHref={cloneHref} />;
+  }
+
+  const match = await findRepoInstallation(workspace.githubAppInstallations, params);
+
+  if (!match) {
+    return <InstallCta repository={params.repository} cloneSearch={cloneSearch} />;
+  }
+
+  return (
+    <DeployForm
+      workspaceSlug={workspace.slug}
+      installationId={match.installationId}
+      repository={{
+        id: match.repo.id,
+        fullName: match.repo.full_name,
+        defaultBranch: match.repo.default_branch,
+        htmlUrl: match.repo.html_url,
+      }}
+      params={params}
+    />
+  );
+}
+
+async function findRepoInstallation(
+  installations: Array<{ installationId: number }>,
+  params: CloneParams,
+) {
+  for (const installation of installations) {
+    try {
+      const repo = await getRepository(
+        installation.installationId,
+        params.repository.owner,
+        params.repository.repo,
+      );
+      return { installationId: installation.installationId, repo };
+    } catch (err) {
+      // 404 means this installation can't see the repo; keep searching.
+      // Any other error is an outage or auth issue the operator needs to see,
+      // but we still fall through so the user gets the install CTA rather
+      // than a 500 for a transient GitHub blip.
+      const message = err instanceof Error ? err.message : String(err);
+      if (!message.includes("GitHub API error 404")) {
+        console.error("clone: getRepository failed", {
+          installationId: installation.installationId,
+          owner: params.repository.owner,
+          repo: params.repository.repo,
+          error: message,
+        });
+      }
+    }
+  }
+  return null;
+}
+
+function InvalidParams({ message }: { message: string }) {
+  return (
+    <CenteredShell>
+      <Empty>
+        <Empty.Title>Invalid deploy link</Empty.Title>
+        <Empty.Description>{message}</Empty.Description>
+      </Empty>
+    </CenteredShell>
+  );
+}
+
+function OnboardingRequired({ cloneHref }: { cloneHref: string }) {
+  return (
+    <CenteredShell>
+      <Empty>
+        <Empty.Title>Finish setting up your workspace</Empty.Title>
+        <Empty.Description>
+          Create your workspace first, then open this link again to deploy.
+        </Empty.Description>
+        <Empty.Actions>
+          <Link
+            href="/new"
+            className="rounded-lg border border-grayA-5 px-3 py-2 text-[13px] text-gray-12 hover:bg-grayA-2"
+          >
+            Start onboarding
+          </Link>
+          <Link
+            href={cloneHref}
+            className="ml-2 rounded-lg px-3 py-2 text-[13px] text-gray-10 hover:text-gray-12"
+          >
+            Reload deploy link
+          </Link>
+        </Empty.Actions>
+      </Empty>
+    </CenteredShell>
+  );
+}
+
+function CenteredShell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-screen flex items-center justify-center p-6">
+      <div className="w-full max-w-md">{children}</div>
+    </div>
+  );
+}

--- a/web/apps/dashboard/app/new/clone/parse-params.test.ts
+++ b/web/apps/dashboard/app/new/clone/parse-params.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import { buildCloneSearchString, parseCloneParams } from "./parse-params";
+
+describe("parseCloneParams", () => {
+  it("rejects missing repository", () => {
+    const result = parseCloneParams({});
+    expect(result.ok).toBe(false);
+  });
+
+  it("parses a full GitHub URL", () => {
+    const result = parseCloneParams({
+      repository: "https://github.com/acme/widgets",
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.params.repository).toEqual({
+      owner: "acme",
+      repo: "widgets",
+      fullName: "acme/widgets",
+      url: "https://github.com/acme/widgets",
+    });
+  });
+
+  it("parses a GitHub URL with .git suffix and trailing slash", () => {
+    const result = parseCloneParams({
+      repository: "https://github.com/acme/widgets.git/",
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.params.repository.fullName).toBe("acme/widgets");
+  });
+
+  it("parses owner/repo shorthand", () => {
+    const result = parseCloneParams({ repository: "acme/widgets" });
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.params.repository.url).toBe("https://github.com/acme/widgets");
+  });
+
+  it("rejects a garbage repository value", () => {
+    const result = parseCloneParams({ repository: "not a repo" });
+    expect(result.ok).toBe(false);
+  });
+
+  it("defaults optional fields to null", () => {
+    const result = parseCloneParams({ repository: "acme/widgets" });
+    if (!result.ok) {
+      throw new Error("expected ok");
+    }
+    expect(result.params.projectName).toBeNull();
+    expect(result.params.branch).toBeNull();
+    expect(result.params.rootDirectory).toBeNull();
+    expect(result.params.dockerfile).toBeNull();
+    expect(result.params.envDescription).toBeNull();
+    expect(result.params.envLink).toBeNull();
+    expect(result.params.envKeys).toEqual([]);
+  });
+
+  it("parses env keys and dedups while preserving order", () => {
+    const result = parseCloneParams({
+      repository: "acme/widgets",
+      env: "FOO,BAR,FOO, BAZ ,",
+    });
+    if (!result.ok) {
+      throw new Error("expected ok");
+    }
+    expect(result.params.envKeys).toEqual(["FOO", "BAR", "BAZ"]);
+  });
+
+  it("rejects invalid env key characters", () => {
+    const result = parseCloneParams({
+      repository: "acme/widgets",
+      env: "OK,BAD KEY",
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects a non-URL envLink", () => {
+    const result = parseCloneParams({
+      repository: "acme/widgets",
+      envLink: "not-a-url",
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("uses the first value when a query param repeats", () => {
+    const result = parseCloneParams({
+      repository: ["acme/widgets", "other/repo"],
+    });
+    if (!result.ok) {
+      throw new Error("expected ok");
+    }
+    expect(result.params.repository.fullName).toBe("acme/widgets");
+  });
+
+  it("round-trips through buildCloneSearchString", () => {
+    const first = parseCloneParams({
+      repository: "https://github.com/acme/widgets",
+      "project-name": "Widgets",
+      branch: "main",
+      "root-directory": "apps/api",
+      dockerfile: "docker/api.Dockerfile",
+      env: "FOO,BAR",
+      envDescription: "API secrets",
+      envLink: "https://acme.com/docs",
+    });
+    if (!first.ok) {
+      throw new Error("expected ok");
+    }
+
+    const rebuilt = parseCloneParams(
+      Object.fromEntries(new URLSearchParams(buildCloneSearchString(first.params))),
+    );
+    if (!rebuilt.ok) {
+      throw new Error("expected rebuilt ok");
+    }
+    expect(rebuilt.params).toEqual(first.params);
+  });
+});

--- a/web/apps/dashboard/app/new/clone/parse-params.ts
+++ b/web/apps/dashboard/app/new/clone/parse-params.ts
@@ -1,0 +1,158 @@
+import { envVarKeySchema } from "@/lib/schemas/env-var";
+import { slugify } from "@/lib/slugify";
+import { z } from "zod";
+
+export { slugify };
+
+const githubUrl = /^https?:\/\/github\.com\/([^/\s]+)\/([^/\s#?]+?)(?:\.git)?\/?$/;
+const ownerRepo = /^([^/\s]+)\/([^/\s]+?)(?:\.git)?$/;
+
+export type ParsedRepository = {
+  owner: string;
+  repo: string;
+  fullName: string;
+  url: string;
+};
+
+function parseRepository(raw: string): ParsedRepository | null {
+  const trimmed = raw.trim();
+  const url = trimmed.match(githubUrl);
+  if (url) {
+    const [, owner, repo] = url;
+    return {
+      owner,
+      repo,
+      fullName: `${owner}/${repo}`,
+      url: `https://github.com/${owner}/${repo}`,
+    };
+  }
+  const short = trimmed.match(ownerRepo);
+  if (short) {
+    const [, owner, repo] = short;
+    return {
+      owner,
+      repo,
+      fullName: `${owner}/${repo}`,
+      url: `https://github.com/${owner}/${repo}`,
+    };
+  }
+  return null;
+}
+
+const rawSchema = z.object({
+  repository: z.string().min(1),
+  "project-name": z.string().trim().min(1).max(256).optional(),
+  branch: z.string().trim().min(1).max(256).optional(),
+  "root-directory": z.string().trim().min(1).max(500).optional(),
+  dockerfile: z.string().trim().min(1).max(500).optional(),
+  env: z.string().optional(),
+  envDescription: z.string().trim().max(1024).optional(),
+  envLink: z.string().trim().url().optional(),
+});
+
+export type CloneParams = {
+  repository: ParsedRepository;
+  projectName: string | null;
+  branch: string | null;
+  rootDirectory: string | null;
+  dockerfile: string | null;
+  envKeys: string[];
+  envDescription: string | null;
+  envLink: string | null;
+};
+
+export type ParseResult = { ok: true; params: CloneParams } | { ok: false; error: string };
+
+function firstString(value: string | string[] | undefined): string | undefined {
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+  return value;
+}
+
+export function parseCloneParams(
+  search: Record<string, string | string[] | undefined>,
+): ParseResult {
+  const normalized: Record<string, string | undefined> = {};
+  for (const key of Object.keys(rawSchema.shape)) {
+    normalized[key] = firstString(search[key]);
+  }
+
+  const parsed = rawSchema.safeParse(normalized);
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    const field = issue.path.join(".") || "query";
+    return { ok: false, error: `Invalid ${field}: ${issue.message}` };
+  }
+
+  const repository = parseRepository(parsed.data.repository);
+  if (!repository) {
+    return {
+      ok: false,
+      error: "repository must be a GitHub URL (https://github.com/owner/repo) or owner/repo",
+    };
+  }
+
+  const envKeys: string[] = [];
+  if (parsed.data.env) {
+    const seen = new Set<string>();
+    for (const raw of parsed.data.env.split(",")) {
+      const key = raw.trim();
+      if (!key) {
+        continue;
+      }
+      const keyCheck = envVarKeySchema.safeParse(key);
+      if (!keyCheck.success) {
+        return {
+          ok: false,
+          error: `Invalid env var key "${key}": ${keyCheck.error.issues[0].message}`,
+        };
+      }
+      if (!seen.has(key)) {
+        seen.add(key);
+        envKeys.push(key);
+      }
+    }
+  }
+
+  return {
+    ok: true,
+    params: {
+      repository,
+      projectName: parsed.data["project-name"] ?? null,
+      branch: parsed.data.branch ?? null,
+      rootDirectory: parsed.data["root-directory"] ?? null,
+      dockerfile: parsed.data.dockerfile ?? null,
+      envKeys,
+      envDescription: parsed.data.envDescription ?? null,
+      envLink: parsed.data.envLink ?? null,
+    },
+  };
+}
+
+export function buildCloneSearchString(params: CloneParams): string {
+  const sp = new URLSearchParams();
+  sp.set("repository", params.repository.url);
+  if (params.projectName) {
+    sp.set("project-name", params.projectName);
+  }
+  if (params.branch) {
+    sp.set("branch", params.branch);
+  }
+  if (params.rootDirectory) {
+    sp.set("root-directory", params.rootDirectory);
+  }
+  if (params.dockerfile) {
+    sp.set("dockerfile", params.dockerfile);
+  }
+  if (params.envKeys.length > 0) {
+    sp.set("env", params.envKeys.join(","));
+  }
+  if (params.envDescription) {
+    sp.set("envDescription", params.envDescription);
+  }
+  if (params.envLink) {
+    sp.set("envLink", params.envLink);
+  }
+  return sp.toString();
+}

--- a/web/apps/dashboard/lib/trpc/routers/deploy/project/get-environment-by-slug.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/project/get-environment-by-slug.ts
@@ -1,0 +1,32 @@
+import { and, db, eq } from "@/lib/db";
+import { workspaceProcedure } from "@/lib/trpc/trpc";
+import { TRPCError } from "@trpc/server";
+import { environments } from "@unkey/db/src/schema";
+import { z } from "zod";
+
+export const getEnvironmentBySlug = workspaceProcedure
+  .input(
+    z.object({
+      projectId: z.string().min(1),
+      slug: z.string().min(1),
+    }),
+  )
+  .query(async ({ ctx, input }) => {
+    const environment = await db.query.environments.findFirst({
+      where: and(
+        eq(environments.workspaceId, ctx.workspace.id),
+        eq(environments.projectId, input.projectId),
+        eq(environments.slug, input.slug),
+      ),
+      columns: { id: true, appId: true },
+    });
+
+    if (!environment) {
+      throw new TRPCError({
+        code: "NOT_FOUND",
+        message: `Environment '${input.slug}' not found for this project`,
+      });
+    }
+
+    return { id: environment.id, appId: environment.appId };
+  });

--- a/web/apps/dashboard/lib/trpc/routers/github.ts
+++ b/web/apps/dashboard/lib/trpc/routers/github.ts
@@ -15,10 +15,17 @@ import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { t, workspaceProcedure } from "../trpc";
 
-const state = z.object({
+const projectState = z.object({
   projectId: z.string().min(1),
   returnTo: z.enum(["settings"]).optional(),
 });
+
+const cloneState = z.object({
+  returnTo: z.literal("clone"),
+  params: z.string().min(1),
+});
+
+const state = z.union([projectState, cloneState]);
 
 const fetchGithubContext = async (workspaceId: string, projectId: string) => {
   const project = await db.query.projects
@@ -169,6 +176,38 @@ export const githubRouter = t.router({
         });
       }
 
+      const saveInstallation = async () => {
+        await db
+          .insert(schema.githubAppInstallations)
+          .values({
+            workspaceId: ctx.workspace.id,
+            installationId: input.installationId,
+            createdAt: Date.now(),
+            updatedAt: null,
+          })
+          .onDuplicateKeyUpdate({
+            set: {
+              updatedAt: Date.now(),
+            },
+          })
+          .catch((err) => {
+            console.error(err);
+            throw new TRPCError({
+              code: "INTERNAL_SERVER_ERROR",
+              message: "Failed to save GitHub installation",
+            });
+          });
+      };
+
+      if ("params" in parsedState) {
+        await saveInstallation();
+        return {
+          kind: "clone" as const,
+          workspaceSlug: ctx.workspace.slug,
+          params: parsedState.params,
+        };
+      }
+
       const projectId = parsedState.projectId;
       const projectInstallation = await fetchProjectInstallation(
         ctx.workspace.id,
@@ -189,28 +228,10 @@ export const githubRouter = t.router({
         });
       }
 
-      await db
-        .insert(schema.githubAppInstallations)
-        .values({
-          workspaceId: ctx.workspace.id,
-          installationId: input.installationId,
-          createdAt: Date.now(),
-          updatedAt: null,
-        })
-        .onDuplicateKeyUpdate({
-          set: {
-            updatedAt: Date.now(),
-          },
-        })
-        .catch((err) => {
-          console.error(err);
-          throw new TRPCError({
-            code: "INTERNAL_SERVER_ERROR",
-            message: "Failed to save GitHub installation",
-          });
-        });
+      await saveInstallation();
 
       return {
+        kind: "project" as const,
         workspaceSlug: ctx.workspace.slug,
         projectId,
         returnTo: parsedState.returnTo ?? null,

--- a/web/apps/dashboard/lib/trpc/routers/index.ts
+++ b/web/apps/dashboard/lib/trpc/routers/index.ts
@@ -98,6 +98,7 @@ import { getSentinelRps } from "./deploy/network/get-sentinel-rps";
 import { createProject } from "./deploy/project/create";
 import { creationContext } from "./deploy/project/creation-context";
 import { deleteProject } from "./deploy/project/delete";
+import { getEnvironmentBySlug } from "./deploy/project/get-environment-by-slug";
 import { listProjects } from "./deploy/project/list";
 
 import { listInstances } from "./deploy/runtime-logs/list-instances";
@@ -426,6 +427,7 @@ export const router = t.router({
       create: createProject,
       delete: deleteProject,
       creationContext,
+      getEnvironmentBySlug,
     }),
     environmentSettings: t.router({
       get: getEnvironmentSettings,


### PR DESCRIPTION
# THIS IS SLOP AND JUST AN IDEA

 ## Summary
  - Adds a Vercel-style one-click deploy flow at `/new/clone?repository=...` that lands an authed user on a pre-filled form and, on
  submit, creates the project, links the repo, applies build settings, writes env vars, and triggers the first deployment in a single
  chain.
  - Supported query params: `repository` (full GitHub URL or `owner/repo`), `project-name`, `branch`, `root-directory`, `dockerfile`,
  `env` (comma-separated keys), `envDescription`, `envLink`.
  - If the repo isn't covered by any workspace GitHub App installation, the user hits an install CTA whose state round-trips the full
  clone query string, so they return to the same pre-filled form after installing.

  ## Implementation notes
  - New route `app/new/clone/` with server page (auth, workspace resolution, repo-access probe), a client deploy form, an install CTA,
   and a zod-backed param parser.
  - `registerInstallation` state is now a union of the existing `{ projectId, returnTo? }` and a new `{ returnTo: "clone", params }`;
  the GH callback page dispatches on a tagged `kind`.
  - New tRPC query `deploy.project.getEnvironmentBySlug` for looking up the production environment after project creation.
  - Dedup'd `slugify` across the new flow and the existing project wizard to the shared `lib/slugify.ts` (the wizard had its own
  inline version).
  - 11 unit tests for `parseCloneParams` covering URL/shorthand parsing, env-key dedup and validation, envLink rejection, array-query
  handling, and a round-trip through `buildCloneSearchString`.

  ## Out of scope (deliberate)
  - Public repos still require the GitHub App: `github_repo_connections.installation_id` is `NOT NULL` and the ctrl build path's
  unauthenticated clone is behind a dev-only flag. Separate change.
  - No workspace picker — uses the session's current workspace, matching the rest of the app.
  - No rollback if a mid-chain mutation fails; orphan projects are possible, same as the existing wizard.

  ## Test plan
  - [ ] `pnpm typecheck` clean, `biome check` clean, `pnpm vitest run app/new/clone/parse-params.test.ts` — 11 tests pass
  - [ ] Hit `http://localhost:3000/new/clone?repository=chronark/chronark.com` while signed out → redirected to sign-in, back to the
  form after auth
  - [ ] Same URL while signed in with the Unkey GitHub App missing on the repo → install CTA, install flow returns to pre-filled form
  - [ ] Submit the form → project + repo link created, deployment triggered, redirected to
  `/[workspaceSlug]/projects/[projectId]/deployments/[deploymentId]`
  - [ ] Try `?repository=acme/widgets&env=API_KEY,DB_URL&envDescription=Secrets&envLink=https://example.com` → env inputs render with
  description + link, empty values block submit
  - [ ] Try invalid params (`?repository=garbage`, `env=BAD KEY`) → invalid-link empty state with a specific message