### PR TITLE
fix(dashboard): z-index issue

### DIFF
--- a/web/apps/dashboard/components/ui/combobox.tsx
+++ b/web/apps/dashboard/components/ui/combobox.tsx
@@ -152,7 +152,9 @@ export function Combobox({
     >
       <div className={cn(comboboxWrapperVariants({ variant }), wrapperClassName)}>
         {leftIcon && (
-          <div className="absolute left-3 flex items-center pointer-events-none">{leftIcon}</div>
+          <div className="absolute left-3 z-10 flex items-center pointer-events-none">
+            {leftIcon}
+          </div>
         )}
         <PopoverTrigger asChild className="w-full">
           <Button


### PR DESCRIPTION
Fixes [ENG-2901](https://linear.app/unkey/issue/ENG-2901/dark-mode-search-icon-has-low-contrast)
 Problem:
 
Absolute icon with no z-index hidden behind the trigger whose bg is transparent in light but dark:bg-black in dark. it was a stacking order bug


Before:
<img width="528" height="107" alt="Screenshot 2026-06-11 at 16 03 48" src="https://github.com/user-attachments/assets/65d39b81-9040-46f2-9272-c87fcb450f8d" />
 

After:
<img width="420" height="163" alt="Screenshot 2026-06-11 at 16 03 36" src="https://github.com/user-attachments/assets/5b47feb8-1c1c-4c02-ac7d-d3d5fa223829" />


