### PR TITLE
fix: dont select attributes due to slow s3 read

### DIFF
--- a/web/internal/clickhouse/src/runtime-logs.ts
+++ b/web/internal/clickhouse/src/runtime-logs.ts
@@ -1,16 +1,16 @@
+import { Err, Ok, type Result } from "@unkey/error";
 import { z } from "zod";
+import type { QueryError } from "./client/error";
 import type { Querier } from "./client/interface";
 
 const TABLE = "default.runtime_logs_raw_v1";
 
 const MAX_PAGE_SIZE = 1_000;
 
-// The table is PARTITION BY toDate(inserted_at) (for clean TTL drops), so
-// pruning partitions requires constraining inserted_at, not just `time`.
-// This grace window covers ingestion lag between event time and arrival.
+// Table is PARTITION BY toDate(inserted_at); grace covers ingestion lag so
+// partition pruning still hits the right partitions for events near the edge.
 const INGESTION_LAG_GRACE_MS = 2 * 60 * 60 * 1000;
 
-// Fail fast on the server instead of hanging until the HTTP client timeout.
 const MAX_EXECUTION_TIME_SECONDS = 20;
 
 export const runtimeLogsRequestSchema = z.object({
@@ -31,7 +31,6 @@ export const runtimeLogsRequestSchema = z.object({
 
 export type RuntimeLogsRequest = z.infer<typeof runtimeLogsRequestSchema>;
 
-// Public shape + the n+1 limit bump for hasMore + derived inserted_at bounds.
 const runtimeLogsQueryParamsSchema = runtimeLogsRequestSchema.extend({
   limit: z
     .int()
@@ -53,6 +52,19 @@ export const runtimeLog = z.object({
 
 export type RuntimeLog = z.infer<typeof runtimeLog>;
 
+// Read attributes_text (plain String) instead of the dynamic `attributes`
+// JSON column: JSON fans out into ~1k subcolumn files per part, so on CH
+// Cloud cold queries pay ~1k S3 GetObjects for the marks alone.
+const runtimeLogRow = z.object({
+  time: z.int(),
+  severity: z.string(),
+  message: z.string(),
+  deployment_id: z.string(),
+  region: z.string(),
+  k8s_pod_name: z.string(),
+  attributes_text: z.string().nullable(),
+});
+
 export function getRuntimeLogs(ch: Querier) {
   return async (args: RuntimeLogsRequest) => {
     const wheres: string[] = [
@@ -60,7 +72,6 @@ export function getRuntimeLogs(ch: Querier) {
       "project_id = {projectId: String}",
       "app_id = {appId: String}",
       "time BETWEEN {startTime: Int64} AND {endTime: Int64}",
-      // Prunes partitions; see INGESTION_LAG_GRACE_MS.
       `toDate(fromUnixTimestamp64Milli(inserted_at))
             BETWEEN toDate(fromUnixTimestamp64Milli({partitionStartTime: Int64}))
                 AND toDate(fromUnixTimestamp64Milli({partitionEndTime: Int64}))`,
@@ -79,8 +90,7 @@ export function getRuntimeLogs(ch: Querier) {
       wheres.push("region IN {region: Array(String)}");
     }
     if (args.message !== null && args.message !== "") {
-      // lower() on both sides so the ngrambf_v1 skip index on lower(message)
-      // is eligible.
+      // lower() on both sides keeps the ngrambf_v1 skip index eligible.
       wheres.push("positionCaseInsensitive(lower(message), lower({message: String})) > 0");
     }
     if (args.k8sPodNames.length > 0) {
@@ -92,7 +102,7 @@ export function getRuntimeLogs(ch: Querier) {
 
     const filterConditions = wheres.join("\n          AND ");
 
-    // +1 over the requested page size lets us compute hasMore without count(*).
+    // +1 to derive hasMore without a count(*).
     const pageSize = Math.min(Math.max(args.limit, 1), MAX_PAGE_SIZE);
     const fetchLimit = pageSize + 1;
 
@@ -100,7 +110,7 @@ export function getRuntimeLogs(ch: Querier) {
       query: `
         SELECT
           time, severity, message, deployment_id,
-          region, k8s_pod_name, attributes
+          region, k8s_pod_name, attributes_text
         FROM ${TABLE}
         WHERE ${filterConditions}
         ORDER BY time DESC, deployment_id DESC
@@ -110,16 +120,41 @@ export function getRuntimeLogs(ch: Querier) {
           optimize_move_to_prewhere = 1,
           max_execution_time = ${MAX_EXECUTION_TIME_SECONDS}`,
       params: runtimeLogsQueryParamsSchema,
-      schema: runtimeLog,
+      schema: runtimeLogRow,
+    });
+
+    const rowsPromise = logsQuery({
+      ...args,
+      limit: fetchLimit,
+      partitionStartTime: args.startTime - INGESTION_LAG_GRACE_MS,
+      partitionEndTime: args.endTime + INGESTION_LAG_GRACE_MS,
     });
 
     return {
-      logsQuery: logsQuery({
-        ...args,
-        limit: fetchLimit,
-        partitionStartTime: args.startTime - INGESTION_LAG_GRACE_MS,
-        partitionEndTime: args.endTime + INGESTION_LAG_GRACE_MS,
-      }),
+      logsQuery: rowsPromise.then(
+        (res): Result<RuntimeLog[], QueryError> =>
+          res.err ? Err(res.err) : Ok(res.val.map(toRuntimeLog)),
+      ),
     };
   };
+}
+
+function toRuntimeLog(row: z.infer<typeof runtimeLogRow>): RuntimeLog {
+  const { attributes_text, ...rest } = row;
+  return { ...rest, attributes: parseAttributes(attributes_text) };
+}
+
+function parseAttributes(text: string | null): RuntimeLog["attributes"] {
+  if (text === null || text === "" || text === "{}") {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(text);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as RuntimeLog["attributes"];
+    }
+  } catch {
+    // Malformed JSON: drop attributes rather than fail the whole page.
+  }
+  return null;
 }


### PR DESCRIPTION
# Speed up dashboard runtime logs query

Cuts the runtime-logs page from ~5–13s down to sub-second on cold ClickHouse caches. 

## Read `attributes_text` instead of `attributes JSON`

The big cold-cache cliff was the dynamic `attributes JSON` column. JSON type fans out into ~1k subcolumn files per part, so on CH Cloud every cold query pays ~1k S3 GetObject calls just to fetch the subcolumn marks before reading any data.

Same prod query, captured from `system.query_log`:
| col              | cold wall | cold rows | cold bytes | mark misses | s3 gets | s3 ms |
| ---------------- | --------- | --------- | ---------- | ----------- | ------- | ----- |
| `attributes`     | 7448 ms   | 3425      | 1.19 MiB   | 561         | 989     | 50155 |
| `attributes_text`| 572 ms    | 6601      | 4.36 MiB   | 12          | 99      | 7767  |
| `attributes_text`| 21 ms     | 6814      | 7.94 MiB   | 0           | 0       | 0     |

`attributes_text` is already materialized on the table as `toJSONString(attributes)`, so the payload is identical. 
We `JSON.parse` it back into `attributes` in `getRuntimeLogs` so the tRPC response shape is unchanged. 
Malformed JSON falls back to `null` rather than failing the whole page.

## How to test

- Hit the runtime-logs page on a project with real traffic on a cold CH cache (e.g. `/steamsets/projects/proj_Gsd4Xbbxsnrz/logs`); should return in under a second instead of timing out.
- `attributes` column in the UI still renders the same key/value payload (parsed from `attributes_text` server-side).
- EXPLAIN the generated query in CH Cloud, verify `Partition: N/355 parts` with N small.

### Queries to test:

Querylog:
```
SELECT
    event_time,
    query_duration_ms                                   AS wall_ms,
    ProfileEvents['SelectedMarks']                      AS marks_read,
    ProfileEvents['MarkCacheHits']                      AS mark_cache_hits,
    ProfileEvents['MarkCacheMisses']                    AS mark_cache_misses,
    ProfileEvents['S3GetObject']                        AS s3_get_object,
    ProfileEvents['ReadBufferFromS3Microseconds'] / 1000 AS s3_read_ms,
    ProfileEvents['DiskReadElapsedMicroseconds']  / 1000 AS disk_read_ms,
    formatReadableQuantity(read_rows)                   AS read_rows,
    formatReadableSize(read_bytes)                      AS read,
    formatReadableSize(result_bytes)                    AS result,
    query
FROM clusterAllReplicas(default, system.query_log)
WHERE type = 'QueryFinish'
  AND event_time > now() - INTERVAL 1 DAY
  AND wall_ms > 200
  AND query LIKE '%runtime_logs_raw_v1%'
  AND query NOT LIKE '%system.query_log%' AND query NOT LIKE 'INSERT INTO %'
ORDER BY event_time DESC
LIMIT 20
FORMAT Vertical;
```

More fucked up queries:
```
SELECT
    extract(query, 'workspace_id = ''([^'']+)''')      AS workspace_id,
    extract(query, 'project_id = ''([^'']+)''')        AS project_id,
    event_time,
    query_duration_ms                                  AS wall_ms,
    ProfileEvents['SelectedMarks']                     AS marks_read,
    ProfileEvents['MarkCacheMisses']                   AS mark_cache_misses,
    ProfileEvents['S3GetObject']                       AS s3_get_object,
    ProfileEvents['ReadBufferFromS3Microseconds']/1000 AS s3_read_ms,
    formatReadableQuantity(read_rows)                  AS read_rows,
    formatReadableSize(read_bytes)                     AS read,
    query
FROM clusterAllReplicas(default, system.query_log)
WHERE type = 'QueryFinish'
  AND event_time > now() - INTERVAL 7 DAY
  AND query LIKE '%runtime_logs_raw_v1%'
  AND query NOT LIKE '%system.query_log%'
  AND query NOT LIKE 'INSERT INTO%'
  AND query_duration_ms > 1000
ORDER BY workspace_id, query_duration_ms DESC
LIMIT 1 BY workspace_id
FORMAT Vertical;
```


------------


If you want to compare rawly in ch cloud::

```
SELECT time, severity, message, deployment_id, region, k8s_pod_name, attributes
FROM default.runtime_logs_raw_v1
WHERE workspace_id  = 'ws_FSCCHS4FcrNPPn5Qdu5XFyDMQ9r'
  AND project_id    = 'proj_HOwkKOaL'
  AND app_id        = 'app_OIc0Fqr2'
  AND time BETWEEN (toUnixTimestamp(now() - INTERVAL 2 DAY) * 1000)
               AND (toUnixTimestamp(now() - INTERVAL 2 DAY + INTERVAL 6 HOUR) * 1000)
  AND toDate(fromUnixTimestamp64Milli(inserted_at))
      BETWEEN toDate(now() - INTERVAL 2 DAY - INTERVAL 2 HOUR)
          AND toDate(now() - INTERVAL 2 DAY + INTERVAL 8 HOUR)
  AND environment_id IN ['env_u57bi1Y8']
ORDER BY time DESC
LIMIT 51;
```

```
SELECT time, severity, message, deployment_id, region, k8s_pod_name, attributes_text
FROM default.runtime_logs_raw_v1
WHERE workspace_id  = 'ws_FSCCHS4FcrNPPn5Qdu5XFyDMQ9r'
  AND project_id    = 'proj_HOwkKOaL'
  AND app_id        = 'app_OIc0Fqr2'
  AND time BETWEEN (toUnixTimestamp(now() - INTERVAL 4 DAY) * 1000)
               AND (toUnixTimestamp(now() - INTERVAL 4 DAY + INTERVAL 6 HOUR) * 1000)
  AND toDate(fromUnixTimestamp64Milli(inserted_at))
      BETWEEN toDate(now() - INTERVAL 4 DAY - INTERVAL 2 HOUR)
          AND toDate(now() - INTERVAL 4 DAY + INTERVAL 8 HOUR)
  AND environment_id IN ['env_u57bi1Y8']
ORDER BY time DESC
LIMIT 51;
```