### PR TITLE
docs: clarify testing standards

### DIFF
--- a/docs/engineering/contributing/quality/code-quality.mdx
+++ b/docs/engineering/contributing/quality/code-quality.mdx
@@ -105,6 +105,8 @@ Comments are sentences. Start with a capital letter and end with a period. Comme
 
 For documentation guidance, see [Documentation](/contributing/quality/documentation).
 
+Test docstrings and comments follow the same rule. They explain the guarantee a test protects, especially for security properties, regressions, invariants, and business rules. They do not repeat the mechanics of setup or assertions.
+
 ### Function length
 
 Keep functions short. If a function does not fit on a screen, it is probably doing too much. Aim for functions under 50 lines. If a function grows to 200 lines, step back and consider whether it should be broken up.

--- a/docs/engineering/contributing/quality/documentation.mdx
+++ b/docs/engineering/contributing/quality/documentation.mdx
@@ -21,7 +21,7 @@ Before submitting documentation, verify each item.
 - [ ] Constraints documented are enforced, and the docs note when and how
 
 **Completeness**
-- [ ] Every exported symbol has a doc comment
+- [ ] Every symbol has a doc comment
 - [ ] Package has a `doc.go` if it has non-trivial behavior
 - [ ] Non-obvious behavior is documented (edge cases, nil handling, concurrency)
 - [ ] The why is explained for design choices that are not self-evident
@@ -97,6 +97,8 @@ func Validate(req *Request) []ValidationError
 ## Public API documentation
 
 Every exported function, type, constant, and variable must be documented. This is the contract with users of the code.
+
+Unexported functions and methods must be documented too. They have no external contract, but the next reader still needs to know what they do and why they exist without reverse-engineering the body. A single sentence is usually enough.
 
 The depth of documentation should match complexity. A simple getter needs one line. A distributed algorithm needs paragraphs.
 

--- a/docs/engineering/contributing/quality/testing/anti-patterns.mdx
+++ b/docs/engineering/contributing/quality/testing/anti-patterns.mdx
@@ -9,7 +9,33 @@ Do not use `time.Sleep` to wait for async work. Use `require.Eventually` or a te
 
 ## Testing implementation details
 
-Verify public behavior, not internal fields. Refactors should not break tests when behavior is unchanged.
+Verify public behavior, not internal fields. Refactors must not break tests when behavior is unchanged.
+
+## Treating tests as throwaway code
+
+Tests are production code. Do not accept unclear names, hidden setup, flaky timing, duplicated fixtures, unsafe casts, ignored errors, or comments that would be rejected in application code.
+
+## Hiding the guarantee
+
+Do not make readers infer the guarantee from setup and assertions alone. Use a precise test name, table case name, and docstring when the protected behavior is not obvious.
+
+```go
+// Bad: the guarantee is hidden.
+func TestAuth(t *testing.T) {
+    // ...
+}
+
+// Good: the guarantee is explicit.
+// TestAuthRejectsRevokedRootKeys guarantees that revoked credentials cannot be
+// used after revocation has been persisted.
+func TestAuthRejectsRevokedRootKeys(t *testing.T) {
+    // ...
+}
+```
+
+## Bypassing `pkg/fuzz`
+
+Fuzz tests must use `pkg/fuzz`. Do not fuzz typed parameters directly, use ad hoc byte slicing, or introduce separate randomness with `math/rand`. Use `fuzz.Seed(f)`, `fuzz.New(t, data)`, and the consumer helpers so every generated value remains controlled by the fuzzer.
 
 ## Shared mutable state
 

--- a/docs/engineering/contributing/quality/testing/fuzz-tests.mdx
+++ b/docs/engineering/contributing/quality/testing/fuzz-tests.mdx
@@ -7,7 +7,11 @@ description: "Finding edge cases with randomized inputs"
 
 Fuzz testing feeds random inputs to your code and watches for crashes, panics, or assertion failures. It finds bugs that humans do not think to test for, such as malformed UTF-8, integer overflows, and nil pointer dereferences.
 
-Go has built-in fuzzing since Go 1.18. You write a fuzz test, provide seed inputs, and the fuzzer mutates those seeds to explore the input space. When it finds a failure, it saves that input so the bug becomes a regression test.
+Go has built-in fuzzing since Go 1.18. Unkey fuzz tests must use `pkg/fuzz` on top of Go's native fuzzing API. `pkg/fuzz` provides deterministic seeds and converts fuzzer-controlled byte slices into typed values without hiding inputs from the coverage-guided fuzzer.
+
+Every fuzz test must call `fuzz.Seed(f)`, accept `data []byte`, create a `fuzz.Consumer` with `fuzz.New(t, data)`, and derive generated values from that consumer. Do not fuzz typed parameters directly, and do not use `math/rand` or ad hoc byte slicing inside fuzz tests.
+
+When the fuzzer finds a failure, Go saves that input so the bug becomes a regression test.
 
 ## When to write fuzz tests
 
@@ -17,14 +21,21 @@ They are less useful for business logic with complex preconditions.
 
 ## Writing your first fuzz test
 
-```go
-func FuzzParseConfig(f *testing.F) {
-    f.Add(`{"timeout": "30s"}`)
-    f.Add(`{"timeout": "0s", "retries": 0}`)
-    f.Add(`{}`)
-    f.Add(`not json at all`)
+Start a fuzz test by naming the property it protects. Seed inputs are examples of the property, not the property itself. Add a docstring when the property is a security boundary, parser invariant, or regression from a production bug.
 
-    f.Fuzz(func(t *testing.T, input string) {
+```go
+import "github.com/unkeyed/unkey/pkg/fuzz"
+
+// FuzzParseConfigPreservesTimeoutBounds guarantees that every accepted config
+// produces a non-negative timeout. Invalid config may be rejected, but accepted
+// config must be safe to execute.
+func FuzzParseConfig(f *testing.F) {
+    fuzz.Seed(f)
+
+    f.Fuzz(func(t *testing.T, data []byte) {
+        c := fuzz.New(t, data)
+        input := c.String()
+
         cfg, err := ParseConfig(input)
         if err != nil {
             return
@@ -38,7 +49,7 @@ func FuzzParseConfig(f *testing.F) {
 
 ## Skipping invalid inputs
 
-Use `t.Skip()` for inputs that do not meet required preconditions.
+Use `t.Skip()` for inputs that do not meet required preconditions. `pkg/fuzz` also calls `t.Skip()` when the consumer runs out of bytes, which keeps every generated value tied to fuzzer-controlled input.
 
 ```go
 if len(key) != 16 && len(key) != 24 && len(key) != 32 {
@@ -49,6 +60,8 @@ if len(key) != 16 && len(key) != 24 && len(key) != 32 {
 ## Testing security properties
 
 Use fuzzing to validate tamper detection and authentication guarantees.
+
+Document security properties in the fuzz test docstring. A future reader must know whether the fuzzer protects parser safety, signature verification, canonical encoding, authorization boundaries, or another guarantee.
 
 ## Running fuzz tests
 
@@ -72,4 +85,4 @@ Write a deterministic unit test for the failing input, then fix the bug. Keep th
 
 ## Bazel configuration
 
-Fuzz tests live in regular `go_test` targets and include the fuzz corpus with `data = glob(["testdata/**"])`.
+Fuzz tests live in regular `go_test` targets. Add `//pkg/fuzz` to the target dependencies, and include the fuzz corpus with `data = glob(["testdata/**"])` when the test has saved failure inputs.

--- a/docs/engineering/contributing/quality/testing/http-handler-tests.mdx
+++ b/docs/engineering/contributing/quality/testing/http-handler-tests.mdx
@@ -7,7 +7,9 @@ description: "Testing API endpoints with the test harness"
 
 HTTP handler tests exercise API endpoints from request to response. A single request might authenticate a user, check permissions, validate input, query a database, update a cache, and write an audit log. Testing handlers end to end catches bugs that unit tests miss.
 
-Every handler should have tests for success, validation errors, authentication errors, and authorization errors.
+Every handler must have tests for success, validation errors, authentication errors, and authorization errors.
+
+Each handler test must make the API guarantee visible. The reader must know which contract the endpoint promises, which client-visible response is expected, and which side effects are required or forbidden.
 
 ## Anatomy of a handler test
 
@@ -59,13 +61,19 @@ Test minimal requests, full requests, and any important variations. Verify side 
 
 Test boundary conditions, missing required fields, and invalid formats. These tests document the API contract.
 
+Use test names and docstrings to identify the contract. For example, document whether invalid input must return `400`, whether the error code is stable for SDKs, and whether the handler must avoid writing partial state.
+
 ## Testing authentication
 
 Reject missing headers, malformed tokens, and revoked credentials.
 
+Authentication tests protect security guarantees. Document the guarantee when a case covers token confusion, revoked credentials, replay behavior, or information disclosure.
+
 ## Testing authorization
 
 Verify that permissions are enforced and cross-workspace access is rejected.
+
+Authorization tests must state the resource boundary they protect. If a response intentionally hides existence with `404`, document that behavior in the test so future changes do not weaken it by accident.
 
 ## Helper functions
 

--- a/docs/engineering/contributing/quality/testing/index.mdx
+++ b/docs/engineering/contributing/quality/testing/index.mdx
@@ -9,6 +9,23 @@ Tests exist to give confidence. Confidence to ship changes quickly, confidence t
 
 We prioritize quality over quantity. A single well-designed test that validates complex business logic is worth more than a dozen tests that exercise trivial code paths. When writing tests, ask what could go wrong in production that this test would catch.
 
+Treat test code as production code. Tests are part of the system contract, not a safety net added after implementation. They must be readable, typed, deterministic, reviewed with the same care as application code, and maintained when behavior changes.
+
+Every test must make its guarantee clear to the reader. The guarantee is the production behavior that would break if the test failed. A future reader must be able to understand what risk the test covers without reverse engineering setup, mocks, or fixtures.
+
+Document non-obvious guarantees with docstrings or comments. Use them when a test protects a security property, regression, invariant, concurrency condition, failure mode, or business rule that the test name cannot fully explain.
+
+```go
+// TestTokenParserRejectsAlgorithmConfusion guarantees that tokens signed with
+// one algorithm cannot be accepted under another algorithm. This protects the
+// verifier from accepting attacker-controlled headers as trusted policy.
+func TestTokenParserRejectsAlgorithmConfusion(t *testing.T) {
+    // ...
+}
+```
+
+Do not document obvious mechanics. A comment that says "creates a workspace" above `createWorkspace(t)` adds noise. A comment that explains why cross-workspace access must return 404 instead of 403 documents a guarantee.
+
 ## What to test
 
 Invest testing effort where bugs would hurt most.
@@ -49,7 +66,9 @@ Tests live alongside the code they test. A file `cache.go` has its tests in `cac
 
 For integration tests that require substantial setup or external dependencies, create an `integration/` subdirectory when it improves clarity.
 
-Bazel requires each test target to declare a size that determines its timeout and resource allocation. Unit tests should be `small`. Integration tests that spin up containers should be `large`.
+Organize tests around guarantees, not implementation details. File names, test names, table cases, and helper names must help a reader answer which behavior is protected and why it matters.
+
+Bazel requires each test target to declare a size that determines its timeout and resource allocation. Unit tests must be `small`. Integration tests that spin up containers must be `large`.
 
 ```python
 go_test(

--- a/docs/engineering/contributing/quality/testing/integration-tests.mdx
+++ b/docs/engineering/contributing/quality/testing/integration-tests.mdx
@@ -7,6 +7,17 @@ description: "Testing components with real dependencies"
 
 Use integration tests to cover behavior across service boundaries, real databases, caches, and storage. These tests catch failures that mocks miss.
 
+Integration tests must document the cross-boundary guarantee they protect. Make it clear which production contract would be broken if the test failed, such as transaction rollback, idempotency, permission propagation, cache invalidation, or persistence after restart.
+
+```go
+// TestCreateKeyRollsBackAuditLogOnDatabaseFailure guarantees that key creation
+// and audit logging remain atomic. Operators must not see an audit log for a
+// key that was never committed.
+func TestCreateKeyRollsBackAuditLogOnDatabaseFailure(t *testing.T) {
+    // ...
+}
+```
+
 ## Container patterns
 
 Use `pkg/testutil/containers` for isolated, per-test containers. Helpers register cleanup with `t.Cleanup` immediately after creating a container, so failed readiness checks don't leak resources. Run tests that use these helpers through Bazel so schema runfiles are available.
@@ -23,6 +34,8 @@ Use `pkg/testutil` when you need a full service graph and seeded data:
 h := testutil.NewHarness(t)
 workspace := h.CreateWorkspace()
 ```
+
+Keep harness setup explicit when it affects the guarantee. Do not hide permissions, feature flags, tenants, or seeded records behind generic helpers unless the helper name or docstring explains the resulting system state.
 
 ## Bazel sizing
 

--- a/docs/engineering/contributing/quality/testing/simulation-tests.mdx
+++ b/docs/engineering/contributing/quality/testing/simulation-tests.mdx
@@ -9,6 +9,8 @@ Example tests verify specific inputs and outputs. Simulation tests verify invari
 
 Unkey uses `pkg/sim` for simulation testing.
 
+Simulation tests must document the invariant they protect. Random events can obscure intent, so the test docstring and validator names must state the production guarantee directly.
+
 ## The mental model
 
 A simulation has state, events, and validators.
@@ -42,6 +44,9 @@ func (e *setEvent) Run(rng *rand.Rand, s *state) error {
 ## Running the simulation
 
 ```go
+// TestCacheSimulation guarantees that cache operations preserve basic cache
+// invariants across random event orderings. No event may leave the cache in a
+// nil or unreadable state.
 func TestCacheSimulation(t *testing.T) {
     seed := sim.NewSeed()
 
@@ -76,7 +81,9 @@ When a simulation fails, save the seed and rerun with `sim.SeedFromString` to re
 
 ## Writing effective events
 
-Events should be self-contained and valid regardless of current state. If preconditions are not met, return early.
+Events must be self-contained and valid regardless of current state. If preconditions are not met, return early.
+
+Name events and validators after domain behavior. `rejectExpiredKeyValidator` is clearer than `validator1` because it tells the reader which guarantee failed.
 
 ## When to use simulations
 

--- a/docs/engineering/contributing/quality/testing/unit-tests.mdx
+++ b/docs/engineering/contributing/quality/testing/unit-tests.mdx
@@ -37,6 +37,19 @@ Use individual tests when setup or assertions diverge meaningfully.
 
 Name test functions `Test<Type>_<Behavior>` or `Test<Function>_<Scenario>`. Name table cases so failures read like a sentence.
 
+Prefer names that state the guarantee under test. `TestParseURN_RejectsCrossWorkspaceResources` is better than `TestParseURN_InvalidInput` because it tells the reader which production boundary the test protects.
+
+Add a docstring when the guarantee is not obvious from the name. Use the docstring to explain the invariant, regression, or business rule, not the steps the test performs.
+
+```go
+// TestAuthorizeRejectsCrossWorkspaceAccess guarantees that a valid key from one
+// workspace cannot authorize reads in another workspace. Returning not found
+// prevents callers from discovering that the target resource exists.
+func TestAuthorizeRejectsCrossWorkspaceAccess(t *testing.T) {
+    // ...
+}
+```
+
 ## Parallel execution
 
 Use `t.Parallel()` only when tests do not share mutable state or external resources.
@@ -45,9 +58,13 @@ Use `t.Parallel()` only when tests do not share mutable state or external resour
 
 Helpers that assert must call `t.Helper()`. Use `t.Cleanup()` for resource cleanup so subtests complete before cleanup runs.
 
+Helpers are production test APIs. Keep them small, typed, and named after the domain object or state they create. If a helper hides important setup, document the guarantee it establishes for callers.
+
 ## Test data
 
 Inline small fixtures. Use `testdata/` for larger files and include them in Bazel targets.
+
+Name fixtures by the behavior they exercise. A fixture named `expired_root_key.json` is better than `case_3.json` because it carries the test guarantee into the filesystem.
 
 ## Time-dependent logic
 


### PR DESCRIPTION
## Summary
- clarify that tests should document the guarantee they protect
- add guidance for test names, docstrings, helpers, fixtures, and handler authorization checks
- document the expected pkg/fuzz pattern for fuzz tests

## Verification
- Reviewed staged docs diff
- Attempted `mise exec -- dprint check --config dev/dprint.json docs/engineering/contributing/quality`; no MDX files matched the configured dprint plugins