### PR TITLE
feat(dashoard): show repo account name when multiple --- Merge after #5888

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/new/steps/select-repo/index.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/new/steps/select-repo/index.tsx
@@ -211,6 +211,7 @@ export const SelectRepo = ({
                       onSelect={handleSelectRepository}
                       disabled={mutatingRepoId !== null}
                       loading={mutatingRepoId === repo.id}
+                      hasMultipleAccounts={ownerOptions.length > 1}
                     />
                   </div>
                 );

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/new/steps/select-repo/repo-list-item.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/new/steps/select-repo/repo-list-item.tsx
@@ -27,12 +27,14 @@ export const RepoListItem = ({
   onSelect,
   disabled,
   loading,
+  hasMultipleAccounts,
 }: {
   repo: RepoItem;
   projectId: string;
   onSelect: (repo: RepoItem, selectedBranch: string) => void;
   disabled: boolean;
   loading: boolean;
+  hasMultipleAccounts: boolean;
 }) => {
   const [owner, repoName] = repo.fullName.split("/");
   const [selectedBranch, setSelectedBranch] = useState(repo.defaultBranch);
@@ -55,12 +57,18 @@ export const RepoListItem = ({
   return (
     <div className="flex px-4 py-5 items-center">
       <LanguageIcon language={repo.language} />
-      <div className="flex flex-col gap-1 w-40">
-        <div className="font-medium text-[13px] text-gray-12 leading-4 truncate max-w-40">
+      <div className="flex flex-col gap-1 w-52">
+        <div className="font-medium text-[13px] text-gray-12 leading-4 truncate max-w-52">
           {repoName}
         </div>
-        <div className="font-medium text-[13px] text-gray-10 leading-3">
-          <TimestampInfo value={repo.pushedAt ?? 0} displayType="relative" />{" "}
+        <div className="text-[13px] text-gray-10 leading-3 truncate max-w-52">
+          {hasMultipleAccounts ? (
+            <>
+              {owner} · <TimestampInfo value={repo.pushedAt ?? 0} displayType="relative" />
+            </>
+          ) : (
+            <TimestampInfo value={repo.pushedAt ?? 0} displayType="relative" />
+          )}
         </div>
       </div>
       <div className="flex gap-2 items-center ml-auto shrink-0">

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/new/steps/select-repo/repo-list-item.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/new/steps/select-repo/repo-list-item.tsx
@@ -58,20 +58,24 @@ export const RepoListItem = ({
     <div className="flex px-4 py-5 items-center">
       <LanguageIcon language={repo.language} />
       <div className="flex flex-col gap-1 w-52">
-        <div className="font-medium text-[13px] text-gray-12 leading-4 truncate max-w-52">
+        <div className="font-medium text-[13px] text-gray-12 leading-4 truncate max-w-40">
           {repoName}
         </div>
-        <div className="text-[13px] text-gray-10 leading-3 truncate max-w-52">
+        <div className="flex items-center gap-0 text-[13px] text-gray-10 leading-3 max-w-52">
           {hasMultipleAccounts ? (
             <>
-              {owner} · <TimestampInfo value={repo.pushedAt ?? 0} displayType="relative" />
+              <span className="truncate shrink min-w-0">{owner}</span>
+              <span className="shrink-0">
+                &nbsp;·&nbsp;
+                <TimestampInfo value={repo.pushedAt ?? 0} displayType="relative" />
+              </span>
             </>
           ) : (
             <TimestampInfo value={repo.pushedAt ?? 0} displayType="relative" />
           )}
         </div>
       </div>
-      <div className="flex gap-2 items-center ml-auto shrink-0">
+      <div className="flex gap-2 items-center ml-auto shrink-0 w-40 justify-end">
         {isLoading ? (
           <div className="h-4 w-28 bg-grayA-3 rounded animate-pulse" />
         ) : details.hasDockerfile ? (


### PR DESCRIPTION
## What does this PR do?

This PR allows us to show organization/account name when there are multiple connected to the app. If user only has one we'll show the previous UI as is.

### Multiple accounts connected
<img width="933" height="850" alt="Screenshot 2026-04-27 at 10 21 19" src="https://github.com/user-attachments/assets/630c3ce0-08a4-4f2b-a9b1-b6215e85037f" />

### Single account
<img width="1129" height="929" alt="Screenshot 2026-04-27 at 10 20 04" src="https://github.com/user-attachments/assets/6dc2ca66-9166-4b6f-9985-ce12b37356ca" />
