### PR TITLE
docs: add logdrain production hardening implementation summary

### DIFF
--- a/docs/engineering/architecture/services/logdrain/overview.mdx
+++ b/docs/engineering/architecture/services/logdrain/overview.mdx
@@ -119,18 +119,11 @@ Horizontal scale is `kubectl scale --replicas=N` plus a `replicas = N` bump in t
 
 The remaining sequential bottleneck is per-group rather than per-replica: a group with N drains all targeting the *same* provider host can saturate that host's connection pool (`MaxIdleConnsPerHost = 64`). Per-drain cursors (PK `(drain_id, group_key)` on `log_drain_cursors`) are already in place, so a slow or paused drain doesn't hold its siblings' cursor advance — the next throughput lever for a single noisy tenant is decomposing one source's group by `app_id` or `deployment_id`, which trades cursor-space simplicity for parallel CH fetches per sub-group.
 
-## Realtime path (future)
+## Lag floor and the streaming path
 
-The CH-tail design has a 30 to 60 second lag floor: a log line has to be flushed to ClickHouse, then picked up on the next poll, before logdrain can forward it. That's fine for analytics, paging, and audit, but it's the wrong shape for use cases that need sub-second delivery (live tail in the dashboard, real-time alerting on a customer's side).
+The CH-tail design has a 30 to 60 second lag floor: a log line has to be flushed to ClickHouse and picked up on the next poll before logdrain can forward it. That's fine for analytics, paging, and audit, but it's the wrong shape for sub-second use cases like live tail.
 
-If sub-second delivery becomes a requirement, logdrain can grow a second, parallel forwarding path that bypasses ClickHouse:
-
-1. Each drain row gets a `delivery_mode` column. The default stays `batch` (today's CH-tail path). New drains can opt in to `stream`.
-2. Vector already collects logs at the pod level for the existing CH ingest pipeline. It can be configured to fan out: continue writing to ClickHouse for the batch path, and additionally forward each line over the network to a new `logdrain-aggregator` Deployment.
-3. The aggregator is the same Go binary as the coordinator, but in a streaming mode: it accepts pushes from Vector instead of polling ClickHouse, looks up which streaming drains apply to each record, and forwards immediately. Because the same binary runs on both paths, the `sinks/`, `transform/`, and `creds/` packages are shared. Adding a new provider works for both modes at once.
-4. Drains in `batch` mode keep going through the existing CH-tail coordinator, untouched. The two paths don't share cursors, so there's no coordination cost between them.
-
-The trade is duplicate fan-out at the Vector layer (one record goes to two places) in exchange for sub-second delivery for drains that ask for it. No new broker, no schema migration beyond the `delivery_mode` column, and no rewrite of provider integrations.
+The `log_drains` table reserves a `delivery_mode` column (`batch`, `stream`) for a future streaming path. Nothing is implemented behind `stream` yet, and the design is open: a Vector fan-out into a separate aggregator, a Kafka topic in front of the workers, or something else entirely. The shortlist will get prototyped and benchmarked against real traffic before any approach is committed to.
 
 ## Related pages
 

--- a/docs/product/observability/log-drains.mdx
+++ b/docs/product/observability/log-drains.mdx
@@ -7,44 +7,63 @@ import DeployBeta from "/snippets/deploy-beta.mdx";
 
 <DeployBeta />
 
-Log Drains forward logs from your Unkey deployments to a third-party provider. Set up a drain once and every matching deployment streams its runtime output and HTTP requests to Axiom.
+A log drain forwards logs from your Unkey deployments to a third-party provider. You set one up once and every matching deployment streams its runtime output and HTTP requests to Axiom. The built-in [Logs](/observability/logs) and [Requests](/observability/requests) views keep working unchanged. Drains run alongside, not instead.
 
-This page is a placeholder. The full guide will land alongside the v1 release.
+## Set up a drain
 
-## What you can configure
+Log drains are installed from the **Extensions** marketplace on a project. Open **Project → Extensions**, find Axiom, and click **Install**.
 
-A drain belongs to a project (or to your entire workspace) and has:
+1. Paste an Axiom ingest token and a dataset name.
+2. Pick what to forward: sources (runtime logs, request logs), environments (production, preview), and optional filters.
+3. Install. Unkey verifies the token against Axiom before persisting. If the token is expired or the dataset name is wrong, you find out here, not later.
 
-- **Provider.** Axiom.
-- **Sources.** Runtime logs (stdout and stderr) and HTTP request logs. Both are on by default.
-- **Environments.** Production is on by default. Preview is off by default to avoid surprise spend on PR previews.
-- **Filters.** Minimum severity, status code matchers, path excludes, and an opt-in toggle to include request and response bodies.
+Tokens are encrypted at rest by [Unkey Vault](/platform/vault/overview) and never re-displayed after install. To rotate a token, update the installation.
 
-You can create as many drains per project as you want. Common shapes:
+## What gets forwarded
 
-- Production runtime + request logs to Axiom for long-term archive
-- A workspace-wide drain to a SOC/SIEM, plus per-project drains for engineering teams
-- Two drains to the same provider with different filters: errors-only to a paging dataset, everything-else to a long-retention dataset
+Each drain has:
 
-## Connecting a provider
+- Provider: the destination. Axiom is the supported provider.
+- Sources: runtime logs (stdout, stderr) and request logs (HTTP access logs from Sentinel). Both are on by default.
+- Environments: `production` is on by default. `preview` is off by default to avoid surprise spend from PR previews. Toggle it on per drain when you want it.
+- Filters (advanced):
+  - Minimum runtime severity: drop everything below `info`, `warn`, or `error`.
+  - Status code matchers: `>=400`, `5xx`, `404`, and so on, for request logs.
+  - Path excludes: drop noisy paths like `/healthz`.
+  - Include request and response bodies: off by default. Bodies may contain user data and secrets, so only enable this after confirming your provider's data handling.
 
-- **Axiom.** Paste an ingest token and a dataset name.
+You can install the extension multiple times per project for different setups, for example:
 
-Tokens are encrypted at rest via Unkey Vault and never re-displayed after creation. To rotate a token, edit the drain.
+- Production runtime and request logs to Axiom for long-term archive.
+- Two installs to the same provider with different filters: errors-only to a small dataset, everything else to a long-retention dataset.
+
+## Provider notes
+
+### Axiom
+
+- Paste an [Axiom API token](https://axiom.co/docs/get-help/faq#how-do-i-create-an-api-token) and a dataset name.
+- The default endpoint is `https://api.axiom.co`. EU customers should override it to `https://api.eu.axiom.co`.
+- Records arrive with `_time` (RFC3339 nanoseconds), `level`, `message`, and tenant identifiers (`workspace_id`, `project_id`, `environment_id`, `deployment_id`) as top-level keys. Structured fields from your app's JSON output show up as nested `attributes`.
 
 ## Delivery semantics
 
-- **Lag.** Logs typically appear at the provider within 30 to 60 seconds of being emitted by your app.
-- **At-least-once.** During a service restart, you may see up to ~30 seconds of duplicates. Where the provider supports `Idempotency-Key`, Unkey sends a per-record key so the provider can dedup automatically.
-- **Backpressure.** If the provider is unreachable or rate-limiting, Unkey retries with exponential backoff. After repeated failures a drain auto-pauses and surfaces the provider's actual error in the dashboard.
-- **Privacy.** Request and response bodies are stripped by default. Enable `Include request and response bodies` only after confirming your provider's data-handling policy.
+Logs typically arrive at the provider within 30 to 60 seconds of being emitted by your app.
 
-## Retention
+Delivery is at-least-once. During a service restart, you can see up to roughly 30 seconds of duplicates. When a provider supports an `Idempotency-Key` header, Unkey sends a per-record key so the provider deduplicates automatically.
+
+If a provider is unreachable or rate-limiting, Unkey retries with exponential backoff. After repeated failures (default: 50 in a row), the drain auto-pauses and surfaces the provider's verbatim error in the dashboard.
+
+Request and response bodies are stripped by default. Enable "Include request and response bodies" only after confirming your provider's data-handling policy.
 
 Drains forward logs as they arrive. Unkey's built-in 90-day runtime log retention and 30-day request log retention are unaffected.
 
-## Coming soon
+## Operate a drain
 
-- Generic HTTP webhook sink for non-Axiom custom endpoints
-- Trace drains (OTLP traces) once tracing lands in the platform
-- Replay UI for re-sending the last N hours after a misconfiguration
+Each install has a status badge in the Extensions view:
+
+- Healthy: the last batch delivered with no recent failures.
+- N recent failures: the last batch failed, but the install hasn't crossed the auto-pause threshold yet.
+- Auto-paused: the install crossed the failure threshold (default 50). Open it, read the verbatim provider error, fix the underlying problem (for example, rotate a revoked token), then re-enable.
+- Disabled: turned off by an operator from the install's detail page.
+
+The detail page shows the last delivery timestamp, the cumulative records-delivered count, and the verbatim last error. Re-enabling clears the failure counter, last error, and pause reason, so the next tick treats the install as fresh.


### PR DESCRIPTION
## What does this PR do?

Updates two documentation pages for log drains:

**Architecture overview (`logdrain/overview.mdx`):** Replaces the speculative "Realtime path (future)" section with a more honest "Lag floor and the streaming path" section. The detailed four-step streaming design proposal is removed in favor of a brief note that the `delivery_mode` column exists in the schema but nothing is implemented behind `stream` yet, and that the approach will be prototyped and benchmarked before any design is committed to.

**Product docs (`log-drains.mdx`):** Expands the placeholder product page into a full user-facing guide covering:
- Step-by-step drain setup via the wizard, including the live test push on save
- A detailed breakdown of what gets forwarded (sources, environments, app filters, advanced filters)
- Axiom-specific notes including the EU endpoint override and the shape of forwarded records
- Delivery semantics with the auto-pause threshold (50 consecutive failures) made explicit
- A new "Operate a drain" section describing the status badges (Healthy, N recent failures, Auto-paused, Paused) and what Resume does
- A cleaned-up Roadmap section replacing the old "Coming soon" list

Fixes # (issue)

_If there is not an issue for this, please create one first. This is used to tracking purposes and also helps us understand why this PR exists_

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How should this be tested?

- Read through the updated product docs page and verify all sections are accurate against the current log drain implementation (setup wizard, status badges, auto-pause threshold, Resume behavior)
- Confirm the architecture overview no longer describes an uncommitted streaming design as a concrete plan
- Check that the Axiom provider notes (EU endpoint, record shape) match what the service actually sends

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [x] Updated the Unkey Docs if changes were necessary