### PR TITLE
feat(billing): mirror Deploy plan into workspaces.deploy_plan via Stripe webhook

### DIFF
--- a/web/apps/dashboard/app/api/webhooks/stripe/route.ts
+++ b/web/apps/dashboard/app/api/webhooks/stripe/route.ts
@@ -4,6 +4,7 @@ import { db, eq, schema } from "@/lib/db";
 import { stripeEnv } from "@/lib/env";
 import { formatPrice } from "@/lib/fmt";
 import { freeTierQuotas } from "@/lib/quotas";
+import { detectDeployPlan } from "@/lib/stripe/deployPlan";
 import { isPaymentRecovery, isPaymentRecoveryUpdate } from "@/lib/stripe/paymentUtils";
 import { validateAndParseQuotas } from "@/lib/stripe/productUtils";
 import {
@@ -20,6 +21,23 @@ import {
   alertSubscriptionUpdate,
 } from "@/lib/utils/slackAlerts";
 import Stripe from "stripe";
+
+/**
+ * Mirrors a subscription's Deploy plan onto its workspace row, writing only when
+ * it changed so the common renewal case (plan unchanged) does no DB write.
+ * Stripe stays the source of truth; workspaces.deploy_plan is the cache the
+ * deploy gate and dashboard read without a Stripe call in the hot path.
+ */
+async function mirrorDeployPlan(
+  ws: { id: string; deployPlan: string | null },
+  sub: Stripe.Subscription,
+): Promise<void> {
+  const deployPlan = detectDeployPlan(sub);
+  const changed = deployPlan !== ws.deployPlan;
+  if (changed) {
+    await db.update(schema.workspaces).set({ deployPlan }).where(eq(schema.workspaces.id, ws.id));
+  }
+}
 
 /**
  * Deactivates every active membership in `orgId` except the earliest one (the original
@@ -121,6 +139,12 @@ export const POST = async (req: Request): Promise<Response> => {
           });
           return new Response("OK", { status: 200 });
         }
+
+        // Sync before the skip-paths below: a plan add/change/remove must be
+        // mirrored even when the rest of the update is a no-op (renewal, card
+        // update) or bails on the API-tier quota validation, which a Deploy-only
+        // subscription does not satisfy.
+        await mirrorDeployPlan(ws, sub);
 
         const previousAttributes = event.data.previous_attributes;
 
@@ -329,6 +353,8 @@ export const POST = async (req: Request): Promise<Response> => {
           .set({
             stripeSubscriptionId: null,
             tier: "Free",
+            // The subscription is gone, so the Deploy plan goes with it.
+            deployPlan: null,
           })
           .where(eq(schema.workspaces.id, ws.id));
 
@@ -405,6 +431,20 @@ export const POST = async (req: Request): Promise<Response> => {
        */
       try {
         const sub = event.data.object as Stripe.Subscription;
+
+        // Mirror the Deploy plan signal when the new subscription already carries
+        // a Deploy plan-fee item (the free-tier path creates a subscription with
+        // Deploy items as its initial set). Best-effort: if the workspace row is
+        // not linked to this subscription yet, a later subscription.updated syncs
+        // it. Done before the alert-only logic below so an early return can't skip
+        // it.
+        const wsForDeploy = await db.query.workspaces.findFirst({
+          where: (table, { and, eq, isNull }) =>
+            and(eq(table.stripeSubscriptionId, sub.id), isNull(table.deletedAtM)),
+        });
+        if (wsForDeploy) {
+          await mirrorDeployPlan(wsForDeploy, sub);
+        }
 
         if (!sub.items?.data?.[0]?.price?.id || !sub.customer) {
           return new Response("OK");

--- a/web/apps/dashboard/lib/stripe/deployPlan.test.ts
+++ b/web/apps/dashboard/lib/stripe/deployPlan.test.ts
@@ -1,0 +1,56 @@
+import type Stripe from "stripe";
+import { describe, expect, it, vi } from "vitest";
+import { detectDeployPlan } from "./deployPlan";
+
+// Minimal subscription stub. detectDeployPlan reads items[].price.metadata.plan.
+function subWithItems(...items: Array<{ id?: string; plan?: string }>): Stripe.Subscription {
+  return {
+    id: "sub_test",
+    items: {
+      data: items.map(({ id, plan }) => ({
+        price: {
+          id: id ?? "price_x",
+          metadata: {
+            ...(plan === undefined ? {} : { plan }),
+          },
+        },
+      })),
+    },
+  } as unknown as Stripe.Subscription;
+}
+
+describe("detectDeployPlan", () => {
+  it("maps the plan-fee metadata to its plan", () => {
+    expect(detectDeployPlan(subWithItems({ plan: "starter" }))).toBe("starter");
+    expect(detectDeployPlan(subWithItems({ plan: "pro" }))).toBe("pro");
+    expect(detectDeployPlan(subWithItems({ plan: "business" }))).toBe("business");
+  });
+
+  it("finds the tagged plan-fee item among other items", () => {
+    const sub = subWithItems(
+      { id: "price_api_plan" },
+      { id: "price_metered_cpu" },
+      { id: "price_plan_fee", plan: "pro" },
+    );
+    expect(detectDeployPlan(sub)).toBe("pro");
+  });
+
+  it("trims surrounding whitespace in the metadata value", () => {
+    expect(detectDeployPlan(subWithItems({ plan: " pro " }))).toBe("pro");
+  });
+
+  it("returns null when no item carries plan metadata", () => {
+    expect(detectDeployPlan(subWithItems({ id: "price_api_plan" }))).toBeNull();
+  });
+
+  it("returns null for a subscription with no items", () => {
+    expect(detectDeployPlan(subWithItems())).toBeNull();
+  });
+
+  it("fails closed on an unrecognized plan value and logs a warning", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(detectDeployPlan(subWithItems({ plan: "enterprise" }))).toBeNull();
+    expect(warn).toHaveBeenCalledOnce();
+    warn.mockRestore();
+  });
+});

--- a/web/apps/dashboard/lib/stripe/deployPlan.ts
+++ b/web/apps/dashboard/lib/stripe/deployPlan.ts
@@ -1,0 +1,48 @@
+import type Stripe from "stripe";
+
+/**
+ * The Unkey Deploy plans we recognize, lowest to highest. Mirrored into
+ * workspaces.deploy_plan; NULL (absence) means no Deploy plan.
+ *
+ * Adding a plan: create its Stripe price(s) tagged with metadata `plan=<name>`
+ * and add the name here. No price ids are hardcoded, so re-pricing an existing
+ * plan needs no change at all: the new price carries the same metadata and
+ * existing subscriptions keep resolving (grandfathered).
+ */
+export const DEPLOY_PLANS = ["starter", "pro", "business"] as const;
+export type DeployPlan = (typeof DEPLOY_PLANS)[number];
+
+function isDeployPlan(value: string): value is DeployPlan {
+  return (DEPLOY_PLANS as readonly string[]).includes(value);
+}
+
+/**
+ * Detects which Deploy plan, if any, a Stripe subscription carries.
+ *
+ * The plan-fee price is tagged in Stripe with metadata `plan=<plan>`, the
+ * canonical "has a plan" marker. We scan the subscription's items (the plan-fee
+ * sits alongside API items and metered Deploy prices) and return the first
+ * recognized plan. price.metadata ships in the webhook payload, so this needs
+ * no extra Stripe calls.
+ *
+ * Fails closed: an item tagged with an unrecognized plan is logged and ignored,
+ * so a Stripe typo can never grant Deploy access. Returns null when no item
+ * carries a recognized Deploy plan.
+ */
+export function detectDeployPlan(sub: Stripe.Subscription): DeployPlan | null {
+  for (const item of sub.items?.data ?? []) {
+    const raw = item.price?.metadata?.plan?.trim();
+    if (!raw) {
+      continue;
+    }
+    if (isDeployPlan(raw)) {
+      return raw;
+    }
+    console.warn("Subscription item carries an unrecognized Deploy plan metadata value", {
+      subscriptionId: sub.id,
+      priceId: item.price?.id,
+      deployPlan: raw,
+    });
+  }
+  return null;
+}

--- a/web/internal/db/src/schema/workspaces.ts
+++ b/web/internal/db/src/schema/workspaces.ts
@@ -34,6 +34,14 @@ export const workspaces = mysqlTable("workspaces", {
   stripeSubscriptionId: varchar("stripe_subscription_id", { length: 256 }),
 
   /**
+   * Local mirror of the workspace's Unkey Deploy plan, synced from Stripe by the
+   * customer.subscription.* webhook. NULL means no Deploy plan (cannot use
+   * Deploy). Lets the deploy gate and dashboard read entitlement without calling
+   * Stripe in the hot path. Stripe stays source of truth; this is a cache.
+   */
+  deployPlan: varchar("deploy_plan", { length: 64 }),
+
+  /**
    * feature flags
    *
    * betaFeatures may be toggled by the user for early access


### PR DESCRIPTION
Mirrors the workspace's Compute plan into `workspaces.deploy_plan` via the Stripe `customer.subscription.*` webhook, so the deploy gate and dashboard read entitlement from the local DB instead of calling Stripe in the hot path.

- Detection based on the subscribed plan metadata plan key
- Synced on created / updated / deleted; only writes when the value actually changes.

Part of ENG-2872 (the "reflect Deploy on the subscription locally" half).
