### PR TITLE
Update Depot onboarding settings link

### DIFF
--- a/docs/engineering/contributing/local/development.mdx
+++ b/docs/engineering/contributing/local/development.mdx
@@ -20,8 +20,12 @@ All other tools are managed via [mise](https://mise.en.dev/), which you'll insta
 
 Unkey uses Depot as the build runner for local development.
 
-To get your Depot token, sign in to <a href="https://depot.dev" target="_blank">Depot</a>,
+To get your Depot token, sign in to <a href="https://depot.dev/orgs/25j3k7j1zw/settings" target="_blank">Depot</a>,
 then create a token. Name it something like `<your-name>-local`.
+
+The Depot org settings page is only accessible to Depot org owners. If you are
+not an owner, Depot might redirect you away from the settings page or block
+access. Ask Andreas for the appropriate token or access path.
 
 During bootstrap, paste that token when prompted or manually add it to
 `./dev/.env.depot`.


### PR DESCRIPTION
> [!IMPORTANT]
> Unkey is not accepting external pull requests at this time. Pull requests from people outside the Unkey team will not be reviewed or merged.

## What does this PR do?

Updates the engineering local development onboarding docs so the Depot token link points to the Unkey org settings page. It also clarifies that only Depot org owners can access that page and directs non-owner members to ask Andreas for the appropriate token or access path.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How should this be tested?

- Verified the old Depot settings URL is absent from engineering docs.
- Verified the local development onboarding page points to `https://depot.dev/orgs/25j3k7j1zw/settings`.
- Verified the page documents the Depot org owner limitation and Andreas escalation path.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `mise run fmt`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [x] Updated the Unkey Docs if changes were necessary