### PR TITLE
feat(uid): bump default length from 8 to 9

### DIFF
--- a/pkg/uid/new.go
+++ b/pkg/uid/new.go
@@ -10,7 +10,7 @@ const defaultAlphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ012
 // New generates a prefixed random identifier.
 //
 // The identifier consists of the prefix, an underscore separator, and random
-// alphanumeric characters. Default random portion is 8 characters; pass a
+// alphanumeric characters. Default random portion is 9 characters; pass a
 // custom length to override.
 //
 // Pass an empty prefix to generate an identifier without a prefix.
@@ -18,7 +18,7 @@ const defaultAlphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ012
 // Uses math/rand/v2 which is NOT cryptographically secure. Do not use for
 // API keys, tokens, or security-sensitive purposes.
 func New(prefix Prefix, length ...int) string {
-	n := 8
+	n := 9
 	if len(length) > 0 {
 		n = length[0]
 	}

--- a/pkg/uid/new_test.go
+++ b/pkg/uid/new_test.go
@@ -15,7 +15,7 @@ func TestNew(t *testing.T) {
 		{
 			name:    "default length",
 			length:  nil,
-			wantLen: 8, // 8 default chars
+			wantLen: 9, // 9 default chars
 		},
 		{
 			name:    "custom length 12",
@@ -82,8 +82,8 @@ func TestNanoWithPrefix(t *testing.T) {
 		t.Errorf("Expected ID to start with prefix %v, got %v", KeyPrefix, id)
 	}
 
-	// Total length should be prefix + 8 default chars
-	expectedLen := len(KeyPrefix) + 1 + 8
+	// Total length should be prefix + 9 default chars
+	expectedLen := len(KeyPrefix) + 1 + 9
 	if len(id) != expectedLen {
 		t.Errorf("Expected total length %v, got %v", expectedLen, len(id))
 	}


### PR DESCRIPTION
8 chars over a 62-symbol alphabet gives ~47.6 bits of entropy. 

At that scale birthday collisions become realistic in the low millions of IDs. Bumping to 9 raises us to ~53.6 bits (~1% collision chance at ~17M IDs) without meaningfully changing ID ergonomics.
