### PR TITLE
fix: Clickhouse user service lock down

### DIFF
--- a/gen/proto/hydra/v1/clickhouse_user_restate.pb.go
+++ b/gen/proto/hydra/v1/clickhouse_user_restate.pb.go
@@ -20,6 +20,10 @@ import (
 // This service creates and configures ClickHouse users with appropriate
 // permissions, quotas, and row-level security policies for analytics access.
 // It uses the vault API for password encryption and stores credentials in MySQL.
+//
+// Internal-only: the workspace_id is taken from the virtual object key with no
+// caller authorization, so this service is bound ingress-private and must only
+// be invoked service-to-service, never from the public ingress.
 type ClickhouseUserServiceClient interface {
 	// ConfigureUser creates or updates a ClickHouse user for a workspace.
 	//
@@ -109,6 +113,10 @@ func (c *clickhouseUserServiceIngressClient) ConfigureUser() ingress.Requester[*
 // This service creates and configures ClickHouse users with appropriate
 // permissions, quotas, and row-level security policies for analytics access.
 // It uses the vault API for password encryption and stores credentials in MySQL.
+//
+// Internal-only: the workspace_id is taken from the virtual object key with no
+// caller authorization, so this service is bound ingress-private and must only
+// be invoked service-to-service, never from the public ingress.
 type ClickhouseUserServiceServer interface {
 	// ConfigureUser creates or updates a ClickHouse user for a workspace.
 	//

--- a/svc/ctrl/proto/hydra/v1/clickhouse_user.proto
+++ b/svc/ctrl/proto/hydra/v1/clickhouse_user.proto
@@ -11,6 +11,10 @@ option go_package = "github.com/unkeyed/unkey/gen/proto/hydra/v1;hydrav1";
 // This service creates and configures ClickHouse users with appropriate
 // permissions, quotas, and row-level security policies for analytics access.
 // It uses the vault API for password encryption and stores credentials in MySQL.
+//
+// Internal-only: the workspace_id is taken from the virtual object key with no
+// caller authorization, so this service is bound ingress-private and must only
+// be invoked service-to-service, never from the public ingress.
 service ClickhouseUserService {
   option (dev.restate.sdk.go.service_type) = VIRTUAL_OBJECT;
 

--- a/svc/ctrl/worker/run.go
+++ b/svc/ctrl/worker/run.go
@@ -432,11 +432,16 @@ func Run(ctx context.Context, cfg Config) error {
 				"error", chAdminErr,
 			)
 		} else {
+			// Ingress-private: the workspace_id is the VO key with no caller
+			// authorization, so a public ingress call could (re)provision any
+			// tenant's ClickHouse user. This service is internal-only (no
+			// production ingress caller exists), matching the other internal
+			// services bound above.
 			restateSrv.Bind(hydrav1.NewClickhouseUserServiceServer(clickhouseuser.New(clickhouseuser.Config{
 				DB:         database,
 				Vault:      vaultClient,
 				Clickhouse: chAdmin,
-			})))
+			}), restate.WithIngressPrivate(true)))
 			logger.Info("ClickhouseUserService enabled")
 		}
 	}


### PR DESCRIPTION

## What does this PR do?

The binding in `svc/ctrl/worker/run.go` was missing `restate.WithIngressPrivate(true)`, unlike every other internal-only service (Deployment, GitHubStatus, Routing, Openapi, BuildSlot)

Fixes ENG-2947

_If there is not an issue for this, create one first. This is used for tracking purposes and helps us understand why this PR exists._

<!-- If there isn't an issue for this PR, review the internal workflow guide and create an issue. -->

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Make sure it doesn't cause any issues.
- There is no prod caller.

## Checklist

<!-- Complete this checklist before requesting review. -->

### Required

- [X] Filled out the "How to test" section in this PR
- [X] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [X] Ran `pnpm build`
- [X] Ran `pnpm fmt`
- [X] Ran `mise run fmt`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary
