### PR TITLE
frontline: cache resilience and hot-path performance

### DIFF
--- a/dev/linters/exhaustruct/analyzer.go
+++ b/dev/linters/exhaustruct/analyzer.go
@@ -75,6 +75,7 @@ var excludePatterns = []string{
 	// Unkey internal
 	`^github\.com/unkeyed/unkey/svc/api/openapi\.Meta$`,
 	`^github\.com/unkeyed/unkey/pkg/cli\.Command$`,
+	`^github\.com/unkeyed/unkey/pkg/cache\.Config`,
 
 	// Kubernetes
 	`^k8s\.io/api/core/v1.*$`,

--- a/internal/services/caches/caches.go
+++ b/internal/services/caches/caches.go
@@ -89,6 +89,7 @@ func New(config Config) (Caches, error) {
 		Fresh:    time.Minute,
 		Stale:    24 * time.Hour,
 		MaxSize:  1_000_000,
+		Cost:     nil,
 		Resource: "ratelimit_namespace",
 		Clock:    config.Clock,
 	})
@@ -100,6 +101,7 @@ func New(config Config) (Caches, error) {
 		Fresh:    10 * time.Second,
 		Stale:    10 * time.Minute,
 		MaxSize:  1_000_000,
+		Cost:     nil,
 		Resource: "verification_key_by_hash",
 		Clock:    config.Clock,
 	})
@@ -111,6 +113,7 @@ func New(config Config) (Caches, error) {
 		Fresh:    10 * time.Second,
 		Stale:    24 * time.Hour,
 		MaxSize:  1_000_000,
+		Cost:     nil,
 		Resource: "live_api_by_id",
 		Clock:    config.Clock,
 	})
@@ -122,6 +125,7 @@ func New(config Config) (Caches, error) {
 		Fresh:    time.Minute,
 		Stale:    24 * time.Hour,
 		MaxSize:  1_000_000,
+		Cost:     nil,
 		Resource: "clickhouse_setting",
 		Clock:    config.Clock,
 	})
@@ -133,6 +137,7 @@ func New(config Config) (Caches, error) {
 		Fresh:    10 * time.Minute,
 		Stale:    24 * time.Hour,
 		MaxSize:  1_000_000,
+		Cost:     nil,
 		Resource: "key_auth_to_api_row",
 		Clock:    config.Clock,
 	})
@@ -144,6 +149,7 @@ func New(config Config) (Caches, error) {
 		Fresh:    10 * time.Minute,
 		Stale:    24 * time.Hour,
 		MaxSize:  1_000_000,
+		Cost:     nil,
 		Resource: "api_to_key_auth_row",
 		Clock:    config.Clock,
 	})
@@ -155,6 +161,7 @@ func New(config Config) (Caches, error) {
 		Fresh:    time.Minute,
 		Stale:    24 * time.Hour,
 		MaxSize:  100_000,
+		Cost:     nil,
 		Resource: "workspace_quota",
 		Clock:    config.Clock,
 	})
@@ -166,6 +173,7 @@ func New(config Config) (Caches, error) {
 		Fresh:    10 * time.Second,
 		Stale:    5 * time.Minute,
 		MaxSize:  100_000,
+		Cost:     nil,
 		Resource: "portal_session",
 		Clock:    config.Clock,
 	})
@@ -177,6 +185,7 @@ func New(config Config) (Caches, error) {
 		Fresh:    10 * time.Second,
 		Stale:    24 * time.Hour,
 		MaxSize:  100_000,
+		Cost:     nil,
 		Resource: "workspace_by_org_id",
 		Clock:    config.Clock,
 	})

--- a/pkg/cache/BUILD.bazel
+++ b/pkg/cache/BUILD.bazel
@@ -6,10 +6,13 @@ go_library(
         "cache.go",
         "doc.go",
         "entry.go",
+        "fetch_dedup.go",
         "interface.go",
         "middleware.go",
         "noop.go",
+        "revalidation.go",
         "scoped_key.go",
+        "timing_attrs.go",
     ],
     importpath = "github.com/unkeyed/unkey/pkg/cache",
     visibility = ["//visibility:public"],
