### PR TITLE
feat(dashboard): show usage based off clickhouse

### DIFF
--- a/svc/ctrl/integration/cleanup_test.go
+++ b/svc/ctrl/integration/cleanup_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
+	restateadmin "github.com/unkeyed/unkey/pkg/restate/admin"
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/svc/ctrl/integration/seed"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/db"
@@ -34,11 +35,25 @@ func TestProjectDeletion_CleansUpAllData(t *testing.T) {
 	h := New(t)
 	ctx := h.Context()
 
+	// The environment delete handler only calls Admin to cancel a deployment's
+	// in-flight Restate invocation, and seeded deployments have no invocation id,
+	// so Admin is never exercised here. It just has to be non-nil.
+	envSvc, err := workerenvironment.New(workerenvironment.Config{
+		DB:    h.DB,
+		Admin: restateadmin.New(restateadmin.Config{BaseURL: "http://127.0.0.1:9070", APIKey: ""}),
+	})
+	require.NoError(t, err)
+
+	projSvc, err := workerproject.New(workerproject.Config{DB: h.DB})
+	require.NoError(t, err)
+	appSvc, err := workerapp.New(workerapp.Config{DB: h.DB})
+	require.NoError(t, err)
+
 	// Start Restate with all three deletion VOs bound.
 	tEnv := restatetest.Start(t,
-		hydrav1.NewProjectServiceServer(workerproject.New(workerproject.Config{DB: h.DB})),
-		hydrav1.NewAppServiceServer(workerapp.New(workerapp.Config{DB: h.DB})),
-		hydrav1.NewEnvironmentServiceServer(workerenvironment.New(workerenvironment.Config{DB: h.DB})),
+		hydrav1.NewProjectServiceServer(projSvc),
+		hydrav1.NewAppServiceServer(appSvc),
+		hydrav1.NewEnvironmentServiceServer(envSvc),
 	)
 
 	workspaceID := h.Seed.Resources.UserWorkspace.ID
@@ -83,7 +98,7 @@ func TestProjectDeletion_CleansUpAllData(t *testing.T) {
 
 	// Region (needed for topology and cilium policies)
 	regionID := uid.New(uid.RegionPrefix)
-	err := h.DB.UpsertRegion(ctx, db.UpsertRegionParams{
+	err = h.DB.UpsertRegion(ctx, db.UpsertRegionParams{
 		ID:       regionID,
 		Name:     "test-cleanup",
 		Platform: "test",
@@ -106,7 +121,6 @@ func TestProjectDeletion_CleansUpAllData(t *testing.T) {
 		AutoscalingThresholdCpu:    sql.NullInt16{Valid: false},
 		AutoscalingThresholdMemory: sql.NullInt16{Valid: false},
 		DesiredStatus:              db.DeploymentTopologyDesiredStatusRunning,
-		Version:                    1,
 		CreatedAt:                  now,
 	})
 	require.NoError(t, err)
@@ -123,7 +137,6 @@ func TestProjectDeletion_CleansUpAllData(t *testing.T) {
 		K8sNamespace:  "test-ns",
 		RegionID:      region.ID,
 		Policy:        json.RawMessage(`{"apiVersion":"cilium.io/v2"}`),
-		Version:       1,
 		CreatedAt:     now,
 	})
 	require.NoError(t, err)
@@ -168,15 +181,14 @@ func TestProjectDeletion_CleansUpAllData(t *testing.T) {
 	require.NoError(t, err)
 
 	// App regional settings
-	err = db.Query.UpsertAppRegionalSettings(ctx, h.DB.RW(), db.UpsertAppRegionalSettingsParams{
-		WorkspaceID:                   workspaceID,
-		AppID:                         app.ID,
-		EnvironmentID:                 env.ID,
-		RegionID:                      region.ID,
-		Replicas:                      2,
-		HorizontalAutoscalingPolicyID: sql.NullString{Valid: false, String: ""},
-		CreatedAt:                     now,
-		UpdatedAt:                     sql.NullInt64{Valid: false},
+	err = h.DB.UpsertAppRegionalSettings(ctx, db.UpsertAppRegionalSettingsParams{
+		WorkspaceID:   workspaceID,
+		AppID:         app.ID,
+		EnvironmentID: env.ID,
+		RegionID:      region.ID,
+		Replicas:      2,
+		CreatedAt:     now,
+		UpdatedAt:     sql.NullInt64{Valid: false},
 	})
 	require.NoError(t, err)
 

--- a/svc/ctrl/integration/create_project_test.go
+++ b/svc/ctrl/integration/create_project_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/unkeyed/unkey/pkg/auditlog"
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/auditlogs"
-	"github.com/unkeyed/unkey/svc/ctrl/internal/db"
 	"github.com/unkeyed/unkey/svc/ctrl/services/project"
 )
 

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/deploy-product-card.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/deploy-product-card.tsx
@@ -16,7 +16,6 @@ import {
 import { ADMIN_ONLY_TOOLTIP } from "./constants";
 import { ProductCard } from "./product-card";
 import { SpendBudget } from "./spend-budget";
-import { UsageMeter } from "./usage-meter";
 
 type DeployProductCardProps = {
   isAdmin: boolean;
@@ -26,10 +25,10 @@ type DeployProductCardProps = {
 };
 
 /**
- * The Deploy product card, the page's hero: current plan and fee, usage spend
- * against the included credits, and the per-meter month-to-date quantities the
- * spend is made of. Without a plan it's the subscribe entry point. Cancelling
- * is a quiet footer link with a confirmation dialog, not a danger zone.
+ * The Deploy product card, the page's hero: current plan and fee, the spend
+ * budget, and the per-meter month-to-date quantities the spend is made of.
+ * Without a plan it's the subscribe entry point. Cancelling is a quiet footer
+ * link with a confirmation dialog, not a danger zone.
  */
 export const DeployProductCard: React.FC<DeployProductCardProps> = ({
   isAdmin,
@@ -57,16 +56,13 @@ export const DeployProductCard: React.FC<DeployProductCardProps> = ({
     trpc: { context: { skipBatch: true } },
     retry: 1,
   });
-  const { data: invoice } = trpc.stripe.getUpcomingInvoice.useQuery(undefined, {
-    enabled: Boolean(currentPlan),
-    staleTime: 30_000,
-  });
 
   const revalidate = async () => {
     await Promise.all([
       trpcUtils.stripe.getDeploySubscription.invalidate(),
       trpcUtils.stripe.getDeployEntitlement.invalidate(),
       trpcUtils.stripe.getUpcomingInvoice.invalidate(),
+      trpcUtils.billing.queryDeployUsage.invalidate(),
       trpcUtils.workspace.getCurrent.invalidate(),
       trpcUtils.stripe.getDeploySubscription.refetch(),
     ]);
@@ -111,9 +107,14 @@ export const DeployProductCard: React.FC<DeployProductCardProps> = ({
   const plans = plansData?.plans ?? [];
   const currentPlanOption = plans.find((p) => p.plan === currentPlan);
 
-  // Credits equal the plan fee; usage beyond them is billed on top.
-  const credits = currentPlanOption?.amount ?? null;
-  const usageAmount = invoice?.deployUsageAmount ?? null;
+  // Gross month-to-date usage in cents, priced the same way the spend-cap
+  // worker prices it, so the budget bar tracks what the cap enforces.
+  const usageAmount = usage?.grossCents ?? null;
+
+  // The plan's recurring fee and its equal monthly credits, from the plan
+  // catalog. The fee includes credits of the same amount, so the two are equal.
+  const planFee = currentPlanOption?.amount ?? null;
+  const credits = planFee;
 
   const meterStats = usage
     ? [
@@ -186,8 +187,8 @@ export const DeployProductCard: React.FC<DeployProductCardProps> = ({
         tag={currentPlan ? (currentPlanOption?.name ?? currentPlan) : undefined}
         subtitle={
           currentPlan
-            ? credits !== null
-              ? `${formatDollars(credits)}/${currentPlanOption?.interval ?? "month"}, includes ${formatDollars(credits)} of usage credits`
+            ? planFee !== null
+              ? `${formatDollars(planFee)}/${currentPlanOption?.interval ?? "month"}, includes ${formatDollars(planFee)} of usage credits`
               : "The plan fee includes usage credits; usage beyond them is billed on top."
             : "Run and scale your projects. Every plan includes usage credits equal to its fee."
         }
@@ -243,18 +244,6 @@ export const DeployProductCard: React.FC<DeployProductCardProps> = ({
       >
         {currentPlan ? (
           <div className="flex flex-col gap-4">
-            <UsageMeter
-              label="Usage this period"
-              value={
-                usageAmount !== null && credits !== null
-                  ? `${formatDollars(usageAmount)} of ${formatDollars(credits)} credits`
-                  : usageAmount !== null
-                    ? formatDollars(usageAmount)
-                    : "—"
-              }
-              fraction={usageAmount !== null && credits ? usageAmount / credits : null}
-              fillClassName="bg-orange-9"
-            />
             {meterStats ? (
               <div className="grid grid-cols-2 gap-px overflow-hidden rounded-lg bg-grayA-3 sm:grid-cols-5">
                 {meterStats.map((stat) => (

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/spend-budget.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/spend-budget.tsx
@@ -37,14 +37,14 @@ function parseDollars(value: string): number | null | undefined {
 
 type SpendBudgetProps = {
   isAdmin: boolean;
-  /** Month-to-date Compute usage spend in cents, or null while loading. */
+  /** Month-to-date gross usage spend in cents, or null while loading. */
   usageCents: number | null;
 };
 
 /**
- * The Compute spend-budget row: a flush section under the usage meter showing
+ * The Compute spend-budget row: a flush section under the meter stats showing
  * month-to-date usage spend against the monthly budget, severity-colored with
- * ticks at the fixed alert thresholds (Vercel's model: one number, alerts at
+ * ticks at the fixed alert thresholds (one number, alerts at
  * percentages of it, stopping workloads is a toggle). The bar spans the full
  * width like the usage meter above it, so the ticks line up; the Edit action
  * sits on the caption line below. Unset budget renders a one-line invitation
@@ -134,8 +134,8 @@ export const SpendBudget: React.FC<SpendBudgetProps> = ({ isAdmin, usageCents })
           <div className="flex items-center justify-between gap-4">
             <span className="text-[12px] text-gray-10">
               {budget?.stopAtBudget
-                ? "Email alerts at 50%, 75% and 100% · workloads stop at the budget"
-                : "Email alerts at 50%, 75% and 100% · workloads keep running"}
+                ? "Email alerts at 50%, 75% and 100% of your budget · workloads stop at the budget"
+                : "Email alerts at 50%, 75% and 100% of your budget · workloads keep running"}
             </span>
             <div className="shrink-0">{editButton}</div>
           </div>
@@ -191,7 +191,7 @@ export const SpendBudget: React.FC<SpendBudgetProps> = ({ isAdmin, usageCents })
         <div className="flex flex-col gap-5">
           <FormInput
             label="Monthly budget"
-            description="We email you when usage spend reaches 50%, 75% and 100% of this amount. Leave empty for no budget."
+            description="We email you when your usage spend reaches 50%, 75% and 100% of this amount. Leave empty for no budget."
             placeholder="300"
             prefix="$"
             inputMode="numeric"

--- a/web/apps/dashboard/app/api/webhooks/stripe/route.ts
+++ b/web/apps/dashboard/app/api/webhooks/stripe/route.ts
@@ -634,7 +634,10 @@ export const POST = async (req: Request): Promise<Response> => {
           customer.email,
           customer.name || "Unknown",
         );
-        break;
+        // Return rather than break so this case can never fall through into
+        // invoice.payment_failed below; every other terminus in this case
+        // returns too.
+        return new Response("OK");
       } catch (error) {
         console.error("Subscription creation webhook error:", {
           error:

--- a/web/apps/dashboard/lib/billing/deployPricing.test.ts
+++ b/web/apps/dashboard/lib/billing/deployPricing.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { microCentsToCents, priceDeployUsageMicroCents } from "./deployPricing";
+
+describe("priceDeployUsageMicroCents", () => {
+  it("prices zero usage as zero", () => {
+    expect(
+      priceDeployUsageMicroCents({
+        cpuSeconds: 0,
+        memoryGiBHours: 0,
+        diskGiBHours: 0,
+        egressGiB: 0,
+        activeKeys: 0,
+      }),
+    ).toBe(0);
+  });
+
+  it("matches the Go catalog rates per meter unit", () => {
+    expect(
+      priceDeployUsageMicroCents({
+        cpuSeconds: 1,
+        memoryGiBHours: 0,
+        diskGiBHours: 0,
+        egressGiB: 0,
+        activeKeys: 0,
+      }),
+    ).toBe(694);
+    expect(
+      priceDeployUsageMicroCents({
+        cpuSeconds: 0,
+        memoryGiBHours: 1 / 3600,
+        diskGiBHours: 0,
+        egressGiB: 0,
+        activeKeys: 0,
+      }),
+    ).toBe(347);
+    expect(
+      priceDeployUsageMicroCents({
+        cpuSeconds: 0,
+        memoryGiBHours: 0,
+        diskGiBHours: 0,
+        egressGiB: 1,
+        activeKeys: 0,
+      }),
+    ).toBe(5_000_000);
+    expect(
+      priceDeployUsageMicroCents({
+        cpuSeconds: 0,
+        memoryGiBHours: 0,
+        diskGiBHours: 1 / 3600,
+        egressGiB: 0,
+        activeKeys: 0,
+      }),
+    ).toBe(6);
+    expect(
+      priceDeployUsageMicroCents({
+        cpuSeconds: 0,
+        memoryGiBHours: 0,
+        diskGiBHours: 0,
+        egressGiB: 0,
+        activeKeys: 1,
+      }),
+    ).toBe(200_000);
+  });
+
+  it("sums meters like the spend-cap worker", () => {
+    const micro = priceDeployUsageMicroCents({
+      cpuSeconds: 0,
+      memoryGiBHours: 0,
+      diskGiBHours: 0,
+      egressGiB: 10,
+      activeKeys: 100,
+    });
+    expect(micro).toBe(70 * 1_000_000);
+  });
+});
+
+describe("microCentsToCents", () => {
+  it("truncates sub-cent fractions for display", () => {
+    expect(microCentsToCents(4_711_499_999)).toBe(4_711);
+  });
+});

--- a/web/apps/dashboard/lib/billing/deployPricing.ts
+++ b/web/apps/dashboard/lib/billing/deployPricing.ts
@@ -1,0 +1,42 @@
+/** Mirrors tools/pricing/catalog.go CentsPerUnit; keep in sync with deploybilling/billing.go. */
+const CENTS_PER_CPU_SECOND = 0.0006944;
+const CENTS_PER_MEMORY_GIB_SECOND = 0.0003472;
+const CENTS_PER_EGRESS_GIB = 5.0;
+const CENTS_PER_DISK_GIB_SECOND = 0.000006;
+const CENTS_PER_ACTIVE_KEY = 0.2;
+
+const SECONDS_PER_HOUR = 3600;
+
+/** Same fixed-point scale as deploybilling.MicroCentsPerCent. */
+export const MICRO_CENTS_PER_CENT = 1_000_000;
+
+export type DeployUsageQuantities = {
+  cpuSeconds: number;
+  memoryGiBHours: number;
+  diskGiBHours: number;
+  egressGiB: number;
+  activeKeys: number;
+};
+
+/**
+ * Prices month-to-date Deploy usage in micro-cents, matching the spend-cap
+ * worker's PriceMicroCents so the dashboard bar tracks what alerts enforce.
+ */
+export function priceDeployUsageMicroCents(usage: DeployUsageQuantities): number {
+  const memoryGiBSeconds = usage.memoryGiBHours * SECONDS_PER_HOUR;
+  const diskGiBSeconds = usage.diskGiBHours * SECONDS_PER_HOUR;
+
+  const cents =
+    usage.cpuSeconds * CENTS_PER_CPU_SECOND +
+    memoryGiBSeconds * CENTS_PER_MEMORY_GIB_SECOND +
+    usage.egressGiB * CENTS_PER_EGRESS_GIB +
+    diskGiBSeconds * CENTS_PER_DISK_GIB_SECOND +
+    usage.activeKeys * CENTS_PER_ACTIVE_KEY;
+
+  return Math.round(cents * MICRO_CENTS_PER_CENT);
+}
+
+/** Converts micro-cents to whole cents for formatDollars and the spend budget bar. */
+export function microCentsToCents(microCents: number): number {
+  return Math.floor(microCents / MICRO_CENTS_PER_CENT);
+}

--- a/web/apps/dashboard/lib/stripe/deployCredits.test.ts
+++ b/web/apps/dashboard/lib/stripe/deployCredits.test.ts
@@ -1,7 +1,17 @@
 import type Stripe from "stripe";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { DeployBillingConfig } from "./deployBilling";
-import { netDeployFee } from "./deployCredits";
+import { grantDeployCreditsForInvoice, netDeployFee } from "./deployCredits";
+
+vi.mock("./deployBilling", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./deployBilling")>();
+  return {
+    ...actual,
+    deployBillingConfig: vi.fn(),
+  };
+});
+
+import { deployBillingConfig } from "./deployBilling";
 
 const config: DeployBillingConfig = {
   planFeePriceIds: {
@@ -109,5 +119,78 @@ describe("netDeployFee", () => {
     // invoice-level coupons this way): the grant tracks the $40 actually paid.
     const fee = netDeployFee(config, [line("price_fee_business", 5000, 1_700_000_000, 1000)]);
     expect(fee?.amountCents).toBe(4000);
+  });
+});
+
+function invoiceStub(overrides: Partial<Stripe.Invoice> = {}): Stripe.Invoice {
+  const periodEnd = Math.floor(Date.now() / 1000) + 7 * 24 * 3600;
+  return {
+    id: "in_test",
+    customer: "cus_test",
+    currency: "usd",
+    lines: {
+      has_more: false,
+      data: [line("price_fee_business", 5000, periodEnd)],
+    },
+    ...overrides,
+  } as unknown as Stripe.Invoice;
+}
+
+describe("grantDeployCreditsForInvoice", () => {
+  afterEach(() => {
+    vi.mocked(deployBillingConfig).mockReset();
+  });
+
+  it("grants credits for a paid renewal fee line", async () => {
+    vi.mocked(deployBillingConfig).mockResolvedValue(config);
+    const create = vi.fn().mockResolvedValue({ id: "credgrant_test" });
+    const list = vi.fn().mockReturnValue((async function* () {})());
+    const stripe = {
+      billing: { creditGrants: { create, list } },
+    } as unknown as Stripe;
+
+    const result = await grantDeployCreditsForInvoice(stripe, invoiceStub());
+    expect(result).toEqual({
+      granted: true,
+      grantId: "credgrant_test",
+      amountCents: 5000,
+      periodTotalCents: 5000,
+    });
+    expect(create).toHaveBeenCalledOnce();
+  });
+
+  it("skips when billing is not configured", async () => {
+    vi.mocked(deployBillingConfig).mockResolvedValue(null);
+    const stripe = {
+      billing: { creditGrants: { create: vi.fn(), list: vi.fn() } },
+    } as unknown as Stripe;
+    const result = await grantDeployCreditsForInvoice(stripe, invoiceStub());
+    expect(result.granted).toBe(false);
+  });
+
+  it("skips duplicate grants for the same invoice", async () => {
+    vi.mocked(deployBillingConfig).mockResolvedValue(config);
+    const periodEnd = Math.floor(Date.now() / 1000) + 7 * 24 * 3600;
+    const expiresAt = periodEnd + 3 * 24 * 3600;
+    const list = vi.fn().mockReturnValue(
+      (async function* () {
+        yield {
+          id: "credgrant_existing",
+          expires_at: expiresAt,
+          amount: { monetary: { value: 5000 } },
+          metadata: { stripe_invoice_id: "in_test" },
+        };
+      })(),
+    );
+    const stripe = {
+      billing: { creditGrants: { create: vi.fn(), list } },
+    } as unknown as Stripe;
+
+    const result = await grantDeployCreditsForInvoice(stripe, invoiceStub());
+    expect(result).toMatchObject({
+      granted: false,
+      reason: expect.stringContaining("already granted"),
+      periodTotalCents: 5000,
+    });
   });
 });

--- a/web/apps/dashboard/lib/stripe/deployCredits.ts
+++ b/web/apps/dashboard/lib/stripe/deployCredits.ts
@@ -18,9 +18,22 @@ import type { DeployPlan } from "./deployPlan";
  */
 const EXPIRY_GRACE_SECONDS = 3 * 24 * 60 * 60;
 
+export { EXPIRY_GRACE_SECONDS };
+
 export type DeployCreditGrantResult =
-  | { granted: false; reason: string }
-  | { granted: true; grantId: string; amountCents: number };
+  | {
+      granted: false;
+      reason: string;
+      /**
+       * The period's total granted credit (cents), recomputed from Stripe's
+       * grants, when the invoice carries Deploy fee lines for an open period.
+       * Present on the already-granted path so a redelivered webhook can
+       * re-persist a total an earlier delivery failed to write. Undefined when
+       * there is nothing to persist (no fee lines, closed period, no config).
+       */
+      periodTotalCents?: number;
+    }
+  | { granted: true; grantId: string; amountCents: number; periodTotalCents: number };
 
 export type NetDeployFee = {
   /** Net of the invoice's Deploy plan-fee lines (cents); can be negative. */
@@ -30,6 +43,17 @@ export type NetDeployFee = {
   /** The plan the charged (largest) fee line maps to, when recognizable. */
   plan?: DeployPlan;
 };
+
+/** The invoice's Deploy plan-fee lines, matched by price id against the config. */
+export function deployPlanFeeLines(
+  config: DeployBillingConfig,
+  lines: Stripe.InvoiceLineItem[],
+): Stripe.InvoiceLineItem[] {
+  return lines.filter((line) => {
+    const priceId = line.pricing?.price_details?.price;
+    return typeof priceId === "string" && Boolean(planForPlanFeePriceId(config, priceId));
+  });
+}
 
 /**
  * Sums an invoice's Deploy plan-fee lines net of discounts, or returns null
@@ -49,10 +73,7 @@ export function netDeployFee(
   config: DeployBillingConfig,
   lines: Stripe.InvoiceLineItem[],
 ): NetDeployFee | null {
-  const feeLines = lines.filter((line) => {
-    const priceId = line.pricing?.price_details?.price;
-    return typeof priceId === "string" && Boolean(planForPlanFeePriceId(config, priceId));
-  });
+  const feeLines = deployPlanFeeLines(config, lines);
   if (feeLines.length === 0) {
     return null;
   }
@@ -124,23 +145,30 @@ export async function grantDeployCreditsForInvoice(
     return { granted: false, reason: "period already closed" };
   }
 
-  // Replay guard beyond the 24h idempotency window: skip if this invoice
-  // already produced a grant. creditGrants.list has no metadata or created
-  // filter, so we page the customer's grants and match on the invoice id.
-  // Grants are roughly one per month, so this is a page or two even for
-  // long-tenured customers; paging avoids missing a match past the first page.
+  // One pass over the customer's grants serves two purposes. Replay guard
+  // beyond the 24h idempotency window: skip if this invoice already produced
+  // a grant (creditGrants.list has no metadata filter, so match on the
+  // invoice id). Period total: sum the grants that expire at this period's
+  // boundary — a period's grants (subscribe or renewal baseline plus upgrade
+  // top-ups) all share expires_at, and no other period's can, so the sum is
+  // the period's true included credit regardless of how many deliveries or
+  // replays got here first. Grants are roughly one per month, so this is a
+  // page or two even for long-tenured customers.
   let duplicate: Stripe.Billing.CreditGrant | undefined;
+  let periodTotalCents = 0;
   for await (const grant of stripe.billing.creditGrants.list({
     customer: customerId,
     limit: 100,
   })) {
+    if (grant.expires_at === expiresAt) {
+      periodTotalCents += grant.amount.monetary?.value ?? 0;
+    }
     if (grant.metadata?.stripe_invoice_id === invoice.id) {
       duplicate = grant;
-      break;
     }
   }
   if (duplicate) {
-    return { granted: false, reason: `already granted (${duplicate.id})` };
+    return { granted: false, reason: `already granted (${duplicate.id})`, periodTotalCents };
   }
 
   // The grant name shows up as the credit line on the invoice, so it should
@@ -166,5 +194,10 @@ export async function grantDeployCreditsForInvoice(
     { idempotencyKey: `deploy-credit-grant:${invoice.id}` },
   );
 
-  return { granted: true, grantId: created.id, amountCents: fee.amountCents };
+  return {
+    granted: true,
+    grantId: created.id,
+    amountCents: fee.amountCents,
+    periodTotalCents: periodTotalCents + fee.amountCents,
+  };
 }

--- a/web/apps/dashboard/lib/trpc/routers/billing/query-deploy-usage/index.ts
+++ b/web/apps/dashboard/lib/trpc/routers/billing/query-deploy-usage/index.ts
@@ -1,3 +1,4 @@
+import { microCentsToCents, priceDeployUsageMicroCents } from "@/lib/billing/deployPricing";
 import { clickhouse } from "@/lib/clickhouse";
 import { ratelimit, withRatelimit, workspaceProcedure } from "@/lib/trpc/trpc";
 import { TRPCError } from "@trpc/server";
@@ -9,6 +10,8 @@ export const queryDeployUsageResponse = z.object({
   diskGiBHours: z.number(),
   egressGiB: z.number(),
   activeKeys: z.number(),
+  /** Month-to-date gross usage priced locally (cents), same math as the spend-cap worker. */
+  grossCents: z.number(),
 });
 
 export type DeployUsageResponse = z.infer<typeof queryDeployUsageResponse>;
@@ -39,7 +42,20 @@ export const queryDeployUsage = workspaceProcedure
           month: now.getUTCMonth() + 1,
         }),
       ]);
-      return { ...meters, activeKeys: keys.activeKeys };
+
+      const grossMicroCents = priceDeployUsageMicroCents({
+        cpuSeconds: meters.cpuSeconds,
+        memoryGiBHours: meters.memoryGiBHours,
+        diskGiBHours: meters.diskGiBHours,
+        egressGiB: meters.egressGiB,
+        activeKeys: keys.activeKeys,
+      });
+
+      return {
+        ...meters,
+        activeKeys: keys.activeKeys,
+        grossCents: microCentsToCents(grossMicroCents),
+      };
     } catch (err) {
       console.error("Failed to query deploy usage", err);
       throw new TRPCError({

--- a/web/apps/dashboard/lib/trpc/routers/stripe/changeDeployPlan.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/changeDeployPlan.ts
@@ -93,11 +93,9 @@ export const changeDeployPlan = workspaceProcedure
     };
 
     const newPriceId = config.planFeePriceIds[input.plan];
-    try {
-      // DEPLOY_PLANS is ordered lowest to highest, so plan order doubles as
-      // the upgrade/downgrade direction.
-      const isDowngrade = DEPLOY_PLANS.indexOf(input.plan) < DEPLOY_PLANS.indexOf(planFeeItem.plan);
+    const isDowngrade = DEPLOY_PLANS.indexOf(input.plan) < DEPLOY_PLANS.indexOf(planFeeItem.plan);
 
+    try {
       await stripe.subscriptionItems.update(planFeeItem.id, {
         price: newPriceId,
         proration_behavior: isDowngrade ? "none" : "always_invoice",

--- a/web/apps/dashboard/lib/trpc/routers/stripe/subscribeDeploy.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/subscribeDeploy.ts
@@ -21,11 +21,8 @@ import { assertSubscriptionAttachable } from "./subscriptionGuards";
  * tier with no subscription yet.
  *
  * Writes workspaces.deploy_plan optimistically so the UI reflects the new plan
- * immediately. Stripe stays source of truth: the resulting customer.subscription.*
- * webhook reconciles the column, and since it derives the same value from the
- * subscription we just mutated, that reconciliation is a no-op. The
- * no-subscription path also writes stripeSubscriptionId so the webhook can find
- * this workspace.
+ * immediately. Stripe stays source of truth: customer.subscription.* reconciles
+ * deploy_plan on webhook retry.
  */
 export const subscribeDeploy = workspaceProcedure
   .use(requireWorkspaceAdmin)

--- a/web/internal/db/src/schema/workspaces.ts
+++ b/web/internal/db/src/schema/workspaces.ts
@@ -53,8 +53,7 @@ export const workspaces = mysqlTable("workspaces", {
    * Monthly Compute (Deploy) spend budget in USD cents, set by workspace
    * admins in the dashboard. NULL = no budget. Email alerts fire at fixed
    * percentages of the budget (50/75/100); deploySpendBudgetStop additionally
-   * stops workloads when month-to-date usage spend reaches it. v1 stores the
-   * preferences only: nothing alerts or stops yet.
+   * stops workloads when month-to-date usage spend reaches it.
    */
   deploySpendBudgetCents: bigint("deploy_spend_budget_cents", {
     mode: "number",


### PR DESCRIPTION
### What

We now compute your usage in the dashboard from our clickhouse db instead of asking stripe for what the meters have, as this is more realtime than an hourly delay til we send stuff to stripe. 