### PR TITLE
feat(rbac): add URN permissions

### DIFF
--- a/docs/engineering/architecture/authorization/resource-permissions.mdx
+++ b/docs/engineering/architecture/authorization/resource-permissions.mdx
@@ -1,0 +1,284 @@
+---
+title: "Resource permissions"
+description: "Authorization permissions built from Unkey Resource Names"
+---
+
+Resource permissions attach an action to a Unkey Resource Name. They are the
+canonical authorization primitive for root keys, users, service tokens, and any
+other principal that needs scoped access to Unkey resources.
+
+The resource portion follows the [Unkey Resource Names](/architecture/resources/unkey-resource-names)
+contract, including resource-name patterns and their matching semantics. The
+permission layer adds only the action suffix.
+
+Resource parsing and pattern matching, the rules deciding whether a stored
+resource pattern covers a requested concrete URN, live in
+[`pkg/urn`](https://github.com/unkeyed/unkey/tree/main/pkg/urn). Action
+validation and permission evaluation live in
+[`pkg/rbac`](https://github.com/unkeyed/unkey/tree/main/pkg/rbac), which
+delegates resource comparison to `pkg/urn` instead of defining its own.
+
+## Format
+
+A permission has a URN, a `#` separator, and an action.
+
+```plaintext
+unkey:v1:{workspace_id}:{resource_path}#{action}
+```
+
+For example:
+
+```plaintext
+unkey:v1:ws_123:keyspaces/ks_123#read_keyspace
+unkey:v1:ws_123:keyspaces/ks_123/keys/key_456#delete_key
+unkey:v1:ws_123:projects/proj_123/apps/app_456#update_app
+```
+
+The action is not part of the URN. Code that evaluates permissions must parse
+the resource and action separately.
+
+## Actions
+
+Actions are explicit operation names. They use lowercase words separated by
+underscores.
+
+```plaintext
+read_keyspace
+create_key
+delete_deployment
+add_role
+remove_permission
+```
+
+Most permissions name one explicit action. The only action wildcard is `*`,
+which is reserved for the `admin:*` migration escape hatch and is valid only on
+the global resource pattern `**`. There is no shorter global form: `*` matches
+exactly one path segment everywhere it appears, so only `**` covers every
+resource in a workspace.
+
+```plaintext
+unkey:v1:ws_123:**#*
+```
+
+Do not add action wildcards to normal product permissions.
+
+## Patterns
+
+Stored permissions can contain resource patterns. Requested resources in audit
+logs and authorization checks must always use concrete URNs.
+
+`v1` supports two resource-pattern operators.
+
+| Operator | Meaning |
+| --- | --- |
+| `*` | Matches exactly one complete path segment. |
+| `/**` | Matches descendants below the preceding path. |
+
+The `/**` operator is valid only at the end of a resource path. It matches the
+path before `/**` and all descendants below that path.
+
+After a resource path uses `*` for an ID selector, every descendant ID selector
+must also use `*`. A permission can continue through child collection segments,
+but it can't select a specific child under a wildcard parent.
+
+Valid:
+
+```plaintext
+unkey:v1:ws_123:projects/*/apps/*#read_app
+unkey:v1:ws_123:projects/*/apps/*/environments/*/deployments/*#read_deployment
+```
+
+Invalid:
+
+```plaintext
+unkey:v1:ws_123:projects/*/apps/app_123#read_app
+unkey:v1:ws_123:projects/proj_123/apps/*/environments/env_123#read_environment
+```
+
+## Matching rules
+
+Permission evaluation compares a requested `{resource, action}` tuple with the
+permissions assigned to the principal.
+
+A permission matches when all rules are true:
+
+1. The version matches.
+2. The workspace ID matches.
+3. The resource path matches exactly or by a valid resource pattern.
+4. The action matches exactly.
+
+The matcher is segment-aware. It must split resource paths on `/` before
+matching wildcards. Rules 2 and 3, workspace and resource matching, are
+implemented by `pkg/urn`; `pkg/rbac` parses the action suffix and adds rule 4.
+
+For example, this permission:
+
+```plaintext
+unkey:v1:ws_123:keyspaces/*/keys/*#read_key
+```
+
+matches this request:
+
+```plaintext
+unkey:v1:ws_123:keyspaces/ks_123/keys/key_456#read_key
+```
+
+It does not match these requests:
+
+```plaintext
+unkey:v1:ws_123:keyspaces/ks_123#read_key
+unkey:v1:ws_123:keyspaces/ks_123/keys/key_456#delete_key
+unkey:v1:ws_123:keyspaces/ks_123/keys/key_456#update_key
+```
+
+## Descendant grants
+
+Use trailing `/**` when a permission must apply to any public descendant of a
+resource.
+
+This permission grants `delete_deployment` for deployments below one project:
+
+```plaintext
+unkey:v1:ws_123:projects/proj_123/**#delete_deployment
+```
+
+It matches:
+
+```plaintext
+unkey:v1:ws_123:projects/proj_123/apps/app_456/environments/env_789/deployments/d_abc#delete_deployment
+```
+
+It also matches the project itself:
+
+```plaintext
+unkey:v1:ws_123:projects/proj_123#delete_deployment
+```
+
+It also does not grant unrelated actions on descendants:
+
+```plaintext
+unkey:v1:ws_123:projects/proj_123/apps/app_456#delete_app
+```
+
+The action still has to match exactly.
+
+## Common permissions
+
+These examples show how broad and narrow permissions use the same grammar.
+
+<AccordionGroup>
+  <Accordion title="Delete one deployment">
+
+    ```plaintext
+    unkey:v1:ws_123:projects/proj_123/apps/app_456/environments/env_789/deployments/d_abc#delete_deployment
+    ```
+
+  </Accordion>
+  <Accordion title="Delete deployments in one environment">
+
+    ```plaintext
+    unkey:v1:ws_123:projects/proj_123/apps/app_456/environments/env_789/deployments/*#delete_deployment
+    ```
+
+  </Accordion>
+  <Accordion title="Delete deployments in one project">
+
+    ```plaintext
+    unkey:v1:ws_123:projects/proj_123/**#delete_deployment
+    ```
+
+  </Accordion>
+  <Accordion title="Read all keys in one keyspace">
+
+    ```plaintext
+    unkey:v1:ws_123:keyspaces/ks_123/keys/*#read_key
+    ```
+
+  </Accordion>
+  <Accordion title="Manage one role">
+
+    ```plaintext
+    unkey:v1:ws_123:rbac/roles/role_123#update_role
+    ```
+
+  </Accordion>
+</AccordionGroup>
+
+## Audit logs
+
+Audit logs store concrete resources and actions. They can also store the
+permission that authorized the action when authorization was evaluated.
+
+```json
+{
+  "actor": {
+    "type": "key",
+    "id": "key_root_123",
+    "urn": "unkey:v1:ws_123:keyspaces/ks_123/keys/key_root_123"
+  },
+  "resource": {
+    "urn": "unkey:v1:ws_123:projects/proj_123/apps/app_456/environments/env_789/deployments/d_abc",
+    "type": "deployment"
+  },
+  "action": "delete_deployment",
+  "authorization": {
+    "permission": "unkey:v1:ws_123:projects/proj_123/**#delete_deployment",
+    "matched": true
+  }
+}
+```
+
+Relationship changes can include multiple concrete resources. For example,
+adding a role to a key can log the key as the primary resource and the role as a
+target resource.
+
+```json
+{
+  "resource": {
+    "urn": "unkey:v1:ws_123:keyspaces/ks_123/keys/key_456",
+    "type": "key"
+  },
+  "targets": [
+    {
+      "urn": "unkey:v1:ws_123:rbac/roles/role_123",
+      "type": "role"
+    }
+  ],
+  "action": "add_role"
+}
+```
+
+## Migration from tuple permissions
+
+Existing tuple permissions map to resource permissions by expanding the old
+resource type, resource ID, and action into a URN path. Legacy API permissions
+map through the keyspace that replaces the API.
+
+| Existing permission | Resource permission |
+| --- | --- |
+| `api.*.create_api` | `unkey:v1:{workspace_id}:keyspaces/*#create_keyspace` |
+| `api.{api_id}.read_api` | `unkey:v1:{workspace_id}:keyspaces/{keyspace_id}#read_keyspace` |
+| `api.{api_id}.create_key` | `unkey:v1:{workspace_id}:keyspaces/{keyspace_id}/keys/*#create_key` |
+| `api.{api_id}.read_key` | `unkey:v1:{workspace_id}:keyspaces/{keyspace_id}/keys/*#read_key` |
+| `api.{api_id}.verify_key` | `unkey:v1:{workspace_id}:keyspaces/{keyspace_id}/keys/*#verify_key` |
+| `identity.*.read_identity` | `unkey:v1:{workspace_id}:identities/*#read_identity` |
+| `ratelimit.*.delete_override` | `unkey:v1:{workspace_id}:ratelimits/namespaces/*/overrides/*#delete_override` |
+| `rbac.*.create_role` | `unkey:v1:{workspace_id}:rbac/roles/*#create_role` |
+
+Migration code must preserve the authorized workspace. The old permission string
+does not contain a workspace ID, so the workspace has to come from the owning
+key, role, user, or session.
+
+## Invalid examples
+
+These permissions are invalid.
+
+| Value | Reason |
+| --- | --- |
+| `unkey:v1:ws_123:keyspaces/ks_123` | Missing the action suffix. |
+| `unkey:v1:ws_123:keyspaces/ks_123.read_keyspace` | Uses the old tuple separator. |
+| `unkey:v1:ws_123:keyspaces/ks_123#*` | Uses an action wildcard outside the global resource pattern. |
+| `unkey:v1:ws_123:**/deployments/*#delete_deployment` | Uses recursive wildcard outside the trailing position. |
+| `unkey:v1:ws_123:projects/proj_123/**/deployments/*#delete_deployment` | Uses recursive wildcard in the middle of the path. |
+| `unkey:v1:ws_123:projects/*/apps/app_123#read_app` | Selects a specific child under a wildcard parent. |
+| `unkey:v1:ws_123:keyspaces/*/keys#read_key` | Does not match a catalog path shape. |

--- a/docs/engineering/architecture/rfcs/0011-unkey-resource-names.mdx
+++ b/docs/engineering/architecture/rfcs/0011-unkey-resource-names.mdx
@@ -6,6 +6,15 @@ authors:
   - Andreas Thomas
 ---
 
+<Note>
+  This RFC records the original proposal. The implemented `v1` resource-name
+  contract is documented in [Unkey Resource Names](/architecture/resources/unkey-resource-names)
+  and [Resource permissions](/architecture/authorization/resource-permissions).
+  The implemented contract uses `unkey:v1:{workspace_id}:{resource_path}` and
+  includes resource-name patterns with `*` and trailing `/**` for authorization
+  grants.
+</Note>
+
 ## 1. Background
 
 As we grow Unkey from a single API authentication product into a comprehensive API infrastructure platform with multiple services, we face increasing complexity in resource identification and error handling. Our current approach lacks a consistent, scalable system for uniquely identifying resources across services and providing structured error information to developers.

--- a/docs/engineering/docs.json
+++ b/docs/engineering/docs.json
@@ -59,6 +59,13 @@
             "pages": [
               "architecture/index",
               {
+                "group": "Resource model",
+                "pages": [
+                  "architecture/resources/unkey-resource-names",
+                  "architecture/authorization/resource-permissions"
+                ]
+              },
+              {
                 "group": "Rate limiting",
                 "pages": [
                   "architecture/ratelimiting/overview",

--- a/pkg/rbac/BUILD.bazel
+++ b/pkg/rbac/BUILD.bazel
@@ -10,12 +10,14 @@ go_library(
         "permissions.go",
         "query.go",
         "rbac.go",
+        "urn.go",
     ],
     importpath = "github.com/unkeyed/unkey/pkg/rbac",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/codes",
         "//pkg/fault",
+        "//pkg/urn",
     ],
 )
 
@@ -28,7 +30,12 @@ go_test(
         "lexer_test.go",
         "parse_test.go",
         "rbac_test.go",
+        "urn_test.go",
     ],
     embed = [":rbac"],
-    deps = ["@com_github_stretchr_testify//require"],
+    deps = [
+        "//pkg/fuzz",
+        "//pkg/urn",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/pkg/rbac/doc.go
+++ b/pkg/rbac/doc.go
@@ -1,11 +1,12 @@
 // Package rbac implements a flexible Role-Based Access Control system for
 // managing permissions and authorization checks.
 //
-// The package provides a way to define fine-grained permissions using a
-// resource type, resource ID, and action tuple model, and to evaluate whether
-// a set of permissions satisfies specific access requirements. This approach
-// allows for both simple and complex authorization rules through boolean
-// operations like AND and OR.
+// The package provides helpers to define fine-grained permission requirements
+// and evaluate whether a set of granted permissions satisfies them. New code
+// should prefer resource permissions built from [UnkeyPermission] and
+// [github.com/unkeyed/unkey/pkg/urn.V1].
+// The older [Tuple] format remains supported for existing root-key permissions
+// while handlers migrate to canonical Unkey resource names.
 //
 // The package supports two ways to construct permission queries:
 // 1. Programmatic construction using helper functions
@@ -17,6 +18,7 @@
 //   - ResourceID: Specific instance identifier within a resource type
 //   - ActionType: Operations that can be performed on resources (e.g., "read", "write")
 //   - Tuple: Combination of ResourceType, ResourceID, and ActionType that defines a permission
+//   - UnkeyPermission: Combination of a canonical Unkey resource name and action
 //   - PermissionQuery: Logical expressions for permission evaluation using AND/OR operations
 //
 // # Programmatic Query Construction
@@ -35,11 +37,7 @@
 //
 //	// Create a permission query using helper functions
 //	query := rbac.And(
-//	    rbac.T(rbac.Tuple{
-//	        ResourceType: rbac.Api,
-//	        ResourceID:   "api1",
-//	        Action:       rbac.ReadAPI,
-//	    }),
+//	    rbac.U(urn.New().Workspace("ws_123").RatelimitNamespace("ns_123").Override("ov_123"), "read_override"),
 //	    rbac.T(rbac.Tuple{
 //	        ResourceType: rbac.Api,
 //	        ResourceID:   "api1",

--- a/pkg/rbac/query.go
+++ b/pkg/rbac/query.go
@@ -31,6 +31,11 @@ type PermissionQuery struct {
 
 	// Children contains sub-queries for non-leaf nodes (OperatorAnd/OperatorOr)
 	Children []PermissionQuery `json:"children,omitempty"`
+
+	// When true, this leaf opts into Unkey resource permission matching. The
+	// marker is intentionally not serialized or set by ParseQuery because
+	// wildcard semantics must be chosen by typed call sites through U().
+	matchUnkeyPermission bool
 }
 
 // And creates a permission query that requires all child queries to be satisfied.
@@ -45,9 +50,10 @@ type PermissionQuery struct {
 //	)
 func And(queries ...PermissionQuery) PermissionQuery {
 	return PermissionQuery{
-		Operation: OperatorAnd,
-		Value:     "",
-		Children:  queries,
+		Operation:            OperatorAnd,
+		Value:                "",
+		Children:             queries,
+		matchUnkeyPermission: false,
 	}
 }
 
@@ -63,9 +69,10 @@ func And(queries ...PermissionQuery) PermissionQuery {
 //	)
 func Or(queries ...PermissionQuery) PermissionQuery {
 	return PermissionQuery{
-		Operation: OperatorOr,
-		Value:     "",
-		Children:  queries,
+		Operation:            OperatorOr,
+		Value:                "",
+		Children:             queries,
+		matchUnkeyPermission: false,
 	}
 }
 
@@ -83,9 +90,10 @@ func Or(queries ...PermissionQuery) PermissionQuery {
 //	})
 func T(tuple Tuple) PermissionQuery {
 	return PermissionQuery{
-		Operation: OperatorNil,
-		Value:     tuple.String(),
-		Children:  []PermissionQuery{},
+		Operation:            OperatorNil,
+		Value:                tuple.String(),
+		Children:             []PermissionQuery{},
+		matchUnkeyPermission: false,
 	}
 }
 
@@ -99,8 +107,9 @@ func T(tuple Tuple) PermissionQuery {
 //	query := rbac.S("resourceType.resourceID.action")
 func S(s string) PermissionQuery {
 	return PermissionQuery{
-		Operation: OperatorNil,
-		Value:     s,
-		Children:  []PermissionQuery{},
+		Operation:            OperatorNil,
+		Value:                s,
+		Children:             []PermissionQuery{},
+		matchUnkeyPermission: false,
 	}
 }

--- a/pkg/rbac/rbac.go
+++ b/pkg/rbac/rbac.go
@@ -70,13 +70,14 @@ func (r *RBAC) EvaluatePermissions(query PermissionQuery, permissions []string) 
 	return r.evaluateQueryV1(query, permissions)
 }
 
+// evaluateQueryV1 recursively evaluates a permission query tree against the
+// granted permission strings, combining child results per the node operator.
 func (r *RBAC) evaluateQueryV1(query PermissionQuery, permissions []string) (EvaluationResult, error) {
 	// Handle simple permission check
 	if query.Value != "" {
-		if slices.Contains(permissions, query.Value) {
+		if evaluateLeafPermission(query, permissions) {
 			return EvaluationResult{Valid: true, Message: ""}, nil
 		}
-
 		return EvaluationResult{
 			Valid:   false,
 			Message: fmt.Sprintf("Missing permission: '%s'", query.Value),
@@ -126,6 +127,28 @@ func (r *RBAC) evaluateQueryV1(query PermissionQuery, permissions []string) (Eva
 	)
 }
 
+// evaluateLeafPermission is the shared leaf evaluator for the boolean query
+// tree. Exact string matching is always available. Unkey wildcard matching is
+// an explicit opt-in carried by U(), not a behavior inferred from string shape.
+func evaluateLeafPermission(query PermissionQuery, permissions []string) bool {
+	if slices.Contains(permissions, query.Value) {
+		return true
+	}
+
+	if !query.matchUnkeyPermission {
+		return false
+	}
+
+	requiredPermission, err := parseUrnPermission(query.Value)
+	if err != nil {
+		return false
+	}
+
+	return evaluateUnkeyPermission(requiredPermission, permissions)
+}
+
+// formatPermissions quotes each permission so evaluation messages stay readable
+// when permissions are concatenated.
 func formatPermissions(permissions []string) []string {
 	formatted := make([]string, len(permissions))
 

--- a/pkg/rbac/rbac_test.go
+++ b/pkg/rbac/rbac_test.go
@@ -66,6 +66,12 @@ func TestRBAC_EvaluatePermissions(t *testing.T) {
 			wantValid:   false,
 		},
 		{
+			name:        "Tuple wildcard remains literal (Fail)",
+			query:       S("api.*.read_key"),
+			permissions: []string{"api.key_123.read_key"},
+			wantValid:   false,
+		},
+		{
 			name: "Complex query with asterisk permissions",
 			query: Or(
 				S("api.*"),

--- a/pkg/rbac/urn.go
+++ b/pkg/rbac/urn.go
@@ -1,0 +1,143 @@
+package rbac
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/unkeyed/unkey/pkg/urn"
+)
+
+var errInvalidURNPermission = errors.New("invalid urn permission")
+
+// UnkeyPermission represents an RBAC permission requirement for a Unkey resource.
+//
+// The resource name itself belongs to [urn.V1]. RBAC only adds the action
+// suffix and evaluates whether a principal's granted permissions cover this
+// concrete requirement.
+type UnkeyPermission struct {
+	// Resource is the canonical v1 resource name being protected.
+	Resource urn.V1
+
+	// Action is the operation required on the resource.
+	Action ActionType
+}
+
+// String returns the full RBAC permission string for this resource and action.
+func (u UnkeyPermission) String() string {
+	return fmt.Sprintf("%s#%s", u.Resource.String(), u.Action)
+}
+
+// U creates a leaf query for an action on a canonical resource name.
+//
+// Handlers should pass the exact resource being accessed. Broader grants such
+// as "unkey:v1:ws_123:ratelimits/**#read_override" are matched during
+// evaluation, not by writing wildcard-heavy queries at call sites.
+func U(u urn.V1, action ActionType) PermissionQuery {
+	return PermissionQuery{
+		Operation:            OperatorNil,
+		Value:                UnkeyPermission{Resource: u, Action: action}.String(),
+		Children:             []PermissionQuery{},
+		matchUnkeyPermission: true,
+	}
+}
+
+// isUnkeyPermission reports whether a granted string is a canonical Unkey
+// permission URN, so the evaluator never applies wildcard semantics to legacy
+// or customer-defined permission strings.
+func isUnkeyPermission(value string) bool {
+	_, err := parseUrnPermission(value)
+	return err == nil
+}
+
+// evaluateUnkeyPermission evaluates Unkey resource permission URNs only.
+//
+// The required permission is already parsed by the leaf evaluator. Legacy tuple
+// permissions and customer-defined permission strings never reach this path, so
+// wildcard characters only expand scope for canonical Unkey permission URNs.
+func evaluateUnkeyPermission(required UnkeyPermission, granted []string) bool {
+	for _, permission := range granted {
+		grantedPermission, err := parseUrnPermission(permission)
+		if err != nil {
+			continue
+		}
+		if permissionCovers(required, grantedPermission) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// parseUrnPermission parses the RBAC action suffix around a resource URN.
+//
+// Resource-name parsing is delegated to pkg/urn so RBAC does not duplicate the
+// Unkey URN grammar. RBAC only validates the action component after "#".
+//
+// Accepted:
+//
+//	unkey:v1:ws_1:ratelimits/namespaces/ns_1/overrides/ov_1#read_override
+//	unkey:v1:ws_1:keyspaces/*/keys/*#read_key    wildcard grant
+//	unkey:v1:ws_1:**#*                           admin grant (translated from admin:*)
+//
+// Rejected with errInvalidURNPermission:
+//
+//	unkey:v1:ws_1:keyspaces/ks_1                 missing "#action"
+//	unkey:v1:ws_1:keyspaces/ks_1#read#key        more than one "#"
+//	unkey:v1:ws_1:keyspaces/ks_1#*               action wildcard off the global resource
+//	api.api_1.read_api                           legacy tuple, not a URN permission
+func parseUrnPermission(value string) (UnkeyPermission, error) {
+	var zero UnkeyPermission
+
+	urnStr, action, ok := strings.Cut(value, "#")
+	if !ok || strings.Contains(action, "#") {
+		return zero, fmt.Errorf("%w: expected exactly one action separator", errInvalidURNPermission)
+	}
+
+	resource, err := urn.ParseV1(urnStr)
+	if err != nil {
+		return zero, fmt.Errorf("%w: %w", errInvalidURNPermission, err)
+	}
+
+	if err := validatePermissionAction(action); err != nil {
+		return zero, fmt.Errorf("%w: invalid action: %v", errInvalidURNPermission, err)
+	}
+	if action == "*" && resource.Resource != "**" {
+		return zero, fmt.Errorf("%w: action wildcard requires the global resource pattern %q", errInvalidURNPermission, "**")
+	}
+
+	return UnkeyPermission{
+		Resource: resource,
+		Action:   ActionType(action),
+	}, nil
+}
+
+// permissionCovers reports whether a granted permission satisfies a required
+// permission. Required permissions should be concrete; granted permissions may
+// use resource wildcards or "*" as the action. Resource matching, including
+// workspace equality, is delegated to [urn.V1.Covers].
+func permissionCovers(required UnkeyPermission, granted UnkeyPermission) bool {
+	if granted.Action != "*" && granted.Action != required.Action {
+		return false
+	}
+
+	return granted.Resource.Covers(required.Resource)
+}
+
+// validatePermissionAction enforces the action grammar after "#": either the
+// "*" wildcard or a word that cannot collide with URN separators.
+func validatePermissionAction(action string) error {
+	if action == "*" {
+		return nil
+	}
+	if action == "" {
+		return errors.New("must not be empty")
+	}
+	if strings.ContainsAny(action, ":#/*") {
+		return errors.New(`must not contain ":", "#", "/", or "*"`)
+	}
+	if strings.HasPrefix(action, "_") || strings.HasSuffix(action, "_") {
+		return errors.New(`must not start or end with "_"`)
+	}
+	return nil
+}

--- a/pkg/rbac/urn_test.go
+++ b/pkg/rbac/urn_test.go
@@ -1,0 +1,377 @@
+package rbac
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/fuzz"
+	"github.com/unkeyed/unkey/pkg/urn"
+)
+
+// TestUnkeyPermissionQuery_BuildsCanonicalPermission guarantees the typed RBAC
+// helper emits the full permission string principals store.
+func TestUnkeyPermissionQuery_BuildsCanonicalPermission(t *testing.T) {
+	t.Parallel()
+
+	resource := urn.V1{
+		WorkspaceID: "ws_123",
+		Resource:    "ratelimits/namespaces/ns_123/overrides/ov_123",
+	}
+	query := U(resource, "read_override")
+	stringQuery := S(UnkeyPermission{
+		Resource: resource,
+		Action:   "read_override",
+	}.String())
+
+	require.Equal(t, "unkey:v1:ws_123:ratelimits/namespaces/ns_123/overrides/ov_123#read_override", query.Value)
+	require.Equal(t, query.Value, stringQuery.Value)
+
+	result, err := New().EvaluatePermissions(query, []string{
+		"unkey:v1:ws_123:ratelimits/namespaces/ns_123/overrides/ov_123#read_override",
+	})
+	require.NoError(t, err)
+	require.True(t, result.Valid)
+}
+
+// TestStringQuery_DoesNotOptIntoUnkeyWildcardMatching guarantees callers must
+// choose U() before canonical Unkey permission grants can expand wildcards.
+func TestStringQuery_DoesNotOptIntoUnkeyWildcardMatching(t *testing.T) {
+	t.Parallel()
+
+	required := "unkey:v1:ws_123:ratelimits/namespaces/ns_123/overrides/ov_123#read_override"
+	permissions := []string{
+		"unkey:v1:ws_123:ratelimits/namespaces/ns_123/overrides/*#read_override",
+	}
+
+	stringResult, err := New().EvaluatePermissions(S(required), permissions)
+	require.NoError(t, err)
+	require.False(t, stringResult.Valid)
+
+	typedResult, err := New().EvaluatePermissions(
+		U(
+			urn.New().
+				Workspace("ws_123").
+				RatelimitNamespace("ns_123").
+				Override("ov_123"),
+			ReadOverride,
+		),
+		permissions,
+	)
+	require.NoError(t, err)
+	require.True(t, typedResult.Valid)
+}
+
+// TestParseUrnPermission_AcceptsOnlySupportedGrammar guarantees malformed
+// permission strings cannot accidentally participate in wildcard matching.
+func TestParseUrnPermission_AcceptsOnlySupportedGrammar(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		value   string
+		want    UnkeyPermission
+		wantErr bool
+	}{
+		{
+			name:  "exact resource",
+			value: "unkey:v1:ws_123:ratelimits/namespaces/ns_123/overrides/ov_123#read_override",
+			want: UnkeyPermission{
+				Resource: urn.V1{WorkspaceID: "ws_123", Resource: "ratelimits/namespaces/ns_123/overrides/ov_123"},
+				Action:   "read_override",
+			},
+		},
+		{
+			name:  "segment wildcard resource",
+			value: "unkey:v1:ws_123:ratelimits/namespaces/*/overrides/*#read_override",
+			want: UnkeyPermission{
+				Resource: urn.V1{WorkspaceID: "ws_123", Resource: "ratelimits/namespaces/*/overrides/*"},
+				Action:   "read_override",
+			},
+		},
+		{
+			name:  "descendant wildcard resource",
+			value: "unkey:v1:ws_123:ratelimits/**#read_override",
+			want: UnkeyPermission{
+				Resource: urn.V1{WorkspaceID: "ws_123", Resource: "ratelimits/**"},
+				Action:   "read_override",
+			},
+		},
+		{
+			name:  "admin permission",
+			value: "unkey:v1:ws_123:**#*",
+			want: UnkeyPermission{
+				Resource: urn.V1{WorkspaceID: "ws_123", Resource: "**"},
+				Action:   "*",
+			},
+		},
+		{name: "missing action separator", value: "unkey:v1:ws_123:ratelimits/namespaces/ns_123", wantErr: true},
+		{name: "empty resource", value: "unkey:v1:ws_123:#read_override", wantErr: true},
+		{name: "empty action", value: "unkey:v1:ws_123:ratelimits/namespaces/ns_123#", wantErr: true},
+		{name: "extra action separator", value: "unkey:v1:ws_123:ratelimits/namespaces/ns_123#read#override", wantErr: true},
+		{name: "wrong prefix", value: "urn:v1:ws_123:ratelimits/namespaces/ns_123#read_override", wantErr: true},
+		{name: "wrong version", value: "unkey:v2:ws_123:ratelimits/namespaces/ns_123#read_override", wantErr: true},
+		{name: "missing workspace resource separator", value: "unkey:v1:ws_123#read_override", wantErr: true},
+		{name: "empty workspace", value: "unkey:v1::ratelimits/namespaces/ns_123#read_override", wantErr: true},
+		{name: "workspace with slash", value: "unkey:v1:ws/123:ratelimits/namespaces/ns_123#read_override", wantErr: true},
+		{name: "resource with colon", value: "unkey:v1:ws_123:ratelimits:namespaces/ns_123#read_override", wantErr: true},
+		{name: "leading slash", value: "unkey:v1:ws_123:/ratelimits/namespaces/ns_123#read_override", wantErr: true},
+		{name: "trailing slash", value: "unkey:v1:ws_123:ratelimits/namespaces/ns_123/#read_override", wantErr: true},
+		{name: "empty segment", value: "unkey:v1:ws_123:ratelimits//namespaces/ns_123#read_override", wantErr: true},
+		{name: "partial wildcard", value: "unkey:v1:ws_123:ratelimits/namespaces/ns_*#read_override", wantErr: true},
+		{name: "descendant wildcard in middle", value: "unkey:v1:ws_123:ratelimits/**/overrides/*#read_override", wantErr: true},
+		{name: "action with slash", value: "unkey:v1:ws_123:ratelimits/namespaces/ns_123#read/override", wantErr: true},
+		{name: "action with colon", value: "unkey:v1:ws_123:ratelimits/namespaces/ns_123#read:override", wantErr: true},
+		{name: "action wildcard without global resource", value: "unkey:v1:ws_123:ratelimits/namespaces/ns_123#*", wantErr: true},
+		{name: "action wildcard with single segment wildcard resource", value: "unkey:v1:ws_123:*#*", wantErr: true},
+		{name: "leading action separator", value: "unkey:v1:ws_123:ratelimits/namespaces/ns_123#_read_override", wantErr: true},
+		{name: "trailing action separator", value: "unkey:v1:ws_123:ratelimits/namespaces/ns_123#read_override_", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parseUrnPermission(tt.value)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestIsUnkeyPermission_OnlyAcceptsCanonicalUnkeyPermissions guarantees the
+// evaluator never applies Unkey wildcard semantics to legacy or customer grants.
+func TestIsUnkeyPermission_OnlyAcceptsCanonicalUnkeyPermissions(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, isUnkeyPermission("unkey:v1:ws_123:ratelimits/namespaces/ns_123#read_override"))
+	require.False(t, isUnkeyPermission("api.*.read_key"))
+	require.False(t, isUnkeyPermission("ratelimit.ns_123.read_override"))
+	require.False(t, isUnkeyPermission("unkey:v1:ws_123:ratelimits/namespaces/ns_123"))
+}
+
+// TestPermissionCovers_GrantedWildcardCoversExactRequiredResource guarantees
+// handlers can query exact resources while principals hold broader grants.
+func TestPermissionCovers_GrantedWildcardCoversExactRequiredResource(t *testing.T) {
+	t.Parallel()
+
+	required := UnkeyPermission{
+		Resource: urn.V1{WorkspaceID: "ws_123", Resource: "ratelimits/namespaces/ns_123/overrides/ov_123"},
+		Action:   "read_override",
+	}
+
+	tests := []struct {
+		name    string
+		granted UnkeyPermission
+		want    bool
+	}{
+		{
+			name:    "exact permission",
+			granted: required,
+			want:    true,
+		},
+		{
+			name: "segment wildcard permission",
+			granted: UnkeyPermission{
+				Resource: urn.V1{WorkspaceID: "ws_123", Resource: "ratelimits/namespaces/ns_123/overrides/*"},
+				Action:   "read_override",
+			},
+			want: true,
+		},
+		{
+			name: "workos wildcard permission",
+			granted: UnkeyPermission{
+				Resource: urn.V1{WorkspaceID: "ws_123", Resource: "ratelimits/namespaces/*/overrides/*"},
+				Action:   "read_override",
+			},
+			want: true,
+		},
+		{
+			name: "descendant wildcard permission",
+			granted: UnkeyPermission{
+				Resource: urn.V1{WorkspaceID: "ws_123", Resource: "ratelimits/**"},
+				Action:   "read_override",
+			},
+			want: true,
+		},
+		{
+			name: "admin permission",
+			granted: UnkeyPermission{
+				Resource: urn.V1{WorkspaceID: "ws_123", Resource: "**"},
+				Action:   "*",
+			},
+			want: true,
+		},
+		{
+			name: "wrong workspace",
+			granted: UnkeyPermission{
+				Resource: urn.V1{WorkspaceID: "ws_456", Resource: "ratelimits/namespaces/ns_123/overrides/ov_123"},
+				Action:   "read_override",
+			},
+			want: false,
+		},
+		{
+			name: "wrong action",
+			granted: UnkeyPermission{
+				Resource: urn.V1{WorkspaceID: "ws_123", Resource: "ratelimits/namespaces/ns_123/overrides/ov_123"},
+				Action:   "delete_override",
+			},
+			want: false,
+		},
+		{
+			name: "sibling resource",
+			granted: UnkeyPermission{
+				Resource: urn.V1{WorkspaceID: "ws_123", Resource: "ratelimits/namespaces/ns_456/overrides/*"},
+				Action:   "read_override",
+			},
+			want: false,
+		},
+		{
+			name: "shorter exact resource",
+			granted: UnkeyPermission{
+				Resource: urn.V1{WorkspaceID: "ws_123", Resource: "ratelimits/namespaces/ns_123"},
+				Action:   "read_override",
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.want, permissionCovers(required, tt.granted))
+		})
+	}
+}
+
+// TestUrnPermissionEvaluation_MatchesThroughRBACEvaluator guarantees the public
+// RBAC evaluator applies URN wildcard semantics, not just private helpers.
+func TestUrnPermissionEvaluation_MatchesThroughRBACEvaluator(t *testing.T) {
+	t.Parallel()
+
+	query := U(
+		urn.New().
+			Workspace("ws_123").
+			RatelimitNamespace("ns_123").
+			Override("ov_123"),
+		ReadOverride,
+	)
+
+	tests := []struct {
+		name        string
+		permissions []string
+		wantValid   bool
+	}{
+		{
+			name: "exact permission",
+			permissions: []string{
+				"unkey:v1:ws_123:ratelimits/namespaces/ns_123/overrides/ov_123#read_override",
+			},
+			wantValid: true,
+		},
+		{
+			name: "namespace override wildcard permission",
+			permissions: []string{
+				"unkey:v1:ws_123:ratelimits/namespaces/ns_123/overrides/*#read_override",
+			},
+			wantValid: true,
+		},
+		{
+			name: "workos wildcard namespace permission",
+			permissions: []string{
+				"unkey:v1:ws_123:ratelimits/namespaces/*/overrides/*#read_override",
+			},
+			wantValid: true,
+		},
+		{
+			name: "ratelimits descendant permission",
+			permissions: []string{
+				"unkey:v1:ws_123:ratelimits/**#read_override",
+			},
+			wantValid: true,
+		},
+		{
+			name: "admin permission",
+			permissions: []string{
+				"unkey:v1:ws_123:**#*",
+			},
+			wantValid: true,
+		},
+		{
+			name: "malformed grants are ignored",
+			permissions: []string{
+				"unkey:v1:ws_123:ratelimits/namespaces/ns_123/overrides/**/nested#read_override",
+				"unkey:v1:ws_123:ratelimits/namespaces/ns_123/overrides/ov_123#delete_override",
+				"ratelimit.ns_123.read_override",
+			},
+			wantValid: false,
+		},
+		{
+			name: "wrong workspace",
+			permissions: []string{
+				"unkey:v1:ws_456:ratelimits/namespaces/ns_123/overrides/*#read_override",
+			},
+			wantValid: false,
+		},
+	}
+
+	rbac := New()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := rbac.EvaluatePermissions(query, tt.permissions)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantValid, result.Valid, result.Message)
+		})
+	}
+}
+
+// FuzzParseUrnPermission_InvalidInputNeverProducesUnsafePermission guarantees
+// arbitrary strings either fail parsing or produce self-covering valid permissions.
+func FuzzParseUrnPermission_InvalidInputNeverProducesUnsafePermission(f *testing.F) {
+	fuzz.Seed(f)
+	for _, seed := range []string{
+		"",
+		"unkey:v1:ws_123:ratelimits/namespaces/ns_123/overrides/ov_123#read_override",
+		"unkey:v1:ws_123:ratelimits/namespaces/*/overrides/*#read_override",
+		"unkey:v1:ws_123:ratelimits/**#read_override",
+		"unkey:v1:ws_123:**#*",
+		"unkey:v1:ws_123:ratelimits/**/overrides/*#read_override",
+		"unkey:v1:ws_123:ratelimits/namespaces/ns_123#read#override",
+	} {
+		f.Add(fuzzStringSeed(seed))
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		c := fuzz.New(t, data)
+		value := c.String()
+
+		permission, err := parseUrnPermission(value)
+		if err != nil {
+			return
+		}
+
+		require.NotEmpty(t, permission.Resource.WorkspaceID)
+		require.NotEmpty(t, permission.Resource.Resource)
+		require.NotEmpty(t, permission.Action)
+		_, err = urn.ParseV1(permission.Resource.String())
+		require.NoError(t, err)
+		require.NoError(t, validatePermissionAction(string(permission.Action)))
+		require.True(t, permissionCovers(permission, permission))
+	})
+}
+
+func fuzzStringSeed(values ...string) []byte {
+	out := make([]byte, 0)
+	for _, value := range values {
+		out = binary.BigEndian.AppendUint16(out, uint16(len(value)))
+		out = append(out, value...)
+	}
+	return out
+}


### PR DESCRIPTION
## Why

The new resource names need authorization semantics before API handlers can use them safely. Legacy tuple permissions are still supported, but they cannot express canonical resource paths or resource-pattern grants in a reusable way.

This PR adds an explicit RBAC entrypoint for Unkey resource permissions so wildcard matching is opt-in at typed call sites. That keeps legacy string permissions literal while giving new handlers a shared, tested evaluator for canonical resource permissions.

## Verification

- `mise exec -- bazel test //pkg/rbac:rbac_test`