### PR TITLE
chore: pin remaining web dependencies

### DIFF
--- a/web/apps/dashboard/package.json
+++ b/web/apps/dashboard/package.json
@@ -78,7 +78,7 @@
     "framer-motion": "12.29.0",
     "geist": "1.3.1",
     "input-otp": "1.2.4",
-    "nanoid": "^5.1.6",
+    "nanoid": "5.1.6",
     "next": "16.2.6",
     "next-themes": "0.4.6",
     "nuqs": "1.17.6",

--- a/web/apps/dashboard/package.json
+++ b/web/apps/dashboard/package.json
@@ -69,7 +69,7 @@
     "@vercel/analytics": "2.0.1",
     "@vercel/toolbar": "0.2.2",
     "@workos-inc/node": "7.47.0",
-    "boring-avatars": "^2.0.4",
+    "boring-avatars": "2.0.4",
     "class-variance-authority": "0.7.0",
     "clsx": "catalog:",
     "cmdk": "1.0.0",

--- a/web/apps/dashboard/package.json
+++ b/web/apps/dashboard/package.json
@@ -35,7 +35,7 @@
     "@radix-ui/react-switch": "1.0.3",
     "@radix-ui/react-tabs": "1.1.0",
     "@radix-ui/react-tooltip": "catalog:",
-    "@sentry/nextjs": "^10",
+    "@sentry/nextjs": "10.53.1",
     "@tailwindcss/container-queries": "0.1.1",
     "@tailwindcss/postcss": "^4.2.1",
     "@tailwindcss/typography": "0.5.12",

--- a/web/apps/dashboard/package.json
+++ b/web/apps/dashboard/package.json
@@ -94,7 +94,7 @@
     "tailwind-merge": "2.5.4",
     "tailwindcss": "catalog:",
     "tailwindcss-animate": "1.0.7",
-    "tldts": "^7.0.28",
+    "tldts": "7.0.30",
     "trpc-tools": "0.12.0",
     "typescript": "5.7.3",
     "usehooks-ts": "3.1.0",

--- a/web/apps/dashboard/package.json
+++ b/web/apps/dashboard/package.json
@@ -78,7 +78,7 @@
     "framer-motion": "12.29.0",
     "geist": "1.3.1",
     "input-otp": "1.2.4",
-    "nanoid": "5.1.6",
+    "nanoid": "5.1.11",
     "next": "16.2.6",
     "next-themes": "0.4.6",
     "nuqs": "1.17.6",

--- a/web/apps/dashboard/package.json
+++ b/web/apps/dashboard/package.json
@@ -37,7 +37,7 @@
     "@radix-ui/react-tooltip": "catalog:",
     "@sentry/nextjs": "10.53.1",
     "@tailwindcss/container-queries": "0.1.1",
-    "@tailwindcss/postcss": "^4.2.1",
+    "@tailwindcss/postcss": "4.3.0",
     "@tailwindcss/typography": "0.5.12",
     "@tanstack/query-core": "5.87.1",
     "@tanstack/query-db-collection": "1.0.22",

--- a/web/apps/portal/package.json
+++ b/web/apps/portal/package.json
@@ -22,7 +22,7 @@
     "@radix-ui/react-tooltip": "catalog:",
     "@radix-ui/react-use-controllable-state": "1.2.2",
     "@tanstack/react-router": "1.170.4",
-    "@tanstack/react-start": "^1.167.16",
+    "@tanstack/react-start": "1.168.6",
     "@tanstack/react-table": "8.21.3",
     "@unkey/api": "^2.3.3",
     "@unkey/db": "workspace:^",

--- a/web/apps/portal/package.json
+++ b/web/apps/portal/package.json
@@ -24,7 +24,7 @@
     "@tanstack/react-router": "1.170.4",
     "@tanstack/react-start": "1.168.6",
     "@tanstack/react-table": "8.21.3",
-    "@unkey/api": "^2.3.3",
+    "@unkey/api": "2.3.4",
     "@unkey/db": "workspace:^",
     "@unkey/icons": "workspace:^",
     "@unkey/ui": "workspace:^",

--- a/web/apps/portal/package.json
+++ b/web/apps/portal/package.json
@@ -21,7 +21,7 @@
     "@radix-ui/react-slot": "1.2.4",
     "@radix-ui/react-tooltip": "catalog:",
     "@radix-ui/react-use-controllable-state": "1.2.2",
-    "@tanstack/react-router": "^1.167.16",
+    "@tanstack/react-router": "1.170.4",
     "@tanstack/react-start": "^1.167.16",
     "@tanstack/react-table": "8.21.3",
     "@unkey/api": "^2.3.3",

