### PR TITLE
fix(dashboard): paginate deployments list and fix deployment detail 404

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/[deploymentId]/layout-provider.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/[deploymentId]/layout-provider.tsx
@@ -33,23 +33,49 @@ export const DeploymentLayoutProvider = ({
   }
 
   const { getDeploymentById, isDeploymentsLoading, projectId } = useProjectData();
-  const deployment = getDeploymentById(deploymentId);
+  const fromCollection = getDeploymentById(deploymentId);
+  const needsFetch = fromCollection === undefined;
 
-  const { data: fetchedDeployment, isLoading: isFetchingById } =
-    trpc.deploy.deployment.getById.useQuery({ deploymentId, projectId }, { enabled: !deployment });
+  const fetchByIdQuery = trpc.deploy.deployment.getById.useQuery(
+    { deploymentId, projectId },
+    { enabled: needsFetch },
+  );
 
-  const parsed = fetchedDeployment ? deploymentSchema.safeParse(fetchedDeployment) : undefined;
-  const resolved = deployment ?? (parsed?.success ? parsed.data : undefined);
+  const parsed = fetchByIdQuery.data ? deploymentSchema.safeParse(fetchByIdQuery.data) : undefined;
+  const resolved = fromCollection ?? (parsed?.success ? parsed.data : undefined);
+
   if (!resolved) {
-    if (isDeploymentsLoading || isFetchingById) {
+    const isWaitingForCollection = isDeploymentsLoading;
+    const isWaitingForFetch = needsFetch && !fetchByIdQuery.isFetched;
+
+    if (isWaitingForCollection || isWaitingForFetch) {
       return (
         <div className="flex flex-col" style={{ height: `calc(100dvh - ${TOP_NAV_HEIGHT}px)` }}>
           <LoadingState message="Loading deployment..." />
         </div>
       );
     }
-    notFound();
+
+    if (needsFetch) {
+      if (fetchByIdQuery.error?.data?.code === "NOT_FOUND") {
+        notFound();
+      }
+      if (fetchByIdQuery.isError) {
+        throw fetchByIdQuery.error;
+      }
+      if (fetchByIdQuery.data && !parsed?.success) {
+        throw new Error(`Invalid deployment payload for ${deploymentId}`);
+      }
+      notFound();
+    }
+
+    return (
+      <div className="flex flex-col" style={{ height: `calc(100dvh - ${TOP_NAV_HEIGHT}px)` }}>
+        <LoadingState message="Loading deployment..." />
+      </div>
+    );
   }
+
   return (
     <DeploymentLayoutContext.Provider value={{ deployment: resolved }}>
       {children}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/components/deployments-card-list.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/components/deployments-card-list.tsx
@@ -5,10 +5,11 @@ import { collection } from "@/lib/collections";
 import { routes } from "@/lib/navigation/routes";
 import { and, eq, useLiveQuery } from "@tanstack/react-db";
 import { BookBookmark } from "@unkey/icons";
-import { Button, Empty } from "@unkey/ui";
+import { Button, Empty, PaginationFooter } from "@unkey/ui";
 import type { ReactNode } from "react";
 import { useAppId, useProjectData } from "../../data-provider";
 import { useDeployments } from "../hooks/use-deployments";
+import { usePaginatedDeployments } from "../hooks/use-paginated-deployments";
 import { DeploymentRow } from "./deployment-row";
 import { DeploymentsSkeleton } from "./deployments-skeleton";
 
@@ -25,10 +26,27 @@ type DeploymentsCardListProps = {
   limit?: number;
   title?: string;
   headerAction?: ReactNode;
+  paginated?: boolean;
 };
 
-export function DeploymentsCardList({ limit, title, headerAction }: DeploymentsCardListProps = {}) {
-  const { deployments } = useDeployments();
+export function DeploymentsCardList({
+  limit,
+  title,
+  headerAction,
+  paginated = false,
+}: DeploymentsCardListProps = {}) {
+  const collectionResult = useDeployments({ enabled: !paginated });
+  const paginatedResult = usePaginatedDeployments({ enabled: paginated });
+  const { deployments, page, pageSize, totalPages, totalCount, onPageChange } = paginated
+    ? paginatedResult
+    : {
+        deployments: collectionResult.deployments,
+        page: 1,
+        pageSize: 0,
+        totalPages: 1,
+        totalCount: 0,
+        onPageChange: () => undefined,
+      };
   const { projectId } = useProjectData();
   const appId = useAppId();
   const appsQuery = useLiveQuery(
@@ -79,28 +97,42 @@ export function DeploymentsCardList({ limit, title, headerAction }: DeploymentsC
   }
 
   return (
-    <div className="border border-grayA-4 rounded-[14px] overflow-hidden">
-      {title && <ListHeader title={title} action={headerAction} />}
-      <div className="divide-y divide-grayA-4">
-        {data.map(({ deployment, environment }) => {
-          const isCurrent = currentDeploymentId === deployment.id;
-          return (
-            <DeploymentRow
-              key={deployment.id}
-              deployment={deployment}
-              environment={environment}
-              isCurrent={isCurrent}
-              isRolledBack={isCurrent && (app?.isRolledBack ?? false)}
-              href={routes.projects.apps.deployment({
-                workspaceSlug: workspace.slug,
-                projectId,
-                appId: deployment.appId,
-                deploymentId: deployment.id,
-              })}
-            />
-          );
-        })}
+    <>
+      <div className="border border-grayA-4 rounded-[14px] overflow-hidden">
+        {title && <ListHeader title={title} action={headerAction} />}
+        <div className="divide-y divide-grayA-4">
+          {data.map(({ deployment, environment }) => {
+            const isCurrent = currentDeploymentId === deployment.id;
+            return (
+              <DeploymentRow
+                key={deployment.id}
+                deployment={deployment}
+                environment={environment}
+                isCurrent={isCurrent}
+                isRolledBack={isCurrent && (app?.isRolledBack ?? false)}
+                href={routes.projects.apps.deployment({
+                  workspaceSlug: workspace.slug,
+                  projectId,
+                  appId: deployment.appId,
+                  deploymentId: deployment.id,
+                })}
+              />
+            );
+          })}
+        </div>
       </div>
-    </div>
+      {paginated && (
+        <PaginationFooter
+          page={page}
+          pageSize={pageSize}
+          totalPages={totalPages}
+          totalCount={totalCount}
+          onPageChange={onPageChange}
+          itemLabel="deployments"
+          loading={deployments.isLoading}
+          hide={totalPages <= 1}
+        />
+      )}
+    </>
   );
 }

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/components/deployments-card-list.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/components/deployments-card-list.tsx
@@ -98,7 +98,8 @@ export function DeploymentsCardList({
 
   return (
     <>
-      <div className="border border-grayA-4 rounded-[14px] overflow-hidden">
+      <div className={paginated ? "pb-28" : undefined}>
+        <div className="border border-grayA-4 rounded-[14px] overflow-hidden">
         {title && <ListHeader title={title} action={headerAction} />}
         <div className="divide-y divide-grayA-4">
           {data.map(({ deployment, environment }) => {
@@ -118,8 +119,9 @@ export function DeploymentsCardList({
                 })}
               />
             );
-          })}
+        })}
         </div>
+      </div>
       </div>
       {paginated && (
         <PaginationFooter

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/filters.schema.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/filters.schema.ts
@@ -121,6 +121,7 @@ export type DeploymentListQuerySearchParams = {
   startTime: number | null;
   endTime: number | null;
   since: string | null;
+  page: number;
 };
 
 export const parseAsAllOperatorsFilterArray = parseAsFilterValueArray<DeploymentListFilterOperator>(

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/hooks/use-deployments.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/hooks/use-deployments.ts
@@ -1,5 +1,5 @@
 import { collection } from "@/lib/collections";
-import { DEPLOYMENTS_DEFAULT_LIMIT } from "@/lib/collections/deploy/deployments";
+import { DEPLOYMENTS_DEFAULT_LIMIT, type Deployment } from "@/lib/collections/deploy/deployments";
 import type { Environment } from "@/lib/collections/deploy/environments";
 import { parseDuration } from "@/lib/duration";
 import { and, eq, gte, lte, useLiveQuery } from "@tanstack/react-db";
@@ -8,7 +8,7 @@ import { useProjectData } from "../../data-provider";
 import type { DeploymentListFilterField } from "../filters.schema";
 import { useFilters } from "./use-filters";
 
-export const useDeployments = () => {
+export const useDeployments = ({ enabled = true }: { enabled?: boolean } = {}) => {
   const { projectId, appId, environments } = useProjectData();
   const { filters } = useFilters();
 
@@ -52,10 +52,17 @@ export const useDeployments = () => {
         .orderBy(({ deployment }) => deployment.createdAt, "desc")
         .limit(DEPLOYMENTS_DEFAULT_LIMIT);
     },
-    [projectId, appId, startTime, endTime, sinceMs],
+    [projectId, appId, startTime, endTime, sinceMs, enabled],
   );
 
   const deployments = useMemo(() => {
+    if (!enabled) {
+      return {
+        isLoading: false,
+        data: [] as { deployment: Deployment; environment?: Environment }[],
+      };
+    }
+
     const withEnvironments = result.data.map((deployment) => ({
       deployment,
       environment: environmentMap.get(deployment.environmentId),
@@ -104,7 +111,7 @@ export const useDeployments = () => {
     });
 
     return { isLoading: result.isLoading, data: filtered };
-  }, [result, filters, environmentMap]);
+  }, [result, filters, environmentMap, enabled]);
 
   return {
     deployments,

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/hooks/use-filters.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/hooks/use-filters.ts
@@ -3,7 +3,7 @@ import {
   parseAsRelativeTime,
 } from "@/components/logs/validation/utils/nuqs-parsers";
 import { parseAsInteger, useQueryStates } from "nuqs";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import {
   type DeploymentListFilterField,
   type DeploymentListFilterOperator,
@@ -22,6 +22,7 @@ export const queryParamsPayload = {
   startTime: parseAsInteger,
   endTime: parseAsInteger,
   since: parseAsRelativeTime,
+  page: parseAsInteger.withDefault(1),
 } as const;
 
 const arrayFields = ["status", "environment", "branch"] as const;
@@ -76,6 +77,7 @@ export const useFilters = () => {
         ...arrayFields.map((field) => [field, null]),
         ...timeFields.map((field) => [field, null]),
       ]);
+      newParams.page = 1;
 
       const filterGroups = arrayFields.reduce(
         (acc, field) => {
@@ -128,10 +130,24 @@ export const useFilters = () => {
     [filters, updateFilters],
   );
 
+  const filterKey = useMemo(
+    () => filters.map((f) => `${f.field}:${f.operator}:${f.value}`).join("|"),
+    [filters],
+  );
+  const prevFilterKeyRef = useRef(filterKey);
+  useEffect(() => {
+    if (prevFilterKeyRef.current !== filterKey) {
+      prevFilterKeyRef.current = filterKey;
+      setSearchParams({ page: 1 });
+    }
+  }, [filterKey, setSearchParams]);
+
   return {
     filters,
     removeFilter,
     updateFilters,
     toggleArrayFilter,
+    page: searchParams.page,
+    setPage: (page: number) => setSearchParams({ page }),
   };
 };

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/hooks/use-paginated-deployments.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/hooks/use-paginated-deployments.ts
@@ -1,0 +1,115 @@
+import type { Deployment } from "@/lib/collections/deploy/deployments";
+import type { Environment } from "@/lib/collections/deploy/environments";
+import { parseDuration } from "@/lib/duration";
+import { trpc } from "@/lib/trpc/client";
+import { useCallback, useEffect, useMemo } from "react";
+import { useProjectData } from "../../data-provider";
+import { useFilters } from "./use-filters";
+
+const PAGE_SIZE = 50;
+
+function extractArrayFilterValues(
+  filters: ReturnType<typeof useFilters>["filters"],
+  field: "status" | "environment" | "branch",
+) {
+  return filters.flatMap((f) =>
+    f.field === field && typeof f.value === "string" ? [f.value] : [],
+  );
+}
+
+export function usePaginatedDeployments({ enabled = true }: { enabled?: boolean } = {}) {
+  const { projectId, appId, environments } = useProjectData();
+  const { filters, page, setPage } = useFilters();
+
+  const environmentMap = useMemo(() => {
+    const map = new Map<string, Environment>();
+    for (const env of environments) {
+      map.set(env.id, env);
+    }
+    return map;
+  }, [environments]);
+
+  const startTimeRaw = filters.find((f) => f.field === "startTime")?.value;
+  const startTime = typeof startTimeRaw === "number" ? startTimeRaw : undefined;
+  const endTimeRaw = filters.find((f) => f.field === "endTime")?.value;
+  const endTime = typeof endTimeRaw === "number" ? endTimeRaw : undefined;
+  const sinceRaw = filters.find((f) => f.field === "since")?.value;
+  const since = typeof sinceRaw === "string" ? sinceRaw : undefined;
+  const sinceMs = useMemo(() => (since ? Date.now() - parseDuration(since) : undefined), [since]);
+
+  const effectiveStartTime = sinceMs ?? startTime;
+  const statuses = extractArrayFilterValues(filters, "status");
+  const branches = extractArrayFilterValues(filters, "branch");
+  const environmentSlugs = extractArrayFilterValues(filters, "environment");
+
+  const queryParams = useMemo(
+    () => ({
+      projectId,
+      appId,
+      page,
+      limit: PAGE_SIZE,
+      ...(effectiveStartTime !== undefined && { startTime: effectiveStartTime }),
+      ...(endTime !== undefined && { endTime }),
+      ...(statuses.length > 0 && { statuses }),
+      ...(branches.length > 0 && { branches }),
+      ...(environmentSlugs.length > 0 && { environmentSlugs }),
+    }),
+    [projectId, appId, page, effectiveStartTime, endTime, statuses, branches, environmentSlugs],
+  );
+
+  const { data, isLoading, isFetching } = trpc.deploy.deployment.listPaginated.useQuery(
+    queryParams,
+    {
+      enabled,
+      keepPreviousData: true,
+      refetchInterval: enabled ? 20_000 : false,
+    },
+  );
+
+  const paginatedData = data ?? {
+    deployments: [] as Deployment[],
+    total: 0,
+    page: 1,
+    pageSize: PAGE_SIZE,
+    totalPages: 1,
+  };
+
+  const deployments = useMemo(() => {
+    return paginatedData.deployments.map((deployment) => ({
+      deployment,
+      environment: environmentMap.get(deployment.environmentId),
+    }));
+  }, [paginatedData.deployments, environmentMap]);
+
+  const totalPages = paginatedData.totalPages;
+  const totalCount = paginatedData.total;
+
+  useEffect(() => {
+    if (data && page > totalPages) {
+      setPage(totalPages);
+    }
+  }, [data, page, totalPages, setPage]);
+
+  const onPageChange = useCallback(
+    (newPage: number) => {
+      if (newPage < 1 || newPage > totalPages) {
+        return;
+      }
+      setPage(newPage);
+    },
+    [totalPages, setPage],
+  );
+
+  return {
+    deployments: {
+      isLoading,
+      isFetching,
+      data: deployments,
+    },
+    page,
+    pageSize: PAGE_SIZE,
+    totalPages,
+    totalCount,
+    onPageChange,
+  };
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/page.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/page.tsx
@@ -1,6 +1,4 @@
 "use client";
-import { collection } from "@/lib/collections";
-import { useCollectionPolling } from "@/lib/collections/use-collection-polling";
 import { Plus } from "@unkey/icons";
 import {
   Button,
@@ -16,11 +14,6 @@ import { DeploymentsListControls } from "./components/controls";
 import { DeploymentsCardList } from "./components/deployments-card-list";
 
 export default function Deployments() {
-  useCollectionPolling(() => collection.deployments.utils.refetch(), {
-    intervalMs: 20_000,
-    enabled: true,
-  });
-
   return (
     <PageContainer>
       <PageHeader>
@@ -40,7 +33,7 @@ export default function Deployments() {
       </PageHeader>
       <PageBody>
         <DeploymentsListControls />
-        <DeploymentsCardList />
+        <DeploymentsCardList paginated />
       </PageBody>
     </PageContainer>
   );

--- a/web/apps/dashboard/lib/trpc/routers/deploy/deployment/deployment-query-helpers.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/deployment/deployment-query-helpers.ts
@@ -1,7 +1,16 @@
 import type { InstanceStatus } from "@/lib/collections/deploy/instance-status";
-import { and, db, eq } from "@/lib/db";
-import { apps, deployments } from "@unkey/db/src/schema";
-import { mapRegionToFlag } from "../network/utils";
+import { and, db, eq, inArray, sql } from "@/lib/db";
+import type { LastExit } from "@/lib/types/deploy";
+import {
+  appRegionalSettings,
+  apps,
+  deploymentSteps,
+  deployments,
+  instances,
+  openapiSpecs,
+  regions,
+} from "@unkey/db/src/schema";
+import { type FlagCode, mapRegionToFlag } from "../network/utils";
 
 export const deploymentSelectFields = {
   id: deployments.id,
@@ -96,4 +105,199 @@ export async function fetchCurrentDeploymentOutsideWindow(
       ),
     );
   return deployment ?? null;
+}
+
+type DeploymentRow = {
+  id: string;
+  appId: string;
+  environmentId: string;
+  projectId: string;
+  gitCommitSha: string | null;
+  gitBranch: string | null;
+  gitCommitMessage: string | null;
+  gitCommitAuthorHandle: string | null;
+  gitCommitAuthorAvatarUrl: string | null;
+  gitCommitTimestamp: number | null;
+  prNumber: number | null;
+  forkRepositoryFullName: string | null;
+  image: string | null;
+  status: (typeof deployments.$inferSelect)["status"];
+  desiredState: (typeof deployments.$inferSelect)["desiredState"];
+  trigger: (typeof deployments.$inferSelect)["trigger"];
+  triggeredBy: string | null;
+  triggerReason: string | null;
+  cpuMillicores: number;
+  memoryMib: number;
+  storageMib: number;
+  port: number;
+  upstreamProtocol: (typeof deployments.$inferSelect)["upstreamProtocol"];
+  healthcheck: (typeof deployments.$inferSelect)["healthcheck"];
+  shutdownSignal: (typeof deployments.$inferSelect)["shutdownSignal"];
+  createdAt: number;
+  updatedAt: number | null;
+};
+
+type InstanceQueryRow = {
+  id: string;
+  deploymentId: string;
+  regionId: string;
+  regionName: string;
+  regionPlatform: string;
+  status: InstanceStatus;
+  containerStatus: {
+    restartCount?: number;
+    lastTerminationState?: {
+      exitCode?: number;
+      signal?: number;
+      reason?: string;
+      finishedAt?: number;
+    } | null;
+    waiting?: { reason?: string } | null;
+  } | null;
+};
+
+export async function enrichDeploymentRows(workspaceId: string, deploymentRows: DeploymentRow[]) {
+  if (deploymentRows.length === 0) {
+    return [];
+  }
+
+  const deploymentIds = deploymentRows.map((d) => d.id);
+  const appIds = [...new Set(deploymentRows.map((d) => d.appId))];
+  const environmentIds = [...new Set(deploymentRows.map((d) => d.environmentId))];
+
+  const [specRows, instanceRows, regionalSettingsRows, stepTimingRows] = await Promise.all([
+    db
+      .select({ deploymentId: openapiSpecs.deploymentId })
+      .from(openapiSpecs)
+      .where(inArray(openapiSpecs.deploymentId, deploymentIds)),
+    db
+      .select({
+        id: instances.id,
+        deploymentId: instances.deploymentId,
+        regionId: regions.id,
+        regionName: regions.name,
+        regionPlatform: regions.platform,
+        status: instances.status,
+        containerStatus: instances.containerStatus,
+      })
+      .from(instances)
+      .innerJoin(regions, eq(regions.id, instances.regionId))
+      .where(inArray(instances.deploymentId, deploymentIds)),
+    db
+      .select({
+        appId: appRegionalSettings.appId,
+        environmentId: appRegionalSettings.environmentId,
+        regionId: regions.id,
+        regionName: regions.name,
+        regionPlatform: regions.platform,
+        replicas: appRegionalSettings.replicas,
+      })
+      .from(appRegionalSettings)
+      .innerJoin(regions, eq(regions.id, appRegionalSettings.regionId))
+      .where(
+        and(
+          eq(appRegionalSettings.workspaceId, workspaceId),
+          inArray(appRegionalSettings.appId, appIds),
+          inArray(appRegionalSettings.environmentId, environmentIds),
+        ),
+      ),
+    db
+      .select({
+        deploymentId: deploymentSteps.deploymentId,
+        maxEndedAt: sql<number | null>`max(${deploymentSteps.endedAt})`,
+        openSteps: sql<number>`sum(case when ${deploymentSteps.endedAt} is null then 1 else 0 end)`,
+      })
+      .from(deploymentSteps)
+      .where(inArray(deploymentSteps.deploymentId, deploymentIds))
+      .groupBy(deploymentSteps.deploymentId),
+  ]);
+
+  const buildEndedAtByDeployment = new Map<string, number | null>();
+  for (const row of stepTimingRows) {
+    const openSteps = Number(row.openSteps ?? 0);
+    const maxEndedAt = row.maxEndedAt == null ? null : Number(row.maxEndedAt);
+    buildEndedAtByDeployment.set(row.deploymentId, openSteps > 0 ? null : maxEndedAt);
+  }
+
+  const specSet = new Set(specRows.map((s) => s.deploymentId));
+  const instancesByDeployment = new Map<string, ReturnType<typeof mapInstanceRow>[]>();
+  const lastExitByDeployment = new Map<string, LastExit>();
+  for (const row of instanceRows as InstanceQueryRow[]) {
+    const entry = mapInstanceRow(row);
+    const list = instancesByDeployment.get(row.deploymentId);
+    if (list) {
+      list.push(entry);
+    } else {
+      instancesByDeployment.set(row.deploymentId, [entry]);
+    }
+
+    const status = row.containerStatus ?? {};
+    const term = status.lastTerminationState ?? null;
+    const waiting = status.waiting ?? null;
+    const candidate: LastExit = {
+      restartCount: status.restartCount ?? 0,
+      exitCode: term?.exitCode ?? null,
+      signal: term?.signal ?? null,
+      reason: term?.reason ?? null,
+      finishedAt: term?.finishedAt ?? null,
+      statusReason: waiting?.reason ?? null,
+    };
+    if (candidate.reason === null && candidate.statusReason === null) {
+      continue;
+    }
+    const prev = lastExitByDeployment.get(row.deploymentId);
+    if (!prev) {
+      lastExitByDeployment.set(row.deploymentId, candidate);
+      continue;
+    }
+    const prevTs = prev.finishedAt ?? -1;
+    const candTs = candidate.finishedAt ?? -1;
+    if (candTs > prevTs || (candTs === prevTs && candidate.restartCount > prev.restartCount)) {
+      lastExitByDeployment.set(row.deploymentId, candidate);
+    }
+  }
+
+  const desiredStateByAppEnv = new Map<
+    string,
+    {
+      desiredInstanceCount: number;
+      desiredRegions: {
+        region: { id: string; name: string; platform: string };
+        flagCode: FlagCode;
+      }[];
+    }
+  >();
+  for (const row of regionalSettingsRows) {
+    const key = `${row.appId}:${row.environmentId}`;
+    const regionEntry = {
+      region: { id: row.regionId, name: row.regionName, platform: row.regionPlatform },
+      flagCode: mapRegionToFlag(row.regionName),
+    };
+    const replicaCount = row.replicas;
+    const existing = desiredStateByAppEnv.get(key);
+    if (existing) {
+      existing.desiredInstanceCount += replicaCount;
+      existing.desiredRegions.push(regionEntry);
+    } else {
+      desiredStateByAppEnv.set(key, {
+        desiredInstanceCount: replicaCount,
+        desiredRegions: [regionEntry],
+      });
+    }
+  }
+
+  return deploymentRows.map(({ appId, ...deployment }) => {
+    const desired = desiredStateByAppEnv.get(`${appId}:${deployment.environmentId}`);
+    return {
+      ...deployment,
+      appId,
+      ...normalizeDeploymentRow(deployment),
+      instances: instancesByDeployment.get(deployment.id) ?? [],
+      buildEndedAt: buildEndedAtByDeployment.get(deployment.id) ?? null,
+      lastExit: lastExitByDeployment.get(deployment.id) ?? null,
+      desiredInstanceCount: desired?.desiredInstanceCount ?? 0,
+      desiredRegions: desired?.desiredRegions ?? [],
+      hasOpenApiSpec: specSet.has(deployment.id),
+    };
+  });
 }

--- a/web/apps/dashboard/lib/trpc/routers/deploy/deployment/getById.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/deployment/getById.ts
@@ -1,20 +1,9 @@
 import { and, db, eq } from "@/lib/db";
 import { workspaceProcedure } from "@/lib/trpc/trpc";
 import { TRPCError } from "@trpc/server";
-import {
-  appRegionalSettings,
-  deployments,
-  instances,
-  openapiSpecs,
-  regions,
-} from "@unkey/db/src/schema";
+import { deployments } from "@unkey/db/src/schema";
 import { z } from "zod";
-import { mapRegionToFlag } from "../network/utils";
-import {
-  deploymentSelectFields,
-  mapInstanceRow,
-  normalizeDeploymentRow,
-} from "./deployment-query-helpers";
+import { deploymentSelectFields, enrichDeploymentRows } from "./deployment-query-helpers";
 
 export const getById = workspaceProcedure
   .input(
@@ -47,62 +36,15 @@ export const getById = workspaceProcedure
         });
       }
 
-      const [specRows, instanceRows, regionalSettingsRows] = await Promise.all([
-        db
-          .select({ deploymentId: openapiSpecs.deploymentId })
-          .from(openapiSpecs)
-          .where(eq(openapiSpecs.deploymentId, deployment.id)),
-        db
-          .select({
-            id: instances.id,
-            deploymentId: instances.deploymentId,
-            regionId: regions.id,
-            regionName: regions.name,
-            regionPlatform: regions.platform,
-            status: instances.status,
-          })
-          .from(instances)
-          .innerJoin(regions, eq(regions.id, instances.regionId))
-          .where(eq(instances.deploymentId, deployment.id)),
-        db
-          .select({
-            regionId: regions.id,
-            regionName: regions.name,
-            regionPlatform: regions.platform,
-            replicas: appRegionalSettings.replicas,
-          })
-          .from(appRegionalSettings)
-          .innerJoin(regions, eq(regions.id, appRegionalSettings.regionId))
-          .where(
-            and(
-              eq(appRegionalSettings.workspaceId, ctx.workspace.id),
-              eq(appRegionalSettings.appId, deployment.appId),
-              eq(appRegionalSettings.environmentId, deployment.environmentId),
-            ),
-          ),
-      ]);
-
-      let desiredInstanceCount = 0;
-      const desiredRegions: {
-        region: { id: string; name: string; platform: string };
-        flagCode: ReturnType<typeof mapRegionToFlag>;
-      }[] = [];
-      for (const row of regionalSettingsRows) {
-        desiredInstanceCount += row.replicas;
-        desiredRegions.push({
-          region: { id: row.regionId, name: row.regionName, platform: row.regionPlatform },
-          flagCode: mapRegionToFlag(row.regionName),
+      const [enriched] = await enrichDeploymentRows(ctx.workspace.id, [deployment]);
+      if (!enriched) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Deployment not found",
         });
       }
 
-      return {
-        ...deployment,
-        ...normalizeDeploymentRow(deployment),
-        instances: instanceRows.map(mapInstanceRow),
-        desiredInstanceCount,
-        desiredRegions,
-        hasOpenApiSpec: specRows.length > 0,
-      };
+      return enriched;
     } catch (error) {
       if (error instanceof TRPCError) {
         throw error;

--- a/web/apps/dashboard/lib/trpc/routers/deploy/deployment/list.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/deployment/list.ts
@@ -1,22 +1,13 @@
-import { and, db, desc, eq, gte, inArray, lte, sql } from "@/lib/db";
+import { DEPLOYMENTS_DEFAULT_LIMIT } from "@/lib/collections/deploy/deployments";
+import { and, db, desc, eq, gte, lte } from "@/lib/db";
 import { workspaceProcedure } from "@/lib/trpc/trpc";
-import type { LastExit } from "@/lib/types/deploy";
 import { TRPCError } from "@trpc/server";
-import {
-  appRegionalSettings,
-  deploymentSteps,
-  deployments,
-  instances,
-  openapiSpecs,
-  regions,
-} from "@unkey/db/src/schema";
+import { deployments } from "@unkey/db/src/schema";
 import { z } from "zod";
-import { type FlagCode, mapRegionToFlag } from "../network/utils";
 import {
   deploymentSelectFields,
+  enrichDeploymentRows,
   fetchCurrentDeploymentOutsideWindow,
-  mapInstanceRow,
-  normalizeDeploymentRow,
 } from "./deployment-query-helpers";
 
 export const listDeployments = workspaceProcedure
@@ -46,7 +37,7 @@ export const listDeployments = workspaceProcedure
           ),
         )
         .orderBy(desc(deployments.createdAt), desc(deployments.id))
-        .limit(100);
+        .limit(DEPLOYMENTS_DEFAULT_LIMIT);
 
       if (deploymentRows.length === 0) {
         return [];
@@ -67,161 +58,7 @@ export const listDeployments = workspaceProcedure
         }
       }
 
-      const deploymentIds = deploymentRows.map((d) => d.id);
-
-      const appIds = [...new Set(deploymentRows.map((d) => d.appId))];
-      const environmentIds = [...new Set(deploymentRows.map((d) => d.environmentId))];
-
-      const [specRows, instanceRows, regionalSettingsRows, stepTimingRows] = await Promise.all([
-        db
-          .select({ deploymentId: openapiSpecs.deploymentId })
-          .from(openapiSpecs)
-          .where(inArray(openapiSpecs.deploymentId, deploymentIds)),
-        db
-          .select({
-            id: instances.id,
-            deploymentId: instances.deploymentId,
-            regionId: regions.id,
-            regionName: regions.name,
-            regionPlatform: regions.platform,
-            status: instances.status,
-            containerStatus: instances.containerStatus,
-          })
-          .from(instances)
-          .innerJoin(regions, eq(regions.id, instances.regionId))
-          .where(inArray(instances.deploymentId, deploymentIds)),
-        db
-          .select({
-            appId: appRegionalSettings.appId,
-            environmentId: appRegionalSettings.environmentId,
-            regionId: regions.id,
-            regionName: regions.name,
-            regionPlatform: regions.platform,
-            replicas: appRegionalSettings.replicas,
-          })
-          .from(appRegionalSettings)
-          .innerJoin(regions, eq(regions.id, appRegionalSettings.regionId))
-          .where(
-            and(
-              eq(appRegionalSettings.workspaceId, ctx.workspace.id),
-              inArray(appRegionalSettings.appId, appIds),
-              inArray(appRegionalSettings.environmentId, environmentIds),
-            ),
-          ),
-        // Build/deploy timing comes from deployment_steps, the only timestamps
-        // stop/wake never mutate. openSteps counts steps still running so we
-        // can tell an in-progress build (tick live) from a finished one.
-        db
-          .select({
-            deploymentId: deploymentSteps.deploymentId,
-            maxEndedAt: sql<number | null>`max(${deploymentSteps.endedAt})`,
-            openSteps: sql<number>`sum(case when ${deploymentSteps.endedAt} is null then 1 else 0 end)`,
-          })
-          .from(deploymentSteps)
-          .where(inArray(deploymentSteps.deploymentId, deploymentIds))
-          .groupBy(deploymentSteps.deploymentId),
-      ]);
-
-      // buildEndedAt is the moment the pipeline finished: the latest step end,
-      // but null while any step is still open so the row ticks live instead of
-      // freezing a partial duration. Null when a deployment has no steps (old
-      // or prebuilt-image rows) — the row then shows no duration.
-      const buildEndedAtByDeployment = new Map<string, number | null>();
-      for (const row of stepTimingRows) {
-        const openSteps = Number(row.openSteps ?? 0);
-        const maxEndedAt = row.maxEndedAt == null ? null : Number(row.maxEndedAt);
-        buildEndedAtByDeployment.set(row.deploymentId, openSteps > 0 ? null : maxEndedAt);
-      }
-
-      const specSet = new Set(specRows.map((s) => s.deploymentId));
-      const instancesByDeployment = new Map<string, ReturnType<typeof mapInstanceRow>[]>();
-      // The header badge picks the most recent exit across all instances of
-      // a deployment so that a multi-region rollout with one OOM-ing pod
-      // still surfaces the failure even when others are healthy. Tie-break
-      // by finishedAt (preferred) and fall back to the live waiting reason
-      // (CrashLoopBackOff, ImagePullBackOff, …) when there's no exit yet.
-      const lastExitByDeployment = new Map<string, LastExit>();
-      for (const row of instanceRows) {
-        const entry = mapInstanceRow(row);
-        const list = instancesByDeployment.get(row.deploymentId);
-        if (list) {
-          list.push(entry);
-        } else {
-          instancesByDeployment.set(row.deploymentId, [entry]);
-        }
-
-        const status = row.containerStatus ?? {};
-        const term = status.lastTerminationState ?? null;
-        const waiting = status.waiting ?? null;
-        const candidate: LastExit = {
-          restartCount: status.restartCount ?? 0,
-          exitCode: term?.exitCode ?? null,
-          signal: term?.signal ?? null,
-          reason: term?.reason ?? null,
-          finishedAt: term?.finishedAt ?? null,
-          statusReason: waiting?.reason ?? null,
-        };
-        if (candidate.reason === null && candidate.statusReason === null) {
-          continue;
-        }
-        const prev = lastExitByDeployment.get(row.deploymentId);
-        if (!prev) {
-          lastExitByDeployment.set(row.deploymentId, candidate);
-          continue;
-        }
-        // Prefer the candidate with a more recent finishedAt; if neither
-        // has one (only statusReason populated) keep whichever has higher
-        // restartCount as a coarse recency tiebreaker.
-        const prevTs = prev.finishedAt ?? -1;
-        const candTs = candidate.finishedAt ?? -1;
-        if (candTs > prevTs || (candTs === prevTs && candidate.restartCount > prev.restartCount)) {
-          lastExitByDeployment.set(row.deploymentId, candidate);
-        }
-      }
-
-      const desiredStateByAppEnv = new Map<
-        string,
-        {
-          desiredInstanceCount: number;
-          desiredRegions: {
-            region: { id: string; name: string; platform: string };
-            flagCode: FlagCode;
-          }[];
-        }
-      >();
-      for (const row of regionalSettingsRows) {
-        const key = `${row.appId}:${row.environmentId}`;
-        const regionEntry = {
-          region: { id: row.regionId, name: row.regionName, platform: row.regionPlatform },
-          flagCode: mapRegionToFlag(row.regionName),
-        };
-        const replicaCount = row.replicas;
-        const existing = desiredStateByAppEnv.get(key);
-        if (existing) {
-          existing.desiredInstanceCount += replicaCount;
-          existing.desiredRegions.push(regionEntry);
-        } else {
-          desiredStateByAppEnv.set(key, {
-            desiredInstanceCount: replicaCount,
-            desiredRegions: [regionEntry],
-          });
-        }
-      }
-
-      return deploymentRows.map(({ appId, ...deployment }) => {
-        const desired = desiredStateByAppEnv.get(`${appId}:${deployment.environmentId}`);
-        return {
-          ...deployment,
-          appId,
-          ...normalizeDeploymentRow(deployment),
-          instances: instancesByDeployment.get(deployment.id) ?? [],
-          buildEndedAt: buildEndedAtByDeployment.get(deployment.id) ?? null,
-          lastExit: lastExitByDeployment.get(deployment.id) ?? null,
-          desiredInstanceCount: desired?.desiredInstanceCount ?? 0,
-          desiredRegions: desired?.desiredRegions ?? [],
-          hasOpenApiSpec: specSet.has(deployment.id),
-        };
-      });
+      return enrichDeploymentRows(ctx.workspace.id, deploymentRows);
     } catch (_error) {
       throw new TRPCError({
         code: "INTERNAL_SERVER_ERROR",

--- a/web/apps/dashboard/lib/trpc/routers/deploy/deployment/listPaginated.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/deployment/listPaginated.ts
@@ -1,0 +1,125 @@
+import { and, count, db, desc, eq, gte, inArray, lte } from "@/lib/db";
+import { workspaceProcedure } from "@/lib/trpc/trpc";
+import { TRPCError } from "@trpc/server";
+import { deployments, environments } from "@unkey/db/src/schema";
+import { z } from "zod";
+import { deploymentSelectFields, enrichDeploymentRows } from "./deployment-query-helpers";
+
+const DEFAULT_PAGE_SIZE = 50;
+const MAX_PAGE_SIZE = 100;
+
+function buildListWhereConditions(
+  workspaceId: string,
+  input: {
+    projectId: string;
+    appId?: string;
+    startTime?: number;
+    endTime?: number;
+    statuses?: string[];
+    branches?: string[];
+    environmentIds?: string[];
+  },
+) {
+  return and(
+    eq(deployments.workspaceId, workspaceId),
+    eq(deployments.projectId, input.projectId),
+    input.appId ? eq(deployments.appId, input.appId) : undefined,
+    input.startTime ? gte(deployments.createdAt, input.startTime) : undefined,
+    input.endTime ? lte(deployments.createdAt, input.endTime) : undefined,
+    input.statuses && input.statuses.length > 0
+      ? inArray(deployments.status, input.statuses as (typeof deployments.$inferSelect)["status"][])
+      : undefined,
+    input.branches && input.branches.length > 0
+      ? inArray(deployments.gitBranch, input.branches)
+      : undefined,
+    input.environmentIds && input.environmentIds.length > 0
+      ? inArray(deployments.environmentId, input.environmentIds)
+      : undefined,
+  );
+}
+
+export const listPaginatedDeployments = workspaceProcedure
+  .input(
+    z.object({
+      projectId: z.string(),
+      appId: z.string().optional(),
+      startTime: z.number().int().optional(),
+      endTime: z.number().int().optional(),
+      page: z.number().int().min(1).default(1),
+      limit: z.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE),
+      statuses: z.array(z.string()).optional(),
+      branches: z.array(z.string()).optional(),
+      environmentSlugs: z.array(z.string()).optional(),
+    }),
+  )
+  .query(async ({ ctx, input }) => {
+    try {
+      const pageSize = Math.min(input.limit, MAX_PAGE_SIZE);
+      const page = input.page;
+
+      let environmentIds: string[] | undefined;
+      if (input.environmentSlugs && input.environmentSlugs.length > 0 && input.appId) {
+        const envRows = await db
+          .select({ id: environments.id })
+          .from(environments)
+          .where(
+            and(
+              eq(environments.workspaceId, ctx.workspace.id),
+              eq(environments.projectId, input.projectId),
+              eq(environments.appId, input.appId),
+              inArray(environments.slug, input.environmentSlugs),
+            ),
+          );
+        environmentIds = envRows.map((row) => row.id);
+        if (environmentIds.length === 0) {
+          return { deployments: [], total: 0, page, pageSize, totalPages: 1 };
+        }
+      }
+
+      const whereConditions = buildListWhereConditions(ctx.workspace.id, {
+        projectId: input.projectId,
+        appId: input.appId,
+        startTime: input.startTime,
+        endTime: input.endTime,
+        statuses: input.statuses,
+        branches: input.branches,
+        environmentIds,
+      });
+
+      const [totalResult, deploymentRows] = await Promise.all([
+        db.select({ count: count() }).from(deployments).where(whereConditions),
+        db
+          .select({
+            ...deploymentSelectFields,
+            appId: deployments.appId,
+          })
+          .from(deployments)
+          .where(whereConditions)
+          .orderBy(desc(deployments.createdAt), desc(deployments.id))
+          .limit(pageSize)
+          .offset((page - 1) * pageSize),
+      ]);
+
+      const total = totalResult[0]?.count ?? 0;
+      const totalPages = Math.max(1, Math.ceil(total / pageSize));
+
+      if (deploymentRows.length === 0) {
+        return { deployments: [], total, page, pageSize, totalPages };
+      }
+
+      const enriched = await enrichDeploymentRows(ctx.workspace.id, deploymentRows);
+
+      return {
+        deployments: enriched,
+        total,
+        page,
+        pageSize,
+        totalPages,
+      };
+    } catch (_error) {
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: "Failed to fetch deployments",
+      });
+    }
+  });

--- a/web/apps/dashboard/lib/trpc/routers/index.ts
+++ b/web/apps/dashboard/lib/trpc/routers/index.ts
@@ -51,6 +51,7 @@ import { getById as getDeploymentById } from "./deploy/deployment/getById";
 import { getOpenApiDiff } from "./deploy/deployment/getOpenApiDiff";
 import { getDeploymentInstanceEvents } from "./deploy/deployment/instance-events";
 import { listDeployments } from "./deploy/deployment/list";
+import { listPaginatedDeployments } from "./deploy/deployment/listPaginated";
 import { searchDeployments } from "./deploy/deployment/llm-search";
 import { promote } from "./deploy/deployment/promote";
 import { redeploy } from "./deploy/deployment/redeploy";
@@ -539,6 +540,7 @@ export const router = t.router({
     }),
     deployment: t.router({
       list: listDeployments,
+      listPaginated: listPaginatedDeployments,
       getById: getDeploymentById,
       buildSteps: getDeploymentBuildSteps,
       runtimeLogs: getDeploymentRuntimeLogs,

--- a/web/internal/ui/src/components/data-table/components/footer/pagination-footer.tsx
+++ b/web/internal/ui/src/components/data-table/components/footer/pagination-footer.tsx
@@ -44,7 +44,7 @@ export const PaginationFooter = memo(function PaginationFooter({
   // Minimized state - parked at right side
   if (!isOpen) {
     return (
-      <div className="fixed bottom-6 right-6 z-10 animate-fade-slide-in">
+      <div className="fixed bottom-6 right-6 z-30 animate-fade-slide-in">
         <button
           type="button"
           onClick={() => setIsOpen(true)}
@@ -73,7 +73,7 @@ export const PaginationFooter = memo(function PaginationFooter({
   return (
     <div
       className={cn(
-        "fixed bottom-0 left-0 right-0 w-full items-center justify-center flex flex-col z-10 animation-ease-out pointer-events-none",
+        "fixed bottom-0 left-0 right-0 w-full items-center justify-center flex flex-col z-30 animation-ease-out pointer-events-none",
         "opacity-100",
       )}
     >


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes deployment detail pages returning 404 for deployments that exist but fall outside the first 100 loaded into the TanStack DB collection, and adds pagination to the deployments list.

## Root cause

`DeploymentLayoutProvider` falls back to `trpc.deploy.deployment.getById` when a deployment is not in the collection. The endpoint returned a payload missing `buildEndedAt` and `lastExit`, which are required by `deploymentSchema`. `safeParse` failed, the provider treated the deployment as missing, and called `notFound()`.

## Changes

- **Shared enrichment**: Extract `enrichDeploymentRows` so `list`, `listPaginated`, and `getById` return the same deployment shape (instances, build timing, last exit, desired regions, etc.).
- **404 behavior**: Only call `notFound()` when `getById` returns `NOT_FOUND`. Wait for the fetch to finish before deciding; surface other errors instead of a false 404.
- **Paginated list**: Add `deploy.deployment.listPaginated` with page/limit, total count, and server-side filters (status, branch, environment slug, time range).
- **UI**: Deployments list page uses `PaginationFooter` (50 per page, `page` URL param). Overview "recent deployments" keeps the existing collection-based hook.

## Verification

- `mise run fmt`
- TypeScript check on changed dashboard files (no new errors in modified paths)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a6c70630-83ed-4ced-a59c-63ff3d010360"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a6c70630-83ed-4ced-a59c-63ff3d010360"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

