### PR TITLE
fix(dashboard): Add usage banner to new sidebar

### DIFF
--- a/web/apps/dashboard/components/navigation/sidebar-v2/index.tsx
+++ b/web/apps/dashboard/components/navigation/sidebar-v2/index.tsx
@@ -6,6 +6,7 @@ import { SidebarLeftHide, SidebarLeftShow } from "@unkey/icons";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@unkey/ui";
 import { TOP_NAV_HEIGHT } from "../top-nav";
 import { SidebarBody } from "./sidebar-body";
+import { UsageBanner } from "./usage-banner";
 
 export const SIDEBAR_WIDTH_VARS: React.CSSProperties & {
   "--sidebar-width": string;
@@ -35,7 +36,8 @@ export function SidebarV2(props: Props) {
       <SidebarContent>
         <SidebarBody />
       </SidebarContent>
-      <SidebarFooter className="mx-0 gap-0 border-t-0 p-2">
+      <SidebarFooter className="mx-0 gap-2 border-t-0 p-2">
+        <UsageBanner />
         <CollapseButton />
       </SidebarFooter>
     </Sidebar>

--- a/web/apps/dashboard/components/navigation/sidebar-v2/usage-banner.tsx
+++ b/web/apps/dashboard/components/navigation/sidebar-v2/usage-banner.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { ProgressCircle } from "@/app/(app)/[workspaceSlug]/settings/billing/components/usage";
+import { getButtonStyles } from "@/components/navigation/sidebar/app-sidebar/components/nav-items/utils";
+import {
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  useSidebar,
+} from "@/components/ui/sidebar";
+import { useWorkspaceNavigation } from "@/hooks/use-workspace-navigation";
+import { trpc } from "@/lib/trpc/client";
+import { useWorkspace } from "@/providers/workspace-provider";
+import Link from "next/link";
+
+export function UsageBanner() {
+  const workspace = useWorkspaceNavigation();
+  const { quotas } = useWorkspace();
+  const { state } = useSidebar();
+  const collapsed = state === "collapsed";
+
+  const usage = trpc.billing.queryUsage.useQuery(undefined, {
+    refetchOnMount: true,
+    refetchInterval: 60 * 1000,
+    // Skip batching to prevent analytics slowdown from blocking core UI
+    trpc: {
+      context: {
+        skipBatch: true,
+      },
+    },
+    retry: 1,
+  });
+
+  const current = usage.data?.billableTotal ?? 0;
+  const max = quotas?.requestsPerMonth;
+
+  if (max === undefined || max === null) {
+    console.error("UsageBanner: quotas.requestsPerMonth is undefined or null");
+    return null;
+  }
+
+  if (max <= 0) {
+    console.error("UsageBanner: quotas.requestsPerMonth must be greater than 0, got:", max);
+    return null;
+  }
+
+  const percentage = (current / max) * 100;
+  const shouldUpgrade = percentage > 90;
+  const href = `/${workspace.slug}/settings/billing`;
+
+  return (
+    <SidebarMenu>
+      <SidebarMenuItem>
+        <SidebarMenuButton asChild tooltip="Usage" className={getButtonStyles(false)}>
+          <Link href={href}>
+            <ProgressCircle
+              value={current}
+              max={max}
+              color={shouldUpgrade ? "#DD4527" : "#0A9B8B"}
+            />
+            <span>Usage {Math.round(percentage).toLocaleString()}%</span>
+            {shouldUpgrade && !collapsed ? (
+              <div className="ml-auto inline-flex h-7 items-center justify-center rounded-md border border-grayA-4 bg-accent-12 px-2 text-sm font-medium text-white drop-shadow-button dark:text-black">
+                Upgrade
+              </div>
+            ) : null}
+          </Link>
+        </SidebarMenuButton>
+      </SidebarMenuItem>
+    </SidebarMenu>
+  );
+}


### PR DESCRIPTION
## What does this PR do?

Adds the usage-period indicator back into the sidebar (behind the `newNavigation` flag).

## Screenshots

<img width="3384" height="2068" alt="CleanShot 2026-06-04 at 14 03 36@2x" src="https://github.com/user-attachments/assets/5ee8ffab-175d-42db-9d05-a25651c99969" />
<img width="3384" height="2068" alt="CleanShot 2026-06-04 at 14 03 27@2x" src="https://github.com/user-attachments/assets/3fb7e5bf-3a03-42fd-a861-2b201354f51d" />


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

Enable the `newNavigation` flag locally, then drive the states via the `ws_local` quota:

1. Normal: set `requests_per_month` high so usage sits under 90% — teal ring, no Upgrade.
2. Over-threshold: `UPDATE quotas SET requests_per_month = 1 WHERE workspace_id = 'ws_local'` — red ring + Upgrade.
3. Hidden: set the quota to 0/NULL — banner does not render.
4. Collapsed: collapse the sidebar — ring only, with a "Usage" tooltip.

Note: usage requires seeded ClickHouse data (`unkey-seed`), otherwise it reads "Usage 0%" regardless of quota.

Notes for reviewers:
- The Upgrade colors use hardcoded hex (`#DD4527` / `#0A9B8B`) rather than design tokens — carried over verbatim from the legacy banner.
- A brief "Usage 0%" flash shows while the query loads; the legacy banner's Suspense wrapper never actually suspended, so this matches prior behavior.
- The percentage label can read over 100% when a workspace is past quota; the ring caps at full.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary