### PR TITLE
feat: release tool

### DIFF
--- a/.depot/workflows/service-release.yaml
+++ b/.depot/workflows/service-release.yaml
@@ -29,6 +29,14 @@ jobs:
 
       - name: Verify tag is on main
         run: |
+          version="${GITHUB_REF_NAME#*/}"
+          # Pre-release tags (anything with a SemVer suffix, e.g. -rc.1) may be
+          # cut from any branch so they can be canaried before merging. Stable
+          # tags must still be reachable from origin/main.
+          if [[ "$version" == *-* ]]; then
+            echo "Pre-release tag $GITHUB_REF_NAME; skipping main-branch check."
+            exit 0
+          fi
           git fetch origin main
           commit="$(git rev-list -n 1 "$GITHUB_REF_NAME")"
           git merge-base --is-ancestor "$commit" origin/main
@@ -84,5 +92,5 @@ jobs:
           fi
           gh release create "${GITHUB_REF_NAME}" \
             --title "${{ steps.tag.outputs.service }} ${{ steps.tag.outputs.version }}" \
-            --notes "Image: ${{ steps.tag.outputs.image }}" \
+            --generate-notes \
             "${args[@]}"

--- a/.mise/tasks/release
+++ b/.mise/tasks/release
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+#MISE description="Tag and push service releases (e.g. mise run release -- --version v1.2.3 api vault)"
+set -euo pipefail
+
+go run ./tools/release "$@"

--- a/docs/engineering/contributing/tooling/releases.mdx
+++ b/docs/engineering/contributing/tooling/releases.mdx
@@ -16,10 +16,11 @@ itself is built, see [Builds](./builds).
   (`<service>/vx.y.z`). Services release independently; bumping `api` does
   not force a release of `vault`. Helm charts and promotion pins are also
   per-service for the same reason.
-- **Tags must be on `main`.** Releases ship code that has already passed CI.
-  The release workflow refuses to publish anything for a tag whose commit is
-  not reachable from `origin/main`, so feature branches can never become a
-  release.
+- **Stable tags must be on `main`.** Stable releases ship code that has
+  already passed CI. The release workflow refuses to publish a stable tag
+  whose commit is not reachable from `origin/main`, so a feature branch can
+  never become a stable release. Pre-release tags (e.g. `-rc.1`) are exempt
+  and may be cut from any branch so they can be canaried before merging.
 - **The release workflow does not re-test.** Tests ran when the code merged
   to `main`. The release job's only responsibilities are build, push, and
   cut a GitHub release.
