### PR TITLE
docs: logdrain architecture and customer-facing skeleton

### DIFF
--- a/docs/engineering/architecture/rfcs/0015-extension-marketplace.mdx
+++ b/docs/engineering/architecture/rfcs/0015-extension-marketplace.mdx
@@ -1,0 +1,172 @@
+---
+title: 0015 Extension Marketplace
+description: A single install/configure/lifecycle surface for third-party integrations, with each integration supplying its own backend hooks behind a uniform API.
+date: 2026-05-12
+authors:
+  - Flo
+---
+
+## Summary
+
+The Extension Marketplace is the install/configure/lifecycle surface for every third-party integration in Unkey: log drains, alert routers, billing webhooks, AI providers, etc. One control-plane table (`extension_installations`) holds the user-facing record; each integration registers a `LiveProvider` whose hooks own the integration-specific runtime work (open a `log_drains` row, register a Slack webhook, etc.).
+
+The first live extension is the Axiom log drain. Adding the next live extension is one provider entry plus one manifest entry — no schema migration, no new tRPC routes, no UI changes.
+
+## Motivation
+
+We were about to build a bespoke "Log Drains" CRUD page (its own list view, its own create wizard, its own routes, its own database table mutations from the UI). Then we noticed every future integration we cared about — alerting, error reporting, billing, OAuth-y "connect this provider" flows — wanted exactly the same shape: pick a destination, fill out a form, optionally OAuth, attach to a project, enable/disable, uninstall.
+
+Building the marketplace once is cheaper than building the same wizard N times. It is also strictly better for the customer: every integration lives in one place, every install flow looks the same, every "is this thing healthy" answer comes from one screen.
+
+The non-goal is generality for its own sake. The marketplace is a thin lifecycle plus a registry; it does not attempt to be a plugin runtime, a sandbox, or a DSL. Each provider is a TypeScript module that we ship and version with the dashboard.
+
+## Design
+
+### Two layers, one table
+
+```diagram
+╭────────────────────────────────╮         ╭────────────────────────────╮
+│  extension_installations       │         │  registry.ts (manifest)     │
+│   id, project_id, slug,        │ ◀─────▶ │   slug, configFields[],     │
+│   instance_name, config json,  │         │   verification[], links     │
+│   status, last_event_at,       │         ╰────────────────────────────╯
+│   oauth_connected, deleted_at  │
+╰──────────────┬─────────────────╯
+               │ slug → provider
+               ▼
+╭────────────────────────────────╮         ╭────────────────────────────╮
+│  providers.ts (registry map)   │ ──────▶ │  providers/log-drain.ts     │
+│   { axiom: logDrainProvider }  │         │   onInstall, onUpdate,      │
+╰────────────────────────────────╯         │   onUninstall, onSetEnabled,│
+                                           │   verify                    │
+                                           ╰─────────────┬───────────────╯
+                                                         │
+                                                         ▼
+                                              ╭──────────────────────╮
+                                              │  log_drains row      │
+                                              │   extension_         │
+                                              │   installation_id    │
+                                              ╰──────────────────────╯
+```
+
+The control-plane row (`extension_installations`) holds everything generic: which extension, in which project, with what configuration, in what status, owned by which workspace. The provider hook chain projects that into integration-specific runtime tables (`log_drains`, `webhook_subscriptions`, `ai_provider_credentials`, …) without the marketplace router ever importing those tables.
+
+### The provider seam
+
+`LiveProvider` is the entire integration contract:
+
+```ts
+type LiveProvider = {
+  onInstall(ctx, installation): Promise<void>;
+  onUninstall(ctx, installation): Promise<void>;
+  onUpdate?(ctx, installation, patch): Promise<void>;
+  onSetEnabled?(ctx, installation, enabled): Promise<void>;
+  verify?(ctx, config): Promise<VerifyResult>;
+};
+```
+
+Each `deploy.extension.*` procedure performs the generic DB op against `extension_installations`, then dispatches to `getProvider(slug)?.<hook>(...)`. There are no `if (slug === "axiom")` branches in the router. Adding a second live extension is:
+
+1. Drop a manifest entry into `registry.ts`.
+2. Drop a provider module under `lib/extensions/providers/<slug>.ts`.
+3. Register it in `PROVIDERS` in `providers.ts`.
+
+That is the entire delta. No new routers, no new schema migrations (unless the integration itself needs runtime tables), no new UI.
+
+### Live vs. preview mode
+
+The marketplace ships both real and stubbed extensions. Each manifest declares `mode: "live" | "preview"`:
+
+- **live** — install hits the real `deploy.extension` tRPC router, which writes to MySQL and calls the provider hook chain. Backed by actual infrastructure.
+- **preview** — install persists to localStorage. Lets us ship marketplace UI for partner integrations whose backend isn't built yet.
+
+An `extensionsLive` feature flag (default on) gates live mode. When the flag is off, every live extension degrades to preview locally — useful for demos, screenshots, and comparing the wired-up flow against a stub without backend writes. The `useEffectiveMode(extension)` hook collapses this into one mode value the UI consumes uniformly.
+
+This is intentionally heavier than a feature flag per extension. The dashboard ships a single switch; the manifest declares intent; everything else falls out of the two values.
+
+### Verification before persistence
+
+Every install wizard has a "Test connection" step. We resisted the temptation to add a per-integration `testPush` tRPC route (we had one for log drains and removed it). Instead, the provider exposes:
+
+```ts
+verify?(ctx, config): Promise<{ ok: true } | { ok: false; status?: number; error: string }>
+```
+
+`deploy.extension.verify({ slug, config })` dispatches to the provider, which runs whatever sanity check makes sense for that integration: a synthetic ingest call (Axiom), a webhook reachability ping (Slack), an API key probe (Datadog). Preview-mode extensions fall through with `{ ok: true }` so the wizard never blocks a stub install.
+
+The wire format the verify call uses **must** match the runtime path so a passing verify is genuine evidence. For Axiom, that means the synthetic event uses the same JSON shape the coordinator sends; if Axiom accepts the test event, it will accept the real one.
+
+### Lifecycle, end to end
+
+```diagram
+   user clicks Install                     user toggles "Enabled"
+          │                                       │
+          ▼                                       ▼
+  deploy.extension.install              deploy.extension.setEnabled
+          │                                       │
+          ├─▶ INSERT extension_installations     ├─▶ UPDATE status
+          │                                       │
+          ▼                                       ▼
+  provider.onInstall                    provider.onSetEnabled?
+   (e.g. INSERT log_drains)              (e.g. UPDATE log_drains.enabled)
+
+
+   user clicks Uninstall                  user edits Configuration
+          │                                       │
+          ▼                                       ▼
+  deploy.extension.uninstall            deploy.extension.update
+          │                                       │
+          ├─▶ soft-delete installation           ├─▶ UPDATE config json
+          │                                       │
+          ▼                                       ▼
+  provider.onUninstall                  provider.onUpdate?
+   (provider chooses cascade            (e.g. reproject filters,
+    semantics for its runtime table)     rotate credentials only if
+                                          a new secret was supplied)
+```
+
+Two design choices in there are load-bearing:
+
+**The router never cascades into runtime tables.** When a user uninstalls, the marketplace soft-deletes the installation row and stops. Whether to delete, soft-delete, or just disable the underlying `log_drains` row is the provider's choice, because the answer differs by integration. (Log drains soft-delete; a Slack webhook would un-subscribe but keep the OAuth grant; a billing integration might keep the row forever for audit.) Pushing this into the provider keeps the router single-purpose and prevents one integration's needs from becoming everyone's policy.
+
+**Enable/disable is a first-class action, not "uninstall + reinstall."** Customers want to pause an integration without re-pasting tokens, and we want to keep the install row around for telemetry (`last_event_at`, `status`). `setEnabled` flips `extension_installations.status` and lets the provider mirror that into its runtime table (`log_drains.enabled = false`). The coordinator filters on `enabled` in its tick query, so pause takes effect on the next poll.
+
+### Multiple instances per extension
+
+The unique key is `(project_id, extension_slug, instance_name)`. A workspace can install the Axiom extension twice — once routing production runtime logs to one dataset, once routing preview request logs to another — because the two installations carry distinct names and distinct configs. Soft-deleted rows keep the slot occupied; reusing an instance name requires a fresh name or a hard cleanup.
+
+This falls out of the table shape; it is not extra code. Most integrations will only ever have one instance per project, but the model does not assume that.
+
+## How log drains compose on top
+
+Log drains are the first live extension and the proof that the seam is right.
+
+The `log_drains` table gains a single column: `extension_installation_id varchar(128)`. The Axiom provider's `onInstall` hook inserts a `log_drains` row with that column populated, plus an encrypted `log_drain_credentials` row. From that point on:
+
+- The dashboard never touches `log_drains` directly. List, configure, enable/disable, and uninstall all flow through `deploy.extension.*` and dispatch to `logDrainProvider`.
+- The Go log-drain coordinator continues to read `log_drains` exactly as before. It is unaware of `extension_installations`. The `extension_installation_id` column is purely a back-reference for joins and audit.
+- Pre-marketplace drains (if any survived a migration) are valid: their `extension_installation_id` is `NULL`, the coordinator processes them identically, and they age out as installations replace them.
+
+The marketplace owns the customer-facing surface; the existing log-drain service owns the data plane. Neither needs to know much about the other.
+
+## Drawbacks
+
+**One JSON config column.** `extension_installations.config` is an opaque JSON blob whose shape is governed by the manifest's `configFields[]`. We get flexibility (no schema migration per integration) at the cost of typed columns and SQL-level filtering. Providers parse the blob defensively in their hooks. Acceptable because `configFields[]` and the install wizard's auto-rendered form are derived from the same registry — typos are caught at compile time, not at write time.
+
+**Provider modules ship with the dashboard.** This is not a runtime plugin system. Adding an integration means a PR to the dashboard repo. We considered remote manifests (load `registry.ts` entries from a CDN) and explicitly deferred — the moment we ship a community/partner-submitted extension, this becomes worth doing.
+
+**Provider hooks are the only seam.** A future integration that wants to inject custom marketplace UI (a non-form configure screen, a custom installed-detail tab) has nowhere to plug in today. We will cross that bridge when the first integration genuinely needs it; until then, the auto-rendered form covers every shape we have shipped.
+
+## Alternatives
+
+**Per-feature CRUD (the original plan).** Build "Log Drains" as a standalone page with its own router, its own create/update/delete tRPC procedures, its own table mutations. This is what we started with and threw away. The pattern would have been copy-pasted N times and we would have ended up with N marketplace clones, each subtly different, each maintained separately.
+
+**Generic webhook receiver.** "Just expose webhooks and let customers wire up Zapier." Works for some integrations, not for the ones that need credentials, batch delivery, replay, or per-row state. Log drains in particular cannot be a Zapier sink — the credential blast radius and replay story (see RFC 0016) require a real per-tenant forwarder.
+
+**Standalone marketplace app.** Build the integration list and submission flow in a separate web service that hands off to the dashboard via OAuth. Defensible long-term; massive overkill for the current scope. Static `registry.ts` lets us iterate on the manifest without a deploy of a separate service.
+
+## Unresolved questions
+
+- **Submission and verification of community extensions.** The manifest has a `verification[]` field and the registry has `type: "partner" | "community"`, but we do not yet have a workflow for accepting third-party submissions. P5 will define what evidence we require (verify checks pass, repo audited, vendor email reachable) before flipping `verified: true`.
+- **OAuth-source extensions.** The schema has `oauth_connected` and provider hooks can read it, but the OAuth grant flow itself is in a sibling stack (`oauth_grants`). The contract between the two is "the OAuth callback writes a grant row, the install wizard then carries the grant id into provider config." This works for log-drains (Datadog OAuth) but has not been exercised by any other integration yet.
+- **Extension telemetry.** `last_event_at` is enough for at-a-glance "is this thing alive." Deeper per-integration telemetry (axiom: `consecutive_failures`, `last_error`) currently lives on per-provider tables (`log_drain_state`). We may eventually want a generic provider telemetry seam — defer until a second integration needs it.

--- a/docs/engineering/architecture/rfcs/0015-log-drains.mdx
+++ b/docs/engineering/architecture/rfcs/0015-log-drains.mdx
@@ -1,0 +1,221 @@
+---
+title: 0015 Log Drains
+description: A per-tenant forwarder that ships runtime and request logs from ClickHouse to third-party observability backends.
+date: 2026-05-03
+authors:
+  - Flo
+---
+
+## Summary
+
+Log Drains let a workspace forward its runtime logs (pod stdout/stderr) and request logs (frontline access logs) to a third-party observability backend without operating a sidecar. v1 ships Axiom, Datadog, and OTLP/HTTP.
+
+This RFC argues for a dedicated batch forwarder that **tails ClickHouse on a polling cycle** rather than pushing from the producers, and walks through the design choices that fall out of that decision: how cursors work, why drains in the same scope share a single read, how failures are isolated, and which trade-offs we explicitly accepted.
+
+## Motivation
+
+The product requirement is a managed, hosted integration: pick a destination, point it at a workspace or project, opt into preview environments by exception, accept a few minutes of latency in exchange for a "set it and forget it" experience. Customers do not want another DaemonSet, another Vector config, or another piece of infrastructure to operate.
+
+We already have the data. Vector pipes deployment stdout/stderr into ClickHouse for runtime; the frontline middleware writes request logs to ClickHouse on every request. The missing piece is the per-tenant forwarder and the management surface around it.
+
+The design space has two natural shapes:
+
+1. **Push from the producer.** Vector or the frontline middleware writes directly to the customer destination, in addition to ClickHouse.
+2. **Pull from storage.** A dedicated service tails ClickHouse and fans out per drain.
+
+We picked (2). The reasons are below; they're the load-bearing rationale for everything else in this document.
+
+## Why pull from ClickHouse instead of pushing from the producer
+
+**Credential blast radius.** Pushing from Vector means every node in the data plane needs every customer's destination credentials. Vector's config is plaintext TOML; the only way to keep tokens out of it is to add a secret-fetch sidecar, at which point we've reinvented the forwarder service inside a different process. With a dedicated puller, plaintext credentials only ever exist in one process's memory.
+
+**Failure isolation.** A customer destination going down should not back-pressure into the request path. Pushing from frontline middleware couples the customer's outage to our request latency unless we add an internal queue, at which point we've also reinvented the forwarder.
+
+**Replay for free.** ClickHouse already retains 90 days of runtime logs and 30 days of request logs. If the forwarder falls over for an hour, every drain resumes from its last committed cursor and backfills. We do not have to operate Kafka or per-tenant queues to get this property; it falls out of "ClickHouse is the source of truth, the forwarder is stateless except for cursors."
+
+**Cost of repeated reads.** This is the real trade-off. Tailing ClickHouse on every poll is repeated work: we pay a query per scope per tick whether or not new rows arrived. The remaining design choices in this RFC exist to keep that cost low enough that the trade above is worth it.
+
+## Architecture
+
+```diagram
+                                       ╭───────────────────────────────╮
+  deploy stdout/stderr ─▶ Vector ────▶ │  ClickHouse                   │
+                       (existing)      │   runtime_logs_raw_v2         │
+                                       │   sentinel_requests_raw_v1    │
+  frontline middleware ────────────────▶                               │
+                                       ╰─────────────┬─────────────────╯
+                                                     │ tail by (time_ms, last_id)
+                                                     │ — one query per scope
+                                                     ▼
+                                       ╭───────────────────────────────╮
+                                       │  svc/logdrain                 │
+                                       │   • coordinator (poll)        │
+                                       │   • per-drain cursors (MySQL) │
+                                       │   • Vault-decrypted creds     │
+                                       │   • axiom / datadog / otlp    │
+                                       ╰─────────────┬─────────────────╯
+                                                     │ HTTPS batch
+                                                     ▼
+                                          customer destination
+```
+
+ClickHouse is the source of truth. The forwarder is stateless except for cursors persisted in MySQL. If the forwarder dies, it resumes from each drain's last committed cursor. If a destination is down, rows stay in ClickHouse and we backfill on recovery.
+
+## How cursors work
+
+Every drain has an independent cursor: a `(time_ms, last_id)` tuple stored in MySQL. The forwarder reads forward from the cursor, advances it after a successful send, and never deletes ClickHouse data — retention is the storage layer's job.
+
+Two design choices are interesting enough to motivate.
+
+### One cursor per drain, not one per scope
+
+The naive design has one cursor per scope (a "scope" is `(workspace, project, environment, source)`) shared by every drain attached to that scope. It is simpler to write and avoids per-drain MySQL writes. We rejected it.
+
+The problem is head-of-line blocking: one slow or failing drain pins the scope's cursor at its position, and every sibling drain stops draining until the slow one catches up or is paused. In a workspace with five drains and one misconfigured token, four healthy drains stall waiting for the bad one. Auto-pause would eventually unstick the group, but only after the threshold is crossed — minutes of unnecessary lag for the healthy drains.
+
+Per-drain cursors let each drain advance independently. A failing drain pins only itself; siblings continue at the rate of the underlying ClickHouse stream. The cost is N MySQL writes per batch instead of one, which is cheap because the writes are keyed on `(drain_id, group_key)` and never contend.
+
+A `blocked` flag on the cursor row lets a paused drain be skipped immediately, without waiting for the in-process drain-list cache (5s TTL) to expire and notice the pause.
+
+### One ClickHouse query per scope, not per drain
+
+This is the symmetric choice on the read side. Drains in the same scope share **one** ClickHouse query per tick and fan out in memory. The query reads from the **MIN cursor across non-blocked drains in the scope**, so the result covers every drain's outstanding window; each drain then trims the batch to the suffix past its own cursor before sending.
+
+The alternative — one query per drain — would multiply ClickHouse load by the number of drains a workspace attaches, which is unbounded by design. A workspace with 100 drains attached to the same scope would generate 100 queries per tick instead of one. The shared-query design trades a small over-read (drains that are ahead of the MIN read more rows than they need and discard the prefix) for an unbounded reduction in query count.
+
+This is the single biggest performance choice in the system. Everything else assumes ClickHouse cost scales with **scopes**, not drains.
+
+### The cursor predicate is an OR-form, not a tuple compare
+
+The obvious way to write a cursor predicate is a tuple compare:
+
+```sql
+WHERE (inserted_at, log_id) > ({prev_t}, {prev_id})
+```
+
+It's correct, and ClickHouse will execute it. But it doesn't prune granules: ClickHouse's sort-key prefix optimisation kicks in for `column > value` on a sort-key prefix, not for tuple compares against a composite. Every cursor scan reads every granule whose `inserted_at` range overlaps the watermark, even granules that contain nothing past the cursor.
+
+The OR-form is equivalent and prunes:
+
+```sql
+WHERE inserted_at > {prev_t}
+   OR (inserted_at = {prev_t} AND log_id > {prev_id})
+```
+
+The first clause is a plain `inserted_at > T` — sort-key-prefix prunable, so ClickHouse skips every granule whose `max(inserted_at) ≤ T` without reading it. The second clause only fires inside the (typically single) granule that contains rows at exactly `inserted_at = T`, where `log_id` is the in-block tiebreaker.
+
+This shape was the reason for the `runtime_logs_raw_v2` sort-key reorder. v1 had `app_id` between the workspace triple and `inserted_at`, which forced an in-block re-sort on every cursor scan. v2 puts `inserted_at` immediately after the workspace/project/env triple so the scan is a contiguous suffix. This is documented separately in the schema migration notes; the RFC-level point is that the cursor predicate's shape and the table's sort key co-evolved.
+
+### The tiebreaker is a stored String, not a hash
+
+An earlier design used `cityHash64(deployment_id, time, message)` as the cursor tiebreaker because we did not yet have a per-row id. It worked but had two problems:
+
+1. **Collision risk.** A 64-bit hash on a high-volume tenant has a non-zero probability of cursor-equal rows colliding, which would silently drop one row at the boundary on every scan.
+2. **Optimizer cost.** `cityHash64(...)` is a computed expression, not a stored column. ClickHouse's optimizer cannot push the comparison into granule pruning; the hash is inlined per row. Every cursor scan paid the hash cost for every row it read, even rows it would discard.
+
+v2 uses stored String columns: `log_id` (a UUID-v7-shaped id Vector mints at ingest) for runtime, `request_id` (frontline mints per request) for sentinel. Both are strictly per-row unique with no collision risk. Both are stored, so the comparison is a stored-column compare — no expression inlining, no hash work.
+
+### Cursor advance is optimistic-locked
+
+The forwarder is meant to scale horizontally. Two coordinator processes touching the same drain on adjacent ticks must not corrupt the cursor. We use an optimistic UPDATE keyed on the previous cursor value:
+
+```sql
+UPDATE log_drain_cursors
+SET    time_ms = {new_t}, last_id = {new_id}
+WHERE  drain_id = {id} AND time_ms = {prev_t} AND last_id = {prev_id}
+```
+
+A 0-row result means another process advanced the cursor first; the loser adopts the winner's position in memory and continues. This avoids the SELECT-FOR-UPDATE round-trip, the deadlock cases, and the connection-hold time of explicit locking, at the cost of a metric (`cursor_update_deadlocks`) we expect to be near zero in steady state.
+
+## How fetches and sends overlap
+
+Per-tick latency for a single group decomposes into ClickHouse round-trip + per-drain HTTP round-trip. Both are network-bound and both run in the hundreds of milliseconds. Without overlap, each iteration of the per-group loop pays both serially, and a group with a real backlog idles half its wall-clock budget on round-trips it could have been doing in parallel.
+
+We pipeline: while the current batch fans out to N HTTP sinks, the next ClickHouse fetch is in flight in the background. The interesting choice is **what cursor to fetch from**.
+
+The next iteration's MIN cursor depends on whether every drain's send succeeded. In the steady state — every drain healthy — it equals the predicted post-fan-out cursor exactly. If a drain fails or is blocked, its cursor stays behind, and the actual next-tick MIN is lower than the prediction.
+
+We pre-fetch using the **predicted** post-fan-out cursor. In the steady state this is a free 2× throughput win. In the failure path, the pre-fetched batch misses the `(stuck_cursor, predicted]` window for the stuck drain — but the stuck drain isn't going to consume anything this tick anyway, and the **next** tick's initial (synchronous) fetch runs at the real post-failure MIN and recovers the gap. We trade a small per-tick correctness window in the failure path for a doubling of steady-state throughput.
+
+A budget guard (`maxBatchesPerTick = 10`) bounds how much work one group can monopolise before yielding. With `MaxBatchRecords = 5000`, the worst case for a single group is 50,000 records per tick before it yields and the next tick picks up the rest.
+
+## Sinks and the retry policy
+
+Each provider lives behind a `Sink` interface. The choice that matters is where the retry decision lives.
+
+It lives **in the sinks package**, not in the coordinator and not in a generic `pkg/retry`. The retry decision is a pure function of `(Sink, SendError)`:
+
+- Transport failures and HTTP 5xx, 408, 429 are retryable.
+- Everything else (auth, bad request, unknown 4xx) is fatal and returns immediately so a misconfigured drain fails loudly instead of looping until auto-pause.
+- `Retry-After`, when the provider supplies it, is honoured verbatim up to a 60s cap. The cap defends against `Retry-After: 86400` parking a worker for a day; per-drain cursors mean the long sleep on one drain only delays its own next batch.
+
+A generic retry helper does not fit because the backoff function needs to see the error to honour `Retry-After`. The schedule between attempts is `250ms → 500ms → 1s` with **full jitter** rather than equal jitter, on the strength of the AWS architecture-blog measurements showing full jitter has the lowest total latency when many clients retry against a shared bottleneck — which is exactly the shape of many concurrent senders hitting the same provider during a regional incident.
+
+The total per-attempt budget (≈1.75s + send latency × 3) stays under the 10s poll interval even when every retry burns the maximum, so a retry storm does not spill into the next tick.
+
+### Test push before save
+
+Every create/update mutation runs one synthetic record through the chosen sink before the database row is committed. The provider's verbatim error is shown in the wizard. This is a small piece of UX with an outsized correctness payoff: misconfigured tokens, wrong regions, and bad endpoints fail at setup time, not silently at runtime an hour later when the customer wonders why the dashboard says "delivered" but their backend is empty. We picked it over server-side validation because the providers' acceptance contracts (auth shape, dataset existence, region selection) are best validated by the provider itself.
+
+## Failure handling
+
+The interesting question is what counts as a "persistent" failure and what we do about it.
+
+**Auto-pause threshold is in code, not SQL.** After `PauseAfterFailures` consecutive failures the drain auto-pauses, the cursor is flagged `blocked`, and the drain stays put until the operator clears `paused_reason`. The threshold lives in `Config.PauseAfterFailures`, not in a SQL `IF` or trigger, because we want operators to change it without a migration. The trade-off is that the SQL is dumber: `RecordLogDrainFailure` is a plain `consecutive_failures += 1`, and the auto-pause decision is a follow-up read — two queries per failure instead of one. At v1's failure rates this is unmeasurable.
+
+**Mid-batch crash semantics.** Cursor advance happens after `Send` returns. If the process dies mid-batch, the next process to take over re-sends the in-flight batch. The duplicate window is bounded by one batch (≤ 5000 records). At-least-once is the contract; idempotency on the customer side is recommended via the per-record `LastID`.
+
+**On resume, no automatic replay.** Earlier drafts replayed the last 30s on un-pause. We dropped it: the pause boundary is exactly where the cursor was, and the in-flight batch when the drain failed is at most one batch's worth of duplicates. A "skip to now" button is an open question, but automatic replay is a footgun for customers paying per-event for ingest.
+
+**Source-agnostic cursor table.** The cursor table doesn't know whether `time_ms` is `inserted_at` (runtime) or `time` (sentinel). Each per-source SQL query knows which ClickHouse column to compare against. This kept the cursor table to a single shape for both sources at the cost of a small amount of per-source SQL duplication — the alternative (a discriminated cursor with two columns) made every cross-source query awkward for no real win.
+
+## Sharding
+
+`TotalShards = 64` is fixed at compile time. Workspace IDs hash via FNV-1a into one of 64 buckets. Each coordinator process owns a contiguous half-open range `[ShardStart, ShardEnd)` of bucket ids.
+
+The shard cardinality is **fixed**, not derived from how many processes happen to be running, deliberately. Scaling out only redraws the range boundaries; every workspace's hash bucket is permanent. A dynamic shard count would create a rollout race where a workspace briefly has no owner (or two) during a scale event. Fixed cardinality eliminates that race at the cost of a hard ceiling: the number of coordinator processes cannot exceed 64. Far above any plausible workload for this service.
+
+When a single process owns the full range, the shard arithmetic short-circuits to skip per-row hashing.
+
+## Configuration knobs
+
+Defaults documented here because the rationale matters more than the values.
+
+| Knob | Default | Rationale |
+| --- | --- | --- |
+| `PollInterval` | 10s | Caps end-to-end latency floor; below this CH read amplification gets uncomfortable on the v2 sort key. |
+| `BatchWindow` | 60s | Bootstrap look-back when a brand-new drain has no cursor. Short enough that a fresh drain doesn't replay an hour, long enough to absorb startup races. |
+| `MaxBatchRecords` | 5000 | Sized to fit Datadog's 5 MiB per-payload cap with comfortable headroom on typical record sizes. Also the unit of duplicate-window damage on a mid-batch crash. |
+| `PauseAfterFailures` | 50 | Conservative; gives a flapping provider time to recover. Recommended follow-up: lower to 10 once we have dashboard signal for the difference. |
+| `MaxGroupsPerShard` | 500 | Caps fan-out per tick so a tenant with thousands of scopes can't monopolise a shard. Over-capacity shards rotate through groups across ticks. |
+| `MaxDrainsPerWorkspace` | 100 | Enforced at create time. Prevents a single workspace from saturating in-process fan-out. |
+| `CredentialCacheTTL` | 1h | SWR window on decrypted creds; rotation invalidates explicitly so the long TTL is safe. |
+
+## Credentials
+
+Two paths: paste tokens (encrypted by `svc/vault`, workspace-scoped keyring, never re-displayed in the dashboard) and OAuth grants (a separate table that backs N drains via a foreign key). The Vault boundary is the **single decryption point**; plaintext never crosses any other process. Rotation is "edit the drain"; revealing the stored secret is not an option, by design — operators who lose a token mint a new one.
+
+The OAuth path's wire is built (table, callback, Datadog connector) but the coordinator returns a known sentinel error for OAuth-backed drains until the resolver lands. Drains using OAuth are silently skipped, not errored: we never want to send to a provider with a placeholder token while we're still building the refresh path.
+
+## Drawbacks
+
+- **We own the drivers.** Each new provider is a small but real maintenance commitment. Customers will ask for the long tail (Better Stack, Loki, S3 archive, generic webhook).
+- **Latency floor.** Vector ingest lag plus the 10s poll plus retry budget puts a hard floor of ~30–60s on end-to-end latency. Customers expecting `tail -f` semantics need the in-app log viewer instead.
+- **Repeated reads.** Tailing ClickHouse on every poll is work we pay even when nothing arrived. The v2 sort key makes the scan cheap, and per-scope grouping keeps the query count tiny, but the per-tenant cost is non-zero and worth tracking as workspaces grow.
+
+## Alternatives considered
+
+**Vector dynamic sinks.** Vector itself supports dynamic sink config. We could have written a control loop that reloads Vector's config when drains change. Rejected on credential blast radius (Vector's config is plaintext on every node), failure isolation (Vector's pipeline back-pressures into ingest), and operational cost (config reload on every drain edit propagated through the data plane). The forwarder service is the right boundary because it co-locates the credential boundary with the failure boundary.
+
+**Kafka in front of fan-out.** Buffer ClickHouse → Kafka → forwarder so the forwarder reads from a queue with explicit offsets. Rejected because ClickHouse already gives 30–90 days of replay and our SLO ("p95 < 2 min") doesn't justify the broker. We revisit if we either outgrow ClickHouse-as-tail-source or add streaming producers that actually need a buffer.
+
+**Push from the producer.** Frontline middleware writes to ClickHouse and the customer destination in parallel. Rejected on every dimension above: credential blast radius (every producer needs every customer's tokens), failure coupling (customer outages back-pressure into the request path), and configuration distribution (every producer needs every drain's config). It is the worst of all worlds for this shape of feature.
+
+**Per-group cursor with a "lagging drain" sidecar.** Keep the simpler shared cursor and run a separate process for drains that fall behind. Rejected as a complexity tax we'd have to pay forever to dodge a per-drain MySQL row.
+
+## Unresolved questions
+
+- **Per-drain outbound rate limit for OTLP/HTTP.** Axiom and Datadog signal back-pressure via 429 + Retry-After, which we honour. Customer-supplied OTLP collectors don't, and a backlogged drain can fire ten back-to-back batches at one collector URL inside a single tick. Is a fixed default (e.g. 10 req/s) plus a per-drain override the right shape, or should we size off the customer's collector capabilities? Leaning toward fixed default + override, off by default for Axiom/Datadog.
+- **Workspace-level body-forwarding kill switch** in addition to the per-drain `IncludeBodies` opt-in. Compliance teams may want a workspace-wide "no body" guarantee regardless of who creates drains.
+- **Backfill on resume.** An un-paused drain resumes from where it stopped — fine when the pause was minutes, awkward when it was days. Do we offer a "skip to now" affordance? Defaulting to skip is wrong (silent data loss); defaulting to replay is wrong (huge bills). The right answer is probably an explicit operator choice on un-pause.
+- **When does the streaming arm become worth building?** `delivery_mode = 'stream'` is in the schema with no implementation. The trigger is probably either a customer SLA below ~30s end-to-end or a workload that needs back-pressure semantics the batch arm can't provide. Neither is on the roadmap; we kept the column so the eventual schema change is zero.

--- a/docs/engineering/architecture/rfcs/0016-log-drains.mdx
+++ b/docs/engineering/architecture/rfcs/0016-log-drains.mdx
@@ -1,5 +1,5 @@
 ---
-title: 0015 Log Drains
+title: 0016 Log Drains
 description: A per-tenant forwarder that ships runtime and request logs from ClickHouse to third-party observability backends.
 date: 2026-05-03
 authors:

--- a/docs/engineering/architecture/services/logdrain/failure-modes.mdx
+++ b/docs/engineering/architecture/services/logdrain/failure-modes.mdx
@@ -1,0 +1,55 @@
+---
+title: "Failure modes"
+description: "What can go wrong with logdrain and how to diagnose it."
+---
+
+## Provider rejects the batch
+
+Most provider errors fall into a few categories: expired credentials, rate limits, invalid payload, and transient 5xx.
+
+The worker classifies errors into `auth | rate_limit | timeout | 5xx | 4xx | network` and increments `logdrain_provider_errors_total{provider, kind}`. After `consecutive_failures` reaches the configured threshold (default 50), the drain auto-pauses with `paused_reason` set on the state row. `LogDrainPausedSpike` may fire if many drains pause at once.
+
+The dashboard surfaces `last_error` verbatim. Customers can resume a paused drain after fixing the underlying problem (token rotation, regional endpoint correction, payload-size reduction).
+
+## Provider is slow but accepting
+
+Symptom: `logdrain_lag_seconds` climbs without errors. The `LogDrainLagHigh` alert fires at 120 seconds p95 sustained over 10 minutes.
+
+Diagnosis: check `logdrain_batch_duration_seconds{provider}` and `logdrain_bytes_total{provider}`. If a single provider is the culprit, notify the customer to check their provider's status page. If lag is broad, the service may need a sharding bump.
+
+## Cursor stuck
+
+Symptom: `logdrain_lag_seconds` for one drain climbs while every other drain in the same group keeps making progress.
+
+Causes:
+
+- The drain has auto-paused and its cursor row is flagged `blocked`. Healthy siblings in the same group keep advancing because the group's MIN cursor (computed across non-blocked drains) skips the paused one — there is no shared cursor to hold up. The paused drain itself stays put until the operator clears `paused_reason` from the dashboard, at which point its cursor resumes from where it stopped (replaying the last 30s, deduped via `Idempotency-Key` where the provider supports it).
+- The group's CH query is hitting an index limit and returning fewer rows than the throughput requires. Inspect `logdrain_clickhouse_query_duration_seconds` and consider widening `MaxBatchRecords`.
+
+Symptom: `logdrain_lag_seconds` climbs across **every** drain in a group simultaneously. That's a CH-side problem, not a paused-drain problem — the group's MIN cursor only moves when at least one non-blocked drain advances. Check ClickHouse health, Vector ingestion lag, and the CH query duration histogram before assuming a per-drain failure.
+
+## Vault unreachable
+
+Symptom: `logdrain_credential_decrypts_total{result="error"}` is non-zero. `LogDrainVaultUnhealthy` pages immediately.
+
+Logdrain caches decrypted credentials in memory after first use, so a brief vault outage doesn't stop in-flight delivery. New drain creation and credential rotation block until vault is back. The cache is purged on pod restart and on credential change.
+
+## OAuth grant revoked at the provider
+
+Symptom: every drain backed by the same `oauth_grants.id` flips to `paused_reason = "oauth grant revoked"` within minutes.
+
+Detection: `logdrain_oauth_grant_revoked_total` increments on the first 401 from the provider. The grant row is marked `revoked_at`, and every drain referencing it auto-pauses.
+
+Recovery: the customer reconnects the provider in the dashboard. The new grant gets a fresh `id`, and customers either rebind the affected drains to the new grant, or the dashboard offers a one-click rebind for grants of the same provider and region.
+
+## Replica restart mid-batch
+
+Logdrain advances each drain's own cursor under an optimistic-lock `UPDATE` once that drain's `sink.Send` has succeeded. A restart in the middle of a fan-out causes the next pod to replay the window for every drain whose cursor wasn't advanced before the kill — drains whose advance had already committed simply pick up from their new position. Providers see at most ~30 seconds of duplicates per affected drain, deduped via `Idempotency-Key` where supported, with at-least-once semantics where not.
+
+This is the same guarantee the `pkg/dockertest` integration test verifies: kill the pod mid-batch, expect duplicates within the documented window, and expect zero gaps.
+
+## Coordinator stalled
+
+Symptom: `LogDrainCoordinatorStalled` fires when `rate(logdrain_records_total[5m]) == 0` and `logdrain_active_groups > 0`.
+
+Causes are usually upstream: ClickHouse cluster unavailable, MySQL primary failover in progress, or a deadlock on the cursor table. Check the corresponding health metrics and the runbook in the infra repo.

--- a/docs/engineering/architecture/services/logdrain/overview.mdx
+++ b/docs/engineering/architecture/services/logdrain/overview.mdx
@@ -1,0 +1,96 @@
+---
+title: "Overview"
+description: "Per-tenant log forwarding from ClickHouse to third-party providers like Axiom, Datadog, and OTLP collectors."
+mode: "wide"
+---
+
+Logdrain forwards customer logs out of ClickHouse to third-party observability providers. Customers configure a drain in the dashboard (project Settings, Log Drains tab) and pick a provider, source, and environment filter. Logdrain reads from ClickHouse, transforms each record, and pushes it to the provider with retry and backoff.
+
+The service is a long-running Go binary that follows the same shape as `heimdall` and `ctrl/worker`. It's decoupled from the data-ingest path: drain CRUD only writes to MySQL, never to Krane, Vector, or ClickHouse.
+
+## Architecture position
+
+```
+pods --> Vector DaemonSet --> runtime_logs_raw_v2 -----+
+                                                       |
+sentinel ---------------------> sentinel_requests_v1 --+--> logdrain --> Axiom / OTLP / Datadog
+                                                       |
+                                                       MySQL: log_drains, _credentials, _state, _cursors
+```
+
+Two ClickHouse tables drive the service:
+
+- `runtime_logs_raw_v2` holds stdout and stderr from Krane-managed deployment pods, written by the Vector DaemonSet. v2 supersedes v1: the sort key was reordered to `(workspace_id, project_id, environment_id, inserted_at, time)` so the logdrain cursor scan reads a contiguous suffix instead of forcing a per-batch in-block re-sort. See `pkg/clickhouse/migrations/20260502160000.sql` for the rationale.
+- `sentinel_requests_raw_v1` holds HTTP request logs (method, path, status, latency, headers, and optionally bodies).
+
+Both tables already carry `workspace_id`, `project_id`, `environment_id`, `app_id`, and `deployment_id` columns, so logdrain can scope reads to a single tenant without any joins.
+
+## Responsibilities
+
+- Read pending log records from ClickHouse on a polling cycle, scoped per drain.
+- Apply per-drain filters (severity, status code, path excludes, body redaction) in-process.
+- Transform records into the provider's expected shape (NDJSON, OTLP/HTTP, Datadog `_input`).
+- Push batches to the provider with retry, exponential backoff, and auto-pause on repeated failure.
+- Persist a per-group cursor in MySQL so restarts don't lose progress.
+- Expose Prometheus metrics for throughput, lag, and provider error rates.
+- Honor OAuth credential revocation by auto-pausing affected drains.
+
+## Why ClickHouse-tail and not Vector dynamic sinks
+
+The team considered two paths for the v1 forwarder:
+
+1. Vector dynamic sinks: extend the existing DaemonSet with per-drain sinks rendered from MySQL.
+2. ClickHouse-tail (chosen): a separate service polls ClickHouse, fans out to providers in-process, and persists progress in MySQL. Lag is intentionally 30 to 60 seconds. Drain CRUD is dashboard-local and never touches the data plane.
+
+The customer requirement explicitly accepts a few minutes of lag in exchange for "platform-level smoothness", so paying for sub-second delivery isn't worth it. The deciding factors against Vector dynamic sinks are credential isolation and operational coupling, in that order:
+
+- Credential blast radius. Vector config is plaintext TOML. Native sinks (Axiom, Datadog, HTTP bearer) need the token in the config or in a referenced env var or file. Today, Vector holds one platform-owned ClickHouse credential. Per-tenant drains would force every DaemonSet node, in every region, to hold every customer's third-party token. A single Vector pod compromise then leaks every drain credential across the fleet.
+- Vault is the decryption boundary. Tokens live in `svc/vault` and are decrypted on demand. Pushing decrypted secrets to every node breaks that boundary. Vector's `secret` providers don't speak Unkey's Vault gRPC, so a per-node sidecar would have to refresh and rewrite the config on a timer. At that point, the result is a reinvention of this service, just running per-node.
+- OAuth refresh. Datadog grants need token refresh. Vector doesn't refresh tokens. The same per-node sidecar problem applies.
+- Failure isolation. A drain config that fails to parse breaks Vector fleet-wide. With a separate service, a bad drain only breaks itself.
+- Operational coupling. Drain CRUD becomes infrastructure config: every change pushes a Vector reload across every cluster, and per-drain pause and backoff become things to coordinate across DaemonSet pods.
+
+The 90-day ClickHouse retention also gives free replay-on-recovery within the TTL window. The trade is intentional: a tens-of-seconds lag floor in exchange for a single decryption surface, application-level pause and retry, and zero data-plane churn on drain edits.
+
+## Topology
+
+Logdrain runs as a single Helm release in the `production001` cluster (us-east-1). ClickHouse Cloud is a single cluster in us-east-1, and every regional Vector DaemonSet writes into it, so a regional logdrain layout adds no benefit. A single deployment co-located with ClickHouse minimizes read latency and avoids any need to coordinate cross-region cursors.
+
+For staging, the same chart deploys to the staging cluster and points at the staging ClickHouse.
+
+## Read amplification: one query per group, not per drain
+
+A naive design polls ClickHouse once per drain. Logdrain instead groups drains by their `(workspace_id, project_id, environment_id, source)` key. One ClickHouse query per group fetches the next window of records. All drains attached to the same group consume from the in-memory batch and apply their own filters before pushing.
+
+So 100 drains attached to the same project's production runtime logs result in **one** ClickHouse query, not 100. Outbound provider throughput is the only per-drain cost.
+
+## Cursor and at-least-once delivery
+
+The cursor is a `(time_ms, last_id)` pair. `time_ms` is `inserted_at` for runtime logs and `time` for sentinel requests; `last_id` is the source's stable per-row id (`log_id` for runtime — Vector mints a UUID-v7-shaped id at ingest — and `request_id` for sentinel). Both `last_id` columns are stored `String` columns in ClickHouse, so the cursor compares them directly without an inline hash on every row.
+
+The query predicate is the prune-friendly OR-form `time_ms > T OR (time_ms = T AND last_id > L)` with `ORDER BY time_ms, last_id LIMIT ?`. The first clause is a sort-key-prefix prune (ClickHouse skips every granule whose max watermark is at or below `T`); the second clause only fires inside the granule(s) that contain rows at exactly `time_ms = T`. Cursors are stored per-`(drain, group)` in `log_drain_cursors` with PK `(drain_id, group_key)` — every drain in a group advances independently under an optimistic-lock `UPDATE`. A drain that fails repeatedly auto-pauses and its cursor row is flagged `blocked`; the group's MIN cursor (computed across non-blocked drains) advances past it on the next tick instead of stalling the whole group on the slowest member.
+
+On restart, the service resumes from each drain's last committed cursor. The duplicate window is bounded by the in-flight batch size (`MaxBatchRecords`) — drains whose advance had already committed pick up cleanly from their new position. This is at-least-once delivery; where the provider supports an `Idempotency-Key` header, `last_id` is sent as the key.
+
+## Sharding (future)
+
+The v1 release ships with `replicas: 1` and a Kubernetes lease for leader election. The schema and code are designed for sharding by `cityHash64(workspace_id) % shard_count`. Each replica runs with a `LOGDRAIN_SHARD_INDEX` and only picks up groups whose hash matches its index. The `log_drain_cursors` `UNIQUE` constraint on `group_key`, combined with optimistic-locking on `UPDATE`, prevents double-write during shard rollouts.
+
+## Realtime path (future)
+
+The CH-tail design has a 30 to 60 second lag floor: a log line has to be flushed to ClickHouse, then picked up on the next poll, before logdrain can forward it. That's fine for analytics, paging, and audit, but it's the wrong shape for use cases that need sub-second delivery (live tail in the dashboard, real-time alerting on a customer's side).
+
+If sub-second delivery becomes a requirement, logdrain can grow a second, parallel forwarding path that bypasses ClickHouse:
+
+1. Each drain row gets a `delivery_mode` column. The default stays `batch` (today's CH-tail path). New drains can opt in to `stream`.
+2. Vector already collects logs at the pod level for the existing CH ingest pipeline. It can be configured to fan out: continue writing to ClickHouse for the batch path, and additionally forward each line over the network to a new `logdrain-aggregator` Deployment.
+3. The aggregator is the same Go binary as the coordinator, but in a streaming mode: it accepts pushes from Vector instead of polling ClickHouse, looks up which streaming drains apply to each record, and forwards immediately. Because the same binary runs on both paths, the `sinks/`, `transform/`, and `creds/` packages are shared. Adding a new provider works for both modes at once.
+4. Drains in `batch` mode keep going through the existing CH-tail coordinator, untouched. The two paths don't share cursors, so there's no coordination cost between them.
+
+The trade is duplicate fan-out at the Vector layer (one record goes to two places) in exchange for sub-second delivery for drains that ask for it. No new broker, no schema migration beyond the `delivery_mode` column, and no rewrite of provider integrations.
+
+## Related pages
+
+- [Schema](/architecture/services/logdrain/schema) for the four MySQL tables.
+- [Sinks](/architecture/services/logdrain/sinks) for per-provider transform and auth details.
+- [Failure modes](/architecture/services/logdrain/failure-modes) for what can go wrong and how to diagnose it.

--- a/docs/engineering/architecture/services/logdrain/schema.mdx
+++ b/docs/engineering/architecture/services/logdrain/schema.mdx
@@ -1,0 +1,27 @@
+---
+title: "Schema"
+description: "MySQL tables that back log drains: config, credentials, state, and cursors."
+---
+
+Logdrain splits its state across separate MySQL tables. The split is driven by lifetime, not by normalization for its own sake:
+
+- Config rarely changes after creation.
+- Credentials rotate independently, especially OAuth grants.
+- State churns on every batch (last delivery, error, failure count).
+- Cursors advance per-`(drain, group)` so one slow drain does not hold up its siblings.
+
+Mixing these into a single row would cause hot-row write contention, bloat the binlog, and force every dashboard read to fetch state it doesn't need.
+
+The canonical column definitions live in the `pkg/mysql/schema/` directory. Schemas change often, so this page describes intent and points at the files; treat the SQL as the source of truth.
+
+## Tables
+
+- [`pkg/mysql/schema/log_drains.sql`](https://github.com/unkeyed/unkey/blob/main/pkg/mysql/schema/log_drains.sql): the configuration row. One per drain, with provider, sources, environments, filters, and the `enabled` flag. `project_id` is nullable so a single drain can apply across an entire workspace.
+- [`pkg/mysql/schema/log_drain_credentials.sql`](https://github.com/unkeyed/unkey/blob/main/pkg/mysql/schema/log_drain_credentials.sql): credentials, split out from config so token rotation doesn't touch the config row. Paste-token drains carry `encrypted_credentials` (decrypted via `svc/vault`); OAuth-backed drains carry only `oauth_grant_id`.
+- [`pkg/mysql/schema/log_drain_state.sql`](https://github.com/unkeyed/unkey/blob/main/pkg/mysql/schema/log_drain_state.sql): hot-path state. Last delivery time, last error, consecutive failure count, paused reason. Updated on every batch, so it lives on its own to keep binlog churn off the config row.
+- [`pkg/mysql/schema/log_drain_cursors.sql`](https://github.com/unkeyed/unkey/blob/main/pkg/mysql/schema/log_drain_cursors.sql): the per-`(drain, group)` cursor. PK is `(drain_id, group_key)` because a drain belongs to N groups (one per `(workspace, project, environment, source)` tuple) and each source has its own `(time_ms, last_id)` timeline. `last_id` is the source's stable per-row id (`log_id` for runtime, `request_id` for sentinel) and acts as the tiebreaker inside a single `time_ms` bucket. Each row carries a `blocked` flag — a drain that auto-pauses flips this flag so the group's MIN cursor (computed across non-blocked drains) advances past it instead of stalling on the slowest member. The coordinator advances it with an optimistic `UPDATE` keyed on the previous cursor value, so two replicas racing during a shard rollout can't both win.
+- [`pkg/mysql/schema/oauth_grants.sql`](https://github.com/unkeyed/unkey/blob/main/pkg/mysql/schema/oauth_grants.sql): provider OAuth connections. A single grant can back multiple drains so a customer connects a provider once and reuses the connection across every project.
+
+## TypeScript types
+
+The dashboard imports typed schemas from [`web/internal/db/src/schema/`](https://github.com/unkeyed/unkey/tree/main/web/internal/db/src/schema), generated from the SQL files above. Update the SQL first, regenerate, and the dashboard picks up the change.

--- a/docs/engineering/architecture/services/logdrain/sinks.mdx
+++ b/docs/engineering/architecture/services/logdrain/sinks.mdx
@@ -1,0 +1,56 @@
+---
+title: "Sinks"
+description: "Per-provider transform, auth, and batching for Axiom, Datadog, and OTLP/HTTP."
+---
+
+Each provider implements the `Sink` interface in `svc/logdrain/internal/sinks`:
+
+```go
+type Sink interface {
+    Send(ctx context.Context, batch []Record) error
+    HealthCheck(ctx context.Context) error
+}
+```
+
+`Record` is the internal in-memory shape: an OTLP-compatible `LogRecord` plus per-tenant identifiers. Each sink converts it to the provider's wire format. Batching and retry are the sink's responsibility, but exponential backoff and auto-pause live in the worker so all sinks share the same operational behavior.
+
+## Axiom
+
+- Endpoint: `POST https://api.axiom.co/v1/datasets/{dataset}/ingest`. Override per-region in `config.endpoint`.
+- Auth: `Authorization: Bearer <token>`. The token comes from vault for `paste` drains.
+- Payload: a JSON array of objects, one per record.
+- Batch limits: 1 MiB per request. Flush on size or 30 seconds, whichever comes first.
+- Idempotency: not honored by Axiom. Duplicate handling relies on dataset-level dedup if configured.
+
+## Datadog
+
+- Endpoint: `POST https://http-intake.logs.datadoghq.com/v1/input/<api_key>`, plus regional endpoints (`datadoghq.eu`, `us3`, `us5`, `ap1`, `ap2`, government variants) chosen via the OAuth grant's `region` field.
+- Auth: `DD-API-KEY: <key>`. The scoped key is obtained via OAuth grant.
+- Payload: a JSON array, up to 1000 records, up to 5 MiB per request.
+- Compression: `Content-Encoding: gzip`.
+- Idempotency: not natively supported.
+
+## OTLP/HTTP
+
+- Endpoint: customer-provided, typically `https://.../v1/logs`.
+- Auth: customer-provided header (typically `Authorization: Bearer ...` or `X-API-Key`).
+- Payload: OTLP/JSON (proto3 JSON mapping), `Content-Type: application/json`.
+- Batch limits: 4 MiB. Flush on size or 30 seconds.
+- Trace context: when the source record carries trace IDs, they're emitted as standard OTLP fields so downstream collectors correlate logs with traces automatically.
+
+## Body redaction
+
+`sentinel_requests_raw_v1` carries `request_body` and `response_body`. The transform unconditionally strips both fields unless the drain config sets `filters.request.include_bodies = true`. The dashboard wizard surfaces this as an explicit warning checkbox and includes the redacted shape in the synthetic record used for the test push, so customers see the masked output before they opt in.
+
+## Test push on save
+
+Every `create` and `update` mutation runs a single synthetic record through the chosen sink before the row is committed. The provider's actual error message is surfaced verbatim in the UI, so a misconfigured token or wrong region fails loudly at setup instead of silently in the background.
+
+## Adding a new sink
+
+1. Implement `Sink` in `svc/logdrain/internal/sinks/<provider>.go`.
+2. Add `<provider>` to the `provider` enum in `pkg/mysql/schema/log_drains.sql` and regenerate with `make generate`.
+3. Wire the dashboard wizard to render the provider's config form (dataset name, endpoint, region, and so on).
+4. If the provider supports OAuth, add an `integrations/<provider>/callback/` route that mirrors `integrations/datadog/callback/`.
+
+The `transform/` package is provider-agnostic and doesn't need changes for new sinks unless the new provider requires a wire format that OTLP can't represent.

--- a/docs/engineering/docs.json
+++ b/docs/engineering/docs.json
@@ -122,6 +122,15 @@
                 ]
               },
               {
+                "group": "Logdrain",
+                "pages": [
+                  "architecture/services/logdrain/overview",
+                  "architecture/services/logdrain/schema",
+                  "architecture/services/logdrain/sinks",
+                  "architecture/services/logdrain/failure-modes"
+                ]
+              },
+              {
                 "group": "Sentinel",
                 "pages": [
                   "architecture/services/sentinel/overview",

--- a/docs/engineering/docs.json
+++ b/docs/engineering/docs.json
@@ -186,7 +186,9 @@
               "architecture/rfcs/0011-unkey-resource-names",
               "architecture/rfcs/0012-stricter-linter",
               "architecture/rfcs/0013-custom-domains",
-              "architecture/rfcs/0014-sentinel-middleware"
+              "architecture/rfcs/0014-sentinel-middleware",
+              "architecture/rfcs/0015-extension-marketplace",
+              "architecture/rfcs/0016-log-drains"
             ]
           }
         ]

--- a/docs/product/docs.json
+++ b/docs/product/docs.json
@@ -243,7 +243,8 @@
               "observability/overview",
               "observability/logs",
               "observability/requests",
-              "observability/metrics"
+              "observability/metrics",
+              "observability/log-drains"
             ]
           },
           {

--- a/docs/product/observability/log-drains.mdx
+++ b/docs/product/observability/log-drains.mdx
@@ -1,0 +1,52 @@
+---
+title: Log Drains
+description: "Forward runtime and request logs from your Unkey deployments to Axiom, Datadog, OTLP collectors, and other providers."
+---
+
+import DeployBeta from "/snippets/deploy-beta.mdx";
+
+<DeployBeta />
+
+Log Drains forward logs from your Unkey deployments to a third-party provider. Set up a drain once and every matching deployment streams its runtime output and HTTP requests to Axiom, Datadog, or any OTLP-compatible collector.
+
+This page is a placeholder. The full guide will land alongside the v1 release.
+
+## What you can configure
+
+A drain belongs to a project (or to your entire workspace) and has:
+
+- **Provider.** Axiom, Datadog, or OTLP/HTTP.
+- **Sources.** Runtime logs (stdout and stderr) and HTTP request logs. Both are on by default.
+- **Environments.** Production is on by default. Preview is off by default to avoid surprise spend on PR previews.
+- **Filters.** Minimum severity, status code matchers, path excludes, and an opt-in toggle to include request and response bodies.
+
+You can create as many drains per project as you want. Common shapes:
+
+- Production runtime + request logs to Datadog, plus production runtime to Axiom for long-term archive
+- A workspace-wide drain to a SOC/SIEM, plus per-project drains for engineering teams
+- Two drains to the same provider with different filters: errors-only to a paging dataset, everything-else to a long-retention dataset
+
+## Connecting a provider
+
+- **Datadog.** OAuth. Click "Connect Datadog" in the wizard, authorize the workspace, and the scoped API key is stored securely. One Datadog connection can back multiple drains across projects.
+- **Axiom.** Paste an ingest token and a dataset name. OAuth coming soon.
+- **OTLP/HTTP.** Paste your collector's endpoint URL and auth header.
+
+Tokens are encrypted at rest via Unkey Vault and never re-displayed after creation. To rotate a token, edit the drain.
+
+## Delivery semantics
+
+- **Lag.** Logs typically appear at the provider within 30 to 60 seconds of being emitted by your app.
+- **At-least-once.** During a service restart, you may see up to ~30 seconds of duplicates. Where the provider supports `Idempotency-Key`, Unkey sends a per-record key so the provider can dedup automatically.
+- **Backpressure.** If the provider is unreachable or rate-limiting, Unkey retries with exponential backoff. After repeated failures a drain auto-pauses and surfaces the provider's actual error in the dashboard.
+- **Privacy.** Request and response bodies are stripped by default. Enable `Include request and response bodies` only after confirming your provider's data-handling policy.
+
+## Retention
+
+Drains forward logs as they arrive. Unkey's built-in 90-day runtime log retention and 30-day request log retention are unaffected.
+
+## Coming soon
+
+- Generic HTTP webhook sink for non-OTLP custom endpoints
+- Trace drains (OTLP traces) once tracing lands in the platform
+- Replay UI for re-sending the last N hours after a misconfiguration


### PR DESCRIPTION
## What does this PR do?

Adds engineering documentation for the Extension Marketplace (RFC 0015) and Log Drains (RFC 0016), along with a full service documentation section for the logdrain service and a product-facing Log Drains page.

**RFC 0015 – Extension Marketplace** documents the design of a unified install/configure/lifecycle surface for third-party integrations. It covers the two-layer architecture (`extension_installations` table + `LiveProvider` hook chain), live vs. preview mode, the `verify` seam for pre-persistence connection testing, the full install/update/uninstall/enable lifecycle, and how multiple instances per extension are supported. The Axiom log drain is the first live extension and serves as the proof-of-concept for the provider seam.

**RFC 0016 – Log Drains** documents the decision to tail ClickHouse on a polling cycle rather than push from producers, and walks through the resulting design: per-drain independent cursors, one ClickHouse query per scope shared across all drains in that scope, the OR-form cursor predicate for sort-key-prefix pruning, optimistic-lock cursor advancement, pipelined fetch/send for steady-state throughput, per-sink retry policy with full jitter, and auto-pause on repeated failure.

**Logdrain service docs** add four pages under `architecture/services/logdrain/`:
- `overview.mdx` – architecture position, responsibilities, topology, read amplification strategy, cursor mechanics, and a sketch of the future streaming path.
- `schema.mdx` – the four MySQL tables (`log_drains`, `log_drain_credentials`, `log_drain_state`, `log_drain_cursors`) and their separation rationale.
- `sinks.mdx` – per-provider wire format, auth, batch limits, body redaction, test-push-on-save behavior, and instructions for adding a new sink.
- `failure-modes.mdx` – diagnosis and recovery for provider rejections, slow providers, stuck cursors, Vault outages, OAuth grant revocation, mid-batch crashes, and coordinator stalls.

**Product docs** add `observability/log-drains.mdx` as a customer-facing placeholder covering configurable options, provider connection flows, delivery semantics, retention behavior, and a "coming soon" section.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How should this be tested?

- Verify all new pages render correctly in the engineering docs under `architecture/services/logdrain/` and `architecture/rfcs/`.
- Verify the new product page renders under `observability/log-drains`.
- Confirm navigation entries in `docs/engineering/docs.json` and `docs/product/docs.json` resolve to the correct pages without broken links.

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [x] Updated the Unkey Docs if changes were necessary