### PR TITLE
fix: ratelimits converge faster

### DIFF
--- a/docs/engineering/architecture/ratelimiting/consistency-model.mdx
+++ b/docs/engineering/architecture/ratelimiting/consistency-model.mdx
@@ -19,7 +19,7 @@ The lower layer always remains useful when a higher layer lags. A process can co
 
 ## Regional convergence
 
-After a request is accepted, the process buffers a replay event for the regional origin. Replay merges the regional value back into local memory with `max`, so processes in the same region converge toward the same count without waiting on every request.
+After a request is accepted, the process buffers a replay event for the regional origin. Replay merges the regional value back into local memory with `max` and marks the entry fresh. Processes in the same region converge toward the same count without waiting on every request.
 
 ```mermaid
 sequenceDiagram
@@ -35,19 +35,23 @@ sequenceDiagram
   Replay->>Local: Merge max(local, regional total)
 ```
 
-Cold counters and strict-mode counters read the regional origin synchronously before deciding. This makes the first decision for a key and the decisions after a denial use a fresher regional baseline.
+Cold counters, stale counters, and strict-mode counters read the regional origin synchronously before deciding. This makes the first decision for a key, decisions after stale local state, and decisions after a denial use a fresher regional baseline.
+
+Warm entries carry a freshness deadline. Regional-origin reads and successful replays extend that deadline. While the entry is fresh, the request path can use local memory without blocking on origin. After the deadline passes, the next request refreshes from origin before deciding.
+
+The freshness interval is intentionally short. Active identifiers normally stay fresh through replay, while idle or lagging identifiers re-read origin before they can keep serving an old local view for the rest of a long window. Concurrent stale requests for the same window cell share one origin read, then continue from the same refreshed value.
 
 ## Strict mode
 
-Strict mode is regional. When a request is denied, the service records a deadline for the `(workspace, namespace, identifier, duration)` tuple. Until that deadline passes, later requests for the same tuple refresh from the regional origin before evaluating the limit.
+Strict mode is regional. When a request is denied, the service records a deadline for the `(workspace, namespace, identifier, duration)` tuple. Until that deadline passes, later requests for the same tuple refresh the current window from the regional origin before evaluating the limit.
 
 The strict-mode key excludes the sequence. A denial in one fixed window can still affect the weighted previous-window term in the next fixed window, so strict mode survives the sequence rollover.
 
-Strict mode does not publish cross-region state. Global convergence is handled by global counters.
+Strict mode does not publish cross-region state. It refreshes the current window only. Previous windows use the normal cold and stale refresh path because they no longer receive new accepted increments.
 
 ## Global convergence
 
-Global convergence is eventual. A region publishes its own regional count when the count becomes meaningful for remote decisions. Other regions import the sum of foreign regional counts and include that imported count in future decisions.
+Global convergence is eventual. A region publishes its own regional count when the count becomes meaningful for remote decisions. Other regions import the sum of foreign regional counts and include that imported count in future decisions. The publishing region may also import its own published count as a lower bound for local regional state on nodes that have not yet seen the same regional origin value.
 
 ```plaintext
 Region A accepts traffic
@@ -67,6 +71,8 @@ Region B includes that count in later decisions
 
 This model means simultaneous traffic in multiple regions can briefly pass before every region has imported the latest remote usage. The tradeoff is deliberate: request-serving processes do not wait for cross-region coordination on the hot path.
 
+Own-region imports are a safety net, not a replacement for the regional origin. They can only raise local regional counts. They do not refresh the local entry's regional-origin freshness deadline, and foreign counts still stay separate so they cannot be published again.
+
 Windows shorter than 60 seconds are effectively regional because the global convergence cadence is too coarse to provide useful cross-region accuracy. Longer windows can include global convergence before the window expires.
 
 ## Failure behavior
@@ -76,7 +82,7 @@ Failures degrade toward local decisions and recover when the affected layer beco
 | Failure | Behavior |
 | --- | --- |
 | Regional read fails | The process continues from its local count |
-| Regional replay lags | Other nodes in the region converge later |
+| Regional replay lags | Other nodes in the region converge later, or refresh when their local entry becomes stale |
 | Global publish lags | Other regions do not see the new count yet |
 | Global import lags | The region continues with its existing imported counts |
 

--- a/docs/engineering/architecture/ratelimiting/consistency-model.mdx
+++ b/docs/engineering/architecture/ratelimiting/consistency-model.mdx
@@ -81,7 +81,7 @@ Failures degrade toward local decisions and recover when the affected layer beco
 
 | Failure | Behavior |
 | --- | --- |
-| Regional read fails | The process continues from its local count |
+| Regional read fails | The process continues from its local count and retries soon; failed reads do not make the local entry fresh |
 | Regional replay lags | Other nodes in the region converge later, or refresh when their local entry becomes stale |
 | Global publish lags | Other regions do not see the new count yet |
 | Global import lags | The region continues with its existing imported counts |

--- a/docs/engineering/architecture/ratelimiting/global-counters.mdx
+++ b/docs/engineering/architecture/ratelimiting/global-counters.mdx
@@ -54,14 +54,17 @@ That gives the counter four useful properties.
 
 ## Importing without feedback loops
 
-A region imports only foreign components. It adds those foreign counts to local decisions, but it does not publish them again.
+A region imports components in two different ways. Its own component is a regional lower bound and can raise the local regional count. Foreign components are summed separately and added to decisions, but they are never published again.
 
 ```plaintext
-Region A decision = A regional count + imported count from B and C
-Region A publish  = A regional count only
+Region A decision        = A regional count + imported count from B and C
+Region A publish         = A regional count only
+Region A own-row import  = max(A regional count, A published component)
 ```
 
-This separation prevents double counting. If Region A published `A + B`, then Region B could import that value and count its own traffic again. The implementation keeps the two values separate as regional count and `globalCount`.
+This separation prevents double counting. If Region A published `A + B`, then Region B could import that value and count its own traffic again. If Region A folded its own component into imported global count instead of regional count, it would count its own traffic twice during local decisions.
+
+Own-row import is only a safety net. The regional origin remains the source of truth for in-region convergence, and importing an own component does not make the local entry fresh against that origin.
 
 ## Why it fits rate limiting
 
@@ -91,6 +94,7 @@ Global counters rely on these invariants:
 
 - Each region owns only its own component.
 - Component values are merged with `max`, never replacement by an older value.
-- Imports exclude the current region's component.
-- Imported count is read by the request path but never republished.
+- A region's own imported component can only raise regional count.
+- Foreign imported count is read by the request path but never republished.
+- Own components and foreign components stay separate during import.
 - A sequence is immutable once it ages out. New windows use new component identities.

--- a/docs/engineering/architecture/ratelimiting/overview.mdx
+++ b/docs/engineering/architecture/ratelimiting/overview.mdx
@@ -24,7 +24,7 @@ These goals create deliberate tradeoffs:
 | Choice | Benefit | Cost |
 | --- | --- | --- |
 | Local-memory decision first | Low latency and high availability | Simultaneous traffic in different processes can briefly see different views |
-| Async regional convergence | Requests don't wait on the regional origin | A neighboring node may lag until replay or strict mode catches up |
+| Async regional convergence | Requests don't wait on the regional origin | A neighboring node may lag until replay, stale refresh, or strict mode catches up |
 | Async global convergence | No request waits on cross-region coordination | Multi-region bursts can briefly pass before imported counts arrive |
 | Publish only meaningful regional usage | Cross-region writes stay proportional to useful signal | Low regional usage may remain regional only |
 | Sliding-window evaluation over fixed cells | Smooths boundary bursts without per-request histories | Requires reading the current and previous window cells |
@@ -43,7 +43,7 @@ flowchart TB
 
   subgraph process[One process]
     memory[Local atomic counters]
-    strict[Strict-mode reads]
+    originReads[Origin reads]
   end
 
   subgraph region[One region]
@@ -59,10 +59,10 @@ flowchart TB
   regional --> memory
   memory --> counters
   counters --> memory
-  strict --> regional
+  originReads --> regional
 ```
 
-Local counters keep the hot path fast. The regional origin converges nodes inside one region. Global counters converge regional observations across regions for longer windows.
+Local counters keep the hot path fast. The regional origin converges nodes inside one region through asynchronous replay, stale-entry refreshes, and strict-mode reads after denials. Global counters converge regional observations across regions for longer windows and can also raise same-region local counts as a safety net when a node has not yet seen the latest regional-origin value.
 
 ## Pages
 
@@ -77,6 +77,7 @@ These invariants shape the implementation:
 - The request path must not wait on cross-region state.
 - A local count represents only this region's own observations.
 - Imported global count represents other regions and must not be pushed back out.
+- Own-region global-counter imports may raise local count but must not mark regional origin state fresh.
 - A fixed window cell is grow-only while it is active.
 - Sliding-window behavior comes from weighting the previous cell, not from decrementing the current cell.
 - Batch requests must preserve all-or-nothing semantics.

--- a/docs/engineering/architecture/ratelimiting/request-path.mdx
+++ b/docs/engineering/architecture/ratelimiting/request-path.mdx
@@ -3,7 +3,7 @@ title: "Request path"
 description: "How one rate limit request is evaluated"
 ---
 
-The rate limit request path turns a `(workspace, namespace, identifier, duration)` tuple into a sliding-window decision. The normal path is local-memory first and only reaches regional state when a counter is cold or strict mode is active.
+The rate limit request path turns a `(workspace, namespace, identifier, duration)` tuple into a sliding-window decision. The normal path is local-memory first and reaches regional state when a counter is cold, stale, or in strict mode.
 
 ## Single request flow
 
