### PR TITLE
feat(pscale): per-PR branch validation workflow

### DIFF
--- a/.github/workflows/pscale-cleanup.yml
+++ b/.github/workflows/pscale-cleanup.yml
@@ -1,0 +1,41 @@
+# Tears down the per-PR PlanetScale branch when a PR closes WITHOUT merging.
+# Merged PRs intentionally leave the branch + deploy request alive so the
+# schema change can still be promoted into staging from the PlanetScale UI.
+name: pscale-cleanup
+
+on:
+  pull_request:
+    types: [closed]
+
+env:
+  PSCALE_ORG: unkey
+  PSCALE_DB: unkey
+  BRANCH: pr-${{ github.event.pull_request.number }}
+
+jobs:
+  cleanup:
+    name: delete planetscale branch
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.merged == false
+    timeout-minutes: 5
+    env:
+      PLANETSCALE_SERVICE_TOKEN_ID: ${{ secrets.PLANETSCALE_SERVICE_TOKEN_ID }}
+      PLANETSCALE_SERVICE_TOKEN: ${{ secrets.PLANETSCALE_SERVICE_TOKEN }}
+    steps:
+      - uses: planetscale/setup-pscale-action@v1
+
+      - name: close open deploy requests
+        # Branch deletion fails while a DR is open, so close them first.
+        run: |
+          set -euo pipefail
+          pscale deploy-request list "$PSCALE_DB" --org "$PSCALE_ORG" --format json \
+            | jq -r --arg b "$BRANCH" \
+                '.[] | select(.branch==$b and .state=="open") | .number' \
+            | while read -r num; do
+                pscale deploy-request close "$PSCALE_DB" "$num" --org "$PSCALE_ORG" || true
+              done
+
+      - name: delete branch
+        run: pscale branch delete "$PSCALE_DB" "$BRANCH" --org "$PSCALE_ORG" --force || true

--- a/.github/workflows/pscale-pr.yml
+++ b/.github/workflows/pscale-pr.yml
@@ -1,0 +1,91 @@
+# Validates MySQL schema changes by spinning up a per-PR PlanetScale branch
+# off staging, running drizzle-kit push against it, and opening a deploy
+# request for review. The branch is left intact so reviewers can connect to it.
+#
+# Security model: this workflow uses `pull_request` (not `pull_request_target`)
+# so secrets are NEVER exposed to fork PRs. The job-level `if:` further skips
+# the run for forks; maintainers re-run by pushing the branch into
+# unkeyed/unkey.
+name: pscale-pr
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "web/internal/db/src/schema/**"
+      - ".github/workflows/pscale-pr.yml"
+
+concurrency:
+  group: pscale-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  PSCALE_ORG: unkey
+  PSCALE_DB: unkey
+  PSCALE_PARENT: staging
+  BRANCH: pr-${{ github.event.pull_request.number }}
+
+jobs:
+  validate:
+    name: validate schema on planetscale branch
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    timeout-minutes: 15
+    env:
+      PLANETSCALE_SERVICE_TOKEN_ID: ${{ secrets.PLANETSCALE_SERVICE_TOKEN_ID }}
+      PLANETSCALE_SERVICE_TOKEN: ${{ secrets.PLANETSCALE_SERVICE_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: planetscale/setup-pscale-action@v1
+
+      - uses: pnpm/action-setup@v4
+        with:
+          package_json_file: web/package.json
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: web/pnpm-lock.yaml
+
+      - name: install web deps
+        run: pnpm --dir=web install --frozen-lockfile
+
+      - name: ensure planetscale branch
+        # Idempotent: re-runs on PR push reuse the existing branch. We probe
+        # with `branch show` to distinguish "already exists" from real errors.
+        run: |
+          set -euo pipefail
+          if ! pscale branch create "$PSCALE_DB" "$BRANCH" \
+              --org "$PSCALE_ORG" --from "$PSCALE_PARENT" --wait; then
+            pscale branch show "$PSCALE_DB" "$BRANCH" --org "$PSCALE_ORG" >/dev/null
+          fi
+
+      - name: run migration
+        run: |
+          set -euo pipefail
+          PW=$(pscale password create "$PSCALE_DB" "$BRANCH" "ci-${GITHUB_SHA::8}" \
+                 --org "$PSCALE_ORG" --format json)
+          USER=$(echo "$PW" | jq -r .username)
+          PASS=$(echo "$PW" | jq -r .plain_text)
+          HOST=$(echo "$PW" | jq -r .access_host_url)
+          export DRIZZLE_DATABASE_URL="mysql://$USER:$PASS@$HOST/$PSCALE_DB?ssl={}"
+          pnpm --dir=web/internal/db run migrate
+
+      - name: ensure deploy request
+        # Open a DR into staging so reviewers have a one-click promotion
+        # surface. Reuse existing open DR for repeat runs of the same PR.
+        run: |
+          set -euo pipefail
+          EXISTING=$(pscale deploy-request list "$PSCALE_DB" --org "$PSCALE_ORG" --format json \
+            | jq -r --arg b "$BRANCH" --arg p "$PSCALE_PARENT" \
+                '.[] | select(.branch==$b and .into_branch==$p and .state=="open") | .number' \
+            | head -n1)
+          if [ -z "$EXISTING" ]; then
+            pscale deploy-request create "$PSCALE_DB" "$BRANCH" \
+              --org "$PSCALE_ORG" --into "$PSCALE_PARENT" \
+              --notes "PR #${{ github.event.pull_request.number }}: ${{ github.event.pull_request.title }}"
+          else
+            echo "Reusing existing deploy request #$EXISTING"
+          fi

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,19 @@ generate-sql:
 	@rm -rf ./web/internal/db/out
 
 
+.PHONY: pscale-branch
+pscale-branch: ## Create PlanetScale branch + run drizzle migration (BRANCH=name [FROM=staging])
+	@if [ -z "$(BRANCH)" ]; then echo "Error: BRANCH is required (e.g., make pscale-branch BRANCH=florian-scratch)"; exit 1; fi
+	@FROM="$${FROM:-staging}"; \
+	pscale branch create unkey "$(BRANCH)" --org unkey --from "$$FROM" --wait \
+		|| pscale branch show unkey "$(BRANCH)" --org unkey >/dev/null; \
+	PW=$$(pscale password create unkey "$(BRANCH)" "local-$$(date +%s)" --org unkey --format json); \
+	USER=$$(echo "$$PW" | jq -r .username); \
+	PASS=$$(echo "$$PW" | jq -r .plain_text); \
+	HOST=$$(echo "$$PW" | jq -r .access_host_url); \
+	DRIZZLE_DATABASE_URL="mysql://$$USER:$$PASS@$$HOST/unkey?ssl={}" \
+		pnpm --dir=web/internal/db run migrate
+
 .PHONY: nuke-docker
 nuke-docker: ## Stop all containers and clean up Docker system
 	docker stop $$(docker ps -aq)


### PR DESCRIPTION
## What does this PR do?

Adds a per-PR PlanetScale branch workflow so MySQL schema changes are validated against a real PlanetScale branch before review, instead of relying on devs to remember `pscale branch create` + `pnpm run migrate` by hand.

**On PR open / push** (when `web/internal/db/src/schema/**` changes):
1. Create branch `pr-N` off `staging` (idempotent, reused across pushes)
2. Mint a CI password
3. Run `drizzle-kit push` against the branch — fails the check if the migration breaks
4. Open (or reuse) a deploy request `pr-N → staging` so reviewers have a one-click promotion surface in the PlanetScale UI

**On PR close (without merging)**: close any open DR + delete the branch.

**On PR merge**: nothing happens — branch + DR stay alive so the schema change can still be promoted from the PlanetScale UI when ready. Promotion (`pr-N → staging` and `staging → main`) stays manual, matching how deploys work today.

Local equivalent: `make pscale-branch BRANCH=florian-scratch [FROM=staging]`.

### Security

- Trigger is `pull_request` (not `pull_request_target`) → secrets are never exposed to fork PRs
- Job-level `if: head.repo.full_name == github.repository` further skips fork PRs entirely

### Files

- `.github/workflows/pscale-pr.yml` — validation on PR open/push
- `.github/workflows/pscale-cleanup.yml` — branch deletion on close (skips merged PRs)
- `Makefile` — `pscale-branch` target for local dev

## What you need to do before merging

1. **Provision a PlanetScale service token** (Settings → Service tokens → New token) on the `unkey` database with scopes:
   - `read_branch`, `write_branch`, `delete_branch`, `connect_branch`
   - `read_deploy_request`, `write_deploy_request`
2. **Add GH repo secrets**:
   - `PLANETSCALE_SERVICE_TOKEN_ID`
   - `PLANETSCALE_SERVICE_TOKEN`
3. (Local devs) `brew install planetscale/tap/pscale jq`

## How to test

1. Land this PR
2. Open a throwaway PR that touches a file under `web/internal/db/src/schema/**`
3. Verify in Actions: `pscale-pr` workflow runs, creates `pr-N` branch in PlanetScale, runs migration, opens DR
4. Close (don't merge) the throwaway PR → verify `pscale-cleanup` deletes the branch + DR
5. Locally: `make pscale-branch BRANCH=$USER-scratch` should create a branch and run the migration

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Chore (refactoring code, technical debt, workflow improvements)

## Checklist

- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
