### PR TITLE
Add root directory autocomplete

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/settings/components/build-settings/root-directory-settings.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/settings/components/build-settings/root-directory-settings.tsx
@@ -1,6 +1,7 @@
+import { FormCombobox } from "@/components/ui/form-combobox";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { FolderLink } from "@unkey/icons";
-import { FormInput } from "@unkey/ui";
+import { useMemo } from "react";
 import { useForm, useWatch } from "react-hook-form";
 import { z } from "zod";
 import { useEnvironmentSettings } from "../../environment-provider";
@@ -17,10 +18,9 @@ export const RootDirectory = () => {
   const { settings, variant } = useEnvironmentSettings();
   const { dockerContext: defaultValue } = settings;
   const updateAllEnvironments = useUpdateAllEnvironments();
-  const { branch, validatePath, findCaseInsensitiveMatch } = useRepoTree();
+  const { branch, validatePath, findCaseInsensitiveMatch, getDirectories } = useRepoTree();
 
   const {
-    register,
     handleSubmit,
     formState: { isValid, isSubmitting, errors },
     control,
@@ -31,11 +31,30 @@ export const RootDirectory = () => {
     defaultValues: { dockerContext: defaultValue },
   });
 
-  const currentDockerContext = useWatch({ control, name: "dockerContext" });
+  const currentDockerContext = useWatch({ control, name: "dockerContext", defaultValue });
 
   const validation = validatePath(currentDockerContext, "tree");
   const caseMatch =
     validation === "invalid" ? findCaseInsensitiveMatch(currentDockerContext, "tree") : null;
+  const detectedDirectories = getDirectories();
+
+  const options = useMemo(
+    () => [
+      {
+        label: <span className="text-gray-11">Repository root (.)</span>,
+        selectedLabel: ".",
+        value: ".",
+        searchValue: "repository root .",
+      },
+      ...detectedDirectories.map((path) => ({
+        label: path,
+        selectedLabel: path,
+        value: path,
+        searchValue: path,
+      })),
+    ],
+    [detectedDirectories],
+  );
 
   const saveState = resolveSaveState([
     [isSubmitting, { status: "saving" }],
@@ -89,17 +108,24 @@ export const RootDirectory = () => {
       autoSave={variant === "onboarding"}
     >
       <SettingField>
-        <FormInput
+        <FormCombobox
           label="Root directory"
           requirement="required"
           description={
             warningMessage ??
             "Unkey detects and builds your app from this directory. For Dockerfile builds it is the build context. Changes apply on next deploy."
           }
+          options={options}
+          wrapperClassName="max-w-[calc(var(--setting-w)-1rem)]"
+          className="max-w-[calc(var(--setting-w)-1rem)]"
+          value={currentDockerContext}
+          onSelect={(val) => setValue("dockerContext", val, { shouldValidate: true })}
+          creatable
+          searchPlaceholder="Search or type a directory..."
+          emptyMessage={<div className="mt-2">No directories detected in repository</div>}
           placeholder="."
           error={errors.dockerContext?.message}
           variant={inputVariant}
-          {...register("dockerContext")}
         />
       </SettingField>
     </FormSettingCard>

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/settings/components/build-settings/root-directory-settings.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/settings/components/build-settings/root-directory-settings.tsx
@@ -14,6 +14,19 @@ const rootDirectorySchema = z.object({
   dockerContext: z.string(),
 });
 
+function normalizeRootDirectory(value: string): string {
+  const normalized = value
+    .trim()
+    .replace(/^(\.\/)+/, "")
+    .replace(/^\/+|\/+$/g, "");
+  return normalized || ".";
+}
+
+function formatRootDirectory(value: string): string {
+  const normalized = normalizeRootDirectory(value);
+  return normalized === "." ? "Repository root (.)" : normalized;
+}
+
 export const RootDirectory = () => {
   const { settings, variant } = useEnvironmentSettings();
   const { dockerContext: defaultValue } = settings;
@@ -42,7 +55,7 @@ export const RootDirectory = () => {
     () => [
       {
         label: <span className="text-gray-11">Repository root (.)</span>,
-        selectedLabel: ".",
+        selectedLabel: "Repository root (.)",
         value: ".",
         searchValue: "repository root .",
       },
@@ -102,7 +115,7 @@ export const RootDirectory = () => {
       icon={<FolderLink className="text-gray-12" iconSize="xl-medium" />}
       title="Root directory"
       description="The directory your app lives in. Unkey builds from here. Set it when your app is in a subdirectory (e.g., services/api)."
-      displayValue={defaultValue || "."}
+      displayValue={formatRootDirectory(defaultValue)}
       onSubmit={handleSubmit(onSubmit)}
       saveState={saveState}
       autoSave={variant === "onboarding"}
@@ -119,7 +132,9 @@ export const RootDirectory = () => {
           wrapperClassName="max-w-[calc(var(--setting-w)-1rem)]"
           className="max-w-[calc(var(--setting-w)-1rem)]"
           value={currentDockerContext}
-          onSelect={(val) => setValue("dockerContext", val, { shouldValidate: true })}
+          onSelect={(val) =>
+            setValue("dockerContext", normalizeRootDirectory(val), { shouldValidate: true })
+          }
           creatable
           searchPlaceholder="Search or type a directory..."
           emptyMessage={<div className="mt-2">No directories detected in repository</div>}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/settings/components/build-settings/use-repo-tree.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/settings/components/build-settings/use-repo-tree.ts
@@ -128,6 +128,13 @@ export function useRepoTree() {
       });
   }
 
+  function getDirectories(): string[] {
+    if (!tree) {
+      return [];
+    }
+    return tree.filter((entry) => entry.type === "tree").map((entry) => entry.path);
+  }
+
   return {
     branch,
     validatePath,
@@ -135,5 +142,6 @@ export function useRepoTree() {
     validateDockerfilePath,
     findDockerfileCaseMatch,
     getDockerfilesForContext,
+    getDirectories,
   };
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Adds a creatable autocomplete combobox for the app deployment settings root directory field. Directory suggestions come from the repository tree, and custom paths remain supported with the existing warning/case-match validation behavior.

Also makes the repository root value display explicitly as `Repository root (.)` and normalizes selected custom directory paths so inputs like `services/api/` display and save as `services/api`.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- `mise exec -- pnpm --dir=web biome check --write "apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/settings/components/build-settings/root-directory-settings.tsx" "apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/settings/components/build-settings/use-repo-tree.ts"`
- `mise exec -- pnpm --dir=web --filter @unkey/dashboard typecheck`
- Manual dashboard test on seeded local app settings:
  - Started local dashboard dependencies with `mise run dashboard` after starting Docker and resetting compose volumes.
  - Opened `/local/projects/proj_D0mFQuvHI/apps/app_9J5kqkiBx/settings`.
  - Verified root displays as `Repository root (.)`.
  - Opened Root directory dropdown, typed `services/api/`, selected the custom option, and confirmed it normalized to `services/api`.
  - Saved the setting and verified MySQL persisted `docker_context=services/api` for both seeded environments.

## Screenshots

Root directory starts with the explicit repository-root label:

[Root directory repository root label](https://cursor.com/agents/bc-ffb878e8-4917-5959-b3db-4abef0c44d2c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Froot_directory_repository_root_label.webp)

Custom path option appears in the dropdown:

[Root directory dropdown custom option](https://cursor.com/agents/bc-ffb878e8-4917-5959-b3db-4abef0c44d2c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Froot_directory_custom_dropdown_final.webp)

Saved state after selecting and saving `services/api`:

[Root directory saved custom path](https://cursor.com/agents/bc-ffb878e8-4917-5959-b3db-4abef0c44d2c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Froot_directory_final_saved.webp)

## Screen recording

[root_directory_dropdown_final_demo.mp4](https://cursor.com/agents/bc-ffb878e8-4917-5959-b3db-4abef0c44d2c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Froot_directory_dropdown_final_demo.mp4)

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `mise run fmt`
- [x] Checked for warnings, there are none relevant to this change
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://unkey.slack.com/archives/C09K14P6UAC/p1782215759514249?thread_ts=1782215759.514249&cid=C09K14P6UAC)

<div><a href="https://cursor.com/agents/bc-ffb878e8-4917-5959-b3db-4abef0c44d2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ffb878e8-4917-5959-b3db-4abef0c44d2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

