### PR TITLE
feat(dashboard): context-aware breadcrumb

### DIFF
--- a/web/apps/dashboard/components/navigation/sidebar-v2/sidebar-body.tsx
+++ b/web/apps/dashboard/components/navigation/sidebar-v2/sidebar-body.tsx
@@ -23,6 +23,7 @@ export function SidebarBody() {
   const links = (() => {
     switch (context.type) {
       case "workspace":
+      case "identity":
         return buildWorkspaceSections(slug, segments);
       case "settings":
         return buildSettingsLinks(slug, segments);

--- a/web/apps/dashboard/components/navigation/top-nav/api-crumb.tsx
+++ b/web/apps/dashboard/components/navigation/top-nav/api-crumb.tsx
@@ -12,6 +12,7 @@ export function ApiCrumb({ apiId }: { apiId: string }) {
 
   const apiName = data?.currentApi?.name ?? apiId;
   const siblings = data?.workspaceApis ?? [];
+  const loading = !data;
 
   const items: CrumbPopoverItem[] = siblings.map((api) => ({
     id: api.id,
@@ -23,6 +24,7 @@ export function ApiCrumb({ apiId }: { apiId: string }) {
     <Crumb
       icon={<Nodes className="size-3.5 text-accent-11" iconSize="sm-regular" />}
       label={apiName}
+      loading={loading}
       href={`/${workspace.slug}/apis/${apiId}`}
       items={items}
       currentId={apiId}

--- a/web/apps/dashboard/components/navigation/top-nav/crumb.tsx
+++ b/web/apps/dashboard/components/navigation/top-nav/crumb.tsx
@@ -14,6 +14,7 @@ type CrumbProps = {
   searchPlaceholder: string;
   emptyText: string;
   footer: CrumbPopoverFooter;
+  loading?: boolean;
 };
 
 export function Crumb({
@@ -25,6 +26,7 @@ export function Crumb({
   searchPlaceholder,
   emptyText,
   footer,
+  loading = false,
 }: CrumbProps) {
   return (
     <div className="flex min-w-0 items-center gap-0.5">
@@ -33,7 +35,11 @@ export function Crumb({
         className="flex min-w-0 items-center gap-1.5 px-1 py-1 text-[13px] font-medium text-accent-12"
       >
         {icon}
-        <span className="truncate max-w-[120px] md:max-w-[180px]">{label}</span>
+        {loading ? (
+          <span aria-hidden="true" className="h-3 w-20 rounded-sm bg-gray-4 animate-pulse" />
+        ) : (
+          <span className="truncate max-w-[120px] md:max-w-[180px]">{label}</span>
+        )}
       </Link>
       <CrumbPopover
         items={items}

--- a/web/apps/dashboard/components/navigation/top-nav/crumb.tsx
+++ b/web/apps/dashboard/components/navigation/top-nav/crumb.tsx
@@ -32,6 +32,7 @@ export function Crumb({
     <div className="flex min-w-0 items-center gap-0.5">
       <Link
         href={href}
+        aria-label={label}
         className="flex min-w-0 items-center gap-1.5 px-1 py-1 text-[13px] font-medium text-accent-12"
       >
         {icon}

--- a/web/apps/dashboard/components/navigation/top-nav/identity-crumb.tsx
+++ b/web/apps/dashboard/components/navigation/top-nav/identity-crumb.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useWorkspaceNavigation } from "@/hooks/use-workspace-navigation";
+import { trpc } from "@/lib/trpc/client";
+import { Fingerprint, Plus } from "@unkey/icons";
+import { Crumb } from "./crumb";
+import type { CrumbPopoverItem } from "./crumb-popover";
+
+export function IdentityCrumb({ identityId }: { identityId: string }) {
+  const workspace = useWorkspaceNavigation();
+  const { data } = trpc.identity.query.useQuery({});
+
+  const identities = data?.identities ?? [];
+
+  const items: CrumbPopoverItem[] = identities.map((identity) => ({
+    id: identity.id,
+    label: identity.id,
+    href: `/${workspace.slug}/identities/${identity.id}`,
+  }));
+
+  return (
+    <Crumb
+      icon={<Fingerprint className="size-3.5 text-accent-11" iconSize="sm-regular" />}
+      label={identityId}
+      href={`/${workspace.slug}/identities/${identityId}`}
+      items={items}
+      currentId={identityId}
+      searchPlaceholder="Find identity..."
+      emptyText="No identities found"
+      footer={{
+        icon: Plus,
+        label: "All identities",
+        href: `/${workspace.slug}/identities`,
+      }}
+    />
+  );
+}

--- a/web/apps/dashboard/components/navigation/top-nav/index.tsx
+++ b/web/apps/dashboard/components/navigation/top-nav/index.tsx
@@ -12,6 +12,7 @@ import { UserButton } from "../sidebar/user-button";
 import { ApiCrumb } from "./api-crumb";
 import { CrumbSeparator } from "./crumb";
 import { TopNavFeedbackButton } from "./feedback-button";
+import { IdentityCrumb } from "./identity-crumb";
 import { NamespaceCrumb } from "./namespace-crumb";
 import { ProjectCrumb } from "./project-crumb";
 import { WorkspaceCrumb } from "./workspace-crumb";
@@ -60,13 +61,15 @@ export function TopNav() {
 function CrumbForDescriptor({ descriptor }: { descriptor: BreadcrumbDescriptor }) {
   switch (descriptor.type) {
     case "workspace":
-      return <WorkspaceCrumb />;
+      return <WorkspaceCrumb href={descriptor.href} />;
     case "project":
       return <ProjectCrumb projectId={descriptor.projectId} />;
     case "api":
       return <ApiCrumb apiId={descriptor.apiId} />;
     case "namespace":
       return <NamespaceCrumb namespaceId={descriptor.namespaceId} />;
+    case "identity":
+      return <IdentityCrumb identityId={descriptor.identityId} />;
   }
 }
 
@@ -80,5 +83,7 @@ function crumbKey(descriptor: BreadcrumbDescriptor): string {
       return `api:${descriptor.apiId}`;
     case "namespace":
       return `namespace:${descriptor.namespaceId}`;
+    case "identity":
+      return `identity:${descriptor.identityId}`;
   }
 }

--- a/web/apps/dashboard/components/navigation/top-nav/namespace-crumb.tsx
+++ b/web/apps/dashboard/components/navigation/top-nav/namespace-crumb.tsx
@@ -17,7 +17,7 @@ export function NamespaceCrumb({ namespaceId }: { namespaceId: string }) {
   );
   const namespaces = namespacesQuery.data ?? [];
   const current = namespaces.find((n) => n.id === namespaceId);
-  const loading = !current && namespaces.length === 0;
+  const loading = namespacesQuery.isLoading;
 
   const items: CrumbPopoverItem[] = namespaces.map((n) => ({
     id: n.id,

--- a/web/apps/dashboard/components/navigation/top-nav/namespace-crumb.tsx
+++ b/web/apps/dashboard/components/navigation/top-nav/namespace-crumb.tsx
@@ -17,6 +17,7 @@ export function NamespaceCrumb({ namespaceId }: { namespaceId: string }) {
   );
   const namespaces = namespacesQuery.data ?? [];
   const current = namespaces.find((n) => n.id === namespaceId);
+  const loading = !current && namespaces.length === 0;
 
   const items: CrumbPopoverItem[] = namespaces.map((n) => ({
     id: n.id,
@@ -28,6 +29,7 @@ export function NamespaceCrumb({ namespaceId }: { namespaceId: string }) {
     <Crumb
       icon={<Gauge className="size-3.5 text-accent-11" iconSize="sm-regular" />}
       label={current?.name ?? namespaceId}
+      loading={loading}
       href={`/${workspace.slug}/ratelimits/${namespaceId}`}
       items={items}
       currentId={namespaceId}

--- a/web/apps/dashboard/components/navigation/top-nav/project-crumb.tsx
+++ b/web/apps/dashboard/components/navigation/top-nav/project-crumb.tsx
@@ -17,7 +17,7 @@ export function ProjectCrumb({ projectId }: { projectId: string }) {
   );
   const projects = projectsQuery.data ?? [];
   const current = projects.find((p) => p.id === projectId);
-  const loading = !current && projects.length === 0;
+  const loading = projectsQuery.isLoading;
 
   const items: CrumbPopoverItem[] = projects.map((p) => ({
     id: p.id,

--- a/web/apps/dashboard/components/navigation/top-nav/project-crumb.tsx
+++ b/web/apps/dashboard/components/navigation/top-nav/project-crumb.tsx
@@ -17,6 +17,7 @@ export function ProjectCrumb({ projectId }: { projectId: string }) {
   );
   const projects = projectsQuery.data ?? [];
   const current = projects.find((p) => p.id === projectId);
+  const loading = !current && projects.length === 0;
 
   const items: CrumbPopoverItem[] = projects.map((p) => ({
     id: p.id,
@@ -28,6 +29,7 @@ export function ProjectCrumb({ projectId }: { projectId: string }) {
     <Crumb
       icon={<Cube className="size-3.5 text-accent-11" iconSize="sm-regular" />}
       label={current?.name ?? projectId}
+      loading={loading}
       href={`/${workspace.slug}/projects/${projectId}`}
       items={items}
       currentId={projectId}

--- a/web/apps/dashboard/components/navigation/top-nav/workspace-crumb.tsx
+++ b/web/apps/dashboard/components/navigation/top-nav/workspace-crumb.tsx
@@ -10,7 +10,7 @@ import { useMemo } from "react";
 import { Crumb } from "./crumb";
 import type { CrumbPopoverItem } from "./crumb-popover";
 
-export function WorkspaceCrumb() {
+export function WorkspaceCrumb({ href }: { href: string }) {
   const workspace = useWorkspaceNavigation();
   const { data: user } = trpc.user.getCurrentUser.useQuery();
   const { data: memberships } = trpc.user.listMemberships.useQuery(user?.id ?? "", {
@@ -69,7 +69,7 @@ export function WorkspaceCrumb() {
         </Avatar>
       }
       label={workspace.name}
-      href={`/${workspace.slug}`}
+      href={href}
       items={items}
       currentId={workspace.orgId}
       searchPlaceholder="Find workspace..."

--- a/web/apps/dashboard/hooks/use-breadcrumbs.ts
+++ b/web/apps/dashboard/hooks/use-breadcrumbs.ts
@@ -1,22 +1,27 @@
 "use client";
 
 import { useParams } from "next/navigation";
+import { useWorkspaceNavigation } from "./use-workspace-navigation";
 
 export type BreadcrumbDescriptor =
-  | { type: "workspace" }
+  | { type: "workspace"; href: string }
   | { type: "project"; projectId: string }
   | { type: "api"; apiId: string }
-  | { type: "namespace"; namespaceId: string };
+  | { type: "namespace"; namespaceId: string }
+  | { type: "identity"; identityId: string };
 
 export function useBreadcrumbs(): BreadcrumbDescriptor[] {
+  const workspace = useWorkspaceNavigation();
   const params = useParams<{
     workspaceSlug?: string;
     projectId?: string;
     apiId?: string;
     namespaceId?: string;
+    identityId?: string;
   }>();
 
-  const crumbs: BreadcrumbDescriptor[] = [{ type: "workspace" }];
+  const workspaceHref = resolveWorkspaceHref(workspace.slug, params);
+  const crumbs: BreadcrumbDescriptor[] = [{ type: "workspace", href: workspaceHref }];
   if (params.projectId) {
     crumbs.push({ type: "project", projectId: params.projectId });
   }
@@ -26,5 +31,32 @@ export function useBreadcrumbs(): BreadcrumbDescriptor[] {
   if (params.namespaceId) {
     crumbs.push({ type: "namespace", namespaceId: params.namespaceId });
   }
+  if (params.identityId) {
+    crumbs.push({ type: "identity", identityId: params.identityId });
+  }
   return crumbs;
+}
+
+function resolveWorkspaceHref(
+  slug: string,
+  params: {
+    projectId?: string;
+    apiId?: string;
+    namespaceId?: string;
+    identityId?: string;
+  },
+): string {
+  if (params.apiId) {
+    return `/${slug}/apis`;
+  }
+  if (params.projectId) {
+    return `/${slug}/projects`;
+  }
+  if (params.namespaceId) {
+    return `/${slug}/ratelimits`;
+  }
+  if (params.identityId) {
+    return `/${slug}/identities`;
+  }
+  return `/${slug}`;
 }

--- a/web/apps/dashboard/hooks/use-breadcrumbs.ts
+++ b/web/apps/dashboard/hooks/use-breadcrumbs.ts
@@ -10,15 +10,16 @@ export type BreadcrumbDescriptor =
   | { type: "namespace"; namespaceId: string }
   | { type: "identity"; identityId: string };
 
+type RouteParams = {
+  projectId?: string;
+  apiId?: string;
+  namespaceId?: string;
+  identityId?: string;
+};
+
 export function useBreadcrumbs(): BreadcrumbDescriptor[] {
   const workspace = useWorkspaceNavigation();
-  const params = useParams<{
-    workspaceSlug?: string;
-    projectId?: string;
-    apiId?: string;
-    namespaceId?: string;
-    identityId?: string;
-  }>();
+  const params = useParams<RouteParams>();
 
   const workspaceHref = resolveWorkspaceHref(workspace.slug, params);
   const crumbs: BreadcrumbDescriptor[] = [{ type: "workspace", href: workspaceHref }];
@@ -37,15 +38,7 @@ export function useBreadcrumbs(): BreadcrumbDescriptor[] {
   return crumbs;
 }
 
-function resolveWorkspaceHref(
-  slug: string,
-  params: {
-    projectId?: string;
-    apiId?: string;
-    namespaceId?: string;
-    identityId?: string;
-  },
-): string {
+function resolveWorkspaceHref(slug: string, params: RouteParams): string {
   if (params.apiId) {
     return `/${slug}/apis`;
   }

--- a/web/apps/dashboard/hooks/use-section-context.ts
+++ b/web/apps/dashboard/hooks/use-section-context.ts
@@ -8,7 +8,8 @@ export type SectionContext =
   | { type: "authorization" }
   | { type: "project"; projectId: string }
   | { type: "api"; apiId: string }
-  | { type: "namespace"; namespaceId: string };
+  | { type: "namespace"; namespaceId: string }
+  | { type: "identity"; identityId: string };
 
 export function useSectionContext(): SectionContext {
   const segments = useSelectedLayoutSegments();
@@ -16,6 +17,7 @@ export function useSectionContext(): SectionContext {
     apiId?: string;
     projectId?: string;
     namespaceId?: string;
+    identityId?: string;
   }>();
 
   if (params.projectId) {
@@ -26,6 +28,9 @@ export function useSectionContext(): SectionContext {
   }
   if (params.namespaceId) {
     return { type: "namespace", namespaceId: params.namespaceId };
+  }
+  if (params.identityId) {
+    return { type: "identity", identityId: params.identityId };
   }
 
   const section = segments[1];


### PR DESCRIPTION
## What does this PR do?

Workspace crumb on nested resource pages now navigate to that section's list, e.g

- clicking from `/apis/[id]` back via the breadcrumb now lands on `/apis` instead of bouncing through the workspace home redirect to Projects. 

Also in this PR:

- Add a crumb for the Identities routes (missed that on the first PR)
- Replaces a flash of the 'raw-id's' on API pages, with a skeleton, so you don't get an awkward flash of an incorrect breadcrumb.

## Type of change

- [x] Enhancement (small improvements)

## How should this be tested?

- On `/apis/[id]`, `/projects/[id]`, `/ratelimits/[id]/...`, `/identities/[id]` → workspace crumb goes to the matching section list.
- At `/apis`, `/projects`, `/audit`, `/settings/general`, `/authorization/roles` → workspace crumb still goes to `/{workspaceSlug}` (unchanged).
- Click into a cold API from `/apis` → crumb shows a skeleton, not `api_xxx`, then resolves to the name.
- `/identities/[id]` → identity crumb appears with the internal `id_xxx` and a popover switcher.

Not tested: settings/authorization (out of scope — they only nest via modals, not real routes).

## Screenshots

https://github.com/user-attachments/assets/14c0fa2c-ea41-4127-b26c-4aa0073b9f2f

When in APIs -> goes back to API.
When in Deploy Route -> Goes back to Deploy.

## Notes for reviewers

- The identitycrumb shows our internal IDs in the list. We can change this to whatever we want but it's consistent with the current title so I kept it that way for the time being. 

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary