### PR TITLE
feat(api): free-form search for apps list

### DIFF
--- a/pkg/db/app_list_by_project.sql_generated.go
+++ b/pkg/db/app_list_by_project.sql_generated.go
@@ -7,6 +7,7 @@ package db
 
 import (
 	"context"
+	"database/sql"
 )
 
 const listAppsByProject = `-- name: ListAppsByProject :many
@@ -14,14 +15,17 @@ SELECT apps.pk, apps.id, apps.workspace_id, apps.project_id, apps.name, apps.slu
 FROM apps
 WHERE project_id = ?
   AND id >= ?
+  -- search is a pre-escaped LIKE pattern built by mysql.SearchContains; NULL disables the filter
+  AND (? IS NULL OR id LIKE ? OR name LIKE ? OR slug LIKE ?)
 ORDER BY id ASC
 LIMIT ?
 `
 
 type ListAppsByProjectParams struct {
-	ProjectID string `db:"project_id"`
-	IDCursor  string `db:"id_cursor"`
-	Limit     int32  `db:"limit"`
+	ProjectID string         `db:"project_id"`
+	IDCursor  string         `db:"id_cursor"`
+	Search    sql.NullString `db:"search"`
+	Limit     int32          `db:"limit"`
 }
 
 // ListAppsByProject
