### PR TITLE
fix(dashboard): identity update actions

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/identities/_components/dialogs/delete-identity-dialog.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/identities/_components/dialogs/delete-identity-dialog.tsx
@@ -4,7 +4,7 @@ import type { IdentityResponseSchema } from "@/lib/trpc/routers/identity/query";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { TriangleWarning2 } from "@unkey/icons";
 import { Button, ConfirmPopover, DialogContainer, FormCheckbox } from "@unkey/ui";
-import { useRef, useState } from "react";
+import { useId, useRef, useState } from "react";
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { z } from "zod";
 import { useDeleteIdentity } from "./hooks/use-delete-identity";
@@ -29,6 +29,7 @@ export const DeleteIdentityDialog = ({
   open,
   onOpenChange,
 }: DeleteIdentityDialogProps) => {
+  const formId = useId();
   const [isConfirmPopoverOpen, setIsConfirmPopoverOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const deleteButtonRef = useRef<HTMLButtonElement>(null);
@@ -89,7 +90,7 @@ export const DeleteIdentityDialog = ({
   return (
     <>
       <FormProvider {...methods}>
-        <form id="delete-identity-form">
+        <form id={formId}>
           <DialogContainer
             isOpen={open}
             subTitle="Permanently remove this identity and its data"
@@ -99,7 +100,7 @@ export const DeleteIdentityDialog = ({
               <div className="w-full flex flex-col gap-2 items-center justify-center">
                 <Button
                   type="button"
-                  form="delete-identity-form"
+                  form={formId}
                   variant="primary"
                   color="danger"
                   size="xlg"

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/identities/_components/dialogs/edit-ratelimit-dialog.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/identities/_components/dialogs/edit-ratelimit-dialog.tsx
@@ -25,20 +25,20 @@ const getIdentityRatelimitsDefaults = (identity: Identity): RatelimitFormValues 
   const hasRatelimits = identity.ratelimits && identity.ratelimits.length > 0;
   const defaultRatelimits = hasRatelimits
     ? identity.ratelimits.map((rl) => ({
-      id: rl.id,
-      name: rl.name,
-      limit: rl.limit,
-      refillInterval: rl.duration,
-      autoApply: rl.autoApply,
-    }))
+        id: rl.id,
+        name: rl.name,
+        limit: rl.limit,
+        refillInterval: rl.duration,
+        autoApply: rl.autoApply,
+      }))
     : [
-      {
-        name: "Default",
-        limit: 10,
-        refillInterval: 1000,
-        autoApply: false,
-      },
-    ];
+        {
+          name: "Default",
+          limit: 10,
+          refillInterval: 1000,
+          autoApply: false,
+        },
+      ];
 
   return {
     ratelimit: {

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/identities/_components/dialogs/edit-ratelimit-dialog.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/identities/_components/dialogs/edit-ratelimit-dialog.tsx
@@ -1,14 +1,14 @@
 "use client";
 
 import { RatelimitSetup } from "@/components/dashboard/ratelimits/ratelimit-setup";
-import { useEditRatelimits } from "@/hooks/use-edit-ratelimits";
+import { useEditIdentityRatelimits } from "@/hooks/use-edit-ratelimits";
 import type { RatelimitFormValues } from "@/lib/schemas/ratelimit";
 import { ratelimitSchema } from "@/lib/schemas/ratelimit";
 import type { DiscriminatedUnionResolver } from "@/lib/schemas/resolver-types";
 import type { IdentityResponseSchema } from "@/lib/trpc/routers/identity/query";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Button, DialogContainer } from "@unkey/ui";
-import { type FC, useCallback, useEffect, useState } from "react";
+import { type FC, useCallback, useEffect, useId, useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import type { z } from "zod";
 import { IdentityInfo } from "./identity-info";
@@ -25,20 +25,20 @@ const getIdentityRatelimitsDefaults = (identity: Identity): RatelimitFormValues 
   const hasRatelimits = identity.ratelimits && identity.ratelimits.length > 0;
   const defaultRatelimits = hasRatelimits
     ? identity.ratelimits.map((rl) => ({
-        id: rl.id,
-        name: rl.name,
-        limit: rl.limit,
-        refillInterval: rl.duration,
-        autoApply: rl.autoApply,
-      }))
+      id: rl.id,
+      name: rl.name,
+      limit: rl.limit,
+      refillInterval: rl.duration,
+      autoApply: rl.autoApply,
+    }))
     : [
-        {
-          name: "Default",
-          limit: 10,
-          refillInterval: 1000,
-          autoApply: false,
-        },
-      ];
+      {
+        name: "Default",
+        limit: 10,
+        refillInterval: 1000,
+        autoApply: false,
+      },
+    ];
 
   return {
     ratelimit: {
@@ -53,6 +53,7 @@ export const EditRatelimitDialog: FC<EditRatelimitDialogProps> = ({
   open,
   onOpenChange,
 }) => {
+  const formId = useId();
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const getDefaultValues = useCallback(() => {
@@ -71,7 +72,7 @@ export const EditRatelimitDialog: FC<EditRatelimitDialogProps> = ({
     }
   }, [open, getDefaultValues, methods]);
 
-  const updateRatelimit = useEditRatelimits("identity", () => {
+  const updateRatelimit = useEditIdentityRatelimits(() => {
     onOpenChange(false);
   });
 
@@ -92,7 +93,7 @@ export const EditRatelimitDialog: FC<EditRatelimitDialogProps> = ({
 
   return (
     <FormProvider {...methods}>
-      <form id="edit-identity-ratelimit-form" onSubmit={onSubmit}>
+      <form id={formId} onSubmit={onSubmit}>
         <DialogContainer
           isOpen={open}
           onOpenChange={onOpenChange}
@@ -104,7 +105,7 @@ export const EditRatelimitDialog: FC<EditRatelimitDialogProps> = ({
             <div className="w-full flex flex-col gap-2 items-center justify-center">
               <Button
                 type="submit"
-                form="edit-identity-ratelimit-form"
+                form={formId}
                 variant="primary"
                 size="xlg"
                 className="w-full rounded-lg"

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/identities/_components/table/edit-metadata-dialog.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/identities/_components/table/edit-metadata-dialog.tsx
@@ -7,7 +7,7 @@ import { trpc } from "@/lib/trpc/client";
 import type { IdentityResponseSchema } from "@/lib/trpc/routers/identity/query";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Button, DialogContainer, toast } from "@unkey/ui";
-import { type FC, useCallback, useEffect, useState } from "react";
+import { type FC, useCallback, useEffect, useId, useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import type { z } from "zod";
 import { IdentityInfo } from "../dialogs/identity-info";
@@ -25,6 +25,7 @@ export const EditMetadataDialog: FC<EditMetadataDialogProps> = ({
   open,
   onOpenChange,
 }) => {
+  const formId = useId();
   const utils = trpc.useUtils();
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -82,7 +83,7 @@ export const EditMetadataDialog: FC<EditMetadataDialogProps> = ({
 
   return (
     <FormProvider {...methods}>
-      <form id="edit-identity-metadata-form" onSubmit={onSubmit}>
+      <form id={formId} onSubmit={onSubmit}>
         <DialogContainer
           isOpen={open}
           onOpenChange={onOpenChange}
@@ -92,7 +93,7 @@ export const EditMetadataDialog: FC<EditMetadataDialogProps> = ({
             <div className="w-full flex flex-col gap-2 items-center justify-center">
               <Button
                 type="submit"
-                form="edit-identity-metadata-form"
+                form={formId}
                 variant="primary"
                 size="xlg"
                 className="w-full rounded-lg"

--- a/web/apps/dashboard/components/api-keys-table/components/actions/components/edit-ratelimits/index.tsx
+++ b/web/apps/dashboard/components/api-keys-table/components/actions/components/edit-ratelimits/index.tsx
@@ -1,6 +1,6 @@
 import { RatelimitSetup } from "@/components/dashboard/ratelimits/ratelimit-setup";
 import type { ActionComponentProps } from "@/components/logs/table-action.popover";
-import { useEditRatelimits } from "@/hooks/use-edit-ratelimits";
+import { useEditKeyRatelimits } from "@/hooks/use-edit-ratelimits";
 import { usePersistedForm } from "@/hooks/use-persisted-form";
 import type { RatelimitFormValues } from "@/lib/schemas/ratelimit";
 import { ratelimitSchema } from "@/lib/schemas/ratelimit";
@@ -48,7 +48,7 @@ export const EditRatelimits = ({ keyDetails, isOpen, onClose }: EditRatelimitsPr
     }
   }, [isOpen, loadSavedValues]);
 
-  const key = useEditRatelimits("key", () => {
+  const key = useEditKeyRatelimits(() => {
     reset(getKeyRatelimitsDefaults(keyDetails));
     clearPersistedData();
     onClose();

--- a/web/apps/dashboard/hooks/use-edit-ratelimits.ts
+++ b/web/apps/dashboard/hooks/use-edit-ratelimits.ts
@@ -106,14 +106,19 @@ const formatInterval = (milliseconds: number): string => {
 
   const duration = intervalToDuration({ start: 0, end: milliseconds });
 
+  // Customize the format for different time ranges
   if (milliseconds < 60000) {
+    // Less than a minute
     return formatDuration(duration, { format: ["seconds"] });
   }
   if (milliseconds < 3600000) {
+    // Less than an hour
     return formatDuration(duration, { format: ["minutes", "seconds"] });
   }
   if (milliseconds < 86400000) {
+    // Less than a day
     return formatDuration(duration, { format: ["hours", "minutes"] });
   }
+  // Days or more
   return formatDuration(duration, { format: ["days", "hours"] });
 };

--- a/web/apps/dashboard/hooks/use-edit-ratelimits.ts
+++ b/web/apps/dashboard/hooks/use-edit-ratelimits.ts
@@ -2,20 +2,10 @@ import { trpc } from "@/lib/trpc/client";
 import { toast } from "@unkey/ui";
 import { formatDuration, intervalToDuration } from "date-fns";
 
-type EntityType = "key" | "identity";
-
-export function useEditRatelimits(
-  entityType: "key",
-  onSuccess?: () => void,
-): ReturnType<typeof trpc.key.update.ratelimit.useMutation>;
-export function useEditRatelimits(
-  entityType: "identity",
-  onSuccess?: () => void,
-): ReturnType<typeof trpc.identity.update.ratelimit.useMutation>;
-export function useEditRatelimits(entityType: EntityType, onSuccess?: () => void) {
+export function useEditKeyRatelimits(onSuccess?: () => void) {
   const trpcUtils = trpc.useUtils();
 
-  const updateKeyRatelimit = trpc.key.update.ratelimit.useMutation({
+  return trpc.key.update.ratelimit.useMutation({
     onSuccess(data, variables) {
       let description = "";
 
@@ -25,9 +15,7 @@ export function useEditRatelimits(entityType: EntityType, onSuccess?: () => void
         if (rulesCount === 1) {
           const rule = variables.ratelimit.data[0];
           const refillInterval = typeof rule.refillInterval === "number" ? rule.refillInterval : 0;
-          description = `Your key ${data.keyId} has been updated with a limit of ${
-            rule.limit
-          } requests per ${formatInterval(refillInterval)}`;
+          description = `Your key ${data.keyId} has been updated with a limit of ${rule.limit} requests per ${formatInterval(refillInterval)}`;
         } else {
           description = `Your key ${data.keyId} has been updated with ${rulesCount} rate limit rules`;
         }
@@ -41,33 +29,18 @@ export function useEditRatelimits(entityType: EntityType, onSuccess?: () => void
       });
 
       trpcUtils.api.keys.list.invalidate();
-      if (onSuccess) {
-        onSuccess();
-      }
+      onSuccess?.();
     },
     onError(err) {
-      if (err.data?.code === "NOT_FOUND") {
-        toast.error("Key Update Failed", {
-          description: "Unable to find the key. Please refresh and try again.",
-        });
-      } else if (err.data?.code === "INTERNAL_SERVER_ERROR") {
-        toast.error("Server Error", {
-          description:
-            "We encountered an issue while updating your key. Please try again later or contact support at support.unkey.dev",
-        });
-      } else {
-        toast.error("Failed to Update Key Limits", {
-          description: err.message || "An unexpected error occurred. Please try again later.",
-          action: {
-            label: "Contact Support",
-            onClick: () => window.open("mailto:support@unkey.com", "_blank"),
-          },
-        });
-      }
+      handleError(err.data?.code, err.message, "key");
     },
   });
+}
 
-  const updateIdentityRatelimit = trpc.identity.update.ratelimit.useMutation({
+export function useEditIdentityRatelimits(onSuccess?: () => void) {
+  const trpcUtils = trpc.useUtils();
+
+  return trpc.identity.update.ratelimit.useMutation({
     onSuccess(data, variables) {
       let description = "";
 
@@ -77,9 +50,7 @@ export function useEditRatelimits(entityType: EntityType, onSuccess?: () => void
         if (rulesCount === 1) {
           const rule = variables.ratelimit.data[0];
           const refillInterval = typeof rule.refillInterval === "number" ? rule.refillInterval : 0;
-          description = `Identity ${data.identityId} has been updated with a limit of ${
-            rule.limit
-          } requests per ${formatInterval(refillInterval)}`;
+          description = `Identity ${data.identityId} has been updated with a limit of ${rule.limit} requests per ${formatInterval(refillInterval)}`;
         } else {
           description = `Identity ${data.identityId} has been updated with ${rulesCount} rate limit rules`;
         }
@@ -93,33 +64,39 @@ export function useEditRatelimits(entityType: EntityType, onSuccess?: () => void
       });
 
       trpcUtils.identity.query.invalidate();
-      if (onSuccess) {
-        onSuccess();
-      }
+      onSuccess?.();
     },
     onError(err) {
-      if (err.data?.code === "NOT_FOUND") {
-        toast.error("Identity Update Failed", {
-          description: "Unable to find the identity. Please refresh and try again.",
-        });
-      } else if (err.data?.code === "INTERNAL_SERVER_ERROR") {
-        toast.error("Server Error", {
-          description:
-            "We encountered an issue while updating your identity. Please try again later or contact support at support.unkey.dev",
-        });
-      } else {
-        toast.error("Failed to Update Identity Limits", {
-          description: err.message || "An unexpected error occurred. Please try again later.",
-          action: {
-            label: "Contact Support",
-            onClick: () => window.open("mailto:support@unkey.com", "_blank"),
-          },
-        });
-      }
+      handleError(err.data?.code, err.message, "identity");
     },
   });
+}
 
-  return entityType === "key" ? updateKeyRatelimit : updateIdentityRatelimit;
+function handleError(
+  code: string | undefined,
+  message: string | undefined,
+  entity: "key" | "identity",
+) {
+  const label = entity === "key" ? "Key" : "Identity";
+  const entityName = entity === "key" ? "key" : "identity";
+
+  if (code === "NOT_FOUND") {
+    toast.error(`${label} Update Failed`, {
+      description: `Unable to find the ${entityName}. Please refresh and try again.`,
+    });
+  } else if (code === "INTERNAL_SERVER_ERROR") {
+    toast.error("Server Error", {
+      description: `We encountered an issue while updating your ${entityName}. Please try again later or contact support at support.unkey.dev`,
+    });
+  } else {
+    toast.error(`Failed to Update ${label} Limits`, {
+      description: message || "An unexpected error occurred. Please try again later.",
+      action: {
+        label: "Contact Support",
+        onClick: () => window.open("mailto:support@unkey.com", "_blank"),
+      },
+    });
+  }
 }
 
 const formatInterval = (milliseconds: number): string => {
@@ -129,19 +106,14 @@ const formatInterval = (milliseconds: number): string => {
 
   const duration = intervalToDuration({ start: 0, end: milliseconds });
 
-  // Customize the format for different time ranges
   if (milliseconds < 60000) {
-    // Less than a minute
     return formatDuration(duration, { format: ["seconds"] });
   }
   if (milliseconds < 3600000) {
-    // Less than an hour
     return formatDuration(duration, { format: ["minutes", "seconds"] });
   }
   if (milliseconds < 86400000) {
-    // Less than a day
     return formatDuration(duration, { format: ["hours", "minutes"] });
   }
-  // Days or more
   return formatDuration(duration, { format: ["days", "hours"] });
 };


### PR DESCRIPTION
## What does this PR do?

The real bug was that every row's `EditRatelimitDialog` shared the same hardcoded form ID "edit-identity-ratelimit-form". Since all visible rows mount their own dialog, the DOM had duplicate IDs. The browser's form="..." attribute on the submit button always resolved to the first row's.                                                                      

Fixed by replacing the hardcoded string with `useId()` so each dialog instance gets a unique form ID.    

https://github.com/user-attachments/assets/c540915a-ec86-431c-9745-d29f5823c54d



### Note
Also cleans up the mutation hook for ratelimit updates, coz it was adding noise rather than help.