### PR TITLE
feat: pull errors

### DIFF
--- a/pkg/prometheus/lazy/metric.go
+++ b/pkg/prometheus/lazy/metric.go
@@ -71,6 +71,10 @@ func (g *GaugeVec) With(labels prometheus.Labels) prometheus.Gauge {
 	return g.m.get().With(labels)
 }
 
+func (g *GaugeVec) DeleteLabelValues(lvs ...string) bool {
+	return g.m.get().DeleteLabelValues(lvs...)
+}
+
 // HistogramVec is a lazy-registering prometheus.HistogramVec.
 type HistogramVec struct {
 	m metric[*prometheus.HistogramVec]

--- a/svc/krane/internal/deployment/controller.go
+++ b/svc/krane/internal/deployment/controller.go
@@ -133,11 +133,13 @@ func New(cfg Config) *Controller {
 
 // Start launches the background control loops.
 //
-// Three independent loops run concurrently:
+// Four independent loops run concurrently:
 //   - [Controller.runActualStateResyncLoop]: periodic safety net for instance
 //     state reporting (complements the real-time pod watch).
 //   - [Controller.runDesiredStateResyncLoop]: periodic reconciliation of desired
 //     state from the control plane (complements the streaming channel).
+//   - [Controller.runImagePullMetricsLoop]: publishes image-pull-failure gauges
+//     derived from a periodic ListPods sweep.
 //   - [Controller.runPodWatchLoop]: real-time Kubernetes watch for pod events.
 //
 // The actual-state and desired-state loops are decoupled so that slow control
@@ -147,6 +149,7 @@ func New(cfg Config) *Controller {
 // All loops continue until the context is cancelled or [Controller.Stop] is called.
 func (c *Controller) Start(ctx context.Context) error {
 	go c.runActualStateResyncLoop(ctx)
+	go c.runImagePullMetricsLoop(ctx)
 	go c.runDesiredStateResyncLoop(ctx)
 
 	if err := c.runPodWatchLoop(ctx); err != nil {

--- a/svc/krane/internal/deployment/image_pull_metrics.go
+++ b/svc/krane/internal/deployment/image_pull_metrics.go
@@ -1,0 +1,102 @@
+package deployment
+
+import (
+	"context"
+	"time"
+
+	"github.com/unkeyed/unkey/pkg/logger"
+	"github.com/unkeyed/unkey/pkg/repeat"
+	"github.com/unkeyed/unkey/svc/krane/pkg/labels"
+	"github.com/unkeyed/unkey/svc/krane/pkg/metrics"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type pullFailureKey struct {
+	deploymentID  string
+	projectID     string
+	environmentID string
+	workspaceID   string
+	reason        string
+}
+
+// runImagePullMetricsLoop publishes unkey_krane_pod_image_pull_failures by
+// listing all krane-managed deployment pods every 30s and counting pods
+// whose containers are Waiting with an image-pull reason.
+//
+// Stale series (deployment recovered, pod deleted, image pull succeeded)
+// are removed via DeleteLabelValues so the gauge reflects current reality
+// without requiring pod-watch wiring.
+func (c *Controller) runImagePullMetricsLoop(ctx context.Context) {
+	selector := labels.New().ManagedByKrane().ComponentDeployment().ToString()
+	previous := map[pullFailureKey]struct{}{}
+
+	repeat.Every(30*time.Second, func() {
+		pods, err := c.clientSet.CoreV1().Pods("").List(ctx, metav1.ListOptions{
+			LabelSelector: selector,
+		})
+		if err != nil {
+			logger.Error("image pull metrics: list pods failed", "error", err.Error())
+			return
+		}
+
+		current := map[pullFailureKey]int{}
+		for i := range pods.Items {
+			pod := &pods.Items[i]
+			l := pod.GetLabels()
+			deploymentID := l[labels.LabelKeyDeploymentID]
+			if deploymentID == "" {
+				continue
+			}
+			for _, cs := range pod.Status.ContainerStatuses {
+				if cs.State.Waiting == nil {
+					continue
+				}
+				if !isImagePullReason(cs.State.Waiting.Reason) {
+					continue
+				}
+				current[pullFailureKey{
+					deploymentID:  deploymentID,
+					projectID:     l[labels.LabelKeyProjectID],
+					environmentID: l[labels.LabelKeyEnvironmentID],
+					workspaceID:   l[labels.LabelKeyWorkspaceID],
+					reason:        cs.State.Waiting.Reason,
+				}]++
+			}
+		}
+
+		for key, count := range current {
+			setPullFailure(key, float64(count))
+		}
+		for key := range previous {
+			if _, still := current[key]; still {
+				continue
+			}
+			deletePullFailure(key)
+		}
+
+		next := make(map[pullFailureKey]struct{}, len(current))
+		for key := range current {
+			next[key] = struct{}{}
+		}
+		previous = next
+	})
+}
+
+func setPullFailure(k pullFailureKey, v float64) {
+	metrics.PodImagePullFailures.
+		WithLabelValues(k.deploymentID, k.projectID, k.environmentID, k.workspaceID, k.reason).
+		Set(v)
+}
+
+func deletePullFailure(k pullFailureKey) {
+	metrics.PodImagePullFailures.
+		DeleteLabelValues(k.deploymentID, k.projectID, k.environmentID, k.workspaceID, k.reason)
+}
+
+func isImagePullReason(reason string) bool {
+	switch reason {
+	case "ImagePullBackOff", "ErrImagePull", "InvalidImageName", "ImageInspectError":
+		return true
+	}
+	return false
+}

--- a/svc/krane/pkg/metrics/prometheus.go
+++ b/svc/krane/pkg/metrics/prometheus.go
@@ -215,6 +215,29 @@ var (
 		},
 		[]string{"component"},
 	)
+
+	// PodImagePullFailures reports, per (deployment, reason), how many pods
+	// are currently blocked on an image pull. Reasons covered:
+	// ImagePullBackOff, ErrImagePull, InvalidImageName, ImageInspectError.
+	//
+	// Derived each tick from a single ListPods — series whose count drops
+	// to zero are deleted so the metric is self-healing across pod churn.
+	//
+	// Labels:
+	//   - "deployment_id":  unkey.com/deployment.id
+	//   - "project_id":     unkey.com/project.id
+	//   - "environment_id": unkey.com/environment.id
+	//   - "workspace_id":   unkey.com/workspace.id
+	//   - "reason":         container waiting reason
+	PodImagePullFailures = lazy.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "unkey",
+			Subsystem: "krane",
+			Name:      "pod_image_pull_failures",
+			Help:      "Pods currently blocked on an image pull, by deployment and reason.",
+		},
+		[]string{"deployment_id", "project_id", "environment_id", "workspace_id", "reason"},
+	)
 )
 
 // RecordReconcile records a reconciliation operation result. Intended for use


### PR DESCRIPTION
## What does this PR do?

Adds a new `unkey_krane_pod_image_pull_failures` Prometheus gauge that tracks pods currently blocked on image pull failures, broken down by deployment, project, environment, workspace, and failure reason (`ImagePullBackOff`, `ErrImagePull`, `InvalidImageName`, `ImageInspectError`).

A new background loop, `runImagePullMetricsLoop`, runs every 30 seconds and performs a `ListPods` sweep across all krane-managed deployment pods. It computes the current set of pull-failing pods, publishes their counts, and deletes stale series for pods that have recovered or been removed — keeping the gauge self-healing without requiring pod-watch integration.

A `DeleteLabelValues` method was also added to the lazy `GaugeVec` wrapper to support the stale series cleanup.

Fixes # (issue)

_If there is not an issue for this, please create one first. This is used to tracking purposes and also helps us understand why this PR exists_

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Deploy a krane-managed pod with an invalid or inaccessible image and confirm that `unkey_krane_pod_image_pull_failures` increments with the correct labels and reason within ~30 seconds.
- Fix the image or delete the pod and confirm the corresponding metric series is removed within the next 30-second tick.
- Verify that pods without image pull issues do not produce any entries in the gauge.

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary