### PR TITLE
chore: persist pstack Cursor model configuration

### DIFF
--- a/.cursor/rules/pstack-models.mdc
+++ b/.cursor/rules/pstack-models.mdc
@@ -1,0 +1,20 @@
+---
+description: pstack per-role model choices (overrides skill defaults)
+alwaysApply: true
+---
+# pstack model configuration. One line per role. Delete a line to fall back to the skill default.
+feature, refactoring: composer-2.5-fast
+bug-fix: gpt-5.5-high-fast
+perf-issue: gpt-5.5-high-fast
+hillclimb: gpt-5.5-high-fast
+judgment and prose: claude-opus-4-8-thinking-xhigh
+how explorer: composer-2.5-fast
+how explainer: claude-opus-4-8-thinking-xhigh
+how critics: claude-opus-4-8-thinking-xhigh, gpt-5.5-high-fast, claude-fable-5-thinking-xhigh
+why investigators: composer-2.5-fast
+why synthesizer: claude-opus-4-8-thinking-xhigh
+reflect tooling: composer-2.5-fast
+reflect judgment, divergent, synthesizer: claude-opus-4-8-thinking-xhigh
+arena runners: claude-opus-4-8-thinking-xhigh, gpt-5.5-high-fast, claude-fable-5-thinking-xhigh
+architect runners: claude-opus-4-8-thinking-xhigh, gpt-5.5-high-fast, claude-fable-5-thinking-xhigh
+interrogate reviewers: claude-opus-4-8-thinking-xhigh, gpt-5.5-high-fast, claude-fable-5-thinking-xhigh

--- a/.mise/tasks/install-cursor-rules
+++ b/.mise/tasks/install-cursor-rules
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+#MISE description="Install repo .cursor/rules into ~/.cursor/rules"
+set -euo pipefail
+
+"$(git rev-parse --show-toplevel)/dev/install-cursor-rules.sh"

--- a/dev/install-cursor-rules.sh
+++ b/dev/install-cursor-rules.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Install repo Cursor rules into ~/.cursor/rules (idempotent).
+# Run after clone or on a fresh cloud agent VM: ./dev/install-cursor-rules.sh
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+src="${repo_root}/.cursor/rules"
+dest="${HOME}/.cursor/rules"
+
+if [ ! -d "$src" ]; then
+  echo "No .cursor/rules in repo at $src" >&2
+  exit 1
+fi
+
+mkdir -p "$dest"
+shopt -s nullglob
+files=("$src"/*)
+shopt -u nullglob
+
+if [ "${#files[@]}" -eq 0 ]; then
+  echo "No rule files in $src" >&2
+  exit 1
+fi
+
+for f in "${files[@]}"; do
+  name="$(basename "$f")"
+  cp "$f" "${dest}/${name}"
+  echo "Installed ${dest}/${name}"
+done
+
+echo "Cursor rules ready."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Persists `/setup-pstack` output in the repo so cloud agents and fresh clones do not need to reconfigure model roles.

## Changes

- **`.cursor/rules/pstack-models.mdc`** — pstack role → model map (Composer for code, GPT 5.5 for debug/perf, Opus for prose, Fable in multi-model panels)
- **`dev/install-cursor-rules.sh`** — copies repo rules to `~/.cursor/rules` (idempotent)
- **`mise run install-cursor-rules`** — mise wrapper for the script

## Usage

After clone or on a new VM:

```bash
./dev/install-cursor-rules.sh
# or
mise run install-cursor-rules
```

Active for this session already via `~/.cursor/rules/pstack-models.mdc`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c4f59bfc-6dfe-42b0-9d1a-3a3c7afada14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c4f59bfc-6dfe-42b0-9d1a-3a3c7afada14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

