### PR TITLE
fix: validate oauth redirects

### DIFF
--- a/web/apps/dashboard/app/auth/actions.ts
+++ b/web/apps/dashboard/app/auth/actions.ts
@@ -7,6 +7,7 @@ import {
   setLastUsedOrgCookie,
   setSessionCookie,
 } from "@/lib/auth/cookies";
+import { sanitizeRedirectPath } from "@/lib/auth/redirect";
 import { auth } from "@/lib/auth/server";
 import {
   AuthErrorCode,
@@ -327,7 +328,10 @@ export async function signIntoWorkspace(orgId: string): Promise<VerificationResu
 
 // OAuth
 export async function signInViaOAuth(options: SignInViaOAuthOptions): Promise<string> {
-  return await auth.signInViaOAuth(options);
+  return await auth.signInViaOAuth({
+    ...options,
+    redirectUrlComplete: sanitizeRedirectPath(options.redirectUrlComplete),
+  });
 }
 
 export async function completeOAuthSignIn(request: Request): Promise<OAuthResult> {
@@ -339,7 +343,7 @@ export async function completeOAuthSignIn(request: Request): Promise<OAuthResult
 
     if (result.success) {
       await setCookies(result.cookies);
-      redirectTo = result.redirectTo;
+      redirectTo = sanitizeRedirectPath(result.redirectTo);
     } else {
       return result;
     }
@@ -350,7 +354,7 @@ export async function completeOAuthSignIn(request: Request): Promise<OAuthResult
       message: error instanceof Error ? error.message : "Unknown error occurred",
     };
   }
-  redirect(redirectTo);
+  redirect(sanitizeRedirectPath(redirectTo));
 }
 
 // Organization Selection

--- a/web/apps/dashboard/app/auth/sign-in/redirect-utils.ts
+++ b/web/apps/dashboard/app/auth/sign-in/redirect-utils.ts
@@ -1,34 +1,5 @@
-/**
- * Validates that a redirect URL is a safe relative path.
- * Uses an allowlist approach — every path segment must contain only
- * alphanumeric characters, hyphens, underscores, dots, or tildes.
- * Query strings and hash fragments are allowed (they stay on the same origin).
- */
-export function isSafeRedirectPath(url: string): boolean {
-  // Must start with exactly one forward slash
-  if (!url.startsWith("/") || url.startsWith("//")) {
-    return false;
-  }
-
-  // Strip query string and hash before validating path segments
-  const pathOnly = url.split("?")[0].split("#")[0];
-
-  // Every segment after splitting on "/" must only contain safe characters.
-  // The first element is always "" (before the leading slash).
-  const segments = pathOnly.split("/");
-  for (let i = 1; i < segments.length; i++) {
-    // Allow empty segments only for trailing slash (last segment)
-    if (segments[i] === "" && i === segments.length - 1) {
-      continue;
-    }
-    // Segments must be non-empty and contain only URL-safe path characters
-    if (!segments[i] || !/^[a-zA-Z0-9\-._~!$&'()*+,;=@%]+$/.test(segments[i])) {
-      return false;
-    }
-  }
-
-  return true;
-}
+export { isSafeRedirectPath } from "@/lib/auth/redirect";
+import { isSafeRedirectPath } from "@/lib/auth/redirect";
 
 const REDIRECT_STORAGE_KEY = "unkey_auth_redirect";
 

--- a/web/apps/dashboard/app/auth/sso-callback/[[...sso-callback]]/route.ts
+++ b/web/apps/dashboard/app/auth/sso-callback/[[...sso-callback]]/route.ts
@@ -1,5 +1,6 @@
 import { isSafeRedirectPath } from "@/app/auth/sign-in/redirect-utils";
 import { setCookiesOnResponse } from "@/lib/auth/cookies";
+import { sanitizeRedirectPath } from "@/lib/auth/redirect";
 import { auth } from "@/lib/auth/server";
 import { AuthErrorCode, SIGN_IN_URL } from "@/lib/auth/types";
 import { type NextRequest, NextResponse } from "next/server";
@@ -60,7 +61,9 @@ export async function GET(request: NextRequest) {
 
   // Get base URL from request because Next.js wants it
   const baseUrl = new URL(request.url).origin;
-  const response = NextResponse.redirect(new URL(authResult.redirectTo, baseUrl));
+  const response = NextResponse.redirect(
+    new URL(sanitizeRedirectPath(authResult.redirectTo), baseUrl),
+  );
 
   return await setCookiesOnResponse(response, authResult.cookies);
 }

--- a/web/apps/dashboard/lib/auth/local.ts
+++ b/web/apps/dashboard/lib/auth/local.ts
@@ -1,6 +1,7 @@
 import { BaseAuthProvider } from "./base-provider";
 import { shouldUseSecureCookies } from "./cookie-security";
 import { getCookie } from "./cookies";
+import { sanitizeRedirectPath } from "./redirect";
 import {
   type AuthenticatedUser,
   type EmailAuthResult,
@@ -484,7 +485,7 @@ export class LocalAuthProvider extends BaseAuthProvider {
 
   // OAuth Methods
   signInViaOAuth(options: SignInViaOAuthOptions): string {
-    return options.redirectUrlComplete;
+    return sanitizeRedirectPath(options.redirectUrlComplete);
   }
 
   async completeOAuthSignIn(_callbackRequest: Request): Promise<OAuthResult> {

--- a/web/apps/dashboard/lib/auth/redirect.ts
+++ b/web/apps/dashboard/lib/auth/redirect.ts
@@ -1,0 +1,37 @@
+const DEFAULT_AUTH_REDIRECT = "/apis";
+
+/**
+ * Validates that a redirect URL is a safe relative path.
+ * Uses an allowlist approach — every path segment must contain only
+ * alphanumeric characters, hyphens, underscores, dots, or tildes.
+ * Query strings and hash fragments are allowed (they stay on the same origin).
+ */
+export function isSafeRedirectPath(url: string): boolean {
+  // Must start with exactly one forward slash
+  if (!url.startsWith("/") || url.startsWith("//")) {
+    return false;
+  }
+
+  // Strip query string and hash before validating path segments
+  const pathOnly = url.split("?")[0].split("#")[0];
+
+  // Every segment after splitting on "/" must only contain safe characters.
+  // The first element is always "" (before the leading slash).
+  const segments = pathOnly.split("/");
+  for (let i = 1; i < segments.length; i++) {
+    // Allow empty segments only for trailing slash (last segment)
+    if (segments[i] === "" && i === segments.length - 1) {
+      continue;
+    }
+    // Segments must be non-empty and contain only URL-safe path characters
+    if (!segments[i] || !/^[a-zA-Z0-9\-._~!$&'()*+,;=@%]+$/.test(segments[i])) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+export function sanitizeRedirectPath(url: string | null | undefined): string {
+  return url && isSafeRedirectPath(url) ? url : DEFAULT_AUTH_REDIRECT;
+}

--- a/web/apps/dashboard/lib/auth/workos.ts
+++ b/web/apps/dashboard/lib/auth/workos.ts
@@ -9,6 +9,7 @@ import { BaseAuthProvider } from "./base-provider";
 import { getAuthCookieOptions } from "./cookie-security";
 import { getCookie } from "./cookies";
 import { getAuth } from "./get-auth";
+import { sanitizeRedirectPath } from "./redirect";
 import {
   AuthErrorCode,
   type EmailAuthResult,
@@ -942,7 +943,9 @@ export class WorkOSAuthProvider extends BaseAuthProvider {
   // OAuth Methods
   signInViaOAuth(options: SignInViaOAuthOptions): string {
     const { provider, redirectUrlComplete } = options;
-    const state = encodeURIComponent(JSON.stringify({ redirectUrlComplete }));
+    const state = encodeURIComponent(
+      JSON.stringify({ redirectUrlComplete: sanitizeRedirectPath(redirectUrlComplete) }),
+    );
     const baseUrl = getBaseUrl();
     const redirect = `${baseUrl}/auth/sso-callback`;
     return this.provider.userManagement.getAuthorizationUrl({
@@ -976,9 +979,7 @@ export class WorkOSAuthProvider extends BaseAuthProvider {
         throw new Error("No sealed session returned");
       }
 
-      const redirectUrlComplete = state
-        ? JSON.parse(decodeURIComponent(state)).redirectUrlComplete
-        : "/apis";
+      const redirectUrlComplete = sanitizeRedirectPath(extractRedirectUrlComplete(state));
 
       return {
         success: true,
@@ -1078,5 +1079,22 @@ export class WorkOSAuthProvider extends BaseAuthProvider {
       createdAt: providerInvitation.createdAt,
       updatedAt: providerInvitation.updatedAt,
     };
+  }
+}
+
+function extractRedirectUrlComplete(state: string | null): string | null {
+  if (!state) {
+    return null;
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(decodeURIComponent(state));
+    if (typeof parsed !== "object" || parsed === null || !("redirectUrlComplete" in parsed)) {
+      return null;
+    }
+
+    return typeof parsed.redirectUrlComplete === "string" ? parsed.redirectUrlComplete : null;
+  } catch {
+    return null;
   }
 }


### PR DESCRIPTION
## Summary
- centralize auth redirect validation in a shared server/client helper
- sanitize OAuth completion redirects before issuing Next.js redirects
- sanitize OAuth state values when creating and completing WorkOS OAuth sign-in

## Why
The OAuth state value could carry an absolute `redirectUrlComplete`, and the callback used it to build a redirect after authentication. Absolute URLs override the local base URL, enabling an open redirect after sign-in.

## Verification
- `pnpm --dir=web exec biome check apps/dashboard/lib/auth/redirect.ts apps/dashboard/app/auth/sign-in/redirect-utils.ts apps/dashboard/app/auth/actions.ts apps/dashboard/app/auth/sso-callback/[[...sso-callback]]/route.ts apps/dashboard/lib/auth/workos.ts apps/dashboard/lib/auth/local.ts`
- `pnpm --dir=web build` *(fails on current workspace/base: dashboard build cannot resolve existing `@unkey/vercel` imports)*

@pullfrog review