### PR TITLE
refactor(worker,dashboard): show raw error when build stream fails

### DIFF
--- a/svc/ctrl/worker/deploy/build.go
+++ b/svc/ctrl/worker/deploy/build.go
@@ -35,6 +35,9 @@ import (
 )
 
 const (
+	// userBuildErrorMaxLen matches the deployment_steps.error 512-char column.
+	userBuildErrorMaxLen = 512
+
 	// defaultCacheKeepGB is the maximum cache size in gigabytes for new Depot
 	// projects. Depot evicts least-recently-used cache entries when exceeded.
 	defaultCacheKeepGB = 25
@@ -111,10 +114,11 @@ type gitBuildParams struct {
 // acquires a remote build machine, and executes the build. BuildKit fetches
 // the repository directly from GitHub using the provided installation token.
 // Build progress is streamed to ClickHouse for observability.
+// retErr is named so the synthetic-step defer below can read it.
 func (w *Workflow) buildDockerImageFromGit(
 	ctx restate.Context,
 	params gitBuildParams,
-) (*buildResult, error) {
+) (_ *buildResult, retErr error) {
 	platform := w.buildPlatform.Platform
 	architecture := w.buildPlatform.Architecture
 
@@ -124,6 +128,20 @@ func (w *Workflow) buildDockerImageFromGit(
 		"project_id", params.ProjectID,
 		"platform", platform,
 		"architecture", architecture)
+
+	// Pre-Solve failures never reach processBuildStatus, so emit a synthetic
+	// row carrying the raw error. Skipped for known errors — those already
+	// have an actionable extracted message, raw text would just add noise.
+	defer func() {
+		if retErr != nil && !isKnownBuildError(retErr) {
+			w.emitSyntheticBuildFailureStep(
+				params.WorkspaceID,
+				params.ProjectID,
+				params.DeploymentID,
+				retErr,
+			)
+		}
+	}()
 
 	depotProjectID, err := restate.Run(ctx, func(runCtx restate.RunContext) (string, error) {
 		return w.getOrCreateDepotProject(runCtx, params.ProjectID)
@@ -581,5 +599,54 @@ func extractUserBuildError(err error) string {
 			return known.message
 		}
 	}
-	return "Build failed. Please check the build logs for details."
+	return fmt.Sprintf("Build failed: %s", truncateString(err.Error(), userBuildErrorMaxLen))
+}
+
+func isKnownBuildError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	for _, known := range knownBuildErrors {
+		if strings.Contains(msg, known.substr) {
+			return true
+		}
+	}
+	return false
+}
+
+// emitSyntheticBuildFailureStep writes a synthetic build_steps_v1 row +
+// build_step_logs_v1 line carrying err. StepID is derived from deploymentID
+// so retries are idempotent.
+func (w *Workflow) emitSyntheticBuildFailureStep(
+	workspaceID, projectID, deploymentID string,
+	err error,
+) {
+	if err == nil {
+		return
+	}
+	now := time.Now().UnixMilli()
+	stepID := fmt.Sprintf("synthetic-build-failure:%s", deploymentID)
+	rawErr := err.Error()
+
+	w.buildSteps.Buffer(schema.BuildStepV1{
+		StartedAt:    now,
+		CompletedAt:  now,
+		WorkspaceID:  workspaceID,
+		ProjectID:    projectID,
+		DeploymentID: deploymentID,
+		StepID:       stepID,
+		Name:         "Build failed before any steps could run",
+		Cached:       false,
+		Error:        truncateString(rawErr, userBuildErrorMaxLen),
+		HasLogs:      true,
+	})
+	w.buildStepLogs.Buffer(schema.BuildStepLogV1{
+		Time:         now,
+		WorkspaceID:  workspaceID,
+		ProjectID:    projectID,
+		DeploymentID: deploymentID,
+		StepID:       stepID,
+		Message:      rawErr,
+	})
 }

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/(deployment-progress)/deployment-progress.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/(deployment-progress)/deployment-progress.tsx
@@ -141,7 +141,7 @@ export function DeploymentProgress({ stepsData }: { stepsData?: StepsData }) {
           {...startingStep}
         />
         <DeploymentStep
-          key={isPrebuilt ? "prebuilt" : "building"}
+          key={isPrebuilt ? "prebuilt" : isFailed ? "building-failed" : "building"}
           icon={<Hammer2 iconSize="sm-medium" className="size-[18px]" />}
           title="Building Image"
           description={match(building)
@@ -175,7 +175,7 @@ export function DeploymentProgress({ stepsData }: { stepsData?: StepsData }) {
               </div>
             )
           }
-          defaultExpanded={!isPrebuilt}
+          defaultExpanded={!isPrebuilt && !isFailed}
         />
         <DeploymentStep
           key={deploying ? "deploying-active" : "deploying-pending"}
@@ -212,6 +212,11 @@ export function DeploymentProgress({ stepsData }: { stepsData?: StepsData }) {
           redeployOpen={redeployOpen}
           onRedeployClose={() => setRedeployOpen(false)}
           deployment={deployment}
+          rawBuildError={
+            buildSteps.data?.steps.find(
+              (s) => s.step_id?.startsWith("synthetic-build-failure:") && s.error,
+            )?.error ?? null
+          }
         />
       )}
       {network?.completed && (

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/(deployment-progress)/failed-deployment-banner.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/(deployment-progress)/failed-deployment-banner.tsx
@@ -35,6 +35,7 @@ export function FailedDeploymentBanner({
   redeployOpen,
   onRedeployClose,
   deployment,
+  rawBuildError,
 }: {
   steps: StepEntry[];
   settingsUrl: string;
@@ -42,37 +43,46 @@ export function FailedDeploymentBanner({
   redeployOpen: boolean;
   onRedeployClose: () => void;
   deployment: Deployment;
+  /** Raw build error from the synthetic build_steps_v1 row. */
+  rawBuildError?: string | null;
 }) {
   const errorMessage = steps.find((s) => s?.error)?.error ?? "Deployment failed";
   const showSettingsLink = isSettingsRelatedError(errorMessage);
 
   return (
     <div className="flex flex-col gap-3 animate-fade-slide-in">
-      <div className="border border-errorA-4 bg-errorA-2 rounded-[14px] p-4 flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <div className="flex flex-col gap-0.5">
-            <span className="text-sm font-medium text-error-11">Deployment failed</span>
-            <span className="text-xs text-gray-11 max-w-150 break-after">
-              {errorMessage}
-              {showSettingsLink && (
-                <>
-                  {" "}
-                  <Link
-                    href={settingsUrl}
-                    className="underline hover:text-gray-12 transition-colors"
-                  >
-                    Go to Settings
-                  </Link>
-                </>
-              )}
-            </span>
+      <div className="border border-errorA-4 bg-errorA-2 rounded-[14px] p-4 flex flex-col gap-3">
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center gap-3">
+            <div className="flex flex-col gap-0.5">
+              <span className="text-sm font-medium text-error-11">Deployment failed</span>
+              <span className="text-xs text-gray-11 max-w-150 break-after">
+                {errorMessage}
+                {showSettingsLink && (
+                  <>
+                    {" "}
+                    <Link
+                      href={settingsUrl}
+                      className="underline hover:text-gray-12 transition-colors"
+                    >
+                      Go to Settings
+                    </Link>
+                  </>
+                )}
+              </span>
+            </div>
+          </div>
+          <div className="flex items-center gap-2 shrink-0">
+            <Button variant="primary" size="sm" onClick={onRedeploy} className="px-3">
+              Redeploy
+            </Button>
           </div>
         </div>
-        <div className="flex items-center gap-2">
-          <Button variant="primary" size="sm" onClick={onRedeploy} className="px-3">
-            Redeploy
-          </Button>
-        </div>
+        {rawBuildError && (
+          <pre className="text-[11px] leading-snug text-gray-11 bg-grayA-2 border border-grayA-4 rounded-md p-2.5  whitespace-normal max-h-48 overflow-auto">
+            {rawBuildError}
+          </pre>
+        )}
       </div>
       <RedeployDialog
         isOpen={redeployOpen}


### PR DESCRIPTION
This PR, allows us to show raw depot error when depot doesn't stream back what went wrong. To achieve this we are adding some synthetic logs to `build_steps_v1` and `build_step_logs`. Other possible way to improve this behavior would be adding an new column to db like `status_message` so when statu




### This is how it looks
<img width="993" height="492" alt="image" src="https://github.com/user-attachments/assets/dc66723c-24a6-47e0-81c9-fbbf6ae287f2" />
