### PR TITLE
fix(dashboard): distinguish 4xx and 5xx icons in logs table

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/logs/components/table/logs-table.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/logs/components/table/logs-table.tsx
@@ -4,7 +4,7 @@ import { VirtualTable } from "@/components/virtual-table/index";
 import type { Column } from "@/components/virtual-table/types";
 import { cn } from "@/lib/utils";
 import type { Log } from "@unkey/clickhouse/src/logs";
-import { BookBookmark, TriangleWarning2 } from "@unkey/icons";
+import { BookBookmark, CircleXMark, TriangleWarning2 } from "@unkey/icons";
 import { Badge, Button, Empty, TimestampInfo } from "@unkey/ui";
 import { useMemo } from "react";
 import { isDisplayProperty, useLogsContext } from "../../context/logs";
@@ -65,8 +65,8 @@ const getStatusStyle = (status: number): StatusStyle => {
   return STATUS_STYLES.success;
 };
 
-const WARNING_ICON_STYLES = {
-  base: "size-3",
+const STATUS_ICON_STYLES = {
+  base: "size-4",
   warning: "text-warning-11",
   error: "text-error-11",
 };
@@ -79,17 +79,22 @@ const getSelectedClassName = (log: Log, isSelected: boolean) => {
   return style.selected;
 };
 
-const WarningIcon = ({ status }: { status: number }) => (
-  <TriangleWarning2
-    iconSize="md-medium"
-    className={cn(
-      WARNING_ICON_STYLES.base,
-      status < 300 && "invisible",
-      status >= 400 && status < 500 && WARNING_ICON_STYLES.warning,
-      status >= 500 && WARNING_ICON_STYLES.error,
-    )}
-  />
-);
+const StatusIcon = ({ status }: { status: number }) => {
+  if (status < 400) {
+    return <span className={cn(STATUS_ICON_STYLES.base, "invisible")} />;
+  }
+  const isError = status >= 500;
+  const Icon = isError ? CircleXMark : TriangleWarning2;
+  return (
+    <Icon
+      iconSize="lg-medium"
+      className={cn(
+        STATUS_ICON_STYLES.base,
+        isError ? STATUS_ICON_STYLES.error : STATUS_ICON_STYLES.warning,
+      )}
+    />
+  );
+};
 
 const additionalColumns: Column<Log>[] = [
   "response_body",
@@ -230,7 +235,7 @@ export const LogsTable = () => {
         headerClassName: "pl-8",
         render: (log: Log) => (
           <div className="flex items-center gap-3 px-2">
-            <WarningIcon status={log.response_status} />
+            <StatusIcon status={log.response_status} />
             <div className="flex-1 min-w-0">{originalRender(log)}</div>
           </div>
         ),

--- a/web/internal/icons/src/icons/triangle-warning-2.tsx
+++ b/web/internal/icons/src/icons/triangle-warning-2.tsx
@@ -19,25 +19,28 @@ export function TriangleWarning2({ iconSize = "xl-thin", ...props }: IconProps) 
     <svg
       height={pixelSize}
       width={pixelSize}
-      viewBox="1 0 18 18"
+      viewBox="0 0 18 18"
       xmlns="http://www.w3.org/2000/svg"
       {...props}
     >
       <g fill="currentColor">
         <path
-          d="m9,8c0-.552.447-1,1-1s1,.448,1,1v4.5c0,.552-.447,1-1,1s-1-.448-1-1v-4.5Z"
-          fill="currentColor"
-          strokeWidth={strokeWidth}
-        />
-        <path
-          d="m13.725,16h1.471c1.54,0,2.502-1.667,1.732-3l-5.196-9c-.77-1.333-2.694-1.333-3.464,0L3.072,13c-.77,1.333.192,3,1.732,3h1.471"
+          d="M7.63796 3.48996L2.21295 12.89C1.60795 13.9399 2.36395 15.25 3.57495 15.25H14.425C15.636 15.25 16.392 13.9399 15.787 12.89L10.362 3.48996C9.75696 2.44996 8.24296 2.44996 7.63796 3.48996Z"
           fill="none"
           stroke="currentColor"
           strokeLinecap="round"
           strokeLinejoin="round"
           strokeWidth={strokeWidth}
         />
-        <circle cx="10" cy="15.75" fill="currentColor" r="1.25" strokeWidth={strokeWidth} />
+        <path
+          d="M9 6.75V9.75"
+          fill="none"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={strokeWidth}
+        />
+        <path d="M9 13.5C8.448 13.5 8 13.05 8 12.5C8 11.95 8.448 11.5 9 11.5C9.552 11.5 10 11.9501 10 12.5C10 13.0499 9.552 13.5 9 13.5Z" />
       </g>
     </svg>
   );


### PR DESCRIPTION
## Summary

- Use `CircleXMark` for 5xx rows and `TriangleWarning2` for 4xx rows in the workspace logs table — previously both used the warning triangle, making errors and warnings indistinguishable at a glance.
- Bump the leading status icon from 12px to 16px so it reads at the same visual weight as the row text.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Open `/<workspace>/logs`
- Filter by 4xx — leading column shows the warning triangle
- Filter by 5xx — leading column shows the circled x-mark
- 2xx rows show no icon (invisible spacer)

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Ran `pnpm fmt`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`