### PR TITLE
fix(krane): re-apply container command override and guard the field p…

### DIFF
--- a/docs/engineering/architecture/services/krane/overview.mdx
+++ b/docs/engineering/architecture/services/krane/overview.mdx
@@ -74,8 +74,9 @@ User workloads are represented as ReplicaSets with the following characteristics
 - Pods tolerate the `karpenter.sh/nodepool=untrusted` taint
 - Topology spread keeps replicas balanced across zones
 - Pod affinity prefers zones already running pods with the environment's sentinel component label (`ComponentSentinel`). This is a soft preference inherited from the sentinel proxy layer; since that layer merged into Frontline and no pods carry the label, the affinity currently matches nothing
-- Env vars include `UNKEY_WORKSPACE_ID`, `UNKEY_PROJECT_ID`, `UNKEY_ENVIRONMENT_ID`, and `UNKEY_DEPLOYMENT_ID`
-- `UNKEY_ENCRYPTED_ENV` contains a base64-encoded secrets blob when present
+- Env vars include `PORT`, `UNKEY_DEPLOYMENT_ID`, `UNKEY_ENVIRONMENT_SLUG`, `UNKEY_REGION`, `UNKEY_INSTANCE_ID`, and the `UNKEY_GIT_*` set (commit SHA, branch, repo, commit message)
+- A `command` override from the deployment spec replaces the image entrypoint when set; otherwise the image's `ENTRYPOINT`/`CMD` runs
+- Decrypted environment variables are mounted from a per-deployment K8s Secret via `envFrom.secretRef`
 - Healthchecks map to HTTP probes, and POST uses an exec probe with `wget`
 - Optional preStop hook sends non-SIGTERM shutdown signals
 

