### PR TITLE
fix(worker): prevent nonvalid port, cpu or memory

### DIFF
--- a/svc/ctrl/worker/deploy/deploy_handler.go
+++ b/svc/ctrl/worker/deploy/deploy_handler.go
@@ -187,6 +187,21 @@ func (w *Workflow) Deploy(ctx restate.ObjectContext, req *hydrav1.DeployRequest)
 
 	// --- Starting ---
 	err = w.DeploymentStep(ctx, db.DeploymentStepsStepStarting, deployment, func(stepCtx restate.ObjectContext) error {
+		// krane asserts these async in its watcher, so a bad value (e.g. port 0)
+		// hangs the deployment until timeout. Both entrypoints funnel here, so
+		// validate at this shared chokepoint and fail fast.
+		if err := assert.All(
+			assert.Greater(deployment.Port, int32(0), "Port must be greater than 0"),
+			assert.LessOrEqual(deployment.Port, int32(65535), "Port must be at most 65535"),
+			assert.Greater(deployment.CpuMillicores, int32(0), "CPU millicores must be greater than 0"),
+			assert.Greater(deployment.MemoryMib, int32(0), "MemoryMib must be greater than 0"),
+		); err != nil {
+			return fault.Wrap(
+				restate.TerminalError(err),
+				fault.Public(err.Error()),
+			)
+		}
+
 		workspace, err = restate.Run(ctx, func(runCtx restate.RunContext) (db.Workspace, error) {
 			var ws db.Workspace
 			err := db.TxRetry(runCtx, w.db.RW(), func(txCtx context.Context, tx db.DBTX) error {
@@ -332,7 +347,8 @@ func (w *Workflow) Deploy(ctx restate.ObjectContext, req *hydrav1.DeployRequest)
 		Description: "Deployment is live",
 	})
 
-	logger.Info("deployment workflow completed",
+	logger.Info(
+		"deployment workflow completed",
 		"deployment_id", deployment.ID,
 		"status", "succeeded",
 	)
@@ -406,7 +422,8 @@ func (w *Workflow) buildImage(ctx restate.ObjectContext, req *hydrav1.DeployRequ
 		var build *buildResult
 		var err error
 		if params.DockerfilePath == "" {
-			logger.Info("no dockerfile configured, building with railpack",
+			logger.Info(
+				"no dockerfile configured, building with railpack",
 				"deployment_id", deployment.ID,
 				"repository", params.Repository,
 				"commit_sha", params.CommitSHA,
@@ -501,7 +518,8 @@ func (w *Workflow) createTopologies(
 	schedulable := make([]db.FindAppRegionalSettingsByAppAndEnvRow, 0, len(regionalSettings))
 	for _, rs := range regionalSettings {
 		if !rs.RegionCanSchedule {
-			logger.Warn("skipping non-schedulable region",
+			logger.Warn(
+				"skipping non-schedulable region",
 				"region_id", rs.RegionID,
 				"region_name", rs.RegionName,
 				"app_id", deployment.AppID,
@@ -888,7 +906,8 @@ func (w *Workflow) waitForDeployments(ctx restate.ObjectContext, compensation *c
 	}
 	requiredRegions := max(len(regionMinReplicas)-1, 1)
 
-	logger.Info("waiting for deployments to be ready",
+	logger.Info(
+		"waiting for deployments to be ready",
 		"deployment_id", deploymentID,
 		"total_regions", len(regionMinReplicas),
 		"required_regions", requiredRegions,
@@ -915,7 +934,8 @@ func (w *Workflow) waitForDeployments(ctx restate.ObjectContext, compensation *c
 		return w.checkInstancesHealthy(runCtx, deploymentID, regionMinReplicas, requiredRegions)
 	}, restate.WithName("initial healthy-regions check"), restate.WithMaxRetryAttempts(runMaxAttempts))
 	if err != nil {
-		logger.Warn("initial healthy-regions check failed, proceeding to await NotifyInstancesReady",
+		logger.Warn(
+			"initial healthy-regions check failed, proceeding to await NotifyInstancesReady",
 			"deployment_id", deploymentID,
 			"error", err,
 		)
@@ -979,7 +999,8 @@ func (w *Workflow) checkInstancesHealthy(
 		}
 	}
 
-	logger.Info("checked instances",
+	logger.Info(
+		"checked instances",
 		"deployment_id", deploymentID,
 		"healthy_regions", healthyRegions,
 		"required_regions", requiredRegions,
@@ -1032,7 +1053,8 @@ func (w *Workflow) initGitHubStatus(
 		return found, nil
 	}, restate.WithName("find github repo connection"), restate.WithMaxRetryAttempts(runMaxAttempts))
 	if err != nil {
-		logger.Warn("failed to look up github repo connection, skipping deployment status reporting",
+		logger.Warn(
+			"failed to look up github repo connection, skipping deployment status reporting",
 			"app_id", deployment.AppID,
 			"error", err,
 		)
@@ -1041,7 +1063,8 @@ func (w *Workflow) initGitHubStatus(
 	}
 
 	if repoConn.InstallationID == 0 {
-		logger.Info("no github repo connection, skipping deployment status reporting",
+		logger.Info(
+			"no github repo connection, skipping deployment status reporting",
 			"app_id", deployment.AppID,
 		)
 

--- a/svc/ctrl/worker/deploy/deploy_handler.go
+++ b/svc/ctrl/worker/deploy/deploy_handler.go
@@ -189,7 +189,7 @@ func (w *Workflow) Deploy(ctx restate.ObjectContext, req *hydrav1.DeployRequest)
 	err = w.DeploymentStep(ctx, db.DeploymentStepsStepStarting, deployment, func(stepCtx restate.ObjectContext) error {
 		if err := assert.All(
 			assert.Greater(deployment.Port, int32(0), "Port must be greater than 0"),
-			assert.LessOrEqual(deployment.Port, int32(65535), "Port must be at most 65535"),
+			assert.LessOrEqual(deployment.Port, int32(65535), "Port cannot exceed 65535"),
 			assert.Greater(deployment.CpuMillicores, int32(0), "CPU millicores must be greater than 0"),
 			assert.Greater(deployment.MemoryMib, int32(0), "MemoryMib must be greater than 0"),
 		); err != nil {

--- a/svc/ctrl/worker/deploy/deploy_handler.go
+++ b/svc/ctrl/worker/deploy/deploy_handler.go
@@ -187,9 +187,6 @@ func (w *Workflow) Deploy(ctx restate.ObjectContext, req *hydrav1.DeployRequest)
 
 	// --- Starting ---
 	err = w.DeploymentStep(ctx, db.DeploymentStepsStepStarting, deployment, func(stepCtx restate.ObjectContext) error {
-		// krane asserts these async in its watcher, so a bad value (e.g. port 0)
-		// hangs the deployment until timeout. Both entrypoints funnel here, so
-		// validate at this shared chokepoint and fail fast.
 		if err := assert.All(
 			assert.Greater(deployment.Port, int32(0), "Port must be greater than 0"),
 			assert.LessOrEqual(deployment.Port, int32(65535), "Port must be at most 65535"),


### PR DESCRIPTION
Fixes [ENG-2921](https://linear.app/unkey/issue/ENG-2921/prevent-port-0-from-being-saved-or-deployed)

## Problem

Port, CPU, or Memory can end up as `0` in the deploy pipeline. krane asserts these `> 0`, but async in its watcher, so the error never propagates back and the deployment hangs in "deploying" until it times out.

## Fix

Assert port, CPU, and memory at the start of the deploy workflow, the shared chokepoint for both entrypoints (API + git push). Bad config now fails fast instead of hanging. UI already prevents these `0` values; this guards the backend path against bad data.


This is how it would look if you try to deploy with `0` port
<img width="1496" height="1072" alt="Screenshot 2026-06-16 at 18 24 35" src="https://github.com/user-attachments/assets/1dca2e3c-8497-451f-997b-feb277bb7984" />
