### PR TITLE
docs: stop calling it Unkey Deploy

### DIFF
--- a/cmd/deploy/main.go
+++ b/cmd/deploy/main.go
@@ -112,7 +112,7 @@ func executeDeploy(ctx context.Context, opts DeployOptions) error {
 	}
 
 	// Print header
-	fmt.Printf("Unkey Deploy Progress\n")
+	fmt.Printf("Deployment Progress\n")
 	fmt.Printf("──────────────────────────────────────────────────\n")
 	printSourceInfo(opts, gitInfo)
 

--- a/docs/product/build-and-deploy/cli.mdx
+++ b/docs/product/build-and-deploy/cli.mdx
@@ -36,7 +36,7 @@ That single command:
 Example output:
 
 ```text
-Unkey Deploy Progress
+Deployment Progress
 ──────────────────────────────────────────────────
 Source Information:
     Branch: main

--- a/docs/product/builds/dockerfile-prompt.mdx
+++ b/docs/product/builds/dockerfile-prompt.mdx
@@ -1,13 +1,13 @@
 ---
 title: Generate a Dockerfile with AI
-description: "Use this prompt with Claude Code, Cursor, or Windsurf to generate a Dockerfile and .dockerignore tuned for Unkey Deploy's runtime."
+description: "Use this prompt with Claude Code, Cursor, or Windsurf to generate a Dockerfile and .dockerignore tuned for Unkey's runtime."
 ---
 
 import DeployBeta from "/snippets/deploy-beta.mdx";
 
 <DeployBeta />
 
-If you're not comfortable writing a Dockerfile from scratch, hand the prompt below to a coding agent. It tells the agent to first inspect your repository and then produce a Dockerfile plus a `.dockerignore` that respect Unkey Deploy's runtime constraints (reading `PORT`, handling `SIGTERM`, build secrets via mount).
+If you're not comfortable writing a Dockerfile from scratch, hand the prompt below to a coding agent. It tells the agent to first inspect your repository and then produce a Dockerfile plus a `.dockerignore` that respect Unkey's runtime constraints (reading `PORT`, handling `SIGTERM`, build secrets via mount).
 
 ## How to use it
 
@@ -19,7 +19,7 @@ Once the files land in your repo, push to the branch connected to your Unkey pro
 
 ````
 You're helping create a Dockerfile for an application that will be deployed on
-Unkey Deploy (https://unkey.com/docs/build-and-deploy/overview). Before writing
+Unkey (https://unkey.com/docs/build-and-deploy/overview). Before writing
 anything, inspect the repository so the Dockerfile matches how the app is
 actually built and run.
 
@@ -56,7 +56,7 @@ Identify:
   figure out which internal packages it depends on.
 - Any existing Dockerfile or container config to preserve intent from.
 
-## Step 2: Respect Unkey Deploy's runtime constraints
+## Step 2: Respect Unkey's runtime constraints
 
 These are not general Docker guidance. The image will not run correctly without
 them.

--- a/docs/product/observability/overview.mdx
+++ b/docs/product/observability/overview.mdx
@@ -7,7 +7,7 @@ import DeployBeta from "/snippets/deploy-beta.mdx";
 
 <DeployBeta />
 
-Every project in Unkey Deploy includes built-in observability so you can inspect what your app is doing without adding extra tooling.
+Every project on Unkey includes built-in observability so you can inspect what your app is doing without adding extra tooling.
 
 ## What you get
 

--- a/docs/product/platform/apps/overview.mdx
+++ b/docs/product/platform/apps/overview.mdx
@@ -11,7 +11,7 @@ An app represents a single deployable service within a [project](/platform/proje
 
 ## How apps fit in
 
-Apps sit between projects and environments in the Unkey Deploy hierarchy:
+Apps sit between projects and environments in the deployment hierarchy:
 
 ```text
 Workspace

--- a/docs/product/platform/instances/overview.mdx
+++ b/docs/product/platform/instances/overview.mdx
@@ -13,7 +13,7 @@ During deployments and scale-down, Unkey sends the configured [shutdown signal](
 
 ## How instances fit in
 
-Instances sit at the bottom of the Unkey Deploy hierarchy. A [deployment](/build-and-deploy/deployments) produces instances across your configured regions:
+Instances sit at the bottom of the deployment hierarchy. A [deployment](/build-and-deploy/deployments) produces instances across your configured regions:
 
 ```text
 Workspace

--- a/docs/product/platform/projects/overview.mdx
+++ b/docs/product/platform/projects/overview.mdx
@@ -7,7 +7,7 @@ import DeployBeta from "/snippets/deploy-beta.mdx";
 
 <DeployBeta />
 
-A project is the top-level organizational unit in Unkey Deploy. Each project maps to a single codebase (typically a GitHub repository) and groups the [apps](/platform/apps/overview), [environments](/environments/overview), and configuration needed to build, deploy, and run your application.
+A project is the top-level organizational unit for deploying applications on Unkey. Each project maps to a single codebase (typically a GitHub repository) and groups the [apps](/platform/apps/overview), [environments](/environments/overview), and configuration needed to build, deploy, and run your application.
 
 ## Project hierarchy
 

--- a/docs/product/platform/root-keys/permissions.mdx
+++ b/docs/product/platform/root-keys/permissions.mdx
@@ -203,7 +203,7 @@ These permissions control [identities](/platform/identities/overview), which let
 
 ## Deployment permissions
 
-These permissions control Unkey Deploy operations. All deployment permissions use the `project.*` scope.
+These permissions control deployment operations. All deployment permissions use the `project.*` scope.
 
 <ResponseField name="project.*.create_deployment">
   Create new deployments in the workspace. Required for CI/CD pipelines that deploy through the Unkey API.

--- a/docs/product/snippets/deploy-beta.mdx
+++ b/docs/product/snippets/deploy-beta.mdx
@@ -1,5 +1,5 @@
 <Info>
-  Unkey Deploy is in public beta. To try it, open the product switcher in the
+  Deploying applications on Unkey is in public beta. To try it, open the product switcher in the
   top-left of the dashboard and select **Deploy**. During beta, deployed
   resources are free. We're eager for feedback, so let us know what you think
   on [Discord](https://unkey.com/discord), [X](https://x.com/unkeydev), or


### PR DESCRIPTION
Deploy is not a separate product: Unkey is deploy and deploy is unkey, the same way you wouldn't say "Vercel Deploy".

Rewords all living docs that used "Unkey Deploy" as a product name (hierarchy pages, permissions, observability, beta snippet, Dockerfile AI prompt), plus the CLI's `Unkey Deploy Progress` header and its doc example, which now read `Deployment Progress`.

Dated changelog entries are left untouched as historical records.

Split out of #6423 to keep that PR focused.