### PR TITLE
fix(dashboard): add Audit Log to new navbar sidebar

### DIFF
--- a/web/apps/dashboard/lib/navigation/leaves.ts
+++ b/web/apps/dashboard/lib/navigation/leaves.ts
@@ -6,6 +6,7 @@ import {
   Fingerprint,
   Gauge,
   Gear,
+  InputSearch,
   Key,
   Layers3,
   Nodes,
@@ -57,6 +58,13 @@ export function buildWorkspaceSections(slug: string, segments: string[]): Resolv
       href: `/${slug}/identities`,
       icon: Fingerprint,
       isActive: top === "identities",
+    },
+    {
+      key: "audit",
+      label: "Audit Log",
+      href: `/${slug}/audit`,
+      icon: InputSearch,
+      isActive: top === "audit",
     },
     {
       key: "settings",


### PR DESCRIPTION
## What does this PR do?

The new (flag-gated) sidebar was missing the Audit Log entry that exists in the old one. This restores it: same `InputSearch` icon, same `/audit` href, slotted between Identities and Settings.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

_To be added — new sidebar with Audit Log visible (flag on)._

## How should this be tested?

- [ ] Enable the `newNavigation` flag → Audit Log entry appears in the workspace sidebar between Identities and Settings.
- [ ] Click it → lands on `/{workspaceSlug}/audit`.
- [ ] Active state highlights when on `/audit`.
- [ ] Flag off → old sidebar unchanged.

Not tested: Customer Billing / Portal entry is still absent in the new sidebar — the `/portal` route folder doesn't exist on disk so the old entry was speculative. Left alone intentionally.