### PR TITLE
fix(dashboard): narrow public server action surface for cookies and revalidate

### DIFF
--- a/web/apps/dashboard/app/actions.ts
+++ b/web/apps/dashboard/app/actions.ts
@@ -1,6 +1,15 @@
 "use server";
+import { getAuth } from "@/lib/auth/get-auth";
 import { revalidatePath } from "next/cache";
 
 export async function revalidate(path: string, segment?: "page" | "layout") {
+  // Server Actions are publicly callable POST endpoints. Without this check,
+  // any visitor who scrapes the action ID from a client bundle could trigger
+  // revalidatePath on arbitrary paths, thrashing the Next.js Data and Router
+  // caches.
+  const { userId } = await getAuth();
+  if (!userId) {
+    throw new Error("Unauthorized");
+  }
   revalidatePath(path, segment || "page");
 }

--- a/web/apps/dashboard/app/auth/hooks/useSignIn.ts
+++ b/web/apps/dashboard/app/auth/hooks/useSignIn.ts
@@ -1,4 +1,4 @@
-import { getCookie } from "@/lib/auth/cookies";
+import { getCookie } from "@/lib/auth/cookies-actions";
 import {
   AuthErrorCode,
   type AuthErrorResponse,

--- a/web/apps/dashboard/app/auth/sign-in/[[...sign-in]]/page.tsx
+++ b/web/apps/dashboard/app/auth/sign-in/[[...sign-in]]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { FadeIn } from "@/components/landing/fade-in";
-import { deleteCookie, getCookie } from "@/lib/auth/cookies";
+import { deleteLastUsedOrgCookie, getCookie } from "@/lib/auth/cookies-actions";
 import {
   AuthErrorCode,
   PENDING_SESSION_COOKIE,
@@ -94,7 +94,7 @@ function SignInContent() {
         .then((result) => {
           if (!result.success) {
             // Auto-selection failed - clear last used workspace to prevent retry loop
-            deleteCookie(UNKEY_LAST_ORG_COOKIE).catch(() => {
+            deleteLastUsedOrgCookie().catch(() => {
               // Ignore cookie deletion errors
             });
 
@@ -112,7 +112,7 @@ function SignInContent() {
         })
         .catch((_err) => {
           // Clear last used workspace on error
-          deleteCookie(UNKEY_LAST_ORG_COOKIE).catch(() => {
+          deleteLastUsedOrgCookie().catch(() => {
             // Ignore cookie deletion errors
           });
 

--- a/web/apps/dashboard/app/integrations/vercel/callback/workspace.tsx
+++ b/web/apps/dashboard/app/integrations/vercel/callback/workspace.tsx
@@ -18,7 +18,7 @@ import type React from "react";
 import { type JSX, useState } from "react";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { setSessionCookie } from "@/lib/auth/cookies";
+import { setSessionCookie } from "@/lib/auth/cookies-actions";
 import { trpc } from "@/lib/trpc/client";
 import { Loading, toast } from "@unkey/ui";
 

--- a/web/apps/dashboard/app/new/hooks/use-workspace-step.tsx
+++ b/web/apps/dashboard/app/new/hooks/use-workspace-step.tsx
@@ -1,4 +1,4 @@
-import { setLastUsedOrgCookie, setSessionCookie } from "@/lib/auth/cookies";
+import { setLastUsedOrgCookie, setSessionCookie } from "@/lib/auth/cookies-actions";
 import { slugify } from "@/lib/slugify";
 import { trpc } from "@/lib/trpc/client";
 import { zodResolver } from "@hookform/resolvers/zod";

--- a/web/apps/dashboard/components/navigation/sidebar/team-switcher.tsx
+++ b/web/apps/dashboard/components/navigation/sidebar/team-switcher.tsx
@@ -10,7 +10,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useSidebar } from "@/components/ui/sidebar";
-import { setLastUsedOrgCookie, setSessionCookie } from "@/lib/auth/cookies";
+import { setLastUsedOrgCookie, setSessionCookie } from "@/lib/auth/cookies-actions";
 import { trpc } from "@/lib/trpc/client";
 import { cn } from "@/lib/utils";
 

--- a/web/apps/dashboard/lib/auth/cookies-actions.ts
+++ b/web/apps/dashboard/lib/auth/cookies-actions.ts
@@ -1,0 +1,54 @@
+"use server";
+
+// Narrow Server Actions exposed to client components.
+//
+// Files marked "use server" expose every export as a public POST endpoint
+// identified by an action ID. The generic helpers in ./cookies.ts (setCookie,
+// setCookies, setCookiesOnResponse, deleteCookie) accept arbitrary name,
+// value, and option fields, which makes them unsafe to expose. This module
+// only re-exports the narrow, fixed-name operations that client components
+// actually need.
+
+import {
+  deleteCookie as deleteCookieInternal,
+  getCookie as getCookieInternal,
+  setLastUsedOrgCookie as setLastUsedOrgCookieInternal,
+  setSessionCookie as setSessionCookieInternal,
+} from "./cookies";
+import { PENDING_SESSION_COOKIE, UNKEY_LAST_ORG_COOKIE } from "./types";
+
+// Cookies the client may read by name. PENDING_SESSION_COOKIE backs the
+// org-selection step before a full session exists, and UNKEY_LAST_ORG_COOKIE
+// stores the last selected workspace for auto-selection on next sign-in.
+function isReadableCookieName(name: string): boolean {
+  return name === PENDING_SESSION_COOKIE || name === UNKEY_LAST_ORG_COOKIE;
+}
+
+export async function getCookie(name: string): Promise<string | null> {
+  if (!isReadableCookieName(name)) {
+    throw new Error(`Cookie ${name} is not readable from the client`);
+  }
+  return getCookieInternal(name);
+}
+
+export async function deleteLastUsedOrgCookie(): Promise<void> {
+  await deleteCookieInternal(UNKEY_LAST_ORG_COOKIE);
+}
+
+export async function setSessionCookie(params: {
+  token: string;
+  expiresAt: Date;
+}): Promise<void> {
+  // The token is validated by the WorkOS sealed-session check on the next
+  // request that reads the session cookie; an attacker who calls this action
+  // can only plant a value into their own browser, where it will fail
+  // session validation. The internal helper hardcodes the cookie name, so
+  // this action cannot be misused to set arbitrary cookies.
+  await setSessionCookieInternal(params);
+}
+
+export async function setLastUsedOrgCookie(params: {
+  orgId: string;
+}): Promise<void> {
+  await setLastUsedOrgCookieInternal(params);
+}

--- a/web/apps/dashboard/lib/auth/cookies.ts
+++ b/web/apps/dashboard/lib/auth/cookies.ts
@@ -1,4 +1,8 @@
-"use server";
+// Server-only cookie helpers. This module is intentionally NOT a "use server"
+// module: that directive would expose every export below as a public POST
+// endpoint identified by an action ID, including the generic setCookie /
+// setCookies helpers that accept arbitrary name, value, and option fields.
+// Client components must go through the narrow wrappers in ./cookies-actions.
 
 import { cookies } from "next/headers";
 import type { NextRequest, NextResponse } from "next/server";


### PR DESCRIPTION
## Summary

Two server-action-no-auth findings:

1. `lib/auth/cookies.ts` had file-level `'use server'`, exposing generic `setCookie` / `deleteCookie` / `setCookiesOnResponse` as public POST endpoints with arbitrary name/value/options. Anyone could plant cookies in a victim browser.
2. `app/actions.ts` exposed `revalidate(path, segment)` as a Server Action with no auth check, enabling cache thrashing.

## Changes

- Remove `'use server'` from `lib/auth/cookies.ts` and add a new `lib/auth/cookies-actions.ts` that exposes only narrow operations: `getCookie` (restricted to `PENDING_SESSION_COOKIE` and `UNKEY_LAST_ORG_COOKIE`), `deleteLastUsedOrgCookie`, `setSessionCookie`, `setLastUsedOrgCookie`.
- Update 5 client-side importers (`useSignIn`, `sign-in/page`, `use-workspace-step`, `vercel/callback/workspace`, `team-switcher`).
- Server-side importers (`route.ts`, `lib/auth/*`, `app/auth/actions.ts`) keep importing from `cookies.ts` as plain async functions.
- `app/actions.ts`: `revalidate` calls `getAuth()` and throws `Unauthorized` when `userId` is null.

## Test plan

- [ ] `pnpm typecheck` in `web/apps/dashboard`.
- [ ] Confirm sign-in / sign-up flows still set the expected cookies.
- [ ] Confirm a cross-origin POST to `/?_action=setCookie` no longer plants cookies.