### PR TITLE
feat(ratelimit): add workspace_id label to decision and strict-mode metrics

### DIFF
--- a/internal/services/ratelimit/metrics/prometheus.go
+++ b/internal/services/ratelimit/metrics/prometheus.go
@@ -93,21 +93,22 @@ var (
 	// RatelimitDecision counts rate-limit decisions.
 	//
 	// Labels:
+	//   - workspace_id: the workspace the request was attributed to.
 	//   - source: "local" when the decision used only in-memory counters;
 	//     "origin" when a cold-window or strict-mode Redis fetch was required.
 	//   - outcome: "passed" (request allowed) or "denied" (limit exceeded).
 	//
 	// Example usage:
-	//   metrics.RatelimitDecision.WithLabelValues("local", "passed").Inc()
-	//   metrics.RatelimitDecision.WithLabelValues("origin", "denied").Inc()
+	//   metrics.RatelimitDecision.WithLabelValues(workspaceID, "local", "passed").Inc()
+	//   metrics.RatelimitDecision.WithLabelValues(workspaceID, "origin", "denied").Inc()
 	RatelimitDecision = lazy.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "unkey",
 			Subsystem: "ratelimit",
 			Name:      "decisions_total",
-			Help:      "Total number of rate-limit decisions, labeled by source (local|origin) and outcome (passed|denied).",
+			Help:      "Total number of rate-limit decisions, labeled by workspace_id, source (local|origin) and outcome (passed|denied).",
 		},
-		[]string{"source", "outcome"},
+		[]string{"workspace_id", "source", "outcome"},
 	)
 
 	// RatelimitCASExhausted counts Ratelimit() calls that exhausted the CAS
@@ -127,20 +128,24 @@ var (
 	)
 
 	// RatelimitStrictModeActivations counts how often a denial triggered strict
-	// mode for a (name, identifier, duration) tuple. Until the deadline passes,
-	// subsequent requests on that tuple force a synchronous origin fetch to
-	// converge local state. Spikes correlate with sustained denial pressure
-	// and an increase in origin-fetch latency on the hot path.
+	// mode for a (workspace, namespace, identifier, duration) tuple. Until the
+	// deadline passes, subsequent requests on that tuple force a synchronous
+	// origin fetch to converge local state. Spikes correlate with sustained
+	// denial pressure and an increase in origin-fetch latency on the hot path.
+	//
+	// Labels:
+	//   - workspace_id: the workspace whose tuple entered strict mode.
 	//
 	// Example usage:
-	//   metrics.RatelimitStrictModeActivations.Inc()
-	RatelimitStrictModeActivations = lazy.NewCounter(
+	//   metrics.RatelimitStrictModeActivations.WithLabelValues(workspaceID).Inc()
+	RatelimitStrictModeActivations = lazy.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "unkey",
 			Subsystem: "ratelimit",
 			Name:      "strict_mode_activations_total",
-			Help:      "Total number of denials that raised the strict-mode deadline for a rate-limit tuple.",
+			Help:      "Total number of denials that raised the strict-mode deadline for a rate-limit tuple, labeled by workspace_id.",
 		},
+		[]string{"workspace_id"},
 	)
 )
 

--- a/internal/services/ratelimit/ratelimit.go
+++ b/internal/services/ratelimit/ratelimit.go
@@ -114,7 +114,7 @@ func (s *service) Ratelimit(ctx context.Context, req RatelimitRequest) (Ratelimi
 			// Also propagates the denial cross-region on the first denial
 			// per counter entry.
 			s.activateStrictMode(req, &cs, effectiveCount)
-			metrics.RatelimitDecision.WithLabelValues(cs.source, "denied").Inc()
+			metrics.RatelimitDecision.WithLabelValues(req.WorkspaceID, cs.source, "denied").Inc()
 			span.SetAttributes(attribute.Bool("passed", false))
 			return RatelimitResponse{
 				Success:   false,
@@ -127,7 +127,7 @@ func (s *service) Ratelimit(ctx context.Context, req RatelimitRequest) (Ratelimi
 
 		if cs.cur.val.CompareAndSwap(curCount, curCount+req.Cost) {
 			s.replayBuffer.Buffer(req)
-			metrics.RatelimitDecision.WithLabelValues(cs.source, "passed").Inc()
+			metrics.RatelimitDecision.WithLabelValues(req.WorkspaceID, cs.source, "passed").Inc()
 			span.SetAttributes(attribute.Bool("passed", true))
 			return RatelimitResponse{
 				Success:   true,
@@ -146,7 +146,7 @@ func (s *service) Ratelimit(ctx context.Context, req RatelimitRequest) (Ratelimi
 		"identifier", req.Identifier,
 	)
 	metrics.RatelimitCASExhausted.Inc()
-	metrics.RatelimitDecision.WithLabelValues(cs.source, "denied").Inc()
+	metrics.RatelimitDecision.WithLabelValues(req.WorkspaceID, cs.source, "denied").Inc()
 	span.SetAttributes(attribute.Bool("passed", false))
 	return RatelimitResponse{
 		Success:   false,
@@ -253,9 +253,9 @@ func (s *service) RatelimitMany(ctx context.Context, reqs []RatelimitRequest) ([
 		}
 
 		if individualPassed {
-			metrics.RatelimitDecision.WithLabelValues(checks[i].source, "passed").Inc()
+			metrics.RatelimitDecision.WithLabelValues(req.WorkspaceID, checks[i].source, "passed").Inc()
 		} else {
-			metrics.RatelimitDecision.WithLabelValues(checks[i].source, "denied").Inc()
+			metrics.RatelimitDecision.WithLabelValues(req.WorkspaceID, checks[i].source, "denied").Inc()
 		}
 	}
 

--- a/internal/services/ratelimit/service.go
+++ b/internal/services/ratelimit/service.go
@@ -288,7 +288,7 @@ func (s *service) loadStrictUntil(key strictKey) int64 {
 func (s *service) setStrictUntil(key strictKey, untilMs int64) {
 	val, _ := s.strictUntils.LoadOrStore(key, &atomic.Int64{})
 	atomicMax(val.(*atomic.Int64), untilMs)
-	metrics.RatelimitStrictModeActivations.Inc()
+	metrics.RatelimitStrictModeActivations.WithLabelValues(key.workspaceID).Inc()
 }
 
 // minPropagationDuration is the shortest window length for which cross-region


### PR DESCRIPTION
## What does this PR do?

Adds `workspace_id` as a label to the `RatelimitDecision` and `RatelimitStrictModeActivations` Prometheus metrics, enabling per-workspace observability of rate-limit decisions and strict mode activations.

`RatelimitDecision` now accepts `workspace_id` as its first label value alongside the existing `source` and `outcome` labels. `RatelimitStrictModeActivations` has been converted from a plain counter to a counter vector, also keyed by `workspace_id`, so strict mode activation spikes can be attributed to a specific workspace rather than being aggregated globally.

Fixes # (issue)

_If there is not an issue for this, please create one first. This is used to tracking purposes and also helps us understand why this PR exists_

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Trigger rate-limit decisions for requests belonging to different workspaces and confirm that `unkey_ratelimit_decisions_total` is emitted with the correct `workspace_id`, `source`, and `outcome` label combinations.
- Trigger a denial that activates strict mode and verify that `unkey_ratelimit_strict_mode_activations_total` is emitted with the correct `workspace_id` label.
- Confirm that previously recorded metrics without the `workspace_id` label do not conflict with the new label schema.

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary