### PR TITLE
fix(dashboard): enforce workspace ownership in rbac and stripe trpc routers

### DIFF
--- a/web/apps/dashboard/lib/trpc/routers/authorization/roles/connected-keys-and-perms.ts
+++ b/web/apps/dashboard/lib/trpc/routers/authorization/roles/connected-keys-and-perms.ts
@@ -63,6 +63,10 @@ export const getConnectedKeysAndPerms = workspaceProcedure
       }
 
       const role = roleResult[0];
+      // Defense in depth: filter the joined keys/permissions on workspaceId too,
+      // not just the link rows. Cross-workspace link rows could exist (the
+      // schema has no FK enforcing workspace consistency), and joining on id
+      // alone would surface foreign key/permission names through this endpoint.
       const [keyResults, permissionResults] = await Promise.all([
         db
           .selectDistinct({
@@ -70,7 +74,7 @@ export const getConnectedKeysAndPerms = workspaceProcedure
             name: keys.name,
           })
           .from(keysRoles)
-          .innerJoin(keys, eq(keysRoles.keyId, keys.id))
+          .innerJoin(keys, and(eq(keysRoles.keyId, keys.id), eq(keys.workspaceId, workspaceId)))
           .where(and(eq(keysRoles.roleId, roleId), eq(keysRoles.workspaceId, workspaceId)))
           .orderBy(keys.name),
 
@@ -82,7 +86,13 @@ export const getConnectedKeysAndPerms = workspaceProcedure
             description: permissions.description,
           })
           .from(rolesPermissions)
-          .innerJoin(permissions, eq(rolesPermissions.permissionId, permissions.id))
+          .innerJoin(
+            permissions,
+            and(
+              eq(rolesPermissions.permissionId, permissions.id),
+              eq(permissions.workspaceId, workspaceId),
+            ),
+          )
           .where(
             and(eq(rolesPermissions.roleId, roleId), eq(rolesPermissions.workspaceId, workspaceId)),
           )

--- a/web/apps/dashboard/lib/trpc/routers/rbac/createRole.ts
+++ b/web/apps/dashboard/lib/trpc/routers/rbac/createRole.ts
@@ -74,6 +74,24 @@ export const createRole = workspaceProcedure
         });
 
         if (input.permissionIds && input.permissionIds.length > 0) {
+          // Re-derive ownership: ensure every supplied permissionId belongs to
+          // the caller's workspace before linking. Without this check a tenant
+          // could attach foreign permissions to a local role; the verification
+          // path joins roles_permissions -> permissions on id alone, so the
+          // foreign permission slug would propagate into key checks.
+          const permissionIds = input.permissionIds;
+          const ownedPermissions = await tx.query.permissions.findMany({
+            where: (table, { and, eq, inArray }) =>
+              and(eq(table.workspaceId, ctx.workspace.id), inArray(table.id, permissionIds)),
+            columns: { id: true },
+          });
+          if (ownedPermissions.length !== permissionIds.length) {
+            throw new TRPCError({
+              code: "NOT_FOUND",
+              message: "One or more permissions were not found in this workspace.",
+            });
+          }
+
           await tx.insert(schema.rolesPermissions).values(
             input.permissionIds.map((permissionId) => ({
               permissionId,

--- a/web/apps/dashboard/lib/trpc/routers/stripe/getCheckoutSession.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/getCheckoutSession.ts
@@ -21,13 +21,24 @@ export const getCheckoutSession = workspaceProcedure
     }),
   )
   .output(checkoutSessionSchema)
-  .query(async ({ input }) => {
+  .query(async ({ ctx, input }) => {
     const stripe = getStripeClient();
 
     try {
       const session = await stripe.checkout.sessions.retrieve(input.sessionId);
 
       if (!session) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Checkout session not found",
+        });
+      }
+
+      // The dashboard sets client_reference_id to the workspace id when
+      // creating the checkout session. Reject any session that does not
+      // belong to the caller's workspace; cs_* ids leak through success_url
+      // query params, browser history, referer headers, etc.
+      if (session.client_reference_id !== ctx.workspace.id) {
         throw new TRPCError({
           code: "NOT_FOUND",
           message: "Checkout session not found",

--- a/web/apps/dashboard/lib/trpc/routers/stripe/getCustomer.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/getCustomer.ts
@@ -24,8 +24,21 @@ export const getCustomer = workspaceProcedure
     }),
   )
   .output(customerSchema)
-  .query(async ({ input }) => {
+  .query(async ({ ctx, input }) => {
     const stripe = getStripeClient();
+
+    // Only the caller's own stripe customer may be retrieved. Without this
+    // check any authenticated workspace user could read another workspace's
+    // customer (email, default payment method) by passing its cus_* id.
+    if (
+      !ctx.workspace.stripeCustomerId ||
+      ctx.workspace.stripeCustomerId !== input.customerId
+    ) {
+      throw new TRPCError({
+        code: "NOT_FOUND",
+        message: "Customer not found",
+      });
+    }
 
     try {
       const customer = await stripe.customers.retrieve(input.customerId);

--- a/web/apps/dashboard/lib/trpc/routers/stripe/getSetupIntent.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/getSetupIntent.ts
@@ -21,11 +21,32 @@ export const getSetupIntent = workspaceProcedure
     }),
   )
   .output(setupIntentSchema)
-  .query(async ({ input }) => {
+  .query(async ({ ctx, input }) => {
     const stripe = getStripeClient();
+
+    if (!ctx.workspace.stripeCustomerId) {
+      throw new TRPCError({
+        code: "NOT_FOUND",
+        message: "Setup intent not found",
+      });
+    }
 
     try {
       const setupIntent = await stripe.setupIntents.retrieve(input.setupIntentId);
+
+      // Cross-check the SetupIntent's customer against the caller's workspace.
+      // Returning the client_secret to a foreign workspace would let an
+      // attacker attach their own payment method to the victim's customer.
+      const intentCustomer =
+        typeof setupIntent.customer === "string"
+          ? setupIntent.customer
+          : (setupIntent.customer?.id ?? null);
+      if (intentCustomer !== ctx.workspace.stripeCustomerId) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Setup intent not found",
+        });
+      }
 
       // Extract payment method ID, handling both string and expanded object
       let paymentMethodId: string | null = null;

--- a/web/apps/dashboard/lib/trpc/routers/stripe/updateCustomer.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/updateCustomer.ts
@@ -18,8 +18,21 @@ export const updateCustomer = workspaceProcedure
   .use(withRatelimit(ratelimit.update))
   .input(updateCustomerInputSchema)
   .output(customerSchema)
-  .mutation(async ({ input }) => {
+  .mutation(async ({ ctx, input }) => {
     const stripe = getStripeClient();
+
+    // Only allow updating the customer recorded on the caller's own workspace.
+    // Without this check a tenant could chain getCheckoutSession leaks into
+    // changing another workspace's default payment method.
+    if (
+      !ctx.workspace.stripeCustomerId ||
+      ctx.workspace.stripeCustomerId !== input.customerId
+    ) {
+      throw new TRPCError({
+        code: "NOT_FOUND",
+        message: "Customer not found",
+      });
+    }
 
     try {
       const customer = await stripe.customers.update(input.customerId, {


### PR DESCRIPTION
## Summary

Three cross-tenant-id findings, all fixed in this PR:

1. **createRole permissionIds** accepted foreign IDs. Combined with the workspace-less join in `key_find_for_verification.sql`, this lets a tenant inject permission slugs into another tenant's keys.
2. **connected-keys-and-perms** joins on `keys` / `permissions` did not filter by workspace, so foreign rows surfaced.
3. **Stripe checkout / customer / setup-intent** routers accepted client-supplied IDs without checking they belong to the caller's workspace.

## Changes

- `createRole.ts`: in the existing transaction, query `permissions` for `(workspaceId = ctx.workspace.id, id IN permissionIds)` and throw `NOT_FOUND` if the count does not match.
- `connected-keys-and-perms.ts`: add `eq(keys.workspaceId, workspaceId)` and `eq(permissions.workspaceId, workspaceId)` to the inner-join conditions.
- `stripe/getCheckoutSession.ts`: reject sessions whose `client_reference_id !== ctx.workspace.id`.
- `stripe/getCustomer.ts` / `updateCustomer.ts`: only act when `input.customerId === ctx.workspace.stripeCustomerId`.
- `stripe/getSetupIntent.ts`: require the SetupIntent's `customer` to equal `ctx.workspace.stripeCustomerId`.

Conflicts with #6058 on `createRole.ts` (different fix, same file). Sequence cleanly at review.

## Test plan

- [ ] `pnpm typecheck` in `web/apps/dashboard`.
- [ ] Try createRole with a permissionId from another workspace, expect NOT_FOUND.
- [ ] Try getCustomer/updateCustomer with a foreign customerId, expect rejection.