### PR TITLE
refactor: use client-provided timestamp for ACME renewal window

### DIFF
--- a/pkg/db/acme_challenge_list_executable.sql_generated.go
+++ b/pkg/db/acme_challenge_list_executable.sql_generated.go
@@ -13,10 +13,15 @@ import (
 const listExecutableChallenges = `-- name: ListExecutableChallenges :many
 SELECT dc.workspace_id, dc.challenge_type, d.domain FROM acme_challenges dc
 JOIN custom_domains d ON dc.domain_id = d.id
-WHERE (dc.status = 'waiting' OR (dc.status = 'verified' AND dc.expires_at <= UNIX_TIMESTAMP(DATE_ADD(NOW(), INTERVAL 30 DAY)) * 1000))
+WHERE (dc.status = 'waiting' OR (dc.status = 'verified' AND dc.expires_at <= ? + (30 * 24 * 60 * 60 * 1000)))
 AND dc.challenge_type IN (/*SLICE:verification_types*/?)
 ORDER BY d.created_at ASC
 `
+
+type ListExecutableChallengesParams struct {
+	Now               int64                         `db:"now"`
+	VerificationTypes []AcmeChallengesChallengeType `db:"verification_types"`
+}
 
 type ListExecutableChallengesRow struct {
 	WorkspaceID   string                      `db:"workspace_id"`
@@ -28,17 +33,18 @@ type ListExecutableChallengesRow struct {
 //
 //	SELECT dc.workspace_id, dc.challenge_type, d.domain FROM acme_challenges dc
 //	JOIN custom_domains d ON dc.domain_id = d.id
-//	WHERE (dc.status = 'waiting' OR (dc.status = 'verified' AND dc.expires_at <= UNIX_TIMESTAMP(DATE_ADD(NOW(), INTERVAL 30 DAY)) * 1000))
+//	WHERE (dc.status = 'waiting' OR (dc.status = 'verified' AND dc.expires_at <= ? + (30 * 24 * 60 * 60 * 1000)))
 //	AND dc.challenge_type IN (/*SLICE:verification_types*/?)
 //	ORDER BY d.created_at ASC
-func (q *Queries) ListExecutableChallenges(ctx context.Context, db DBTX, verificationTypes []AcmeChallengesChallengeType) ([]ListExecutableChallengesRow, error) {
+func (q *Queries) ListExecutableChallenges(ctx context.Context, db DBTX, arg ListExecutableChallengesParams) ([]ListExecutableChallengesRow, error) {
 	query := listExecutableChallenges
 	var queryParams []interface{}
-	if len(verificationTypes) > 0 {
-		for _, v := range verificationTypes {
+	queryParams = append(queryParams, arg.Now)
+	if len(arg.VerificationTypes) > 0 {
+		for _, v := range arg.VerificationTypes {
 			queryParams = append(queryParams, v)
 		}
-		query = strings.Replace(query, "/*SLICE:verification_types*/?", strings.Repeat(",?", len(verificationTypes))[1:], 1)
+		query = strings.Replace(query, "/*SLICE:verification_types*/?", strings.Repeat(",?", len(arg.VerificationTypes))[1:], 1)
 	} else {
 		query = strings.Replace(query, "/*SLICE:verification_types*/?", "NULL", 1)
 	}

--- a/pkg/db/querier_generated.go
+++ b/pkg/db/querier_generated.go
@@ -2311,10 +2311,10 @@ type Querier interface {
 	//
 	//  SELECT dc.workspace_id, dc.challenge_type, d.domain FROM acme_challenges dc
 	//  JOIN custom_domains d ON dc.domain_id = d.id
-	//  WHERE (dc.status = 'waiting' OR (dc.status = 'verified' AND dc.expires_at <= UNIX_TIMESTAMP(DATE_ADD(NOW(), INTERVAL 30 DAY)) * 1000))
+	//  WHERE (dc.status = 'waiting' OR (dc.status = 'verified' AND dc.expires_at <= ? + (30 * 24 * 60 * 60 * 1000)))
 	//  AND dc.challenge_type IN (/*SLICE:verification_types*/?)
 	//  ORDER BY d.created_at ASC
-	ListExecutableChallenges(ctx context.Context, db DBTX, verificationTypes []AcmeChallengesChallengeType) ([]ListExecutableChallengesRow, error)
+	ListExecutableChallenges(ctx context.Context, db DBTX, arg ListExecutableChallengesParams) ([]ListExecutableChallengesRow, error)
 	//ListGithubRepoConnections
 	//
 	//  SELECT

--- a/pkg/db/queries/acme_challenge_list_executable.sql
+++ b/pkg/db/queries/acme_challenge_list_executable.sql
@@ -1,6 +1,6 @@
 -- name: ListExecutableChallenges :many
 SELECT dc.workspace_id, dc.challenge_type, d.domain FROM acme_challenges dc
 JOIN custom_domains d ON dc.domain_id = d.id
-WHERE (dc.status = 'waiting' OR (dc.status = 'verified' AND dc.expires_at <= UNIX_TIMESTAMP(DATE_ADD(NOW(), INTERVAL 30 DAY)) * 1000))
+WHERE (dc.status = 'waiting' OR (dc.status = 'verified' AND dc.expires_at <= sqlc.arg(now) + (30 * 24 * 60 * 60 * 1000)))
 AND dc.challenge_type IN (sqlc.slice(verification_types))
 ORDER BY d.created_at ASC;

--- a/svc/ctrl/worker/certificate/renew_handler.go
+++ b/svc/ctrl/worker/certificate/renew_handler.go
@@ -32,7 +32,10 @@ func (s *Service) RenewExpiringCertificates(
 
 	// Find all challenges that need processing (waiting or expiring soon)
 	challenges, err := restate.Run(ctx, func(stepCtx restate.RunContext) ([]db.ListExecutableChallengesRow, error) {
-		return db.Query.ListExecutableChallenges(stepCtx, s.db.RO(), challengeTypes)
+		return db.Query.ListExecutableChallenges(stepCtx, s.db.RO(), db.ListExecutableChallengesParams{
+			Now:               time.Now().UnixMilli(),
+			VerificationTypes: challengeTypes,
+		})
 	}, restate.WithName("list expiring certificates"))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## What does this PR do?

Replaces the server-side `UNIX_TIMESTAMP(DATE_ADD(NOW(), INTERVAL 30 DAY)) * 1000` expiry check in `ListExecutableChallenges` (`acme_challenge_list_executable.sql`) with a client-supplied `now` parameter, so the application layer is the single authoritative source of time for expiry logic rather than relying on the DB server clock.

The portal session queries called out in the issue (`portal_session_find`, `portal_session_token_find`, `portal_session_token_exchange`) already use `sqlc.arg(now)`, so the ACME query was the only remaining one.

The 30-day renewal window is preserved as `expires_at <= now + (30 * 24 * 60 * 60 * 1000)`, with `now` passed via `time.Now().UnixMilli()` inside the existing `restate.Run` step.

## Type of change

- [x] Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

- Existing certificate renewal flow: `RenewExpiringCertificates` should still surface challenges whose `expires_at` is within 30 days, now using the application-provided timestamp.

> [!NOTE]
> The sqlc-generated Go (`acme_challenge_list_executable.sql_generated.go`, `querier_generated.go`) was regenerated by hand-matching sqlc's output because `go`/`mise` are unavailable in this environment. Worth re-running `mise run generate` to confirm no drift.