### PR TITLE
feat(api): use codes.HTTPStatus resolver in error middleware

### DIFF
--- a/svc/api/internal/middleware/BUILD.bazel
+++ b/svc/api/internal/middleware/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "middleware",
@@ -11,5 +11,16 @@ go_library(
         "//pkg/logger",
         "//pkg/zen",
         "//svc/api/openapi",
+    ],
+)
+
+go_test(
+    name = "middleware_test",
+    srcs = ["errors_test.go"],
+    embed = [":middleware"],
+    deps = [
+        "//pkg/codes",
+        "//svc/api/openapi",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/svc/api/internal/middleware/errors.go
+++ b/svc/api/internal/middleware/errors.go
@@ -11,8 +11,76 @@ import (
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
 
-// WithErrorHandling returns middleware that translates errors into appropriate
-// HTTP responses based on error URNs.
+// apiStatusOverrides holds the rare cases where the api emits a different
+// HTTP status than the code's canonical mapping in pkg/codes.
+//
+// The api treats missing or malformed credentials as 400 Bad Request
+// rather than 401 Unauthorized — historical behavior, kept here for
+// backwards compatibility with documented client expectations.
+//
+//nolint:exhaustive // sparse override map; not every URN has an override.
+var apiStatusOverrides = map[codes.URN]codes.HTTPStatus{
+	codes.Auth.Authentication.Missing.URN():   codes.StatusBadRequest,
+	codes.Auth.Authentication.Malformed.URN(): codes.StatusBadRequest,
+	codes.Portal.Session.TokenMissing.URN():   codes.StatusBadRequest,
+}
+
+// apiTitleOverrides holds per-URN titles that differ from the standard
+// status reason phrase (status.Text()). Most error pages use the stdlib
+// reason phrase; entries here express api-specific phrasing.
+//
+//nolint:exhaustive // sparse override map; not every URN has an override.
+var apiTitleOverrides = map[codes.URN]string{
+	codes.User.BadRequest.ClientClosedRequest.URN():        "Client Closed Request", // 499 has no stdlib name
+	codes.Data.RatelimitNamespace.Gone.URN():               "Resource Gone",
+	codes.Auth.Authorization.InsufficientPermissions.URN(): "Insufficient Permissions",
+	codes.Data.Permission.Duplicate.URN():                  "Conflicting Resource",
+	codes.Data.Role.Duplicate.URN():                        "Conflicting Resource",
+	codes.Data.Identity.Duplicate.URN():                    "Conflicting Resource",
+	codes.App.Protection.ProtectedResource.URN():           "Resource is protected",
+	codes.Auth.Authorization.KeyDisabled.URN():             "Key is disabled",
+	codes.Auth.Authorization.WorkspaceDisabled.URN():       "Workspace is disabled",
+}
+
+// httpStatus resolves the HTTP status the api should return for urn.
+// Resolution order:
+//
+//  1. Per-service override (apiStatusOverrides).
+//  2. Per-code mapping in pkg/codes (Code.HTTPStatus()).
+//  3. 500 — the URN is malformed or the code lives in a non-HTTP
+//     category and leaked. Both are bugs worth alerting on.
+func httpStatus(urn codes.URN) codes.HTTPStatus {
+	if s, ok := apiStatusOverrides[urn]; ok {
+		return s
+	}
+	code, err := codes.ParseURN(urn)
+	if err != nil {
+		return codes.StatusInternalServerError
+	}
+	if s := code.HTTPStatus(); s != 0 {
+		return s
+	}
+	return codes.StatusInternalServerError
+}
+
+// errorTitle returns the human-readable title for the response. Defaults
+// to status.Text() (the standard reason phrase); special-cases live in
+// apiTitleOverrides.
+func errorTitle(status codes.HTTPStatus, urn codes.URN) string {
+	if t, ok := apiTitleOverrides[urn]; ok {
+		return t
+	}
+	return status.Text()
+}
+
+// WithErrorHandling returns middleware that translates errors into
+// appropriate HTTP responses based on the URN attached to the error.
+//
+// The status comes from pkg/codes (Category default + per-code overrides
+// + per-service overrides). The response *body shape* still varies per
+// status (BadRequestErrorResponse, NotFoundErrorResponse, …) and is
+// selected by buildErrorBody — a switch on status, not URN, so adding
+// a new code never requires touching this file.
 func WithErrorHandling() zen.Middleware {
 	return func(next zen.HandleFunc) zen.HandleFunc {
 		return func(ctx context.Context, s *zen.Session) error {
@@ -21,11 +89,11 @@ func WithErrorHandling() zen.Middleware {
 				return nil
 			}
 
-			// Store the internal error message for metrics logging before we
-			// convert it to an HTTP response and lose the details.
+			// Store the internal error message for metrics logging
+			// before we convert it to an HTTP response and lose the
+			// details.
 			s.SetInternalError(fault.InternalMessage(err))
 
-			// Get the error URN from the error
 			urn, ok := fault.GetCode(err)
 			if !ok {
 				urn = codes.App.Internal.UnexpectedError.URN()
@@ -35,326 +103,96 @@ func WithErrorHandling() zen.Middleware {
 			if parseErr != nil {
 				logger.Error("failed to parse error code", "error", parseErr.Error())
 				code = codes.App.Internal.UnexpectedError
+				urn = code.URN()
 			}
-			//nolint:exhaustive
-			switch urn {
-			// Not Found errors
-			case codes.UnkeyDataErrorsKeyNotFound,
-				codes.UnkeyDataErrorsWorkspaceNotFound,
-				codes.UnkeyDataErrorsApiNotFound,
-				codes.UnkeyDataErrorsMigrationNotFound,
-				codes.UnkeyDataErrorsKeySpaceNotFound,
-				codes.UnkeyDataErrorsPermissionNotFound,
-				codes.UnkeyDataErrorsProjectNotFound,
-				codes.UnkeyDataErrorsRoleNotFound,
-				codes.UnkeyDataErrorsKeyAuthNotFound,
-				codes.UnkeyDataErrorsRatelimitNamespaceNotFound,
-				codes.UnkeyDataErrorsRatelimitOverrideNotFound,
-				codes.UnkeyDataErrorsIdentityNotFound,
-				codes.UnkeyDataErrorsAuditLogNotFound,
-				codes.UnkeyDataErrorsPortalConfigNotFound:
-				return s.ProblemJSON(http.StatusNotFound, openapi.NotFoundErrorResponse{
-					Meta: openapi.Meta{
-						RequestId: s.RequestID(),
-					},
-					Error: openapi.BaseError{
-						Title:  "Not Found",
-						Type:   code.DocsURL(),
-						Detail: fault.UserFacingMessage(err),
-						Status: http.StatusNotFound,
-					},
-				})
 
-			// Bad Request errors - General validation
-			case codes.UnkeyAppErrorsValidationInvalidInput,
-				codes.UnkeyAuthErrorsAuthenticationMissing,
-				codes.UnkeyAuthErrorsAuthenticationMalformed,
-				codes.UserErrorsBadRequestPermissionsQuerySyntaxError,
-				codes.UserErrorsBadRequestRequestBodyUnreadable,
-				codes.UnkeyPortalErrorsSessionTokenMissing:
-				return s.ProblemJSON(http.StatusBadRequest, openapi.BadRequestErrorResponse{
-					Meta: openapi.Meta{
-						RequestId: s.RequestID(),
-					},
-					Error: openapi.BadRequestErrorDetails{
-						Title:  "Bad Request",
-						Type:   code.DocsURL(),
-						Detail: fault.UserFacingMessage(err),
-						Status: http.StatusBadRequest,
-						Errors: []openapi.ValidationError{},
-					},
-				})
+			status := httpStatus(urn)
+			detail := fault.UserFacingMessage(err)
+			title := errorTitle(status, urn)
 
-			// Bad Request errors - Query validation (malformed queries)
-			case codes.UserErrorsBadRequestInvalidAnalyticsQuery,
-				codes.UserErrorsBadRequestInvalidAnalyticsTable,
-				codes.UserErrorsBadRequestInvalidAnalyticsFunction,
-				codes.UserErrorsBadRequestInvalidAnalyticsQueryType,
-				codes.UserErrorsBadRequestQueryRangeExceedsRetention:
-				return s.ProblemJSON(http.StatusBadRequest, openapi.BadRequestErrorResponse{
-					Meta: openapi.Meta{
-						RequestId: s.RequestID(),
-					},
-					Error: openapi.BadRequestErrorDetails{
-						Title:  "Bad Request",
-						Type:   code.DocsURL(),
-						Detail: fault.UserFacingMessage(err),
-						Status: http.StatusBadRequest,
-						Errors: []openapi.ValidationError{},
-					},
-				})
-
-			// Unprocessable Entity - Query resource limits
-			case codes.UserErrorsUnprocessableEntityQueryExecutionTimeout,
-				codes.UserErrorsUnprocessableEntityQueryMemoryLimitExceeded,
-				codes.UserErrorsUnprocessableEntityQueryRowsLimitExceeded:
-				return s.ProblemJSON(http.StatusUnprocessableEntity, openapi.UnprocessableEntityErrorResponse{
-					Meta: openapi.Meta{
-						RequestId: s.RequestID(),
-					},
-					Error: openapi.BaseError{
-						Title:  http.StatusText(http.StatusUnprocessableEntity),
-						Type:   code.DocsURL(),
-						Detail: fault.UserFacingMessage(err),
-						Status: http.StatusUnprocessableEntity,
-					},
-				})
-
-			// Too Many Requests - Rate limiting
-			case codes.UserErrorsTooManyRequestsQueryQuotaExceeded,
-				codes.UserErrorsTooManyRequestsWorkspaceRateLimited:
-				return s.ProblemJSON(http.StatusTooManyRequests, openapi.TooManyRequestsErrorResponse{
-					Meta: openapi.Meta{
-						RequestId: s.RequestID(),
-					},
-					Error: openapi.BaseError{
-						Title:  http.StatusText(http.StatusTooManyRequests),
-						Type:   code.DocsURL(),
-						Detail: fault.UserFacingMessage(err),
-						Status: http.StatusTooManyRequests,
-					},
-				})
-
-			// Request Timeout errors
-			case codes.UserErrorsBadRequestRequestTimeout:
-				return s.ProblemJSON(http.StatusRequestTimeout, openapi.BadRequestErrorResponse{
-					Meta: openapi.Meta{
-						RequestId: s.RequestID(),
-					},
-					Error: openapi.BadRequestErrorDetails{
-						Title:  "Request Timeout",
-						Type:   code.DocsURL(),
-						Detail: fault.UserFacingMessage(err),
-						Status: http.StatusRequestTimeout,
-						Errors: []openapi.ValidationError{},
-					},
-				})
-
-			// Client Closed Request errors (499 - non-standard but widely used)
-			case codes.UserErrorsBadRequestClientClosedRequest:
-				return s.ProblemJSON(499, openapi.BadRequestErrorResponse{
-					Meta: openapi.Meta{
-						RequestId: s.RequestID(),
-					},
-					Error: openapi.BadRequestErrorDetails{
-						Title:  "Client Closed Request",
-						Type:   code.DocsURL(),
-						Detail: fault.UserFacingMessage(err),
-						Status: 499,
-						Errors: []openapi.ValidationError{},
-					},
-				})
-
-			// Request Entity Too Large errors
-			case codes.UserErrorsBadRequestRequestBodyTooLarge:
-				return s.ProblemJSON(http.StatusRequestEntityTooLarge, openapi.BadRequestErrorResponse{
-					Meta: openapi.Meta{
-						RequestId: s.RequestID(),
-					},
-					Error: openapi.BadRequestErrorDetails{
-						Title:  "Request Entity Too Large",
-						Type:   code.DocsURL(),
-						Detail: fault.UserFacingMessage(err),
-						Status: http.StatusRequestEntityTooLarge,
-						Errors: []openapi.ValidationError{},
-					},
-				})
-
-			// Gone errors
-			case codes.UnkeyDataErrorsRatelimitNamespaceGone:
-				return s.ProblemJSON(http.StatusGone, openapi.GoneErrorResponse{
-					Meta: openapi.Meta{
-						RequestId: s.RequestID(),
-					},
-					Error: openapi.BaseError{
-						Title:  "Resource Gone",
-						Type:   code.DocsURL(),
-						Detail: fault.UserFacingMessage(err),
-						Status: http.StatusGone,
-					},
-				})
-
-			// Unauthorized errors
-			case codes.UnkeyAuthErrorsAuthenticationKeyNotFound,
-				codes.UnkeyPortalErrorsSessionSessionNotFound:
-				return s.ProblemJSON(http.StatusUnauthorized, openapi.UnauthorizedErrorResponse{
-					Meta: openapi.Meta{
-						RequestId: s.RequestID(),
-					},
-					Error: openapi.BaseError{
-						Title:  "Unauthorized",
-						Type:   code.DocsURL(),
-						Detail: fault.UserFacingMessage(err),
-						Status: http.StatusUnauthorized,
-					},
-				})
-
-			// Forbidden errors
-			case codes.UnkeyAuthErrorsAuthorizationForbidden:
-				return s.ProblemJSON(http.StatusForbidden, openapi.ForbiddenErrorResponse{
-					Meta: openapi.Meta{
-						RequestId: s.RequestID(),
-					},
-					Error: openapi.BaseError{
-						Title:  "Forbidden",
-						Type:   code.DocsURL(),
-						Detail: fault.UserFacingMessage(err),
-						Status: http.StatusForbidden,
-					},
-				})
-
-			// Insufficient Permissions
-			case codes.UnkeyAuthErrorsAuthorizationInsufficientPermissions:
-				return s.ProblemJSON(http.StatusForbidden, openapi.ForbiddenErrorResponse{
-					Meta: openapi.Meta{
-						RequestId: s.RequestID(),
-					},
-					Error: openapi.BaseError{
-						Title:  "Insufficient Permissions",
-						Type:   code.DocsURL(),
-						Detail: fault.UserFacingMessage(err),
-						Status: http.StatusForbidden,
-					},
-				})
-
-			// Duplicate errors
-			case codes.UnkeyDataErrorsIdentityDuplicate,
-				codes.UnkeyDataErrorsRoleDuplicate,
-				codes.UnkeyDataErrorsPermissionDuplicate:
-				return s.ProblemJSON(http.StatusConflict, openapi.ConflictErrorResponse{
-					Meta: openapi.Meta{
-						RequestId: s.RequestID(),
-					},
-					Error: openapi.BaseError{
-						Title:  "Conflicting Resource",
-						Type:   code.DocsURL(),
-						Detail: fault.UserFacingMessage(err),
-						Status: http.StatusConflict,
-					},
-				})
-
-			// Protected Resource
-			case codes.UnkeyAppErrorsProtectionProtectedResource:
-				return s.ProblemJSON(http.StatusPreconditionFailed, openapi.PreconditionFailedErrorResponse{
-					Meta: openapi.Meta{
-						RequestId: s.RequestID(),
-					},
-					Error: openapi.BaseError{
-						Title:  "Resource is protected",
-						Type:   code.DocsURL(),
-						Detail: fault.UserFacingMessage(err),
-						Status: http.StatusPreconditionFailed,
-					},
-				})
-
-			// Precondition Failed
-			case codes.UnkeyDataErrorsAnalyticsNotConfigured,
-				codes.UnkeyAppErrorsPreconditionPreconditionFailed:
-				return s.ProblemJSON(http.StatusPreconditionFailed, openapi.PreconditionFailedErrorResponse{
-					Meta: openapi.Meta{
-						RequestId: s.RequestID(),
-					},
-					Error: openapi.BaseError{
-						Title:  "Precondition Failed",
-						Type:   code.DocsURL(),
-						Detail: fault.UserFacingMessage(err),
-						Status: http.StatusPreconditionFailed,
-					},
-				})
-
-			// Key disabled
-			case codes.UnkeyAuthErrorsAuthorizationKeyDisabled:
-				return s.ProblemJSON(http.StatusForbidden, openapi.ForbiddenErrorResponse{
-					Meta: openapi.Meta{
-						RequestId: s.RequestID(),
-					},
-					Error: openapi.BaseError{
-						Title:  "Key is disabled",
-						Type:   code.DocsURL(),
-						Detail: fault.UserFacingMessage(err),
-						Status: http.StatusForbidden,
-					},
-				})
-
-			// Workspace disabled
-			case codes.UnkeyAuthErrorsAuthorizationWorkspaceDisabled:
-				return s.ProblemJSON(http.StatusForbidden, openapi.ForbiddenErrorResponse{
-					Meta: openapi.Meta{
-						RequestId: s.RequestID(),
-					},
-					Error: openapi.BaseError{
-						Title:  "Workspace is disabled",
-						Type:   code.DocsURL(),
-						Detail: fault.UserFacingMessage(err),
-						Status: http.StatusForbidden,
-					},
-				})
-
-			// Service Unavailable errors
-			case codes.UnkeyDataErrorsAnalyticsConnectionFailed:
+			// Analytics connection failures are an operational concern
+			// even though they're a 503, not a 500. Log them so on-call
+			// can see the upstream is down.
+			if urn == codes.Data.Analytics.ConnectionFailed.URN() {
 				logger.Error(
 					"analytics connection error",
 					"error", err.Error(),
 					"requestId", s.RequestID(),
-					"publicMessage", fault.UserFacingMessage(err),
+					"publicMessage", detail,
 				)
-
-				return s.ProblemJSON(http.StatusServiceUnavailable, openapi.ServiceUnavailableErrorResponse{
-					Meta: openapi.Meta{
-						RequestId: s.RequestID(),
-					},
-					Error: openapi.BaseError{
-						Title:  "Service Unavailable",
-						Type:   code.DocsURL(),
-						Detail: fault.UserFacingMessage(err),
-						Status: http.StatusServiceUnavailable,
-					},
-				})
-
-			// Internal errors
-			case codes.UnkeyAppErrorsInternalUnexpectedError,
-				codes.UnkeyAppErrorsInternalServiceUnavailable,
-				codes.UnkeyAppErrorsValidationAssertionFailed:
-				// Fall through to default 500 error
 			}
 
-			logger.Error("api error",
-				"error", err.Error(),
-				"requestId", s.RequestID(),
-				"publicMessage", fault.UserFacingMessage(err),
-			)
+			// Genuine 500s log loudly so they page on-call.
+			if status == codes.StatusInternalServerError {
+				logger.Error("api error",
+					"error", err.Error(),
+					"requestId", s.RequestID(),
+					"publicMessage", detail,
+				)
+			}
 
-			return s.ProblemJSON(http.StatusInternalServerError, openapi.InternalServerErrorResponse{
-				Meta: openapi.Meta{
-					RequestId: s.RequestID(),
-				},
-				Error: openapi.BaseError{
-					Title:  "Internal Server Error",
-					Type:   code.DocsURL(),
-					Detail: fault.UserFacingMessage(err),
-					Status: http.StatusInternalServerError,
-				},
-			})
+			body := buildErrorBody(status, title, code.DocsURL(), detail, s.RequestID())
+			return s.ProblemJSON(status.Int(), body)
 		}
 	}
+}
+
+// buildErrorBody returns the openapi response body matching status.
+// The api's openapi schema defines a separate response type per status
+// (NotFoundErrorResponse, BadRequestErrorResponse, …); they all share
+// the {Meta, Error} shape with BaseError, except 4xx-with-validation
+// statuses which use BadRequestErrorDetails.
+func buildErrorBody(status codes.HTTPStatus, title, docsURL, detail, requestID string) any {
+	meta := openapi.Meta{RequestId: requestID}
+	base := openapi.BaseError{
+		Title:  title,
+		Type:   docsURL,
+		Detail: detail,
+		Status: status.Int(),
+	}
+	badReqDetails := openapi.BadRequestErrorDetails{
+		Title:  title,
+		Type:   docsURL,
+		Detail: detail,
+		Status: status.Int(),
+		Errors: []openapi.ValidationError{},
+	}
+
+	switch status {
+	case codes.StatusBadRequest,
+		codes.StatusRequestTimeout,
+		codes.StatusRequestEntityTooLarge,
+		codes.StatusClientClosedRequest:
+		return openapi.BadRequestErrorResponse{Meta: meta, Error: badReqDetails}
+	case codes.StatusUnauthorized:
+		return openapi.UnauthorizedErrorResponse{Meta: meta, Error: base}
+	case codes.StatusForbidden:
+		return openapi.ForbiddenErrorResponse{Meta: meta, Error: base}
+	case codes.StatusNotFound:
+		return openapi.NotFoundErrorResponse{Meta: meta, Error: base}
+	case codes.StatusConflict:
+		return openapi.ConflictErrorResponse{Meta: meta, Error: base}
+	case codes.StatusGone:
+		return openapi.GoneErrorResponse{Meta: meta, Error: base}
+	case codes.StatusPreconditionFailed:
+		return openapi.PreconditionFailedErrorResponse{Meta: meta, Error: base}
+	case codes.StatusUnprocessableEntity:
+		return openapi.UnprocessableEntityErrorResponse{Meta: meta, Error: base}
+	case codes.StatusTooManyRequests:
+		return openapi.TooManyRequestsErrorResponse{Meta: meta, Error: base}
+	case codes.StatusServiceUnavailable:
+		return openapi.ServiceUnavailableErrorResponse{Meta: meta, Error: base}
+	case codes.StatusInternalServerError,
+		codes.StatusBadGateway,
+		codes.StatusGatewayTimeout:
+		base.Status = http.StatusInternalServerError
+		base.Title = http.StatusText(http.StatusInternalServerError)
+		return openapi.InternalServerErrorResponse{Meta: meta, Error: base}
+	}
+	// Unmapped status: surface as 500 so on-call notices, and let the
+	// exhaustive linter catch any new HTTPStatus that lands in pkg/codes
+	// without a body mapping here.
+	base.Status = http.StatusInternalServerError
+	base.Title = http.StatusText(http.StatusInternalServerError)
+	return openapi.InternalServerErrorResponse{Meta: meta, Error: base}
 }

--- a/svc/api/internal/middleware/errors_test.go
+++ b/svc/api/internal/middleware/errors_test.go
@@ -1,0 +1,152 @@
+package middleware
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/codes"
+	"github.com/unkeyed/unkey/svc/api/openapi"
+)
+
+// TestHTTPStatus_Mapping locks in the URN → HTTP status mapping for the
+// api service. Most rows resolve via pkg/codes (Code.HTTPStatus); a few
+// resolve via apiStatusOverrides (api treats missing/malformed auth as
+// 400 Bad Request rather than 401, for backwards compatibility).
+//
+// A new URN that ends up returning 500 unintentionally — because either
+// pkg/codes or this package forgot to map it — will fail this test.
+func TestHTTPStatus_Mapping(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		urn        codes.URN
+		wantStatus int
+	}{
+		// Per-service overrides (api maps these to 400, not 401):
+		{codes.Auth.Authentication.Missing.URN(), http.StatusBadRequest},
+		{codes.Auth.Authentication.Malformed.URN(), http.StatusBadRequest},
+		{codes.Portal.Session.TokenMissing.URN(), http.StatusBadRequest},
+
+		// Inherited from pkg/codes (User.BadRequest category → 400).
+		{codes.User.BadRequest.PermissionsQuerySyntaxError.URN(), http.StatusBadRequest},
+		{codes.User.BadRequest.RequestBodyUnreadable.URN(), http.StatusBadRequest},
+		{codes.User.BadRequest.InvalidAnalyticsQuery.URN(), http.StatusBadRequest},
+
+		// pkg/codes per-code overrides:
+		{codes.User.BadRequest.RequestTimeout.URN(), http.StatusRequestTimeout},
+		{codes.User.BadRequest.ClientClosedRequest.URN(), 499},
+		{codes.User.BadRequest.RequestBodyTooLarge.URN(), http.StatusRequestEntityTooLarge},
+		{codes.App.Validation.InvalidInput.URN(), http.StatusBadRequest},
+		{codes.App.Precondition.PreconditionFailed.URN(), http.StatusPreconditionFailed},
+		{codes.App.Protection.ProtectedResource.URN(), http.StatusPreconditionFailed},
+
+		// CategoryUserUnprocessableEntity → 422
+		{codes.User.UnprocessableEntity.QueryExecutionTimeout.URN(), http.StatusUnprocessableEntity},
+		{codes.User.UnprocessableEntity.QueryMemoryLimitExceeded.URN(), http.StatusUnprocessableEntity},
+		{codes.User.UnprocessableEntity.QueryRowsLimitExceeded.URN(), http.StatusUnprocessableEntity},
+
+		// CategoryUserTooManyRequests → 429
+		{codes.User.TooManyRequests.QueryQuotaExceeded.URN(), http.StatusTooManyRequests},
+		{codes.User.TooManyRequests.WorkspaceRateLimited.URN(), http.StatusTooManyRequests},
+
+		// CategoryUnkeyData → 404 by default.
+		{codes.Data.Key.NotFound.URN(), http.StatusNotFound},
+		{codes.Data.Workspace.NotFound.URN(), http.StatusNotFound},
+		{codes.Data.Api.NotFound.URN(), http.StatusNotFound},
+		{codes.Data.PortalConfig.NotFound.URN(), http.StatusNotFound},
+
+		// CategoryUnkeyData per-code overrides:
+		{codes.Data.Permission.Duplicate.URN(), http.StatusConflict},
+		{codes.Data.Role.Duplicate.URN(), http.StatusConflict},
+		{codes.Data.Identity.Duplicate.URN(), http.StatusConflict},
+		{codes.Data.RatelimitNamespace.Gone.URN(), http.StatusGone},
+		{codes.Data.Analytics.NotConfigured.URN(), http.StatusPreconditionFailed},
+		{codes.Data.Analytics.ConnectionFailed.URN(), http.StatusServiceUnavailable},
+
+		// CategoryUnkeyAuthentication → 401
+		{codes.Auth.Authentication.KeyNotFound.URN(), http.StatusUnauthorized},
+		{codes.Portal.Session.SessionNotFound.URN(), http.StatusUnauthorized},
+
+		// CategoryUnkeyAuthorization → 403
+		{codes.Auth.Authorization.Forbidden.URN(), http.StatusForbidden},
+		{codes.Auth.Authorization.InsufficientPermissions.URN(), http.StatusForbidden},
+		{codes.Auth.Authorization.KeyDisabled.URN(), http.StatusForbidden},
+		{codes.Auth.Authorization.WorkspaceDisabled.URN(), http.StatusForbidden},
+
+		// CategoryUnkeyApplication → 500 (genuine server-side faults).
+		{codes.App.Internal.UnexpectedError.URN(), http.StatusInternalServerError},
+		{codes.App.Internal.ServiceUnavailable.URN(), http.StatusInternalServerError},
+		{codes.App.Validation.AssertionFailed.URN(), http.StatusInternalServerError},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.urn), func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.wantStatus, httpStatus(tt.urn).Int(),
+				"URN %s should map to HTTP %d", tt.urn, tt.wantStatus)
+		})
+	}
+}
+
+func TestHTTPStatus_UnknownURNDefaultsTo500(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, http.StatusInternalServerError,
+		httpStatus("err:made:up:nonexistent").Int(),
+		"unknown URN should default to 500 so we get alerted on it")
+}
+
+// TestBuildErrorBody_PicksRightShape verifies that the body builder
+// returns the correct openapi response type for each status. Drift
+// here would mean clients receive a body shape that doesn't match the
+// status code.
+func TestBuildErrorBody_PicksRightShape(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		status   codes.HTTPStatus
+		wantType any
+	}{
+		{codes.StatusBadRequest, openapi.BadRequestErrorResponse{}},
+		{codes.StatusRequestTimeout, openapi.BadRequestErrorResponse{}},
+		{codes.StatusRequestEntityTooLarge, openapi.BadRequestErrorResponse{}},
+		{codes.StatusClientClosedRequest, openapi.BadRequestErrorResponse{}},
+		{codes.StatusUnauthorized, openapi.UnauthorizedErrorResponse{}},
+		{codes.StatusForbidden, openapi.ForbiddenErrorResponse{}},
+		{codes.StatusNotFound, openapi.NotFoundErrorResponse{}},
+		{codes.StatusConflict, openapi.ConflictErrorResponse{}},
+		{codes.StatusGone, openapi.GoneErrorResponse{}},
+		{codes.StatusPreconditionFailed, openapi.PreconditionFailedErrorResponse{}},
+		{codes.StatusUnprocessableEntity, openapi.UnprocessableEntityErrorResponse{}},
+		{codes.StatusTooManyRequests, openapi.TooManyRequestsErrorResponse{}},
+		{codes.StatusServiceUnavailable, openapi.ServiceUnavailableErrorResponse{}},
+		{codes.StatusInternalServerError, openapi.InternalServerErrorResponse{}},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.status.Text(), func(t *testing.T) {
+			t.Parallel()
+			body := buildErrorBody(tt.status, "Title", "https://docs", "detail", "req_xyz")
+			require.IsType(t, tt.wantType, body)
+		})
+	}
+}
+
+func TestErrorTitle(t *testing.T) {
+	t.Parallel()
+
+	// 499 has no stdlib reason phrase — must come from override map.
+	require.Equal(t, "Client Closed Request",
+		errorTitle(codes.StatusClientClosedRequest, codes.User.BadRequest.ClientClosedRequest.URN()))
+
+	// Standard reason phrase kicks in when no override exists.
+	require.Equal(t, http.StatusText(http.StatusNotFound),
+		errorTitle(codes.StatusNotFound, codes.Data.Key.NotFound.URN()))
+
+	// API-specific phrasing for forbidden variants.
+	require.Equal(t, "Insufficient Permissions",
+		errorTitle(codes.StatusForbidden, codes.Auth.Authorization.InsufficientPermissions.URN()))
+	require.Equal(t, "Key is disabled",
+		errorTitle(codes.StatusForbidden, codes.Auth.Authorization.KeyDisabled.URN()))
+}


### PR DESCRIPTION
## What does this PR do?

Replaces the large `switch`-on-URN block in the API error handling middleware with a data-driven approach that derives HTTP status codes from `pkg/codes` mappings rather than hardcoding them per-URN.

**Middleware changes:**
- The ~300-line `switch urn { ... }` is replaced by three small, focused pieces:
  - `httpStatus(urn)` — resolves status via per-service overrides → `pkg/codes` → 500 fallback.
  - `errorTitle(status, urn)` — resolves the human-readable title via per-URN overrides → stdlib reason phrase.
  - `buildErrorBody(status, ...)` — switches on *status* (not URN) to pick the correct openapi response shape, so adding a new error code never requires touching this file.
- Per-service overrides (`apiStatusOverrides`) preserve the existing backwards-compatible behavior of mapping missing/malformed auth credentials to 400 instead of 401.
- Analytics connection failures and genuine 500s each log at the appropriate level independently of the response-building path.
- When `codes.ParseURN` fails, the URN is now also reset to the fallback code's URN so status resolution stays consistent.

Tests are added for `httpStatus`, `buildErrorBody`, and `errorTitle`, covering the full URN → HTTP status mapping, unknown URN fallback to 500, correct openapi response shape per status, and title override behavior for non-standard status codes like 499.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Run `go test ./svc/api/internal/middleware/...` and verify `TestHTTPStatus_Mapping`, `TestHTTPStatus_UnknownURNDefaultsTo500`, `TestBuildErrorBody_PicksRightShape`, and `TestErrorTitle` all pass.
- Manually trigger an API call that produces a `Data.*NotFound` error and confirm the response is `404`.
- Manually trigger an API call with a missing auth credential and confirm the response remains `400` (not `401`), preserving backwards compatibility.
- Manually trigger an analytics connection failure and confirm a `503` is returned and the error is logged at `Error` level.

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary