### PR TITLE
fix(dashboard): don't crash requests table on response_status 0

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/(overview)/components/table/utils/get-sentinel-logs-row-class.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/(overview)/components/table/utils/get-sentinel-logs-row-class.ts
@@ -42,7 +42,7 @@ const STATUS_STYLES = {
 };
 
 export const getStatusStyle = (status: number): StatusStyle => {
-  if (status >= 500) {
+  if (!Number.isInteger(status) || status < 100 || status >= 500) {
     return STATUS_STYLES.error;
   }
   if (status >= 400) {
@@ -58,19 +58,8 @@ export const WARNING_ICON_STYLES = {
 };
 
 export const getRowClassName = (log: SentinelLogsResponse): string => {
-  // Early validation
   if (!log?.request_id) {
     throw new Error("Log must have a valid request_id");
-  }
-
-  if (
-    !Number.isInteger(log.response_status) ||
-    log.response_status < 100 ||
-    log.response_status > 599
-  ) {
-    throw new Error(
-      `Invalid response_status: ${log.response_status}. Must be a valid HTTP status code.`,
-    );
   }
 
   const style = getStatusStyle(log.response_status);

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/requests/components/table/utils/get-row-class.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/requests/components/table/utils/get-row-class.ts
@@ -56,7 +56,7 @@ const STATUS_STYLES = {
 };
 
 export const getStatusStyle = (status: number): StatusStyle => {
-  if (status >= 500) {
+  if (!Number.isInteger(status) || status < 100 || status >= 500) {
     return STATUS_STYLES.error;
   }
   if (status >= 400) {
@@ -88,19 +88,8 @@ export const getRowClassName = (
   isLive?: boolean,
   realtimeLogs?: SentinelLogsResponse[],
 ): string => {
-  // Early validation
   if (!log?.request_id) {
     throw new Error("Log must have a valid request_id");
-  }
-
-  if (
-    !Number.isInteger(log.response_status) ||
-    log.response_status < 100 ||
-    log.response_status > 599
-  ) {
-    throw new Error(
-      `Invalid response_status: ${log.response_status}. Must be a valid HTTP status code.`,
-    );
   }
 
   const style = getStatusStyle(log.response_status);


### PR DESCRIPTION
## What does this PR do?

- Removes the `throw` in `getRowClassName` for sentinel-log tables — `response_status: 0` (aborted / no-response requests) was crashing the requests and deployment-requests
  tables during render.
- Routes non-integer / `<100` / `>=500` statuses through `getStatusStyle` to the `error` style, so `0` renders as an error badge instead of being mis-styled as `success`.
- Keeps the `request_id` invariant guard (programming error, not data-driven).

Fixes # (issue)

_If there is not an issue for this, please create one first. This is used to tracking purposes and also helps us understand why this PR exists_

<!-- If there isn't an issue for this PR, please re-review our Contributing Guide and create an issue -->

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

  - [ ] Load `/{workspace}/projects/{projectId}/requests` with logs that include a `response_status: 0` row — table renders, row uses error styling, no Sentry error.
  - [ ] Same for `/{workspace}/projects/{projectId}/deployments/{deploymentId}` requests table.
  - [ ] Spot-check that 2xx / 3xx / 4xx / 5xx rows still get success / info / warning / error styles respectively.

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [X] Filled out the "How to test" section in this PR
- [X] Read [Contributing Guide](./CONTRIBUTING.md)
- [X] Self-reviewed my own code
- [X] Commented on my code in hard-to-understand areas
- [X] Ran `pnpm build`
- [X] Ran `pnpm fmt`
- [X] Ran `make fmt` on `/go` directory
- [X] Checked for warnings, there are none
- [X] Removed all `console.logs`
- [X] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary
