### PR TITLE
fix(dashboard): Fix blank app overview card 

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/overview/components/production-deployment-card.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/overview/components/production-deployment-card.tsx
@@ -40,7 +40,6 @@ export function ProductionDeploymentCard() {
     deployments,
     environments,
     customDomains,
-    getDeploymentById,
     getDomainsForDeployment,
     isDeploymentsLoading,
   } = useProjectData();
@@ -60,9 +59,20 @@ export function ProductionDeploymentCard() {
   const repoFullName = app?.repositoryFullName ?? null;
 
   const currentDeploymentId = app?.currentDeploymentId ?? null;
-  const currentDeployment = currentDeploymentId
-    ? getDeploymentById(currentDeploymentId)
-    : undefined;
+  const currentDeploymentQuery = useLiveQuery(
+    (q) =>
+      q
+        .from({ deployment: collection.deployments })
+        .where(({ deployment }) =>
+          and(
+            eq(deployment.projectId, projectId),
+            eq(deployment.appId, appId),
+            eq(deployment.id, currentDeploymentId ?? ""),
+          ),
+        ),
+    [projectId, appId, currentDeploymentId],
+  );
+  const currentDeployment = currentDeploymentId ? currentDeploymentQuery.data?.[0] : undefined;
 
   const productionEnvironmentId = environments.find((e) => e.slug === "production")?.id;
   const latestProductionDeployment = productionEnvironmentId
@@ -77,7 +87,10 @@ export function ProductionDeploymentCard() {
     { refetchInterval: 30_000 },
   );
 
-  if (isDeploymentsLoading || appsQuery.isLoading) {
+  const isResolvingCurrentDeployment =
+    currentDeploymentId != null && currentDeploymentQuery.isLoading;
+
+  if (isDeploymentsLoading || appsQuery.isLoading || isResolvingCurrentDeployment) {
     return <ProductionDeploymentCardSkeleton />;
   }
 

--- a/web/apps/dashboard/lib/trpc/routers/deploy/deployment/deployment-query-helpers.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/deployment/deployment-query-helpers.ts
@@ -1,5 +1,6 @@
 import type { InstanceStatus } from "@/lib/collections/deploy/instance-status";
-import { deployments } from "@unkey/db/src/schema";
+import { and, db, eq } from "@/lib/db";
+import { apps, deployments } from "@unkey/db/src/schema";
 import { mapRegionToFlag } from "../network/utils";
 
 export const deploymentSelectFields = {
@@ -61,4 +62,38 @@ export function normalizeDeploymentRow(deployment: {
       deployment.gitCommitAuthorAvatarUrl ?? "https://github.com/identicons/dummy-user.png",
     gitCommitTimestamp: deployment.gitCommitTimestamp,
   };
+}
+
+// The overview resolves the live deployment by id from the collection, so it
+// must be present even when older than the newest-N window the list returns.
+export async function fetchCurrentDeploymentOutsideWindow(
+  workspaceId: string,
+  input: { projectId: string; appId: string },
+  loadedRows: { id: string }[],
+) {
+  const [app] = await db
+    .select({ currentDeploymentId: apps.currentDeploymentId })
+    .from(apps)
+    .where(
+      and(
+        eq(apps.workspaceId, workspaceId),
+        eq(apps.projectId, input.projectId),
+        eq(apps.id, input.appId),
+      ),
+    );
+  const currentId = app?.currentDeploymentId;
+  if (!currentId || loadedRows.some((d) => d.id === currentId)) {
+    return null;
+  }
+  const [deployment] = await db
+    .select({ ...deploymentSelectFields, appId: deployments.appId })
+    .from(deployments)
+    .where(
+      and(
+        eq(deployments.workspaceId, workspaceId),
+        eq(deployments.projectId, input.projectId),
+        eq(deployments.id, currentId),
+      ),
+    );
+  return deployment ?? null;
 }

--- a/web/apps/dashboard/lib/trpc/routers/deploy/deployment/list.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/deployment/list.ts
@@ -14,6 +14,7 @@ import { z } from "zod";
 import { type FlagCode, mapRegionToFlag } from "../network/utils";
 import {
   deploymentSelectFields,
+  fetchCurrentDeploymentOutsideWindow,
   mapInstanceRow,
   normalizeDeploymentRow,
 } from "./deployment-query-helpers";
@@ -49,6 +50,21 @@ export const listDeployments = workspaceProcedure
 
       if (deploymentRows.length === 0) {
         return [];
+      }
+
+      if (
+        input.appId !== undefined &&
+        input.startTime === undefined &&
+        input.endTime === undefined
+      ) {
+        const currentDeployment = await fetchCurrentDeploymentOutsideWindow(
+          ctx.workspace.id,
+          { projectId: input.projectId, appId: input.appId },
+          deploymentRows,
+        );
+        if (currentDeployment) {
+          deploymentRows.push(currentDeployment);
+        }
       }
 
       const deploymentIds = deploymentRows.map((d) => d.id);


### PR DESCRIPTION
## What does this PR do?

- Fixes a bug with the app overview page, where live deployments that fall outside of the latest 100 deploys were appearing as blank on the overview card. 

**Note from claude:**

One implementation note: the fix lives in the shared `list.ts` rather than a one-off `getById` fetch on the card. Keeping it in the list query means the deployment flows through the same collection as everything else, so it stays live (the card polls and updates) and there's a single source of truth. The cost is one extra indexed `apps` lookup per unfiltered list call.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

1. Find an app whose current deployment is older than its 100 newest deployments (or seed 100+ newer ones for an app whose `currentDeploymentId` points at the oldest deployment).
2. Open the app overview. Before this change the hero showed "No domain yet" and "0 running". Now it shows that deployment's domain, region, instances, and real status.
3. Check the deployments list page still behaves the same (newest first, still capped), and that adding a date filter doesn't pull the old deployment into the results.

Not tested: a project-wide list call that resolves several apps' current deployments at once. The overview always queries a single app, so that path doesn't run here.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary

_Screenshots: to be added (light, dark, mobile)._