### PR TITLE
fix(ctrl): trust repo connection for git builds

### DIFF
--- a/svc/ctrl/worker/deploy/build_test.go
+++ b/svc/ctrl/worker/deploy/build_test.go
@@ -6,6 +6,8 @@ import (
 
 	restate "github.com/restatedev/sdk-go"
 	"github.com/stretchr/testify/require"
+	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
+	"github.com/unkeyed/unkey/svc/ctrl/internal/db"
 	githubclient "github.com/unkeyed/unkey/svc/ctrl/worker/github"
 )
 
@@ -142,6 +144,61 @@ func TestValidateGitBuildParams(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGitBuildParamsFromSourceUsesRepoConnectionIdentity(t *testing.T) {
+	deployment := &db.Deployment{
+		ID:                            "dep_123",
+		ProjectID:                     "proj_123",
+		AppID:                         "app_123",
+		WorkspaceID:                   "ws_123",
+		EnvironmentID:                 "env_123",
+		EncryptedEnvironmentVariables: []byte(`{"secrets":[]}`),
+	}
+	repoConn := db.GithubRepoConnection{
+		InstallationID:     42,
+		RepositoryFullName: "trusted/app",
+	}
+	source := &hydrav1.GitSource{
+		InstallationId: 999,
+		Repository:     "attacker/app",
+		ForkRepository: "contributor/app",
+		CommitSha:      "deadbeef",
+		ContextPath:    "services/api",
+		DockerfilePath: " Dockerfile ",
+		BuildCommand:   " pnpm build ",
+		PrNumber:       7,
+	}
+
+	params, err := gitBuildParamsFromSource(source, deployment, repoConn)
+
+	require.NoError(t, err)
+	require.Equal(t, int64(42), params.InstallationID)
+	require.Equal(t, "trusted/app", params.Repository)
+	require.Equal(t, "contributor/app", params.ForkRepository)
+	require.Equal(t, "deadbeef", params.CommitSHA)
+	require.Equal(t, "services/api", params.ContextPath)
+	require.Equal(t, "Dockerfile", params.DockerfilePath)
+	require.Equal(t, "pnpm build", params.BuildCommand)
+	require.Equal(t, int64(7), params.PrNumber)
+	require.Equal(t, "proj_123", params.ProjectID)
+	require.Equal(t, "app_123", params.AppID)
+	require.Equal(t, "dep_123", params.DeploymentID)
+	require.Equal(t, "ws_123", params.WorkspaceID)
+	require.Equal(t, "env_123", params.EnvironmentID)
+}
+
+func TestGitBuildParamsFromSourceRequiresResolvedCommit(t *testing.T) {
+	deployment := &db.Deployment{ID: "dep_123"}
+	repoConn := db.GithubRepoConnection{
+		InstallationID:     42,
+		RepositoryFullName: "trusted/app",
+	}
+
+	_, err := gitBuildParamsFromSource(&hydrav1.GitSource{}, deployment, repoConn)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "dep_123")
 }
 
 // TestBuildGitSolverOptions_EnvSecretGating proves env vars only become a

--- a/svc/ctrl/worker/deploy/deploy_handler.go
+++ b/svc/ctrl/worker/deploy/deploy_handler.go
@@ -393,34 +393,29 @@ func (w *Workflow) buildImage(ctx restate.ObjectContext, req *hydrav1.DeployRequ
 	case *hydrav1.DeployRequest_DockerImage:
 		dockerImage = source.DockerImage.GetImage()
 	case *hydrav1.DeployRequest_Git:
-		commitSHA := source.Git.GetCommitSha()
-		forkRepo := source.Git.GetForkRepository()
-
-		if commitSHA == "" {
-			return fault.Wrap(
-				restate.TerminalError(fmt.Errorf("git source missing commit SHA for deployment %q", deployment.ID)),
-				fault.Public("Deployment has no resolved commit; cannot build."),
-			)
+		repoConn, repoErr := restate.Run(ctx, func(runCtx restate.RunContext) (db.GithubRepoConnection, error) {
+			found, findErr := w.db.FindGithubRepoConnectionByAppId(runCtx, deployment.AppID)
+			if findErr != nil {
+				if db.IsNotFound(findErr) {
+					return db.GithubRepoConnection{}, fault.Wrap(
+						restate.TerminalError(fmt.Errorf("github repo connection not found for app %q", deployment.AppID)),
+						fault.Public("This app is not connected to a GitHub repository."),
+					) //nolint:exhaustruct
+				}
+				return db.GithubRepoConnection{}, findErr //nolint:exhaustruct
+			}
+			return found, nil
+		}, restate.WithName("find github repo connection for build"), restate.WithMaxRetryAttempts(runMaxAttempts))
+		if repoErr != nil {
+			return fault.Wrap(repoErr, fault.Public("Failed to read GitHub repository settings."))
 		}
 
-		params := gitBuildParams{
-			InstallationID: source.Git.GetInstallationId(),
-			Repository:     source.Git.GetRepository(),
-			ForkRepository: forkRepo,
-			CommitSHA:      commitSHA,
-			ContextPath:    source.Git.GetContextPath(),
-			// Normalized here because the value routes the build method below:
-			// a whitespace-only setting must mean "no Dockerfile configured".
-			DockerfilePath: strings.TrimSpace(source.Git.GetDockerfilePath()),
-			// Trimmed so a whitespace-only setting means "let Railpack auto-detect".
-			BuildCommand:                  strings.TrimSpace(source.Git.GetBuildCommand()),
-			ProjectID:                     deployment.ProjectID,
-			AppID:                         deployment.AppID,
-			DeploymentID:                  deployment.ID,
-			WorkspaceID:                   deployment.WorkspaceID,
-			PrNumber:                      source.Git.GetPrNumber(),
-			EncryptedEnvironmentVariables: deployment.EncryptedEnvironmentVariables,
-			EnvironmentID:                 deployment.EnvironmentID,
+		params, paramsErr := gitBuildParamsFromSource(source.Git, deployment, repoConn)
+		if paramsErr != nil {
+			return fault.Wrap(
+				restate.TerminalError(paramsErr),
+				fault.Public("Deployment has no resolved commit; cannot build."),
+			)
 		}
 
 		// The configured Dockerfile path decides the build method: when the
@@ -487,6 +482,33 @@ func (w *Workflow) buildImage(ctx restate.ObjectContext, req *hydrav1.DeployRequ
 	}
 
 	return nil
+}
+
+func gitBuildParamsFromSource(source *hydrav1.GitSource, deployment *db.Deployment, repoConn db.GithubRepoConnection) (gitBuildParams, error) {
+	commitSHA := source.GetCommitSha()
+	if commitSHA == "" {
+		return gitBuildParams{}, fmt.Errorf("git source missing commit SHA for deployment %q", deployment.ID) //nolint:exhaustruct
+	}
+
+	return gitBuildParams{
+		InstallationID: repoConn.InstallationID,
+		Repository:     repoConn.RepositoryFullName,
+		ForkRepository: source.GetForkRepository(),
+		CommitSHA:      commitSHA,
+		ContextPath:    source.GetContextPath(),
+		// Normalized here because the value routes the build method below:
+		// a whitespace-only setting must mean "no Dockerfile configured".
+		DockerfilePath: strings.TrimSpace(source.GetDockerfilePath()),
+		// Trimmed so a whitespace-only setting means "let Railpack auto-detect".
+		BuildCommand:                  strings.TrimSpace(source.GetBuildCommand()),
+		ProjectID:                     deployment.ProjectID,
+		AppID:                         deployment.AppID,
+		DeploymentID:                  deployment.ID,
+		WorkspaceID:                   deployment.WorkspaceID,
+		PrNumber:                      source.GetPrNumber(),
+		EncryptedEnvironmentVariables: deployment.EncryptedEnvironmentVariables,
+		EnvironmentID:                 deployment.EnvironmentID,
+	}, nil
 }
 
 // createTopologies determines the target regions and replica counts, bulk-inserts


### PR DESCRIPTION
## Summary
- Resolve GitHub repository connection during deploy builds instead of trusting repository identity from the deploy request Git source
- Keep commit, fork repository, PR number, paths, and build command from the resolved source payload
- Add regression coverage for spoofed installation/repository input and missing commit SHA

## Testing
- mise exec -- rask ./svc/ctrl/worker/deploy