### PR TITLE
feat(tui): styled terminal output package for CLI commands

### DIFF
--- a/pkg/tui/BUILD.bazel
+++ b/pkg/tui/BUILD.bazel
@@ -1,0 +1,26 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "tui",
+    srcs = [
+        "doc.go",
+        "kv.go",
+        "renderer.go",
+        "style.go",
+        "table.go",
+        "width.go",
+    ],
+    importpath = "github.com/unkeyed/unkey/pkg/tui",
+    visibility = ["//visibility:public"],
+    deps = ["@org_golang_x_term//:term"],
+)
+
+go_test(
+    name = "tui_test",
+    srcs = [
+        "bench_test.go",
+        "tui_test.go",
+    ],
+    embed = [":tui"],
+    deps = ["@com_github_stretchr_testify//require"],
+)

--- a/pkg/tui/bench_test.go
+++ b/pkg/tui/bench_test.go
@@ -1,0 +1,35 @@
+package tui
+
+import (
+	"io"
+	"testing"
+)
+
+func BenchmarkTablePrint(b *testing.B) {
+	r := NewWithColor(io.Discard, true)
+	for b.Loop() {
+		t := r.Table("ID", "STATUS", "PERIOD ENDS")
+		for range 50 {
+			t.Row("cus_UgEeZp1mjNpcYy", r.Green("ready"), "2026-07-01T19:52:51Z")
+		}
+		t.Print()
+	}
+}
+
+func BenchmarkKVPrint(b *testing.B) {
+	r := NewWithColor(io.Discard, true)
+	for b.Loop() {
+		r.KV().Indent(2).
+			Add("status", r.Green("ready")).
+			Add("frozen at", "2026-06-10T19:52:51Z").
+			Add("customer", "cus_UgEeZp1mjNpcYy").
+			Print()
+	}
+}
+
+func BenchmarkVisibleWidth(b *testing.B) {
+	s := "\033[32mcus_UgEeZp1mjNpcYy\033[0m"
+	for b.Loop() {
+		visibleWidth(s)
+	}
+}

--- a/pkg/tui/doc.go
+++ b/pkg/tui/doc.go
@@ -1,0 +1,26 @@
+// Package tui renders styled, aligned terminal output for CLI commands.
+//
+// It covers the non-interactive half of terminal UX: colors, aligned tables,
+// and key-value blocks. For interactive input (menus, pickers) see pkg/prompt.
+// Like pkg/prompt it sticks to the standard library plus golang.org/x/term,
+// avoiding heavier TUI dependencies.
+//
+// Styling degrades gracefully: escape codes are emitted only when the writer
+// is a terminal, NO_COLOR is unset, and TERM is not "dumb". The same code
+// path written to a pipe or file produces plain aligned text, so command
+// output stays grep-friendly.
+//
+// # Usage
+//
+//	out := tui.New(os.Stdout)
+//	out.Println(out.Bold("local") + "  " + out.Dim("clock_123"))
+//
+//	out.KV().Indent(2).
+//		Add("status", out.Green("ready")).
+//		Add("frozen at", "2026-06-10T19:52:51Z").
+//		Print()
+//
+//	out.Table("CUSTOMER", "WORKSPACE").
+//		Row("cus_123", "ws_local").
+//		Print()
+package tui

--- a/pkg/tui/kv.go
+++ b/pkg/tui/kv.go
@@ -1,0 +1,65 @@
+package tui
+
+import "strings"
+
+// KV accumulates key-value pairs and prints them with values aligned to the
+// widest key. Keys render dim; values carry whatever styling the caller
+// applied.
+type KV struct {
+	r      *Renderer
+	pairs  [][2]string
+	indent int
+}
+
+// KV starts a key-value block.
+func (r *Renderer) KV() *KV {
+	return &KV{r: r, pairs: nil, indent: 0}
+}
+
+// Indent shifts the whole block right by n spaces.
+func (kv *KV) Indent(n int) *KV {
+	kv.indent = n
+	return kv
+}
+
+// Add appends a pair.
+func (kv *KV) Add(key, value string) *KV {
+	kv.pairs = append(kv.pairs, [2]string{key, value})
+	return kv
+}
+
+// AddIf appends a pair only when the value is non-empty, for optional fields.
+func (kv *KV) AddIf(key, value string) *KV {
+	if value == "" {
+		return kv
+	}
+	return kv.Add(key, value)
+}
+
+// Print writes the block in a single write. An empty block prints nothing.
+func (kv *KV) Print() {
+	if len(kv.pairs) == 0 {
+		return
+	}
+
+	width := 0
+	for _, pair := range kv.pairs {
+		if w := visibleWidth(pair[0]); w > width {
+			width = w
+		}
+	}
+
+	var b strings.Builder
+	for _, pair := range kv.pairs {
+		writeSpaces(&b, kv.indent)
+		// Pad inside the Dim so the escape codes wrap the whole column once;
+		// trailing spaces render identically dim or plain.
+		var key strings.Builder
+		writePadded(&key, pair[0], width)
+		b.WriteString(kv.r.Dim(key.String()))
+		b.WriteString("  ")
+		b.WriteString(pair[1])
+		b.WriteByte('\n')
+	}
+	kv.r.write(b.String())
+}

--- a/pkg/tui/renderer.go
+++ b/pkg/tui/renderer.go
@@ -1,0 +1,63 @@
+package tui
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"golang.org/x/term"
+)
+
+// Renderer writes styled output to a single destination. Create one per
+// command invocation with [New]; all styling methods return their input
+// unchanged when the destination does not support color.
+type Renderer struct {
+	w     io.Writer
+	color bool
+}
+
+// New returns a Renderer that auto-detects color support on w.
+func New(w io.Writer) *Renderer {
+	return &Renderer{w: w, color: shouldColor(w)}
+}
+
+// NewWithColor returns a Renderer with color support forced on or off,
+// bypassing terminal detection. Useful in tests.
+func NewWithColor(w io.Writer, color bool) *Renderer {
+	return &Renderer{w: w, color: color}
+}
+
+// shouldColor reports whether escape codes should be emitted: the writer must
+// be a terminal, and the user must not have opted out via the NO_COLOR
+// convention (https://no-color.org) or a dumb TERM.
+func shouldColor(w io.Writer) bool {
+	if os.Getenv("NO_COLOR") != "" || os.Getenv("TERM") == "dumb" {
+		return false
+	}
+	f, ok := w.(*os.File)
+	return ok && term.IsTerminal(int(f.Fd()))
+}
+
+// Println writes the arguments followed by a newline. Write errors are
+// dropped: terminal output is best-effort and a failing stdout leaves the
+// caller nothing useful to do.
+func (r *Renderer) Println(args ...any) {
+	_, _ = fmt.Fprintln(r.w, args...)
+}
+
+// Printf writes formatted output, dropping write errors like [Renderer.Println].
+func (r *Renderer) Printf(format string, args ...any) {
+	_, _ = fmt.Fprintf(r.w, format, args...)
+}
+
+// Blank writes an empty line, dropping write errors like [Renderer.Println].
+func (r *Renderer) Blank() {
+	_, _ = fmt.Fprintln(r.w)
+}
+
+// write emits a fully rendered block in a single Write call. Table and KV
+// rendering assemble their output in memory first so a multi-row block does
+// not turn into one syscall per row on unbuffered stdout.
+func (r *Renderer) write(s string) {
+	_, _ = io.WriteString(r.w, s)
+}

--- a/pkg/tui/style.go
+++ b/pkg/tui/style.go
@@ -1,0 +1,47 @@
+package tui
+
+import "strings"
+
+// SGR (Select Graphic Rendition) escape codes, same dialect as pkg/prompt.
+const (
+	codeReset  = "\033[0m"
+	codeBold   = "\033[1m"
+	codeDim    = "\033[90m" // bright black reads as gray on light and dark themes
+	codeRed    = "\033[31m"
+	codeGreen  = "\033[32m"
+	codeYellow = "\033[33m"
+	codeCyan   = "\033[36m"
+)
+
+func (r *Renderer) paint(code, s string) string {
+	if !r.color || s == "" {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(code) + len(s) + len(codeReset))
+	b.WriteString(code)
+	b.WriteString(s)
+	b.WriteString(codeReset)
+	return b.String()
+}
+
+// Bold renders s bold when color is enabled.
+func (r *Renderer) Bold(s string) string { return r.paint(codeBold, s) }
+
+// Dim renders s gray when color is enabled. Use for secondary detail such as
+// ids, labels, and hints.
+func (r *Renderer) Dim(s string) string { return r.paint(codeDim, s) }
+
+// Red renders s red when color is enabled. Use for failure states.
+func (r *Renderer) Red(s string) string { return r.paint(codeRed, s) }
+
+// Green renders s green when color is enabled. Use for success states.
+func (r *Renderer) Green(s string) string { return r.paint(codeGreen, s) }
+
+// Yellow renders s yellow when color is enabled. Use for pending or
+// in-progress states.
+func (r *Renderer) Yellow(s string) string { return r.paint(codeYellow, s) }
+
+// Cyan renders s cyan when color is enabled. Use for links and identifiers
+// the user is expected to act on.
+func (r *Renderer) Cyan(s string) string { return r.paint(codeCyan, s) }

--- a/pkg/tui/table.go
+++ b/pkg/tui/table.go
@@ -1,0 +1,80 @@
+package tui
+
+import "strings"
+
+// Table accumulates rows and prints them with columns aligned to the widest
+// cell. Column widths account for ANSI escape codes, so styled cells (for
+// example a Green status) align with plain ones.
+type Table struct {
+	r       *Renderer
+	headers []string
+	rows    [][]string
+	indent  int
+}
+
+// Table starts a table. Headers are optional; pass none for a bare aligned
+// grid. Headers render dim so data stands out over chrome.
+func (r *Renderer) Table(headers ...string) *Table {
+	return &Table{r: r, headers: headers, rows: nil, indent: 0}
+}
+
+// Indent shifts the whole table right by n spaces.
+func (t *Table) Indent(n int) *Table {
+	t.indent = n
+	return t
+}
+
+// Row appends a row. Rows may have more or fewer cells than the header.
+func (t *Table) Row(cells ...string) *Table {
+	t.rows = append(t.rows, cells)
+	return t
+}
+
+// Print writes the table in a single write. A table with headers but no rows
+// prints nothing: the caller decides how to phrase emptiness.
+func (t *Table) Print() {
+	if len(t.rows) == 0 {
+		return
+	}
+
+	var widths []int
+	measure := func(cells []string) {
+		for i, cell := range cells {
+			for len(widths) <= i {
+				widths = append(widths, 0)
+			}
+			if w := visibleWidth(cell); w > widths[i] {
+				widths[i] = w
+			}
+		}
+	}
+	measure(t.headers)
+	for _, row := range t.rows {
+		measure(row)
+	}
+
+	var b strings.Builder
+	if len(t.headers) > 0 {
+		styled := make([]string, len(t.headers))
+		for i, h := range t.headers {
+			styled[i] = t.r.Dim(h)
+		}
+		t.writeRow(&b, styled, widths)
+	}
+	for _, row := range t.rows {
+		t.writeRow(&b, row, widths)
+	}
+	t.r.write(b.String())
+}
+
+func (t *Table) writeRow(b *strings.Builder, cells []string, widths []int) {
+	writeSpaces(b, t.indent)
+	for i, cell := range cells {
+		if i == len(cells)-1 {
+			b.WriteString(cell) // never pad the last cell: no trailing whitespace
+			break
+		}
+		writePadded(b, cell, widths[i]+2) // two-space column gap
+	}
+	b.WriteByte('\n')
+}

