### PR TITLE
fix(dashboard): close invitation-email enumeration and tighten sentry replay masking

### DIFF
--- a/web/apps/dashboard/app/auth/actions.ts
+++ b/web/apps/dashboard/app/auth/actions.ts
@@ -22,7 +22,7 @@ import {
   type VerificationResult,
   errorMessages,
 } from "@/lib/auth/types";
-import { requireEmailMatch } from "@/lib/auth/utils";
+import { requireEmailMatch } from "@/lib/auth/invitation";
 import { env } from "@/lib/env";
 import { Ratelimit } from "@unkey/ratelimit";
 import { cookies, headers } from "next/headers";

--- a/web/apps/dashboard/instrumentation-client.ts
+++ b/web/apps/dashboard/instrumentation-client.ts
@@ -17,10 +17,15 @@ if (process.env.NODE_ENV !== "development" && !isSentryDisabled) {
     // Add optional integrations for additional features
     integrations: [
       Sentry.replayIntegration({
-        // Unmask all text content by default
-        maskAllText: false,
-        // Unblock all media elements by default
-        blockAllMedia: false,
+        // Mask all text and block all media by default. The dashboard renders
+        // multi-tenant content (workspace and project names, audit log entries
+        // surfacing key prefixes and identity metadata, role assignments,
+        // ratelimit overrides, root-key creation flows) and the per-selector
+        // mask list below is incomplete coverage for those surfaces. Default
+        // to mask-everything so a Sentry replay leak cannot expose tenant
+        // text. The selector list is retained as defense in depth.
+        maskAllText: true,
+        blockAllMedia: true,
         // Mask sensitive data selectors
         mask: [
           // Email addresses

--- a/web/apps/dashboard/lib/auth/invitation.ts
+++ b/web/apps/dashboard/lib/auth/invitation.ts
@@ -1,0 +1,26 @@
+import { auth } from "./server";
+
+/**
+ * Validates that the supplied email matches the email recorded for an
+ * invitation token. Throws a single generic error for any failure path
+ * (token lookup failed, token resolved but emails differ) so callers cannot
+ * use this helper to enumerate the email registered to a token.
+ *
+ * This module is intentionally not a Server Action ('use server') so it
+ * cannot be invoked directly from the network.
+ */
+export async function requireEmailMatch(params: {
+  email: string;
+  invitationToken: string;
+}): Promise<void> {
+  const { email, invitationToken } = params;
+  try {
+    const invitation = await auth.getInvitation(invitationToken);
+    if (invitation?.email === email) {
+      return;
+    }
+  } catch {
+    // Fall through to the generic error below.
+  }
+  throw new Error("Invalid invitation");
+}

--- a/web/apps/dashboard/lib/auth/utils.ts
+++ b/web/apps/dashboard/lib/auth/utils.ts
@@ -5,22 +5,6 @@ import { deleteCookie, getCookie } from "./cookies";
 import { auth } from "./server";
 import { UNKEY_SESSION_COOKIE } from "./types";
 
-// Helper to check invite email matches
-export async function requireEmailMatch(params: {
-  email: string;
-  invitationToken: string;
-}): Promise<void> {
-  const { email, invitationToken } = params;
-  try {
-    const invitation = await auth.getInvitation(invitationToken);
-    if (invitation?.email !== email) {
-      throw new Error("Email address does not match the invitation email.");
-    }
-  } catch (_error) {
-    throw new Error("Invalid invitation");
-  }
-}
-
 // Sign Out
 export async function signOut(): Promise<void> {
   const sessionToken = await getCookie(UNKEY_SESSION_COOKIE);


### PR DESCRIPTION
## Summary

Two info-disclosure findings (one in this slug was a false-positive on revalidation):

1. `requireEmailMatch` was a Server Action exposed via `'use server'`, callable directly over the network. Distinguishable errors let a caller turn an invitation token into the registered email.
2. Sentry replay used per-selector masks that did not match any current dashboard markup, so sensitive text was being captured in session replays.

The third finding (`unkey-other-info-disclosure-47417c34cd.md`) was already revalidated as false-positive: only producer is `svc/ctrl/services/deployment/get_deployment.go` setting `EnvironmentVariables: nil`. No code change.

## Changes

- New file `web/apps/dashboard/lib/auth/invitation.ts` (no `use server`); throws a single generic `Invalid invitation` for both lookup-failed and email-mismatch paths.
- Remove `requireEmailMatch` from `lib/auth/utils.ts` and update the import in `app/auth/actions.ts`.
- `instrumentation-client.ts`: flip Sentry replay defaults to `maskAllText: true` and `blockAllMedia: true`.

## Test plan

- [ ] `pnpm typecheck` in `web/apps/dashboard`.
- [ ] Submit an invalid email against a valid invitation token: response is `Invalid invitation`, identical to the unknown-token response.
- [ ] Confirm Sentry replay sessions on staging mask text by default.