### PR TITLE
fix: make deployments spread more across nodes

### DIFF
--- a/docs/engineering/architecture/services/krane/overview.mdx
+++ b/docs/engineering/architecture/services/krane/overview.mdx
@@ -71,7 +71,7 @@ User workloads are represented as ReplicaSets with the following characteristics
 
 - Namespaces are created on demand
 - Pods run with `RuntimeClassName: gvisor` for isolation
-- Pods tolerate the `karpenter.sh/nodepool=untrusted` taint
+- Pods select and tolerate `node-class=untrusted` nodes
 - Topology spread keeps replicas balanced across zones
 - Pod affinity prefers zones already running pods with the environment's sentinel component label (`ComponentSentinel`). This is a soft preference inherited from the sentinel proxy layer; since that layer merged into Frontline and no pods carry the label, the affinity currently matches nothing
 - Env vars include `UNKEY_WORKSPACE_ID`, `UNKEY_PROJECT_ID`, `UNKEY_ENVIRONMENT_ID`, and `UNKEY_DEPLOYMENT_ID`

--- a/svc/krane/doc.go
+++ b/svc/krane/doc.go
@@ -1,30 +1,28 @@
 // Package krane provides a distributed container orchestration agent for managing
-// deployments and sentinels across Kubernetes clusters via gRPC APIs.
+// deployments across Kubernetes clusters via gRPC APIs.
 //
 // Krane acts as a node-level agent that exposes gRPC endpoints for container
-// orchestration operations. It manages two primary resource types: deployments
-// (application workloads implemented as ReplicaSets) and sentinels (monitoring/gateway
-// components implemented as Deployments). The agent handles authentication,
-// secrets decryption, and resource lifecycle management through streaming APIs.
+// orchestration operations. It manages deployments (application workloads
+// implemented as ReplicaSets) along with their supporting Kubernetes resources.
+// The agent handles authentication, secrets decryption, and resource lifecycle
+// management through streaming APIs.
 //
 // # Architecture
 //
-// Krane uses a split control loop architecture with two independent controllers:
+// Krane consumes a single unified WatchDeploymentChanges stream from the control
+// plane. A [watcher.Watcher] dispatches each change to the controllers that
+// reconcile the corresponding Kubernetes resources:
 //
-//   - [deployment.Controller]: Manages user workload ReplicaSets via the
-//     SyncDeployments stream. Has its own version cursor and circuit breaker.
+//   - [deployment.Controller]: Manages user workload ReplicaSets, their
+//     HorizontalPodAutoscalers, and per-deployment CiliumNetworkPolicies. Reports
+//     observed pod state back to the control plane.
 //
-//   - [sentinel.Controller]: Manages sentinel Deployments and Services via the
-//     SyncSentinels stream. Has its own version cursor and circuit breaker.
-//
-// This separation provides failure isolation: if one controller experiences errors,
-// the other continues operating independently. Each controller maintains its own
-// connection to the control plane with separate version cursors for resumable
-// streaming.
+// The stream carries a version cursor so it can resume after disconnects, and a
+// resync loop periodically reconciles drift as a safety net.
 //
 // The system consists of these main components:
 //   - Control Plane: External service that streams state to krane agents
-//   - Krane Agents: Node-level agents with independent deployment/sentinel controllers
+//   - Krane Agents: Node-level agents running the watcher and deployment controller
 //   - Kubernetes Cluster: Target infrastructure where containers are deployed
 //
 // Each krane instance is identified by a unique InstanceID. The agent uses in-cluster
@@ -33,8 +31,8 @@
 // # Key Services
 //
 // [kubernetes.Service]: Implements the SchedulerService gRPC interface for
-// deployment and sentinel management operations. Handles ReplicaSet and Deployment
-// creation, updates, deletion, and real-time status streaming.
+// deployment management operations. Handles ReplicaSet creation, updates,
+// deletion, and real-time status streaming.
 //
 // [secrets.Service]: Implements the SecretsService gRPC interface for decrypting
 // environment variables and secrets. Integrates with vault service for secure
@@ -45,10 +43,6 @@
 // Deployment: Application workloads implemented as Kubernetes ReplicaSets with
 // specified container images, resource limits, and replica counts. Each deployment
 // receives standardized environment variables and optional encrypted secrets.
-//
-// Sentinel: Edge components implemented as Kubernetes Deployments for monitoring,
-// routing, and security functions. Sentinels are managed separately from deployments
-// and provide infrastructure services.
 //
 // # Usage
 //

--- a/svc/krane/internal/deployment/apply.go
+++ b/svc/krane/internal/deployment/apply.go
@@ -42,8 +42,8 @@ import (
 // namespace, owned by the ReplicaSet, that permits ingress only from
 // frontline pods on the deployment's container port. Pods run with gVisor
 // isolation (RuntimeClass "gvisor") since they execute untrusted user code,
-// and are scheduled on Karpenter-managed untrusted nodes with zone-spread
-// constraints.
+// and are scheduled on Karpenter-managed untrusted nodes with node- and
+// zone-spread constraints so replicas don't stack on a single node.
 func (c *Controller) ApplyDeployment(ctx context.Context, req *ctrlv1.ApplyDeployment) (retErr error) {
 	defer func() { metrics.RecordReconcile("deployment", "apply", retErr) }()
 	logger.Info("applying deployment",
@@ -216,9 +216,9 @@ func (c *Controller) ApplyDeployment(ctx context.Context, req *ctrlv1.ApplyDeplo
 		RestartPolicy:                corev1.RestartPolicyAlways,
 		AutomountServiceAccountToken: ptr.P(false),
 		EnableServiceLinks:           ptr.P(false),
+		NodeSelector:                 map[string]string{nodeClassLabelKey: CustomerNodeClass},
 		Tolerations:                  []corev1.Toleration{untrustedToleration},
 		TopologySpreadConstraints:    deploymentTopologySpread(req.GetDeploymentId()),
-		Affinity:                     deploymentAffinity(req.GetEnvironmentId()),
 		Containers:                   []corev1.Container{container},
 	}
 

--- a/svc/krane/internal/deployment/consts.go
+++ b/svc/krane/internal/deployment/consts.go
@@ -15,6 +15,10 @@ const (
 	// workloads. Nodes in this pool have additional isolation and monitoring.
 	CustomerNodeClass = "untrusted"
 
+	// nodeClassLabelKey selects and tolerates the infra node class assigned by
+	// the Karpenter NodePool.
+	nodeClassLabelKey = "node-class"
+
 	// resourceRequestFraction is the fraction of limits used for resource requests.
 	// Requests determine scheduling; limits cap actual usage.
 	resourceRequestFraction = 2 // requests = limits / N
@@ -41,9 +45,7 @@ const (
 	// so only pods inside the frontline namespace can reach the customer
 	// pods. We trust the namespace boundary instead of additionally
 	// matching an "app" label because the prod helm chart and the dev
-	// manifest disagree on label conventions; matching by namespace alone
-	// is also the approach the cluster-wide allow-frontline-to-sentinel
-	// policy in infra/eks-cluster/helm-chart/networking already uses.
+	// manifest disagree on label conventions.
 	frontlineNamespace = "frontline"
 )
 
@@ -51,7 +53,7 @@ const (
 // for untrusted workloads. Without this toleration, pods would be rejected by
 // the Karpenter-managed nodepool's NoSchedule taint.
 var untrustedToleration = corev1.Toleration{
-	Key:      "karpenter.sh/nodepool",
+	Key:      nodeClassLabelKey,
 	Operator: corev1.TolerationOpEqual,
 	Value:    CustomerNodeClass,
 	Effect:   corev1.TaintEffectNoSchedule,

--- a/svc/krane/internal/deployment/doc.go
+++ b/svc/krane/internal/deployment/doc.go
@@ -24,13 +24,14 @@
 //
 // All user workloads run with gVisor isolation (RuntimeClass "gvisor") since they
 // execute untrusted code. Each namespace gets a CiliumNetworkPolicy that restricts
-// ingress to only sentinels with matching workspace and environment IDs.
+// ingress to only the frontline namespace on the deployment's container port.
 //
 // # Scheduling
 //
-// Deployment pods are spread across availability zones using TopologySpreadConstraints
-// with maxSkew=1 for high availability. Pod affinity prefers scheduling in the same
-// zone as the environment's sentinels to minimize cross-AZ latency.
+// Deployment pods are spread across both nodes and availability zones using
+// TopologySpreadConstraints with maxSkew=1 for high availability. The hostname
+// constraint keeps a deployment's replicas from stacking on a single node; the
+// zone constraint adds cross-AZ redundancy once the cluster spans multiple zones.
 //
 // # Usage
 //

--- a/svc/krane/internal/deployment/scheduling.go
+++ b/svc/krane/internal/deployment/scheduling.go
@@ -10,51 +10,49 @@ const (
 	// topologyKeyZone is the standard Kubernetes label for availability zones,
 	// used for spreading pods across zones for high availability.
 	topologyKeyZone = "topology.kubernetes.io/zone"
+
+	// topologyKeyHostname is the standard Kubernetes label for individual nodes,
+	// used for spreading pods across nodes so a single node failure can't take
+	// out all of a deployment's replicas.
+	topologyKeyHostname = "kubernetes.io/hostname"
 )
 
 // deploymentTopologySpread returns topology spread constraints that distribute
-// deployment pods evenly across availability zones.
+// customer workload pods across both nodes and availability zones.
 //
-// The constraints use maxSkew=1 with WhenUnsatisfiable=ScheduleAnyway, meaning
-// the scheduler prefers even distribution but won't block scheduling if zones
-// are imbalanced. This ensures deployments remain schedulable even in degraded
-// cluster states while still achieving zone redundancy under normal conditions.
+// Both constraints use maxSkew=1 with WhenUnsatisfiable=ScheduleAnyway, meaning
+// the scheduler prefers even distribution but won't block scheduling if the
+// topology is imbalanced. This keeps deployments schedulable even in degraded
+// cluster states while still achieving node and zone redundancy under normal
+// conditions.
+//
+// The hostname constraint is what prevents replicas from stacking on a single
+// node. It selects on deployment ID so each deployment spreads independently of
+// others sharing the nodepool. The zone constraint selects all krane deployment
+// pods in the namespace, so single-replica deployments still contribute to
+// namespace-level AZ spread and Karpenter gets pressure to provision untrusted
+// nodes outside the currently crowded AZ.
 func deploymentTopologySpread(deploymentID string) []corev1.TopologySpreadConstraint {
+	deploymentSelector := &metav1.LabelSelector{
+		MatchLabels: labels.New().DeploymentID(deploymentID),
+	}
+	fleetSelector := &metav1.LabelSelector{
+		MatchLabels: labels.New().
+			ManagedByKrane().
+			ComponentDeployment(),
+	}
 	return []corev1.TopologySpreadConstraint{
+		{
+			MaxSkew:           1,
+			TopologyKey:       topologyKeyHostname,
+			WhenUnsatisfiable: corev1.ScheduleAnyway,
+			LabelSelector:     deploymentSelector,
+		},
 		{
 			MaxSkew:           1,
 			TopologyKey:       topologyKeyZone,
 			WhenUnsatisfiable: corev1.ScheduleAnyway,
-			LabelSelector: &metav1.LabelSelector{
-				MatchLabels: labels.New().DeploymentID(deploymentID),
-			},
-		},
-	}
-}
-
-// deploymentAffinity returns pod affinity rules that prefer co-locating deployment
-// pods with their environment's sentinel pods in the same availability zone.
-//
-// This optimization reduces cross-AZ latency between sentinels and the user code
-// they proxy to. The affinity is a soft preference (weight=100) rather than a hard
-// requirement, so deployments can still schedule if no sentinel-local zones have
-// capacity.
-func deploymentAffinity(environmentID string) *corev1.Affinity {
-	return &corev1.Affinity{
-		PodAffinity: &corev1.PodAffinity{
-			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
-				{
-					Weight: 100,
-					PodAffinityTerm: corev1.PodAffinityTerm{
-						TopologyKey: topologyKeyZone,
-						LabelSelector: &metav1.LabelSelector{
-							MatchLabels: labels.New().
-								EnvironmentID(environmentID).
-								ComponentSentinel(),
-						},
-					},
-				},
-			},
+			LabelSelector:     fleetSelector,
 		},
 	}
 }

--- a/svc/krane/internal/podstatus/podstatus.go
+++ b/svc/krane/internal/podstatus/podstatus.go
@@ -1,7 +1,6 @@
 // Package podstatus provides small helpers for inspecting a pod's
-// ContainersReady condition from krane's watch loops. Both the deployment
-// and sentinel controllers use them to emit the same lag metric and log
-// fields.
+// ContainersReady condition from krane's watch loops. The deployment
+// controller uses them to emit the lag metric and log fields.
 package podstatus
 
 import (
@@ -26,7 +25,7 @@ import (
 // skipped entirely for the same reason: the LastTransitionTime on a
 // deleted pod is historical.
 type LagRecorder struct {
-	// component labels the metric ("deployment" or "sentinel").
+	// component labels the metric (e.g. "deployment").
 	component string
 
 	// observed caches (pod UID -> last recorded LastTransitionTime) so we

--- a/svc/krane/pkg/labels/doc.go
+++ b/svc/krane/pkg/labels/doc.go
@@ -19,11 +19,10 @@
 //   - unkey.com/project.id - Project identifier
 //   - unkey.com/environment.id - Environment identifier
 //   - unkey.com/deployment.id - Deployment identifier
-//   - unkey.com/sentinel.id - Sentinel identifier
 //
 // Component and management labels:
 //   - app.kubernetes.io/managed-by - Always "krane" for managed resources
-//   - app.kubernetes.io/component - Either "deployment" or "sentinel"
+//   - app.kubernetes.io/component - Either "deployment" or "ciliumnetworkpolicy"
 //
 // # Key Types
 //

--- a/svc/krane/pkg/labels/labels.go
+++ b/svc/krane/pkg/labels/labels.go
@@ -14,7 +14,6 @@ const (
 	LabelKeyEnvironmentID   = "unkey.com/environment.id"
 	LabelKeyDeploymentID    = "unkey.com/deployment.id"
 	LabelKeyBuildID         = "unkey.com/build.id"
-	LabelKeySentinelID      = "unkey.com/sentinel.id"
 	LabelKeyNetworkPolicyID = "unkey.com/networkpolicy.id"
 	LabelKeyPlatform        = "unkey.com/platform"
 	LabelKeyManagedBy       = "app.kubernetes.io/managed-by"
@@ -98,16 +97,6 @@ func (l Labels) ManagedByKrane() Labels {
 	return l
 }
 
-// SentinelID adds sentinel ID label to the label set.
-//
-// This method sets the "unkey.com/sentinel.id" label for identifying
-// the specific sentinel that owns this resource. Returns the same
-// Labels instance for method chaining.
-func (l Labels) SentinelID(id string) Labels {
-	l[LabelKeySentinelID] = id
-	return l
-}
-
 // NetworkPolicyID adds network policy ID label to the label set.
 //
 // This method sets the "unkey.com/networkpolicy.id" label for identifying
@@ -115,16 +104,6 @@ func (l Labels) SentinelID(id string) Labels {
 // for method chaining.
 func (l Labels) NetworkPolicyID(id string) Labels {
 	l[LabelKeyNetworkPolicyID] = id
-	return l
-}
-
-// ComponentSentinel adds component label for sentinel resources.
-//
-// This method sets "app.kubernetes.io/component" label to "sentinel"
-// to identify resource as a sentinel component. Returns the same
-// Labels instance for method chaining.
-func (l Labels) ComponentSentinel() Labels {
-	l[LabelKeyComponent] = "sentinel"
 	return l
 }
 
@@ -191,16 +170,6 @@ func (l Labels) ToString() string {
 		s += fmt.Sprintf("%s=%s,", k, v)
 	}
 	return strings.TrimSuffix(s, ",")
-}
-
-// GetSentinelID extracts sentinel ID from Kubernetes label map.
-//
-// This helper function retrieves the "unkey.com/sentinel.id" label from
-// a Kubernetes resource's labels. Returns the ID and a boolean indicating
-// whether the label was found.
-func GetSentinelID(l map[string]string) (string, bool) {
-	v, ok := l[LabelKeySentinelID]
-	return v, ok
 }
 
 // GetDeploymentID extracts deployment ID from Kubernetes label map.

--- a/svc/krane/pkg/metrics/prometheus.go
+++ b/svc/krane/pkg/metrics/prometheus.go
@@ -10,7 +10,7 @@ var (
 	// Use this to monitor deployment throughput and error rates.
 	//
 	// Labels:
-	//   - "resource_type": "deployment", "sentinel", or "cilium_network_policy"
+	//   - "resource_type": "deployment" or "cilium_network_policy"
 	//   - "operation": "apply" or "delete"
 	//   - "result": "success" or "error"
 	ReconcileOperationsTotal = lazy.NewCounterVec(
@@ -27,7 +27,7 @@ var (
 	// High values indicate the streaming path is missing events and resync is compensating.
 	//
 	// Labels:
-	//   - "resource_type": "deployment", "sentinel", or "cilium_network_policy"
+	//   - "resource_type": "deployment" or "cilium_network_policy"
 	ResyncCorrectionsTotal = lazy.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "unkey",
@@ -89,7 +89,7 @@ var (
 	//
 	// Labels:
 	//   - "source": "stream" or "full_sync"
-	//   - "resource_type": "deployment", "sentinel", or "cilium_network_policy"
+	//   - "resource_type": "deployment" or "cilium_network_policy"
 	//   - "status": "success" or "error"
 	DispatchTotal = lazy.NewCounterVec(
 		prometheus.CounterOpts{
@@ -123,10 +123,10 @@ var (
 	)
 
 	// PodWatchEventsTotal counts pod watch events and their disposition for
-	// both the deployment and sentinel controllers.
+	// the deployment controller.
 	//
 	// Labels:
-	//   - "component": "deployment" or "sentinel"
+	//   - "component": "deployment"
 	//   - "event_type": k8s watch event type ("added", "modified", "deleted")
 	//   - "outcome": "reported", "deduped", "skipped_no_rs", "skipped_rs_gone",
 	//                "skipped_no_deployment", "error"
@@ -151,7 +151,7 @@ var (
 	// missed") lives on [ResyncCorrectionsTotal].
 	//
 	// Labels:
-	//   - "component": "deployment" or "sentinel"
+	//   - "component": "deployment"
 	//   - "source": "watch" (real-time) — kept as a label for future
 	//               resync-sourced samples.
 	PodWatchDeliveryLagSeconds = lazy.NewHistogramVec(
@@ -171,7 +171,7 @@ var (
 	// on the "resync" label of PodWatchDeliveryLagSeconds.
 	//
 	// Labels:
-	//   - "component": "deployment" or "sentinel"
+	//   - "component": "deployment"
 	//   - "reason": "channel_closed", "error"
 	PodWatchReconnectsTotal = lazy.NewCounterVec(
 		prometheus.CounterOpts{
@@ -184,18 +184,17 @@ var (
 	)
 
 	// ReportStatusDurationSeconds measures krane-side latency of the
-	// ReportDeploymentStatus and ReportSentinelStatus RPCs, including
-	// circuit breaker overhead.
+	// ReportDeploymentStatus RPC, including circuit breaker overhead.
 	//
 	// Labels:
-	//   - "component": "deployment" or "sentinel"
+	//   - "component": "deployment"
 	//   - "result": "success", "error"
 	ReportStatusDurationSeconds = lazy.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: "unkey",
 			Subsystem: "krane",
 			Name:      "report_status_duration_seconds",
-			Help:      "Duration of ReportDeploymentStatus / ReportSentinelStatus calls from krane.",
+			Help:      "Duration of ReportDeploymentStatus calls from krane.",
 			Buckets:   []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5},
 		},
 		[]string{"component", "result"},
@@ -205,7 +204,7 @@ var (
 	// because the fingerprint matched the last successful report.
 	//
 	// Labels:
-	//   - "component": "deployment" or "sentinel"
+	//   - "component": "deployment"
 	ReportDedupedTotal = lazy.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "unkey",


### PR DESCRIPTION
## What

Updates krane's customer workload scheduling so deployments spread more effectively across untrusted capacity:

- Removes the stale sentinel pod affinity path.
- Keeps per-deployment hostname spread, so replicas of the same deployment avoid stacking on one node.
- Changes the AZ spread selector from a single `deployment_id` to all krane deployment pods in the namespace (`app.kubernetes.io/managed-by=krane`, `app.kubernetes.io/component=deployment`).
- Selects/tolerates the infra-owned `node-class=untrusted` node class explicitly.

## Why

The untrusted Karpenter pool can concentrate nodes in one AZ because Karpenter does not balance NodePools by itself. Nodes follow pod scheduling constraints.

The previous per-deployment AZ spread only helped multi-replica deployments. Single-replica deployments did not contribute to any shared AZ balance, so many independent customer pods could still stack into the same AZ and cause Karpenter to provision all untrusted nodes there.

Using a namespace-level krane deployment selector gives kube-scheduler/Karpenter pressure to place new customer pods in less-crowded AZs without making AZ spread a hard requirement. This keeps customer pods schedulable during AZ or capacity issues because the constraint remains `ScheduleAnyway`.

Note: Kubernetes topology spread is namespace-scoped, so this improves spread within each customer namespace. It is not a global NodePool balancing knob.

## Testing

```bash
mise exec -- bazel test //svc/krane/internal/deployment:deployment_test --test_output=errors
```
