### PR TITLE
fix(dashboard): focus on error step on build logs

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/[deploymentId]/(deployment-progress)/build-steps-table/deployment-build-steps-table.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/[deploymentId]/(deployment-progress)/build-steps-table/deployment-build-steps-table.tsx
@@ -18,23 +18,25 @@ type Props = {
   steps: BuildStepRow[];
   isLoading: boolean;
   fixedHeight?: number;
-  focusStepId?: string | null;
+  focusStep?: { stepId: string; tick: number } | null;
 };
 
 export const DeploymentBuildStepsTable: React.FC<Props> = ({
   steps,
   isLoading,
   fixedHeight = 500,
-  focusStepId,
+  focusStep,
 }) => {
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
   const containerRef = useRef<HTMLDivElement>(null);
 
+  const stepId = focusStep?.stepId;
+  const tick = focusStep?.tick;
+  // biome-ignore lint/correctness/useExhaustiveDependencies: tick is the intentional re-fire trigger.
   useEffect(() => {
-    if (!focusStepId) {
+    if (!stepId) {
       return;
     }
-    const stepId = focusStepId.split("#")[0];
     setExpandedIds((prev) => (prev.has(stepId) ? prev : new Set(prev).add(stepId)));
     requestAnimationFrame(() => {
       requestAnimationFrame(() => {
@@ -43,7 +45,7 @@ export const DeploymentBuildStepsTable: React.FC<Props> = ({
           ?.scrollIntoView({ behavior: "smooth", block: "center" });
       });
     });
-  }, [focusStepId]);
+  }, [stepId, tick]);
 
   const toggleExpand = (step: BuildStepRow) => {
     if (!step.has_logs) {

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/[deploymentId]/(deployment-progress)/deployment-progress.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/[deploymentId]/(deployment-progress)/deployment-progress.tsx
@@ -7,7 +7,7 @@ import type { inferRouterOutputs } from "@trpc/server";
 import { CloudUp, Earth, Hammer2, LayerFront, Pulse, Sparkle3 } from "@unkey/icons";
 import { P, match } from "@unkey/match";
 import { SettingCardGroup } from "@unkey/ui";
-import { useParams, useRouter } from "next/navigation";
+import { useParams, usePathname, useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { DeploymentDomainsCard } from "../../../../components/deployment-domains-card";
 import { useProjectData } from "../../../data-provider";
@@ -21,9 +21,12 @@ import { FailedDeploymentBanner } from "./failed-deployment-banner";
 type RouterOutputs = inferRouterOutputs<Router>;
 export type StepsData = RouterOutputs["deploy"]["deployment"]["steps"];
 
+const EXPAND_ANIMATION_MS = 300;
+
 export function DeploymentProgress({ stepsData }: { stepsData?: StepsData }) {
   const { deployment } = useDeployment();
   const router = useRouter();
+  const pathname = usePathname();
   const params = useParams();
   const workspaceSlug = params.workspaceSlug as string;
   const isFailed = deployment.status === "failed";
@@ -71,25 +74,35 @@ export function DeploymentProgress({ stepsData }: { stepsData?: StepsData }) {
   }
   const isPrebuilt = !hasFreshBuild.current && !building?.error;
 
-  const [focusBuildStepId, setFocusBuildStepId] = useState<string | null>(null);
+  const [buildFocus, setBuildFocus] = useState<{ stepId: string; tick: number } | null>(null);
   const [buildExpanded, setBuildExpanded] = useState(!isPrebuilt);
-  const failedBuildStep = buildSteps.data?.steps.find((s) => Boolean(s.error));
-  const handleViewBuildLogs = () => {
-    const wasExpanded = buildExpanded;
-    setBuildExpanded(true);
-    const focusFailedStep = () => {
-      if (failedBuildStep) {
-        setFocusBuildStepId(`${failedBuildStep.step_id}#${Date.now()}`);
-      }
-    };
-    // Wait out the SettingCard expand animation so the panel has real
-    // height to scroll to.
-    if (wasExpanded) {
-      focusFailedStep();
-    } else {
-      setTimeout(focusFailedStep, 320);
+  const failedBuildStep = buildSteps.data?.steps.findLast((s) => Boolean(s.error));
+  const failedStepId = failedBuildStep?.step_id;
+
+  const focusFailedStep = () => {
+    if (failedStepId) {
+      // Bump tick so the table re-scrolls even when the same step is focused again.
+      setBuildFocus((prev) => ({ stepId: failedStepId, tick: (prev?.tick ?? 0) + 1 }));
     }
   };
+
+  const revealFailedStep = () => {
+    if (buildExpanded) {
+      focusFailedStep();
+      return;
+    }
+    setBuildExpanded(true);
+    return setTimeout(focusFailedStep, EXPAND_ANIMATION_MS);
+  };
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: revealFailedStep reads buildExpanded for the open-state branch; failedStepId + pathname are the real triggers.
+  useEffect(() => {
+    if (!failedStepId || isPrebuilt) {
+      return;
+    }
+    const timer = revealFailedStep();
+    return () => clearTimeout(timer);
+  }, [failedStepId, isPrebuilt, pathname]);
 
   const queuedStep = resolveDeploymentStep({
     step: queued,
@@ -180,7 +193,7 @@ export function DeploymentProgress({ stepsData }: { stepsData?: StepsData }) {
                 <BuildErrorDescription
                   error={b?.error ?? ""}
                   canViewLogs={Boolean(failedBuildStep)}
-                  onViewLogs={handleViewBuildLogs}
+                  onViewLogs={revealFailedStep}
                 />
               ),
             )
@@ -210,7 +223,7 @@ export function DeploymentProgress({ stepsData }: { stepsData?: StepsData }) {
                 <DeploymentBuildStepsTable
                   steps={buildSteps.data?.steps ?? []}
                   isLoading={buildSteps.isLoading}
-                  focusStepId={focusBuildStepId}
+                  focusStep={buildFocus}
                 />
               </div>
             )

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/[deploymentId]/(deployment-progress)/truncated-cell.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/[deploymentId]/(deployment-progress)/truncated-cell.tsx
@@ -1,31 +1,19 @@
 import { cn } from "@/lib/utils";
-import { InfoTooltip } from "@unkey/ui";
 
 type Props = {
   text: string;
   className?: string;
-  side?: "top" | "bottom";
 };
 
-export function TruncatedCell({ text, className, side = "bottom" }: Props) {
+export function TruncatedCell({ text, className }: Props) {
   return (
-    <InfoTooltip
-      content={
-        <div className="whitespace-pre-wrap font-mono text-xs break-all text-pretty max-w-125">
-          {text}
-        </div>
-      }
-      position={{ side, align: "start" }}
-      asChild
+    <div
+      className={cn(
+        "whitespace-pre-wrap font-mono text-xs break-all text-pretty max-w-125 my-2",
+        className,
+      )}
     >
-      <div
-        className={cn(
-          "whitespace-pre-wrap font-mono text-xs break-all text-pretty max-w-125 my-2",
-          className,
-        )}
-      >
-        {text}
-      </div>
-    </InfoTooltip>
+      {text}
+    </div>
   );
 }


### PR DESCRIPTION
## Problem

When we have errors during build logs users have to dig through the see the actual issue. We also had a redundant tooltip.

## Fix

We now auto focus and scroll to the inner log so its clearer for users to what actually went wrong.


### Before

https://github.com/user-attachments/assets/aa1dea0e-2b86-4553-9023-04638ae4a237





### After

https://github.com/user-attachments/assets/4eaf79d9-1c7d-4a91-9ba5-b9f7bfa9a7c6