### PR TITLE
fix: ci web build 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ install-brew-tools: ## Install Homebrew tools if they don't exist
 
 .PHONY: install
 install: install-go ## Install all dependencies
-	pnpm --dir=web install --frozen-lockfile
+	cd web && pnpm install --frozen-lockfile
 
 
 
@@ -56,7 +56,7 @@ fmt: fmt-yaml ## Format code
 	go fmt ./...
 	go tool buf format -w
 
-	pnpm --dir=web fmt
+	cd web && pnpm fmt
 
 .PHONY: pull
 pull: ## Pull latest Docker images for services
@@ -72,7 +72,7 @@ clean: ## Stop and remove all services with volumes
 
 .PHONY: build-web
 build-web: ## Build web services
-	pnpm --dir=web build
+	cd web && pnpm build
 
 .PHONY: build
 build:  ## Build all artifacts
@@ -91,7 +91,7 @@ generate: generate-sql ## Generate code from protobuf and other sources (NOT eBP
 	go run ./tools/exportoneof ./gen/proto
 	bazel run //:gazelle
 	go fmt ./...
-	pnpm --dir=web fmt
+	cd web && pnpm fmt
 
 .PHONY: generate-bpf
 generate-bpf: ## Compile the heimdall eBPF program and regenerate Go bindings (uses pinned clang/Go in docker for bytewise reproducibility across hosts)
@@ -136,7 +136,7 @@ oci-load: build ## Build and load OCI images into Docker
 
 .PHONY: local-dashboard
 local-dashboard: install oci-load ## Run local development setup for dashboard
-	pnpm --dir=web/apps/dashboard local
+	cd web/apps/dashboard && pnpm local
 
 .PHONY: build-local-image
 build-local-image: ## Build and push image to local registry (usage: make build-local-image DOCKERFILE=./path/to/Dockerfile NAME=myapp TAG=latest)


### PR DESCRIPTION
## What does this PR do?
`make fmt` runs from the repo root. `pnpm --dir=web fmt` starts pnpm in the root directory and points it at `web/`, but Corepack resolves `packageManager` by walking up from the cwd (repo root), not from the `--dir` target. There is no `package.json` at the repo root, so Corepack falls back to its bundled default (pnpm 11.0.8). Then pnpm 11.0.8 sees `web/package.json` declares `pnpm@8.6.9` and refuses the mismatch.

