### PR TITLE
fix: actually set command override

### DIFF
--- a/svc/krane/internal/deployment/apply.go
+++ b/svc/krane/internal/deployment/apply.go
@@ -99,6 +99,7 @@ func (c *Controller) ApplyDeployment(ctx context.Context, req *ctrlv1.ApplyDeplo
 	container := corev1.Container{
 		Image:           req.GetImage(),
 		Name:            "deployment",
+		Command:         req.GetCommand(),
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		SecurityContext: &corev1.SecurityContext{},
 		Env: []corev1.EnvVar{


### PR DESCRIPTION
make sure when creating the container in k8s that we actually override the command if the deployment specifies it.

this feels like the 5th time this got removed im going to look into adding tests for deployments