### PR TITLE
fix(portal): enforce session capability scopes

### DIFF
--- a/dev/portal-local-testing.md
+++ b/dev/portal-local-testing.md
@@ -52,7 +52,7 @@ go run . dev seed local --slug awesome --portal
 Save the root key printed at the end (e.g. `unkey_xxx`).
 
 The portal slug is the value you passed to `--slug` (e.g. `awesome`). Use
-it in `createSession` calls — it's also written to `dev/.env.seed` as
+it in `createSession` calls. It's also written to `dev/.env.seed` as
 `UNKEY_PORTAL_SLUG`.
 
 ---
@@ -92,7 +92,7 @@ The portal is port-forwarded to `http://localhost:3100`.
 curl -s -X POST http://localhost:7070/v2/portal.createSession \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer <ROOT_KEY>" \
-  -d '{"slug": "awesome", "externalId": "user_123", "permissions": ["api.*.read_key", "api.*.create_key", "api.*.read_analytics"]}'
+  -d '{"slug": "awesome", "externalId": "user_123", "permissions": ["keys:read", "keys:create", "keys:reroll", "analytics:read"]}'
 ```
 
 Open `http://localhost:3100/?session=pst_xxx` in the browser.
@@ -124,7 +124,7 @@ Runs on `http://localhost:3100`. Port 3100 avoids conflict with the dashboard.
 curl -s -X POST http://localhost:7070/v2/portal.createSession \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer <ROOT_KEY>" \
-  -d '{"slug": "awesome", "externalId": "user_123", "permissions": ["api.*.read_key", "api.*.create_key", "api.*.read_analytics"]}'
+  -d '{"slug": "awesome", "externalId": "user_123", "permissions": ["keys:read", "keys:create", "keys:reroll", "analytics:read"]}'
 ```
 
 Take the `sessionId` from the response and open:
@@ -143,7 +143,7 @@ Deploy the portal as an app on Unkey Deploy.
 In the Unkey dashboard, create a project for the portal (or use an existing
 internal project). Add an app with:
 - Dockerfile path: `web/apps/portal/Dockerfile`
-- Docker context: `.` (repo root — the Dockerfile uses `web/` paths)
+- Docker context: `.` (repo root because the Dockerfile uses `web/` paths)
 - Default branch: `main` (or your feature branch)
 
 ### 2. Configure environment variables
@@ -180,7 +180,7 @@ like `<app-slug>-<env>.unkey.com`.
 curl -s -X POST https://api.unkey.dev/v2/portal.createSession \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer <ROOT_KEY>" \
-  -d '{"slug": "<YOUR_SLUG>", "externalId": "user_123", "permissions": ["api.*.read_key", "api.*.create_key", "api.*.read_analytics"]}'
+  -d '{"slug": "<YOUR_SLUG>", "externalId": "user_123", "permissions": ["keys:read", "keys:create", "keys:reroll", "analytics:read"]}'
 ```
 
 The response URL will point to the portal's deployment URL (or custom
@@ -192,7 +192,7 @@ domain if configured). Open it in the browser.
   deployment URL for session redirect URLs to work correctly.
 - For preview environments, you may need to manually adjust the session URL
   domain if `portal_base_url` points to production.
-- Custom domains work the same as any Deploy app — add the domain in the
+- Custom domains work the same as any Deploy app. Add the domain in the
   dashboard, set the CNAME, and certificates are provisioned automatically.
 
 ---

--- a/dev/portal-local-testing.md
+++ b/dev/portal-local-testing.md
@@ -52,7 +52,7 @@ go run . dev seed local --slug awesome --portal
 Save the root key printed at the end (e.g. `unkey_xxx`).
 
 The portal slug is the value you passed to `--slug` (e.g. `awesome`). Use
-it in `createSession` calls. It's also written to `dev/.env.seed` as
+it in `createSession` calls — it's also written to `dev/.env.seed` as
 `UNKEY_PORTAL_SLUG`.
 
 ---
@@ -143,7 +143,7 @@ Deploy the portal as an app on Unkey Deploy.
 In the Unkey dashboard, create a project for the portal (or use an existing
 internal project). Add an app with:
 - Dockerfile path: `web/apps/portal/Dockerfile`
-- Docker context: `.` (repo root because the Dockerfile uses `web/` paths)
+- Docker context: `.` (repo root — the Dockerfile uses `web/` paths)
 - Default branch: `main` (or your feature branch)
 
 ### 2. Configure environment variables
@@ -192,7 +192,7 @@ domain if configured). Open it in the browser.
   deployment URL for session redirect URLs to work correctly.
 - For preview environments, you may need to manually adjust the session URL
   domain if `portal_base_url` points to production.
-- Custom domains work the same as any Deploy app. Add the domain in the
+- Custom domains work the same as any Deploy app — add the domain in the
   dashboard, set the CNAME, and certificates are provisioned automatically.
 
 ---

--- a/docs/product/errors/unkey/authentication/portal_session_not_found.mdx
+++ b/docs/product/errors/unkey/authentication/portal_session_not_found.mdx
@@ -23,9 +23,9 @@ description: "The provided portal session was not found, has expired, or has alr
 
 This error is returned by `POST /v2/portal.exchangeSession` and any portal-authenticated endpoint when the supplied session identifier cannot be resolved. There are three common reasons:
 
-- **Expired session ID** — The short-lived session ID returned by `portal.createSession` is valid for **15 minutes**. After that it can no longer be exchanged.
-- **Already-used session ID** — Session IDs are **single-use**. Once a browser exchanges it, the same ID cannot be exchanged again.
-- **Expired browser session** — After exchange, the browser session is valid for **24 hours**. Once it expires, requests using that token return this error.
+- **Expired session ID:** The short-lived session ID returned by `portal.createSession` is valid for **15 minutes**. After that it can no longer be exchanged.
+- **Already-used session ID:** Session IDs are **single-use**. Once a browser exchanges it, the same ID cannot be exchanged again.
+- **Expired browser session:** After exchange, the browser session is valid for **24 hours**. Once it expires, requests using that token return this error.
 
 ## How To Fix
 
@@ -38,26 +38,16 @@ curl -X POST https://api.unkey.com/v2/portal.createSession \
   -d '{
     "slug": "my-portal",
     "externalId": "user_123",
-    "permissions": ["api.*.read_key", "api.*.read_analytics"]
+    "permissions": ["keys:read"]
   }'
 ```
 
 Then redirect the user to the returned `url`. The portal will exchange the new session ID for a 24-hour browser cookie.
 
-If you have configured a `return_url` on your portal, expired browser sessions will automatically redirect there with `?reason=session_expired`. Use that hook to re-mint a session and bounce the user back into the portal seamlessly.
-
-```typescript
-// In your backend route handler
-if (request.url.searchParams.get("reason") === "session_expired") {
-  const { data } = await createPortalSession(currentUser);
-  return Response.redirect(data.url, 302);
-}
-```
-
 ## Common Mistakes
 
 - **Reusing a session ID**: Session IDs are single-use. Generate a new one for every redirect.
-- **Storing session IDs**: Don't persist session IDs — they are short-lived and meant to be consumed immediately.
+- **Storing session IDs**: Don't persist session IDs. They are short-lived and meant to be consumed immediately.
 - **Skipping the exchange**: The portal frontend must call `portal.exchangeSession` to convert the session ID into a browser session.
 - **Long-running tabs**: Users who keep the portal open beyond 24 hours need a fresh session.
 

--- a/docs/product/errors/unkey/authentication/portal_session_not_found.mdx
+++ b/docs/product/errors/unkey/authentication/portal_session_not_found.mdx
@@ -23,9 +23,9 @@ description: "The provided portal session was not found, has expired, or has alr
 
 This error is returned by `POST /v2/portal.exchangeSession` and any portal-authenticated endpoint when the supplied session identifier cannot be resolved. There are three common reasons:
 
-- **Expired session ID:** The short-lived session ID returned by `portal.createSession` is valid for **15 minutes**. After that it can no longer be exchanged.
-- **Already-used session ID:** Session IDs are **single-use**. Once a browser exchanges it, the same ID cannot be exchanged again.
-- **Expired browser session:** After exchange, the browser session is valid for **24 hours**. Once it expires, requests using that token return this error.
+- **Expired session ID** — The short-lived session ID returned by `portal.createSession` is valid for **15 minutes**. After that it can no longer be exchanged.
+- **Already-used session ID** — Session IDs are **single-use**. Once a browser exchanges it, the same ID cannot be exchanged again.
+- **Expired browser session** — After exchange, the browser session is valid for **24 hours**. Once it expires, requests using that token return this error.
 
 ## How To Fix
 
@@ -44,10 +44,20 @@ curl -X POST https://api.unkey.com/v2/portal.createSession \
 
 Then redirect the user to the returned `url`. The portal will exchange the new session ID for a 24-hour browser cookie.
 
+If you have configured a `return_url` on your portal, expired browser sessions will automatically redirect there with `?reason=session_expired`. Use that hook to re-mint a session and bounce the user back into the portal seamlessly.
+
+```typescript
+// In your backend route handler
+if (request.url.searchParams.get("reason") === "session_expired") {
+  const { data } = await createPortalSession(currentUser);
+  return Response.redirect(data.url, 302);
+}
+```
+
 ## Common Mistakes
 
 - **Reusing a session ID**: Session IDs are single-use. Generate a new one for every redirect.
-- **Storing session IDs**: Don't persist session IDs. They are short-lived and meant to be consumed immediately.
+- **Storing session IDs**: Don't persist session IDs — they are short-lived and meant to be consumed immediately.
 - **Skipping the exchange**: The portal frontend must call `portal.exchangeSession` to convert the session ID into a browser session.
 - **Long-running tabs**: Users who keep the portal open beyond 24 hours need a fresh session.
 

--- a/docs/product/errors/unkey/authentication/portal_token_missing.mdx
+++ b/docs/product/errors/unkey/authentication/portal_token_missing.mdx
@@ -1,6 +1,6 @@
 ---
 title: "portal_token_missing"
-description: "A request to a portal-authenticated endpoint was made without a portal session token. Provide the session cookie or session header from the portal."
+description: "A request to a portal-authenticated endpoint was made without a portal session cookie."
 ---
 
 <Danger>`err:unkey:authentication:portal_token_missing`</Danger>
@@ -21,15 +21,12 @@ description: "A request to a portal-authenticated endpoint was made without a po
 
 ## What Happened?
 
-This error occurs when a request was made to an endpoint that requires a [Customer Portal](/quickstart/portal) session, but no session token was supplied. Portal-authenticated endpoints expect either:
-
-- An `httpOnly` session cookie set by the portal after a successful session exchange, or
-- An `Authorization: Bearer <portal-session-token>` header on direct API calls from a browser session.
+This error occurs when a request was made to an endpoint that requires a [Customer Portal](/quickstart/portal) session, but the `portal_session` cookie was not supplied. The portal sets this `httpOnly` cookie after a successful session exchange.
 
 Common causes include:
 
 - The user's browser has cookies disabled or blocked for the portal domain.
-- The session was never created — the user landed on the portal without going through `POST /v2/portal.exchangeSession`.
+- The session was never created. The user landed on the portal without going through `POST /v2/portal.exchangeSession`.
 - A backend integration is calling a portal-only endpoint with a root key instead of a portal session token.
 - The session cookie was cleared or the user opened the portal in a private/incognito window with stripped state.
 
@@ -39,7 +36,7 @@ Make sure the user has an active portal session before calling portal endpoints:
 
 1. From your backend, call `POST /v2/portal.createSession` with your root key to create a session.
 2. Redirect the user to the returned `url`. The portal will exchange the short-lived session ID for a 24-hour browser session.
-3. Subsequent requests from the browser must include the portal session cookie or token.
+3. Subsequent requests from the browser must include the portal session cookie.
 
 ```bash
 curl -X POST https://api.unkey.com/v2/portal.createSession \
@@ -48,23 +45,14 @@ curl -X POST https://api.unkey.com/v2/portal.createSession \
   -d '{
     "slug": "my-portal",
     "externalId": "user_123",
-    "permissions": ["api.*.read_key"]
+    "permissions": ["keys:read"]
   }'
-```
-
-If you are calling the portal API directly from JavaScript, ensure your fetch includes credentials so the session cookie is sent:
-
-```typescript
-await fetch("https://api.unkey.com/v2/...", {
-  credentials: "include",
-});
 ```
 
 ## Common Mistakes
 
 - **Calling portal endpoints with a root key**: Root keys authenticate backend requests, not portal endpoints. Use a portal session.
-- **Missing `credentials: "include"`**: Cross-origin browser requests omit cookies by default.
-- **Expired session not refreshed**: After 24 hours the session expires — your backend must create a new one.
+- **Expired session not refreshed**: After 24 hours, your backend must create a new session.
 - **Direct navigation to the portal**: Users must arrive via your backend redirect, not by visiting the portal URL directly.
 
 ## Related Errors

--- a/docs/product/errors/unkey/authentication/portal_token_missing.mdx
+++ b/docs/product/errors/unkey/authentication/portal_token_missing.mdx
@@ -1,6 +1,6 @@
 ---
 title: "portal_token_missing"
-description: "A request to a portal-authenticated endpoint was made without a portal session cookie."
+description: "A request to a portal-authenticated endpoint was made without a portal session token. Provide the session cookie or session header from the portal."
 ---
 
 <Danger>`err:unkey:authentication:portal_token_missing`</Danger>
@@ -21,12 +21,15 @@ description: "A request to a portal-authenticated endpoint was made without a po
 
 ## What Happened?
 
-This error occurs when a request was made to an endpoint that requires a [Customer Portal](/quickstart/portal) session, but the `portal_session` cookie was not supplied. The portal sets this `httpOnly` cookie after a successful session exchange.
+This error occurs when a request was made to an endpoint that requires a [Customer Portal](/quickstart/portal) session, but no session token was supplied. Portal-authenticated endpoints expect either:
+
+- An `httpOnly` session cookie set by the portal after a successful session exchange, or
+- An `Authorization: Bearer <portal-session-token>` header on direct API calls from a browser session.
 
 Common causes include:
 
 - The user's browser has cookies disabled or blocked for the portal domain.
-- The session was never created. The user landed on the portal without going through `POST /v2/portal.exchangeSession`.
+- The session was never created — the user landed on the portal without going through `POST /v2/portal.exchangeSession`.
 - A backend integration is calling a portal-only endpoint with a root key instead of a portal session token.
 - The session cookie was cleared or the user opened the portal in a private/incognito window with stripped state.
 
@@ -36,7 +39,7 @@ Make sure the user has an active portal session before calling portal endpoints:
 
 1. From your backend, call `POST /v2/portal.createSession` with your root key to create a session.
 2. Redirect the user to the returned `url`. The portal will exchange the short-lived session ID for a 24-hour browser session.
-3. Subsequent requests from the browser must include the portal session cookie.
+3. Subsequent requests from the browser must include the portal session cookie or token.
 
 ```bash
 curl -X POST https://api.unkey.com/v2/portal.createSession \
@@ -49,10 +52,19 @@ curl -X POST https://api.unkey.com/v2/portal.createSession \
   }'
 ```
 
+If you are calling the portal API directly from JavaScript, ensure your fetch includes credentials so the session cookie is sent:
+
+```typescript
+await fetch("https://api.unkey.com/v2/...", {
+  credentials: "include",
+});
+```
+
 ## Common Mistakes
 
 - **Calling portal endpoints with a root key**: Root keys authenticate backend requests, not portal endpoints. Use a portal session.
-- **Expired session not refreshed**: After 24 hours, your backend must create a new session.
+- **Missing `credentials: "include"`**: Cross-origin browser requests omit cookies by default.
+- **Expired session not refreshed**: After 24 hours the session expires — your backend must create a new one.
 - **Direct navigation to the portal**: Users must arrive via your backend redirect, not by visiting the portal URL directly.
 
 ## Related Errors

--- a/docs/product/errors/unkey/data/portal_config_not_found.mdx
+++ b/docs/product/errors/unkey/data/portal_config_not_found.mdx
@@ -44,7 +44,7 @@ curl -X POST https://api.unkey.com/v2/portal.createSession \
   -d '{
     "slug": "my-portal",
     "externalId": "user_123",
-    "permissions": ["api.*.read_key"]
+    "permissions": ["keys:read"]
   }'
 ```
 

--- a/docs/product/quickstart/portal.mdx
+++ b/docs/product/quickstart/portal.mdx
@@ -3,7 +3,7 @@ title: 'Customer Portal'
 description: "Give your end users a white-labeled self-service portal for API key management, usage analytics, and docs, with a Stripe-style session auth flow."
 ---
 
-The Customer Portal is a white-labeled web app you can offer to your end users. They get key management, usage analytics, and API documentation — without you building any UI.
+The Customer Portal is a white-labeled web app you can offer to your end users. They get key management, usage analytics, and API documentation without you building any UI.
 
 Authentication uses a Stripe-style session flow: your backend creates a session, redirects the user, and the portal handles the rest.
 
@@ -23,14 +23,14 @@ Your Backend                    Unkey API                     Portal
     │                              │◄─ POST /v2/portal.exchangeSession ─┤
     │                              │──── browser session token ──►│
     │                              │                            │
-    │                              │◄── Direct API calls ───────┤
+    │                              │◄── Portal API calls ───────┤
 ```
 
 1. Your backend authenticates the user in your own system
 2. Your backend calls `POST /v2/portal.createSession` with a root key
 3. You redirect the user to the returned portal URL
 4. The portal exchanges the session ID for a 24-hour browser session
-5. The browser calls Unkey API directly with the session token
+5. The browser calls the Unkey API with the portal session cookie
 
 ## 1. Configure a portal
 
@@ -40,7 +40,7 @@ Enable the Customer Portal for your workspace in the Unkey dashboard.
 Dashboard configuration UI is coming soon. During early access, reach out to the Unkey team to get your portal configured.
 </Note>
 
-When configuring your portal, you'll choose a slug — a short, human-readable identifier like `my-portal` or `billing-dashboard`. Use this slug when creating sessions.
+When configuring your portal, you'll choose a short, human-readable slug like `my-portal` or `billing-dashboard`. Use this slug when creating sessions.
 
 Slugs must be 3–64 characters, lowercase alphanumeric and hyphens only, and cannot start or end with a hyphen.
 
@@ -59,7 +59,7 @@ curl -X POST https://api.unkey.com/v2/portal.createSession \
   -d '{
     "slug": "my-portal",
     "externalId": "user_123",
-    "permissions": ["api.*.read_key", "api.*.create_key", "api.*.read_analytics"]
+    "permissions": ["keys:read", "keys:create", "keys:reroll", "analytics:read"]
   }'
 ```
 
@@ -73,14 +73,13 @@ const response = await fetch("https://api.unkey.com/v2/portal.createSession", {
   body: JSON.stringify({
     slug: "my-portal",
     externalId: "user_123",
-    permissions: ["api.*.read_key", "api.*.create_key", "api.*.read_analytics"],
+    permissions: ["keys:read", "keys:create", "keys:reroll", "analytics:read"],
   }),
 });
 
 const { data } = await response.json();
-// data.sessionId  — short-lived token (15 min)
-// data.url        — full portal URL with session param
-// data.expiresAt  — expiry timestamp (unix ms)
+// data.sessionId: short-lived token (15 min)
+// data.url: full portal URL with session param
 ```
 
 ```go Go
@@ -88,7 +87,7 @@ const { data } = await response.json();
 body := map[string]any{
     "slug":        "my-portal",
     "externalId":  "user_123",
-    "permissions": []string{"api.*.read_key", "api.*.create_key", "api.*.read_analytics"},
+    "permissions": []string{"keys:read", "keys:create", "keys:reroll", "analytics:read"},
 }
 ```
 
@@ -101,8 +100,7 @@ The response:
   "meta": { "requestId": "req_..." },
   "data": {
     "sessionId": "pst_xxx",
-    "url": "https://portal.unkey.com/?session=pst_xxx",
-    "expiresAt": 1742000000000
+    "url": "https://portal.unkey.com/?session=pst_xxx"
   }
 }
 ```
@@ -119,7 +117,7 @@ The response:
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `preview` | `boolean` | Shows a "Preview mode" banner — useful for testing as a specific user |
+| `preview` | `boolean` | Shows a "Preview mode" banner for testing as a specific user |
 
 ```bash
 curl -X POST https://api.unkey.com/v2/portal.createSession \
@@ -128,7 +126,7 @@ curl -X POST https://api.unkey.com/v2/portal.createSession \
   -d '{
     "slug": "my-portal",
     "externalId": "user_123",
-    "permissions": ["api.*.read_key", "api.*.read_analytics"],
+    "permissions": ["keys:read", "analytics:read"],
     "preview": true
   }'
 ```
@@ -149,21 +147,19 @@ The portal will:
 
 ## Permissions and tabs
 
-Permissions use the RBAC tuple format `{resourceType}.{resourceId}.{action}`. Use `*` as the resourceId to grant access to all resources of that type.
+Permissions use a fixed capability vocabulary. The portal configuration and
+session identity determine which keys and analytics the user can access.
 
-Tab visibility is derived from the action segment (third part) of each permission:
+| Capability | Access |
+|------------|--------|
+| `keys:read` | API Keys |
+| `keys:create` | API Keys |
+| `keys:reroll` | API Keys |
+| `analytics:read` | Analytics |
+| Any capability present | Documentation |
 
-| Action | Tab |
-|--------|-----|
-| `read_key`, `create_key`, `update_key`, `delete_key` | API Keys |
-| `read_analytics` | Analytics |
-| Any permission present | Documentation |
-
-Examples:
-- `api.*.read_key` → shows the Keys tab
-- `api.api_123.create_key` → shows the Keys tab (specific resource)
-- `api.*.read_analytics` → shows the Analytics tab
-- Docs tab is visible whenever at least one permission is present
+All key and analytics operations remain limited to the configured keyspaces and
+the session's `externalId`.
 
 The API requires at least one permission. An empty permissions array is rejected with HTTP 400.
 
@@ -174,9 +170,7 @@ The API requires at least one permission. An empty permissions array is rejected
 | Session ID (`pst_xxx`) | 15 minutes | Single-use, exchanged for browser session |
 | Browser session | 24 hours | Stored as httpOnly cookie, used for API calls |
 
-When the browser session expires:
-- If `return_url` is set on the portal config → redirects to `{return_url}?reason=session_expired`
-- Otherwise → shows a "Session expired" error page
+When the browser session expires, the portal requires a fresh session from your backend.
 
 ## Branding
 

--- a/docs/product/quickstart/portal.mdx
+++ b/docs/product/quickstart/portal.mdx
@@ -3,7 +3,7 @@ title: 'Customer Portal'
 description: "Give your end users a white-labeled self-service portal for API key management, usage analytics, and docs, with a Stripe-style session auth flow."
 ---
 
-The Customer Portal is a white-labeled web app you can offer to your end users. They get key management, usage analytics, and API documentation without you building any UI.
+The Customer Portal is a white-labeled web app you can offer to your end users. They get key management, usage analytics, and API documentation — without you building any UI.
 
 Authentication uses a Stripe-style session flow: your backend creates a session, redirects the user, and the portal handles the rest.
 
@@ -23,14 +23,14 @@ Your Backend                    Unkey API                     Portal
     │                              │◄─ POST /v2/portal.exchangeSession ─┤
     │                              │──── browser session token ──►│
     │                              │                            │
-    │                              │◄── Portal API calls ───────┤
+    │                              │◄── Direct API calls ───────┤
 ```
 
 1. Your backend authenticates the user in your own system
 2. Your backend calls `POST /v2/portal.createSession` with a root key
 3. You redirect the user to the returned portal URL
 4. The portal exchanges the session ID for a 24-hour browser session
-5. The browser calls the Unkey API with the portal session cookie
+5. The browser calls Unkey API directly with the session token
 
 ## 1. Configure a portal
 
@@ -40,7 +40,7 @@ Enable the Customer Portal for your workspace in the Unkey dashboard.
 Dashboard configuration UI is coming soon. During early access, reach out to the Unkey team to get your portal configured.
 </Note>
 
-When configuring your portal, you'll choose a short, human-readable slug like `my-portal` or `billing-dashboard`. Use this slug when creating sessions.
+When configuring your portal, you'll choose a slug — a short, human-readable identifier like `my-portal` or `billing-dashboard`. Use this slug when creating sessions.
 
 Slugs must be 3–64 characters, lowercase alphanumeric and hyphens only, and cannot start or end with a hyphen.
 
@@ -78,8 +78,9 @@ const response = await fetch("https://api.unkey.com/v2/portal.createSession", {
 });
 
 const { data } = await response.json();
-// data.sessionId: short-lived token (15 min)
-// data.url: full portal URL with session param
+// data.sessionId  — short-lived token (15 min)
+// data.url        — full portal URL with session param
+// data.expiresAt  — expiry timestamp (unix ms)
 ```
 
 ```go Go
@@ -100,7 +101,8 @@ The response:
   "meta": { "requestId": "req_..." },
   "data": {
     "sessionId": "pst_xxx",
-    "url": "https://portal.unkey.com/?session=pst_xxx"
+    "url": "https://portal.unkey.com/?session=pst_xxx",
+    "expiresAt": 1742000000000
   }
 }
 ```
@@ -117,7 +119,7 @@ The response:
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `preview` | `boolean` | Shows a "Preview mode" banner for testing as a specific user |
+| `preview` | `boolean` | Shows a "Preview mode" banner — useful for testing as a specific user |
 
 ```bash
 curl -X POST https://api.unkey.com/v2/portal.createSession \
@@ -170,7 +172,9 @@ The API requires at least one permission. An empty permissions array is rejected
 | Session ID (`pst_xxx`) | 15 minutes | Single-use, exchanged for browser session |
 | Browser session | 24 hours | Stored as httpOnly cookie, used for API calls |
 
-When the browser session expires, the portal requires a fresh session from your backend.
+When the browser session expires:
+- If `return_url` is set on the portal config → redirects to `{return_url}?reason=session_expired`
+- Otherwise → shows a "Session expired" error page
 
 ## Branding
 

--- a/internal/services/portal/get_session.go
+++ b/internal/services/portal/get_session.go
@@ -2,7 +2,6 @@ package portal
 
 import (
 	"context"
-	"time"
 
 	"github.com/unkeyed/unkey/internal/services/caches"
 	"github.com/unkeyed/unkey/pkg/cache"
@@ -29,7 +28,7 @@ func (s *service) GetSession(ctx context.Context, token string) (*SessionInfo, e
 	row, hit, err := s.sessionCache.SWR(ctx, token, func(ctx context.Context) (db.PortalSession, error) {
 		return db.Query.FindValidPortalSession(ctx, s.db.RO(), db.FindValidPortalSessionParams{
 			ID:  token,
-			Now: time.Now().UnixMilli(),
+			Now: s.clock.Now().UnixMilli(),
 		})
 	}, caches.DefaultFindFirstOp)
 	if err != nil {
@@ -53,10 +52,16 @@ func (s *service) GetSession(ctx context.Context, token string) (*SessionInfo, e
 			fault.Public("The portal session is invalid or has expired."),
 		)
 	}
+	if row.ExpiresAt <= s.clock.Now().UnixMilli() {
+		return nil, fault.New("invalid or expired portal session",
+			fault.Code(codes.Portal.Session.SessionNotFound.URN()),
+			fault.Internal("portal session cached after expiry"),
+			fault.Public("The portal session is invalid or has expired."),
+		)
+	}
 
 	// The permissions column stores the simplified capability model as a JSON
 	// object {keyspaceIds, permissions:[verbs]}, written by portal.createSession.
-	// The resolver expands the verbs into RBAC via portalrbac.
 	grant, err := db.UnmarshalNullableJSONTo[storedGrant](row.Permissions)
 	if err != nil {
 		return nil, fault.Wrap(err,

--- a/internal/services/portal/service.go
+++ b/internal/services/portal/service.go
@@ -18,9 +18,8 @@ type SessionInfo struct {
 	// KeyspaceIDs scopes the session's key capabilities to a set of keyspaces.
 	KeyspaceIDs []string
 
-	// Permissions is the session's simplified capability verbs (e.g. "keys:reroll",
-	// "analytics:read"). The portal_session resolver expands these into RBAC
-	// permission strings via portalrbac.
+	// Permissions is the persisted capability vocabulary. The portal session
+	// resolver validates it before constructing a principal.
 	Permissions []string
 }
 

--- a/internal/services/portal/service.go
+++ b/internal/services/portal/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/unkeyed/unkey/pkg/cache"
+	"github.com/unkeyed/unkey/pkg/clock"
 	"github.com/unkeyed/unkey/pkg/db"
 )
 
@@ -18,8 +19,7 @@ type SessionInfo struct {
 	// KeyspaceIDs scopes the session's key capabilities to a set of keyspaces.
 	KeyspaceIDs []string
 
-	// Permissions is the persisted capability vocabulary. The portal session
-	// resolver validates it before constructing a principal.
+	// Permissions is the persisted capability vocabulary.
 	Permissions []string
 }
 
@@ -34,11 +34,13 @@ type Service interface {
 type Config struct {
 	DB           db.Database
 	SessionCache cache.Cache[string, db.PortalSession]
+	Clock        clock.Clock
 }
 
 type service struct {
 	db           db.Database
 	sessionCache cache.Cache[string, db.PortalSession]
+	clock        clock.Clock
 }
 
 // New creates a new portal service instance.
@@ -46,5 +48,6 @@ func New(config Config) Service {
 	return &service{
 		db:           config.DB,
 		sessionCache: config.SessionCache,
+		clock:        config.Clock,
 	}
 }

--- a/pkg/auth/portal_session/resolver.go
+++ b/pkg/auth/portal_session/resolver.go
@@ -46,19 +46,15 @@ func (r *Resolver) Resolve(ctx context.Context, sess *zen.Session) (*principal.P
 		return nil, err
 	}
 
-	// Translate the session's simplified capability model (keyspace ids + verbs)
-	// into the RBAC permission strings the shared handlers check. This is the one
-	// place the portal capability vocabulary is mapped onto RBAC — see the
-	// portalrbac package.
+	// Validate the persisted strings before exposing them as exact-match grants.
 	capabilities, err := portalrbac.ParseAll(session.Permissions)
 	if err != nil {
 		return nil, err
 	}
-	permissions := portalrbac.Grant{
-		WorkspaceID:  session.WorkspaceID,
-		KeyspaceIDs:  session.KeyspaceIDs,
-		Capabilities: capabilities,
-	}.Expand()
+	permissions := make([]string, len(capabilities))
+	for i, capability := range capabilities {
+		permissions[i] = string(capability)
+	}
 
 	return &principal.Principal{
 		Version: principal.Version,

--- a/pkg/auth/portal_session/resolver.go
+++ b/pkg/auth/portal_session/resolver.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"net/http"
-	"slices"
 
 	"github.com/unkeyed/unkey/internal/services/portal"
 	"github.com/unkeyed/unkey/pkg/auth/principal"
@@ -46,8 +45,6 @@ func (r *Resolver) Resolve(ctx context.Context, sess *zen.Session) (*principal.P
 		return nil, err
 	}
 
-	permissions := slices.Clone(session.Permissions)
-
 	return &principal.Principal{
 		Version: principal.Version,
 		Subject: principal.Subject{
@@ -61,9 +58,9 @@ func (r *Resolver) Resolve(ctx context.Context, sess *zen.Session) (*principal.P
 			PortalConfigID: session.PortalConfigID,
 			ExternalID:     session.ExternalID,
 			KeyspaceIDs:    session.KeyspaceIDs,
-			Permissions:    permissions,
+			Permissions:    session.Permissions,
 		},
 		WorkspaceID: session.WorkspaceID,
-		Permissions: permissions,
+		Permissions: session.Permissions,
 	}, nil
 }

--- a/pkg/auth/portal_session/resolver.go
+++ b/pkg/auth/portal_session/resolver.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"slices"
 
 	"github.com/unkeyed/unkey/internal/services/portal"
-	"github.com/unkeyed/unkey/pkg/auth/portalrbac"
 	"github.com/unkeyed/unkey/pkg/auth/principal"
 	"github.com/unkeyed/unkey/pkg/zen"
 )
@@ -46,15 +46,7 @@ func (r *Resolver) Resolve(ctx context.Context, sess *zen.Session) (*principal.P
 		return nil, err
 	}
 
-	// Validate the persisted strings before exposing them as exact-match grants.
-	capabilities, err := portalrbac.ParseAll(session.Permissions)
-	if err != nil {
-		return nil, err
-	}
-	permissions := make([]string, len(capabilities))
-	for i, capability := range capabilities {
-		permissions[i] = string(capability)
-	}
+	permissions := slices.Clone(session.Permissions)
 
 	return &principal.Principal{
 		Version: principal.Version,

--- a/pkg/auth/portal_session/resolver_test.go
+++ b/pkg/auth/portal_session/resolver_test.go
@@ -59,7 +59,7 @@ func TestResolver_ResolvePortalCookie(t *testing.T) {
 
 	// Portal principals carry the product capability directly. Resource scope is
 	// enforced separately by portal handlers.
-	expected := []string{string(portalrbac.CapKeysReroll)}
+	expected := []string{portalrbac.CapKeysReroll}
 	require.Equal(t, expected, source.Permissions)
 	require.Equal(t, expected, principal.Permissions)
 }

--- a/pkg/auth/portal_session/resolver_test.go
+++ b/pkg/auth/portal_session/resolver_test.go
@@ -57,13 +57,9 @@ func TestResolver_ResolvePortalCookie(t *testing.T) {
 	require.Equal(t, "portal_session_123", source.SessionID)
 	require.Equal(t, "pc_123", source.PortalConfigID)
 
-	// The resolver expands the simplified capability model into RBAC strings via
-	// portalrbac; the principal must carry the expanded permissions, not the verbs.
-	expected := portalrbac.Grant{
-		WorkspaceID:  "ws_123",
-		KeyspaceIDs:  []string{"ks_1"},
-		Capabilities: []portalrbac.Capability{portalrbac.CapKeysReroll},
-	}.Expand()
+	// Portal principals carry the product capability directly. Resource scope is
+	// enforced separately by portal handlers.
+	expected := []string{string(portalrbac.CapKeysReroll)}
 	require.Equal(t, expected, source.Permissions)
 	require.Equal(t, expected, principal.Permissions)
 }

--- a/pkg/auth/portalrbac/portalrbac.go
+++ b/pkg/auth/portalrbac/portalrbac.go
@@ -6,49 +6,16 @@
 // the session's workspace, keyspace, and external identity scope.
 package portalrbac
 
-import "fmt"
-
-// Capability is one entry in the portal's simplified permission vocabulary. It
-// is intentionally coarse and product-oriented; the fine-grained RBAC actions it
-// maps to are an implementation detail owned by this package.
-type Capability string
-
 const (
 	// CapKeysRead lets the end user list and read their own keys.
-	CapKeysRead Capability = "keys:read"
+	CapKeysRead = "keys:read"
 
 	// CapKeysCreate lets the end user create new keys.
-	CapKeysCreate Capability = "keys:create"
+	CapKeysCreate = "keys:create"
 
 	// CapKeysReroll lets the end user rotate the secret of an existing key.
-	CapKeysReroll Capability = "keys:reroll"
+	CapKeysReroll = "keys:reroll"
 
 	// CapAnalyticsRead lets the end user read their verification analytics.
-	CapAnalyticsRead Capability = "analytics:read"
+	CapAnalyticsRead = "analytics:read"
 )
-
-// Parse validates a raw capability string and returns the typed Capability.
-// Callers should use this at the API boundary (portal.createSession) to reject
-// unknown verbs before they are ever persisted.
-func Parse(s string) (Capability, error) {
-	switch Capability(s) {
-	case CapKeysRead, CapKeysCreate, CapKeysReroll, CapAnalyticsRead:
-		return Capability(s), nil
-	default:
-		return "", fmt.Errorf("unknown portal capability %q", s)
-	}
-}
-
-// ParseAll validates a slice of raw capability strings, returning the first
-// error encountered.
-func ParseAll(raw []string) ([]Capability, error) {
-	caps := make([]Capability, 0, len(raw))
-	for _, s := range raw {
-		c, err := Parse(s)
-		if err != nil {
-			return nil, err
-		}
-		caps = append(caps, c)
-	}
-	return caps, nil
-}

--- a/pkg/auth/portalrbac/portalrbac.go
+++ b/pkg/auth/portalrbac/portalrbac.go
@@ -1,32 +1,12 @@
-// Package portalrbac is the single translation seam between the portal's
-// simplified, public-facing permission model and the RBAC mechanism that
-// actually enforces access.
+// Package portalrbac defines the portal's public capability vocabulary.
 //
 // A workspace owner creates a portal session with a small, stable vocabulary of
 // capabilities ("keys:read", "keys:reroll", ...) scoped to a set of keyspaces.
-// That simplified grant is what gets persisted on the session and what the
-// public API exposes. Enforcement, however, currently reuses the existing
-// keyspace-scoped URN permissions checked by the shared key handlers.
-//
-// Keeping the mapping here — invoked once, when a session principal is resolved
-// — means:
-//
-//   - The persisted/public form never leaks the enforcement representation, so
-//     the mapping can change without migrating stored sessions.
-//   - Handlers stay ignorant of "portal": they keep authorizing against ordinary
-//     RBAC permission strings.
-//   - To later run a bespoke portal RBAC instead of the shared URN system, only
-//     this package changes (swap [Expand] for an alternative [Authorizer], and
-//     have the portal route wrappers consult it directly).
+// Portal handlers authorize these capabilities directly and separately enforce
+// the session's workspace, keyspace, and external identity scope.
 package portalrbac
 
-import (
-	"fmt"
-
-	"github.com/unkeyed/unkey/pkg/rbac"
-	"github.com/unkeyed/unkey/pkg/rbac/permissions"
-	"github.com/unkeyed/unkey/pkg/urn"
-)
+import "fmt"
 
 // Capability is one entry in the portal's simplified permission vocabulary. It
 // is intentionally coarse and product-oriented; the fine-grained RBAC actions it
@@ -43,7 +23,7 @@ const (
 	// CapKeysReroll lets the end user rotate the secret of an existing key.
 	CapKeysReroll Capability = "keys:reroll"
 
-	// CapAnalyticsRead lets the end user read verification analytics.
+	// CapAnalyticsRead lets the end user read their verification analytics.
 	CapAnalyticsRead Capability = "analytics:read"
 )
 
@@ -71,73 +51,4 @@ func ParseAll(raw []string) ([]Capability, error) {
 		caps = append(caps, c)
 	}
 	return caps, nil
-}
-
-// Grant is the simplified authorization a portal session carries: a set of
-// capabilities scoped to a set of keyspaces within one workspace.
-type Grant struct {
-	WorkspaceID  string
-	KeyspaceIDs  []string
-	Capabilities []Capability
-}
-
-// Expand translates a Grant into the concrete RBAC permission strings the shared
-// key/analytics handlers authorize against. The strings are built with the same
-// urn + permission primitives the handlers use in their rbac.U/rbac.T queries,
-// so they match by construction (see portalrbac_test.go, which checks Expand's
-// output against the real handler queries).
-//
-// Key capabilities are keyspace-scoped: each is expanded once per keyspace in
-// the grant. Analytics is workspace-wide and expands to a single wildcard tuple.
-func (g Grant) Expand() []string {
-	var granted []string
-
-	for _, c := range g.Capabilities {
-		switch c {
-		case CapKeysRead:
-			// listKeys requires read_key on the keyspace's keys AND read_keyspace
-			// on the keyspace itself.
-			for _, ks := range g.KeyspaceIDs {
-				granted = append(granted,
-					unkeyPerm(urn.New().Workspace(g.WorkspaceID).Keyspace(ks).Key("*"), permissions.ReadKey{}),
-					unkeyPerm(urn.New().Workspace(g.WorkspaceID).Keyspace(ks), permissions.ReadKeyspace{}),
-				)
-			}
-
-		case CapKeysCreate:
-			for _, ks := range g.KeyspaceIDs {
-				granted = append(granted,
-					unkeyPerm(urn.New().Workspace(g.WorkspaceID).Keyspace(ks), permissions.CreateKey{}),
-				)
-			}
-
-		case CapKeysReroll:
-			// Reroll is authorized as create_key today (it mints a fresh key), plus
-			// encrypt_key so recoverable keys can be rotated. When reroll gets its
-			// own RBAC action, only this arm changes.
-			for _, ks := range g.KeyspaceIDs {
-				granted = append(granted,
-					unkeyPerm(urn.New().Workspace(g.WorkspaceID).Keyspace(ks), permissions.CreateKey{}),
-					unkeyPerm(urn.New().Workspace(g.WorkspaceID).Keyspace(ks).Key("*"), permissions.EncryptKey{}),
-				)
-			}
-
-		case CapAnalyticsRead:
-			// Analytics is not keyspace-scoped; the portal getVerifications handler
-			// checks the wildcard api tuple.
-			granted = append(granted, rbac.Tuple{
-				ResourceType: rbac.Api,
-				ResourceID:   "*",
-				Action:       rbac.ReadAnalytics,
-			}.String())
-		}
-	}
-
-	return granted
-}
-
-// unkeyPerm renders a keyspace/key-scoped URN permission string in the exact
-// format rbac.U produces, so granted strings match the handler queries.
-func unkeyPerm(resource fmt.Stringer, action fmt.Stringer) string {
-	return fmt.Sprintf("%s#%s", resource.String(), action.String())
 }

--- a/pkg/auth/portalrbac/portalrbac_test.go
+++ b/pkg/auth/portalrbac/portalrbac_test.go
@@ -9,25 +9,16 @@ import (
 	"github.com/unkeyed/unkey/pkg/rbac"
 )
 
-func TestParseRejectsUnknownCapability(t *testing.T) {
-	_, err := portalrbac.Parse("keys:destroy")
-	require.Error(t, err)
-
-	c, err := portalrbac.Parse("keys:reroll")
-	require.NoError(t, err)
-	require.Equal(t, portalrbac.CapKeysReroll, c)
-}
-
 func TestCapabilitiesUseExactMatching(t *testing.T) {
 	granted := []string{
-		string(portalrbac.CapKeysRead),
-		string(portalrbac.CapKeysCreate),
-		string(portalrbac.CapAnalyticsRead),
+		portalrbac.CapKeysRead,
+		portalrbac.CapKeysCreate,
+		portalrbac.CapAnalyticsRead,
 	}
 
-	require.NoError(t, rbac.Check(rbac.S(string(portalrbac.CapKeysRead)), granted))
-	require.NoError(t, rbac.Check(rbac.S(string(portalrbac.CapKeysCreate)), granted))
-	require.NoError(t, rbac.Check(rbac.S(string(portalrbac.CapAnalyticsRead)), granted))
-	require.Error(t, rbac.Check(rbac.S(string(portalrbac.CapKeysReroll)), granted),
+	require.NoError(t, rbac.Check(rbac.S(portalrbac.CapKeysRead), granted))
+	require.NoError(t, rbac.Check(rbac.S(portalrbac.CapKeysCreate), granted))
+	require.NoError(t, rbac.Check(rbac.S(portalrbac.CapAnalyticsRead), granted))
+	require.Error(t, rbac.Check(rbac.S(portalrbac.CapKeysReroll), granted),
 		"keys:create must not imply keys:reroll")
 }

--- a/pkg/auth/portalrbac/portalrbac_test.go
+++ b/pkg/auth/portalrbac/portalrbac_test.go
@@ -7,32 +7,7 @@ import (
 
 	"github.com/unkeyed/unkey/pkg/auth/portalrbac"
 	"github.com/unkeyed/unkey/pkg/rbac"
-	"github.com/unkeyed/unkey/pkg/rbac/permissions"
-	"github.com/unkeyed/unkey/pkg/urn"
 )
-
-const (
-	ws  = "ws_123"
-	ks1 = "ks_111"
-	ks2 = "ks_222"
-)
-
-// These queries mirror the URN legs the shared handlers authorize against, so a
-// passing rbac.Check proves Expand's output actually satisfies them.
-func listKeysQuery(ks string) rbac.PermissionQuery {
-	return rbac.And(
-		rbac.U(urn.New().Workspace(ws).Keyspace(ks).Key("*"), permissions.ReadKey{}),
-		rbac.U(urn.New().Workspace(ws).Keyspace(ks), permissions.ReadKeyspace{}),
-	)
-}
-
-func rerollQuery(ks string) rbac.PermissionQuery {
-	return rbac.U(urn.New().Workspace(ws).Keyspace(ks), permissions.CreateKey{})
-}
-
-func analyticsQuery() rbac.PermissionQuery {
-	return rbac.T(rbac.Tuple{ResourceType: rbac.Api, ResourceID: "*", Action: rbac.ReadAnalytics})
-}
 
 func TestParseRejectsUnknownCapability(t *testing.T) {
 	_, err := portalrbac.Parse("keys:destroy")
@@ -43,38 +18,16 @@ func TestParseRejectsUnknownCapability(t *testing.T) {
 	require.Equal(t, portalrbac.CapKeysReroll, c)
 }
 
-func TestExpandSatisfiesHandlerQueries(t *testing.T) {
-	granted := portalrbac.Grant{
-		WorkspaceID:  ws,
-		KeyspaceIDs:  []string{ks1},
-		Capabilities: []portalrbac.Capability{portalrbac.CapKeysRead, portalrbac.CapKeysReroll, portalrbac.CapAnalyticsRead},
-	}.Expand()
+func TestCapabilitiesUseExactMatching(t *testing.T) {
+	granted := []string{
+		string(portalrbac.CapKeysRead),
+		string(portalrbac.CapKeysCreate),
+		string(portalrbac.CapAnalyticsRead),
+	}
 
-	require.NoError(t, rbac.Check(listKeysQuery(ks1), granted), "keys:read should satisfy listKeys")
-	require.NoError(t, rbac.Check(rerollQuery(ks1), granted), "keys:reroll should satisfy reroll")
-	require.NoError(t, rbac.Check(analyticsQuery(), granted), "analytics:read should satisfy getVerifications")
-}
-
-func TestExpandIsScopedToGrantedKeyspaces(t *testing.T) {
-	granted := portalrbac.Grant{
-		WorkspaceID:  ws,
-		KeyspaceIDs:  []string{ks1},
-		Capabilities: []portalrbac.Capability{portalrbac.CapKeysReroll},
-	}.Expand()
-
-	require.NoError(t, rbac.Check(rerollQuery(ks1), granted), "reroll allowed on granted keyspace")
-	require.Error(t, rbac.Check(rerollQuery(ks2), granted), "reroll must be denied on a keyspace not in the grant")
-}
-
-func TestExpandDoesNotOvergrant(t *testing.T) {
-	// A read-only grant must not satisfy a reroll (create_key) query.
-	granted := portalrbac.Grant{
-		WorkspaceID:  ws,
-		KeyspaceIDs:  []string{ks1},
-		Capabilities: []portalrbac.Capability{portalrbac.CapKeysRead},
-	}.Expand()
-
-	require.NoError(t, rbac.Check(listKeysQuery(ks1), granted))
-	require.Error(t, rbac.Check(rerollQuery(ks1), granted), "read-only grant must not allow reroll")
-	require.Error(t, rbac.Check(analyticsQuery(), granted), "read-only grant must not allow analytics")
+	require.NoError(t, rbac.Check(rbac.S(string(portalrbac.CapKeysRead)), granted))
+	require.NoError(t, rbac.Check(rbac.S(string(portalrbac.CapKeysCreate)), granted))
+	require.NoError(t, rbac.Check(rbac.S(string(portalrbac.CapAnalyticsRead)), granted))
+	require.Error(t, rbac.Check(rbac.S(string(portalrbac.CapKeysReroll)), granted),
+		"keys:create must not imply keys:reroll")
 }

--- a/pkg/auth/principal/principal.go
+++ b/pkg/auth/principal/principal.go
@@ -55,7 +55,7 @@ type Principal struct {
 	// WorkspaceID scopes all handler reads and writes for this principal.
 	WorkspaceID string
 
-	// Permissions is the flat RBAC permission set granted to this principal.
+	// Permissions is the flat set of exact or resource-scoped authorization grants.
 	Permissions []string
 }
 
@@ -140,7 +140,7 @@ type PortalSessionSource struct {
 	// these; the request never carries a keyspace or api id.
 	KeyspaceIDs []string
 
-	// Permissions are the raw RBAC permission strings attached to the portal session.
+	// Permissions are the capabilities attached to the portal session.
 	Permissions []string
 }
 

--- a/pkg/clickhouse/interface.go
+++ b/pkg/clickhouse/interface.go
@@ -26,9 +26,9 @@ type Querier interface {
 	GetBillableVerifications(ctx context.Context, workspaceID string, year, month int) (int64, error)
 
 	// GetVerificationsByExternalID returns a zero-filled verification timeseries
-	// for a single end user (workspace_id + external_id), optionally narrowed to
-	// one key. Used by the portal getVerifications endpoint. Bucket granularity
-	// is chosen from the window size.
+	// for a single end user within explicit keyspaces, optionally narrowed to one
+	// key. Used by the portal getVerifications endpoint. Bucket granularity is
+	// chosen from the window size.
 	GetVerificationsByExternalID(ctx context.Context, req VerificationTimeseriesRequest) ([]VerificationTimeseriesDataPoint, error)
 
 	GetBillableRatelimits(ctx context.Context, workspaceID string, year, month int) (int64, error)

--- a/pkg/clickhouse/key_verifications_timeseries.go
+++ b/pkg/clickhouse/key_verifications_timeseries.go
@@ -3,18 +3,20 @@ package clickhouse
 import (
 	"context"
 	"fmt"
-	"strconv"
 
+	ch "github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/unkeyed/unkey/pkg/fault"
 )
 
 // VerificationTimeseriesRequest scopes a verification timeseries to a single
-// portal end user. WorkspaceID and ExternalID are required; KeyID optionally
-// narrows to one key. StartTime and EndTime bound the window in unix
-// milliseconds (StartTime inclusive, EndTime exclusive).
+// portal end user within an explicit set of keyspaces. WorkspaceID, ExternalID,
+// and KeyspaceIDs are required; KeyID optionally narrows to one key. StartTime
+// and EndTime bound the window in unix milliseconds (StartTime inclusive,
+// EndTime exclusive).
 type VerificationTimeseriesRequest struct {
 	WorkspaceID string
 	ExternalID  string
+	KeyspaceIDs []string
 	KeyID       string
 	StartTime   int64
 	EndTime     int64
@@ -60,14 +62,15 @@ func selectVerificationInterval(windowMs int64) verificationInterval {
 }
 
 // GetVerificationsByExternalID returns a zero-filled verification timeseries for
-// one end user (workspace_id + external_id), optionally narrowed to a single
+// one end user within the requested keyspaces, optionally narrowed to a single
 // key. Bucket granularity is chosen from the window size. Empty buckets are
 // returned with zero counts so callers get a contiguous series.
 //
 // The query runs on the shared ClickHouse connection (not a per-workspace user)
-// and filters on external_id, which is denormalized onto each event at write
-// time. This is the portal-scoped read: the workspace and identity are pinned by
-// the caller, so no query DSL or per-workspace connection is involved.
+// and filters on key_space_id and external_id, which are denormalized onto each
+// event at write time. This is the portal-scoped read: the workspace, keyspaces,
+// and identity are pinned by the caller, so no query DSL or per-workspace
+// connection is involved.
 func (c *Client) GetVerificationsByExternalID(ctx context.Context, req VerificationTimeseriesRequest) ([]VerificationTimeseriesDataPoint, error) {
 	iv := selectVerificationInterval(req.EndTime - req.StartTime)
 
@@ -89,27 +92,33 @@ func (c *Client) GetVerificationsByExternalID(ctx context.Context, req Verificat
 		toInt64(SUM(IF(outcome = 'EXPIRED', count, 0))) AS expired,
 		toInt64(SUM(IF(outcome = 'USAGE_EXCEEDED', count, 0))) AS usage_exceeded
 	FROM %[2]s
-	WHERE workspace_id = {workspace_id:String}
-		AND external_id = {external_id:String}
-		AND time >= fromUnixTimestamp64Milli({start:Int64})
-		AND time < fromUnixTimestamp64Milli({end:Int64})
-		AND ({key_id:String} = '' OR key_id = {key_id:String})
+	WHERE workspace_id = @workspace_id
+		AND external_id = @external_id
+		AND key_space_id IN @keyspace_ids
+		AND time >= fromUnixTimestamp64Milli(@start)
+		AND time < fromUnixTimestamp64Milli(@end)
+		AND (@key_id = '' OR key_id = @key_id)
 	GROUP BY x
 	ORDER BY x ASC
 	WITH FILL
-		FROM toUnixTimestamp64Milli(CAST(toStartOfInterval(fromUnixTimestamp64Milli({start:Int64}), INTERVAL 1 %[1]s) AS DateTime64(3)))
-		TO toUnixTimestamp64Milli(CAST(toStartOfInterval(fromUnixTimestamp64Milli({end:Int64}), INTERVAL 1 %[1]s) AS DateTime64(3))) + %[3]d
+		FROM toUnixTimestamp64Milli(CAST(toStartOfInterval(fromUnixTimestamp64Milli(@start), INTERVAL 1 %[1]s) AS DateTime64(3)))
+		TO toUnixTimestamp64Milli(CAST(toStartOfInterval(fromUnixTimestamp64Milli(@end), INTERVAL 1 %[1]s) AS DateTime64(3))) + %[3]d
 		STEP %[3]d`,
 		iv.unit, iv.table, iv.stepMs,
 	)
 
