### PR TITLE
feat(api): free-form search for projects list

### DIFF
--- a/pkg/db/project_list_by_workspace.sql_generated.go
+++ b/pkg/db/project_list_by_workspace.sql_generated.go
@@ -22,14 +22,17 @@ SELECT
 FROM projects
 WHERE workspace_id = ?
   AND id >= ?
+  -- search is a pre-escaped LIKE pattern built by mysql.SearchContains; NULL disables the filter
+  AND (? IS NULL OR id LIKE ? OR name LIKE ? OR slug LIKE ?)
 ORDER BY id ASC
 LIMIT ?
 `
 
 type ListProjectsByWorkspaceIdParams struct {
-	WorkspaceID string `db:"workspace_id"`
-	IDCursor    string `db:"id_cursor"`
-	Limit       int32  `db:"limit"`
+	WorkspaceID string         `db:"workspace_id"`
+	IDCursor    string         `db:"id_cursor"`
+	Search      sql.NullString `db:"search"`
+	Limit       int32          `db:"limit"`
 }
 
 type ListProjectsByWorkspaceIdRow struct {
@@ -55,10 +58,20 @@ type ListProjectsByWorkspaceIdRow struct {
 //	FROM projects
 //	WHERE workspace_id = ?
 //	  AND id >= ?
+//	  -- search is a pre-escaped LIKE pattern built by mysql.SearchContains; NULL disables the filter
+//	  AND (? IS NULL OR id LIKE ? OR name LIKE ? OR slug LIKE ?)
 //	ORDER BY id ASC
 //	LIMIT ?
 func (q *Queries) ListProjectsByWorkspaceId(ctx context.Context, db DBTX, arg ListProjectsByWorkspaceIdParams) ([]ListProjectsByWorkspaceIdRow, error) {
-	rows, err := db.QueryContext(ctx, listProjectsByWorkspaceId, arg.WorkspaceID, arg.IDCursor, arg.Limit)
+	rows, err := db.QueryContext(ctx, listProjectsByWorkspaceId,
+		arg.WorkspaceID,
+		arg.IDCursor,
+		arg.Search,
+		arg.Search,
+		arg.Search,
+		arg.Search,
+		arg.Limit,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/db/querier_generated.go
+++ b/pkg/db/querier_generated.go
@@ -2666,6 +2666,8 @@ type Querier interface {
 	//  FROM projects
 	//  WHERE workspace_id = ?
 	//    AND id >= ?
+	//    -- search is a pre-escaped LIKE pattern built by mysql.SearchContains; NULL disables the filter
+	//    AND (? IS NULL OR id LIKE ? OR name LIKE ? OR slug LIKE ?)
 	//  ORDER BY id ASC
 	//  LIMIT ?
 	ListProjectsByWorkspaceId(ctx context.Context, db DBTX, arg ListProjectsByWorkspaceIdParams) ([]ListProjectsByWorkspaceIdRow, error)

--- a/pkg/db/queries/project_list_by_workspace.sql
+++ b/pkg/db/queries/project_list_by_workspace.sql
@@ -10,5 +10,7 @@ SELECT
 FROM projects
 WHERE workspace_id = sqlc.arg(workspace_id)
   AND id >= sqlc.arg(id_cursor)
+  -- search is a pre-escaped LIKE pattern built by mysql.SearchContains; NULL disables the filter
+  AND (sqlc.narg(search) IS NULL OR id LIKE sqlc.narg(search) OR name LIKE sqlc.narg(search) OR slug LIKE sqlc.narg(search))
 ORDER BY id ASC
 LIMIT ?;

--- a/svc/api/openapi/gen.go
+++ b/svc/api/openapi/gen.go
@@ -2593,6 +2593,9 @@ type V2ProjectsListProjectsRequestBody struct {
 	// Limit Maximum number of projects to return per request.
 	// Balance between response size and number of pagination calls needed.
 	Limit *int `json:"limit,omitempty"`
+
+	// Search Free-form text to filter projects. Returns projects whose ID, name, or slug contains the search string. Matching is case-insensitive.
+	Search *string `json:"search,omitempty"`
 }
 
 // V2ProjectsListProjectsResponseBody defines model for V2ProjectsListProjectsResponseBody.

--- a/svc/api/openapi/openapi-generated.yaml
+++ b/svc/api/openapi/openapi-generated.yaml
@@ -2365,6 +2365,11 @@ components:
                         Pagination cursor from a previous response to fetch the next page.
                         Use when `hasMore: true` in the previous response.
                     example: proj_1234abcd
+                search:
+                    type: string
+                    maxLength: 256
+                    description: Free-form text to filter projects. Returns projects whose ID, name, or slug contains the search string. Matching is case-insensitive.
+                    example: billing-service
             additionalProperties: false
         V2ProjectsListProjectsResponseBody:
             type: object

--- a/svc/api/openapi/spec/paths/v2/projects/listProjects/V2ProjectsListProjectsRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/projects/listProjects/V2ProjectsListProjectsRequestBody.yaml
@@ -14,6 +14,12 @@ properties:
       Pagination cursor from a previous response to fetch the next page.
       Use when `hasMore: true` in the previous response.
     example: proj_1234abcd
+  search:
+    type: string
+    maxLength: 256
+    description: Free-form text to filter projects. Returns projects whose ID,
+      name, or slug contains the search string. Matching is case-insensitive.
+    example: billing-service
 additionalProperties: false
 examples:
   basic:

--- a/svc/api/routes/v2_projects_list_projects/200_test.go
+++ b/svc/api/routes/v2_projects_list_projects/200_test.go
@@ -191,3 +191,83 @@ func TestListProjectsWorkspaceIsolation(t *testing.T) {
 		}
 	})
 }
+
+func TestListProjectsSearch(t *testing.T) {
+	h := testutil.NewHarness(t)
+
+	route := &handler.Handler{DB: h.DB}
+	h.Register(route)
+
+	// Fresh workspace so search results are not polluted by other tests
+	workspace := h.CreateWorkspace()
+	rootKey := h.CreateRootKey(workspace.ID, "project.*.read_project")
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}
+
+	seeded := []struct {
+		Name string
+		Slug string
+	}{
+		{"Billing Service", "billing-service"},
+		{"Web Frontend", "web-frontend"},
+		{"Reports 100%", "reports-full"},
+	}
+	projectIDs := make(map[string]string)
+	for _, p := range seeded {
+		project := h.CreateProject(seed.CreateProjectRequest{
+			ID:          uid.New(uid.ProjectPrefix),
+			WorkspaceID: workspace.ID,
+			Name:        p.Name,
+			Slug:        p.Slug,
+		})
+		projectIDs[p.Name] = project.ID
+	}
+
+	list := func(t *testing.T, search string) []string {
+		t.Helper()
+		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{
+			Search: ptr.P(search),
+		})
+		require.Equal(t, 200, res.Status, "expected 200, received: %s", res.RawBody)
+		names := make([]string, 0, len(res.Body.Data))
+		for _, p := range res.Body.Data {
+			names = append(names, p.Name)
+		}
+		return names
+	}
+
+	t.Run("matches name substring", func(t *testing.T) {
+		require.Equal(t, []string{"Billing Service"}, list(t, "billing"))
+	})
+
+	t.Run("matches slug substring", func(t *testing.T) {
+		require.Equal(t, []string{"Web Frontend"}, list(t, "web-frontend"))
+	})
+
+	t.Run("matches project id", func(t *testing.T) {
+		require.Equal(t, []string{"Reports 100%"}, list(t, projectIDs["Reports 100%"]))
+	})
+
+	t.Run("is case insensitive", func(t *testing.T) {
+		require.Equal(t, []string{"Billing Service"}, list(t, "BILLING"))
+	})
+
+	t.Run("wildcards match literally", func(t *testing.T) {
+		// Unescaped, "%" would match every project and "s_rvice" would match "Service"
+		require.Equal(t, []string{"Reports 100%"}, list(t, "100%"))
+		require.Empty(t, list(t, "s_rvice"))
+	})
+
+	t.Run("no matches returns empty list", func(t *testing.T) {
+		require.Empty(t, list(t, "does-not-exist"))
+	})
+
+	t.Run("whitespace-only search returns all", func(t *testing.T) {
+		require.ElementsMatch(t,
+			[]string{"Billing Service", "Web Frontend", "Reports 100%"},
+			list(t, "   "),
+		)
+	})
+}

--- a/svc/api/routes/v2_projects_list_projects/400_test.go
+++ b/svc/api/routes/v2_projects_list_projects/400_test.go
@@ -32,6 +32,7 @@ func TestListProjectsBadRequest(t *testing.T) {
 	}{
 		{name: "limit below minimum", req: handler.Request{Limit: ptr.P(0)}},
 		{name: "limit above maximum", req: handler.Request{Limit: ptr.P(101)}},
+		{name: "search above max length", req: handler.Request{Search: ptr.P(strings.Repeat("a", 257))}},
 	}
 
 	for _, tc := range testCases {

--- a/svc/api/routes/v2_projects_list_projects/BUILD.bazel
+++ b/svc/api/routes/v2_projects_list_projects/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//pkg/codes",
         "//pkg/db",
         "//pkg/fault",
+        "//pkg/mysql",
         "//pkg/ptr",
         "//pkg/rbac",
         "//pkg/zen",

--- a/svc/api/routes/v2_projects_list_projects/handler.go
+++ b/svc/api/routes/v2_projects_list_projects/handler.go
@@ -3,10 +3,12 @@ package handler
 import (
 	"context"
 	"net/http"
+	"strings"
 
 	"github.com/unkeyed/unkey/pkg/codes"
 	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/fault"
+	"github.com/unkeyed/unkey/pkg/mysql"
 	"github.com/unkeyed/unkey/pkg/ptr"
 	"github.com/unkeyed/unkey/pkg/rbac"
 	"github.com/unkeyed/unkey/pkg/zen"
@@ -56,10 +58,12 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 	limit := ptr.SafeDeref(req.Limit, 100)
 	cursor := ptr.SafeDeref(req.Cursor, "")
+	search := mysql.SearchContains(strings.TrimSpace(ptr.SafeDeref(req.Search)))
 
 	rows, err := db.Query.ListProjectsByWorkspaceId(ctx, h.DB.RO(), db.ListProjectsByWorkspaceIdParams{
 		WorkspaceID: principal.WorkspaceID,
 		IDCursor:    cursor,
+		Search:      search,
 		Limit:       int32(limit + 1), // nolint:gosec
 	})
 	if err != nil {


### PR DESCRIPTION
Adds a `search` field to `POST /v2/projects.listProjects`, following the identities implementation (#6639).

- Contains-match on `id`, `name`, or `slug`, case-insensitive.
- LIKE wildcards in the input are escaped via `mysql.SearchContains`, so they match literally.
- Max length 256, schema-validated. Empty or whitespace-only input applies no filter.
- Cursor pagination unchanged.

Stacked on #6641.
