### PR TITLE
fix: correct dashboard env template path in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ oci-load: build ## Build and load OCI images into Docker
 
 .PHONY: dashboard
 dashboard: build oci-load ## Run local development setup for dashboard
-	@test -f web/apps/dashboard/.env || cp web/apps/dashboard/dev/.env.template web/apps/dashboard/.env
+	@test -f web/apps/dashboard/.env || cp web/apps/dashboard/.env.example web/apps/dashboard/.env
 	@docker compose -f web/apps/dashboard/dev/docker-compose.yaml up -d --wait
 	@bin/unkey dev seed local
 	@cd web/apps/dashboard && pnpm dev


### PR DESCRIPTION
## What does this PR do?

Fixes a typo when `make dashboard` was first added. 
It tries to copy `.env` from `web/apps/dashboard/dev/.env.template` on first run, but that file doesn't exist - the actual one is `.env.example`. So on a fresh clone the copy just skips and `pnpm dev` boots without an env. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- From a clean checkout (no `web/apps/dashboard/.env`), run `make dashboard` and confirm `.env` is created from `.env.example` before the compose / seed / dev steps run.

## Checklist

### Required

- [x] Self-reviewed my own code
- [x] Merged the latest changes from main onto my branch with `git pull origin main`