--- a/svc/ctrl/services/cluster/BUILD.bazel
+++ b/svc/ctrl/services/cluster/BUILD.bazel
@@ -42,6 +42,7 @@ go_library(
 go_test(
     name = "cluster_test",
     srcs = [
+        "apply_deployment_coverage_test.go",
         "region_key_test.go",
         "state_converters_test.go",
     ],
@@ -49,6 +50,7 @@ go_test(
     deps = [
         "//gen/proto/ctrl/v1:ctrl",
         "//pkg/db",
+        "//pkg/db/types",
         "@com_connectrpc_connect//:connect",
         "@com_github_stretchr_testify//require",
     ],

--- a/svc/ctrl/services/cluster/apply_deployment_coverage_test.go
+++ b/svc/ctrl/services/cluster/apply_deployment_coverage_test.go
@@ -1,0 +1,172 @@
+package cluster
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	ctrlv1 "github.com/unkeyed/unkey/gen/proto/ctrl/v1"
+	"github.com/unkeyed/unkey/pkg/db"
+	dbtype "github.com/unkeyed/unkey/pkg/db/types"
+)
+
+// fullDeploymentRow returns a deploymentRow with every field that
+// deploymentRowToState reads populated with a non-zero value, so the producer
+// coverage guard can verify each ApplyDeployment proto field is actually filled
+// in from the database row.
+func fullDeploymentRow() deploymentRow {
+	return deploymentRow{
+		dt: db.DeploymentTopology{
+			DesiredStatus:              db.DeploymentTopologyDesiredStatusRunning,
+			AutoscalingReplicasMin:     2,
+			AutoscalingReplicasMax:     5,
+			AutoscalingThresholdCpu:    sql.NullInt16{Valid: true, Int16: 80},
+			AutoscalingThresholdMemory: sql.NullInt16{Valid: true, Int16: 75},
+		},
+		d: db.Deployment{
+			ID:                            "deploy_sentinel",
+			K8sName:                       "k8s-name-sentinel",
+			WorkspaceID:                   "ws_sentinel",
+			ProjectID:                     "prj_sentinel",
+			EnvironmentID:                 "env_sentinel",
+			AppID:                         "app_sentinel",
+			Image:                         sql.NullString{Valid: true, String: "registry.io/sentinel:v1"},
+			CpuMillicores:                 250,
+			MemoryMib:                     256,
+			StorageMib:                    2048,
+			EncryptedEnvironmentVariables: []byte("ciphertext-sentinel"),
+			BuildID:                       sql.NullString{Valid: true, String: "build_sentinel"},
+			Command:                       dbtype.StringSlice{"/sentinel-app", "serve"},
+			Port:                          8080,
+			ShutdownSignal:                db.DeploymentsShutdownSignalSIGTERM,
+			GitCommitSha:                  sql.NullString{Valid: true, String: "abc123sha"},
+			GitBranch:                     sql.NullString{Valid: true, String: "main-sentinel"},
+			GitCommitMessage:              sql.NullString{Valid: true, String: "sentinel commit"},
+			Healthcheck: dbtype.NullHealthcheck{
+				Valid:       true,
+				Healthcheck: &dbtype.Healthcheck{Method: "GET", Path: "/sentinel-healthz"},
+			},
+		},
+		k8sNamespace:    sql.NullString{Valid: true, String: "ns-sentinel"},
+		environmentSlug: "production",
+		regionName:      "us-east-1",
+		gitRepo:         sql.NullString{Valid: true, String: "github.com/test/sentinel"},
+	}
+}
+
+// producerFieldAssertions maps each ApplyDeployment proto field (by proto name)
+// to an assertion that deploymentRowToState populated it from the database row.
+// Every proto field must have an entry; the coverage test fails otherwise, so a
+// field cannot be added or dropped on the producer side without a test. This
+// mirrors the krane render-side guard in apply_test.go.
+var producerFieldAssertions = map[string]func(t *testing.T, a *ctrlv1.ApplyDeployment){
+	"k8s_namespace": func(t *testing.T, a *ctrlv1.ApplyDeployment) {
+		require.Equal(t, "ns-sentinel", a.GetK8SNamespace())
+	},
+	"k8s_name": func(t *testing.T, a *ctrlv1.ApplyDeployment) {
+		require.Equal(t, "k8s-name-sentinel", a.GetK8SName())
+	},
+	"workspace_id": func(t *testing.T, a *ctrlv1.ApplyDeployment) {
+		require.Equal(t, "ws_sentinel", a.GetWorkspaceId())
+	},
+	"project_id": func(t *testing.T, a *ctrlv1.ApplyDeployment) {
+		require.Equal(t, "prj_sentinel", a.GetProjectId())
+	},
+	"environment_id": func(t *testing.T, a *ctrlv1.ApplyDeployment) {
+		require.Equal(t, "env_sentinel", a.GetEnvironmentId())
+	},
+	"deployment_id": func(t *testing.T, a *ctrlv1.ApplyDeployment) {
+		require.Equal(t, "deploy_sentinel", a.GetDeploymentId())
+	},
+	"image": func(t *testing.T, a *ctrlv1.ApplyDeployment) {
+		require.Equal(t, "registry.io/sentinel:v1", a.GetImage())
+	},
+	"cpu_millicores": func(t *testing.T, a *ctrlv1.ApplyDeployment) {
+		require.Equal(t, int64(250), a.GetCpuMillicores())
+	},
+	"memory_mib": func(t *testing.T, a *ctrlv1.ApplyDeployment) {
+		require.Equal(t, int64(256), a.GetMemoryMib())
+	},
+	"build_id": func(t *testing.T, a *ctrlv1.ApplyDeployment) {
+		require.Equal(t, "build_sentinel", a.GetBuildId())
+	},
+	"encrypted_environment_variables": func(t *testing.T, a *ctrlv1.ApplyDeployment) {
+		require.NotEmpty(t, a.GetEncryptedEnvironmentVariables())
+	},
+	"command": func(t *testing.T, a *ctrlv1.ApplyDeployment) {
+		require.Equal(t, []string{"/sentinel-app", "serve"}, a.GetCommand(),
+			"command must be carried from the DB row")
+	},
+	"port": func(t *testing.T, a *ctrlv1.ApplyDeployment) {
+		require.Equal(t, int32(8080), a.GetPort())
+	},
+	"shutdown_signal": func(t *testing.T, a *ctrlv1.ApplyDeployment) {
+		require.NotEmpty(t, a.GetShutdownSignal())
+	},
+	"healthcheck": func(t *testing.T, a *ctrlv1.ApplyDeployment) {
+		require.NotEmpty(t, a.GetHealthcheck())
+	},
+	"app_id": func(t *testing.T, a *ctrlv1.ApplyDeployment) {
+		require.Equal(t, "app_sentinel", a.GetAppId())
+	},
+	"environment_slug": func(t *testing.T, a *ctrlv1.ApplyDeployment) {
+		require.Equal(t, "production", a.GetEnvironmentSlug())
+	},
+	"region": func(t *testing.T, a *ctrlv1.ApplyDeployment) {
+		require.Equal(t, "us-east-1", a.GetRegion())
+	},
+	"git_commit_sha": func(t *testing.T, a *ctrlv1.ApplyDeployment) {
+		require.Equal(t, "abc123sha", a.GetGitCommitSha())
+	},
+	"git_branch": func(t *testing.T, a *ctrlv1.ApplyDeployment) {
+		require.Equal(t, "main-sentinel", a.GetGitBranch())
+	},
+	"git_repo": func(t *testing.T, a *ctrlv1.ApplyDeployment) {
+		require.Equal(t, "github.com/test/sentinel", a.GetGitRepo())
+	},
+	"git_commit_message": func(t *testing.T, a *ctrlv1.ApplyDeployment) {
+		require.Equal(t, "sentinel commit", a.GetGitCommitMessage())
+	},
+	"autoscaling": func(t *testing.T, a *ctrlv1.ApplyDeployment) {
+		require.NotNil(t, a.GetAutoscaling())
+		require.Equal(t, uint32(2), a.GetAutoscaling().GetMinReplicas())
+		require.Equal(t, uint32(5), a.GetAutoscaling().GetMaxReplicas())
+	},
+	"ephemeral_storage": func(t *testing.T, a *ctrlv1.ApplyDeployment) {
+		require.NotNil(t, a.GetEphemeralStorage())
+		require.Equal(t, int64(2048), a.GetEphemeralStorage().GetSizeMib())
+	},
+}
+
+// TestDeploymentRowToState_PopulatesProtoFields converts a fully-populated row
+// and asserts each ApplyDeployment proto field was carried over from the DB.
+func TestDeploymentRowToState_PopulatesProtoFields(t *testing.T) {
+	state, err := deploymentRowToState(fullDeploymentRow(), 1)
+	require.NoError(t, err)
+
+	apply := state.GetApply()
+	require.NotNil(t, apply)
+
+	for field, assert := range producerFieldAssertions {
+		t.Run(field, func(t *testing.T) {
+			assert(t, apply)
+		})
+	}
+}
+
+// TestApplyDeploymentProducerFieldCoverage enumerates every field in the
+// ApplyDeployment proto and fails if any is not covered by
+// producerFieldAssertions, so a field cannot be dropped from the DB-to-proto
+// mapping in deploymentRowToState without a failing test naming it.
+func TestApplyDeploymentProducerFieldCoverage(t *testing.T) {
+	fields := (&ctrlv1.ApplyDeployment{}).ProtoReflect().Descriptor().Fields()
+
+	for i := 0; i < fields.Len(); i++ {
+		name := string(fields.Get(i).Name())
+		_, ok := producerFieldAssertions[name]
+		require.Truef(t, ok,
+			"ApplyDeployment proto field %q is not covered by a producer test. Map it "+
+				"from the deployment row in deploymentRowToState and add an entry to "+
+				"producerFieldAssertions.", name)
+	}
+}

--- a/svc/krane/internal/deployment/BUILD.bazel
+++ b/svc/krane/internal/deployment/BUILD.bazel
@@ -62,6 +62,7 @@ go_library(
 go_test(
     name = "deployment_test",
     srcs = [
+        "apply_test.go",
         "controller_test.go",
         "instance_events_test.go",
         "state_test.go",
@@ -70,6 +71,8 @@ go_test(
     deps = [
         "//gen/proto/ctrl/v1:ctrl",
         "//pkg/cache",
+        "//pkg/db/types",
+        "//pkg/ptr",
         "//svc/krane/internal/testutil",
         "//svc/krane/pkg/labels",
         "@com_github_stretchr_testify//require",

--- a/svc/krane/internal/deployment/apply.go
+++ b/svc/krane/internal/deployment/apply.go
@@ -85,6 +85,83 @@ func (c *Controller) ApplyDeployment(ctx context.Context, req *ctrlv1.ApplyDeplo
 
 	hasSecrets := len(plaintext) > 0
 
+	desired := c.buildReplicaSet(req, hasSecrets)
+
+	// Create the Secret and ServiceAccount before the ReplicaSet so they
+	// exist by the time pods are scheduled. This prevents the
+	// "serviceaccount not found" race condition. We patch ownerReferences
+	// onto them after the RS is created so K8s still garbage-collects them.
+	if hasSecrets {
+		if err := c.ensureDeploymentSecret(ctx, req.GetK8SNamespace(), req.GetDeploymentId(), plaintext); err != nil {
+			return fmt.Errorf("failed to ensure deployment secret: %w", err)
+		}
+
+		if err := c.ensureDeploymentServiceAccount(ctx, req.GetK8SNamespace(), req.GetDeploymentId()); err != nil {
+			return fmt.Errorf("failed to ensure deployment service account: %w", err)
+		}
+	}
+
+	client := c.clientSet.AppsV1().ReplicaSets(req.GetK8SNamespace())
+
+	patch, err := json.Marshal(desired)
+	if err != nil {
+		return fmt.Errorf("failed to marshal replicaset: %w", err)
+	}
+
+	applied, err := client.Patch(ctx, req.GetK8SName(), types.ApplyPatchType, patch, metav1.PatchOptions{
+		FieldManager: fieldManagerKrane,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to apply replicaset: %w", err)
+	}
+
+	// Patch ownerReferences onto the Secret and SA so K8s garbage-collects
+	// them when the ReplicaSet is deleted.
+	if hasSecrets {
+		ownerRef := metav1.OwnerReference{
+			APIVersion:         "apps/v1",
+			Kind:               "ReplicaSet",
+			Name:               applied.Name,
+			UID:                applied.UID,
+			Controller:         ptr.P(true),
+			BlockOwnerDeletion: ptr.P(true),
+		}
+
+		resName := deploymentResourcePrefix(req.GetDeploymentId())
+		if err := c.patchOwnerRef(ctx, req.GetK8SNamespace(), resName, ownerRef); err != nil {
+			return fmt.Errorf("failed to patch owner references: %w", err)
+		}
+	}
+
+	if err := c.ensureHPAExists(ctx, req, applied); err != nil {
+		return fmt.Errorf("failed to ensure HPA: %w", err)
+	}
+
+	if err := c.ensureCiliumNetworkPolicy(ctx, req, applied); err != nil {
+		return fmt.Errorf("failed to ensure cilium network policy: %w", err)
+	}
+
+	status, err := c.buildDeploymentStatus(ctx, applied)
+	if err != nil {
+		return err
+	}
+
+	err = c.reportDeploymentStatus(ctx, status)
+	if err != nil {
+		logger.Error("failed to report deployment status", "deployment_id", req.GetDeploymentId(), "error", err)
+		return err
+	}
+
+	return nil
+}
+
+// buildReplicaSet renders the desired ReplicaSet for a deployment request.
+//
+// It performs no I/O so the mapping from every ApplyDeployment proto field to
+// the Kubernetes object is unit-testable without a cluster (see apply_test.go).
+// hasSecrets indicates whether a per-deployment K8s Secret will be mounted via
+// envFrom; the caller computes it from the decrypted environment variables.
+func (c *Controller) buildReplicaSet(req *ctrlv1.ApplyDeployment, hasSecrets bool) *appsv1.ReplicaSet {
 	usedLabels := labels.New().
 		WorkspaceID(req.GetWorkspaceId()).
 		ProjectID(req.GetProjectId()).
@@ -99,6 +176,7 @@ func (c *Controller) ApplyDeployment(ctx context.Context, req *ctrlv1.ApplyDeplo
 	container := corev1.Container{
 		Image:           req.GetImage(),
 		Name:            "deployment",
+		Command:         req.GetCommand(),
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		SecurityContext: &corev1.SecurityContext{},
 		Env: []corev1.EnvVar{
@@ -231,7 +309,7 @@ func (c *Controller) ApplyDeployment(ctx context.Context, req *ctrlv1.ApplyDeplo
 
 	podSpec.ImagePullSecrets = c.imagePullSecrets
 
-	desired := &appsv1.ReplicaSet{
+	return &appsv1.ReplicaSet{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps/v1",
 			Kind:       "ReplicaSet",
@@ -254,73 +332,6 @@ func (c *Controller) ApplyDeployment(ctx context.Context, req *ctrlv1.ApplyDeplo
 			},
 		},
 	}
-
-	// Create the Secret and ServiceAccount before the ReplicaSet so they
-	// exist by the time pods are scheduled. This prevents the
-	// "serviceaccount not found" race condition. We patch ownerReferences
-	// onto them after the RS is created so K8s still garbage-collects them.
-	if hasSecrets {
-		if err := c.ensureDeploymentSecret(ctx, req.GetK8SNamespace(), req.GetDeploymentId(), plaintext); err != nil {
-			return fmt.Errorf("failed to ensure deployment secret: %w", err)
-		}
-
-		if err := c.ensureDeploymentServiceAccount(ctx, req.GetK8SNamespace(), req.GetDeploymentId()); err != nil {
-			return fmt.Errorf("failed to ensure deployment service account: %w", err)
-		}
-	}
-
-	client := c.clientSet.AppsV1().ReplicaSets(req.GetK8SNamespace())
-
-	patch, err := json.Marshal(desired)
-	if err != nil {
-		return fmt.Errorf("failed to marshal replicaset: %w", err)
-	}
-
-	applied, err := client.Patch(ctx, req.GetK8SName(), types.ApplyPatchType, patch, metav1.PatchOptions{
-		FieldManager: fieldManagerKrane,
-	})
-	if err != nil {
-		return fmt.Errorf("failed to apply replicaset: %w", err)
-	}
-
-	// Patch ownerReferences onto the Secret and SA so K8s garbage-collects
-	// them when the ReplicaSet is deleted.
-	if hasSecrets {
-		ownerRef := metav1.OwnerReference{
-			APIVersion:         "apps/v1",
-			Kind:               "ReplicaSet",
-			Name:               applied.Name,
-			UID:                applied.UID,
-			Controller:         ptr.P(true),
-			BlockOwnerDeletion: ptr.P(true),
-		}
-
-		resName := deploymentResourcePrefix(req.GetDeploymentId())
-		if err := c.patchOwnerRef(ctx, req.GetK8SNamespace(), resName, ownerRef); err != nil {
-			return fmt.Errorf("failed to patch owner references: %w", err)
-		}
-	}
-
-	if err := c.ensureHPAExists(ctx, req, applied); err != nil {
-		return fmt.Errorf("failed to ensure HPA: %w", err)
-	}
-
-	if err := c.ensureCiliumNetworkPolicy(ctx, req, applied); err != nil {
-		return fmt.Errorf("failed to ensure cilium network policy: %w", err)
-	}
-
-	status, err := c.buildDeploymentStatus(ctx, applied)
-	if err != nil {
-		return err
-	}
-
-	err = c.reportDeploymentStatus(ctx, status)
-	if err != nil {
-		logger.Error("failed to report deployment status", "deployment_id", req.GetDeploymentId(), "error", err)
-		return err
-	}
-
-	return nil
 }
 
 // buildProbeHandler creates the K8s probe handler based on the healthcheck method.

--- a/svc/krane/internal/deployment/apply_test.go
+++ b/svc/krane/internal/deployment/apply_test.go
@@ -1,0 +1,319 @@
+package deployment
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	ctrlv1 "github.com/unkeyed/unkey/gen/proto/ctrl/v1"
+	dbtype "github.com/unkeyed/unkey/pkg/db/types"
+	"github.com/unkeyed/unkey/pkg/ptr"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// Sentinel values for every ApplyDeployment field. Each is distinctive so the
+// assertions can prove the value reached the rendered ReplicaSet.
+const (
+	testNamespace        = "test-ns"
+	testK8sName          = "test-k8s-name"
+	testWorkspaceID      = "ws_sentinel"
+	testProjectID        = "proj_sentinel"
+	testEnvironmentID    = "env_sentinel"
+	testDeploymentID     = "dep_sentinel"
+	testImage            = "registry.test/sentinel-image:v1"
+	testCPUMillicores    = int64(1000)
+	testMemoryMib        = int64(512)
+	testBuildID          = "build_sentinel"
+	testPort             = int32(8080)
+	testShutdownSignal   = "SIGINT"
+	testAppID            = "app_sentinel"
+	testEnvironmentSlug  = "production"
+	testRegion           = "us-east-1"
+	testGitCommitSha     = "abc123sha"
+	testGitBranch        = "main-sentinel"
+	testGitRepo          = "github.com/test/sentinel"
+	testGitCommitMessage = "sentinel commit message"
+	testHealthcheckPath  = "/sentinel-healthz"
+	testEphemeralMib     = int64(2048)
+)
+
+var testCommand = []string{"/sentinel-app", "serve", "--flag"}
+
+// fullApplyRequest returns an ApplyDeployment with every field populated with a
+// sentinel value. The field-coverage guard depends on this populating every
+// field, so when the proto gains a field this helper must be updated too.
+func fullApplyRequest(t *testing.T) *ctrlv1.ApplyDeployment {
+	t.Helper()
+
+	hc, err := json.Marshal(dbtype.Healthcheck{
+		Method:              "GET",
+		Path:                testHealthcheckPath,
+		IntervalSeconds:     10,
+		TimeoutSeconds:      2,
+		FailureThreshold:    3,
+		InitialDelaySeconds: 5,
+	})
+	require.NoError(t, err)
+
+	return &ctrlv1.ApplyDeployment{
+		K8SNamespace:                  testNamespace,
+		K8SName:                       testK8sName,
+		WorkspaceId:                   testWorkspaceID,
+		ProjectId:                     testProjectID,
+		EnvironmentId:                 testEnvironmentID,
+		DeploymentId:                  testDeploymentID,
+		Image:                         testImage,
+		CpuMillicores:                 testCPUMillicores,
+		MemoryMib:                     testMemoryMib,
+		BuildId:                       ptr.P(testBuildID),
+		EncryptedEnvironmentVariables: []byte("ciphertext-sentinel"),
+		Command:                       testCommand,
+		Port:                          testPort,
+		ShutdownSignal:                testShutdownSignal,
+		Healthcheck:                   hc,
+		AppId:                         testAppID,
+		EnvironmentSlug:               ptr.P(testEnvironmentSlug),
+		Region:                        ptr.P(testRegion),
+		GitCommitSha:                  ptr.P(testGitCommitSha),
+		GitBranch:                     ptr.P(testGitBranch),
+		GitRepo:                       ptr.P(testGitRepo),
+		GitCommitMessage:              ptr.P(testGitCommitMessage),
+		Autoscaling:                   &ctrlv1.AutoscalingPolicy{MinReplicas: 2, MaxReplicas: 5},
+		EphemeralStorage:              &ctrlv1.EphemeralStorage{SizeMib: testEphemeralMib},
+	}
+}
+
+func testController() *Controller {
+	return &Controller{
+		platform:         "test-platform",
+		storageClassName: "test-storage-class",
+		imagePullSecrets: []corev1.LocalObjectReference{{Name: "pull-secret"}},
+	}
+}
+
+func mainContainer(t *testing.T, rs *appsv1.ReplicaSet) corev1.Container {
+	t.Helper()
+	require.Len(t, rs.Spec.Template.Spec.Containers, 1, "expected exactly one container")
+	return rs.Spec.Template.Spec.Containers[0]
+}
+
+func envValue(c corev1.Container, name string) (string, bool) {
+	for _, e := range c.Env {
+		if e.Name == name {
+			return e.Value, true
+		}
+	}
+	return "", false
+}
+
+func hasLabelValue(labels map[string]string, want string) bool {
+	for _, v := range labels {
+		if v == want {
+			return true
+		}
+	}
+	return false
+}
+
+// fieldAssertions maps each ApplyDeployment proto field (by proto name) to an
+// assertion that it is wired into the rendered ReplicaSet. Together with
+// fieldsRenderedElsewhere it must cover every proto field; the coverage test
+// fails otherwise, so a field cannot be added or dropped without a test.
+var fieldAssertions = map[string]func(t *testing.T, rs *appsv1.ReplicaSet){
+	"k8s_namespace": func(t *testing.T, rs *appsv1.ReplicaSet) {
+		require.Equal(t, testNamespace, rs.Namespace)
+	},
+	"k8s_name": func(t *testing.T, rs *appsv1.ReplicaSet) {
+		require.Equal(t, testK8sName, rs.Name)
+		require.Equal(t, testK8sName+"-", rs.Spec.Template.GenerateName)
+	},
+	"workspace_id": func(t *testing.T, rs *appsv1.ReplicaSet) {
+		require.True(t, hasLabelValue(rs.Labels, testWorkspaceID), "workspace_id must appear as a label")
+	},
+	"project_id": func(t *testing.T, rs *appsv1.ReplicaSet) {
+		require.True(t, hasLabelValue(rs.Labels, testProjectID), "project_id must appear as a label")
+	},
+	"environment_id": func(t *testing.T, rs *appsv1.ReplicaSet) {
+		require.True(t, hasLabelValue(rs.Labels, testEnvironmentID), "environment_id must appear as a label")
+	},
+	"deployment_id": func(t *testing.T, rs *appsv1.ReplicaSet) {
+		require.True(t, hasLabelValue(rs.Labels, testDeploymentID), "deployment_id must appear as a label")
+		require.Equal(t, testDeploymentID, rs.Spec.Selector.MatchLabels[labelDeploymentIDKey(t)])
+		v, ok := envValue(mainContainer(t, rs), "UNKEY_DEPLOYMENT_ID")
+		require.True(t, ok)
+		require.Equal(t, testDeploymentID, v)
+	},
+	"image": func(t *testing.T, rs *appsv1.ReplicaSet) {
+		require.Equal(t, testImage, mainContainer(t, rs).Image)
+	},
+	"cpu_millicores": func(t *testing.T, rs *appsv1.ReplicaSet) {
+		cpu := mainContainer(t, rs).Resources.Limits[corev1.ResourceCPU]
+		require.Equal(t, "1", cpu.String(), "1000m CPU limit normalizes to 1")
+	},
+	"memory_mib": func(t *testing.T, rs *appsv1.ReplicaSet) {
+		mem := mainContainer(t, rs).Resources.Limits[corev1.ResourceMemory]
+		require.Equal(t, "512Mi", mem.String())
+	},
+	"build_id": func(t *testing.T, rs *appsv1.ReplicaSet) {
+		require.True(t, hasLabelValue(rs.Labels, testBuildID), "build_id must appear as a label")
+	},
+	"encrypted_environment_variables": func(t *testing.T, rs *appsv1.ReplicaSet) {
+		// Decrypted into a K8s Secret outside buildReplicaSet; its effect here is
+		// the envFrom secretRef mount, gated on hasSecrets.
+		c := mainContainer(t, rs)
+		require.Len(t, c.EnvFrom, 1, "secret env vars must be mounted via envFrom")
+		require.NotNil(t, c.EnvFrom[0].SecretRef)
+	},
+	"command": func(t *testing.T, rs *appsv1.ReplicaSet) {
+		require.Equal(t, testCommand, mainContainer(t, rs).Command,
+			"command override must be applied to the container")
+	},
+	"port": func(t *testing.T, rs *appsv1.ReplicaSet) {
+		c := mainContainer(t, rs)
+		require.Len(t, c.Ports, 1)
+		require.Equal(t, testPort, c.Ports[0].ContainerPort)
+		v, ok := envValue(c, "PORT")
+		require.True(t, ok)
+		require.Equal(t, "8080", v)
+	},
+	"shutdown_signal": func(t *testing.T, rs *appsv1.ReplicaSet) {
+		c := mainContainer(t, rs)
+		require.NotNil(t, c.Lifecycle)
+		require.NotNil(t, c.Lifecycle.PreStop)
+		require.NotNil(t, c.Lifecycle.PreStop.Exec)
+		require.Contains(t, c.Lifecycle.PreStop.Exec.Command, "-SIGINT")
+	},
+	"healthcheck": func(t *testing.T, rs *appsv1.ReplicaSet) {
+		c := mainContainer(t, rs)
+		require.NotNil(t, c.LivenessProbe)
+		require.NotNil(t, c.ReadinessProbe)
+		require.NotNil(t, c.LivenessProbe.HTTPGet)
+		require.Equal(t, testHealthcheckPath, c.LivenessProbe.HTTPGet.Path)
+	},
+	"app_id": func(t *testing.T, rs *appsv1.ReplicaSet) {
+		require.True(t, hasLabelValue(rs.Labels, testAppID), "app_id must appear as a label")
+	},
+	"environment_slug": func(t *testing.T, rs *appsv1.ReplicaSet) {
+		v, ok := envValue(mainContainer(t, rs), "UNKEY_ENVIRONMENT_SLUG")
+		require.True(t, ok)
+		require.Equal(t, testEnvironmentSlug, v)
+	},
+	"region": func(t *testing.T, rs *appsv1.ReplicaSet) {
+		v, ok := envValue(mainContainer(t, rs), "UNKEY_REGION")
+		require.True(t, ok)
+		require.Equal(t, testRegion, v)
+	},
+	"git_commit_sha": func(t *testing.T, rs *appsv1.ReplicaSet) {
+		v, ok := envValue(mainContainer(t, rs), "UNKEY_GIT_COMMIT_SHA")
+		require.True(t, ok)
+		require.Equal(t, testGitCommitSha, v)
+	},
+	"git_branch": func(t *testing.T, rs *appsv1.ReplicaSet) {
+		v, ok := envValue(mainContainer(t, rs), "UNKEY_GIT_BRANCH")
+		require.True(t, ok)
+		require.Equal(t, testGitBranch, v)
+	},
+	"git_repo": func(t *testing.T, rs *appsv1.ReplicaSet) {
+		v, ok := envValue(mainContainer(t, rs), "UNKEY_GIT_REPO")
+		require.True(t, ok)
+		require.Equal(t, testGitRepo, v)
+	},
+	"git_commit_message": func(t *testing.T, rs *appsv1.ReplicaSet) {
+		v, ok := envValue(mainContainer(t, rs), "UNKEY_GIT_COMMIT_MESSAGE")
+		require.True(t, ok)
+		require.Equal(t, testGitCommitMessage, v)
+	},
+	"ephemeral_storage": func(t *testing.T, rs *appsv1.ReplicaSet) {
+		var found bool
+		for _, vol := range rs.Spec.Template.Spec.Volumes {
+			if vol.Name == "data" && vol.Ephemeral != nil {
+				found = true
+			}
+		}
+		require.True(t, found, "ephemeral_storage must produce a generic ephemeral volume")
+		var mounted bool
+		for _, m := range mainContainer(t, rs).VolumeMounts {
+			if m.MountPath == "/data" {
+				mounted = true
+			}
+		}
+		require.True(t, mounted, "ephemeral volume must be mounted at /data")
+	},
+}
+
+// fieldsRenderedElsewhere lists proto fields that intentionally do not surface
+// in the ReplicaSet, with the reason.
+var fieldsRenderedElsewhere = map[string]string{
+	"autoscaling": "rendered into a HorizontalPodAutoscaler by ensureHPAExists, not the ReplicaSet",
+}
+
+// labelDeploymentIDKey returns the label key used for the deployment id by
+// rendering a known value and reading it back, so the test does not hardcode
+// the label package's internal key string.
+func labelDeploymentIDKey(t *testing.T) string {
+	t.Helper()
+	rs := testController().buildReplicaSet(fullApplyRequest(t), true)
+	for k, v := range rs.Spec.Selector.MatchLabels {
+		if v == testDeploymentID {
+			return k
+		}
+	}
+	t.Fatal("deployment id label key not found in selector")
+	return ""
+}
+
+// TestBuildReplicaSet_WiresProtoFields renders a fully-populated request and
+// asserts each proto field surfaces in the ReplicaSet.
+func TestBuildReplicaSet_WiresProtoFields(t *testing.T) {
+	rs := testController().buildReplicaSet(fullApplyRequest(t), true /* hasSecrets */)
+
+	for field, assert := range fieldAssertions {
+		t.Run(field, func(t *testing.T) {
+			assert(t, rs)
+		})
+	}
+}
+
+// TestApplyDeploymentFieldCoverage enumerates every field in the
+// ApplyDeployment proto and fails if any is not covered by fieldAssertions or
+// fieldsRenderedElsewhere, so a field cannot be dropped from the render path
+// without a failing test naming it.
+func TestApplyDeploymentFieldCoverage(t *testing.T) {
+	fields := (&ctrlv1.ApplyDeployment{}).ProtoReflect().Descriptor().Fields()
+
+	for i := 0; i < fields.Len(); i++ {
+		name := string(fields.Get(i).Name())
+
+		_, asserted := fieldAssertions[name]
+		_, elsewhere := fieldsRenderedElsewhere[name]
+
+		require.Truef(t, asserted || elsewhere,
+			"ApplyDeployment proto field %q is not covered by a test. Wire it into "+
+				"buildReplicaSet and add an entry to fieldAssertions, or document it in "+
+				"fieldsRenderedElsewhere.", name)
+
+		require.Falsef(t, asserted && elsewhere,
+			"ApplyDeployment proto field %q is in both fieldAssertions and "+
+				"fieldsRenderedElsewhere; it must be in exactly one.", name)
+	}
+}
+
+// TestBuildReplicaSet_NoCommandUsesImageEntrypoint verifies the safe default:
+// when no command override is provided, the container command stays nil so the
+// image's ENTRYPOINT/CMD runs.
+func TestBuildReplicaSet_NoCommandUsesImageEntrypoint(t *testing.T) {
+	req := fullApplyRequest(t)
+	req.Command = nil
+
+	rs := testController().buildReplicaSet(req, true)
+	require.Nil(t, mainContainer(t, rs).Command)
+}
+
+// TestBuildReplicaSet_NoSecretsOmitsEnvFrom verifies that without secrets the
+// container has no envFrom mount and the pod uses no dedicated service account.
+func TestBuildReplicaSet_NoSecretsOmitsEnvFrom(t *testing.T) {
+	rs := testController().buildReplicaSet(fullApplyRequest(t), false)
+	require.Empty(t, mainContainer(t, rs).EnvFrom)
+	require.Empty(t, rs.Spec.Template.Spec.ServiceAccountName)
+}


### PR DESCRIPTION
This isn't perfect... id rather have e2e tests but we dont have all the api's for it ready so this is the next best thing.

Basically is checks if code cover what the protos have.