### PR TITLE
fix: frontline panic

### DIFF
--- a/svc/frontline/services/proxy/BUILD.bazel
+++ b/svc/frontline/services/proxy/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "proxy",
@@ -29,4 +29,10 @@ go_library(
         "@com_github_prometheus_client_golang//prometheus",
         "@org_golang_x_net//http2",
     ],
+)
+
+go_test(
+    name = "proxy_test",
+    srcs = ["forward_test.go"],
+    embed = [":proxy"],
 )

--- a/svc/frontline/services/proxy/forward.go
+++ b/svc/frontline/services/proxy/forward.go
@@ -168,8 +168,8 @@ func (s *service) forward(ctx context.Context, sess *zen.Session, cfg forwardCon
 		},
 	}
 
-	// Proxy the request with the middleware context (carries timeout deadline)
-	proxy.ServeHTTP(wrapper, sess.Request().WithContext(ctx))
+	// Proxy the request with the middleware context (carries timeout deadline).
+	serveWithAbortRecovery(proxy, wrapper, sess.Request().WithContext(ctx), cfg.destination)
 
 	// Feed captured response body back into the session for zen middleware logging.
 	if responseBuf.Len() > 0 {
@@ -358,6 +358,24 @@ func extractSentinelError(resp *http.Response, statusCode int) (codes.URN, strin
 	}
 
 	return fallbackURN, fallbackMessage
+}
+
+// serveWithAbortRecovery calls h.ServeHTTP and swallows http.ErrAbortHandler panics.
+// httputil.ReverseProxy panics with that sentinel when the response body copy fails
+// after headers have been flushed (typically the client disconnected mid-stream).
+// There is no recovery path at that point — the panic is the library's signal that
+// the handler is aborting. Swallowing it keeps the global panic middleware strict
+// for real bugs; other panic values are re-raised unchanged.
+func serveWithAbortRecovery(h http.Handler, w http.ResponseWriter, r *http.Request, destination string) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			if rec != http.ErrAbortHandler {
+				panic(rec)
+			}
+			proxyAbortedTotal.WithLabelValues(destination).Inc()
+		}
+	}()
+	h.ServeHTTP(w, r)
 }
 
 func statusClass(code int) string {

--- a/svc/frontline/services/proxy/forward_test.go
+++ b/svc/frontline/services/proxy/forward_test.go
@@ -1,0 +1,68 @@
+package proxy
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestServeWithAbortRecovery_SwallowsErrAbortHandler(t *testing.T) {
+	t.Parallel()
+
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic(http.ErrAbortHandler)
+	})
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	// Must not bubble up. If it does, the test process crashes.
+	serveWithAbortRecovery(h, w, r, "test")
+}
+
+func TestServeWithAbortRecovery_RepanicsOtherValues(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("boom")
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic(sentinel)
+	})
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	defer func() {
+		rec := recover()
+		if rec == nil {
+			t.Fatal("expected panic to propagate, got none")
+		}
+		if rec != sentinel {
+			t.Fatalf("expected original panic value, got %v", rec)
+		}
+	}()
+
+	serveWithAbortRecovery(h, w, r, "test")
+}
+
+func TestServeWithAbortRecovery_NoPanicPassthrough(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusTeapot)
+	})
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	serveWithAbortRecovery(h, w, r, "test")
+
+	if !called {
+		t.Fatal("handler was not invoked")
+	}
+	if w.Code != http.StatusTeapot {
+		t.Fatalf("expected status %d, got %d", http.StatusTeapot, w.Code)
+	}
+}

--- a/svc/frontline/services/proxy/metrics.go
+++ b/svc/frontline/services/proxy/metrics.go
@@ -74,6 +74,20 @@ var (
 		[]string{"destination", "source"},
 	)
 
+	// proxyAbortedTotal counts client-disconnect aborts during streaming responses.
+	// httputil.ReverseProxy panics with http.ErrAbortHandler when the response body
+	// copy fails after headers have been flushed (typically the client went away).
+	// We swallow that sentinel locally; this counter preserves visibility.
+	proxyAbortedTotal = lazy.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "unkey",
+			Subsystem: "frontline",
+			Name:      "aborted_total",
+			Help:      "Client-disconnect aborts during streaming by destination.",
+		},
+		[]string{"destination"},
+	)
+
 	// proxyBackendResponseTotal tracks HTTP status codes returned by backends.
 	//
 	// Labels:

--- a/svc/sentinel/routes/proxy/BUILD.bazel
+++ b/svc/sentinel/routes/proxy/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
 go_test(
     name = "proxy_test",
     srcs = [
+        "abort_test.go",
         "handler_test.go",
         "transport_test.go",
     ],

--- a/svc/sentinel/routes/proxy/abort_test.go
+++ b/svc/sentinel/routes/proxy/abort_test.go
@@ -1,0 +1,68 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestServeWithAbortRecovery_SwallowsErrAbortHandler(t *testing.T) {
+	t.Parallel()
+
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic(http.ErrAbortHandler)
+	})
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	// Must not bubble up. If it does, the test process crashes.
+	serveWithAbortRecovery(h, w, r)
+}
+
+func TestServeWithAbortRecovery_RepanicsOtherValues(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("boom")
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic(sentinel)
+	})
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	defer func() {
+		rec := recover()
+		if rec == nil {
+			t.Fatal("expected panic to propagate, got none")
+		}
+		if rec != sentinel {
+			t.Fatalf("expected original panic value, got %v", rec)
+		}
+	}()
+
+	serveWithAbortRecovery(h, w, r)
+}
+
+func TestServeWithAbortRecovery_NoPanicPassthrough(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusTeapot)
+	})
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	serveWithAbortRecovery(h, w, r)
+
+	if !called {
+		t.Fatal("handler was not invoked")
+	}
+	if w.Code != http.StatusTeapot {
+		t.Fatalf("expected status %d, got %d", http.StatusTeapot, w.Code)
+	}
+}

--- a/svc/sentinel/routes/proxy/handler.go
+++ b/svc/sentinel/routes/proxy/handler.go
@@ -249,7 +249,7 @@ func (h *Handler) Handle(ctx context.Context, sess *zen.Session) error {
 		},
 	}
 
-	proxy.ServeHTTP(wrapper, req)
+	serveWithAbortRecovery(proxy, wrapper, req)
 
 	// Mark the true end of the instance interaction (includes full stream duration).
 	if tracking != nil {
@@ -274,4 +274,22 @@ func (h *Handler) Handle(ctx context.Context, sess *zen.Session) error {
 	}
 
 	return wrapper.Error()
+}
+
+// serveWithAbortRecovery calls h.ServeHTTP and swallows http.ErrAbortHandler panics.
+// httputil.ReverseProxy panics with that sentinel when the response body copy fails
+// after headers have been flushed (typically the client disconnected mid-stream).
+// There is no recovery path at that point — the panic is the library's signal that
+// the handler is aborting. Swallowing it keeps the global panic middleware strict
+// for real bugs; other panic values are re-raised unchanged.
+func serveWithAbortRecovery(h http.Handler, w http.ResponseWriter, r *http.Request) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			if rec != http.ErrAbortHandler {
+				panic(rec)
+			}
+			proxyAbortedTotal.Inc()
+		}
+	}()
+	h.ServeHTTP(w, r)
 }

--- a/svc/sentinel/routes/proxy/metrics.go
+++ b/svc/sentinel/routes/proxy/metrics.go
@@ -26,6 +26,19 @@ var (
 		},
 		[]string{"status_class"},
 	)
+
+	// proxyAbortedTotal counts client-disconnect aborts during streaming responses.
+	// httputil.ReverseProxy panics with http.ErrAbortHandler when the response body
+	// copy fails after headers have been flushed (typically the client went away).
+	// We swallow that sentinel locally; this counter preserves visibility.
+	proxyAbortedTotal = lazy.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "unkey",
+			Subsystem: "sentinel",
+			Name:      "aborted_total",
+			Help:      "Client-disconnect aborts during streaming.",
+		},
+	)
 )
 
 func upstreamStatusClass(code int) string {


### PR DESCRIPTION
## What does this PR do?

`httputil.ReverseProxy` panics with `http.ErrAbortHandler` when the response body copy fails after headers have already been flushed — typically because the client disconnected mid-stream. This panic was previously propagating up to the global panic middleware, which is intended to catch real bugs, not expected client-disconnect scenarios.

This PR introduces `serveWithAbortRecovery`, a thin wrapper around `h.ServeHTTP` that recovers `http.ErrAbortHandler` panics and swallows them silently, while re-raising any other panic values unchanged. This keeps the global panic middleware strict for genuine errors.

To preserve observability, a new `unkey_frontline_aborted_total` Prometheus counter is incremented (labeled by destination) whenever an abort is swallowed.

Fixes # (issue)

_If there is not an issue for this, please create one first. This is used to tracking purposes and also helps us understand why this PR exists_

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- `TestServeWithAbortRecovery_SwallowsErrAbortHandler`: verifies that a handler panicking with `http.ErrAbortHandler` does not crash the test process.
- `TestServeWithAbortRecovery_RepanicsOtherValues`: verifies that non-abort panics are re-raised with the original value intact.
- `TestServeWithAbortRecovery_NoPanicPassthrough`: verifies that a normal handler executes correctly and its response is recorded as expected.

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary