### PR TITLE
fix(dashboard): clarify app overview chart legend units

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/overview/components/card-chart.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/overview/components/card-chart.tsx
@@ -17,8 +17,8 @@ const ERROR = "hsl(var(--error-9))";
 const ERROR_FILL = "hsl(var(--error-3))";
 
 const CHART_CONFIG: ChartConfig = {
-  total: { label: "Requests", color: BLUE },
-  errors: { label: "Errors", color: ERROR },
+  total: { label: "Requests / s", color: BLUE },
+  errors: { label: "Errors / s", color: ERROR },
 };
 
 // Hoisted so its identity is stable: a fresh object each render resets recharts' cursor.
@@ -47,8 +47,14 @@ function LegendStat({
   return (
     <span className="flex items-center gap-1.5 whitespace-nowrap tabular-nums">
       <span className="size-2 shrink-0 rounded-full" style={{ backgroundColor: color }} />
-      <span className="text-gray-9">{label}</span>
-      <span className={cn("font-medium", alert ? "text-error-11" : "text-accent-12")}>{value}</span>
+      <span
+        className={cn(
+          "rounded-full bg-grayA-3 px-2 py-0.5 text-[13px] font-medium",
+          alert ? "text-error-11" : "text-accent-12",
+        )}
+      >
+        {value} {label}
+      </span>
     </span>
   );
 }
@@ -117,10 +123,10 @@ export function ProductionCardChart() {
         onActiveChange={setActive}
       />
       <div className="flex items-center gap-4 text-[13px]">
-        <LegendStat color={BLUE} label="Requests" value={formatBucketCount(reqValue)} />
+        <LegendStat color={BLUE} label="Requests / s" value={formatBucketCount(reqValue)} />
         <LegendStat
           color={ERROR}
-          label="Errors"
+          label="Errors / s"
           value={formatBucketCount(errValue)}
           alert={errValue > 0}
         />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Clarifies the app overview chart legend so values read as per-second rates:

- Legend values render in pill badges as `47 Requests / s` / `0 Errors / s` instead of ambiguous `Requests 47` labels.

## Type of change

- [x] Enhancement (small improvements)

## How should this be tested?

1. Open an app overview page with a production deployment that has traffic.
2. Confirm the chart legend shows pill badges like `47 Requests / s` and `0 Errors / s`.

Verified locally with `mise exec -- pnpm --dir=web/apps/dashboard typecheck`.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://unkey.slack.com/archives/C05SYU6P2DC/p1782291528258349?thread_ts=1782291528.258349&cid=C05SYU6P2DC)

<div><a href="https://cursor.com/agents/bc-603ed158-eec7-5f5f-a412-00018cf81f2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-603ed158-eec7-5f5f-a412-00018cf81f2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

