### PR TITLE
Add unique index on openapi_specs.deployment_id

### DIFF
--- a/pkg/mysql/schema/openapi_specs.sql
+++ b/pkg/mysql/schema/openapi_specs.sql
@@ -13,3 +13,4 @@ CREATE TABLE `openapi_specs` (
 	CONSTRAINT `workspace_portal_config_idx` UNIQUE(`workspace_id`,`portal_config_id`)
 );
 
+CREATE INDEX `idx_openapi_specs_on_deployment_id` ON `openapi_specs` (`deployment_id`);

--- a/pkg/mysql/schema/openapi_specs.sql
+++ b/pkg/mysql/schema/openapi_specs.sql
@@ -13,4 +13,4 @@ CREATE TABLE `openapi_specs` (
 	CONSTRAINT `workspace_portal_config_idx` UNIQUE(`workspace_id`,`portal_config_id`)
 );
 
-CREATE INDEX `idx_openapi_specs_on_deployment_id` ON `openapi_specs` (`deployment_id`);
+CREATE UNIQUE INDEX `idx_openapi_specs_on_deployment_id` ON `openapi_specs` (`deployment_id`);

--- a/web/internal/db/src/schema/openapi_specs.ts
+++ b/web/internal/db/src/schema/openapi_specs.ts
@@ -1,5 +1,5 @@
 import { relations } from "drizzle-orm";
-import { bigint, mysqlTable, uniqueIndex, varchar } from "drizzle-orm/mysql-core";
+import { bigint, index, mysqlTable, uniqueIndex, varchar } from "drizzle-orm/mysql-core";
 import { deployments } from "./deployments";
 import { lifecycleDates } from "./util/lifecycle_dates";
 import { longblob } from "./util/longblob";
@@ -17,6 +17,7 @@ export const openapiSpecs = mysqlTable(
     ...lifecycleDates,
   },
   (table) => [
+    index("idx_openapi_specs_on_deployment_id").on(table.deploymentId),
     uniqueIndex("workspace_deployment_idx").on(table.workspaceId, table.deploymentId),
     uniqueIndex("workspace_portal_config_idx").on(table.workspaceId, table.portalConfigId),
   ],

--- a/web/internal/db/src/schema/openapi_specs.ts
+++ b/web/internal/db/src/schema/openapi_specs.ts
@@ -1,5 +1,5 @@
 import { relations } from "drizzle-orm";
-import { bigint, index, mysqlTable, uniqueIndex, varchar } from "drizzle-orm/mysql-core";
+import { bigint, mysqlTable, uniqueIndex, varchar } from "drizzle-orm/mysql-core";
 import { deployments } from "./deployments";
 import { lifecycleDates } from "./util/lifecycle_dates";
 import { longblob } from "./util/longblob";
@@ -17,7 +17,7 @@ export const openapiSpecs = mysqlTable(
     ...lifecycleDates,
   },
   (table) => [
-    index("idx_openapi_specs_on_deployment_id").on(table.deploymentId),
+    uniqueIndex("idx_openapi_specs_on_deployment_id").on(table.deploymentId),
     uniqueIndex("workspace_deployment_idx").on(table.workspaceId, table.deploymentId),
     uniqueIndex("workspace_portal_config_idx").on(table.workspaceId, table.portalConfigId),
   ],


### PR DESCRIPTION
> [!IMPORTANT]
> Unkey is not accepting external pull requests at this time. Pull requests from people outside the Unkey team will not be reviewed or merged.

## What does this PR do?

Adds a dedicated unique index on `openapi_specs.deployment_id` in the Drizzle schema and generated MySQL schema so PlanetScale can stop scanning as many rows for deployment-scoped lookups while enforcing one spec row per deployment.

Fixes # (issue)

_If there is not an issue for this, create one first. This is used for tracking purposes and helps us understand why this PR exists._

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Apply the schema change on a non-production PlanetScale branch.
- Confirm `SHOW INDEX FROM openapi_specs` includes `idx_openapi_specs_on_deployment_id` as a unique index.
- Verify deployment-scoped lookups still succeed and that duplicate non-null `deployment_id` writes are rejected or hit the existing upsert path.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `mise run fmt`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary