### PR TITLE
feat(vector): use strip_ansi_escape_codes

### DIFF
--- a/dev/k8s/manifests/vector-logs.yaml
+++ b/dev/k8s/manifests/vector-logs.yaml
@@ -129,7 +129,9 @@ data:
     .attributes = {}
 
     # Try to parse structured logs (JSON or key=value)
-    raw_message = string!(.message)
+    # Strip ANSI color codes first: colorized level words (e.g. \x1b[31mERROR)
+    # would otherwise defeat the severity regexes and can corrupt JSON/logfmt parsing.
+    raw_message = strip_ansi_escape_codes(string!(.message))
     parsed, err = parse_json(raw_message)
     if err == null && is_object(parsed) {
         # JSON structured log - keep nested structure
@@ -156,7 +158,12 @@ data:
             del(.attributes.level)
             del(.attributes.severity)
         } else {
-            # Plain text log - comprehensive severity detection
+            # Plain text log - store the decolorized message (the structured
+            # branches above already do this via raw_message; this branch must too,
+            # otherwise .message keeps its original ANSI codes).
+            .message = raw_message
+
+            # Comprehensive severity detection.
             # After multiline merge, we scan the ENTIRE content for error indicators
             # Based on: https://betterstack.com/community/guides/logging/log-levels-explained/
             msg_lower = downcase(raw_message)


### PR DESCRIPTION
https://vector.dev/docs/reference/vrl/functions/#strip_ansi_escape_codes

make use of said vector options to make logs nicer to look at.

Actual output; <img width="2176" height="298" alt="CleanShot 2026-07-01 at 16 27 50@2x" src="https://github.com/user-attachments/assets/e079d5fe-50b7-48b8-91f5-d9a4f916a296" />

in unkey: <img width="1328" height="802" alt="CleanShot 2026-07-01 at 16 27 34@2x" src="https://github.com/user-attachments/assets/d2982ba6-d1e8-489e-aaab-4239c86153eb" />
