### PR TITLE
feat(dashboard): app-aware sidebar + breadcrumb

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/navigations/project-navigation.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/navigations/project-navigation.tsx
@@ -4,7 +4,7 @@ import { QuickNavPopover } from "@/components/navbar-popover";
 import { Navbar } from "@/components/navigation/navbar";
 import { useWorkspaceNavigation } from "@/hooks/use-workspace-navigation";
 import { collection } from "@/lib/collections";
-import { useLiveQuery } from "@tanstack/react-db";
+import { eq, useLiveQuery } from "@tanstack/react-db";
 import { ArrowDottedRotateAnticlockwise, ChevronExpandY, Cube } from "@unkey/icons";
 import { Button, InfoTooltip } from "@unkey/ui";
 import dynamic from "next/dynamic";
@@ -45,12 +45,24 @@ export const ProjectNavigation = ({ onMount }: ProjectNavigationProps) => {
     ? { id: project.id, name: project.name, repositoryFullName: project.repositoryFullName }
     : undefined;
 
+  const apps = useLiveQuery(
+    (q) =>
+      q
+        .from({ app: collection.apps })
+        .where(({ app }) => eq(app.projectId, projectId))
+        .select(({ app }) => ({ id: app.id, name: app.name })),
+    [projectId],
+  );
+  const appName = apps.data?.find((a) => a.id === appId)?.name;
+
   const basePath = `/${workspace.slug}/projects`;
   const breadcrumbs = useBreadcrumbConfig({
     projectId,
     appId: appId ?? "",
+    appName,
     basePath,
     projects: projects.data || [],
+    apps: apps.data || [],
     activeProject,
   });
 

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/navigations/use-breadcrumb-config.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/navigations/use-breadcrumb-config.ts
@@ -31,14 +31,18 @@ type SubPage = {
 export const useBreadcrumbConfig = ({
   projectId,
   appId,
+  appName,
   basePath,
   projects,
+  apps,
   activeProject,
 }: {
   projectId: string;
   appId: string;
+  appName: string | undefined;
   basePath: string;
   projects: Array<{ id: string; name: string }>;
+  apps: Array<{ id: string; name: string }>;
   activeProject: { id: string; name: string } | undefined;
 }): BreadcrumbItem[] => {
   const segments = useSelectedLayoutSegments() ?? [];
@@ -131,7 +135,27 @@ export const useBreadcrumbConfig = ({
       },
     },
 
-    // 3. Sub-page with QuickNav (Overview, Deployments, etc.)
+    // 3. Current app with QuickNav (switch apps within the project)
+    {
+      id: "app",
+      children: appName || appId,
+      href: `${appBase}/deployments`,
+      shouldRender: true,
+      active: false,
+      isLast: false,
+      noop: true,
+      className: "flex",
+      quickNavConfig: {
+        items: apps.map((app) => ({
+          id: app.id,
+          label: app.name,
+          href: `${basePath}/${projectId}/apps/${app.id}/deployments`,
+        })),
+        shortcutKey: "A",
+      },
+    },
+
+    // 4. Sub-page with QuickNav (Overview, Deployments, etc.)
     {
       id: "subpage",
       children: isOnDeploymentDetail ? "Deployments" : activeSubPage.label,

--- a/web/apps/dashboard/components/navigation/sidebar/app-sidebar/hooks/use-app-data.tsx
+++ b/web/apps/dashboard/components/navigation/sidebar/app-sidebar/hooks/use-app-data.tsx
@@ -1,0 +1,35 @@
+"use client";
+import type { NavItem } from "@/components/navigation/sidebar/workspace-navigations";
+import { useWorkspaceNavigation } from "@/hooks/use-workspace-navigation";
+import { trpc } from "@/lib/trpc/client";
+import { useMemo } from "react";
+
+/**
+ * When viewing a specific app, the sidebar resource is the app, so the parent
+ * nav item shows the app name (not the project name). Resolves the app name and
+ * relabels the project-resource parent item.
+ */
+export const useAppData = (baseNavItems: NavItem[], projectId?: string, appId?: string) => {
+  const workspace = useWorkspaceNavigation();
+  const { data: apps } = trpc.deploy.app.list.useQuery(
+    { projectId: projectId ?? "" },
+    { enabled: Boolean(projectId) && Boolean(appId) },
+  );
+
+  const appName = useMemo(
+    () => (appId ? apps?.find((app) => app.id === appId)?.name : undefined),
+    [apps, appId],
+  );
+
+  const enhancedNavItems = useMemo(() => {
+    if (!projectId || !appId || !appName) {
+      return baseNavItems;
+    }
+    const parentHref = `/${workspace.slug}/projects/${projectId}`;
+    return baseNavItems.map((item) =>
+      item.href === parentHref ? { ...item, label: appName, loading: false } : item,
+    );
+  }, [baseNavItems, projectId, appId, appName, workspace.slug]);
+
+  return { enhancedNavItems, appName };
+};

--- a/web/apps/dashboard/components/navigation/sidebar/context-navigation.tsx
+++ b/web/apps/dashboard/components/navigation/sidebar/context-navigation.tsx
@@ -8,6 +8,7 @@ import { useEffect, useMemo } from "react";
 import { NavItems } from "./app-sidebar/components/nav-items";
 import { useApiKeyspace } from "./app-sidebar/hooks/use-api-keyspace";
 import { useApiNavigation } from "./app-sidebar/hooks/use-api-navigation";
+import { useAppData } from "./app-sidebar/hooks/use-app-data";
 import { useNamespaceName } from "./app-sidebar/hooks/use-namespace-name";
 import { useProjectData } from "./app-sidebar/hooks/use-project-data";
 import { useProjectNavigation } from "./app-sidebar/hooks/use-projects-navigation";
@@ -52,7 +53,7 @@ export function ContextNavigation({ context, onResourceNameFetched }: ContextNav
         case "api":
           return createApiNavigation(context.resourceId, workspace, segments, context.keyAuthId);
         case "project":
-          return createProjectNavigation(context.resourceId, workspace, segments);
+          return createProjectNavigation(context.resourceId, workspace, segments, context.appId);
         case "namespace":
           return createNamespaceNavigation(context.resourceId, workspace, segments);
       }
@@ -84,7 +85,16 @@ export function ContextNavigation({ context, onResourceNameFetched }: ContextNav
     context.type === "resource" && context.resourceType === "project"
       ? context.resourceId
       : undefined;
-  const { enhancedNavItems: finalNavItems, projectName } = useProjectData(withApiData, projectId);
+  const { enhancedNavItems: withProjectData, projectName } = useProjectData(withApiData, projectId);
+
+  // When inside a specific app, relabel the project-resource parent with the app name.
+  const appId =
+    context.type === "resource" && context.resourceType === "project" ? context.appId : undefined;
+  const { enhancedNavItems: finalNavItems, appName } = useAppData(
+    withProjectData,
+    projectId,
+    appId,
+  );
 
   // For namespace resources, get namespace name
   const namespaceId =
@@ -98,6 +108,8 @@ export function ContextNavigation({ context, onResourceNameFetched }: ContextNav
     if (onResourceNameFetched) {
       if (apiName) {
         onResourceNameFetched(apiName);
+      } else if (appName) {
+        onResourceNameFetched(appName);
       } else if (projectName) {
         onResourceNameFetched(projectName);
       } else if (namespaceName) {
@@ -107,7 +119,7 @@ export function ContextNavigation({ context, onResourceNameFetched }: ContextNav
         onResourceNameFetched(undefined);
       }
     }
-  }, [apiName, projectName, namespaceName, onResourceNameFetched]);
+  }, [apiName, appName, projectName, namespaceName, onResourceNameFetched]);
 
   return (
     <SidebarGroup className="overflow-hidden">

--- a/web/apps/dashboard/components/navigation/sidebar/navigation-configs.tsx
+++ b/web/apps/dashboard/components/navigation/sidebar/navigation-configs.tsx
@@ -170,62 +170,64 @@ export function createProjectNavigation(
   projectId: string,
   workspace: Workspace,
   segments: string[],
+  appId?: string,
 ): NavItem[] {
-  const basePath = `/${workspace.slug}/projects/${projectId}`;
+  const projectBase = `/${workspace.slug}/projects/${projectId}`;
 
-  const childItems: NavItem[] = [
-    // Removed until we hsve something to place in Overview
-    // {
-    //   icon: Grid,
-    //   href: basePath,
-    //   label: "Overview",
-    //   active: segments.at(2) === projectId && !segments.at(3),
-    // },
+  // Tabs live under the active app. At project home (no appId) the page itself
+  // lists the project's apps, so the sidebar shows only the project parent.
+  const childItems: NavItem[] = appId
+    ? createAppTabs(`${projectBase}/apps/${appId}`, segments)
+    : [];
+
+  return [
     {
       icon: Cube,
-      href: `${basePath}/deployments`,
+      href: projectBase,
+      label: projectId, // Will be replaced with actual project name
+      active: segments.includes(projectId),
+      items: childItems,
+    },
+  ];
+}
+
+function createAppTabs(appBase: string, segments: string[]): NavItem[] {
+  return [
+    {
+      icon: Cube,
+      href: `${appBase}/deployments`,
       label: "Deployments",
       active: segments.includes("deployments"),
     },
     {
       icon: Layers3,
-      href: `${basePath}/logs`,
+      href: `${appBase}/logs`,
       label: "Logs",
       active: segments.includes("logs") && segments.includes("projects"),
     },
     {
       icon: ArrowOppositeDirectionY,
-      href: `${basePath}/requests`,
+      href: `${appBase}/requests`,
       label: "Requests",
       active: segments.includes("requests") && segments.includes("projects"),
     },
     {
       icon: BracketsSquareDots,
-      href: `${basePath}/env-vars`,
+      href: `${appBase}/env-vars`,
       label: "Environment Variables",
       active: segments.includes("env-vars") && segments.includes("projects"),
     },
     {
       icon: ShieldKey,
-      href: `${basePath}/sentinel-policies`,
+      href: `${appBase}/sentinel-policies`,
       label: "Sentinel Policies",
       active: segments.includes("sentinel-policies") && segments.includes("projects"),
     },
     {
       icon: Gear,
-      href: `${basePath}/settings`,
+      href: `${appBase}/settings`,
       label: "Settings",
       active: segments.includes("settings") && segments.includes("projects"),
-    },
-  ];
-
-  return [
-    {
-      icon: Cube,
-      href: basePath,
-      label: projectId, // Will be replaced with actual project name
-      active: segments.includes(projectId),
-      items: childItems,
     },
   ];
 }

--- a/web/apps/dashboard/hooks/use-navigation-context.ts
+++ b/web/apps/dashboard/hooks/use-navigation-context.ts
@@ -12,6 +12,7 @@ export type NavigationContext =
       resourceId: string;
       resourceName?: string;
       keyAuthId?: string; // For API resources, the keyspace/keyAuth ID
+      appId?: string; // For project resources, the active app within the project
     };
 
 /**
@@ -111,6 +112,7 @@ export function useNavigationContext(): NavigationContext {
     const apiId = getParamSingle(params, "apiId");
     const keyAuthId = getParamSingle(params, "keyAuthId");
     const projectId = getParamSingle(params, "projectId");
+    const appId = getParamSingle(params, "appId");
     const namespaceId = getParamSingle(params, "namespaceId");
 
     if (apiId) {
@@ -129,6 +131,7 @@ export function useNavigationContext(): NavigationContext {
         resourceType: "project",
         resourceId: projectId,
         resourceName: undefined,
+        appId,
       };
     }
 


### PR DESCRIPTION
> [!IMPORTANT]
> Unkey is not accepting external pull requests at this time. Pull requests from people outside the Unkey team will not be reviewed or merged.

## What does this PR do?

Adds app-level awareness to the sidebar and breadcrumb navigation when viewing a specific app within a project.

Previously, the sidebar navigation for project resources always showed project-level tabs regardless of whether the user was inside a specific app. Now, when an `appId` is present in the URL, the sidebar displays app-scoped tabs (Deployments, Logs, Requests, Environment Variables, Sentinel Policies, Settings) rooted under the active app's path, and the parent nav item label is replaced with the app's name instead of the project name.

The breadcrumb bar also gains a new "app" crumb between the project and sub-page crumbs, with a quick-nav popover (shortcut `A`) that lets users switch between apps within the same project.

Fixes # (issue)

_If there is not an issue for this, create one first. This is used for tracking purposes and helps us understand why this PR exists._

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Navigate to a project that has multiple apps. Confirm the sidebar parent label shows the active app's name rather than the project name, and that the sidebar tabs link to the correct app-scoped paths.
- Confirm that navigating to the project root (no app selected) shows no app-level tabs in the sidebar.
- In the breadcrumb bar, verify a new app crumb appears between the project crumb and the sub-page crumb, displaying the app name.
- Click the app crumb's quick-nav popover and confirm all apps in the project are listed and each link navigates to the correct app's deployments page.
- Press the `A` shortcut key and confirm the quick-nav popover opens for switching apps.
- Confirm the `onResourceNameFetched` callback reports the app name when inside an app context.

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `mise run fmt`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary