### PR TITLE
fix(dashboard): permission sheet scrolling + click bugs

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/root-keys/components/dialog/components/permission-sheet.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/root-keys/components/dialog/components/permission-sheet.tsx
@@ -62,11 +62,11 @@ export const PermissionSheet = ({
         <SheetOverlay className="bg-black/30 backdrop-blur-xs" />
         <SheetContent
           disableClose={false}
-          className="flex flex-col p-0 m-0 h-full gap-0 border-l border-l-gray-4 w-[420px] bg-gray-1 dark:bg-black"
+          className="flex flex-col p-0 m-0 h-full gap-0 border-l border-l-gray-4 w-[420px] bg-gray-1 dark:bg-black overflow-hidden"
           side="right"
           overlay="transparent"
         >
-          <SheetHeader className="flex flex-row min-w-full border-b border-gray-4 gap-2 ">
+          <SheetHeader className="flex flex-row min-w-full border-b border-gray-4 gap-2 shrink-0">
             <SheetTitle className="sr-only">Select Permissions</SheetTitle>
             <SearchPermissions
               isProcessing={isProcessing}
@@ -75,71 +75,59 @@ export const PermissionSheet = ({
               onChange={handleSearchChange}
             />
           </SheetHeader>
-          <div className="w-full h-full">
-            <div className="flex flex-col h-full">
-              <div
-                className={`flex flex-col ${
-                  hasNextPage ? "max-h-[calc(100%-80px)]" : "max-h-[calc(100%-40px)]"
-                }`}
-              >
-                <ScrollArea className="flex flex-col h-full pt-2">
-                  <div className="flex flex-col pt-0 mt-0 gap-1 pb-6">
-                    {hasNoResults ? (
-                      <p className="text-sm text-gray-10 ml-6 py-1.5 mt-1.5">
-                        {ROOT_KEY_MESSAGES.UI.NO_RESULTS}
-                      </p>
-                    ) : (
-                      <>
-                        {/* Workspace Permissions */}
-                        <PermissionContentList
-                          selected={selectedPermissions}
-                          searchValue={searchValue}
-                          key="workspace"
-                          type="workspace"
-                          onPermissionChange={handleWorkspacePermissionChange}
-                        />
-                        {/* From APIs */}
-                        {apis.length > 0 && (
-                          <p className="text-sm text-gray-10 ml-6 py-1.5 mb-2">
-                            {ROOT_KEY_MESSAGES.UI.FROM_APIS}
-                          </p>
-                        )}
-                        {apis.map((api) => (
-                          <PermissionContentList
-                            selected={selectedPermissions}
-                            searchValue={searchValue}
-                            key={api.id}
-                            type="api"
-                            api={api}
-                            onPermissionChange={(permissions) =>
-                              handleApiPermissionChange(api.id, permissions)
-                            }
-                          />
-                        ))}
-                      </>
-                    )}
-                  </div>
-                </ScrollArea>
-              </div>
-              <div className="sticky bottom-0 bg-background border-t border-gray-4 mt-auto">
-                {hasNextPage ? (
-                  <div className="w-full py-4">
-                    <div className="flex flex-row justify-center items-center">
-                      <Button
-                        className="mx-auto rounded-lg"
-                        size="sm"
-                        onClick={() => loadMore?.()}
-                        disabled={!hasNextPage || !loadMore}
-                        loading={isFetchingNextPage}
-                      >
-                        {ROOT_KEY_MESSAGES.UI.LOAD_MORE}
-                      </Button>
-                    </div>
-                  </div>
-                ) : undefined}
+          <ScrollArea className="flex-1 min-h-0">
+            <div className="flex flex-col gap-1 pt-2 pb-6">
+              {hasNoResults ? (
+                <p className="text-sm text-gray-10 ml-6 py-1.5 mt-1.5">
+                  {ROOT_KEY_MESSAGES.UI.NO_RESULTS}
+                </p>
+              ) : (
+                <>
+                  {/* Workspace Permissions */}
+                  <PermissionContentList
+                    selected={selectedPermissions}
+                    searchValue={searchValue}
+                    key="workspace"
+                    type="workspace"
+                    onPermissionChange={handleWorkspacePermissionChange}
+                  />
+                  {/* From APIs */}
+                  {apis.length > 0 && (
+                    <p className="text-sm text-gray-10 ml-6 py-1.5 mb-2">
+                      {ROOT_KEY_MESSAGES.UI.FROM_APIS}
+                    </p>
+                  )}
+                  {apis.map((api) => (
+                    <PermissionContentList
+                      selected={selectedPermissions}
+                      searchValue={searchValue}
+                      key={api.id}
+                      type="api"
+                      api={api}
+                      onPermissionChange={(permissions) =>
+                        handleApiPermissionChange(api.id, permissions)
+                      }
+                    />
+                  ))}
+                </>
+              )}
+            </div>
+          </ScrollArea>
+          {hasNextPage && (
+            <div className="shrink-0 bg-gray-1 dark:bg-black border-t border-gray-4 w-full py-4">
+              <div className="flex flex-row justify-center items-center">
+                <Button
+                  className="mx-auto rounded-lg"
+                  size="sm"
+                  onClick={() => loadMore?.()}
+                  disabled={!loadMore}
+                  loading={isFetchingNextPage}
+                >
+                  {ROOT_KEY_MESSAGES.UI.LOAD_MORE}
+                </Button>
               </div>
             </div>
-          </div>
+          )}
         </SheetContent>
       </SheetPortal>
     </Sheet>

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/root-keys/components/dialog/root-key-dialog.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/root-keys/components/dialog/root-key-dialog.tsx
@@ -7,6 +7,7 @@ import { Button } from "@unkey/ui";
 import { FormInput } from "@unkey/ui";
 import dynamic from "next/dynamic";
 import * as React from "react";
+import { createPortal } from "react-dom";
 import { PermissionBadgeList } from "./components/permission-badge-list";
 import { PermissionSheet } from "./components/permission-sheet";
 import { ROOT_KEY_CONSTANTS, ROOT_KEY_MESSAGES } from "./constants";
@@ -53,10 +54,13 @@ export const RootKeyDialog = ({
   };
 
   const handleDialogOpenChange = (open: boolean) => {
-    onOpenChange(open);
-    if (!open) {
+    // Suppress dialog close while the permission sheet is open — Esc/outside-close events
+    // can otherwise propagate to the (non-modal) outer dialog and close both at once.
+    if (!open && isSheetOpen) {
       setIsSheetOpen(false);
+      return;
     }
+    onOpenChange(open);
   };
 
   const {
@@ -168,7 +172,21 @@ export const RootKeyDialog = ({
 
   return (
     <>
-      {/* Only show creation dialog if no key has been created yet */}
+      {/* The outer dialog is non-modal so its react-remove-scroll doesn't block wheel events
+          inside the sheet (which is portaled outside the dialog's DOM subtree). We render our
+          own backdrop here to replace the modal overlay we lost. */}
+      {!key.data?.key &&
+        isOpen &&
+        typeof document !== "undefined" &&
+        createPortal(
+          // @dh hacky fix, delete asap
+          <div
+            className="fixed inset-0 z-40 bg-black/30 backdrop-blur-xs"
+            aria-hidden="true"
+            onClick={() => handleDialogOpenChange(false)}
+          />,
+          document.body,
+        )}
       {!key.data?.key && (
         <DynamicDialogContainer
           isOpen={isOpen}
@@ -178,7 +196,7 @@ export const RootKeyDialog = ({
           className="max-w-[460px]"
           subTitle={subTitle}
           footer={footerContent}
-          modal={true}
+          modal={false}
           preventOutsideClose={isSheetOpen}
         >
           {dialogContent}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/root-keys/components/dialog/root-key-dialog.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/root-keys/components/dialog/root-key-dialog.tsx
@@ -180,6 +180,7 @@ export const RootKeyDialog = ({
         typeof document !== "undefined" &&
         createPortal(
           // @dh hacky fix, delete asap
+          // biome-ignore lint/a11y/useKeyWithClickEvents: decorative backdrop (aria-hidden); keyboard close is handled by Radix Esc handling on the dialog.
           <div
             className="fixed inset-0 z-40 bg-black/30 backdrop-blur-xs"
             aria-hidden="true"


### PR DESCRIPTION
## What does this PR do?

As discussed on slack, fixes scrolling within the permission sheet and click throughs being disabled after the portal is closed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

On `/<workspaceSlug>/settings/root-keys`, open **New root key** → **Select Permissions…**. Expand a few APIs:

- Mouse wheel scrolls the sheet; search header stays pinned.
- Esc closes the sheet only; second Esc closes the dialog.
- Clicking the dim backdrop matches Esc behavior.
- After closing both, the root-keys table is interactive.

## Notes for reviewers

The custom backdrop is marked `@dh hacky fix, delete asap` — it replaces Radix's modal overlay and so drops the focus trap. When the dialog is open alone, Tab can move focus behind the backdrop. Follow-up: reintroduce a manual `FocusScope` or restructure the nested-modal pattern.

The backdrop snaps instead of fading like peer dialogs. Cosmetic.

Separately, submitting the dialog with permissions selected fires the "You need to add at least one permission" toast (`use-root-key-dialog.ts:107`). Pre-existing, not in this diff.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary