### PR TITLE
fix: ratelimit validation does not retrigger

### DIFF
--- a/web/apps/dashboard/components/dashboard/ratelimits/ratelimit-setup.tsx
+++ b/web/apps/dashboard/components/dashboard/ratelimits/ratelimit-setup.tsx
@@ -138,6 +138,7 @@ export const RatelimitSetup = ({
       refillInterval: 1000,
       autoApply: false,
     });
+    trigger("ratelimit");
   };
 
   const description =

--- a/web/apps/dashboard/components/dashboard/ratelimits/ratelimit-setup.tsx
+++ b/web/apps/dashboard/components/dashboard/ratelimits/ratelimit-setup.tsx
@@ -2,12 +2,25 @@
 import { ProtectionSwitch } from "@/components/dashboard/metadata/protection-switch";
 import { parseDuration } from "@/lib/duration";
 import { formatMs } from "@/lib/ms";
-import type { RatelimitFormValues, RatelimitItem } from "@/lib/schemas/ratelimit";
+import type { RatelimitItem } from "@/lib/schemas/ratelimit";
 import { Gauge, Trash } from "@unkey/icons";
 import { Button, FormCheckbox, FormInput, InlineLink } from "@unkey/ui";
 import { cn } from "@unkey/ui/src/lib/utils";
 import { useEffect, useState } from "react";
 import { Controller, useFieldArray, useFormContext, useWatch } from "react-hook-form";
+
+// The form's `ratelimit` field is a Zod discriminated union (enabled false/true),
+// which makes react-hook-form collapse the `ratelimit.data` field-array element
+// type and reject `RatelimitItem`. Typing the form context against the concrete
+// runtime shape lets the field-array helpers infer `RatelimitItem` directly,
+// avoiding `any` casts. The disabled branch still carries `data` at runtime
+// (set via the schema's prefault), so `boolean` is accurate here.
+type RatelimitFieldValues = {
+  ratelimit: {
+    enabled: boolean;
+    data: RatelimitItem[];
+  };
+};
 
 function RefillIntervalField({
   value,
@@ -81,7 +94,8 @@ export const RatelimitSetup = ({
     control,
     setValue,
     trigger,
-  } = useFormContext<RatelimitFormValues>();
+    clearErrors,
+  } = useFormContext<RatelimitFieldValues>();
 
   // Helper to safely access error messages from conditional schema
   const getFieldError = (index: number, field: keyof RatelimitItem): string | undefined => {
@@ -113,8 +127,7 @@ export const RatelimitSetup = ({
   // Ensure there's always at least one ratelimit item
   useEffect(() => {
     if (fields.length === 0) {
-      // biome-ignore lint/suspicious/noExplicitAny: useFieldArray with discriminated unions requires type assertion
-      (append as any)({
+      append({
         id: undefined,
         name: "Default",
         limit: 10,
@@ -129,16 +142,21 @@ export const RatelimitSetup = ({
     trigger("ratelimit");
   };
 
-  const handleAddRatelimit = () => {
-    // biome-ignore lint/suspicious/noExplicitAny: useFieldArray with discriminated unions requires type assertion
-    (append as any)({
+  const handleAddRatelimit = async () => {
+    const newIndex = fields.length;
+    append({
       id: undefined,
       name: "",
       limit: 10,
       refillInterval: 1000,
       autoApply: false,
     });
-    trigger("ratelimit");
+    // Re-run validation so the form/step validity reflects the newly added
+    // (incomplete) rule and the submit button disables. Then clear the new
+    // rule's errors so we don't flag fields the user hasn't filled in yet.
+    // clearErrors only mutates the errors object, leaving isValid untouched.
+    await trigger("ratelimit");
+    clearErrors(`ratelimit.data.${newIndex}`);
   };
 
   const description =
@@ -178,8 +196,7 @@ export const RatelimitSetup = ({
       </div>
 
       <div>
-        {/* biome-ignore lint/suspicious/noExplicitAny: useFieldArray with discriminated unions requires type assertion */}
-        {(fields as any[]).map((field: any, index: number) => (
+        {fields.map((field, index) => (
           <div key={field.id} className="flex flex-col gap-4 w-full border-t border-grayA-3 py-6">
             <div className="flex items-center gap-3.5 w-full">
               <FormInput


### PR DESCRIPTION
## What does this PR do?

We now trigger regardless of the state or how we add them. 

_If there is not an issue for this, create one first. This is used for tracking purposes and helps us understand why this PR exists._

<!-- If there isn't an issue for this PR, review the internal workflow guide and create an issue. -->

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- edit a key and add another ratelimit and add the name. 
- create a key and add as many ratelimits as you want.

## Checklist

<!-- Complete this checklist before requesting review. -->

### Required

- [X] Filled out the "How to test" section in this PR
- [X] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [X] Self-reviewed my own code
- [X] Commented on my code in hard-to-understand areas
- [X] Ran `pnpm build`
- [X] Ran `pnpm fmt`
- [X] Ran `mise run fmt`
- [X] Checked for warnings, there are none
- [X] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary
