### PR TITLE
fix(dashboard): malformed ESCAPE clause breaks key filters

### DIFF
--- a/web/apps/dashboard/lib/trpc/routers/api/keys/api-query.ts
+++ b/web/apps/dashboard/lib/trpc/routers/api/keys/api-query.ts
@@ -85,9 +85,11 @@ export interface QueryApiKeysResult {
 // Drizzle parameterizes LIKE patterns (no SQL injection risk), but MySQL still
 // interprets % and _ as wildcards at query time. A user searching for a key
 // named "100%_test" would otherwise match "100xyz_test" etc. Escape the three
-// LIKE metacharacters and use ESCAPE '\\' so they match literally.
+// LIKE metacharacters with a non-special character so we can pass ESCAPE '!'
+// inline — backslash would need to be doubled in the SQL string literal and is
+// fragile across sql_mode settings (e.g. NO_BACKSLASH_ESCAPES).
 function escapeLikePattern(value: string): string {
-  return value.replace(/[%_\\]/g, "\\$&");
+  return value.replace(/[%_!]/g, "!$&");
 }
 
 // Cap the rows we ever scan from a single keyspace. The dashboard only renders
@@ -137,11 +139,11 @@ export async function queryApiKeys({
       }
       const escaped = escapeLikePattern(value);
       if (f.operator === "contains") {
-        conditions.push(sql`${keys.name} LIKE ${`%${escaped}%`} ESCAPE '\\'`);
+        conditions.push(sql`${keys.name} LIKE ${`%${escaped}%`} ESCAPE '!'`);
       } else if (f.operator === "startsWith") {
-        conditions.push(sql`${keys.name} LIKE ${`${escaped}%`} ESCAPE '\\'`);
+        conditions.push(sql`${keys.name} LIKE ${`${escaped}%`} ESCAPE '!'`);
       } else if (f.operator === "endsWith") {
-        conditions.push(sql`${keys.name} LIKE ${`%${escaped}`} ESCAPE '\\'`);
+        conditions.push(sql`${keys.name} LIKE ${`%${escaped}`} ESCAPE '!'`);
       }
     }
   }
@@ -159,7 +161,7 @@ export async function queryApiKeys({
         continue;
       }
       if (f.operator === "contains") {
-        conditions.push(sql`${keys.id} LIKE ${`%${escapeLikePattern(value)}%`} ESCAPE '\\'`);
+        conditions.push(sql`${keys.id} LIKE ${`%${escapeLikePattern(value)}%`} ESCAPE '!'`);
       }
     }
   }
@@ -177,16 +179,16 @@ export async function queryApiKeys({
       const escaped = escapeLikePattern(value);
       switch (filter.operator) {
         case "contains":
-          externalMatch = sql`${identities.externalId} LIKE ${`%${escaped}%`} ESCAPE '\\'`;
-          ownerMatch = sql`${keys.ownerId} LIKE ${`%${escaped}%`} ESCAPE '\\'`;
+          externalMatch = sql`${identities.externalId} LIKE ${`%${escaped}%`} ESCAPE '!'`;
+          ownerMatch = sql`${keys.ownerId} LIKE ${`%${escaped}%`} ESCAPE '!'`;
           break;
         case "startsWith":
-          externalMatch = sql`${identities.externalId} LIKE ${`${escaped}%`} ESCAPE '\\'`;
-          ownerMatch = sql`${keys.ownerId} LIKE ${`${escaped}%`} ESCAPE '\\'`;
+          externalMatch = sql`${identities.externalId} LIKE ${`${escaped}%`} ESCAPE '!'`;
+          ownerMatch = sql`${keys.ownerId} LIKE ${`${escaped}%`} ESCAPE '!'`;
           break;
         case "endsWith":
-          externalMatch = sql`${identities.externalId} LIKE ${`%${escaped}`} ESCAPE '\\'`;
-          ownerMatch = sql`${keys.ownerId} LIKE ${`%${escaped}`} ESCAPE '\\'`;
+          externalMatch = sql`${identities.externalId} LIKE ${`%${escaped}`} ESCAPE '!'`;
+          ownerMatch = sql`${keys.ownerId} LIKE ${`%${escaped}`} ESCAPE '!'`;
           break;
         default:
           externalMatch = sql`${identities.externalId} = ${value}`;


### PR DESCRIPTION
## What does this PR do?

`escapeLikePattern` produced LIKE patterns like `ESCAPE '\\'` in JS, which lowers to a single backslash in the SQL string — MySQL parses `ESCAPE '\'` as an unterminated literal (the `\` escapes the closing `'`), so every `contains` / `startsWith` / `endsWith` filter on names, keyIds, or identities threw the generic "Failed to retrieve API information" TRPCError.

  Switched the escape character to `!`, which needs no SQL-literal escaping and is immune to `NO_BACKSLASH_ESCAPES` sql_mode. Updated `escapeLikePattern` to prefix `%`, `_`, and `!` with `!`, and replaced the four `ESCAPE '\\'` occurrences with `ESCAPE '!'`.

Fixes #5950
Fixes ENG-2757
Fixes UNKEY-DASHBOARD-7Z

_If there is not an issue for this, please create one first. This is used to tracking purposes and also helps us understand why this PR exists_

<!-- If there isn't an issue for this PR, please re-review our Contributing Guide and create an issue -->

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

 - [ ] On an API overview page, filter keyIds with `contains` (e.g. `key_`) — chart loads instead of erroring
  - [ ] Filter identities with `startsWith` (e.g. `test_`) — chart loads
  - [ ] Filter names with `endsWith` containing a literal `_` or `%` — only exact matches return (wildcard chars stay literal)
  - [ ] Filter with a value containing a literal `!` — `!` is treated as literal, not as the escape character
  - [ ] `is` operator filters still work (unchanged path via `inArray`)

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [X] Filled out the "How to test" section in this PR
- [X] Read [Contributing Guide](./CONTRIBUTING.md)
- [X] Self-reviewed my own code
- [X] Commented on my code in hard-to-understand areas
- [X] Ran `pnpm build`
- [X] Ran `pnpm fmt`
- [X] Ran `make fmt` on `/go` directory
- [X] Checked for warnings, there are none
- [X] Removed all `console.logs`
- [X] Merged the latest changes from main onto my branch with `git pull origin main`
- [X] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary
