### PR TITLE
refactor(portal): authorize exact capabilities

### DIFF
--- a/pkg/auth/portal_session/resolver.go
+++ b/pkg/auth/portal_session/resolver.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 
 	"github.com/unkeyed/unkey/internal/services/portal"
-	"github.com/unkeyed/unkey/pkg/auth/portalrbac"
 	"github.com/unkeyed/unkey/pkg/auth/principal"
 	"github.com/unkeyed/unkey/pkg/zen"
 )
@@ -46,20 +45,6 @@ func (r *Resolver) Resolve(ctx context.Context, sess *zen.Session) (*principal.P
 		return nil, err
 	}
 
-	// Translate the session's simplified capability model (keyspace ids + verbs)
-	// into the RBAC permission strings the shared handlers check. This is the one
-	// place the portal capability vocabulary is mapped onto RBAC — see the
-	// portalrbac package.
-	capabilities, err := portalrbac.ParseAll(session.Permissions)
-	if err != nil {
-		return nil, err
-	}
-	permissions := portalrbac.Grant{
-		WorkspaceID:  session.WorkspaceID,
-		KeyspaceIDs:  session.KeyspaceIDs,
-		Capabilities: capabilities,
-	}.Expand()
-
 	return &principal.Principal{
 		Version: principal.Version,
 		Subject: principal.Subject{
@@ -73,9 +58,9 @@ func (r *Resolver) Resolve(ctx context.Context, sess *zen.Session) (*principal.P
 			PortalConfigID: session.PortalConfigID,
 			ExternalID:     session.ExternalID,
 			KeyspaceIDs:    session.KeyspaceIDs,
-			Permissions:    permissions,
+			Permissions:    session.Permissions,
 		},
 		WorkspaceID: session.WorkspaceID,
-		Permissions: permissions,
+		Permissions: session.Permissions,
 	}, nil
 }

--- a/pkg/auth/portal_session/resolver_test.go
+++ b/pkg/auth/portal_session/resolver_test.go
@@ -57,13 +57,9 @@ func TestResolver_ResolvePortalCookie(t *testing.T) {
 	require.Equal(t, "portal_session_123", source.SessionID)
 	require.Equal(t, "pc_123", source.PortalConfigID)
 
-	// The resolver expands the simplified capability model into RBAC strings via
-	// portalrbac; the principal must carry the expanded permissions, not the verbs.
-	expected := portalrbac.Grant{
-		WorkspaceID:  "ws_123",
-		KeyspaceIDs:  []string{"ks_1"},
-		Capabilities: []portalrbac.Capability{portalrbac.CapKeysReroll},
-	}.Expand()
+	// Portal principals carry the product capability directly. Resource scope is
+	// enforced separately by portal handlers.
+	expected := []string{portalrbac.CapKeysReroll}
 	require.Equal(t, expected, source.Permissions)
 	require.Equal(t, expected, principal.Permissions)
 }

--- a/pkg/auth/portalrbac/portalrbac.go
+++ b/pkg/auth/portalrbac/portalrbac.go
@@ -1,143 +1,21 @@
-// Package portalrbac is the single translation seam between the portal's
-// simplified, public-facing permission model and the RBAC mechanism that
-// actually enforces access.
+// Package portalrbac defines the portal's public capability vocabulary.
 //
 // A workspace owner creates a portal session with a small, stable vocabulary of
 // capabilities ("keys:read", "keys:reroll", ...) scoped to a set of keyspaces.
-// That simplified grant is what gets persisted on the session and what the
-// public API exposes. Enforcement, however, currently reuses the existing
-// keyspace-scoped URN permissions checked by the shared key handlers.
-//
-// Keeping the mapping here — invoked once, when a session principal is resolved
-// — means:
-//
-//   - The persisted/public form never leaks the enforcement representation, so
-//     the mapping can change without migrating stored sessions.
-//   - Handlers stay ignorant of "portal": they keep authorizing against ordinary
-//     RBAC permission strings.
-//   - To later run a bespoke portal RBAC instead of the shared URN system, only
-//     this package changes (swap [Expand] for an alternative [Authorizer], and
-//     have the portal route wrappers consult it directly).
+// Portal handlers authorize these capabilities directly and separately enforce
+// the session's workspace, keyspace, and external identity scope.
 package portalrbac
-
-import (
-	"fmt"
-
-	"github.com/unkeyed/unkey/pkg/rbac"
-	"github.com/unkeyed/unkey/pkg/rbac/permissions"
-	"github.com/unkeyed/unkey/pkg/urn"
-)
-
-// Capability is one entry in the portal's simplified permission vocabulary. It
-// is intentionally coarse and product-oriented; the fine-grained RBAC actions it
-// maps to are an implementation detail owned by this package.
-type Capability string
 
 const (
 	// CapKeysRead lets the end user list and read their own keys.
-	CapKeysRead Capability = "keys:read"
+	CapKeysRead = "keys:read"
 
 	// CapKeysCreate lets the end user create new keys.
-	CapKeysCreate Capability = "keys:create"
+	CapKeysCreate = "keys:create"
 
 	// CapKeysReroll lets the end user rotate the secret of an existing key.
-	CapKeysReroll Capability = "keys:reroll"
+	CapKeysReroll = "keys:reroll"
 
-	// CapAnalyticsRead lets the end user read verification analytics.
-	CapAnalyticsRead Capability = "analytics:read"
+	// CapAnalyticsRead lets the end user read their verification analytics.
+	CapAnalyticsRead = "analytics:read"
 )
-
-// Parse validates a raw capability string and returns the typed Capability.
-// Callers should use this at the API boundary (portal.createSession) to reject
-// unknown verbs before they are ever persisted.
-func Parse(s string) (Capability, error) {
-	switch Capability(s) {
-	case CapKeysRead, CapKeysCreate, CapKeysReroll, CapAnalyticsRead:
-		return Capability(s), nil
-	default:
-		return "", fmt.Errorf("unknown portal capability %q", s)
-	}
-}
-
-// ParseAll validates a slice of raw capability strings, returning the first
-// error encountered.
-func ParseAll(raw []string) ([]Capability, error) {
-	caps := make([]Capability, 0, len(raw))
-	for _, s := range raw {
-		c, err := Parse(s)
-		if err != nil {
-			return nil, err
-		}
-		caps = append(caps, c)
-	}
-	return caps, nil
-}
-
-// Grant is the simplified authorization a portal session carries: a set of
-// capabilities scoped to a set of keyspaces within one workspace.
-type Grant struct {
-	WorkspaceID  string
-	KeyspaceIDs  []string
-	Capabilities []Capability
-}
-
-// Expand translates a Grant into the concrete RBAC permission strings the shared
-// key/analytics handlers authorize against. The strings are built with the same
-// urn + permission primitives the handlers use in their rbac.U/rbac.T queries,
-// so they match by construction (see portalrbac_test.go, which checks Expand's
-// output against the real handler queries).
-//
-// Key capabilities are keyspace-scoped: each is expanded once per keyspace in
-// the grant. Analytics is workspace-wide and expands to a single wildcard tuple.
-func (g Grant) Expand() []string {
-	var granted []string
-
-	for _, c := range g.Capabilities {
-		switch c {
-		case CapKeysRead:
-			// listKeys requires read_key on the keyspace's keys AND read_keyspace
-			// on the keyspace itself.
-			for _, ks := range g.KeyspaceIDs {
-				granted = append(granted,
-					unkeyPerm(urn.New().Workspace(g.WorkspaceID).Keyspace(ks).Key("*"), permissions.ReadKey{}),
-					unkeyPerm(urn.New().Workspace(g.WorkspaceID).Keyspace(ks), permissions.ReadKeyspace{}),
-				)
-			}
-
-		case CapKeysCreate:
-			for _, ks := range g.KeyspaceIDs {
-				granted = append(granted,
-					unkeyPerm(urn.New().Workspace(g.WorkspaceID).Keyspace(ks), permissions.CreateKey{}),
-				)
-			}
-
-		case CapKeysReroll:
-			// Reroll is authorized as create_key today (it mints a fresh key), plus
-			// encrypt_key so recoverable keys can be rotated. When reroll gets its
-			// own RBAC action, only this arm changes.
-			for _, ks := range g.KeyspaceIDs {
-				granted = append(granted,
-					unkeyPerm(urn.New().Workspace(g.WorkspaceID).Keyspace(ks), permissions.CreateKey{}),
-					unkeyPerm(urn.New().Workspace(g.WorkspaceID).Keyspace(ks).Key("*"), permissions.EncryptKey{}),
-				)
-			}
-
-		case CapAnalyticsRead:
-			// Analytics is not keyspace-scoped; the portal getVerifications handler
-			// checks the wildcard api tuple.
-			granted = append(granted, rbac.Tuple{
-				ResourceType: rbac.Api,
-				ResourceID:   "*",
-				Action:       rbac.ReadAnalytics,
-			}.String())
-		}
-	}
-
-	return granted
-}
-
-// unkeyPerm renders a keyspace/key-scoped URN permission string in the exact
-// format rbac.U produces, so granted strings match the handler queries.
-func unkeyPerm(resource fmt.Stringer, action fmt.Stringer) string {
-	return fmt.Sprintf("%s#%s", resource.String(), action.String())
-}

--- a/pkg/auth/portalrbac/portalrbac_test.go
+++ b/pkg/auth/portalrbac/portalrbac_test.go
@@ -7,74 +7,18 @@ import (
 
 	"github.com/unkeyed/unkey/pkg/auth/portalrbac"
 	"github.com/unkeyed/unkey/pkg/rbac"
-	"github.com/unkeyed/unkey/pkg/rbac/permissions"
-	"github.com/unkeyed/unkey/pkg/urn"
 )
 
-const (
-	ws  = "ws_123"
-	ks1 = "ks_111"
-	ks2 = "ks_222"
-)
+func TestCapabilitiesUseExactMatching(t *testing.T) {
+	granted := []string{
+		portalrbac.CapKeysRead,
+		portalrbac.CapKeysCreate,
+		portalrbac.CapAnalyticsRead,
+	}
 
-// These queries mirror the URN legs the shared handlers authorize against, so a
-// passing rbac.Check proves Expand's output actually satisfies them.
-func listKeysQuery(ks string) rbac.PermissionQuery {
-	return rbac.And(
-		rbac.U(urn.New().Workspace(ws).Keyspace(ks).Key("*"), permissions.ReadKey{}),
-		rbac.U(urn.New().Workspace(ws).Keyspace(ks), permissions.ReadKeyspace{}),
-	)
-}
-
-func rerollQuery(ks string) rbac.PermissionQuery {
-	return rbac.U(urn.New().Workspace(ws).Keyspace(ks), permissions.CreateKey{})
-}
-
-func analyticsQuery() rbac.PermissionQuery {
-	return rbac.T(rbac.Tuple{ResourceType: rbac.Api, ResourceID: "*", Action: rbac.ReadAnalytics})
-}
-
-func TestParseRejectsUnknownCapability(t *testing.T) {
-	_, err := portalrbac.Parse("keys:destroy")
-	require.Error(t, err)
-
-	c, err := portalrbac.Parse("keys:reroll")
-	require.NoError(t, err)
-	require.Equal(t, portalrbac.CapKeysReroll, c)
-}
-
-func TestExpandSatisfiesHandlerQueries(t *testing.T) {
-	granted := portalrbac.Grant{
-		WorkspaceID:  ws,
-		KeyspaceIDs:  []string{ks1},
-		Capabilities: []portalrbac.Capability{portalrbac.CapKeysRead, portalrbac.CapKeysReroll, portalrbac.CapAnalyticsRead},
-	}.Expand()
-
-	require.NoError(t, rbac.Check(listKeysQuery(ks1), granted), "keys:read should satisfy listKeys")
-	require.NoError(t, rbac.Check(rerollQuery(ks1), granted), "keys:reroll should satisfy reroll")
-	require.NoError(t, rbac.Check(analyticsQuery(), granted), "analytics:read should satisfy getVerifications")
-}
-
-func TestExpandIsScopedToGrantedKeyspaces(t *testing.T) {
-	granted := portalrbac.Grant{
-		WorkspaceID:  ws,
-		KeyspaceIDs:  []string{ks1},
-		Capabilities: []portalrbac.Capability{portalrbac.CapKeysReroll},
-	}.Expand()
-
-	require.NoError(t, rbac.Check(rerollQuery(ks1), granted), "reroll allowed on granted keyspace")
-	require.Error(t, rbac.Check(rerollQuery(ks2), granted), "reroll must be denied on a keyspace not in the grant")
-}
-
-func TestExpandDoesNotOvergrant(t *testing.T) {
-	// A read-only grant must not satisfy a reroll (create_key) query.
-	granted := portalrbac.Grant{
-		WorkspaceID:  ws,
-		KeyspaceIDs:  []string{ks1},
-		Capabilities: []portalrbac.Capability{portalrbac.CapKeysRead},
-	}.Expand()
-
-	require.NoError(t, rbac.Check(listKeysQuery(ks1), granted))
-	require.Error(t, rbac.Check(rerollQuery(ks1), granted), "read-only grant must not allow reroll")
-	require.Error(t, rbac.Check(analyticsQuery(), granted), "read-only grant must not allow analytics")
+	require.NoError(t, rbac.Check(rbac.S(portalrbac.CapKeysRead), granted))
+	require.NoError(t, rbac.Check(rbac.S(portalrbac.CapKeysCreate), granted))
+	require.NoError(t, rbac.Check(rbac.S(portalrbac.CapAnalyticsRead), granted))
+	require.Error(t, rbac.Check(rbac.S(portalrbac.CapKeysReroll), granted),
+		"keys:create must not imply keys:reroll")
 }

--- a/pkg/auth/principal/principal.go
+++ b/pkg/auth/principal/principal.go
@@ -55,7 +55,7 @@ type Principal struct {
 	// WorkspaceID scopes all handler reads and writes for this principal.
 	WorkspaceID string
 
-	// Permissions is the flat RBAC permission set granted to this principal.
+	// Permissions is the flat set of exact or resource-scoped authorization grants.
 	Permissions []string
 }
 
@@ -140,7 +140,7 @@ type PortalSessionSource struct {
 	// these; the request never carries a keyspace or api id.
 	KeyspaceIDs []string
 
-	// Permissions are the raw RBAC permission strings attached to the portal session.
+	// Permissions are the capabilities attached to the portal session.
 	Permissions []string
 }
 

--- a/svc/api/routes/v2_portal_get_verifications/200_test.go
+++ b/svc/api/routes/v2_portal_get_verifications/200_test.go
@@ -214,11 +214,9 @@ func TestPortalSessionAnalyticsKeyIdFilter(t *testing.T) {
 	}, 30*time.Second, time.Second)
 }
 
-// TestPortalSessionAnalyticsRequiresReadAnalytics verifies that a portal session
-// whose permissions do not include a read_analytics grant is rejected, even
-// though the endpoint is otherwise scoped to its own identity. The workspace
-// owner gates analytics access via the session permissions.
-func TestPortalSessionAnalyticsRequiresReadAnalytics(t *testing.T) {
+// TestPortalSessionAnalyticsRequiresAnalyticsRead verifies that reading keys
+// does not implicitly grant access to analytics.
+func TestPortalSessionAnalyticsRequiresAnalyticsRead(t *testing.T) {
 	// No ClickHouse needed: the handler rejects on the permission check before it
 	// ever queries analytics.
 	h := testutil.NewHarness(t, testutil.HarnessConfig{})
@@ -227,15 +225,17 @@ func TestPortalSessionAnalyticsRequiresReadAnalytics(t *testing.T) {
 	route := newHandler(h)
 	h.Register(route, h.PortalMiddleware()...)
 
-	// Session granted key access but not analytics.
 	headers := h.CreatePortalSession(workspace.ID, "portal_user_A", []string{"ks_none"}, []string{"keys:read"})
 
 	now := time.Now().UnixMilli()
-	res := testutil.CallRoute[Request, Response](h, route, headers, Request{
+	res := testutil.CallRoute[Request, openapi.ForbiddenErrorResponse](h, route, headers, Request{
 		StartTime: now - int64(time.Hour/time.Millisecond),
 		EndTime:   now + int64(time.Minute/time.Millisecond),
 	})
 
 	require.Equal(t, 403, res.Status,
-		"portal session without read_analytics must be forbidden from reading analytics")
+		"portal session without analytics:read must be forbidden from reading analytics")
+	require.NotContains(t, res.RawBody, workspace.ID)
+	require.NotContains(t, res.RawBody, "portal_user_A")
+	require.NotContains(t, res.RawBody, "ks_none")
 }

--- a/svc/api/routes/v2_portal_get_verifications/handler.go
+++ b/svc/api/routes/v2_portal_get_verifications/handler.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/unkeyed/unkey/internal/services/caches"
 	keysdb "github.com/unkeyed/unkey/internal/services/keys/db"
+	"github.com/unkeyed/unkey/pkg/auth/portalrbac"
 	"github.com/unkeyed/unkey/pkg/cache"
 	"github.com/unkeyed/unkey/pkg/clickhouse"
 	"github.com/unkeyed/unkey/pkg/codes"
@@ -58,16 +59,9 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	// The workspace owner controls whether a portal session may read analytics by
-	// including a read_analytics grant in the session permissions. Identity scoping
-	// already restricts *what* is returned to the session's own events; this gates
-	// whether analytics is exposed to this end user at all. The query spans all of
-	// the identity's keys across every API, so require the wildcard grant.
-	err = principal.Authorize(rbac.T(rbac.Tuple{
-		ResourceType: rbac.Api,
-		ResourceID:   "*",
-		Action:       rbac.ReadAnalytics,
-	}))
+	// Capability and identity scope are separate: this gates the action while the
+	// ClickHouse query below fixes the visible data to the session external ID.
+	err = principal.Authorize(rbac.S(portalrbac.CapAnalyticsRead))
 	if err != nil {
 		return err
 	}

--- a/svc/api/routes/v2_portal_list_keys/200_test.go
+++ b/svc/api/routes/v2_portal_list_keys/200_test.go
@@ -141,6 +141,30 @@ func TestPortalSessionScopesToOwnExternalID(t *testing.T) {
 	require.True(t, returnedIDs[setup.key2ID], "key2 should be in results")
 }
 
+// TestPortalSessionListKeysRequiresKeysRead guarantees that another key
+// capability cannot expose identity or key data through the listing endpoint.
+func TestPortalSessionListKeysRequiresKeysRead(t *testing.T) {
+	h := testutil.NewHarness(t)
+
+	route := newHandler(h)
+	h.Register(route, h.PortalMiddleware()...)
+
+	setup := setupPortalSessionTest(t, h)
+	headers := h.CreatePortalSession(
+		setup.workspace.ID,
+		setup.identity1ExternalID,
+		[]string{setup.keySpaceID},
+		[]string{"keys:reroll"},
+	)
+
+	res := testutil.CallRoute[Request, openapi.ForbiddenErrorResponse](h, route, headers, Request{})
+
+	require.Equal(t, 403, res.Status, "keys:reroll must not authorize portal.listKeys")
+	require.NotContains(t, res.RawBody, setup.workspace.ID)
+	require.NotContains(t, res.RawBody, setup.identity1ExternalID)
+	require.NotContains(t, res.RawBody, setup.key1ID)
+}
+
 func TestPortalSessionUnionsConfiguredKeyspaces(t *testing.T) {
 	h := testutil.NewHarness(t)
 

--- a/svc/api/routes/v2_portal_list_keys/handler.go
+++ b/svc/api/routes/v2_portal_list_keys/handler.go
@@ -7,12 +7,11 @@ import (
 	"sort"
 
 	"github.com/unkeyed/unkey/pkg/array"
+	"github.com/unkeyed/unkey/pkg/auth/portalrbac"
 	"github.com/unkeyed/unkey/pkg/codes"
 	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/fault"
 	"github.com/unkeyed/unkey/pkg/rbac"
-	"github.com/unkeyed/unkey/pkg/rbac/permissions"
-	"github.com/unkeyed/unkey/pkg/urn"
 	"github.com/unkeyed/unkey/pkg/zen"
 	"github.com/unkeyed/unkey/svc/api/internal/pagination"
 	"github.com/unkeyed/unkey/svc/api/internal/portalscope"
@@ -73,23 +72,13 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 	p := pagination.Parse(req.Limit, req.Cursor, 100)
 
-	// A session with no keyspaces (e.g. analytics only) can never see any keys.
-	if len(keyspaceIDs) == 0 {
-		return h.emptyResponse(s)
+	if err := principal.Authorize(rbac.S(portalrbac.CapKeysRead)); err != nil {
+		return err
 	}
 
-	// The session may only list keys in keyspaces it was granted keys:read on.
-	// These are the same keyspaces the grant scoped, so this passes iff the
-	// session carries keys:read and fails closed for an analytics-only session.
-	keyReadChecks := make([]rbac.PermissionQuery, 0, len(keyspaceIDs))
-	for _, ks := range keyspaceIDs {
-		keyReadChecks = append(keyReadChecks, rbac.And(
-			rbac.U(urn.New().Workspace(principal.WorkspaceID).Keyspace(ks).Key("*"), permissions.ReadKey{}),
-			rbac.U(urn.New().Workspace(principal.WorkspaceID).Keyspace(ks), permissions.ReadKeyspace{}),
-		))
-	}
-	if err := principal.Authorize(rbac.And(keyReadChecks...)); err != nil {
-		return err
+	// A session with no keyspaces can never see any keys.
+	if len(keyspaceIDs) == 0 {
+		return h.emptyResponse(s)
 	}
 
 	// Scope to the end user's own keys. If the identity does not exist yet, the


### PR DESCRIPTION
## Summary

- reduce `pkg/auth/portalrbac` to the four untyped public capability constants
- pass persisted portal session permissions directly into the principal without parsing, validation, cloning, or URN expansion
- authorize `portal.listKeys` with exact `keys:read` and `portal.getVerifications` with exact `analytics:read`
- preserve workspace, configured keyspace, and external identity scoping in the existing handlers

This removes the URN translation layer. Portal handlers now check the product capability strings stored on the session instead of translating them into resource permissions or wildcard tuples.

## Tests

- `mise exec -- rask ./pkg/auth/portalrbac`
- `mise exec -- rask ./pkg/auth/portal_session`
- `mise exec -- rask ./svc/api/routes/v2_portal_list_keys`
- `mise exec -- rask ./svc/api/routes/v2_portal_get_verifications`
- `mise run build`
- `git diff --check`

## Caveat

This PR intentionally leaves the ClickHouse verification request unchanged. Analytics remains scoped by workspace and external ID, but configured keyspace filtering belongs in the separate stacked analytics-scope PR.