### PR TITLE
feat(pkg): webhook receiver framework

### DIFF
--- a/pkg/webhook/BUILD.bazel
+++ b/pkg/webhook/BUILD.bazel
@@ -1,0 +1,26 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "webhook",
+    srcs = [
+        "doc.go",
+        "interface.go",
+        "metrics.go",
+        "receiver.go",
+        "typed.go",
+    ],
+    importpath = "github.com/unkeyed/unkey/pkg/webhook",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/logger",
+        "//pkg/prometheus/lazy",
+        "@com_github_prometheus_client_golang//prometheus",
+    ],
+)
+
+go_test(
+    name = "webhook_test",
+    srcs = ["webhook_test.go"],
+    embed = [":webhook"],
+    deps = ["@com_github_stretchr_testify//require"],
+)

--- a/pkg/webhook/doc.go
+++ b/pkg/webhook/doc.go
@@ -1,0 +1,47 @@
+// Package webhook receives provider webhooks over HTTP.
+//
+// Every inbound webhook integration repeats the same transport chores:
+// method and body-size policing, signature verification, routing by event
+// type, deciding which failures the provider should retry, and counting all
+// of it so nobody flies blind. This package owns those chores once, so an
+// integration only writes event handlers:
+//
+//	receiver := webhook.New("stripe", stripeverifier.New(secret)). // pkg/webhook/verifiers/stripe
+//		On([]string{"invoice.created"}, handleInvoiceCreated).
+//		On([]string{"invoice.payment_failed"}, handlePaymentFailed)
+//	mux.Handle("POST /webhooks/stripe", receiver)
+//
+// [Receiver.On] takes the event types first so one handler can serve several:
+// On([]string{"create", "delete"}, handleBranchLifecycle). Handlers that parse
+// the payload wrap themselves in [Typed] to receive it already unmarshalled:
+// On([]string{"invoice.created"}, webhook.Typed(handleInvoiceCreated)).
+//
+// Handler semantics drive the HTTP response and the metrics outcome:
+//
+//   - return nil: handled, 200. The provider considers the event delivered.
+//   - return an error wrapping [ErrIgnore]: ignored, 200. The handler looked
+//     at the event and deliberately declined it (wrong subtype, not our
+//     tenant). Acknowledged so the provider does not retry, but counted
+//     separately from handled.
+//   - return an error wrapping [ErrBadRequest]: bad_request, 400. The verified
+//     request is malformed (e.g. an unparseable payload), so the same bytes
+//     will fail every retry; the provider should not keep retrying.
+//   - return any other error: error, 500. The provider retries, so handlers
+//     must be idempotent.
+//
+// Events without a registered handler are acknowledged with 200 and counted
+// as unhandled; providers treat non-2xx as "retry forever", so refusing
+// uninteresting event types would only create noise on both sides. Register
+// a [Receiver.Default] handler to take over that fallback path instead.
+//
+// # Durability
+//
+// The receiver is plain HTTP on purpose; it does not wrap handlers in
+// Restate. Handlers should do their cheap synchronous filtering inline
+// (parse the payload, decide relevance) and then dispatch the actual work
+// into a Restate handler via the ingress client, ideally with an idempotency
+// key — see ctrl-api's Stripe and GitHub webhooks for the pattern. Forcing
+// every event through Restate at the transport layer would journal ignored
+// events and drag virtual-object key derivation into code that cannot know
+// it.
+package webhook

--- a/pkg/webhook/interface.go
+++ b/pkg/webhook/interface.go
@@ -1,0 +1,55 @@
+package webhook
+
+import (
+	"context"
+	"errors"
+	"net/http"
+)
+
+// ErrIgnore marks an event a handler examined and deliberately declined.
+// Wrap it to carry the reason into logs:
+//
+//	return fmt.Errorf("%w: not a deploy workspace", webhook.ErrIgnore)
+var ErrIgnore = errors.New("webhook event ignored")
+
+// ErrBadRequest marks an event the handler cannot process because the request
+// itself is malformed (e.g. a payload that does not parse). It maps to HTTP
+// 400, not 500: the request was signature-verified, so retrying the same bytes
+// will fail identically, and a 5xx would tell the provider to keep retrying a
+// poison payload. Wrap it to carry the reason into logs:
+//
+//	return fmt.Errorf("%w: parse payload: %v", webhook.ErrBadRequest, err)
+var ErrBadRequest = errors.New("webhook bad request")
+
+// Event is a verified provider event: identity, type, and the raw payload
+// for the handler to parse into its provider-specific shape.
+type Event struct {
+	// ID is the provider-assigned event id, for logs and idempotency.
+	ID string
+	// Type routes the event, e.g. "invoice.created".
+	Type string
+	// Payload is the raw event object (for Stripe, event.data.object).
+	Payload []byte
+}
+
+// Verifier authenticates a request and extracts its event. Implementations
+// are provider-specific (signature schemes differ); the returned error is
+// never exposed to the caller, only logged.
+//
+// The implementation reads the request body itself (r.Body), which the
+// Receiver has already bounded with http.MaxBytesReader. Owning the single
+// read keeps the raw bytes in one place: the verifier needs them for the
+// signature, and the resulting [Event.Payload] is the same bytes (or a slice
+// of them), never a second copy.
+type Verifier interface {
+	Verify(r *http.Request) (Event, error)
+}
+
+// HandlerFunc processes one verified event. See the package documentation
+// for how the returned error maps to HTTP responses and retries.
+type HandlerFunc func(ctx context.Context, event Event) error
+
+// Middleware wraps every registered handler, outermost first. Use it for
+// integration-specific concerns the transport cannot know about: custom
+// metrics, tracing attributes, payload archival.
+type Middleware func(next HandlerFunc) HandlerFunc

--- a/pkg/webhook/metrics.go
+++ b/pkg/webhook/metrics.go
@@ -1,0 +1,51 @@
+package webhook
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/unkeyed/unkey/pkg/prometheus/lazy"
+)
+
+// The transport metrics live here, next to the code that emits them, because
+// they are generic to every webhook integration: a silent provider, a
+// signature mismatch after a secret rotation, or a handler that started
+// erroring all show up the same way regardless of provider. Integration-
+// specific metrics belong next to the integration's handlers, layered in via
+// [Receiver.Use] middleware.
+var (
+	// eventsTotal counts inbound webhook events by outcome.
+	//
+	// Labels:
+	//   - "provider": the webhook source, e.g. "stripe"
+	//   - "event": the provider's event type, e.g. "invoice.created".
+	//     Bounded by the provider's event catalog.
+	//   - "outcome": one of
+	//     "handled" (a handler ran and succeeded),
+	//     "ignored" (a handler looked and declined via ErrIgnore),
+	//     "unhandled" (no handler registered for the event type),
+	//     "error" (a handler failed; the provider will retry),
+	//     "verification_failed" (signature rejected),
+	//     "too_large" (body exceeded the size limit),
+	//     "bad_request" (a handler rejected the payload via ErrBadRequest).
+	eventsTotal = lazy.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "unkey",
+		Subsystem: "webhook",
+		Name:      "events_total",
+		Help:      "Inbound webhook events by provider, event type and outcome.",
+	}, []string{"provider", "event", "outcome"})
+
+	// handlerDuration measures how long webhook event handlers run.
+	// Providers retry on slow responses (Stripe times out around 20s), so a
+	// drifting p99 here is an early warning before events start double
+	// delivering.
+	//
+	// Labels:
+	//   - "provider": the webhook source, e.g. "stripe"
+	//   - "event": the provider's event type
+	handlerDuration = lazy.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "unkey",
+		Subsystem: "webhook",
+		Name:      "handler_duration_seconds",
+		Help:      "Duration of webhook event handlers.",
+		Buckets:   prometheus.DefBuckets,
+	}, []string{"provider", "event"})
+)

--- a/pkg/webhook/receiver.go
+++ b/pkg/webhook/receiver.go
@@ -1,0 +1,177 @@
+package webhook
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/unkeyed/unkey/pkg/logger"
+)
+
+// defaultMaxBodySize bounds webhook payloads when the caller doesn't override
+// it. Providers send events, not uploads; 2 MB is far above any real event
+// while still bounding memory per request. Providers with larger caps (GitHub
+// allows up to 25 MB) can raise it with [WithMaxBodySize].
+const defaultMaxBodySize int64 = 2 * 1024 * 1024
+
+// Receiver is an http.Handler that verifies and routes provider webhooks.
+//
+// Register handlers and middleware (On, Default, Use) during setup, before the
+// Receiver is served. Once ServeHTTP has been called it is read-only and safe
+// for concurrent requests; registering on a live Receiver races, like writing
+// to an http.ServeMux after it starts serving.
+type Receiver struct {
+	provider    string
+	verifier    Verifier
+	handlers    map[string]HandlerFunc
+	fallback    HandlerFunc
+	middlewares []Middleware
+	maxBodySize int64
+}
+
+var _ http.Handler = (*Receiver)(nil)
+
+// Option configures a Receiver at construction.
+type Option func(*Receiver)
+
+// WithMaxBodySize overrides the maximum accepted request body, in bytes. The
+// default is 2 MB; providers with larger payloads (GitHub caps at 25 MB) can
+// raise it to match their limit.
+func WithMaxBodySize(n int64) Option {
+	return func(rec *Receiver) { rec.maxBodySize = n }
+}
+
+// New builds a Receiver for one provider endpoint. The provider name labels
+// metrics and logs.
+func New(provider string, verifier Verifier, opts ...Option) *Receiver {
+	rec := &Receiver{
+		provider:    provider,
+		verifier:    verifier,
+		handlers:    map[string]HandlerFunc{},
+		fallback:    nil,
+		middlewares: nil,
+		maxBodySize: defaultMaxBodySize,
+	}
+	for _, opt := range opts {
+		opt(rec)
+	}
+	return rec
+}
+
+// On registers the handler for the given event types, replacing any previous
+// registration. Reads as "on these events, run this handler". Returns the
+// Receiver for chaining.
+func (rec *Receiver) On(eventTypes []string, fn HandlerFunc) *Receiver {
+	if len(eventTypes) == 0 {
+		panic("webhook: On requires at least one event type")
+	}
+	for _, eventType := range eventTypes {
+		rec.handlers[eventType] = fn
+	}
+	return rec
+}
+
+// Default registers the fallback handler for event types with no [On]
+// registration. Without one, unknown events are acknowledged with 200 and
+// counted as unhandled; with one, the handler decides the outcome like any
+// other (return [ErrIgnore] to keep the 200-and-count-separately behavior
+// with a logged reason). Returns the Receiver for chaining.
+func (rec *Receiver) Default(fn HandlerFunc) *Receiver {
+	rec.fallback = fn
+	return rec
+}
+
+// Use appends middlewares that wrap every handler, applied outermost first
+// (the first Use wraps closest to the transport). Returns the Receiver for
+// chaining.
+func (rec *Receiver) Use(mw ...Middleware) *Receiver {
+	rec.middlewares = append(rec.middlewares, mw...)
+	return rec
+}
+
+func (rec *Receiver) count(event, outcome string) {
+	eventsTotal.WithLabelValues(rec.provider, event, outcome).Inc()
+}
+
+func (rec *Receiver) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Bound the body before the verifier reads it; providers send events, not
+	// uploads. The verifier owns the single read, so the raw bytes live in one
+	// place rather than being read here and handed down too.
+	r.Body = http.MaxBytesReader(w, r.Body, rec.maxBodySize)
+
+	event, err := rec.verifier.Verify(r)
+	if err != nil {
+		var tooLarge *http.MaxBytesError
+		if errors.As(err, &tooLarge) {
+			rec.count("none", "too_large")
+			logger.Warn("webhook rejected: body too large", "provider", rec.provider)
+			http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+			return
+		}
+		rec.count("none", "verification_failed")
+		logger.Warn("webhook rejected: verification failed", "provider", rec.provider, "error", err)
+		http.Error(w, "verification failed", http.StatusUnauthorized)
+		return
+	}
+
+	handler, ok := rec.handlers[event.Type]
+	if !ok {
+		if rec.fallback == nil {
+			rec.count(event.Type, "unhandled")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		handler = rec.fallback
+	}
+
+	for i := len(rec.middlewares) - 1; i >= 0; i-- {
+		handler = rec.middlewares[i](handler)
+	}
+
+	start := time.Now()
+	err = handler(r.Context(), event)
+	handlerDuration.WithLabelValues(rec.provider, event.Type).
+		Observe(time.Since(start).Seconds())
+
+	switch {
+	case err == nil:
+		rec.count(event.Type, "handled")
+		w.WriteHeader(http.StatusOK)
+	case errors.Is(err, ErrIgnore):
+		rec.count(event.Type, "ignored")
+		logger.Info("webhook event ignored",
+			"provider", rec.provider,
+			"event", event.Type,
+			"event_id", event.ID,
+			"reason", err.Error(),
+		)
+		w.WriteHeader(http.StatusOK)
+	case errors.Is(err, ErrBadRequest):
+		rec.count(event.Type, "bad_request")
+		logger.Warn("webhook bad request",
+			"provider", rec.provider,
+			"event", event.Type,
+			"event_id", event.ID,
+			"error", err,
+		)
+		// 4xx: the verified request is malformed, so retrying the same bytes
+		// would fail identically. The provider should not keep retrying.
+		http.Error(w, fmt.Sprintf("handling %s failed: bad request", event.Type), http.StatusBadRequest)
+	default:
+		rec.count(event.Type, "error")
+		logger.Error("webhook handler failed",
+			"provider", rec.provider,
+			"event", event.Type,
+			"event_id", event.ID,
+			"error", err,
+		)
+		// 5xx so the provider retries; handlers are required to be idempotent.
+		http.Error(w, fmt.Sprintf("handling %s failed", event.Type), http.StatusInternalServerError)
+	}
+}

--- a/pkg/webhook/typed.go
+++ b/pkg/webhook/typed.go
@@ -1,0 +1,30 @@
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// Typed adapts a handler that takes a parsed payload into a [HandlerFunc],
+// removing the per-handler unmarshal boilerplate:
+//
+//	receiver.On(webhook.Typed(s.handlePush), "push")
+//
+//	func (s *service) handlePush(ctx context.Context, event webhook.Event, payload pushPayload) error
+//
+// The event's raw payload is unmarshalled into T before the handler runs. A
+// payload that does not parse maps to HTTP 400, outcome "bad_request" (via
+// [ErrBadRequest]): the request was signature-verified, so the same bytes will
+// fail to parse on every retry, and a 5xx would have the provider hammer a
+// poison payload. T should parse minimally, reading only the fields the
+// handler needs.
+func Typed[T any](fn func(ctx context.Context, event Event, payload T) error) HandlerFunc {
+	return func(ctx context.Context, event Event) error {
+		var payload T
+		if err := json.Unmarshal(event.Payload, &payload); err != nil {
+			return fmt.Errorf("%w: parse %s payload: %v", ErrBadRequest, event.Type, err)
+		}
+		return fn(ctx, event, payload)
+	}
+}

--- a/pkg/webhook/verifiers/github/BUILD.bazel
+++ b/pkg/webhook/verifiers/github/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "github",
+    srcs = ["github.go"],
+    importpath = "github.com/unkeyed/unkey/pkg/webhook/verifiers/github",
+    visibility = ["//visibility:public"],
+    deps = ["//pkg/webhook"],
+)
+
+go_test(
+    name = "github_test",
+    srcs = ["github_test.go"],
+    embed = [":github"],
+    deps = ["@com_github_stretchr_testify//require"],
+)

--- a/pkg/webhook/verifiers/github/github.go
+++ b/pkg/webhook/verifiers/github/github.go
@@ -1,0 +1,72 @@
+// Package github verifies GitHub App webhook signatures for
+// pkg/webhook receivers.
+package github
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/unkeyed/unkey/pkg/webhook"
+)
+
+// Verifier checks the X-Hub-Signature-256 header (HMAC-SHA256 over the raw
+// body) against the webhook secret. Unlike Stripe, GitHub carries the event
+// type and id in headers rather than the payload: X-GitHub-Event routes the
+// event and X-GitHub-Delivery identifies it, so the payload is handed to
+// handlers verbatim.
+type Verifier struct {
+	secret string
+}
+
+var _ webhook.Verifier = (*Verifier)(nil)
+
+// New builds a Verifier from the GitHub App's webhook secret.
+func New(secret string) *Verifier {
+	return &Verifier{secret: secret}
+}
+
+func (v *Verifier) Verify(r *http.Request) (webhook.Event, error) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return webhook.Event{}, err
+	}
+
+	signature := r.Header.Get("X-Hub-Signature-256")
+	hexDigest, ok := strings.CutPrefix(signature, "sha256=")
+	if !ok {
+		return webhook.Event{}, errors.New("missing or malformed X-Hub-Signature-256 header")
+	}
+	got, err := hex.DecodeString(hexDigest)
+	if err != nil {
+		return webhook.Event{}, errors.New("malformed X-Hub-Signature-256 hex digest")
+	}
+
+	mac := hmac.New(sha256.New, []byte(v.secret))
+	mac.Write(body)
+	if !hmac.Equal(got, mac.Sum(nil)) {
+		return webhook.Event{}, errors.New("signature mismatch")
+	}
+
+	eventType := r.Header.Get("X-GitHub-Event")
+	if eventType == "" {
+		return webhook.Event{}, errors.New("missing X-GitHub-Event header")
+	}
+
+	// X-GitHub-Delivery is Event.ID, the idempotency key for downstream
+	// dispatch. Reject an empty one rather than silently disabling dedup.
+	deliveryID := r.Header.Get("X-GitHub-Delivery")
+	if deliveryID == "" {
+		return webhook.Event{}, errors.New("missing X-GitHub-Delivery header")
+	}
+
+	return webhook.Event{
+		ID:      deliveryID,
+		Type:    eventType,
+		Payload: body,
+	}, nil
+}

--- a/pkg/webhook/verifiers/github/github_test.go
+++ b/pkg/webhook/verifiers/github/github_test.go
@@ -1,0 +1,81 @@
+package github
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// sign produces an X-Hub-Signature-256 header for body: sha256=<hmac-sha256
+// of the raw body>, the scheme GitHub documents for webhook deliveries.
+func sign(secret, body string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(body))
+	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+func TestVerifier(t *testing.T) {
+	const secret = "gh_test_secret"
+	body := `{"ref":"refs/heads/main","after":"abc123"}`
+
+	request := func(mutate func(*http.Request)) *http.Request {
+		r := httptest.NewRequest(http.MethodPost, "/webhooks/github", strings.NewReader(body))
+		r.Header.Set("X-Hub-Signature-256", sign(secret, body))
+		r.Header.Set("X-GitHub-Event", "push")
+		r.Header.Set("X-GitHub-Delivery", "delivery-123")
+		if mutate != nil {
+			mutate(r)
+		}
+		return r
+	}
+
+	t.Run("valid signature yields event from headers", func(t *testing.T) {
+		event, err := New(secret).Verify(request(nil))
+		require.NoError(t, err)
+		require.Equal(t, "delivery-123", event.ID)
+		require.Equal(t, "push", event.Type)
+		require.Equal(t, body, string(event.Payload))
+	})
+
+	t.Run("wrong secret is rejected", func(t *testing.T) {
+		_, err := New("other_secret").Verify(request(nil))
+		require.Error(t, err)
+	})
+
+	t.Run("missing signature header is rejected", func(t *testing.T) {
+		_, err := New(secret).Verify(request(func(r *http.Request) {
+			r.Header.Del("X-Hub-Signature-256")
+		}))
+		require.Error(t, err)
+	})
+
+	t.Run("tampered body is rejected", func(t *testing.T) {
+		// Body differs from what the signature was computed over.
+		r := request(func(r *http.Request) {
+			r.Body = io.NopCloser(strings.NewReader(`{"ref":"refs/heads/evil"}`))
+		})
+		_, err := New(secret).Verify(r)
+		require.Error(t, err)
+	})
+
+	t.Run("missing event header is rejected", func(t *testing.T) {
+		_, err := New(secret).Verify(request(func(r *http.Request) {
+			r.Header.Del("X-GitHub-Event")
+		}))
+		require.Error(t, err)
+	})
+
+	t.Run("missing delivery header is rejected", func(t *testing.T) {
+		_, err := New(secret).Verify(request(func(r *http.Request) {
+			r.Header.Del("X-GitHub-Delivery")
+		}))
+		require.Error(t, err)
+	})
+}

--- a/pkg/webhook/verifiers/stripe/BUILD.bazel
+++ b/pkg/webhook/verifiers/stripe/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "stripe",
+    srcs = ["stripe.go"],
+    importpath = "github.com/unkeyed/unkey/pkg/webhook/verifiers/stripe",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/webhook",
+        "@com_github_stripe_stripe_go_v86//webhook",
+    ],
+)
+
+go_test(
+    name = "stripe_test",
+    srcs = ["stripe_test.go"],
+    embed = [":stripe"],
+    deps = ["@com_github_stretchr_testify//require"],
+)

--- a/pkg/webhook/verifiers/stripe/stripe.go
+++ b/pkg/webhook/verifiers/stripe/stripe.go
@@ -1,0 +1,54 @@
+// Package stripe verifies Stripe webhook signatures for
+// pkg/webhook receivers.
+package stripe
+
+import (
+	"io"
+	"net/http"
+
+	stripewebhook "github.com/stripe/stripe-go/v86/webhook"
+	"github.com/unkeyed/unkey/pkg/webhook"
+)
+
+// Verifier checks the Stripe-Signature header against the endpoint's signing
+// secret and unwraps the event. The payload handed to handlers is the event's
+// data.object (e.g. the invoice itself), not the event envelope.
+type Verifier struct {
+	secret string
+}
+
+var _ webhook.Verifier = (*Verifier)(nil)
+
+// New builds a Verifier from the endpoint's signing secret (whsec_...).
+func New(secret string) *Verifier {
+	return &Verifier{secret: secret}
+}
+
+func (v *Verifier) Verify(r *http.Request) (webhook.Event, error) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return webhook.Event{}, err
+	}
+
+	// IgnoreAPIVersionMismatch: stripe-go otherwise rejects events whose
+	// api_version differs from the SDK's pin, turning an endpoint-version
+	// drift into a total webhook outage. Verification stays strict on the
+	// signature; handlers are expected to parse the raw payload minimally,
+	// reading only fields that are stable across Stripe API versions.
+	//nolint:exhaustruct // defaults are correct for everything else
+	event, err := stripewebhook.ConstructEventWithOptions(
+		body,
+		r.Header.Get("Stripe-Signature"),
+		v.secret,
+		stripewebhook.ConstructEventOptions{IgnoreAPIVersionMismatch: true},
+	)
+	if err != nil {
+		return webhook.Event{}, err
+	}
+
+	return webhook.Event{
+		ID:      event.ID,
+		Type:    string(event.Type),
+		Payload: event.Data.Raw,
+	}, nil
+}

--- a/pkg/webhook/verifiers/stripe/stripe_test.go
+++ b/pkg/webhook/verifiers/stripe/stripe_test.go
@@ -1,0 +1,55 @@
+package stripe
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// sign produces a Stripe-Signature header for body: t=<ts>,v1=<hmac-sha256
+// of "<ts>.<body>">, the scheme ConstructEvent validates.
+func sign(secret, body string, ts time.Time) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(fmt.Appendf(nil, "%d.%s", ts.Unix(), body))
+	return fmt.Sprintf("t=%d,v1=%s", ts.Unix(), hex.EncodeToString(mac.Sum(nil)))
+}
+
+func TestVerifier(t *testing.T) {
+	const secret = "whsec_test"
+	// "object":"event" matters: stripe-go v21+ rejects payloads without it as
+	// thin event notifications, which need a different parser.
+	body := `{"id":"evt_123","object":"event","type":"invoice.created","data":{"object":{"id":"in_123"}}}`
+
+	request := func(signature string) *http.Request {
+		r := httptest.NewRequest(http.MethodPost, "/webhooks/stripe", strings.NewReader(body))
+		r.Header.Set("Stripe-Signature", signature)
+		return r
+	}
+
+	t.Run("valid signature yields the unwrapped event", func(t *testing.T) {
+		event, err := New(secret).Verify(request(sign(secret, body, time.Now())))
+		require.NoError(t, err)
+		require.Equal(t, "evt_123", event.ID)
+		require.Equal(t, "invoice.created", event.Type)
+		require.JSONEq(t, `{"id":"in_123"}`, string(event.Payload))
+	})
+
+	t.Run("wrong secret is rejected", func(t *testing.T) {
+		_, err := New(secret).Verify(request(sign("whsec_other", body, time.Now())))
+		require.Error(t, err)
+	})
+
+	t.Run("stale timestamp is rejected", func(t *testing.T) {
+		_, err := New(secret).Verify(
+			request(sign(secret, body, time.Now().Add(-time.Hour))))
+		require.Error(t, err)
+	})
+}

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -1,0 +1,227 @@
+package webhook
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// staticVerifier returns a fixed event, or an error when the body says so. It
+// reads the body from the request like a real verifier does.
+type staticVerifier struct {
+	event Event
+}
+
+func (v staticVerifier) Verify(r *http.Request) (Event, error) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return Event{}, err
+	}
+	if string(body) == "tampered" {
+		return Event{}, errors.New("bad signature")
+	}
+	return v.event, nil
+}
+
+func post(t *testing.T, rec *Receiver, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	w := httptest.NewRecorder()
+	rec.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/webhooks/test", strings.NewReader(body)))
+	return w
+}
+
+func TestReceiver(t *testing.T) {
+	newReceiver := func(eventType string) *Receiver {
+		return New("test", staticVerifier{event: Event{ID: "evt_1", Type: eventType, Payload: []byte(`{}`)}})
+	}
+
+	t.Run("handled event returns 200", func(t *testing.T) {
+		called := false
+		rec := newReceiver("thing.created").On([]string{"thing.created"}, func(ctx context.Context, e Event) error {
+			called = true
+			require.Equal(t, "evt_1", e.ID)
+			return nil
+		})
+		require.Equal(t, http.StatusOK, post(t, rec, "{}").Code)
+		require.True(t, called)
+	})
+
+	t.Run("ignored event returns 200", func(t *testing.T) {
+		rec := newReceiver("thing.created").On([]string{"thing.created"}, func(ctx context.Context, e Event) error {
+			return fmt.Errorf("%w: not ours", ErrIgnore)
+		})
+		require.Equal(t, http.StatusOK, post(t, rec, "{}").Code)
+	})
+
+	t.Run("handler error returns 500 so the provider retries", func(t *testing.T) {
+		rec := newReceiver("thing.created").On([]string{"thing.created"}, func(ctx context.Context, e Event) error {
+			return errors.New("downstream broke")
+		})
+		require.Equal(t, http.StatusInternalServerError, post(t, rec, "{}").Code)
+	})
+
+	t.Run("bad request returns 400 without retry", func(t *testing.T) {
+		rec := newReceiver("thing.created").On([]string{"thing.created"}, func(ctx context.Context, e Event) error {
+			return fmt.Errorf("%w: malformed", ErrBadRequest)
+		})
+		require.Equal(t, http.StatusBadRequest, post(t, rec, "{}").Code)
+	})
+
+	t.Run("unregistered event type is acknowledged", func(t *testing.T) {
+		rec := newReceiver("thing.deleted").On([]string{"thing.created"}, func(ctx context.Context, e Event) error {
+			t.Fatal("handler must not run for other event types")
+			return nil
+		})
+		require.Equal(t, http.StatusOK, post(t, rec, "{}").Code)
+	})
+
+	t.Run("verification failure returns 401", func(t *testing.T) {
+		rec := newReceiver("thing.created").On([]string{"thing.created"}, func(ctx context.Context, e Event) error {
+			t.Fatal("handler must not run for unverified requests")
+			return nil
+		})
+		require.Equal(t, http.StatusUnauthorized, post(t, rec, "tampered").Code)
+	})
+
+	t.Run("one handler serves several event types", func(t *testing.T) {
+		for _, eventType := range []string{"branch.created", "branch.deleted"} {
+			called := false
+			rec := newReceiver(eventType).On([]string{"branch.created", "branch.deleted"}, func(ctx context.Context, e Event) error {
+				called = true
+				return nil
+			})
+			require.Equal(t, http.StatusOK, post(t, rec, "{}").Code)
+			require.True(t, called, eventType)
+		}
+	})
+
+	t.Run("On without event types panics", func(t *testing.T) {
+		require.Panics(t, func() {
+			newReceiver("thing.created").On(nil, func(ctx context.Context, e Event) error { return nil })
+		})
+	})
+
+	t.Run("default handler takes the fallback path", func(t *testing.T) {
+		var got string
+		rec := newReceiver("thing.deleted").
+			On([]string{"thing.created"}, func(ctx context.Context, e Event) error {
+				t.Fatal("registered handler must not run for other event types")
+				return nil
+			}).
+			Default(func(ctx context.Context, e Event) error {
+				got = e.Type
+				return nil
+			})
+		require.Equal(t, http.StatusOK, post(t, rec, "{}").Code)
+		require.Equal(t, "thing.deleted", got)
+	})
+
+	t.Run("default handler error returns 500", func(t *testing.T) {
+		rec := newReceiver("thing.deleted").Default(func(ctx context.Context, e Event) error {
+			return errors.New("downstream broke")
+		})
+		require.Equal(t, http.StatusInternalServerError, post(t, rec, "{}").Code)
+	})
+
+	t.Run("default handler can ignore via ErrIgnore", func(t *testing.T) {
+		rec := newReceiver("thing.deleted").Default(func(ctx context.Context, e Event) error {
+			return fmt.Errorf("%w: not ours", ErrIgnore)
+		})
+		require.Equal(t, http.StatusOK, post(t, rec, "{}").Code)
+	})
+
+	t.Run("middleware runs outermost-first in Use order", func(t *testing.T) {
+		var order []string
+		mw := func(name string) Middleware {
+			return func(next HandlerFunc) HandlerFunc {
+				return func(ctx context.Context, e Event) error {
+					order = append(order, name)
+					return next(ctx, e)
+				}
+			}
+		}
+		rec := newReceiver("thing.created").
+			Use(mw("first"), mw("second")).
+			On([]string{"thing.created"}, func(ctx context.Context, e Event) error {
+				order = append(order, "handler")
+				return nil
+			})
+		require.Equal(t, http.StatusOK, post(t, rec, "{}").Code)
+		// The first Use wraps outermost, so it runs before the second.
+		require.Equal(t, []string{"first", "second", "handler"}, order)
+	})
+
+	t.Run("non-POST is rejected", func(t *testing.T) {
+		rec := newReceiver("thing.created")
+		w := httptest.NewRecorder()
+		rec.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/webhooks/test", nil))
+		require.Equal(t, http.StatusMethodNotAllowed, w.Code)
+	})
+
+	t.Run("body over the size limit returns 413", func(t *testing.T) {
+		rec := New("test",
+			staticVerifier{event: Event{ID: "evt_1", Type: "thing.created", Payload: []byte(`{}`)}},
+			WithMaxBodySize(8),
+		).On([]string{"thing.created"}, func(ctx context.Context, e Event) error {
+			t.Fatal("handler must not run for oversized bodies")
+			return nil
+		})
+		require.Equal(t, http.StatusRequestEntityTooLarge, post(t, rec, strings.Repeat("a", 64)).Code)
+	})
+
+	t.Run("WithMaxBodySize raises the limit", func(t *testing.T) {
+		called := false
+		rec := New("test",
+			staticVerifier{event: Event{ID: "evt_1", Type: "thing.created", Payload: []byte(`{}`)}},
+			WithMaxBodySize(128),
+		).On([]string{"thing.created"}, func(ctx context.Context, e Event) error {
+			called = true
+			return nil
+		})
+		require.Equal(t, http.StatusOK, post(t, rec, strings.Repeat("a", 64)).Code)
+		require.True(t, called)
+	})
+}
+
+func TestTyped(t *testing.T) {
+	newReceiver := func(payload string) *Receiver {
+		return New("test", staticVerifier{
+			event: Event{ID: "evt_1", Type: "thing.created", Payload: []byte(payload)},
+		})
+	}
+
+	type thing struct {
+		Name string `json:"name"`
+	}
+
+	t.Run("handler receives the parsed payload", func(t *testing.T) {
+		var got thing
+		rec := newReceiver(`{"name":"box"}`).On(
+			[]string{"thing.created"},
+			Typed(func(ctx context.Context, e Event, payload thing) error {
+				got = payload
+				return nil
+			}),
+		)
+		require.Equal(t, http.StatusOK, post(t, rec, "{}").Code)
+		require.Equal(t, "box", got.Name)
+	})
+
+	t.Run("malformed payload is a 400 bad request", func(t *testing.T) {
+		rec := newReceiver(`not json`).On(
+			[]string{"thing.created"},
+			Typed(func(ctx context.Context, e Event, payload thing) error {
+				t.Fatal("handler must not run for unparseable payloads")
+				return nil
+			}),
+		)
+		require.Equal(t, http.StatusBadRequest, post(t, rec, "{}").Code)
+	})
+}


### PR DESCRIPTION
pkg/webhook owns the transport chores every inbound webhook integration
repeats: method and body-size policing, signature verification via pluggable
verifiers, event-type routing, middleware for integration-specific concerns,
and transport metrics so no webhook integration flies blind.

- Handler semantics map to HTTP and metrics explicitly: nil = handled (200),
  ErrIgnore = ignored (200, counted separately), error = 500 and the
  provider retries, so handlers must be idempotent. Unregistered event types
  are acked and counted as unhandled, unless a Receiver.Default fallback
  handler is registered to take over that path (log a reason, archive the
  payload, ...).
- Receiver.On takes the handler first and event types variadic, so one
  handler can serve several types: On(handleBranchLifecycle, "create",
  "delete").
- unkey_webhook_events_total{provider,event,outcome} and
  unkey_webhook_handler_duration_seconds, defined in the package next to the
  code that emits them. Integration-specific metrics layer in via
  Receiver.Use middleware, next to the integration.
- Verifiers live under pkg/webhook/verifiers/ (stripe and github). The
  Stripe verifier keeps signature checking strict but ignores api_version
  mismatches: handlers parse raw payloads minimally, and hard-failing on
  version drift would turn an endpoint-version change into a total webhook
  outage. The GitHub verifier shows why Verify receives the full request:
  GitHub carries the event type and delivery id in headers
  (X-GitHub-Event, X-GitHub-Delivery) rather than the payload, and signs
  the raw body with HMAC-SHA256 (X-Hub-Signature-256). Migrating
  ctrl-api's GitHub webhook onto it is a follow-up.
- The receiver is deliberately plain HTTP, not Restate-wrapped: handlers do
  cheap synchronous filtering inline and dispatch durable work to Restate
  themselves (documented as the package convention). Wrapping the transport
  in Restate would journal ignored events and drag VO key derivation into
  code that cannot know it.

First consumer is the Stripe month-end billing close in the change above.