### PR TITLE
fix(demo_api): drop hardcoded bearer token in /v1/protected

### DIFF
--- a/demo_api/main.go
+++ b/demo_api/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"crypto/rand"
+	"crypto/subtle"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -446,10 +447,19 @@ func main() {
 		})
 	})
 
+	// Demo only. The expected bearer token is read from DEMO_PROTECTED_TOKEN.
+	// If unset, the endpoint fails closed with 503 so a copy-paste of this
+	// file cannot ship with a hardcoded credential.
+	protectedToken := os.Getenv("DEMO_PROTECTED_TOKEN")
+	expectedAuth := []byte("Bearer " + protectedToken)
 	mux.HandleFunc("/v1/protected", func(w http.ResponseWriter, r *http.Request) {
-		auth := r.Header.Get("Authorization")
+		if protectedToken == "" {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
 
-		if auth == "" || auth != "Bearer 123" {
+		auth := r.Header.Get("Authorization")
+		if subtle.ConstantTimeCompare([]byte(auth), expectedAuth) != 1 {
 			w.WriteHeader(http.StatusUnauthorized)
 			return
 		}


### PR DESCRIPTION
## Summary

`demo_api/main.go` had a hardcoded literal `"Bearer 123"` as the auth check on `/v1/protected`. The token sat in the binary and was identical across deployments.

## Changes

- Read `DEMO_PROTECTED_TOKEN` at startup. If unset, `/v1/protected` returns 503 instead of authenticating.
- Compare via `crypto/subtle.ConstantTimeCompare` to avoid leaking token length.

## Test plan

- [x] `bazel build //demo_api:demo_api`
- [ ] Hit `/v1/protected` without `DEMO_PROTECTED_TOKEN` set: expect 503.
- [ ] With it set, correct token returns 200, wrong token returns 401.