### PR TITLE
fix(dashboard): Open create-project dialog from projects empty state

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/_components/create-project-button.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/_components/create-project-button.tsx
@@ -1,30 +1,10 @@
 "use client";
 
 import { NavbarActionButton } from "@/components/navigation/action-button";
-import { collection } from "@/lib/collections";
-import {
-  type CreateProjectRequestSchema,
-  createProjectRequestSchema,
-} from "@/lib/collections/deploy/projects";
-import { SERVER_PLACEHOLDER } from "@/lib/collections/deploy/utils";
-import { slugify } from "@/lib/slugify";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { DuplicateKeyError } from "@tanstack/react-db";
 import { Plus } from "@unkey/icons";
-import { Button, FormInput } from "@unkey/ui";
-import dynamic from "next/dynamic";
-import { useRouter } from "next/navigation";
 import type React from "react";
 import { useState } from "react";
-import { useForm } from "react-hook-form";
-
-const DynamicDialogContainer = dynamic(
-  () =>
-    import("@unkey/ui").then((mod) => ({
-      default: mod.DialogContainer,
-    })),
-  { ssr: false },
-);
+import { CreateProjectDialog } from "./create-project-dialog";
 
 type Props = {
   defaultOpen?: boolean;
@@ -37,55 +17,6 @@ export const CreateProjectButton = ({
   ...rest
 }: React.ButtonHTMLAttributes<HTMLButtonElement> & Props) => {
   const [isOpen, setIsOpen] = useState(defaultOpen ?? false);
-  const router = useRouter();
-  const {
-    register,
-    handleSubmit,
-    setValue,
-    setError,
-    formState: { errors, isValid, isSubmitting },
-  } = useForm<CreateProjectRequestSchema>({
-    resolver: zodResolver(createProjectRequestSchema),
-    defaultValues: { name: "", slug: "" },
-    mode: "onChange",
-  });
-
-  const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setValue("slug", slugify(e.target.value));
-  };
-
-  async function onSubmit(values: CreateProjectRequestSchema) {
-    try {
-      const tx = collection.projects.insert({
-        name: values.name,
-        slug: values.slug,
-        repositoryFullName: null,
-        currentDeploymentId: null,
-        isRolledBack: false,
-        id: SERVER_PLACEHOLDER,
-        latestDeploymentId: null,
-        author: SERVER_PLACEHOLDER,
-        authorAvatar: SERVER_PLACEHOLDER,
-        branch: SERVER_PLACEHOLDER,
-        commitTimestamp: Date.now(),
-        commitTitle: SERVER_PLACEHOLDER,
-        domain: SERVER_PLACEHOLDER,
-      });
-      await tx.isPersisted.promise;
-      const { projectId } = tx.metadata as { projectId: string };
-      router.push(`/${workspaceSlug}/projects/${projectId}/apps/new`);
-      setIsOpen(false);
-    } catch (error) {
-      if (error instanceof DuplicateKeyError) {
-        setError("slug", {
-          type: "custom",
-          message: "Project with this slug already exists",
-        });
-      } else {
-        console.error("Form submission error:", error);
-      }
-    }
-  }
 
   return (
     <>
@@ -99,52 +30,7 @@ export const CreateProjectButton = ({
         Create new project
       </NavbarActionButton>
 
-      <DynamicDialogContainer
-        isOpen={isOpen}
-        onOpenChange={setIsOpen}
-        title="Create New Project"
-        footer={
-          <div className="w-full flex flex-col gap-2 items-center justify-center">
-            <Button
-              type="submit"
-              form="create-project-form"
-              variant="primary"
-              size="xlg"
-              disabled={isSubmitting || !isValid}
-              loading={isSubmitting}
-              className="w-full rounded-lg"
-            >
-              Create Project
-            </Button>
-            <div className="text-gray-9 text-xs">
-              You'll be redirected to your new project after creation
-            </div>
-          </div>
-        }
-      >
-        <form
-          id="create-project-form"
-          onSubmit={handleSubmit(onSubmit)}
-          className="flex flex-col gap-4"
-        >
-          <FormInput
-            requirement="required"
-            label="Project Name"
-            description="A descriptive name for your project."
-            error={errors.name?.message}
-            {...register("name", { onChange: handleNameChange })}
-            placeholder="My Awesome Project"
-          />
-          <FormInput
-            requirement="required"
-            label="Slug"
-            description="URL-friendly identifier for your project (auto-generated from name)."
-            error={errors.slug?.message}
-            {...register("slug")}
-            placeholder="my-awesome-project"
-          />
-        </form>
-      </DynamicDialogContainer>
+      <CreateProjectDialog isOpen={isOpen} onOpenChange={setIsOpen} workspaceSlug={workspaceSlug} />
     </>
   );
 };

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/_components/create-project-dialog.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/_components/create-project-dialog.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { collection } from "@/lib/collections";
+import {
+  type CreateProjectRequestSchema,
+  createProjectRequestSchema,
+} from "@/lib/collections/deploy/projects";
+import { SERVER_PLACEHOLDER } from "@/lib/collections/deploy/utils";
+import { slugify } from "@/lib/slugify";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { DuplicateKeyError } from "@tanstack/react-db";
+import { Button, FormInput } from "@unkey/ui";
+import dynamic from "next/dynamic";
+import { useRouter } from "next/navigation";
+import type React from "react";
+import { useForm } from "react-hook-form";
+
+const DynamicDialogContainer = dynamic(
+  () =>
+    import("@unkey/ui").then((mod) => ({
+      default: mod.DialogContainer,
+    })),
+  { ssr: false },
+);
+
+type Props = {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  workspaceSlug: string;
+};
+
+export const CreateProjectDialog = ({ isOpen, onOpenChange, workspaceSlug }: Props) => {
+  const router = useRouter();
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    setError,
+    formState: { errors, isValid, isSubmitting },
+  } = useForm<CreateProjectRequestSchema>({
+    resolver: zodResolver(createProjectRequestSchema),
+    defaultValues: { name: "", slug: "" },
+    mode: "onChange",
+  });
+
+  const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setValue("slug", slugify(e.target.value));
+  };
+
+  async function onSubmit(values: CreateProjectRequestSchema) {
+    try {
+      const tx = collection.projects.insert({
+        name: values.name,
+        slug: values.slug,
+        repositoryFullName: null,
+        currentDeploymentId: null,
+        isRolledBack: false,
+        id: SERVER_PLACEHOLDER,
+        latestDeploymentId: null,
+        author: SERVER_PLACEHOLDER,
+        authorAvatar: SERVER_PLACEHOLDER,
+        branch: SERVER_PLACEHOLDER,
+        commitTimestamp: Date.now(),
+        commitTitle: SERVER_PLACEHOLDER,
+        domain: SERVER_PLACEHOLDER,
+      });
+      await tx.isPersisted.promise;
+      const { projectId } = tx.metadata as { projectId: string };
+      router.push(`/${workspaceSlug}/projects/${projectId}/apps/new`);
+      onOpenChange(false);
+    } catch (error) {
+      if (error instanceof DuplicateKeyError) {
+        setError("slug", {
+          type: "custom",
+          message: "Project with this slug already exists",
+        });
+      } else {
+        console.error("Form submission error:", error);
+      }
+    }
+  }
+
+  return (
+    <DynamicDialogContainer
+      isOpen={isOpen}
+      onOpenChange={onOpenChange}
+      title="Create New Project"
+      footer={
+        <div className="w-full flex flex-col gap-2 items-center justify-center">
+          <Button
+            type="submit"
+            form="create-project-form"
+            variant="primary"
+            size="xlg"
+            disabled={isSubmitting || !isValid}
+            loading={isSubmitting}
+            className="w-full rounded-lg"
+          >
+            Create Project
+          </Button>
+          <div className="text-gray-9 text-xs">
+            You'll be redirected to your new project after creation
+          </div>
+        </div>
+      }
+    >
+      <form
+        id="create-project-form"
+        onSubmit={handleSubmit(onSubmit)}
+        className="flex flex-col gap-4"
+      >
+        <FormInput
+          requirement="required"
+          label="Project Name"
+          description="A descriptive name for your project."
+          error={errors.name?.message}
+          {...register("name", { onChange: handleNameChange })}
+          placeholder="My Awesome Project"
+        />
+        <FormInput
+          requirement="required"
+          label="Slug"
+          description="URL-friendly identifier for your project (auto-generated from name)."
+          error={errors.slug?.message}
+          {...register("slug")}
+          placeholder="my-awesome-project"
+        />
+      </form>
+    </DynamicDialogContainer>
+  );
+};

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/_components/list/empty-projects.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/_components/list/empty-projects.tsx
@@ -2,8 +2,9 @@ import { useWorkspaceNavigation } from "@/hooks/use-workspace-navigation";
 import { ArrowRight, BookBookmark, Code, Cube, Earth, Github, HeartPulse } from "@unkey/icons";
 import { Button } from "@unkey/ui";
 import { cn } from "@unkey/ui/src/lib/utils";
