### PR TITLE
chore(nuke): stop and remove containers before pruning

### DIFF
--- a/.mise/tasks/nuke
+++ b/.mise/tasks/nuke
@@ -4,6 +4,16 @@ set -euo pipefail
 
 read -r -p "Delete local Docker data? [Y/n] " delete_docker
 if [[ ! "${delete_docker}" =~ ^[Nn]$ ]]; then
+  running_containers="$(docker --context default ps --quiet)"
+  if [[ -n "${running_containers}" ]]; then
+    docker --context default stop ${running_containers}
+  fi
+
+  containers="$(docker --context default ps --all --quiet)"
+  if [[ -n "${containers}" ]]; then
+    docker --context default rm --force ${containers}
+  fi
+
   docker --context default builder prune --all --force
   docker --context default system prune --all --force --volumes
 fi
@@ -11,8 +21,8 @@ fi
 read -r -p "Delete Bazel, Next.js, and Turborepo caches? [Y/n] " delete_caches
 if [[ ! "${delete_caches}" =~ ^[Nn]$ ]]; then
   bazel shutdown || true
-  bazel clean --expunge --async || true
   rm -rf ./.cache
+  bazel clean --expunge || true
 
   rm -rf ./**/.turbo
   rm -rf ./**/.next


### PR DESCRIPTION
## What

Updates the `nuke` mise task so the Docker cleanup actually reclaims everything:

- Stop all running containers, then force-remove every container (running and stopped) before pruning. Previously `system prune` could not reclaim volumes still attached to existing containers.
- Run `bazel clean --expunge` synchronously (drop `--async`) and delete `./.cache` after `bazel shutdown` so the expunge does not race the cache deletion.

## Why

Running the task on a machine with existing containers left them (and their volumes) behind, so a "nuke" did not fully reset local state.

## Verification

Shell script change only; `bash -n` parses cleanly. No automated task covers this file.