### PR TITLE
feat: add failure % for cb

### DIFF
--- a/internal/services/ratelimit/origin.go
+++ b/internal/services/ratelimit/origin.go
@@ -48,6 +48,17 @@ const originFetchTimeout = 300 * time.Millisecond
 // since in-region Redis recovers fast.
 const originBreakerOpenTimeout = 5 * time.Second
 
+// The origin breaker trips on failure *rate*, not an absolute count. A pod runs
+// hundreds of origin ops/s, and individual timeouts already degrade gracefully
+// (the request falls back to local state). An absolute threshold trips on
+// harmless sub-1% blips — e.g. the cold-key herd at window rollover — and then
+// fail-fasts every tenant on the pod. A rate only fires when a real outage
+// makes most ops fail, independent of throughput.
+const (
+	originBreakerFailureRatio = 0.5 // open when >=50% of origin ops in the window fail
+	originBreakerMinRequests  = 20  // ...but only after a meaningful sample
+)
+
 // fetchFromOrigin returns the current counter value from the origin. The call is
 // wrapped in the origin circuit breaker so that Redis outages fail fast instead
 // of stalling every request in strict mode. On any failure (circuit tripped,

--- a/internal/services/ratelimit/service.go
+++ b/internal/services/ratelimit/service.go
@@ -380,6 +380,7 @@ func New(config Config) (*service, error) {
 		originCircuitBreaker: circuitbreaker.New[int64](
 			"ratelimitOrigin",
 			circuitbreaker.WithTimeout(originBreakerOpenTimeout),
+			circuitbreaker.WithFailureRatio(originBreakerFailureRatio, originBreakerMinRequests),
 		),
 		globalCircuitBreaker: circuitbreaker.New[any]("ratelimit_global_push"),
 		db:                   db.New(config.DB.RW(), config.DB.RO()),

--- a/pkg/circuitbreaker/lib.go
+++ b/pkg/circuitbreaker/lib.go
@@ -59,6 +59,18 @@ type config struct {
 	// circuit trips and opens
 	tripThreshold int
 
+	// failureRatio, when > 0, switches tripping from an absolute count to a
+	// rate: the circuit opens once failures/requests within the cyclic period
+	// reaches this fraction, but only after at least minRequests requests so a
+	// tiny sample can't trip it. This is robust to traffic volume — a brief
+	// sub-1% blip never trips, while a real outage (most requests failing)
+	// trips fast regardless of throughput. When 0, tripThreshold is used.
+	failureRatio float64
+
+	// minRequests is the minimum number of requests within the cyclic period
+	// before failureRatio is evaluated. Ignored when failureRatio is 0.
+	minRequests int
+
 	// Clock to use for timing, defaults to the system clock but can be overridden for testing
 	clock clock.Clock
 }
@@ -98,6 +110,24 @@ func WithTripThreshold(tripThreshold int) applyConfig {
 	}
 }
 
+// WithFailureRatio switches tripping from an absolute failure count to a
+// failure rate. The circuit opens once failures/requests within the cyclic
+// period reaches ratio (0..1], but only after at least minRequests requests so
+// a small sample can't trip it. Prefer this for high-throughput call sites
+// where a fixed count is either trivially exceeded by harmless blips or never
+// reached during a low-traffic outage. ratio <= 0 disables it (falls back to
+// WithTripThreshold). A ratio above 1 is clamped to 1 (requires 100% failures)
+// so a typo can't silently produce a breaker that never trips on rate.
+func WithFailureRatio(ratio float64, minRequests int) applyConfig {
+	return func(c *config) {
+		if ratio > 1 {
+			ratio = 1
+		}
+		c.failureRatio = ratio
+		c.minRequests = minRequests
+	}
+}
+
 // WithTimeout sets how long the circuit remains [Open] before transitioning
 // to [HalfOpen] to probe for recovery. Defaults to 1 minute.
 func WithTimeout(timeout time.Duration) applyConfig {
@@ -131,6 +161,8 @@ func New[Res any](name string, applyConfigs ...applyConfig) *CB[Res] {
 			return err != nil
 		},
 		tripThreshold: 5,
+		failureRatio:  0,
+		minRequests:   0,
 		clock:         clock.New(),
 	}
 
@@ -236,7 +268,7 @@ func (cb *CB[Res]) postflight(_ context.Context, err error) {
 	switch cb.state {
 
 	case Closed:
-		if cb.failures >= cb.config.tripThreshold {
+		if cb.shouldTrip() {
 			cb.state = Open
 		}
 
@@ -246,4 +278,17 @@ func (cb *CB[Res]) postflight(_ context.Context, err error) {
 		}
 	}
 
+}
+
+// shouldTrip reports whether the accumulated counts in the current cyclic
+// period warrant opening the circuit. Rate-based when failureRatio is set,
+// otherwise the legacy absolute count. Caller must hold the lock.
+func (cb *CB[Res]) shouldTrip() bool {
+	if cb.config.failureRatio > 0 {
+		if cb.requests < cb.config.minRequests {
+			return false
+		}
+		return float64(cb.failures)/float64(cb.requests) >= cb.config.failureRatio
+	}
+	return cb.failures >= cb.config.tripThreshold
 }

--- a/pkg/circuitbreaker/lib_test.go
+++ b/pkg/circuitbreaker/lib_test.go
@@ -42,6 +42,56 @@ func TestCircuitBreakerStates(t *testing.T) {
 	require.Equal(t, HalfOpen, cb.state)
 }
 
+func TestCircuitBreakerFailureRatio(t *testing.T) {
+	run := func(cb *CB[int], fail bool) {
+		_, _ = cb.Do(context.Background(), func(ctx context.Context) (int, error) {
+			if fail {
+				return 0, errTestDownstream
+			}
+			return 0, nil
+		})
+	}
+
+	t.Run("low failure rate does not trip even with many absolute failures", func(t *testing.T) {
+		c := clock.NewTestClock()
+		// 50% ratio, but a high-throughput window: 1000 ok + 5 fail = 0.5% << 50%.
+		cb := New[int]("test", WithClock(c), WithCyclicPeriod(time.Hour),
+			WithFailureRatio(0.5, 20))
+		for i := 0; i < 1000; i++ {
+			run(cb, false)
+		}
+		for i := 0; i < 5; i++ {
+			run(cb, true)
+		}
+		require.Equal(t, Closed, cb.state, "0.5%% failure rate must not trip a 50%% breaker")
+	})
+
+	t.Run("high failure rate trips once past minRequests", func(t *testing.T) {
+		c := clock.NewTestClock()
+		cb := New[int]("test", WithClock(c), WithCyclicPeriod(time.Hour),
+			WithFailureRatio(0.5, 20))
+		// Below minRequests: all failing but sample too small to act.
+		for i := 0; i < 19; i++ {
+			run(cb, true)
+		}
+		require.Equal(t, Closed, cb.state, "must not trip before minRequests")
+		run(cb, true) // 20th failing request crosses minRequests at 100% failure
+		require.Equal(t, Open, cb.state, "100%% failure past minRequests must trip")
+	})
+
+	t.Run("ratio above 1 is clamped to 1 and still trips at 100% failure", func(t *testing.T) {
+		c := clock.NewTestClock()
+		// A typo'd ratio of 1.5 must not silently produce a never-tripping breaker.
+		cb := New[int]("test", WithClock(c), WithCyclicPeriod(time.Hour),
+			WithFailureRatio(1.5, 5))
+		require.Equal(t, 1.0, cb.config.failureRatio, "ratio above 1 must clamp to 1")
+		for i := 0; i < 5; i++ {
+			run(cb, true)
+		}
+		require.Equal(t, Open, cb.state, "100%% failure past minRequests must trip a clamped breaker")
+	})
+}
+
 func TestCircuitBreakerReset(t *testing.T) {
 
 	c := clock.NewTestClock()


### PR DESCRIPTION
## What

Add failure-*rate* tripping to the circuit breaker (`WithFailureRatio(ratio, minRequests)`) and use it for the ratelimit origin breaker instead of an absolute failure count.

## Why

This is the fix for the recurring `RatelimitOriginErrors` alert in us-west-2. The origin breaker tripped on an **absolute** count (`tripThreshold`, default 5 failures per 5s cyclic window). On the request path each pod runs hundreds of origin ops/s, so:

- A harmless sub-1% blip trips it instantly. The window-rollover cold-key herd produces a brief tail of timeouts (a few/s); at ~840 ops/s that is well under 1% of ops, but it blows past 5 absolute failures in milliseconds. The breaker then opens and fail-fasts **every tenant on the pod** for the whole open window, turning a ~0.14% timeout blip into a ~3% `circuit_open` flood that fires the alert.
- An absolute count is also wrong in the other direction: during a genuine low-traffic outage it can take too long to reach the number.

The breaker exists to fail fast when the origin is genuinely unreachable, not to react to a sub-1% blip that each request already handles gracefully by falling back to local state. So it should trip on the failure *fraction*, which is independent of throughput.

Confirmed in prod: Dragonfly answers GETs in ~24us the whole time, and after the CPU-limit fix (separate infra change) CFS throttling dropped to zero and real timeouts fell to ~2.3/s, yet `circuit_open` stayed at ~62/s (26x the real failures) and the alert still fired. The breaker amplification was the remaining cause.

## How

`WithFailureRatio(ratio, minRequests)` switches tripping to "open when failures/requests within the cyclic period >= ratio, but only after at least minRequests requests" so a tiny sample cannot trip it. It is backward compatible: when unset (ratio = 0) the breaker uses the existing `tripThreshold` count, so other call sites are unchanged. The breaker already tracked `requests` and `failures` per cyclic period, so this is a small, contained change.

The ratelimit origin breaker now uses `WithFailureRatio(0.5, 20)`: open only when >=50% of origin ops in the window fail, after a meaningful sample. A 0.14% herd blip never trips it; a real Dragonfly outage (most ops failing) still trips it fast, regardless of traffic volume.

## Test

`TestCircuitBreakerFailureRatio`:
- 1000 ok + 5 fail (0.5%) against a 50% breaker stays Closed.
- 100% failures stay Closed until minRequests, then trip on the request that crosses it.

```bash
mise exec -- bazel test //pkg/circuitbreaker:circuitbreaker_test
```

## Companion changes

- infra: raise `unkey-api` CPU limit 1 -> 2 (matches GOMAXPROCS=2, removes the CFS throttling that produced the real timeouts).
- infra: stop dropping `container_cpu_cfs_throttled_seconds_total` so throttle severity is measurable.

Together these address the incident: the CPU limit removes the cause of the timeouts, and this PR stops the breaker from amplifying the small residual into an alert.
