### PR TITLE
feat: mirror main into canary

### DIFF
--- a/.depot/workflows/mirror_canary.yaml
+++ b/.depot/workflows/mirror_canary.yaml
@@ -1,0 +1,29 @@
+name: Mirror Canary
+# Keeps the `canary` branch an exact mirror of `main` so Vercel can serve a
+# stable preview deployment for it (app.unkey-canary.com) that always matches
+# main, instead of hunting for an up-to-date PR preview link.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+permissions:
+  contents: write
+concurrency:
+  group: mirror-canary
+  cancel-in-progress: true
+jobs:
+  mirror:
+    name: Mirror main to canary
+    runs-on: depot-ubuntu-24.04-4
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        with:
+          # Full history: pushing from a shallow clone can be rejected by the
+          # remote ("shallow update not allowed").
+          fetch-depth: 0
+      - name: Push main to canary
+        # Pushes the remote-tracking ref so a manual dispatch from any branch
+        # still mirrors main, not the dispatched ref. Force push keeps canary
+        # an exact mirror even if it ever diverges.
+        run: git push --force origin origin/main:refs/heads/canary

--- a/web/apps/dashboard/vercel.json
+++ b/web/apps/dashboard/vercel.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": {
+      "pullfrog/tmp/**": false
+    }
+  }
+}


### PR DESCRIPTION
**Problem:**

Testing against the canary environment means finding a dashboard preview deployment that is both up to date with main and free of its own breaking changes, every single time. There is no stable URL that always serves "main as a preview".

Separately, `pullfrog/tmp/*` branches trigger Vercel dashboard deployments that nobody looks at, eating build slots and deployment quota.

**Solution:**

Add a Depot workflow that force-pushes `main` to a `canary` branch on every push to main, with `workflow_dispatch` as a manual fallback. Vercel will serve that branch's latest preview deployment on app.unkey-canary.com, so the domain always matches main. The push uses the remote-tracking ref (`origin/main`) so a manual dispatch from any branch still mirrors main, not the dispatched ref.

Add `vercel.json` to the dashboard app disabling deployments for `pullfrog/tmp/**` via `git.deploymentEnabled`. Unlike the Ignored Build Step, this prevents the deployment from being created at all, so it does not count against quota or concurrent build slots.

**Impact:**

No production behavior change. Requires one-time manual setup in Vercel: create the `canary` branch, assign app.unkey-canary.com to it, and scope canary-specific env vars to that branch so regular PR previews are unaffected.

This is the first Depot workflow that pushes back to the repo (`contents: write`). If the Depot token turns out not to have write access, the push step fails with a 403 and we need a PAT secret instead.

**Testing:**

```bash
mise exec -- dprint check --config dev/dprint.json .depot/workflows/mirror_canary.yaml web/apps/dashboard/vercel.json
# exit 0
```

YAML validated with the same safe_load check `job_validate_workflows.yaml` runs in CI. The workflow itself has not been exercised yet; the first push to main after merge verifies the token can push. The `git.deploymentEnabled` glob behavior is per Vercel docs, not live-tested.
