### PR TITLE
fix(dashboard): rule of hook violation and biome rule to catch future…

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/root-keys/components/dialog/components/permission-list.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/root-keys/components/dialog/components/permission-list.tsx
@@ -80,10 +80,6 @@ export const PermissionContentList = ({
     0,
   );
 
-  if (totalPermissions === 0) {
-    return null;
-  }
-
   const handleCategoryToggleExpanded = useCallback((category: string, open: boolean) => {
     setExpandedCategories((prev) => {
       const newSet = new Set(prev);
@@ -95,6 +91,10 @@ export const PermissionContentList = ({
       return newSet;
     });
   }, []);
+
+  if (totalPermissions === 0) {
+    return null;
+  }
 
   const header = getScopeHeader(scope);
 

--- a/web/apps/dashboard/components/permissions-table/hooks/use-permissions-list-query.ts
+++ b/web/apps/dashboard/components/permissions-table/hooks/use-permissions-list-query.ts
@@ -60,6 +60,7 @@ export function usePermissionsListPaginated(pageSize = DEFAULT_PAGE_SIZE) {
     filterFieldNames: permissionsListFilterFieldNames,
     filterFieldConfig: permissionsFilterFieldConfig,
     useListQuery: (params) =>
+      // biome-ignore lint/correctness/useHookAtTopLevel: hook factory invoked unconditionally inside the paginated-list hook
       trpc.authorization.permissions.query.useQuery(params, PAGINATED_LIST_QUERY_OPTIONS),
     prefetch: (params) =>
       utils.authorization.permissions.query.prefetch(params, PAGINATED_LIST_PREFETCH_OPTIONS),

--- a/web/apps/dashboard/components/roles-table/hooks/use-roles-list-query.ts
+++ b/web/apps/dashboard/components/roles-table/hooks/use-roles-list-query.ts
@@ -57,6 +57,7 @@ export function useRolesListPaginated(pageSize = DEFAULT_PAGE_SIZE) {
     filterFieldNames: rolesListFilterFieldNames,
     filterFieldConfig: rolesFilterFieldConfig,
     useListQuery: (params) =>
+      // biome-ignore lint/correctness/useHookAtTopLevel: hook factory invoked unconditionally inside the paginated-list hook
       trpc.authorization.roles.query.useQuery(params, PAGINATED_LIST_QUERY_OPTIONS),
     prefetch: (params) =>
       utils.authorization.roles.query.prefetch(params, PAGINATED_LIST_PREFETCH_OPTIONS),

--- a/web/biome.json
+++ b/web/biome.json
@@ -18,7 +18,8 @@
         "noUnusedImports": "error",
         "noChildrenProp": "off",
         "useJsxKeyInIterable": "error",
-        "noUnsafeOptionalChaining": "error"
+        "noUnsafeOptionalChaining": "error",
+        "useHookAtTopLevel": "error"
       },
       "security": {
         "noDangerouslySetInnerHtml": "error"

--- a/web/internal/ui/src/components/form/form-checkbox.tsx
+++ b/web/internal/ui/src/components/form/form-checkbox.tsx
@@ -38,7 +38,8 @@ const FormCheckbox = React.forwardRef<HTMLButtonElement, FormCheckboxProps>(
     const descriptionAsTooltip = descriptionPosition === "label";
     const checkboxVariant = error ? "primary" : variant;
     const checkboxColor = error ? "danger" : color;
-    const checkboxId = id || React.useId();
+    const generatedId = React.useId();
+    const checkboxId = id || generatedId;
     const descriptionId = `${checkboxId}-helper`;
     const errorId = `${checkboxId}-error`;
 

--- a/web/internal/ui/src/components/form/form-input.tsx
+++ b/web/internal/ui/src/components/form/form-input.tsx
@@ -31,7 +31,8 @@ const FormInput = React.forwardRef<HTMLInputElement, FormInputProps>(
   ) => {
     const descriptionAsTooltip = descriptionPosition === "label";
     const inputVariant = error ? "error" : variant;
-    const inputId = id || React.useId();
+    const generatedId = React.useId();
+    const inputId = id || generatedId;
     const descriptionId = `${inputId}-helper`;
     const errorId = `${inputId}-error`;
 

--- a/web/internal/ui/src/components/form/form-select.tsx
+++ b/web/internal/ui/src/components/form/form-select.tsx
@@ -47,7 +47,8 @@ function FormSelect({
 }: FormSelectProps) {
   const descriptionAsTooltip = descriptionPosition === "label";
   const selectVariant = error ? "error" : undefined;
-  const selectId = id || React.useId();
+  const generatedId = React.useId();
+  const selectId = id || generatedId;
   const descriptionId = `${selectId}-helper`;
   const errorId = `${selectId}-error`;
 

--- a/web/internal/ui/src/components/form/form-textarea.tsx
+++ b/web/internal/ui/src/components/form/form-textarea.tsx
@@ -34,7 +34,8 @@ const FormTextarea = React.forwardRef<HTMLTextAreaElement, FormTextareaProps>(
   ) => {
     const descriptionAsTooltip = descriptionPosition === "label";
     const textareaVariant = error ? "error" : variant;
-    const textareaId = id || React.useId();
+    const generatedId = React.useId();
+    const textareaId = id || generatedId;
     const descriptionId = `${textareaId}-helper`;
     const errorId = `${textareaId}-error`;
 


### PR DESCRIPTION
Fixes ENG-2852.


## Problem

There were a couple of cases where we did react hook violations, by calling hooks after conditional statements or in them.

## Fix

Those issues are fixed and also added a biome rule to catch future similar issues before they can happen.


## How to test

- dashboard should build correct
- `[local/settings/root-keys`](http://localhost:3000/local/settings/root-keys)` should work as before 