### PR TITLE
fix(pprof): reject partial basic-auth credentials

### DIFF
--- a/bazel-agent-a1054efe1b26e78d8
+++ b/bazel-agent-a1054efe1b26e78d8
@@ -1,0 +1,1 @@
+/private/var/tmp/_bazel_chronark/1c9e04396dc19b74fe135ce001efaf8d/execroot/_main

--- a/pkg/pprof/handler.go
+++ b/pkg/pprof/handler.go
@@ -14,7 +14,17 @@ import (
 // New creates a standalone zen server for pprof endpoints, intended to be
 // served on an internal-only (loopback) listener. This mirrors the pattern
 // used by the prometheus package.
+//
+// Reject partial credential configuration. A previous version skipped
+// BasicAuth entirely when only one of Username/Password was set, which
+// turned a typo in ops config into an unauthenticated pprof endpoint
+// exposing heap, goroutine, and cmdline profiles.
 func New(cfg *config.PprofConfig, prefix string) (*zen.Server, error) {
+	if (cfg.Username == "") != (cfg.Password == "") {
+		return nil, fault.New("pprof requires both username and password or neither",
+			fault.Internal("pprof basic auth credentials are partially configured"))
+	}
+
 	srv, err := zen.New(zen.Config{
 		TLS:                nil,
 		Flags:              nil,
@@ -61,8 +71,10 @@ func (h *Handler) Path() string {
 
 // Handle processes the HTTP request and delegates to pprof handlers
 func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
-	// Only require authentication if username and password are configured
-	if h.Username != "" && h.Password != "" {
+	// Skip BasicAuth only when both credentials are empty (intentional dev mode).
+	// If either field is set, require auth so a partial config cannot bypass
+	// the credential check and expose heap/goroutine/cmdline profiles.
+	if h.Username != "" || h.Password != "" {
 		username, password, ok := s.Request().BasicAuth()
 		if !ok {
 			s.ResponseWriter().Header().Set("WWW-Authenticate", `Basic realm="pprof"`)


### PR DESCRIPTION
## Summary

`pkg/pprof/handler.go` previously bypassed BasicAuth when exactly one of `Username` / `Password` was configured, because the gate was `Username != "" && Password != ""`. A misconfiguration that set only one field silently exposed pprof.

## Changes

- `New(cfg, prefix)` returns a `fault.New` if exactly one of `cfg.Username` / `cfg.Password` is set.
- `Handle` switched the gate to `||`: any non-empty credential field still requires BasicAuth, defending direct `&Handler{...}` construction (e.g. `svc/api/routes/register.go`).

## Test plan

- [x] `bazel build //pkg/pprof:pprof`
- [x] `bazel build //svc/api/...`
- [ ] Run a service with only `PPROF_USERNAME` set and confirm pprof returns 401 instead of unauthenticated 200.