### PR TITLE
feat(billing): grant Deploy usage credits on invoice.paid

### DIFF
--- a/web/apps/dashboard/app/api/webhooks/stripe/route.ts
+++ b/web/apps/dashboard/app/api/webhooks/stripe/route.ts
@@ -4,6 +4,8 @@ import { db, eq, schema } from "@/lib/db";
 import { stripeEnv } from "@/lib/env";
 import { formatPrice } from "@/lib/fmt";
 import { freeTierQuotas } from "@/lib/quotas";
+import { deployBillingConfig, findApiItem } from "@/lib/stripe/deployBilling";
+import { grantDeployCreditsForInvoice } from "@/lib/stripe/deployCredits";
 import { detectDeployPlan } from "@/lib/stripe/deployPlan";
 import { isPaymentRecovery, isPaymentRecoveryUpdate } from "@/lib/stripe/paymentUtils";
 import { validateAndParseQuotas } from "@/lib/stripe/productUtils";
@@ -37,6 +39,44 @@ async function mirrorDeployPlan(
   if (changed) {
     await db.update(schema.workspaces).set({ deployPlan }).where(eq(schema.workspaces.id, ws.id));
   }
+}
+
+/**
+ * Resolves the API plan item on a subscription and loads its price, customer,
+ * and product. Anchors on findApiItem rather than items[0] so a mixed
+ * (API + Compute) subscription resolves the API product, not a Compute item.
+ * Returns null when there is nothing to act on: no API item (e.g. a
+ * Compute-only subscription), no customer, or a price with no product/amount.
+ */
+async function resolveApiSubscriptionContext(
+  stripe: Stripe,
+  sub: Stripe.Subscription,
+): Promise<{
+  // Narrowed to a number here so callers do not have to re-check it; the guard
+  // below rejects a price with no unit_amount.
+  unitAmount: number;
+  customer: Stripe.Customer | Stripe.DeletedCustomer;
+  product: Stripe.Product;
+} | null> {
+  const apiItem = findApiItem(await deployBillingConfig(), sub.items?.data ?? []);
+  if (!apiItem?.price?.id || !sub.customer) {
+    return null;
+  }
+
+  const [price, customer] = await Promise.all([
+    stripe.prices.retrieve(apiItem.price.id),
+    stripe.customers.retrieve(typeof sub.customer === "string" ? sub.customer : sub.customer.id),
+  ]);
+
+  if (!price.product || price.unit_amount === null || price.unit_amount === undefined) {
+    return null;
+  }
+
+  const product = await stripe.products.retrieve(
+    typeof price.product === "string" ? price.product : price.product.id,
+  );
+
+  return { unitAmount: price.unit_amount, customer, product };
 }
 
 /**
@@ -172,24 +212,13 @@ export const POST = async (req: Request): Promise<Response> => {
           return new Response("OK", { status: 201 });
         }
 
-        if (!sub.items?.data?.[0]?.price?.id || !sub.customer) {
+        // Reconcile tier/quotas from the API plan item (the Deploy signal is
+        // mirrored above). Nothing to reconcile on a Compute-only subscription.
+        const apiContext = await resolveApiSubscriptionContext(stripe, sub);
+        if (!apiContext) {
           return new Response("OK");
         }
-
-        const [price, customer] = await Promise.all([
-          stripe.prices.retrieve(sub.items.data[0].price.id),
-          stripe.customers.retrieve(
-            typeof sub.customer === "string" ? sub.customer : sub.customer.id,
-          ),
-        ]);
-
-        if (!price.product || price.unit_amount === null || price.unit_amount === undefined) {
-          return new Response("OK");
-        }
-
-        const product = await stripe.products.retrieve(
-          typeof price.product === "string" ? price.product : price.product.id,
-        );
+        const { unitAmount, customer, product } = apiContext;
 
         /**
          * In our case, when a user cancels their subscription, it's not in effect until the beginning of the next month.
@@ -197,7 +226,7 @@ export const POST = async (req: Request): Promise<Response> => {
          */
         if (sub.cancel_at) {
           if (customer && !customer.deleted && customer.email) {
-            const formattedPrice = formatPrice(price.unit_amount);
+            const formattedPrice = formatPrice(unitAmount);
             await alertIsCancellingSubscription(
               product.name,
               formattedPrice,
@@ -283,7 +312,7 @@ export const POST = async (req: Request): Promise<Response> => {
               previousTier = previousProduct.name;
 
               // Compare amounts to determine upgrade/downgrade
-              const currentAmount = price.unit_amount;
+              const currentAmount = unitAmount;
               const previousAmount = previousPrice.unit_amount;
 
               if (currentAmount !== previousAmount && previousAmount !== null) {
@@ -305,7 +334,7 @@ export const POST = async (req: Request): Promise<Response> => {
 
         // Send notification for subscription update
         if (customer && !customer.deleted && customer.email) {
-          const formattedPrice = formatPrice(price.unit_amount);
+          const formattedPrice = formatPrice(unitAmount);
 
           await alertSubscriptionUpdate(
             product.name,
@@ -446,30 +475,19 @@ export const POST = async (req: Request): Promise<Response> => {
           await mirrorDeployPlan(wsForDeploy, sub);
         }
 
-        if (!sub.items?.data?.[0]?.price?.id || !sub.customer) {
+        // Alert on the API plan item (the Deploy signal is mirrored above).
+        // Nothing to alert on for a Compute-only subscription.
+        const apiContext = await resolveApiSubscriptionContext(stripe, sub);
+        if (!apiContext) {
           return new Response("OK");
         }
-
-        const [price, customer] = await Promise.all([
-          stripe.prices.retrieve(sub.items.data[0].price.id),
-          stripe.customers.retrieve(
-            typeof sub.customer === "string" ? sub.customer : sub.customer.id,
-          ),
-        ]);
-
-        if (!price.product || price.unit_amount === null || price.unit_amount === undefined) {
-          return new Response("OK");
-        }
-
-        const product = await stripe.products.retrieve(
-          typeof price.product === "string" ? price.product : price.product.id,
-        );
+        const { unitAmount, customer, product } = apiContext;
 
         if (customer.deleted || !customer.email) {
           return new Response("OK");
         }
 
-        const formattedPrice = formatPrice(price.unit_amount);
+        const formattedPrice = formatPrice(unitAmount);
 
         await alertSubscriptionCreation(
           product.name,
@@ -611,6 +629,37 @@ export const POST = async (req: Request): Promise<Response> => {
             eventId: event.id,
           });
           return new Response("OK", { status: 200 });
+        }
+
+        // A paid invoice carrying a Deploy plan-fee entitles the workspace to
+        // usage credits equal to the fee. This must run before the alert
+        // logic below, whose early returns (deleted customer, no email) must
+        // not skip the grant. Failure returns 500 so Stripe retries; the
+        // grant is idempotent per invoice, so retries cannot double-grant.
+        try {
+          const grant = await grantDeployCreditsForInvoice(stripe, invoice);
+          if (grant.granted) {
+            console.info("Granted Deploy usage credits", {
+              invoiceId: invoice.id,
+              grantId: grant.grantId,
+              amountCents: grant.amountCents,
+            });
+          } else {
+            // No credits is usually a deliberate skip: no Deploy plan-fee
+            // line, period already closed, already granted, or non-positive
+            // net. Log the reason so the skip is explained.
+            console.info("Did not grant Deploy usage credits", {
+              invoiceId: invoice.id,
+              reason: grant.reason,
+            });
+          }
+        } catch (grantError) {
+          console.error("Failed to grant Deploy usage credits:", {
+            error: grantError,
+            invoiceId: invoice.id,
+            eventId: event.id,
+          });
+          return new Response("Error granting Deploy credits", { status: 500 });
         }
 
         let customer: Stripe.Customer | Stripe.DeletedCustomer;

--- a/web/apps/dashboard/lib/stripe/deployCredits.ts
+++ b/web/apps/dashboard/lib/stripe/deployCredits.ts
@@ -1,0 +1,137 @@
+import type Stripe from "stripe";
+import { deployBillingConfig, planForPlanFeePriceId } from "./deployBilling";
+
+/**
+ * How long credits stay redeemable past the plan-fee period they belong to.
+ *
+ * A period's metered usage is billed on the invoice that finalizes at the
+ * START of the next period (e.g. June usage bills on the July 1 invoice).
+ * Credits that expired exactly at period end would therefore never apply to
+ * the one invoice they exist for. Three days covers webhook-driven
+ * finalization and the backup cron, while still expiring before the next
+ * month's usage invoice, keeping the use-it-or-lose-it semantics.
+ */
+const EXPIRY_GRACE_SECONDS = 3 * 24 * 60 * 60;
+
+export type DeployCreditGrantResult =
+  | { granted: false; reason: string }
+  | { granted: true; grantId: string; amountCents: number };
+
+/**
+ * Grants the Deploy usage credits a paid invoice entitles the customer to:
+ * the net amount of its Deploy plan-fee lines, scoped to metered prices (the
+ * only metered prices on a subscription are the Deploy meters; API tiers are
+ * licensed), expiring shortly after the period the fee covers.
+ *
+ * Summing the plan-fee lines (rather than reading the catalog price) makes
+ * prorations self-correcting: a mid-cycle subscribe grants the prorated
+ * amount, and a renewal invoice carrying up/downgrade prorations grants the
+ * net fee actually paid for the period. Each line's discount_amounts are
+ * subtracted so coupons (line-level and invoice-level alike) reduce the credit
+ * the way they reduce the bill. A net of zero or less grants nothing.
+ *
+ * Idempotent per invoice twice over: an idempotency key derived from the
+ * invoice id covers webhook retries, and a metadata check against existing
+ * grants covers replays beyond Stripe's 24h idempotency window.
+ */
+export async function grantDeployCreditsForInvoice(
+  stripe: Stripe,
+  invoice: Stripe.Invoice,
+): Promise<DeployCreditGrantResult> {
+  const config = await deployBillingConfig();
+  if (!config) {
+    return { granted: false, reason: "deploy billing not configured" };
+  }
+  if (!invoice.customer) {
+    return { granted: false, reason: "invoice has no customer" };
+  }
+  const customerId = typeof invoice.customer === "string" ? invoice.customer : invoice.customer.id;
+
+  // The webhook payload carries the first page of lines. Our subscriptions
+  // have well under a page of items, so more pages means something unexpected;
+  // log it rather than silently miscounting the fee.
+  if (invoice.lines.has_more) {
+    console.warn("Invoice has more lines than the webhook payload carries", {
+      invoiceId: invoice.id,
+    });
+  }
+
+  const feeLines = invoice.lines.data.filter((line) => {
+    const priceId = line.pricing?.price_details?.price;
+    return typeof priceId === "string" && Boolean(planForPlanFeePriceId(config, priceId));
+  });
+  if (feeLines.length === 0) {
+    return { granted: false, reason: "no deploy plan-fee lines" };
+  }
+
+  // line.amount is the gross fee, excluding tax and discounts. Subtracting the
+  // per-line discount_amounts (Stripe distributes invoice-level coupons into
+  // these too) makes the credit track the fee actually paid, not the list
+  // price; a customer with a coupon would otherwise be granted more than billed.
+  const amountCents = feeLines.reduce((sum, line) => {
+    const discounts = (line.discount_amounts ?? []).reduce((d, da) => d + da.amount, 0);
+    return sum + line.amount - discounts;
+  }, 0);
+  if (amountCents <= 0) {
+    return { granted: false, reason: `non-positive net plan-fee amount (${amountCents})` };
+  }
+
+  const periodEnd = Math.max(...feeLines.map((line) => line.period.end));
+  const expiresAt = periodEnd + EXPIRY_GRACE_SECONDS;
+  if (expiresAt * 1000 <= Date.now()) {
+    // Paid long after the period closed; the usage invoice has already
+    // finalized, so a grant could never be redeemed.
+    return { granted: false, reason: "period already closed" };
+  }
+
+  // Replay guard beyond the 24h idempotency window: skip if this invoice
+  // already produced a grant. creditGrants.list has no metadata or created
+  // filter, so we page the customer's grants and match on the invoice id.
+  // Grants are roughly one per month, so this is a page or two even for
+  // long-tenured customers; paging avoids missing a match past the first page.
+  let duplicate: Stripe.Billing.CreditGrant | undefined;
+  for await (const grant of stripe.billing.creditGrants.list({
+    customer: customerId,
+    limit: 100,
+  })) {
+    if (grant.metadata?.stripe_invoice_id === invoice.id) {
+      duplicate = grant;
+      break;
+    }
+  }
+  if (duplicate) {
+    return { granted: false, reason: `already granted (${duplicate.id})` };
+  }
+
+  const firstFeeLine = feeLines[0];
+  const firstFeePriceId = firstFeeLine?.pricing?.price_details?.price;
+  const plan =
+    typeof firstFeePriceId === "string"
+      ? planForPlanFeePriceId(config, firstFeePriceId)
+      : undefined;
+
+  // The grant name shows up as the credit line on the invoice, so it should
+  // explain itself there: "Business plan monthly included usage ($50.00 off)".
+  const planLabel = plan ? plan.charAt(0).toUpperCase() + plan.slice(1) : "Compute";
+
+  const created = await stripe.billing.creditGrants.create(
+    {
+      name: `${planLabel} plan monthly included usage`,
+      customer: customerId,
+      category: "promotional",
+      amount: {
+        type: "monetary",
+        monetary: { currency: invoice.currency, value: amountCents },
+      },
+      applicability_config: { scope: { price_type: "metered" } },
+      expires_at: expiresAt,
+      metadata: {
+        stripe_invoice_id: invoice.id,
+        ...(plan ? { deploy_plan: plan } : {}),
+      },
+    },
+    { idempotencyKey: `deploy-credit-grant:${invoice.id}` },
+  );
+
+  return { granted: true, grantId: created.id, amountCents };
+}


### PR DESCRIPTION
Once a user pays us money we need to grant him credits so he can use them for our meters

this includes everything we charge for
- egress
- cpu
- memory
- disk
- active keys

does not apply to api key verifications product.