--- a/pkg/tui/tui_test.go
+++ b/pkg/tui/tui_test.go
@@ -1,0 +1,145 @@
+package tui
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStylesDisabledWithoutColor(t *testing.T) {
+	buf := &bytes.Buffer{}
+	r := NewWithColor(buf, false)
+
+	require.Equal(t, "hello", r.Bold("hello"))
+	require.Equal(t, "hello", r.Dim("hello"))
+	require.Equal(t, "hello", r.Red("hello"))
+	require.Equal(t, "hello", r.Green("hello"))
+	require.Equal(t, "hello", r.Yellow("hello"))
+	require.Equal(t, "hello", r.Cyan("hello"))
+}
+
+func TestStylesEnabledWithColor(t *testing.T) {
+	buf := &bytes.Buffer{}
+	r := NewWithColor(buf, true)
+
+	require.Equal(t, "\033[1mhello\033[0m", r.Bold("hello"))
+	require.Equal(t, "\033[90mhello\033[0m", r.Dim("hello"))
+	require.Equal(t, "\033[32mhello\033[0m", r.Green("hello"))
+}
+
+func TestStyleEmptyStringStaysEmpty(t *testing.T) {
+	r := NewWithColor(&bytes.Buffer{}, true)
+	require.Equal(t, "", r.Bold(""))
+}
+
+func TestVisibleWidth(t *testing.T) {
+	require.Equal(t, 5, visibleWidth("hello"))
+	require.Equal(t, 5, visibleWidth("\033[32mhello\033[0m"))
+	require.Equal(t, 0, visibleWidth("\033[0m"))
+	require.Equal(t, 6, visibleWidth("héllo!")) // multibyte runes count once
+}
+
+func TestTableAlignsColumns(t *testing.T) {
+	buf := &bytes.Buffer{}
+	r := NewWithColor(buf, false)
+
+	r.Table("ID", "STATUS").
+		Row("cus_short", "ready").
+		Row("cus_much_longer_id", "advancing").
+		Print()
+
+	require.Equal(t,
+		"ID                  STATUS\n"+
+			"cus_short           ready\n"+
+			"cus_much_longer_id  advancing\n",
+		buf.String())
+}
+
+func TestTableAlignsStyledCells(t *testing.T) {
+	buf := &bytes.Buffer{}
+	r := NewWithColor(buf, true)
+
+	r.Table().
+		Row(r.Green("ok"), "a").
+		Row("long", "b").
+		Print()
+
+	require.Equal(t,
+		"\033[32mok\033[0m    a\n"+
+			"long  b\n",
+		buf.String())
+}
+
+func TestTableIndentAndNoTrailingWhitespace(t *testing.T) {
+	buf := &bytes.Buffer{}
+	r := NewWithColor(buf, false)
+
+	r.Table("A", "B").
+		Indent(2).
+		Row("x", "y").
+		Row("xx", "").
+		Print()
+
+	require.Equal(t,
+		"  A   B\n"+
+			"  x   y\n"+
+			"  xx  \n",
+		buf.String())
+}
+
+func TestTableWithoutRowsPrintsNothing(t *testing.T) {
+	buf := &bytes.Buffer{}
+	r := NewWithColor(buf, false)
+
+	r.Table("A", "B").Print()
+
+	require.Empty(t, buf.String())
+}
+
+func TestTableRowsWiderThanHeader(t *testing.T) {
+	buf := &bytes.Buffer{}
+	r := NewWithColor(buf, false)
+
+	r.Table("A").
+		Row("x", "extra").
+		Print()
+
+	require.Equal(t, "A\nx  extra\n", buf.String())
+}
+
+func TestKVAlignsValues(t *testing.T) {
+	buf := &bytes.Buffer{}
+	r := NewWithColor(buf, false)
+
+	r.KV().Indent(2).
+		Add("status", "ready").
+		Add("frozen at", "2026-06-10T19:52:51Z").
+		Print()
+
+	require.Equal(t,
+		"  status     ready\n"+
+			"  frozen at  2026-06-10T19:52:51Z\n",
+		buf.String())
+}
+
+func TestKVAddIfSkipsEmptyValues(t *testing.T) {
+	buf := &bytes.Buffer{}
+	r := NewWithColor(buf, false)
+
+	r.KV().
+		Add("present", "yes").
+		AddIf("absent", "").
+		Print()
+
+	require.Equal(t, "present  yes\n", buf.String())
+}
+
+func TestKVEmptyPrintsNothing(t *testing.T) {
+	buf := &bytes.Buffer{}
+	r := NewWithColor(buf, false)
+
+	r.KV().Print()
+
+	require.Empty(t, buf.String())
+}

--- a/pkg/tui/width.go
+++ b/pkg/tui/width.go
@@ -1,0 +1,49 @@
+package tui
+
+import "strings"
+
+// visibleWidth returns the number of terminal cells s occupies, skipping ANSI
+// escape sequences so styled cells align with plain ones. CSI sequences run
+// from ESC to the first ASCII letter.
+func visibleWidth(s string) int {
+	width := 0
+	inEscape := false
+	for _, ch := range s {
+		if inEscape {
+			if (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') {
+				inEscape = false
+			}
+			continue
+		}
+		if ch == '\033' {
+			inEscape = true
+			continue
+		}
+		width++
+	}
+	return width
+}
+
+// writePadded writes s to b followed by enough spaces to fill width terminal
+// cells, measuring visible width so ANSI styling does not break alignment.
+// Writing into the builder avoids the intermediate string a pad-then-append
+// approach would allocate per cell.
+func writePadded(b *strings.Builder, s string, width int) {
+	b.WriteString(s)
+	writeSpaces(b, width-visibleWidth(s))
+}
+
+const spaces = "                                                                "
+
+// writeSpaces writes n spaces to b without allocating, chunking through a
+// fixed buffer for the rare n larger than it.
+func writeSpaces(b *strings.Builder, n int) {
+	for n > 0 {
+		chunk := n
+		if chunk > len(spaces) {
+			chunk = len(spaces)
+		}
+		b.WriteString(spaces[:chunk])
+		n -= chunk
+	}
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/deploy-product-card.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/deploy-product-card.tsx
@@ -244,16 +244,16 @@ export const DeployProductCard: React.FC<DeployProductCardProps> = ({
         }))}
         currentId={currentPlan}
         // Warn when the period's metered spend already exceeds the credits the
-        // selected plan includes: the downgrade is allowed, but the difference
-        // becomes overage instead of being covered.
+        // selected plan includes. Downgrades keep the current period's credits,
+        // so the overage only starts biting at the next renewal.
         warningFor={(option) =>
           option.amount !== null && usageAmount !== null && usageAmount > option.amount
             ? `Your usage this period (${formatDollars(usageAmount)}) already exceeds the ${formatDollars(
                 option.amount,
-              )} of credits ${option.name} includes; the difference is billed as overage.`
+              )} of monthly credits ${option.name} includes. This period keeps your current credits; from next period, usage at this level is billed as overage.`
             : null
         }
-        changeNote="Takes effect immediately; the fee difference is prorated on your next invoice."
+        changeNote="Takes effect immediately. Upgrades are charged now and add the difference as usage credits; downgrades keep this period's credits, with the new fee starting next period."
         submittingId={
           subscribe.isLoading
             ? subscribe.variables?.plan

--- a/web/apps/dashboard/lib/stripe/deployCredits.test.ts
+++ b/web/apps/dashboard/lib/stripe/deployCredits.test.ts
@@ -1,0 +1,113 @@
+import type Stripe from "stripe";
+import { describe, expect, it } from "vitest";
+import type { DeployBillingConfig } from "./deployBilling";
+import { netDeployFee } from "./deployCredits";
+
+const config: DeployBillingConfig = {
+  planFeePriceIds: {
+    starter: "price_fee_starter",
+    pro: "price_fee_pro",
+    business: "price_fee_business",
+  },
+  meteredPriceIds: ["price_cpu", "price_mem", "price_egress", "price_disk"],
+  allDeployPriceIds: new Set([
+    "price_fee_starter",
+    "price_fee_pro",
+    "price_fee_business",
+    "price_cpu",
+    "price_mem",
+    "price_egress",
+    "price_disk",
+  ]),
+};
+
+// Minimal invoice line stub: netDeployFee reads amount, discount_amounts,
+// period.end, and the price id under pricing.price_details.price.
+function line(
+  priceId: string,
+  amount: number,
+  periodEnd: number,
+  discountCents = 0,
+): Stripe.InvoiceLineItem {
+  return {
+    amount,
+    discount_amounts: discountCents ? [{ amount: discountCents, discount: "di_test" }] : [],
+    period: { end: periodEnd, start: periodEnd - 3600 },
+    pricing: { type: "price_details", price_details: { price: priceId } },
+  } as unknown as Stripe.InvoiceLineItem;
+}
+
+describe("netDeployFee", () => {
+  it("returns the fee of a single plan-fee line (subscribe / renewal)", () => {
+    const fee = netDeployFee(config, [
+      line("price_fee_business", 5000, 1_700_000_000),
+      line("price_cpu", 123, 1_700_000_000),
+    ]);
+    expect(fee).toEqual({ amountCents: 5000, periodEnd: 1_700_000_000, plan: "business" });
+  });
+
+  it("nets a mid-cycle upgrade's proration pair to the top-up", () => {
+    // always_invoice upgrade Starter -> Business: unused Starter credited,
+    // prorated Business charged. The net is exactly the credits to top up.
+    const fee = netDeployFee(config, [
+      line("price_fee_starter", -300, 1_700_000_000),
+      line("price_fee_business", 2800, 1_700_000_000),
+    ]);
+    expect(fee?.amountCents).toBe(2500);
+  });
+
+  it("nets a downgrade negative, which grants nothing upstream", () => {
+    const fee = netDeployFee(config, [
+      line("price_fee_business", -2800, 1_700_000_000),
+      line("price_fee_starter", 300, 1_700_000_000),
+    ]);
+    expect(fee?.amountCents).toBeLessThan(0);
+  });
+
+  it("ignores metered and unrelated lines", () => {
+    expect(
+      netDeployFee(config, [
+        line("price_cpu", 866, 1_700_000_000),
+        line("price_api_plan", 7500, 1_700_000_000),
+      ]),
+    ).toBeNull();
+  });
+
+  it("uses the latest period end across fee lines", () => {
+    const fee = netDeployFee(config, [
+      line("price_fee_starter", -300, 1_700_000_000),
+      line("price_fee_business", 2800, 1_700_500_000),
+    ]);
+    expect(fee?.periodEnd).toBe(1_700_500_000);
+  });
+
+  it("ignores metered lines", () => {
+    expect(netDeployFee(config, [line("price_cpu", 866, 1_700_000_000)])).toBeNull();
+  });
+
+  it("ignores lines without price details (e.g. credit lines)", () => {
+    const creditLine = {
+      amount: -500,
+      period: { end: 1_700_000_000, start: 1_699_996_400 },
+      pricing: null,
+    } as unknown as Stripe.InvoiceLineItem;
+    expect(netDeployFee(config, [creditLine])).toBeNull();
+  });
+
+  it("labels the plan from the charge line regardless of proration order", () => {
+    // Negative (departing) line first: plan must still reflect the new plan,
+    // since that is what the credit name and metadata are read against.
+    const fee = netDeployFee(config, [
+      line("price_fee_starter", -300, 1_700_000_000),
+      line("price_fee_business", 2800, 1_700_000_000),
+    ]);
+    expect(fee?.plan).toBe("business");
+  });
+
+  it("subtracts discount_amounts so a coupon reduces the credit", () => {
+    // $50 fee with a $10 coupon allocated to the line (Stripe distributes
+    // invoice-level coupons this way): the grant tracks the $40 actually paid.
+    const fee = netDeployFee(config, [line("price_fee_business", 5000, 1_700_000_000, 1000)]);
+    expect(fee?.amountCents).toBe(4000);
+  });
+});

--- a/web/apps/dashboard/lib/stripe/deployCredits.ts
+++ b/web/apps/dashboard/lib/stripe/deployCredits.ts
@@ -1,5 +1,10 @@
 import type Stripe from "stripe";
-import { deployBillingConfig, planForPlanFeePriceId } from "./deployBilling";
+import {
+  type DeployBillingConfig,
+  deployBillingConfig,
+  planForPlanFeePriceId,
+} from "./deployBilling";
+import type { DeployPlan } from "./deployPlan";
 
 /**
  * How long credits stay redeemable past the plan-fee period they belong to.
@@ -17,18 +22,66 @@ export type DeployCreditGrantResult =
   | { granted: false; reason: string }
   | { granted: true; grantId: string; amountCents: number };
 
+export type NetDeployFee = {
+  /** Net of the invoice's Deploy plan-fee lines (cents); can be negative. */
+  amountCents: number;
+  /** Latest period end across the fee lines (unix seconds). */
+  periodEnd: number;
+  /** The plan the charged (largest) fee line maps to, when recognizable. */
+  plan?: DeployPlan;
+};
+
+/**
+ * Sums an invoice's Deploy plan-fee lines net of discounts, or returns null
+ * when it has none.
+ *
+ * Summing the lines (rather than reading the catalog price) makes prorations
+ * self-correcting across every flow: a mid-cycle subscribe grants the
+ * prorated amount, a mid-cycle upgrade's always_invoice proration invoice
+ * nets (+new fee, -unused old fee) to exactly the top-up, a downgrade nets
+ * negative (no grant, no clawback), and a renewal grants the full fee.
+ *
+ * line.amount is the gross fee, excluding tax and discounts, so each line's
+ * discount_amounts are subtracted (Stripe distributes invoice-level coupons
+ * into these too) to track the fee actually paid, not the list price.
+ */
+export function netDeployFee(
+  config: DeployBillingConfig,
+  lines: Stripe.InvoiceLineItem[],
+): NetDeployFee | null {
+  const feeLines = lines.filter((line) => {
+    const priceId = line.pricing?.price_details?.price;
+    return typeof priceId === "string" && Boolean(planForPlanFeePriceId(config, priceId));
+  });
+  if (feeLines.length === 0) {
+    return null;
+  }
+
+  // Label from the largest fee line. On an upgrade proration the lines are
+  // +new prorated fee and -unused old fee in Stripe's own order, and the plan
+  // being charged is the positive, larger one; picking feeLines[0] could name
+  // the credit after the departing plan. Subscribe and renewal have a single
+  // fee line, so this is a no-op there.
+  const chargeLine = feeLines.reduce((max, line) => (line.amount > max.amount ? line : max));
+  const chargePriceId = chargeLine.pricing?.price_details?.price;
+
+  return {
+    amountCents: feeLines.reduce((sum, line) => {
+      const discounts = (line.discount_amounts ?? []).reduce((d, da) => d + da.amount, 0);
+      return sum + line.amount - discounts;
+    }, 0),
+    periodEnd: Math.max(...feeLines.map((line) => line.period.end)),
+    plan:
+      typeof chargePriceId === "string" ? planForPlanFeePriceId(config, chargePriceId) : undefined,
+  };
+}
+
 /**
  * Grants the Deploy usage credits a paid invoice entitles the customer to:
- * the net amount of its Deploy plan-fee lines, scoped to metered prices (the
- * only metered prices on a subscription are the Deploy meters; API tiers are
- * licensed), expiring shortly after the period the fee covers.
- *
- * Summing the plan-fee lines (rather than reading the catalog price) makes
- * prorations self-correcting: a mid-cycle subscribe grants the prorated
- * amount, and a renewal invoice carrying up/downgrade prorations grants the
- * net fee actually paid for the period. Each line's discount_amounts are
- * subtracted so coupons (line-level and invoice-level alike) reduce the credit
- * the way they reduce the bill. A net of zero or less grants nothing.
+ * the net amount of its Deploy plan-fee lines ([[netDeployFee]]), scoped to
+ * metered prices (the only metered prices on a subscription are the Deploy
+ * meters; API tiers are licensed), expiring shortly after the period the fee
+ * covers. A net of zero or less grants nothing.
  *
  * Idempotent per invoice twice over: an idempotency key derived from the
  * invoice id covers webhook retries, and a metadata check against existing
@@ -56,28 +109,15 @@ export async function grantDeployCreditsForInvoice(
     });
   }
 
-  const feeLines = invoice.lines.data.filter((line) => {
-    const priceId = line.pricing?.price_details?.price;
-    return typeof priceId === "string" && Boolean(planForPlanFeePriceId(config, priceId));
-  });
-  if (feeLines.length === 0) {
+  const fee = netDeployFee(config, invoice.lines.data);
+  if (!fee) {
     return { granted: false, reason: "no deploy plan-fee lines" };
   }
-
-  // line.amount is the gross fee, excluding tax and discounts. Subtracting the
-  // per-line discount_amounts (Stripe distributes invoice-level coupons into
-  // these too) makes the credit track the fee actually paid, not the list
-  // price; a customer with a coupon would otherwise be granted more than billed.
-  const amountCents = feeLines.reduce((sum, line) => {
-    const discounts = (line.discount_amounts ?? []).reduce((d, da) => d + da.amount, 0);
-    return sum + line.amount - discounts;
-  }, 0);
-  if (amountCents <= 0) {
-    return { granted: false, reason: `non-positive net plan-fee amount (${amountCents})` };
+  if (fee.amountCents <= 0) {
+    return { granted: false, reason: `non-positive net plan-fee amount (${fee.amountCents})` };
   }
 
-  const periodEnd = Math.max(...feeLines.map((line) => line.period.end));
-  const expiresAt = periodEnd + EXPIRY_GRACE_SECONDS;
+  const expiresAt = fee.periodEnd + EXPIRY_GRACE_SECONDS;
   if (expiresAt * 1000 <= Date.now()) {
     // Paid long after the period closed; the usage invoice has already
     // finalized, so a grant could never be redeemed.
@@ -103,16 +143,9 @@ export async function grantDeployCreditsForInvoice(
     return { granted: false, reason: `already granted (${duplicate.id})` };
   }
 
-  const firstFeeLine = feeLines[0];
-  const firstFeePriceId = firstFeeLine?.pricing?.price_details?.price;
-  const plan =
-    typeof firstFeePriceId === "string"
-      ? planForPlanFeePriceId(config, firstFeePriceId)
-      : undefined;
-
   // The grant name shows up as the credit line on the invoice, so it should
   // explain itself there: "Business plan monthly included usage ($50.00 off)".
-  const planLabel = plan ? plan.charAt(0).toUpperCase() + plan.slice(1) : "Compute";
+  const planLabel = fee.plan ? fee.plan.charAt(0).toUpperCase() + fee.plan.slice(1) : "Compute";
 
   const created = await stripe.billing.creditGrants.create(
     {
@@ -121,17 +154,17 @@ export async function grantDeployCreditsForInvoice(
       category: "promotional",
       amount: {
         type: "monetary",
-        monetary: { currency: invoice.currency, value: amountCents },
+        monetary: { currency: invoice.currency, value: fee.amountCents },
       },
       applicability_config: { scope: { price_type: "metered" } },
       expires_at: expiresAt,
       metadata: {
         stripe_invoice_id: invoice.id,
-        ...(plan ? { deploy_plan: plan } : {}),
+        ...(fee.plan ? { deploy_plan: fee.plan } : {}),
       },
     },
     { idempotencyKey: `deploy-credit-grant:${invoice.id}` },
   );
 
-  return { granted: true, grantId: created.id, amountCents };
+  return { granted: true, grantId: created.id, amountCents: fee.amountCents };
 }

--- a/web/apps/dashboard/lib/trpc/routers/stripe/changeDeployPlan.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/changeDeployPlan.ts
@@ -14,6 +14,16 @@ import { requireWorkspaceAdmin, workspaceProcedure } from "../../trpc";
  * its subscription. Metered items are shared across plans, so they are left
  * untouched. Writes workspaces.deploy_plan optimistically for instant UI;
  * the subscription.updated webhook reconciles it to the same value.
+ *
+ * Upgrades charge the prorated fee difference immediately (always_invoice).
+ * Paying that invoice triggers the credit-grant webhook, which tops up the
+ * period's usage credits by the same net amount, so an upgrade buys more
+ * credits for the rest of the month, not just a bigger fee.
+ *
+ * Downgrades keep the period as bought: no proration at all, so there is no
+ * refund of the fee difference AND no clawback of the usage credits that fee
+ * already granted. The customer rides out the period at the level they paid
+ * for; the lower fee (and its smaller credits) starts at the next renewal.
  */
 export const changeDeployPlan = workspaceProcedure
   .use(requireWorkspaceAdmin)
@@ -58,9 +68,13 @@ export const changeDeployPlan = workspaceProcedure
 
     const newPriceId = config.planFeePriceIds[input.plan];
     try {
+      // DEPLOY_PLANS is ordered lowest to highest, so plan order doubles as
+      // the upgrade/downgrade direction.
+      const isDowngrade = DEPLOY_PLANS.indexOf(input.plan) < DEPLOY_PLANS.indexOf(planFeeItem.plan);
+
       await stripe.subscriptionItems.update(planFeeItem.id, {
         price: newPriceId,
-        proration_behavior: "create_prorations",
+        proration_behavior: isDowngrade ? "none" : "always_invoice",
         payment_behavior: "error_if_incomplete",
       });
     } catch (err) {


### PR DESCRIPTION

pkg/tui covers the non-interactive half of terminal UX for CLI commands:
colors, aligned tables, and key-value blocks. Interactive input (menus,
pickers) stays in pkg/prompt; like it, this sticks to the standard library
plus golang.org/x/term, no heavier TUI dependencies.

Styling degrades gracefully: escape codes are emitted only when the writer is
a TTY, NO_COLOR is unset, and TERM is not "dumb". The same code written to a
pipe or file produces plain aligned text (alignment is computed on visible
width, ANSI codes excluded), so command output stays grep-friendly.

API surface: Renderer (Println/Printf/Blank + Bold/Dim/Red/Green/Yellow/Cyan),
KV blocks (Add/AddIf/Indent), and Table with header underlining and per-column
width alignment.

First consumer is `unkey dev stripe` in the change above this one.