### PR TITLE
chore(db): narrow JSON unmarshal inputs

### DIFF
--- a/pkg/db/custom_types.go
+++ b/pkg/db/custom_types.go
@@ -66,8 +66,6 @@ func UnmarshalNullableJSONTo[T any](data any) (T, error) {
 	switch v := data.(type) {
 	case []byte:
 		bytes = v
-	case json.RawMessage:
-		bytes = v
 	case string:
 		bytes = []byte(v)
 	default:


### PR DESCRIPTION
## Summary
- remove the explicit `json.RawMessage` case from `UnmarshalNullableJSONTo`
- keep database JSON decoding limited to the driver shapes this helper documents: `[]byte` and `string`

## Verification
- `mise exec -- bazel test //pkg/db:db_test`