### PR TITLE
fix: hide if not enough logs to fetch

### DIFF
--- a/web/apps/dashboard/components/virtual-table/components/loading-indicator.tsx
+++ b/web/apps/dashboard/components/virtual-table/components/loading-indicator.tsx
@@ -1,7 +1,7 @@
 import { cn } from "@/lib/utils";
 import { ArrowsToAllDirections, ArrowsToCenter } from "@unkey/icons";
 import { Button } from "@unkey/ui";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 type LoadMoreFooterProps = {
   onLoadMore?: () => void;
@@ -31,6 +31,14 @@ export const LoadMoreFooter = ({
 }: LoadMoreFooterProps) => {
   const [isOpen, setIsOpen] = useState(true);
   const [hasLoadedMore, setHasLoadedMore] = useState(false);
+  const prevTotalCountRef = useRef(totalCount);
+
+  useEffect(() => {
+    if (totalCount < prevTotalCountRef.current) {
+      setHasLoadedMore(false);
+    }
+    prevTotalCountRef.current = totalCount;
+  }, [totalCount]);
 
   const shouldShow = !!onLoadMore;
 

--- a/web/apps/dashboard/components/virtual-table/components/loading-indicator.tsx
+++ b/web/apps/dashboard/components/virtual-table/components/loading-indicator.tsx
@@ -30,6 +30,7 @@ export const LoadMoreFooter = ({
   headerContent,
 }: LoadMoreFooterProps) => {
   const [isOpen, setIsOpen] = useState(true);
+  const [hasLoadedMore, setHasLoadedMore] = useState(false);
 
   const shouldShow = !!onLoadMore;
 
@@ -41,7 +42,12 @@ export const LoadMoreFooter = ({
     setIsOpen(true);
   }, []);
 
-  if (hide) {
+  const handleLoadMore = useCallback(() => {
+    setHasLoadedMore(true);
+    onLoadMore?.();
+  }, [onLoadMore]);
+
+  if (hide || (!hasMore && !hasLoadedMore)) {
     return null;
   }
 
@@ -115,7 +121,7 @@ export const LoadMoreFooter = ({
               <Button
                 variant="outline"
                 size="sm"
-                onClick={onLoadMore}
+                onClick={handleLoadMore}
                 loading={isFetchingNextPage}
                 disabled={isFetchingNextPage || !hasMore}
                 className="transition-all"


### PR DESCRIPTION

## What does this PR do?

Fixes ENG-2805 by hiding the floating logs footer when the initial response contains no further pages. Previously, the Load more logs control rendered with a disabled button and "Showing 1 of 1" indicator even when only a single log existed and pagination was unnecessary. The change lives in the shared LoadMoreFooter component, so it applies uniformly across every consumer of VirtualTable's loadMoreFooterProps — main logs, ratelimit overview/details, project runtime logs, sentinel/requests, identity logs, and the identities list. To preserve the totals indicator after a user has actually paginated, the footer tracks whether onLoadMore has been invoked at least once; once it has, it stays mounted even when hasMore flips to false, so the "Showing X of Y" summary survives reaching the last page.

Fixes #6183


## Type of change

<!-- Please mark the relevant points by using [x] -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Open a workspace with a single log entry — verify the Load more logs footer does not render
- Open a workspace with many logs — verify the footer renders normally with the "Load more logs" button active
- Click Load more logs repeatedly until reaching the last page — verify the footer stays visible with the button disabled and the totals indicator intact
- Minimize the footer (chevron-in icon) and reload — verify it reappears as expected when there is more data
- Repeat the above for: ratelimit logs overview, ratelimit logs details, project runtime logs, project sentinel/requests, identity detail logs, identities list
- Apply filters that yield zero or one result — verify the footer is hidden
- Apply filters that yield many results — verify the footer reappears

## Checklist

<!-- Complete this checklist before requesting review. -->

### Required

- [X] Filled out the "How to test" section in this PR
- [X] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [X] Self-reviewed my own code
- [X] Commented on my code in hard-to-understand areas
- [X] Ran `pnpm build`
- [X] Ran `pnpm fmt`
- [X] Ran `make fmt` on `/go` directory
- [X] Checked for warnings, there are none
- [X] Removed all `console.logs`
- [X] Merged the latest changes from main onto my branch with `git pull origin main`
- [X] My changes don't cause any responsiveness issues

### Appreciated

- [X] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary
