### PR TITLE
fix(ci): configure service monorepo releases

### DIFF
--- a/.depot/workflows/service-release.yaml
+++ b/.depot/workflows/service-release.yaml
@@ -80,8 +80,7 @@ jobs:
         with:
           distribution: goreleaser-pro
           version: "v2.15.4"
-          args: release --clean --config .goreleaser.service.yaml
+          args: release --clean --config build/${{ steps.tag.outputs.service }}/.goreleaser.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
-          SERVICE: ${{ steps.tag.outputs.service }}

--- a/.goreleaser.service.yaml
+++ b/.goreleaser.service.yaml
@@ -1,17 +1,12 @@
 version: 2
 
-project_name: "{{ .Env.SERVICE }}"
-
-monorepo:
-  tag_prefix: "{{ .Env.SERVICE }}/"
-
 before:
   hooks:
     - go mod tidy
 
 builds:
   - id: service
-    main: "./build/{{ .Env.SERVICE }}"
+    main: "./build/{{ .ProjectName }}"
     binary: unkey
     env:
       - CGO_ENABLED=0
@@ -31,7 +26,7 @@ dockers_v2:
       - service
     dockerfile: Dockerfile.release
     images:
-      - "ghcr.io/unkeyed/{{ .Env.SERVICE }}"
+      - "ghcr.io/unkeyed/{{ .ProjectName }}"
     tags:
       - "{{ .Version }}"
     labels:
@@ -48,7 +43,7 @@ checksum:
 
 release:
   prerelease: auto
-  name_template: "{{ .Env.SERVICE }} {{ .Version }}"
+  name_template: "{{ .ProjectName }} {{ .Version }}"
 
 changelog:
   use: github

--- a/build/api/.goreleaser.yaml
+++ b/build/api/.goreleaser.yaml
@@ -1,0 +1,10 @@
+version: 2
+
+includes:
+  - from_file:
+      path: .goreleaser.service.yaml
+
+project_name: api
+
+monorepo:
+  tag_prefix: api/

--- a/build/control-api/.goreleaser.yaml
+++ b/build/control-api/.goreleaser.yaml
@@ -1,0 +1,10 @@
+version: 2
+
+includes:
+  - from_file:
+      path: .goreleaser.service.yaml
+
+project_name: control-api
+
+monorepo:
+  tag_prefix: control-api/

--- a/build/control-worker/.goreleaser.yaml
+++ b/build/control-worker/.goreleaser.yaml
@@ -1,0 +1,10 @@
+version: 2
+
+includes:
+  - from_file:
+      path: .goreleaser.service.yaml
+
+project_name: control-worker
+
+monorepo:
+  tag_prefix: control-worker/

--- a/build/frontline/.goreleaser.yaml
+++ b/build/frontline/.goreleaser.yaml
@@ -1,0 +1,10 @@
+version: 2
+
+includes:
+  - from_file:
+      path: .goreleaser.service.yaml
+
+project_name: frontline
+
+monorepo:
+  tag_prefix: frontline/

--- a/build/heimdall/.goreleaser.yaml
+++ b/build/heimdall/.goreleaser.yaml
@@ -1,0 +1,10 @@
+version: 2
+
+includes:
+  - from_file:
+      path: .goreleaser.service.yaml
+
+project_name: heimdall
+
+monorepo:
+  tag_prefix: heimdall/

--- a/build/krane/.goreleaser.yaml
+++ b/build/krane/.goreleaser.yaml
@@ -1,0 +1,10 @@
+version: 2
+
+includes:
+  - from_file:
+      path: .goreleaser.service.yaml
+
+project_name: krane
+
+monorepo:
+  tag_prefix: krane/

--- a/build/vault/.goreleaser.yaml
+++ b/build/vault/.goreleaser.yaml
@@ -1,0 +1,10 @@
+version: 2
+
+includes:
+  - from_file:
+      path: .goreleaser.service.yaml
+
+project_name: vault
+
+monorepo:
+  tag_prefix: vault/


### PR DESCRIPTION
## Summary
- add a small GoReleaser entrypoint for each released service with a concrete monorepo tag prefix
- inherit shared build, Docker, archive, and release settings from `.goreleaser.service.yaml`
- select the service config from the release tag and use `project_name` as the shared service identity

## Root cause
We didn't configure it correctly: https://goreleaser.com/customization/monorepo/