### PR TITLE
fix(ctrl): redirect Domain Connect callback to app settings

### DIFF
--- a/svc/ctrl/services/customdomain/service.go
+++ b/svc/ctrl/services/customdomain/service.go
@@ -114,7 +114,7 @@ func (s *Service) AddCustomDomain(
 	if len(s.domainConnectPrivateKeyPEM) > 0 {
 		logger.Info("running domain connect discovery", "domain", domain)
 
-		// Build redirect URL back to project settings via the public Domain Connect
+		// Build redirect URL back to app settings via the public Domain Connect
 		// callback. Going through a public path keeps the return navigation working
 		// even though the SameSite=Strict session cookie is dropped on the cross-site
 		// redirect from the DNS provider — the callback page does a same-site client
@@ -124,7 +124,7 @@ func (s *Service) AddCustomDomain(
 		if wsErr != nil {
 			logger.Warn("failed to fetch workspace for redirect URL", "error", wsErr)
 		} else {
-			settingsPath := fmt.Sprintf("/%s/projects/%s/settings", ws.Slug, req.Msg.GetProjectId())
+			settingsPath := fmt.Sprintf("/%s/projects/%s/apps/%s/settings", ws.Slug, req.Msg.GetProjectId(), req.Msg.GetAppId())
 			redirectURL = fmt.Sprintf("https://app.unkey.com/integrations/domain-connect/callback?to=%s", url.QueryEscape(settingsPath))
 		}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Updates the Domain Connect post-approval redirect so users return to the app settings page where they added the custom domain, instead of project settings.

Fixes ENG-2959

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Add a custom domain from an app's settings page with a DNS provider that supports Domain Connect
- Complete the Domain Connect flow at the provider
- Confirm the callback redirects to `/{workspaceSlug}/projects/{projectId}/apps/{appId}/settings` instead of `/{workspaceSlug}/projects/{projectId}/settings`

Verified locally:
- `mise exec -- bazel build //svc/ctrl/services/customdomain:customdomain`
- `mise exec -- bazel test //pkg/dns/domainconnect:domainconnect_test --test_output=errors`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-2959](https://linear.app/unkey/issue/ENG-2959/adjust-domain-connect-custom-domain-redirect-to-app-settings)

<div><a href="https://cursor.com/agents/bc-f55dfd45-ebfd-4a62-8f6e-4d8ab60cd6c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f55dfd45-ebfd-4a62-8f6e-4d8ab60cd6c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

