### PR TITLE
fix(dashboard): return 404 for missing deployments or projects

### DIFF
--- a/web/apps/dashboard/app/(app)/[...not-found]/page.tsx
+++ b/web/apps/dashboard/app/(app)/[...not-found]/page.tsx
@@ -1,24 +1,6 @@
 "use client";
-import { Button, Empty } from "@unkey/ui";
-import { useRouter } from "next/navigation";
+import { NotFoundState } from "@/components/not-found-state";
 
 export default function NotFound() {
-  const router = useRouter();
-
-  return (
-    <Empty>
-      <Empty.Title>404 Not Found</Empty.Title>
-      <Empty.Description>We couldn't find the page that you're looking for!</Empty.Description>
-      <Empty.Actions>
-        <Button
-          variant="default"
-          onClick={() => {
-            router.push("/");
-          }}
-        >
-          Go Back
-        </Button>
-      </Empty.Actions>
-    </Empty>
-  );
+  return <NotFoundState />;
 }

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/data-provider.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/data-provider.tsx
@@ -7,7 +7,7 @@ import type { Domain } from "@/lib/collections/deploy/domains";
 import type { Environment } from "@/lib/collections/deploy/environments";
 import type { Project } from "@/lib/collections/deploy/projects";
 import { and, eq, useLiveQuery } from "@tanstack/react-db";
-import { useParams } from "next/navigation";
+import { notFound, useParams } from "next/navigation";
 import {
   type PropsWithChildren,
   createContext,
@@ -194,6 +194,13 @@ export const ProjectDataProvider = ({
     environmentsQuery,
     customDomainsQuery,
   ]);
+
+  // The projects collection holds every project in the workspace, so once it has
+  // finished loading an absent project means it does not exist (or is inaccessible).
+  // Checked after all hooks have run to keep hook ordering stable across renders.
+  if (!projectQuery.isLoading && !project) {
+    notFound();
+  }
 
   return <ProjectDataContext.Provider value={value}>{children}</ProjectDataContext.Provider>;
 };

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/[deploymentId]/layout-provider.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/[deploymentId]/layout-provider.tsx
@@ -3,7 +3,7 @@
 import { LoadingState } from "@/components/loading-state";
 import { type Deployment, deploymentSchema } from "@/lib/collections/deploy/deployments";
 import { trpc } from "@/lib/trpc/client";
-import { useParams } from "next/navigation";
+import { notFound, useParams } from "next/navigation";
 import { createContext, useContext } from "react";
 import { useProjectData } from "../../data-provider";
 
@@ -43,7 +43,7 @@ export const DeploymentLayoutProvider = ({
     if (isDeploymentsLoading || isFetchingById) {
       return <LoadingState message="Loading deployment..." />;
     }
-    throw new Error(`Deployment not found: ${deploymentId}`);
+    notFound();
   }
   return (
     <DeploymentLayoutContext.Provider value={{ deployment: resolved }}>

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/not-found.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/not-found.tsx
@@ -1,0 +1,8 @@
+"use client";
+import { NotFoundState } from "@/components/not-found-state";
+
+export default function ProjectNotFound() {
+  return (
+    <NotFoundState description="We couldn't find the project or deployment that you're looking for." />
+  );
+}

--- a/web/apps/dashboard/components/not-found-state.tsx
+++ b/web/apps/dashboard/components/not-found-state.tsx
@@ -1,0 +1,32 @@
+"use client";
+import { Button, Empty } from "@unkey/ui";
+import { useRouter } from "next/navigation";
+
+type NotFoundStateProps = {
+  title?: string;
+  description?: string;
+};
+
+export function NotFoundState({
+  title = "404 Not Found",
+  description = "We couldn't find the page that you're looking for!",
+}: NotFoundStateProps) {
+  const router = useRouter();
+
+  return (
+    <Empty>
+      <Empty.Title>{title}</Empty.Title>
+      <Empty.Description>{description}</Empty.Description>
+      <Empty.Actions>
+        <Button
+          variant="default"
+          onClick={() => {
+            router.push("/");
+          }}
+        >
+          Go Back
+        </Button>
+      </Empty.Actions>
+    </Empty>
+  );
+}


### PR DESCRIPTION
## What does this PR do?

Navigating to a non-existent deployment or project threw a runtime error, surfacing as a 500 (e.g. `Deployment not found: d_...`). This replaces those throws with Next.js `notFound()` so missing resources render a 404 boundary instead.

- `DeploymentLayoutProvider`: `throw new Error(...)` → `notFound()` once the deployment is confirmed absent (after the by-id fallback fetch).
- `ProjectDataProvider`: calls `notFound()` once the workspace's projects collection has loaded and the project isn't in it. The check runs after all hooks so hook ordering stays stable.
- Adds a `not-found.tsx` boundary under `projects/[projectId]` so the 404 renders inside the workspace shell, reusing a new shared `NotFoundState` component (extracted from the existing catch-all 404 page).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Open a project URL with a bogus `deploymentId` → see the 404 page instead of a runtime error.
- Open a URL with a bogus `projectId` → see the 404 page.
- Valid deployments/projects still load normally.

## Checklist

### Required

- [x] Self-reviewed my own code
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
