### PR TITLE
feat(api): add app listing endpoint

### DIFF
--- a/pkg/db/app_list_by_project.sql_generated.go
+++ b/pkg/db/app_list_by_project.sql_generated.go
@@ -13,8 +13,16 @@ const listAppsByProject = `-- name: ListAppsByProject :many
 SELECT apps.pk, apps.id, apps.workspace_id, apps.project_id, apps.name, apps.slug, apps.default_branch, apps.current_deployment_id, apps.is_rolled_back, apps.delete_protection, apps.created_at, apps.updated_at
 FROM apps
 WHERE project_id = ?
-ORDER BY created_at ASC
+  AND id >= ?
+ORDER BY id ASC
+LIMIT ?
 `
+
+type ListAppsByProjectParams struct {
+	ProjectID string `db:"project_id"`
+	IDCursor  string `db:"id_cursor"`
+	Limit     int32  `db:"limit"`
+}
 
 type ListAppsByProjectRow struct {
 	App App `db:"app"`
@@ -25,9 +33,11 @@ type ListAppsByProjectRow struct {
 //	SELECT apps.pk, apps.id, apps.workspace_id, apps.project_id, apps.name, apps.slug, apps.default_branch, apps.current_deployment_id, apps.is_rolled_back, apps.delete_protection, apps.created_at, apps.updated_at
 //	FROM apps
 //	WHERE project_id = ?
-//	ORDER BY created_at ASC
-func (q *Queries) ListAppsByProject(ctx context.Context, db DBTX, projectID string) ([]ListAppsByProjectRow, error) {
-	rows, err := db.QueryContext(ctx, listAppsByProject, projectID)
+//	  AND id >= ?
+//	ORDER BY id ASC
+//	LIMIT ?
+func (q *Queries) ListAppsByProject(ctx context.Context, db DBTX, arg ListAppsByProjectParams) ([]ListAppsByProjectRow, error) {
+	rows, err := db.QueryContext(ctx, listAppsByProject, arg.ProjectID, arg.IDCursor, arg.Limit)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/db/app_list_by_project.sql_generated.go
+++ b/pkg/db/app_list_by_project.sql_generated.go
@@ -24,10 +24,6 @@ type ListAppsByProjectParams struct {
 	Limit     int32  `db:"limit"`
 }
 
-type ListAppsByProjectRow struct {
-	App App `db:"app"`
-}
-
 // ListAppsByProject
 //
 //	SELECT apps.pk, apps.id, apps.workspace_id, apps.project_id, apps.name, apps.slug, apps.default_branch, apps.current_deployment_id, apps.is_rolled_back, apps.delete_protection, apps.created_at, apps.updated_at
@@ -36,28 +32,28 @@ type ListAppsByProjectRow struct {
 //	  AND id >= ?
 //	ORDER BY id ASC
 //	LIMIT ?
-func (q *Queries) ListAppsByProject(ctx context.Context, db DBTX, arg ListAppsByProjectParams) ([]ListAppsByProjectRow, error) {
+func (q *Queries) ListAppsByProject(ctx context.Context, db DBTX, arg ListAppsByProjectParams) ([]App, error) {
 	rows, err := db.QueryContext(ctx, listAppsByProject, arg.ProjectID, arg.IDCursor, arg.Limit)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []ListAppsByProjectRow
+	var items []App
 	for rows.Next() {
-		var i ListAppsByProjectRow
+		var i App
 		if err := rows.Scan(
-			&i.App.Pk,
-			&i.App.ID,
-			&i.App.WorkspaceID,
-			&i.App.ProjectID,
-			&i.App.Name,
-			&i.App.Slug,
-			&i.App.DefaultBranch,
-			&i.App.CurrentDeploymentID,
-			&i.App.IsRolledBack,
-			&i.App.DeleteProtection,
-			&i.App.CreatedAt,
-			&i.App.UpdatedAt,
+			&i.Pk,
+			&i.ID,
+			&i.WorkspaceID,
+			&i.ProjectID,
+			&i.Name,
+			&i.Slug,
+			&i.DefaultBranch,
+			&i.CurrentDeploymentID,
+			&i.IsRolledBack,
+			&i.DeleteProtection,
+			&i.CreatedAt,
+			&i.UpdatedAt,
 		); err != nil {
 			return nil, err
 		}

--- a/pkg/db/querier_generated.go
+++ b/pkg/db/querier_generated.go
@@ -2272,7 +2272,7 @@ type Querier interface {
 	//    AND id >= ?
 	//  ORDER BY id ASC
 	//  LIMIT ?
-	ListAppsByProject(ctx context.Context, db DBTX, arg ListAppsByProjectParams) ([]ListAppsByProjectRow, error)
+	ListAppsByProject(ctx context.Context, db DBTX, arg ListAppsByProjectParams) ([]App, error)
 	// ListClickhouseOutboxByWorkspace returns every outbox row queued for a
 	// workspace, regardless of drainer state. Intended for tests and ad-hoc
 	// inspection (the live drainer uses FindClickhouseOutboxBatch which locks

--- a/pkg/db/querier_generated.go
+++ b/pkg/db/querier_generated.go
@@ -2269,8 +2269,10 @@ type Querier interface {
 	//  SELECT apps.pk, apps.id, apps.workspace_id, apps.project_id, apps.name, apps.slug, apps.default_branch, apps.current_deployment_id, apps.is_rolled_back, apps.delete_protection, apps.created_at, apps.updated_at
 	//  FROM apps
 	//  WHERE project_id = ?
-	//  ORDER BY created_at ASC
-	ListAppsByProject(ctx context.Context, db DBTX, projectID string) ([]ListAppsByProjectRow, error)
+	//    AND id >= ?
+	//  ORDER BY id ASC
+	//  LIMIT ?
+	ListAppsByProject(ctx context.Context, db DBTX, arg ListAppsByProjectParams) ([]ListAppsByProjectRow, error)
 	// ListClickhouseOutboxByWorkspace returns every outbox row queued for a
 	// workspace, regardless of drainer state. Intended for tests and ad-hoc
 	// inspection (the live drainer uses FindClickhouseOutboxBatch which locks

--- a/pkg/db/queries/app_list_by_project.sql
+++ b/pkg/db/queries/app_list_by_project.sql
@@ -1,5 +1,5 @@
 -- name: ListAppsByProject :many
-SELECT sqlc.embed(apps)
+SELECT apps.*
 FROM apps
 WHERE project_id = sqlc.arg(project_id)
   AND id >= sqlc.arg(id_cursor)

--- a/pkg/db/queries/app_list_by_project.sql
+++ b/pkg/db/queries/app_list_by_project.sql
@@ -2,4 +2,6 @@
 SELECT sqlc.embed(apps)
 FROM apps
 WHERE project_id = sqlc.arg(project_id)
-ORDER BY created_at ASC;
+  AND id >= sqlc.arg(id_cursor)
+ORDER BY id ASC
+LIMIT ?;

--- a/svc/api/openapi/gen.go
+++ b/svc/api/openapi/gen.go
@@ -801,6 +801,33 @@ type V2AppsGetAppResponseBody struct {
 	Meta Meta `json:"meta"`
 }
 
+// V2AppsListAppsRequestBody defines model for V2AppsListAppsRequestBody.
+type V2AppsListAppsRequestBody struct {
+	// Cursor Pagination cursor from a previous response to fetch the next page.
+	// Use when `hasMore: true` in the previous response.
+	Cursor *string `json:"cursor,omitempty"`
+
+	// Limit Maximum number of apps to return per request.
+	// Balance between response size and number of pagination calls needed.
+	Limit *int `json:"limit,omitempty"`
+
+	// ProjectSlug The slug of the project whose apps you want to list, unique within your workspace.
+	// Identifies the parent project the apps are enumerated under.
+	ProjectSlug string `json:"projectSlug"`
+}
+
+// V2AppsListAppsResponseBody defines model for V2AppsListAppsResponseBody.
+type V2AppsListAppsResponseBody struct {
+	// Data Array of apps in the project, ordered by app id.
+	Data []App `json:"data"`
+
+	// Meta Metadata object included in every API response. This provides context about the request and is essential for debugging, audit trails, and support inquiries. The `requestId` is particularly important when troubleshooting issues with the Unkey support team.
+	Meta Meta `json:"meta"`
+
+	// Pagination Pagination metadata for list endpoints. Provides information necessary to traverse through large result sets efficiently using cursor-based pagination.
+	Pagination *Pagination `json:"pagination,omitempty"`
+}
+
 // V2DeployCreateDeploymentRequestBody Create a deployment from a pre-built Docker image
 type V2DeployCreateDeploymentRequestBody struct {
 	// App App slug within the project
@@ -2645,6 +2672,9 @@ type AppsCreateAppJSONRequestBody = V2AppsCreateAppRequestBody
 
 // AppsGetAppJSONRequestBody defines body for AppsGetApp for application/json ContentType.
 type AppsGetAppJSONRequestBody = V2AppsGetAppRequestBody
+
+// AppsListAppsJSONRequestBody defines body for AppsListApps for application/json ContentType.
+type AppsListAppsJSONRequestBody = V2AppsListAppsRequestBody
 
 // DeployCreateDeploymentJSONRequestBody defines body for DeployCreateDeployment for application/json ContentType.
 type DeployCreateDeploymentJSONRequestBody = V2DeployCreateDeploymentRequestBody

--- a/svc/api/openapi/gen.go
+++ b/svc/api/openapi/gen.go
@@ -811,9 +811,9 @@ type V2AppsListAppsRequestBody struct {
 	// Balance between response size and number of pagination calls needed.
 	Limit *int `json:"limit,omitempty"`
 
-	// ProjectId Identifies the parent project whose apps you want to list by its unique identifier.
-	// Must be a valid project ID that begins with 'proj_' and exists within your workspace.
-	ProjectId string `json:"projectId"`
+	// Project URL-safe handle of the project whose apps you want to list.
+	// Must be lowercase letters, numbers, and hyphens, starting and ending with a letter or number.
+	Project string `json:"project"`
 }
 
 // V2AppsListAppsResponseBody defines model for V2AppsListAppsResponseBody.

--- a/svc/api/openapi/gen.go
+++ b/svc/api/openapi/gen.go
@@ -811,7 +811,8 @@ type V2AppsListAppsRequestBody struct {
 	// Balance between response size and number of pagination calls needed.
 	Limit *int `json:"limit,omitempty"`
 
-	// Project Slug of the parent project this app belongs to, unique within your workspace.
+	// Project Identifies the parent project whose apps to list, by either its unique ID or its slug.
+	// Accepts a project ID that begins with 'proj_' or a project slug.
 	Project string `json:"project"`
 }
 

--- a/svc/api/openapi/gen.go
+++ b/svc/api/openapi/gen.go
@@ -811,9 +811,9 @@ type V2AppsListAppsRequestBody struct {
 	// Balance between response size and number of pagination calls needed.
 	Limit *int `json:"limit,omitempty"`
 
-	// Project Identifies the parent project whose apps to list, by either its unique ID or its slug.
-	// Accepts a project ID that begins with 'proj_' or a project slug.
-	Project string `json:"project"`
+	// Project Identifies a resource by either its unique ID or its slug.
+	// Accepts a prefixed ID (such as 'proj_' or 'app_') or a slug.
+	Project ResourceIdentifier `json:"project"`
 }
 
 // V2AppsListAppsResponseBody defines model for V2AppsListAppsResponseBody.

--- a/svc/api/openapi/gen.go
+++ b/svc/api/openapi/gen.go
@@ -811,8 +811,7 @@ type V2AppsListAppsRequestBody struct {
 	// Balance between response size and number of pagination calls needed.
 	Limit *int `json:"limit,omitempty"`
 
-	// Project URL-safe handle of the project whose apps you want to list.
-	// Must be lowercase letters, numbers, and hyphens, starting and ending with a letter or number.
+	// Project Slug of the parent project this app belongs to, unique within your workspace.
 	Project string `json:"project"`
 }
 

--- a/svc/api/openapi/gen.go
+++ b/svc/api/openapi/gen.go
@@ -811,9 +811,9 @@ type V2AppsListAppsRequestBody struct {
 	// Balance between response size and number of pagination calls needed.
 	Limit *int `json:"limit,omitempty"`
 
-	// ProjectSlug The slug of the project whose apps you want to list, unique within your workspace.
-	// Identifies the parent project the apps are enumerated under.
-	ProjectSlug string `json:"projectSlug"`
+	// ProjectId Identifies the parent project whose apps you want to list by its unique identifier.
+	// Must be a valid project ID that begins with 'proj_' and exists within your workspace.
+	ProjectId string `json:"projectId"`
 }
 
 // V2AppsListAppsResponseBody defines model for V2AppsListAppsResponseBody.

--- a/svc/api/openapi/openapi-generated.yaml
+++ b/svc/api/openapi/openapi-generated.yaml
@@ -4886,7 +4886,7 @@ paths:
             description: |
                 Retrieve a paginated list of apps within a project.
 
-                Use this to build app management dashboards or to enumerate the apps belonging to a project. Apps are scoped to a project, so the project id is required. Results are ordered by app id and returned in pages. When `hasMore` is true, pass the returned `cursor` to fetch the next page.
+                Use this to enumerate every app in a project. Results are ordered by app id and paginated; when `hasMore` is true, pass the returned `cursor` to fetch the next page.
 
                 **Required Permissions**
 
@@ -4937,7 +4937,6 @@ paths:
                                         meta:
                                             requestId: req_1234abcd
                                         pagination:
-                                            cursor: app_5678efgh
                                             hasMore: false
                             schema:
                                 $ref: '#/components/schemas/V2AppsListAppsResponseBody'

--- a/svc/api/openapi/openapi-generated.yaml
+++ b/svc/api/openapi/openapi-generated.yaml
@@ -417,14 +417,7 @@ components:
                 - project
             properties:
                 project:
-                    type: string
-                    minLength: 1
-                    maxLength: 255
-                    pattern: "^[a-zA-Z0-9_-]+$"
-                    description: |
-                        Identifies the parent project whose apps to list, by either its unique ID or its slug.
-                        Accepts a project ID that begins with 'proj_' or a project slug.
-                    example: payments-service
+                    "$ref": "#/components/schemas/ResourceIdentifier"
                 limit:
                     type: integer
                     description: |
@@ -4890,9 +4883,8 @@ paths:
 
                 **Required Permissions**
 
-                Your root key must have one of the following permissions:
-                - `project.*.read_app` (to read apps in any project)
-                - `project.<project_id>.read_app` (to read apps in a specific project)
+                Your root key must have the following permission:
+                - `app.*.read_app` (to read apps in any project)
             operationId: apps.listApps
             requestBody:
                 content:
@@ -4977,7 +4969,7 @@ paths:
                                     summary: Missing required permission
                                     value:
                                         error:
-                                            detail: Your root key requires the 'project.*.read_app' permission to perform this operation
+                                            detail: Your root key requires the 'app.*.read_app' permission to perform this operation
                                             status: 403
                                             title: Forbidden
                                             type: forbidden
@@ -4985,7 +4977,7 @@ paths:
                                             requestId: req_1234abcd
                             schema:
                                 $ref: '#/components/schemas/ForbiddenErrorResponse'
-                    description: Forbidden - Insufficient permissions (requires `project.*.read_app`)
+                    description: Forbidden - Insufficient permissions (requires `app.*.read_app`)
                 "404":
                     content:
                         application/json:

--- a/svc/api/openapi/openapi-generated.yaml
+++ b/svc/api/openapi/openapi-generated.yaml
@@ -421,9 +421,7 @@ components:
                     minLength: 1
                     maxLength: 256
                     pattern: "^[a-z0-9]+(-[a-z0-9]+)*$"
-                    description: |
-                        URL-safe handle of the project whose apps you want to list.
-                        Must be lowercase letters, numbers, and hyphens, starting and ending with a letter or number.
+                    description: Slug of the parent project this app belongs to, unique within your workspace.
                     example: payments-service
                 limit:
                     type: integer

--- a/svc/api/openapi/openapi-generated.yaml
+++ b/svc/api/openapi/openapi-generated.yaml
@@ -414,17 +414,17 @@ components:
         V2AppsListAppsRequestBody:
             type: object
             required:
-                - projectId
+                - project
             properties:
-                projectId:
+                project:
                     type: string
-                    minLength: 8
-                    maxLength: 255
-                    pattern: "^[a-zA-Z0-9_]+$"
+                    minLength: 1
+                    maxLength: 256
+                    pattern: "^[a-z0-9]+(-[a-z0-9]+)*$"
                     description: |
-                        Identifies the parent project whose apps you want to list by its unique identifier.
-                        Must be a valid project ID that begins with 'proj_' and exists within your workspace.
-                    example: proj_1234abcd
+                        URL-safe handle of the project whose apps you want to list.
+                        Must be lowercase letters, numbers, and hyphens, starting and ending with a letter or number.
+                    example: payments-service
                 limit:
                     type: integer
                     description: |
@@ -4902,7 +4902,7 @@ paths:
                                 description: List the first page of apps in the given project
                                 summary: List a project's apps
                                 value:
-                                    projectId: proj_1234abcd
+                                    project: payments-service
                         schema:
                             $ref: '#/components/schemas/V2AppsListAppsRequestBody'
                 required: true

--- a/svc/api/openapi/openapi-generated.yaml
+++ b/svc/api/openapi/openapi-generated.yaml
@@ -411,6 +411,54 @@ components:
                 data:
                     "$ref": "#/components/schemas/App"
             additionalProperties: false
+        V2AppsListAppsRequestBody:
+            type: object
+            required:
+                - projectSlug
+            properties:
+                projectSlug:
+                    type: string
+                    minLength: 1
+                    maxLength: 256
+                    pattern: "^[a-z0-9]+(-[a-z0-9]+)*$"
+                    description: |
+                        The slug of the project whose apps you want to list, unique within your workspace.
+                        Identifies the parent project the apps are enumerated under.
+                    example: payments-service
+                limit:
+                    type: integer
+                    description: |
+                        Maximum number of apps to return per request.
+                        Balance between response size and number of pagination calls needed.
+                    default: 100
+                    minimum: 1
+                    maximum: 100
+                cursor:
+                    type: string
+                    description: |
+                        Pagination cursor from a previous response to fetch the next page.
+                        Use when `hasMore: true` in the previous response.
+                    example: app_1234abcd
+            additionalProperties: false
+        V2AppsListAppsResponseBody:
+            type: object
+            required:
+                - meta
+                - data
+            properties:
+                meta:
+                    "$ref": "#/components/schemas/Meta"
+                data:
+                    type: array
+                    maxItems: 100
+                    items:
+                        "$ref": "#/components/schemas/App"
+                    description: Array of apps in the project, ordered by app id.
+                pagination:
+                    "$ref": "#/components/schemas/Pagination"
+                    x-go-type-skip-optional-pointer: true
+                    x-go-type-skip-optional-pointer-with-omitzero: true
+            additionalProperties: false
         V2DeployCreateDeploymentRequestBody:
             type: object
             required:
@@ -4833,6 +4881,155 @@ paths:
             tags:
                 - apps
             x-speakeasy-name-override: getApp
+    /v2/apps.listApps:
+        post:
+            description: |
+                Retrieve a paginated list of apps within a project.
+
+                Use this to build app management dashboards or to enumerate the apps belonging to a project. Apps are scoped to a project, so the project slug is required. Results are ordered by app id and returned in pages. When `hasMore` is true, pass the returned `cursor` to fetch the next page.
+
+                **Required Permissions**
+
+                Your root key must have one of the following permissions:
+                - `project.*.read_app` (to read apps in any project)
+                - `project.<project_id>.read_app` (to read apps in a specific project)
+            operationId: apps.listApps
+            requestBody:
+                content:
+                    application/json:
+                        examples:
+                            basic:
+                                description: List the first page of apps in the given project
+                                summary: List a project's apps
+                                value:
+                                    projectSlug: payments-service
+                        schema:
+                            $ref: '#/components/schemas/V2AppsListAppsRequestBody'
+                required: true
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            examples:
+                                appList:
+                                    description: Successfully retrieved a page of apps
+                                    summary: App list
+                                    value:
+                                        data:
+                                            - createdAt: 1704067200000
+                                              currentDeploymentId: dep_1234abcd
+                                              defaultBranch: main
+                                              deleteProtection: false
+                                              id: app_1234abcd
+                                              isRolledBack: false
+                                              name: Payments API
+                                              projectId: proj_1234abcd
+                                              slug: payments-api
+                                              updatedAt: 1704153600000
+                                            - createdAt: 1704240000000
+                                              defaultBranch: main
+                                              deleteProtection: false
+                                              id: app_5678efgh
+                                              isRolledBack: false
+                                              name: Billing API
+                                              projectId: proj_1234abcd
+                                              slug: billing-api
+                                        meta:
+                                            requestId: req_1234abcd
+                                        pagination:
+                                            cursor: app_5678efgh
+                                            hasMore: false
+                            schema:
+                                $ref: '#/components/schemas/V2AppsListAppsResponseBody'
+                    description: |
+                        Successfully retrieved a paginated list of apps. Use the pagination cursor for additional results when `hasMore: true`.
+                "400":
+                    content:
+                        application/json:
+                            examples:
+                                invalidLimit:
+                                    summary: Invalid limit
+                                    value:
+                                        error:
+                                            detail: The limit must be between 1 and 100.
+                                            errors:
+                                                - fix: Use a limit between 1 and 100
+                                                  location: body.limit
+                                                  message: must be less than or equal to 100
+                                            status: 400
+                                            title: Bad Request
+                                            type: validation-error
+                                        meta:
+                                            requestId: req_1234abcd
+                            schema:
+                                $ref: '#/components/schemas/BadRequestErrorResponse'
+                    description: Bad request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/UnauthorizedErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            examples:
+                                missingPermission:
+                                    summary: Missing required permission
+                                    value:
+                                        error:
+                                            detail: Your root key requires the 'project.*.read_app' permission to perform this operation
+                                            status: 403
+                                            title: Forbidden
+                                            type: forbidden
+                                        meta:
+                                            requestId: req_1234abcd
+                            schema:
+                                $ref: '#/components/schemas/ForbiddenErrorResponse'
+                    description: Forbidden - Insufficient permissions (requires `project.*.read_app`)
+                "404":
+                    content:
+                        application/json:
+                            examples:
+                                projectNotFound:
+                                    summary: Project not found
+                                    value:
+                                        error:
+                                            detail: The requested project does not exist.
+                                            status: 404
+                                            title: Not Found
+                                            type: not-found
+                                        meta:
+                                            requestId: req_1234abcd
+                            schema:
+                                $ref: '#/components/schemas/NotFoundErrorResponse'
+                    description: Not Found - The requested project does not exist in your workspace
+                "429":
+                    content:
+                        application/problem+json:
+                            schema:
+                                $ref: '#/components/schemas/TooManyRequestsErrorResponse'
+                    description: Too Many Requests
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/InternalServerErrorResponse'
+                    description: Internal server error
+            security:
+                - rootKey: []
+            summary: List apps
+            tags:
+                - apps
+            x-speakeasy-name-override: listApps
+            x-speakeasy-pagination:
+                inputs:
+                    - in: requestBody
+                      name: cursor
+                      type: cursor
+                outputs:
+                    nextCursor: $.pagination.cursor
+                type: cursor
     /v2/deploy.createDeployment:
         post:
             description: |

--- a/svc/api/openapi/openapi-generated.yaml
+++ b/svc/api/openapi/openapi-generated.yaml
@@ -414,17 +414,17 @@ components:
         V2AppsListAppsRequestBody:
             type: object
             required:
-                - projectSlug
+                - projectId
             properties:
-                projectSlug:
+                projectId:
                     type: string
-                    minLength: 1
-                    maxLength: 256
-                    pattern: "^[a-z0-9]+(-[a-z0-9]+)*$"
+                    minLength: 8
+                    maxLength: 255
+                    pattern: "^[a-zA-Z0-9_]+$"
                     description: |
-                        The slug of the project whose apps you want to list, unique within your workspace.
-                        Identifies the parent project the apps are enumerated under.
-                    example: payments-service
+                        Identifies the parent project whose apps you want to list by its unique identifier.
+                        Must be a valid project ID that begins with 'proj_' and exists within your workspace.
+                    example: proj_1234abcd
                 limit:
                     type: integer
                     description: |
@@ -4886,7 +4886,7 @@ paths:
             description: |
                 Retrieve a paginated list of apps within a project.
 
-                Use this to build app management dashboards or to enumerate the apps belonging to a project. Apps are scoped to a project, so the project slug is required. Results are ordered by app id and returned in pages. When `hasMore` is true, pass the returned `cursor` to fetch the next page.
+                Use this to build app management dashboards or to enumerate the apps belonging to a project. Apps are scoped to a project, so the project id is required. Results are ordered by app id and returned in pages. When `hasMore` is true, pass the returned `cursor` to fetch the next page.
 
                 **Required Permissions**
 
@@ -4902,7 +4902,7 @@ paths:
                                 description: List the first page of apps in the given project
                                 summary: List a project's apps
                                 value:
-                                    projectSlug: payments-service
+                                    projectId: proj_1234abcd
                         schema:
                             $ref: '#/components/schemas/V2AppsListAppsRequestBody'
                 required: true

--- a/svc/api/openapi/openapi-generated.yaml
+++ b/svc/api/openapi/openapi-generated.yaml
@@ -419,9 +419,11 @@ components:
                 project:
                     type: string
                     minLength: 1
-                    maxLength: 256
-                    pattern: "^[a-z0-9]+(-[a-z0-9]+)*$"
-                    description: Slug of the parent project this app belongs to, unique within your workspace.
+                    maxLength: 255
+                    pattern: "^[a-zA-Z0-9_-]+$"
+                    description: |
+                        Identifies the parent project whose apps to list, by either its unique ID or its slug.
+                        Accepts a project ID that begins with 'proj_' or a project slug.
                     example: payments-service
                 limit:
                     type: integer

--- a/svc/api/openapi/openapi-split.yaml
+++ b/svc/api/openapi/openapi-split.yaml
@@ -226,6 +226,8 @@ paths:
     $ref: "./spec/paths/v2/apps/createApp/index.yaml"
   /v2/apps.getApp:
     $ref: "./spec/paths/v2/apps/getApp/index.yaml"
+  /v2/apps.listApps:
+    $ref: "./spec/paths/v2/apps/listApps/index.yaml"
 
   # Permissions Endpoints
   /v2/permissions.createRole:

--- a/svc/api/openapi/spec/paths/v2/apps/listApps/V2AppsListAppsRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/apps/listApps/V2AppsListAppsRequestBody.yaml
@@ -1,16 +1,16 @@
 type: object
 required:
-  - projectId
+  - project
 properties:
-  projectId:
+  project:
     type: string
-    minLength: 8
-    maxLength: 255
-    pattern: "^[a-zA-Z0-9_]+$"
+    minLength: 1
+    maxLength: 256
+    pattern: "^[a-z0-9]+(-[a-z0-9]+)*$"
     description: |
-      Identifies the parent project whose apps you want to list by its unique identifier.
-      Must be a valid project ID that begins with 'proj_' and exists within your workspace.
-    example: proj_1234abcd
+      URL-safe handle of the project whose apps you want to list.
+      Must be lowercase letters, numbers, and hyphens, starting and ending with a letter or number.
+    example: payments-service
   limit:
     type: integer
     description: |
@@ -31,11 +31,11 @@ examples:
     summary: List a project's apps
     description: List the first page of apps in the given project
     value:
-      projectId: proj_1234abcd
+      project: payments-service
   paginated:
     summary: Paginate with a smaller page size
     description: Fetch a smaller page and continue from a cursor
     value:
-      projectId: proj_1234abcd
+      project: payments-service
       limit: 20
       cursor: app_1234abcd

--- a/svc/api/openapi/spec/paths/v2/apps/listApps/V2AppsListAppsRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/apps/listApps/V2AppsListAppsRequestBody.yaml
@@ -1,0 +1,41 @@
+type: object
+required:
+  - projectSlug
+properties:
+  projectSlug:
+    type: string
+    minLength: 1
+    maxLength: 256
+    pattern: "^[a-z0-9]+(-[a-z0-9]+)*$"
+    description: |
+      The slug of the project whose apps you want to list, unique within your workspace.
+      Identifies the parent project the apps are enumerated under.
+    example: payments-service
+  limit:
+    type: integer
+    description: |
+      Maximum number of apps to return per request.
+      Balance between response size and number of pagination calls needed.
+    default: 100
+    minimum: 1
+    maximum: 100
+  cursor:
+    type: string
+    description: |
+      Pagination cursor from a previous response to fetch the next page.
+      Use when `hasMore: true` in the previous response.
+    example: app_1234abcd
+additionalProperties: false
+examples:
+  basic:
+    summary: List a project's apps
+    description: List the first page of apps in the given project
+    value:
+      projectSlug: payments-service
+  paginated:
+    summary: Paginate with a smaller page size
+    description: Fetch a smaller page and continue from a cursor
+    value:
+      projectSlug: payments-service
+      limit: 20
+      cursor: app_1234abcd

--- a/svc/api/openapi/spec/paths/v2/apps/listApps/V2AppsListAppsRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/apps/listApps/V2AppsListAppsRequestBody.yaml
@@ -5,9 +5,11 @@ properties:
   project:
     type: string
     minLength: 1
-    maxLength: 256
-    pattern: "^[a-z0-9]+(-[a-z0-9]+)*$"
-    description: Slug of the parent project this app belongs to, unique within your workspace.
+    maxLength: 255
+    pattern: "^[a-zA-Z0-9_-]+$"
+    description: |
+      Identifies the parent project whose apps to list, by either its unique ID or its slug.
+      Accepts a project ID that begins with 'proj_' or a project slug.
     example: payments-service
   limit:
     type: integer
@@ -25,11 +27,16 @@ properties:
     example: app_1234abcd
 additionalProperties: false
 examples:
-  basic:
-    summary: List a project's apps
-    description: List the first page of apps in the given project
+  byProjectSlug:
+    summary: List a project's apps by slug
+    description: List the first page of apps, locating the project by its slug
     value:
       project: payments-service
+  byProjectId:
+    summary: List a project's apps by ID
+    description: List the first page of apps, locating the project by its ID
+    value:
+      project: proj_1234abcd
   paginated:
     summary: Paginate with a smaller page size
     description: Fetch a smaller page and continue from a cursor

--- a/svc/api/openapi/spec/paths/v2/apps/listApps/V2AppsListAppsRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/apps/listApps/V2AppsListAppsRequestBody.yaml
@@ -3,14 +3,7 @@ required:
   - project
 properties:
   project:
-    type: string
-    minLength: 1
-    maxLength: 255
-    pattern: "^[a-zA-Z0-9_-]+$"
-    description: |
-      Identifies the parent project whose apps to list, by either its unique ID or its slug.
-      Accepts a project ID that begins with 'proj_' or a project slug.
-    example: payments-service
+    "$ref": "../../../../common/ResourceIdentifier.yaml"
   limit:
     type: integer
     description: |

--- a/svc/api/openapi/spec/paths/v2/apps/listApps/V2AppsListAppsRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/apps/listApps/V2AppsListAppsRequestBody.yaml
@@ -1,16 +1,16 @@
 type: object
 required:
-  - projectSlug
+  - projectId
 properties:
-  projectSlug:
+  projectId:
     type: string
-    minLength: 1
-    maxLength: 256
-    pattern: "^[a-z0-9]+(-[a-z0-9]+)*$"
+    minLength: 8
+    maxLength: 255
+    pattern: "^[a-zA-Z0-9_]+$"
     description: |
-      The slug of the project whose apps you want to list, unique within your workspace.
-      Identifies the parent project the apps are enumerated under.
-    example: payments-service
+      Identifies the parent project whose apps you want to list by its unique identifier.
+      Must be a valid project ID that begins with 'proj_' and exists within your workspace.
+    example: proj_1234abcd
   limit:
     type: integer
     description: |
@@ -31,11 +31,11 @@ examples:
     summary: List a project's apps
     description: List the first page of apps in the given project
     value:
-      projectSlug: payments-service
+      projectId: proj_1234abcd
   paginated:
     summary: Paginate with a smaller page size
     description: Fetch a smaller page and continue from a cursor
     value:
-      projectSlug: payments-service
+      projectId: proj_1234abcd
       limit: 20
       cursor: app_1234abcd

--- a/svc/api/openapi/spec/paths/v2/apps/listApps/V2AppsListAppsRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/apps/listApps/V2AppsListAppsRequestBody.yaml
@@ -7,9 +7,7 @@ properties:
     minLength: 1
     maxLength: 256
     pattern: "^[a-z0-9]+(-[a-z0-9]+)*$"
-    description: |
-      URL-safe handle of the project whose apps you want to list.
-      Must be lowercase letters, numbers, and hyphens, starting and ending with a letter or number.
+    description: Slug of the parent project this app belongs to, unique within your workspace.
     example: payments-service
   limit:
     type: integer

--- a/svc/api/openapi/spec/paths/v2/apps/listApps/V2AppsListAppsResponseBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/apps/listApps/V2AppsListAppsResponseBody.yaml
@@ -43,7 +43,6 @@ examples:
           deleteProtection: false
           createdAt: 1704240000000
       pagination:
-        cursor: app_5678efgh
         hasMore: false
   paginatedResponse:
     summary: Paginated app listing with more results

--- a/svc/api/openapi/spec/paths/v2/apps/listApps/V2AppsListAppsResponseBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/apps/listApps/V2AppsListAppsResponseBody.yaml
@@ -1,0 +1,83 @@
+type: object
+required:
+  - meta
+  - data
+properties:
+  meta:
+    "$ref": "../../../../common/Meta.yaml"
+  data:
+    type: array
+    maxItems: 100
+    items:
+      "$ref": "../../../../common/App.yaml"
+    description: Array of apps in the project, ordered by app id.
+  pagination:
+    "$ref": "../../../../common/Pagination.yaml"
+    x-go-type-skip-optional-pointer: true
+    x-go-type-skip-optional-pointer-with-omitzero: true
+additionalProperties: false
+examples:
+  appList:
+    summary: App list
+    description: Typical response listing apps in a project
+    value:
+      meta:
+        requestId: req_1234abcd
+      data:
+        - id: app_1234abcd
+          name: Payments API
+          slug: payments-api
+          projectId: proj_1234abcd
+          defaultBranch: main
+          currentDeploymentId: dep_1234abcd
+          isRolledBack: false
+          deleteProtection: false
+          createdAt: 1704067200000
+          updatedAt: 1704153600000
+        - id: app_5678efgh
+          name: Billing API
+          slug: billing-api
+          projectId: proj_1234abcd
+          defaultBranch: main
+          isRolledBack: false
+          deleteProtection: false
+          createdAt: 1704240000000
+      pagination:
+        cursor: app_5678efgh
+        hasMore: false
+  paginatedResponse:
+    summary: Paginated app listing with more results
+    description: Response showing pagination when there are more apps than the requested limit
+    value:
+      meta:
+        requestId: req_5678efgh
+      data:
+        - id: app_1111aaaa
+          name: Payments API
+          slug: payments-api
+          projectId: proj_1234abcd
+          defaultBranch: main
+          isRolledBack: false
+          deleteProtection: false
+          createdAt: 1704067200000
+        - id: app_2222bbbb
+          name: Billing API
+          slug: billing-api
+          projectId: proj_1234abcd
+          defaultBranch: main
+          isRolledBack: false
+          deleteProtection: false
+          createdAt: 1704153600000
+      pagination:
+        cursor: app_2222bbbb
+        hasMore: true
+  emptyResponse:
+    summary: Empty app list
+    description: Response when the project has no apps
+    value:
+      meta:
+        requestId: req_9876zyxw
+      data: []
+      pagination:
+        cursor: null
+        hasMore: false

--- a/svc/api/openapi/spec/paths/v2/apps/listApps/index.yaml
+++ b/svc/api/openapi/spec/paths/v2/apps/listApps/index.yaml
@@ -5,7 +5,7 @@ post:
   description: |
     Retrieve a paginated list of apps within a project.
 
-    Use this to build app management dashboards or to enumerate the apps belonging to a project. Apps are scoped to a project, so the project id is required. Results are ordered by app id and returned in pages. When `hasMore` is true, pass the returned `cursor` to fetch the next page.
+    Use this to enumerate every app in a project. Results are ordered by app id and paginated; when `hasMore` is true, pass the returned `cursor` to fetch the next page.
 
     **Required Permissions**
 
@@ -61,7 +61,6 @@ post:
                     deleteProtection: false
                     createdAt: 1704240000000
                 pagination:
-                  cursor: app_5678efgh
                   hasMore: false
       description: |
         Successfully retrieved a paginated list of apps. Use the pagination cursor for additional results when `hasMore: true`.

--- a/svc/api/openapi/spec/paths/v2/apps/listApps/index.yaml
+++ b/svc/api/openapi/spec/paths/v2/apps/listApps/index.yaml
@@ -26,7 +26,7 @@ post:
             summary: List a project's apps
             description: List the first page of apps in the given project
             value:
-              projectId: proj_1234abcd
+              project: payments-service
     required: true
   responses:
     "200":

--- a/svc/api/openapi/spec/paths/v2/apps/listApps/index.yaml
+++ b/svc/api/openapi/spec/paths/v2/apps/listApps/index.yaml
@@ -5,7 +5,7 @@ post:
   description: |
     Retrieve a paginated list of apps within a project.
 
-    Use this to build app management dashboards or to enumerate the apps belonging to a project. Apps are scoped to a project, so the project slug is required. Results are ordered by app id and returned in pages. When `hasMore` is true, pass the returned `cursor` to fetch the next page.
+    Use this to build app management dashboards or to enumerate the apps belonging to a project. Apps are scoped to a project, so the project id is required. Results are ordered by app id and returned in pages. When `hasMore` is true, pass the returned `cursor` to fetch the next page.
 
     **Required Permissions**
 
@@ -26,7 +26,7 @@ post:
             summary: List a project's apps
             description: List the first page of apps in the given project
             value:
-              projectSlug: payments-service
+              projectId: proj_1234abcd
     required: true
   responses:
     "200":

--- a/svc/api/openapi/spec/paths/v2/apps/listApps/index.yaml
+++ b/svc/api/openapi/spec/paths/v2/apps/listApps/index.yaml
@@ -1,0 +1,148 @@
+post:
+  tags:
+    - apps
+  summary: List apps
+  description: |
+    Retrieve a paginated list of apps within a project.
+
+    Use this to build app management dashboards or to enumerate the apps belonging to a project. Apps are scoped to a project, so the project slug is required. Results are ordered by app id and returned in pages. When `hasMore` is true, pass the returned `cursor` to fetch the next page.
+
+    **Required Permissions**
+
+    Your root key must have one of the following permissions:
+    - `project.*.read_app` (to read apps in any project)
+    - `project.<project_id>.read_app` (to read apps in a specific project)
+  operationId: apps.listApps
+  x-speakeasy-name-override: listApps
+  security:
+    - rootKey: []
+  requestBody:
+    content:
+      application/json:
+        schema:
+          "$ref": "./V2AppsListAppsRequestBody.yaml"
+        examples:
+          basic:
+            summary: List a project's apps
+            description: List the first page of apps in the given project
+            value:
+              projectSlug: payments-service
+    required: true
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            "$ref": "./V2AppsListAppsResponseBody.yaml"
+          examples:
+            appList:
+              summary: App list
+              description: Successfully retrieved a page of apps
+              value:
+                meta:
+                  requestId: req_1234abcd
+                data:
+                  - id: app_1234abcd
+                    name: Payments API
+                    slug: payments-api
+                    projectId: proj_1234abcd
+                    defaultBranch: main
+                    currentDeploymentId: dep_1234abcd
+                    isRolledBack: false
+                    deleteProtection: false
+                    createdAt: 1704067200000
+                    updatedAt: 1704153600000
+                  - id: app_5678efgh
+                    name: Billing API
+                    slug: billing-api
+                    projectId: proj_1234abcd
+                    defaultBranch: main
+                    isRolledBack: false
+                    deleteProtection: false
+                    createdAt: 1704240000000
+                pagination:
+                  cursor: app_5678efgh
+                  hasMore: false
+      description: |
+        Successfully retrieved a paginated list of apps. Use the pagination cursor for additional results when `hasMore: true`.
+    "400":
+      description: Bad request
+      content:
+        application/json:
+          schema:
+            "$ref": "../../../../error/BadRequestErrorResponse.yaml"
+          examples:
+            invalidLimit:
+              summary: Invalid limit
+              value:
+                meta:
+                  requestId: req_1234abcd
+                error:
+                  title: Bad Request
+                  detail: The limit must be between 1 and 100.
+                  status: 400
+                  type: validation-error
+                  errors:
+                    - location: body.limit
+                      message: must be less than or equal to 100
+                      fix: Use a limit between 1 and 100
+    "401":
+      description: Unauthorized
+      content:
+        application/json:
+          schema:
+            "$ref": "../../../../error/UnauthorizedErrorResponse.yaml"
+    "403":
+      description: Forbidden - Insufficient permissions (requires `project.*.read_app`)
+      content:
+        application/json:
+          schema:
+            "$ref": "../../../../error/ForbiddenErrorResponse.yaml"
+          examples:
+            missingPermission:
+              summary: Missing required permission
+              value:
+                meta:
+                  requestId: req_1234abcd
+                error:
+                  title: Forbidden
+                  detail: Your root key requires the 'project.*.read_app' permission to perform this operation
+                  status: 403
+                  type: forbidden
+    "404":
+      description: Not Found - The requested project does not exist in your workspace
+      content:
+        application/json:
+          schema:
+            "$ref": "../../../../error/NotFoundErrorResponse.yaml"
+          examples:
+            projectNotFound:
+              summary: Project not found
+              value:
+                meta:
+                  requestId: req_1234abcd
+                error:
+                  title: Not Found
+                  detail: The requested project does not exist.
+                  status: 404
+                  type: not-found
+    "429":
+      description: Too Many Requests
+      content:
+        application/problem+json:
+          schema:
+            "$ref": "../../../../error/TooManyRequestsErrorResponse.yaml"
+    "500":
+      description: Internal server error
+      content:
+        application/json:
+          schema:
+            "$ref": "../../../../error/InternalServerErrorResponse.yaml"
+  x-speakeasy-pagination:
+    type: cursor
+    inputs:
+      - name: cursor
+        in: requestBody
+        type: cursor
+    outputs:
+      nextCursor: "$.pagination.cursor"

--- a/svc/api/openapi/spec/paths/v2/apps/listApps/index.yaml
+++ b/svc/api/openapi/spec/paths/v2/apps/listApps/index.yaml
@@ -9,9 +9,8 @@ post:
 
     **Required Permissions**
 
-    Your root key must have one of the following permissions:
-    - `project.*.read_app` (to read apps in any project)
-    - `project.<project_id>.read_app` (to read apps in a specific project)
+    Your root key must have the following permission:
+    - `app.*.read_app` (to read apps in any project)
   operationId: apps.listApps
   x-speakeasy-name-override: listApps
   security:
@@ -92,7 +91,7 @@ post:
           schema:
             "$ref": "../../../../error/UnauthorizedErrorResponse.yaml"
     "403":
-      description: Forbidden - Insufficient permissions (requires `project.*.read_app`)
+      description: Forbidden - Insufficient permissions (requires `app.*.read_app`)
       content:
         application/json:
           schema:
@@ -105,7 +104,7 @@ post:
                   requestId: req_1234abcd
                 error:
                   title: Forbidden
-                  detail: Your root key requires the 'project.*.read_app' permission to perform this operation
+                  detail: Your root key requires the 'app.*.read_app' permission to perform this operation
                   status: 403
                   type: forbidden
     "404":

--- a/svc/api/routes/BUILD.bazel
+++ b/svc/api/routes/BUILD.bazel
@@ -35,6 +35,7 @@ go_library(
         "//svc/api/routes/v2_apis_list_keys",
         "//svc/api/routes/v2_apps_create_app",
         "//svc/api/routes/v2_apps_get_app",
+        "//svc/api/routes/v2_apps_list_apps",
         "//svc/api/routes/v2_deploy_create_deployment",
         "//svc/api/routes/v2_deploy_get_deployment",
         "//svc/api/routes/v2_identities_create_identity",

--- a/svc/api/routes/register.go
+++ b/svc/api/routes/register.go
@@ -63,6 +63,7 @@ import (
 
 	v2AppsCreateApp "github.com/unkeyed/unkey/svc/api/routes/v2_apps_create_app"
 	v2AppsGetApp "github.com/unkeyed/unkey/svc/api/routes/v2_apps_get_app"
+	v2AppsListApps "github.com/unkeyed/unkey/svc/api/routes/v2_apps_list_apps"
 	v2ProjectsCreateProject "github.com/unkeyed/unkey/svc/api/routes/v2_projects_create_project"
 	v2ProjectsDeleteProject "github.com/unkeyed/unkey/svc/api/routes/v2_projects_delete_project"
 	v2ProjectsGetProject "github.com/unkeyed/unkey/svc/api/routes/v2_projects_get_project"
@@ -659,6 +660,14 @@ func Register(srv *zen.Server, svc *Services, info zen.InstanceInfo) {
 	srv.RegisterRoute(
 		protectedMiddlewares,
 		&v2AppsGetApp.Handler{
+			DB: svc.Database,
+		},
+	)
+
+	// v2/apps.listApps
+	srv.RegisterRoute(
+		protectedMiddlewares,
+		&v2AppsListApps.Handler{
 			DB: svc.Database,
 		},
 	)

--- a/svc/api/routes/v2_apps_list_apps/200_test.go
+++ b/svc/api/routes/v2_apps_list_apps/200_test.go
@@ -1,0 +1,217 @@
+package handler_test
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/ptr"
+	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_apps_list_apps"
+)
+
+func TestListAppsSuccessfully(t *testing.T) {
+	h := testutil.NewHarness(t)
+
+	route := &handler.Handler{DB: h.DB}
+	h.Register(route)
+
+	workspace := h.Resources().UserWorkspace
+	rootKey := h.CreateRootKey(workspace.ID, "project.*.read_app")
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}
+
+	projectSlug := strings.ToLower(strings.ReplaceAll(uid.New("test"), "_", "-"))
+	project := h.CreateProject(seed.CreateProjectRequest{
+		ID:          uid.New(uid.ProjectPrefix),
+		WorkspaceID: workspace.ID,
+		Name:        "Payments Service",
+		Slug:        projectSlug,
+	})
+
+	t.Run("project with no apps returns empty list", func(t *testing.T) {
+		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{ProjectSlug: projectSlug})
+		require.Equal(t, 200, res.Status, "expected 200, received: %s", res.RawBody)
+		require.NotNil(t, res.Body)
+		require.Empty(t, res.Body.Data)
+		require.NotNil(t, res.Body.Pagination)
+		require.False(t, res.Body.Pagination.HasMore)
+		require.Nil(t, res.Body.Pagination.Cursor)
+	})
+
+	seeded := map[string]string{}
+	for i := 0; i < 3; i++ {
+		slug := strings.ToLower(strings.ReplaceAll(uid.New("test"), "_", "-"))
+		app := h.CreateApp(seed.CreateAppRequest{
+			ID:            uid.New(uid.AppPrefix),
+			WorkspaceID:   workspace.ID,
+			ProjectID:     project.ID,
+			Name:          fmt.Sprintf("App %d", i),
+			Slug:          slug,
+			DefaultBranch: "main",
+		})
+		seeded[app.ID] = slug
+	}
+
+	t.Run("lists seeded apps with populated fields", func(t *testing.T) {
+		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{ProjectSlug: projectSlug})
+		require.Equal(t, 200, res.Status, "expected 200, received: %s", res.RawBody)
+		require.NotEmpty(t, res.Body.Meta.RequestId)
+		require.Len(t, res.Body.Data, len(seeded))
+		require.False(t, res.Body.Pagination.HasMore)
+
+		for _, a := range res.Body.Data {
+			slug, ok := seeded[a.Id]
+			require.True(t, ok, "unexpected app %s in response", a.Id)
+			require.True(t, strings.HasPrefix(a.Id, "app_"), "id should have app_ prefix: %s", a.Id)
+			require.Equal(t, slug, a.Slug)
+			require.Equal(t, project.ID, a.ProjectId)
+			require.Equal(t, "main", a.DefaultBranch)
+			require.NotEmpty(t, a.Name)
+			require.Empty(t, a.CurrentDeploymentId, "freshly seeded app has no active deployment")
+			require.False(t, a.IsRolledBack)
+			require.False(t, a.DeleteProtection)
+			require.Greater(t, a.CreatedAt, int64(0))
+			require.Zero(t, a.UpdatedAt, "never-updated app should have zero (omitted) updatedAt")
+		}
+	})
+
+	t.Run("apps from other projects are not listed", func(t *testing.T) {
+		otherSlug := strings.ToLower(strings.ReplaceAll(uid.New("test"), "_", "-"))
+		otherProject := h.CreateProject(seed.CreateProjectRequest{
+			ID:          uid.New(uid.ProjectPrefix),
+			WorkspaceID: workspace.ID,
+			Name:        "Billing Service",
+			Slug:        otherSlug,
+		})
+		strayApp := h.CreateApp(seed.CreateAppRequest{
+			ID:            uid.New(uid.AppPrefix),
+			WorkspaceID:   workspace.ID,
+			ProjectID:     otherProject.ID,
+			Name:          "Stray",
+			Slug:          strings.ToLower(strings.ReplaceAll(uid.New("test"), "_", "-")),
+			DefaultBranch: "main",
+		})
+
+		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{ProjectSlug: projectSlug})
+		require.Equal(t, 200, res.Status, "expected 200, received: %s", res.RawBody)
+		require.Len(t, res.Body.Data, len(seeded))
+		for _, a := range res.Body.Data {
+			require.NotEqual(t, strayApp.ID, a.Id, "app from another project must not be listed")
+		}
+	})
+
+	t.Run("non-existent cursor returns 200 without error", func(t *testing.T) {
+		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{
+			ProjectSlug: projectSlug,
+			Cursor:      ptr.P("app_doesnotexist"),
+		})
+		require.Equal(t, 200, res.Status, "expected 200, received: %s", res.RawBody)
+		require.NotNil(t, res.Body.Pagination)
+	})
+
+	t.Run("cursor borrowed from another workspace stays project-scoped", func(t *testing.T) {
+		// A caller-supplied cursor that is a real app ID from another workspace
+		// must not widen results beyond the authorized project. The query is
+		// scoped by project_id, so the foreign app can never appear and only this
+		// project's own apps (with id >= cursor) are returned.
+		foreignWorkspace := h.CreateWorkspace()
+		foreignSlug := strings.ToLower(strings.ReplaceAll(uid.New("test"), "_", "-"))
+		foreignProject := h.CreateProject(seed.CreateProjectRequest{
+			ID:          uid.New(uid.ProjectPrefix),
+			WorkspaceID: foreignWorkspace.ID,
+			Name:        "Foreign",
+			Slug:        foreignSlug,
+		})
+		foreignApp := h.CreateApp(seed.CreateAppRequest{
+			ID:            uid.New(uid.AppPrefix),
+			WorkspaceID:   foreignWorkspace.ID,
+			ProjectID:     foreignProject.ID,
+			Name:          "Foreign App",
+			Slug:          strings.ToLower(strings.ReplaceAll(uid.New("test"), "_", "-")),
+			DefaultBranch: "main",
+		})
+
+		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{
+			ProjectSlug: projectSlug,
+			Cursor:      ptr.P(foreignApp.ID),
+		})
+		require.Equal(t, 200, res.Status, "expected 200, received: %s", res.RawBody)
+		for _, a := range res.Body.Data {
+			require.NotEqual(t, foreignApp.ID, a.Id, "foreign app must never be returned")
+			require.Equal(t, project.ID, a.ProjectId, "only the authorized project's apps may be returned")
+		}
+		require.NotContains(t, res.RawBody, foreignProject.ID, "response must not leak the foreign project ID")
+	})
+}
+
+func TestListAppsPagination(t *testing.T) {
+	h := testutil.NewHarness(t)
+
+	route := &handler.Handler{DB: h.DB}
+	h.Register(route)
+
+	workspace := h.Resources().UserWorkspace
+	rootKey := h.CreateRootKey(workspace.ID, "project.*.read_app")
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}
+
+	projectSlug := strings.ToLower(strings.ReplaceAll(uid.New("test"), "_", "-"))
+	project := h.CreateProject(seed.CreateProjectRequest{
+		ID:          uid.New(uid.ProjectPrefix),
+		WorkspaceID: workspace.ID,
+		Name:        "Payments Service",
+		Slug:        projectSlug,
+	})
+
+	total := 5
+	for i := 0; i < total; i++ {
+		h.CreateApp(seed.CreateAppRequest{
+			ID:            uid.New(uid.AppPrefix),
+			WorkspaceID:   workspace.ID,
+			ProjectID:     project.ID,
+			Name:          fmt.Sprintf("App %d", i),
+			Slug:          strings.ToLower(strings.ReplaceAll(uid.New("test"), "_", "-")),
+			DefaultBranch: "main",
+		})
+	}
+
+	seen := map[string]struct{}{}
+	cursor := (*string)(nil)
+	pages := 0
+	for {
+		req := handler.Request{ProjectSlug: projectSlug, Limit: ptr.P(2)}
+		if cursor != nil {
+			req.Cursor = cursor
+		}
+		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, req)
+		require.Equal(t, 200, res.Status, "expected 200, received: %s", res.RawBody)
+		require.LessOrEqual(t, len(res.Body.Data), 2)
+
+		for _, a := range res.Body.Data {
+			_, dup := seen[a.Id]
+			require.False(t, dup, "app %s returned on more than one page", a.Id)
+			seen[a.Id] = struct{}{}
+		}
+
+		pages++
+		require.LessOrEqual(t, pages, total+1, "pagination did not terminate")
+
+		if !res.Body.Pagination.HasMore {
+			require.Nil(t, res.Body.Pagination.Cursor)
+			break
+		}
+		require.NotNil(t, res.Body.Pagination.Cursor)
+		cursor = res.Body.Pagination.Cursor
+	}
+
+	require.Len(t, seen, total)
+}

--- a/svc/api/routes/v2_apps_list_apps/200_test.go
+++ b/svc/api/routes/v2_apps_list_apps/200_test.go
@@ -36,7 +36,7 @@ func TestListAppsSuccessfully(t *testing.T) {
 	})
 
 	t.Run("project with no apps returns empty list", func(t *testing.T) {
-		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{ProjectSlug: projectSlug})
+		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{ProjectId: project.ID})
 		require.Equal(t, 200, res.Status, "expected 200, received: %s", res.RawBody)
 		require.NotNil(t, res.Body)
 		require.Empty(t, res.Body.Data)
@@ -60,7 +60,7 @@ func TestListAppsSuccessfully(t *testing.T) {
 	}
 
 	t.Run("lists seeded apps with populated fields", func(t *testing.T) {
-		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{ProjectSlug: projectSlug})
+		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{ProjectId: project.ID})
 		require.Equal(t, 200, res.Status, "expected 200, received: %s", res.RawBody)
 		require.NotEmpty(t, res.Body.Meta.RequestId)
 		require.Len(t, res.Body.Data, len(seeded))
@@ -99,7 +99,7 @@ func TestListAppsSuccessfully(t *testing.T) {
 			DefaultBranch: "main",
 		})
 
-		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{ProjectSlug: projectSlug})
+		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{ProjectId: project.ID})
 		require.Equal(t, 200, res.Status, "expected 200, received: %s", res.RawBody)
 		require.Len(t, res.Body.Data, len(seeded))
 		for _, a := range res.Body.Data {
@@ -109,8 +109,8 @@ func TestListAppsSuccessfully(t *testing.T) {
 
 	t.Run("non-existent cursor returns 200 without error", func(t *testing.T) {
 		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{
-			ProjectSlug: projectSlug,
-			Cursor:      ptr.P("app_doesnotexist"),
+			ProjectId: project.ID,
+			Cursor:    ptr.P("app_doesnotexist"),
 		})
 		require.Equal(t, 200, res.Status, "expected 200, received: %s", res.RawBody)
 		require.NotNil(t, res.Body.Pagination)
@@ -139,8 +139,8 @@ func TestListAppsSuccessfully(t *testing.T) {
 		})
 
 		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{
-			ProjectSlug: projectSlug,
-			Cursor:      ptr.P(foreignApp.ID),
+			ProjectId: project.ID,
+			Cursor:    ptr.P(foreignApp.ID),
 		})
 		require.Equal(t, 200, res.Status, "expected 200, received: %s", res.RawBody)
 		for _, a := range res.Body.Data {
@@ -188,7 +188,7 @@ func TestListAppsPagination(t *testing.T) {
 	cursor := (*string)(nil)
 	pages := 0
 	for {
-		req := handler.Request{ProjectSlug: projectSlug, Limit: ptr.P(2)}
+		req := handler.Request{ProjectId: project.ID, Limit: ptr.P(2)}
 		if cursor != nil {
 			req.Cursor = cursor
 		}

--- a/svc/api/routes/v2_apps_list_apps/200_test.go
+++ b/svc/api/routes/v2_apps_list_apps/200_test.go
@@ -21,7 +21,7 @@ func TestListAppsSuccessfully(t *testing.T) {
 	h.Register(route)
 
 	workspace := h.Resources().UserWorkspace
-	rootKey := h.CreateRootKey(workspace.ID, "project.*.read_app")
+	rootKey := h.CreateRootKey(workspace.ID, "app.*.read_app")
 	headers := http.Header{
 		"Content-Type":  {"application/json"},
 		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
@@ -168,7 +168,7 @@ func TestListAppsPagination(t *testing.T) {
 	h.Register(route)
 
 	workspace := h.Resources().UserWorkspace
-	rootKey := h.CreateRootKey(workspace.ID, "project.*.read_app")
+	rootKey := h.CreateRootKey(workspace.ID, "app.*.read_app")
 	headers := http.Header{
 		"Content-Type":  {"application/json"},
 		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},

--- a/svc/api/routes/v2_apps_list_apps/200_test.go
+++ b/svc/api/routes/v2_apps_list_apps/200_test.go
@@ -59,6 +59,16 @@ func TestListAppsSuccessfully(t *testing.T) {
 		seeded[app.ID] = slug
 	}
 
+	t.Run("lists seeded apps by project id", func(t *testing.T) {
+		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{Project: project.ID})
+		require.Equal(t, 200, res.Status, "expected 200, received: %s", res.RawBody)
+		require.Len(t, res.Body.Data, len(seeded))
+		for _, a := range res.Body.Data {
+			_, ok := seeded[a.Id]
+			require.True(t, ok, "unexpected app %s in response", a.Id)
+		}
+	})
+
 	t.Run("lists seeded apps with populated fields", func(t *testing.T) {
 		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{Project: project.Slug})
 		require.Equal(t, 200, res.Status, "expected 200, received: %s", res.RawBody)

--- a/svc/api/routes/v2_apps_list_apps/200_test.go
+++ b/svc/api/routes/v2_apps_list_apps/200_test.go
@@ -36,7 +36,7 @@ func TestListAppsSuccessfully(t *testing.T) {
 	})
 
 	t.Run("project with no apps returns empty list", func(t *testing.T) {
-		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{ProjectId: project.ID})
+		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{Project: project.Slug})
 		require.Equal(t, 200, res.Status, "expected 200, received: %s", res.RawBody)
 		require.NotNil(t, res.Body)
 		require.Empty(t, res.Body.Data)
@@ -60,7 +60,7 @@ func TestListAppsSuccessfully(t *testing.T) {
 	}
 
 	t.Run("lists seeded apps with populated fields", func(t *testing.T) {
-		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{ProjectId: project.ID})
+		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{Project: project.Slug})
 		require.Equal(t, 200, res.Status, "expected 200, received: %s", res.RawBody)
 		require.NotEmpty(t, res.Body.Meta.RequestId)
 		require.Len(t, res.Body.Data, len(seeded))
@@ -99,7 +99,7 @@ func TestListAppsSuccessfully(t *testing.T) {
 			DefaultBranch: "main",
 		})
 
-		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{ProjectId: project.ID})
+		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{Project: project.Slug})
 		require.Equal(t, 200, res.Status, "expected 200, received: %s", res.RawBody)
 		require.Len(t, res.Body.Data, len(seeded))
 		for _, a := range res.Body.Data {
@@ -109,8 +109,8 @@ func TestListAppsSuccessfully(t *testing.T) {
 
 	t.Run("non-existent cursor returns 200 without error", func(t *testing.T) {
 		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{
-			ProjectId: project.ID,
-			Cursor:    ptr.P("app_doesnotexist"),
+			Project: project.Slug,
+			Cursor:  ptr.P("app_doesnotexist"),
 		})
 		require.Equal(t, 200, res.Status, "expected 200, received: %s", res.RawBody)
 		require.NotNil(t, res.Body.Pagination)
@@ -139,8 +139,8 @@ func TestListAppsSuccessfully(t *testing.T) {
 		})
 
 		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{
-			ProjectId: project.ID,
-			Cursor:    ptr.P(foreignApp.ID),
+			Project: project.Slug,
+			Cursor:  ptr.P(foreignApp.ID),
 		})
 		require.Equal(t, 200, res.Status, "expected 200, received: %s", res.RawBody)
 		for _, a := range res.Body.Data {
@@ -188,7 +188,7 @@ func TestListAppsPagination(t *testing.T) {
 	cursor := (*string)(nil)
 	pages := 0
 	for {
-		req := handler.Request{ProjectId: project.ID, Limit: ptr.P(2)}
+		req := handler.Request{Project: project.Slug, Limit: ptr.P(2)}
 		if cursor != nil {
 			req.Cursor = cursor
 		}

--- a/svc/api/routes/v2_apps_list_apps/400_test.go
+++ b/svc/api/routes/v2_apps_list_apps/400_test.go
@@ -26,18 +26,18 @@ func TestListAppsValidationErrors(t *testing.T) {
 		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
 	}
 
+	validProjectID := "proj_1234abcd"
+
 	testCases := []struct {
 		name string
 		req  handler.Request
 	}{
-		{name: "missing projectSlug", req: handler.Request{Limit: ptr.P(10)}},
-		{name: "projectSlug uppercase", req: handler.Request{ProjectSlug: "Payments"}},
-		{name: "projectSlug underscore", req: handler.Request{ProjectSlug: "payments_service"}},
-		{name: "projectSlug leading hyphen", req: handler.Request{ProjectSlug: "-payments"}},
-		{name: "projectSlug consecutive hyphens", req: handler.Request{ProjectSlug: "pay--ments"}},
-		{name: "projectSlug too long", req: handler.Request{ProjectSlug: strings.Repeat("a", 257)}},
-		{name: "limit below minimum", req: handler.Request{ProjectSlug: "payments", Limit: ptr.P(0)}},
-		{name: "limit above maximum", req: handler.Request{ProjectSlug: "payments", Limit: ptr.P(101)}},
+		{name: "missing projectId", req: handler.Request{Limit: ptr.P(10)}},
+		{name: "projectId too short", req: handler.Request{ProjectId: "proj_1"}},
+		{name: "projectId invalid chars", req: handler.Request{ProjectId: "proj-1234abc"}},
+		{name: "projectId too long", req: handler.Request{ProjectId: strings.Repeat("a", 256)}},
+		{name: "limit below minimum", req: handler.Request{ProjectId: validProjectID, Limit: ptr.P(0)}},
+		{name: "limit above maximum", req: handler.Request{ProjectId: validProjectID, Limit: ptr.P(101)}},
 	}
 
 	for _, tc := range testCases {

--- a/svc/api/routes/v2_apps_list_apps/400_test.go
+++ b/svc/api/routes/v2_apps_list_apps/400_test.go
@@ -33,7 +33,7 @@ func TestListAppsValidationErrors(t *testing.T) {
 		req  handler.Request
 	}{
 		{name: "missing project", req: handler.Request{Limit: ptr.P(10)}},
-		{name: "project invalid chars", req: handler.Request{Project: "Payments_Service"}},
+		{name: "project invalid chars", req: handler.Request{Project: "payments.service"}},
 		{name: "project too long", req: handler.Request{Project: strings.Repeat("a", 257)}},
 		{name: "limit below minimum", req: handler.Request{Project: validProject, Limit: ptr.P(0)}},
 		{name: "limit above maximum", req: handler.Request{Project: validProject, Limit: ptr.P(101)}},

--- a/svc/api/routes/v2_apps_list_apps/400_test.go
+++ b/svc/api/routes/v2_apps_list_apps/400_test.go
@@ -26,18 +26,17 @@ func TestListAppsValidationErrors(t *testing.T) {
 		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
 	}
 
-	validProjectID := "proj_1234abcd"
+	validProject := "payments-service"
 
 	testCases := []struct {
 		name string
 		req  handler.Request
 	}{
-		{name: "missing projectId", req: handler.Request{Limit: ptr.P(10)}},
-		{name: "projectId too short", req: handler.Request{ProjectId: "proj_1"}},
-		{name: "projectId invalid chars", req: handler.Request{ProjectId: "proj-1234abc"}},
-		{name: "projectId too long", req: handler.Request{ProjectId: strings.Repeat("a", 256)}},
-		{name: "limit below minimum", req: handler.Request{ProjectId: validProjectID, Limit: ptr.P(0)}},
-		{name: "limit above maximum", req: handler.Request{ProjectId: validProjectID, Limit: ptr.P(101)}},
+		{name: "missing project", req: handler.Request{Limit: ptr.P(10)}},
+		{name: "project invalid chars", req: handler.Request{Project: "Payments_Service"}},
+		{name: "project too long", req: handler.Request{Project: strings.Repeat("a", 257)}},
+		{name: "limit below minimum", req: handler.Request{Project: validProject, Limit: ptr.P(0)}},
+		{name: "limit above maximum", req: handler.Request{Project: validProject, Limit: ptr.P(101)}},
 	}
 
 	for _, tc := range testCases {

--- a/svc/api/routes/v2_apps_list_apps/400_test.go
+++ b/svc/api/routes/v2_apps_list_apps/400_test.go
@@ -20,7 +20,7 @@ func TestListAppsValidationErrors(t *testing.T) {
 	h.Register(route)
 
 	workspace := h.Resources().UserWorkspace
-	rootKey := h.CreateRootKey(workspace.ID, "project.*.read_app")
+	rootKey := h.CreateRootKey(workspace.ID, "app.*.read_app")
 	headers := http.Header{
 		"Content-Type":  {"application/json"},
 		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},

--- a/svc/api/routes/v2_apps_list_apps/400_test.go
+++ b/svc/api/routes/v2_apps_list_apps/400_test.go
@@ -1,0 +1,50 @@
+package handler_test
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/ptr"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	"github.com/unkeyed/unkey/svc/api/openapi"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_apps_list_apps"
+)
+
+func TestListAppsValidationErrors(t *testing.T) {
+	h := testutil.NewHarness(t)
+
+	route := &handler.Handler{DB: h.DB}
+	h.Register(route)
+
+	workspace := h.Resources().UserWorkspace
+	rootKey := h.CreateRootKey(workspace.ID, "project.*.read_app")
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}
+
+	testCases := []struct {
+		name string
+		req  handler.Request
+	}{
+		{name: "missing projectSlug", req: handler.Request{Limit: ptr.P(10)}},
+		{name: "projectSlug uppercase", req: handler.Request{ProjectSlug: "Payments"}},
+		{name: "projectSlug underscore", req: handler.Request{ProjectSlug: "payments_service"}},
+		{name: "projectSlug leading hyphen", req: handler.Request{ProjectSlug: "-payments"}},
+		{name: "projectSlug consecutive hyphens", req: handler.Request{ProjectSlug: "pay--ments"}},
+		{name: "projectSlug too long", req: handler.Request{ProjectSlug: strings.Repeat("a", 257)}},
+		{name: "limit below minimum", req: handler.Request{ProjectSlug: "payments", Limit: ptr.P(0)}},
+		{name: "limit above maximum", req: handler.Request{ProjectSlug: "payments", Limit: ptr.P(101)}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := testutil.CallRoute[handler.Request, openapi.BadRequestErrorResponse](h, route, headers, tc.req)
+			require.Equal(t, http.StatusBadRequest, res.Status, "expected 400, sent: %+v, received: %s", tc.req, res.RawBody)
+			require.Equal(t, "https://unkey.com/docs/errors/unkey/application/invalid_input", res.Body.Error.Type)
+		})
+	}
+}

--- a/svc/api/routes/v2_apps_list_apps/401_test.go
+++ b/svc/api/routes/v2_apps_list_apps/401_test.go
@@ -1,0 +1,26 @@
+package handler_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_apps_list_apps"
+)
+
+func TestListAppsUnauthorized(t *testing.T) {
+	h := testutil.NewHarness(t)
+
+	route := &handler.Handler{DB: h.DB}
+	h.Register(route)
+
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {"Bearer invalid_token"},
+	}
+	res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{
+		ProjectSlug: "payments",
+	})
+	require.Equal(t, http.StatusUnauthorized, res.Status, "expected 401, received: %s", res.RawBody)
+}

--- a/svc/api/routes/v2_apps_list_apps/401_test.go
+++ b/svc/api/routes/v2_apps_list_apps/401_test.go
@@ -20,7 +20,7 @@ func TestListAppsUnauthorized(t *testing.T) {
 		"Authorization": {"Bearer invalid_token"},
 	}
 	res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{
-		ProjectId: "proj_1234abcd",
+		Project: "payments-service",
 	})
 	require.Equal(t, http.StatusUnauthorized, res.Status, "expected 401, received: %s", res.RawBody)
 }

--- a/svc/api/routes/v2_apps_list_apps/401_test.go
+++ b/svc/api/routes/v2_apps_list_apps/401_test.go
@@ -20,7 +20,7 @@ func TestListAppsUnauthorized(t *testing.T) {
 		"Authorization": {"Bearer invalid_token"},
 	}
 	res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{
-		ProjectSlug: "payments",
+		ProjectId: "proj_1234abcd",
 	})
 	require.Equal(t, http.StatusUnauthorized, res.Status, "expected 401, received: %s", res.RawBody)
 }

--- a/svc/api/routes/v2_apps_list_apps/403_test.go
+++ b/svc/api/routes/v2_apps_list_apps/403_test.go
@@ -63,7 +63,7 @@ func TestListAppsForbidden(t *testing.T) {
 				"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
 			}
 			res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{
-				ProjectId: project.ID,
+				Project: project.Slug,
 			})
 			if tc.shouldPass {
 				require.Equal(t, 200, res.Status, "expected 200 for %v, got: %s", tc.permissions, res.RawBody)
@@ -108,7 +108,7 @@ func TestListAppsExistenceNotLeaked(t *testing.T) {
 		DefaultBranch: "main",
 	})
 
-	missingID := uid.New(uid.ProjectPrefix)
+	missingSlug := strings.ToLower(strings.ReplaceAll(uid.New("test"), "_", "-"))
 
 	// Key in the same workspace with an unrelated grant but no read_app action.
 	rootKey := h.CreateRootKey(workspace.ID, "api.*.read_api")
@@ -117,8 +117,8 @@ func TestListAppsExistenceNotLeaked(t *testing.T) {
 		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
 	}
 
-	realRes := testutil.CallRoute[handler.Request, openapi.NotFoundErrorResponse](h, route, headers, handler.Request{ProjectId: project.ID})
-	missingRes := testutil.CallRoute[handler.Request, openapi.NotFoundErrorResponse](h, route, headers, handler.Request{ProjectId: missingID})
+	realRes := testutil.CallRoute[handler.Request, openapi.NotFoundErrorResponse](h, route, headers, handler.Request{Project: project.Slug})
+	missingRes := testutil.CallRoute[handler.Request, openapi.NotFoundErrorResponse](h, route, headers, handler.Request{Project: missingSlug})
 
 	require.Equal(t, http.StatusNotFound, realRes.Status, "real project should look not-found, got: %s", realRes.RawBody)
 	require.Equal(t, http.StatusNotFound, missingRes.Status, "missing project should be not-found, got: %s", missingRes.RawBody)

--- a/svc/api/routes/v2_apps_list_apps/403_test.go
+++ b/svc/api/routes/v2_apps_list_apps/403_test.go
@@ -45,13 +45,14 @@ func TestListAppsForbidden(t *testing.T) {
 		permissions []string
 		shouldPass  bool
 	}{
-		{name: "wildcard app permission", permissions: []string{"project.*.read_app"}, shouldPass: true},
-		{name: "specific project permission", permissions: []string{fmt.Sprintf("project.%s.read_app", project.ID)}, shouldPass: true},
-		{name: "permission and more", permissions: []string{"some.other.permission", "project.*.read_app"}, shouldPass: true},
-		{name: "wrong action", permissions: []string{"project.*.create_project"}, shouldPass: false},
+		{name: "wildcard app permission", permissions: []string{"app.*.read_app"}, shouldPass: true},
+		{name: "permission and more", permissions: []string{"some.other.permission", "app.*.read_app"}, shouldPass: true},
+		{name: "specific app does not satisfy list", permissions: []string{fmt.Sprintf("app.%s.read_app", app.ID)}, shouldPass: false},
+		{name: "project scoped read does not match", permissions: []string{fmt.Sprintf("project.%s.read_app", project.ID)}, shouldPass: false},
+		{name: "wrong action", permissions: []string{"app.*.create_app"}, shouldPass: false},
 		{name: "read does not match create", permissions: []string{"project.*.create_app"}, shouldPass: false},
 		{name: "unrelated permission", permissions: []string{"api.*.read_api"}, shouldPass: false},
-		{name: "urn style does not satisfy legacy check", permissions: []string{"unkey:v1:" + workspace.ID + ":projects/*/apps/*#read_app"}, shouldPass: false},
+		{name: "urn style does not satisfy legacy check", permissions: []string{"unkey:v1:" + workspace.ID + ":apps/*#read_app"}, shouldPass: false},
 		{name: "no permissions", permissions: []string{}, shouldPass: false},
 	}
 

--- a/svc/api/routes/v2_apps_list_apps/403_test.go
+++ b/svc/api/routes/v2_apps_list_apps/403_test.go
@@ -63,7 +63,7 @@ func TestListAppsForbidden(t *testing.T) {
 				"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
 			}
 			res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{
-				ProjectSlug: projectSlug,
+				ProjectId: project.ID,
 			})
 			if tc.shouldPass {
 				require.Equal(t, 200, res.Status, "expected 200 for %v, got: %s", tc.permissions, res.RawBody)
@@ -108,7 +108,7 @@ func TestListAppsExistenceNotLeaked(t *testing.T) {
 		DefaultBranch: "main",
 	})
 
