### PR TITLE
feat(rbac): add resource names and permissions

### DIFF
--- a/docs/engineering/architecture/authorization/resource-permissions.mdx
+++ b/docs/engineering/architecture/authorization/resource-permissions.mdx
@@ -1,0 +1,353 @@
+---
+title: "Resource permissions"
+description: "Authorization permissions built from Unkey Resource Names"
+---
+
+Resource permissions attach an action to a Unkey Resource Name. They are the
+canonical authorization primitive for root keys, users, service tokens, and any
+other principal that needs scoped access to Unkey resources.
+
+The resource portion follows the [Unkey Resource Names](/architecture/resources/unkey-resource-names)
+contract, including resource-name patterns and their matching semantics. The
+permission layer adds only the action suffix.
+
+Resource parsing and pattern matching, the rules deciding whether a stored
+resource pattern covers a requested concrete URN, live in
+[`pkg/urn`](https://github.com/unkeyed/unkey/tree/main/pkg/urn). Action
+validation and permission evaluation live in
+[`pkg/rbac`](https://github.com/unkeyed/unkey/tree/main/pkg/rbac), which
+delegates resource comparison to `pkg/urn` instead of defining its own.
+
+Creation actions live on the nearest parent resource that already exists when
+the operation runs. For example, `create_key` applies to the keyspace, while
+`read_key`, `update_key`, and `delete_key` apply to concrete key resources or
+key-resource patterns. This avoids inventing collection URNs only for create
+operations.
+
+Top-level resources are the exception. Their parent is the workspace itself,
+which isn't an expressible resource path in `v1`. For those actions, use the
+top-level collection wildcard as the closest expressible scope. For example,
+`create_keyspace` uses `keyspaces/*`, and `create_role` uses `rbac/roles/*`.
+
+## Format
+
+A permission has a URN, a `#` separator, and an action.
+
+```plaintext
+unkey:v1:{workspace_id}:{resource_path}#{action}
+```
+
+For example:
+
+```plaintext
+unkey:v1:ws_123:keyspaces/ks_123#read_keyspace
+unkey:v1:ws_123:keyspaces/ks_123#create_key
+unkey:v1:ws_123:keyspaces/ks_123/keys/key_456#delete_key
+unkey:v1:ws_123:projects/proj_123/apps/app_456#update_app
+```
+
+The action is not part of the URN. Code that evaluates permissions must parse
+the resource and action separately.
+
+## Actions
+
+Actions are explicit operation names. They use lowercase words separated by
+underscores.
+
+```plaintext
+read_keyspace
+create_key
+delete_deployment
+add_role
+remove_permission
+```
+
+Most permissions name one explicit action. The only action wildcard is `*`,
+which is reserved for the `admin:*` migration escape hatch and is valid only on
+the global resource pattern `**`. There is no shorter global form: `*` matches
+exactly one path segment everywhere it appears, so only `**` covers every
+resource in a workspace.
+
+```plaintext
+unkey:v1:ws_123:**#*
+```
+
+Do not add action wildcards to normal product permissions.
+
+## Create actions
+
+Create actions authorize the parent resource that receives the child resource.
+Handlers must query the parent resource because the child ID may not exist until
+after the operation succeeds.
+
+For example, creating a key in a keyspace uses the keyspace resource:
+
+```plaintext
+unkey:v1:ws_123:keyspaces/ks_123#create_key
+```
+
+Creating nested deploy resources follows the same parent-resource rule:
+
+```plaintext
+unkey:v1:ws_123:projects/proj_123#create_app
+unkey:v1:ws_123:projects/proj_123/apps/app_456#create_environment
+unkey:v1:ws_123:projects/proj_123/apps/app_456/environments/env_789#create_deployment
+unkey:v1:ws_123:projects/proj_123/apps/app_456/environments/env_789#create_domain
+unkey:v1:ws_123:projects/proj_123/apps/app_456/environments/env_789#create_variable
+```
+
+The same parent can still hold non-create actions that target the parent itself,
+such as `read_keyspace` on `keyspaces/ks_123`. The action name determines which
+operation is authorized.
+
+Top-level create actions target the collection wildcard because there is no
+workspace resource path to attach the action to:
+
+```plaintext
+unkey:v1:ws_123:keyspaces/*#create_keyspace
+unkey:v1:ws_123:rbac/roles/*#create_role
+```
+
+Go handlers can pass typed URN builders directly to `rbac.U` when the builder
+represents the parent resource. Use typed actions from `pkg/rbac/permissions`,
+where action structs are split by resource type:
+
+```go
+import "github.com/unkeyed/unkey/pkg/rbac/permissions"
+
+rbac.U(
+	urn.New().Workspace(workspaceID).Keyspace(keyspaceID),
+	permissions.CreateKey{},
+)
+
+rbac.U(
+	urn.New().Workspace(workspaceID).Project(projectID),
+	permissions.CreateApp{},
+)
+
+rbac.U(
+	urn.New().Workspace(workspaceID).Project(projectID).App(appID),
+	permissions.CreateEnvironment{},
+)
+```
+
+## Patterns
+
+Stored permissions can contain resource patterns. Requested resources in audit
+logs and authorization checks must always use concrete URNs.
+
+`v1` supports two resource-pattern operators.
+
+| Operator | Meaning |
+| --- | --- |
+| `*` | Matches exactly one complete path segment. |
+| `/**` | Matches descendants below the preceding path. |
+
+The `/**` operator is valid only at the end of a resource path. It matches the
+path before `/**` and all descendants below that path.
+
+After a resource path uses `*` for an ID selector, every descendant ID selector
+must also use `*`. A permission can continue through child collection segments,
+but it can't select a specific child under a wildcard parent.
+
+Valid:
+
+```plaintext
+unkey:v1:ws_123:projects/*/apps/*#read_app
+unkey:v1:ws_123:projects/*/apps/*/environments/*/deployments/*#read_deployment
+```
+
+Invalid:
+
+```plaintext
+unkey:v1:ws_123:projects/*/apps/app_123#read_app
+unkey:v1:ws_123:projects/proj_123/apps/*/environments/env_123#read_environment
+```
+
+## Matching rules
+
+Permission evaluation compares a requested `{resource, action}` tuple with the
+permissions assigned to the principal.
+
+A permission matches when all rules are true:
+
+1. The version matches.
+2. The workspace ID matches.
+3. The resource path matches exactly or by a valid resource pattern.
+4. The action matches exactly.
+
+The matcher is segment-aware. It must split resource paths on `/` before
+matching wildcards. Rules 2 and 3, workspace and resource matching, are
+implemented by `pkg/urn`; `pkg/rbac` parses the action suffix and adds rule 4.
+
+For example, this permission:
+
+```plaintext
+unkey:v1:ws_123:keyspaces/*/keys/*#read_key
+```
+
+matches this request:
+
+```plaintext
+unkey:v1:ws_123:keyspaces/ks_123/keys/key_456#read_key
+```
+
+It does not match these requests:
+
+```plaintext
+unkey:v1:ws_123:keyspaces/ks_123#read_key
+unkey:v1:ws_123:keyspaces/ks_123/keys/key_456#delete_key
+unkey:v1:ws_123:keyspaces/ks_123/keys/key_456#update_key
+```
+
+## Descendant grants
+
+Use trailing `/**` when a permission must apply to any public descendant of a
+resource.
+
+This permission grants `delete_deployment` for deployments below one project:
+
+```plaintext
+unkey:v1:ws_123:projects/proj_123/**#delete_deployment
+```
+
+It matches:
+
+```plaintext
+unkey:v1:ws_123:projects/proj_123/apps/app_456/environments/env_789/deployments/d_abc#delete_deployment
+```
+
+It also matches the project itself:
+
+```plaintext
+unkey:v1:ws_123:projects/proj_123#delete_deployment
+```
+
+It also does not grant unrelated actions on descendants:
+
+```plaintext
+unkey:v1:ws_123:projects/proj_123/apps/app_456#delete_app
+```
+
+The action still has to match exactly.
+
+## Common permissions
+
+These examples show how broad and narrow permissions use the same grammar.
+
+<AccordionGroup>
+  <Accordion title="Delete one deployment">
+
+    ```plaintext
+    unkey:v1:ws_123:projects/proj_123/apps/app_456/environments/env_789/deployments/d_abc#delete_deployment
+    ```
+
+  </Accordion>
+  <Accordion title="Delete deployments in one environment">
+
+    ```plaintext
+    unkey:v1:ws_123:projects/proj_123/apps/app_456/environments/env_789/deployments/*#delete_deployment
+    ```
+
+  </Accordion>
+  <Accordion title="Delete deployments in one project">
+
+    ```plaintext
+    unkey:v1:ws_123:projects/proj_123/**#delete_deployment
+    ```
+
+  </Accordion>
+  <Accordion title="Read all keys in one keyspace">
+
+    ```plaintext
+    unkey:v1:ws_123:keyspaces/ks_123/keys/*#read_key
+    ```
+
+  </Accordion>
+  <Accordion title="Manage one role">
+
+    ```plaintext
+    unkey:v1:ws_123:rbac/roles/role_123#update_role
+    ```
+
+  </Accordion>
+</AccordionGroup>
+
+## Audit logs
+
+Audit logs store concrete resources and actions. They can also store the
+permission that authorized the action when authorization was evaluated.
+
+```json
+{
+  "actor": {
+    "type": "key",
+    "id": "key_root_123",
+    "urn": "unkey:v1:ws_123:keyspaces/ks_123/keys/key_root_123"
+  },
+  "resource": {
+    "urn": "unkey:v1:ws_123:projects/proj_123/apps/app_456/environments/env_789/deployments/d_abc",
+    "type": "deployment"
+  },
+  "action": "delete_deployment",
+  "authorization": {
+    "permission": "unkey:v1:ws_123:projects/proj_123/**#delete_deployment",
+    "matched": true
+  }
+}
+```
+
+Relationship changes can include multiple concrete resources. For example,
+adding a role to a key can log the key as the primary resource and the role as a
+target resource.
+
+```json
+{
+  "resource": {
+    "urn": "unkey:v1:ws_123:keyspaces/ks_123/keys/key_456",
+    "type": "key"
+  },
+  "targets": [
+    {
+      "urn": "unkey:v1:ws_123:rbac/roles/role_123",
+      "type": "role"
+    }
+  ],
+  "action": "add_role"
+}
+```
+
+## Migration from tuple permissions
+
+Existing tuple permissions map to resource permissions by expanding the old
+resource type, resource ID, and action into a URN path. Legacy API permissions
+map through the keyspace that replaces the API.
+
+| Existing permission | Resource permission |
+| --- | --- |
+| `api.*.create_api` | `unkey:v1:{workspace_id}:keyspaces/*#create_keyspace` |
+| `api.{api_id}.read_api` | `unkey:v1:{workspace_id}:keyspaces/{keyspace_id}#read_keyspace` |
+| `api.{api_id}.create_key` | `unkey:v1:{workspace_id}:keyspaces/{keyspace_id}#create_key` |
+| `api.{api_id}.read_key` | `unkey:v1:{workspace_id}:keyspaces/{keyspace_id}/keys/*#read_key` |
+| `api.{api_id}.verify_key` | `unkey:v1:{workspace_id}:keyspaces/{keyspace_id}/keys/*#verify_key` |
+| `identity.*.read_identity` | `unkey:v1:{workspace_id}:identities/*#read_identity` |
+| `ratelimit.*.delete_override` | `unkey:v1:{workspace_id}:ratelimits/namespaces/*/overrides/*#delete_override` |
+| `rbac.*.create_role` | `unkey:v1:{workspace_id}:rbac/roles/*#create_role` |
+
+Migration code must preserve the authorized workspace. The old permission string
+does not contain a workspace ID, so the workspace has to come from the owning
+key, role, user, or session.
+
+## Invalid examples
+
+These permissions are invalid.
+
+| Value | Reason |
+| --- | --- |
+| `unkey:v1:ws_123:keyspaces/ks_123` | Missing the action suffix. |
+| `unkey:v1:ws_123:keyspaces/ks_123.read_keyspace` | Uses the old tuple separator. |
+| `unkey:v1:ws_123:keyspaces/ks_123#*` | Uses an action wildcard outside the global resource pattern. |
+| `unkey:v1:ws_123:**/deployments/*#delete_deployment` | Uses recursive wildcard outside the trailing position. |
+| `unkey:v1:ws_123:projects/proj_123/**/deployments/*#delete_deployment` | Uses recursive wildcard in the middle of the path. |
+| `unkey:v1:ws_123:projects/*/apps/app_123#read_app` | Selects a specific child under a wildcard parent. |
+| `unkey:v1:ws_123:keyspaces/*/keys#read_key` | Does not match a catalog path shape. |

--- a/docs/engineering/architecture/resources/unkey-resource-names.mdx
+++ b/docs/engineering/architecture/resources/unkey-resource-names.mdx
@@ -1,0 +1,319 @@
+---
+title: "Unkey Resource Names"
+description: "Canonical resource names for public Unkey resources"
+---
+
+Unkey Resource Names, or URNs, identify public Unkey resources in a stable,
+parseable format. URNs are used anywhere Unkey needs to refer to the same
+resource across product surfaces, audit logs, permission checks, traces, and
+internal events.
+
+This document defines the `v1` resource-name contract. Future versions can add
+path shapes or change parsing rules, but `v1` URNs must keep the behavior
+defined here. A permission attaches an action to a URN, but the URN itself names
+only the resource.
+
+The Go implementation lives in
+[`pkg/urn`](https://github.com/unkeyed/unkey/tree/main/pkg/urn).
+
+## Format
+
+A URN has four colon-separated fields.
+
+```plaintext
+unkey:v1:{workspace_id}:{resource_path}
+```
+
+Each field has a fixed meaning.
+
+| Field | Description |
+| --- | --- |
+| `unkey` | Fixed prefix for every Unkey Resource Name. |
+| `v1` | Resource-name grammar version. |
+| `{workspace_id}` | Workspace that owns the resource. |
+| `{resource_path}` | Canonical path to the resource inside the workspace. |
+
+For example:
+
+```plaintext
+unkey:v1:ws_123:projects/proj_123
+unkey:v1:ws_123:projects/proj_123/apps/app_456
+unkey:v1:ws_123:projects/proj_123/apps/app_456/environments/env_789/deployments/d_abc
+```
+
+The workspace ID is part of the URN even when the caller already has workspace
+context. Audit logs, background jobs, and support tools must be able to copy a
+URN and identify the owning workspace without extra state.
+
+## Path rules
+
+Resource paths are part of the contract. Code that creates, parses, or matches
+URNs must follow these rules.
+
+- Concrete resource URNs must use the full canonical path from the catalog.
+- Collection segments are plural, for example `keyspaces`, `keys`, and
+  `projects`.
+- ID segments use the existing public Unkey ID for that resource.
+- `:` is reserved for top-level URN fields and must not appear in a resource
+  path.
+- `#` is reserved for permissions and must not appear in a URN.
+- A resource path must not start or end with `/`.
+
+Concrete URNs identify one resource. Resource-name patterns identify a set of
+resources and are part of the `v1` URN grammar. Callers that need one exact
+resource, such as audit logs and authorization requests, must use concrete
+URNs. Stored authorization grants can use patterns.
+
+## Resource-name patterns
+
+Resource-name patterns use the same four-field URN format as concrete resource
+names. The difference is in the resource path.
+
+| Operator | Meaning |
+| --- | --- |
+| `*` | Matches exactly one complete path segment. |
+| `/**` | Matches the base path and every descendant below it. |
+
+The `*` operator must be the whole path segment. A pattern such as `key_*` is
+invalid because it would make prefix matching ambiguous.
+
+The `/**` operator must be the final path segment. A pattern such as
+`projects/**/deployments/*` is invalid because descendant matching has to stop
+at the end of the path.
+
+After a path uses `*` for an ID selector, descendant ID selectors must also use
+`*`. The path can still name child collections, but it can't narrow back to a
+specific child. This keeps wildcard paths canonical and avoids permissions that
+pretend to select a child without selecting the parent that owns it.
+
+Valid:
+
+```plaintext
+unkey:v1:ws_123:projects/*/apps/*
+unkey:v1:ws_123:projects/*/apps/*/environments/*/deployments/*
+unkey:v1:ws_123:projects/proj_123/apps/*/environments/*
+```
+
+Invalid:
+
+```plaintext
+unkey:v1:ws_123:projects/*/apps/app_123
+unkey:v1:ws_123:projects/proj_123/apps/*/environments/env_123
+unkey:v1:ws_123:projects/proj_123/apps/*/environments/*/deployments/dep_123
+```
+
+For example, this pattern:
+
+```plaintext
+unkey:v1:ws_123:keyspaces/*/keys/*
+```
+
+matches this concrete URN:
+
+```plaintext
+unkey:v1:ws_123:keyspaces/ks_123/keys/key_456
+```
+
+This descendant pattern:
+
+```plaintext
+unkey:v1:ws_123:projects/proj_123/**
+```
+
+matches the project itself and every public descendant below that project.
+Patterns never cross workspace boundaries, including the global workspace
+pattern:
+
+```plaintext
+unkey:v1:ws_123:**
+```
+
+`pkg/urn` parses concrete names and patterns. It also decides whether one URN
+covers another. The permission system adds the action suffix and decides what a
+covered resource authorizes. It doesn't define its own path matching.
+
+## Resource catalog
+
+The public catalog defines every concrete resource path that can appear in a
+`v1` URN. Implementation code must reject concrete URNs that don't match one of
+these path shapes. Pattern grants must still be built from these path shapes,
+with `*` replacing complete ID segments or trailing `/**` covering descendants.
+
+### Team
+
+Team resources are rooted under `team`.
+
+| Resource | Path |
+| --- | --- |
+| Membership | `team/memberships/{membership_id}` |
+| Invitation | `team/invitations/{invitation_id}` |
+
+Examples:
+
+```plaintext
+unkey:v1:ws_123:team/memberships/mbr_123
+unkey:v1:ws_123:team/invitations/inv_456
+```
+
+### Billing
+
+Billing resources are rooted under `billing`. Workspace quota is a singleton
+resource because quota applies to the workspace billing state.
+
+| Resource | Path |
+| --- | --- |
+| Billing state | `billing` |
+| Invoice | `billing/invoices/{invoice_id}` |
+| Quota | `billing/quotas` |
+
+Examples:
+
+```plaintext
+unkey:v1:ws_123:billing
+unkey:v1:ws_123:billing/invoices/inv_123
+unkey:v1:ws_123:billing/quotas
+```
+
+### Keyspaces
+
+Key resources are rooted under the keyspace that owns the key.
+
+| Resource | Path |
+| --- | --- |
+| Keyspace | `keyspaces/{keyspace_id}` |
+| Key | `keyspaces/{keyspace_id}/keys/{key_id}` |
+
+Examples:
+
+```plaintext
+unkey:v1:ws_123:keyspaces/ks_123
+unkey:v1:ws_123:keyspaces/ks_123/keys/key_456
+```
+
+### Identities
+
+Identity resources are rooted under `identities`.
+
+| Resource | Path |
+| --- | --- |
+| Identity | `identities/{identity_id}` |
+
+Example:
+
+```plaintext
+unkey:v1:ws_123:identities/id_123
+```
+
+### Rate limits
+
+Standalone rate limiting resources are rooted under `ratelimits`. Overrides
+belong to the namespace they modify.
+
+| Resource | Path |
+| --- | --- |
+| Namespace | `ratelimits/namespaces/{namespace_id}` |
+| Override | `ratelimits/namespaces/{namespace_id}/overrides/{override_id}` |
+
+Examples:
+
+```plaintext
+unkey:v1:ws_123:ratelimits/namespaces/rlns_123
+unkey:v1:ws_123:ratelimits/namespaces/rlns_123/overrides/rlor_456
+```
+
+### RBAC
+
+RBAC resources are rooted under `rbac`. Relationship changes, such as adding a
+role to a key, are audited against both affected resources rather than by
+creating a separate join-table URN.
+
+| Resource | Path |
+| --- | --- |
+| Role | `rbac/roles/{role_id}` |
+| Permission | `rbac/permissions/{permission_id}` |
+
+Examples:
+
+```plaintext
+unkey:v1:ws_123:rbac/roles/role_123
+unkey:v1:ws_123:rbac/permissions/perm_456
+```
+
+### Deploy
+
+Deploy resources use the full product hierarchy. A deployment belongs to one
+environment, which belongs to one app, which belongs to one project.
+
+| Resource | Path |
+| --- | --- |
+| Project | `projects/{project_id}` |
+| App | `projects/{project_id}/apps/{app_id}` |
+| Environment | `projects/{project_id}/apps/{app_id}/environments/{environment_id}` |
+| Deployment | `projects/{project_id}/apps/{app_id}/environments/{environment_id}/deployments/{deployment_id}` |
+| Deployment instance | `projects/{project_id}/apps/{app_id}/environments/{environment_id}/deployments/{deployment_id}/instances/{instance_id}` |
+| Domain | `projects/{project_id}/apps/{app_id}/environments/{environment_id}/domains/{domain_id}` |
+| Variable | `projects/{project_id}/apps/{app_id}/environments/{environment_id}/variables/{variable_id}` |
+
+Examples:
+
+```plaintext
+unkey:v1:ws_123:projects/proj_123
+unkey:v1:ws_123:projects/proj_123/apps/app_456
+unkey:v1:ws_123:projects/proj_123/apps/app_456/environments/env_789
+unkey:v1:ws_123:projects/proj_123/apps/app_456/environments/env_789/deployments/d_abc
+```
+
+### Portal
+
+Portal resources are rooted under `portals`. Session tokens and sessions belong
+to the portal that created them.
+
+| Resource | Path |
+| --- | --- |
+| Portal | `portals/{portal_id}` |
+| Portal session token | `portals/{portal_id}/session_tokens/{portal_session_token_id}` |
+| Portal session | `portals/{portal_id}/sessions/{portal_session_id}` |
+| Portal branding | `portals/{portal_id}/branding` |
+
+Examples:
+
+```plaintext
+unkey:v1:ws_123:portals/portal_123
+unkey:v1:ws_123:portals/portal_123/sessions/ps_456
+```
+
+## Internal resources
+
+Runtime and implementation resources are not part of the public `v1` catalog
+unless a product feature explicitly promotes them.
+
+This includes:
+
+- Frontline routes
+- Sentinels
+- Regional counters
+- ClickHouse outbox rows
+- Cache entries
+- Join-table rows
+
+Internal systems can still log implementation IDs in metadata. They must not
+mint public URNs for these resources unless the catalog is updated first.
+
+## Invalid examples
+
+These strings are invalid URNs or invalid concrete URNs.
+
+| Value | Reason |
+| --- | --- |
+| `urn:unkey:v1:ws_123:keyspaces/ks_123` | Uses the wrong prefix. |
+| `unkey:v1:ws_123` | Missing the resource path. |
+| `unkey:v1:ws_123:keyspaces/ks_123#read_keyspace` | Contains a permission action. |
+| `unkey:v1:ws_123:keyspaces/ks_*` | Uses `*` inside a path segment. |
+| `unkey:v1:ws_123:projects/**/deployments/*` | Uses `**` before the end of the path. |
+| `unkey:v1:ws_123:projects/*/apps/app_123` | Selects a specific child under a wildcard parent. |
+| `unkey:v1:ws_123:keyspace/ks_123` | Uses an unknown path shape. |
+
+## Related pages
+
+- [Resource permissions](/architecture/authorization/resource-permissions)
+  defines how actions attach to URNs for authorization.

--- a/docs/engineering/architecture/rfcs/0011-unkey-resource-names.mdx
+++ b/docs/engineering/architecture/rfcs/0011-unkey-resource-names.mdx
@@ -6,6 +6,15 @@ authors:
   - Andreas Thomas
 ---
 
+<Note>
+  This RFC records the original proposal. The implemented `v1` resource-name
+  contract is documented in [Unkey Resource Names](/architecture/resources/unkey-resource-names)
+  and [Resource permissions](/architecture/authorization/resource-permissions).
+  The implemented contract uses `unkey:v1:{workspace_id}:{resource_path}` and
+  includes resource-name patterns with `*` and trailing `/**` for authorization
+  grants.
+</Note>
+
 ## 1. Background
 
 As we grow Unkey from a single API authentication product into a comprehensive API infrastructure platform with multiple services, we face increasing complexity in resource identification and error handling. Our current approach lacks a consistent, scalable system for uniquely identifying resources across services and providing structured error information to developers.

--- a/docs/engineering/docs.json
+++ b/docs/engineering/docs.json
@@ -59,6 +59,13 @@
             "pages": [
               "architecture/index",
               {
+                "group": "Resource model",
+                "pages": [
+                  "architecture/resources/unkey-resource-names",
+                  "architecture/authorization/resource-permissions"
+                ]
+              },
+              {
                 "group": "Rate limiting",
                 "pages": [
                   "architecture/ratelimiting/overview",

--- a/pkg/rbac/BUILD.bazel
+++ b/pkg/rbac/BUILD.bazel
@@ -10,12 +10,15 @@ go_library(
         "permissions.go",
         "query.go",
         "rbac.go",
+        "urn.go",
     ],
     importpath = "github.com/unkeyed/unkey/pkg/rbac",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/codes",
         "//pkg/fault",
+        "//pkg/rbac/permissions",
+        "//pkg/urn",
     ],
 )
 
@@ -28,7 +31,13 @@ go_test(
         "lexer_test.go",
         "parse_test.go",
         "rbac_test.go",
+        "urn_test.go",
     ],
     embed = [":rbac"],
-    deps = ["@com_github_stretchr_testify//require"],
+    deps = [
+        "//pkg/fuzz",
+        "//pkg/rbac/permissions",
+        "//pkg/urn",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/pkg/rbac/doc.go
+++ b/pkg/rbac/doc.go
@@ -1,11 +1,12 @@
 // Package rbac implements a flexible Role-Based Access Control system for
 // managing permissions and authorization checks.
 //
-// The package provides a way to define fine-grained permissions using a
-// resource type, resource ID, and action tuple model, and to evaluate whether
-// a set of permissions satisfies specific access requirements. This approach
-// allows for both simple and complex authorization rules through boolean
-// operations like AND and OR.
+// The package provides helpers to define fine-grained permission requirements
+// and evaluate whether a set of granted permissions satisfies them. New code
+// should prefer resource permissions built from [UnkeyPermission] and
+// [github.com/unkeyed/unkey/pkg/urn.V1].
+// The older [Tuple] format remains supported for existing root-key permissions
+// while handlers migrate to canonical Unkey resource names.
 //
 // The package supports two ways to construct permission queries:
 // 1. Programmatic construction using helper functions
@@ -17,6 +18,7 @@
 //   - ResourceID: Specific instance identifier within a resource type
 //   - ActionType: Operations that can be performed on resources (e.g., "read", "write")
 //   - Tuple: Combination of ResourceType, ResourceID, and ActionType that defines a permission
+//   - UnkeyPermission: Combination of a canonical Unkey resource name and action
 //   - PermissionQuery: Logical expressions for permission evaluation using AND/OR operations
 //
 // # Programmatic Query Construction
@@ -35,11 +37,7 @@
 //
 //	// Create a permission query using helper functions
 //	query := rbac.And(
-//	    rbac.T(rbac.Tuple{
-//	        ResourceType: rbac.Api,
-//	        ResourceID:   "api1",
-//	        Action:       rbac.ReadAPI,
-//	    }),
+//	    rbac.U(urn.New().Workspace("ws_123").RatelimitNamespace("ns_123").Override("ov_123"), permissions.ReadOverride{}),
 //	    rbac.T(rbac.Tuple{
 //	        ResourceType: rbac.Api,
 //	        ResourceID:   "api1",

--- a/pkg/rbac/permissions/BUILD.bazel
+++ b/pkg/rbac/permissions/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "permissions",
+    srcs = [
+        "action.go",
+        "apps.go",
+        "environments.go",
+        "keys.go",
+        "keyspaces.go",
+        "projects.go",
+        "ratelimit_namespaces.go",
+        "ratelimit_overrides.go",
+    ],
+    importpath = "github.com/unkeyed/unkey/pkg/rbac/permissions",
+    visibility = ["//visibility:public"],
+    deps = ["//pkg/urn"],
+)

--- a/pkg/rbac/permissions/action.go
+++ b/pkg/rbac/permissions/action.go
@@ -1,0 +1,22 @@
+// Package permissions defines typed actions for Unkey resource permissions.
+//
+// Resource permissions combine a URN resource with an action, but not every
+// action is meaningful for every resource. These action structs encode valid
+// resource/action pairs in the type system, so handler code can't accidentally
+// ask for create_key on a key resource or read_key on a keyspace resource.
+//
+// Each action declares the resource type it supports through ActionFor. For
+// example, CreateKey implements ActionFor(urn.Keyspace), so rbac.U accepts it
+// with urn.Keyspace values and rejects it with urn.Key values at compile time.
+//
+// This keeps pkg/urn focused on naming resources while pkg/rbac owns query
+// construction and evaluation.
+package permissions
+
+import "fmt"
+
+// Action is an action that is valid for resource type R.
+type Action[R fmt.Stringer] interface {
+	ActionFor(R)
+	fmt.Stringer
+}

--- a/pkg/rbac/permissions/apps.go
+++ b/pkg/rbac/permissions/apps.go
@@ -1,0 +1,11 @@
+package permissions
+
+import "github.com/unkeyed/unkey/pkg/urn"
+
+// CreateEnvironment authorizes creating environments in an app.
+//
+// Valid resource: urn.App.
+type CreateEnvironment struct{}
+
+func (CreateEnvironment) ActionFor(urn.App) {}
+func (CreateEnvironment) String() string    { return "create_environment" }

--- a/pkg/rbac/permissions/environments.go
+++ b/pkg/rbac/permissions/environments.go
@@ -1,0 +1,27 @@
+package permissions
+
+import "github.com/unkeyed/unkey/pkg/urn"
+
+// CreateDeployment authorizes creating deployments in an environment.
+//
+// Valid resource: urn.Environment.
+type CreateDeployment struct{}
+
+func (CreateDeployment) ActionFor(urn.Environment) {}
+func (CreateDeployment) String() string            { return "create_deployment" }
+
+// CreateDomain authorizes creating domains in an environment.
+//
+// Valid resource: urn.Environment.
+type CreateDomain struct{}
+
+func (CreateDomain) ActionFor(urn.Environment) {}
+func (CreateDomain) String() string            { return "create_domain" }
+
+// CreateVariable authorizes creating variables in an environment.
+//
+// Valid resource: urn.Environment.
+type CreateVariable struct{}
+
+func (CreateVariable) ActionFor(urn.Environment) {}
+func (CreateVariable) String() string            { return "create_variable" }

--- a/pkg/rbac/permissions/keys.go
+++ b/pkg/rbac/permissions/keys.go
@@ -1,0 +1,35 @@
+package permissions
+
+import "github.com/unkeyed/unkey/pkg/urn"
+
+// ReadKey authorizes reading key resources.
+//
+// Valid resource: urn.Key.
+type ReadKey struct{}
+
+func (ReadKey) ActionFor(urn.Key) {}
+func (ReadKey) String() string    { return "read_key" }
+
+// EncryptKey authorizes creating recoverable encrypted keys.
+//
+// Valid resource: urn.Key.
+type EncryptKey struct{}
+
+func (EncryptKey) ActionFor(urn.Key) {}
+func (EncryptKey) String() string    { return "encrypt_key" }
+
+// DecryptKey authorizes decrypting recoverable key material.
+//
+// Valid resource: urn.Key.
+type DecryptKey struct{}
+
+func (DecryptKey) ActionFor(urn.Key) {}
+func (DecryptKey) String() string    { return "decrypt_key" }
+
+// VerifyKey authorizes verifying key resources.
+//
+// Valid resource: urn.Key.
+type VerifyKey struct{}
+
+func (VerifyKey) ActionFor(urn.Key) {}
+func (VerifyKey) String() string    { return "verify_key" }

--- a/pkg/rbac/permissions/keyspaces.go
+++ b/pkg/rbac/permissions/keyspaces.go
@@ -1,0 +1,11 @@
+package permissions
+
+import "github.com/unkeyed/unkey/pkg/urn"
+
+// CreateKey authorizes creating keys in a keyspace.
+//
+// Valid resource: urn.Keyspace.
+type CreateKey struct{}
+
+func (CreateKey) ActionFor(urn.Keyspace) {}
+func (CreateKey) String() string         { return "create_key" }

--- a/pkg/rbac/permissions/projects.go
+++ b/pkg/rbac/permissions/projects.go
@@ -1,0 +1,11 @@
+package permissions
+
+import "github.com/unkeyed/unkey/pkg/urn"
+
+// CreateApp authorizes creating apps in a project.
+//
+// Valid resource: urn.Project.
+type CreateApp struct{}
+
+func (CreateApp) ActionFor(urn.Project) {}
+func (CreateApp) String() string        { return "create_app" }

--- a/pkg/rbac/permissions/ratelimit_namespaces.go
+++ b/pkg/rbac/permissions/ratelimit_namespaces.go
@@ -1,0 +1,11 @@
+package permissions
+
+import "github.com/unkeyed/unkey/pkg/urn"
+
+// SetOverride authorizes setting overrides in a rate limit namespace.
+//
+// Valid resource: urn.RatelimitNamespace.
+type SetOverride struct{}
+
+func (SetOverride) ActionFor(urn.RatelimitNamespace) {}
+func (SetOverride) String() string                   { return "set_override" }

--- a/pkg/rbac/permissions/ratelimit_overrides.go
+++ b/pkg/rbac/permissions/ratelimit_overrides.go
@@ -1,0 +1,19 @@
+package permissions
+
+import "github.com/unkeyed/unkey/pkg/urn"
+
+// ReadOverride authorizes reading rate limit override resources.
+//
+// Valid resource: urn.RatelimitOverride.
+type ReadOverride struct{}
+
+func (ReadOverride) ActionFor(urn.RatelimitOverride) {}
+func (ReadOverride) String() string                  { return "read_override" }
+
+// DeleteOverride authorizes deleting rate limit override resources.
+//
+// Valid resource: urn.RatelimitOverride.
+type DeleteOverride struct{}
+
+func (DeleteOverride) ActionFor(urn.RatelimitOverride) {}
+func (DeleteOverride) String() string                  { return "delete_override" }

--- a/pkg/rbac/query.go
+++ b/pkg/rbac/query.go
@@ -31,6 +31,11 @@ type PermissionQuery struct {
 
 	// Children contains sub-queries for non-leaf nodes (OperatorAnd/OperatorOr)
 	Children []PermissionQuery `json:"children,omitempty"`
+
+	// When true, this leaf opts into Unkey resource permission matching. The
+	// marker is intentionally not serialized or set by ParseQuery because
+	// wildcard semantics must be chosen by typed call sites through U().
+	matchUnkeyPermission bool
 }
 
 // And creates a permission query that requires all child queries to be satisfied.
@@ -45,9 +50,10 @@ type PermissionQuery struct {
 //	)
 func And(queries ...PermissionQuery) PermissionQuery {
 	return PermissionQuery{
-		Operation: OperatorAnd,
-		Value:     "",
-		Children:  queries,
+		Operation:            OperatorAnd,
+		Value:                "",
+		Children:             queries,
+		matchUnkeyPermission: false,
 	}
 }
 
@@ -63,9 +69,10 @@ func And(queries ...PermissionQuery) PermissionQuery {
 //	)
 func Or(queries ...PermissionQuery) PermissionQuery {
 	return PermissionQuery{
-		Operation: OperatorOr,
-		Value:     "",
-		Children:  queries,
+		Operation:            OperatorOr,
+		Value:                "",
+		Children:             queries,
+		matchUnkeyPermission: false,
 	}
 }
 
@@ -83,9 +90,10 @@ func Or(queries ...PermissionQuery) PermissionQuery {
 //	})
 func T(tuple Tuple) PermissionQuery {
 	return PermissionQuery{
-		Operation: OperatorNil,
-		Value:     tuple.String(),
-		Children:  []PermissionQuery{},
+		Operation:            OperatorNil,
+		Value:                tuple.String(),
+		Children:             []PermissionQuery{},
+		matchUnkeyPermission: false,
 	}
 }
 
@@ -99,8 +107,9 @@ func T(tuple Tuple) PermissionQuery {
 //	query := rbac.S("resourceType.resourceID.action")
 func S(s string) PermissionQuery {
 	return PermissionQuery{
-		Operation: OperatorNil,
-		Value:     s,
-		Children:  []PermissionQuery{},
+		Operation:            OperatorNil,
+		Value:                s,
+		Children:             []PermissionQuery{},
+		matchUnkeyPermission: false,
 	}
 }

--- a/pkg/rbac/rbac.go
+++ b/pkg/rbac/rbac.go
@@ -70,13 +70,14 @@ func (r *RBAC) EvaluatePermissions(query PermissionQuery, permissions []string) 
 	return r.evaluateQueryV1(query, permissions)
 }
 
+// evaluateQueryV1 recursively evaluates a permission query tree against the
+// granted permission strings, combining child results per the node operator.
 func (r *RBAC) evaluateQueryV1(query PermissionQuery, permissions []string) (EvaluationResult, error) {
 	// Handle simple permission check
 	if query.Value != "" {
-		if slices.Contains(permissions, query.Value) {
+		if evaluateLeafPermission(query, permissions) {
 			return EvaluationResult{Valid: true, Message: ""}, nil
 		}
-
 		return EvaluationResult{
 			Valid:   false,
 			Message: fmt.Sprintf("Missing permission: '%s'", query.Value),
@@ -126,6 +127,28 @@ func (r *RBAC) evaluateQueryV1(query PermissionQuery, permissions []string) (Eva
 	)
 }
 
+// evaluateLeafPermission is the shared leaf evaluator for the boolean query
+// tree. Exact string matching is always available. Unkey wildcard matching is
+// an explicit opt-in carried by U(), not a behavior inferred from string shape.
+func evaluateLeafPermission(query PermissionQuery, permissions []string) bool {
+	if slices.Contains(permissions, query.Value) {
+		return true
+	}
+
+	if !query.matchUnkeyPermission {
+		return false
+	}
+
+	requiredPermission, err := parseUrnPermission(query.Value)
+	if err != nil {
+		return false
+	}
+
+	return evaluateUnkeyPermission(requiredPermission, permissions)
+}
+
+// formatPermissions quotes each permission so evaluation messages stay readable
+// when permissions are concatenated.
 func formatPermissions(permissions []string) []string {
 	formatted := make([]string, len(permissions))
 

--- a/pkg/rbac/rbac_test.go
+++ b/pkg/rbac/rbac_test.go
@@ -66,6 +66,12 @@ func TestRBAC_EvaluatePermissions(t *testing.T) {
 			wantValid:   false,
 		},
 		{
+			name:        "Tuple wildcard remains literal (Fail)",
+			query:       S("api.*.read_key"),
+			permissions: []string{"api.key_123.read_key"},
+			wantValid:   false,
+		},
+		{
 			name: "Complex query with asterisk permissions",
 			query: Or(
 				S("api.*"),

--- a/pkg/rbac/urn.go
+++ b/pkg/rbac/urn.go
@@ -1,0 +1,144 @@
+package rbac
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/unkeyed/unkey/pkg/rbac/permissions"
+	"github.com/unkeyed/unkey/pkg/urn"
+)
+
+var errInvalidURNPermission = errors.New("invalid urn permission")
+
+// UnkeyPermission represents an RBAC permission requirement for a Unkey resource.
+//
+// The resource name itself belongs to [urn.V1]. RBAC only adds the action
+// suffix and evaluates whether a principal's granted permissions cover this
+// concrete requirement.
+type UnkeyPermission struct {
+	// Resource is the canonical v1 resource name being protected.
+	Resource urn.V1
+
+	// Action is the operation required on the resource.
+	Action ActionType
+}
+
+// String returns the full RBAC permission string for this resource and action.
+func (u UnkeyPermission) String() string {
+	return fmt.Sprintf("%s#%s", u.Resource.String(), u.Action)
+}
+
+// U creates a leaf query for a typed action on a canonical resource name.
+//
+// Handlers should pass the exact resource being accessed. Broader grants such
+// as "unkey:v1:ws_123:ratelimits/**#read_override" are matched during
+// evaluation, not by writing wildcard-heavy queries at call sites.
+func U[R fmt.Stringer, A permissions.Action[R]](resource R, action A) PermissionQuery {
+	return PermissionQuery{
+		Operation:            OperatorNil,
+		Value:                fmt.Sprintf("%s#%s", resource.String(), action.String()),
+		Children:             []PermissionQuery{},
+		matchUnkeyPermission: true,
+	}
+}
+
+// isUnkeyPermission reports whether a granted string is a canonical Unkey
+// permission URN, so the evaluator never applies wildcard semantics to legacy
+// or customer-defined permission strings.
+func isUnkeyPermission(value string) bool {
+	_, err := parseUrnPermission(value)
+	return err == nil
+}
+
+// evaluateUnkeyPermission evaluates Unkey resource permission URNs only.
+//
+// The required permission is already parsed by the leaf evaluator. Legacy tuple
+// permissions and customer-defined permission strings never reach this path, so
+// wildcard characters only expand scope for canonical Unkey permission URNs.
+func evaluateUnkeyPermission(required UnkeyPermission, granted []string) bool {
+	for _, permission := range granted {
+		grantedPermission, err := parseUrnPermission(permission)
+		if err != nil {
+			continue
+		}
+		if permissionCovers(required, grantedPermission) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// parseUrnPermission parses the RBAC action suffix around a resource URN.
+//
+// Resource-name parsing is delegated to pkg/urn so RBAC does not duplicate the
+// Unkey URN grammar. RBAC only validates the action component after "#".
+//
+// Accepted:
+//
+//	unkey:v1:ws_1:ratelimits/namespaces/ns_1/overrides/ov_1#read_override
+//	unkey:v1:ws_1:keyspaces/*/keys/*#read_key    wildcard grant
+//	unkey:v1:ws_1:**#*                           admin grant (translated from admin:*)
+//
+// Rejected with errInvalidURNPermission:
+//
+//	unkey:v1:ws_1:keyspaces/ks_1                 missing "#action"
+//	unkey:v1:ws_1:keyspaces/ks_1#read#key        more than one "#"
+//	unkey:v1:ws_1:keyspaces/ks_1#*               action wildcard off the global resource
+//	api.api_1.read_api                           legacy tuple, not a URN permission
+func parseUrnPermission(value string) (UnkeyPermission, error) {
+	var zero UnkeyPermission
+
+	urnStr, action, ok := strings.Cut(value, "#")
+	if !ok || strings.Contains(action, "#") {
+		return zero, fmt.Errorf("%w: expected exactly one action separator", errInvalidURNPermission)
+	}
+
+	resource, err := urn.ParseV1(urnStr)
+	if err != nil {
+		return zero, fmt.Errorf("%w: %w", errInvalidURNPermission, err)
+	}
+
+	if err := validatePermissionAction(action); err != nil {
+		return zero, fmt.Errorf("%w: invalid action: %v", errInvalidURNPermission, err)
+	}
+	if action == "*" && resource.Resource != "**" {
+		return zero, fmt.Errorf("%w: action wildcard requires the global resource pattern %q", errInvalidURNPermission, "**")
+	}
+
+	return UnkeyPermission{
+		Resource: resource,
+		Action:   ActionType(action),
+	}, nil
+}
+
+// permissionCovers reports whether a granted permission satisfies a required
+// permission. Required permissions should be concrete; granted permissions may
+// use resource wildcards or "*" as the action. Resource matching, including
+// workspace equality, is delegated to [urn.V1.Covers].
+func permissionCovers(required UnkeyPermission, granted UnkeyPermission) bool {
+	if granted.Action != "*" && granted.Action != required.Action {
+		return false
+	}
+
+	return granted.Resource.Covers(required.Resource)
+}
+
+// validatePermissionAction enforces the action grammar after "#": either the
+// "*" wildcard or a word that cannot collide with URN separators.
+func validatePermissionAction(action string) error {
+	if action == "*" {
+		return nil
+	}
+	if action == "" {
+		return errors.New("must not be empty")
+	}
+	if strings.ContainsAny(action, ":#/*") {
+		return errors.New(`must not contain ":", "#", "/", or "*"`)
+	}
+	if strings.HasPrefix(action, "_") || strings.HasSuffix(action, "_") {
+		return errors.New(`must not start or end with "_"`)
+	}
+	return nil
+}

--- a/pkg/rbac/urn_test.go
+++ b/pkg/rbac/urn_test.go
@@ -1,0 +1,377 @@
+package rbac
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/fuzz"
+	"github.com/unkeyed/unkey/pkg/rbac/permissions"
+	"github.com/unkeyed/unkey/pkg/urn"
+)
+
+// TestUnkeyPermissionQuery_BuildsCanonicalPermission guarantees the typed RBAC
+// helper emits the full permission string principals store.
+func TestUnkeyPermissionQuery_BuildsCanonicalPermission(t *testing.T) {
+	t.Parallel()
+
+	resource := urn.New().Workspace("ws_123").RatelimitNamespace("ns_123").Override("ov_123")
+	query := U(resource, permissions.ReadOverride{})
+	stringQuery := S(UnkeyPermission{
+		Resource: resource.V1(),
+		Action:   "read_override",
+	}.String())
+	createQuery := U(urn.New().Workspace("ws_123").Keyspace("ks_123"), permissions.CreateKey{})
+
+	require.Equal(t, "unkey:v1:ws_123:ratelimits/namespaces/ns_123/overrides/ov_123#read_override", query.Value)
+	require.Equal(t, query.Value, stringQuery.Value)
+	require.Equal(t, "unkey:v1:ws_123:keyspaces/ks_123#create_key", createQuery.Value)
+
+	result, err := New().EvaluatePermissions(query, []string{
+		"unkey:v1:ws_123:ratelimits/namespaces/ns_123/overrides/ov_123#read_override",
+	})
+	require.NoError(t, err)
+	require.True(t, result.Valid)
+}
+
+// TestStringQuery_DoesNotOptIntoUnkeyWildcardMatching guarantees callers must
+// choose U() before canonical Unkey permission grants can expand wildcards.
+func TestStringQuery_DoesNotOptIntoUnkeyWildcardMatching(t *testing.T) {
+	t.Parallel()
+
+	required := "unkey:v1:ws_123:ratelimits/namespaces/ns_123/overrides/ov_123#read_override"
+	grants := []string{
+		"unkey:v1:ws_123:ratelimits/namespaces/ns_123/overrides/*#read_override",
+	}
+
+	stringResult, err := New().EvaluatePermissions(S(required), grants)
+	require.NoError(t, err)
+	require.False(t, stringResult.Valid)
+
+	typedResult, err := New().EvaluatePermissions(
+		U(
+			urn.New().
+				Workspace("ws_123").
+				RatelimitNamespace("ns_123").
+				Override("ov_123"),
+			permissions.ReadOverride{},
+		),
+		grants,
+	)
+	require.NoError(t, err)
+	require.True(t, typedResult.Valid)
+}
+
+// TestParseUrnPermission_AcceptsOnlySupportedGrammar guarantees malformed
+// permission strings cannot accidentally participate in wildcard matching.
+func TestParseUrnPermission_AcceptsOnlySupportedGrammar(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		value   string
+		want    UnkeyPermission
+		wantErr bool
+	}{
+		{
+			name:  "exact resource",
+			value: "unkey:v1:ws_123:ratelimits/namespaces/ns_123/overrides/ov_123#read_override",
+			want: UnkeyPermission{
+				Resource: urn.V1{WorkspaceID: "ws_123", Resource: "ratelimits/namespaces/ns_123/overrides/ov_123"},
+				Action:   "read_override",
+			},
+		},
+		{
+			name:  "segment wildcard resource",
+			value: "unkey:v1:ws_123:ratelimits/namespaces/*/overrides/*#read_override",
+			want: UnkeyPermission{
+				Resource: urn.V1{WorkspaceID: "ws_123", Resource: "ratelimits/namespaces/*/overrides/*"},
+				Action:   "read_override",
+			},
+		},
+		{
+			name:  "descendant wildcard resource",
+			value: "unkey:v1:ws_123:ratelimits/**#read_override",
+			want: UnkeyPermission{
+				Resource: urn.V1{WorkspaceID: "ws_123", Resource: "ratelimits/**"},
+				Action:   "read_override",
+			},
+		},
+		{
+			name:  "admin permission",
+			value: "unkey:v1:ws_123:**#*",
+			want: UnkeyPermission{
+				Resource: urn.V1{WorkspaceID: "ws_123", Resource: "**"},
+				Action:   "*",
+			},
+		},
+		{name: "missing action separator", value: "unkey:v1:ws_123:ratelimits/namespaces/ns_123", wantErr: true},
+		{name: "empty resource", value: "unkey:v1:ws_123:#read_override", wantErr: true},
+		{name: "empty action", value: "unkey:v1:ws_123:ratelimits/namespaces/ns_123#", wantErr: true},
+		{name: "extra action separator", value: "unkey:v1:ws_123:ratelimits/namespaces/ns_123#read#override", wantErr: true},
+		{name: "wrong prefix", value: "urn:v1:ws_123:ratelimits/namespaces/ns_123#read_override", wantErr: true},
+		{name: "wrong version", value: "unkey:v2:ws_123:ratelimits/namespaces/ns_123#read_override", wantErr: true},
+		{name: "missing workspace resource separator", value: "unkey:v1:ws_123#read_override", wantErr: true},
+		{name: "empty workspace", value: "unkey:v1::ratelimits/namespaces/ns_123#read_override", wantErr: true},
+		{name: "workspace with slash", value: "unkey:v1:ws/123:ratelimits/namespaces/ns_123#read_override", wantErr: true},
+		{name: "resource with colon", value: "unkey:v1:ws_123:ratelimits:namespaces/ns_123#read_override", wantErr: true},
+		{name: "leading slash", value: "unkey:v1:ws_123:/ratelimits/namespaces/ns_123#read_override", wantErr: true},
+		{name: "trailing slash", value: "unkey:v1:ws_123:ratelimits/namespaces/ns_123/#read_override", wantErr: true},
+		{name: "empty segment", value: "unkey:v1:ws_123:ratelimits//namespaces/ns_123#read_override", wantErr: true},
+		{name: "partial wildcard", value: "unkey:v1:ws_123:ratelimits/namespaces/ns_*#read_override", wantErr: true},
+		{name: "descendant wildcard in middle", value: "unkey:v1:ws_123:ratelimits/**/overrides/*#read_override", wantErr: true},
+		{name: "action with slash", value: "unkey:v1:ws_123:ratelimits/namespaces/ns_123#read/override", wantErr: true},
+		{name: "action with colon", value: "unkey:v1:ws_123:ratelimits/namespaces/ns_123#read:override", wantErr: true},
+		{name: "action wildcard without global resource", value: "unkey:v1:ws_123:ratelimits/namespaces/ns_123#*", wantErr: true},
+		{name: "action wildcard with single segment wildcard resource", value: "unkey:v1:ws_123:*#*", wantErr: true},
+		{name: "leading action separator", value: "unkey:v1:ws_123:ratelimits/namespaces/ns_123#_read_override", wantErr: true},
+		{name: "trailing action separator", value: "unkey:v1:ws_123:ratelimits/namespaces/ns_123#read_override_", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parseUrnPermission(tt.value)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestIsUnkeyPermission_OnlyAcceptsCanonicalUnkeyPermissions guarantees the
+// evaluator never applies Unkey wildcard semantics to legacy or customer grants.
+func TestIsUnkeyPermission_OnlyAcceptsCanonicalUnkeyPermissions(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, isUnkeyPermission("unkey:v1:ws_123:ratelimits/namespaces/ns_123#read_override"))
+	require.False(t, isUnkeyPermission("api.*.read_key"))
+	require.False(t, isUnkeyPermission("ratelimit.ns_123.read_override"))
+	require.False(t, isUnkeyPermission("unkey:v1:ws_123:ratelimits/namespaces/ns_123"))
+}
+
+// TestPermissionCovers_GrantedWildcardCoversExactRequiredResource guarantees
+// handlers can query exact resources while principals hold broader grants.
+func TestPermissionCovers_GrantedWildcardCoversExactRequiredResource(t *testing.T) {
+	t.Parallel()
+
+	required := UnkeyPermission{
+		Resource: urn.V1{WorkspaceID: "ws_123", Resource: "ratelimits/namespaces/ns_123/overrides/ov_123"},
+		Action:   "read_override",
+	}
+
+	tests := []struct {
+		name    string
+		granted UnkeyPermission
+		want    bool
+	}{
+		{
+			name:    "exact permission",
+			granted: required,
+			want:    true,
+		},
+		{
+			name: "segment wildcard permission",
+			granted: UnkeyPermission{
+				Resource: urn.V1{WorkspaceID: "ws_123", Resource: "ratelimits/namespaces/ns_123/overrides/*"},
+				Action:   "read_override",
+			},
+			want: true,
+		},
+		{
+			name: "workos wildcard permission",
+			granted: UnkeyPermission{
+				Resource: urn.V1{WorkspaceID: "ws_123", Resource: "ratelimits/namespaces/*/overrides/*"},
+				Action:   "read_override",
+			},
+			want: true,
+		},
+		{
+			name: "descendant wildcard permission",
+			granted: UnkeyPermission{
+				Resource: urn.V1{WorkspaceID: "ws_123", Resource: "ratelimits/**"},
+				Action:   "read_override",
+			},
+			want: true,
+		},
+		{
+			name: "admin permission",
+			granted: UnkeyPermission{
+				Resource: urn.V1{WorkspaceID: "ws_123", Resource: "**"},
+				Action:   "*",
+			},
+			want: true,
+		},
+		{
+			name: "wrong workspace",
+			granted: UnkeyPermission{
+				Resource: urn.V1{WorkspaceID: "ws_456", Resource: "ratelimits/namespaces/ns_123/overrides/ov_123"},
+				Action:   "read_override",
+			},
+			want: false,
+		},
+		{
+			name: "wrong action",
+			granted: UnkeyPermission{
+				Resource: urn.V1{WorkspaceID: "ws_123", Resource: "ratelimits/namespaces/ns_123/overrides/ov_123"},
+				Action:   "delete_override",
+			},
+			want: false,
+		},
+		{
+			name: "sibling resource",
+			granted: UnkeyPermission{
+				Resource: urn.V1{WorkspaceID: "ws_123", Resource: "ratelimits/namespaces/ns_456/overrides/*"},
+				Action:   "read_override",
+			},
+			want: false,
+		},
+		{
+			name: "shorter exact resource",
+			granted: UnkeyPermission{
+				Resource: urn.V1{WorkspaceID: "ws_123", Resource: "ratelimits/namespaces/ns_123"},
+				Action:   "read_override",
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.want, permissionCovers(required, tt.granted))
+		})
+	}
+}
+
+// TestUrnPermissionEvaluation_MatchesThroughRBACEvaluator guarantees the public
+// RBAC evaluator applies URN wildcard semantics, not just private helpers.
+func TestUrnPermissionEvaluation_MatchesThroughRBACEvaluator(t *testing.T) {
+	t.Parallel()
+
+	query := U(
+		urn.New().
+			Workspace("ws_123").
+			RatelimitNamespace("ns_123").
+			Override("ov_123"),
+		permissions.ReadOverride{},
+	)
+
+	tests := []struct {
+		name        string
+		permissions []string
+		wantValid   bool
+	}{
+		{
+			name: "exact permission",
+			permissions: []string{
+				"unkey:v1:ws_123:ratelimits/namespaces/ns_123/overrides/ov_123#read_override",
+			},
+			wantValid: true,
+		},
+		{
+			name: "namespace override wildcard permission",
+			permissions: []string{
+				"unkey:v1:ws_123:ratelimits/namespaces/ns_123/overrides/*#read_override",
+			},
+			wantValid: true,
+		},
+		{
+			name: "workos wildcard namespace permission",
+			permissions: []string{
+				"unkey:v1:ws_123:ratelimits/namespaces/*/overrides/*#read_override",
+			},
+			wantValid: true,
+		},
+		{
+			name: "ratelimits descendant permission",
+			permissions: []string{
+				"unkey:v1:ws_123:ratelimits/**#read_override",
+			},
+			wantValid: true,
+		},
+		{
+			name: "admin permission",
+			permissions: []string{
+				"unkey:v1:ws_123:**#*",
+			},
+			wantValid: true,
+		},
+		{
+			name: "malformed grants are ignored",
+			permissions: []string{
+				"unkey:v1:ws_123:ratelimits/namespaces/ns_123/overrides/**/nested#read_override",
+				"unkey:v1:ws_123:ratelimits/namespaces/ns_123/overrides/ov_123#delete_override",
+				"ratelimit.ns_123.read_override",
+			},
+			wantValid: false,
+		},
+		{
+			name: "wrong workspace",
+			permissions: []string{
+				"unkey:v1:ws_456:ratelimits/namespaces/ns_123/overrides/*#read_override",
+			},
+			wantValid: false,
+		},
+	}
+
+	rbac := New()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := rbac.EvaluatePermissions(query, tt.permissions)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantValid, result.Valid, result.Message)
+		})
+	}
+}
+
+// FuzzParseUrnPermission_InvalidInputNeverProducesUnsafePermission guarantees
+// arbitrary strings either fail parsing or produce self-covering valid permissions.
+func FuzzParseUrnPermission_InvalidInputNeverProducesUnsafePermission(f *testing.F) {
+	fuzz.Seed(f)
+	for _, seed := range []string{
+		"",
+		"unkey:v1:ws_123:ratelimits/namespaces/ns_123/overrides/ov_123#read_override",
+		"unkey:v1:ws_123:ratelimits/namespaces/*/overrides/*#read_override",
+		"unkey:v1:ws_123:ratelimits/**#read_override",
+		"unkey:v1:ws_123:**#*",
+		"unkey:v1:ws_123:ratelimits/**/overrides/*#read_override",
+		"unkey:v1:ws_123:ratelimits/namespaces/ns_123#read#override",
+	} {
+		f.Add(fuzzStringSeed(seed))
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		c := fuzz.New(t, data)
+		value := c.String()
+
+		permission, err := parseUrnPermission(value)
+		if err != nil {
+			return
+		}
+
+		require.NotEmpty(t, permission.Resource.WorkspaceID)
+		require.NotEmpty(t, permission.Resource.Resource)
+		require.NotEmpty(t, permission.Action)
+		_, err = urn.ParseV1(permission.Resource.String())
+		require.NoError(t, err)
+		require.NoError(t, validatePermissionAction(string(permission.Action)))
+		require.True(t, permissionCovers(permission, permission))
+	})
+}
+
+func fuzzStringSeed(values ...string) []byte {
+	out := make([]byte, 0)
+	for _, value := range values {
+		out = binary.BigEndian.AppendUint16(out, uint16(len(value)))
+		out = append(out, value...)
+	}
+	return out
+}

--- a/pkg/urn/BUILD.bazel
+++ b/pkg/urn/BUILD.bazel
@@ -1,0 +1,34 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "urn",
+    srcs = [
+        "doc.go",
+        "resources.go",
+        "resources_app.go",
+        "resources_billing.go",
+        "resources_deployment.go",
+        "resources_environment.go",
+        "resources_keyspace.go",
+        "resources_portal.go",
+        "resources_project.go",
+        "resources_ratelimit.go",
+        "resources_rbac.go",
+        "resources_team.go",
+        "resources_workspace.go",
+        "urn.go",
+    ],
+    importpath = "github.com/unkeyed/unkey/pkg/urn",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "urn_test",
+    size = "small",
+    srcs = ["urn_test.go"],
+    embed = [":urn"],
+    deps = [
+        "//pkg/fuzz",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/urn/doc.go
+++ b/pkg/urn/doc.go
@@ -1,0 +1,25 @@
+// Package urn constructs and parses Unkey resource names.
+//
+// A v1 resource name has four colon-separated fields:
+//
+//	unkey:v1:{workspace_id}:{resource_path}
+//
+// A resource permission adds an action suffix:
+//
+//	unkey:v1:{workspace_id}:{resource_path}#{action}
+//
+// [ParseV1] accepts both concrete resource names and resource-name patterns:
+// "*" matches one path segment and a trailing "/**" matches all descendants.
+// [V1.Covers] decides whether a pattern covers a concrete name. Callers that
+// require one concrete resource, such as audit logs, must reject wildcard
+// paths themselves. The permission action and authorization semantics live
+// outside this package.
+//
+// [New] exposes typed resource builders. For example:
+//
+//	urn.New().Workspace("ws_123").Project("proj_123").App("app_123").Any()
+//
+// See:
+//   - docs/engineering/architecture/resources/unkey-resource-names.mdx
+//   - docs/engineering/architecture/authorization/resource-permissions.mdx
+package urn

--- a/pkg/urn/resources.go
+++ b/pkg/urn/resources.go
@@ -1,0 +1,26 @@
+package urn
+
+// New returns builders for canonical Unkey resource names.
+func New() Builder {
+	return Builder{}
+}
+
+// Builder starts typed URN construction.
+type Builder struct{}
+
+// Workspace returns builders for canonical v1 resource names in a workspace.
+//
+// Workspace is the root of every v1 Unkey resource name:
+//
+//	unkey:v1:{workspace_id}:{resource_path}
+//
+// Every builder below this point stays inside this workspace. A wildcard such
+// as "**" can cover every resource in this workspace, but never crosses into
+// another workspace.
+func (Builder) Workspace(workspaceID string) workspace {
+	return workspace{
+		workspaceID: workspaceID,
+		Team:        team{workspaceID: workspaceID, path: "team"},
+		RBAC:        rbac{workspaceID: workspaceID, path: "rbac"},
+	}
+}

--- a/pkg/urn/resources_app.go
+++ b/pkg/urn/resources_app.go
@@ -1,0 +1,43 @@
+package urn
+
+import "fmt"
+
+// App builds app resource paths.
+//
+// Hierarchy:
+//
+//	workspace
+//	└── projects/{project_id}
+//	    └── apps/{app_id}
+type App struct {
+	workspaceID string
+	path        string
+}
+
+// String returns this app resource path.
+//
+// Subresource:
+//
+//	projects/{project_id}
+//	└── apps/{app_id}
+func (a App) String() string {
+	return V1{WorkspaceID: a.workspaceID, Resource: a.path}.String()
+}
+
+// Environment returns builders for environment resource paths.
+//
+// Subresource:
+//
+//	apps/{app_id}
+//	└── environments/{environment_id}
+func (a App) Environment(environmentID string) Environment {
+	return Environment{workspaceID: a.workspaceID, path: fmt.Sprintf("%s/environments/%s", a.path, environmentID)}
+}
+
+// Any returns a descendant pattern below this app.
+func (a App) Any() V1 {
+	return V1{
+		WorkspaceID: a.workspaceID,
+		Resource:    a.path + "/**",
+	}
+}

--- a/pkg/urn/resources_billing.go
+++ b/pkg/urn/resources_billing.go
@@ -1,0 +1,40 @@
+package urn
+
+import "fmt"
+
+// billing builds billing resource paths.
+//
+// Hierarchy:
+//
+//	workspace
+//	└── billing
+type billing struct {
+	workspaceID string
+	path        string
+}
+
+// Invoice returns a billing invoice resource path.
+//
+// Subresource:
+//
+//	billing
+//	└── invoices/{invoice_id}
+func (b billing) Invoice(invoiceID string) V1 {
+	return V1{
+		WorkspaceID: b.workspaceID,
+		Resource:    fmt.Sprintf("%s/invoices/%s", b.path, invoiceID),
+	}
+}
+
+// Quotas returns the workspace billing quotas resource path.
+//
+// Subresource:
+//
+//	billing
+//	└── quotas
+func (b billing) Quotas() V1 {
+	return V1{
+		WorkspaceID: b.workspaceID,
+		Resource:    b.path + "/quotas",
+	}
+}

--- a/pkg/urn/resources_deployment.go
+++ b/pkg/urn/resources_deployment.go
@@ -1,0 +1,48 @@
+package urn
+
+import "fmt"
+
+// Deployment builds deployment resource paths.
+//
+// Hierarchy:
+//
+//	workspace
+//	└── projects/{project_id}
+//	    └── apps/{app_id}
+//	        └── environments/{environment_id}
+//	            └── deployments/{deployment_id}
+type Deployment struct {
+	workspaceID string
+	path        string
+}
+
+// String returns this deployment resource path.
+//
+// Subresource:
+//
+//	environments/{environment_id}
+//	└── deployments/{deployment_id}
+func (d Deployment) String() string {
+	return V1{WorkspaceID: d.workspaceID, Resource: d.path}.String()
+}
+
+// Instance returns a deployment instance resource path.
+//
+// Subresource:
+//
+//	deployments/{deployment_id}
+//	└── instances/{instance_id}
+func (d Deployment) Instance(instanceID string) V1 {
+	return V1{
+		WorkspaceID: d.workspaceID,
+		Resource:    fmt.Sprintf("%s/instances/%s", d.path, instanceID),
+	}
+}
+
+// Any returns a descendant pattern below this deployment.
+func (d Deployment) Any() V1 {
+	return V1{
+		WorkspaceID: d.workspaceID,
+		Resource:    d.path + "/**",
+	}
+}

--- a/pkg/urn/resources_environment.go
+++ b/pkg/urn/resources_environment.go
@@ -1,0 +1,70 @@
+package urn
+
+import "fmt"
+
+// Environment builds environment resource paths.
+//
+// Hierarchy:
+//
+//	workspace
+//	└── projects/{project_id}
+//	    └── apps/{app_id}
+//	        └── environments/{environment_id}
+type Environment struct {
+	workspaceID string
+	path        string
+}
+
+// String returns this environment resource path.
+//
+// Subresource:
+//
+//	apps/{app_id}
+//	└── environments/{environment_id}
+func (e Environment) String() string {
+	return V1{WorkspaceID: e.workspaceID, Resource: e.path}.String()
+}
+
+// Deployment returns builders for deployment resource paths.
+//
+// Subresource:
+//
+//	environments/{environment_id}
+//	└── deployments/{deployment_id}
+func (e Environment) Deployment(deploymentID string) Deployment {
+	return Deployment{workspaceID: e.workspaceID, path: fmt.Sprintf("%s/deployments/%s", e.path, deploymentID)}
+}
+
+// Domain returns a domain resource path.
+//
+// Subresource:
+//
+//	environments/{environment_id}
+//	└── domains/{domain_id}
+func (e Environment) Domain(domainID string) V1 {
+	return V1{
+		WorkspaceID: e.workspaceID,
+		Resource:    fmt.Sprintf("%s/domains/%s", e.path, domainID),
+	}
+}
+
+// Variable returns a variable resource path.
+//
+// Subresource:
+//
+//	environments/{environment_id}
+//	└── variables/{variable_id}
+func (e Environment) Variable(variableID string) V1 {
+	return V1{
+		WorkspaceID: e.workspaceID,
+		Resource:    fmt.Sprintf("%s/variables/%s", e.path, variableID),
+	}
+}
+
+// Any returns a descendant pattern below this environment.
+func (e Environment) Any() V1 {
+	return V1{
+		WorkspaceID: e.workspaceID,
+		Resource:    e.path + "/**",
+	}
+}

--- a/pkg/urn/resources_keyspace.go
+++ b/pkg/urn/resources_keyspace.go
@@ -1,0 +1,61 @@
+package urn
+
+import "fmt"
+
+// Keyspace builds keyspace resource paths.
+//
+// Hierarchy:
+//
+//	workspace
+//	└── keyspaces/{keyspace_id}
+//
+// A keyspace can also produce a descendant pattern for grants covering every
+// key and future keyspace child.
+type Keyspace struct {
+	workspaceID string
+	path        string
+}
+
+// String returns this keyspace resource path.
+//
+// Subresource:
+//
+//	workspace
+//	└── keyspaces/{keyspace_id}
+func (k Keyspace) String() string {
+	return V1{WorkspaceID: k.workspaceID, Resource: k.path}.String()
+}
+
+// Key is a key resource path.
+type Key struct {
+	workspaceID string
+	path        string
+}
+
+// String returns this key resource path.
+func (k Key) String() string {
+	return V1{WorkspaceID: k.workspaceID, Resource: k.path}.String()
+}
+
+// V1 returns this key as a parsed v1 resource name.
+func (k Key) V1() V1 {
+	return V1{WorkspaceID: k.workspaceID, Resource: k.path}
+}
+
+// Key returns a key resource path.
+//
+// Subresource:
+//
+//	keyspaces/{keyspace_id}
+//	└── keys/{key_id}
+func (k Keyspace) Key(keyID string) Key {
+	return Key{workspaceID: k.workspaceID, path: fmt.Sprintf("%s/keys/%s", k.path, keyID)}
+}
+
+// Any returns a descendant pattern below this keyspace.
+func (k Keyspace) Any() V1 {
+	return V1{
+		WorkspaceID: k.workspaceID,
+		Resource:    k.path + "/**",
+	}
+}

--- a/pkg/urn/resources_portal.go
+++ b/pkg/urn/resources_portal.go
@@ -1,0 +1,71 @@
+package urn
+
+import "fmt"
+
+// Portal builds portal resource paths.
+//
+// Hierarchy:
+//
+//	workspace
+//	└── portals/{portal_id}
+type Portal struct {
+	workspaceID string
+	path        string
+}
+
+// String returns this portal resource path.
+//
+// Subresource:
+//
+//	workspace
+//	└── portals/{portal_id}
+func (p Portal) String() string {
+	return V1{WorkspaceID: p.workspaceID, Resource: p.path}.String()
+}
+
+// SessionToken returns a portal session token resource path.
+//
+// Subresource:
+//
+//	portals/{portal_id}
+//	└── session_tokens/{portal_session_token_id}
+func (p Portal) SessionToken(tokenID string) V1 {
+	return V1{
+		WorkspaceID: p.workspaceID,
+		Resource:    fmt.Sprintf("%s/session_tokens/%s", p.path, tokenID),
+	}
+}
+
+// Session returns a portal session resource path.
+//
+// Subresource:
+//
+//	portals/{portal_id}
+//	└── sessions/{session_id}
+func (p Portal) Session(sessionID string) V1 {
+	return V1{
+		WorkspaceID: p.workspaceID,
+		Resource:    fmt.Sprintf("%s/sessions/%s", p.path, sessionID),
+	}
+}
+
+// Branding returns a portal branding resource path.
+//
+// Subresource:
+//
+//	portals/{portal_id}
+//	└── branding
+func (p Portal) Branding() V1 {
+	return V1{
+		WorkspaceID: p.workspaceID,
+		Resource:    p.path + "/branding",
+	}
+}
+
+// Any returns a descendant pattern below this portal.
+func (p Portal) Any() V1 {
+	return V1{
+		WorkspaceID: p.workspaceID,
+		Resource:    p.path + "/**",
+	}
+}

--- a/pkg/urn/resources_project.go
+++ b/pkg/urn/resources_project.go
@@ -1,0 +1,44 @@
+package urn
+
+import "fmt"
+
+// Project builds project resource paths.
+//
+// Hierarchy:
+//
+//	workspace
+//	└── projects/{project_id}
+//
+// Projects are owned by a workspace.
+type Project struct {
+	workspaceID string
+	path        string
+}
+
+// String returns this project resource path.
+//
+// Subresource:
+//
+//	workspace
+//	└── projects/{project_id}
+func (p Project) String() string {
+	return V1{WorkspaceID: p.workspaceID, Resource: p.path}.String()
+}
+
+// App returns builders for app resource paths.
+//
+// Subresource:
+//
+//	projects/{project_id}
+//	└── apps/{app_id}
+func (p Project) App(appID string) App {
+	return App{workspaceID: p.workspaceID, path: fmt.Sprintf("%s/apps/%s", p.path, appID)}
+}
+
+// Any returns a descendant pattern below this project.
+func (p Project) Any() V1 {
+	return V1{
+		WorkspaceID: p.workspaceID,
+		Resource:    p.path + "/**",
+	}
+}

--- a/pkg/urn/resources_ratelimit.go
+++ b/pkg/urn/resources_ratelimit.go
@@ -1,0 +1,61 @@
+package urn
+
+import "fmt"
+
+// RatelimitNamespace builds rate limit namespace resource paths.
+//
+// Hierarchy:
+//
+//	workspace
+//	└── ratelimits/namespaces/{namespace_id}
+//
+// The namespace is intentionally below the literal "ratelimits" segment so all
+// rate limit resources can share one top-level workspace branch.
+type RatelimitNamespace struct {
+	workspaceID string
+	path        string
+}
+
+// String returns this rate limit namespace resource path.
+//
+// Subresource:
+//
+//	workspace
+//	└── ratelimits/namespaces/{namespace_id}
+func (r RatelimitNamespace) String() string {
+	return V1{WorkspaceID: r.workspaceID, Resource: r.path}.String()
+}
+
+// RatelimitOverride is a rate limit override resource path.
+type RatelimitOverride struct {
+	workspaceID string
+	path        string
+}
+
+// String returns this rate limit override resource path.
+func (r RatelimitOverride) String() string {
+	return V1{WorkspaceID: r.workspaceID, Resource: r.path}.String()
+}
+
+// V1 returns this rate limit override as a parsed v1 resource name.
+func (r RatelimitOverride) V1() V1 {
+	return V1{WorkspaceID: r.workspaceID, Resource: r.path}
+}
+
+// Override returns a rate limit override resource path.
+//
+// Subresource:
+//
+//	ratelimits/namespaces/{namespace_id}
+//	└── overrides/{override_id}
+func (r RatelimitNamespace) Override(overrideID string) RatelimitOverride {
+	return RatelimitOverride{workspaceID: r.workspaceID, path: fmt.Sprintf("%s/overrides/%s", r.path, overrideID)}
+}
+
+// Any returns a descendant pattern below this rate limit namespace.
+func (r RatelimitNamespace) Any() V1 {
+	return V1{
+		WorkspaceID: r.workspaceID,
+		Resource:    r.path + "/**",
+	}
+}

--- a/pkg/urn/resources_rbac.go
+++ b/pkg/urn/resources_rbac.go
@@ -1,0 +1,40 @@
+package urn
+
+import "fmt"
+
+// rbac builds RBAC resource paths.
+//
+// Hierarchy:
+//
+//	workspace
+//	└── rbac
+type rbac struct {
+	workspaceID string
+	path        string
+}
+
+// Role returns an RBAC role resource path.
+//
+// Subresource:
+//
+//	rbac
+//	└── roles/{role_id}
+func (r rbac) Role(roleID string) V1 {
+	return V1{
+		WorkspaceID: r.workspaceID,
+		Resource:    fmt.Sprintf("%s/roles/%s", r.path, roleID),
+	}
+}
+
+// Permission returns an RBAC permission resource path.
+//
+// Subresource:
+//
+//	rbac
+//	└── permissions/{permission_id}
+func (r rbac) Permission(permissionID string) V1 {
+	return V1{
+		WorkspaceID: r.workspaceID,
+		Resource:    fmt.Sprintf("%s/permissions/%s", r.path, permissionID),
+	}
+}

--- a/pkg/urn/resources_team.go
+++ b/pkg/urn/resources_team.go
@@ -1,0 +1,40 @@
+package urn
+
+import "fmt"
+
+// team builds team resource paths.
+//
+// Hierarchy:
+//
+//	workspace
+//	└── team
+type team struct {
+	workspaceID string
+	path        string
+}
+
+// Membership returns a team membership resource path.
+//
+// Subresource:
+//
+//	team
+//	└── memberships/{membership_id}
+func (t team) Membership(membershipID string) V1 {
+	return V1{
+		WorkspaceID: t.workspaceID,
+		Resource:    fmt.Sprintf("%s/memberships/%s", t.path, membershipID),
+	}
+}
+
+// Invitation returns a team invitation resource path.
+//
+// Subresource:
+//
+//	team
+//	└── invitations/{invitation_id}
+func (t team) Invitation(invitationID string) V1 {
+	return V1{
+		WorkspaceID: t.workspaceID,
+		Resource:    fmt.Sprintf("%s/invitations/%s", t.path, invitationID),
+	}
+}

--- a/pkg/urn/resources_workspace.go
+++ b/pkg/urn/resources_workspace.go
@@ -1,0 +1,92 @@
+package urn
+
+import "fmt"
+
+// workspace builds resource paths inside one workspace.
+//
+// Hierarchy:
+//
+//	workspace
+//	├── team
+//	├── billing
+//	├── keyspaces/{keyspace_id}
+//	├── identities/{identity_id}
+//	├── ratelimits/namespaces/{namespace_id}
+//	├── rbac
+//	├── projects/{project_id}
+//	└── portals/{portal_id}
+//
+// Children with their own descendants return another typed builder. Leaf
+// resources return V1 directly.
+type workspace struct {
+	workspaceID string
+
+	// Team builds team resource paths in this workspace.
+	Team team
+
+	// RBAC builds RBAC resource paths in this workspace.
+	RBAC rbac
+}
+
+// Billing returns builders for billing resource paths.
+//
+// Subresource:
+//
+//	workspace
+//	└── billing
+func (w workspace) Billing() billing {
+	return billing{workspaceID: w.workspaceID, path: "billing"}
+}
+
+// Keyspace returns builders for keyspace resource paths.
+//
+// Subresource:
+//
+//	workspace
+//	└── keyspaces/{keyspace_id}
+func (w workspace) Keyspace(keyspaceID string) Keyspace {
+	return Keyspace{workspaceID: w.workspaceID, path: fmt.Sprintf("keyspaces/%s", keyspaceID)}
+}
+
+// Identity returns an identity resource path.
+func (w workspace) Identity(identityID string) V1 {
+	return w.v1(fmt.Sprintf("identities/%s", identityID))
+}
+
+// RatelimitNamespace returns builders for rate limit namespace resource paths.
+//
+// Subresource:
+//
+//	workspace
+//	└── ratelimits/namespaces/{namespace_id}
+func (w workspace) RatelimitNamespace(namespaceID string) RatelimitNamespace {
+	return RatelimitNamespace{workspaceID: w.workspaceID, path: fmt.Sprintf("ratelimits/namespaces/%s", namespaceID)}
+}
+
+// Project returns builders for project resource paths.
+//
+// Subresource:
+//
+//	workspace
+//	└── projects/{project_id}
+func (w workspace) Project(projectID string) Project {
+	return Project{workspaceID: w.workspaceID, path: fmt.Sprintf("projects/%s", projectID)}
+}
+
+// Portal returns builders for portal resource paths.
+//
+// Subresource:
+//
+//	workspace
+//	└── portals/{portal_id}
+func (w workspace) Portal(portalID string) Portal {
+	return Portal{workspaceID: w.workspaceID, path: fmt.Sprintf("portals/%s", portalID)}
+}
+
+// v1 wraps a resource path in a [V1] for this workspace.
+func (w workspace) v1(path string) V1 {
+	return V1{
+		WorkspaceID: w.workspaceID,
+		Resource:    path,
+	}
+}

--- a/pkg/urn/urn.go
+++ b/pkg/urn/urn.go
@@ -1,0 +1,181 @@
+package urn
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+const (
+	prefix  = "unkey"
+	version = "v1"
+)
+
+// ErrInvalidResourceName is returned when a resource name cannot be parsed.
+var ErrInvalidResourceName = errors.New("invalid resource name")
+
+// V1 is a parsed v1 Unkey resource name.
+type V1 struct {
+	WorkspaceID string
+	Resource    string
+}
+
+// String returns the canonical v1 resource-name string.
+func (v V1) String() string {
+	return fmt.Sprintf("%s:%s:%s:%s", prefix, version, v.WorkspaceID, v.Resource)
+}
+
+// Covers reports whether the receiver, treated as a resource-name pattern,
+// covers the target resource name. The workspace must match exactly. In the
+// resource path, "*" matches exactly one path segment and a trailing "**"
+// matches the base path and all descendants. A concrete resource name covers
+// only itself. The standalone path "**" is the global pattern covering every
+// resource in the workspace; the standalone path "*" covers only resources
+// with single-segment paths.
+//
+// These patterns cover unkey:v1:ws_1:keyspaces/ks_1/keys/k_1:
+//
+//	unkey:v1:ws_1:keyspaces/ks_1/keys/k_1   (itself)
+//	unkey:v1:ws_1:keyspaces/*/keys/*
+//	unkey:v1:ws_1:keyspaces/ks_1/**
+//	unkey:v1:ws_1:**
+//
+// and these do not:
+//
+//	unkey:v1:ws_1:keyspaces/ks_1            (concrete name, not the same resource)
+//	unkey:v1:ws_1:keyspaces/*               ("*" does not cross into keys/k_1)
+//	unkey:v1:ws_1:*                         ("*" is one segment, not a global wildcard)
+//	unkey:v1:ws_2:**                        (different workspace)
+func (v V1) Covers(target V1) bool {
+	if v.WorkspaceID != target.WorkspaceID {
+		return false
+	}
+	patternSegments := strings.Split(v.Resource, "/")
+	targetSegments := strings.Split(target.Resource, "/")
+
+	if len(patternSegments) > 0 && patternSegments[len(patternSegments)-1] == "**" {
+		patternSegments = patternSegments[:len(patternSegments)-1]
+		return len(targetSegments) >= len(patternSegments) &&
+			segmentsMatch(patternSegments, targetSegments[:len(patternSegments)])
+	}
+
+	return len(patternSegments) == len(targetSegments) &&
+		segmentsMatch(patternSegments, targetSegments)
+}
+
+// segmentsMatch compares equal-length segment slices, treating "*" in the
+// pattern as matching any single target segment.
+func segmentsMatch(pattern []string, target []string) bool {
+	for i := range pattern {
+		if pattern[i] != "*" && pattern[i] != target[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// ParseV1 parses a v1 resource name of the form
+//
+//	unkey:v1:{workspace_id}:{resource_path}
+//
+// The resource path may be concrete or a pattern: "*" matches exactly one
+// path segment and a trailing "/**" matches the base path and all
+// descendants. Whether a wildcard path is acceptable is the caller's concern;
+// the parser only enforces the grammar.
+//
+// Accepted:
+//
+//	unkey:v1:ws_123:keyspaces/ks_1/keys/k_1    concrete resource name
+//	unkey:v1:ws_123:keyspaces/*/keys/*         one wildcard per segment
+//	unkey:v1:ws_123:ratelimits/**              descendant scope
+//	unkey:v1:ws_123:**                         everything in the workspace
+//
+// Rejected with [ErrInvalidResourceName]:
+//
+//	unkey:v1:ws_123                            missing resource path
+//	unkey:v1:ws_123:keyspaces/ks_1#read_key    "#" belongs to permissions, not URNs
+//	unkey:v1:ws_123:keyspaces/ks_*             "*" must be a whole segment
+//	unkey:v1:ws_123:ratelimits/**/overrides    "**" must be the last segment
+//	unkey:v1:ws_123:projects/*/apps/app_123    specific selector nested under "*"
+func ParseV1(value string) (V1, error) {
+	parts := strings.SplitN(value, ":", 4)
+	if len(parts) != 4 {
+		return V1{}, fmt.Errorf("%w: expected 4 colon-separated fields", ErrInvalidResourceName)
+	}
+	if parts[0] != prefix {
+		return V1{}, fmt.Errorf("%w: prefix must be %q", ErrInvalidResourceName, prefix)
+	}
+	if parts[1] != version {
+		return V1{}, fmt.Errorf("%w: version must be %q", ErrInvalidResourceName, version)
+	}
+	if err := validateWorkspaceID(parts[2]); err != nil {
+		return V1{}, fmt.Errorf("%w: invalid workspace id: %v", ErrInvalidResourceName, err)
+	}
+	if err := validateResourcePath(parts[3]); err != nil {
+		return V1{}, fmt.Errorf("%w: invalid resource path: %v", ErrInvalidResourceName, err)
+	}
+
+	return V1{
+		WorkspaceID: parts[2],
+		Resource:    parts[3],
+	}, nil
+}
+
+// validateWorkspaceID enforces two invariants on the workspace field:
+//
+//  1. It is not empty.
+//  2. It contains none of the reserved characters ":" (URN field separator),
+//     "#" (permission action separator), and "/" (path segment separator).
+func validateWorkspaceID(value string) error {
+	if value == "" {
+		return errors.New("must not be empty")
+	}
+	if strings.ContainsAny(value, ":#/") {
+		return errors.New(`must not contain ":", "#", or "/"`)
+	}
+	return nil
+}
+
+// validateResourcePath enforces five invariants on every "/"-separated path
+// segment:
+//
+//  1. No segment is empty. This subsumes rejecting an empty path and paths
+//     with a leading, trailing, or doubled "/".
+//  2. No segment contains ":" (URN field separator) or "#" (permission action
+//     separator).
+//  3. "*" appears only as a whole segment, never inside one, so a wildcard
+//     can only ever expand to exactly one segment.
+//  4. "**" appears only as the final segment, so a descendant scope cannot
+//     have a suffix constraint the matcher would have to guess about.
+//  5. Once an id selector is "*", later id selectors must also be "*" or a
+//     trailing "**" descendant scope. A path may continue through concrete
+//     collection labels, such as "projects/*/apps/*" or "projects/*/apps/**",
+//     but it cannot narrow again to a specific child like
+//     "projects/*/apps/app_123".
+func validateResourcePath(path string) error {
+	segments := strings.Split(path, "/")
+	seenWildcardSelector := false
+	for i, segment := range segments {
+		isLastSegment := i == len(segments)-1
+
+		switch {
+		case segment == "":
+			return errors.New("must not contain empty segments")
+		case strings.ContainsAny(segment, ":#"):
+			return errors.New(`must not contain ":" or "#"`)
+		case segment == "*":
+			seenWildcardSelector = true
+		case segment == "**":
+			if !isLastSegment {
+				return errors.New(`"**" must be the last segment`)
+			}
+		case strings.Contains(segment, "*"):
+			return errors.New(`"*" must be a whole segment`)
+		case seenWildcardSelector:
+			if isLastSegment || (segments[i+1] != "*" && segments[i+1] != "**") {
+				return errors.New(`specific selectors must not appear below "*"`)
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/urn/urn_test.go
+++ b/pkg/urn/urn_test.go
@@ -1,0 +1,277 @@
+package urn
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/fuzz"
+)
+
+// TestParseV1 guarantees concrete v1 resource names round-trip
+// through parsing.
+func TestParseV1(t *testing.T) {
+	t.Parallel()
+
+	resource, err := ParseV1("unkey:v1:ws_123:projects/proj_123/apps/app_456")
+	require.NoError(t, err)
+	require.Equal(t, V1{
+		WorkspaceID: "ws_123",
+		Resource:    "projects/proj_123/apps/app_456",
+	}, resource)
+	require.Equal(t, "unkey:v1:ws_123:projects/proj_123/apps/app_456", resource.String())
+}
+
+// TestParseV1_AllowsResourcePatterns guarantees RBAC grants can use resource
+// wildcards in the shared resource-name grammar.
+func TestParseV1_AllowsResourcePatterns(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value string
+		want  V1
+	}{
+		{
+			name:  "segment wildcard",
+			value: "unkey:v1:ws_123:ratelimits/namespaces/*/overrides/*",
+			want: V1{
+				WorkspaceID: "ws_123",
+				Resource:    "ratelimits/namespaces/*/overrides/*",
+			},
+		},
+		{
+			name:  "nested segment wildcards",
+			value: "unkey:v1:ws_123:projects/*/apps/*/environments/*/deployments/*",
+			want: V1{
+				WorkspaceID: "ws_123",
+				Resource:    "projects/*/apps/*/environments/*/deployments/*",
+			},
+		},
+		{
+			name:  "wildcard project apps descendant scope",
+			value: "unkey:v1:ws_123:projects/*/apps/**",
+			want: V1{
+				WorkspaceID: "ws_123",
+				Resource:    "projects/*/apps/**",
+			},
+		},
+		{
+			name:  "wildcard keyspace keys descendant scope",
+			value: "unkey:v1:ws_123:keyspaces/*/keys/**",
+			want: V1{
+				WorkspaceID: "ws_123",
+				Resource:    "keyspaces/*/keys/**",
+			},
+		},
+		{
+			name:  "wildcard ratelimit overrides descendant scope",
+			value: "unkey:v1:ws_123:ratelimits/namespaces/*/overrides/**",
+			want: V1{
+				WorkspaceID: "ws_123",
+				Resource:    "ratelimits/namespaces/*/overrides/**",
+			},
+		},
+		{
+			name:  "descendant wildcard",
+			value: "unkey:v1:ws_123:ratelimits/**",
+			want: V1{
+				WorkspaceID: "ws_123",
+				Resource:    "ratelimits/**",
+			},
+		},
+		{
+			name:  "single segment wildcard",
+			value: "unkey:v1:ws_123:*",
+			want: V1{
+				WorkspaceID: "ws_123",
+				Resource:    "*",
+			},
+		},
+		{
+			name:  "global wildcard",
+			value: "unkey:v1:ws_123:**",
+			want: V1{
+				WorkspaceID: "ws_123",
+				Resource:    "**",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ParseV1(tt.value)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestParseV1RejectsInvalidValues guarantees malformed values cannot be
+// treated as resource names.
+func TestParseV1RejectsInvalidValues(t *testing.T) {
+	t.Parallel()
+
+	for _, value := range []string{
+		"",
+		"urn:unkey:v1:ws_123:keyspaces/ks_123",
+		"unkey:v1:ws_123",
+		"unkey:v2:ws_123:keyspaces/ks_123",
+		"unkey:v1::keyspaces/ks_123",
+		"unkey:v1:ws_123:keyspaces/ks_123#read_keyspace",
+		"unkey:v1:ws_123:/keyspaces/ks_123",
+		"unkey:v1:ws_123:keyspaces/ks_123/",
+		"unkey:v1:ws_123:keyspaces//ks_123",
+	} {
+		_, err := ParseV1(value)
+		require.ErrorIs(t, err, ErrInvalidResourceName, value)
+	}
+}
+
+// TestParseV1_RejectsAmbiguousPatterns guarantees "*" only expands as
+// a full path segment and "**" only appears at the end of a resource path.
+func TestParseV1_RejectsAmbiguousPatterns(t *testing.T) {
+	t.Parallel()
+
+	for _, value := range []string{
+		"unkey:v1:ws_123:ratelimits/**/overrides/*",
+		"unkey:v1:ws_123:ratelimits/namespaces/ns_*",
+		"unkey:v1:ws_123:projects/*/apps/app_123",
+		"unkey:v1:ws_123:projects/proj_123/apps/*/environments/env_123",
+		"unkey:v1:ws_123:projects/proj_123/apps/*/environments/*/deployments/dep_123",
+		"unkey:v1:ws_123:ratelimits/namespaces/*/overrides/override_123",
+		"unkey:v1:ws_123:/ratelimits/*",
+		"unkey:v1:ws_123:ratelimits//namespaces/*",
+		"unkey:v1:ws_123:ratelimits/*/",
+	} {
+		_, err := ParseV1(value)
+		require.ErrorIs(t, err, ErrInvalidResourceName, value)
+	}
+}
+
+// TestResourceCatalogHelpers guarantees the typed builders produce the resource
+// paths documented for API handlers and permission grants.
+func TestResourceCatalogHelpers(t *testing.T) {
+	t.Parallel()
+
+	workspace := New().Workspace("ws_123")
+	require.Equal(t, "unkey:v1:ws_123:team/memberships/mbr_123", workspace.Team.Membership("mbr_123").String())
+	require.Equal(t, "unkey:v1:ws_123:team/invitations/inv_123", workspace.Team.Invitation("inv_123").String())
+	require.Equal(t, "unkey:v1:ws_123:billing/invoices/inv_123", workspace.Billing().Invoice("inv_123").String())
+	require.Equal(t, "unkey:v1:ws_123:billing/quotas", workspace.Billing().Quotas().String())
+	require.Equal(t, "unkey:v1:ws_123:keyspaces/ks_123", workspace.Keyspace("ks_123").String())
+	require.Equal(t, "unkey:v1:ws_123:keyspaces/ks_123/keys/key_123", workspace.Keyspace("ks_123").Key("key_123").String())
+	require.Equal(t, "unkey:v1:ws_123:keyspaces/ks_123/**", workspace.Keyspace("ks_123").Any().String())
+	require.Equal(t, "unkey:v1:ws_123:identities/id_123", workspace.Identity("id_123").String())
+	require.Equal(t, "unkey:v1:ws_123:ratelimits/namespaces/ns_123/overrides/ov_123", workspace.RatelimitNamespace("ns_123").Override("ov_123").String())
+	require.Equal(t, "unkey:v1:ws_123:ratelimits/namespaces/ns_123", workspace.RatelimitNamespace("ns_123").String())
+	require.Equal(t, "unkey:v1:ws_123:ratelimits/namespaces/ns_123/**", workspace.RatelimitNamespace("ns_123").Any().String())
+	require.Equal(t, "unkey:v1:ws_123:rbac/roles/role_123", workspace.RBAC.Role("role_123").String())
+	require.Equal(t, "unkey:v1:ws_123:rbac/permissions/perm_123", workspace.RBAC.Permission("perm_123").String())
+	require.Equal(t, "unkey:v1:ws_123:projects/proj_123", workspace.Project("proj_123").String())
+	require.Equal(t, "unkey:v1:ws_123:projects/proj_123/**", workspace.Project("proj_123").Any().String())
+	require.Equal(t, "unkey:v1:ws_123:projects/proj_123/apps/app_123", workspace.Project("proj_123").App("app_123").String())
+	require.Equal(t, "unkey:v1:ws_123:projects/proj_123/apps/app_123/**", workspace.Project("proj_123").App("app_123").Any().String())
+	require.Equal(t, "unkey:v1:ws_123:projects/proj_123/apps/app_123/environments/env_123", workspace.Project("proj_123").App("app_123").Environment("env_123").String())
+	require.Equal(t, "unkey:v1:ws_123:projects/proj_123/apps/app_123/environments/env_123/**", workspace.Project("proj_123").App("app_123").Environment("env_123").Any().String())
+	require.Equal(t, "unkey:v1:ws_123:projects/proj_123/apps/app_123/environments/env_123/deployments/dep_123/instances/inst_123", workspace.Project("proj_123").App("app_123").Environment("env_123").Deployment("dep_123").Instance("inst_123").String())
+	require.Equal(t, "unkey:v1:ws_123:projects/proj_123/apps/app_123/environments/env_123/deployments/dep_123", workspace.Project("proj_123").App("app_123").Environment("env_123").Deployment("dep_123").String())
+	require.Equal(t, "unkey:v1:ws_123:projects/proj_123/apps/app_123/environments/env_123/deployments/dep_123/**", workspace.Project("proj_123").App("app_123").Environment("env_123").Deployment("dep_123").Any().String())
+	require.Equal(t, "unkey:v1:ws_123:projects/proj_123/apps/app_123/environments/env_123/domains/dom_123", workspace.Project("proj_123").App("app_123").Environment("env_123").Domain("dom_123").String())
+	require.Equal(t, "unkey:v1:ws_123:projects/proj_123/apps/app_123/environments/env_123/variables/var_123", workspace.Project("proj_123").App("app_123").Environment("env_123").Variable("var_123").String())
+	require.Equal(t, "unkey:v1:ws_123:portals/portal_123/session_tokens/token_123", workspace.Portal("portal_123").SessionToken("token_123").String())
+	require.Equal(t, "unkey:v1:ws_123:portals/portal_123/sessions/session_123", workspace.Portal("portal_123").Session("session_123").String())
+	require.Equal(t, "unkey:v1:ws_123:portals/portal_123/branding", workspace.Portal("portal_123").Branding().String())
+	require.Equal(t, "unkey:v1:ws_123:portals/portal_123", workspace.Portal("portal_123").String())
+	require.Equal(t, "unkey:v1:ws_123:portals/portal_123/**", workspace.Portal("portal_123").Any().String())
+}
+
+// TestV1Covers_OnlySupportedWildcardsExpandScope guarantees "*" matches one
+// path segment, trailing "**" is the only descendant wildcard, and workspaces
+// must match exactly.
+func TestV1Covers_OnlySupportedWildcardsExpandScope(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		pattern string
+		target  string
+		want    bool
+	}{
+		{name: "global wildcard", pattern: "**", target: "ratelimits/namespaces/ns_123", want: true},
+		{name: "global wildcard covers single segment", pattern: "**", target: "settings", want: true},
+		{name: "single segment wildcard matches one segment", pattern: "*", target: "settings", want: true},
+		{name: "single segment wildcard does not match nested paths", pattern: "*", target: "ratelimits/namespaces/ns_123", want: false},
+		{name: "exact", pattern: "ratelimits/namespaces/ns_123", target: "ratelimits/namespaces/ns_123", want: true},
+		{name: "segment wildcard", pattern: "ratelimits/namespaces/*", target: "ratelimits/namespaces/ns_123", want: true},
+		{name: "descendant wildcard", pattern: "ratelimits/**", target: "ratelimits/namespaces/ns_123", want: true},
+		{name: "descendant wildcard covers base", pattern: "ratelimits/**", target: "ratelimits", want: true},
+		{name: "descendant wildcard target shorter than base", pattern: "ratelimits/namespaces/**", target: "ratelimits", want: false},
+		{name: "descendant wildcard wrong prefix", pattern: "identities/**", target: "ratelimits/namespaces/ns_123", want: false},
+		{name: "segment wildcard does not cross segments", pattern: "ratelimits/*", target: "ratelimits/namespaces/ns_123", want: false},
+		{name: "exact shorter", pattern: "ratelimits", target: "ratelimits/namespaces/ns_123", want: false},
+		{name: "exact longer", pattern: "ratelimits/namespaces/ns_123", target: "ratelimits", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			pattern := V1{WorkspaceID: "ws_123", Resource: tt.pattern}
+			target := V1{WorkspaceID: "ws_123", Resource: tt.target}
+			require.Equal(t, tt.want, pattern.Covers(target))
+		})
+	}
+}
+
+// TestV1Covers_RequiresMatchingWorkspace guarantees no resource pattern, even
+// the global wildcard, crosses workspace boundaries.
+func TestV1Covers_RequiresMatchingWorkspace(t *testing.T) {
+	t.Parallel()
+
+	pattern := V1{WorkspaceID: "ws_123", Resource: "**"}
+	target := V1{WorkspaceID: "ws_456", Resource: "ratelimits/namespaces/ns_123"}
+	require.False(t, pattern.Covers(target))
+}
+
+// FuzzV1Covers_ExactAndGlobalWildcardInvariants guarantees fuzzed matcher
+// inputs preserve the two smallest invariants every caller relies on.
+func FuzzV1Covers_ExactAndGlobalWildcardInvariants(f *testing.F) {
+	fuzz.Seed(f)
+	for _, seed := range []struct {
+		pattern string
+		target  string
+	}{
+		{pattern: "**", target: "ratelimits/namespaces/ns_123"},
+		{pattern: "ratelimits/**", target: "ratelimits/namespaces/ns_123/overrides/ov_123"},
+		{pattern: "ratelimits/namespaces/*", target: "ratelimits/namespaces/ns_123"},
+		{pattern: "ratelimits/namespaces/ns_123", target: "ratelimits/namespaces/ns_123"},
+	} {
+		f.Add(fuzzStringSeed(seed.pattern, seed.target))
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		c := fuzz.New(t, data)
+		pattern := V1{WorkspaceID: "ws_123", Resource: c.String()}
+		target := V1{WorkspaceID: "ws_123", Resource: c.String()}
+
+		got := pattern.Covers(target)
+		if pattern.Resource == target.Resource {
+			require.True(t, got)
+		}
+		if pattern.Resource == "**" {
+			require.True(t, got)
+		}
+	})
+}
+
+func fuzzStringSeed(values ...string) []byte {
+	out := make([]byte, 0)
+	for _, value := range values {
+		out = binary.BigEndian.AppendUint16(out, uint16(len(value)))
+		out = append(out, value...)
+	}
+	return out
+}


### PR DESCRIPTION
We need a better way to handle fine grained permissions.

This allows a user to grant explicit permissions to individual resources, or group of resources, so we do not end up like Railway where an agent can delete broad sets of resources by accident.

Check out the docs in this PR for the details.

Usage examples:

```go
// Creating a key is authorized against the parent keyspace because the key does
// not exist until after the operation succeeds.
err := principal.Authorize(rbac.U(
	urn.New().Workspace(workspaceID).Keyspace(keyspaceID),
	permissions.CreateKey{},
))
```

```go
// Reading a rate limit override is authorized against the concrete override
// resource. Broader stored grants, such as ratelimits/namespaces/{id}/**, still
// match through the URN matcher.
err := principal.Authorize(rbac.U(
	urn.New().
		Workspace(workspaceID).
		RatelimitNamespace(namespaceID).
		Override(overrideID),
	permissions.ReadOverride{},
))
```

To see this in action, check out the other stacked PRs, where we actually use permissions in two handlers as proof of concept.