### PR TITLE
fix: frontline generate domain name

### DIFF
--- a/svc/ctrl/api/certificate.go
+++ b/svc/ctrl/api/certificate.go
@@ -39,7 +39,7 @@ func (c *certificateBootstrap) run(ctx context.Context) {
 			logger.Error("Failed to list regions for certificate bootstrap", "error", err)
 		} else {
 			for _, region := range regions {
-				domain := fmt.Sprintf("*.%s.%s", region.Name, c.regionalDomain)
+				domain := fmt.Sprintf("*.%s.%s.%s", region.Name, region.Platform, c.regionalDomain)
 				c.bootstrapDomain(ctx, domain)
 			}
 		}


### PR DESCRIPTION
## What does this PR do?

Updates the certificate bootstrap domain format to include the region's platform as part of the domain structure. Previously, wildcard domains were generated as `*.{region}.{regionalDomain}`, but now they are generated as `*.{region}.{platform}.{regionalDomain}` to properly account for platform-specific subdomain segmentation.

Fixes # (issue)

_If there is not an issue for this, please create one first. This is used to tracking purposes and also helps us understand why this PR exists_

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Verify that certificate bootstrap generates wildcard domains in the format `*.{region}.{platform}.{regionalDomain}`
- Confirm that certificates are successfully provisioned for regions across different platforms
- Ensure existing certificates are not disrupted or that a migration path is accounted for

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary