### PR TITLE
refactor(sentinel): shared openapi validation

### DIFF
--- a/pkg/openapi/validation/BUILD.bazel
+++ b/pkg/openapi/validation/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "validation",
+    srcs = ["validator.go"],
+    importpath = "github.com/unkeyed/unkey/pkg/openapi/validation",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/fault",
+        "@com_github_pb33f_libopenapi//:libopenapi",
+        "@com_github_pb33f_libopenapi_validator//:libopenapi-validator",
+        "@com_github_pb33f_libopenapi_validator//config",
+        "@com_github_pb33f_libopenapi_validator//errors",
+        "@com_github_pb33f_libopenapi_validator//helpers",
+    ],
+)

--- a/pkg/openapi/validation/validator.go
+++ b/pkg/openapi/validation/validator.go
@@ -95,7 +95,7 @@ func (v *Validator) Validate(r *http.Request) *Result {
 }
 
 func filterIgnoredSecurityErrors(errs []*validatorErrors.ValidationError) []*validatorErrors.ValidationError {
-	filtered := errs[:0]
+	filtered := make([]*validatorErrors.ValidationError, 0, len(errs))
 	for _, e := range errs {
 		if e.ValidationType == helpers.SecurityValidation && e.Reason == "Authorization header had incorrect scheme" {
 			continue

--- a/pkg/openapi/validation/validator.go
+++ b/pkg/openapi/validation/validator.go
@@ -1,0 +1,106 @@
+package validation
+
+import (
+	"net/http"
+	"sync"
+
+	"github.com/pb33f/libopenapi"
+	validator "github.com/pb33f/libopenapi-validator"
+	"github.com/pb33f/libopenapi-validator/config"
+	validatorErrors "github.com/pb33f/libopenapi-validator/errors"
+	"github.com/pb33f/libopenapi-validator/helpers"
+	"github.com/unkeyed/unkey/pkg/fault"
+)
+
+type ValidationError struct {
+	Message  string
+	Location string
+	Fix      *string
+}
+
+type Result struct {
+	Detail string
+	Errors []ValidationError
+}
+
+type Validator struct {
+	validator validator.Validator
+}
+
+func NewFromBytes(spec []byte) (*Validator, error) {
+	document, err := libopenapi.NewDocument(spec)
+	if err != nil {
+		return nil, fault.Wrap(err, fault.Internal("failed to create OpenAPI document"))
+	}
+
+	v, errors := validator.NewValidator(document, config.WithRegexCache(&sync.Map{}))
+	if len(errors) > 0 {
+		messages := make([]fault.Wrapper, len(errors))
+		for i, e := range errors {
+			messages[i] = fault.Internal(e.Error())
+		}
+		return nil, fault.New("failed to create validator", messages...)
+	}
+
+	valid, docErrors := v.ValidateDocument()
+	if !valid {
+		messages := make([]fault.Wrapper, len(docErrors))
+		for i, e := range docErrors {
+			messages[i] = fault.Internal(e.Message)
+		}
+		return nil, fault.New("openapi document is invalid", messages...)
+	}
+
+	return &Validator{validator: v}, nil
+}
+
+func (v *Validator) Validate(r *http.Request) *Result {
+	valid, errors := v.validator.ValidateHttpRequestSync(r)
+
+	if !valid {
+		errors = filterIgnoredSecurityErrors(errors)
+		valid = len(errors) == 0
+	}
+
+	if valid {
+		return nil
+	}
+
+	result := &Result{
+		Detail: "One or more fields failed validation",
+		Errors: []ValidationError{},
+	}
+
+	if len(errors) > 0 {
+		err := errors[0]
+		result.Detail = err.Message
+		for _, verr := range err.SchemaValidationErrors {
+			result.Errors = append(result.Errors, ValidationError{
+				Message:  verr.Reason,
+				Location: verr.KeywordLocation,
+				Fix:      nil,
+			})
+		}
+		if len(result.Errors) == 0 {
+			howToFix := err.HowToFix
+			result.Errors = append(result.Errors, ValidationError{
+				Message:  err.Reason,
+				Location: err.ValidationType,
+				Fix:      &howToFix,
+			})
+		}
+	}
+
+	return result
+}
+
+func filterIgnoredSecurityErrors(errs []*validatorErrors.ValidationError) []*validatorErrors.ValidationError {
+	filtered := errs[:0]
+	for _, e := range errs {
+		if e.ValidationType == helpers.SecurityValidation && e.Reason == "Authorization header had incorrect scheme" {
+			continue
+		}
+		filtered = append(filtered, e)
+	}
+	return filtered
+}

--- a/pkg/openapi/validation/validator.go
+++ b/pkg/openapi/validation/validator.go
@@ -94,6 +94,14 @@ func (v *Validator) Validate(r *http.Request) *Result {
 	return result
 }
 
+// filterIgnoredSecurityErrors drops OpenAPI security-scheme errors that our
+// handlers already produce richer messages for. Specifically:
+//
+//   - "scheme mismatch" (added in libopenapi-validator v0.13): the handler's
+//     bearer parser returns a more useful "missing 'Bearer ' prefix" error.
+//
+// A missing Authorization header is still surfaced by the validator so that
+// the existing 400 invalid_input contract is preserved.
 func filterIgnoredSecurityErrors(errs []*validatorErrors.ValidationError) []*validatorErrors.ValidationError {
 	filtered := make([]*validatorErrors.ValidationError, 0, len(errs))
 	for _, e := range errs {

--- a/pkg/openapi/validation/validator.go
+++ b/pkg/openapi/validation/validator.go
@@ -12,21 +12,28 @@ import (
 	"github.com/unkeyed/unkey/pkg/fault"
 )
 
+// ValidationError represents a single field-level validation failure.
+// Fix is non-nil when the validator can suggest a concrete correction.
 type ValidationError struct {
 	Message  string
 	Location string
 	Fix      *string
 }
 
+// Result holds the validation outcome when a request is invalid.
+// A nil *Result means the request passed validation.
 type Result struct {
 	Detail string
 	Errors []ValidationError
 }
 
+// Validator validates HTTP requests against an OpenAPI specification.
 type Validator struct {
 	validator validator.Validator
 }
 
+// NewFromBytes creates a Validator from a raw OpenAPI spec.
+// Returns an error if the spec cannot be parsed or is itself invalid.
 func NewFromBytes(spec []byte) (*Validator, error) {
 	document, err := libopenapi.NewDocument(spec)
 	if err != nil {
@@ -54,6 +61,9 @@ func NewFromBytes(spec []byte) (*Validator, error) {
 	return &Validator{validator: v}, nil
 }
 
+// Validate checks r against the OpenAPI spec.
+// Returns nil when the request is valid; returns a *Result describing
+// the failures otherwise.
 func (v *Validator) Validate(r *http.Request) *Result {
 	valid, errors := v.validator.ValidateHttpRequestSync(r)
 

--- a/pkg/zen/validation/BUILD.bazel
+++ b/pkg/zen/validation/BUILD.bazel
@@ -6,15 +6,9 @@ go_library(
     importpath = "github.com/unkeyed/unkey/pkg/zen/validation",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/ctxutil",
-        "//pkg/fault",
+        "//pkg/openapi/validation",
         "//pkg/otel/tracing",
         "//svc/api/openapi",
-        "@com_github_pb33f_libopenapi//:libopenapi",
-        "@com_github_pb33f_libopenapi_validator//:libopenapi-validator",
-        "@com_github_pb33f_libopenapi_validator//config",
-        "@com_github_pb33f_libopenapi_validator//errors",
-        "@com_github_pb33f_libopenapi_validator//helpers",
     ],
 )
 

--- a/pkg/zen/validation/BUILD.bazel
+++ b/pkg/zen/validation/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/unkeyed/unkey/pkg/zen/validation",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/ctxutil",
         "//pkg/openapi/validation",
         "//pkg/otel/tracing",
         "//svc/api/openapi",

--- a/pkg/zen/validation/validator.go
+++ b/pkg/zen/validation/validator.go
@@ -3,127 +3,51 @@ package validation
 import (
 	"context"
 	"net/http"
-	"sync"
 
-	"github.com/pb33f/libopenapi"
-	validator "github.com/pb33f/libopenapi-validator"
-	"github.com/pb33f/libopenapi-validator/config"
-	validatorErrors "github.com/pb33f/libopenapi-validator/errors"
-	"github.com/pb33f/libopenapi-validator/helpers"
-	"github.com/unkeyed/unkey/pkg/ctxutil"
-	"github.com/unkeyed/unkey/pkg/fault"
+	core "github.com/unkeyed/unkey/pkg/openapi/validation"
 	"github.com/unkeyed/unkey/pkg/otel/tracing"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
 
-type OpenAPIValidator interface {
-	// Validate reads the request and validates it against the OpenAPI spec
-	//
-	// Returns a BadRequestError if the request is invalid that should be
-	// marshalled and returned to the client.
-	// The second return value is a boolean that is true if the request is valid.
-	Validate(r *http.Request) (openapi.BadRequestErrorResponse, bool)
-}
-
 type Validator struct {
-	validator validator.Validator
+	core *core.Validator
 }
 
 func New() (*Validator, error) {
-	document, err := libopenapi.NewDocument(openapi.Spec)
+	v, err := core.NewFromBytes(openapi.Spec)
 	if err != nil {
-		return nil, fault.Wrap(err, fault.Internal("failed to create OpenAPI document"))
+		return nil, err
 	}
-
-	v, errors := validator.NewValidator(document, config.WithRegexCache(&sync.Map{}))
-	if len(errors) > 0 {
-		messages := make([]fault.Wrapper, len(errors))
-		for i, e := range errors {
-			messages[i] = fault.Internal(e.Error())
-		}
-		// nolint:wrapcheck
-		return nil, fault.New("failed to create validator", messages...)
-	}
-	valid, docErrors := v.ValidateDocument()
-	if !valid {
-		messages := make([]fault.Wrapper, len(docErrors))
-		for i, e := range docErrors {
-			messages[i] = fault.Internal(e.Message)
-		}
-
-		return nil, fault.New("openapi document is invalid", messages...)
-	}
-
-	return &Validator{
-		validator: v,
-	}, nil
+	return &Validator{core: v}, nil
 }
 
 func (v *Validator) Validate(ctx context.Context, r *http.Request) (openapi.BadRequestErrorResponse, bool) {
-	_, validationSpan := tracing.Start(ctx, "openapi.Validate")
-	defer validationSpan.End()
+	_, span := tracing.Start(ctx, "openapi.Validate")
+	defer span.End()
 
-	valid, errors := v.validator.ValidateHttpRequestSync(r)
-
-	if !valid {
-		errors = filterIgnoredSecurityErrors(errors)
-		valid = len(errors) == 0
-	}
-
-	if valid {
-		// nolint:exhaustruct
+	result := v.core.Validate(r)
+	if result == nil {
+		//nolint:exhaustruct
 		return openapi.BadRequestErrorResponse{}, true
 	}
-	res := openapi.BadRequestErrorResponse{
-		Meta: openapi.Meta{
-			RequestId: ctxutil.GetRequestID(r.Context()),
-		},
+
+	errors := make([]openapi.ValidationError, len(result.Errors))
+	for i, e := range result.Errors {
+		errors[i] = openapi.ValidationError{
+			Message:  e.Message,
+			Location: e.Location,
+			Fix:      e.Fix,
+		}
+	}
+
+	//nolint:exhaustruct
+	return openapi.BadRequestErrorResponse{
 		Error: openapi.BadRequestErrorDetails{
 			Title:  "Bad Request",
-			Detail: "One or more fields failed validation",
+			Detail: result.Detail,
 			Status: http.StatusBadRequest,
 			Type:   "https://unkey.com/docs/errors/unkey/application/invalid_input",
-			Errors: []openapi.ValidationError{},
+			Errors: errors,
 		},
-	}
-
-	if len(errors) > 0 {
-		err := errors[0]
-		res.Error.Detail = err.Message
-		for _, verr := range err.SchemaValidationErrors {
-			res.Error.Errors = append(res.Error.Errors, openapi.ValidationError{
-				Message:  verr.Reason,
-				Location: verr.KeywordLocation,
-				Fix:      nil,
-			})
-		}
-		if len(res.Error.Errors) == 0 {
-			res.Error.Errors = append(res.Error.Errors, openapi.ValidationError{
-				Message:  err.Reason,
-				Location: err.ValidationType,
-				Fix:      &err.HowToFix,
-			})
-		}
-	}
-
-	return res, false
-}
-
-// filterIgnoredSecurityErrors drops OpenAPI security-scheme errors that our
-// handlers already produce richer messages for. Specifically:
-//
-//   - "scheme mismatch" (added in libopenapi-validator v0.13): the handler's
-//     bearer parser returns a more useful "missing 'Bearer ' prefix" error.
-//
-// A missing Authorization header is still surfaced by the validator so that
-// the existing 400 invalid_input contract is preserved.
-func filterIgnoredSecurityErrors(errs []*validatorErrors.ValidationError) []*validatorErrors.ValidationError {
-	filtered := errs[:0]
-	for _, e := range errs {
-		if e.ValidationType == helpers.SecurityValidation && e.Reason == "Authorization header had incorrect scheme" {
-			continue
-		}
-		filtered = append(filtered, e)
-	}
-	return filtered
+	}, false
 }

--- a/pkg/zen/validation/validator.go
+++ b/pkg/zen/validation/validator.go
@@ -10,10 +10,13 @@ import (
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
 
+// Validator wraps the core OpenAPI validator with tracing and
+// API-specific error formatting.
 type Validator struct {
 	core *core.Validator
 }
 
+// New creates a Validator backed by the compiled API OpenAPI spec.
 func New() (*Validator, error) {
 	v, err := core.NewFromBytes(openapi.Spec)
 	if err != nil {
@@ -22,6 +25,9 @@ func New() (*Validator, error) {
 	return &Validator{core: v}, nil
 }
 
+// Validate checks r against the OpenAPI spec.
+// Returns (_, true) when valid. On failure returns a ready-to-marshal
+// BadRequestErrorResponse and false.
 func (v *Validator) Validate(ctx context.Context, r *http.Request) (openapi.BadRequestErrorResponse, bool) {
 	_, span := tracing.Start(ctx, "openapi.Validate")
 	defer span.End()

--- a/pkg/zen/validation/validator.go
+++ b/pkg/zen/validation/validator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/unkeyed/unkey/pkg/ctxutil"
 	core "github.com/unkeyed/unkey/pkg/openapi/validation"
 	"github.com/unkeyed/unkey/pkg/otel/tracing"
 	"github.com/unkeyed/unkey/svc/api/openapi"
@@ -42,6 +43,9 @@ func (v *Validator) Validate(ctx context.Context, r *http.Request) (openapi.BadR
 
 	//nolint:exhaustruct
 	return openapi.BadRequestErrorResponse{
+		Meta: openapi.Meta{
+			RequestId: ctxutil.GetRequestID(r.Context()),
+		},
 		Error: openapi.BadRequestErrorDetails{
 			Title:  "Bad Request",
 			Detail: result.Detail,

--- a/pkg/zen/validation/validator_test.go
+++ b/pkg/zen/validation/validator_test.go
@@ -7,10 +7,6 @@ import (
 )
 
 func TestSchemaIsValid(t *testing.T) {
-	v, err := New()
+	_, err := New()
 	require.NoError(t, err)
-
-	valid, errors := v.validator.ValidateDocument()
-	require.True(t, valid)
-	require.Len(t, errors, 0)
 }


### PR DESCRIPTION
## What does this PR do?

Extracts the core OpenAPI request validation logic from `pkg/zen/validation` into a new standalone package at `pkg/openapi/validation`. The new `Validator` type in `pkg/openapi/validation` handles document parsing, validator construction, and HTTP request validation (including filtering of ignored security errors), returning a generic `Result` type decoupled from any HTTP framework or API-specific types.

The `pkg/zen/validation` package is then refactored to delegate to this new core validator, reducing it to a thin adapter that maps the generic `Result` into the `openapi.BadRequestErrorResponse` shape used by the API service.

Fixes # (issue)

_If there is not an issue for this, please create one first. This is used to tracking purposes and also helps us understand why this PR exists_

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Run `TestSchemaIsValid` in `pkg/zen/validation` to confirm the OpenAPI document is still parsed and validated correctly via the new core package
- Send a malformed HTTP request through the API and confirm a `400 Bad Request` response is returned with the expected validation error details

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary