### PR TITLE
test(validation): cover portal slug boundaries

### DIFF
--- a/pkg/validation/BUILD.bazel
+++ b/pkg/validation/BUILD.bazel
@@ -14,7 +14,10 @@ go_library(
 go_test(
     name = "validation_test",
     size = "small",
-    srcs = ["env_var_test.go"],
+    srcs = [
+        "env_var_test.go",
+        "slug_test.go",
+    ],
     embed = [":validation"],
     deps = ["@com_github_stretchr_testify//require"],
 )

--- a/pkg/validation/slug_test.go
+++ b/pkg/validation/slug_test.go
@@ -1,0 +1,39 @@
+package validation
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidateSlug_ProtectsPortalSlugBoundary guarantees that portal slugs stay
+// URL-safe and human-readable before route handlers use them for lookup.
+func TestValidateSlug_ProtectsPortalSlugBoundary(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		slug string
+		want bool
+	}{
+		{name: "minimum length", slug: "abc", want: true},
+		{name: "maximum length", slug: strings.Repeat("a", SlugMaxLength), want: true},
+		{name: "single hyphen inside", slug: "acme-prod", want: true},
+		{name: "too short", slug: "ab", want: false},
+		{name: "too long", slug: strings.Repeat("a", SlugMaxLength+1), want: false},
+		{name: "uppercase", slug: "Acme", want: false},
+		{name: "starts with hyphen", slug: "-acme", want: false},
+		{name: "ends with hyphen", slug: "acme-", want: false},
+		{name: "consecutive hyphens", slug: "acme--prod", want: false},
+		{name: "underscore", slug: "acme_prod", want: false},
+		{name: "space", slug: "acme prod", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, ValidateSlug(tt.slug))
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add direct coverage for portal slug validation boundaries
- wire the new Go test into //pkg/validation:validation_test

## Investigation
- checked open PRs first; earlier test coverage PR #6547 covers pkg/openapi/validation, so this avoids that area
- found several redundant/low-leverage areas, including generated route status tests and trivial utility/helper tests where extra assertions would mostly duplicate compiler or library behavior
- chose pkg/validation because ValidateSlug protects the portal session slug boundary used by v2_portal_create_session and had no direct package test for length, character, or hyphen invariants

## Verification
- mise exec -- bazel test //pkg/validation/...

## Self-review
- This is intentionally small but important: it locks down user-controlled slug constraints at the shared validation boundary instead of adding another route-level status test. The guarantee is clear, deterministic, and cheap to maintain.