### PR TITLE
fix(auth): bind turnstile token to a server-sealed challenge

### DIFF
--- a/web/apps/dashboard/app/auth/actions.ts
+++ b/web/apps/dashboard/app/auth/actions.ts
@@ -8,6 +8,7 @@ import {
   setSessionCookie,
 } from "@/lib/auth/cookies";
 import { auth } from "@/lib/auth/server";
+import { verifyTurnstileChallenge } from "@/lib/auth/turnstile-challenge-token";
 import {
   AuthErrorCode,
   type AuthErrorResponse,
@@ -15,7 +16,6 @@ import {
   type NavigationResponse,
   type OAuthResult,
   PENDING_SESSION_COOKIE,
-  type PendingTurnstileResponse,
   type SignInViaOAuthOptions,
   UNKEY_LAST_ORG_COOKIE,
   type UserData,
@@ -40,8 +40,13 @@ async function getRequestMetadata() {
   return { ipAddress, userAgent };
 }
 
-// Turnstile verification helper
-async function verifyTurnstileToken(token: string): Promise<boolean> {
+// Turnstile verification helper.
+//
+// `expectedAction` is the per-challenge action we bound into the widget.
+// Cloudflare echoes the action back in the siteverify response and we
+// require it to match so a token solved for one challenge cannot be
+// replayed against another.
+async function verifyTurnstileToken(token: string, expectedAction: string): Promise<boolean> {
   const environment = env();
   const secretKey = environment.CLOUDFLARE_TURNSTILE_SECRET_KEY;
 
@@ -65,9 +70,19 @@ async function verifyTurnstileToken(token: string): Promise<boolean> {
       return false;
     }
 
-    const data = await response.json();
-
-    return data.success === true;
+    const data: unknown = await response.json();
+    if (typeof data !== "object" || data === null) {
+      return false;
+    }
+    if (!("success" in data) || data.success !== true) {
+      return false;
+    }
+    // Cloudflare returns the widget's `action` value. Reject any token
+    // whose action does not match the expected per-challenge action.
+    if (!("action" in data) || typeof data.action !== "string" || data.action !== expectedAction) {
+      return false;
+    }
+    return true;
   } catch (_error) {
     return false;
   }
@@ -460,18 +475,31 @@ export async function acceptInvitationAndJoin(
 }
 
 /**
- * Verify Turnstile token and retry original auth operation
+ * Verify Turnstile token and retry original auth operation.
+ *
+ * Takes only the Turnstile token plus the server-issued `challengeToken`
+ * sealed in `signUp/signInViaEmail`. The sealed token carries the original
+ * email, action, and (for sign-up) the user's name. We trust ONLY those
+ * sealed values when retrying so a single solved Turnstile token cannot be
+ * used to flood arbitrary emails or change the action / user data.
  */
 export async function verifyTurnstileAndRetry(params: {
   turnstileToken: string;
-  email: string;
-  challengeParams: PendingTurnstileResponse["challengeParams"];
-  userData?: { firstName: string; lastName: string }; // Only for sign-up
+  challengeToken: string;
 }): Promise<EmailAuthResult> {
-  const { turnstileToken, email, challengeParams, userData } = params;
+  const { turnstileToken, challengeToken } = params;
 
-  // Verify Turnstile token
-  const isValidToken = await verifyTurnstileToken(turnstileToken);
+  const challenge = verifyTurnstileChallenge(challengeToken);
+  if (!challenge) {
+    return {
+      success: false,
+      code: AuthErrorCode.UNKNOWN_ERROR,
+      message: "Verification failed. Please try again.",
+    };
+  }
+
+  // Verify Turnstile token, requiring the action we bound into the widget.
+  const isValidToken = await verifyTurnstileToken(turnstileToken, challenge.cloudflareAction);
 
   if (!isValidToken) {
     return {
@@ -481,22 +509,30 @@ export async function verifyTurnstileAndRetry(params: {
     };
   }
 
-  // Retry original auth operation based on action
+  // Retry original auth operation using ONLY the sealed values. We pull
+  // metadata fresh from the current request so the downstream call uses
+  // today's IP/UA, not whatever was captured when the challenge was issued.
   const metadata = await getRequestMetadata();
 
-  if (challengeParams.action === "sign-up" && userData) {
-    // For sign-up, we need the user data
+  if (challenge.action === "sign-up") {
+    if (!challenge.userData) {
+      return {
+        success: false,
+        code: AuthErrorCode.UNKNOWN_ERROR,
+        message: "Invalid challenge.",
+      };
+    }
     return await auth.signUpViaEmail({
-      ...userData,
-      email,
+      firstName: challenge.userData.firstName,
+      lastName: challenge.userData.lastName,
+      email: challenge.email,
       ...metadata,
       bypassRadar: true,
     });
   }
-  if (challengeParams.action === "sign-in") {
-    // For sign-in, we just need the email
+  if (challenge.action === "sign-in") {
     return await auth.signInViaEmail({
-      email,
+      email: challenge.email,
       ...metadata,
       bypassRadar: true,
     });

--- a/web/apps/dashboard/app/auth/hooks/useSignIn.ts
+++ b/web/apps/dashboard/app/auth/hooks/useSignIn.ts
@@ -40,7 +40,8 @@ function isPendingTurnstileChallenge(result: EmailAuthResult): result is Pending
     !result.success &&
     result.code === AuthErrorCode.RADAR_CHALLENGE_REQUIRED &&
     "email" in result &&
-    "challengeParams" in result
+    "challengeToken" in result &&
+    "cloudflareAction" in result
   );
 }
 
@@ -206,15 +207,12 @@ export function useSignIn() {
   const handleTurnstileVerification = async (
     turnstileToken: string,
     challengeData: PendingTurnstileResponse,
-    userData?: { firstName: string; lastName: string },
   ): Promise<void> => {
     try {
       setError(null);
       const result = await verifyTurnstileAndRetry({
         turnstileToken,
-        email: challengeData.email,
-        challengeParams: challengeData.challengeParams,
-        userData,
+        challengeToken: challengeData.challengeToken,
       });
 
       if (result.success) {

--- a/web/apps/dashboard/app/auth/hooks/useSignUp.ts
+++ b/web/apps/dashboard/app/auth/hooks/useSignUp.ts
@@ -26,7 +26,8 @@ export function useSignUp() {
       !result.success &&
       result.code === AuthErrorCode.RADAR_CHALLENGE_REQUIRED &&
       "email" in result &&
-      "challengeParams" in result
+      "challengeToken" in result &&
+      "cloudflareAction" in result
     );
   };
 
@@ -45,19 +46,9 @@ export function useSignUp() {
     turnstileToken: string,
     challengeData: PendingTurnstileResponse,
   ): Promise<EmailAuthResult> => {
-    // Validate userData exists and has required properties
-    if (!userData || !userData.firstName || !userData.lastName) {
-      throw new Error("User data is incomplete. First name and last name are required.");
-    }
-
     const result = await verifyTurnstileAndRetry({
       turnstileToken,
-      email: challengeData.email,
-      challengeParams: challengeData.challengeParams,
-      userData: {
-        firstName: userData.firstName,
-        lastName: userData.lastName,
-      },
+      challengeToken: challengeData.challengeToken,
     });
     return result;
   };

--- a/web/apps/dashboard/app/auth/sign-in/email-signin.tsx
+++ b/web/apps/dashboard/app/auth/sign-in/email-signin.tsx
@@ -82,6 +82,7 @@ export function EmailSignIn() {
       <div className="grid gap-6">
         <TurnstileChallenge
           email={turnstileChallenge.email}
+          action={turnstileChallenge.cloudflareAction}
           onSuccess={handleTurnstileSuccess}
           onError={handleTurnstileError}
           isLoading={isTurnstileLoading}

--- a/web/apps/dashboard/app/auth/sign-up/email-signup.tsx
+++ b/web/apps/dashboard/app/auth/sign-up/email-signup.tsx
@@ -132,6 +132,7 @@ export const EmailSignUp: React.FC<Props> = ({ setVerification }) => {
       <div className="grid gap-6">
         <TurnstileChallenge
           email={turnstileChallenge.email}
+          action={turnstileChallenge.cloudflareAction}
           onSuccess={handleTurnstileSuccess}
           onError={handleTurnstileError}
           isLoading={isTurnstileLoading}

--- a/web/apps/dashboard/components/auth/turnstile-challenge.tsx
+++ b/web/apps/dashboard/components/auth/turnstile-challenge.tsx
@@ -5,12 +5,15 @@ import { useState } from "react";
 
 interface TurnstileChallengeProps {
   email: string;
+  // Server-issued, per-challenge action string. Bound to the widget so the
+  // resulting Turnstile token cannot be replayed against another challenge.
+  action: string;
   onSuccess: (token: string) => void;
   onError: (error?: Error | string) => void;
   isLoading?: boolean;
 }
 
-export function TurnstileChallenge({ email, onSuccess, onError }: TurnstileChallengeProps) {
+export function TurnstileChallenge({ email, action, onSuccess, onError }: TurnstileChallengeProps) {
   const [isWidgetLoading, setIsWidgetLoading] = useState(true);
   const siteKey = process.env.NEXT_PUBLIC_CLOUDFLARE_TURNSTILE_SITE_KEY;
 
@@ -61,6 +64,7 @@ export function TurnstileChallenge({ email, onSuccess, onError }: TurnstileChall
               options={{
                 theme: "dark",
                 size: "normal",
+                action,
               }}
             />
           </div>

--- a/web/apps/dashboard/lib/auth/turnstile-challenge-token.ts
+++ b/web/apps/dashboard/lib/auth/turnstile-challenge-token.ts
@@ -1,0 +1,153 @@
+import crypto from "node:crypto";
+import { env } from "@/lib/env";
+
+// Lifetime of a sealed Turnstile challenge. Long enough for a user to solve
+// the widget, short enough to limit replay if a token leaks.
+const CHALLENGE_TTL_MS = 10 * 60 * 1000;
+
+export type SealedChallengeAction = "sign-up" | "sign-in";
+
+export type SealedChallengePayload = {
+  email: string;
+  action: SealedChallengeAction;
+  userData?: { firstName: string; lastName: string };
+};
+
+type SealedChallengeBody = SealedChallengePayload & {
+  // Random per-challenge id. We pass a hash of this back to Cloudflare as
+  // the widget action so the Turnstile token itself is bound to this exact
+  // challenge and cannot be replayed across different emails or actions.
+  nonce: string;
+  expiresAt: number;
+};
+
+export type VerifiedChallenge = SealedChallengePayload & {
+  // Action string sent to Cloudflare's siteverify and the Turnstile widget.
+  // Callers compare this to the action returned by Cloudflare to ensure the
+  // solved token is for this exact challenge.
+  cloudflareAction: string;
+};
+
+// Derive a stable HMAC key from WORKOS_COOKIE_PASSWORD so we don't need a
+// new secret. The password is already required in production for sealed
+// session cookies.
+function getSigningKey(): Buffer {
+  const password = env().WORKOS_COOKIE_PASSWORD;
+  if (!password) {
+    throw new Error("WORKOS_COOKIE_PASSWORD is required to seal Turnstile challenges");
+  }
+  return crypto.createHash("sha256").update(`turnstile-challenge:${password}`).digest();
+}
+
+function base64UrlEncode(input: Buffer | string): string {
+  const buf = typeof input === "string" ? Buffer.from(input, "utf8") : input;
+  return buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function base64UrlDecode(input: string): Buffer {
+  const padded = input.replace(/-/g, "+").replace(/_/g, "/");
+  const padLen = (4 - (padded.length % 4)) % 4;
+  return Buffer.from(padded + "=".repeat(padLen), "base64");
+}
+
+function sign(payload: string): string {
+  return base64UrlEncode(crypto.createHmac("sha256", getSigningKey()).update(payload).digest());
+}
+
+// Cloudflare's `action` field accepts up to 32 chars matching `[a-zA-Z0-9_-]`.
+// We hash the random nonce and truncate so the bound action is unique per
+// challenge while staying within Cloudflare's constraints.
+function deriveCloudflareAction(nonce: string): string {
+  const digest = crypto.createHash("sha256").update(nonce).digest("base64url");
+  return digest.slice(0, 32);
+}
+
+export function sealTurnstileChallenge(payload: SealedChallengePayload): {
+  token: string;
+  cloudflareAction: string;
+} {
+  const nonce = crypto.randomBytes(16).toString("base64url");
+  const body: SealedChallengeBody = {
+    ...payload,
+    nonce,
+    expiresAt: Date.now() + CHALLENGE_TTL_MS,
+  };
+  const encoded = base64UrlEncode(JSON.stringify(body));
+  const signature = sign(encoded);
+  return {
+    token: `${encoded}.${signature}`,
+    cloudflareAction: deriveCloudflareAction(nonce),
+  };
+}
+
+function isUserData(value: unknown): value is { firstName: string; lastName: string } {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  if (!("firstName" in value) || typeof value.firstName !== "string") {
+    return false;
+  }
+  if (!("lastName" in value) || typeof value.lastName !== "string") {
+    return false;
+  }
+  return true;
+}
+
+function isSealedChallengeBody(value: unknown): value is SealedChallengeBody {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  if (!("email" in value) || typeof value.email !== "string") {
+    return false;
+  }
+  if (!("action" in value) || (value.action !== "sign-up" && value.action !== "sign-in")) {
+    return false;
+  }
+  if (!("nonce" in value) || typeof value.nonce !== "string") {
+    return false;
+  }
+  if (!("expiresAt" in value) || typeof value.expiresAt !== "number") {
+    return false;
+  }
+  if ("userData" in value && value.userData !== undefined && !isUserData(value.userData)) {
+    return false;
+  }
+  return true;
+}
+
+export function verifyTurnstileChallenge(token: string): VerifiedChallenge | null {
+  const parts = token.split(".");
+  if (parts.length !== 2) {
+    return null;
+  }
+  const [encoded, signature] = parts;
+  const expected = sign(encoded);
+  // Constant-time comparison to avoid leaking signature bytes.
+  const expectedBuf = base64UrlDecode(expected);
+  const providedBuf = base64UrlDecode(signature);
+  if (expectedBuf.length !== providedBuf.length) {
+    return null;
+  }
+  if (!crypto.timingSafeEqual(expectedBuf, providedBuf)) {
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(base64UrlDecode(encoded).toString("utf8"));
+  } catch {
+    return null;
+  }
+  if (!isSealedChallengeBody(parsed)) {
+    return null;
+  }
+  if (parsed.expiresAt < Date.now()) {
+    return null;
+  }
+  return {
+    email: parsed.email,
+    action: parsed.action,
+    userData: parsed.userData,
+    cloudflareAction: deriveCloudflareAction(parsed.nonce),
+  };
+}

--- a/web/apps/dashboard/lib/auth/types.ts
+++ b/web/apps/dashboard/lib/auth/types.ts
@@ -90,13 +90,20 @@ export interface PendingEmailVerificationResponse extends AuthErrorResponse {
   cookies: Cookie[];
 }
 
-// Special case for Turnstile challenge
+// Special case for Turnstile challenge.
+//
+// `challengeToken` is a server-signed seal binding the email, action, and
+// (for sign-up) the user's name to a single challenge. The client echoes it
+// back when submitting the Turnstile solution and the server uses the
+// sealed values, NOT the client-supplied ones, when retrying the auth call.
+// `cloudflareAction` is also bound into the Turnstile widget so a solved
+// token cannot be replayed against a different challenge.
 export interface PendingTurnstileResponse extends AuthErrorResponse {
   code: AuthErrorCode.RADAR_CHALLENGE_REQUIRED;
   email: string;
+  challengeToken: string;
+  cloudflareAction: string;
   challengeParams: {
-    ipAddress?: string;
-    userAgent?: string;
     authMethod: string;
     action: string;
   };

--- a/web/apps/dashboard/lib/auth/workos.ts
+++ b/web/apps/dashboard/lib/auth/workos.ts
@@ -9,6 +9,7 @@ import { BaseAuthProvider } from "./base-provider";
 import { getAuthCookieOptions } from "./cookie-security";
 import { getCookie } from "./cookies";
 import { getAuth } from "./get-auth";
+import { sealTurnstileChallenge } from "./turnstile-challenge-token";
 import {
   AuthErrorCode,
   type EmailAuthResult,
@@ -576,7 +577,7 @@ export class WorkOSAuthProvider extends BaseAuthProvider {
   ): Promise<EmailAuthResult> {
     const { email, firstName, lastName, ipAddress, userAgent, bypassRadar } = params;
     const auth_method = "Email_OTP"; // WorkOS value
-    const action = "sign-up"; // WorkOS value
+    const action = "sign-up" as const; // WorkOS value
     /**
      * We can bypass radar after the user has gone through the cloudflare challenge, as we already verified they are in fact human.
      */
@@ -591,14 +592,19 @@ export class WorkOSAuthProvider extends BaseAuthProvider {
 
       // Handle challenge decisions with Turnstile
       if (radarDecision.action === "challenge") {
+        const sealed = sealTurnstileChallenge({
+          email,
+          action,
+          userData: { firstName, lastName },
+        });
         return {
           success: false,
           code: AuthErrorCode.RADAR_CHALLENGE_REQUIRED,
           message: "Please complete the verification challenge to continue.",
           email,
+          challengeToken: sealed.token,
+          cloudflareAction: sealed.cloudflareAction,
           challengeParams: {
-            ipAddress,
-            userAgent,
             authMethod: auth_method,
             action,
           },
@@ -662,7 +668,7 @@ export class WorkOSAuthProvider extends BaseAuthProvider {
   }): Promise<EmailAuthResult> {
     const { email, ipAddress, userAgent, bypassRadar } = params;
     const auth_method = "Email_OTP"; // WorkOS value
-    const action = "sign-in"; // WorkOS value
+    const action = "sign-in" as const; // WorkOS value
 
     /**
      * We can bypass radar after the user has gone through the cloudflare challenge, as we already verified they are in fact human.
@@ -677,14 +683,18 @@ export class WorkOSAuthProvider extends BaseAuthProvider {
       });
 
       if (radarDecision.action === "challenge") {
+        const sealed = sealTurnstileChallenge({
+          email,
+          action,
+        });
         return {
           success: false,
           code: AuthErrorCode.RADAR_CHALLENGE_REQUIRED,
           message: "Please complete the verification challenge to continue.",
           email,
+          challengeToken: sealed.token,
+          cloudflareAction: sealed.cloudflareAction,
           challengeParams: {
-            ipAddress,
-            userAgent,
             authMethod: auth_method,
             action,
           },


### PR DESCRIPTION
## Summary

`verifyTurnstileAndRetry` did not bind the Turnstile token to email or action. Cloudflare siteverify was called without an expected action, so a single solved Turnstile widget output could be replayed to retry signup/signin for arbitrary email addresses (Radar bypass + unsolicited signup-email amplification).

## Changes

- New `lib/auth/turnstile-challenge-token.ts`: HMAC-SHA256 sealed token. Key derived from `WORKOS_COOKIE_PASSWORD`. Carries email, action (`sign-up`/`sign-in`), userData, nonce, expiresAt (10 min). `cloudflareAction` is `sha256(nonce)` so the widget action is unique per challenge.
- `lib/auth/types.ts`: `PendingTurnstileResponse` now includes `challengeToken` and `cloudflareAction`. Drop client-exposed `ipAddress` / `userAgent` from `challengeParams`.
- `lib/auth/workos.ts`: `signUpViaEmail` / `signInViaEmail` call `sealTurnstileChallenge` and return the sealed token + cloudflareAction.
- `app/auth/actions.ts`: `verifyTurnstileAndRetry` takes only `turnstileToken` + `challengeToken`. Verifies the seal, calls siteverify with the bound action, rejects on action mismatch. Retry uses only sealed (email, action, userData).
- `useSignUp.ts`, `useSignIn.ts`: pass only `challengeToken`; no client-side userData / email / challengeParams in retry.
- `components/auth/turnstile-challenge.tsx`: accepts `action` prop and forwards to widget.
- `email-signin.tsx`, `email-signup.tsx`: pass `turnstileChallenge.cloudflareAction` to widget.

Type safety: no `any`, no `!`, no `as Type` (only `as const` for literals). `crypto.timingSafeEqual` for signature comparison.

## Test plan

- [ ] `pnpm typecheck` in `web/apps/dashboard`.
- [ ] Sign up succeeds; replaying the same Turnstile token for a different email is rejected.
- [ ] Sign in flow still works.