### PR TITLE
fix(vercel): encode URL path segments to prevent traversal

### DIFF
--- a/web/internal/vercel/src/client.ts
+++ b/web/internal/vercel/src/client.ts
@@ -33,7 +33,10 @@ export class Vercel {
     opts?: { cache?: RequestCache; revalidate?: number };
     body?: unknown;
   }): Promise<Result<TResult, FetchError>> {
-    const url = new URL(req.path.join("/"), this.baseUrl);
+    // Encode each segment so that values like "../v1/leak" cannot collapse
+    // dot-segments via WHATWG URL parsing (RFC 3986 5.2.4) and reach
+    // unintended endpoints on api.vercel.com using the workspace token.
+    const url = new URL(req.path.map(encodeURIComponent).join("/"), this.baseUrl);
     try {
       if (req.parameters) {
         for (const [key, value] of Object.entries(req.parameters)) {


### PR DESCRIPTION
## Summary

`web/internal/vercel/src/client.ts` built API URLs from `req.path.join("/")`. The WHATWG `URL` parser collapses `..` segments, so an unvalidated `projectId` / `envId` reaching the client (`web/apps/dashboard/lib/trpc/routers/vercel.ts` defines them as plain `z.string()`) lets a workspace member redirect calls to arbitrary `api.vercel.com` paths under the workspace's bearer token.

## Changes

- Encode each path segment with `encodeURIComponent` before `.join("/")` so `..` becomes `..%2F` and cannot collapse.

Defense-in-depth at the URL layer covers all current and future call sites without churning tRPC schemas.

## Test plan

- [ ] Confirm `new URL(["v10","projects","../../v1/leak","env"].map(encodeURIComponent).join("/"), "https://api.vercel.com").toString()` stays under `/v10/projects/`.
- [ ] Existing Vercel integration smoke test still passes.