### PR TITLE
fix(ctrl): cap OpenAPI spec parsing size

### DIFF
--- a/svc/ctrl/worker/openapi/scrape_handler.go
+++ b/svc/ctrl/worker/openapi/scrape_handler.go
@@ -2,6 +2,7 @@ package openapi
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -16,6 +17,10 @@ import (
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/db"
 )
+
+const maxOpenAPISpecBytes = 10 * 1024 * 1024
+
+var errOpenAPISpecTooLarge = errors.New("openapi spec exceeds maximum size")
 
 // ScrapeSpec fetches the OpenAPI spec from a running deployment and persists it
 // in the database. It uses the deployment's runtime settings to locate the spec
@@ -128,20 +133,26 @@ func (s *Service) ScrapeSpec(ctx restate.Context, req *hydrav1.ScrapeSpecRequest
 			return nil, fmt.Errorf("fetching openapi spec: %w", doErr)
 		}
 
-		body, readErr := io.ReadAll(resp.Body)
+		if resp.StatusCode == http.StatusNotFound {
+			if closeErr := resp.Body.Close(); closeErr != nil {
+				return nil, fmt.Errorf("closing openapi response body: %w", closeErr)
+			}
+			return nil, nil
+		}
+		if resp.StatusCode != http.StatusOK {
+			if closeErr := resp.Body.Close(); closeErr != nil {
+				return nil, fmt.Errorf("closing openapi response body: %w", closeErr)
+			}
+			return nil, fmt.Errorf("unexpected status %d from %q endpoint", resp.StatusCode, specURL)
+		}
+
+		body, readErr := readOpenAPISpecBody(resp.Body)
 		closeErr := resp.Body.Close()
 		if readErr != nil {
 			return nil, fmt.Errorf("reading openapi response body: %w", readErr)
 		}
 		if closeErr != nil {
 			return nil, fmt.Errorf("closing openapi response body: %w", closeErr)
-		}
-
-		if resp.StatusCode == http.StatusNotFound {
-			return nil, nil
-		}
-		if resp.StatusCode != http.StatusOK {
-			return nil, fmt.Errorf("unexpected status %d from %q endpoint", resp.StatusCode, specURL)
 		}
 
 		return body, nil
@@ -172,6 +183,21 @@ func (s *Service) ScrapeSpec(ctx restate.Context, req *hydrav1.ScrapeSpecRequest
 
 	logger.Info("openapi spec scraped and persisted", "deployment_id", deploymentID)
 	return &hydrav1.ScrapeSpecResponse{}, nil
+}
+
+// readOpenAPISpecBody caps the response reader before buffering it. Reading one
+// byte past the limit lets us distinguish an exactly-max-sized spec from an
+// oversized one without loading the full tenant-controlled response.
+func readOpenAPISpecBody(body io.Reader) ([]byte, error) {
+	cappedBody := io.LimitReader(body, maxOpenAPISpecBytes+1)
+	spec, err := io.ReadAll(cappedBody)
+	if err != nil {
+		return nil, err
+	}
+	if len(spec) > maxOpenAPISpecBytes {
+		return nil, errOpenAPISpecTooLarge
+	}
+	return spec, nil
 }
 
 // validateSpecPath checks that path is a clean, absolute path suitable for resolving

--- a/svc/ctrl/worker/openapi/scrape_handler_test.go
+++ b/svc/ctrl/worker/openapi/scrape_handler_test.go
@@ -1,6 +1,7 @@
 package openapi
 
 import (
+	"bytes"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -46,6 +47,16 @@ func TestValidateSpecPath(t *testing.T) {
 			require.NotNil(t, parsed)
 		})
 	}
+}
+
+// TestReadOpenAPISpecBodyRejectsOversizedBody guarantees tenant-controlled specs
+// cannot force ctrl to buffer more than the configured OpenAPI spec limit.
+func TestReadOpenAPISpecBodyRejectsOversizedBody(t *testing.T) {
+	body := bytes.NewReader(bytes.Repeat([]byte("a"), maxOpenAPISpecBytes+1))
+
+	_, err := readOpenAPISpecBody(body)
+
+	require.ErrorIs(t, err, errOpenAPISpecTooLarge)
 }
 
 func TestHTTPClientRefusesRedirects(t *testing.T) {

--- a/web/apps/dashboard/lib/trpc/routers/deploy/deployment/getOpenApiDiff.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/deployment/getOpenApiDiff.ts
@@ -1,11 +1,12 @@
 import { OpenApiService } from "@/gen/proto/ctrl/v1/openapi_pb";
 import { createCtrlClient } from "@/lib/ctrl-client";
 import { db } from "@/lib/db";
-import { workspaceProcedure } from "@/lib/trpc/trpc";
+import { ratelimit, withRatelimit, workspaceProcedure } from "@/lib/trpc/trpc";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 
 export const getOpenApiDiff = workspaceProcedure
+  .use(withRatelimit(ratelimit.read))
   .input(
     z.object({
       oldDeploymentId: z.string(),


### PR DESCRIPTION
Previously we read the entire body when scraping openapi specs from untrusted customer workloads. Needless to say, that's a bad idea, as they could just respond with gigabytes or more of data, and we'd oom our control plane.

This adds a hard cap of 10mb and fails instead of reading more, which should be plenty for now.

I also found a missing ratelimit for reading openapi specs, so I added that in trpc