### PR TITLE
fix(dashboard): add missing appID

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/components/deployment-id-link.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/components/deployment-id-link.tsx
@@ -2,6 +2,7 @@
 
 import { useWorkspaceNavigation } from "@/hooks/use-workspace-navigation";
 import { shortenId } from "@/lib/shorten-id";
+import { CopyButton } from "@unkey/ui";
 import { useProjectData } from "../(overview)/data-provider";
 import { DottedLink } from "./dotted-link";
 
@@ -11,7 +12,18 @@ type DeploymentIdLinkProps = {
 
 export function DeploymentIdLink({ deploymentId }: DeploymentIdLinkProps) {
   const workspace = useWorkspaceNavigation();
-  const { projectId, appId } = useProjectData();
+  const { projectId, getDeploymentById } = useProjectData();
+  const appId = getDeploymentById(deploymentId)?.appId;
+
+  // no appId means the deployment is not in the loaded collection, show the id without a broken link
+  if (!appId) {
+    return (
+      <div className="flex items-center gap-2">
+        <span className="font-mono text-xs">{shortenId(deploymentId)}</span>
+        <CopyButton value={deploymentId} variant="ghost" className="h-4 w-4" />
+      </div>
+    );
+  }
 
   return (
     <DottedLink


### PR DESCRIPTION
> [!IMPORTANT]
> Unkey is not accepting external pull requests at this time. Pull requests from people outside the Unkey team will not be reviewed or merged.

Fixes ENG-2886

## Problem

Clicking the deployment ID button opens a new tab and hits a URL with apps/undefined, which causes a client-side exception.
Example URL: https://app.unkey.com/workspace_id/projects/proj_123/apps/undefined/deployments/d_123

## Fix

This PR adds missing appId for `deployment-id-link`. Since `appId` is not available in `project` level we have to derive it from deployments. If its missing we fallback to `deploymentId` without a link.

<img width="704" height="999" alt="image" src="https://github.com/user-attachments/assets/56a53679-1ff1-40e7-8162-a12942b87732" />
