### PR TITLE
feat: enable runtime metrics charts in node details panel

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/network/unkey-flow/components/overlay/node-details-panel/components/resource-metrics.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/network/unkey-flow/components/overlay/node-details-panel/components/resource-metrics.tsx
@@ -33,8 +33,6 @@ import {
 // per open panel, well within budget.
 const REFETCH_INTERVAL_MS = 3_000;
 
-const RUNTIME_METRICS_ENABLED = true;
-
 const WINDOW_LABELS: Record<TimeWindow, string> = {
   "15m": "Past 15 minutes",
   "1h": "Past hour",
@@ -224,50 +222,46 @@ export function ResourceMetrics({ resourceId, storageMib, instanceName }: Resour
         />
       )}
 
-      {RUNTIME_METRICS_ENABLED && (
-        <>
-          <CpuSection
-            points={cpu.data}
-            usedMilli={cpuUsedMilli}
-            allocatedMilli={cpuAllocatedMilli}
-            isLoading={cpu.isLoading || isWindowTransition}
-            isError={cpu.isError}
-            showDateInTooltip={showDateInTooltip}
-            xAxisDomain={xAxisDomain}
-          />
+      <CpuSection
+        points={cpu.data}
+        usedMilli={cpuUsedMilli}
+        allocatedMilli={cpuAllocatedMilli}
+        isLoading={cpu.isLoading || isWindowTransition}
+        isError={cpu.isError}
+        showDateInTooltip={showDateInTooltip}
+        xAxisDomain={xAxisDomain}
+      />
 
-          <MemorySection
-            points={memory.data}
-            usedBytes={memUsedBytes}
-            allocatedBytes={memAllocatedBytes}
-            isLoading={memory.isLoading || isWindowTransition}
-            isError={memory.isError}
-            showDateInTooltip={showDateInTooltip}
-            xAxisDomain={xAxisDomain}
-          />
+      <MemorySection
+        points={memory.data}
+        usedBytes={memUsedBytes}
+        allocatedBytes={memAllocatedBytes}
+        isLoading={memory.isLoading || isWindowTransition}
+        isError={memory.isError}
+        showDateInTooltip={showDateInTooltip}
+        xAxisDomain={xAxisDomain}
+      />
 
-          {diskEnabled && (
-            <DiskSection
-              points={disk.data}
-              usedBytes={diskUsedBytes}
-              allocatedBytes={diskAllocatedBytes}
-              isLoading={disk.isLoading || isWindowTransition}
-              isError={disk.isError}
-              showDateInTooltip={showDateInTooltip}
-              xAxisDomain={xAxisDomain}
-            />
-          )}
-
-          <NetworkSection
-            egressPoints={networkEgress.data}
-            ingressPoints={networkIngress.data}
-            isLoading={networkEgress.isLoading || networkIngress.isLoading || isWindowTransition}
-            isError={networkEgress.isError || networkIngress.isError}
-            showDateInTooltip={showDateInTooltip}
-            xAxisDomain={xAxisDomain}
-          />
-        </>
+      {diskEnabled && (
+        <DiskSection
+          points={disk.data}
+          usedBytes={diskUsedBytes}
+          allocatedBytes={diskAllocatedBytes}
+          isLoading={disk.isLoading || isWindowTransition}
+          isError={disk.isError}
+          showDateInTooltip={showDateInTooltip}
+          xAxisDomain={xAxisDomain}
+        />
       )}
+
+      <NetworkSection
+        egressPoints={networkEgress.data}
+        ingressPoints={networkIngress.data}
+        isLoading={networkEgress.isLoading || networkIngress.isLoading || isWindowTransition}
+        isError={networkEgress.isError || networkIngress.isError}
+        showDateInTooltip={showDateInTooltip}
+        xAxisDomain={xAxisDomain}
+      />
     </div>
   );
 }

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/network/unkey-flow/components/overlay/node-details-panel/components/resource-metrics.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/network/unkey-flow/components/overlay/node-details-panel/components/resource-metrics.tsx
@@ -33,11 +33,7 @@ import {
 // per open panel, well within budget.
 const REFETCH_INTERVAL_MS = 3_000;
 
-// Heimdall isn't shipped yet, so cpu/memory/disk/network charts would
-// render as empty timeseries. Hide them until the metering pipeline lands.
-// Queries still fire — the tables exist and return empty, so there's
-// nothing to gate at the network layer.
-const RUNTIME_METRICS_ENABLED = false;
+const RUNTIME_METRICS_ENABLED = true;
 
 const WINDOW_LABELS: Record<TimeWindow, string> = {
   "15m": "Past 15 minutes",
@@ -186,13 +182,6 @@ export function ResourceMetrics({ resourceId, storageMib, instanceName }: Resour
       setIsWindowTransition(false);
     }
   }, [isWindowTransition, anyFetching]);
-
-  // Instance-scoped panel hides the instances chart, so with the runtime
-  // metrics flag off there's nothing left to render — skip the empty
-  // "Runtime metrics" header + window selector entirely.
-  if (!RUNTIME_METRICS_ENABLED && isInstanceScoped) {
-    return null;
-  }
 
   return (
     <div>


### PR DESCRIPTION
## Summary

- Flips `RUNTIME_METRICS_ENABLED` from `false` to `true` in `resource-metrics.tsx`
- Removes the now-dead instance-scoped early-return guard and its stale comment

## Test plan

- [ ] Open a deployment's network view, click a node, verify CPU/memory/disk/network charts render in the details panel
- [ ] Verify instance-scoped panel (single replica) also shows the metrics section