### PR TITLE
feat(dashboard): add duration timer to deployment cards

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/components/deployment-duration.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/components/deployment-duration.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import type { DeploymentStatus } from "@/lib/collections/deploy/deployment-status";
+import { formatCompoundDuration } from "@/lib/utils/metric-formatters";
+import { Loading } from "@unkey/ui";
+import { useEffect, useState } from "react";
+
+type DurationDisplay = "hidden" | "terminal" | "live";
+
+const STATUS_DISPLAY: Record<DeploymentStatus, DurationDisplay> = {
+  pending: "hidden",
+  awaiting_approval: "hidden",
+  starting: "live",
+  building: "live",
+  deploying: "live",
+  network: "live",
+  finalizing: "live",
+  ready: "terminal",
+  failed: "terminal",
+  skipped: "terminal",
+  stopped: "terminal",
+  superseded: "terminal",
+  cancelled: "terminal",
+};
+
+type Props = {
+  status: DeploymentStatus;
+  createdAt: number;
+  updatedAt: number | null;
+};
+
+export function DeploymentDuration({ status, createdAt, updatedAt }: Props) {
+  const display = STATUS_DISPLAY[status];
+  const isLive = display === "live";
+
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (!isLive) {
+      return;
+    }
+    const interval = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(interval);
+  }, [isLive]);
+
+  if (display === "hidden") {
+    return null;
+  }
+
+  const endTime = isLive ? now : updatedAt;
+  if (endTime === null) {
+    return null;
+  }
+
+  return (
+    <span className="flex items-center gap-1 text-xs font-mono text-gray-9">
+      {isLive && <Loading size={14} className="text-accent-12" />}
+      {formatCompoundDuration(Math.max(0, endTime - createdAt))}
+    </span>
+  );
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/components/deployment-row.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/components/deployment-row.tsx
@@ -10,6 +10,7 @@ import { useState } from "react";
 import { DeploymentStatusBadge } from "../../../components/deployment-status-badge";
 import { Avatar } from "../../../components/git-avatar";
 import { DeploymentApproval } from "../[deploymentId]/(deployment-progress)/deployment-approval";
+import { DeploymentDuration } from "./deployment-duration";
 import { EnvStatusBadge } from "./table/components/env-status-badge";
 import { ActionColumnSkeleton } from "./table/components/skeletons";
 
@@ -82,8 +83,13 @@ export function DeploymentRow({
           <span className="text-xs text-gray-9 capitalize">{environment?.slug}</span>
         </div>
 
-        <div className="md:w-[20%] md:shrink-0">
+        <div className="md:w-[20%] md:shrink-0 flex flex-col gap-1 items-start">
           <DeploymentStatusBadge status={deployment.status} />
+          <DeploymentDuration
+            status={deployment.status}
+            createdAt={deployment.createdAt}
+            updatedAt={deployment.updatedAt}
+          />
         </div>
       </div>
 

--- a/web/apps/dashboard/lib/collections/deploy/deployments.ts
+++ b/web/apps/dashboard/lib/collections/deploy/deployments.ts
@@ -52,6 +52,7 @@ const schema = z.object({
     .nullable(),
   shutdownSignal: z.enum(["SIGTERM", "SIGINT", "SIGQUIT", "SIGKILL"]),
   createdAt: z.number(),
+  updatedAt: z.number().nullable(),
 });
 
 export type Deployment = z.infer<typeof schema>;

--- a/web/apps/dashboard/lib/trpc/routers/deploy/deployment/list.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/deployment/list.ts
@@ -31,6 +31,7 @@ export const listDeployments = workspaceProcedure
           healthcheck: deployments.healthcheck,
           shutdownSignal: deployments.shutdownSignal,
           createdAt: deployments.createdAt,
+          updatedAt: deployments.updatedAt,
         })
         .from(deployments)
         .where(


### PR DESCRIPTION
## What does this PR do?

- Adds a duration indicator under the deployment row status badge
- In-progress (`starting` / `building` / `deploying` / `network` / `finalizing`): ticks every 1s with a spinner
- Hidden for `pending` and `awaiting_approval`

DES-5

## Screenshot

<img width="3384" height="2064" alt="CleanShot 2026-04-30 at 14 11 59@2x" src="https://github.com/user-attachments/assets/f51fafe0-8941-491c-aa10-5eba51a834c9" />


https://github.com/user-attachments/assets/d41662e2-324e-4ed2-ba16-40c0e09a3d58




## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Ready / Failed / Cancelled rows show frozen duration under the badge
- Building / Deploying rows tick every 1s with a spinner
- Pending / Awaiting Approval rows show no duration

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary
