### PR TITLE
fix(dashboard): 'redeploy' toast overlaying on new top nav

### DIFF
--- a/web/apps/dashboard/components/navigation/top-nav/index.tsx
+++ b/web/apps/dashboard/components/navigation/top-nav/index.tsx
@@ -26,7 +26,7 @@ export function TopNav() {
 
   return (
     <header
-      className="z-30 flex w-full shrink-0 items-center gap-1 border-b border-grayA-4 bg-gray-1 px-4"
+      className="flex w-full shrink-0 items-center gap-1 border-b border-grayA-4 bg-gray-1 px-4"
       style={{ height: TOP_NAV_HEIGHT }}
     >
       <Link href={`/${workspace.slug}`} aria-label="Unkey" className="inline-flex items-center">


### PR DESCRIPTION
## What does this PR do?

Dropped the new nav's `z-30` so the toast can paint above it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

_To be added — toast visible above the navbar in light + dark mode._

## How should this be tested?

Behind the \`newNavigation\` flag.

- [ ] On a project page, trigger the redeploy toast (e.g. save an environment settings change). Toast appears top-right, fully visible, in front of the navbar.
- [ ] Breadcrumb popovers, user/help dropdowns still open above content as before.
- [ ] Old (flag-off) navigation unchanged.

Not tested: every dropdown / popover inside the navbar individually. They use Radix \`Portal\` so they render at body level, outside the nav's stacking context — the nav's z-index couldn't reach them anyway.