### PR TITLE
fix(dashboard): scrollbar gutter gap and loading state overflow

### DIFF
--- a/web/apps/dashboard/app/(app)/layout.tsx
+++ b/web/apps/dashboard/app/(app)/layout.tsx
@@ -101,7 +101,11 @@ export default function Layout({ children }: LayoutProps) {
 
   // Show loading state while checking authentication and workspace
   if (isLoading || !user || !workspace) {
-    return <LoadingState message="Loading workspace..." />;
+    return (
+      <div className="h-dvh flex flex-col">
+        <LoadingState message="Loading workspace..." />
+      </div>
+    );
   }
 
   // Combine workspace with quotas for AppSidebar
@@ -120,7 +124,7 @@ export default function Layout({ children }: LayoutProps) {
           <MobileNavDrawer />
           <div className="flex flex-1 overflow-hidden">
             <SidebarV2 className="bg-gray-1 border-grayA-4" />
-            <div className="flex-1 overflow-auto" style={{ scrollbarGutter: "stable" }}>
+            <div className="flex-1 overflow-auto">
               <div
                 className="isolate bg-base-12 w-full min-h-full overflow-x-auto flex flex-col items-center"
                 id="layout-wrapper"
@@ -143,7 +147,7 @@ export default function Layout({ children }: LayoutProps) {
           <AppSidebar workspace={workspaceWithQuotas} className="bg-gray-1 border-grayA-4" />
 
           {/* Main content area */}
-          <div className="flex-1 overflow-auto" style={{ scrollbarGutter: "stable" }}>
+          <div className="flex-1 overflow-auto">
             <div
               className="isolate bg-base-12 w-full min-h-full overflow-x-auto flex flex-col items-center"
               id="layout-wrapper"

--- a/web/apps/dashboard/components/loading-state.tsx
+++ b/web/apps/dashboard/components/loading-state.tsx
@@ -2,8 +2,8 @@ import { Loading } from "@unkey/ui";
 
 export function LoadingState({ message = "Loading..." }: { message?: string }) {
   return (
-    <div className="h-dvh relative flex flex-col overflow-hidden bg-white dark:bg-base-12 lg:flex-row">
-      <div className="flex items-center justify-center w-full h-full">
+    <div className="flex-1 relative flex flex-col overflow-hidden bg-white dark:bg-base-12 lg:flex-row">
+      <div className="flex items-center justify-center w-full flex-1">
         <div className="flex flex-col items-center gap-4">
           <Loading size={24} />
           <p className="text-sm text-gray-11">{message}</p>


### PR DESCRIPTION
## What does this PR do?

Fixes two scrollbar glitches in the dashboard app shell. 

- `scrollbar-gutter: stable` on the main content pane created a permanent gutter on every route, which showed as an empty gap down the right side of pages that don't scroll:

- `LoadingState` was `h-dvh` (full viewport height) but is used as a Suspense fallback *inside* the content pane, which is shorter than the viewport — so on page load the fallback overflowed the pane and flashed a vertical scrollbar before the real content swapped in.

## Screenshots

Before:


<img width="4264" height="2584" alt="CleanShot 2026-05-14 at 17 02 30@2x" src="https://github.com/user-attachments/assets/c16e56b7-1134-42a1-9c02-541e75e31bae" />



After:

<img width="4264" height="2584" alt="CleanShot 2026-05-14 at 17 03 22@2x" src="https://github.com/user-attachments/assets/252f796e-6891-4ce9-8ade-b8440c24dd1b" />

yay - no space!

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- On a route that doesn't scroll (e.g. `/projects` with few projects), confirm there's no empty gap on the right edge of the content area.
- Hard-refresh dashboard routes and confirm no scrollbar flashes in the content area during load.
- Confirm the workspace-loading screen and in-page loading fallbacks still fill their space with the spinner centered.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary