### PR TITLE
feat(api,frontline): write verification source again

### DIFF
--- a/pkg/clickhouse/billable_source_test.go
+++ b/pkg/clickhouse/billable_source_test.go
@@ -18,12 +18,6 @@ import (
 // API usage, while analytics rollups keep them: gateway traffic is still the
 // customer's traffic.
 func TestBillableExcludesGatewaySource(t *testing.T) {
-	// Source is temporarily excluded from inserts (ch:"-" on
-	// schema.KeyVerification.Source) until the 20260612000000 migration has
-	// run everywhere, so gateway rows cannot be tagged. Unskip when the tag
-	// is restored to ch:"source".
-	t.Skip("source column writes are disabled, see schema.KeyVerification.Source")
-
 	chCfg := containers.ClickHouse(t)
 
 	client, err := clickhouse.New(clickhouse.Config{URL: chCfg.DSN})

--- a/pkg/clickhouse/flush_test.go
+++ b/pkg/clickhouse/flush_test.go
@@ -17,10 +17,8 @@ func TestInsertQuery(t *testing.T) {
 		"INSERT INTO default.build_step_logs_v1 (`time`, `workspace_id`, `project_id`, `deployment_id`, `step_id`, `message`)",
 		InsertQuery[schema.BuildStepLogV1]())
 
-	// Source is tagged ch:"-" until the 20260612000000 migration has run
-	// everywhere; see the comment on schema.KeyVerification.Source.
 	query := InsertQuery[schema.KeyVerification]()
-	require.NotContains(t, query, "source")
+	require.Contains(t, query, "`source`")
 	require.Contains(t, query, "`request_id`")
 }
 

--- a/pkg/clickhouse/schema/columns_generated.go
+++ b/pkg/clickhouse/schema/columns_generated.go
@@ -9,7 +9,7 @@ func (KeyVerification) Table() string {
 
 // InsertColumns implements [Row]; derived from KeyVerification's ch tags.
 func (KeyVerification) InsertColumns() string {
-	return "`request_id`, `time`, `workspace_id`, `key_space_id`, `identity_id`, `external_id`, `key_id`, `region`, `outcome`, `tags`, `spent_credits`, `latency`"
+	return "`request_id`, `time`, `workspace_id`, `key_space_id`, `identity_id`, `external_id`, `key_id`, `region`, `source`, `outcome`, `tags`, `spent_credits`, `latency`"
 }
 
 // Table implements [Row].

--- a/pkg/clickhouse/schema/types.go
+++ b/pkg/clickhouse/schema/types.go
@@ -26,14 +26,9 @@ type KeyVerification struct {
 	ExternalID  string `ch:"external_id" json:"external_id"`
 	KeyID       string `ch:"key_id" json:"key_id"`
 	Region      string `ch:"region" json:"region"`
-	// Source is temporarily excluded from ClickHouse inserts (ch:"-"): the
-	// 20260612000000 migration ran before every writer binary knew the
-	// column, and binaries predating it dropped every verification batch
-	// ("missing destination name"). Excluding the column makes inserts work
-	// against both migrated and unmigrated tables; omitted values fall back
-	// to the column DEFAULT 'api'. To re-enable, restore ch:"source" once
-	// the column exists in every environment this binary writes to.
-	Source       string   `ch:"-" json:"source"`
+	// Source distinguishes verification origin (e.g. api vs gateway). Column
+	// DEFAULTs to 'api' for rows written before it existed.
+	Source       string   `ch:"source" json:"source"`
 	Outcome      string   `ch:"outcome" json:"outcome"`
 	Tags         []string `ch:"tags" json:"tags"`
 	SpentCredits int64    `ch:"spent_credits" json:"spent_credits"`


### PR DESCRIPTION
**Problem:**

`schema.KeyVerification.Source` was tagged `ch:"-"` to exclude it from
ClickHouse inserts. That was a temporary measure: the `20260612000000`
migration added the `source` column before every writer binary knew about it,
and any binary predating the migration dropped its entire verification batch
with "missing destination name". Excluding the column kept inserts working
against both migrated and unmigrated tables, but it also meant verification
origin (api vs gateway) was never recorded, always falling back to the column
DEFAULT of 'api'.

The migration has now propagated to every environment and all writer binaries
know the column, so the workaround can be removed and source tracking
restored.

**Solution:**

Restore `ch:"source"` on `KeyVerification.Source` so api and frontline writers
tag each verification with its origin again. Regenerate `InsertColumns` to
include `source`, flip the `flush_test` assertion back to requiring the column,
and unskip `TestBillableExcludesGatewaySource`.

The disable-history is preserved in the git log in case the exclusion has to
be reinstated.

**Impact:**

Verification rows written after deploy carry a real `source` value again;
rows written during the exclusion window keep the DEFAULT 'api'. No migration
in this PR, no config changes. Safe only because the `20260612000000`
migration and column-aware binaries are already everywhere.

**Testing:**

```bash
mise exec -- go test -run 'TestInsertQuery' ./pkg/clickhouse/
# ok  github.com/unkeyed/unkey/pkg/clickhouse  0.417s
```

`TestBillableExcludesGatewaySource` is unskipped by this change but is
container-backed (ClickHouse) and was not run in this session.
