### PR TITLE
feat(dashboard): drive runtime setting sliders from the workspace quota

### DIFF
--- a/cmd/dev/stripe/reset.go
+++ b/cmd/dev/stripe/reset.go
@@ -107,6 +107,7 @@ func reset(ctx context.Context, cmd *cli.Command) error {
 		MaxMemoryMibPerInstance:     4_096,
 		MaxStorageMibPerInstance:    10_240,
 		MaxConcurrentBuilds:         1,
+		MaxReplicasPerRegion:        4,
 		WorkspaceID:                 workspaceID,
 	}); err != nil {
 		return fmt.Errorf("reset quota row: %w", err)

--- a/pkg/db/clickhouse_workspace_settings_find_by_workspace_id.sql_generated.go
+++ b/pkg/db/clickhouse_workspace_settings_find_by_workspace_id.sql_generated.go
@@ -12,7 +12,7 @@ import (
 const findClickhouseWorkspaceSettingsByWorkspaceID = `-- name: FindClickhouseWorkspaceSettingsByWorkspaceID :one
 SELECT
     c.pk, c.workspace_id, c.username, c.password_encrypted, c.quota_duration_seconds, c.max_queries_per_window, c.max_execution_time_per_window, c.max_query_execution_time, c.max_query_memory_bytes, c.max_query_result_rows, c.created_at, c.updated_at,
-    q.pk, q.workspace_id, q.requests_per_month, q.logs_retention_days, q.audit_logs_retention_days, q.team, q.ratelimit_api_limit, q.ratelimit_api_duration, q.allocated_cpu_millicores_total, q.allocated_memory_mib_total, q.allocated_storage_mib_total, q.max_cpu_millicores_per_instance, q.max_memory_mib_per_instance, q.max_storage_mib_per_instance, q.max_concurrent_builds
+    q.pk, q.workspace_id, q.requests_per_month, q.logs_retention_days, q.audit_logs_retention_days, q.team, q.ratelimit_api_limit, q.ratelimit_api_duration, q.allocated_cpu_millicores_total, q.allocated_memory_mib_total, q.allocated_storage_mib_total, q.max_cpu_millicores_per_instance, q.max_memory_mib_per_instance, q.max_storage_mib_per_instance, q.max_concurrent_builds, q.max_replicas_per_region
 FROM ` + "`" + `clickhouse_workspace_settings` + "`" + ` c
 JOIN ` + "`" + `quota` + "`" + ` q ON c.workspace_id = q.workspace_id
 WHERE c.workspace_id = ?
@@ -27,7 +27,7 @@ type FindClickhouseWorkspaceSettingsByWorkspaceIDRow struct {
 //
 //	SELECT
 //	    c.pk, c.workspace_id, c.username, c.password_encrypted, c.quota_duration_seconds, c.max_queries_per_window, c.max_execution_time_per_window, c.max_query_execution_time, c.max_query_memory_bytes, c.max_query_result_rows, c.created_at, c.updated_at,
-//	    q.pk, q.workspace_id, q.requests_per_month, q.logs_retention_days, q.audit_logs_retention_days, q.team, q.ratelimit_api_limit, q.ratelimit_api_duration, q.allocated_cpu_millicores_total, q.allocated_memory_mib_total, q.allocated_storage_mib_total, q.max_cpu_millicores_per_instance, q.max_memory_mib_per_instance, q.max_storage_mib_per_instance, q.max_concurrent_builds
+//	    q.pk, q.workspace_id, q.requests_per_month, q.logs_retention_days, q.audit_logs_retention_days, q.team, q.ratelimit_api_limit, q.ratelimit_api_duration, q.allocated_cpu_millicores_total, q.allocated_memory_mib_total, q.allocated_storage_mib_total, q.max_cpu_millicores_per_instance, q.max_memory_mib_per_instance, q.max_storage_mib_per_instance, q.max_concurrent_builds, q.max_replicas_per_region
 //	FROM `clickhouse_workspace_settings` c
 //	JOIN `quota` q ON c.workspace_id = q.workspace_id
 //	WHERE c.workspace_id = ?
@@ -62,6 +62,7 @@ func (q *Queries) FindClickhouseWorkspaceSettingsByWorkspaceID(ctx context.Conte
 		&i.Quotas.MaxMemoryMibPerInstance,
 		&i.Quotas.MaxStorageMibPerInstance,
 		&i.Quotas.MaxConcurrentBuilds,
+		&i.Quotas.MaxReplicasPerRegion,
 	)
 	return i, err
 }

--- a/pkg/db/models_generated.go
+++ b/pkg/db/models_generated.go
@@ -1373,6 +1373,7 @@ type Quotas struct {
 	MaxMemoryMibPerInstance     uint32        `db:"max_memory_mib_per_instance"`
 	MaxStorageMibPerInstance    uint32        `db:"max_storage_mib_per_instance"`
 	MaxConcurrentBuilds         uint32        `db:"max_concurrent_builds"`
+	MaxReplicasPerRegion        uint32        `db:"max_replicas_per_region"`
 }
 
 type Ratelimit struct {

--- a/pkg/db/querier_generated.go
+++ b/pkg/db/querier_generated.go
@@ -493,7 +493,7 @@ type Querier interface {
 	//
 	//  SELECT
 	//      c.pk, c.workspace_id, c.username, c.password_encrypted, c.quota_duration_seconds, c.max_queries_per_window, c.max_execution_time_per_window, c.max_query_execution_time, c.max_query_memory_bytes, c.max_query_result_rows, c.created_at, c.updated_at,
-	//      q.pk, q.workspace_id, q.requests_per_month, q.logs_retention_days, q.audit_logs_retention_days, q.team, q.ratelimit_api_limit, q.ratelimit_api_duration, q.allocated_cpu_millicores_total, q.allocated_memory_mib_total, q.allocated_storage_mib_total, q.max_cpu_millicores_per_instance, q.max_memory_mib_per_instance, q.max_storage_mib_per_instance, q.max_concurrent_builds
+	//      q.pk, q.workspace_id, q.requests_per_month, q.logs_retention_days, q.audit_logs_retention_days, q.team, q.ratelimit_api_limit, q.ratelimit_api_duration, q.allocated_cpu_millicores_total, q.allocated_memory_mib_total, q.allocated_storage_mib_total, q.max_cpu_millicores_per_instance, q.max_memory_mib_per_instance, q.max_storage_mib_per_instance, q.max_concurrent_builds, q.max_replicas_per_region
 	//  FROM `clickhouse_workspace_settings` c
 	//  JOIN `quota` q ON c.workspace_id = q.workspace_id
 	//  WHERE c.workspace_id = ?
@@ -1201,7 +1201,7 @@ type Querier interface {
 	FindProjectBySlug(ctx context.Context, db DBTX, slug string) (Project, error)
 	//FindQuotaByWorkspaceID
 	//
-	//  SELECT pk, workspace_id, requests_per_month, logs_retention_days, audit_logs_retention_days, team, ratelimit_api_limit, ratelimit_api_duration, allocated_cpu_millicores_total, allocated_memory_mib_total, allocated_storage_mib_total, max_cpu_millicores_per_instance, max_memory_mib_per_instance, max_storage_mib_per_instance, max_concurrent_builds
+	//  SELECT pk, workspace_id, requests_per_month, logs_retention_days, audit_logs_retention_days, team, ratelimit_api_limit, ratelimit_api_duration, allocated_cpu_millicores_total, allocated_memory_mib_total, allocated_storage_mib_total, max_cpu_millicores_per_instance, max_memory_mib_per_instance, max_storage_mib_per_instance, max_concurrent_builds, max_replicas_per_region
 	//  FROM `quota`
 	//  WHERE workspace_id = ?
 	FindQuotaByWorkspaceID(ctx context.Context, db DBTX, workspaceID string) (Quotas, error)
@@ -2988,7 +2988,7 @@ type Querier interface {
 	//
 	//  SELECT
 	//     w.pk, w.id, w.org_id, w.name, w.slug, w.k8s_namespace, w.tier, w.stripe_customer_id, w.stripe_subscription_id, w.deploy_plan, w.deploy_plan_override, w.deploy_spend_budget_cents, w.deploy_spend_budget_stop, w.deploy_spend_suspended, w.beta_features, w.subscriptions, w.enabled, w.delete_protection, w.created_at_m, w.updated_at_m, w.deleted_at_m,
-	//     q.pk, q.workspace_id, q.requests_per_month, q.logs_retention_days, q.audit_logs_retention_days, q.team, q.ratelimit_api_limit, q.ratelimit_api_duration, q.allocated_cpu_millicores_total, q.allocated_memory_mib_total, q.allocated_storage_mib_total, q.max_cpu_millicores_per_instance, q.max_memory_mib_per_instance, q.max_storage_mib_per_instance, q.max_concurrent_builds
+	//     q.pk, q.workspace_id, q.requests_per_month, q.logs_retention_days, q.audit_logs_retention_days, q.team, q.ratelimit_api_limit, q.ratelimit_api_duration, q.allocated_cpu_millicores_total, q.allocated_memory_mib_total, q.allocated_storage_mib_total, q.max_cpu_millicores_per_instance, q.max_memory_mib_per_instance, q.max_storage_mib_per_instance, q.max_concurrent_builds, q.max_replicas_per_region
 	//  FROM `workspaces` w
 	//  LEFT JOIN quota q ON w.id = q.workspace_id
 	//  WHERE w.id > ?
@@ -3695,7 +3695,8 @@ type Querier interface {
 	//      max_cpu_millicores_per_instance = ?,
 	//      max_memory_mib_per_instance = ?,
 	//      max_storage_mib_per_instance = ?,
-	//      max_concurrent_builds = ?
+	//      max_concurrent_builds = ?,
+	//      max_replicas_per_region = ?
 	//  WHERE workspace_id = ?
 	UpdateQuota(ctx context.Context, db DBTX, arg UpdateQuotaParams) error
 	//UpdateRatelimit

--- a/pkg/db/queries/quota_update.sql
+++ b/pkg/db/queries/quota_update.sql
@@ -17,5 +17,6 @@ SET requests_per_month = sqlc.arg(requests_per_month),
     max_cpu_millicores_per_instance = sqlc.arg(max_cpu_millicores_per_instance),
     max_memory_mib_per_instance = sqlc.arg(max_memory_mib_per_instance),
     max_storage_mib_per_instance = sqlc.arg(max_storage_mib_per_instance),
-    max_concurrent_builds = sqlc.arg(max_concurrent_builds)
+    max_concurrent_builds = sqlc.arg(max_concurrent_builds),
+    max_replicas_per_region = sqlc.arg(max_replicas_per_region)
 WHERE workspace_id = sqlc.arg(workspace_id);

--- a/pkg/db/quota_find_by_workspace_id.sql_generated.go
+++ b/pkg/db/quota_find_by_workspace_id.sql_generated.go
@@ -10,14 +10,14 @@ import (
 )
 
 const findQuotaByWorkspaceID = `-- name: FindQuotaByWorkspaceID :one
-SELECT pk, workspace_id, requests_per_month, logs_retention_days, audit_logs_retention_days, team, ratelimit_api_limit, ratelimit_api_duration, allocated_cpu_millicores_total, allocated_memory_mib_total, allocated_storage_mib_total, max_cpu_millicores_per_instance, max_memory_mib_per_instance, max_storage_mib_per_instance, max_concurrent_builds
+SELECT pk, workspace_id, requests_per_month, logs_retention_days, audit_logs_retention_days, team, ratelimit_api_limit, ratelimit_api_duration, allocated_cpu_millicores_total, allocated_memory_mib_total, allocated_storage_mib_total, max_cpu_millicores_per_instance, max_memory_mib_per_instance, max_storage_mib_per_instance, max_concurrent_builds, max_replicas_per_region
 FROM ` + "`" + `quota` + "`" + `
 WHERE workspace_id = ?
 `
 
 // FindQuotaByWorkspaceID
 //
-//	SELECT pk, workspace_id, requests_per_month, logs_retention_days, audit_logs_retention_days, team, ratelimit_api_limit, ratelimit_api_duration, allocated_cpu_millicores_total, allocated_memory_mib_total, allocated_storage_mib_total, max_cpu_millicores_per_instance, max_memory_mib_per_instance, max_storage_mib_per_instance, max_concurrent_builds
+//	SELECT pk, workspace_id, requests_per_month, logs_retention_days, audit_logs_retention_days, team, ratelimit_api_limit, ratelimit_api_duration, allocated_cpu_millicores_total, allocated_memory_mib_total, allocated_storage_mib_total, max_cpu_millicores_per_instance, max_memory_mib_per_instance, max_storage_mib_per_instance, max_concurrent_builds, max_replicas_per_region
 //	FROM `quota`
 //	WHERE workspace_id = ?
 func (q *Queries) FindQuotaByWorkspaceID(ctx context.Context, db DBTX, workspaceID string) (Quotas, error) {
@@ -39,6 +39,7 @@ func (q *Queries) FindQuotaByWorkspaceID(ctx context.Context, db DBTX, workspace
 		&i.MaxMemoryMibPerInstance,
 		&i.MaxStorageMibPerInstance,
 		&i.MaxConcurrentBuilds,
+		&i.MaxReplicasPerRegion,
 	)
 	return i, err
 }

--- a/pkg/db/quota_update.sql_generated.go
+++ b/pkg/db/quota_update.sql_generated.go
@@ -24,7 +24,8 @@ SET requests_per_month = ?,
     max_cpu_millicores_per_instance = ?,
     max_memory_mib_per_instance = ?,
     max_storage_mib_per_instance = ?,
-    max_concurrent_builds = ?
+    max_concurrent_builds = ?,
+    max_replicas_per_region = ?
 WHERE workspace_id = ?
 `
 
@@ -42,6 +43,7 @@ type UpdateQuotaParams struct {
 	MaxMemoryMibPerInstance     uint32        `db:"max_memory_mib_per_instance"`
 	MaxStorageMibPerInstance    uint32        `db:"max_storage_mib_per_instance"`
 	MaxConcurrentBuilds         uint32        `db:"max_concurrent_builds"`
+	MaxReplicasPerRegion        uint32        `db:"max_replicas_per_region"`
 	WorkspaceID                 string        `db:"workspace_id"`
 }
 
@@ -64,7 +66,8 @@ type UpdateQuotaParams struct {
 //	    max_cpu_millicores_per_instance = ?,
 //	    max_memory_mib_per_instance = ?,
 //	    max_storage_mib_per_instance = ?,
-//	    max_concurrent_builds = ?
+//	    max_concurrent_builds = ?,
+//	    max_replicas_per_region = ?
 //	WHERE workspace_id = ?
 func (q *Queries) UpdateQuota(ctx context.Context, db DBTX, arg UpdateQuotaParams) error {
 	_, err := db.ExecContext(ctx, updateQuota,
@@ -81,6 +84,7 @@ func (q *Queries) UpdateQuota(ctx context.Context, db DBTX, arg UpdateQuotaParam
 		arg.MaxMemoryMibPerInstance,
 		arg.MaxStorageMibPerInstance,
 		arg.MaxConcurrentBuilds,
+		arg.MaxReplicasPerRegion,
 		arg.WorkspaceID,
 	)
 	return err

--- a/pkg/db/workspace_list.sql_generated.go
+++ b/pkg/db/workspace_list.sql_generated.go
@@ -12,7 +12,7 @@ import (
 const listWorkspaces = `-- name: ListWorkspaces :many
 SELECT
    w.pk, w.id, w.org_id, w.name, w.slug, w.k8s_namespace, w.tier, w.stripe_customer_id, w.stripe_subscription_id, w.deploy_plan, w.deploy_plan_override, w.deploy_spend_budget_cents, w.deploy_spend_budget_stop, w.deploy_spend_suspended, w.beta_features, w.subscriptions, w.enabled, w.delete_protection, w.created_at_m, w.updated_at_m, w.deleted_at_m,
-   q.pk, q.workspace_id, q.requests_per_month, q.logs_retention_days, q.audit_logs_retention_days, q.team, q.ratelimit_api_limit, q.ratelimit_api_duration, q.allocated_cpu_millicores_total, q.allocated_memory_mib_total, q.allocated_storage_mib_total, q.max_cpu_millicores_per_instance, q.max_memory_mib_per_instance, q.max_storage_mib_per_instance, q.max_concurrent_builds
+   q.pk, q.workspace_id, q.requests_per_month, q.logs_retention_days, q.audit_logs_retention_days, q.team, q.ratelimit_api_limit, q.ratelimit_api_duration, q.allocated_cpu_millicores_total, q.allocated_memory_mib_total, q.allocated_storage_mib_total, q.max_cpu_millicores_per_instance, q.max_memory_mib_per_instance, q.max_storage_mib_per_instance, q.max_concurrent_builds, q.max_replicas_per_region
 FROM ` + "`" + `workspaces` + "`" + ` w
 LEFT JOIN quota q ON w.id = q.workspace_id
 WHERE w.id > ?
@@ -29,7 +29,7 @@ type ListWorkspacesRow struct {
 //
 //	SELECT
 //	   w.pk, w.id, w.org_id, w.name, w.slug, w.k8s_namespace, w.tier, w.stripe_customer_id, w.stripe_subscription_id, w.deploy_plan, w.deploy_plan_override, w.deploy_spend_budget_cents, w.deploy_spend_budget_stop, w.deploy_spend_suspended, w.beta_features, w.subscriptions, w.enabled, w.delete_protection, w.created_at_m, w.updated_at_m, w.deleted_at_m,
-//	   q.pk, q.workspace_id, q.requests_per_month, q.logs_retention_days, q.audit_logs_retention_days, q.team, q.ratelimit_api_limit, q.ratelimit_api_duration, q.allocated_cpu_millicores_total, q.allocated_memory_mib_total, q.allocated_storage_mib_total, q.max_cpu_millicores_per_instance, q.max_memory_mib_per_instance, q.max_storage_mib_per_instance, q.max_concurrent_builds
+//	   q.pk, q.workspace_id, q.requests_per_month, q.logs_retention_days, q.audit_logs_retention_days, q.team, q.ratelimit_api_limit, q.ratelimit_api_duration, q.allocated_cpu_millicores_total, q.allocated_memory_mib_total, q.allocated_storage_mib_total, q.max_cpu_millicores_per_instance, q.max_memory_mib_per_instance, q.max_storage_mib_per_instance, q.max_concurrent_builds, q.max_replicas_per_region
 //	FROM `workspaces` w
 //	LEFT JOIN quota q ON w.id = q.workspace_id
 //	WHERE w.id > ?
@@ -81,6 +81,7 @@ func (q *Queries) ListWorkspaces(ctx context.Context, db DBTX, cursor string) ([
 			&i.Quotas.MaxMemoryMibPerInstance,
 			&i.Quotas.MaxStorageMibPerInstance,
 			&i.Quotas.MaxConcurrentBuilds,
+			&i.Quotas.MaxReplicasPerRegion,
 		); err != nil {
 			return nil, err
 		}

--- a/pkg/mysql/schema/quota.sql
+++ b/pkg/mysql/schema/quota.sql
@@ -14,6 +14,7 @@ CREATE TABLE `quota` (
 	`max_memory_mib_per_instance` int unsigned NOT NULL DEFAULT 4096,
 	`max_storage_mib_per_instance` int unsigned NOT NULL DEFAULT 10240,
 	`max_concurrent_builds` int unsigned NOT NULL DEFAULT 1,
+	`max_replicas_per_region` int unsigned NOT NULL DEFAULT 4,
 	CONSTRAINT `quota_pk` PRIMARY KEY(`pk`),
 	CONSTRAINT `quota_workspace_id_unique` UNIQUE(`workspace_id`)
 );

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/settings/components/runtime-settings/cpu.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/settings/components/runtime-settings/cpu.tsx
@@ -2,32 +2,36 @@
 
 import { formatCpuParts } from "@/lib/utils/deployment-formatters";
 import { Microchip } from "@unkey/icons";
-import { type ResourceSliderConfig, ResourceSliderSetting } from "../shared/resource-slider";
+import { ResourceSliderSetting, defineResourceSlider } from "../shared/resource-slider";
 
+// CPU tiers on the slider. resolveStrategy bounds these to the workspace quota
+// and adds the exact quota value as a stop when it is not one of these tiers.
 const CPU_OPTIONS = [
   { label: "1/4 vCPU", value: 250 },
   { label: "1/2 vCPU", value: 500 },
   { label: "1 vCPU", value: 1000 },
   { label: "2 vCPU", value: 2000 },
-  //{ label: "4 vCPU", value: 4000 },
-  //{ label: "8 vCPU", value: 8000 },
-  //{ label: "16 vCPU", value: 16000 },
-  //{ label: "32 vCPU", value: 32000 },
+  { label: "4 vCPU", value: 4000 },
+  { label: "8 vCPU", value: 8000 },
+  { label: "16 vCPU", value: 16000 },
+  { label: "32 vCPU", value: 32000 },
 ] as const;
 
-const cpuConfig: ResourceSliderConfig = {
+const cpuConfig = defineResourceSlider({
   icon: <Microchip className="text-gray-12" iconSize="xl-medium" />,
   title: "Max CPU",
   description: "Maximum CPU limit per instance. You are only charged for actual usage.",
   settingDescription:
-    "Changes apply on next deploy. During beta, CPU is limited to 2 vCPUs. Please contact support@unkey.com if you need more.",
+    "Changes apply on next deploy. Contact support@unkey.com if you need higher limits.",
   colorVar: "infoA",
-  slider: { kind: "index-mapped", options: CPU_OPTIONS, fallback: 250 },
+  options: CPU_OPTIONS,
+  fallback: 250,
   formatValue: formatCpuParts,
-  readValue: (s) => s.cpuMillicores,
-  writeValue: (draft, value) => {
+  read: (s) => s.cpuMillicores,
+  write: (draft, value) => {
     draft.cpuMillicores = value;
   },
-};
+  quotaKey: "maxCpuMillicoresPerInstance",
+});
 
 export const Cpu = () => <ResourceSliderSetting config={cpuConfig} />;

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/settings/components/runtime-settings/instances.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/settings/components/runtime-settings/instances.tsx
@@ -2,11 +2,13 @@
 
 import { collection } from "@/lib/collections";
 import type { EnvironmentSettings } from "@/lib/collections/deploy/environment-settings";
+import { freeTierQuotas } from "@/lib/quotas";
 import { mapRegionToFlag } from "@/lib/trpc/routers/deploy/network/utils";
+import { useWorkspace } from "@/providers/workspace-provider";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Connections3 } from "@unkey/icons";
 import { Slider } from "@unkey/ui";
-import { useContext, useEffect } from "react";
+import { useContext, useEffect, useMemo } from "react";
 import { useForm, useWatch } from "react-hook-form";
 import { z } from "zod";
 import { RegionFlag } from "../../../../components/region-flag";
@@ -19,28 +21,35 @@ import { EnvironmentDisplayValue } from "../shared/resource-slider/environment-d
 import { EnvironmentSliderSection } from "../shared/resource-slider/environment-slider-section";
 
 const REPLICAS_MIN = 1;
-const REPLICAS_MAX = 4;
 const COLOR_VAR = "featureA";
+
+// Per-region instance cap from the workspace quota, or the free-tier default
+// until quotas load.
+const useReplicasMax = () => {
+  const { quotas } = useWorkspace();
+  return quotas?.maxReplicasPerRegion ?? freeTierQuotas.maxReplicasPerRegion;
+};
 
 const formatRangeParts = (replicasMin: number, replicasMax: number) => ({
   value: replicasMin === replicasMax ? String(replicasMax) : `${replicasMin} – ${replicasMax}`,
   unit: "",
 });
 
-const rangeSchema = z
-  .object({
-    replicasMin: z.number().int().min(REPLICAS_MIN).max(REPLICAS_MAX),
-    replicasMax: z.number().int().min(REPLICAS_MIN).max(REPLICAS_MAX),
-  })
-  .refine((d) => d.replicasMin <= d.replicasMax, {
-    message: "replicasMin must be ≤ replicasMax",
-    path: ["replicasMin"],
-  });
+const makeRangeSchema = (limit: number) =>
+  z
+    .object({
+      replicasMin: z.number().int().min(REPLICAS_MIN).max(limit),
+      replicasMax: z.number().int().min(REPLICAS_MIN).max(limit),
+    })
+    .refine((d) => d.replicasMin <= d.replicasMax, {
+      message: "replicasMin must be ≤ replicasMax",
+      path: ["replicasMin"],
+    });
 
-type RangeFormValues = z.infer<typeof rangeSchema>;
+type RangeFormValues = z.infer<ReturnType<typeof makeRangeSchema>>;
 
-const buildSliderRangeStyle = (replicasMin: number, replicasMax: number) => {
-  const span = REPLICAS_MAX - REPLICAS_MIN;
+const buildSliderRangeStyle = (replicasMin: number, replicasMax: number, limit: number) => {
+  const span = limit - REPLICAS_MIN;
   const left = span > 0 ? (replicasMin - REPLICAS_MIN) / span : 0;
   const right = span > 0 ? (replicasMax - REPLICAS_MIN) / span : 0;
   return {
@@ -110,13 +119,16 @@ export const Instances = () => {
 
 const description =
   "Autoscaling range per region. Scales up to the maximum based on CPU usage, down to the minimum when load is low.";
-const settingDescription =
-  "Changes apply on next deploy. During beta, instances are limited to 4 per region. Contact support@unkey.com if you need more.";
+const settingDescription = (limit: number) =>
+  `Changes apply on next deploy. Instances are limited to ${limit} per region. Contact support@unkey.com if you need more.`;
 
 const SingleMode = () => {
   const { settings, variant } = useEnvironmentSettings();
   const updateAllEnvironments = useUpdateAllEnvironments();
+  const replicasMaxLimit = useReplicasMax();
   const defaultValues = readRange(settings);
+
+  const rangeSchema = useMemo(() => makeRangeSchema(replicasMaxLimit), [replicasMaxLimit]);
 
   const {
     handleSubmit,
@@ -170,7 +182,7 @@ const SingleMode = () => {
         <div className="flex items-center gap-3">
           <Slider
             min={REPLICAS_MIN}
-            max={REPLICAS_MAX}
+            max={replicasMaxLimit}
             step={1}
             value={[currentReplicasMin, currentReplicasMax]}
             onValueChange={([replicasMin, replicasMax]) => {
@@ -200,36 +212,41 @@ const SingleMode = () => {
                 : undefined
             }
             className="flex-1 max-w-(--setting-w)"
-            rangeStyle={buildSliderRangeStyle(currentReplicasMin, currentReplicasMax)}
+            rangeStyle={buildSliderRangeStyle(
+              currentReplicasMin,
+              currentReplicasMax,
+              replicasMaxLimit,
+            )}
           />
           <RegionFlags settings={settings} />
           <span className="text-[13px] font-medium text-gray-12">
             {formatRangeParts(currentReplicasMin, currentReplicasMax).value}
           </span>
         </div>
-        <SettingDescription>{settingDescription}</SettingDescription>
+        <SettingDescription>{settingDescription(replicasMaxLimit)}</SettingDescription>
       </WideContent>
     </FormSettingCard>
   );
 };
 
-const dualSchema = z
-  .object({
-    productionReplicasMin: z.number().int().min(REPLICAS_MIN).max(REPLICAS_MAX),
-    productionReplicasMax: z.number().int().min(REPLICAS_MIN).max(REPLICAS_MAX),
-    previewReplicasMin: z.number().int().min(REPLICAS_MIN).max(REPLICAS_MAX),
-    previewReplicasMax: z.number().int().min(REPLICAS_MIN).max(REPLICAS_MAX),
-  })
-  .refine((d) => d.productionReplicasMin <= d.productionReplicasMax, {
-    message: "replicasMin must be ≤ replicasMax",
-    path: ["productionReplicasMin"],
-  })
-  .refine((d) => d.previewReplicasMin <= d.previewReplicasMax, {
-    message: "replicasMin must be ≤ replicasMax",
-    path: ["previewReplicasMin"],
-  });
+const makeDualSchema = (limit: number) =>
+  z
+    .object({
+      productionReplicasMin: z.number().int().min(REPLICAS_MIN).max(limit),
+      productionReplicasMax: z.number().int().min(REPLICAS_MIN).max(limit),
+      previewReplicasMin: z.number().int().min(REPLICAS_MIN).max(limit),
+      previewReplicasMax: z.number().int().min(REPLICAS_MIN).max(limit),
+    })
+    .refine((d) => d.productionReplicasMin <= d.productionReplicasMax, {
+      message: "replicasMin must be ≤ replicasMax",
+      path: ["productionReplicasMin"],
+    })
+    .refine((d) => d.previewReplicasMin <= d.previewReplicasMax, {
+      message: "replicasMin must be ≤ replicasMax",
+      path: ["previewReplicasMin"],
+    });
 
-type DualFormValues = z.infer<typeof dualSchema>;
+type DualFormValues = z.infer<ReturnType<typeof makeDualSchema>>;
 
 const DualMode = () => {
   const multiSettings = useMultiEnvironmentSettings();
@@ -247,8 +264,11 @@ type DualInnerProps = {
 };
 
 const DualInner = ({ production, preview }: DualInnerProps) => {
+  const replicasMaxLimit = useReplicasMax();
   const defaultProduction = readRange(production);
   const defaultPreview = readRange(preview);
+
+  const dualSchema = useMemo(() => makeDualSchema(replicasMaxLimit), [replicasMaxLimit]);
 
   const {
     handleSubmit,
@@ -355,6 +375,7 @@ const DualInner = ({ production, preview }: DualInnerProps) => {
           settings={production}
           replicasMin={currentProductionReplicasMin}
           replicasMax={currentProductionReplicasMax}
+          replicasMaxLimit={replicasMaxLimit}
           onChange={(replicasMin, replicasMax) => {
             setValue("productionReplicasMin", replicasMin, { shouldValidate: true });
             setValue("productionReplicasMax", replicasMax, { shouldValidate: true });
@@ -365,12 +386,13 @@ const DualInner = ({ production, preview }: DualInnerProps) => {
           settings={preview}
           replicasMin={currentPreviewReplicasMin}
           replicasMax={currentPreviewReplicasMax}
+          replicasMaxLimit={replicasMaxLimit}
           onChange={(replicasMin, replicasMax) => {
             setValue("previewReplicasMin", replicasMin, { shouldValidate: true });
             setValue("previewReplicasMax", replicasMax, { shouldValidate: true });
           }}
         />
-        <SettingDescription>{settingDescription}</SettingDescription>
+        <SettingDescription>{settingDescription(replicasMaxLimit)}</SettingDescription>
       </WideContent>
     </FormSettingCard>
   );
@@ -381,6 +403,7 @@ type DualSliderSectionProps = {
   settings: EnvironmentSettings;
   replicasMin: number;
   replicasMax: number;
+  replicasMaxLimit: number;
   onChange: (replicasMin: number, replicasMax: number) => void;
 };
 
@@ -389,13 +412,14 @@ const DualSliderSection = ({
   settings,
   replicasMin,
   replicasMax,
+  replicasMaxLimit,
   onChange,
 }: DualSliderSectionProps) => (
   <EnvironmentSliderSection label={label}>
     <div className="flex items-center gap-3">
       <Slider
         min={REPLICAS_MIN}
-        max={REPLICAS_MAX}
+        max={replicasMaxLimit}
         step={1}
         value={[replicasMin, replicasMax]}
         onValueChange={([nextReplicasMin, nextReplicasMax]) => {
@@ -404,7 +428,7 @@ const DualSliderSection = ({
           }
         }}
         className="flex-1 max-w-(--setting-w)"
-        rangeStyle={buildSliderRangeStyle(replicasMin, replicasMax)}
+        rangeStyle={buildSliderRangeStyle(replicasMin, replicasMax, replicasMaxLimit)}
       />
       <RegionFlags settings={settings} />
       <span className="text-[13px] font-medium text-gray-12">

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/settings/components/runtime-settings/memory.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/settings/components/runtime-settings/memory.tsx
@@ -2,32 +2,36 @@
 
 import { formatMemoryParts } from "@/lib/utils/deployment-formatters";
 import { Ram } from "@unkey/icons";
-import { type ResourceSliderConfig, ResourceSliderSetting } from "../shared/resource-slider";
+import { ResourceSliderSetting, defineResourceSlider } from "../shared/resource-slider";
 
+// Memory tiers on the slider. resolveStrategy bounds these to the workspace quota
+// and adds the exact quota value as a stop when it is not one of these tiers.
 const MEMORY_OPTIONS = [
   { label: "256 MiB", value: 256 },
   { label: "512 MiB", value: 512 },
   { label: "1 GiB", value: 1024 },
   { label: "2 GiB", value: 2048 },
   { label: "4 GiB", value: 4096 },
-  // { label: "8 GiB", value: 8192 },
-  // { label: "16 GiB", value: 16384 },
-  // { label: "32 GiB", value: 32768 },
+  { label: "8 GiB", value: 8192 },
+  { label: "16 GiB", value: 16384 },
+  { label: "32 GiB", value: 32768 },
 ] as const;
 
-const memoryConfig: ResourceSliderConfig = {
+const memoryConfig = defineResourceSlider({
   icon: <Ram className="text-gray-12" iconSize="xl-medium" />,
   title: "Memory",
   description: "Memory allocation for each instance",
   settingDescription:
-    "Changes apply on next deploy. During beta, memory is limited to 4 GiB. Please contact support@unkey.com if you need more.",
+    "Changes apply on next deploy. Contact support@unkey.com if you need higher limits.",
   colorVar: "warningA",
-  slider: { kind: "index-mapped", options: MEMORY_OPTIONS, fallback: 256 },
+  options: MEMORY_OPTIONS,
+  fallback: 256,
   formatValue: formatMemoryParts,
-  readValue: (s) => s.memoryMib,
-  writeValue: (draft, value) => {
+  read: (s) => s.memoryMib,
+  write: (draft, value) => {
     draft.memoryMib = value;
   },
-};
+  quotaKey: "maxMemoryMibPerInstance",
+});
 
 export const Memory = () => <ResourceSliderSetting config={memoryConfig} />;

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/settings/components/runtime-settings/storage.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/settings/components/runtime-settings/storage.tsx
@@ -2,8 +2,10 @@
 
 import { formatStorageParts } from "@/lib/utils/deployment-formatters";
 import { Database } from "@unkey/icons";
-import { type ResourceSliderConfig, ResourceSliderSetting } from "../shared/resource-slider";
+import { ResourceSliderSetting, defineResourceSlider } from "../shared/resource-slider";
 
+// Storage tiers on the slider. resolveStrategy bounds these to the workspace
+// quota and adds the exact quota value as a stop when it is not one of these tiers.
 const STORAGE_OPTIONS = [
   { label: "None", value: 0 },
   { label: "512 MiB", value: 512 },
@@ -11,21 +13,25 @@ const STORAGE_OPTIONS = [
   { label: "2 GiB", value: 2048 },
   { label: "5 GiB", value: 5120 },
   { label: "10 GiB", value: 10240 },
+  { label: "20 GiB", value: 20480 },
+  { label: "50 GiB", value: 51200 },
 ] as const;
 
-const storageConfig: ResourceSliderConfig = {
+const storageConfig = defineResourceSlider({
   icon: <Database className="text-gray-12" iconSize="xl-medium" />,
   title: "Storage",
   description: "Ephemeral disk space per instance",
   settingDescription:
-    "Dedicated EBS volume destroyed when the instance stops. Changes apply on next deploy. During beta, storage is limited to 10 GiB. Contact support@unkey.com for larger volumes.",
+    "We wipe this volume when the instance stops, so don't keep anything you need on it. Changes apply on next deploy. Contact support@unkey.com for larger volumes.",
   colorVar: "successA",
-  slider: { kind: "index-mapped", options: STORAGE_OPTIONS, fallback: 0 },
+  options: STORAGE_OPTIONS,
+  fallback: 0,
   formatValue: formatStorageParts,
-  readValue: (s) => s.storageMib,
-  writeValue: (draft, value) => {
+  read: (s) => s.storageMib,
+  write: (draft, value) => {
     draft.storageMib = value;
   },
-};
+  quotaKey: "maxStorageMibPerInstance",
+});
 
 export const Storage = () => <ResourceSliderSetting config={storageConfig} />;

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/settings/components/shared/resource-slider/index.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/settings/components/shared/resource-slider/index.ts
@@ -1,3 +1,7 @@
-export { ResourceSliderSetting, type ResourceSliderConfig } from "./resource-slider-setting";
+export {
+  ResourceSliderSetting,
+  type ResourceSliderConfig,
+  defineResourceSlider,
+} from "./resource-slider-setting";
 export { EnvironmentSliderSection } from "./environment-slider-section";
 export { indexToValue, valueToIndex } from "./slider-utils";

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/settings/components/shared/resource-slider/resource-slider-setting.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/settings/components/shared/resource-slider/resource-slider-setting.tsx
@@ -2,8 +2,11 @@
 
 import { collection } from "@/lib/collections";
 import type { EnvironmentSettings } from "@/lib/collections/deploy/environment-settings";
+import { freeTierQuotas } from "@/lib/quotas";
 import type { FormattedParts } from "@/lib/utils/deployment-formatters";
+import { useWorkspace } from "@/providers/workspace-provider";
 import { zodResolver } from "@hookform/resolvers/zod";
+import type { Quotas } from "@unkey/db";
 import { Slider } from "@unkey/ui";
 import type React from "react";
 import { useContext, useEffect, useMemo } from "react";
@@ -38,7 +41,126 @@ export type ResourceSliderConfig = {
   writeValue: (draft: EnvironmentSettings, value: number) => void;
   extraSaveChecks?: (settings: EnvironmentSettings[]) => SaveState | null;
   sliderAdornment?: (s: EnvironmentSettings) => React.ReactNode;
+  /**
+   * Returns the per-instance quota that caps this resource. Index-mapped sliders
+   * hide options above it, so the slider matches the workspace's real quota.
+   * Falls back to the default quota until quotas load.
+   */
+  resolveMax?: (quotas: Quotas | null) => number;
 };
+
+// Numeric quota columns a slider can bound to. Taken from freeTierQuotas so the
+// fallback lookup always resolves; that type omits pk and workspaceId.
+type PerInstanceQuotaKey = {
+  [K in keyof typeof freeTierQuotas]: (typeof freeTierQuotas)[K] extends number ? K : never;
+}[keyof typeof freeTierQuotas];
+
+function optionForValue(value: number, formatValue: (n: number) => FormattedParts) {
+  const parts = formatValue(value);
+  return { value, label: parts.unit ? `${parts.value} ${parts.unit}` : parts.value };
+}
+
+/**
+ * Bounds an index-mapped slider to the workspace quota. Drops options above the
+ * cap. When the cap is not already one of the options, adds it as the final stop
+ * so a raised quota is always reachable.
+ */
+function resolveStrategy(
+  strategy: SliderStrategy,
+  quotas: Quotas | null,
+  resolveMax: ResourceSliderConfig["resolveMax"],
+  formatValue: (n: number) => FormattedParts,
+): SliderStrategy {
+  if (strategy.kind !== "index-mapped" || !resolveMax) {
+    return strategy;
+  }
+  const max = resolveMax(quotas);
+  const withinQuota = strategy.options.filter((o) => o.value <= max);
+
+  // Quota sits below the lowest defined tier: the only coherent stop is the
+  // quota itself. Keeping the smallest tier here would offer a value above the
+  // cap and, once the quota is appended, produce an out-of-order list like
+  // [{250}, {100}]. Fall back to the smallest tier only for a non-positive cap,
+  // which can't happen for real quotas but keeps the option list non-empty.
+  if (withinQuota.length === 0) {
+    return {
+      ...strategy,
+      options: max > 0 ? [optionForValue(max, formatValue)] : strategy.options.slice(0, 1),
+    };
+  }
+
+  const options = [...withinQuota];
+  const top = options.at(-1);
+  if (top && max > 0 && top.value !== max) {
+    options.push(optionForValue(max, formatValue));
+  }
+  return { ...strategy, options };
+}
+
+/**
+ * Keeps stored values selectable. resolveStrategy rebuilds the option list from
+ * the quota alone, so a value saved under an old quota (e.g. 3000 saved when the
+ * cap was 3000, then raised to 5000) can fall off the list. valueToIndex would
+ * then return 0 and the thumb would render at the minimum while the label still
+ * shows the true value; the next drag auto-saves a silent downgrade. Re-inserting
+ * absent stored values and sorting ascending makes the thumb reflect what is
+ * stored and leaves any still-valid value selectable.
+ */
+function ensureValuesSelectable(
+  strategy: SliderStrategy,
+  values: number[],
+  formatValue: (n: number) => FormattedParts,
+): SliderStrategy {
+  if (strategy.kind !== "index-mapped") {
+    return strategy;
+  }
+  const present = new Set(strategy.options.map((o) => o.value));
+  const missing = [...new Set(values.filter((v) => v > 0 && !present.has(v)))];
+  if (missing.length === 0) {
+    return strategy;
+  }
+  const options = [...strategy.options, ...missing.map((v) => optionForValue(v, formatValue))];
+  options.sort((a, b) => a.value - b.value);
+  return { ...strategy, options };
+}
+
+type ResourceSliderDefinition = {
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+  settingDescription: string;
+  colorVar: string;
+  options: readonly { readonly label: string; readonly value: number }[];
+  fallback: number;
+  formatValue: (n: number) => FormattedParts;
+  read: (s: EnvironmentSettings) => number;
+  write: (draft: EnvironmentSettings, value: number) => void;
+  /**
+   * Quota column that caps this resource. The slider tops out at the workspace's
+   * value for this column, or the default quota until quotas load.
+   */
+  quotaKey: PerInstanceQuotaKey;
+};
+
+/**
+ * Builds a quota-bounded, index-mapped slider config. Callers pass the options,
+ * the quota column, and how to read and write the value. The slider strategy and
+ * quota fallback stay here.
+ */
+export function defineResourceSlider(definition: ResourceSliderDefinition): ResourceSliderConfig {
+  return {
+    icon: definition.icon,
+    title: definition.title,
+    description: definition.description,
+    settingDescription: definition.settingDescription,
+    colorVar: definition.colorVar,
+    slider: { kind: "index-mapped", options: definition.options, fallback: definition.fallback },
+    formatValue: definition.formatValue,
+    readValue: definition.read,
+    writeValue: definition.write,
+    resolveMax: (quotas) => quotas?.[definition.quotaKey] ?? freeTierQuotas[definition.quotaKey],
+  };
+}
 
 function getSliderProps(strategy: SliderStrategy, currentValue: number) {
   if (strategy.kind === "index-mapped") {
@@ -68,16 +190,25 @@ function getSliderProps(strategy: SliderStrategy, currentValue: number) {
 
 export const ResourceSliderSetting = ({ config }: { config: ResourceSliderConfig }) => {
   const envContext = useContext(EnvironmentContext);
+  const { quotas } = useWorkspace();
+
+  const effectiveConfig = useMemo<ResourceSliderConfig>(
+    () => ({
+      ...config,
+      slider: resolveStrategy(config.slider, quotas, config.resolveMax, config.formatValue),
+    }),
+    [config, quotas],
+  );
 
   if (!envContext) {
     throw new Error("ResourceSliderSetting must be used within EnvironmentProvider");
   }
 
   if (envContext.variant === "onboarding") {
-    return <SingleMode config={config} />;
+    return <SingleMode config={effectiveConfig} />;
   }
 
-  return <DualMode config={config} />;
+  return <DualMode config={effectiveConfig} />;
 };
 
 const singleSchema = z.object({ value: z.number() });
@@ -112,8 +243,13 @@ const SingleMode = ({ config }: { config: ResourceSliderConfig }) => {
     });
   };
 
+  const slider = useMemo(
+    () => ensureValuesSelectable(config.slider, [defaultValue], config.formatValue),
+    [config.slider, config.formatValue, defaultValue],
+  );
+
   const hasChanges = currentValue !== defaultValue;
-  const sp = getSliderProps(config.slider, currentValue);
+  const sp = getSliderProps(slider, currentValue);
 
   const extraCheck = config.extraSaveChecks?.([settings]);
   const saveState = resolveSaveState([
@@ -259,14 +395,13 @@ const DualInner = ({ config, production, preview }: DualInnerProps) => {
     [!hasChanges, { status: "disabled", reason: "No changes to save" }],
   ]);
 
-  const prodSp = useMemo(
-    () => getSliderProps(config.slider, currentProd),
-    [config.slider, currentProd],
+  const slider = useMemo(
+    () => ensureValuesSelectable(config.slider, [defaultProd, defaultPreview], config.formatValue),
+    [config.slider, config.formatValue, defaultProd, defaultPreview],
   );
-  const previewSp = useMemo(
-    () => getSliderProps(config.slider, currentPreview),
-    [config.slider, currentPreview],
-  );
+
+  const prodSp = useMemo(() => getSliderProps(slider, currentProd), [slider, currentProd]);
+  const previewSp = useMemo(() => getSliderProps(slider, currentPreview), [slider, currentPreview]);
 
   return (
     <FormSettingCard

--- a/web/apps/dashboard/lib/quotas.ts
+++ b/web/apps/dashboard/lib/quotas.ts
@@ -14,4 +14,5 @@ export const freeTierQuotas: Omit<Quotas, "workspaceId" | "pk"> = {
   maxMemoryMibPerInstance: 4096, // 4 GiB
   maxStorageMibPerInstance: 10240, // 10 GiB
   maxConcurrentBuilds: 1,
+  maxReplicasPerRegion: 4,
 };

--- a/web/apps/dashboard/lib/trpc/routers/deploy/environment-settings/runtime/update-instances.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/environment-settings/runtime/update-instances.ts
@@ -1,26 +1,18 @@
 import { and, db, eq } from "@/lib/db";
+import { freeTierQuotas } from "@/lib/quotas";
 import { TRPCError } from "@trpc/server";
-import { appRegionalSettings, horizontalAutoscalingPolicies } from "@unkey/db/src/schema";
+import { appRegionalSettings, horizontalAutoscalingPolicies, quotas } from "@unkey/db/src/schema";
 import { newId } from "@unkey/id";
 import { z } from "zod";
 import { workspaceProcedure } from "../../../../trpc";
-
-const REPLICAS_MAX_BETA = 4;
 
 export const updateInstances = workspaceProcedure
   .input(
     z
       .object({
         environmentId: z.string(),
-        replicasMin: z.number().int().min(1).max(REPLICAS_MAX_BETA),
-        replicasMax: z
-          .number()
-          .int()
-          .min(1)
-          .max(
-            REPLICAS_MAX_BETA,
-            "Instances are limited to 4 per region during beta. Please contact support@unkey.com if you need more.",
-          ),
+        replicasMin: z.number().int().min(1),
+        replicasMax: z.number().int().min(1),
       })
       .refine((d) => d.replicasMin <= d.replicasMax, {
         message: "replicasMin must be ≤ replicasMax",
@@ -28,6 +20,19 @@ export const updateInstances = workspaceProcedure
       }),
   )
   .mutation(async ({ ctx, input }) => {
+    const quota = await db.query.quotas.findFirst({
+      where: eq(quotas.workspaceId, ctx.workspace.id),
+      columns: { maxReplicasPerRegion: true },
+    });
+
+    const maxPerRegion = quota?.maxReplicasPerRegion ?? freeTierQuotas.maxReplicasPerRegion;
+    if (input.replicasMax > maxPerRegion) {
+      throw new TRPCError({
+        code: "BAD_REQUEST",
+        message: `Instances per region cannot exceed ${maxPerRegion}. Contact support@unkey.com to increase it.`,
+      });
+    }
+
     await db.transaction(async (tx) => {
       const regions = await tx.query.appRegionalSettings.findMany({
         where: and(

--- a/web/internal/db/src/schema/quota.ts
+++ b/web/internal/db/src/schema/quota.ts
@@ -114,6 +114,15 @@ export const quotas = mysqlTable("quota", {
   })
     .notNull()
     .default(1),
+
+  // maxReplicasPerRegion caps how many instances (replicas) a single environment
+  // can autoscale to within one region. The runtime "Instances" slider tops out
+  // at this value.
+  maxReplicasPerRegion: int("max_replicas_per_region", {
+    unsigned: true,
+  })
+    .notNull()
+    .default(4),
 });
 export const quotasRelations = relations(quotas, ({ one }) => ({
   workspace: one(workspaces, {


### PR DESCRIPTION
**Problem:**

The CPU, Memory, Storage, and Instances sliders in app runtime settings capped what you could select at hardcoded values (2 vCPU, 4 GiB, 10 GiB, 4 instances). The backend update-cpu/memory/storage mutations already validated against the real per-instance quota columns, so a workspace with a raised quota was accepted by the server but could not reach that value on the slider. Instances had no quota column at all: both UI and backend hardcoded a max of 4.

**Solution:**

CPU/Memory/Storage sliders now read the workspace quota from `useWorkspace().quotas` and bound their options to it. Options above the quota are dropped. When the quota is not one of the named tiers (a raised quota above the top tier or between tiers, e.g. 100 GiB), the exact quota value is added as the top stop, so any quota is reachable.

Instances gets a new quota column `max_replicas_per_region` (default 4). update-instances validates against it instead of the hardcoded `REPLICAS_MAX_BETA`, and the slider maxes at it.

<img width="1888" height="3218" alt="quota-after-raised" src="https://github.com/user-attachments/assets/e5319f0e-8ca9-4240-b349-32a6a85e9401" />

<img width="1888" height="3218" alt="quota-before-default" src="https://github.com/user-attachments/assets/4420361b-c136-405a-83bd-6d122deb1cf0" />




**Impact:**

Adds column `max_replicas_per_region` to the quota table (NOT NULL default 4). Must be applied before deploy: `getCurrentWorkspace` selects the quotas relation, so the column has to exist. Local dev and the free-quota seed (`freeTierQuotas`, used by the Stripe downgrade path) both set it to 4.

Behavior neutral for workspaces at the default quota: ranges are unchanged. Raising any per-instance quota column now lifts the matching slider.

**Testing:**

- `tsc --noEmit` on the dashboard: clean, 0 errors.
- Drove local dev against a workspace, toggling its quota row and reloading the settings page.

| | Before (default quota) | After (raised quota) |
|---|---|---|
| Max CPU | 2 vCPU | 32 vCPU |
| Memory | 4 GiB | 32 GiB |
| Storage | 10 GiB | 100 GiB |
| Instances | limited to 4 per region | limited to 12 per region |

The 100 GiB stop confirms the exact-quota append path, since 100 GiB is not a named tier.
