### PR TITLE
fix: add missing untrusted overwrite

### DIFF
--- a/dev/Tiltfile
+++ b/dev/Tiltfile
@@ -26,6 +26,12 @@ local_resource(
 )
 
 local_resource(
+  'node-labels',
+  'kubectl label node --all node-class=untrusted --overwrite',
+  labels=['setup'],
+)
+
+local_resource(
   'registry',
   '''
   REGISTRY_IP=$(docker inspect ctlptl-registry --format '{{range .NetworkSettings.Networks}}{{.IPAddress}} {{end}}' | awk '{print $NF}')


### PR DESCRIPTION
 ## Problem

local deploys never came up. Customer pods carry nodeSelector: node-class=untrusted (krane consts.go), but the dev minikube node was never labeled, so pods sat Pending (FailedScheduling), krane reported instances=0, and the deploy failed at the 15-min healthy-regions timeout.

 ## Fix

  Label the minikube node node-class=untrusted on every tilt up. 

## How should this be tested?

- Run `mise run dev` (or `tilt up`) on a fresh minikube; confirm the `node-labels` setup resource runs and `kubectl get nodes -L node-class` shows `untrusted`.
- Trigger a deployment; confirm the customer pod schedules (not `Pending`), reaches `Running`, krane reports `instances>=1`, and the deploy reaches `ready` instead of failing at the healthy-regions timeout.

## Befor the fix
<img width="1235" height="918" alt="Screenshot 2026-06-29 at 19 11 15" src="https://github.com/user-attachments/assets/e1ec2c0b-c7e9-436e-a342-610f2aad677a" />

<img width="1573" height="426" alt="Screenshot 2026-06-29 at 19 11 25" src="https://github.com/user-attachments/assets/844eaa42-e19c-4614-a0a6-034692707874" />
