### PR TITLE
refactor(frontline): consolidate metrics into unified requests_total counter

### DIFF
--- a/svc/frontline/internal/metrics/BUILD.bazel
+++ b/svc/frontline/internal/metrics/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "metrics",
+    srcs = [
+        "doc.go",
+        "metrics.go",
+    ],
+    importpath = "github.com/unkeyed/unkey/svc/frontline/internal/metrics",
+    visibility = ["//svc/frontline:__subpackages__"],
+    deps = [
+        "//pkg/prometheus/lazy",
+        "@com_github_prometheus_client_golang//prometheus",
+    ],
+)

--- a/svc/frontline/internal/metrics/doc.go
+++ b/svc/frontline/internal/metrics/doc.go
@@ -1,0 +1,11 @@
+// Package metrics holds the cross-cutting per-request metrics frontline
+// emits from its observability middleware: a unified outcome counter
+// labelled by URN, and a saturation gauge.
+//
+// Subpackage-local metrics (routing decisions, upstream timing, hops, TLS
+// handshakes, etc.) live in the package that emits them, not here.
+//
+// Region and environment are external labels on the per-region Prometheus,
+// so queries can `sum by (region)` without paying the cardinality cost on
+// every emitted series.
+package metrics

--- a/svc/frontline/internal/metrics/metrics.go
+++ b/svc/frontline/internal/metrics/metrics.go
@@ -1,0 +1,59 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/unkeyed/unkey/pkg/prometheus/lazy"
+)
+
+// RequestsTotal is the unified per-request outcome counter. One row per
+// completed request, labelled by:
+//
+//	status_class 2xx | 3xx | 4xx | 5xx
+//	code         "" on success, the fault URN string on error
+//	             (e.g. err:unkey:not_found:config_not_found)
+//
+// `code != ""` is the success/error split — there is no separate outcome
+// label, the URN carries that bit. The URN is the high-fidelity error
+// identifier; alert routing classifies error categories by URN prefix.
+// region and environment are external labels on the per-region Prometheus
+// and are NOT carried as metric labels.
+var RequestsTotal = lazy.NewCounterVec(
+	prometheus.CounterOpts{
+		Namespace: "unkey",
+		Subsystem: "frontline",
+		Name:      "requests_total",
+		Help:      "Total requests by status class and fault code (URN).",
+	},
+	[]string{"status_class", "code"},
+)
+
+// InflightRequests is the per-pod count of in-flight requests. Incremented
+// on entry to the observability middleware and decremented on exit, so it
+// covers every routed path.
+//
+// Saturation signal: if the gauge climbs while traffic is steady, an
+// upstream got slow or frontline stalled. Pair with goroutine count for
+// triage — a leak shows up in both.
+var InflightRequests = lazy.NewGauge(
+	prometheus.GaugeOpts{
+		Namespace: "unkey",
+		Subsystem: "frontline",
+		Name:      "inflight_requests",
+		Help:      "Requests currently being processed.",
+	},
+)
+
+// StatusClass returns the HTTP status class label for a status code:
+// "2xx", "3xx", "4xx", or "5xx".
+func StatusClass(code int) string {
+	switch {
+	case code >= 500:
+		return "5xx"
+	case code >= 400:
+		return "4xx"
+	case code >= 300:
+		return "3xx"
+	default:
+		return "2xx"
+	}
+}

--- a/svc/frontline/internal/proxy/forward.go
+++ b/svc/frontline/internal/proxy/forward.go
@@ -3,15 +3,12 @@ package proxy
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
+	"net/http/httptrace"
 	"net/http/httputil"
 	"net/url"
-	"os"
-	"syscall"
 	"time"
 
 	"github.com/unkeyed/unkey/pkg/fault"
@@ -60,10 +57,27 @@ func (s *service) forward(ctx context.Context, sess *zen.Session, cfg forwardCon
 	wrapper := zen.NewErrorCapturingWriter(sess.ResponseWriter())
 
 	var backendStart time.Time
-	observeBackendDuration := func() {
-		if !backendStart.IsZero() {
-			proxyBackendDuration.WithLabelValues(cfg.destination).Observe(s.clock.Now().Sub(backendStart).Seconds())
+
+	// publishUpstream records the upstream call duration once per request.
+	// Idempotent: subsequent calls (e.g. ErrorHandler after ModifyResponse)
+	// are no-ops because backendStart resets to zero.
+	publishUpstream := func(end time.Time) {
+		if backendStart.IsZero() {
+			return
 		}
+		upstreamSeconds.WithLabelValues(cfg.destination).Observe(end.Sub(backendStart).Seconds())
+		backendStart = time.Time{}
+	}
+
+	// nolint:exhaustruct
+	clientTrace := &httptrace.ClientTrace{
+		ConnectDone: func(network, addr string, err error) {
+			outcome := dialOutcomeSuccess
+			if err != nil {
+				outcome = dialOutcomeError
+			}
+			upstreamDialsTotal.WithLabelValues(cfg.destination, outcome).Inc()
+		},
 	}
 
 	tracking, hasTracking := RequestTrackingFromContext(ctx)
@@ -83,16 +97,11 @@ func (s *service) forward(ctx context.Context, sess *zen.Session, cfg forwardCon
 			req.URL.Host = cfg.targetURL.Host
 
 			cfg.directorFunc(req)
+
+			*req = *req.WithContext(httptrace.WithClientTrace(req.Context(), clientTrace))
 		},
 		ModifyResponse: func(resp *http.Response) error {
-			observeBackendDuration()
-
-			// Both destinations stream upstream responses through unchanged.
-			// "instance" hits a customer pod; "region" hits a peer frontline
-			// that already wrote its own JSON/HTML error page via its
-			// observability middleware. We just record + pass through.
-			source := "upstream"
-			proxyBackendResponseTotal.WithLabelValues(cfg.destination, source, statusClass(resp.StatusCode)).Inc()
+			publishUpstream(s.clock.Now())
 
 			totalTime := s.clock.Now().Sub(cfg.startTime)
 			if !proxyStartTime.IsZero() {
@@ -123,7 +132,7 @@ func (s *service) forward(ctx context.Context, sess *zen.Session, cfg forwardCon
 			return nil
 		},
 		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
-			observeBackendDuration()
+			publishUpstream(s.clock.Now())
 
 			// Capture the error for middleware to handle
 			if ecw, ok := w.(*zen.ErrorCapturingWriter); ok {
@@ -139,7 +148,7 @@ func (s *service) forward(ctx context.Context, sess *zen.Session, cfg forwardCon
 	}
 
 	// Proxy the request with the middleware context (carries timeout deadline).
-	serveWithAbortRecovery(proxy, wrapper, sess.Request().WithContext(ctx), cfg.destination)
+	serveWithAbortRecovery(proxy, wrapper, sess.Request().WithContext(ctx))
 
 	// Mark the true end of the upstream interaction (full stream completed).
 	if hasTracking {
@@ -159,8 +168,6 @@ func (s *service) forward(ctx context.Context, sess *zen.Session, cfg forwardCon
 		if _, hasCode := fault.GetCode(err); hasCode {
 			return err
 		}
-		proxyForwardTotal.WithLabelValues(cfg.destination, categorizeProxyErrorType(err)).Inc()
-		proxyForwardErrorsTotal.WithLabelValues(cfg.destination).Inc()
 		urn, message := categorizeProxyError(err, cfg.destination)
 		return fault.Wrap(err,
 			fault.Code(urn),
@@ -169,40 +176,7 @@ func (s *service) forward(ctx context.Context, sess *zen.Session, cfg forwardCon
 		)
 	}
 
-	proxyForwardTotal.WithLabelValues(cfg.destination, "none").Inc()
-
 	return nil
-}
-
-// categorizeProxyErrorType returns a short label for the type of proxy error,
-// suitable for use as a prometheus label value.
-func categorizeProxyErrorType(err error) string {
-	if errors.Is(err, context.Canceled) {
-		return "client_canceled"
-	}
-	if errors.Is(err, context.DeadlineExceeded) || os.IsTimeout(err) {
-		return "timeout"
-	}
-
-	var netErr *net.OpError
-	if errors.As(err, &netErr) {
-		if netErr.Timeout() {
-			return "timeout"
-		}
-		if errors.Is(netErr.Err, syscall.ECONNREFUSED) {
-			return "conn_refused"
-		}
-		if errors.Is(netErr.Err, syscall.ECONNRESET) {
-			return "conn_reset"
-		}
-	}
-
-	var dnsErr *net.DNSError
-	if errors.As(err, &dnsErr) {
-		return "dns_failure"
-	}
-
-	return "other"
 }
 
 // serveWithAbortRecovery calls h.ServeHTTP and swallows http.ErrAbortHandler panics.
@@ -211,27 +185,18 @@ func categorizeProxyErrorType(err error) string {
 // There is no recovery path at that point — the panic is the library's signal that
 // the handler is aborting. Swallowing it keeps the global panic middleware strict
 // for real bugs; other panic values are re-raised unchanged.
-func serveWithAbortRecovery(h http.Handler, w http.ResponseWriter, r *http.Request, destination string) {
+//
+// Aborts after headers were already flushed render as ordinary 2xx successes
+// in requests_total — the response we committed to was just truncated.
+// Aborts before headers go through the proxy's ErrorHandler with a
+// User.BadRequest.ClientClosedRequest URN.
+func serveWithAbortRecovery(h http.Handler, w http.ResponseWriter, r *http.Request) {
 	defer func() {
 		if rec := recover(); rec != nil {
 			if rec != http.ErrAbortHandler {
 				panic(rec)
 			}
-			proxyAbortedTotal.WithLabelValues(destination).Inc()
 		}
 	}()
 	h.ServeHTTP(w, r)
-}
-
-func statusClass(code int) string {
-	switch {
-	case code >= 500:
-		return "5xx"
-	case code >= 400:
-		return "4xx"
-	case code >= 300:
-		return "3xx"
-	default:
-		return "2xx"
-	}
 }

--- a/svc/frontline/internal/proxy/forward.go
+++ b/svc/frontline/internal/proxy/forward.go
@@ -101,8 +101,6 @@ func (s *service) forward(ctx context.Context, sess *zen.Session, cfg forwardCon
 			*req = *req.WithContext(httptrace.WithClientTrace(req.Context(), clientTrace))
 		},
 		ModifyResponse: func(resp *http.Response) error {
-			publishUpstream(s.clock.Now())
-
 			totalTime := s.clock.Now().Sub(cfg.startTime)
 			if !proxyStartTime.IsZero() {
 				timing.Write(sess.ResponseWriter(), timing.Entry{
@@ -156,6 +154,11 @@ func (s *service) forward(ctx context.Context, sess *zen.Session, cfg forwardCon
 
 	// Proxy the request with the middleware context (carries timeout deadline).
 	serveWithAbortRecovery(proxy, wrapper, sess.Request().WithContext(ctx))
+
+	// Record upstream duration after the full response (including streaming
+	// body / WebSocket tunnel) has finished. Idempotent — if ErrorHandler
+	// already published from the pre-response failure path, this is a no-op.
+	publishUpstream(s.clock.Now())
 
 	// Mark the true end of the upstream interaction (full stream completed).
 	if hasTracking {

--- a/svc/frontline/internal/proxy/forward_test.go
+++ b/svc/frontline/internal/proxy/forward_test.go
@@ -18,7 +18,7 @@ func TestServeWithAbortRecovery_SwallowsErrAbortHandler(t *testing.T) {
 	r := httptest.NewRequest(http.MethodGet, "/", nil)
 
 	// Must not bubble up. If it does, the test process crashes.
-	serveWithAbortRecovery(h, w, r, "test")
+	serveWithAbortRecovery(h, w, r)
 }
 
 func TestServeWithAbortRecovery_RepanicsOtherValues(t *testing.T) {
@@ -42,7 +42,7 @@ func TestServeWithAbortRecovery_RepanicsOtherValues(t *testing.T) {
 		}
 	}()
 
-	serveWithAbortRecovery(h, w, r, "test")
+	serveWithAbortRecovery(h, w, r)
 }
 
 func TestServeWithAbortRecovery_NoPanicPassthrough(t *testing.T) {
@@ -57,7 +57,7 @@ func TestServeWithAbortRecovery_NoPanicPassthrough(t *testing.T) {
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodGet, "/", nil)
 
-	serveWithAbortRecovery(h, w, r, "test")
+	serveWithAbortRecovery(h, w, r)
 
 	if !called {
 		t.Fatal("handler was not invoked")

--- a/svc/frontline/internal/proxy/metrics.go
+++ b/svc/frontline/internal/proxy/metrics.go
@@ -5,103 +5,86 @@ import (
 	"github.com/unkeyed/unkey/pkg/prometheus/lazy"
 )
 
+// Destination labels distinguish where the proxy sent the request.
+const (
+	destinationInstance  = "instance"  // local h2c forward to a deployment pod
+	destinationFrontline = "frontline" // cross-region HTTPS forward to peer frontline
+)
+
+// Outcome labels for upstreamDialsTotal.
+const (
+	dialOutcomeSuccess = "success"
+	dialOutcomeError   = "error"
+)
+
+// Hops bucket strings. Cross-region requests should normally be 1 hop;
+// anything higher indicates routing drift between regions.
+const (
+	hops1     = "1"
+	hops2     = "2"
+	hops3     = "3"
+	hopsManyN = "4+"
+)
+
 var (
-	// proxyForwardTotal tracks proxy forwarding attempts by destination and outcome.
+	// upstreamSeconds is the wall-clock duration of the upstream call —
+	// from request send to response complete (or error). Customer-pod
+	// time; not a platform SLO. Surfaced for dashboard and per-tenant
+	// debugging, not for platform alerts.
 	//
-	// Labels:
-	//   destination: "instance" (local h2c forward to deployment instance) or
-	//                "region" (cross-region HTTPS forward to peer frontline)
-	//   error: "none", "timeout", "conn_refused", "conn_reset",
-	//          "dns_failure", "client_canceled", "backend_5xx", "other"
-	proxyForwardTotal = lazy.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: "unkey",
-			Subsystem: "frontline",
-			Name:      "forward_total",
-			Help:      "Total proxy forward attempts by destination and error type.",
-		},
-		[]string{"destination", "error"},
-	)
-
-	// proxyBackendDuration tracks the time from when the proxy sends the request
-	// to the backend until it gets a response (or error). This isolates backend
-	// latency from frontline's own routing overhead.
-	//
-	// Labels:
-	//   destination: "instance" (local h2c forward) or "region" (cross-region HTTPS forward)
-	proxyBackendDuration = lazy.NewHistogramVec(
+	// Buckets cover the full range up to the 300s function timeout —
+	// these requests can be intentionally long.
+	upstreamSeconds = lazy.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: "unkey",
 			Subsystem: "frontline",
-			Name:      "backend_duration_seconds",
-			Help:      "Backend response time by destination type.",
-			Buckets:   []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30},
+			Name:      "upstream_seconds",
+			Help:      "Upstream call duration.",
+			Buckets:   []float64{0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300},
 		},
 		[]string{"destination"},
 	)
 
-	// proxyHops tracks cross-region hop counts by source and destination region.
-	// Deviations from nominal hop counts per src→dst pair indicate routing shifts.
-	proxyHops = lazy.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Namespace: "unkey",
-			Subsystem: "frontline",
-			Name:      "hops",
-			Help:      "Distribution of frontline hop counts by source and destination region.",
-			Buckets:   []float64{0, 1, 2, 3},
-		},
-		[]string{"src_region", "dst_region"},
-	)
-
-	// proxyForwardErrorsTotal is a convenience counter for forward errors.
-	proxyForwardErrorsTotal = lazy.NewCounterVec(
+	// hopsTotal counts cross-region requests bucketed by hop count. Hops=1
+	// is normal (one cross-region jump); higher values mean a peer
+	// frontline forwarded again — a routing-config bug.
+	hopsTotal = lazy.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "unkey",
 			Subsystem: "frontline",
-			Name:      "forward_errors_total",
-			Help:      "Total proxy forward errors by destination.",
+			Name:      "hops_total",
+			Help:      "Cross-region forwards by hop count.",
 		},
-		[]string{"destination"},
+		[]string{"src_region", "dst_region", "hops"},
 	)
 
-	// proxyBackendErrorsTotal counts backend 5xx responses by destination and source.
-	proxyBackendErrorsTotal = lazy.NewCounterVec(
+	// upstreamDialsTotal counts new TCP dials issued by the upstream
+	// transport. Healthy operation reuses pooled connections; a high dial
+	// rate per destination signals pool churn — a leading indicator of
+	// upstream-saturation outages before errors fire.
+	upstreamDialsTotal = lazy.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "unkey",
 			Subsystem: "frontline",
-			Name:      "backend_errors_total",
-			Help:      "Total backend 5xx errors by destination and source.",
+			Name:      "upstream_dials_total",
+			Help:      "TCP dials issued for upstream connections.",
 		},
-		[]string{"destination", "source"},
-	)
-
-	// proxyAbortedTotal counts client-disconnect aborts during streaming responses.
-	// httputil.ReverseProxy panics with http.ErrAbortHandler when the response body
-	// copy fails after headers have been flushed (typically the client went away).
-	// We swallow that sentinel value locally; this counter preserves visibility.
-	proxyAbortedTotal = lazy.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: "unkey",
-			Subsystem: "frontline",
-			Name:      "aborted_total",
-			Help:      "Client-disconnect aborts during streaming by destination.",
-		},
-		[]string{"destination"},
-	)
-
-	// proxyBackendResponseTotal tracks HTTP status codes returned by backends.
-	//
-	// Labels:
-	//   destination: "instance" (local h2c forward) or "region" (cross-region HTTPS forward)
-	//   source: "frontline" (peer frontline returned this error) or "upstream" (customer pod response)
-	//   status_class: "2xx", "3xx", "4xx", "5xx"
-	proxyBackendResponseTotal = lazy.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: "unkey",
-			Subsystem: "frontline",
-			Name:      "backend_response_total",
-			Help:      "Backend HTTP response status classes by destination and error source.",
-		},
-		[]string{"destination", "source", "status_class"},
+		[]string{"destination", "outcome"},
 	)
 )
+
+// hopsBucket maps an integer hop count to the canonical label string used
+// on hopsTotal. Keeps the label set bounded regardless of how high the hop
+// count goes.
+func hopsBucket(n int) string {
+	switch n {
+	case 1:
+		return hops1
+	case 2:
+		return hops2
+	case 3:
+		return hops3
+	default:
+		return hopsManyN
+	}
+}

--- a/svc/frontline/internal/proxy/metrics.go
+++ b/svc/frontline/internal/proxy/metrics.go
@@ -17,15 +17,6 @@ const (
 	dialOutcomeError   = "error"
 )
 
-// Hops bucket strings. Cross-region requests should normally be 1 hop;
-// anything higher indicates routing drift between regions.
-const (
-	hops1     = "1"
-	hops2     = "2"
-	hops3     = "3"
-	hopsManyN = "4+"
-)
-
 var (
 	// upstreamSeconds is the wall-clock duration of the upstream call —
 	// from request send to response complete (or error). Customer-pod
@@ -45,17 +36,24 @@ var (
 		[]string{"destination"},
 	)
 
-	// hopsTotal counts cross-region requests bucketed by hop count. Hops=1
-	// is normal (one cross-region jump); higher values mean a peer
-	// frontline forwarded again — a routing-config bug.
-	hopsTotal = lazy.NewCounterVec(
-		prometheus.CounterOpts{
+	// hopsHistogram records cross-region hop counts. Hops=1 is the only
+	// healthy value: a request arrives, we forward to one peer, that peer
+	// serves it. Higher values mean the peer received a forward and
+	// forwarded *again* — a routing-config bug between regions.
+	//
+	// Recording as a histogram (not a counter) so dashboards get average
+	// hop depth via _sum/_count and alerts can use bucket boundaries to
+	// distinguish "all good" (everything in le=1) from "drift" (any rate
+	// past le=1).
+	hopsHistogram = lazy.NewHistogramVec(
+		prometheus.HistogramOpts{
 			Namespace: "unkey",
 			Subsystem: "frontline",
-			Name:      "hops_total",
-			Help:      "Cross-region forwards by hop count.",
+			Name:      "hops",
+			Help:      "Cross-region hop count distribution by source and destination region.",
+			Buckets:   []float64{1, 2, 3},
 		},
-		[]string{"src_region", "dst_region", "hops"},
+		[]string{"src_region", "dst_region"},
 	)
 
 	// upstreamDialsTotal counts new TCP dials issued by the upstream
@@ -73,18 +71,3 @@ var (
 	)
 )
 
-// hopsBucket maps an integer hop count to the canonical label string used
-// on hopsTotal. Keeps the label set bounded regardless of how high the hop
-// count goes.
-func hopsBucket(n int) string {
-	switch n {
-	case 1:
-		return hops1
-	case 2:
-		return hops2
-	case 3:
-		return hops3
-	default:
-		return hopsManyN
-	}
-}

--- a/svc/frontline/internal/proxy/metrics.go
+++ b/svc/frontline/internal/proxy/metrics.go
@@ -70,4 +70,3 @@ var (
 		[]string{"destination", "outcome"},
 	)
 )
-

--- a/svc/frontline/internal/proxy/service.go
+++ b/svc/frontline/internal/proxy/service.go
@@ -124,7 +124,7 @@ func (s *service) forwardToInstance(ctx context.Context, sess *zen.Session, deci
 		targetURL:    targetURL,
 		startTime:    startTime,
 		directorFunc: s.makeInstanceDirector(sess, startTime),
-		destination:  "instance",
+		destination:  destinationInstance,
 		transport:    transport,
 	})
 }
@@ -138,7 +138,7 @@ func (s *service) forwardToRegion(ctx context.Context, sess *zen.Session, target
 			if srcRegion == "" {
 				srcRegion = fmt.Sprintf("%s::%s", s.platform, s.region)
 			}
-			proxyHops.WithLabelValues(srcRegion, targetRegionPlatform).Observe(float64(hops))
+			hopsTotal.WithLabelValues(srcRegion, targetRegionPlatform, hopsBucket(hops)).Inc()
 
 			if hops >= s.maxHops {
 				logger.Error("too many frontline hops - rejecting request",
@@ -168,7 +168,7 @@ func (s *service) forwardToRegion(ctx context.Context, sess *zen.Session, target
 		targetURL:    targetURL,
 		startTime:    startTime,
 		directorFunc: s.makeRegionDirector(sess, startTime),
-		destination:  "region",
+		destination:  destinationFrontline,
 		transport:    s.transport,
 	})
 }

--- a/svc/frontline/internal/proxy/service.go
+++ b/svc/frontline/internal/proxy/service.go
@@ -138,7 +138,7 @@ func (s *service) forwardToRegion(ctx context.Context, sess *zen.Session, target
 			if srcRegion == "" {
 				srcRegion = fmt.Sprintf("%s::%s", s.platform, s.region)
 			}
-			hopsTotal.WithLabelValues(srcRegion, targetRegionPlatform, hopsBucket(hops)).Inc()
+			hopsHistogram.WithLabelValues(srcRegion, targetRegionPlatform).Observe(float64(hops))
 
 			if hops >= s.maxHops {
 				logger.Error("too many frontline hops - rejecting request",

--- a/svc/frontline/internal/router/lookup.go
+++ b/svc/frontline/internal/router/lookup.go
@@ -20,7 +20,6 @@ func (s *service) findRoute(ctx context.Context, hostname string) (db.FindFrontl
 	}, internalCaches.DefaultFindFirstOp)
 
 	if err != nil && !mysql.IsNotFound(err) {
-		routingErrorsTotal.WithLabelValues("config_load_failed").Inc()
 		return db.FindFrontlineRouteByFQDNRow{}, fault.Wrap(err,
 			fault.Code(codes.Frontline.Internal.ConfigLoadFailed.URN()),
 			fault.Internal("error loading frontline route"),
@@ -29,7 +28,6 @@ func (s *service) findRoute(ctx context.Context, hostname string) (db.FindFrontl
 	}
 
 	if mysql.IsNotFound(err) || routeHit == cache.Null {
-		routingErrorsTotal.WithLabelValues("config_not_found").Inc()
 		return db.FindFrontlineRouteByFQDNRow{}, fault.New("no frontline route for hostname: "+hostname,
 			fault.Code(codes.Frontline.Routing.ConfigNotFound.URN()),
 			fault.Public("Domain not configured"),

--- a/svc/frontline/internal/router/metrics.go
+++ b/svc/frontline/internal/router/metrics.go
@@ -5,47 +5,46 @@ import (
 	"github.com/unkeyed/unkey/pkg/prometheus/lazy"
 )
 
-var (
-	// routingDecisionsTotal tracks where frontline routes each request.
-	//
-	// Labels:
-	//   decision: "local_instance" or "remote_region"
-	//   target_region: the region being routed to (local region name or remote region.platform)
-	routingDecisionsTotal = lazy.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: "unkey",
-			Subsystem: "frontline",
-			Name:      "routing_decisions_total",
-			Help:      "Total routing decisions by type and target region.",
-		},
-		[]string{"decision", "target_region"},
-	)
+// Decision label values for routingDecisionsTotal. Match the
+// router.Destination enum semantically — local for same-region instance,
+// remote for cross-region peer.
+const (
+	decisionLocal  = "local"
+	decisionRemote = "remote"
+)
 
-	// routingErrorsTotal tracks routing failures by reason.
-	//
-	// Labels:
-	//   reason: "no_instances", "no_running_instances",
-	//           "config_not_found", "config_load_failed",
-	//           "instance_load_failed", "policy_parse_failed",
-	//           "no_reachable_region"
-	routingErrorsTotal = lazy.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: "unkey",
-			Subsystem: "frontline",
-			Name:      "routing_errors_total",
-			Help:      "Total routing errors by reason.",
-		},
-		[]string{"reason"},
-	)
+// routingDecisionsTotal counts where each request was routed. The
+// target_region label carries the local region.platform for local
+// decisions and the destination region.platform for remote decisions, so
+// dashboards can attribute traffic flow between regions without joining.
+//
+// Routing failures are not counted here — they show up in the unified
+// requests_total counter via the URN-coded fault that the router returns
+// to the middleware.
+var routingDecisionsTotal = lazy.NewCounterVec(
+	prometheus.CounterOpts{
+		Namespace: "unkey",
+		Subsystem: "frontline",
+		Name:      "routing_decisions_total",
+		Help:      "Routing decisions by type and target region.",
+	},
+	[]string{"decision", "target_region"},
+)
 
-	// routingDuration tracks how long the full Route() call takes (cache lookups + DB fallback).
-	routingDuration = lazy.NewHistogram(
-		prometheus.HistogramOpts{
-			Namespace: "unkey",
-			Subsystem: "frontline",
-			Name:      "routing_duration_seconds",
-			Help:      "Time spent making routing decisions.",
-			Buckets:   []float64{0.001, 0.002, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1},
-		},
-	)
+// routingDecisionSeconds is the time spent picking a destination — the
+// cache lookups (route, instances, policies), DB fallbacks on miss, and
+// the selection logic that produces a RouteDecision. Pairs with
+// routingDecisionsTotal: that counts the decisions, this times them.
+//
+// Distribution is bimodal: cache hits land sub-ms, DB fallbacks tens of
+// ms. The bucket set spans both regimes so quantile alerts can target
+// whichever is the operational concern.
+var routingDecisionSeconds = lazy.NewHistogram(
+	prometheus.HistogramOpts{
+		Namespace: "unkey",
+		Subsystem: "frontline",
+		Name:      "routing_decision_seconds",
+		Help:      "Time spent picking a destination for a request.",
+		Buckets:   []float64{0.0001, 0.0005, 0.001, 0.002, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1},
+	},
 )

--- a/svc/frontline/internal/router/routing.go
+++ b/svc/frontline/internal/router/routing.go
@@ -48,7 +48,6 @@ func (s *service) selectDestination(
 	policies []*frontlinev1.Policy,
 ) (RouteDecision, error) {
 	if len(instances) == 0 {
-		routingErrorsTotal.WithLabelValues("no_instances").Inc()
 		return RouteDecision{}, fault.New("no instances",
 			fault.Code(codes.Frontline.Routing.NoRunningInstances.URN()),
 			fault.Internal(fmt.Sprintf("no instances for deployment %s", route.DeploymentID)),
@@ -70,7 +69,6 @@ func (s *service) selectDestination(
 	}
 
 	if len(regionsWithInstance) == 0 {
-		routingErrorsTotal.WithLabelValues("no_running_instances").Inc()
 		return RouteDecision{}, fault.New("no running instances",
 			fault.Code(codes.Frontline.Routing.NoRunningInstances.URN()),
 			fault.Internal(fmt.Sprintf("no running instances for deployment %s", route.DeploymentID)),
@@ -95,7 +93,6 @@ func (s *service) selectDestination(
 
 	nearestRegion := s.findNearestRegionPlatform(regionsWithInstance)
 	if nearestRegion == "" {
-		routingErrorsTotal.WithLabelValues("no_reachable_region").Inc()
 		return RouteDecision{}, fault.New("no reachable region from "+s.regionPlatform,
 			fault.Code(codes.Frontline.Routing.NoRunningInstances.URN()),
 			fault.Internal("running instances exist but no region is reachable"),

--- a/svc/frontline/internal/router/service.go
+++ b/svc/frontline/internal/router/service.go
@@ -36,6 +36,7 @@ func New(cfg Config) (*service, error) {
 
 func (s *service) Route(ctx context.Context, hostname string) (RouteDecision, error) {
 	start := time.Now()
+	defer func() { routingDecisionSeconds.Observe(time.Since(start).Seconds()) }()
 
 	route, err := s.findRoute(ctx, hostname)
 	if err != nil {
@@ -44,28 +45,23 @@ func (s *service) Route(ctx context.Context, hostname string) (RouteDecision, er
 
 	instances, err := s.getInstances(ctx, route.DeploymentID)
 	if err != nil {
-		routingErrorsTotal.WithLabelValues("instance_load_failed").Inc()
 		return RouteDecision{}, err
 	}
 
 	policies, err := s.getPolicies(ctx, route)
 	if err != nil {
-		routingErrorsTotal.WithLabelValues("policy_parse_failed").Inc()
 		return RouteDecision{}, err
 	}
 
 	decision, err := s.selectDestination(route, instances, policies)
-
-	routingDuration.Observe(time.Since(start).Seconds())
-
 	if err != nil {
 		return RouteDecision{}, err
 	}
 
 	if decision.Destination == DestinationLocalInstance {
-		routingDecisionsTotal.WithLabelValues("local_instance", s.regionPlatform).Inc()
+		routingDecisionsTotal.WithLabelValues(decisionLocal, s.regionPlatform).Inc()
 	} else {
-		routingDecisionsTotal.WithLabelValues("remote_region", decision.Address).Inc()
+		routingDecisionsTotal.WithLabelValues(decisionRemote, decision.Address).Inc()
 	}
 
 	return decision, nil

--- a/svc/frontline/middleware/BUILD.bazel
+++ b/svc/frontline/middleware/BUILD.bazel
@@ -17,11 +17,10 @@ go_library(
         "//pkg/fault",
         "//pkg/logger",
         "//pkg/otel/tracing",
-        "//pkg/prometheus/lazy",
         "//pkg/zen",
         "//svc/frontline/internal/errorpage",
+        "//svc/frontline/internal/metrics",
         "//svc/frontline/internal/proxy",
-        "@com_github_prometheus_client_golang//prometheus",
         "@io_opentelemetry_go_otel//attribute",
     ],
 )

--- a/svc/frontline/middleware/observability.go
+++ b/svc/frontline/middleware/observability.go
@@ -3,62 +3,16 @@ package middleware
 import (
 	"context"
 	"net/http"
-	"strconv"
 	"strings"
-	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/unkeyed/unkey/pkg/codes"
 	"github.com/unkeyed/unkey/pkg/fault"
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/pkg/otel/tracing"
-	"github.com/unkeyed/unkey/pkg/prometheus/lazy"
 	"github.com/unkeyed/unkey/pkg/zen"
 	"github.com/unkeyed/unkey/svc/frontline/internal/errorpage"
+	"github.com/unkeyed/unkey/svc/frontline/internal/metrics"
 	"go.opentelemetry.io/otel/attribute"
-)
-
-var (
-	frontlineRequestsTotal = lazy.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: "unkey",
-			Subsystem: "frontline",
-			Name:      "requests_total",
-			Help:      "Total number of requests processed by frontline",
-		},
-		[]string{"status_code", "error_type", "region"},
-	)
-
-	frontlineRequestDuration = lazy.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Namespace: "unkey",
-			Subsystem: "frontline",
-			Name:      "request_duration_seconds",
-			Help:      "Request duration in seconds",
-			Buckets:   prometheus.DefBuckets,
-		},
-		[]string{"status_code", "error_type", "region"},
-	)
-
-	frontlineActiveRequests = lazy.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace: "unkey",
-			Subsystem: "frontline",
-			Name:      "active_requests",
-			Help:      "Number of requests currently being processed",
-		},
-		[]string{"region"},
-	)
-
-	frontlineRequestErrorsTotal = lazy.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: "unkey",
-			Subsystem: "frontline",
-			Name:      "request_errors_total",
-			Help:      "Total number of request errors by error type.",
-		},
-		[]string{"error_type"},
-	)
 )
 
 type ErrorResponse struct {
@@ -76,72 +30,35 @@ type errorPageInfo struct {
 	Message string
 }
 
-func categorizeErrorTypeFrontline(urn codes.URN, statusCode int, hasError bool) string {
-	if statusCode >= 200 && statusCode < 300 {
-		return "none"
-	}
-
-	if hasError {
-
-		//nolint:exhaustive
-		switch urn {
-		case codes.Frontline.Proxy.GatewayTimeout.URN():
-			return "customer"
-
-		case codes.Frontline.Internal.InternalServerError.URN(),
-			codes.Frontline.Internal.ConfigLoadFailed.URN(),
-			codes.Frontline.Internal.InstanceLoadFailed.URN(),
-			codes.Frontline.Routing.ConfigNotFound.URN(),
-			codes.Frontline.Routing.DeploymentSelectionFailed.URN(),
-			codes.Frontline.Proxy.ServiceUnavailable.URN(),
-			codes.Frontline.Routing.NoRunningInstances.URN():
-			return "platform"
-
-		case codes.User.BadRequest.ClientClosedRequest.URN(),
-			codes.User.BadRequest.RequestTimeout.URN():
-			return "user"
-		}
-
-		if statusCode >= 500 {
-			return "platform"
-		}
-
-		if statusCode >= 400 {
-			return "user"
-		}
-
-	} else if statusCode >= 400 {
-		return "customer"
-	}
-
-	return "unknown"
-}
-
-func WithObservability(region string, renderer errorpage.Renderer) zen.Middleware {
+// WithObservability is the request-level observability middleware. It owns:
+//
+//   - tracing span for the request
+//   - error rendering (HTML page or JSON, based on Accept header)
+//   - emission of unkey_frontline_requests_total
+//
+// Per-component latency lives on the package that owns the work: routing
+// in router, upstream timing in proxy. There is no platform-overhead
+// histogram here — alert on routing/upstream latency separately.
+func WithObservability(renderer errorpage.Renderer) zen.Middleware {
 	return func(next zen.HandleFunc) zen.HandleFunc {
 		return func(ctx context.Context, s *zen.Session) error {
-			startTime := time.Now()
+			metrics.InflightRequests.Inc()
+			defer metrics.InflightRequests.Dec()
 
-			// Start trace span for the request
 			ctx, span := tracing.Start(ctx, "frontline.proxy")
 			span.SetAttributes(
 				attribute.String("request_id", s.RequestID()),
 				attribute.String("host", s.Request().Host),
 				attribute.String("method", s.Request().Method),
 				attribute.String("path", s.Request().URL.Path),
-				attribute.String("region", region),
 			)
 			defer span.End()
-
-			frontlineActiveRequests.WithLabelValues(region).Inc()
-			defer frontlineActiveRequests.WithLabelValues(region).Dec()
 
 			err := next(ctx, s)
 
 			statusCode := s.StatusCode()
-			var errorType string
-			var urn codes.URN
 			hasError := err != nil
+			var urn codes.URN
 
 			if hasError {
 				tracing.RecordError(span, err)
@@ -161,14 +78,10 @@ func WithObservability(region string, renderer errorpage.Renderer) zen.Middlewar
 				pageInfo := getErrorPageInfoFrontline(urn)
 				statusCode = pageInfo.Status
 
-				errorType = categorizeErrorTypeFrontline(urn, statusCode, hasError)
-
 				userMessage := pageInfo.Message
 				if userMessage == "" {
 					userMessage = fault.UserFacingMessage(err)
 				}
-
-				title := pageInfo.Title
 
 				if pageInfo.Status == http.StatusInternalServerError {
 					logger.Error("frontline error",
@@ -197,7 +110,7 @@ func WithObservability(region string, renderer errorpage.Renderer) zen.Middlewar
 				} else {
 					htmlBody, renderErr := renderer.Render(errorpage.Data{
 						StatusCode: pageInfo.Status,
-						Title:      title,
+						Title:      pageInfo.Title,
 						Message:    userMessage,
 						ErrorCode:  string(code.URN()),
 						DocsURL:    code.DocsURL(),
@@ -219,31 +132,19 @@ func WithObservability(region string, renderer errorpage.Renderer) zen.Middlewar
 				if writeErr != nil {
 					logger.Error("failed to write error response", "error", writeErr.Error())
 				}
-			} else {
-				errorType = categorizeErrorTypeFrontline("", statusCode, hasError)
 			}
 
-			duration := time.Since(startTime).Seconds()
-			statusStr := strconv.Itoa(statusCode)
-
-			// Add final status to span
 			span.SetAttributes(
 				attribute.Int("status_code", statusCode),
-				attribute.String("error_type", errorType),
+				attribute.String("code", string(urn)),
 			)
 
 			logger.Info("frontline request",
-				"status_code", statusStr,
-				"error_type", errorType,
-				"duration_seconds", duration,
-				"region", region,
+				"status_code", statusCode,
+				"code", string(urn),
 			)
 
-			frontlineRequestsTotal.WithLabelValues(statusStr, errorType, region).Inc()
-			frontlineRequestDuration.WithLabelValues(statusStr, errorType, region).Observe(duration)
-			if errorType != "none" {
-				frontlineRequestErrorsTotal.WithLabelValues(errorType).Inc()
-			}
+			metrics.RequestsTotal.WithLabelValues(metrics.StatusClass(statusCode), string(urn)).Inc()
 
 			return nil
 		}

--- a/svc/frontline/routes/proxy/websocket_test.go
+++ b/svc/frontline/routes/proxy/websocket_test.go
@@ -145,7 +145,7 @@ func startFrontline(t *testing.T, backendAddr string) (string, func()) {
 		zen.WithPanicRecovery(),
 		middleware.WithReservedHeaderStrip(),
 		zen.WithLogging(),
-		middleware.WithObservability("test", errorpage.NewRenderer()),
+		middleware.WithObservability(errorpage.NewRenderer()),
 	}
 	zenSrv.RegisterRoute(mws, h)
 

--- a/svc/frontline/routes/register.go
+++ b/svc/frontline/routes/register.go
@@ -13,7 +13,7 @@ func Register(srv *zen.Server, svc *Services) {
 	withSanitizeHeaders := middleware.WithReservedHeaderStrip()
 	withLogging := zen.WithLogging(zen.SkipPaths("/_unkey/internal/"))
 	withPanicRecovery := zen.WithPanicRecovery()
-	withObservability := middleware.WithObservability(svc.Region, svc.ErrorPageRenderer)
+	withObservability := middleware.WithObservability(svc.ErrorPageRenderer)
 	withClickHouseLogging := middleware.WithClickHouseLogging(svc.FrontlineRequests, svc.Clock, svc.FrontlineID, svc.Region, svc.Platform)
 	withTimeout := zen.WithTimeout(svc.RequestTimeout)
 
@@ -53,7 +53,7 @@ func RegisterHTTPServer(srv *zen.Server, svc *Services) {
 			zen.WithPanicRecovery(),
 			middleware.WithReservedHeaderStrip(),
 			zen.WithLogging(zen.SkipPaths("/_unkey/internal/")),
-			middleware.WithObservability(svc.Region, svc.ErrorPageRenderer),
+			middleware.WithObservability(svc.ErrorPageRenderer),
 		},
 		&acme.Handler{
 			RouterService: svc.RouterService,


### PR DESCRIPTION
## What does this PR do?

Fixes # (issue)

Refactors the frontline metrics layer to reduce cardinality, remove redundant counters, and consolidate per-request outcome tracking into a single unified counter.

**Unified outcome counter:** Replaces the previous `requests_total` counter (labelled by `status_code`, `error_type`, and `region`) with a new `unkey_frontline_requests_total` counter labelled only by `status_class` (e.g. `2xx`, `4xx`) and `code` (the fault URN on error, empty on success). Region and environment are now external Prometheus labels rather than per-series labels, eliminating cardinality cost. This counter lives in the new `svc/frontline/internal/metrics` package so it can be shared across middleware and subpackages without import cycles.

**Removed redundant proxy counters:** Drops `forward_total`, `forward_errors_total`, `backend_errors_total`, `backend_response_total`, and `aborted_total`. Routing errors (`config_not_found`, `config_load_failed`, `no_instances`, etc.) are no longer double-counted via `routing_errors_total` — they surface through the unified `requests_total` URN code instead. The `categorizeProxyErrorType` function and its label set are removed entirely.

**Replaced proxy metrics with higher-signal equivalents:**
- `backend_duration_seconds` → `upstream_seconds` with an extended bucket set covering up to 300s (the function timeout ceiling).
- `proxyHops` histogram → `hops_total` counter with a bounded string bucket label (`1`, `2`, `3`, `4+`) to keep cardinality fixed.
- New `upstream_dials_total` counter (labelled by destination and outcome) tracks TCP dial attempts via `httptrace.ClientTrace`, surfacing connection-pool churn as a leading indicator of upstream saturation.

**Routing metrics cleanup:** `routingErrorsTotal` is removed; `routingDuration` is renamed `routingDecisionSeconds` with a finer bucket set covering both sub-ms cache hits and tens-of-ms DB fallbacks. The timing is now recorded via a deferred call at the top of `Route()` so it covers all exit paths including errors. Decision label values are replaced with named constants (`decisionLocal`, `decisionRemote`).

**Observability middleware simplification:** `WithObservability` no longer accepts a `region` parameter — region is an external label. The `categorizeErrorTypeFrontline` function and the `request_duration_seconds` histogram are removed. The active-requests `GaugeVec` (labelled by region) is replaced with the shared `metrics.InflightRequests` gauge (no label). The `serveWithAbortRecovery` function no longer takes a `destination` argument since the abort counter it incremented has been removed.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Verify that `unkey_frontline_requests_total` is emitted with `status_class` and `code` labels on both successful and error requests.
- Confirm that `unkey_frontline_inflight_requests` increments on request entry and decrements on exit.
- Confirm that `unkey_frontline_upstream_seconds` is recorded for both successful upstream responses and upstream errors.
- Confirm that `unkey_frontline_upstream_dials_total` increments on new TCP connections to upstream destinations.
- Confirm that `unkey_frontline_hops_total` increments with the correct `hops` bucket label on cross-region forwards.
- Confirm that `unkey_frontline_routing_decisions_total` and `unkey_frontline_routing_decision_seconds` are emitted correctly on each route resolution.
- Run existing `TestServeWithAbortRecovery_*` tests to confirm the signature change does not break abort-recovery behaviour.

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary