### PR TITLE
fix(docker): drop root and pin minimal base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,11 @@ RUN bazelisk build //:unkey
 # Extract the binary path and copy it to a known location
 RUN cp $(bazelisk cquery //:unkey --output=files 2>/dev/null) /unkey
 
-FROM gcr.io/distroless/static-debian12
+FROM gcr.io/distroless/static-debian12:nonroot
 COPY --from=builder /unkey /unkey
 
 LABEL org.opencontainers.image.source=https://github.com/unkeyed/unkey
 LABEL org.opencontainers.image.description="Unkey API"
 
+USER nonroot:nonroot
 ENTRYPOINT  ["/unkey"]

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,4 +1,5 @@
-FROM gcr.io/distroless/static-debian12
+FROM gcr.io/distroless/static-debian12:nonroot
 ARG TARGETPLATFORM
 COPY ${TARGETPLATFORM}/unkey /unkey
+USER nonroot:nonroot
 ENTRYPOINT ["/unkey"]

--- a/demo_api/Dockerfile
+++ b/demo_api/Dockerfile
@@ -9,14 +9,16 @@ COPY . .
 
 RUN CGO_ENABLED=0 GOOS=linux go build -a -o main .
 
-FROM alpine:latest
+FROM alpine:3.20
 
-RUN apk --no-cache add ca-certificates
+RUN apk --no-cache add ca-certificates \
+    && adduser -D -H -u 10001 app
 
-WORKDIR /root/
+WORKDIR /app
 
 COPY --from=builder /app/main .
 
 ENV PORT 8080
 
+USER app
 CMD ["./main"]


### PR DESCRIPTION
## Summary

Three Dockerfiles ran the final image as root and used mutable base tags. A container compromise then runs with full root inside, and base-image drift can ship unreviewed binaries.

## Changes

- `Dockerfile` and `Dockerfile.release`: switch final stage to `gcr.io/distroless/static-debian12:nonroot` and add `USER nonroot:nonroot`.
- `demo_api/Dockerfile`: pin base to `alpine:3.20`, add an `app` user (UID 10001), move `WORKDIR` from `/root/` to `/app`, add `USER app`.

Digest pinning (`@sha256:...`) is left to a follow-up that has docker pull access.

## Test plan

- [ ] `docker build -f Dockerfile .`
- [ ] `docker build -f Dockerfile.release .`
- [ ] `docker build -f demo_api/Dockerfile demo_api`
- [ ] Confirm each image runs as a non-root user (`docker run --rm <image> id`).