### PR TITLE
fix(dashboard): Keyspace button size mismatch

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/_components/api-list-client.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/_components/api-list-client.tsx
@@ -112,7 +112,7 @@ export const ApiListClient = ({ workspaceSlug }: { workspaceSlug: string }) => {
             </Empty.Description>
             {!isSearching && (
               <Empty.Actions className="mt-4">
-                <CreateApiButton defaultOpen={isNewApi} workspaceSlug={workspaceSlug} />
+                <CreateApiButton defaultOpen={isNewApi} workspaceSlug={workspaceSlug} size="md" />
                 <a
                   href="https://www.unkey.com/docs/introduction"
                   target="_blank"

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/_components/create-api-button.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/_components/create-api-button.tsx
@@ -1,7 +1,10 @@
 "use client";
 
 import { revalidate } from "@/app/actions";
-import { NavbarActionButton } from "@/components/navigation/action-button";
+import {
+  NavbarActionButton,
+  type NavbarActionButtonProps,
+} from "@/components/navigation/action-button";
 import { routes } from "@/lib/navigation/routes";
 import { trpc } from "@/lib/trpc/client";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -29,13 +32,14 @@ const formSchema = z.object({
 type Props = {
   defaultOpen?: boolean;
   workspaceSlug: string;
+  size?: NavbarActionButtonProps["size"];
 };
 
 export const CreateApiButton = ({
   defaultOpen,
   workspaceSlug,
   ...rest
-}: React.ButtonHTMLAttributes<HTMLButtonElement> & Props) => {
+}: Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "size"> & Props) => {
   const [isOpen, setIsOpen] = useState(defaultOpen ?? false);
   const router = useRouter();
   const { api } = trpc.useUtils();


### PR DESCRIPTION
## What does this PR do?

Fixes the size mismatch between the create keyspace button and the documentation button.

## Screenshots

Before:

<img width="4264" height="2584" alt="CleanShot 2026-06-30 at 13 53 20@2x" src="https://github.com/user-attachments/assets/a5a72df1-dd3c-4f90-b83e-88112bfb3d01" />

After:

<img width="4264" height="2584" alt="CleanShot 2026-06-30 at 13 54 03@2x" src="https://github.com/user-attachments/assets/45ee4847-438d-4ae2-ad05-e67596469b16" />


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

1. Open the keyspaces (APIs) page in a workspace with no keyspaces.
2. Confirm the "Create new keyspace" and "Documentation" buttons are the same height.
3. Confirm the "Create new keyspace" button in the page navbar (non-empty state) is unchanged (`sm`).

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary

_Screenshots to be added — light, dark, mobile._