### PR TITLE
Fix: This resolve a number of issuer related to Github and Stripe and more

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/actions.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/actions.ts
@@ -1,4 +1,14 @@
-"use server";
+// Both functions in this file are pure server-side helpers consumed only by
+// tRPC routers (api/overview/query-overview, api/overview-api-search), which
+// pass `ctx.workspace.id` from an authenticated workspaceProcedure context.
+//
+// We deliberately do NOT mark this file `"use server"`. With that directive,
+// Next.js registers every async export as a publicly callable Server Action
+// whose action id is a deterministic hash of the file path + export name.
+// Because the workspaceId is taken straight from a function parameter, an
+// authenticated user could compute the action id from this open-source repo
+// and POST any other workspace's id to leak that workspace's API list and
+// key counts (a cross-tenant info-disclosure).
 import { and, count, db, eq, inArray, isNull, schema, sql } from "@/lib/db";
 import type { ApisOverviewResponse } from "@/lib/trpc/routers/api/overview/query-overview/schemas";
 

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/build-settings/github-settings/github-connected.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/build-settings/github-settings/github-connected.tsx
@@ -7,15 +7,13 @@ import { ComboboxSkeleton, GitHubSettingCard, ManageGitHubAppLink, RepoNameLabel
 export const GitHubConnected = ({
   projectId,
   appId,
-  installUrl,
+  onInstall,
   repoFullName,
-  onBeforeNavigate,
 }: {
   projectId: string;
   appId: string;
-  installUrl: string;
+  onInstall: () => Promise<void> | void;
   repoFullName: string;
-  onBeforeNavigate?: () => void;
 }) => {
   const utils = trpc.useUtils();
 
@@ -72,10 +70,9 @@ export const GitHubConnected = ({
       </span>
       <div className="flex items-center gap-5 pt-1">
         <ManageGitHubAppLink
-          installUrl={installUrl}
+          onInstall={onInstall}
           variant="primary"
           text={<span>Manage GitHub</span>}
-          onBeforeNavigate={onBeforeNavigate}
         />
       </div>
     </div>

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/build-settings/github-settings/github-no-repo.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/build-settings/github-settings/github-no-repo.tsx
@@ -7,13 +7,11 @@ import { ComboboxSkeleton, GitHubSettingCard, ManageGitHubAppLink, RepoNameLabel
 export const GitHubNoRepo = ({
   projectId,
   appId,
-  installUrl,
-  onBeforeNavigate,
+  onInstall,
 }: {
   projectId: string;
   appId: string;
-  installUrl: string;
-  onBeforeNavigate?: () => void;
+  onInstall: () => Promise<void> | void;
 }) => {
   const utils = trpc.useUtils();
   const [selectedRepo, setSelectedRepo] = useState("");
@@ -80,10 +78,9 @@ export const GitHubNoRepo = ({
         />
       ) : (
         <ManageGitHubAppLink
-          installUrl={installUrl}
+          onInstall={onInstall}
           variant="outline"
           className="ml-0 h-8 px-3 py-2 rounded-lg"
-          onBeforeNavigate={onBeforeNavigate}
           text={
             <>
               <span className="text-gray-9">Import from</span>

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/build-settings/github-settings/index.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/build-settings/github-settings/index.tsx
@@ -2,6 +2,8 @@
 
 import { trpc } from "@/lib/trpc/client";
 import { match } from "@unkey/match";
+import { toast } from "@unkey/ui";
+import { useCallback } from "react";
 import { useProjectData } from "../../../../data-provider";
 import { SelectedConfig } from "../../shared/selected-config";
 import { GitHubConnected } from "./github-connected";
@@ -10,14 +12,14 @@ import { ComboboxSkeleton, GitHubSettingCard, ManageGitHubAppLink, RepoNameLabel
 
 type GitHubConnectionState =
   | { status: "loading" }
-  | { status: "no-app"; installUrl: string }
-  | { status: "no-repo"; appId: string; installUrl: string }
+  | { status: "no-app"; onInstall: () => Promise<void> }
+  | { status: "no-repo"; appId: string; onInstall: () => Promise<void> }
   | {
       status: "connected";
       appId: string;
       repoFullName: string;
       repositoryId: number;
-      installUrl: string;
+      onInstall: () => Promise<void>;
     };
 
 type GitHubProps = {
@@ -28,8 +30,22 @@ type GitHubProps = {
 export const GitHub = ({ readOnly = false, onBeforeNavigate }: GitHubProps) => {
   const { projectId } = useProjectData();
 
-  const state = JSON.stringify({ projectId, returnTo: "settings" });
-  const installUrl = `https://github.com/apps/${process.env.NEXT_PUBLIC_GITHUB_APP_NAME}/installations/new?state=${encodeURIComponent(state)}`;
+  // The state on the GitHub install URL is a server-signed token bound to
+  // this user, workspace, and project. Computing it requires a tRPC round
+  // trip, so we mint it lazily on click rather than in render.
+  const prepareInstallation = trpc.github.prepareInstallation.useMutation();
+  const onInstall = useCallback(async () => {
+    try {
+      const { state } = await prepareInstallation.mutateAsync({
+        projectId,
+        returnTo: "settings",
+      });
+      onBeforeNavigate?.();
+      window.location.href = `https://github.com/apps/${process.env.NEXT_PUBLIC_GITHUB_APP_NAME}/installations/new?state=${encodeURIComponent(state)}`;
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to start GitHub install");
+    }
+  }, [projectId, prepareInstallation, onBeforeNavigate]);
 
   const { data, isLoading } = trpc.github.getInstallations.useQuery(
     { projectId },
@@ -42,18 +58,18 @@ export const GitHub = ({ readOnly = false, onBeforeNavigate }: GitHubProps) => {
     }
     const hasInstallations = (data?.installations?.length ?? 0) > 0;
     if (!hasInstallations) {
-      return { status: "no-app", installUrl };
+      return { status: "no-app", onInstall };
     }
     const appId = data?.appId;
     if (!appId) {
-      return { status: "no-app", installUrl };
+      return { status: "no-app", onInstall };
     }
     const repoFullName = data?.repoConnection?.repositoryFullName;
     if (repoFullName) {
       const repositoryId = data?.repoConnection?.repositoryId ?? 0;
-      return { status: "connected", appId, repoFullName, repositoryId, installUrl };
+      return { status: "connected", appId, repoFullName, repositoryId, onInstall };
     }
-    return { status: "no-repo", appId, installUrl };
+    return { status: "no-repo", appId, onInstall };
   })();
 
   return match(connectionState)
@@ -62,25 +78,19 @@ export const GitHub = ({ readOnly = false, onBeforeNavigate }: GitHubProps) => {
         <ComboboxSkeleton />
       </GitHubSettingCard>
     ))
-    .with({ status: "no-app" }, ({ installUrl: url }) => (
+    .with({ status: "no-app" }, ({ onInstall: install }) => (
       <GitHubSettingCard chevronState="disabled">
         <ManageGitHubAppLink
-          installUrl={url}
+          onInstall={install}
           variant="outline"
           className="px-2.5 py-3 text-gray-12 font-medium text-[13px] hover:bg-grayA-2"
-          onBeforeNavigate={onBeforeNavigate}
         />
       </GitHubSettingCard>
     ))
-    .with({ status: "no-repo" }, ({ appId, installUrl: url }) => (
-      <GitHubNoRepo
-        projectId={projectId}
-        appId={appId}
-        installUrl={url}
-        onBeforeNavigate={onBeforeNavigate}
-      />
+    .with({ status: "no-repo" }, ({ appId, onInstall: install }) => (
+      <GitHubNoRepo projectId={projectId} appId={appId} onInstall={install} />
     ))
-    .with({ status: "connected" }, ({ appId, repoFullName, installUrl: url }) => {
+    .with({ status: "connected" }, ({ appId, repoFullName, onInstall: install }) => {
       if (readOnly) {
         return (
           <GitHubSettingCard chevronState="disabled">
@@ -92,9 +102,8 @@ export const GitHub = ({ readOnly = false, onBeforeNavigate }: GitHubProps) => {
         <GitHubConnected
           projectId={projectId}
           appId={appId}
-          installUrl={url}
+          onInstall={install}
           repoFullName={repoFullName}
-          onBeforeNavigate={onBeforeNavigate}
         />
       );
     })

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/build-settings/github-settings/shared.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/settings/components/build-settings/github-settings/shared.tsx
@@ -46,27 +46,24 @@ export const RepoNameLabel = ({ fullName }: { fullName: string }) => {
 };
 
 export const ManageGitHubAppLink = ({
-  installUrl,
+  onInstall,
   variant = "primary",
   className = "px-3 py-2 rounded-md",
   text = "Manage Github App",
-  onBeforeNavigate,
 }: {
-  installUrl: string;
+  onInstall: () => Promise<void> | void;
   variant?: "outline" | "ghost" | "primary";
   className?: string;
   text?: React.ReactNode;
-  onBeforeNavigate?: () => void;
 }) => (
-  <Button variant={variant} className={className}>
-    <a
-      href={installUrl}
-      className="text-sm"
-      target="_blank"
-      rel="noopener noreferrer"
-      onClick={onBeforeNavigate}
-    >
-      {text}
-    </a>
+  <Button
+    variant={variant}
+    className={className}
+    onClick={(e) => {
+      e.preventDefault();
+      void onInstall();
+    }}
+  >
+    <span className="text-sm">{text}</span>
   </Button>
 );

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/new/steps/connect-github.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/new/steps/connect-github.tsx
@@ -1,6 +1,8 @@
 "use client";
+import { trpc } from "@/lib/trpc/client";
 import { Github, Layers3 } from "@unkey/icons";
-import { Button } from "@unkey/ui";
+import { Button, toast } from "@unkey/ui";
+import { useState } from "react";
 import { OnboardingLinks } from "../onboarding-links";
 
 type ConnectGithubStepProps = {
@@ -9,7 +11,26 @@ type ConnectGithubStepProps = {
 };
 
 export const ConnectGithubStep = ({ projectId, onBeforeNavigate }: ConnectGithubStepProps) => {
-  const installUrl = `https://github.com/apps/${process.env.NEXT_PUBLIC_GITHUB_APP_NAME}/installations/new?state=${encodeURIComponent(JSON.stringify({ projectId }))}`;
+  // The install URL state is server-signed and bound to this user/workspace.
+  // We can't compute it client-side without a server round-trip, so we mint
+  // it lazily when the user clicks Import.
+  const prepare = trpc.github.prepareInstallation.useMutation();
+  const [isPreparing, setIsPreparing] = useState(false);
+  const handleClick = async (e: React.MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault();
+    if (isPreparing) {
+      return;
+    }
+    setIsPreparing(true);
+    try {
+      const { state } = await prepare.mutateAsync({ projectId });
+      onBeforeNavigate?.();
+      window.location.href = `https://github.com/apps/${process.env.NEXT_PUBLIC_GITHUB_APP_NAME}/installations/new?state=${encodeURIComponent(state)}`;
+    } catch (err) {
+      setIsPreparing(false);
+      toast.error(err instanceof Error ? err.message : "Failed to start GitHub install");
+    }
+  };
 
   return (
     <div className="flex flex-col items-center">
@@ -24,10 +45,10 @@ export const ConnectGithubStep = ({ projectId, onBeforeNavigate }: ConnectGithub
           </span>
         </div>
         <a
-          href={installUrl}
+          href="#"
           rel="noopener noreferrer"
           className="ml-auto"
-          onClick={onBeforeNavigate}
+          onClick={handleClick}
         >
           <Button
             variant="outline"

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/new/steps/select-repo/index.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/new/steps/select-repo/index.tsx
@@ -22,7 +22,19 @@ export const SelectRepo = ({
 }) => {
   const { next } = useStepWizard();
   const trpcUtils = trpc.useUtils();
-  const installUrl = `https://github.com/apps/${process.env.NEXT_PUBLIC_GITHUB_APP_NAME}/installations/new?state=${encodeURIComponent(JSON.stringify({ projectId }))}`;
+  // Server-signed install state — minted on click via prepareInstallation so
+  // the GitHub callback can verify this user/workspace started the install.
+  const prepareInstallation = trpc.github.prepareInstallation.useMutation();
+  const handleInstallClick = async (e: React.MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault();
+    try {
+      const { state } = await prepareInstallation.mutateAsync({ projectId });
+      onBeforeNavigate?.();
+      window.location.href = `https://github.com/apps/${process.env.NEXT_PUBLIC_GITHUB_APP_NAME}/installations/new?state=${encodeURIComponent(state)}`;
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to start GitHub install");
+    }
+  };
 
   const [selectedOwner, setSelectedOwner] = useState("");
   const [searchQuery, setSearchQuery] = useState("");
@@ -254,7 +266,7 @@ export const SelectRepo = ({
       )}
 
       {hasGithubInstallation && (
-        <a href={installUrl} rel="noopener noreferrer" onClick={onBeforeNavigate} className="group">
+        <a href="#" rel="noopener noreferrer" onClick={handleInstallClick} className="group">
           <OnboardingStepHint>
             Can't find your repo? Add more from{" "}
             <OnboardingStepHintHighlight>GitHub</OnboardingStepHintHighlight>.

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/client.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/client.tsx
@@ -194,7 +194,11 @@ export const Client: React.FC = () => {
           </div>
         )}
 
-        <CancelAlert cancelAt={subscription?.cancelAt} />
+        <CancelAlert
+          cancelAt={subscription?.cancelAt}
+          disabled={!isAdmin}
+          disabledReason={ADMIN_ONLY_TOOLTIP}
+        />
 
         {allowCancel ? (
           <SettingsDangerZone>

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/client.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/client.tsx
@@ -4,6 +4,7 @@ import { trpc } from "@/lib/trpc/client";
 import {
   Button,
   Empty,
+  InfoTooltip,
   SettingCard,
   SettingCardGroup,
   SettingsDangerZone,
@@ -23,10 +24,19 @@ import { Usage } from "./components/usage";
 
 const MAX_QUOTA = 150000;
 
+const ADMIN_ONLY_TOOLTIP = "Admin access required to manage billing";
+
 export const Client: React.FC = () => {
   const router = useRouter();
   const workspace = useWorkspaceNavigation();
   const [showPlanModal, setShowPlanModal] = useState(false);
+
+  // Server-side `requireWorkspaceAdmin` enforces this on every billing
+  // mutation; we mirror it on the client purely for UX so non-admin members
+  // get a clear "admin required" affordance instead of a request that fails
+  // with FORBIDDEN.
+  const { data: currentUser } = trpc.user.getCurrentUser.useQuery();
+  const isAdmin = currentUser?.role === "admin";
 
   // Fetch billing info using new tRPC route
   // Query is automatically keyed by workspace context and will refetch on workspace change
@@ -116,6 +126,8 @@ export const Client: React.FC = () => {
               <CurrentPlanCard
                 currentProduct={currentProduct}
                 onChangePlan={() => setShowPlanModal(true)}
+                disabled={!isAdmin}
+                disabledReason={ADMIN_ONLY_TOOLTIP}
               />
               <Usage quota={currentProduct?.quotas?.requestsPerMonth ?? MAX_QUOTA} />
               <SettingCard
@@ -123,16 +135,21 @@ export const Client: React.FC = () => {
                 description="Manage payment methods and see your invoices."
               >
                 <div className="w-full flex h-full items-center justify-end gap-4">
-                  <Button
-                    variant="outline"
-                    className="py-2 px-3 text-gray-12 font-medium text-sm bg-grayA-2 hover:bg-grayA-3"
-                    aria-label="Open billing portal"
-                    onClick={() => {
-                      router.push(`/${workspace.slug}/settings/billing/stripe/portal`);
-                    }}
-                  >
-                    Open Portal
-                  </Button>
+                  <InfoTooltip content={ADMIN_ONLY_TOOLTIP} disabled={isAdmin} asChild>
+                    <span>
+                      <Button
+                        variant="outline"
+                        className="py-2 px-3 text-gray-12 font-medium text-sm bg-grayA-2 hover:bg-grayA-3"
+                        aria-label="Open billing portal"
+                        disabled={!isAdmin}
+                        onClick={() => {
+                          router.push(`/${workspace.slug}/settings/billing/stripe/portal`);
+                        }}
+                      >
+                        Open Portal
+                      </Button>
+                    </span>
+                  </InfoTooltip>
                 </div>
               </SettingCard>
             </SettingCardGroup>
@@ -155,16 +172,21 @@ export const Client: React.FC = () => {
                 contentWidth="w-full lg:w-[320px]"
               >
                 <div className="flex justify-end w-full">
-                  <Button
-                    variant="outline"
-                    className="px-3 py-2 text-gray-12 font-medium text-[13px] bg-grayA-2 shadow-md hover:bg-grayA-3"
-                    aria-label="Add payment method"
-                    onClick={() => {
-                      router.push(`/${workspace.slug}/settings/billing/stripe/checkout`);
-                    }}
-                  >
-                    Add payment method
-                  </Button>
+                  <InfoTooltip content={ADMIN_ONLY_TOOLTIP} disabled={isAdmin} asChild>
+                    <span>
+                      <Button
+                        variant="outline"
+                        className="px-3 py-2 text-gray-12 font-medium text-[13px] bg-grayA-2 shadow-md hover:bg-grayA-3"
+                        aria-label="Add payment method"
+                        disabled={!isAdmin}
+                        onClick={() => {
+                          router.push(`/${workspace.slug}/settings/billing/stripe/checkout`);
+                        }}
+                      >
+                        Add payment method
+                      </Button>
+                    </span>
+                  </InfoTooltip>
                 </div>
               </SettingCard>
               <Usage quota={currentProduct?.quotas?.requestsPerMonth ?? MAX_QUOTA} />
@@ -176,7 +198,7 @@ export const Client: React.FC = () => {
 
         {allowCancel ? (
           <SettingsDangerZone>
-            <CancelPlan />
+            <CancelPlan disabled={!isAdmin} disabledReason={ADMIN_ONLY_TOOLTIP} />
           </SettingsDangerZone>
         ) : null}
       </SettingsShell>

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/cancel-alert.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/cancel-alert.tsx
@@ -4,7 +4,11 @@ import { trpc } from "@/lib/trpc/client";
 import { SettingsZone, SettingsZoneRow, toast } from "@unkey/ui";
 import { useRouter } from "next/navigation";
 
-export const CancelAlert: React.FC<{ cancelAt?: number }> = (props) => {
+export const CancelAlert: React.FC<{
+  cancelAt?: number;
+  disabled?: boolean;
+  disabledReason?: string;
+}> = (props) => {
   const router = useRouter();
   const trpcUtils = trpc.useUtils();
   const uncancelSubscription = trpc.stripe.uncancelSubscription.useMutation({
@@ -35,29 +39,34 @@ export const CancelAlert: React.FC<{ cancelAt?: number }> = (props) => {
     return null;
   }
 
+  const description =
+    props.disabled && props.disabledReason ? (
+      props.disabledReason
+    ) : (
+      <>
+        Your subscription ends in
+        <span className="text-warning-12 font-medium">
+          {" "}
+          {formatMs(timeRemaining, { long: true })}
+        </span>{" "}
+        on{" "}
+        <span className="text-warning-12 font-medium">
+          {new Date(props.cancelAt).toLocaleDateString()}
+        </span>
+        .
+      </>
+    );
+
   return (
     <SettingsZone variant="warning" title="Cancellation Scheduled">
       <SettingsZoneRow
         title="Subscription ending"
-        description={
-          <>
-            Your subscription ends in
-            <span className="text-warning-12 font-medium">
-              {" "}
-              {formatMs(timeRemaining, { long: true })}
-            </span>{" "}
-            on{" "}
-            <span className="text-warning-12 font-medium">
-              {new Date(props.cancelAt).toLocaleDateString()}
-            </span>
-            .
-          </>
-        }
+        description={description}
         action={{
           label: "Resubscribe",
           onClick: () => uncancelSubscription.mutate(),
           loading: uncancelSubscription.isLoading,
-          disabled: uncancelSubscription.isLoading,
+          disabled: uncancelSubscription.isLoading || Boolean(props.disabled),
         }}
       />
     </SettingsZone>

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/cancel-plan.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/cancel-plan.tsx
@@ -5,7 +5,12 @@ import { Button, DialogContainer, SettingsZoneRow, toast } from "@unkey/ui";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
-export const CancelPlan: React.FC = () => {
+type CancelPlanProps = {
+  disabled?: boolean;
+  disabledReason?: string;
+};
+
+export const CancelPlan: React.FC<CancelPlanProps> = ({ disabled = false, disabledReason }) => {
   const trpcUtils = trpc.useUtils();
   const router = useRouter();
   const [isDialogOpen, setIsDialogOpen] = useState(false);
@@ -34,10 +39,15 @@ export const CancelPlan: React.FC = () => {
     <>
       <SettingsZoneRow
         title="Cancel subscription"
-        description="Cancelling your subscription will downgrade your workspace to the free tier."
+        description={
+          disabled && disabledReason
+            ? disabledReason
+            : "Cancelling your subscription will downgrade your workspace to the free tier."
+        }
         action={{
           label: "Cancel Plan",
           onClick: () => setIsDialogOpen(true),
+          disabled,
         }}
       />
 

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/current-plan-card.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/current-plan-card.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { Button, SettingCard } from "@unkey/ui";
+import { Button, InfoTooltip, SettingCard } from "@unkey/ui";
 import { useCallback } from "react";
 
 type CurrentPlanCardProps = {
@@ -9,9 +9,16 @@ type CurrentPlanCardProps = {
     quotas?: { requestsPerMonth: number };
   };
   onChangePlan?: () => void;
+  disabled?: boolean;
+  disabledReason?: string;
 };
 
-export const CurrentPlanCard = ({ currentProduct, onChangePlan }: CurrentPlanCardProps) => {
+export const CurrentPlanCard = ({
+  currentProduct,
+  onChangePlan,
+  disabled = false,
+  disabledReason,
+}: CurrentPlanCardProps) => {
   const handleChangePlan = useCallback(() => {
     onChangePlan?.();
   }, [onChangePlan]);
@@ -33,13 +40,18 @@ export const CurrentPlanCard = ({ currentProduct, onChangePlan }: CurrentPlanCar
       contentWidth="w-full lg:w-[320px]"
     >
       <div className="w-full flex h-full items-center justify-end gap-4">
-        <Button
-          variant="outline"
-          className="px-2.5 py-3 text-gray-12 font-medium text-sm bg-grayA-2 hover:bg-grayA-3"
-          onClick={handleChangePlan}
-        >
-          {currentProduct ? "Change Plan" : "Upgrade"}
-        </Button>
+        <InfoTooltip content={disabledReason ?? ""} disabled={!disabled || !disabledReason} asChild>
+          <span>
+            <Button
+              variant="outline"
+              className="px-2.5 py-3 text-gray-12 font-medium text-sm bg-grayA-2 hover:bg-grayA-3"
+              onClick={handleChangePlan}
+              disabled={disabled}
+            >
+              {currentProduct ? "Change Plan" : "Upgrade"}
+            </Button>
+          </span>
+        </InfoTooltip>
       </div>
     </SettingCard>
   );

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/plan-selection-modal.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/plan-selection-modal.tsx
@@ -95,9 +95,10 @@ export const PlanSelectionModal = ({
 
     setIsLoading(true);
     if (isChangingPlan && currentProductId) {
-      // Update existing subscription
+      // Update existing subscription. The current product is derived from
+      // the existing subscription server-side, so we no longer need to send
+      // `oldProductId` from the client.
       await updateSubscription.mutateAsync({
-        oldProductId: currentProductId,
         newProductId: selectedProductId,
       });
     } else {

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/stripe/checkout/page.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/stripe/checkout/page.tsx
@@ -1,6 +1,7 @@
 import { getAuth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { getStripeClient } from "@/lib/stripe";
+import { getBaseUrl } from "@/lib/utils";
 import { Code, Empty } from "@unkey/ui";
 import { redirect } from "next/navigation";
 import type Stripe from "stripe";
@@ -48,11 +49,9 @@ export default async function StripeRedirect() {
     );
   }
 
-  const baseUrl = process.env.VERCEL
-    ? process.env.VERCEL_TARGET_ENV === "production"
-      ? "https://app.unkey.com"
-      : `https://${process.env.VERCEL_URL}`
-    : "http://localhost:3000";
+  // Use the shared `getBaseUrl()` helper so previews resolve to the stable
+  // VERCEL_BRANCH_URL rather than a deployment-specific VERCEL_URL.
+  const baseUrl = getBaseUrl();
 
   const session = await stripe.checkout.sessions.create({
     client_reference_id: ws.id,

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/stripe/checkout/page.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/stripe/checkout/page.tsx
@@ -8,7 +8,24 @@ import type Stripe from "stripe";
 export const dynamic = "force-dynamic";
 
 export default async function StripeRedirect() {
-  const { orgId } = await getAuth();
+  const { orgId, role } = await getAuth();
+
+  if (!orgId) {
+    return redirect("/sign-in");
+  }
+
+  // Mirror the client-side admin gate. The Add-payment-method button is
+  // hidden for non-admins, but this page is reachable directly via URL.
+  if (role !== "admin") {
+    return (
+      <Empty>
+        <Empty.Title>Admin access required</Empty.Title>
+        <Empty.Description>
+          Only workspace admins can manage billing. Ask an admin to make changes.
+        </Empty.Description>
+      </Empty>
+    );
+  }
 
   const ws = await db.query.workspaces.findFirst({
     where: (table, { and, eq, isNull }) => and(eq(table.orgId, orgId), isNull(table.deletedAtM)),

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/stripe/portal/page.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/stripe/portal/page.tsx
@@ -8,10 +8,24 @@ import type Stripe from "stripe";
 export const dynamic = "force-dynamic";
 
 export default async function StripeRedirect() {
-  const { orgId } = await getAuth();
+  const { orgId, role } = await getAuth();
 
   if (!orgId) {
     return redirect("/sign-in");
+  }
+
+  // Mirror the client-side admin gate. Even though the dashboard now hides
+  // the portal button for non-admins, this page is reachable directly via
+  // URL — refuse to mint a Stripe billing-portal session for non-admins.
+  if (role !== "admin") {
+    return (
+      <Empty>
+        <Empty.Title>Admin access required</Empty.Title>
+        <Empty.Description>
+          Only workspace admins can manage billing. Ask an admin to make changes.
+        </Empty.Description>
+      </Empty>
+    );
   }
 
   const ws = await db.query.workspaces.findFirst({

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/stripe/portal/page.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/stripe/portal/page.tsx
@@ -1,6 +1,7 @@
 import { getAuth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { getStripeClient } from "@/lib/stripe";
+import { getBaseUrl } from "@/lib/utils";
 import { Code, Empty } from "@unkey/ui";
 import { redirect } from "next/navigation";
 import type Stripe from "stripe";
@@ -50,11 +51,11 @@ export default async function StripeRedirect() {
     );
   }
 
-  const baseUrl = process.env.VERCEL
-    ? process.env.VERCEL_TARGET_ENV === "production"
-      ? "https://app.unkey.com"
-      : `https://${process.env.VERCEL_URL}`
-    : "http://localhost:3000";
+  // Use the shared `getBaseUrl()` helper so previews resolve to the stable
+  // VERCEL_BRANCH_URL (e.g. dashboard-git-<branch>-unkey.vercel.app) rather
+  // than a deployment-specific VERCEL_URL that changes on every push and
+  // breaks links the user already has open.
+  const baseUrl = getBaseUrl();
 
   if (!ws.stripeCustomerId) {
     return (

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/stripe/portal/page.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/stripe/portal/page.tsx
@@ -69,9 +69,14 @@ export default async function StripeRedirect() {
     );
   }
 
+  // Return the user back to the workspace's billing page. /success is the
+  // post-checkout landing page and isn't the right destination for the
+  // billing-portal round-trip — it has no `session_id` here, so it shows an
+  // empty state, and (depending on auth state after the Stripe round-trip)
+  // can bounce the user to sign-in.
   const { url } = await stripe.billingPortal.sessions.create({
     customer: ws.stripeCustomerId,
-    return_url: `${baseUrl}/success`,
+    return_url: `${baseUrl}/${ws.slug}/settings/billing`,
   });
   return redirect(url);
 }

--- a/web/apps/dashboard/app/auth/actions.ts
+++ b/web/apps/dashboard/app/auth/actions.ts
@@ -296,6 +296,12 @@ export async function signIntoWorkspace(orgId: string): Promise<VerificationResu
     };
   }
 
+  // `redirect()` works by throwing a NEXT_REDIRECT error that the framework
+  // catches at the boundary. Keep it OUTSIDE the try/catch — otherwise our
+  // catch swallows the redirect, leaves the user on the previous page with
+  // their session cookie set, and surfaces the framework's internal
+  // "NEXT_REDIRECT;..." digest as an error message.
+  let redirectTo: string | null = null;
   try {
     const result = await auth.completeOrgSelection({
       orgId,
@@ -305,10 +311,10 @@ export async function signIntoWorkspace(orgId: string): Promise<VerificationResu
     if (result.success) {
       await setCookies(result.cookies);
       await deleteCookie(PENDING_SESSION_COOKIE);
-      redirect(result.redirectTo);
+      redirectTo = result.redirectTo;
+    } else {
+      return result;
     }
-
-    return result;
   } catch (error) {
     return {
       success: false,
@@ -316,6 +322,7 @@ export async function signIntoWorkspace(orgId: string): Promise<VerificationResu
       message: error instanceof Error ? error.message : "Unknown error occurred",
     };
   }
+  redirect(redirectTo);
 }
 
 // OAuth
@@ -324,15 +331,18 @@ export async function signInViaOAuth(options: SignInViaOAuthOptions): Promise<st
 }
 
 export async function completeOAuthSignIn(request: Request): Promise<OAuthResult> {
+  // See note in signIntoWorkspace — keep redirect() outside the try/catch so
+  // the NEXT_REDIRECT error is not swallowed.
+  let redirectTo: string | null = null;
   try {
     const result = await auth.completeOAuthSignIn(request);
 
     if (result.success) {
       await setCookies(result.cookies);
-      redirect(result.redirectTo);
+      redirectTo = result.redirectTo;
+    } else {
+      return result;
     }
-
-    return result;
   } catch (error) {
     return {
       success: false,
@@ -340,6 +350,7 @@ export async function completeOAuthSignIn(request: Request): Promise<OAuthResult
       message: error instanceof Error ? error.message : "Unknown error occurred",
     };
   }
+  redirect(redirectTo);
 }
 
 // Organization Selection

--- a/web/apps/dashboard/app/react-query-provider.tsx
+++ b/web/apps/dashboard/app/react-query-provider.tsx
@@ -14,12 +14,19 @@ export const ReactQueryProvider: React.FC<PropsWithChildren> = ({ children }) =>
       return "";
     }
 
-    if (process.env.VERCEL_URL) {
-      // reference for vercel.com
+    // Production: VERCEL_URL is the custom domain (app.unkey.com).
+    // Preview: prefer VERCEL_BRANCH_URL (stable across deploys of the same
+    // branch) so links and redirects remain valid between deployments.
+    // Otherwise fall back to VERCEL_URL or localhost.
+    if (process.env.VERCEL_ENV === "production" && process.env.VERCEL_URL) {
       return `https://${process.env.VERCEL_URL}`;
     }
-
-    // assume localhost
+    if (process.env.VERCEL_BRANCH_URL) {
+      return `https://${process.env.VERCEL_BRANCH_URL}`;
+    }
+    if (process.env.VERCEL_URL) {
+      return `https://${process.env.VERCEL_URL}`;
+    }
     return `http://localhost:${process.env.PORT ?? 3000}`;
   }
 

--- a/web/apps/dashboard/app/success/page.tsx
+++ b/web/apps/dashboard/app/success/page.tsx
@@ -99,18 +99,24 @@ function SuccessContent() {
           return;
         }
 
-        // Get customer details
+        // Get customer details. We pass sessionId so the server can verify
+        // that the session (and therefore the customer) belongs to this
+        // workspace via session.client_reference_id, rather than trusting a
+        // client-supplied customer id.
         const customer = await trpcUtils.stripe.getCustomer.fetch({
-          customerId: sessionResponse.customer,
+          sessionId,
         });
 
         if (!isMounted) {
           return;
         }
 
-        // Get setup intent details
+        // Get setup intent details. Pass sessionId so the server can verify
+        // the setup intent belongs to a session bound to this workspace,
+        // before the workspace has a stripeCustomerId of its own.
         const setupIntent = await trpcUtils.stripe.getSetupIntent.fetch({
           setupIntentId: sessionResponse.setup_intent,
+          sessionId,
         });
 
         if (!isMounted) {
@@ -152,10 +158,13 @@ function SuccessContent() {
           return;
         }
 
-        // Update workspace with stripe customer ID
+        // Update workspace with stripe customer ID. The mutation resolves the
+        // customer id from the checkout session server-side and verifies the
+        // session belongs to this workspace, so we pass sessionId instead of
+        // a client-supplied stripeCustomerId.
         try {
           await updateWorkspaceFn({
-            stripeCustomerId: customer.id,
+            sessionId,
           });
 
           if (!isMounted) {

--- a/web/apps/dashboard/lib/trpc/routers/github.ts
+++ b/web/apps/dashboard/lib/trpc/routers/github.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import { and, db, eq, schema } from "@/lib/db";
 import { githubAppEnv } from "@/lib/env";
 import {
@@ -16,10 +17,84 @@ import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { t, workspaceProcedure } from "../trpc";
 
-const state = z.object({
+const STATE_TTL_MS = 15 * 60 * 1000;
+
+// State payload signed and handed to GitHub's install URL. The signature
+// binds the state to a specific user + workspace + project so the callback
+// cannot be replayed across sessions or used by an attacker who phishes
+// a logged-in victim into hitting /integrations/github/callback?state=...
+const signedStatePayload = z.object({
   projectId: z.string().min(1),
   returnTo: z.enum(["settings"]).optional(),
+  workspaceId: z.string().min(1),
+  userId: z.string().min(1),
+  nonce: z.string().min(1),
+  exp: z.number().int().positive(),
 });
+
+const signedState = signedStatePayload.extend({ sig: z.string().min(1) });
+
+type SignedStatePayload = z.infer<typeof signedStatePayload>;
+
+const stateSigningKey = (): Buffer | null => {
+  const env = githubAppEnv();
+  if (!env) {
+    return null;
+  }
+  // The GitHub App's RSA private key already exists as a long-lived server
+  // secret; derive a separate HMAC key from it so the signing key never
+  // leaves the server and rotates with the GitHub App credentials.
+  return crypto
+    .createHash("sha256")
+    .update(`unkey-github-install-state:${env.UNKEY_GITHUB_PRIVATE_KEY_PEM}`)
+    .digest();
+};
+
+const stableStringify = (payload: SignedStatePayload): string =>
+  JSON.stringify(payload, Object.keys(payload).sort());
+
+const signState = (payload: SignedStatePayload): string => {
+  const key = stateSigningKey();
+  if (!key) {
+    throw new TRPCError({
+      code: "INTERNAL_SERVER_ERROR",
+      message: "GitHub App not configured",
+    });
+  }
+  const sig = crypto.createHmac("sha256", key).update(stableStringify(payload)).digest("base64url");
+  return JSON.stringify({ ...payload, sig });
+};
+
+const verifyState = (raw: string): SignedStatePayload | null => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  const result = signedState.safeParse(parsed);
+  if (!result.success) {
+    return null;
+  }
+  const { sig, ...payload } = result.data;
+  const key = stateSigningKey();
+  if (!key) {
+    return null;
+  }
+  const expected = crypto
+    .createHmac("sha256", key)
+    .update(stableStringify(payload))
+    .digest("base64url");
+  const a = Buffer.from(sig);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length || !crypto.timingSafeEqual(a, b)) {
+    return null;
+  }
+  if (payload.exp < Date.now()) {
+    return null;
+  }
+  return payload;
+};
 
 const fetchGithubContext = async (workspaceId: string, projectId: string) => {
   const project = await db.query.projects
@@ -142,6 +217,48 @@ export const githubRouter = t.router({
     return { hasInstallation: Boolean(installation) };
   }),
 
+  prepareInstallation: workspaceProcedure
+    .input(
+      z.object({
+        projectId: z.string().min(1),
+        returnTo: z.enum(["settings"]).optional(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      if (!githubAppEnv()) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "GitHub App not configured",
+        });
+      }
+
+      // Verify the project belongs to the calling workspace before issuing a
+      // signed state. Without this, an attacker could mint a state for an
+      // arbitrary project id.
+      const project = await db.query.projects.findFirst({
+        where: (table, { and, eq }) =>
+          and(eq(table.id, input.projectId), eq(table.workspaceId, ctx.workspace.id)),
+        columns: { id: true },
+      });
+      if (!project) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Project not found",
+        });
+      }
+
+      return {
+        state: signState({
+          projectId: input.projectId,
+          returnTo: input.returnTo,
+          workspaceId: ctx.workspace.id,
+          userId: ctx.user.id,
+          nonce: crypto.randomBytes(16).toString("base64url"),
+          exp: Date.now() + STATE_TTL_MS,
+        }),
+      };
+    }),
+
   registerInstallation: workspaceProcedure
     .input(
       z.object({
@@ -156,14 +273,20 @@ export const githubRouter = t.router({
           message: "GitHub App not configured",
         });
       }
-      let parsedState: z.infer<typeof state> | null = null;
-      try {
-        const result = state.safeParse(JSON.parse(input.state));
-        parsedState = result.success ? result.data : null;
-      } catch {
-        parsedState = null;
-      }
-      if (!parsedState) {
+
+      // The state must be a server-signed token bound to the calling user
+      // and workspace. This prevents two attacks:
+      //  1) An attacker claiming a victim's installation id (sequential
+      //     integers visible in webhooks/URLs) by forging a JSON state.
+      //  2) Phishing a logged-in victim into POSTing this mutation under
+      //     the attacker's chosen state — the userId/workspaceId binding
+      //     in the signature would not match the victim's session.
+      const parsedState = verifyState(input.state);
+      if (
+        !parsedState ||
+        parsedState.workspaceId !== ctx.workspace.id ||
+        parsedState.userId !== ctx.user.id
+      ) {
         throw new TRPCError({
           code: "BAD_REQUEST",
           message: "Invalid callback state",
@@ -171,6 +294,22 @@ export const githubRouter = t.router({
       }
 
       const projectId = parsedState.projectId;
+
+      // Refuse to bind the same installation id to multiple workspaces. An
+      // attacker who already owns a workspace could otherwise re-register a
+      // victim org's installation id under their workspace, and use the
+      // resulting Unkey-minted access token to read the victim's repos.
+      const existing = await db.query.githubAppInstallations.findFirst({
+        where: (table, { eq }) => eq(table.installationId, input.installationId),
+        columns: { workspaceId: true },
+      });
+      if (existing && existing.workspaceId !== ctx.workspace.id) {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message: "GitHub installation is already bound to another workspace",
+        });
+      }
+
       const projectInstallation = await fetchProjectInstallation(
         ctx.workspace.id,
         projectId,

--- a/web/apps/dashboard/lib/trpc/routers/identity/updateRatelimit.ts
+++ b/web/apps/dashboard/lib/trpc/routers/identity/updateRatelimit.ts
@@ -1,5 +1,5 @@
 import { type UnkeyAuditLog, insertAuditLogs } from "@/lib/audit";
-import { type Identity, db, eq, schema } from "@/lib/db";
+import { type Identity, and, db, eq, schema } from "@/lib/db";
 import { ratelimitSchema } from "@/lib/schemas/ratelimit";
 import { TRPCError } from "@trpc/server";
 import { newId } from "@unkey/id";
@@ -59,11 +59,20 @@ const updateRatelimitV2 = async (
   try {
     await db.transaction(async (tx) => {
       if (input.ratelimit.enabled && input.ratelimit.data.length > 0) {
-        // First, fetch existing ratelimits for this identity
+        // Scope the lookup by the verified identity AND workspace, so any
+        // subsequent UPDATE/DELETE that re-uses these ids cannot escape the
+        // caller's tenant boundary even if a future code change passes an
+        // unverified id through.
         const existingRatelimits = await tx
           .select()
           .from(schema.ratelimits)
-          .where(eq(schema.ratelimits.identityId, input.identityId));
+          .where(
+            and(
+              eq(schema.ratelimits.identityId, input.identityId),
+              eq(schema.ratelimits.workspaceId, ctx.workspaceId),
+            ),
+          );
+        const existingRatelimitIds = new Set(existingRatelimits.map((r) => r.id));
 
         const inputRatelimitIds = new Set(
           input.ratelimit.data.filter((r) => r.id).map((r) => r.id),
@@ -72,14 +81,30 @@ const updateRatelimitV2 = async (
         // Delete ratelimits that exist in DB but are not in the input (they were removed)
         for (const existing of existingRatelimits) {
           if (!inputRatelimitIds.has(existing.id)) {
-            await tx.delete(schema.ratelimits).where(eq(schema.ratelimits.id, existing.id));
+            await tx
+              .delete(schema.ratelimits)
+              .where(
+                and(
+                  eq(schema.ratelimits.id, existing.id),
+                  eq(schema.ratelimits.identityId, input.identityId),
+                  eq(schema.ratelimits.workspaceId, ctx.workspaceId),
+                ),
+              );
           }
         }
 
         // Update or insert each ratelimit sequentially
         for (const ratelimit of input.ratelimit.data) {
           if (ratelimit.id) {
-            // Update existing
+            // Reject any client-supplied id that isn't already bound to this
+            // identity. Without this, an attacker could pass another tenant's
+            // ratelimit id and rewrite its limit/duration/autoApply fields.
+            if (!existingRatelimitIds.has(ratelimit.id)) {
+              throw new TRPCError({
+                code: "NOT_FOUND",
+                message: "Ratelimit not found",
+              });
+            }
             await tx
               .update(schema.ratelimits)
               .set({
@@ -89,7 +114,13 @@ const updateRatelimitV2 = async (
                 updatedAt: Date.now(),
                 autoApply: ratelimit.autoApply,
               })
-              .where(eq(schema.ratelimits.id, ratelimit.id));
+              .where(
+                and(
+                  eq(schema.ratelimits.id, ratelimit.id),
+                  eq(schema.ratelimits.identityId, input.identityId),
+                  eq(schema.ratelimits.workspaceId, ctx.workspaceId),
+                ),
+              );
           } else {
             // Create new
             await tx.insert(schema.ratelimits).values({
@@ -112,7 +143,12 @@ const updateRatelimitV2 = async (
         // If rate limiting is disabled, remove all rate limit rules for this identity
         await tx
           .delete(schema.ratelimits)
-          .where(eq(schema.ratelimits.identityId, input.identityId));
+          .where(
+            and(
+              eq(schema.ratelimits.identityId, input.identityId),
+              eq(schema.ratelimits.workspaceId, ctx.workspaceId),
+            ),
+          );
       }
       const description = input.ratelimit.enabled
         ? `Updated rate limits for identity ${identity.id} (${input.ratelimit.data.length} rules)`

--- a/web/apps/dashboard/lib/trpc/routers/key/create.ts
+++ b/web/apps/dashboard/lib/trpc/routers/key/create.ts
@@ -80,6 +80,30 @@ export async function createKeyCore(
   ctx: CreateKeyContext,
   tx: DatabaseTransaction,
 ) {
+  // The keys.identity_id column has no FK or workspace predicate. If we
+  // accept a client-supplied identityId without verifying it belongs to this
+  // workspace, an attacker can later call /v2/keys.verifyKey on the key and
+  // exfiltrate the foreign identity's external_id and meta via the LEFT
+  // JOIN in key_find_for_verification.sql.
+  const requestedIdentityId = input.identityId;
+  if (requestedIdentityId) {
+    const identity = await tx.query.identities.findFirst({
+      where: (table, { and, eq }) =>
+        and(
+          eq(table.id, requestedIdentityId),
+          eq(table.workspaceId, ctx.workspace.id),
+          eq(table.deleted, false),
+        ),
+      columns: { id: true },
+    });
+    if (!identity) {
+      throw new TRPCError({
+        code: "NOT_FOUND",
+        message: "Identity not found",
+      });
+    }
+  }
+
   const keyId = newId("key");
   const { key, hash, start } = await newKey({
     prefix: input.prefix,

--- a/web/apps/dashboard/lib/trpc/routers/key/updateOwnerId.ts
+++ b/web/apps/dashboard/lib/trpc/routers/key/updateOwnerId.ts
@@ -187,6 +187,30 @@ const updateOwnerV2 = async (
     });
   }
 
+  // Verify the identity belongs to this workspace before binding any key to
+  // it. Without this, an attacker can rebind a key they own to an identity
+  // in another workspace and then leak that identity's external_id and meta
+  // through /v2/keys.verifyKey (the join in key_find_for_verification.sql
+  // has no workspace filter on the identities table).
+  const requestedIdentityId = input.identity.id;
+  if (requestedIdentityId) {
+    const identity = await db.query.identities.findFirst({
+      where: (table, { and, eq }) =>
+        and(
+          eq(table.id, requestedIdentityId),
+          eq(table.workspaceId, ctx.workspaceId),
+          eq(table.deleted, false),
+        ),
+      columns: { id: true },
+    });
+    if (!identity) {
+      throw new TRPCError({
+        code: "NOT_FOUND",
+        message: "Identity not found",
+      });
+    }
+  }
+
   try {
     await db.transaction(async (tx) => {
       await tx

--- a/web/apps/dashboard/lib/trpc/routers/key/updateRatelimit.ts
+++ b/web/apps/dashboard/lib/trpc/routers/key/updateRatelimit.ts
@@ -1,5 +1,5 @@
 import { type UnkeyAuditLog, insertAuditLogs } from "@/lib/audit";
-import { type Key, db, eq, schema } from "@/lib/db";
+import { type Key, and, db, eq, schema } from "@/lib/db";
 import { ratelimitSchema } from "@/lib/schemas/ratelimit";
 import { TRPCError } from "@trpc/server";
 import { newId } from "@unkey/id";
@@ -63,27 +63,53 @@ const updateRatelimitV2 = async (
   try {
     await db.transaction(async (tx) => {
       if (input.ratelimit.enabled && input.ratelimit.data.length > 0) {
-        // First, fetch existing ratelimits for this key
+        // Scope the existing-row lookup to the verified key AND workspace,
+        // so any subsequent UPDATE/DELETE that re-uses these ids is implicitly
+        // limited to rows the caller owns.
         const existingRatelimits = await tx
           .select()
           .from(schema.ratelimits)
-          .where(eq(schema.ratelimits.keyId, input.keyId));
+          .where(
+            and(
+              eq(schema.ratelimits.keyId, input.keyId),
+              eq(schema.ratelimits.workspaceId, ctx.workspaceId),
+            ),
+          );
+        const existingRatelimitIds = new Set(existingRatelimits.map((r) => r.id));
 
         const inputRatelimitIds = new Set(
           input.ratelimit.data.filter((r) => r.id).map((r) => r.id),
         );
 
-        // Delete ratelimits that exist in DB but are not in the input (they were removed)
+        // Delete ratelimits that exist in DB but are not in the input (they were removed).
+        // Filter by workspace + key to defend against any future code path that
+        // might pass an unverified id here.
         for (const existing of existingRatelimits) {
           if (!inputRatelimitIds.has(existing.id)) {
-            await tx.delete(schema.ratelimits).where(eq(schema.ratelimits.id, existing.id));
+            await tx
+              .delete(schema.ratelimits)
+              .where(
+                and(
+                  eq(schema.ratelimits.id, existing.id),
+                  eq(schema.ratelimits.keyId, input.keyId),
+                  eq(schema.ratelimits.workspaceId, ctx.workspaceId),
+                ),
+              );
           }
         }
 
         // Update or insert each ratelimit sequentially
         for (const ratelimit of input.ratelimit.data) {
           if (ratelimit.id) {
-            // Update existing
+            // Reject any client-supplied id that doesn't belong to this key.
+            // Without this, an attacker could pass a foreign workspace's
+            // ratelimit id and rewrite its limit/duration/autoApply fields.
+            if (!existingRatelimitIds.has(ratelimit.id)) {
+              throw new TRPCError({
+                code: "NOT_FOUND",
+                message: "Ratelimit not found",
+              });
+            }
             await tx
               .update(schema.ratelimits)
               .set({
@@ -93,7 +119,13 @@ const updateRatelimitV2 = async (
                 updatedAt: Date.now(),
                 autoApply: ratelimit.autoApply,
               })
-              .where(eq(schema.ratelimits.id, ratelimit.id));
+              .where(
+                and(
+                  eq(schema.ratelimits.id, ratelimit.id),
+                  eq(schema.ratelimits.keyId, input.keyId),
+                  eq(schema.ratelimits.workspaceId, ctx.workspaceId),
+                ),
+              );
           } else {
             // Create new
             await tx.insert(schema.ratelimits).values({
@@ -113,7 +145,14 @@ const updateRatelimitV2 = async (
         throw new Error("Rate limiting is enabled but no rules were provided");
       } else {
         // If rate limiting is disabled, remove all rate limit rules for this key
-        await tx.delete(schema.ratelimits).where(eq(schema.ratelimits.keyId, input.keyId));
+        await tx
+          .delete(schema.ratelimits)
+          .where(
+            and(
+              eq(schema.ratelimits.keyId, input.keyId),
+              eq(schema.ratelimits.workspaceId, ctx.workspaceId),
+            ),
+          );
       }
       const description = input.ratelimit.enabled
         ? `Updated rate limits for key ${key.id} (${input.ratelimit.data.length} rules)`

--- a/web/apps/dashboard/lib/trpc/routers/rbac.ts
+++ b/web/apps/dashboard/lib/trpc/routers/rbac.ts
@@ -100,7 +100,10 @@ export const rbacRouter = t.router({
       }
 
       const key = await db.query.keys.findFirst({
-        where: eq(schema.keys.forWorkspaceId, workspace.id) && eq(schema.keys.id, input.rootKeyId),
+        where: and(
+          eq(schema.keys.forWorkspaceId, workspace.id),
+          eq(schema.keys.id, input.rootKeyId),
+        ),
         with: {
           permissions: {
             with: {
@@ -127,6 +130,13 @@ export const rbacRouter = t.router({
       }
 
       await db.transaction(async (tx) => {
+        // keysPermissions rows are scoped to the key's owning workspace
+        // (`keys.workspaceId`), which for root keys is Unkey's internal
+        // workspace — not `workspace.id` (the customer's workspace, which
+        // appears as `keys.forWorkspaceId`). Use `permissionRelation.workspaceId`
+        // here so the DELETE matches the actual row. Cross-tenant safety
+        // is already enforced by the `forWorkspaceId === workspace.id` check
+        // on the `key` lookup above.
         await tx
           .delete(schema.keysPermissions)
           .where(

--- a/web/apps/dashboard/lib/trpc/routers/stripe/cancelSubscription.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/cancelSubscription.ts
@@ -1,29 +1,31 @@
 import { getStripeClient } from "@/lib/stripe";
 import { TRPCError } from "@trpc/server";
-import { workspaceProcedure } from "../../trpc";
+import { requireWorkspaceAdmin, workspaceProcedure } from "../../trpc";
 
-export const cancelSubscription = workspaceProcedure.mutation(async ({ ctx }) => {
-  const stripe = getStripeClient();
+export const cancelSubscription = workspaceProcedure
+  .use(requireWorkspaceAdmin)
+  .mutation(async ({ ctx }) => {
+    const stripe = getStripeClient();
 
-  if (!ctx.workspace.stripeCustomerId) {
-    throw new TRPCError({
-      code: "PRECONDITION_FAILED",
-      message: "Workspace doesn't have a stripe customer id.",
+    if (!ctx.workspace.stripeCustomerId) {
+      throw new TRPCError({
+        code: "PRECONDITION_FAILED",
+        message: "Workspace doesn't have a stripe customer id.",
+      });
+    }
+    if (!ctx.workspace.stripeSubscriptionId) {
+      throw new TRPCError({
+        code: "PRECONDITION_FAILED",
+        message: "Workspace doesn't have a stripe subscrption id.",
+      });
+    }
+
+    /**
+     * Stripe deletes the subscription at period end. The webhook handler for
+     * `customer.subscription.deleted` reverts tier/quotas and deactivates all non-creator
+     * memberships, so we don't need to block cancellation on member count here.
+     */
+    await stripe.subscriptions.update(ctx.workspace.stripeSubscriptionId, {
+      cancel_at_period_end: true,
     });
-  }
-  if (!ctx.workspace.stripeSubscriptionId) {
-    throw new TRPCError({
-      code: "PRECONDITION_FAILED",
-      message: "Workspace doesn't have a stripe subscrption id.",
-    });
-  }
-
-  /**
-   * Stripe deletes the subscription at period end. The webhook handler for
-   * `customer.subscription.deleted` reverts tier/quotas and deactivates all non-creator
-   * memberships, so we don't need to block cancellation on member count here.
-   */
-  await stripe.subscriptions.update(ctx.workspace.stripeSubscriptionId, {
-    cancel_at_period_end: true,
   });
-});

--- a/web/apps/dashboard/lib/trpc/routers/stripe/createSubscription.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/createSubscription.ts
@@ -7,10 +7,11 @@ import { invalidateWorkspaceCache } from "@/lib/workspace-cache";
 import { TRPCError } from "@trpc/server";
 import Stripe from "stripe";
 import { z } from "zod";
-import { workspaceProcedure } from "../../trpc";
+import { requireWorkspaceAdmin, workspaceProcedure } from "../../trpc";
 import { clearWorkspaceCache } from "../workspace/getCurrent";
 
 export const createSubscription = workspaceProcedure
+  .use(requireWorkspaceAdmin)
   .input(
     z.object({
       productId: z.string(),
@@ -23,6 +24,22 @@ export const createSubscription = workspaceProcedure
       throw new TRPCError({
         code: "INTERNAL_SERVER_ERROR",
         message: "Stripe is not set up",
+      });
+    }
+
+    // Reject any product that is not on the configured allow-list, so a
+    // workspace admin can only subscribe to plans the operator has explicitly
+    // exposed. Without this, a known/internal Stripe product id with $0
+    // default price (or permissive quota metadata) lets an admin self-grant
+    // a higher tier.
+    const allowedProductIds = new Set<string>([
+      ...e.STRIPE_PRODUCT_IDS_PRO,
+      ...e.STRIPE_PRODUCT_IDS_ENTERPRISE,
+    ]);
+    if (!allowedProductIds.has(input.productId)) {
+      throw new TRPCError({
+        code: "NOT_FOUND",
+        message: `Could not find product ${input.productId}.`,
       });
     }
 

--- a/web/apps/dashboard/lib/trpc/routers/stripe/getCheckoutSession.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/getCheckoutSession.ts
@@ -21,13 +21,26 @@ export const getCheckoutSession = workspaceProcedure
     }),
   )
   .output(checkoutSessionSchema)
-  .query(async ({ input }) => {
+  .query(async ({ ctx, input }) => {
     const stripe = getStripeClient();
 
     try {
       const session = await stripe.checkout.sessions.retrieve(input.sessionId);
 
       if (!session) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Checkout session not found",
+        });
+      }
+
+      // Sessions for billing are created with `client_reference_id` set to the
+      // workspace id. Reject if the session was created for a different
+      // workspace — otherwise an attacker can phish a victim into hitting
+      // /success?session_id=<attacker_session> while logged in, leaking the
+      // attacker's customer id to the victim's UI and triggering downstream
+      // workspace mutations.
+      if (session.client_reference_id !== ctx.workspace.id) {
         throw new TRPCError({
           code: "NOT_FOUND",
           message: "Checkout session not found",

--- a/web/apps/dashboard/lib/trpc/routers/stripe/getCustomer.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/getCustomer.ts
@@ -20,15 +20,51 @@ export const getCustomer = workspaceProcedure
   .use(withRatelimit(ratelimit.read))
   .input(
     z.object({
-      customerId: z.string(),
+      // Either an already-bound workspace customer id, or a checkout session
+      // id whose `client_reference_id` matches this workspace. Customer ids
+      // are not secret, so we never trust a raw input — we always verify the
+      // customer is one this workspace is allowed to read.
+      customerId: z.string().optional(),
+      sessionId: z.string().optional(),
     }),
   )
   .output(customerSchema)
-  .query(async ({ input }) => {
+  .query(async ({ ctx, input }) => {
     const stripe = getStripeClient();
 
+    let resolvedCustomerId: string | null = null;
+
+    if (input.sessionId) {
+      const session = await stripe.checkout.sessions.retrieve(input.sessionId);
+      if (!session || session.client_reference_id !== ctx.workspace.id) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Customer not found",
+        });
+      }
+      resolvedCustomerId =
+        typeof session.customer === "string"
+          ? session.customer
+          : (session.customer?.id ?? null);
+    } else if (input.customerId && ctx.workspace.stripeCustomerId) {
+      if (input.customerId !== ctx.workspace.stripeCustomerId) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Customer not found",
+        });
+      }
+      resolvedCustomerId = input.customerId;
+    }
+
+    if (!resolvedCustomerId) {
+      throw new TRPCError({
+        code: "NOT_FOUND",
+        message: "Customer not found",
+      });
+    }
+
     try {
-      const customer = await stripe.customers.retrieve(input.customerId);
+      const customer = await stripe.customers.retrieve(resolvedCustomerId);
 
       if (customer.deleted) {
         throw new TRPCError({

--- a/web/apps/dashboard/lib/trpc/routers/stripe/getSetupIntent.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/getSetupIntent.ts
@@ -18,14 +18,61 @@ export const getSetupIntent = workspaceProcedure
   .input(
     z.object({
       setupIntentId: z.string(),
+      // Optional sessionId path: needed for the post-checkout flow where the
+      // workspace doesn't yet have a stripeCustomerId. The session must
+      // belong to this workspace and reference the same setup intent.
+      sessionId: z.string().optional(),
     }),
   )
   .output(setupIntentSchema)
-  .query(async ({ input }) => {
+  .query(async ({ ctx, input }) => {
     const stripe = getStripeClient();
+
+    let allowedCustomerId: string | null = null;
+
+    if (input.sessionId) {
+      const session = await stripe.checkout.sessions.retrieve(input.sessionId);
+      if (
+        !session ||
+        session.client_reference_id !== ctx.workspace.id ||
+        (typeof session.setup_intent === "string"
+          ? session.setup_intent
+          : session.setup_intent?.id) !== input.setupIntentId
+      ) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Setup intent not found",
+        });
+      }
+      allowedCustomerId =
+        typeof session.customer === "string"
+          ? session.customer
+          : (session.customer?.id ?? null);
+    } else if (ctx.workspace.stripeCustomerId) {
+      allowedCustomerId = ctx.workspace.stripeCustomerId;
+    }
+
+    if (!allowedCustomerId) {
+      throw new TRPCError({
+        code: "NOT_FOUND",
+        message: "Setup intent not found",
+      });
+    }
 
     try {
       const setupIntent = await stripe.setupIntents.retrieve(input.setupIntentId);
+
+      const setupIntentCustomerId =
+        typeof setupIntent.customer === "string"
+          ? setupIntent.customer
+          : (setupIntent.customer?.id ?? null);
+
+      if (setupIntentCustomerId !== allowedCustomerId) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Setup intent not found",
+        });
+      }
 
       // Extract payment method ID, handling both string and expanded object
       let paymentMethodId: string | null = null;

--- a/web/apps/dashboard/lib/trpc/routers/stripe/uncancelSubscription.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/uncancelSubscription.ts
@@ -1,24 +1,26 @@
 import { getStripeClient } from "@/lib/stripe";
 import { TRPCError } from "@trpc/server";
-import { workspaceProcedure } from "../../trpc";
+import { requireWorkspaceAdmin, workspaceProcedure } from "../../trpc";
 
-export const uncancelSubscription = workspaceProcedure.mutation(async ({ ctx }) => {
-  const stripe = getStripeClient();
+export const uncancelSubscription = workspaceProcedure
+  .use(requireWorkspaceAdmin)
+  .mutation(async ({ ctx }) => {
+    const stripe = getStripeClient();
 
-  if (!ctx.workspace.stripeCustomerId) {
-    throw new TRPCError({
-      code: "PRECONDITION_FAILED",
-      message: "Workspace doesn't have a stripe customer id.",
+    if (!ctx.workspace.stripeCustomerId) {
+      throw new TRPCError({
+        code: "PRECONDITION_FAILED",
+        message: "Workspace doesn't have a stripe customer id.",
+      });
+    }
+    if (!ctx.workspace.stripeSubscriptionId) {
+      throw new TRPCError({
+        code: "PRECONDITION_FAILED",
+        message: "Workspace doesn't have a stripe subscrption id.",
+      });
+    }
+
+    await stripe.subscriptions.update(ctx.workspace.stripeSubscriptionId, {
+      cancel_at_period_end: false,
     });
-  }
-  if (!ctx.workspace.stripeSubscriptionId) {
-    throw new TRPCError({
-      code: "PRECONDITION_FAILED",
-      message: "Workspace doesn't have a stripe subscrption id.",
-    });
-  }
-
-  await stripe.subscriptions.update(ctx.workspace.stripeSubscriptionId, {
-    cancel_at_period_end: false,
   });
-});

--- a/web/apps/dashboard/lib/trpc/routers/stripe/updateSubscription.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/updateSubscription.ts
@@ -1,22 +1,45 @@
 import { insertAuditLogs } from "@/lib/audit";
 import { db, eq, schema } from "@/lib/db";
+import { stripeEnv } from "@/lib/env";
 import { getStripeClient } from "@/lib/stripe";
 import { validateAndParseQuotas } from "@/lib/stripe/productUtils";
 import { invalidateWorkspaceCache } from "@/lib/workspace-cache";
 import { TRPCError } from "@trpc/server";
 import Stripe from "stripe";
 import { z } from "zod";
-import { workspaceProcedure } from "../../trpc";
+import { requireWorkspaceAdmin, workspaceProcedure } from "../../trpc";
 
 export const updateSubscription = workspaceProcedure
+  .use(requireWorkspaceAdmin)
   .input(
     z.object({
-      oldProductId: z.string(),
       newProductId: z.string(),
     }),
   )
   .mutation(async ({ ctx, input }) => {
     const stripe = getStripeClient();
+    const e = stripeEnv();
+    if (!e) {
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: "Stripe is not set up",
+      });
+    }
+
+    // Reject any product not on the configured allow-list. Without this,
+    // an admin can switch the workspace to any product in the connected
+    // Stripe account — including test/internal products with $0 prices or
+    // permissive quota metadata.
+    const allowedProductIds = new Set<string>([
+      ...e.STRIPE_PRODUCT_IDS_PRO,
+      ...e.STRIPE_PRODUCT_IDS_ENTERPRISE,
+    ]);
+    if (!allowedProductIds.has(input.newProductId)) {
+      throw new TRPCError({
+        code: "NOT_FOUND",
+        message: `Could not find product ${input.newProductId}.`,
+      });
+    }
 
     if (!ctx.workspace.stripeCustomerId) {
       throw new TRPCError({
@@ -31,17 +54,7 @@ export const updateSubscription = workspaceProcedure
       });
     }
 
-    const [oldProduct, newProduct] = await Promise.all([
-      stripe.products.retrieve(input.oldProductId),
-      stripe.products.retrieve(input.newProductId),
-    ]);
-
-    if (!oldProduct) {
-      throw new TRPCError({
-        code: "NOT_FOUND",
-        message: `Could not find product ${input.oldProductId}.`,
-      });
-    }
+    const newProduct = await stripe.products.retrieve(input.newProductId);
 
     if (!newProduct) {
       throw new TRPCError({
@@ -72,15 +85,15 @@ export const updateSubscription = workspaceProcedure
       });
     }
 
-    const item = sub.items.data.find((i) => {
-      const product = i.plan.product;
-      return product && product.toString() === oldProduct.id;
-    });
+    // Derive the current subscription item from the existing subscription
+    // rather than trusting a client-supplied `oldProductId`. The client should
+    // not be able to influence which item gets repriced.
+    const item = sub.items.data[0];
 
     if (!item) {
       throw new TRPCError({
         code: "PRECONDITION_FAILED",
-        message: `You're not currently subscribed to ${oldProduct.id}.`,
+        message: "Subscription has no items to update.",
       });
     }
 

--- a/web/apps/dashboard/lib/trpc/routers/stripe/updateWorkspace.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/updateWorkspace.ts
@@ -1,5 +1,6 @@
 import { insertAuditLogs } from "@/lib/audit";
 import { db, eq, schema } from "@/lib/db";
+import { getStripeClient } from "@/lib/stripe";
 import { invalidateWorkspaceCache } from "@/lib/workspace-cache";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
@@ -9,16 +10,47 @@ import { clearWorkspaceCache } from "../workspace/getCurrent";
 export const updateWorkspaceStripeCustomer = workspaceProcedure
   .input(
     z.object({
-      stripeCustomerId: z.string().min(1, "Stripe customer ID is required"),
+      sessionId: z.string().min(1, "Stripe checkout session ID is required"),
     }),
   )
   .mutation(async ({ ctx, input }) => {
+    const stripe = getStripeClient();
+
+    // Resolve customer id server-side from the checkout session, and verify
+    // the session was created for this workspace. This prevents an attacker
+    // from tricking a logged-in user into binding the attacker's Stripe
+    // customer to the victim's workspace via a /success?session_id=... link.
+    const session = await stripe.checkout.sessions.retrieve(input.sessionId);
+    if (!session) {
+      throw new TRPCError({
+        code: "NOT_FOUND",
+        message: "Checkout session not found",
+      });
+    }
+    if (session.client_reference_id !== ctx.workspace.id) {
+      throw new TRPCError({
+        code: "FORBIDDEN",
+        message: "Checkout session does not belong to this workspace",
+      });
+    }
+
+    const stripeCustomerId =
+      typeof session.customer === "string"
+        ? session.customer
+        : (session.customer?.id ?? null);
+    if (!stripeCustomerId) {
+      throw new TRPCError({
+        code: "PRECONDITION_FAILED",
+        message: "Checkout session does not have a customer",
+      });
+    }
+
     await db
       .transaction(async (tx) => {
         await tx
           .update(schema.workspaces)
           .set({
-            stripeCustomerId: input.stripeCustomerId,
+            stripeCustomerId,
           })
           .where(eq(schema.workspaces.id, ctx.workspace.id));
 

--- a/web/apps/dashboard/lib/trpc/routers/vercel.ts
+++ b/web/apps/dashboard/lib/trpc/routers/vercel.ts
@@ -622,12 +622,35 @@ export const vercelRouter = t.router({
         teamId: integration.vercelTeamId ?? undefined,
       });
 
+      // Scope by integrationId so we can never mutate a binding that lives
+      // under a different (victim) integration. Filtering only by the
+      // user-supplied projectId previously allowed an attacker who knew a
+      // foreign Vercel project id (visible in deployment URLs and build
+      // logs) to soft-delete the victim's bindings while the actual env var
+      // remained live in Vercel.
       const bindings = await db.query.vercelBindings.findMany({
-        where: and(eq(schema.vercelBindings.projectId, input.projectId)),
+        where: and(
+          eq(schema.vercelBindings.projectId, input.projectId),
+          eq(schema.vercelBindings.integrationId, integration.id),
+        ),
       });
 
       for (const binding of bindings) {
-        await vercel.removeEnvironmentVariable(binding.projectId, binding.vercelEnvId);
+        const result = await vercel.removeEnvironmentVariable(
+          binding.projectId,
+          binding.vercelEnvId,
+        );
+        if (result.err) {
+          // Surface upstream Vercel failures rather than silently soft-deleting
+          // a binding row whose remote env var is still live. The Vercel SDK
+          // returns Result<void, FetchError> and never throws, so without this
+          // check the audit log would record success while the env var
+          // remained in place.
+          throw new TRPCError({
+            code: "INTERNAL_SERVER_ERROR",
+            message: `Failed to remove Vercel environment variable: ${result.err.message}`,
+          });
+        }
         await db.transaction(async (tx) => {
           await tx
             .update(schema.vercelBindings)

--- a/web/apps/dashboard/lib/trpc/trpc.ts
+++ b/web/apps/dashboard/lib/trpc/trpc.ts
@@ -304,6 +304,25 @@ export const requireOrgAdmin = t.middleware(async ({ next, ctx, rawInput }) => {
   }
 });
 
+/**
+ * Middleware: Requires the caller to be an admin of the workspace's tenant.
+ *
+ * Unlike `requireOrgAdmin`, this does not require the caller to pass an
+ * `orgId` field in the input — the workspaceProcedure has already verified
+ * the workspace belongs to `ctx.tenant`, so the role check on `ctx.tenant`
+ * is sufficient. Use this for billing and other workspace-scoped admin-only
+ * mutations where adding `orgId` to the input shape would be awkward.
+ */
+export const requireWorkspaceAdmin = t.middleware(({ next, ctx }) => {
+  if (ctx.tenant?.role !== "admin") {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "This action requires admin privileges.",
+    });
+  }
+  return next();
+});
+
 // =============================================================================
 // RATE LIMITING
 // =============================================================================

--- a/web/apps/dashboard/proxy.ts
+++ b/web/apps/dashboard/proxy.ts
@@ -40,7 +40,11 @@ export default async function proxy(req: NextRequest, _evt: NextFetchEvent) {
     "/api/auth/refresh",
     "/success",
     "/_next/*",
-    "/integrations/github/callback",
+    // /integrations/github/callback is intentionally NOT public: the page
+    // calls trpc.github.registerInstallation under the user's session, and
+    // marking it public would let an unauthenticated visitor reach the page
+    // with a phishing-friendly URL. The page now requires an authenticated
+    // session and verifies a server-signed `state` HMAC.
     "/integrations/domain-connect/callback",
   ];
 


### PR DESCRIPTION
## What does this PR do?

This fixes HIGH issues that were found by Vercel's tool.

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

1. Auth flows — app/auth/actions.ts

  The redirect-in-try-catch change is auth-critical; test both success and failure.

  1a. Org selection success (happy path)

  - Sign in with an account that belongs to multiple orgs (forces signIntoWorkspace).
  - Pick an org.
  - Expected: redirected to the org's apis page; URL bar changes; no toast.
  - Regression sentinel: if you see a toast like NEXT_REDIRECT;replace;/... you've reintroduced the bug.

  1b. Org selection failure

  - Sign in, then on the org-picker page, manually call signIntoWorkspace("ws_invalid") via DevTools.
  - Expected: clean error toast, no redirect, no leaked NEXT_REDIRECT string.

  1c. OAuth (Google/GitHub) sign-in

  - Sign in via OAuth on a fresh browser profile.
  - Expected: lands on apis page; cookies set.
  - Repeat with an account that requires email verification → expect the email-verification flow (no redirect).
  - Repeat with an account that requires org selection → expect org-picker (no redirect).

  1d. Single-org sign-in (regression)

  - Sign in with an account that has only one org (auth flow that doesn't hit signIntoWorkspace).
  - Expected: unchanged behavior.

  ---
  2. Billing (stripe/*, requireWorkspaceAdmin, success page)

  Use Stripe test mode. Create at least one allow-listed Pro product and one non-allowlisted product to test rejection.

  2a. Admin can create subscription

  - As a workspace admin, click an upgrade button → Stripe Checkout → complete with 4242 4242 4242 4242.
  - Lands on /success?session_id=....
  - Expected: workspace tier updates; quotas row populated; redirect into the workspace.

  2b. Member is blocked

  - As a workspace member (non-admin), call trpc.stripe.createSubscription with any productId.
  - Expected: FORBIDDEN — This action requires admin privileges.
  - Repeat for updateSubscription. Same expected error.

  2c. Product allow-list

  - As an admin, call trpc.stripe.createSubscription({ productId: "prod_unknown" }).
  - Expected: NOT_FOUND — Could not find product prod_unknown. (rejected before Stripe is called).
  - Repeat with a real but non-allowlisted product id — same rejection.

  2d. updateSubscription no longer accepts oldProductId

  - The plan-selection modal no longer sends oldProductId. Switch plan as admin.
  - Expected: plan changes; Stripe subscription_items.update called on the existing item; tier in DB updates.

  2e. getCustomer IDOR

  - As workspace A, call trpc.stripe.getCustomer({ customerId: "<workspace-B-customer-id>" }).
  - Expected: NOT_FOUND.
  - Call trpc.stripe.getCustomer({ customerId: ctx.workspace.stripeCustomerId }) → expect customer details.
  - Call trpc.stripe.getCustomer({ sessionId: "<your-session>" }) (workspace pre-checkout) → expect customer details.
  - Call trpc.stripe.getCustomer({ sessionId: "<another-workspace's-session>" }) → expect NOT_FOUND.

  2f. getSetupIntent IDOR

  - As workspace A, call getSetupIntent({ setupIntentId: "<workspace-B-setup-intent>" }) → expect NOT_FOUND.
  - Pre-checkout (no stripeCustomerId yet): call with sessionId matching your own → expect ok.
  - Same call with a foreign sessionId → expect NOT_FOUND.

  2g. getCheckoutSession scope

  - As workspace A, call getCheckoutSession({ sessionId: "<workspace-B-session>" }) → expect NOT_FOUND.

  2h. updateWorkspaceStripeCustomer hijack

  - Cannot call this with raw stripeCustomerId anymore — schema rejects it.
  - Phishing repro: as workspace A, complete checkout, copy the session_id from the URL. Open /success?session_id=<that_id> while signed in as workspace B.
  - Expected: getCheckoutSession errors out (client_reference_id mismatch). Workspace B's stripeCustomerId is unchanged. Verify in DB.

  2i. First-time customer setup still works

  - Brand new workspace, never had a Stripe customer. Run the full checkout → /success flow.
  - Expected: customer created on Stripe; setup intent's payment method attached; workspace's stripeCustomerId populated; subscription can be created afterwards.

  ---
  3. RBAC (rbac.ts)

  3a. Add and remove permission on a root key (your own)

  - In /settings/root-keys, add a permission to a root key.
  - Remove the same permission.
  - Expected: both succeed; the row in keys_permissions is created/deleted.

  3b. Cross-tenant attempt

  - As workspace A, find a root key id from workspace B (e.g. by querying DB directly).
  - Call trpc.rbac.removePermissionFromRootKey({ rootKeyId: "<B's key>", permissionName: "..." }).
  - Expected: NOT_FOUND — key ... not found (was previously a successful cross-tenant delete).

  3c. Verify root-key audit log

  - Remove a permission and check the audit log for the root key.
  - Expected: entry exists with the correct workspaceId (the key's owning workspace, i.e. the same one where addPermissionToRootKey writes its log). Sanity check: this is not
  changed from main.

  ---
  4. Ratelimits (key/updateRatelimit.ts, identity/updateRatelimit.ts)

  Same shape for both — repeat for each.

  4a. Update existing ratelimits

  - Open a key/identity with 1+ existing ratelimits in the dashboard.
  - Edit a name and limit; save.
  - Expected: updated row shows new values.

  4b. Add a new ratelimit

  - Add a new ratelimit (no id) → save.
  - Expected: new row inserted, listed in UI.

  4c. Remove a ratelimit

  - Delete one rule from the form, save.
  - Expected: that row is deleted; others remain.

  4d. Disable ratelimits

  - Toggle off the enabled switch, save.
  - Expected: all ratelimits for the key/identity are deleted.

  4e. Cross-tenant attempt

  - As workspace A, find a rl_* id belonging to workspace B (DB query).
  - Call trpc.key.update.ratelimit({ keyId: "<your key>", ratelimit: { enabled: true, data: [{ id: "<B's rl_*>", limit: 1, refillInterval: 60000, name: "x" }] } }).
  - Expected: NOT_FOUND — Ratelimit not found. Workspace B's row is unchanged (verify in DB).
  - Repeat with trpc.identity.update.ratelimit.

  ---
  5. Keys + Identities (key/create.ts, key/updateOwnerId.ts)

  5a. Create key with a valid identity

  - In the API key creation form, attach an identity belonging to your workspace.
  - Expected: key created; keys.identity_id set.

  5b. Create key with a foreign identity

  - Call trpc.key.create with identityId: "<foreign identity>".
  - Expected: NOT_FOUND — Identity not found. Key not created.

  5c. Create key with no identity

  - Create a key with no identity at all.
  - Expected: works as before.

  5d. Rebind a key to a valid identity (updateOwnerId v2)

  - For a key in your workspace, change the identity to another in the same workspace.
  - Expected: updates.

  5e. Rebind to a foreign identity

  - Call trpc.key.update.ownerId with ownerType: "v2" and a foreign identity.id.
  - Expected: NOT_FOUND — Identity not found. Key's identityId unchanged.

  5f. v2 verifyKey downstream check

  - For a key bound to your own identity, hit /v2/keys.verifyKey.
  - Expected: identity meta returns correctly (no regression in the legitimate path).

  ---
  6. GitHub install flow (github.ts, install-URL components, callback page, proxy.ts)

  This is the highest-touch area — exercise every entry point.

  6a. Onboarding new project install

  - Go to /[workspace]/projects/new → connect-github step → click Import from GitHub.
  - Expected: brief loading, then redirect to https://github.com/apps/.../installations/new?state=.... The state is now URL-encoded JSON containing sig, nonce, exp, etc.
  (inspect with browser network tab before redirect).
  - Complete install on GitHub → redirected back to /integrations/github/callback?state=...&installation_id=... → autopost succeeds → land on select-repo step.

  6b. Settings install

  - Open a project → Settings → Build → GitHub → click Manage GitHub App (or the no-repo install button).
  - Expected: same signed-state flow → after install, returned to project settings.

  6c. Select-repo "add more" link

  - On the select-repo step, click "Can't find your repo? Add more from GitHub".
  - Expected: signed state minted, redirect to install URL.

  6d. Reused/replayed state

  - Capture a state value from your own install URL. Wait > 15 minutes (TTL). Try to use it on the callback URL.
  - Expected: BAD_REQUEST — Invalid callback state.

  6e. Cross-user state replay

  - User A captures a state from their install URL (still fresh).
  - User B logs in and visits /integrations/github/callback?state=<A's state>&installation_id=<any>.
  - Expected: BAD_REQUEST — Invalid callback state (signature is bound to A's userId/workspaceId).

  6f. Forged state

  - Hand-craft a state JSON ({projectId, workspaceId, userId, exp, nonce, sig: "x"}) and POST it.
  - Expected: BAD_REQUEST — Invalid callback state.

  6g. Same installation_id, different workspace

  - Workspace A registers installation 12345. Workspace B (different user) goes through their own flow but, in network tab, replace installation_id with 12345.
  - Expected: CONFLICT — GitHub installation is already bound to another workspace.

  6h. Public-paths change (proxy.ts)

  - Sign out completely. Visit /integrations/github/callback?state=...&installation_id=....
  - Expected: redirected to sign-in page (callback is no longer in publicPaths).
  - Sign in, navigate to that URL again → mutation runs.

  6i. Install with no repo connection

  - Install the app, but cancel before selecting a repo.
  - Expected: workspace gets the installation in github_app_installations; selectRepository still works.


  ---
  7. Cross-cutting regression sweeps

  7a. Audit log writes

  For each mutation you touched, verify an audit log entry still appears:
  - key.create, key.update (rename, identity change), ratelimit.update, vercelBinding.delete, authorization.disconnect_permission_and_key, workspace.update (subscription
  create/update).

  7b. Permission-denied UI

  - As a workspace member (non-admin), open Billing settings. Buttons that trigger createSubscription / updateSubscription should either be hidden or, on click, surface the
  new FORBIDDEN error cleanly.

  7c. Workspace cache invalidation

  - After billing changes, refresh the dashboard. Tier displayed should reflect new product immediately.

  7d. Sign-out/in cycle

  - After all changes, sign out and back in once.
  - Expected: clean. No leaked NEXT_REDIRECT digests anywhere.

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary
