### PR TITLE
feat(dashboard): empty state for APIs with no verification history

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/_components/create-key/index.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/_components/create-key/index.tsx
@@ -16,7 +16,7 @@ import {
   NavigableDialogRoot,
   toast,
 } from "@unkey/ui";
-import { Suspense, useEffect, useState } from "react";
+import { type ReactNode, Suspense, useEffect, useState } from "react";
 import { FormProvider, type Resolver } from "react-hook-form";
 import { KeyCreatedSuccessDialog } from "./components/key-created-success-dialog";
 import { SectionLabel } from "./components/section-label";
@@ -34,6 +34,7 @@ export const CreateKeyDialog = ({
   apiId,
   copyIdValue,
   keyspaceDefaults,
+  trigger: renderTrigger,
 }: {
   keyspaceId: string | null;
   apiId: string;
@@ -42,6 +43,7 @@ export const CreateKeyDialog = ({
     prefix?: string;
     bytes?: number;
   } | null;
+  trigger?: (open: () => void) => ReactNode;
 }) => {
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [successDialogOpen, setSuccessDialogOpen] = useState(false);
@@ -144,13 +146,17 @@ export const CreateKeyDialog = ({
 
   return (
     <>
-      <Navbar.Actions>
-        <NavbarActionButton title="Create new key" onClick={() => setIsSettingsOpen(true)}>
-          <Plus />
-          Create new key
-        </NavbarActionButton>
-        <CopyableIDButton value={copyIdValue ?? apiId} />
-      </Navbar.Actions>
+      {renderTrigger ? (
+        renderTrigger(() => setIsSettingsOpen(true))
+      ) : (
+        <Navbar.Actions>
+          <NavbarActionButton title="Create new key" onClick={() => setIsSettingsOpen(true)}>
+            <Plus />
+            Create new key
+          </NavbarActionButton>
+          <CopyableIDButton value={copyIdValue ?? apiId} />
+        </Navbar.Actions>
+      )}
 
       <FormProvider {...methods}>
         <form id="new-key-form" onSubmit={handleSubmit(onSubmit)}>

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/_overview/components/empty-state.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/_overview/components/empty-state.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { trpc } from "@/lib/trpc/client";
+import { BookBookmark, Plus } from "@unkey/icons";
+import { Button, Empty } from "@unkey/ui";
+import { CreateKeyDialog } from "../../_components/create-key";
+
+export function ApiRequestsEmptyState({ apiId }: { apiId: string }) {
+  const { data: layoutData } = trpc.api.queryApiKeyDetails.useQuery(
+    { apiId },
+    { enabled: Boolean(apiId) },
+  );
+
+  const keyspaceId = layoutData?.keyAuth?.id ?? null;
+  const keyspaceDefaults = layoutData?.currentApi.keyspaceDefaults ?? null;
+
+  return (
+    <div className="flex-1 min-h-[300px] w-full flex items-center justify-center">
+      <Empty className="w-[400px] flex items-start">
+        <Empty.Icon className="w-auto" />
+        <Empty.Title>No verification data yet</Empty.Title>
+        <Empty.Description className="text-left">
+          This API hasn't verified any keys yet. Create a key, use it in a request, and verification
+          activity will show up here.
+        </Empty.Description>
+        <Empty.Actions className="mt-4 justify-center md:justify-start">
+          {/* CreateKeyDialog also renders its (invisible) form and dialog as
+              siblings — wrap it so only one flex item lands in the gap-4 row. */}
+          <div className="flex items-center">
+            <CreateKeyDialog
+              keyspaceId={keyspaceId}
+              apiId={apiId}
+              keyspaceDefaults={keyspaceDefaults}
+              trigger={(open) => (
+                <Button onClick={open} size="md">
+                  <Plus />
+                  Create key
+                </Button>
+              )}
+            />
+          </div>
+          <a
+            href="https://www.unkey.com/docs/introduction"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <Button size="md" variant="outline">
+              <BookBookmark />
+              Documentation
+            </Button>
+          </a>
+        </Empty.Actions>
+      </Empty>
+    </div>
+  );
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/_overview/logs-client.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/_overview/logs-client.tsx
@@ -1,16 +1,20 @@
 "use client";
 
 import { KeysOverviewLogDetails } from "@/components/api-requests-table/components/log-details";
+import { trpc } from "@/lib/trpc/client";
 import type { KeysOverviewLog } from "@unkey/clickhouse/src/keys/keys";
 import { useCallback, useState } from "react";
 import { KeysOverviewLogsCharts } from "./components/charts";
 import { KeysOverviewLogsControlCloud } from "./components/control-cloud";
 import { KeysOverviewLogsControls } from "./components/controls";
+import { ApiRequestsEmptyState } from "./components/empty-state";
 import { KeysOverviewLogsTable } from "./components/table/logs-table";
 
 export const LogsClient = ({ apiId }: { apiId: string }) => {
   const [selectedLog, setSelectedLog] = useState<KeysOverviewLog | null>(null);
   const [tableDistanceToTop, setTableDistanceToTop] = useState(0);
+
+  const { data, isError } = trpc.api.keys.hasData.useQuery({ apiId }, { enabled: Boolean(apiId) });
 
   const handleDistanceToTop = useCallback((distanceToTop: number) => {
     setTableDistanceToTop(distanceToTop);
@@ -19,6 +23,16 @@ export const LogsClient = ({ apiId }: { apiId: string }) => {
   const handleSelectedLog = useCallback((log: KeysOverviewLog | null) => {
     setSelectedLog(log);
   }, []);
+
+  // Wait for the all-time check before rendering; optimistically mounting the
+  // charts/table flashes them on brand-new APIs. On error, render normally.
+  if (!data && !isError) {
+    return null;
+  }
+
+  if (data && !data.hasData) {
+    return <ApiRequestsEmptyState apiId={apiId} />;
+  }
 
   return (
     <div className="flex flex-col">

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/page.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/page.tsx
@@ -10,7 +10,7 @@ export default function ApiPage(props: { params: Promise<{ apiId: string }> }) {
   const workspace = useWorkspaceNavigation();
 
   return (
-    <div>
+    <div className="flex flex-col h-full">
       <ApisNavbar
         apiId={apiId}
         activePage={{

--- a/web/apps/dashboard/lib/trpc/routers/api/keys/has-verifications.ts
+++ b/web/apps/dashboard/lib/trpc/routers/api/keys/has-verifications.ts
@@ -1,0 +1,39 @@
+import { clickhouse } from "@/lib/clickhouse";
+import { ratelimit, withRatelimit, workspaceProcedure } from "@/lib/trpc/trpc";
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+import { getApi } from "./api-query";
+
+/**
+ * Answers "has this API's keyspace ever recorded a key verification" — an
+ * all-time, unbounded check, unlike the timeframe-scoped overview queries. The
+ * Requests page uses it to decide whether to collapse to a single empty state
+ * for brand-new APIs.
+ */
+export const keyspaceHasVerifications = workspaceProcedure
+  .use(withRatelimit(ratelimit.read))
+  .input(z.object({ apiId: z.string() }))
+  .output(z.object({ hasData: z.boolean() }))
+  .query(async ({ ctx, input }) => {
+    const api = await getApi(input.apiId, ctx.workspace.id);
+    if (!api || !api.keyAuth?.id) {
+      throw new TRPCError({
+        code: "NOT_FOUND",
+        message: "API not found or does not have key authentication enabled",
+      });
+    }
+
+    const result = await clickhouse.api.keys.hasVerifications({
+      workspaceId: ctx.workspace.id,
+      keyspaceId: api.keyAuth.id,
+    });
+
+    if (result.err) {
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: "Something went wrong when checking verification data from ClickHouse.",
+      });
+    }
+
+    return { hasData: result.val.hasData };
+  });

--- a/web/apps/dashboard/lib/trpc/routers/index.ts
+++ b/web/apps/dashboard/lib/trpc/routers/index.ts
@@ -1,6 +1,7 @@
 import { t } from "../trpc";
 import { createApi } from "./api/create";
 import { deleteApi } from "./api/delete";
+import { keyspaceHasVerifications } from "./api/keys/has-verifications";
 import { keysLlmSearch } from "./api/keys/llm-search";
 import { apiKeysLlmSearch } from "./api/keys/llm-search-api-keys";
 import { activeKeysTimeseries } from "./api/keys/query-active-keys-timeseries";
@@ -276,6 +277,7 @@ export const router = t.router({
       timeseries: keyVerificationsTimeseries,
       activeKeysTimeseries: activeKeysTimeseries,
       query: queryKeysOverviewLogs,
+      hasData: keyspaceHasVerifications,
       llmSearch: keysLlmSearch,
       list: queryKeysList,
       listLlmSearch: apiKeysLlmSearch,

--- a/web/internal/clickhouse/src/index.ts
+++ b/web/internal/clickhouse/src/index.ts
@@ -20,7 +20,7 @@ import {
   getTwoHourlyActiveKeysTimeseries,
   getWeeklyActiveKeysTimeseries,
 } from "./keys/active_keys";
-import { getKeysOverviewLogs } from "./keys/keys";
+import { getKeysOverviewLogs, getKeyspaceHasVerifications } from "./keys/keys";
 import { getLatestVerifications } from "./latest_verifications";
 import {
   getDailyLogsTimeseries,
@@ -298,6 +298,7 @@ export class ClickHouse {
       logs: getLogs(this.querier),
       keys: {
         logs: getKeysOverviewLogs(this.querier),
+        hasVerifications: getKeyspaceHasVerifications(this.querier),
       },
       key: {
         logs: getKeyDetailsLogs(this.querier),

--- a/web/internal/clickhouse/src/keys/keys.ts
+++ b/web/internal/clickhouse/src/keys/keys.ts
@@ -422,3 +422,43 @@ FROM (
     };
   };
 }
+
+const keyspaceHasVerificationsParams = z.object({
+  workspaceId: z.string(),
+  keyspaceId: z.string(),
+});
+
+type KeyspaceHasVerificationsParams = z.infer<typeof keyspaceHasVerificationsParams>;
+
+// Probes both the long-retention monthly rollup and the raw table so the answer
+// holds for keyspaces verified long ago (raw rows since TTL'd) and ones verified
+// moments ago (not yet rolled up). LIMIT 1 per branch keeps it an existence check.
+export function getKeyspaceHasVerifications(ch: Querier) {
+  return async (args: KeyspaceHasVerificationsParams) => {
+    const query = ch.query({
+      query: `
+SELECT 1 AS has_data
+FROM default.key_verifications_per_month_v3
+WHERE workspace_id = {workspaceId: String}
+    AND key_space_id = {keyspaceId: String}
+LIMIT 1
+UNION ALL
+SELECT 1 AS has_data
+FROM default.key_verifications_raw_v2
+WHERE workspace_id = {workspaceId: String}
+    AND key_space_id = {keyspaceId: String}
+LIMIT 1
+`,
+      params: keyspaceHasVerificationsParams,
+      schema: z.object({
+        has_data: z.int(),
+      }),
+    });
+
+    const result = await query(args);
+    if (result.err) {
+      return { err: result.err, val: undefined };
+    }
+    return { err: undefined, val: { hasData: (result.val ?? []).length > 0 } };
+  };
+}

--- a/web/internal/ui/src/components/data-table/components/empty/empty-api-requests.tsx
+++ b/web/internal/ui/src/components/data-table/components/empty/empty-api-requests.tsx
@@ -1,5 +1,3 @@
-import { BookBookmark } from "@unkey/icons";
-import { buttonVariants } from "../../../buttons/button";
 import { Empty } from "../../../empty";
 
 export function EmptyApiRequests() {
@@ -7,22 +5,11 @@ export function EmptyApiRequests() {
     <div className="w-full flex justify-center items-center h-full">
       <Empty className="w-100 flex items-start">
         <Empty.Icon className="w-auto" />
-        <Empty.Title>Key Verification Logs</Empty.Title>
+        <Empty.Title>No verifications in this time range</Empty.Title>
         <Empty.Description className="text-left">
-          No key verification data to show. Once requests are made with API keys, you'll see a
-          summary of successful and failed verification attempts.
+          This API has verification history, but none in the selected time range. Try a wider range
+          or check your active filters.
         </Empty.Description>
-        <Empty.Actions className="mt-4 justify-center md:justify-start">
-          <a
-            href="https://www.unkey.com/docs/introduction"
-            target="_blank"
-            rel="noopener noreferrer"
-            className={buttonVariants({ size: "md" })}
-          >
-            <BookBookmark />
-            Documentation
-          </a>
-        </Empty.Actions>
       </Empty>
     </div>
   );


### PR DESCRIPTION
## What does this PR do?

Essentially adds a 'truly empty' state to the Verifications log. For numerous reasons, as discussed on slack. 

LLM GENERATED:

The API requests page used to render empty search controls, two blank charts, and an empty table for an API that had never received a request. It now collapses to a single full-page empty state ("No verification data yet" + Create key) when an API has never recorded a key verification.

The collapse decision uses a new all-time `api.keys.hasData` query that probes ClickHouse unbounded by timeframe — deliberately not the existing timeframe-scoped queries. An API that has verifications but none in the selected window keeps the full layout so its timeframe and filter controls stay reachable, rather than stranding the user on a dead-end screen. The in-table empty state copy was reworded to match (it now only appears for APIs that do have history), and `CreateKeyDialog` gained an optional custom trigger so the empty state can reuse it.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots

<img width="4318" height="2588" alt="CleanShot 2026-05-14 at 10 08 53@2x" src="https://github.com/user-attachments/assets/d701b664-9db9-4429-b750-cef4fd5782a7" />

<img width="4318" height="2588" alt="CleanShot 2026-05-14 at 10 08 51@2x" src="https://github.com/user-attachments/assets/bf1a1838-0982-4427-990c-d55f2170531a" />

<img width="4318" height="2588" alt="CleanShot 2026-05-14 at 10 08 50@2x" src="https://github.com/user-attachments/assets/cf113dcd-d793-483f-8626-b65bfcc1641d" />


## How should this be tested?

On the API requests page (`/{workspace}/apis/{apiId}`):

- [ ] API that has never recorded a verification → full-page empty state, no controls/charts/table, no page scrollbar.
- [ ] API with keys but zero verifications → same empty state (the check is verification-based, not key-based).
- [ ] API with verifications only older than the default 12h window → full layout renders; charts show "No data for timeframe", table shows "No verifications in this time range". Widening the timeframe surfaces the data.
- [ ] API with recent verifications → unchanged: full layout with populated charts and table.
- [ ] No flash of the charts/table before the empty state on a brand-new API.

Not covered: the `hasData` ClickHouse query has no automated test — the `@unkey/clickhouse` package has none for any query, so this matches existing convention rather than standing up a new test harness. The error path (ClickHouse unreachable) falls through to the normal layout; verified by reading the code path, not exercised live.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary

🤖 Generated with [Claude Code](https://claude.com/claude-code)