### PR TITLE
fix: use speakeasy pagination meta for endpoints that support it

### DIFF
--- a/svc/api/openapi/openapi-generated.yaml
+++ b/svc/api/openapi/openapi-generated.yaml
@@ -4202,6 +4202,14 @@ paths:
             tags:
                 - apis
             x-speakeasy-name-override: listKeys
+            x-speakeasy-pagination:
+                inputs:
+                    - in: requestBody
+                      name: cursor
+                      type: cursor
+                outputs:
+                    nextCursor: $.pagination.cursor
+                type: cursor
     /v2/deploy.createDeployment:
         post:
             description: |
@@ -4771,7 +4779,7 @@ paths:
                       name: cursor
                       type: cursor
                 outputs:
-                    nextCursor: $.data.cursor
+                    nextCursor: $.pagination.cursor
                 type: cursor
     /v2/identities.updateIdentity:
         post:
@@ -6557,6 +6565,14 @@ paths:
             tags:
                 - permissions
             x-speakeasy-name-override: ListPermissions
+            x-speakeasy-pagination:
+                inputs:
+                    - in: requestBody
+                      name: cursor
+                      type: cursor
+                outputs:
+                    nextCursor: $.pagination.cursor
+                type: cursor
     /v2/permissions.listRoles:
         post:
             description: |
@@ -6623,6 +6639,14 @@ paths:
             tags:
                 - permissions
             x-speakeasy-name-override: ListRoles
+            x-speakeasy-pagination:
+                inputs:
+                    - in: requestBody
+                      name: cursor
+                      type: cursor
+                outputs:
+                    nextCursor: $.pagination.cursor
+                type: cursor
     /v2/portal.createSession:
         post:
             description: |
@@ -7190,6 +7214,14 @@ paths:
             tags:
                 - ratelimit
             x-speakeasy-name-override: listOverrides
+            x-speakeasy-pagination:
+                inputs:
+                    - in: requestBody
+                      name: cursor
+                      type: cursor
+                outputs:
+                    nextCursor: $.pagination.cursor
+                type: cursor
     /v2/ratelimit.multiLimit:
         post:
             description: |

--- a/svc/api/openapi/spec/paths/v2/apis/listKeys/index.yaml
+++ b/svc/api/openapi/spec/paths/v2/apis/listKeys/index.yaml
@@ -74,3 +74,11 @@ post:
         application/json:
           schema:
             $ref: "../../../../error/InternalServerErrorResponse.yaml"
+  x-speakeasy-pagination:
+    type: cursor
+    inputs:
+      - name: cursor
+        in: requestBody
+        type: cursor
+    outputs:
+      nextCursor: "$.pagination.cursor"

--- a/svc/api/openapi/spec/paths/v2/identities/listIdentities/index.yaml
+++ b/svc/api/openapi/spec/paths/v2/identities/listIdentities/index.yaml
@@ -112,4 +112,4 @@ post:
         in: requestBody
         type: cursor
     outputs:
-      nextCursor: "$.data.cursor"
+      nextCursor: "$.pagination.cursor"

--- a/svc/api/openapi/spec/paths/v2/permissions/listPermissions/index.yaml
+++ b/svc/api/openapi/spec/paths/v2/permissions/listPermissions/index.yaml
@@ -57,3 +57,11 @@ post:
         application/json:
           schema:
             "$ref": "../../../../error/InternalServerErrorResponse.yaml"
+  x-speakeasy-pagination:
+    type: cursor
+    inputs:
+      - name: cursor
+        in: requestBody
+        type: cursor
+    outputs:
+      nextCursor: "$.pagination.cursor"

--- a/svc/api/openapi/spec/paths/v2/permissions/listRoles/index.yaml
+++ b/svc/api/openapi/spec/paths/v2/permissions/listRoles/index.yaml
@@ -63,3 +63,11 @@ post:
           schema:
             "$ref": "../../../../error/InternalServerErrorResponse.yaml"
       description: Internal Server Error
+  x-speakeasy-pagination:
+    type: cursor
+    inputs:
+      - name: cursor
+        in: requestBody
+        type: cursor
+    outputs:
+      nextCursor: "$.pagination.cursor"

--- a/svc/api/openapi/spec/paths/v2/ratelimit/listOverrides/index.yaml
+++ b/svc/api/openapi/spec/paths/v2/ratelimit/listOverrides/index.yaml
@@ -112,3 +112,11 @@ post:
           schema:
             "$ref": "../../../../error/InternalServerErrorResponse.yaml"
       description: Error
+  x-speakeasy-pagination:
+    type: cursor
+    inputs:
+      - name: cursor
+        in: requestBody
+        type: cursor
+    outputs:
+      nextCursor: "$.pagination.cursor"


### PR DESCRIPTION
spekeasys allows for generating nice pagination stuff https://www.speakeasy.com/docs/sdks/customize/runtime/pagination
for our pagination endpoints which we now use

Fixes #4109