### PR TITLE
fix: refresh warm rate limit counters from origin periodically

### DIFF
--- a/internal/services/ratelimit/doc.go
+++ b/internal/services/ratelimit/doc.go
@@ -6,8 +6,9 @@ algorithm with atomic counters.
 
 All rate limit state is stored in a flat sync.Map of counter entries, keyed by
 (workspace, namespace, identifier, duration, sequence). Each entry holds an
-atomic.Int64 counter plus a sync.Once that gates the first origin hydration.
-There are no mutexes in the hot path:
+atomic.Int64 counter plus a sync.Once that gates the first origin sync. Warm
+entries periodically refresh from origin to prevent idle replicas from serving
+stale long-window state indefinitely. There are no mutexes in the hot path:
 
   - Denials are wait-free: two atomic loads, arithmetic, return.
   - Single checks are lock-free: a bounded CAS loop commits the increment.

--- a/internal/services/ratelimit/origin_test.go
+++ b/internal/services/ratelimit/origin_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -90,4 +92,103 @@ func TestFetchFromOrigin_CircuitBreakerShortCircuitsAfterTrip(t *testing.T) {
 	require.Less(t, additionalCalls, maxTolerated,
 		"circuit breaker should short-circuit most calls after repeated failures (got %d, tolerated <%d)",
 		additionalCalls, maxTolerated)
+}
+
+func TestCounterEntryEnsureFreshFromOrigin_RefreshesWarmEntryAfterMaxAge(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	start := time.Now().UTC().Truncate(time.Millisecond)
+	var fetchCalls atomic.Int64
+	entry := counterEntry{
+		fetch: func(context.Context) int64 {
+			return fetchCalls.Add(1) * 10
+		},
+	}
+
+	entry.EnsureFreshFromOrigin(ctx, start)
+	require.Equal(t, int64(1), fetchCalls.Load(), "cold entry should fetch once")
+	require.Equal(t, int64(10), entry.val.Load())
+
+	entry.EnsureFreshFromOrigin(ctx, start.Add(originFetchAgeMax-time.Millisecond))
+	require.Equal(t, int64(1), fetchCalls.Load(), "warm entry should not refresh before max age")
+	require.Equal(t, int64(10), entry.val.Load())
+
+	entry.EnsureFreshFromOrigin(ctx, start.Add(originFetchAgeMax))
+	require.Equal(t, int64(2), fetchCalls.Load(), "warm entry should refresh at max age")
+	require.Equal(t, int64(20), entry.val.Load())
+}
+
+func TestCounterEntryEnsureFreshFromOrigin_GatesConcurrentWarmRefresh(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	start := time.Now().UTC().Truncate(time.Millisecond)
+	fetchStarted := make(chan struct{})
+	releaseFetch := make(chan struct{})
+	var closeFetchStarted sync.Once
+	var fetchCalls atomic.Int64
+	entry := counterEntry{
+		fetch: func(context.Context) int64 {
+			fetchCalls.Add(1)
+			closeFetchStarted.Do(func() { close(fetchStarted) })
+			<-releaseFetch
+			return 10
+		},
+	}
+	entry.hydrated.Store(true)
+	entry.originFetchMsLast.Store(start.UnixMilli())
+
+	const goroutines = 32
+	ready := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			<-ready
+			entry.EnsureFreshFromOrigin(ctx, start.Add(originFetchAgeMax))
+		}()
+	}
+
+	close(ready)
+	<-fetchStarted
+	close(releaseFetch)
+	wg.Wait()
+
+	require.Equal(t, int64(1), fetchCalls.Load(), "only one stale warm caller should refresh origin")
+	require.Equal(t, int64(10), entry.val.Load())
+}
+
+func TestCounterEntryEnsureFreshFromOrigin_FailedWarmRefreshSuppressesRetryUntilMaxAge(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	start := time.Now().UTC().Truncate(time.Millisecond)
+	var fetchCalls atomic.Int64
+	entry := counterEntry{
+		fetch: func(context.Context) int64 {
+			if fetchCalls.Add(1) == 1 {
+				return 0
+			}
+			return 99
+		},
+	}
+	entry.val.Store(7)
+	entry.hydrated.Store(true)
+	entry.originFetchMsLast.Store(start.UnixMilli())
+
+	failedRefresh := start.Add(originFetchAgeMax)
+	entry.EnsureFreshFromOrigin(ctx, failedRefresh)
+	require.Equal(t, int64(1), fetchCalls.Load())
+	require.Equal(t, int64(7), entry.val.Load(), "failed fetch returns 0 and should preserve local state")
+	require.Equal(t, failedRefresh.UnixMilli(), entry.originFetchMsLast.Load(), "failed refresh still advances retry gate")
+
+	entry.EnsureFreshFromOrigin(ctx, failedRefresh.Add(time.Second))
+	require.Equal(t, int64(1), fetchCalls.Load(), "failed refresh should not retry before max age")
+	require.Equal(t, int64(7), entry.val.Load())
+
+	entry.EnsureFreshFromOrigin(ctx, failedRefresh.Add(originFetchAgeMax))
+	require.Equal(t, int64(2), fetchCalls.Load(), "failed refresh should retry after max age")
+	require.Equal(t, int64(99), entry.val.Load())
 }

--- a/internal/services/ratelimit/origin_test.go
+++ b/internal/services/ratelimit/origin_test.go
@@ -137,7 +137,7 @@ func TestCounterEntryEnsureFreshFromOrigin_GatesConcurrentWarmRefresh(t *testing
 		},
 	}
 	entry.hydrated.Store(true)
-	entry.originFetchMsLast.Store(start.UnixMilli())
+	entry.originFetchLastMs.Store(start.UnixMilli())
 
 	const goroutines = 32
 	ready := make(chan struct{})
@@ -176,13 +176,13 @@ func TestCounterEntryEnsureFreshFromOrigin_FailedWarmRefreshSuppressesRetryUntil
 	}
 	entry.val.Store(7)
 	entry.hydrated.Store(true)
-	entry.originFetchMsLast.Store(start.UnixMilli())
+	entry.originFetchLastMs.Store(start.UnixMilli())
 
 	failedRefresh := start.Add(originFetchAgeMax)
 	entry.EnsureFreshFromOrigin(ctx, failedRefresh)
 	require.Equal(t, int64(1), fetchCalls.Load())
 	require.Equal(t, int64(7), entry.val.Load(), "failed fetch returns 0 and should preserve local state")
-	require.Equal(t, failedRefresh.UnixMilli(), entry.originFetchMsLast.Load(), "failed refresh still advances retry gate")
+	require.Equal(t, failedRefresh.UnixMilli(), entry.originFetchLastMs.Load(), "failed refresh still advances retry gate")
 
 	entry.EnsureFreshFromOrigin(ctx, failedRefresh.Add(time.Second))
 	require.Equal(t, int64(1), fetchCalls.Load(), "failed refresh should not retry before max age")

--- a/internal/services/ratelimit/ratelimit.go
+++ b/internal/services/ratelimit/ratelimit.go
@@ -51,11 +51,11 @@ func (s *service) prepareCheck(ctx context.Context, req RatelimitRequest) checkS
 	prev := s.loadCounter(prevKey)
 
 	// First caller per entry runs fetchFromOrigin; concurrent callers block
-	// inside Do until it returns, then take the fast path (single atomic
-	// load of hydrated) forever. This prevents late arrivals on a cold key
-	// from reading a zero counter while the owner is still fetching.
-	cur.Hydrate(ctx)
-	prev.Hydrate(ctx)
+	// inside Do until it returns. Warm entries refresh from origin when their
+	// last origin fetch is stale, preventing idle replicas from serving an old
+	// local view for the rest of a long window.
+	cur.EnsureFreshFromOrigin(ctx, req.Time)
+	prev.EnsureFreshFromOrigin(ctx, req.Time)
 
 	// Strict mode: a recent denial in this region forces an additional
 	// synchronous origin fetch until the deadline passes. This is the

--- a/internal/services/ratelimit/service.go
+++ b/internal/services/ratelimit/service.go
@@ -192,7 +192,10 @@ func (e *counterEntry) EnsureFreshFromOrigin(ctx context.Context, now time.Time)
 			return
 		}
 		if e.originFetchMsLast.CompareAndSwap(last, nowMs) {
-			atomicMax(&e.originFetchMsLast, nowMs)
+		if e.originFetchMsLast.CompareAndSwap(last, nowMs) {
+			atomicMax(&e.val, e.fetch(ctx))
+			return
+		}
 			atomicMax(&e.val, e.fetch(ctx))
 			return
 		}

--- a/internal/services/ratelimit/service.go
+++ b/internal/services/ratelimit/service.go
@@ -80,12 +80,12 @@ type counterEntry struct {
 	// globalCount to get the global count.
 	val atomic.Int64
 
-	// originFetchMsLast is the last request timestamp at which this replica
+	// originFetchLastMs is the last request timestamp at which this replica
 	// deliberately refreshed the cell from origin. EnsureFreshFromOrigin initializes
 	// it for cold entries and advances it for periodic stale-state refreshes.
 	// It is intentionally request-time based so tests can drive refresh behavior
 	// with a simulated clock.
-	originFetchMsLast atomic.Int64
+	originFetchLastMs atomic.Int64
 
 	// speculative tracks RatelimitMany increments that have been applied to val
 	// but are not committed yet. The global push loop subtracts this value before
@@ -172,7 +172,7 @@ func (e *counterEntry) shouldPushGlobalCount(val int64) bool {
 // warm entries whose last origin fetch is older than originFetchAgeMax. The
 // fetched value is CAS-merged via atomicMax so the local counter only moves
 // forward. Concurrent callers on a cold entry block inside Do until the first
-// fetch returns; concurrent warm callers use originFetchMsLast as a single-fetch
+// fetch returns; concurrent warm callers use originFetchLastMs as a single-fetch
 // gate. A fetch failure surfaces as a returned 0, which atomicMax treats as a
 // no-op — the entry is left at whatever val held before and marked refreshed so
 // retries stay bounded by originFetchAgeMax when origin is unavailable.
@@ -181,17 +181,17 @@ func (e *counterEntry) EnsureFreshFromOrigin(ctx context.Context, now time.Time)
 	if !e.hydrated.Load() {
 		e.once.Do(func() {
 			atomicMax(&e.val, e.fetch(ctx))
-			atomicMax(&e.originFetchMsLast, nowMs)
+			atomicMax(&e.originFetchLastMs, nowMs)
 			e.hydrated.Store(true)
 		})
 	}
 
 	for range maxCASRetries {
-		last := e.originFetchMsLast.Load()
+		last := e.originFetchLastMs.Load()
 		if last != 0 && nowMs-last < originFetchAgeMax.Milliseconds() {
 			return
 		}
-		if e.originFetchMsLast.CompareAndSwap(last, nowMs) {
+		if e.originFetchLastMs.CompareAndSwap(last, nowMs) {
 			atomicMax(&e.val, e.fetch(ctx))
 			return
 		}

--- a/internal/services/ratelimit/service.go
+++ b/internal/services/ratelimit/service.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/unkeyed/unkey/pkg/buffer"
 	"github.com/unkeyed/unkey/pkg/circuitbreaker"
@@ -44,6 +45,12 @@ var ErrRegionRequired = errors.New("ratelimit: Config.Region is required")
 // bounded by GOMAXPROCS; 100 is astronomically generous.
 const maxCASRetries = 100
 
+// originFetchAgeMax bounds how long a warm local counter can make decisions
+// without re-reading the shared origin. Short windows naturally rotate before
+// this matters; longer windows refresh periodically so idle replicas do not keep
+// serving stale state for the rest of the window.
+const originFetchAgeMax = time.Minute
+
 // atomicMax raises target to val atomically via a bounded CAS loop.
 // The value only ever moves forward — a smaller val is a no-op. If the retry
 // bound is exhausted, an error is logged and the function returns without
@@ -72,6 +79,13 @@ type counterEntry struct {
 	// background replay path. The deny decision adds val to
 	// globalCount to get the global count.
 	val atomic.Int64
+
+	// originFetchMsLast is the last request timestamp at which this replica
+	// deliberately refreshed the cell from origin. EnsureFreshFromOrigin initializes
+	// it for cold entries and advances it for periodic stale-state refreshes.
+	// It is intentionally request-time based so tests can drive refresh behavior
+	// with a simulated clock.
+	originFetchMsLast atomic.Int64
 
 	// speculative tracks RatelimitMany increments that have been applied to val
 	// but are not committed yet. The global push loop subtracts this value before
@@ -116,8 +130,8 @@ type counterEntry struct {
 	// entries eligible for retry on the next tick.
 	lastPushed atomic.Int64
 
-	// fetch is bound to the entry's key at creation so the hot path
-	// doesn't allocate a per-call closure to pass into Hydrate.
+	// fetch is bound to the entry's key at creation so the hot path doesn't
+	// allocate a per-call closure to pass into EnsureFreshFromOrigin.
 	fetch func(context.Context) int64
 }
 
@@ -154,22 +168,36 @@ func (e *counterEntry) shouldPushGlobalCount(val int64) bool {
 	return threshold > 0 && val >= threshold && val > e.lastPushed.Load()
 }
 
-// Hydrate populates val from the bound fetcher exactly once. The fetched
-// value is CAS-merged via atomicMax so the local counter only moves
-// forward. Concurrent callers on a cold entry block inside Do until the
-// first fetch returns; subsequent callers return after a single atomic
-// load of hydrated. A fetch failure surfaces as a returned 0, which
-// atomicMax treats as a no-op — the entry is left at whatever val held
-// before (typically 0 on a failed first hydration) and marked hydrated
-// so the hot path stays fast.
-func (e *counterEntry) Hydrate(ctx context.Context) {
-	if e.hydrated.Load() {
-		return
+// EnsureFreshFromOrigin populates val from origin on first use and refreshes
+// warm entries whose last origin fetch is older than originFetchAgeMax. The
+// fetched value is CAS-merged via atomicMax so the local counter only moves
+// forward. Concurrent callers on a cold entry block inside Do until the first
+// fetch returns; concurrent warm callers use originFetchMsLast as a single-fetch
+// gate. A fetch failure surfaces as a returned 0, which atomicMax treats as a
+// no-op — the entry is left at whatever val held before and marked refreshed so
+// the hot path stays fast when origin is unavailable.
+func (e *counterEntry) EnsureFreshFromOrigin(ctx context.Context, now time.Time) {
+	nowMs := now.UnixMilli()
+	if !e.hydrated.Load() {
+		e.once.Do(func() {
+			atomicMax(&e.val, e.fetch(ctx))
+			atomicMax(&e.originFetchMsLast, nowMs)
+			e.hydrated.Store(true)
+		})
 	}
-	e.once.Do(func() {
-		atomicMax(&e.val, e.fetch(ctx))
-		e.hydrated.Store(true)
-	})
+
+	for range maxCASRetries {
+		last := e.originFetchMsLast.Load()
+		if last != 0 && nowMs-last < originFetchAgeMax.Milliseconds() {
+			return
+		}
+		if e.originFetchMsLast.CompareAndSwap(last, nowMs) {
+			atomicMax(&e.originFetchMsLast, nowMs)
+			atomicMax(&e.val, e.fetch(ctx))
+			return
+		}
+	}
+	logger.Error("origin refresh timestamp retries exhausted")
 }
 
 // service implements lockless distributed rate limiting using a sliding
@@ -177,7 +205,7 @@ func (e *counterEntry) Hydrate(ctx context.Context) {
 // single flat sync.Map with no mutexes in the hot path: per-window counter
 // entries keyed by (workspace, namespace, identifier, duration, sequence),
 // each holding the window's request count plus a sync.Once coordinating the
-// first origin hydration.
+// first origin sync.
 //
 // Ratelimit uses a CAS loop: denials are wait-free (single atomic Load),
 // allows retry only when another goroutine incremented the same counter
@@ -343,9 +371,10 @@ func (s *service) Close() error {
 
 // loadCounter returns the counter entry for the given key, creating it if
 // needed. Newly created entries carry a fetcher closure bound to the key,
-// so callers only need to invoke entry.Hydrate(ctx) to ensure the counter
-// has been populated from origin. Callers that skip Hydrate risk reading a
-// zero-valued counter while another goroutine is mid-fetch.
+// so callers only need to invoke entry.EnsureFreshFromOrigin to ensure the
+// counter has been populated or refreshed from origin. Callers that skip
+// EnsureFreshFromOrigin risk reading a stale or zero-valued counter while
+// another goroutine is mid-fetch.
 //
 // Counters created here are attributed to traffic via RatelimitWindowsCreated.
 // The global-counters sync uses [findOrCreateCounter] directly so its

--- a/internal/services/ratelimit/service.go
+++ b/internal/services/ratelimit/service.go
@@ -175,7 +175,7 @@ func (e *counterEntry) shouldPushGlobalCount(val int64) bool {
 // fetch returns; concurrent warm callers use originFetchMsLast as a single-fetch
 // gate. A fetch failure surfaces as a returned 0, which atomicMax treats as a
 // no-op — the entry is left at whatever val held before and marked refreshed so
-// the hot path stays fast when origin is unavailable.
+// retries stay bounded by originFetchAgeMax when origin is unavailable.
 func (e *counterEntry) EnsureFreshFromOrigin(ctx context.Context, now time.Time) {
 	nowMs := now.UnixMilli()
 	if !e.hydrated.Load() {
@@ -192,10 +192,6 @@ func (e *counterEntry) EnsureFreshFromOrigin(ctx context.Context, now time.Time)
 			return
 		}
 		if e.originFetchMsLast.CompareAndSwap(last, nowMs) {
-		if e.originFetchMsLast.CompareAndSwap(last, nowMs) {
-			atomicMax(&e.val, e.fetch(ctx))
-			return
-		}
 			atomicMax(&e.val, e.fetch(ctx))
 			return
 		}

--- a/svc/api/routes/v2_keys_verify_key/ratelimit_response_test.go
+++ b/svc/api/routes/v2_keys_verify_key/ratelimit_response_test.go
@@ -71,7 +71,7 @@ func TestRatelimitResponse(t *testing.T) {
 		require.True(t, rl.AutoApply, "Rate limit should be auto-applied")
 		require.False(t, rl.Exceeded, "Rate limit should not be exceeded")
 		require.Equal(t, int64(4), rl.Remaining, "Should have 4 remaining requests")
-		require.Greater(t, rl.Reset, time.Now().UnixMilli(), "Reset time should be in the future")
+		require.Greater(t, rl.Reset, h.Clock.Now().UnixMilli(), "Reset time should be in the future")
 	})
 
 	t.Run("rate limit exceeded fields", func(t *testing.T) {


### PR DESCRIPTION
> [!IMPORTANT]
> Unkey is not accepting external pull requests at this time. Pull requests from people outside the Unkey team will not be reviewed or merged.

Fix for tests in #6280

## What does this PR do?

Replaces the one-shot `Hydrate` mechanism on rate limit counter entries with `EnsureFreshFromOrigin`, which periodically re-reads the shared origin for warm entries. Previously, once a counter was hydrated it would never re-fetch from origin, meaning idle replicas could serve stale state for the remainder of a long window. Now, warm entries refresh from origin when their last fetch is older than `originFetchAgeMax` (1 minute), using a CAS loop on a new `originFetchMsLast` timestamp field to gate concurrent refresh attempts to a single fetch. The timestamp is driven by request time so tests can control refresh behavior with a simulated clock.

