### PR TITLE
feat(dashboard): new-navigation redesign

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/page.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/page.tsx
@@ -1,13 +1,29 @@
 "use client";
 import { PRODUCT_HOME_ROUTES, useProductSelection } from "@/hooks/use-product-selection";
 import { useWorkspaceNavigation } from "@/hooks/use-workspace-navigation";
+import { useFlag } from "@/lib/flags/provider";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
 
 export default function WorkspacePage() {
+  const newNavigation = useFlag("newNavigation");
+  return newNavigation ? <NewWorkspaceHome /> : <LegacyWorkspaceHome />;
+}
+
+function NewWorkspaceHome() {
   const router = useRouter();
   const workspace = useWorkspaceNavigation();
 
+  useEffect(() => {
+    router.replace(`/${workspace.slug}/projects`);
+  }, [router, workspace.slug]);
+
+  return null;
+}
+
+function LegacyWorkspaceHome() {
+  const router = useRouter();
+  const workspace = useWorkspaceNavigation();
   const { product } = useProductSelection();
 
   useEffect(() => {

--- a/web/apps/dashboard/app/(app)/layout.tsx
+++ b/web/apps/dashboard/app/(app)/layout.tsx
@@ -1,10 +1,14 @@
 "use client";
 
+import { SIDEBAR_WIDTH_VARS, SidebarV2 } from "@/components/navigation/sidebar-v2";
+import { MobileNavDrawer } from "@/components/navigation/sidebar-v2/mobile-nav-drawer";
 import { AppSidebar } from "@/components/navigation/sidebar/app-sidebar";
 import { SidebarMobile } from "@/components/navigation/sidebar/sidebar-mobile";
+import { TopNav } from "@/components/navigation/top-nav";
 import { SidebarProvider } from "@/components/ui/sidebar";
 
 import { LoadingState } from "@/components/loading-state";
+import { useFlag } from "@/lib/flags/provider";
 import { useWorkspace } from "@/providers/workspace-provider";
 import { Empty } from "@unkey/ui";
 import Link from "next/link";
@@ -16,9 +20,58 @@ interface LayoutProps {
   children: React.ReactNode;
 }
 
+type WorkspaceLike = { id: string; enabled: boolean };
+
+// Inner content area shared by the legacy and new-navigation layout
+// shells. The new shell wraps it in TopNav + SidebarV2; the legacy
+// shell wraps it in AppSidebar + SidebarMobile. PR 4 deletes the
+// legacy shell and inlines this back into the only remaining branch.
+function WorkspaceContent({
+  workspace,
+  children,
+}: {
+  workspace: WorkspaceLike;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="w-full flex-1 flex flex-col">
+      {workspace.enabled ? (
+        <QueryTimeProvider>{children}</QueryTimeProvider>
+      ) : (
+        <div className="flex items-center justify-center w-full h-full">
+          <Empty>
+            <Empty.Icon />
+            <Empty.Title>This workspace is disabled</Empty.Title>
+            <Empty.Description>
+              Contact{" "}
+              <Link
+                href={`mailto:support@unkey.com?body=workspaceId: ${workspace.id}`}
+                className="underline"
+              >
+                support@unkey.com
+              </Link>
+            </Empty.Description>
+          </Empty>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ImpersonationBanner() {
+  return (
+    <div className="fixed top-0 inset-x-0 z-50 flex justify-center border-t-2 border-error-9">
+      <div className="bg-error-9 flex -mt-1 font-mono items-center gap-2 text-white text-xs rounded-b overflow-hidden shadow-lg select-none pointer-events-none px-1.5 py-0.5">
+        Impersonation Mode. Do not change anything and log out after you are done.
+      </div>
+    </div>
+  );
+}
+
 export default function Layout({ children }: LayoutProps) {
   const router = useRouter();
   const { user, workspace, quotas, isLoading, error } = useWorkspace();
+  const newNavigation = useFlag("newNavigation");
   useEffect(() => {
     // Don't navigate while loading
     if (isLoading) {
@@ -63,6 +116,29 @@ export default function Layout({ children }: LayoutProps) {
 
   const isImpersonator = user?.impersonator;
 
+  if (newNavigation) {
+    return (
+      <SidebarProvider style={SIDEBAR_WIDTH_VARS}>
+        <div className="h-dvh w-full flex flex-col overflow-hidden bg-white dark:bg-base-12">
+          <TopNav />
+          <MobileNavDrawer />
+          <div className="flex flex-1 overflow-hidden">
+            <SidebarV2 className="bg-gray-1 border-grayA-4" />
+            <div className="flex-1 overflow-auto" style={{ scrollbarGutter: "stable" }}>
+              <div
+                className="isolate bg-base-12 w-full min-h-full overflow-x-auto flex flex-col items-center"
+                id="layout-wrapper"
+              >
+                <WorkspaceContent workspace={workspace}>{children}</WorkspaceContent>
+              </div>
+              {isImpersonator ? <ImpersonationBanner /> : null}
+            </div>
+          </div>
+        </div>
+      </SidebarProvider>
+    );
+  }
+
   return (
     <div className="h-dvh relative flex flex-col overflow-hidden bg-white dark:bg-base-12 lg:flex-row">
       <SidebarProvider>
@@ -79,35 +155,9 @@ export default function Layout({ children }: LayoutProps) {
               {/* Mobile sidebar at the top of content */}
               <SidebarMobile />
 
-              <div className="w-full flex-1 flex flex-col">
-                {workspace.enabled ? (
-                  <QueryTimeProvider>{children}</QueryTimeProvider>
-                ) : (
-                  <div className="flex items-center justify-center w-full h-full">
-                    <Empty>
-                      <Empty.Icon />
-                      <Empty.Title>This workspace is disabled</Empty.Title>
-                      <Empty.Description>
-                        Contact{" "}
-                        <Link
-                          href={`mailto:support@unkey.com?body=workspaceId: ${workspace.id}`}
-                          className="underline"
-                        >
-                          support@unkey.com
-                        </Link>
-                      </Empty.Description>
-                    </Empty>
-                  </div>
-                )}
-              </div>
+              <WorkspaceContent workspace={workspace}>{children}</WorkspaceContent>
             </div>
-            {isImpersonator ? (
-              <div className="fixed top-0 inset-x-0 z-50 flex justify-center border-t-2 border-error-9">
-                <div className="bg-error-9 flex -mt-1 font-mono items-center gap-2 text-white text-xs rounded-b overflow-hidden shadow-lg select-none pointer-events-none px-1.5 py-0.5">
-                  Impersonation Mode. Do not change anything and log out after you are done.
-                </div>
-              </div>
-            ) : null}
+            {isImpersonator ? <ImpersonationBanner /> : null}
           </div>
         </div>
       </SidebarProvider>

--- a/web/apps/dashboard/app/(app)/layout.tsx
+++ b/web/apps/dashboard/app/(app)/layout.tsx
@@ -22,10 +22,6 @@ interface LayoutProps {
 
 type WorkspaceLike = { id: string; enabled: boolean };
 
-// Inner content area shared by the legacy and new-navigation layout
-// shells. The new shell wraps it in TopNav + SidebarV2; the legacy
-// shell wraps it in AppSidebar + SidebarMobile. PR 4 deletes the
-// legacy shell and inlines this back into the only remaining branch.
 function WorkspaceContent({
   workspace,
   children,

--- a/web/apps/dashboard/app/(app)/page.tsx
+++ b/web/apps/dashboard/app/(app)/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useFlag } from "@/lib/flags/provider";
 import { useWorkspace } from "@/providers/workspace-provider";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
@@ -7,12 +8,14 @@ import { useEffect } from "react";
 export default function AppHomePage() {
   const { workspace } = useWorkspace();
   const router = useRouter();
+  const newNavigation = useFlag("newNavigation");
 
   useEffect(() => {
     if (workspace) {
-      router.push(`/${workspace.slug}/apis`);
+      const home = newNavigation ? "projects" : "apis";
+      router.push(`/${workspace.slug}/${home}`);
     }
-  }, [workspace, router]);
+  }, [workspace, router, newNavigation]);
 
   return null; // Layout handles loading states
 }

--- a/web/apps/dashboard/components/dashboard/deploy-feedback-button.tsx
+++ b/web/apps/dashboard/components/dashboard/deploy-feedback-button.tsx
@@ -1,11 +1,17 @@
 "use client";
 
 import { useFeedback } from "@/components/dashboard/feedback-component";
+import { useFlag } from "@/lib/flags/provider";
 import { Chats } from "@unkey/icons";
 import { Button } from "@unkey/ui";
 
 export function DeployFeedbackButton() {
   const { openFeedback } = useFeedback();
+  const newNavigation = useFlag("newNavigation");
+
+  if (newNavigation) {
+    return null;
+  }
 
   return (
     <Button variant="outline" size="md" onClick={() => openFeedback(true, "feedback")}>

--- a/web/apps/dashboard/components/logomark.tsx
+++ b/web/apps/dashboard/components/logomark.tsx
@@ -1,0 +1,30 @@
+import { cn } from "@/lib/utils";
+
+type LogomarkProps = {
+  className?: string;
+};
+
+// "U" glyph from the marketing favicons. `currentColor` lets the parent's
+// text color drive light/dark variants.
+export function Logomark({ className }: LogomarkProps) {
+  return (
+    <span
+      className={cn(
+        "inline-flex size-6 shrink-0 items-center justify-center text-accent-12",
+        className,
+      )}
+      aria-label="Unkey"
+    >
+      <svg
+        viewBox="0 0 512 512"
+        fill="currentColor"
+        xmlns="http://www.w3.org/2000/svg"
+        className="size-5"
+      >
+        <title>Unkey</title>
+        <path d="M170.8 115V340.6H341.2L284.4 397H170.8C139.418 397 114 371.761 114 340.6V115H170.8Z" />
+        <path d="M398 284.2L341.2 340.6V115H398V284.2Z" />
+      </svg>
+    </span>
+  );
+}

--- a/web/apps/dashboard/components/logomark.tsx
+++ b/web/apps/dashboard/components/logomark.tsx
@@ -4,8 +4,6 @@ type LogomarkProps = {
   className?: string;
 };
 
-// "U" glyph from the marketing favicons. `currentColor` lets the parent's
-// text color drive light/dark variants.
 export function Logomark({ className }: LogomarkProps) {
   return (
     <span

--- a/web/apps/dashboard/components/navbar-popover.tsx
+++ b/web/apps/dashboard/components/navbar-popover.tsx
@@ -1,12 +1,13 @@
 "use client";
 import { DisabledWrapper } from "@/app/(app)/[workspaceSlug]/projects/[projectId]/components/disabled-wrapper";
 import { useKeyboardShortcut } from "@/hooks/use-keyboard-shortcut";
+import { useFlag } from "@/lib/flags/provider";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { CaretRight } from "@unkey/icons";
 import { KeyboardButton, Popover, PopoverContent, PopoverTrigger } from "@unkey/ui";
 import { cn } from "@unkey/ui/src/lib/utils";
 import { usePathname, useRouter } from "next/navigation";
-import { type PropsWithChildren, useCallback, useEffect, useRef, useState } from "react";
+import React, { type PropsWithChildren, useCallback, useEffect, useRef, useState } from "react";
 
 export type QuickNavItem = {
   id: string;
@@ -39,7 +40,23 @@ type QuickNavPopoverProps = {
   virtualizationThreshold?: number;
 };
 
-export const QuickNavPopover = ({
+export const QuickNavPopover = (props: PropsWithChildren<QuickNavPopoverProps>) => {
+  const newNavigation = useFlag("newNavigation");
+  if (newNavigation) {
+    return <QuickNavLabel>{props.children}</QuickNavLabel>;
+  }
+  return <QuickNavPopoverLegacy {...props} />;
+};
+
+const QuickNavLabel = ({ children }: PropsWithChildren) => {
+  if (React.isValidElement<{ children?: React.ReactNode }>(children)) {
+    const inner = React.Children.toArray(children.props.children);
+    return <>{inner[0] ?? null}</>;
+  }
+  return <>{children}</>;
+};
+
+const QuickNavPopoverLegacy = ({
   children,
   items,
   title = "Navigate to...",

--- a/web/apps/dashboard/components/navigation/navbar.tsx
+++ b/web/apps/dashboard/components/navigation/navbar.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useFlag } from "@/lib/flags/provider";
 import { Dots } from "@unkey/icons";
 import { Button } from "@unkey/ui";
 import { cn } from "@unkey/ui/src/lib/utils";
@@ -59,34 +62,38 @@ const NavbarUser = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDiv
 NavbarUser.displayName = "GlobalNavbar.User";
 
 const BreadcrumbsLink = React.forwardRef<HTMLAnchorElement, LinkProps>(
-  ({ children, href, className, active, isLast, noop, ...props }, ref) => (
-    <li className="flex items-center gap-3">
-      {noop ? (
-        <span className={cn("text-sm", active ? "text-accent-12" : "text-accent-10", className)}>
-          {children}
-        </span>
-      ) : (
-        <Link
-          ref={ref}
-          href={href}
-          className={cn(
-            "text-sm transition-colors",
-            active ? "text-accent-12" : "text-accent-10 hover:text-accent-11",
-            className,
-          )}
-          {...(active || isLast ? { "aria-current": "page" } : {})}
-          {...props}
-        >
-          {children}
-        </Link>
-      )}
-      {!isLast && (
-        <div className="text-accent-10" aria-hidden="true">
-          /
-        </div>
-      )}
-    </li>
-  ),
+  ({ children, href, className, active, isLast, noop, ...props }, ref) => {
+    const newNavigation = useFlag("newNavigation");
+    const renderAsLabel = noop || newNavigation;
+    return (
+      <li className="flex items-center gap-3">
+        {renderAsLabel ? (
+          <span className={cn("text-sm", active ? "text-accent-12" : "text-accent-10", className)}>
+            {children}
+          </span>
+        ) : (
+          <Link
+            ref={ref}
+            href={href}
+            className={cn(
+              "text-sm transition-colors",
+              active ? "text-accent-12" : "text-accent-10 hover:text-accent-11",
+              className,
+            )}
+            {...(active || isLast ? { "aria-current": "page" } : {})}
+            {...props}
+          >
+            {children}
+          </Link>
+        )}
+        {!isLast && (
+          <div className="text-accent-10" aria-hidden="true">
+            /
+          </div>
+        )}
+      </li>
+    );
+  },
 );
 BreadcrumbsLink.displayName = "GlobalNavbar.Breadcrumbs.Link";
 
@@ -106,7 +113,9 @@ BreadcrumbsEllipsis.displayName = "GlobalNavbar.Breadcrumbs.Ellipsis";
 
 const Breadcrumbs = React.forwardRef<HTMLElement, BaseProps & { icon: React.ReactNode }>(
   ({ children, className, icon, ...props }, ref) => {
+    const newNavigation = useFlag("newNavigation");
     const childrenArray = React.Children.toArray(children);
+    const visibleChildren = newNavigation ? childrenArray.slice(-1) : childrenArray;
     return (
       <nav ref={ref} aria-label="breadcrumb" className={cn("flex", className)} {...props}>
         <ol className="flex items-center gap-3">
@@ -118,7 +127,7 @@ const Breadcrumbs = React.forwardRef<HTMLElement, BaseProps & { icon: React.Reac
               {icon}
             </Button>
           </li>
-          {childrenArray.map((child, index) => {
+          {visibleChildren.map((child, index) => {
             if (!React.isValidElement(child)) {
               return null;
             }
@@ -127,7 +136,7 @@ const Breadcrumbs = React.forwardRef<HTMLElement, BaseProps & { icon: React.Reac
               if (typeof childProps === "object" && childProps !== null) {
                 const enhancedProps = {
                   ...childProps,
-                  isLast: index === childrenArray.length - 1,
+                  isLast: index === visibleChildren.length - 1,
                   key: child.key || `breadcrumb-${index}`,
                 };
                 return React.cloneElement(child, enhancedProps);
@@ -148,6 +157,7 @@ Breadcrumbs.Ellipsis = BreadcrumbsEllipsis;
 
 export const Navbar = React.forwardRef<HTMLElement, BaseProps>(
   ({ children, className, ...props }, ref) => {
+    const newNavigation = useFlag("newNavigation");
     const childrenArray = React.Children.toArray(children);
     const breadcrumbs = childrenArray.find(
       (child) => React.isValidElement(child) && child.type === Breadcrumbs,
@@ -158,6 +168,8 @@ export const Navbar = React.forwardRef<HTMLElement, BaseProps>(
     const user = childrenArray.find(
       (child) => React.isValidElement(child) && child.type === NavbarUser,
     );
+
+    const renderUser = !newNavigation;
 
     return (
       <nav
@@ -171,7 +183,7 @@ export const Navbar = React.forwardRef<HTMLElement, BaseProps>(
         {breadcrumbs}
         <div className="flex-1" />
         {actions}
-        {user || <NavbarUser />}
+        {renderUser && (user || <NavbarUser />)}
       </nav>
     );
   },

--- a/web/apps/dashboard/components/navigation/sidebar-v2/index.tsx
+++ b/web/apps/dashboard/components/navigation/sidebar-v2/index.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { Sidebar, SidebarContent, SidebarFooter, useSidebar } from "@/components/ui/sidebar";
+import { cn } from "@/lib/utils";
+import { SidebarLeftHide, SidebarLeftShow } from "@unkey/icons";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@unkey/ui";
+import { TOP_NAV_HEIGHT } from "../top-nav";
+import { SidebarBody } from "./sidebar-body";
+
+export const SIDEBAR_WIDTH_VARS: React.CSSProperties & {
+  "--sidebar-width": string;
+  "--sidebar-width-icon": string;
+} = {
+  "--sidebar-width": "13rem",
+  "--sidebar-width-icon": "3rem",
+};
+
+type Props = React.ComponentProps<typeof Sidebar>;
+
+export function SidebarV2(props: Props) {
+  const { isMobile } = useSidebar();
+  if (isMobile) {
+    return null;
+  }
+  return (
+    <Sidebar
+      {...props}
+      collapsible="icon"
+      className={cn("[&_[data-sidebar=sidebar]]:bg-gray-1", props.className)}
+      style={{
+        top: TOP_NAV_HEIGHT,
+        height: `calc(100svh - ${TOP_NAV_HEIGHT}px)`,
+      }}
+    >
+      <SidebarContent>
+        <SidebarBody />
+      </SidebarContent>
+      <SidebarFooter className="mx-0 gap-0 border-t-0 p-2">
+        <CollapseButton />
+      </SidebarFooter>
+    </Sidebar>
+  );
+}
+
+function CollapseButton() {
+  const { state, toggleSidebar } = useSidebar();
+  const collapsed = state === "collapsed";
+  const Icon = collapsed ? SidebarLeftShow : SidebarLeftHide;
+  const label = collapsed ? "Expand sidebar" : "Collapse sidebar";
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          onClick={toggleSidebar}
+          aria-label={label}
+          className="flex size-8 items-center justify-center rounded-md text-gray-11 hover:bg-grayA-3 hover:text-gray-12"
+        >
+          <Icon iconSize="md-regular" className="shrink-0" />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent
+        side="right"
+        align="center"
+        className="dark:bg-white bg-black text-gray-1 px-2 py-1 border border-accent-6 shadow-md font-medium text-xs"
+      >
+        {label}
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/web/apps/dashboard/components/navigation/sidebar-v2/mobile-nav-drawer.tsx
+++ b/web/apps/dashboard/components/navigation/sidebar-v2/mobile-nav-drawer.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useSidebar } from "@/components/ui/sidebar";
+import { Drawer } from "@unkey/ui";
+import { usePathname } from "next/navigation";
+import { useEffect } from "react";
+import { SidebarBody } from "./sidebar-body";
+
+// Bottom drawer surfacing SidebarBody on mobile. Built on vaul (via
+// @unkey/ui's Drawer) rather than the local Sheet primitive — vaul is
+// purpose-built for mobile bottom sheets: pinned to the bottom,
+// drag-to-dismiss, momentum, max-h baked in. Reuses shadcn's
+// SidebarProvider openMobile state so the hamburger in TopNav drives
+// this drawer.
+export function MobileNavDrawer() {
+  const { isMobile, openMobile, setOpenMobile } = useSidebar();
+  const pathname = usePathname();
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: pathname is the trigger; the effect body intentionally closes the drawer on route change.
+  useEffect(() => {
+    setOpenMobile(false);
+  }, [pathname, setOpenMobile]);
+
+  if (!isMobile) {
+    return null;
+  }
+
+  return (
+    <Drawer.Root open={openMobile} onOpenChange={setOpenMobile}>
+      <Drawer.Content>
+        <Drawer.Title className="sr-only">Navigation</Drawer.Title>
+        <Drawer.Description className="sr-only">
+          Navigate to sections and sub-pages of the dashboard.
+        </Drawer.Description>
+        <div className="overflow-y-auto">
+          <SidebarBody />
+        </div>
+      </Drawer.Content>
+    </Drawer.Root>
+  );
+}

--- a/web/apps/dashboard/components/navigation/sidebar-v2/mobile-nav-drawer.tsx
+++ b/web/apps/dashboard/components/navigation/sidebar-v2/mobile-nav-drawer.tsx
@@ -6,17 +6,11 @@ import { usePathname } from "next/navigation";
 import { useEffect } from "react";
 import { SidebarBody } from "./sidebar-body";
 
-// Bottom drawer surfacing SidebarBody on mobile. Built on vaul (via
-// @unkey/ui's Drawer) rather than the local Sheet primitive — vaul is
-// purpose-built for mobile bottom sheets: pinned to the bottom,
-// drag-to-dismiss, momentum, max-h baked in. Reuses shadcn's
-// SidebarProvider openMobile state so the hamburger in TopNav drives
-// this drawer.
 export function MobileNavDrawer() {
   const { isMobile, openMobile, setOpenMobile } = useSidebar();
   const pathname = usePathname();
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: pathname is the trigger; the effect body intentionally closes the drawer on route change.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: pathname is the trigger
   useEffect(() => {
     setOpenMobile(false);
   }, [pathname, setOpenMobile]);

--- a/web/apps/dashboard/components/navigation/sidebar-v2/nav-link-list.tsx
+++ b/web/apps/dashboard/components/navigation/sidebar-v2/nav-link-list.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { SidebarGroup, SidebarGroupContent, SidebarMenu } from "@/components/ui/sidebar";
+import type { ResolvedNavLink } from "@/lib/navigation/types";
+import { NavRow } from "./nav-row";
+
+export function NavLinkList({ links }: { links: ResolvedNavLink[] }) {
+  return (
+    <SidebarGroup>
+      <SidebarGroupContent>
+        <SidebarMenu>
+          {links.map((link) => (
+            <NavRow key={link.key} link={link} />
+          ))}
+        </SidebarMenu>
+      </SidebarGroupContent>
+    </SidebarGroup>
+  );
+}

--- a/web/apps/dashboard/components/navigation/sidebar-v2/nav-row.tsx
+++ b/web/apps/dashboard/components/navigation/sidebar-v2/nav-row.tsx
@@ -5,13 +5,6 @@ import { SidebarMenuButton, SidebarMenuItem } from "@/components/ui/sidebar";
 import type { ResolvedNavLink } from "@/lib/navigation/types";
 import Link from "next/link";
 
-// Single-row primitive. `getButtonStyles` carries the legacy active visuals
-// (bg-grayA-3 / text-accent-12) because the dashboard theme doesn't define
-// --sidebar-accent yet — theming the sidebar tokens is a follow-up.
-//
-// Disabled rows render as a real disabled <button> instead of `asChild` Link:
-// aria-disabled on a Link still allows Enter to navigate. The disabled
-// button removes the row from tab order and blocks activation.
 export function NavRow({ link }: { link: ResolvedNavLink }) {
   const Icon = link.icon;
   const tooltip = typeof link.label === "string" ? link.label : undefined;

--- a/web/apps/dashboard/components/navigation/sidebar-v2/nav-row.tsx
+++ b/web/apps/dashboard/components/navigation/sidebar-v2/nav-row.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { getButtonStyles } from "@/components/navigation/sidebar/app-sidebar/components/nav-items/utils";
+import { SidebarMenuButton, SidebarMenuItem } from "@/components/ui/sidebar";
+import type { ResolvedNavLink } from "@/lib/navigation/types";
+import Link from "next/link";
+
+// Single-row primitive. `getButtonStyles` carries the legacy active visuals
+// (bg-grayA-3 / text-accent-12) because the dashboard theme doesn't define
+// --sidebar-accent yet — theming the sidebar tokens is a follow-up.
+//
+// Disabled rows render as a real disabled <button> instead of `asChild` Link:
+// aria-disabled on a Link still allows Enter to navigate. The disabled
+// button removes the row from tab order and blocks activation.
+export function NavRow({ link }: { link: ResolvedNavLink }) {
+  const Icon = link.icon;
+  const tooltip = typeof link.label === "string" ? link.label : undefined;
+  const contents = (
+    <>
+      {Icon ? <Icon iconSize="xl-medium" /> : null}
+      <span>{link.label}</span>
+      {link.tag ? <div className="ml-auto">{link.tag}</div> : null}
+    </>
+  );
+
+  if (link.disabled) {
+    return (
+      <SidebarMenuItem>
+        <SidebarMenuButton
+          disabled
+          tooltip={tooltip}
+          isActive={link.isActive}
+          className={getButtonStyles(link.isActive)}
+        >
+          {contents}
+        </SidebarMenuButton>
+      </SidebarMenuItem>
+    );
+  }
+
+  const linkProps = link.external ? { target: "_blank", rel: "noopener noreferrer" } : {};
+
+  return (
+    <SidebarMenuItem>
+      <SidebarMenuButton
+        asChild
+        tooltip={tooltip}
+        isActive={link.isActive}
+        className={getButtonStyles(link.isActive)}
+      >
+        <Link href={link.href} {...linkProps}>
+          {contents}
+        </Link>
+      </SidebarMenuButton>
+    </SidebarMenuItem>
+  );
+}

--- a/web/apps/dashboard/components/navigation/sidebar-v2/sidebar-body.tsx
+++ b/web/apps/dashboard/components/navigation/sidebar-v2/sidebar-body.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useApiKeyAuthId } from "@/hooks/use-api-key-auth-id";
+import { useSectionContext } from "@/hooks/use-section-context";
+import { useWorkspaceNavigation } from "@/hooks/use-workspace-navigation";
+import {
+  buildApiLinks,
+  buildAuthorizationLinks,
+  buildNamespaceLinks,
+  buildProjectLinks,
+  buildSettingsLinks,
+  buildWorkspaceSections,
+} from "@/lib/navigation/leaves";
+import { useSelectedLayoutSegments } from "next/navigation";
+import { NavLinkList } from "./nav-link-list";
+
+// Pure mapping from route context → ResolvedNavLink[]. Data fetches that
+// the builders need (e.g. keyAuthId for the API leaf) are hoisted here
+// so the builders themselves stay pure functions — testable, and
+// reusable by the future cmd-k registry.
+export function SidebarBody() {
+  const context = useSectionContext();
+  const segments = useSelectedLayoutSegments().slice(1);
+  const { slug } = useWorkspaceNavigation();
+  const keyAuthId = useApiKeyAuthId(context.type === "api" ? context.apiId : undefined);
+
+  const links = (() => {
+    switch (context.type) {
+      case "workspace":
+        return buildWorkspaceSections(slug, segments);
+      case "settings":
+        return buildSettingsLinks(slug, segments);
+      case "authorization":
+        return buildAuthorizationLinks(slug, segments);
+      case "project":
+        return buildProjectLinks(slug, context.projectId, segments);
+      case "api":
+        return buildApiLinks(slug, context.apiId, keyAuthId, segments);
+      case "namespace":
+        return buildNamespaceLinks(slug, context.namespaceId, segments);
+    }
+  })();
+
+  return <NavLinkList links={links} />;
+}

--- a/web/apps/dashboard/components/navigation/sidebar-v2/sidebar-body.tsx
+++ b/web/apps/dashboard/components/navigation/sidebar-v2/sidebar-body.tsx
@@ -14,10 +14,6 @@ import {
 import { useSelectedLayoutSegments } from "next/navigation";
 import { NavLinkList } from "./nav-link-list";
 
-// Pure mapping from route context → ResolvedNavLink[]. Data fetches that
-// the builders need (e.g. keyAuthId for the API leaf) are hoisted here
-// so the builders themselves stay pure functions — testable, and
-// reusable by the future cmd-k registry.
 export function SidebarBody() {
   const context = useSectionContext();
   const segments = useSelectedLayoutSegments().slice(1);

--- a/web/apps/dashboard/components/navigation/top-nav/api-crumb.tsx
+++ b/web/apps/dashboard/components/navigation/top-nav/api-crumb.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useWorkspaceNavigation } from "@/hooks/use-workspace-navigation";
+import { trpc } from "@/lib/trpc/client";
+import { Nodes, Plus } from "@unkey/icons";
+import { Crumb } from "./crumb";
+import type { CrumbPopoverItem } from "./crumb-popover";
+
+export function ApiCrumb({ apiId }: { apiId: string }) {
+  const workspace = useWorkspaceNavigation();
+  const { data } = trpc.api.queryApiKeyDetails.useQuery({ apiId }, { enabled: !!apiId });
+
+  const apiName = data?.currentApi?.name ?? apiId;
+  const siblings = data?.workspaceApis ?? [];
+
+  const items: CrumbPopoverItem[] = siblings.map((api) => ({
+    id: api.id,
+    label: api.name,
+    href: `/${workspace.slug}/apis/${api.id}`,
+  }));
+
+  return (
+    <Crumb
+      icon={<Nodes className="size-3.5 text-accent-11" iconSize="sm-regular" />}
+      label={apiName}
+      href={`/${workspace.slug}/apis/${apiId}`}
+      items={items}
+      currentId={apiId}
+      searchPlaceholder="Find API..."
+      emptyText="No APIs found"
+      footer={{
+        icon: Plus,
+        label: "All APIs",
+        href: `/${workspace.slug}/apis`,
+      }}
+    />
+  );
+}

--- a/web/apps/dashboard/components/navigation/top-nav/crumb-popover.tsx
+++ b/web/apps/dashboard/components/navigation/top-nav/crumb-popover.tsx
@@ -67,6 +67,9 @@ export function CrumbPopover({
       <PopoverContent align="start" className="w-64 p-0" sideOffset={8}>
         <Command
           filter={(value, search) => {
+            if (value.startsWith("__footer__")) {
+              return 1;
+            }
             if (!search) {
               return 1;
             }
@@ -105,7 +108,9 @@ export function CrumbPopover({
                 footer={footer}
                 onSelect={() => {
                   setOpen(false);
-                  if (footer.onClick) {
+                  if (footer.href) {
+                    router.push(footer.href);
+                  } else if (footer.onClick) {
                     footer.onClick();
                   }
                 }}
@@ -135,8 +140,8 @@ function FooterRow({
 
   if (footer.href) {
     return (
-      <CommandItem asChild value={`__footer__${footer.label}`}>
-        <Link href={footer.href} onClick={onSelect} className="gap-2">
+      <CommandItem asChild value={`__footer__${footer.label}`} onSelect={onSelect}>
+        <Link href={footer.href} className="gap-2">
           {body}
         </Link>
       </CommandItem>

--- a/web/apps/dashboard/components/navigation/top-nav/crumb-popover.tsx
+++ b/web/apps/dashboard/components/navigation/top-nav/crumb-popover.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "@/components/ui/command";
+import { cn } from "@/lib/utils";
+import { Check } from "@unkey/icons";
+import type { IconProps } from "@unkey/icons";
+import { Popover, PopoverContent, PopoverTrigger } from "@unkey/ui";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { type ComponentType, type ReactNode, useState } from "react";
+
+export type CrumbPopoverItem = {
+  id: string;
+  label: string;
+  href?: string;
+  onClick?: () => void;
+  badge?: ReactNode;
+};
+
+export type CrumbPopoverFooter = {
+  icon: ComponentType<IconProps>;
+  label: string;
+  href?: string;
+  onClick?: () => void;
+};
+
+type CrumbPopoverProps = {
+  items: CrumbPopoverItem[];
+  currentId?: string;
+  searchPlaceholder: string;
+  emptyText: string;
+  footer: CrumbPopoverFooter;
+  children: ReactNode;
+};
+
+export function CrumbPopover({
+  items,
+  currentId,
+  searchPlaceholder,
+  emptyText,
+  footer,
+  children,
+}: CrumbPopoverProps) {
+  const [open, setOpen] = useState(false);
+  const router = useRouter();
+
+  const selectItem = (item: CrumbPopoverItem) => {
+    setOpen(false);
+    if (item.href) {
+      router.push(item.href);
+    } else if (item.onClick) {
+      item.onClick();
+    }
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>{children}</PopoverTrigger>
+      <PopoverContent align="start" className="w-64 p-0" sideOffset={8}>
+        <Command
+          filter={(value, search) => {
+            if (!search) {
+              return 1;
+            }
+            return value.toLowerCase().includes(search.toLowerCase()) ? 1 : 0;
+          }}
+        >
+          <CommandInput placeholder={searchPlaceholder} />
+          <CommandList>
+            <CommandEmpty className="py-6">{emptyText}</CommandEmpty>
+            <CommandGroup>
+              {items.map((item) => {
+                const isCurrent = item.id === currentId;
+                return (
+                  <CommandItem
+                    key={item.id}
+                    value={item.label}
+                    onSelect={() => selectItem(item)}
+                    className="gap-2"
+                  >
+                    <span className="flex-1 truncate">{item.label}</span>
+                    {item.badge ? <span className="shrink-0">{item.badge}</span> : null}
+                    <Check
+                      iconSize="sm-regular"
+                      className={cn(
+                        "size-3.5 shrink-0 text-accent-12",
+                        isCurrent ? "opacity-100" : "opacity-0",
+                      )}
+                    />
+                  </CommandItem>
+                );
+              })}
+            </CommandGroup>
+            <CommandSeparator />
+            <CommandGroup>
+              <FooterRow
+                footer={footer}
+                onSelect={() => {
+                  setOpen(false);
+                  if (footer.onClick) {
+                    footer.onClick();
+                  }
+                }}
+              />
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function FooterRow({
+  footer,
+  onSelect,
+}: {
+  footer: CrumbPopoverFooter;
+  onSelect: () => void;
+}) {
+  const Icon = footer.icon;
+  const body = (
+    <>
+      <Icon iconSize="sm-regular" className="size-3.5 shrink-0 text-accent-11" />
+      <span className="flex-1 truncate">{footer.label}</span>
+    </>
+  );
+
+  if (footer.href) {
+    return (
+      <CommandItem asChild value={`__footer__${footer.label}`}>
+        <Link href={footer.href} onClick={onSelect} className="gap-2">
+          {body}
+        </Link>
+      </CommandItem>
+    );
+  }
+
+  return (
+    <CommandItem value={`__footer__${footer.label}`} onSelect={onSelect} className="gap-2">
+      {body}
+    </CommandItem>
+  );
+}

--- a/web/apps/dashboard/components/navigation/top-nav/crumb.tsx
+++ b/web/apps/dashboard/components/navigation/top-nav/crumb.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { ChevronExpandY } from "@unkey/icons";
+import Link from "next/link";
+import type { ReactNode } from "react";
+import { CrumbPopover, type CrumbPopoverFooter, type CrumbPopoverItem } from "./crumb-popover";
+
+type CrumbProps = {
+  icon: ReactNode;
+  label: string;
+  href: string;
+  items: CrumbPopoverItem[];
+  currentId: string;
+  searchPlaceholder: string;
+  emptyText: string;
+  footer: CrumbPopoverFooter;
+};
+
+export function Crumb({
+  icon,
+  label,
+  href,
+  items,
+  currentId,
+  searchPlaceholder,
+  emptyText,
+  footer,
+}: CrumbProps) {
+  return (
+    <div className="flex min-w-0 items-center gap-0.5">
+      <Link
+        href={href}
+        className="flex min-w-0 items-center gap-1.5 px-1 py-1 text-[13px] font-medium text-accent-12"
+      >
+        {icon}
+        <span className="truncate max-w-[120px] md:max-w-[180px]">{label}</span>
+      </Link>
+      {/* Sibling switcher is desktop-only. On mobile the crumb is a
+          pure link; lateral navigation uses the section list pages. */}
+      <CrumbPopover
+        items={items}
+        currentId={currentId}
+        searchPlaceholder={searchPlaceholder}
+        emptyText={emptyText}
+        footer={footer}
+      >
+        <button
+          type="button"
+          className="hidden size-6 shrink-0 items-center justify-center rounded-md text-gray-11 hover:bg-grayA-3 hover:text-accent-12 md:flex"
+          aria-label={`Switch ${label}`}
+        >
+          <ChevronExpandY className="size-3" iconSize="sm-regular" />
+        </button>
+      </CrumbPopover>
+    </div>
+  );
+}
+
+export function CrumbSeparator() {
+  return <span className="select-none px-0.5 text-gray-7">/</span>;
+}

--- a/web/apps/dashboard/components/navigation/top-nav/crumb.tsx
+++ b/web/apps/dashboard/components/navigation/top-nav/crumb.tsx
@@ -35,8 +35,6 @@ export function Crumb({
         {icon}
         <span className="truncate max-w-[120px] md:max-w-[180px]">{label}</span>
       </Link>
-      {/* Sibling switcher is desktop-only. On mobile the crumb is a
-          pure link; lateral navigation uses the section list pages. */}
       <CrumbPopover
         items={items}
         currentId={currentId}

--- a/web/apps/dashboard/components/navigation/top-nav/feedback-button.tsx
+++ b/web/apps/dashboard/components/navigation/top-nav/feedback-button.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useFeedback } from "@/components/dashboard/feedback-component";
+import { Chats } from "@unkey/icons";
+import { Button } from "@unkey/ui";
+
+export function TopNavFeedbackButton({ className }: { className?: string }) {
+  const { openFeedback } = useFeedback();
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={() => openFeedback(true, "feedback")}
+      className={className}
+    >
+      <Chats className="size-4" />
+      Feedback
+    </Button>
+  );
+}

--- a/web/apps/dashboard/components/navigation/top-nav/index.tsx
+++ b/web/apps/dashboard/components/navigation/top-nav/index.tsx
@@ -21,9 +21,6 @@ export const TOP_NAV_HEIGHT = 52;
 export function TopNav() {
   const workspace = useWorkspaceNavigation();
   const crumbs = useBreadcrumbs();
-  // The shadcn Sidebar primitive renders itself as a Sheet on mobile via
-  // useSidebar().setOpenMobile — reuse that instead of mounting a parallel
-  // drawer, otherwise the two stack on top of each other.
   const { setOpenMobile } = useSidebar();
 
   return (
@@ -34,10 +31,6 @@ export function TopNav() {
       <Link href={`/${workspace.slug}`} aria-label="Unkey" className="inline-flex items-center">
         <Logomark />
       </Link>
-      {/* Crumbs render on every viewport. min-w-0 lets the labels
-          truncate when the chain would otherwise overflow on narrow
-          screens. Chevron switchers are hidden on mobile inside the
-          Crumb primitive itself. */}
       <div className="flex min-w-0 items-center gap-1">
         <CrumbSeparator />
         {crumbs.map((descriptor, i) => (

--- a/web/apps/dashboard/components/navigation/top-nav/index.tsx
+++ b/web/apps/dashboard/components/navigation/top-nav/index.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { Logomark } from "@/components/logomark";
+import { useSidebar } from "@/components/ui/sidebar";
+import { type BreadcrumbDescriptor, useBreadcrumbs } from "@/hooks/use-breadcrumbs";
+import { useWorkspaceNavigation } from "@/hooks/use-workspace-navigation";
+import { Menu } from "@unkey/icons";
+import Link from "next/link";
+import { Fragment } from "react";
+import { HelpButton } from "../sidebar/help-button";
+import { UserButton } from "../sidebar/user-button";
+import { ApiCrumb } from "./api-crumb";
+import { CrumbSeparator } from "./crumb";
+import { TopNavFeedbackButton } from "./feedback-button";
+import { NamespaceCrumb } from "./namespace-crumb";
+import { ProjectCrumb } from "./project-crumb";
+import { WorkspaceCrumb } from "./workspace-crumb";
+
+export const TOP_NAV_HEIGHT = 52;
+
+export function TopNav() {
+  const workspace = useWorkspaceNavigation();
+  const crumbs = useBreadcrumbs();
+  // The shadcn Sidebar primitive renders itself as a Sheet on mobile via
+  // useSidebar().setOpenMobile — reuse that instead of mounting a parallel
+  // drawer, otherwise the two stack on top of each other.
+  const { setOpenMobile } = useSidebar();
+
+  return (
+    <header
+      className="z-30 flex w-full shrink-0 items-center gap-1 border-b border-grayA-4 bg-gray-1 px-4"
+      style={{ height: TOP_NAV_HEIGHT }}
+    >
+      <Link href={`/${workspace.slug}`} aria-label="Unkey" className="inline-flex items-center">
+        <Logomark />
+      </Link>
+      {/* Crumbs render on every viewport. min-w-0 lets the labels
+          truncate when the chain would otherwise overflow on narrow
+          screens. Chevron switchers are hidden on mobile inside the
+          Crumb primitive itself. */}
+      <div className="flex min-w-0 items-center gap-1">
+        <CrumbSeparator />
+        {crumbs.map((descriptor, i) => (
+          <Fragment key={crumbKey(descriptor)}>
+            {i > 0 && <CrumbSeparator />}
+            <CrumbForDescriptor descriptor={descriptor} />
+          </Fragment>
+        ))}
+      </div>
+      <div className="ml-auto flex shrink-0 items-center gap-1">
+        <TopNavFeedbackButton className="hidden md:inline-flex" />
+        <HelpButton />
+        <UserButton />
+        <button
+          type="button"
+          onClick={() => setOpenMobile(true)}
+          aria-label="Open navigation"
+          className="flex size-8 items-center justify-center rounded-md text-gray-11 hover:bg-grayA-3 hover:text-accent-12 md:hidden"
+        >
+          <Menu className="size-4" iconSize="md-regular" />
+        </button>
+      </div>
+    </header>
+  );
+}
+
+function CrumbForDescriptor({ descriptor }: { descriptor: BreadcrumbDescriptor }) {
+  switch (descriptor.type) {
+    case "workspace":
+      return <WorkspaceCrumb />;
+    case "project":
+      return <ProjectCrumb projectId={descriptor.projectId} />;
+    case "api":
+      return <ApiCrumb apiId={descriptor.apiId} />;
+    case "namespace":
+      return <NamespaceCrumb namespaceId={descriptor.namespaceId} />;
+  }
+}
+
+function crumbKey(descriptor: BreadcrumbDescriptor): string {
+  switch (descriptor.type) {
+    case "workspace":
+      return "workspace";
+    case "project":
+      return `project:${descriptor.projectId}`;
+    case "api":
+      return `api:${descriptor.apiId}`;
+    case "namespace":
+      return `namespace:${descriptor.namespaceId}`;
+  }
+}

--- a/web/apps/dashboard/components/navigation/top-nav/namespace-crumb.tsx
+++ b/web/apps/dashboard/components/navigation/top-nav/namespace-crumb.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useWorkspaceNavigation } from "@/hooks/use-workspace-navigation";
+import { collection } from "@/lib/collections";
+import { useLiveQuery } from "@tanstack/react-db";
+import { Gauge, Plus } from "@unkey/icons";
+import { Crumb } from "./crumb";
+import type { CrumbPopoverItem } from "./crumb-popover";
+
+export function NamespaceCrumb({ namespaceId }: { namespaceId: string }) {
+  const workspace = useWorkspaceNavigation();
+  const namespacesQuery = useLiveQuery((q) =>
+    q.from({ namespace: collection.ratelimitNamespaces }).select(({ namespace }) => ({
+      id: namespace.id,
+      name: namespace.name,
+    })),
+  );
+  const namespaces = namespacesQuery.data ?? [];
+  const current = namespaces.find((n) => n.id === namespaceId);
+
+  const items: CrumbPopoverItem[] = namespaces.map((n) => ({
+    id: n.id,
+    label: n.name,
+    href: `/${workspace.slug}/ratelimits/${n.id}`,
+  }));
+
+  return (
+    <Crumb
+      icon={<Gauge className="size-3.5 text-accent-11" iconSize="sm-regular" />}
+      label={current?.name ?? namespaceId}
+      href={`/${workspace.slug}/ratelimits/${namespaceId}`}
+      items={items}
+      currentId={namespaceId}
+      searchPlaceholder="Find namespace..."
+      emptyText="No namespaces found"
+      footer={{
+        icon: Plus,
+        label: "All namespaces",
+        href: `/${workspace.slug}/ratelimits`,
+      }}
+    />
+  );
+}

--- a/web/apps/dashboard/components/navigation/top-nav/project-crumb.tsx
+++ b/web/apps/dashboard/components/navigation/top-nav/project-crumb.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useWorkspaceNavigation } from "@/hooks/use-workspace-navigation";
+import { collection } from "@/lib/collections";
+import { useLiveQuery } from "@tanstack/react-db";
+import { Cube, Plus } from "@unkey/icons";
+import { Crumb } from "./crumb";
+import type { CrumbPopoverItem } from "./crumb-popover";
+
+export function ProjectCrumb({ projectId }: { projectId: string }) {
+  const workspace = useWorkspaceNavigation();
+  const projectsQuery = useLiveQuery((q) =>
+    q.from({ project: collection.projects }).select(({ project }) => ({
+      id: project.id,
+      name: project.name,
+    })),
+  );
+  const projects = projectsQuery.data ?? [];
+  const current = projects.find((p) => p.id === projectId);
+
+  const items: CrumbPopoverItem[] = projects.map((p) => ({
+    id: p.id,
+    label: p.name,
+    href: `/${workspace.slug}/projects/${p.id}`,
+  }));
+
+  return (
+    <Crumb
+      icon={<Cube className="size-3.5 text-accent-11" iconSize="sm-regular" />}
+      label={current?.name ?? projectId}
+      href={`/${workspace.slug}/projects/${projectId}`}
+      items={items}
+      currentId={projectId}
+      searchPlaceholder="Find project..."
+      emptyText="No projects found"
+      footer={{
+        icon: Plus,
+        label: "New project",
+        href: `/${workspace.slug}/projects/new`,
+      }}
+    />
+  );
+}

--- a/web/apps/dashboard/components/navigation/top-nav/workspace-crumb.tsx
+++ b/web/apps/dashboard/components/navigation/top-nav/workspace-crumb.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { useWorkspaceNavigation } from "@/hooks/use-workspace-navigation";
+import { setLastUsedOrgCookie, setSessionCookie } from "@/lib/auth/cookies-actions";
+import { trpc } from "@/lib/trpc/client";
+import { Plus } from "@unkey/icons";
+import { toast } from "@unkey/ui";
+import { useMemo } from "react";
+import { Crumb } from "./crumb";
+import type { CrumbPopoverItem } from "./crumb-popover";
+
+export function WorkspaceCrumb() {
+  const workspace = useWorkspaceNavigation();
+  const { data: user } = trpc.user.getCurrentUser.useQuery();
+  const { data: memberships } = trpc.user.listMemberships.useQuery(user?.id ?? "", {
+    enabled: !!user?.id,
+  });
+  const orgs = memberships?.data ?? [];
+
+  const switchOrg = trpc.user.switchOrg.useMutation({
+    async onSuccess(sessionData, orgId) {
+      if (!sessionData.token || !sessionData.expiresAt) {
+        toast.error("Failed to switch workspace. Invalid session data.");
+        return;
+      }
+      try {
+        await setSessionCookie({
+          token: sessionData.token,
+          expiresAt: sessionData.expiresAt,
+        });
+      } catch {
+        toast.error("Failed to complete workspace switch. Please try again.");
+        return;
+      }
+      try {
+        await setLastUsedOrgCookie({ orgId });
+      } catch {}
+      // Full reload re-fetches the new org's workspace + permissions; a
+      // soft router.refresh() leaves stale providers tied to the old org.
+      window.location.replace("/");
+    },
+    onError() {
+      toast.error("Failed to switch workspace. Contact support if error persists.");
+    },
+  });
+
+  const items: CrumbPopoverItem[] = useMemo(
+    () =>
+      orgs.map((m) => ({
+        id: m.organization.id,
+        label: m.organization.name,
+        onClick: () => {
+          if (m.organization.id !== workspace.orgId) {
+            switchOrg.mutate(m.organization.id);
+          }
+        },
+      })),
+    [orgs, switchOrg, workspace.orgId],
+  );
+
+  return (
+    <Crumb
+      icon={
+        <Avatar className="size-4 rounded-sm border border-grayA-6 shrink-0">
+          <AvatarFallback name={workspace.name} variant="marble" square />
+        </Avatar>
+      }
+      label={workspace.name}
+      href={`/${workspace.slug}`}
+      items={items}
+      currentId={workspace.orgId}
+      searchPlaceholder="Find workspace..."
+      emptyText="No workspaces found"
+      footer={{ icon: Plus, label: "New workspace", href: "/new" }}
+    />
+  );
+}

--- a/web/apps/dashboard/components/navigation/top-nav/workspace-crumb.tsx
+++ b/web/apps/dashboard/components/navigation/top-nav/workspace-crumb.tsx
@@ -45,18 +45,20 @@ export function WorkspaceCrumb() {
     },
   });
 
+  const switchOrgMutate = switchOrg.mutate;
+  const switchOrgLoading = switchOrg.isLoading;
   const items: CrumbPopoverItem[] = useMemo(
     () =>
       orgs.map((m) => ({
         id: m.organization.id,
         label: m.organization.name,
         onClick: () => {
-          if (m.organization.id !== workspace.orgId) {
-            switchOrg.mutate(m.organization.id);
+          if (m.organization.id !== workspace.orgId && !switchOrgLoading) {
+            switchOrgMutate(m.organization.id);
           }
         },
       })),
-    [orgs, switchOrg, workspace.orgId],
+    [orgs, switchOrgMutate, switchOrgLoading, workspace.orgId],
   );
 
   return (

--- a/web/apps/dashboard/hooks/use-api-key-auth-id.ts
+++ b/web/apps/dashboard/hooks/use-api-key-auth-id.ts
@@ -1,0 +1,17 @@
+"use client";
+
+import { trpc } from "@/lib/trpc/client";
+
+// Resolves the keyAuthId for a given API. The Keys sidebar item deep-links
+// into /apis/{apiId}/keys/{keyAuthId} so the API leaf needs this to build
+// a real href; until it resolves, the item renders disabled.
+//
+// Lifted up to the sidebar dispatcher so the build function (buildApiLinks)
+// stays pure.
+export function useApiKeyAuthId(apiId: string | undefined): string | undefined {
+  const { data } = trpc.api.queryApiKeyDetails.useQuery(
+    { apiId: apiId ?? "" },
+    { enabled: !!apiId },
+  );
+  return data?.currentApi?.keyAuthId ?? undefined;
+}

--- a/web/apps/dashboard/hooks/use-api-key-auth-id.ts
+++ b/web/apps/dashboard/hooks/use-api-key-auth-id.ts
@@ -2,12 +2,6 @@
 
 import { trpc } from "@/lib/trpc/client";
 
-// Resolves the keyAuthId for a given API. The Keys sidebar item deep-links
-// into /apis/{apiId}/keys/{keyAuthId} so the API leaf needs this to build
-// a real href; until it resolves, the item renders disabled.
-//
-// Lifted up to the sidebar dispatcher so the build function (buildApiLinks)
-// stays pure.
 export function useApiKeyAuthId(apiId: string | undefined): string | undefined {
   const { data } = trpc.api.queryApiKeyDetails.useQuery(
     { apiId: apiId ?? "" },

--- a/web/apps/dashboard/hooks/use-breadcrumbs.ts
+++ b/web/apps/dashboard/hooks/use-breadcrumbs.ts
@@ -1,0 +1,34 @@
+"use client";
+
+import { useParams } from "next/navigation";
+
+export type BreadcrumbDescriptor =
+  | { type: "workspace" }
+  | { type: "project"; projectId: string }
+  | { type: "api"; apiId: string }
+  | { type: "namespace"; namespaceId: string };
+
+// Derives the breadcrumb chain from the current route's params. The
+// TopNav renders one typed crumb component per descriptor; each crumb
+// owns its own data fetching so this hook stays a pure function of
+// the URL.
+export function useBreadcrumbs(): BreadcrumbDescriptor[] {
+  const params = useParams<{
+    workspaceSlug?: string;
+    projectId?: string;
+    apiId?: string;
+    namespaceId?: string;
+  }>();
+
+  const crumbs: BreadcrumbDescriptor[] = [{ type: "workspace" }];
+  if (params.projectId) {
+    crumbs.push({ type: "project", projectId: params.projectId });
+  }
+  if (params.apiId) {
+    crumbs.push({ type: "api", apiId: params.apiId });
+  }
+  if (params.namespaceId) {
+    crumbs.push({ type: "namespace", namespaceId: params.namespaceId });
+  }
+  return crumbs;
+}

--- a/web/apps/dashboard/hooks/use-breadcrumbs.ts
+++ b/web/apps/dashboard/hooks/use-breadcrumbs.ts
@@ -8,10 +8,6 @@ export type BreadcrumbDescriptor =
   | { type: "api"; apiId: string }
   | { type: "namespace"; namespaceId: string };
 
-// Derives the breadcrumb chain from the current route's params. The
-// TopNav renders one typed crumb component per descriptor; each crumb
-// owns its own data fetching so this hook stays a pure function of
-// the URL.
 export function useBreadcrumbs(): BreadcrumbDescriptor[] {
   const params = useParams<{
     workspaceSlug?: string;

--- a/web/apps/dashboard/hooks/use-section-context.ts
+++ b/web/apps/dashboard/hooks/use-section-context.ts
@@ -1,0 +1,45 @@
+"use client";
+
+import { useParams, useSelectedLayoutSegments } from "next/navigation";
+
+// Drives which leaf the contextual sidebar renders. Pure function of
+// the URL — no localStorage, no product split. PR 4 deletes the legacy
+// useNavigationContext that this replaces.
+export type SectionContext =
+  | { type: "workspace" }
+  | { type: "settings" }
+  | { type: "authorization" }
+  | { type: "project"; projectId: string }
+  | { type: "api"; apiId: string }
+  | { type: "namespace"; namespaceId: string };
+
+export function useSectionContext(): SectionContext {
+  const segments = useSelectedLayoutSegments();
+  const params = useParams<{
+    apiId?: string;
+    projectId?: string;
+    namespaceId?: string;
+  }>();
+
+  if (params.projectId) {
+    return { type: "project", projectId: params.projectId };
+  }
+  if (params.apiId) {
+    return { type: "api", apiId: params.apiId };
+  }
+  if (params.namespaceId) {
+    return { type: "namespace", namespaceId: params.namespaceId };
+  }
+
+  // segments[0] is the workspace slug from [workspaceSlug]; the section name
+  // is the next segment.
+  const section = segments[1];
+  if (section === "settings") {
+    return { type: "settings" };
+  }
+  if (section === "authorization") {
+    return { type: "authorization" };
+  }
+
+  return { type: "workspace" };
+}

--- a/web/apps/dashboard/hooks/use-section-context.ts
+++ b/web/apps/dashboard/hooks/use-section-context.ts
@@ -2,9 +2,6 @@
 
 import { useParams, useSelectedLayoutSegments } from "next/navigation";
 
-// Drives which leaf the contextual sidebar renders. Pure function of
-// the URL — no localStorage, no product split. PR 4 deletes the legacy
-// useNavigationContext that this replaces.
 export type SectionContext =
   | { type: "workspace" }
   | { type: "settings" }
@@ -31,8 +28,6 @@ export function useSectionContext(): SectionContext {
     return { type: "namespace", namespaceId: params.namespaceId };
   }
 
-  // segments[0] is the workspace slug from [workspaceSlug]; the section name
-  // is the next segment.
   const section = segments[1];
   if (section === "settings") {
     return { type: "settings" };

--- a/web/apps/dashboard/lib/flags/index.ts
+++ b/web/apps/dashboard/lib/flags/index.ts
@@ -16,3 +16,15 @@ export const helloWorld = flag<boolean, Entities>({
   identify,
   adapter: adapter(),
 });
+
+export const newNavigation = flag<boolean, Entities>({
+  key: "new-navigation",
+  description: "Renders the redesigned top breadcrumb header and contextual sidebar",
+  defaultValue: false,
+  options: [
+    { value: false, label: "Off" },
+    { value: true, label: "On" },
+  ],
+  identify,
+  adapter: adapter(),
+});

--- a/web/apps/dashboard/lib/flags/resolve.ts
+++ b/web/apps/dashboard/lib/flags/resolve.ts
@@ -5,8 +5,11 @@ import * as flags from ".";
 // from this function's return shape, so any flag missing from this list will
 // fail to type-check at every useFlag(key) call site.
 export async function resolveAll() {
-  const [helloWorld] = await Promise.all([flags.helloWorld()]);
-  return { helloWorld };
+  const [helloWorld, newNavigation] = await Promise.all([
+    flags.helloWorld(),
+    flags.newNavigation(),
+  ]);
+  return { helloWorld, newNavigation };
 }
 
 export type Flags = Awaited<ReturnType<typeof resolveAll>>;

--- a/web/apps/dashboard/lib/navigation/leaves.ts
+++ b/web/apps/dashboard/lib/navigation/leaves.ts
@@ -13,14 +13,6 @@ import {
 } from "@unkey/icons";
 import type { ResolvedNavLink } from "./types";
 
-// Pure builders: take URL params + post-slug route segments, return the
-// fully-resolved ResolvedNavLink list to render. No hooks, no JSX — so the same
-// data feeds the sidebar today and a cmd-k registry tomorrow.
-//
-// `segments` is `useSelectedLayoutSegments().slice(1)` — i.e. the route
-// segments *below* the workspace slug. So for /{slug}/projects/{id}/deployments,
-// segments is ["projects", "{id}", "deployments"].
-
 export function buildWorkspaceSections(slug: string, segments: string[]): ResolvedNavLink[] {
   const top = segments[0];
   return [
@@ -66,6 +58,13 @@ export function buildWorkspaceSections(slug: string, segments: string[]): Resolv
       icon: Fingerprint,
       isActive: top === "identities",
     },
+    {
+      key: "settings",
+      label: "Settings",
+      href: `/${slug}/settings/general`,
+      icon: Gear,
+      isActive: top === "settings",
+    },
   ];
 }
 
@@ -104,7 +103,6 @@ export function buildProjectLinks(
   projectId: string,
   segments: string[],
 ): ResolvedNavLink[] {
-  // Project sub-pages live at segments[2] under /projects/{id}/...
   const page = segments[2];
   const base = `/${slug}/projects/${projectId}`;
   return [
@@ -159,7 +157,6 @@ export function buildApiLinks(
   keyAuthId: string | undefined,
   segments: string[],
 ): ResolvedNavLink[] {
-  // API sub-pages: /apis/{apiId}/<page>?. Requests is the bare route (no page).
   const page = segments[2];
   const base = `/${slug}/apis/${apiId}`;
   return [
@@ -173,11 +170,10 @@ export function buildApiLinks(
     {
       key: "keys",
       label: "Keys",
-      // Keys deep-links the keyspace; disable until we've resolved keyAuthId.
       href: keyAuthId ? `${base}/keys/${keyAuthId}` : base,
       icon: Key,
       isActive: page === "keys",
-      disabled: !keyAuthId,
+      disabled: !keyAuthId && page !== "keys",
     },
     {
       key: "settings",
@@ -194,7 +190,6 @@ export function buildNamespaceLinks(
   namespaceId: string,
   segments: string[],
 ): ResolvedNavLink[] {
-  // Namespace sub-pages: /ratelimits/{namespaceId}/<page>?. Requests is bare.
   const page = segments[2];
   const base = `/${slug}/ratelimits/${namespaceId}`;
   return [

--- a/web/apps/dashboard/lib/navigation/leaves.ts
+++ b/web/apps/dashboard/lib/navigation/leaves.ts
@@ -173,7 +173,7 @@ export function buildApiLinks(
       href: keyAuthId ? `${base}/keys/${keyAuthId}` : base,
       icon: Key,
       isActive: page === "keys",
-      disabled: !keyAuthId && page !== "keys",
+      disabled: !keyAuthId,
     },
     {
       key: "settings",

--- a/web/apps/dashboard/lib/navigation/leaves.ts
+++ b/web/apps/dashboard/lib/navigation/leaves.ts
@@ -1,0 +1,230 @@
+import {
+  ArrowDottedRotateAnticlockwise,
+  ArrowOppositeDirectionY,
+  BracketsSquareDots,
+  Cube,
+  Fingerprint,
+  Gauge,
+  Gear,
+  Key,
+  Layers3,
+  Nodes,
+  ShieldKey,
+} from "@unkey/icons";
+import type { ResolvedNavLink } from "./types";
+
+// Pure builders: take URL params + post-slug route segments, return the
+// fully-resolved ResolvedNavLink list to render. No hooks, no JSX — so the same
+// data feeds the sidebar today and a cmd-k registry tomorrow.
+//
+// `segments` is `useSelectedLayoutSegments().slice(1)` — i.e. the route
+// segments *below* the workspace slug. So for /{slug}/projects/{id}/deployments,
+// segments is ["projects", "{id}", "deployments"].
+
+export function buildWorkspaceSections(slug: string, segments: string[]): ResolvedNavLink[] {
+  const top = segments[0];
+  return [
+    {
+      key: "projects",
+      label: "Projects",
+      href: `/${slug}/projects`,
+      icon: Cube,
+      isActive: top === "projects",
+    },
+    {
+      key: "apis",
+      label: "APIs",
+      href: `/${slug}/apis`,
+      icon: Nodes,
+      isActive: top === "apis",
+    },
+    {
+      key: "ratelimits",
+      label: "Ratelimit",
+      href: `/${slug}/ratelimits`,
+      icon: Gauge,
+      isActive: top === "ratelimits",
+    },
+    {
+      key: "authorization",
+      label: "Authorization",
+      href: `/${slug}/authorization/roles`,
+      icon: ShieldKey,
+      isActive: top === "authorization",
+    },
+    {
+      key: "logs",
+      label: "Logs",
+      href: `/${slug}/logs`,
+      icon: Layers3,
+      isActive: top === "logs",
+    },
+    {
+      key: "identities",
+      label: "Identities",
+      href: `/${slug}/identities`,
+      icon: Fingerprint,
+      isActive: top === "identities",
+    },
+  ];
+}
+
+export function buildSettingsLinks(slug: string, segments: string[]): ResolvedNavLink[] {
+  const page = segments[1];
+  const base = `/${slug}/settings`;
+  return [
+    { key: "general", label: "General", href: `${base}/general`, isActive: page === "general" },
+    { key: "team", label: "Team", href: `${base}/team`, isActive: page === "team" },
+    {
+      key: "root-keys",
+      label: "Root Keys",
+      href: `${base}/root-keys`,
+      isActive: page === "root-keys",
+    },
+    { key: "billing", label: "Billing", href: `${base}/billing`, isActive: page === "billing" },
+  ];
+}
+
+export function buildAuthorizationLinks(slug: string, segments: string[]): ResolvedNavLink[] {
+  const page = segments[1];
+  const base = `/${slug}/authorization`;
+  return [
+    { key: "roles", label: "Roles", href: `${base}/roles`, isActive: page === "roles" },
+    {
+      key: "permissions",
+      label: "Permissions",
+      href: `${base}/permissions`,
+      isActive: page === "permissions",
+    },
+  ];
+}
+
+export function buildProjectLinks(
+  slug: string,
+  projectId: string,
+  segments: string[],
+): ResolvedNavLink[] {
+  // Project sub-pages live at segments[2] under /projects/{id}/...
+  const page = segments[2];
+  const base = `/${slug}/projects/${projectId}`;
+  return [
+    {
+      key: "deployments",
+      label: "Deployments",
+      href: `${base}/deployments`,
+      icon: Cube,
+      isActive: page === "deployments",
+    },
+    {
+      key: "logs",
+      label: "Logs",
+      href: `${base}/logs`,
+      icon: Layers3,
+      isActive: page === "logs",
+    },
+    {
+      key: "requests",
+      label: "Requests",
+      href: `${base}/requests`,
+      icon: ArrowOppositeDirectionY,
+      isActive: page === "requests",
+    },
+    {
+      key: "env-vars",
+      label: "Environment Variables",
+      href: `${base}/env-vars`,
+      icon: BracketsSquareDots,
+      isActive: page === "env-vars",
+    },
+    {
+      key: "sentinel-policies",
+      label: "Sentinel Policies",
+      href: `${base}/sentinel-policies`,
+      icon: ShieldKey,
+      isActive: page === "sentinel-policies",
+    },
+    {
+      key: "settings",
+      label: "Settings",
+      href: `${base}/settings`,
+      icon: Gear,
+      isActive: page === "settings",
+    },
+  ];
+}
+
+export function buildApiLinks(
+  slug: string,
+  apiId: string,
+  keyAuthId: string | undefined,
+  segments: string[],
+): ResolvedNavLink[] {
+  // API sub-pages: /apis/{apiId}/<page>?. Requests is the bare route (no page).
+  const page = segments[2];
+  const base = `/${slug}/apis/${apiId}`;
+  return [
+    {
+      key: "requests",
+      label: "Requests",
+      href: base,
+      icon: ArrowOppositeDirectionY,
+      isActive: !page,
+    },
+    {
+      key: "keys",
+      label: "Keys",
+      // Keys deep-links the keyspace; disable until we've resolved keyAuthId.
+      href: keyAuthId ? `${base}/keys/${keyAuthId}` : base,
+      icon: Key,
+      isActive: page === "keys",
+      disabled: !keyAuthId,
+    },
+    {
+      key: "settings",
+      label: "Settings",
+      href: `${base}/settings`,
+      icon: Gear,
+      isActive: page === "settings",
+    },
+  ];
+}
+
+export function buildNamespaceLinks(
+  slug: string,
+  namespaceId: string,
+  segments: string[],
+): ResolvedNavLink[] {
+  // Namespace sub-pages: /ratelimits/{namespaceId}/<page>?. Requests is bare.
+  const page = segments[2];
+  const base = `/${slug}/ratelimits/${namespaceId}`;
+  return [
+    {
+      key: "requests",
+      label: "Requests",
+      href: base,
+      icon: ArrowOppositeDirectionY,
+      isActive: !page,
+    },
+    {
+      key: "logs",
+      label: "Logs",
+      href: `${base}/logs`,
+      icon: Layers3,
+      isActive: page === "logs",
+    },
+    {
+      key: "settings",
+      label: "Settings",
+      href: `${base}/settings`,
+      icon: Gear,
+      isActive: page === "settings",
+    },
+    {
+      key: "overrides",
+      label: "Overrides",
+      href: `${base}/overrides`,
+      icon: ArrowDottedRotateAnticlockwise,
+      isActive: page === "overrides",
+    },
+  ];
+}

--- a/web/apps/dashboard/lib/navigation/types.ts
+++ b/web/apps/dashboard/lib/navigation/types.ts
@@ -1,15 +1,5 @@
 import type { ElementType, ReactNode } from "react";
 
-// A single renderable navigation row. Pre-resolved: hrefs are built,
-// active state is computed against the current route. Producers (the
-// build functions in ./leaves.ts) flatten URL params + segments into
-// this shape so the renderer stays a dumb map.
-//
-// This is the *rendering* shape — not a registry of destinations. When
-// cmd-k lands it'll need a parallel NavDescriptor type (keywords,
-// visibility predicate, path builder) plus a resolver that produces
-// ResolvedNavLink[] from descriptors + context. Don't reuse this type
-// for that purpose.
 export type ResolvedNavLink = {
   key: string;
   label: ReactNode;

--- a/web/apps/dashboard/lib/navigation/types.ts
+++ b/web/apps/dashboard/lib/navigation/types.ts
@@ -1,0 +1,22 @@
+import type { ElementType, ReactNode } from "react";
+
+// A single renderable navigation row. Pre-resolved: hrefs are built,
+// active state is computed against the current route. Producers (the
+// build functions in ./leaves.ts) flatten URL params + segments into
+// this shape so the renderer stays a dumb map.
+//
+// This is the *rendering* shape — not a registry of destinations. When
+// cmd-k lands it'll need a parallel NavDescriptor type (keywords,
+// visibility predicate, path builder) plus a resolver that produces
+// ResolvedNavLink[] from descriptors + context. Don't reuse this type
+// for that purpose.
+export type ResolvedNavLink = {
+  key: string;
+  label: ReactNode;
+  href: string;
+  icon?: ElementType;
+  isActive: boolean;
+  disabled?: boolean;
+  external?: boolean;
+  tag?: ReactNode;
+};

--- a/web/apps/dashboard/tsconfig.json
+++ b/web/apps/dashboard/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -21,7 +25,9 @@
       }
     ],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": [
+        "./*"
+      ]
     }
   },
   "include": [
@@ -31,5 +37,7 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/web/apps/dashboard/tsconfig.json
+++ b/web/apps/dashboard/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es2017",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -25,9 +21,7 @@
       }
     ],
     "paths": {
-      "@/*": [
-        "./*"
-      ]
+      "@/*": ["./*"]
     }
   },
   "include": [
@@ -37,7 +31,5 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": [
-    "node_modules"
-  ]
+  "exclude": ["node_modules"]
 }

--- a/web/internal/icons/src/icons/menu.tsx
+++ b/web/internal/icons/src/icons/menu.tsx
@@ -1,0 +1,63 @@
+/**
+ * Copyright © Nucleo
+ * Version 1.3, January 3, 2024
+ * Nucleo Icons
+ * https://nucleoapp.com/
+ * - Redistribution of icons is prohibited.
+ * - Icons are restricted for use only within the product they are bundled with.
+ *
+ * For more details:
+ * https://nucleoapp.com/license
+ */
+
+import { type IconProps, sizeMap } from "../props";
+
+export function Menu({ iconSize = "xl-thin", ...props }: IconProps) {
+  const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
+
+  return (
+    <svg
+      height={pixelSize}
+      width={pixelSize}
+      viewBox="0 0 18 18"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <g fill="currentColor">
+        <line
+          fill="none"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={strokeWidth}
+          x1="2.25"
+          x2="15.75"
+          y1="4.75"
+          y2="4.75"
+        />
+        <line
+          fill="none"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={strokeWidth}
+          x1="2.25"
+          x2="15.75"
+          y1="9"
+          y2="9"
+        />
+        <line
+          fill="none"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={strokeWidth}
+          x1="2.25"
+          x2="15.75"
+          y1="13.25"
+          y2="13.25"
+        />
+      </g>
+    </svg>
+  );
+}

--- a/web/internal/icons/src/index.ts
+++ b/web/internal/icons/src/index.ts
@@ -118,6 +118,7 @@ export * from "./icons/lock";
 export * from "./icons/magnifier";
 export * from "./icons/math-function";
 export * from "./icons/maximize";
+export * from "./icons/menu";
 export * from "./icons/message-writing";
 export * from "./icons/minus";
 export * from "./icons/microchip";


### PR DESCRIPTION
## What does this PR do?

Adds two new navigation patterns behind a feature flag and updates the dashboard homepage to redirect to `/projects` instead.

## Screenshots

<img width="4264" height="2584" alt="CleanShot 2026-05-12 at 16 14 55@2x" src="https://github.com/user-attachments/assets/05e51339-ee0e-4319-93b8-d259b56ad28b" />

<img width="4264" height="2584" alt="CleanShot 2026-05-12 at 16 14 52@2x" src="https://github.com/user-attachments/assets/28f8509e-1dc5-46c2-bb25-6ffd3efceeb6" />

## How should this be tested?


Flag-gated behind `new-navigation`. Toggle in the Vercel Toolbar.

- [ ] Flag off → click through every section. No regression.
- [ ] Flag on → top header crumbs render workspace / project / api / namespace by route. Click the chevron → sibling popover.
- [ ] `/{workspace}` lands on `/projects` (not `/apis`).
- [ ] Drill into a project → Deployments / Logs / Requests / Env Vars / Sentinel / Settings.
- [ ] Drill into an API → Requests / Keys / Settings (Keys disabled until keyAuthId resolves).
- [ ] Drill into a namespace → Requests / Logs / Settings / Overrides.
- [ ] Settings and Authorization render their sub-pages in the sidebar.
- [ ] Mobile (375px) → hamburger on the right, tap → drawer slides up from the bottom, drag-to-dismiss, route change auto-closes.

## Notes for reviewers

- Two commits, reviewable in order: new chrome + flag declaration, then legacy integration.