### PR TITLE
fix: keyspace cross contam

### DIFF
--- a/svc/api/routes/v2_deploy_create_deployment/404_test.go
+++ b/svc/api/routes/v2_deploy_create_deployment/404_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	ctrlv1 "github.com/unkeyed/unkey/gen/proto/ctrl/v1"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_deploy_create_deployment"
 )
@@ -101,6 +102,96 @@ func TestCrossWorkspaceProjectIsolation(t *testing.T) {
 	// The resolved project ID must be the attacker's, not the victim's.
 	require.Equal(t, attackerSetup.Project.ID, capturedProjectID,
 		"slug resolved to wrong workspace's project")
+}
+
+func TestCrossWorkspaceKeyspaceIsolation(t *testing.T) {
+	h := testutil.NewHarness(t)
+
+	// Attacker owns a project they can deploy to.
+	attackerSetup := h.CreateTestDeploymentSetup(testutil.CreateTestDeploymentSetupOptions{
+		Permissions: []string{"project.*.create_deployment"},
+	})
+
+	// Victim has a keyspace in a *different* workspace.
+	victimWorkspace := h.CreateWorkspace()
+	victimApi := h.CreateApi(seed.CreateApiRequest{
+		WorkspaceID: victimWorkspace.ID,
+	})
+	victimKeyspaceID := victimApi.KeyAuthID.String
+
+	var ctrlCalled bool
+	route := &handler.Handler{
+		DB: h.DB,
+		CtrlClient: &testutil.MockDeploymentClient{
+			CreateDeploymentFunc: func(ctx context.Context, req *ctrlv1.CreateDeploymentRequest) (*ctrlv1.CreateDeploymentResponse, error) {
+				ctrlCalled = true
+				return &ctrlv1.CreateDeploymentResponse{DeploymentId: "test-deployment-id"}, nil
+			},
+		},
+	}
+	h.Register(route)
+
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", attackerSetup.RootKey)},
+	}
+
+	// Attacker tries to bind the victim's keyspace into their deployment.
+	req := handler.Request{
+		Project:         attackerSetup.Project.Slug,
+		App:             "default",
+		Branch:          "main",
+		EnvironmentSlug: "production",
+		DockerImage:     "nginx:latest",
+		KeyspaceId:      &victimKeyspaceID,
+	}
+
+	res := testutil.CallRoute[handler.Request, openapi.NotFoundErrorResponse](h, route, headers, req)
+	require.Equal(t, http.StatusNotFound, res.Status, "expected 404, received: %s", res.RawBody)
+	require.NotNil(t, res.Body)
+	require.Equal(t, "https://unkey.com/docs/errors/unkey/data/key_auth_not_found", res.Body.Error.Type)
+	require.False(t, ctrlCalled, "ctrl CreateDeployment must not be called for a foreign keyspace")
+}
+
+func TestKeyspaceNotFound(t *testing.T) {
+	h := testutil.NewHarness(t)
+
+	setup := h.CreateTestDeploymentSetup(testutil.CreateTestDeploymentSetupOptions{
+		Permissions: []string{"project.*.create_deployment"},
+	})
+
+	var ctrlCalled bool
+	route := &handler.Handler{
+		DB: h.DB,
+		CtrlClient: &testutil.MockDeploymentClient{
+			CreateDeploymentFunc: func(ctx context.Context, req *ctrlv1.CreateDeploymentRequest) (*ctrlv1.CreateDeploymentResponse, error) {
+				ctrlCalled = true
+				return &ctrlv1.CreateDeploymentResponse{DeploymentId: "test-deployment-id"}, nil
+			},
+		},
+	}
+	h.Register(route)
+
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", setup.RootKey)},
+	}
+
+	nonexistentKeyspace := "ks_nonexistent"
+	req := handler.Request{
+		Project:         setup.Project.Slug,
+		App:             "default",
+		Branch:          "main",
+		EnvironmentSlug: "production",
+		DockerImage:     "nginx:latest",
+		KeyspaceId:      &nonexistentKeyspace,
+	}
+
+	res := testutil.CallRoute[handler.Request, openapi.NotFoundErrorResponse](h, route, headers, req)
+	require.Equal(t, http.StatusNotFound, res.Status, "expected 404, received: %s", res.RawBody)
+	require.NotNil(t, res.Body)
+	require.Equal(t, "https://unkey.com/docs/errors/unkey/data/key_auth_not_found", res.Body.Error.Type)
+	require.False(t, ctrlCalled, "ctrl CreateDeployment must not be called for an unknown keyspace")
 }
 
 func TestEnvironmentNotFound(t *testing.T) {

--- a/svc/api/routes/v2_deploy_create_deployment/BUILD.bazel
+++ b/svc/api/routes/v2_deploy_create_deployment/BUILD.bazel
@@ -32,6 +32,7 @@ go_test(
         "//gen/proto/ctrl/v1:ctrl",
         "//pkg/ptr",
         "//svc/api/internal/testutil",
+        "//svc/api/internal/testutil/seed",
         "//svc/api/openapi",
         "@com_connectrpc_connect//:connect",
         "@com_github_stretchr_testify//require",

--- a/svc/api/routes/v2_deploy_create_deployment/handler.go
+++ b/svc/api/routes/v2_deploy_create_deployment/handler.go
@@ -98,8 +98,31 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		TriggeredBy: principal.Subject.ID,
 	}
 
-	// Add optional keyspace ID for authentication
+	// Add optional keyspace ID for authentication. Verify the keyspace belongs
+	// to the caller's workspace before attaching it; otherwise a root key for
+	// one workspace could bind another workspace's keyspace into its
+	// deployment's key-auth allowlist (cross-tenant isolation violation).
 	if req.KeyspaceId != nil {
+		keySpace, err := db.Query.FindKeySpaceByID(ctx, h.DB.RO(), *req.KeyspaceId)
+		if err != nil {
+			if db.IsNotFound(err) {
+				return fault.New("keyspace not found",
+					fault.Code(codes.Data.KeyAuth.NotFound.URN()),
+					fault.Internal("keyspace not found"),
+					fault.Public("The specified keyspace was not found."),
+				)
+			}
+			return fault.Wrap(err, fault.Internal("failed to find keyspace"))
+		}
+
+		if keySpace.WorkspaceID != principal.WorkspaceID {
+			return fault.New("keyspace not found",
+				fault.Code(codes.Data.KeyAuth.NotFound.URN()),
+				fault.Internal("keyspace belongs to different workspace, masking as 404"),
+				fault.Public("The specified keyspace was not found."),
+			)
+		}
+
 		ctrlReq.KeyspaceId = req.KeyspaceId
 	}
 

--- a/svc/ctrl/services/project/BUILD.bazel
+++ b/svc/ctrl/services/project/BUILD.bazel
@@ -17,7 +17,6 @@ go_library(
         "//pkg/db",
         "//pkg/uid",
         "//svc/ctrl/internal/auth",
-        "//svc/ctrl/services/app",
         "@com_connectrpc_connect//:connect",
         "@com_github_restatedev_sdk_go//ingress",
     ],


### PR DESCRIPTION
We shouldnt blindly trust the keyspace id given to us when creating a deployment