### PR TITLE
chore(dashboard): filter by deploymentId

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/components/table/components/actions/deployment-list-table-action.popover.constants.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/components/table/components/actions/deployment-list-table-action.popover.constants.tsx
@@ -109,7 +109,7 @@ export const DeploymentListTableActions = ({
         icon: <Layers3 iconSize="md-regular" />,
         onClick: () => {
           router.push(
-            `/${workspace.slug}/projects/${selectedDeployment.projectId}/logs?appId=${selectedDeployment.appId}`,
+            `/${workspace.slug}/projects/${selectedDeployment.projectId}/logs?deploymentId=is:${selectedDeployment.id}`,
           );
         },
       },


### PR DESCRIPTION
> [!IMPORTANT]
> Unkey is not accepting external pull requests at this time. Pull requests from people outside the Unkey team will not be reviewed or merged.

## Problem

We were redirecting to app wide logs instead of deployment wide logs when user clicked on `Go to logs` on deployment row.

## Fix 

We should directly filter by `deploymentId` to make it consistent with other table actions here. Also `appId` does filter by app wide what we need is deployment wide

