### PR TITLE
fix: update tests, cleanup struct

### DIFF
--- a/svc/api/routes/v2_portal_exchange_session/200_test.go
+++ b/svc/api/routes/v2_portal_exchange_session/200_test.go
@@ -29,6 +29,7 @@ func TestExchangeSessionSuccess(t *testing.T) {
 	err := db.Query.InsertPortalConfig(ctx, h.DB.RW(), db.InsertPortalConfigParams{
 		ID:          portalConfigID,
 		WorkspaceID: workspaceID,
+		Slug:        "test-portal",
 		KeyAuthID:   sql.NullString{Valid: true, String: uid.New(uid.KeySpacePrefix)},
 		Enabled:     true,
 		CreatedAt:   now,

--- a/svc/api/routes/v2_portal_exchange_session/401_test.go
+++ b/svc/api/routes/v2_portal_exchange_session/401_test.go
@@ -31,6 +31,7 @@ func TestExchangeSessionUnauthorized(t *testing.T) {
 	err := db.Query.InsertPortalConfig(ctx, h.DB.RW(), db.InsertPortalConfigParams{
 		ID:          portalConfigID,
 		WorkspaceID: workspaceID,
+		Slug:        "test-portal",
 		KeyAuthID:   sql.NullString{Valid: true, String: uid.New(uid.KeySpacePrefix)},
 		Enabled:     true,
 		CreatedAt:   now,

--- a/svc/api/routes/v2_portal_exchange_session/handler.go
+++ b/svc/api/routes/v2_portal_exchange_session/handler.go
@@ -22,6 +22,15 @@ type (
 	Response = openapi.V2PortalExchangeSessionResponseBody
 )
 
+// exchangeResult holds the values produced by the atomic exchange transaction.
+type exchangeResult struct {
+	browserSessionID string
+	expiresAt        int64
+	workspaceID      string
+	externalID       string
+	portalConfigID   string
+}
+
 // Handler implements zen.Route for the portal session exchange endpoint.
 // This endpoint is unauthenticated — it validates the session token itself.
 type Handler struct {
@@ -51,14 +60,6 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	nowMs := time.Now().UnixMilli()
-
-	type exchangeResult struct {
-		browserSessionID string
-		expiresAt        int64
-		workspaceID      string
-		externalID       string
-		portalConfigID   string
-	}
 
 	result, err := db.TxWithResultRetry(ctx, h.DB.RW(), func(ctx context.Context, tx db.DBTX) (exchangeResult, error) {
 		var zero exchangeResult


### PR DESCRIPTION
## What does this PR do?

Fixes the `v2_portal_exchange_session` handler and tests to account for the new `Slug` field on portal configs. Moves the `exchangeResult` struct from an inline function-scoped type to a package-level type for clarity and reusability.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Run the portal exchange session tests: `bazel test //svc/api/routes/v2_portal_exchange_session:v2_portal_exchange_session_test --test_output=all`
- Verify both the 200 and 401 test cases pass with the new `Slug` field included in `InsertPortalConfigParams`
- Confirm the handler still compiles and behaves identically (struct promotion is a no-op refactor)

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [x] Ran `make fmt` on `/go` directory
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary
