### PR TITLE
fix(dashboard): remove double copy ws

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/general/copy-workspace-id.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/general/copy-workspace-id.tsx
@@ -12,10 +12,10 @@ export const CopyWorkspaceId = ({ workspaceId }: { workspaceId: string }) => {
       <div className="flex flex-row justify-end items-center">
         <div
           className={
-            "flex flex-row justify-between min-w-[395px] pl-2 pr-2 py-2 bg-gray-2 dark:bg-black border rounded-lg border-grayA-5"
+            "flex flex-row justify-between min-w-[395px] pl-2 pr-2 py-2 bg-gray-2 dark:bg-black border rounded-lg border-grayA-5 h-9"
           }
         >
-          <div className="text-sm leading-5 text-gray-11">{workspaceId}</div>
+          <div className="text-sm leading-5 text-gray-11 flex items-center">{workspaceId}</div>
           <CopyButton value={workspaceId} variant="ghost" toastMessage={workspaceId} />
         </div>
       </div>

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/general/page.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/general/page.tsx
@@ -1,21 +1,9 @@
 "use client";
 
-import { CopyableIDButton } from "@/components/navigation/copyable-id-button";
 import { useWorkspaceNavigation } from "@/hooks/use-workspace-navigation";
-import {
-  PageBody,
-  PageContainer,
-  PageHeader,
-  PageHeaderActions,
-  PageHeaderContent,
-  PageHeaderTitle,
-} from "@unkey/ui";
+import { PageBody, PageContainer, PageHeader, PageHeaderContent, PageHeaderTitle } from "@unkey/ui";
 import { CopyWorkspaceId } from "./copy-workspace-id";
 import { UpdateWorkspaceName } from "./update-workspace-name";
-
-/**
- * TODO: WorkOS doesn't have workspace images
- */
 
 export default function SettingsPage() {
   const workspace = useWorkspaceNavigation();
@@ -26,9 +14,6 @@ export default function SettingsPage() {
         <PageHeaderContent>
           <PageHeaderTitle>General</PageHeaderTitle>
         </PageHeaderContent>
-        <PageHeaderActions>
-          <CopyableIDButton value={workspace.id} />
-        </PageHeaderActions>
       </PageHeader>
       <PageBody>
         <div className="w-full flex flex-col pt-4">


### PR DESCRIPTION
Fixes ENG-2894

## What does this PR do?
This PR removes double copy of ws, aligns input heights and centers copy workspace in settings card

Before:
<img width="1372" height="418" alt="image" src="https://github.com/user-attachments/assets/900d9868-94f6-40d4-9ae2-fa03d24c143d" />

After:
<img width="1352" height="400" alt="Screenshot 2026-06-10 at 12 51 45" src="https://github.com/user-attachments/assets/aa26f152-db3b-43af-9153-0fbe08d22dc9" />
