### PR TITLE
perf(db): optimize hot verification and global counter queries

### DIFF
--- a/internal/services/keys/db/key_find_for_verification.sql_generated.go
+++ b/internal/services/keys/db/key_find_for_verification.sql_generated.go
@@ -11,89 +11,133 @@ import (
 )
 
 const findKeyForVerification = `-- name: FindKeyForVerification :one
-select k.id,
-       k.key_auth_id,
-       k.workspace_id,
-       k.for_workspace_id,
-       k.name,
-       k.meta,
-       k.expires,
-       k.deleted_at_m,
-       k.refill_day,
-       k.refill_amount,
-       k.last_refill_at,
-       k.enabled,
-       k.remaining_requests,
-       k.pending_migration_id,
-       a.ip_whitelist,
-       a.workspace_id  as api_workspace_id,
-       a.id            as api_id,
-       a.deleted_at_m  as api_deleted_at_m,
-
-       COALESCE(
-               (SELECT JSON_ARRAYAGG(name)
-                FROM (SELECT name
-                      FROM keys_roles kr
-                               JOIN roles r ON r.id = kr.role_id
-                      WHERE kr.key_id = k.id) as roles),
-               JSON_ARRAY()
-       )               as roles,
-
-       COALESCE(
-               (SELECT JSON_ARRAYAGG(slug)
-                FROM (SELECT slug
-                      FROM keys_permissions kp
-                               JOIN permissions p ON kp.permission_id = p.id
-                      WHERE kp.key_id = k.id
-
-                      UNION ALL
-
-                      SELECT slug
-                      FROM keys_roles kr
-                               JOIN roles_permissions rp ON kr.role_id = rp.role_id
-                               JOIN permissions p ON rp.permission_id = p.id
-                      WHERE kr.key_id = k.id) as combined_perms),
-               JSON_ARRAY()
-       )               as permissions,
-
-       coalesce(
-               (select json_arrayagg(
-                    json_object(
-                       'id', id,
-                       'name', name,
-                       'key_id', key_id,
-                       'identity_id', identity_id,
-                       'limit', ` + "`" + `limit` + "`" + `,
-                       'duration', duration,
-                       'auto_apply', auto_apply
-                    )
-                )
-                from (
-                    select rl.id, rl.name, rl.key_id, rl.identity_id, rl.` + "`" + `limit` + "`" + `, rl.duration, rl.auto_apply
-                    from ` + "`" + `ratelimits` + "`" + ` rl
-                    where rl.key_id = k.id
-                    UNION ALL
-                    select rl.id, rl.name, rl.key_id, rl.identity_id, rl.` + "`" + `limit` + "`" + `, rl.duration, rl.auto_apply
-                    from ` + "`" + `ratelimits` + "`" + ` rl
-                    where rl.identity_id = i.id
-                ) as combined_rl),
-               json_array()
-       ) as ratelimits,
-
-       i.id as identity_id,
-       i.external_id,
-       i.meta          as identity_meta,
-       ka.deleted_at_m as key_auth_deleted_at_m,
-       ws.enabled      as workspace_enabled,
-       fws.enabled     as for_workspace_enabled
-from ` + "`" + `keys` + "`" + ` k
-         JOIN apis a USING (key_auth_id)
-         JOIN key_auth ka ON ka.id = k.key_auth_id
-         JOIN workspaces ws ON ws.id = k.workspace_id
-         LEFT JOIN workspaces fws ON fws.id = k.for_workspace_id
-         LEFT JOIN identities i ON k.identity_id = i.id AND i.deleted = 0
-where k.hash = ?
-  and k.deleted_at_m is null
+SELECT
+  k.id,
+  k.key_auth_id,
+  k.workspace_id,
+  k.for_workspace_id,
+  k.name,
+  k.meta,
+  k.expires,
+  k.deleted_at_m,
+  k.refill_day,
+  k.refill_amount,
+  k.last_refill_at,
+  k.enabled,
+  k.remaining_requests,
+  k.pending_migration_id,
+  a.ip_whitelist,
+  a.workspace_id AS api_workspace_id,
+  a.id AS api_id,
+  a.deleted_at_m AS api_deleted_at_m,
+  COALESCE(
+    (
+      SELECT
+        JSON_ARRAYAGG(r.name)
+      FROM
+        keys_roles kr
+        STRAIGHT_JOIN roles r ON r.id = kr.role_id
+      WHERE
+        kr.key_id = k.id
+    ),
+    JSON_ARRAY()
+  ) AS roles,
+  COALESCE(
+    (
+      SELECT
+        JSON_ARRAYAGG(slug)
+      FROM
+        (
+          SELECT
+            p.slug
+          FROM
+            keys_permissions kp
+            STRAIGHT_JOIN permissions p ON p.id = kp.permission_id
+          WHERE
+            kp.key_id = k.id
+          UNION ALL
+          SELECT
+            p.slug
+          FROM
+            keys_roles kr
+            STRAIGHT_JOIN roles_permissions rp ON rp.role_id = kr.role_id
+            STRAIGHT_JOIN permissions p ON p.id = rp.permission_id
+          WHERE
+            kr.key_id = k.id
+        ) combined_perms
+    ),
+    JSON_ARRAY()
+  ) AS permissions,
+  COALESCE(
+    (
+      SELECT
+        JSON_ARRAYAGG(
+          JSON_OBJECT(
+            'id',
+            rl.id,
+            'name',
+            rl.name,
+            'key_id',
+            rl.key_id,
+            'identity_id',
+            rl.identity_id,
+            'limit',
+            rl.` + "`" + `limit` + "`" + `,
+            'duration',
+            rl.duration,
+            'auto_apply',
+            rl.auto_apply
+          )
+        )
+      FROM
+        (
+          SELECT
+            rl.id,
+            rl.name,
+            rl.key_id,
+            rl.identity_id,
+            rl.` + "`" + `limit` + "`" + `,
+            rl.duration,
+            rl.auto_apply
+          FROM
+            ` + "`" + `ratelimits` + "`" + ` rl
+          WHERE
+            rl.key_id = k.id
+          UNION ALL
+          SELECT
+            rl.id,
+            rl.name,
+            rl.key_id,
+            rl.identity_id,
+            rl.` + "`" + `limit` + "`" + `,
+            rl.duration,
+            rl.auto_apply
+          FROM
+            ` + "`" + `ratelimits` + "`" + ` rl
+          WHERE
+            k.identity_id IS NOT NULL
+            AND rl.identity_id = k.identity_id
+        ) rl
+    ),
+    JSON_ARRAY()
+  ) AS ratelimits,
+  i.id AS identity_id,
+  i.external_id,
+  i.meta AS identity_meta,
+  ka.deleted_at_m AS key_auth_deleted_at_m,
+  ws.enabled AS workspace_enabled,
+  fws.enabled AS for_workspace_enabled
+FROM
+  ` + "`" + `keys` + "`" + ` k
+  JOIN apis a ON a.key_auth_id = k.key_auth_id
+  JOIN key_auth ka ON ka.id = k.key_auth_id
+  JOIN workspaces ws ON ws.id = k.workspace_id
+  LEFT JOIN workspaces fws ON fws.id = k.for_workspace_id
+  LEFT JOIN identities i ON k.identity_id = i.id
+  AND i.deleted = 0
+WHERE
+  k.hash = ?
+  AND k.deleted_at_m IS NULL
 `
 
 type FindKeyForVerificationRow struct {
@@ -133,89 +177,137 @@ type FindKeyForVerificationRow struct {
 // them into typed Go structs. Key-level and identity-level rate limits are
 // unioned so that both sources are available for the verification pipeline.
 //
-//	select k.id,
-//	       k.key_auth_id,
-//	       k.workspace_id,
-//	       k.for_workspace_id,
-//	       k.name,
-//	       k.meta,
-//	       k.expires,
-//	       k.deleted_at_m,
-//	       k.refill_day,
-//	       k.refill_amount,
-//	       k.last_refill_at,
-//	       k.enabled,
-//	       k.remaining_requests,
-//	       k.pending_migration_id,
-//	       a.ip_whitelist,
-//	       a.workspace_id  as api_workspace_id,
-//	       a.id            as api_id,
-//	       a.deleted_at_m  as api_deleted_at_m,
+// hash_idx resolves the key row first. Correlated aggregates drive from
+// keys_roles / keys_permissions / ratelimits keyed by k.id so MySQL does not
+// scan workspace-wide role or permission catalogs (see EXPLAIN plans).
 //
-//	       COALESCE(
-//	               (SELECT JSON_ARRAYAGG(name)
-//	                FROM (SELECT name
-//	                      FROM keys_roles kr
-//	                               JOIN roles r ON r.id = kr.role_id
-//	                      WHERE kr.key_id = k.id) as roles),
-//	               JSON_ARRAY()
-//	       )               as roles,
-//
-//	       COALESCE(
-//	               (SELECT JSON_ARRAYAGG(slug)
-//	                FROM (SELECT slug
-//	                      FROM keys_permissions kp
-//	                               JOIN permissions p ON kp.permission_id = p.id
-//	                      WHERE kp.key_id = k.id
-//
-//	                      UNION ALL
-//
-//	                      SELECT slug
-//	                      FROM keys_roles kr
-//	                               JOIN roles_permissions rp ON kr.role_id = rp.role_id
-//	                               JOIN permissions p ON rp.permission_id = p.id
-//	                      WHERE kr.key_id = k.id) as combined_perms),
-//	               JSON_ARRAY()
-//	       )               as permissions,
-//
-//	       coalesce(
-//	               (select json_arrayagg(
-//	                    json_object(
-//	                       'id', id,
-//	                       'name', name,
-//	                       'key_id', key_id,
-//	                       'identity_id', identity_id,
-//	                       'limit', `limit`,
-//	                       'duration', duration,
-//	                       'auto_apply', auto_apply
-//	                    )
-//	                )
-//	                from (
-//	                    select rl.id, rl.name, rl.key_id, rl.identity_id, rl.`limit`, rl.duration, rl.auto_apply
-//	                    from `ratelimits` rl
-//	                    where rl.key_id = k.id
-//	                    UNION ALL
-//	                    select rl.id, rl.name, rl.key_id, rl.identity_id, rl.`limit`, rl.duration, rl.auto_apply
-//	                    from `ratelimits` rl
-//	                    where rl.identity_id = i.id
-//	                ) as combined_rl),
-//	               json_array()
-//	       ) as ratelimits,
-//
-//	       i.id as identity_id,
-//	       i.external_id,
-//	       i.meta          as identity_meta,
-//	       ka.deleted_at_m as key_auth_deleted_at_m,
-//	       ws.enabled      as workspace_enabled,
-//	       fws.enabled     as for_workspace_enabled
-//	from `keys` k
-//	         JOIN apis a USING (key_auth_id)
-//	         JOIN key_auth ka ON ka.id = k.key_auth_id
-//	         JOIN workspaces ws ON ws.id = k.workspace_id
-//	         LEFT JOIN workspaces fws ON fws.id = k.for_workspace_id
-//	         LEFT JOIN identities i ON k.identity_id = i.id AND i.deleted = 0
-//	where k.hash = ?
-//	  and k.deleted_at_m is null
+//	SELECT
+//	  k.id,
+//	  k.key_auth_id,
+//	  k.workspace_id,
+//	  k.for_workspace_id,
+//	  k.name,
+//	  k.meta,
+//	  k.expires,
+//	  k.deleted_at_m,
+//	  k.refill_day,
+//	  k.refill_amount,
+//	  k.last_refill_at,
+//	  k.enabled,
+//	  k.remaining_requests,
+//	  k.pending_migration_id,
+//	  a.ip_whitelist,
+//	  a.workspace_id AS api_workspace_id,
+//	  a.id AS api_id,
+//	  a.deleted_at_m AS api_deleted_at_m,
+//	  COALESCE(
+//	    (
+//	      SELECT
+//	        JSON_ARRAYAGG(r.name)
+//	      FROM
+//	        keys_roles kr
+//	        STRAIGHT_JOIN roles r ON r.id = kr.role_id
+//	      WHERE
+//	        kr.key_id = k.id
+//	    ),
+//	    JSON_ARRAY()
+//	  ) AS roles,
+//	  COALESCE(
+//	    (
+//	      SELECT
+//	        JSON_ARRAYAGG(slug)
+//	      FROM
+//	        (
+//	          SELECT
+//	            p.slug
+//	          FROM
+//	            keys_permissions kp
+//	            STRAIGHT_JOIN permissions p ON p.id = kp.permission_id
+//	          WHERE
+//	            kp.key_id = k.id
+//	          UNION ALL
+//	          SELECT
+//	            p.slug
+//	          FROM
+//	            keys_roles kr
+//	            STRAIGHT_JOIN roles_permissions rp ON rp.role_id = kr.role_id
+//	            STRAIGHT_JOIN permissions p ON p.id = rp.permission_id
+//	          WHERE
+//	            kr.key_id = k.id
+//	        ) combined_perms
+//	    ),
+//	    JSON_ARRAY()
+//	  ) AS permissions,
+//	  COALESCE(
+//	    (
+//	      SELECT
+//	        JSON_ARRAYAGG(
+//	          JSON_OBJECT(
+//	            'id',
+//	            rl.id,
+//	            'name',
+//	            rl.name,
+//	            'key_id',
+//	            rl.key_id,
+//	            'identity_id',
+//	            rl.identity_id,
+//	            'limit',
+//	            rl.`limit`,
+//	            'duration',
+//	            rl.duration,
+//	            'auto_apply',
+//	            rl.auto_apply
+//	          )
+//	        )
+//	      FROM
+//	        (
+//	          SELECT
+//	            rl.id,
+//	            rl.name,
+//	            rl.key_id,
+//	            rl.identity_id,
+//	            rl.`limit`,
+//	            rl.duration,
+//	            rl.auto_apply
+//	          FROM
+//	            `ratelimits` rl
+//	          WHERE
+//	            rl.key_id = k.id
+//	          UNION ALL
+//	          SELECT
+//	            rl.id,
+//	            rl.name,
+//	            rl.key_id,
+//	            rl.identity_id,
+//	            rl.`limit`,
+//	            rl.duration,
+//	            rl.auto_apply
+//	          FROM
+//	            `ratelimits` rl
+//	          WHERE
+//	            k.identity_id IS NOT NULL
+//	            AND rl.identity_id = k.identity_id
+//	        ) rl
+//	    ),
+//	    JSON_ARRAY()
+//	  ) AS ratelimits,
+//	  i.id AS identity_id,
+//	  i.external_id,
+//	  i.meta AS identity_meta,
+//	  ka.deleted_at_m AS key_auth_deleted_at_m,
+//	  ws.enabled AS workspace_enabled,
+//	  fws.enabled AS for_workspace_enabled
+//	FROM
+//	  `keys` k
+//	  JOIN apis a ON a.key_auth_id = k.key_auth_id
+//	  JOIN key_auth ka ON ka.id = k.key_auth_id
+//	  JOIN workspaces ws ON ws.id = k.workspace_id
+//	  LEFT JOIN workspaces fws ON fws.id = k.for_workspace_id
+//	  LEFT JOIN identities i ON k.identity_id = i.id
+//	  AND i.deleted = 0
+//	WHERE
+//	  k.hash = ?
+//	  AND k.deleted_at_m IS NULL
 func (q *Queries) FindKeyForVerification(ctx context.Context, db DBTX, hash string) (FindKeyForVerificationRow, error) {
 	row := db.QueryRowContext(ctx, findKeyForVerification, hash)
 	var i FindKeyForVerificationRow

--- a/internal/services/keys/db/querier_generated.go
+++ b/internal/services/keys/db/querier_generated.go
@@ -16,89 +16,137 @@ type Querier interface {
 	// them into typed Go structs. Key-level and identity-level rate limits are
 	// unioned so that both sources are available for the verification pipeline.
 	//
-	//  select k.id,
-	//         k.key_auth_id,
-	//         k.workspace_id,
-	//         k.for_workspace_id,
-	//         k.name,
-	//         k.meta,
-	//         k.expires,
-	//         k.deleted_at_m,
-	//         k.refill_day,
-	//         k.refill_amount,
-	//         k.last_refill_at,
-	//         k.enabled,
-	//         k.remaining_requests,
-	//         k.pending_migration_id,
-	//         a.ip_whitelist,
-	//         a.workspace_id  as api_workspace_id,
-	//         a.id            as api_id,
-	//         a.deleted_at_m  as api_deleted_at_m,
+	// hash_idx resolves the key row first. Correlated aggregates drive from
+	// keys_roles / keys_permissions / ratelimits keyed by k.id so MySQL does not
+	// scan workspace-wide role or permission catalogs (see EXPLAIN plans).
 	//
-	//         COALESCE(
-	//                 (SELECT JSON_ARRAYAGG(name)
-	//                  FROM (SELECT name
-	//                        FROM keys_roles kr
-	//                                 JOIN roles r ON r.id = kr.role_id
-	//                        WHERE kr.key_id = k.id) as roles),
-	//                 JSON_ARRAY()
-	//         )               as roles,
-	//
-	//         COALESCE(
-	//                 (SELECT JSON_ARRAYAGG(slug)
-	//                  FROM (SELECT slug
-	//                        FROM keys_permissions kp
-	//                                 JOIN permissions p ON kp.permission_id = p.id
-	//                        WHERE kp.key_id = k.id
-	//
-	//                        UNION ALL
-	//
-	//                        SELECT slug
-	//                        FROM keys_roles kr
-	//                                 JOIN roles_permissions rp ON kr.role_id = rp.role_id
-	//                                 JOIN permissions p ON rp.permission_id = p.id
-	//                        WHERE kr.key_id = k.id) as combined_perms),
-	//                 JSON_ARRAY()
-	//         )               as permissions,
-	//
-	//         coalesce(
-	//                 (select json_arrayagg(
-	//                      json_object(
-	//                         'id', id,
-	//                         'name', name,
-	//                         'key_id', key_id,
-	//                         'identity_id', identity_id,
-	//                         'limit', `limit`,
-	//                         'duration', duration,
-	//                         'auto_apply', auto_apply
-	//                      )
-	//                  )
-	//                  from (
-	//                      select rl.id, rl.name, rl.key_id, rl.identity_id, rl.`limit`, rl.duration, rl.auto_apply
-	//                      from `ratelimits` rl
-	//                      where rl.key_id = k.id
-	//                      UNION ALL
-	//                      select rl.id, rl.name, rl.key_id, rl.identity_id, rl.`limit`, rl.duration, rl.auto_apply
-	//                      from `ratelimits` rl
-	//                      where rl.identity_id = i.id
-	//                  ) as combined_rl),
-	//                 json_array()
-	//         ) as ratelimits,
-	//
-	//         i.id as identity_id,
-	//         i.external_id,
-	//         i.meta          as identity_meta,
-	//         ka.deleted_at_m as key_auth_deleted_at_m,
-	//         ws.enabled      as workspace_enabled,
-	//         fws.enabled     as for_workspace_enabled
-	//  from `keys` k
-	//           JOIN apis a USING (key_auth_id)
-	//           JOIN key_auth ka ON ka.id = k.key_auth_id
-	//           JOIN workspaces ws ON ws.id = k.workspace_id
-	//           LEFT JOIN workspaces fws ON fws.id = k.for_workspace_id
-	//           LEFT JOIN identities i ON k.identity_id = i.id AND i.deleted = 0
-	//  where k.hash = ?
-	//    and k.deleted_at_m is null
+	//  SELECT
+	//    k.id,
+	//    k.key_auth_id,
+	//    k.workspace_id,
+	//    k.for_workspace_id,
+	//    k.name,
+	//    k.meta,
+	//    k.expires,
+	//    k.deleted_at_m,
+	//    k.refill_day,
+	//    k.refill_amount,
+	//    k.last_refill_at,
+	//    k.enabled,
+	//    k.remaining_requests,
+	//    k.pending_migration_id,
+	//    a.ip_whitelist,
+	//    a.workspace_id AS api_workspace_id,
+	//    a.id AS api_id,
+	//    a.deleted_at_m AS api_deleted_at_m,
+	//    COALESCE(
+	//      (
+	//        SELECT
+	//          JSON_ARRAYAGG(r.name)
+	//        FROM
+	//          keys_roles kr
+	//          STRAIGHT_JOIN roles r ON r.id = kr.role_id
+	//        WHERE
+	//          kr.key_id = k.id
+	//      ),
+	//      JSON_ARRAY()
+	//    ) AS roles,
+	//    COALESCE(
+	//      (
+	//        SELECT
+	//          JSON_ARRAYAGG(slug)
+	//        FROM
+	//          (
+	//            SELECT
+	//              p.slug
+	//            FROM
+	//              keys_permissions kp
+	//              STRAIGHT_JOIN permissions p ON p.id = kp.permission_id
+	//            WHERE
+	//              kp.key_id = k.id
+	//            UNION ALL
+	//            SELECT
+	//              p.slug
+	//            FROM
+	//              keys_roles kr
+	//              STRAIGHT_JOIN roles_permissions rp ON rp.role_id = kr.role_id
+	//              STRAIGHT_JOIN permissions p ON p.id = rp.permission_id
+	//            WHERE
+	//              kr.key_id = k.id
+	//          ) combined_perms
+	//      ),
+	//      JSON_ARRAY()
+	//    ) AS permissions,
+	//    COALESCE(
+	//      (
+	//        SELECT
+	//          JSON_ARRAYAGG(
+	//            JSON_OBJECT(
+	//              'id',
+	//              rl.id,
+	//              'name',
+	//              rl.name,
+	//              'key_id',
+	//              rl.key_id,
+	//              'identity_id',
+	//              rl.identity_id,
+	//              'limit',
+	//              rl.`limit`,
+	//              'duration',
+	//              rl.duration,
+	//              'auto_apply',
+	//              rl.auto_apply
+	//            )
+	//          )
+	//        FROM
+	//          (
+	//            SELECT
+	//              rl.id,
+	//              rl.name,
+	//              rl.key_id,
+	//              rl.identity_id,
+	//              rl.`limit`,
+	//              rl.duration,
+	//              rl.auto_apply
+	//            FROM
+	//              `ratelimits` rl
+	//            WHERE
+	//              rl.key_id = k.id
+	//            UNION ALL
+	//            SELECT
+	//              rl.id,
+	//              rl.name,
+	//              rl.key_id,
+	//              rl.identity_id,
+	//              rl.`limit`,
+	//              rl.duration,
+	//              rl.auto_apply
+	//            FROM
+	//              `ratelimits` rl
+	//            WHERE
+	//              k.identity_id IS NOT NULL
+	//              AND rl.identity_id = k.identity_id
+	//          ) rl
+	//      ),
+	//      JSON_ARRAY()
+	//    ) AS ratelimits,
+	//    i.id AS identity_id,
+	//    i.external_id,
+	//    i.meta AS identity_meta,
+	//    ka.deleted_at_m AS key_auth_deleted_at_m,
+	//    ws.enabled AS workspace_enabled,
+	//    fws.enabled AS for_workspace_enabled
+	//  FROM
+	//    `keys` k
+	//    JOIN apis a ON a.key_auth_id = k.key_auth_id
+	//    JOIN key_auth ka ON ka.id = k.key_auth_id
+	//    JOIN workspaces ws ON ws.id = k.workspace_id
+	//    LEFT JOIN workspaces fws ON fws.id = k.for_workspace_id
+	//    LEFT JOIN identities i ON k.identity_id = i.id
+	//    AND i.deleted = 0
+	//  WHERE
+	//    k.hash = ?
+	//    AND k.deleted_at_m IS NULL
 	FindKeyForVerification(ctx context.Context, db DBTX, hash string) (FindKeyForVerificationRow, error)
 	// FindKeyMigrationByID returns the migration record for a key, scoped to
 	// the given workspace. The algorithm field determines which hashing scheme

--- a/internal/services/keys/db/queries/key_find_for_verification.sql
+++ b/internal/services/keys/db/queries/key_find_for_verification.sql
@@ -5,86 +5,134 @@
 -- are returned as JSON arrays via JSON_ARRAYAGG so the caller can unmarshal
 -- them into typed Go structs. Key-level and identity-level rate limits are
 -- unioned so that both sources are available for the verification pipeline.
-select k.id,
-       k.key_auth_id,
-       k.workspace_id,
-       k.for_workspace_id,
-       k.name,
-       k.meta,
-       k.expires,
-       k.deleted_at_m,
-       k.refill_day,
-       k.refill_amount,
-       k.last_refill_at,
-       k.enabled,
-       k.remaining_requests,
-       k.pending_migration_id,
-       a.ip_whitelist,
-       a.workspace_id  as api_workspace_id,
-       a.id            as api_id,
-       a.deleted_at_m  as api_deleted_at_m,
-
-       COALESCE(
-               (SELECT JSON_ARRAYAGG(name)
-                FROM (SELECT name
-                      FROM keys_roles kr
-                               JOIN roles r ON r.id = kr.role_id
-                      WHERE kr.key_id = k.id) as roles),
-               JSON_ARRAY()
-       )               as roles,
-
-       COALESCE(
-               (SELECT JSON_ARRAYAGG(slug)
-                FROM (SELECT slug
-                      FROM keys_permissions kp
-                               JOIN permissions p ON kp.permission_id = p.id
-                      WHERE kp.key_id = k.id
-
-                      UNION ALL
-
-                      SELECT slug
-                      FROM keys_roles kr
-                               JOIN roles_permissions rp ON kr.role_id = rp.role_id
-                               JOIN permissions p ON rp.permission_id = p.id
-                      WHERE kr.key_id = k.id) as combined_perms),
-               JSON_ARRAY()
-       )               as permissions,
-
-       coalesce(
-               (select json_arrayagg(
-                    json_object(
-                       'id', id,
-                       'name', name,
-                       'key_id', key_id,
-                       'identity_id', identity_id,
-                       'limit', `limit`,
-                       'duration', duration,
-                       'auto_apply', auto_apply
-                    )
-                )
-                from (
-                    select rl.id, rl.name, rl.key_id, rl.identity_id, rl.`limit`, rl.duration, rl.auto_apply
-                    from `ratelimits` rl
-                    where rl.key_id = k.id
-                    UNION ALL
-                    select rl.id, rl.name, rl.key_id, rl.identity_id, rl.`limit`, rl.duration, rl.auto_apply
-                    from `ratelimits` rl
-                    where rl.identity_id = i.id
-                ) as combined_rl),
-               json_array()
-       ) as ratelimits,
-
-       i.id as identity_id,
-       i.external_id,
-       i.meta          as identity_meta,
-       ka.deleted_at_m as key_auth_deleted_at_m,
-       ws.enabled      as workspace_enabled,
-       fws.enabled     as for_workspace_enabled
-from `keys` k
-         JOIN apis a USING (key_auth_id)
-         JOIN key_auth ka ON ka.id = k.key_auth_id
-         JOIN workspaces ws ON ws.id = k.workspace_id
-         LEFT JOIN workspaces fws ON fws.id = k.for_workspace_id
-         LEFT JOIN identities i ON k.identity_id = i.id AND i.deleted = 0
-where k.hash = ?
-  and k.deleted_at_m is null;
+--
+-- hash_idx resolves the key row first. Correlated aggregates drive from
+-- keys_roles / keys_permissions / ratelimits keyed by k.id so MySQL does not
+-- scan workspace-wide role or permission catalogs (see EXPLAIN plans).
+SELECT
+  k.id,
+  k.key_auth_id,
+  k.workspace_id,
+  k.for_workspace_id,
+  k.name,
+  k.meta,
+  k.expires,
+  k.deleted_at_m,
+  k.refill_day,
+  k.refill_amount,
+  k.last_refill_at,
+  k.enabled,
+  k.remaining_requests,
+  k.pending_migration_id,
+  a.ip_whitelist,
+  a.workspace_id AS api_workspace_id,
+  a.id AS api_id,
+  a.deleted_at_m AS api_deleted_at_m,
+  COALESCE(
+    (
+      SELECT
+        JSON_ARRAYAGG(r.name)
+      FROM
+        keys_roles kr
+        STRAIGHT_JOIN roles r ON r.id = kr.role_id
+      WHERE
+        kr.key_id = k.id
+    ),
+    JSON_ARRAY()
+  ) AS roles,
+  COALESCE(
+    (
+      SELECT
+        JSON_ARRAYAGG(slug)
+      FROM
+        (
+          SELECT
+            p.slug
+          FROM
+            keys_permissions kp
+            STRAIGHT_JOIN permissions p ON p.id = kp.permission_id
+          WHERE
+            kp.key_id = k.id
+          UNION ALL
+          SELECT
+            p.slug
+          FROM
+            keys_roles kr
+            STRAIGHT_JOIN roles_permissions rp ON rp.role_id = kr.role_id
+            STRAIGHT_JOIN permissions p ON p.id = rp.permission_id
+          WHERE
+            kr.key_id = k.id
+        ) combined_perms
+    ),
+    JSON_ARRAY()
+  ) AS permissions,
+  COALESCE(
+    (
+      SELECT
+        JSON_ARRAYAGG(
+          JSON_OBJECT(
+            'id',
+            rl.id,
+            'name',
+            rl.name,
+            'key_id',
+            rl.key_id,
+            'identity_id',
+            rl.identity_id,
+            'limit',
+            rl.`limit`,
+            'duration',
+            rl.duration,
+            'auto_apply',
+            rl.auto_apply
+          )
+        )
+      FROM
+        (
+          SELECT
+            rl.id,
+            rl.name,
+            rl.key_id,
+            rl.identity_id,
+            rl.`limit`,
+            rl.duration,
+            rl.auto_apply
+          FROM
+            `ratelimits` rl
+          WHERE
+            rl.key_id = k.id
+          UNION ALL
+          SELECT
+            rl.id,
+            rl.name,
+            rl.key_id,
+            rl.identity_id,
+            rl.`limit`,
+            rl.duration,
+            rl.auto_apply
+          FROM
+            `ratelimits` rl
+          WHERE
+            k.identity_id IS NOT NULL
+            AND rl.identity_id = k.identity_id
+        ) rl
+    ),
+    JSON_ARRAY()
+  ) AS ratelimits,
+  i.id AS identity_id,
+  i.external_id,
+  i.meta AS identity_meta,
+  ka.deleted_at_m AS key_auth_deleted_at_m,
+  ws.enabled AS workspace_enabled,
+  fws.enabled AS for_workspace_enabled
+FROM
+  `keys` k
+  JOIN apis a ON a.key_auth_id = k.key_auth_id
+  JOIN key_auth ka ON ka.id = k.key_auth_id
+  JOIN workspaces ws ON ws.id = k.workspace_id
+  LEFT JOIN workspaces fws ON fws.id = k.for_workspace_id
+  LEFT JOIN identities i ON k.identity_id = i.id
+  AND i.deleted = 0
+WHERE
+  k.hash = sqlc.arg(hash)
+  AND k.deleted_at_m IS NULL;

--- a/internal/services/ratelimit/db/global_counters_imported.sql_generated.go
+++ b/internal/services/ratelimit/db/global_counters_imported.sql_generated.go
@@ -11,16 +11,27 @@ import (
 
 const globalCountersImported = `-- name: GlobalCountersImported :many
 SELECT
-    workspace_id,
-    namespace,
-    identifier,
-    duration_ms,
-    sequence,
-    CAST(SUM(CASE WHEN region = ? THEN count ELSE 0 END) AS SIGNED) AS regional,
-    CAST(SUM(CASE WHEN region != ? THEN count ELSE 0 END) AS SIGNED) AS imported
-FROM ratelimit_global_counters
-WHERE expires_at > ?
-GROUP BY workspace_id, namespace, identifier, duration_ms, sequence
+  workspace_id,
+  namespace,
+  identifier,
+  duration_ms,
+  sequence,
+  CAST(
+    SUM(IF(region = ?, count, 0)) AS SIGNED
+  ) AS regional,
+  CAST(
+    SUM(IF(region != ?, count, 0)) AS SIGNED
+  ) AS imported
+FROM
+  ratelimit_global_counters FORCE INDEX (active_window_import_idx)
+WHERE
+  expires_at > ?
+GROUP BY
+  workspace_id,
+  namespace,
+  identifier,
+  duration_ms,
+  sequence
 `
 
 type GlobalCountersImportedParams struct {
@@ -48,16 +59,27 @@ type GlobalCountersImportedRow struct {
 // cast to SIGNED so sqlc maps them to int64, matching atomic.Int64 in the caller.
 //
 //	SELECT
-//	    workspace_id,
-//	    namespace,
-//	    identifier,
-//	    duration_ms,
-//	    sequence,
-//	    CAST(SUM(CASE WHEN region = ? THEN count ELSE 0 END) AS SIGNED) AS regional,
-//	    CAST(SUM(CASE WHEN region != ? THEN count ELSE 0 END) AS SIGNED) AS imported
-//	FROM ratelimit_global_counters
-//	WHERE expires_at > ?
-//	GROUP BY workspace_id, namespace, identifier, duration_ms, sequence
+//	  workspace_id,
+//	  namespace,
+//	  identifier,
+//	  duration_ms,
+//	  sequence,
+//	  CAST(
+//	    SUM(IF(region = ?, count, 0)) AS SIGNED
+//	  ) AS regional,
+//	  CAST(
+//	    SUM(IF(region != ?, count, 0)) AS SIGNED
+//	  ) AS imported
+//	FROM
+//	  ratelimit_global_counters FORCE INDEX (active_window_import_idx)
+//	WHERE
+//	  expires_at > ?
+//	GROUP BY
+//	  workspace_id,
+//	  namespace,
+//	  identifier,
+//	  duration_ms,
+//	  sequence
 func (q *Queries) GlobalCountersImported(ctx context.Context, arg GlobalCountersImportedParams) ([]GlobalCountersImportedRow, error) {
 	rows, err := q.db.QueryContext(ctx, globalCountersImported, arg.SelfRegion, arg.SelfRegion, arg.Now)
 	if err != nil {

--- a/internal/services/ratelimit/db/querier_generated.go
+++ b/internal/services/ratelimit/db/querier_generated.go
@@ -27,16 +27,27 @@ type Querier interface {
 	// cast to SIGNED so sqlc maps them to int64, matching atomic.Int64 in the caller.
 	//
 	//  SELECT
-	//      workspace_id,
-	//      namespace,
-	//      identifier,
-	//      duration_ms,
-	//      sequence,
-	//      CAST(SUM(CASE WHEN region = ? THEN count ELSE 0 END) AS SIGNED) AS regional,
-	//      CAST(SUM(CASE WHEN region != ? THEN count ELSE 0 END) AS SIGNED) AS imported
-	//  FROM ratelimit_global_counters
-	//  WHERE expires_at > ?
-	//  GROUP BY workspace_id, namespace, identifier, duration_ms, sequence
+	//    workspace_id,
+	//    namespace,
+	//    identifier,
+	//    duration_ms,
+	//    sequence,
+	//    CAST(
+	//      SUM(IF(region = ?, count, 0)) AS SIGNED
+	//    ) AS regional,
+	//    CAST(
+	//      SUM(IF(region != ?, count, 0)) AS SIGNED
+	//    ) AS imported
+	//  FROM
+	//    ratelimit_global_counters FORCE INDEX (active_window_import_idx)
+	//  WHERE
+	//    expires_at > ?
+	//  GROUP BY
+	//    workspace_id,
+	//    namespace,
+	//    identifier,
+	//    duration_ms,
+	//    sequence
 	GlobalCountersImported(ctx context.Context, arg GlobalCountersImportedParams) ([]GlobalCountersImportedRow, error)
 	// GlobalCountersListAll returns raw per-region global counter rows for tests
 	// that need to assert which region wrote which observation. Production callers

--- a/internal/services/ratelimit/db/queries/global_counters_imported.sql
+++ b/internal/services/ratelimit/db/queries/global_counters_imported.sql
@@ -8,13 +8,24 @@
 -- rows just to collapse them in Go wastes bandwidth and memory. The sums are
 -- cast to SIGNED so sqlc maps them to int64, matching atomic.Int64 in the caller.
 SELECT
-    workspace_id,
-    namespace,
-    identifier,
-    duration_ms,
-    sequence,
-    CAST(SUM(CASE WHEN region = sqlc.arg("self_region") THEN count ELSE 0 END) AS SIGNED) AS regional,
-    CAST(SUM(CASE WHEN region != sqlc.arg("self_region") THEN count ELSE 0 END) AS SIGNED) AS imported
-FROM ratelimit_global_counters
-WHERE expires_at > sqlc.arg("now")
-GROUP BY workspace_id, namespace, identifier, duration_ms, sequence;
+  workspace_id,
+  namespace,
+  identifier,
+  duration_ms,
+  sequence,
+  CAST(
+    SUM(IF(region = sqlc.arg("self_region"), count, 0)) AS SIGNED
+  ) AS regional,
+  CAST(
+    SUM(IF(region != sqlc.arg("self_region"), count, 0)) AS SIGNED
+  ) AS imported
+FROM
+  ratelimit_global_counters FORCE INDEX (active_window_import_idx)
+WHERE
+  expires_at > sqlc.arg("now")
+GROUP BY
+  workspace_id,
+  namespace,
+  identifier,
+  duration_ms,
+  sequence;

--- a/pkg/mysql/schema/ratelimit_global_counters.sql
+++ b/pkg/mysql/schema/ratelimit_global_counters.sql
@@ -15,3 +15,5 @@ CREATE TABLE `ratelimit_global_counters` (
 
 CREATE INDEX `expires_at_idx` ON `ratelimit_global_counters` (`expires_at`);
 
+CREATE INDEX `active_window_import_idx` ON `ratelimit_global_counters` (`expires_at`,`workspace_id`,`namespace`,`identifier`,`duration_ms`,`sequence`,`region`,`count`);
+

--- a/web/internal/db/src/schema/ratelimit.ts
+++ b/web/internal/db/src/schema/ratelimit.ts
@@ -143,5 +143,15 @@ export const ratelimitGlobalCounters = mysqlTable(
       table.region,
     ),
     index("expires_at_idx").on(table.expiresAt),
+    index("active_window_import_idx").on(
+      table.expiresAt,
+      table.workspaceId,
+      table.namespace,
+      table.identifier,
+      table.durationMs,
+      table.sequence,
+      table.region,
+      table.count,
+    ),
   ],
 );


### PR DESCRIPTION
## Summary

- **`FindKeyForVerification`**: Drive RBAC joins from `keys_roles` / `keys_permissions` by `key_id` (`STRAIGHT_JOIN`), skip identity ratelimit lookups when `identity_id IS NULL`, and resolve the key via `hash_idx` without workspace-wide role/permission scans.
- **`GlobalCountersImported`**: Add covering `active_window_import_idx` on `expires_at` and use `FORCE INDEX` so MySQL picks an index range scan on active windows instead of `unique_window_region` or a full table scan when most rows are expired.
- **Schema**: Mirror the new index in `pkg/mysql/schema` and Drizzle (`web/internal/db/src/schema/ratelimit.ts`).

## Benchmark results

Measured locally with Docker MySQL (`UNKEY_TEST_CONTAINER_SCOPE`), `containers.WithDiskStorage()` + `WithDedicatedContainer()`, 100 iterations (`-test.benchtime=100x`).

### `FindKeyForVerification` (1M keys seeded)

| Variant | ns/op |
|---|---|
| baseline (main query shape) | 487,933 (~0.49 ms) |
| optimized | 346,227 (~0.35 ms) |

**~29% faster.** EXPLAIN ANALYZE showed the baseline scanning the workspace `roles` catalog; the optimized plan starts from `keys_roles` by `key_id`.

### `GlobalCountersImported` (100k active rows)

| Variant | ns/op |
|---|---|
| baseline (`CASE WHEN`, no index hint) | 598,852,439 (~599 ms) |
| optimized (`IF()`, `FORCE INDEX`) | 595,416,692 (~595 ms) |

End-to-end time is dominated by fetching ~100k grouped rows into Go (~65 MB/op, ~1M allocs/op). SQL execution is ~20–27 ms with the covering index; further gains likely need application-side chunking or streaming, not more SQL tuning.

On a selective workload (500k expired + 10k active rows), `FORCE INDEX (active_window_import_idx)` scans ~110k active rows via covering index range scan instead of a full table scan.

## Test plan

- [x] `mise exec -- bazel build //internal/services/keys/db:db //internal/services/ratelimit/db:db`
- [ ] Deploy index migration to PlanetScale before/with query change (`active_window_import_idx`)
- [ ] Verify Insights query time for `FindKeyForVerification` and `GlobalCountersImported` in staging/production

Made with [Cursor](https://cursor.com)