@@ -30,10 +34,20 @@ type ListAppsByProjectParams struct {
 //	FROM apps
 //	WHERE project_id = ?
 //	  AND id >= ?
+//	  -- search is a pre-escaped LIKE pattern built by mysql.SearchContains; NULL disables the filter
+//	  AND (? IS NULL OR id LIKE ? OR name LIKE ? OR slug LIKE ?)
 //	ORDER BY id ASC
 //	LIMIT ?
 func (q *Queries) ListAppsByProject(ctx context.Context, db DBTX, arg ListAppsByProjectParams) ([]App, error) {
-	rows, err := db.QueryContext(ctx, listAppsByProject, arg.ProjectID, arg.IDCursor, arg.Limit)
+	rows, err := db.QueryContext(ctx, listAppsByProject,
+		arg.ProjectID,
+		arg.IDCursor,
+		arg.Search,
+		arg.Search,
+		arg.Search,
+		arg.Search,
+		arg.Limit,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/db/project_list_by_workspace.sql_generated.go
+++ b/pkg/db/project_list_by_workspace.sql_generated.go
@@ -22,14 +22,17 @@ SELECT
 FROM projects
 WHERE workspace_id = ?
   AND id >= ?
+  -- search is a pre-escaped LIKE pattern built by mysql.SearchContains; NULL disables the filter
+  AND (? IS NULL OR id LIKE ? OR name LIKE ? OR slug LIKE ?)
 ORDER BY id ASC
 LIMIT ?
 `
 
 type ListProjectsByWorkspaceIdParams struct {
-	WorkspaceID string `db:"workspace_id"`
-	IDCursor    string `db:"id_cursor"`
-	Limit       int32  `db:"limit"`
+	WorkspaceID string         `db:"workspace_id"`
+	IDCursor    string         `db:"id_cursor"`
+	Search      sql.NullString `db:"search"`
+	Limit       int32          `db:"limit"`
 }
 
 type ListProjectsByWorkspaceIdRow struct {
@@ -55,10 +58,20 @@ type ListProjectsByWorkspaceIdRow struct {
 //	FROM projects
 //	WHERE workspace_id = ?
 //	  AND id >= ?
+//	  -- search is a pre-escaped LIKE pattern built by mysql.SearchContains; NULL disables the filter
+//	  AND (? IS NULL OR id LIKE ? OR name LIKE ? OR slug LIKE ?)
 //	ORDER BY id ASC
 //	LIMIT ?
 func (q *Queries) ListProjectsByWorkspaceId(ctx context.Context, db DBTX, arg ListProjectsByWorkspaceIdParams) ([]ListProjectsByWorkspaceIdRow, error) {
-	rows, err := db.QueryContext(ctx, listProjectsByWorkspaceId, arg.WorkspaceID, arg.IDCursor, arg.Limit)
+	rows, err := db.QueryContext(ctx, listProjectsByWorkspaceId,
+		arg.WorkspaceID,
+		arg.IDCursor,
+		arg.Search,
+		arg.Search,
+		arg.Search,
+		arg.Search,
+		arg.Limit,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/db/querier_generated.go
+++ b/pkg/db/querier_generated.go
@@ -2666,6 +2666,8 @@ type Querier interface {
 	//  FROM projects
 	//  WHERE workspace_id = ?
 	//    AND id >= ?
+	//    -- search is a pre-escaped LIKE pattern built by mysql.SearchContains; NULL disables the filter
+	//    AND (? IS NULL OR id LIKE ? OR name LIKE ? OR slug LIKE ?)
 	//  ORDER BY id ASC
 	//  LIMIT ?
 	ListProjectsByWorkspaceId(ctx context.Context, db DBTX, arg ListProjectsByWorkspaceIdParams) ([]ListProjectsByWorkspaceIdRow, error)

--- a/pkg/db/querier_generated.go
+++ b/pkg/db/querier_generated.go
@@ -2259,6 +2259,8 @@ type Querier interface {
 	//  FROM apps
 	//  WHERE project_id = ?
 	//    AND id >= ?
+	//    -- search is a pre-escaped LIKE pattern built by mysql.SearchContains; NULL disables the filter
+	//    AND (? IS NULL OR id LIKE ? OR name LIKE ? OR slug LIKE ?)
 	//  ORDER BY id ASC
 	//  LIMIT ?
 	ListAppsByProject(ctx context.Context, db DBTX, arg ListAppsByProjectParams) ([]App, error)

--- a/pkg/db/queries/app_list_by_project.sql
+++ b/pkg/db/queries/app_list_by_project.sql
@@ -3,5 +3,7 @@ SELECT apps.*
 FROM apps
 WHERE project_id = sqlc.arg(project_id)
   AND id >= sqlc.arg(id_cursor)
+  -- search is a pre-escaped LIKE pattern built by mysql.SearchContains; NULL disables the filter
+  AND (sqlc.narg(search) IS NULL OR id LIKE sqlc.narg(search) OR name LIKE sqlc.narg(search) OR slug LIKE sqlc.narg(search))
 ORDER BY id ASC
 LIMIT ?;

--- a/pkg/db/queries/project_list_by_workspace.sql
+++ b/pkg/db/queries/project_list_by_workspace.sql
@@ -10,5 +10,7 @@ SELECT
 FROM projects
 WHERE workspace_id = sqlc.arg(workspace_id)
   AND id >= sqlc.arg(id_cursor)
+  -- search is a pre-escaped LIKE pattern built by mysql.SearchContains; NULL disables the filter
+  AND (sqlc.narg(search) IS NULL OR id LIKE sqlc.narg(search) OR name LIKE sqlc.narg(search) OR slug LIKE sqlc.narg(search))
 ORDER BY id ASC
 LIMIT ?;

--- a/svc/api/openapi/gen.go
+++ b/svc/api/openapi/gen.go
@@ -986,6 +986,9 @@ type V2AppsListAppsRequestBody struct {
 	// Project Identifies a resource by either its unique ID or its slug.
 	// Accepts a prefixed ID (such as 'proj_' or 'app_') or a slug.
 	Project ResourceIdentifier `json:"project"`
+
+	// Search Free-form text to filter apps. Returns apps whose ID, name, or slug contains the search string. Matching is case-insensitive.
+	Search *string `json:"search,omitempty"`
 }
 
 // V2AppsListAppsResponseBody defines model for V2AppsListAppsResponseBody.

--- a/svc/api/openapi/gen.go
+++ b/svc/api/openapi/gen.go
@@ -2593,6 +2593,9 @@ type V2ProjectsListProjectsRequestBody struct {
 	// Limit Maximum number of projects to return per request.
 	// Balance between response size and number of pagination calls needed.
 	Limit *int `json:"limit,omitempty"`
+
+	// Search Free-form text to filter projects. Returns projects whose ID, name, or slug contains the search string. Matching is case-insensitive.
+	Search *string `json:"search,omitempty"`
 }
 
 // V2ProjectsListProjectsResponseBody defines model for V2ProjectsListProjectsResponseBody.

--- a/svc/api/openapi/openapi-generated.yaml
+++ b/svc/api/openapi/openapi-generated.yaml
@@ -2365,6 +2365,11 @@ components:
                         Pagination cursor from a previous response to fetch the next page.
                         Use when `hasMore: true` in the previous response.
                     example: proj_1234abcd
+                search:
+                    type: string
+                    maxLength: 256
+                    description: Free-form text to filter projects. Returns projects whose ID, name, or slug contains the search string. Matching is case-insensitive.
+                    example: billing-service
             additionalProperties: false
         V2ProjectsListProjectsResponseBody:
             type: object

--- a/svc/api/openapi/openapi-generated.yaml
+++ b/svc/api/openapi/openapi-generated.yaml
@@ -461,6 +461,11 @@ components:
                         Pagination cursor from a previous response to fetch the next page.
                         Use when `hasMore: true` in the previous response.
                     example: app_1234abcd
+                search:
+                    type: string
+                    maxLength: 256
+                    description: Free-form text to filter apps. Returns apps whose ID, name, or slug contains the search string. Matching is case-insensitive.
+                    example: checkout
             additionalProperties: false
         V2AppsListAppsResponseBody:
             type: object

--- a/svc/api/openapi/spec/paths/v2/apps/listApps/V2AppsListAppsRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/apps/listApps/V2AppsListAppsRequestBody.yaml
@@ -18,6 +18,12 @@ properties:
       Pagination cursor from a previous response to fetch the next page.
       Use when `hasMore: true` in the previous response.
     example: app_1234abcd
+  search:
+    type: string
+    maxLength: 256
+    description: Free-form text to filter apps. Returns apps whose ID, name,
+      or slug contains the search string. Matching is case-insensitive.
+    example: checkout
 additionalProperties: false
 examples:
   byProjectSlug:

--- a/svc/api/openapi/spec/paths/v2/projects/listProjects/V2ProjectsListProjectsRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/projects/listProjects/V2ProjectsListProjectsRequestBody.yaml
@@ -14,6 +14,12 @@ properties:
       Pagination cursor from a previous response to fetch the next page.
       Use when `hasMore: true` in the previous response.
     example: proj_1234abcd
+  search:
+    type: string
+    maxLength: 256
+    description: Free-form text to filter projects. Returns projects whose ID,
+      name, or slug contains the search string. Matching is case-insensitive.
+    example: billing-service
 additionalProperties: false
 examples:
   basic:

--- a/svc/api/routes/v2_apps_list_apps/200_test.go
+++ b/svc/api/routes/v2_apps_list_apps/200_test.go
@@ -223,3 +223,93 @@ func TestListAppsPagination(t *testing.T) {
 
 	require.Len(t, seen, total)
 }
+
+func TestListAppsSearch(t *testing.T) {
+	h := testutil.NewHarness(t)
+
+	route := &handler.Handler{DB: h.DB}
+	h.Register(route)
+
+	workspace := h.Resources().UserWorkspace
+	rootKey := h.CreateRootKey(workspace.ID, "app.*.read_app")
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}
+
+	// Fresh project so search results are not polluted by other tests
+	project := h.CreateProject(seed.CreateProjectRequest{
+		ID:          uid.New(uid.ProjectPrefix),
+		WorkspaceID: workspace.ID,
+		Name:        "Search Project",
+		Slug:        strings.ToLower(strings.ReplaceAll(uid.New("test"), "_", "-")),
+	})
+
+	seeded := []struct {
+		Name string
+		Slug string
+	}{
+		{"Checkout Flow", "checkout-flow"},
+		{"Admin Panel", "admin-panel"},
+		{"Uptime 100%", "uptime-full"},
+	}
+	appIDs := make(map[string]string)
+	for _, a := range seeded {
+		app := h.CreateApp(seed.CreateAppRequest{
+			ID:            uid.New(uid.AppPrefix),
+			WorkspaceID:   workspace.ID,
+			ProjectID:     project.ID,
+			Name:          a.Name,
+			Slug:          a.Slug,
+			DefaultBranch: "main",
+		})
+		appIDs[a.Name] = app.ID
+	}
+
+	list := func(t *testing.T, search string) []string {
+		t.Helper()
+		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{
+			Project: project.ID,
+			Search:  ptr.P(search),
+		})
+		require.Equal(t, 200, res.Status, "expected 200, received: %s", res.RawBody)
+		names := make([]string, 0, len(res.Body.Data))
+		for _, a := range res.Body.Data {
+			names = append(names, a.Name)
+		}
+		return names
+	}
+
+	t.Run("matches name substring", func(t *testing.T) {
+		require.Equal(t, []string{"Checkout Flow"}, list(t, "checkout"))
+	})
+
+	t.Run("matches slug substring", func(t *testing.T) {
+		require.Equal(t, []string{"Admin Panel"}, list(t, "admin-panel"))
+	})
+
+	t.Run("matches app id", func(t *testing.T) {
+		require.Equal(t, []string{"Uptime 100%"}, list(t, appIDs["Uptime 100%"]))
+	})
+
+	t.Run("is case insensitive", func(t *testing.T) {
+		require.Equal(t, []string{"Checkout Flow"}, list(t, "CHECKOUT"))
+	})
+
+	t.Run("wildcards match literally", func(t *testing.T) {
+		// Unescaped, "%" would match every app and "p_nel" would match "Panel"
+		require.Equal(t, []string{"Uptime 100%"}, list(t, "100%"))
+		require.Empty(t, list(t, "p_nel"))
+	})
+
+	t.Run("no matches returns empty list", func(t *testing.T) {
+		require.Empty(t, list(t, "does-not-exist"))
+	})
+
+	t.Run("whitespace-only search returns all", func(t *testing.T) {
+		require.ElementsMatch(t,
+			[]string{"Checkout Flow", "Admin Panel", "Uptime 100%"},
+			list(t, "   "),
+		)
+	})
+}

--- a/svc/api/routes/v2_apps_list_apps/400_test.go
+++ b/svc/api/routes/v2_apps_list_apps/400_test.go
@@ -37,6 +37,7 @@ func TestListAppsValidationErrors(t *testing.T) {
 		{name: "project too long", req: handler.Request{Project: strings.Repeat("a", 257)}},
 		{name: "limit below minimum", req: handler.Request{Project: validProject, Limit: ptr.P(0)}},
 		{name: "limit above maximum", req: handler.Request{Project: validProject, Limit: ptr.P(101)}},
+		{name: "search above max length", req: handler.Request{Project: validProject, Search: ptr.P(strings.Repeat("a", 257))}},
 	}
 
 	for _, tc := range testCases {

--- a/svc/api/routes/v2_apps_list_apps/BUILD.bazel
+++ b/svc/api/routes/v2_apps_list_apps/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//pkg/codes",
         "//pkg/db",
         "//pkg/fault",
+        "//pkg/mysql",
         "//pkg/ptr",
         "//pkg/rbac",
         "//pkg/zen",

--- a/svc/api/routes/v2_apps_list_apps/handler.go
+++ b/svc/api/routes/v2_apps_list_apps/handler.go
@@ -3,10 +3,12 @@ package handler
 import (
 	"context"
 	"net/http"
+	"strings"
 
 	"github.com/unkeyed/unkey/pkg/codes"
 	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/fault"
+	"github.com/unkeyed/unkey/pkg/mysql"
 	"github.com/unkeyed/unkey/pkg/ptr"
 	"github.com/unkeyed/unkey/pkg/rbac"
 	"github.com/unkeyed/unkey/pkg/zen"
@@ -82,10 +84,12 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 	limit := ptr.SafeDeref(req.Limit, 100)
 	cursor := ptr.SafeDeref(req.Cursor, "")
+	search := mysql.SearchContains(strings.TrimSpace(ptr.SafeDeref(req.Search)))
 
 	rows, err := db.Query.ListAppsByProject(ctx, h.DB.RO(), db.ListAppsByProjectParams{
 		ProjectID: project.ID,
 		IDCursor:  cursor,
+		Search:    search,
 		Limit:     int32(limit + 1), // nolint:gosec
 	})
 	if err != nil {

--- a/svc/api/routes/v2_projects_list_projects/200_test.go
+++ b/svc/api/routes/v2_projects_list_projects/200_test.go
@@ -191,3 +191,83 @@ func TestListProjectsWorkspaceIsolation(t *testing.T) {
 		}
 	})
 }
+
+func TestListProjectsSearch(t *testing.T) {
+	h := testutil.NewHarness(t)
+
+	route := &handler.Handler{DB: h.DB}
+	h.Register(route)
+
+	// Fresh workspace so search results are not polluted by other tests
+	workspace := h.CreateWorkspace()
+	rootKey := h.CreateRootKey(workspace.ID, "project.*.read_project")
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}
+
+	seeded := []struct {
+		Name string
+		Slug string
+	}{
+		{"Billing Service", "billing-service"},
+		{"Web Frontend", "web-frontend"},
+		{"Reports 100%", "reports-full"},
+	}
+	projectIDs := make(map[string]string)
+	for _, p := range seeded {
+		project := h.CreateProject(seed.CreateProjectRequest{
+			ID:          uid.New(uid.ProjectPrefix),
+			WorkspaceID: workspace.ID,
+			Name:        p.Name,
+			Slug:        p.Slug,
+		})
+		projectIDs[p.Name] = project.ID
+	}
+
+	list := func(t *testing.T, search string) []string {
+		t.Helper()
+		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{
+			Search: ptr.P(search),
+		})
+		require.Equal(t, 200, res.Status, "expected 200, received: %s", res.RawBody)
+		names := make([]string, 0, len(res.Body.Data))
+		for _, p := range res.Body.Data {
+			names = append(names, p.Name)
+		}
+		return names
+	}
+
+	t.Run("matches name substring", func(t *testing.T) {
+		require.Equal(t, []string{"Billing Service"}, list(t, "billing"))
+	})
+
+	t.Run("matches slug substring", func(t *testing.T) {
+		require.Equal(t, []string{"Web Frontend"}, list(t, "web-frontend"))
+	})
+
+	t.Run("matches project id", func(t *testing.T) {
+		require.Equal(t, []string{"Reports 100%"}, list(t, projectIDs["Reports 100%"]))
+	})
+
+	t.Run("is case insensitive", func(t *testing.T) {
+		require.Equal(t, []string{"Billing Service"}, list(t, "BILLING"))
+	})
+
+	t.Run("wildcards match literally", func(t *testing.T) {
+		// Unescaped, "%" would match every project and "s_rvice" would match "Service"
+		require.Equal(t, []string{"Reports 100%"}, list(t, "100%"))
+		require.Empty(t, list(t, "s_rvice"))
+	})
+
+	t.Run("no matches returns empty list", func(t *testing.T) {
+		require.Empty(t, list(t, "does-not-exist"))
+	})
+
+	t.Run("whitespace-only search returns all", func(t *testing.T) {
+		require.ElementsMatch(t,
+			[]string{"Billing Service", "Web Frontend", "Reports 100%"},
+			list(t, "   "),
+		)
+	})
+}

--- a/svc/api/routes/v2_projects_list_projects/400_test.go
+++ b/svc/api/routes/v2_projects_list_projects/400_test.go
@@ -32,6 +32,7 @@ func TestListProjectsBadRequest(t *testing.T) {
 	}{
 		{name: "limit below minimum", req: handler.Request{Limit: ptr.P(0)}},
 		{name: "limit above maximum", req: handler.Request{Limit: ptr.P(101)}},
+		{name: "search above max length", req: handler.Request{Search: ptr.P(strings.Repeat("a", 257))}},
 	}
 
 	for _, tc := range testCases {

--- a/svc/api/routes/v2_projects_list_projects/BUILD.bazel
+++ b/svc/api/routes/v2_projects_list_projects/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//pkg/codes",
         "//pkg/db",
         "//pkg/fault",
+        "//pkg/mysql",
         "//pkg/ptr",
         "//pkg/rbac",
         "//pkg/zen",

--- a/svc/api/routes/v2_projects_list_projects/handler.go
+++ b/svc/api/routes/v2_projects_list_projects/handler.go
@@ -3,10 +3,12 @@ package handler
 import (
 	"context"
 	"net/http"
+	"strings"
 
 	"github.com/unkeyed/unkey/pkg/codes"
 	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/fault"
+	"github.com/unkeyed/unkey/pkg/mysql"
 	"github.com/unkeyed/unkey/pkg/ptr"
 	"github.com/unkeyed/unkey/pkg/rbac"
 	"github.com/unkeyed/unkey/pkg/zen"
@@ -56,10 +58,12 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 	limit := ptr.SafeDeref(req.Limit, 100)
 	cursor := ptr.SafeDeref(req.Cursor, "")
+	search := mysql.SearchContains(strings.TrimSpace(ptr.SafeDeref(req.Search)))
 
 	rows, err := db.Query.ListProjectsByWorkspaceId(ctx, h.DB.RO(), db.ListProjectsByWorkspaceIdParams{
 		WorkspaceID: principal.WorkspaceID,
 		IDCursor:    cursor,
+		Search:      search,
 		Limit:       int32(limit + 1), // nolint:gosec
 	})
 	if err != nil {


### PR DESCRIPTION
Adds a `search` field to `POST /v2/apps.listApps`, following the identities implementation (#6639).

- Contains-match on `id`, `name`, or `slug`, case-insensitive, scoped to the requested project.
- LIKE wildcards in the input are escaped via `mysql.SearchContains`, so they match literally.
- Max length 256, schema-validated. Empty or whitespace-only input applies no filter.
- Cursor pagination unchanged.

Stacked on #6642.