--- a/web/internal/id/package.json
+++ b/web/internal/id/package.json
@@ -14,6 +14,6 @@
     "typescript": "5.5.3"
   },
   "dependencies": {
-    "nanoid": "5.1.6"
+    "nanoid": "5.1.11"
   }
 }

--- a/web/internal/id/package.json
+++ b/web/internal/id/package.json
@@ -14,6 +14,6 @@
     "typescript": "5.5.3"
   },
   "dependencies": {
-    "nanoid": "^5.1.6"
+    "nanoid": "5.1.6"
   }
 }

--- a/web/internal/ui/package.json
+++ b/web/internal/ui/package.json
@@ -26,7 +26,7 @@
     "@radix-ui/react-popover": "catalog:",
     "@radix-ui/react-select": "2.2.6",
     "@radix-ui/react-separator": "1.1.8",
-    "@radix-ui/react-slider": "^1.3.6",
+    "@radix-ui/react-slider": "1.3.6",
     "@radix-ui/react-slot": "1.2.4",
     "@radix-ui/react-tabs": "1.1.0",
     "@radix-ui/react-tooltip": "catalog:",

--- a/web/internal/ui/package.json
+++ b/web/internal/ui/package.json
@@ -31,7 +31,7 @@
     "@radix-ui/react-tabs": "1.1.0",
     "@radix-ui/react-tooltip": "catalog:",
     "@radix-ui/react-use-controllable-state": "1.2.2",
