### PR TITLE
fix: restate jornal run issues

### DIFF
--- a/svc/ctrl/worker/deploy/deploy_handler.go
+++ b/svc/ctrl/worker/deploy/deploy_handler.go
@@ -569,6 +569,9 @@ func (w *Workflow) createTopologies(
 			autoscalingMax = autoscalingMin
 		}
 
+		// CreatedAt is filled in below inside the Run so the timestamp stays
+		// stable across Restate replays.
+		//nolint: exhaustruct
 		topologies = append(topologies, db.InsertDeploymentTopologyParams{
 			WorkspaceID:                workspace.ID,
 			DeploymentID:               deployment.ID,
@@ -578,17 +581,19 @@ func (w *Workflow) createTopologies(
 			AutoscalingThresholdCpu:    rs.AutoscalingThresholdCpu,
 			AutoscalingThresholdMemory: rs.AutoscalingThresholdMemory,
 			DesiredStatus:              db.DeploymentTopologyDesiredStatusRunning,
-			CreatedAt:                  time.Now().UnixMilli(),
 		})
 	}
 
 	err = restate.RunVoid(ctx, func(runCtx restate.RunContext) error {
 		return db.Tx(runCtx, w.db.RW(), func(txCtx context.Context, tx db.DBTX) error {
+			now := time.Now().UnixMilli()
+			for i := range topologies {
+				topologies[i].CreatedAt = now
+			}
 			err := db.BulkQuery.InsertDeploymentTopologies(txCtx, tx, topologies)
 			if err != nil {
 				return err
 			}
-			now := time.Now().UnixMilli()
 			for _, topo := range topologies {
 				err := db.Query.InsertDeploymentChange(txCtx, tx, db.InsertDeploymentChangeParams{
 					ResourceType: db.DeploymentChangesResourceTypeDeploymentTopology,

--- a/svc/ctrl/worker/deploy/domains.go
+++ b/svc/ctrl/worker/deploy/domains.go
@@ -2,7 +2,6 @@ package deploy
 
 import (
 	"fmt"
-	"math/rand/v2"
 	"regexp"
 	"strings"
 
@@ -65,12 +64,21 @@ func buildDomains(workspaceSlug, projectSlug, appSlug, environmentSlug, gitSha, 
 		prefix = prefix + "-fork-" + sluggify(forkOwner)
 	}
 
-	// Deploying via CLI often sends the same git sha, and we want to make them unique,
-	// to prevent changes from overwriting each other.
-	randomSuffix := ""
+	// Deploying via CLI often sends the same git sha across deployments, so the
+	// per-commit domain needs disambiguation. The suffix must be deterministic:
+	// this function runs inside a Restate workflow, so re-rolling a random
+	// value on replay would change the per-domain Run name and trigger a
+	// journal mismatch. We take the tail of the deployment ID since each
+	// deployment has a unique slug already.
+	disambiguator := ""
 	if source == ctrlv1.SourceType_SOURCE_TYPE_CLI_UPLOAD {
-		//nolint: gosec
-		randomSuffix = fmt.Sprintf("-%d", 1000+rand.IntN(9000))
+		tail := sluggify(deploymentID)
+		if len(tail) > 4 {
+			tail = tail[len(tail)-4:]
+		}
+		if tail != "" {
+			disambiguator = "-" + tail
+		}
 	}
 
 	var domains []newDomain
@@ -80,7 +88,7 @@ func buildDomains(workspaceSlug, projectSlug, appSlug, environmentSlug, gitSha, 
 		if len(short) > 7 {
 			short = short[:7]
 		}
-		short += randomSuffix
+		short += disambiguator
 		domains = append(domains,
 			newDomain{
 				domain: fmt.Sprintf("%s-git-%s-%s.%s", prefix, short, workspaceSlug, apex),

--- a/svc/ctrl/worker/deploy/scale_down_idle_preview_deployments.go
+++ b/svc/ctrl/worker/deploy/scale_down_idle_preview_deployments.go
@@ -22,7 +22,15 @@ var idleTime = 6 * time.Hour
 // checking request counts in ClickHouse.
 func (w *Workflow) ScaleDownIdlePreviewDeployments(ctx restate.ObjectContext, req *hydrav1.ScaleDownIdlePreviewDeploymentsRequest) (*hydrav1.ScaleDownIdlePreviewDeploymentsResponse, error) {
 
-	cutoff := time.Now().Add(-idleTime).UnixMilli()
+	// Journal the cutoff so replays reuse the same value. Pulling time.Now()
+	// outside a Run would re-evaluate on every replay and drift the query
+	// inputs of later Runs that have not yet been journaled.
+	cutoff, err := restate.Run(ctx, func(runCtx restate.RunContext) (int64, error) {
+		return time.Now().Add(-idleTime).UnixMilli(), nil
+	}, restate.WithName("compute idle cutoff"), restate.WithMaxRetryAttempts(runMaxAttempts))
+	if err != nil {
+		return nil, err
+	}
 
 	cursor := uint64(0)
 	for {


### PR DESCRIPTION
Fixes #6270

our frontline random suffix needs to be deterministic otherwise restate will error on us and lead to stuck deployments