-	missingSlug := strings.ToLower(strings.ReplaceAll(uid.New("test"), "_", "-"))
+	missingID := uid.New(uid.ProjectPrefix)
 
 	// Key in the same workspace with an unrelated grant but no read_app action.
 	rootKey := h.CreateRootKey(workspace.ID, "api.*.read_api")
@@ -117,8 +117,8 @@ func TestListAppsExistenceNotLeaked(t *testing.T) {
 		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
 	}
 
-	realRes := testutil.CallRoute[handler.Request, openapi.NotFoundErrorResponse](h, route, headers, handler.Request{ProjectSlug: realSlug})
-	missingRes := testutil.CallRoute[handler.Request, openapi.NotFoundErrorResponse](h, route, headers, handler.Request{ProjectSlug: missingSlug})
+	realRes := testutil.CallRoute[handler.Request, openapi.NotFoundErrorResponse](h, route, headers, handler.Request{ProjectId: project.ID})
+	missingRes := testutil.CallRoute[handler.Request, openapi.NotFoundErrorResponse](h, route, headers, handler.Request{ProjectId: missingID})
 
 	require.Equal(t, http.StatusNotFound, realRes.Status, "real project should look not-found, got: %s", realRes.RawBody)
 	require.Equal(t, http.StatusNotFound, missingRes.Status, "missing project should be not-found, got: %s", missingRes.RawBody)

--- a/svc/api/routes/v2_apps_list_apps/403_test.go
+++ b/svc/api/routes/v2_apps_list_apps/403_test.go
@@ -1,0 +1,133 @@
+package handler_test
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
+	"github.com/unkeyed/unkey/svc/api/openapi"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_apps_list_apps"
+)
+
+func TestListAppsForbidden(t *testing.T) {
+	h := testutil.NewHarness(t)
+
+	route := &handler.Handler{DB: h.DB}
+	h.Register(route)
+
+	workspace := h.Resources().UserWorkspace
+
+	// Seed a real project with an app so the lookup succeeds and authorization
+	// is the only gate.
+	projectSlug := strings.ToLower(strings.ReplaceAll(uid.New("test"), "_", "-"))
+	project := h.CreateProject(seed.CreateProjectRequest{
+		ID:          uid.New(uid.ProjectPrefix),
+		WorkspaceID: workspace.ID,
+		Name:        "Payments Service",
+		Slug:        projectSlug,
+	})
+	app := h.CreateApp(seed.CreateAppRequest{
+		ID:            uid.New(uid.AppPrefix),
+		WorkspaceID:   workspace.ID,
+		ProjectID:     project.ID,
+		Name:          "Payments API",
+		Slug:          strings.ToLower(strings.ReplaceAll(uid.New("test"), "_", "-")),
+		DefaultBranch: "main",
+	})
+
+	testCases := []struct {
+		name        string
+		permissions []string
+		shouldPass  bool
+	}{
+		{name: "wildcard app permission", permissions: []string{"project.*.read_app"}, shouldPass: true},
+		{name: "specific project permission", permissions: []string{fmt.Sprintf("project.%s.read_app", project.ID)}, shouldPass: true},
+		{name: "permission and more", permissions: []string{"some.other.permission", "project.*.read_app"}, shouldPass: true},
+		{name: "wrong action", permissions: []string{"project.*.create_project"}, shouldPass: false},
+		{name: "read does not match create", permissions: []string{"project.*.create_app"}, shouldPass: false},
+		{name: "unrelated permission", permissions: []string{"api.*.read_api"}, shouldPass: false},
+		{name: "urn style does not satisfy legacy check", permissions: []string{"unkey:v1:" + workspace.ID + ":projects/*/apps/*#read_app"}, shouldPass: false},
+		{name: "no permissions", permissions: []string{}, shouldPass: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rootKey := h.CreateRootKey(workspace.ID, tc.permissions...)
+			headers := http.Header{
+				"Content-Type":  {"application/json"},
+				"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+			}
+			res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{
+				ProjectSlug: projectSlug,
+			})
+			if tc.shouldPass {
+				require.Equal(t, 200, res.Status, "expected 200 for %v, got: %s", tc.permissions, res.RawBody)
+				return
+			}
+
+			// An unauthorized same-workspace key must not be able to tell a real
+			// project apart from a missing one. The response mirrors the 404 a
+			// nonexistent slug returns and must never echo the project or app IDs.
+			require.Equal(t, http.StatusNotFound, res.Status, "expected 404 for %v, got: %s", tc.permissions, res.RawBody)
+			require.NotContains(t, res.RawBody, project.ID, "response must not leak the project ID for %v", tc.permissions)
+			require.NotContains(t, res.RawBody, app.ID, "response must not leak any app ID for %v", tc.permissions)
+		})
+	}
+}
+
+// TestListAppsExistenceNotLeaked asserts the existence oracle is closed: an
+// unauthorized key listing a real project and a nonexistent project receives
+// byte-identical responses (modulo the per-request ID), so it cannot enumerate
+// the workspace's project inventory.
+func TestListAppsExistenceNotLeaked(t *testing.T) {
+	h := testutil.NewHarness(t)
+
+	route := &handler.Handler{DB: h.DB}
+	h.Register(route)
+
+	workspace := h.Resources().UserWorkspace
+
+	realSlug := strings.ToLower(strings.ReplaceAll(uid.New("test"), "_", "-"))
+	project := h.CreateProject(seed.CreateProjectRequest{
+		ID:          uid.New(uid.ProjectPrefix),
+		WorkspaceID: workspace.ID,
+		Name:        "Payments Service",
+		Slug:        realSlug,
+	})
+	app := h.CreateApp(seed.CreateAppRequest{
+		ID:            uid.New(uid.AppPrefix),
+		WorkspaceID:   workspace.ID,
+		ProjectID:     project.ID,
+		Name:          "Payments API",
+		Slug:          strings.ToLower(strings.ReplaceAll(uid.New("test"), "_", "-")),
+		DefaultBranch: "main",
+	})
+
+	missingSlug := strings.ToLower(strings.ReplaceAll(uid.New("test"), "_", "-"))
+
+	// Key in the same workspace with an unrelated grant but no read_app action.
+	rootKey := h.CreateRootKey(workspace.ID, "api.*.read_api")
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}
+
+	realRes := testutil.CallRoute[handler.Request, openapi.NotFoundErrorResponse](h, route, headers, handler.Request{ProjectSlug: realSlug})
+	missingRes := testutil.CallRoute[handler.Request, openapi.NotFoundErrorResponse](h, route, headers, handler.Request{ProjectSlug: missingSlug})
+
+	require.Equal(t, http.StatusNotFound, realRes.Status, "real project should look not-found, got: %s", realRes.RawBody)
+	require.Equal(t, http.StatusNotFound, missingRes.Status, "missing project should be not-found, got: %s", missingRes.RawBody)
+
+	require.NotContains(t, realRes.RawBody, project.ID, "response must not leak the project ID")
+	require.NotContains(t, realRes.RawBody, app.ID, "response must not leak any app ID")
+
+	// The only field allowed to differ is the per-request ID in meta.
+	require.Equal(t, missingRes.Body.Error.Detail, realRes.Body.Error.Detail, "error detail must be identical for real and missing projects")
+	require.Equal(t, missingRes.Body.Error.Type, realRes.Body.Error.Type, "error type must be identical for real and missing projects")
+	require.Equal(t, missingRes.Body.Error.Status, realRes.Body.Error.Status, "error status must be identical for real and missing projects")
+}

