### PR TITLE
fix(dashboard): deployment resource charts utilization bar

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/network/unkey-flow/components/overlay/node-details-panel/components/resource-metrics.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/network/unkey-flow/components/overlay/node-details-panel/components/resource-metrics.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { trpc } from "@/lib/trpc/client";
-import { useDeployment } from "../../../../../../layout-provider";
 import {
   bytesToMib,
   formatBytesPerSecondParts,
@@ -21,6 +20,7 @@ import {
 } from "@unkey/icons";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@unkey/ui";
 import { useEffect, useRef, useState } from "react";
+import { useDeployment } from "../../../../../../layout-provider";
 import {
   type AreaChartPoint,
   AreaTimeseriesChart,
@@ -29,10 +29,10 @@ import {
 
 // Dashboard panel refreshes every 3s. The chart's live tip reads from raw
 // FINAL so new checkpoints (5s heimdall cadence) show up at most one
-// refresh after they land. Each refresh fires 7 queries (cpu, memory,
-// disk, instances, network ingress, network egress, summary), each
-// scanning at most ~1 minute of raw data per workspace+resource. ~2.3 q/s
-// per open panel, well within budget.
+// refresh after they land. Each refresh fires 6 queries (cpu, memory,
+// disk, instances, network ingress, network egress), each scanning at
+// most ~1 minute of raw data per workspace+resource. ~2 q/s per open
+// panel, well within budget.
 const REFETCH_INTERVAL_MS = 3_000;
 
 const WINDOW_LABELS: Record<TimeWindow, string> = {

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/network/unkey-flow/components/overlay/node-details-panel/components/resource-metrics.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(overview)/deployments/[deploymentId]/network/unkey-flow/components/overlay/node-details-panel/components/resource-metrics.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { trpc } from "@/lib/trpc/client";
+import { useDeployment } from "../../../../../../layout-provider";
 import {
   bytesToMib,
   formatBytesPerSecondParts,
@@ -98,6 +99,7 @@ type ResourceMetricsProps = {
 };
 
 export function ResourceMetrics({ resourceId, storageMib, instanceName }: ResourceMetricsProps) {
+  const { deployment } = useDeployment();
   const params = { resourceId, instanceName };
   const [window, setWindow] = useState<TimeWindow>("1h");
   const showDateInTooltip = WINDOWS_NEEDING_DATE.includes(window);
@@ -140,18 +142,16 @@ export function ResourceMetrics({ resourceId, storageMib, instanceName }: Resour
       keepPreviousData: true,
     },
   );
-  const summary = trpc.deploy.metrics.getDeploymentResourceSummary.useQuery(params, {
-    refetchInterval: REFETCH_INTERVAL_MS,
-  });
-
-  const summaryData = summary.data;
-  const cpuUsedMilli = Math.round(summaryData?.current_cpu_millicores ?? 0);
-  const cpuAllocatedMilli = Math.round(summaryData?.cpu_allocated_millicores ?? 0);
-  const memUsedBytes = summaryData?.current_memory_bytes ?? 0;
-  const memAllocatedBytes = summaryData?.memory_allocated_bytes ?? 0;
-  const diskUsedBytes = summaryData?.current_disk_used_bytes ?? 0;
+  // Bar reads the chart's right-edge bucket so the two stay in lockstep —
+  // a rolling-average "current" smooths bursts, which made a 72% chart peak
+  // sit next to a 30% bar and read as a contradiction.
+  const cpuUsedMilli = Math.round(cpu.data?.at(-1)?.y ?? 0);
+  const cpuAllocatedMilli = deployment.cpuMillicores;
+  const memUsedBytes = memory.data?.at(-1)?.y ?? 0;
+  const memAllocatedBytes = deployment.memoryMib * 1024 * 1024;
+  const diskUsedBytes = disk.data?.at(-1)?.y ?? 0;
   const diskAllocatedBytes = (storageMib ?? 0) * 1024 * 1024;
-  const instanceCount = summaryData?.active_instances ?? 0;
+  const instanceCount = Math.round(instances.data?.at(-1)?.y ?? 0);
 
   const nowMs = Date.now();
   const xAxisDomain: [number, number] = [nowMs - WINDOW_MS[window], nowMs];


### PR DESCRIPTION
Fixes #6271 

Deployment resource charts utilization bar was showing the deployments average data instead of charts current value, so this PR should fix it.


### How to test

- Make a deployment
- Run CPU or Memory intensive endpoint
- Make sure instance resources chart's right side and utilization bar matches

<img width="309" height="263" alt="Screenshot 2026-05-25 at 22 31 30" src="https://github.com/user-attachments/assets/084523d4-ec6c-4a8e-8dc1-deccafc2fbab" />
