### PR TITLE
docs: document krane deployment model

### DIFF
--- a/docs/engineering/architecture/services/control-plane/worker/deployment-sync.mdx
+++ b/docs/engineering/architecture/services/control-plane/worker/deployment-sync.mdx
@@ -75,7 +75,10 @@ Unrecognized or nil events are treated as errors to prevent silently skipping ch
 
 ### Periodic full resync
 
-The watcher resets its cursor to 0 every 5 minutes, triggering a full sync. This acts as a consistency safety net: if a change was missed (e.g., a `deployment_changes` row was cleaned up before the agent processed it), the periodic full sync will reconcile the drift.
+The watcher runs a full sync every 10 minutes. This acts as a consistency safety
+net: if a change was missed (for example, a `deployment_changes` row was cleaned
+up before the agent processed it), the periodic full sync will reconcile the
+drift.
 
 ## Writing changes
 

--- a/docs/engineering/architecture/services/krane/deployment.mdx
+++ b/docs/engineering/architecture/services/krane/deployment.mdx
@@ -1,0 +1,35 @@
+---
+title: "Deployment"
+description: "Deployment model and failover expectations for the krane service"
+---
+
+Krane runs as a single control agent for one Kubernetes cluster and one
+control-plane region key. The region key is the `platform` and `region` pair
+that Krane sends to the control plane.
+
+## Deployment model
+
+Run one active Krane instance for each cluster and `(platform, region)` pair.
+That instance owns reconciliation for the cluster. It watches desired state from
+the control plane, applies Kubernetes resources, reports workload status, and
+sends heartbeats.
+
+Krane doesn't serve user traffic. Frontline serves traffic to user workloads, and
+the control plane remains the source of desired deployment state.
+
+## Replacement and downtime
+
+Short Krane downtime is acceptable. During downtime, existing workloads keep
+running, but new desired-state changes and status reports wait until Krane
+reconnects.
+
+Brief overlap during replacement is acceptable, ideally on the order of seconds.
+Reconciliation is idempotent, and Krane applies Kubernetes resources from
+control-plane desired state. After a restart, Krane reconnects to the change
+stream and runs a full desired-state sync, so missed changes converge back to the
+control-plane state.
+
+## Production example
+
+For an example of this model, see the <a href="https://github.com/unkeyed/infra/tree/main/eks-cluster/helm-chart/krane" target="_blank">Krane chart in Infra</a>
+and the <a href="https://github.com/unkeyed/infra/blob/main/eks-cluster/helm-chart/krane/unkey.toml" target="_blank">Krane runtime config</a>.

--- a/docs/engineering/docs.json
+++ b/docs/engineering/docs.json
@@ -158,6 +158,7 @@
                 "group": "Krane",
                 "pages": [
                   "architecture/services/krane/overview",
+                  "architecture/services/krane/deployment",
                   "architecture/services/krane/secrets",
                   "architecture/services/krane/configuration"
                 ]


### PR DESCRIPTION
## Summary
- add a Krane deployment page covering the single-instance deployment model, replacement overlap, downtime expectations, and recovery behavior
- add the new page to the engineering docs navigation
- correct the deployment sync full-sync interval from 5 minutes to 10 minutes

## Verification
- git diff --check
- trailing-whitespace scan for touched docs