### PR TITLE
fix(ci): keep v prefix on service image tags

### DIFF
--- a/.goreleaser.service.yaml
+++ b/.goreleaser.service.yaml
@@ -28,7 +28,7 @@ dockers_v2:
     images:
       - "ghcr.io/unkeyed/{{ .ProjectName }}"
     tags:
-      - "{{ .Version }}"
+      - "v{{ .Version }}"
     labels:
       "org.opencontainers.image.source": "https://github.com/unkeyed/unkey"
     platforms:


### PR DESCRIPTION
**Problem:**

#6701 moved service image pushes from Bazel to GoReleaser dockers_v2. The old workflow tagged images with the raw tag version (v1.0.7); the GoReleaser template uses {{ .Version }}, which strips the leading v. Todays releases landed as ghcr.io/unkeyed/frontline:1.0.7 and ghcr.io/unkeyed/api:1.1.3, so helm charts pinned to v-prefixed tags cannot pull them.

**Solution:**

Tag images with v{{ .Version }} to match the pre-#6701 scheme and every existing tag in GHCR.

**Testing:**

Ran a local snapshot release at this commit in a clean clone:

```bash
goreleaser release --clean --snapshot --config build/frontline/.goreleaser.yaml
```

Images rendered as ghcr.io/unkeyed/frontline:v1.0.7-SNAPSHOT-079f6402a for amd64 and arm64, confirming the v prefix. The broken config produced bare 1.0.7 in the real v1.0.7 release run. Local goreleaser-pro is 2.17.0 vs 2.15.4 in CI.

The already-pushed 1.0.7 and 1.1.3 manifests still need to be aliased to v1.0.7 and v1.1.3 (or re-released) to unblock deploys.