### PR TITLE
feat(dashboard): Report unexpected session logouts to Sentry

### DIFF
--- a/web/apps/dashboard/lib/auth/sessions.ts
+++ b/web/apps/dashboard/lib/auth/sessions.ts
@@ -1,10 +1,49 @@
 "use server";
 
 import { env } from "@/lib/env";
+import * as Sentry from "@sentry/nextjs";
 import type { NextRequest } from "next/server";
 import { getCookie, getCookieOptionsAsString, setSessionCookie } from "./cookies";
 import { auth } from "./server";
 import { LOCAL_ORG_ID, LOCAL_ORG_ROLE, LOCAL_USER_ID, UNKEY_SESSION_COOKIE } from "./types";
+
+type SessionFailureReason =
+  | "refresh_failed"
+  | "validation_unrefreshable"
+  | "validation_threw"
+  | "unexpected_error";
+
+// Diagnostic instrumentation for the GitHub-callback logout. Reaching any of
+// these branches returns a null session, which makes the proxy redirect the
+// user to sign-in. We only get here when a session cookie was present, so this
+// reports unexpected logouts and ignores anonymous visitors.
+//
+// Prime suspect: a single-use refresh-token race. A sealed session's refresh
+// token is consumed on first use, but one navigation can trigger several
+// refreshes of the same token — the proxy middleware, the tRPC context's
+// getAuth, and its post-login retry all call updateSession(req) with the same
+// cookie. The first refresh rotates the token; the rest throw "already used".
+// Remove once the cause is confirmed and the refresh path is deduped.
+function reportSessionFailure(
+  reason: SessionFailureReason,
+  request: NextRequest | undefined,
+  error: unknown,
+): void {
+  Sentry.captureException(error instanceof Error ? error : new Error(`auth: ${reason}`), {
+    level: "warning",
+    tags: {
+      auth_failure: reason,
+      // request => proxy middleware (edge); no request => RSC/server-component
+      // session reads. Lets us see which context lost the refresh race.
+      auth_context: request ? "request" : "no_request",
+    },
+    extra: {
+      // pathname only; the query string carries the signed GitHub `state`
+      // token and installation id, which must not reach Sentry.
+      path: request?.nextUrl.pathname ?? null,
+    },
+  });
+}
 
 type SessionResult = {
   session: {
@@ -151,18 +190,22 @@ export async function updateSession(request?: NextRequest): Promise<SessionResul
               headers,
             };
           }
-        } catch (_refreshError) {
+        } catch (refreshError) {
           // If refresh fails, treat as no session
+          reportSessionFailure("refresh_failed", request, refreshError);
           return { session: null, headers };
         }
       }
 
       // Session is neither valid nor refreshable
+      reportSessionFailure("validation_unrefreshable", request, undefined);
       return { session: null, headers };
-    } catch (_validationError) {
+    } catch (validationError) {
+      reportSessionFailure("validation_threw", request, validationError);
       return { session: null, headers };
     }
-  } catch (_error) {
+  } catch (error) {
+    reportSessionFailure("unexpected_error", request, error);
     return { session: null, headers };
   }
 }


### PR DESCRIPTION
## What does this PR do?

The auth middleware redirects a user to sign-in whenever `updateSession` returns a null session. Today the validation and refresh branches that produce that null swallow their errors, so a logged-in user being dropped to the sign-in page leaves no trace anywhere. This adds Sentry reporting at each of those branches, tagged by failure reason, request context (edge proxy vs server read), and pathname.

This is diagnostic-only — no behaviour changes. It exists to confirm a suspected single-use refresh-token race: one navigation can trigger several refreshes of the same sealed-session token (the proxy middleware, the tRPC context's `getAuth`, and its post-login retry all call `updateSession(req)` with the same cookie), and the loser throws "token already used", which currently surfaces as a silent logout — most visibly on the GitHub installation callback.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

Not reproducible locally: the `local` auth provider short-circuits with a token that never expires, so the refresh branches never run and Sentry is disabled in development. Validate on a preview or prod deploy instead:

1. Sign in and walk the GitHub app install/return flow (the `setup_action=update` round-trip is the one that drops the session).
2. If logged out, check Sentry for a warning-level event tagged `auth_failure` (expect `refresh_failed`) with `path` = the callback route and `auth_context` showing which context lost the race.

Once the event confirms the cause, the follow-up is to make the refresh path single-flight (dedupe concurrent refreshes of the same token) and remove this instrumentation.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`