### PR TITLE
fix(auth): validate oauth redirect targets to prevent open redirect

### DIFF
--- a/web/apps/dashboard/app/auth/actions.ts
+++ b/web/apps/dashboard/app/auth/actions.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { isSafeRedirectPath } from "@/app/auth/sign-in/redirect-utils";
 import {
   deleteCookie,
   getCookie,
@@ -320,7 +321,16 @@ export async function signIntoWorkspace(orgId: string): Promise<VerificationResu
 
 // OAuth
 export async function signInViaOAuth(options: SignInViaOAuthOptions): Promise<string> {
-  return await auth.signInViaOAuth(options);
+  // Server Actions are publicly callable, so a client-side allow-list
+  // check is insufficient. Reject anything that is not a same-origin
+  // relative path before it is embedded in the OAuth state.
+  const safeOptions: SignInViaOAuthOptions = {
+    ...options,
+    redirectUrlComplete: isSafeRedirectPath(options.redirectUrlComplete)
+      ? options.redirectUrlComplete
+      : "/apis",
+  };
+  return await auth.signInViaOAuth(safeOptions);
 }
 
 export async function completeOAuthSignIn(request: Request): Promise<OAuthResult> {
@@ -329,7 +339,11 @@ export async function completeOAuthSignIn(request: Request): Promise<OAuthResult
 
     if (result.success) {
       await setCookies(result.cookies);
-      redirect(result.redirectTo);
+      // Defense in depth: completeOAuthSignIn already filters, but the
+      // value originates from the OAuth state query parameter which is
+      // attacker-controllable on the callback URL.
+      const safeRedirect = isSafeRedirectPath(result.redirectTo) ? result.redirectTo : "/apis";
+      redirect(safeRedirect);
     }
 
     return result;

--- a/web/apps/dashboard/app/auth/sso-callback/[[...sso-callback]]/route.ts
+++ b/web/apps/dashboard/app/auth/sso-callback/[[...sso-callback]]/route.ts
@@ -60,7 +60,11 @@ export async function GET(request: NextRequest) {
 
   // Get base URL from request because Next.js wants it
   const baseUrl = new URL(request.url).origin;
-  const response = NextResponse.redirect(new URL(authResult.redirectTo, baseUrl));
+  // Re-validate even though completeOAuthSignIn already filters: an
+  // absolute URL passed to `new URL(input, base)` ignores the base and
+  // would yield an open redirect to an attacker-controlled origin.
+  const safeRedirect = isSafeRedirectPath(authResult.redirectTo) ? authResult.redirectTo : "/apis";
+  const response = NextResponse.redirect(new URL(safeRedirect, baseUrl));
 
   return await setCookiesOnResponse(response, authResult.cookies);
 }

--- a/web/apps/dashboard/lib/auth/workos.ts
+++ b/web/apps/dashboard/lib/auth/workos.ts
@@ -1,3 +1,4 @@
+import { isSafeRedirectPath } from "@/app/auth/sign-in/redirect-utils";
 import { env } from "@/lib/env";
 import {
   WorkOS,
@@ -67,6 +68,30 @@ type Decision = {
   action: "allow" | "block" | "challenge";
   reason?: string;
 };
+
+const DEFAULT_OAUTH_REDIRECT = "/apis";
+
+// Returns a same-origin relative path parsed from the OAuth state query
+// parameter. Falls back to DEFAULT_OAUTH_REDIRECT for missing, malformed,
+// or absolute/protocol-relative values so the callback handler cannot be
+// tricked into redirecting to an attacker-controlled origin.
+function parseRedirectFromState(state: string | null): string {
+  if (!state) {
+    return DEFAULT_OAUTH_REDIRECT;
+  }
+  try {
+    const parsed: unknown = JSON.parse(decodeURIComponent(state));
+    if (parsed !== null && typeof parsed === "object" && "redirectUrlComplete" in parsed) {
+      const candidate: unknown = parsed.redirectUrlComplete;
+      if (typeof candidate === "string" && isSafeRedirectPath(candidate)) {
+        return candidate;
+      }
+    }
+  } catch {
+    // Fall through to the default redirect when state is malformed.
+  }
+  return DEFAULT_OAUTH_REDIRECT;
+}
 
 export class WorkOSAuthProvider extends BaseAuthProvider {
   //INFO: Best to leave this alone, some other class might be accessing `instance` implicitly
@@ -930,7 +955,14 @@ export class WorkOSAuthProvider extends BaseAuthProvider {
   // OAuth Methods
   signInViaOAuth(options: SignInViaOAuthOptions): string {
     const { provider, redirectUrlComplete } = options;
-    const state = encodeURIComponent(JSON.stringify({ redirectUrlComplete }));
+    // Reject absolute URLs and protocol-relative paths so a caller cannot
+    // embed an attacker-controlled origin into the OAuth state. The same
+    // value is read back in completeOAuthSignIn and used as a redirect
+    // target after the session cookie is set.
+    const safeRedirect = isSafeRedirectPath(redirectUrlComplete)
+      ? redirectUrlComplete
+      : DEFAULT_OAUTH_REDIRECT;
+    const state = encodeURIComponent(JSON.stringify({ redirectUrlComplete: safeRedirect }));
     const baseUrl = getBaseUrl();
     const redirect = `${baseUrl}/auth/sso-callback`;
     return this.provider.userManagement.getAuthorizationUrl({
@@ -964,9 +996,10 @@ export class WorkOSAuthProvider extends BaseAuthProvider {
         throw new Error("No sealed session returned");
       }
 
-      const redirectUrlComplete = state
-        ? JSON.parse(decodeURIComponent(state)).redirectUrlComplete
-        : "/apis";
+      // Re-validate after parsing because the state query parameter
+      // is attacker-controllable on the callback URL even when our own
+      // signInViaOAuth filtered the value at creation time.
+      const redirectUrlComplete = parseRedirectFromState(state);
 
       return {
         success: true,


### PR DESCRIPTION
## Summary

Three open-redirect findings on the OAuth signin flow, all fixed in this PR because they are co-located:

1. `signInViaOAuth` Server Action took an unvalidated `redirectUrlComplete`.
2. `completeOAuthSignIn` returned the user-controlled redirect parsed back from OAuth state.
3. The SSO callback route's success branch redirected to the unvalidated target.

## Changes

- `web/apps/dashboard/lib/auth/workos.ts`: validate `redirectUrlComplete` with `isSafeRedirectPath` at creation and at parse time. Type narrowing rewritten with `in` + `unknown` so the existing `as` cast goes away.
- `web/apps/dashboard/app/auth/actions.ts`: `signInViaOAuth` validates the input before calling the provider; `completeOAuthSignIn` validates `result.redirectTo` before `redirect()`.
- `web/apps/dashboard/app/auth/sso-callback/[[...sso-callback]]/route.ts`: re-validate the success-branch redirect.

## Test plan

- [ ] OAuth signin with a same-origin redirect succeeds.
- [ ] OAuth signin with `https://attacker.example/x` is rejected at the server action layer.