### PR TITLE
fix(dashboard): show custom domain only for current deployment

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/components/deployment-domains-card.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/components/deployment-domains-card.tsx
@@ -44,6 +44,8 @@ export function DeploymentDomainsCard({
     domains: filtered,
     customDomains,
     environmentId: deployment.environmentId,
+    deploymentId: deployment.id,
+    currentDeploymentId: project?.currentDeploymentId ?? null,
   });
 
   const isLoading = isDomainsLoading || isCustomDomainsLoading;

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/components/domain-priority.test.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/components/domain-priority.test.ts
@@ -44,6 +44,8 @@ const baseCtx = {
   domains: [] as Domain[],
   customDomains: [] as CustomDomain[],
   environmentId: "env-1",
+  deploymentId: "dep-current",
+  currentDeploymentId: "dep-current" as string | null,
 };
 
 describe("getDomainPriority", () => {
@@ -214,6 +216,46 @@ describe("getDomainPriority", () => {
 
     expect(result.all).toHaveLength(2);
     expect(result.all.map((d) => d.id)).toEqual(["cd-1", "d-a"]);
+    expect(result.primary?.id).toBe("cd-1");
+  });
+
+  test("custom domains hidden when viewing non-current deployment", () => {
+    const result = getDomainPriority({
+      ...baseCtx,
+      deploymentId: "dep-other",
+      currentDeploymentId: "dep-current",
+      domains: [makeDomain({ id: "d-a", fullyQualifiedDomainName: "a.example.com" })],
+      customDomains: [makeCustomDomain({ id: "cd-1", domain: "custom.example.com" })],
+    });
+
+    expect(result.all).toHaveLength(1);
+    expect(result.primary?.id).toBe("d-a");
+    expect(result.all.map((d) => d.id)).toEqual(["d-a"]);
+  });
+
+  test("custom domains hidden when currentDeploymentId is null", () => {
+    const result = getDomainPriority({
+      ...baseCtx,
+      deploymentId: "dep-other",
+      currentDeploymentId: null,
+      domains: [makeDomain({ id: "d-a", fullyQualifiedDomainName: "a.example.com" })],
+      customDomains: [makeCustomDomain({ id: "cd-1", domain: "custom.example.com" })],
+    });
+
+    expect(result.all).toHaveLength(1);
+    expect(result.primary?.id).toBe("d-a");
+  });
+
+  test("custom domains shown when viewing current deployment", () => {
+    const result = getDomainPriority({
+      ...baseCtx,
+      deploymentId: "dep-current",
+      currentDeploymentId: "dep-current",
+      domains: [makeDomain({ id: "d-a", fullyQualifiedDomainName: "a.example.com" })],
+      customDomains: [makeCustomDomain({ id: "cd-1", domain: "custom.example.com" })],
+    });
+
+    expect(result.all).toHaveLength(2);
     expect(result.primary?.id).toBe("cd-1");
   });
 

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/components/domain-priority.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/components/domain-priority.ts
@@ -22,6 +22,8 @@ export type DomainPriorityContext = {
   domains: ReadonlyArray<Domain>;
   customDomains: ReadonlyArray<CustomDomain>;
   environmentId: string;
+  deploymentId: string;
+  currentDeploymentId: string | null;
 };
 
 export type DomainPriorityResult = {
@@ -31,16 +33,22 @@ export type DomainPriorityResult = {
 };
 
 export function getDomainPriority(ctx: DomainPriorityContext): DomainPriorityResult {
-  const customDisplayDomains: ReadonlyArray<DisplayDomain> = [...ctx.customDomains]
-    .filter((cd) => cd.environmentId === ctx.environmentId && cd.verificationStatus === "verified")
-    .sort((a, b) => a.domain.localeCompare(b.domain))
-    .map((cd) => ({
-      source: "custom" as const,
-      id: cd.id,
-      hostname: cd.domain,
-      url: `https://${cd.domain}`,
-      customDomain: cd,
-    }));
+  const isCurrentDeployment = ctx.deploymentId === ctx.currentDeploymentId;
+
+  const customDisplayDomains: ReadonlyArray<DisplayDomain> = isCurrentDeployment
+    ? [...ctx.customDomains]
+        .filter(
+          (cd) => cd.environmentId === ctx.environmentId && cd.verificationStatus === "verified",
+        )
+        .sort((a, b) => a.domain.localeCompare(b.domain))
+        .map((cd) => ({
+          source: "custom" as const,
+          id: cd.id,
+          hostname: cd.domain,
+          url: `https://${cd.domain}`,
+          customDomain: cd,
+        }))
+    : [];
 
   // Exclude platform domains that match a verified custom domain to avoid duplicates
   const customHostnames = new Set(customDisplayDomains.map((cd) => cd.hostname));


### PR DESCRIPTION
## What does this PR do?

  Adds deploymentId and `currentDeploymentId` to `DomainPriorityContext` so `getDomainPriority` can gate custom domains to only the current
  deployment. Non-current deployments see only platform domains. Three new tests cover the gating logic.


## How to Test

- Testing them locally is hard but you can use a mock domain list to verify that "custom" is only visible for "current"