### PR TITLE
fix(dashboard): Point new-navigation banner Learn more at the changelog

### DIFF
--- a/web/apps/dashboard/components/navigation/new-navigation-banner.tsx
+++ b/web/apps/dashboard/components/navigation/new-navigation-banner.tsx
@@ -8,7 +8,7 @@ import { Badge, BannerCard, Button } from "@unkey/ui";
 import { motion, useReducedMotion } from "framer-motion";
 import Link from "next/link";
 
-const DOCS_URL = "https://www.unkey.com/docs/platform/apis/overview";
+const CHANGELOG_URL = "https://www.unkey.com/changelog#2026-06-01";
 
 function NewNavigationIllustration() {
   return (
@@ -71,7 +71,7 @@ export function NewNavigationBanner() {
             </p>
           </div>
           <Button variant="outline" size="sm" asChild className="self-start">
-            <Link href={DOCS_URL} target="_blank" rel="noreferrer">
+            <Link href={CHANGELOG_URL} target="_blank" rel="noreferrer">
               Learn more
             </Link>
           </Button>


### PR DESCRIPTION
## What does this PR do?

The new-navigation banner's "Learn more" button pointed at the docs
(`docs/platform/apis/overview`). This repoints it to the keyspaces changelog
entry (`https://www.unkey.com/changelog#2026-06-01`) so the announcement links to
the announcement. The in-banner "Keyspaces (APIs)" link (to the dashboard section)
is unchanged. Follow-up to #6178, which is already merged.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

Enable the `newNavigation` flag for a workspace that has at least one keyspace,
open the projects page, and click the banner's "Learn more" — it should open
`https://www.unkey.com/changelog#2026-06-01` in a new tab.

Verified locally with `tsc` (clean) and `mise run fmt` (no drift). The full
dashboard `pnpm build` could not run in this fresh worktree — it fails env
validation for `/auth/sso-callback` (missing SSO env vars), which is unrelated to
this one-line change.

Note: used `www.unkey.com` to match the host already used in this file — flag if
the changelog should be on the apex `unkey.com` instead.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary