### PR TITLE
feat(dashboard): tRPC changes for app

### DIFF
--- a/web/apps/dashboard/lib/audit.ts
+++ b/web/apps/dashboard/lib/audit.ts
@@ -47,6 +47,7 @@ export type UnkeyAuditLog = {
       | "reporter"
       | "secret"
       | "project"
+      | "app"
       | "identity"
       | "auditLogBucket"
       | "environment"

--- a/web/apps/dashboard/lib/collections/deploy/apps.ts
+++ b/web/apps/dashboard/lib/collections/deploy/apps.ts
@@ -1,0 +1,165 @@
+"use client";
+import { parseLoadSubsetOptions, queryCollectionOptions } from "@tanstack/query-db-collection";
+import { createCollection } from "@tanstack/react-db";
+import { toast } from "@unkey/ui";
+import { z } from "zod";
+import { queryClient, trpcClient } from "../client";
+
+const schema = z.object({
+  id: z.string(),
+  projectId: z.string(),
+  name: z.string(),
+  slug: z.string(),
+  defaultBranch: z.string(),
+  currentDeploymentId: z.string().nullable(),
+  isRolledBack: z.boolean(),
+});
+
+export const createAppRequestSchema = z.object({
+  projectId: z.string().min(1, "Project is required"),
+  name: z.string().trim().min(1, "App name is required").max(256, "App name too long"),
+  slug: z
+    .string()
+    .trim()
+    .min(1, "App slug is required")
+    .max(256, "App slug too long")
+    .regex(/^[a-z0-9-]+$/, "App slug must contain only lowercase letters, numbers, and hyphens"),
+});
+
+export type App = z.infer<typeof schema>;
+export type CreateAppRequestSchema = z.infer<typeof createAppRequestSchema>;
+
+type ParsedFilter = { field: Array<string | number>; operator: string; value?: unknown };
+
+function extractStringFilter(filters: ParsedFilter[], fieldName: string, operator: string) {
+  const value = filters.find((f) => f.field.at(-1) === fieldName && f.operator === operator)?.value;
+  return typeof value === "string" ? value : undefined;
+}
+
+/**
+ * Global apps collection.
+ *
+ * IMPORTANT: All queries MUST filter by projectId:
+ * .where(({ app }) => eq(app.projectId, projectId))
+ */
+export const apps = createCollection<App, string>(
+  queryCollectionOptions({
+    queryClient,
+    queryKey: (opts) => {
+      const { filters } = parseLoadSubsetOptions(opts);
+      const projectId = extractStringFilter(filters, "projectId", "eq");
+      return projectId ? ["apps", projectId] : ["apps"];
+    },
+    retry: 3,
+    syncMode: "on-demand",
+    refetchInterval: 5000,
+    queryFn: async (ctx) => {
+      const { filters } = parseLoadSubsetOptions(ctx.meta?.loadSubsetOptions);
+      const projectId = extractStringFilter(filters, "projectId", "eq");
+
+      if (!projectId) {
+        throw new Error("Query must include eq(collection.projectId, projectId) constraint");
+      }
+
+      return trpcClient.deploy.app.list.query({ projectId });
+    },
+    getKey: (item) => item.id,
+    id: "apps",
+    onDelete: async ({ transaction }) => {
+      const mutation = transaction.mutations[0];
+      const appId = mutation.original.id;
+
+      const deleteMutation = trpcClient.deploy.app.delete.mutate({ appId });
+
+      toast.promise(deleteMutation, {
+        loading: "Deleting app...",
+        success: "App deleted successfully",
+        error: (err) => {
+          console.error("Failed to delete app", err);
+          switch (err.data?.code) {
+            case "NOT_FOUND":
+              return {
+                message: "App Deletion Failed",
+                description: "Unable to find the app. Please refresh and try again.",
+              };
+            case "FORBIDDEN":
+              return {
+                message: "Permission Denied",
+                description: "You don't have permission to delete this app.",
+              };
+            case "PRECONDITION_FAILED":
+              return {
+                message: "Delete Protection Enabled",
+                description: err.message || "Disable delete protection before deleting this app.",
+              };
+            case "INTERNAL_SERVER_ERROR":
+              return {
+                message: "Server Error",
+                description:
+                  "We encountered an issue while deleting your app. Please try again later or contact support at support@unkey.com",
+              };
+            default:
+              return {
+                message: "Failed to Delete App",
+                description: err.message || "An unexpected error occurred. Please try again later.",
+              };
+          }
+        },
+      });
+
+      await deleteMutation;
+    },
+    onInsert: async ({ transaction }) => {
+      const { changes } = transaction.mutations[0];
+
+      const createInput = createAppRequestSchema.parse({
+        projectId: changes.projectId,
+        name: changes.name,
+        slug: changes.slug,
+      });
+      const mutation = trpcClient.deploy.app.create.mutate(createInput);
+
+      toast.promise(mutation, {
+        loading: "Creating app...",
+        success: "App created successfully",
+        error: (err) => {
+          console.error("Failed to create app", err);
+          switch (err.data?.code) {
+            case "CONFLICT":
+              return {
+                message: "App Already Exists",
+                description: err.message || "An app with this slug already exists in this project.",
+              };
+            case "FORBIDDEN":
+              return {
+                message: "Permission Denied",
+                description:
+                  err.message || "You don't have permission to create apps in this project.",
+              };
+            case "NOT_FOUND":
+              return {
+                message: "App Creation Failed",
+                description: "Unable to find the project. Please refresh and try again.",
+              };
+            case "INTERNAL_SERVER_ERROR":
+              return {
+                message: "Server Error",
+                description:
+                  "We encountered an issue while creating your app. Please try again later or contact support at support@unkey.com",
+              };
+            default:
+              return {
+                message: "Failed to Create App",
+                description: err.message || "An unexpected error occurred. Please try again later.",
+              };
+          }
+        },
+      });
+
+      const result = await mutation;
+      transaction.metadata = {
+        appId: result.id,
+      };
+    },
+  }),
+);

--- a/web/apps/dashboard/lib/collections/index.ts
+++ b/web/apps/dashboard/lib/collections/index.ts
@@ -1,4 +1,5 @@
 "use client";
+import { apps } from "./deploy/apps";
 import { customDomains } from "./deploy/custom-domains";
 import { deployments } from "./deploy/deployments";
 import { domains } from "./deploy/domains";
@@ -11,6 +12,7 @@ import { ratelimitNamespaces } from "./ratelimit/namespaces";
 import { ratelimitOverrides } from "./ratelimit/overrides";
 
 // Export types
+export type { App } from "./deploy/apps";
 export type { CustomDomain } from "./deploy/custom-domains";
 export type { DeploymentStatus } from "./deploy/deployment-status";
 export { DEPLOYMENT_STATUSES } from "./deploy/deployment-status";
@@ -33,6 +35,7 @@ export type { Environment } from "./deploy/environments";
 // Global collections
 export const collection = {
   projects,
+  apps,
   ratelimitNamespaces,
   ratelimitOverrides,
   environments,

--- a/web/apps/dashboard/lib/trpc/routers/ctrl.ts
+++ b/web/apps/dashboard/lib/trpc/routers/ctrl.ts
@@ -1,3 +1,4 @@
+import { AppService } from "@/gen/proto/ctrl/v1/app_pb";
 import { ProjectService } from "@/gen/proto/ctrl/v1/project_pb";
 import { env } from "@/lib/env";
 import { createClient } from "@connectrpc/connect";
@@ -28,6 +29,7 @@ export function getCtrlClients() {
   const transport = getTransport();
   return {
     project: createClient(ProjectService, transport),
+    app: createClient(AppService, transport),
     // more typed clients can be added here
   };
 }

--- a/web/apps/dashboard/lib/trpc/routers/deploy/app/create.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/app/create.ts
@@ -1,0 +1,62 @@
+import { createAppRequestSchema } from "@/lib/collections/deploy/apps";
+import { db } from "@/lib/db";
+import { ratelimit, withRatelimit, workspaceProcedure } from "@/lib/trpc/trpc";
+import { TRPCError } from "@trpc/server";
+import { getCtrlClients } from "../../ctrl";
+
+export const createApp = workspaceProcedure
+  .input(createAppRequestSchema)
+  .use(withRatelimit(ratelimit.create))
+  .mutation(async ({ ctx, input }) => {
+    const workspaceId = ctx.workspace.id;
+
+    const project = await db.query.projects.findFirst({
+      where: (table, { and, eq }) =>
+        and(eq(table.id, input.projectId), eq(table.workspaceId, workspaceId)),
+      columns: { id: true },
+    });
+
+    if (!project) {
+      throw new TRPCError({
+        code: "NOT_FOUND",
+        message: "Project not found",
+      });
+    }
+
+    const existingApp = await db.query.apps.findFirst({
+      where: (table, { and, eq }) =>
+        and(eq(table.projectId, input.projectId), eq(table.slug, input.slug)),
+      columns: { id: true },
+    });
+
+    if (existingApp) {
+      throw new TRPCError({
+        code: "CONFLICT",
+        message: `An app with slug "${input.slug}" already exists in this project`,
+      });
+    }
+
+    const ctrl = getCtrlClients();
+
+    try {
+      const response = await ctrl.app.createApp({
+        workspaceId,
+        projectId: input.projectId,
+        name: input.name,
+        slug: input.slug,
+      });
+
+      return {
+        id: response.id,
+      };
+    } catch (err) {
+      if (err instanceof TRPCError) {
+        throw err;
+      }
+      console.error("Failed to create app:", err);
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: "Failed to create app. Our team has been notified of this issue.",
+      });
+    }
+  });

--- a/web/apps/dashboard/lib/trpc/routers/deploy/app/delete.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/app/delete.ts
@@ -1,0 +1,67 @@
+import { insertAuditLogs } from "@/lib/audit";
+import { db } from "@/lib/db";
+import { ratelimit, withRatelimit, workspaceProcedure } from "@/lib/trpc/trpc";
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+import { getCtrlClients } from "../../ctrl";
+
+export const deleteApp = workspaceProcedure
+  .input(z.object({ appId: z.string() }))
+  .use(withRatelimit(ratelimit.delete))
+  .mutation(async ({ ctx, input }) => {
+    const app = await db.query.apps.findFirst({
+      where: (table, { and, eq }) =>
+        and(eq(table.id, input.appId), eq(table.workspaceId, ctx.workspace.id)),
+    });
+
+    if (!app) {
+      throw new TRPCError({
+        code: "NOT_FOUND",
+        message: "App not found",
+      });
+    }
+
+    if (app.deleteProtection) {
+      throw new TRPCError({
+        code: "PRECONDITION_FAILED",
+        message: "Cannot delete app with delete protection enabled",
+      });
+    }
+
+    const ctrl = getCtrlClients();
+
+    try {
+      await ctrl.app.deleteApp({
+        appId: input.appId,
+      });
+    } catch (err) {
+      if (err instanceof TRPCError) {
+        throw err;
+      }
+      console.error("Failed to delete app:", err);
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: "Failed to delete app",
+      });
+    }
+
+    await insertAuditLogs(db, {
+      workspaceId: ctx.workspace.id,
+      actor: { type: "user", id: ctx.user.id },
+      event: "app.delete",
+      description: `Deleted ${app.id}`,
+      resources: [
+        {
+          type: "app",
+          id: app.id,
+          name: app.name,
+        },
+      ],
+      context: {
+        location: ctx.audit.location,
+        userAgent: ctx.audit.userAgent,
+      },
+    });
+
+    return { success: true, appId: input.appId };
+  });

--- a/web/apps/dashboard/lib/trpc/routers/deploy/app/list.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/app/list.ts
@@ -1,0 +1,34 @@
+import type { App } from "@/lib/collections/deploy/apps";
+import { and, db, desc, eq } from "@/lib/db";
+import { ratelimit, withRatelimit, workspaceProcedure } from "@/lib/trpc/trpc";
+import { apps } from "@unkey/db/src/schema";
+import { z } from "zod";
+
+export const listApps = workspaceProcedure
+  .input(z.object({ projectId: z.string() }))
+  .use(withRatelimit(ratelimit.read))
+  .query(async ({ ctx, input }): Promise<App[]> => {
+    const rows = await db
+      .select({
+        id: apps.id,
+        projectId: apps.projectId,
+        name: apps.name,
+        slug: apps.slug,
+        defaultBranch: apps.defaultBranch,
+        currentDeploymentId: apps.currentDeploymentId,
+        isRolledBack: apps.isRolledBack,
+      })
+      .from(apps)
+      .where(and(eq(apps.workspaceId, ctx.workspace.id), eq(apps.projectId, input.projectId)))
+      .orderBy(desc(apps.updatedAt), desc(apps.id));
+
+    return rows.map((row) => ({
+      id: row.id,
+      projectId: row.projectId,
+      name: row.name,
+      slug: row.slug,
+      defaultBranch: row.defaultBranch,
+      currentDeploymentId: row.currentDeploymentId ?? null,
+      isRolledBack: Boolean(row.isRolledBack),
+    }));
+  });

