### PR TITLE
fix: restore oci-load task

### DIFF
--- a/.mise/tasks/dev
+++ b/.mise/tasks/dev
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #MISE description="Start dev environment"
-#MISE depends=["install-web"]
+#MISE depends=["install-web", "oci-load"]
 set -euo pipefail
 
 # Make sure you have ./dev/.env.depot populated, or you will get some funny errors.

--- a/.mise/tasks/oci-load
+++ b/.mise/tasks/oci-load
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+#MISE description="Build and load OCI images into Docker"
+set -euo pipefail
+
+bazel run //build/api:load
+bazel run //build/control-api:load
+bazel run //build/control-worker:load
+bazel run //build/frontline:load
+bazel run //build/heimdall:load
+bazel run //build/krane:load
+bazel run //build/vault:load


### PR DESCRIPTION
## Summary

- `.mise/tasks/dashboard` and `.mise/tasks/test` still declare `depends=["oci-load"]`, but the task file was removed in #6356, so `mise run dashboard` fails before doing anything. The old aggregate `//:oci_load_unkey` target also no longer exists.
- Recreate `.mise/tasks/oci-load` to invoke the per-service `:load` targets that exist under `//build/{api,control-api,control-worker,frontline,heimdall,krane,vault}`.
- Add `oci-load` as a dependency of `.mise/tasks/dev` so the Tilt flow gets its images built upfront instead of lazily on first use.

## Test plan

- [ ] `mise run dashboard` brings up the compose stack without `No such image: unkey/vault:dev`
- [ ] `mise run dev` builds images before Tilt starts
- [ ] `mise tasks` lists `oci-load`