-import Link from "next/link";
-import type { ReactNode } from "react";
+import { useSearchParams } from "next/navigation";
+import { type ReactNode, useState } from "react";
+import { CreateProjectDialog } from "../create-project-dialog";
 
 type IconBoxProps = {
   children?: ReactNode;
@@ -33,6 +34,7 @@ const flankItems: { icon: ReactNode; large?: boolean; opacity: string }[] = [
 
 const ProjectIconRow = () => (
   <div
+    aria-hidden="true"
     className="p-2 mb-8"
     style={{
       maskImage: "linear-gradient(to right, transparent, black 20%, black 80%, transparent)",
@@ -52,6 +54,8 @@ const ProjectIconRow = () => (
 
 export function EmptyProjects() {
   const workspace = useWorkspaceNavigation();
+  const searchParams = useSearchParams();
+  const [isDialogOpen, setIsDialogOpen] = useState(searchParams.get("new") === "true");
 
   return (
     <div className="grow w-full flex justify-center items-center p-12">
@@ -65,15 +69,15 @@ export function EmptyProjects() {
         </p>
 
         <div className="flex flex-col sm:flex-row items-center justify-center gap-3 w-full">
-          <Link
-            href={`/${workspace.slug}/projects/new`}
+          <Button
+            variant="primary"
+            size="md"
+            onClick={() => setIsDialogOpen(true)}
             className="w-full max-w-[200px] sm:w-auto sm:max-w-none"
           >
-            <Button variant="primary" size="md" className="w-full sm:w-auto">
-              Create your first project
-              <ArrowRight />
-            </Button>
-          </Link>
+            Create your first project
+            <ArrowRight />
+          </Button>
           <a
             href="https://www.unkey.com/docs/quickstart/deploy"
             target="_blank"
@@ -87,6 +91,12 @@ export function EmptyProjects() {
           </a>
         </div>
       </div>
+
+      <CreateProjectDialog
+        isOpen={isDialogOpen}
+        onOpenChange={setIsDialogOpen}
+        workspaceSlug={workspace.slug}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## What does this PR do?

The "Create your first project" button on the projects empty state linked to `/[workspace]/projects/new`, which isn't a route, so it 404'd. It now opens the same create-project dialog the navbar button uses.

The dialog was previously inlined in the navbar button and never mounted on the empty state (the page returns the empty state early, before the navbar). This pulls it into a controlled `CreateProjectDialog` that both the navbar button and the empty-state CTA open, and the empty state honors the existing `?new=true` deep link too.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

1. On a workspace with no projects, open `/[workspace]/projects`.
2. Click "Create your first project" — the create-project dialog should open in place (previously a 404).
3. Submit it and confirm the redirect to the new project's app-creation step.
4. Confirm the navbar "Create new project" button (on a populated workspace) still opens the same dialog, and `/[workspace]/projects?new=true` auto-opens it in both the empty and populated cases.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary

_Screenshots to be added — light, dark, mobile._