### PR TITLE
fix: authorize portal session creation

### DIFF
--- a/pkg/rbac/permissions.go
+++ b/pkg/rbac/permissions.go
@@ -31,6 +31,9 @@ const (
 
 	// Deploy represents deployment resources and operations
 	Project ResourceType = "project"
+
+	// Portal represents customer portal sessions and configuration.
+	Portal ResourceType = "portal"
 )
 
 // Predefined API actions. These constants define operations that can be
@@ -177,6 +180,13 @@ const (
 
 	// GenerateUploadURL permits generating S3 upload URLs for build contexts
 	GenerateUploadURL ActionType = "generate_upload_url"
+)
+
+// Predefined portal actions. These constants define operations that can be
+// performed on customer portal resources.
+const (
+	// CreatePortalSession permits creating customer portal sessions.
+	CreatePortalSession ActionType = "create_session"
 )
 
 // Tuple represents a specific permission as a combination of resource type,

--- a/svc/api/routes/v2_portal_create_session/200_test.go
+++ b/svc/api/routes/v2_portal_create_session/200_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/unkeyed/unkey/pkg/db"
+	"github.com/unkeyed/unkey/pkg/rbac"
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_portal_create_session"
@@ -42,7 +43,11 @@ func TestCreateSessionSuccess(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	rootKey := h.CreateRootKey(workspaceID)
+	rootKey := h.CreateRootKey(workspaceID, rbac.Tuple{
+		ResourceType: rbac.Portal,
+		ResourceID:   "*",
+		Action:       rbac.CreatePortalSession,
+	}.String(), "api.*.read_key")
 
 	headers := http.Header{
 		"Content-Type":  {"application/json"},

--- a/svc/api/routes/v2_portal_create_session/403_test.go
+++ b/svc/api/routes/v2_portal_create_session/403_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/unkeyed/unkey/pkg/db"
+	"github.com/unkeyed/unkey/pkg/rbac"
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/openapi"
@@ -43,7 +44,11 @@ func TestCreateSessionForbiddenDisabledPortal(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	rootKey := h.CreateRootKey(workspaceID)
+	rootKey := h.CreateRootKey(workspaceID, rbac.Tuple{
+		ResourceType: rbac.Portal,
+		ResourceID:   "*",
+		Action:       rbac.CreatePortalSession,
+	}.String(), "api.*.read_key")
 
 	headers := http.Header{
 		"Content-Type":  {"application/json"},
@@ -52,6 +57,98 @@ func TestCreateSessionForbiddenDisabledPortal(t *testing.T) {
 
 	req := handler.Request{
 		Slug:        "disabled-portal",
+		ExternalId:  "user_123",
+		Permissions: []string{"api.*.read_key"},
+	}
+
+	res := testutil.CallRoute[handler.Request, openapi.ForbiddenErrorResponse](h, route, headers, req)
+	require.Equal(t, 403, res.Status)
+	require.NotNil(t, res.Body)
+}
+
+func TestCreateSessionForbiddenMissingPermission(t *testing.T) {
+	h := testutil.NewHarness(t)
+	ctx := context.Background()
+
+	route := &handler.Handler{
+		DB:            h.DB,
+		Auditlogs:     h.Auditlogs,
+		Keys:          h.Keys,
+		PortalBaseURL: "https://portal.unkey.com",
+	}
+	h.Register(route)
+
+	workspaceID := h.Resources().UserWorkspace.ID
+	portalConfigID := uid.New(uid.PortalConfigPrefix)
+	now := time.Now().UnixMilli()
+
+	err := db.Query.InsertPortalConfig(ctx, h.DB.RW(), db.InsertPortalConfigParams{
+		ID:          portalConfigID,
+		WorkspaceID: workspaceID,
+		Slug:        "test-portal",
+		KeyAuthID:   sql.NullString{Valid: true, String: uid.New(uid.KeySpacePrefix)},
+		Enabled:     true,
+		CreatedAt:   now,
+	})
+	require.NoError(t, err)
+
+	rootKey := h.CreateRootKey(workspaceID)
+
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}
+
+	req := handler.Request{
+		Slug:        "test-portal",
+		ExternalId:  "user_123",
+		Permissions: []string{"api.*.read_key"},
+	}
+
+	res := testutil.CallRoute[handler.Request, openapi.ForbiddenErrorResponse](h, route, headers, req)
+	require.Equal(t, 403, res.Status)
+	require.NotNil(t, res.Body)
+}
+
+func TestCreateSessionForbiddenDelegatedPermission(t *testing.T) {
+	h := testutil.NewHarness(t)
+	ctx := context.Background()
+
+	route := &handler.Handler{
+		DB:            h.DB,
+		Auditlogs:     h.Auditlogs,
+		Keys:          h.Keys,
+		PortalBaseURL: "https://portal.unkey.com",
+	}
+	h.Register(route)
+
+	workspaceID := h.Resources().UserWorkspace.ID
+	portalConfigID := uid.New(uid.PortalConfigPrefix)
+	now := time.Now().UnixMilli()
+
+	err := db.Query.InsertPortalConfig(ctx, h.DB.RW(), db.InsertPortalConfigParams{
+		ID:          portalConfigID,
+		WorkspaceID: workspaceID,
+		Slug:        "test-portal",
+		KeyAuthID:   sql.NullString{Valid: true, String: uid.New(uid.KeySpacePrefix)},
+		Enabled:     true,
+		CreatedAt:   now,
+	})
+	require.NoError(t, err)
+
+	rootKey := h.CreateRootKey(workspaceID, rbac.Tuple{
+		ResourceType: rbac.Portal,
+		ResourceID:   "*",
+		Action:       rbac.CreatePortalSession,
+	}.String())
+
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}
+
+	req := handler.Request{
+		Slug:        "test-portal",
 		ExternalId:  "user_123",
 		Permissions: []string{"api.*.read_key"},
 	}

--- a/svc/api/routes/v2_portal_create_session/BUILD.bazel
+++ b/svc/api/routes/v2_portal_create_session/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//pkg/codes",
         "//pkg/db",
         "//pkg/fault",
+        "//pkg/rbac",
         "//pkg/uid",
         "//pkg/validation",
         "//pkg/zen",
@@ -32,6 +33,7 @@ go_test(
     deps = [
         ":v2_portal_create_session",
         "//pkg/db",
+        "//pkg/rbac",
         "//pkg/uid",
         "//svc/api/internal/testutil",
         "//svc/api/openapi",

--- a/svc/api/routes/v2_portal_create_session/handler.go
+++ b/svc/api/routes/v2_portal_create_session/handler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/unkeyed/unkey/pkg/codes"
 	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/fault"
+	"github.com/unkeyed/unkey/pkg/rbac"
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/pkg/validation"
 	"github.com/unkeyed/unkey/pkg/zen"
@@ -61,6 +62,31 @@ func validatePermissionFormat(permissions []string) error {
 	return nil
 }
 
+func delegatedPermissionChecks(permissions []string) ([]rbac.PermissionQuery, error) {
+	checks := make([]rbac.PermissionQuery, 0, len(permissions))
+	for _, permission := range permissions {
+		tuple, err := rbac.TupleFromString(permission)
+		if err != nil {
+			return nil, fault.Wrap(err,
+				fault.Code(codes.App.Validation.InvalidInput.URN()),
+				fault.Internal(fmt.Sprintf("permission %q failed tuple parsing", permission)),
+				fault.Public(fmt.Sprintf("Permission %q is invalid. Expected format: {resourceType}.{resourceId}.{action}", permission)),
+			)
+		}
+
+		checks = append(checks, rbac.Or(
+			rbac.S(permission),
+			rbac.T(rbac.Tuple{
+				ResourceType: tuple.ResourceType,
+				ResourceID:   "*",
+				Action:       tuple.Action,
+			}),
+		))
+	}
+
+	return checks, nil
+}
+
 func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	auth, emit, err := h.Keys.GetRootKey(ctx, s)
 	defer emit()
@@ -74,6 +100,10 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	if err := validatePermissionFormat(req.Permissions); err != nil {
+		return err
+	}
+	delegatedChecks, err := delegatedPermissionChecks(req.Permissions)
+	if err != nil {
 		return err
 	}
 
@@ -104,6 +134,24 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			fault.Internal("database error looking up portal config"),
 			fault.Public("Failed to look up portal configuration."),
 		)
+	}
+
+	if err := auth.VerifyRootKey(ctx, keys.WithPermissions(rbac.Or(
+		rbac.T(rbac.Tuple{
+			ResourceType: rbac.Portal,
+			ResourceID:   portalConfig.ID,
+			Action:       rbac.CreatePortalSession,
+		}),
+		rbac.T(rbac.Tuple{
+			ResourceType: rbac.Portal,
+			ResourceID:   "*",
+			Action:       rbac.CreatePortalSession,
+		}),
+	))); err != nil {
+		return err
+	}
+	if err := auth.VerifyRootKey(ctx, keys.WithPermissions(rbac.And(delegatedChecks...))); err != nil {
+		return err
 	}
 
 	if !portalConfig.Enabled {


### PR DESCRIPTION
## Summary
- add explicit `portal.*.create_session` / `portal.<configID>.create_session` RBAC permission support
- require `/v2/portal.createSession` callers to pass `VerifyRootKey` before minting a portal session token
- require the issuing root key to possess every permission delegated into the portal session
- update portal session tests so authorized root keys still succeed and missing portal/delegated permissions are rejected

## Why
`portal.createSession` authenticated root keys with `GetRootKey` but did not authorize them with `VerifyRootKey`. It also stored caller-supplied session permissions without proving the issuing root key had those permissions, allowing a session to be minted with more privilege than the root key should delegate.

## Verification
- `bazel test //svc/api/routes/v2_portal_create_session:v2_portal_create_session_test --test_output=errors`

@pullfrog review