### PR TITLE
test(billing): shadow-mode meter validation (ENG-2879)

### DIFF
--- a/cmd/dev/stripe/shadow.go
+++ b/cmd/dev/stripe/shadow.go
@@ -1,0 +1,264 @@
+package stripe
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"os"
+	"time"
+
+	stripesdk "github.com/stripe/stripe-go/v86"
+	"github.com/unkeyed/unkey/pkg/billingperiod"
+	"github.com/unkeyed/unkey/pkg/cli"
+	"github.com/unkeyed/unkey/pkg/clickhouse"
+	"github.com/unkeyed/unkey/pkg/db"
+	"github.com/unkeyed/unkey/pkg/mysql/sqlcomment"
+	"github.com/unkeyed/unkey/pkg/tui"
+)
+
+// Worker unit conversions (svc/ctrl/worker/cron/deploybilling/billing.go): the
+// ClickHouse query reports memory/disk in GiB-hours and egress in bytes, while
+// the meters bill in GiB-seconds and GiB. Kept in sync by hand; the fixture
+// test TestMeterUsageHandComputedBill guards the same factors.
+const (
+	secondsPerHour = 3600.0
+	bytesPerGiB    = float64(int64(1024 * 1024 * 1024))
+)
+
+// relativeTolerance is the drift a meter may show before shadow flags it. The
+// hourly push can lag the live query by up to an hour, so a small difference
+// is usually that lag rather than a real problem. Set above the lag, below
+// any difference that would indicate the pipeline is dropping or double-counting.
+const relativeTolerance = 0.001 // 0.1%
+
+// shadowCmd recomputes a workspace's month-to-date Deploy usage from ClickHouse
+// and diffs it against the values Stripe holds for the customer's meters. Use it
+// before enabling billing to check the query, hourly push, and meters agree.
+var shadowCmd = &cli.Command{
+	Name:  "shadow",
+	Usage: "Diff a workspace's ClickHouse usage against Stripe's meter values",
+	Flags: []cli.Flag{
+		keyFlag(),
+		cli.String("clickhouse-url", "ClickHouse DSN",
+			cli.Default("clickhouse://default:password@127.0.0.1:9000"),
+			cli.EnvVar("UNKEY_CLICKHOUSE_URL")),
+		cli.String("database-primary", "MySQL DSN, used to resolve the workspace's Stripe customer",
+			cli.Default("unkey:password@tcp(127.0.0.1:3306)/unkey?parseTime=true&interpolateParams=true"),
+			cli.EnvVar("UNKEY_DATABASE_PRIMARY")),
+		cli.String("workspace", "Workspace id", cli.Required()),
+		cli.String("customer", "Stripe customer id (cus_...). Defaults to the workspace's customer from the DB", cli.Default("")),
+		cli.String("month", "Billing month YYYY-MM (default: current)", cli.Default("")),
+	},
+	Action: shadow,
+}
+
+// meterValues holds one workspace's usage in the exact units each Stripe meter
+// expects, keyed by the meter's event_name so it lines up with the summaries.
+type meterValues map[string]float64
+
+func shadow(ctx context.Context, cmd *cli.Command) error {
+	sc, err := newClient(cmd)
+	if err != nil {
+		return err
+	}
+	out := tui.New(os.Stdout)
+
+	workspace := cmd.RequireString("workspace")
+
+	ch, err := clickhouse.New(clickhouse.Config{URL: cmd.RequireString("clickhouse-url")})
+	if err != nil {
+		return fmt.Errorf("connect clickhouse: %w", err)
+	}
+	defer func() { _ = ch.Close() }()
+
+	customer, err := resolveCustomer(ctx, cmd, workspace)
+	if err != nil {
+		return err
+	}
+
+	period, err := resolvePeriod(ctx, sc, cmd.String("month"))
+	if err != nil {
+		return err
+	}
+	start := period.Start()
+	end := period.End()
+
+	out.Printf("Shadow %s  workspace=%s  customer=%s\n",
+		out.Bold(start.Format("2006-01")), workspace, customer)
+	out.Println(out.Dim(fmt.Sprintf("  window %s -> %s", start.Format("2006-01-02"), end.Format("2006-01-02"))))
+
+	chValues, err := clickhouseUsage(ctx, ch, workspace, start.UnixMilli(), end.UnixMilli())
+	if err != nil {
+		return err
+	}
+
+	stripeValues, err := stripeMeterValues(ctx, sc, customer, start.Unix(), end.Unix())
+	if err != nil {
+		return err
+	}
+
+	return report(out, chValues, stripeValues)
+}
+
+// resolveCustomer returns the Stripe customer to inspect: the --customer flag
+// if given, otherwise the workspace's stripe_customer_id from the database, so
+// the common case only needs --workspace. The database is opened only on the
+// lookup path, since passing --customer needs no DB at all.
+func resolveCustomer(ctx context.Context, cmd *cli.Command, workspace string) (string, error) {
+	if c := cmd.String("customer"); c != "" {
+		return c, nil
+	}
+
+	database, err := db.New(db.Config{
+		PrimaryDSN:  cmd.RequireString("database-primary"),
+		ReadOnlyDSN: "",
+		Tags:        sqlcomment.Disabled(),
+	})
+	if err != nil {
+		return "", fmt.Errorf("connect database: %w", err)
+	}
+	defer func() { _ = database.Close() }()
+
+	rows, err := db.Query.ListWorkspacesForDeployBillingByIDs(ctx, database.RO(), []string{workspace})
+	if err != nil {
+		return "", fmt.Errorf("look up workspace %s: %w", workspace, err)
+	}
+	if len(rows) == 0 {
+		return "", fmt.Errorf("workspace %s not found", workspace)
+	}
+	if !rows[0].StripeCustomerID.Valid || rows[0].StripeCustomerID.String == "" {
+		return "", fmt.Errorf("workspace %s has no stripe customer; pass --customer", workspace)
+	}
+	return rows[0].StripeCustomerID.String, nil
+}
+
+// resolvePeriod picks the billing period: the --month flag if given, else the
+// current calendar month from the local clock. For clocked test customers
+// whose "now" is not wall-clock time, pass --month explicitly.
+func resolvePeriod(_ context.Context, _ *stripesdk.Client, month string) (billingperiod.Period, error) {
+	if month != "" {
+		return billingperiod.Parse(month)
+	}
+	now := time.Now().UTC()
+	return billingperiod.Period{Year: now.Year(), Month: now.Month()}, nil
+}
+
+// clickhouseUsage runs the production billing queries for the window and folds
+// them into meter units, exactly as the worker does before pushing.
+func clickhouseUsage(ctx context.Context, ch *clickhouse.Client, workspace string, startMillis, endMillis int64) (meterValues, error) {
+	usage, err := ch.GetInstanceMeterUsage(ctx, clickhouse.GetInstanceMeterUsageRequest{
+		WorkspaceID: workspace,
+		Start:       startMillis,
+		End:         endMillis,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("query instance usage: %w", err)
+	}
+
+	var cpuSeconds, memoryGiBHours, diskGiBHours float64
+	var egressBytes int64
+	for _, r := range usage {
+		cpuSeconds += r.CPUSeconds
+		memoryGiBHours += r.MemoryGiBHours
+		diskGiBHours += r.DiskGiBHours
+		egressBytes += r.EgressBytes
+	}
+
+	monthStart := time.UnixMilli(startMillis).UTC()
+	keys, err := ch.GetActiveKeysUsage(ctx, clickhouse.GetActiveKeysUsageRequest{
+		WorkspaceID: workspace,
+		Year:        monthStart.Year(),
+		Month:       monthStart.Month(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("query active keys: %w", err)
+	}
+	var activeKeys float64
+	for _, k := range keys {
+		activeKeys += float64(k.ActiveKeys)
+	}
+
+	return meterValues{
+		"cpu_seconds":        cpuSeconds,
+		"memory_gib_seconds": memoryGiBHours * secondsPerHour,
+		"egress_public_gib":  float64(egressBytes) / bytesPerGiB,
+		"disk_gib_seconds":   diskGiBHours * secondsPerHour,
+		"active_keys":        activeKeys,
+	}, nil
+}
+
+// stripeMeterValues reads the value Stripe currently holds for each meter: the
+// "last"-aggregated summary over the window is the most recent month-to-date
+// total the worker pushed.
+func stripeMeterValues(ctx context.Context, sc *stripesdk.Client, customer string, startUnix, endUnix int64) (meterValues, error) {
+	values := meterValues{}
+
+	meters := sc.V1BillingMeters.List(ctx, &stripesdk.BillingMeterListParams{
+		ListParams: stripesdk.ListParams{Limit: stripesdk.Int64(100)},
+	})
+	for meter, err := range meters.All(ctx) {
+		if err != nil {
+			return nil, fmt.Errorf("list meters: %w", err)
+		}
+
+		summaries := sc.V1BillingMeterEventSummaries.List(ctx, &stripesdk.BillingMeterEventSummaryListParams{
+			ID:        stripesdk.String(meter.ID),
+			Customer:  stripesdk.String(customer),
+			StartTime: stripesdk.Int64(startUnix),
+			EndTime:   stripesdk.Int64(endUnix),
+		})
+		var value float64
+		for summary, sErr := range summaries.All(ctx) {
+			if sErr != nil {
+				return nil, fmt.Errorf("meter %s summaries: %w", meter.EventName, sErr)
+			}
+			// One summary for the whole window (no grouping requested); for a
+			// "last" meter its aggregated value is the latest MTD push.
+			value = summary.AggregatedValue
+		}
+		values[meter.EventName] = value
+	}
+
+	return values, nil
+}
+
+// report prints a per-meter ClickHouse-vs-Stripe table and returns an error if
+// any meter drifts beyond the tolerance, so scripts can gate on the exit code.
+func report(out *tui.Renderer, ch, stripe meterValues) error {
+	order := []string{"cpu_seconds", "memory_gib_seconds", "egress_public_gib", "disk_gib_seconds", "active_keys"}
+
+	drifted := 0
+	out.Blank()
+	for _, meter := range order {
+		chVal := ch[meter]
+		stripeVal := stripe[meter]
+		diff := chVal - stripeVal
+
+		ok := withinTolerance(chVal, stripeVal)
+		verdict := out.Green("ok")
+		if !ok {
+			verdict = out.Red("DRIFT")
+			drifted++
+		}
+		out.Printf("  %-20s clickhouse=%-16.6f stripe=%-16.6f diff=%-14.6f %s\n",
+			meter, chVal, stripeVal, diff, verdict)
+	}
+	out.Blank()
+
+	if drifted > 0 {
+		return fmt.Errorf("%d meter(s) drifted beyond %.3f%%; a gap this large is more than the hourly push lag can explain",
+			drifted, relativeTolerance*100)
+	}
+	out.Println(out.Green("All meters agree within tolerance."))
+	return nil
+}
+
+// withinTolerance compares two meter values with a relative tolerance, treating
+// two zeros as agreement and any zero-vs-nonzero as drift.
+func withinTolerance(a, b float64) bool {
+	if a == 0 && b == 0 {
+		return true
+	}
+	scale := math.Max(math.Abs(a), math.Abs(b))
+	return math.Abs(a-b)/scale <= relativeTolerance
+}

--- a/cmd/dev/stripe/shadow_test.go
+++ b/cmd/dev/stripe/shadow_test.go
@@ -1,0 +1,25 @@
+package stripe
+
+import "testing"
+
+func TestWithinTolerance(t *testing.T) {
+	cases := []struct {
+		name string
+		a, b float64
+		want bool
+	}{
+		{"both zero", 0, 0, true},
+		{"zero vs nonzero drifts", 0, 1, false},
+		{"identical", 3600, 3600, true},
+		{"within 0.1% (push lag)", 100000, 100050, true},
+		{"beyond 0.1% drifts", 100000, 100200, false},
+		{"tiny absolute, equal", 0.234375, 0.234375, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := withinTolerance(tc.a, tc.b); got != tc.want {
+				t.Fatalf("withinTolerance(%v, %v) = %v, want %v", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/dev/stripe/stripe.go
+++ b/cmd/dev/stripe/stripe.go
@@ -31,6 +31,7 @@ var Cmd = &cli.Command{
 		invoicesCmd,
 		grantsCmd,
 		resetCmd,
+		shadowCmd,
 	},
 }
 

--- a/pkg/clickhouse/active_keys.go
+++ b/pkg/clickhouse/active_keys.go
@@ -1,0 +1,62 @@
+package clickhouse
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/unkeyed/unkey/pkg/fault"
+)
+
+// GetActiveKeysUsageRequest scopes the active-keys count to one billing month
+// and optionally a single workspace.
+type GetActiveKeysUsageRequest struct {
+	// WorkspaceID restricts the query to one workspace. Empty aggregates
+	// across every workspace (the reconciliation / shadow-mode path).
+	WorkspaceID string
+
+	// Year and Month name the billing month directly. The per-month rollup is
+	// keyed by calendar month, so no instant or timezone is involved.
+	Year  int
+	Month time.Month
+}
+
+// ActiveKeysUsage is the number of distinct active keys for one workspace in
+// the requested month.
+type ActiveKeysUsage struct {
+	WorkspaceID string `ch:"workspace_id"`
+	ActiveKeys  int64  `ch:"active_keys"`
+}
+
+// GetActiveKeysUsage counts the distinct keys verified through the Deploy
+// gateway (source = 'gateway') in the billing month, per workspace. A key is
+// active once it has at least one verification in the month, regardless of
+// outcome: a RATE_LIMITED or DISABLED verification is still work done for
+// that key. API-sourced verifications never count; they are the API product's
+// usage, not Deploy's.
+func (c *Client) GetActiveKeysUsage(
+	ctx context.Context,
+	req GetActiveKeysUsageRequest,
+) ([]ActiveKeysUsage, error) {
+	query := `
+	SELECT
+		workspace_id,
+		toInt64(uniqExact(key_id)) AS active_keys
+	FROM default.key_verifications_per_month_v3
+	WHERE time = makeDate({year:Int32}, {month:Int32}, 1)
+	  AND source = 'gateway'
+	  AND ({workspace_id:String} = '' OR workspace_id = {workspace_id:String})
+	GROUP BY workspace_id
+	`
+
+	usage, err := Select[ActiveKeysUsage](ctx, c.conn, query, map[string]string{
+		"year":         strconv.Itoa(req.Year),
+		"month":        strconv.Itoa(int(req.Month)),
+		"workspace_id": req.WorkspaceID,
+	})
+	if err != nil {
+		return nil, fault.Wrap(err, fault.Internal("failed to query active keys usage"))
+	}
+
+	return usage, nil
+}

--- a/pkg/clickhouse/active_keys_test.go
+++ b/pkg/clickhouse/active_keys_test.go
@@ -1,0 +1,83 @@
+package clickhouse_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	ch "github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/clickhouse"
+	"github.com/unkeyed/unkey/pkg/clickhouse/schema"
+	"github.com/unkeyed/unkey/pkg/testutil/containers"
+	"github.com/unkeyed/unkey/pkg/uid"
+)
+
+// Active keys = distinct keys verified through the gateway in the month,
+// regardless of outcome. API-sourced verifications never count.
+func TestGetActiveKeysUsage(t *testing.T) {
+	chCfg := containers.ClickHouse(t)
+
+	client, err := clickhouse.New(clickhouse.Config{URL: chCfg.DSN})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
+
+	opts, err := ch.ParseDSN(chCfg.DSN)
+	require.NoError(t, err)
+	conn, err := ch.Open(opts)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, conn.Close()) })
+
+	ctx := context.Background()
+	require.NoError(t, conn.Ping(ctx))
+
+	now := time.Now()
+	workspaceID := uid.New(uid.WorkspacePrefix)
+
+	// 3 distinct gateway keys: one VALID, one RATE_LIMITED (still active),
+	// one verified twice (counted once). Plus 2 API-sourced keys (never
+	// counted) and one gateway key in another workspace.
+	gateway := func(keyID, outcome string) schema.KeyVerification {
+		v := createVerifications(workspaceID, 1, now, outcome)[0]
+		v.KeyID = keyID
+		v.Source = schema.SourceGateway
+		return v
+	}
+	rows := []schema.KeyVerification{
+		gateway("key_a", "VALID"),
+		gateway("key_b", "RATE_LIMITED"),
+		gateway("key_c", "VALID"),
+		gateway("key_c", "VALID"),
+	}
+	api := createVerifications(workspaceID, 2, now, "VALID")
+	for i := range api {
+		api[i].Source = schema.SourceAPI
+	}
+	other := createVerifications(uid.New(uid.WorkspacePrefix), 1, now, "VALID")
+	other[0].Source = schema.SourceGateway
+	insertVerifications(t, ctx, conn, append(append(rows, api...), other...))
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		usage, err := client.GetActiveKeysUsage(ctx, clickhouse.GetActiveKeysUsageRequest{
+			WorkspaceID: workspaceID,
+			Year:        now.Year(),
+			Month:       now.Month(),
+		})
+		require.NoError(c, err)
+		require.Len(c, usage, 1)
+		assert.Equal(c, workspaceID, usage[0].WorkspaceID)
+		assert.Equal(c, int64(3), usage[0].ActiveKeys)
+	}, time.Minute, time.Second)
+
+	// All-workspaces variant includes the other workspace's key.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		usage, err := client.GetActiveKeysUsage(ctx, clickhouse.GetActiveKeysUsageRequest{
+			WorkspaceID: "",
+			Year:        now.Year(),
+			Month:       now.Month(),
+		})
+		require.NoError(c, err)
+		assert.GreaterOrEqual(c, len(usage), 2)
+	}, time.Minute, time.Second)
+}

--- a/pkg/clickhouse/instance_meter_bill_test.go
+++ b/pkg/clickhouse/instance_meter_bill_test.go
@@ -1,0 +1,181 @@
+package clickhouse_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	ch "github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/clickhouse"
+	"github.com/unkeyed/unkey/pkg/clickhouse/schema"
+	"github.com/unkeyed/unkey/pkg/testutil/containers"
+	"github.com/unkeyed/unkey/pkg/uid"
+)
+
+// Catalog rates in USD per meter unit, copied from the Terraform source of
+// truth (infra terraform/stripe/modules/catalog/prices.tf, usage_rates). The
+// trailing cents value there is per-unit; these are the dollar equivalents the
+// hand-computed bills below multiply against. If Terraform changes a rate,
+// this test should be updated in lockstep — it is the canary that the meter
+// units the query produces map to the dollars we intend to charge.
+const (
+	rateCPUSecond       = 0.000006944 // per CPU-second
+	rateMemoryGiBSecond = 0.000003472 // per GiB-second
+	rateEgressGiB       = 0.05        // per GiB
+	rateDiskGiBSecond   = 0.00000006  // per GiB-second
+)
+
+// The worker's unit conversions (svc/ctrl/worker/cron/deploybilling/billing.go).
+// Replicated here so the test asserts the same path end to end: query natural
+// units -> meter units -> dollars.
+const (
+	secondsPerHour = 3600.0
+	bytesPerGiB    = float64(int64(1024 * 1024 * 1024))
+)
+
+// TestMeterUsageHandComputedBill seeds a workload with a computable bill: one
+// container holding 1 vCPU, 2 GiB memory, and 10 GiB disk steady for exactly
+// one hour, plus 240 MiB of egress. It runs the production billing query and
+// checks the meter units and the resulting dollar bill against values worked
+// out by hand below, so a query change that alters either is caught here.
+func TestMeterUsageHandComputedBill(t *testing.T) {
+	t.Parallel()
+
+	cfg := containers.ClickHouse(t)
+	client, err := clickhouse.New(clickhouse.Config{URL: cfg.DSN})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
+
+	opts, err := ch.ParseDSN(cfg.DSN)
+	require.NoError(t, err)
+	conn, err := ch.Open(opts)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, conn.Close()) })
+
+	ctx := context.Background()
+	require.NoError(t, conn.Ping(ctx))
+
+	base := time.Now().UTC().Truncate(24 * time.Hour).Add(-24 * time.Hour).UnixMilli()
+
+	ws := uid.New(uid.WorkspacePrefix)
+	resource := uid.New("res")
+	c := newContainer()
+
+	// 240 intervals of 15s = exactly one hour (241 samples). Steady gauges; the
+	// CPU and egress counters climb linearly so every interval contributes the
+	// same delta.
+	const (
+		intervals      = 240
+		cpuUsecPerStep = 15_000_000  // 1 vCPU for 15s = 15s of CPU time
+		egressPerStep  = 1024 * 1024 // 1 MiB/step -> 240 MiB = 0.234375 GiB exact
+		memBytes       = 2 * gib
+		diskBytes      = 10 * gib
+	)
+	var samples []schema.InstanceCheckpoint
+	for i := 0; i <= intervals; i++ {
+		samples = append(samples, c.sample(ws, resource, base+int64(i)*sampleGap, sampleValues{
+			cpuUsec:     int64(i) * cpuUsecPerStep,
+			egressBytes: int64(i) * egressPerStep,
+			memoryBytes: memBytes,
+			diskBytes:   diskBytes,
+		}))
+	}
+	insertCheckpoints(t, ctx, conn, samples)
+
+	rows, err := client.GetInstanceMeterUsage(ctx, clickhouse.GetInstanceMeterUsageRequest{
+		WorkspaceID: ws,
+		Start:       base - sampleGap,
+		End:         base + int64(2*time.Hour/time.Millisecond),
+	})
+	require.NoError(t, err)
+	u := findUsage(t, rows, resource)
+
+	// Natural units straight from the query.
+	// CPU: 240 deltas * 15s = 3600 CPU-seconds.
+	require.InDelta(t, 3600.0, u.CPUSeconds, 1e-6)
+	// Memory: 2 GiB integrated over 240*15s = 3600s -> 2 GiB-hours.
+	require.InDelta(t, 2.0, u.MemoryGiBHours, 1e-9)
+	// Disk: 10 GiB over the same hour -> 10 GiB-hours.
+	require.InDelta(t, 10.0, u.DiskGiBHours, 1e-9)
+	// Egress: 240 deltas of 1 MiB = 240 MiB = 0.234375 GiB exact.
+	require.Equal(t, int64(egressPerStep*intervals), u.EgressBytes)
+
+	// Convert to meter units exactly as the worker does, then to dollars.
+	cpuSeconds := u.CPUSeconds
+	memoryGiBSeconds := u.MemoryGiBHours * secondsPerHour
+	diskGiBSeconds := u.DiskGiBHours * secondsPerHour
+	egressGiB := float64(u.EgressBytes) / bytesPerGiB
+
+	bill := cpuSeconds*rateCPUSecond +
+		memoryGiBSeconds*rateMemoryGiBSecond +
+		diskGiBSeconds*rateDiskGiBSecond +
+		egressGiB*rateEgressGiB
+
+	// Hand-computed:
+	//   CPU    3600 s          * 0.000006944 = 0.02499840
+	//   Memory 7200 GiB-s      * 0.000003472 = 0.02499840
+	//   Disk   36000 GiB-s     * 0.00000006  = 0.00216000
+	//   Egress 0.234375 GiB    * 0.05        = 0.01171875
+	//   total                                 = 0.06387555
+	require.InDelta(t, 0.06387555, bill, 1e-9,
+		"hand-computed bill drifted: cpu=%.6f mem=%.6f disk=%.6f egress=%.6f",
+		cpuSeconds, memoryGiBSeconds, diskGiBSeconds, egressGiB)
+}
+
+// TestMeterUsageStraddlesWindow checks that only the in-window deltas are
+// billed when a container's life straddles the billing window edges: samples
+// before Start and after End exist, but the counter delta and time integral
+// must cover only [Start, End]. This is the month-boundary case (close stamps
+// period_end - 1s; the next period starts fresh).
+func TestMeterUsageStraddlesWindow(t *testing.T) {
+	t.Parallel()
+
+	cfg := containers.ClickHouse(t)
+	client, err := clickhouse.New(clickhouse.Config{URL: cfg.DSN})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
+
+	opts, err := ch.ParseDSN(cfg.DSN)
+	require.NoError(t, err)
+	conn, err := ch.Open(opts)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, conn.Close()) })
+
+	ctx := context.Background()
+	require.NoError(t, conn.Ping(ctx))
+
+	base := time.Now().UTC().Truncate(24 * time.Hour).Add(-24 * time.Hour).UnixMilli()
+
+	ws := uid.New(uid.WorkspacePrefix)
+	resource := uid.New("res")
+	c := newContainer()
+
+	// 9 samples 15s apart, counter +1 CPU-second per step. We query the middle
+	// window [sample2, sample6], so only the deltas fully inside it count.
+	var samples []schema.InstanceCheckpoint
+	for i := 0; i < 9; i++ {
+		samples = append(samples, c.sample(ws, resource, base+int64(i)*sampleGap, sampleValues{
+			cpuUsec:     int64(i) * 1_000_000,
+			memoryBytes: gib,
+			diskBytes:   gib,
+		}))
+	}
+	insertCheckpoints(t, ctx, conn, samples)
+
+	// Window [start, end) = [base+2*gap, base+6*gap). The WHERE filters to the
+	// in-window rows {2,3,4,5} first; the delta is lead() over that filtered
+	// set, so kept pairs are (2,3),(3,4),(4,5) = 3 CPU-seconds. Sample 5's
+	// successor (sample 6) is outside the window, so 5 contributes no delta:
+	// an interval is billed only when both its endpoints fall in-window. At a
+	// month boundary this drops at most one sub-sample interval (~15s) of usage
+	// at the edge, which under-counts rather than over-charges.
+	rows, err := client.GetInstanceMeterUsage(ctx, clickhouse.GetInstanceMeterUsageRequest{
+		WorkspaceID: ws,
+		Start:       base + 2*sampleGap,
+		End:         base + 6*sampleGap,
+	})
+	require.NoError(t, err)
+	u := findUsage(t, rows, resource)
+	require.InDelta(t, 3.0, u.CPUSeconds, 1e-9)
+}

--- a/svc/ctrl/internal/billingmeter/interface.go
+++ b/svc/ctrl/internal/billingmeter/interface.go
@@ -23,8 +23,9 @@ type PushRequest struct {
 }
 
 // MeterValues is the month-to-date usage for one workspace, in the exact units
-// each meter expects. These are sent as decimal strings, so they are kept as
-// floats and never rounded.
+// each meter expects. Values are sent to Stripe as decimal strings: the
+// continuous meters are kept as floats and never rounded, and ActiveKeys is a
+// count, so it stays integral and formats exactly.
 type MeterValues struct {
 	// CPUSeconds is CPU time used, in CPU-seconds.
 	CPUSeconds float64
@@ -34,9 +35,13 @@ type MeterValues struct {
 	EgressGiB float64
 	// DiskGiBSeconds is allocated disk integrated over time, in GiB-seconds.
 	DiskGiBSeconds float64
+	// ActiveKeys is the number of distinct keys verified through the Deploy
+	// gateway this period (month-to-date, like every other meter).
+	ActiveKeys int64
 }
 
 // Positive reports whether any meter has usage worth pushing.
 func (v MeterValues) Positive() bool {
-	return v.CPUSeconds > 0 || v.MemoryGiBSeconds > 0 || v.EgressGiB > 0 || v.DiskGiBSeconds > 0
+	return v.CPUSeconds > 0 || v.MemoryGiBSeconds > 0 || v.EgressGiB > 0 || v.DiskGiBSeconds > 0 ||
+		v.ActiveKeys > 0
 }

--- a/svc/ctrl/internal/billingmeter/stripe.go
+++ b/svc/ctrl/internal/billingmeter/stripe.go
@@ -21,6 +21,7 @@ const (
 	eventMemory = "memory_gib_seconds"
 	eventEgress = "egress_public_gib"
 	eventDisk   = "disk_gib_seconds"
+	eventKeys   = "active_keys"
 )
 
 // payloadKeyCustomer and payloadKeyValue are the meter's
@@ -80,19 +81,24 @@ func NewStripe(secretKey string) Pusher {
 // rejects a duplicate identifier with a hard 400, turning a harmless re-run
 // into a failure.)
 func (p *stripePusher) Push(ctx context.Context, req PushRequest) (int, error) {
+	// Values are pre-rendered so each meter formats in its natural
+	// representation: the continuous meters as bounded decimals, the
+	// active-keys count as an exact integer.
 	meters := []struct {
-		name  string
-		value float64
+		name     string
+		value    string
+		positive bool
 	}{
-		{eventCPU, req.Values.CPUSeconds},
-		{eventMemory, req.Values.MemoryGiBSeconds},
-		{eventEgress, req.Values.EgressGiB},
-		{eventDisk, req.Values.DiskGiBSeconds},
+		{eventCPU, formatMeterValue(req.Values.CPUSeconds), req.Values.CPUSeconds > 0},
+		{eventMemory, formatMeterValue(req.Values.MemoryGiBSeconds), req.Values.MemoryGiBSeconds > 0},
+		{eventEgress, formatMeterValue(req.Values.EgressGiB), req.Values.EgressGiB > 0},
+		{eventDisk, formatMeterValue(req.Values.DiskGiBSeconds), req.Values.DiskGiBSeconds > 0},
+		{eventKeys, strconv.FormatInt(req.Values.ActiveKeys, 10), req.Values.ActiveKeys > 0},
 	}
 
 	pushed := 0
 	for _, m := range meters {
-		if m.value <= 0 {
+		if !m.positive {
 			continue
 		}
 		_, err := p.client.V1BillingMeterEvents.Create(ctx, &stripe.BillingMeterEventCreateParams{
@@ -100,7 +106,7 @@ func (p *stripePusher) Push(ctx context.Context, req PushRequest) (int, error) {
 			Timestamp: stripe.Int64(req.Timestamp),
 			Payload: map[string]string{
 				payloadKeyCustomer: req.StripeCustomerID,
-				payloadKeyValue:    formatMeterValue(m.value),
+				payloadKeyValue:    m.value,
 			},
 		})
 		if err != nil {

--- a/svc/ctrl/worker/cron/deploy_billing_close_integration_test.go
+++ b/svc/ctrl/worker/cron/deploy_billing_close_integration_test.go
@@ -39,8 +39,18 @@ func (f *fakeUsageReader) GetInstanceMeterUsage(
 	return f.rows, nil
 }
 
-// fakePusher records pushes by customer. failFor exercises the defer path.
-// Mutex because the close fans out concurrently.
+// GetActiveKeysUsage returns no active-keys rows: this suite asserts the
+// instance meters and the finalize behavior, not the active-keys meter.
+func (f *fakeUsageReader) GetActiveKeysUsage(
+	_ context.Context,
+	_ clickhouse.GetActiveKeysUsageRequest,
+) ([]clickhouse.ActiveKeysUsage, error) {
+	return nil, nil
+}
+
+// fakePusher records the meter totals it is asked to push, keyed by customer,
+// and can be told to fail for a given customer to exercise the defer path. The
+// push fans out concurrently, so every field is mutex-guarded.
 type fakePusher struct {
 	mu      sync.Mutex
 	pushed  map[string]billingmeter.PushRequest

--- a/svc/ctrl/worker/cron/deploybilling/billing.go
+++ b/svc/ctrl/worker/cron/deploybilling/billing.go
@@ -10,6 +10,7 @@ import (
 // UsageReader is the one ClickHouse query the handler needs.
 type UsageReader interface {
 	GetInstanceMeterUsage(ctx context.Context, req clickhouse.GetInstanceMeterUsageRequest) ([]clickhouse.InstanceMeterUsage, error)
+	GetActiveKeysUsage(ctx context.Context, req clickhouse.GetActiveKeysUsageRequest) ([]clickhouse.ActiveKeysUsage, error)
 }
 
 const (
@@ -47,7 +48,23 @@ func aggregateUsage(rows []clickhouse.InstanceMeterUsage) map[string]billingmete
 			MemoryGiBSeconds: a.memoryGiBHours * secondsPerHour,
 			EgressGiB:        float64(a.egressBytes) / bytesPerGiB,
 			DiskGiBSeconds:   a.diskGiBHours * secondsPerHour,
+			ActiveKeys:       0, // merged in from the active-keys query below
 		}
 	}
 	return out
+}
+
+// mergeActiveKeys folds the per-workspace active-key counts into the meter
+// values, adding entries for workspaces that have key activity but no
+// instance usage (possible: a deployment can be scaled to zero while its
+// keys keep verifying through the gateway).
+func mergeActiveKeys(
+	values map[string]billingmeter.MeterValues,
+	rows []clickhouse.ActiveKeysUsage,
+) {
+	for _, r := range rows {
+		v := values[r.WorkspaceID] // zero value when instance usage is absent
+		v.ActiveKeys = r.ActiveKeys
+		values[r.WorkspaceID] = v
+	}
 }

--- a/svc/ctrl/worker/cron/deploybilling/billing_test.go
+++ b/svc/ctrl/worker/cron/deploybilling/billing_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/unkeyed/unkey/pkg/clickhouse"
+	"github.com/unkeyed/unkey/svc/ctrl/internal/billingmeter"
 )
 
 func TestAggregateUsage(t *testing.T) {
@@ -37,4 +38,21 @@ func TestAggregateUsage(t *testing.T) {
 	t.Run("empty input yields empty map", func(t *testing.T) {
 		require.Empty(t, aggregateUsage(nil))
 	})
+}
+
+func TestMergeActiveKeys(t *testing.T) {
+	values := map[string]billingmeter.MeterValues{
+		"ws_with_usage": {CPUSeconds: 10, MemoryGiBSeconds: 0, EgressGiB: 0, DiskGiBSeconds: 0, ActiveKeys: 0},
+	}
+	mergeActiveKeys(values, []clickhouse.ActiveKeysUsage{
+		{WorkspaceID: "ws_with_usage", ActiveKeys: 5},
+		// Key activity without instance usage: deployment scaled to zero
+		// while its keys keep verifying through the gateway.
+		{WorkspaceID: "ws_keys_only", ActiveKeys: 2},
+	})
+
+	require.Equal(t, int64(5), values["ws_with_usage"].ActiveKeys)
+	require.Equal(t, 10.0, values["ws_with_usage"].CPUSeconds, "existing meters must survive the merge")
+	require.Equal(t, int64(2), values["ws_keys_only"].ActiveKeys)
+	require.True(t, values["ws_keys_only"].Positive())
 }

--- a/svc/ctrl/worker/cron/deploybilling/handler.go
+++ b/svc/ctrl/worker/cron/deploybilling/handler.go
@@ -137,14 +137,26 @@ func (h *Handler) pushUsage(
 		return 0, 0, 0, nil, fmt.Errorf("get period usage: %w", err)
 	}
 
-	if len(rows) == 0 {
+	keyRows, err := restate.Run(ctx, func(rc restate.RunContext) ([]clickhouse.ActiveKeysUsage, error) {
+		return h.usage.GetActiveKeysUsage(rc, clickhouse.GetActiveKeysUsageRequest{
+			WorkspaceID: "", // all workspaces; we filter to billable ones below
+			Year:        p.Year,
+			Month:       p.Month,
+		})
+	}, restate.WithName("get active keys"))
+	if err != nil {
+		return 0, 0, 0, nil, fmt.Errorf("get active keys: %w", err)
+	}
+
+	valuesByWorkspace := aggregateUsage(rows)
+	mergeActiveKeys(valuesByWorkspace, keyRows)
+	if len(valuesByWorkspace) == 0 {
 		logger.Info("no deploy usage this period", "billing_period", period)
 		return 0, 0, 0, nil, nil
 	}
 
-	valuesByWorkspace := aggregateUsage(rows)
-
-	// Stable order for Restate replay.
+	// Sort so the downstream journaled steps (db fetch, per-workspace push)
+	// replay in a stable order.
 	workspaceIDs := make([]string, 0, len(valuesByWorkspace))
 	for id := range valuesByWorkspace {
 		workspaceIDs = append(workspaceIDs, id)

--- a/svc/ctrl/worker/cron/deploybilling/push.go
+++ b/svc/ctrl/worker/cron/deploybilling/push.go
@@ -50,6 +50,7 @@ func (h *Handler) pushAll(ctx restate.ObjectContext, tasks []pushTask) (workspac
 					"stripe_customer_id", task.req.StripeCustomerID,
 					"cpu_seconds", task.req.Values.CPUSeconds,
 					"memory_gib_seconds", task.req.Values.MemoryGiBSeconds,
+					"active_keys", task.req.Values.ActiveKeys,
 					"egress_gib", task.req.Values.EgressGiB,
 					"disk_gib_seconds", task.req.Values.DiskGiBSeconds,
 					"meters_pushed", n,

--- a/web/apps/dashboard/.env.example
+++ b/web/apps/dashboard/.env.example
@@ -57,6 +57,7 @@ STRIPE_LOOKUP_DEPLOY_METER_CPU=
 STRIPE_LOOKUP_DEPLOY_METER_MEMORY=
 STRIPE_LOOKUP_DEPLOY_METER_EGRESS=
 STRIPE_LOOKUP_DEPLOY_METER_DISK=
+STRIPE_LOOKUP_DEPLOY_METER_ACTIVE_KEYS=
 
 # Dev only: create Stripe customers under a test clock so billing can be
 # time-traveled. Advance clocks and fetch invoice PDFs with

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/deploy-product-card.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/deploy-product-card.tsx
@@ -127,6 +127,11 @@ export const DeployProductCard: React.FC<DeployProductCardProps> = ({
           value: `${formatQuantity(usage.diskGiBHours)} GiB-hrs`,
           hint: "Disk reserved over time, in GiB-hours. 1 GiB reserved for 1 hour is 1 GiB-hour. Charged on size reserved, not reads, writes, or space used.",
         },
+        {
+          label: "Active keys",
+          value: formatQuantity(usage.activeKeys),
+          hint: "Distinct keys verified through the Deploy gateway this period.",
+        },
       ]
     : null;
 
@@ -209,7 +214,7 @@ export const DeployProductCard: React.FC<DeployProductCardProps> = ({
               fillClassName="bg-orange-9"
             />
             {meterStats ? (
-              <div className="grid grid-cols-2 gap-px overflow-hidden rounded-lg bg-grayA-3 sm:grid-cols-4">
+              <div className="grid grid-cols-2 gap-px overflow-hidden rounded-lg bg-grayA-3 sm:grid-cols-5">
                 {meterStats.map((stat) => (
                   <div key={stat.label} className="bg-white px-3 py-2 dark:bg-black">
                     <InfoTooltip content={stat.hint} asChild>

--- a/web/apps/dashboard/lib/env.ts
+++ b/web/apps/dashboard/lib/env.ts
@@ -128,6 +128,7 @@ const stripeSchema = z.object({
   STRIPE_LOOKUP_DEPLOY_METER_MEMORY: z.string().optional(),
   STRIPE_LOOKUP_DEPLOY_METER_EGRESS: z.string().optional(),
   STRIPE_LOOKUP_DEPLOY_METER_DISK: z.string().optional(),
+  STRIPE_LOOKUP_DEPLOY_METER_ACTIVE_KEYS: z.string().optional(),
   // Dev/test only: create Stripe customers under a test clock so the billing
   // lifecycle can be time-traveled (advance the clock, invoices finalize for
   // real, PDFs exist). Requires a test-mode key; see

--- a/web/apps/dashboard/lib/stripe/deployBilling.test.ts
+++ b/web/apps/dashboard/lib/stripe/deployBilling.test.ts
@@ -28,6 +28,7 @@ const ID: Record<string, string> = {
   lk_memory: "price_memory",
   lk_egress: "price_egress",
   lk_disk: "price_disk",
+  lk_active_keys: "price_active_keys",
 };
 
 function envWith(overrides: Partial<StripeEnv> = {}): StripeEnv {
@@ -43,6 +44,7 @@ function envWith(overrides: Partial<StripeEnv> = {}): StripeEnv {
     STRIPE_LOOKUP_DEPLOY_METER_MEMORY: "lk_memory",
     STRIPE_LOOKUP_DEPLOY_METER_EGRESS: "lk_egress",
     STRIPE_LOOKUP_DEPLOY_METER_DISK: "lk_disk",
+    STRIPE_LOOKUP_DEPLOY_METER_ACTIVE_KEYS: "lk_active_keys",
     ...overrides,
   };
 }
@@ -61,7 +63,7 @@ function stubStripe() {
 
 const CONFIG: DeployBillingConfig = {
   planFeePriceIds: { starter: "price_starter", pro: "price_pro", business: "price_business" },
-  meteredPriceIds: ["price_cpu", "price_memory", "price_egress", "price_disk"],
+  meteredPriceIds: ["price_cpu", "price_memory", "price_egress", "price_disk", "price_active_keys"],
   allDeployPriceIds: new Set([
     "price_starter",
     "price_pro",
@@ -70,6 +72,7 @@ const CONFIG: DeployBillingConfig = {
     "price_memory",
     "price_egress",
     "price_disk",
+    "price_active_keys",
   ]),
 };
 
@@ -92,8 +95,14 @@ describe("deployBillingConfig", () => {
       pro: "price_pro",
       business: "price_business",
     });
-    expect(c?.meteredPriceIds).toEqual(["price_cpu", "price_memory", "price_egress", "price_disk"]);
-    expect(c?.allDeployPriceIds.size).toBe(7);
+    expect(c?.meteredPriceIds).toEqual([
+      "price_cpu",
+      "price_memory",
+      "price_egress",
+      "price_disk",
+      "price_active_keys",
+    ]);
+    expect(c?.allDeployPriceIds.size).toBe(8);
   });
 
   it("returns null when Stripe is not configured", async () => {
@@ -129,6 +138,7 @@ describe("deploySubscriptionItems", () => {
       { price: "price_memory" },
       { price: "price_egress" },
       { price: "price_disk" },
+      { price: "price_active_keys" },
     ]);
   });
 });

--- a/web/apps/dashboard/lib/stripe/deployBilling.ts
+++ b/web/apps/dashboard/lib/stripe/deployBilling.ts
@@ -44,6 +44,7 @@ export function deployBillingConfigured(): boolean {
     e.STRIPE_LOOKUP_DEPLOY_METER_MEMORY,
     e.STRIPE_LOOKUP_DEPLOY_METER_EGRESS,
     e.STRIPE_LOOKUP_DEPLOY_METER_DISK,
+    e.STRIPE_LOOKUP_DEPLOY_METER_ACTIVE_KEYS,
   ].every(Boolean);
 }
 
@@ -72,6 +73,7 @@ export async function deployBillingConfig(): Promise<DeployBillingConfig | null>
     e.STRIPE_LOOKUP_DEPLOY_METER_MEMORY,
     e.STRIPE_LOOKUP_DEPLOY_METER_EGRESS,
     e.STRIPE_LOOKUP_DEPLOY_METER_DISK,
+    e.STRIPE_LOOKUP_DEPLOY_METER_ACTIVE_KEYS,
   ];
 
   // All-or-nothing: a partially configured set would attach an incomplete

--- a/web/apps/dashboard/lib/trpc/routers/billing/query-deploy-usage/index.ts
+++ b/web/apps/dashboard/lib/trpc/routers/billing/query-deploy-usage/index.ts
@@ -8,6 +8,7 @@ export const queryDeployUsageResponse = z.object({
   memoryGiBHours: z.number(),
   diskGiBHours: z.number(),
   egressGiB: z.number(),
+  activeKeys: z.number(),
 });
 
 export type DeployUsageResponse = z.infer<typeof queryDeployUsageResponse>;
@@ -25,11 +26,20 @@ export const queryDeployUsage = workspaceProcedure
     const monthStart = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1);
 
     try {
-      return await clickhouse.billing.deployMeterUsage({
-        workspaceId: ctx.workspace.id,
-        start: monthStart,
-        end: now.getTime(),
-      });
+      const [meters, keys] = await Promise.all([
+        clickhouse.billing.deployMeterUsage({
+          workspaceId: ctx.workspace.id,
+          start: monthStart,
+          end: now.getTime(),
+        }),
+        clickhouse.billing.activeKeysUsage({
+          workspaceId: ctx.workspace.id,
+          year: now.getUTCFullYear(),
+          // getUTCMonth is 0-based; the query takes a calendar month.
+          month: now.getUTCMonth() + 1,
+        }),
+      ]);
+      return { ...meters, activeKeys: keys.activeKeys };
     } catch (err) {
       console.error("Failed to query deploy usage", err);
       throw new TRPCError({

--- a/web/internal/clickhouse/src/deploy_billing.ts
+++ b/web/internal/clickhouse/src/deploy_billing.ts
@@ -83,3 +83,51 @@ export function getDeployMeterUsage(ch: Querier) {
     );
   };
 }
+
+export const activeKeysUsage = z.object({
+  activeKeys: z.number(),
+});
+
+export type ActiveKeysUsage = z.infer<typeof activeKeysUsage>;
+
+/**
+ * Distinct keys verified through the Deploy gateway (source = 'gateway') in
+ * the billing month, regardless of outcome: a RATE_LIMITED or DISABLED
+ * verification is still work done for that key. Mirrors GetActiveKeysUsage in
+ * pkg/clickhouse, the authoritative billing query. Display-only.
+ */
+export function getActiveKeysUsage(ch: Querier) {
+  return async (args: {
+    workspaceId: string;
+    /** Calendar year of the billing month. */
+    year: number;
+    /** Calendar month, 1-12. */
+    month: number;
+  }): Promise<ActiveKeysUsage> => {
+    const query = ch.query({
+      query: `
+        SELECT toInt64(uniqExact(key_id)) AS activeKeys
+        FROM default.key_verifications_per_month_v3
+        WHERE time = makeDate({year: Int32}, {month: Int32}, 1)
+          AND source = 'gateway'
+          AND workspace_id = {workspaceId: String}
+      `,
+      params: z.object({
+        workspaceId: z.string(),
+        year: z.number().int(),
+        month: z.number().int().min(1).max(12),
+      }),
+      schema: activeKeysUsage,
+    });
+
+    const result = await query({
+      workspaceId: args.workspaceId,
+      year: args.year,
+      month: args.month,
+    });
+    if (result.err) {
+      throw new Error(`Failed to fetch active keys usage: ${result.err.message}`);
+    }
+    return result.val.at(0) ?? { activeKeys: 0 };
+  };
+}

--- a/web/internal/clickhouse/src/index.ts
+++ b/web/internal/clickhouse/src/index.ts
@@ -1,8 +1,13 @@
 import { getAuditLogs } from "./audit-logs";
 import { getBillableRatelimits, getBillableVerifications } from "./billing";
 import { getBuildStepLogs, getBuildSteps } from "./build-steps";
-import { getDeployMeterUsage } from "./deploy_billing";
-export { type DeployMeterUsage, deployMeterUsage } from "./deploy_billing";
+import { getActiveKeysUsage, getDeployMeterUsage } from "./deploy_billing";
+export {
+  type ActiveKeysUsage,
+  activeKeysUsage,
+  type DeployMeterUsage,
+  deployMeterUsage,
+} from "./deploy_billing";
 import { Client, type Inserter, Noop, type Querier } from "./client";
 import { getInstanceEvents } from "./instance-events";
 export { instanceEventKind, type InstanceEventKind } from "./instance-events";
@@ -294,6 +299,7 @@ export class ClickHouse {
       billableVerifications: getBillableVerifications(this.querier),
       billableRatelimits: getBillableRatelimits(this.querier),
       deployMeterUsage: getDeployMeterUsage(this.querier),
+      activeKeysUsage: getActiveKeysUsage(this.querier),
     };
   }
   public get api() {


### PR DESCRIPTION
## Summary

We need to trust the Deploy meter query before real invoices go out. This PR adds fixture tests that pin the query to a hand-computed bill ($0.06387555 for a one-hour workload), and a `dev stripe shadow` command that recomputes month-to-date usage from ClickHouse and diffs it against what Stripe has on each meter.

Stacked on ENG-2897 (#6450).

## Fixture tests (`pkg/clickhouse`)

`TestMeterUsageHandComputedBill` seeds one container at 1 vCPU, 2 GiB RAM, 10 GiB disk for exactly one hour, plus 240 MiB egress. It runs the production billing query, converts to meter units the same way the worker does, and checks the result against catalog rates from Terraform.

`TestMeterUsageStraddlesWindow` covers the month-boundary case. Samples outside `[Start, End)` do not contribute deltas. At most one sub-sample interval (~15s) drops at the edge, and that under-counts rather than over-charges.

## Shadow command

```bash
mise run unkey -- dev stripe shadow --workspace ws_... --customer cus_... [--month YYYY-MM]
```

Recomputes usage for the billing month from ClickHouse, fetches Stripe meter summaries for the same window, and prints a per-meter diff. Exits non-zero when any meter drifts beyond 0.1%. That tolerance is intentional. The hourly push can lag the live query by up to an hour.

## Test plan

```bash
mise exec -- bazel test //pkg/clickhouse:clickhouse_test
mise exec -- bazel test //cmd/dev/stripe:stripe_test
```

Manual check before launch:

1. Seed or checkpoint usage for a workspace in local ClickHouse.
2. Run the hourly push:

```bash
curl -X POST "http://localhost:8080/hydra.v1.CronService/$(date -u +%Y-%m)/RunDeployBillingPush/send"
```

3. Shadow should show all meters within tolerance:

```bash
mise run unkey -- dev stripe shadow --workspace ws_... --customer cus_...
```

4. Advance the test clock past month end and confirm close finalizes the invoice:

```bash
mise run unkey -- dev stripe clock advance --customer cus_...
```

Local setup: `mise run dev`, `stripe login`, Stripe env vars per `dev/.env.stripe.example`.