### PR TITLE
refactor(dashboard) Switch component: drop overrides and cleanup

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/env-vars/components/add/add-env-var-expandable.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/env-vars/components/add/add-env-var-expandable.tsx
@@ -343,11 +343,7 @@ export const AddEnvVarExpandable = ({
                   control={control}
                   name="secret"
                   render={({ field }) => (
-                    <Switch
-                      className="data-[state=checked]:bg-success-9 data-[state=checked]:ring-2 data-[state=checked]:ring-successA-5 data-[state=unchecked]:ring-2 data-[state=unchecked]:ring-grayA-3 data-[state=unchecked]:bg-gray-5"
-                      checked={field.value}
-                      onCheckedChange={field.onChange}
-                    />
+                    <Switch checked={field.value} onCheckedChange={field.onChange} />
                   )}
                 />
                 <span className="text-[13px] text-gray-12 font-medium">Sensitive</span>

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/env-vars/components/list/env-var-edit-row.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/env-vars/components/list/env-var-edit-row.tsx
@@ -183,11 +183,7 @@ export function EnvVarEditRow({ envVarId, variableKey, type, note, onClose }: En
               control={control}
               name="sensitive"
               render={({ field }) => (
-                <Switch
-                  className="data-[state=checked]:bg-success-9 data-[state=checked]:ring-2 data-[state=checked]:ring-successA-5 data-[state=unchecked]:ring-2 data-[state=unchecked]:ring-grayA-3 data-[state=unchecked]:bg-gray-5"
-                  checked={field.value}
-                  onCheckedChange={field.onChange}
-                />
+                <Switch checked={field.value} onCheckedChange={field.onChange} />
               )}
             />
             <span className="text-[13px] text-gray-12 font-medium">Sensitive</span>

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/sentinel-policies/components/list/row.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/sentinel-policies/components/list/row.tsx
@@ -243,12 +243,7 @@ function EnvSwitch({
         onKeyDown={(e) => e.stopPropagation()}
       >
         <span className="text-[13px] text-gray-11 capitalize whitespace-nowrap">{slug}</span>
-        <Switch
-          checked={envPolicy.enabled}
-          onCheckedChange={() => onToggle(id)}
-          className="h-5 w-10 data-[state=checked]:bg-info-9 data-[state=checked]:ring-2 data-[state=checked]:ring-infoA-5 data-[state=unchecked]:bg-grayA-6 data-[state=unchecked]:ring-2 data-[state=unchecked]:ring-grayA-5"
-          thumbClassName="h-4 w-4 data-[state=checked]:translate-x-5"
-        />
+        <Switch checked={envPolicy.enabled} onCheckedChange={() => onToggle(id)} size="sm" />
       </span>
     );
   }

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/settings/components/build-settings/auto-deploy-settings.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/settings/components/build-settings/auto-deploy-settings.tsx
@@ -129,12 +129,7 @@ const EnvRow = ({
   onChange: (value: boolean) => void;
 }) => (
   <div className="flex items-center gap-3 py-1.5 cursor-pointer">
-    <Switch
-      checked={checked}
-      onCheckedChange={onChange}
-      className="h-5"
-      thumbClassName="h-4 w-4 data-[state=checked]:translate-x-5"
-    />
+    <Switch checked={checked} onCheckedChange={onChange} size="sm" />
     <span className="text-sm text-gray-12">
       <span className="font-medium">{label}</span>
       <span className="text-gray-9"> — {description}</span>

--- a/web/apps/dashboard/components/dashboard/metadata/protection-switch.tsx
+++ b/web/apps/dashboard/components/dashboard/metadata/protection-switch.tsx
@@ -26,13 +26,7 @@ export const ProtectionSwitch = forwardRef<HTMLDivElement, FeatureCardProps>(
           </div>
           <div className="text-gray-9 text-xs">{description}</div>
         </div>
-        <Switch
-          className="data-[state=checked]:bg-success-9 data-[state=checked]:ring-2 data-[state=checked]:ring-successA-5 data-[state=unchecked]:bg-gray-3 data-[state=unchecked]:ring-2 data-[state=unchecked]:ring-grayA-3"
-          thumbClassName="data-[state=unchecked]:bg-grayA-9 data-[state=checked]:bg-white"
-          checked={checked}
-          onCheckedChange={onCheckedChange}
-          {...switchProps}
-        />
+        <Switch checked={checked} onCheckedChange={onCheckedChange} {...switchProps} />
       </div>
     );
   },

--- a/web/apps/dashboard/components/ui/switch.tsx
+++ b/web/apps/dashboard/components/ui/switch.tsx
@@ -8,12 +8,13 @@ import { cn } from "@/lib/utils";
 const Switch = React.forwardRef<
   React.ElementRef<typeof SwitchPrimitives.Root>,
   React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root> & {
-    thumbClassName?: string;
+    size?: "default" | "sm";
   }
->(({ className, thumbClassName, ...props }, ref) => (
+>(({ className, size = "default", ...props }, ref) => (
   <SwitchPrimitives.Root
+    data-size={size}
     className={cn(
-      "peer inline-flex h-6 w-10 shrink-0 cursor-pointer items-center rounded-full p-0.5 transition-[background-color,box-shadow] duration-150 ease-out focus-visible:outline-2 focus-visible:outline-accent-8 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-50 disabled:grayscale data-[state=checked]:bg-primary data-[state=unchecked]:bg-grayA-5",
+      "peer group/switch inline-flex shrink-0 cursor-pointer items-center rounded-full p-0.5 transition-[background-color,box-shadow] duration-150 ease-out focus-visible:outline-2 focus-visible:outline-accent-8 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-50 disabled:grayscale data-[state=checked]:bg-primary data-[state=unchecked]:bg-grayA-5 data-[size=default]:h-6 data-[size=default]:w-10 data-[size=sm]:h-5 data-[size=sm]:w-10",
       className,
     )}
     {...props}
@@ -21,10 +22,11 @@ const Switch = React.forwardRef<
   >
     <SwitchPrimitives.Thumb
       className={cn(
-        "pointer-events-none block h-5 w-5 rounded-full bg-background shadow-sm transition-transform duration-150 ease-out data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0 dark:data-[state=checked]:bg-primary-foreground dark:data-[state=unchecked]:bg-foreground",
-        thumbClassName,
+        "pointer-events-none block rounded-full bg-background shadow-sm transition-transform duration-150 ease-out data-[state=unchecked]:translate-x-0 dark:data-[state=checked]:bg-primary-foreground dark:data-[state=unchecked]:bg-foreground",
+        "group-data-[size=default]/switch:h-5 group-data-[size=default]/switch:w-5 group-data-[size=default]/switch:data-[state=checked]:translate-x-4",
+        "group-data-[size=sm]/switch:h-4 group-data-[size=sm]/switch:w-4 group-data-[size=sm]/switch:data-[state=checked]:translate-x-5",
       )}
-    />{" "}
+    />
   </SwitchPrimitives.Root>
 ));
 Switch.displayName = SwitchPrimitives.Root.displayName;


### PR DESCRIPTION
## Summary
- Follow-up to #6130. 
- Five Switch callsites were each hand-rolling track colors, rings, and sizes causing inconsistencies with each other and with the rest of the design system. 
- Added a `size: 'default' | 'sm'` prop on the base for the smaller variant a couple of callsites needed, 
- All five callsites collapse to plain `<Switch checked onCheckedChange />` (with `size="sm"` where applicable). .

## Test plan
If you're reviewing this PR, please test each switch manually and confirm each switch appears correctly, and check light and dark modes too just to be safe.

- [ ] `/<workspaceSlug>/projects/<projectId>/settings` → Auto deploy card
- [ ] `/<workspaceSlug>/projects/<projectId>/sentinel-policies` → per-env toggles on each policy row
- [ ] `/<workspaceSlug>/projects/<projectId>/env-vars` → Add panel → Sensitive toggle
- [ ] `/<workspaceSlug>/projects/<projectId>/env-vars` → click an existing row → Sensitive toggle
- [ ] `/<workspaceSlug>/apis/<apiId>` → Create key → Expiration / Credits / Rate limit toggles