-    "@radix-ui/react-visually-hidden": "^1.2.4",
+    "@radix-ui/react-visually-hidden": "1.2.4",
     "@unkey/icons": "workspace:^",
     "class-variance-authority": "0.7.1",
     "clsx": "catalog:",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -803,7 +803,7 @@ importers:
         specifier: 1.1.8
         version: 1.1.8(@types/react-dom@19.2.3(@types/react@19.2.4))(@types/react@19.2.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-slider':
-        specifier: ^1.3.6
+        specifier: 1.3.6
         version: 1.3.6(@types/react-dom@19.2.3(@types/react@19.2.4))(@types/react@19.2.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-slot':
         specifier: 1.2.4

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -313,7 +313,7 @@ importers:
         specifier: 1.0.7
         version: 1.0.7(tailwindcss@4.2.1)
       tldts:
-        specifier: ^7.0.28
+        specifier: 7.0.30
         version: 7.0.30
       trpc-tools:
         specifier: 0.12.0

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -818,7 +818,7 @@ importers:
         specifier: 1.2.2
         version: 1.2.2(@types/react@19.2.4)(react@19.2.3)
       '@radix-ui/react-visually-hidden':
-        specifier: ^1.2.4
+        specifier: 1.2.4
         version: 1.2.4(@types/react-dom@19.2.3(@types/react@19.2.4))(@types/react@19.2.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@tanstack/react-table':
         specifier: 8.21.3

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -966,7 +966,7 @@ importers:
         specifier: workspace:^
         version: link:../../internal/tsconfig
       mitata:
-        specifier: ^1.0.34
+        specifier: 1.0.34
         version: 1.0.34
       mysql2:
         specifier: 'catalog:'

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -395,7 +395,7 @@ importers:
         specifier: 8.21.3
         version: 8.21.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@unkey/api':
-        specifier: ^2.3.3
+        specifier: 2.3.4
         version: 2.3.4
       '@unkey/db':
         specifier: workspace:^

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -235,7 +235,7 @@ importers:
         specifier: 7.47.0
         version: 7.47.0(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       boring-avatars:
-        specifier: ^2.0.4
+        specifier: 2.0.4
         version: 2.0.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       class-variance-authority:
         specifier: 0.7.0

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -133,7 +133,7 @@ importers:
         specifier: 'catalog:'
         version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.4))(@types/react@19.2.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@sentry/nextjs':
-        specifier: ^10
+        specifier: 10.53.1
         version: 10.53.1(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.106.2(esbuild@0.18.20)(lightningcss@1.32.0)(postcss@8.4.38))
       '@tailwindcss/container-queries':
         specifier: 0.1.1

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -139,7 +139,7 @@ importers:
         specifier: 0.1.1
         version: 0.1.1(tailwindcss@4.2.1)
       '@tailwindcss/postcss':
-        specifier: ^4.2.1
+        specifier: 4.3.0
         version: 4.3.0
       '@tailwindcss/typography':
         specifier: 0.5.12

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -386,7 +386,7 @@ importers:
         specifier: 1.2.2
         version: 1.2.2(@types/react@19.2.4)(react@19.2.4)
       '@tanstack/react-router':
-        specifier: ^1.167.16
+        specifier: 1.170.4
         version: 1.170.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@tanstack/react-start':
         specifier: ^1.167.16

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -948,7 +948,7 @@ importers:
         specifier: 0.7.0
         version: 0.7.0
       '@clickhouse/client':
-        specifier: ^1.18.3
+        specifier: 1.18.5
         version: 1.18.5
       '@clickhouse/client-web':
         specifier: 'catalog:'

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -265,8 +265,8 @@ importers:
         specifier: 'catalog:'
         version: 3.10.3
       nanoid:
-        specifier: ^5.1.6
-        version: 5.1.11
+        specifier: 5.1.6
+        version: 5.1.6
       next:
         specifier: 16.2.6
         version: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -625,8 +625,8 @@ importers:
   internal/id:
     dependencies:
       nanoid:
-        specifier: ^5.1.6
-        version: 5.1.11
+        specifier: 5.1.6
+        version: 5.1.6
     devDependencies:
       '@types/node':
         specifier: 20.14.9
@@ -6807,8 +6807,8 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nanoid@5.1.11:
-    resolution: {integrity: sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==}
+  nanoid@5.1.6:
+    resolution: {integrity: sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==}
     engines: {node: ^18 || >=20}
     hasBin: true
 
@@ -14097,7 +14097,7 @@ snapshots:
 
   nanoid@3.3.12: {}
 
-  nanoid@5.1.11: {}
+  nanoid@5.1.6: {}
 
   negotiator@0.6.3: {}
 

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -265,8 +265,8 @@ importers:
         specifier: 'catalog:'
         version: 3.10.3
       nanoid:
-        specifier: 5.1.6
-        version: 5.1.6
+        specifier: 5.1.11
+        version: 5.1.11
       next:
         specifier: 16.2.6
         version: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -625,8 +625,8 @@ importers:
   internal/id:
     dependencies:
       nanoid:
-        specifier: 5.1.6
-        version: 5.1.6
+        specifier: 5.1.11
+        version: 5.1.11
     devDependencies:
       '@types/node':
         specifier: 20.14.9
@@ -6807,8 +6807,8 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nanoid@5.1.6:
-    resolution: {integrity: sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==}
+  nanoid@5.1.11:
+    resolution: {integrity: sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==}
     engines: {node: ^18 || >=20}
     hasBin: true
 
@@ -14097,7 +14097,7 @@ snapshots:
 
   nanoid@3.3.12: {}
 
-  nanoid@5.1.6: {}
+  nanoid@5.1.11: {}
 
   negotiator@0.6.3: {}
 

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -389,7 +389,7 @@ importers:
         specifier: 1.170.4
         version: 1.170.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@tanstack/react-start':
-        specifier: ^1.167.16
+        specifier: 1.168.6
         version: 1.168.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@6.3.5(@types/node@22.14.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.19.1)(yaml@2.9.0))(webpack@5.106.2(lightningcss@1.32.0))
       '@tanstack/react-table':
         specifier: 8.21.3

--- a/web/tools/local/package.json
+++ b/web/tools/local/package.json
@@ -19,7 +19,7 @@
     "@unkey/db": "workspace:^",
     "@unkey/id": "workspace:^",
     "@unkey/tsconfig": "workspace:^",
-    "mitata": "^1.0.34",
+    "mitata": "1.0.34",
     "mysql2": "catalog:",
     "tsx": "4.19.1"
   },

--- a/web/tools/local/package.json
+++ b/web/tools/local/package.json
@@ -13,7 +13,7 @@
   "license": "AGPL-3.0",
   "devDependencies": {
     "@clack/prompts": "0.7.0",
-    "@clickhouse/client": "^1.18.3",
+    "@clickhouse/client": "1.18.5",
     "@clickhouse/client-web": "catalog:",
     "@unkey/clickhouse": "workspace:^",
     "@unkey/db": "workspace:^",


### PR DESCRIPTION
## Summary

Pins the remaining ranged npm dependencies in `web` one at a time, using #6200 (`pnpm-v-11`) as the base.

Pinned:
- `@sentry/nextjs` -> `10.53.1`
- `@tailwindcss/postcss` -> `4.3.0`
- `boring-avatars` -> `2.0.4`
- `nanoid` -> `5.1.11`
- `tldts` -> `7.0.30`
- `@tanstack/react-router` -> `1.170.4`
- `@tanstack/react-start` -> `1.168.6`
- `@unkey/api` -> `2.3.4`
- `@radix-ui/react-slider` -> `1.3.6`
- `@radix-ui/react-visually-hidden` -> `1.2.4`
- `@clickhouse/client` -> `1.18.5`
- `mitata` -> `1.0.34`

## Verification

Normal remote Vercel deploys after each pin; no `--prebuilt`.

Final deploy after all pins:
- https://dashboard-2xosqvgm0-unkey.vercel.app

Earlier deploys stayed green as each dependency was added.
