### PR TITLE
fix: Make cookies lax

### DIFF
--- a/web/apps/dashboard/lib/auth/cookies.ts
+++ b/web/apps/dashboard/lib/auth/cookies.ts
@@ -6,7 +6,7 @@
 
 import { cookies } from "next/headers";
 import type { NextRequest, NextResponse } from "next/server";
-import { getDefaultCookieOptions } from "./cookie-security";
+import { getAuthCookieOptions, getDefaultCookieOptions } from "./cookie-security";
 import { UNKEY_LAST_ORG_COOKIE, UNKEY_SESSION_COOKIE } from "./types";
 
 export interface CookieOptions {
@@ -110,11 +110,15 @@ export async function setSessionCookie(params: {
 }): Promise<void> {
   const { token, expiresAt } = params;
 
+  // The session cookie must always be SameSite=Lax, matching how sign-in
+  // issues it. Strict would not be sent on cross-site top-level navigations
+  // back into the app (OAuth callbacks, GitHub App install returns), which
+  // makes the user appear logged out on those requests.
   await setCookie({
     name: UNKEY_SESSION_COOKIE,
     value: token,
     options: {
-      ...getDefaultCookieOptions(),
+      ...getAuthCookieOptions(),
       maxAge: Math.floor((expiresAt.getTime() - Date.now()) / 1000),
     },
   });

--- a/web/apps/dashboard/lib/auth/sessions.ts
+++ b/web/apps/dashboard/lib/auth/sessions.ts
@@ -2,6 +2,7 @@
 
 import { env } from "@/lib/env";
 import type { NextRequest } from "next/server";
+import { getAuthCookieOptions } from "./cookie-security";
 import { getCookie, getCookieOptionsAsString, setSessionCookie } from "./cookies";
 import { auth } from "./server";
 import { LOCAL_ORG_ID, LOCAL_ORG_ROLE, LOCAL_USER_ID, UNKEY_SESSION_COOKIE } from "./types";
@@ -46,7 +47,7 @@ export async function updateSession(request?: NextRequest): Promise<SessionResul
       } catch (_error) {
         headers.append(
           "Set-Cookie",
-          `${UNKEY_SESSION_COOKIE}=${localSessionToken}; Path=/; SameSite=Strict; Max-Age=${
+          `${UNKEY_SESSION_COOKIE}=${localSessionToken}; Path=/; SameSite=Lax; Max-Age=${
             60 * 60 * 24 * 365 * 10
           }`,
         );
@@ -114,6 +115,7 @@ export async function updateSession(request?: NextRequest): Promise<SessionResul
               `${UNKEY_SESSION_COOKIE}=${
                 refreshedSession.newToken
               }; ${await getCookieOptionsAsString({
+                ...getAuthCookieOptions(),
                 expiresAt: refreshedSession.expiresAt,
               })}`,
             );
@@ -132,6 +134,7 @@ export async function updateSession(request?: NextRequest): Promise<SessionResul
                 `${UNKEY_SESSION_COOKIE}=${
                   refreshedSession.newToken
                 }; ${await getCookieOptionsAsString({
+                  ...getAuthCookieOptions(),
                   expiresAt: refreshedSession.expiresAt,
                 })}`,
               );


### PR DESCRIPTION
## What does this PR do?

In a couple scenarios we set the cookie back to stritct, like creating a new workspace. We should not do that, it should be LAX. This only became an issue after we redirect to Github more often then not. 

_If there is not an issue for this, create one first. This is used for tracking purposes and helps us understand why this PR exists._

<!-- If there isn't an issue for this PR, review the internal workflow guide and create an issue. -->

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Create a new workspace from being logged in
- Verify that the cookie in devtools is not strict

## Checklist

<!-- Complete this checklist before requesting review. -->

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `mise run fmt`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary
