### PR TITLE
feat(billing): grant prorated Deploy credit top-ups on mid-cycle upgrades

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/deploy-product-card.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/deploy-product-card.tsx
@@ -244,16 +244,16 @@ export const DeployProductCard: React.FC<DeployProductCardProps> = ({
         }))}
         currentId={currentPlan}
         // Warn when the period's metered spend already exceeds the credits the
-        // selected plan includes: the downgrade is allowed, but the difference
-        // becomes overage instead of being covered.
+        // selected plan includes. Downgrades keep the current period's credits,
+        // so the overage only starts biting at the next renewal.
         warningFor={(option) =>
           option.amount !== null && usageAmount !== null && usageAmount > option.amount
             ? `Your usage this period (${formatDollars(usageAmount)}) already exceeds the ${formatDollars(
                 option.amount,
-              )} of credits ${option.name} includes; the difference is billed as overage.`
+              )} of monthly credits ${option.name} includes. This period keeps your current credits; from next period, usage at this level is billed as overage.`
             : null
         }
-        changeNote="Takes effect immediately; the fee difference is prorated on your next invoice."
+        changeNote="Takes effect immediately. Upgrades are charged now and add the difference as usage credits; downgrades keep this period's credits, with the new fee starting next period."
         submittingId={
           subscribe.isLoading
             ? subscribe.variables?.plan

--- a/web/apps/dashboard/lib/stripe/deployCredits.test.ts
+++ b/web/apps/dashboard/lib/stripe/deployCredits.test.ts
@@ -1,0 +1,113 @@
+import type Stripe from "stripe";
+import { describe, expect, it } from "vitest";
+import type { DeployBillingConfig } from "./deployBilling";
+import { netDeployFee } from "./deployCredits";
+
+const config: DeployBillingConfig = {
+  planFeePriceIds: {
+    starter: "price_fee_starter",
+    pro: "price_fee_pro",
+    business: "price_fee_business",
+  },
+  meteredPriceIds: ["price_cpu", "price_mem", "price_egress", "price_disk"],
+  allDeployPriceIds: new Set([
+    "price_fee_starter",
+    "price_fee_pro",
+    "price_fee_business",
+    "price_cpu",
+    "price_mem",
+    "price_egress",
+    "price_disk",
+  ]),
+};
+
+// Minimal invoice line stub: netDeployFee reads amount, discount_amounts,
+// period.end, and the price id under pricing.price_details.price.
+function line(
+  priceId: string,
+  amount: number,
+  periodEnd: number,
+  discountCents = 0,
+): Stripe.InvoiceLineItem {
+  return {
+    amount,
+    discount_amounts: discountCents ? [{ amount: discountCents, discount: "di_test" }] : [],
+    period: { end: periodEnd, start: periodEnd - 3600 },
+    pricing: { type: "price_details", price_details: { price: priceId } },
+  } as unknown as Stripe.InvoiceLineItem;
+}
+
+describe("netDeployFee", () => {
+  it("returns the fee of a single plan-fee line (subscribe / renewal)", () => {
+    const fee = netDeployFee(config, [
+      line("price_fee_business", 5000, 1_700_000_000),
+      line("price_cpu", 123, 1_700_000_000),
+    ]);
+    expect(fee).toEqual({ amountCents: 5000, periodEnd: 1_700_000_000, plan: "business" });
+  });
+
+  it("nets a mid-cycle upgrade's proration pair to the top-up", () => {
+    // always_invoice upgrade Starter -> Business: unused Starter credited,
+    // prorated Business charged. The net is exactly the credits to top up.
+    const fee = netDeployFee(config, [
+      line("price_fee_starter", -300, 1_700_000_000),
+      line("price_fee_business", 2800, 1_700_000_000),
+    ]);
+    expect(fee?.amountCents).toBe(2500);
+  });
+
+  it("nets a downgrade negative, which grants nothing upstream", () => {
+    const fee = netDeployFee(config, [
+      line("price_fee_business", -2800, 1_700_000_000),
+      line("price_fee_starter", 300, 1_700_000_000),
+    ]);
+    expect(fee?.amountCents).toBeLessThan(0);
+  });
+
+  it("ignores metered and unrelated lines", () => {
+    expect(
+      netDeployFee(config, [
+        line("price_cpu", 866, 1_700_000_000),
+        line("price_api_plan", 7500, 1_700_000_000),
+      ]),
+    ).toBeNull();
+  });
+
+  it("uses the latest period end across fee lines", () => {
+    const fee = netDeployFee(config, [
+      line("price_fee_starter", -300, 1_700_000_000),
+      line("price_fee_business", 2800, 1_700_500_000),
+    ]);
+    expect(fee?.periodEnd).toBe(1_700_500_000);
+  });
+
+  it("ignores metered lines", () => {
+    expect(netDeployFee(config, [line("price_cpu", 866, 1_700_000_000)])).toBeNull();
+  });
+
+  it("ignores lines without price details (e.g. credit lines)", () => {
+    const creditLine = {
+      amount: -500,
+      period: { end: 1_700_000_000, start: 1_699_996_400 },
+      pricing: null,
+    } as unknown as Stripe.InvoiceLineItem;
+    expect(netDeployFee(config, [creditLine])).toBeNull();
+  });
+
+  it("labels the plan from the charge line regardless of proration order", () => {
+    // Negative (departing) line first: plan must still reflect the new plan,
+    // since that is what the credit name and metadata are read against.
+    const fee = netDeployFee(config, [
+      line("price_fee_starter", -300, 1_700_000_000),
+      line("price_fee_business", 2800, 1_700_000_000),
+    ]);
+    expect(fee?.plan).toBe("business");
+  });
+
+  it("subtracts discount_amounts so a coupon reduces the credit", () => {
+    // $50 fee with a $10 coupon allocated to the line (Stripe distributes
+    // invoice-level coupons this way): the grant tracks the $40 actually paid.
+    const fee = netDeployFee(config, [line("price_fee_business", 5000, 1_700_000_000, 1000)]);
+    expect(fee?.amountCents).toBe(4000);
+  });
+});

--- a/web/apps/dashboard/lib/stripe/deployCredits.ts
+++ b/web/apps/dashboard/lib/stripe/deployCredits.ts
@@ -1,5 +1,10 @@
 import type Stripe from "stripe";
-import { deployBillingConfig, planForPlanFeePriceId } from "./deployBilling";
+import {
+  type DeployBillingConfig,
+  deployBillingConfig,
+  planForPlanFeePriceId,
+} from "./deployBilling";
+import type { DeployPlan } from "./deployPlan";
 
 /**
  * How long credits stay redeemable past the plan-fee period they belong to.
@@ -17,18 +22,66 @@ export type DeployCreditGrantResult =
   | { granted: false; reason: string }
   | { granted: true; grantId: string; amountCents: number };
 
+export type NetDeployFee = {
+  /** Net of the invoice's Deploy plan-fee lines (cents); can be negative. */
+  amountCents: number;
+  /** Latest period end across the fee lines (unix seconds). */
+  periodEnd: number;
+  /** The plan the charged (largest) fee line maps to, when recognizable. */
+  plan?: DeployPlan;
+};
+
+/**
+ * Sums an invoice's Deploy plan-fee lines net of discounts, or returns null
+ * when it has none.
+ *
+ * Summing the lines (rather than reading the catalog price) makes prorations
+ * self-correcting across every flow: a mid-cycle subscribe grants the
+ * prorated amount, a mid-cycle upgrade's always_invoice proration invoice
+ * nets (+new fee, -unused old fee) to exactly the top-up, a downgrade nets
+ * negative (no grant, no clawback), and a renewal grants the full fee.
+ *
+ * line.amount is the gross fee, excluding tax and discounts, so each line's
+ * discount_amounts are subtracted (Stripe distributes invoice-level coupons
+ * into these too) to track the fee actually paid, not the list price.
+ */
+export function netDeployFee(
+  config: DeployBillingConfig,
+  lines: Stripe.InvoiceLineItem[],
+): NetDeployFee | null {
+  const feeLines = lines.filter((line) => {
+    const priceId = line.pricing?.price_details?.price;
+    return typeof priceId === "string" && Boolean(planForPlanFeePriceId(config, priceId));
+  });
+  if (feeLines.length === 0) {
+    return null;
+  }
+
+  // Label from the largest fee line. On an upgrade proration the lines are
+  // +new prorated fee and -unused old fee in Stripe's own order, and the plan
+  // being charged is the positive, larger one; picking feeLines[0] could name
+  // the credit after the departing plan. Subscribe and renewal have a single
+  // fee line, so this is a no-op there.
+  const chargeLine = feeLines.reduce((max, line) => (line.amount > max.amount ? line : max));
+  const chargePriceId = chargeLine.pricing?.price_details?.price;
+
+  return {
+    amountCents: feeLines.reduce((sum, line) => {
+      const discounts = (line.discount_amounts ?? []).reduce((d, da) => d + da.amount, 0);
+      return sum + line.amount - discounts;
+    }, 0),
+    periodEnd: Math.max(...feeLines.map((line) => line.period.end)),
+    plan:
+      typeof chargePriceId === "string" ? planForPlanFeePriceId(config, chargePriceId) : undefined,
+  };
+}
+
 /**
  * Grants the Deploy usage credits a paid invoice entitles the customer to:
- * the net amount of its Deploy plan-fee lines, scoped to metered prices (the
- * only metered prices on a subscription are the Deploy meters; API tiers are
- * licensed), expiring shortly after the period the fee covers.
- *
- * Summing the plan-fee lines (rather than reading the catalog price) makes
- * prorations self-correcting: a mid-cycle subscribe grants the prorated
- * amount, and a renewal invoice carrying up/downgrade prorations grants the
- * net fee actually paid for the period. Each line's discount_amounts are
- * subtracted so coupons (line-level and invoice-level alike) reduce the credit
- * the way they reduce the bill. A net of zero or less grants nothing.
+ * the net amount of its Deploy plan-fee lines ([[netDeployFee]]), scoped to
+ * metered prices (the only metered prices on a subscription are the Deploy
+ * meters; API tiers are licensed), expiring shortly after the period the fee
+ * covers. A net of zero or less grants nothing.
  *
  * Idempotent per invoice twice over: an idempotency key derived from the
  * invoice id covers webhook retries, and a metadata check against existing
@@ -56,28 +109,15 @@ export async function grantDeployCreditsForInvoice(
     });
   }
 
-  const feeLines = invoice.lines.data.filter((line) => {
-    const priceId = line.pricing?.price_details?.price;
-    return typeof priceId === "string" && Boolean(planForPlanFeePriceId(config, priceId));
-  });
-  if (feeLines.length === 0) {
+  const fee = netDeployFee(config, invoice.lines.data);
+  if (!fee) {
     return { granted: false, reason: "no deploy plan-fee lines" };
   }
-
-  // line.amount is the gross fee, excluding tax and discounts. Subtracting the
-  // per-line discount_amounts (Stripe distributes invoice-level coupons into
-  // these too) makes the credit track the fee actually paid, not the list
-  // price; a customer with a coupon would otherwise be granted more than billed.
-  const amountCents = feeLines.reduce((sum, line) => {
-    const discounts = (line.discount_amounts ?? []).reduce((d, da) => d + da.amount, 0);
-    return sum + line.amount - discounts;
-  }, 0);
-  if (amountCents <= 0) {
-    return { granted: false, reason: `non-positive net plan-fee amount (${amountCents})` };
+  if (fee.amountCents <= 0) {
+    return { granted: false, reason: `non-positive net plan-fee amount (${fee.amountCents})` };
   }
 
-  const periodEnd = Math.max(...feeLines.map((line) => line.period.end));
-  const expiresAt = periodEnd + EXPIRY_GRACE_SECONDS;
+  const expiresAt = fee.periodEnd + EXPIRY_GRACE_SECONDS;
   if (expiresAt * 1000 <= Date.now()) {
     // Paid long after the period closed; the usage invoice has already
     // finalized, so a grant could never be redeemed.
@@ -103,16 +143,9 @@ export async function grantDeployCreditsForInvoice(
     return { granted: false, reason: `already granted (${duplicate.id})` };
   }
 
-  const firstFeeLine = feeLines[0];
-  const firstFeePriceId = firstFeeLine?.pricing?.price_details?.price;
-  const plan =
-    typeof firstFeePriceId === "string"
-      ? planForPlanFeePriceId(config, firstFeePriceId)
-      : undefined;
-
   // The grant name shows up as the credit line on the invoice, so it should
   // explain itself there: "Business plan monthly included usage ($50.00 off)".
-  const planLabel = plan ? plan.charAt(0).toUpperCase() + plan.slice(1) : "Compute";
+  const planLabel = fee.plan ? fee.plan.charAt(0).toUpperCase() + fee.plan.slice(1) : "Compute";
 
   const created = await stripe.billing.creditGrants.create(
     {
@@ -121,17 +154,17 @@ export async function grantDeployCreditsForInvoice(
       category: "promotional",
       amount: {
         type: "monetary",
-        monetary: { currency: invoice.currency, value: amountCents },
+        monetary: { currency: invoice.currency, value: fee.amountCents },
       },
       applicability_config: { scope: { price_type: "metered" } },
       expires_at: expiresAt,
       metadata: {
         stripe_invoice_id: invoice.id,
-        ...(plan ? { deploy_plan: plan } : {}),
+        ...(fee.plan ? { deploy_plan: fee.plan } : {}),
       },
     },
     { idempotencyKey: `deploy-credit-grant:${invoice.id}` },
   );
 
-  return { granted: true, grantId: created.id, amountCents };
+  return { granted: true, grantId: created.id, amountCents: fee.amountCents };
 }

--- a/web/apps/dashboard/lib/trpc/routers/stripe/changeDeployPlan.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/changeDeployPlan.ts
@@ -14,6 +14,16 @@ import { requireWorkspaceAdmin, workspaceProcedure } from "../../trpc";
  * its subscription. Metered items are shared across plans, so they are left
  * untouched. Writes workspaces.deploy_plan optimistically for instant UI;
  * the subscription.updated webhook reconciles it to the same value.
+ *
+ * Upgrades charge the prorated fee difference immediately (always_invoice).
+ * Paying that invoice triggers the credit-grant webhook, which tops up the
+ * period's usage credits by the same net amount, so an upgrade buys more
+ * credits for the rest of the month, not just a bigger fee.
+ *
+ * Downgrades keep the period as bought: no proration at all, so there is no
+ * refund of the fee difference AND no clawback of the usage credits that fee
+ * already granted. The customer rides out the period at the level they paid
+ * for; the lower fee (and its smaller credits) starts at the next renewal.
  */
 export const changeDeployPlan = workspaceProcedure
   .use(requireWorkspaceAdmin)
@@ -58,9 +68,13 @@ export const changeDeployPlan = workspaceProcedure
 
     const newPriceId = config.planFeePriceIds[input.plan];
     try {
+      // DEPLOY_PLANS is ordered lowest to highest, so plan order doubles as
+      // the upgrade/downgrade direction.
+      const isDowngrade = DEPLOY_PLANS.indexOf(input.plan) < DEPLOY_PLANS.indexOf(planFeeItem.plan);
+
       await stripe.subscriptionItems.update(planFeeItem.id, {
         price: newPriceId,
-        proration_behavior: "create_prorations",
+        proration_behavior: isDowngrade ? "none" : "always_invoice",
         payment_behavior: "error_if_incomplete",
       });
     } catch (err) {


### PR DESCRIPTION

Upgrades: changeDeployPlan uses always_invoice, so a mid-cycle upgrade
charges the prorated fee difference immediately. Paying that invoice triggers
the existing credit grant webhook, whose net-fee summing turns the proration
pair (+new prorated fee, -unused old fee) into exactly the right top-up,
expiring with the current period. No new grant logic needed.

Downgrades keep the period as bought (proration_behavior none): no refund of
the fee difference AND no clawback of the usage credits that fee already
granted. The customer rides out the period at the level they paid for; the
lower fee and its smaller credits start at the next renewal. Direction is
derived from DEPLOY_PLANS order (lowest to highest).

Supporting changes:

- netDeployFee extracted as a pure function with unit tests covering
  subscribe/renewal, upgrade netting, downgrade netting, unrelated lines,
  multi-line period ends, and both webhook payload shapes.
- Compute plan modal: footnote describes the immediate charge / keep-credits
  semantics, and the downgrade overage warning now says the current period
  keeps its credits.

ENG-2871