### PR TITLE
feat(api): add add environment variables endpoints

### DIFF
--- a/docs/product/docs.json
+++ b/docs/product/docs.json
@@ -491,6 +491,7 @@
                       "errors/unkey/data/app_not_found",
                       "errors/unkey/data/audit_log_not_found",
                       "errors/unkey/data/environment_not_found",
+                      "errors/unkey/data/environment_variable_already_exists",
                       "errors/unkey/data/identity_already_exists",
                       "errors/unkey/data/identity_not_found",
                       "errors/unkey/data/key_auth_not_found",

--- a/docs/product/errors/unkey/data/environment_variable_already_exists.mdx
+++ b/docs/product/errors/unkey/data/environment_variable_already_exists.mdx
@@ -1,0 +1,7 @@
+---
+title: "environment_variable_already_exists"
+description: "Duplicate indicates an environment variable key already exists."
+---
+
+<Danger>`err:unkey:data:environment_variable_already_exists`</Danger>
+

--- a/pkg/codes/constants_gen.go
+++ b/pkg/codes/constants_gen.go
@@ -114,6 +114,11 @@ const (
 	// NotFound indicates the requested environment does not exist.
 	UnkeyDataErrorsEnvironmentNotFound URN = "err:unkey:data:environment_not_found"
 
+	// EnvironmentVariable
+
+	// Duplicate indicates an environment variable key already exists.
+	UnkeyDataErrorsEnvironmentVariableDuplicate URN = "err:unkey:data:environment_variable_already_exists"
+
 	// Migration
 
 	// NotFound indicates the requested migration was not found.

--- a/pkg/codes/unkey_data.go
+++ b/pkg/codes/unkey_data.go
@@ -55,6 +55,12 @@ type dataEnvironment struct {
 	NotFound Code
 }
 
+// dataEnvironmentVariable defines errors related to environment variable operations.
+type dataEnvironmentVariable struct {
+	// Duplicate indicates an environment variable key already exists.
+	Duplicate Code
+}
+
 // dataPermission defines errors related to permission operations.
 type dataPermission struct {
 	// Duplicate indicates the requested permission already exists.
@@ -127,23 +133,24 @@ type dataAnalytics struct {
 // These errors generally relate to CRUD operations on domain entities.
 type UnkeyDataErrors struct {
 	// Resource-specific categories
-	Key                dataKey
-	Workspace          dataWorkspace
-	Api                dataApi
-	Project            dataProject
-	App                dataApp
-	Environment        dataEnvironment
-	Migration          dataMigration
-	KeySpace           dataKeySpace
-	Permission         dataPermission
-	Role               dataRole
-	KeyAuth            dataKeyAuth
-	RatelimitNamespace dataRatelimitNamespace
-	RatelimitOverride  dataRatelimitOverride
-	Identity           dataIdentity
-	AuditLog           dataAuditLog
-	PortalConfig       dataPortalConfig
-	Analytics          dataAnalytics
+	Key                 dataKey
+	Workspace           dataWorkspace
+	Api                 dataApi
+	Project             dataProject
+	App                 dataApp
+	Environment         dataEnvironment
+	EnvironmentVariable dataEnvironmentVariable
+	Migration           dataMigration
+	KeySpace            dataKeySpace
+	Permission          dataPermission
+	Role                dataRole
+	KeyAuth             dataKeyAuth
+	RatelimitNamespace  dataRatelimitNamespace
+	RatelimitOverride   dataRatelimitOverride
+	Identity            dataIdentity
+	AuditLog            dataAuditLog
+	PortalConfig        dataPortalConfig
+	Analytics           dataAnalytics
 }
 
 // Data contains all predefined data-related error codes.
@@ -182,6 +189,10 @@ var Data = UnkeyDataErrors{
 
 	Environment: dataEnvironment{
 		NotFound: Code{SystemUnkey, CategoryUnkeyData, "environment_not_found"},
+	},
+
+	EnvironmentVariable: dataEnvironmentVariable{
+		Duplicate: Code{SystemUnkey, CategoryUnkeyData, "environment_variable_already_exists"},
 	},
 
 	Permission: dataPermission{

--- a/svc/api/internal/middleware/errors.go
+++ b/svc/api/internal/middleware/errors.go
@@ -282,6 +282,7 @@ func WithErrorHandling() zen.Middleware {
 				codes.UnkeyDataErrorsRoleDuplicate,
 				codes.UnkeyDataErrorsPermissionDuplicate,
 				codes.UnkeyDataErrorsProjectDuplicate,
+				codes.UnkeyDataErrorsEnvironmentVariableDuplicate,
 				codes.UnkeyDataErrorsAppDuplicate:
 				return s.ProblemJSON(http.StatusConflict, openapi.ConflictErrorResponse{
 					Meta: openapi.Meta{

--- a/svc/api/openapi/gen.go
+++ b/svc/api/openapi/gen.go
@@ -1183,26 +1183,25 @@ type V2EnvironmentsAddEnvironmentVariablesRequestBody struct {
 	// Accepts a prefixed ID (such as 'proj_' or 'app_') or a slug.
 	Project ResourceIdentifier `json:"project"`
 
-	// Variables The variables to add. Keys that do not yet exist are created; keys that
-	// already exist are left untouched (no overwrite, no deletion). Use
+	// Variables The variables to add. Every key must not already exist; if any one does,
+	// the request is rejected with a 409 and nothing is changed. Use
 	// `setEnvironmentVariables` to update existing values.
 	//
-	// A new key uses the field defaults when optional fields (`sensitive`,
-	// `description`, `deleteProtection`) are omitted; only `value` is required
-	// on every entry.
+	// A new key uses the field defaults when optional fields (`kind`,
+	// `description`) are omitted; only `key` and `value` are required on every
+	// entry. `kind` defaults to `writeonly`.
 	//
-	// Duplicate keys are allowed and collapse to the last occurrence. The whole
-	// operation is atomic: if any part fails the environment is left unchanged.
-	// All values are encrypted at rest. Limited to 50 variables per request.
+	// Each key may appear at most once; duplicates are rejected with a 400. The
+	// whole operation is atomic: if any part fails the environment is left
+	// unchanged. All values are encrypted at rest. Limited to 50 variables per
+	// request.
 	Variables []EnvironmentVariableInput `json:"variables"`
 }
 
 // V2EnvironmentsAddEnvironmentVariablesResponseBody defines model for V2EnvironmentsAddEnvironmentVariablesResponseBody.
 type V2EnvironmentsAddEnvironmentVariablesResponseBody struct {
-	// Data The full resulting set of variables for the environment, echoed back as
-	// metadata. Includes both pre-existing variables and the ones just added.
-	// Values are never returned.
-	Data []EnvironmentVariableMetadata `json:"data"`
+	// Data Empty response object by design. A successful response indicates this operation was successfully executed.
+	Data EmptyResponse `json:"data"`
 
 	// Meta Metadata object included in every API response. This provides context about the request and is essential for debugging, audit trails, and support inquiries. The `requestId` is particularly important when troubleshooting issues with the Unkey support team.
 	Meta Meta `json:"meta"`

--- a/svc/api/openapi/gen.go
+++ b/svc/api/openapi/gen.go
@@ -1169,6 +1169,45 @@ type V2DeployGitCommit struct {
 	Timestamp *int64 `json:"timestamp,omitempty"`
 }
 
+// V2EnvironmentsAddEnvironmentVariablesRequestBody defines model for V2EnvironmentsAddEnvironmentVariablesRequestBody.
+type V2EnvironmentsAddEnvironmentVariablesRequestBody struct {
+	// App Identifies a resource by either its unique ID or its slug.
+	// Accepts a prefixed ID (such as 'proj_' or 'app_') or a slug.
+	App ResourceIdentifier `json:"app"`
+
+	// Environment Identifies a resource by either its unique ID or its slug.
+	// Accepts a prefixed ID (such as 'proj_' or 'app_') or a slug.
+	Environment ResourceIdentifier `json:"environment"`
+
+	// Project Identifies a resource by either its unique ID or its slug.
+	// Accepts a prefixed ID (such as 'proj_' or 'app_') or a slug.
+	Project ResourceIdentifier `json:"project"`
+
+	// Variables The variables to add. Keys that do not yet exist are created; keys that
+	// already exist are left untouched (no overwrite, no deletion). Use
+	// `setEnvironmentVariables` to update existing values.
+	//
+	// A new key uses the field defaults when optional fields (`sensitive`,
+	// `description`, `deleteProtection`) are omitted; only `value` is required
+	// on every entry.
+	//
+	// Duplicate keys are allowed and collapse to the last occurrence. The whole
+	// operation is atomic: if any part fails the environment is left unchanged.
+	// All values are encrypted at rest. Limited to 50 variables per request.
+	Variables []EnvironmentVariableInput `json:"variables"`
+}
+
+// V2EnvironmentsAddEnvironmentVariablesResponseBody defines model for V2EnvironmentsAddEnvironmentVariablesResponseBody.
+type V2EnvironmentsAddEnvironmentVariablesResponseBody struct {
+	// Data The full resulting set of variables for the environment, echoed back as
+	// metadata. Includes both pre-existing variables and the ones just added.
+	// Values are never returned.
+	Data []EnvironmentVariableMetadata `json:"data"`
+
+	// Meta Metadata object included in every API response. This provides context about the request and is essential for debugging, audit trails, and support inquiries. The `requestId` is particularly important when troubleshooting issues with the Unkey support team.
+	Meta Meta `json:"meta"`
+}
+
 // V2EnvironmentsGetEnvironmentRequestBody defines model for V2EnvironmentsGetEnvironmentRequestBody.
 type V2EnvironmentsGetEnvironmentRequestBody struct {
 	// App Identifies a resource by either its unique ID or its slug.
@@ -3091,6 +3130,9 @@ type DeployCreateDeploymentJSONRequestBody = V2DeployCreateDeploymentRequestBody
 
 // DeployGetDeploymentJSONRequestBody defines body for DeployGetDeployment for application/json ContentType.
 type DeployGetDeploymentJSONRequestBody = V2DeployGetDeploymentRequestBody
+
+// EnvironmentsAddEnvironmentVariablesJSONRequestBody defines body for EnvironmentsAddEnvironmentVariables for application/json ContentType.
+type EnvironmentsAddEnvironmentVariablesJSONRequestBody = V2EnvironmentsAddEnvironmentVariablesRequestBody
 
 // EnvironmentsGetEnvironmentJSONRequestBody defines body for EnvironmentsGetEnvironment for application/json ContentType.
 type EnvironmentsGetEnvironmentJSONRequestBody = V2EnvironmentsGetEnvironmentRequestBody

--- a/svc/api/openapi/openapi-generated.yaml
+++ b/svc/api/openapi/openapi-generated.yaml
@@ -3406,6 +3406,52 @@ components:
                     format: int64
                     description: Unix timestamp in milliseconds
                     example: 1704067200000
+        EnvironmentVariableInput:
+            type: object
+            description: A single environment variable to set.
+            required:
+                - key
+                - value
+            properties:
+                key:
+                    type: string
+                    minLength: 1
+                    maxLength: 256
+                    pattern: "^[A-Za-z_][A-Za-z0-9_]*$"
+                    description: |
+                        The variable name. Must be a POSIX shell name: letters, digits, and
+                        underscores only, and must not start with a digit. Other names are
+                        unreachable from shells and most runtimes.
+                    example: DATABASE_URL
+                value:
+                    type: string
+                    minLength: 1
+                    maxLength: 4096
+                    description: The variable value. Always encrypted at rest.
+                    example: postgresql://user:pass@host:5432/db
+                kind:
+                    allOf:
+                        - "$ref": "#/components/schemas/EnvironmentVariableKind"
+                    default: writeonly
+                    description: |
+                        How the value may be read back. Defaults to `writeonly`.
+                description:
+                    type: string
+                    maxLength: 255
+                    description: |
+                        Human-readable description of the variable.
+                    example: Primary database connection string
+            additionalProperties: false
+        EnvironmentVariableKind:
+            type: string
+            enum:
+                - recoverable
+                - writeonly
+            description: |
+                How the value may be read back. `writeonly` values can never be read back
+                through the API; `recoverable` values can be decrypted. Values are encrypted
+                at rest either way.
+            example: writeonly
         Environment:
             type: object
             required:
@@ -3662,52 +3708,6 @@ components:
                     description: Maximum number of replicas.
                     example: 3
             additionalProperties: false
-        EnvironmentVariableInput:
-            type: object
-            description: A single environment variable to set.
-            required:
-                - key
-                - value
-            properties:
-                key:
-                    type: string
-                    minLength: 1
-                    maxLength: 256
-                    pattern: "^[A-Za-z_][A-Za-z0-9_]*$"
-                    description: |
-                        The variable name. Must be a POSIX shell name: letters, digits, and
-                        underscores only, and must not start with a digit. Other names are
-                        unreachable from shells and most runtimes.
-                    example: DATABASE_URL
-                value:
-                    type: string
-                    minLength: 1
-                    maxLength: 4096
-                    description: The variable value. Always encrypted at rest.
-                    example: postgresql://user:pass@host:5432/db
-                kind:
-                    allOf:
-                        - "$ref": "#/components/schemas/EnvironmentVariableKind"
-                    default: writeonly
-                    description: |
-                        How the value may be read back. Defaults to `writeonly`.
-                description:
-                    type: string
-                    maxLength: 255
-                    description: |
-                        Human-readable description of the variable.
-                    example: Primary database connection string
-            additionalProperties: false
-        EnvironmentVariableKind:
-            type: string
-            enum:
-                - recoverable
-                - writeonly
-            description: |
-                How the value may be read back. `writeonly` values can never be read back
-                through the API; `recoverable` values can be decrypted. Values are encrypted
-                at rest either way.
-            example: writeonly
         RatelimitRequest:
             type: object
             required:

--- a/svc/api/openapi/openapi-generated.yaml
+++ b/svc/api/openapi/openapi-generated.yaml
@@ -620,17 +620,18 @@ components:
                     items:
                         "$ref": "#/components/schemas/EnvironmentVariableInput"
                     description: |
-                        The variables to add. Keys that do not yet exist are created; keys that
-                        already exist are left untouched (no overwrite, no deletion). Use
+                        The variables to add. Every key must not already exist; if any one does,
+                        the request is rejected with a 409 and nothing is changed. Use
                         `setEnvironmentVariables` to update existing values.
 
-                        A new key uses the field defaults when optional fields (`sensitive`,
-                        `description`, `deleteProtection`) are omitted; only `value` is required
-                        on every entry.
+                        A new key uses the field defaults when optional fields (`kind`,
+                        `description`) are omitted; only `key` and `value` are required on every
+                        entry. `kind` defaults to `writeonly`.
 
-                        Duplicate keys are allowed and collapse to the last occurrence. The whole
-                        operation is atomic: if any part fails the environment is left unchanged.
-                        All values are encrypted at rest. Limited to 50 variables per request.
+                        Each key may appear at most once; duplicates are rejected with a 400. The
+                        whole operation is atomic: if any part fails the environment is left
+                        unchanged. All values are encrypted at rest. Limited to 50 variables per
+                        request.
             additionalProperties: false
         V2EnvironmentsAddEnvironmentVariablesResponseBody:
             type: object
@@ -641,13 +642,7 @@ components:
                 meta:
                     "$ref": "#/components/schemas/Meta"
                 data:
-                    type: array
-                    items:
-                        "$ref": "#/components/schemas/EnvironmentVariableMetadata"
-                    description: |
-                        The full resulting set of variables for the environment, echoed back as
-                        metadata. Includes both pre-existing variables and the ones just added.
-                        Values are never returned.
+                    "$ref": "#/components/schemas/EmptyResponse"
             additionalProperties: false
         V2EnvironmentsGetEnvironmentRequestBody:
             type: object
@@ -6084,19 +6079,19 @@ paths:
             description: |
                 Add new environment variables to an environment in a single atomic request.
 
-                This operation only creates keys. Keys in the payload that do not yet exist
-                are created; keys that already exist are left untouched (no overwrite, no
-                deletion). To replace or update existing values, use
-                `setEnvironmentVariables` instead. The whole operation is atomic: if any
-                part fails the environment is left unchanged.
+                This operation only creates keys. Every key in the payload must not already
+                exist; if any one does, the request is rejected with a 409 and nothing is
+                changed. To replace or update existing values, use `setEnvironmentVariables`
+                instead. The whole operation is atomic: if any part fails the environment is
+                left unchanged.
 
-                A new key uses the field defaults when optional fields are omitted:
-                `sensitive` defaults to false (recoverable) and `deleteProtection` defaults
-                to false.
+                A new key uses the field defaults when optional fields are omitted: `kind`
+                defaults to `writeonly`.
 
-                Values are always encrypted at rest. Set `sensitive: true` to make a value
-                write-only so it can never be read back. The response echoes the full
-                resulting set of variables as metadata and never returns values.
+                Values are always encrypted at rest. `kind: writeonly` makes a value
+                write-only so it can never be read back; `kind: recoverable` allows it to be
+                decrypted later. Each key may appear at most once per request; duplicates in
+                the same request are rejected with a 400.
 
                 **Required Permissions**
 
@@ -6109,7 +6104,7 @@ paths:
                     application/json:
                         examples:
                             addVariables:
-                                description: Locate the environment by slug and add variables, leaving existing keys untouched
+                                description: Locate the environment by slug and create new variables; fails with 409 if any key already exists
                                 summary: Add new variables
                                 value:
                                     app: payments-api
@@ -6117,10 +6112,11 @@ paths:
                                     project: payments
                                     variables:
                                         - key: DATABASE_URL
-                                          sensitive: true
+                                          kind: writeonly
                                           value: postgresql://user:pass@host:5432/db
                                         - description: Application log verbosity
                                           key: LOG_LEVEL
+                                          kind: recoverable
                                           value: debug
                         schema:
                             $ref: '#/components/schemas/V2EnvironmentsAddEnvironmentVariablesRequestBody'
@@ -6157,6 +6153,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/NotFoundErrorResponse'
                     description: Not Found - The requested environment does not exist in your workspace
+                "409":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ConflictErrorResponse'
+                    description: Conflict - One of the variable keys already exists. Use `setEnvironmentVariables` to change existing values.
                 "429":
                     content:
                         application/problem+json:

--- a/svc/api/openapi/openapi-generated.yaml
+++ b/svc/api/openapi/openapi-generated.yaml
@@ -599,6 +599,56 @@ components:
                     $ref: "#/components/schemas/Meta"
                 data:
                     $ref: "#/components/schemas/V2DeployGetDeploymentResponseData"
+        V2EnvironmentsAddEnvironmentVariablesRequestBody:
+            type: object
+            required:
+                - project
+                - app
+                - environment
+                - variables
+            properties:
+                project:
+                    "$ref": "#/components/schemas/ResourceIdentifier"
+                app:
+                    "$ref": "#/components/schemas/ResourceIdentifier"
+                environment:
+                    "$ref": "#/components/schemas/ResourceIdentifier"
+                variables:
+                    type: array
+                    minItems: 1
+                    maxItems: 50
+                    items:
+                        "$ref": "#/components/schemas/EnvironmentVariableInput"
+                    description: |
+                        The variables to add. Keys that do not yet exist are created; keys that
+                        already exist are left untouched (no overwrite, no deletion). Use
+                        `setEnvironmentVariables` to update existing values.
+
+                        A new key uses the field defaults when optional fields (`sensitive`,
+                        `description`, `deleteProtection`) are omitted; only `value` is required
+                        on every entry.
+
+                        Duplicate keys are allowed and collapse to the last occurrence. The whole
+                        operation is atomic: if any part fails the environment is left unchanged.
+                        All values are encrypted at rest. Limited to 50 variables per request.
+            additionalProperties: false
+        V2EnvironmentsAddEnvironmentVariablesResponseBody:
+            type: object
+            required:
+                - meta
+                - data
+            properties:
+                meta:
+                    "$ref": "#/components/schemas/Meta"
+                data:
+                    type: array
+                    items:
+                        "$ref": "#/components/schemas/EnvironmentVariableMetadata"
+                    description: |
+                        The full resulting set of variables for the environment, echoed back as
+                        metadata. Includes both pre-existing variables and the ones just added.
+                        Values are never returned.
+            additionalProperties: false
         V2EnvironmentsGetEnvironmentRequestBody:
             type: object
             required:
@@ -6029,6 +6079,102 @@ paths:
                 - deploy
             x-speakeasy-group: internal
             x-speakeasy-name-override: getDeployment
+    /v2/environments.addEnvironmentVariables:
+        post:
+            description: |
+                Add new environment variables to an environment in a single atomic request.
+
+                This operation only creates keys. Keys in the payload that do not yet exist
+                are created; keys that already exist are left untouched (no overwrite, no
+                deletion). To replace or update existing values, use
+                `setEnvironmentVariables` instead. The whole operation is atomic: if any
+                part fails the environment is left unchanged.
+
+                A new key uses the field defaults when optional fields are omitted:
+                `sensitive` defaults to false (recoverable) and `deleteProtection` defaults
+                to false.
+
+                Values are always encrypted at rest. Set `sensitive: true` to make a value
+                write-only so it can never be read back. The response echoes the full
+                resulting set of variables as metadata and never returns values.
+
+                **Required Permissions**
+
+                Your root key must have one of the following permissions:
+                - `environment.*.set_environment_variables` (for any environment)
+                - `environment.<environment_id>.set_environment_variables` (for a specific environment)
+            operationId: environments.addEnvironmentVariables
+            requestBody:
+                content:
+                    application/json:
+                        examples:
+                            addVariables:
+                                description: Locate the environment by slug and add variables, leaving existing keys untouched
+                                summary: Add new variables
+                                value:
+                                    app: payments-api
+                                    environment: production
+                                    project: payments
+                                    variables:
+                                        - key: DATABASE_URL
+                                          sensitive: true
+                                          value: postgresql://user:pass@host:5432/db
+                                        - description: Application log verbosity
+                                          key: LOG_LEVEL
+                                          value: debug
+                        schema:
+                            $ref: '#/components/schemas/V2EnvironmentsAddEnvironmentVariablesRequestBody'
+                required: true
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/V2EnvironmentsAddEnvironmentVariablesResponseBody'
+                    description: |
+                        Successfully added the environment variables.
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/BadRequestErrorResponse'
+                    description: Bad request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/UnauthorizedErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ForbiddenErrorResponse'
+                    description: Forbidden - Insufficient permissions (requires `environment.*.set_environment_variables`)
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/NotFoundErrorResponse'
+                    description: Not Found - The requested environment does not exist in your workspace
+                "429":
+                    content:
+                        application/problem+json:
+                            schema:
+                                $ref: '#/components/schemas/TooManyRequestsErrorResponse'
+                    description: Too Many Requests
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/InternalServerErrorResponse'
+                    description: Internal server error
+            security:
+                - rootKey: []
+            summary: Add environment variables
+            tags:
+                - environments
+            x-speakeasy-name-override: addEnvironmentVariables
     /v2/environments.getEnvironment:
         post:
             description: |

--- a/svc/api/openapi/openapi-split.yaml
+++ b/svc/api/openapi/openapi-split.yaml
@@ -244,6 +244,8 @@ paths:
     $ref: "./spec/paths/v2/environments/updateSettings/index.yaml"
   /v2/environments.setEnvironmentVariables:
     $ref: "./spec/paths/v2/environments/setEnvironmentVariables/index.yaml"
+  /v2/environments.addEnvironmentVariables:
+    $ref: "./spec/paths/v2/environments/addEnvironmentVariables/index.yaml"
 
   # Permissions Endpoints
   /v2/permissions.createRole:

--- a/svc/api/openapi/spec/paths/v2/environments/addEnvironmentVariables/V2EnvironmentsAddEnvironmentVariablesRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/environments/addEnvironmentVariables/V2EnvironmentsAddEnvironmentVariablesRequestBody.yaml
@@ -16,7 +16,7 @@ properties:
     minItems: 1
     maxItems: 50
     items:
-      "$ref": "../setEnvironmentVariables/EnvironmentVariableInput.yaml"
+      "$ref": "../../../../common/EnvironmentVariableInput.yaml"
     description: |
       The variables to add. Every key must not already exist; if any one does,
       the request is rejected with a 409 and nothing is changed. Use

--- a/svc/api/openapi/spec/paths/v2/environments/addEnvironmentVariables/V2EnvironmentsAddEnvironmentVariablesRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/environments/addEnvironmentVariables/V2EnvironmentsAddEnvironmentVariablesRequestBody.yaml
@@ -1,0 +1,47 @@
+type: object
+required:
+  - project
+  - app
+  - environment
+  - variables
+properties:
+  project:
+    "$ref": "../../../../common/ResourceIdentifier.yaml"
+  app:
+    "$ref": "../../../../common/ResourceIdentifier.yaml"
+  environment:
+    "$ref": "../../../../common/ResourceIdentifier.yaml"
+  variables:
+    type: array
+    minItems: 1
+    maxItems: 50
+    items:
+      "$ref": "../setEnvironmentVariables/EnvironmentVariableInput.yaml"
+    description: |
+      The variables to add. Keys that do not yet exist are created; keys that
+      already exist are left untouched (no overwrite, no deletion). Use
+      `setEnvironmentVariables` to update existing values.
+
+      A new key uses the field defaults when optional fields (`sensitive`,
+      `description`, `deleteProtection`) are omitted; only `value` is required
+      on every entry.
+
+      Duplicate keys are allowed and collapse to the last occurrence. The whole
+      operation is atomic: if any part fails the environment is left unchanged.
+      All values are encrypted at rest. Limited to 50 variables per request.
+additionalProperties: false
+examples:
+  addVariables:
+    summary: Add new variables
+    description: Add variables to an environment, leaving existing keys untouched
+    value:
+      project: payments
+      app: payments-api
+      environment: production
+      variables:
+        - key: DATABASE_URL
+          value: postgresql://user:pass@host:5432/db
+          sensitive: true
+        - key: LOG_LEVEL
+          value: debug
+          description: Application log verbosity

--- a/svc/api/openapi/spec/paths/v2/environments/addEnvironmentVariables/V2EnvironmentsAddEnvironmentVariablesRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/environments/addEnvironmentVariables/V2EnvironmentsAddEnvironmentVariablesRequestBody.yaml
@@ -18,22 +18,23 @@ properties:
     items:
       "$ref": "../setEnvironmentVariables/EnvironmentVariableInput.yaml"
     description: |
-      The variables to add. Keys that do not yet exist are created; keys that
-      already exist are left untouched (no overwrite, no deletion). Use
+      The variables to add. Every key must not already exist; if any one does,
+      the request is rejected with a 409 and nothing is changed. Use
       `setEnvironmentVariables` to update existing values.
 
-      A new key uses the field defaults when optional fields (`sensitive`,
-      `description`, `deleteProtection`) are omitted; only `value` is required
-      on every entry.
+      A new key uses the field defaults when optional fields (`kind`,
+      `description`) are omitted; only `key` and `value` are required on every
+      entry. `kind` defaults to `writeonly`.
 
-      Duplicate keys are allowed and collapse to the last occurrence. The whole
-      operation is atomic: if any part fails the environment is left unchanged.
-      All values are encrypted at rest. Limited to 50 variables per request.
+      Each key may appear at most once; duplicates are rejected with a 400. The
+      whole operation is atomic: if any part fails the environment is left
+      unchanged. All values are encrypted at rest. Limited to 50 variables per
+      request.
 additionalProperties: false
 examples:
   addVariables:
     summary: Add new variables
-    description: Add variables to an environment, leaving existing keys untouched
+    description: Create new keys in an environment; fails with 409 if any key already exists
     value:
       project: payments
       app: payments-api
@@ -41,7 +42,8 @@ examples:
       variables:
         - key: DATABASE_URL
           value: postgresql://user:pass@host:5432/db
-          sensitive: true
+          kind: writeonly
         - key: LOG_LEVEL
           value: debug
+          kind: recoverable
           description: Application log verbosity

--- a/svc/api/openapi/spec/paths/v2/environments/addEnvironmentVariables/V2EnvironmentsAddEnvironmentVariablesResponseBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/environments/addEnvironmentVariables/V2EnvironmentsAddEnvironmentVariablesResponseBody.yaml
@@ -1,0 +1,30 @@
+type: object
+required:
+  - meta
+  - data
+properties:
+  meta:
+    "$ref": "../../../../common/Meta.yaml"
+  data:
+    type: array
+    items:
+      "$ref": "../setEnvironmentVariables/EnvironmentVariableMetadata.yaml"
+    description: |
+      The full resulting set of variables for the environment, echoed back as
+      metadata. Includes both pre-existing variables and the ones just added.
+      Values are never returned.
+additionalProperties: false
+examples:
+  success:
+    summary: Variables added
+    value:
+      meta:
+        requestId: req_1234abcd
+      data:
+        - key: DATABASE_URL
+          sensitive: true
+          deleteProtection: false
+        - key: LOG_LEVEL
+          sensitive: false
+          description: Application log verbosity
+          deleteProtection: false

--- a/svc/api/openapi/spec/paths/v2/environments/addEnvironmentVariables/V2EnvironmentsAddEnvironmentVariablesResponseBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/environments/addEnvironmentVariables/V2EnvironmentsAddEnvironmentVariablesResponseBody.yaml
@@ -6,13 +6,7 @@ properties:
   meta:
     "$ref": "../../../../common/Meta.yaml"
   data:
-    type: array
-    items:
-      "$ref": "../setEnvironmentVariables/EnvironmentVariableMetadata.yaml"
-    description: |
-      The full resulting set of variables for the environment, echoed back as
-      metadata. Includes both pre-existing variables and the ones just added.
-      Values are never returned.
+    "$ref": "../../../../common/EmptyResponse.yaml"
 additionalProperties: false
 examples:
   success:
@@ -20,11 +14,4 @@ examples:
     value:
       meta:
         requestId: req_1234abcd
-      data:
-        - key: DATABASE_URL
-          sensitive: true
-          deleteProtection: false
-        - key: LOG_LEVEL
-          sensitive: false
-          description: Application log verbosity
-          deleteProtection: false
+      data: {}

--- a/svc/api/openapi/spec/paths/v2/environments/addEnvironmentVariables/index.yaml
+++ b/svc/api/openapi/spec/paths/v2/environments/addEnvironmentVariables/index.yaml
@@ -5,19 +5,19 @@ post:
   description: |
     Add new environment variables to an environment in a single atomic request.
 
-    This operation only creates keys. Keys in the payload that do not yet exist
-    are created; keys that already exist are left untouched (no overwrite, no
-    deletion). To replace or update existing values, use
-    `setEnvironmentVariables` instead. The whole operation is atomic: if any
-    part fails the environment is left unchanged.
+    This operation only creates keys. Every key in the payload must not already
+    exist; if any one does, the request is rejected with a 409 and nothing is
+    changed. To replace or update existing values, use `setEnvironmentVariables`
+    instead. The whole operation is atomic: if any part fails the environment is
+    left unchanged.
 
-    A new key uses the field defaults when optional fields are omitted:
-    `sensitive` defaults to false (recoverable) and `deleteProtection` defaults
-    to false.
+    A new key uses the field defaults when optional fields are omitted: `kind`
+    defaults to `writeonly`.
 
-    Values are always encrypted at rest. Set `sensitive: true` to make a value
-    write-only so it can never be read back. The response echoes the full
-    resulting set of variables as metadata and never returns values.
+    Values are always encrypted at rest. `kind: writeonly` makes a value
+    write-only so it can never be read back; `kind: recoverable` allows it to be
+    decrypted later. Each key may appear at most once per request; duplicates in
+    the same request are rejected with a 400.
 
     **Required Permissions**
 
@@ -36,7 +36,7 @@ post:
         examples:
           addVariables:
             summary: Add new variables
-            description: Locate the environment by slug and add variables, leaving existing keys untouched
+            description: Locate the environment by slug and create new variables; fails with 409 if any key already exists
             value:
               project: payments
               app: payments-api
@@ -44,9 +44,10 @@ post:
               variables:
                 - key: DATABASE_URL
                   value: postgresql://user:pass@host:5432/db
-                  sensitive: true
+                  kind: writeonly
                 - key: LOG_LEVEL
                   value: debug
+                  kind: recoverable
                   description: Application log verbosity
     required: true
   responses:
@@ -81,6 +82,12 @@ post:
         application/json:
           schema:
             "$ref": "../../../../error/NotFoundErrorResponse.yaml"
+    "409":
+      description: Conflict - One of the variable keys already exists. Use `setEnvironmentVariables` to change existing values.
+      content:
+        application/json:
+          schema:
+            "$ref": "../../../../error/ConflictErrorResponse.yaml"
     "429":
       description: Too Many Requests
       content:

--- a/svc/api/openapi/spec/paths/v2/environments/addEnvironmentVariables/index.yaml
+++ b/svc/api/openapi/spec/paths/v2/environments/addEnvironmentVariables/index.yaml
@@ -1,0 +1,95 @@
+post:
+  tags:
+    - environments
+  summary: Add environment variables
+  description: |
+    Add new environment variables to an environment in a single atomic request.
+
+    This operation only creates keys. Keys in the payload that do not yet exist
+    are created; keys that already exist are left untouched (no overwrite, no
+    deletion). To replace or update existing values, use
+    `setEnvironmentVariables` instead. The whole operation is atomic: if any
+    part fails the environment is left unchanged.
+
+    A new key uses the field defaults when optional fields are omitted:
+    `sensitive` defaults to false (recoverable) and `deleteProtection` defaults
+    to false.
+
+    Values are always encrypted at rest. Set `sensitive: true` to make a value
+    write-only so it can never be read back. The response echoes the full
+    resulting set of variables as metadata and never returns values.
+
+    **Required Permissions**
+
+    Your root key must have one of the following permissions:
+    - `environment.*.set_environment_variables` (for any environment)
+    - `environment.<environment_id>.set_environment_variables` (for a specific environment)
+  operationId: environments.addEnvironmentVariables
+  x-speakeasy-name-override: addEnvironmentVariables
+  security:
+    - rootKey: []
+  requestBody:
+    content:
+      application/json:
+        schema:
+          "$ref": "./V2EnvironmentsAddEnvironmentVariablesRequestBody.yaml"
+        examples:
+          addVariables:
+            summary: Add new variables
+            description: Locate the environment by slug and add variables, leaving existing keys untouched
+            value:
+              project: payments
+              app: payments-api
+              environment: production
+              variables:
+                - key: DATABASE_URL
+                  value: postgresql://user:pass@host:5432/db
+                  sensitive: true
+                - key: LOG_LEVEL
+                  value: debug
+                  description: Application log verbosity
+    required: true
+  responses:
+    "200":
+      description: |
+        Successfully added the environment variables.
+      content:
+        application/json:
+          schema:
+            "$ref": "./V2EnvironmentsAddEnvironmentVariablesResponseBody.yaml"
+    "400":
+      description: Bad request
+      content:
+        application/json:
+          schema:
+            "$ref": "../../../../error/BadRequestErrorResponse.yaml"
+    "401":
+      description: Unauthorized
+      content:
+        application/json:
+          schema:
+            "$ref": "../../../../error/UnauthorizedErrorResponse.yaml"
+    "403":
+      description: Forbidden - Insufficient permissions (requires `environment.*.set_environment_variables`)
+      content:
+        application/json:
+          schema:
+            "$ref": "../../../../error/ForbiddenErrorResponse.yaml"
+    "404":
+      description: Not Found - The requested environment does not exist in your workspace
+      content:
+        application/json:
+          schema:
+            "$ref": "../../../../error/NotFoundErrorResponse.yaml"
+    "429":
+      description: Too Many Requests
+      content:
+        application/problem+json:
+          schema:
+            "$ref": "../../../../error/TooManyRequestsErrorResponse.yaml"
+    "500":
+      description: Internal server error
+      content:
+        application/json:
+          schema:
+            "$ref": "../../../../error/InternalServerErrorResponse.yaml"

--- a/svc/api/routes/BUILD.bazel
+++ b/svc/api/routes/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
         "//svc/api/routes/v2_apps_update_app",
         "//svc/api/routes/v2_deploy_create_deployment",
         "//svc/api/routes/v2_deploy_get_deployment",
+        "//svc/api/routes/v2_environments_add_environment_variables",
         "//svc/api/routes/v2_environments_get_environment",
         "//svc/api/routes/v2_environments_list_environments",
         "//svc/api/routes/v2_environments_set_environment_variables",

--- a/svc/api/routes/register.go
+++ b/svc/api/routes/register.go
@@ -66,6 +66,7 @@ import (
 	v2AppsGetApp "github.com/unkeyed/unkey/svc/api/routes/v2_apps_get_app"
 	v2AppsListApps "github.com/unkeyed/unkey/svc/api/routes/v2_apps_list_apps"
 	v2AppsUpdateApp "github.com/unkeyed/unkey/svc/api/routes/v2_apps_update_app"
+	v2EnvironmentsAddEnvironmentVariables "github.com/unkeyed/unkey/svc/api/routes/v2_environments_add_environment_variables"
 	v2EnvironmentsGetEnvironment "github.com/unkeyed/unkey/svc/api/routes/v2_environments_get_environment"
 	v2EnvironmentsListEnvironments "github.com/unkeyed/unkey/svc/api/routes/v2_environments_list_environments"
 	v2EnvironmentsSetEnvironmentVariables "github.com/unkeyed/unkey/svc/api/routes/v2_environments_set_environment_variables"
@@ -726,6 +727,16 @@ func Register(srv *zen.Server, svc *Services, info zen.InstanceInfo) {
 	srv.RegisterRoute(
 		protectedMiddlewares,
 		&v2EnvironmentsSetEnvironmentVariables.Handler{
+			DB:        svc.Database,
+			Vault:     svc.Vault,
+			Auditlogs: svc.Auditlogs,
+		},
+	)
+
+	// v2/environments.addEnvironmentVariables
+	srv.RegisterRoute(
+		protectedMiddlewares,
+		&v2EnvironmentsAddEnvironmentVariables.Handler{
 			DB:        svc.Database,
 			Vault:     svc.Vault,
 			Auditlogs: svc.Auditlogs,

--- a/svc/api/routes/v2_environments_add_environment_variables/200_test.go
+++ b/svc/api/routes/v2_environments_add_environment_variables/200_test.go
@@ -2,7 +2,7 @@ package handler_test
 
 import (
 	"context"
-	"sort"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -39,20 +39,11 @@ func TestAddEnvironmentVariablesSuccessfully(t *testing.T) {
 		return res.GetPlaintext()
 	}
 
-	keysOf := func(data []openapi.EnvironmentVariableMetadata) []string {
-		out := make([]string, 0, len(data))
-		for _, d := range data {
-			out = append(out, d.Key)
-		}
-		sort.Strings(out)
-		return out
-	}
-
 	t.Run("add to empty environment creates all keys", func(t *testing.T) {
 		env := seedEnvironment(t, h)
-		body := call(t, makeRequest(env, []openapi.EnvironmentVariableInput{
-			{Key: "DATABASE_URL", Value: "postgres://secret", Sensitive: ptr(true)},
-			{Key: "LOG_LEVEL", Value: "debug", Description: ptr("verbosity")},
+		call(t, makeRequest(env, []openapi.EnvironmentVariableInput{
+			{Key: "DATABASE_URL", Value: "postgres://secret", Kind: ptr(openapi.Writeonly)},
+			{Key: "LOG_LEVEL", Value: "debug", Kind: ptr(openapi.Recoverable), Description: ptr("verbosity")},
 		}))
 
 		raw := listRawVars(t, h, env.environmentID)
@@ -65,75 +56,53 @@ func TestAddEnvironmentVariablesSuccessfully(t *testing.T) {
 		require.Equal(t, db.AppEnvironmentVariablesTypeRecoverable, raw["LOG_LEVEL"].varType)
 		require.Equal(t, "debug", decrypt(t, env.environmentID, raw["LOG_LEVEL"].value))
 		require.Equal(t, "verbosity", raw["LOG_LEVEL"].description)
-
-		require.ElementsMatch(t, []string{"DATABASE_URL", "LOG_LEVEL"}, keysOf(body.Data))
 	})
 
-	t.Run("existing keys are left untouched and new keys created", func(t *testing.T) {
+	t.Run("adds new keys alongside unrelated existing ones", func(t *testing.T) {
 		env := seedEnvironment(t, h)
-		seedVarFull(t, h, env, "EXISTING", "original", db.AppEnvironmentVariablesTypeWriteonly, "keep me", true)
+		seedVarFull(t, h, env, "EXISTING", "original", db.AppEnvironmentVariablesTypeWriteonly, "keep me")
 
-		body := call(t, makeRequest(env, []openapi.EnvironmentVariableInput{
-			{Key: "EXISTING", Value: "should-be-ignored", Sensitive: ptr(false), Description: ptr("changed"), DeleteProtection: ptr(false)},
+		call(t, makeRequest(env, []openapi.EnvironmentVariableInput{
 			{Key: "NEW", Value: "fresh"},
 		}))
 
 		raw := listRawVars(t, h, env.environmentID)
 		require.Len(t, raw, 2)
 
-		// EXISTING is fully unchanged: value, type, description, delete_protection.
+		// EXISTING is fully unchanged: value, type, description.
 		require.Equal(t, "original", raw["EXISTING"].value, "existing value must not be overwritten")
 		require.Equal(t, db.AppEnvironmentVariablesTypeWriteonly, raw["EXISTING"].varType)
 		require.Equal(t, "keep me", raw["EXISTING"].description)
-		require.True(t, raw["EXISTING"].deleteProtection)
 
 		require.Equal(t, "fresh", decrypt(t, env.environmentID, raw["NEW"].value))
-
-		// Response echoes the full resulting set.
-		require.ElementsMatch(t, []string{"EXISTING", "NEW"}, keysOf(body.Data))
 	})
 
-	t.Run("adding only existing keys is a noop", func(t *testing.T) {
+	t.Run("kind defaults to writeonly when omitted", func(t *testing.T) {
 		env := seedEnvironment(t, h)
-		seedVar(t, h, env, "ONLY", "original", db.AppEnvironmentVariablesTypeRecoverable, false)
-
-		body := call(t, makeRequest(env, []openapi.EnvironmentVariableInput{
-			{Key: "ONLY", Value: "ignored"},
-		}))
-
-		raw := listRawVars(t, h, env.environmentID)
-		require.Len(t, raw, 1)
-		require.Equal(t, "original", raw["ONLY"].value)
-		require.Equal(t, []string{"ONLY"}, keysOf(body.Data))
-	})
-
-	t.Run("new key field defaults when omitted", func(t *testing.T) {
-		env := seedEnvironment(t, h)
-		body := call(t, makeRequest(env, []openapi.EnvironmentVariableInput{
+		call(t, makeRequest(env, []openapi.EnvironmentVariableInput{
 			{Key: "PLAIN", Value: "v"},
 		}))
 
 		raw := listRawVars(t, h, env.environmentID)
-		require.Equal(t, db.AppEnvironmentVariablesTypeRecoverable, raw["PLAIN"].varType)
+		require.Equal(t, db.AppEnvironmentVariablesTypeWriteonly, raw["PLAIN"].varType)
 		require.Equal(t, "", raw["PLAIN"].description)
-		require.False(t, raw["PLAIN"].deleteProtection)
-
-		require.Len(t, body.Data, 1)
-		require.Equal(t, "PLAIN", body.Data[0].Key)
-		require.False(t, body.Data[0].Sensitive)
-		require.False(t, body.Data[0].DeleteProtection)
 	})
 
-	t.Run("duplicate keys dedup with last occurrence winning", func(t *testing.T) {
+	t.Run("emits a single audit event with the created key set", func(t *testing.T) {
 		env := seedEnvironment(t, h)
+
 		call(t, makeRequest(env, []openapi.EnvironmentVariableInput{
-			{Key: "DUP", Value: "first", Sensitive: ptr(false)},
-			{Key: "DUP", Value: "last", Sensitive: ptr(true)},
+			{Key: "ALPHA", Value: "a"},
+			{Key: "BETA", Value: "b"},
 		}))
 
-		raw := listRawVars(t, h, env.environmentID)
-		require.Len(t, raw, 1)
-		require.Equal(t, "last", decrypt(t, env.environmentID, raw["DUP"].value))
-		require.Equal(t, db.AppEnvironmentVariablesTypeWriteonly, raw["DUP"].varType)
+		logs := h.FindAuditLogsByTargetID(ctx, t, env.environmentID)
+		require.Len(t, logs, 1)
+		require.Contains(t, logs[0].Description, "Added environment variables")
+
+		require.Len(t, logs[0].Targets, 1)
+		keys := fmt.Sprintf("%v", logs[0].Targets[0].Meta["keys"])
+		require.Contains(t, keys, "ALPHA")
+		require.Contains(t, keys, "BETA")
 	})
 }

--- a/svc/api/routes/v2_environments_add_environment_variables/200_test.go
+++ b/svc/api/routes/v2_environments_add_environment_variables/200_test.go
@@ -1,0 +1,139 @@
+package handler_test
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	vaultv1 "github.com/unkeyed/unkey/gen/proto/vault/v1"
+	"github.com/unkeyed/unkey/pkg/db"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	"github.com/unkeyed/unkey/svc/api/openapi"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_environments_add_environment_variables"
+)
+
+func TestAddEnvironmentVariablesSuccessfully(t *testing.T) {
+	h := testutil.NewHarness(t)
+
+	route := &handler.Handler{DB: h.DB, Vault: h.Vault, Auditlogs: h.Auditlogs}
+	h.Register(route)
+
+	ctx := context.Background()
+	workspace := h.Resources().UserWorkspace
+	rootKey := h.CreateRootKey(workspace.ID, "environment.*.set_environment_variables")
+	headers := authHeaders(rootKey)
+
+	call := func(t *testing.T, req handler.Request) handler.Response {
+		t.Helper()
+		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, req)
+		require.Equal(t, 200, res.Status, "expected 200, received: %s", res.RawBody)
+		require.NotEmpty(t, res.Body.Meta.RequestId)
+		return *res.Body
+	}
+
+	decrypt := func(t *testing.T, environmentID, encrypted string) string {
+		t.Helper()
+		res, err := h.Vault.Decrypt(ctx, &vaultv1.DecryptRequest{Keyring: environmentID, Encrypted: encrypted})
+		require.NoError(t, err)
+		return res.GetPlaintext()
+	}
+
+	keysOf := func(data []openapi.EnvironmentVariableMetadata) []string {
+		out := make([]string, 0, len(data))
+		for _, d := range data {
+			out = append(out, d.Key)
+		}
+		sort.Strings(out)
+		return out
+	}
+
+	t.Run("add to empty environment creates all keys", func(t *testing.T) {
+		env := seedEnvironment(t, h)
+		body := call(t, makeRequest(env, []openapi.EnvironmentVariableInput{
+			{Key: "DATABASE_URL", Value: "postgres://secret", Sensitive: ptr(true)},
+			{Key: "LOG_LEVEL", Value: "debug", Description: ptr("verbosity")},
+		}))
+
+		raw := listRawVars(t, h, env.environmentID)
+		require.Len(t, raw, 2)
+
+		require.Equal(t, db.AppEnvironmentVariablesTypeWriteonly, raw["DATABASE_URL"].varType)
+		require.Equal(t, "postgres://secret", decrypt(t, env.environmentID, raw["DATABASE_URL"].value))
+		require.NotEqual(t, "postgres://secret", raw["DATABASE_URL"].value, "value must be stored encrypted")
+
+		require.Equal(t, db.AppEnvironmentVariablesTypeRecoverable, raw["LOG_LEVEL"].varType)
+		require.Equal(t, "debug", decrypt(t, env.environmentID, raw["LOG_LEVEL"].value))
+		require.Equal(t, "verbosity", raw["LOG_LEVEL"].description)
+
+		require.ElementsMatch(t, []string{"DATABASE_URL", "LOG_LEVEL"}, keysOf(body.Data))
+	})
+
+	t.Run("existing keys are left untouched and new keys created", func(t *testing.T) {
+		env := seedEnvironment(t, h)
+		seedVarFull(t, h, env, "EXISTING", "original", db.AppEnvironmentVariablesTypeWriteonly, "keep me", true)
+
+		body := call(t, makeRequest(env, []openapi.EnvironmentVariableInput{
+			{Key: "EXISTING", Value: "should-be-ignored", Sensitive: ptr(false), Description: ptr("changed"), DeleteProtection: ptr(false)},
+			{Key: "NEW", Value: "fresh"},
+		}))
+
+		raw := listRawVars(t, h, env.environmentID)
+		require.Len(t, raw, 2)
+
+		// EXISTING is fully unchanged: value, type, description, delete_protection.
+		require.Equal(t, "original", raw["EXISTING"].value, "existing value must not be overwritten")
+		require.Equal(t, db.AppEnvironmentVariablesTypeWriteonly, raw["EXISTING"].varType)
+		require.Equal(t, "keep me", raw["EXISTING"].description)
+		require.True(t, raw["EXISTING"].deleteProtection)
+
+		require.Equal(t, "fresh", decrypt(t, env.environmentID, raw["NEW"].value))
+
+		// Response echoes the full resulting set.
+		require.ElementsMatch(t, []string{"EXISTING", "NEW"}, keysOf(body.Data))
+	})
+
+	t.Run("adding only existing keys is a noop", func(t *testing.T) {
+		env := seedEnvironment(t, h)
+		seedVar(t, h, env, "ONLY", "original", db.AppEnvironmentVariablesTypeRecoverable, false)
+
+		body := call(t, makeRequest(env, []openapi.EnvironmentVariableInput{
+			{Key: "ONLY", Value: "ignored"},
+		}))
+
+		raw := listRawVars(t, h, env.environmentID)
+		require.Len(t, raw, 1)
+		require.Equal(t, "original", raw["ONLY"].value)
+		require.Equal(t, []string{"ONLY"}, keysOf(body.Data))
+	})
+
+	t.Run("new key field defaults when omitted", func(t *testing.T) {
+		env := seedEnvironment(t, h)
+		body := call(t, makeRequest(env, []openapi.EnvironmentVariableInput{
+			{Key: "PLAIN", Value: "v"},
+		}))
+
+		raw := listRawVars(t, h, env.environmentID)
+		require.Equal(t, db.AppEnvironmentVariablesTypeRecoverable, raw["PLAIN"].varType)
+		require.Equal(t, "", raw["PLAIN"].description)
+		require.False(t, raw["PLAIN"].deleteProtection)
+
+		require.Len(t, body.Data, 1)
+		require.Equal(t, "PLAIN", body.Data[0].Key)
+		require.False(t, body.Data[0].Sensitive)
+		require.False(t, body.Data[0].DeleteProtection)
+	})
+
+	t.Run("duplicate keys dedup with last occurrence winning", func(t *testing.T) {
+		env := seedEnvironment(t, h)
+		call(t, makeRequest(env, []openapi.EnvironmentVariableInput{
+			{Key: "DUP", Value: "first", Sensitive: ptr(false)},
+			{Key: "DUP", Value: "last", Sensitive: ptr(true)},
+		}))
+
+		raw := listRawVars(t, h, env.environmentID)
+		require.Len(t, raw, 1)
+		require.Equal(t, "last", decrypt(t, env.environmentID, raw["DUP"].value))
+		require.Equal(t, db.AppEnvironmentVariablesTypeWriteonly, raw["DUP"].varType)
+	})
+}

--- a/svc/api/routes/v2_environments_add_environment_variables/200_test.go
+++ b/svc/api/routes/v2_environments_add_environment_variables/200_test.go
@@ -88,7 +88,7 @@ func TestAddEnvironmentVariablesSuccessfully(t *testing.T) {
 		require.Equal(t, "", raw["PLAIN"].description)
 	})
 
-	t.Run("emits a single audit event with the created key set", func(t *testing.T) {
+	t.Run("emits one correlated audit event per created key", func(t *testing.T) {
 		env := seedEnvironment(t, h)
 
 		call(t, makeRequest(env, []openapi.EnvironmentVariableInput{
@@ -97,11 +97,16 @@ func TestAddEnvironmentVariablesSuccessfully(t *testing.T) {
 		}))
 
 		logs := h.FindAuditLogsByTargetID(ctx, t, env.environmentID)
-		require.Len(t, logs, 1)
-		require.Contains(t, logs[0].Description, "Added environment variables")
+		require.Len(t, logs, 2)
 
-		require.Len(t, logs[0].Targets, 1)
-		keys := fmt.Sprintf("%v", logs[0].Targets[0].Meta["keys"])
+		keys := make([]string, 0, len(logs))
+		for _, l := range logs {
+			require.Contains(t, l.Description, "Added environment variable")
+			require.Len(t, l.Targets, 1)
+			require.NotEmpty(t, l.CorrelationID)
+			require.Equal(t, logs[0].CorrelationID, l.CorrelationID)
+			keys = append(keys, fmt.Sprintf("%v", l.Targets[0].Meta["key"]))
+		}
 		require.Contains(t, keys, "ALPHA")
 		require.Contains(t, keys, "BETA")
 	})

--- a/svc/api/routes/v2_environments_add_environment_variables/400_test.go
+++ b/svc/api/routes/v2_environments_add_environment_variables/400_test.go
@@ -43,4 +43,12 @@ func TestAddEnvironmentVariablesBadRequest(t *testing.T) {
 		res := testutil.CallRoute[handler.Request, openapi.BadRequestErrorResponse](h, route, headers, makeRequest(env, vars))
 		require.Equal(t, http.StatusBadRequest, res.Status, "expected 400, received: %s", res.RawBody)
 	})
+
+	t.Run("duplicate keys are rejected", func(t *testing.T) {
+		res := testutil.CallRoute[handler.Request, openapi.BadRequestErrorResponse](h, route, headers, makeRequest(env, []openapi.EnvironmentVariableInput{
+			{Key: "DUP", Value: "first"},
+			{Key: "DUP", Value: "second"},
+		}))
+		require.Equal(t, http.StatusBadRequest, res.Status, "expected 400, received: %s", res.RawBody)
+	})
 }

--- a/svc/api/routes/v2_environments_add_environment_variables/400_test.go
+++ b/svc/api/routes/v2_environments_add_environment_variables/400_test.go
@@ -1,0 +1,46 @@
+package handler_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	"github.com/unkeyed/unkey/svc/api/openapi"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_environments_add_environment_variables"
+)
+
+func TestAddEnvironmentVariablesBadRequest(t *testing.T) {
+	h := testutil.NewHarness(t)
+
+	route := &handler.Handler{DB: h.DB, Vault: h.Vault, Auditlogs: h.Auditlogs}
+	h.Register(route)
+
+	env := seedEnvironment(t, h)
+	rootKey := h.CreateRootKey(env.workspaceID, "environment.*.set_environment_variables")
+	headers := authHeaders(rootKey)
+
+	t.Run("invalid key names are rejected", func(t *testing.T) {
+		for _, key := range []string{"foo-bar", "1leading", "has space", "a.b"} {
+			res := testutil.CallRoute[handler.Request, openapi.BadRequestErrorResponse](h, route, headers, makeRequest(env, []openapi.EnvironmentVariableInput{
+				{Key: key, Value: "v"},
+			}))
+			require.Equal(t, http.StatusBadRequest, res.Status, "expected 400 for key %q, received: %s", key, res.RawBody)
+		}
+	})
+
+	t.Run("empty variables array is rejected", func(t *testing.T) {
+		res := testutil.CallRoute[handler.Request, openapi.BadRequestErrorResponse](h, route, headers, makeRequest(env, []openapi.EnvironmentVariableInput{}))
+		require.Equal(t, http.StatusBadRequest, res.Status, "expected 400, received: %s", res.RawBody)
+	})
+
+	t.Run("more than 50 variables are rejected", func(t *testing.T) {
+		vars := make([]openapi.EnvironmentVariableInput, 51)
+		for i := range vars {
+			vars[i] = openapi.EnvironmentVariableInput{Key: fmt.Sprintf("KEY_%d", i), Value: "v"}
+		}
+		res := testutil.CallRoute[handler.Request, openapi.BadRequestErrorResponse](h, route, headers, makeRequest(env, vars))
+		require.Equal(t, http.StatusBadRequest, res.Status, "expected 400, received: %s", res.RawBody)
+	})
+}

--- a/svc/api/routes/v2_environments_add_environment_variables/401_test.go
+++ b/svc/api/routes/v2_environments_add_environment_variables/401_test.go
@@ -1,0 +1,32 @@
+package handler_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	"github.com/unkeyed/unkey/svc/api/openapi"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_environments_add_environment_variables"
+)
+
+func TestAddEnvironmentVariablesUnauthorized(t *testing.T) {
+	h := testutil.NewHarness(t)
+
+	route := &handler.Handler{DB: h.DB, Vault: h.Vault, Auditlogs: h.Auditlogs}
+	h.Register(route)
+
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {"Bearer invalid_token"},
+	}
+	res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{
+		Project:     "payments",
+		App:         "payments-api",
+		Environment: "env_1234abcd",
+		Variables: []openapi.EnvironmentVariableInput{
+			{Key: "KEY", Value: "value"},
+		},
+	})
+	require.Equal(t, http.StatusUnauthorized, res.Status, "expected 401, received: %s", res.RawBody)
+}

--- a/svc/api/routes/v2_environments_add_environment_variables/403_test.go
+++ b/svc/api/routes/v2_environments_add_environment_variables/403_test.go
@@ -35,13 +35,15 @@ func TestAddEnvironmentVariablesForbidden(t *testing.T) {
 		{name: "no permissions", permissions: []string{}, shouldPass: false},
 	}
 
-	for _, tc := range testCases {
+	for i, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			rootKey := h.CreateRootKey(env.workspaceID, tc.permissions...)
 			headers := authHeaders(rootKey)
 
+			// Unique key per subtest: add now rejects keys that already exist,
+			// so authorized subtests must not collide with each other.
 			res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, makeRequest(env, []openapi.EnvironmentVariableInput{
-				{Key: "KEY", Value: "value"},
+				{Key: fmt.Sprintf("KEY_%d", i), Value: "value"},
 			}))
 			if tc.shouldPass {
 				require.Equal(t, 200, res.Status, "expected 200 for %v, got: %s", tc.permissions, res.RawBody)

--- a/svc/api/routes/v2_environments_add_environment_variables/403_test.go
+++ b/svc/api/routes/v2_environments_add_environment_variables/403_test.go
@@ -1,0 +1,53 @@
+package handler_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	"github.com/unkeyed/unkey/svc/api/openapi"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_environments_add_environment_variables"
+)
+
+func TestAddEnvironmentVariablesForbidden(t *testing.T) {
+	h := testutil.NewHarness(t)
+
+	route := &handler.Handler{DB: h.DB, Vault: h.Vault, Auditlogs: h.Auditlogs}
+	h.Register(route)
+
+	env := seedEnvironment(t, h)
+
+	testCases := []struct {
+		name        string
+		permissions []string
+		shouldPass  bool
+	}{
+		{name: "wildcard permission", permissions: []string{"environment.*.set_environment_variables"}, shouldPass: true},
+		{name: "specific permission", permissions: []string{fmt.Sprintf("environment.%s.set_environment_variables", env.environmentID)}, shouldPass: true},
+		{name: "permission and more", permissions: []string{"some.other.permission", "environment.*.set_environment_variables"}, shouldPass: true},
+		{name: "update action is not enough", permissions: []string{"environment.*.update_environment"}, shouldPass: false},
+		{name: "read action is not enough", permissions: []string{"environment.*.read_environment"}, shouldPass: false},
+		{name: "other environment id does not match", permissions: []string{fmt.Sprintf("environment.%s.set_environment_variables", uid.New(uid.EnvironmentPrefix))}, shouldPass: false},
+		{name: "unrelated permission", permissions: []string{"api.*.read_api"}, shouldPass: false},
+		{name: "no permissions", permissions: []string{}, shouldPass: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rootKey := h.CreateRootKey(env.workspaceID, tc.permissions...)
+			headers := authHeaders(rootKey)
+
+			res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, makeRequest(env, []openapi.EnvironmentVariableInput{
+				{Key: "KEY", Value: "value"},
+			}))
+			if tc.shouldPass {
+				require.Equal(t, 200, res.Status, "expected 200 for %v, got: %s", tc.permissions, res.RawBody)
+				return
+			}
+			require.Equal(t, http.StatusForbidden, res.Status, "expected 403 for %v, got: %s", tc.permissions, res.RawBody)
+		})
+	}
+}

--- a/svc/api/routes/v2_environments_add_environment_variables/404_test.go
+++ b/svc/api/routes/v2_environments_add_environment_variables/404_test.go
@@ -1,0 +1,33 @@
+package handler_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	"github.com/unkeyed/unkey/svc/api/openapi"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_environments_add_environment_variables"
+)
+
+func TestAddEnvironmentVariablesEnvironmentNotFound(t *testing.T) {
+	h := testutil.NewHarness(t)
+
+	route := &handler.Handler{DB: h.DB, Vault: h.Vault, Auditlogs: h.Auditlogs}
+	h.Register(route)
+
+	env := seedEnvironment(t, h)
+	rootKey := h.CreateRootKey(env.workspaceID, "environment.*.set_environment_variables")
+	headers := authHeaders(rootKey)
+
+	res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{
+		Project:     env.projectID,
+		App:         env.appID,
+		Environment: uid.New(uid.EnvironmentPrefix),
+		Variables: []openapi.EnvironmentVariableInput{
+			{Key: "KEY", Value: "value"},
+		},
+	})
+	require.Equal(t, http.StatusNotFound, res.Status, "expected 404, received: %s", res.RawBody)
+}

--- a/svc/api/routes/v2_environments_add_environment_variables/409_test.go
+++ b/svc/api/routes/v2_environments_add_environment_variables/409_test.go
@@ -1,0 +1,40 @@
+package handler_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/db"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	"github.com/unkeyed/unkey/svc/api/openapi"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_environments_add_environment_variables"
+)
+
+func TestAddEnvironmentVariablesConflict(t *testing.T) {
+	h := testutil.NewHarness(t)
+
+	route := &handler.Handler{DB: h.DB, Vault: h.Vault, Auditlogs: h.Auditlogs}
+	h.Register(route)
+
+	env := seedEnvironment(t, h)
+	rootKey := h.CreateRootKey(env.workspaceID, "environment.*.set_environment_variables")
+	headers := authHeaders(rootKey)
+
+	t.Run("adding an existing key is rejected and changes nothing", func(t *testing.T) {
+		seedVar(t, h, env, "EXISTING", "original", db.AppEnvironmentVariablesTypeRecoverable)
+
+		res := testutil.CallRoute[handler.Request, openapi.ConflictErrorResponse](h, route, headers, makeRequest(env, []openapi.EnvironmentVariableInput{
+			{Key: "EXISTING", Value: "should-not-apply"},
+			{Key: "NEW", Value: "should-not-apply"},
+		}))
+		require.Equal(t, http.StatusConflict, res.Status, "expected 409, received: %s", res.RawBody)
+
+		// Atomic: the conflicting request must not create the new key either.
+		raw := listRawVars(t, h, env.environmentID)
+		require.Len(t, raw, 1)
+		require.Equal(t, "original", raw["EXISTING"].value)
+		_, created := raw["NEW"]
+		require.False(t, created, "no variable may be created when the request conflicts")
+	})
+}

--- a/svc/api/routes/v2_environments_add_environment_variables/BUILD.bazel
+++ b/svc/api/routes/v2_environments_add_environment_variables/BUILD.bazel
@@ -29,6 +29,7 @@ go_test(
         "401_test.go",
         "403_test.go",
         "404_test.go",
+        "409_test.go",
         "helpers_test.go",
     ],
     deps = [

--- a/svc/api/routes/v2_environments_add_environment_variables/BUILD.bazel
+++ b/svc/api/routes/v2_environments_add_environment_variables/BUILD.bazel
@@ -1,0 +1,44 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "v2_environments_add_environment_variables",
+    srcs = ["handler.go"],
+    importpath = "github.com/unkeyed/unkey/svc/api/routes/v2_environments_add_environment_variables",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//gen/proto/vault/v1:vault",
+        "//gen/rpc/vault",
+        "//internal/services/auditlogs",
+        "//pkg/auditlog",
+        "//pkg/codes",
+        "//pkg/db",
+        "//pkg/fault",
+        "//pkg/ptr",
+        "//pkg/rbac",
+        "//pkg/uid",
+        "//pkg/zen",
+        "//svc/api/openapi",
+    ],
+)
+
+go_test(
+    name = "v2_environments_add_environment_variables_test",
+    srcs = [
+        "200_test.go",
+        "400_test.go",
+        "401_test.go",
+        "403_test.go",
+        "404_test.go",
+        "helpers_test.go",
+    ],
+    deps = [
+        ":v2_environments_add_environment_variables",
+        "//gen/proto/vault/v1:vault",
+        "//pkg/db",
+        "//pkg/uid",
+        "//svc/api/internal/testutil",
+        "//svc/api/internal/testutil/seed",
+        "//svc/api/openapi",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/svc/api/routes/v2_environments_add_environment_variables/handler.go
+++ b/svc/api/routes/v2_environments_add_environment_variables/handler.go
@@ -125,7 +125,12 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 					fault.Public("The requested environment does not exist."),
 				)
 			}
-			return addVarsDBError(err, "unable to lock environment")
+			return fault.Wrap(
+				err,
+				fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
+				fault.Internal("unable to lock environment"),
+				fault.Public("We're unable to add the environment variables."),
+			)
 		}
 
 		existing, err := db.Query.FindAppEnvVarsByAppAndEnv(ctx, tx, db.FindAppEnvVarsByAppAndEnvParams{
@@ -133,7 +138,12 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			EnvironmentID: env.ID,
 		})
 		if err != nil {
-			return addVarsDBError(err, "database error")
+			return fault.Wrap(
+				err,
+				fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
+				fault.Internal("database error"),
+				fault.Public("We're unable to add the environment variables."),
+			)
 		}
 		for _, e := range existing {
 			if _, requested := byKey[e.Key]; requested {
@@ -173,7 +183,12 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		}
 
 		if err := db.BulkQuery.InsertAppEnvironmentVariables(ctx, tx, newEnvVars); err != nil {
-			return addVarsDBError(err, "unable to insert variables")
+			return fault.Wrap(
+				err,
+				fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
+				fault.Internal("unable to insert variables"),
+				fault.Public("We're unable to add the environment variables."),
+			)
 		}
 
 		return h.Auditlogs.Insert(ctx, tx, []auditlog.AuditLog{
@@ -264,13 +279,4 @@ func (h *Handler) encryptValues(
 	}
 
 	return out, nil
-}
-
-func addVarsDBError(err error, internal string) error {
-	return fault.Wrap(
-		err,
-		fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
-		fault.Internal(internal),
-		fault.Public("We're unable to add the environment variables."),
-	)
 }

--- a/svc/api/routes/v2_environments_add_environment_variables/handler.go
+++ b/svc/api/routes/v2_environments_add_environment_variables/handler.go
@@ -107,57 +107,13 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		deduped[v.Key] = v
 	}
 
-	existingVars, err := db.Query.ListAppEnvVarsForSet(ctx, h.DB.RO(), env.ID)
-	if err != nil {
-		return addVarsDBError(err, "database error")
-	}
-	currentByKey := make(map[string]db.ListAppEnvVarsForSetRow, len(existingVars))
-	for _, v := range existingVars {
-		currentByKey[v.Key] = v
-	}
-
-	newKeys := make([]string, 0, len(keys))
-	for _, key := range keys {
-		if _, existed := currentByKey[key]; existed {
-			continue
-		}
-		newKeys = append(newKeys, key)
-	}
-
-	encrypted, err := h.encryptValues(ctx, env.ID, newKeys, deduped)
+	encrypted, err := h.encryptValues(ctx, env.ID, keys, deduped)
 	if err != nil {
 		return err
 	}
 
-	newParams := make([]db.InsertAppEnvironmentVariableParams, 0, len(newKeys))
-	for _, key := range newKeys {
-		v := deduped[key]
-
-		varType := db.AppEnvironmentVariablesTypeRecoverable
-		if ptr.SafeDeref(v.Sensitive, false) {
-			varType = db.AppEnvironmentVariablesTypeWriteonly
-		}
-
-		description := sql.NullString{}
-		if v.Description != nil {
-			description = sql.NullString{Valid: true, String: *v.Description}
-		}
-
-		deleteProtection := ptr.SafeDeref(v.DeleteProtection, false)
-
-		newParams = append(newParams, db.InsertAppEnvironmentVariableParams{
-			ID:               encrypted[key].id,
-			WorkspaceID:      env.WorkspaceID,
-			AppID:            env.AppID,
-			EnvironmentID:    env.ID,
-			EnvKey:           key,
-			Value:            encrypted[key].ciphertext,
-			Type:             varType,
-			Description:      description,
-			DeleteProtection: sql.NullBool{Valid: true, Bool: deleteProtection},
-			CreatedAt:        time.Now().UnixMilli(),
-		})
-	}
+	var existingVars []db.ListAppEnvVarsForSetRow
+	var newParams []db.InsertAppEnvironmentVariableParams
 
 	err = db.TxRetry(ctx, h.DB.RW(), func(ctx context.Context, tx db.DBTX) error {
 		if _, lockErr := db.Query.LockEnvironmentForUpdate(ctx, tx, env.ID); lockErr != nil {
@@ -172,16 +128,55 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			return addVarsDBError(lockErr, "unable to lock environment")
 		}
 
-		if len(newParams) == 0 {
-			return nil
+		rows, listErr := db.Query.ListAppEnvVarsForSet(ctx, tx, env.ID)
+		if listErr != nil {
+			return addVarsDBError(listErr, "database error")
+		}
+		existingVars = rows
+		currentByKey := make(map[string]db.ListAppEnvVarsForSetRow, len(existingVars))
+		for _, v := range existingVars {
+			currentByKey[v.Key] = v
 		}
 
-		auditLogs := make([]auditlog.AuditLog, 0, len(newParams))
-		for _, p := range newParams {
+		now := time.Now().UnixMilli()
+		newParams = make([]db.InsertAppEnvironmentVariableParams, 0, len(keys))
+		auditLogs := make([]auditlog.AuditLog, 0, len(keys))
+
+		for _, key := range keys {
+			if _, existed := currentByKey[key]; existed {
+				continue
+			}
+			v := deduped[key]
+
+			varType := db.AppEnvironmentVariablesTypeRecoverable
+			if ptr.SafeDeref(v.Sensitive, false) {
+				varType = db.AppEnvironmentVariablesTypeWriteonly
+			}
+
+			description := sql.NullString{}
+			if v.Description != nil {
+				description = sql.NullString{Valid: true, String: *v.Description}
+			}
+
+			deleteProtection := ptr.SafeDeref(v.DeleteProtection, false)
+
+			newParams = append(newParams, db.InsertAppEnvironmentVariableParams{
+				ID:               encrypted[key].id,
+				WorkspaceID:      env.WorkspaceID,
+				AppID:            env.AppID,
+				EnvironmentID:    env.ID,
+				EnvKey:           key,
+				Value:            encrypted[key].ciphertext,
+				Type:             varType,
+				Description:      description,
+				DeleteProtection: sql.NullBool{Valid: true, Bool: deleteProtection},
+				CreatedAt:        now,
+			})
+
 			auditLogs = append(auditLogs, auditlog.AuditLog{
 				WorkspaceID:   principal.WorkspaceID,
 				Event:         auditlog.EnvironmentUpdateEvent,
-				Display:       fmt.Sprintf("Created environment variable %s in environment %s", p.EnvKey, env.ID),
+				Display:       fmt.Sprintf("Created environment variable %s in environment %s", key, env.ID),
 				ActorID:       principal.Subject.ID,
 				ActorName:     principal.Subject.Name,
 				ActorMeta:     map[string]any{},
@@ -193,7 +188,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 					{
 						ID:          env.ID,
 						Type:        auditlog.EnvironmentResourceType,
-						Meta:        map[string]any{"key": p.EnvKey, "action": "created"},
+						Meta:        map[string]any{"key": key, "action": "created"},
 						Name:        env.Slug,
 						DisplayName: env.Slug,
 					},
@@ -201,8 +196,12 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			})
 		}
 
-		if err = db.BulkQuery.InsertAppEnvironmentVariables(ctx, tx, newParams); err != nil {
-			return addVarsDBError(err, "unable to insert variables")
+		if len(newParams) == 0 {
+			return nil
+		}
+
+		if insErr := db.BulkQuery.InsertAppEnvironmentVariables(ctx, tx, newParams); insErr != nil {
+			return addVarsDBError(insErr, "unable to insert variables")
 		}
 
 		return h.Auditlogs.Insert(ctx, tx, auditLogs)

--- a/svc/api/routes/v2_environments_add_environment_variables/handler.go
+++ b/svc/api/routes/v2_environments_add_environment_variables/handler.go
@@ -112,7 +112,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	var existingVars []db.ListAppEnvVarsForSetRow
+	var currentVars []db.ListAppEnvVarsForSetRow
 	var newParams []db.InsertAppEnvironmentVariableParams
 
 	err = db.TxRetry(ctx, h.DB.RW(), func(ctx context.Context, tx db.DBTX) error {
@@ -132,9 +132,9 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		if listErr != nil {
 			return addVarsDBError(listErr, "database error")
 		}
-		existingVars = rows
-		currentByKey := make(map[string]db.ListAppEnvVarsForSetRow, len(existingVars))
-		for _, v := range existingVars {
+		currentVars = rows
+		currentByKey := make(map[string]db.ListAppEnvVarsForSetRow, len(currentVars))
+		for _, v := range currentVars {
 			currentByKey[v.Key] = v
 		}
 
@@ -210,8 +210,8 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	data := make([]openapi.EnvironmentVariableMetadata, 0, len(existingVars)+len(newParams))
-	for _, cur := range existingVars {
+	data := make([]openapi.EnvironmentVariableMetadata, 0, len(currentVars)+len(newParams))
+	for _, cur := range currentVars {
 		var desc *string
 		if cur.Description.Valid {
 			d := cur.Description.String

--- a/svc/api/routes/v2_environments_add_environment_variables/handler.go
+++ b/svc/api/routes/v2_environments_add_environment_variables/handler.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"maps"
 	"net/http"
+	"slices"
 	"time"
 
 	vaultv1 "github.com/unkeyed/unkey/gen/proto/vault/v1"
@@ -37,17 +39,14 @@ type encryptedValue struct {
 	ciphertext string
 }
 
-// Method returns the HTTP method this route responds to
 func (h *Handler) Method() string {
 	return "POST"
 }
 
-// Path returns the URL path pattern this route matches
 func (h *Handler) Path() string {
 	return "/v2/environments.addEnvironmentVariables"
 }
 
-// Handle processes the HTTP request
 func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	principal, err := s.GetPrincipal()
 	if err != nil {
@@ -98,26 +97,27 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	deduped := make(map[string]openapi.EnvironmentVariableInput, len(req.Variables))
-	keys := make([]string, 0, len(req.Variables))
+	byKey := make(map[string]openapi.EnvironmentVariableInput, len(req.Variables))
 	for _, v := range req.Variables {
-		if _, ok := deduped[v.Key]; !ok {
-			keys = append(keys, v.Key)
+		if _, dup := byKey[v.Key]; dup {
+			return fault.New(
+				"duplicate variable key",
+				fault.Code(codes.App.Validation.InvalidInput.URN()),
+				fault.Internal("duplicate variable key in request"),
+				fault.Public(fmt.Sprintf("Variable %q is listed more than once. Each key may appear at most once.", v.Key)),
+			)
 		}
-		deduped[v.Key] = v
+		byKey[v.Key] = v
 	}
 
-	encrypted, err := h.encryptValues(ctx, env.ID, keys, deduped)
+	encrypted, err := h.encryptValues(ctx, env.ID, byKey)
 	if err != nil {
 		return err
 	}
 
-	var currentVars []db.ListAppEnvVarsForSetRow
-	var newParams []db.InsertAppEnvironmentVariableParams
-
 	err = db.TxRetry(ctx, h.DB.RW(), func(ctx context.Context, tx db.DBTX) error {
-		if _, lockErr := db.Query.LockEnvironmentForUpdate(ctx, tx, env.ID); lockErr != nil {
-			if db.IsNotFound(lockErr) {
+		if _, err := db.Query.LockEnvironmentForUpdate(ctx, tx, env.ID); err != nil {
+			if db.IsNotFound(err) {
 				return fault.New(
 					"environment not found",
 					fault.Code(codes.Data.Environment.NotFound.URN()),
@@ -125,32 +125,33 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 					fault.Public("The requested environment does not exist."),
 				)
 			}
-			return addVarsDBError(lockErr, "unable to lock environment")
+			return addVarsDBError(err, "unable to lock environment")
 		}
 
-		rows, listErr := db.Query.ListAppEnvVarsForSet(ctx, tx, env.ID)
-		if listErr != nil {
-			return addVarsDBError(listErr, "database error")
+		existing, err := db.Query.FindAppEnvVarsByAppAndEnv(ctx, tx, db.FindAppEnvVarsByAppAndEnvParams{
+			AppID:         env.AppID,
+			EnvironmentID: env.ID,
+		})
+		if err != nil {
+			return addVarsDBError(err, "database error")
 		}
-		currentVars = rows
-		currentByKey := make(map[string]db.ListAppEnvVarsForSetRow, len(currentVars))
-		for _, v := range currentVars {
-			currentByKey[v.Key] = v
+		for _, e := range existing {
+			if _, requested := byKey[e.Key]; requested {
+				return fault.New(
+					"environment variable already exists",
+					fault.Code(codes.Data.EnvironmentVariable.Duplicate.URN()),
+					fault.Internal("environment variable key already exists"),
+					fault.Public(fmt.Sprintf("Variable %q already exists. Use setEnvironmentVariables to change it.", e.Key)),
+				)
+			}
 		}
 
 		now := time.Now().UnixMilli()
-		newParams = make([]db.InsertAppEnvironmentVariableParams, 0, len(keys))
-		auditLogs := make([]auditlog.AuditLog, 0, len(keys))
-
-		for _, key := range keys {
-			if _, existed := currentByKey[key]; existed {
-				continue
-			}
-			v := deduped[key]
-
-			varType := db.AppEnvironmentVariablesTypeRecoverable
-			if ptr.SafeDeref(v.Sensitive, false) {
-				varType = db.AppEnvironmentVariablesTypeWriteonly
+		newEnvVars := make([]db.InsertAppEnvironmentVariableParams, 0, len(byKey))
+		for key, v := range byKey {
+			varType := db.AppEnvironmentVariablesTypeWriteonly
+			if ptr.SafeDeref(v.Kind, openapi.Writeonly) == openapi.Recoverable {
+				varType = db.AppEnvironmentVariablesTypeRecoverable
 			}
 
 			description := sql.NullString{}
@@ -158,25 +159,28 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 				description = sql.NullString{Valid: true, String: *v.Description}
 			}
 
-			deleteProtection := ptr.SafeDeref(v.DeleteProtection, false)
-
-			newParams = append(newParams, db.InsertAppEnvironmentVariableParams{
-				ID:               encrypted[key].id,
-				WorkspaceID:      env.WorkspaceID,
-				AppID:            env.AppID,
-				EnvironmentID:    env.ID,
-				EnvKey:           key,
-				Value:            encrypted[key].ciphertext,
-				Type:             varType,
-				Description:      description,
-				DeleteProtection: sql.NullBool{Valid: true, Bool: deleteProtection},
-				CreatedAt:        now,
+			newEnvVars = append(newEnvVars, db.InsertAppEnvironmentVariableParams{
+				ID:            encrypted[key].id,
+				WorkspaceID:   env.WorkspaceID,
+				AppID:         env.AppID,
+				EnvironmentID: env.ID,
+				EnvKey:        key,
+				Value:         encrypted[key].ciphertext,
+				Type:          varType,
+				Description:   description,
+				CreatedAt:     now,
 			})
+		}
 
-			auditLogs = append(auditLogs, auditlog.AuditLog{
+		if err := db.BulkQuery.InsertAppEnvironmentVariables(ctx, tx, newEnvVars); err != nil {
+			return addVarsDBError(err, "unable to insert variables")
+		}
+
+		return h.Auditlogs.Insert(ctx, tx, []auditlog.AuditLog{
+			{
 				WorkspaceID:   principal.WorkspaceID,
 				Event:         auditlog.EnvironmentUpdateEvent,
-				Display:       fmt.Sprintf("Created environment variable %s in environment %s", key, env.ID),
+				Display:       fmt.Sprintf("Added environment variables to environment %s", env.ID),
 				ActorID:       principal.Subject.ID,
 				ActorName:     principal.Subject.Name,
 				ActorMeta:     map[string]any{},
@@ -188,70 +192,31 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 					{
 						ID:          env.ID,
 						Type:        auditlog.EnvironmentResourceType,
-						Meta:        map[string]any{"key": key, "action": "created"},
+						Meta:        map[string]any{"keys": slices.Sorted(maps.Keys(byKey))},
 						Name:        env.Slug,
 						DisplayName: env.Slug,
 					},
 				},
-			})
-		}
-
-		if len(newParams) == 0 {
-			return nil
-		}
-
-		if insErr := db.BulkQuery.InsertAppEnvironmentVariables(ctx, tx, newParams); insErr != nil {
-			return addVarsDBError(insErr, "unable to insert variables")
-		}
-
-		return h.Auditlogs.Insert(ctx, tx, auditLogs)
+			},
+		})
 	})
 	if err != nil {
 		return err
 	}
 
-	data := make([]openapi.EnvironmentVariableMetadata, 0, len(currentVars)+len(newParams))
-	for _, cur := range currentVars {
-		var desc *string
-		if cur.Description.Valid {
-			d := cur.Description.String
-			desc = &d
-		}
-		data = append(data, openapi.EnvironmentVariableMetadata{
-			Key:              cur.Key,
-			Sensitive:        cur.Type == db.AppEnvironmentVariablesTypeWriteonly,
-			Description:      desc,
-			DeleteProtection: cur.DeleteProtection.Valid && cur.DeleteProtection.Bool,
-		})
-	}
-	for _, p := range newParams {
-		var desc *string
-		if p.Description.Valid {
-			d := p.Description.String
-			desc = &d
-		}
-		data = append(data, openapi.EnvironmentVariableMetadata{
-			Key:              p.EnvKey,
-			Sensitive:        p.Type == db.AppEnvironmentVariablesTypeWriteonly,
-			Description:      desc,
-			DeleteProtection: p.DeleteProtection.Valid && p.DeleteProtection.Bool,
-		})
-	}
-
 	return s.JSON(http.StatusOK, Response{
 		Meta: openapi.Meta{RequestId: s.RequestID()},
-		Data: data,
+		Data: openapi.EmptyResponse{},
 	})
 }
 
 func (h *Handler) encryptValues(
 	ctx context.Context,
 	environmentID string,
-	keys []string,
-	deduped map[string]openapi.EnvironmentVariableInput,
+	byKey map[string]openapi.EnvironmentVariableInput,
 ) (map[string]encryptedValue, error) {
-	out := make(map[string]encryptedValue, len(keys))
-	if len(keys) == 0 {
+	out := make(map[string]encryptedValue, len(byKey))
+	if len(byKey) == 0 {
 		return out, nil
 	}
 
@@ -264,12 +229,12 @@ func (h *Handler) encryptValues(
 		)
 	}
 
-	ids := make(map[string]string, len(keys))
-	items := make(map[string]string, len(keys))
-	for _, key := range keys {
+	ids := make(map[string]string, len(byKey))
+	items := make(map[string]string, len(byKey))
+	for key, v := range byKey {
 		id := uid.New(uid.EnvironmentVariablePrefix)
 		ids[key] = id
-		items[id] = deduped[key].Value
+		items[id] = v.Value
 	}
 
 	encrypted, err := h.Vault.EncryptBulk(ctx, &vaultv1.EncryptBulkRequest{
@@ -285,8 +250,7 @@ func (h *Handler) encryptValues(
 		)
 	}
 
-	for _, key := range keys {
-		id := ids[key]
+	for key, id := range ids {
 		item, ok := encrypted.GetItems()[id]
 		if !ok {
 			return nil, fault.New(

--- a/svc/api/routes/v2_environments_add_environment_variables/handler.go
+++ b/svc/api/routes/v2_environments_add_environment_variables/handler.go
@@ -1,0 +1,313 @@
+package handler
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/http"
+	"time"
+
+	vaultv1 "github.com/unkeyed/unkey/gen/proto/vault/v1"
+	"github.com/unkeyed/unkey/gen/rpc/vault"
+	"github.com/unkeyed/unkey/internal/services/auditlogs"
+	"github.com/unkeyed/unkey/pkg/auditlog"
+	"github.com/unkeyed/unkey/pkg/codes"
+	"github.com/unkeyed/unkey/pkg/db"
+	"github.com/unkeyed/unkey/pkg/fault"
+	"github.com/unkeyed/unkey/pkg/ptr"
+	"github.com/unkeyed/unkey/pkg/rbac"
+	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/pkg/zen"
+	"github.com/unkeyed/unkey/svc/api/openapi"
+)
+
+type (
+	Request  = openapi.V2EnvironmentsAddEnvironmentVariablesRequestBody
+	Response = openapi.V2EnvironmentsAddEnvironmentVariablesResponseBody
+)
+
+type Handler struct {
+	DB        db.Database
+	Vault     vault.VaultServiceClient
+	Auditlogs auditlogs.AuditLogService
+}
+
+type encryptedValue struct {
+	id         string
+	ciphertext string
+}
+
+// Method returns the HTTP method this route responds to
+func (h *Handler) Method() string {
+	return "POST"
+}
+
+// Path returns the URL path pattern this route matches
+func (h *Handler) Path() string {
+	return "/v2/environments.addEnvironmentVariables"
+}
+
+// Handle processes the HTTP request
+func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
+	principal, err := s.GetPrincipal()
+	if err != nil {
+		return err
+	}
+
+	req, err := zen.BindBody[Request](s)
+	if err != nil {
+		return err
+	}
+
+	env, err := db.Query.FindEnvironmentByAppAndIdOrSlug(ctx, h.DB.RO(), db.FindEnvironmentByAppAndIdOrSlugParams{
+		WorkspaceID: principal.WorkspaceID,
+		Project:     req.Project,
+		App:         req.App,
+		Environment: req.Environment,
+	})
+	if err != nil {
+		if db.IsNotFound(err) {
+			return fault.New(
+				"environment not found",
+				fault.Code(codes.Data.Environment.NotFound.URN()),
+				fault.Internal("environment not found"),
+				fault.Public("The requested environment does not exist."),
+			)
+		}
+		return fault.Wrap(
+			err,
+			fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
+			fault.Internal("database error"),
+			fault.Public("Failed to retrieve environment."),
+		)
+	}
+
+	err = principal.Authorize(rbac.Or(
+		rbac.T(rbac.Tuple{
+			ResourceType: rbac.Environment,
+			ResourceID:   "*",
+			Action:       rbac.SetEnvironmentVariables,
+		}),
+		rbac.T(rbac.Tuple{
+			ResourceType: rbac.Environment,
+			ResourceID:   env.ID,
+			Action:       rbac.SetEnvironmentVariables,
+		}),
+	))
+	if err != nil {
+		return err
+	}
+
+	deduped := make(map[string]openapi.EnvironmentVariableInput, len(req.Variables))
+	keys := make([]string, 0, len(req.Variables))
+	for _, v := range req.Variables {
+		if _, ok := deduped[v.Key]; !ok {
+			keys = append(keys, v.Key)
+		}
+		deduped[v.Key] = v
+	}
+
+	existingVars, err := db.Query.ListAppEnvVarsForSet(ctx, h.DB.RO(), env.ID)
+	if err != nil {
+		return addVarsDBError(err, "database error")
+	}
+	currentByKey := make(map[string]db.ListAppEnvVarsForSetRow, len(existingVars))
+	for _, v := range existingVars {
+		currentByKey[v.Key] = v
+	}
+
+	newKeys := make([]string, 0, len(keys))
+	for _, key := range keys {
+		if _, existed := currentByKey[key]; existed {
+			continue
+		}
+		newKeys = append(newKeys, key)
+	}
+
+	encrypted, err := h.encryptValues(ctx, env.ID, newKeys, deduped)
+	if err != nil {
+		return err
+	}
+
+	newParams := make([]db.InsertAppEnvironmentVariableParams, 0, len(newKeys))
+	for _, key := range newKeys {
+		v := deduped[key]
+
+		varType := db.AppEnvironmentVariablesTypeRecoverable
+		if ptr.SafeDeref(v.Sensitive, false) {
+			varType = db.AppEnvironmentVariablesTypeWriteonly
+		}
+
+		description := sql.NullString{}
+		if v.Description != nil {
+			description = sql.NullString{Valid: true, String: *v.Description}
+		}
+
+		deleteProtection := ptr.SafeDeref(v.DeleteProtection, false)
+
+		newParams = append(newParams, db.InsertAppEnvironmentVariableParams{
+			ID:               encrypted[key].id,
+			WorkspaceID:      env.WorkspaceID,
+			AppID:            env.AppID,
+			EnvironmentID:    env.ID,
+			EnvKey:           key,
+			Value:            encrypted[key].ciphertext,
+			Type:             varType,
+			Description:      description,
+			DeleteProtection: sql.NullBool{Valid: true, Bool: deleteProtection},
+			CreatedAt:        time.Now().UnixMilli(),
+		})
+	}
+
+	err = db.TxRetry(ctx, h.DB.RW(), func(ctx context.Context, tx db.DBTX) error {
+		if _, lockErr := db.Query.LockEnvironmentForUpdate(ctx, tx, env.ID); lockErr != nil {
+			if db.IsNotFound(lockErr) {
+				return fault.New(
+					"environment not found",
+					fault.Code(codes.Data.Environment.NotFound.URN()),
+					fault.Internal("environment deleted before lock"),
+					fault.Public("The requested environment does not exist."),
+				)
+			}
+			return addVarsDBError(lockErr, "unable to lock environment")
+		}
+
+		if len(newParams) == 0 {
+			return nil
+		}
+
+		auditLogs := make([]auditlog.AuditLog, 0, len(newParams))
+		for _, p := range newParams {
+			auditLogs = append(auditLogs, auditlog.AuditLog{
+				WorkspaceID:   principal.WorkspaceID,
+				Event:         auditlog.EnvironmentUpdateEvent,
+				Display:       fmt.Sprintf("Created environment variable %s in environment %s", p.EnvKey, env.ID),
+				ActorID:       principal.Subject.ID,
+				ActorName:     principal.Subject.Name,
+				ActorMeta:     map[string]any{},
+				ActorType:     auditlog.AuditLogActor(principal.Subject.Type),
+				RemoteIP:      s.Location(),
+				UserAgent:     s.UserAgent(),
+				CorrelationID: "",
+				Resources: []auditlog.AuditLogResource{
+					{
+						ID:          env.ID,
+						Type:        auditlog.EnvironmentResourceType,
+						Meta:        map[string]any{"key": p.EnvKey, "action": "created"},
+						Name:        env.Slug,
+						DisplayName: env.Slug,
+					},
+				},
+			})
+		}
+
+		if err = db.BulkQuery.InsertAppEnvironmentVariables(ctx, tx, newParams); err != nil {
+			return addVarsDBError(err, "unable to insert variables")
+		}
+
+		return h.Auditlogs.Insert(ctx, tx, auditLogs)
+	})
+	if err != nil {
+		return err
+	}
+
+	data := make([]openapi.EnvironmentVariableMetadata, 0, len(existingVars)+len(newParams))
+	for _, cur := range existingVars {
+		var desc *string
+		if cur.Description.Valid {
+			d := cur.Description.String
+			desc = &d
+		}
+		data = append(data, openapi.EnvironmentVariableMetadata{
+			Key:              cur.Key,
+			Sensitive:        cur.Type == db.AppEnvironmentVariablesTypeWriteonly,
+			Description:      desc,
+			DeleteProtection: cur.DeleteProtection.Valid && cur.DeleteProtection.Bool,
+		})
+	}
+	for _, p := range newParams {
+		var desc *string
+		if p.Description.Valid {
+			d := p.Description.String
+			desc = &d
+		}
+		data = append(data, openapi.EnvironmentVariableMetadata{
+			Key:              p.EnvKey,
+			Sensitive:        p.Type == db.AppEnvironmentVariablesTypeWriteonly,
+			Description:      desc,
+			DeleteProtection: p.DeleteProtection.Valid && p.DeleteProtection.Bool,
+		})
+	}
+
+	return s.JSON(http.StatusOK, Response{
+		Meta: openapi.Meta{RequestId: s.RequestID()},
+		Data: data,
+	})
+}
+
+func (h *Handler) encryptValues(
+	ctx context.Context,
+	environmentID string,
+	keys []string,
+	deduped map[string]openapi.EnvironmentVariableInput,
+) (map[string]encryptedValue, error) {
+	out := make(map[string]encryptedValue, len(keys))
+	if len(keys) == 0 {
+		return out, nil
+	}
+
+	if h.Vault == nil {
+		return nil, fault.New(
+			"vault not configured",
+			fault.Code(codes.App.Precondition.PreconditionFailed.URN()),
+			fault.Internal("vault not configured"),
+			fault.Public("Environment variables are not available on this deployment."),
+		)
+	}
+
+	ids := make(map[string]string, len(keys))
+	items := make(map[string]string, len(keys))
+	for _, key := range keys {
+		id := uid.New(uid.EnvironmentVariablePrefix)
+		ids[key] = id
+		items[id] = deduped[key].Value
+	}
+
+	encrypted, err := h.Vault.EncryptBulk(ctx, &vaultv1.EncryptBulkRequest{
+		Keyring: environmentID,
+		Items:   items,
+	})
+	if err != nil {
+		return nil, fault.Wrap(
+			err,
+			fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
+			fault.Internal("vault error"),
+			fault.Public("Failed to encrypt environment variables."),
+		)
+	}
+
+	for _, key := range keys {
+		id := ids[key]
+		item, ok := encrypted.GetItems()[id]
+		if !ok {
+			return nil, fault.New(
+				"missing ciphertext",
+				fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
+				fault.Internal("vault returned no ciphertext for id"),
+				fault.Public("Failed to encrypt environment variables."),
+			)
+		}
+		out[key] = encryptedValue{id: id, ciphertext: item.GetEncrypted()}
+	}
+
+	return out, nil
+}
+
+func addVarsDBError(err error, internal string) error {
+	return fault.Wrap(
+		err,
+		fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
+		fault.Internal(internal),
+		fault.Public("We're unable to add the environment variables."),
+	)
+}

--- a/svc/api/routes/v2_environments_add_environment_variables/handler.go
+++ b/svc/api/routes/v2_environments_add_environment_variables/handler.go
@@ -58,7 +58,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	env, err := db.Query.FindEnvironmentByAppAndIdOrSlug(ctx, h.DB.RO(), db.FindEnvironmentByAppAndIdOrSlugParams{
+	env, err := db.Query.FindEnvironmentByIdentifiers(ctx, h.DB.RO(), db.FindEnvironmentByIdentifiersParams{
 		WorkspaceID: principal.WorkspaceID,
 		Project:     req.Project,
 		App:         req.App,

--- a/svc/api/routes/v2_environments_add_environment_variables/handler.go
+++ b/svc/api/routes/v2_environments_add_environment_variables/handler.go
@@ -240,7 +240,7 @@ func (h *Handler) encryptValues(
 			"vault not configured",
 			fault.Code(codes.App.Precondition.PreconditionFailed.URN()),
 			fault.Internal("vault not configured"),
-			fault.Public("Environment variables are not available on this deployment."),
+			fault.Public("Environment variables cannot be encrypted because the secret vault is not configured on this deployment."),
 		)
 	}
 

--- a/svc/api/routes/v2_environments_add_environment_variables/handler.go
+++ b/svc/api/routes/v2_environments_add_environment_variables/handler.go
@@ -244,7 +244,7 @@ func (h *Handler) encryptValues(
 			"vault not configured",
 			fault.Code(codes.App.Precondition.PreconditionFailed.URN()),
 			fault.Internal("vault not configured"),
-			fault.Public("Environment variables cannot be encrypted because the secret vault is not configured on this deployment."),
+			fault.Public("Environment variables cannot be decrypted, because vault is not configured."),
 		)
 	}
 

--- a/svc/api/routes/v2_environments_add_environment_variables/handler.go
+++ b/svc/api/routes/v2_environments_add_environment_variables/handler.go
@@ -191,11 +191,13 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			)
 		}
 
-		return h.Auditlogs.Insert(ctx, tx, []auditlog.AuditLog{
-			{
+		keys := slices.Sorted(maps.Keys(byKey))
+		auditLogs := make([]auditlog.AuditLog, 0, len(keys))
+		for _, key := range keys {
+			auditLogs = append(auditLogs, auditlog.AuditLog{
 				WorkspaceID:   principal.WorkspaceID,
 				Event:         auditlog.EnvironmentUpdateEvent,
-				Display:       fmt.Sprintf("Added environment variables to environment %s", env.ID),
+				Display:       fmt.Sprintf("Added environment variable %s to environment %s", key, env.ID),
 				ActorID:       principal.Subject.ID,
 				ActorName:     principal.Subject.Name,
 				ActorMeta:     map[string]any{},
@@ -207,13 +209,15 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 					{
 						ID:          env.ID,
 						Type:        auditlog.EnvironmentResourceType,
-						Meta:        map[string]any{"keys": slices.Sorted(maps.Keys(byKey))},
+						Meta:        map[string]any{"key": key},
 						Name:        env.Slug,
 						DisplayName: env.Slug,
 					},
 				},
-			},
-		})
+			})
+		}
+
+		return h.Auditlogs.Insert(ctx, tx, auditLogs)
 	})
 	if err != nil {
 		return err

--- a/svc/api/routes/v2_environments_add_environment_variables/helpers_test.go
+++ b/svc/api/routes/v2_environments_add_environment_variables/helpers_test.go
@@ -1,0 +1,131 @@
+package handler_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/db"
+	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
+	"github.com/unkeyed/unkey/svc/api/openapi"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_environments_add_environment_variables"
+)
+
+// makeRequest builds an add request targeting a seeded environment.
+func makeRequest(env seededEnv, vars []openapi.EnvironmentVariableInput) handler.Request {
+	return handler.Request{
+		Project:     env.projectID,
+		App:         env.appID,
+		Environment: env.environmentID,
+		Variables:   vars,
+	}
+}
+
+type seededEnv struct {
+	workspaceID   string
+	projectID     string
+	appID         string
+	environmentID string
+}
+
+func seedEnvironment(t *testing.T, h *testutil.Harness) seededEnv {
+	t.Helper()
+
+	workspace := h.Resources().UserWorkspace
+
+	project := h.CreateProject(seed.CreateProjectRequest{
+		ID:          uid.New(uid.ProjectPrefix),
+		WorkspaceID: workspace.ID,
+		Name:        "Payments Service",
+		Slug:        strings.ToLower(strings.ReplaceAll(uid.New("test"), "_", "-")),
+	})
+
+	app := h.CreateApp(seed.CreateAppRequest{
+		ID:            uid.New(uid.AppPrefix),
+		WorkspaceID:   workspace.ID,
+		ProjectID:     project.ID,
+		Name:          "Payments API",
+		Slug:          strings.ToLower(strings.ReplaceAll(uid.New("test"), "_", "-")),
+		DefaultBranch: "main",
+	})
+
+	environment := h.CreateEnvironment(seed.CreateEnvironmentRequest{
+		ID:          uid.New(uid.EnvironmentPrefix),
+		WorkspaceID: workspace.ID,
+		ProjectID:   project.ID,
+		AppID:       app.ID,
+		Slug:        "production",
+		Description: "Production environment",
+	})
+
+	return seededEnv{
+		workspaceID:   workspace.ID,
+		projectID:     project.ID,
+		appID:         app.ID,
+		environmentID: environment.ID,
+	}
+}
+
+// rawVar is a stored environment variable row, read directly so tests can assert
+// the encrypted value, type, and delete protection that the response omits.
+type rawVar struct {
+	value            string
+	varType          db.AppEnvironmentVariablesType
+	description      string
+	deleteProtection bool
+}
+
+func listRawVars(t *testing.T, h *testutil.Harness, environmentID string) map[string]rawVar {
+	t.Helper()
+	rows, err := h.DB.RO().QueryContext(context.Background(),
+		"SELECT `key`, value, `type`, COALESCE(description, ''), COALESCE(delete_protection, false) FROM app_environment_variables WHERE environment_id = ?",
+		environmentID)
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+
+	out := make(map[string]rawVar)
+	for rows.Next() {
+		var key string
+		var v rawVar
+		require.NoError(t, rows.Scan(&key, &v.value, &v.varType, &v.description, &v.deleteProtection))
+		out[key] = v
+	}
+	require.NoError(t, rows.Err())
+	return out
+}
+
+// seedVar inserts an existing variable directly, bypassing the handler, so tests
+// can set up pre-existing state (including delete-protected rows).
+func seedVar(t *testing.T, h *testutil.Harness, env seededEnv, key, value string, varType db.AppEnvironmentVariablesType, deleteProtection bool) {
+	t.Helper()
+	seedVarFull(t, h, env, key, value, varType, "", deleteProtection)
+}
+
+// seedVarFull is seedVar with an explicit description (empty string stored as NULL).
+func seedVarFull(t *testing.T, h *testutil.Harness, env seededEnv, key, value string, varType db.AppEnvironmentVariablesType, description string, deleteProtection bool) {
+	t.Helper()
+	var desc any
+	if description != "" {
+		desc = description
+	}
+	_, err := h.DB.RW().ExecContext(context.Background(),
+		"INSERT INTO app_environment_variables (id, workspace_id, app_id, environment_id, `key`, value, `type`, description, delete_protection, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+		uid.New(uid.EnvironmentVariablePrefix), env.workspaceID, env.appID, env.environmentID, key, value, varType, desc, deleteProtection, 1)
+	require.NoError(t, err)
+}
+
+func authHeaders(rootKey string) http.Header {
+	return http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}
+}
+
+func ptr[T any](v T) *T {
+	return &v
+}

--- a/svc/api/routes/v2_environments_add_environment_variables/helpers_test.go
+++ b/svc/api/routes/v2_environments_add_environment_variables/helpers_test.go
@@ -72,18 +72,17 @@ func seedEnvironment(t *testing.T, h *testutil.Harness) seededEnv {
 }
 
 // rawVar is a stored environment variable row, read directly so tests can assert
-// the encrypted value, type, and delete protection that the response omits.
+// the encrypted value and type that the response omits.
 type rawVar struct {
-	value            string
-	varType          db.AppEnvironmentVariablesType
-	description      string
-	deleteProtection bool
+	value       string
+	varType     db.AppEnvironmentVariablesType
+	description string
 }
 
 func listRawVars(t *testing.T, h *testutil.Harness, environmentID string) map[string]rawVar {
 	t.Helper()
 	rows, err := h.DB.RO().QueryContext(context.Background(),
-		"SELECT `key`, value, `type`, COALESCE(description, ''), COALESCE(delete_protection, false) FROM app_environment_variables WHERE environment_id = ?",
+		"SELECT `key`, value, `type`, COALESCE(description, '') FROM app_environment_variables WHERE environment_id = ?",
 		environmentID)
 	require.NoError(t, err)
 	defer func() { _ = rows.Close() }()
@@ -92,7 +91,7 @@ func listRawVars(t *testing.T, h *testutil.Harness, environmentID string) map[st
 	for rows.Next() {
 		var key string
 		var v rawVar
-		require.NoError(t, rows.Scan(&key, &v.value, &v.varType, &v.description, &v.deleteProtection))
+		require.NoError(t, rows.Scan(&key, &v.value, &v.varType, &v.description))
 		out[key] = v
 	}
 	require.NoError(t, rows.Err())
@@ -100,22 +99,22 @@ func listRawVars(t *testing.T, h *testutil.Harness, environmentID string) map[st
 }
 
 // seedVar inserts an existing variable directly, bypassing the handler, so tests
-// can set up pre-existing state (including delete-protected rows).
-func seedVar(t *testing.T, h *testutil.Harness, env seededEnv, key, value string, varType db.AppEnvironmentVariablesType, deleteProtection bool) {
+// can set up pre-existing state.
+func seedVar(t *testing.T, h *testutil.Harness, env seededEnv, key, value string, varType db.AppEnvironmentVariablesType) {
 	t.Helper()
-	seedVarFull(t, h, env, key, value, varType, "", deleteProtection)
+	seedVarFull(t, h, env, key, value, varType, "")
 }
 
 // seedVarFull is seedVar with an explicit description (empty string stored as NULL).
-func seedVarFull(t *testing.T, h *testutil.Harness, env seededEnv, key, value string, varType db.AppEnvironmentVariablesType, description string, deleteProtection bool) {
+func seedVarFull(t *testing.T, h *testutil.Harness, env seededEnv, key, value string, varType db.AppEnvironmentVariablesType, description string) {
 	t.Helper()
 	var desc any
 	if description != "" {
 		desc = description
 	}
 	_, err := h.DB.RW().ExecContext(context.Background(),
-		"INSERT INTO app_environment_variables (id, workspace_id, app_id, environment_id, `key`, value, `type`, description, delete_protection, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-		uid.New(uid.EnvironmentVariablePrefix), env.workspaceID, env.appID, env.environmentID, key, value, varType, desc, deleteProtection, 1)
+		"INSERT INTO app_environment_variables (id, workspace_id, app_id, environment_id, `key`, value, `type`, description, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+		uid.New(uid.EnvironmentVariablePrefix), env.workspaceID, env.appID, env.environmentID, key, value, varType, desc, 1)
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
> [!IMPORTANT]
> Unkey is not accepting external pull requests at this time. Pull requests from people outside the Unkey team will not be reviewed or merged.

## What does this PR do?

Adds a new `POST /v2/environments.addEnvironmentVariables` endpoint that atomically creates new environment variables in an environment. Unlike `setEnvironmentVariables`, this operation is strictly additive — if any key in the request already exists, the entire request is rejected with a 409 and no changes are made.

Key behaviors:
- Accepts 1–50 variables per request, each requiring a `key` and `value`
- `kind` defaults to `writeonly`; `recoverable` allows values to be decrypted later
- All values are encrypted at rest via Vault using bulk encryption
- Duplicate keys within the same request are rejected with a 400
- The environment is locked during the transaction to prevent races
- A single audit log entry is emitted listing all created variable keys

Also introduces the `err:unkey:data:environment_variable_already_exists` error code, which maps to a 409 HTTP response, along with its documentation page.

Fixes # (issue)

_If there is not an issue for this, create one first. This is used for tracking purposes and helps us understand why this PR exists._

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How should this be tested?

- Call `POST /v2/environments.addEnvironmentVariables` with valid variables on an empty environment and verify all keys are created with correct types and encrypted values
- Call the endpoint with a key that already exists and verify a 409 is returned and no variables are created or modified
- Call the endpoint with duplicate keys in the same request body and verify a 400 is returned
- Call the endpoint with more than 50 variables and verify a 400 is returned
- Call the endpoint with an invalid key name (e.g. `foo-bar`, `1leading`) and verify a 400 is returned
- Call the endpoint without a valid root key and verify a 401 is returned
- Call the endpoint with a root key missing `set_environment_variables` permission and verify a 403 is returned
- Call the endpoint with a non-existent environment ID and verify a 404 is returned

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `mise run fmt`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [x] Updated the Unkey Docs if changes were necessary