### PR TITLE
docs: add Cursor Cloud dev environment setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,3 +136,63 @@ Report failed or skipped verification honestly.
 - Code quality: `docs/engineering/contributing/quality/code-quality.mdx`.
 - Testing: `docs/engineering/contributing/quality/testing/index.mdx`.
 - Documentation: `docs/engineering/contributing/quality/documentation.mdx`.
+
+## Cursor Cloud specific instructions
+
+The startup update script already runs `dev/install-mise`, `mise install`, and
+`mise run install-web`, so the pinned toolchain and `web/` deps are ready. The
+notes below are the non-obvious caveats for running the stack.
+
+### mise / PATH
+
+- `mise` lives at `$HOME/.local/bin/mise` and is not on `PATH` by default in
+ non-login shells. Use the full path, or `eval "$(mise activate bash --shims)"`,
+ or prefix tool commands with `mise exec -- <tool>` (e.g. `mise exec -- bazel`).
+ `mise run <task>` works without activation.
+
+### Docker (required, not auto-started)
+
+- Docker Engine is installed but the daemon is not running on boot. Start it
+ once per session: `sudo dockerd > /tmp/dockerd.log 2>&1 &` (best run in a
+ dedicated `tmux` session so it outlives the command).
+- The `ubuntu` user is added to the `docker` group, but shells started before
+ that change cannot reach the socket. Quick unblock:
+ `sudo chmod 666 /var/run/docker.sock`.
+- This is Docker 29; `/etc/docker/daemon.json` must set
+ `storage-driver: fuse-overlayfs` and `features.containerd-snapshotter: false`
+ for the VM kernel. If Docker fails to start with overlay errors, recreate that
+ file (and `update-alternatives --set iptables /usr/sbin/iptables-legacy`).
+
+### Running the full stack (dashboard + core key flows)
+
+- Lightest path is `mise run dashboard`, but it depends on `build` + `oci-load`,
+ which compile the entire Bazel graph (first run is long, ~15 min) and load 7
+ service images. The dashboard docker-compose only needs 4 of them, so to save
+ time you can build just those:
+ `mise exec -- bazel run //build/api:load` and likewise for `control-api`,
+ `control-worker`, and `vault`. The full `oci-load` also builds
+ `frontline`/`heimdall`/`krane`.
+- Then start infra and seed directly:
+ `docker compose -f web/apps/dashboard/dev/docker-compose.yaml up -d --wait`
+ then `./bin/unkey dev seed local`, then `pnpm --dir=web/apps/dashboard dev`
+ (dashboard on `http://localhost:3000`).
+- The dashboard needs `web/apps/dashboard/.env`; create it with
+ `cp web/apps/dashboard/dev/.env.example web/apps/dashboard/.env`. Do NOT run
+ `mise run bootstrap` unattended; it is interactive and requires a Depot token.
+- `AUTH_PROVIDER="local"` makes the dashboard auto-authenticate into workspace
+ `ws_local` with no login screen.
+
+### Service ports
+
+- dashboard 3000, data-plane api 7070, ctrl-api 7091, vault 8060, restate
+ 8081/9070, mysql 3306, clickhouse 8123/9000, redis 6379.
+
+### Seeding and the data-plane API
+
+- `./bin/unkey dev seed local` prints a root key (and writes `dev/.env.seed`).
+ That root key is scoped to workspace `ws_local`. The seeded "project" does NOT
+ create a row in the `apis` table, so to exercise the data plane create an API
+ first: `POST /v2/keys`... use `/v2/apis.createApi`, then `/v2/keys.createKey`,
+ then `/v2/keys.verifyKey` (all on `http://localhost:7070`, bearer = root key).
+- The full `mise run dev` (Tilt + minikube) path is heavier, needs a Depot
+ token, and is not required for core key lifecycle work.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,6 +143,17 @@ The startup update script already runs `dev/install-mise`, `mise install`, and
 `mise run install-web`, so the pinned toolchain and `web/` deps are ready. The
 notes below are the non-obvious caveats for running the stack.
 
+### Commit co-author email
+
+- The startup update script also patches the Cursor-managed co-author hook
+ (`~/.cursor/agent-hooks/*/commit-msg.cursor.co-author`) to use GitHub's
+ canonical no-reply email `Flo <53355483+Flo4604@users.noreply.github.com>`
+ instead of the legacy `Flo <Flo4604@users.noreply.github.com>`. The legacy
+ form does not resolve to the GitHub account, which left the CLA bot pending.
+ Keep that line in the update script; the hook is `@cursor-managed` and can be
+ regenerated with the legacy email. The durable fix is to set the correct
+ email in Cursor account settings.
+
 ### mise / PATH
 
 - `mise` lives at `$HOME/.local/bin/mise` and is not on `PATH` by default in

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,5 +194,26 @@ notes below are the non-obvious caveats for running the stack.
  create a row in the `apis` table, so to exercise the data plane create an API
  first: `POST /v2/keys`... use `/v2/apis.createApi`, then `/v2/keys.createKey`,
  then `/v2/keys.verifyKey` (all on `http://localhost:7070`, bearer = root key).
-- The full `mise run dev` (Tilt + minikube) path is heavier, needs a Depot
- token, and is not required for core key lifecycle work.
+### Full deploy stack (`mise run dev`) does NOT run in Cursor Cloud
+
+- The full Tilt + minikube deploy stack cannot start in the Cursor Cloud agent
+ VM. This is an environment limitation, not a code issue.
+- Root cause: the VM's cgroup v2 root is `domain threaded` (verify with
+ `cat /sys/fs/cgroup/cgroup.type`). A threaded subtree cannot contain domain
+ child cgroups, only exposes the `cpuset`/`cpu`/`pids` controllers (no
+ `memory`/`io`), and rejects moving a process into a child cgroup with `EIO`.
+ The root type cannot be reverted to `domain` from inside the VM (`EIO`).
+- Consequently every Kubernetes node agent fails at startup:
+ - minikube (docker driver, systemd-based kicbase node):
+   `Failed to create /init.scope control group: Structure needs cleaning`.
+ - k3s/k3d (kubelet):
+   `failed to evacuate root cgroup: read /sys/fs/cgroup/cgroup.procs: operation not supported`.
+ - kind, microk8s, etc. fail the same way (all build a `kubepods` cgroup tree).
+ - The k3s control plane alone (`server --disable-agent`) does start, since it
+   runs as in-process components, but it cannot schedule real pods.
+- Net effect: `krane`, `heimdall`, `frontline`, topolvm, cilium, and the
+ deploy/gateway flow cannot be exercised here. Use the docker-compose path
+ above for the dashboard and core key/ratelimit/RBAC flows. Test deploy-stack
+ code with targeted Bazel unit/integration tests instead.
+- The `mise run dev` path is also heavier and historically needs a Depot token
+ for builds (`dev/.env.depot`); not required for the compose path.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,14 +145,16 @@ notes below are the non-obvious caveats for running the stack.
 
 ### Commit co-author email
 
-- The startup update script also patches the Cursor-managed co-author hook
- (`~/.cursor/agent-hooks/*/commit-msg.cursor.co-author`) to use GitHub's
- canonical no-reply email `Flo <53355483+Flo4604@users.noreply.github.com>`
- instead of the legacy `Flo <Flo4604@users.noreply.github.com>`. The legacy
- form does not resolve to the GitHub account, which left the CLA bot pending.
- Keep that line in the update script; the hook is `@cursor-managed` and can be
- regenerated with the legacy email. The durable fix is to set the correct
- email in Cursor account settings.
+- The startup update script rewrites the `CO_AUTHOR` line in the Cursor-managed
+ co-author hook (`~/.cursor/agent-hooks/*/commit-msg.cursor.co-author`) to
+ `Flo <flo@unkey.com>`, overriding whatever email Cursor generates. Keep that
+ line in the update script; the hook is `@cursor-managed` and gets regenerated.
+ The durable fix is to set the desired email in Cursor account settings.
+- Commits are authored/committed by `Cursor Agent <cursoragent@cursor.com>` and
+ SSH-signed (`commit.gpgsign=true`, `gpg.format=ssh`); the `Co-authored-by`
+ trailer is only attribution and does not affect signing. Whether GitHub shows
+ "Verified" depends on the committer identity and its registered SSH signing
+ key, not on the co-author trailer.
 
 ### mise / PATH
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,10 @@ notes below are the non-obvious caveats for running the stack.
  trailer is only attribution and does not affect signing. Whether GitHub shows
  "Verified" depends on the committer identity and its registered SSH signing
  key, not on the co-author trailer.
+- When rewriting history (e.g. fixing a trailer), re-sign with
+ `git rebase --gpg-sign <base>` (or amend with `-S`). `git filter-branch`
+ DROPS the SSH signature and leaves commits unsigned/Unverified, so never use it
+ alone for signed branches; follow it with a signing rebase.
 
 ### mise / PATH
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the Unkey development environment for Cursor Cloud agents, and documents the non-obvious startup caveats in `AGENTS.md`.

The only code change is the new `## Cursor Cloud specific instructions` section in `AGENTS.md`.

### Startup update script

```
./dev/install-mise
mise trust --yes
mise install
mise run install-web
# force Cursor-managed co-author hook to: Flo <flo@unkey.com>
```

The last step rewrites the `CO_AUTHOR` line in the Cursor-managed hook to `Flo <flo@unkey.com>` (idempotent, guarded). Commits are authored by `Cursor Agent` and SSH-signed; the co-author trailer is attribution only and does not affect signing.

## Verification (compose / dashboard stack)

- Toolchain via `mise install`; web deps via `mise run install-web`.
- `mise run build` (full Bazel graph) succeeded; produced `./bin/unkey`.
- `mise exec -- bazel test //pkg/cache:cache_test` passed.
- `pnpm biome check apps/dashboard/lib` clean (409 files).
- docker-compose infra (mysql, clickhouse, redis, vault, restate, ctrl-api, ctrl-worker, api) all healthy; seeded with `./bin/unkey dev seed local`.
- Ran dashboard dev server (`http://localhost:3000`) and created an API key via the UI.
- Core key lifecycle end-to-end against the data plane: `apis.createApi` -> `keys.createKey` -> `keys.verifyKey` returned `valid: true`.

[unkey_dashboard_create_key.mp4](https://cursor.com/agents/bc-074ce618-e8cc-4dfb-a3df-123b8bd939a2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Funkey_dashboard_create_key.mp4)

## Full deploy stack (minikube/k8s) - environment limitation

The full Tilt + minikube deploy stack cannot run in the Cursor Cloud agent VM. The VM's cgroup v2 root is `domain threaded`, which forbids domain child cgroups, exposes only `cpuset`/`cpu`/`pids` (no `memory`/`io`), and rejects moving processes into child cgroups (EIO). Every Kubernetes node agent fails at startup:

- minikube (systemd kicbase node): `Failed to create /init.scope control group: Structure needs cleaning`
- k3s/k3d (kubelet): `failed to evacuate root cgroup: read /sys/fs/cgroup/cgroup.procs: operation not supported`

No hardware virtualization is exposed (`/dev/kvm` absent), so a KVM guest VM isn't possible. Documented in `AGENTS.md`; deploy-stack code should be exercised via targeted Bazel tests instead.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-074ce618-e8cc-4dfb-a3df-123b8bd939a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-074ce618-e8cc-4dfb-a3df-123b8bd939a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