--- a/svc/api/routes/v2_apps_list_apps/404_test.go
+++ b/svc/api/routes/v2_apps_list_apps/404_test.go
@@ -1,0 +1,56 @@
+package handler_test
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_apps_list_apps"
+)
+
+func TestListAppsNotFound(t *testing.T) {
+	h := testutil.NewHarness(t)
+
+	route := &handler.Handler{DB: h.DB}
+	h.Register(route)
+
+	workspace := h.Resources().UserWorkspace
+	rootKey := h.CreateRootKey(workspace.ID, "project.*.read_app")
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}
+
+	t.Run("unknown project slug returns 404", func(t *testing.T) {
+		slug := strings.ToLower(strings.ReplaceAll(uid.New("test"), "_", "-"))
+		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{ProjectSlug: slug})
+		require.Equal(t, http.StatusNotFound, res.Status, "expected 404, received: %s", res.RawBody)
+	})
+
+	t.Run("project in another workspace returns 404", func(t *testing.T) {
+		otherWorkspace := h.CreateWorkspace()
+		otherProjectSlug := strings.ToLower(strings.ReplaceAll(uid.New("test"), "_", "-"))
+		otherProject := h.CreateProject(seed.CreateProjectRequest{
+			ID:          uid.New(uid.ProjectPrefix),
+			WorkspaceID: otherWorkspace.ID,
+			Name:        "Theirs",
+			Slug:        otherProjectSlug,
+		})
+		h.CreateApp(seed.CreateAppRequest{
+			ID:            uid.New(uid.AppPrefix),
+			WorkspaceID:   otherWorkspace.ID,
+			ProjectID:     otherProject.ID,
+			Name:          "Theirs",
+			Slug:          strings.ToLower(strings.ReplaceAll(uid.New("test"), "_", "-")),
+			DefaultBranch: "main",
+		})
+
+		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{ProjectSlug: otherProjectSlug})
+		require.Equal(t, http.StatusNotFound, res.Status, "expected 404 for cross-workspace project, received: %s", res.RawBody)
+	})
+}

--- a/svc/api/routes/v2_apps_list_apps/404_test.go
+++ b/svc/api/routes/v2_apps_list_apps/404_test.go
@@ -20,7 +20,7 @@ func TestListAppsNotFound(t *testing.T) {
 	h.Register(route)
 
 	workspace := h.Resources().UserWorkspace
-	rootKey := h.CreateRootKey(workspace.ID, "project.*.read_app")
+	rootKey := h.CreateRootKey(workspace.ID, "app.*.read_app")
 	headers := http.Header{
 		"Content-Type":  {"application/json"},
 		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},

--- a/svc/api/routes/v2_apps_list_apps/404_test.go
+++ b/svc/api/routes/v2_apps_list_apps/404_test.go
@@ -26,9 +26,8 @@ func TestListAppsNotFound(t *testing.T) {
 		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
 	}
 
-	t.Run("unknown project slug returns 404", func(t *testing.T) {
-		slug := strings.ToLower(strings.ReplaceAll(uid.New("test"), "_", "-"))
-		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{ProjectSlug: slug})
+	t.Run("unknown project id returns 404", func(t *testing.T) {
+		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{ProjectId: uid.New(uid.ProjectPrefix)})
 		require.Equal(t, http.StatusNotFound, res.Status, "expected 404, received: %s", res.RawBody)
 	})
 
@@ -50,7 +49,7 @@ func TestListAppsNotFound(t *testing.T) {
 			DefaultBranch: "main",
 		})
 
-		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{ProjectSlug: otherProjectSlug})
+		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{ProjectId: otherProject.ID})
 		require.Equal(t, http.StatusNotFound, res.Status, "expected 404 for cross-workspace project, received: %s", res.RawBody)
 	})
 }

--- a/svc/api/routes/v2_apps_list_apps/404_test.go
+++ b/svc/api/routes/v2_apps_list_apps/404_test.go
@@ -26,8 +26,8 @@ func TestListAppsNotFound(t *testing.T) {
 		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
 	}
 
-	t.Run("unknown project id returns 404", func(t *testing.T) {
-		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{ProjectId: uid.New(uid.ProjectPrefix)})
+	t.Run("unknown project slug returns 404", func(t *testing.T) {
+		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{Project: strings.ToLower(strings.ReplaceAll(uid.New("test"), "_", "-"))})
 		require.Equal(t, http.StatusNotFound, res.Status, "expected 404, received: %s", res.RawBody)
 	})
 
@@ -49,7 +49,7 @@ func TestListAppsNotFound(t *testing.T) {
 			DefaultBranch: "main",
 		})
 
-		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{ProjectId: otherProject.ID})
+		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{Project: otherProject.Slug})
 		require.Equal(t, http.StatusNotFound, res.Status, "expected 404 for cross-workspace project, received: %s", res.RawBody)
 	})
 }

--- a/svc/api/routes/v2_apps_list_apps/BUILD.bazel
+++ b/svc/api/routes/v2_apps_list_apps/BUILD.bazel
@@ -1,0 +1,37 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "v2_apps_list_apps",
+    srcs = ["handler.go"],
+    importpath = "github.com/unkeyed/unkey/svc/api/routes/v2_apps_list_apps",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/codes",
+        "//pkg/db",
+        "//pkg/fault",
+        "//pkg/ptr",
+        "//pkg/rbac",
+        "//pkg/zen",
+        "//svc/api/openapi",
+    ],
+)
+
+go_test(
+    name = "v2_apps_list_apps_test",
+    srcs = [
+        "200_test.go",
+        "400_test.go",
+        "401_test.go",
+        "403_test.go",
+        "404_test.go",
+    ],
+    deps = [
+        ":v2_apps_list_apps",
+        "//pkg/ptr",
+        "//pkg/uid",
+        "//svc/api/internal/testutil",
+        "//svc/api/internal/testutil/seed",
+        "//svc/api/openapi",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/svc/api/routes/v2_apps_list_apps/handler.go
+++ b/svc/api/routes/v2_apps_list_apps/handler.go
@@ -100,23 +100,23 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	hasMore := len(rows) > limit
 	var nextCursor *string
 	if hasMore {
-		nextCursor = ptr.P(rows[limit].App.ID)
+		nextCursor = ptr.P(rows[limit].ID)
 		rows = rows[:limit]
 	}
 
 	data := make([]openapi.App, len(rows))
 	for i, row := range rows {
 		data[i] = openapi.App{
-			Id:                  row.App.ID,
-			Name:                row.App.Name,
-			Slug:                row.App.Slug,
-			ProjectId:           row.App.ProjectID,
-			DefaultBranch:       row.App.DefaultBranch,
-			CurrentDeploymentId: row.App.CurrentDeploymentID.String,
-			IsRolledBack:        row.App.IsRolledBack,
-			DeleteProtection:    row.App.DeleteProtection.Bool,
-			CreatedAt:           row.App.CreatedAt,
-			UpdatedAt:           row.App.UpdatedAt.Int64,
+			Id:                  row.ID,
+			Name:                row.Name,
+			Slug:                row.Slug,
+			ProjectId:           row.ProjectID,
+			DefaultBranch:       row.DefaultBranch,
+			CurrentDeploymentId: row.CurrentDeploymentID.String,
+			IsRolledBack:        row.IsRolledBack,
+			DeleteProtection:    row.DeleteProtection.Bool,
+			CreatedAt:           row.CreatedAt,
+			UpdatedAt:           row.UpdatedAt.Int64,
 		}
 	}
 

--- a/svc/api/routes/v2_apps_list_apps/handler.go
+++ b/svc/api/routes/v2_apps_list_apps/handler.go
@@ -1,0 +1,142 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/unkeyed/unkey/pkg/codes"
+	"github.com/unkeyed/unkey/pkg/db"
+	"github.com/unkeyed/unkey/pkg/fault"
+	"github.com/unkeyed/unkey/pkg/ptr"
+	"github.com/unkeyed/unkey/pkg/rbac"
+	"github.com/unkeyed/unkey/pkg/zen"
+	"github.com/unkeyed/unkey/svc/api/openapi"
+)
+
+type (
+	Request  = openapi.V2AppsListAppsRequestBody
+	Response = openapi.V2AppsListAppsResponseBody
+)
+
+// Handler implements zen.Route interface for the v2 apps list apps endpoint
+type Handler struct {
+	DB db.Database
+}
+
+// Method returns the HTTP method this route responds to
+func (h *Handler) Method() string {
+	return "POST"
+}
+
+// Path returns the URL path pattern this route matches
+func (h *Handler) Path() string {
+	return "/v2/apps.listApps"
+}
+
+// Handle processes the HTTP request
+func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
+	principal, err := s.GetPrincipal()
+	if err != nil {
+		return err
+	}
+
+	req, err := zen.BindBody[Request](s)
+	if err != nil {
+		return err
+	}
+
+	project, err := db.Query.FindProjectByWorkspaceAndSlug(ctx, h.DB.RO(), db.FindProjectByWorkspaceAndSlugParams{
+		WorkspaceID: principal.WorkspaceID,
+		Slug:        req.ProjectSlug,
+	})
+	if err != nil {
+		if db.IsNotFound(err) {
+			return fault.New(
+				"project not found",
+				fault.Code(codes.Data.Project.NotFound.URN()),
+				fault.Internal("project not found"),
+				fault.Public("The requested project does not exist."),
+			)
+		}
+		return fault.Wrap(
+			err,
+			fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
+			fault.Internal("database error"),
+			fault.Public("Failed to retrieve project."),
+		)
+	}
+
+	err = principal.Authorize(rbac.Or(
+		rbac.T(rbac.Tuple{
+			ResourceType: rbac.Project,
+			ResourceID:   "*",
+			Action:       rbac.ReadApp,
+		}),
+		rbac.T(rbac.Tuple{
+			ResourceType: rbac.Project,
+			ResourceID:   project.ID,
+			Action:       rbac.ReadApp,
+		}),
+	))
+	if err != nil {
+		// Mirror the missing-project 404 so an unauthorized key can't probe which
+		// project slugs exist or read the project ID from the authorization error.
+		return fault.New(
+			"project not found",
+			fault.Code(codes.Data.Project.NotFound.URN()),
+			fault.Internal("authorization failed; returning not found to avoid leaking project existence"),
+			fault.Public("The requested project does not exist."),
+		)
+	}
+
+	limit := ptr.SafeDeref(req.Limit, 100)
+	cursor := ptr.SafeDeref(req.Cursor, "")
+
+	rows, err := db.Query.ListAppsByProject(ctx, h.DB.RO(), db.ListAppsByProjectParams{
+		ProjectID: project.ID,
+		IDCursor:  cursor,
+		Limit:     int32(limit + 1), // nolint:gosec
+	})
+	if err != nil {
+		return fault.Wrap(
+			err,
+			fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
+			fault.Internal("database error"),
+			fault.Public("Failed to retrieve apps."),
+		)
+	}
+
+	hasMore := len(rows) > limit
+	var nextCursor *string
+	if hasMore {
+		nextCursor = ptr.P(rows[limit].App.ID)
+		rows = rows[:limit]
+	}
+
+	data := make([]openapi.App, len(rows))
+	for i, row := range rows {
+		data[i] = openapi.App{
+			Id:                  row.App.ID,
+			Name:                row.App.Name,
+			Slug:                row.App.Slug,
+			ProjectId:           row.App.ProjectID,
+			DefaultBranch:       row.App.DefaultBranch,
+			CurrentDeploymentId: row.App.CurrentDeploymentID.String,
+			IsRolledBack:        row.App.IsRolledBack,
+			DeleteProtection:    row.App.DeleteProtection.Bool,
+			CreatedAt:           row.App.CreatedAt,
+			UpdatedAt:           row.App.UpdatedAt.Int64,
+		}
+	}
+
+	return s.JSON(http.StatusOK, Response{
+		Meta: openapi.Meta{
+			RequestId: s.RequestID(),
+		},
+		Data: data,
+		Pagination: &openapi.Pagination{
+			Cursor:  nextCursor,
+			HasMore: hasMore,
+		},
+	})
+}

--- a/svc/api/routes/v2_apps_list_apps/handler.go
+++ b/svc/api/routes/v2_apps_list_apps/handler.go
@@ -45,9 +45,9 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	project, err := db.Query.FindProjectByWorkspaceAndSlug(ctx, h.DB.RO(), db.FindProjectByWorkspaceAndSlugParams{
+	project, err := db.Query.FindProjectByIdOrSlug(ctx, h.DB.RO(), db.FindProjectByIdOrSlugParams{
 		WorkspaceID: principal.WorkspaceID,
-		Slug:        req.Project,
+		Project:     req.Project,
 	})
 	if err != nil {
 		if db.IsNotFound(err) {

--- a/svc/api/routes/v2_apps_list_apps/handler.go
+++ b/svc/api/routes/v2_apps_list_apps/handler.go
@@ -66,18 +66,11 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		)
 	}
 
-	err = principal.Authorize(rbac.Or(
-		rbac.T(rbac.Tuple{
-			ResourceType: rbac.Project,
-			ResourceID:   "*",
-			Action:       rbac.ReadApp,
-		}),
-		rbac.T(rbac.Tuple{
-			ResourceType: rbac.Project,
-			ResourceID:   project.ID,
-			Action:       rbac.ReadApp,
-		}),
-	))
+	err = principal.Authorize(rbac.T(rbac.Tuple{
+		ResourceType: rbac.App,
+		ResourceID:   "*",
+		Action:       rbac.ReadApp,
+	}))
 	if err != nil {
 		return fault.New(
 			"project not found",

--- a/svc/api/routes/v2_apps_list_apps/handler.go
+++ b/svc/api/routes/v2_apps_list_apps/handler.go
@@ -79,8 +79,6 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		}),
 	))
 	if err != nil {
-		// Mirror the missing-project 404 so an unauthorized key can't probe which
-		// project slugs exist or read the project ID from the authorization error.
 		return fault.New(
 			"project not found",
 			fault.Code(codes.Data.Project.NotFound.URN()),

--- a/svc/api/routes/v2_apps_list_apps/handler.go
+++ b/svc/api/routes/v2_apps_list_apps/handler.go
@@ -45,9 +45,9 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	project, err := db.Query.FindProjectByWorkspaceAndId(ctx, h.DB.RO(), db.FindProjectByWorkspaceAndIdParams{
+	project, err := db.Query.FindProjectByWorkspaceAndSlug(ctx, h.DB.RO(), db.FindProjectByWorkspaceAndSlugParams{
 		WorkspaceID: principal.WorkspaceID,
-		ID:          req.ProjectId,
+		Slug:        req.Project,
 	})
 	if err != nil {
 		if db.IsNotFound(err) {

--- a/svc/api/routes/v2_apps_list_apps/handler.go
+++ b/svc/api/routes/v2_apps_list_apps/handler.go
@@ -45,9 +45,9 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	project, err := db.Query.FindProjectByWorkspaceAndSlug(ctx, h.DB.RO(), db.FindProjectByWorkspaceAndSlugParams{
+	project, err := db.Query.FindProjectByWorkspaceAndId(ctx, h.DB.RO(), db.FindProjectByWorkspaceAndIdParams{
 		WorkspaceID: principal.WorkspaceID,
-		Slug:        req.ProjectSlug,
+		ID:          req.ProjectId,
 	})
 	if err != nil {
 		if db.IsNotFound(err) {


### PR DESCRIPTION
> [!IMPORTANT]
> Unkey is not accepting external pull requests at this time. Pull requests from people outside the Unkey team will not be reviewed or merged.

## What does this PR do?

Adds the `POST /v2/apps.listApps` endpoint, which returns a cursor-paginated list of apps belonging to a given project.

The SQL query backing this endpoint was updated to support cursor-based pagination: it now filters by `id >= id_cursor`, orders by `id ASC`, and accepts a `LIMIT` parameter. Previously the query ordered by `created_at` with no pagination support.

The handler:
- Looks up the project by workspace and ID, returning 404 if not found
- Enforces `project.*.read_app` or `project.<project_id>.read_app` permissions, returning a 404 (rather than 403) on authorization failure to avoid leaking project existence to unauthorized callers
- Fetches `limit + 1` rows to determine whether more pages exist, then trims the result and sets the `cursor` and `hasMore` fields in the pagination response

OpenAPI schemas and the generated YAML were updated to include `V2AppsListAppsRequestBody` (with `projectId`, `limit`, and `cursor` fields) and `V2AppsListAppsResponseBody` (with `data`, `meta`, and `pagination` fields). Speakeasy cursor pagination metadata is included.

Tests cover:
- 200: empty project, populated project, cross-project isolation, non-existent cursor, cursor borrowed from a foreign workspace, and full pagination traversal
- 400: missing/invalid `projectId`, out-of-range `limit`
- 401: invalid bearer token
- 403/404: missing permissions, cross-workspace project access, and an existence oracle test asserting that unauthorized responses for real and nonexistent projects are indistinguishable

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Call `POST /v2/apps.listApps` with a valid root key and a `projectId` that belongs to your workspace; verify a 200 response with the correct apps and pagination fields
- Call with `limit: 2` against a project with more than 2 apps and follow the cursor across pages; verify all apps are returned exactly once and the final page has `hasMore: false` and no cursor
- Call with a root key that lacks `read_app` permission; verify a 404 is returned and no project or app IDs are present in the response body
- Call with an invalid `projectId` (too short, invalid characters, too long) or an out-of-range `limit`; verify a 400 validation error is returned
- Run the unit tests in `svc/api/routes/v2_apps_list_apps/`

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `mise run fmt`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary