### PR TITLE
fix: Make sure the permissions are owned correctly

### DIFF
--- a/web/apps/dashboard/lib/trpc/routers/authorization/roles/upsert.ts
+++ b/web/apps/dashboard/lib/trpc/routers/authorization/roles/upsert.ts
@@ -3,7 +3,54 @@ import { insertAuditLogs } from "@/lib/audit";
 import { and, db, eq, schema } from "@/lib/db";
 import { workspaceProcedure } from "@/lib/trpc/trpc";
 import { TRPCError } from "@trpc/server";
+import type { Transaction } from "@unkey/db";
 import { newId } from "@unkey/id";
+
+// Without these checks the caller could attach a role to keys or permissions
+// owned by another workspace, which leaks role permissions into a victim's
+// keys at verification time (the Go authoritative join chain has no
+// workspace filter).
+async function assertKeysInWorkspace(tx: Transaction, workspaceId: string, keyIds: string[]) {
+  if (keyIds.length === 0) {
+    return;
+  }
+  const found = await tx.query.keys.findMany({
+    where: (table, { and, eq, inArray }) =>
+      and(eq(table.workspaceId, workspaceId), inArray(table.id, keyIds)),
+    columns: { id: true },
+  });
+  const foundIds = new Set(found.map((k) => k.id));
+  const missing = keyIds.filter((id) => !foundIds.has(id));
+  if (missing.length > 0) {
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: `Key(s) not found or not in this workspace: ${missing.join(", ")}`,
+    });
+  }
+}
+
+async function assertPermissionsInWorkspace(
+  tx: Transaction,
+  workspaceId: string,
+  permissionIds: string[],
+) {
+  if (permissionIds.length === 0) {
+    return;
+  }
+  const found = await tx.query.permissions.findMany({
+    where: (table, { and, eq, inArray }) =>
+      and(eq(table.workspaceId, workspaceId), inArray(table.id, permissionIds)),
+    columns: { id: true },
+  });
+  const foundIds = new Set(found.map((p) => p.id));
+  const missing = permissionIds.filter((id) => !foundIds.has(id));
+  if (missing.length > 0) {
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: `Permission(s) not found or not in this workspace: ${missing.join(", ")}`,
+    });
+  }
+}
 
 export const upsertRole = workspaceProcedure
   .input(rbacRoleSchema)
@@ -43,6 +90,13 @@ export const upsertRole = workspaceProcedure
             code: "NOT_FOUND",
             message: "Role not found or access denied",
           });
+        }
+
+        if (input.permissionIds && input.permissionIds.length > 0) {
+          await assertPermissionsInWorkspace(tx, ctx.workspace.id, input.permissionIds);
+        }
+        if (input.keyIds && input.keyIds.length > 0) {
+          await assertKeysInWorkspace(tx, ctx.workspace.id, input.keyIds);
         }
 
         // Only check for name conflicts if the name is actually changing
@@ -217,6 +271,13 @@ export const upsertRole = workspaceProcedure
             code: "CONFLICT",
             message: `Role with name '${input.roleName}' already exists`,
           });
+        }
+
+        if (input.permissionIds && input.permissionIds.length > 0) {
+          await assertPermissionsInWorkspace(tx, ctx.workspace.id, input.permissionIds);
+        }
+        if (input.keyIds && input.keyIds.length > 0) {
+          await assertKeysInWorkspace(tx, ctx.workspace.id, input.keyIds);
         }
 
         // Create new role


### PR DESCRIPTION
## What does this PR do?

fixes upsertRole accepts arbitrary keyIds/permissionIds and links them to user's role without workspace ownership check, enabling cross-tenant permission injection into other tenants' API keys

_If there is not an issue for this, please create one first. This is used to tracking purposes and also helps us understand why this PR exists_

<!-- If there isn't an issue for this PR, please re-review our Contributing Guide and create an issue -->

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Test A
- Test B

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary
