### PR TITLE
chore: delete oci-load

### DIFF
--- a/.mise/tasks/oci-load
+++ b/.mise/tasks/oci-load
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-#MISE description="Build and load OCI images into Docker"
-#MISE depends=["build"]
-set -euo pipefail
-
-bazel run //:oci_load_unkey

--- a/.mise/tasks/test
+++ b/.mise/tasks/test
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 #MISE description="Run the Bazel test suite"
-#MISE depends=["oci-load"]
-
 
 bazel test //...
 


### PR DESCRIPTION
We no longer need it and it fails currently
