### PR TITLE
fix(dashboard): stop leaking provider error strings from workos webhook

### DIFF
--- a/web/apps/dashboard/app/api/webhooks/workos/route.ts
+++ b/web/apps/dashboard/app/api/webhooks/workos/route.ts
@@ -53,7 +53,11 @@ export async function POST(req: NextRequest) {
 
     return NextResponse.json({}, { status: 200 });
   } catch (err) {
-    const message = err instanceof Error ? err.message : "Unknown error";
-    return NextResponse.json({ error: message }, { status: 400 });
+    // Log full error server-side. Return a generic body with a uniform status
+    // so unauthenticated callers cannot distinguish signature failures from
+    // downstream provider failures (Resend, WorkOS) and cannot harvest
+    // SDK error strings (URLs, audience IDs, rate-limit hints) for recon.
+    console.error("WorkOS webhook processing failed:", err);
+    return NextResponse.json({ error: "Webhook processing failed" }, { status: 400 });
   }
 }


### PR DESCRIPTION
## Summary

The `/api/webhooks/workos` route in `web/apps/dashboard/app/api/webhooks/workos/route.ts` returned `err.message` directly to unauthenticated callers in its catch block. That leaks SDK error strings from WorkOS and Resend (URLs, audience IDs, rate-limit hints) and lets callers distinguish signature-verification failures from downstream provider failures, both of which aid recon.

## Changes

- Log the full error server-side via `console.error`.
- Return a generic body `{ error: "Webhook processing failed" }` with a uniform 400.

## Test plan

- [ ] POST a request with an invalid signature — confirm response is `{ error: "Webhook processing failed" }` with status 400.
- [ ] POST a malformed body to trigger a downstream parse error — confirm same response shape, no SDK strings leaked.