@@ -13,7 +13,7 @@ Each request builds two counter keys: the current fixed window cell and the prev
 flowchart TD
   start[Ratelimit request] --> validate[Validate request fields]
   validate --> keys[Build current and previous keys]
-  keys --> hydrate[Hydrate cold counters]
+  keys --> hydrate[Hydrate cold or stale counters]
   hydrate --> strict{Strict mode active?}
   strict -->|Yes| fetch[Refresh from regional origin]
   strict -->|No| read[Read local and imported counts]
@@ -77,6 +77,8 @@ This prevents a caller from using the full limit at the end of one fixed window 
 | Regional count | This region's count for the window cell |
 | Speculative count | In-flight `RatelimitMany` increments that may roll back |
 | Hydration state | Cold-start coordination for regional origin reads |
+| Origin freshness | Last regional-origin read or replay time for stale detection |
+| Stale refresh mutex | Single-flight guard for concurrent stale origin reads |
 | Global count | Imported count from other regions |
 | Global push threshold | Minimum regional count worth sharing globally |
 | Last pushed count | Last regional count published for global convergence |

--- a/internal/services/ratelimit/db/global_counters_imported.sql_generated.go
+++ b/internal/services/ratelimit/db/global_counters_imported.sql_generated.go
@@ -16,16 +16,16 @@ SELECT
     identifier,
     duration_ms,
     sequence,
-    CAST(SUM(count) AS SIGNED) AS imported
+    CAST(SUM(CASE WHEN region = ? THEN count ELSE 0 END) AS SIGNED) AS regional,
+    CAST(SUM(CASE WHEN region != ? THEN count ELSE 0 END) AS SIGNED) AS imported
 FROM ratelimit_global_counters
 WHERE expires_at > ?
-  AND region != ?
 GROUP BY workspace_id, namespace, identifier, duration_ms, sequence
 `
 
 type GlobalCountersImportedParams struct {
-	Now        uint64 `db:"now"`
 	SelfRegion string `db:"self_region"`
+	Now        uint64 `db:"now"`
 }
 
 type GlobalCountersImportedRow struct {
@@ -34,16 +34,18 @@ type GlobalCountersImportedRow struct {
 	Identifier  string `db:"identifier"`
 	DurationMs  uint64 `db:"duration_ms"`
 	Sequence    int64  `db:"sequence"`
+	Regional    int64  `db:"regional"`
 	Imported    int64  `db:"imported"`
 }
 
-// GlobalCountersImported returns the sum of foreign-region contributions for
-// every still-active window cell, with each region's row excluded from its
-// own caller. Receivers fold the returned `imported` directly into
-// counterEntry.globalCount via atomicMax; aggregation runs in MySQL because
-// the application only ever uses the sum, so transferring per-region rows
-// just to collapse them in Go wastes bandwidth and memory. The SUM is cast
-// to SIGNED so sqlc maps it to int64, matching atomic.Int64 in the caller.
+// GlobalCountersImported returns the caller's own-region count and the sum of
+// foreign-region contributions for every still-active window cell. Receivers
+// fold the own-region count into counterEntry.val and the foreign-region count
+// into counterEntry.globalCount; keeping them separate prevents own traffic
+// from being double-counted as imported global state. Aggregation runs in MySQL
+// because the application only ever uses these sums, so transferring per-region
+// rows just to collapse them in Go wastes bandwidth and memory. The sums are
+// cast to SIGNED so sqlc maps them to int64, matching atomic.Int64 in the caller.
 //
 //	SELECT
 //	    workspace_id,
@@ -51,13 +53,13 @@ type GlobalCountersImportedRow struct {
 //	    identifier,
 //	    duration_ms,
 //	    sequence,
-//	    CAST(SUM(count) AS SIGNED) AS imported
+//	    CAST(SUM(CASE WHEN region = ? THEN count ELSE 0 END) AS SIGNED) AS regional,
+//	    CAST(SUM(CASE WHEN region != ? THEN count ELSE 0 END) AS SIGNED) AS imported
 //	FROM ratelimit_global_counters
 //	WHERE expires_at > ?
-//	  AND region != ?
 //	GROUP BY workspace_id, namespace, identifier, duration_ms, sequence
 func (q *Queries) GlobalCountersImported(ctx context.Context, arg GlobalCountersImportedParams) ([]GlobalCountersImportedRow, error) {
-	rows, err := q.db.QueryContext(ctx, globalCountersImported, arg.Now, arg.SelfRegion)
+	rows, err := q.db.QueryContext(ctx, globalCountersImported, arg.SelfRegion, arg.SelfRegion, arg.Now)
 	if err != nil {
 		return nil, err
 	}
@@ -71,6 +73,7 @@ func (q *Queries) GlobalCountersImported(ctx context.Context, arg GlobalCounters
 			&i.Identifier,
 			&i.DurationMs,
 			&i.Sequence,
+			&i.Regional,
 			&i.Imported,
 		); err != nil {
 			return nil, err

--- a/internal/services/ratelimit/db/querier_generated.go
+++ b/internal/services/ratelimit/db/querier_generated.go
@@ -17,13 +17,14 @@ type Querier interface {
 	//  DELETE FROM ratelimit_global_counters
 	//  WHERE expires_at < ?
 	GlobalCountersDeleteExpired(ctx context.Context, cutoff uint64) (int64, error)
-	// GlobalCountersImported returns the sum of foreign-region contributions for
-	// every still-active window cell, with each region's row excluded from its
-	// own caller. Receivers fold the returned `imported` directly into
-	// counterEntry.globalCount via atomicMax; aggregation runs in MySQL because
-	// the application only ever uses the sum, so transferring per-region rows
-	// just to collapse them in Go wastes bandwidth and memory. The SUM is cast
-	// to SIGNED so sqlc maps it to int64, matching atomic.Int64 in the caller.
+	// GlobalCountersImported returns the caller's own-region count and the sum of
+	// foreign-region contributions for every still-active window cell. Receivers
+	// fold the own-region count into counterEntry.val and the foreign-region count
+	// into counterEntry.globalCount; keeping them separate prevents own traffic
+	// from being double-counted as imported global state. Aggregation runs in MySQL
+	// because the application only ever uses these sums, so transferring per-region
+	// rows just to collapse them in Go wastes bandwidth and memory. The sums are
+	// cast to SIGNED so sqlc maps them to int64, matching atomic.Int64 in the caller.
 	//
 	//  SELECT
 	//      workspace_id,
@@ -31,10 +32,10 @@ type Querier interface {
 	//      identifier,
 	//      duration_ms,
 	//      sequence,
-	//      CAST(SUM(count) AS SIGNED) AS imported
+	//      CAST(SUM(CASE WHEN region = ? THEN count ELSE 0 END) AS SIGNED) AS regional,
+	//      CAST(SUM(CASE WHEN region != ? THEN count ELSE 0 END) AS SIGNED) AS imported
 	//  FROM ratelimit_global_counters
 	//  WHERE expires_at > ?
-	//    AND region != ?
 	//  GROUP BY workspace_id, namespace, identifier, duration_ms, sequence
 	GlobalCountersImported(ctx context.Context, arg GlobalCountersImportedParams) ([]GlobalCountersImportedRow, error)
 	// GlobalCountersListAll returns raw per-region global counter rows for tests

--- a/internal/services/ratelimit/db/queries/global_counters_imported.sql
+++ b/internal/services/ratelimit/db/queries/global_counters_imported.sql
@@ -1,19 +1,20 @@
 -- name: GlobalCountersImported :many
--- GlobalCountersImported returns the sum of foreign-region contributions for
--- every still-active window cell, with each region's row excluded from its
--- own caller. Receivers fold the returned `imported` directly into
--- counterEntry.globalCount via atomicMax; aggregation runs in MySQL because
--- the application only ever uses the sum, so transferring per-region rows
--- just to collapse them in Go wastes bandwidth and memory. The SUM is cast
--- to SIGNED so sqlc maps it to int64, matching atomic.Int64 in the caller.
+-- GlobalCountersImported returns the caller's own-region count and the sum of
+-- foreign-region contributions for every still-active window cell. Receivers
+-- fold the own-region count into counterEntry.val and the foreign-region count
+-- into counterEntry.globalCount; keeping them separate prevents own traffic
+-- from being double-counted as imported global state. Aggregation runs in MySQL
+-- because the application only ever uses these sums, so transferring per-region
+-- rows just to collapse them in Go wastes bandwidth and memory. The sums are
+-- cast to SIGNED so sqlc maps them to int64, matching atomic.Int64 in the caller.
 SELECT
     workspace_id,
     namespace,
     identifier,
     duration_ms,
     sequence,
-    CAST(SUM(count) AS SIGNED) AS imported
+    CAST(SUM(CASE WHEN region = sqlc.arg("self_region") THEN count ELSE 0 END) AS SIGNED) AS regional,
+    CAST(SUM(CASE WHEN region != sqlc.arg("self_region") THEN count ELSE 0 END) AS SIGNED) AS imported
 FROM ratelimit_global_counters
 WHERE expires_at > sqlc.arg("now")
-  AND region != sqlc.arg("self_region")
 GROUP BY workspace_id, namespace, identifier, duration_ms, sequence;

--- a/internal/services/ratelimit/global.go
+++ b/internal/services/ratelimit/global.go
@@ -15,14 +15,14 @@ import (
 // the counters map and emits eligible rows to the cross-region
 // ratelimit_global_counters table. Lower values tighten cross-region
 // propagation latency at the cost of more writes.
-const globalPushInterval = 10 * time.Second
+const globalPushInterval = 5 * time.Second
 
-// globalPullInterval is how often each region pulls the active set of
-// other regions' counts from ratelimit_global_counters and merges them into
-// local globalCount state. Lower values tighten cross-region propagation
-// latency at the cost of more reads; higher values let local state lag
-// the global picture during bursts.
-const globalPullInterval = 10 * time.Second
+// globalPullInterval is how often each region pulls the active set of counts
+// from ratelimit_global_counters. Own-region rows merge into val as an
+// intra-region safety net; foreign-region rows merge into globalCount for
+// cross-region decisions. Lower values tighten propagation latency at the cost
+// of more reads; higher values let local state lag during bursts.
+const globalPullInterval = 5 * time.Second
 
 // globalUtilizationFloor is the fraction of the per-row limit that an
 // entry's local count must reach before its state is shared with other
@@ -31,7 +31,7 @@ const globalPullInterval = 10 * time.Second
 // it to the cross-region table is wasted MySQL load. Trading coverage
 // against write rate is a global property of the system, not a
 // per-instance tuning knob, so this stays a package constant.
-const globalUtilizationFloor = 0.5
+const globalUtilizationFloor = 0.2
 
 // globalJitter spreads cross-region push and pull ticks across the
 // fleet to avoid every instance hammering MySQL on the same wall-clock
@@ -166,23 +166,24 @@ func (s *service) runGlobalPushOnce() {
 	}
 }
 
-// startGlobalPull schedules runGlobalPullOnce on the package
-// sync cadence. Each tick pulls the per-key sum of other regions'
-// contributions and merges them into local counterEntry.globalCount
-// via atomicMax. Jitter desynchronizes reads across the fleet so the
-// database is not hit by every region's sync at the same instant.
+// startGlobalPull schedules runGlobalPullOnce on the package sync cadence. Each
+// tick pulls per-key sums from ratelimit_global_counters. Own-region rows merge
+// into counterEntry.val; foreign-region rows merge into counterEntry.globalCount.
+// Jitter desynchronizes reads across the fleet so the database is not hit by
+// every region's sync at the same instant.
 func (s *service) startGlobalPull() {
 	stop := repeat.Every(globalPullInterval, s.runGlobalPullOnce, globalJitter)
 	s.stopBackground = append(s.stopBackground, stop)
 }
 
-// runGlobalPullOnce fetches the per-key sum of every other region's
-// contribution and writes each into the matching
-// counterEntry.globalCount. Aggregation runs in MySQL via
-// GROUP BY + SUM, so this loop is one atomicMax per active window cell
-// rather than one per (region, cell) pair. Sums are monotonic per cell
-// (each region's contribution only grows within a sequence), so
-// atomicMax is sufficient and idempotent across overlapping ticks.
+// runGlobalPullOnce fetches the per-key own-region count and foreign-region sum.
+// Own-region count is an opportunistic intra-region safety net and merges into
+// val. Foreign-region count merges into globalCount and must stay separate from
+// val so it does not feed back into this region's next push. Aggregation runs in
+// MySQL via GROUP BY + SUM, so this loop is one pair of atomicMax operations per
+// active window cell rather than one per (region, cell) pair. Sums are
+// monotonic per cell (each region's contribution only grows within a sequence),
+// so atomicMax is sufficient and idempotent across overlapping ticks.
 //
 // When no local entry exists for a key seen in the result set, one is
 // created on demand via findOrCreateCounter. These entries are attributed
@@ -215,6 +216,7 @@ func (s *service) runGlobalPullOnce() {
 			sequence:    r.Sequence,
 		}
 		entry, created := s.findOrCreateCounter(key)
+		atomicMax(&entry.val, r.Regional)
 		atomicMax(&entry.globalCount, r.Imported)
 		if created {
 			metrics.RatelimitGlobalEntriesCreated.Inc()

--- a/internal/services/ratelimit/global_integration_test.go
+++ b/internal/services/ratelimit/global_integration_test.go
@@ -339,16 +339,13 @@ func TestGlobal_PushUsesConvergedLocalCount(t *testing.T) {
 	// Each instance accepts 1/10 locally, below the 0.2 utilization floor
 	// (threshold=2). Their shared Redis origin converges the region total to 2/10,
 	// which crosses the floor and triggers the push.
-	for range 1 {
-		resp, reqErr := regionA1.Ratelimit(ctx, makeReq())
-		require.NoError(t, reqErr)
-		require.True(t, resp.Success)
-	}
-	for range 1 {
-		resp, reqErr := regionA2.Ratelimit(ctx, makeReq())
-		require.NoError(t, reqErr)
-		require.True(t, resp.Success)
-	}
+	resp, reqErr := regionA1.Ratelimit(ctx, makeReq())
+	require.NoError(t, reqErr)
+	require.True(t, resp.Success)
+
+	resp, reqErr = regionA2.Ratelimit(ctx, makeReq())
+	require.NoError(t, reqErr)
+	require.True(t, resp.Success)
 
 	curKey := counterKey{
 		workspaceID: workspaceID,

--- a/internal/services/ratelimit/global_integration_test.go
+++ b/internal/services/ratelimit/global_integration_test.go
@@ -97,7 +97,7 @@ func TestGlobal_PropagatesCountAcrossRegions(t *testing.T) {
 		}
 	}
 
-	// Region A consumes 6 of 10 — past the 0.5 utilization floor so flush
+	// Region A consumes 6 of 10 — past the 0.2 utilization floor so flush
 	// is eligible. None of these denies; A is well within its limit on its
 	// own, but its consumption is now relevant to other regions.
 	for range 6 {
@@ -106,7 +106,7 @@ func TestGlobal_PropagatesCountAcrossRegions(t *testing.T) {
 		require.True(t, resp.Success)
 	}
 
-	// Trigger flush deterministically rather than waiting for the 10s
+	// Trigger flush deterministically rather than waiting for the 5s
 	// jittered ticker. The bulk upsert inside runGlobalPushOnce is
 	// synchronous, so by the time it returns the row is in MySQL.
 	regionA.runGlobalPushOnce()
@@ -268,15 +268,13 @@ func TestGlobal_BelowUtilizationFloorDoesNotPush(t *testing.T) {
 	duration := time.Minute
 	ctx := context.Background()
 
-	// Consume 4 of 10 — strictly below the default 0.5 floor.
-	for range 4 {
-		resp, err := region.Ratelimit(ctx, RatelimitRequest{
-			WorkspaceID: workspaceID, Namespace: namespace, Identifier: identifier,
-			Limit: limit, Duration: duration, Cost: 1, Time: clk.Now(),
-		})
-		require.NoError(t, err)
-		require.True(t, resp.Success)
-	}
+	// Consume 1 of 10 — strictly below the 0.2 floor (threshold=2).
+	resp, err := region.Ratelimit(ctx, RatelimitRequest{
+		WorkspaceID: workspaceID, Namespace: namespace, Identifier: identifier,
+		Limit: limit, Duration: duration, Cost: 1, Time: clk.Now(),
+	})
+	require.NoError(t, err)
+	require.True(t, resp.Success)
 
 	region.runGlobalPushOnce()
 
@@ -338,14 +336,15 @@ func TestGlobal_PushUsesConvergedLocalCount(t *testing.T) {
 		}
 	}
 
-	// Each instance accepts 4/10 locally, below the 0.5 utilization floor.
-	// Their shared Redis origin converges the region total to 8/10.
-	for range 4 {
+	// Each instance accepts 1/10 locally, below the 0.2 utilization floor
+	// (threshold=2). Their shared Redis origin converges the region total to 2/10,
+	// which crosses the floor and triggers the push.
+	for range 1 {
 		resp, reqErr := regionA1.Ratelimit(ctx, makeReq())
 		require.NoError(t, reqErr)
 		require.True(t, resp.Success)
 	}
-	for range 4 {
+	for range 1 {
 		resp, reqErr := regionA2.Ratelimit(ctx, makeReq())
 		require.NoError(t, reqErr)
 		require.True(t, resp.Success)
@@ -361,7 +360,7 @@ func TestGlobal_PushUsesConvergedLocalCount(t *testing.T) {
 	require.Eventually(t, func() bool {
 		for _, region := range []*service{regionA1, regionA2} {
 			entry, ok := region.counters.Load(curKey)
-			if ok && entry.(*counterEntry).val.Load() >= 8 {
+			if ok && entry.(*counterEntry).val.Load() >= 2 {
 				return true
 			}
 		}
@@ -372,7 +371,7 @@ func TestGlobal_PushUsesConvergedLocalCount(t *testing.T) {
 	regionA2.runGlobalPushOnce()
 
 	row := env.waitForRow(workspaceID, namespace, identifier, "region-a", duration.Milliseconds())
-	require.Equal(t, uint64(8), row.Count, "push must use the converged local count")
+	require.Equal(t, uint64(2), row.Count, "push must use the converged local count")
 }
 
 // TestGlobal_PushIgnoresSpeculativeBatchIncrements covers the small window in
@@ -452,8 +451,8 @@ func TestGlobal_AtFloorPushes(t *testing.T) {
 	duration := time.Minute
 	ctx := context.Background()
 
-	// Consume exactly 5 of 10 — at the 0.5 floor.
-	for range 5 {
+	// Consume exactly 2 of 10 — at the 0.2 floor (threshold=2).
+	for range 2 {
 		resp, err := region.Ratelimit(ctx, RatelimitRequest{
 			WorkspaceID: workspaceID, Namespace: namespace, Identifier: identifier,
 			Limit: limit, Duration: duration, Cost: 1, Time: clk.Now(),
@@ -465,14 +464,14 @@ func TestGlobal_AtFloorPushes(t *testing.T) {
 	region.runGlobalPushOnce()
 
 	row := env.waitForRow(workspaceID, namespace, identifier, "region-a", duration.Milliseconds())
-	require.Equal(t, uint64(5), row.Count, "row count must reflect the at-floor utilization")
+	require.Equal(t, uint64(2), row.Count, "row count must reflect the at-floor utilization")
 }
 
-// TestGlobal_SyncExcludesOwnRegion asserts that a region's sync skips
-// rows it wrote itself. Without the region != self predicate, a region would
-// fold its own contribution back into its globalCount field, double-counting on
-// every request and over-blocking by a factor proportional to sync frequency.
-func TestGlobal_SyncExcludesOwnRegion(t *testing.T) {
+// TestGlobal_SyncKeepsOwnRegionOutOfGlobalCount asserts that a region's own
+// MySQL row merges into regional val, not globalCount. Folding own traffic into
+// globalCount would double-count it because sliding-window math already adds
+// val and globalCount together.
+func TestGlobal_SyncKeepsOwnRegionOutOfGlobalCount(t *testing.T) {
 	t.Parallel()
 
 	env := newIntegrationTestEnv(t)
@@ -500,8 +499,8 @@ func TestGlobal_SyncExcludesOwnRegion(t *testing.T) {
 	region.runGlobalPushOnce()
 	env.waitForRow(workspaceID, namespace, identifier, "region-a", duration.Milliseconds())
 
-	// Sync from this same region — should NOT pull its own row, so globalCount
-	// must stay at zero.
+	// Sync from this same region. Own-region count may raise val as a safety net,
+	// but globalCount must stay foreign-only.
 	region.runGlobalPullOnce()
 
 	curKey := counterKey{
@@ -511,8 +510,78 @@ func TestGlobal_SyncExcludesOwnRegion(t *testing.T) {
 	}
 	entry, ok := region.counters.Load(curKey)
 	require.True(t, ok)
-	require.Equal(t, int64(0), entry.(*counterEntry).globalCount.Load(),
-		"sync must not import the region's own contribution")
+	counter := entry.(*counterEntry)
+	require.Equal(t, int64(6), counter.val.Load(),
+		"sync should merge own-region contribution into regional val")
+	require.Equal(t, int64(0), counter.globalCount.Load(),
+		"sync must not import the region's own contribution into globalCount")
+}
+
+// TestGlobal_OwnRegionImportIsRegionalSafetyNet models two instances tagged as
+// the same region that have not converged through Redis. If one has pushed a
+// higher regional observation to MySQL, the other may use that row as a
+// monotonic lower bound for its own regional val. This is only a safety net:
+// it must not mark the entry fresh against the regional origin.
+func TestGlobal_OwnRegionImportIsRegionalSafetyNet(t *testing.T) {
+	t.Parallel()
+
+	env := newIntegrationTestEnv(t)
+	clk := clock.NewTestClock()
+	regionA1 := env.newRegionAs(clk, "region-a")
+	regionA2 := env.newRegionAs(clk, "region-a")
+
+	const (
+		workspaceID = "ws_test"
+		namespace   = "ns"
+		identifier  = "user-own-region-import"
+		limit       = int64(10)
+	)
+	duration := time.Minute
+	ctx := context.Background()
+
+	makeReq := func() RatelimitRequest {
+		return RatelimitRequest{
+			WorkspaceID: workspaceID,
+			Namespace:   namespace,
+			Identifier:  identifier,
+			Limit:       limit,
+			Duration:    duration,
+			Cost:        1,
+			Time:        clk.Now(),
+		}
+	}
+
+	for range 6 {
+		resp, err := regionA1.Ratelimit(ctx, makeReq())
+		require.NoError(t, err)
+		require.True(t, resp.Success)
+	}
+	regionA1.runGlobalPushOnce()
+	env.waitForRow(workspaceID, namespace, identifier, "region-a", duration.Milliseconds())
+
+	regionA2.runGlobalPullOnce()
+
+	curKey := counterKey{
+		workspaceID: workspaceID,
+		namespace:   namespace,
+		identifier:  identifier,
+		durationMs:  duration.Milliseconds(),
+		sequence:    calculateSequence(clk.Now(), duration),
+	}
+	entry, ok := regionA2.counters.Load(curKey)
+	require.True(t, ok, "own-region import should create the local entry")
+	counter := entry.(*counterEntry)
+	require.Equal(t, int64(6), counter.val.Load())
+	require.Equal(t, int64(0), counter.globalCount.Load())
+	require.Equal(t, int64(0), counter.originFreshUntilMs.Load(),
+		"MySQL safety-net import must not mark regional origin freshness")
+
+	denyReq := makeReq()
+	denyReq.Cost = 5
+	resp, err := regionA2.Ratelimit(ctx, denyReq)
+	require.NoError(t, err)
+	require.False(t, resp.Success,
+		"own-region import should participate in local sliding-window decisions")
 }
 
 // TestGlobal_SumsAcrossMultipleRegions asserts that a third region
@@ -544,7 +613,7 @@ func TestGlobal_SumsAcrossMultipleRegions(t *testing.T) {
 		}
 	}
 
-	// A consumes 12 (above floor=10), B consumes 11 (above floor=10).
+	// A consumes 12 (above floor=4), B consumes 11 (above floor=4).
 	// Total true global at this point is 23.
 	for range 12 {
 		_, err := regionA.Ratelimit(ctx, makeReq())

--- a/internal/services/ratelimit/origin.go
+++ b/internal/services/ratelimit/origin.go
@@ -130,6 +130,7 @@ func (s *service) syncWithOrigin(ctx context.Context, req RatelimitRequest) erro
 	// CAS-merge: update local counter if Redis value is higher.
 	counter := s.loadCounter(key)
 	atomicMax(&counter.val, newCounter)
+	atomicMax(&counter.originFreshUntilMs, s.clock.Now().Add(originFreshDuration).UnixMilli())
 
 	return nil
 }

--- a/internal/services/ratelimit/origin.go
+++ b/internal/services/ratelimit/origin.go
@@ -33,14 +33,12 @@ func errorReason(err error) string {
 // caller will retry.
 const originFetchTimeout = 150 * time.Millisecond
 
-// fetchFromOrigin returns the current counter value from the origin. The
-// call is wrapped in the origin circuit breaker so that Redis outages fail
-// fast instead of stalling every request in strict mode. On any failure
-// (circuit tripped, timeout, or Redis error) it returns 0 — callers feed
-// this into atomicMax, which is a no-op against any existing positive
-// counter, so failed fetches preserve whatever local state is already
-// there.
-func (s *service) fetchFromOrigin(ctx context.Context, key counterKey, op string) int64 {
+// fetchFromOrigin returns the current counter value from the origin. The call is
+// wrapped in the origin circuit breaker so that Redis outages fail fast instead
+// of stalling every request in strict mode. On any failure (circuit tripped,
+// timeout, or Redis error) it returns ok=false so callers can preserve local
+// state without marking it fresh.
+func (s *service) fetchFromOrigin(ctx context.Context, key counterKey, op string) (count int64, ok bool) {
 	rk := key.redisKey()
 	metrics.RatelimitOriginOperations.WithLabelValues(op).Inc()
 
@@ -60,9 +58,9 @@ func (s *service) fetchFromOrigin(ctx context.Context, key counterKey, op string
 			"key", rk,
 			"error", err.Error(),
 		)
-		return 0
+		return 0, false
 	}
-	return res
+	return res, true
 }
 
 // replayRequests processes buffered rate limit events by synchronizing them

--- a/internal/services/ratelimit/origin_test.go
+++ b/internal/services/ratelimit/origin_test.go
@@ -94,7 +94,7 @@ func TestFetchFromOrigin_CircuitBreakerShortCircuitsAfterTrip(t *testing.T) {
 		additionalCalls, maxTolerated)
 }
 
-func TestCounterEntryEnsureFreshFromOrigin_RefreshesWarmEntryAfterMaxAge(t *testing.T) {
+func TestCounterEntryEnsureFreshFromOrigin_RefreshesWarmEntryAfterFreshUntil(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -112,12 +112,13 @@ func TestCounterEntryEnsureFreshFromOrigin_RefreshesWarmEntryAfterMaxAge(t *test
 	require.Equal(t, int64(1), fetchCalls.Load(), "cold entry should fetch once")
 	require.Equal(t, int64(10), entry.val.Load())
 
-	entry.EnsureFreshFromOrigin(ctx, start.Add(originFetchAgeMax-time.Millisecond))
-	require.Equal(t, int64(1), fetchCalls.Load(), "warm entry should not refresh before max age")
+	freshUntil := start.Add(originFreshDuration)
+	entry.EnsureFreshFromOrigin(ctx, freshUntil.Add(-time.Millisecond))
+	require.Equal(t, int64(1), fetchCalls.Load(), "warm entry should not refresh before freshUntil")
 	require.Equal(t, int64(10), entry.val.Load())
 
-	entry.EnsureFreshFromOrigin(ctx, start.Add(originFetchAgeMax))
-	require.Equal(t, int64(2), fetchCalls.Load(), "warm entry should refresh at max age")
+	entry.EnsureFreshFromOrigin(ctx, freshUntil)
+	require.Equal(t, int64(2), fetchCalls.Load(), "warm entry should refresh at freshUntil")
 	require.Equal(t, int64(20), entry.val.Load())
 	require.Equal(t, []string{"fetch_cold", "fetch_stale"}, fetchOps)
 }
@@ -140,7 +141,7 @@ func TestCounterEntryEnsureFreshFromOrigin_GatesConcurrentWarmRefresh(t *testing
 		},
 	}
 	entry.hydrated.Store(true)
-	entry.originFetchLastMs.Store(start.UnixMilli())
+	entry.originFreshUntilMs.Store(start.Add(originFreshDuration).UnixMilli())
 
 	const goroutines = 32
 	ready := make(chan struct{})
@@ -150,7 +151,7 @@ func TestCounterEntryEnsureFreshFromOrigin_GatesConcurrentWarmRefresh(t *testing
 		go func() {
 			defer wg.Done()
 			<-ready
-			entry.EnsureFreshFromOrigin(ctx, start.Add(originFetchAgeMax))
+			entry.EnsureFreshFromOrigin(ctx, start.Add(originFreshDuration))
 		}()
 	}
 
@@ -163,7 +164,7 @@ func TestCounterEntryEnsureFreshFromOrigin_GatesConcurrentWarmRefresh(t *testing
 	require.Equal(t, int64(10), entry.val.Load())
 }
 
-func TestCounterEntryEnsureFreshFromOrigin_FailedWarmRefreshSuppressesRetryUntilMaxAge(t *testing.T) {
+func TestCounterEntryEnsureFreshFromOrigin_FailedWarmRefreshSuppressesRetryUntilFreshUntil(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -179,19 +180,19 @@ func TestCounterEntryEnsureFreshFromOrigin_FailedWarmRefreshSuppressesRetryUntil
 	}
 	entry.val.Store(7)
 	entry.hydrated.Store(true)
-	entry.originFetchLastMs.Store(start.UnixMilli())
+	entry.originFreshUntilMs.Store(start.Add(originFreshDuration).UnixMilli())
 
-	failedRefresh := start.Add(originFetchAgeMax)
+	failedRefresh := start.Add(originFreshDuration)
 	entry.EnsureFreshFromOrigin(ctx, failedRefresh)
 	require.Equal(t, int64(1), fetchCalls.Load())
 	require.Equal(t, int64(7), entry.val.Load(), "failed fetch returns 0 and should preserve local state")
-	require.Equal(t, failedRefresh.UnixMilli(), entry.originFetchLastMs.Load(), "failed refresh still advances retry gate")
+	require.Equal(t, failedRefresh.Add(originFreshDuration).UnixMilli(), entry.originFreshUntilMs.Load(), "failed refresh still advances freshUntil")
 
 	entry.EnsureFreshFromOrigin(ctx, failedRefresh.Add(time.Second))
-	require.Equal(t, int64(1), fetchCalls.Load(), "failed refresh should not retry before max age")
+	require.Equal(t, int64(1), fetchCalls.Load(), "failed refresh should not retry before freshUntil")
 	require.Equal(t, int64(7), entry.val.Load())
 
-	entry.EnsureFreshFromOrigin(ctx, failedRefresh.Add(originFetchAgeMax))
-	require.Equal(t, int64(2), fetchCalls.Load(), "failed refresh should retry after max age")
+	entry.EnsureFreshFromOrigin(ctx, failedRefresh.Add(originFreshDuration))
+	require.Equal(t, int64(2), fetchCalls.Load(), "failed refresh should retry at freshUntil")
 	require.Equal(t, int64(99), entry.val.Load())
 }

--- a/internal/services/ratelimit/origin_test.go
+++ b/internal/services/ratelimit/origin_test.go
@@ -102,9 +102,9 @@ func TestCounterEntryEnsureFreshFromOrigin_RefreshesWarmEntryAfterFreshUntil(t *
 	fetchOps := []string{}
 	var fetchCalls atomic.Int64
 	entry := counterEntry{
-		fetch: func(_ context.Context, op string) int64 {
+		fetch: func(_ context.Context, op string) (int64, bool) {
 			fetchOps = append(fetchOps, op)
-			return fetchCalls.Add(1) * 10
+			return fetchCalls.Add(1) * 10, true
 		},
 	}
 
@@ -133,11 +133,11 @@ func TestCounterEntryEnsureFreshFromOrigin_GatesConcurrentWarmRefresh(t *testing
 	var closeFetchStarted sync.Once
 	var fetchCalls atomic.Int64
 	entry := counterEntry{
-		fetch: func(context.Context, string) int64 {
+		fetch: func(context.Context, string) (int64, bool) {
 			fetchCalls.Add(1)
 			closeFetchStarted.Do(func() { close(fetchStarted) })
 			<-releaseFetch
-			return 10
+			return 10, true
 		},
 	}
 	entry.hydrated.Store(true)
@@ -164,18 +164,50 @@ func TestCounterEntryEnsureFreshFromOrigin_GatesConcurrentWarmRefresh(t *testing
 	require.Equal(t, int64(10), entry.val.Load())
 }
 
-func TestCounterEntryEnsureFreshFromOrigin_FailedWarmRefreshSuppressesRetryUntilFreshUntil(t *testing.T) {
+func TestCounterEntryEnsureFreshFromOrigin_FailedColdRefreshRetriesBeforeFreshDuration(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
 	start := time.Now().UTC().Truncate(time.Millisecond)
 	var fetchCalls atomic.Int64
 	entry := counterEntry{
-		fetch: func(context.Context, string) int64 {
+		fetch: func(context.Context, string) (int64, bool) {
 			if fetchCalls.Add(1) == 1 {
-				return 0
+				return 0, false
 			}
-			return 99
+			return 99, true
+		},
+	}
+
+	entry.EnsureFreshFromOrigin(ctx, start)
+	require.Equal(t, int64(1), fetchCalls.Load())
+	require.Equal(t, int64(0), entry.val.Load(), "failed cold fetch should preserve zero local state")
+	require.Equal(t, start.Add(originFetchRetryDuration).UnixMilli(), entry.originFreshUntilMs.Load())
+
+	entry.EnsureFreshFromOrigin(ctx, start.Add(originFetchRetryDuration-time.Millisecond))
+	require.Equal(t, int64(1), fetchCalls.Load(), "failed cold fetch should suppress immediate retry")
+
+	entry.EnsureFreshFromOrigin(ctx, start.Add(originFetchRetryDuration))
+	require.Equal(t, int64(2), fetchCalls.Load(), "failed cold fetch should retry before full fresh duration")
+	require.Equal(t, int64(99), entry.val.Load())
+	require.Equal(t,
+		start.Add(originFetchRetryDuration).Add(originFreshDuration).UnixMilli(),
+		entry.originFreshUntilMs.Load(),
+	)
+}
+
+func TestCounterEntryEnsureFreshFromOrigin_FailedWarmRefreshRetriesBeforeFreshDuration(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	start := time.Now().UTC().Truncate(time.Millisecond)
+	var fetchCalls atomic.Int64
+	entry := counterEntry{
+		fetch: func(context.Context, string) (int64, bool) {
+			if fetchCalls.Add(1) == 1 {
+				return 0, false
+			}
+			return 99, true
 		},
 	}
 	entry.val.Store(7)
@@ -185,14 +217,18 @@ func TestCounterEntryEnsureFreshFromOrigin_FailedWarmRefreshSuppressesRetryUntil
 	failedRefresh := start.Add(originFreshDuration)
 	entry.EnsureFreshFromOrigin(ctx, failedRefresh)
 	require.Equal(t, int64(1), fetchCalls.Load())
-	require.Equal(t, int64(7), entry.val.Load(), "failed fetch returns 0 and should preserve local state")
-	require.Equal(t, failedRefresh.Add(originFreshDuration).UnixMilli(), entry.originFreshUntilMs.Load(), "failed refresh still advances freshUntil")
+	require.Equal(t, int64(7), entry.val.Load(), "failed fetch should preserve local state")
+	require.Equal(t,
+		failedRefresh.Add(originFetchRetryDuration).UnixMilli(),
+		entry.originFreshUntilMs.Load(),
+		"failed refresh should only advance retry deadline",
+	)
 
-	entry.EnsureFreshFromOrigin(ctx, failedRefresh.Add(time.Second))
-	require.Equal(t, int64(1), fetchCalls.Load(), "failed refresh should not retry before freshUntil")
+	entry.EnsureFreshFromOrigin(ctx, failedRefresh.Add(originFetchRetryDuration-time.Millisecond))
+	require.Equal(t, int64(1), fetchCalls.Load(), "failed refresh should not retry before retry deadline")
 	require.Equal(t, int64(7), entry.val.Load())
 
-	entry.EnsureFreshFromOrigin(ctx, failedRefresh.Add(originFreshDuration))
-	require.Equal(t, int64(2), fetchCalls.Load(), "failed refresh should retry at freshUntil")
+	entry.EnsureFreshFromOrigin(ctx, failedRefresh.Add(originFetchRetryDuration))
+	require.Equal(t, int64(2), fetchCalls.Load(), "failed refresh should retry before full fresh duration")
 	require.Equal(t, int64(99), entry.val.Load())
 }

--- a/internal/services/ratelimit/ratelimit.go
+++ b/internal/services/ratelimit/ratelimit.go
@@ -61,9 +61,11 @@ func (s *service) prepareCheck(ctx context.Context, req RatelimitRequest) checkS
 	// previous window cannot receive new local decisions anymore, so its normal
 	// cold/stale refresh is enough.
 	if req.Time.UnixMilli() < s.loadStrictUntil(sk) {
-		countOriginCurrent := s.fetchFromOrigin(ctx, curKey, "fetch_strict")
-		atomicMax(&cur.val, countOriginCurrent)
-		atomicMax(&cur.originFreshUntilMs, req.Time.Add(originFreshDuration).UnixMilli())
+		countOriginCurrent, ok := s.fetchFromOrigin(ctx, curKey, "fetch_strict")
+		if ok {
+			atomicMax(&cur.val, countOriginCurrent)
+			atomicMax(&cur.originFreshUntilMs, req.Time.Add(originFreshDuration).UnixMilli())
+		}
 	}
 
 	windowStartMs := curSeq * durationMs

--- a/internal/services/ratelimit/ratelimit.go
+++ b/internal/services/ratelimit/ratelimit.go
@@ -24,7 +24,7 @@ type checkState struct {
 	// counterEntry.globalCount taken at prepareCheck time so the
 	// CAS retry loop in Ratelimit does not re-load them on every retry.
 	// Cross-region counts only mutate from the cross-region pull
-	// goroutine on a 10s cadence, so they are effectively constant for
+	// goroutine on a 5s cadence, so they are effectively constant for
 	// the lifetime of any single request; snapshotting matches that
 	// lifetime and saves two atomic loads per CAS attempt.
 	curGlobal  int64
@@ -57,18 +57,13 @@ func (s *service) prepareCheck(ctx context.Context, req RatelimitRequest) checkS
 	cur.EnsureFreshFromOrigin(ctx, req.Time)
 	prev.EnsureFreshFromOrigin(ctx, req.Time)
 
-	// Strict mode: a recent denial in this region forces an additional
-	// synchronous origin fetch until the deadline passes. This is the
-	// in-region convergence aid — instances within a region share state
-	// through Redis, so the forced fetch drains any lag between this
-	// instance's local view and the region's Redis-backed truth.
-	// Cross-region convergence is handled separately via
-	// cur.globalCount.
+	// Strict mode always refreshes the current window before deciding. The
+	// previous window cannot receive new local decisions anymore, so its normal
+	// cold/stale refresh is enough.
 	if req.Time.UnixMilli() < s.loadStrictUntil(sk) {
 		countOriginCurrent := s.fetchFromOrigin(ctx, curKey, "fetch_strict")
-		countOriginPrevious := s.fetchFromOrigin(ctx, prevKey, "fetch_strict")
 		atomicMax(&cur.val, countOriginCurrent)
-		atomicMax(&prev.val, countOriginPrevious)
+		atomicMax(&cur.originFreshUntilMs, req.Time.Add(originFreshDuration).UnixMilli())
 	}
 
 	windowStartMs := curSeq * durationMs

--- a/internal/services/ratelimit/ratelimit_test.go
+++ b/internal/services/ratelimit/ratelimit_test.go
@@ -2,6 +2,9 @@ package ratelimit
 
 import (
 	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -46,7 +49,8 @@ func TestRatelimit_SlidingWindowDecision(t *testing.T) {
 
 			clk := clock.NewTestClock()
 			svc, err := New(Config{
-				Clock: clk, Counter: counter.NewMemory(), DB: newTestDB(t), Region: "test-region"})
+				Clock: clk, Counter: counter.NewMemory(), DB: newTestDB(t), Region: "test-region",
+			})
 			require.NoError(t, err)
 			t.Cleanup(func() { _ = svc.Close() })
 
@@ -94,7 +98,8 @@ func TestRatelimit_DenialSetsStrictUntil(t *testing.T) {
 
 	clk := clock.NewTestClock()
 	svc, err := New(Config{
-		Clock: clk, Counter: counter.NewMemory(), DB: newTestDB(t), Region: "test-region"})
+		Clock: clk, Counter: counter.NewMemory(), DB: newTestDB(t), Region: "test-region",
+	})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = svc.Close() })
 
@@ -123,17 +128,18 @@ func TestRatelimit_DenialSetsStrictUntil(t *testing.T) {
 	require.Equal(t, want, got, "strictUntil should equal req.Time + req.Duration")
 }
 
-// TestRatelimit_StrictModeForcesOriginFetch asserts that once strict mode
-// is active, prepareCheck fetches from origin even when the local windows
-// are warm. We verify by observing local state converge to a seeded origin
-// value — the only way that can happen is if origin was consulted.
+// TestRatelimit_StrictModeForcesOriginFetch asserts that once strict mode is
+// active, every request fetches the current window from origin before deciding.
+// We verify by observing local state converge to a seeded origin value — the
+// only way that can happen is if origin was consulted.
 func TestRatelimit_StrictModeForcesOriginFetch(t *testing.T) {
 	t.Parallel()
 
 	clk := clock.NewTestClock()
 	origin := counter.NewMemory()
 	svc, err := New(Config{
-		Clock: clk, Counter: origin, DB: newTestDB(t), Region: "test-region"})
+		Clock: clk, Counter: origin, DB: newTestDB(t), Region: "test-region",
+	})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = svc.Close() })
 
@@ -177,7 +183,54 @@ func TestRatelimit_StrictModeForcesOriginFetch(t *testing.T) {
 	require.NoError(t, err)
 
 	require.GreaterOrEqual(t, cur.val.Load(), originValue, "current window should have picked up origin value")
-	require.GreaterOrEqual(t, prev.val.Load(), originValue, "previous window should have picked up origin value")
+	require.Equal(t, int64(0), prev.val.Load(), "strict mode should not refetch the previous window")
+}
+
+func TestRatelimit_ReplayMarksEntryFresh(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	clk := clock.NewTestClock()
+	origin := counter.NewMemory()
+	svc, err := New(Config{
+		Clock: clk, Counter: origin, DB: newTestDB(t), Region: "test-region",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = svc.Close() })
+
+	ws := uid.New(uid.WorkspacePrefix)
+	duration := time.Minute
+	durationMs := duration.Milliseconds()
+	reqTime := clk.Now()
+	curSeq := calculateSequence(reqTime, duration)
+	curKey := counterKey{workspaceID: ws, namespace: "ns", identifier: "id", durationMs: durationMs, sequence: curSeq}
+
+	req := RatelimitRequest{
+		WorkspaceID: ws,
+		Namespace:   "ns",
+		Identifier:  "id",
+		Limit:       10,
+		Duration:    duration,
+		Cost:        1,
+		Time:        reqTime,
+	}
+
+	resp, err := svc.Ratelimit(ctx, req)
+	require.NoError(t, err)
+	require.True(t, resp.Success)
+
+	clk.Tick(time.Second)
+	req.Time = clk.Now()
+	resp, err = svc.Ratelimit(ctx, req)
+	require.NoError(t, err)
+	require.True(t, resp.Success)
+
+	entryValue, ok := svc.counters.Load(curKey)
+	require.True(t, ok)
+	entry := entryValue.(*counterEntry)
+	require.Eventually(t, func() bool {
+		return entry.originFreshUntilMs.Load() >= req.Time.Add(originFreshDuration).UnixMilli()
+	}, 3*time.Second, 50*time.Millisecond, "successful replay should keep origin freshness current")
 }
 
 // TestRatelimitMany_RollsBackOnPartialFailure asserts that when any entry in
@@ -188,7 +241,8 @@ func TestRatelimitMany_RollsBackOnPartialFailure(t *testing.T) {
 
 	clk := clock.NewTestClock()
 	svc, err := New(Config{
-		Clock: clk, Counter: counter.NewMemory(), DB: newTestDB(t), Region: "test-region"})
+		Clock: clk, Counter: counter.NewMemory(), DB: newTestDB(t), Region: "test-region",
+	})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = svc.Close() })
 
@@ -232,7 +286,8 @@ func TestRatelimitMany_DoesNotMutateRequests(t *testing.T) {
 
 	clk := clock.NewTestClock()
 	svc, err := New(Config{
-		Clock: clk, Counter: counter.NewMemory(), DB: newTestDB(t), Region: "test-region"})
+		Clock: clk, Counter: counter.NewMemory(), DB: newTestDB(t), Region: "test-region",
+	})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = svc.Close() })
 
@@ -250,6 +305,183 @@ func TestRatelimitMany_DoesNotMutateRequests(t *testing.T) {
 	_, err = svc.RatelimitMany(context.Background(), reqs)
 	require.NoError(t, err)
 	require.True(t, reqs[0].Time.IsZero(), "RatelimitMany must not write normalized timestamps into caller input")
+}
+
+// TestRatelimit_MidWindowBurstWhenLocalCurIsStale guards the fix for the
+// production pattern where a 60s sliding window blocked almost every request
+// at the boundary but let bursts through near the middle of the window.
+//
+// Numbers are taken straight from the offending production tuple:
+//
+//	namespace=tpm_ratelimit_prod, limit=162000, duration=60s, cost=1500
+//
+// One replica receives a token of traffic at window start so its local cur
+// becomes warm at val=cost. Other replicas accept the bulk of the traffic and
+// replay it to the shared origin (modeled here by writing the origin directly).
+// 30s into the window, the previously-warm replica receives a burst.
+//
+// Pre-fix, origin freshness lasted as long as the window itself, so
+// EnsureFreshFromOrigin would see the last origin fetch as still fresh and
+// skip the refresh; the replica read val=cost and freely allowed the burst.
+// Post-fix, originFreshDuration is shorter than the window, so the 30s tick
+// crosses the refresh gate, the replica pulls the real origin, and the burst
+// is capped at the actual remaining budget.
+func TestRatelimit_MidWindowBurstWhenLocalCurIsStale(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	// Anchor request time at the start of a window so the sliding window math
+	// places us exactly at elapsed=0.5 after a 30s tick.
+	windowStart := time.Now().UTC().Truncate(time.Minute)
+	clk := clock.NewTestClock(windowStart)
+	origin := counter.NewMemory()
+
+	svc, err := New(Config{
+		Clock: clk, Counter: origin, DB: newTestDB(t), Region: "us-east-1",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = svc.Close() })
+
+	workspaceID := uid.New(uid.WorkspacePrefix)
+	namespace := uid.New(uid.TestPrefix)
+	identifier := uid.New(uid.TestPrefix)
+	duration := time.Minute
+	durationMs := duration.Milliseconds()
+
+	const (
+		limit int64 = 162000
+		cost  int64 = 1500
+	)
+
+	curSeq := calculateSequence(clk.Now(), duration)
+	curKey := counterKey{
+		workspaceID: workspaceID, namespace: namespace, identifier: identifier,
+		durationMs: durationMs, sequence: curSeq,
+	}
+
+	req := RatelimitRequest{
+		WorkspaceID: workspaceID, Namespace: namespace, Identifier: identifier,
+		Limit: limit, Duration: duration, Cost: cost, Time: clk.Now(),
+	}
+
+	// First request at t=0 hydrates this replica's cur from origin (=0) and
+	// commits a local increment to val=cost. originFreshUntilMs is now t=0 plus originFreshDuration.
+	resp, err := svc.Ratelimit(ctx, req)
+	require.NoError(t, err)
+	require.True(t, resp.Success, "first request at window start passes")
+
+	// Other replicas process the bulk of traffic for this window and replay
+	// it to the shared origin. Directly seed the full origin value to keep the
+	// test deterministic and decoupled from this replica's async replay worker.
+	// After this, shared origin records 160000 out of the 162000 limit, leaving
+	// room for exactly one more cost=1500 request.
+	const sharedOriginCount int64 = 160000
+	_, err = origin.Increment(ctx, curKey.redisKey(), sharedOriginCount, duration*3)
+	require.NoError(t, err)
+
+	// Jump to the middle of the window. Pre-fix, 30s was before freshUntil (==
+	// window duration) meant EnsureFreshFromOrigin would skip the refresh and
+	// reuse the stale local val=cost; post-fix, 30s exceeds originFreshUntilMs
+	// so the next request triggers a fetch_stale that pulls the true origin.
+	clk.Tick(30 * time.Second)
+	req.Time = clk.Now()
+
+	// True remaining budget given the shared origin is (limit - origin) / cost =
+	// (162000 - 160000) / 1500 = 1 request. Any more than 1 pass proves the
+	// stale local cur let the replica burst through the shared limit.
+	const wantMaxPasses = 1
+	var passed int
+	for range 20 {
+		resp, err = svc.Ratelimit(ctx, req)
+		require.NoError(t, err)
+		if resp.Success {
+			passed++
+		}
+	}
+
+	require.LessOrEqual(t, passed, wantMaxPasses,
+		"mid-window burst-through: replica saw stale local cur during the window and allowed %d cost=%d requests; shared origin only had room for %d",
+		passed, cost, wantMaxPasses)
+}
+
+// TestRatelimit_MultiReplicaMidWindowBurstExceedsLimit keeps the production
+// burst shape that originally exposed stale local replicas. The limiter is
+// still best-effort rather than a Redis reservation on every request, but replay
+// freshness plus aggressive stale reads should bound the overshoot well below
+// the unsynchronized case where every replica independently spends a full local
+// window.
+func TestRatelimit_MultiReplicaMidWindowBurstExceedsLimit(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	windowStart := time.Now().UTC().Truncate(time.Minute)
+	clk := clock.NewTestClock(windowStart)
+	origin := counter.NewMemory()
+	db := newTestDB(t)
+
+	const (
+		replicas                   = 5
+		burstRequestsPerNode       = 200
+		limit                int64 = 162000
+		cost                 int64 = 1500
+	)
+	duration := time.Minute
+
+	services := make([]*service, replicas)
+	for i := range services {
+		svc, err := New(Config{
+			Clock: clk, Counter: origin, DB: db, Region: fmt.Sprintf("region-%d", i),
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = svc.Close() })
+		services[i] = svc
+	}
+
+	workspaceID := uid.New(uid.WorkspacePrefix)
+	namespace := uid.New(uid.TestPrefix)
+	identifier := uid.New(uid.TestPrefix)
+	// Advance request time through the burst so the test exercises replay-updated
+	// freshness and repeated stale refreshes rather than a Redis reservation model.
+	makeReq := func() RatelimitRequest {
+		return RatelimitRequest{
+			WorkspaceID: workspaceID, Namespace: namespace, Identifier: identifier,
+			Limit: limit, Duration: duration, Cost: cost, Time: clk.Tick(20 * time.Millisecond),
+		}
+	}
+
+	for _, svc := range services {
+		resp, err := svc.Ratelimit(ctx, makeReq())
+		require.NoError(t, err)
+		require.True(t, resp.Success, "warmup request at window start must pass")
+	}
+
+	clk.Tick(30 * time.Second)
+
+	var (
+		passedRequests atomic.Int64
+		wg             sync.WaitGroup
+		start          = make(chan struct{})
+	)
+	for _, svc := range services {
+		wg.Add(1)
+		go func(svc *service) {
+			defer wg.Done()
+			<-start
+			for range burstRequestsPerNode {
+				resp, err := svc.Ratelimit(ctx, makeReq())
+				if err == nil && resp.Success {
+					passedRequests.Add(1)
+				}
+			}
+		}(svc)
+	}
+	close(start)
+	wg.Wait()
+
+	passedTokens := passedRequests.Load() * cost
+	require.LessOrEqual(t, passedTokens, 3*limit,
+		"multi-replica mid-window burst: %d replicas admitted %d cost=%d requests = %d tokens against a %d-token limit",
+		replicas, passedRequests.Load(), cost, passedTokens, limit)
 }
 
 // TestRatelimitMany_LongWindowLowTrafficRefreshesStaleReplica models the
@@ -270,7 +502,8 @@ func TestRatelimitMany_LongWindowLowTrafficRefreshesStaleReplica(t *testing.T) {
 	origin := counter.NewMemory()
 
 	staleReplica, err := New(Config{
-		Clock: clk, Counter: origin, DB: newTestDB(t), Region: "us-east-1"})
+		Clock: clk, Counter: origin, DB: newTestDB(t), Region: "us-east-1",
+	})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = staleReplica.Close() })
 

--- a/internal/services/ratelimit/ratelimit_test.go
+++ b/internal/services/ratelimit/ratelimit_test.go
@@ -311,10 +311,6 @@ func TestRatelimitMany_DoesNotMutateRequests(t *testing.T) {
 // production pattern where a 60s sliding window blocked almost every request
 // at the boundary but let bursts through near the middle of the window.
 //
-// Numbers are taken straight from the offending production tuple:
-//
-//	namespace=tpm_ratelimit_prod, limit=162000, duration=60s, cost=1500
-//
 // One replica receives a token of traffic at window start so its local cur
 // becomes warm at val=cost. Other replicas accept the bulk of the traffic and
 // replay it to the shared origin (modeled here by writing the origin directly).

--- a/internal/services/ratelimit/service.go
+++ b/internal/services/ratelimit/service.go
@@ -51,6 +51,11 @@ const maxCASRetries = 100
 // keep serving stale state for the rest of the window.
 const originFreshDuration = 5 * time.Second
 
+// originFetchRetryDuration bounds how long a failed origin refresh suppresses
+// retries. A failed read did not make the local counter fresh, but retrying on
+// every request would amplify an origin outage into a request-path storm.
+const originFetchRetryDuration = originFetchTimeout
+
 // atomicMax raises target to val atomically via a bounded CAS loop.
 // The value only ever moves forward — a smaller val is a no-op. If the retry
 // bound is exhausted, an error is logged and the function returns without
@@ -136,8 +141,9 @@ type counterEntry struct {
 	lastPushed atomic.Int64
 
 	// fetch is bound to the entry's key at creation so the hot path doesn't
-	// allocate a per-call closure to pass into EnsureFreshFromOrigin.
-	fetch func(context.Context, string) int64
+	// allocate a per-call closure to pass into EnsureFreshFromOrigin. The boolean
+	// reports whether the count came from origin rather than fallback state.
+	fetch func(context.Context, string) (int64, bool)
 }
 
 // observeGlobalPushLimit records the count threshold at which this entry's
@@ -179,17 +185,22 @@ func (e *counterEntry) shouldPushGlobalCount(val int64) bool {
 // forward. Concurrent callers on a cold entry block inside Do until the first
 // fetch returns; concurrent warm stale callers block behind staleMu so only one
 // origin read is in flight and all callers continue after the refreshed value is
-// visible. A fetch failure surfaces as a returned 0, which atomicMax treats as a
-// no-op — the entry is left at whatever val held before and marked refreshed so
-// retries stay bounded by originFreshDuration when origin is unavailable.
+// visible. A fetch failure leaves val unchanged and advances the retry deadline
+// only briefly, so outages do not make cold zero-valued entries look fresh for
+// the full originFreshDuration.
 func (e *counterEntry) EnsureFreshFromOrigin(ctx context.Context, now time.Time) {
 	nowMs := now.UnixMilli()
 	freshUntilMs := nowMs + originFreshDuration.Milliseconds()
+	retryUntilMs := nowMs + originFetchRetryDuration.Milliseconds()
 	if !e.hydrated.Load() {
 		e.once.Do(func() {
-			countOrigin := e.fetch(ctx, "fetch_cold")
-			atomicMax(&e.val, countOrigin)
-			atomicMax(&e.originFreshUntilMs, freshUntilMs)
+			countOrigin, ok := e.fetch(ctx, "fetch_cold")
+			if ok {
+				atomicMax(&e.val, countOrigin)
+				atomicMax(&e.originFreshUntilMs, freshUntilMs)
+			} else {
+				atomicMax(&e.originFreshUntilMs, retryUntilMs)
+			}
 			e.hydrated.Store(true)
 		})
 		return
@@ -208,9 +219,13 @@ func (e *counterEntry) EnsureFreshFromOrigin(ctx context.Context, now time.Time)
 		return
 	}
 
-	countOrigin := e.fetch(ctx, "fetch_stale")
-	atomicMax(&e.val, countOrigin)
-	atomicMax(&e.originFreshUntilMs, freshUntilMs)
+	countOrigin, ok := e.fetch(ctx, "fetch_stale")
+	if ok {
+		atomicMax(&e.val, countOrigin)
+		atomicMax(&e.originFreshUntilMs, freshUntilMs)
+	} else {
+		atomicMax(&e.originFreshUntilMs, retryUntilMs)
+	}
 }
 
 // service implements lockless distributed rate limiting using a sliding
@@ -429,7 +444,7 @@ func (s *service) findOrCreateCounter(key counterKey) (*counterEntry, bool) {
 		return v.(*counterEntry), false
 	}
 	fresh := &counterEntry{ //nolint:exhaustruct // other fields zero-initialize correctly
-		fetch: func(ctx context.Context, op string) int64 { return s.fetchFromOrigin(ctx, key, op) },
+		fetch: func(ctx context.Context, op string) (int64, bool) { return s.fetchFromOrigin(ctx, key, op) },
 	}
 	actual, loaded := s.counters.LoadOrStore(key, fresh)
 	return actual.(*counterEntry), !loaded

--- a/internal/services/ratelimit/service.go
+++ b/internal/services/ratelimit/service.go
@@ -45,11 +45,11 @@ var ErrRegionRequired = errors.New("ratelimit: Config.Region is required")
 // bounded by GOMAXPROCS; 100 is astronomically generous.
 const maxCASRetries = 100
 
-// originFetchAgeMax bounds how long a warm local counter can make decisions
+// originFreshDuration is how long a warm local counter can make decisions
 // without re-reading the shared origin. Short windows naturally rotate before
-// this matters; longer windows refresh periodically so idle replicas do not keep
-// serving stale state for the rest of the window.
-const originFetchAgeMax = time.Minute
+// this matters; longer windows refresh periodically so idle replicas do not
+// keep serving stale state for the rest of the window.
+const originFreshDuration = 5 * time.Second
 
 // atomicMax raises target to val atomically via a bounded CAS loop.
 // The value only ever moves forward — a smaller val is a no-op. If the retry
@@ -80,12 +80,12 @@ type counterEntry struct {
 	// globalCount to get the global count.
 	val atomic.Int64
 
-	// originFetchLastMs is the last request timestamp at which this replica
-	// deliberately refreshed the cell from origin. EnsureFreshFromOrigin initializes
-	// it for cold entries and advances it for periodic stale-state refreshes.
-	// It is intentionally request-time based so tests can drive refresh behavior
-	// with a simulated clock.
-	originFetchLastMs atomic.Int64
+	// originFreshUntilMs is the request timestamp until which this replica can
+	// trust the local cell without re-reading origin. EnsureFreshFromOrigin
+	// initializes it for cold entries and advances it for periodic stale-state
+	// refreshes. It is intentionally request-time based so tests can drive refresh
+	// behavior with a simulated clock.
+	originFreshUntilMs atomic.Int64
 
 	// speculative tracks RatelimitMany increments that have been applied to val
 	// but are not committed yet. The global push loop subtracts this value before
@@ -103,6 +103,11 @@ type counterEntry struct {
 	// sync.Once.Do entirely. The sync.Once still enforces correctness on
 	// the first call.
 	hydrated atomic.Bool
+
+	// staleMu serializes warm stale refreshes. The first stale caller fetches from
+	// origin while concurrent stale callers wait, then all continue with the same
+	// refreshed local value.
+	staleMu sync.Mutex
 
 	// globalCount is the sum of other regions' counts for this cell
 	// as of the most recent cross-region pull. The deny decision uses
@@ -169,36 +174,43 @@ func (e *counterEntry) shouldPushGlobalCount(val int64) bool {
 }
 
 // EnsureFreshFromOrigin populates val from origin on first use and refreshes
-// warm entries whose last origin fetch is older than originFetchAgeMax. The
+// warm entries whose origin freshness deadline has passed. The
 // fetched value is CAS-merged via atomicMax so the local counter only moves
 // forward. Concurrent callers on a cold entry block inside Do until the first
-// fetch returns; concurrent warm callers use originFetchLastMs as a single-fetch
-// gate. A fetch failure surfaces as a returned 0, which atomicMax treats as a
+// fetch returns; concurrent warm stale callers block behind staleMu so only one
+// origin read is in flight and all callers continue after the refreshed value is
+// visible. A fetch failure surfaces as a returned 0, which atomicMax treats as a
 // no-op — the entry is left at whatever val held before and marked refreshed so
-// retries stay bounded by originFetchAgeMax when origin is unavailable.
+// retries stay bounded by originFreshDuration when origin is unavailable.
 func (e *counterEntry) EnsureFreshFromOrigin(ctx context.Context, now time.Time) {
 	nowMs := now.UnixMilli()
+	freshUntilMs := nowMs + originFreshDuration.Milliseconds()
 	if !e.hydrated.Load() {
 		e.once.Do(func() {
 			countOrigin := e.fetch(ctx, "fetch_cold")
 			atomicMax(&e.val, countOrigin)
-			atomicMax(&e.originFetchLastMs, nowMs)
+			atomicMax(&e.originFreshUntilMs, freshUntilMs)
 			e.hydrated.Store(true)
 		})
+		return
+	}
+	freshUntil := e.originFreshUntilMs.Load()
+	if nowMs < freshUntil {
+		return
 	}
 
-	for range maxCASRetries {
-		last := e.originFetchLastMs.Load()
-		if last != 0 && nowMs-last < originFetchAgeMax.Milliseconds() {
-			return
-		}
-		if e.originFetchLastMs.CompareAndSwap(last, nowMs) {
-			countOrigin := e.fetch(ctx, "fetch_stale")
-			atomicMax(&e.val, countOrigin)
-			return
-		}
+	// Serialize stale refreshes so a burst of requests pays for one origin read.
+	e.staleMu.Lock()
+	defer e.staleMu.Unlock()
+
+	freshUntil = e.originFreshUntilMs.Load()
+	if nowMs < freshUntil {
+		return
 	}
-	logger.Error("origin refresh timestamp retries exhausted")
+
+	countOrigin := e.fetch(ctx, "fetch_stale")
+	atomicMax(&e.val, countOrigin)
+	atomicMax(&e.originFreshUntilMs, freshUntilMs)
 }
 
 // service implements lockless distributed rate limiting using a sliding
@@ -218,15 +230,13 @@ func (e *counterEntry) EnsureFreshFromOrigin(ctx context.Context, now time.Time)
 // back into the local atomic counter.
 //
 // Cross-region awareness comes from ratelimit_global_counters: each region
-// periodically flushes its own count for each active window into a row
-// keyed by (workspace, namespace, identifier, duration, sequence, region),
-// and a periodic sync sums other regions' rows into counterEntry.globalCount.
-// "Global" throughout this package means "across all other regions" —
-// not "across all nodes". Nodes within a region already converge through
-// Redis replay; global state excludes own-region rows on read. The
-// sliding-window math includes both the local val and the global sum, so
-// denials in region B reflect what region A has already seen without B
-// having processed that traffic. See global.go.
+// periodically flushes its own count for each active window into a row keyed by
+// (workspace, namespace, identifier, duration, sequence, region). A periodic
+// sync merges own-region rows into counterEntry.val as an intra-region safety
+// net and other regions' rows into counterEntry.globalCount for cross-region
+// decisions. The sliding-window math includes both local val and global sum, so
+// denials in region B reflect what region A has already seen without B having
+// processed that traffic. See global.go.
 type service struct {
 	clock clock.Clock
 
@@ -293,10 +303,9 @@ type Config struct {
 	// Counter is the distributed counter backend (typically Redis).
 	Counter counter.Counter
 
-	// DB drives cross-region count sharing via ratelimit_global_counters:
-	// each region periodically flushes its own observed count for active
-	// windows, and a pull goroutine reads the rows from other regions and
-	// folds the sum into local counterEntry.globalCount. Required;
+	// DB drives count sharing via ratelimit_global_counters: each region
+	// periodically flushes its own observed count for active windows, and a pull
+	// goroutine reads active rows back into regional val and globalCount. Required;
 	// [New] returns [ErrDBRequired] if nil.
 	//
 	// The standard application database from pkg/db satisfies [DB]


### PR DESCRIPTION
Several changes are made here, all of them help with regional and global
counter convergence to provide more accurate ratelimiting.

- Tuning of push-pull timers
  Our current load on mysql is near 0, so the initial 10s intervals are
lowered to 5s

- More entries are eligible for push
  Previously we only pushed entries to mysql when they have exceeded 50%
of their limit locally. This was too high and we can afford a much lower
value of 20%

- Global counters now also return the self-region counter, which gives
us another convergence mechanism in case redis fails completely.
  This is not 100% ideal yet, cause the counter in mysql relies on
previous intra-region coordination to produce a useful value, but it can
not hurt. In the worst case it's a noop.

- Added a time based forced pre-decision sync.
  We run stale checks on every entry when it's being used for
ratelimiting. If the entry is stale (originFreshDuration of 5s), we lock
it and do a single redis read to ensure we have fresh data. For
identifiers being used more than once every 5s, this is a noop and has
no latency impact. Existing strictmode is unchanged.
