### PR TITLE
chore: add nuke cleanup task

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -8,13 +8,13 @@ common --show_timestamps
 # Caching - Critical for performance
 # ============================================================
 # Persist external repository downloads (Go modules, etc.)
-common --repository_cache=~/.cache/bazel-repo
+common --repository_cache=./.cache/bazel-repo
 
 # Persist build artifacts across clean/workspaces
-common --disk_cache=~/.cache/bazel-disk
+common --disk_cache=./.cache/bazel-disk
 common --experimental_disk_cache_gc_max_size=100G
 
- ============================================================
+# ============================================================
 # Build & Test performance
 # ============================================================
 # Increase action parallelism

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 rm
 
 .turbo
+.cache/
 node_modules
 dist
 .next

--- a/.mise/tasks/nuke
+++ b/.mise/tasks/nuke
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#MISE description="Delete local Docker, Bazel, Next.js, and Turborepo caches"
+set -euo pipefail
+
+read -r -p "Delete local Docker data? [Y/n] " delete_docker
+if [[ ! "${delete_docker}" =~ ^[Nn]$ ]]; then
+  docker --context default builder prune --all --force
+  docker --context default system prune --all --force --volumes
+fi
+
+read -r -p "Delete Bazel, Next.js, and Turborepo caches? [Y/n] " delete_caches
+if [[ ! "${delete_caches}" =~ ^[Nn]$ ]]; then
+  bazel shutdown || true
+  bazel clean --expunge || true
+  rm -rf ./.cache
+
+  rm -rf ./**/.turbo
+  rm -rf ./**/.next
+fi


### PR DESCRIPTION
Tired of cleaning docker images or bazel caches?
just run `mise run nuke`