### PR TITLE
feat(billing): subscribe / change / cancel Unkey Deploy plans

### DIFF
--- a/web/apps/dashboard/.env.example
+++ b/web/apps/dashboard/.env.example
@@ -45,6 +45,17 @@ STRIPE_PRODUCT_IDS_PRO=prod_UfOFuZWPmvHX6g,prod_UfOFUUKrnrfAWK,prod_UfOFCoweeWpj
 STRIPE_PRODUCT_IDS_ENTERPRISE=prod_UfOFaRxkNs1DJu
 STRIPE_WEBHOOK_SECRET=
 
+# Unkey Deploy billing price ids. Plan-fee price per tier (the canonical
+# "has Deploy" item) plus the shared metered usage prices. Leave blank locally
+# unless exercising the Deploy subscribe / change / cancel flows.
+STRIPE_LOOKUP_DEPLOY_STARTER=
+STRIPE_LOOKUP_DEPLOY_PRO=
+STRIPE_LOOKUP_DEPLOY_BUSINESS=
+STRIPE_LOOKUP_DEPLOY_METER_CPU=
+STRIPE_LOOKUP_DEPLOY_METER_MEMORY=
+STRIPE_LOOKUP_DEPLOY_METER_EGRESS=
+STRIPE_LOOKUP_DEPLOY_METER_DISK=
+
 # Feature flags (local)
 # Comma-separated list of flag keys to force "on" locally without configuring
 # Vercel Flags. Handy for exercising flag-gated UI in dev, e.g.

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/client.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/client.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useWorkspaceNavigation } from "@/hooks/use-workspace-navigation";
+import { useFlag } from "@/lib/flags/provider";
 import { routes } from "@/lib/navigation/routes";
 import { trpc } from "@/lib/trpc/client";
 import {
@@ -17,6 +18,7 @@ import { BillingContainer } from "./billing-container";
 import { CancelAlert } from "./components/cancel-alert";
 import { CancelPlan } from "./components/cancel-plan";
 import { CurrentPlanCard } from "./components/current-plan-card";
+import { DeployBillingSection } from "./components/deploy-billing-section";
 import { FreeTierAlert } from "./components/free-tier-alert";
 import { PlanSelectionModal } from "./components/plan-selection-modal";
 import { SubscriptionStatus } from "./components/subscription-status";
@@ -30,6 +32,7 @@ export const Client: React.FC = () => {
   const router = useRouter();
   const workspace = useWorkspaceNavigation();
   const [showPlanModal, setShowPlanModal] = useState(false);
+  const deployBillingEnabled = useFlag("deployBilling");
 
   // Server-side `requireWorkspaceAdmin` enforces this on every billing
   // mutation; we mirror it on the client purely for UX so non-admin members
@@ -184,6 +187,13 @@ export const Client: React.FC = () => {
             </SettingCardGroup>
           </div>
         )}
+
+        {deployBillingEnabled ? (
+          <DeployBillingSection
+            isAdmin={isAdmin}
+            hasPaymentMethod={Boolean(workspace.stripeCustomerId)}
+          />
+        ) : null}
 
         <CancelAlert
           cancelAt={subscription?.cancelAt}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/deploy-billing-section.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/deploy-billing-section.tsx
@@ -1,0 +1,285 @@
+"use client";
+
+import { formatPrice } from "@/lib/fmt";
+import type { DeployPlan } from "@/lib/stripe/deployPlan";
+import { trpc } from "@/lib/trpc/client";
+import type { DeployPlanOption } from "@/lib/trpc/routers/stripe/getDeployPlans";
+import { cn } from "@/lib/utils";
+import {
+  Button,
+  DialogContainer,
+  InfoTooltip,
+  SettingCard,
+  SettingCardGroup,
+  SettingsDangerZone,
+  SettingsZoneRow,
+  toast,
+} from "@unkey/ui";
+import { useEffect, useState } from "react";
+
+const ADMIN_ONLY_TOOLTIP = "Admin access required to manage billing";
+const NEEDS_PAYMENT_TOOLTIP = "Add a payment method before subscribing to Unkey Deploy";
+
+type DeployBillingSectionProps = {
+  isAdmin: boolean;
+  hasPaymentMethod: boolean;
+};
+
+/**
+ * Flag-gated Unkey Deploy billing section. Reads the current plan from the local
+ * deploy_plan signal (getDeploySubscription) and the available tiers from Stripe
+ * (getDeployPlans). Subscribe / change / cancel mutate Stripe; the webhook syncs
+ * deploy_plan, so on success we just refetch.
+ */
+export const DeployBillingSection: React.FC<DeployBillingSectionProps> = ({
+  isAdmin,
+  hasPaymentMethod,
+}) => {
+  const trpcUtils = trpc.useUtils();
+  const [isPlanModalOpen, setPlanModalOpen] = useState(false);
+  const [isCancelOpen, setCancelOpen] = useState(false);
+
+  const { data: subscription, isLoading: subscriptionLoading } =
+    trpc.stripe.getDeploySubscription.useQuery(undefined, { staleTime: 30_000 });
+  const { data: plansData, isLoading: plansLoading } = trpc.stripe.getDeployPlans.useQuery(
+    undefined,
+    { staleTime: 60_000 },
+  );
+
+  const revalidate = async () => {
+    await Promise.all([
+      trpcUtils.stripe.getDeploySubscription.invalidate(),
+      trpcUtils.workspace.getCurrent.invalidate(),
+    ]);
+  };
+
+  const subscribe = trpc.stripe.subscribeDeploy.useMutation({
+    onSuccess: async () => {
+      setPlanModalOpen(false);
+      toast.success("Subscribed to Unkey Deploy");
+      await revalidate();
+    },
+    onError: (err) => toast.error(err.message),
+  });
+  const change = trpc.stripe.changeDeployPlan.useMutation({
+    onSuccess: async () => {
+      setPlanModalOpen(false);
+      toast.success("Unkey Deploy plan changed");
+      await revalidate();
+    },
+    onError: (err) => toast.error(err.message),
+  });
+  const cancel = trpc.stripe.cancelDeploy.useMutation({
+    onSuccess: async () => {
+      setCancelOpen(false);
+      toast.info("Unkey Deploy cancelled");
+      await revalidate();
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  if (subscriptionLoading || plansLoading) {
+    return <div className="w-full h-[120px] bg-grayA-3 rounded-lg animate-pulse" />;
+  }
+
+  // Deploy billing not configured server-side: hide the section entirely.
+  if (plansData && !plansData.configured) {
+    return null;
+  }
+
+  const currentPlan = subscription?.plan ?? null;
+  const plans = plansData?.plans ?? [];
+  const currentPlanOption = plans.find((p) => p.plan === currentPlan);
+  const manageDisabled = !isAdmin;
+  const subscribeDisabled = !isAdmin || !hasPaymentMethod;
+  const subscribeTooltip = isAdmin
+    ? hasPaymentMethod
+      ? undefined
+      : NEEDS_PAYMENT_TOOLTIP
+    : ADMIN_ONLY_TOOLTIP;
+
+  return (
+    <div className="w-full">
+      <SettingCardGroup>
+        <SettingCard
+          title="Unkey Deploy"
+          description={
+            currentPlan
+              ? `You are on the ${currentPlanOption?.name ?? currentPlan} plan. Usage is billed on top of the plan fee.`
+              : "Deploy requires a plan. Subscribe to start deploying projects."
+          }
+        >
+          <div className="w-full flex h-full items-center justify-end gap-4">
+            <InfoTooltip
+              content={currentPlan ? ADMIN_ONLY_TOOLTIP : subscribeTooltip}
+              disabled={currentPlan ? !manageDisabled : !subscribeDisabled}
+              asChild
+            >
+              <span>
+                <Button
+                  variant={currentPlan ? "outline" : "primary"}
+                  className="py-2 px-3 font-medium text-sm"
+                  disabled={currentPlan ? manageDisabled : subscribeDisabled}
+                  onClick={() => setPlanModalOpen(true)}
+                >
+                  {currentPlan ? "Change plan" : "Choose a plan"}
+                </Button>
+              </span>
+            </InfoTooltip>
+          </div>
+        </SettingCard>
+      </SettingCardGroup>
+
+      {currentPlan ? (
+        <SettingsDangerZone>
+          <SettingsZoneRow
+            title="Cancel Unkey Deploy"
+            description={
+              manageDisabled
+                ? ADMIN_ONLY_TOOLTIP
+                : "Stops Unkey Deploy immediately and removes it from your subscription. Usage so far is billed; the plan fee is not refunded."
+            }
+            action={{
+              label: "Cancel Deploy",
+              onClick: () => setCancelOpen(true),
+              disabled: manageDisabled,
+            }}
+          />
+        </SettingsDangerZone>
+      ) : null}
+
+      <DeployPlanModal
+        isOpen={isPlanModalOpen}
+        onOpenChange={setPlanModalOpen}
+        plans={plans}
+        currentPlan={currentPlan}
+        isSubmittingPlan={subscribe.isLoading ? subscribe.variables?.plan : change.variables?.plan}
+        onSelect={(plan) => {
+          if (currentPlan) {
+            change.mutate({ plan });
+          } else {
+            subscribe.mutate({ plan });
+          }
+        }}
+      />
+
+      <DialogContainer
+        isOpen={isCancelOpen}
+        onOpenChange={setCancelOpen}
+        title="Cancel Unkey Deploy"
+        subTitle="Stop deploying with this workspace"
+        footer={
+          <Button
+            type="button"
+            variant="primary"
+            color="danger"
+            size="xlg"
+            className="w-full rounded-lg"
+            loading={cancel.isLoading}
+            onClick={() => cancel.mutate()}
+          >
+            Cancel Unkey Deploy
+          </Button>
+        }
+      >
+        <div className="text-gray-11 text-[13px] leading-6">
+          Cancelling stops Unkey Deploy immediately: your deployments stop and no further usage is
+          billed. Usage up to now is still charged, and the plan fee already paid is not refunded.
+        </div>
+      </DialogContainer>
+    </div>
+  );
+};
+
+type DeployPlanModalProps = {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  plans: DeployPlanOption[];
+  currentPlan: DeployPlan | null;
+  /** The plan whose mutation is in flight, for the per-button loading state. */
+  isSubmittingPlan: DeployPlan | undefined;
+  onSelect: (plan: DeployPlan) => void;
+};
+
+const DeployPlanModal: React.FC<DeployPlanModalProps> = ({
+  isOpen,
+  onOpenChange,
+  plans,
+  currentPlan,
+  isSubmittingPlan,
+  onSelect,
+}) => {
+  const [selected, setSelected] = useState<DeployPlan | null>(currentPlan);
+
+  // Reset the highlighted plan to the current one whenever the modal opens.
+  useEffect(() => {
+    if (isOpen) {
+      setSelected(currentPlan);
+    }
+  }, [isOpen, currentPlan]);
+
+  const isSubmitting = isSubmittingPlan !== undefined;
+  const ctaDisabled = !selected || selected === currentPlan || isSubmitting;
+
+  return (
+    <DialogContainer
+      isOpen={isOpen}
+      onOpenChange={onOpenChange}
+      title={currentPlan ? "Change Unkey Deploy plan" : "Choose an Unkey Deploy plan"}
+      subTitle="The plan fee is billed monthly; usage is billed on top."
+      footer={
+        <Button
+          type="button"
+          variant="primary"
+          size="xlg"
+          className="w-full rounded-lg"
+          loading={isSubmitting}
+          disabled={ctaDisabled}
+          onClick={() => {
+            if (selected) {
+              onSelect(selected);
+            }
+          }}
+        >
+          {currentPlan ? "Change plan" : "Subscribe"}
+        </Button>
+      }
+    >
+      <div className="flex flex-col gap-3">
+        {plans.map((plan) => {
+          const isCurrent = plan.plan === currentPlan;
+          const isSelected = plan.plan === selected;
+          return (
+            <button
+              type="button"
+              key={plan.plan}
+              onClick={() => setSelected(plan.plan)}
+              className={cn(
+                "w-full text-left rounded-lg border px-4 py-3 transition-colors",
+                isSelected ? "border-accent-9 bg-accentA-2" : "border-grayA-4 hover:bg-grayA-2",
+              )}
+            >
+              <div className="flex items-center justify-between">
+                <span className="font-medium text-gray-12 text-sm">{plan.name}</span>
+                <span className="text-gray-12 text-sm">
+                  {plan.amount !== null ? (
+                    <>
+                      {formatPrice(plan.amount)}
+                      {plan.interval ? `/${plan.interval}` : ""}
+                    </>
+                  ) : (
+                    "Contact us"
+                  )}
+                </span>
+              </div>
+              {plan.description ? (
+                <p className="text-gray-10 text-[13px] mt-1">{plan.description}</p>
+              ) : null}
+              {isCurrent ? <p className="text-gray-9 text-xs mt-1">Current plan</p> : null}
+            </button>
+          );
+        })}
+      </div>
+    </DialogContainer>
+  );
+};

--- a/web/apps/dashboard/lib/env.ts
+++ b/web/apps/dashboard/lib/env.ts
@@ -90,6 +90,23 @@ const stripeSchema = z.object({
   STRIPE_PRODUCT_IDS_PRO: z.string().transform((s) => s.split(",")),
   STRIPE_PRODUCT_IDS_ENTERPRISE: z.string().transform((s) => s.split(",")),
   STRIPE_WEBHOOK_SECRET: z.string(),
+  // Unkey Deploy plan-fee price lookup_keys, one per plan. subscribeDeploy /
+  // changeDeployPlan resolve these to the current active price and attach (or
+  // swap) the plan-fee for the chosen tier. lookup_keys (not price ids) so a
+  // reprice needs no env change. Optional so environments without Deploy
+  // billing configured still parse; the Deploy mutations reject with a clear
+  // error when unset.
+  STRIPE_LOOKUP_DEPLOY_STARTER: z.string().optional(),
+  STRIPE_LOOKUP_DEPLOY_PRO: z.string().optional(),
+  STRIPE_LOOKUP_DEPLOY_BUSINESS: z.string().optional(),
+  // Unkey Deploy metered usage price lookup_keys, shared across all plans.
+  // Resolved and attached alongside the plan-fee on subscribe; usage is billed
+  // from the meter events the ctrl billing worker pushes (CPU / memory /
+  // egress / disk).
+  STRIPE_LOOKUP_DEPLOY_METER_CPU: z.string().optional(),
+  STRIPE_LOOKUP_DEPLOY_METER_MEMORY: z.string().optional(),
+  STRIPE_LOOKUP_DEPLOY_METER_EGRESS: z.string().optional(),
+  STRIPE_LOOKUP_DEPLOY_METER_DISK: z.string().optional(),
 });
 
 const stripeParsed = stripeSchema.safeParse(process.env);

--- a/web/apps/dashboard/lib/stripe/deployBilling.test.ts
+++ b/web/apps/dashboard/lib/stripe/deployBilling.test.ts
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/env", () => ({ stripeEnv: vi.fn() }));
+vi.mock("@/lib/stripe", () => ({ getStripeClient: vi.fn() }));
+
+import { stripeEnv } from "@/lib/env";
+import { getStripeClient } from "@/lib/stripe";
+import {
+  type DeployBillingConfig,
+  deployBillingConfig,
+  deploySubscriptionItems,
+  findDeployItems,
+  findPlanFeeItem,
+  planForPlanFeePriceId,
+} from "./deployBilling";
+
+const mockedStripeEnv = vi.mocked(stripeEnv);
+const mockedGetStripeClient = vi.mocked(getStripeClient);
+
+type StripeEnv = NonNullable<ReturnType<typeof stripeEnv>>;
+
+// lookup_key -> resolved active price id, the mapping Stripe would return.
+const ID: Record<string, string> = {
+  lk_starter: "price_starter",
+  lk_pro: "price_pro",
+  lk_business: "price_business",
+  lk_cpu: "price_cpu",
+  lk_memory: "price_memory",
+  lk_egress: "price_egress",
+  lk_disk: "price_disk",
+};
+
+function envWith(overrides: Partial<StripeEnv> = {}): StripeEnv {
+  return {
+    STRIPE_SECRET_KEY: "sk_test_x",
+    STRIPE_PRODUCT_IDS_PRO: ["prod_pro"],
+    STRIPE_PRODUCT_IDS_ENTERPRISE: ["prod_ent"],
+    STRIPE_WEBHOOK_SECRET: "whsec_x",
+    STRIPE_LOOKUP_DEPLOY_STARTER: "lk_starter",
+    STRIPE_LOOKUP_DEPLOY_PRO: "lk_pro",
+    STRIPE_LOOKUP_DEPLOY_BUSINESS: "lk_business",
+    STRIPE_LOOKUP_DEPLOY_METER_CPU: "lk_cpu",
+    STRIPE_LOOKUP_DEPLOY_METER_MEMORY: "lk_memory",
+    STRIPE_LOOKUP_DEPLOY_METER_EGRESS: "lk_egress",
+    STRIPE_LOOKUP_DEPLOY_METER_DISK: "lk_disk",
+    ...overrides,
+  };
+}
+
+// Stripe whose prices.list returns the active price for each known lookup_key.
+function stubStripe() {
+  mockedGetStripeClient.mockReturnValue({
+    prices: {
+      list: vi.fn(async ({ lookup_keys }: { lookup_keys: string[] }) => ({
+        data: lookup_keys.filter((k) => ID[k]).map((k) => ({ id: ID[k], lookup_key: k })),
+      })),
+    },
+    // Test double; only prices.list is exercised here.
+  } as unknown as ReturnType<typeof getStripeClient>);
+}
+
+const CONFIG: DeployBillingConfig = {
+  planFeePriceIds: { starter: "price_starter", pro: "price_pro", business: "price_business" },
+  meteredPriceIds: ["price_cpu", "price_memory", "price_egress", "price_disk"],
+  allDeployPriceIds: new Set([
+    "price_starter",
+    "price_pro",
+    "price_business",
+    "price_cpu",
+    "price_memory",
+    "price_egress",
+    "price_disk",
+  ]),
+};
+
+function item(id: string, priceId: string) {
+  return { id, price: { id: priceId } };
+}
+
+describe("deployBillingConfig", () => {
+  beforeEach(() => {
+    mockedStripeEnv.mockReset();
+    mockedGetStripeClient.mockReset();
+    stubStripe();
+  });
+
+  it("resolves lookup_keys to active price ids when fully configured", async () => {
+    mockedStripeEnv.mockReturnValue(envWith());
+    const c = await deployBillingConfig();
+    expect(c?.planFeePriceIds).toEqual({
+      starter: "price_starter",
+      pro: "price_pro",
+      business: "price_business",
+    });
+    expect(c?.meteredPriceIds).toEqual(["price_cpu", "price_memory", "price_egress", "price_disk"]);
+    expect(c?.allDeployPriceIds.size).toBe(7);
+  });
+
+  it("returns null when Stripe is not configured", async () => {
+    mockedStripeEnv.mockReturnValue(null);
+    expect(await deployBillingConfig()).toBeNull();
+  });
+
+  it("returns null when a plan-fee lookup_key is missing (all-or-nothing)", async () => {
+    mockedStripeEnv.mockReturnValue(envWith({ STRIPE_LOOKUP_DEPLOY_BUSINESS: undefined }));
+    expect(await deployBillingConfig()).toBeNull();
+  });
+
+  it("returns null when a metered lookup_key is missing (all-or-nothing)", async () => {
+    mockedStripeEnv.mockReturnValue(envWith({ STRIPE_LOOKUP_DEPLOY_METER_DISK: undefined }));
+    expect(await deployBillingConfig()).toBeNull();
+  });
+
+  it("returns null when a lookup_key resolves to no active price", async () => {
+    // A distinct key set, so the earlier success is not served from cache; the
+    // stub knows every key except this archived one.
+    mockedStripeEnv.mockReturnValue(
+      envWith({ STRIPE_LOOKUP_DEPLOY_BUSINESS: "lk_business_archived" }),
+    );
+    expect(await deployBillingConfig()).toBeNull();
+  });
+});
+
+describe("deploySubscriptionItems", () => {
+  it("builds the plan-fee for the tier plus the shared metered prices", () => {
+    expect(deploySubscriptionItems(CONFIG, "pro")).toEqual([
+      { price: "price_pro" },
+      { price: "price_cpu" },
+      { price: "price_memory" },
+      { price: "price_egress" },
+      { price: "price_disk" },
+    ]);
+  });
+});
+
+describe("planForPlanFeePriceId", () => {
+  it("maps a plan-fee price id back to its plan", () => {
+    expect(planForPlanFeePriceId(CONFIG, "price_business")).toBe("business");
+  });
+  it("returns undefined for a metered or unknown price id", () => {
+    expect(planForPlanFeePriceId(CONFIG, "price_cpu")).toBeUndefined();
+    expect(planForPlanFeePriceId(CONFIG, "price_unknown")).toBeUndefined();
+  });
+});
+
+describe("findDeployItems", () => {
+  it("returns every Deploy item (plan-fee + metered), ignoring API items", () => {
+    const found = findDeployItems(CONFIG, [
+      item("si_api", "price_api"),
+      item("si_fee", "price_pro"),
+      item("si_cpu", "price_cpu"),
+      item("si_disk", "price_disk"),
+    ]);
+    expect(found).toEqual([
+      { id: "si_fee", priceId: "price_pro" },
+      { id: "si_cpu", priceId: "price_cpu" },
+      { id: "si_disk", priceId: "price_disk" },
+    ]);
+  });
+
+  it("returns empty when no Deploy items are present", () => {
+    expect(findDeployItems(CONFIG, [item("si_api", "price_api")])).toEqual([]);
+  });
+});
+
+describe("findPlanFeeItem", () => {
+  it("finds the plan-fee item and its plan among other items", () => {
+    const found = findPlanFeeItem(CONFIG, [
+      item("si_cpu", "price_cpu"),
+      item("si_fee", "price_business"),
+    ]);
+    expect(found).toEqual({ id: "si_fee", plan: "business" });
+  });
+
+  it("returns undefined when there is no plan-fee item (metered only)", () => {
+    expect(findPlanFeeItem(CONFIG, [item("si_cpu", "price_cpu")])).toBeUndefined();
+  });
+});

--- a/web/apps/dashboard/lib/stripe/deployBilling.ts
+++ b/web/apps/dashboard/lib/stripe/deployBilling.ts
@@ -1,0 +1,220 @@
+import { stripeEnv } from "@/lib/env";
+import { getStripeClient } from "@/lib/stripe";
+import { DEPLOY_PLANS, type DeployPlan } from "./deployPlan";
+
+/**
+ * Resolved Stripe price ids for Unkey Deploy billing. The webhook detects the
+ * plan from price metadata ([[deployPlan]]); these ids are the write side, used
+ * by subscribe / change / cancel to attach, swap, and remove the right items.
+ */
+export type DeployBillingConfig = {
+  /** Plan-fee price id per plan. The canonical "has Deploy" item on the sub. */
+  planFeePriceIds: Record<DeployPlan, string>;
+  /** Metered usage price ids, shared across plans (cpu, memory, egress, disk). */
+  meteredPriceIds: string[];
+  /** Every Deploy price id (plan-fee + metered), for identifying Deploy items. */
+  allDeployPriceIds: Set<string>;
+};
+
+// Resolved lookup_keys -> price ids change only on a reprice, which is rare, so
+// the resolution is cached: long enough to avoid a prices.list call on every
+// request, short enough to pick up a reprice without a redeploy.
+const RESOLUTION_TTL_MS = 5 * 60 * 1000;
+let cache: { key: string; expiresAt: number; config: DeployBillingConfig } | null = null;
+
+/**
+ * Whether every Deploy lookup_key env var is set. deployBillingConfig() returns
+ * null both when Deploy is unconfigured (these keys absent) AND when configured
+ * keys fail to resolve to active prices (a transient reprice / Stripe window).
+ * Callers that make a destructive choice from item classification use this to
+ * tell the two apart: unconfigured means "not a Deploy subscription" (treating
+ * the first item as the API item is safe), while configured-but-unresolved means
+ * they must fail closed rather than guess which item to touch.
+ */
+export function deployBillingConfigured(): boolean {
+  const e = stripeEnv();
+  if (!e) {
+    return false;
+  }
+  return [
+    e.STRIPE_LOOKUP_DEPLOY_STARTER,
+    e.STRIPE_LOOKUP_DEPLOY_PRO,
+    e.STRIPE_LOOKUP_DEPLOY_BUSINESS,
+    e.STRIPE_LOOKUP_DEPLOY_METER_CPU,
+    e.STRIPE_LOOKUP_DEPLOY_METER_MEMORY,
+    e.STRIPE_LOOKUP_DEPLOY_METER_EGRESS,
+    e.STRIPE_LOOKUP_DEPLOY_METER_DISK,
+  ].every(Boolean);
+}
+
+/**
+ * Resolves and validates the Deploy billing config. Env holds Stripe price
+ * lookup_keys (stable handles); this resolves them to the current active price
+ * ids via one prices.list call, cached. A reprice transfers the lookup_key onto
+ * the new price, so the ids update with no env change. Returns null if Stripe is
+ * not configured or any lookup_key is missing or unresolved, so callers can
+ * reject with a clear "not configured" error instead of attaching half a
+ * subscription.
+ */
+export async function deployBillingConfig(): Promise<DeployBillingConfig | null> {
+  const e = stripeEnv();
+  if (!e) {
+    return null;
+  }
+
+  const planFeeLookupKeys: Record<DeployPlan, string | undefined> = {
+    starter: e.STRIPE_LOOKUP_DEPLOY_STARTER,
+    pro: e.STRIPE_LOOKUP_DEPLOY_PRO,
+    business: e.STRIPE_LOOKUP_DEPLOY_BUSINESS,
+  };
+  const meterLookupKeys = [
+    e.STRIPE_LOOKUP_DEPLOY_METER_CPU,
+    e.STRIPE_LOOKUP_DEPLOY_METER_MEMORY,
+    e.STRIPE_LOOKUP_DEPLOY_METER_EGRESS,
+    e.STRIPE_LOOKUP_DEPLOY_METER_DISK,
+  ];
+
+  // All-or-nothing: a partially configured set would attach an incomplete
+  // subscription (e.g. plan-fee with no metering), so treat it as unconfigured.
+  if (!deployBillingConfigured()) {
+    return null;
+  }
+  const planFee = planFeeLookupKeys as Record<DeployPlan, string>;
+  const meters = meterLookupKeys as string[];
+
+  const allLookupKeys = [...Object.values(planFee), ...meters];
+  const cacheKey = allLookupKeys.join(",");
+  const now = Date.now();
+  if (cache && cache.key === cacheKey && cache.expiresAt > now) {
+    return cache.config;
+  }
+
+  // One list call: <=10 lookup_keys, one active price each, so no paging.
+  const stripe = getStripeClient();
+  const prices = await stripe.prices.list({ lookup_keys: allLookupKeys, active: true, limit: 100 });
+  const idByLookupKey = new Map<string, string>();
+  for (const price of prices.data) {
+    if (price.lookup_key) {
+      idByLookupKey.set(price.lookup_key, price.id);
+    }
+  }
+
+  // Every declared lookup_key must resolve to an active price, else the set is
+  // incomplete: treat it as unconfigured rather than attach a partial sub.
+  const planFeeEntries: Array<[DeployPlan, string]> = [];
+  for (const plan of DEPLOY_PLANS) {
+    const id = idByLookupKey.get(planFee[plan]);
+    if (!id) {
+      return null;
+    }
+    planFeeEntries.push([plan, id]);
+  }
+  const meteredPriceIds: string[] = [];
+  for (const key of meters) {
+    const id = idByLookupKey.get(key);
+    if (!id) {
+      return null;
+    }
+    meteredPriceIds.push(id);
+  }
+  const planFeePriceIds = Object.fromEntries(planFeeEntries) as Record<DeployPlan, string>;
+
+  const config: DeployBillingConfig = {
+    planFeePriceIds,
+    meteredPriceIds,
+    allDeployPriceIds: new Set<string>([...Object.values(planFeePriceIds), ...meteredPriceIds]),
+  };
+  cache = { key: cacheKey, expiresAt: now + RESOLUTION_TTL_MS, config };
+  return config;
+}
+
+/**
+ * The full set of subscription items for a Deploy plan: the plan-fee for the
+ * chosen tier plus the shared metered prices. Metered items carry no quantity;
+ * usage is billed from meter events.
+ */
+export function deploySubscriptionItems(
+  config: DeployBillingConfig,
+  plan: DeployPlan,
+): Array<{ price: string }> {
+  return [
+    { price: config.planFeePriceIds[plan] },
+    ...config.meteredPriceIds.map((price) => ({ price })),
+  ];
+}
+
+/**
+ * Maps a plan-fee price id back to its plan, or undefined if it is not a
+ * plan-fee price. Used to find the current Deploy plan-fee item on a
+ * subscription so change/cancel act on the right item.
+ */
+export function planForPlanFeePriceId(
+  config: DeployBillingConfig,
+  priceId: string,
+): DeployPlan | undefined {
+  return DEPLOY_PLANS.find((plan) => config.planFeePriceIds[plan] === priceId);
+}
+
+/** A subscription item, narrowed to the fields the Deploy logic reads. */
+export type SubscriptionItemLike = {
+  id: string;
+  price?: { id?: string | null } | null;
+};
+
+/**
+ * Returns the Deploy items (plan-fee + metered) among a subscription's items,
+ * matched by price id. Used to detect an existing Deploy subscription and to
+ * pick which items to remove on cancel.
+ */
+export function findDeployItems(
+  config: DeployBillingConfig,
+  items: SubscriptionItemLike[],
+): Array<{ id: string; priceId: string }> {
+  return items.flatMap((item) => {
+    const priceId = item.price?.id;
+    return priceId && config.allDeployPriceIds.has(priceId) ? [{ id: item.id, priceId }] : [];
+  });
+}
+
+/**
+ * Returns the first subscription item that is not a Deploy item (plan-fee or
+ * metered): the API plan item on a mixed subscription. The API routes
+ * (create/update/cancel/read) must anchor on this instead of items[0], which
+ * on a Compute-first subscription is a Deploy item. When Deploy billing is
+ * not configured every item is "not Deploy", which preserves the legacy
+ * first-item behavior on single-product subscriptions.
+ */
+export function findApiItem<T extends SubscriptionItemLike>(
+  config: DeployBillingConfig | null,
+  items: T[],
+): T | undefined {
+  if (!config) {
+    return items[0];
+  }
+  return items.find((item) => {
+    const priceId = item.price?.id;
+    return !priceId || !config.allDeployPriceIds.has(priceId);
+  });
+}
+
+/**
+ * Finds the plan-fee item on a subscription and the plan it maps to, or
+ * undefined when no Deploy plan-fee item is present. The plan-fee item is the
+ * one change/cancel reprice or anchor on.
+ */
+export function findPlanFeeItem(
+  config: DeployBillingConfig,
+  items: SubscriptionItemLike[],
+): { id: string; plan: DeployPlan } | undefined {
+  for (const item of items) {
+    const priceId = item.price?.id;
+    if (!priceId) {
+      continue;
+    }
+    const plan = planForPlanFeePriceId(config, priceId);
+    if (plan) {
+      return { id: item.id, plan };
+    }
+  }
+  return undefined;
+}

--- a/web/apps/dashboard/lib/trpc/routers/index.ts
+++ b/web/apps/dashboard/lib/trpc/routers/index.ts
@@ -196,13 +196,18 @@ import { updateRole } from "./rbac/updateRole";
 import { deleteRootKeys } from "./settings/root-keys/delete";
 import { rootKeysLlmSearch } from "./settings/root-keys/llm-search";
 import { queryRootKeys } from "./settings/root-keys/query";
+import { cancelDeploy } from "./stripe/cancelDeploy";
 import { cancelSubscription } from "./stripe/cancelSubscription";
+import { changeDeployPlan } from "./stripe/changeDeployPlan";
 import { createSubscription } from "./stripe/createSubscription";
 import { getBillingInfo } from "./stripe/getBillingInfo";
 import { getCheckoutSession } from "./stripe/getCheckoutSession";
 import { getCustomer } from "./stripe/getCustomer";
+import { getDeployPlans } from "./stripe/getDeployPlans";
+import { getDeploySubscription } from "./stripe/getDeploySubscription";
 import { getProducts } from "./stripe/getProducts";
 import { getSetupIntent } from "./stripe/getSetupIntent";
+import { subscribeDeploy } from "./stripe/subscribeDeploy";
 import { uncancelSubscription } from "./stripe/uncancelSubscription";
 import { updateCustomer } from "./stripe/updateCustomer";
 import { updateSubscription } from "./stripe/updateSubscription";
@@ -309,6 +314,11 @@ export const router = t.router({
     getProducts,
     getSetupIntent,
     updateWorkspaceStripeCustomer,
+    subscribeDeploy,
+    changeDeployPlan,
+    cancelDeploy,
+    getDeploySubscription,
+    getDeployPlans,
   }),
   github: githubRouter,
   plain: t.router({

--- a/web/apps/dashboard/lib/trpc/routers/stripe/cancelDeploy.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/cancelDeploy.ts
@@ -1,0 +1,96 @@
+import { insertAuditLogs } from "@/lib/audit";
+import { db, eq, schema } from "@/lib/db";
+import { getStripeClient } from "@/lib/stripe";
+import { deployBillingConfig, findDeployItems } from "@/lib/stripe/deployBilling";
+import { invalidateWorkspaceCache } from "@/lib/workspace-cache";
+import { TRPCError } from "@trpc/server";
+import { requireWorkspaceAdmin, workspaceProcedure } from "../../trpc";
+
+/**
+ * Cancels Unkey Deploy immediately: clears deploy_plan so the dashboard gate
+ * blocks new deploys, and removes the Deploy items (plan-fee + metered) from
+ * Stripe now, with no refund of the prepaid plan-fee. If Deploy was the only
+ * thing on the subscription (the free-tier path created it), the whole
+ * subscription is cancelled now instead, since Stripe requires at least one
+ * item. The webhook reconciles deploy_plan to the same value.
+ *
+ * This does NOT stop running compute and does NOT bill usage correctly. Nothing
+ * in ctrl/krane reacts to the cancel, so instances keep running and keep
+ * emitting meter events after the items are gone, and those events are
+ * uncollectable. The Deploy-only path invoices usage up to now (best effort);
+ * the mixed path cannot, because subscriptionItems.del has no invoice_now.
+ * Either way, usage between cancel and actual shutdown is lost.
+ *
+ * Correct cancel can only bill as the last step of a teardown sequence (stop
+ * compute, wait for drain, flush final meter events, then bill and remove
+ * items). Tracked in ENG-2922.
+ */
+export const cancelDeploy = workspaceProcedure
+  .use(requireWorkspaceAdmin)
+  .mutation(async ({ ctx }) => {
+    const config = await deployBillingConfig();
+    if (!config) {
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: "Unkey Deploy billing is not configured.",
+      });
+    }
+
+    if (!ctx.workspace.stripeSubscriptionId) {
+      throw new TRPCError({
+        code: "PRECONDITION_FAILED",
+        message: "Workspace has no Unkey Deploy plan to cancel.",
+      });
+    }
+
+    const stripe = getStripeClient();
+    const sub = await stripe.subscriptions.retrieve(ctx.workspace.stripeSubscriptionId);
+
+    const deployItems = findDeployItems(config, sub.items.data);
+    if (deployItems.length === 0) {
+      throw new TRPCError({
+        code: "PRECONDITION_FAILED",
+        message: "Workspace has no Unkey Deploy plan to cancel.",
+      });
+    }
+
+    if (deployItems.length === sub.items.data.length) {
+      // Deploy-only subscription: can't delete the last item, so cancel the
+      // whole subscription now. prorate:false = no plan-fee refund; invoice_now
+      // bills metered usage up to now. Usage after this point is not billed,
+      // because compute is not torn down here (ENG-2922).
+      await stripe.subscriptions.cancel(sub.id, { prorate: false, invoice_now: true });
+    } else {
+      // Mixed subscription: drop just the Deploy items now, keep the API items.
+      // One subscriptions.update marking each Deploy item deleted, so the
+      // removal is atomic: a per-item del loop that dies mid-way would leave
+      // orphaned metered items still billing while deploy_plan is never cleared.
+      // proration_behavior:none = no plan-fee refund. There is no invoice_now on
+      // this path, so metered usage since the last invoice on these meters is
+      // NOT billed; the teardown-then-bill flow in ENG-2922 is the real fix.
+      await stripe.subscriptions.update(sub.id, {
+        items: deployItems.map((item) => ({ id: item.id, deleted: true })),
+        proration_behavior: "none",
+      });
+    }
+
+    // Immediate cutoff: clear the plan now so access stops right away. One
+    // transaction so the clear and its audit log commit together; a failure in
+    // either rolls back the other. The resulting webhook reconciles to null.
+    await db.transaction(async (tx) => {
+      await tx
+        .update(schema.workspaces)
+        .set({ deployPlan: null })
+        .where(eq(schema.workspaces.id, ctx.workspace.id));
+      await insertAuditLogs(tx, {
+        workspaceId: ctx.workspace.id,
+        actor: { type: "user", id: ctx.user.id },
+        event: "workspace.update",
+        description: "Cancelled Unkey Deploy.",
+        resources: [],
+        context: { location: ctx.audit.location, userAgent: ctx.audit.userAgent },
+      });
+    });
+
+    await invalidateWorkspaceCache(ctx.tenant.id);
+  });

--- a/web/apps/dashboard/lib/trpc/routers/stripe/cancelSubscription.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/cancelSubscription.ts
@@ -1,4 +1,5 @@
 import { getStripeClient } from "@/lib/stripe";
+import { deployBillingConfig, findDeployItems } from "@/lib/stripe/deployBilling";
 import { TRPCError } from "@trpc/server";
 import { requireWorkspaceAdmin, workspaceProcedure } from "../../trpc";
 
@@ -17,6 +18,32 @@ export const cancelSubscription = workspaceProcedure
       throw new TRPCError({
         code: "PRECONDITION_FAILED",
         message: "Workspace doesn't have a stripe subscrption id.",
+      });
+    }
+
+    // Cancelling at period end ends the WHOLE subscription — on a mixed
+    // subscription that would silently take Compute (and its deployments)
+    // down with the API plan. Until per-item scheduled cancellation exists,
+    // require Compute to be cancelled first.
+    //
+    // Fail closed when config can't be resolved: a null config means we can't
+    // tell whether this subscription carries Compute, so proceeding would skip
+    // the guard and risk cancelling Compute along with the API plan. A transient
+    // resolution failure is better surfaced as a retryable error than as a
+    // silent Compute teardown.
+    const config = await deployBillingConfig();
+    if (!config) {
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: "Billing is temporarily unavailable. Please try again in a moment.",
+      });
+    }
+    const sub = await stripe.subscriptions.retrieve(ctx.workspace.stripeSubscriptionId);
+    if (findDeployItems(config, sub.items.data).length > 0) {
+      throw new TRPCError({
+        code: "PRECONDITION_FAILED",
+        message:
+          "This subscription also carries your Compute plan. Cancel Compute first, then cancel the API plan.",
       });
     }
 

--- a/web/apps/dashboard/lib/trpc/routers/stripe/changeDeployPlan.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/changeDeployPlan.ts
@@ -1,0 +1,100 @@
+import { insertAuditLogs } from "@/lib/audit";
+import { db, eq, schema } from "@/lib/db";
+import { getStripeClient } from "@/lib/stripe";
+import { deployBillingConfig, findPlanFeeItem } from "@/lib/stripe/deployBilling";
+import { DEPLOY_PLANS } from "@/lib/stripe/deployPlan";
+import { invalidateWorkspaceCache } from "@/lib/workspace-cache";
+import { TRPCError } from "@trpc/server";
+import Stripe from "stripe";
+import { z } from "zod";
+import { requireWorkspaceAdmin, workspaceProcedure } from "../../trpc";
+
+/**
+ * Switches the workspace's Unkey Deploy plan by repricing the plan-fee item on
+ * its subscription. Metered items are shared across plans, so they are left
+ * untouched. Writes workspaces.deploy_plan optimistically for instant UI;
+ * the subscription.updated webhook reconciles it to the same value.
+ */
+export const changeDeployPlan = workspaceProcedure
+  .use(requireWorkspaceAdmin)
+  .input(
+    z.object({
+      plan: z.enum(DEPLOY_PLANS),
+    }),
+  )
+  .mutation(async ({ ctx, input }) => {
+    const config = await deployBillingConfig();
+    if (!config) {
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: "Unkey Deploy billing is not configured.",
+      });
+    }
+
+    if (!ctx.workspace.stripeSubscriptionId) {
+      throw new TRPCError({
+        code: "PRECONDITION_FAILED",
+        message: "Workspace has no Unkey Deploy plan to change.",
+      });
+    }
+
+    const stripe = getStripeClient();
+    const sub = await stripe.subscriptions.retrieve(ctx.workspace.stripeSubscriptionId);
+
+    // Find the current plan-fee item by matching its price against the
+    // configured plan-fee ids, rather than trusting any client input.
+    const planFeeItem = findPlanFeeItem(config, sub.items.data);
+    if (!planFeeItem) {
+      throw new TRPCError({
+        code: "PRECONDITION_FAILED",
+        message: "Workspace has no Unkey Deploy plan to change.",
+      });
+    }
+
+    if (planFeeItem.plan === input.plan) {
+      // Already on the requested plan; nothing to do.
+      return;
+    }
+
+    const newPriceId = config.planFeePriceIds[input.plan];
+    try {
+      await stripe.subscriptionItems.update(planFeeItem.id, {
+        price: newPriceId,
+        proration_behavior: "create_prorations",
+        payment_behavior: "error_if_incomplete",
+      });
+    } catch (err) {
+      if (
+        err instanceof Stripe.errors.StripeCardError ||
+        err instanceof Stripe.errors.StripeError
+      ) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message:
+            err.message ||
+            "Payment could not be completed. Please update your payment method and try again.",
+        });
+      }
+      throw err;
+    }
+
+    // One transaction so the plan write and its audit log commit together; a
+    // failure in either rolls back the other. Written optimistically; the
+    // subscription.updated webhook reconciles deploy_plan to the same value.
+    await db.transaction(async (tx) => {
+      await tx
+        .update(schema.workspaces)
+        .set({ deployPlan: input.plan })
+        .where(eq(schema.workspaces.id, ctx.workspace.id));
+      await insertAuditLogs(tx, {
+        workspaceId: ctx.workspace.id,
+        actor: { type: "user", id: ctx.user.id },
+        event: "workspace.update",
+        description: `Changed Unkey Deploy plan to ${input.plan}.`,
+        resources: [],
+        context: { location: ctx.audit.location, userAgent: ctx.audit.userAgent },
+      });
+    });
+
+    await invalidateWorkspaceCache(ctx.tenant.id);
+  });

--- a/web/apps/dashboard/lib/trpc/routers/stripe/createSubscription.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/createSubscription.ts
@@ -2,6 +2,11 @@ import { insertAuditLogs } from "@/lib/audit";
 import { db, eq, schema } from "@/lib/db";
 import { stripeEnv } from "@/lib/env";
 import { getStripeClient } from "@/lib/stripe";
+import {
+  deployBillingConfig,
+  deployBillingConfigured,
+  findApiItem,
+} from "@/lib/stripe/deployBilling";
 import { validateAndParseQuotas } from "@/lib/stripe/productUtils";
 import { invalidateWorkspaceCache } from "@/lib/workspace-cache";
 import { TRPCError } from "@trpc/server";
@@ -9,6 +14,7 @@ import Stripe from "stripe";
 import { z } from "zod";
 import { requireWorkspaceAdmin, workspaceProcedure } from "../../trpc";
 import { clearWorkspaceCache } from "../workspace/getCurrent";
+import { assertSubscriptionAttachable } from "./subscriptionGuards";
 
 export const createSubscription = workspaceProcedure
   .use(requireWorkspaceAdmin)
@@ -78,11 +84,37 @@ export const createSubscription = workspaceProcedure
         message: "Workspaces does not have a stripe account.",
       });
     }
+
+    // A Compute-first workspace already has a subscription, carrying only
+    // Deploy items. Both products live on one subscription (one invoice), so
+    // the API item is appended to it — mirroring how subscribeDeploy appends
+    // Deploy items to an API-first subscription. Only a subscription that
+    // already carries an API plan item is refused.
+    let existingSub: Stripe.Subscription | undefined;
     if (ctx.workspace.stripeSubscriptionId) {
-      throw new TRPCError({
-        code: "PRECONDITION_FAILED",
-        message: `Customer ${ctx.workspace.stripeCustomerId} already has a subscription.`,
-      });
+      existingSub = await stripe.subscriptions.retrieve(ctx.workspace.stripeSubscriptionId);
+      // Fail closed when Deploy is configured but unresolved: findApiItem(null)
+      // falls back to items[0], which on a Compute-first subscription is a
+      // Deploy item, so the check below would wrongly report "already has an API
+      // plan". Unconfigured (no Deploy) still uses the items[0] fallback safely.
+      const deployConfig = await deployBillingConfig();
+      if (!deployConfig && deployBillingConfigured()) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Billing is temporarily unavailable. Please try again in a moment.",
+        });
+      }
+      if (findApiItem(deployConfig, existingSub.items.data)) {
+        throw new TRPCError({
+          code: "PRECONDITION_FAILED",
+          message: `Customer ${ctx.workspace.stripeCustomerId} already has an API plan.`,
+        });
+      }
+      // Same guards subscribeDeploy applies to its append path: don't attach
+      // the API item to a subscription that is delinquent, scheduled to cancel,
+      // or non-USD. cancel_at_period_end especially is accepted silently by
+      // Stripe, so the item would never bill next cycle.
+      assertSubscriptionAttachable(existingSub);
     }
 
     const customer = await stripe.customers.retrieve(ctx.workspace.stripeCustomerId);
@@ -94,30 +126,41 @@ export const createSubscription = workspaceProcedure
     }
 
     /**
-     * `error_if_incomplete` makes Stripe reject the create call with a 402 if the first
+     * `error_if_incomplete` makes Stripe reject the call with a 402 if the first
      * invoice cannot be paid (e.g. card declined). We rely on this to keep the workspace
      * on the Free tier when a first-time signup's payment fails — no DB writes happen
      * unless the subscription is fully active.
      */
     let sub: Stripe.Subscription;
     try {
-      sub = await stripe.subscriptions.create({
-        customer: customer.id,
-        items: [
-          {
-            price: product.default_price.toString(),
-          },
-        ],
-        billing_cycle_anchor_config: {
-          day_of_month: 1,
-        },
-        // Stripe API 2025-09-30 (clover) and later default new
-        // subscriptions to the "flexible" billing mode, which itemizes
-        // prorations differently. Stay on classic.
-        billing_mode: { type: "classic" },
-        proration_behavior: "always_invoice",
-        payment_behavior: "error_if_incomplete",
-      });
+      sub = existingSub
+        ? await stripe.subscriptions.update(existingSub.id, {
+            items: [
+              {
+                price: product.default_price.toString(),
+              },
+            ],
+            proration_behavior: "always_invoice",
+            payment_behavior: "error_if_incomplete",
+          })
+        : await stripe.subscriptions.create({
+            customer: customer.id,
+            items: [
+              {
+                price: product.default_price.toString(),
+              },
+            ],
+            billing_cycle_anchor_config: {
+              day_of_month: 1,
+            },
+            // Stripe API 2025-09-30 (clover) and later default new
+            // subscriptions to the "flexible" billing mode, which itemizes
+            // prorations differently and would change the Deploy
+            // credit-grant net-fee math. Stay on classic.
+            billing_mode: { type: "classic" },
+            proration_behavior: "always_invoice",
+            payment_behavior: "error_if_incomplete",
+          });
     } catch (err) {
       if (err instanceof Stripe.errors.StripeCardError) {
         throw new TRPCError({
@@ -138,9 +181,11 @@ export const createSubscription = workspaceProcedure
       throw err;
     }
 
-    if (sub.status !== "active" && sub.status !== "trialing") {
+    if (!existingSub && sub.status !== "active" && sub.status !== "trialing") {
       // Defensive guard: error_if_incomplete should make this unreachable, but never
-      // grant tier access to a subscription that isn't actually paid.
+      // grant tier access to a subscription that isn't actually paid. Only the
+      // freshly created subscription is cancelled here — on the append path the
+      // subscription pre-exists and carries the Compute plan.
       try {
         await stripe.subscriptions.cancel(sub.id);
       } catch (cancelErr) {

--- a/web/apps/dashboard/lib/trpc/routers/stripe/getBillingInfo.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/getBillingInfo.ts
@@ -1,5 +1,6 @@
 import { stripeEnv } from "@/lib/env";
 import { getStripeClient } from "@/lib/stripe";
+import { deployBillingConfig, findApiItem } from "@/lib/stripe/deployBilling";
 import { ratelimit, withRatelimit, workspaceProcedure } from "@/lib/trpc/trpc";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
@@ -58,16 +59,19 @@ export const getBillingInfo = workspaceProcedure
         : false,
     ]);
 
+    // The API plan item, skipping Deploy items: on a Compute-first
+    // subscription items[0] is a Deploy price, not the API plan.
+    const apiItem = subscription
+      ? findApiItem(await deployBillingConfig(), subscription.items.data)
+      : undefined;
+    // Product via the item's price; the plan field is legacy.
+    const apiProduct = apiItem?.price.product;
+    const currentProductId = typeof apiProduct === "string" ? apiProduct : apiProduct?.id;
+
     // Check if user has an active enterprise subscription
     let enterpriseProductId: string | undefined;
-    try {
-      const currentProductId = subscription?.items.data.at(0)?.plan.product?.toString();
-      if (currentProductId && e.STRIPE_PRODUCT_IDS_ENTERPRISE.includes(currentProductId)) {
-        enterpriseProductId = currentProductId;
-      }
-    } catch (error) {
-      // If subscription retrieval fails, default to showing only Pro products
-      console.error("Error checking enterprise subscription:", error);
+    if (currentProductId && e.STRIPE_PRODUCT_IDS_ENTERPRISE.includes(currentProductId)) {
+      enterpriseProductId = currentProductId;
     }
 
     const productIds = enterpriseProductId
@@ -93,6 +97,6 @@ export const getBillingInfo = workspaceProcedure
           }
         : undefined,
       hasPreviousSubscriptions,
-      currentProductId: subscription?.items.data.at(0)?.plan.product?.toString() ?? undefined,
+      currentProductId,
     };
   });

--- a/web/apps/dashboard/lib/trpc/routers/stripe/getDeployPlans.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/getDeployPlans.ts
@@ -1,0 +1,53 @@
+import { getStripeClient } from "@/lib/stripe";
+import { deployBillingConfig } from "@/lib/stripe/deployBilling";
+import { DEPLOY_PLANS, type DeployPlan } from "@/lib/stripe/deployPlan";
+import type Stripe from "stripe";
+import { workspaceProcedure } from "../../trpc";
+
+export type DeployPlanOption = {
+  plan: DeployPlan;
+  name: string;
+  description: string | null;
+  /** Plan-fee amount in the smallest currency unit (cents), or null if unset. */
+  amount: number | null;
+  currency: string;
+  /** Recurring interval (e.g. "month"), or null for non-recurring prices. */
+  interval: string | null;
+};
+
+/**
+ * Lists the available Unkey Deploy plans with their plan-fee pricing, for the
+ * subscribe / change UI. Unlike getDeploySubscription (which reads the local
+ * deploy_plan signal), this is a catalog read and hits Stripe, mirroring
+ * getProducts for the API plans. Returns configured=false when Deploy billing
+ * is not set up so the UI can hide the section gracefully.
+ */
+export const getDeployPlans = workspaceProcedure.query(async () => {
+  const config = await deployBillingConfig();
+  if (!config) {
+    return { configured: false as const, plans: [] as DeployPlanOption[] };
+  }
+
+  const stripe = getStripeClient();
+  const plans = await Promise.all(
+    DEPLOY_PLANS.map(async (plan): Promise<DeployPlanOption> => {
+      const price = await stripe.prices.retrieve(config.planFeePriceIds[plan], {
+        expand: ["product"],
+      });
+      const product = price.product;
+      const resolvedProduct =
+        typeof product !== "string" && !product.deleted ? (product as Stripe.Product) : null;
+
+      return {
+        plan,
+        name: resolvedProduct?.name ?? plan,
+        description: resolvedProduct?.description ?? null,
+        amount: price.unit_amount ?? null,
+        currency: price.currency,
+        interval: price.recurring?.interval ?? null,
+      };
+    }),
+  );
+
+  return { configured: true as const, plans };
+});

--- a/web/apps/dashboard/lib/trpc/routers/stripe/getDeploySubscription.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/getDeploySubscription.ts
@@ -1,0 +1,14 @@
+import { DEPLOY_PLANS, type DeployPlan } from "@/lib/stripe/deployPlan";
+import { workspaceProcedure } from "../../trpc";
+
+/**
+ * Returns the workspace's current Unkey Deploy plan, read from the local
+ * deploy_plan signal (synced from Stripe by the webhook). No Stripe call on
+ * read; null means no Deploy plan.
+ */
+export const getDeploySubscription = workspaceProcedure.query(({ ctx }) => {
+  const raw = ctx.workspace.deployPlan;
+  const plan: DeployPlan | null =
+    raw && (DEPLOY_PLANS as readonly string[]).includes(raw) ? (raw as DeployPlan) : null;
+  return { plan };
+});

--- a/web/apps/dashboard/lib/trpc/routers/stripe/getProducts.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/getProducts.ts
@@ -1,5 +1,6 @@
 import { stripeEnv } from "@/lib/env";
 import { getStripeClient } from "@/lib/stripe";
+import { deployBillingConfig, findApiItem } from "@/lib/stripe/deployBilling";
 import { ratelimit, withRatelimit, workspaceProcedure } from "@/lib/trpc/trpc";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
@@ -35,7 +36,11 @@ export const getProducts = workspaceProcedure
         const subscription = await stripe.subscriptions.retrieve(
           ctx.workspace.stripeSubscriptionId,
         );
-        const currentProductId = subscription.items.data.at(0)?.plan.product?.toString();
+        // The API item, skipping Deploy items (items[0] is a Deploy price on
+        // a Compute-first subscription); product via price, plan is legacy.
+        const apiItem = findApiItem(await deployBillingConfig(), subscription.items.data);
+        const product = apiItem?.price.product;
+        const currentProductId = typeof product === "string" ? product : product?.id;
         if (currentProductId && e.STRIPE_PRODUCT_IDS_ENTERPRISE.includes(currentProductId)) {
           enterpriseProductId = currentProductId;
         }

--- a/web/apps/dashboard/lib/trpc/routers/stripe/subscribeDeploy.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/subscribeDeploy.ts
@@ -1,0 +1,171 @@
+import { insertAuditLogs } from "@/lib/audit";
+import { db, eq, schema } from "@/lib/db";
+import { getStripeClient } from "@/lib/stripe";
+import {
+  deployBillingConfig,
+  deploySubscriptionItems,
+  findDeployItems,
+} from "@/lib/stripe/deployBilling";
+import { DEPLOY_PLANS } from "@/lib/stripe/deployPlan";
+import { invalidateWorkspaceCache } from "@/lib/workspace-cache";
+import { TRPCError } from "@trpc/server";
+import Stripe from "stripe";
+import { z } from "zod";
+import { requireWorkspaceAdmin, workspaceProcedure } from "../../trpc";
+import { assertSubscriptionAttachable } from "./subscriptionGuards";
+
+/**
+ * Subscribes the workspace to an Unkey Deploy plan: attaches the plan-fee price
+ * for the chosen tier plus the shared metered prices to the workspace's Stripe
+ * subscription, creating the subscription first if the workspace is on the free
+ * tier with no subscription yet.
+ *
+ * Writes workspaces.deploy_plan optimistically so the UI reflects the new plan
+ * immediately. Stripe stays source of truth: the resulting customer.subscription.*
+ * webhook reconciles the column, and since it derives the same value from the
+ * subscription we just mutated, that reconciliation is a no-op. The
+ * no-subscription path also writes stripeSubscriptionId so the webhook can find
+ * this workspace.
+ */
+export const subscribeDeploy = workspaceProcedure
+  .use(requireWorkspaceAdmin)
+  .input(
+    z.object({
+      plan: z.enum(DEPLOY_PLANS),
+    }),
+  )
+  .mutation(async ({ ctx, input }) => {
+    const config = await deployBillingConfig();
+    if (!config) {
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: "Unkey Deploy billing is not configured.",
+      });
+    }
+
+    if (!ctx.workspace.stripeCustomerId) {
+      throw new TRPCError({
+        code: "PRECONDITION_FAILED",
+        message: "Add a payment method before subscribing to Unkey Deploy.",
+      });
+    }
+
+    if (ctx.workspace.deployPlan) {
+      throw new TRPCError({
+        code: "PRECONDITION_FAILED",
+        message: "Workspace already has an Unkey Deploy plan. Use change instead.",
+      });
+    }
+
+    const stripe = getStripeClient();
+    const items = deploySubscriptionItems(config, input.plan);
+
+    // Columns to write once the Stripe mutation below succeeds, set in whichever
+    // branch runs. Written optimistically so the UI reflects the new plan now;
+    // the customer.subscription.* webhook reconciles them (a no-op, since it
+    // derives the same value from the subscription we just mutated).
+    let workspaceUpdate: { deployPlan: string; stripeSubscriptionId?: string };
+
+    if (ctx.workspace.stripeSubscriptionId) {
+      // Existing subscription (e.g. a paid API plan): append the Deploy items.
+      // Items not listed here are left untouched, so API items are preserved.
+      const sub = await stripe.subscriptions.retrieve(ctx.workspace.stripeSubscriptionId);
+
+      if (findDeployItems(config, sub.items.data).length > 0) {
+        throw new TRPCError({
+          code: "PRECONDITION_FAILED",
+          message: "Workspace already has Unkey Deploy items on its subscription.",
+        });
+      }
+
+      // Deploy items only attach to a subscription that will actually keep
+      // billing them; reject anything else here instead of letting Stripe
+      // attach to a subscription that ends at the period roll.
+      assertSubscriptionAttachable(sub);
+
+      try {
+        await stripe.subscriptions.update(sub.id, {
+          items,
+          proration_behavior: "always_invoice",
+          payment_behavior: "error_if_incomplete",
+        });
+      } catch (err) {
+        throw toBillingError(err);
+      }
+
+      workspaceUpdate = { deployPlan: input.plan };
+    } else {
+      // Free tier: create a subscription whose initial items are the Deploy set.
+      // error_if_incomplete keeps us off a half-paid state if the card declines.
+      let sub: Stripe.Subscription;
+      try {
+        sub = await stripe.subscriptions.create({
+          customer: ctx.workspace.stripeCustomerId,
+          items,
+          billing_cycle_anchor_config: { day_of_month: 1 },
+          // Pin classic billing mode (clover defaults new subscriptions to
+          // "flexible", which itemizes prorations differently); see the same
+          // pin in createSubscription.
+          billing_mode: { type: "classic" },
+          proration_behavior: "always_invoice",
+          payment_behavior: "error_if_incomplete",
+        });
+      } catch (err) {
+        throw toBillingError(err);
+      }
+
+      if (sub.status !== "active" && sub.status !== "trialing") {
+        try {
+          await stripe.subscriptions.cancel(sub.id);
+        } catch (cancelErr) {
+          console.error(
+            `Failed to cancel non-active subscription ${sub.id} after creation:`,
+            cancelErr,
+          );
+        }
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: `Subscription was created but is not active (ID: ${sub.id}). Please contact support.`,
+        });
+      }
+
+      // Link the new subscription so the customer.subscription.* webhook can
+      // resolve this workspace.
+      workspaceUpdate = { stripeSubscriptionId: sub.id, deployPlan: input.plan };
+    }
+
+    // One transaction so the plan write and its audit log commit together; a
+    // failure in either rolls back the other.
+    await db.transaction(async (tx) => {
+      await tx
+        .update(schema.workspaces)
+        .set(workspaceUpdate)
+        .where(eq(schema.workspaces.id, ctx.workspace.id));
+      await insertAuditLogs(tx, {
+        workspaceId: ctx.workspace.id,
+        actor: { type: "user", id: ctx.user.id },
+        event: "workspace.update",
+        description: `Subscribed to Unkey Deploy ${input.plan} plan.`,
+        resources: [],
+        context: { location: ctx.audit.location, userAgent: ctx.audit.userAgent },
+      });
+    });
+
+    await invalidateWorkspaceCache(ctx.tenant.id);
+  });
+
+/**
+ * Surfaces Stripe payment errors as actionable TRPCErrors; rethrows anything
+ * else so genuine bugs are not masked as a card problem.
+ */
+function toBillingError(err: unknown): TRPCError {
+  if (err instanceof Stripe.errors.StripeCardError || err instanceof Stripe.errors.StripeError) {
+    return new TRPCError({
+      code: "BAD_REQUEST",
+      message:
+        err.message ||
+        "Payment could not be completed. Please update your payment method and try again.",
+    });
+  }
+  throw err;
+}

--- a/web/apps/dashboard/lib/trpc/routers/stripe/subscriptionGuards.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/subscriptionGuards.ts
@@ -1,0 +1,34 @@
+import { TRPCError } from "@trpc/server";
+import type Stripe from "stripe";
+
+/**
+ * Guards that a pre-existing subscription can safely have a new billed item
+ * attached. Stripe silently accepts attaching an item to a subscription that is
+ * scheduled to cancel (the item then never bills next cycle), and to a non-USD
+ * subscription, so these are checked explicitly rather than left to
+ * error_if_incomplete. Used by both subscribeDeploy (adding Deploy items) and
+ * createSubscription (adding the API plan) so the two append paths stay in
+ * lock-step. Decided in ENG-2876.
+ */
+export function assertSubscriptionAttachable(sub: Stripe.Subscription): void {
+  if (sub.status !== "active" && sub.status !== "trialing") {
+    throw new TRPCError({
+      code: "PRECONDITION_FAILED",
+      message: `Your subscription is ${sub.status.replace(/_/g, " ")}. Settle any outstanding invoices before changing your plan.`,
+    });
+  }
+  if (sub.cancel_at_period_end) {
+    throw new TRPCError({
+      code: "PRECONDITION_FAILED",
+      message:
+        "Your subscription is set to cancel at the end of this period. Resume it before adding a plan, or wait until it ends to start fresh.",
+    });
+  }
+  if (sub.currency !== "usd") {
+    throw new TRPCError({
+      code: "PRECONDITION_FAILED",
+      message:
+        "Prices are in USD and cannot be added to a non-USD subscription. Contact support@unkey.com.",
+    });
+  }
+}

--- a/web/apps/dashboard/lib/trpc/routers/stripe/updateSubscription.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/updateSubscription.ts
@@ -2,6 +2,11 @@ import { insertAuditLogs } from "@/lib/audit";
 import { db, eq, schema } from "@/lib/db";
 import { stripeEnv } from "@/lib/env";
 import { getStripeClient } from "@/lib/stripe";
+import {
+  deployBillingConfig,
+  deployBillingConfigured,
+  findApiItem,
+} from "@/lib/stripe/deployBilling";
 import { validateAndParseQuotas } from "@/lib/stripe/productUtils";
 import { invalidateWorkspaceCache } from "@/lib/workspace-cache";
 import { TRPCError } from "@trpc/server";
@@ -87,20 +92,29 @@ export const updateSubscription = workspaceProcedure
 
     // Derive the current subscription item from the existing subscription
     // rather than trusting a client-supplied `oldProductId`. The client should
-    // not be able to influence which item gets repriced.
-    const item = sub.items.data[0];
+    // not be able to influence which item gets repriced. On a mixed
+    // subscription the Deploy items (plan-fee + meters) are skipped — items[0]
+    // would be one of them on a Compute-first subscription, and repricing it
+    // to an API price would destroy the Compute plan.
+    //
+    // Fail closed when Deploy is configured but its config can't be resolved:
+    // findApiItem(null) falls back to items[0], which on a Compute-first
+    // subscription is a Deploy item, so repricing under a transient resolution
+    // failure would destroy Compute. Unconfigured (no Deploy at all) still uses
+    // the items[0] fallback safely.
+    const deployConfig = await deployBillingConfig();
+    if (!deployConfig && deployBillingConfigured()) {
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: "Billing is temporarily unavailable. Please try again in a moment.",
+      });
+    }
+    const item = findApiItem(deployConfig, sub.items.data);
 
     if (!item) {
       throw new TRPCError({
         code: "PRECONDITION_FAILED",
-        message: "Subscription has no items to update.",
-      });
-    }
-
-    if (!item.id) {
-      throw new TRPCError({
-        code: "INTERNAL_SERVER_ERROR",
-        message: "Subscription item is missing an ID.",
+        message: "Subscription has no API plan item to update.",
       });
     }
 


### PR DESCRIPTION
# DO NOT AUTOMERGE! 

Stripe products have to be created first using our billing tool and setting some metadata in our current products for both prod and preview

---------

Adds a small plan picker for compute plans, this is not the final ui it will get polished abit more in a following pr but just to test the flow quickly. 

- **tRPC**: `subscribeDeploy` (attach the plan-fee + metered prices to the workspace's existing Stripe subscription, or create one on the free tier), `changeDeployPlan` (reprice the plan-fee item), `cancelDeploy` (**immediate** cutoff — no open metered tab — no refund), and `getDeploySubscription` / `getDeployPlans` reads.
- **UI**: behind `deployBilling`, a separate two-product billing page (API Management + Compute as peers) with a tiled plan picker.
- Mutations mutate Stripe; the webhook (PR #6397) reconciles `deploy_plan`. Optimistic writes on subscribe/change for instant UI.

Closes ENG-2873.
Part of ENG-2872 (attach to existing subscription).

UI here is not the goal its behind a flag anyways 

<img width="2968" height="2410" alt="CleanShot 2026-06-16 at 16 53 52@2x" src="https://github.com/user-attachments/assets/b70bc94c-eaa2-404f-89c5-9491247f0bc9" />
<img width="1908" height="1170" alt="CleanShot 2026-06-16 at 16 54 24@2x" src="https://github.com/user-attachments/assets/810c9ceb-d376-4ac6-993f-a6cc91be44bc" />


