### PR TITLE
Add frontline request ClickHouse tables

### DIFF
--- a/cmd/dev/seed/BUILD.bazel
+++ b/cmd/dev/seed/BUILD.bazel
@@ -5,7 +5,7 @@ go_library(
     srcs = [
         "local.go",
         "run.go",
-        "sentinel.go",
+        "frontline.go",
         "verifications.go",
     ],
     importpath = "github.com/unkeyed/unkey/cmd/dev/seed",

--- a/cmd/dev/seed/frontline.go
+++ b/cmd/dev/seed/frontline.go
@@ -16,10 +16,10 @@ import (
 	"github.com/unkeyed/unkey/pkg/uid"
 )
 
-var sentinelCmd = &cli.Command{
-	Name:        "sentinel",
-	Usage:       "Seed sentinel request events for last 12 hours",
-	Description: "Generates realistic sentinel request data for testing RPS and latency charts",
+var frontlineCmd = &cli.Command{
+	Name:        "frontline",
+	Usage:       "Seed frontline request events for last 12 hours",
+	Description: "Generates realistic frontline request data for testing RPS and latency charts",
 	Flags: []cli.Flag{
 		cli.String("deployment-id", "Deployment ID to seed data for (if not provided, uses first available deployment)", cli.Default("")),
 		cli.Int("num-requests", "Number of requests to generate", cli.Default(100_000_000)),
@@ -29,10 +29,10 @@ var sentinelCmd = &cli.Command{
 		cli.String("clickhouse-url", "ClickHouse URL", cli.Default("clickhouse://default:password@127.0.0.1:9000")),
 		cli.String("database-primary", "MySQL database DSN", cli.Default("unkey:password@tcp(127.0.0.1:3306)/unkey?parseTime=true&interpolateParams=true"), cli.EnvVar("UNKEY_DATABASE_PRIMARY")),
 	},
-	Action: seedSentinel,
+	Action: seedFrontline,
 }
 
-func seedSentinel(ctx context.Context, cmd *cli.Command) error {
+func seedFrontline(ctx context.Context, cmd *cli.Command) error {
 	database, err := db.New(db.Config{
 		PrimaryDSN:  cmd.RequireString("database-primary"),
 		ReadOnlyDSN: "",
@@ -54,8 +54,8 @@ func seedSentinel(ctx context.Context, cmd *cli.Command) error {
 
 	log.Printf("Buffer config: batch-size=%d, buffer-size=%d, consumers=%d", batchSize, bufferSize, consumers)
 
-	sentinelRequests := clickhouse.NewBuffer[schema.SentinelRequest](ch, "default.sentinel_requests_raw_v1", clickhouse.BufferConfig{
-		Name:          "seed-sentinel-requests",
+	frontlineRequests := clickhouse.NewBuffer[schema.FrontlineRequest](ch, "default.frontline_requests_raw_v1", clickhouse.BufferConfig{
+		Name:          "seed-frontline-requests",
 		BatchSize:     batchSize,
 		BufferSize:    bufferSize,
 		FlushInterval: 5 * time.Second,
@@ -73,25 +73,25 @@ func seedSentinel(ctx context.Context, cmd *cli.Command) error {
 		log.Printf("Using deployment: %s", deploymentID)
 	}
 
-	seeder := &SentinelSeeder{
-		deploymentID:     deploymentID,
-		numRequests:      cmd.RequireInt("num-requests"),
-		db:               database,
-		sentinelRequests: sentinelRequests,
+	seeder := &FrontlineSeeder{
+		deploymentID:      deploymentID,
+		numRequests:       cmd.RequireInt("num-requests"),
+		db:                database,
+		frontlineRequests: frontlineRequests,
 	}
 
 	return seeder.Seed(ctx)
 }
 
-type SentinelSeeder struct {
-	deploymentID     string
-	numRequests      int
-	db               db.Database
-	sentinelRequests *batch.BatchProcessor[schema.SentinelRequest]
+type FrontlineSeeder struct {
+	deploymentID      string
+	numRequests       int
+	db                db.Database
+	frontlineRequests *batch.BatchProcessor[schema.FrontlineRequest]
 }
 
-func (s *SentinelSeeder) Seed(ctx context.Context) error {
-	log.Printf("Starting sentinel seed for deployment: %s", s.deploymentID)
+func (s *FrontlineSeeder) Seed(ctx context.Context) error {
+	log.Printf("Starting frontline seed for deployment: %s", s.deploymentID)
 
 	// 1. Get deployment details
 	deployment, domain, err := s.getDeploymentDetails(ctx)
@@ -99,15 +99,15 @@ func (s *SentinelSeeder) Seed(ctx context.Context) error {
 		return fmt.Errorf("failed to get deployment: %w", err)
 	}
 
-	// 2. Generate placeholder instance/sentinel IDs
-	instanceIDs, sentinelIDs := s.generatePlaceholderIDs()
+	// 2. Generate placeholder instance/frontline IDs
+	instanceIDs, frontlineIDs := s.generatePlaceholderIDs()
 
 	// 3. Generate and buffer requests (like verifications.go does)
-	if err := s.generateRequests(ctx, deployment, domain, instanceIDs, sentinelIDs); err != nil {
+	if err := s.generateRequests(ctx, deployment, domain, instanceIDs, frontlineIDs); err != nil {
 		return fmt.Errorf("failed to generate requests: %w", err)
 	}
 
-	log.Printf("Successfully seeded %d sentinel requests", s.numRequests)
+	log.Printf("Successfully seeded %d frontline requests", s.numRequests)
 	return nil
 }
 
@@ -122,7 +122,7 @@ func findFirstDeployment(ctx context.Context, database db.Database) (string, err
 	return deploymentID, nil
 }
 
-func (s *SentinelSeeder) getDeploymentDetails(ctx context.Context) (db.Deployment, string, error) {
+func (s *FrontlineSeeder) getDeploymentDetails(ctx context.Context) (db.Deployment, string, error) {
 	log.Printf("Fetching deployment details...")
 
 	// Fetch deployment (like verifications.go line 183)
@@ -149,19 +149,19 @@ func (s *SentinelSeeder) getDeploymentDetails(ctx context.Context) (db.Deploymen
 	return deployment, domain, nil
 }
 
-func (s *SentinelSeeder) generatePlaceholderIDs() ([]string, []string) {
+func (s *FrontlineSeeder) generatePlaceholderIDs() ([]string, []string) {
 	instanceIDs := []string{uid.New("inst"), uid.New("inst"), uid.New("inst"), uid.New("inst")}
-	sentinelIDs := []string{uid.New("sent"), uid.New("sent"), uid.New("sent")}
+	frontlineIDs := []string{uid.New(uid.FrontlinePrefix), uid.New(uid.FrontlinePrefix), uid.New(uid.FrontlinePrefix)}
 
-	log.Printf("  Using %d instances and %d sentinels", len(instanceIDs), len(sentinelIDs))
-	return instanceIDs, sentinelIDs
+	log.Printf("  Using %d instances and %d frontlines", len(instanceIDs), len(frontlineIDs))
+	return instanceIDs, frontlineIDs
 }
 
-func (s *SentinelSeeder) generateRequests(
+func (s *FrontlineSeeder) generateRequests(
 	_ context.Context,
 	deployment db.Deployment,
 	domain string,
-	instanceIDs, sentinelIDs []string,
+	instanceIDs, frontlineIDs []string,
 ) error {
 	endTime := time.Now()
 	startTime := endTime.Add(-12 * time.Hour)
@@ -239,36 +239,37 @@ func (s *SentinelSeeder) generateRequests(
 		}
 
 		instanceLatency := generateLatency()
-		sentinelLatency := rand.Float64()*3 + 1
-		totalLatency := instanceLatency + sentinelLatency
+		frontlineLatency := rand.Float64()*3 + 1
+		totalLatency := instanceLatency + frontlineLatency
 
-		s.sentinelRequests.Buffer(schema.SentinelRequest{
-			RequestID:       uid.New("req"),
-			Time:            timestamp.UnixMilli(),
-			WorkspaceID:     deployment.WorkspaceID,
-			ProjectID:       deployment.ProjectID,
-			DeploymentID:    deployment.ID,
-			EnvironmentID:   deployment.EnvironmentID,
-			SentinelID:      sentinelIDs[rand.IntN(len(sentinelIDs))],
-			InstanceID:      instanceIDs[rand.IntN(len(instanceIDs))],
-			InstanceAddress: generateIP(),
-			Region:          weightedSelectString(regions),
-			Platform:        "dev",
-			Method:          weightedSelectString(methods),
-			Host:            domain,
-			Path:            paths[rand.IntN(len(paths))],
-			ResponseStatus:  weightedSelectInt32(statuses),
-			UserAgent:       userAgents[rand.IntN(len(userAgents))],
-			IPAddress:       generateIP(),
-			TotalLatency:    int64(totalLatency),
-			InstanceLatency: int64(instanceLatency),
-			SentinelLatency: int64(sentinelLatency),
-			QueryString:     "",
-			QueryParams:     make(map[string][]string),
-			RequestHeaders:  []string{},
-			RequestBody:     "",
-			ResponseHeaders: []string{},
-			ResponseBody:    "",
+		s.frontlineRequests.Buffer(schema.FrontlineRequest{
+			RequestID:        uid.New("req"),
+			Time:             timestamp.UnixMilli(),
+			WorkspaceID:      deployment.WorkspaceID,
+			ProjectID:        deployment.ProjectID,
+			AppID:            deployment.AppID,
+			DeploymentID:     deployment.ID,
+			EnvironmentID:    deployment.EnvironmentID,
+			FrontlineID:      frontlineIDs[rand.IntN(len(frontlineIDs))],
+			InstanceID:       instanceIDs[rand.IntN(len(instanceIDs))],
+			InstanceAddress:  generateIP(),
+			Region:           weightedSelectString(regions),
+			Platform:         "dev",
+			Method:           weightedSelectString(methods),
+			Host:             domain,
+			Path:             paths[rand.IntN(len(paths))],
+			ResponseStatus:   weightedSelectInt32(statuses),
+			UserAgent:        userAgents[rand.IntN(len(userAgents))],
+			IPAddress:        generateIP(),
+			TotalLatency:     int64(totalLatency),
+			InstanceLatency:  int64(instanceLatency),
+			FrontlineLatency: int64(frontlineLatency),
+			QueryString:      "",
+			QueryParams:      make(map[string][]string),
+			RequestHeaders:   []string{},
+			RequestBody:      "",
+			ResponseHeaders:  []string{},
+			ResponseBody:     "",
 		})
 
 		if (i+1)%10000 == 0 {
@@ -277,7 +278,7 @@ func (s *SentinelSeeder) generateRequests(
 	}
 
 	log.Printf("  Buffered all %d requests, waiting for flush...", s.numRequests)
-	s.sentinelRequests.Close()
+	s.frontlineRequests.Close()
 	log.Printf("  All requests sent to ClickHouse")
 	return nil
 }

--- a/cmd/dev/seed/run.go
+++ b/cmd/dev/seed/run.go
@@ -13,7 +13,7 @@ var Cmd = &cli.Command{
 	Commands: []*cli.Command{
 		localCmd,
 		verificationsCmd,
-		sentinelCmd,
+		frontlineCmd,
 		checkpoints.Cmd,
 	},
 }

--- a/pkg/clickhouse/buffer.go
+++ b/pkg/clickhouse/buffer.go
@@ -44,8 +44,8 @@ type BufferConfig struct {
 //
 // Example:
 //
-//	buf := clickhouse.NewBuffer[schema.SentinelRequest](client, "default.sentinel_requests_raw_v1", clickhouse.BufferConfig{
-//	    Name:          "sentinel_requests",
+//	buf := clickhouse.NewBuffer[schema.FrontlineRequest](client, "default.frontline_requests_raw_v1", clickhouse.BufferConfig{
+//	    Name:          "frontline_requests",
 //	    BatchSize:     50_000,
 //	    BufferSize:    50_000,
 //	    FlushInterval: 5 * time.Second,

--- a/pkg/clickhouse/deployment_request_count.go
+++ b/pkg/clickhouse/deployment_request_count.go
@@ -8,31 +8,33 @@ import (
 	"github.com/unkeyed/unkey/pkg/fault"
 )
 
-// GetDeploymentRequestCount queries the sentinel_requests_raw_v1 table for the number of
+// GetDeploymentRequestCount queries the 15-minute request aggregate for the number of
 // requests routed to a specific deployment within a recent time window. This is used to
 // identify idle deployments that can be scaled down to save resources.
 //
-// The query filters on workspace_id, project_id, environment_id, and deployment_id to
-// match the table's sort key, ensuring efficient index usage. The duration is computed
-// relative to the current wall clock time.
+// The idle window is 15-minute granular for this background workflow. We round
+// the lower bound down to the start of the interval so a deployment with
+// traffic in the current partial interval is not considered idle.
 //
 // Returns 0 (not an error) if no requests exist for the deployment in the given window.
 func (c *Client) GetDeploymentRequestCount(ctx context.Context, req GetDeploymentRequestCountRequest) (int64, error) {
 	query := `
-	SELECT toInt64(count()) as count
-	FROM default.sentinel_requests_raw_v1
+	SELECT toInt64(sum(count)) as count
+	FROM default.frontline_requests_per_15m_v1
 	WHERE workspace_id = {workspace_id:String}
 	  AND project_id = {project_id:String}
+	  AND app_id = {app_id:String}
 	  AND environment_id = {environment_id:String}
 	  AND deployment_id = {deployment_id:String}
-	  AND time >= {since_ms:Int64}
+	  AND time >= fromUnixTimestamp64Milli({since_ms:Int64})
 	`
 
-	sinceMs := time.Now().Add(-req.Duration).UnixMilli()
+	sinceMs := time.Now().Add(-req.Duration).Truncate(15 * time.Minute).UnixMilli()
 
 	rows, err := c.conn.Query(ctx, query,
 		ch.Named("workspace_id", req.WorkspaceID),
 		ch.Named("project_id", req.ProjectID),
+		ch.Named("app_id", req.AppID),
 		ch.Named("environment_id", req.EnvironmentID),
 		ch.Named("deployment_id", req.DeploymentID),
 		ch.Named("since_ms", sinceMs),
@@ -62,6 +64,7 @@ func (c *Client) GetDeploymentRequestCount(ctx context.Context, req GetDeploymen
 type GetDeploymentRequestCountRequest struct {
 	WorkspaceID   string
 	ProjectID     string
+	AppID         string
 	EnvironmentID string
 	DeploymentID  string
 

--- a/pkg/clickhouse/migrations/20260623000000.sql
+++ b/pkg/clickhouse/migrations/20260623000000.sql
@@ -1,0 +1,270 @@
+-- Create frontline request storage with the dimensions needed by dashboard
+-- request queries. The old sentinel request tables are intentionally left in
+-- place and will be dropped in a separate cleanup migration.
+
+CREATE TABLE `default`.`frontline_requests_raw_v1` (
+  `request_id` String,
+  `time` Int64 CODEC(Delta, LZ4),
+  `workspace_id` String,
+  `project_id` String,
+  `app_id` String,
+  `environment_id` String,
+  `frontline_id` String,
+  `deployment_id` String,
+  `instance_id` String,
+  `instance_address` String,
+  `region` LowCardinality(String),
+  `platform` LowCardinality(String),
+  `method` LowCardinality(String),
+  `host` String,
+  `path` String,
+  `query_string` String,
+  `query_params` Map(String, Array(String)),
+  `request_headers` Array(String),
+  `request_body` String,
+  `response_status` Int32,
+  `response_headers` Array(String),
+  `response_body` String,
+  `user_agent` String,
+  `ip_address` String,
+  `total_latency` Int64,
+  `instance_latency` Int64,
+  `frontline_latency` Int64,
+  INDEX idx_request_id (`request_id`) TYPE bloom_filter GRANULARITY 1,
+  INDEX idx_deployment_id (`deployment_id`) TYPE bloom_filter GRANULARITY 1,
+  INDEX idx_instance_id (`instance_id`) TYPE bloom_filter GRANULARITY 1,
+  INDEX idx_frontline_id (`frontline_id`) TYPE bloom_filter GRANULARITY 1
+) ENGINE = MergeTree()
+ORDER BY (`workspace_id`, `project_id`, `app_id`, `environment_id`, `time`, `deployment_id`)
+TTL toDateTime(fromUnixTimestamp64Milli(`time`)) + toIntervalDay(7)
+SETTINGS index_granularity = 8192, non_replicated_deduplication_window = 10000;
+
+CREATE TABLE `default`.`frontline_requests_per_minute_v1` (
+  `time` DateTime,
+  `workspace_id` String,
+  `project_id` String,
+  `app_id` String,
+  `environment_id` String,
+  `deployment_id` String,
+  `response_status` Int32,
+  `count` SimpleAggregateFunction(sum, Int64),
+  `latency_p50` AggregateFunction(quantileTDigest(0.5), Float64),
+  `latency_p75` AggregateFunction(quantileTDigest(0.75), Float64),
+  `latency_p90` AggregateFunction(quantileTDigest(0.9), Float64),
+  `latency_p95` AggregateFunction(quantileTDigest(0.95), Float64),
+  `latency_p99` AggregateFunction(quantileTDigest(0.99), Float64)
+) ENGINE = AggregatingMergeTree()
+ORDER BY (`workspace_id`, `project_id`, `app_id`, `environment_id`, `time`, `deployment_id`, `response_status`)
+PARTITION BY toYYYYMM(`time`)
+TTL `time` + INTERVAL 14 DAY DELETE
+SETTINGS index_granularity = 8192;
+
+CREATE TABLE `default`.`frontline_requests_per_5m_v1` (
+  `time` DateTime,
+  `workspace_id` String,
+  `project_id` String,
+  `app_id` String,
+  `environment_id` String,
+  `deployment_id` String,
+  `response_status` Int32,
+  `count` SimpleAggregateFunction(sum, Int64),
+  `latency_p50` AggregateFunction(quantileTDigest(0.5), Float64),
+  `latency_p75` AggregateFunction(quantileTDigest(0.75), Float64),
+  `latency_p90` AggregateFunction(quantileTDigest(0.9), Float64),
+  `latency_p95` AggregateFunction(quantileTDigest(0.95), Float64),
+  `latency_p99` AggregateFunction(quantileTDigest(0.99), Float64)
+) ENGINE = AggregatingMergeTree()
+ORDER BY (`workspace_id`, `project_id`, `app_id`, `environment_id`, `time`, `deployment_id`, `response_status`)
+PARTITION BY toYYYYMM(`time`)
+TTL `time` + INTERVAL 30 DAY DELETE
+SETTINGS index_granularity = 8192;
+
+CREATE TABLE `default`.`frontline_requests_per_15m_v1` (
+  `time` DateTime,
+  `workspace_id` String,
+  `project_id` String,
+  `app_id` String,
+  `environment_id` String,
+  `deployment_id` String,
+  `response_status` Int32,
+  `count` SimpleAggregateFunction(sum, Int64),
+  `latency_p50` AggregateFunction(quantileTDigest(0.5), Float64),
+  `latency_p75` AggregateFunction(quantileTDigest(0.75), Float64),
+  `latency_p90` AggregateFunction(quantileTDigest(0.9), Float64),
+  `latency_p95` AggregateFunction(quantileTDigest(0.95), Float64),
+  `latency_p99` AggregateFunction(quantileTDigest(0.99), Float64)
+) ENGINE = AggregatingMergeTree()
+ORDER BY (`workspace_id`, `project_id`, `app_id`, `environment_id`, `time`, `deployment_id`, `response_status`)
+PARTITION BY toYYYYMM(`time`)
+TTL `time` + INTERVAL 30 DAY DELETE
+SETTINGS index_granularity = 8192;
+
+CREATE TABLE `default`.`frontline_requests_per_hour_v1` (
+  `time` DateTime,
+  `workspace_id` String,
+  `project_id` String,
+  `app_id` String,
+  `environment_id` String,
+  `deployment_id` String,
+  `response_status` Int32,
+  `count` SimpleAggregateFunction(sum, Int64),
+  `latency_p50` AggregateFunction(quantileTDigest(0.5), Float64),
+  `latency_p75` AggregateFunction(quantileTDigest(0.75), Float64),
+  `latency_p90` AggregateFunction(quantileTDigest(0.9), Float64),
+  `latency_p95` AggregateFunction(quantileTDigest(0.95), Float64),
+  `latency_p99` AggregateFunction(quantileTDigest(0.99), Float64)
+) ENGINE = AggregatingMergeTree()
+ORDER BY (`workspace_id`, `project_id`, `app_id`, `environment_id`, `time`, `deployment_id`, `response_status`)
+PARTITION BY toYYYYMM(`time`)
+TTL `time` + INTERVAL 90 DAY DELETE
+SETTINGS index_granularity = 8192;
+
+CREATE TABLE `default`.`frontline_requests_per_day_v1` (
+  `time` DateTime,
+  `workspace_id` String,
+  `project_id` String,
+  `app_id` String,
+  `environment_id` String,
+  `deployment_id` String,
+  `response_status` Int32,
+  `count` SimpleAggregateFunction(sum, Int64),
+  `latency_p50` AggregateFunction(quantileTDigest(0.5), Float64),
+  `latency_p75` AggregateFunction(quantileTDigest(0.75), Float64),
+  `latency_p90` AggregateFunction(quantileTDigest(0.9), Float64),
+  `latency_p95` AggregateFunction(quantileTDigest(0.95), Float64),
+  `latency_p99` AggregateFunction(quantileTDigest(0.99), Float64)
+) ENGINE = AggregatingMergeTree()
+ORDER BY (`workspace_id`, `project_id`, `app_id`, `environment_id`, `time`, `deployment_id`, `response_status`)
+PARTITION BY toYYYYMM(`time`)
+TTL `time` + INTERVAL 365 DAY DELETE
+SETTINGS index_granularity = 8192;
+
+CREATE MATERIALIZED VIEW `default`.`frontline_requests_per_day_mv_v1`
+TO `default`.`frontline_requests_per_day_v1` AS
+SELECT
+  toStartOfDay(`time`) AS `time`,
+  `workspace_id`,
+  `project_id`,
+  `app_id`,
+  `environment_id`,
+  `deployment_id`,
+  `response_status`,
+  sum(`count`) AS `count`,
+  quantileTDigestMergeState(0.5)(`latency_p50`) AS `latency_p50`,
+  quantileTDigestMergeState(0.75)(`latency_p75`) AS `latency_p75`,
+  quantileTDigestMergeState(0.9)(`latency_p90`) AS `latency_p90`,
+  quantileTDigestMergeState(0.95)(`latency_p95`) AS `latency_p95`,
+  quantileTDigestMergeState(0.99)(`latency_p99`) AS `latency_p99`
+FROM `default`.`frontline_requests_per_hour_v1`
+GROUP BY
+  `time`,
+  `workspace_id`,
+  `project_id`,
+  `app_id`,
+  `environment_id`,
+  `deployment_id`,
+  `response_status`;
+
+CREATE MATERIALIZED VIEW `default`.`frontline_requests_per_hour_mv_v1`
+TO `default`.`frontline_requests_per_hour_v1` AS
+SELECT
+  toStartOfHour(`time`) AS `time`,
+  `workspace_id`,
+  `project_id`,
+  `app_id`,
+  `environment_id`,
+  `deployment_id`,
+  `response_status`,
+  sum(`count`) AS `count`,
+  quantileTDigestMergeState(0.5)(`latency_p50`) AS `latency_p50`,
+  quantileTDigestMergeState(0.75)(`latency_p75`) AS `latency_p75`,
+  quantileTDigestMergeState(0.9)(`latency_p90`) AS `latency_p90`,
+  quantileTDigestMergeState(0.95)(`latency_p95`) AS `latency_p95`,
+  quantileTDigestMergeState(0.99)(`latency_p99`) AS `latency_p99`
+FROM `default`.`frontline_requests_per_15m_v1`
+GROUP BY
+  `time`,
+  `workspace_id`,
+  `project_id`,
+  `app_id`,
+  `environment_id`,
+  `deployment_id`,
+  `response_status`;
+
+CREATE MATERIALIZED VIEW `default`.`frontline_requests_per_15m_mv_v1`
+TO `default`.`frontline_requests_per_15m_v1` AS
+SELECT
+  toStartOfInterval(`time`, INTERVAL 15 MINUTE) AS `time`,
+  `workspace_id`,
+  `project_id`,
+  `app_id`,
+  `environment_id`,
+  `deployment_id`,
+  `response_status`,
+  sum(`count`) AS `count`,
+  quantileTDigestMergeState(0.5)(`latency_p50`) AS `latency_p50`,
+  quantileTDigestMergeState(0.75)(`latency_p75`) AS `latency_p75`,
+  quantileTDigestMergeState(0.9)(`latency_p90`) AS `latency_p90`,
+  quantileTDigestMergeState(0.95)(`latency_p95`) AS `latency_p95`,
+  quantileTDigestMergeState(0.99)(`latency_p99`) AS `latency_p99`
+FROM `default`.`frontline_requests_per_5m_v1`
+GROUP BY
+  `time`,
+  `workspace_id`,
+  `project_id`,
+  `app_id`,
+  `environment_id`,
+  `deployment_id`,
+  `response_status`;
+
+CREATE MATERIALIZED VIEW `default`.`frontline_requests_per_5m_mv_v1`
+TO `default`.`frontline_requests_per_5m_v1` AS
+SELECT
+  toStartOfInterval(`time`, INTERVAL 5 MINUTE) AS `time`,
+  `workspace_id`,
+  `project_id`,
+  `app_id`,
+  `environment_id`,
+  `deployment_id`,
+  `response_status`,
+  sum(`count`) AS `count`,
+  quantileTDigestMergeState(0.5)(`latency_p50`) AS `latency_p50`,
+  quantileTDigestMergeState(0.75)(`latency_p75`) AS `latency_p75`,
+  quantileTDigestMergeState(0.9)(`latency_p90`) AS `latency_p90`,
+  quantileTDigestMergeState(0.95)(`latency_p95`) AS `latency_p95`,
+  quantileTDigestMergeState(0.99)(`latency_p99`) AS `latency_p99`
+FROM `default`.`frontline_requests_per_minute_v1`
+GROUP BY
+  `time`,
+  `workspace_id`,
+  `project_id`,
+  `app_id`,
+  `environment_id`,
+  `deployment_id`,
+  `response_status`;
+
+CREATE MATERIALIZED VIEW `default`.`frontline_requests_per_minute_mv_v1`
+TO `default`.`frontline_requests_per_minute_v1` AS
+SELECT
+  toStartOfMinute(fromUnixTimestamp64Milli(`time`)) AS `time`,
+  `workspace_id`,
+  `project_id`,
+  `app_id`,
+  `environment_id`,
+  `deployment_id`,
+  `response_status`,
+  toInt64(count()) AS `count`,
+  quantileTDigestState(0.5)(CAST(`total_latency` AS Float64)) AS `latency_p50`,
+  quantileTDigestState(0.75)(CAST(`total_latency` AS Float64)) AS `latency_p75`,
+  quantileTDigestState(0.9)(CAST(`total_latency` AS Float64)) AS `latency_p90`,
+  quantileTDigestState(0.95)(CAST(`total_latency` AS Float64)) AS `latency_p95`,
+  quantileTDigestState(0.99)(CAST(`total_latency` AS Float64)) AS `latency_p99`
+FROM `default`.`frontline_requests_raw_v1`
+GROUP BY
+  `time`,
+  `workspace_id`,
+  `project_id`,
+  `app_id`,
+  `environment_id`,
+  `deployment_id`,
+  `response_status`;

--- a/pkg/clickhouse/migrations/20260623000001.sql
+++ b/pkg/clickhouse/migrations/20260623000001.sql
@@ -1,0 +1,63 @@
+-- Backfill historical sentinel request rows into the new frontline request
+-- raw table. The legacy table did not store app_id, so historical rows use
+-- the empty string for that dimension. Materialized views on
+-- frontline_requests_raw_v1 populate the new aggregate tables from this insert.
+
+INSERT INTO `default`.`frontline_requests_raw_v1` (
+  `request_id`,
+  `time`,
+  `workspace_id`,
+  `project_id`,
+  `app_id`,
+  `environment_id`,
+  `frontline_id`,
+  `deployment_id`,
+  `instance_id`,
+  `instance_address`,
+  `region`,
+  `platform`,
+  `method`,
+  `host`,
+  `path`,
+  `query_string`,
+  `query_params`,
+  `request_headers`,
+  `request_body`,
+  `response_status`,
+  `response_headers`,
+  `response_body`,
+  `user_agent`,
+  `ip_address`,
+  `total_latency`,
+  `instance_latency`,
+  `frontline_latency`
+)
+SELECT
+  `request_id`,
+  `time`,
+  `workspace_id`,
+  `project_id`,
+  '' AS `app_id`,
+  `environment_id`,
+  `sentinel_id` AS `frontline_id`,
+  `deployment_id`,
+  `instance_id`,
+  `instance_address`,
+  `region`,
+  `platform`,
+  `method`,
+  `host`,
+  `path`,
+  `query_string`,
+  `query_params`,
+  `request_headers`,
+  `request_body`,
+  `response_status`,
+  `response_headers`,
+  `response_body`,
+  `user_agent`,
+  `ip_address`,
+  `total_latency`,
+  `instance_latency`,
+  `sentinel_latency` AS `frontline_latency`
+FROM `default`.`sentinel_requests_raw_v1`;

--- a/pkg/clickhouse/migrations/20260623000002.sql
+++ b/pkg/clickhouse/migrations/20260623000002.sql
@@ -1,0 +1,9 @@
+-- Drop legacy sentinel request storage after services have moved to
+-- frontline_requests_* reads and writes and historical raw rows have been
+-- backfilled.
+
+DROP VIEW IF EXISTS `default`.`sentinel_requests_per_hour_mv_v1`;
+DROP VIEW IF EXISTS `default`.`sentinel_requests_per_15m_mv_v1`;
+DROP TABLE IF EXISTS `default`.`sentinel_requests_per_hour_v1`;
+DROP TABLE IF EXISTS `default`.`sentinel_requests_per_15m_v1`;
+DROP TABLE IF EXISTS `default`.`sentinel_requests_raw_v1`;

--- a/pkg/clickhouse/schema/022_frontline_requests_raw_v1.sql
+++ b/pkg/clickhouse/schema/022_frontline_requests_raw_v1.sql
@@ -1,11 +1,12 @@
-CREATE TABLE sentinel_requests_raw_v1 (
+CREATE TABLE frontline_requests_raw_v1 (
   request_id String,
   -- unix milli
   time Int64 CODEC(Delta, LZ4),
   workspace_id String,
-  environment_id String,
   project_id String,
-  sentinel_id String,
+  app_id String,
+  environment_id String,
+  frontline_id String,
   deployment_id String,
   instance_id String,
   instance_address String,
@@ -32,13 +33,13 @@ CREATE TABLE sentinel_requests_raw_v1 (
   total_latency Int64,
   -- Milliseconds - instance processing time
   instance_latency Int64,
-  -- Milliseconds - sentinel overhead
-  sentinel_latency Int64,
+  -- Milliseconds - frontline overhead
+  frontline_latency Int64,
   INDEX idx_request_id (request_id) TYPE bloom_filter GRANULARITY 1,
   INDEX idx_deployment_id (deployment_id) TYPE bloom_filter GRANULARITY 1,
   INDEX idx_instance_id (instance_id) TYPE bloom_filter GRANULARITY 1,
-  INDEX idx_sentinel_id (sentinel_id) TYPE bloom_filter GRANULARITY 1
+  INDEX idx_frontline_id (frontline_id) TYPE bloom_filter GRANULARITY 1
 ) ENGINE = MergeTree()
-ORDER BY (`workspace_id`, `project_id`, `environment_id`, `time`, `deployment_id`) 
-TTL toDateTime(fromUnixTimestamp64Milli(time)) + toIntervalDay(30) 
+ORDER BY (`workspace_id`, `project_id`, `app_id`, `environment_id`, `time`, `deployment_id`)
+TTL toDateTime(fromUnixTimestamp64Milli(time)) + toIntervalDay(7)
 SETTINGS index_granularity = 8192, non_replicated_deduplication_window = 10000;

--- a/pkg/clickhouse/schema/025_audit_logs_raw_v1.sql
+++ b/pkg/clickhouse/schema/025_audit_logs_raw_v1.sql
@@ -7,7 +7,7 @@
 --
 -- Time fields are stored as Int64 unix-milli for consistency with the rest
 -- of Unkey's CH tables (`time` in key_verifications_raw_v2,
--- sentinel_requests_raw_v1, etc.). Partition and TTL expressions wrap them
+-- frontline_requests_raw_v1, etc.). Partition and TTL expressions wrap them
 -- in fromUnixTimestamp64Milli.
 --
 -- Metadata columns use the native CH JSON type (24.10+). Each JSON column

--- a/pkg/clickhouse/schema/036_frontline_requests_per_minute_v1.sql
+++ b/pkg/clickhouse/schema/036_frontline_requests_per_minute_v1.sql
@@ -1,9 +1,11 @@
-CREATE TABLE sentinel_requests_per_15m_v1 (
+CREATE TABLE frontline_requests_per_minute_v1 (
   time DateTime,
   workspace_id String,
   project_id String,
+  app_id String,
   environment_id String,
   deployment_id String,
+  response_status Int32,
   count SimpleAggregateFunction(sum, Int64),
   latency_p50 AggregateFunction(quantileTDigest(0.5), Float64),
   latency_p75 AggregateFunction(quantileTDigest(0.75), Float64),
@@ -11,29 +13,33 @@ CREATE TABLE sentinel_requests_per_15m_v1 (
   latency_p95 AggregateFunction(quantileTDigest(0.95), Float64),
   latency_p99 AggregateFunction(quantileTDigest(0.99), Float64)
 ) ENGINE = AggregatingMergeTree()
-ORDER BY (workspace_id, project_id, environment_id, deployment_id, time)
+ORDER BY (workspace_id, project_id, app_id, environment_id, time, deployment_id, response_status)
 PARTITION BY toYYYYMM(time)
-TTL time + INTERVAL 30 DAY DELETE
+TTL time + INTERVAL 14 DAY DELETE
 SETTINGS index_granularity = 8192;
 
-CREATE MATERIALIZED VIEW sentinel_requests_per_15m_mv_v1
-TO sentinel_requests_per_15m_v1 AS
+CREATE MATERIALIZED VIEW frontline_requests_per_minute_mv_v1
+TO frontline_requests_per_minute_v1 AS
 SELECT
-  toStartOfInterval(fromUnixTimestamp64Milli(time), INTERVAL 15 MINUTE) AS time,
+  toStartOfMinute(fromUnixTimestamp64Milli(time)) AS time,
   workspace_id,
   project_id,
+  app_id,
   environment_id,
   deployment_id,
+  response_status,
   toInt64(count()) AS count,
   quantileTDigestState(0.5)(CAST(total_latency AS Float64)) AS latency_p50,
   quantileTDigestState(0.75)(CAST(total_latency AS Float64)) AS latency_p75,
   quantileTDigestState(0.9)(CAST(total_latency AS Float64)) AS latency_p90,
   quantileTDigestState(0.95)(CAST(total_latency AS Float64)) AS latency_p95,
   quantileTDigestState(0.99)(CAST(total_latency AS Float64)) AS latency_p99
-FROM sentinel_requests_raw_v1
+FROM frontline_requests_raw_v1
 GROUP BY
   time,
   workspace_id,
   project_id,
+  app_id,
   environment_id,
-  deployment_id;
+  deployment_id,
+  response_status;

--- a/pkg/clickhouse/schema/037_frontline_requests_per_5m_v1.sql
+++ b/pkg/clickhouse/schema/037_frontline_requests_per_5m_v1.sql
@@ -1,0 +1,45 @@
+CREATE TABLE frontline_requests_per_5m_v1 (
+  time DateTime,
+  workspace_id String,
+  project_id String,
+  app_id String,
+  environment_id String,
+  deployment_id String,
+  response_status Int32,
+  count SimpleAggregateFunction(sum, Int64),
+  latency_p50 AggregateFunction(quantileTDigest(0.5), Float64),
+  latency_p75 AggregateFunction(quantileTDigest(0.75), Float64),
+  latency_p90 AggregateFunction(quantileTDigest(0.9), Float64),
+  latency_p95 AggregateFunction(quantileTDigest(0.95), Float64),
+  latency_p99 AggregateFunction(quantileTDigest(0.99), Float64)
+) ENGINE = AggregatingMergeTree()
+ORDER BY (workspace_id, project_id, app_id, environment_id, time, deployment_id, response_status)
+PARTITION BY toYYYYMM(time)
+TTL time + INTERVAL 30 DAY DELETE
+SETTINGS index_granularity = 8192;
+
+CREATE MATERIALIZED VIEW frontline_requests_per_5m_mv_v1
+TO frontline_requests_per_5m_v1 AS
+SELECT
+  toStartOfInterval(time, INTERVAL 5 MINUTE) AS time,
+  workspace_id,
+  project_id,
+  app_id,
+  environment_id,
+  deployment_id,
+  response_status,
+  sum(count) AS count,
+  quantileTDigestMergeState(0.5)(latency_p50) AS latency_p50,
+  quantileTDigestMergeState(0.75)(latency_p75) AS latency_p75,
+  quantileTDigestMergeState(0.9)(latency_p90) AS latency_p90,
+  quantileTDigestMergeState(0.95)(latency_p95) AS latency_p95,
+  quantileTDigestMergeState(0.99)(latency_p99) AS latency_p99
+FROM frontline_requests_per_minute_v1
+GROUP BY
+  time,
+  workspace_id,
+  project_id,
+  app_id,
+  environment_id,
+  deployment_id,
+  response_status;

--- a/pkg/clickhouse/schema/038_frontline_requests_per_15m_v1.sql
+++ b/pkg/clickhouse/schema/038_frontline_requests_per_15m_v1.sql
@@ -1,0 +1,45 @@
+CREATE TABLE frontline_requests_per_15m_v1 (
+  time DateTime,
+  workspace_id String,
+  project_id String,
+  app_id String,
+  environment_id String,
+  deployment_id String,
+  response_status Int32,
+  count SimpleAggregateFunction(sum, Int64),
+  latency_p50 AggregateFunction(quantileTDigest(0.5), Float64),
+  latency_p75 AggregateFunction(quantileTDigest(0.75), Float64),
+  latency_p90 AggregateFunction(quantileTDigest(0.9), Float64),
+  latency_p95 AggregateFunction(quantileTDigest(0.95), Float64),
+  latency_p99 AggregateFunction(quantileTDigest(0.99), Float64)
+) ENGINE = AggregatingMergeTree()
+ORDER BY (workspace_id, project_id, app_id, environment_id, time, deployment_id, response_status)
+PARTITION BY toYYYYMM(time)
+TTL time + INTERVAL 30 DAY DELETE
+SETTINGS index_granularity = 8192;
+
+CREATE MATERIALIZED VIEW frontline_requests_per_15m_mv_v1
+TO frontline_requests_per_15m_v1 AS
+SELECT
+  toStartOfInterval(time, INTERVAL 15 MINUTE) AS time,
+  workspace_id,
+  project_id,
+  app_id,
+  environment_id,
+  deployment_id,
+  response_status,
+  sum(count) AS count,
+  quantileTDigestMergeState(0.5)(latency_p50) AS latency_p50,
+  quantileTDigestMergeState(0.75)(latency_p75) AS latency_p75,
+  quantileTDigestMergeState(0.9)(latency_p90) AS latency_p90,
+  quantileTDigestMergeState(0.95)(latency_p95) AS latency_p95,
+  quantileTDigestMergeState(0.99)(latency_p99) AS latency_p99
+FROM frontline_requests_per_5m_v1
+GROUP BY
+  time,
+  workspace_id,
+  project_id,
+  app_id,
+  environment_id,
+  deployment_id,
+  response_status;

--- a/pkg/clickhouse/schema/039_frontline_requests_per_hour_v1.sql
+++ b/pkg/clickhouse/schema/039_frontline_requests_per_hour_v1.sql
@@ -1,0 +1,45 @@
+CREATE TABLE frontline_requests_per_hour_v1 (
+  time DateTime,
+  workspace_id String,
+  project_id String,
+  app_id String,
+  environment_id String,
+  deployment_id String,
+  response_status Int32,
+  count SimpleAggregateFunction(sum, Int64),
+  latency_p50 AggregateFunction(quantileTDigest(0.5), Float64),
+  latency_p75 AggregateFunction(quantileTDigest(0.75), Float64),
+  latency_p90 AggregateFunction(quantileTDigest(0.9), Float64),
+  latency_p95 AggregateFunction(quantileTDigest(0.95), Float64),
+  latency_p99 AggregateFunction(quantileTDigest(0.99), Float64)
+) ENGINE = AggregatingMergeTree()
+ORDER BY (workspace_id, project_id, app_id, environment_id, time, deployment_id, response_status)
+PARTITION BY toYYYYMM(time)
+TTL time + INTERVAL 90 DAY DELETE
+SETTINGS index_granularity = 8192;
+
+CREATE MATERIALIZED VIEW frontline_requests_per_hour_mv_v1
+TO frontline_requests_per_hour_v1 AS
+SELECT
+  toStartOfHour(time) AS time,
+  workspace_id,
+  project_id,
+  app_id,
+  environment_id,
+  deployment_id,
+  response_status,
+  sum(count) AS count,
+  quantileTDigestMergeState(0.5)(latency_p50) AS latency_p50,
+  quantileTDigestMergeState(0.75)(latency_p75) AS latency_p75,
+  quantileTDigestMergeState(0.9)(latency_p90) AS latency_p90,
+  quantileTDigestMergeState(0.95)(latency_p95) AS latency_p95,
+  quantileTDigestMergeState(0.99)(latency_p99) AS latency_p99
+FROM frontline_requests_per_15m_v1
+GROUP BY
+  time,
+  workspace_id,
+  project_id,
+  app_id,
+  environment_id,
+  deployment_id,
+  response_status;

--- a/pkg/clickhouse/schema/040_frontline_requests_per_day_v1.sql
+++ b/pkg/clickhouse/schema/040_frontline_requests_per_day_v1.sql
@@ -1,0 +1,45 @@
+CREATE TABLE frontline_requests_per_day_v1 (
+  time DateTime,
+  workspace_id String,
+  project_id String,
+  app_id String,
+  environment_id String,
+  deployment_id String,
+  response_status Int32,
+  count SimpleAggregateFunction(sum, Int64),
+  latency_p50 AggregateFunction(quantileTDigest(0.5), Float64),
+  latency_p75 AggregateFunction(quantileTDigest(0.75), Float64),
+  latency_p90 AggregateFunction(quantileTDigest(0.9), Float64),
+  latency_p95 AggregateFunction(quantileTDigest(0.95), Float64),
+  latency_p99 AggregateFunction(quantileTDigest(0.99), Float64)
+) ENGINE = AggregatingMergeTree()
+ORDER BY (workspace_id, project_id, app_id, environment_id, time, deployment_id, response_status)
+PARTITION BY toYYYYMM(time)
+TTL time + INTERVAL 365 DAY DELETE
+SETTINGS index_granularity = 8192;
+
+CREATE MATERIALIZED VIEW frontline_requests_per_day_mv_v1
+TO frontline_requests_per_day_v1 AS
+SELECT
+  toStartOfDay(time) AS time,
+  workspace_id,
+  project_id,
+  app_id,
+  environment_id,
+  deployment_id,
+  response_status,
+  sum(count) AS count,
+  quantileTDigestMergeState(0.5)(latency_p50) AS latency_p50,
+  quantileTDigestMergeState(0.75)(latency_p75) AS latency_p75,
+  quantileTDigestMergeState(0.9)(latency_p90) AS latency_p90,
+  quantileTDigestMergeState(0.95)(latency_p95) AS latency_p95,
+  quantileTDigestMergeState(0.99)(latency_p99) AS latency_p99
+FROM frontline_requests_per_hour_v1
+GROUP BY
+  time,
+  workspace_id,
+  project_id,
+  app_id,
+  environment_id,
+  deployment_id,
+  response_status;

--- a/pkg/clickhouse/schema/types.go
+++ b/pkg/clickhouse/schema/types.go
@@ -278,36 +278,37 @@ type InstanceEventV1 struct {
 	Attributes string `ch:"attributes" json:"attributes"`
 }
 
-// SentinelRequest represents the v1 sentinel request raw table structure.
-// This tracks requests routed through sentinel proxy to deployment instances
+// FrontlineRequest represents the v1 frontline request raw table structure.
+// This tracks requests routed through frontline proxy to deployment instances
 // with deployment routing, performance breakdown, and error categorization.
-type SentinelRequest struct {
-	RequestID       string              `ch:"request_id" json:"request_id"`
-	Time            int64               `ch:"time" json:"time"`
-	WorkspaceID     string              `ch:"workspace_id" json:"workspace_id"`
-	EnvironmentID   string              `ch:"environment_id" json:"environment_id"`
-	ProjectID       string              `ch:"project_id" json:"project_id"`
-	SentinelID      string              `ch:"sentinel_id" json:"sentinel_id"`
-	DeploymentID    string              `ch:"deployment_id" json:"deployment_id"`
-	InstanceID      string              `ch:"instance_id" json:"instance_id"`
-	InstanceAddress string              `ch:"instance_address" json:"instance_address"`
-	Region          string              `ch:"region" json:"region"`
-	Platform        string              `ch:"platform" json:"platform"`
-	Method          string              `ch:"method" json:"method"`
-	Host            string              `ch:"host" json:"host"`
-	Path            string              `ch:"path" json:"path"`
-	QueryString     string              `ch:"query_string" json:"query_string"`
-	QueryParams     map[string][]string `ch:"query_params" json:"query_params"`
-	RequestHeaders  []string            `ch:"request_headers" json:"request_headers"`
-	RequestBody     string              `ch:"request_body" json:"request_body"`
-	ResponseStatus  int32               `ch:"response_status" json:"response_status"`
-	ResponseHeaders []string            `ch:"response_headers" json:"response_headers"`
-	ResponseBody    string              `ch:"response_body" json:"response_body"`
-	UserAgent       string              `ch:"user_agent" json:"user_agent"`
-	IPAddress       string              `ch:"ip_address" json:"ip_address"`
-	TotalLatency    int64               `ch:"total_latency" json:"total_latency"`
-	InstanceLatency int64               `ch:"instance_latency" json:"instance_latency"`
-	SentinelLatency int64               `ch:"sentinel_latency" json:"sentinel_latency"`
+type FrontlineRequest struct {
+	RequestID        string              `ch:"request_id" json:"request_id"`
+	Time             int64               `ch:"time" json:"time"`
+	WorkspaceID      string              `ch:"workspace_id" json:"workspace_id"`
+	ProjectID        string              `ch:"project_id" json:"project_id"`
+	AppID            string              `ch:"app_id" json:"app_id"`
+	EnvironmentID    string              `ch:"environment_id" json:"environment_id"`
+	FrontlineID      string              `ch:"frontline_id" json:"frontline_id"`
+	DeploymentID     string              `ch:"deployment_id" json:"deployment_id"`
+	InstanceID       string              `ch:"instance_id" json:"instance_id"`
+	InstanceAddress  string              `ch:"instance_address" json:"instance_address"`
+	Region           string              `ch:"region" json:"region"`
+	Platform         string              `ch:"platform" json:"platform"`
+	Method           string              `ch:"method" json:"method"`
+	Host             string              `ch:"host" json:"host"`
+	Path             string              `ch:"path" json:"path"`
+	QueryString      string              `ch:"query_string" json:"query_string"`
+	QueryParams      map[string][]string `ch:"query_params" json:"query_params"`
+	RequestHeaders   []string            `ch:"request_headers" json:"request_headers"`
+	RequestBody      string              `ch:"request_body" json:"request_body"`
+	ResponseStatus   int32               `ch:"response_status" json:"response_status"`
+	ResponseHeaders  []string            `ch:"response_headers" json:"response_headers"`
+	ResponseBody     string              `ch:"response_body" json:"response_body"`
+	UserAgent        string              `ch:"user_agent" json:"user_agent"`
+	IPAddress        string              `ch:"ip_address" json:"ip_address"`
+	TotalLatency     int64               `ch:"total_latency" json:"total_latency"`
+	InstanceLatency  int64               `ch:"instance_latency" json:"instance_latency"`
+	FrontlineLatency int64               `ch:"frontline_latency" json:"frontline_latency"`
 }
 
 // AuditLogV1 represents one logical audit event in audit_logs_raw_v1.

--- a/pkg/uid/prefix.go
+++ b/pkg/uid/prefix.go
@@ -19,7 +19,7 @@ const (
 	AuditLogPrefix            Prefix = "log"
 	CorrelationPrefix         Prefix = "cor"
 	InstancePrefix            Prefix = "ins"
-	SentinelPrefix            Prefix = "s"
+	FrontlinePrefix           Prefix = "fl"
 	CiliumNetworkPolicyPrefix Prefix = "net"
 	ClusterPrefix             Prefix = "cls"
 	RegionPrefix              Prefix = "rgn"

--- a/svc/ctrl/integration/seed/clickhouse.go
+++ b/svc/ctrl/integration/seed/clickhouse.go
@@ -235,44 +235,45 @@ func (s *ClickHouseSeeder) insertVerificationsForKeyChunk(
 	return nil
 }
 
-// InsertSentinelRequests inserts sentinel request records for a workspace.
-func (s *ClickHouseSeeder) InsertSentinelRequests(ctx context.Context, workspaceID, projectID, environmentID, deploymentID string, count int, timestamp time.Time) {
+// InsertFrontlineRequests inserts frontline request records for a workspace.
+func (s *ClickHouseSeeder) InsertFrontlineRequests(ctx context.Context, workspaceID, projectID, appID, environmentID, deploymentID string, count int, timestamp time.Time) {
 	const batchSize = 10_000
 	for i := 0; i < count; i += batchSize {
 		batchCount := min(batchSize, count-i)
-		requests := make([]schema.SentinelRequest, batchCount)
+		requests := make([]schema.FrontlineRequest, batchCount)
 		for j := range batchCount {
-			requests[j] = schema.SentinelRequest{
-				RequestID:       uid.New(uid.RequestPrefix),
-				Time:            timestamp.Add(time.Duration(i+j) * time.Millisecond).UnixMilli(),
-				WorkspaceID:     workspaceID,
-				ProjectID:       projectID,
-				EnvironmentID:   environmentID,
-				DeploymentID:    deploymentID,
-				SentinelID:      uid.New(uid.SentinelPrefix),
-				InstanceID:      uid.New(uid.InstancePrefix),
-				InstanceAddress: "10.0.0.1:8080",
-				Region:          "local",
-				Platform:        "dev",
-				Method:          "GET",
-				Host:            "test.example.com",
-				Path:            "/",
-				QueryString:     "",
-				QueryParams:     map[string][]string{},
-				RequestHeaders:  []string{},
-				RequestBody:     "",
-				ResponseStatus:  200,
-				ResponseHeaders: []string{},
-				ResponseBody:    "",
-				UserAgent:       "test-agent",
-				IPAddress:       "127.0.0.1",
-				TotalLatency:    10,
-				InstanceLatency: 8,
-				SentinelLatency: 2,
+			requests[j] = schema.FrontlineRequest{
+				RequestID:        uid.New(uid.RequestPrefix),
+				Time:             timestamp.Add(time.Duration(i+j) * time.Millisecond).UnixMilli(),
+				WorkspaceID:      workspaceID,
+				ProjectID:        projectID,
+				AppID:            appID,
+				EnvironmentID:    environmentID,
+				DeploymentID:     deploymentID,
+				FrontlineID:      uid.New(uid.FrontlinePrefix),
+				InstanceID:       uid.New(uid.InstancePrefix),
+				InstanceAddress:  "10.0.0.1:8080",
+				Region:           "local",
+				Platform:         "dev",
+				Method:           "GET",
+				Host:             "test.example.com",
+				Path:             "/",
+				QueryString:      "",
+				QueryParams:      map[string][]string{},
+				RequestHeaders:   []string{},
+				RequestBody:      "",
+				ResponseStatus:   200,
+				ResponseHeaders:  []string{},
+				ResponseBody:     "",
+				UserAgent:        "test-agent",
+				IPAddress:        "127.0.0.1",
+				TotalLatency:     10,
+				InstanceLatency:  8,
+				FrontlineLatency: 2,
 			}
 		}
 
-		batch, err := s.conn.PrepareBatch(ctx, "INSERT INTO default.sentinel_requests_raw_v1")
+		batch, err := s.conn.PrepareBatch(ctx, "INSERT INTO default.frontline_requests_raw_v1")
 		require.NoError(s.t, err)
 
 		for _, r := range requests {

--- a/svc/ctrl/worker/deploy/scale_down_idle_preview_deployments.go
+++ b/svc/ctrl/worker/deploy/scale_down_idle_preview_deployments.go
@@ -66,6 +66,7 @@ func (w *Workflow) ScaleDownIdlePreviewDeployments(ctx restate.ObjectContext, re
 					return w.clickhouse.GetDeploymentRequestCount(runCtx, clickhouse.GetDeploymentRequestCountRequest{
 						WorkspaceID:   deployment.WorkspaceID,
 						ProjectID:     deployment.ProjectID,
+						AppID:         deployment.AppID,
 						EnvironmentID: deployment.EnvironmentID,
 						DeploymentID:  deployment.ID,
 						Duration:      idleTime,

--- a/svc/ctrl/worker/deploy/scale_down_idle_preview_deployments_test.go
+++ b/svc/ctrl/worker/deploy/scale_down_idle_preview_deployments_test.go
@@ -104,7 +104,7 @@ func TestScaleDownIdlePreviewDeployments_DoesNotScaleDownDeploymentWithRecentReq
 		UpdatedAt:     oldUpdatedAt,
 	})
 
-	h.ClickHouseSeed.InsertSentinelRequests(h.Ctx, ws.ID, project.ID, env.ID, dep.ID, 10, time.Now().Add(-1*time.Hour))
+	h.ClickHouseSeed.InsertFrontlineRequests(h.Ctx, ws.ID, project.ID, app.ID, env.ID, dep.ID, 10, time.Now().Add(-1*time.Hour))
 
 	triggerScaleDown(t, h)
 
@@ -365,7 +365,7 @@ func TestScaleDownIdlePreviewDeployments_HandlesMultipleDeploymentsAcrossMultipl
 			CreatedAt:     oldTime,
 			UpdatedAt:     oldUpdatedAt,
 		})
-		h.ClickHouseSeed.InsertSentinelRequests(h.Ctx, ws.ID, project.ID, env.ID, active.ID, 5, time.Now().Add(-30*time.Minute))
+		h.ClickHouseSeed.InsertFrontlineRequests(h.Ctx, ws.ID, project.ID, app.ID, env.ID, active.ID, 5, time.Now().Add(-30*time.Minute))
 		activeDeployments = append(activeDeployments, active)
 	}
 

--- a/svc/frontline/internal/proxy/tracking.go
+++ b/svc/frontline/internal/proxy/tracking.go
@@ -20,25 +20,26 @@ import (
 // Cross-region requests do not populate tracking — the peer frontline writes
 // its own ClickHouse row.
 type RequestTracking struct {
-	// Set by handler before proxy
+	// Set by the handler before proxying.
 	RequestID     string
 	StartTime     time.Time
 	DeploymentID  string
 	WorkspaceID   string
-	EnvironmentID string
 	ProjectID     string
+	AppID         string
+	EnvironmentID string
 
-	// (Re)set by handler before each ForwardToInstance attempt
+	// Reset by the handler before each ForwardToInstance attempt.
 	InstanceID string
 	Address    string
 
 	// Populated by a handler-side TeeReader as the upstream drains the body.
 	RequestBody []byte
 
-	// Set by proxy on dispatch (Director callback)
+	// Set by proxy on dispatch through the Director callback.
 	InstanceStart time.Time
 
-	// Set by proxy once the upstream response stream completes
+	// Set by proxy once the upstream response stream completes.
 	InstanceEnd  time.Time
 	ResponseBody []byte
 }

--- a/svc/frontline/internal/router/interface.go
+++ b/svc/frontline/internal/router/interface.go
@@ -36,6 +36,7 @@ type RouteDecision struct {
 	EnvironmentID       string
 	WorkspaceID         string
 	ProjectID           string
+	AppID               string
 	LocalInstances      []db.FindInstancesByDeploymentIDRow
 	RemoteRegionAddress string
 	UpstreamProtocol    db.DeploymentsUpstreamProtocol

--- a/svc/frontline/internal/router/routing.go
+++ b/svc/frontline/internal/router/routing.go
@@ -99,6 +99,7 @@ func (s *service) selectDestination(
 			EnvironmentID:       route.EnvironmentID,
 			WorkspaceID:         localRunning[0].WorkspaceID,
 			ProjectID:           localRunning[0].ProjectID,
+			AppID:               localRunning[0].AppID,
 			UpstreamProtocol:    route.UpstreamProtocol,
 			Policies:            policies,
 			LocalInstances:      localRunning,

--- a/svc/frontline/middleware/clickhouse_logging.go
+++ b/svc/frontline/middleware/clickhouse_logging.go
@@ -18,7 +18,7 @@ import (
 // during proxy execution; this middleware reads it back and emits the row
 // after next() returns. Cross-region requests do not populate tracking and
 // are skipped — the peer frontline writes its own row.
-func WithClickHouseLogging(buf *batch.BatchProcessor[schema.SentinelRequest], clk clock.Clock, frontlineID, region, platform string) zen.Middleware {
+func WithClickHouseLogging(buf *batch.BatchProcessor[schema.FrontlineRequest], clk clock.Clock, frontlineID, region, platform string) zen.Middleware {
 	return func(next zen.HandleFunc) zen.HandleFunc {
 		return func(ctx context.Context, s *zen.Session) error {
 			//nolint:exhaustruct
@@ -48,33 +48,34 @@ func WithClickHouseLogging(buf *batch.BatchProcessor[schema.SentinelRequest], cl
 
 			req := s.Request()
 
-			buf.Buffer(schema.SentinelRequest{
-				RequestID:       tracking.RequestID,
-				Time:            tracking.StartTime.UnixMilli(),
-				WorkspaceID:     tracking.WorkspaceID,
-				EnvironmentID:   tracking.EnvironmentID,
-				ProjectID:       tracking.ProjectID,
-				SentinelID:      frontlineID,
-				DeploymentID:    tracking.DeploymentID,
-				InstanceID:      tracking.InstanceID,
-				InstanceAddress: tracking.Address,
-				Region:          region,
-				Platform:        platform,
-				Method:          strings.ToUpper(req.Method),
-				Host:            req.Host,
-				Path:            req.URL.Path,
-				QueryString:     req.URL.RawQuery,
-				QueryParams:     req.URL.Query(),
-				RequestHeaders:  formatHeaders(req.Header),
-				RequestBody:     unsafe.String(unsafe.SliceData(tracking.RequestBody), len(tracking.RequestBody)),
-				ResponseStatus:  int32(s.StatusCode()),
-				ResponseHeaders: formatHeaders(s.ResponseWriter().Header()),
-				ResponseBody:    unsafe.String(unsafe.SliceData(tracking.ResponseBody), len(tracking.ResponseBody)),
-				UserAgent:       req.UserAgent(),
-				IPAddress:       s.Location(),
-				TotalLatency:    totalLatency,
-				InstanceLatency: instanceLatency,
-				SentinelLatency: frontlineLatency,
+			buf.Buffer(schema.FrontlineRequest{
+				RequestID:        tracking.RequestID,
+				Time:             tracking.StartTime.UnixMilli(),
+				WorkspaceID:      tracking.WorkspaceID,
+				ProjectID:        tracking.ProjectID,
+				AppID:            tracking.AppID,
+				EnvironmentID:    tracking.EnvironmentID,
+				FrontlineID:      frontlineID,
+				DeploymentID:     tracking.DeploymentID,
+				InstanceID:       tracking.InstanceID,
+				InstanceAddress:  tracking.Address,
+				Region:           region,
+				Platform:         platform,
+				Method:           strings.ToUpper(req.Method),
+				Host:             req.Host,
+				Path:             req.URL.Path,
+				QueryString:      req.URL.RawQuery,
+				QueryParams:      req.URL.Query(),
+				RequestHeaders:   formatHeaders(req.Header),
+				RequestBody:      unsafe.String(unsafe.SliceData(tracking.RequestBody), len(tracking.RequestBody)),
+				ResponseStatus:   int32(s.StatusCode()),
+				ResponseHeaders:  formatHeaders(s.ResponseWriter().Header()),
+				ResponseBody:     unsafe.String(unsafe.SliceData(tracking.ResponseBody), len(tracking.ResponseBody)),
+				UserAgent:        req.UserAgent(),
+				IPAddress:        s.Location(),
+				TotalLatency:     totalLatency,
+				InstanceLatency:  instanceLatency,
+				FrontlineLatency: frontlineLatency,
 			})
 
 			return err

--- a/svc/frontline/routes/proxy/handler.go
+++ b/svc/frontline/routes/proxy/handler.go
@@ -64,8 +64,9 @@ func (h *Handler) Handle(ctx context.Context, sess *zen.Session) error {
 	tracking.RequestID = sess.RequestID()
 	tracking.DeploymentID = decision.DeploymentID
 	tracking.WorkspaceID = decision.WorkspaceID
-	tracking.EnvironmentID = decision.EnvironmentID
 	tracking.ProjectID = decision.ProjectID
+	tracking.AppID = decision.AppID
+	tracking.EnvironmentID = decision.EnvironmentID
 
 	// Evaluate policies before forwarding. The edge middleware has already
 	// stripped any client-supplied X-Unkey-Principal header; if KeyAuth

--- a/svc/frontline/routes/services.go
+++ b/svc/frontline/routes/services.go
@@ -27,7 +27,6 @@ type Services struct {
 	ErrorPageRenderer errorpage.Renderer
 	RequestTimeout    time.Duration
 	// FrontlineRequests buffers per-request analytics for ClickHouse on the
-	// local-instance path. Carries the same schema sentinel used so existing
-	// dashboards and materialized views keep working through the cutover.
-	FrontlineRequests *batch.BatchProcessor[schema.SentinelRequest]
+	// local-instance path.
+	FrontlineRequests *batch.BatchProcessor[schema.FrontlineRequest]
 }

--- a/svc/frontline/run.go
+++ b/svc/frontline/run.go
@@ -210,7 +210,7 @@ func Run(ctx context.Context, cfg Config) error {
 	}
 	r.Defer(engineDatabase.Close)
 
-	frontlineRequests := batch.NewNoop[schema.SentinelRequest]()
+	frontlineRequests := batch.NewNoop[schema.FrontlineRequest]()
 	keyVerifications := batch.NewNoop[schema.KeyVerification]()
 
 	var chClient *clickhouse.Client
@@ -222,8 +222,8 @@ func Run(ctx context.Context, cfg Config) error {
 			return fmt.Errorf("unable to create clickhouse: %w", err)
 		}
 
-		frontlineRequests = clickhouse.NewBuffer[schema.SentinelRequest](chClient, "default.sentinel_requests_raw_v1", clickhouse.BufferConfig{
-			Name:          "sentinel_requests",
+		frontlineRequests = clickhouse.NewBuffer[schema.FrontlineRequest](chClient, "default.frontline_requests_raw_v1", clickhouse.BufferConfig{
+			Name:          "frontline_requests",
 			BatchSize:     cfg.ClickHouse.BatchSize,
 			BufferSize:    cfg.ClickHouse.BufferSize,
 			FlushInterval: 5 * time.Second,

--- a/web/internal/clickhouse/src/sentinel.ts
+++ b/web/internal/clickhouse/src/sentinel.ts
@@ -7,8 +7,8 @@ const TIMESERIES_INTERVAL_SECONDS = TIMESERIES_INTERVAL_MINUTES * 60;
 const CURRENT_RPS_WINDOW_MINUTES = 15;
 const CURRENT_RPS_WINDOW_MS = CURRENT_RPS_WINDOW_MINUTES * 60 * 1000;
 
-const TABLE = "default.sentinel_requests_raw_v1";
-const MV_TABLE = "default.sentinel_requests_per_15m_v1";
+const TABLE = "default.frontline_requests_raw_v1";
+const MV_TABLE = "default.frontline_requests_per_15m_v1";
 
 const SQL = {
   deploymentFilter: `
@@ -184,7 +184,7 @@ export function getSentinelLogs(ch: Querier) {
     const logsQuery = ch.query({
       query: `
         SELECT request_id, time, deployment_id, region, method, path, host,
-               response_status, total_latency, instance_latency, sentinel_latency,
+               response_status, total_latency, instance_latency, frontline_latency AS sentinel_latency,
                query_string, query_params, request_headers, request_body,
                response_headers, response_body, user_agent, ip_address
         FROM ${TABLE}


### PR DESCRIPTION
We forgot to add the `response_status` to the aggregated sentinel views and fixing that got me down this rabbit hole of also renaming them and adding more granularities for our metrics pages later.


I've settled on these tables with the following TTLs:
```
- raw:  7d
- 1m:   14d
- 5m:   30d
- 15m:  30d
- hour: 90d
- day:  365d
``` 

I also changed the sort key to be `workspaceId, time, ..` because we use workspaceID and time on every single query. Project and apps are probably also present on most, but not guaranteed.


The idea is to 
1. run these migrations first to create new tables
2. then deploy frontline
3. then backfill the data
4. finally remove the old tables