### PR TITLE
fix: linting errs

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/env-vars/components/list/env-var-edit-row.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/env-vars/components/list/env-var-edit-row.tsx
@@ -28,13 +28,7 @@ type EnvVarEditRowProps = {
   onClose: () => void;
 };
 
-export function EnvVarEditRow({
-  envVarId,
-  variableKey,
-  type,
-  note,
-  onClose,
-}: EnvVarEditRowProps) {
+export function EnvVarEditRow({ envVarId, variableKey, type, note, onClose }: EnvVarEditRowProps) {
   const decryptMutation = trpc.deploy.envVar.decrypt.useMutation();
 
   const isWriteonly = type === "writeonly";

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/env-vars/hooks/use-row-selection.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/env-vars/hooks/use-row-selection.ts
@@ -88,6 +88,7 @@ export function useRowSelection(displayRows: DisplayRow[]) {
 
   const makeSensitiveMutation = trpc.deploy.envVar.makeSensitive.useMutation();
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: mutateAsync is a stable reference from React Query
   const handleBulkMakeSensitive = useCallback(async () => {
     const ids = Array.from(selectedIds);
     if (ids.length === 0) {

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/sentinel-policies/components/add-panel/schema.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/sentinel-policies/components/add-panel/schema.ts
@@ -514,4 +514,3 @@ export function fromSentinelPolicy(
     }))
     .exhaustive();
 }
-


### PR DESCRIPTION
## What does this PR do?

Minor code cleanup and linting fixes across the env vars and sentinel policies areas:

- Collapsed multi-line destructured props into a single line in `EnvVarEditRow` for consistency
- Added a `biome-ignore` comment to suppress a false-positive exhaustive dependencies lint warning on `handleBulkMakeSensitive`, noting that `mutateAsync` is a stable reference from React Query
- Removed a trailing newline at the end of the sentinel policies `schema.ts` file

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Verify the env vars list renders and editing an env var row still works as expected
- Verify bulk "make sensitive" functionality still works correctly on selected env vars

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary