### PR TITLE
feat(dashboard): Customer portal settings prototype

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/portal/page.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/portal/page.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { PortalSettings } from "@/app/(app)/[workspaceSlug]/portal/components/portal-settings";
+import { useWorkspaceNavigation } from "@/hooks/use-workspace-navigation";
+import { trpc } from "@/lib/trpc/client";
+import { SettingsShell } from "@unkey/ui";
+import { use } from "react";
+import { ApisNavbar } from "../api-id-navbar";
+
+type Props = {
+  params: Promise<{ apiId: string }>;
+};
+
+export default function ApiPortalPage(props: Props) {
+  const { apiId } = use(props.params);
+  const workspace = useWorkspaceNavigation();
+  const { data } = trpc.api.queryApiKeyDetails.useQuery({ apiId }, { enabled: Boolean(apiId) });
+  const name = data?.currentApi?.name ?? apiId;
+
+  return (
+    <div>
+      <ApisNavbar
+        apiId={apiId}
+        activePage={{ href: `/${workspace.slug}/apis/${apiId}/portal`, text: "Customer portal" }}
+      />
+      <SettingsShell>
+        <PortalSettings resourceName={name} portalId={`portal_${apiId}`} />
+      </SettingsShell>
+    </div>
+  );
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/portal/[portalId]/page.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/portal/[portalId]/page.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { Switch } from "@/components/ui/switch";
+import { useWorkspaceNavigation } from "@/hooks/use-workspace-navigation";
+import {
+  Button,
+  CopyButton,
+  PageBody,
+  PageContainer,
+  PageHeader,
+  PageHeaderActions,
+  PageHeaderContent,
+  PageHeaderTitle,
+  SettingCard,
+  SettingCardGroup,
+  SettingsDangerZone,
+} from "@unkey/ui";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { useState } from "react";
+import { DeletePortal } from "../components/delete-portal";
+import { IntegrateDialog } from "../components/integrate-dialog";
+import { portalUrl, setPortalEnabled, usePortal } from "../data/portals";
+
+export default function PortalConfigPage() {
+  const workspace = useWorkspaceNavigation();
+  const params = useParams<{ portalId: string }>();
+  const portal = usePortal(params.portalId);
+  const [integrateOpen, setIntegrateOpen] = useState(false);
+
+  if (!portal) {
+    return (
+      <PageContainer>
+        <PageHeader>
+          <PageHeaderContent>
+            <PageHeaderTitle>Portal not found</PageHeaderTitle>
+          </PageHeaderContent>
+        </PageHeader>
+        <PageBody>
+          <div className="text-gray-11 text-sm">
+            This portal doesn't exist.{" "}
+            <Link className="text-accent-11 underline" href={`/${workspace.slug}/portal`}>
+              Back to portals
+            </Link>
+          </div>
+        </PageBody>
+      </PageContainer>
+    );
+  }
+
+  return (
+    <PageContainer>
+      <PageHeader>
+        <PageHeaderContent>
+          <PageHeaderTitle>{portal.resourceName}</PageHeaderTitle>
+        </PageHeaderContent>
+        <PageHeaderActions>
+          <Button variant="primary" onClick={() => setIntegrateOpen(true)}>
+            How to integrate
+          </Button>
+        </PageHeaderActions>
+      </PageHeader>
+      <PageBody>
+        <div className="flex w-full flex-col gap-6">
+          <SettingCardGroup>
+            <SettingCard
+              title="Portal access"
+              description="When enabled, sessions can be created and your customers can sign in."
+              contentWidth="w-auto"
+            >
+              <div className="flex w-full justify-end">
+                <Switch
+                  checked={portal.enabled}
+                  onCheckedChange={(checked) => setPortalEnabled(portal.id, checked)}
+                />
+              </div>
+            </SettingCard>
+            <SettingCard
+              title="Portal URL"
+              description="Served on your Unkey subdomain. Custom domains come later."
+              contentWidth="w-full lg:w-[420px]"
+            >
+              <div className="flex w-full items-center justify-end gap-2">
+                <div className="flex-1 lg:flex-none lg:w-[300px] truncate rounded-lg border border-grayA-4 px-3 py-2 text-[13px] text-gray-11">
+                  {portalUrl(portal.slug)}
+                </div>
+                <CopyButton value={portalUrl(portal.slug)} />
+              </div>
+            </SettingCard>
+            <SettingCard
+              title="Connected resource"
+              description="Set when the portal was created. Changing it means deleting and recreating."
+              contentWidth="w-auto"
+            >
+              <span className="text-[11px] rounded-full border border-grayA-4 px-2 py-0.5 text-gray-11 whitespace-nowrap">
+                {portal.resourceType === "app" ? "Deploy app" : "API keyspace"} ·{" "}
+                {portal.resourceName}
+              </span>
+            </SettingCard>
+          </SettingCardGroup>
+
+          <SettingsDangerZone>
+            <DeletePortal portal={portal} />
+          </SettingsDangerZone>
+        </div>
+      </PageBody>
+      <IntegrateDialog
+        portalId={portal.id}
+        isOpen={integrateOpen}
+        onOpenChange={setIntegrateOpen}
+      />
+    </PageContainer>
+  );
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/portal/components/create-portal-button.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/portal/components/create-portal-button.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { Plus } from "@unkey/icons";
+import { Button } from "@unkey/ui";
+import type { ComponentProps } from "react";
+import { useState } from "react";
+import { CreatePortalDialog } from "./create-portal-dialog";
+
+export function CreatePortalButton({
+  size = "md",
+}: {
+  size?: ComponentProps<typeof Button>["size"];
+}) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <Button variant="primary" size={size} onClick={() => setOpen(true)}>
+        <Plus iconSize="sm-regular" />
+        Create portal
+      </Button>
+      <CreatePortalDialog isOpen={open} onOpenChange={setOpen} />
+    </>
+  );
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/portal/components/create-portal-dialog.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/portal/components/create-portal-dialog.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { FormCombobox } from "@/components/ui/form-combobox";
+import { useWorkspaceNavigation } from "@/hooks/use-workspace-navigation";
+import { cn } from "@/lib/utils";
+import { Button, DialogContainer } from "@unkey/ui";
+import { useRouter } from "next/navigation";
+import { useMemo, useState } from "react";
+import { MOCK_APPS, MOCK_KEYSPACES, type PortalResourceType, createPortal } from "../data/portals";
+
+type Props = {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+export function CreatePortalDialog({ isOpen, onOpenChange }: Props) {
+  const workspace = useWorkspaceNavigation();
+  const router = useRouter();
+
+  const [resourceType, setResourceType] = useState<PortalResourceType>("app");
+  const [resource, setResource] = useState("");
+
+  const noun = resourceType === "app" ? "app" : "keyspace";
+
+  const options = useMemo(() => {
+    const list = resourceType === "app" ? MOCK_APPS : MOCK_KEYSPACES;
+    return list.map((r) => ({
+      value: r.name,
+      label: r.name,
+      searchValue: r.name,
+      selectedLabel: r.name,
+    }));
+  }, [resourceType]);
+
+  const reset = () => {
+    setResourceType("app");
+    setResource("");
+  };
+
+  const selectType = (type: PortalResourceType) => {
+    setResourceType(type);
+    setResource("");
+  };
+
+  const onCreate = () => {
+    if (!resource) {
+      return;
+    }
+    const id = createPortal({ resourceType, resourceName: resource });
+    onOpenChange(false);
+    reset();
+    router.push(`/${workspace.slug}/portal/${id}`);
+  };
+
+  return (
+    <DialogContainer
+      isOpen={isOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          reset();
+        }
+        onOpenChange(open);
+      }}
+      title="Create portal"
+      footer={
+        <div className="w-full flex justify-end gap-2">
+          <Button variant="outline" size="lg" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button variant="primary" size="lg" disabled={!resource} onClick={onCreate}>
+            Create portal
+          </Button>
+        </div>
+      }
+    >
+      <div className="flex flex-col gap-4">
+        <p className="text-gray-11 text-[13px]">
+          Connect this portal to one resource. This can't be changed later.
+        </p>
+        <div className="flex flex-col gap-2">
+          <ResourceOption
+            selected={resourceType === "app"}
+            onSelect={() => selectType("app")}
+            title="Deploy app"
+            description="Multi-keyspace portal for an app deployed on Unkey"
+          />
+          <ResourceOption
+            selected={resourceType === "keyspace"}
+            onSelect={() => selectType("keyspace")}
+            title="API keyspace"
+            description="Self-serve key management for a single keyspace"
+          />
+        </div>
+        <FormCombobox
+          label={resourceType === "app" ? "Select app" : "Select keyspace"}
+          requirement="required"
+          options={options}
+          value={resource}
+          onSelect={setResource}
+          placeholder={<span className="text-gray-9">{`Search ${noun}s…`}</span>}
+          searchPlaceholder={`Search ${noun}s...`}
+          emptyMessage={`No ${noun}s found`}
+        />
+      </div>
+    </DialogContainer>
+  );
+}
+
+function ResourceOption({
+  selected,
+  onSelect,
+  title,
+  description,
+}: {
+  selected: boolean;
+  onSelect: () => void;
+  title: string;
+  description: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className={cn(
+        "text-left rounded-lg border p-3 transition-colors",
+        selected ? "border-accent-9 bg-accent-2" : "border-grayA-4 hover:border-grayA-6",
+      )}
+    >
+      <div className="flex items-center gap-2">
+        <span
+          className={cn(
+            "size-4 rounded-full border flex items-center justify-center",
+            selected ? "border-accent-9" : "border-grayA-6",
+          )}
+        >
+          {selected && <span className="size-2 rounded-full bg-accent-9" />}
+        </span>
+        <span className="text-gray-12 text-[13px] font-medium">{title}</span>
+      </div>
+      <p className="text-gray-11 text-[13px] mt-1 ml-6">{description}</p>
+    </button>
+  );
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/portal/components/delete-portal.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/portal/components/delete-portal.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useWorkspaceNavigation } from "@/hooks/use-workspace-navigation";
+import { Button, DialogContainer, Input, SettingsZoneRow } from "@unkey/ui";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { type Portal, deletePortal } from "../data/portals";
+
+export function DeletePortal({ portal }: { portal: Portal }) {
+  const workspace = useWorkspaceNavigation();
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [confirm, setConfirm] = useState("");
+
+  const isValid = confirm === portal.resourceName;
+
+  const onDelete = () => {
+    if (!isValid) {
+      return;
+    }
+    deletePortal(portal.id);
+    setOpen(false);
+    router.push(`/${workspace.slug}/portal`);
+  };
+
+  return (
+    <>
+      <SettingsZoneRow
+        title="Delete portal"
+        description="Permanently removes this portal. Existing sessions stop working. This action cannot be undone."
+        action={{ label: "Delete portal", onClick: () => setOpen(true) }}
+      />
+      <DialogContainer
+        isOpen={open}
+        onOpenChange={(o) => {
+          if (!o) {
+            setConfirm("");
+          }
+          setOpen(o);
+        }}
+        title="Delete portal"
+        footer={
+          <div className="w-full flex flex-col gap-2 items-center justify-center">
+            <Button
+              type="button"
+              variant="primary"
+              color="danger"
+              size="xlg"
+              className="w-full"
+              disabled={!isValid}
+              onClick={onDelete}
+            >
+              Delete portal
+            </Button>
+            <div className="text-gray-9 text-xs">
+              This action cannot be undone – proceed with caution
+            </div>
+          </div>
+        }
+      >
+        <div className="flex flex-col gap-1">
+          <p className="text-gray-11 text-[13px]">
+            Type <span className="text-gray-12 font-medium">{portal.resourceName}</span> to confirm
+          </p>
+          <Input
+            value={confirm}
+            onChange={(e) => setConfirm(e.target.value)}
+            placeholder={`Enter "${portal.resourceName}" to confirm`}
+          />
+        </div>
+      </DialogContainer>
+    </>
+  );
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/portal/components/integrate-dialog.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/portal/components/integrate-dialog.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import {
+  Code,
+  CopyButton,
+  DialogContainer,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@unkey/ui";
+
+type Props = {
+  portalId: string;
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+export function IntegrateDialog({ portalId, isOpen, onOpenChange }: Props) {
+  const curl = `curl -X POST https://api.unkey.com/v2/portal.createSession \\
+  -H "Authorization: Bearer $UNKEY_ROOT_KEY" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "portalId": "${portalId}",
+    "externalId": "user_123",
+    "permissions": ["keys.read", "keys.create"]
+  }'`;
+
+  const ts = `// server-side, after you've authenticated the user
+const { url } = await unkey.portal.createSession({
+  portalId: "${portalId}",
+  externalId: user.id,
+  permissions: ["keys.read", "keys.create"],
+});
+
+redirect(url); // send them to their portal`;
+
+  return (
+    <DialogContainer isOpen={isOpen} onOpenChange={onOpenChange} title="How to integrate">
+      <div className="flex flex-col gap-5">
+        <p className="text-gray-11 text-[13px]">
+          Create a session for a user you've already signed in, then redirect them to the portal.
+          The permissions you pass decide which tabs they see.
+        </p>
+
+        <div className="flex flex-col gap-2">
+          <p className="text-gray-9 text-[11px] uppercase tracking-wide">
+            Step 1 · Create a session (server-side)
+          </p>
+          <Tabs defaultValue="curl">
+            <TabsList>
+              <TabsTrigger value="curl">cURL</TabsTrigger>
+              <TabsTrigger value="ts">TypeScript</TabsTrigger>
+            </TabsList>
+            <TabsContent value="curl">
+              <Code copyButton={<CopyButton value={curl} />}>{curl}</Code>
+            </TabsContent>
+            <TabsContent value="ts">
+              <Code copyButton={<CopyButton value={ts} />}>{ts}</Code>
+            </TabsContent>
+          </Tabs>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <p className="text-gray-9 text-[11px] uppercase tracking-wide">
+            Step 2 · Redirect the user
+          </p>
+          <Code copyButton={<CopyButton value="redirect(session.url)" />}>
+            redirect(session.url)
+          </Code>
+        </div>
+
+        <a
+          href="https://www.unkey.com/docs"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-accent-11 text-[13px] underline"
+        >
+          Full documentation →
+        </a>
+      </div>
+    </DialogContainer>
+  );
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/portal/components/portal-actions.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/portal/components/portal-actions.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { type MenuItem, TableActionPopover } from "@/components/logs/table-action.popover";
+import { Clone, ExternalLink, Trash } from "@unkey/icons";
+import { toast } from "@unkey/ui";
+import type { PropsWithChildren } from "react";
+import { type Portal, deletePortal, portalUrl } from "../data/portals";
+
+export function PortalActions({ portal, children }: PropsWithChildren<{ portal: Portal }>) {
+  const url = portalUrl(portal.slug);
+
+  const menuItems: MenuItem[] = [];
+
+  if (portal.enabled) {
+    menuItems.push({
+      id: "open-portal",
+      label: "Open portal",
+      icon: <ExternalLink iconSize="md-medium" />,
+      onClick: () => window.open(`https://${url}`, "_blank", "noopener,noreferrer"),
+    });
+  }
+
+  menuItems.push({
+    id: "copy-url",
+    label: "Copy URL",
+    icon: <Clone iconSize="md-medium" />,
+    onClick: () => {
+      navigator.clipboard
+        .writeText(url)
+        .then(() => toast.success("Portal URL copied to clipboard"))
+        .catch(() => toast.error("Failed to copy to clipboard"));
+    },
+    divider: true,
+  });
+
+  menuItems.push({
+    id: "delete-portal",
+    label: "Delete portal",
+    icon: <Trash iconSize="md-medium" />,
+    className: "text-error-11",
+    onClick: () => deletePortal(portal.id),
+  });
+
+  return <TableActionPopover items={menuItems}>{children}</TableActionPopover>;
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/portal/components/portal-branding.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/portal/components/portal-branding.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { Button, Input, SettingCard, SettingCardGroup } from "@unkey/ui";
+import { type ReactNode, useRef, useState } from "react";
+
+// Mirrors the portal_branding schema columns so this can be wired to trpc later.
+// logoUrl holds a data URL in the prototype; real impl uploads and stores a URL.
+export type PortalBrandingValue = {
+  logoUrl: string;
+  primaryColor: string;
+};
+
+const SWATCHES = ["#18181B", "#7C3AED", "#0D9488", "#D97706", "#DC2626"];
+const MAX_LOGO_BYTES = 1024 * 1024;
+
+export function PortalBranding({
+  value,
+  onChange,
+  preview,
+}: {
+  value: PortalBrandingValue;
+  onChange: (next: PortalBrandingValue) => void;
+  preview?: ReactNode;
+}) {
+  const fileRef = useRef<HTMLInputElement>(null);
+  const [dragging, setDragging] = useState(false);
+  const [logoError, setLogoError] = useState<string | null>(null);
+
+  const readLogo = (file: File | undefined) => {
+    if (!file) {
+      return;
+    }
+    if (!file.type.startsWith("image/")) {
+      setLogoError("That file isn't an image.");
+      return;
+    }
+    if (file.size > MAX_LOGO_BYTES) {
+      setLogoError("Logo must be 1 MB or less.");
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = () => {
+      setLogoError(null);
+      onChange({ ...value, logoUrl: String(reader.result) });
+    };
+    reader.readAsDataURL(file);
+  };
+
+  return (
+    <SettingCardGroup>
+      <SettingCard
+        title="Logo"
+        description="Square image, PNG or SVG, up to 1 MB. Shown in the portal header."
+        contentWidth="w-auto"
+      >
+        <div className="flex items-center justify-end gap-3">
+          {logoError && <span className="text-[12px] text-error-11">{logoError}</span>}
+          <button
+            type="button"
+            aria-label="Upload logo"
+            onClick={() => fileRef.current?.click()}
+            onDragOver={(e) => {
+              e.preventDefault();
+              setDragging(true);
+            }}
+            onDragLeave={() => setDragging(false)}
+            onDrop={(e) => {
+              e.preventDefault();
+              setDragging(false);
+              readLogo(e.dataTransfer.files[0]);
+            }}
+            className={cn(
+              "flex size-12 shrink-0 items-center justify-center overflow-hidden rounded-lg border border-dashed border-grayA-6 bg-gray-2 transition-colors hover:border-grayA-8",
+              dragging && "border-accent-12 bg-grayA-3",
+              value.logoUrl && "border-solid",
+            )}
+          >
+            {value.logoUrl ? (
+              <img src={value.logoUrl} alt="Portal logo" className="size-full object-contain" />
+            ) : (
+              <span className="text-[18px] leading-none text-gray-9">+</span>
+            )}
+          </button>
+          <div className="flex flex-col items-start gap-1">
+            <Button size="sm" onClick={() => fileRef.current?.click()}>
+              {value.logoUrl ? "Replace" : "Upload"}
+            </Button>
+            {value.logoUrl && (
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => {
+                  setLogoError(null);
+                  onChange({ ...value, logoUrl: "" });
+                }}
+              >
+                Remove
+              </Button>
+            )}
+          </div>
+          <input
+            ref={fileRef}
+            type="file"
+            accept="image/*"
+            className="hidden"
+            onChange={(e) => {
+              readLogo(e.target.files?.[0]);
+              e.target.value = "";
+            }}
+          />
+        </div>
+      </SettingCard>
+      <SettingCard
+        title="Brand color"
+        description="Used for buttons and links in the portal."
+        contentWidth="w-auto"
+      >
+        <div className="flex items-center justify-end gap-2">
+          <div className="flex items-center gap-1.5 pr-1">
+            {SWATCHES.map((hex) => (
+              <button
+                key={hex}
+                type="button"
+                aria-label={`Use ${hex}`}
+                onClick={() => onChange({ ...value, primaryColor: hex })}
+                className={cn(
+                  "size-5 rounded-full border border-grayA-6 transition-shadow",
+                  value.primaryColor.toUpperCase() === hex &&
+                    "ring-2 ring-accent-12 ring-offset-2 ring-offset-gray-1",
+                )}
+                style={{ backgroundColor: hex }}
+              />
+            ))}
+          </div>
+          <label
+            className="relative size-9 shrink-0 cursor-pointer overflow-hidden rounded-lg border border-gray-5"
+            style={{ backgroundColor: value.primaryColor }}
+          >
+            <span className="sr-only">Pick brand color</span>
+            <input
+              type="color"
+              value={value.primaryColor}
+              onChange={(e) => onChange({ ...value, primaryColor: e.target.value.toUpperCase() })}
+              className="absolute inset-0 cursor-pointer opacity-0"
+            />
+          </label>
+          <Input
+            className="w-[96px] font-mono uppercase"
+            value={value.primaryColor}
+            maxLength={7}
+            onChange={(e) => {
+              const raw = e.target.value.trim();
+              onChange({ ...value, primaryColor: raw.startsWith("#") ? raw : `#${raw}` });
+            }}
+          />
+        </div>
+      </SettingCard>
+      {preview && (
+        <SettingCard
+          title="Preview"
+          description="How the portal looks to your users with the branding above."
+          contentWidth="w-full lg:w-[420px]"
+        >
+          <div className="flex w-full justify-end">{preview}</div>
+        </SettingCard>
+      )}
+    </SettingCardGroup>
+  );
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/portal/components/portal-card.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/portal/components/portal-card.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { Dots } from "@unkey/icons";
+import { Button, InfoTooltip } from "@unkey/ui";
+import type { Route } from "next";
+import Link from "next/link";
+import { type Portal, portalUrl } from "../data/portals";
+import { PortalActions } from "./portal-actions";
+
+export function PortalCard({ portal, workspaceSlug }: { portal: Portal; workspaceSlug: string }) {
+  const url = portalUrl(portal.slug);
+  const href = `/${workspaceSlug}/portal/${portal.id}` as Route;
+
+  return (
+    <div className="relative p-5 flex flex-col border border-grayA-4 hover:border-grayA-7 rounded-2xl w-full h-full gap-5 group transition-all duration-300 [&_a]:z-10 [&_button]:z-10">
+      {/* Invisible base clickable layer — covers the whole card, opens config. */}
+      <Link
+        href={href}
+        className="absolute inset-0 z-0"
+        aria-label={`Configure ${portal.resourceName}`}
+      />
+
+      <div className="flex gap-4 items-center min-h-11">
+        <div className="flex flex-col w-full gap-2 py-[5px] min-w-0">
+          <div className="flex items-center gap-2 min-w-0">
+            <InfoTooltip
+              content={portal.resourceName}
+              asChild
+              position={{ align: "start", side: "top" }}
+            >
+              <Link
+                href={href}
+                className={cn(
+                  "font-medium text-sm leading-[14px] truncate hover:underline",
+                  portal.enabled ? "text-accent-12" : "text-gray-11",
+                )}
+              >
+                {portal.resourceName}
+              </Link>
+            </InfoTooltip>
+            {!portal.enabled && (
+              <span className="shrink-0 rounded-full bg-grayA-3 px-2 py-0.5 text-[10px] font-medium text-gray-11">
+                Disabled
+              </span>
+            )}
+          </div>
+
+          {portal.enabled ? (
+            <InfoTooltip content={url} asChild position={{ align: "start", side: "top" }}>
+              <a
+                href={`https://${url}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="relative font-medium text-xs leading-[12px] text-gray-11 truncate max-w-[180px] hover:text-accent-12 transition-colors hover:underline"
+              >
+                {url}
+              </a>
+            </InfoTooltip>
+          ) : (
+            <span className="font-medium text-xs leading-[12px] text-gray-10 truncate max-w-[180px]">
+              {url}
+            </span>
+          )}
+        </div>
+
+        <div className="relative">
+          <PortalActions portal={portal}>
+            <Button variant="ghost" size="icon" className="mb-auto shrink-0" title="Portal actions">
+              <Dots iconSize="sm-regular" />
+            </Button>
+          </PortalActions>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/portal/components/portal-preview.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/portal/components/portal-preview.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import type { PortalBrandingValue } from "./portal-branding";
+
+const HEX_RE = /^#[0-9a-fA-F]{6}$/;
+
+function contrastText(hex: string) {
+  const n = Number.parseInt(hex.slice(1), 16);
+  const luminance = 0.2126 * ((n >> 16) & 255) + 0.7152 * ((n >> 8) & 255) + 0.0722 * (n & 255);
+  return luminance > 160 ? "#18181B" : "#FFFFFF";
+}
+
+/**
+ * Static, deliberately-lo-fi mock of the end-user portal page so operators can
+ * see their logo + brand color in context before going live.
+ */
+export function PortalPreview({
+  name,
+  url,
+  branding,
+  className,
+}: {
+  name: string;
+  url: string;
+  branding: PortalBrandingValue;
+  className?: string;
+}) {
+  const color = HEX_RE.test(branding.primaryColor) ? branding.primaryColor : "#18181B";
+  const initial = (name.trim()[0] ?? "P").toUpperCase();
+
+  return (
+    <div
+      className={cn(
+        "w-full overflow-hidden rounded-xl border border-grayA-4 bg-gray-1 shadow-sm",
+        className,
+      )}
+    >
+      <div className="flex items-center gap-2 border-b border-grayA-3 bg-gray-2 px-3 py-2">
+        <div className="flex gap-1.5">
+          <span className="size-2 rounded-full bg-grayA-5" />
+          <span className="size-2 rounded-full bg-grayA-5" />
+          <span className="size-2 rounded-full bg-grayA-5" />
+        </div>
+        <div className="flex-1 truncate rounded-md border border-grayA-3 bg-gray-1 px-2 py-0.5 text-center text-[10px] text-gray-9">
+          {url}
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between border-b border-grayA-3 px-4 py-3">
+        <div className="flex min-w-0 items-center gap-2.5">
+          {branding.logoUrl ? (
+            <img
+              src={branding.logoUrl}
+              alt=""
+              className="size-6 shrink-0 rounded-md object-contain"
+            />
+          ) : (
+            <span
+              className="flex size-6 shrink-0 items-center justify-center rounded-md text-[12px] font-semibold"
+              style={{ backgroundColor: color, color: contrastText(color) }}
+            >
+              {initial}
+            </span>
+          )}
+          <span className="truncate text-[13px] font-medium text-accent-12">{name}</span>
+        </div>
+        <span className="size-5 shrink-0 rounded-full bg-grayA-4" />
+      </div>
+
+      <div className="flex flex-col gap-3 px-4 py-4">
+        <div className="h-3 w-24 rounded bg-grayA-5" />
+        <div className="h-2 w-44 max-w-full rounded bg-grayA-3" />
+        <div className="rounded-lg border border-grayA-3">
+          {[0, 1].map((row) => (
+            <div
+              key={row}
+              className={cn(
+                "flex items-center justify-between px-3 py-3",
+                row > 0 && "border-t border-grayA-3",
+              )}
+            >
+              <div className="flex flex-col gap-1.5">
+                <div className="h-2 w-20 rounded bg-grayA-5" />
+                <div className="h-1.5 w-32 rounded bg-grayA-3" />
+              </div>
+              <div className="h-2 w-10 rounded bg-grayA-3" />
+            </div>
+          ))}
+        </div>
+        <div className="flex items-center justify-between pt-1">
+          <span
+            className="rounded-md px-3 py-1.5 text-[11px] font-medium"
+            style={{ backgroundColor: color, color: contrastText(color) }}
+          >
+            Create key
+          </span>
+          <span className="h-2 w-16 rounded" style={{ backgroundColor: `${color}33` }} />
+        </div>
+      </div>
+
+      <div className="border-t border-grayA-3 px-4 py-2 text-center text-[10px] text-gray-8">
+        Powered by Unkey
+      </div>
+    </div>
+  );
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/portal/components/portal-settings.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/portal/components/portal-settings.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { Switch } from "@/components/ui/switch";
+import { slugify } from "@/lib/slugify";
+import { cn } from "@/lib/utils";
+import { Button, CopyButton, SettingCard, SettingCardGroup } from "@unkey/ui";
+import { useState } from "react";
+import { IntegrateDialog } from "./integrate-dialog";
+import { PortalBranding, type PortalBrandingValue } from "./portal-branding";
+import { PortalPreview } from "./portal-preview";
+
+/**
+ * Portal config that lives inside a project or keyspace: a prominent
+ * enable/disable header (auth-providers style) that gates the settings below,
+ * plus branding controls with a live preview card.
+ * Local state only — prototype; wire to portal_configurations/portal_branding later.
+ */
+export function PortalSettings({
+  resourceName,
+  portalId,
+  defaultEnabled = false,
+}: {
+  resourceName: string;
+  portalId: string;
+  defaultEnabled?: boolean;
+}) {
+  const [enabled, setEnabled] = useState(defaultEnabled);
+  const [integrateOpen, setIntegrateOpen] = useState(false);
+  const [branding, setBranding] = useState<PortalBrandingValue>({
+    logoUrl: "",
+    primaryColor: "#18181B",
+  });
+  const url = `${slugify(resourceName)}.unkey.com/portal`;
+
+  return (
+    <div className="flex w-full flex-col gap-6">
+      <div className="flex items-center gap-4 rounded-2xl border border-grayA-4 p-5">
+        <div className="flex-1">
+          <div className="text-sm font-medium text-accent-12">Customer portal</div>
+          <p className="mt-1 text-[13px] leading-5 text-gray-11">
+            Give your end users a branded page to manage their API keys. When enabled, you can
+            create sessions and redirect users to it.
+          </p>
+        </div>
+        <Switch checked={enabled} onCheckedChange={setEnabled} />
+      </div>
+
+      <div
+        className={cn(
+          "flex flex-col gap-6 transition-opacity duration-200",
+          !enabled && "pointer-events-none select-none opacity-50",
+        )}
+        aria-hidden={!enabled}
+      >
+        <SettingCardGroup>
+          <SettingCard
+            title="Portal URL"
+            description="Served on your Unkey subdomain. Custom domains come later."
+            contentWidth="w-full lg:w-[420px]"
+          >
+            <div className="flex w-full items-center justify-end gap-2">
+              <div className="flex-1 truncate rounded-lg border border-grayA-4 px-3 py-2 text-[13px] text-gray-11 lg:w-[300px] lg:flex-none">
+                {url}
+              </div>
+              <CopyButton value={url} />
+            </div>
+          </SettingCard>
+          <SettingCard
+            title="Integration"
+            description="Create a session for a signed-in user, then redirect them here."
+            contentWidth="w-auto"
+          >
+            <Button onClick={() => setIntegrateOpen(true)}>How to integrate</Button>
+          </SettingCard>
+        </SettingCardGroup>
+
+        <PortalBranding
+          value={branding}
+          onChange={setBranding}
+          preview={<PortalPreview name={resourceName} url={url} branding={branding} />}
+        />
+      </div>
+
+      <IntegrateDialog portalId={portalId} isOpen={integrateOpen} onOpenChange={setIntegrateOpen} />
+    </div>
+  );
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/portal/data/portals.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/portal/data/portals.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { slugify } from "@/lib/slugify";
+import { useSyncExternalStore } from "react";
+
+export type PortalResourceType = "app" | "keyspace";
+
+export type Portal = {
+  id: string;
+  slug: string;
+  resourceType: PortalResourceType;
+  resourceName: string;
+  enabled: boolean;
+};
+
+// Resources a portal can connect to. Prototype fixtures — swap for
+// trpc queries (deploy apps / keyspaces) when the data layer lands.
+export const MOCK_APPS = [
+  { id: "app_billing", name: "billing-api" },
+  { id: "app_payments", name: "payments-api" },
+  { id: "app_search", name: "search-api" },
+];
+
+export const MOCK_KEYSPACES = [
+  { id: "ks_docs", name: "docs-keys" },
+  { id: "ks_partner", name: "partner-api" },
+];
+
+// Module-level store rather than React context: the top-nav breadcrumb renders
+// above the portal layout, so it needs to read portals without a provider in
+// scope. Swap this whole file for trpc hooks when the backend lands.
+let portals: Portal[] = [
+  {
+    id: "portal_billing",
+    slug: "billing-api",
+    resourceType: "app",
+    resourceName: "billing-api",
+    enabled: true,
+  },
+  {
+    id: "portal_docs",
+    slug: "docs-keys",
+    resourceType: "keyspace",
+    resourceName: "docs-keys",
+    enabled: false,
+  },
+];
+
+const listeners = new Set<() => void>();
+
+function emit() {
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+function subscribe(listener: () => void) {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function getSnapshot() {
+  return portals;
+}
+
+export function portalUrl(slug: string): string {
+  return `${slug}.unkey.com/portal`;
+}
+
+// Monotonic id source for created portals — avoids Math.random and stays
+// stable across renders in the prototype.
+let createdCount = 0;
+
+export function createPortal(input: {
+  resourceType: PortalResourceType;
+  resourceName: string;
+}): string {
+  createdCount += 1;
+  const id = `portal_new_${createdCount}`;
+  portals = [
+    {
+      id,
+      slug: slugify(input.resourceName),
+      resourceType: input.resourceType,
+      resourceName: input.resourceName,
+      enabled: true,
+    },
+    ...portals,
+  ];
+  emit();
+  return id;
+}
+
+export function setPortalEnabled(id: string, enabled: boolean) {
+  portals = portals.map((p) => (p.id === id ? { ...p, enabled } : p));
+  emit();
+}
+
+export function deletePortal(id: string) {
+  portals = portals.filter((p) => p.id !== id);
+  emit();
+}
+
+export function usePortals(): Portal[] {
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
+export function usePortal(id: string): Portal | null {
+  return usePortals().find((p) => p.id === id) ?? null;
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/portal/debug/debug-panel.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/portal/debug/debug-panel.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { type ReactNode, createContext, useContext, useMemo, useState } from "react";
+
+type DebugControl = { key: string; label: string; options: string[] };
+
+// Register debug state switches here. Each renders as a segmented control in
+// the fixed panel and is readable from any portal page via useDebug().
+// Intentionally not dev-gated so states can be reviewed in any environment.
+export const DEBUG_CONTROLS: DebugControl[] = [
+  { key: "listView", label: "Portal list", options: ["filled", "empty"] },
+];
+
+type DebugContextValue = {
+  values: Record<string, string>;
+  set: (key: string, value: string) => void;
+};
+
+const DebugContext = createContext<DebugContextValue | null>(null);
+
+export function DebugProvider({ children }: { children: ReactNode }) {
+  const [values, setValues] = useState<Record<string, string>>(() =>
+    Object.fromEntries(DEBUG_CONTROLS.map((control) => [control.key, control.options[0]])),
+  );
+
+  const value = useMemo<DebugContextValue>(
+    () => ({
+      values,
+      set: (key, next) => setValues((prev) => ({ ...prev, [key]: next })),
+    }),
+    [values],
+  );
+
+  return <DebugContext.Provider value={value}>{children}</DebugContext.Provider>;
+}
+
+export function useDebug(): DebugContextValue {
+  const ctx = useContext(DebugContext);
+  if (!ctx) {
+    throw new Error("useDebug must be used within a DebugProvider");
+  }
+  return ctx;
+}
+
+export function DebugPanel() {
+  const { values, set } = useDebug();
+  const [open, setOpen] = useState(true);
+
+  return (
+    <div className="fixed bottom-4 right-4 z-50 flex flex-col gap-2 rounded-xl border border-dashed border-grayA-6 bg-gray-1 p-3 shadow-lg">
+      <div className="flex items-center justify-between gap-4">
+        <span className="text-[11px] uppercase tracking-wide text-gray-9">Debug</span>
+        <button
+          type="button"
+          onClick={() => setOpen((prev) => !prev)}
+          className="text-[11px] text-gray-10 hover:text-gray-12"
+        >
+          {open ? "hide" : "show"}
+        </button>
+      </div>
+      {open &&
+        DEBUG_CONTROLS.map((control) => (
+          <div key={control.key} className="flex items-center gap-2">
+            <span className="w-20 text-[11px] text-gray-10">{control.label}</span>
+            <div className="flex items-center gap-1 rounded-lg border border-grayA-4 bg-grayA-2 p-0.5">
+              {control.options.map((option) => (
+                <button
+                  key={option}
+                  type="button"
+                  onClick={() => set(control.key, option)}
+                  className={cn(
+                    "rounded-md px-2 py-0.5 text-[12px] capitalize transition-colors",
+                    values[control.key] === option
+                      ? "bg-white text-gray-12 shadow-sm dark:bg-black"
+                      : "text-gray-10 hover:text-gray-12",
+                  )}
+                >
+                  {option}
+                </button>
+              ))}
+            </div>
+          </div>
+        ))}
+    </div>
+  );
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/portal/layout.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/portal/layout.tsx
@@ -1,0 +1,11 @@
+import type { ReactNode } from "react";
+import { DebugPanel, DebugProvider } from "./debug/debug-panel";
+
+export default function PortalLayout({ children }: { children: ReactNode }) {
+  return (
+    <DebugProvider>
+      {children}
+      <DebugPanel />
+    </DebugProvider>
+  );
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/portal/page.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/portal/page.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useWorkspaceNavigation } from "@/hooks/use-workspace-navigation";
+import { BookBookmark } from "@unkey/icons";
+import {
+  Button,
+  Empty,
+  PageBody,
+  PageContainer,
+  PageHeader,
+  PageHeaderActions,
+  PageHeaderContent,
+  PageHeaderTitle,
+} from "@unkey/ui";
+import { CreatePortalButton } from "./components/create-portal-button";
+import { PortalCard } from "./components/portal-card";
+import { usePortals } from "./data/portals";
+import { useDebug } from "./debug/debug-panel";
+
+export default function PortalPage() {
+  const workspace = useWorkspaceNavigation();
+  const portals = usePortals();
+  const { values } = useDebug();
+  const showEmpty = values.listView === "empty";
+
+  return (
+    <PageContainer>
+      <PageHeader>
+        <PageHeaderContent>
+          <PageHeaderTitle>Customer portal</PageHeaderTitle>
+        </PageHeaderContent>
+        {!showEmpty && (
+          <PageHeaderActions>
+            <CreatePortalButton />
+          </PageHeaderActions>
+        )}
+      </PageHeader>
+      <PageBody>
+        {showEmpty ? (
+          <div className="h-full min-h-[300px] flex items-center justify-center">
+            <Empty>
+              <Empty.Icon />
+              <Empty.Title>Enable Customer Portal for your end users</Empty.Title>
+              <Empty.Description>
+                Give your customers a branded page to manage their API keys, view usage, and read
+                your docs. No code on their side.
+              </Empty.Description>
+              <Empty.Actions className="mt-4">
+                <CreatePortalButton size="md" />
+                <a href="https://www.unkey.com/docs" target="_blank" rel="noopener noreferrer">
+                  <Button size="md">
+                    <BookBookmark />
+                    Documentation
+                  </Button>
+                </a>
+              </Empty.Actions>
+            </Empty>
+          </div>
+        ) : (
+          <div className="grid gap-4 grid-cols-1 md:grid-cols-2 xl:grid-cols-3">
+            {portals.map((portal) => (
+              <PortalCard key={portal.id} portal={portal} workspaceSlug={workspace.slug} />
+            ))}
+          </div>
+        )}
+      </PageBody>
+    </PageContainer>
+  );
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(project)/portal/page.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/(project)/portal/page.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { PortalSettings } from "@/app/(app)/[workspaceSlug]/portal/components/portal-settings";
+import { useProjectData } from "@/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/data-provider";
+import { PageBody, PageContainer, PageHeader, PageHeaderContent, PageHeaderTitle } from "@unkey/ui";
+
+export default function ProjectPortalPage() {
+  const { projectId, project } = useProjectData();
+  const name = project?.name ?? "your-project";
+
+  return (
+    <PageContainer>
+      <PageHeader>
+        <PageHeaderContent>
+          <PageHeaderTitle>Customer portal</PageHeaderTitle>
+        </PageHeaderContent>
+      </PageHeader>
+      <PageBody>
+        <PortalSettings resourceName={name} portalId={`portal_${projectId}`} />
+      </PageBody>
+    </PageContainer>
+  );
+}

--- a/web/apps/dashboard/components/navigation/top-nav/index.tsx
+++ b/web/apps/dashboard/components/navigation/top-nav/index.tsx
@@ -15,6 +15,7 @@ import { TopNavFeedbackButton } from "./feedback-button";
 import { HelpButton } from "./help-button";
 import { IdentityCrumb } from "./identity-crumb";
 import { NamespaceCrumb } from "./namespace-crumb";
+import { PortalCrumb } from "./portal-crumb";
 import { ProjectCrumb } from "./project-crumb";
 import { UserButton } from "./user-button";
 import { WorkspaceCrumb } from "./workspace-crumb";
@@ -78,6 +79,8 @@ function CrumbForDescriptor({ descriptor }: { descriptor: BreadcrumbDescriptor }
       return <NamespaceCrumb namespaceId={descriptor.namespaceId} />;
     case "identity":
       return <IdentityCrumb identityId={descriptor.identityId} />;
+    case "portal":
+      return <PortalCrumb portalId={descriptor.portalId} />;
   }
 }
 
@@ -95,5 +98,7 @@ function crumbKey(descriptor: BreadcrumbDescriptor): string {
       return `namespace:${descriptor.namespaceId}`;
     case "identity":
       return `identity:${descriptor.identityId}`;
+    case "portal":
+      return `portal:${descriptor.portalId}`;
   }
 }

--- a/web/apps/dashboard/components/navigation/top-nav/portal-crumb.tsx
+++ b/web/apps/dashboard/components/navigation/top-nav/portal-crumb.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { usePortal, usePortals } from "@/app/(app)/[workspaceSlug]/portal/data/portals";
+import { useWorkspaceNavigation } from "@/hooks/use-workspace-navigation";
+import { Plus, WindowLayout } from "@unkey/icons";
+import { Crumb } from "./crumb";
+import type { CrumbPopoverItem } from "./crumb-popover";
+
+export function PortalCrumb({ portalId }: { portalId: string }) {
+  const workspace = useWorkspaceNavigation();
+  const portals = usePortals();
+  const portal = usePortal(portalId);
+  const label = portal?.resourceName ?? portalId;
+
+  const items: CrumbPopoverItem[] = portals.map((p) => ({
+    id: p.id,
+    label: p.resourceName,
+    href: `/${workspace.slug}/portal/${p.id}`,
+  }));
+
+  return (
+    <Crumb
+      icon={<WindowLayout className="size-3.5 text-accent-11" iconSize="sm-regular" />}
+      label={label}
+      href={`/${workspace.slug}/portal/${portalId}`}
+      items={items}
+      currentId={portalId}
+      searchPlaceholder="Find portal..."
+      emptyText="No portals found"
+      footer={{
+        icon: Plus,
+        label: "All portals",
+        href: `/${workspace.slug}/portal`,
+      }}
+    />
+  );
+}

--- a/web/apps/dashboard/hooks/use-breadcrumbs.ts
+++ b/web/apps/dashboard/hooks/use-breadcrumbs.ts
@@ -10,7 +10,8 @@ export type BreadcrumbDescriptor =
   | { type: "app"; projectId: string; appId: string }
   | { type: "api"; apiId: string }
   | { type: "namespace"; namespaceId: string }
-  | { type: "identity"; identityId: string };
+  | { type: "identity"; identityId: string }
+  | { type: "portal"; portalId: string };
 
 type RouteParams = {
   projectId?: string;
@@ -18,6 +19,7 @@ type RouteParams = {
   apiId?: string;
   namespaceId?: string;
   identityId?: string;
+  portalId?: string;
 };
 
 export function useBreadcrumbs(): BreadcrumbDescriptor[] {
@@ -41,6 +43,9 @@ export function useBreadcrumbs(): BreadcrumbDescriptor[] {
   if (params.identityId) {
     crumbs.push({ type: "identity", identityId: params.identityId });
   }
+  if (params.portalId) {
+    crumbs.push({ type: "portal", portalId: params.portalId });
+  }
   return crumbs;
 }
 
@@ -56,6 +61,9 @@ function resolveWorkspaceHref(slug: string, params: RouteParams): string {
   }
   if (params.identityId) {
     return `/${slug}/identities`;
+  }
+  if (params.portalId) {
+    return `/${slug}/portal`;
   }
   return `/${slug}`;
 }

--- a/web/apps/dashboard/lib/navigation/leaves.ts
+++ b/web/apps/dashboard/lib/navigation/leaves.ts
@@ -12,6 +12,7 @@ import {
   Nodes,
   ShieldKey,
   SquareBulletList,
+  WindowLayout,
 } from "@unkey/icons";
 import { routes } from "./routes";
 import type { ResolvedNavLink } from "./types";
@@ -69,6 +70,13 @@ export function buildWorkspaceSections(slug: string, segments: string[]): Resolv
       isActive: top === "audit",
     },
     {
+      key: "portal",
+      label: "Customer portal",
+      href: `/${slug}/portal`,
+      icon: WindowLayout,
+      isActive: top === "portal",
+    },
+    {
       key: "settings",
       label: "Settings",
       href: routes.settings.general({ workspaceSlug: slug }),
@@ -106,6 +114,13 @@ export function buildProjectLinks(
       href: routes.projects.requests(scope),
       icon: ArrowOppositeDirectionY,
       isActive: page === "requests",
+    },
+    {
+      key: "portal",
+      label: "Customer portal",
+      href: `/${slug}/projects/${projectId}/portal`,
+      icon: WindowLayout,
+      isActive: page === "portal",
     },
     {
       key: "settings",
@@ -216,6 +231,13 @@ export function buildApiLinks(
       icon: Key,
       isActive: page === "keys",
       disabled: !keyAuthId,
+    },
+    {
+      key: "portal",
+      label: "Customer portal",
+      href: `/${slug}/apis/${apiId}/portal`,
+      icon: WindowLayout,
+      isActive: page === "portal",
     },
     {
       key: "settings",

--- a/web/apps/dashboard/lib/navigation/leaves.ts
+++ b/web/apps/dashboard/lib/navigation/leaves.ts
@@ -69,13 +69,18 @@ export function buildWorkspaceSections(slug: string, segments: string[]): Resolv
       icon: InputSearch,
       isActive: top === "audit",
     },
-    {
-      key: "portal",
-      label: "Customer portal",
-      href: `/${slug}/portal`,
-      icon: WindowLayout,
-      isActive: top === "portal",
-    },
+    // HUMANS: the workspace-level Customer portal nav item is intentionally
+    // hidden while the prototype is under review — nav placement is still an
+    // open question with Meg (workspace level vs project/keyspace only). The
+    // route stays reachable at /[workspaceSlug]/portal for direct-URL review.
+    // Restore this entry (or delete the route) once placement is decided.
+    // {
+    //   key: "portal",
+    //   label: "Customer portal",
+    //   href: `/${slug}/portal`,
+    //   icon: WindowLayout,
+    //   isActive: top === "portal",
+    // },
     {
       key: "settings",
       label: "Settings",

--- a/web/internal/icons/src/icons/window-layout.tsx
+++ b/web/internal/icons/src/icons/window-layout.tsx
@@ -1,0 +1,42 @@
+/**
+ * Copyright © Nucleo
+ * Version 1.3, January 3, 2024
+ * Nucleo Icons
+ * https://nucleoapp.com/
+ * - Redistribution of icons is prohibited.
+ * - Icons are restricted for use only within the product they are bundled with.
+ *
+ * For more details:
+ * https://nucleoapp.com/license
+ */
+
+import { type IconProps, sizeMap } from "../props";
+
+export function WindowLayout({ iconSize = "md-regular", ...props }: IconProps) {
+  const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
+  return (
+    <svg
+      height={pixelSize}
+      width={pixelSize}
+      {...props}
+      viewBox="0 0 18 18"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round">
+        <line x1="6.25" y1="7.75" x2="6.25" y2="15.25" strokeWidth={strokeWidth} />
+        <line x1="1.75" y1="7.75" x2="16.25" y2="7.75" strokeWidth={strokeWidth} />
+        <rect
+          x="1.75"
+          y="2.75"
+          width="14.5"
+          height="12.5"
+          rx="2"
+          ry="2"
+          strokeWidth={strokeWidth}
+        />
+        <circle cx="4.25" cy="5.25" r=".75" fill="currentColor" stroke="none" />
+        <circle cx="6.75" cy="5.25" r=".75" fill="currentColor" stroke="none" />
+      </g>
+    </svg>
+  );
+}

--- a/web/internal/icons/src/index.ts
+++ b/web/internal/icons/src/index.ts
@@ -169,4 +169,5 @@ export * from "./icons/unlink";
 export * from "./icons/user-search";
 export * from "./icons/user";
 export * from "./icons/user-plus";
+export * from "./icons/window-layout";
 export * from "./icons/xmark";


### PR DESCRIPTION
## What does this PR do?

**THIS IS A PROTOTYPE DO NOT MERGE**

Adds a mock-data prototype of the Customer Portal configuration UI so we can review the design in the real dashboard before wiring it up. Workspace level gets a portal list with a create dialog; projects and API keyspaces get an embedded settings page with an enable/disable header that gates the settings below: portal URL with copy, an integration guide dialog (createSession + redirect snippets), and branding — logo upload and brand color with a live preview card showing how the end-user portal will look. Also adds the "Customer portal" nav leaf on all three levels, breadcrumb support, and a WindowLayout icon.

Everything runs on local state and mock data (no trpc, no persistence) — the branding value is shaped to the `portal_branding` schema so it can be wired up later. A floating debug panel on the portal pages switches list states for review; it's prototype scaffolding, not intended to ship.

https://linear.app/unkey/issue/ENG-2586

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Visit `/{workspaceSlug}/portal` — portal list renders; use the debug panel (bottom right) to flip between filled and empty states; create/delete portals via the dialogs.
- Visit a project's or API's "Customer portal" page — toggle the portal on, copy the URL, open "How to integrate", upload a logo (click or drag onto the well) and change the brand color; the preview card should update live, including button text contrast on light colors.
- Not tested: mobile layouts beyond basic responsive stacking, and non-image/oversized file rejection only checks type and 1 MB size client-side.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR

_Screenshots to be added — light, dark, mobile._

🤖 Generated with [Claude Code](https://claude.com/claude-code)