### PR TITLE
fix(dashboard): bump root key updatedAt on permission edits

### DIFF
--- a/web/apps/dashboard/lib/trpc/routers/key/updateRootKeyPermissions.ts
+++ b/web/apps/dashboard/lib/trpc/routers/key/updateRootKeyPermissions.ts
@@ -167,6 +167,16 @@ export const updateRootKeyPermissions = workspaceProcedure
           );
         }
 
+        // Touch the root key itself so its `updatedAtM` reflects the
+        // permission change. The join table writes above don't update the
+        // `keys` row, so without this an edit wouldn't bump "last updated".
+        if (permissionsToRemove.length > 0 || permissionsToAdd.length > 0) {
+          await tx
+            .update(schema.keys)
+            .set({ updatedAtM: Date.now() })
+            .where(eq(schema.keys.id, input.keyId));
+        }
+
         await insertAuditLogs(tx, auditLogs);
       });
     } catch (_err) {


### PR DESCRIPTION
## What does this PR do?

Editing a root key's permissions in the dashboard didn't update the key's "last updated" value, while editing its name did. The permission update (`updateRootKeyPermissions`) only wrote the `keys_permissions` join table, so the `keys.updated_at_m` column never changed.

This touches the `keys` row inside the same transaction whenever permissions are added or removed, so a permission edit bumps `updated_at_m` as expected. Following the discussion on the issue, this writes the timestamp explicitly (multiple writes) rather than inferring the latest timestamp at read time — the latter wouldn't correctly reflect permission deletions.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Edit a root key's name in the dashboard → "last updated" changes (unchanged behavior).
- Edit a root key's permissions (add or remove one) → "last updated" now also changes.

## Checklist

### Required

- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
