### PR TITLE
feat(billing): meter active keys for Deploy

### DIFF
--- a/pkg/clickhouse/active_keys.go
+++ b/pkg/clickhouse/active_keys.go
@@ -1,0 +1,62 @@
+package clickhouse
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/unkeyed/unkey/pkg/fault"
+)
+
+// GetActiveKeysUsageRequest scopes the active-keys count to one billing month
+// and optionally a single workspace.
+type GetActiveKeysUsageRequest struct {
+	// WorkspaceID restricts the query to one workspace. Empty aggregates
+	// across every workspace (the reconciliation / shadow-mode path).
+	WorkspaceID string
+
+	// Year and Month name the billing month directly. The per-month rollup is
+	// keyed by calendar month, so no instant or timezone is involved.
+	Year  int
+	Month time.Month
+}
+
+// ActiveKeysUsage is the number of distinct active keys for one workspace in
+// the requested month.
+type ActiveKeysUsage struct {
+	WorkspaceID string `ch:"workspace_id"`
+	ActiveKeys  int64  `ch:"active_keys"`
+}
+
+// GetActiveKeysUsage counts the distinct keys verified through the Deploy
+// gateway (source = 'gateway') in the billing month, per workspace. A key is
+// active once it has at least one verification in the month, regardless of
+// outcome: a RATE_LIMITED or DISABLED verification is still work done for
+// that key. API-sourced verifications never count; they are the API product's
+// usage, not Deploy's.
+func (c *Client) GetActiveKeysUsage(
+	ctx context.Context,
+	req GetActiveKeysUsageRequest,
+) ([]ActiveKeysUsage, error) {
+	query := `
+	SELECT
+		workspace_id,
+		toInt64(uniqExact(key_id)) AS active_keys
+	FROM default.key_verifications_per_month_v3
+	WHERE time = makeDate({year:Int32}, {month:Int32}, 1)
+	  AND source = 'gateway'
+	  AND ({workspace_id:String} = '' OR workspace_id = {workspace_id:String})
+	GROUP BY workspace_id
+	`
+
+	usage, err := Select[ActiveKeysUsage](ctx, c.conn, query, map[string]string{
+		"year":         strconv.Itoa(req.Year),
+		"month":        strconv.Itoa(int(req.Month)),
+		"workspace_id": req.WorkspaceID,
+	})
+	if err != nil {
+		return nil, fault.Wrap(err, fault.Internal("failed to query active keys usage"))
+	}
+
+	return usage, nil
+}

--- a/pkg/clickhouse/active_keys_test.go
+++ b/pkg/clickhouse/active_keys_test.go
@@ -1,0 +1,83 @@
+package clickhouse_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	ch "github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/clickhouse"
+	"github.com/unkeyed/unkey/pkg/clickhouse/schema"
+	"github.com/unkeyed/unkey/pkg/testutil/containers"
+	"github.com/unkeyed/unkey/pkg/uid"
+)
+
+// Active keys = distinct keys verified through the gateway in the month,
+// regardless of outcome. API-sourced verifications never count.
+func TestGetActiveKeysUsage(t *testing.T) {
+	chCfg := containers.ClickHouse(t)
+
+	client, err := clickhouse.New(clickhouse.Config{URL: chCfg.DSN})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
+
+	opts, err := ch.ParseDSN(chCfg.DSN)
+	require.NoError(t, err)
+	conn, err := ch.Open(opts)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, conn.Close()) })
+
+	ctx := context.Background()
+	require.NoError(t, conn.Ping(ctx))
+
+	now := time.Now()
+	workspaceID := uid.New(uid.WorkspacePrefix)
+
+	// 3 distinct gateway keys: one VALID, one RATE_LIMITED (still active),
+	// one verified twice (counted once). Plus 2 API-sourced keys (never
+	// counted) and one gateway key in another workspace.
+	gateway := func(keyID, outcome string) schema.KeyVerification {
+		v := createVerifications(workspaceID, 1, now, outcome)[0]
+		v.KeyID = keyID
+		v.Source = schema.SourceGateway
+		return v
+	}
+	rows := []schema.KeyVerification{
+		gateway("key_a", "VALID"),
+		gateway("key_b", "RATE_LIMITED"),
+		gateway("key_c", "VALID"),
+		gateway("key_c", "VALID"),
+	}
+	api := createVerifications(workspaceID, 2, now, "VALID")
+	for i := range api {
+		api[i].Source = schema.SourceAPI
+	}
+	other := createVerifications(uid.New(uid.WorkspacePrefix), 1, now, "VALID")
+	other[0].Source = schema.SourceGateway
+	insertVerifications(t, ctx, conn, append(append(rows, api...), other...))
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		usage, err := client.GetActiveKeysUsage(ctx, clickhouse.GetActiveKeysUsageRequest{
+			WorkspaceID: workspaceID,
+			Year:        now.Year(),
+			Month:       now.Month(),
+		})
+		require.NoError(c, err)
+		require.Len(c, usage, 1)
+		assert.Equal(c, workspaceID, usage[0].WorkspaceID)
+		assert.Equal(c, int64(3), usage[0].ActiveKeys)
+	}, time.Minute, time.Second)
+
+	// All-workspaces variant includes the other workspace's key.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		usage, err := client.GetActiveKeysUsage(ctx, clickhouse.GetActiveKeysUsageRequest{
+			WorkspaceID: "",
+			Year:        now.Year(),
+			Month:       now.Month(),
+		})
+		require.NoError(c, err)
+		assert.GreaterOrEqual(c, len(usage), 2)
+	}, time.Minute, time.Second)
+}

--- a/svc/ctrl/internal/billingmeter/interface.go
+++ b/svc/ctrl/internal/billingmeter/interface.go
@@ -23,8 +23,9 @@ type PushRequest struct {
 }
 
 // MeterValues is the month-to-date usage for one workspace, in the exact units
-// each meter expects. These are sent as decimal strings, so they are kept as
-// floats and never rounded.
+// each meter expects. Values are sent to Stripe as decimal strings: the
+// continuous meters are kept as floats and never rounded, and ActiveKeys is a
+// count, so it stays integral and formats exactly.
 type MeterValues struct {
 	// CPUSeconds is CPU time used, in CPU-seconds.
 	CPUSeconds float64
@@ -34,9 +35,13 @@ type MeterValues struct {
 	EgressGiB float64
 	// DiskGiBSeconds is allocated disk integrated over time, in GiB-seconds.
 	DiskGiBSeconds float64
+	// ActiveKeys is the number of distinct keys verified through the Deploy
+	// gateway this period (month-to-date, like every other meter).
+	ActiveKeys int64
 }
 
 // Positive reports whether any meter has usage worth pushing.
 func (v MeterValues) Positive() bool {
-	return v.CPUSeconds > 0 || v.MemoryGiBSeconds > 0 || v.EgressGiB > 0 || v.DiskGiBSeconds > 0
+	return v.CPUSeconds > 0 || v.MemoryGiBSeconds > 0 || v.EgressGiB > 0 || v.DiskGiBSeconds > 0 ||
+		v.ActiveKeys > 0
 }

--- a/svc/ctrl/internal/billingmeter/stripe.go
+++ b/svc/ctrl/internal/billingmeter/stripe.go
@@ -21,6 +21,7 @@ const (
 	eventMemory = "memory_gib_seconds"
 	eventEgress = "egress_public_gib"
 	eventDisk   = "disk_gib_seconds"
+	eventKeys   = "active_keys"
 )
 
 // payloadKeyCustomer and payloadKeyValue are the meter's
@@ -80,19 +81,24 @@ func NewStripe(secretKey string) Pusher {
 // rejects a duplicate identifier with a hard 400, turning a harmless re-run
 // into a failure.)
 func (p *stripePusher) Push(ctx context.Context, req PushRequest) (int, error) {
+	// Values are pre-rendered so each meter formats in its natural
+	// representation: the continuous meters as bounded decimals, the
+	// active-keys count as an exact integer.
 	meters := []struct {
-		name  string
-		value float64
+		name     string
+		value    string
+		positive bool
 	}{
-		{eventCPU, req.Values.CPUSeconds},
-		{eventMemory, req.Values.MemoryGiBSeconds},
-		{eventEgress, req.Values.EgressGiB},
-		{eventDisk, req.Values.DiskGiBSeconds},
+		{eventCPU, formatMeterValue(req.Values.CPUSeconds), req.Values.CPUSeconds > 0},
+		{eventMemory, formatMeterValue(req.Values.MemoryGiBSeconds), req.Values.MemoryGiBSeconds > 0},
+		{eventEgress, formatMeterValue(req.Values.EgressGiB), req.Values.EgressGiB > 0},
+		{eventDisk, formatMeterValue(req.Values.DiskGiBSeconds), req.Values.DiskGiBSeconds > 0},
+		{eventKeys, strconv.FormatInt(req.Values.ActiveKeys, 10), req.Values.ActiveKeys > 0},
 	}
 
 	pushed := 0
 	for _, m := range meters {
-		if m.value <= 0 {
+		if !m.positive {
 			continue
 		}
 		_, err := p.client.V1BillingMeterEvents.Create(ctx, &stripe.BillingMeterEventCreateParams{
@@ -100,7 +106,7 @@ func (p *stripePusher) Push(ctx context.Context, req PushRequest) (int, error) {
 			Timestamp: stripe.Int64(req.Timestamp),
 			Payload: map[string]string{
 				payloadKeyCustomer: req.StripeCustomerID,
-				payloadKeyValue:    formatMeterValue(m.value),
+				payloadKeyValue:    m.value,
 			},
 		})
 		if err != nil {

--- a/svc/ctrl/worker/cron/deploy_billing_close_integration_test.go
+++ b/svc/ctrl/worker/cron/deploy_billing_close_integration_test.go
@@ -39,8 +39,18 @@ func (f *fakeUsageReader) GetInstanceMeterUsage(
 	return f.rows, nil
 }
 
-// fakePusher records pushes by customer. failFor exercises the defer path.
-// Mutex because the close fans out concurrently.
+// GetActiveKeysUsage returns no active-keys rows: this suite asserts the
+// instance meters and the finalize behavior, not the active-keys meter.
+func (f *fakeUsageReader) GetActiveKeysUsage(
+	_ context.Context,
+	_ clickhouse.GetActiveKeysUsageRequest,
+) ([]clickhouse.ActiveKeysUsage, error) {
+	return nil, nil
+}
+
+// fakePusher records the meter totals it is asked to push, keyed by customer,
+// and can be told to fail for a given customer to exercise the defer path. The
+// push fans out concurrently, so every field is mutex-guarded.
 type fakePusher struct {
 	mu      sync.Mutex
 	pushed  map[string]billingmeter.PushRequest

--- a/svc/ctrl/worker/cron/deploybilling/billing.go
+++ b/svc/ctrl/worker/cron/deploybilling/billing.go
@@ -10,6 +10,7 @@ import (
 // UsageReader is the one ClickHouse query the handler needs.
 type UsageReader interface {
 	GetInstanceMeterUsage(ctx context.Context, req clickhouse.GetInstanceMeterUsageRequest) ([]clickhouse.InstanceMeterUsage, error)
+	GetActiveKeysUsage(ctx context.Context, req clickhouse.GetActiveKeysUsageRequest) ([]clickhouse.ActiveKeysUsage, error)
 }
 
 const (
@@ -47,7 +48,23 @@ func aggregateUsage(rows []clickhouse.InstanceMeterUsage) map[string]billingmete
 			MemoryGiBSeconds: a.memoryGiBHours * secondsPerHour,
 			EgressGiB:        float64(a.egressBytes) / bytesPerGiB,
 			DiskGiBSeconds:   a.diskGiBHours * secondsPerHour,
+			ActiveKeys:       0, // merged in from the active-keys query below
 		}
 	}
 	return out
+}
+
+// mergeActiveKeys folds the per-workspace active-key counts into the meter
+// values, adding entries for workspaces that have key activity but no
+// instance usage (possible: a deployment can be scaled to zero while its
+// keys keep verifying through the gateway).
+func mergeActiveKeys(
+	values map[string]billingmeter.MeterValues,
+	rows []clickhouse.ActiveKeysUsage,
+) {
+	for _, r := range rows {
+		v := values[r.WorkspaceID] // zero value when instance usage is absent
+		v.ActiveKeys = r.ActiveKeys
+		values[r.WorkspaceID] = v
+	}
 }

--- a/svc/ctrl/worker/cron/deploybilling/billing_test.go
+++ b/svc/ctrl/worker/cron/deploybilling/billing_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/unkeyed/unkey/pkg/clickhouse"
+	"github.com/unkeyed/unkey/svc/ctrl/internal/billingmeter"
 )
 
 func TestAggregateUsage(t *testing.T) {
@@ -37,4 +38,21 @@ func TestAggregateUsage(t *testing.T) {
 	t.Run("empty input yields empty map", func(t *testing.T) {
 		require.Empty(t, aggregateUsage(nil))
 	})
+}
+
+func TestMergeActiveKeys(t *testing.T) {
+	values := map[string]billingmeter.MeterValues{
+		"ws_with_usage": {CPUSeconds: 10, MemoryGiBSeconds: 0, EgressGiB: 0, DiskGiBSeconds: 0, ActiveKeys: 0},
+	}
+	mergeActiveKeys(values, []clickhouse.ActiveKeysUsage{
+		{WorkspaceID: "ws_with_usage", ActiveKeys: 5},
+		// Key activity without instance usage: deployment scaled to zero
+		// while its keys keep verifying through the gateway.
+		{WorkspaceID: "ws_keys_only", ActiveKeys: 2},
+	})
+
+	require.Equal(t, int64(5), values["ws_with_usage"].ActiveKeys)
+	require.Equal(t, 10.0, values["ws_with_usage"].CPUSeconds, "existing meters must survive the merge")
+	require.Equal(t, int64(2), values["ws_keys_only"].ActiveKeys)
+	require.True(t, values["ws_keys_only"].Positive())
 }

--- a/svc/ctrl/worker/cron/deploybilling/handler.go
+++ b/svc/ctrl/worker/cron/deploybilling/handler.go
@@ -137,14 +137,26 @@ func (h *Handler) pushUsage(
 		return 0, 0, 0, nil, fmt.Errorf("get period usage: %w", err)
 	}
 
-	if len(rows) == 0 {
+	keyRows, err := restate.Run(ctx, func(rc restate.RunContext) ([]clickhouse.ActiveKeysUsage, error) {
+		return h.usage.GetActiveKeysUsage(rc, clickhouse.GetActiveKeysUsageRequest{
+			WorkspaceID: "", // all workspaces; we filter to billable ones below
+			Year:        p.Year,
+			Month:       p.Month,
+		})
+	}, restate.WithName("get active keys"))
+	if err != nil {
+		return 0, 0, 0, nil, fmt.Errorf("get active keys: %w", err)
+	}
+
+	valuesByWorkspace := aggregateUsage(rows)
+	mergeActiveKeys(valuesByWorkspace, keyRows)
+	if len(valuesByWorkspace) == 0 {
 		logger.Info("no deploy usage this period", "billing_period", period)
 		return 0, 0, 0, nil, nil
 	}
 
-	valuesByWorkspace := aggregateUsage(rows)
-
-	// Stable order for Restate replay.
+	// Sort so the downstream journaled steps (db fetch, per-workspace push)
+	// replay in a stable order.
 	workspaceIDs := make([]string, 0, len(valuesByWorkspace))
 	for id := range valuesByWorkspace {
 		workspaceIDs = append(workspaceIDs, id)

--- a/svc/ctrl/worker/cron/deploybilling/push.go
+++ b/svc/ctrl/worker/cron/deploybilling/push.go
@@ -50,6 +50,7 @@ func (h *Handler) pushAll(ctx restate.ObjectContext, tasks []pushTask) (workspac
 					"stripe_customer_id", task.req.StripeCustomerID,
 					"cpu_seconds", task.req.Values.CPUSeconds,
 					"memory_gib_seconds", task.req.Values.MemoryGiBSeconds,
+					"active_keys", task.req.Values.ActiveKeys,
 					"egress_gib", task.req.Values.EgressGiB,
 					"disk_gib_seconds", task.req.Values.DiskGiBSeconds,
 					"meters_pushed", n,

--- a/web/apps/dashboard/.env.example
+++ b/web/apps/dashboard/.env.example
@@ -57,6 +57,7 @@ STRIPE_LOOKUP_DEPLOY_METER_CPU=
 STRIPE_LOOKUP_DEPLOY_METER_MEMORY=
 STRIPE_LOOKUP_DEPLOY_METER_EGRESS=
 STRIPE_LOOKUP_DEPLOY_METER_DISK=
+STRIPE_LOOKUP_DEPLOY_METER_ACTIVE_KEYS=
 
 # Dev only: create Stripe customers under a test clock so billing can be
 # time-traveled. Advance clocks and fetch invoice PDFs with

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/deploy-product-card.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/deploy-product-card.tsx
@@ -127,6 +127,11 @@ export const DeployProductCard: React.FC<DeployProductCardProps> = ({
           value: `${formatQuantity(usage.diskGiBHours)} GiB-hrs`,
           hint: "Disk reserved over time, in GiB-hours. 1 GiB reserved for 1 hour is 1 GiB-hour. Charged on size reserved, not reads, writes, or space used.",
         },
+        {
+          label: "Active keys",
+          value: formatQuantity(usage.activeKeys),
+          hint: "Distinct keys verified through the Deploy gateway this period.",
+        },
       ]
     : null;
 
@@ -209,7 +214,7 @@ export const DeployProductCard: React.FC<DeployProductCardProps> = ({
               fillClassName="bg-orange-9"
             />
             {meterStats ? (
-              <div className="grid grid-cols-2 gap-px overflow-hidden rounded-lg bg-grayA-3 sm:grid-cols-4">
+              <div className="grid grid-cols-2 gap-px overflow-hidden rounded-lg bg-grayA-3 sm:grid-cols-5">
                 {meterStats.map((stat) => (
                   <div key={stat.label} className="bg-white px-3 py-2 dark:bg-black">
                     <InfoTooltip content={stat.hint} asChild>

--- a/web/apps/dashboard/lib/env.ts
+++ b/web/apps/dashboard/lib/env.ts
@@ -128,6 +128,7 @@ const stripeSchema = z.object({
   STRIPE_LOOKUP_DEPLOY_METER_MEMORY: z.string().optional(),
   STRIPE_LOOKUP_DEPLOY_METER_EGRESS: z.string().optional(),
   STRIPE_LOOKUP_DEPLOY_METER_DISK: z.string().optional(),
+  STRIPE_LOOKUP_DEPLOY_METER_ACTIVE_KEYS: z.string().optional(),
   // Dev/test only: create Stripe customers under a test clock so the billing
   // lifecycle can be time-traveled (advance the clock, invoices finalize for
   // real, PDFs exist). Requires a test-mode key; see

--- a/web/apps/dashboard/lib/stripe/deployBilling.test.ts
+++ b/web/apps/dashboard/lib/stripe/deployBilling.test.ts
@@ -28,6 +28,7 @@ const ID: Record<string, string> = {
   lk_memory: "price_memory",
   lk_egress: "price_egress",
   lk_disk: "price_disk",
+  lk_active_keys: "price_active_keys",
 };
 
 function envWith(overrides: Partial<StripeEnv> = {}): StripeEnv {
@@ -43,6 +44,7 @@ function envWith(overrides: Partial<StripeEnv> = {}): StripeEnv {
     STRIPE_LOOKUP_DEPLOY_METER_MEMORY: "lk_memory",
     STRIPE_LOOKUP_DEPLOY_METER_EGRESS: "lk_egress",
     STRIPE_LOOKUP_DEPLOY_METER_DISK: "lk_disk",
+    STRIPE_LOOKUP_DEPLOY_METER_ACTIVE_KEYS: "lk_active_keys",
     ...overrides,
   };
 }
@@ -61,7 +63,7 @@ function stubStripe() {
 
 const CONFIG: DeployBillingConfig = {
   planFeePriceIds: { starter: "price_starter", pro: "price_pro", business: "price_business" },
-  meteredPriceIds: ["price_cpu", "price_memory", "price_egress", "price_disk"],
+  meteredPriceIds: ["price_cpu", "price_memory", "price_egress", "price_disk", "price_active_keys"],
   allDeployPriceIds: new Set([
     "price_starter",
     "price_pro",
@@ -70,6 +72,7 @@ const CONFIG: DeployBillingConfig = {
     "price_memory",
     "price_egress",
     "price_disk",
+    "price_active_keys",
   ]),
 };
 
@@ -92,8 +95,14 @@ describe("deployBillingConfig", () => {
       pro: "price_pro",
       business: "price_business",
     });
-    expect(c?.meteredPriceIds).toEqual(["price_cpu", "price_memory", "price_egress", "price_disk"]);
-    expect(c?.allDeployPriceIds.size).toBe(7);
+    expect(c?.meteredPriceIds).toEqual([
+      "price_cpu",
+      "price_memory",
+      "price_egress",
+      "price_disk",
+      "price_active_keys",
+    ]);
+    expect(c?.allDeployPriceIds.size).toBe(8);
   });
 
   it("returns null when Stripe is not configured", async () => {
@@ -129,6 +138,7 @@ describe("deploySubscriptionItems", () => {
       { price: "price_memory" },
       { price: "price_egress" },
       { price: "price_disk" },
+      { price: "price_active_keys" },
     ]);
   });
 });

--- a/web/apps/dashboard/lib/stripe/deployBilling.ts
+++ b/web/apps/dashboard/lib/stripe/deployBilling.ts
@@ -44,6 +44,7 @@ export function deployBillingConfigured(): boolean {
     e.STRIPE_LOOKUP_DEPLOY_METER_MEMORY,
     e.STRIPE_LOOKUP_DEPLOY_METER_EGRESS,
     e.STRIPE_LOOKUP_DEPLOY_METER_DISK,
+    e.STRIPE_LOOKUP_DEPLOY_METER_ACTIVE_KEYS,
   ].every(Boolean);
 }
 
@@ -72,6 +73,7 @@ export async function deployBillingConfig(): Promise<DeployBillingConfig | null>
     e.STRIPE_LOOKUP_DEPLOY_METER_MEMORY,
     e.STRIPE_LOOKUP_DEPLOY_METER_EGRESS,
     e.STRIPE_LOOKUP_DEPLOY_METER_DISK,
+    e.STRIPE_LOOKUP_DEPLOY_METER_ACTIVE_KEYS,
   ];
 
   // All-or-nothing: a partially configured set would attach an incomplete

--- a/web/apps/dashboard/lib/trpc/routers/billing/query-deploy-usage/index.ts
+++ b/web/apps/dashboard/lib/trpc/routers/billing/query-deploy-usage/index.ts
@@ -8,6 +8,7 @@ export const queryDeployUsageResponse = z.object({
   memoryGiBHours: z.number(),
   diskGiBHours: z.number(),
   egressGiB: z.number(),
+  activeKeys: z.number(),
 });
 
 export type DeployUsageResponse = z.infer<typeof queryDeployUsageResponse>;
@@ -25,11 +26,20 @@ export const queryDeployUsage = workspaceProcedure
     const monthStart = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1);
 
     try {
-      return await clickhouse.billing.deployMeterUsage({
-        workspaceId: ctx.workspace.id,
-        start: monthStart,
-        end: now.getTime(),
-      });
+      const [meters, keys] = await Promise.all([
+        clickhouse.billing.deployMeterUsage({
+          workspaceId: ctx.workspace.id,
+          start: monthStart,
+          end: now.getTime(),
+        }),
+        clickhouse.billing.activeKeysUsage({
+          workspaceId: ctx.workspace.id,
+          year: now.getUTCFullYear(),
+          // getUTCMonth is 0-based; the query takes a calendar month.
+          month: now.getUTCMonth() + 1,
+        }),
+      ]);
+      return { ...meters, activeKeys: keys.activeKeys };
     } catch (err) {
       console.error("Failed to query deploy usage", err);
       throw new TRPCError({

--- a/web/internal/clickhouse/src/deploy_billing.ts
+++ b/web/internal/clickhouse/src/deploy_billing.ts
@@ -83,3 +83,51 @@ export function getDeployMeterUsage(ch: Querier) {
     );
   };
 }
+
+export const activeKeysUsage = z.object({
+  activeKeys: z.number(),
+});
+
+export type ActiveKeysUsage = z.infer<typeof activeKeysUsage>;
+
+/**
+ * Distinct keys verified through the Deploy gateway (source = 'gateway') in
+ * the billing month, regardless of outcome: a RATE_LIMITED or DISABLED
+ * verification is still work done for that key. Mirrors GetActiveKeysUsage in
+ * pkg/clickhouse, the authoritative billing query. Display-only.
+ */
+export function getActiveKeysUsage(ch: Querier) {
+  return async (args: {
+    workspaceId: string;
+    /** Calendar year of the billing month. */
+    year: number;
+    /** Calendar month, 1-12. */
+    month: number;
+  }): Promise<ActiveKeysUsage> => {
+    const query = ch.query({
+      query: `
+        SELECT toInt64(uniqExact(key_id)) AS activeKeys
+        FROM default.key_verifications_per_month_v3
+        WHERE time = makeDate({year: Int32}, {month: Int32}, 1)
+          AND source = 'gateway'
+          AND workspace_id = {workspaceId: String}
+      `,
+      params: z.object({
+        workspaceId: z.string(),
+        year: z.number().int(),
+        month: z.number().int().min(1).max(12),
+      }),
+      schema: activeKeysUsage,
+    });
+
+    const result = await query({
+      workspaceId: args.workspaceId,
+      year: args.year,
+      month: args.month,
+    });
+    if (result.err) {
+      throw new Error(`Failed to fetch active keys usage: ${result.err.message}`);
+    }
+    return result.val.at(0) ?? { activeKeys: 0 };
+  };
+}

--- a/web/internal/clickhouse/src/index.ts
+++ b/web/internal/clickhouse/src/index.ts
@@ -1,8 +1,13 @@
 import { getAuditLogs } from "./audit-logs";
 import { getBillableRatelimits, getBillableVerifications } from "./billing";
 import { getBuildStepLogs, getBuildSteps } from "./build-steps";
-import { getDeployMeterUsage } from "./deploy_billing";
-export { type DeployMeterUsage, deployMeterUsage } from "./deploy_billing";
+import { getActiveKeysUsage, getDeployMeterUsage } from "./deploy_billing";
+export {
+  type ActiveKeysUsage,
+  activeKeysUsage,
+  type DeployMeterUsage,
+  deployMeterUsage,
+} from "./deploy_billing";
 import { Client, type Inserter, Noop, type Querier } from "./client";
 import { getInstanceEvents } from "./instance-events";
 export { instanceEventKind, type InstanceEventKind } from "./instance-events";
@@ -294,6 +299,7 @@ export class ClickHouse {
       billableVerifications: getBillableVerifications(this.querier),
       billableRatelimits: getBillableRatelimits(this.querier),
       deployMeterUsage: getDeployMeterUsage(this.querier),
+      activeKeysUsage: getActiveKeysUsage(this.querier),
     };
   }
   public get api() {


### PR DESCRIPTION
**Problem:**

Deploy bills CPU, memory, egress, and disk, but keys verified through the gateway were free. Active keys become the fifth meter: $0.002 per distinct key per month.

Stacked on #6448, whose source dimension is what makes this possible: only gateway-sourced verifications count. API-sourced verifications are the API product's usage, not Deploy's.

**Solution:**

A key is active once it has at least one gateway verification in the month, regardless of outcome: a RATE_LIMITED or DISABLED verification is still work done for that key. The hourly push runs one grouped `uniqExact` scan over `key_verifications_per_month_v3` as a second journaled Restate step and folds per-workspace counts into the meter map, creating entries for workspaces with key activity but zero instance usage (a deployment can be scaled to zero while its keys keep verifying). Values are absolute month-to-date like every other meter, so retries and overlapping ticks converge on Stripe's "last" formula. The count stays integral end to end: `MeterValues.ActiveKeys` is an `int64` and the pusher formats it exactly, while the continuous meters keep their bounded-decimal formatting.

The dashboard gets a display-only mirror of the query for the billing card, and the new price lookup key joins the existing all-or-nothing metered price set, so a partial configuration can never attach an incomplete meter set.

**Impact:**

- New Stripe meter event name `active_keys`: the meter and its metered price must exist in Stripe before this bills anything.
- New dashboard env `STRIPE_LOOKUP_DEPLOY_METER_ACTIVE_KEYS`. Leaving it unset disables Deploy billing config entirely rather than partially attaching.
- Workspaces with zero instance usage but gateway key activity now get billed.
- One extra ClickHouse query per hourly push and month-end close (single query for the whole fleet, not per workspace). No migrations.

**Testing:**

- `TestGetActiveKeysUsage` (container-backed ClickHouse): outcome-agnostic dedup (double-verified key counts once), API-source exclusion, workspace isolation, all-workspaces mode.
- `TestMergeActiveKeys`: keys-only workspaces get entries and pass `Positive()`.
- `deployBilling.test.ts`: the new lookup key participates in config resolution and subscription items.
- Manual: gateway verifications, trigger the billing push, meter events visible in the Stripe test dashboard.