-	results, err := Select[VerificationTimeseriesDataPoint](ctx, c.conn, query, map[string]string{
-		"workspace_id": req.WorkspaceID,
-		"external_id":  req.ExternalID,
-		"key_id":       req.KeyID,
-		"start":        strconv.FormatInt(req.StartTime, 10),
-		"end":          strconv.FormatInt(req.EndTime, 10),
-	})
+	results, err := Select[VerificationTimeseriesDataPoint](
+		ctx,
+		c.conn,
+		query,
+		nil,
+		ch.Named("workspace_id", req.WorkspaceID),
+		ch.Named("external_id", req.ExternalID),
+		ch.Named("keyspace_ids", req.KeyspaceIDs),
+		ch.Named("key_id", req.KeyID),
+		ch.Named("start", req.StartTime),
+		ch.Named("end", req.EndTime),
+	)
 	if err != nil {
 		return nil, fault.Wrap(err, fault.Internal("failed to query verification timeseries"))
 	}

--- a/pkg/clickhouse/key_verifications_timeseries.go
+++ b/pkg/clickhouse/key_verifications_timeseries.go
@@ -3,8 +3,9 @@ package clickhouse
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
 
-	ch "github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/unkeyed/unkey/pkg/fault"
 )
 
@@ -77,7 +78,7 @@ func (c *Client) GetVerificationsByExternalID(ctx context.Context, req Verificat
 	// iv.unit, iv.table and iv.stepMs come from selectVerificationInterval — a
 	// fixed switch over the window size, never caller input — so they are safe to
 	// interpolate. Every caller-supplied value (workspace, identity, key, window
-	// bounds) goes through a typed named parameter instead. SUM results are cast
+	// bounds) goes through a typed query parameter instead. SUM results are cast
 	// to Int64 so they scan into the int64 struct fields. An empty key_id means
 	// "all keys": the OR short-circuits the filter rather than binding it.
 	query := fmt.Sprintf(`
@@ -92,33 +93,35 @@ func (c *Client) GetVerificationsByExternalID(ctx context.Context, req Verificat
 		toInt64(SUM(IF(outcome = 'EXPIRED', count, 0))) AS expired,
 		toInt64(SUM(IF(outcome = 'USAGE_EXCEEDED', count, 0))) AS usage_exceeded
 	FROM %[2]s
-	WHERE workspace_id = @workspace_id
-		AND external_id = @external_id
-		AND key_space_id IN @keyspace_ids
-		AND time >= fromUnixTimestamp64Milli(@start)
-		AND time < fromUnixTimestamp64Milli(@end)
-		AND (@key_id = '' OR key_id = @key_id)
+	WHERE workspace_id = {workspace_id:String}
+		AND external_id = {external_id:String}
+		AND key_space_id IN {keyspace_ids:Array(String)}
+		AND time >= fromUnixTimestamp64Milli({start:Int64})
+		AND time < fromUnixTimestamp64Milli({end:Int64})
+		AND ({key_id:String} = '' OR key_id = {key_id:String})
 	GROUP BY x
 	ORDER BY x ASC
 	WITH FILL
-		FROM toUnixTimestamp64Milli(CAST(toStartOfInterval(fromUnixTimestamp64Milli(@start), INTERVAL 1 %[1]s) AS DateTime64(3)))
-		TO toUnixTimestamp64Milli(CAST(toStartOfInterval(fromUnixTimestamp64Milli(@end), INTERVAL 1 %[1]s) AS DateTime64(3))) + %[3]d
+		FROM toUnixTimestamp64Milli(CAST(toStartOfInterval(fromUnixTimestamp64Milli({start:Int64}), INTERVAL 1 %[1]s) AS DateTime64(3)))
+		TO toUnixTimestamp64Milli(CAST(toStartOfInterval(fromUnixTimestamp64Milli({end:Int64}), INTERVAL 1 %[1]s) AS DateTime64(3))) + %[3]d
 		STEP %[3]d`,
 		iv.unit, iv.table, iv.stepMs,
 	)
 
-	results, err := Select[VerificationTimeseriesDataPoint](
-		ctx,
-		c.conn,
-		query,
-		nil,
-		ch.Named("workspace_id", req.WorkspaceID),
-		ch.Named("external_id", req.ExternalID),
-		ch.Named("keyspace_ids", req.KeyspaceIDs),
-		ch.Named("key_id", req.KeyID),
-		ch.Named("start", req.StartTime),
-		ch.Named("end", req.EndTime),
-	)
+	escapeKeyspaceID := strings.NewReplacer(`\`, `\\`, `'`, `\'`)
+	keyspaceIDs := make([]string, len(req.KeyspaceIDs))
+	for i, keyspaceID := range req.KeyspaceIDs {
+		keyspaceIDs[i] = "'" + escapeKeyspaceID.Replace(keyspaceID) + "'"
+	}
+
+	results, err := Select[VerificationTimeseriesDataPoint](ctx, c.conn, query, map[string]string{
+		"workspace_id": req.WorkspaceID,
+		"external_id":  req.ExternalID,
+		"keyspace_ids": fmt.Sprintf("[%s]", strings.Join(keyspaceIDs, ",")),
+		"key_id":       req.KeyID,
+		"start":        strconv.FormatInt(req.StartTime, 10),
+		"end":          strconv.FormatInt(req.EndTime, 10),
+	})
 	if err != nil {
 		return nil, fault.Wrap(err, fault.Internal("failed to query verification timeseries"))
 	}

--- a/pkg/clickhouse/key_verifications_timeseries.go
+++ b/pkg/clickhouse/key_verifications_timeseries.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/unkeyed/unkey/pkg/array"
 	"github.com/unkeyed/unkey/pkg/fault"
 )
 
@@ -108,11 +109,9 @@ func (c *Client) GetVerificationsByExternalID(ctx context.Context, req Verificat
 		iv.unit, iv.table, iv.stepMs,
 	)
 
-	escapeKeyspaceID := strings.NewReplacer(`\`, `\\`, `'`, `\'`)
-	keyspaceIDs := make([]string, len(req.KeyspaceIDs))
-	for i, keyspaceID := range req.KeyspaceIDs {
-		keyspaceIDs[i] = "'" + escapeKeyspaceID.Replace(keyspaceID) + "'"
-	}
+	keyspaceIDs := array.Map(req.KeyspaceIDs, func(keyspaceID string) string {
+		return fmt.Sprintf("'%s'", keyspaceID)
+	})
 
 	results, err := Select[VerificationTimeseriesDataPoint](ctx, c.conn, query, map[string]string{
 		"workspace_id": req.WorkspaceID,

--- a/pkg/clickhouse/key_verifications_timeseries_test.go
+++ b/pkg/clickhouse/key_verifications_timeseries_test.go
@@ -29,6 +29,7 @@ func TestGetVerificationsByExternalID(t *testing.T) {
 	extA := "ext_" + uid.New("")
 	extB := "ext_" + uid.New("")
 	keySpaceID := uid.New(uid.KeySpacePrefix)
+	otherKeySpaceID := uid.New(uid.KeySpacePrefix)
 	targetKey := uid.New(uid.KeyPrefix)
 	otherKey := uid.New(uid.KeyPrefix)
 
@@ -38,7 +39,7 @@ func TestGetVerificationsByExternalID(t *testing.T) {
 	dayA := base.Add(12 * time.Hour)
 	dayB := base.Add(2*24*time.Hour + 12*time.Hour)
 
-	mk := func(extID, keyID, outcome string, ts time.Time) schema.KeyVerification {
+	mk := func(extID, keySpaceID, keyID, outcome string, ts time.Time) schema.KeyVerification {
 		return schema.KeyVerification{
 			RequestID:   uid.New(uid.RequestPrefix),
 			Time:        ts.UnixMilli(),
@@ -55,19 +56,21 @@ func TestGetVerificationsByExternalID(t *testing.T) {
 
 	rows := []schema.KeyVerification{
 		// extA, day A: 3 VALID (one on targetKey), 2 RATE_LIMITED
-		mk(extA, targetKey, "VALID", dayA),
-		mk(extA, otherKey, "VALID", dayA),
-		mk(extA, otherKey, "VALID", dayA),
-		mk(extA, otherKey, "RATE_LIMITED", dayA),
-		mk(extA, otherKey, "RATE_LIMITED", dayA),
+		mk(extA, keySpaceID, targetKey, "VALID", dayA),
+		mk(extA, keySpaceID, otherKey, "VALID", dayA),
+		mk(extA, keySpaceID, otherKey, "VALID", dayA),
+		mk(extA, keySpaceID, otherKey, "RATE_LIMITED", dayA),
+		mk(extA, keySpaceID, otherKey, "RATE_LIMITED", dayA),
 		// extA, day B: 1 VALID
-		mk(extA, otherKey, "VALID", dayB),
+		mk(extA, keySpaceID, otherKey, "VALID", dayB),
+		// extA in another keyspace: excluded unless explicitly requested.
+		mk(extA, otherKeySpaceID, otherKey, "VALID", dayA),
 		// extB, day A: 5 VALID (must NOT appear in extA results)
-		mk(extB, otherKey, "VALID", dayA),
-		mk(extB, otherKey, "VALID", dayA),
-		mk(extB, otherKey, "VALID", dayA),
-		mk(extB, otherKey, "VALID", dayA),
-		mk(extB, otherKey, "VALID", dayA),
+		mk(extB, keySpaceID, otherKey, "VALID", dayA),
+		mk(extB, keySpaceID, otherKey, "VALID", dayA),
+		mk(extB, keySpaceID, otherKey, "VALID", dayA),
+		mk(extB, keySpaceID, otherKey, "VALID", dayA),
+		mk(extB, keySpaceID, otherKey, "VALID", dayA),
 	}
 
 	batch, err := client.Conn().PrepareBatch(ctx, "INSERT INTO default.key_verifications_raw_v2")
@@ -77,7 +80,7 @@ func TestGetVerificationsByExternalID(t *testing.T) {
 	}
 	require.NoError(t, batch.Send())
 
-	// Wait for the per_day materialized view to catch up (extA has 6 events).
+	// Wait for the per_day materialized view to catch up (extA has 7 events).
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		var got int64
 		err := client.Conn().QueryRow(ctx,
@@ -85,7 +88,7 @@ func TestGetVerificationsByExternalID(t *testing.T) {
 			workspaceID, extA,
 		).Scan(&got)
 		assert.NoError(c, err)
-		assert.Equal(c, int64(6), got)
+		assert.Equal(c, int64(7), got)
 	}, time.Minute, time.Second)
 
 	startMs := base.UnixMilli()
@@ -105,6 +108,7 @@ func TestGetVerificationsByExternalID(t *testing.T) {
 		points, err := client.GetVerificationsByExternalID(ctx, clickhouse.VerificationTimeseriesRequest{
 			WorkspaceID: workspaceID,
 			ExternalID:  extA,
+			KeyspaceIDs: []string{keySpaceID},
 			StartTime:   startMs,
 			EndTime:     endMs,
 		})
@@ -129,6 +133,7 @@ func TestGetVerificationsByExternalID(t *testing.T) {
 		points, err := client.GetVerificationsByExternalID(ctx, clickhouse.VerificationTimeseriesRequest{
 			WorkspaceID: workspaceID,
 			ExternalID:  extA,
+			KeyspaceIDs: []string{keySpaceID},
 			StartTime:   startMs,
 			EndTime:     endMs,
 		})
@@ -146,6 +151,7 @@ func TestGetVerificationsByExternalID(t *testing.T) {
 		points, err := client.GetVerificationsByExternalID(ctx, clickhouse.VerificationTimeseriesRequest{
 			WorkspaceID: workspaceID,
 			ExternalID:  extA,
+			KeyspaceIDs: []string{keySpaceID},
 			KeyID:       targetKey,
 			StartTime:   startMs,
 			EndTime:     endMs,
@@ -156,5 +162,39 @@ func TestGetVerificationsByExternalID(t *testing.T) {
 		require.Equal(t, int64(1), m[dayABucket].Total)
 		require.Equal(t, int64(1), m[dayABucket].Valid)
 		require.Equal(t, int64(0), m[dayBBucket].Total)
+	})
+
+	t.Run("multiple keyspaces are unioned", func(t *testing.T) {
+		points, err := client.GetVerificationsByExternalID(ctx, clickhouse.VerificationTimeseriesRequest{
+			WorkspaceID: workspaceID,
+			ExternalID:  extA,
+			KeyspaceIDs: []string{keySpaceID, otherKeySpaceID},
+			StartTime:   startMs,
+			EndTime:     endMs,
+		})
+		require.NoError(t, err)
+
+		var total int64
+		for _, point := range points {
+			total += point.Total
+		}
+		require.Equal(t, int64(7), total)
+	})
+
+	t.Run("empty keyspace scope returns no events", func(t *testing.T) {
+		points, err := client.GetVerificationsByExternalID(ctx, clickhouse.VerificationTimeseriesRequest{
+			WorkspaceID: workspaceID,
+			ExternalID:  extA,
+			KeyspaceIDs: []string{},
+			StartTime:   startMs,
+			EndTime:     endMs,
+		})
+		require.NoError(t, err)
+
+		var total int64
+		for _, point := range points {
+			total += point.Total
+		}
+		require.Zero(t, total)
 	})
 }

--- a/pkg/clickhouse/select.go
+++ b/pkg/clickhouse/select.go
@@ -14,6 +14,10 @@ import (
 // replaced with values from the parameters map. This helps prevent SQL injection
 // by properly escaping parameter values.
 //
+// Args are forwarded to the ClickHouse driver for positional or named binding.
+// Do not combine args with a non-empty parameters map: native query parameters
+// take precedence and the driver does not bind args in that mode.
+//
 // Important: The generic type T must be properly annotated with `ch` struct tags to be
 // unmarshalled correctly. Each field that corresponds to a ClickHouse column must have
 // a `ch` tag specifying the column name, like:
@@ -59,12 +63,13 @@ import (
 //
 // This function is thread-safe and can be used concurrently with the same connection,
 // as the underlying ClickHouse driver handles connection pooling.
-func Select[T any](ctx context.Context, conn ch.Conn, query string, parameters map[string]string) ([]T, error) {
+func Select[T any](ctx context.Context, conn ch.Conn, query string, parameters map[string]string, args ...any) ([]T, error) {
 	var dest []T
 	err := conn.Select(
 		ch.Context(ctx, ch.WithParameters(parameters)),
 		&dest,
 		query,
+		args...,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/clickhouse/select.go
+++ b/pkg/clickhouse/select.go
@@ -14,10 +14,6 @@ import (
 // replaced with values from the parameters map. This helps prevent SQL injection
 // by properly escaping parameter values.
 //
-// Args are forwarded to the ClickHouse driver for positional or named binding.
-// Do not combine args with a non-empty parameters map: native query parameters
-// take precedence and the driver does not bind args in that mode.
-//
 // Important: The generic type T must be properly annotated with `ch` struct tags to be
 // unmarshalled correctly. Each field that corresponds to a ClickHouse column must have
 // a `ch` tag specifying the column name, like:
@@ -63,13 +59,12 @@ import (
 //
 // This function is thread-safe and can be used concurrently with the same connection,
 // as the underlying ClickHouse driver handles connection pooling.
-func Select[T any](ctx context.Context, conn ch.Conn, query string, parameters map[string]string, args ...any) ([]T, error) {
+func Select[T any](ctx context.Context, conn ch.Conn, query string, parameters map[string]string) ([]T, error) {
 	var dest []T
 	err := conn.Select(
 		ch.Context(ctx, ch.WithParameters(parameters)),
 		&dest,
 		query,
-		args...,
 	)
 	if err != nil {
 		return nil, err

--- a/svc/api/internal/middleware/errors_test.go
+++ b/svc/api/internal/middleware/errors_test.go
@@ -35,7 +35,7 @@ func newSession(t *testing.T, method, path string) (*zen.Session, *httptest.Resp
 	return sess, w
 }
 
-func TestErrorMiddleware_500_LogsRichContext(t *testing.T) {
+func TestErrorMiddleware_500_LogsRichContextAndHidesInternalDetails(t *testing.T) {
 	h := loggertest.Install(t)
 
 	sess, rec := newSession(t, http.MethodPost, "/v2/keys.verifyKey?debug=1")
@@ -61,6 +61,9 @@ func TestErrorMiddleware_500_LogsRichContext(t *testing.T) {
 
 	require.Equal(t, http.StatusInternalServerError, rec.Code,
 		"unmapped fault errors must produce a 500")
+	require.Contains(t, rec.Body.String(), "Something went wrong.")
+	require.NotContains(t, rec.Body.String(), "db connection refused")
+	require.NotContains(t, rec.Body.String(), "could not look up key")
 
 	r := h.Find(t, "api error")
 	attrs := loggertest.FlatAttrs(r)

--- a/svc/api/internal/testutil/http.go
+++ b/svc/api/internal/testutil/http.go
@@ -282,6 +282,7 @@ func NewHarness(t *testing.T, configs ...HarnessConfig) *Harness {
 	portalService := portal.New(portal.Config{
 		DB:           database,
 		SessionCache: caches.PortalSession,
+		Clock:        clk,
 	})
 	// Mirror production: portal sessions authenticate only on a dedicated portal
 	// auth service, so protected routes reject portal-session cookies.
@@ -391,6 +392,7 @@ func (h *Harness) CreatePortalSession(workspaceID, externalID string, keyspaceID
 	})
 	require.NoError(h.t, err)
 
+	now := h.Clock.Now()
 	err = db.Query.InsertPortalSession(context.Background(), h.DB.RW(), db.InsertPortalSessionParams{
 		ID:             sessionID,
 		WorkspaceID:    workspaceID,
@@ -398,8 +400,8 @@ func (h *Harness) CreatePortalSession(workspaceID, externalID string, keyspaceID
 		ExternalID:     externalID,
 		Permissions:    permsJSON,
 		Preview:        false,
-		ExpiresAt:      time.Now().Add(24 * time.Hour).UnixMilli(),
-		CreatedAt:      time.Now().UnixMilli(),
+		ExpiresAt:      now.Add(24 * time.Hour).UnixMilli(),
+		CreatedAt:      now.UnixMilli(),
 	})
 	require.NoError(h.t, err)
 

--- a/svc/api/openapi/gen.go
+++ b/svc/api/openapi/gen.go
@@ -2642,9 +2642,9 @@ type V2PortalCreateSessionRequestBody struct {
 	// Permissions The capabilities granted to the end user in the Portal, from a fixed
 	// vocabulary. All capabilities are scoped to this end user: key capabilities
 	// (`keys:*`) apply only to keys the end user owns within the keyspace
-	// configured on the portal configuration, and `analytics:read` returns only
-	// the end user's own verification events. An end user can never see another
-	// identity's keys or analytics.
+	// configured on the portal configuration. `analytics:read` grants access to
+	// the end user's own verification analytics within those keyspaces. An end
+	// user can never see another identity's keys or analytics.
 	//
 	// Tab visibility is derived from the capabilities:
 	// - Keys tab: any `keys:*` capability

--- a/svc/api/openapi/openapi-generated.yaml
+++ b/svc/api/openapi/openapi-generated.yaml
@@ -2369,7 +2369,7 @@ components:
                     type: string
                     minLength: 3
                     maxLength: 64
-                    pattern: "^[a-z0-9][a-z0-9-]*[a-z0-9]$"
+                    pattern: "^[a-z0-9]+(?:-[a-z0-9]+)*$"
                     description: |
                         The human-readable slug of the portal configuration to create the session against.
                         Identifies which app's portal the end user will access.
@@ -2398,9 +2398,9 @@ components:
                         The capabilities granted to the end user in the Portal, from a fixed
                         vocabulary. All capabilities are scoped to this end user: key capabilities
                         (`keys:*`) apply only to keys the end user owns within the keyspace
-                        configured on the portal configuration, and `analytics:read` returns only
-                        the end user's own verification events. An end user can never see another
-                        identity's keys or analytics.
+                        configured on the portal configuration. `analytics:read` grants access to
+                        the end user's own verification analytics within those keyspaces. An end
+                        user can never see another identity's keys or analytics.
 
                         Tab visibility is derived from the capabilities:
                         - Keys tab: any `keys:*` capability

--- a/svc/api/openapi/openapi-generated.yaml
+++ b/svc/api/openapi/openapi-generated.yaml
@@ -2369,7 +2369,7 @@ components:
                     type: string
                     minLength: 3
                     maxLength: 64
-                    pattern: "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+                    pattern: "^[a-z0-9][a-z0-9-]*[a-z0-9]$"
                     description: |
                         The human-readable slug of the portal configuration to create the session against.
                         Identifies which app's portal the end user will access.

--- a/svc/api/openapi/spec/paths/v2/portal/createSession/V2PortalCreateSessionRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/portal/createSession/V2PortalCreateSessionRequestBody.yaml
@@ -8,7 +8,7 @@ properties:
     type: string
     minLength: 3
     maxLength: 64
-    pattern: "^[a-z0-9][a-z0-9-]*[a-z0-9]$"
+    pattern: "^[a-z0-9]+(?:-[a-z0-9]+)*$"
     description: |
       The human-readable slug of the portal configuration to create the session against.
       Identifies which app's portal the end user will access.
@@ -37,9 +37,9 @@ properties:
       The capabilities granted to the end user in the Portal, from a fixed
       vocabulary. All capabilities are scoped to this end user: key capabilities
       (`keys:*`) apply only to keys the end user owns within the keyspace
-      configured on the portal configuration, and `analytics:read` returns only
-      the end user's own verification events. An end user can never see another
-      identity's keys or analytics.
+      configured on the portal configuration. `analytics:read` grants access to
+      the end user's own verification analytics within those keyspaces. An end
+      user can never see another identity's keys or analytics.
 
       Tab visibility is derived from the capabilities:
       - Keys tab: any `keys:*` capability

--- a/svc/api/openapi/spec/paths/v2/portal/createSession/V2PortalCreateSessionRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/portal/createSession/V2PortalCreateSessionRequestBody.yaml
@@ -8,7 +8,7 @@ properties:
     type: string
     minLength: 3
     maxLength: 64
-    pattern: "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+    pattern: "^[a-z0-9][a-z0-9-]*[a-z0-9]$"
     description: |
       The human-readable slug of the portal configuration to create the session against.
       Identifies which app's portal the end user will access.

--- a/svc/api/routes/v2_keys_reroll_key/handler.go
+++ b/svc/api/routes/v2_keys_reroll_key/handler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/unkeyed/unkey/svc/api/openapi"
 
 	"github.com/unkeyed/unkey/gen/rpc/vault"
+	"github.com/unkeyed/unkey/pkg/assert"
 	"github.com/unkeyed/unkey/pkg/auditlog"
 	"github.com/unkeyed/unkey/pkg/codes"
 	"github.com/unkeyed/unkey/pkg/db"
@@ -51,6 +52,11 @@ func (h *Handler) Path() string {
 
 // Handle processes the HTTP request.
 func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
+	principal, err := s.GetPrincipal()
+	if err != nil {
+		return err
+	}
+
 	req, err := zen.BindBody[Request](s)
 	if err != nil {
 		return err
@@ -58,6 +64,17 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 	key, err := h.FindLiveKey(ctx, req.KeyId)
 	if err != nil {
+		return err
+	}
+
+	if key.WorkspaceID != principal.WorkspaceID {
+		return fault.New("key not found",
+			fault.Code(codes.Data.Key.NotFound.URN()),
+			fault.Internal("key belongs to different workspace"),
+			fault.Public("The specified key was not found."),
+		)
+	}
+	if err := principal.Authorize(rerollPermissionQuery(key)); err != nil {
 		return err
 	}
 
@@ -89,85 +106,27 @@ func (h *Handler) FindLiveKey(ctx context.Context, keyID string) (db.FindLiveKey
 	return key, nil
 }
 
-// RerollKey rerolls a pre-loaded key. The workspace-ownership check is enforced
-// here; any identity scoping is the caller's responsibility (the portal route
-// applies it before calling). This core is identity-agnostic.
-func (h *Handler) RerollKey(ctx context.Context, s *zen.Session, req Request, key db.FindLiveKeyByIDRow) error {
+// RerollKey mutates a pre-loaded key after the route handler has completed its
+// authorization and scope checks.
+func (h *Handler) RerollKey(
+	ctx context.Context,
+	s *zen.Session,
+	req Request,
+	key db.FindLiveKeyByIDRow,
+) error {
 	principal, err := s.GetPrincipal()
 	if err != nil {
 		return err
 	}
-
-	// Validate key belongs to authorized workspace
-	if key.WorkspaceID != principal.WorkspaceID {
-		return fault.New("key not found",
-			fault.Code(codes.Data.Key.NotFound.URN()),
-			fault.Internal("key belongs to different workspace"),
-			fault.Public("The specified key was not found."),
-		)
-	}
-
-	// Portal-authenticated rerolls are attributed to a portalEndUser actor so
-	// customers can see end-user activity in their audit logs; auditactor derives
-	// this from the principal, so this core stays identity-agnostic.
-	actor := auditactor.FromPrincipal(principal)
-
-	keyData := db.ToKeyData(key)
-
-	// Rerolling is authorized as a create_key operation because it mints a fresh
-	// key. Today this is fine for the portal too: portal sessions carry only the
-	// permissions the workspace owner enumerated at portal.createSession, and the
-	// only key-creating route we expose to them is reroll (there is no
-	// portal.createKey route). So an owner granting create_key for reroll cannot
-	// actually create arbitrary keys.
-	//
-	// TODO: when we add a portal.createKey route, that equivalence breaks — an
-	// owner will want to let a portal user reroll an existing key WITHOUT also
-	// letting them create new ones. At that point introduce a dedicated
-	// reroll_key action and authorize reroll against it instead of create_key.
-	checks := rbac.Or(
-		rbac.T(rbac.Tuple{
-			ResourceType: rbac.Api,
-			ResourceID:   key.Api.ID,
-			Action:       rbac.CreateKey,
-		}),
-		rbac.T(rbac.Tuple{
-			ResourceType: rbac.Api,
-			ResourceID:   "*",
-			Action:       rbac.CreateKey,
-		}),
-		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Keyspace(key.KeyAuthID),
-			permissions.CreateKey{},
-		),
-	)
-
-	if keyData.EncryptionKeyID.Valid {
-		checks = rbac.And(
-			checks,
-			rbac.Or(
-				rbac.T(rbac.Tuple{
-					ResourceType: rbac.Api,
-					ResourceID:   key.Api.ID,
-					Action:       rbac.EncryptKey,
-				}),
-				rbac.T(rbac.Tuple{
-					ResourceType: rbac.Api,
-					ResourceID:   "*",
-					Action:       rbac.EncryptKey,
-				}),
-				rbac.U(
-					urn.New().Workspace(principal.WorkspaceID).Keyspace(key.KeyAuthID).Key("*"),
-					permissions.EncryptKey{},
-				),
-			),
-		)
-	}
-
-	err = principal.Authorize(checks)
-	if err != nil {
+	if err := assert.Equal(key.WorkspaceID, principal.WorkspaceID, "reroll key workspace must match principal"); err != nil {
 		return err
 	}
+	if err := assert.Equal(key.ID, req.KeyId, "preloaded reroll key must match request"); err != nil {
+		return err
+	}
+
+	actor := auditactor.FromPrincipal(principal)
+	keyData := db.ToKeyData(key)
 
 	length := 16
 	prefix := ""
@@ -435,4 +394,50 @@ func (h *Handler) RerollKey(ctx context.Context, s *zen.Session, req Request, ke
 			Key:   keyResult.Key,
 		},
 	})
+}
+
+// rerollPermissionQuery builds the generic API permission requirement. Portal
+// routes pass their product capability directly instead.
+func rerollPermissionQuery(key db.FindLiveKeyByIDRow) rbac.PermissionQuery {
+	keyData := db.ToKeyData(key)
+	checks := rbac.Or(
+		rbac.T(rbac.Tuple{
+			ResourceType: rbac.Api,
+			ResourceID:   key.Api.ID,
+			Action:       rbac.CreateKey,
+		}),
+		rbac.T(rbac.Tuple{
+			ResourceType: rbac.Api,
+			ResourceID:   "*",
+			Action:       rbac.CreateKey,
+		}),
+		rbac.U(
+			urn.New().Workspace(key.WorkspaceID).Keyspace(key.KeyAuthID),
+			permissions.CreateKey{},
+		),
+	)
+
+	if keyData.EncryptionKeyID.Valid {
+		checks = rbac.And(
+			checks,
+			rbac.Or(
+				rbac.T(rbac.Tuple{
+					ResourceType: rbac.Api,
+					ResourceID:   key.Api.ID,
+					Action:       rbac.EncryptKey,
+				}),
+				rbac.T(rbac.Tuple{
+					ResourceType: rbac.Api,
+					ResourceID:   "*",
+					Action:       rbac.EncryptKey,
+				}),
+				rbac.U(
+					urn.New().Workspace(key.WorkspaceID).Keyspace(key.KeyAuthID).Key("*"),
+					permissions.EncryptKey{},
+				),
+			),
+		)
+	}
+
+	return checks
 }

--- a/svc/api/routes/v2_keys_reroll_key/handler.go
+++ b/svc/api/routes/v2_keys_reroll_key/handler.go
@@ -118,10 +118,10 @@ func (h *Handler) RerollKey(
 	if err != nil {
 		return err
 	}
-	if err := assert.Equal(key.WorkspaceID, principal.WorkspaceID, "reroll key workspace must match principal"); err != nil {
-		return err
-	}
-	if err := assert.Equal(key.ID, req.KeyId, "preloaded reroll key must match request"); err != nil {
+	if err := assert.All(
+		assert.Equal(key.WorkspaceID, principal.WorkspaceID, "reroll key workspace must match principal"),
+		assert.Equal(key.ID, req.KeyId, "preloaded reroll key must match request"),
+	); err != nil {
 		return err
 	}
 

--- a/svc/api/routes/v2_portal_create_session/200_test.go
+++ b/svc/api/routes/v2_portal_create_session/200_test.go
@@ -64,7 +64,7 @@ func TestCreateSessionSuccess(t *testing.T) {
 		req := handler.Request{
 			Slug:        "test-portal",
 			ExternalId:  "user_123",
-			Permissions: []openapi.V2PortalCreateSessionRequestBodyPermissions{"keys:read"},
+			Permissions: []openapi.V2PortalCreateSessionRequestBodyPermissions{"keys:read", "analytics:read"},
 		}
 
 		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, req)

--- a/svc/api/routes/v2_portal_create_session/403_test.go
+++ b/svc/api/routes/v2_portal_create_session/403_test.go
@@ -9,8 +9,10 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	authprincipal "github.com/unkeyed/unkey/pkg/auth/principal"
 	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/pkg/zen"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_portal_create_session"
@@ -58,4 +60,63 @@ func TestCreateSessionForbiddenDisabledPortal(t *testing.T) {
 	res := testutil.CallRoute[handler.Request, openapi.ForbiddenErrorResponse](h, route, headers, req)
 	require.Equal(t, 403, res.Status)
 	require.NotNil(t, res.Body)
+}
+
+// TestCreateSessionForbiddenForNonRootPrincipal guarantees that authenticated
+// JWT users cannot probe portal configurations or mint end-user capabilities.
+func TestCreateSessionForbiddenForNonRootPrincipal(t *testing.T) {
+	tests := []struct {
+		name          string
+		principalType authprincipal.Type
+		source        authprincipal.Source
+	}{
+		{name: "JWT", principalType: authprincipal.TypeJWT, source: authprincipal.JWTSource{}},
+		{name: "non-root API key", principalType: authprincipal.TypeAPIKey, source: authprincipal.KeySource{}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			h := testutil.NewHarness(t)
+			route := &handler.Handler{
+				DB:            h.DB,
+				Auditlogs:     h.Auditlogs,
+				PortalBaseURL: "https://portal.unkey.com",
+			}
+
+			middlewares := append([]zen.Middleware{}, h.PublicMiddleware()...)
+			middlewares = append(middlewares, func(next zen.HandleFunc) zen.HandleFunc {
+				return func(ctx context.Context, session *zen.Session) error {
+					session.SetPrincipal(&authprincipal.Principal{
+						Version: authprincipal.Version,
+						Subject: authprincipal.Subject{
+							ID:   "user_123",
+							Name: "Portal Admin",
+							Type: authprincipal.SubjectTypeUser,
+						},
+						Type:        test.principalType,
+						Source:      test.source,
+						WorkspaceID: h.Resources().UserWorkspace.ID,
+					})
+					return next(ctx, session)
+				}
+			})
+			h.Register(route, middlewares...)
+
+			req := handler.Request{
+				Slug:        "hidden-portal",
+				ExternalId:  "customer_123",
+				Permissions: []openapi.V2PortalCreateSessionRequestBodyPermissions{"keys:read"},
+			}
+			headers := http.Header{
+				"Content-Type":  {"application/json"},
+				"Authorization": {"Bearer token"},
+			}
+
+			res := testutil.CallRoute[handler.Request, openapi.ForbiddenErrorResponse](h, route, headers, req)
+			require.Equal(t, http.StatusForbidden, res.Status)
+			require.Equal(t, "This operation requires a root key.", res.Body.Error.Detail)
+			require.NotContains(t, res.RawBody, req.Slug)
+			require.NotContains(t, res.RawBody, req.ExternalId)
+		})
+	}
 }

--- a/svc/api/routes/v2_portal_create_session/404_test.go
+++ b/svc/api/routes/v2_portal_create_session/404_test.go
@@ -42,7 +42,9 @@ func TestCreateSessionNotFoundNonExistentPortalId(t *testing.T) {
 
 	res := testutil.CallRoute[handler.Request, openapi.NotFoundErrorResponse](h, route, headers, req)
 	require.Equal(t, http.StatusNotFound, res.Status, "expected 404, received: %s", res.RawBody)
-	require.NotNil(t, res.Body)
+	require.Equal(t, "Portal configuration not found.", res.Body.Error.Detail)
+	require.NotContains(t, res.RawBody, req.Slug)
+	require.NotContains(t, res.RawBody, req.ExternalId)
 }
 
 func TestCreateSessionNotFoundWrongWorkspace(t *testing.T) {
@@ -89,5 +91,7 @@ func TestCreateSessionNotFoundWrongWorkspace(t *testing.T) {
 
 	res := testutil.CallRoute[handler.Request, openapi.NotFoundErrorResponse](h, route, headers, req)
 	require.Equal(t, http.StatusNotFound, res.Status, "expected 404, received: %s", res.RawBody)
-	require.NotNil(t, res.Body)
+	require.Equal(t, "Portal configuration not found.", res.Body.Error.Detail)
+	require.NotContains(t, res.RawBody, portalConfigID)
+	require.NotContains(t, res.RawBody, workspaceA)
 }

--- a/svc/api/routes/v2_portal_create_session/handler.go
+++ b/svc/api/routes/v2_portal_create_session/handler.go
@@ -10,6 +10,7 @@ import (
 	frontlinev1 "github.com/unkeyed/unkey/gen/proto/frontline/v1"
 	"github.com/unkeyed/unkey/internal/services/auditlogs"
 	"github.com/unkeyed/unkey/pkg/auditlog"
+	authprincipal "github.com/unkeyed/unkey/pkg/auth/principal"
 	"github.com/unkeyed/unkey/pkg/codes"
 	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/fault"
@@ -21,8 +22,7 @@ import (
 )
 
 // storedGrant is the JSON shape persisted in the portal session's permissions
-// column: the simplified capability model the resolver later expands into RBAC
-// via portalrbac. It must stay in sync with the shape parsed in
+// column. It must stay in sync with the shape parsed in
 // internal/services/portal.GetSession.
 type storedGrant struct {
 	KeyspaceIDs []string `json:"keyspaceIds"`
@@ -144,6 +144,13 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	principal, err := s.GetPrincipal()
 	if err != nil {
 		return err
+	}
+	if principal.Type != authprincipal.TypeAPIKey || principal.Subject.Type != authprincipal.SubjectTypeRootKey {
+		return fault.New("portal session creation requires root key authentication",
+			fault.Code(codes.Auth.Authorization.Forbidden.URN()),
+			fault.Internal("non-root principal attempted to create a portal session"),
+			fault.Public("This operation requires a root key."),
+		)
 	}
 
 	req, err := zen.BindBody[Request](s)

--- a/svc/api/routes/v2_portal_exchange_session/200_test.go
+++ b/svc/api/routes/v2_portal_exchange_session/200_test.go
@@ -15,6 +15,20 @@ import (
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_portal_exchange_session"
 )
 
+func marshalPortalGrant(t *testing.T, keyspaceIDs, permissions []string) []byte {
+	t.Helper()
+
+	grant, err := json.Marshal(struct {
+		KeyspaceIDs []string `json:"keyspaceIds"`
+		Permissions []string `json:"permissions"`
+	}{
+		KeyspaceIDs: keyspaceIDs,
+		Permissions: permissions,
+	})
+	require.NoError(t, err)
+	return grant
+}
+
 func TestExchangeSessionSuccess(t *testing.T) {
 	h := testutil.NewHarness(t)
 	ctx := context.Background()
@@ -26,11 +40,12 @@ func TestExchangeSessionSuccess(t *testing.T) {
 	portalConfigID := uid.New(uid.PortalConfigPrefix)
 	now := time.Now().UnixMilli()
 
+	keyspaceID := uid.New(uid.KeySpacePrefix)
 	err := db.Query.InsertPortalConfig(ctx, h.DB.RW(), db.InsertPortalConfigParams{
 		ID:          portalConfigID,
 		WorkspaceID: workspaceID,
 		Slug:        "test-portal",
-		KeyAuthID:   sql.NullString{Valid: true, String: uid.New(uid.KeySpacePrefix)},
+		KeyAuthID:   sql.NullString{Valid: true, String: keyspaceID},
 		Enabled:     true,
 		CreatedAt:   now,
 	})
@@ -42,14 +57,14 @@ func TestExchangeSessionSuccess(t *testing.T) {
 
 	t.Run("valid exchange", func(t *testing.T) {
 		tokenID := uid.New(uid.PortalSessionTokenPrefix)
-		perms, _ := json.Marshal([]string{"api.*.read_key", "api.*.read_analytics"})
+		permissions := marshalPortalGrant(t, []string{keyspaceID}, []string{"keys:read", "keys:reroll"})
 
 		err := db.Query.InsertPortalSessionToken(ctx, h.DB.RW(), db.InsertPortalSessionTokenParams{
 			ID:             tokenID,
 			WorkspaceID:    workspaceID,
 			PortalConfigID: portalConfigID,
 			ExternalID:     "user_valid",
-			Permissions:    perms,
+			Permissions:    permissions,
 			ExpiresAt:      now + int64(15*time.Minute/time.Millisecond),
 			CreatedAt:      now,
 		})
@@ -82,18 +97,19 @@ func TestExchangeSessionSuccess(t *testing.T) {
 		require.Equal(t, workspaceID, session.WorkspaceID)
 		require.Equal(t, "user_valid", session.ExternalID)
 		require.Equal(t, portalConfigID, session.PortalConfigID)
+		require.JSONEq(t, string(permissions), string(session.Permissions))
 	})
 
 	t.Run("single-use enforcement", func(t *testing.T) {
 		tokenID := uid.New(uid.PortalSessionTokenPrefix)
-		perms, _ := json.Marshal([]string{"api.*.read_key"})
+		permissions := marshalPortalGrant(t, []string{keyspaceID}, []string{"keys:read"})
 
 		err := db.Query.InsertPortalSessionToken(ctx, h.DB.RW(), db.InsertPortalSessionTokenParams{
 			ID:             tokenID,
 			WorkspaceID:    workspaceID,
 			PortalConfigID: portalConfigID,
 			ExternalID:     "user_single_use",
-			Permissions:    perms,
+			Permissions:    permissions,
 			ExpiresAt:      now + int64(15*time.Minute/time.Millisecond),
 			CreatedAt:      now,
 		})

--- a/svc/api/routes/v2_portal_exchange_session/401_test.go
+++ b/svc/api/routes/v2_portal_exchange_session/401_test.go
@@ -3,7 +3,6 @@ package handler_test
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"net/http"
 	"testing"
 	"time"
@@ -51,7 +50,7 @@ func TestExchangeSessionUnauthorized(t *testing.T) {
 
 	t.Run("expired session token", func(t *testing.T) {
 		tokenID := uid.New(uid.PortalSessionTokenPrefix)
-		perms, _ := json.Marshal([]string{"api.*.read_key"})
+		permissions := marshalPortalGrant(t, []string{}, []string{"keys:read"})
 
 		// Insert a token that expired 1 hour ago.
 		err := db.Query.InsertPortalSessionToken(ctx, h.DB.RW(), db.InsertPortalSessionTokenParams{
@@ -59,7 +58,7 @@ func TestExchangeSessionUnauthorized(t *testing.T) {
 			WorkspaceID:    workspaceID,
 			PortalConfigID: portalConfigID,
 			ExternalID:     "user_expired",
-			Permissions:    perms,
+			Permissions:    permissions,
 			ExpiresAt:      now - int64(time.Hour/time.Millisecond),
 			CreatedAt:      now - int64(2*time.Hour/time.Millisecond),
 		})
@@ -73,7 +72,7 @@ func TestExchangeSessionUnauthorized(t *testing.T) {
 
 	t.Run("already exchanged session token", func(t *testing.T) {
 		tokenID := uid.New(uid.PortalSessionTokenPrefix)
-		perms, _ := json.Marshal([]string{"api.*.read_key"})
+		permissions := marshalPortalGrant(t, []string{}, []string{"keys:read"})
 
 		// Insert a valid token that is already exchanged.
 		err := db.Query.InsertPortalSessionToken(ctx, h.DB.RW(), db.InsertPortalSessionTokenParams{
@@ -81,7 +80,7 @@ func TestExchangeSessionUnauthorized(t *testing.T) {
 			WorkspaceID:    workspaceID,
 			PortalConfigID: portalConfigID,
 			ExternalID:     "user_exchanged",
-			Permissions:    perms,
+			Permissions:    permissions,
 			ExpiresAt:      now + int64(15*time.Minute/time.Millisecond),
 			CreatedAt:      now,
 		})

--- a/svc/api/routes/v2_portal_exchange_session/401_test.go
+++ b/svc/api/routes/v2_portal_exchange_session/401_test.go
@@ -45,7 +45,8 @@ func TestExchangeSessionUnauthorized(t *testing.T) {
 		req := handler.Request{SessionId: "nonexistent_session"}
 		res := testutil.CallRoute[handler.Request, openapi.UnauthorizedErrorResponse](h, route, headers, req)
 		require.Equal(t, 401, res.Status)
-		require.NotNil(t, res.Body)
+		require.Equal(t, "Session is invalid, expired, or has already been used.", res.Body.Error.Detail)
+		require.NotContains(t, res.RawBody, req.SessionId)
 	})
 
 	t.Run("expired session token", func(t *testing.T) {
@@ -67,7 +68,8 @@ func TestExchangeSessionUnauthorized(t *testing.T) {
 		req := handler.Request{SessionId: tokenID}
 		res := testutil.CallRoute[handler.Request, openapi.UnauthorizedErrorResponse](h, route, headers, req)
 		require.Equal(t, 401, res.Status)
-		require.NotNil(t, res.Body)
+		require.Equal(t, "Session is invalid, expired, or has already been used.", res.Body.Error.Detail)
+		require.NotContains(t, res.RawBody, tokenID)
 	})
 
 	t.Run("already exchanged session token", func(t *testing.T) {
@@ -97,7 +99,8 @@ func TestExchangeSessionUnauthorized(t *testing.T) {
 		req := handler.Request{SessionId: tokenID}
 		res := testutil.CallRoute[handler.Request, openapi.UnauthorizedErrorResponse](h, route, headers, req)
 		require.Equal(t, 401, res.Status)
-		require.NotNil(t, res.Body)
+		require.Equal(t, "Session is invalid, expired, or has already been used.", res.Body.Error.Detail)
+		require.NotContains(t, res.RawBody, tokenID)
 	})
 
 	t.Run("empty sessionId", func(t *testing.T) {

--- a/svc/api/routes/v2_portal_get_verifications/200_test.go
+++ b/svc/api/routes/v2_portal_get_verifications/200_test.go
@@ -44,15 +44,18 @@ func sumTotals(points []openapi.V2PortalGetVerificationsDataPoint) int64 {
 }
 
 // TestPortalSessionAnalyticsScopedToOwnKeys verifies a portal session only sees
-// verification events attributed to its own externalId, even when another
-// identity in the same workspace has its own events, and that events for a
-// soft-deleted key still count (scoping is by external_id at write time, not by
-// current key ownership).
+// verification events attributed to its own externalId and configured
+// keyspaces, even when the same identity has keys elsewhere. Events for a
+// soft-deleted key still count because both scope fields are written to the
+// event before deletion.
 func TestPortalSessionAnalyticsScopedToOwnKeys(t *testing.T) {
 	h := testutil.NewHarness(t, testutil.HarnessConfig{ClickHouse: true})
 
 	workspace := h.CreateWorkspace()
 	api := h.CreateApi(seed.CreateApiRequest{
+		WorkspaceID: workspace.ID,
+	})
+	otherApi := h.CreateApi(seed.CreateApiRequest{
 		WorkspaceID: workspace.ID,
 	})
 	h.SetupAnalytics(workspace.ID)
@@ -83,6 +86,11 @@ func TestPortalSessionAnalyticsScopedToOwnKeys(t *testing.T) {
 		Now: sql.NullInt64{Int64: time.Now().UnixMilli(), Valid: true},
 		ID:  keyADeleted.KeyID,
 	}))
+	keyAOtherKeyspace := h.CreateKey(seed.CreateKeyRequest{
+		WorkspaceID: workspace.ID,
+		KeySpaceID:  otherApi.KeyAuthID.String,
+		IdentityID:  ptr.P(identityA.ID),
+	})
 
 	// Identity B owns a different key whose events must never be visible to A.
 	identityB := h.CreateIdentity(seed.CreateIdentityRequest{
@@ -97,13 +105,13 @@ func TestPortalSessionAnalyticsScopedToOwnKeys(t *testing.T) {
 
 	now := time.Now().UnixMilli()
 
-	buffer := func(keyID, externalID, identityID string, n int) {
+	buffer := func(keyID, keyspaceID, externalID, identityID string, n int) {
 		for i := range n {
 			h.KeyVerifications.Buffer(schema.KeyVerification{
 				RequestID:   uid.New(uid.RequestPrefix),
 				Time:        now - int64(i*1000),
 				WorkspaceID: workspace.ID,
-				KeySpaceID:  api.KeyAuthID.String,
+				KeySpaceID:  keyspaceID,
 				KeyID:       keyID,
 				Region:      "us-west-1",
 				Outcome:     "VALID",
@@ -114,9 +122,24 @@ func TestPortalSessionAnalyticsScopedToOwnKeys(t *testing.T) {
 		}
 	}
 
-	buffer(keyA.KeyID, externalA, identityA.ID, 3)            // A live key
-	buffer(keyADeleted.KeyID, externalA, identityA.ID, 2)     // A deleted key
-	buffer(keyB.KeyID, identityB.ExternalID, identityB.ID, 5) // B key (must not leak)
+	buffer(keyA.KeyID, api.KeyAuthID.String, externalA, identityA.ID, 3)                   // A live key
+	buffer(keyADeleted.KeyID, api.KeyAuthID.String, externalA, identityA.ID, 2)            // A deleted key
+	buffer(keyAOtherKeyspace.KeyID, otherApi.KeyAuthID.String, externalA, identityA.ID, 7) // A key outside the session keyspaces
+	buffer(keyB.KeyID, api.KeyAuthID.String, identityB.ExternalID, identityB.ID, 5)        // B key (must not leak)
+
+	// Prove all same-identity events reached the aggregate before testing that the
+	// route excludes the seven events outside the session keyspace.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		var total int64
+		err := h.ClickHouse.Conn().QueryRow(
+			context.Background(),
+			"SELECT SUM(count) FROM default.key_verifications_per_minute_v3 WHERE workspace_id = ? AND external_id = ?",
+			workspace.ID,
+			externalA,
+		).Scan(&total)
+		assert.NoError(c, err)
+		assert.Equal(c, int64(12), total)
+	}, 30*time.Second, time.Second)
 
 	headers := h.CreatePortalSession(workspace.ID, externalA, []string{api.KeyAuthID.String}, []string{"analytics:read"})
 
@@ -126,15 +149,14 @@ func TestPortalSessionAnalyticsScopedToOwnKeys(t *testing.T) {
 		EndTime:   now + int64(time.Minute/time.Millisecond),
 	}
 
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		res := testutil.CallRoute[Request, Response](h, route, headers, req)
-		require.Equal(c, 200, res.Status)
-		require.NotNil(c, res.Body)
+	res := testutil.CallRoute[Request, Response](h, route, headers, req)
+	require.Equal(t, 200, res.Status)
+	require.NotNil(t, res.Body)
 
-		// A's 3 live-key events + 2 deleted-key events = 5, never B's 5.
-		require.Equal(c, int64(5), sumTotals(res.Body.Data),
-			"portal session should see its own keys' events (including deleted keys) but never another identity's")
-	}, 30*time.Second, time.Second)
+	// Only A's events in the session keyspace are visible: 3 live-key events plus
+	// 2 deleted-key events. Neither B's events nor A's other keyspace leak.
+	require.Equal(t, int64(5), sumTotals(res.Body.Data),
+		"portal session analytics must remain within its external identity and configured keyspaces")
 }
 
 // TestPortalSessionAnalyticsKeyIdFilter verifies the optional keyId narrows the
@@ -214,11 +236,9 @@ func TestPortalSessionAnalyticsKeyIdFilter(t *testing.T) {
 	}, 30*time.Second, time.Second)
 }
 
-// TestPortalSessionAnalyticsRequiresReadAnalytics verifies that a portal session
-// whose permissions do not include a read_analytics grant is rejected, even
-// though the endpoint is otherwise scoped to its own identity. The workspace
-// owner gates analytics access via the session permissions.
-func TestPortalSessionAnalyticsRequiresReadAnalytics(t *testing.T) {
+// TestPortalSessionAnalyticsRequiresAnalyticsRead verifies that reading keys
+// does not implicitly grant access to analytics.
+func TestPortalSessionAnalyticsRequiresAnalyticsRead(t *testing.T) {
 	// No ClickHouse needed: the handler rejects on the permission check before it
 	// ever queries analytics.
 	h := testutil.NewHarness(t, testutil.HarnessConfig{})
@@ -227,7 +247,6 @@ func TestPortalSessionAnalyticsRequiresReadAnalytics(t *testing.T) {
 	route := newHandler(h)
 	h.Register(route, h.PortalMiddleware()...)
 
-	// Session granted key access but not analytics.
 	headers := h.CreatePortalSession(workspace.ID, "portal_user_A", []string{"ks_none"}, []string{"keys:read"})
 
 	now := time.Now().UnixMilli()
@@ -237,5 +256,5 @@ func TestPortalSessionAnalyticsRequiresReadAnalytics(t *testing.T) {
 	})
 
 	require.Equal(t, 403, res.Status,
-		"portal session without read_analytics must be forbidden from reading analytics")
+		"portal session without analytics:read must be forbidden from reading analytics")
 }

--- a/svc/api/routes/v2_portal_get_verifications/200_test.go
+++ b/svc/api/routes/v2_portal_get_verifications/200_test.go
@@ -250,11 +250,14 @@ func TestPortalSessionAnalyticsRequiresAnalyticsRead(t *testing.T) {
 	headers := h.CreatePortalSession(workspace.ID, "portal_user_A", []string{"ks_none"}, []string{"keys:read"})
 
 	now := time.Now().UnixMilli()
-	res := testutil.CallRoute[Request, Response](h, route, headers, Request{
+	res := testutil.CallRoute[Request, openapi.ForbiddenErrorResponse](h, route, headers, Request{
 		StartTime: now - int64(time.Hour/time.Millisecond),
 		EndTime:   now + int64(time.Minute/time.Millisecond),
 	})
 
 	require.Equal(t, 403, res.Status,
 		"portal session without analytics:read must be forbidden from reading analytics")
+	require.NotContains(t, res.RawBody, workspace.ID)
+	require.NotContains(t, res.RawBody, "portal_user_A")
+	require.NotContains(t, res.RawBody, "ks_none")
 }

--- a/svc/api/routes/v2_portal_get_verifications/handler.go
+++ b/svc/api/routes/v2_portal_get_verifications/handler.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/unkeyed/unkey/internal/services/caches"
 	keysdb "github.com/unkeyed/unkey/internal/services/keys/db"
+	"github.com/unkeyed/unkey/pkg/auth/portalrbac"
 	"github.com/unkeyed/unkey/pkg/cache"
 	"github.com/unkeyed/unkey/pkg/clickhouse"
 	"github.com/unkeyed/unkey/pkg/codes"
@@ -46,7 +47,7 @@ func (h *Handler) Method() string { return "POST" }
 func (h *Handler) Path() string { return "/v2/portal.getVerifications" }
 
 // Handle returns a verification timeseries scoped to the portal session's
-// external identity.
+// external identity and configured keyspaces.
 func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	principal, err := s.GetPrincipal()
 	if err != nil {
@@ -57,17 +58,14 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	if err != nil {
 		return err
 	}
+	keyspaceIDs, err := portalscope.KeyspaceIDs(s)
+	if err != nil {
+		return err
+	}
 
-	// The workspace owner controls whether a portal session may read analytics by
-	// including a read_analytics grant in the session permissions. Identity scoping
-	// already restricts *what* is returned to the session's own events; this gates
-	// whether analytics is exposed to this end user at all. The query spans all of
-	// the identity's keys across every API, so require the wildcard grant.
-	err = principal.Authorize(rbac.T(rbac.Tuple{
-		ResourceType: rbac.Api,
-		ResourceID:   "*",
-		Action:       rbac.ReadAnalytics,
-	}))
+	// Capability and identity scope are separate: this gates the action while the
+	// ClickHouse query below fixes the visible data to the session external ID.
+	err = principal.Authorize(rbac.S(string(portalrbac.CapAnalyticsRead)))
 	if err != nil {
 		return err
 	}
@@ -113,6 +111,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	points, err := h.ClickHouse.GetVerificationsByExternalID(ctx, clickhouse.VerificationTimeseriesRequest{
 		WorkspaceID: principal.WorkspaceID,
 		ExternalID:  externalID,
+		KeyspaceIDs: keyspaceIDs,
 		KeyID:       ptr.SafeDeref(req.KeyId),
 		StartTime:   req.StartTime,
 		EndTime:     req.EndTime,

--- a/svc/api/routes/v2_portal_get_verifications/handler.go
+++ b/svc/api/routes/v2_portal_get_verifications/handler.go
@@ -65,7 +65,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 	// Capability and identity scope are separate: this gates the action while the
 	// ClickHouse query below fixes the visible data to the session external ID.
-	err = principal.Authorize(rbac.S(string(portalrbac.CapAnalyticsRead)))
+	err = principal.Authorize(rbac.S(portalrbac.CapAnalyticsRead))
 	if err != nil {
 		return err
 	}

--- a/svc/api/routes/v2_portal_list_keys/200_test.go
+++ b/svc/api/routes/v2_portal_list_keys/200_test.go
@@ -141,6 +141,25 @@ func TestPortalSessionScopesToOwnExternalID(t *testing.T) {
 	require.True(t, returnedIDs[setup.key2ID], "key2 should be in results")
 }
 
+func TestPortalSessionListKeysRequiresKeysRead(t *testing.T) {
+	h := testutil.NewHarness(t)
+
+	route := newHandler(h)
+	h.Register(route, h.PortalMiddleware()...)
+
+	setup := setupPortalSessionTest(t, h)
+	headers := h.CreatePortalSession(
+		setup.workspace.ID,
+		setup.identity1ExternalID,
+		[]string{setup.keySpaceID},
+		[]string{"keys:reroll"},
+	)
+
+	res := testutil.CallRoute[Request, Response](h, route, headers, Request{})
+
+	require.Equal(t, 403, res.Status, "keys:reroll must not authorize portal.listKeys")
+}
+
 func TestPortalSessionUnionsConfiguredKeyspaces(t *testing.T) {
 	h := testutil.NewHarness(t)
 

--- a/svc/api/routes/v2_portal_list_keys/200_test.go
+++ b/svc/api/routes/v2_portal_list_keys/200_test.go
@@ -3,6 +3,8 @@ package handler_test
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
+	"net/http"
 	"testing"
 	"time"
 
@@ -155,9 +157,12 @@ func TestPortalSessionListKeysRequiresKeysRead(t *testing.T) {
 		[]string{"keys:reroll"},
 	)
 
-	res := testutil.CallRoute[Request, Response](h, route, headers, Request{})
+	res := testutil.CallRoute[Request, openapi.ForbiddenErrorResponse](h, route, headers, Request{})
 
 	require.Equal(t, 403, res.Status, "keys:reroll must not authorize portal.listKeys")
+	require.NotContains(t, res.RawBody, setup.workspace.ID)
+	require.NotContains(t, res.RawBody, setup.identity1ExternalID)
+	require.NotContains(t, res.RawBody, setup.key1ID)
 }
 
 func TestPortalSessionUnionsConfiguredKeyspaces(t *testing.T) {
@@ -224,4 +229,47 @@ func TestPortalSessionNonExistentIdentityReturnsEmpty(t *testing.T) {
 	require.NotNil(t, res.Body.Data)
 	require.Len(t, res.Body.Data, 0)
 	require.False(t, res.Body.Pagination.HasMore)
+}
+
+// TestPortalSessionIsRejectedAfterCachedSessionExpires guarantees that the
+// authentication cache cannot extend a portal session beyond its expiry.
+func TestPortalSessionIsRejectedAfterCachedSessionExpires(t *testing.T) {
+	h := testutil.NewHarness(t)
+	route := newHandler(h)
+	h.Register(route, h.PortalMiddleware()...)
+
+	setup := setupPortalSessionTest(t, h)
+	sessionID := uid.New(uid.PortalSessionPrefix)
+	permissions, err := json.Marshal(struct {
+		KeyspaceIDs []string `json:"keyspaceIds"`
+		Permissions []string `json:"permissions"`
+	}{
+		KeyspaceIDs: []string{setup.keySpaceID},
+		Permissions: []string{"keys:read"},
+	})
+	require.NoError(t, err)
+
+	expiresAt := h.Clock.Now().Add(time.Minute)
+	require.NoError(t, db.Query.InsertPortalSession(context.Background(), h.DB.RW(), db.InsertPortalSessionParams{
+		ID:             sessionID,
+		WorkspaceID:    setup.workspace.ID,
+		PortalConfigID: uid.New(uid.PortalConfigPrefix),
+		ExternalID:     setup.identity1ExternalID,
+		Permissions:    permissions,
+		ExpiresAt:      expiresAt.UnixMilli(),
+		CreatedAt:      h.Clock.Now().UnixMilli(),
+	}))
+
+	headers := http.Header{
+		"Content-Type": {"application/json"},
+		"Cookie":       {"portal_session=" + sessionID},
+	}
+	warm := testutil.CallRoute[Request, Response](h, route, headers, Request{})
+	require.Equal(t, http.StatusOK, warm.Status)
+
+	h.Clock.Tick(time.Minute)
+	expired := testutil.CallRoute[Request, openapi.UnauthorizedErrorResponse](h, route, headers, Request{})
+	require.Equal(t, http.StatusUnauthorized, expired.Status)
+	require.Equal(t, "The portal session is invalid or has expired.", expired.Body.Error.Detail)
+	require.NotContains(t, expired.RawBody, sessionID)
 }

--- a/svc/api/routes/v2_portal_list_keys/handler.go
+++ b/svc/api/routes/v2_portal_list_keys/handler.go
@@ -6,13 +6,12 @@ import (
 	"net/http"
 	"sort"
 
+	"github.com/unkeyed/unkey/pkg/auth/portalrbac"
 	"github.com/unkeyed/unkey/pkg/codes"
 	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/fault"
 	"github.com/unkeyed/unkey/pkg/ptr"
 	"github.com/unkeyed/unkey/pkg/rbac"
-	"github.com/unkeyed/unkey/pkg/rbac/permissions"
-	"github.com/unkeyed/unkey/pkg/urn"
 	"github.com/unkeyed/unkey/pkg/zen"
 	"github.com/unkeyed/unkey/svc/api/internal/portalscope"
 	"github.com/unkeyed/unkey/svc/api/openapi"
@@ -73,23 +72,13 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	limit := ptr.SafeDeref(req.Limit, 100)
 	cursor := ptr.SafeDeref(req.Cursor, "")
 
-	// A session with no keyspaces (e.g. analytics only) can never see any keys.
-	if len(keyspaceIDs) == 0 {
-		return h.emptyResponse(s)
+	if err := principal.Authorize(rbac.S(string(portalrbac.CapKeysRead))); err != nil {
+		return err
 	}
 
-	// The session may only list keys in keyspaces it was granted keys:read on.
-	// These are the same keyspaces the grant scoped, so this passes iff the
-	// session carries keys:read and fails closed for an analytics-only session.
-	keyReadChecks := make([]rbac.PermissionQuery, 0, len(keyspaceIDs))
-	for _, ks := range keyspaceIDs {
-		keyReadChecks = append(keyReadChecks, rbac.And(
-			rbac.U(urn.New().Workspace(principal.WorkspaceID).Keyspace(ks).Key("*"), permissions.ReadKey{}),
-			rbac.U(urn.New().Workspace(principal.WorkspaceID).Keyspace(ks), permissions.ReadKeyspace{}),
-		))
-	}
-	if err := principal.Authorize(rbac.And(keyReadChecks...)); err != nil {
-		return err
+	// A session with no keyspaces can never see any keys.
+	if len(keyspaceIDs) == 0 {
+		return h.emptyResponse(s)
 	}
 
 	// Scope to the end user's own keys. If the identity does not exist yet, the

--- a/svc/api/routes/v2_portal_list_keys/handler.go
+++ b/svc/api/routes/v2_portal_list_keys/handler.go
@@ -72,7 +72,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	limit := ptr.SafeDeref(req.Limit, 100)
 	cursor := ptr.SafeDeref(req.Cursor, "")
 
-	if err := principal.Authorize(rbac.S(string(portalrbac.CapKeysRead))); err != nil {
+	if err := principal.Authorize(rbac.S(portalrbac.CapKeysRead)); err != nil {
 		return err
 	}
 

--- a/svc/api/routes/v2_portal_reroll_key/200_test.go
+++ b/svc/api/routes/v2_portal_reroll_key/200_test.go
@@ -76,6 +76,67 @@ func TestPortalSessionRerollOwnKey(t *testing.T) {
 	require.Equal(t, identity.ID, newKey.IdentityID.String)
 }
 
+func TestPortalSessionRequiresRerollCapability(t *testing.T) {
+	h := testutil.NewHarness(t)
+
+	route := newHandler(h)
+	h.Register(route, h.PortalMiddleware()...)
+
+	workspace := h.Resources().UserWorkspace
+	api := h.CreateApi(seed.CreateApiRequest{
+		WorkspaceID: workspace.ID,
+	})
+	identity := h.CreateIdentity(seed.CreateIdentityRequest{
+		WorkspaceID: workspace.ID,
+		ExternalID:  "portal_user_A",
+	})
+	key := h.CreateKey(seed.CreateKeyRequest{
+		WorkspaceID: workspace.ID,
+		KeySpaceID:  api.KeyAuthID.String,
+		IdentityID:  ptr.P(identity.ID),
+	})
+
+	headers := h.CreatePortalSession(
+		workspace.ID,
+		identity.ExternalID,
+		[]string{api.KeyAuthID.String},
+		[]string{"keys:create"},
+	)
+	res := testutil.CallRoute[Request, Response](h, route, headers, Request{KeyId: key.KeyID})
+
+	require.Equal(t, 403, res.Status, "keys:create must not authorize portal.rerollKey")
+}
+
+func TestPortalSessionCannotRerollKeyOutsideSessionKeyspaces(t *testing.T) {
+	h := testutil.NewHarness(t)
+
+	route := newHandler(h)
+	h.Register(route, h.PortalMiddleware()...)
+
+	workspace := h.Resources().UserWorkspace
+	keyApi := h.CreateApi(seed.CreateApiRequest{WorkspaceID: workspace.ID})
+	sessionApi := h.CreateApi(seed.CreateApiRequest{WorkspaceID: workspace.ID})
+	identity := h.CreateIdentity(seed.CreateIdentityRequest{
+		WorkspaceID: workspace.ID,
+		ExternalID:  "portal_user_A",
+	})
+	key := h.CreateKey(seed.CreateKeyRequest{
+		WorkspaceID: workspace.ID,
+		KeySpaceID:  keyApi.KeyAuthID.String,
+		IdentityID:  ptr.P(identity.ID),
+	})
+
+	headers := h.CreatePortalSession(
+		workspace.ID,
+		identity.ExternalID,
+		[]string{sessionApi.KeyAuthID.String},
+		[]string{"keys:reroll"},
+	)
+	res := testutil.CallRoute[Request, Response](h, route, headers, Request{KeyId: key.KeyID})
+
+	require.Equal(t, 404, res.Status, "keys outside the session keyspaces must be hidden")
+}
+
 // TestPortalSessionCannotRerollOtherIdentityKey verifies a portal session
 // cannot reroll a key belonging to a different externalId and receives a 404
 // so the key's existence is not leaked.

--- a/svc/api/routes/v2_portal_reroll_key/200_test.go
+++ b/svc/api/routes/v2_portal_reroll_key/200_test.go
@@ -2,13 +2,16 @@ package handler_test
 
 import (
 	"context"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/ptr"
+	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
+	"github.com/unkeyed/unkey/svc/api/openapi"
 	rerollkey "github.com/unkeyed/unkey/svc/api/routes/v2_keys_reroll_key"
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_portal_reroll_key"
 )
@@ -102,9 +105,14 @@ func TestPortalSessionRequiresRerollCapability(t *testing.T) {
 		[]string{api.KeyAuthID.String},
 		[]string{"keys:create"},
 	)
-	res := testutil.CallRoute[Request, Response](h, route, headers, Request{KeyId: key.KeyID})
+	owned := testutil.CallRoute[Request, openapi.ForbiddenErrorResponse](h, route, headers, Request{KeyId: key.KeyID})
+	missingKeyID := uid.New(uid.KeyPrefix)
+	missing := testutil.CallRoute[Request, openapi.ForbiddenErrorResponse](h, route, headers, Request{KeyId: missingKeyID})
 
-	require.Equal(t, 403, res.Status, "keys:create must not authorize portal.rerollKey")
+	require.Equal(t, http.StatusForbidden, owned.Status, "keys:create must not authorize portal.rerollKey")
+	require.Equal(t, owned.Body.Error, missing.Body.Error, "authorization must run before key lookup")
+	require.NotContains(t, owned.RawBody, key.KeyID)
+	require.NotContains(t, missing.RawBody, missingKeyID)
 }
 
 func TestPortalSessionCannotRerollKeyOutsideSessionKeyspaces(t *testing.T) {
@@ -162,16 +170,18 @@ func TestPortalSessionCannotRerollOtherIdentityKey(t *testing.T) {
 		IdentityID:  ptr.P(otherIdentity.ID),
 	})
 
-	// Session belongs to user A but holds create_key permission on the API.
+	// Session belongs to user A and can reroll its own keys.
 	headers := h.CreatePortalSession(workspace.ID, "portal_user_A", []string{api.KeyAuthID.String}, []string{"keys:reroll"})
 
 	req := Request{
 		KeyId: otherKey.KeyID,
 	}
 
-	res := testutil.CallRoute[Request, Response](h, route, headers, req)
+	res := testutil.CallRoute[Request, openapi.NotFoundErrorResponse](h, route, headers, req)
 
 	require.Equal(t, 404, res.Status, "rerolling another identity's key should return 404")
+	require.Equal(t, "The specified key was not found.", res.Body.Error.Detail)
+	require.NotContains(t, res.RawBody, otherKey.KeyID)
 }
 
 // TestPortalSessionCannotRerollKeyWithoutIdentity verifies a portal session

--- a/svc/api/routes/v2_portal_reroll_key/handler.go
+++ b/svc/api/routes/v2_portal_reroll_key/handler.go
@@ -80,7 +80,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			fault.Public("The specified key was not found."),
 		)
 	}
-	if err := principal.Authorize(rbac.S(string(portalrbac.CapKeysReroll))); err != nil {
+	if err := principal.Authorize(rbac.S(portalrbac.CapKeysReroll)); err != nil {
 		return err
 	}
 

--- a/svc/api/routes/v2_portal_reroll_key/handler.go
+++ b/svc/api/routes/v2_portal_reroll_key/handler.go
@@ -2,9 +2,12 @@ package handler
 
 import (
 	"context"
+	"slices"
 
+	"github.com/unkeyed/unkey/pkg/auth/portalrbac"
 	"github.com/unkeyed/unkey/pkg/codes"
 	"github.com/unkeyed/unkey/pkg/fault"
+	"github.com/unkeyed/unkey/pkg/rbac"
 	"github.com/unkeyed/unkey/pkg/zen"
 	"github.com/unkeyed/unkey/svc/api/internal/portalscope"
 	rerollkey "github.com/unkeyed/unkey/svc/api/routes/v2_keys_reroll_key"
@@ -49,6 +52,10 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	if err != nil {
 		return err
 	}
+	keyspaceIDs, err := portalscope.KeyspaceIDs(s)
+	if err != nil {
+		return err
+	}
 
 	req, err := zen.BindBody[rerollkey.Request](s)
 	if err != nil {
@@ -64,6 +71,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	// own external identity within its own workspace. Fail closed with a 404 so
 	// the caller cannot probe for keys it does not own.
 	if key.WorkspaceID != principal.WorkspaceID ||
+		!slices.Contains(keyspaceIDs, key.KeyAuthID) ||
 		!key.IdentityExternalID.Valid ||
 		key.IdentityExternalID.String != externalID {
 		return fault.New("key not found",
@@ -71,6 +79,9 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			fault.Internal("key does not belong to portal session identity"),
 			fault.Public("The specified key was not found."),
 		)
+	}
+	if err := principal.Authorize(rbac.S(string(portalrbac.CapKeysReroll))); err != nil {
+		return err
 	}
 
 	return h.reroll.RerollKey(ctx, s, req, key)

--- a/svc/api/routes/v2_portal_reroll_key/handler.go
+++ b/svc/api/routes/v2_portal_reroll_key/handler.go
@@ -47,6 +47,9 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	if err != nil {
 		return err
 	}
+	if err := principal.Authorize(rbac.S(portalrbac.CapKeysReroll)); err != nil {
+		return err
+	}
 
 	externalID, err := portalscope.ExternalID(s)
 	if err != nil {
@@ -80,9 +83,5 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			fault.Public("The specified key was not found."),
 		)
 	}
-	if err := principal.Authorize(rbac.S(portalrbac.CapKeysReroll)); err != nil {
-		return err
-	}
-
 	return h.reroll.RerollKey(ctx, s, req, key)
 }

--- a/svc/api/run.go
+++ b/svc/api/run.go
@@ -321,6 +321,7 @@ func Run(ctx context.Context, cfg Config) error {
 	portalSvc := portal.New(portal.Config{
 		DB:           database,
 		SessionCache: caches.PortalSession,
+		Clock:        cfg.Clock,
 	})
 
 	// JWT resolvers hit this lookup on every authenticated request, so the

--- a/web/apps/portal/src/components/portal-header.tsx
+++ b/web/apps/portal/src/components/portal-header.tsx
@@ -1,8 +1,9 @@
 import { Link, useLocation } from "@tanstack/react-router";
+import type { PortalCapability } from "~/lib/capabilities";
 import { deriveVisibleTabs } from "~/lib/permissions";
 
 type PortalHeaderProps = {
-  permissions: string[];
+  permissions: ReadonlyArray<PortalCapability>;
   logoUrl?: string;
 };
 

--- a/web/apps/portal/src/lib/capabilities.ts
+++ b/web/apps/portal/src/lib/capabilities.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+
+/** Capabilities accepted in persisted portal session grants. */
+export const PORTAL_CAPABILITIES = [
+  "keys:read",
+  "keys:create",
+  "keys:reroll",
+  "analytics:read",
+] as const;
+
+const portalCapabilitySchema = z.enum(PORTAL_CAPABILITIES);
+
+/** One product action granted to a portal session. */
+export type PortalCapability = z.infer<typeof portalCapabilitySchema>;
+
+/** Validates the complete authorization grant stored on a portal session. */
+export const portalSessionGrantSchema = z.object({
+  keyspaceIds: z.array(z.string().min(1)),
+  permissions: z.array(portalCapabilitySchema).min(1),
+});

--- a/web/apps/portal/src/lib/permissions.test.ts
+++ b/web/apps/portal/src/lib/permissions.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from "vitest";
+import { portalSessionGrantSchema } from "./capabilities";
 import { deriveVisibleTabs } from "./permissions";
 
 describe("deriveVisibleTabs", () => {
-  it("shows Keys and Docs tabs for key read permission", () => {
-    const tabs = deriveVisibleTabs(["api.*.read_key"]);
+  it("shows Keys and Docs tabs for keys:read", () => {
+    const tabs = deriveVisibleTabs(["keys:read"]);
     const ids = tabs.map((t) => t.id);
 
     expect(ids).toContain("keys");
@@ -11,8 +12,8 @@ describe("deriveVisibleTabs", () => {
     expect(ids).not.toContain("analytics");
   });
 
-  it("shows Analytics and Docs tabs for analytics permission", () => {
-    const tabs = deriveVisibleTabs(["api.*.read_analytics"]);
+  it("shows Analytics and Docs tabs for analytics:read", () => {
+    const tabs = deriveVisibleTabs(["analytics:read"]);
     const ids = tabs.map((t) => t.id);
 
     expect(ids).toContain("analytics");
@@ -20,17 +21,8 @@ describe("deriveVisibleTabs", () => {
     expect(ids).not.toContain("keys");
   });
 
-  it("shows Keys, Analytics, and Docs tabs for all permissions", () => {
-    const tabs = deriveVisibleTabs(["api.*.read_key", "api.*.create_key", "api.*.read_analytics"]);
-    const ids = tabs.map((t) => t.id);
-
-    expect(ids).toContain("keys");
-    expect(ids).toContain("analytics");
-    expect(ids).toContain("docs");
-  });
-
-  it("shows Keys and Docs tabs for specific resource ID", () => {
-    const tabs = deriveVisibleTabs(["api.api_123.read_key"]);
+  it("shows Keys and Docs tabs for non-read key capabilities", () => {
+    const tabs = deriveVisibleTabs(["keys:create", "keys:reroll"]);
     const ids = tabs.map((t) => t.id);
 
     expect(ids).toContain("keys");
@@ -38,24 +30,30 @@ describe("deriveVisibleTabs", () => {
     expect(ids).not.toContain("analytics");
   });
 
-  it("shows only Docs tab for non-matching action", () => {
-    const tabs = deriveVisibleTabs(["ratelimit.*.limit"]);
-    const ids = tabs.map((t) => t.id);
-
-    expect(ids).toEqual(["docs"]);
-  });
-
-  it("shows only Docs tab for malformed permission with fewer than 3 segments", () => {
-    const tabs = deriveVisibleTabs(["keys:read"]);
-    const ids = tabs.map((t) => t.id);
-
-    // Present in array (length > 0) so Docs is visible, but no action segment matches
-    expect(ids).toEqual(["docs"]);
-  });
-
   it("returns no tabs for empty permissions array", () => {
     const tabs = deriveVisibleTabs([]);
 
     expect(tabs).toHaveLength(0);
+  });
+});
+
+describe("portalSessionGrantSchema", () => {
+  it("accepts the persisted portal grant", () => {
+    expect(
+      portalSessionGrantSchema.safeParse({
+        keyspaceIds: ["ks_123"],
+        permissions: ["keys:read", "analytics:read"],
+      }).success,
+    ).toBe(true);
+  });
+
+  it("rejects malformed and unknown grants", () => {
+    expect(portalSessionGrantSchema.safeParse(["keys:read"]).success).toBe(false);
+    expect(
+      portalSessionGrantSchema.safeParse({
+        keyspaceIds: ["ks_123"],
+        permissions: ["unknown:capability"],
+      }).success,
+    ).toBe(false);
   });
 });

--- a/web/apps/portal/src/lib/permissions.ts
+++ b/web/apps/portal/src/lib/permissions.ts
@@ -1,3 +1,5 @@
+import type { PortalCapability } from "./capabilities";
+
 /**
  * Portal tab identifiers. Each tab maps to a route in the portal app.
  */
@@ -15,37 +17,20 @@ const TAB_CONFIGS: ReadonlyArray<TabConfig> = [
   { id: "docs", label: "Documentation", href: "/docs" },
 ] as const;
 
-/**
- * RBAC actions that grant visibility to the Keys tab.
- */
-const KEY_ACTIONS = new Set(["read_key", "create_key", "update_key", "delete_key"]);
+const KEY_CAPABILITIES: ReadonlySet<PortalCapability> = new Set([
+  "keys:read",
+  "keys:create",
+  "keys:reroll",
+]);
 
 /**
- * RBAC actions that grant visibility to the Analytics tab.
+ * Derive visible portal tabs from a session's capabilities.
  */
-const ANALYTICS_ACTIONS = new Set(["read_analytics"]);
-
-/**
- * Derive visible portal tabs from a session's RBAC tuple permissions.
- *
- * Each permission is expected in the format `{resourceType}.{resourceId}.{action}`.
- * The action segment (third dot-separated segment) determines tab visibility:
- * - Keys tab: action ∈ {read_key, create_key, update_key, delete_key}
- * - Analytics tab: action = read_analytics
- * - Docs tab: visible when any permission is present (regardless of action)
- *
- * Permissions with fewer than 3 segments are silently ignored (defensive fallback).
- */
-export function deriveVisibleTabs(permissions: ReadonlyArray<string>): ReadonlyArray<TabConfig> {
-  const actions = permissions
-    .map((p) => {
-      const parts = p.split(".");
-      return parts.length === 3 ? parts[2] : null;
-    })
-    .filter((a): a is string => a !== null);
-
-  const hasKeys = actions.some((a) => KEY_ACTIONS.has(a));
-  const hasAnalytics = actions.some((a) => ANALYTICS_ACTIONS.has(a));
+export function deriveVisibleTabs(
+  permissions: ReadonlyArray<PortalCapability>,
+): ReadonlyArray<TabConfig> {
+  const hasKeys = permissions.some((permission) => KEY_CAPABILITIES.has(permission));
+  const hasAnalytics = permissions.includes("analytics:read");
   const hasDocs = permissions.length > 0;
 
   return TAB_CONFIGS.filter((tab) => {
@@ -63,7 +48,7 @@ export function deriveVisibleTabs(permissions: ReadonlyArray<string>): ReadonlyA
 /**
  * Get the first visible tab's href for redirect after session exchange.
  */
-export function getDefaultTabHref(permissions: ReadonlyArray<string>): string | null {
+export function getDefaultTabHref(permissions: ReadonlyArray<PortalCapability>): string | null {
   const tabs = deriveVisibleTabs(permissions);
   return tabs.length > 0 ? tabs[0].href : null;
 }

--- a/web/apps/portal/src/lib/session.ts
+++ b/web/apps/portal/src/lib/session.ts
@@ -1,6 +1,7 @@
 import { createServerFn } from "@tanstack/react-start";
 import { deleteCookie, getCookie, setCookie } from "@tanstack/react-start/server";
 import { z } from "zod";
+import { type PortalCapability, portalSessionGrantSchema } from "./capabilities";
 import { env } from "./env";
 import type { PortalConfig } from "./portal-config";
 
@@ -11,7 +12,7 @@ export type SessionData = {
   id: string;
   portalConfigId: string;
   externalId: string;
-  permissions: string[];
+  permissions: PortalCapability[];
   preview: boolean;
   expiresAt: number;
 };
@@ -122,6 +123,14 @@ export const getSessionWithConfig = createServerFn({ method: "GET" }).handler(
     if (!session) {
       return null;
     }
+    const grant = portalSessionGrantSchema.safeParse(session.permissions);
+    if (!grant.success) {
+      console.error("Invalid portal session grant", {
+        portalConfigId: session.portalConfigId,
+        issues: grant.error.issues,
+      });
+      return null;
+    }
 
     let config: PortalConfig | null = null;
     try {
@@ -133,7 +142,13 @@ export const getSessionWithConfig = createServerFn({ method: "GET" }).handler(
       });
     }
 
-    return { session, config };
+    return {
+      session: {
+        ...session,
+        permissions: grant.data.permissions,
+      },
+      config,
+    };
   },
 );
 

--- a/web/internal/db/src/schema/portal_session_tokens.ts
+++ b/web/internal/db/src/schema/portal_session_tokens.ts
@@ -1,6 +1,7 @@
 import { relations } from "drizzle-orm";
 import { bigint, boolean, index, json, mysqlTable, varchar } from "drizzle-orm/mysql-core";
 import { portalConfigurations } from "./portal_configurations";
+import type { PortalSessionGrant } from "./portal_sessions";
 import { workspaces } from "./workspaces";
 
 export const portalSessionTokens = mysqlTable(
@@ -11,7 +12,7 @@ export const portalSessionTokens = mysqlTable(
     workspaceId: varchar("workspace_id", { length: 256 }).notNull(),
     portalConfigId: varchar("portal_config_id", { length: 64 }).notNull(),
     externalId: varchar("external_id", { length: 256 }).notNull(),
-    permissions: json("permissions").$type<string[]>().notNull(),
+    permissions: json("permissions").$type<PortalSessionGrant>().notNull(),
     preview: boolean("preview").notNull().default(false),
     exchangedAt: bigint("exchanged_at", { mode: "number" }),
     expiresAt: bigint("expires_at", { mode: "number" }).notNull(),

--- a/web/internal/db/src/schema/portal_sessions.ts
+++ b/web/internal/db/src/schema/portal_sessions.ts
@@ -3,6 +3,12 @@ import { bigint, boolean, index, json, mysqlTable, varchar } from "drizzle-orm/m
 import { portalConfigurations } from "./portal_configurations";
 import { workspaces } from "./workspaces";
 
+/** The capability and keyspace scope persisted in the permissions JSON column. */
+export type PortalSessionGrant = {
+  keyspaceIds: string[];
+  permissions: string[];
+};
+
 export const portalSessions = mysqlTable(
   "portal_sessions",
   {
@@ -11,7 +17,7 @@ export const portalSessions = mysqlTable(
     workspaceId: varchar("workspace_id", { length: 256 }).notNull(),
     portalConfigId: varchar("portal_config_id", { length: 64 }).notNull(),
     externalId: varchar("external_id", { length: 256 }).notNull(),
-    permissions: json("permissions").$type<string[]>().notNull(),
+    permissions: json("permissions").$type<PortalSessionGrant>().notNull(),
     preview: boolean("preview").notNull().default(false),
     expiresAt: bigint("expires_at", { mode: "number" }).notNull(),
     createdAt: bigint("created_at", { mode: "number" }).notNull(),


### PR DESCRIPTION
## Summary

- authorize portal sessions with exact product capabilities instead of expanding them into resource URNs
- enforce workspace, keyspace, and external identity scope explicitly in portal handlers, including analytics and reroll
- validate persisted portal grants at the web boundary and align OpenAPI, UI tab visibility, fixtures, and portal documentation

## Verification

- `mise run generate`
- `mise run build`
- `mise exec -- rask ./internal/services/portal ./pkg/auth/portalrbac ./pkg/auth/portal_session ./svc/api/routes/v2_portal_create_session ./svc/api/routes/v2_portal_exchange_session ./svc/api/routes/v2_portal_list_keys ./svc/api/routes/v2_portal_reroll_key ./svc/api/routes/v2_portal_get_verifications ./svc/api/routes/v2_keys_reroll_key`
- `mise exec -- go test -run '^TestGetVerificationsByExternalID$' ./pkg/clickhouse`
- `mise exec -- pnpm --dir=web --filter @unkey/portal test`
- `mise exec -- pnpm --dir=web --filter @unkey/portal typecheck`