### PR TITLE
👮 Dependency Police: Remove usehooks-ts

### DIFF
--- a/web/apps/dashboard/app/auth/sign-in/last_used.tsx
+++ b/web/apps/dashboard/app/auth/sign-in/last_used.tsx
@@ -1,10 +1,15 @@
 "use client";
-import { useLocalStorage } from "usehooks-ts";
+
+import { useLocalStorage } from "@/hooks/use-local-storage";
+
+type LastUsedProvider = "github" | "google" | "email";
+
+const LAST_USED_LOGIN_KEY = "last_unkey_login";
 
 export function useLastUsed() {
-  return useLocalStorage<"github" | "google" | "email" | undefined>("last_unkey_login", undefined);
+  return useLocalStorage<LastUsedProvider | undefined>(LAST_USED_LOGIN_KEY, undefined);
 }
 
-export const LastUsed: React.FC = () => {
+export const LastUsed = () => {
   return <span className="absolute right-4 text-xs text-content-subtle">Last used</span>;
 };

--- a/web/apps/dashboard/components/logs/details/resizable-panel.tsx
+++ b/web/apps/dashboard/components/logs/details/resizable-panel.tsx
@@ -1,6 +1,5 @@
 import type React from "react";
 import { type PropsWithChildren, useCallback, useEffect, useRef, useState } from "react";
-import { useOnClickOutside } from "usehooks-ts";
 
 export const MAX_DRAGGABLE_WIDTH = 800;
 export const MIN_DRAGGABLE_WIDTH = 300;
@@ -25,7 +24,26 @@ export const ResizablePanel = ({
   const [width, setWidth] = useState<string>(String(style?.width));
   const panelRef = useRef<HTMLDivElement>(null) as React.RefObject<HTMLDivElement>;
 
-  useOnClickOutside(panelRef, onClose);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: panelRef is stable and read when the event fires
+  useEffect(() => {
+    const handlePointerDown = (event: MouseEvent | TouchEvent) => {
+      const panel = panelRef.current;
+      const target = event.target;
+      if (!panel || !(target instanceof Node) || panel.contains(target)) {
+        return;
+      }
+
+      onClose();
+    };
+
+    document.addEventListener("mousedown", handlePointerDown);
+    document.addEventListener("touchstart", handlePointerDown);
+
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown);
+      document.removeEventListener("touchstart", handlePointerDown);
+    };
+  }, [onClose]);
 
   const handleMouseDown = useCallback((e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
     e.preventDefault();

--- a/web/apps/dashboard/hooks/use-local-storage.ts
+++ b/web/apps/dashboard/hooks/use-local-storage.ts
@@ -1,0 +1,74 @@
+"use client";
+
+import { type Dispatch, type SetStateAction, useCallback, useState } from "react";
+
+// resolveValue handles lazy initial values with the same shape as React state initializers.
+function resolveValue<TValue>(value: TValue | (() => TValue)): TValue {
+  return value instanceof Function ? value() : value;
+}
+
+/**
+ * useLocalStorage persists React state in localStorage using JSON serialization.
+ *
+ * The hook mirrors the subset of `usehooks-ts` behavior used by the dashboard:
+ * it reads once during state initialization, accepts direct values or updater
+ * functions, stores values with `JSON.stringify`, and returns a remove helper
+ * that clears the key and resets state to the initial value.
+ *
+ * If localStorage is unavailable or contains invalid JSON, the hook returns the
+ * initial value and keeps the UI usable.
+ */
+export function useLocalStorage<TValue>(
+  key: string,
+  initialValue: TValue | (() => TValue),
+): readonly [TValue, Dispatch<SetStateAction<TValue>>, () => void] {
+  const readValue = useCallback(() => {
+    const resolvedInitialValue = resolveValue(initialValue);
+
+    if (typeof window === "undefined") {
+      return resolvedInitialValue;
+    }
+
+    try {
+      const storedValue = window.localStorage.getItem(key);
+      if (storedValue === null) {
+        return resolvedInitialValue;
+      }
+
+      if (storedValue === "undefined") {
+        return undefined as TValue;
+      }
+
+      return JSON.parse(storedValue) as TValue;
+    } catch {
+      return resolvedInitialValue;
+    }
+  }, [key, initialValue]);
+
+  const [value, setValueState] = useState<TValue>(readValue);
+
+  const setValue = useCallback(
+    (nextValue: SetStateAction<TValue>) => {
+      try {
+        const resolvedValue = nextValue instanceof Function ? nextValue(readValue()) : nextValue;
+        setValueState(resolvedValue);
+        window.localStorage.setItem(key, JSON.stringify(resolvedValue));
+      } catch {
+        // Keep the UI usable when localStorage is blocked or unavailable.
+      }
+    },
+    [key, readValue],
+  );
+
+  const removeValue = useCallback(() => {
+    const resolvedInitialValue = resolveValue(initialValue);
+    setValueState(resolvedInitialValue);
+    try {
+      window.localStorage.removeItem(key);
+    } catch {
+      // Keep the UI usable when localStorage is blocked or unavailable.
+    }
+  }, [key, initialValue]);
+
+  return [value, setValue, removeValue] as const;
+}

--- a/web/apps/dashboard/package.json
+++ b/web/apps/dashboard/package.json
@@ -98,7 +98,6 @@
     "tldts": "7.0.30",
     "trpc-tools": "0.12.0",
     "typescript": "5.7.3",
-    "usehooks-ts": "3.1.0",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -325,9 +325,6 @@ importers:
       typescript:
         specifier: 5.7.3
         version: 5.7.3
-      usehooks-ts:
-        specifier: 3.1.0
-        version: 3.1.0(react@19.2.4)
       zod:
         specifier: 4.3.5
         version: 4.3.5
@@ -7097,9 +7094,6 @@ packages:
   lodash.castarray@4.4.0:
     resolution: {integrity: sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==}
 
-  lodash.debounce@4.0.8:
-    resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
-
   lodash.isplainobject@4.0.6:
     resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
 
@@ -8904,12 +8898,6 @@ packages:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
-  usehooks-ts@3.1.0:
-    resolution: {integrity: sha512-bBIa7yUyPhE1BCc0GmR96VU/15l/9gP1Ch5mYdLcFBaFGQsdmXkvjV0TtOqW1yUd6VjIwDunm+flSciCQXujiw==}
-    engines: {node: '>=16.15.0'}
-    peerDependencies:
-      react: ^16.8.0  || ^17 || ^18
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -15554,8 +15542,6 @@ snapshots:
 
   lodash.castarray@4.4.0: {}
 
-  lodash.debounce@4.0.8: {}
-
   lodash.isplainobject@4.0.6: {}
 
   lodash.merge@4.6.2: {}
@@ -17789,11 +17775,6 @@ snapshots:
 
   use-sync-external-store@1.6.0(react@19.2.4):
     dependencies:
-      react: 19.2.4
-
-  usehooks-ts@3.1.0(react@19.2.4):
-    dependencies:
-      lodash.debounce: 4.0.8
       react: 19.2.4
 
   util-deprecate@1.0.2: {}


### PR DESCRIPTION
## Summary
- replace the dashboard's usehooks-ts localStorage usage with a documented shared useLocalStorage hook
- inline the resizable log details outside-click listener
- remove usehooks-ts and its lodash.debounce transitive dependency from the web lockfile


The last-used indicator still works
<img width="1700" height="1422" alt="CleanShot 2026-06-25 at 08 41 44@2x" src="https://github.com/user-attachments/assets/82b72fc4-53ca-4e43-b859-d3a6ee35b292" />


The resize also still works
https://cleanshot.com/share/BDKZ0WWN