### PR TITLE
docs: define deploy instance availability expectations

### DIFF
--- a/docs/product/build-and-deploy/regions.mdx
+++ b/docs/product/build-and-deploy/regions.mdx
@@ -34,11 +34,11 @@ Production and preview environments can use different region configurations. For
 
 ## Instances per region
 
-Each region runs one or more instances of your app. Configure the autoscaling range in **Settings > Runtime settings > Instances** as a minimum and maximum replica count. The default is one instance per region (`1 – 1`).
+Each region runs one or more instances of your app. Configure the autoscaling range in **Settings > Runtime settings > Instances** as a minimum and maximum instance count. The default is one instance per region (`1 – 1`).
 
 When the minimum and maximum differ, Unkey scales each region between those bounds based on CPU load. Setting both values to the same number pins the instance count and disables autoscaling.
 
-Running multiple instances in a region provides redundancy. If one instance fails, traffic routes to the remaining healthy instances.
+Running multiple instances in a region provides redundancy. If one instance fails, traffic routes to the remaining healthy instances. For high availability, use at least 2 instances per region. See [Instances](/platform/instances/overview#high-availability) for the full availability model.
 
 <Note>
   During the beta, the maximum is four instances per region. Contact [support@unkey.com](mailto:support@unkey.com) if you need more.

--- a/docs/product/platform/instances/overview.mdx
+++ b/docs/product/platform/instances/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Instances
-description: "Understand instances in Unkey, running container replicas of your app deployed to specific regions with automatic scaling and routing."
+description: "Understand instances in Unkey, running copies of your app deployed to specific regions with automatic scaling and routing."
 ---
 
 import DeployBeta from "/snippets/deploy-beta.mdx";
@@ -35,6 +35,22 @@ Running multiple instances in a region provides redundancy and distributes load.
 <Note>
   During the beta, the maximum is 4 instances per region. Contact [support@unkey.com](mailto:support@unkey.com) if you need more.
 </Note>
+
+## High availability
+
+High availability depends on how many instances you run in each region and how many regions you select. If you configure too few instances, Unkey can't guarantee that your app stays available during infrastructure interruptions.
+
+Use this model when choosing an instance count:
+
+| Instances per region | Availability expectation |
+| -------------------- | ------------------------ |
+| 1                    | No high availability guarantee. If the instance stops, your app can become unavailable in that region. |
+| 2                    | Designed to keep at least 1 instance available during one underlying infrastructure interruption in the region. |
+| 3                    | Designed to keep at least 2 instances available during one underlying infrastructure interruption in the region. |
+
+For production workloads that need high availability, configure at least 2 instances per region. Use 3 instances when you want extra capacity during an interruption.
+
+Regional availability is separate from instance availability. To tolerate a regional outage, deploy to at least 2 regions. Each region still needs enough instances for the availability level you want.
 
 ## Resource allocation
 


### PR DESCRIPTION
## Summary
- define user-facing high availability expectations for Deploy instances
- document 1, 2, and 3 instance availability behavior without Kubernetes details
- update regions docs to use instance-count terminology and link to the HA model

## Verification
- git diff --check
- rg -n "replica count|replicas of your app|Kubernetes|ReplicaSet|pod|pods|k8s" docs/product/platform/instances/overview.mdx docs/product/build-and-deploy/regions.mdx