### PR TITLE
refactor(dashboard): update renderable content list

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/requests/components/table/sentinel-log-details/index.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/requests/components/table/sentinel-log-details/index.tsx
@@ -187,6 +187,9 @@ const isDisplayableContentType = (contentType: string | null): boolean => {
     return true;
   }
   const ct = contentType.toLowerCase();
+  if (ct.includes("text/x-")) {
+    return false;
+  }
   return (
     ct.includes("text/") ||
     ct.includes("json") ||
@@ -202,7 +205,7 @@ const formatBody = (body: string, headers: string[]): React.ReactNode | string =
     return (
       <details className="text-xs">
         <summary className="text-grayA-10 italic cursor-pointer select-none">
-          Binary body ({contentType}) — click to expand
+          Raw body ({contentType}) — click to expand
         </summary>
         <pre className="mt-1 whitespace-pre-wrap break-all text-accent-12">{body}</pre>
       </details>

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/requests/components/table/sentinel-log-details/index.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/requests/components/table/sentinel-log-details/index.tsx
@@ -203,9 +203,10 @@ const formatBody = (body: string, headers: string[]): React.ReactNode | string =
   const contentType = getHeaderValue(headers, "content-type");
   if (!isDisplayableContentType(contentType)) {
     return (
-      <details className="text-xs">
+      <details className="group text-xs">
         <summary className="text-grayA-10 italic cursor-pointer select-none">
-          Raw body ({contentType}) — click to expand
+          Raw body ({contentType})<span className="group-open:hidden"> — click to expand</span>
+          <span className="hidden group-open:inline"> — click to collapse</span>
         </summary>
         <pre className="mt-1 whitespace-pre-wrap break-all text-accent-12">{body}</pre>
       </details>


### PR DESCRIPTION
Fixes #6221 

This PR updates renderable human readable content list

<img width="502" height="186" alt="image" src="https://github.com/user-attachments/assets/37252b97-3b4d-4032-bd3b-78625f2f9223" />


### How to test

- Make a deployment
- Call an endpoint that returns `text/x-[suffix]`
- Make sure response body doesn't render it initially
