### PR TITLE
fix: run distroless images as nonroot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,5 @@ FROM gcr.io/distroless/static-debian12@sha256:9c346e4be81b5ca7ff31a0d89eaeade58b
 
 COPY --from=builder /out/unkey /unkey
 LABEL org.opencontainers.image.source=https://github.com/unkeyed/unkey
+USER nonroot:nonroot
 ENTRYPOINT ["/unkey"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY . .
 
 RUN go build -o /out/unkey .
 
-FROM gcr.io/distroless/static-debian12:nonroot@sha256:b7bb25d9f7c31d2bdd1982feb4dafcaf137703c7075dbe2febb41c24212b946f
+FROM gcr.io/distroless/static-debian13:nonroot@sha256:d29e660cc75a5b6b1334e03c5c81ccf9bc0884a002c6000dbf0fb96034814478
 
 COPY --from=builder /out/unkey /unkey
 LABEL org.opencontainers.image.source=https://github.com/unkeyed/unkey

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,6 @@ FROM gcr.io/distroless/static-debian12@sha256:9c346e4be81b5ca7ff31a0d89eaeade58b
 
 COPY --from=builder /out/unkey /unkey
 LABEL org.opencontainers.image.source=https://github.com/unkeyed/unkey
-USER nonroot:nonroot
+# Distroless nonroot UID/GID.
+USER 65532:65532
 ENTRYPOINT ["/unkey"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,8 @@ COPY . .
 
 RUN go build -o /out/unkey .
 
-FROM gcr.io/distroless/static-debian12@sha256:9c346e4be81b5ca7ff31a0d89eaeade58b0f95cfd3baed1f36083ddb47ca3160
+FROM gcr.io/distroless/static-debian12:nonroot@sha256:b7bb25d9f7c31d2bdd1982feb4dafcaf137703c7075dbe2febb41c24212b946f
 
 COPY --from=builder /out/unkey /unkey
 LABEL org.opencontainers.image.source=https://github.com/unkeyed/unkey
-# Distroless nonroot UID/GID.
-USER 65532:65532
 ENTRYPOINT ["/unkey"]

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/static-debian12:nonroot@sha256:b7bb25d9f7c31d2bdd1982feb4dafcaf137703c7075dbe2febb41c24212b946f
+FROM gcr.io/distroless/static-debian13:nonroot@sha256:d29e660cc75a5b6b1334e03c5c81ccf9bc0884a002c6000dbf0fb96034814478
 ARG TARGETPLATFORM
 COPY ${TARGETPLATFORM}/unkey /unkey
 LABEL org.opencontainers.image.source=https://github.com/unkeyed/unkey

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -2,5 +2,6 @@ FROM gcr.io/distroless/static-debian12@sha256:9c346e4be81b5ca7ff31a0d89eaeade58b
 ARG TARGETPLATFORM
 COPY ${TARGETPLATFORM}/unkey /unkey
 LABEL org.opencontainers.image.source=https://github.com/unkeyed/unkey
-USER nonroot:nonroot
+# Distroless nonroot UID/GID.
+USER 65532:65532
 ENTRYPOINT ["/unkey"]

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -2,4 +2,5 @@ FROM gcr.io/distroless/static-debian12@sha256:9c346e4be81b5ca7ff31a0d89eaeade58b
 ARG TARGETPLATFORM
 COPY ${TARGETPLATFORM}/unkey /unkey
 LABEL org.opencontainers.image.source=https://github.com/unkeyed/unkey
+USER nonroot:nonroot
 ENTRYPOINT ["/unkey"]

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,7 +1,5 @@
-FROM gcr.io/distroless/static-debian12@sha256:9c346e4be81b5ca7ff31a0d89eaeade58b0f95cfd3baed1f36083ddb47ca3160
+FROM gcr.io/distroless/static-debian12:nonroot@sha256:b7bb25d9f7c31d2bdd1982feb4dafcaf137703c7075dbe2febb41c24212b946f
 ARG TARGETPLATFORM
 COPY ${TARGETPLATFORM}/unkey /unkey
 LABEL org.opencontainers.image.source=https://github.com/unkeyed/unkey
-# Distroless nonroot UID/GID.
-USER 65532:65532
 ENTRYPOINT ["/unkey"]

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -17,5 +17,6 @@ FROM gcr.io/distroless/static-debian12@sha256:9c346e4be81b5ca7ff31a0d89eaeade58b
 
 COPY --from=builder /out/unkey /unkey
 LABEL org.opencontainers.image.source=https://github.com/unkeyed/unkey
-USER nonroot:nonroot
+# Distroless nonroot UID/GID.
+USER 65532:65532
 ENTRYPOINT ["/unkey"]

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -13,7 +13,7 @@ COPY . .
 
 RUN go build -o /out/unkey ${PACKAGE}
 
-FROM gcr.io/distroless/static-debian12:nonroot@sha256:b7bb25d9f7c31d2bdd1982feb4dafcaf137703c7075dbe2febb41c24212b946f
+FROM gcr.io/distroless/static-debian13:nonroot@sha256:d29e660cc75a5b6b1334e03c5c81ccf9bc0884a002c6000dbf0fb96034814478
 
 COPY --from=builder /out/unkey /unkey
 LABEL org.opencontainers.image.source=https://github.com/unkeyed/unkey

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -17,4 +17,5 @@ FROM gcr.io/distroless/static-debian12@sha256:9c346e4be81b5ca7ff31a0d89eaeade58b
 
 COPY --from=builder /out/unkey /unkey
 LABEL org.opencontainers.image.source=https://github.com/unkeyed/unkey
+USER nonroot:nonroot
 ENTRYPOINT ["/unkey"]

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -13,10 +13,8 @@ COPY . .
 
 RUN go build -o /out/unkey ${PACKAGE}
 
-FROM gcr.io/distroless/static-debian12@sha256:9c346e4be81b5ca7ff31a0d89eaeade58b0f95cfd3baed1f36083ddb47ca3160
+FROM gcr.io/distroless/static-debian12:nonroot@sha256:b7bb25d9f7c31d2bdd1982feb4dafcaf137703c7075dbe2febb41c24212b946f
 
 COPY --from=builder /out/unkey /unkey
 LABEL org.opencontainers.image.source=https://github.com/unkeyed/unkey
-# Distroless nonroot UID/GID.
-USER 65532:65532
 ENTRYPOINT ["/unkey"]

--- a/svc/kitchensink/Dockerfile
+++ b/svc/kitchensink/Dockerfile
@@ -35,5 +35,6 @@ EXPOSE 8080
 LABEL org.opencontainers.image.source=https://github.com/unkeyed/unkey
 LABEL org.opencontainers.image.description="Kitchensink — stdlib HTTP server for testing platform features"
 
-USER nonroot:nonroot
+# Distroless nonroot UID/GID.
+USER 65532:65532
 ENTRYPOINT ["/kitchensink"]

--- a/svc/kitchensink/Dockerfile
+++ b/svc/kitchensink/Dockerfile
@@ -25,7 +25,7 @@ RUN --mount=type=secret,id=${UNKEY_SECRETS_ID},target=/run/secrets/.env \
       -ldflags "-X 'github.com/unkeyed/unkey/svc/kitchensink/buildinfo.Version=${VERSION:-unset}'" \
       -o /kitchensink ./svc/kitchensink
 
-FROM gcr.io/distroless/static-debian12@sha256:9c346e4be81b5ca7ff31a0d89eaeade58b0f95cfd3baed1f36083ddb47ca3160
+FROM gcr.io/distroless/static-debian12:nonroot@sha256:b7bb25d9f7c31d2bdd1982feb4dafcaf137703c7075dbe2febb41c24212b946f
 
 COPY --from=builder /kitchensink /kitchensink
 
@@ -35,6 +35,4 @@ EXPOSE 8080
 LABEL org.opencontainers.image.source=https://github.com/unkeyed/unkey
 LABEL org.opencontainers.image.description="Kitchensink — stdlib HTTP server for testing platform features"
 
-# Distroless nonroot UID/GID.
-USER 65532:65532
 ENTRYPOINT ["/kitchensink"]

--- a/svc/kitchensink/Dockerfile
+++ b/svc/kitchensink/Dockerfile
@@ -35,4 +35,5 @@ EXPOSE 8080
 LABEL org.opencontainers.image.source=https://github.com/unkeyed/unkey
 LABEL org.opencontainers.image.description="Kitchensink — stdlib HTTP server for testing platform features"
 
+USER nonroot:nonroot
 ENTRYPOINT ["/kitchensink"]

--- a/svc/kitchensink/Dockerfile
+++ b/svc/kitchensink/Dockerfile
@@ -25,7 +25,7 @@ RUN --mount=type=secret,id=${UNKEY_SECRETS_ID},target=/run/secrets/.env \
       -ldflags "-X 'github.com/unkeyed/unkey/svc/kitchensink/buildinfo.Version=${VERSION:-unset}'" \
       -o /kitchensink ./svc/kitchensink
 
-FROM gcr.io/distroless/static-debian12:nonroot@sha256:b7bb25d9f7c31d2bdd1982feb4dafcaf137703c7075dbe2febb41c24212b946f
+FROM gcr.io/distroless/static-debian13:nonroot@sha256:d29e660cc75a5b6b1334e03c5c81ccf9bc0884a002c6000dbf0fb96034814478
 
 COPY --from=builder /kitchensink /kitchensink
 


### PR DESCRIPTION
## Summary

Fixes ENG-3047 and ENG-3046 by switching the distroless runtime images to the current pinned `static-debian13:nonroot` variant.
