### PR TITLE
fix: handle frontline errs

### DIFF
--- a/svc/frontline/middleware/BUILD.bazel
+++ b/svc/frontline/middleware/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "middleware",
     srcs = [
         "clickhouse_logging.go",
+        "client_gone.go",
         "observability.go",
         "sanitize_headers.go",
     ],
@@ -27,9 +28,14 @@ go_library(
 
 go_test(
     name = "middleware_test",
-    srcs = ["sanitize_headers_test.go"],
+    srcs = [
+        "client_gone_test.go",
+        "observability_test.go",
+        "sanitize_headers_test.go",
+    ],
     embed = [":middleware"],
     deps = [
+        "//pkg/codes",
         "//pkg/zen",
         "@com_github_stretchr_testify//require",
     ],

--- a/svc/frontline/middleware/client_gone.go
+++ b/svc/frontline/middleware/client_gone.go
@@ -1,0 +1,33 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"syscall"
+)
+
+// isClientGone reports whether err indicates that the client closed the
+// connection before we finished writing a response. These are not server
+// faults and must not be alerted on.
+//
+// We check exported sentinels first (context.Canceled, EPIPE, ECONNRESET)
+// and fall back to substring matches for unexported errors emitted by
+// net/http/http2 such as "http2: stream closed" and "client disconnected".
+func isClientGone(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	if errors.Is(err, context.Canceled) ||
+		errors.Is(err, syscall.EPIPE) ||
+		errors.Is(err, syscall.ECONNRESET) {
+		return true
+	}
+
+	msg := err.Error()
+	return strings.Contains(msg, "client disconnected") ||
+		strings.Contains(msg, "stream closed") ||
+		strings.Contains(msg, "broken pipe") ||
+		strings.Contains(msg, "connection reset by peer")
+}

--- a/svc/frontline/middleware/client_gone_test.go
+++ b/svc/frontline/middleware/client_gone_test.go
@@ -1,0 +1,40 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsClientGone(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "context canceled", err: context.Canceled, want: true},
+		{name: "wrapped context canceled", err: fmt.Errorf("send: %w", context.Canceled), want: true},
+		{name: "EPIPE", err: syscall.EPIPE, want: true},
+		{name: "ECONNRESET", err: syscall.ECONNRESET, want: true},
+		{name: "http2 stream closed", err: errors.New("failed to send bytes: http2: stream closed"), want: true},
+		{name: "client disconnected", err: errors.New("failed to send bytes: client disconnected"), want: true},
+		{name: "broken pipe text", err: errors.New("write tcp: broken pipe"), want: true},
+		{name: "connection reset by peer text", err: errors.New("read tcp: connection reset by peer"), want: true},
+		{name: "unrelated error", err: errors.New("json marshal failed"), want: false},
+		{name: "context deadline exceeded is server-side", err: context.DeadlineExceeded, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, isClientGone(tt.err))
+		})
+	}
+}

--- a/svc/frontline/middleware/observability.go
+++ b/svc/frontline/middleware/observability.go
@@ -130,7 +130,16 @@ func WithObservability(renderer errorpage.Renderer) zen.Middleware {
 				}
 
 				if writeErr != nil {
-					logger.Error("failed to write error response", "error", writeErr.Error())
+					if isClientGone(writeErr) {
+						// Client disconnected before we could flush the error
+						// page. Not actionable — don't alert on it.
+						logger.Debug("client gone before error response was written",
+							"error", writeErr.Error(),
+							"requestId", s.RequestID(),
+						)
+					} else {
+						logger.Error("failed to write error response", "error", writeErr.Error())
+					}
 				}
 			}
 
@@ -159,6 +168,45 @@ func getErrorPageInfoFrontline(urn codes.URN) errorPageInfo {
 			Status:  499,
 			Title:   "Client Closed Request",
 			Message: "The client closed the connection before the request completed.",
+		}
+	case codes.User.BadRequest.RequestTimeout.URN():
+		// Frontline acts as a gateway: a request-processing deadline that
+		// fires here means upstream took too long. Surface as 504, not 500,
+		// so it doesn't trigger server-error alerting.
+		return errorPageInfo{
+			Status:  http.StatusGatewayTimeout,
+			Title:   http.StatusText(http.StatusGatewayTimeout),
+			Message: "The request took too long to process. Please try again later.",
+		}
+	case codes.User.BadRequest.RequestBodyTooLarge.URN():
+		return errorPageInfo{
+			Status:  http.StatusRequestEntityTooLarge,
+			Title:   http.StatusText(http.StatusRequestEntityTooLarge),
+			Message: "The request body exceeds the maximum allowed size.",
+		}
+	case codes.User.BadRequest.RequestBodyUnreadable.URN():
+		return errorPageInfo{
+			Status:  http.StatusBadRequest,
+			Title:   http.StatusText(http.StatusBadRequest),
+			Message: "The request body could not be read.",
+		}
+	case codes.Auth.Authentication.Missing.URN():
+		return errorPageInfo{
+			Status:  http.StatusUnauthorized,
+			Title:   http.StatusText(http.StatusUnauthorized),
+			Message: "Authentication required.",
+		}
+	case codes.Auth.Authentication.Malformed.URN():
+		return errorPageInfo{
+			Status:  http.StatusUnauthorized,
+			Title:   http.StatusText(http.StatusUnauthorized),
+			Message: "The authentication credentials are malformed.",
+		}
+	case codes.App.Validation.InvalidInput.URN():
+		return errorPageInfo{
+			Status:  http.StatusBadRequest,
+			Title:   http.StatusText(http.StatusBadRequest),
+			Message: "",
 		}
 	case codes.Frontline.Routing.ConfigNotFound.URN():
 		return errorPageInfo{

--- a/svc/frontline/middleware/observability_test.go
+++ b/svc/frontline/middleware/observability_test.go
@@ -1,0 +1,70 @@
+package middleware
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/codes"
+)
+
+// TestGetErrorPageInfoFrontline_StatusMapping locks in the URN → HTTP status
+// mapping. A new URN that lacks an explicit case will fall through to the
+// default branch and be reported as 500, which causes false 5xx alerts.
+//
+// When you add a new URN that frontline can produce, add a case here too.
+func TestGetErrorPageInfoFrontline_StatusMapping(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		urn        codes.URN
+		wantStatus int
+	}{
+		// Client-side / user errors — must not be 5xx.
+		{codes.User.BadRequest.ClientClosedRequest.URN(), 499},
+		{codes.User.BadRequest.RequestTimeout.URN(), http.StatusGatewayTimeout},
+		{codes.User.BadRequest.RequestBodyTooLarge.URN(), http.StatusRequestEntityTooLarge},
+		{codes.User.BadRequest.RequestBodyUnreadable.URN(), http.StatusBadRequest},
+		{codes.Auth.Authentication.Missing.URN(), http.StatusUnauthorized},
+		{codes.Auth.Authentication.Malformed.URN(), http.StatusUnauthorized},
+		{codes.App.Validation.InvalidInput.URN(), http.StatusBadRequest},
+
+		// Frontline-specific errors with established mappings.
+		{codes.Frontline.Routing.ConfigNotFound.URN(), http.StatusNotFound},
+		{codes.Frontline.Routing.DeploymentNotFound.URN(), http.StatusNotFound},
+		{codes.Frontline.Routing.NoRunningInstances.URN(), http.StatusServiceUnavailable},
+		{codes.Frontline.Proxy.BadGateway.URN(), http.StatusBadGateway},
+		{codes.Frontline.Proxy.ProxyForwardFailed.URN(), http.StatusBadGateway},
+		{codes.Frontline.Proxy.ServiceUnavailable.URN(), http.StatusServiceUnavailable},
+		{codes.Frontline.Proxy.GatewayTimeout.URN(), http.StatusGatewayTimeout},
+		{codes.Frontline.Auth.MissingCredentials.URN(), http.StatusUnauthorized},
+		{codes.Frontline.Auth.InvalidKey.URN(), http.StatusUnauthorized},
+		{codes.Frontline.Auth.InsufficientPermissions.URN(), http.StatusForbidden},
+		{codes.Frontline.Auth.RateLimited.URN(), http.StatusTooManyRequests},
+		{codes.Frontline.Firewall.Denied.URN(), http.StatusForbidden},
+		{codes.Frontline.OpenApi.InvalidRequest.URN(), http.StatusBadRequest},
+
+		// Genuine server-side faults — 5xx is correct.
+		{codes.Frontline.Routing.DeploymentSelectionFailed.URN(), http.StatusInternalServerError},
+		{codes.Frontline.Internal.InvalidConfiguration.URN(), http.StatusInternalServerError},
+		{codes.Frontline.Internal.InternalServerError.URN(), http.StatusInternalServerError},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.urn), func(t *testing.T) {
+			t.Parallel()
+			got := getErrorPageInfoFrontline(tt.urn)
+			require.Equal(t, tt.wantStatus, got.Status,
+				"URN %s should map to HTTP %d, got %d",
+				tt.urn, tt.wantStatus, got.Status)
+		})
+	}
+}
+
+func TestGetErrorPageInfoFrontline_UnknownURNDefaultsTo500(t *testing.T) {
+	t.Parallel()
+
+	got := getErrorPageInfoFrontline("err:made:up:nonexistent")
+	require.Equal(t, http.StatusInternalServerError, got.Status,
+		"unknown URN should default to 500 so we get alerted on it")
+}


### PR DESCRIPTION
## What does this PR do?

Fixes false-positive server-error alerts in the frontline middleware by distinguishing client-initiated disconnections from genuine server faults.

Adds an `isClientGone` helper that detects when a client closed the connection before a response could be flushed. It checks exported sentinels (`context.Canceled`, `EPIPE`, `ECONNRESET`) and falls back to substring matching for unexported `net/http/http2` errors. When a write failure is caused by a gone client, the observability middleware now logs at `Debug` instead of `Error`, preventing spurious alerts.

Also expands `getErrorPageInfoFrontline` to explicitly map several URNs that were previously falling through to the 500 default:

- `RequestTimeout` → 504 Gateway Timeout (frontline acts as a gateway, so upstream timeouts should not trigger server-error alerting)
- `RequestBodyTooLarge` → 413
- `RequestBodyUnreadable` → 400
- `Auth.Authentication.Missing` → 401
- `Auth.Authentication.Malformed` → 401
- `App.Validation.InvalidInput` → 400

A new `observability_test.go` locks in the full URN → HTTP status mapping so that any future URN added without an explicit case will be caught before it silently produces a 500.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Run `TestIsClientGone` to verify that `context.Canceled`, `EPIPE`, `ECONNRESET`, and the various string-matched error messages are all detected as client-gone, while unrelated errors and `context.DeadlineExceeded` are not.
- Run `TestGetErrorPageInfoFrontline_StatusMapping` to confirm every listed URN maps to its expected HTTP status and no client-side URN resolves to 5xx.
- Run `TestGetErrorPageInfoFrontline_UnknownURNDefaultsTo500` to confirm that an unrecognised URN still defaults to 500 so genuine unknown faults remain alerted on.

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary