### PR TITLE
fix(dashboard): give option to override vercel url

### DIFF
--- a/web/apps/dashboard/lib/env.ts
+++ b/web/apps/dashboard/lib/env.ts
@@ -10,6 +10,11 @@ export const env = () =>
       VERCEL_URL: z.string().optional(), // Always *.vercel.app — not the custom domain
       VERCEL_BRANCH_URL: z.string().optional(), // Only set in preview deployments
       VERCEL_PROJECT_PRODUCTION_URL: z.string().optional(), // Custom production domain (e.g. app.unkey.com)
+      // Overrides getBaseUrl() entirely. Vercel has no env var for a custom
+      // domain assigned to a preview branch, so branch-scoped deployments with
+      // their own domain (e.g. app.unkey-canary.com on `canary`) set this to
+      // keep redirects on the custom host. No trailing slash.
+      DASHBOARD_BASE_URL: z.url().optional(),
 
       UNKEY_WORKSPACE_ID: z.string(),
       UNKEY_API_ID: z.string(),

--- a/web/apps/dashboard/lib/utils.ts
+++ b/web/apps/dashboard/lib/utils.ts
@@ -177,6 +177,15 @@ export function getBaseUrl() {
     return "";
   }
 
+  // Vercel never exposes a custom domain assigned to a preview branch through
+  // env vars, so deployments like the canary (app.unkey-canary.com on the
+  // `canary` branch) need an explicit, branch-scoped override. Without it,
+  // auth and billing redirects fall through to VERCEL_BRANCH_URL and strand
+  // users on the *.vercel.app host.
+  if (process.env.DASHBOARD_BASE_URL) {
+    return process.env.DASHBOARD_BASE_URL;
+  }
+
   // VERCEL_URL is always the auto-generated *.vercel.app deployment URL —
   // never the custom domain, even in production. The production custom
   // domain lives in VERCEL_PROJECT_PRODUCTION_URL.


### PR DESCRIPTION
**Problem:**

app.unkey-canary.com is a custom domain on the `canary` branch preview deployment, but opening it and signing in strands you on dashboard-git-canary-unkey.vercel.app. `getBaseUrl()` resolves the server-side base URL from Vercel env vars, and Vercel never exposes a custom domain assigned to a preview branch: previews only get `VERCEL_BRANCH_URL` / `VERCEL_URL`, which are always *.vercel.app hosts (`VERCEL_PROJECT_PRODUCTION_URL` exists only in production). The WorkOS sign-in redirect URI is built from `getBaseUrl()`, so the first auth hop moves the session to the raw branch URL and the custom domain is lost. Stripe checkout/portal return URLs and share links have the same problem.

**Solution:**

Add an optional `DASHBOARD_BASE_URL` env var that `getBaseUrl()` returns before any Vercel-injected URL. It gets set branch-scoped in Vercel (`DASHBOARD_BASE_URL=https://app.unkey-canary.com` for Preview + `canary` only) so redirects stay on the custom host. Environments without it behave exactly as before.

**Impact:**

No behavior change until the env var is set. Canary rollout needs two manual steps: the branch-scoped var in Vercel, and `https://app.unkey-canary.com/auth/sso-callback` added to the WorkOS redirect URI allowlist. Without the allowlist entry, canary login fails once the var is live.

**Testing:**

```bash
pnpm --dir=web/apps/dashboard typecheck  # passes
```

Not verified end-to-end yet; that requires the Vercel env var and the WorkOS allowlist entry.
