### PR TITLE
fix(dev): validate OAuth state and bind localhost in github setup

### DIFF
--- a/cmd/dev/github/BUILD.bazel
+++ b/cmd/dev/github/BUILD.bazel
@@ -15,5 +15,6 @@ go_library(
         "//pkg/db",
         "//pkg/jwt",
         "//pkg/runner",
+        "//pkg/uid",
     ],
 )

--- a/cmd/dev/github/setup.go
+++ b/cmd/dev/github/setup.go
@@ -16,6 +16,7 @@ package github
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"fmt"
 	"html/template"
@@ -28,6 +29,7 @@ import (
 	"time"
 
 	"github.com/unkeyed/unkey/pkg/cli"
+	"github.com/unkeyed/unkey/pkg/uid"
 )
 
 type githubAppManifest struct {
@@ -89,7 +91,14 @@ func setupGitHubApp(_ context.Context, cmd *cli.Command) error {
 	outDir := cmd.String("out-dir")
 
 	callbackURL := fmt.Sprintf("http://localhost:%s/callback", port)
-	listenAddr := fmt.Sprintf(":%s", port)
+	// Bind to loopback only so other hosts on the network cannot reach the
+	// callback handler and inject an attacker-controlled manifest code.
+	listenAddr := fmt.Sprintf("127.0.0.1:%s", port)
+
+	// Per-invocation random state. GitHub echoes it back on the callback;
+	// the handler rejects mismatches so a CSRF / cross-origin GET cannot
+	// race a forged code into codeCh.
+	state := uid.Secure(32)
 
 	manifest := githubAppManifest{
 		Name:   appName,
@@ -126,7 +135,7 @@ func setupGitHubApp(_ context.Context, cmd *cli.Command) error {
 	mux.HandleFunc("GET /", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html")
 		if err := htmlPage.Execute(w, map[string]string{
-			"State":    "unkey-dev-setup",
+			"State":    state,
 			"Manifest": string(manifestJSON),
 		}); err != nil {
 			http.Error(w, "internal error", http.StatusInternalServerError)
@@ -134,6 +143,11 @@ func setupGitHubApp(_ context.Context, cmd *cli.Command) error {
 	})
 
 	mux.HandleFunc("GET /callback", func(w http.ResponseWriter, r *http.Request) {
+		gotState := r.URL.Query().Get("state")
+		if subtle.ConstantTimeCompare([]byte(gotState), []byte(state)) != 1 {
+			http.Error(w, "invalid state", http.StatusBadRequest)
+			return
+		}
 		code := r.URL.Query().Get("code")
 		if code == "" {
 			http.Error(w, "missing code", http.StatusBadRequest)


### PR DESCRIPTION
## Summary

The local callback server in `dev github setup` (`cmd/dev/github/setup.go`)
had two issues that together allow an attacker-controlled GitHub App to be
provisioned in place of the developer's:

- Listened on `:9999` (all interfaces) instead of loopback, so any other
  host on the same network could reach `/callback`.
- Used a hardcoded `state` and never validated the `state` returned on the
  callback, so a same-origin or cross-origin GET (e.g. an `<img>` tag on
  any page the developer visits during setup) could race a forged `code`
  into the callback channel.

If the attacker's `code` arrives first, the CLI exchanges it via
`exchangeManifestCode` and writes the attacker's App ID, PEM, and webhook
secret to `dev/.env.github` and `web/apps/dashboard/.env`. Whoever owns
that App can then mint installation tokens against any org that installs
the dev app.

## Changes

- Bind the callback server to `127.0.0.1:<port>`.
- Generate a per-invocation random state via `uid.Secure(32)` and reject
  callbacks whose `state` does not match (constant-time compare).

## Test plan

- [ ] `bazel build //cmd/dev/github:github` (passes locally)
- [ ] Run `go run . dev github setup` end-to-end against a throwaway GitHub org and confirm the redirect flow still completes.
- [ ] Manually request `http://localhost:9999/callback?code=x` (no state) and confirm the response is `400 invalid state` and the CLI does not exchange the code.