### PR TITLE
feat: more dockerbuild things for tilt

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 .git
 .gitignore
+.jj
 
 .cache
 .turbo
@@ -17,6 +18,9 @@
 
 bin
 dist
+dev/bin
+# stray local `go build -o unkey` artifacts
+unkey
 
 bazel-*
 bazel-bin

--- a/dev/Dockerfile.binary
+++ b/dev/Dockerfile.binary
@@ -1,0 +1,19 @@
+# Packages a host-built binary. Tilt compiles Go on the host (fast,
+# incremental, shared build cache) and only uses Docker to wrap the result.
+# The build context must contain a single static linux binary named "unkey".
+#
+# busybox instead of distroless because Tilt's live_update needs sh, date,
+# and tar inside the container to sync the rebuilt binary and poke the
+# restart_process wrapper. Dev-only; release images stay distroless.
+#
+# busybox ships no CA bundle, so pull the same trust store the release image
+# uses out of distroless. Without it, CGO_ENABLED=0 binaries fail outbound
+# public TLS (Stripe, GitHub, ACME) with x509 unknown-authority errors.
+FROM gcr.io/distroless/static-debian13:nonroot@sha256:d29e660cc75a5b6b1334e03c5c81ccf9bc0884a002c6000dbf0fb96034814478 AS certs
+
+FROM busybox:1.36@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662
+
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY unkey /unkey
+LABEL org.opencontainers.image.source=https://github.com/unkeyed/unkey
+ENTRYPOINT ["/unkey"]

--- a/dev/Tiltfile
+++ b/dev/Tiltfile
@@ -1,6 +1,7 @@
 load('ext://namespace', 'namespace_create')
 load('ext://secret', 'secret_create_generic')
 load('ext://helm_remote', 'helm_remote')
+load('ext://restart_process', 'docker_build_with_restart')
 
 config.define_string('topolvm_backing_size')
 cfg = config.parse()
@@ -312,36 +313,101 @@ k8s_resource('restate-deploy-billing-push', resource_deps=['restate', 'ctrl-work
 k8s_resource('restate-idle-preview-deployments', resource_deps=['restate', 'ctrl-worker'], labels=['unkey'])
 
 
-# Service images use Tilt's native Docker builder and the shared dev Dockerfile.
+# Service binaries are compiled on the host so rebuilds hit the local Go
+# build cache (incremental, shared across all services). The image is only
+# built once; after that, live_update syncs the fresh binary straight into
+# the running container and the restart_process wrapper re-execs it — no
+# image build, no registry push, no pod rollout. Building inside Docker
+# (dev/Dockerfile) recompiles the whole module from scratch on every change,
+# seven times in parallel — that Dockerfile stays around for the dashboard
+# docker-compose setup, but Tilt deliberately avoids it.
+#
+# Each service watches only the repo-local packages it actually imports, so
+# editing one service's code re-fires just that compile, not all seven. Edits
+# to a widely-shared package still fan out to every service that imports it,
+# which is correct. GOARCH follows the host because the minikube node runs the
+# same architecture as the machine hosting it.
+
+# Broad fallback: watch all Go sources if the per-service import graph can't be
+# computed (e.g. the service doesn't currently compile).
+GO_SERVICE_DEPS = ['../build', '../svc', '../internal', '../pkg', '../gen', '../go.mod', '../go.sum']
+
+# Scoped deps are absolute repo paths outside dev/, so the test-file ignore is
+# anchored at the repo root (an ignore glob relative to dev/ wouldn't match
+# them). Editing a _test.go then never recompiles or restarts a service.
+REPO_ROOT = os.path.abspath('..')
+GO_TEST_IGNORE = [REPO_ROOT + '/**/*_test.go']
+
+def go_local_deps(name):
+    # Repo-local package dirs this service imports, resolved once at tilt up via
+    # `go list -deps`. We select packages in the main module (.Module.Main) so
+    # the filter is independent of where the repo is checked out; matching on
+    # the filesystem path would only work when the clone happens to live under
+    # a matching directory. Adding a brand-new import needs a Tiltfile reload
+    # before the new edge is watched. `|| true` keeps a broken build from
+    # crashing the Tiltfile; we then fall back to the broad list so a service
+    # never silently stops rebuilding.
+    out = str(local(
+        'cd .. && go list -deps -f "{{if .Module}}{{if .Module.Main}}{{.Dir}}{{end}}{{end}}" ./build/%s 2>/dev/null || true' % name,
+        quiet=True, echo_off=True,
+    )).strip()
+    dirs = [d for d in out.split('\n') if d]
+    if not dirs:
+        return GO_SERVICE_DEPS
+    return dirs + ['../go.mod', '../go.sum']
+
+def go_service_image(ref, name):
+    # The context dir must exist when the Tiltfile is evaluated, before the
+    # compile resource has produced a binary (fresh clone case).
+    local('mkdir -p bin/' + name, quiet=True, echo_off=True)
+    compile_name = name + '-compile'
+    local_resource(
+        compile_name,
+        'cd .. && ' +
+        'CGO_ENABLED=0 GOOS=linux GOARCH=$(go env GOARCH) ' +
+        'go build -o dev/bin/%s/unkey ./build/%s' % (name, name),
+        deps=go_local_deps(name),
+        ignore=GO_TEST_IGNORE,
+        labels=['build'],
+        allow_parallel=True,
+    )
+    docker_build_with_restart(
+        ref=ref,
+        context='bin/' + name,
+        dockerfile='Dockerfile.binary',
+        entrypoint=['/unkey'],
+        live_update=[sync('bin/%s/unkey' % name, '/unkey')],
+    )
+    return compile_name
 
 # ─── Vault ─────────────────────────────────────────────────────────────────
-docker_build('unkey/vault:dev', '..', dockerfile='Dockerfile', build_args={'PACKAGE': './build/vault'})
+go_service_image('unkey/vault:dev', 'vault')
 k8s_yaml('k8s/manifests/vault.yaml')
 k8s_resource(
   'vault',
   port_forwards='8060:8060',
-  resource_deps=['s3'],
+  resource_deps=['s3', 'vault-compile'],
   labels=['unkey'],
   auto_init=True,
   trigger_mode=TRIGGER_MODE_AUTO
 )
 
 # ─── API ───────────────────────────────────────────────────────────────────
-docker_build('unkey/api:dev', '..', dockerfile='Dockerfile', build_args={'PACKAGE': './build/api'})
+go_service_image('unkey/api:dev', 'api')
 k8s_yaml('k8s/manifests/api.yaml')
 k8s_resource(
   'api',
   port_forwards='7070:7070',
-  resource_deps=['mysql', 'clickhouse', 'redis'],
+  resource_deps=['mysql', 'clickhouse', 'redis', 'api-compile'],
   labels=['unkey'],
   auto_init=True,
   trigger_mode=TRIGGER_MODE_AUTO
 )
 
 # ─── Ctrl API ──────────────────────────────────────────────────────────────
-docker_build('unkey/control-api:dev', '..', dockerfile='Dockerfile', build_args={'PACKAGE': './build/control-api'})
+go_service_image('unkey/control-api:dev', 'control-api')
 k8s_yaml('k8s/manifests/ctrl-api.yaml')
-ctrl_api_deps = ['mysql', 'clickhouse', 'restate', 'vault', 'github-credentials', 'domain-connect-credentials', 'stripe-credentials']
+ctrl_api_deps = ['mysql', 'clickhouse', 'restate', 'vault', 'github-credentials', 'domain-connect-credentials', 'stripe-credentials', 'control-api-compile']
 if has_depot_credentials:
     ctrl_api_deps.append('depot-credentials')
 k8s_resource(
@@ -354,9 +420,9 @@ k8s_resource(
 )
 
 # ─── Ctrl Worker (Restate workflow handlers) ───────────────────────────────
-docker_build('unkey/control-worker:dev', '..', dockerfile='Dockerfile', build_args={'PACKAGE': './build/control-worker'})
+go_service_image('unkey/control-worker:dev', 'control-worker')
 k8s_yaml('k8s/manifests/ctrl-worker.yaml')
-ctrl_worker_deps = ['mysql', 'clickhouse', 'restate', 'webhooks-config', 'github-credentials', 'stripe-credentials']
+ctrl_worker_deps = ['mysql', 'clickhouse', 'restate', 'webhooks-config', 'github-credentials', 'stripe-credentials', 'control-worker-compile']
 if has_depot_credentials:
     ctrl_worker_deps.append('depot-credentials')
 k8s_resource(
@@ -381,12 +447,12 @@ if has_github_credentials:
     )
 
 # ─── Frontline (TLS termination proxy for *.unkey.local) ───────────────────
-docker_build('unkey/frontline:dev', '..', dockerfile='Dockerfile', build_args={'PACKAGE': './build/frontline'})
+go_service_image('unkey/frontline:dev', 'frontline')
 k8s_yaml('k8s/manifests/frontline.yaml')
 k8s_resource(
   'frontline',
   port_forwards=['9443:7443', '9080:7070'],
-  resource_deps=['mysql', 'ctrl-api', 'vault', 'frontline-certs'],
+  resource_deps=['mysql', 'ctrl-api', 'vault', 'frontline-certs', 'frontline-compile'],
   labels=['unkey'],
   auto_init=True,
   trigger_mode=TRIGGER_MODE_AUTO,
@@ -394,23 +460,23 @@ k8s_resource(
 )
 
 # ─── Krane ─────────────────────────────────────────────────────────────────
-docker_build('unkey/krane:dev', '..', dockerfile='Dockerfile', build_args={'PACKAGE': './build/krane'})
+go_service_image('unkey/krane:dev', 'krane')
 k8s_yaml('k8s/manifests/krane.yaml')
 k8s_resource(
   'krane',
   port_forwards='8070:8070',
-  resource_deps=['ctrl-api', 'rbac', 'namespace', 'cilium-policies', 'depot-credentials', 'topolvm-storageclass'],
+  resource_deps=['ctrl-api', 'rbac', 'namespace', 'cilium-policies', 'depot-credentials', 'topolvm-storageclass', 'krane-compile'],
   labels=['unkey'],
   auto_init=True,
   trigger_mode=TRIGGER_MODE_AUTO
 )
 
 # ─── Heimdall (resource metering agent) ────────────────────────────────────
-docker_build('unkey/heimdall:dev', '..', dockerfile='Dockerfile', build_args={'PACKAGE': './build/heimdall'})
+go_service_image('unkey/heimdall:dev', 'heimdall')
 k8s_yaml('k8s/manifests/heimdall.yaml')
 k8s_resource(
   'heimdall',
-  resource_deps=['clickhouse', 'rbac'],
+  resource_deps=['clickhouse', 'rbac', 'heimdall-compile'],
   labels=['unkey'],
   auto_init=True,
   trigger_mode=TRIGGER_MODE_AUTO

--- a/docs/engineering/contributing/tooling/builds.mdx
+++ b/docs/engineering/contributing/tooling/builds.mdx
@@ -14,8 +14,9 @@ Unkey uses Docker for image production for three reasons:
    files.
 2. **Multi-arch releases.** The release workflow uses Docker Buildx to publish
    `linux/amd64` and `linux/arm64` variants.
-3. **Simple local builds.** Tilt and Docker Compose build service images on
-   demand from the same dev Dockerfile.
+3. **Simple local builds.** Docker Compose builds service images on demand
+   from the dev Dockerfile. Tilt compiles binaries on the host for fast
+   incremental rebuilds and only uses Docker to package them.
 
 ## What ships in an image
 
@@ -55,23 +56,30 @@ Build configuration is split by concern:
   repository source label.
 - `.goreleaser.service.yaml` builds release binaries and publishes multi-arch
   images with `Dockerfile.release`.
-- `dev/Tiltfile` uses Tilt's native `docker_build` for on-demand local images.
+- `dev/Tiltfile` compiles each service on the host with the local Go build
+  cache, then packages the binary with `dev/Dockerfile.binary`. The image is
+  built once per service; after that, Tilt's `live_update` syncs the rebuilt
+  binary into the running container and restarts the process in place, so a
+  code change never rebuilds an image or rolls a pod.
 - `web/apps/dashboard/dev/docker-compose.yaml` builds dashboard-local service
   images with `dev/Dockerfile`.
 
 ## Local images
 
-Tilt and the dashboard `docker-compose` setup use `dev/Dockerfile` under the
-local `unkey/<service>:dev` tag:
+Tilt and the dashboard `docker-compose` setup both produce local
+`unkey/<service>:dev` tags:
 
 | Local environment | Image source |
 | --- | --- |
-| `dev/k8s` (Tilt) | `docker_build` in `dev/Tiltfile` |
-| Dashboard compose | `build` entries in `web/apps/dashboard/dev/docker-compose.yaml` |
+| `dev/k8s` (Tilt) | host `go build` + `dev/Dockerfile.binary` + `live_update` in `dev/Tiltfile` |
+| Dashboard compose | `build` entries in `web/apps/dashboard/dev/docker-compose.yaml` using `dev/Dockerfile` |
 
-Because the same image runs locally and in production, you can reproduce
-production-image issues in dev without a separate codepath. There is no
-"dev image" that diverges from the shipped one.
+The compose images match production exactly (static binary, distroless
+base), so production-image issues reproduce there without a separate
+codepath. The Tilt images trade that fidelity for speed: they use a busybox
+base because `live_update` needs `sh`, `date`, and `tar` inside the
+container. To debug something that depends on the distroless base itself,
+use the compose setup or build `dev/Dockerfile` directly.
 
 ## Adding a new service image
 
@@ -79,8 +87,8 @@ production-image issues in dev without a separate codepath. There is no
 2. Add the service's tag pattern to `.depot/workflows/service-release.yaml`
    so the release workflow picks up `<service>/vx.y.z` pushes.
 3. Add the service to `.goreleaser.service.yaml`.
-4. Wire it into local dev: a `docker_build` call in `dev/Tiltfile`, and any
-   compose file that needs it.
+4. Wire it into local dev: a `go_service_image` call in `dev/Tiltfile`, and
+   any compose file that needs it.
 
 Keep new entrypoints thin. Anything that looks like service behavior, such
 as defaults, injected clocks, or generated instance IDs, belongs in the


### PR DESCRIPTION
## Problem

Tilt rebuilds are painfully slow. Each service builds with `docker_build('unkey/<svc>:dev', '..', dockerfile='dev/Dockerfile', ...)`, so the build context is the whole repo root for all seven services. Editing anything under `svc/`, `pkg/`, etc. dirties the context for every target, and each rebuild runs an in-container `go build` from cold, then pushes an image and rolls a pod. Reported builds ran 400s+ each (heimdall 441s, frontline 430s) even when the service's own source was untouched, and one edit cascaded into rebuilding unrelated services serially. Round-trip on a code change was 10-15 minutes.

## Solution

Compile each service on the host and only use Docker to package the result.

- A `<svc>-compile` `local_resource` runs `go build` on the host into `dev/bin/<svc>/unkey`, hitting the shared incremental Go build cache. `dev/Dockerfile.binary` (busybox) wraps that prebuilt binary, and `live_update` syncs the fresh binary into the running container and re-execs it. A code change never rebuilds an image, pushes to the registry, or rolls a pod.
- Each service's compile `deps` are scoped to the repo-local packages it actually imports, resolved via `go list -deps` at `tilt up`. Editing one service's code re-fires only that compile; edits to a shared package still fan out to its consumers, which is correct. `_test.go` changes are ignored so tests don't trigger a recompile.
- busybox instead of distroless in dev because `live_update` needs `sh`/`date`/`tar` in the container. busybox ships no CA bundle, so `Dockerfile.binary` copies `ca-certificates.crt` from the distroless image (same trust store as the release image); without it, `CGO_ENABLED=0` binaries fail outbound public TLS (Stripe, GitHub, ACME) with x509 unknown-authority errors. `dev/Dockerfile` (distroless, in-container build) stays for the dashboard docker-compose setup, so production-image fidelity is unchanged there. Documented in `builds.mdx`.

## Testing

Verified in a live minikube/Tilt cluster running this branch:

- Tiltfile loads clean, all seven services `runtime ok`.
- Host compiles run in 0.86-0.99s each (vs 400s+ before).
- Dep scoping confirmed from the resolved graphs: `vault-compile` does not watch `svc/api`; `heimdall-compile` watches neither `pkg/db` nor `pkg/otel`; `api-compile` watches `svc/api` and `pkg/db`.