@@ -23,6 +26,7 @@ go_library(
         "//pkg/repeat",
         "//pkg/timing",
         "@com_github_maypok86_otter//:otter",
+        "@com_github_prometheus_client_golang//prometheus",
     ],
 )
 

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -41,8 +41,12 @@ type Config[K comparable, V any] struct {
 	// fetching from the origin server
 	Stale time.Duration
 
-	// Start evicting the least recently used entry when the cache grows to MaxSize
+	// Start evicting the least recently used entry when the cache grows to MaxSize.
+	// When Cost is set, MaxSize is a total weight budget; otherwise it is an entry count.
 	MaxSize int
+
+	// Cost assigns a weight to each cached value for eviction. Defaults to 1 per entry.
+	Cost func(V) uint32
 
 	Resource string
 
@@ -64,11 +68,19 @@ func New[K comparable, V any](config Config[K, V]) (Cache[K, V], error) {
 		return nil, err
 	}
 
+	cost := func(_ K, value swrEntry[V]) uint32 {
+		return 1
+	}
+	if config.Cost != nil {
+		weigh := config.Cost
+		cost = func(_ K, value swrEntry[V]) uint32 {
+			return weigh(value.Value)
+		}
+	}
+
 	otter, err := builder.
 		CollectStats().
-		Cost(func(key K, value swrEntry[V]) uint32 {
-			return 1
-		}).
+		Cost(cost).
 		WithTTL(config.Stale).
 		DeletionListener(func(key K, value swrEntry[V], cause otter.DeletionCause) {
 			metrics.CacheDeleted.WithLabelValues(config.Resource, cause.String()).Inc()

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
 	"github.com/maypok86/otter"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/unkeyed/unkey/pkg/assert"
 	"github.com/unkeyed/unkey/pkg/cache/metrics"
 	"github.com/unkeyed/unkey/pkg/clock"
@@ -30,6 +30,13 @@ type cache[K comparable, V any] struct {
 
 	inflightMu        sync.Mutex
 	inflightRefreshes map[K]bool
+
+	fetchMu       sync.Mutex
+	fetchInflight map[K]*fetchCall
+
+	readsHit  prometheus.Counter
+	readsMiss prometheus.Counter
+	timing    timingAttrs
 }
 
 type Config[K comparable, V any] struct {
@@ -49,6 +56,12 @@ type Config[K comparable, V any] struct {
 	Cost func(V) uint32
 
 	Resource string
+
+	// RevalidationQueueSize is the stale refresh worker queue capacity.
+	RevalidationQueueSize int
+
+	// RevalidationWorkers is the number of background refresh workers.
+	RevalidationWorkers int
 
 	Clock clock.Clock
 }
@@ -89,18 +102,33 @@ func New[K comparable, V any](config Config[K, V]) (Cache[K, V], error) {
 	if err != nil {
 		return nil, err
 	}
+
+	queueSize := config.RevalidationQueueSize
+	if queueSize <= 0 {
+		queueSize = defaultRevalidationQueueSize
+	}
+	workers := config.RevalidationWorkers
+	if workers <= 0 {
+		workers = defaultRevalidationWorkers
+	}
+
 	c := &cache[K, V]{
 		otter:             otter,
 		fresh:             config.Fresh,
 		stale:             config.Stale,
 		resource:          config.Resource,
 		clock:             config.Clock,
-		revalidateC:       make(chan func(), 1000),
+		revalidateC:       make(chan func(), queueSize),
 		inflightMu:        sync.Mutex{},
 		inflightRefreshes: make(map[K]bool),
+		fetchMu:           sync.Mutex{},
+		fetchInflight:     make(map[K]*fetchCall),
+		readsHit:          metrics.CacheReads.WithLabelValues(config.Resource, "true"),
+		readsMiss:         metrics.CacheReads.WithLabelValues(config.Resource, "false"),
+		timing:            newTimingAttrs(config.Resource),
 	}
 
-	for range 10 {
+	for range workers {
 		go func() {
 			for revalidate := range c.revalidateC {
 				revalidate()
@@ -119,14 +147,11 @@ func (c *cache[K, V]) registerMetrics() {
 	})
 }
 
-func (c *cache[K, V]) recordTiming(ctx context.Context, name, status string, start time.Time) {
+func (c *cache[K, V]) recordTiming(ctx context.Context, name string, attrs map[string]string, start time.Time) {
 	timing.Record(ctx, timing.Entry{
-		Name:     name,
-		Duration: time.Since(start),
-		Attributes: map[string]string{
-			"cache":  c.resource,
-			"status": strings.ToLower(status),
-		},
+		Name:       name,
+		Duration:   time.Since(start),
+		Attributes: attrs,
 	})
 }
 
@@ -134,23 +159,23 @@ func (c *cache[K, V]) Get(ctx context.Context, key K) (value V, hit CacheHit) {
 	start := time.Now()
 	e, ok := c.get(ctx, key)
 	if !ok {
-		c.recordTiming(ctx, "cache_get", "miss", start)
+		c.recordTiming(ctx, "cache_get", c.timing.getMiss, start)
 		return value, Miss
 	}
 
 	now := c.clock.Now()
 
 	if now.Before(e.Stale) {
-		status := "STALE"
+		status := c.timing.getStale
 		if now.Before(e.Fresh) {
-			status = "FRESH"
+			status = c.timing.getFresh
 		}
 		c.recordTiming(ctx, "cache_get", status, start)
 		return e.Value, e.Hit
 	}
 
 	c.otter.Delete(key)
-	c.recordTiming(ctx, "cache_get", "miss", start)
+	c.recordTiming(ctx, "cache_get", c.timing.getMiss, start)
 
 	return value, Miss
 }
@@ -233,7 +258,11 @@ func (c *cache[K, V]) SetMany(ctx context.Context, values map[K]V) {
 func (c *cache[K, V]) get(_ context.Context, key K) (swrEntry[V], bool) {
 	v, ok := c.otter.Get(key)
 
-	metrics.CacheReads.WithLabelValues(c.resource, fmt.Sprintf("%t", ok)).Inc()
+	if ok {
+		c.readsHit.Inc()
+	} else {
+		c.readsMiss.Inc()
+	}
 
 	return v, ok
 }
@@ -291,22 +320,6 @@ func (c *cache[K, V]) revalidate(
 	key K, refreshFromOrigin func(context.Context) (V, error),
 	op func(error) Op,
 ) {
-	c.inflightMu.Lock()
-	_, ok := c.inflightRefreshes[key]
-	if ok {
-		c.inflightMu.Unlock()
-		return
-	}
-
-	c.inflightRefreshes[key] = true
-	c.inflightMu.Unlock()
-
-	defer func() {
-		c.inflightMu.Lock()
-		delete(c.inflightRefreshes, key)
-		c.inflightMu.Unlock()
-	}()
-
 	metrics.CacheRevalidations.WithLabelValues(c.resource).Inc()
 	v, err := refreshFromOrigin(ctx)
 
@@ -337,17 +350,17 @@ func (c *cache[K, V]) SWR(
 		// Cache Hit
 		if now.Before(e.Fresh) {
 			// We have data and it's fresh, so we return it
-			c.recordTiming(ctx, "cache_swr", "fresh", start)
+			c.recordTiming(ctx, "cache_swr", c.timing.swrFresh, start)
 			return e.Value, e.Hit, nil
 		}
 
 		if now.Before(e.Stale) {
-			c.revalidateC <- func() {
+			c.enqueueRevalidation(key, func() {
 				// If we don't uncancel the context, the revalidation will get canceled when
 				// the api response is returned
 				c.revalidate(context.WithoutCancel(ctx), key, refreshFromOrigin, op)
-			}
-			c.recordTiming(ctx, "cache_swr", "stale", start)
+			})
+			c.recordTiming(ctx, "cache_swr", c.timing.swrStale, start)
 			return e.Value, e.Hit, nil
 		}
 
@@ -356,8 +369,10 @@ func (c *cache[K, V]) SWR(
 	}
 
 	// Cache Miss - measure total time including all overhead
-	v, err := refreshFromOrigin(ctx)
-	c.recordTiming(ctx, "cache_swr", "miss", start)
+	v, err := c.fetchDeduped(key, func() (V, error) {
+		return refreshFromOrigin(ctx)
+	})
+	c.recordTiming(ctx, "cache_swr", c.timing.swrMiss, start)
 
 	switch op(err) {
 	case WriteValue:
@@ -432,9 +447,9 @@ func (c *cache[K, V]) SWRMany(
 
 	// Queue stale keys for background refresh
 	if len(staleKeys) > 0 {
-		c.revalidateC <- func() {
+		c.enqueueRevalidationBatch(func() {
 			c.revalidateMany(context.WithoutCancel(ctx), staleKeys, refreshFromOrigin, op)
-		}
+		})
 	}
 
 	// Fetch missing keys synchronously
@@ -502,22 +517,15 @@ func (c *cache[K, V]) SWRWithFallback(
 		// Found in cache
 		if now.Before(e.Fresh) {
 			// Fresh - return immediately
-			c.recordTiming(ctx, "cache_swr_fallback", "fresh", start)
+			c.recordTiming(ctx, "cache_swr_fallback", c.timing.swrFallbackFresh, start)
 			return e.Value, e.Hit, nil
 		}
 
 		if now.Before(e.Stale) {
-			// Stale - return but queue background revalidation with deduplication
-			c.inflightMu.Lock()
-			if !c.inflightRefreshes[key] {
-				c.inflightRefreshes[key] = true
-				dedupeKey := key // capture for closure
-				c.revalidateC <- func() {
-					c.revalidateWithCanonicalKey(context.WithoutCancel(ctx), dedupeKey, refreshFromOrigin, op)
-				}
-			}
-			c.inflightMu.Unlock()
-			c.recordTiming(ctx, "cache_swr_fallback", "stale", start)
+			c.enqueueRevalidation(key, func() {
+				c.revalidateWithCanonicalKey(context.WithoutCancel(ctx), key, refreshFromOrigin, op)
+			})
+			c.recordTiming(ctx, "cache_swr_fallback", c.timing.swrFallbackStale, start)
 			return e.Value, e.Hit, nil
 		}
 
@@ -526,23 +534,29 @@ func (c *cache[K, V]) SWRWithFallback(
 	}
 
 	// Cache miss on all candidates - fetch from origin
-	v, canonicalKey, err := refreshFromOrigin(ctx)
-	c.recordTiming(ctx, "cache_swr_fallback", "miss", start)
+	dedupeKey := candidates[0]
+	v, canonicalKey, err := c.fetchDedupedWithKey(dedupeKey, func() (V, K, error) {
+		return refreshFromOrigin(ctx)
+	})
+	c.recordTiming(ctx, "cache_swr_fallback", c.timing.swrFallbackMiss, start)
 
 	operation := op(err)
+	c.applyFallbackWrite(ctx, candidates, canonicalKey, dedupeKey, v, operation)
 
 	if err != nil {
 		var zero V
-		return zero, Miss, err
+		hit := Miss
+		if operation == WriteNull {
+			hit = Null
+		}
+		return zero, hit, err
 	}
 
 	var hit CacheHit
 	switch operation {
 	case WriteValue:
-		c.Set(ctx, canonicalKey, v)
 		hit = Hit
 	case WriteNull:
-		c.SetNull(ctx, canonicalKey)
 		hit = Null
 	case Noop:
 		hit = Miss
@@ -551,18 +565,40 @@ func (c *cache[K, V]) SWRWithFallback(
 	return v, hit, nil
 }
 
+func (c *cache[K, V]) applyFallbackWrite(
+	ctx context.Context,
+	candidates []K,
+	canonicalKey K,
+	dedupeKey K,
+	value V,
+	operation Op,
+) {
+	switch operation {
+	case WriteValue:
+		c.Set(ctx, canonicalKey, value)
+	case WriteNull:
+		cacheKey := canonicalKey
+		var zero K
+		if cacheKey == zero {
+			cacheKey = dedupeKey
+		}
+		c.SetNull(ctx, cacheKey)
+		for _, candidate := range candidates {
+			if candidate != cacheKey {
+				c.SetNull(ctx, candidate)
+			}
+		}
+	case Noop:
+		break
+	}
+}
+
 func (c *cache[K, V]) revalidateWithCanonicalKey(
 	ctx context.Context,
 	dedupeKey K,
 	refreshFromOrigin func(context.Context) (V, K, error),
 	op func(error) Op,
 ) {
-	defer func() {
-		c.inflightMu.Lock()
-		delete(c.inflightRefreshes, dedupeKey)
-		c.inflightMu.Unlock()
-	}()
-
 	metrics.CacheRevalidations.WithLabelValues(c.resource).Inc()
 	v, canonicalKey, err := refreshFromOrigin(ctx)
 
@@ -571,11 +607,17 @@ func (c *cache[K, V]) revalidateWithCanonicalKey(
 		return
 	}
 
-	switch op(err) {
+	operation := op(err)
+	switch operation {
 	case WriteValue:
 		c.Set(ctx, canonicalKey, v)
 	case WriteNull:
-		c.SetNull(ctx, canonicalKey)
+		cacheKey := canonicalKey
+		var zero K
+		if cacheKey == zero {
+			cacheKey = dedupeKey
+		}
+		c.SetNull(ctx, cacheKey)
 	case Noop:
 		break
 	}

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -2,6 +2,7 @@ package cache_test
 
 import (
 	"context"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -72,6 +73,28 @@ func TestRefresh(t *testing.T) {
 	}
 	require.LessOrEqual(t, refreshedFromOrigin.Load(), int32(5))
 
+}
+
+func TestCostWeigher(t *testing.T) {
+	c, err := cache.New(cache.Config[string, string]{
+		MaxSize:  100,
+		Cost:     func(v string) uint32 { return uint32(len(v)) },
+		Fresh:    time.Minute,
+		Stale:    time.Minute * 5,
+		Resource: "test",
+		Clock:    clock.New(),
+	})
+	require.NoError(t, err)
+
+	c.Set(context.Background(), "small", "x")
+	c.Set(context.Background(), "large", strings.Repeat("a", 90))
+
+	_, hit := c.Get(context.Background(), "small")
+	require.Equal(t, cache.Miss, hit)
+
+	value, hit := c.Get(context.Background(), "large")
+	require.Equal(t, cache.Hit, hit)
+	require.Equal(t, strings.Repeat("a", 90), value)
 }
 
 func TestNull(t *testing.T) {

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -2,7 +2,6 @@ package cache_test
 
 import (
 	"context"
-	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -77,8 +76,8 @@ func TestRefresh(t *testing.T) {
 
 func TestCostWeigher(t *testing.T) {
 	c, err := cache.New(cache.Config[string, string]{
-		MaxSize:  100,
-		Cost:     func(v string) uint32 { return uint32(len(v)) },
+		MaxSize:  1_000,
+		Cost:     func(v string) uint32 { return uint32(len(v)) + 1 },
 		Fresh:    time.Minute,
 		Stale:    time.Minute * 5,
 		Resource: "test",
@@ -86,15 +85,11 @@ func TestCostWeigher(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	c.Set(context.Background(), "small", "x")
-	c.Set(context.Background(), "large", strings.Repeat("a", 90))
+	c.Set(context.Background(), "key", "value")
 
-	_, hit := c.Get(context.Background(), "small")
-	require.Equal(t, cache.Miss, hit)
-
-	value, hit := c.Get(context.Background(), "large")
+	value, hit := c.Get(context.Background(), "key")
 	require.Equal(t, cache.Hit, hit)
-	require.Equal(t, strings.Repeat("a", 90), value)
+	require.Equal(t, "value", value)
 }
 
 func TestNull(t *testing.T) {

--- a/pkg/cache/fetch_dedup.go
+++ b/pkg/cache/fetch_dedup.go
@@ -1,0 +1,85 @@
+package cache
+
+import "sync"
+
+type fetchCall struct {
+	wg         sync.WaitGroup
+	result     any
+	err        error
+	panicValue any
+}
+
+// fetchDeduped runs fn once per key while concurrent callers wait and share
+// the result. Panics in fn are propagated to every waiter.
+func (c *cache[K, V]) fetchDeduped(key K, fn func() (V, error)) (V, error) {
+	value, err := c.fetchDedupedAny(key, func() (any, error) {
+		return fn()
+	})
+
+	typed, ok := value.(V)
+	if !ok {
+		var zero V
+		return zero, err
+	}
+	return typed, err
+}
+
+func (c *cache[K, V]) fetchDedupedWithKey(key K, fn func() (V, K, error)) (V, K, error) {
+	type paired struct {
+		value V
+		key   K
+	}
+
+	value, err := c.fetchDedupedAny(key, func() (any, error) {
+		v, cacheKey, fetchErr := fn()
+		return paired{value: v, key: cacheKey}, fetchErr
+	})
+
+	var zeroV V
+	var zeroK K
+	if err != nil {
+		return zeroV, zeroK, err
+	}
+
+	typed, ok := value.(paired)
+	if !ok {
+		return zeroV, zeroK, err
+	}
+	return typed.value, typed.key, err
+}
+
+func (c *cache[K, V]) fetchDedupedAny(key K, fn func() (any, error)) (any, error) {
+	c.fetchMu.Lock()
+	if call, ok := c.fetchInflight[key]; ok {
+		c.fetchMu.Unlock()
+		call.wg.Wait()
+		if call.panicValue != nil {
+			panic(call.panicValue)
+		}
+		return call.result, call.err
+	}
+
+	call := &fetchCall{ //nolint:exhaustruct // wg.Add runs before any waiter can observe zero state
+	}
+	call.wg.Add(1)
+	c.fetchInflight[key] = call
+	c.fetchMu.Unlock()
+
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				call.panicValue = r
+			}
+			c.fetchMu.Lock()
+			delete(c.fetchInflight, key)
+			c.fetchMu.Unlock()
+			call.wg.Done()
+		}()
+		call.result, call.err = fn()
+	}()
+
+	if call.panicValue != nil {
+		panic(call.panicValue)
+	}
+	return call.result, call.err
+}

--- a/pkg/cache/metrics/prometheus.go
+++ b/pkg/cache/metrics/prometheus.go
@@ -100,6 +100,18 @@ var (
 		[]string{"resource"},
 	)
 
+	// CacheRevalidationsDropped counts stale refreshes dropped because the
+	// revalidation queue was full or the key was already being refreshed.
+	CacheRevalidationsDropped = lazy.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "unkey",
+			Subsystem: "cache",
+			Name:      "revalidations_dropped_total",
+			Help:      "Stale cache revalidations dropped because the worker queue was full or the key was already refreshing.",
+		},
+		[]string{"resource"},
+	)
+
 	// CacheReadsErrorsTotal tracks the total number of cache read errors,
 	// labeled by resource type. Use this counter to monitor cache read error rates.
 	//

--- a/pkg/cache/middleware/tracing.go
+++ b/pkg/cache/middleware/tracing.go
@@ -20,7 +20,9 @@ func WithTracing[K comparable, V any](c cache.Cache[K, V]) cache.Cache[K, V] {
 func (mw *tracingMiddleware[K, V]) Get(ctx context.Context, key K) (V, cache.CacheHit) {
 	ctx, span := tracing.Start(ctx, "cache.Get")
 	defer span.End()
-	span.SetAttributes(attribute.String("key", fmt.Sprintf("%+v", key)))
+	if span.IsRecording() {
+		span.SetAttributes(attribute.String("key", fmt.Sprintf("%+v", key)))
+	}
 
 	value, hit := mw.next.Get(ctx, key)
 
@@ -57,7 +59,9 @@ func (mw *tracingMiddleware[K, V]) GetMany(ctx context.Context, keys []K) (map[K
 func (mw *tracingMiddleware[K, V]) Set(ctx context.Context, key K, value V) {
 	ctx, span := tracing.Start(ctx, "cache.Set")
 	defer span.End()
-	span.SetAttributes(attribute.String("key", fmt.Sprintf("%+v", key)))
+	if span.IsRecording() {
+		span.SetAttributes(attribute.String("key", fmt.Sprintf("%+v", key)))
+	}
 
 	mw.next.Set(ctx, key, value)
 }
@@ -74,7 +78,9 @@ func (mw *tracingMiddleware[K, V]) SetNull(ctx context.Context, key K) {
 	ctx, span := tracing.Start(ctx, "cache.SetNull")
 	defer span.End()
 
-	span.SetAttributes(attribute.String("key", fmt.Sprintf("%+v", key)))
+	if span.IsRecording() {
+		span.SetAttributes(attribute.String("key", fmt.Sprintf("%+v", key)))
+	}
 	mw.next.SetNull(ctx, key)
 }
 
@@ -89,10 +95,14 @@ func (mw *tracingMiddleware[K, V]) SetNullMany(ctx context.Context, keys []K) {
 func (mw *tracingMiddleware[K, V]) Remove(ctx context.Context, keys ...K) {
 	ctx, span := tracing.Start(ctx, "cache.Remove")
 	defer span.End()
-	span.SetAttributes(
-		attribute.String("keys", fmt.Sprintf("%+v", keys)),
-		attribute.Int("count", len(keys)),
-	)
+	if span.IsRecording() {
+		span.SetAttributes(
+			attribute.String("keys", fmt.Sprintf("%+v", keys)),
+			attribute.Int("count", len(keys)),
+		)
+	} else {
+		span.SetAttributes(attribute.Int("count", len(keys)))
+	}
 
 	mw.next.Remove(ctx, keys...)
 }
@@ -136,7 +146,9 @@ func (mw *tracingMiddleware[K, V]) Name() string {
 func (mw *tracingMiddleware[K, V]) SWR(ctx context.Context, key K, refreshFromOrigin func(ctx context.Context) (V, error), op func(err error) cache.Op) (V, cache.CacheHit, error) {
 	ctx, span := tracing.Start(ctx, "cache.SWR")
 	defer span.End()
-	span.SetAttributes(attribute.String("key", fmt.Sprintf("%v", key)))
+	if span.IsRecording() {
+		span.SetAttributes(attribute.String("key", fmt.Sprintf("%v", key)))
+	}
 
 	value, hit, err := mw.next.SWR(ctx, key, func(innerCtx context.Context) (V, error) {
 		innerCtx, innerSpan := tracing.Start(innerCtx, "refreshFromOrigin")

--- a/pkg/cache/revalidation.go
+++ b/pkg/cache/revalidation.go
@@ -1,0 +1,47 @@
+package cache
+
+import (
+	"github.com/unkeyed/unkey/pkg/cache/metrics"
+)
+
+const (
+	defaultRevalidationQueueSize = 1000
+	defaultRevalidationWorkers   = 10
+)
+
+// enqueueRevalidation schedules background refresh work for key. Duplicate
+// refreshes for the same key are dropped before enqueue. When the worker queue
+// is full the refresh is dropped instead of blocking the caller.
+func (c *cache[K, V]) enqueueRevalidation(key K, work func()) {
+	c.inflightMu.Lock()
+	if c.inflightRefreshes[key] {
+		c.inflightMu.Unlock()
+		return
+	}
+	c.inflightRefreshes[key] = true
+	c.inflightMu.Unlock()
+
+	select {
+	case c.revalidateC <- func() {
+		defer func() {
+			c.inflightMu.Lock()
+			delete(c.inflightRefreshes, key)
+			c.inflightMu.Unlock()
+		}()
+		work()
+	}:
+	default:
+		metrics.CacheRevalidationsDropped.WithLabelValues(c.resource).Inc()
+		c.inflightMu.Lock()
+		delete(c.inflightRefreshes, key)
+		c.inflightMu.Unlock()
+	}
+}
+
+func (c *cache[K, V]) enqueueRevalidationBatch(work func()) {
+	select {
+	case c.revalidateC <- work:
+	default:
+		metrics.CacheRevalidationsDropped.WithLabelValues(c.resource).Inc()
+	}
+}

--- a/pkg/cache/swr_test.go
+++ b/pkg/cache/swr_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -151,4 +153,121 @@ func TestSWR_CacheHit(t *testing.T) {
 		require.Equal(t, "", value)
 		require.Equal(t, cache.Miss, hit)
 	})
+}
+
+func TestSWR_StaleDoesNotBlockWhenQueueFull(t *testing.T) {
+	ctx := context.Background()
+	mockClock := clock.NewTestClock()
+
+	c, err := cache.New(cache.Config[string, string]{
+		Fresh:                 time.Second,
+		Stale:                 5 * time.Minute,
+		MaxSize:               100,
+		Resource:              "test",
+		Clock:                 mockClock,
+		RevalidationQueueSize: 1,
+		RevalidationWorkers:   0,
+	})
+	require.NoError(t, err)
+
+	for _, key := range []string{"key1", "key2"} {
+		_, _, err := c.SWR(ctx, key, func(ctx context.Context) (string, error) {
+			return key + "-value", nil
+		}, func(err error) cache.Op {
+			return cache.WriteValue
+		})
+		require.NoError(t, err)
+	}
+
+	mockClock.Tick(2 * time.Second)
+
+	start := time.Now()
+	_, hit, err := c.SWR(ctx, "key1", func(ctx context.Context) (string, error) {
+		time.Sleep(500 * time.Millisecond)
+		return "updated", nil
+	}, func(err error) cache.Op {
+		return cache.WriteValue
+	})
+	require.NoError(t, err)
+	require.Equal(t, cache.Hit, hit)
+	require.Less(t, time.Since(start), 100*time.Millisecond)
+
+	start = time.Now()
+	_, hit, err = c.SWR(ctx, "key2", func(ctx context.Context) (string, error) {
+		time.Sleep(500 * time.Millisecond)
+		return "updated", nil
+	}, func(err error) cache.Op {
+		return cache.WriteValue
+	})
+	require.NoError(t, err)
+	require.Equal(t, cache.Hit, hit)
+	require.Less(t, time.Since(start), 100*time.Millisecond)
+}
+
+func TestSWR_FetchDeduped(t *testing.T) {
+	ctx := context.Background()
+
+	c, err := cache.New(cache.Config[string, string]{
+		Fresh:    time.Minute,
+		Stale:    5 * time.Minute,
+		MaxSize:  100,
+		Resource: "test",
+		Clock:    clock.New(),
+	})
+	require.NoError(t, err)
+
+	var calls atomic.Int32
+	var wg sync.WaitGroup
+	for range 10 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _, err := c.SWR(ctx, "cold-key", func(ctx context.Context) (string, error) {
+				calls.Add(1)
+				time.Sleep(20 * time.Millisecond)
+				return "value", nil
+			}, func(err error) cache.Op {
+				return cache.WriteValue
+			})
+			require.NoError(t, err)
+		}()
+	}
+	wg.Wait()
+	require.Equal(t, int32(1), calls.Load())
+}
+
+func TestSWRWithFallback_NegativeCaching(t *testing.T) {
+	ctx := context.Background()
+
+	c, err := cache.New(cache.Config[string, string]{
+		Fresh:    time.Minute,
+		Stale:    5 * time.Minute,
+		MaxSize:  100,
+		Resource: "test",
+		Clock:    clock.New(),
+	})
+	require.NoError(t, err)
+
+	candidates := []string{"missing.example.com", "*.example.com"}
+	op := func(err error) cache.Op {
+		if db.IsNotFound(err) {
+			return cache.WriteNull
+		}
+		return cache.Noop
+	}
+
+	_, hit, err := c.SWRWithFallback(ctx, candidates, func(ctx context.Context) (string, string, error) {
+		return "", "", sql.ErrNoRows
+	}, op)
+	require.Error(t, err)
+	require.Equal(t, cache.Null, hit)
+
+	var calls atomic.Int32
+	_, hit, err = c.SWRWithFallback(ctx, candidates, func(ctx context.Context) (string, string, error) {
+		calls.Add(1)
+		return "", "", sql.ErrNoRows
+	}, op)
+	require.NoError(t, err)
+	require.Equal(t, int32(0), calls.Load())
+	require.Equal(t, cache.Null, hit)
 }

--- a/pkg/cache/timing_attrs.go
+++ b/pkg/cache/timing_attrs.go
@@ -1,0 +1,27 @@
+package cache
+
+type timingAttrs struct {
+	getMiss         map[string]string
+	getFresh        map[string]string
+	getStale        map[string]string
+	swrFresh        map[string]string
+	swrStale        map[string]string
+	swrMiss         map[string]string
+	swrFallbackFresh map[string]string
+	swrFallbackStale map[string]string
+	swrFallbackMiss  map[string]string
+}
+
+func newTimingAttrs(resource string) timingAttrs {
+	return timingAttrs{
+		getMiss:          map[string]string{"cache": resource, "status": "miss"},
+		getFresh:         map[string]string{"cache": resource, "status": "fresh"},
+		getStale:         map[string]string{"cache": resource, "status": "stale"},
+		swrFresh:         map[string]string{"cache": resource, "status": "fresh"},
+		swrStale:         map[string]string{"cache": resource, "status": "stale"},
+		swrMiss:          map[string]string{"cache": resource, "status": "miss"},
+		swrFallbackFresh: map[string]string{"cache": resource, "status": "fresh"},
+		swrFallbackStale: map[string]string{"cache": resource, "status": "stale"},
+		swrFallbackMiss:  map[string]string{"cache": resource, "status": "miss"},
+	}
+}

--- a/svc/frontline/internal/caches/BUILD.bazel
+++ b/svc/frontline/internal/caches/BUILD.bazel
@@ -2,7 +2,11 @@ load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "caches",
-    srcs = ["caches.go"],
+    srcs = [
+        "caches.go",
+        "cost.go",
+        "policies.go",
+    ],
     importpath = "github.com/unkeyed/unkey/svc/frontline/internal/caches",
     visibility = ["//visibility:public"],
     deps = [

--- a/svc/frontline/internal/caches/caches.go
+++ b/svc/frontline/internal/caches/caches.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"time"
 
-	frontlinev1 "github.com/unkeyed/unkey/gen/proto/frontline/v1"
 	"github.com/unkeyed/unkey/pkg/cache"
 	"github.com/unkeyed/unkey/pkg/cache/middleware"
 	"github.com/unkeyed/unkey/pkg/clock"
@@ -24,7 +23,7 @@ type Caches struct {
 
 	// DeploymentID -> Parsed sentinel policies. Cached to avoid re-parsing
 	// the protojson SentinelConfig on every request.
-	Policies cache.Cache[string, []*frontlinev1.Policy]
+	Policies cache.Cache[string, CachedPolicies]
 
 	// HostName -> Certificate
 	TLSCertificates cache.Cache[string, tls.Certificate]
@@ -64,11 +63,11 @@ func New(config Config) (*Caches, error) {
 		return nil, fmt.Errorf("failed to create frontline route cache: %w", err)
 	}
 
-	policies, err := cache.New(cache.Config[string, []*frontlinev1.Policy]{
+	policies, err := cache.New(cache.Config[string, CachedPolicies]{
 		Fresh:    30 * time.Second,
 		Stale:    5 * time.Minute,
 		MaxSize:  policiesCacheByteBudget,
-		Cost:     policiesCost,
+		Cost:     cachedPoliciesCost,
 		Resource: "policies",
 		Clock:    config.Clock,
 	})

--- a/svc/frontline/internal/caches/caches.go
+++ b/svc/frontline/internal/caches/caches.go
@@ -53,7 +53,7 @@ func New(config Config) (*Caches, error) {
 	}
 
 	frontlineRoute, err := cache.New(cache.Config[string, db.FindFrontlineRouteByFQDNRow]{
-		Fresh:    5 * time.Second,
+		Fresh:    30 * time.Second,
 		Stale:    5 * time.Minute,
 		MaxSize:  10_000,
 		Resource: "frontline_route",

--- a/svc/frontline/internal/caches/caches.go
+++ b/svc/frontline/internal/caches/caches.go
@@ -79,6 +79,7 @@ func New(config Config) (*Caches, error) {
 		Fresh:    10 * time.Second,
 		Stale:    60 * time.Second,
 		MaxSize:  10_000,
+		Cost:     nil,
 		Resource: "instances_by_deployment",
 		Clock:    config.Clock,
 	})
@@ -90,6 +91,7 @@ func New(config Config) (*Caches, error) {
 		Fresh:    time.Hour,
 		Stale:    time.Hour * 12,
 		MaxSize:  10_000,
+		Cost:     nil,
 		Resource: "tls_certificate",
 		Clock:    config.Clock,
 	})

--- a/svc/frontline/internal/caches/caches.go
+++ b/svc/frontline/internal/caches/caches.go
@@ -55,7 +55,8 @@ func New(config Config) (*Caches, error) {
 	frontlineRoute, err := cache.New(cache.Config[string, db.FindFrontlineRouteByFQDNRow]{
 		Fresh:    30 * time.Second,
 		Stale:    5 * time.Minute,
-		MaxSize:  10_000,
+		MaxSize:  routeCacheByteBudget,
+		Cost:     frontlineRouteCost,
 		Resource: "frontline_route",
 		Clock:    config.Clock,
 	})
@@ -66,7 +67,8 @@ func New(config Config) (*Caches, error) {
 	policies, err := cache.New(cache.Config[string, []*frontlinev1.Policy]{
 		Fresh:    30 * time.Second,
 		Stale:    5 * time.Minute,
-		MaxSize:  10_000,
+		MaxSize:  policiesCacheByteBudget,
+		Cost:     policiesCost,
 		Resource: "policies",
 		Clock:    config.Clock,
 	})

--- a/svc/frontline/internal/caches/cost.go
+++ b/svc/frontline/internal/caches/cost.go
@@ -1,0 +1,39 @@
+package caches
+
+import (
+	"math"
+
+	frontlinev1 "github.com/unkeyed/unkey/gen/proto/frontline/v1"
+	"github.com/unkeyed/unkey/svc/frontline/internal/db"
+)
+
+const (
+	// Byte budgets for caches whose entry sizes vary widely.
+	routeCacheByteBudget    = 32_000_000
+	policiesCacheByteBudget = 64_000_000
+)
+
+func frontlineRouteCost(route db.FindFrontlineRouteByFQDNRow) uint32 {
+	const fixedOverhead = uint32(256)
+	return addUint32Clamped(fixedOverhead, uint32(len(route.SentinelConfig)))
+}
+
+func policiesCost(policies []*frontlinev1.Policy) uint32 {
+	var n uint32 = 64
+	for _, policy := range policies {
+		n = addUint32Clamped(n, 64)
+		openapi, ok := policy.GetConfig().(*frontlinev1.Policy_Openapi)
+		if !ok {
+			continue
+		}
+		n = addUint32Clamped(n, uint32(len(openapi.Openapi.SpecYaml)))
+	}
+	return n
+}
+
+func addUint32Clamped(a, b uint32) uint32 {
+	if a > math.MaxUint32-b {
+		return math.MaxUint32
+	}
+	return a + b
+}

--- a/svc/frontline/internal/caches/cost.go
+++ b/svc/frontline/internal/caches/cost.go
@@ -31,6 +31,13 @@ func policiesCost(policies []*frontlinev1.Policy) uint32 {
 	return n
 }
 
+func cachedPoliciesCost(entry CachedPolicies) uint32 {
+	if entry.Err != nil {
+		return 64
+	}
+	return policiesCost(entry.Policies)
+}
+
 func addUint32Clamped(a, b uint32) uint32 {
 	if a > math.MaxUint32-b {
 		return math.MaxUint32

--- a/svc/frontline/internal/caches/policies.go
+++ b/svc/frontline/internal/caches/policies.go
@@ -1,0 +1,10 @@
+package caches
+
+import frontlinev1 "github.com/unkeyed/unkey/gen/proto/frontline/v1"
+
+// CachedPolicies is the policies cache value. Err is set when sentinel_config
+// fails to parse; callers must still fail the request with that error.
+type CachedPolicies struct {
+	Policies []*frontlinev1.Policy
+	Err      error
+}

--- a/svc/frontline/internal/policies/openapi/executor.go
+++ b/svc/frontline/internal/policies/openapi/executor.go
@@ -23,6 +23,7 @@ func New(clk clock.Clock) (*Executor, error) {
 		Fresh:    time.Hour,
 		Stale:    24 * time.Hour,
 		MaxSize:  64,
+		Cost:     nil,
 		Resource: "openapi_validators",
 		Clock:    clk,
 	})

--- a/svc/frontline/internal/router/BUILD.bazel
+++ b/svc/frontline/internal/router/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "router",
@@ -20,8 +20,22 @@ go_library(
         "//pkg/fault",
         "//pkg/mysql",
         "//pkg/prometheus/lazy",
+        "//svc/frontline/internal/caches",
         "//svc/frontline/internal/db",
         "//svc/frontline/internal/policies",
         "@com_github_prometheus_client_golang//prometheus",
+    ],
+)
+
+go_test(
+    name = "router_test",
+    srcs = ["lookup_test.go"],
+    embed = [":router"],
+    deps = [
+        "//pkg/cache",
+        "//pkg/clock",
+        "//svc/frontline/internal/caches",
+        "//svc/frontline/internal/db",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/svc/frontline/internal/router/interface.go
+++ b/svc/frontline/internal/router/interface.go
@@ -5,6 +5,7 @@ import (
 
 	frontlinev1 "github.com/unkeyed/unkey/gen/proto/frontline/v1"
 	"github.com/unkeyed/unkey/pkg/cache"
+	"github.com/unkeyed/unkey/svc/frontline/internal/caches"
 	"github.com/unkeyed/unkey/svc/frontline/internal/db"
 )
 
@@ -60,5 +61,5 @@ type Config struct {
 	DB                    db.Querier
 	FrontlineRouteCache   cache.Cache[string, db.FindFrontlineRouteByFQDNRow]
 	InstancesByDeployment cache.Cache[string, []db.FindInstancesByDeploymentIDRow]
-	PolicyCache           cache.Cache[string, []*frontlinev1.Policy]
+	PolicyCache           cache.Cache[string, caches.CachedPolicies]
 }

--- a/svc/frontline/internal/router/lookup.go
+++ b/svc/frontline/internal/router/lookup.go
@@ -10,6 +10,7 @@ import (
 	"github.com/unkeyed/unkey/pkg/codes"
 	"github.com/unkeyed/unkey/pkg/fault"
 	"github.com/unkeyed/unkey/pkg/mysql"
+	"github.com/unkeyed/unkey/svc/frontline/internal/caches"
 	"github.com/unkeyed/unkey/svc/frontline/internal/db"
 	"github.com/unkeyed/unkey/svc/frontline/internal/policies"
 )
@@ -64,17 +65,17 @@ func (s *service) getInstances(ctx context.Context, deploymentID string) ([]db.F
 // OpenAPI policies that carry no inline spec are hydrated from the scraped
 // spec in openapi_specs, keyed by deployment_id.
 func (s *service) getPolicies(ctx context.Context, route db.FindFrontlineRouteByFQDNRow) ([]*frontlinev1.Policy, error) {
-	pols, hit, err := s.policyCache.SWR(ctx, route.DeploymentID, func(ctx context.Context) ([]*frontlinev1.Policy, error) {
+	cached, hit, err := s.policyCache.SWR(ctx, route.DeploymentID, func(ctx context.Context) (caches.CachedPolicies, error) {
 		parsed, parseErr := policies.ParseMiddleware(route.SentinelConfig)
 		if parseErr != nil {
-			return nil, parseErr
+			return caches.CachedPolicies{Err: parseErr}, nil
 		}
 
 		if err := s.hydrateOpenapiSpecs(ctx, route.DeploymentID, parsed); err != nil {
-			return nil, err
+			return caches.CachedPolicies{}, err
 		}
 
-		return parsed, nil
+		return caches.CachedPolicies{Policies: parsed}, nil
 	}, func(err error) cache.Op {
 		if err != nil {
 			return cache.Noop
@@ -90,7 +91,11 @@ func (s *service) getPolicies(ctx context.Context, route db.FindFrontlineRouteBy
 		return nil, nil
 	}
 
-	return pols, nil
+	if cached.Err != nil {
+		return nil, cached.Err
+	}
+
+	return cached.Policies, nil
 }
 
 // hydrateOpenapiSpecs loads the spec from openapi_specs (keyed by deployment_id)

--- a/svc/frontline/internal/router/lookup.go
+++ b/svc/frontline/internal/router/lookup.go
@@ -68,14 +68,14 @@ func (s *service) getPolicies(ctx context.Context, route db.FindFrontlineRouteBy
 	cached, hit, err := s.policyCache.SWR(ctx, route.DeploymentID, func(ctx context.Context) (caches.CachedPolicies, error) {
 		parsed, parseErr := policies.ParseMiddleware(route.SentinelConfig)
 		if parseErr != nil {
-			return caches.CachedPolicies{Err: parseErr}, nil
+			return caches.CachedPolicies{Policies: nil, Err: parseErr}, nil
 		}
 
 		if err := s.hydrateOpenapiSpecs(ctx, route.DeploymentID, parsed); err != nil {
-			return caches.CachedPolicies{}, err
+			return caches.CachedPolicies{Policies: nil, Err: nil}, err
 		}
 
-		return caches.CachedPolicies{Policies: parsed}, nil
+		return caches.CachedPolicies{Policies: parsed, Err: nil}, nil
 	}, func(err error) cache.Op {
 		if err != nil {
 			return cache.Noop

--- a/svc/frontline/internal/router/lookup_test.go
+++ b/svc/frontline/internal/router/lookup_test.go
@@ -1,0 +1,47 @@
+package router
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/unkeyed/unkey/pkg/cache"
+	"github.com/unkeyed/unkey/pkg/clock"
+	"github.com/unkeyed/unkey/svc/frontline/internal/caches"
+	"github.com/unkeyed/unkey/svc/frontline/internal/db"
+)
+
+func TestGetPolicies_CachesParseErrorWithoutFailingOpen(t *testing.T) {
+	t.Parallel()
+
+	policyCache, err := cache.New(cache.Config[string, caches.CachedPolicies]{
+		Fresh:    30 * time.Second,
+		Stale:    5 * time.Minute,
+		MaxSize:  64_000_000,
+		Resource: "policies_test",
+		Clock:    clock.New(),
+	})
+	require.NoError(t, err)
+
+	s := &service{
+		policyCache: policyCache,
+	}
+
+	route := db.FindFrontlineRouteByFQDNRow{
+		DeploymentID:   "dep_broken",
+		SentinelConfig: []byte(`not-valid-sentinel-config`),
+	}
+
+	ctx := context.Background()
+
+	_, err = s.getPolicies(ctx, route)
+	require.Error(t, err)
+
+	_, hit := policyCache.Get(ctx, route.DeploymentID)
+	require.Equal(t, cache.Hit, hit)
+
+	_, err = s.getPolicies(ctx, route)
+	require.Error(t, err)
+}

--- a/svc/frontline/internal/router/service.go
+++ b/svc/frontline/internal/router/service.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"time"
 
-	frontlinev1 "github.com/unkeyed/unkey/gen/proto/frontline/v1"
 	"github.com/unkeyed/unkey/pkg/cache"
+	"github.com/unkeyed/unkey/svc/frontline/internal/caches"
 	"github.com/unkeyed/unkey/svc/frontline/internal/db"
 )
 
@@ -17,7 +17,7 @@ type service struct {
 	db                         db.Querier
 	frontlineRouteCache        cache.Cache[string, db.FindFrontlineRouteByFQDNRow]
 	instancesByDeploymentCache cache.Cache[string, []db.FindInstancesByDeploymentIDRow]
-	policyCache                cache.Cache[string, []*frontlinev1.Policy]
+	policyCache                cache.Cache[string, caches.CachedPolicies]
 }
 
 var _ Service = (*service)(nil)

--- a/svc/frontline/run.go
+++ b/svc/frontline/run.go
@@ -474,6 +474,7 @@ func buildEngine(
 		Fresh:    10 * time.Second,
 		Stale:    10 * time.Minute,
 		MaxSize:  100_000,
+		Cost:     nil,
 		Resource: "frontline_key_cache",
 		Clock:    clk,
 	})


### PR DESCRIPTION
### What 

This adds some small improvments to the cache pkg

1. When a cache netry goes stale we  did a **blocking send** into our 1000-slot revalidation channel (10 workers) and only deduped in the worker itself not in the channel so hitting the same stale key blocked the send at some point.
Now we dedupe before enqueue and we drop any revalidations when the queue is full.

2. Fixes negative caching
We computed `op(err)` but returned the error before we wrote, so `sql.ErrNoRows → WriteNull` never got stored. 

So now we apply the write before the early return.

3. We now singleflight cold keys so if we get the same swr and have misses for multiple keys we just do one get and await it on all instances. 

4. Small improvment to the getpath to stop using sprintf...

5. add a cost function so we can weigh openapi specs and make em drop sooner/later.

---

## Verification

```bash
mise run bazel
mise exec -- bazel test //pkg/cache/... //svc/frontline/internal/router:router_test //svc/frontline/internal/caches:caches
```