### PR TITLE
fix(dashboard): Stop API overview charts oscillating

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/_overview/components/charts/index.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/_overview/components/charts/index.tsx
@@ -86,7 +86,7 @@ export const KeysOverviewLogsCharts = ({
 
   return (
     <div className="flex flex-col md:flex-row w-full md:h-[320px]">
-      <div className="w-full md:w-1/2 border-r border-gray-4 max-md:h-72">
+      <div className="w-full md:w-1/2 min-w-0 overflow-hidden border-r border-gray-4 max-md:h-72">
         <OverviewBarChart
           data={verificationTimeseries}
           isLoading={verificationIsLoading}
@@ -111,7 +111,7 @@ export const KeysOverviewLogsCharts = ({
           granularity={verificationGranularity}
         />
       </div>
-      <div className="w-full md:w-1/2 max-md:h-72">
+      <div className="w-full md:w-1/2 min-w-0 overflow-hidden max-md:h-72">
         <OverviewAreaChart
           data={activeKeysTimeseries}
           isLoading={activeKeysIsLoading}


### PR DESCRIPTION
## What does this PR do?

The API overview page (`/[workspaceSlug]/apis/[apiId]`) had its charts, header, and surrounding layout visibly oscillating. The two recharts `ResponsiveContainer`s draw their wrapper a few pixels wider than their box mid-resize. That overflow reached the page shell's `overflow-x-auto` container and toggled a horizontal scrollbar, which pushed the scroll parent past its height and toggled its vertical scrollbar, which shrank the charts and removed the overflow, repeating endlessly (~2000 DOM mutations/sec).

The fix adds `min-w-0 overflow-hidden` to each chart's flex cell so the transient over-draw stays inside its own box and never reaches the scrolling ancestors. This is the standard flexbox + responsive-chart pattern: `min-w-0` lets the flex child shrink below its content width, and `overflow-hidden` clips the chart to its cell. Deliberately avoided `scrollbar-gutter: stable`, which only masks the symptom and would touch the shared app layout shell.

## Demo

Before:

https://github.com/user-attachments/assets/20643c78-9802-4fae-822a-c96fde693f7c

Afrer:

https://github.com/user-attachments/assets/ca23ea1e-4ba6-4cbe-a395-a975b09c8681

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

1. Open an API overview page with chart data, e.g. `/[workspaceSlug]/apis/[apiId]`.
2. Confirm the charts and header are static — no width jitter or scrollbar flicker.
3. Hover a bar to confirm the tooltip (including the full outcome breakdown) renders without being clipped by the new `overflow-hidden`.

Verified live in-browser: every layout dimension is now single-valued (no oscillation) and DOM mutations drop to 0 at rest. Checked on both desktop (two-column `md:flex-row`) and mobile (stacked) layouts.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary