### PR TITLE
refactor(dashboard): simplify Key Created success dialog

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/_components/create-key/components/key-created-success-dialog.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/_components/create-key/components/key-created-success-dialog.tsx
@@ -1,46 +1,25 @@
 "use client";
 
-import { useWorkspaceNavigation } from "@/hooks/use-workspace-navigation";
-import { ArrowRight, Check, Key2, Plus } from "@unkey/icons";
-import {
-  Button,
-  ConfirmPopover,
-  Dialog,
-  DialogContent,
-  DialogTitle,
-  InfoTooltip,
-  toast,
-} from "@unkey/ui";
-import { useRouter } from "next/navigation";
+import { Check, Key2 } from "@unkey/icons";
+import { ConfirmPopover, Dialog, DialogContent, DialogTitle, VisuallyHidden } from "@unkey/ui";
 import { type FC, useEffect, useRef, useState } from "react";
-import { UNNAMED_KEY } from "../create-key.constants";
 import { KeySecretSection } from "./key-secret-section";
 
 interface KeyCreatedSuccessDialogProps {
   isOpen: boolean;
-  onClose: (() => void) | (() => Promise<void>);
-  keyData: { key: string; id: string; name?: string } | null;
-  apiId: string;
-  keyspaceId?: string | null;
-  onCreateAnother?: (() => void) | (() => Promise<void>);
+  onClose: () => void;
+  keyData: { key: string } | null;
 }
 
 export const KeyCreatedSuccessDialog: FC<KeyCreatedSuccessDialogProps> = ({
   isOpen,
   onClose,
   keyData,
-  apiId,
-  keyspaceId,
-  onCreateAnother,
 }) => {
-  const workspace = useWorkspaceNavigation();
   const [isConfirmOpen, setIsConfirmOpen] = useState(false);
-  const [pendingAction, setPendingAction] = useState<
-    "close" | "create-another" | "go-to-details" | null
-  >(null);
-  const dividerRef = useRef<HTMLDivElement>(null);
-  const router = useRouter();
-  // Prevent accidental tab/window close when dialog is open
+  const popoverAnchorRef = useRef<HTMLDivElement>(null);
+
+  // Prevent accidental tab/window close while the secret is visible
   useEffect(() => {
     if (!isOpen) {
       return;
@@ -61,177 +40,84 @@ export const KeyCreatedSuccessDialog: FC<KeyCreatedSuccessDialogProps> = ({
     return null;
   }
 
-  const handleCloseAttempt = (action: "close" | "create-another" | "go-to-details" = "close") => {
-    setPendingAction(action);
+  const handleCloseAttempt = () => {
     setIsConfirmOpen(true);
   };
 
-  const handleConfirmClose = async () => {
-    if (!pendingAction) {
-      console.error("No pending action when confirming close");
-      return;
-    }
-
+  const handleConfirmClose = () => {
     setIsConfirmOpen(false);
-
-    try {
-      // Always close the dialog first
-      await Promise.resolve(onClose());
-
-      // Then execute the specific action
-      switch (pendingAction) {
-        case "create-another":
-          if (onCreateAnother) {
-            await Promise.resolve(onCreateAnother());
-          } else {
-            console.warn("onCreateAnother callback not provided");
-          }
-          break;
-
-        case "go-to-details":
-          if (!keyspaceId) {
-            toast.error("Failed to Navigate", {
-              description: "Keyspace ID is required to view key details.",
-              action: {
-                label: "Contact Support",
-                onClick: () => window.open("mailto:support@unkey.com", "_blank"),
-              },
-            });
-            return;
-          }
-          router.push(`/${workspace.slug}/apis/${apiId}/keys/${keyspaceId}/${keyData.id}`);
-          break;
-
-        default:
-          // Dialog already closed, nothing more to do
-          break;
-      }
-    } catch (error) {
-      console.error("Error executing pending action:", error);
-      toast.error("Action Failed", {
-        description: "An unexpected error occurred. Please try again.",
-      });
-    } finally {
-      setPendingAction(null);
-    }
-  };
-
-  const handleDialogOpenChange = (open: boolean) => {
-    if (!open) {
-      handleCloseAttempt("close");
-    }
+    onClose();
   };
 
   return (
-    <Dialog open={isOpen} onOpenChange={handleDialogOpenChange}>
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          handleCloseAttempt();
+        }
+      }}
+    >
       <DialogContent
-        className="drop-shadow-2xl transform-gpu border-gray-4 rounded-2xl! p-0 gap-0 min-w-[760px] max-h-[90vh] overflow-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]"
+        className="drop-shadow-2xl transform-gpu border-grayA-4 overflow-hidden rounded-2xl! p-0 gap-0 w-full max-w-[760px] max-h-[90vh] overflow-y-auto"
         showCloseWarning
-        onAttemptClose={() => handleCloseAttempt("close")}
+        onAttemptClose={handleCloseAttempt}
       >
-        <>
-          <DialogTitle className="sr-only">Key Created Successfully</DialogTitle>
-          <div className="bg-grayA-2 py-6 flex flex-col items-center justify-center w-full px-[120px] overflow-auto">
-            <div className="py-4">
-              <div className="flex gap-4">
-                <div className="border border-grayA-4 rounded-[14px] size-14 opacity-35" />
-                <div className="border border-grayA-4 rounded-[14px] size-14" />
-                <div className="border border-grayA-4 rounded-[14px] size-14 flex items-center justify-center relative">
-                  <div className="border border-grayA-4 rounded-full border-dashed size-[24px] absolute left-0 top-0" />
-                  <div className="border border-grayA-4 rounded-full border-dashed size-[24px] absolute right-0 top-0" />
-                  <div className="border border-grayA-4 rounded-full border-dashed size-[24px] absolute right-0 bottom-0" />
-                  <div className="border border-grayA-4 rounded-full border-dashed size-[24px] absolute left-0 bottom-0" />
-                  <Key2 iconSize="2xl-thin" />
-                  <div className="flex items-center justify-center border border-grayA-3 rounded-full bg-success-9 text-white size-[22px] absolute right-[-10px] top-[-10px]">
-                    <Check iconSize="sm-bold" />
-                  </div>
-                </div>
-                <div className="border border-grayA-4 rounded-[14px] size-14" />
-                <div className="border border-grayA-4 rounded-[14px] size-14 opacity-35" />
-              </div>
-            </div>
-            <div className="mt-2 flex flex-col gap-2 items-center">
-              <div className="font-semibold text-gray-12 text-[16px] leading-[24px]">
-                Key Created
-              </div>
-              <div className="text-gray-10 text-[13px] leading-[24px] text-center" ref={dividerRef}>
-                You've successfully generated a new API key.
-                <br /> Use this key to authenticate requests from your application.
-              </div>
-            </div>
-            <div className="p-1 w-full my-4">
-              <div className="h-px bg-grayA-3 w-full" />
-            </div>
-            <div className="flex flex-col gap-2 items-start w-full">
-              <div className="text-gray-12 text-sm font-semibold">Key Details</div>
-              <div className="bg-white dark:bg-black border rounded-xl border-grayA-5 px-6 w-full">
-                <div className="flex gap-6 items-center">
-                  <div className="bg-grayA-5 text-gray-12 size-5 flex items-center justify-center rounded-sm ">
-                    <Key2 iconSize="sm-regular" />
-                  </div>
-                  <div className="flex flex-col gap-1 py-6">
-                    <div className="text-accent-12 text-xs font-mono">{keyData.id}</div>
-                    <InfoTooltip
-                      content={keyData.name}
-                      position={{ side: "bottom", align: "center" }}
-                      asChild
-                      disabled={!keyData.name}
-                      variant="inverted"
-                    >
-                      <div className="text-accent-9 text-xs max-w-[160px] truncate">
-                        {keyData.name ?? UNNAMED_KEY}
-                      </div>
-                    </InfoTooltip>
-                  </div>
-                  <Button
-                    variant="outline"
-                    className="ml-auto font-medium text-[13px] text-gray-12"
-                    onClick={() => handleCloseAttempt("go-to-details")}
-                  >
-                    See key details <ArrowRight iconSize="sm-regular" />
-                  </Button>
+        <VisuallyHidden asChild>
+          <DialogTitle>Key Created</DialogTitle>
+        </VisuallyHidden>
+        <div className="bg-grayA-2 py-10 flex flex-col items-center justify-center w-full px-[120px]">
+          <div className="py-4 mt-[30px]">
+            <div className="flex gap-4">
+              <div className="border border-grayA-4 rounded-[14px] size-14 opacity-35" />
+              <div className="border border-grayA-4 rounded-[14px] size-14" />
+              <div className="border border-grayA-4 rounded-[14px] size-14 flex items-center justify-center relative">
+                <div className="border border-grayA-4 rounded-full border-dashed size-[24px] absolute left-0 top-0" />
+                <div className="border border-grayA-4 rounded-full border-dashed size-[24px] absolute right-0 top-0" />
+                <div className="border border-grayA-4 rounded-full border-dashed size-[24px] absolute right-0 bottom-0" />
+                <div className="border border-grayA-4 rounded-full border-dashed size-[24px] absolute left-0 bottom-0" />
+                <Key2 iconSize="2xl-thin" aria-hidden="true" focusable={false} />
+                <div className="flex items-center justify-center border border-grayA-3 rounded-full bg-success-9 text-white size-[22px] absolute right-[-10px] top-[-10px]">
+                  <Check iconSize="sm-bold" aria-hidden="true" focusable={false} />
                 </div>
               </div>
-            </div>
-            <KeySecretSection
-              keyValue={keyData.key}
-              apiId={apiId}
-              className="mt-6 w-full"
-              secretKeyClassName="bg-white dark:bg-black overflow-x-auto"
-              codeClassName="p-0"
-            />
-            <div className="mt-6">
-              <div className="flex gap-3 mt-4 items-center justify-center w-full">
-                <Button
-                  variant="outline"
-                  className="font-medium text-[13px] text-gray-12"
-                  onClick={() => handleCloseAttempt("create-another")}
-                >
-                  <Plus iconSize="sm-regular" />
-                  Create another key
-                </Button>
-              </div>
+              <div className="border border-grayA-4 rounded-[14px] size-14" />
+              <div className="border border-grayA-4 rounded-[14px] size-14 opacity-35" />
             </div>
           </div>
-          <ConfirmPopover
-            isOpen={isConfirmOpen}
-            onOpenChange={setIsConfirmOpen}
-            onConfirm={handleConfirmClose}
-            triggerRef={dividerRef}
-            title="You won't see this secret key again!"
-            description="Make sure to copy your secret key before closing. It cannot be retrieved later."
-            confirmButtonText="Close anyway"
-            cancelButtonText="Dismiss"
-            variant="warning"
-            popoverProps={{
-              side: "right",
-              align: "end",
-              sideOffset: 5,
-              alignOffset: 30,
-              onOpenAutoFocus: (e) => e.preventDefault(),
-            }}
-          />
-        </>
+          <div className="mt-5 flex flex-col gap-2 items-center">
+            <div className="font-semibold text-gray-12 text-[16px] leading-[24px]">Key Created</div>
+            <div
+              className="text-gray-10 text-[13px] leading-[24px] text-center"
+              ref={popoverAnchorRef}
+            >
+              You've successfully generated a new API key.
+              <br /> Use this key to authenticate requests from your application.
+            </div>
+          </div>
+          <div className="p-1 w-full my-8">
+            <div className="h-px bg-grayA-3 w-full" />
+          </div>
+          <KeySecretSection keyValue={keyData.key} className="w-full" />
+        </div>
+        <ConfirmPopover
+          isOpen={isConfirmOpen}
+          onOpenChange={setIsConfirmOpen}
+          onConfirm={handleConfirmClose}
+          triggerRef={popoverAnchorRef}
+          title="You won't see this secret key again!"
+          description="Make sure to copy your secret key before closing. It cannot be retrieved later."
+          confirmButtonText="Close anyway"
+          cancelButtonText="Dismiss"
+          variant="warning"
+          popoverProps={{
+            side: "right",
+            align: "end",
+            sideOffset: 5,
+            alignOffset: 30,
+            onOpenAutoFocus: (e) => e.preventDefault(),
+          }}
+        />
       </DialogContent>
     </Dialog>
   );

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/_components/create-key/components/key-secret-section.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/_components/create-key/components/key-secret-section.tsx
@@ -5,22 +5,15 @@ import { CircleInfo } from "@unkey/icons";
 
 type KeySecretSectionProps = {
   keyValue: string;
-  apiId: string;
   className?: string;
-  secretKeyClassName?: string;
-  codeClassName?: string;
 };
 
-export const KeySecretSection = ({
-  keyValue,
-  className,
-  secretKeyClassName = "bg-white dark:bg-black",
-}: KeySecretSectionProps) => {
+export const KeySecretSection = ({ keyValue, className }: KeySecretSectionProps) => {
   return (
     <div className={className}>
       <div className="flex flex-col gap-2 items-start w-full">
         <div className="text-gray-12 text-sm font-semibold">Key Secret</div>
-        <SecretKey value={keyValue} title="API Key" className={secretKeyClassName} />
+        <SecretKey value={keyValue} title="API Key" />
         <div className="text-gray-9 text-[13px] flex items-center gap-1.5 self-center">
           <CircleInfo className="text-accent-9" iconSize="sm-regular" />
           <span>

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/_components/create-key/index.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/_components/create-key/index.tsx
@@ -45,11 +45,7 @@ export const CreateKeyDialog = ({
 }) => {
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [successDialogOpen, setSuccessDialogOpen] = useState(false);
-  const [createdKeyData, setCreatedKeyData] = useState<{
-    key: string;
-    id: string;
-    name?: string;
-  } | null>(null);
+  const [createdKeyData, setCreatedKeyData] = useState<{ key: string } | null>(null);
   const [dialogKey, setDialogKey] = useState(0);
 
   const methods = usePersistedForm<FormValues>(
@@ -90,12 +86,8 @@ export const CreateKeyDialog = ({
   );
 
   const key = useCreateKey((data) => {
-    if (data?.key && data?.keyId) {
-      setCreatedKeyData({
-        key: data.key,
-        id: data.keyId,
-        name: data.name,
-      });
+    if (data?.key) {
+      setCreatedKeyData({ key: data.key });
       setSuccessDialogOpen(true);
     }
 
@@ -148,10 +140,6 @@ export const CreateKeyDialog = ({
   const handleSuccessDialogClose = () => {
     setSuccessDialogOpen(false);
     setCreatedKeyData(null);
-  };
-
-  const openNewKeyDialog = () => {
-    setIsSettingsOpen(true);
   };
 
   return (
@@ -219,12 +207,9 @@ export const CreateKeyDialog = ({
       {/* Success Dialog */}
       <Suspense fallback={<Loading type="spinner" />}>
         <KeyCreatedSuccessDialog
-          apiId={apiId}
-          keyspaceId={keyspaceId}
           isOpen={successDialogOpen}
           onClose={handleSuccessDialogClose}
           keyData={createdKeyData}
-          onCreateAnother={openNewKeyDialog}
         />
       </Suspense>
     </>


### PR DESCRIPTION
Fixes DES-40

## What does this PR do?

- Drop Key ID from the "Key Created" dialog. 
- Bring the dialog in line with the root key creation flow: just the secret, the warning, and the "Learn more" link.
- Drops the "See key details" button and "Create another key" CTA — both reachable from the keys table.

## Screenshot
<img width="3384" height="2064" alt="CleanShot 2026-04-30 at 10 25 15@2x" src="https://github.com/user-attachments/assets/4fd334af-488b-4bf3-abe7-178e0282e214" />



## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

1. Open an API in the dashboard and click "Create new key".
2. Submit the form to create a key.
3. Verify the success dialog shows only the secret + "Learn more" line — no `key_xxx` ID, no "See key details" or "Create another key" buttons.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary
