### PR TITLE
fix(ci): stop bazel test from leaking containers across the run

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -39,6 +39,19 @@ test --test_summary=terse
 test --local_test_jobs=auto
 
 # ============================================================
+# CI overrides (activated via --config=ci)
+# ============================================================
+# CI runners have a fixed RAM budget. Bazel's local resource manager
+# schedules test parallelism against --local_ram_resources (default: all
+# host RAM), but per-test RAM estimates derived from the `size` attribute
+# are far below what container-backed integration tests actually use.
+# Leaving headroom here prevents concurrently scheduled tests from OOM
+# killing the Bazel server itself (see incident where 8 concurrent test
+# actions exhausted a 32GB depot-ubuntu-24.04-8 runner).
+test:ci --local_ram_resources=HOST_RAM*.75
+test:ci --local_test_jobs=6
+
+# ============================================================
 # Release stamping
 # ============================================================
 # Bakes STABLE_VERSION, STABLE_GIT_COMMIT, and BUILD_TIMESTAMP

--- a/.depot/workflows/job_bazel.yaml
+++ b/.depot/workflows/job_bazel.yaml
@@ -20,4 +20,13 @@ jobs:
       - name: Build
         run: bazel build //...
       - name: Run tests
-        run: bazel test //... --test_output=errors
+        # UNKEY_TEST_CONTAINER_SCOPE must be forwarded via --test_env: Bazel
+        # does not pass host env vars into test sandboxes. Without it, every
+        # container-backed test target falls back to TEST_SRCDIR (unique per
+        # target) for its container scope, so each one starts its own
+        # MySQL/ClickHouse/etc pair that never gets cleaned up. Across the
+        # full suite that piles up dozens of container pairs and OOMs the
+        # runner. See .mise/tasks/test, which does the same for local runs.
+        run: |
+          export UNKEY_TEST_CONTAINER_SCOPE="${GITHUB_WORKSPACE}"
+          bazel test --config=ci --test_env=UNKEY_TEST_CONTAINER_SCOPE //... --test_output=errors

--- a/svc/api/BUILD.bazel
+++ b/svc/api/BUILD.bazel
@@ -54,7 +54,7 @@ go_library(
 
 go_test(
     name = "api_test",
-    size = "small",
+    size = "large",
     srcs = [
         "cancel_test.go",
         "config_test.go",

--- a/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes01_limit0010_duration000060000_load00_90_windows010/BUILD.bazel
+++ b/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes01_limit0010_duration000060000_load00_90_windows010/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "ratelimit_nodes01_limit0010_duration000060000_load00_90_windows010_test",
+    size = "large",
     srcs = ["generated_test.go"],
     deps = [
         "//pkg/clock",

--- a/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes01_limit0100_duration000010000_load00_90_windows010/BUILD.bazel
+++ b/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes01_limit0100_duration000010000_load00_90_windows010/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "ratelimit_nodes01_limit0100_duration000010000_load00_90_windows010_test",
+    size = "large",
     srcs = ["generated_test.go"],
     deps = [
         "//pkg/clock",

--- a/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes01_limit0100_duration000010000_load01_00_windows010/BUILD.bazel
+++ b/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes01_limit0100_duration000010000_load01_00_windows010/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "ratelimit_nodes01_limit0100_duration000010000_load01_00_windows010_test",
+    size = "large",
     srcs = ["generated_test.go"],
     deps = [
         "//pkg/clock",

--- a/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes01_limit0100_duration000010000_load02_00_windows010/BUILD.bazel
+++ b/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes01_limit0100_duration000010000_load02_00_windows010/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "ratelimit_nodes01_limit0100_duration000010000_load02_00_windows010_test",
+    size = "large",
     srcs = ["generated_test.go"],
     deps = [
         "//pkg/clock",

--- a/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes01_limit0100_duration000300000_load00_90_windows010/BUILD.bazel
+++ b/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes01_limit0100_duration000300000_load00_90_windows010/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "ratelimit_nodes01_limit0100_duration000300000_load00_90_windows010_test",
+    size = "large",
     srcs = ["generated_test.go"],
     deps = [
         "//pkg/clock",

--- a/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes03_limit0010_duration000060000_load00_90_windows010/BUILD.bazel
+++ b/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes03_limit0010_duration000060000_load00_90_windows010/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "ratelimit_nodes03_limit0010_duration000060000_load00_90_windows010_test",
+    size = "large",
     srcs = ["generated_test.go"],
     deps = [
         "//pkg/clock",

--- a/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes03_limit0010_duration000060000_load01_50_windows010/BUILD.bazel
+++ b/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes03_limit0010_duration000060000_load01_50_windows010/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "ratelimit_nodes03_limit0010_duration000060000_load01_50_windows010_test",
+    size = "large",
     srcs = ["generated_test.go"],
     deps = [
         "//pkg/clock",

--- a/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes03_limit0100_duration000010000_load00_90_windows010/BUILD.bazel
+++ b/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes03_limit0100_duration000010000_load00_90_windows010/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "ratelimit_nodes03_limit0100_duration000010000_load00_90_windows010_test",
+    size = "large",
     srcs = ["generated_test.go"],
     deps = [
         "//pkg/clock",

--- a/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes03_limit0100_duration000010000_load01_00_windows010/BUILD.bazel
+++ b/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes03_limit0100_duration000010000_load01_00_windows010/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "ratelimit_nodes03_limit0100_duration000010000_load01_00_windows010_test",
+    size = "large",
     srcs = ["generated_test.go"],
     deps = [
         "//pkg/clock",

--- a/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes03_limit0100_duration000010000_load02_00_windows010/BUILD.bazel
+++ b/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes03_limit0100_duration000010000_load02_00_windows010/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "ratelimit_nodes03_limit0100_duration000010000_load02_00_windows010_test",
+    size = "large",
     srcs = ["generated_test.go"],
     deps = [
         "//pkg/clock",

--- a/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes03_limit0100_duration000300000_load00_90_windows010/BUILD.bazel
+++ b/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes03_limit0100_duration000300000_load00_90_windows010/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "ratelimit_nodes03_limit0100_duration000300000_load00_90_windows010_test",
+    size = "large",
     srcs = ["generated_test.go"],
     deps = [
         "//pkg/clock",

--- a/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes03_limit0100_duration000300000_load01_50_windows010/BUILD.bazel
+++ b/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes03_limit0100_duration000300000_load01_50_windows010/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "ratelimit_nodes03_limit0100_duration000300000_load01_50_windows010_test",
+    size = "large",
     srcs = ["generated_test.go"],
     deps = [
         "//pkg/clock",

--- a/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes03_limit10000_duration000060000_load00_90_windows005/BUILD.bazel
+++ b/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes03_limit10000_duration000060000_load00_90_windows005/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "ratelimit_nodes03_limit10000_duration000060000_load00_90_windows005_test",
+    size = "large",
     srcs = ["generated_test.go"],
     deps = [
         "//pkg/clock",

--- a/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes03_limit10000_duration000060000_load01_00_windows005/BUILD.bazel
+++ b/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes03_limit10000_duration000060000_load01_00_windows005/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "ratelimit_nodes03_limit10000_duration000060000_load01_00_windows005_test",
+    size = "large",
     srcs = ["generated_test.go"],
     deps = [
         "//pkg/clock",

--- a/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes03_limit10000_duration000060000_load02_00_windows005/BUILD.bazel
+++ b/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes03_limit10000_duration000060000_load02_00_windows005/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "ratelimit_nodes03_limit10000_duration000060000_load02_00_windows005_test",
+    size = "large",
     srcs = ["generated_test.go"],
     deps = [
         "//pkg/clock",

--- a/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes03_limit1000_duration000010000_load00_90_windows010/BUILD.bazel
+++ b/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes03_limit1000_duration000010000_load00_90_windows010/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "ratelimit_nodes03_limit1000_duration000010000_load00_90_windows010_test",
+    size = "large",
     srcs = ["generated_test.go"],
     deps = [
         "//pkg/clock",

--- a/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes03_limit1000_duration000010000_load01_00_windows010/BUILD.bazel
+++ b/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes03_limit1000_duration000010000_load01_00_windows010/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "ratelimit_nodes03_limit1000_duration000010000_load01_00_windows010_test",
+    size = "large",
     srcs = ["generated_test.go"],
     deps = [
         "//pkg/clock",

--- a/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes03_limit1000_duration000010000_load02_00_windows010/BUILD.bazel
+++ b/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes03_limit1000_duration000010000_load02_00_windows010/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "ratelimit_nodes03_limit1000_duration000010000_load02_00_windows010_test",
+    size = "large",
     srcs = ["generated_test.go"],
     deps = [
         "//pkg/clock",

--- a/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes05_limit0010_duration000060000_load00_90_windows010/BUILD.bazel
+++ b/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes05_limit0010_duration000060000_load00_90_windows010/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "ratelimit_nodes05_limit0010_duration000060000_load00_90_windows010_test",
+    size = "large",
     srcs = ["generated_test.go"],
     deps = [
         "//pkg/clock",

--- a/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes05_limit0010_duration000060000_load01_50_windows010/BUILD.bazel
+++ b/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes05_limit0010_duration000060000_load01_50_windows010/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "ratelimit_nodes05_limit0010_duration000060000_load01_50_windows010_test",
+    size = "large",
     srcs = ["generated_test.go"],
     deps = [
         "//pkg/clock",

--- a/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes05_limit0100_duration000010000_load00_90_windows010/BUILD.bazel
+++ b/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes05_limit0100_duration000010000_load00_90_windows010/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "ratelimit_nodes05_limit0100_duration000010000_load00_90_windows010_test",
+    size = "large",
     srcs = ["generated_test.go"],
     deps = [
         "//pkg/clock",

--- a/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes05_limit0100_duration000010000_load01_00_windows010/BUILD.bazel
+++ b/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes05_limit0100_duration000010000_load01_00_windows010/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "ratelimit_nodes05_limit0100_duration000010000_load01_00_windows010_test",
+    size = "large",
     srcs = ["generated_test.go"],
     deps = [
         "//pkg/clock",

--- a/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes05_limit0100_duration000010000_load02_00_windows010/BUILD.bazel
+++ b/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes05_limit0100_duration000010000_load02_00_windows010/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "ratelimit_nodes05_limit0100_duration000010000_load02_00_windows010_test",
+    size = "large",
     srcs = ["generated_test.go"],
     deps = [
         "//pkg/clock",

--- a/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes05_limit0100_duration000300000_load00_90_windows010/BUILD.bazel
+++ b/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes05_limit0100_duration000300000_load00_90_windows010/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "ratelimit_nodes05_limit0100_duration000300000_load00_90_windows010_test",
+    size = "large",
     srcs = ["generated_test.go"],
     deps = [
         "//pkg/clock",

--- a/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes05_limit0100_duration000300000_load01_50_windows010/BUILD.bazel
+++ b/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes05_limit0100_duration000300000_load01_50_windows010/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "ratelimit_nodes05_limit0100_duration000300000_load01_50_windows010_test",
+    size = "large",
     srcs = ["generated_test.go"],
     deps = [
         "//pkg/clock",

--- a/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes05_limit10000_duration000060000_load01_00_windows005/BUILD.bazel
+++ b/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes05_limit10000_duration000060000_load01_00_windows005/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "ratelimit_nodes05_limit10000_duration000060000_load01_00_windows005_test",
+    size = "large",
     srcs = ["generated_test.go"],
     deps = [
         "//pkg/clock",

--- a/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes05_limit10000_duration000060000_load02_00_windows005/BUILD.bazel
+++ b/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes05_limit10000_duration000060000_load02_00_windows005/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "ratelimit_nodes05_limit10000_duration000060000_load02_00_windows005_test",
+    size = "large",
     srcs = ["generated_test.go"],
     deps = [
         "//pkg/clock",

--- a/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes05_limit1000_duration000010000_load01_00_windows010/BUILD.bazel
+++ b/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes05_limit1000_duration000010000_load01_00_windows010/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "ratelimit_nodes05_limit1000_duration000010000_load01_00_windows010_test",
+    size = "large",
     srcs = ["generated_test.go"],
     deps = [
         "//pkg/clock",

--- a/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes05_limit1000_duration000010000_load02_00_windows010/BUILD.bazel
+++ b/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes05_limit1000_duration000010000_load02_00_windows010/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "ratelimit_nodes05_limit1000_duration000010000_load02_00_windows010_test",
+    size = "large",
     srcs = ["generated_test.go"],
     deps = [
         "//pkg/clock",

--- a/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes09_limit0100_duration000030000_load02_00_windows005/BUILD.bazel
+++ b/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes09_limit0100_duration000030000_load02_00_windows005/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "ratelimit_nodes09_limit0100_duration000030000_load02_00_windows005_test",
+    size = "large",
     srcs = ["generated_test.go"],
     deps = [
         "//pkg/clock",

--- a/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes09_limit0100_duration000300000_load01_00_windows003/BUILD.bazel
+++ b/svc/api/integration/multi_node_ratelimiting/generated/ratelimit_nodes09_limit0100_duration000300000_load01_00_windows003/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "ratelimit_nodes09_limit0100_duration000300000_load01_00_windows003_test",
+    size = "large",
     srcs = ["generated_test.go"],
     deps = [
         "//pkg/clock",

--- a/svc/api/integration/multi_node_usagelimiting/generated/usagelimit_nodes01_credits0010_cost01_load00_80_duration015/BUILD.bazel
+++ b/svc/api/integration/multi_node_usagelimiting/generated/usagelimit_nodes01_credits0010_cost01_load00_80_duration015/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "usagelimit_nodes01_credits0010_cost01_load00_80_duration015_test",
+    size = "large",
     srcs = ["generated_test.go"],
     deps = [
         "//svc/api/integration",

--- a/svc/api/integration/multi_node_usagelimiting/generated/usagelimit_nodes01_credits0100_cost01_load00_90_duration030/BUILD.bazel
+++ b/svc/api/integration/multi_node_usagelimiting/generated/usagelimit_nodes01_credits0100_cost01_load00_90_duration030/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "usagelimit_nodes01_credits0100_cost01_load00_90_duration030_test",
+    size = "large",
     srcs = ["generated_test.go"],
     deps = [
         "//svc/api/integration",

--- a/svc/api/integration/multi_node_usagelimiting/generated/usagelimit_nodes01_credits0100_cost01_load01_00_duration030/BUILD.bazel
+++ b/svc/api/integration/multi_node_usagelimiting/generated/usagelimit_nodes01_credits0100_cost01_load01_00_duration030/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "usagelimit_nodes01_credits0100_cost01_load01_00_duration030_test",
+    size = "large",
     srcs = ["generated_test.go"],
     deps = [
         "//svc/api/integration",

--- a/svc/api/integration/multi_node_usagelimiting/generated/usagelimit_nodes01_credits0100_cost01_load02_00_duration030/BUILD.bazel
+++ b/svc/api/integration/multi_node_usagelimiting/generated/usagelimit_nodes01_credits0100_cost01_load02_00_duration030/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "usagelimit_nodes01_credits0100_cost01_load02_00_duration030_test",
+    size = "large",
     srcs = ["generated_test.go"],
     deps = [
         "//svc/api/integration",

--- a/svc/api/integration/multi_node_usagelimiting/generated/usagelimit_nodes03_credits0010_cost01_load01_20_duration015/BUILD.bazel
+++ b/svc/api/integration/multi_node_usagelimiting/generated/usagelimit_nodes03_credits0010_cost01_load01_20_duration015/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "usagelimit_nodes03_credits0010_cost01_load01_20_duration015_test",
+    size = "large",
     srcs = ["generated_test.go"],
     deps = [
         "//svc/api/integration",

--- a/svc/api/integration/multi_node_usagelimiting/generated/usagelimit_nodes03_credits0100_cost01_load00_90_duration030/BUILD.bazel
+++ b/svc/api/integration/multi_node_usagelimiting/generated/usagelimit_nodes03_credits0100_cost01_load00_90_duration030/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "usagelimit_nodes03_credits0100_cost01_load00_90_duration030_test",
+    size = "large",
     srcs = ["generated_test.go"],
     deps = [
         "//svc/api/integration",

--- a/svc/api/integration/multi_node_usagelimiting/generated/usagelimit_nodes03_credits0100_cost01_load01_00_duration030/BUILD.bazel
+++ b/svc/api/integration/multi_node_usagelimiting/generated/usagelimit_nodes03_credits0100_cost01_load01_00_duration030/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "usagelimit_nodes03_credits0100_cost01_load01_00_duration030_test",
+    size = "large",
     srcs = ["generated_test.go"],
     deps = [
         "//svc/api/integration",

--- a/svc/api/integration/multi_node_usagelimiting/generated/usagelimit_nodes03_credits0100_cost01_load02_00_duration030/BUILD.bazel
+++ b/svc/api/integration/multi_node_usagelimiting/generated/usagelimit_nodes03_credits0100_cost01_load02_00_duration030/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "usagelimit_nodes03_credits0100_cost01_load02_00_duration030_test",
+    size = "large",
     srcs = ["generated_test.go"],
     deps = [
         "//svc/api/integration",

--- a/svc/api/integration/multi_node_usagelimiting/generated/usagelimit_nodes03_credits0100_cost20_load01_00_duration010/BUILD.bazel
+++ b/svc/api/integration/multi_node_usagelimiting/generated/usagelimit_nodes03_credits0100_cost20_load01_00_duration010/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "usagelimit_nodes03_credits0100_cost20_load01_00_duration010_test",
+    size = "large",
     srcs = ["generated_test.go"],
     deps = [
         "//svc/api/integration",

--- a/svc/api/integration/multi_node_usagelimiting/generated/usagelimit_nodes03_credits0500_cost05_load01_00_duration025/BUILD.bazel
+++ b/svc/api/integration/multi_node_usagelimiting/generated/usagelimit_nodes03_credits0500_cost05_load01_00_duration025/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "usagelimit_nodes03_credits0500_cost05_load01_00_duration025_test",
+    size = "large",
     srcs = ["generated_test.go"],
     deps = [
         "//svc/api/integration",

--- a/svc/api/integration/multi_node_usagelimiting/generated/usagelimit_nodes03_credits1000_cost10_load00_90_duration020/BUILD.bazel
+++ b/svc/api/integration/multi_node_usagelimiting/generated/usagelimit_nodes03_credits1000_cost10_load00_90_duration020/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "usagelimit_nodes03_credits1000_cost10_load00_90_duration020_test",
+    size = "large",
     srcs = ["generated_test.go"],
     deps = [
         "//svc/api/integration",

--- a/svc/api/integration/multi_node_usagelimiting/generated/usagelimit_nodes05_credits0010_cost01_load01_50_duration015/BUILD.bazel
+++ b/svc/api/integration/multi_node_usagelimiting/generated/usagelimit_nodes05_credits0010_cost01_load01_50_duration015/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "usagelimit_nodes05_credits0010_cost01_load01_50_duration015_test",
+    size = "large",
     srcs = ["generated_test.go"],
     deps = [
         "//svc/api/integration",

--- a/svc/api/integration/multi_node_usagelimiting/generated/usagelimit_nodes05_credits0100_cost01_load00_90_duration030/BUILD.bazel
+++ b/svc/api/integration/multi_node_usagelimiting/generated/usagelimit_nodes05_credits0100_cost01_load00_90_duration030/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "usagelimit_nodes05_credits0100_cost01_load00_90_duration030_test",
+    size = "large",
     srcs = ["generated_test.go"],
     deps = [
         "//svc/api/integration",

--- a/svc/api/integration/multi_node_usagelimiting/generated/usagelimit_nodes05_credits0100_cost01_load01_00_duration030/BUILD.bazel
+++ b/svc/api/integration/multi_node_usagelimiting/generated/usagelimit_nodes05_credits0100_cost01_load01_00_duration030/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "usagelimit_nodes05_credits0100_cost01_load01_00_duration030_test",
+    size = "large",
     srcs = ["generated_test.go"],
     deps = [
         "//svc/api/integration",

--- a/svc/api/integration/multi_node_usagelimiting/generated/usagelimit_nodes05_credits0100_cost01_load02_00_duration030/BUILD.bazel
+++ b/svc/api/integration/multi_node_usagelimiting/generated/usagelimit_nodes05_credits0100_cost01_load02_00_duration030/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "usagelimit_nodes05_credits0100_cost01_load02_00_duration030_test",
+    size = "large",
     srcs = ["generated_test.go"],
     deps = [
         "//svc/api/integration",

--- a/svc/api/integration/multi_node_usagelimiting/generated/usagelimit_nodes05_credits0100_cost20_load01_50_duration010/BUILD.bazel
+++ b/svc/api/integration/multi_node_usagelimiting/generated/usagelimit_nodes05_credits0100_cost20_load01_50_duration010/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "usagelimit_nodes05_credits0100_cost20_load01_50_duration010_test",
+    size = "large",
     srcs = ["generated_test.go"],
     deps = [
         "//svc/api/integration",

--- a/svc/api/integration/multi_node_usagelimiting/generated/usagelimit_nodes05_credits0500_cost05_load02_00_duration025/BUILD.bazel
+++ b/svc/api/integration/multi_node_usagelimiting/generated/usagelimit_nodes05_credits0500_cost05_load02_00_duration025/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "usagelimit_nodes05_credits0500_cost05_load02_00_duration025_test",
+    size = "large",
     srcs = ["generated_test.go"],
     deps = [
         "//svc/api/integration",

--- a/svc/api/integration/multi_node_usagelimiting/generated/usagelimit_nodes05_credits1000_cost10_load01_50_duration020/BUILD.bazel
+++ b/svc/api/integration/multi_node_usagelimiting/generated/usagelimit_nodes05_credits1000_cost10_load01_50_duration020/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "usagelimit_nodes05_credits1000_cost10_load01_50_duration020_test",
+    size = "large",
     srcs = ["generated_test.go"],
     deps = [
         "//svc/api/integration",

--- a/svc/api/integration/multi_node_usagelimiting/generated/usagelimit_nodes09_credits0500_cost05_load02_00_duration015/BUILD.bazel
+++ b/svc/api/integration/multi_node_usagelimiting/generated/usagelimit_nodes09_credits0500_cost05_load02_00_duration015/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "usagelimit_nodes09_credits0500_cost05_load02_00_duration015_test",
+    size = "large",
     srcs = ["generated_test.go"],
     deps = [
         "//svc/api/integration",

--- a/svc/api/integration/multi_node_usagelimiting/generated/usagelimit_nodes09_credits1000_cost01_load03_00_duration015/BUILD.bazel
+++ b/svc/api/integration/multi_node_usagelimiting/generated/usagelimit_nodes09_credits1000_cost01_load03_00_duration015/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "usagelimit_nodes09_credits1000_cost01_load03_00_duration015_test",
+    size = "large",
     srcs = ["generated_test.go"],
     deps = [
         "//svc/api/integration",

--- a/svc/ctrl/api/BUILD.bazel
+++ b/svc/ctrl/api/BUILD.bazel
@@ -53,6 +53,7 @@ go_library(
 
 go_test(
     name = "api_test",
+    size = "large",
     srcs = [
         "deployment_integration_test.go",
         "github_webhook_integration_test.go",

--- a/svc/ctrl/worker/clickhouseuser/BUILD.bazel
+++ b/svc/ctrl/worker/clickhouseuser/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
 
 go_test(
     name = "clickhouseuser_test",
+    size = "large",
     srcs = [
         "configure_user_handler_test.go",
         "configure_user_integration_test.go",

--- a/svc/ctrl/worker/cron/BUILD.bazel
+++ b/svc/ctrl/worker/cron/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
 
 go_test(
     name = "cron_test",
+    size = "large",
     srcs = [
         "audit_log_outbox_cleanup_integration_test.go",
         "key_last_used_sync_integration_test.go",

--- a/svc/frontline/internal/policies/BUILD.bazel
+++ b/svc/frontline/internal/policies/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
 
 go_test(
     name = "policies_test",
+    size = "large",
     srcs = [
         "engine_test.go",
         "integration_test.go",


### PR DESCRIPTION
## Summary

CI's `bazel test //...` OOM-killed the Bazel server twice (PR #6491, PR #6607) on the depot-ubuntu-24.04-8 runner (8 vCPU / 32GB).

Root cause: `pkg/testutil/containers` reuses MySQL/ClickHouse/Restate/Vault containers by a scope hash, and `.mise/tasks/test` forwards that scope via `--test_env=UNKEY_TEST_CONTAINER_SCOPE` so every test target in a run shares one container set. CI's workflow called `bazel test` directly instead of going through that task, so Bazel never forwarded the scope env var into test sandboxes. Every container-backed test target fell back to `TEST_SRCDIR` for its scope, which is unique per target, so each one started its own private container pair that was never cleaned up. Across ~200 tests those pile up until the runner runs out of RAM.

Verified locally with `docker ps` counts:
- 51 generated multi-node test targets, no scope var: 48 containers (24 distinct MySQL+ClickHouse pairs, ~5GB).
- Same 51 targets, with `UNKEY_TEST_CONTAINER_SCOPE` + `--test_env` set: 1 pair.
- Full 204-target suite with the fix: 5 containers total for the whole ~190s run, all tests passing.

## Changes

- `.depot/workflows/job_bazel.yaml`: export `UNKEY_TEST_CONTAINER_SCOPE` and pass `--test_env=UNKEY_TEST_CONTAINER_SCOPE`, matching `.mise/tasks/test`.
- `.bazelrc`: add a `test:ci` config capping `--local_ram_resources` and `--local_test_jobs` as defense in depth.
- A handful of container-backed `go_test` targets (`cron_test`, `clickhouseuser_test`, `svc/ctrl/api:api_test`, `frontline/internal/policies:policies_test`, `svc/api:api_test`, and the 51 generated multi-node targets) were missing `size = "large"` (or had `size = "small"`), inconsistent with sibling packages using the same container pattern. Fixed to match convention.

## Test plan

- [x] Ran the previously-crashing targets (`cron_test`, `v2_ratelimit_limit_test`) locally, pass.
- [x] Ran the full local suite (`bazel test --config=ci --test_env=UNKEY_TEST_CONTAINER_SCOPE //...`), 204/204 pass, container count stayed flat at 5 for the whole run.