### PR TITLE
feat(logdrain): cut Vector + reader + generator over to runtime_logs_raw_v2

### DIFF
--- a/benchmarks/logdrain/cmd/data-generator/main.go
+++ b/benchmarks/logdrain/cmd/data-generator/main.go
@@ -89,7 +89,7 @@ func main() {
 	//nolint:exhaustruct // Drop, OnFlushError use defaults; we want blocking sends and the package-level error logger.
 	runtimeBuf := clickhouse.NewBuffer[schema.RuntimeLog](
 		ch,
-		"default.runtime_logs_raw_v1",
+		"default.runtime_logs_raw_v2",
 		clickhouse.BufferConfig{
 			Name:          "perf-runtime-logs",
 			BatchSize:     *batchSize,

--- a/dev/k8s/manifests/vector-logs.yaml
+++ b/dev/k8s/manifests/vector-logs.yaml
@@ -207,6 +207,11 @@ data:
     .time, err = to_unix_timestamp(.timestamp, unit: "milliseconds")
     if err != null { .time = to_unix_timestamp(now(), unit: "milliseconds") }
 
+    # Stable per-row id. 8 random bytes → 16 hex chars; collision probability
+    # is negligible at log volume. Must be set inside extract_labels (before
+    # dedupe) so dedupe still operates on content fields, not the unique id.
+    .log_id = "log_" + encode_base16(random_bytes(8))
+
     # Clean up
     del(.kubernetes)
     del(.stream)
@@ -228,7 +233,7 @@ data:
     inputs = ["dedupe"]
     endpoint = "http://clickhouse:8123"
     database = "default"
-    table = "runtime_logs_raw_v1"
+    table = "runtime_logs_raw_v2"
     compression = "gzip"
     skip_unknown_fields = true
     healthcheck.enabled = true

--- a/web/apps/dashboard/lib/schemas/runtime-logs.schema.ts
+++ b/web/apps/dashboard/lib/schemas/runtime-logs.schema.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 export const dashboardRuntimeLog = z.object({
   time: z.int(),
+  log_id: z.string(),
   severity: z.string(),
   message: z.string(),
   deployment_id: z.string(),

--- a/web/apps/dashboard/lib/trpc/routers/deploy/runtime-logs/query.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/runtime-logs/query.ts
@@ -114,6 +114,7 @@ export const queryRuntimeLogs = workspaceProcedure
 
     const logs = chLogs.map((log) => ({
       time: log.time,
+      log_id: log.log_id,
       severity: log.severity,
       message: log.message,
       deployment_id: log.deployment_id,

--- a/web/internal/clickhouse/src/runtime-logs.ts
+++ b/web/internal/clickhouse/src/runtime-logs.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { Querier } from "./client/interface";
 
-const TABLE = "default.runtime_logs_raw_v1";
+const TABLE = "default.runtime_logs_raw_v2";
 
 // Hard cap on rows per request. Bounds response payload size and ClickHouse
 // scan cost regardless of what an upstream caller sends.
@@ -36,6 +36,7 @@ const runtimeLogsQueryParamsSchema = runtimeLogsRequestSchema.extend({
 
 export const runtimeLog = z.object({
   time: z.int(),
+  log_id: z.string(),
   severity: z.string(),
   message: z.string(),
   deployment_id: z.string(),
@@ -89,7 +90,7 @@ export function getRuntimeLogs(ch: Querier) {
     const logsQuery = ch.query({
       query: `
         SELECT
-          time, severity, message, deployment_id,
+          time, log_id, severity, message, deployment_id,
           region, k8s_pod_name, attributes
         FROM ${TABLE}
         WHERE ${filterConditions}


### PR DESCRIPTION
## What does this PR do?

Migrates runtime logs from `runtime_logs_raw_v1` to `runtime_logs_raw_v2` and introduces a stable per-row `log_id` field.

A unique `log_id` (prefixed `log_` followed by 8 random bytes encoded as 16 hex characters) is now generated in the Vector pipeline before the dedupe step, ensuring each log row has a stable identifier without affecting deduplication logic. The `log_id` field is propagated through the ClickHouse query, the internal ClickHouse client schema, and the dashboard tRPC router and Zod schema.

Fixes # (issue)

_If there is not an issue for this, please create one first. This is used to tracking purposes and also helps us understand why this PR exists_

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Verify that runtime logs are being written to and read from `runtime_logs_raw_v2`
- Confirm that each log row returned from the API includes a non-empty `log_id` field in the format `log_<16 hex chars>`
- Confirm that the dedupe step in Vector still correctly deduplicates on content fields and is not affected by the unique `log_id`
- Run the data generator benchmark and confirm logs land in `runtime_logs_raw_v2`

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary