### PR TITLE
fix(ctrl): no-op ChangeDesiredState when deployment row is missing (ENG-3004)

### DIFF
--- a/svc/ctrl/worker/deployment/BUILD.bazel
+++ b/svc/ctrl/worker/deployment/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "deployment",
@@ -14,5 +14,18 @@ go_library(
         "//gen/proto/hydra/v1:hydra",
         "//svc/ctrl/internal/db",
         "@com_github_restatedev_sdk_go//:sdk-go",
+    ],
+)
+
+go_test(
+    name = "deployment_test",
+    srcs = ["deployment_state_integration_test.go"],
+    deps = [
+        "//gen/proto/hydra/v1:hydra",
+        "//pkg/uid",
+        "//svc/ctrl/integration/harness",
+        "//svc/ctrl/integration/seed",
+        "//svc/ctrl/internal/db",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/svc/ctrl/worker/deployment/deployment_state.go
+++ b/svc/ctrl/worker/deployment/deployment_state.go
@@ -66,9 +66,11 @@ func (v *VirtualObject) ScheduleDesiredStateChange(ctx restate.ObjectContext, re
 // the database. It validates the request nonce against the stored transition:
 // if no transition exists (already applied and cleared) or the nonce mismatches
 // (a newer schedule has superseded this one), the call returns successfully
-// without making any changes. On match, it maps the protobuf state enum to the
-// database representation, updates the deployment's desired state and all
-// topology entries, and clears the stored transition.
+// without making any changes. If the deployment or app row no longer exists,
+// typically because an environment delete removed it while a delayed transition
+// was still pending, the call also no-ops. On match, it maps the protobuf state
+// enum to the database representation, updates the deployment's desired state
+// and all topology entries, and clears the stored transition.
 func (v *VirtualObject) ChangeDesiredState(ctx restate.ObjectContext, req *hydrav1.ChangeDesiredStateRequest) (*hydrav1.ChangeDesiredStateResponse, error) {
 	deploymentID := restate.Key(ctx)
 
@@ -101,19 +103,25 @@ func (v *VirtualObject) ChangeDesiredState(ctx restate.ObjectContext, req *hydra
 		return nil, restate.TerminalErrorf("unhandled state: %s", req.GetState())
 	}
 
-	err = restate.RunVoid(ctx, func(runCtx restate.RunContext) error {
-		return db.Tx(runCtx, v.db.RW(), func(txCtx context.Context, tx db.DBTX) error {
+	applied, err := restate.Run(ctx, func(runCtx restate.RunContext) (bool, error) {
+		return db.TxWithResult(runCtx, v.db.RW(), func(txCtx context.Context, tx db.DBTX) (bool, error) {
 			deployment, err := db.NewQueries(tx).FindDeploymentById(txCtx, deploymentID)
 			if err != nil {
-				return err
+				if db.IsNotFound(err) {
+					return false, nil
+				}
+				return false, err
 			}
 			app, err := db.NewQueries(tx).FindAppById(txCtx, deployment.AppID)
 			if err != nil {
-				return err
+				if db.IsNotFound(err) {
+					return false, nil
+				}
+				return false, err
 			}
 
 			if app.CurrentDeploymentID.Valid && app.CurrentDeploymentID.String == deploymentID {
-				return restate.TerminalErrorf("not allowed to modify the current deployment")
+				return false, restate.TerminalErrorf("not allowed to modify the current deployment")
 			}
 
 			err = db.NewQueries(tx).UpdateDeploymentDesiredState(txCtx, db.UpdateDeploymentDesiredStateParams{
@@ -122,14 +130,18 @@ func (v *VirtualObject) ChangeDesiredState(ctx restate.ObjectContext, req *hydra
 				UpdatedAt:    sql.NullInt64{Valid: true, Int64: time.Now().UnixMilli()},
 			})
 			if err != nil {
-				return err
+				return false, err
 			}
 
-			return nil
+			return true, nil
 		})
 	}, restate.WithName("updating desired state"))
 	if err != nil {
 		return nil, err
+	}
+	if !applied {
+		restate.Clear(ctx, transitionKey)
+		return &hydrav1.ChangeDesiredStateResponse{}, nil
 	}
 
 	// Update all topology entries and insert deployment_changes so WatchDeployments picks up the change.

--- a/svc/ctrl/worker/deployment/deployment_state_integration_test.go
+++ b/svc/ctrl/worker/deployment/deployment_state_integration_test.go
@@ -1,0 +1,79 @@
+package deployment_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
+	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/ctrl/integration/harness"
+	"github.com/unkeyed/unkey/svc/ctrl/integration/seed"
+	"github.com/unkeyed/unkey/svc/ctrl/internal/db"
+)
+
+// TestChangeDesiredState_NoOpsWhenDeploymentDeleted verifies that a delayed
+// ChangeDesiredState call succeeds when the deployment row was removed after
+// scheduling, for example by an environment delete cascade.
+func TestChangeDesiredState_NoOpsWhenDeploymentDeleted(t *testing.T) {
+	h := harness.New(t)
+
+	ws := h.Seed.CreateWorkspace(h.Ctx)
+	project := h.Seed.CreateProject(h.Ctx, seed.CreateProjectRequest{
+		ID:               uid.New(uid.ProjectPrefix),
+		WorkspaceID:      ws.ID,
+		Name:             "test-project",
+		Slug:             uid.New("slug"),
+		DeleteProtection: false,
+	})
+	app := h.Seed.CreateApp(h.Ctx, seed.CreateAppRequest{
+		ID:          uid.New(uid.AppPrefix),
+		WorkspaceID: ws.ID,
+		ProjectID:   project.ID,
+		Name:        "default",
+		Slug:        "default",
+	})
+	env := h.Seed.CreateEnvironment(h.Ctx, seed.CreateEnvironmentRequest{
+		ID:               uid.New(uid.EnvironmentPrefix),
+		WorkspaceID:      ws.ID,
+		ProjectID:        project.ID,
+		AppID:            app.ID,
+		Slug:             "preview",
+		Description:      "",
+		SentinelConfig:   nil,
+		DeleteProtection: false,
+	})
+	dep := h.Seed.CreateDeployment(h.Ctx, seed.CreateDeploymentRequest{
+		WorkspaceID:   ws.ID,
+		ProjectID:     project.ID,
+		AppID:         app.ID,
+		EnvironmentID: env.ID,
+		Status:        db.DeploymentsStatusReady,
+	})
+
+	client := hydrav1.NewDeploymentServiceIngressClient(h.Restate, dep.ID)
+	_, err := client.ScheduleDesiredStateChange().Request(h.Ctx, &hydrav1.ScheduleDesiredStateChangeRequest{
+		DelayMillis: 500,
+		State:       hydrav1.DeploymentDesiredState_DEPLOYMENT_DESIRED_STATE_STOPPED,
+		Overwrite:   true,
+	})
+	require.NoError(t, err)
+
+	_, err = h.DB.RW().ExecContext(h.Ctx, "DELETE FROM deployment_topology WHERE deployment_id = ?", dep.ID)
+	require.NoError(t, err)
+	_, err = h.DB.RW().ExecContext(h.Ctx, "DELETE FROM deployments WHERE id = ?", dep.ID)
+	require.NoError(t, err)
+
+	time.Sleep(time.Second)
+
+	_, err = h.DB.FindDeploymentById(h.Ctx, dep.ID)
+	require.Error(t, err)
+	require.True(t, db.IsNotFound(err))
+
+	_, err = client.ScheduleDesiredStateChange().Request(h.Ctx, &hydrav1.ScheduleDesiredStateChangeRequest{
+		DelayMillis: 0,
+		State:       hydrav1.DeploymentDesiredState_DEPLOYMENT_DESIRED_STATE_STOPPED,
+		Overwrite:   true,
+	})
+	require.NoError(t, err)
+}

--- a/svc/ctrl/worker/deployment/doc.go
+++ b/svc/ctrl/worker/deployment/doc.go
@@ -39,4 +39,8 @@
 // [VirtualObject.ClearScheduledStateChanges] removes the stored transition
 // entirely, which causes any in-flight delayed call to no-op because there is
 // no transition record left to match against.
+//
+// If the deployment row is deleted before a delayed [VirtualObject.ChangeDesiredState]
+// call fires, for example when an environment delete cascades deployment rows,
+// ChangeDesiredState also no-ops and clears any leftover transition state.
 package deployment


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes `sql: no rows in result set` errors in the `DeploymentService` virtual object's `ChangeDesiredState` handler.

**Root cause:** `ScheduleDesiredStateChange` enqueues delayed `ChangeDesiredState` calls that Restate cannot cancel. When an environment delete cascades deployment rows away (or the deployment is otherwise removed) before the delay elapses, `FindDeploymentById` / `FindAppById` return `sql.ErrNoRows` and the invocation fails.

**Fix:** Treat missing deployment/app rows as a successful no-op (same as stale nonce mismatch), clear any leftover transition state, and return success.

## Changes

- `svc/ctrl/worker/deployment/deployment_state.go`: handle `db.IsNotFound` in the desired-state update transaction; skip topology updates when the deployment is gone
- `svc/ctrl/worker/deployment/doc.go`: document the missing-row no-op path
- `svc/ctrl/worker/deployment/deployment_state_integration_test.go`: regression test scheduling a delayed stop, deleting the deployment row, and verifying the VO recovers

## Verification

- `mise exec -- bazel build //svc/ctrl/worker/deployment:deployment //svc/ctrl/worker/deployment:deployment_test`
- Integration test `//svc/ctrl/worker/deployment:deployment_test` requires Docker (not available in cloud agent VM); should pass in CI

Closes ENG-3004
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-3004](https://linear.app/unkey/issue/ENG-3004/investigate-no-rows-errors-in-desired-change-state-vo)

<div><a href="https://cursor.com/agents/bc-1476fc3d-884b-44eb-adf1-0b21911c497e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1476fc3d-884b-44eb-adf1-0b21911c497e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

