### PR TITLE
fix: ENG-2850 stripe billing non atomic subscriptiondeleted

### DIFF
--- a/pkg/mysql/schema/workspaces.sql
+++ b/pkg/mysql/schema/workspaces.sql
@@ -19,6 +19,7 @@ CREATE TABLE `workspaces` (
 	CONSTRAINT `workspaces_id_unique` UNIQUE(`id`),
 	CONSTRAINT `workspaces_org_id_unique` UNIQUE(`org_id`),
 	CONSTRAINT `workspaces_slug_unique` UNIQUE(`slug`),
-	CONSTRAINT `workspaces_k8s_namespace_unique` UNIQUE(`k8s_namespace`)
+	CONSTRAINT `workspaces_k8s_namespace_unique` UNIQUE(`k8s_namespace`),
+	CONSTRAINT `workspaces_stripe_subscription_id_unique` UNIQUE(`stripe_subscription_id`)
 );
 

--- a/web/apps/dashboard/app/api/webhooks/stripe/route.ts
+++ b/web/apps/dashboard/app/api/webhooks/stripe/route.ts
@@ -324,37 +324,44 @@ export const POST = async (req: Request): Promise<Response> => {
           });
           return new Response("OK", { status: 200 });
         }
-        await db
-          .update(schema.workspaces)
-          .set({
-            stripeSubscriptionId: null,
-            tier: "Free",
-          })
-          .where(eq(schema.workspaces.id, ws.id));
+        // All downgrade writes must be atomic: the workspace is located by
+        // stripeSubscriptionId, and the workspace update nulls that key. If a later
+        // write failed mid-sequence, the 500 would make Stripe retry, but the retry
+        // could no longer find the workspace and would no-op with a 200 — leaving the
+        // downgrade permanently half-applied (e.g. tier=Free but paid quotas intact).
+        await db.transaction(async (tx) => {
+          await tx
+            .update(schema.workspaces)
+            .set({
+              stripeSubscriptionId: null,
+              tier: "Free",
+            })
+            .where(eq(schema.workspaces.id, ws.id));
 
-        await db
-          .insert(schema.quotas)
-          .values({
+          await tx
+            .insert(schema.quotas)
+            .values({
+              workspaceId: ws.id,
+              ...freeTierQuotas,
+            })
+            .onDuplicateKeyUpdate({
+              set: freeTierQuotas,
+            });
+
+          await insertAuditLogs(tx, {
             workspaceId: ws.id,
-            ...freeTierQuotas,
-          })
-          .onDuplicateKeyUpdate({
-            set: freeTierQuotas,
+            actor: {
+              type: "system",
+              id: "stripe",
+            },
+            event: "workspace.update",
+            description: "Cancelled subscription.",
+            resources: [],
+            context: {
+              location: "",
+              userAgent: undefined,
+            },
           });
-
-        await insertAuditLogs(db, {
-          workspaceId: ws.id,
-          actor: {
-            type: "system",
-            id: "stripe",
-          },
-          event: "workspace.update",
-          description: "Cancelled subscription.",
-          resources: [],
-          context: {
-            location: "",
-            userAgent: undefined,
-          },
         });
 
         // Free tier doesn't include team access — deactivate all members except the

--- a/web/apps/dashboard/lib/trpc/routers/stripe/createSubscription.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/createSubscription.ts
@@ -1,5 +1,5 @@
 import { insertAuditLogs } from "@/lib/audit";
-import { db, eq, schema } from "@/lib/db";
+import { and, db, eq, isNull, schema } from "@/lib/db";
 import { stripeEnv } from "@/lib/env";
 import { getStripeClient } from "@/lib/stripe";
 import { validateAndParseQuotas } from "@/lib/stripe/productUtils";
@@ -93,27 +93,63 @@ export const createSubscription = workspaceProcedure
       });
     }
 
+    // ctx.workspace was loaded at context-creation time (and may come from a cache),
+    // so the guard above can be stale. Re-read right before creating the Stripe
+    // subscription so a request racing a just-completed subscribe fails here instead
+    // of charging the customer a second time.
+    const freshWorkspace = await db.query.workspaces.findFirst({
+      where: (table, { and, eq, isNull }) =>
+        and(eq(table.id, ctx.workspace.id), isNull(table.deletedAtM)),
+      columns: { stripeSubscriptionId: true },
+    });
+    if (!freshWorkspace) {
+      throw new TRPCError({
+        code: "NOT_FOUND",
+        message: "Workspace not found.",
+      });
+    }
+    if (freshWorkspace.stripeSubscriptionId) {
+      throw new TRPCError({
+        code: "PRECONDITION_FAILED",
+        message: `Customer ${ctx.workspace.stripeCustomerId} already has a subscription.`,
+      });
+    }
+
     /**
      * `error_if_incomplete` makes Stripe reject the create call with a 402 if the first
      * invoice cannot be paid (e.g. card declined). We rely on this to keep the workspace
      * on the Free tier when a first-time signup's payment fails — no DB writes happen
      * unless the subscription is fully active.
      */
+    // Deterministic idempotency key so concurrent duplicate calls (double-clicked
+    // subscribe button, HTTP retry of the mutation) collapse to a single subscription
+    // on Stripe's side instead of billing the customer twice. The 5-minute time
+    // bucket keeps the key stable across the realistic race window while still
+    // letting a user make a fresh attempt after a card decline — Stripe replays
+    // error responses for a reused key for 24h, which would otherwise lock a user
+    // out after fixing their payment method.
+    const idempotencyKey = `create-subscription:${ctx.workspace.id}:${
+      input.productId
+    }:${Math.floor(Date.now() / 300_000)}`;
+
     let sub: Stripe.Subscription;
     try {
-      sub = await stripe.subscriptions.create({
-        customer: customer.id,
-        items: [
-          {
-            price: product.default_price.toString(),
+      sub = await stripe.subscriptions.create(
+        {
+          customer: customer.id,
+          items: [
+            {
+              price: product.default_price.toString(),
+            },
+          ],
+          billing_cycle_anchor_config: {
+            day_of_month: 1,
           },
-        ],
-        billing_cycle_anchor_config: {
-          day_of_month: 1,
+          proration_behavior: "always_invoice",
+          payment_behavior: "error_if_incomplete",
         },
-        proration_behavior: "always_invoice",
-        payment_behavior: "error_if_incomplete",
-      });
+        { idempotencyKey },
+      );
     } catch (err) {
       if (err instanceof Stripe.errors.StripeCardError) {
         throw new TRPCError({
@@ -151,48 +187,91 @@ export const createSubscription = workspaceProcedure
       });
     }
 
-    await db.transaction(async (tx) => {
-      await tx
-        .update(schema.workspaces)
-        .set({
-          stripeSubscriptionId: sub.id,
-          tier: product.name,
-        })
-        .where(eq(schema.workspaces.id, ctx.workspace.id));
+    // Only attach the new subscription if the workspace still has none. If a
+    // concurrent request won the race between our pre-check and here, an
+    // unconditional write would silently overwrite its subscription id, leaving the
+    // other subscription active and billing but untracked by the app.
+    //
+    // "alreadyRecorded" covers the idempotent-replay case: a concurrent request with
+    // the same idempotency key received this exact subscription from Stripe and
+    // committed it first. That is a success, and crucially we must NOT cancel the
+    // subscription — it is the one the workspace is now using.
+    const outcome = await db.transaction(
+      async (tx): Promise<"created" | "alreadyRecorded" | "lostRace"> => {
+        const [updateResult] = await tx
+          .update(schema.workspaces)
+          .set({
+            stripeSubscriptionId: sub.id,
+            tier: product.name,
+          })
+          .where(
+            and(
+              eq(schema.workspaces.id, ctx.workspace.id),
+              isNull(schema.workspaces.stripeSubscriptionId),
+            ),
+          );
 
-      await tx
-        .insert(schema.quotas)
-        .values({
-          workspaceId: ctx.workspace.id,
-          requestsPerMonth: quotas.requestsPerMonth,
-          logsRetentionDays: quotas.logsRetentionDays,
-          auditLogsRetentionDays: quotas.auditLogsRetentionDays,
-          team: true,
-        })
-        .onDuplicateKeyUpdate({
-          set: {
+        if (updateResult.affectedRows === 0) {
+          const current = await tx.query.workspaces.findFirst({
+            where: (table, { eq }) => eq(table.id, ctx.workspace.id),
+            columns: { stripeSubscriptionId: true },
+          });
+          return current?.stripeSubscriptionId === sub.id ? "alreadyRecorded" : "lostRace";
+        }
+
+        await tx
+          .insert(schema.quotas)
+          .values({
+            workspaceId: ctx.workspace.id,
             requestsPerMonth: quotas.requestsPerMonth,
             logsRetentionDays: quotas.logsRetentionDays,
             auditLogsRetentionDays: quotas.auditLogsRetentionDays,
             team: true,
+          })
+          .onDuplicateKeyUpdate({
+            set: {
+              requestsPerMonth: quotas.requestsPerMonth,
+              logsRetentionDays: quotas.logsRetentionDays,
+              auditLogsRetentionDays: quotas.auditLogsRetentionDays,
+              team: true,
+            },
+          });
+
+        await insertAuditLogs(tx, {
+          workspaceId: ctx.workspace.id,
+          actor: {
+            type: "user",
+            id: ctx.user.id,
+          },
+          event: "workspace.update",
+          description: `Subscribed to ${product.name} plan`,
+          resources: [],
+          context: {
+            location: ctx.audit.location,
+            userAgent: ctx.audit.userAgent,
           },
         });
 
-      await insertAuditLogs(tx, {
-        workspaceId: ctx.workspace.id,
-        actor: {
-          type: "user",
-          id: ctx.user.id,
-        },
-        event: "workspace.update",
-        description: `Subscribed to ${product.name} plan`,
-        resources: [],
-        context: {
-          location: ctx.audit.location,
-          userAgent: ctx.audit.userAgent,
-        },
+        return "created";
+      },
+    );
+
+    if (outcome === "lostRace") {
+      // Another request attached a different subscription first. Cancel the one we
+      // just created so the customer is not billed twice.
+      try {
+        await stripe.subscriptions.cancel(sub.id);
+      } catch (cancelErr) {
+        console.error(
+          `Failed to cancel duplicate subscription ${sub.id} for workspace ${ctx.workspace.id}. It is still active in Stripe and must be cancelled manually:`,
+          cancelErr,
+        );
+      }
+      throw new TRPCError({
+        code: "PRECONDITION_FAILED",
+        message: `Customer ${ctx.workspace.stripeCustomerId} already has a subscription.`,
       });
-    });
+    }
 
     // Invalidate workspace cache after subscription creation
     await invalidateWorkspaceCache(ctx.tenant.id);

--- a/web/apps/dashboard/lib/trpc/routers/stripe/createSubscription.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/createSubscription.ts
@@ -257,14 +257,35 @@ export const createSubscription = workspaceProcedure
     );
 
     if (outcome === "lostRace") {
-      // Another request attached a different subscription first. Cancel the one we
-      // just created so the customer is not billed twice.
+      // Another request attached a different subscription first. Cancelling stops
+      // future billing, but `error_if_incomplete` means an active subscription has
+      // already paid its first invoice — so we must also refund that invoice, or the
+      // customer keeps a duplicate paid charge.
       try {
         await stripe.subscriptions.cancel(sub.id);
       } catch (cancelErr) {
         console.error(
           `Failed to cancel duplicate subscription ${sub.id} for workspace ${ctx.workspace.id}. It is still active in Stripe and must be cancelled manually:`,
           cancelErr,
+        );
+      }
+      try {
+        const invoiceId =
+          typeof sub.latest_invoice === "string" ? sub.latest_invoice : sub.latest_invoice?.id;
+        if (invoiceId) {
+          const invoice = await stripe.invoices.retrieve(invoiceId);
+          const paymentIntentId =
+            typeof invoice.payment_intent === "string"
+              ? invoice.payment_intent
+              : invoice.payment_intent?.id;
+          if (invoice.amount_paid > 0 && paymentIntentId) {
+            await stripe.refunds.create({ payment_intent: paymentIntentId });
+          }
+        }
+      } catch (refundErr) {
+        console.error(
+          `Failed to refund the first invoice of duplicate subscription ${sub.id} for workspace ${ctx.workspace.id}. The customer was charged twice and must be refunded manually:`,
+          refundErr,
         );
       }
       throw new TRPCError({

--- a/web/internal/db/src/schema/workspaces.ts
+++ b/web/internal/db/src/schema/workspaces.ts
@@ -31,7 +31,10 @@ export const workspaces = mysqlTable("workspaces", {
 
   // stripe
   stripeCustomerId: varchar("stripe_customer_id", { length: 256 }),
-  stripeSubscriptionId: varchar("stripe_subscription_id", { length: 256 }),
+  // Unique so two workspaces can never claim the same Stripe subscription, and a
+  // race in createSubscription cannot record a duplicate. MySQL unique indexes
+  // permit multiple NULLs, so free workspaces are unaffected.
+  stripeSubscriptionId: varchar("stripe_subscription_id", { length: 256 }).unique(),
 
   /**
    * feature flags


### PR DESCRIPTION
## What does this PR do?

This PR fixes two related billing-safety bugs in the Stripe flow.

The first is in the customer.subscription.deleted webhook handler. The downgrade consisted of four sequential, non-transactionalwrites, and the very first one nulled out stripeSubscriptionId — the same key used to look the workspace up. If any later write failed, we returned a 500 and Stripe retried, but the retry could no longer find the workspace and returned 200, so Stripe marked the event delivered and the workspace was left permanently half-downgraded (for example tier=Free with paid quotas still in place). The DB writes are now wrapped in a single db.transaction(), matching what the customer.subscription.updated handler already does: any failure rolls everything back, the lookup key survives, and Stripe's retry reprocesses the event cleanly. The membership deactivation stays outside the transaction because it calls the external auth API and is deliberately designed never to throw.

The second is a TOCTOU race in the createSubscription tRPC mutation that could double-bill a customer. The "already subscribed" guard read ctx.workspace.stripeSubscriptionId, which is loaded once at context-creation time and can be stale, the Stripe create call carried no idempotency key, and the DB write was unconditional — so a double-clicked subscribe button, a retried request, or two concurrent tabs could each create a separate active subscription, with the database only remembering the last one. The fix is layered: the workspace is re-read from the database immediately before calling Stripe; the subscriptions.create call now carries a deterministic idempotency key (workspace + product + a 5-minute time bucket, so duplicate calls collapse to one subscription while a user who fixes a declined card isn't locked out by Stripe's 24-hour error replay); and the DB write is now conditional on stripe_subscription_id IS NULL with an affected-rows check. When that check fails, the code distinguishes an idempotent replay of the same subscription (treated as success) from a genuinely different subscription created by a racing request, in which case the duplicate is cancelled in Stripe before the customer is billed for it. As a hard backstop, stripe_subscription_id now has a unique  index so two workspaces can never claim the same subscription; MySQL unique indexes permit multiple NULLs, so free workspaces are unaffected. The Go-side schema mirror (pkg/mysql/schema/workspaces.sql) was regenerated via make generate-sql, and the sqlc-generated code was confirmed unchanged.

Fixes # (issue)

_If there is not an issue for this, create one first. This is used for tracking purposes and helps us understand why this PR exists._

<!-- If there isn't an issue for this PR, review the internal workflow guide and create an issue. -->

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [X] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Make sure the DB changes are in staging 
-Double click the subscribe button (or fire the mutation twice concurrently, e.g. two tabs). Exactly one subscription should exist in Stripe test mode afterwards; the losing request should fail with "already has a subscription" and must not leave a second active subscription behind.
- Trigger a customer.subscription.deleted event via the Stripe CLI (stripe trigger customer.subscription.deleted) and confirm the workspace is downgraded to Free with free-tier quotas in one shot.
- To verify retry safety, force a failure mid-handler (e.g. temporarily throw after the workspace update inside the transaction) and confirm the webhook returns 500 and the workspace row is unchanged — the retry should then find the workspace and complete the downgrade.
- With a card that declines (Stripe test card 4000000000000002), confirm the subscribe attempt fails cleanly and a retry after switching to a valid card succeeds.

## Checklist

<!-- Complete this checklist before requesting review. -->

### Required

- [X] Filled out the "How to test" section in this PR
- [ ] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [X] Ran `pnpm build`
- [X] Ran `pnpm fmt`
- [X] Ran `mise run fmt`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary
