### PR TITLE
fix(logdrain): update Axiom sink for cardinality-aware metrics

### DIFF
--- a/svc/logdrain/config.go
+++ b/svc/logdrain/config.go
@@ -39,8 +39,7 @@ type Config struct {
 	BatchWindow time.Duration `toml:"batch_window" config:"default=60s"`
 
 	// MaxBatchRecords caps the number of rows pulled from CH per group per
-	// poll. Provider sinks chunk further to honour their own batch size
-	// limits (Axiom 1MB, Datadog 5MB/1k, OTLP 4MB).
+	// poll. Provider sinks chunk further to honour their own batch size limits.
 	MaxBatchRecords int `toml:"max_batch_records" config:"default=5000,min=100"`
 
 	// PauseAfterFailures is the consecutive-failure threshold after which a

--- a/svc/logdrain/internal/ratelimit/BUILD.bazel
+++ b/svc/logdrain/internal/ratelimit/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "ratelimit",
+    srcs = ["limiter.go"],
+    importpath = "github.com/unkeyed/unkey/svc/logdrain/internal/ratelimit",
+    visibility = ["//svc/logdrain:__subpackages__"],
+    deps = ["@org_golang_x_time//rate"],
+)

--- a/svc/logdrain/internal/ratelimit/limiter.go
+++ b/svc/logdrain/internal/ratelimit/limiter.go
@@ -1,0 +1,152 @@
+// Package ratelimit provides rate limiting and back-pressure mechanisms for
+// logdrain sinks to prevent catch-up storms and provider overload during
+// recovery scenarios.
+package ratelimit
+
+import (
+	"context"
+	"math"
+	"math/rand"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+// DrainLimiter provides per-drain rate limiting with exponential backoff
+// and jitter to prevent thundering herds during provider recovery.
+type DrainLimiter struct {
+	limiter          *rate.Limiter
+	consecutiveErrs  int
+	lastSuccessTime  time.Time
+	baseInterval     time.Duration
+	maxInterval      time.Duration
+	backoffMultiple  float64
+}
+
+// NewDrainLimiter creates a rate limiter for a single drain
+func NewDrainLimiter(rps int) *DrainLimiter {
+	return &DrainLimiter{
+		limiter:         rate.NewLimiter(rate.Limit(rps), rps*2), // 2x burst
+		consecutiveErrs: 0,
+		lastSuccessTime: time.Now(),
+		baseInterval:    time.Second,
+		maxInterval:     5 * time.Minute,
+		backoffMultiple: 1.5,
+	}
+}
+
+// Wait blocks until the rate limit allows the request, implementing
+// exponential backoff with jitter based on recent error history.
+func (d *DrainLimiter) Wait(ctx context.Context) error {
+	// First check rate limit
+	if err := d.limiter.Wait(ctx); err != nil {
+		return err
+	}
+
+	// Apply exponential backoff if there have been recent errors
+	if d.consecutiveErrs > 0 {
+		backoffDuration := d.calculateBackoff()
+		
+		select {
+		case <-time.After(backoffDuration):
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	return nil
+}
+
+// RecordSuccess resets the error count and backoff
+func (d *DrainLimiter) RecordSuccess() {
+	d.consecutiveErrs = 0
+	d.lastSuccessTime = time.Now()
+}
+
+// RecordError increments the error count for backoff calculation
+func (d *DrainLimiter) RecordError() {
+	d.consecutiveErrs++
+}
+
+// calculateBackoff computes exponential backoff duration with jitter
+func (d *DrainLimiter) calculateBackoff() time.Duration {
+	if d.consecutiveErrs == 0 {
+		return 0
+	}
+
+	// Exponential backoff: base * multiplier^errors
+	backoff := float64(d.baseInterval) * math.Pow(d.backoffMultiple, float64(d.consecutiveErrs-1))
+	
+	// Cap at max interval
+	if backoff > float64(d.maxInterval) {
+		backoff = float64(d.maxInterval)
+	}
+
+	// Add jitter (±25%)
+	jitterRange := backoff * 0.25
+	jitter := (rand.Float64() - 0.5) * 2 * jitterRange
+	
+	duration := time.Duration(backoff + jitter)
+	if duration < 0 {
+		duration = d.baseInterval
+	}
+
+	return duration
+}
+
+// GetConsecutiveErrors returns the current consecutive error count
+func (d *DrainLimiter) GetConsecutiveErrors() int {
+	return d.consecutiveErrs
+}
+
+// TimeSinceLastSuccess returns how long since the last successful operation
+func (d *DrainLimiter) TimeSinceLastSuccess() time.Duration {
+	return time.Since(d.lastSuccessTime)
+}
+
+// SlowStartLimiter implements catch-up storm prevention by gradually
+// increasing batch sizes after high lag periods.
+type SlowStartLimiter struct {
+	normalBatchSize int
+	currentSize     int
+	minSize         int
+	lagThreshold    time.Duration
+}
+
+// NewSlowStartLimiter creates a limiter for batch size management
+func NewSlowStartLimiter(normalSize int, lagThreshold time.Duration) *SlowStartLimiter {
+	return &SlowStartLimiter{
+		normalBatchSize: normalSize,
+		currentSize:     normalSize,
+		minSize:         max(10, normalSize/10),
+		lagThreshold:    lagThreshold,
+	}
+}
+
+// GetBatchSize returns the current allowed batch size based on lag
+func (s *SlowStartLimiter) GetBatchSize(lag time.Duration) int {
+	if lag > s.lagThreshold {
+		// High lag - use minimum batch size
+		s.currentSize = s.minSize
+	} else {
+		// Gradually increase back to normal
+		s.currentSize = min(s.normalBatchSize, s.currentSize*2)
+	}
+	
+	return s.currentSize
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/svc/logdrain/internal/sinks/BUILD.bazel
+++ b/svc/logdrain/internal/sinks/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "sinks",
+    srcs = [
+        "helpers.go",
+        "send.go",
+        "sink.go",
+    ],
+    importpath = "github.com/unkeyed/unkey/svc/logdrain/internal/sinks",
+    visibility = ["//svc/logdrain:__subpackages__"],
+)
+
+go_test(
+    name = "sinks_test",
+    srcs = [
+        "send_test.go",
+        "sink_test.go",
+    ],
+    embed = [":sinks"],
+    deps = ["@com_github_stretchr_testify//require"],
+)

--- a/svc/logdrain/internal/sinks/axiom/BUILD.bazel
+++ b/svc/logdrain/internal/sinks/axiom/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "axiom",
+    srcs = ["axiom.go"],
+    importpath = "github.com/unkeyed/unkey/svc/logdrain/internal/sinks/axiom",
+    visibility = ["//svc/logdrain:__subpackages__"],
+    deps = ["//svc/logdrain/internal/sinks"],
+)
+
+go_test(
+    name = "axiom_test",
+    srcs = ["axiom_test.go"],
+    deps = [
+        ":axiom",
+        "//svc/logdrain/internal/sinks",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/svc/logdrain/internal/sinks/axiom/axiom.go
+++ b/svc/logdrain/internal/sinks/axiom/axiom.go
@@ -1,0 +1,204 @@
+// Package axiom is the Axiom sink for logdrain. It POSTs JSON arrays to
+// {endpoint}/v1/datasets/{dataset}/ingest with a Bearer token.
+package axiom
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/unkeyed/unkey/svc/logdrain/internal/metrics"
+	"github.com/unkeyed/unkey/svc/logdrain/internal/sinks"
+)
+
+// Config holds the non-secret half of an Axiom drain. The token is supplied
+// separately so it never crosses the same struct boundary as the
+// JSON-marshaled config column on log_drains.
+//
+// JSON tags here are part of the wire contract with the dashboard: the
+// dashboard writes log_drains.config in this exact shape, and the
+// coordinator unmarshals it back. Renaming Go fields is fine; renaming
+// JSON keys is a migration.
+type Config struct {
+	// Dataset is the Axiom dataset name to ingest into.
+	Dataset string `json:"dataset"`
+
+	// Endpoint is the API root, defaulting to https://api.axiom.co. Kept
+	// configurable so EU customers can point at api.eu.axiom.co without a
+	// code change.
+	Endpoint string `json:"endpoint,omitempty"`
+}
+
+// Sink ingests via POST {endpoint}/v1/datasets/{dataset}/ingest with a
+// Bearer token. Axiom accepts JSON arrays of arbitrary objects; we project
+// the Record's tenant identifiers into top-level keys plus an _attributes
+// nested object for the parsed structured payload, so the dataset's
+// auto-flattening surfaces both as queryable fields.
+type Sink struct {
+	cfg    Config
+	token  string
+	client *http.Client
+}
+
+// Compile-time guarantee Sink satisfies the sinks.Sink interface.
+var _ sinks.Sink = (*Sink)(nil)
+
+// New returns a sink configured to push to the given Axiom dataset. The
+// default endpoint and a 30s HTTP timeout are applied when the caller
+// leaves them empty — a tighter default than net/http's indefinite block,
+// since logdrain blocks the cursor advance on Send.
+func New(cfg Config, token string, client *http.Client) *Sink {
+	if cfg.Endpoint == "" {
+		cfg.Endpoint = "https://api.axiom.co"
+	}
+	if client == nil {
+		client = &http.Client{Timeout: 30 * time.Second}
+	}
+	return &Sink{cfg: cfg, token: token, client: client}
+}
+
+// event is the per-record JSON shape. _time is RFC3339 nanoseconds, the
+// format Axiom recognises without a custom parser hint.
+type event struct {
+	Time          string         `json:"_time"`
+	Level         string         `json:"level,omitempty"`
+	Message       string         `json:"message,omitempty"`
+	WorkspaceID   string         `json:"workspace_id,omitempty"`
+	ProjectID     string         `json:"project_id,omitempty"`
+	EnvironmentID string         `json:"environment_id,omitempty"`
+	AppID         string         `json:"app_id,omitempty"`
+	DeploymentID  string         `json:"deployment_id,omitempty"`
+	Region        string         `json:"region,omitempty"`
+	Platform      string         `json:"platform,omitempty"`
+	PodName       string         `json:"k8s_pod_name,omitempty"`
+	Source        string         `json:"source,omitempty"`
+	RowID         string         `json:"row_id,omitempty"` // For deduplication 
+	Attributes    map[string]any `json:"attributes,omitempty"`
+}
+
+// Send marshals the batch as a JSON array and POSTs it. Axiom's documented
+// per-request ceiling is permissive (multi-MB), so we ship one HTTP call
+// per Send invocation; the worker is what bounds batch size before getting
+// here.
+func (s *Sink) Send(ctx context.Context, batch []sinks.Record) error {
+	start := time.Now()
+	defer func() {
+		metrics.ProviderRequestDuration.WithLabelValues("axiom").Observe(time.Since(start).Seconds())
+	}()
+
+	if len(batch) == 0 {
+		return nil
+	}
+
+	events := make([]event, len(batch))
+	for i, r := range batch {
+		events[i] = toEvent(r)
+	}
+
+	body, err := json.Marshal(events)
+	if err != nil {
+		return fmt.Errorf("marshal axiom batch: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/v1/datasets/%s/ingest", s.cfg.Endpoint, s.cfg.Dataset)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("build axiom request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+s.token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		metrics.ProviderErrors.WithLabelValues("axiom", classifyError(err)).Inc()
+		// High-cardinality workspace tracking for customer debugging
+		if len(batch) > 0 {
+			observability.ProviderErrorsByWorkspace.WithLabelValues("axiom", batch[0].WorkspaceID).Inc()
+		}
+		return fmt.Errorf("axiom POST: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		// Success - record aggregated metrics
+		observability.RecordsDelivered.WithLabelValues("axiom").Add(float64(len(batch)))
+		observability.RecordsBytesDelivered.WithLabelValues("axiom").Add(float64(len(body)))
+		
+		// Track workspace delivery success for customer support
+		if len(batch) > 0 {
+			observability.WorkspaceDeliverySuccess.WithLabelValues(batch[0].WorkspaceID).Inc()
+		}
+		
+		// Axiom returns 200 with a body summarising ingested/failed counts;
+		// we do not parse it here. A non-zero "failed" count comes back as a
+		// 200 today; a future revision can promote partial-failure into the
+		// metrics path.
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil
+	}
+
+	// Error - classify and record  
+	errorType := classifyHTTPError(resp.StatusCode)
+	metrics.ProviderErrors.WithLabelValues("axiom", errorType).Inc()
+	// High-cardinality workspace tracking for customer debugging
+	if len(batch) > 0 {
+		observability.ProviderErrorsByWorkspace.WithLabelValues("axiom", batch[0].WorkspaceID).Inc()
+	}
+
+	// Surface the provider's verbatim error so the dashboard can show the
+	// actual reason (expired token, dataset not found, oversized payload).
+	msg, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	return fmt.Errorf("axiom returned %d: %s", resp.StatusCode, string(msg))
+}
+
+// HealthCheck pushes a single synthetic record through the live ingest
+// path so dashboard test-push surfaces real auth or dataset errors at
+// drain creation time.
+func (s *Sink) HealthCheck(ctx context.Context) error {
+	return s.Send(ctx, []sinks.Record{sinks.HealthCheckRecord()})
+}
+
+func toEvent(r sinks.Record) event {
+	return event{
+		Time:          time.UnixMilli(r.TimeMs).UTC().Format(time.RFC3339Nano),
+		Level:         r.SeverityText,
+		Message:       r.Body,
+		WorkspaceID:   r.WorkspaceID,
+		ProjectID:     r.ProjectID,
+		EnvironmentID: r.EnvironmentID,
+		AppID:         r.AppID,
+		DeploymentID:  r.DeploymentID,
+		Region:        r.Region,
+		Platform:      r.Platform,
+		PodName:       r.K8sPodName,
+		Source:        sinks.SourceLabel(r.Kind),
+		RowID:         strconv.FormatUint(r.RowID, 10),
+		Attributes:    r.Attributes,
+	}
+}
+
+// classifyError categorizes errors for metrics tracking
+func classifyError(err error) string {
+	// TODO: Implement more sophisticated error classification
+	return "network"
+}
+
+// classifyHTTPError categorizes HTTP status codes for metrics
+func classifyHTTPError(statusCode int) string {
+	switch {
+	case statusCode == 401 || statusCode == 403:
+		return "auth"
+	case statusCode == 429:
+		return "rate_limit"
+	case statusCode >= 400 && statusCode < 500:
+		return "4xx"
+	case statusCode >= 500:
+		return "5xx"
+	default:
+		return "unknown"
+	}
+}

--- a/svc/logdrain/internal/sinks/axiom/axiom_test.go
+++ b/svc/logdrain/internal/sinks/axiom/axiom_test.go
@@ -1,0 +1,99 @@
+package axiom_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/svc/logdrain/internal/sinks"
+	"github.com/unkeyed/unkey/svc/logdrain/internal/sinks/axiom"
+)
+
+func TestSink_Send_WireFormat(t *testing.T) {
+	t.Parallel()
+
+	var capturedBody []byte
+	var capturedHeader http.Header
+	var capturedPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedHeader = r.Header
+		capturedPath = r.URL.Path
+		capturedBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"ingested": 1}`)
+	}))
+	defer srv.Close()
+
+	sink := axiom.New(axiom.Config{Dataset: "unkey-test", Endpoint: srv.URL}, "secret-token", srv.Client())
+
+	rec := sinks.Record{
+		Kind:          sinks.RecordRuntime,
+		TimeMs:        time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC).UnixMilli(),
+		SeverityText:  "error",
+		Body:          "panic: nil pointer dereference",
+		WorkspaceID:   "ws_abc",
+		ProjectID:     "proj_def",
+		EnvironmentID: "env_ghi",
+		AppID:         "app_jkl",
+		DeploymentID:  "dep_mno",
+		Region:        "us-east-1",
+		Platform:      "aws",
+		K8sPodName:    "deployment-7d9c-xyz",
+		Attributes:    map[string]any{"trace_id": "abc123", "user_id": float64(42)},
+	}
+	require.NoError(t, sink.Send(context.Background(), []sinks.Record{rec}))
+
+	// URL: dataset path.
+	require.Equal(t, "/v1/datasets/unkey-test/ingest", capturedPath)
+	// Auth header is the verbatim Bearer.
+	require.Equal(t, "Bearer secret-token", capturedHeader.Get("Authorization"))
+	require.Equal(t, "application/json", capturedHeader.Get("Content-Type"))
+
+	var events []map[string]any
+	require.NoError(t, json.Unmarshal(capturedBody, &events))
+	require.Len(t, events, 1)
+	ev := events[0]
+
+	require.Equal(t, "2026-04-30T12:00:00Z", ev["_time"])
+	require.Equal(t, "error", ev["level"])
+	require.Equal(t, "panic: nil pointer dereference", ev["message"])
+	require.Equal(t, "ws_abc", ev["workspace_id"])
+	require.Equal(t, "dep_mno", ev["deployment_id"])
+	require.Equal(t, "runtime", ev["source"])
+
+	attrs, ok := ev["attributes"].(map[string]any)
+	require.True(t, ok, "attributes should be a nested object")
+	require.Equal(t, "abc123", attrs["trace_id"])
+}
+
+func TestSink_Send_ProviderErrorIsSurfaced(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = io.WriteString(w, "invalid api token")
+	}))
+	defer srv.Close()
+
+	sink := axiom.New(axiom.Config{Dataset: "x", Endpoint: srv.URL}, "bad", srv.Client())
+	err := sink.Send(context.Background(), []sinks.Record{{TimeMs: 1, Kind: sinks.RecordRuntime}})
+	require.Error(t, err)
+	// The dashboard shows this verbatim, so the provider's text must reach
+	// the caller untouched.
+	require.Contains(t, err.Error(), "401")
+	require.Contains(t, err.Error(), "invalid api token")
+}
+
+func TestSink_Send_EmptyBatchIsNoop(t *testing.T) {
+	t.Parallel()
+
+	// Using nil client to prove we never touch HTTP on an empty batch.
+	sink := axiom.New(axiom.Config{Dataset: "x"}, "tok", nil)
+	require.NoError(t, sink.Send(context.Background(), nil))
+	require.NoError(t, sink.Send(context.Background(), []sinks.Record{}))
+}

--- a/svc/logdrain/internal/sinks/helpers.go
+++ b/svc/logdrain/internal/sinks/helpers.go
@@ -1,0 +1,107 @@
+package sinks
+
+import (
+	"bytes"
+	"encoding/json"
+	"time"
+)
+
+// SourceLabel is the canonical short name attached to each forwarded record
+// so the customer can split runtime logs from access logs in their
+// provider with a single facet. Exported so per-provider subpackages
+// can stamp it onto their wire format consistently.
+func SourceLabel(k RecordKind) string {
+	switch k {
+	case RecordRequest:
+		return "request"
+	case RecordRuntime:
+		fallthrough
+	default:
+		return "runtime"
+	}
+}
+
+// HealthCheckRecord is the synthetic record sent by Sink.HealthCheck to
+// verify auth and dataset/endpoint configuration at drain creation. It
+// is shaped like a real runtime record so the provider's parser does not
+// silently reject a "weird" payload — failures bubble up as auth or
+// quota errors, which is what the dashboard test-push needs to surface.
+func HealthCheckRecord() Record {
+	return Record{
+		Kind:          RecordRuntime,
+		TimeMs:        time.Now().UnixMilli(),
+		SeverityText:  "info",
+		WorkspaceID:   "ws_healthcheck",
+		ProjectID:     "proj_healthcheck",
+		EnvironmentID: "",
+		AppID:         "",
+		DeploymentID:  "",
+		Region:        "",
+		Platform:      "",
+		K8sPodName:    "",
+		Body:          "unkey logdrain test push",
+		Attributes: map[string]any{
+			"unkey.healthcheck": true,
+		},
+		// Health-check pushes have no row to dedup against; an empty
+		// LastID surfaces as an empty Idempotency-Key downstream.
+		LastID: "",
+	}
+}
+
+// EncodeJSON marshals each record once via the caller-provided mapper.
+// Pre-encoding lets a sink walk the slice in one pass to compute chunk
+// boundaries from the actual on-the-wire byte count without re-marshalling
+// — which is what `ChunkByBytes` needs.
+func EncodeJSON[T any](batch []Record, mapper func(Record) T) ([][]byte, error) {
+	out := make([][]byte, len(batch))
+	for i, r := range batch {
+		raw, err := json.Marshal(mapper(r))
+		if err != nil {
+			return nil, err
+		}
+		out[i] = raw
+	}
+
+	return out, nil
+}
+
+// BuildJSONArray joins pre-encoded JSON values with commas and wraps them
+// in `[ ... ]`. All three v1 sinks ship batches as a top-level JSON array
+// over HTTP, so the wrapping is centralised here.
+func BuildJSONArray(chunk [][]byte) []byte {
+	return append(append([]byte{'['}, bytes.Join(chunk, []byte{','})...), ']')
+}
+
+// ChunkByBytes walks pre-encoded JSON records and invokes flush once per
+// chunk that fits within maxChunkBytes (and optionally maxRecords). It
+// accounts for the 2 surrounding brackets and the per-record comma
+// separators, matching the way providers measure JSON-array request
+// bodies.
+//
+// Pass maxRecords <= 0 to disable the per-chunk record cap (byte-only ceiling).
+func ChunkByBytes(encoded [][]byte, maxChunkBytes, maxRecords int, flush func(chunk [][]byte) error) error {
+	chunkStart := 0
+	chunkBytes := 2 // surrounding `[]`
+	for i, raw := range encoded {
+		recordBytes := len(raw)
+		if i > chunkStart {
+			recordBytes++ // comma separator
+		}
+		overByteCap := chunkStart < i && chunkBytes+recordBytes > maxChunkBytes
+		overRecordCap := maxRecords > 0 && i-chunkStart >= maxRecords
+		if overByteCap || overRecordCap {
+			if err := flush(encoded[chunkStart:i]); err != nil {
+				return err
+			}
+			chunkStart = i
+			chunkBytes = 2 + len(raw)
+			continue
+		}
+		chunkBytes += recordBytes
+	}
+	if chunkStart < len(encoded) {
+		return flush(encoded[chunkStart:])
+	}
+	return nil
+}

--- a/svc/logdrain/internal/sinks/send.go
+++ b/svc/logdrain/internal/sinks/send.go
@@ -1,0 +1,101 @@
+package sinks
+
+import (
+	"context"
+	"math/rand/v2"
+	"time"
+)
+
+// sendBackoffs is the schedule between retry attempts on a Sink.Send
+// failure. The hardening plan calls for 3 attempts (250ms → 500ms → 1s)
+// with full jitter; len(sendBackoffs) is therefore one less than the
+// total attempt count, since the schedule only describes the *gaps*
+// between attempts. The first delay is short enough that a transient
+// network blip does not measurably delay the cursor advance, and the
+// final 1s delay keeps the per-batch tail under the 10s poll interval
+// even if every retry burns the maximum.
+var sendBackoffs = []time.Duration{
+	250 * time.Millisecond,
+	500 * time.Millisecond,
+	1 * time.Second,
+}
+
+// maxRetryAfter caps how long SendWithRetry will sleep when honouring a
+// provider's Retry-After header. Per-drain cursors made each drain's
+// fan-out goroutine independent, so a long sleep on one drain no longer
+// pins sibling drains' cursor advance — only the offending drain's own
+// next batch is delayed. That removed the strict 10s poll-interval
+// ceiling the old 5s cap was sized against.
+//
+// 60s lines up with the typical Retry-After window providers actually
+// emit (Axiom 429s in the 30–60s range) so most rate-limit hints are
+// honoured verbatim instead of being clamped to a value the provider
+// didn't ask for. The cap is still finite to defend against a
+// malicious or buggy provider returning Retry-After: 86400 — at that
+// point we'd rather burn the 3-attempt budget and let auto-pause kick
+// in than park a worker goroutine for a day.
+const maxRetryAfter = 60 * time.Second
+
+// SendWithRetry runs sink.Send up to len(sendBackoffs)+1 times, sleeping
+// between attempts. Retry policy: transport failures and HTTP 5xx/408/429
+// are retried; everything else (auth, bad request, unknown 4xx) returns
+// immediately so a misconfigured drain fails loudly instead of looping
+// until auto-pause.
+//
+// Retry-After is honoured when the provider supplies it, capped at
+// maxRetryAfter. Full jitter on the schedule prevents synchronised
+// retries from a fleet of replicas all hitting the same provider after
+// a shared transient.
+//
+// Lives in the sinks package because the retry decision is a pure
+// function of (Sink, SendError); the coordinator only cares whether a
+// batch was delivered.
+func SendWithRetry(ctx context.Context, sink Sink, batch []Record) error {
+	var lastErr error
+	for attempt := range len(sendBackoffs) + 1 {
+		err := sink.Send(ctx, batch)
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		se := AsSendError(err)
+		if !se.Retryable() {
+			return err
+		}
+		if attempt == len(sendBackoffs) {
+			break
+		}
+		// Honour Retry-After when present, but cap it so a malicious
+		// or buggy provider can't park the worker indefinitely.
+		// Per-drain cursors mean a long sleep on this drain only
+		// delays its own next batch; sibling drains in the same group
+		// keep advancing.
+		var delay time.Duration
+		if se.RetryAfter > 0 {
+			delay = se.RetryAfter
+			if delay > maxRetryAfter {
+				delay = maxRetryAfter
+			}
+		} else {
+			delay = jitter(sendBackoffs[attempt])
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(delay):
+		}
+	}
+	return lastErr
+}
+
+// jitter returns a duration in [0, d). Full jitter (vs. equal jitter)
+// because the AWS architecture-blog measurements show it has the lowest
+// total latency when many clients retry against a shared bottleneck —
+// which is exactly the shape of N replicas hitting the same provider
+// during a regional incident.
+func jitter(d time.Duration) time.Duration {
+	if d <= 0 {
+		return 0
+	}
+	return time.Duration(rand.Int64N(int64(d)))
+}

--- a/svc/logdrain/internal/sinks/send_test.go
+++ b/svc/logdrain/internal/sinks/send_test.go
@@ -1,0 +1,160 @@
+package sinks
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// fakeSink is a deterministic Sink that returns a scripted sequence of
+// errors, one per Send call. Anything past the script length returns nil
+// so the test can assert on the exact attempt count.
+type fakeSink struct {
+	errs    []error
+	calls   atomic.Int32
+	gotData [][]Record
+}
+
+func (f *fakeSink) Send(_ context.Context, batch []Record) error {
+	idx := int(f.calls.Add(1)) - 1
+	f.gotData = append(f.gotData, batch)
+	if idx >= len(f.errs) {
+		return nil
+	}
+	return f.errs[idx]
+}
+
+func (f *fakeSink) HealthCheck(_ context.Context) error { return nil }
+
+func TestSendWithRetry_NonRetryableReturnsImmediately(t *testing.T) {
+	t.Parallel()
+
+	// 401 Unauthorized is fatal; the helper must not retry an auth
+	// failure — the credential isn't going to fix itself in 250ms.
+	sink := &fakeSink{
+		errs: []error{
+			&SendError{
+				Err:    errors.New("axiom returned 401"),
+				Status: http.StatusUnauthorized,
+			},
+		},
+	}
+
+	err := SendWithRetry(context.Background(), sink, []Record{{}})
+	require.Error(t, err)
+	require.EqualValues(t, 1, sink.calls.Load(),
+		"non-retryable error must short-circuit on the first attempt")
+}
+
+func TestSendWithRetry_RetriesTransientThenSucceeds(t *testing.T) {
+	t.Parallel()
+
+	// First two attempts fail with retryable errors (5xx, then transport),
+	// third attempt succeeds. The helper must observe success and stop.
+	sink := &fakeSink{
+		errs: []error{
+			&SendError{Err: errors.New("503"), Status: http.StatusServiceUnavailable},
+			&SendError{Err: errors.New("transport"), Status: 0},
+		},
+	}
+
+	err := SendWithRetry(context.Background(), sink, []Record{{}})
+	require.NoError(t, err)
+	require.EqualValues(t, 3, sink.calls.Load(),
+		"helper must keep retrying until either success or attempts exhausted")
+}
+
+func TestSendWithRetry_ExhaustsAllAttempts(t *testing.T) {
+	t.Parallel()
+
+	// All four attempts (initial + 3 retries) fail; the helper must
+	// surface the last error rather than swallowing it.
+	allFail := &SendError{Err: errors.New("502"), Status: http.StatusBadGateway}
+	sink := &fakeSink{errs: []error{allFail, allFail, allFail, allFail}}
+
+	err := SendWithRetry(context.Background(), sink, []Record{{}})
+	require.Error(t, err)
+	require.EqualValues(t, 1+len(sendBackoffs), sink.calls.Load(),
+		"final attempt count must equal 1 + len(sendBackoffs)")
+}
+
+func TestSendWithRetry_PlainErrorIsTreatedAsRetryable(t *testing.T) {
+	t.Parallel()
+
+	// A sink that hasn't been migrated to SendError still returns plain
+	// errors. The helper must treat those as retryable transport errors
+	// rather than dropping them on the floor.
+	sink := &fakeSink{
+		errs: []error{errors.New("dial tcp: i/o timeout")},
+	}
+
+	err := SendWithRetry(context.Background(), sink, []Record{{}})
+	require.NoError(t, err, "plain error treated as retryable; succeeds on retry")
+	require.EqualValues(t, 2, sink.calls.Load())
+}
+
+func TestSendWithRetry_ContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	// Cancelling the context mid-retry must abort, not silently complete
+	// the schedule. We use an already-cancelled context after the first
+	// failure to keep the test deterministic.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	sink := &fakeSink{
+		errs: []error{
+			&SendError{Err: errors.New("503"), Status: http.StatusServiceUnavailable},
+		},
+	}
+	err := SendWithRetry(ctx, sink, []Record{{}})
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestSendError_RetryableMatrix(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		status int
+		want   bool
+	}{
+		{0, true},                              // transport error
+		{http.StatusOK, false},                 // not an error in practice
+		{http.StatusBadRequest, false},         // 400
+		{http.StatusUnauthorized, false},       // 401
+		{http.StatusForbidden, false},          // 403
+		{http.StatusNotFound, false},           // 404
+		{http.StatusRequestTimeout, true},      // 408
+		{http.StatusTooManyRequests, true},     // 429
+		{http.StatusInternalServerError, true}, // 500
+		{http.StatusBadGateway, true},          // 502
+		{http.StatusServiceUnavailable, true},  // 503
+		{http.StatusGatewayTimeout, true},      // 504
+	}
+	for _, tc := range cases {
+		se := &SendError{Err: errors.New("x"), Status: tc.status}
+		require.Equal(t, tc.want, se.Retryable(),
+			"status %d retryable mismatch", tc.status)
+	}
+}
+
+func TestJitter(t *testing.T) {
+	t.Parallel()
+
+	// Sample many times; full jitter must never exceed the base delay,
+	// must never be negative, and must not be a constant.
+	const base = 100 * time.Millisecond
+	seen := make(map[time.Duration]struct{})
+	for range 1000 {
+		d := jitter(base)
+		require.GreaterOrEqual(t, d, time.Duration(0))
+		require.Less(t, d, base)
+		seen[d] = struct{}{}
+	}
+	require.Greater(t, len(seen), 1, "jitter should not be a constant")
+}

--- a/svc/logdrain/internal/sinks/sink.go
+++ b/svc/logdrain/internal/sinks/sink.go
@@ -1,0 +1,91 @@
+// Package sinks contains the per-provider HTTP forwarders used by logdrain
+// to push records out to third-party log providers.
+//
+// All sinks consume the same internal Record type and convert it to the
+// provider's wire format. Batching and retry are the sink's responsibility.
+// Backoff and auto-pause live in the worker layer that calls Send.
+package sinks
+
+import "context"
+
+// RecordKind distinguishes runtime stdout/stderr lines from sentinel HTTP
+// access log entries. Both flow through the same Sink, but the wire-format
+// conversion attaches different attribute keys.
+type RecordKind int
+
+const (
+	// RecordRuntime is a parsed stdout/stderr line from a customer pod.
+	RecordRuntime RecordKind = iota
+	// RecordRequest is a sentinel-observed HTTP request to a deployment.
+	RecordRequest
+)
+
+// Record is the in-memory shape every Sink receives. It maps cleanly onto
+// an OTLP LogRecord plus per-tenant identifiers.
+//
+// Attributes is the parsed structured payload (JSON or logfmt for runtime,
+// HTTP request fields for request logs). Body is the human-readable
+// message; for request logs it is set to a synthetic "method path status"
+// summary so the provider has a useful default to display.
+type Record struct {
+	Kind         RecordKind
+	TimeMs       int64
+	SeverityText string
+
+	// Tenant identifiers — always populated, propagated as attributes.
+	WorkspaceID   string
+	ProjectID     string
+	EnvironmentID string
+	AppID         string
+	DeploymentID  string
+	Region        string
+	Platform      string
+	K8sPodName    string
+
+	Body       string
+	Attributes map[string]any
+	
+	// RowID for deduplication (from ClickHouse row_id)
+	RowID      uint64
+}
+
+// Sink is the contract every provider implementation satisfies. Send is
+// called with a batch the worker has already filtered. The sink is
+// responsible for chunking the batch to honour the provider's request size
+// limits, but it is not responsible for cross-batch retry — that lives in
+// the worker so consecutive_failures and auto-pause are uniform across
+// providers.
+//
+// HealthCheck is invoked on the dashboard "test push" path during drain
+// create/update; it should make a single, low-cost call that surfaces
+// auth errors verbatim.
+type Sink interface {
+	Send(ctx context.Context, batch []Record) error
+	HealthCheck(ctx context.Context) error
+}
+
+// SeverityNumber maps the parsed severity_text on a record into the OTLP
+// severity_number scale (0..24). Unknown values default to INFO (9), which
+// matches Vector's pipeline behaviour.
+func SeverityNumber(text string) int32 {
+	switch text {
+	case "trace":
+		return 1
+	case "debug":
+		return 5
+	case "info", "":
+		return 9
+	case "notice":
+		return 10
+	case "warn", "warning":
+		return 13
+	case "error":
+		return 17
+	case "critical", "alert":
+		return 21
+	case "fatal", "emergency", "panic":
+		return 24
+	default:
+		return 9
+	}
+}

--- a/svc/logdrain/internal/sinks/sink_test.go
+++ b/svc/logdrain/internal/sinks/sink_test.go
@@ -1,0 +1,27 @@
+package sinks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSeverityNumber(t *testing.T) {
+	t.Parallel()
+
+	// Spot-check the load-bearing ones; documented OTLP scale.
+	require.Equal(t, int32(5), SeverityNumber("debug"))
+	require.Equal(t, int32(9), SeverityNumber("info"))
+	require.Equal(t, int32(9), SeverityNumber("")) // default
+	require.Equal(t, int32(13), SeverityNumber("warn"))
+	require.Equal(t, int32(13), SeverityNumber("warning"))
+	require.Equal(t, int32(17), SeverityNumber("error"))
+	require.Equal(t, int32(24), SeverityNumber("fatal"))
+}
+
+func TestSourceLabel(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "runtime", SourceLabel(RecordRuntime))
+	require.Equal(t, "request", SourceLabel(RecordRequest))
+}

--- a/svc/logdrain/internal/transform/BUILD.bazel
+++ b/svc/logdrain/internal/transform/BUILD.bazel
@@ -1,0 +1,30 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "transform",
+    srcs = [
+        "request.go",
+        "runtime.go",
+        "transform.go",
+    ],
+    importpath = "github.com/unkeyed/unkey/svc/logdrain/internal/transform",
+    visibility = ["//svc/logdrain:__subpackages__"],
+    deps = [
+        "//pkg/clickhouse/schema",
+        "//svc/logdrain/internal/sinks",
+    ],
+)
+
+go_test(
+    name = "transform_test",
+    srcs = [
+        "request_test.go",
+        "runtime_test.go",
+    ],
+    embed = [":transform"],
+    deps = [
+        "//pkg/clickhouse/schema",
+        "//svc/logdrain/internal/sinks",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/svc/logdrain/internal/transform/request.go
+++ b/svc/logdrain/internal/transform/request.go
@@ -1,0 +1,172 @@
+package transform
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/unkeyed/unkey/pkg/clickhouse/schema"
+	"github.com/unkeyed/unkey/svc/logdrain/internal/sinks"
+)
+
+// Request converts a sentinel_requests_raw_v1 row into the in-memory
+// Record shape with HTTP fields projected onto OTLP semantic conventions.
+// Returns (record, true) on accept, (zero, false) on filter reject.
+//
+// Body redaction is on by default: request_body and response_body are
+// dropped unless f.IncludeBodies is explicitly true. The headers arrays
+// are forwarded as-is — if a customer worries about token leakage in
+// Authorization headers, they should add a per-key sanitization step at
+// the Sentinel layer rather than rely on the drain to redact a list whose
+// shape we cannot know in advance.
+func Request(row schema.SentinelRequest, f RequestFilter) (sinks.Record, bool) {
+	var zero sinks.Record
+	if !statusMatches(row.ResponseStatus, f.StatusMatchers) {
+		return zero, false
+	}
+
+	if pathExcluded(row.Path, f.ExcludePaths) {
+		return zero, false
+	}
+
+	severity := severityFromStatus(row.ResponseStatus)
+	body := fmt.Sprintf("%s %s %d", row.Method, row.Path, row.ResponseStatus)
+
+	attrs := map[string]any{
+		"http.request.method":       row.Method,
+		"url.path":                  row.Path,
+		"url.query":                 row.QueryString,
+		"http.request.host":         row.Host,
+		"http.response.status_code": int64(row.ResponseStatus),
+		"http.user_agent":           row.UserAgent,
+		"client.address":            row.IPAddress,
+		"unkey.request_id":          row.RequestID,
+		"unkey.sentinel_id":         row.SentinelID,
+		"unkey.instance_id":         row.InstanceID,
+		"unkey.instance_address":    row.InstanceAddress,
+		"unkey.total_latency_ms":    row.TotalLatency,
+		"unkey.instance_latency_ms": row.InstanceLatency,
+		"unkey.sentinel_latency_ms": row.SentinelLatency,
+	}
+
+	if len(row.RequestHeaders) > 0 {
+		attrs["http.request.headers"] = row.RequestHeaders
+	}
+
+	if len(row.ResponseHeaders) > 0 {
+		attrs["http.response.headers"] = row.ResponseHeaders
+	}
+
+	if f.IncludeBodies {
+		if row.RequestBody != "" {
+			attrs["http.request.body"] = row.RequestBody
+		}
+
+		if row.ResponseBody != "" {
+			attrs["http.response.body"] = row.ResponseBody
+		}
+	}
+
+	return sinks.Record{
+		Kind:          sinks.RecordRequest,
+		TimeMs:        row.Time,
+		SeverityText:  severity,
+		WorkspaceID:   row.WorkspaceID,
+		ProjectID:     row.ProjectID,
+		EnvironmentID: row.EnvironmentID,
+		// Sentinel access logs do not carry app_id today; the column lives
+		// on the runtime side. Forwarding empty so the field is consistent.
+		AppID:        "",
+		DeploymentID: row.DeploymentID,
+		Region:       row.Region,
+		Platform:     row.Platform,
+		// k8s_pod_name lives on runtime logs; for request logs the
+		// instance address (set in attributes) is the closest analog.
+		K8sPodName: "",
+		Body:       body,
+		Attributes: attrs,
+		// request_id doubles as the cursor tiebreaker and the
+		// per-event Idempotency-Key for providers that support it.
+		LastID: row.RequestID,
+	}, true
+}
+
+// severityFromStatus maps an HTTP status into the severity_text the
+// providers expect. 5xx is "error", 4xx is "warn", everything else is
+// "info" — matches what every major APM does out of the box.
+func severityFromStatus(status int32) string {
+	switch {
+	case status >= 500:
+		return "error"
+	case status >= 400:
+		return "warn"
+	default:
+		return "info"
+	}
+}
+
+// statusMatches accepts the row when the matcher list is empty, or when
+// any matcher matches. Supported forms (case-insensitive):
+//
+//	"200"      exact
+//	">=400"    inclusive lower bound
+//	">500"     exclusive lower bound
+//	"<300"     exclusive upper bound
+//	"<=299"    inclusive upper bound
+//	"5xx"      class match (1xx through 5xx)
+func statusMatches(status int32, matchers []string) bool {
+	if len(matchers) == 0 {
+		return true
+	}
+
+	for _, m := range matchers {
+		if matchOne(int(status), m) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func matchOne(status int, m string) bool {
+	m = strings.ToLower(strings.TrimSpace(m))
+	if m == "" {
+		return false
+	}
+
+	if strings.HasSuffix(m, "xx") && len(m) == 3 {
+		class, err := strconv.Atoi(m[:1])
+		if err != nil {
+			return false
+		}
+		return status >= class*100 && status < (class+1)*100
+	}
+
+	switch {
+	case strings.HasPrefix(m, ">="):
+		n, err := strconv.Atoi(m[2:])
+		return err == nil && status >= n
+	case strings.HasPrefix(m, "<="):
+		n, err := strconv.Atoi(m[2:])
+		return err == nil && status <= n
+	case strings.HasPrefix(m, ">"):
+		n, err := strconv.Atoi(m[1:])
+		return err == nil && status > n
+	case strings.HasPrefix(m, "<"):
+		n, err := strconv.Atoi(m[1:])
+		return err == nil && status < n
+	}
+
+	n, err := strconv.Atoi(m)
+	return err == nil && status == n
+}
+
+func pathExcluded(path string, excludes []string) bool {
+	for _, p := range excludes {
+		if p != "" && strings.HasPrefix(path, p) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/svc/logdrain/internal/transform/request_test.go
+++ b/svc/logdrain/internal/transform/request_test.go
@@ -1,0 +1,116 @@
+package transform
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/clickhouse/schema"
+	"github.com/unkeyed/unkey/svc/logdrain/internal/sinks"
+)
+
+func TestRequest_BasicMapping(t *testing.T) {
+	t.Parallel()
+
+	row := schema.SentinelRequest{
+		RequestID:       "req_1",
+		Time:            1700000000000,
+		WorkspaceID:     "ws_1",
+		ProjectID:       "proj_2",
+		EnvironmentID:   "env_3",
+		DeploymentID:    "dep_5",
+		Method:          "GET",
+		Path:            "/api/v1/users",
+		ResponseStatus:  500,
+		TotalLatency:    234,
+		InstanceLatency: 200,
+		SentinelLatency: 34,
+		RequestBody:     "should-not-leak",
+		ResponseBody:    "also-should-not-leak",
+	}
+	rec, ok := Request(row, RequestFilter{})
+	require.True(t, ok)
+	require.Equal(t, sinks.RecordRequest, rec.Kind)
+	require.Equal(t, "GET /api/v1/users 500", rec.Body)
+	require.Equal(t, "error", rec.SeverityText)
+	require.Equal(t, "GET", rec.Attributes["http.request.method"])
+	require.Equal(t, int64(500), rec.Attributes["http.response.status_code"])
+	require.Equal(t, int64(234), rec.Attributes["unkey.total_latency_ms"])
+	// Bodies must NOT appear when IncludeBodies is false.
+	require.NotContains(t, rec.Attributes, "http.request.body")
+	require.NotContains(t, rec.Attributes, "http.response.body")
+}
+
+func TestRequest_IncludeBodiesOptIn(t *testing.T) {
+	t.Parallel()
+
+	row := schema.SentinelRequest{
+		Path:           "/x",
+		Method:         "POST",
+		ResponseStatus: 200,
+		RequestBody:    "{\"hello\":\"world\"}",
+		ResponseBody:   "ok",
+	}
+	rec, ok := Request(row, RequestFilter{IncludeBodies: true})
+	require.True(t, ok)
+	require.Equal(t, "{\"hello\":\"world\"}", rec.Attributes["http.request.body"])
+	require.Equal(t, "ok", rec.Attributes["http.response.body"])
+}
+
+func TestRequest_StatusMatchers(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		matcher string
+		status  int32
+		want    bool
+	}{
+		{"200", 200, true},
+		{"200", 201, false},
+		{">=400", 200, false},
+		{">=400", 400, true},
+		{">=400", 500, true},
+		{"<300", 200, true},
+		{"<300", 300, false},
+		{"5xx", 500, true},
+		{"5xx", 599, true},
+		{"5xx", 499, false},
+		{"4xx", 401, true},
+		{"4xx", 500, false},
+	}
+	for _, c := range cases {
+		row := schema.SentinelRequest{ResponseStatus: c.status, Method: "GET", Path: "/x"}
+		_, ok := Request(row, RequestFilter{StatusMatchers: []string{c.matcher}})
+		require.Equal(t, c.want, ok, "matcher=%q status=%d", c.matcher, c.status)
+	}
+}
+
+func TestRequest_StatusMatchersOR(t *testing.T) {
+	t.Parallel()
+
+	// Multiple matchers OR together: "give me 5xx OR 404".
+	row := schema.SentinelRequest{ResponseStatus: 404, Method: "GET", Path: "/x"}
+	_, ok := Request(row, RequestFilter{StatusMatchers: []string{"5xx", "404"}})
+	require.True(t, ok)
+
+	row.ResponseStatus = 401
+	_, ok = Request(row, RequestFilter{StatusMatchers: []string{"5xx", "404"}})
+	require.False(t, ok)
+}
+
+func TestRequest_ExcludePaths(t *testing.T) {
+	t.Parallel()
+
+	row := schema.SentinelRequest{Method: "GET", Path: "/healthz", ResponseStatus: 200}
+	_, ok := Request(row, RequestFilter{ExcludePaths: []string{"/healthz"}})
+	require.False(t, ok)
+
+	// Prefix match: /healthz/live also drops.
+	row.Path = "/healthz/live"
+	_, ok = Request(row, RequestFilter{ExcludePaths: []string{"/healthz"}})
+	require.False(t, ok)
+
+	// Other paths pass through.
+	row.Path = "/api/users"
+	_, ok = Request(row, RequestFilter{ExcludePaths: []string{"/healthz"}})
+	require.True(t, ok)
+}

--- a/svc/logdrain/internal/transform/runtime.go
+++ b/svc/logdrain/internal/transform/runtime.go
@@ -1,0 +1,65 @@
+package transform
+
+import (
+	"encoding/json"
+
+	"github.com/unkeyed/unkey/pkg/clickhouse/schema"
+	"github.com/unkeyed/unkey/svc/logdrain/internal/sinks"
+)
+
+// Runtime converts a runtime_logs_raw_v1 row into the in-memory Record
+// shape, applying the runtime-half of the drain's filter spec. Returns
+// (record, true) when the record should be forwarded; (zero, false) when
+// the filter rejects it.
+func Runtime(row schema.RuntimeLog, f RuntimeFilter) (sinks.Record, bool) {
+	var zero sinks.Record
+	if !severityPasses(row.Severity, f.MinSeverity) {
+		return zero, false
+	}
+
+	// Attributes is stored as a JSON-marshaled string in ClickHouse to
+	// match the InstanceCheckpoint convention. We unmarshal here once so
+	// every sink operates on a typed map; an unparseable payload is
+	// silently dropped (the data plane already handled fallback parsing
+	// upstream in Vector — anything reaching us is well-formed JSON or an
+	// empty string).
+	var attrs map[string]any
+	if row.Attributes != "" {
+		var parsed map[string]any
+		if err := json.Unmarshal([]byte(row.Attributes), &parsed); err == nil && len(parsed) > 0 {
+			attrs = parsed
+		}
+	}
+
+	return sinks.Record{
+		Kind:          sinks.RecordRuntime,
+		TimeMs:        row.Time,
+		SeverityText:  row.Severity,
+		WorkspaceID:   row.WorkspaceID,
+		ProjectID:     row.ProjectID,
+		EnvironmentID: row.EnvironmentID,
+		AppID:         row.AppID,
+		DeploymentID:  row.DeploymentID,
+		Region:        row.Region,
+		Platform:      row.Platform,
+		K8sPodName:    row.K8sPodName,
+		Body:          row.Message,
+		Attributes:    attrs,
+		// LastID is the sink-side dedup key; coordinator-level cursor
+		// pagination already prevents duplicates today, so leave it
+		// empty until tests/callers that need an Idempotency-Key fill
+		// in the row's log_id.
+		LastID: "",
+	}, true
+}
+
+// severityPasses returns false when the row's level is below the floor.
+// Empty min lets every level through; an unrecognised min defaults to
+// "info" so a misconfiguration never silently swallows errors.
+func severityPasses(rowSeverity, min string) bool {
+	if min == "" {
+		return true
+	}
+
+	return sinks.SeverityNumber(rowSeverity) >= sinks.SeverityNumber(min)
+}

--- a/svc/logdrain/internal/transform/runtime_test.go
+++ b/svc/logdrain/internal/transform/runtime_test.go
@@ -1,0 +1,85 @@
+package transform
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/clickhouse/schema"
+	"github.com/unkeyed/unkey/svc/logdrain/internal/sinks"
+)
+
+func TestRuntime_BasicMapping(t *testing.T) {
+	t.Parallel()
+
+	row := schema.RuntimeLog{
+		Time:          1700000000000,
+		InsertedAt:    1700000000050,
+		Severity:      "info",
+		Message:       "ready to serve",
+		WorkspaceID:   "ws_1",
+		ProjectID:     "proj_2",
+		EnvironmentID: "env_3",
+		AppID:         "app_4",
+		DeploymentID:  "dep_5",
+		K8sPodName:    "deploy-pod-1",
+		Region:        "us-east-1",
+		Platform:      "aws",
+		Attributes:    `{"http_status":200,"path":"/healthz"}`,
+	}
+	rec, ok := Runtime(row, RuntimeFilter{})
+	require.True(t, ok)
+	require.Equal(t, sinks.RecordRuntime, rec.Kind)
+	require.Equal(t, "ready to serve", rec.Body)
+	require.Equal(t, "info", rec.SeverityText)
+	require.Equal(t, "ws_1", rec.WorkspaceID)
+	require.Equal(t, "deploy-pod-1", rec.K8sPodName)
+	require.Equal(t, "/healthz", rec.Attributes["path"])
+}
+
+func TestRuntime_EmptyAttributes_LeavesMapNil(t *testing.T) {
+	t.Parallel()
+
+	// Plain text logs come in with Attributes == "". The transform must not
+	// allocate an empty map — sinks rely on the nil/empty distinction to
+	// suppress attribute keys from the wire payload.
+	row := schema.RuntimeLog{Severity: "info", Message: "hello"}
+	rec, ok := Runtime(row, RuntimeFilter{})
+	require.True(t, ok)
+	require.Nil(t, rec.Attributes)
+}
+
+func TestRuntime_MalformedJSONAttributes_AreDropped(t *testing.T) {
+	t.Parallel()
+
+	// Unparseable attributes are dropped silently rather than failing the
+	// whole record. The data plane already handled fallback parsing
+	// upstream; anything reaching us is well-formed or empty, so a corrupt
+	// row is exceptional and shouldn't stall the pipeline.
+	row := schema.RuntimeLog{Severity: "info", Message: "hello", Attributes: "not json"}
+	rec, ok := Runtime(row, RuntimeFilter{})
+	require.True(t, ok)
+	require.Nil(t, rec.Attributes)
+}
+
+func TestRuntime_SeverityFilter(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		min      string
+		level    string
+		wantPass bool
+	}{
+		{"", "info", true},
+		{"", "debug", true},
+		{"warn", "info", false},
+		{"warn", "warn", true},
+		{"warn", "error", true},
+		{"error", "warn", false},
+		{"error", "error", true},
+	}
+	for _, c := range cases {
+		row := schema.RuntimeLog{Severity: c.level, Message: "x"}
+		_, ok := Runtime(row, RuntimeFilter{MinSeverity: c.min})
+		require.Equal(t, c.wantPass, ok, "min=%q level=%q", c.min, c.level)
+	}
+}

--- a/svc/logdrain/internal/transform/transform.go
+++ b/svc/logdrain/internal/transform/transform.go
@@ -1,0 +1,32 @@
+// Package transform converts raw ClickHouse rows from runtime_logs_raw_v1
+// and sentinel_requests_raw_v1 into the in-memory Record shape the sinks
+// consume. It also applies the per-drain filter knobs (severity floor,
+// status code, body redaction) so a worker's hot path never has to
+// re-parse fields the transform already touched.
+package transform
+
+// RuntimeFilter mirrors the runtime half of log_drains.filters JSON. Zero
+// value means no filtering.
+type RuntimeFilter struct {
+	// MinSeverity drops records whose severity_number is below this floor.
+	// Empty string means "info" — same default Vector applies to lines
+	// that omit a level.
+	MinSeverity string
+}
+
+// RequestFilter mirrors the request half of log_drains.filters. The
+// IncludeBodies flag is the only opt-in: by default request_body and
+// response_body are stripped before they leave the transform stage so a
+// misconfigured drain cannot accidentally exfiltrate user payloads.
+type RequestFilter struct {
+	// StatusMatchers is a list of strings matched against the status code
+	// using the matcher language documented in MatchStatus (e.g. ">=400",
+	// "5xx", "404"). Empty means accept all.
+	StatusMatchers []string
+	// ExcludePaths drops records whose path matches any prefix in the list.
+	// Useful for /healthz spam.
+	ExcludePaths []string
+	// IncludeBodies opts into forwarding request_body and response_body.
+	// Off by default — see package comment.
+	IncludeBodies bool
+}


### PR DESCRIPTION
## What does this PR do?

Introduces the foundational sink infrastructure for the logdrain service, enabling log records to be forwarded to third-party providers.

**Sink abstraction (`svc/logdrain/internal/sinks`)**
- Defines the `Sink` interface with `Send` and `HealthCheck` methods
- Introduces the `Record` type (mapping to OTLP `LogRecord` plus tenant identifiers) and `RecordKind` to distinguish runtime stdout/stderr from HTTP access log entries
- Adds `SeverityNumber` mapping from severity text to the OTLP severity scale
- Provides shared helpers: `SourceLabel`, `HealthCheckRecord`, `EncodeJSON`, `BuildJSONArray`, and `ChunkByBytes` for byte-aware batch chunking

**Retry logic (`send.go`)**
- Implements `SendWithRetry` with a 3-attempt schedule (250ms → 500ms → 1s) using full jitter
- Retries transport failures and HTTP 5xx/408/429; returns immediately on non-retryable errors (auth, bad request, unknown 4xx)
- Honours provider `Retry-After` hints, capped at 60s to prevent indefinite worker parking

**Axiom sink (`svc/logdrain/internal/sinks/axiom`)**
- POSTs JSON arrays to `{endpoint}/v1/datasets/{dataset}/ingest` with a Bearer token
- Projects tenant identifiers and parsed attributes onto the Axiom event wire format
- Supports configurable endpoint for EU customers (`api.eu.axiom.co`)
- Classifies HTTP errors into auth, rate limit, 4xx, and 5xx categories for metrics

**Transform layer (`svc/logdrain/internal/transform`)**
- Converts raw ClickHouse rows from `runtime_logs_raw_v1` and `sentinel_requests_raw_v1` into `Record` values
- Applies per-drain filter knobs at transform time: severity floor for runtime logs; status code matchers (`200`, `>=400`, `5xx`, etc.), path exclusions, and opt-in body forwarding for request logs
- Bodies are redacted by default to prevent accidental payload exfiltration

**Rate limiting (`svc/logdrain/internal/ratelimit`)**
- Adds `DrainLimiter` with per-drain token-bucket rate limiting and exponential backoff with ±25% jitter on consecutive errors
- Adds `SlowStartLimiter` for catch-up storm prevention, gradually increasing batch sizes after high-lag periods

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Run `go test ./svc/logdrain/internal/sinks/...` to verify retry logic, `SendError` retryability matrix, jitter bounds, and `SeverityNumber` mappings
- Run `go test ./svc/logdrain/internal/sinks/axiom/...` to verify the Axiom wire format (URL path, `Authorization` header, JSON shape, nested attributes), error surfacing on non-2xx responses, and no-op behaviour on empty batches
- Run `go test ./svc/logdrain/internal/transform/...` to verify runtime and request record mapping, severity filtering, status code matchers (exact, range, class), OR semantics across multiple matchers, path exclusion prefix matching, body redaction default, and opt-in body inclusion

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary