### PR TITLE
perf(dev): cache Go artifacts in Docker builds

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -8,10 +8,13 @@ WORKDIR /src
 ENV CGO_ENABLED=0
 
 COPY go.mod go.sum ./
-RUN go mod download
+RUN --mount=type=cache,id=unkey-go-mod,target=/go/pkg/mod \
+    go mod download
 COPY . .
 
-RUN go build -o /out/unkey ${PACKAGE}
+RUN --mount=type=cache,id=unkey-go-build,target=/root/.cache/go-build \
+    --mount=type=cache,id=unkey-go-mod,target=/go/pkg/mod \
+    go build -o /out/unkey ${PACKAGE}
 
 FROM gcr.io/distroless/static-debian12@sha256:9c346e4be81b5ca7ff31a0d89eaeade58b0f95cfd3baed1f36083ddb47ca3160
 


### PR DESCRIPTION
## Summary

- persist downloaded Go modules across development image builds
- persist Go compiler artifacts across all Tilt service builds
- keep the existing containerized build workflow

## Why

Every source change invalidates the repository copy layer. Without BuildKit cache mounts, each service then recompiles its dependency graph from scratch.

In a local API rebuild benchmark, a warm cached Docker build completed in 5.6 seconds versus 88.4 seconds without the caches.

## Testing

- `docker build --progress=plain -f dev/Dockerfile --build-arg PACKAGE=./build/api -t unkey/tilt-cache-verification:dev .`
- verified cold-cache image build completes successfully
- verified module and compiler caches are reused by subsequent builds