### PR TITLE
chore(dashboard): Unify card surfaces to an 8px(lg) border radius

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/_components/apps-list/index.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/_components/apps-list/index.tsx
@@ -40,7 +40,7 @@ export const AppsList = () => {
           ))}
         </div>
       ) : apps.data.length === 0 ? (
-        <div className="flex-1 flex justify-center items-center px-4 py-16 border border-grayA-4 rounded-[14px] overflow-hidden">
+        <div className="flex-1 flex justify-center items-center px-4 py-16 border border-grayA-4 rounded-lg overflow-hidden">
           <Empty className="w-[400px] flex items-start">
             <Empty.Icon className="w-auto" />
             <Empty.Title>No Apps Found</Empty.Title>

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/components/card.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/components/card.tsx
@@ -8,7 +8,5 @@ export function Card({
   children: ReactNode;
   className?: string;
 }) {
-  return (
-    <div className={cn("border border-gray-4 w-full rounded-[14px]", className)}>{children}</div>
-  );
+  return <div className={cn("border border-gray-4 w-full rounded-lg", className)}>{children}</div>;
 }

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/components/empty-section.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/components/empty-section.tsx
@@ -21,7 +21,7 @@ export const EmptySection = ({
 }: EmptySectionProps) => (
   <Empty
     className={cn(
-      "min-h-[150px] rounded-[14px] border border-dashed border-gray-4 bg-gray-1/50",
+      "min-h-[150px] rounded-lg border border-dashed border-gray-4 bg-gray-1/50",
       className,
     )}
   >

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/[deploymentId]/(deployment-progress)/deployment-cancelled.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/[deploymentId]/(deployment-progress)/deployment-cancelled.tsx
@@ -103,7 +103,7 @@ export function DeploymentCancelled({ deployment, stepsData, reason }: Deploymen
         })}
       </SettingCardGroup>
 
-      <div className="border border-grayA-4 bg-grayA-2 rounded-[14px] p-4 flex items-center justify-between">
+      <div className="border border-grayA-4 bg-grayA-2 rounded-lg p-4 flex items-center justify-between">
         <div className="flex items-center gap-3">
           <div className="flex flex-col gap-0.5">
             <span className="text-sm font-medium text-gray-12">{copy.title}</span>

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/[deploymentId]/(deployment-progress)/deployment-skipped.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/[deploymentId]/(deployment-progress)/deployment-skipped.tsx
@@ -61,7 +61,7 @@ export function DeploymentSkipped() {
         />
       </SettingCardGroup>
 
-      <div className="border border-grayA-4 bg-grayA-2 rounded-[14px] p-4 flex items-center justify-between">
+      <div className="border border-grayA-4 bg-grayA-2 rounded-lg p-4 flex items-center justify-between">
         <div className="flex items-center gap-3">
           <div className="flex flex-col gap-0.5">
             <span className="text-sm font-medium text-gray-12">Deployment skipped</span>

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/[deploymentId]/(deployment-progress)/failed-deployment-banner.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/[deploymentId]/(deployment-progress)/failed-deployment-banner.tsx
@@ -49,7 +49,7 @@ export function FailedDeploymentBanner({
 
   return (
     <div className="flex flex-col gap-3 animate-fade-slide-in">
-      <div className="border border-errorA-4 bg-errorA-2 rounded-[14px] p-4 flex items-center justify-between">
+      <div className="border border-errorA-4 bg-errorA-2 rounded-lg p-4 flex items-center justify-between">
         <div className="flex items-center gap-3">
           <div className="flex flex-col gap-0.5">
             <span className="text-sm font-medium text-error-11">Deployment failed</span>

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/[deploymentId]/(overview)/components/metrics/metric-card.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/[deploymentId]/(overview)/components/metrics/metric-card.tsx
@@ -103,7 +103,7 @@ export function MetricCard({
   const gradientColor = isError ? "hsl(var(--error-9))" : config.color;
 
   return (
-    <div className="border border-gray-4 bg-grayA-1 w-full rounded-[14px] flex flex-col">
+    <div className="border border-gray-4 bg-grayA-1 w-full rounded-lg flex flex-col">
       <div className="flex items-center gap-3 w-full px-[14px] pt-[12px] pb-[8px]">
         <div
           className={cn(
@@ -141,7 +141,7 @@ export function MetricCard({
         </div>
       </div>
       <div
-        className="flex flex-col rounded-b-[14px]"
+        className="flex flex-col rounded-b-lg"
         style={{
           background: `linear-gradient(to top, color-mix(in srgb, ${gradientColor} 6%, transparent), transparent)`,
         }}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/components/deployments-card-list.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/components/deployments-card-list.tsx
@@ -50,7 +50,7 @@ export function DeploymentsCardList({ limit, title, headerAction }: DeploymentsC
 
   if (data.length === 0) {
     return (
-      <div className="border border-grayA-4 rounded-[14px] overflow-hidden">
+      <div className="border border-grayA-4 rounded-lg overflow-hidden">
         {title && <ListHeader title={title} action={headerAction} />}
         <div className="w-full flex justify-center items-center py-16 px-4">
           <Empty className="w-[400px] flex items-start">
@@ -79,7 +79,7 @@ export function DeploymentsCardList({ limit, title, headerAction }: DeploymentsC
   }
 
   return (
-    <div className="border border-grayA-4 rounded-[14px] overflow-hidden">
+    <div className="border border-grayA-4 rounded-lg overflow-hidden">
       {title && <ListHeader title={title} action={headerAction} />}
       <div className="divide-y divide-grayA-4">
         {data.map(({ deployment, environment }) => {

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/components/deployments-skeleton.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/components/deployments-skeleton.tsx
@@ -4,7 +4,7 @@ import { Dots } from "@unkey/icons";
 
 export function DeploymentsSkeleton() {
   return (
-    <div className="border border-grayA-4 rounded-[14px] overflow-hidden divide-y divide-grayA-4">
+    <div className="border border-grayA-4 rounded-lg overflow-hidden divide-y divide-grayA-4">
       {Array.from({ length: 8 }).map((_, i) => (
         // biome-ignore lint/suspicious/noArrayIndexKey: skeleton items don't need stable keys
         <div key={i} className="flex flex-col md:flex-row md:items-center px-4 py-3 gap-3 md:gap-0">

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/details/domain-row.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/details/domain-row.tsx
@@ -12,7 +12,7 @@ export function DomainRow({ domain, className }: DomainRowProps) {
   return (
     <div
       className={cn(
-        "border border-gray-4 border-t-0 first:border-t first:rounded-t-[14px] last:rounded-b-[14px] last:border-b w-full px-4 py-3 flex justify-between items-center",
+        "border border-gray-4 border-t-0 first:border-t first:rounded-t-lg last:rounded-b-lg last:border-b w-full px-4 py-3 flex justify-between items-center",
         className,
       )}
     >
@@ -38,7 +38,7 @@ export function DomainRow({ domain, className }: DomainRowProps) {
 
 export const DomainRowSkeleton = () => {
   return (
-    <div className="border border-gray-4 border-t-0 first:border-t first:rounded-t-[14px] last:rounded-b-[14px] last:border-b w-full px-4 py-3 flex justify-between items-center">
+    <div className="border border-gray-4 border-t-0 first:border-t first:rounded-t-lg last:rounded-b-lg last:border-b w-full px-4 py-3 flex justify-between items-center">
       <div className="flex items-center">
         <Link4 className="text-grayA-6" iconSize="sm-medium" />
         <div className="h-3 w-32 bg-grayA-3 rounded-sm animate-pulse ml-3 mr-2" />

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/env-vars/components/list/env-vars-list.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/env-vars/components/list/env-vars-list.tsx
@@ -134,7 +134,7 @@ export function EnvVarsList({
 
   return (
     <>
-      <div ref={listRefCallback} className="border border-grayA-4 rounded-[14px] overflow-hidden">
+      <div ref={listRefCallback} className="border border-grayA-4 rounded-lg overflow-hidden">
         <div
           style={{
             height: virtualizer.getTotalSize(),

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/env-vars/components/shared/env-vars-empty.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/env-vars/components/shared/env-vars-empty.tsx
@@ -6,7 +6,7 @@ type EnvVarsEmptyProps = {
 
 export function EnvVarsEmpty({ searchQuery }: EnvVarsEmptyProps) {
   return (
-    <div className="border border-grayA-4 rounded-[14px] overflow-hidden">
+    <div className="border border-grayA-4 rounded-lg overflow-hidden">
       <div className="flex items-center justify-center py-16 px-4">
         <Empty className="w-[400px] flex items-start">
           <Empty.Icon className="w-auto" />

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/env-vars/components/shared/env-vars-skeleton.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/env-vars/components/shared/env-vars-skeleton.tsx
@@ -2,7 +2,7 @@ import { Dots } from "@unkey/icons";
 
 export function EnvVarsSkeleton() {
   return (
-    <div className="border border-grayA-4 rounded-[14px] overflow-hidden divide-y divide-grayA-4">
+    <div className="border border-grayA-4 rounded-lg overflow-hidden divide-y divide-grayA-4">
       {Array.from({ length: 10 }).map((_, i) => (
         // biome-ignore lint/suspicious/noArrayIndexKey: skeleton items don't need stable keys
         <div key={i} className="flex items-center h-17.5">

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/openapi-diff/page.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/openapi-diff/page.tsx
@@ -146,7 +146,7 @@ export default function DiffPage() {
           </div>
 
           {/* Content Area */}
-          <div className="bg-gray-1 rounded-b-[14px] border-t border-gray-4">
+          <div className="bg-gray-1 rounded-b-lg border-t border-gray-4">
             {showEmptyState && (
               <div className="flex flex-col items-center gap-4 px-8 py-12 text-center">
                 <div className="relative">

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/overview/components/card-header.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/overview/components/card-header.tsx
@@ -83,7 +83,7 @@ export function ProductionCardHeader() {
   } = useProductionCard();
 
   return (
-    <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2 px-4 py-3 border-b border-gray-4 bg-background rounded-t-[14px]">
+    <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2 px-4 py-3 border-b border-gray-4 bg-background rounded-t-lg">
       <DomainHero />
       <div className="flex items-center gap-2 shrink-0">
         {diagnostic && (

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/overview/components/card-rollback-banner.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/overview/components/card-rollback-banner.tsx
@@ -7,7 +7,7 @@ import { useProductionCard } from "./production-card-context";
 export function ProductionCardRollbackBanner() {
   const { openUndo } = useProductionCard();
   return (
-    <div className="relative z-0 -mb-3 flex items-center justify-between gap-3 rounded-t-[14px] border border-b-0 border-warning-6 bg-warning-3 px-4 pt-2.5 pb-5">
+    <div className="relative z-0 -mb-3 flex items-center justify-between gap-3 rounded-t-lg border border-b-0 border-warning-6 bg-warning-3 px-4 pt-2.5 pb-5">
       <div className="flex items-center gap-1.5 text-[13px] min-w-0">
         <ArrowDottedRotateAnticlockwise
           iconSize="sm-regular"

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/sentinel-policies/components/list/empty.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/sentinel-policies/components/list/empty.tsx
@@ -2,7 +2,7 @@ import { Empty } from "@unkey/ui";
 
 export function SentinelPoliciesEmpty() {
   return (
-    <div className="border border-grayA-4 rounded-[14px] overflow-hidden">
+    <div className="border border-grayA-4 rounded-lg overflow-hidden">
       <div className="flex items-center justify-center py-16 px-4">
         <Empty className="w-[400px] flex items-start">
           <Empty.Icon className="w-auto" />

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/sentinel-policies/components/list/error.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/sentinel-policies/components/list/error.tsx
@@ -3,7 +3,7 @@ import { Empty } from "@unkey/ui";
 
 export function SentinelPoliciesError() {
   return (
-    <div className="border border-errorA-4 bg-errorA-2 rounded-[14px] overflow-hidden">
+    <div className="border border-errorA-4 bg-errorA-2 rounded-lg overflow-hidden">
       <div className="flex items-center justify-center py-16 px-4">
         <Empty className="w-100 flex items-start">
           <Empty.Title className="text-error-11">Failed to load policies</Empty.Title>

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/sentinel-policies/components/list/index.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/sentinel-policies/components/list/index.tsx
@@ -78,7 +78,7 @@ export function SentinelPoliciesList({
   }, []);
 
   return (
-    <div className="border border-grayA-4 rounded-[14px] overflow-hidden">
+    <div className="border border-grayA-4 rounded-lg overflow-hidden">
       {merged.map((policy, i) => (
         <SentinelPolicyRow
           key={policy.id}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/sentinel-policies/components/list/skeleton.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/sentinel-policies/components/list/skeleton.tsx
@@ -7,7 +7,7 @@ import { Button } from "@unkey/ui";
  */
 export function SentinelPoliciesListSkeleton({ rows = 10 }: { rows?: number }) {
   return (
-    <div className="border border-grayA-4 rounded-[14px] overflow-hidden">
+    <div className="border border-grayA-4 rounded-lg overflow-hidden">
       <div>
         {Array.from({ length: rows }).map((_, i) => (
           // biome-ignore lint/suspicious/noArrayIndexKey: skeleton items are static placeholders with no stable id

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/settings/components/build-settings/github-settings/github-connected.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/settings/components/build-settings/github-settings/github-connected.tsx
@@ -64,7 +64,7 @@ export const GitHubConnected = ({
   };
 
   const expandable = (
-    <div className="px-6 py-4 flex flex-col gap-3 bg-grayA-2 rounded-b-xl">
+    <div className="px-6 py-4 flex flex-col gap-3 bg-grayA-2 rounded-b-lg">
       <span className="text-gray-9 text-[13px]">
         Pushes to this repository will trigger deployments.
       </span>

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/components/active-deployment-card/components/skeleton.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/components/active-deployment-card/components/skeleton.tsx
@@ -31,9 +31,9 @@ export function ActiveDeploymentCardSkeleton() {
         </div>
       </div>
 
-      <div className="bg-gray-1 rounded-b-[14px]">
+      <div className="bg-gray-1 rounded-b-lg">
         <div className="relative h-4 flex items-center justify-center">
-          <div className="absolute top-0 left-0 right-0 h-4 border-b border-gray-4 rounded-b-[14px] bg-white dark:bg-black" />
+          <div className="absolute top-0 left-0 right-0 h-4 border-b border-gray-4 rounded-b-lg bg-white dark:bg-black" />
         </div>
 
         <div className="pb-2.5 pt-2 flex justify-between items-center px-3">

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/new/steps/configure-deployment/fallback.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/new/steps/configure-deployment/fallback.tsx
@@ -22,7 +22,7 @@ export const ConfigureDeploymentFallback = ({ settingsReady }: { settingsReady: 
     <div className="w-225">
       <div className="flex flex-col gap-6">
         {/* SettingCardGroup skeleton */}
-        <div className="border border-grayA-4 rounded-[14px] overflow-hidden divide-y divide-grayA-4">
+        <div className="border border-grayA-4 rounded-lg overflow-hidden divide-y divide-grayA-4">
           {cards.map(({ titleW, descW, badgeW }, i) => (
             <div
               // biome-ignore lint/suspicious/noArrayIndexKey: safe to leave

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/new/steps/connect-github.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/new/steps/connect-github.tsx
@@ -38,7 +38,7 @@ export const ConnectGithubStep = ({
 
   return (
     <div className="flex flex-col items-center">
-      <div className="border border-grayA-5 rounded-[14px] flex justify-start items-center gap-4 py-[18px] px-4 min-w-[600px]">
+      <div className="border border-grayA-5 rounded-lg flex justify-start items-center gap-4 py-[18px] px-4 min-w-[600px]">
         <div className="size-8 rounded-[10px] bg-gray-12 grid place-items-center">
           <Layers3 className="size-[18px] text-gray-1" iconSize="md-medium" />
         </div>

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/new/steps/create-app.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/new/steps/create-app.tsx
@@ -76,7 +76,7 @@ export const CreateAppStep = ({ projectId, onAppCreated }: CreateAppStepProps) =
 
   return (
     <div className="w-full justify-center items-center flex flex-col">
-      <div className="flex flex-col items-center border border-grayA-5 rounded-[14px] justify-center gap-4 py-[18px] px-4 min-w-[600px]">
+      <div className="flex flex-col items-center border border-grayA-5 rounded-lg justify-center gap-4 py-[18px] px-4 min-w-[600px]">
         <form onSubmit={handleSubmit(onSubmitForm)} className="flex flex-col gap-4 w-full">
           <FormInput
             requirement="required"

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/new/steps/select-repo/index.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/new/steps/select-repo/index.tsx
@@ -161,7 +161,7 @@ export const SelectRepo = ({
         {isLoadingRepos ? (
           <SelectRepoSkeleton />
         ) : reposError ? (
-          <div className="mt-3 flex flex-col items-center justify-center min-w-[var(--repo-list-w)] h-[462px] gap-3 border border-dashed rounded-[14px] border-grayA-5">
+          <div className="mt-3 flex flex-col items-center justify-center min-w-[var(--repo-list-w)] h-[462px] gap-3 border border-dashed rounded-lg border-grayA-5">
             <p className="text-[15px] text-accent-12 font-semibold">Failed to load repositories</p>
             <p className="text-[13px] text-accent-11 text-center whitespace-pre-line w-[350px]">
               {reposError.message}
@@ -204,7 +204,7 @@ export const SelectRepo = ({
         (filteredRepos.length > 0 ? (
           <div
             ref={parentRef}
-            className="mt-3 border rounded-[14px] border-grayA-5 min-w-[var(--repo-list-w)] max-h-[462px] overflow-y-auto"
+            className="mt-3 border rounded-lg border-grayA-5 min-w-[var(--repo-list-w)] max-h-[462px] overflow-y-auto"
           >
             <div style={{ height: `${virtualizer.getTotalSize()}px`, position: "relative" }}>
               {virtualizer.getVirtualItems().map((virtualRow) => {
@@ -238,13 +238,13 @@ export const SelectRepo = ({
             </div>
           </div>
         ) : (
-          <div className="mt-3 flex flex-col items-center justify-center min-w-[var(--repo-list-w)] h-[462px] gap-3 border border-dashed rounded-[14px] border-grayA-5">
+          <div className="mt-3 flex flex-col items-center justify-center min-w-[var(--repo-list-w)] h-[462px] gap-3 border border-dashed rounded-lg border-grayA-5">
             <p className="text-[15px] text-accent-12 font-semibold">No repositories found</p>
           </div>
         ))}
 
       {onSkip && (
-        <div className="mt-3 border border-grayA-5 rounded-[14px] flex justify-start items-center gap-4 py-[18px] px-4 min-w-[var(--repo-list-w)]">
+        <div className="mt-3 border border-grayA-5 rounded-lg flex justify-start items-center gap-4 py-[18px] px-4 min-w-[var(--repo-list-w)]">
           <div className="size-8 rounded-[10px] grid place-items-center ring-1 ring-grayA-4 shadow-sm shadow-grayA-8/20 dark:shadow-none">
             <Clock className="size-[18px] text-gray-12" iconSize="md-medium" />
           </div>

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/new/steps/select-repo/skeleton.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/new/steps/select-repo/skeleton.tsx
@@ -27,7 +27,7 @@ export const SelectRepoSkeleton = () => (
       <div className="w-[200px] h-9 bg-grayA-3 rounded-lg animate-pulse shrink-0" />
       <div className="flex-1 h-9 bg-grayA-3 rounded-lg animate-pulse" />
     </div>
-    <ul className="mt-3 flex flex-col border rounded-[14px] border-grayA-5 divide-y divide-grayA-5 min-w-[var(--repo-list-w)] max-h-[462px] overflow-y-auto">
+    <ul className="mt-3 flex flex-col border rounded-lg border-grayA-5 divide-y divide-grayA-5 min-w-[var(--repo-list-w)] max-h-[462px] overflow-y-auto">
       {Array.from({ length: 3 }).map((_, i) => (
         // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton list
         <li key={i}>

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/_components/list/project-card-skeleton.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/_components/list/project-card-skeleton.tsx
@@ -1,7 +1,7 @@
 export function ProjectCardSkeleton() {
   return (
     // min-h matches a populated ProjectCard (~120.5px) so the grid doesn't shift on load.
-    <div className="p-5 flex flex-col justify-between border border-grayA-4 rounded-2xl w-full h-full min-h-[120px] gap-6">
+    <div className="p-5 flex flex-col justify-between border border-grayA-4 rounded-lg w-full h-full min-h-[120px] gap-6">
       {/* Mirrors ProjectCard's header: 20px title line beside a size-6 actions button. */}
       <div className="flex gap-4 items-start justify-between min-h-5">
         <div className="h-[14px] w-28 bg-grayA-3 rounded-sm animate-pulse" />

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/_components/list/project-card.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/_components/list/project-card.tsx
@@ -63,7 +63,7 @@ export function ProjectCard({ name, projectId, appCount, apps, actions }: Projec
   });
 
   return (
-    <div className="relative p-5 flex flex-col justify-between border border-grayA-4 hover:border-grayA-7 rounded-2xl w-full h-full gap-6 group transition-all duration-300 [&_a]:z-10 [&_button]:z-10">
+    <div className="relative p-5 flex flex-col justify-between border border-grayA-4 hover:border-grayA-7 rounded-lg w-full h-full gap-6 group transition-all duration-300 [&_a]:z-10 [&_button]:z-10">
       <Link
         href={projectPath}
         className="absolute inset-0 z-0"

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/_components/list/resource-card-skeleton.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/_components/list/resource-card-skeleton.tsx
@@ -2,7 +2,7 @@ import { Cube } from "@unkey/icons";
 
 export const ResourceCardSkeleton = () => {
   return (
-    <div className="p-5 flex flex-col border border-grayA-4 rounded-2xl w-full h-full gap-5">
+    <div className="p-5 flex flex-col border border-grayA-4 rounded-lg w-full h-full gap-5">
       {/* Top Section */}
       <div className="flex gap-4 items-center min-h-11">
         <div className="size-10 bg-gray-3 rounded-[10px] flex items-center justify-center shrink-0 dark:ring-1 dark:ring-gray-4">

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/_components/list/resource-card.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/_components/list/resource-card.tsx
@@ -43,7 +43,7 @@ export const ResourceCard = ({
   }, []);
 
   return (
-    <div className="relative p-5 flex flex-col border border-grayA-4 hover:border-grayA-7 rounded-2xl w-full h-full gap-5 group transition-all duration-300 [&_a]:z-10 [&_button]:z-10">
+    <div className="relative p-5 flex flex-col border border-grayA-4 hover:border-grayA-7 rounded-lg w-full h-full gap-5 group transition-all duration-300 [&_a]:z-10 [&_button]:z-10">
       {/* Invisible base clickable layer - covers entire card */}
       <Link
         href={href}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/ratelimits/_components/list/skeleton.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/ratelimits/_components/list/skeleton.tsx
@@ -31,7 +31,7 @@ const MetricStatsSkeleton = () => {
 
 export const NamespaceCardSkeleton = () => {
   return (
-    <div className="flex flex-col border border-gray-6 rounded-xl overflow-hidden">
+    <div className="flex flex-col border border-gray-6 rounded-lg overflow-hidden">
       <ChartSkeleton />
       <div className="p-4 md:p-6 border-t border-gray-6 flex flex-col gap-2">
         <div className="flex justify-between items-center">

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/billing-summary.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/billing-summary.tsx
@@ -36,7 +36,7 @@ export const BillingSummary: React.FC<BillingSummaryProps> = ({
 
   if (!hasPaymentMethod) {
     return (
-      <div className="flex w-full items-center justify-between gap-4 rounded-xl border border-grayA-4 bg-white px-5 py-4 dark:bg-black">
+      <div className="flex w-full items-center justify-between gap-4 rounded-lg border border-grayA-4 bg-white px-5 py-4 dark:bg-black">
         <div>
           <p className="font-medium text-gray-12 text-sm">No payment method</p>
           <p className="text-[13px] text-gray-10">
@@ -62,7 +62,7 @@ export const BillingSummary: React.FC<BillingSummaryProps> = ({
   }
 
   return (
-    <div className="flex w-full items-center justify-between gap-4 rounded-xl border border-grayA-4 bg-white px-5 py-4 dark:bg-black">
+    <div className="flex w-full items-center justify-between gap-4 rounded-lg border border-grayA-4 bg-white px-5 py-4 dark:bg-black">
       {/* Both columns share one type ramp and start at the top, so the two
           labels and the two values each sit on a common baseline. */}
       <div className="flex items-start gap-10">

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/deploy-product-card.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/deploy-product-card.tsx
@@ -89,7 +89,7 @@ export const DeployProductCard: React.FC<DeployProductCardProps> = ({
   });
 
   if (subscriptionLoading || plansLoading) {
-    return <div className="h-[150px] w-full animate-pulse rounded-xl bg-grayA-3" />;
+    return <div className="h-[150px] w-full animate-pulse rounded-lg bg-grayA-3" />;
   }
 
   // Deploy billing not configured server-side: hide the card entirely.

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/free-tier-alert.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/free-tier-alert.tsx
@@ -5,7 +5,7 @@ import type React from "react";
 
 export const FreeTierAlert: React.FC = () => {
   return (
-    <Empty className="border border-gray-4 rounded-xl">
+    <Empty className="border border-gray-4 rounded-lg">
       <Empty.Title>You are on the Free tier.</Empty.Title>
       <Empty.Description>
         The Free tier includes 150k requests of free usage.

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/product-card.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/product-card.tsx
@@ -36,7 +36,7 @@ export const ProductCard: React.FC<ProductCardProps> = ({
   footer,
 }) => {
   return (
-    <div className="w-full overflow-hidden rounded-xl border border-grayA-4 bg-white dark:bg-black">
+    <div className="w-full overflow-hidden rounded-lg border border-grayA-4 bg-white dark:bg-black">
       <div className="flex items-center justify-between gap-4 px-5 py-4">
         <div className="flex min-w-0 items-center gap-3">
           <div

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/deploy-billing-client.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/deploy-billing-client.tsx
@@ -117,9 +117,9 @@ export const DeployBillingClient: React.FC = () => {
       <Shell>
         <div className="animate-pulse">
           <div className="flex w-full flex-col items-center gap-4 pt-4 pb-16">
-            <div className="h-[72px] w-full rounded-xl bg-grayA-3" />
-            <div className="h-[180px] w-full rounded-xl bg-grayA-3" />
-            <div className="h-[120px] w-full rounded-xl bg-grayA-3" />
+            <div className="h-[72px] w-full rounded-lg bg-grayA-3" />
+            <div className="h-[180px] w-full rounded-lg bg-grayA-3" />
+            <div className="h-[120px] w-full rounded-lg bg-grayA-3" />
           </div>
         </div>
       </Shell>

--- a/web/apps/dashboard/app/new/components/onboarding-card.tsx
+++ b/web/apps/dashboard/app/new/components/onboarding-card.tsx
@@ -2,9 +2,7 @@ import { cn } from "@/lib/utils";
 import type React from "react";
 
 export function OnboardingCard({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
-  return (
-    <div className={cn("border border-gray-5 rounded-2xl w-full p-8", className)} {...props} />
-  );
+  return <div className={cn("border border-gray-5 rounded-lg w-full p-8", className)} {...props} />;
 }
 
 export function OnboardingCardHeader({

--- a/web/apps/dashboard/app/share/share-reveal.tsx
+++ b/web/apps/dashboard/app/share/share-reveal.tsx
@@ -20,7 +20,7 @@ function parseShareId(hash: string): string | null {
 
 function ShareCard({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex flex-col items-center gap-6 rounded-2xl border border-gray-5 p-8 text-center">
+    <div className="flex flex-col items-center gap-6 rounded-lg border border-gray-5 p-8 text-center">
       {children}
     </div>
   );

--- a/web/apps/dashboard/components/stats-card/index.tsx
+++ b/web/apps/dashboard/components/stats-card/index.tsx
@@ -28,7 +28,7 @@ export const StatsCard = ({
     <Link
       href={linkPath as Route}
       prefetch
-      className="flex flex-col border border-gray-4 rounded-xl bg-grayA-1 overflow-hidden cursor-pointer"
+      className="flex flex-col border border-gray-4 rounded-lg bg-grayA-1 overflow-hidden cursor-pointer"
     >
       <div className="h-35">{chart}</div>
       <div className="p-4 md:p-6 border-t border-gray-4 flex flex-col gap-2">

--- a/web/internal/ui/src/components/settings-card.tsx
+++ b/web/internal/ui/src/components/settings-card.tsx
@@ -32,7 +32,7 @@ const SettingCardGroupContext = React.createContext(false);
 function SettingCardGroup({ children }: { children: React.ReactNode }) {
   return (
     <SettingCardGroupContext.Provider value={true}>
-      <div className="border border-grayA-4 rounded-[14px] overflow-hidden divide-y divide-grayA-4">
+      <div className="border border-grayA-4 rounded-lg overflow-hidden divide-y divide-grayA-4">
         {children}
       </div>
     </SettingCardGroupContext.Provider>
@@ -93,14 +93,14 @@ function SettingCard({
       return "";
     }
     if (border === "top") {
-      return "rounded-t-[14px]";
+      return "rounded-t-lg";
     }
     if (border === "bottom") {
-      return !expandable || !isExpanded ? "rounded-b-[14px]" : "";
+      return !expandable || !isExpanded ? "rounded-b-lg" : "";
     }
     if (border === "both") {
-      const bottom = !expandable || !isExpanded ? "rounded-b-[14px]" : "";
-      return cn("rounded-t-[14px]", bottom);
+      const bottom = !expandable || !isExpanded ? "rounded-b-lg" : "";
+      return cn("rounded-t-lg", bottom);
     }
     return "";
   };
@@ -115,7 +115,7 @@ function SettingCard({
 
   const expandedBottomRadius =
     !inGroup && expandable && isExpanded && (border === "bottom" || border === "both")
-      ? "rounded-b-[14px]"
+      ? "rounded-b-lg"
       : "";
 
   const handleToggle = () => {


### PR DESCRIPTION
## What does this PR do?

Pretty much does what it says on the tin. I want to unify our corner radiuses for cards so they all fit together nicely. 

This is a bit of a precursor to this PR: https://github.com/unkeyed/unkey/pull/6685 which has a new card style for keyspaces, that PR will look pretty crappy if we go for the current 'full send' corner radii. 

## Screenshots

<img width="3384" height="2066" alt="CleanShot 2026-07-09 at 12 05 44@2x" src="https://github.com/user-attachments/assets/638e0b18-a3e7-43ad-91a8-0d4a920f6605" />
<img width="3384" height="2066" alt="CleanShot 2026-07-09 at 12 05 32@2x" src="https://github.com/user-attachments/assets/c4ac723c-3611-4108-bee2-025b16870886" />
<img width="3384" height="2066" alt="CleanShot 2026-07-09 at 12 05 30@2x" src="https://github.com/user-attachments/assets/cc31e58c-9255-4394-962d-3dc5f04bce2b" />
<img width="3384" height="2066" alt="CleanShot 2026-07-09 at 12 05 25@2x" src="https://github.com/user-attachments/assets/71d9ac16-8b72-40cc-bc96-ddda79c8c7f4" />

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

Projects grid, project detail, app overview (including loading skeletons), deployments/env-vars/sentinel lists, deployment metrics, app + workspace settings (expand the GitHub repo card), ratelimits list, billing page, new-app flow, /new and /share — all cards should read as one 8px system in light and dark. Dialogs, popovers, and the deployment network canvas should be visually unchanged.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR

_Screenshots: To be added — light, dark, mobile._

🤖 Generated with [Claude Code](https://claude.com/claude-code)