### PR TITLE
fix(dashboard): cap createIdentity meta payload at 1MB

### DIFF
--- a/web/apps/dashboard/lib/trpc/routers/identity/create.ts
+++ b/web/apps/dashboard/lib/trpc/routers/identity/create.ts
@@ -43,14 +43,15 @@ export const createIdentity = workspaceProcedure
         });
       }
 
-      // Validate that meta is valid if provided
+      // Enforce 1MB size limit on metadata to match updateIdentityMetadata
+      // and prevent storage-exhaustion via the create path.
       if (input.meta) {
-        try {
-          JSON.stringify(input.meta);
-        } catch {
+        const metadataString = JSON.stringify(input.meta);
+        const sizeInBytes = new TextEncoder().encode(metadataString).length;
+        if (sizeInBytes > 1048576) {
           throw new TRPCError({
             code: "BAD_REQUEST",
-            message: "The provided metadata is invalid. Please ensure it's valid JSON.",
+            message: `Metadata size (${Math.round(sizeInBytes / 1024)}KB) exceeds the 1MB limit.`,
           });
         }
       }


### PR DESCRIPTION
## Summary

`web/apps/dashboard/lib/trpc/routers/identity/create.ts` accepted `meta` as `z.record(z.string(), z.unknown()).nullable()` with no upper bound, while the sibling `updateMetadata` mutation enforces a 1MB cap. The existing `JSON.stringify` try/catch was a no-op (`JSON.stringify` of plain JSON values never throws).

## Changes

- Replace the no-op try/catch with `new TextEncoder().encode(JSON.stringify(meta)).length > 1_048_576`, throwing `BAD_REQUEST` on overflow. Mirrors `updateMetadata.ts`.

## Test plan

- [ ] `pnpm typecheck` in `web/apps/dashboard`.
- [ ] Posting a 2MB `meta` to createIdentity returns 400; under-1MB still succeeds.