### PR TITLE
fix: redact any values

### DIFF
--- a/web/apps/dashboard/lib/sentry/error-filter.ts
+++ b/web/apps/dashboard/lib/sentry/error-filter.ts
@@ -22,6 +22,51 @@ import { classifyError } from "../utils/error-classification";
 export type BeforeSendHook = Parameters<typeof Sentry.init>[0]["beforeSend"];
 
 /**
+ * Input field names that may carry plaintext secrets and must never be sent to
+ * Sentry. The tRPC Sentry middleware attaches the raw procedure input to
+ * `event.contexts.trpc.input` (via `attachRpcInput: true`), which would
+ * otherwise exfiltrate env-var secret values (`value`, `variables[].value`,
+ * `items[].value`) when an unexpected error is forwarded. `sendDefaultPii: false`
+ * does not scrub custom contexts, so we redact these explicitly.
+ */
+const SENSITIVE_INPUT_KEYS = new Set(["value"]);
+
+const REDACTED = "[REDACTED]";
+
+/**
+ * Recursively replaces the values of sensitive keys with a redaction marker.
+ * Walks nested objects and arrays so secrets nested under `variables`/`items`
+ * are also scrubbed. Returns a new structure and never mutates the input.
+ */
+function redactSensitiveValues(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(redactSensitiveValues);
+  }
+
+  if (value && typeof value === "object") {
+    const result: Record<string, unknown> = {};
+    for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
+      result[key] = SENSITIVE_INPUT_KEYS.has(key) ? REDACTED : redactSensitiveValues(nested);
+    }
+    return result;
+  }
+
+  return value;
+}
+
+/**
+ * Scrubs plaintext secrets from the tRPC input attached by the Sentry tRPC
+ * middleware before an event is forwarded to Sentry. Mutates the event in place
+ * because Sentry consumes the same object returned from `beforeSend`.
+ */
+function scrubTrpcInput(event: Sentry.ErrorEvent): void {
+  const trpcContext = event.contexts?.trpc;
+  if (trpcContext && "input" in trpcContext) {
+    trpcContext.input = redactSensitiveValues(trpcContext.input);
+  }
+}
+
+/**
  * Configuration options for error filtering
  */
 export interface ErrorFilterOptions {
@@ -58,6 +103,12 @@ export function createErrorFilter(options: ErrorFilterOptions = {}): BeforeSendH
   const { logFilteredErrors = true, additionalFilters = [], contextProvider } = options;
 
   return (event, hint) => {
+    // Always redact plaintext secrets from the attached tRPC input before any
+    // forwarding path returns the event. This must run regardless of error
+    // classification so that INTERNAL_SERVER_ERROR and uncaught errors do not
+    // leak secret values through `contexts.trpc.input`.
+    scrubTrpcInput(event);
+
     const error = hint.originalException;
 
     // Handle missing exception

--- a/web/apps/dashboard/lib/trpc/routers/deploy/env-vars/create-bulk.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/env-vars/create-bulk.ts
@@ -30,52 +30,63 @@ export const createBulkEnvVars = workspaceProcedure
     }),
   )
   .mutation(async ({ ctx, input }) => {
-    const environmentIds = [...new Set(input.variables.map((v) => v.environmentId))];
+    try {
+      const environmentIds = [...new Set(input.variables.map((v) => v.environmentId))];
 
-    const envRecords = await db.query.environments.findMany({
-      where: and(
-        inArray(environments.id, environmentIds),
-        eq(environments.workspaceId, ctx.workspace.id),
-      ),
-      columns: {
-        id: true,
-        appId: true,
-      },
-    });
+      const envRecords = await db.query.environments.findMany({
+        where: and(
+          inArray(environments.id, environmentIds),
+          eq(environments.workspaceId, ctx.workspace.id),
+        ),
+        columns: {
+          id: true,
+          appId: true,
+        },
+      });
 
-    const envMap = new Map(envRecords.map((e) => [e.id, e]));
+      const envMap = new Map(envRecords.map((e) => [e.id, e]));
 
-    // Group by keyring (environmentId) so each encryptBulk call uses one DEK, avoids concurrent S3 PutObject on the same key
-    const grouped = Map.groupBy(input.variables, (v) => v.environmentId);
+      // Group by keyring (environmentId) so each encryptBulk call uses one DEK, avoids concurrent S3 PutObject on the same key
+      const grouped = Map.groupBy(input.variables, (v) => v.environmentId);
 
-    const encryptedVars = (
-      await Promise.all(
-        grouped.entries().map(async ([environmentId, vars]) => {
-          const environment = envMap.get(environmentId);
-          if (!environment) {
-            throw new TRPCError({
-              code: "NOT_FOUND",
-              message: `Environment ${environmentId} not found`,
-            });
-          }
+      const encryptedVars = (
+        await Promise.all(
+          grouped.entries().map(async ([environmentId, vars]) => {
+            const environment = envMap.get(environmentId);
+            if (!environment) {
+              throw new TRPCError({
+                code: "NOT_FOUND",
+                message: `Environment ${environmentId} not found`,
+              });
+            }
 
-          const tagged = vars.map((v) => [newId("environmentVariable"), v] as const);
-          const items = Object.fromEntries(tagged.map(([id, v]) => [id, v.value]));
-          const result = await vault.encryptBulk({ keyring: environmentId, items });
+            const tagged = vars.map((v) => [newId("environmentVariable"), v] as const);
+            const items = Object.fromEntries(tagged.map(([id, v]) => [id, v.value]));
+            const result = await vault.encryptBulk({ keyring: environmentId, items });
 
-          return tagged.map(([id, v]) => ({
-            id,
-            workspaceId: ctx.workspace.id,
-            appId: environment.appId,
-            environmentId,
-            key: v.key,
-            value: result.items[id].encrypted,
-            type: v.type,
-            description: v.description ?? null,
-          }));
-        }),
-      )
-    ).flat();
+            return tagged.map(([id, v]) => ({
+              id,
+              workspaceId: ctx.workspace.id,
+              appId: environment.appId,
+              environmentId,
+              key: v.key,
+              value: result.items[id].encrypted,
+              type: v.type,
+              description: v.description ?? null,
+            }));
+          }),
+        )
+      ).flat();
 
-    await db.insert(schema.appEnvironmentVariables).values(encryptedVars);
+      await db.insert(schema.appEnvironmentVariables).values(encryptedVars);
+    } catch (error) {
+      if (error instanceof TRPCError) {
+        throw error;
+      }
+
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: "Failed to create environment variables",
+      });
+    }
   });


### PR DESCRIPTION
## What does this PR do?

The deploy env-var tRPC procedures (create, create-bulk, update) accept plaintext secret values and inherit Sentry.trpcMiddleware({ attachRpcInput: true }) from baseProcedure, which attaches the raw, unmodified procedure input to every Sentry event under contexts.trpc.input. Our beforeSend filter only drops events whose tRPC code is in the expected set (NOT_FOUND, BAD_REQUEST, etc.), so any INTERNAL_SERVER_ERROR — raised on a Vault encrypt failure, a ConnectRPC network error, or a DB insert error — was forwarded to Sentry with the attached input intact. The result is that every plaintext secret a user submitted (database URLs, API keys, signing secrets) could be exfiltrated to Sentry on a backend failure. Setting sendDefaultPii: false does not help here, because it does not scrub custom contexts like contexts.trpc.input.

This PR fixes the leak centrally in the Sentry beforeSend hook rather than per-procedure. In lib/sentry/error-filter.ts I added a recursive scrubber that walks the attached tRPC input and redacts the value of any key named value, replacing it with [REDACTED]. Because it recurses through nested objects and arrays, it covers all the shapes the env-var procedures produce — the top-level value in update, variables[].value in create, and the bulk variables[].value / items[].value in create-bulk — as well as any future secret-bearing procedure that follows the same naming convention. The scrubber runs at the very top of the hook, before any error-classification branching, so it applies to every forwarded event regardless of error code, while expected errors are still dropped exactly as before. The match is driven purely by the field name rather than by inspecting content, which keeps it deterministic: non-secret fields such as an API name, key, environmentId, or type are preserved in full so errors remain debuggable, and only the secret-carrying value fields are removed. Since the client, server, and edge filters all build on createErrorFilter, the fix takes effect across all three runtimes from a single place.

As defense in depth, I also wrapped the create-bulk mutation body in a try/catch that re-throws TRPCError instances unchanged and maps any unexpected error to a generic INTERNAL_SERVER_ERROR with a non-revealing message. This brings it in line with the existing error handling in create and update, and ensures internal failures (including the NOT_FOUND thrown inside the Promise.all map) never propagate raw.

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist

<!-- Complete this checklist before requesting review. -->

### Required

- [X] Filled out the "How to test" section in this PR
- [ ] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [X] Ran `pnpm build`
- [X] Ran `pnpm fmt`
- [X] Ran `mise run fmt`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary
