### PR TITLE
fix: create key should use keyspace prefix/bytelength defaults

### DIFF
--- a/svc/api/routes/v2_keys_create_key/200_test.go
+++ b/svc/api/routes/v2_keys_create_key/200_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"testing"
 
@@ -315,5 +316,151 @@ func TestCreateKeyWithCreditsRemainingNull(t *testing.T) {
 		require.NotNil(t, res.Body)
 		require.NotEmpty(t, res.Body.Data.KeyId)
 		require.NotEmpty(t, res.Body.Data.Key)
+	})
+}
+
+// TestCreateKeyAppliesKeySpaceDefaults guards the keyspace `default_prefix`
+// and `default_bytes` columns. The dashboard surfaces both fields, so when
+// the request omits them they must fall back to what the keyspace stores.
+// Regression: previously the handler ignored both columns and always used
+// the hardcoded byte length 16 with no prefix.
+func TestCreateKeyAppliesKeySpaceDefaults(t *testing.T) {
+	t.Parallel()
+
+	h := testutil.NewHarness(t)
+
+	route := &handler.Handler{
+		DB:        h.DB,
+		Keys:      h.Keys,
+		Auditlogs: h.Auditlogs,
+		Vault:     h.Vault,
+	}
+
+	h.Register(route)
+
+	rootKey := h.CreateRootKey(h.Resources().UserWorkspace.ID, "api.*.create_key")
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}
+
+	// base58 length is deterministic per byte length within ±1 char (leading
+	// zero handling), so the floor below safely separates 16-byte from
+	// 64-byte keys: 16 → ~22 chars, 64 → ~86 chars.
+	const minEncodedLengthFor64Bytes = 80
+
+	t.Run("default prefix is applied when request omits prefix", func(t *testing.T) {
+		t.Parallel()
+
+		defaultPrefix := "dash"
+		api := h.CreateApi(seed.CreateApiRequest{
+			WorkspaceID:   h.Resources().UserWorkspace.ID,
+			DefaultPrefix: &defaultPrefix,
+		})
+
+		res := testutil.CallRoute[handler.Request, handler.Response](
+			h, route, headers, handler.Request{ApiId: api.ID},
+		)
+		require.Equal(t, 200, res.Status)
+		require.True(t, strings.HasPrefix(res.Body.Data.Key, defaultPrefix+"_"),
+			"key %q should start with keyspace default_prefix %q", res.Body.Data.Key, defaultPrefix)
+	})
+
+	t.Run("default bytes is applied when request omits byteLength", func(t *testing.T) {
+		t.Parallel()
+
+		defaultBytes := int32(64)
+		api := h.CreateApi(seed.CreateApiRequest{
+			WorkspaceID:  h.Resources().UserWorkspace.ID,
+			DefaultBytes: &defaultBytes,
+		})
+
+		res := testutil.CallRoute[handler.Request, handler.Response](
+			h, route, headers, handler.Request{ApiId: api.ID},
+		)
+		require.Equal(t, 200, res.Status)
+		require.GreaterOrEqual(t, len(res.Body.Data.Key), minEncodedLengthFor64Bytes,
+			"key %q (len=%d) should be long enough to reflect default_bytes=64",
+			res.Body.Data.Key, len(res.Body.Data.Key))
+	})
+
+	t.Run("both defaults apply together", func(t *testing.T) {
+		t.Parallel()
+
+		defaultPrefix := "both"
+		defaultBytes := int32(64)
+		api := h.CreateApi(seed.CreateApiRequest{
+			WorkspaceID:   h.Resources().UserWorkspace.ID,
+			DefaultPrefix: &defaultPrefix,
+			DefaultBytes:  &defaultBytes,
+		})
+
+		res := testutil.CallRoute[handler.Request, handler.Response](
+			h, route, headers, handler.Request{ApiId: api.ID},
+		)
+		require.Equal(t, 200, res.Status)
+		require.True(t, strings.HasPrefix(res.Body.Data.Key, defaultPrefix+"_"),
+			"key %q should start with default_prefix %q", res.Body.Data.Key, defaultPrefix)
+
+		encoded := strings.TrimPrefix(res.Body.Data.Key, defaultPrefix+"_")
+		require.GreaterOrEqual(t, len(encoded), minEncodedLengthFor64Bytes,
+			"encoded portion %q (len=%d) should reflect default_bytes=64",
+			encoded, len(encoded))
+	})
+
+	t.Run("request prefix overrides keyspace default_prefix", func(t *testing.T) {
+		t.Parallel()
+
+		defaultPrefix := "dash"
+		api := h.CreateApi(seed.CreateApiRequest{
+			WorkspaceID:   h.Resources().UserWorkspace.ID,
+			DefaultPrefix: &defaultPrefix,
+		})
+
+		reqPrefix := "explicit"
+		res := testutil.CallRoute[handler.Request, handler.Response](
+			h, route, headers, handler.Request{ApiId: api.ID, Prefix: &reqPrefix},
+		)
+		require.Equal(t, 200, res.Status)
+		require.True(t, strings.HasPrefix(res.Body.Data.Key, reqPrefix+"_"),
+			"request prefix should win, got %q", res.Body.Data.Key)
+		require.False(t, strings.HasPrefix(res.Body.Data.Key, defaultPrefix+"_"),
+			"keyspace default should not apply when request supplies prefix, got %q", res.Body.Data.Key)
+	})
+
+	t.Run("request byteLength overrides keyspace default_bytes", func(t *testing.T) {
+		t.Parallel()
+
+		defaultBytes := int32(64)
+		api := h.CreateApi(seed.CreateApiRequest{
+			WorkspaceID:  h.Resources().UserWorkspace.ID,
+			DefaultBytes: &defaultBytes,
+		})
+
+		reqByteLength := 16
+		res := testutil.CallRoute[handler.Request, handler.Response](
+			h, route, headers, handler.Request{ApiId: api.ID, ByteLength: &reqByteLength},
+		)
+		require.Equal(t, 200, res.Status)
+		// 16 bytes encodes to ~22 base58 chars, well below the 64-byte floor.
+		require.Less(t, len(res.Body.Data.Key), minEncodedLengthFor64Bytes,
+			"request byteLength=16 should win over default_bytes=64, got %q (len=%d)",
+			res.Body.Data.Key, len(res.Body.Data.Key))
+	})
+
+	t.Run("falls back to 16 bytes when neither request nor keyspace provides byteLength", func(t *testing.T) {
+		t.Parallel()
+
+		api := h.CreateApi(seed.CreateApiRequest{
+			WorkspaceID: h.Resources().UserWorkspace.ID,
+		})
+
+		res := testutil.CallRoute[handler.Request, handler.Response](
+			h, route, headers, handler.Request{ApiId: api.ID},
+		)
+		require.Equal(t, 200, res.Status)
+		// 16 bytes → ~22 base58 chars; allow a small ± window for leading zeros.
+		require.GreaterOrEqual(t, len(res.Body.Data.Key), 20)
+		require.LessOrEqual(t, len(res.Body.Data.Key), 24)
 	})
 }

