### PR TITLE
fix(docs): use absolute GitHub URLs in query-insights-tags

### DIFF
--- a/docs/engineering/infra/planetscale/query-insights-tags.mdx
+++ b/docs/engineering/infra/planetscale/query-insights-tags.mdx
@@ -40,7 +40,7 @@ SELECT ... FROM keys WHERE ... /*application='unkey',service='api',region='us-ea
 
 ## Go services
 
-Annotation happens in [`pkg/mysql.Replica`](../../../../pkg/mysql/replica.go) (and the mirrored [`pkg/db`](../../../../pkg/db/database.go) package). sqlc call sites stay unchanged.
+Annotation happens in [`pkg/mysql.Replica`](https://github.com/unkeyed/unkey/blob/main/pkg/mysql/replica.go) (and the mirrored [`pkg/db`](https://github.com/unkeyed/unkey/blob/main/pkg/db/database.go) package). sqlc call sites stay unchanged.
 
 1. Pass static tags when opening the database:
 
@@ -53,7 +53,7 @@ database, err := db.New(db.Config{
 })
 ```
 
-2. Optional dynamic tags via context (HTTP zen services set these automatically with [`zen.WithSQLComment`](../../../../pkg/zen/middleware_sqlcomment.go)):
+2. Optional dynamic tags via context (HTTP zen services set these automatically with [`zen.WithSQLComment`](https://github.com/unkeyed/unkey/blob/main/pkg/zen/middleware_sqlcomment.go)):
 
 ```go
 ctx = sqlcomment.WithDynamic(ctx, sqlcomment.Dynamic{Route: "POST /v2/keys.verifyKey", Source: "http"})
@@ -66,11 +66,11 @@ rows, err := database.RO().QueryContext(ctx, query, args...)
 
 `sqlcomment.Static{}` disables annotation (tests and dev seeds).
 
-Package reference: [`pkg/mysql/sqlcomment`](../../../../pkg/mysql/sqlcomment/doc.go).
+Package reference: [`pkg/mysql/sqlcomment`](https://github.com/unkeyed/unkey/blob/main/pkg/mysql/sqlcomment/doc.go).
 
 ## TypeScript apps
 
-Dashboard and portal use Drizzle on top of [`createCommentedPool`](../../../../web/internal/db/src/commented-pool.ts) from `@unkey/db`. The pool proxy annotates `query` and `execute` on the pool and on connections from `getConnection`, which is what Drizzle uses inside transactions.
+Dashboard and portal use Drizzle on top of [`createCommentedPool`](https://github.com/unkeyed/unkey/blob/main/web/internal/db/src/commented-pool.ts) from `@unkey/db`. The pool proxy annotates `query` and `execute` on the pool and on connections from `getConnection`, which is what Drizzle uses inside transactions.
 
 Useful tags on the TypeScript side:
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes broken link CI failures in `docs/engineering/infra/planetscale/query-insights-tags.mdx` by replacing relative file paths with absolute GitHub URLs.

Mintlify's `broken-links` check does not resolve relative paths to source files outside the docs tree. Other engineering docs already use `https://github.com/unkeyed/unkey/blob/main/...` for code references.

## Changes

Updated 5 links:

- `pkg/mysql/replica.go`
- `pkg/db/database.go`
- `pkg/zen/middleware_sqlcomment.go`
- `pkg/mysql/sqlcomment/doc.go`
- `web/internal/db/src/commented-pool.ts`

## Verification

- Confirmed no remaining `../` relative links in the file.
- Did not run `mintlify broken-links` locally (requires Docker docs image).
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://unkey.slack.com/archives/C05SYU6P2DC/p1783504251459139?thread_ts=1783504251.459139&cid=C05SYU6P2DC)

<div><a href="https://cursor.com/agents/bc-7eb1876a-d12c-5e20-9084-cde4fedb1740"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7eb1876a-d12c-5e20-9084-cde4fedb1740"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

