### PR TITLE
docs(clickhouse): add eve read-only analytics user

### DIFF
--- a/docs/engineering/docs.json
+++ b/docs/engineering/docs.json
@@ -227,6 +227,7 @@
                 "group": "Users",
                 "pages": [
                   "infra/clickhouse/users/apiv2",
+                  "infra/clickhouse/users/eve",
                   "infra/clickhouse/users/github",
                   "infra/clickhouse/users/grafana",
                   "infra/clickhouse/users/frontline",

--- a/docs/engineering/infra/clickhouse/index.mdx
+++ b/docs/engineering/infra/clickhouse/index.mdx
@@ -16,6 +16,7 @@ Workspace users (`ws_*`) are also excluded, cuz we create them ourselves.
 | [`ctrl`](./users/ctrl) | Control plane data writer/reader (ctrl-api + ctrl-worker) | direct grants (see script) |
 | [`frontline`](./users/frontline) | Frontline service | direct grants (see script) |
 | [`vector`](./users/vector) | Runtime logs | INSERT on `runtime_logs_raw_v1` |
+| [`eve`](./users/eve) | Ad-hoc analytics exploration (human) | direct grants (see script) |
 | [`github`](./users/github) | GitHub integrations | `readonly_role` |
 | [`vercel_dashboard`](./users/vercel-dashboard) | Vercel dashboard | `readonly_role` |
 | [`unkey_admin`](./users/unkey-admin) | Admin access | all roles |

--- a/docs/engineering/infra/clickhouse/users/eve.mdx
+++ b/docs/engineering/infra/clickhouse/users/eve.mdx
@@ -1,0 +1,28 @@
+---
+title: eve
+description: Read-only analytics user for ad-hoc data exploration
+---
+
+Human exploration user. Gets read access to the analytics tables but not the
+raw request/response streams.
+
+Uses a direct `GRANT SELECT ON default.*` plus targeted `REVOKE`s instead of
+`readonly_role` because the role grants every table in `default`, including the
+raw tables that store request and response bodies, headers, IP addresses, and
+free-form logs. Those can contain customer PII and secrets (for example
+`Authorization` headers or API keys in request bodies), which an exploration
+user has no reason to read. The direct-grant-then-revoke shape still auto-picks
+up new rollup tables while keeping the four raw streams out.
+
+```sql
+CREATE USER IF NOT EXISTS eve IDENTIFIED WITH sha256_password BY '<password>';
+
+-- Read access to the default database.
+GRANT SELECT ON default.* TO eve;
+
+-- Exclude the raw streams that carry bodies / headers / IPs / free-form logs.
+REVOKE SELECT ON default.api_requests_raw_v2      FROM eve;  -- request/response bodies, headers, IP, UA
+REVOKE SELECT ON default.frontline_requests_raw_v1 FROM eve;  -- request/response bodies, headers, IP, UA
+REVOKE SELECT ON default.runtime_logs_raw_v1      FROM eve;  -- free-form app log messages + attributes
+REVOKE SELECT ON default.audit_logs_raw_v1        FROM eve;  -- actor / target / meta JSON
+```


### PR DESCRIPTION
Adds eve readonly user docs

User got already added, this is just documentation for it.