### PR TITLE
fix(heimdall): suppress netns-gone retries and reconcile stale network entries

### DIFF
--- a/svc/heimdall/internal/collector/collect.go
+++ b/svc/heimdall/internal/collector/collect.go
@@ -53,9 +53,12 @@ type podInfo struct {
 func (c *Collector) collect(_ context.Context) error {
 	tickStart := time.Now()
 	now := c.clk.Now().UnixMilli()
-	pods := c.buildKranePodLookup()
+	pods, listed := c.buildKranePodLookup()
 
-	if c.network != nil {
+	// Only reconcile when we have an authoritative pod set. A lister error
+	// returns an empty map; reconciling against it would evict every attached
+	// BPF program on a transient cache failure.
+	if listed && c.network != nil {
 		active := make(map[types.UID]struct{}, len(pods))
 		for uid := range pods {
 			active[types.UID(uid)] = struct{}{}
@@ -176,12 +179,16 @@ func (c *Collector) collect(_ context.Context) error {
 	return nil
 }
 
-func (c *Collector) buildKranePodLookup() map[string]podInfo {
+// buildKranePodLookup returns the billable pods on this node and a flag
+// indicating whether the lister read succeeded. Callers must treat ok=false
+// as "pod set unknown" rather than "no pods", since the empty map and a
+// genuinely empty cluster are otherwise indistinguishable.
+func (c *Collector) buildKranePodLookup() (map[string]podInfo, bool) {
 	pods := make(map[string]podInfo)
 	allPods, err := c.podLister.List(labels.Everything())
 	if err != nil {
 		logger.Error("failed to list pods from cache", "error", err.Error())
-		return pods
+		return pods, false
 	}
 
 	for _, pod := range allPods {
@@ -194,7 +201,7 @@ func (c *Collector) buildKranePodLookup() map[string]podInfo {
 		pods[string(pod.UID)] = buildPodInfo(pod)
 	}
 
-	return pods
+	return pods, true
 }
 
 // isBillablePod returns true if pod is a krane-managed deployment or a sentinel.

--- a/svc/heimdall/internal/collector/collect.go
+++ b/svc/heimdall/internal/collector/collect.go
@@ -55,6 +55,14 @@ func (c *Collector) collect(_ context.Context) error {
 	now := c.clk.Now().UnixMilli()
 	pods := c.buildKranePodLookup()
 
+	if c.network != nil {
+		active := make(map[types.UID]struct{}, len(pods))
+		for uid := range pods {
+			active[types.UID(uid)] = struct{}{}
+		}
+		c.network.Reconcile(active)
+	}
+
 	var written int
 	for _, info := range pods {
 		// If Status.ContainerStatuses hasn't caught up with the primary

--- a/svc/heimdall/internal/metrics/prometheus.go
+++ b/svc/heimdall/internal/metrics/prometheus.go
@@ -187,6 +187,20 @@ var (
 		[]string{"op"}, // "stat_root", "stat_mount", "statfs"
 	)
 
+	// NetworkReconcileEvictions counts attached entries closed by the
+	// periodic reconcile pass because their pod UID was no longer in the
+	// informer cache. Non-zero means the CRI exit event and informer
+	// status update were both missed for that pod; the reconciler cleaned
+	// up the leaked BPF program FDs.
+	NetworkReconcileEvictions = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "unkey",
+			Subsystem: "heimdall",
+			Name:      "network_reconcile_evictions_total",
+			Help:      "Stale attached-pod entries closed by the reconcile pass (CRI+informer exit event both missed).",
+		},
+	)
+
 	// NetworkReadErrors counts per-pod BPF map lookup failures. Read
 	// errors currently degrade silently to zeroCounters in the collector;
 	// a rising counter means the map or its attachments are in a bad

--- a/svc/heimdall/internal/metrics/prometheus.go
+++ b/svc/heimdall/internal/metrics/prometheus.go
@@ -99,7 +99,7 @@ var (
 			Name:      "network_attach_failures_total",
 			Help:      "Per-pod network attach failures, labeled by reason.",
 		},
-		[]string{"reason"}, // "sandbox_not_found", "netns_open", "veth_lookup", "tcx_attach", "queue_full", "other"
+		[]string{"reason"}, // "sandbox_not_found", "netns_gone", "netns_open", "veth_lookup", "tcx_attach", "queue_full", "other"
 	)
 
 	// BPFMapEntries tracks how many per-pod counter entries are live in

--- a/svc/heimdall/internal/network/network.go
+++ b/svc/heimdall/internal/network/network.go
@@ -101,6 +101,14 @@ type Reader interface {
 	// is full). Returns 0 on the non-Linux stub.
 	MapEntries() int
 
+	// Reconcile evicts stale entries whose pod UID is no longer in the
+	// active set. Call once per collection tick after the informer pod
+	// list is built. Without this, pods whose CRI exit event and
+	// informer status update were both missed accumulate in attached
+	// (leaking BPF program FDs) and terminated (leaking map memory)
+	// until process restart.
+	Reconcile(active map[types.UID]struct{})
+
 	// Close releases all attach links and frees the BPF map. Idempotent.
 	Close() error
 }

--- a/svc/heimdall/internal/network/network_linux.go
+++ b/svc/heimdall/internal/network/network_linux.go
@@ -30,9 +30,10 @@ type linuxReader struct {
 	podCounters *ebpf.Map            // shared pinned counter map, read by Read()
 	cd          *containerd.Client   // sandbox-container lookups for netns resolution
 
-	mu       sync.Mutex
-	attached map[types.UID]attachedPod // pod uid → per-pod links + collection + cookie
-	pending  map[types.UID]struct{}    // uids currently enqueued or being attached
+	mu         sync.Mutex
+	attached   map[types.UID]attachedPod // pod uid → per-pod links + collection + cookie
+	pending    map[types.UID]struct{}    // uids currently enqueued or being attached
+	terminated map[types.UID]struct{}    // uids whose CNI netns is confirmed gone (ENOENT); never re-enqueued
 
 	// Async attach worker pool. Attach() enqueues; workers dequeue and
 	// call attachSync. Keeps the 5s collect tick from serialising on
@@ -147,6 +148,7 @@ func NewReader(criSocket string) (Reader, error) {
 		mu:          sync.Mutex{},
 		attached:    make(map[types.UID]attachedPod),
 		pending:     make(map[types.UID]struct{}),
+		terminated:  make(map[types.UID]struct{}),
 		attachQ:     make(chan types.UID, attachQueueSize),
 		closed:      make(chan struct{}),
 		workerWG:    sync.WaitGroup{},
@@ -197,6 +199,10 @@ func PinDir() string { return bpfPinDir }
 // attachQueueSize. The caller's next tick will re-request the same UID.
 func (r *linuxReader) Attach(uid types.UID) error {
 	r.mu.Lock()
+	if _, ok := r.terminated[uid]; ok {
+		r.mu.Unlock()
+		return nil
+	}
 	if _, ok := r.attached[uid]; ok {
 		r.mu.Unlock()
 		return nil
@@ -245,23 +251,39 @@ func (r *linuxReader) runAttachWorker() {
 
 			r.mu.Lock()
 			delete(r.pending, uid)
+			// ENOENT on the CNI netns path means DEL already ran and the pod
+			// is definitively gone. Mark it terminated so Attach never
+			// re-enqueues it. Set this under the same lock as delete(pending)
+			// to close the window where pending is clear but terminated isn't
+			// set yet and a concurrent Attach call could sneak in.
+			netnsGone := err != nil && errors.Is(err, ErrNetnsOpen) && errors.Is(err, os.ErrNotExist)
+			if netnsGone {
+				r.terminated[uid] = struct{}{}
+			}
 			r.mu.Unlock()
 
 			if err != nil {
-				// Fire-and-forget means the collector can't see this
-				// error; surface it through the same metric it used to
-				// observe before the move to async, plus a Warn log so
-				// the full wrap chain (the part the metric label can't
-				// capture) is visible without flipping to Debug level.
-				// Deeper per-step diagnostics live at Debug in sandbox_linux.go
-				// and veth_linux.go.
-				reason := attachFailureReason(err)
-				metrics.NetworkAttachFailures.WithLabelValues(reason).Inc()
-				logger.Warn("network attach failed",
-					"pod_uid", string(uid),
-					"reason", reason,
-					"error", err.Error(),
-				)
+				if netnsGone {
+					// Benign churn: CNI already tore down the netns. No warn,
+					// no alert. Debug log once; future Attach calls are no-ops.
+					metrics.NetworkAttachFailures.WithLabelValues("netns_gone").Inc()
+					logger.Debug("network attach: pod netns gone, suppressing retries",
+						"pod_uid", string(uid),
+					)
+				} else {
+					// Fire-and-forget means the collector can't see this
+					// error; surface it through the metric plus a Warn log so
+					// the full wrap chain is visible without flipping to Debug.
+					// Deeper per-step diagnostics live in sandbox_linux.go and
+					// veth_linux.go.
+					reason := attachFailureReason(err)
+					metrics.NetworkAttachFailures.WithLabelValues(reason).Inc()
+					logger.Warn("network attach failed",
+						"pod_uid", string(uid),
+						"reason", reason,
+						"error", err.Error(),
+					)
+				}
 			}
 		}
 	}
@@ -374,6 +396,7 @@ func (r *linuxReader) Detach(uid types.UID) {
 	defer r.mu.Unlock()
 
 	delete(r.pending, uid)
+	delete(r.terminated, uid)
 
 	p, ok := r.attached[uid]
 	if !ok {
@@ -448,6 +471,7 @@ func (r *linuxReader) Close() error {
 	}
 
 	r.pending = map[types.UID]struct{}{}
+	r.terminated = map[types.UID]struct{}{}
 	_ = r.cd.Close()
 
 	// Close the shared map handle. The pinned inode stays on disk (under

--- a/svc/heimdall/internal/network/network_linux.go
+++ b/svc/heimdall/internal/network/network_linux.go
@@ -451,6 +451,38 @@ func (r *linuxReader) MapEntries() int {
 	return len(r.attached)
 }
 
+// Reconcile evicts entries from attached and terminated whose pod UID is
+// absent from active (the current informer pod set). Must be called once
+// per collection tick. It is the backstop for pods whose CRI exit event
+// and informer status update were both missed: without it those entries
+// accumulate across the process lifetime, leaking BPF program FDs (from
+// attached) and map memory (from terminated).
+//
+// Reconcile does NOT touch pending — those entries self-clear when the
+// worker finishes attachSync.
+func (r *linuxReader) Reconcile(active map[types.UID]struct{}) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for uid, p := range r.attached {
+		if _, ok := active[uid]; ok {
+			continue
+		}
+		_ = p.ingress.Close()
+		_ = p.egress.Close()
+		p.coll.Close()
+		_ = r.podCounters.Delete(p.cookie)
+		delete(r.attached, uid)
+		metrics.NetworkReconcileEvictions.Inc()
+	}
+
+	for uid := range r.terminated {
+		if _, ok := active[uid]; !ok {
+			delete(r.terminated, uid)
+		}
+	}
+}
+
 func (r *linuxReader) Close() error {
 	// Signal Attach callers and workers (both select on r.closed). Workers
 	// exit their for-select; any UIDs still in the queue are dropped (we

--- a/svc/heimdall/internal/network/network_stub.go
+++ b/svc/heimdall/internal/network/network_stub.go
@@ -14,9 +14,10 @@ type stubReader struct{}
 // eBPF programs. Heimdall only runs on Linux in production.
 func PinDir() string { return "" }
 
-func NewReader(_ string) (Reader, error)              { return stubReader{}, nil }
-func (stubReader) Attach(_ types.UID) error           { return nil }
-func (stubReader) Detach(_ types.UID)                 {}
-func (stubReader) Read(_ types.UID) (Counters, error) { return zeroCounters, nil }
-func (stubReader) MapEntries() int                    { return 0 }
-func (stubReader) Close() error                       { return nil }
+func NewReader(_ string) (Reader, error)                          { return stubReader{}, nil }
+func (stubReader) Attach(_ types.UID) error                       { return nil }
+func (stubReader) Detach(_ types.UID)                             {}
+func (stubReader) Read(_ types.UID) (Counters, error)             { return zeroCounters, nil }
+func (stubReader) MapEntries() int                                { return 0 }
+func (stubReader) Reconcile(_ map[types.UID]struct{})             {}
+func (stubReader) Close() error                                   { return nil }

--- a/svc/heimdall/internal/network/network_stub.go
+++ b/svc/heimdall/internal/network/network_stub.go
@@ -14,10 +14,10 @@ type stubReader struct{}
 // eBPF programs. Heimdall only runs on Linux in production.
 func PinDir() string { return "" }
 
-func NewReader(_ string) (Reader, error)                          { return stubReader{}, nil }
-func (stubReader) Attach(_ types.UID) error                       { return nil }
-func (stubReader) Detach(_ types.UID)                             {}
-func (stubReader) Read(_ types.UID) (Counters, error)             { return zeroCounters, nil }
-func (stubReader) MapEntries() int                                { return 0 }
-func (stubReader) Reconcile(_ map[types.UID]struct{})             {}
-func (stubReader) Close() error                                   { return nil }
+func NewReader(_ string) (Reader, error)              { return stubReader{}, nil }
+func (stubReader) Attach(_ types.UID) error           { return nil }
+func (stubReader) Detach(_ types.UID)                 {}
+func (stubReader) Read(_ types.UID) (Counters, error) { return zeroCounters, nil }
+func (stubReader) MapEntries() int                    { return 0 }
+func (stubReader) Reconcile(_ map[types.UID]struct{}) {}
+func (stubReader) Close() error                       { return nil }


### PR DESCRIPTION
## Summary

- When `netns_open` fails with `ENOENT`, the CNI has already run DEL and the pod is definitively gone. Previously heimdall logged a warn and cleared the UID from `pending`, so every subsequent tick re-enqueued the same pod and re-fired the warn — turning normal pod churn into a sustained alert.
- Adds a `terminated` set: on `ErrNetnsOpen`+`os.ErrNotExist`, the worker marks the UID terminated (atomically with `delete(pending)`) and downgrades to a debug log + `netns_gone` metric label. `Attach()` short-circuits on terminated UIDs. `Detach()` clears the mark.
- Adds `Reader.Reconcile(active)`, called once per collection tick after the informer pod list is built. Evicts any UID from `attached` (closing BPF program FDs + TCX links) or `terminated` (memory) that is no longer in the informer cache. This is the backstop for pods whose CRI exit event and informer status update were both missed — without it those entries accumulate for the process lifetime on multi-day runs.
- Adds `network_reconcile_evictions_total` counter so operators can see when the backstop fires.

## Test plan

- [ ] Deploy to a node with pod churn and confirm `network_attach_failures_total{reason="netns_gone"}` replaces the previous `netns_open` warn storm
- [ ] Confirm `network_reconcile_evictions_total` stays at zero under normal operation (primary Detach path working) and increments only when CRI+informer both miss a termination
- [ ] Confirm heimdall memory is stable across a multi-day run with pod churn