### PR TITLE
fix(ratelimit): emit counters after remote sync

### DIFF
--- a/internal/services/ratelimit/global.go
+++ b/internal/services/ratelimit/global.go
@@ -101,13 +101,13 @@ func (s *service) runGlobalPushOnce() {
 		if val <= 0 {
 			return true
 		}
-		// shouldPushGlobalCount gates on both the observed threshold and
-		// the change filter. Pull-created entries with no local traffic
-		// have no threshold; quiet entries with unchanged val fail the
-		// lastPushed comparison. The lastPushed comparison uses `<`
-		// (i.e. val > lastPushed inside shouldPushGlobalCount) so a
-		// transient regression from a RatelimitMany rollback doesn't leak
-		// a write that the receiver's GREATEST would no-op anyway.
+		// shouldPushGlobalCount always applies the change filter, then either
+		// accepts remote-aware entries or requires the observed threshold.
+		// Pull-created entries with no local traffic have no val; quiet entries
+		// with unchanged val fail the lastPushed comparison. The lastPushed
+		// comparison uses `<` (i.e. val > lastPushed inside shouldPushGlobalCount)
+		// so a transient regression from a RatelimitMany rollback doesn't leak a
+		// write that the receiver's GREATEST would no-op anyway.
 		if !entry.shouldPushGlobalCount(val) {
 			return true
 		}

--- a/internal/services/ratelimit/global_integration_test.go
+++ b/internal/services/ratelimit/global_integration_test.go
@@ -464,6 +464,64 @@ func TestGlobal_AtFloorPushes(t *testing.T) {
 	require.Equal(t, uint64(2), row.Count, "row count must reflect the at-floor utilization")
 }
 
+// TestGlobal_RemoteEmitForcesLocalSubFloorPush covers ENG-2903: skewed multi-region
+// traffic: once one region has published a global counter for a cell, another
+// region must publish any non-zero local contribution for the same cell instead
+// of waiting for its own utilization floor.
+func TestGlobal_RemoteEmitForcesLocalSubFloorPush(t *testing.T) {
+	t.Parallel()
+
+	env := newIntegrationTestEnv(t)
+	clk := clock.NewTestClock()
+	regionA := env.newRegionAs(clk, "region-a")
+	regionB := env.newRegionAs(clk, "region-b")
+
+	const (
+		workspaceID = "ws_test"
+		namespace   = "ns"
+		identifier  = "user-skewed"
+		limit       = int64(10)
+	)
+	duration := time.Minute
+	ctx := context.Background()
+
+	makeReq := func() RatelimitRequest {
+		return RatelimitRequest{
+			WorkspaceID: workspaceID,
+			Namespace:   namespace,
+			Identifier:  identifier,
+			Limit:       limit,
+			Duration:    duration,
+			Cost:        1,
+			Time:        clk.Now(),
+		}
+	}
+
+	// A crosses the normal floor and emits. B imports that row before it sees
+	// enough local traffic to cross its own floor.
+	for range 6 {
+		resp, err := regionA.Ratelimit(ctx, makeReq())
+		require.NoError(t, err)
+		require.True(t, resp.Success)
+	}
+	regionA.runGlobalPushOnce()
+	env.waitForRow(workspaceID, namespace, identifier, "region-a", duration.Milliseconds())
+
+	regionB.runGlobalPullOnce()
+	regionB.runGlobalPushOnce()
+	require.False(t, env.hasRow(workspaceID, namespace, identifier, "region-b", duration.Milliseconds()),
+		"import alone must not emit a zero-local row")
+
+	resp, err := regionB.Ratelimit(ctx, makeReq())
+	require.NoError(t, err)
+	require.True(t, resp.Success)
+
+	regionB.runGlobalPushOnce()
+	row := env.waitForRow(workspaceID, namespace, identifier, "region-b", duration.Milliseconds())
+	require.Equal(t, uint64(1), row.Count,
+		"remote emission must force B to publish below its normal utilization floor")
+}
+
 // TestGlobal_SyncKeepsOwnRegionOutOfGlobalCount asserts that a region's own
 // MySQL row merges into regional val, not globalCount. Folding own traffic into
 // globalCount would double-count it because sliding-window math already adds

--- a/internal/services/ratelimit/service.go
+++ b/internal/services/ratelimit/service.go
@@ -169,14 +169,24 @@ func (e *counterEntry) observeGlobalPushLimit(limit int64) {
 	logger.Error("global push threshold update retries exhausted")
 }
 
-// shouldPushGlobalCount is true when the entry's live local count has reached
-// the observed global-push threshold and grown past what we last successfully
-// pushed. Both checks are necessary: the threshold excludes pull-created or
-// low-utilization entries; lastPushed excludes entries with no new state to
-// share.
+// shouldPushGlobalCount reports whether the entry's local count should be
+// shared through ratelimit_global_counters.
 func (e *counterEntry) shouldPushGlobalCount(val int64) bool {
+	// If the counter hasn't increased, there's nothing to push.
+	if val <= e.lastPushed.Load() {
+		return false
+	}
+
+	// Once another region has emitted this cell, any changed local count matters
+	// globally and should not wait for this region's utilization floor.
+	if e.globalCount.Load() > 0 {
+		return true
+	}
+
+	// Without imported remote count, keep the normal floor so pull-created or
+	// low-utilization entries do not create unnecessary MySQL writes.
 	threshold := e.globalPushThreshold.Load()
-	return threshold > 0 && val >= threshold && val > e.lastPushed.Load()
+	return threshold > 0 && val >= threshold
 }
 
 // EnsureFreshFromOrigin populates val from origin on first use and refreshes


### PR DESCRIPTION
Fixes imbalanced traffic patterns, where an identifier exceeds less than 20% of its limit in one region.
Previously that region would not emit counters globally and therefore other regions couldn't factor this into their calculations.

Now if any region publishes counters, that triggers all other regions to also publish it, regardless of their threshold.
So if an identifier exceeds 20% of their limit in one region, now all regions converge on the next sync-cycle