### PR TITLE
feat(ui): add Skeleton primitive

### DIFF
--- a/web/internal/ui/src/components/skeleton.tsx
+++ b/web/internal/ui/src/components/skeleton.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import type * as React from "react";
 
 import { cn } from "../lib/utils";
 

--- a/web/internal/ui/src/components/skeleton.tsx
+++ b/web/internal/ui/src/components/skeleton.tsx
@@ -1,0 +1,13 @@
+import * as React from "react";
+
+import { cn } from "../lib/utils";
+
+export function Skeleton({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      aria-hidden="true"
+      className={cn("animate-pulse motion-reduce:animate-none rounded-sm bg-grayA-3", className)}
+      {...props}
+    />
+  );
+}

--- a/web/internal/ui/src/index.ts
+++ b/web/internal/ui/src/index.ts
@@ -28,6 +28,7 @@ export * from "./components/llm-search";
 export * from "./components/llm-search/components/search-icon";
 export * from "./components/dialog/popover";
 export * from "./components/settings-card";
+export * from "./components/skeleton";
 export * from "./components/timestamp-info";
 export * from "./components/tooltip";
 export * from "./components/tabs";


### PR DESCRIPTION
## What does this PR do?

I've needed this twice today already - adding a new skeleton primitive so we don't have to keep repeating ourselves.

**LLM description version:**

Adds a small `Skeleton` primitive to `@unkey/ui`. Future loading states can `<Skeleton className="h-4 w-24" />` instead of hand-rolling another `bg-grayA-3 rounded-sm animate-pulse` div — which the codebase currently does about 140 times.

## How should this be tested?

This PR only adds the primitive; nothing in the app consumes it yet, so there's nothing user-visible to click through.

- [ ] `pnpm --dir=web build` passes (verified locally).
- [ ] `import { Skeleton } from "@unkey/ui"` resolves in the dashboard.
- [ ] Drop `<Skeleton className="h-4 w-24" />` next to an existing inline skeleton bar (e.g. on `/projects` while loading) — visually identical.

Not tested: actual migration of any of the existing 140 call sites — out of scope for this PR.

## Notes for reviewers

- Single primitive only. No `Skeleton.Text` / `Skeleton.Circle` presets, no `asChild`, no `SkeletonGroup` wrapper. Easy to add later if real call sites want them.
- Element is always `<div>` — if a future caller needs a `<span>` for inline contexts, we'll add `asChild` then.