### PR TITLE
Clean toast errors

### DIFF
--- a/web/apps/dashboard/lib/unkey-client.test.ts
+++ b/web/apps/dashboard/lib/unkey-client.test.ts
@@ -1,0 +1,32 @@
+import { ForbiddenErrorResponse } from "@unkey/api/models/errors";
+import { describe, expect, it } from "vitest";
+import { getErrorMessage } from "./unkey-client";
+
+describe("getErrorMessage", () => {
+  it("returns the SDK error detail", () => {
+    const error = new ForbiddenErrorResponse(
+      {
+        error: {
+          detail: "Missing one of these permissions: api.*.update_key",
+          status: 403,
+          title: "Insufficient Permissions",
+          type: "https://unkey.com/docs/errors/unkey/authorization/insufficient_permissions",
+        },
+        meta: {
+          requestId: "req_123",
+        },
+      },
+      {
+        body: "",
+        request: new Request("https://api.unkey.com/v2/keys.updateKey"),
+        response: new Response(null, { status: 403 }),
+      },
+    );
+
+    expect(getErrorMessage(error)).toBe("Missing one of these permissions: api.*.update_key");
+  });
+
+  it("returns the fallback for non-SDK errors", () => {
+    expect(getErrorMessage(new Error("Network request failed"), "Try again")).toBe("Try again");
+  });
+});

--- a/web/apps/dashboard/lib/unkey-client.ts
+++ b/web/apps/dashboard/lib/unkey-client.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { Unkey } from "@unkey/api";
-import { UnkeyError } from "@unkey/api/models/errors";
+import * as errors from "@unkey/api/models/errors";
 
 let client: Unkey | null = null;
 const fallbackErrorMessage = "An unexpected error occurred. Please try again later.";
@@ -20,8 +20,21 @@ export function getUnkeyClient(): Unkey {
 }
 
 export function getErrorMessage(error: unknown, fallback = fallbackErrorMessage): string {
-  if (error instanceof UnkeyError) {
-    return error.message;
+  if (
+    error instanceof errors.BadRequestErrorResponse ||
+    error instanceof errors.UnauthorizedErrorResponse ||
+    error instanceof errors.ForbiddenErrorResponse ||
+    error instanceof errors.NotFoundErrorResponse ||
+    error instanceof errors.ConflictErrorResponse ||
+    error instanceof errors.GoneErrorResponse ||
+    error instanceof errors.PreconditionFailedErrorResponse ||
+    error instanceof errors.UnprocessableEntityErrorResponse ||
+    error instanceof errors.TooManyRequestsErrorResponse ||
+    error instanceof errors.InternalServerErrorResponse ||
+    error instanceof errors.ServiceUnavailableErrorResponse
+  ) {
+    return error.error.detail || fallback;
   }
+
   return fallback;
 }


### PR DESCRIPTION
yesterday we [found out](https://unkey.slack.com/archives/C060CBE5YLB/p1783439008262559?thread_ts=1783438581.492589&cid=C060CBE5YLB) that we're piping raw response bodies straight into the error-toast

this fixes the util method to only return the human-readable and user-intended string.



and before you ask, no speakeasy doesn't generate a base error that we could use, we actually have to check all or do some type sacrilege.