--- a/web/apps/dashboard/lib/trpc/routers/index.ts
+++ b/web/apps/dashboard/lib/trpc/routers/index.ts
@@ -36,6 +36,9 @@ import { searchRolesPermissions } from "./authorization/roles/permissions/search
 import { queryRoles } from "./authorization/roles/query";
 import { upsertRole } from "./authorization/roles/upsert";
 import { queryUsage } from "./billing/query-usage";
+import { createApp } from "./deploy/app/create";
+import { deleteApp } from "./deploy/app/delete";
+import { listApps } from "./deploy/app/list";
 import { addCustomDomain } from "./deploy/custom-domains/add";
 import { deleteCustomDomain } from "./deploy/custom-domains/delete";
 import { listCustomDomains } from "./deploy/custom-domains/list";
@@ -437,6 +440,11 @@ export const router = t.router({
       create: createProject,
       delete: deleteProject,
       creationContext,
+    }),
+    app: t.router({
+      list: listApps,
+      create: createApp,
+      delete: deleteApp,
     }),
     environmentSettings: t.router({
       get: getEnvironmentSettings,

--- a/web/internal/schema/src/auditlog.ts
+++ b/web/internal/schema/src/auditlog.ts
@@ -49,6 +49,8 @@ export const unkeyAuditLogEvents = z.enum([
   "auditLogBucket.create",
   "project.create",
   "project.delete",
+  "app.create",
+  "app.delete",
   "environment.create",
   "deployment.rollback",
   "deployment.promote",


### PR DESCRIPTION
> [!IMPORTANT]
> Unkey is not accepting external pull requests at this time. Pull requests from people outside the Unkey team will not be reviewed or merged.

## What does this PR do?

Adds full CRUD support for deploy apps, including a reactive TanStack collection, tRPC procedures, and audit logging.

- Introduces a new `apps` TanStack collection (`lib/collections/deploy/apps.ts`) with `on-demand` sync, 5-second refetch interval, and optimistic `onInsert`/`onDelete` handlers that surface toast notifications with detailed error messaging per error code
- Adds `listApps`, `createApp`, and `deleteApp` tRPC procedures under the `deploy.app` router namespace
- `createApp` validates that the target project belongs to the workspace, checks for slug conflicts, and delegates creation to the `ctrl` gRPC `AppService`
- `deleteApp` enforces delete protection, delegates deletion to `ctrl`, and writes an `app.delete` audit log entry
- Registers `AppService` as a typed `ctrl` client alongside the existing `ProjectService`
- Adds `app.create` and `app.delete` to the audit log event enum and adds `"app"` as a valid audit log resource type

Fixes # (issue)

_If there is not an issue for this, create one first. This is used for tracking purposes and helps us understand why this PR exists._

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Create an app within an existing project and verify it appears in the collection and the database
- Attempt to create an app with a duplicate slug in the same project and confirm a `CONFLICT` toast is shown
- Delete an app without delete protection enabled and confirm the `app.delete` audit log entry is written
- Attempt to delete an app with delete protection enabled and confirm a `PRECONDITION_FAILED` toast is shown
- Verify that querying the `apps` collection without a `projectId` filter throws an error

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `mise run fmt`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary