### PR TITLE
fix(dashboard): mark keyauths as softdeleted when api is deleted

### DIFF
--- a/web/apps/dashboard/lib/trpc/routers/api/delete.ts
+++ b/web/apps/dashboard/lib/trpc/routers/api/delete.ts
@@ -52,10 +52,15 @@ export const deleteApi = workspaceProcedure
     }
     try {
       await db.transaction(async (tx) => {
+        const now = Date.now();
         await tx
           .update(schema.apis)
-          .set({ deletedAtM: Date.now() })
+          .set({ deletedAtM: now })
           .where(eq(schema.apis.id, input.apiId));
+        await tx
+          .update(schema.keyAuth)
+          .set({ deletedAtM: now })
+          .where(eq(schema.keyAuth.id, keyAuthId));
         await insertAuditLogs(tx, {
           workspaceId: api.workspaceId,
           actor: {

--- a/web/apps/dashboard/lib/trpc/routers/deploy/environment-settings/get-available-keyspaces.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/environment-settings/get-available-keyspaces.ts
@@ -27,7 +27,6 @@ export const getAvailableKeyspaces = workspaceProcedure.query(async ({ ctx }) =>
       });
     });
 
-
   return keyspaces.reduce(
     (acc, ks) => {
       if (ks.api && ks.api.deletedAtM === null) {

--- a/web/apps/dashboard/lib/trpc/routers/deploy/environment-settings/get-available-keyspaces.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/environment-settings/get-available-keyspaces.ts
@@ -14,6 +14,7 @@ export const getAvailableKeyspaces = workspaceProcedure.query(async ({ ctx }) =>
         api: {
           columns: {
             name: true,
+            deletedAtM: true,
           },
         },
       },
@@ -26,9 +27,12 @@ export const getAvailableKeyspaces = workspaceProcedure.query(async ({ ctx }) =>
       });
     });
 
+
   return keyspaces.reduce(
     (acc, ks) => {
-      acc[ks.id] = ks;
+      if (ks.api && ks.api.deletedAtM === null) {
+        acc[ks.id] = { id: ks.id, api: { name: ks.api.name } };
+      }
       return acc;
     },
     {} as Record<string, { id: string; api: { name: string } }>,


### PR DESCRIPTION
## What does this PR do?

When an API is deleted, its `key_auth` row was left with `deleted_at_m = NULL` while the `apis` and `keys` rows were soft-deleted. This caused deleted APIs to still appear in the available keyspaces list, since the query filters on `key_auth.deleted_at_m`.

## Changes
- `api/delete.ts`: Soft-delete the `key_auth` row in the same transaction as the API and keys
- `get-available-keyspaces.ts`: Filter out keyspaces whose associated API is soft-deleted, as a safeguard for existing orphaned rows

## How to Test
- Create an API
- Go to /deploy/policies
- Add a key verification policy and confirm the new API appears in the keyspace dropdown
- Delete the API
- Go back to /deploy/policies and verify the deleted API no longer appears in the keyspace dropdown