### PR TITLE
fix: SSRF via redirect

### DIFF
--- a/svc/ctrl/worker/openapi/scrape_handler_test.go
+++ b/svc/ctrl/worker/openapi/scrape_handler_test.go
@@ -1,6 +1,8 @@
 package openapi
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -44,4 +46,27 @@ func TestValidateSpecPath(t *testing.T) {
 			require.NotNil(t, parsed)
 		})
 	}
+}
+
+func TestHTTPClientRefusesRedirects(t *testing.T) {
+	internalHit := false
+	internal := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		internalHit = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(internal.Close)
+
+	deployment := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Redirect(w, &http.Request{}, internal.URL, http.StatusFound)
+	}))
+	t.Cleanup(deployment.Close)
+
+	client := New(Config{}).httpClient
+
+	resp, err := client.Get(deployment.URL)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	require.Equal(t, http.StatusFound, resp.StatusCode)
+	require.False(t, internalHit, "client must not follow redirect to internal host")
 }

--- a/svc/ctrl/worker/openapi/service.go
+++ b/svc/ctrl/worker/openapi/service.go
@@ -29,6 +29,11 @@ func New(cfg Config) *Service {
 	return &Service{
 		UnimplementedOpenapiServiceServer: hydrav1.UnimplementedOpenapiServiceServer{},
 		db:                                cfg.DB,
-		httpClient:                        &http.Client{Timeout: 30 * time.Second},
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
 	}
 }


### PR DESCRIPTION
## What does this PR do?

Fixes ENG-2949

svc/ctrl/worker/openapi/service.go:32 created the scrape http.Client with no CheckRedirect, so Go's default followed up to 10 redirects to any host. Since the scrape target is the tenant's own deployment container (which fully controls its HTTP responses), it could answer the spec request with 302 Location: IP ADDRESS... and have ctrl follow it under its in-cluster identity — an SSRF that validateSpecPath (which only guards the initial path) couldn't catch.

This stops the redirect immediately to stop the potential of this happening.

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

-(scrape_handler_test.go): TestHTTPClientRefusesRedirects stands up a deployment server that 302s to an "internal" server and asserts the client returns the 302 without hitting the internal host.

## Checklist

<!-- Complete this checklist before requesting review. -->

### Required

- [X] Filled out the "How to test" section in this PR
- [X] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [X] Self-reviewed my own code
- [X] Commented on my code in hard-to-understand areas
- [X] Ran `pnpm build`
- [X] Ran `pnpm fmt`
- [X] Ran `mise run fmt`
- [X] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary
