### PR TITLE
fix(pscale): move to .depot workflows + security fixes from CodeRabbit

### DIFF
--- a/.depot/workflows/job_detect_changes.yaml
+++ b/.depot/workflows/job_detect_changes.yaml
@@ -26,6 +26,9 @@ on:
       configs:
         description: "Whether config files have changed"
         value: ${{ jobs.build.outputs.configs }}
+      db_schema:
+        description: "Whether MySQL drizzle schema has changed"
+        value: ${{ jobs.build.outputs.db_schema }}
 permissions:
   contents: read
 jobs:
@@ -43,6 +46,7 @@ jobs:
       dependencies: ${{ steps.changes.outputs.dependencies }}
       packages: ${{ steps.changes.outputs.packages }}
       configs: ${{ steps.changes.outputs.configs }}
+      db_schema: ${{ steps.changes.outputs.db_schema }}
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
@@ -116,6 +120,10 @@ jobs:
             packages:
               - 'web/internal/**'
               - 'web/packages/**'
+
+            # MySQL schema (drizzle source of truth)
+            db_schema:
+              - 'web/internal/db/src/schema/**'
 
             # Configuration files
             configs:

--- a/.depot/workflows/job_pscale_pr.yaml
+++ b/.depot/workflows/job_pscale_pr.yaml
@@ -1,41 +1,24 @@
-# Validates MySQL schema changes by spinning up a per-PR PlanetScale branch
-# off staging, running drizzle-kit push against it, and opening a deploy
-# request for review. The branch is left intact so reviewers can connect to it.
-#
-# Security model: this workflow uses `pull_request` (not `pull_request_target`)
-# so secrets are NEVER exposed to fork PRs. The job-level `if:` further skips
-# the run for forks; maintainers re-run by pushing the branch into
-# unkeyed/unkey.
-name: pscale-pr
-
+name: PlanetScale PR Branch
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-    paths:
-      - "web/internal/db/src/schema/**"
-      - ".github/workflows/pscale-pr.yml"
-
-concurrency:
-  group: pscale-pr-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
-
+  workflow_call:
+permissions:
+  contents: read
 env:
   PSCALE_ORG: unkey
   PSCALE_DB: unkey
   PSCALE_PARENT: staging
   BRANCH: pr-${{ github.event.pull_request.number }}
-
 jobs:
   validate:
-    name: validate schema on planetscale branch
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    name: Validate schema on PlanetScale branch
+    runs-on: depot-ubuntu-24.04-4
     timeout-minutes: 15
+    if: github.event.pull_request.head.repo.full_name == github.repository
     env:
       PLANETSCALE_SERVICE_TOKEN_ID: ${{ secrets.PLANETSCALE_SERVICE_TOKEN_ID }}
       PLANETSCALE_SERVICE_TOKEN: ${{ secrets.PLANETSCALE_SERVICE_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
 
       - uses: planetscale/setup-pscale-action@v1
 
@@ -53,8 +36,8 @@ jobs:
         run: pnpm --dir=web install --frozen-lockfile
 
       - name: ensure planetscale branch
-        # Idempotent: re-runs on PR push reuse the existing branch. We probe
-        # with `branch show` to distinguish "already exists" from real errors.
+        # Idempotent: re-runs on PR push reuse the existing branch. Probe with
+        # `branch show` to distinguish "already exists" from real errors.
         run: |
           set -euo pipefail
           if ! pscale branch create "$PSCALE_DB" "$BRANCH" \
@@ -63,19 +46,26 @@ jobs:
           fi
 
       - name: run migration
+        # USER/PASS/HOST are URL-encoded via jq's @uri before composing the DSN
+        # so reserved characters in any field can't break parsing.
         run: |
           set -euo pipefail
           PW=$(pscale password create "$PSCALE_DB" "$BRANCH" "ci-${GITHUB_SHA::8}" \
                  --org "$PSCALE_ORG" --format json)
-          USER=$(echo "$PW" | jq -r .username)
-          PASS=$(echo "$PW" | jq -r .plain_text)
-          HOST=$(echo "$PW" | jq -r .access_host_url)
+          USER=$(echo "$PW" | jq -r '.username | @uri')
+          PASS=$(echo "$PW" | jq -r '.plain_text | @uri')
+          HOST=$(echo "$PW" | jq -r '.access_host_url | @uri')
           export DRIZZLE_DATABASE_URL="mysql://$USER:$PASS@$HOST/$PSCALE_DB?ssl={}"
           pnpm --dir=web/internal/db run migrate
 
       - name: ensure deploy request
         # Open a DR into staging so reviewers have a one-click promotion
         # surface. Reuse existing open DR for repeat runs of the same PR.
+        # PR_NUMBER and PR_TITLE come in via env so untrusted PR title text
+        # can't be interpreted as shell.
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           set -euo pipefail
           EXISTING=$(pscale deploy-request list "$PSCALE_DB" --org "$PSCALE_ORG" --format json \
@@ -85,7 +75,7 @@ jobs:
           if [ -z "$EXISTING" ]; then
             pscale deploy-request create "$PSCALE_DB" "$BRANCH" \
               --org "$PSCALE_ORG" --into "$PSCALE_PARENT" \
-              --notes "PR #${{ github.event.pull_request.number }}: ${{ github.event.pull_request.title }}"
+              --notes "PR #${PR_NUMBER}: ${PR_TITLE}"
           else
             echo "Reusing existing deploy request #$EXISTING"
           fi

--- a/.depot/workflows/pr.yaml
+++ b/.depot/workflows/pr.yaml
@@ -42,3 +42,9 @@ jobs:
     if: ((github.event_name == 'pull_request' && github.event.pull_request.draft == false) || github.event_name != 'pull_request') && needs.detect_changes.result == 'success' && needs.detect_changes.outputs.workflows == 'true'
     needs: [detect_changes]
     uses: ./.depot/workflows/job_validate_workflows.yaml
+  pscale_pr:
+    name: PlanetScale PR Branch
+    if: ((github.event_name == 'pull_request' && github.event.pull_request.draft == false) || github.event_name != 'pull_request') && needs.detect_changes.result == 'success' && needs.detect_changes.outputs.db_schema == 'true'
+    needs: [detect_changes]
+    uses: ./.depot/workflows/job_pscale_pr.yaml
+    secrets: inherit

--- a/.depot/workflows/pscale_cleanup.yaml
+++ b/.depot/workflows/pscale_cleanup.yaml
@@ -1,25 +1,24 @@
+name: PlanetScale Cleanup
 # Tears down the per-PR PlanetScale branch when a PR closes WITHOUT merging.
 # Merged PRs intentionally leave the branch + deploy request alive so the
 # schema change can still be promoted into staging from the PlanetScale UI.
-name: pscale-cleanup
-
 on:
   pull_request:
     types: [closed]
-
+permissions:
+  contents: read
 env:
   PSCALE_ORG: unkey
   PSCALE_DB: unkey
   BRANCH: pr-${{ github.event.pull_request.number }}
-
 jobs:
   cleanup:
-    name: delete planetscale branch
-    runs-on: ubuntu-latest
+    name: Delete PlanetScale branch
+    runs-on: depot-ubuntu-24.04-4
+    timeout-minutes: 5
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.merged == false
-    timeout-minutes: 5
     env:
       PLANETSCALE_SERVICE_TOKEN_ID: ${{ secrets.PLANETSCALE_SERVICE_TOKEN_ID }}
       PLANETSCALE_SERVICE_TOKEN: ${{ secrets.PLANETSCALE_SERVICE_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -46,9 +46,9 @@ pscale-branch: ## Create PlanetScale branch + run drizzle migration (BRANCH=name
 	pscale branch create unkey "$(BRANCH)" --org unkey --from "$$FROM" --wait \
 		|| pscale branch show unkey "$(BRANCH)" --org unkey >/dev/null; \
 	PW=$$(pscale password create unkey "$(BRANCH)" "local-$$(date +%s)" --org unkey --format json); \
-	USER=$$(echo "$$PW" | jq -r .username); \
-	PASS=$$(echo "$$PW" | jq -r .plain_text); \
-	HOST=$$(echo "$$PW" | jq -r .access_host_url); \
+	USER=$$(echo "$$PW" | jq -r '.username | @uri'); \
+	PASS=$$(echo "$$PW" | jq -r '.plain_text | @uri'); \
+	HOST=$$(echo "$$PW" | jq -r '.access_host_url | @uri'); \
 	DRIZZLE_DATABASE_URL="mysql://$$USER:$$PASS@$$HOST/unkey?ssl={}" \
 		pnpm --dir=web/internal/db run migrate
 


### PR DESCRIPTION
## What does this PR do?

Three follow-ups to #6135:

1. **Move workflows to `.depot/`** — the original PR put workflows under `.github/workflows/`, but this repo runs CI through Depot's reusable workflow system in `.depot/workflows/`. Files there were never going to be picked up by the existing `pr.yaml` orchestrator. Migrated:
   - `.github/workflows/pscale-pr.yml` → `.depot/workflows/job_pscale_pr.yaml` (reusable, called from `pr.yaml`)
   - `.github/workflows/pscale-cleanup.yml` → `.depot/workflows/pscale_cleanup.yaml` (standalone, on `pull_request: closed`)
   - Added `db_schema` paths-filter output to `job_detect_changes.yaml`
   - Wired `pscale_pr` job into `pr.yaml` with `secrets: inherit`, gated on `db_schema == 'true'`
   - Switched runners to `depot-ubuntu-24.04-4`

2. **Command injection fix** (CodeRabbit on #6135): `${{ github.event.pull_request.title }}` was interpolated directly into a `bash -c` block. A maliciously crafted PR title could execute arbitrary shell. Now passed via `env:` so it's a regular `$PR_TITLE` expansion.

3. **URL-encode connection string components** (CodeRabbit on #6135): `username`, `plain_text` (password), and `access_host_url` from `pscale password create` are now piped through `jq … | @uri` before being assembled into `DRIZZLE_DATABASE_URL`. PlanetScale-issued credentials are URL-safe today; this is defensive.

### Skipped (with reason)

- "Use proper JSON `ssl=` value" — current `ssl={}` matches existing manual workflow + Drizzle convention.
- "Log cleanup failures instead of `\|\| true`" — CodeRabbit itself flagged as low value.

## How to test

1. Merge this
2. Open a throwaway PR touching `web/internal/db/src/schema/**`
3. Verify the `pscale_pr` job runs as part of the `PR` workflow (visible under the PR's checks)
4. Close (don't merge) the PR → `pscale_cleanup` runs and tears down branch + DR

## Reminder

GitHub repo secrets `PLANETSCALE_SERVICE_TOKEN_ID` and `PLANETSCALE_SERVICE_TOKEN` still need to be set (from #6135 setup). Depot runners are just compute — they read from the same GH secret store.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (workflow improvements)
