### PR TITLE
fix(lint): isolate golangci-lint cache per worktree

### DIFF
--- a/.mise/tasks/lint
+++ b/.mise/tasks/lint
@@ -2,4 +2,5 @@
 #MISE description="Run Go lint checks"
 set -euo pipefail
 
+export GOLANGCI_LINT_CACHE="${PWD}/.cache/golangci-lint"
 golangci-lint run ./...


### PR DESCRIPTION
## What changed

The lint task now gives golangci-lint a cache inside the current checkout:

```bash
GOLANGCI_LINT_CACHE=${PWD}/.cache/golangci-lint
```

`.cache/` is already ignored, so each worktree gets its own lint cache.

## Why

`golangci-lint run` was somehow showing errors from other worktrees.
Apparently it uses a global cache and doesn't handle worktrees at all. So this just moves the cache to a per-worktree folder to fix that.

## Checked

```bash
mise run lint
```