--- a/svc/api/routes/v2_keys_create_key/handler.go
+++ b/svc/api/routes/v2_keys_create_key/handler.go
@@ -117,11 +117,30 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		)
 	}
 
-	// 5. Generate key using key service
+	// Per-request values win; otherwise fall back to the keyspace
+	// defaults (`default_prefix` / `default_bytes` configured in the
+	// dashboard, persisted on key_auth). Without these fallbacks the
+	// columns round-trip through the DB for nothing.
+	var prefix string
+	switch {
+	case req.Prefix != nil:
+		prefix = *req.Prefix
+	case keySpace.DefaultPrefix.Valid:
+		prefix = keySpace.DefaultPrefix.String
+	}
+
+	byteLength := ptr.SafeDeref(req.ByteLength)
+	if byteLength == 0 && keySpace.DefaultBytes.Valid {
+		byteLength = int(keySpace.DefaultBytes.Int32)
+	}
+	if byteLength == 0 {
+		byteLength = 16
+	}
+
 	keyID := uid.New(uid.KeyPrefix)
 	keyResult, err := h.Keys.CreateKey(ctx, keys.CreateKeyRequest{
-		Prefix:     ptr.SafeDeref(req.Prefix),
-		ByteLength: ptr.SafeDeref(req.ByteLength, 16),
+		Prefix:     prefix,
+		ByteLength: byteLength,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
## What does this PR do?

Fixes a regression where the `create_key` handler ignored the `default_prefix` and `default_bytes` columns stored on the keyspace (`key_auth`). These values are configurable from the dashboard, but the handler was always falling back to a hardcoded 16-byte length with no prefix, making those columns effectively no-ops.

The fix applies a clear precedence: an explicit value in the request wins, otherwise the keyspace default is used, and if neither is present the byte length falls back to 16.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

The new `TestCreateKeyAppliesKeySpaceDefaults` test covers the following scenarios:

- When the request omits a prefix, the keyspace `default_prefix` is applied and the generated key starts with that prefix.
- When the request omits a byte length, the keyspace `default_bytes` is applied and the generated key is long enough to reflect the larger byte count.
- When both defaults are set on the keyspace and the request omits both, both defaults apply together.
- When the request explicitly supplies a prefix, it overrides the keyspace `default_prefix`.
- When the request explicitly supplies a `byteLength`, it overrides the keyspace `default_bytes`.
- When neither the request nor the keyspace provides a byte length, the key falls back to 16 bytes (~20–24 base58 characters).

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary