### PR TITLE
fix(dashboard): read audit logs from ClickHouse with correct filter

### DIFF
--- a/web/apps/dashboard/lib/trpc/routers/audit/fetch.ts
+++ b/web/apps/dashboard/lib/trpc/routers/audit/fetch.ts
@@ -1,22 +1,13 @@
 import { auditLogsQueryPayload } from "@/components/audit-logs-table/schema/audit-logs.schema";
 import { auth } from "@/lib/auth/server";
 import type { User } from "@/lib/auth/types";
-import {
-  type Quotas,
-  type Workspace,
-  and,
-  between,
-  count,
-  db,
-  eq,
-  gte,
-  inArray,
-  schema,
-} from "@/lib/db";
+import { clickhouse } from "@/lib/clickhouse";
+import type { Quotas, Workspace } from "@/lib/db";
 import { freeTierQuotas } from "@/lib/quotas";
 import { ratelimit, withRatelimit, workspaceProcedure } from "@/lib/trpc/trpc";
+import { TRPCError } from "@trpc/server";
 import { z } from "zod";
-import { type AuditLogWithTargets, type AuditQueryLogsParams, auditLog } from "./schema";
+import { type AuditQueryLogsParams, auditLog } from "./schema";
 import { transformFilters } from "./utils";
 
 const LIMIT = 50;
@@ -55,11 +46,21 @@ const AuditLogsResponse = z.object({
 
 type AuditLogsResponse = z.infer<typeof AuditLogsResponse>;
 
-// Reads audit logs from the legacy MySQL `audit_log` table while the
-// ClickHouse backfill catches up. Writers still dual-write to MySQL +
-// the clickhouse_outbox, so MySQL is the complete source of truth; CH
-// only has rows from the moment the export drainer started shipping.
-// Flip back to clickhouse.auditLogs.logs() once the backfill is done.
+function nullIfEmpty(s: string): string | null {
+  return s.length === 0 ? null : s;
+}
+
+function parseJSON(s: string): unknown {
+  if (s.length === 0) {
+    return null;
+  }
+  try {
+    return JSON.parse(s);
+  } catch {
+    return s;
+  }
+}
+
 export const fetchAuditLog = workspaceProcedure
   .use(withRatelimit(ratelimit.read))
   .input(auditLogsQueryPayload)
@@ -70,46 +71,35 @@ export const fetchAuditLog = workspaceProcedure
     const page = Math.max(1, params.page ?? 1);
     const offset = (page - 1) * pageSize;
 
-    const whereConditions = buildWhereConditions(params, ctx.workspace);
+    const queryArgs = buildQueryArgs(params, ctx.workspace, pageSize, offset);
     const cacheKey = getCountCacheKey(ctx.workspace.id, params);
     const cachedCount = getCachedCount(cacheKey);
 
-    // Tiebreak on pk so the workspace_id_bucket_time_idx composite covers
-    // the sort: InnoDB stores pk as the implicit trailing column in every
-    // secondary index, so ORDER BY (time, pk) avoids a filesort. id is
-    // unique and monotonic-with-insert like pk, so pagination stability
-    // is preserved.
-    const [totalCount, logs] = await (cachedCount !== null
-      ? Promise.all([
-          cachedCount,
-          db.query.auditLog.findMany({
-            where: and(...whereConditions),
-            with: { targets: true },
-            orderBy: (table, { desc }) => [desc(table.time), desc(table.pk)],
-            limit: pageSize,
-            offset,
-          }),
-        ])
-      : Promise.all([
-          db
-            .select({ count: count() })
-            .from(schema.auditLog)
-            .where(and(...whereConditions))
-            .then((result) => {
-              const total = result[0]?.count ?? 0;
-              countCache.set(cacheKey, { count: total, timestamp: Date.now() });
-              return total;
-            }),
-          db.query.auditLog.findMany({
-            where: and(...whereConditions),
-            with: { targets: true },
-            orderBy: (table, { desc }) => [desc(table.time), desc(table.pk)],
-            limit: pageSize,
-            offset,
-          }),
-        ]));
+    const { getLogsQuery, getTotalQuery } = clickhouse.auditLogs.logs(queryArgs);
 
-    const uniqueUsers = await fetchUsersFromLogs(logs);
+    const [countResult, logsResult] = await Promise.all([
+      cachedCount !== null
+        ? Promise.resolve({ val: [{ totalCount: cachedCount }], err: null })
+        : getTotalQuery(),
+      getLogsQuery(),
+    ]);
+
+    if (countResult.err || logsResult.err) {
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: "Something went wrong when fetching audit logs from clickhouse.",
+      });
+    }
+
+    const totalCount = countResult.val[0]?.totalCount ?? 0;
+    if (cachedCount === null) {
+      countCache.set(cacheKey, { count: totalCount, timestamp: Date.now() });
+    }
+
+    const logs = logsResult.val;
+    const uniqueUsers = await fetchUsersByActorIds(
+      logs.filter((l) => l.actorType === "user").map((l) => l.actorId),
+    );
 
     const items: AuditLogsResponse["auditLogs"] = logs.map((l) => {
       const user = uniqueUsers[l.actorId];
@@ -123,23 +113,23 @@ export const fetchAuditLog = workspaceProcedure
             }
           : undefined,
         auditLog: {
-          id: l.id,
+          id: l.eventId,
           time: l.time,
           actor: {
             id: l.actorId,
-            name: l.actorName,
+            name: nullIfEmpty(l.actorName),
             type: l.actorType,
           },
-          location: l.remoteIp,
-          description: l.display,
-          userAgent: l.userAgent,
+          location: nullIfEmpty(l.remoteIp),
+          description: l.description,
+          userAgent: nullIfEmpty(l.userAgent),
           event: l.event,
-          workspaceId: l.workspaceId,
-          targets: l.targets.map((t) => ({
-            id: t.id,
-            type: t.type,
-            name: t.name,
-            meta: t.meta,
+          workspaceId: ctx.workspace.id,
+          targets: l.targets.map(([type, id, name, meta]) => ({
+            id,
+            type,
+            name: nullIfEmpty(name),
+            meta: parseJSON(meta),
           })),
         },
       };
@@ -151,58 +141,43 @@ export const fetchAuditLog = workspaceProcedure
     };
   });
 
-function buildWhereConditions(
+function buildQueryArgs(
   params: Omit<AuditQueryLogsParams, "workspaceId">,
   workspace: Workspace & { quotas: Quotas | null },
+  limit: number,
+  offset: number,
 ) {
   const events = (params.events ?? []).map((e) => e.value);
   const userValues = (params.users ?? []).map((u) => u.value);
   const rootKeyValues = (params.rootKeys ?? []).map((r) => r.value);
-  const users = [...userValues, ...rootKeyValues];
+  const actorIds = [...userValues, ...rootKeyValues];
 
   const retentionDays =
     workspace.quotas?.auditLogsRetentionDays || freeTierQuotas.auditLogsRetentionDays;
   const retentionCutoffUnixMilli = Date.now() - retentionDays * 24 * 60 * 60 * 1000;
 
-  const hasTimeFilter = params.startTime !== undefined || params.endTime !== undefined;
+  const startTime = Math.max(
+    params.startTime ?? retentionCutoffUnixMilli,
+    retentionCutoffUnixMilli,
+  );
+  const endTime = params.endTime ?? Date.now();
 
-  const conditions = [
-    eq(schema.auditLog.workspaceId, workspace.id),
-    eq(schema.auditLog.bucket, params.bucket),
-  ];
-
-  if (events.length > 0) {
-    conditions.push(inArray(schema.auditLog.event, events));
-  }
-
-  if (hasTimeFilter) {
-    conditions.push(
-      between(
-        schema.auditLog.time,
-        Math.max(params.startTime ?? retentionCutoffUnixMilli, retentionCutoffUnixMilli),
-        params.endTime ?? Date.now(),
-      ),
-    );
-  } else {
-    conditions.push(gte(schema.auditLog.time, retentionCutoffUnixMilli));
-  }
-
-  if (users.length > 0) {
-    conditions.push(inArray(schema.auditLog.actorId, users));
-  }
-
-  return conditions;
+  return {
+    workspaceId: workspace.id,
+    bucketId: params.bucket,
+    limit,
+    offset,
+    startTime,
+    endTime,
+    events,
+    actorIds,
+  };
 }
 
-export const fetchUsersFromLogs = async (
-  logs: AuditLogWithTargets[],
-): Promise<Record<string, User>> => {
+async function fetchUsersByActorIds(actorIds: string[]): Promise<Record<string, User>> {
   try {
-    const userIds = [...new Set(logs.filter((l) => l.actorType === "user").map((l) => l.actorId))];
-
-    const users = await Promise.all(
-      userIds.map((userId) => auth.getUser(userId).catch(() => null)),
-    );
+    const unique = [...new Set(actorIds)];
+    const users = await Promise.all(unique.map((userId) => auth.getUser(userId).catch(() => null)));
 
     return users.reduce(
       (acc, user) => {
@@ -217,4 +192,4 @@ export const fetchUsersFromLogs = async (
     console.error("Error fetching users:", error);
     return {};
   }
-};
+}

--- a/web/internal/clickhouse/src/audit-logs.ts
+++ b/web/internal/clickhouse/src/audit-logs.ts
@@ -16,21 +16,21 @@ export const auditLogsRequestSchema = z.object({
 
 export type AuditLogsRequest = z.infer<typeof auditLogsRequestSchema>;
 
-// workspace_id and bucket_id are intentionally omitted: they're always equal
-// to the query filter values and selecting `any(workspace_id) AS workspace_id`
+// workspace_id and bucket are intentionally omitted: they're always equal
+// to the query filter values and selecting `any(workspace_id) AS workspaceId`
 // would shadow the WHERE column and trigger ILLEGAL_AGGREGATION in ClickHouse.
 // Callers reconstruct those fields from their own context.
 export const auditLogRow = z.object({
-  event_id: z.string(),
+  eventId: z.string(),
   time: z.int(),
   event: z.string(),
   description: z.string(),
-  actor_type: z.string(),
-  actor_id: z.string(),
-  actor_name: z.string(),
-  actor_meta: z.string(),
-  remote_ip: z.string(),
-  user_agent: z.string(),
+  actorType: z.string(),
+  actorId: z.string(),
+  actorName: z.string(),
+  actorMeta: z.string(),
+  remoteIp: z.string(),
+  userAgent: z.string(),
   meta: z.string(),
   targets: z.array(z.tuple([z.string(), z.string(), z.string(), z.string()])),
 });
@@ -39,23 +39,20 @@ export type AuditLogRow = z.infer<typeof auditLogRow>;
 
 export function getAuditLogs(ch: Querier) {
   return (args: AuditLogsRequest) => {
-    const filterConditions = `
-      workspace_id = {workspaceId: String}
-      AND bucket = {bucketId: String}
-      AND time BETWEEN {startTime: UInt64} AND {endTime: UInt64}
-      AND (
-        CASE
-          WHEN length({events: Array(String)}) > 0 THEN event IN {events: Array(String)}
-          ELSE TRUE
-        END
-      )
-      AND (
-        CASE
-          WHEN length({actorIds: Array(String)}) > 0 THEN actor_id IN {actorIds: Array(String)}
-          ELSE TRUE
-        END
-      )
-    `;
+    // Conditions are built per-call rather than wrapped in CASE WHEN so CH
+    // can push event/actor predicates into the set/bloom skip indexes.
+    const conditions = [
+      "workspace_id = {workspaceId: String}",
+      "bucket = {bucketId: String}",
+      "time BETWEEN {startTime: UInt64} AND {endTime: UInt64}",
+    ];
+    if (args.events.length > 0) {
+      conditions.push("event IN {events: Array(String)}");
+    }
+    if (args.actorIds.length > 0) {
+      conditions.push("actor_id IN {actorIds: Array(String)}");
+    }
+    const filterConditions = conditions.join(" AND ");
 
     // Targets are Nested(type, id, name, meta) — already grouped per
     // event_id in the table layout — so no GROUP BY / ARRAY JOIN
@@ -64,16 +61,16 @@ export function getAuditLogs(ch: Querier) {
     const logsQuery = ch.query({
       query: `
         SELECT
-          event_id,
+          event_id AS eventId,
           time,
           event,
           description,
-          actor_type,
-          actor_id,
-          actor_name,
-          toJSONString(actor_meta) AS actor_meta,
-          remote_ip,
-          user_agent,
+          actor_type AS actorType,
+          actor_id AS actorId,
+          actor_name AS actorName,
+          toJSONString(actor_meta) AS actorMeta,
+          remote_ip AS remoteIp,
+          user_agent AS userAgent,
           toJSONString(meta) AS meta,
           arrayMap(
             (targetType, targetId, targetName, targetMeta) ->
@@ -88,18 +85,22 @@ export function getAuditLogs(ch: Querier) {
       schema: auditLogRow,
     });
 
+    // count() over countDistinct(event_id): event_id is row-identity and the
+    // ReplacingMergeTree dedup catches retries, so the only divergence is a
+    // few unmerged rows in a short window. The result is cached for 5min
+    // upstream, which makes that drift invisible.
     const totalQuery = ch.query({
       query: `
-        SELECT countDistinct(event_id) AS total_count
+        SELECT count() AS totalCount
         FROM ${TABLE}
         WHERE ${filterConditions}`,
       params: auditLogsRequestSchema,
-      schema: z.object({ total_count: z.int() }),
+      schema: z.object({ totalCount: z.int() }),
     });
 
     return {
-      logsQuery: logsQuery(args),
-      totalQuery: totalQuery(args),
+      getLogsQuery: () => logsQuery(args),
+      getTotalQuery: () => totalQuery(args),
     };
   };
 }


### PR DESCRIPTION
## What

This replaces our auditlog reads from mysql to clickhouse, so that we can drop auditlogs from mysql afterwards.

## Test plan

- [ ] tsc + biome clean (verified locally)
- [ ] `pnpm --dir=apps/dashboard build` clean (verified locally)
- [ ] On staging: open the audit log page, confirm rows show up that match what the MySQL read in #6143 was returning
- [ ] Pagination still works (ORDER BY `time DESC, event_id DESC`)
- [ ] Event / actor / time filters still narrow results
- [ ] Per-workspace `auditLogsRetentionDays` still clamps the time window

Once this is verified on staging the MySQL fallback path is dead code and can be deleted, but I'm leaving that for a follow-up so this PR stays surgical.