### PR TITLE
fix(dashboard) Switch component: dark mode and contrast issues

### DIFF
--- a/web/apps/dashboard/components/ui/switch.tsx
+++ b/web/apps/dashboard/components/ui/switch.tsx
@@ -21,7 +21,7 @@ const Switch = React.forwardRef<
   >
     <SwitchPrimitives.Thumb
       className={cn(
-        "pointer-events-none block h-5 w-5 rounded-full bg-white shadow-sm transition-transform duration-150 ease-out data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0",
+        "pointer-events-none block h-5 w-5 rounded-full bg-background shadow-sm transition-transform duration-150 ease-out data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0 dark:data-[state=checked]:bg-primary-foreground dark:data-[state=unchecked]:bg-foreground",
         thumbClassName,
       )}
     />{" "}

--- a/web/apps/dashboard/components/ui/switch.tsx
+++ b/web/apps/dashboard/components/ui/switch.tsx
@@ -13,7 +13,7 @@ const Switch = React.forwardRef<
 >(({ className, thumbClassName, ...props }, ref) => (
   <SwitchPrimitives.Root
     className={cn(
-      "peer inline-flex h-6 w-10 shrink-0 cursor-pointer items-center rounded-full p-0.5 transition-[background-color,box-shadow] duration-150 ease-out focus-visible:outline-2 focus-visible:outline-accent-8 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-50 disabled:grayscale data-[state=checked]:bg-primary data-[state=unchecked]:bg-grayA-3",
+      "peer inline-flex h-6 w-10 shrink-0 cursor-pointer items-center rounded-full p-0.5 transition-[background-color,box-shadow] duration-150 ease-out focus-visible:outline-2 focus-visible:outline-accent-8 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-50 disabled:grayscale data-[state=checked]:bg-primary data-[state=unchecked]:bg-grayA-5",
       className,
     )}
     {...props}


### PR DESCRIPTION
## Summary
- Fix the hardcoded bg-white on the switch component
- Improve the contrast on the component, so it's easier to see if we put them on areas with muted backgrounds. 

## Screenshots
<img width="1872" height="498" alt="CleanShot 2026-05-08 at 07 57 19@2x" src="https://github.com/user-attachments/assets/88a2fcd2-73a0-4727-accd-7ed8e467cfd3" />
<img width="1878" height="498" alt="CleanShot 2026-05-08 at 07 57 16@2x" src="https://github.com/user-attachments/assets/7dfeac02-f33c-402b-9cee-9af0bd1ea2a1" />
<img width="1864" height="500" alt="CleanShot 2026-05-08 at 07 57 12@2x" src="https://github.com/user-attachments/assets/deecd828-9c18-4f3f-a511-4d9fc9ab53fe" />
<img width="1884" height="498" alt="CleanShot 2026-05-08 at 07 57 04@2x" src="https://github.com/user-attachments/assets/e06dd438-b2c5-416b-93bb-036bab212007" />

## Test plan
- [ ] Visit a project's settings → Auto deploy in dark mode; verify both Production/Preview toggles have visible thumbs in checked and unchecked states.
- [ ] Light mode still looks the same (white thumb on dark/faint track).
- [ ] Sentinel policies, env-var sensitive/secret toggles, metadata protection switch still legible — they override the track but inherit the thumb.

## Follow-up
I'll follow this work up with another PR that fixes the rest of the switches that have overrides on them, to keep everything consistent. 