### PR TITLE
feat(icons): normalize stroke weights — drop thin/bold, bump default to medium

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/_components/create-key/components/key-created-success-dialog.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/_components/create-key/components/key-created-success-dialog.tsx
@@ -112,9 +112,9 @@ export const KeyCreatedSuccessDialog: FC<KeyCreatedSuccessDialogProps> = ({
                 <div className="border border-grayA-4 rounded-full border-dashed size-[24px] absolute right-0 top-0" />
                 <div className="border border-grayA-4 rounded-full border-dashed size-[24px] absolute right-0 bottom-0" />
                 <div className="border border-grayA-4 rounded-full border-dashed size-[24px] absolute left-0 bottom-0" />
-                <Key2 iconSize="2xl-thin" aria-hidden="true" focusable={false} />
+                <Key2 iconSize="2xl-medium" aria-hidden="true" focusable={false} />
                 <div className="flex items-center justify-center border border-grayA-3 rounded-full bg-success-9 text-white size-[22px] absolute right-[-10px] top-[-10px]">
-                  <Check iconSize="sm-bold" aria-hidden="true" focusable={false} />
+                  <Check iconSize="sm-regular" aria-hidden="true" focusable={false} />
                 </div>
               </div>
               <div className="border border-grayA-4 rounded-[14px] size-14" />

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/keys/[keyAuthId]/[keyId]/components/controls/index.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/keys/[keyAuthId]/[keyId]/components/controls/index.tsx
@@ -84,7 +84,7 @@ export function KeysDetailsLogsControls({
                       className="text-xs"
                       variant="enabled"
                       text={formatNumber(data?.remainingCredit ?? 0)}
-                      icon={<Coins iconSize="sm-thin" />}
+                      icon={<Coins iconSize="sm-medium" />}
                     />
                   </motion.div>
                 ) : (
@@ -105,7 +105,7 @@ export function KeysDetailsLogsControls({
                       className="text-xs"
                       variant="disabled"
                       text="0"
-                      icon={<Coins iconSize="sm-thin" />}
+                      icon={<Coins iconSize="sm-medium" />}
                     />
                   </motion.div>
                 )}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/settings/components/delete-api.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/settings/components/delete-api.tsx
@@ -73,7 +73,7 @@ export const DeleteApi: React.FC<Props> = ({ api, keys }) => {
           <div className="inline-flex gap-2">
             <span>Delete API</span>
             {api.deleteProtection && (
-              <StatusBadge variant="locked" text="Locked" icon={<Lock iconSize="sm-thin" />} />
+              <StatusBadge variant="locked" text="Locked" icon={<Lock iconSize="sm-medium" />} />
             )}
           </div>
         }

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/settings/components/delete-protection.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/settings/components/delete-protection.tsx
@@ -122,7 +122,7 @@ export const DeleteProtection: React.FC<Props> = ({ api }) => {
               target="_blank"
               rel="noopener noreferrer"
               href="https://www.unkey.com/docs/security/delete-protection"
-              icon={<ArrowUpRight iconSize="sm-thin" />}
+              icon={<ArrowUpRight iconSize="sm-medium" />}
             />
           </p>
           <form id="delete-protection-form" onSubmit={handleSubmit(onSubmit)}>

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/audit/components/table/log-details/components/log-footer.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/audit/components/table/log-details/components/log-footer.tsx
@@ -22,12 +22,12 @@ export const LogFooter = ({ log }: Props) => {
       </div>
     ) : log.auditLog.actor.type === "key" ? (
       <div className="flex items-center gap-2">
-        <Key iconSize="sm-thin" />
+        <Key iconSize="sm-medium" />
         <span className="font-mono text-xs">{log.auditLog.actor.id}</span>
       </div>
     ) : (
       <div className="flex items-center gap-2">
-        <MathFunction iconSize="sm-thin" />
+        <MathFunction iconSize="sm-medium" />
         <span className="font-mono text-xs">{log.auditLog.actor.id}</span>
       </div>
     );

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/authorization/roles/components/upsert-role/components/assign-key/create-key-options.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/authorization/roles/components/upsert-role/components/assign-key/create-key-options.tsx
@@ -44,7 +44,7 @@ export function createKeyOptions({
                     <StatusBadge
                       variant="locked"
                       text="Already assigned"
-                      icon={<Lock iconSize="sm-thin" />}
+                      icon={<Lock iconSize="sm-medium" />}
                     />
                   )}
                 </div>

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/authorization/roles/components/upsert-role/components/assign-permission/create-permission-options.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/authorization/roles/components/upsert-role/components/assign-permission/create-permission-options.tsx
@@ -48,7 +48,7 @@ export function createPermissionOptions({
                         <StatusBadge
                           variant="locked"
                           text="Already assigned"
-                          icon={<Lock iconSize="sm-thin" />}
+                          icon={<Lock iconSize="sm-medium" />}
                         />
                       )}
                     </div>

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/identities/[identityId]/components/controls/index.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/identities/[identityId]/components/controls/index.tsx
@@ -82,7 +82,7 @@ export function IdentityDetailsLogsControls({
                     className="text-xs"
                     variant={totalKeys > 0 ? "enabled" : "disabled"}
                     text={formatNumber(totalKeys)}
-                    icon={<Key iconSize="sm-thin" />}
+                    icon={<Key iconSize="sm-medium" />}
                   />
                 </motion.div>
               </div>

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/network/unkey-flow/components/overlay/project-details.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/network/unkey-flow/components/overlay/project-details.tsx
@@ -31,7 +31,7 @@ export const ProjectDetails = () => {
                     "text-gray-8 transition-transform origin-center",
                     isOpen ? "rotate-180" : "",
                   )}
-                  iconSize="sm-bold"
+                  iconSize="sm-regular"
                 />
               </div>
             </button>

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/env-vars/components/list/env-var-group-row.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/env-vars/components/list/env-var-group-row.tsx
@@ -68,7 +68,7 @@ export function GroupRow({
         <span className="flex items-center gap-1.5 text-[13px] text-gray-11 transition-colors pl-2">
           {row.items.length} values
           <ChevronRight
-            iconSize="sm-thin"
+            iconSize="sm-medium"
             className={cn(
               "size-[12px] transition-transform duration-200",
               isExpanded && "rotate-90",

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/new/onboarding-step-header.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/new/onboarding-step-header.tsx
@@ -26,7 +26,7 @@ const iconItems: { icon: ReactNode; large?: boolean; opacity: string }[] = [
   { icon: null, opacity: "opacity-60" },
   { icon: <Harddrive className="size-[18px]" iconSize="md-medium" />, opacity: "opacity-75" },
   { icon: <Location2 className="size-[18px]" iconSize="md-medium" />, opacity: "opacity-80" },
-  { icon: <CloudUp className="size-9" iconSize="md-thin" />, large: true, opacity: "opacity-90" },
+  { icon: <CloudUp className="size-9" iconSize="md-medium" />, large: true, opacity: "opacity-90" },
   { icon: <HeartPulse className="size-[18px]" iconSize="md-medium" />, opacity: "opacity-80" },
   { icon: <Nodes2 className="size-[18px]" iconSize="md-medium" />, opacity: "opacity-75" },
   { icon: null, opacity: "opacity-60" },

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/root-keys/components/dialog/root-key-success.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/root-keys/components/dialog/root-key-success.tsx
@@ -48,9 +48,9 @@ export const RootKeySuccess = ({ keyValue, onClose }: RootKeySuccessProps) => {
                 <div className="border border-grayA-4 rounded-full border-dashed size-[24px] absolute right-0 top-0" />
                 <div className="border border-grayA-4 rounded-full border-dashed size-[24px] absolute right-0 bottom-0" />
                 <div className="border border-grayA-4 rounded-full border-dashed size-[24px] absolute left-0 bottom-0" />
-                <Key2 iconSize="2xl-thin" aria-hidden="true" focusable={false} />
+                <Key2 iconSize="2xl-medium" aria-hidden="true" focusable={false} />
                 <div className="flex items-center justify-center border border-grayA-3 rounded-full bg-success-9 text-white size-[22px] absolute right-[-10px] top-[-10px]">
-                  <Check iconSize="sm-bold" aria-hidden="true" focusable={false} />
+                  <Check iconSize="sm-regular" aria-hidden="true" focusable={false} />
                 </div>
               </div>
               <div className="border border-grayA-4 rounded-[14px] size-14" />

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/vercel/client.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/vercel/client.tsx
@@ -131,9 +131,9 @@ export const Client: React.FC<Props> = ({ projects, integration, apis, rootKeys 
                         >
                           <div className="flex items-center w-full md:w-1/5">
                             {binding ? (
-                              <Link4 iconSize="md-thin" className="rotate-90" />
+                              <Link4 iconSize="md-medium" className="rotate-90" />
                             ) : (
-                              <Unlink iconSize="md-thin" className="rotate-90" />
+                              <Unlink iconSize="md-medium" className="rotate-90" />
                             )}
                             <span className="text-xs text-content">{envLabel}</span>
                           </div>

--- a/web/apps/dashboard/app/auth/layout.tsx
+++ b/web/apps/dashboard/app/auth/layout.tsx
@@ -29,7 +29,7 @@ export default async function AuthenticatedLayout({
           href="https://www.unkey.com/docs"
           target="_blank"
         >
-          <Page2 iconSize="md-thin" />
+          <Page2 iconSize="md-medium" />
           Documentation
         </Link>
       </nav>

--- a/web/apps/dashboard/components/api-keys-table/components/actions/components/edit-rbac/components/assign-role/create-key-options.tsx
+++ b/web/apps/dashboard/components/api-keys-table/components/actions/components/edit-rbac/components/assign-role/create-key-options.tsx
@@ -50,7 +50,7 @@ export function createRoleOptions({
                     <StatusBadge
                       variant="locked"
                       text="Already assigned"
-                      icon={<Lock iconSize="sm-thin" />}
+                      icon={<Lock iconSize="sm-medium" />}
                     />
                   )}
                 </div>

--- a/web/apps/dashboard/components/audit-logs-table/components/cells/actor-cell.tsx
+++ b/web/apps/dashboard/components/audit-logs-table/components/cells/actor-cell.tsx
@@ -21,7 +21,7 @@ export const ActorCell = ({ log }: ActorCellProps) => {
           </span>
         ) : (
           <>
-            {isKey ? <Key iconSize="sm-thin" /> : <MathFunction iconSize="sm-thin" />}
+            {isKey ? <Key iconSize="sm-medium" /> : <MathFunction iconSize="sm-medium" />}
             <span className="font-mono text-xs truncate secret">{log.auditLog.actor.id}</span>
           </>
         )}

--- a/web/apps/dashboard/components/logs/queries/empty.tsx
+++ b/web/apps/dashboard/components/logs/queries/empty.tsx
@@ -11,9 +11,9 @@ export const EmptyQueries = ({ selectedTab, isEmpty }: EmptyQueriesProps) => {
       <Empty>
         <Empty.Icon>
           {selectedTab === 0 ? (
-            <ClockRotateClockwise iconSize="2xl-thin" className="p-0 text-accent-12" />
+            <ClockRotateClockwise iconSize="2xl-medium" className="p-0 text-accent-12" />
           ) : (
-            <Bookmark iconSize="2xl-thin" className="w-full h-full p-0 m-0 text-accent-12" />
+            <Bookmark iconSize="2xl-medium" className="w-full h-full p-0 m-0 text-accent-12" />
           )}
         </Empty.Icon>
         <Empty.Title className="mt-5">

--- a/web/apps/dashboard/components/navigation/sidebar/app-sidebar/components/nav-items/nested-nav-item.tsx
+++ b/web/apps/dashboard/components/navigation/sidebar/app-sidebar/components/nav-items/nested-nav-item.tsx
@@ -255,7 +255,7 @@ export const NestedNavItem = ({
                   "transition-transform duration-200 text-gray-9 w-[9px]! h-[9px]!",
                   (isSubItem ? isChildrenOpen : isOpen) ? "rotate-90" : "rotate-0",
                 )}
-                iconSize="sm-bold"
+                iconSize="sm-regular"
               />
             </div>
           )}

--- a/web/apps/dashboard/components/virtual-table/index.tsx
+++ b/web/apps/dashboard/components/virtual-table/index.tsx
@@ -509,9 +509,9 @@ function SortIcon({ direction }: { direction?: SortDirection | null }) {
     return <CaretExpandY className="color-gray-9" />;
   }
   return direction === "asc" ? (
-    <CaretUp className="color-gray-9" iconSize="sm-thin" />
+    <CaretUp className="color-gray-9" iconSize="sm-medium" />
   ) : (
-    <CaretDown className="color-gray-9" iconSize="sm-thin" />
+    <CaretDown className="color-gray-9" iconSize="sm-medium" />
   );
 }
 

--- a/web/internal/icons/src/icons/adjust-contrast-3.tsx
+++ b/web/internal/icons/src/icons/adjust-contrast-3.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function AdjustContrast3({ iconSize = "xl-thin", ...props }: IconProps) {
+export function AdjustContrast3({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/arrow-dot-anti-clockwise.tsx
+++ b/web/internal/icons/src/icons/arrow-dot-anti-clockwise.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function ArrowDotAntiClockwise({ iconSize = "xl-thin", ...props }: IconProps) {
+export function ArrowDotAntiClockwise({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/arrow-dotted-rotate-anticlockwise.tsx
+++ b/web/internal/icons/src/icons/arrow-dotted-rotate-anticlockwise.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function ArrowDottedRotateAnticlockwise({ iconSize = "xl-thin", ...props }: IconProps) {
+export function ArrowDottedRotateAnticlockwise({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/arrow-opposite-direction-y.tsx
+++ b/web/internal/icons/src/icons/arrow-opposite-direction-y.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function ArrowOppositeDirectionY({ iconSize = "xl-thin", ...props }: IconProps) {
+export function ArrowOppositeDirectionY({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/arrow-right.tsx
+++ b/web/internal/icons/src/icons/arrow-right.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function ArrowRight({ iconSize = "xl-thin", ...props }: IconProps) {
+export function ArrowRight({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/arrow-up-right.tsx
+++ b/web/internal/icons/src/icons/arrow-up-right.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function ArrowUpRight({ iconSize = "xl-thin", ...props }: IconProps) {
+export function ArrowUpRight({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/arrows-to-all-directions.tsx
+++ b/web/internal/icons/src/icons/arrows-to-all-directions.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function ArrowsToAllDirections({ iconSize = "xl-thin", ...props }: IconProps) {
+export function ArrowsToAllDirections({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/arrows-to-center.tsx
+++ b/web/internal/icons/src/icons/arrows-to-center.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function ArrowsToCenter({ iconSize = "xl-thin", ...props }: IconProps) {
+export function ArrowsToCenter({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/ban.tsx
+++ b/web/internal/icons/src/icons/ban.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Ban({ iconSize = "xl-thin", ...props }: IconProps) {
+export function Ban({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/bars-filter.tsx
+++ b/web/internal/icons/src/icons/bars-filter.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function BarsFilter({ iconSize = "xl-thin", ...props }: IconProps) {
+export function BarsFilter({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/bolt.tsx
+++ b/web/internal/icons/src/icons/bolt.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Bolt({ iconSize = "xl-thin", ...props }: IconProps) {
+export function Bolt({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/book-2.tsx
+++ b/web/internal/icons/src/icons/book-2.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Book2({ iconSize = "xl-thin", ...props }: IconProps) {
+export function Book2({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/book-open.tsx
+++ b/web/internal/icons/src/icons/book-open.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function BookOpen({ iconSize = "xl-thin", ...props }: IconProps) {
+export function BookOpen({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/brackets-curly.tsx
+++ b/web/internal/icons/src/icons/brackets-curly.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function BracketsCurly({ iconSize = "xl-thin", ...props }: IconProps) {
+export function BracketsCurly({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/brackets-square-dots.tsx
+++ b/web/internal/icons/src/icons/brackets-square-dots.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function BracketsSquareDots({ iconSize = "xl-thin", ...props }: IconProps) {
+export function BracketsSquareDots({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/calendar-clock.tsx
+++ b/web/internal/icons/src/icons/calendar-clock.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function CalendarClock({ iconSize = "xl-thin", ...props }: IconProps) {
+export function CalendarClock({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/caret-down.tsx
+++ b/web/internal/icons/src/icons/caret-down.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function CaretDown({ iconSize = "xl-thin", ...props }: IconProps) {
+export function CaretDown({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/caret-expand-y.tsx
+++ b/web/internal/icons/src/icons/caret-expand-y.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function CaretExpandY({ iconSize = "xl-thin", ...props }: IconProps) {
+export function CaretExpandY({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/caret-right.tsx
+++ b/web/internal/icons/src/icons/caret-right.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function CaretRight({ iconSize = "xl-thin", ...props }: IconProps) {
+export function CaretRight({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/caret-up.tsx
+++ b/web/internal/icons/src/icons/caret-up.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function CaretUp({ iconSize = "xl-thin", ...props }: IconProps) {
+export function CaretUp({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/chart-activity-2.tsx
+++ b/web/internal/icons/src/icons/chart-activity-2.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function ChartActivity2({ iconSize = "xl-thin", ...props }: IconProps) {
+export function ChartActivity2({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/chart-activity.tsx
+++ b/web/internal/icons/src/icons/chart-activity.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function ChartActivity({ iconSize = "xl-thin", filled, ...props }: IconProps) {
+export function ChartActivity({ iconSize = "xl-medium", filled, ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/chart-pie.tsx
+++ b/web/internal/icons/src/icons/chart-pie.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function ChartPie({ iconSize = "xl-thin", ...props }: IconProps) {
+export function ChartPie({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/chats.tsx
+++ b/web/internal/icons/src/icons/chats.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Chats({ iconSize = "xl-thin", ...props }: IconProps) {
+export function Chats({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/check.tsx
+++ b/web/internal/icons/src/icons/check.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Check({ iconSize = "xl-thin", ...props }: IconProps) {
+export function Check({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/chevron-down.tsx
+++ b/web/internal/icons/src/icons/chevron-down.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function ChevronDown({ iconSize = "xl-thin", ...props }: IconProps) {
+export function ChevronDown({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/chevron-left.tsx
+++ b/web/internal/icons/src/icons/chevron-left.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function ChevronLeft({ iconSize = "xl-thin", ...props }: IconProps) {
+export function ChevronLeft({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/chevron-right.tsx
+++ b/web/internal/icons/src/icons/chevron-right.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function ChevronRight({ iconSize = "xl-thin", ...props }: IconProps) {
+export function ChevronRight({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/chevron-up.tsx
+++ b/web/internal/icons/src/icons/chevron-up.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function ChevronUp({ iconSize = "xl-thin", ...props }: IconProps) {
+export function ChevronUp({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/circle-caret-down.tsx
+++ b/web/internal/icons/src/icons/circle-caret-down.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function CircleCaretDown({ iconSize = "xl-thin", ...props }: IconProps) {
+export function CircleCaretDown({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/circle-dotted.tsx
+++ b/web/internal/icons/src/icons/circle-dotted.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function CircleDotted({ iconSize = "xl-thin", ...props }: IconProps) {
+export function CircleDotted({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/circle-half-dotted-clock.tsx
+++ b/web/internal/icons/src/icons/circle-half-dotted-clock.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function CircleHalfDottedClock({ iconSize = "xl-thin", ...props }: IconProps) {
+export function CircleHalfDottedClock({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/circle-info-sparkle.tsx
+++ b/web/internal/icons/src/icons/circle-info-sparkle.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function CircleInfoSparkle({ iconSize = "lg-thin", ...props }: IconProps) {
+export function CircleInfoSparkle({ iconSize = "lg-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/circle-info.tsx
+++ b/web/internal/icons/src/icons/circle-info.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function CircleInfo({ iconSize = "xl-thin", ...props }: IconProps) {
+export function CircleInfo({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/circle-lock.tsx
+++ b/web/internal/icons/src/icons/circle-lock.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function CircleLock({ iconSize = "xl-thin", ...props }: IconProps) {
+export function CircleLock({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/circle-question.tsx
+++ b/web/internal/icons/src/icons/circle-question.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function CircleQuestion({ iconSize = "xl-thin", ...props }: IconProps) {
+export function CircleQuestion({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/circle-warning.tsx
+++ b/web/internal/icons/src/icons/circle-warning.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function CircleWarning({ iconSize = "xl-thin", ...props }: IconProps) {
+export function CircleWarning({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/circle.tsx
+++ b/web/internal/icons/src/icons/circle.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Circle({ iconSize = "xl-thin", ...props }: IconProps) {
+export function Circle({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/clone.tsx
+++ b/web/internal/icons/src/icons/clone.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Clone({ iconSize = "xl-thin", ...props }: IconProps) {
+export function Clone({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/cloud-up.tsx
+++ b/web/internal/icons/src/icons/cloud-up.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function CloudUp({ iconSize = "xl-thin", ...props }: IconProps) {
+export function CloudUp({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/cloud.tsx
+++ b/web/internal/icons/src/icons/cloud.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Cloud({ iconSize = "xl-thin", ...props }: IconProps) {
+export function Cloud({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/code-branch.tsx
+++ b/web/internal/icons/src/icons/code-branch.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function CodeBranch({ iconSize = "xl-thin", ...props }: IconProps) {
+export function CodeBranch({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/code-commit.tsx
+++ b/web/internal/icons/src/icons/code-commit.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function CodeCommit({ iconSize = "xl-thin", ...props }: IconProps) {
+export function CodeCommit({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/code.tsx
+++ b/web/internal/icons/src/icons/code.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Code({ iconSize = "xl-thin", ...props }: IconProps) {
+export function Code({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/coins.tsx
+++ b/web/internal/icons/src/icons/coins.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Coins({ iconSize = "xl-thin", ...props }: IconProps) {
+export function Coins({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/connections.tsx
+++ b/web/internal/icons/src/icons/connections.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Connections({ iconSize = "xl-thin", ...props }: IconProps) {
+export function Connections({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/connections3.tsx
+++ b/web/internal/icons/src/icons/connections3.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Connections3({ iconSize = "xl-thin", ...props }: IconProps) {
+export function Connections3({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/cube.tsx
+++ b/web/internal/icons/src/icons/cube.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Cube({ iconSize = "xl-thin", ...props }: IconProps) {
+export function Cube({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/database.tsx
+++ b/web/internal/icons/src/icons/database.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Database({ iconSize = "xl-thin", ...props }: IconProps) {
+export function Database({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/discord.tsx
+++ b/web/internal/icons/src/icons/discord.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Discord({ iconSize = "xl-thin", ...props }: IconProps) {
+export function Discord({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/dots.tsx
+++ b/web/internal/icons/src/icons/dots.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Dots({ iconSize = "xl-thin", ...props }: IconProps) {
+export function Dots({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/double-chevron-left.tsx
+++ b/web/internal/icons/src/icons/double-chevron-left.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function DoubleChevronLeft({ iconSize = "xl-thin", filled, ...props }: IconProps) {
+export function DoubleChevronLeft({ iconSize = "xl-medium", filled, ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/double-chevron-right.tsx
+++ b/web/internal/icons/src/icons/double-chevron-right.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function DoubleChevronRight({ iconSize = "xl-thin", filled, ...props }: IconProps) {
+export function DoubleChevronRight({ iconSize = "xl-medium", filled, ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/earth.tsx
+++ b/web/internal/icons/src/icons/earth.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Earth({ iconSize = "xl-thin", ...props }: IconProps) {
+export function Earth({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/eye-slash.tsx
+++ b/web/internal/icons/src/icons/eye-slash.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function EyeSlash({ iconSize = "xl-thin", ...props }: IconProps) {
+export function EyeSlash({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/eye.tsx
+++ b/web/internal/icons/src/icons/eye.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Eye({ iconSize = "xl-thin", ...props }: IconProps) {
+export function Eye({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/file-settings.tsx
+++ b/web/internal/icons/src/icons/file-settings.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function FileSettings({ iconSize = "xl-thin", ...props }: IconProps) {
+export function FileSettings({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/focus.tsx
+++ b/web/internal/icons/src/icons/focus.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Focus({ iconSize = "xl-thin", ...props }: IconProps) {
+export function Focus({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/folder-cloud.tsx
+++ b/web/internal/icons/src/icons/folder-cloud.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function FolderCloud({ iconSize = "xl-thin", filled, ...props }: IconProps) {
+export function FolderCloud({ iconSize = "xl-medium", filled, ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/folder-link.tsx
+++ b/web/internal/icons/src/icons/folder-link.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function FolderLink({ iconSize = "xl-thin", ...props }: IconProps) {
+export function FolderLink({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/gauge.tsx
+++ b/web/internal/icons/src/icons/gauge.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Gauge({ iconSize = "xl-thin", ...props }: IconProps) {
+export function Gauge({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/gear.tsx
+++ b/web/internal/icons/src/icons/gear.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Gear({ iconSize = "xl-thin", ...props }: IconProps) {
+export function Gear({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/github.tsx
+++ b/web/internal/icons/src/icons/github.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Github({ iconSize = "xl-thin", ...props }: IconProps) {
+export function Github({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/grid-circle.tsx
+++ b/web/internal/icons/src/icons/grid-circle.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function GridCircle({ iconSize = "xl-thin", ...props }: IconProps) {
+export function GridCircle({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/grid-dots-vertical.tsx
+++ b/web/internal/icons/src/icons/grid-dots-vertical.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function GripDotsVertical({ iconSize = "xl-thin", ...props }: IconProps) {
+export function GripDotsVertical({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/grid.tsx
+++ b/web/internal/icons/src/icons/grid.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Grid({ iconSize = "xl-thin", ...props }: IconProps) {
+export function Grid({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/half-dotted-circle-play.tsx
+++ b/web/internal/icons/src/icons/half-dotted-circle-play.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function HalfDottedCirclePlay({ iconSize = "xl-thin", ...props }: IconProps) {
+export function HalfDottedCirclePlay({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/hammer-2.tsx
+++ b/web/internal/icons/src/icons/hammer-2.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Hammer2({ iconSize = "xl-thin", filled, ...props }: IconProps) {
+export function Hammer2({ iconSize = "xl-medium", filled, ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/hard-drive.tsx
+++ b/web/internal/icons/src/icons/hard-drive.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Harddrive({ iconSize = "xl-thin", filled, ...props }: IconProps) {
+export function Harddrive({ iconSize = "xl-medium", filled, ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/heart-pulse.tsx
+++ b/web/internal/icons/src/icons/heart-pulse.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function HeartPulse({ iconSize = "xl-thin", ...props }: IconProps) {
+export function HeartPulse({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/heart.tsx
+++ b/web/internal/icons/src/icons/heart.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Heart({ iconSize = "xl-thin", filled, ...props }: IconProps) {
+export function Heart({ iconSize = "xl-medium", filled, ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/input-password-edit.tsx
+++ b/web/internal/icons/src/icons/input-password-edit.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function InputPasswordEdit({ iconSize = "xl-thin", ...props }: IconProps) {
+export function InputPasswordEdit({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/input-password-settings.tsx
+++ b/web/internal/icons/src/icons/input-password-settings.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function InputPasswordSettings({ iconSize = "xl-thin", ...props }: IconProps) {
+export function InputPasswordSettings({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/key-2.tsx
+++ b/web/internal/icons/src/icons/key-2.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Key2({ iconSize = "xl-thin", ...props }: IconProps) {
+export function Key2({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/key.tsx
+++ b/web/internal/icons/src/icons/key.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Key({ iconSize = "xl-thin", ...props }: IconProps) {
+export function Key({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/lang-elixir.tsx
+++ b/web/internal/icons/src/icons/lang-elixir.tsx
@@ -1,6 +1,6 @@
 import { type IconProps, sizeMap } from "../props";
 
-export function LangElixir({ iconSize = "xl-thin", ...props }: IconProps) {
+export function LangElixir({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/lang-go.tsx
+++ b/web/internal/icons/src/icons/lang-go.tsx
@@ -1,6 +1,6 @@
 import { type IconProps, sizeMap } from "../props";
 
-export function LangGo({ iconSize = "xl-thin", ...props }: IconProps) {
+export function LangGo({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/lang-java.tsx
+++ b/web/internal/icons/src/icons/lang-java.tsx
@@ -1,6 +1,6 @@
 import { type IconProps, sizeMap } from "../props";
 
-export function LangJava({ iconSize = "xl-thin", ...props }: IconProps) {
+export function LangJava({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/lang-javascript.tsx
+++ b/web/internal/icons/src/icons/lang-javascript.tsx
@@ -1,6 +1,6 @@
 import { type IconProps, sizeMap } from "../props";
 
-export function LangJavascript({ iconSize = "xl-thin", ...props }: IconProps) {
+export function LangJavascript({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/lang-php.tsx
+++ b/web/internal/icons/src/icons/lang-php.tsx
@@ -1,6 +1,6 @@
 import { type IconProps, sizeMap } from "../props";
 
-export function LangPhp({ iconSize = "xl-thin", ...props }: IconProps) {
+export function LangPhp({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/lang-python.tsx
+++ b/web/internal/icons/src/icons/lang-python.tsx
@@ -1,6 +1,6 @@
 import { type IconProps, sizeMap } from "../props";
 
-export function LangPython({ iconSize = "xl-thin", ...props }: IconProps) {
+export function LangPython({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/lang-ruby.tsx
+++ b/web/internal/icons/src/icons/lang-ruby.tsx
@@ -1,6 +1,6 @@
 import { type IconProps, sizeMap } from "../props";
 
-export function LangRuby({ iconSize = "xl-thin", ...props }: IconProps) {
+export function LangRuby({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/lang-rust.tsx
+++ b/web/internal/icons/src/icons/lang-rust.tsx
@@ -1,6 +1,6 @@
 import { type IconProps, sizeMap } from "../props";
 
-export function LangRust({ iconSize = "xl-thin", ...props }: IconProps) {
+export function LangRust({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/lang-typescript.tsx
+++ b/web/internal/icons/src/icons/lang-typescript.tsx
@@ -1,6 +1,6 @@
 import { type IconProps, sizeMap } from "../props";
 
-export function LangTypescript({ iconSize = "xl-thin", ...props }: IconProps) {
+export function LangTypescript({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/laptop-2.tsx
+++ b/web/internal/icons/src/icons/laptop-2.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Laptop2({ iconSize = "xl-thin", ...props }: IconProps) {
+export function Laptop2({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/layer-front.tsx
+++ b/web/internal/icons/src/icons/layer-front.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function LayerFront({ iconSize = "xl-thin", ...props }: IconProps) {
+export function LayerFront({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/layers-3.tsx
+++ b/web/internal/icons/src/icons/layers-3.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Layers3({ iconSize = "xl-thin", ...props }: IconProps) {
+export function Layers3({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/layout-right.tsx
+++ b/web/internal/icons/src/icons/layout-right.tsx
@@ -12,7 +12,7 @@
 import type React from "react";
 import { type IconProps, sizeMap } from "../props";
 
-export const LayoutRight: React.FC<IconProps> = ({ iconSize = "xl-thin", ...props }) => {
+export const LayoutRight: React.FC<IconProps> = ({ iconSize = "xl-medium", ...props }) => {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/list-radio.tsx
+++ b/web/internal/icons/src/icons/list-radio.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function ListRadio({ iconSize = "xl-thin", ...props }: IconProps) {
+export function ListRadio({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/location2.tsx
+++ b/web/internal/icons/src/icons/location2.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Location2({ iconSize = "xl-thin", ...props }: IconProps) {
+export function Location2({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/lock.tsx
+++ b/web/internal/icons/src/icons/lock.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Lock({ iconSize = "xl-thin", ...props }: IconProps) {
+export function Lock({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/magnifier.tsx
+++ b/web/internal/icons/src/icons/magnifier.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Magnifier({ iconSize = "xl-thin", ...props }: IconProps) {
+export function Magnifier({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/maximize.tsx
+++ b/web/internal/icons/src/icons/maximize.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Maximize({ iconSize = "xl-thin", ...props }: IconProps) {
+export function Maximize({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/menu.tsx
+++ b/web/internal/icons/src/icons/menu.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Menu({ iconSize = "xl-thin", ...props }: IconProps) {
+export function Menu({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/microchip.tsx
+++ b/web/internal/icons/src/icons/microchip.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Microchip({ iconSize = "xl-thin", ...props }: IconProps) {
+export function Microchip({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/minimize.tsx
+++ b/web/internal/icons/src/icons/minimize.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Minimize({ iconSize = "xl-thin", ...props }: IconProps) {
+export function Minimize({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/minus.tsx
+++ b/web/internal/icons/src/icons/minus.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Minus({ iconSize = "xl-thin", ...props }: IconProps) {
+export function Minus({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/moon-stars.tsx
+++ b/web/internal/icons/src/icons/moon-stars.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function MoonStars({ iconSize = "xl-thin", ...props }: IconProps) {
+export function MoonStars({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/nodes-2.tsx
+++ b/web/internal/icons/src/icons/nodes-2.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Nodes2({ iconSize = "xl-thin", ...props }: IconProps) {
+export function Nodes2({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/nodes.tsx
+++ b/web/internal/icons/src/icons/nodes.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Nodes({ iconSize = "xl-thin", ...props }: IconProps) {
+export function Nodes({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/note-3.tsx
+++ b/web/internal/icons/src/icons/note-3.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Note3({ iconSize = "xl-thin", ...props }: IconProps) {
+export function Note3({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/number-input.tsx
+++ b/web/internal/icons/src/icons/number-input.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function NumberInput({ iconSize = "xl-thin", ...props }: IconProps) {
+export function NumberInput({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/nut.tsx
+++ b/web/internal/icons/src/icons/nut.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Nut({ iconSize = "xl-thin", ...props }: IconProps) {
+export function Nut({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/page-2.tsx
+++ b/web/internal/icons/src/icons/page-2.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Page2({ iconSize = "xl-thin", ...props }: IconProps) {
+export function Page2({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/paperclip-2.tsx
+++ b/web/internal/icons/src/icons/paperclip-2.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function PaperClip2({ iconSize = "xl-thin", ...props }: IconProps) {
+export function PaperClip2({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/pen-writing-3.tsx
+++ b/web/internal/icons/src/icons/pen-writing-3.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function PenWriting3({ iconSize = "xl-thin", ...props }: IconProps) {
+export function PenWriting3({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/plus.tsx
+++ b/web/internal/icons/src/icons/plus.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Plus({ iconSize = "xl-thin", filled, ...props }: IconProps) {
+export function Plus({ iconSize = "xl-medium", filled, ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/progress-bar.tsx
+++ b/web/internal/icons/src/icons/progress-bar.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function ProgressBar({ iconSize = "xl-thin", ...props }: IconProps) {
+export function ProgressBar({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/pulse.tsx
+++ b/web/internal/icons/src/icons/pulse.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Pulse({ iconSize = "xl-thin", ...props }: IconProps) {
+export function Pulse({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/ram.tsx
+++ b/web/internal/icons/src/icons/ram.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Ram({ iconSize = "xl-thin", ...props }: IconProps) {
+export function Ram({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/refresh-3.tsx
+++ b/web/internal/icons/src/icons/refresh-3.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Refresh3({ iconSize = "xl-thin", ...props }: IconProps) {
+export function Refresh3({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/scan-code.tsx
+++ b/web/internal/icons/src/icons/scan-code.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function ScanCode({ iconSize = "xl-thin", filled, ...props }: IconProps) {
+export function ScanCode({ iconSize = "xl-medium", filled, ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/share-up-right.tsx
+++ b/web/internal/icons/src/icons/share-up-right.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function ShareUpRight({ iconSize = "xl-thin", ...props }: IconProps) {
+export function ShareUpRight({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/shield-alert.tsx
+++ b/web/internal/icons/src/icons/shield-alert.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function ShieldAlert({ iconSize = "xl-thin", ...props }: IconProps) {
+export function ShieldAlert({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/shield-check.tsx
+++ b/web/internal/icons/src/icons/shield-check.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function ShieldCheck({ iconSize = "xl-thin", ...props }: IconProps) {
+export function ShieldCheck({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/shield-key.tsx
+++ b/web/internal/icons/src/icons/shield-key.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function ShieldKey({ iconSize = "xl-thin", ...props }: IconProps) {
+export function ShieldKey({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/shield.tsx
+++ b/web/internal/icons/src/icons/shield.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Shield({ iconSize = "xl-thin", ...props }: IconProps) {
+export function Shield({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/sidebar-left-hide.tsx
+++ b/web/internal/icons/src/icons/sidebar-left-hide.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function SidebarLeftHide({ iconSize = "xl-thin", ...props }: IconProps) {
+export function SidebarLeftHide({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/sidebar-left-show.tsx
+++ b/web/internal/icons/src/icons/sidebar-left-show.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function SidebarLeftShow({ iconSize = "xl-thin", ...props }: IconProps) {
+export function SidebarLeftShow({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/sliders.tsx
+++ b/web/internal/icons/src/icons/sliders.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Sliders({ iconSize = "xl-thin", ...props }: IconProps) {
+export function Sliders({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/sparkle-3.tsx
+++ b/web/internal/icons/src/icons/sparkle-3.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Sparkle3({ iconSize = "xl-thin", ...props }: IconProps) {
+export function Sparkle3({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/square-terminal.tsx
+++ b/web/internal/icons/src/icons/square-terminal.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function SquareTerminal({ iconSize = "xl-thin", ...props }: IconProps) {
+export function SquareTerminal({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/stack-perspective-2.tsx
+++ b/web/internal/icons/src/icons/stack-perspective-2.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function StackPerspective2({ iconSize = "xl-thin", ...props }: IconProps) {
+export function StackPerspective2({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/storage.tsx
+++ b/web/internal/icons/src/icons/storage.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Storage({ iconSize = "xl-thin", ...props }: IconProps) {
+export function Storage({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/sun.tsx
+++ b/web/internal/icons/src/icons/sun.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Sun({ iconSize = "xl-thin", ...props }: IconProps) {
+export function Sun({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/tag.tsx
+++ b/web/internal/icons/src/icons/tag.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Tag({ iconSize = "xl-thin", ...props }: IconProps) {
+export function Tag({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/task-checked.tsx
+++ b/web/internal/icons/src/icons/task-checked.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function TaskChecked({ iconSize = "xl-thin", ...props }: IconProps) {
+export function TaskChecked({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/task-unchecked.tsx
+++ b/web/internal/icons/src/icons/task-unchecked.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function TaskUnchecked({ iconSize = "xl-thin", ...props }: IconProps) {
+export function TaskUnchecked({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/text-input.tsx
+++ b/web/internal/icons/src/icons/text-input.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function TextInput({ iconSize = "xl-thin", ...props }: IconProps) {
+export function TextInput({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/time-clock.tsx
+++ b/web/internal/icons/src/icons/time-clock.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function TimeClock({ iconSize = "xl-thin", ...props }: IconProps) {
+export function TimeClock({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/trash.tsx
+++ b/web/internal/icons/src/icons/trash.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function Trash({ iconSize = "xl-thin", ...props }: IconProps) {
+export function Trash({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/icons/triangle-warning-2.tsx
+++ b/web/internal/icons/src/icons/triangle-warning-2.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function TriangleWarning2({ iconSize = "xl-thin", ...props }: IconProps) {
+export function TriangleWarning2({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/triangle-warning.tsx
+++ b/web/internal/icons/src/icons/triangle-warning.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function TriangleWarning({ iconSize = "xl-thin", ...props }: IconProps) {
+export function TriangleWarning({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/user-plus.tsx
+++ b/web/internal/icons/src/icons/user-plus.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function UserPlus({ iconSize = "xl-thin", ...props }: IconProps) {
+export function UserPlus({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/user.tsx
+++ b/web/internal/icons/src/icons/user.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function User({ iconSize = "xl-thin", ...props }: IconProps) {
+export function User({ iconSize = "xl-medium", ...props }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
 
   return (

--- a/web/internal/icons/src/icons/xmark.tsx
+++ b/web/internal/icons/src/icons/xmark.tsx
@@ -12,7 +12,7 @@
 
 import { type IconProps, sizeMap } from "../props";
 
-export function XMark({ iconSize = "xl-thin", ...rest }: IconProps) {
+export function XMark({ iconSize = "xl-medium", ...rest }: IconProps) {
   const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
   return (
     <svg

--- a/web/internal/icons/src/props.ts
+++ b/web/internal/icons/src/props.ts
@@ -2,31 +2,21 @@ import type { CSSProperties } from "react";
 
 // Clean external types that map to detailed internal types
 export type Size = "sm" | "md" | "lg" | "xl" | "2xl";
-export type Weight = "thin" | "regular" | "medium" | "bold";
+export type Weight = "medium" | "regular";
 
 export type iconSize = `${Size}-${Weight}`;
 
 export const sizeMap = {
-  "sm-thin": { iconSize: 12, strokeWidth: 1 },
   "sm-medium": { iconSize: 12, strokeWidth: 1.5 },
   "sm-regular": { iconSize: 12, strokeWidth: 2 },
-  "sm-bold": { iconSize: 12, strokeWidth: 3 },
-  "md-thin": { iconSize: 14, strokeWidth: 1 },
   "md-medium": { iconSize: 14, strokeWidth: 1.5 },
   "md-regular": { iconSize: 14, strokeWidth: 2 },
-  "md-bold": { iconSize: 14, strokeWidth: 3 },
-  "lg-thin": { iconSize: 16, strokeWidth: 1 },
   "lg-medium": { iconSize: 16, strokeWidth: 1.5 },
   "lg-regular": { iconSize: 16, strokeWidth: 2 },
-  "lg-bold": { iconSize: 16, strokeWidth: 3 },
-  "xl-thin": { iconSize: 18, strokeWidth: 1 },
   "xl-medium": { iconSize: 18, strokeWidth: 1.5 },
   "xl-regular": { iconSize: 18, strokeWidth: 2 },
-  "xl-bold": { iconSize: 18, strokeWidth: 3 },
-  "2xl-thin": { iconSize: 30, strokeWidth: 1 },
   "2xl-medium": { iconSize: 30, strokeWidth: 1.5 },
   "2xl-regular": { iconSize: 30, strokeWidth: 2 },
-  "2xl-bold": { iconSize: 30, strokeWidth: 3 },
 } as const;
 
 // export type IconProps = {

--- a/web/internal/ui/src/components/circle-progress.tsx
+++ b/web/internal/ui/src/components/circle-progress.tsx
@@ -62,7 +62,7 @@ type CircleProgressProps = React.HTMLAttributes<HTMLDivElement> & {
  * <CircleProgress
  *   value={progress}
  *   total={100}
- *   iconSize="sm-thin"
+ *   iconSize="sm-medium"
  * />
  * ```
  */

--- a/web/internal/ui/src/components/data-table/components/footer/pagination-footer.tsx
+++ b/web/internal/ui/src/components/data-table/components/footer/pagination-footer.tsx
@@ -63,7 +63,7 @@ export const PaginationFooter = memo(function PaginationFooter({
                 </span>
               </>
             )}
-            <Maximize iconSize="lg-thin" />
+            <Maximize iconSize="lg-medium" />
           </div>
         </button>
       </div>


### PR DESCRIPTION
## What does this PR do?

Every Nucleo icon source file shipped with `iconSize = "xl-thin"` baked in as a destructure default — 135 of the 165 icons. That's a 1px stroke, and Nucleo draws these icons at 1.5px. The result is that anywhere in the dashboard that renders an icon without explicitly passing `iconSize`, the stroke is half the weight the geometry was designed for. It's most visible next to text, where icons look spindly and ghost-like.

This PR does three things, all mechanical:

- Bumps the default from `xl-thin` to `xl-medium` on 135 icon source files (and `lg-thin` → `lg-medium` on the one outlier).
- Removes `"thin"` and `"bold"` from the `Weight` type union. `sizeMap` drops from 20 entries to 10. `thin` was used at 24 explicit callsites; `bold` at 4 — all migrated to the closest neighbor (`medium`/`regular`).
- Updates the 30 explicit callsites that used those weights.

Pixel sizes are unchanged — this is purely a stroke-weight change.

## Type of change

- [x] Chore (refactoring code, technical debt, workflow improvements)

## Screenshots

_To be added — before/after of dashboard top nav and sidebar icons._

## How should this be tested?

- [ ] `pnpm --dir=web build` passes (verified locally).
- [ ] `pnpm --dir=web typecheck` passes (verified locally).
- [ ] `iconSize="xl-thin"` or `iconSize="sm-bold"` etc. now fails typecheck — nobody can reintroduce these.
- [ ] Visually compare top nav (Feedback button, help button, copy ID button), sidebar, and any table with caret icons — strokes should look heftier but icons should be the same size.

Not tested: every specific icon callsite in the dashboard. The change is uniform (same px size, 50% thicker stroke) so per-callsite regressions are unlikely, but worth a quick eyeball on the heavily-iconned screens (audit log table, projects list, settings).

## Notes for reviewers

- This is the smallest piece of a larger icon-consistency cleanup. Two more PRs to come: a top-nav icon fix-up (Help button, Feedback button geometry mismatches), and an internal `/dev/icons` audit page that finds remaining violations.
- The `xl-thin` defaults look deliberate but aren't — they're a copy-paste artifact from whatever Nucleo template the icons were exported with. Only 10 of the 165 icons had a thoughtful non-thin default (`xl-medium`, `md-regular`, etc.); those are preserved.