### PR TITLE
Handle Vitess transaction timeouts in database operations

### DIFF
--- a/internal/services/ratelimit/global.go
+++ b/internal/services/ratelimit/global.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/unkeyed/unkey/pkg/logger"
+	"github.com/unkeyed/unkey/pkg/mysql"
 	"github.com/unkeyed/unkey/pkg/repeat"
 
 	"github.com/unkeyed/unkey/internal/services/ratelimit/db"
@@ -149,7 +150,9 @@ func (s *service) runGlobalPushOnce() {
 		chunkEntries := pushedEntries[start:end]
 
 		_, err := s.globalCircuitBreaker.Do(ctx, func(ctx context.Context) (any, error) {
-			return nil, s.db.BulkUpsertGlobalCounters(ctx, chunkRows)
+			return mysql.WithRetryContext(ctx, func() (any, error) {
+				return nil, s.db.BulkUpsertGlobalCounters(ctx, chunkRows)
+			})
 		})
 		if err != nil {
 			metrics.RatelimitGlobalPushErrors.Inc()
@@ -196,9 +199,11 @@ func (s *service) runGlobalPullOnce() {
 
 	nowMs := s.clock.Now().UnixMilli()
 
-	rows, err := s.db.RO().GlobalCountersImported(ctx, db.GlobalCountersImportedParams{
-		Now:        uint64(nowMs),
-		SelfRegion: s.region,
+	rows, err := mysql.WithRetryContext(ctx, func() ([]db.GlobalCountersImportedRow, error) {
+		return s.db.RO().GlobalCountersImported(ctx, db.GlobalCountersImportedParams{
+			Now:        uint64(nowMs),
+			SelfRegion: s.region,
+		})
 	})
 	if err != nil {
 		metrics.RatelimitGlobalPullErrors.Inc()

--- a/pkg/db/handle_err_deadlock.go
+++ b/pkg/db/handle_err_deadlock.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/go-sql-driver/mysql"
+	mysqlpkg "github.com/unkeyed/unkey/pkg/mysql"
 )
 
 // MySQL server error codes
@@ -99,13 +100,17 @@ func IsConnectionError(err error) bool {
 	return false
 }
 
+// IsTransactionTimeoutError returns true when Vitess/PlanetScale aborts a
+// transaction because it exceeded the configured timeout.
+func IsTransactionTimeoutError(err error) bool {
+	return mysqlpkg.IsTransactionTimeoutError(err)
+}
+
 // IsTransientError returns true if the error is a transient MySQL error that should be retried.
-// This includes deadlocks, lock wait timeouts, connection errors, and too many connections.
+// This includes deadlocks, lock wait timeouts, connection errors, too many connections,
+// and Vitess transaction timeouts.
 func IsTransientError(err error) bool {
-	return IsDeadlockError(err) ||
-		IsLockWaitTimeoutError(err) ||
-		IsConnectionError(err) ||
-		IsTooManyConnectionsError(err)
+	return mysqlpkg.IsTransientError(err)
 }
 
 // isMySQLError checks if the error is a MySQL error with the given error number.

--- a/pkg/db/retry.go
+++ b/pkg/db/retry.go
@@ -66,6 +66,7 @@ func backoffStrategy(n int) time.Duration {
 //   - Lock wait timeouts (MySQL error 1205)
 //   - Connection errors (MySQL errors 2006, 2013, network errors)
 //   - Too many connections (MySQL error 1040)
+//   - Vitess transaction timeouts (MySQL error 1105 with "exceeded timeout")
 //
 // Returns false for permanent errors that won't succeed on retry:
 //   - Not found errors

--- a/pkg/db/retry_test.go
+++ b/pkg/db/retry_test.go
@@ -77,6 +77,27 @@ func TestWithRetryContext_SkipsRetryOnDuplicateKey(t *testing.T) {
 	require.Equal(t, 1, callCount, "should not retry on duplicate key error")
 }
 
+func TestWithRetryContext_RetriesVitessTransactionTimeout(t *testing.T) {
+	ctx := context.Background()
+	callCount := 0
+	vitessTimeoutErr := &mysql.MySQLError{
+		Number:  1105,
+		Message: "vttablet: rpc error: code = Aborted desc = transaction 1: ended (exceeded timeout: 20s)",
+	}
+
+	result, err := WithRetryContext(ctx, func() (string, error) {
+		callCount++
+		if callCount < 3 {
+			return "", vitessTimeoutErr
+		}
+		return "success", nil
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "success", result)
+	require.Equal(t, 3, callCount, "should retry twice then succeed")
+}
+
 func TestWithRetryContext_ExhaustsRetries(t *testing.T) {
 	ctx := context.Background()
 	callCount := 0

--- a/pkg/mysql/BUILD.bazel
+++ b/pkg/mysql/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "mysql",
@@ -26,5 +26,15 @@ go_library(
         "//pkg/retry",
         "@com_github_go_sql_driver_mysql//:mysql",
         "@io_opentelemetry_go_otel//attribute",
+    ],
+)
+
+go_test(
+    name = "mysql_test",
+    srcs = ["handle_err_deadlock_test.go"],
+    embed = [":mysql"],
+    deps = [
+        "@com_github_go_sql_driver_mysql//:mysql",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/mysql/doc.go
+++ b/pkg/mysql/doc.go
@@ -16,7 +16,8 @@
 // for single-attempt transactions, and [TxRetry] / [TxWithResultRetry] when the
 // operation is safe to retry on transient failures.
 //
-// Retry helpers only retry errors classified as transient by [IsTransientError].
+// Retry helpers only retry errors classified as transient by [IsTransientError],
+// including Vitess/PlanetScale transaction timeouts (MySQL 1105).
 // [IsNotFound] and [IsDuplicateKeyError] are treated as terminal and are not
 // retried.
 package mysql

--- a/pkg/mysql/handle_err_deadlock.go
+++ b/pkg/mysql/handle_err_deadlock.go
@@ -14,6 +14,9 @@ const (
 	errDeadlock           = 1213
 	errLockWaitTimeout    = 1205
 	errTooManyConnections = 1040
+	// errVitessUnknown is Vitess/PlanetScale's wrapper for tablet-side failures,
+	// including transaction timeouts (message contains "exceeded timeout").
+	errVitessUnknown = 1105
 )
 
 // MySQL client error codes (CR_* errors)
@@ -71,12 +74,36 @@ func IsConnectionError(err error) bool {
 	return false
 }
 
+// IsTransactionTimeoutError returns true when Vitess/PlanetScale aborts a
+// transaction because it exceeded the configured timeout (typically 20s).
+// The error surfaces as MySQL 1105 with a message like:
+// "rpc error: code = Aborted desc = transaction ... (exceeded timeout: 20s)".
+func IsTransactionTimeoutError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var mysqlErr *mysql.MySQLError
+	if errors.As(err, &mysqlErr) && mysqlErr.Number == errVitessUnknown {
+		return isVitessTransactionTimeoutMessage(mysqlErr.Message)
+	}
+
+	return isVitessTransactionTimeoutMessage(err.Error())
+}
+
+func isVitessTransactionTimeoutMessage(msg string) bool {
+	msg = strings.ToLower(msg)
+	return strings.Contains(msg, "exceeded timeout") &&
+		(strings.Contains(msg, "transaction") || strings.Contains(msg, "aborted"))
+}
+
 // IsTransientError returns true if the error is a transient MySQL error that should be retried.
 func IsTransientError(err error) bool {
 	return IsDeadlockError(err) ||
 		IsLockWaitTimeoutError(err) ||
 		IsConnectionError(err) ||
-		IsTooManyConnectionsError(err)
+		IsTooManyConnectionsError(err) ||
+		IsTransactionTimeoutError(err)
 }
 
 // isMySQLError checks if the error is a MySQL error with the given error number.

--- a/pkg/mysql/handle_err_deadlock_test.go
+++ b/pkg/mysql/handle_err_deadlock_test.go
@@ -1,0 +1,41 @@
+package mysql
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsTransactionTimeoutError(t *testing.T) {
+	t.Parallel()
+
+	vitessTimeout := &mysql.MySQLError{
+		Number:  1105,
+		Message: "target: unkey.-.primary: vttablet: rpc error: code = Aborted desc = transaction 1782950310686082683: ended at 2026-07-02 05:31:19.003 UTC (exceeded timeout: 20s)",
+	}
+
+	t.Run("vitess transaction timeout", func(t *testing.T) {
+		require.True(t, IsTransactionTimeoutError(vitessTimeout))
+		require.True(t, IsTransientError(vitessTimeout))
+	})
+
+	t.Run("wrapped vitess transaction timeout", func(t *testing.T) {
+		wrapped := fmt.Errorf("database failed to update ratelimit: %w", vitessTimeout)
+		require.True(t, IsTransactionTimeoutError(wrapped))
+		require.True(t, IsTransientError(wrapped))
+	})
+
+	t.Run("other vitess 1105 error", func(t *testing.T) {
+		other := &mysql.MySQLError{Number: 1105, Message: "syntax error near 'FROM'"}
+		require.False(t, IsTransactionTimeoutError(other))
+		require.False(t, IsTransientError(other))
+	})
+
+	t.Run("innodb lock wait timeout is not vitess timeout", func(t *testing.T) {
+		lockWait := &mysql.MySQLError{Number: 1205, Message: "Lock wait timeout exceeded"}
+		require.False(t, IsTransactionTimeoutError(lockWait))
+		require.True(t, IsTransientError(lockWait))
+	})
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Fixes ENG-2999.

Database operations were failing permanently when Vitess/PlanetScale transactions exceeded the 20s timeout. These errors surface as MySQL 1105 with messages like:

```
vttablet: rpc error: code = Aborted desc = transaction ... (exceeded timeout: 20s)
```

This change classifies those errors as transient so the existing retry helpers (`WithRetryContext`, `TxRetry`, `TxWithResultRetry`) automatically retry affected operations.

Changes:
- Add `IsTransactionTimeoutError` to `pkg/mysql` and include it in `IsTransientError`
- Delegate `pkg/db.IsTransientError` to `pkg/mysql` to avoid drift
- Wrap ratelimit cross-region push/pull (`internal/services/ratelimit/global.go`) with `mysql.WithRetryContext`, which previously bypassed retry logic

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- `mise exec -- bazel test //pkg/mysql:mysql_test --test_output=errors`
- `mise exec -- bazel test //pkg/db:db_test --test_filter='TestWithRetryContext_RetriesVitessTransactionTimeout|TestWithRetryContext_RetriesTransientErrors' --test_output=errors`

Integration tests requiring Docker were not run in the cloud agent environment.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [x] Ran `mise run fmt`
- [x] Checked for warnings, there are none

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-2999](https://linear.app/unkey/issue/ENG-2999/handle-vitess-timeouts-in-database-operations)

<div><a href="https://cursor.com/agents/bc-e29ce5b2-a397-4739-9146-a2d9f99c6c71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e29ce5b2-a397-4739-9146-a2d9f99c6c71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

