### PR TITLE
feat(ui,dashboard): add links variant to empty state actions

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/components/deployments-card-list.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/components/deployments-card-list.tsx
@@ -2,7 +2,7 @@
 
 import { useWorkspaceNavigation } from "@/hooks/use-workspace-navigation";
 import { BookBookmark } from "@unkey/icons";
-import { Button, Empty } from "@unkey/ui";
+import { Empty, InlineLink } from "@unkey/ui";
 import { useProjectData } from "../../data-provider";
 import { useDeployments } from "../hooks/use-deployments";
 import { DeploymentRow } from "./deployment-row";
@@ -29,17 +29,15 @@ export function DeploymentsCardList() {
               There are no deployments yet. Push to your connected repository or trigger a manual
               deployment to get started.
             </Empty.Description>
-            <Empty.Actions className="mt-4 justify-start">
-              <a
+            <Empty.Actions variant="links">
+              <InlineLink
                 href="https://www.unkey.com/docs/build-and-deploy/deployments"
                 target="_blank"
                 rel="noopener noreferrer"
-              >
-                <Button size="md">
-                  <BookBookmark />
-                  Learn about Deployments
-                </Button>
-              </a>
+                label="Learn about Deployments"
+                icon={<BookBookmark />}
+                iconPosition="left"
+              />
             </Empty.Actions>
           </Empty>
         </div>

--- a/web/internal/ui/src/components/empty.tsx
+++ b/web/internal/ui/src/components/empty.tsx
@@ -3,6 +3,19 @@ import React from "react";
 import { cn } from "../lib/utils";
 import { Ufo } from "@unkey/icons";
 
+/**
+ * Empty state for lists, tables, and panels with no content yet.
+ *
+ * Composition:
+ *   Empty
+ *   ├── Empty.Icon
+ *   ├── Empty.Title
+ *   ├── Empty.Description
+ *   └── Empty.Actions (variant="buttons" | "links")
+ *
+ * Pick the actions variant based on whether a primary CTA already exists
+ * elsewhere on the page — see Empty.Actions for guidance.
+ */
 interface EmptyRootProps extends React.HTMLAttributes<HTMLDivElement> {}
 function Empty({ className, children, ...props }: EmptyRootProps) {
   return (
@@ -61,11 +74,35 @@ Empty.Description = function EmptyDescription({ className, ...props }: EmptyDesc
   );
 };
 
-type EmptyActionsProps = React.HTMLAttributes<HTMLDivElement>;
+type EmptyActionsProps = React.HTMLAttributes<HTMLDivElement> & {
+  /**
+   * Visual style of the actions slot.
+   * - `"buttons"` (default): horizontal row of one or two `<Button>`s. Use when the
+   *   empty state itself owns the primary CTA on the page.
+   * - `"links"`: vertical stack of low-weight `<InlineLink>`s sized to match the
+   *   description. Use when a primary CTA already exists elsewhere (e.g. a header
+   *   action) and the empty state should only offer secondary guidance — links to
+   *   docs or related pages — so it doesn't compete with that primary action.
+   */
+  variant?: "buttons" | "links";
+};
 
-Empty.Actions = function EmptyActions({ className, children, ...props }: EmptyActionsProps) {
+Empty.Actions = function EmptyActions({
+  className,
+  children,
+  variant = "buttons",
+  ...props
+}: EmptyActionsProps) {
   return (
-    <div className={cn("w-full flex items-center justify-center gap-4 mt-2", className)} {...props}>
+    <div
+      className={cn(
+        "w-full",
+        variant === "buttons" && "flex items-center justify-center gap-4 mt-2",
+        variant === "links" && "flex flex-col items-start gap-1.5 mt-3 text-[13px] leading-6",
+        className,
+      )}
+      {...props}
+    >
       {children}
     </div>
   );

--- a/web/internal/ui/src/components/inline-link.tsx
+++ b/web/internal/ui/src/components/inline-link.tsx
@@ -34,7 +34,11 @@ const InlineLink: React.FC<InlineLinkProps> = ({
   ...props
 }) => {
   return (
-    <a href={href} className={cn(className, "underline inline-flex hover:opacity-70")} {...props}>
+    <a
+      href={href}
+      className={cn(className, "underline underline-offset-2 inline-flex hover:opacity-70")}
+      {...props}
+    >
       <span className="inline-flex gap-x-1 items-center">
         {iconPosition === "left" && icon && <span aria-hidden="true">{icon}</span>}
         {label}


### PR DESCRIPTION
## What does this PR do?

Fixes DES-6

Adds a links variant to `Empty.Actions` for cases where the empty state should defer to a primary CTA elsewhere on the page. Apply it to the deployments empty state so the docs link no longer competes with the header's Create Deployment button.

## Screenshot

<!-- drop screenshot or video here -->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

1. Open a project with no deployments.
2. Confirm the docs CTA renders as an inline link below the description and no longer competes with the header's Create Deployment button.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary
