### PR TITLE
fix(ctrl): disable external openapi $ref resolution in diff handler

### DIFF
--- a/svc/ctrl/services/openapi/get_diff.go
+++ b/svc/ctrl/services/openapi/get_diff.go
@@ -35,9 +35,13 @@ func (s *Service) GetOpenApiDiff(ctx context.Context, req *connect.Request[ctrlv
 		))
 	}
 
-	// Parse OpenAPI specs
+	// Parse OpenAPI specs.
+	// Keep IsExternalRefsAllowed at its default (false). The spec bytes
+	// come from tenant-controlled deployments via ScrapeSpec, so allowing
+	// external $ref resolution would let a tenant point a $ref at IMDS,
+	// internal services (Restate admin, ClickHouse, K8s API), or file://
+	// URLs and have ctrl issue the request under its identity.
 	loader := openapi3.NewLoader()
-	loader.IsExternalRefsAllowed = true
 
 	s1, err := loader.LoadFromData(oldSpec)
 	if err != nil {


### PR DESCRIPTION
## Summary

`svc/ctrl/services/openapi/get_diff.go:40` set `loader.IsExternalRefsAllowed = true` before parsing tenant-controlled OpenAPI bytes (sourced from `openapi_specs.content`, which `ScrapeSpec` fills from `${fqdn}${openapi_spec_path}` against the tenant's running pod).

The default `kin-openapi` `ReadFromURIFunc` honors `http(s)://` and `file://` schemes, so a tenant can serve a spec containing:

```json
{"components":{"schemas":{"X":{"$ref":"http://169.254.169.254/latest/meta-data/iam/security-credentials/role-name"}}}}
```

When an authorized caller invokes `GetOpenApiDiff`, the ctrl service issues outbound GETs to whatever the `$ref` points to: cloud metadata (IMDS), internal services (Restate admin, ClickHouse, the K8s API), or local files via `file:///proc/self/environ`. Parseable responses round-trip back through the diff or changelog text.

## Changes

- Drop `loader.IsExternalRefsAllowed = true` so the loader defaults to `false`. External `$ref`s are no longer resolved.
- The spec is supposed to be self-contained; `ScrapeSpec` already fetches the full document, so legitimate diffs are unaffected.

## Test plan

- [x] `bazel build //svc/ctrl/services/openapi:openapi`
- [ ] Run `GetOpenApiDiff` against a normal spec pair, confirm it still produces the expected diff.
- [ ] Run it against a spec containing an absolute external `$ref`. Expect the loader to refuse to resolve it and produce a parse error rather than an outbound HTTP/file fetch.

Refs `unkey-findings/HIGH/unkey-ssrf-7bbf6cea18.md`.