### PR TITLE
fix: hide readiness check errors

### DIFF
--- a/pkg/runner/health.go
+++ b/pkg/runner/health.go
@@ -151,7 +151,8 @@ func (r *Runner) handleReady(w http.ResponseWriter, req *http.Request) {
 	allPassed := true
 	for _, result := range results {
 		if result.err != nil {
-			response.Checks[result.name] = result.err.Error()
+			logger.Error("readiness check failed", "check", result.name, "error", result.err)
+			response.Checks[result.name] = "fail"
 			allPassed = false
 		} else {
 			response.Checks[result.name] = "ok"

--- a/pkg/runner/health_test.go
+++ b/pkg/runner/health_test.go
@@ -105,7 +105,8 @@ func TestHealthReady_WithChecks_OneFails(t *testing.T) {
 	require.NoError(t, unmarshalErr)
 	require.Equal(t, "fail", resp.Status)
 	require.Equal(t, "ok", resp.Checks["database"])
-	require.Equal(t, "connection refused", resp.Checks["redis"])
+	require.Equal(t, "fail", resp.Checks["redis"])
+	require.NotContains(t, rec.Body.String(), "connection refused")
 }
 
 func TestHealthReady_CheckTimeout(t *testing.T) {
@@ -133,7 +134,8 @@ func TestHealthReady_CheckTimeout(t *testing.T) {
 	unmarshalErr := json.Unmarshal(rec.Body.Bytes(), &resp)
 	require.NoError(t, unmarshalErr)
 	require.Equal(t, "fail", resp.Status)
-	require.Contains(t, resp.Checks["slow"], "context deadline exceeded")
+	require.Equal(t, "fail", resp.Checks["slow"])
+	require.NotContains(t, rec.Body.String(), "context deadline exceeded")
 }
 
 func TestAddReadinessCheck_PanicsOnEmptyName(t *testing.T) {


### PR DESCRIPTION
## Summary
- return generic per-check failure statuses from readiness probes
- log detailed readiness check errors server-side instead of reflecting them to callers
- update readiness tests to assert raw errors are not disclosed

## API behavior

Before, a failing readiness check returned the raw backend error to unauthenticated callers:

```http
GET /_unkey/internal/health/ready
HTTP/1.1 503 Service Unavailable
Content-Type: application/json

{
  "status": "fail",
  "checks": {
    "database": "dial tcp mysql.unkey.svc.cluster.local:3306: connect: connection refused"
  }
}
```

After, the response only exposes the per-check health state:

```http
GET /_unkey/internal/health/ready
HTTP/1.1 503 Service Unavailable
Content-Type: application/json

{
  "status": "fail",
  "checks": {
    "database": "fail"
  }
}
```

Passing checks are unchanged:

```http
GET /_unkey/internal/health/ready
HTTP/1.1 200 OK
Content-Type: application/json

{
  "status": "ok",
  "checks": {
    "database": "ok"
  }
}
```

## Testing
- mise exec -- bazel test //pkg/runner:runner_test --test_output=errors

Fixes ENG-3054