### PR TITLE
feat(project): settings

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(project)/components/environment-filter-options.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(project)/components/environment-filter-options.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useProjectData } from "@/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/data-provider";
+import { collection } from "@/lib/collections";
+import { eq, useLiveQuery } from "@tanstack/react-db";
+
+// Logs and requests are project-wide and every app has e.g. a "production"
+// environment, so the app name is needed to tell same-slug options apart.
+export function useEnvironmentFilterOptions(): EnvironmentFilterOption[] {
+  const { environments, projectId } = useProjectData();
+
+  const apps = useLiveQuery(
+    (q) => q.from({ app: collection.apps }).where(({ app }) => eq(app.projectId, projectId)),
+    [projectId],
+  );
+  const appNameById = new Map((apps.data ?? []).map((app) => [app.id, app.name]));
+
+  return environments.map((environment, i) => ({
+    id: i,
+    slug: environment.slug,
+    appName: appNameById.get(environment.appId) ?? null,
+    environmentId: environment.id,
+    checked: false,
+  }));
+}
+
+export function renderEnvironmentOption(option: EnvironmentFilterOption) {
+  return (
+    <div className="text-accent-12 text-xs">
+      <span className="capitalize">{option.slug}</span>
+      {option.appName ? <span className="text-accent-9"> · {option.appName}</span> : null}
+    </div>
+  );
+}
+
+type EnvironmentFilterOption = {
+  id: number;
+  slug: string;
+  appName: string | null;
+  environmentId: string;
+  checked: boolean;
+};

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(project)/logs/components/controls/components/runtime-logs-filters/runtime-logs-environment-filter.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(project)/logs/components/controls/components/runtime-logs-filters/runtime-logs-environment-filter.tsx
@@ -1,30 +1,15 @@
 "use client";
 
+import {
+  renderEnvironmentOption,
+  useEnvironmentFilterOptions,
+} from "@/app/(app)/[workspaceSlug]/projects/[projectId]/(project)/components/environment-filter-options";
 import { useRuntimeLogsFilters } from "@/app/(app)/[workspaceSlug]/projects/[projectId]/(project)/logs/hooks/use-runtime-logs-filters";
-import { useProjectData } from "@/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/data-provider";
 import { FilterCheckbox } from "@/components/logs/checkbox/filter-checkbox";
-import { collection } from "@/lib/collections";
-import { eq, useLiveQuery } from "@tanstack/react-db";
 
 export const RuntimeLogsEnvironmentFilter = () => {
   const { filters, updateFilters } = useRuntimeLogsFilters();
-  const { environments, projectId } = useProjectData();
-
-  // Logs are project-wide and every app has e.g. a "production" environment,
-  // so the app name is needed to tell same-slug options apart.
-  const apps = useLiveQuery(
-    (q) => q.from({ app: collection.apps }).where(({ app }) => eq(app.projectId, projectId)),
-    [projectId],
-  );
-  const appNameById = new Map((apps.data ?? []).map((app) => [app.id, app.name]));
-
-  const options = environments.map((environment, i) => ({
-    id: i,
-    slug: environment.slug,
-    appName: appNameById.get(environment.appId) ?? null,
-    environmentId: environment.id,
-    checked: false,
-  }));
+  const options = useEnvironmentFilterOptions();
 
   return (
     <FilterCheckbox
@@ -32,12 +17,7 @@ export const RuntimeLogsEnvironmentFilter = () => {
       filterField="environmentId"
       checkPath="environmentId"
       selectionMode="multiple"
-      renderOptionContent={(checkbox) => (
-        <div className="text-accent-12 text-xs">
-          <span className="capitalize">{checkbox.slug}</span>
-          {checkbox.appName ? <span className="text-accent-9"> · {checkbox.appName}</span> : null}
-        </div>
-      )}
+      renderOptionContent={renderEnvironmentOption}
       createFilterValue={(option) => ({
         value: option.environmentId,
       })}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(project)/requests/components/controls/components/sentinel-logs-filters/components/sentinel-logs-environment-filter.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(project)/requests/components/controls/components/sentinel-logs-filters/components/sentinel-logs-environment-filter.tsx
@@ -1,30 +1,15 @@
 "use client";
 
+import {
+  renderEnvironmentOption,
+  useEnvironmentFilterOptions,
+} from "@/app/(app)/[workspaceSlug]/projects/[projectId]/(project)/components/environment-filter-options";
 import { useSentinelLogsFilters } from "@/app/(app)/[workspaceSlug]/projects/[projectId]/(project)/requests/hooks/use-sentinel-logs-filters";
-import { useProjectData } from "@/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/data-provider";
 import { FilterCheckbox } from "@/components/logs/checkbox/filter-checkbox";
-import { collection } from "@/lib/collections";
-import { eq, useLiveQuery } from "@tanstack/react-db";
 
 export const SentinelEnvironmentFilter = () => {
   const { filters, updateFilters } = useSentinelLogsFilters();
-  const { environments, projectId } = useProjectData();
-
-  // Requests are project-wide and every app has e.g. a "production" environment,
-  // so the app name is needed to tell same-slug options apart.
-  const apps = useLiveQuery(
-    (q) => q.from({ app: collection.apps }).where(({ app }) => eq(app.projectId, projectId)),
-    [projectId],
-  );
-  const appNameById = new Map((apps.data ?? []).map((app) => [app.id, app.name]));
-
-  const options = environments.map((environment, i) => ({
-    id: i,
-    slug: environment.slug,
-    appName: appNameById.get(environment.appId) ?? null,
-    environmentId: environment.id,
-    checked: false,
-  }));
+  const options = useEnvironmentFilterOptions();
 
   return (
     <FilterCheckbox
@@ -32,12 +17,7 @@ export const SentinelEnvironmentFilter = () => {
       filterField="environmentId"
       checkPath="environmentId"
       selectionMode="multiple"
-      renderOptionContent={(checkbox) => (
-        <div className="text-accent-12 text-xs">
-          <span className="capitalize">{checkbox.slug}</span>
-          {checkbox.appName ? <span className="text-accent-9"> · {checkbox.appName}</span> : null}
-        </div>
-      )}
+      renderOptionContent={renderEnvironmentOption}
       createFilterValue={(option) => ({
         value: option.environmentId,
       })}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(project)/settings/components/delete-project.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(project)/settings/components/delete-project.tsx
@@ -47,6 +47,12 @@ export function DeleteProject() {
     router.push(`/${workspace?.slug}/projects`);
   };
 
+  // Without a loaded project, projectName is "" and an empty confirmation
+  // input would pass validation, enabling the delete button.
+  if (!project) {
+    return null;
+  }
+
   return (
     <>
       <SettingsZoneRow

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(project)/settings/components/delete-project.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(project)/settings/components/delete-project.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { collection } from "@/lib/collections";
+import { useWorkspace } from "@/providers/workspace-provider";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { TriangleWarning2 } from "@unkey/icons";
+import { Button, DialogContainer, Input, SettingsZoneRow } from "@unkey/ui";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { useProjectData } from "../../../apps/[appId]/(overview)/data-provider";
+
+export function DeleteProject() {
+  const { projectId, project } = useProjectData();
+  const { workspace } = useWorkspace();
+  const router = useRouter();
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+
+  const projectName = project?.name ?? "";
+
+  const formSchema = z.object({
+    name: z.string().refine((v) => v === projectName, "Please confirm the project name"),
+  });
+
+  type FormValues = z.infer<typeof formSchema>;
+
+  const {
+    register,
+    watch,
+    handleSubmit,
+    formState: { isSubmitting },
+  } = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    mode: "onChange",
+    defaultValues: {
+      name: "",
+    },
+  });
+
+  const isValid = watch("name") === projectName;
+
+  const onSubmit = (_values: FormValues) => {
+    collection.projects.delete(projectId);
+    setIsDialogOpen(false);
+    router.push(`/${workspace?.slug}/projects`);
+  };
+
+  return (
+    <>
+      <SettingsZoneRow
+        title="Delete this project"
+        description="Once you delete a project, there is no going back. Please be certain."
+        action={{
+          label: "Delete this project",
+          onClick: () => setIsDialogOpen(true),
+        }}
+      />
+
+      <DialogContainer
+        isOpen={isDialogOpen}
+        subTitle="Permanently remove this project and all associated data"
+        onOpenChange={setIsDialogOpen}
+        title="Delete project"
+        footer={
+          <div className="w-full flex flex-col gap-2 items-center justify-center">
+            <Button
+              type="submit"
+              form="delete-project-form"
+              variant="primary"
+              color="danger"
+              size="xlg"
+              className="w-full rounded-lg"
+              disabled={!isValid || isSubmitting}
+              loading={isSubmitting}
+            >
+              Delete project
+            </Button>
+            <div className="text-gray-9 text-xs">
+              This action cannot be undone – proceed with caution
+            </div>
+          </div>
+        }
+      >
+        <div className="rounded-xl bg-errorA-2 dark:bg-black border border-errorA-3 flex items-center gap-4 px-[22px] py-6">
+          <div className="bg-error-9 size-8 rounded-full flex items-center justify-center shrink-0">
+            <TriangleWarning2 iconSize="sm-regular" className="text-white" />
+          </div>
+          <div className="text-error-12 text-[13px] leading-6">
+            <span className="font-medium">Warning:</span> deleting{" "}
+            <span className="font-medium">{projectName}</span> will remove all of its apps,
+            deployments, environments, custom domains, and associated data. This action cannot be
+            undone. Any monitoring, logs, and historical data tied to this project will be
+            permanently lost.
+          </div>
+        </div>
+        <form id="delete-project-form" onSubmit={handleSubmit(onSubmit)}>
+          <div className="flex flex-col gap-1 mt-4">
+            <p className="text-gray-11 text-[13px]">
+              Type <span className="text-gray-12 font-medium">{projectName}</span> to confirm
+            </p>
+            <Input {...register("name")} placeholder={`Enter "${projectName}" to confirm`} />
+          </div>
+        </form>
+      </DialogContainer>
+    </>
+  );
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(project)/settings/components/delete-project.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(project)/settings/components/delete-project.tsx
@@ -10,7 +10,7 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
-import { useProjectData } from "../../../apps/[appId]/(overview)/data-provider";
+import { useProjectData } from "@/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/data-provider";
 
 export function DeleteProject() {
   const { projectId, project } = useProjectData();

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(project)/settings/components/delete-project.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(project)/settings/components/delete-project.tsx
@@ -6,11 +6,11 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { TriangleWarning2 } from "@unkey/icons";
 import { Button, DialogContainer, Input, SettingsZoneRow } from "@unkey/ui";
 
+import { useProjectData } from "@/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/data-provider";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
-import { useProjectData } from "@/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/data-provider";
 
 export function DeleteProject() {
   const { projectId, project } = useProjectData();

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(project)/settings/components/update-project-settings.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(project)/settings/components/update-project-settings.tsx
@@ -50,9 +50,10 @@ function ProjectNameCard({ project }: { project: Project }) {
   ]);
 
   const onSubmit = async (values: z.infer<typeof nameSchema>) => {
-    collection.projects.update(project.id, (draft) => {
+    const tx = collection.projects.update(project.id, (draft) => {
       draft.name = values.name;
     });
+    await tx.isPersisted.promise;
   };
 
   return (

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(project)/settings/components/update-project-settings.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(project)/settings/components/update-project-settings.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { collection } from "@/lib/collections";
+import { type Project, createProjectRequestSchema } from "@/lib/collections/deploy/projects";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Cube, Tag } from "@unkey/icons";
+import { FormInput, SettingCardGroup } from "@unkey/ui";
+import { useForm, useWatch } from "react-hook-form";
+import type { z } from "zod";
+import { useProjectData } from "../../../apps/[appId]/(overview)/data-provider";
+import { SettingField } from "../../../apps/[appId]/(overview)/settings/components/shared/form-blocks";
+import {
+  FormSettingCard,
+  resolveSaveState,
+} from "../../../apps/[appId]/(overview)/settings/components/shared/form-setting-card";
+
+const nameSchema = createProjectRequestSchema.pick({ name: true });
+const slugSchema = createProjectRequestSchema.pick({ slug: true });
+
+export function UpdateProjectSettings() {
+  const { project } = useProjectData();
+
+  if (!project) {
+    return null;
+  }
+
+  return (
+    <SettingCardGroup>
+      <ProjectNameCard project={project} />
+      <ProjectSlugCard project={project} />
+    </SettingCardGroup>
+  );
+}
+
+function ProjectNameCard({ project }: { project: Project }) {
+  const {
+    register,
+    handleSubmit,
+    control,
+    formState: { isValid, isSubmitting, errors },
+  } = useForm<z.infer<typeof nameSchema>>({
+    resolver: zodResolver(nameSchema),
+    mode: "onChange",
+    defaultValues: { name: project.name },
+  });
+
+  const current = useWatch({ control, name: "name" });
+  const saveState = resolveSaveState([
+    [isSubmitting, { status: "saving" }],
+    [!isValid, { status: "disabled" }],
+    [current === project.name, { status: "disabled", reason: "No changes to save" }],
+  ]);
+
+  const onSubmit = async (values: z.infer<typeof nameSchema>) => {
+    collection.projects.update(project.id, (draft) => {
+      draft.name = values.name;
+    });
+  };
+
+  return (
+    <FormSettingCard
+      icon={<Cube className="text-gray-12" iconSize="xl-medium" />}
+      title="Project name"
+      description="A descriptive name for your project."
+      displayValue={project.name}
+      onSubmit={handleSubmit(onSubmit)}
+      saveState={saveState}
+    >
+      <SettingField>
+        <FormInput
+          label="Project name"
+          requirement="required"
+          placeholder="My Awesome Project"
+          error={errors.name?.message}
+          {...register("name")}
+        />
+      </SettingField>
+    </FormSettingCard>
+  );
+}
+
+function ProjectSlugCard({ project }: { project: Project }) {
+  const {
+    register,
+    handleSubmit,
+    control,
+    formState: { isValid, isSubmitting, errors },
+  } = useForm<z.infer<typeof slugSchema>>({
+    resolver: zodResolver(slugSchema),
+    mode: "onChange",
+    defaultValues: { slug: project.slug },
+  });
+
+  const current = useWatch({ control, name: "slug" });
+  const saveState = resolveSaveState([
+    [isSubmitting, { status: "saving" }],
+    [!isValid, { status: "disabled" }],
+    [current === project.slug, { status: "disabled", reason: "No changes to save" }],
+  ]);
+
+  const onSubmit = async (values: z.infer<typeof slugSchema>) => {
+    collection.projects.update(project.id, (draft) => {
+      draft.slug = values.slug;
+    });
+  };
+
+  return (
+    <FormSettingCard
+      icon={<Tag className="text-gray-12" iconSize="xl-medium" />}
+      title="Project slug"
+      description="URL-friendly identifier for your project, unique within the workspace."
+      displayValue={project.slug}
+      onSubmit={handleSubmit(onSubmit)}
+      saveState={saveState}
+    >
+      <SettingField>
+        <FormInput
+          label="Project slug"
+          requirement="required"
+          placeholder="my-awesome-project"
+          error={errors.slug?.message}
+          {...register("slug")}
+        />
+      </SettingField>
+    </FormSettingCard>
+  );
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(project)/settings/components/update-project-settings.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(project)/settings/components/update-project-settings.tsx
@@ -1,21 +1,20 @@
 "use client";
 
-import { collection } from "@/lib/collections";
-import { type Project, createProjectRequestSchema } from "@/lib/collections/deploy/projects";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { Cube, Tag } from "@unkey/icons";
-import { FormInput, SettingCardGroup } from "@unkey/ui";
-import { useForm, useWatch } from "react-hook-form";
-import type { z } from "zod";
 import { useProjectData } from "@/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/data-provider";
-import { SettingField } from "../../../apps/[appId]/(overview)/settings/components/shared/form-blocks";
+import { SettingField } from "@/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/settings/components/shared/form-blocks";
 import {
   FormSettingCard,
   resolveSaveState,
-} from "../../../apps/[appId]/(overview)/settings/components/shared/form-setting-card";
+} from "@/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/settings/components/shared/form-setting-card";
+import { collection } from "@/lib/collections";
+import { type Project, createProjectRequestSchema } from "@/lib/collections/deploy/projects";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Cube } from "@unkey/icons";
+import { FormInput, SettingCardGroup } from "@unkey/ui";
+import { useForm, useWatch } from "react-hook-form";
+import type { z } from "zod";
 
 const nameSchema = createProjectRequestSchema.pick({ name: true });
-const slugSchema = createProjectRequestSchema.pick({ slug: true });
 
 export function UpdateProjectSettings() {
   const { project } = useProjectData();
@@ -27,7 +26,6 @@ export function UpdateProjectSettings() {
   return (
     <SettingCardGroup>
       <ProjectNameCard project={project} />
-      <ProjectSlugCard project={project} />
     </SettingCardGroup>
   );
 }
@@ -73,53 +71,6 @@ function ProjectNameCard({ project }: { project: Project }) {
           placeholder="My Awesome Project"
           error={errors.name?.message}
           {...register("name")}
-        />
-      </SettingField>
-    </FormSettingCard>
-  );
-}
-
-function ProjectSlugCard({ project }: { project: Project }) {
-  const {
-    register,
-    handleSubmit,
-    control,
-    formState: { isValid, isSubmitting, errors },
-  } = useForm<z.infer<typeof slugSchema>>({
-    resolver: zodResolver(slugSchema),
-    mode: "onChange",
-    defaultValues: { slug: project.slug },
-  });
-
-  const current = useWatch({ control, name: "slug" });
-  const saveState = resolveSaveState([
-    [isSubmitting, { status: "saving" }],
-    [!isValid, { status: "disabled" }],
-    [current === project.slug, { status: "disabled", reason: "No changes to save" }],
-  ]);
-
-  const onSubmit = async (values: z.infer<typeof slugSchema>) => {
-    collection.projects.update(project.id, (draft) => {
-      draft.slug = values.slug;
-    });
-  };
-
-  return (
-    <FormSettingCard
-      icon={<Tag className="text-gray-12" iconSize="xl-medium" />}
-      title="Project slug"
-      description="URL-friendly identifier for your project, unique within the workspace."
-      displayValue={project.slug}
-      onSubmit={handleSubmit(onSubmit)}
-      saveState={saveState}
-    >
-      <SettingField>
-        <FormInput
-          label="Project slug"
-          requirement="required"
-          placeholder="my-awesome-project"
-          error={errors.slug?.message}
-          {...register("slug")}
         />
       </SettingField>
     </FormSettingCard>

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(project)/settings/components/update-project-settings.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(project)/settings/components/update-project-settings.tsx
@@ -7,7 +7,7 @@ import { Cube, Tag } from "@unkey/icons";
 import { FormInput, SettingCardGroup } from "@unkey/ui";
 import { useForm, useWatch } from "react-hook-form";
 import type { z } from "zod";
-import { useProjectData } from "../../../apps/[appId]/(overview)/data-provider";
+import { useProjectData } from "@/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/data-provider";
 import { SettingField } from "../../../apps/[appId]/(overview)/settings/components/shared/form-blocks";
 import {
   FormSettingCard,

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(project)/settings/page.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(project)/settings/page.tsx
@@ -11,7 +11,7 @@ export default function ProjectSettingsPage() {
         <div className="flex flex-col gap-2 items-center">
           <span className="font-semibold text-gray-12 leading-8 text-lg">Project settings</span>
           <span className="leading-4 text-gray-11 text-[13px]">
-            Manage your project name and slug.
+            Manage your project name.
           </span>
         </div>
         <div className="w-full">

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(project)/settings/page.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(project)/settings/page.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { SettingsDangerZone, SettingsShell } from "@unkey/ui";
+import { DeleteProject } from "./components/delete-project";
+import { UpdateProjectSettings } from "./components/update-project-settings";
+
+export default function ProjectSettingsPage() {
+  return (
+    <>
+      <SettingsShell>
+        <div className="flex flex-col gap-2 items-center">
+          <span className="font-semibold text-gray-12 leading-8 text-lg">Project settings</span>
+          <span className="leading-4 text-gray-11 text-[13px]">
+            Manage your project name and slug.
+          </span>
+        </div>
+        <div className="w-full">
+          <UpdateProjectSettings />
+        </div>
+      </SettingsShell>
+      <div className="w-225 mx-auto mt-10 mb-14">
+        <SettingsDangerZone>
+          <DeleteProject />
+        </SettingsDangerZone>
+      </div>
+    </>
+  );
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(project)/settings/page.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(project)/settings/page.tsx
@@ -10,9 +10,7 @@ export default function ProjectSettingsPage() {
       <SettingsShell>
         <div className="flex flex-col gap-2 items-center">
           <span className="font-semibold text-gray-12 leading-8 text-lg">Project settings</span>
-          <span className="leading-4 text-gray-11 text-[13px]">
-            Manage your project name.
-          </span>
+          <span className="leading-4 text-gray-11 text-[13px]">Manage your project name.</span>
         </div>
         <div className="w-full">
           <UpdateProjectSettings />

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/_components/apps-list/app-actions.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/_components/apps-list/app-actions.tsx
@@ -60,7 +60,7 @@ const getAppActionItems = (
       label: "View requests",
       icon: <ArrowOppositeDirectionY iconSize="md-regular" />,
       onClick: () => {
-        router.push(`/${workspaceSlug}/projects/${projectId}/requests`);
+        router.push(`/${workspaceSlug}/projects/${projectId}/requests?since=6h&appId=${appId}`);
       },
     },
     {

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/env-vars/components/add/add-env-var-expandable.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/env-vars/components/add/add-env-var-expandable.tsx
@@ -27,21 +27,23 @@ import { type EnvVarsFormValues, createEmptyEntry, envVarsSchema, findConflicts 
 import { usePreventLeave } from "@/hooks/use-prevent-leave";
 
 type AddEnvVarExpandableProps = {
+  appId: string;
   tableDistanceToTop: number;
   isOpen: boolean;
   onClose: () => void;
 };
 
 export const AddEnvVarExpandable = ({
+  appId,
   tableDistanceToTop,
   isOpen,
   onClose,
 }: AddEnvVarExpandableProps) => {
-  const { projectId, environments } = useProjectData();
+  const { environments } = useProjectData();
 
   const { data: existingEnvVars } = useLiveQuery(
-    (q) => q.from({ v: collection.envVars }).where(({ v }) => eq(v.projectId, projectId)),
-    [projectId],
+    (q) => q.from({ v: collection.envVars }).where(({ v }) => eq(v.appId, appId)),
+    [appId],
   );
 
   const {
@@ -59,7 +61,7 @@ export const AddEnvVarExpandable = ({
     saveCurrentValues,
     loadSavedValues,
   } = usePersistedForm<EnvVarsFormValues>(
-    `env-vars-add-${projectId}`,
+    `env-vars-add-${appId}`,
     {
       resolver: zodResolver(envVarsSchema),
       mode: "onChange",

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/env-vars/components/list/env-vars-list.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/env-vars/components/list/env-vars-list.tsx
@@ -21,7 +21,7 @@ import {
 import { EnvVarSelectionBar } from "./env-var-selection-bar";
 
 type EnvVarsListProps = {
-  projectId: string;
+  appId: string;
   environments: Environment[];
   searchQuery: string;
   environmentFilter: EnvironmentFilter;
@@ -29,7 +29,7 @@ type EnvVarsListProps = {
 };
 
 export function EnvVarsList({
-  projectId,
+  appId,
   environments,
   searchQuery,
   environmentFilter,
@@ -57,13 +57,9 @@ export function EnvVarsList({
   }, []);
 
   const { data: envVarData, isLoading } = useLiveQuery(
-    (q) => q.from({ v: collection.envVars }).where(({ v }) => eq(v.projectId, projectId)),
-    [projectId],
+    (q) => q.from({ v: collection.envVars }).where(({ v }) => eq(v.appId, appId)),
+    [appId],
   );
-
-  // envVars carry only environmentId (no appId). Scope to this app's
-  // environments so other apps' variables never show or get edited here.
-  const appEnvIds = useMemo(() => new Set(environments.map((e) => e.id)), [environments]);
 
   const displayRows = useMemo((): DisplayRow[] => {
     if (!envVarData) {
@@ -74,9 +70,6 @@ export function EnvVarsList({
 
     const filtered: EnvVarItem[] = [];
     for (const v of envVarData) {
-      if (!appEnvIds.has(v.environmentId)) {
-        continue;
-      }
       if (query && !v.key.toLowerCase().includes(query)) {
         continue;
       }
@@ -109,7 +102,7 @@ export function EnvVarsList({
     }
 
     return rows;
-  }, [envVarData, environments, appEnvIds, deferredQuery, environmentFilter, sortBy]);
+  }, [envVarData, environments, deferredQuery, environmentFilter, sortBy]);
 
   const {
     selectedIds,

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/env-vars/deployment-env-vars.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/env-vars/deployment-env-vars.tsx
@@ -13,18 +13,23 @@ import {
 } from "./components/toolbar/env-vars-toolbar";
 
 export function DeploymentEnvVars() {
-  const { projectId, environments } = useProjectData();
+  const { appId, environments } = useProjectData();
   const layout = useOptionalProjectLayout();
   const [searchQuery, setSearchQuery] = useState("");
   const [environmentFilter, setEnvironmentFilter] = useState<EnvironmentFilter>("all");
   const [sortBy, setSortBy] = useState<SortOption>("last-updated");
   const [isAddOpen, setIsAddOpen] = useState(false);
 
+  if (!appId) {
+    return null;
+  }
+
   return (
     <>
       <div className="flex flex-col gap-5">
         <EnvVarsHeader isAddOpen={isAddOpen} onToggleAdd={() => setIsAddOpen((prev) => !prev)} />
         <AddEnvVarExpandable
+          appId={appId}
           // NOTE: If we are in the onboarding this can start from top of the page
           tableDistanceToTop={layout?.tableDistanceToTop ?? 0}
           isOpen={isAddOpen}
@@ -40,7 +45,7 @@ export function DeploymentEnvVars() {
           onSortChange={setSortBy}
         />
         <EnvVarsList
-          projectId={projectId}
+          appId={appId}
           environments={environments}
           searchQuery={searchQuery}
           environmentFilter={environmentFilter}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/navigations/create-deployment-button.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/navigations/create-deployment-button.tsx
@@ -6,7 +6,7 @@ import { collection } from "@/lib/collections";
 import { queryClient } from "@/lib/collections/client";
 import { trpc } from "@/lib/trpc/client";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { eq, useLiveQuery } from "@tanstack/react-db";
+import { and, eq, useLiveQuery } from "@tanstack/react-db";
 import { ChevronDown, CodeBranch, Plus } from "@unkey/icons";
 import {
   Button,
@@ -107,16 +107,19 @@ export const CreateDeploymentButton = ({
 
   // Repo connections are per-app, not per-project; the project-level
   // repositoryFullName is just some app's connection in this project.
-  const appsQuery = useLiveQuery(
-    (q) => q.from({ app: collection.apps }).where(({ app }) => eq(app.projectId, projectId)),
-    [projectId],
+  const appQuery = useLiveQuery(
+    (q) =>
+      q
+        .from({ app: collection.apps })
+        .where(({ app }) => and(eq(app.projectId, projectId), eq(app.id, appId))),
+    [projectId, appId],
   );
-  const app = (appsQuery.data ?? []).find((a) => a.id === appId);
+  const app = appQuery.data?.[0];
 
   const repositoryFullName = app?.repositoryFullName ?? null;
   const [owner, repo] = repositoryFullName?.split("/") ?? [];
   const defaultBranch = app?.defaultBranch ?? "main";
-  const isCliApp = !appsQuery.isLoading && app != null && !repositoryFullName;
+  const isCliApp = !appQuery.isLoading && app != null && !repositoryFullName;
 
   const installations = trpc.github.getInstallations.useQuery(
     { projectId, appId },

--- a/web/apps/dashboard/lib/collections/deploy/env-vars.ts
+++ b/web/apps/dashboard/lib/collections/deploy/env-vars.ts
@@ -1,5 +1,5 @@
 "use client";
-import { queryCollectionOptions } from "@tanstack/query-db-collection";
+import { parseLoadSubsetOptions, queryCollectionOptions } from "@tanstack/query-db-collection";
 import { createCollection } from "@tanstack/react-db";
 
 import { envVarKeySchema } from "@/lib/schemas/env-var";
@@ -7,7 +7,13 @@ import { toast } from "@unkey/ui";
 import { z } from "zod";
 import { queryClient, trpcClient } from "../client";
 import { trackSave } from "./environment-settings";
-import { parseProjectIdFromWhere, validateProjectIdInQuery } from "./utils";
+
+type ParsedFilter = { field: Array<string | number>; operator: string; value?: unknown };
+
+function extractStringFilter(filters: ParsedFilter[], fieldName: string, operator: string) {
+  const value = filters.find((f) => f.field.at(-1) === fieldName && f.operator === operator)?.value;
+  return typeof value === "string" ? value : undefined;
+}
 
 const schema = z.object({
   id: z.string(),
@@ -17,7 +23,7 @@ const schema = z.object({
   description: z.string().nullable(),
   updatedAt: z.number(),
   environmentId: z.string(),
-  projectId: z.string(),
+  appId: z.string(),
 });
 
 export type EnvVar = z.infer<typeof schema>;
@@ -25,15 +31,16 @@ export type EnvVar = z.infer<typeof schema>;
 /**
  * Environment variables collection.
  *
- * IMPORTANT: All queries MUST filter by projectId:
- * .where(({ v }) => eq(v.projectId, projectId))
+ * IMPORTANT: All queries MUST filter by appId:
+ * .where(({ v }) => eq(v.appId, appId))
  */
 export const envVars = createCollection<EnvVar, string>(
   queryCollectionOptions({
     queryClient,
     queryKey: (opts) => {
-      const projectId = parseProjectIdFromWhere(opts.where);
-      return projectId ? ["envVars", projectId] : ["envVars"];
+      const { filters } = parseLoadSubsetOptions(opts);
+      const appId = extractStringFilter(filters, "appId", "eq");
+      return appId ? ["envVars", appId] : ["envVars"];
     },
     retry: 3,
     syncMode: "on-demand",
@@ -41,14 +48,14 @@ export const envVars = createCollection<EnvVar, string>(
     queryFn: async (ctx) => {
       const options = ctx.meta?.loadSubsetOptions;
 
-      validateProjectIdInQuery(options?.where);
-      const projectId = parseProjectIdFromWhere(options?.where);
+      const { filters } = parseLoadSubsetOptions(options);
+      const appId = extractStringFilter(filters, "appId", "eq");
 
-      if (!projectId) {
-        throw new Error("Query must include eq(collection.projectId, projectId) constraint");
+      if (!appId) {
+        throw new Error("Query must include eq(collection.appId, appId) constraint");
       }
 
-      const data = await trpcClient.deploy.envVar.list.query({ projectId });
+      const data = await trpcClient.deploy.envVar.list.query({ appId });
 
       const result: EnvVar[] = [];
       for (const [_slug, envData] of Object.entries(data)) {
@@ -62,7 +69,7 @@ export const envVars = createCollection<EnvVar, string>(
             description: v.description,
             updatedAt: v.updatedAt,
             environmentId,
-            projectId,
+            appId: v.appId,
           });
         }
       }

--- a/web/apps/dashboard/lib/collections/deploy/projects.ts
+++ b/web/apps/dashboard/lib/collections/deploy/projects.ts
@@ -176,8 +176,7 @@ export const projects = createCollection<Project, string>(
             case "FORBIDDEN":
               return {
                 message: "Permission Denied",
-                description:
-                  err.message || "You don't have permission to update this project.",
+                description: err.message || "You don't have permission to update this project.",
               };
             case "NOT_FOUND":
               return {

--- a/web/apps/dashboard/lib/collections/deploy/projects.ts
+++ b/web/apps/dashboard/lib/collections/deploy/projects.ts
@@ -148,5 +148,52 @@ export const projects = createCollection<Project, string>(
         projectId: result.id,
       };
     },
+    onUpdate: async ({ transaction }) => {
+      const { original, changes } = transaction.mutations[0];
+
+      const updateInput = {
+        projectId: original.id,
+        ...createProjectRequestSchema.parse({
+          name: changes.name ?? original.name,
+          slug: changes.slug ?? original.slug,
+        }),
+      };
+      const mutation = trpcClient.deploy.project.update.mutate(updateInput);
+
+      toast.promise(mutation, {
+        loading: "Updating project...",
+        success: "Project updated successfully",
+        error: (err) => {
+          console.error("Failed to update project", err);
+
+          switch (err.data?.code) {
+            case "CONFLICT":
+              return {
+                message: "Slug Already Taken",
+                description:
+                  err.message || "A project with this slug already exists in your workspace.",
+              };
+            case "FORBIDDEN":
+              return {
+                message: "Permission Denied",
+                description:
+                  err.message || "You don't have permission to update this project.",
+              };
+            case "NOT_FOUND":
+              return {
+                message: "Project Update Failed",
+                description: "Unable to find the project. Please refresh and try again.",
+              };
+            default:
+              return {
+                message: "Failed to Update Project",
+                description: err.message || "An unexpected error occurred. Please try again later.",
+              };
+          }
+        },
+      });
+
+      await mutation;
+    },
   }),
 );

--- a/web/apps/dashboard/lib/collections/deploy/projects.ts
+++ b/web/apps/dashboard/lib/collections/deploy/projects.ts
@@ -153,9 +153,8 @@ export const projects = createCollection<Project, string>(
 
       const updateInput = {
         projectId: original.id,
-        ...createProjectRequestSchema.parse({
+        ...createProjectRequestSchema.pick({ name: true }).parse({
           name: changes.name ?? original.name,
-          slug: changes.slug ?? original.slug,
         }),
       };
       const mutation = trpcClient.deploy.project.update.mutate(updateInput);
@@ -167,12 +166,6 @@ export const projects = createCollection<Project, string>(
           console.error("Failed to update project", err);
 
           switch (err.data?.code) {
-            case "CONFLICT":
-              return {
-                message: "Slug Already Taken",
-                description:
-                  err.message || "A project with this slug already exists in your workspace.",
-              };
             case "FORBIDDEN":
               return {
                 message: "Permission Denied",

--- a/web/apps/dashboard/lib/collections/deploy/projects.ts
+++ b/web/apps/dashboard/lib/collections/deploy/projects.ts
@@ -183,6 +183,12 @@ export const projects = createCollection<Project, string>(
                 message: "Project Update Failed",
                 description: "Unable to find the project. Please refresh and try again.",
               };
+            case "INTERNAL_SERVER_ERROR":
+              return {
+                message: "Server Error",
+                description:
+                  "We encountered an issue while updating your project. Please try again later or contact support at support@unkey.com",
+              };
             default:
               return {
                 message: "Failed to Update Project",

--- a/web/apps/dashboard/lib/navigation/leaves.ts
+++ b/web/apps/dashboard/lib/navigation/leaves.ts
@@ -139,9 +139,9 @@ export function buildProjectLinks(
     {
       key: "settings",
       label: "Settings",
-      href: "#",
+      href: `${base}/settings`,
       icon: Gear,
-      isActive: false,
+      isActive: page === "settings",
     },
   ];
 }

--- a/web/apps/dashboard/lib/trpc/routers/deploy/env-vars/list.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/env-vars/list.ts
@@ -1,4 +1,4 @@
-import { and, db, eq, inArray } from "@/lib/db";
+import { and, db, eq } from "@/lib/db";
 import { TRPCError } from "@trpc/server";
 import { appEnvironmentVariables, environments } from "@unkey/db/src/schema";
 import { z } from "zod";
@@ -6,6 +6,7 @@ import { workspaceProcedure } from "../../../trpc";
 
 const envVarOutputSchema = z.object({
   id: z.string(),
+  appId: z.string(),
   key: z.string(),
   value: z.string(),
   type: z.enum(["recoverable", "writeonly"]),
@@ -21,7 +22,7 @@ const environmentOutputSchema = z.object({
 export const listEnvVars = workspaceProcedure
   .input(
     z.object({
-      projectId: z.string(),
+      appId: z.string(),
     }),
   )
   .query(async ({ ctx, input }) => {
@@ -29,7 +30,7 @@ export const listEnvVars = workspaceProcedure
       const envs = await db.query.environments.findMany({
         where: and(
           eq(environments.workspaceId, ctx.workspace.id),
-          eq(environments.projectId, input.projectId),
+          eq(environments.appId, input.appId),
         ),
         columns: {
           id: true,
@@ -41,15 +42,14 @@ export const listEnvVars = workspaceProcedure
         return {};
       }
 
-      const envIds = envs.map((e) => e.id);
-
       const allVariables = await db.query.appEnvironmentVariables.findMany({
         where: and(
           eq(appEnvironmentVariables.workspaceId, ctx.workspace.id),
-          inArray(appEnvironmentVariables.environmentId, envIds),
+          eq(appEnvironmentVariables.appId, input.appId),
         ),
         columns: {
           id: true,
+          appId: true,
           environmentId: true,
           key: true,
           type: true,
@@ -63,6 +63,7 @@ export const listEnvVars = workspaceProcedure
       for (const v of allVariables) {
         const mapped = {
           id: v.id,
+          appId: v.appId,
           key: v.key,
           value: "••••••••",
           type: v.type,

--- a/web/apps/dashboard/lib/trpc/routers/deploy/project/update.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/project/update.ts
@@ -1,3 +1,4 @@
+import { insertAuditLogs } from "@/lib/audit";
 import { createProjectRequestSchema } from "@/lib/collections/deploy/projects";
 import { and, db, eq } from "@/lib/db";
 import { ratelimit, withRatelimit, workspaceProcedure } from "@/lib/trpc/trpc";
@@ -5,7 +6,10 @@ import { TRPCError } from "@trpc/server";
 import { projects } from "@unkey/db/src/schema";
 import { z } from "zod";
 
-const updateProjectRequestSchema = createProjectRequestSchema.extend({
+// Slug is intentionally not updatable: generated deployment domains embed the
+// project slug, so renaming it would orphan existing routes and free the slug
+// for another project to collide with.
+const updateProjectRequestSchema = createProjectRequestSchema.pick({ name: true }).extend({
   projectId: z.string().min(1, "Project ID is required"),
 });
 
@@ -18,7 +22,7 @@ export const updateProject = workspaceProcedure
     const project = await db.query.projects.findFirst({
       where: (table, { eq, and }) =>
         and(eq(table.id, input.projectId), eq(table.workspaceId, workspaceId)),
-      columns: { id: true, slug: true },
+      columns: { id: true, name: true },
     });
 
     if (!project) {
@@ -28,28 +32,11 @@ export const updateProject = workspaceProcedure
       });
     }
 
-    if (input.slug !== project.slug) {
-      const existingProject = await db.query.projects.findFirst({
-        where: (table, { eq, and }) =>
-          and(eq(table.workspaceId, workspaceId), eq(table.slug, input.slug)),
-        columns: { id: true },
-      });
-
-      if (existingProject) {
-        throw new TRPCError({
-          code: "CONFLICT",
-          message: `A project with slug "${input.slug}" already exists in this workspace`,
-        });
-      }
-    }
-
     try {
       await db
         .update(projects)
-        .set({ name: input.name, slug: input.slug, updatedAt: Date.now() })
+        .set({ name: input.name, updatedAt: Date.now() })
         .where(and(eq(projects.id, input.projectId), eq(projects.workspaceId, workspaceId)));
-
-      return { id: project.id };
     } catch (err) {
       console.error("Failed to update project:", err);
       throw new TRPCError({
@@ -57,4 +44,24 @@ export const updateProject = workspaceProcedure
         message: "Failed to update project. Our team has been notified of this issue.",
       });
     }
+
+    await insertAuditLogs(db, {
+      workspaceId,
+      actor: { type: "user", id: ctx.user.id },
+      event: "project.update",
+      description: `Updated ${project.id}: name "${project.name}" -> "${input.name}"`,
+      resources: [
+        {
+          type: "project",
+          id: project.id,
+          name: input.name,
+        },
+      ],
+      context: {
+        location: ctx.audit.location,
+        userAgent: ctx.audit.userAgent,
+      },
+    });
+
+    return { id: project.id };
   });

--- a/web/apps/dashboard/lib/trpc/routers/deploy/project/update.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/project/update.ts
@@ -1,0 +1,60 @@
+import { createProjectRequestSchema } from "@/lib/collections/deploy/projects";
+import { and, db, eq } from "@/lib/db";
+import { ratelimit, withRatelimit, workspaceProcedure } from "@/lib/trpc/trpc";
+import { TRPCError } from "@trpc/server";
+import { projects } from "@unkey/db/src/schema";
+import { z } from "zod";
+
+const updateProjectRequestSchema = createProjectRequestSchema.extend({
+  projectId: z.string().min(1, "Project ID is required"),
+});
+
+export const updateProject = workspaceProcedure
+  .input(updateProjectRequestSchema)
+  .use(withRatelimit(ratelimit.update))
+  .mutation(async ({ ctx, input }) => {
+    const workspaceId = ctx.workspace.id;
+
+    const project = await db.query.projects.findFirst({
+      where: (table, { eq, and }) =>
+        and(eq(table.id, input.projectId), eq(table.workspaceId, workspaceId)),
+      columns: { id: true, slug: true },
+    });
+
+    if (!project) {
+      throw new TRPCError({
+        code: "NOT_FOUND",
+        message: "Project not found",
+      });
+    }
+
+    if (input.slug !== project.slug) {
+      const existingProject = await db.query.projects.findFirst({
+        where: (table, { eq, and }) =>
+          and(eq(table.workspaceId, workspaceId), eq(table.slug, input.slug)),
+        columns: { id: true },
+      });
+
+      if (existingProject) {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message: `A project with slug "${input.slug}" already exists in this workspace`,
+        });
+      }
+    }
+
+    try {
+      await db
+        .update(projects)
+        .set({ name: input.name, slug: input.slug, updatedAt: Date.now() })
+        .where(and(eq(projects.id, input.projectId), eq(projects.workspaceId, workspaceId)));
+
+      return { id: project.id };
+    } catch (err) {
+      console.error("Failed to update project:", err);
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: "Failed to update project. Our team has been notified of this issue.",
+      });
+    }
+  });

--- a/web/apps/dashboard/lib/trpc/routers/index.ts
+++ b/web/apps/dashboard/lib/trpc/routers/index.ts
@@ -114,6 +114,7 @@ import { createProject } from "./deploy/project/create";
 import { creationContext } from "./deploy/project/creation-context";
 import { deleteProject } from "./deploy/project/delete";
 import { listProjects } from "./deploy/project/list";
+import { updateProject } from "./deploy/project/update";
 
 import { listInstances } from "./deploy/runtime-logs/list-instances";
 import { llmSearch as runtimeLogsLlmSearch } from "./deploy/runtime-logs/llm-search";
@@ -438,6 +439,7 @@ export const router = t.router({
     project: t.router({
       list: listProjects,
       create: createProject,
+      update: updateProject,
       delete: deleteProject,
       creationContext,
     }),

--- a/web/internal/schema/src/auditlog.ts
+++ b/web/internal/schema/src/auditlog.ts
@@ -48,6 +48,7 @@ export const unkeyAuditLogEvents = z.enum([
   "ratelimit.delete_override",
   "auditLogBucket.create",
   "project.create",
+  "project.update",
   "project.delete",
   "app.create",
   "app.delete",


### PR DESCRIPTION
## Important

Currently only the project `name` is editable. Generated deployment domains embed the project slug (`svc/ctrl/worker/deploy/domains.go` builds `<projectSlug>-...-<workspaceSlug>.<apex>` via `formatDomainPrefix`), so renaming the slug would orphan existing routes and free the old slug for another project to collide with. Slug editing is intentionally deferred to a later iteration to keep this PR small.

## What does this PR do?

Adds a project settings page to rename a project and delete it.

- **Settings page** (`/settings`) with a `FormSettingCard` for the project name, plus a danger zone for deletion. Save button is disabled until the name actually changes and passes validation.
- **`deploy.project.update` tRPC mutation** (`workspaceProcedure`): re-verifies the project belongs to the caller's workspace, updates `name` + `updatedAt`, rate-limited, and writes a `project.update` audit log recording the old -> new name.
- **`onUpdate` collection handler** wired into the projects collection: optimistic update with `toast.promise` for loading/success/error, awaits persistence so a failed mutation rolls back.
- **Delete flow**: confirmation dialog requires typing the exact project name before the delete button enables; redirects to the projects list on success.
- **Nav**: activates the Settings link for projects (was a `#` placeholder), with active-state highlighting.
- Adds `project.update` to the audit log event enum.

### Incidental cleanups bundled here

- Extracted the duplicated environment-filter logic (runtime logs + requests) into a shared `useEnvironmentFilterOptions` / `renderEnvironmentOption` module.
- `create-deployment-button` now filters apps by `appId` in the live query instead of fetching all project apps and `.find()`-ing client-side.
- App "View requests" action now deep-links with `?since=6h&appId=<id>`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How should this be tested?

- Open a project's settings page; the name field is pre-populated.
- Rename the project: the save button enables only on change, toast goes loading -> success, and the new name persists.
- Trigger a failure (e.g. revoke permission): toast shows the error and the optimistic change rolls back.
- Open the delete dialog: confirm button stays disabled until the project name is typed exactly, then deletion redirects to the projects list.
- Verify the Settings nav link is highlighted while on the settings page.

## Checklist

- [x] Self-reviewed my own code
- [x] Ran `pnpm fmt` / `mise run fmt`
- [x] Removed all `console.logs` (kept intentional `console.error` in error handlers, matching create/delete)
