### PR TITLE
fix: make tunnel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ clean-docker-test: ## Clean up dangling test containers
 
 .PHONY: tunnel
 tunnel: ## Forward ports 80/443 to frontline for *.unkey.local (run in separate terminal)
-	@sudo -v && ( while sudo -n true 2>/dev/null; do sleep 50; done & ) && while true; do sudo kubectl port-forward -n unkey svc/frontline 443:443 80:80 2>/dev/null; echo "port-forward exited, reconnecting..."; sleep 1; done
+	@sudo -v && ( while sudo -n true 2>/dev/null; do sleep 50; done & ) && while true; do sudo kubectl port-forward -n frontline svc/frontline 443:443 80:80 2>/dev/null; echo "port-forward exited, reconnecting..."; sleep 1; done
 
 .PHONY: dev
 dev: ## Start dev environment


### PR DESCRIPTION
## What does this PR do?


PR #5993 moved frontline from the unkey namespace to its own frontline namespace but didn't update the makefile. The `tunnel` target was still port-forwarding to -n unkey, where the service no longer exists, causing an infinite reconnect loop. Changed to -n frontline.