### PR TITLE
feat(api): add app delete endpoint

### DIFF
--- a/gen/proto/ctrl/v1/app.pb.go
+++ b/gen/proto/ctrl/v1/app.pb.go
@@ -144,6 +144,7 @@ func (x *CreateAppResponse) GetId() string {
 type DeleteAppRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	AppId         string                 `protobuf:"bytes,1,opt,name=app_id,json=appId,proto3" json:"app_id,omitempty"`
+	Actor         *ActorInfo             `protobuf:"bytes,2,opt,name=actor,proto3" json:"actor,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -183,6 +184,13 @@ func (x *DeleteAppRequest) GetAppId() string {
 		return x.AppId
 	}
 	return ""
+}
+
+func (x *DeleteAppRequest) GetActor() *ActorInfo {
+	if x != nil {
+		return x.Actor
+	}
+	return nil
 }
 
 type DeleteAppResponse struct {
@@ -234,9 +242,10 @@ const file_ctrl_v1_app_proto_rawDesc = "" +
 	"\x04slug\x18\x04 \x01(\tR\x04slug\x12(\n" +
 	"\x05actor\x18\x05 \x01(\v2\x12.ctrl.v1.ActorInfoR\x05actor\"#\n" +
 	"\x11CreateAppResponse\x12\x0e\n" +
-	"\x02id\x18\x01 \x01(\tR\x02id\")\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\"S\n" +
 	"\x10DeleteAppRequest\x12\x15\n" +
-	"\x06app_id\x18\x01 \x01(\tR\x05appId\"\x13\n" +
+	"\x06app_id\x18\x01 \x01(\tR\x05appId\x12(\n" +
+	"\x05actor\x18\x02 \x01(\v2\x12.ctrl.v1.ActorInfoR\x05actor\"\x13\n" +
 	"\x11DeleteAppResponse2\x98\x01\n" +
 	"\n" +
 	"AppService\x12D\n" +
@@ -266,15 +275,16 @@ var file_ctrl_v1_app_proto_goTypes = []any{
 }
 var file_ctrl_v1_app_proto_depIdxs = []int32{
 	4, // 0: ctrl.v1.CreateAppRequest.actor:type_name -> ctrl.v1.ActorInfo
-	0, // 1: ctrl.v1.AppService.CreateApp:input_type -> ctrl.v1.CreateAppRequest
-	2, // 2: ctrl.v1.AppService.DeleteApp:input_type -> ctrl.v1.DeleteAppRequest
-	1, // 3: ctrl.v1.AppService.CreateApp:output_type -> ctrl.v1.CreateAppResponse
-	3, // 4: ctrl.v1.AppService.DeleteApp:output_type -> ctrl.v1.DeleteAppResponse
-	3, // [3:5] is the sub-list for method output_type
-	1, // [1:3] is the sub-list for method input_type
-	1, // [1:1] is the sub-list for extension type_name
-	1, // [1:1] is the sub-list for extension extendee
-	0, // [0:1] is the sub-list for field type_name
+	4, // 1: ctrl.v1.DeleteAppRequest.actor:type_name -> ctrl.v1.ActorInfo
+	0, // 2: ctrl.v1.AppService.CreateApp:input_type -> ctrl.v1.CreateAppRequest
+	2, // 3: ctrl.v1.AppService.DeleteApp:input_type -> ctrl.v1.DeleteAppRequest
+	1, // 4: ctrl.v1.AppService.CreateApp:output_type -> ctrl.v1.CreateAppResponse
+	3, // 5: ctrl.v1.AppService.DeleteApp:output_type -> ctrl.v1.DeleteAppResponse
+	4, // [4:6] is the sub-list for method output_type
+	2, // [2:4] is the sub-list for method input_type
+	2, // [2:2] is the sub-list for extension type_name
+	2, // [2:2] is the sub-list for extension extendee
+	0, // [0:2] is the sub-list for field type_name
 }
 
 func init() { file_ctrl_v1_app_proto_init() }

--- a/gen/proto/hydra/v1/BUILD.bazel
+++ b/gen/proto/hydra/v1/BUILD.bazel
@@ -38,6 +38,7 @@ go_library(
     importpath = "github.com/unkeyed/unkey/gen/proto/hydra/v1",
     visibility = ["//visibility:public"],
     deps = [
+        "//gen/proto/ctrl/v1:ctrl",
         "@com_github_restatedev_sdk_go//:sdk-go",
         "@com_github_restatedev_sdk_go//encoding",
         "@com_github_restatedev_sdk_go//generated/dev/restate/sdk",

--- a/gen/proto/hydra/v1/app.pb.go
+++ b/gen/proto/hydra/v1/app.pb.go
@@ -8,6 +8,7 @@ package hydrav1
 
 import (
 	_ "github.com/restatedev/sdk-go/generated/dev/restate/sdk"
+	v1 "github.com/unkeyed/unkey/gen/proto/ctrl/v1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
@@ -22,8 +23,16 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// DeleteAppRequest carries the caller identity and correlation ID into the
+// durable workflow so the app.delete audit log can be written as part of the
+// retried deletion unit rather than best-effort on the synchronous RPC path.
 type DeleteAppRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Actor *v1.ActorInfo          `protobuf:"bytes,1,opt,name=actor,proto3" json:"actor,omitempty"`
+	// correlation_id groups this deletion with the other audit events from the
+	// same teardown (project -> app -> environment cascade). Minted at the RPC
+	// entry point and threaded down.
+	CorrelationId string `protobuf:"bytes,2,opt,name=correlation_id,json=correlationId,proto3" json:"correlation_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -56,6 +65,20 @@ func (x *DeleteAppRequest) ProtoReflect() protoreflect.Message {
 // Deprecated: Use DeleteAppRequest.ProtoReflect.Descriptor instead.
 func (*DeleteAppRequest) Descriptor() ([]byte, []int) {
 	return file_hydra_v1_app_proto_rawDescGZIP(), []int{0}
+}
+
+func (x *DeleteAppRequest) GetActor() *v1.ActorInfo {
+	if x != nil {
+		return x.Actor
+	}
+	return nil
+}
+
+func (x *DeleteAppRequest) GetCorrelationId() string {
+	if x != nil {
+		return x.CorrelationId
+	}
+	return ""
 }
 
 type DeleteAppResponse struct {
@@ -98,8 +121,10 @@ var File_hydra_v1_app_proto protoreflect.FileDescriptor
 
 const file_hydra_v1_app_proto_rawDesc = "" +
 	"\n" +
-	"\x12hydra/v1/app.proto\x12\bhydra.v1\x1a\x18dev/restate/sdk/go.proto\"\x12\n" +
-	"\x10DeleteAppRequest\"\x13\n" +
+	"\x12hydra/v1/app.proto\x12\bhydra.v1\x1a\x13ctrl/v1/actor.proto\x1a\x18dev/restate/sdk/go.proto\"c\n" +
+	"\x10DeleteAppRequest\x12(\n" +
+	"\x05actor\x18\x01 \x01(\v2\x12.ctrl.v1.ActorInfoR\x05actor\x12%\n" +
+	"\x0ecorrelation_id\x18\x02 \x01(\tR\rcorrelationId\"\x13\n" +
 	"\x11DeleteAppResponse2W\n" +
 	"\n" +
 	"AppService\x12C\n" +
@@ -122,15 +147,17 @@ var file_hydra_v1_app_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
 var file_hydra_v1_app_proto_goTypes = []any{
 	(*DeleteAppRequest)(nil),  // 0: hydra.v1.DeleteAppRequest
 	(*DeleteAppResponse)(nil), // 1: hydra.v1.DeleteAppResponse
+	(*v1.ActorInfo)(nil),      // 2: ctrl.v1.ActorInfo
 }
 var file_hydra_v1_app_proto_depIdxs = []int32{
-	0, // 0: hydra.v1.AppService.Delete:input_type -> hydra.v1.DeleteAppRequest
-	1, // 1: hydra.v1.AppService.Delete:output_type -> hydra.v1.DeleteAppResponse
-	1, // [1:2] is the sub-list for method output_type
-	0, // [0:1] is the sub-list for method input_type
-	0, // [0:0] is the sub-list for extension type_name
-	0, // [0:0] is the sub-list for extension extendee
-	0, // [0:0] is the sub-list for field type_name
+	2, // 0: hydra.v1.DeleteAppRequest.actor:type_name -> ctrl.v1.ActorInfo
+	0, // 1: hydra.v1.AppService.Delete:input_type -> hydra.v1.DeleteAppRequest
+	1, // 2: hydra.v1.AppService.Delete:output_type -> hydra.v1.DeleteAppResponse
+	2, // [2:3] is the sub-list for method output_type
+	1, // [1:2] is the sub-list for method input_type
+	1, // [1:1] is the sub-list for extension type_name
+	1, // [1:1] is the sub-list for extension extendee
+	0, // [0:1] is the sub-list for field type_name
 }
 
 func init() { file_hydra_v1_app_proto_init() }

--- a/gen/proto/hydra/v1/environment.pb.go
+++ b/gen/proto/hydra/v1/environment.pb.go
@@ -8,6 +8,7 @@ package hydrav1
 
 import (
 	_ "github.com/restatedev/sdk-go/generated/dev/restate/sdk"
+	v1 "github.com/unkeyed/unkey/gen/proto/ctrl/v1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
@@ -22,8 +23,16 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// DeleteEnvironmentRequest carries the caller identity and correlation ID into
+// the durable workflow so the environment.delete audit log is written as part
+// of the retried deletion unit. Environment deletes are cascade-only (no direct
+// RPC), so these always arrive from a parent app or project teardown.
 type DeleteEnvironmentRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Actor *v1.ActorInfo          `protobuf:"bytes,1,opt,name=actor,proto3" json:"actor,omitempty"`
+	// correlation_id groups this deletion with the parent teardown's other audit
+	// events. Threaded down from the app/project workflow.
+	CorrelationId string `protobuf:"bytes,2,opt,name=correlation_id,json=correlationId,proto3" json:"correlation_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -56,6 +65,20 @@ func (x *DeleteEnvironmentRequest) ProtoReflect() protoreflect.Message {
 // Deprecated: Use DeleteEnvironmentRequest.ProtoReflect.Descriptor instead.
 func (*DeleteEnvironmentRequest) Descriptor() ([]byte, []int) {
 	return file_hydra_v1_environment_proto_rawDescGZIP(), []int{0}
+}
+
+func (x *DeleteEnvironmentRequest) GetActor() *v1.ActorInfo {
+	if x != nil {
+		return x.Actor
+	}
+	return nil
+}
+
+func (x *DeleteEnvironmentRequest) GetCorrelationId() string {
+	if x != nil {
+		return x.CorrelationId
+	}
+	return ""
 }
 
 type DeleteEnvironmentResponse struct {
@@ -98,8 +121,10 @@ var File_hydra_v1_environment_proto protoreflect.FileDescriptor
 
 const file_hydra_v1_environment_proto_rawDesc = "" +
 	"\n" +
-	"\x1ahydra/v1/environment.proto\x12\bhydra.v1\x1a\x18dev/restate/sdk/go.proto\"\x1a\n" +
-	"\x18DeleteEnvironmentRequest\"\x1b\n" +
+	"\x1ahydra/v1/environment.proto\x12\bhydra.v1\x1a\x13ctrl/v1/actor.proto\x1a\x18dev/restate/sdk/go.proto\"k\n" +
+	"\x18DeleteEnvironmentRequest\x12(\n" +
+	"\x05actor\x18\x01 \x01(\v2\x12.ctrl.v1.ActorInfoR\x05actor\x12%\n" +
+	"\x0ecorrelation_id\x18\x02 \x01(\tR\rcorrelationId\"\x1b\n" +
 	"\x19DeleteEnvironmentResponse2o\n" +
 	"\x12EnvironmentService\x12S\n" +
 	"\x06Delete\x12\".hydra.v1.DeleteEnvironmentRequest\x1a#.hydra.v1.DeleteEnvironmentResponse\"\x00\x1a\x04\x98\x80\x01\x01B\x96\x01\n" +
@@ -121,15 +146,17 @@ var file_hydra_v1_environment_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
 var file_hydra_v1_environment_proto_goTypes = []any{
 	(*DeleteEnvironmentRequest)(nil),  // 0: hydra.v1.DeleteEnvironmentRequest
 	(*DeleteEnvironmentResponse)(nil), // 1: hydra.v1.DeleteEnvironmentResponse
+	(*v1.ActorInfo)(nil),              // 2: ctrl.v1.ActorInfo
 }
 var file_hydra_v1_environment_proto_depIdxs = []int32{
-	0, // 0: hydra.v1.EnvironmentService.Delete:input_type -> hydra.v1.DeleteEnvironmentRequest
-	1, // 1: hydra.v1.EnvironmentService.Delete:output_type -> hydra.v1.DeleteEnvironmentResponse
-	1, // [1:2] is the sub-list for method output_type
-	0, // [0:1] is the sub-list for method input_type
-	0, // [0:0] is the sub-list for extension type_name
-	0, // [0:0] is the sub-list for extension extendee
-	0, // [0:0] is the sub-list for field type_name
+	2, // 0: hydra.v1.DeleteEnvironmentRequest.actor:type_name -> ctrl.v1.ActorInfo
+	0, // 1: hydra.v1.EnvironmentService.Delete:input_type -> hydra.v1.DeleteEnvironmentRequest
+	1, // 2: hydra.v1.EnvironmentService.Delete:output_type -> hydra.v1.DeleteEnvironmentResponse
+	2, // [2:3] is the sub-list for method output_type
+	1, // [1:2] is the sub-list for method input_type
+	1, // [1:1] is the sub-list for extension type_name
+	1, // [1:1] is the sub-list for extension extendee
+	0, // [0:1] is the sub-list for field type_name
 }
 
 func init() { file_hydra_v1_environment_proto_init() }

--- a/gen/proto/hydra/v1/project.pb.go
+++ b/gen/proto/hydra/v1/project.pb.go
@@ -8,6 +8,7 @@ package hydrav1
 
 import (
 	_ "github.com/restatedev/sdk-go/generated/dev/restate/sdk"
+	v1 "github.com/unkeyed/unkey/gen/proto/ctrl/v1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
@@ -22,8 +23,16 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// DeleteProjectRequest carries the caller identity and correlation ID into the
+// durable workflow so the project.delete audit log is written as part of the
+// retried deletion unit, and the same correlation ID can be threaded down to
+// each cascaded app and environment delete.
 type DeleteProjectRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Actor *v1.ActorInfo          `protobuf:"bytes,1,opt,name=actor,proto3" json:"actor,omitempty"`
+	// correlation_id groups this deletion with every cascaded app.delete and
+	// environment.delete audit event. Minted at the RPC entry point.
+	CorrelationId string `protobuf:"bytes,2,opt,name=correlation_id,json=correlationId,proto3" json:"correlation_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -56,6 +65,20 @@ func (x *DeleteProjectRequest) ProtoReflect() protoreflect.Message {
 // Deprecated: Use DeleteProjectRequest.ProtoReflect.Descriptor instead.
 func (*DeleteProjectRequest) Descriptor() ([]byte, []int) {
 	return file_hydra_v1_project_proto_rawDescGZIP(), []int{0}
+}
+
+func (x *DeleteProjectRequest) GetActor() *v1.ActorInfo {
+	if x != nil {
+		return x.Actor
+	}
+	return nil
+}
+
+func (x *DeleteProjectRequest) GetCorrelationId() string {
+	if x != nil {
+		return x.CorrelationId
+	}
+	return ""
 }
 
 type DeleteProjectResponse struct {
@@ -98,8 +121,10 @@ var File_hydra_v1_project_proto protoreflect.FileDescriptor
 
 const file_hydra_v1_project_proto_rawDesc = "" +
 	"\n" +
-	"\x16hydra/v1/project.proto\x12\bhydra.v1\x1a\x18dev/restate/sdk/go.proto\"\x16\n" +
-	"\x14DeleteProjectRequest\"\x17\n" +
+	"\x16hydra/v1/project.proto\x12\bhydra.v1\x1a\x13ctrl/v1/actor.proto\x1a\x18dev/restate/sdk/go.proto\"g\n" +
+	"\x14DeleteProjectRequest\x12(\n" +
+	"\x05actor\x18\x01 \x01(\v2\x12.ctrl.v1.ActorInfoR\x05actor\x12%\n" +
+	"\x0ecorrelation_id\x18\x02 \x01(\tR\rcorrelationId\"\x17\n" +
 	"\x15DeleteProjectResponse2c\n" +
 	"\x0eProjectService\x12K\n" +
 	"\x06Delete\x12\x1e.hydra.v1.DeleteProjectRequest\x1a\x1f.hydra.v1.DeleteProjectResponse\"\x00\x1a\x04\x98\x80\x01\x01B\x92\x01\n" +
@@ -121,15 +146,17 @@ var file_hydra_v1_project_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
 var file_hydra_v1_project_proto_goTypes = []any{
 	(*DeleteProjectRequest)(nil),  // 0: hydra.v1.DeleteProjectRequest
 	(*DeleteProjectResponse)(nil), // 1: hydra.v1.DeleteProjectResponse
+	(*v1.ActorInfo)(nil),          // 2: ctrl.v1.ActorInfo
 }
 var file_hydra_v1_project_proto_depIdxs = []int32{
-	0, // 0: hydra.v1.ProjectService.Delete:input_type -> hydra.v1.DeleteProjectRequest
-	1, // 1: hydra.v1.ProjectService.Delete:output_type -> hydra.v1.DeleteProjectResponse
-	1, // [1:2] is the sub-list for method output_type
-	0, // [0:1] is the sub-list for method input_type
-	0, // [0:0] is the sub-list for extension type_name
-	0, // [0:0] is the sub-list for extension extendee
-	0, // [0:0] is the sub-list for field type_name
+	2, // 0: hydra.v1.DeleteProjectRequest.actor:type_name -> ctrl.v1.ActorInfo
+	0, // 1: hydra.v1.ProjectService.Delete:input_type -> hydra.v1.DeleteProjectRequest
+	1, // 2: hydra.v1.ProjectService.Delete:output_type -> hydra.v1.DeleteProjectResponse
+	2, // [2:3] is the sub-list for method output_type
+	1, // [1:2] is the sub-list for method input_type
+	1, // [1:1] is the sub-list for extension type_name
+	1, // [1:1] is the sub-list for extension extendee
+	0, // [0:1] is the sub-list for field type_name
 }
 
 func init() { file_hydra_v1_project_proto_init() }

--- a/pkg/auditlog/events.go
+++ b/pkg/auditlog/events.go
@@ -76,4 +76,5 @@ const (
 	// App events
 	AppCreateEvent AuditLogEvent = "app.create"
 	AppUpdateEvent AuditLogEvent = "app.update"
+	AppDeleteEvent AuditLogEvent = "app.delete"
 )

--- a/pkg/auditlog/events.go
+++ b/pkg/auditlog/events.go
@@ -77,4 +77,7 @@ const (
 	AppCreateEvent AuditLogEvent = "app.create"
 	AppUpdateEvent AuditLogEvent = "app.update"
 	AppDeleteEvent AuditLogEvent = "app.delete"
+
+	// Environment events
+	EnvironmentDeleteEvent AuditLogEvent = "environment.delete"
 )

--- a/pkg/auditlog/target.go
+++ b/pkg/auditlog/target.go
@@ -19,4 +19,5 @@ const (
 	DeploymentResourceType         AuditLogResourceType = "deployment"
 	ProjectResourceType            AuditLogResourceType = "project"
 	AppResourceType                AuditLogResourceType = "app"
+	EnvironmentResourceType        AuditLogResourceType = "environment"
 )

--- a/pkg/rbac/permissions.go
+++ b/pkg/rbac/permissions.go
@@ -205,6 +205,9 @@ const (
 
 	// UpdateApp permits modifying existing apps within a project
 	UpdateApp ActionType = "update_app"
+
+	// DeleteApp permits deleting apps within a project
+	DeleteApp ActionType = "delete_app"
 )
 
 // Tuple represents a specific permission as a combination of resource type,

--- a/svc/api/internal/testutil/http.go
+++ b/svc/api/internal/testutil/http.go
@@ -467,12 +467,13 @@ func (h *Harness) CreateTestDeploymentSetup(opts ...CreateTestDeploymentSetupOpt
 	})
 
 	app := h.CreateApp(seed.CreateAppRequest{
-		ID:            uid.New(uid.AppPrefix),
-		WorkspaceID:   workspace.ID,
-		ProjectID:     project.ID,
-		Name:          "Default",
-		Slug:          "default",
-		DefaultBranch: "main",
+		ID:               uid.New(uid.AppPrefix),
+		WorkspaceID:      workspace.ID,
+		ProjectID:        project.ID,
+		Name:             "Default",
+		Slug:             "default",
+		DefaultBranch:    "main",
+		DeleteProtection: false,
 	})
 
 	var environment db.Environment

--- a/svc/api/internal/testutil/seed/seed.go
+++ b/svc/api/internal/testutil/seed/seed.go
@@ -186,12 +186,13 @@ func (h *Seeder) CreateProject(ctx context.Context, req CreateProjectRequest) db
 
 // CreateAppRequest configures the app to create.
 type CreateAppRequest struct {
-	ID            string
-	WorkspaceID   string
-	ProjectID     string
-	Name          string
-	Slug          string
-	DefaultBranch string
+	ID               string
+	WorkspaceID      string
+	ProjectID        string
+	Name             string
+	Slug             string
+	DefaultBranch    string
+	DeleteProtection bool
 }
 
 // CreateApp creates an app within a project.
@@ -205,7 +206,7 @@ func (s *Seeder) CreateApp(ctx context.Context, req CreateAppRequest) db.App {
 		Name:             req.Name,
 		Slug:             req.Slug,
 		DefaultBranch:    req.DefaultBranch,
-		DeleteProtection: sql.NullBool{Valid: true, Bool: false},
+		DeleteProtection: sql.NullBool{Valid: true, Bool: req.DeleteProtection},
 		CreatedAt:        now,
 		UpdatedAt:        sql.NullInt64{Valid: false},
 	})

--- a/svc/api/openapi/gen.go
+++ b/svc/api/openapi/gen.go
@@ -784,9 +784,13 @@ type V2AppsCreateAppResponseData struct {
 
 // V2AppsDeleteAppRequestBody defines model for V2AppsDeleteAppRequestBody.
 type V2AppsDeleteAppRequestBody struct {
-	// AppId Specifies which app to delete by its unique identifier.
-	// Must be a valid app ID that begins with 'app_' and exists within your workspace.
-	AppId string `json:"appId"`
+	// App Identifies which app to delete, by either its unique ID or its slug.
+	// Accepts an app ID that begins with 'app_' or an app slug. The app must exist within the specified project.
+	App string `json:"app"`
+
+	// Project Identifies the parent project, by either its unique ID or its slug.
+	// Required to resolve the app, since app slugs are only unique within a project.
+	Project string `json:"project"`
 }
 
 // V2AppsDeleteAppResponseBody defines model for V2AppsDeleteAppResponseBody.

--- a/svc/api/openapi/gen.go
+++ b/svc/api/openapi/gen.go
@@ -784,13 +784,13 @@ type V2AppsCreateAppResponseData struct {
 
 // V2AppsDeleteAppRequestBody defines model for V2AppsDeleteAppRequestBody.
 type V2AppsDeleteAppRequestBody struct {
-	// App Identifies which app to delete, by either its unique ID or its slug.
-	// Accepts an app ID that begins with 'app_' or an app slug. The app must exist within the specified project.
-	App string `json:"app"`
+	// App Identifies a resource by either its unique ID or its slug.
+	// Accepts a prefixed ID (such as 'proj_' or 'app_') or a slug.
+	App ResourceIdentifier `json:"app"`
 
-	// Project Identifies the parent project, by either its unique ID or its slug.
-	// Required to resolve the app, since app slugs are only unique within a project.
-	Project string `json:"project"`
+	// Project Identifies a resource by either its unique ID or its slug.
+	// Accepts a prefixed ID (such as 'proj_' or 'app_') or a slug.
+	Project ResourceIdentifier `json:"project"`
 }
 
 // V2AppsDeleteAppResponseBody defines model for V2AppsDeleteAppResponseBody.

--- a/svc/api/openapi/gen.go
+++ b/svc/api/openapi/gen.go
@@ -782,6 +782,22 @@ type V2AppsCreateAppResponseData struct {
 	AppId string `json:"appId"`
 }
 
+// V2AppsDeleteAppRequestBody defines model for V2AppsDeleteAppRequestBody.
+type V2AppsDeleteAppRequestBody struct {
+	// AppId Specifies which app to delete by its unique identifier.
+	// Must be a valid app ID that begins with 'app_' and exists within your workspace.
+	AppId string `json:"appId"`
+}
+
+// V2AppsDeleteAppResponseBody defines model for V2AppsDeleteAppResponseBody.
+type V2AppsDeleteAppResponseBody struct {
+	// Data Empty response object by design. A successful response indicates this operation was successfully executed.
+	Data EmptyResponse `json:"data"`
+
+	// Meta Metadata object included in every API response. This provides context about the request and is essential for debugging, audit trails, and support inquiries. The `requestId` is particularly important when troubleshooting issues with the Unkey support team.
+	Meta Meta `json:"meta"`
+}
+
 // V2AppsGetAppRequestBody defines model for V2AppsGetAppRequestBody.
 type V2AppsGetAppRequestBody struct {
 	// App Identifies a resource by either its unique ID or its slug.
@@ -2704,6 +2720,9 @@ type ApisListKeysJSONRequestBody = V2ApisListKeysRequestBody
 
 // AppsCreateAppJSONRequestBody defines body for AppsCreateApp for application/json ContentType.
 type AppsCreateAppJSONRequestBody = V2AppsCreateAppRequestBody
+
+// AppsDeleteAppJSONRequestBody defines body for AppsDeleteApp for application/json ContentType.
+type AppsDeleteAppJSONRequestBody = V2AppsDeleteAppRequestBody
 
 // AppsGetAppJSONRequestBody defines body for AppsGetApp for application/json ContentType.
 type AppsGetAppJSONRequestBody = V2AppsGetAppRequestBody

--- a/svc/api/openapi/openapi-generated.yaml
+++ b/svc/api/openapi/openapi-generated.yaml
@@ -389,6 +389,32 @@ components:
                 - Violating unique constraints or business rules
 
                 To resolve this error, check the current state of the resource and adjust your request accordingly.
+        V2AppsDeleteAppRequestBody:
+            type: object
+            required:
+                - appId
+            properties:
+                appId:
+                    type: string
+                    minLength: 8
+                    maxLength: 255
+                    pattern: "^[a-zA-Z0-9_]+$"
+                    description: |
+                        Specifies which app to delete by its unique identifier.
+                        Must be a valid app ID that begins with 'app_' and exists within your workspace.
+                    example: app_1234abcd
+            additionalProperties: false
+        V2AppsDeleteAppResponseBody:
+            type: object
+            required:
+                - meta
+                - data
+            properties:
+                meta:
+                    "$ref": "#/components/schemas/Meta"
+                data:
+                    "$ref": "#/components/schemas/EmptyResponse"
+            additionalProperties: false
         V2AppsGetAppRequestBody:
             type: object
             required:
@@ -4798,6 +4824,119 @@ paths:
                 - apps
             x-speakeasy-name-override: createApp
             x-unkey-idempotency: conditionally-idempotent
+    /v2/apps.deleteApp:
+        post:
+            description: |
+                Delete an existing app, identified by its id.
+
+                Deletion is asynchronous and eventually consistent. The app and all of its associated resources (environments, deployments, custom domains) are torn down by a background workflow. A successful response indicates the deletion was enqueued, not that every resource has already been removed.
+
+                Apps with delete protection enabled cannot be deleted until protection is disabled.
+
+                **Required Permissions**
+
+                Your root key must have one of the following permissions:
+                - `project.*.delete_app` (to delete apps in any project)
+                - `project.<project_id>.delete_app` (to delete apps in a specific project)
+            operationId: apps.deleteApp
+            requestBody:
+                content:
+                    application/json:
+                        examples:
+                            delete:
+                                description: Delete an app by its unique identifier
+                                summary: Delete an app
+                                value:
+                                    appId: app_1234abcd
+                        schema:
+                            $ref: '#/components/schemas/V2AppsDeleteAppRequestBody'
+                required: true
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            examples:
+                                success:
+                                    description: App deletion was successfully enqueued
+                                    summary: Deletion enqueued
+                                    value:
+                                        data: {}
+                                        meta:
+                                            requestId: req_1234abcd
+                            schema:
+                                $ref: '#/components/schemas/V2AppsDeleteAppResponseBody'
+                    description: |
+                        Successfully enqueued deletion of the app.
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/BadRequestErrorResponse'
+                    description: Bad request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/UnauthorizedErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            examples:
+                                missingPermission:
+                                    summary: Missing required permission
+                                    value:
+                                        error:
+                                            detail: Your root key requires the 'delete_app' permission on the target project to perform this operation
+                                            status: 403
+                                            title: Forbidden
+                                            type: forbidden
+                                        meta:
+                                            requestId: req_1234abcd
+                            schema:
+                                $ref: '#/components/schemas/ForbiddenErrorResponse'
+                    description: Forbidden - Insufficient permissions (requires `project.*.delete_app`)
+                "404":
+                    content:
+                        application/json:
+                            examples:
+                                appNotFound:
+                                    summary: App not found
+                                    value:
+                                        error:
+                                            detail: The requested app does not exist.
+                                            status: 404
+                                            title: Not Found
+                                            type: not-found
+                                        meta:
+                                            requestId: req_1234abcd
+                            schema:
+                                $ref: '#/components/schemas/NotFoundErrorResponse'
+                    description: Not Found - The requested app does not exist in your workspace
+                "412":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/PreconditionFailedErrorResponse'
+                    description: Delete protection is enabled. Disable protection through the dashboard or API, then retry the deletion.
+                "429":
+                    content:
+                        application/problem+json:
+                            schema:
+                                $ref: '#/components/schemas/TooManyRequestsErrorResponse'
+                    description: Too Many Requests
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/InternalServerErrorResponse'
+                    description: Internal server error
+            security:
+                - rootKey: []
+            summary: Delete app
+            tags:
+                - apps
+            x-speakeasy-name-override: deleteApp
     /v2/apps.getApp:
         post:
             description: |

--- a/svc/api/openapi/openapi-generated.yaml
+++ b/svc/api/openapi/openapi-generated.yaml
@@ -396,23 +396,9 @@ components:
                 - app
             properties:
                 project:
-                    type: string
-                    minLength: 1
-                    maxLength: 255
-                    pattern: "^[a-zA-Z0-9_-]+$"
-                    description: |
-                        Identifies the parent project, by either its unique ID or its slug.
-                        Required to resolve the app, since app slugs are only unique within a project.
-                    example: payments
+                    "$ref": "#/components/schemas/ResourceIdentifier"
                 app:
-                    type: string
-                    minLength: 1
-                    maxLength: 255
-                    pattern: "^[a-zA-Z0-9_-]+$"
-                    description: |
-                        Identifies which app to delete, by either its unique ID or its slug.
-                        Accepts an app ID that begins with 'app_' or an app slug. The app must exist within the specified project.
-                    example: app_1234abcd
+                    "$ref": "#/components/schemas/ResourceIdentifier"
             additionalProperties: false
         V2AppsDeleteAppResponseBody:
             type: object
@@ -4846,8 +4832,8 @@ paths:
                 **Required Permissions**
 
                 Your root key must have one of the following permissions:
-                - `project.*.delete_app` (to delete apps in any project)
-                - `project.<project_id>.delete_app` (to delete apps in a specific project)
+                - `app.*.delete_app` (to delete any app)
+                - `app.<app_id>.delete_app` (to delete a specific app)
             operationId: apps.deleteApp
             requestBody:
                 content:
@@ -4869,7 +4855,7 @@ paths:
                             $ref: '#/components/schemas/V2AppsDeleteAppRequestBody'
                 required: true
             responses:
-                "200":
+                "202":
                     content:
                         application/json:
                             examples:
@@ -4904,7 +4890,7 @@ paths:
                                     summary: Missing required permission
                                     value:
                                         error:
-                                            detail: Your root key requires the 'delete_app' permission on the target project to perform this operation
+                                            detail: Your root key requires the 'delete_app' permission on the target app to perform this operation
                                             status: 403
                                             title: Forbidden
                                             type: forbidden
@@ -4912,7 +4898,7 @@ paths:
                                             requestId: req_1234abcd
                             schema:
                                 $ref: '#/components/schemas/ForbiddenErrorResponse'
-                    description: Forbidden - Insufficient permissions (requires `project.*.delete_app`)
+                    description: Forbidden - Insufficient permissions (requires `app.*.delete_app`)
                 "404":
                     content:
                         application/json:
@@ -8108,7 +8094,7 @@ paths:
                             $ref: '#/components/schemas/V2ProjectsDeleteProjectRequestBody'
                 required: true
             responses:
-                "200":
+                "202":
                     content:
                         application/json:
                             examples:

--- a/svc/api/openapi/openapi-generated.yaml
+++ b/svc/api/openapi/openapi-generated.yaml
@@ -392,16 +392,26 @@ components:
         V2AppsDeleteAppRequestBody:
             type: object
             required:
-                - appId
+                - project
+                - app
             properties:
-                appId:
+                project:
                     type: string
-                    minLength: 8
+                    minLength: 1
                     maxLength: 255
-                    pattern: "^[a-zA-Z0-9_]+$"
+                    pattern: "^[a-zA-Z0-9_-]+$"
                     description: |
-                        Specifies which app to delete by its unique identifier.
-                        Must be a valid app ID that begins with 'app_' and exists within your workspace.
+                        Identifies the parent project, by either its unique ID or its slug.
+                        Required to resolve the app, since app slugs are only unique within a project.
+                    example: payments
+                app:
+                    type: string
+                    minLength: 1
+                    maxLength: 255
+                    pattern: "^[a-zA-Z0-9_-]+$"
+                    description: |
+                        Identifies which app to delete, by either its unique ID or its slug.
+                        Accepts an app ID that begins with 'app_' or an app slug. The app must exist within the specified project.
                     example: app_1234abcd
             additionalProperties: false
         V2AppsDeleteAppResponseBody:
@@ -4843,11 +4853,18 @@ paths:
                 content:
                     application/json:
                         examples:
-                            delete:
-                                description: Delete an app by its unique identifier
-                                summary: Delete an app
+                            deleteById:
+                                description: Delete an app using its unique identifier
+                                summary: Delete by app ID
                                 value:
-                                    appId: app_1234abcd
+                                    app: app_1234abcd
+                                    project: payments
+                            deleteBySlug:
+                                description: Delete an app using its slug
+                                summary: Delete by app slug
+                                value:
+                                    app: payments-service
+                                    project: payments
                         schema:
                             $ref: '#/components/schemas/V2AppsDeleteAppRequestBody'
                 required: true

--- a/svc/api/openapi/openapi-split.yaml
+++ b/svc/api/openapi/openapi-split.yaml
@@ -230,6 +230,8 @@ paths:
     $ref: "./spec/paths/v2/apps/listApps/index.yaml"
   /v2/apps.updateApp:
     $ref: "./spec/paths/v2/apps/updateApp/index.yaml"
+  /v2/apps.deleteApp:
+    $ref: "./spec/paths/v2/apps/deleteApp/index.yaml"
 
   # Permissions Endpoints
   /v2/permissions.createRole:

--- a/svc/api/openapi/spec/paths/v2/apps/deleteApp/V2AppsDeleteAppRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/apps/deleteApp/V2AppsDeleteAppRequestBody.yaml
@@ -1,0 +1,20 @@
+type: object
+required:
+  - appId
+properties:
+  appId:
+    type: string
+    minLength: 8
+    maxLength: 255
+    pattern: "^[a-zA-Z0-9_]+$"
+    description: |
+      Specifies which app to delete by its unique identifier.
+      Must be a valid app ID that begins with 'app_' and exists within your workspace.
+    example: app_1234abcd
+additionalProperties: false
+examples:
+  delete:
+    summary: Delete an app
+    description: Delete an app by its unique identifier
+    value:
+      appId: app_1234abcd

--- a/svc/api/openapi/spec/paths/v2/apps/deleteApp/V2AppsDeleteAppRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/apps/deleteApp/V2AppsDeleteAppRequestBody.yaml
@@ -1,20 +1,37 @@
 type: object
 required:
-  - appId
+  - project
+  - app
 properties:
-  appId:
+  project:
     type: string
-    minLength: 8
+    minLength: 1
     maxLength: 255
-    pattern: "^[a-zA-Z0-9_]+$"
+    pattern: "^[a-zA-Z0-9_-]+$"
     description: |
-      Specifies which app to delete by its unique identifier.
-      Must be a valid app ID that begins with 'app_' and exists within your workspace.
+      Identifies the parent project, by either its unique ID or its slug.
+      Required to resolve the app, since app slugs are only unique within a project.
+    example: payments
+  app:
+    type: string
+    minLength: 1
+    maxLength: 255
+    pattern: "^[a-zA-Z0-9_-]+$"
+    description: |
+      Identifies which app to delete, by either its unique ID or its slug.
+      Accepts an app ID that begins with 'app_' or an app slug. The app must exist within the specified project.
     example: app_1234abcd
 additionalProperties: false
 examples:
-  delete:
-    summary: Delete an app
-    description: Delete an app by its unique identifier
+  deleteById:
+    summary: Delete by app ID
+    description: Delete an app using its unique identifier
     value:
-      appId: app_1234abcd
+      project: payments
+      app: app_1234abcd
+  deleteBySlug:
+    summary: Delete by app slug
+    description: Delete an app using its slug
+    value:
+      project: payments
+      app: payments-service

--- a/svc/api/openapi/spec/paths/v2/apps/deleteApp/V2AppsDeleteAppRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/apps/deleteApp/V2AppsDeleteAppRequestBody.yaml
@@ -4,23 +4,9 @@ required:
   - app
 properties:
   project:
-    type: string
-    minLength: 1
-    maxLength: 255
-    pattern: "^[a-zA-Z0-9_-]+$"
-    description: |
-      Identifies the parent project, by either its unique ID or its slug.
-      Required to resolve the app, since app slugs are only unique within a project.
-    example: payments
+    "$ref": "../../../../common/ResourceIdentifier.yaml"
   app:
-    type: string
-    minLength: 1
-    maxLength: 255
-    pattern: "^[a-zA-Z0-9_-]+$"
-    description: |
-      Identifies which app to delete, by either its unique ID or its slug.
-      Accepts an app ID that begins with 'app_' or an app slug. The app must exist within the specified project.
-    example: app_1234abcd
+    "$ref": "../../../../common/ResourceIdentifier.yaml"
 additionalProperties: false
 examples:
   deleteById:

--- a/svc/api/openapi/spec/paths/v2/apps/deleteApp/V2AppsDeleteAppResponseBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/apps/deleteApp/V2AppsDeleteAppResponseBody.yaml
@@ -1,0 +1,18 @@
+type: object
+required:
+  - meta
+  - data
+properties:
+  meta:
+    "$ref": "../../../../common/Meta.yaml"
+  data:
+    "$ref": "../../../../common/EmptyResponse.yaml"
+additionalProperties: false
+examples:
+  success:
+    summary: Deletion enqueued
+    description: App deletion was successfully enqueued
+    value:
+      meta:
+        requestId: req_1234abcd
+      data: {}

--- a/svc/api/openapi/spec/paths/v2/apps/deleteApp/index.yaml
+++ b/svc/api/openapi/spec/paths/v2/apps/deleteApp/index.yaml
@@ -24,11 +24,18 @@ post:
         schema:
           "$ref": "./V2AppsDeleteAppRequestBody.yaml"
         examples:
-          delete:
-            summary: Delete an app
-            description: Delete an app by its unique identifier
+          deleteById:
+            summary: Delete by app ID
+            description: Delete an app using its unique identifier
             value:
-              appId: app_1234abcd
+              project: payments
+              app: app_1234abcd
+          deleteBySlug:
+            summary: Delete by app slug
+            description: Delete an app using its slug
+            value:
+              project: payments
+              app: payments-service
     required: true
   responses:
     "200":

--- a/svc/api/openapi/spec/paths/v2/apps/deleteApp/index.yaml
+++ b/svc/api/openapi/spec/paths/v2/apps/deleteApp/index.yaml
@@ -12,8 +12,8 @@ post:
     **Required Permissions**
 
     Your root key must have one of the following permissions:
-    - `project.*.delete_app` (to delete apps in any project)
-    - `project.<project_id>.delete_app` (to delete apps in a specific project)
+    - `app.*.delete_app` (to delete any app)
+    - `app.<app_id>.delete_app` (to delete a specific app)
   operationId: apps.deleteApp
   x-speakeasy-name-override: deleteApp
   security:
@@ -38,7 +38,7 @@ post:
               app: payments-service
     required: true
   responses:
-    "200":
+    "202":
       description: |
         Successfully enqueued deletion of the app.
       content:
@@ -66,7 +66,7 @@ post:
           schema:
             "$ref": "../../../../error/UnauthorizedErrorResponse.yaml"
     "403":
-      description: Forbidden - Insufficient permissions (requires `project.*.delete_app`)
+      description: Forbidden - Insufficient permissions (requires `app.*.delete_app`)
       content:
         application/json:
           schema:
@@ -79,7 +79,7 @@ post:
                   requestId: req_1234abcd
                 error:
                   title: Forbidden
-                  detail: Your root key requires the 'delete_app' permission on the target project to perform this operation
+                  detail: Your root key requires the 'delete_app' permission on the target app to perform this operation
                   status: 403
                   type: forbidden
     "404":

--- a/svc/api/openapi/spec/paths/v2/apps/deleteApp/index.yaml
+++ b/svc/api/openapi/spec/paths/v2/apps/deleteApp/index.yaml
@@ -1,0 +1,112 @@
+post:
+  tags:
+    - apps
+  summary: Delete app
+  description: |
+    Delete an existing app, identified by its id.
+
+    Deletion is asynchronous and eventually consistent. The app and all of its associated resources (environments, deployments, custom domains) are torn down by a background workflow. A successful response indicates the deletion was enqueued, not that every resource has already been removed.
+
+    Apps with delete protection enabled cannot be deleted until protection is disabled.
+
+    **Required Permissions**
+
+    Your root key must have one of the following permissions:
+    - `project.*.delete_app` (to delete apps in any project)
+    - `project.<project_id>.delete_app` (to delete apps in a specific project)
+  operationId: apps.deleteApp
+  x-speakeasy-name-override: deleteApp
+  security:
+    - rootKey: []
+  requestBody:
+    content:
+      application/json:
+        schema:
+          "$ref": "./V2AppsDeleteAppRequestBody.yaml"
+        examples:
+          delete:
+            summary: Delete an app
+            description: Delete an app by its unique identifier
+            value:
+              appId: app_1234abcd
+    required: true
+  responses:
+    "200":
+      description: |
+        Successfully enqueued deletion of the app.
+      content:
+        application/json:
+          schema:
+            "$ref": "./V2AppsDeleteAppResponseBody.yaml"
+          examples:
+            success:
+              summary: Deletion enqueued
+              description: App deletion was successfully enqueued
+              value:
+                meta:
+                  requestId: req_1234abcd
+                data: {}
+    "400":
+      description: Bad request
+      content:
+        application/json:
+          schema:
+            "$ref": "../../../../error/BadRequestErrorResponse.yaml"
+    "401":
+      description: Unauthorized
+      content:
+        application/json:
+          schema:
+            "$ref": "../../../../error/UnauthorizedErrorResponse.yaml"
+    "403":
+      description: Forbidden - Insufficient permissions (requires `project.*.delete_app`)
+      content:
+        application/json:
+          schema:
+            "$ref": "../../../../error/ForbiddenErrorResponse.yaml"
+          examples:
+            missingPermission:
+              summary: Missing required permission
+              value:
+                meta:
+                  requestId: req_1234abcd
+                error:
+                  title: Forbidden
+                  detail: Your root key requires the 'delete_app' permission on the target project to perform this operation
+                  status: 403
+                  type: forbidden
+    "404":
+      description: Not Found - The requested app does not exist in your workspace
+      content:
+        application/json:
+          schema:
+            "$ref": "../../../../error/NotFoundErrorResponse.yaml"
+          examples:
+            appNotFound:
+              summary: App not found
+              value:
+                meta:
+                  requestId: req_1234abcd
+                error:
+                  title: Not Found
+                  detail: The requested app does not exist.
+                  status: 404
+                  type: not-found
+    "412":
+      description: Delete protection is enabled. Disable protection through the dashboard or API, then retry the deletion.
+      content:
+        application/json:
+          schema:
+            "$ref": "../../../../error/PreconditionFailedErrorResponse.yaml"
+    "429":
+      description: Too Many Requests
+      content:
+        application/problem+json:
+          schema:
+            "$ref": "../../../../error/TooManyRequestsErrorResponse.yaml"
+    "500":
+      description: Internal server error
+      content:
+        application/json:
+          schema:
+            "$ref": "../../../../error/InternalServerErrorResponse.yaml"

--- a/svc/api/openapi/spec/paths/v2/projects/deleteProject/index.yaml
+++ b/svc/api/openapi/spec/paths/v2/projects/deleteProject/index.yaml
@@ -36,7 +36,7 @@ post:
               project: payment-service
     required: true
   responses:
-    "200":
+    "202":
       description: |
         Successfully enqueued deletion of the project.
       content:

--- a/svc/api/routes/BUILD.bazel
+++ b/svc/api/routes/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
         "//svc/api/routes/v2_apis_get_api",
         "//svc/api/routes/v2_apis_list_keys",
         "//svc/api/routes/v2_apps_create_app",
+        "//svc/api/routes/v2_apps_delete_app",
         "//svc/api/routes/v2_apps_get_app",
         "//svc/api/routes/v2_apps_list_apps",
         "//svc/api/routes/v2_apps_update_app",

--- a/svc/api/routes/register.go
+++ b/svc/api/routes/register.go
@@ -62,6 +62,7 @@ import (
 	v2PortalExchangeSession "github.com/unkeyed/unkey/svc/api/routes/v2_portal_exchange_session"
 
 	v2AppsCreateApp "github.com/unkeyed/unkey/svc/api/routes/v2_apps_create_app"
+	v2AppsDeleteApp "github.com/unkeyed/unkey/svc/api/routes/v2_apps_delete_app"
 	v2AppsGetApp "github.com/unkeyed/unkey/svc/api/routes/v2_apps_get_app"
 	v2AppsListApps "github.com/unkeyed/unkey/svc/api/routes/v2_apps_list_apps"
 	v2AppsUpdateApp "github.com/unkeyed/unkey/svc/api/routes/v2_apps_update_app"
@@ -679,6 +680,15 @@ func Register(srv *zen.Server, svc *Services, info zen.InstanceInfo) {
 		&v2AppsUpdateApp.Handler{
 			DB:        svc.Database,
 			Auditlogs: svc.Auditlogs,
+		},
+	)
+
+	// v2/apps.deleteApp
+	srv.RegisterRoute(
+		protectedMiddlewares,
+		&v2AppsDeleteApp.Handler{
+			DB:         svc.Database,
+			CtrlClient: svc.CtrlAppClient,
 		},
 	)
 

--- a/svc/api/routes/v2_apps_delete_app/200_test.go
+++ b/svc/api/routes/v2_apps_delete_app/200_test.go
@@ -53,7 +53,8 @@ func TestDeleteAppSuccessfully(t *testing.T) {
 	})
 
 	res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{
-		AppId: app.ID,
+		Project: project.ID,
+		App:     app.ID,
 	})
 	require.Equal(t, 200, res.Status, "expected 200, received: %s", res.RawBody)
 	require.NotEmpty(t, res.Body.Meta.RequestId)

--- a/svc/api/routes/v2_apps_delete_app/200_test.go
+++ b/svc/api/routes/v2_apps_delete_app/200_test.go
@@ -68,9 +68,6 @@ func TestDeleteAppSuccessfully(t *testing.T) {
 
 	// Sanity: the app still exists in our DB because the cascade runs in the
 	// (mocked) control plane, not in this handler.
-	_, err := db.Query.FindAppByWorkspaceAndId(ctx, h.DB.RO(), db.FindAppByWorkspaceAndIdParams{
-		WorkspaceID: workspace.ID,
-		ID:          app.ID,
-	})
+	_, err := db.Query.FindAppById(ctx, h.DB.RO(), app.ID)
 	require.NoError(t, err)
 }

--- a/svc/api/routes/v2_apps_delete_app/200_test.go
+++ b/svc/api/routes/v2_apps_delete_app/200_test.go
@@ -28,7 +28,7 @@ func TestDeleteAppSuccessfully(t *testing.T) {
 	h.Register(route)
 
 	workspace := h.Resources().UserWorkspace
-	rootKey := h.CreateRootKey(workspace.ID, "project.*.delete_app")
+	rootKey := h.CreateRootKey(workspace.ID, "app.*.delete_app")
 	headers := http.Header{
 		"Content-Type":  {"application/json"},
 		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
@@ -56,7 +56,7 @@ func TestDeleteAppSuccessfully(t *testing.T) {
 		Project: project.ID,
 		App:     app.ID,
 	})
-	require.Equal(t, 200, res.Status, "expected 200, received: %s", res.RawBody)
+	require.Equal(t, 202, res.Status, "expected 202, received: %s", res.RawBody)
 	require.NotEmpty(t, res.Body.Meta.RequestId)
 
 	// Deletion is delegated to the control plane, which also writes the audit

--- a/svc/api/routes/v2_apps_delete_app/200_test.go
+++ b/svc/api/routes/v2_apps_delete_app/200_test.go
@@ -1,0 +1,75 @@
+package handler_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	ctrlv1 "github.com/unkeyed/unkey/gen/proto/ctrl/v1"
+	"github.com/unkeyed/unkey/pkg/db"
+	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_apps_delete_app"
+)
+
+func TestDeleteAppSuccessfully(t *testing.T) {
+	ctx := context.Background()
+	h := testutil.NewHarness(t)
+
+	ctrlClient := &testutil.MockAppClient{}
+	route := &handler.Handler{
+		DB:         h.DB,
+		CtrlClient: ctrlClient,
+	}
+	h.Register(route)
+
+	workspace := h.Resources().UserWorkspace
+	rootKey := h.CreateRootKey(workspace.ID, "project.*.delete_app")
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}
+
+	projectSlug := strings.ToLower(strings.ReplaceAll(uid.New("test"), "_", "-"))
+	project := h.CreateProject(seed.CreateProjectRequest{
+		ID:          uid.New(uid.ProjectPrefix),
+		WorkspaceID: workspace.ID,
+		Name:        "Payments",
+		Slug:        projectSlug,
+	})
+
+	appSlug := strings.ToLower(strings.ReplaceAll(uid.New("test"), "_", "-"))
+	app := h.CreateApp(seed.CreateAppRequest{
+		ID:            uid.New(uid.AppPrefix),
+		WorkspaceID:   workspace.ID,
+		ProjectID:     project.ID,
+		Name:          "Doomed",
+		Slug:          appSlug,
+		DefaultBranch: "main",
+	})
+
+	res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{
+		AppId: app.ID,
+	})
+	require.Equal(t, 200, res.Status, "expected 200, received: %s", res.RawBody)
+	require.NotEmpty(t, res.Body.Meta.RequestId)
+
+	// Deletion is delegated to the control plane, which also writes the audit
+	// log. Assert the RPC carried the resolved app id and the actor. The row is
+	// torn down asynchronously, so we do not assert it is gone here.
+	require.Len(t, ctrlClient.DeleteAppCalls, 1)
+	require.Equal(t, app.ID, ctrlClient.DeleteAppCalls[0].GetAppId())
+	require.Equal(t, ctrlv1.ActorType_ACTOR_TYPE_ROOT_KEY, ctrlClient.DeleteAppCalls[0].GetActor().GetType())
+
+	// Sanity: the app still exists in our DB because the cascade runs in the
+	// (mocked) control plane, not in this handler.
+	_, err := db.Query.FindAppByWorkspaceAndId(ctx, h.DB.RO(), db.FindAppByWorkspaceAndIdParams{
+		WorkspaceID: workspace.ID,
+		ID:          app.ID,
+	})
+	require.NoError(t, err)
+}

--- a/svc/api/routes/v2_apps_delete_app/400_test.go
+++ b/svc/api/routes/v2_apps_delete_app/400_test.go
@@ -32,10 +32,13 @@ func TestDeleteAppBadRequest(t *testing.T) {
 		name string
 		req  handler.Request
 	}{
-		{name: "missing appId", req: handler.Request{}},
-		{name: "appId too short", req: handler.Request{AppId: "app_1"}},
-		{name: "appId with invalid chars", req: handler.Request{AppId: "app-1234abc"}},
-		{name: "appId too long", req: handler.Request{AppId: strings.Repeat("a", 256)}},
+		{name: "missing project and app", req: handler.Request{}},
+		{name: "missing app", req: handler.Request{Project: "payments"}},
+		{name: "missing project", req: handler.Request{App: "app_1234abcd"}},
+		{name: "app with invalid chars", req: handler.Request{Project: "payments", App: "app.1234"}},
+		{name: "app too long", req: handler.Request{Project: "payments", App: strings.Repeat("a", 256)}},
+		{name: "project with invalid chars", req: handler.Request{Project: "pay.ments", App: "app_1234abcd"}},
+		{name: "project too long", req: handler.Request{Project: strings.Repeat("a", 256), App: "app_1234abcd"}},
 	}
 
 	for _, tc := range testCases {

--- a/svc/api/routes/v2_apps_delete_app/400_test.go
+++ b/svc/api/routes/v2_apps_delete_app/400_test.go
@@ -22,7 +22,7 @@ func TestDeleteAppBadRequest(t *testing.T) {
 	}
 	h.Register(route)
 
-	rootKey := h.CreateRootKey(h.Resources().UserWorkspace.ID, "project.*.delete_app")
+	rootKey := h.CreateRootKey(h.Resources().UserWorkspace.ID, "app.*.delete_app")
 	headers := http.Header{
 		"Content-Type":  {"application/json"},
 		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},

--- a/svc/api/routes/v2_apps_delete_app/400_test.go
+++ b/svc/api/routes/v2_apps_delete_app/400_test.go
@@ -1,0 +1,65 @@
+//nolint:exhaustruct
+package handler_test
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	"github.com/unkeyed/unkey/svc/api/openapi"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_apps_delete_app"
+)
+
+func TestDeleteAppBadRequest(t *testing.T) {
+	h := testutil.NewHarness(t)
+
+	route := &handler.Handler{
+		DB:         h.DB,
+		CtrlClient: &testutil.MockAppClient{},
+	}
+	h.Register(route)
+
+	rootKey := h.CreateRootKey(h.Resources().UserWorkspace.ID, "project.*.delete_app")
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}
+
+	testCases := []struct {
+		name string
+		req  handler.Request
+	}{
+		{name: "missing appId", req: handler.Request{}},
+		{name: "appId too short", req: handler.Request{AppId: "app_1"}},
+		{name: "appId with invalid chars", req: handler.Request{AppId: "app-1234abc"}},
+		{name: "appId too long", req: handler.Request{AppId: strings.Repeat("a", 256)}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := testutil.CallRoute[handler.Request, openapi.BadRequestErrorResponse](h, route, headers, tc.req)
+			require.Equal(t, http.StatusBadRequest, res.Status, "expected 400, sent: %+v, received: %s", tc.req, res.RawBody)
+			require.NotEmpty(t, res.Body.Meta.RequestId)
+			require.Equal(t, "Bad Request", res.Body.Error.Title)
+			require.Equal(t, http.StatusBadRequest, res.Body.Error.Status)
+			require.Greater(t, len(res.Body.Error.Errors), 0)
+		})
+	}
+
+	t.Run("invalid json", func(t *testing.T) {
+		invalidJSON := `{"appId": }`
+
+		req, err := http.NewRequest(route.Method(), route.Path(), strings.NewReader(invalidJSON))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", rootKey))
+
+		res := testutil.CallRaw[openapi.BadRequestErrorResponse](h, req)
+		require.Equal(t, http.StatusBadRequest, res.Status)
+		require.NotEmpty(t, res.Body.Meta.RequestId)
+		require.Equal(t, "Bad Request", res.Body.Error.Title)
+	})
+}

--- a/svc/api/routes/v2_apps_delete_app/401_test.go
+++ b/svc/api/routes/v2_apps_delete_app/401_test.go
@@ -24,7 +24,7 @@ func TestDeleteAppUnauthorized(t *testing.T) {
 			"Authorization": {"Bearer invalid_token"},
 		}
 
-		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{AppId: "app_1234abcd"})
+		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{Project: "payments", App: "app_1234abcd"})
 		require.Equal(t, http.StatusUnauthorized, res.Status, "expected 401, received: %s", res.RawBody)
 	})
 }

--- a/svc/api/routes/v2_apps_delete_app/401_test.go
+++ b/svc/api/routes/v2_apps_delete_app/401_test.go
@@ -1,0 +1,30 @@
+package handler_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_apps_delete_app"
+)
+
+func TestDeleteAppUnauthorized(t *testing.T) {
+	h := testutil.NewHarness(t)
+
+	route := &handler.Handler{
+		DB:         h.DB,
+		CtrlClient: &testutil.MockAppClient{},
+	}
+	h.Register(route)
+
+	t.Run("invalid auth token", func(t *testing.T) {
+		headers := http.Header{
+			"Content-Type":  {"application/json"},
+			"Authorization": {"Bearer invalid_token"},
+		}
+
+		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{AppId: "app_1234abcd"})
+		require.Equal(t, http.StatusUnauthorized, res.Status, "expected 401, received: %s", res.RawBody)
+	})
+}

--- a/svc/api/routes/v2_apps_delete_app/403_test.go
+++ b/svc/api/routes/v2_apps_delete_app/403_test.go
@@ -26,14 +26,16 @@ func TestDeleteAppForbidden(t *testing.T) {
 
 	testCases := []struct {
 		name        string
-		permissions func(projectID string) []string
+		permissions func(projectID, appID string) []string
 		shouldPass  bool
 	}{
-		{name: "wildcard permission", permissions: func(_ string) []string { return []string{"project.*.delete_app"} }, shouldPass: true},
-		{name: "scoped permission", permissions: func(p string) []string { return []string{fmt.Sprintf("project.%s.delete_app", p)} }, shouldPass: true},
-		{name: "wildcard and more", permissions: func(_ string) []string { return []string{"some.other.permission", "project.*.delete_app"} }, shouldPass: true},
-		{name: "wrong action", permissions: func(_ string) []string { return []string{"project.*.read_app"} }, shouldPass: false},
-		{name: "unrelated permission", permissions: func(_ string) []string { return []string{"api.*.create_api"} }, shouldPass: false},
+		{name: "wildcard app permission", permissions: func(_, _ string) []string { return []string{"app.*.delete_app"} }, shouldPass: true},
+		{name: "specific app permission", permissions: func(_, a string) []string { return []string{fmt.Sprintf("app.%s.delete_app", a)} }, shouldPass: true},
+		{name: "wildcard and more", permissions: func(_, _ string) []string { return []string{"some.other.permission", "app.*.delete_app"} }, shouldPass: true},
+		{name: "project scoped delete does not match", permissions: func(p, _ string) []string { return []string{fmt.Sprintf("project.%s.delete_app", p)} }, shouldPass: false},
+		{name: "wrong action", permissions: func(_, _ string) []string { return []string{"app.*.read_app"} }, shouldPass: false},
+		{name: "create does not match delete", permissions: func(_, _ string) []string { return []string{"app.*.create_app"} }, shouldPass: false},
+		{name: "unrelated permission", permissions: func(_, _ string) []string { return []string{"api.*.create_api"} }, shouldPass: false},
 	}
 
 	for _, tc := range testCases {
@@ -55,7 +57,7 @@ func TestDeleteAppForbidden(t *testing.T) {
 				DefaultBranch: "main",
 			})
 
-			rootKey := h.CreateRootKey(workspace.ID, tc.permissions(project.ID)...)
+			rootKey := h.CreateRootKey(workspace.ID, tc.permissions(project.ID, app.ID)...)
 			headers := http.Header{
 				"Content-Type":  {"application/json"},
 				"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
@@ -63,7 +65,7 @@ func TestDeleteAppForbidden(t *testing.T) {
 
 			res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{Project: project.ID, App: app.ID})
 			if tc.shouldPass {
-				require.Equal(t, 200, res.Status, "expected 200 for %v, got: %s", tc.name, res.RawBody)
+				require.Equal(t, 202, res.Status, "expected 202 for %v, got: %s", tc.name, res.RawBody)
 			} else {
 				require.Equal(t, http.StatusForbidden, res.Status, "expected 403 for %v, got: %s", tc.name, res.RawBody)
 			}

--- a/svc/api/routes/v2_apps_delete_app/403_test.go
+++ b/svc/api/routes/v2_apps_delete_app/403_test.go
@@ -61,7 +61,7 @@ func TestDeleteAppForbidden(t *testing.T) {
 				"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
 			}
 
-			res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{AppId: app.ID})
+			res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{Project: project.ID, App: app.ID})
 			if tc.shouldPass {
 				require.Equal(t, 200, res.Status, "expected 200 for %v, got: %s", tc.name, res.RawBody)
 			} else {

--- a/svc/api/routes/v2_apps_delete_app/403_test.go
+++ b/svc/api/routes/v2_apps_delete_app/403_test.go
@@ -1,0 +1,72 @@
+package handler_test
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_apps_delete_app"
+)
+
+func TestDeleteAppForbidden(t *testing.T) {
+	h := testutil.NewHarness(t)
+
+	route := &handler.Handler{
+		DB:         h.DB,
+		CtrlClient: &testutil.MockAppClient{},
+	}
+	h.Register(route)
+
+	workspace := h.Resources().UserWorkspace
+
+	testCases := []struct {
+		name        string
+		permissions func(projectID string) []string
+		shouldPass  bool
+	}{
+		{name: "wildcard permission", permissions: func(_ string) []string { return []string{"project.*.delete_app"} }, shouldPass: true},
+		{name: "scoped permission", permissions: func(p string) []string { return []string{fmt.Sprintf("project.%s.delete_app", p)} }, shouldPass: true},
+		{name: "wildcard and more", permissions: func(_ string) []string { return []string{"some.other.permission", "project.*.delete_app"} }, shouldPass: true},
+		{name: "wrong action", permissions: func(_ string) []string { return []string{"project.*.read_app"} }, shouldPass: false},
+		{name: "unrelated permission", permissions: func(_ string) []string { return []string{"api.*.create_api"} }, shouldPass: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			projectSlug := strings.ToLower(strings.ReplaceAll(uid.New("test"), "_", "-"))
+			project := h.CreateProject(seed.CreateProjectRequest{
+				ID:          uid.New(uid.ProjectPrefix),
+				WorkspaceID: workspace.ID,
+				Name:        "Forbidden Test",
+				Slug:        projectSlug,
+			})
+			appSlug := strings.ToLower(strings.ReplaceAll(uid.New("test"), "_", "-"))
+			app := h.CreateApp(seed.CreateAppRequest{
+				ID:            uid.New(uid.AppPrefix),
+				WorkspaceID:   workspace.ID,
+				ProjectID:     project.ID,
+				Name:          "Forbidden Test",
+				Slug:          appSlug,
+				DefaultBranch: "main",
+			})
+
+			rootKey := h.CreateRootKey(workspace.ID, tc.permissions(project.ID)...)
+			headers := http.Header{
+				"Content-Type":  {"application/json"},
+				"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+			}
+
+			res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{AppId: app.ID})
+			if tc.shouldPass {
+				require.Equal(t, 200, res.Status, "expected 200 for %v, got: %s", tc.name, res.RawBody)
+			} else {
+				require.Equal(t, http.StatusForbidden, res.Status, "expected 403 for %v, got: %s", tc.name, res.RawBody)
+			}
+		})
+	}
+}

--- a/svc/api/routes/v2_apps_delete_app/404_test.go
+++ b/svc/api/routes/v2_apps_delete_app/404_test.go
@@ -30,7 +30,7 @@ func TestDeleteAppNotFound(t *testing.T) {
 	}
 
 	t.Run("unknown app id returns 404", func(t *testing.T) {
-		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{AppId: uid.New(uid.AppPrefix)})
+		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{Project: uid.New(uid.ProjectPrefix), App: uid.New(uid.AppPrefix)})
 		require.Equal(t, http.StatusNotFound, res.Status, "expected 404, received: %s", res.RawBody)
 	})
 
@@ -53,7 +53,7 @@ func TestDeleteAppNotFound(t *testing.T) {
 			DefaultBranch: "main",
 		})
 
-		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{AppId: otherApp.ID})
+		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{Project: otherProject.ID, App: otherApp.ID})
 		require.Equal(t, http.StatusNotFound, res.Status, "expected 404 for cross-workspace app, received: %s", res.RawBody)
 	})
 }

--- a/svc/api/routes/v2_apps_delete_app/404_test.go
+++ b/svc/api/routes/v2_apps_delete_app/404_test.go
@@ -1,0 +1,59 @@
+package handler_test
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_apps_delete_app"
+)
+
+func TestDeleteAppNotFound(t *testing.T) {
+	h := testutil.NewHarness(t)
+
+	route := &handler.Handler{
+		DB:         h.DB,
+		CtrlClient: &testutil.MockAppClient{},
+	}
+	h.Register(route)
+
+	workspace := h.Resources().UserWorkspace
+	rootKey := h.CreateRootKey(workspace.ID, "project.*.delete_app")
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}
+
+	t.Run("unknown app id returns 404", func(t *testing.T) {
+		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{AppId: uid.New(uid.AppPrefix)})
+		require.Equal(t, http.StatusNotFound, res.Status, "expected 404, received: %s", res.RawBody)
+	})
+
+	t.Run("app in another workspace returns 404", func(t *testing.T) {
+		otherWorkspace := h.CreateWorkspace()
+		otherProjectSlug := strings.ToLower(strings.ReplaceAll(uid.New("test"), "_", "-"))
+		otherProject := h.CreateProject(seed.CreateProjectRequest{
+			ID:          uid.New(uid.ProjectPrefix),
+			WorkspaceID: otherWorkspace.ID,
+			Name:        "Theirs",
+			Slug:        otherProjectSlug,
+		})
+		otherAppSlug := strings.ToLower(strings.ReplaceAll(uid.New("test"), "_", "-"))
+		otherApp := h.CreateApp(seed.CreateAppRequest{
+			ID:            uid.New(uid.AppPrefix),
+			WorkspaceID:   otherWorkspace.ID,
+			ProjectID:     otherProject.ID,
+			Name:          "Theirs",
+			Slug:          otherAppSlug,
+			DefaultBranch: "main",
+		})
+
+		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{AppId: otherApp.ID})
+		require.Equal(t, http.StatusNotFound, res.Status, "expected 404 for cross-workspace app, received: %s", res.RawBody)
+	})
+}

--- a/svc/api/routes/v2_apps_delete_app/404_test.go
+++ b/svc/api/routes/v2_apps_delete_app/404_test.go
@@ -23,7 +23,7 @@ func TestDeleteAppNotFound(t *testing.T) {
 	h.Register(route)
 
 	workspace := h.Resources().UserWorkspace
-	rootKey := h.CreateRootKey(workspace.ID, "project.*.delete_app")
+	rootKey := h.CreateRootKey(workspace.ID, "app.*.delete_app")
 	headers := http.Header{
 		"Content-Type":  {"application/json"},
 		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},

--- a/svc/api/routes/v2_apps_delete_app/412_test.go
+++ b/svc/api/routes/v2_apps_delete_app/412_test.go
@@ -1,0 +1,62 @@
+package handler_test
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
+	"github.com/unkeyed/unkey/svc/api/openapi"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_apps_delete_app"
+)
+
+func TestDeleteAppDeleteProtection(t *testing.T) {
+	h := testutil.NewHarness(t)
+
+	ctrlClient := &testutil.MockAppClient{}
+	route := &handler.Handler{
+		DB:         h.DB,
+		CtrlClient: ctrlClient,
+	}
+	h.Register(route)
+
+	workspace := h.Resources().UserWorkspace
+	rootKey := h.CreateRootKey(workspace.ID, "project.*.delete_app")
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}
+
+	projectSlug := strings.ToLower(strings.ReplaceAll(uid.New("test"), "_", "-"))
+	project := h.CreateProject(seed.CreateProjectRequest{
+		ID:          uid.New(uid.ProjectPrefix),
+		WorkspaceID: workspace.ID,
+		Name:        "Payments",
+		Slug:        projectSlug,
+	})
+
+	appSlug := strings.ToLower(strings.ReplaceAll(uid.New("test"), "_", "-"))
+	app := h.CreateApp(seed.CreateAppRequest{
+		ID:               uid.New(uid.AppPrefix),
+		WorkspaceID:      workspace.ID,
+		ProjectID:        project.ID,
+		Name:             "Protected",
+		Slug:             appSlug,
+		DefaultBranch:    "main",
+		DeleteProtection: true,
+	})
+
+	res := testutil.CallRoute[handler.Request, openapi.PreconditionFailedErrorResponse](h, route, headers, handler.Request{
+		AppId: app.ID,
+	})
+	require.Equal(t, 412, res.Status, "expected 412, received: %s", res.RawBody)
+	require.NotNil(t, res.Body.Error)
+	require.Equal(t, "This app has delete protection enabled. Disable it before attempting to delete.", res.Body.Error.Detail)
+
+	// The control plane must not be invoked when delete protection blocks the request.
+	require.Empty(t, ctrlClient.DeleteAppCalls)
+}

--- a/svc/api/routes/v2_apps_delete_app/412_test.go
+++ b/svc/api/routes/v2_apps_delete_app/412_test.go
@@ -51,7 +51,8 @@ func TestDeleteAppDeleteProtection(t *testing.T) {
 	})
 
 	res := testutil.CallRoute[handler.Request, openapi.PreconditionFailedErrorResponse](h, route, headers, handler.Request{
-		AppId: app.ID,
+		Project: project.ID,
+		App:     app.ID,
 	})
 	require.Equal(t, 412, res.Status, "expected 412, received: %s", res.RawBody)
 	require.NotNil(t, res.Body.Error)

--- a/svc/api/routes/v2_apps_delete_app/412_test.go
+++ b/svc/api/routes/v2_apps_delete_app/412_test.go
@@ -25,7 +25,7 @@ func TestDeleteAppDeleteProtection(t *testing.T) {
 	h.Register(route)
 
 	workspace := h.Resources().UserWorkspace
-	rootKey := h.CreateRootKey(workspace.ID, "project.*.delete_app")
+	rootKey := h.CreateRootKey(workspace.ID, "app.*.delete_app")
 	headers := http.Header{
 		"Content-Type":  {"application/json"},
 		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},

--- a/svc/api/routes/v2_apps_delete_app/BUILD.bazel
+++ b/svc/api/routes/v2_apps_delete_app/BUILD.bazel
@@ -1,0 +1,41 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "v2_apps_delete_app",
+    srcs = ["handler.go"],
+    importpath = "github.com/unkeyed/unkey/svc/api/routes/v2_apps_delete_app",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//gen/proto/ctrl/v1:ctrl",
+        "//gen/rpc/ctrl",
+        "//pkg/codes",
+        "//pkg/db",
+        "//pkg/fault",
+        "//pkg/rbac",
+        "//pkg/zen",
+        "//svc/api/internal/ctrlclient",
+        "//svc/api/openapi",
+    ],
+)
+
+go_test(
+    name = "v2_apps_delete_app_test",
+    srcs = [
+        "200_test.go",
+        "400_test.go",
+        "401_test.go",
+        "403_test.go",
+        "404_test.go",
+        "412_test.go",
+    ],
+    deps = [
+        ":v2_apps_delete_app",
+        "//gen/proto/ctrl/v1:ctrl",
+        "//pkg/db",
+        "//pkg/uid",
+        "//svc/api/internal/testutil",
+        "//svc/api/internal/testutil/seed",
+        "//svc/api/openapi",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/svc/api/routes/v2_apps_delete_app/handler.go
+++ b/svc/api/routes/v2_apps_delete_app/handler.go
@@ -44,7 +44,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	row, err := db.Query.FindAppByProjectAndIdOrSlug(ctx, h.DB.RO(), db.FindAppByProjectAndIdOrSlugParams{
+	app, err := db.Query.FindAppByProjectAndIdOrSlug(ctx, h.DB.RO(), db.FindAppByProjectAndIdOrSlugParams{
 		WorkspaceID: principal.WorkspaceID,
 		Project:     req.Project,
 		App:         req.App,
@@ -66,8 +66,6 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			fault.Public("Failed to retrieve app."),
 		)
 	}
-
-	app := row.App
 
 	err = principal.Authorize(rbac.Or(
 		rbac.T(rbac.Tuple{

--- a/svc/api/routes/v2_apps_delete_app/handler.go
+++ b/svc/api/routes/v2_apps_delete_app/handler.go
@@ -1,0 +1,116 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+
+	ctrlv1 "github.com/unkeyed/unkey/gen/proto/ctrl/v1"
+	"github.com/unkeyed/unkey/gen/rpc/ctrl"
+	"github.com/unkeyed/unkey/pkg/codes"
+	"github.com/unkeyed/unkey/pkg/db"
+	"github.com/unkeyed/unkey/pkg/fault"
+	"github.com/unkeyed/unkey/pkg/rbac"
+	"github.com/unkeyed/unkey/pkg/zen"
+	"github.com/unkeyed/unkey/svc/api/internal/ctrlclient"
+	"github.com/unkeyed/unkey/svc/api/openapi"
+)
+
+type (
+	Request  = openapi.V2AppsDeleteAppRequestBody
+	Response = openapi.V2AppsDeleteAppResponseBody
+)
+
+type Handler struct {
+	DB         db.Database
+	CtrlClient ctrl.AppServiceClient
+}
+
+func (h *Handler) Method() string {
+	return "POST"
+}
+
+func (h *Handler) Path() string {
+	return "/v2/apps.deleteApp"
+}
+
+func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
+	principal, err := s.GetPrincipal()
+	if err != nil {
+		return err
+	}
+
+	req, err := zen.BindBody[Request](s)
+	if err != nil {
+		return err
+	}
+
+	app, err := db.Query.FindAppByWorkspaceAndId(ctx, h.DB.RO(), db.FindAppByWorkspaceAndIdParams{
+		WorkspaceID: principal.WorkspaceID,
+		ID:          req.AppId,
+	})
+	if err != nil {
+		if db.IsNotFound(err) {
+			return fault.New(
+				"app not found",
+				fault.Code(codes.Data.App.NotFound.URN()),
+				fault.Internal("app not found"),
+				fault.Public("The requested app does not exist."),
+			)
+		}
+
+		return fault.Wrap(
+			err,
+			fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
+			fault.Internal("database error"),
+			fault.Public("Failed to retrieve app."),
+		)
+	}
+
+	err = principal.Authorize(rbac.Or(
+		rbac.T(rbac.Tuple{
+			ResourceType: rbac.Project,
+			ResourceID:   "*",
+			Action:       rbac.DeleteApp,
+		}),
+		rbac.T(rbac.Tuple{
+			ResourceType: rbac.Project,
+			ResourceID:   app.ProjectID,
+			Action:       rbac.DeleteApp,
+		}),
+	))
+	if err != nil {
+		return err
+	}
+
+	if app.DeleteProtection.Valid && app.DeleteProtection.Bool {
+		return fault.New(
+			"delete protected",
+			fault.Code(codes.App.Protection.ProtectedResource.URN()),
+			fault.Internal("app is protected from deletion"),
+			fault.Public("This app has delete protection enabled. Disable it before attempting to delete."),
+		)
+	}
+
+	actor, err := ctrlclient.Actor(s)
+	if err != nil {
+		return err
+	}
+
+	// Deletion cascades through the app's environments and deployments via a
+	// durable Restate workflow. The control plane enqueues the workflow and
+	// returns immediately; teardown is eventually consistent.
+	_, err = h.CtrlClient.DeleteApp(ctx, &ctrlv1.DeleteAppRequest{
+		AppId: app.ID,
+		Actor: actor,
+	})
+	if err != nil {
+		return ctrlclient.HandleError(err, "delete app")
+	}
+
+	return s.JSON(http.StatusOK, Response{
+		Meta: openapi.Meta{
+			RequestId: s.RequestID(),
+		},
+		Data: openapi.EmptyResponse{},
+	})
+}

--- a/svc/api/routes/v2_apps_delete_app/handler.go
+++ b/svc/api/routes/v2_apps_delete_app/handler.go
@@ -71,13 +71,13 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 	err = principal.Authorize(rbac.Or(
 		rbac.T(rbac.Tuple{
-			ResourceType: rbac.Project,
+			ResourceType: rbac.App,
 			ResourceID:   "*",
 			Action:       rbac.DeleteApp,
 		}),
 		rbac.T(rbac.Tuple{
-			ResourceType: rbac.Project,
-			ResourceID:   app.ProjectID,
+			ResourceType: rbac.App,
+			ResourceID:   app.ID,
 			Action:       rbac.DeleteApp,
 		}),
 	))
@@ -110,7 +110,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return ctrlclient.HandleError(err, "delete app")
 	}
 
-	return s.JSON(http.StatusOK, Response{
+	return s.JSON(http.StatusAccepted, Response{
 		Meta: openapi.Meta{
 			RequestId: s.RequestID(),
 		},

--- a/svc/api/routes/v2_apps_delete_app/handler.go
+++ b/svc/api/routes/v2_apps_delete_app/handler.go
@@ -44,9 +44,10 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	app, err := db.Query.FindAppByWorkspaceAndId(ctx, h.DB.RO(), db.FindAppByWorkspaceAndIdParams{
+	row, err := db.Query.FindAppByProjectAndIdOrSlug(ctx, h.DB.RO(), db.FindAppByProjectAndIdOrSlugParams{
 		WorkspaceID: principal.WorkspaceID,
-		ID:          req.AppId,
+		Project:     req.Project,
+		App:         req.App,
 	})
 	if err != nil {
 		if db.IsNotFound(err) {
@@ -65,6 +66,8 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			fault.Public("Failed to retrieve app."),
 		)
 	}
+
+	app := row.App
 
 	err = principal.Authorize(rbac.Or(
 		rbac.T(rbac.Tuple{

--- a/svc/api/routes/v2_projects_delete_project/200_test.go
+++ b/svc/api/routes/v2_projects_delete_project/200_test.go
@@ -60,7 +60,7 @@ func TestDeleteProjectSuccessfully(t *testing.T) {
 			res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{
 				Project: tc.identifier(project),
 			})
-			require.Equal(t, 200, res.Status, "expected 200, received: %s", res.RawBody)
+			require.Equal(t, 202, res.Status, "expected 202, received: %s", res.RawBody)
 			require.NotEmpty(t, res.Body.Meta.RequestId)
 
 			// Deletion is delegated to the control plane, which also writes the audit

--- a/svc/api/routes/v2_projects_delete_project/403_test.go
+++ b/svc/api/routes/v2_projects_delete_project/403_test.go
@@ -53,7 +53,7 @@ func TestDeleteProjectForbidden(t *testing.T) {
 
 			res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{Project: project.ID})
 			if tc.shouldPass {
-				require.Equal(t, 200, res.Status, "expected 200 for %v, got: %s", tc.permissions, res.RawBody)
+				require.Equal(t, 202, res.Status, "expected 202 for %v, got: %s", tc.permissions, res.RawBody)
 			} else {
 				require.Equal(t, http.StatusForbidden, res.Status, "expected 403 for %v, got: %s", tc.permissions, res.RawBody)
 			}

--- a/svc/api/routes/v2_projects_delete_project/handler.go
+++ b/svc/api/routes/v2_projects_delete_project/handler.go
@@ -107,7 +107,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return ctrlclient.HandleError(err, "delete project")
 	}
 
-	return s.JSON(http.StatusOK, Response{
+	return s.JSON(http.StatusAccepted, Response{
 		Meta: openapi.Meta{
 			RequestId: s.RequestID(),
 		},

--- a/svc/ctrl/internal/audit/BUILD.bazel
+++ b/svc/ctrl/internal/audit/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "audit",
+    srcs = ["audit.go"],
+    importpath = "github.com/unkeyed/unkey/svc/ctrl/internal/audit",
+    visibility = ["//svc/ctrl:__subpackages__"],
+    deps = [
+        "//gen/proto/ctrl/v1:ctrl",
+        "//internal/services/auditlogs",
+        "//pkg/auditlog",
+        "//svc/ctrl/internal/actor",
+        "@com_github_restatedev_sdk_go//:sdk-go",
+    ],
+)

--- a/svc/ctrl/internal/audit/audit.go
+++ b/svc/ctrl/internal/audit/audit.go
@@ -1,0 +1,57 @@
+// Package audit writes audit logs from inside Restate deletion workflows.
+//
+// Delete RPCs enqueue a durable workflow and can't share a transaction with
+// the audit insert, so writing the audit log on the RPC path risks a
+// deleting-but-unaudited window if the insert fails. Workflows instead call
+// [Insert], which records the event as its own durable step: the nil tx makes
+// auditlogs.Insert open its own transaction, and the enclosing RunVoid journals
+// the result so it commits exactly once across retries.
+package audit
+
+import (
+	restate "github.com/restatedev/sdk-go"
+	ctrlv1 "github.com/unkeyed/unkey/gen/proto/ctrl/v1"
+	"github.com/unkeyed/unkey/internal/services/auditlogs"
+	"github.com/unkeyed/unkey/pkg/auditlog"
+	"github.com/unkeyed/unkey/svc/ctrl/internal/actor"
+)
+
+// Event is a single audit log entry to write from a workflow. The actor fields
+// and the durable-step wiring are shared; callers supply only the parts that
+// vary per resource.
+type Event struct {
+	// Actor is the caller threaded in via the workflow request. A cascade
+	// (project -> app -> environment) carries the same actor down every level.
+	Actor *ctrlv1.ActorInfo
+
+	// CorrelationID groups this event with the other deletions in the same
+	// teardown. Minted once at the RPC entry point and threaded down.
+	CorrelationID string
+
+	WorkspaceID string
+	Event       auditlog.AuditLogEvent
+	Display     string
+	Resource    auditlog.AuditLogResource
+}
+
+// Insert writes e as a durable Restate step named "insert audit log".
+func Insert(ctx restate.ObjectContext, svc auditlogs.AuditLogService, e Event) error {
+	a := e.Actor
+	return restate.RunVoid(ctx, func(runCtx restate.RunContext) error {
+		return svc.Insert(runCtx, nil, []auditlog.AuditLog{
+			{
+				WorkspaceID:   e.WorkspaceID,
+				Event:         e.Event,
+				Display:       e.Display,
+				ActorID:       a.GetId(),
+				ActorName:     a.GetName(),
+				ActorType:     actor.AuditType(a.GetType()),
+				ActorMeta:     actor.Meta(a.GetMeta()),
+				RemoteIP:      a.GetRemoteIp(),
+				UserAgent:     a.GetUserAgent(),
+				CorrelationID: e.CorrelationID,
+				Resources:     []auditlog.AuditLogResource{e.Resource},
+			},
+		})
+	}, restate.WithName("insert audit log"))
+}

--- a/svc/ctrl/proto/ctrl/v1/app.proto
+++ b/svc/ctrl/proto/ctrl/v1/app.proto
@@ -27,6 +27,7 @@ message CreateAppResponse {
 
 message DeleteAppRequest {
   string app_id = 1;
+  ActorInfo actor = 2;
 }
 
 message DeleteAppResponse {}

--- a/svc/ctrl/proto/hydra/v1/app.proto
+++ b/svc/ctrl/proto/hydra/v1/app.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package hydra.v1;
 
+import "ctrl/v1/actor.proto";
 import "dev/restate/sdk/go.proto";
 
 option go_package = "github.com/unkeyed/unkey/gen/proto/hydra/v1;hydrav1";
@@ -16,6 +17,15 @@ service AppService {
   rpc Delete(DeleteAppRequest) returns (DeleteAppResponse) {}
 }
 
-message DeleteAppRequest {}
+// DeleteAppRequest carries the caller identity and correlation ID into the
+// durable workflow so the app.delete audit log can be written as part of the
+// retried deletion unit rather than best-effort on the synchronous RPC path.
+message DeleteAppRequest {
+  ctrl.v1.ActorInfo actor = 1;
+  // correlation_id groups this deletion with the other audit events from the
+  // same teardown (project -> app -> environment cascade). Minted at the RPC
+  // entry point and threaded down.
+  string correlation_id = 2;
+}
 
 message DeleteAppResponse {}

--- a/svc/ctrl/proto/hydra/v1/environment.proto
+++ b/svc/ctrl/proto/hydra/v1/environment.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package hydra.v1;
 
+import "ctrl/v1/actor.proto";
 import "dev/restate/sdk/go.proto";
 
 option go_package = "github.com/unkeyed/unkey/gen/proto/hydra/v1;hydrav1";
@@ -16,6 +17,15 @@ service EnvironmentService {
   rpc Delete(DeleteEnvironmentRequest) returns (DeleteEnvironmentResponse) {}
 }
 
-message DeleteEnvironmentRequest {}
+// DeleteEnvironmentRequest carries the caller identity and correlation ID into
+// the durable workflow so the environment.delete audit log is written as part
+// of the retried deletion unit. Environment deletes are cascade-only (no direct
+// RPC), so these always arrive from a parent app or project teardown.
+message DeleteEnvironmentRequest {
+  ctrl.v1.ActorInfo actor = 1;
+  // correlation_id groups this deletion with the parent teardown's other audit
+  // events. Threaded down from the app/project workflow.
+  string correlation_id = 2;
+}
 
 message DeleteEnvironmentResponse {}

--- a/svc/ctrl/proto/hydra/v1/project.proto
+++ b/svc/ctrl/proto/hydra/v1/project.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package hydra.v1;
 
+import "ctrl/v1/actor.proto";
 import "dev/restate/sdk/go.proto";
 
 option go_package = "github.com/unkeyed/unkey/gen/proto/hydra/v1;hydrav1";
@@ -16,6 +17,15 @@ service ProjectService {
   rpc Delete(DeleteProjectRequest) returns (DeleteProjectResponse) {}
 }
 
-message DeleteProjectRequest {}
+// DeleteProjectRequest carries the caller identity and correlation ID into the
+// durable workflow so the project.delete audit log is written as part of the
+// retried deletion unit, and the same correlation ID can be threaded down to
+// each cascaded app and environment delete.
+message DeleteProjectRequest {
+  ctrl.v1.ActorInfo actor = 1;
+  // correlation_id groups this deletion with every cascaded app.delete and
+  // environment.delete audit event. Minted at the RPC entry point.
+  string correlation_id = 2;
+}
 
 message DeleteProjectResponse {}

--- a/svc/ctrl/services/app/delete_app.go
+++ b/svc/ctrl/services/app/delete_app.go
@@ -10,7 +10,6 @@ import (
 	"github.com/unkeyed/unkey/pkg/assert"
 	"github.com/unkeyed/unkey/pkg/auditlog"
 	"github.com/unkeyed/unkey/pkg/db"
-	"github.com/unkeyed/unkey/svc/ctrl/internal/actor"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/auth"
 )
 
@@ -18,6 +17,13 @@ import (
 // the app's environments and cleans up all associated resources.
 // Returns immediately after the workflow is enqueued; actual deletion
 // is eventually consistent.
+//
+// The app.delete audit log is written inside the workflow, not here: a
+// Restate enqueue can't share a transaction with a DB write, so writing the
+// audit log after the enqueue would leave a deleting-but-unaudited window if
+// the insert failed. The workflow owns the audit write as part of its durable,
+// retried unit. The caller's identity and a correlation ID are threaded in so
+// the workflow can attribute the event and group it with any cascade siblings.
 func (s *Service) DeleteApp(
 	ctx context.Context,
 	req *connect.Request[ctrlv1.DeleteAppRequest],
@@ -32,8 +38,7 @@ func (s *Service) DeleteApp(
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 
-	app, err := db.Query.FindAppById(ctx, s.db.RO(), req.Msg.GetAppId())
-	if err != nil {
+	if _, err := db.Query.FindAppById(ctx, s.db.RO(), req.Msg.GetAppId()); err != nil {
 		if db.IsNotFound(err) {
 			return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("app not found: %s", req.Msg.GetAppId()))
 		}
@@ -41,37 +46,12 @@ func (s *Service) DeleteApp(
 	}
 
 	client := hydrav1.NewAppServiceIngressClient(s.restate, req.Msg.GetAppId())
-	_, err = client.Delete().Send(ctx, &hydrav1.DeleteAppRequest{})
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to trigger app deletion: %w", err))
-	}
-
-	a := req.Msg.GetActor()
-	err = s.auditlogs.Insert(ctx, nil, []auditlog.AuditLog{
-		{
-			WorkspaceID:   app.WorkspaceID,
-			Event:         auditlog.AppDeleteEvent,
-			Display:       fmt.Sprintf("Deleted app %s", app.ID),
-			ActorID:       a.GetId(),
-			ActorName:     a.GetName(),
-			ActorType:     actor.AuditType(a.GetType()),
-			ActorMeta:     actor.Meta(a.GetMeta()),
-			RemoteIP:      a.GetRemoteIp(),
-			UserAgent:     a.GetUserAgent(),
-			CorrelationID: "",
-			Resources: []auditlog.AuditLogResource{
-				{
-					ID:          app.ID,
-					Type:        auditlog.AppResourceType,
-					Meta:        map[string]any{"name": app.Name, "slug": app.Slug, "projectId": app.ProjectID},
-					Name:        app.Name,
-					DisplayName: app.Name,
-				},
-			},
-		},
+	_, err := client.Delete().Send(ctx, &hydrav1.DeleteAppRequest{
+		Actor:         req.Msg.GetActor(),
+		CorrelationId: auditlog.NewCorrelationID(),
 	})
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to insert audit log: %w", err))
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to trigger app deletion: %w", err))
 	}
 
 	return connect.NewResponse(&ctrlv1.DeleteAppResponse{}), nil

--- a/svc/ctrl/services/app/delete_app.go
+++ b/svc/ctrl/services/app/delete_app.go
@@ -8,7 +8,9 @@ import (
 	ctrlv1 "github.com/unkeyed/unkey/gen/proto/ctrl/v1"
 	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
 	"github.com/unkeyed/unkey/pkg/assert"
+	"github.com/unkeyed/unkey/pkg/auditlog"
 	"github.com/unkeyed/unkey/pkg/db"
+	"github.com/unkeyed/unkey/svc/ctrl/internal/actor"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/auth"
 )
 
@@ -23,11 +25,14 @@ func (s *Service) DeleteApp(
 	if err := auth.Authenticate(req, s.bearer); err != nil {
 		return nil, err
 	}
-	if err := assert.NotEmpty(req.Msg.GetAppId(), "app_id is required"); err != nil {
+	if err := assert.All(
+		assert.NotEmpty(req.Msg.GetAppId(), "app_id is required"),
+		assert.NotNil(req.Msg.GetActor(), "actor is required"),
+	); err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 
-	_, err := db.Query.FindAppById(ctx, s.db.RW(), req.Msg.GetAppId())
+	app, err := db.Query.FindAppById(ctx, s.db.RO(), req.Msg.GetAppId())
 	if err != nil {
 		if db.IsNotFound(err) {
 			return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("app not found: %s", req.Msg.GetAppId()))
@@ -39,6 +44,34 @@ func (s *Service) DeleteApp(
 	_, err = client.Delete().Send(ctx, &hydrav1.DeleteAppRequest{})
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to trigger app deletion: %w", err))
+	}
+
+	a := req.Msg.GetActor()
+	err = s.auditlogs.Insert(ctx, nil, []auditlog.AuditLog{
+		{
+			WorkspaceID:   app.WorkspaceID,
+			Event:         auditlog.AppDeleteEvent,
+			Display:       fmt.Sprintf("Deleted app %s", app.ID),
+			ActorID:       a.GetId(),
+			ActorName:     a.GetName(),
+			ActorType:     actor.AuditType(a.GetType()),
+			ActorMeta:     actor.Meta(a.GetMeta()),
+			RemoteIP:      a.GetRemoteIp(),
+			UserAgent:     a.GetUserAgent(),
+			CorrelationID: "",
+			Resources: []auditlog.AuditLogResource{
+				{
+					ID:          app.ID,
+					Type:        auditlog.AppResourceType,
+					Meta:        map[string]any{"name": app.Name, "slug": app.Slug, "projectId": app.ProjectID},
+					Name:        app.Name,
+					DisplayName: app.Name,
+				},
+			},
+		},
+	})
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to insert audit log: %w", err))
 	}
 
 	return connect.NewResponse(&ctrlv1.DeleteAppResponse{}), nil

--- a/svc/ctrl/services/project/delete_project.go
+++ b/svc/ctrl/services/project/delete_project.go
@@ -10,7 +10,6 @@ import (
 	"github.com/unkeyed/unkey/pkg/assert"
 	"github.com/unkeyed/unkey/pkg/auditlog"
 	"github.com/unkeyed/unkey/pkg/db"
-	"github.com/unkeyed/unkey/svc/ctrl/internal/actor"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/auth"
 )
 
@@ -18,6 +17,13 @@ import (
 // the project's apps and environments, cleaning up all associated resources.
 // Returns immediately after the workflow is enqueued; actual deletion
 // is eventually consistent.
+//
+// The project.delete audit log is written inside the workflow, not here: a
+// Restate enqueue can't share a transaction with a DB write, so an after-enqueue
+// insert would leave a deleting-but-unaudited window on failure. The workflow
+// owns the audit write as part of its durable unit and threads the correlation
+// ID down to every cascaded app.delete and environment.delete so the whole
+// teardown groups under one ID.
 func (s *Service) DeleteProject(
 	ctx context.Context,
 	req *connect.Request[ctrlv1.DeleteProjectRequest],
@@ -32,8 +38,7 @@ func (s *Service) DeleteProject(
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 
-	project, err := db.Query.FindProjectById(ctx, s.db.RO(), req.Msg.GetProjectId())
-	if err != nil {
+	if _, err := db.Query.FindProjectById(ctx, s.db.RO(), req.Msg.GetProjectId()); err != nil {
 		if db.IsNotFound(err) {
 			return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("project not found: %s", req.Msg.GetProjectId()))
 		}
@@ -41,37 +46,12 @@ func (s *Service) DeleteProject(
 	}
 
 	client := hydrav1.NewProjectServiceIngressClient(s.restate, req.Msg.GetProjectId())
-	_, err = client.Delete().Send(ctx, &hydrav1.DeleteProjectRequest{})
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to trigger project deletion: %w", err))
-	}
-
-	a := req.Msg.GetActor()
-	err = s.auditlogs.Insert(ctx, nil, []auditlog.AuditLog{
-		{
-			WorkspaceID:   project.WorkspaceID,
-			Event:         auditlog.ProjectDeleteEvent,
-			Display:       fmt.Sprintf("Deleted project %s", project.ID),
-			ActorID:       a.GetId(),
-			ActorName:     a.GetName(),
-			ActorType:     actor.AuditType(a.GetType()),
-			ActorMeta:     actor.Meta(a.GetMeta()),
-			RemoteIP:      a.GetRemoteIp(),
-			UserAgent:     a.GetUserAgent(),
-			CorrelationID: "",
-			Resources: []auditlog.AuditLogResource{
-				{
-					ID:          project.ID,
-					Type:        auditlog.ProjectResourceType,
-					Meta:        map[string]any{"name": project.Name, "slug": project.Slug},
-					Name:        project.Name,
-					DisplayName: project.Name,
-				},
-			},
-		},
+	_, err := client.Delete().Send(ctx, &hydrav1.DeleteProjectRequest{
+		Actor:         req.Msg.GetActor(),
+		CorrelationId: auditlog.NewCorrelationID(),
 	})
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to insert audit log: %w", err))
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to trigger project deletion: %w", err))
 	}
 
 	return connect.NewResponse(&ctrlv1.DeleteProjectResponse{}), nil

--- a/svc/ctrl/worker/BUILD.bazel
+++ b/svc/ctrl/worker/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//gen/proto/hydra/v1:hydra",
         "//gen/proto/vault/v1/vaultv1connect",
         "//gen/rpc/vault",
+        "//internal/services/auditlogs",
         "//internal/services/ratelimit/db",
         "//pkg/assert",
         "//pkg/batch",

--- a/svc/ctrl/worker/app/BUILD.bazel
+++ b/svc/ctrl/worker/app/BUILD.bazel
@@ -10,8 +10,12 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//gen/proto/hydra/v1:hydra",
+        "//internal/services/auditlogs",
+        "//pkg/assert",
+        "//pkg/auditlog",
         "//pkg/db",
         "//pkg/logger",
+        "//svc/ctrl/internal/audit",
         "@com_github_restatedev_sdk_go//:sdk-go",
     ],
 )

--- a/svc/ctrl/worker/app/delete_handler.go
+++ b/svc/ctrl/worker/app/delete_handler.go
@@ -5,21 +5,39 @@ import (
 
 	restate "github.com/restatedev/sdk-go"
 	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
+	"github.com/unkeyed/unkey/pkg/auditlog"
 	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/logger"
+	"github.com/unkeyed/unkey/svc/ctrl/internal/audit"
 )
 
 // Delete removes an app by delegating environment cleanup to each environment's
 // virtual object, then deleting app-level resources and the app record itself.
 //
+// The app.delete audit log is written here as a durable step rather than on the
+// RPC that enqueued this workflow: a Restate enqueue can't share a transaction
+// with the audit insert, so writing it on the RPC path risked a
+// deleting-but-unaudited window. The actor and correlation ID are threaded in
+// via the request and forwarded to each environment delete so the whole teardown
+// groups under one correlation ID.
+//
 // Key: app_id
 func (s *Service) Delete(
 	ctx restate.ObjectContext,
-	_ *hydrav1.DeleteAppRequest,
+	req *hydrav1.DeleteAppRequest,
 ) (*hydrav1.DeleteAppResponse, error) {
 	appID := restate.Key(ctx)
 
 	logger.Info("starting app deletion", "app_id", appID)
+
+	// Capture the app's metadata before the cascade deletes the row, so the
+	// audit log written at the end still has a name/slug to display.
+	app, err := restate.Run(ctx, func(runCtx restate.RunContext) (db.App, error) {
+		return db.Query.FindAppById(runCtx, s.db.RO(), appID)
+	}, restate.WithName("find app"))
+	if err != nil {
+		return nil, fmt.Errorf("find app: %w", err)
+	}
 
 	envIDs, err := restate.Run(ctx, func(runCtx restate.RunContext) ([]string, error) {
 		return db.Query.ListEnvironmentIdsByApp(runCtx, s.db.RO(), appID)
@@ -32,7 +50,10 @@ func (s *Service) Delete(
 		logger.Info("deleting environment", "app_id", appID, "environment_id", envID)
 
 		envClient := hydrav1.NewEnvironmentServiceClient(ctx, envID)
-		envClient.Delete().Send(&hydrav1.DeleteEnvironmentRequest{})
+		envClient.Delete().Send(&hydrav1.DeleteEnvironmentRequest{
+			Actor:         req.GetActor(),
+			CorrelationId: req.GetCorrelationId(),
+		})
 	}
 
 	if err := restate.RunVoid(ctx, func(runCtx restate.RunContext) error {
@@ -45,6 +66,23 @@ func (s *Service) Delete(
 		return db.Query.DeleteAppById(runCtx, s.db.RW(), appID)
 	}, restate.WithName("delete app")); err != nil {
 		return nil, fmt.Errorf("delete app: %w", err)
+	}
+
+	if err := audit.Insert(ctx, s.auditlogs, audit.Event{
+		Actor:         req.GetActor(),
+		CorrelationID: req.GetCorrelationId(),
+		WorkspaceID:   app.WorkspaceID,
+		Event:         auditlog.AppDeleteEvent,
+		Display:       fmt.Sprintf("Deleted app %s", app.ID),
+		Resource: auditlog.AuditLogResource{
+			ID:          app.ID,
+			Type:        auditlog.AppResourceType,
+			Meta:        map[string]any{"name": app.Name, "slug": app.Slug, "projectId": app.ProjectID},
+			Name:        app.Name,
+			DisplayName: app.Name,
+		},
+	}); err != nil {
+		return nil, fmt.Errorf("insert audit log: %w", err)
 	}
 
 	logger.Info("app deletion complete", "app_id", appID)

--- a/svc/ctrl/worker/app/service.go
+++ b/svc/ctrl/worker/app/service.go
@@ -2,6 +2,8 @@ package app
 
 import (
 	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
+	"github.com/unkeyed/unkey/internal/services/auditlogs"
+	"github.com/unkeyed/unkey/pkg/assert"
 	"github.com/unkeyed/unkey/pkg/db"
 )
 
@@ -9,7 +11,8 @@ import (
 // app deletion. The virtual object key is the app ID.
 type Service struct {
 	hydrav1.UnimplementedAppServiceServer
-	db db.Database
+	db        db.Database
+	auditlogs auditlogs.AuditLogService
 }
 
 var _ hydrav1.AppServiceServer = (*Service)(nil)
@@ -17,12 +20,21 @@ var _ hydrav1.AppServiceServer = (*Service)(nil)
 // Config holds configuration for creating a [Service].
 type Config struct {
 	DB db.Database
+
+	// Auditlogs writes the app.delete event as a durable step inside the
+	// deletion workflow, so the audit record is tied to the retried unit
+	// rather than the synchronous RPC that enqueued it.
+	Auditlogs auditlogs.AuditLogService
 }
 
 // New creates a [Service] with the given configuration.
-func New(cfg Config) *Service {
+func New(cfg Config) (*Service, error) {
+	if err := assert.NotNil(cfg.Auditlogs, "Auditlogs must not be nil"); err != nil {
+		return nil, err
+	}
 	return &Service{
 		UnimplementedAppServiceServer: hydrav1.UnimplementedAppServiceServer{},
 		db:                            cfg.DB,
-	}
+		auditlogs:                     cfg.Auditlogs,
+	}, nil
 }

--- a/svc/ctrl/worker/environment/BUILD.bazel
+++ b/svc/ctrl/worker/environment/BUILD.bazel
@@ -10,10 +10,13 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//gen/proto/hydra/v1:hydra",
+        "//internal/services/auditlogs",
         "//pkg/assert",
+        "//pkg/auditlog",
         "//pkg/db",
         "//pkg/logger",
         "//pkg/restate/admin",
+        "//svc/ctrl/internal/audit",
         "@com_github_restatedev_sdk_go//:sdk-go",
     ],
 )

--- a/svc/ctrl/worker/environment/delete_handler.go
+++ b/svc/ctrl/worker/environment/delete_handler.go
@@ -7,8 +7,10 @@ import (
 
 	restate "github.com/restatedev/sdk-go"
 	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
+	"github.com/unkeyed/unkey/pkg/auditlog"
 	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/logger"
+	"github.com/unkeyed/unkey/svc/ctrl/internal/audit"
 )
 
 // envDeletedMessage is stamped onto in-flight deployment steps when an
@@ -26,11 +28,19 @@ const envDeletedMessage = "Environment deleted"
 // Key: environment_id
 func (s *Service) Delete(
 	ctx restate.ObjectContext,
-	_ *hydrav1.DeleteEnvironmentRequest,
+	req *hydrav1.DeleteEnvironmentRequest,
 ) (*hydrav1.DeleteEnvironmentResponse, error) {
 	envID := restate.Key(ctx)
 
 	logger.Info("starting environment deletion", "environment_id", envID)
+
+	// Capture env metadata before the row is deleted, for the audit log.
+	env, err := restate.Run(ctx, func(runCtx restate.RunContext) (db.Environment, error) {
+		return db.Query.FindEnvironmentById(runCtx, s.db.RO(), envID)
+	}, restate.WithName("find environment"))
+	if err != nil {
+		return nil, fmt.Errorf("find environment: %w", err)
+	}
 
 	if err := s.cancelProgressingDeployments(ctx, envID); err != nil {
 		return nil, fmt.Errorf("cancel progressing deployments: %w", err)
@@ -106,6 +116,24 @@ func (s *Service) Delete(
 		return db.Query.DeleteEnvironmentById(runCtx, s.db.RW(), envID)
 	}, restate.WithName("delete environment")); err != nil {
 		return nil, fmt.Errorf("delete environment: %w", err)
+	}
+
+	// The environment has no display name, so its slug stands in.
+	if err := audit.Insert(ctx, s.auditlogs, audit.Event{
+		Actor:         req.GetActor(),
+		CorrelationID: req.GetCorrelationId(),
+		WorkspaceID:   env.WorkspaceID,
+		Event:         auditlog.EnvironmentDeleteEvent,
+		Display:       fmt.Sprintf("Deleted environment %s", env.Slug),
+		Resource: auditlog.AuditLogResource{
+			ID:          env.ID,
+			Type:        auditlog.EnvironmentResourceType,
+			Meta:        map[string]any{"slug": env.Slug, "appId": env.AppID, "projectId": env.ProjectID},
+			Name:        env.Slug,
+			DisplayName: env.Slug,
+		},
+	}); err != nil {
+		return nil, fmt.Errorf("insert audit log: %w", err)
 	}
 
 	logger.Info("environment deletion complete", "environment_id", envID)

--- a/svc/ctrl/worker/environment/service.go
+++ b/svc/ctrl/worker/environment/service.go
@@ -2,6 +2,7 @@ package environment
 
 import (
 	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
+	"github.com/unkeyed/unkey/internal/services/auditlogs"
 	"github.com/unkeyed/unkey/pkg/assert"
 	"github.com/unkeyed/unkey/pkg/db"
 	restateadmin "github.com/unkeyed/unkey/pkg/restate/admin"
@@ -11,8 +12,9 @@ import (
 // environment deletion. The virtual object key is the environment ID.
 type Service struct {
 	hydrav1.UnimplementedEnvironmentServiceServer
-	db    db.Database
-	admin *restateadmin.Client
+	db        db.Database
+	admin     *restateadmin.Client
+	auditlogs auditlogs.AuditLogService
 }
 
 var _ hydrav1.EnvironmentServiceServer = (*Service)(nil)
@@ -24,16 +26,25 @@ type Config struct {
 	// Admin cancels in-flight deployment invocations before the env delete
 	// cascade drops deployment rows. Required.
 	Admin *restateadmin.Client
+
+	// Auditlogs writes the environment.delete event as a durable step inside
+	// the deletion workflow. Environment deletes are cascade-only, so the event
+	// always carries the actor and correlation ID of the parent teardown.
+	Auditlogs auditlogs.AuditLogService
 }
 
 // New creates a [Service] with the given configuration.
 func New(cfg Config) (*Service, error) {
-	if err := assert.NotNil(cfg.Admin, "Admin must not be nil"); err != nil {
+	if err := assert.All(
+		assert.NotNil(cfg.Admin, "Admin must not be nil"),
+		assert.NotNil(cfg.Auditlogs, "Auditlogs must not be nil"),
+	); err != nil {
 		return nil, err
 	}
 	return &Service{
 		UnimplementedEnvironmentServiceServer: hydrav1.UnimplementedEnvironmentServiceServer{},
 		db:                                    cfg.DB,
 		admin:                                 cfg.Admin,
+		auditlogs:                             cfg.Auditlogs,
 	}, nil
 }

--- a/svc/ctrl/worker/project/BUILD.bazel
+++ b/svc/ctrl/worker/project/BUILD.bazel
@@ -10,8 +10,12 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//gen/proto/hydra/v1:hydra",
+        "//internal/services/auditlogs",
+        "//pkg/assert",
+        "//pkg/auditlog",
         "//pkg/db",
         "//pkg/logger",
+        "//svc/ctrl/internal/audit",
         "@com_github_restatedev_sdk_go//:sdk-go",
     ],
 )

--- a/svc/ctrl/worker/project/delete_handler.go
+++ b/svc/ctrl/worker/project/delete_handler.go
@@ -5,8 +5,10 @@ import (
 
 	restate "github.com/restatedev/sdk-go"
 	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
+	"github.com/unkeyed/unkey/pkg/auditlog"
 	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/logger"
+	"github.com/unkeyed/unkey/svc/ctrl/internal/audit"
 )
 
 // Delete removes a project by delegating all resource cleanup to each
@@ -15,14 +17,27 @@ import (
 // closest owner of deployment rows), which the app -> environment cascade
 // fans out to.
 //
+// The project.delete audit log is written here as a durable step rather than
+// on the enqueueing RPC, so the audit record is tied to the retried unit. The
+// actor and correlation ID are forwarded to each app delete (and on to each
+// environment delete) so the whole teardown groups under one correlation ID.
+//
 // Key: project_id
 func (s *Service) Delete(
 	ctx restate.ObjectContext,
-	_ *hydrav1.DeleteProjectRequest,
+	req *hydrav1.DeleteProjectRequest,
 ) (*hydrav1.DeleteProjectResponse, error) {
 	projectID := restate.Key(ctx)
 
 	logger.Info("starting project deletion", "project_id", projectID)
+
+	// Capture project metadata before the row is deleted, for the audit log.
+	project, err := restate.Run(ctx, func(runCtx restate.RunContext) (db.Project, error) {
+		return db.Query.FindProjectById(runCtx, s.db.RO(), projectID)
+	}, restate.WithName("find project"))
+	if err != nil {
+		return nil, fmt.Errorf("find project: %w", err)
+	}
 
 	apps, err := restate.Run(ctx, func(runCtx restate.RunContext) ([]string, error) {
 		return db.Query.ListAppIdsByProject(runCtx, s.db.RO(), projectID)
@@ -35,13 +50,33 @@ func (s *Service) Delete(
 		logger.Info("deleting app", "project_id", projectID, "app_id", appID)
 
 		appClient := hydrav1.NewAppServiceClient(ctx, appID)
-		appClient.Delete().Send(&hydrav1.DeleteAppRequest{})
+		appClient.Delete().Send(&hydrav1.DeleteAppRequest{
+			Actor:         req.GetActor(),
+			CorrelationId: req.GetCorrelationId(),
+		})
 	}
 
 	if err := restate.RunVoid(ctx, func(runCtx restate.RunContext) error {
 		return db.Query.DeleteProjectById(runCtx, s.db.RW(), projectID)
 	}, restate.WithName("delete project")); err != nil {
 		return nil, fmt.Errorf("delete project: %w", err)
+	}
+
+	if err := audit.Insert(ctx, s.auditlogs, audit.Event{
+		Actor:         req.GetActor(),
+		CorrelationID: req.GetCorrelationId(),
+		WorkspaceID:   project.WorkspaceID,
+		Event:         auditlog.ProjectDeleteEvent,
+		Display:       fmt.Sprintf("Deleted project %s", project.ID),
+		Resource: auditlog.AuditLogResource{
+			ID:          project.ID,
+			Type:        auditlog.ProjectResourceType,
+			Meta:        map[string]any{"name": project.Name, "slug": project.Slug},
+			Name:        project.Name,
+			DisplayName: project.Name,
+		},
+	}); err != nil {
+		return nil, fmt.Errorf("insert audit log: %w", err)
 	}
 
 	logger.Info("project deletion complete", "project_id", projectID)

--- a/svc/ctrl/worker/project/service.go
+++ b/svc/ctrl/worker/project/service.go
@@ -2,6 +2,8 @@ package project
 
 import (
 	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
+	"github.com/unkeyed/unkey/internal/services/auditlogs"
+	"github.com/unkeyed/unkey/pkg/assert"
 	"github.com/unkeyed/unkey/pkg/db"
 )
 
@@ -9,7 +11,8 @@ import (
 // project deletion. The virtual object key is the project ID.
 type Service struct {
 	hydrav1.UnimplementedProjectServiceServer
-	db db.Database
+	db        db.Database
+	auditlogs auditlogs.AuditLogService
 }
 
 var _ hydrav1.ProjectServiceServer = (*Service)(nil)
@@ -17,12 +20,20 @@ var _ hydrav1.ProjectServiceServer = (*Service)(nil)
 // Config holds configuration for creating a [Service].
 type Config struct {
 	DB db.Database
+
+	// Auditlogs writes the project.delete event as a durable step inside the
+	// deletion workflow, tying the audit record to the retried unit.
+	Auditlogs auditlogs.AuditLogService
 }
 
 // New creates a [Service] with the given configuration.
-func New(cfg Config) *Service {
+func New(cfg Config) (*Service, error) {
+	if err := assert.NotNil(cfg.Auditlogs, "Auditlogs must not be nil"); err != nil {
+		return nil, err
+	}
 	return &Service{
 		UnimplementedProjectServiceServer: hydrav1.UnimplementedProjectServiceServer{},
 		db:                                cfg.DB,
-	}
+		auditlogs:                         cfg.Auditlogs,
+	}, nil
 }

--- a/svc/ctrl/worker/run.go
+++ b/svc/ctrl/worker/run.go
@@ -53,6 +53,7 @@ import (
 	"github.com/unkeyed/unkey/svc/ctrl/worker/githubwebhook"
 	"github.com/unkeyed/unkey/svc/ctrl/worker/keylastusedsync"
 
+	"github.com/unkeyed/unkey/internal/services/auditlogs"
 	ratelimitdb "github.com/unkeyed/unkey/internal/services/ratelimit/db"
 	"github.com/unkeyed/unkey/svc/ctrl/worker/openapi"
 	workerproject "github.com/unkeyed/unkey/svc/ctrl/worker/project"
@@ -311,15 +312,35 @@ func Run(ctx context.Context, cfg Config) error {
 		AllowUnauthenticatedDeployments: ptr.SafeDeref(cfg.GitHub).AllowUnauthenticatedDeployments,
 	})))
 
-	restateSrv.Bind(hydrav1.NewProjectServiceServer(workerproject.New(workerproject.Config{
-		DB: database,
-	})))
-	restateSrv.Bind(hydrav1.NewAppServiceServer(workerapp.New(workerapp.Config{
-		DB: database,
-	})))
+	// Deletion workflows write their audit logs as durable steps, so the audit
+	// record is tied to the retried deletion unit rather than the enqueueing RPC.
+	auditlogSvc, err := auditlogs.New(auditlogs.Config{DB: database})
+	if err != nil {
+		return fmt.Errorf("failed to create audit log service: %w", err)
+	}
+
+	projectSvc, err := workerproject.New(workerproject.Config{
+		DB:        database,
+		Auditlogs: auditlogSvc,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create project worker service: %w", err)
+	}
+	restateSrv.Bind(hydrav1.NewProjectServiceServer(projectSvc))
+
+	appSvc, err := workerapp.New(workerapp.Config{
+		DB:        database,
+		Auditlogs: auditlogSvc,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create app worker service: %w", err)
+	}
+	restateSrv.Bind(hydrav1.NewAppServiceServer(appSvc))
+
 	envSvc, err := workerenvironment.New(workerenvironment.Config{
-		DB:    database,
-		Admin: restateAdminClient,
+		DB:        database,
+		Admin:     restateAdminClient,
+		Auditlogs: auditlogSvc,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create environment worker service: %w", err)

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/root-keys/components/dialog/permissions.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/root-keys/components/dialog/permissions.ts
@@ -220,6 +220,10 @@ export const workspacePermissions = {
       description: "Update apps in any project in this workspace",
       permission: "app.*.update_app",
     },
+    delete_app: {
+      description: "Delete apps in any project in this workspace",
+      permission: "app.*.delete_app",
+    },
   },
 } satisfies Record<string, UnkeyPermissions>;
 
@@ -319,6 +323,10 @@ export function appPermissions(appId: string): {
       update_app: {
         description: "Update apps in this project.",
         permission: `app.${appId}.update_app`,
+      },
+         delete_app: {
+        description: "Delete apps in this project.",
+        permission: `app.${appId}.delete_app`,
       },
     },
   };

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/root-keys/components/dialog/permissions.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/root-keys/components/dialog/permissions.ts
@@ -324,7 +324,7 @@ export function appPermissions(appId: string): {
         description: "Update apps in this project.",
         permission: `app.${appId}.update_app`,
       },
-         delete_app: {
+      delete_app: {
         description: "Delete apps in this project.",
         permission: `app.${appId}.delete_app`,
       },

--- a/web/apps/dashboard/gen/proto/ctrl/v1/app_pb.ts
+++ b/web/apps/dashboard/gen/proto/ctrl/v1/app_pb.ts
@@ -12,7 +12,7 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file ctrl/v1/app.proto.
  */
 export const file_ctrl_v1_app: GenFile = /*@__PURE__*/
-  fileDesc("ChFjdHJsL3YxL2FwcC5wcm90bxIHY3RybC52MSJ7ChBDcmVhdGVBcHBSZXF1ZXN0EhQKDHdvcmtzcGFjZV9pZBgBIAEoCRISCgpwcm9qZWN0X2lkGAIgASgJEgwKBG5hbWUYAyABKAkSDAoEc2x1ZxgEIAEoCRIhCgVhY3RvchgFIAEoCzISLmN0cmwudjEuQWN0b3JJbmZvIh8KEUNyZWF0ZUFwcFJlc3BvbnNlEgoKAmlkGAEgASgJIiIKEERlbGV0ZUFwcFJlcXVlc3QSDgoGYXBwX2lkGAEgASgJIhMKEURlbGV0ZUFwcFJlc3BvbnNlMpgBCgpBcHBTZXJ2aWNlEkQKCUNyZWF0ZUFwcBIZLmN0cmwudjEuQ3JlYXRlQXBwUmVxdWVzdBoaLmN0cmwudjEuQ3JlYXRlQXBwUmVzcG9uc2UiABJECglEZWxldGVBcHASGS5jdHJsLnYxLkRlbGV0ZUFwcFJlcXVlc3QaGi5jdHJsLnYxLkRlbGV0ZUFwcFJlc3BvbnNlIgBChwEKC2NvbS5jdHJsLnYxQghBcHBQcm90b1ABWjFnaXRodWIuY29tL3Vua2V5ZWQvdW5rZXkvZ2VuL3Byb3RvL2N0cmwvdjE7Y3RybHYxogIDQ1hYqgIHQ3RybC5WMcoCB0N0cmxcVjHiAhNDdHJsXFYxXEdQQk1ldGFkYXRh6gIIQ3RybDo6VjFiBnByb3RvMw", [file_ctrl_v1_actor]);
+  fileDesc("ChFjdHJsL3YxL2FwcC5wcm90bxIHY3RybC52MSJ7ChBDcmVhdGVBcHBSZXF1ZXN0EhQKDHdvcmtzcGFjZV9pZBgBIAEoCRISCgpwcm9qZWN0X2lkGAIgASgJEgwKBG5hbWUYAyABKAkSDAoEc2x1ZxgEIAEoCRIhCgVhY3RvchgFIAEoCzISLmN0cmwudjEuQWN0b3JJbmZvIh8KEUNyZWF0ZUFwcFJlc3BvbnNlEgoKAmlkGAEgASgJIkUKEERlbGV0ZUFwcFJlcXVlc3QSDgoGYXBwX2lkGAEgASgJEiEKBWFjdG9yGAIgASgLMhIuY3RybC52MS5BY3RvckluZm8iEwoRRGVsZXRlQXBwUmVzcG9uc2UymAEKCkFwcFNlcnZpY2USRAoJQ3JlYXRlQXBwEhkuY3RybC52MS5DcmVhdGVBcHBSZXF1ZXN0GhouY3RybC52MS5DcmVhdGVBcHBSZXNwb25zZSIAEkQKCURlbGV0ZUFwcBIZLmN0cmwudjEuRGVsZXRlQXBwUmVxdWVzdBoaLmN0cmwudjEuRGVsZXRlQXBwUmVzcG9uc2UiAEKHAQoLY29tLmN0cmwudjFCCEFwcFByb3RvUAFaMWdpdGh1Yi5jb20vdW5rZXllZC91bmtleS9nZW4vcHJvdG8vY3RybC92MTtjdHJsdjGiAgNDWFiqAgdDdHJsLlYxygIHQ3RybFxWMeICE0N0cmxcVjFcR1BCTWV0YWRhdGHqAghDdHJsOjpWMWIGcHJvdG8z", [file_ctrl_v1_actor]);
 
 /**
  * @generated from message ctrl.v1.CreateAppRequest
@@ -76,6 +76,11 @@ export type DeleteAppRequest = Message<"ctrl.v1.DeleteAppRequest"> & {
    * @generated from field: string app_id = 1;
    */
   appId: string;
+
+  /**
+   * @generated from field: ctrl.v1.ActorInfo actor = 2;
+   */
+  actor?: ActorInfo;
 };
 
 /**

--- a/web/internal/rbac/src/permissions.ts
+++ b/web/internal/rbac/src/permissions.ts
@@ -80,7 +80,7 @@ export const projectActions = z.enum([
   "read_deployment",
   "generate_upload_url",
 ]);
-export const appActions = z.enum(["read_app", "update_app"]);
+export const appActions = z.enum(["read_app","update_app","delete_app"]);
 
 // Resources that require an ID (resource.id.action format)
 const scopedResources = {

--- a/web/internal/rbac/src/permissions.ts
+++ b/web/internal/rbac/src/permissions.ts
@@ -80,7 +80,7 @@ export const projectActions = z.enum([
   "read_deployment",
   "generate_upload_url",
 ]);
-export const appActions = z.enum(["read_app","update_app","delete_app"]);
+export const appActions = z.enum(["read_app", "update_app", "delete_app"]);
 
 // Resources that require an ID (resource.id.action format)
 const scopedResources = {


### PR DESCRIPTION
## What does this PR do?

Adds a `POST /v2/apps.deleteApp` endpoint that allows callers to delete an existing app by its ID. Deletion is asynchronous and eventually consistent — the handler enqueues a durable Restate workflow via the control plane, which tears down the app and all associated resources (environments, deployments, custom domains) in the background.

Key behaviors:
- Apps with **delete protection** enabled return `412 Precondition Failed` before the control plane is ever contacted.
- The app is looked up by workspace to prevent cross-workspace access, returning `404` for unknown or foreign apps.
- Authorization requires `project.*.delete_app` or `project.<project_id>.delete_app` on the caller's root key.
- The control plane now accepts an `ActorInfo` field on `DeleteAppRequest` and writes an `app.delete` audit log entry after enqueuing the workflow.
- A new `delete_app` RBAC action and `AppDeleteEvent` audit log constant are introduced.
- The root key permission dialog in the dashboard exposes the new `delete_app` permission at both the workspace and per-project level.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- `200`: Create an app without delete protection and call `POST /v2/apps.deleteApp` with a root key bearing `project.*.delete_app`. Expect a `200` response and verify the control plane received the correct `app_id` and actor type.
- `400`: Send requests with a missing `appId`, an `appId` that is too short, contains invalid characters, or is too long. Expect `400` for each.
- `401`: Call the endpoint with an invalid bearer token. Expect `401`.
- `403`: Call the endpoint with a root key that lacks `delete_app` (e.g. `project.*.read_app`). Expect `403`. Confirm that wildcard and scoped `delete_app` permissions both grant access.
- `404`: Call the endpoint with a non-existent app ID, or with an app that belongs to a different workspace. Expect `404` in both cases.
- `412`: Create an app with `DeleteProtection: true` and attempt deletion. Expect `412` and confirm the control plane is never called.

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `mise run fmt`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary