### PR TITLE
fix: local vault storage fig

### DIFF
--- a/dev/k8s/manifests/vault.yaml
+++ b/dev/k8s/manifests/vault.yaml
@@ -13,7 +13,7 @@ data:
     [encryption]
     master_key = "Ch9rZWtfMmdqMFBJdVhac1NSa0ZhNE5mOWlLSnBHenFPENTt7an5MRogENt9Si6wms4pQ2XIvqNSIgNpaBenJmXgcInhu6Nfv2U="
 
-    [s3]
+    [storage.s3]
     url = "http://s3:3902"
     bucket = "vault"
     access_key_id = "minio_root_user"


### PR DESCRIPTION
## What does this PR do?

Fixes the Vault configuration section header for S3 storage by correcting `[s3]` to `[storage.s3]` in the local Kubernetes development manifest.

Fixes # (issue)

_If there is not an issue for this, please create one first. This is used to tracking purposes and also helps us understand why this PR exists_

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Spin up the local Kubernetes dev environment and verify that the Vault service starts correctly and can connect to the S3-compatible storage (Minio) without configuration errors.
- Confirm that Vault can read and write to the `vault` bucket using the provided credentials.

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary