### PR TITLE
fix(dashboard): add rate limiting to 23 trpc mutations

### DIFF
--- a/web/apps/dashboard/lib/trpc/routers/deploy/env-vars/create-bulk.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/env-vars/create-bulk.ts
@@ -6,7 +6,7 @@ import { TRPCError } from "@trpc/server";
 import { environments } from "@unkey/db/src/schema";
 import { newId } from "@unkey/id";
 import { z } from "zod";
-import { workspaceProcedure } from "../../../trpc";
+import { ratelimit, withRatelimit, workspaceProcedure } from "../../../trpc";
 
 const vault = new Vault({
   baseUrl: env().VAULT_URL,
@@ -22,6 +22,7 @@ const bulkEnvVarInputSchema = z.object({
 });
 
 export const createBulkEnvVars = workspaceProcedure
+  .use(withRatelimit(ratelimit.create))
   .input(
     z.object({
       variables: z.array(bulkEnvVarInputSchema).min(1),

--- a/web/apps/dashboard/lib/trpc/routers/deploy/env-vars/create.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/env-vars/create.ts
@@ -6,7 +6,7 @@ import { TRPCError } from "@trpc/server";
 import { environments } from "@unkey/db/src/schema";
 import { newId } from "@unkey/id";
 import { z } from "zod";
-import { workspaceProcedure } from "../../../trpc";
+import { ratelimit, withRatelimit, workspaceProcedure } from "../../../trpc";
 
 const vault = new Vault({
   baseUrl: env().VAULT_URL,
@@ -21,6 +21,7 @@ const envVarInputSchema = z.object({
 });
 
 export const createEnvVars = workspaceProcedure
+  .use(withRatelimit(ratelimit.create))
   .input(
     z.object({
       environmentId: z.string(),

--- a/web/apps/dashboard/lib/trpc/routers/identity/create.ts
+++ b/web/apps/dashboard/lib/trpc/routers/identity/create.ts
@@ -4,7 +4,7 @@ import { ratelimitItemSchema } from "@/lib/schemas/ratelimit";
 import { TRPCError } from "@trpc/server";
 import { newId } from "@unkey/id";
 import { z } from "zod";
-import { workspaceProcedure } from "../../trpc";
+import { ratelimit, withRatelimit, workspaceProcedure } from "../../trpc";
 
 export const createIdentityInputSchema = z.object({
   externalId: z
@@ -18,6 +18,7 @@ export const createIdentityInputSchema = z.object({
 });
 
 export const createIdentity = workspaceProcedure
+  .use(withRatelimit(ratelimit.create))
   .input(createIdentityInputSchema)
   .mutation(async ({ input, ctx }) => {
     const identityId = newId("identity");

--- a/web/apps/dashboard/lib/trpc/routers/identity/delete.ts
+++ b/web/apps/dashboard/lib/trpc/routers/identity/delete.ts
@@ -2,9 +2,10 @@ import { insertAuditLogs } from "@/lib/audit";
 import { db, eq, schema } from "@/lib/db";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
-import { workspaceProcedure } from "../../trpc";
+import { ratelimit, withRatelimit, workspaceProcedure } from "../../trpc";
 
 export const deleteIdentity = workspaceProcedure
+  .use(withRatelimit(ratelimit.delete))
   .input(
     z.object({
       identityId: z.string(),

--- a/web/apps/dashboard/lib/trpc/routers/identity/updateMetadata.ts
+++ b/web/apps/dashboard/lib/trpc/routers/identity/updateMetadata.ts
@@ -3,9 +3,10 @@ import { db, eq, schema } from "@/lib/db";
 import { metadataSchema } from "@/lib/schemas/metadata";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
-import { workspaceProcedure } from "../../trpc";
+import { ratelimit, withRatelimit, workspaceProcedure } from "../../trpc";
 
 export const updateIdentityMetadata = workspaceProcedure
+  .use(withRatelimit(ratelimit.update))
   .input(
     metadataSchema.extend({
       identityId: z.string(),

--- a/web/apps/dashboard/lib/trpc/routers/identity/updateRatelimit.ts
+++ b/web/apps/dashboard/lib/trpc/routers/identity/updateRatelimit.ts
@@ -4,7 +4,7 @@ import { ratelimitSchema } from "@/lib/schemas/ratelimit";
 import { TRPCError } from "@trpc/server";
 import { newId } from "@unkey/id";
 import { z } from "zod";
-import { workspaceProcedure } from "../../trpc";
+import { ratelimit, withRatelimit, workspaceProcedure } from "../../trpc";
 
 const baseRatelimitInputSchema = z.object({
   identityId: z.string(),
@@ -15,6 +15,7 @@ export const ratelimitInputSchema = ratelimitSchema.and(baseRatelimitInputSchema
 type RatelimitInputSchema = z.infer<typeof ratelimitInputSchema>;
 
 export const updateIdentityRatelimit = workspaceProcedure
+  .use(withRatelimit(ratelimit.update))
   .input(ratelimitInputSchema)
   .mutation(async ({ input, ctx }) => {
     const identity = await db.query.identities

--- a/web/apps/dashboard/lib/trpc/routers/key/createRootKey.ts
+++ b/web/apps/dashboard/lib/trpc/routers/key/createRootKey.ts
@@ -6,12 +6,13 @@ import { newId } from "@unkey/id";
 import { newKey } from "@unkey/keys";
 import { unkeyPermissionValidation } from "@unkey/rbac";
 import { z } from "zod";
-import { workspaceProcedure } from "../../trpc";
+import { ratelimit, withRatelimit, workspaceProcedure } from "../../trpc";
 
 import { insertAuditLogs } from "@/lib/audit";
 import { upsertPermissions } from "../rbac";
 
 export const createRootKey = workspaceProcedure
+  .use(withRatelimit(ratelimit.create))
   .input(
     z.object({
       name: z.string().optional(),

--- a/web/apps/dashboard/lib/trpc/routers/key/delete.ts
+++ b/web/apps/dashboard/lib/trpc/routers/key/delete.ts
@@ -2,9 +2,10 @@ import { insertAuditLogs } from "@/lib/audit";
 import { and, db, eq, inArray, schema } from "@/lib/db";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
-import { workspaceProcedure } from "../../trpc";
+import { ratelimit, withRatelimit, workspaceProcedure } from "../../trpc";
 
 export const deleteKeys = workspaceProcedure
+  .use(withRatelimit(ratelimit.delete))
   .input(
     z.object({
       keyIds: z.array(z.string()).min(1, "At least one key ID must be provided"),

--- a/web/apps/dashboard/lib/trpc/routers/key/updateEnabled.ts
+++ b/web/apps/dashboard/lib/trpc/routers/key/updateEnabled.ts
@@ -2,9 +2,10 @@ import { type UnkeyAuditLog, insertAuditLogs } from "@/lib/audit";
 import { and, db, eq, inArray, schema } from "@/lib/db";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
-import { workspaceProcedure } from "../../trpc";
+import { ratelimit, withRatelimit, workspaceProcedure } from "../../trpc";
 
 export const updateKeysEnabled = workspaceProcedure
+  .use(withRatelimit(ratelimit.update))
   .input(
     z.object({
       keyIds: z

--- a/web/apps/dashboard/lib/trpc/routers/key/updateRatelimit.ts
+++ b/web/apps/dashboard/lib/trpc/routers/key/updateRatelimit.ts
@@ -4,7 +4,7 @@ import { ratelimitSchema } from "@/lib/schemas/ratelimit";
 import { TRPCError } from "@trpc/server";
 import { newId } from "@unkey/id";
 import { z } from "zod";
-import { workspaceProcedure } from "../../trpc";
+import { ratelimit, withRatelimit, workspaceProcedure } from "../../trpc";
 
 const baseRatelimitInputSchema = z.object({
   keyId: z.string(),
@@ -15,6 +15,7 @@ export const ratelimitInputSchema = ratelimitSchema.and(baseRatelimitInputSchema
 type RatelimitInputSchema = z.infer<typeof ratelimitInputSchema>;
 
 export const updateKeyRatelimit = workspaceProcedure
+  .use(withRatelimit(ratelimit.update))
   .input(ratelimitInputSchema)
   .mutation(async ({ input, ctx }) => {
     const key = await db.query.keys

--- a/web/apps/dashboard/lib/trpc/routers/key/updateRemaining.ts
+++ b/web/apps/dashboard/lib/trpc/routers/key/updateRemaining.ts
@@ -3,9 +3,10 @@ import { insertAuditLogs } from "@/lib/audit";
 import { and, db, eq, schema } from "@/lib/db";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
-import { workspaceProcedure } from "../../trpc";
+import { ratelimit, withRatelimit, workspaceProcedure } from "../../trpc";
 
 export const updateKeyRemaining = workspaceProcedure
+  .use(withRatelimit(ratelimit.update))
   .input(
     creditsSchema.extend({
       keyId: z.string(),

--- a/web/apps/dashboard/lib/trpc/routers/rbac/connectPermissionToRole.ts
+++ b/web/apps/dashboard/lib/trpc/routers/rbac/connectPermissionToRole.ts
@@ -2,9 +2,10 @@ import { insertAuditLogs } from "@/lib/audit";
 import { db, schema } from "@/lib/db";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
-import { workspaceProcedure } from "../../trpc";
+import { ratelimit, withRatelimit, workspaceProcedure } from "../../trpc";
 
 export const connectPermissionToRole = workspaceProcedure
+  .use(withRatelimit(ratelimit.update))
   .input(
     z.object({
       roleId: z.string(),

--- a/web/apps/dashboard/lib/trpc/routers/rbac/connectRoleToKey.ts
+++ b/web/apps/dashboard/lib/trpc/routers/rbac/connectRoleToKey.ts
@@ -2,9 +2,10 @@ import { insertAuditLogs } from "@/lib/audit";
 import { db, schema } from "@/lib/db";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
-import { workspaceProcedure } from "../../trpc";
+import { ratelimit, withRatelimit, workspaceProcedure } from "../../trpc";
 
 export const connectRoleToKey = workspaceProcedure
+  .use(withRatelimit(ratelimit.update))
   .input(
     z.object({
       roleId: z.string(),

--- a/web/apps/dashboard/lib/trpc/routers/rbac/createPermission.ts
+++ b/web/apps/dashboard/lib/trpc/routers/rbac/createPermission.ts
@@ -3,7 +3,7 @@ import { db, schema } from "@/lib/db";
 import { TRPCError } from "@trpc/server";
 import { newId } from "@unkey/id";
 import { z } from "zod";
-import { workspaceProcedure } from "../../trpc";
+import { ratelimit, withRatelimit, workspaceProcedure } from "../../trpc";
 const nameSchema = z
   .string()
   .min(3)
@@ -13,6 +13,7 @@ const nameSchema = z
   });
 
 export const createPermission = workspaceProcedure
+  .use(withRatelimit(ratelimit.create))
   .input(
     z.object({
       name: nameSchema,

--- a/web/apps/dashboard/lib/trpc/routers/rbac/createRole.ts
+++ b/web/apps/dashboard/lib/trpc/routers/rbac/createRole.ts
@@ -3,7 +3,7 @@ import { db, schema } from "@/lib/db";
 import { TRPCError } from "@trpc/server";
 import { newId } from "@unkey/id";
 import { z } from "zod";
-import { workspaceProcedure } from "../../trpc";
+import { ratelimit, withRatelimit, workspaceProcedure } from "../../trpc";
 const nameSchema = z
   .string()
   .min(3)
@@ -13,6 +13,7 @@ const nameSchema = z
   });
 
 export const createRole = workspaceProcedure
+  .use(withRatelimit(ratelimit.create))
   .input(
     z.object({
       name: nameSchema,

--- a/web/apps/dashboard/lib/trpc/routers/rbac/deletePermission.ts
+++ b/web/apps/dashboard/lib/trpc/routers/rbac/deletePermission.ts
@@ -2,9 +2,10 @@ import { insertAuditLogs } from "@/lib/audit";
 import { and, db, eq, schema } from "@/lib/db";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
-import { workspaceProcedure } from "../../trpc";
+import { ratelimit, withRatelimit, workspaceProcedure } from "../../trpc";
 
 export const deletePermission = workspaceProcedure
+  .use(withRatelimit(ratelimit.delete))
   .input(
     z.object({
       permissionId: z.string(),

--- a/web/apps/dashboard/lib/trpc/routers/rbac/deleteRole.ts
+++ b/web/apps/dashboard/lib/trpc/routers/rbac/deleteRole.ts
@@ -2,9 +2,10 @@ import { insertAuditLogs } from "@/lib/audit";
 import { and, db, eq, schema } from "@/lib/db";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
-import { workspaceProcedure } from "../../trpc";
+import { ratelimit, withRatelimit, workspaceProcedure } from "../../trpc";
 
 export const deleteRole = workspaceProcedure
+  .use(withRatelimit(ratelimit.delete))
   .input(
     z.object({
       roleId: z.string(),

--- a/web/apps/dashboard/lib/trpc/routers/rbac/disconnectPermissionFromRole.ts
+++ b/web/apps/dashboard/lib/trpc/routers/rbac/disconnectPermissionFromRole.ts
@@ -2,9 +2,10 @@ import { insertAuditLogs } from "@/lib/audit";
 import { and, db, eq, schema } from "@/lib/db";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
-import { workspaceProcedure } from "../../trpc";
+import { ratelimit, withRatelimit, workspaceProcedure } from "../../trpc";
 
 export const disconnectPermissionFromRole = workspaceProcedure
+  .use(withRatelimit(ratelimit.update))
   .input(
     z.object({
       roleId: z.string(),

--- a/web/apps/dashboard/lib/trpc/routers/rbac/disconnectRoleFromKey.ts
+++ b/web/apps/dashboard/lib/trpc/routers/rbac/disconnectRoleFromKey.ts
@@ -2,9 +2,10 @@ import { insertAuditLogs } from "@/lib/audit";
 import { and, db, eq, schema } from "@/lib/db";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
-import { workspaceProcedure } from "../../trpc";
+import { ratelimit, withRatelimit, workspaceProcedure } from "../../trpc";
 
 export const disconnectRoleFromKey = workspaceProcedure
+  .use(withRatelimit(ratelimit.update))
   .input(
     z.object({
       roleId: z.string(),

--- a/web/apps/dashboard/lib/trpc/routers/rbac/updatePermission.ts
+++ b/web/apps/dashboard/lib/trpc/routers/rbac/updatePermission.ts
@@ -2,7 +2,7 @@ import { insertAuditLogs } from "@/lib/audit";
 import { db, eq, schema } from "@/lib/db";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
-import { workspaceProcedure } from "../../trpc";
+import { ratelimit, withRatelimit, workspaceProcedure } from "../../trpc";
 const nameSchema = z
   .string()
   .min(3)
@@ -12,6 +12,7 @@ const nameSchema = z
   });
 
 export const updatePermission = workspaceProcedure
+  .use(withRatelimit(ratelimit.update))
   .input(
     z.object({
       id: z.string(),

--- a/web/apps/dashboard/lib/trpc/routers/rbac/updateRole.ts
+++ b/web/apps/dashboard/lib/trpc/routers/rbac/updateRole.ts
@@ -2,7 +2,7 @@ import { insertAuditLogs } from "@/lib/audit";
 import { db, eq, schema } from "@/lib/db";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
-import { workspaceProcedure } from "../../trpc";
+import { ratelimit, withRatelimit, workspaceProcedure } from "../../trpc";
 const nameSchema = z
   .string()
   .min(3)
@@ -12,6 +12,7 @@ const nameSchema = z
   });
 
 export const updateRole = workspaceProcedure
+  .use(withRatelimit(ratelimit.update))
   .input(
     z.object({
       id: z.string(),

--- a/web/apps/dashboard/lib/trpc/routers/stripe/createSubscription.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/createSubscription.ts
@@ -5,10 +5,11 @@ import { getStripeClient } from "@/lib/stripe";
 import { invalidateWorkspaceCache } from "@/lib/workspace-cache";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
-import { workspaceProcedure } from "../../trpc";
+import { ratelimit, withRatelimit, workspaceProcedure } from "../../trpc";
 import { clearWorkspaceCache } from "../workspace/getCurrent";
 
 export const createSubscription = workspaceProcedure
+  .use(withRatelimit(ratelimit.create))
   .input(
     z.object({
       productId: z.string(),

--- a/web/apps/dashboard/lib/trpc/routers/stripe/updateSubscription.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/updateSubscription.ts
@@ -4,9 +4,10 @@ import { getStripeClient } from "@/lib/stripe";
 import { invalidateWorkspaceCache } from "@/lib/workspace-cache";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
-import { workspaceProcedure } from "../../trpc";
+import { ratelimit, withRatelimit, workspaceProcedure } from "../../trpc";
 
 export const updateSubscription = workspaceProcedure
+  .use(withRatelimit(ratelimit.update))
   .input(
     z.object({
       oldProductId: z.string(),


### PR DESCRIPTION
## Summary

23 tRPC mutations ran on `workspaceProcedure` with no rate limit, allowing an authenticated member to spam them at request rate.

The 24th finding (`unkey-rate-limit-bypass-28755eb4b8.md`, `auth/actions.ts` `resendAuthCode`) needs separate architectural decisions (fail-closed onError, IP-based limits across multiple endpoints) and is not included here.

## Pattern applied

```ts
import { ratelimit, withRatelimit, workspaceProcedure } from "../../trpc";

export const myMutation = workspaceProcedure
  .use(withRatelimit(ratelimit.<create|update|delete>))
  .input(...)
  .mutation(...);
```

Bucket: `create` for inserts, `delete` for soft/hard deletes, `update` for mutations and connect/disconnect (matches the legacy `rbac.ts` ratelimits and finding recommendations).

## Files (23)

- `rbac/{connectPermissionToRole, connectRoleToKey, createPermission, createRole, deletePermission, deleteRole, disconnectPermissionFromRole, disconnectRoleFromKey, updatePermission, updateRole}.ts` (10)
- `identity/{create, delete, updateMetadata, updateRatelimit}.ts` (4)
- `key/{createRootKey, delete, updateEnabled, updateRatelimit, updateRemaining}.ts` (5)
- `stripe/{createSubscription, updateSubscription}.ts` (2)
- `deploy/env-vars/{create, create-bulk}.ts` (2)

Conflicts likely with #6058 (`createRole.ts`), #6059 (`createRole.ts`), #6060 (`env-vars/create.ts`, `create-bulk.ts`). All compatible at the diff level (different lines or trivial merge).

## Test plan

- [ ] `pnpm typecheck` in `web/apps/dashboard`.
- [ ] Burst 50 createRole calls from a single workspace and confirm rate-limit kicks in.
- [ ] Sample one or two endpoints in each bucket; confirm normal usage still works.