### PR TITLE
fix(dashboard): Project Cards - Visual Tweaks 

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/_components/list/index.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/_components/list/index.tsx
@@ -28,7 +28,7 @@ export const ProjectsList = () => {
         <div
           className="grid gap-4"
           style={{
-            gridTemplateColumns: "repeat(auto-fit, minmax(325px, 350px))",
+            gridTemplateColumns: "repeat(auto-fit, minmax(325px, 370px))",
           }}
         >
           {Array.from({ length: MAX_SKELETON_COUNT }).map((_, i) => (

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/_components/list/projects-card-skeleton.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/_components/list/projects-card-skeleton.tsx
@@ -1,72 +1,26 @@
-import { CodeBranch, Cube, Dots, Earth, Github, User } from "@unkey/icons";
-import { Button } from "@unkey/ui";
+import { Cube } from "@unkey/icons";
 
 export const ProjectCardSkeleton = () => {
   return (
-    <div className="p-5 flex flex-col border border-grayA-4 hover:border-grayA-7 cursor-pointer rounded-2xl w-full gap-5 group transition-all duration-400">
+    <div className="p-5 flex flex-col border border-grayA-4 rounded-2xl w-full h-full gap-5">
       {/* Top Section */}
-      <div className="flex gap-4 items-center">
-        <div className="relative size-10 bg-linear-to-br from-grayA-2 to-grayA-7 rounded-[10px] flex items-center justify-center shrink-0 shadow-sm shadow-grayA-8/20 dark:ring-1 dark:ring-gray-4 dark:shadow-none">
-          <div className="absolute inset-0 bg-linear-to-br from-grayA-2 to-grayA-4 rounded-[10px] opacity-0 group-hover:opacity-100 transition-opacity duration-500 ease-out" />
-          <Cube iconSize="xl-medium" className="relative text-gray-11 opacity-30 shrink-0 size-5" />
+      <div className="flex gap-4 items-center min-h-11">
+        <div className="size-10 bg-gray-3 rounded-[10px] flex items-center justify-center shrink-0 dark:ring-1 dark:ring-gray-4">
+          <Cube iconSize="xl-medium" className="text-gray-11 opacity-30 shrink-0 size-5" />
         </div>
         <div className="flex flex-col w-full gap-2 py-[5px] min-w-0">
-          {/* Project Name Skeleton */}
-          <div className="h-[14px] leading-[14px] w-24 bg-grayA-3 rounded-sm animate-pulse" />
-          {/* Domain Skeleton */}
-          <div className="h-3 leading-3 w-32 bg-grayA-3 rounded-sm animate-pulse" />
+          <div className="h-[14px] w-24 bg-grayA-3 rounded-sm animate-pulse" />
+          <div className="h-3 w-32 bg-grayA-3 rounded-sm animate-pulse" />
         </div>
-        {/* Actions Button Skeleton */}
-        <Button variant="ghost" size="icon" className="shrink-0" title="Project actions">
-          <Dots iconSize="sm-regular" className="text-gray-11 opacity-30 shrink-0" />
-        </Button>
       </div>
 
-      {/* Middle Section - Commit Info */}
+      {/* Middle Section */}
       <div className="flex flex-col gap-2">
-        {/* Commit Title Skeleton */}
-        <div className="h-5 leading-5 w-40 bg-grayA-3 rounded-sm animate-pulse" />
+        <div className="h-5 w-40 bg-grayA-3 rounded-sm animate-pulse" />
 
-        <div className="flex gap-2 items-center min-w-0">
-          {/* Commit Date Skeleton */}
-          <div className="h-4 w-10 bg-grayA-3 rounded-sm animate-pulse" />
-          <span className="text-xs text-gray-11 opacity-30 h-3 flex items-center">on</span>
-
-          {/* Branch Icon */}
-          <CodeBranch className="text-gray-12 opacity-30 shrink-0" iconSize="sm-regular" />
-
-          {/* Branch Name Skeleton */}
-          <div className="h-4 w-10 max-w-[70px] bg-grayA-3 rounded-sm animate-pulse" />
-
-          <span className="text-xs text-gray-10 opacity-30 h-3 flex items-center">by</span>
-
-          {/* User Avatar */}
-          <div className="border border-grayA-6 items-center justify-center rounded-full size-[18px] flex shrink-0">
-            <User className="text-gray-11 opacity-30 shrink-0" iconSize="sm-regular" />
-          </div>
-
-          {/* Author Name Skeleton */}
-          <div className="h-4 w-16 max-w-[90px] bg-grayA-3 rounded-sm animate-pulse" />
-        </div>
-      </div>
-
-      {/* Bottom Section - Regions Skeleton */}
-      <div className="flex gap-2 items-center">
-        {/* First region badge skeleton */}
-        <div className="bg-grayA-4 px-1.5 font-medium text-xs text-gray-12 rounded-full min-h-[22px] flex items-center gap-1.5 opacity-50">
-          <Earth iconSize="lg-medium" className="shrink-0 opacity-30" />
-          <div className="h-3 w-16 bg-grayA-6 rounded-sm animate-pulse" />
-        </div>
-
-        {/* "+X more" badge skeleton */}
-        <div className="bg-grayA-4 px-1.5 font-medium text-xs text-gray-12 rounded-full min-h-[22px] flex items-center opacity-50">
-          <div className="h-3 w-12 bg-grayA-6 rounded-sm animate-pulse" />
-        </div>
-
-        {/* Repository badge skeleton */}
-        <div className="bg-grayA-4 px-1.5 font-medium text-xs text-gray-12 rounded-full min-h-[22px] flex items-center gap-1.5 max-w-[130px] opacity-50">
-          <Github iconSize="lg-medium" className="shrink-0 opacity-30" />
-          <div className="h-3 w-20 bg-grayA-6 rounded-sm animate-pulse" />
+        <div className="flex gap-2 items-center min-w-0 justify-between min-h-5">
+          <div className="h-4 w-16 bg-grayA-3 rounded-sm animate-pulse" />
+          <div className="h-4 w-16 bg-grayA-3 rounded-sm animate-pulse" />
         </div>
       </div>
     </div>

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/_components/list/projects-card.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/_components/list/projects-card.tsx
@@ -40,7 +40,7 @@ export const ProjectCard = ({
   const projectPath = `/${workspace.slug}/projects/${projectId}`;
 
   return (
-    <div className="relative p-5 flex flex-col border border-grayA-4 hover:border-grayA-7 rounded-2xl w-full gap-5 group transition-all duration-300 [&_a]:z-10 [&_button]:z-10">
+    <div className="relative p-5 flex flex-col border border-grayA-4 hover:border-grayA-7 rounded-2xl w-full h-full gap-5 group transition-all duration-300 [&_a]:z-10 [&_button]:z-10">
       {/* Invisible base clickable layer - covers entire card */}
       <Link
         href={projectPath}
@@ -49,8 +49,8 @@ export const ProjectCard = ({
         onClick={handleLinkClick}
       />
       {/*Top Section*/}
-      <div className="flex gap-4 items-center">
-        <div className="size-10 bg-gray-3 rounded-[10px] flex items-center justify-center shrink-0 shadow-sm shadow-grayA-8/20 dark:ring-1 dark:ring-gray-4 dark:shadow-none">
+      <div className="flex gap-4 items-center min-h-11">
+        <div className="size-10 bg-gray-3 rounded-[10px] flex items-center justify-center shrink-0 dark:ring-1 dark:ring-gray-4">
           {isNavigating ? (
             <Loading size={20} className="text-grayA-11" />
           ) : (
@@ -68,7 +68,7 @@ export const ProjectCard = ({
             </Link>
           </InfoTooltip>
           {/*Top Section > Domains/Hostnames*/}
-          {domain && (
+          {domain ? (
             <InfoTooltip content={domain} asChild position={{ align: "start", side: "top" }}>
               <a
                 href={`https://${domain}`}
@@ -79,6 +79,10 @@ export const ProjectCard = ({
                 {domain}
               </a>
             </InfoTooltip>
+          ) : (
+            <span aria-hidden="true" className="text-xs leading-[12px] invisible">
+              &nbsp;
+            </span>
           )}
         </div>
         {/*Top Section > Project actions*/}
@@ -96,24 +100,26 @@ export const ProjectCard = ({
             </Link>
           </InfoTooltip>
         ) : (
-          <div className="text-[13px] text-accent-12 leading-5 opacity-70">No commit info</div>
+          <div className="h-5">
+            <span className="sr-only">No commit info</span>
+          </div>
         )}
 
-        <div className="flex gap-2 items-center min-w-0 justify-between">
-          <div className="flex items-center gap-2">
+        <div className="flex gap-2 items-center min-w-0 justify-between min-h-5">
+          <div className="flex items-center gap-3">
             {commitTimestamp ? (
               <TimestampInfo value={commitTimestamp} className="hover:underline whitespace-pre" />
             ) : (
-              <span className="text-xs text-gray-12 truncate max-w-[70px] opacity-70">
-                No deployments
-              </span>
+              <span className="sr-only">No deployments</span>
             )}
-            <CodeBranch className="text-gray-12 shrink-0" iconSize="sm-regular" />
-            <InfoTooltip content={branch} asChild position={{ align: "start", side: "top" }}>
-              <span className="text-xs text-gray-12 truncate max-w-[70px]">{branch}</span>
-            </InfoTooltip>
+            <div className="flex items-center gap-1">
+              <CodeBranch className="text-gray-12 shrink-0" iconSize="sm-regular" />
+              <InfoTooltip content={branch} asChild position={{ align: "start", side: "top" }}>
+                <span className="text-xs text-gray-12 truncate max-w-[70px]">{branch}</span>
+              </InfoTooltip>
+            </div>
           </div>
-          {authorAvatar && (
+          {authorAvatar && author ? (
             <div className="flex items-center gap-2">
               <span className="text-xs text-gray-10">by</span>
               <Avatar alt="Author avatar" src={authorAvatar} />
@@ -123,6 +129,13 @@ export const ProjectCard = ({
                 </span>
               </InfoTooltip>
             </div>
+          ) : (
+            <>
+              <span className="sr-only">No author</span>
+              <div aria-hidden="true" className="flex items-center gap-2 invisible">
+                <Avatar src={null} alt="" />
+              </div>
+            </>
           )}
         </div>
       </div>


### PR DESCRIPTION
## What does this PR do?

Project cards were rendering inconsistently in different states so i've cleaned them up a little bit and tidied the skeleton loader also. 

One thing reviewers might disagree with, I've removed the 'No commit info' and 'No deployment' text. For me, that seems like an unnecessary thing to include so I excluded it. If anyone has a strong reason for including it lmk.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots
https://github.com/user-attachments/assets/d0467212-4c32-4bd6-a4ee-4243d140f769

Before:
<img width="4268" height="2584" alt="CleanShot 2026-05-18 at 12 05 47@2x" src="https://github.com/user-attachments/assets/6feec7a4-4da5-460b-b3c7-9275c46dc9df" />


## How should this be tested?

- [ ] Cards in a row are the same height regardless of which fields are populated.
- [ ] Cards without a domain show the name top-aligned, not centered against the avatar.
- [ ] Skeleton card heights match loaded card heights — no jump on hydration.
- [ ] Screen reader announces "No commit info" / "No deployments" / "No author" on cards missing those fields.