### PR TITLE
fix(keys): align key byte length minimum

### DIFF
--- a/docs/product/platform/apis/overview.mdx
+++ b/docs/product/platform/apis/overview.mdx
@@ -35,7 +35,7 @@ Each keyspace exposes configuration through its settings page.
 | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
 | Name                 | Human-readable label shown in the dashboard                                                                                              |
 | Default prefix       | Prefix prepended to every key created in this keyspace (for example, `sk_live`)                                                          |
-| Default bytes        | Number of random bytes used to generate new keys (default: 16)                                                                           |
+| Default bytes        | Number of random bytes used to generate new keys (default: 16, range: 16 to 255)                                                         |
 | Store encrypted keys | When enabled, Unkey stores an encrypted copy of each key so it can be recovered later. See [Recovering keys](/security/recovering-keys). |
 | IP whitelist         | Restrict key verification to specific IP addresses. See [IP whitelist](/platform/apis/features/whitelist).                               |
 
@@ -58,7 +58,7 @@ The keyspace stores:
 | ---------------------- | ------------------------------------------------------------------------------------------------------ |
 | `id`                   | Unique identifier (`ks_xxx`), used in gateway policies and analytics queries                           |
 | `default_prefix`       | Prefix for new keys (for example, `sk_live`). The prefix appears before the random portion of the key. |
-| `default_bytes`        | Number of random bytes per key (default: 16, producing a 24-character base58 string)                   |
+| `default_bytes`        | Number of random bytes per key (default: 16, range: 16 to 255)                                        |
 | `store_encrypted_keys` | Whether to store a recoverable encrypted copy of each key                                              |
 | `size_approx`          | Approximate number of live keys in this keyspace                                                       |
 
@@ -91,7 +91,7 @@ Deleting a keyspace permanently removes it and all of its keys. This action cann
 | ----------------------- | -------------- |
 | Keyspaces per workspace | Varies by plan |
 | Key prefix max length   | 8 characters   |
-| Default bytes range     | 16 to 32       |
+| Default bytes range     | 16 to 255      |
 
 ## Related pages
 

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/_components/create-key/create-key.schema.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/_components/create-key/create-key.schema.ts
@@ -26,8 +26,8 @@ export const keyBytesSchema = z.coerce
   .int({
     error: "Key length must be a whole number (integer)",
   })
-  .min(8, {
-    error: "Key length is too short (minimum 8 bytes required)",
+  .min(16, {
+    error: "Key length is too short (minimum 16 bytes required)",
   })
   .max(255, {
     error: "Key length is too long (maximum 255 bytes allowed)",

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/_components/create-key/create-key.utils.test.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/_components/create-key/create-key.utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { type FormValues, formSchema } from "./create-key.schema";
+import { type FormValues, formSchema, keyBytesSchema } from "./create-key.schema";
 import { formValuesToCreateKeyRequest, getDefaultValues } from "./create-key.utils";
 
 function formValues(overrides: Partial<FormValues> = {}): FormValues {
@@ -10,6 +10,17 @@ function formValues(overrides: Partial<FormValues> = {}): FormValues {
 }
 
 describe("formValuesToCreateKeyRequest", () => {
+  it("rejects key byte lengths below 16", () => {
+    const result = keyBytesSchema.safeParse(15);
+
+    if (result.success) {
+      throw new Error("expected key byte length validation to fail");
+    }
+    expect(result.error.issues[0]?.message).toBe(
+      "Key length is too short (minimum 16 bytes required)",
+    );
+  });
+
   it("maps minimal form values to the SDK request", () => {
     expect(formValuesToCreateKeyRequest(formValues(), "api_123")).toEqual({
       apiId: "api_123",

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/settings/components/default-bytes.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/settings/components/default-bytes.tsx
@@ -72,7 +72,7 @@ export const DefaultBytes: React.FC<Props> = ({ keyAuth, apiId }) => {
       title="Default Bytes"
       description={
         <div className="max-w-[380px]">
-          Sets the default byte size for keys under this keyspace. Must be between 8 and 255.
+          Sets the default byte size for keys under this keyspace. Must be between 16 and 255.
         </div>
       }
       contentWidth="w-full lg:w-[420px] h-full justify-end items-end"

--- a/web/internal/keys/src/v1.test.ts
+++ b/web/internal/keys/src/v1.test.ts
@@ -6,6 +6,12 @@ test("create v1 key", () => {
   expect(key.toString()).toMatch(/^[a-zA-Z0-9]+$/);
 });
 
+test("rejects keys shorter than 16 bytes", () => {
+  expect(() => new KeyV1({ byteLength: 15 })).toThrow(
+    "v1 keys must be between 16 and 255 bytes long",
+  );
+});
+
 test("unmarshal", () => {
   const key = new KeyV1({ prefix: "prfx", byteLength: 16 });
   const key2 = KeyV1.fromString(key.toString());

--- a/web/internal/keys/src/v1.ts
+++ b/web/internal/keys/src/v1.ts
@@ -12,7 +12,7 @@ const SEPARATOR = "_";
  */
 export class KeyV1 {
   public readonly version = 1;
-  public readonly prefix?: string;
+  public readonly prefix: string | undefined;
   public readonly random: Uint8Array;
 
   constructor(s: string);
@@ -34,8 +34,8 @@ export class KeyV1 {
       return;
     }
 
-    if (arg.byteLength < 8 || arg.byteLength > 255) {
-      throw new Error("v1 keys must be between 8 and 255 bytes long");
+    if (arg.byteLength < 16 || arg.byteLength > 255) {
+      throw new Error("v1 keys must be between 16 and 255 bytes long");
     }
     this.prefix = arg.prefix;
     this.random = crypto.getRandomValues(new Uint8Array(arg.byteLength));


### PR DESCRIPTION
The dashboard was still using minBytes=8 for creating keys, but since we switched to call the api (which enforces >=16bytes) this would break your dashboard experience when trying to use less than 16 bytes.

16 is the intended length anyways and this PR just updates the dashboard's client side validation to catch it earlier.