@@ -35,36 +36,56 @@ lives in the
 [infra deploy guide](https://github.com/unkeyed/infra/blob/main/README.md#deploying-unkey-api)
 and picks up from there.
 
-### 1. Tag the service from `main`
+### 1. Tag the service with `mise run release`
 
-Sync `main`, then tag and push:
+`mise run release` is the supported way to cut a release. Everything after the
+`--` is passed to the tool. It fetches `origin/main` and all tags first, so the
+version it picks and the "already exists" check reflect origin rather than your
+local state. It then prints the plan and the commits and PRs merged since the
+last release, asks for confirmation, and pushes one tag at a time (GitHub drops
+tag-push events when more than three land at once).
 
 ```bash
-git fetch origin main
-git checkout main
-git pull --ff-only
-git tag <service>/v<x>.<y>.<z>
-git push origin <service>/v<x>.<y>.<z>
+# preview without tagging anything
+mise run release -- --dry-run api
+
+# patch-bump api and frontline from their latest tags, confirm, push
+mise run release -- api frontline
 ```
 
-Supported service names are `api`, `frontline`, `vault`, `heimdall`,
-`krane`, `control-api`, `control-worker`. Use semantic versioning and never
-reuse a tag.
+Supported services are `api`, `frontline`, `vault`, `heimdall`, `krane`,
+`control-api`, `control-worker`, and `cli`. The version is auto-numbered from
+the service's existing tags (patch bump by default). For a service's very
+first release there is nothing to number from, so pass an explicit version
+(e.g. `api@v0.1.0`).
+
+Common variations:
+
+```bash
+mise run release -- --bump minor api               # minor bump instead of patch
+mise run release -- --rc api                        # next release candidate (-rc.N)
+mise run release -- --version v1.2.3 api vault      # pin an exact version for both
+mise run release -- api@v1.2.3 vault@v0.4.0-rc.1    # per-service explicit versions
+```
+
+`--version` pins an exact version and cannot be combined with
+`--bump`/`--rc`/`--pre`. `--yes` skips the confirmation prompt, `--no-log`
+hides the changelog, and `--no-fetch` skips the origin fetch for offline use.
 
 #### Pre-release tags
 
-Tags with a SemVer pre-release suffix (anything after a hyphen, e.g.
-`api/v1.2.3-beta`, `vault/v0.4.0-rc.1`, `heimdall/v2.0.0-alpha.3`) are
-supported. They build and push the image the same way and produce a GitHub
-release marked as a pre-release so it does not show up as "Latest". Use them
-when you want a real, immutable artifact to canary in infra without claiming
-it as a stable version. The same rules still apply: the tag must be on
-`main`, and tags are immutable, so iterate by bumping the pre-release suffix
-(`-rc.1` -> `-rc.2`) rather than re-pushing.
+`--rc` (shorthand for `--pre rc`) cuts the next release candidate; `--pre
+<label>` does the same for any SemVer pre-release label (`beta`, `alpha`, ...).
+Pre-releases build and push the image the same way but produce a GitHub release
+marked as a pre-release, so it does not show up as "Latest". Use them when you
+want a real, immutable artifact to canary in infra without claiming it as a
+stable version. Unlike stable tags, a pre-release may be cut from any branch,
+so you can canary a feature branch before merging it to `main`. Tags are
+immutable, so iterate by bumping the suffix (`-rc.1` -> `-rc.2`); the tool does
+this automatically on each run.
 
 ```bash
-git tag api/v1.2.3-beta
-git push origin api/v1.2.3-beta
+mise run release -- --rc api     # api/v1.2.3-rc.1, then -rc.2 on the next run
 ```
 
 ### 2. Wait for CI
@@ -90,6 +111,65 @@ Two things to be aware of for per-service releases: helm values live at
 production promotion pin under
 `eks-cluster/promotions/production001/<service>.yaml`.
 
+## Walkthrough: shipping a new `api` minor
+
+A full run from code on `main` to production, canarying a release candidate
+first. Substitute your own service and version.
+
+1. **Preview the plan.** See what the tool would tag without touching origin.
+
+   ```bash
+   mise run release -- --dry-run --bump minor --rc api
+   ```
+
+   It prints the next version (e.g. `api/v1.3.0-rc.1`) and the commits and PRs
+   merged since the last `api` release.
+
+2. **Cut the release candidate.** Drop `--dry-run` and confirm at the prompt.
+
+   ```bash
+   mise run release -- --bump minor --rc api
+   ```
+
+   The tag is pushed and the tool prints the `depot ci run list` command.
+
+3. **Wait for CI and confirm artifacts.** Watch the run, then check the image
+   at `ghcr.io/unkeyed/api:v1.3.0-rc.1` and the GitHub pre-release exist
+   (see [step 2 above](#2-wait-for-ci)).
+
+4. **Canary the RC in infra.** Pin `api` to `v1.3.0-rc.1` and roll it out per
+   the [infra deploy guide](https://github.com/unkeyed/infra/blob/main/README.md#deploying-unkey-api).
+   Watch metrics until you trust it.
+
+5. **Cut the stable tag.** Same commit, now without `--rc`. The bump matches
+   the RC so you get `api/v1.3.0`.
+
+   ```bash
+   mise run release -- --bump minor api
+   ```
+
+6. **Wait for CI, then promote.** Confirm `ghcr.io/unkeyed/api:v1.3.0` and the
+   GitHub release exist, then update the production promotion pin in infra.
+
+If anything looks wrong, never delete or re-push a tag. Fix forward on `main`
+and cut the next patch or RC.
+
+## Tagging by hand
+
+`mise run release` is preferred, but the tags it pushes are ordinary git tags,
+so you can create them directly when the tool is unavailable (for example from
+a machine without the Go toolchain). Sync `main` first, and remember that
+stable tags must be on `main` and that CI drops tag-push events when more than
+three are pushed at once, so push one at a time.
+
+```bash
+git fetch origin main --tags
+git checkout main
+git pull --ff-only
+git tag <service>/v<x>.<y>.<z>
+git push origin <service>/v<x>.<y>.<z>
+```
+
 ## CLI releases
 
 The CLI ships through a separate path because it is an npm package, not a
@@ -98,7 +178,9 @@ which uses GoReleaser to build the CLI binaries and publish to npm. The
 GoReleaser config is scoped to the `cli/` tag prefix, so a service tag
 never produces CLI artifacts and vice versa.
 
+Tag it the same way as a service; only the downstream CI differs:
+
 ```bash
-git tag cli/v1.2.3
-git push origin cli/v1.2.3
+mise run release -- cli              # auto patch-bump from the latest cli tag
+mise run release -- cli@v1.2.3       # or pin an explicit version
 ```

--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -26,6 +26,7 @@ go_test(
     name = "cli_test",
     size = "small",
     srcs = [
+        "enum_flag_test.go",
         "flag_test.go",
         "help_test.go",
         "parser_test.go",

--- a/pkg/cli/command.go
+++ b/pkg/cli/command.go
@@ -83,6 +83,17 @@ func (c *Command) RequireString(name string) string {
 	return sf.Value()
 }
 
+// Enum returns the value of an enum flag by name
+// Returns empty string if flag doesn't exist or isn't an EnumFlag
+func (c *Command) Enum(name string) string {
+	if flag, ok := c.flagMap[name]; ok {
+		if ef, ok := flag.(*EnumFlag); ok {
+			return ef.Value()
+		}
+	}
+	return ""
+}
+
 // Duration returns the value of a duration flag by name
 // Returns 0 if flag doesn't exist or isn't a DurationFlag
 func (c *Command) Duration(name string) time.Duration {

--- a/pkg/cli/docs.go
+++ b/pkg/cli/docs.go
@@ -346,6 +346,8 @@ func (c *Command) getTypeString(flag Flag) string {
 		return "float"
 	case *StringSliceFlag:
 		return "string[]"
+	case *EnumFlag:
+		return "enum"
 	default:
 		return "unknown"
 	}

--- a/pkg/cli/enum_flag_test.go
+++ b/pkg/cli/enum_flag_test.go
@@ -1,0 +1,74 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnumFlag_AcceptsAllowedValue(t *testing.T) {
+	flag := Enum("bump", "bump kind", []string{"patch", "minor", "major"})
+	require.NoError(t, flag.Parse("minor"))
+	require.Equal(t, "minor", flag.Value())
+	require.True(t, flag.IsSet())
+	require.True(t, flag.HasValue())
+}
+
+func TestEnumFlag_RejectsDisallowedValue(t *testing.T) {
+	flag := Enum("bump", "bump kind", []string{"patch", "minor", "major"})
+	err := flag.Parse("sideways")
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrInvalidEnumValue)
+	require.Contains(t, err.Error(), "patch, minor, major")
+}
+
+func TestEnumFlag_Allowed(t *testing.T) {
+	flag := Enum("bump", "bump kind", []string{"patch", "minor", "major"})
+	require.Equal(t, []string{"patch", "minor", "major"}, flag.Allowed())
+}
+
+func TestEnumFlag_Default(t *testing.T) {
+	flag := Enum("bump", "bump kind", []string{"patch", "minor", "major"}, Default("patch"))
+	require.Equal(t, "patch", flag.Value())
+	require.False(t, flag.IsSet())
+	require.True(t, flag.HasValue())
+}
+
+func TestEnumFlag_EnvVar(t *testing.T) {
+	require.NoError(t, os.Setenv("TEST_ENUM", "major"))
+	t.Cleanup(func() { require.NoError(t, os.Unsetenv("TEST_ENUM")) })
+
+	flag := Enum("bump", "bump kind", []string{"patch", "minor", "major"}, EnvVar("TEST_ENUM"))
+	require.Equal(t, "major", flag.Value())
+	require.False(t, flag.IsSet())
+	require.True(t, flag.HasValue())
+}
+
+func TestCommand_EnumAccessorAndHelpLabel(t *testing.T) {
+	var got string
+	cmd := &Command{
+		Name:        "release",
+		Usage:       "test",
+		Description: "",
+		Examples:    []string{},
+		Version:     "",
+		Commands:    []*Command{},
+		AcceptsArgs: false,
+		Aliases:     []string{},
+		Flags: []Flag{
+			Enum("bump", "bump kind", []string{"patch", "minor", "major"}, Default("patch")),
+		},
+		Action: func(_ context.Context, c *Command) error {
+			got = c.Enum("bump")
+			return nil
+		},
+	}
+
+	require.NoError(t, cmd.Run(context.Background(), []string{"release", "--bump", "minor"}))
+	require.Equal(t, "minor", got)
+
+	// The allowed values appear in the rendered flag signature.
+	require.Equal(t, "--bump (patch|minor|major)", cmd.buildFlagName(cmd.Flags[0]))
+}

--- a/pkg/cli/flag.go
+++ b/pkg/cli/flag.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -15,6 +16,7 @@ var (
 	ErrInvalidIntValue   = errors.New("invalid integer value")
 	ErrInvalidInt64Value = errors.New("invalid int64 value")
 	ErrInvalidFloatValue = errors.New("invalid float value")
+	ErrInvalidEnumValue  = errors.New("invalid enum value")
 )
 
 type Flag interface {
@@ -292,6 +294,44 @@ func (f *StringSliceFlag) Value() []string { return f.value }
 // HasValue returns true if the slice is not empty or came from environment
 func (f *StringSliceFlag) HasValue() bool { return len(f.value) > 0 || f.hasEnvValue }
 
+// EnumFlag represents a string flag whose value must be one of a fixed set of
+// allowed values. The allowed values are surfaced in help text and validation
+// errors, so they only need to be declared once.
+type EnumFlag struct {
+	baseFlag
+	value       string   // Current value
+	allowed     []string // Permitted values
+	hasEnvValue bool     // Track if value came from environment
+}
+
+// Parse sets the flag value, rejecting anything outside the allowed set.
+func (f *EnumFlag) Parse(value string) error {
+	if !slices.Contains(f.allowed, value) {
+		return newValidationError(f.name,
+			fmt.Errorf("%w: %q is not one of: %s", ErrInvalidEnumValue, value, strings.Join(f.allowed, ", ")))
+	}
+
+	// Run additional validation if provided
+	if f.validate != nil {
+		if err := f.validate(value); err != nil {
+			return newValidationError(f.name, err)
+		}
+	}
+
+	f.value = value
+	f.set = true
+	return nil
+}
+
+// Value returns the current value
+func (f *EnumFlag) Value() string { return f.value }
+
+// Allowed returns the permitted values, in declaration order
+func (f *EnumFlag) Allowed() []string { return f.allowed }
+
+// HasValue returns true if the flag has any value (from user, env, or default)
+func (f *EnumFlag) HasValue() bool { return f.value != "" || f.hasEnvValue }
+
 // FlagOption represents an option for configuring flags
 type FlagOption func(flag any)
 
@@ -312,6 +352,8 @@ func Required() FlagOption {
 		case *StringSliceFlag:
 			flag.required = true
 		case *DurationFlag:
+			flag.required = true
+		case *EnumFlag:
 			flag.required = true
 		}
 	}
@@ -335,6 +377,8 @@ func EnvVar(envVar string) FlagOption {
 			flag.envVar = envVar
 		case *DurationFlag:
 			flag.envVar = envVar
+		case *EnumFlag:
+			flag.envVar = envVar
 		}
 	}
 }
@@ -356,6 +400,8 @@ func Validate(fn ValidateFunc) FlagOption {
 		case *StringSliceFlag:
 			flag.validate = fn
 		case *DurationFlag:
+			flag.validate = fn
+		case *EnumFlag:
 			flag.validate = fn
 		}
 	}
@@ -407,6 +453,16 @@ func Default(value any) FlagOption {
 				flag.value = v
 			} else {
 				err = fmt.Errorf("default value for duration flag '%s' must be time.Duration, got %T", flag.name, value)
+			}
+		case *EnumFlag:
+			v, ok := value.(string)
+			switch {
+			case !ok:
+				err = fmt.Errorf("default value for enum flag '%s' must be string, got %T", flag.name, value)
+			case !slices.Contains(flag.allowed, v):
+				err = fmt.Errorf("default value %q for enum flag '%s' must be one of: %s", v, flag.name, strings.Join(flag.allowed, ", "))
+			default:
+				flag.value = v
 			}
 		}
 
@@ -650,6 +706,48 @@ func StringSlice(name, usage string, opts ...FlagOption) *StringSliceFlag {
 			flag.value = flag.parseCommaSeparated(envValue)
 			flag.hasEnvValue = true
 			// Don't mark as explicitly set - this is from environment
+		}
+	}
+
+	return flag
+}
+
+// Enum creates a new enum flag whose value must be one of allowed. The allowed
+// values are shown in help text and validation errors, so they are declared in
+// a single place.
+func Enum(name, usage string, allowed []string, opts ...FlagOption) *EnumFlag {
+	// nolint: exhaustruct
+	flag := &EnumFlag{
+		// nolint: exhaustruct
+		baseFlag: baseFlag{
+			name:     name,
+			usage:    usage,
+			required: false, // Default to not required
+		},
+		value:   "", // Default to empty (unset)
+		allowed: allowed,
+	}
+
+	// Apply options
+	for _, opt := range opts {
+		opt(flag)
+	}
+
+	// Check environment variable for default value if specified
+	if flag.envVar != "" {
+		if envValue := os.Getenv(flag.envVar); envValue != "" {
+			if !slices.Contains(flag.allowed, envValue) {
+				_ = Exit(fmt.Sprintf("Environment variable error: %s=%q must be one of: %s",
+					flag.envVar, envValue, strings.Join(flag.allowed, ", ")), 1)
+			}
+			if flag.validate != nil {
+				if err := flag.validate(envValue); err != nil {
+					_ = Exit(fmt.Sprintf("Environment variable error: validation failed for %s=%q: %v",
+						flag.envVar, envValue, err), 1)
+				}
+			}
+			flag.value = envValue
+			flag.hasEnvValue = true
 		}
 	}
 

--- a/pkg/cli/help.go
+++ b/pkg/cli/help.go
@@ -271,7 +271,7 @@ func (c *Command) buildFlagName(flag Flag) string {
 
 // flagTypeLabel returns a human-readable type hint for a flag.
 func flagTypeLabel(flag Flag) string {
-	switch flag.(type) {
+	switch f := flag.(type) {
 	case *StringFlag:
 		return "string"
 	case *BoolFlag:
@@ -286,6 +286,10 @@ func flagTypeLabel(flag Flag) string {
 		return "strings"
 	case *DurationFlag:
 		return "duration"
+	case *EnumFlag:
+		// Surface the allowed values directly in the flag signature, e.g.
+		// --bump (patch|minor|major).
+		return "(" + strings.Join(f.Allowed(), "|") + ")"
 	default:
 		return ""
 	}
@@ -330,6 +334,8 @@ func (c *Command) getEnvVar(flag Flag) string {
 		return f.EnvVar()
 	case *DurationFlag:
 		return f.EnvVar()
+	case *EnumFlag:
+		return f.EnvVar()
 	default:
 		return ""
 	}
@@ -361,6 +367,10 @@ func (c *Command) getDefaultValue(flag Flag) string {
 	case *DurationFlag:
 		if f.HasValue() {
 			return f.Value().String()
+		}
+	case *EnumFlag:
+		if val := f.Value(); val != "" {
+			return fmt.Sprintf(`"%s"`, val)
 		}
 	}
 	return ""

--- a/tools/release/BUILD.bazel
+++ b/tools/release/BUILD.bazel
@@ -1,0 +1,33 @@
+load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+
+go_library(
+    name = "release_lib",
+    srcs = [
+        "changelog.go",
+        "git.go",
+        "main.go",
+        "release.go",
+        "semver.go",
+        "tags.go",
+        "validate.go",
+    ],
+    importpath = "github.com/unkeyed/unkey/tools/release",
+    visibility = ["//visibility:private"],
+    deps = ["//pkg/cli"],
+)
+
+go_binary(
+    name = "release",
+    embed = [":release_lib"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "release_test",
+    srcs = [
+        "main_test.go",
+        "semver_test.go",
+    ],
+    embed = [":release_lib"],
+    deps = ["@com_github_stretchr_testify//require"],
+)

--- a/tools/release/changelog.go
+++ b/tools/release/changelog.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// prRefRe matches the `(#NNNN)` PR reference squash-merges leave in the subject.
+var prRefRe = regexp.MustCompile(`\(#(\d+)\)`)
+
+// changelogLimit caps how many commits are listed in the preview.
+const changelogLimit = 20
+
+// serviceRange is the set of commits a service's release will newly ship,
+// i.e. everything since its last stable tag.
+type serviceRange struct {
+	service  string
+	baseline string
+	hashes   map[string]bool
+}
+
+// printChangelog prints a deduplicated preview of the commits merged since each
+// service's last stable release, annotating each with the services it ships in.
+func printChangelog(tags []plannedTag) {
+	var ranges []serviceRange
+	widest := serviceRange{service: "", baseline: "", hashes: nil}
+	for _, service := range uniqueServices(tags) {
+		latest, found := maxStable(listServiceVersions(service))
+		if !found {
+			fmt.Printf("\n%s: no previous stable release; full history will ship.\n", service)
+			continue
+		}
+		r := serviceRange{
+			service:  service,
+			baseline: service + "/" + formatVersion(latest),
+			hashes:   commitHashes(service + "/" + formatVersion(latest)),
+		}
+		ranges = append(ranges, r)
+		if len(r.hashes) > len(widest.hashes) {
+			widest = r
+		}
+	}
+	if len(ranges) == 0 {
+		return
+	}
+
+	// The widest range (oldest baseline) is a superset on linear history, so
+	// its ordered log gives a stable order covering every commit.
+	out, err := gitOutput("log", "--no-merges", "--pretty=format:%H%x1f%h %s", widest.baseline+"..HEAD")
+	if err != nil || strings.TrimSpace(out) == "" {
+		fmt.Println("\nNo new commits since the last release.")
+		return
+	}
+
+	lines := strings.Split(out, "\n")
+	fmt.Printf("\nChanges since last release (%d unique commit(s)):\n", len(lines))
+	for i, line := range lines {
+		if i == changelogLimit {
+			fmt.Printf("  ... and %d more\n", len(lines)-changelogLimit)
+			break
+		}
+		full, disp, ok := strings.Cut(line, "\x1f")
+		if !ok {
+			continue
+		}
+		svcs := strings.Join(servicesFor(full, ranges), ", ")
+		if url := prURL(disp); url != "" {
+			fmt.Printf("  %s  %s  [%s]\n", disp, url, svcs)
+		} else {
+			fmt.Printf("  %s  [%s]\n", disp, svcs)
+		}
+	}
+}
+
+// prURL returns the GitHub PR URL referenced in a commit subject, if any.
+func prURL(subject string) string {
+	m := prRefRe.FindStringSubmatch(subject)
+	if m == nil {
+		return ""
+	}
+	return "https://github.com/unkeyed/unkey/pull/" + m[1]
+}
+
+// servicesFor returns the services whose release range includes the commit.
+func servicesFor(hash string, ranges []serviceRange) []string {
+	var out []string
+	for _, r := range ranges {
+		if r.hashes[hash] {
+			out = append(out, r.service)
+		}
+	}
+	return out
+}

--- a/tools/release/git.go
+++ b/tools/release/git.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// gitRun runs a git command, streaming output to the terminal.
+func gitRun(args ...string) error {
+	cmd := exec.Command("git", args...)
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// gitOutput runs a git command and returns its trimmed stdout.
+func gitOutput(args ...string) (string, error) {
+	out, err := exec.Command("git", args...).Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// versionCache memoizes parsed tags per service for a single run.
+var versionCache = map[string][]semver{}
+
+// listServiceVersions returns all semantic versions tagged for a service.
+func listServiceVersions(service string) []semver {
+	if cached, ok := versionCache[service]; ok {
+		return cached
+	}
+	out, err := gitOutput("tag", "-l", service+"/v*")
+	if err != nil || out == "" {
+		versionCache[service] = nil
+		return nil
+	}
+
+	var versions []semver
+	for _, line := range strings.Split(out, "\n") {
+		raw := strings.TrimPrefix(strings.TrimSpace(line), service+"/")
+		if v, ok := parseSemver(raw); ok {
+			versions = append(versions, v)
+		}
+	}
+	versionCache[service] = versions
+	return versions
+}
+
+// commitHashes returns the set of full commit hashes in baseline..HEAD.
+func commitHashes(baseline string) map[string]bool {
+	set := map[string]bool{}
+	out, err := gitOutput("log", "--no-merges", "--pretty=format:%H", baseline+"..HEAD")
+	if err != nil || strings.TrimSpace(out) == "" {
+		return set
+	}
+	for _, h := range strings.Split(out, "\n") {
+		if h = strings.TrimSpace(h); h != "" {
+			set[h] = true
+		}
+	}
+	return set
+}
+
+// verifyRepoState enforces CI's rules: stable tags must be on origin/main and
+// no tag may already exist. Pre-release tags are allowed from any branch.
+func verifyRepoState(tags []plannedTag) error {
+	onMain := gitRun("merge-base", "--is-ancestor", "HEAD", "origin/main") == nil
+	if !onMain {
+		if hasStableTag(tags) {
+			return fmt.Errorf("HEAD is not reachable from origin/main; stable release tags must be on main (use --rc/--pre to release a pre-release from a branch)")
+		}
+		branch, _ := gitOutput("rev-parse", "--abbrev-ref", "HEAD")
+		fmt.Printf("note: tagging pre-release(s) from %q (not on main); CI will build but this is not a stable release.\n", branch)
+	}
+
+	for _, t := range tags {
+		if tagExists(t.String()) {
+			return fmt.Errorf("tag %s already exists; tags are immutable, bump the version instead", t)
+		}
+	}
+	return nil
+}
+
+// tagExists checks for an existing tag locally (origin tags arrive via fetch).
+func tagExists(tag string) bool {
+	_, err := gitOutput("rev-parse", "--verify", "--quiet", "refs/tags/"+tag)
+	return err == nil
+}
+
+// createAndPush creates a lightweight tag per entry and pushes each separately.
+// GitHub drops tag push events when more than three are pushed at once, so a
+// combined push would silently fail to trigger CI.
+func createAndPush(tags []plannedTag) error {
+	created := make([]plannedTag, 0, len(tags))
+	for _, t := range tags {
+		// tag.gpgsign=false avoids a signed annotated tag (and its editor
+		// prompt) when the user has tag signing enabled globally.
+		if err := gitRun("-c", "tag.gpgsign=false", "tag", t.String()); err != nil {
+			rollback(created)
+			return fmt.Errorf("creating tag %s: %w", t, err)
+		}
+		created = append(created, t)
+	}
+
+	// One push per tag; see the function doc for why.
+	for _, t := range tags {
+		if err := gitRun("push", "--no-progress", "origin", t.String()); err != nil {
+			fmt.Fprintln(os.Stderr, "push failed; local tags were created but not all pushed.")
+			fmt.Fprintln(os.Stderr, "fix the issue and re-run `git push origin "+strings.Join(tagNames(tags), " ")+"` (one at a time)")
+			return fmt.Errorf("pushing tag %s: %w", t, err)
+		}
+	}
+
+	fmt.Printf("\nPushed %d tag(s). Watch CI:\n", len(tags))
+	fmt.Println("  depot ci run list --repo unkeyed/unkey --trigger push --status running")
+	return nil
+}
+
+// rollback deletes locally created tags after a partial failure.
+func rollback(created []plannedTag) {
+	for _, t := range created {
+		_ = gitRun("tag", "-d", t.String())
+	}
+	if len(created) > 0 {
+		fmt.Fprintln(os.Stderr, "rolled back locally created tags.")
+	}
+}

--- a/tools/release/main.go
+++ b/tools/release/main.go
@@ -1,0 +1,88 @@
+// Command release tags one or more Unkey services and pushes the tags to origin.
+// Pushing a `<service>/vx.y.z` tag drives CI to build the image, push it to
+// GHCR, and cut a GitHub release. Versions are auto-numbered from existing tags
+// unless pinned; --bump selects the stable increment and --rc/--pre cut a
+// pre-release. See docs/engineering/contributing/tooling/releases.mdx.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/unkeyed/unkey/pkg/cli"
+)
+
+func main() {
+	if err := cmd().Run(context.Background(), os.Args); err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		os.Exit(1)
+	}
+}
+
+// cmd builds the release command, its flags, and validation.
+func cmd() *cli.Command {
+	return &cli.Command{
+		Name:        "release",
+		Usage:       "Tag and push Unkey service releases",
+		Description: "Tag one or more services and push the tags to origin. Versions are auto-numbered from existing tags unless pinned explicitly.",
+		Examples: []string{
+			"release api vault                    # auto patch-bump each service",
+			"release --bump minor api             # auto minor-bump",
+			"release --rc api                     # next release candidate (-rc.N)",
+			"release --bump minor --rc api vault  # next minor-version rc",
+			"release --version v1.2.3 api vault   # pin an explicit version",
+			"release api@v1.2.3 vault@v0.4.0-rc.1 # per-service explicit versions",
+			"release --dry-run --rc api           # preview only",
+		},
+		AcceptsArgs: true,
+		Version:     "",
+		Aliases:     []string{},
+		Commands:    []*cli.Command{},
+		Flags: []cli.Flag{
+			cli.String("version", "Pin an exact version (vX.Y.Z[-pre]) for all bare service args", cli.Validate(validSemver)),
+			cli.Enum("bump", "Auto-bump kind when no version is given", bumpKinds(), cli.Default(string(bumpPatch))),
+			cli.String("pre", "Auto-number the next pre-release with this label (rc, beta, alpha, ...)"),
+			cli.Bool("rc", "Shorthand for --pre rc"),
+			cli.Bool("dry-run", "Print the plan without creating or pushing tags"),
+			cli.Bool("yes", "Skip the confirmation prompt"),
+			cli.Bool("no-log", "Don't print the commits/PRs merged since the last release"),
+			cli.Bool("no-fetch", "Skip fetching origin tags before numbering (offline)"),
+			cli.Bool("no-verify", "Skip git safety checks (on-main, tag-exists)"),
+		},
+		Action: action,
+	}
+}
+
+// action translates parsed flags into options and runs the release.
+func action(_ context.Context, cmd *cli.Command) error {
+	if cmd.FlagIsSet("version") && (cmd.FlagIsSet("bump") || cmd.FlagIsSet("rc") || cmd.FlagIsSet("pre")) {
+		return errors.New("--version cannot be combined with --bump/--rc/--pre (it pins an exact version)")
+	}
+	if cmd.Bool("rc") && cmd.FlagIsSet("pre") {
+		return errors.New("--rc and --pre cannot be combined")
+	}
+
+	services := cmd.Args()
+	if len(services) == 0 {
+		return errors.New("no services specified (e.g. `release api vault` or `release --rc api`)")
+	}
+
+	pre := cmd.String("pre")
+	if cmd.Bool("rc") {
+		pre = "rc"
+	}
+
+	return release(options{
+		version:  cmd.String("version"),
+		bump:     bumpKind(cmd.Enum("bump")),
+		pre:      pre,
+		services: services,
+		dryRun:   cmd.Bool("dry-run"),
+		yes:      cmd.Bool("yes"),
+		noFetch:  cmd.Bool("no-fetch"),
+		noLog:    cmd.Bool("no-log"),
+		noVerify: cmd.Bool("no-verify"),
+	})
+}

--- a/tools/release/main_test.go
+++ b/tools/release/main_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHasStableTag(t *testing.T) {
+	stable := plannedTag{service: "api", version: "v1.2.3"}
+	rc := plannedTag{service: "api", version: "v1.2.3-rc.1"}
+
+	require.True(t, hasStableTag([]plannedTag{stable}))
+	require.True(t, hasStableTag([]plannedTag{rc, stable}))
+	require.False(t, hasStableTag([]plannedTag{rc}))
+	require.False(t, hasStableTag([]plannedTag{
+		{service: "vault", version: "v0.4.0-beta"},
+		{service: "api", version: "v1.2.3-rc.2"},
+	}))
+	require.False(t, hasStableTag(nil))
+}
+
+func TestUniqueServices(t *testing.T) {
+	tags := []plannedTag{
+		{service: "api", version: "v1.0.1"},
+		{service: "vault", version: "v0.4.1"},
+		{service: "api", version: "v1.0.1-rc.1"},
+	}
+	require.Equal(t, []string{"api", "vault"}, uniqueServices(tags))
+	require.Nil(t, uniqueServices(nil))
+}
+
+func TestServicesFor(t *testing.T) {
+	ranges := []serviceRange{
+		{service: "api", baseline: "api/v1.0.0", hashes: map[string]bool{"a": true, "b": true}},
+		{service: "vault", baseline: "vault/v0.4.0", hashes: map[string]bool{"b": true}},
+	}
+	require.Equal(t, []string{"api"}, servicesFor("a", ranges))
+	require.Equal(t, []string{"api", "vault"}, servicesFor("b", ranges))
+	require.Nil(t, servicesFor("missing", ranges))
+}

--- a/tools/release/release.go
+++ b/tools/release/release.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// options is the fully-resolved input to a release run.
+type options struct {
+	version  string   // explicit version pinned for all bare service args (optional)
+	bump     bumpKind // stable increment used when auto-numbering
+	pre      string   // pre-release label (e.g. "rc"); empty for a stable release
+	services []string // service args (bare name, service@version, or service/vX.Y.Z)
+	dryRun   bool
+	yes      bool
+	noFetch  bool
+	noLog    bool
+	noVerify bool
+}
+
+// release plans the tags, previews them, and (unless dry-run) creates and
+// pushes them.
+func release(opts options) error {
+	if _, err := gitOutput("rev-parse", "--git-dir"); err != nil {
+		return errors.New("not inside a git repository")
+	}
+
+	// Fetch tags up front so auto-numbering and existence checks see the
+	// authoritative state on origin. The explicit "+refs/tags/*" refspec
+	// force-updates any stale local tags that have diverged from origin; a
+	// plain "--tags" (even with --force, which only covers the named refspec)
+	// is rejected with "would clobber existing tag" and numbering would be
+	// wrong anyway. origin is the source of truth and its tags are immutable.
+	if !opts.noFetch {
+		if err := gitRun("fetch", "--no-progress", "origin", "main", "+refs/tags/*:refs/tags/*"); err != nil {
+			return fmt.Errorf("fetching origin/main and tags: %w", err)
+		}
+	}
+
+	tags, err := buildTags(opts)
+	if err != nil {
+		return err
+	}
+
+	if !opts.noVerify {
+		if err := verifyRepoState(tags); err != nil {
+			return err
+		}
+	}
+
+	head, err := gitOutput("rev-parse", "--short", "HEAD")
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("About to tag commit %s with:\n", head)
+	for _, t := range tags {
+		fmt.Printf("  - %s\n", t)
+	}
+	if !opts.noLog {
+		printChangelog(tags)
+	}
+
+	if opts.dryRun {
+		fmt.Println("\ndry-run: no tags created or pushed.")
+		return nil
+	}
+	if !opts.yes && !confirm() {
+		fmt.Println("aborted.")
+		return nil
+	}
+
+	return createAndPush(tags)
+}
+
+// confirm prompts the user to proceed and returns true only on an affirmative
+// answer.
+func confirm() bool {
+	fmt.Print("\nProceed? [y/N] ")
+	line, err := bufio.NewReader(os.Stdin).ReadString('\n')
+	if err != nil {
+		return false
+	}
+	answer := strings.ToLower(strings.TrimSpace(line))
+	return answer == "y" || answer == "yes"
+}

--- a/tools/release/semver.go
+++ b/tools/release/semver.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// semver is a minimal SemVer representation good enough for ordering release
+// tags. pre holds the dot-separated pre-release identifiers and is empty for a
+// stable release. Build metadata is intentionally not modelled.
+type semver struct {
+	major int
+	minor int
+	patch int
+	pre   []string
+}
+
+// parseSemver parses `vMAJOR.MINOR.PATCH[-pre]`. The leading `v` is required to
+// match the repo's tag convention.
+func parseSemver(s string) (semver, bool) {
+	zero := semver{major: 0, minor: 0, patch: 0, pre: nil}
+	if !strings.HasPrefix(s, "v") {
+		return zero, false
+	}
+	s = strings.TrimPrefix(s, "v")
+
+	// Drop build metadata, if any.
+	if i := strings.Index(s, "+"); i >= 0 {
+		s = s[:i]
+	}
+
+	core := s
+	var pre []string
+	if i := strings.Index(s, "-"); i >= 0 {
+		core = s[:i]
+		if rest := s[i+1:]; rest != "" {
+			pre = strings.Split(rest, ".")
+		}
+	}
+
+	parts := strings.Split(core, ".")
+	if len(parts) != 3 {
+		return zero, false
+	}
+	maj, err1 := strconv.Atoi(parts[0])
+	min, err2 := strconv.Atoi(parts[1])
+	pat, err3 := strconv.Atoi(parts[2])
+	if err1 != nil || err2 != nil || err3 != nil {
+		return zero, false
+	}
+	return semver{major: maj, minor: min, patch: pat, pre: pre}, true
+}
+
+func formatVersion(v semver) string {
+	out := fmt.Sprintf("v%d.%d.%d", v.major, v.minor, v.patch)
+	if len(v.pre) > 0 {
+		out += "-" + strings.Join(v.pre, ".")
+	}
+	return out
+}
+
+// sameBase reports whether two versions share the same MAJOR.MINOR.PATCH.
+func (v semver) sameBase(o semver) bool {
+	return v.major == o.major && v.minor == o.minor && v.patch == o.patch
+}
+
+// cmp orders two versions per the SemVer precedence rules. A stable release
+// outranks any pre-release of the same base version.
+func cmp(a, b semver) int {
+	if c := intCmp(a.major, b.major); c != 0 {
+		return c
+	}
+	if c := intCmp(a.minor, b.minor); c != 0 {
+		return c
+	}
+	if c := intCmp(a.patch, b.patch); c != 0 {
+		return c
+	}
+	if len(a.pre) == 0 && len(b.pre) == 0 {
+		return 0
+	}
+	if len(a.pre) == 0 {
+		return 1
+	}
+	if len(b.pre) == 0 {
+		return -1
+	}
+	n := len(a.pre)
+	if len(b.pre) < n {
+		n = len(b.pre)
+	}
+	for i := 0; i < n; i++ {
+		ai, an, aNum := identifier(a.pre[i])
+		bi, bn, bNum := identifier(b.pre[i])
+		switch {
+		case aNum && bNum:
+			if c := intCmp(an, bn); c != 0 {
+				return c
+			}
+		case aNum:
+			return -1 // numeric identifiers rank below alphanumeric
+		case bNum:
+			return 1
+		default:
+			if c := strings.Compare(ai, bi); c != 0 {
+				return c
+			}
+		}
+	}
+	return intCmp(len(a.pre), len(b.pre))
+}
+
+func identifier(s string) (str string, num int, isNum bool) {
+	if n, err := strconv.Atoi(s); err == nil {
+		return s, n, true
+	}
+	return s, 0, false
+}
+
+func intCmp(a, b int) int {
+	switch {
+	case a < b:
+		return -1
+	case a > b:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// maxStable returns the highest stable (non-pre-release) version in the set.
+func maxStable(versions []semver) (semver, bool) {
+	best := semver{major: 0, minor: 0, patch: 0, pre: nil}
+	found := false
+	for _, v := range versions {
+		if len(v.pre) > 0 {
+			continue
+		}
+		if !found || cmp(v, best) > 0 {
+			best = v
+			found = true
+		}
+	}
+	return best, found
+}
+
+// bumpVersion increments a stable version by the given kind, clearing any
+// pre-release identifiers.
+func bumpVersion(v semver, kind bumpKind) semver {
+	v.pre = nil
+	switch kind {
+	case bumpMajor:
+		v.major++
+		v.minor = 0
+		v.patch = 0
+	case bumpMinor:
+		v.minor++
+		v.patch = 0
+	case bumpPatch:
+		v.patch++
+	default:
+		v.patch++
+	}
+	return v
+}
+
+// nextPreNumber returns the next pre-release number for the given base version
+// and label (e.g. for label "rc" with an existing -rc.2 it returns 3; with no
+// matching pre-release it returns 1).
+func nextPreNumber(versions []semver, target semver, label string) int {
+	highest := -1
+	for _, v := range versions {
+		if !v.sameBase(target) || len(v.pre) == 0 || v.pre[0] != label {
+			continue
+		}
+		num := 0
+		if len(v.pre) >= 2 {
+			if n, err := strconv.Atoi(v.pre[1]); err == nil {
+				num = n
+			}
+		}
+		if num > highest {
+			highest = num
+		}
+	}
+	if highest < 0 {
+		return 1
+	}
+	return highest + 1
+}

--- a/tools/release/semver_test.go
+++ b/tools/release/semver_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func mustParse(t *testing.T, s string) semver {
+	t.Helper()
+	v, ok := parseSemver(s)
+	require.True(t, ok, "parse %q", s)
+	return v
+}
+
+func TestParseAndFormatRoundTrip(t *testing.T) {
+	for _, s := range []string{"v1.2.3", "v0.0.1", "v10.20.30", "v1.2.3-rc.1", "v2.0.0-alpha.3", "v0.4.0-beta"} {
+		require.Equal(t, s, formatVersion(mustParse(t, s)))
+	}
+}
+
+func TestParseRejectsInvalid(t *testing.T) {
+	for _, s := range []string{"1.2.3", "v1.2", "vx.y.z", "v1.2.3.4", ""} {
+		_, ok := parseSemver(s)
+		require.False(t, ok, "expected %q to be invalid", s)
+	}
+}
+
+func TestValidSemver(t *testing.T) {
+	valid := []string{
+		"v1.2.3", "v0.0.1", "v10.20.30",
+		"v1.2.3-rc.1", "v0.4.0-beta", "v2.0.0-alpha.3",
+		"v1.0.0-alpha-beta", // hyphen inside an identifier is legal (SemVer §9)
+		"v1.0.0-rc--1",      // consecutive hyphens form one valid identifier
+	}
+	for _, s := range valid {
+		require.NoError(t, validSemver(s), "expected %q to be valid", s)
+	}
+
+	invalid := []string{
+		"1.2.3", "v1.2", "v1.2.3.4", "",
+		"v1.2.3-rc..1", // empty identifier from consecutive dots
+		"v1.2.3-rc.",   // trailing dot leaves an empty identifier
+		"v1.2.3-.rc",   // leading dot leaves an empty identifier
+	}
+	for _, s := range invalid {
+		require.Error(t, validSemver(s), "expected %q to be invalid", s)
+	}
+}
+
+func TestCmpPrecedence(t *testing.T) {
+	require.Equal(t, 1, cmp(mustParse(t, "v1.2.4"), mustParse(t, "v1.2.3")))
+	require.Equal(t, 1, cmp(mustParse(t, "v1.3.0"), mustParse(t, "v1.2.9")))
+	// Stable outranks a pre-release of the same base.
+	require.Equal(t, 1, cmp(mustParse(t, "v1.2.3"), mustParse(t, "v1.2.3-rc.1")))
+	// Higher rc number is greater.
+	require.Equal(t, 1, cmp(mustParse(t, "v1.2.3-rc.2"), mustParse(t, "v1.2.3-rc.1")))
+	// alpha < beta < rc lexically.
+	require.Equal(t, -1, cmp(mustParse(t, "v1.0.0-alpha"), mustParse(t, "v1.0.0-beta")))
+}
+
+func TestMaxStableIgnoresPreReleases(t *testing.T) {
+	versions := []semver{
+		mustParse(t, "v1.2.3"),
+		mustParse(t, "v1.3.0-rc.5"),
+		mustParse(t, "v1.2.2"),
+	}
+	latest, ok := maxStable(versions)
+	require.True(t, ok)
+	require.Equal(t, "v1.2.3", formatVersion(latest))
+}
+
+func TestMaxStableNoneFound(t *testing.T) {
+	_, ok := maxStable([]semver{mustParse(t, "v1.0.0-rc.1")})
+	require.False(t, ok)
+}
+
+func TestBumpVersion(t *testing.T) {
+	base := mustParse(t, "v1.2.3")
+	require.Equal(t, "v1.2.4", formatVersion(bumpVersion(base, "patch")))
+	require.Equal(t, "v1.3.0", formatVersion(bumpVersion(base, "minor")))
+	require.Equal(t, "v2.0.0", formatVersion(bumpVersion(base, "major")))
+	// Default kind is patch.
+	require.Equal(t, "v1.2.4", formatVersion(bumpVersion(base, "")))
+	// Pre-release identifiers are cleared.
+	require.Equal(t, "v1.2.4", formatVersion(bumpVersion(mustParse(t, "v1.2.3-rc.1"), "patch")))
+}
+
+func TestNextPreNumber(t *testing.T) {
+	target := mustParse(t, "v1.2.4")
+	// No existing rc -> 1.
+	require.Equal(t, 1, nextPreNumber(nil, target, "rc"))
+	// Existing rc.2 -> 3.
+	versions := []semver{mustParse(t, "v1.2.4-rc.1"), mustParse(t, "v1.2.4-rc.2")}
+	require.Equal(t, 3, nextPreNumber(versions, target, "rc"))
+	// rc tags for a different base are ignored.
+	other := []semver{mustParse(t, "v1.3.0-rc.5")}
+	require.Equal(t, 1, nextPreNumber(other, target, "rc"))
+	// Different label is ignored.
+	require.Equal(t, 1, nextPreNumber([]semver{mustParse(t, "v1.2.4-beta.4")}, target, "rc"))
+	// Bare label with no number counts as 0 -> next 1.
+	require.Equal(t, 1, nextPreNumber([]semver{mustParse(t, "v1.2.4-rc")}, target, "rc"))
+}

--- a/tools/release/tags.go
+++ b/tools/release/tags.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// plannedTag is a service/version pair to be tagged.
+type plannedTag struct {
+	service string
+	version string
+}
+
+func (p plannedTag) String() string {
+	return fmt.Sprintf("%s/%s", p.service, p.version)
+}
+
+// isPreRelease reports whether the tag is a SemVer pre-release (e.g. -rc.1).
+func (p plannedTag) isPreRelease() bool {
+	return strings.Contains(p.version, "-")
+}
+
+// buildTags turns the service args into a validated, de-duplicated list of
+// tags, auto-numbering versions from existing tags where none is given.
+func buildTags(opts options) ([]plannedTag, error) {
+	seen := map[string]bool{}
+	tags := make([]plannedTag, 0, len(opts.services))
+
+	for _, arg := range opts.services {
+		service, version := splitArg(arg)
+		if version == "" {
+			version = opts.version
+		}
+
+		if err := validateService(service); err != nil {
+			return nil, err
+		}
+
+		if version == "" {
+			// No explicit version: auto-number from the service's tags.
+			computed, err := nextVersion(service, opts.bump, opts.pre)
+			if err != nil {
+				return nil, err
+			}
+			version = computed
+		}
+
+		if err := validSemver(version); err != nil {
+			return nil, fmt.Errorf("invalid version %q for %s: %w", version, service, err)
+		}
+
+		tag := plannedTag{service: service, version: version}
+		if seen[tag.String()] {
+			continue
+		}
+		seen[tag.String()] = true
+		tags = append(tags, tag)
+	}
+	return tags, nil
+}
+
+// splitArg parses `service`, `service@version`, or `service/vx.y.z`.
+func splitArg(arg string) (service, version string) {
+	if s, v, ok := strings.Cut(arg, "@"); ok {
+		return s, v
+	}
+	if s, v, ok := strings.Cut(arg, "/"); ok {
+		return s, v
+	}
+	return arg, ""
+}
+
+// nextVersion computes the next version string for a service from its existing
+// tags. bump selects the stable increment; pre, when set, produces the next
+// pre-release (e.g. -rc.N) for that bumped version.
+func nextVersion(service string, bump bumpKind, pre string) (string, error) {
+	versions := listServiceVersions(service)
+	latest, ok := maxStable(versions)
+	if !ok {
+		return "", fmt.Errorf("no existing version tags for %q; pass an explicit version for the first release (e.g. %s@v0.1.0)", service, service)
+	}
+
+	target := bumpVersion(latest, bump)
+	if pre == "" {
+		return formatVersion(target), nil
+	}
+
+	next := nextPreNumber(versions, target, pre)
+	target.pre = []string{pre, strconv.Itoa(next)}
+	return formatVersion(target), nil
+}
+
+// tagNames returns the string form of each tag.
+func tagNames(tags []plannedTag) []string {
+	names := make([]string, len(tags))
+	for i, t := range tags {
+		names[i] = t.String()
+	}
+	return names
+}
+
+// hasStableTag reports whether any planned tag is a stable (non-pre-release)
+// version.
+func hasStableTag(tags []plannedTag) bool {
+	for _, t := range tags {
+		if !t.isPreRelease() {
+			return true
+		}
+	}
+	return false
+}
+
+// uniqueServices returns the distinct services in the planned tags, preserving
+// first-seen order.
+func uniqueServices(tags []plannedTag) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, t := range tags {
+		if !seen[t.service] {
+			seen[t.service] = true
+			out = append(out, t.service)
+		}
+	}
+	return out
+}

--- a/tools/release/validate.go
+++ b/tools/release/validate.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"fmt"
+	"regexp"
+	"slices"
+	"strings"
+)
+
+// bumpKind is the stable-version increment applied when auto-numbering.
+type bumpKind string
+
+const (
+	bumpPatch bumpKind = "patch"
+	bumpMinor bumpKind = "minor"
+	bumpMajor bumpKind = "major"
+)
+
+// bumpKinds lists the accepted --bump values, used for flag validation.
+func bumpKinds() []string {
+	return []string{string(bumpPatch), string(bumpMinor), string(bumpMajor)}
+}
+
+// supportedServices is the set of service names that map to a release tag
+// namespace. Keep this in sync with releases.mdx and the CI workflows.
+var supportedServices = []string{
+	"api",
+	"frontline",
+	"vault",
+	"heimdall",
+	"krane",
+	"control-api",
+	"control-worker",
+	"cli",
+}
+
+// semverPattern matches `vMAJOR.MINOR.PATCH` with an optional SemVer
+// pre-release suffix (e.g. v1.2.3, v1.2.3-rc.1, v0.4.0-beta, v2.0.0-alpha.3).
+// The suffix is one or more dot-separated identifiers, each non-empty and made
+// of [0-9A-Za-z-] (hyphens are legal inside an identifier per SemVer §9). The
+// per-identifier `+` rejects empty identifiers, so `-rc..1` or a trailing `-rc.`
+// are refused before parseSemver can split them into an empty-string element.
+var semverPattern = regexp.MustCompile(`^v\d+\.\d+\.\d+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$`)
+
+// validSemver is a cli validator for version strings.
+func validSemver(value string) error {
+	if !semverPattern.MatchString(value) {
+		return fmt.Errorf("expected vMAJOR.MINOR.PATCH with optional -prerelease (e.g. v1.2.3 or v1.2.3-rc.1)")
+	}
+	return nil
+}
+
+// validateService reports whether a service name is releasable.
+func validateService(service string) error {
+	if slices.Contains(supportedServices, service) {
+		return nil
+	}
+	return fmt.Errorf("unsupported service %q (supported: %s)", service, strings.Join(supportedServices, ", "))
+}


### PR DESCRIPTION
small utility that allows us to tag new services.

example usage:

```
mise run release -- api frontline control-api control-worker
```

also allows us to do pre-releases from branches that are not main.