### PR TITLE
Fix deployment detail header overflow

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/components/active-deployment-card/index.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/components/active-deployment-card/index.tsx
@@ -14,6 +14,7 @@ import { eq, useLiveQuery } from "@tanstack/react-db";
 import { CodeBranch, CodeCommit, Layers2 } from "@unkey/icons";
 import { match } from "@unkey/match";
 import { Badge, InfoTooltip, TimestampInfo } from "@unkey/ui";
+import { cn } from "@unkey/ui/src/lib/utils";
 import { Card } from "../../(overview)/components/card";
 import { useProjectData } from "../../(overview)/data-provider";
 import { DeploymentTriggerBadge } from "../../../../components/deployment-trigger-badge";
@@ -24,12 +25,20 @@ import { ActiveDeploymentCardEmpty } from "./components/active-deployment-card-e
 import { MetadataCell } from "./components/metadata-cell";
 import { ActiveDeploymentCardSkeleton } from "./components/skeleton";
 
-function GitHubLink({ href, children }: { href: string | undefined; children: React.ReactNode }) {
+function GitHubLink({
+  href,
+  children,
+  className,
+}: {
+  href: string | undefined;
+  children: React.ReactNode;
+  className?: string;
+}) {
   if (!href) {
-    return children;
+    return <span className={className}>{children}</span>;
   }
   return (
-    <DottedLink href={href} external>
+    <DottedLink href={href} external className={cn("min-w-0", className)}>
       {children}
     </DottedLink>
   );
@@ -94,8 +103,8 @@ export function ActiveDeploymentCard({
   return (
     <Card className="flex flex-col">
       <div className="px-4 pt-3 pb-2.5">
-        <div className="flex w-full justify-between items-center gap-4">
-          <div className="flex items-baseline gap-2">
+        <div className="flex w-full justify-between items-center gap-4 min-w-0">
+          <div className="flex items-baseline gap-2 shrink-0">
             <span className="font-mono text-[13px] text-accent-12 font-semibold shrink-0">
               {deployment.id}
             </span>
@@ -106,9 +115,12 @@ export function ActiveDeploymentCard({
               />
             )}
           </div>
-          <div className="flex items-center gap-3 min-w-0">
+          <div className="flex items-center justify-end gap-3 min-w-0 flex-1">
             {deployment.gitCommitMessage && (
-              <GitHubLink href={githubUrl.commit(sourceRepo, deployment.gitCommitSha)}>
+              <GitHubLink
+                href={githubUrl.commit(sourceRepo, deployment.gitCommitSha)}
+                className="flex items-center min-w-0"
+              >
                 <div className="flex items-center gap-1.5 min-w-0">
                   <CodeCommit iconSize="sm-regular" className="text-accent-12 shrink-0" />
                   <span className="text-xs text-accent-12 truncate">
@@ -118,9 +130,11 @@ export function ActiveDeploymentCard({
               </GitHubLink>
             )}
             {showLastExit && deployment.lastExit && (
-              <LastExitBadge lastExit={deployment.lastExit} />
+              <div className="shrink-0">
+                <LastExitBadge lastExit={deployment.lastExit} />
+              </div>
             )}
-            {statusBadge}
+            {statusBadge && <div className="shrink-0">{statusBadge}</div>}
           </div>
         </div>
       </div>

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/components/dotted-link.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/components/dotted-link.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { CopyButton } from "@unkey/ui";
+import { cn } from "@unkey/ui/src/lib/utils";
 import type { Route } from "next";
 import Link from "next/link";
 
@@ -15,21 +16,22 @@ type DottedLinkProps = {
   children: React.ReactNode;
 };
 
-export function DottedLink({
-  href,
-  copyValue,
-  external,
-  className = DEFAULT_LINK_CLASS,
-  children,
-}: DottedLinkProps) {
+export function DottedLink({ href, copyValue, external, className, children }: DottedLinkProps) {
+  const linkClassName = cn(DEFAULT_LINK_CLASS, className);
+
   return (
-    <div className="flex items-center gap-2">
+    <div className="flex min-w-0 items-center gap-2">
       {external ? (
-        <a href={href} target="_blank" rel="noopener noreferrer" className={className}>
+        <a href={href} target="_blank" rel="noopener noreferrer" className={linkClassName}>
           {children}
         </a>
       ) : (
-        <Link href={href as Route} target="_blank" rel="noopener noreferrer" className={className}>
+        <Link
+          href={href as Route}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={linkClassName}
+        >
           {children}
         </Link>
       )}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Fixes ENG-2955.

Prevents long deployment commit messages from pushing status badges beyond the active deployment card. The commit link now participates in flex shrinking/truncation while the exit/status badges stay fixed-width.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- `mise exec -- pnpm --dir=web biome format --write "apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/components/active-deployment-card/index.tsx" "apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/components/dotted-link.tsx"`
- `mise exec -- pnpm --dir=web biome check --write "apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/components/active-deployment-card/index.tsx" "apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/components/dotted-link.tsx"`
- `mise exec -- pnpm --dir=web --filter @unkey/dashboard typecheck`

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `mise run fmt`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://unkey.slack.com/archives/C0A7JD8HKMY/p1782202001347079?thread_ts=1782202001.347079&cid=C0A7JD8HKMY)

<div><a href="https://cursor.com/agents/bc-69285aba-fa78-562b-aba7-3631bc20c9f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-69285aba-fa78-562b-aba7-3631bc20c9f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

