### PR TITLE
perf(web): replace handler-only useState with useRef

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/keys/[keyAuthId]/[keyId]/components/table/logs-table.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/keys/[keyAuthId]/[keyId]/components/table/logs-table.tsx
@@ -10,7 +10,7 @@ import { useQueryTime } from "@/providers/query-time-provider";
 import type { RowSelectionState } from "@tanstack/react-table";
 import type { KeyDetailsLog } from "@unkey/clickhouse/src/verifications";
 import { DataTable, PaginationFooter } from "@unkey/ui";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useKeyDetailsLogsContext } from "../../context/logs";
 
 type Props = {
@@ -39,7 +39,7 @@ export const KeyDetailsLogsTable = ({ keyspaceId, keyId, selectedLog, onLogSelec
     pollIntervalMs: 2000,
   });
 
-  const [hoveredLogId, setHoveredLogId] = useState<string | null>(null);
+  const hoveredLogIdRef = useRef<string | null>(null);
   const { queryTime: timestamp } = useQueryTime();
   const utils = trpc.useUtils();
   const hoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -56,8 +56,8 @@ export const KeyDetailsLogsTable = ({ keyspaceId, keyId, selectedLog, onLogSelec
 
   const handleRowHover = useCallback(
     (log: KeyDetailsLog) => {
-      if (log.request_id !== hoveredLogId) {
-        setHoveredLogId(log.request_id);
+      if (log.request_id !== hoveredLogIdRef.current) {
+        hoveredLogIdRef.current = log.request_id;
 
         // Debounce the prefetch so rapid mouse movement across rows
         // doesn't fire N separate queryLogs API calls.
@@ -89,11 +89,11 @@ export const KeyDetailsLogsTable = ({ keyspaceId, keyId, selectedLog, onLogSelec
         }, 150);
       }
     },
-    [hoveredLogId, utils.logs.queryLogs, timestamp],
+    [utils.logs.queryLogs, timestamp],
   );
 
   const handleRowMouseLeave = useCallback(() => {
-    setHoveredLogId(null);
+    hoveredLogIdRef.current = null;
     if (hoverTimerRef.current) {
       clearTimeout(hoverTimerRef.current);
       hoverTimerRef.current = null;

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/identities/[identityId]/components/table/components/log-details/index.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/identities/[identityId]/components/table/components/log-details/index.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useEffect, useRef } from "react";
 
 import { LogDetails } from "@/components/logs/details/log-details";
 import type { IdentityLog } from "@/lib/trpc/routers/identity/query-logs";
@@ -17,10 +17,10 @@ export const IdentityDetailsDrawer = ({ distanceToTop, onLogSelect, selectedLog 
     requestId: selectedLog?.request_id,
   });
 
-  const [errorShown, setErrorShown] = useState(false);
+  const errorShownRef = useRef(false);
 
   useEffect(() => {
-    if (!errorShown && selectedLog && !isLoading) {
+    if (!errorShownRef.current && selectedLog && !isLoading) {
       if (error) {
         toast.error("Error Loading Log Details", {
           description: `${
@@ -28,20 +28,20 @@ export const IdentityDetailsDrawer = ({ distanceToTop, onLogSelect, selectedLog 
             "An unexpected error occurred while fetching log data. Please try again."
           }`,
         });
-        setErrorShown(true);
+        errorShownRef.current = true;
       } else if (!log) {
         toast.error("Log Data Unavailable", {
           description:
             "Could not retrieve log information for this identity. The log may have been deleted or is still processing.",
         });
-        setErrorShown(true);
+        errorShownRef.current = true;
       }
     }
 
     if (!selectedLog) {
-      setErrorShown(false);
+      errorShownRef.current = false;
     }
-  }, [error, log, selectedLog, errorShown, isLoading]);
+  }, [error, log, selectedLog, isLoading]);
 
   const handleClose = () => {
     onLogSelect(null);

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/identities/[identityId]/components/table/logs-table.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/identities/[identityId]/components/table/logs-table.tsx
@@ -24,7 +24,7 @@ import {
   TriangleWarning2,
 } from "@unkey/icons";
 import { Badge, Button, CopyButton, Empty, InfoTooltip, TimestampInfo } from "@unkey/ui";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { useIdentityDetailsLogsContext } from "../../context/logs";
 import { useIdentityLogsQuery } from "./hooks/use-logs-query";
 
@@ -139,7 +139,7 @@ export const IdentityDetailsLogsTable = ({ identityId, selectedLog, onLogSelect 
     );
   };
 
-  const [hoveredLogId, setHoveredLogId] = useState<string | null>(null);
+  const hoveredLogIdRef = useRef<string | null>(null);
   const { queryTime: timestamp } = useQueryTime();
   const utils = trpc.useUtils();
   const hoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -156,8 +156,8 @@ export const IdentityDetailsLogsTable = ({ identityId, selectedLog, onLogSelect 
 
   const handleRowHover = useCallback(
     (log: IdentityLog) => {
-      if (log.request_id !== hoveredLogId) {
-        setHoveredLogId(log.request_id);
+      if (log.request_id !== hoveredLogIdRef.current) {
+        hoveredLogIdRef.current = log.request_id;
 
         // Debounce the prefetch so rapid mouse movement across rows
         // doesn't fire N separate queryLogs API calls.
@@ -189,11 +189,11 @@ export const IdentityDetailsLogsTable = ({ identityId, selectedLog, onLogSelect 
         }, 150);
       }
     },
-    [hoveredLogId, utils.logs.queryLogs, timestamp],
+    [utils.logs.queryLogs, timestamp],
   );
 
   const handleRowMouseLeave = useCallback(() => {
-    setHoveredLogId(null);
+    hoveredLogIdRef.current = null;
     if (hoverTimerRef.current) {
       clearTimeout(hoverTimerRef.current);
       hoverTimerRef.current = null;

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/sentinel-policies/components/list/index.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/sentinel-policies/components/list/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { SentinelPolicy } from "@/lib/collections/deploy/sentinel-policies.schema";
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import type { MergedPolicy } from "./merge";
 import { SentinelPolicyRow } from "./row";
 
@@ -26,7 +26,7 @@ export function SentinelPoliciesList({
   onDelete,
   onEdit,
 }: SentinelPoliciesListProps) {
-  const [dragSrcIndex, setDragSrcIndex] = useState<number | null>(null);
+  const dragSrcIndexRef = useRef<number | null>(null);
   const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
 
   const handleToggleEnvA = useCallback((id: string) => onToggleEnv(id, "envA"), [onToggleEnv]);
@@ -35,7 +35,7 @@ export function SentinelPoliciesList({
   const handleAddToEnvB = useCallback((id: string) => onAddToEnv(id, "envB"), [onAddToEnv]);
 
   const handleDragStart = useCallback((index: number) => {
-    setDragSrcIndex(index);
+    dragSrcIndexRef.current = index;
   }, []);
 
   const handleDragOver = useCallback((index: number) => {
@@ -44,8 +44,9 @@ export function SentinelPoliciesList({
 
   const handleDrop = useCallback(
     (targetIndex: number) => {
+      const dragSrcIndex = dragSrcIndexRef.current;
       if (dragSrcIndex === null || dragSrcIndex === targetIndex) {
-        setDragSrcIndex(null);
+        dragSrcIndexRef.current = null;
         setDragOverIndex(null);
         return;
       }
@@ -66,14 +67,14 @@ export function SentinelPoliciesList({
       if (envs.length > 0) {
         onReorder(envs, orderedIds);
       }
-      setDragSrcIndex(null);
+      dragSrcIndexRef.current = null;
       setDragOverIndex(null);
     },
-    [dragSrcIndex, merged, onReorder],
+    [merged, onReorder],
   );
 
   const handleDragEnd = useCallback(() => {
-    setDragSrcIndex(null);
+    dragSrcIndexRef.current = null;
     setDragOverIndex(null);
   }, []);
 

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/new/steps/connect-github.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/new/steps/connect-github.tsx
@@ -2,7 +2,7 @@
 import { trpc } from "@/lib/trpc/client";
 import { Github, Layers3 } from "@unkey/icons";
 import { Button, toast } from "@unkey/ui";
-import { useState } from "react";
+import { useRef } from "react";
 import { OnboardingLinks } from "../onboarding-links";
 
 type ConnectGithubStepProps = {
@@ -20,18 +20,18 @@ export const ConnectGithubStep = ({
   // We can't compute it client-side without a server round-trip, so we mint
   // it lazily when the user clicks Import.
   const prepare = trpc.github.prepareInstallation.useMutation();
-  const [isPreparing, setIsPreparing] = useState(false);
+  const isPreparingRef = useRef(false);
   const handleClick = async () => {
-    if (isPreparing) {
+    if (isPreparingRef.current) {
       return;
     }
-    setIsPreparing(true);
+    isPreparingRef.current = true;
     try {
       const { state } = await prepare.mutateAsync({ projectId, appId });
       onBeforeNavigate?.();
       window.location.href = `https://github.com/apps/${process.env.NEXT_PUBLIC_GITHUB_APP_NAME}/installations/new?state=${encodeURIComponent(state)}`;
     } catch (err) {
-      setIsPreparing(false);
+      isPreparingRef.current = false;
       toast.error(err instanceof Error ? err.message : "Failed to start GitHub install");
     }
   };

--- a/web/apps/dashboard/components/api-keys-table/components/actions/components/edit-external-id/index.tsx
+++ b/web/apps/dashboard/components/api-keys-table/components/actions/components/edit-external-id/index.tsx
@@ -21,7 +21,7 @@ export const EditExternalId = ({
   const [selectedIdentityId, setSelectedIdentityId] = useState<string | null>(
     keyDetails.identity_id || null,
   );
-  const [selectedExternalId, setSelectedExternalId] = useState<string | null>(null);
+  const selectedExternalIdRef = useRef<string | null>(null);
   const [isConfirmPopoverOpen, setIsConfirmPopoverOpen] = useState(false);
   const clearButtonRef = useRef<HTMLButtonElement>(null);
 
@@ -36,7 +36,7 @@ export const EditExternalId = ({
       ownerType: "v2",
       identity: {
         id: selectedIdentityId,
-        externalId: selectedExternalId,
+        externalId: selectedExternalIdRef.current,
       },
     });
   };
@@ -125,7 +125,7 @@ export const EditExternalId = ({
           value={selectedIdentityId}
           onChange={(identityId: string | null, externalId: string | null) => {
             setSelectedIdentityId(identityId);
-            setSelectedExternalId(externalId);
+            selectedExternalIdRef.current = externalId;
           }}
           currentIdentity={
             keyDetails.identity_id

--- a/web/apps/dashboard/components/api-keys-table/components/selection-controls/components/batch-edit-external-id.tsx
+++ b/web/apps/dashboard/components/api-keys-table/components/selection-controls/components/batch-edit-external-id.tsx
@@ -18,7 +18,7 @@ export const BatchEditExternalId = ({
   onClose,
 }: BatchEditExternalIdProps): JSX.Element => {
   const [selectedIdentityId, setSelectedIdentityId] = useState<string | null>(null);
-  const [selectedExternalId, setSelectedExternalId] = useState<string | null>(null);
+  const selectedExternalIdRef = useRef<string | null>(null);
   const [isConfirmPopoverOpen, setIsConfirmPopoverOpen] = useState(false);
   const clearButtonRef = useRef<HTMLButtonElement>(null);
 
@@ -32,7 +32,7 @@ export const BatchEditExternalId = ({
       ownerType: "v2",
       identity: {
         id: selectedIdentityId,
-        externalId: selectedExternalId,
+        externalId: selectedExternalIdRef.current,
       },
     });
   };
@@ -145,7 +145,7 @@ export const BatchEditExternalId = ({
             value={selectedIdentityId}
             onChange={(identityId: string | null, externalId: string | null) => {
               setSelectedIdentityId(identityId);
-              setSelectedExternalId(externalId);
+              selectedExternalIdRef.current = externalId;
             }}
             disabled={updateKeyOwner.isLoading}
           />

--- a/web/apps/dashboard/components/auth/post-auth-invitation-handler.tsx
+++ b/web/apps/dashboard/components/auth/post-auth-invitation-handler.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter, useSearchParams } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useRef } from "react";
 
 interface PostAuthInvitationHandlerProps {
   /**
@@ -27,11 +27,11 @@ export function PostAuthInvitationHandler({
 }: PostAuthInvitationHandlerProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const [isProcessing, setIsProcessing] = useState(false);
-  const [hasProcessed, setHasProcessed] = useState(false);
+  const isProcessingRef = useRef(false);
+  const hasProcessedRef = useRef(false);
 
   useEffect(() => {
-    if (!autoProcess || hasProcessed) {
+    if (!autoProcess || hasProcessedRef.current) {
       return;
     }
 
@@ -47,13 +47,13 @@ export function PostAuthInvitationHandler({
     }, 500);
 
     return () => clearTimeout(timer);
-  }, [autoProcess, hasProcessed, searchParams]);
+  }, [autoProcess, searchParams]);
 
   const processInvitation = async (invitationToken: string, retryCount = 0) => {
-    if (isProcessing) {
+    if (isProcessingRef.current) {
       return;
     }
-    setIsProcessing(true);
+    isProcessingRef.current = true;
 
     try {
       const response = await fetch("/api/auth/invitation", {
@@ -87,7 +87,7 @@ export function PostAuthInvitationHandler({
       } else {
         // If authentication failed and we haven't retried too many times, try again
         if (response.status === 401 && retryCount < 2) {
-          setIsProcessing(false);
+          isProcessingRef.current = false;
           setTimeout(() => {
             processInvitation(invitationToken, retryCount + 1);
           }, 1000);
@@ -101,7 +101,7 @@ export function PostAuthInvitationHandler({
 
       // Retry on network errors if we haven't retried too many times
       if (retryCount < 2) {
-        setIsProcessing(false);
+        isProcessingRef.current = false;
         setTimeout(() => {
           processInvitation(invitationToken, retryCount + 1);
         }, 2000);
@@ -110,8 +110,8 @@ export function PostAuthInvitationHandler({
 
       onComplete?.(false, errorMessage);
     } finally {
-      setIsProcessing(false);
-      setHasProcessed(true);
+      isProcessingRef.current = false;
+      hasProcessedRef.current = true;
     }
   };
 

--- a/web/apps/dashboard/components/logs/checkbox/filters-popover.tsx
+++ b/web/apps/dashboard/components/logs/checkbox/filters-popover.tsx
@@ -63,7 +63,7 @@ export const FiltersPopover = ({
 }: PropsWithChildren<FiltersPopoverProps>) => {
   const [focusedIndex, setFocusedIndex] = useState<number | null>(null);
   const [activeFilter, setActiveFilter] = useState<string | null>(null);
-  const [lastFocusedIndex, setLastFocusedIndex] = useState<number | null>(null);
+  const lastFocusedIndexRef = useRef<number | null>(null);
   const triggerRef = useRef<HTMLButtonElement | null>(null);
 
   // Handle local state if external state isn't provided
@@ -86,15 +86,15 @@ export const FiltersPopover = ({
     if (!isOpen) {
       setActiveFilter(null);
       setFocusedIndex(null);
-      setLastFocusedIndex(null);
+      lastFocusedIndexRef.current = null;
     }
   }, [isOpen]);
 
   useEffect(() => {
-    if (!activeFilter && lastFocusedIndex !== null && isOpen) {
-      setFocusedIndex(lastFocusedIndex);
+    if (!activeFilter && lastFocusedIndexRef.current !== null && isOpen) {
+      setFocusedIndex(lastFocusedIndexRef.current);
     }
-  }, [activeFilter, lastFocusedIndex, isOpen]);
+  }, [activeFilter, isOpen]);
 
   useKeyboardShortcut(
     "f",
@@ -118,7 +118,7 @@ export const FiltersPopover = ({
         const index = items.findIndex((i) => i.id === id);
         if (index !== -1) {
           setFocusedIndex(index);
-          setLastFocusedIndex(index);
+          lastFocusedIndexRef.current = index;
         }
       }, 0);
     },
@@ -142,7 +142,7 @@ export const FiltersPopover = ({
         e.preventDefault();
         const closingIndex = items.findIndex((i) => i.id === activeFilter);
         if (closingIndex !== -1) {
-          setLastFocusedIndex(closingIndex); // Remember index to return focus to
+          lastFocusedIndexRef.current = closingIndex; // Remember index to return focus to
         }
         setActiveFilter(null); // Deactivate child popover
         // useEffect [activeFilter] will handle setting focusedIndex based on lastFocusedIndex
@@ -157,7 +157,7 @@ export const FiltersPopover = ({
         e.preventDefault();
         const newIndex = focusedIndex === null ? 0 : (focusedIndex + 1) % items.length;
         setFocusedIndex(newIndex);
-        setLastFocusedIndex(newIndex); // Keep track for potential activation
+        lastFocusedIndexRef.current = newIndex; // Keep track for potential activation
         break;
       }
       case "ArrowUp": {
@@ -167,7 +167,7 @@ export const FiltersPopover = ({
             ? items.length - 1
             : (focusedIndex - 1 + items.length) % items.length;
         setFocusedIndex(newIndex);
-        setLastFocusedIndex(newIndex); // Keep track
+        lastFocusedIndexRef.current = newIndex; // Keep track
         break;
       }
       case "Enter":
@@ -176,7 +176,7 @@ export const FiltersPopover = ({
         if (focusedIndex !== null) {
           const selectedFilter = items[focusedIndex];
           if (selectedFilter) {
-            setLastFocusedIndex(focusedIndex); // Store index before activating
+            lastFocusedIndexRef.current = focusedIndex; // Store index before activating
             setActiveFilter(selectedFilter.id); // Activate the child popover
           }
         }

--- a/web/apps/dashboard/components/logs/queries/queries-popover.tsx
+++ b/web/apps/dashboard/components/logs/queries/queries-popover.tsx
@@ -36,16 +36,16 @@ export function QueriesPopover<T extends FilterValue, U extends QueryParamsTypes
   const [open, setOpen] = useState(false);
   const [focusedTabIndex, setFocusedTabIndex] = useState(0);
   const [selectedQueryIndex, setSelectedQueryIndex] = useState(0);
-  const [isDisabled, setIsDisabled] = useState(false);
+  const isDisabledRef = useRef(false);
 
   useKeyboardShortcut("q", () => {
-    if (!open && !isDisabled) {
+    if (!open && !isDisabledRef.current) {
       setOpen(true);
       setSelectedQueryIndex(0);
       setFocusedTabIndex(0);
-      setIsDisabled(filters.length === 0);
+      isDisabledRef.current = filters.length === 0;
     } else {
-      setIsDisabled(filters.length === 0);
+      isDisabledRef.current = filters.length === 0;
       setOpen(false);
       setFocusedTabIndex(0);
       setSelectedQueryIndex(0);

--- a/web/internal/ui/src/components/buttons/refresh-button.tsx
+++ b/web/internal/ui/src/components/buttons/refresh-button.tsx
@@ -2,7 +2,7 @@
 import { Refresh3 } from "@unkey/icons";
 // biome-ignore lint: React in this context is used throughout, so biome will change to types because no APIs are used even though React is needed.
 import * as React from "react";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useKeyboardShortcut } from "../../hooks/use-keyboard-shortcut";
 import { InfoTooltip } from "../info-tooltip";
 import { Button } from "./button";
@@ -19,7 +19,7 @@ const REFRESH_TIMEOUT_MS = 1000;
 
 const RefreshButton = ({ onRefresh, isEnabled, isLive, toggleLive }: RefreshButtonProps) => {
   const [isLoading, setIsLoading] = useState(false);
-  const [refreshTimeout, setRefreshTimeout] = useState<NodeJS.Timeout | null>(null);
+  const refreshTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   const handleRefresh = () => {
     if (isLoading) {
@@ -30,18 +30,16 @@ const RefreshButton = ({ onRefresh, isEnabled, isLive, toggleLive }: RefreshButt
     toggleLive?.(false);
     onRefresh();
 
-    if (refreshTimeout) {
-      clearTimeout(refreshTimeout);
+    if (refreshTimeoutRef.current) {
+      clearTimeout(refreshTimeoutRef.current);
     }
 
-    const timeout = setTimeout(() => {
+    refreshTimeoutRef.current = setTimeout(() => {
       setIsLoading(false);
       if (isLiveBefore) {
         toggleLive?.(true);
       }
     }, REFRESH_TIMEOUT_MS);
-
-    setRefreshTimeout(timeout);
   };
 
   useKeyboardShortcut("option+shift+w", handleRefresh, {


### PR DESCRIPTION
## Summary

Fixes 12 of 19 `react-doctor/rerender-state-only-in-handlers` findings (Performance, warn). These `useState` values were written by event handlers but never read anywhere on the render path, so every update re-rendered the component for nothing. They are now `useRef`s, which update without re-rendering.

Notable wins:
- The key/identity logs tables re-rendered the entire (virtualized) table on **every row hover and leave** just to dedupe prefetch calls — hovering now causes zero re-renders.
- `post-auth-invitation-handler` and `queries-popover` also had stale-closure guards that the ref fixes as a side effect (the old async `isProcessing` check read a stale value).

## Intentionally not changed (false positives per the rule's validation recipe)

In these 7 flagged sites the state-driven re-render is load-bearing (it re-runs an effect or the value actually reaches JSX), and a ref would silently break behavior: `time-split`, sign-in page, `resizable-panel`, `table-action.popover`, `list-group`, `chart-loading`, `proximity-prefetch`.

## Verification

- `npx react-doctor@latest --verbose` re-run: rule count 19 → 7, all 7 remaining are the documented false positives above
- `tsc`: dashboard 0 errors; `@unkey/ui` unchanged at its 1289 pre-existing errors (no typecheck script in that package)
- `biome check`: clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)