### PR TITLE
Replace memory metric separator

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/[deploymentId]/(overview)/components/metrics/metric-card.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/[deploymentId]/(overview)/components/metrics/metric-card.tsx
@@ -131,7 +131,7 @@ export function MetricCard({
           <span className="text-grayA-10 text-[11px]">{parts.unit}</span>
           {secondaryValue && (
             <>
-              <span className="text-grayA-9 text-[11px]">/</span>
+              <span className="text-grayA-9 text-[11px]">·</span>
               <span className="text-gray-12 font-medium text-[12px] tabular-nums">
                 {secondaryText}
               </span>


### PR DESCRIPTION


| Before | After |
|--------|--------|
| <img width="556" height="276" alt="image" src="https://github.com/user-attachments/assets/82dc757f-d6de-47a8-b391-84dd63aca4ed" /> | <img width="612" height="266" alt="CleanShot 2026-07-06 at 19 59 23@2x" src="https://github.com/user-attachments/assets/cbe4d800-20a6-4195-af58-1c32b9f1fe22" /> | 

## What does this PR do?

Updates the deployment memory metric header so the percentage and absolute memory value are separated by a dot instead of a slash. The branch name links this PR to the Linear issue.
