### PR TITLE
fix(web): add keyboard access to click-only controls

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/settings/components/runtime-settings/regions.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/settings/components/runtime-settings/regions.tsx
@@ -76,8 +76,10 @@ const RegionTags = ({
             />
             {r}
             {canRemove && (
-              //biome-ignore lint/a11y/useKeyWithClickEvents: we can't use button here otherwise we'll nest two buttons
-              <span
+              // The surrounding tag is a span (even as TooltipTrigger asChild), so a native button does not nest interactives.
+              <button
+                type="button"
+                aria-label={`Remove region ${r}`}
                 onClick={(e) => {
                   e.stopPropagation();
                   onRemove(r);
@@ -85,7 +87,7 @@ const RegionTags = ({
                 className="p-0.5 hover:bg-grayA-4 rounded text-grayA-9 hover:text-accent-12 transition-colors"
               >
                 <XMark iconSize="sm-regular" />
-              </span>
+              </button>
             )}
           </span>
         );

--- a/web/apps/dashboard/components/logs/details/request-response-details.tsx
+++ b/web/apps/dashboard/components/logs/details/request-response-details.tsx
@@ -60,15 +60,27 @@ export const RequestResponseDetails = <T extends unknown[]>({ fields, className 
   };
 
   const renderField = (field: Field<T[number]>, index: number) => {
+    const isCopyable = !field.skipTooltip;
     const baseContent = (
-      // biome-ignore lint/a11y/useKeyWithClickEvents: no need
       <div
         className={cn(
           "flex w-full justify-between border-grayA-3 border-solid pr-3 py-3 items-center cursor-pointer",
           "border-b",
           field.className,
         )}
-        onClick={field.skipTooltip ? undefined : () => handleClick(field)}
+        onClick={isCopyable ? () => handleClick(field) : undefined}
+        onKeyDown={
+          isCopyable
+            ? (e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  handleClick(field);
+                }
+              }
+            : undefined
+        }
+        role={isCopyable ? "button" : undefined}
+        tabIndex={isCopyable ? 0 : undefined}
       >
         <span className="text-accent-11 text-[13px] lg:no-wrap text-left">{field.label}</span>
         <span className="text-accent-12 text-right w-3/4">

--- a/web/apps/dashboard/components/virtual-table/index.tsx
+++ b/web/apps/dashboard/components/virtual-table/index.tsx
@@ -528,13 +528,24 @@ function HeaderCell<T>({ column }: { column: Column<T> }) {
   };
 
   return (
-    // biome-ignore lint/a11y/useKeyWithClickEvents: <explanation>
     <div
       className={cn(
         "flex items-center gap-1 truncate text-accent-12",
         sortable && "cursor-pointer",
       )}
       onClick={sortable ? handleSort : undefined}
+      onKeyDown={
+        sortable
+          ? (e: React.KeyboardEvent) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                handleSort();
+              }
+            }
+          : undefined
+      }
+      role={sortable ? "button" : undefined}
+      tabIndex={sortable ? 0 : undefined}
     >
       <span>{column.header}</span>
       {sortable && (

--- a/web/internal/ui/src/components/data-table/components/cells/hidden-value-cell.tsx
+++ b/web/internal/ui/src/components/data-table/components/cells/hidden-value-cell.tsx
@@ -27,8 +27,9 @@ export const HiddenValueCell = ({ value, title = "Value", selected }: HiddenValu
 
   return (
     <>
-      {/* biome-ignore lint/a11y/useKeyWithClickEvents: <explanation> */}
-      <div
+      <button
+        type="button"
+        aria-label={`Copy ${title} to clipboard`}
         className={cn(
           "rounded-lg border bg-white dark:bg-base-12 border-accent-4 text-grayA-11 w-[150px] px-2 py-1 flex gap-2 items-center cursor-pointer h-[28px] group-hover:border-grayA-3 font-mono",
           selected && "border-grayA-3",
@@ -39,7 +40,7 @@ export const HiddenValueCell = ({ value, title = "Value", selected }: HiddenValu
           <CircleLock iconSize="sm-regular" className="text-gray-9" />
         </div>
         <div>{displayValue}</div>
-      </div>
+      </button>
     </>
   );
 };

--- a/web/internal/ui/src/components/timestamp-info.tsx
+++ b/web/internal/ui/src/components/timestamp-info.tsx
@@ -119,8 +119,8 @@ const TimestampInfo: React.FC<{
   const TooltipRow = ({ label, value }: { label: string; value: string }) => {
     const [copied, setCopied] = useState(false);
     return (
-      //biome-ignore lint/a11y/useKeyWithClickEvents: no need
-      <span
+      <button
+        type="button"
         onClick={(e) => {
           e.stopPropagation();
           navigator.clipboard.writeText(value);
@@ -133,7 +133,7 @@ const TimestampInfo: React.FC<{
         <span className={cn("ml-2 text-xs text-accent-12", copied ? "text-success-11" : "")}>
           {copied ? "Copied!" : value}
         </span>
-      </span>
+      </button>
     );
   };
 


### PR DESCRIPTION
## Summary

Fixes 5 of 7 `react-doctor/click-events-have-key-events` findings (Accessibility, warn). These controls only worked with a mouse — keyboard users could not reach or trigger them at all.

- `hidden-value-cell`: the copy-secret cell is now a native `<button>` with an aria-label (was an unlabeled clickable div)
- `timestamp-info`: the copy-on-click tooltip rows are now native buttons
- `regions`: the remove-region ✕ is now a native button with an aria-label — the old comment feared nested buttons, but the surrounding element is a `span` (even as `TooltipTrigger asChild`), so a native button is legal; previously keyboard users could not remove a region at all
- `request-response-details`: copyable rows get `role=button`, `tabIndex` and Enter/Space activation (the div stays because rows are conditionally non-interactive and double as tooltip triggers)
- `virtual-table`: sortable column headers get `role=button`, `tabIndex` and Enter/Space activation — sorting was mouse-only

Where elements became real `<button>`s, the now-redundant `biome-ignore lint/a11y/useKeyWithClickEvents` suppressions were removed.

## Intentionally not changed (false positives per the rule's recipe)

- `env-var-base-row`: the wrapper div only widens the click target of the inner Radix `Checkbox` (a real button) — pressing Space on the focused checkbox fires a click that bubbles to the wrapper handler, so keyboard already works
- `filter-item`: the parent popover implements the ARIA menu keyboard pattern (Enter/ArrowRight activates the focused `role=menuitem`), so a local key handler would be dead code

## Verification

- `npx react-doctor@latest --verbose` re-run: rule count 7 → 2, both remaining are the documented false positives above
- `tsc` dashboard clean; `@unkey/ui` unchanged at its pre-existing error count; `biome check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)