### PR TITLE
fix: ratelimit origin breaker

### DIFF
--- a/internal/services/ratelimit/BUILD.bazel
+++ b/internal/services/ratelimit/BUILD.bazel
@@ -46,6 +46,7 @@ go_test(
     embed = [":ratelimit"],
     deps = [
         "//internal/services/ratelimit/db",
+        "//pkg/circuitbreaker",
         "//pkg/clock",
         "//pkg/counter",
         "//pkg/mysql",

--- a/internal/services/ratelimit/metrics/prometheus.go
+++ b/internal/services/ratelimit/metrics/prometheus.go
@@ -198,23 +198,15 @@ var (
 	// RatelimitOriginErrors counts origin operations that returned an error
 	// (including circuit-breaker trips and hot-path timeouts).
 	//
-	// Labels:
-	//   - reason: "timeout" when the per-call deadline elapsed (e.g. the
-	//     150ms hot-path budget on fetch); "other" for any other error
-	//     surface (Redis returned an error, circuit breaker open, etc.).
-	//     Sustained timeouts on op="fetch_*" are alert-worthy: they mean
-	//     the rate-limit decision is falling back to local state because
-	//     Redis is slow, which loosens cross-node convergence.
-	//
-	// Example usage:
-	//   metrics.RatelimitOriginErrors.WithLabelValues("fetch_stale", "timeout").Inc()
-	//   metrics.RatelimitOriginErrors.WithLabelValues("sync", "other").Inc()
+	// reason: "circuit_open" (breaker short-circuit — dominates the count once
+	// open, not a real failure), "timeout" (deadline or socket timeout), or
+	// "other" (Redis/network error). For root cause, look at reason!="circuit_open".
 	RatelimitOriginErrors = lazy.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "unkey",
 			Subsystem: "ratelimit",
 			Name:      "origin_errors_total",
-			Help:      "Total number of origin operations that returned an error, labeled by op (fetch_cold|fetch_stale|fetch_strict|sync) and reason (timeout|other).",
+			Help:      "Total number of origin operations that returned an error, labeled by op (fetch_cold|fetch_stale|fetch_strict|sync) and reason (circuit_open|timeout|other).",
 		},
 		[]string{"op", "reason"},
 	)

--- a/internal/services/ratelimit/origin.go
+++ b/internal/services/ratelimit/origin.go
@@ -3,25 +3,35 @@ package ratelimit
 import (
 	"context"
 	"errors"
+	"net"
 	"time"
 
 	"github.com/unkeyed/unkey/pkg/assert"
+	"github.com/unkeyed/unkey/pkg/circuitbreaker"
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/pkg/otel/tracing"
 
 	"github.com/unkeyed/unkey/internal/services/ratelimit/metrics"
 )
 
-// errorReason classifies err for the origin_errors_total{reason} label.
-// We only single out timeouts because they are the most actionable signal
-// (the per-call budget elapsed, not a Redis-side problem); everything else
-// — Redis errors, circuit-breaker trips, network failures — collapses to
-// "other".
+// errorReason buckets err for the origin_errors_total{reason} label so breaker
+// short-circuits don't drown out the real failures that tripped it.
 func errorReason(err error) string {
-	if errors.Is(err, context.DeadlineExceeded) {
+	if isCircuitOpen(err) {
+		return "circuit_open"
+	}
+	// go-redis surfaces a blown deadline as a socket timeout that doesn't unwrap
+	// to context.DeadlineExceeded, so check net.Error too.
+	var netErr net.Error
+	if errors.Is(err, context.DeadlineExceeded) || (errors.As(err, &netErr) && netErr.Timeout()) {
 		return "timeout"
 	}
 	return "other"
+}
+
+// isCircuitOpen reports whether err is the breaker short-circuiting rather than a real origin failure.
+func isCircuitOpen(err error) bool {
+	return circuitbreaker.IsErrTripped(err) || circuitbreaker.IsErrTooManyRequests(err)
 }
 
 // originFetchTimeout caps how long a single Redis GET on the hot path may
@@ -31,7 +41,12 @@ func errorReason(err error) string {
 // times out we treat the origin as unavailable for this request — local
 // state is used, the circuit breaker tracks the failure, and the next
 // caller will retry.
-const originFetchTimeout = 150 * time.Millisecond
+const originFetchTimeout = 300 * time.Millisecond
+
+// originBreakerOpenTimeout caps how long the breaker stays open — i.e. how long
+// ratelimiting runs local-only after a blip. Far below the 60s library default
+// since in-region Redis recovers fast.
+const originBreakerOpenTimeout = 5 * time.Second
 
 // fetchFromOrigin returns the current counter value from the origin. The call is
 // wrapped in the origin circuit breaker so that Redis outages fail fast instead
@@ -54,10 +69,14 @@ func (s *service) fetchFromOrigin(ctx context.Context, key counterKey, op string
 	})
 	if err != nil {
 		metrics.RatelimitOriginErrors.WithLabelValues(op, errorReason(err)).Inc()
-		logger.Error("unable to get counter value from origin",
-			"key", rk,
-			"error", err.Error(),
-		)
+		// Don't log breaker short-circuits — they'd flood the log for the whole
+		// open window; the circuit_open metric already tracks them.
+		if !isCircuitOpen(err) {
+			logger.Error("unable to get counter value from origin",
+				"key", rk,
+				"error", err.Error(),
+			)
+		}
 		return 0, false
 	}
 	return res, true
@@ -72,7 +91,8 @@ func (s *service) replayRequests() {
 			continue
 		}
 		err := s.syncWithOrigin(context.Background(), *ptr)
-		if err != nil {
+		// Don't log breaker short-circuits (see fetchFromOrigin).
+		if err != nil && !isCircuitOpen(err) {
 			logger.Error("failed to replay request", "error", err.Error())
 		}
 	}

--- a/internal/services/ratelimit/origin_test.go
+++ b/internal/services/ratelimit/origin_test.go
@@ -10,9 +10,47 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/circuitbreaker"
 	"github.com/unkeyed/unkey/pkg/clock"
 	"github.com/unkeyed/unkey/pkg/uid"
 )
+
+// timeoutError is a net.Error whose Timeout() reports true, mimicking the
+// socket-level i/o timeout the redis client surfaces when a deadline blows but
+// the error does not unwrap to context.DeadlineExceeded.
+type timeoutError struct{}
+
+func (timeoutError) Error() string   { return "read tcp: i/o timeout" }
+func (timeoutError) Timeout() bool   { return true }
+func (timeoutError) Temporary() bool { return true }
+
+// TestErrorReason asserts that errorReason keeps breaker short-circuits,
+// real timeouts, and other errors in separate reason buckets — the count of
+// circuit_open dwarfs the rest during a burst, so they must not collapse
+// together.
+func TestErrorReason(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"breaker tripped", circuitbreaker.ErrTripped, "circuit_open"},
+		{"breaker half-open", circuitbreaker.ErrTooManyRequests, "circuit_open"},
+		{"wrapped breaker trip", fmt.Errorf("fetch: %w", circuitbreaker.ErrTripped), "circuit_open"},
+		{"context deadline", context.DeadlineExceeded, "timeout"},
+		{"wrapped deadline", fmt.Errorf("get: %w", context.DeadlineExceeded), "timeout"},
+		{"socket i/o timeout", timeoutError{}, "timeout"},
+		{"redis error", errors.New("READONLY You can't write against a read only replica"), "other"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, errorReason(tt.err))
+		})
+	}
+}
 
 // TestRatelimit_FailsOverToLocalWhenOriginErrors asserts that when the origin
 // counter returns errors, Ratelimit still returns a decision based on local

--- a/internal/services/ratelimit/service.go
+++ b/internal/services/ratelimit/service.go
@@ -377,7 +377,10 @@ func New(config Config) (*service, error) {
 			Capacity: 10_000,
 			Drop:     true,
 		}),
-		originCircuitBreaker: circuitbreaker.New[int64]("ratelimitOrigin"),
+		originCircuitBreaker: circuitbreaker.New[int64](
+			"ratelimitOrigin",
+			circuitbreaker.WithTimeout(originBreakerOpenTimeout),
+		),
 		globalCircuitBreaker: circuitbreaker.New[any]("ratelimit_global_push"),
 		db:                   db.New(config.DB.RW(), config.DB.RO()),
 	}


### PR DESCRIPTION
1. Make sure we categorize the ratellimits errors correctly 
2. stop log spam from circuit breaker
3. reduce circuit breaker open timeout