### PR TITLE
fix(portal): align capability contract

### DIFF
--- a/dev/portal-local-testing.md
+++ b/dev/portal-local-testing.md
@@ -92,7 +92,7 @@ The portal is port-forwarded to `http://localhost:3100`.
 curl -s -X POST http://localhost:7070/v2/portal.createSession \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer <ROOT_KEY>" \
-  -d '{"slug": "awesome", "externalId": "user_123", "permissions": ["api.*.read_key", "api.*.create_key", "api.*.read_analytics"]}'
+  -d '{"slug": "awesome", "externalId": "user_123", "permissions": ["keys:read", "keys:create", "keys:reroll", "analytics:read"]}'
 ```
 
 Open `http://localhost:3100/?session=pst_xxx` in the browser.
@@ -124,7 +124,7 @@ Runs on `http://localhost:3100`. Port 3100 avoids conflict with the dashboard.
 curl -s -X POST http://localhost:7070/v2/portal.createSession \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer <ROOT_KEY>" \
-  -d '{"slug": "awesome", "externalId": "user_123", "permissions": ["api.*.read_key", "api.*.create_key", "api.*.read_analytics"]}'
+  -d '{"slug": "awesome", "externalId": "user_123", "permissions": ["keys:read", "keys:create", "keys:reroll", "analytics:read"]}'
 ```
 
 Take the `sessionId` from the response and open:
@@ -180,7 +180,7 @@ like `<app-slug>-<env>.unkey.com`.
 curl -s -X POST https://api.unkey.dev/v2/portal.createSession \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer <ROOT_KEY>" \
-  -d '{"slug": "<YOUR_SLUG>", "externalId": "user_123", "permissions": ["api.*.read_key", "api.*.create_key", "api.*.read_analytics"]}'
+  -d '{"slug": "<YOUR_SLUG>", "externalId": "user_123", "permissions": ["keys:read", "keys:create", "keys:reroll", "analytics:read"]}'
 ```
 
 The response URL will point to the portal's deployment URL (or custom

--- a/docs/product/errors/unkey/authentication/portal_session_not_found.mdx
+++ b/docs/product/errors/unkey/authentication/portal_session_not_found.mdx
@@ -38,7 +38,7 @@ curl -X POST https://api.unkey.com/v2/portal.createSession \
   -d '{
     "slug": "my-portal",
     "externalId": "user_123",
-    "permissions": ["api.*.read_key", "api.*.read_analytics"]
+    "permissions": ["keys:read"]
   }'
 ```
 

--- a/docs/product/errors/unkey/authentication/portal_token_missing.mdx
+++ b/docs/product/errors/unkey/authentication/portal_token_missing.mdx
@@ -48,7 +48,7 @@ curl -X POST https://api.unkey.com/v2/portal.createSession \
   -d '{
     "slug": "my-portal",
     "externalId": "user_123",
-    "permissions": ["api.*.read_key"]
+    "permissions": ["keys:read"]
   }'
 ```
 

--- a/docs/product/errors/unkey/data/portal_config_not_found.mdx
+++ b/docs/product/errors/unkey/data/portal_config_not_found.mdx
@@ -44,7 +44,7 @@ curl -X POST https://api.unkey.com/v2/portal.createSession \
   -d '{
     "slug": "my-portal",
     "externalId": "user_123",
-    "permissions": ["api.*.read_key"]
+    "permissions": ["keys:read"]
   }'
 ```
 

--- a/docs/product/quickstart/portal.mdx
+++ b/docs/product/quickstart/portal.mdx
@@ -59,7 +59,7 @@ curl -X POST https://api.unkey.com/v2/portal.createSession \
   -d '{
     "slug": "my-portal",
     "externalId": "user_123",
-    "permissions": ["api.*.read_key", "api.*.create_key", "api.*.read_analytics"]
+    "permissions": ["keys:read", "keys:create", "keys:reroll", "analytics:read"]
   }'
 ```
 
@@ -73,7 +73,7 @@ const response = await fetch("https://api.unkey.com/v2/portal.createSession", {
   body: JSON.stringify({
     slug: "my-portal",
     externalId: "user_123",
-    permissions: ["api.*.read_key", "api.*.create_key", "api.*.read_analytics"],
+    permissions: ["keys:read", "keys:create", "keys:reroll", "analytics:read"],
   }),
 });
 
@@ -88,7 +88,7 @@ const { data } = await response.json();
 body := map[string]any{
     "slug":        "my-portal",
     "externalId":  "user_123",
-    "permissions": []string{"api.*.read_key", "api.*.create_key", "api.*.read_analytics"},
+    "permissions": []string{"keys:read", "keys:create", "keys:reroll", "analytics:read"},
 }
 ```
 
@@ -128,7 +128,7 @@ curl -X POST https://api.unkey.com/v2/portal.createSession \
   -d '{
     "slug": "my-portal",
     "externalId": "user_123",
-    "permissions": ["api.*.read_key", "api.*.read_analytics"],
+    "permissions": ["keys:read", "analytics:read"],
     "preview": true
   }'
 ```
@@ -149,21 +149,19 @@ The portal will:
 
 ## Permissions and tabs
 
-Permissions use the RBAC tuple format `{resourceType}.{resourceId}.{action}`. Use `*` as the resourceId to grant access to all resources of that type.
+Permissions use a fixed capability vocabulary. The portal configuration and
+session identity determine which keys and analytics the user can access.
 
-Tab visibility is derived from the action segment (third part) of each permission:
+| Capability | Access |
+|------------|--------|
+| `keys:read` | API Keys |
+| `keys:create` | API Keys |
+| `keys:reroll` | API Keys |
+| `analytics:read` | Analytics |
+| Any capability present | Documentation |
 
-| Action | Tab |
-|--------|-----|
-| `read_key`, `create_key`, `update_key`, `delete_key` | API Keys |
-| `read_analytics` | Analytics |
-| Any permission present | Documentation |
-
-Examples:
-- `api.*.read_key` → shows the Keys tab
-- `api.api_123.create_key` → shows the Keys tab (specific resource)
-- `api.*.read_analytics` → shows the Analytics tab
-- Docs tab is visible whenever at least one permission is present
+All key and analytics operations remain limited to the configured keyspaces and
+the session's `externalId`.
 
 The API requires at least one permission. An empty permissions array is rejected with HTTP 400.
 

--- a/svc/api/openapi/gen.go
+++ b/svc/api/openapi/gen.go
@@ -2642,9 +2642,9 @@ type V2PortalCreateSessionRequestBody struct {
 	// Permissions The capabilities granted to the end user in the Portal, from a fixed
 	// vocabulary. All capabilities are scoped to this end user: key capabilities
 	// (`keys:*`) apply only to keys the end user owns within the keyspace
-	// configured on the portal configuration, and `analytics:read` returns only
-	// the end user's own verification events. An end user can never see another
-	// identity's keys or analytics.
+	// configured on the portal configuration. `analytics:read` grants access to
+	// the end user's own verification analytics within those keyspaces. An end
+	// user can never see another identity's keys or analytics.
 	//
 	// Tab visibility is derived from the capabilities:
 	// - Keys tab: any `keys:*` capability

--- a/svc/api/openapi/openapi-generated.yaml
+++ b/svc/api/openapi/openapi-generated.yaml
@@ -2393,9 +2393,9 @@ components:
                         The capabilities granted to the end user in the Portal, from a fixed
                         vocabulary. All capabilities are scoped to this end user: key capabilities
                         (`keys:*`) apply only to keys the end user owns within the keyspace
-                        configured on the portal configuration, and `analytics:read` returns only
-                        the end user's own verification events. An end user can never see another
-                        identity's keys or analytics.
+                        configured on the portal configuration. `analytics:read` grants access to
+                        the end user's own verification analytics within those keyspaces. An end
+                        user can never see another identity's keys or analytics.
 
                         Tab visibility is derived from the capabilities:
                         - Keys tab: any `keys:*` capability

--- a/svc/api/openapi/spec/paths/v2/portal/createSession/V2PortalCreateSessionRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/portal/createSession/V2PortalCreateSessionRequestBody.yaml
@@ -37,9 +37,9 @@ properties:
       The capabilities granted to the end user in the Portal, from a fixed
       vocabulary. All capabilities are scoped to this end user: key capabilities
       (`keys:*`) apply only to keys the end user owns within the keyspace
-      configured on the portal configuration, and `analytics:read` returns only
-      the end user's own verification events. An end user can never see another
-      identity's keys or analytics.
+      configured on the portal configuration. `analytics:read` grants access to
+      the end user's own verification analytics within those keyspaces. An end
+      user can never see another identity's keys or analytics.
 
       Tab visibility is derived from the capabilities:
       - Keys tab: any `keys:*` capability

--- a/web/apps/portal/src/components/portal-header.tsx
+++ b/web/apps/portal/src/components/portal-header.tsx
@@ -1,8 +1,9 @@
 import { Link, useLocation } from "@tanstack/react-router";
+import type { PortalCapability } from "~/lib/capabilities";
 import { deriveVisibleTabs } from "~/lib/permissions";
 
 type PortalHeaderProps = {
-  permissions: string[];
+  permissions: ReadonlyArray<PortalCapability>;
   logoUrl?: string;
 };
 

--- a/web/apps/portal/src/lib/capabilities.ts
+++ b/web/apps/portal/src/lib/capabilities.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+
+/** Capabilities accepted in persisted portal session grants. */
+export const PORTAL_CAPABILITIES = [
+  "keys:read",
+  "keys:create",
+  "keys:reroll",
+  "analytics:read",
+] as const;
+
+const portalCapabilitySchema = z.enum(PORTAL_CAPABILITIES);
+
+/** One product action granted to a portal session. */
+export type PortalCapability = z.infer<typeof portalCapabilitySchema>;
+
+/** Validates the complete authorization grant stored on a portal session. */
+export const portalSessionGrantSchema = z.object({
+  keyspaceIds: z.array(z.string().min(1)),
+  permissions: z.array(portalCapabilitySchema).min(1),
+});

--- a/web/apps/portal/src/lib/permissions.test.ts
+++ b/web/apps/portal/src/lib/permissions.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from "vitest";
+import { portalSessionGrantSchema } from "./capabilities";
 import { deriveVisibleTabs } from "./permissions";
 
 describe("deriveVisibleTabs", () => {
-  it("shows Keys and Docs tabs for key read permission", () => {
-    const tabs = deriveVisibleTabs(["api.*.read_key"]);
+  it("shows Keys and Docs tabs for keys:read", () => {
+    const tabs = deriveVisibleTabs(["keys:read"]);
     const ids = tabs.map((t) => t.id);
 
     expect(ids).toContain("keys");
@@ -11,8 +12,8 @@ describe("deriveVisibleTabs", () => {
     expect(ids).not.toContain("analytics");
   });
 
-  it("shows Analytics and Docs tabs for analytics permission", () => {
-    const tabs = deriveVisibleTabs(["api.*.read_analytics"]);
+  it("shows Analytics and Docs tabs for analytics:read", () => {
+    const tabs = deriveVisibleTabs(["analytics:read"]);
     const ids = tabs.map((t) => t.id);
 
     expect(ids).toContain("analytics");
@@ -20,17 +21,8 @@ describe("deriveVisibleTabs", () => {
     expect(ids).not.toContain("keys");
   });
 
-  it("shows Keys, Analytics, and Docs tabs for all permissions", () => {
-    const tabs = deriveVisibleTabs(["api.*.read_key", "api.*.create_key", "api.*.read_analytics"]);
-    const ids = tabs.map((t) => t.id);
-
-    expect(ids).toContain("keys");
-    expect(ids).toContain("analytics");
-    expect(ids).toContain("docs");
-  });
-
-  it("shows Keys and Docs tabs for specific resource ID", () => {
-    const tabs = deriveVisibleTabs(["api.api_123.read_key"]);
+  it("shows Keys and Docs tabs for non-read key capabilities", () => {
+    const tabs = deriveVisibleTabs(["keys:create", "keys:reroll"]);
     const ids = tabs.map((t) => t.id);
 
     expect(ids).toContain("keys");
@@ -38,24 +30,30 @@ describe("deriveVisibleTabs", () => {
     expect(ids).not.toContain("analytics");
   });
 
-  it("shows only Docs tab for non-matching action", () => {
-    const tabs = deriveVisibleTabs(["ratelimit.*.limit"]);
-    const ids = tabs.map((t) => t.id);
-
-    expect(ids).toEqual(["docs"]);
-  });
-
-  it("shows only Docs tab for malformed permission with fewer than 3 segments", () => {
-    const tabs = deriveVisibleTabs(["keys:read"]);
-    const ids = tabs.map((t) => t.id);
-
-    // Present in array (length > 0) so Docs is visible, but no action segment matches
-    expect(ids).toEqual(["docs"]);
-  });
-
   it("returns no tabs for empty permissions array", () => {
     const tabs = deriveVisibleTabs([]);
 
     expect(tabs).toHaveLength(0);
+  });
+});
+
+describe("portalSessionGrantSchema", () => {
+  it("accepts the persisted portal grant", () => {
+    expect(
+      portalSessionGrantSchema.safeParse({
+        keyspaceIds: ["ks_123"],
+        permissions: ["keys:read", "analytics:read"],
+      }).success,
+    ).toBe(true);
+  });
+
+  it("rejects malformed and unknown grants", () => {
+    expect(portalSessionGrantSchema.safeParse(["keys:read"]).success).toBe(false);
+    expect(
+      portalSessionGrantSchema.safeParse({
+        keyspaceIds: ["ks_123"],
+        permissions: ["unknown:capability"],
+      }).success,
+    ).toBe(false);
   });
 });

--- a/web/apps/portal/src/lib/permissions.ts
+++ b/web/apps/portal/src/lib/permissions.ts
@@ -1,3 +1,5 @@
+import type { PortalCapability } from "./capabilities";
+
 /**
  * Portal tab identifiers. Each tab maps to a route in the portal app.
  */
@@ -15,37 +17,20 @@ const TAB_CONFIGS: ReadonlyArray<TabConfig> = [
   { id: "docs", label: "Documentation", href: "/docs" },
 ] as const;
 
-/**
- * RBAC actions that grant visibility to the Keys tab.
- */
-const KEY_ACTIONS = new Set(["read_key", "create_key", "update_key", "delete_key"]);
+const KEY_CAPABILITIES: ReadonlySet<PortalCapability> = new Set([
+  "keys:read",
+  "keys:create",
+  "keys:reroll",
+]);
 
 /**
- * RBAC actions that grant visibility to the Analytics tab.
+ * Derive visible portal tabs from a session's capabilities.
  */
-const ANALYTICS_ACTIONS = new Set(["read_analytics"]);
-
-/**
- * Derive visible portal tabs from a session's RBAC tuple permissions.
- *
- * Each permission is expected in the format `{resourceType}.{resourceId}.{action}`.
- * The action segment (third dot-separated segment) determines tab visibility:
- * - Keys tab: action ∈ {read_key, create_key, update_key, delete_key}
- * - Analytics tab: action = read_analytics
- * - Docs tab: visible when any permission is present (regardless of action)
- *
- * Permissions with fewer than 3 segments are silently ignored (defensive fallback).
- */
-export function deriveVisibleTabs(permissions: ReadonlyArray<string>): ReadonlyArray<TabConfig> {
-  const actions = permissions
-    .map((p) => {
-      const parts = p.split(".");
-      return parts.length === 3 ? parts[2] : null;
-    })
-    .filter((a): a is string => a !== null);
-
-  const hasKeys = actions.some((a) => KEY_ACTIONS.has(a));
-  const hasAnalytics = actions.some((a) => ANALYTICS_ACTIONS.has(a));
+export function deriveVisibleTabs(
+  permissions: ReadonlyArray<PortalCapability>,
+): ReadonlyArray<TabConfig> {
+  const hasKeys = permissions.some((permission) => KEY_CAPABILITIES.has(permission));
+  const hasAnalytics = permissions.includes("analytics:read");
   const hasDocs = permissions.length > 0;
 
   return TAB_CONFIGS.filter((tab) => {
@@ -63,7 +48,7 @@ export function deriveVisibleTabs(permissions: ReadonlyArray<string>): ReadonlyA
 /**
  * Get the first visible tab's href for redirect after session exchange.
  */
-export function getDefaultTabHref(permissions: ReadonlyArray<string>): string | null {
+export function getDefaultTabHref(permissions: ReadonlyArray<PortalCapability>): string | null {
   const tabs = deriveVisibleTabs(permissions);
   return tabs.length > 0 ? tabs[0].href : null;
 }

--- a/web/apps/portal/src/lib/session.ts
+++ b/web/apps/portal/src/lib/session.ts
@@ -1,6 +1,7 @@
 import { createServerFn } from "@tanstack/react-start";
 import { deleteCookie, getCookie, setCookie } from "@tanstack/react-start/server";
 import { z } from "zod";
+import { type PortalCapability, portalSessionGrantSchema } from "./capabilities";
 import { env } from "./env";
 import type { PortalConfig } from "./portal-config";
 
@@ -11,7 +12,7 @@ export type SessionData = {
   id: string;
   portalConfigId: string;
   externalId: string;
-  permissions: string[];
+  permissions: PortalCapability[];
   preview: boolean;
   expiresAt: number;
 };
@@ -122,6 +123,14 @@ export const getSessionWithConfig = createServerFn({ method: "GET" }).handler(
     if (!session) {
       return null;
     }
+    const grant = portalSessionGrantSchema.safeParse(session.permissions);
+    if (!grant.success) {
+      console.error("Invalid portal session grant", {
+        portalConfigId: session.portalConfigId,
+        issues: grant.error.issues,
+      });
+      return null;
+    }
 
     let config: PortalConfig | null = null;
     try {
@@ -133,7 +142,13 @@ export const getSessionWithConfig = createServerFn({ method: "GET" }).handler(
       });
     }
 
-    return { session, config };
+    return {
+      session: {
+        ...session,
+        permissions: grant.data.permissions,
+      },
+      config,
+    };
   },
 );
 

--- a/web/internal/db/src/schema/portal_session_tokens.ts
+++ b/web/internal/db/src/schema/portal_session_tokens.ts
@@ -1,6 +1,7 @@
 import { relations } from "drizzle-orm";
 import { bigint, boolean, index, json, mysqlTable, varchar } from "drizzle-orm/mysql-core";
 import { portalConfigurations } from "./portal_configurations";
+import type { PortalSessionGrant } from "./portal_sessions";
 import { workspaces } from "./workspaces";
 
 export const portalSessionTokens = mysqlTable(
@@ -11,7 +12,7 @@ export const portalSessionTokens = mysqlTable(
     workspaceId: varchar("workspace_id", { length: 256 }).notNull(),
     portalConfigId: varchar("portal_config_id", { length: 64 }).notNull(),
     externalId: varchar("external_id", { length: 256 }).notNull(),
-    permissions: json("permissions").$type<string[]>().notNull(),
+    permissions: json("permissions").$type<PortalSessionGrant>().notNull(),
     preview: boolean("preview").notNull().default(false),
     exchangedAt: bigint("exchanged_at", { mode: "number" }),
     expiresAt: bigint("expires_at", { mode: "number" }).notNull(),

--- a/web/internal/db/src/schema/portal_sessions.ts
+++ b/web/internal/db/src/schema/portal_sessions.ts
@@ -3,6 +3,12 @@ import { bigint, boolean, index, json, mysqlTable, varchar } from "drizzle-orm/m
 import { portalConfigurations } from "./portal_configurations";
 import { workspaces } from "./workspaces";
 
+/** The capability and keyspace scope persisted in the permissions JSON column. */
+export type PortalSessionGrant = {
+  keyspaceIds: string[];
+  permissions: string[];
+};
+
 export const portalSessions = mysqlTable(
   "portal_sessions",
   {
@@ -11,7 +17,7 @@ export const portalSessions = mysqlTable(
     workspaceId: varchar("workspace_id", { length: 256 }).notNull(),
     portalConfigId: varchar("portal_config_id", { length: 64 }).notNull(),
     externalId: varchar("external_id", { length: 256 }).notNull(),
-    permissions: json("permissions").$type<string[]>().notNull(),
+    permissions: json("permissions").$type<PortalSessionGrant>().notNull(),
     preview: boolean("preview").notNull().default(false),
     expiresAt: bigint("expires_at", { mode: "number" }).notNull(),
     createdAt: bigint("created_at", { mode: "number" }).notNull(),


### PR DESCRIPTION
## Summary

- validate persisted portal session grants at runtime against the fixed capability vocabulary
- derive portal tab visibility from typed capabilities
- model portal session and exchange-token JSON columns as scoped grant objects
- align the create-session OpenAPI description, generated artifacts, quickstart, error docs, and local testing guide

## Verification

- `mise run generate`
- `mise exec -- pnpm --dir=web --filter @unkey/portal exec vitest run src/lib/permissions.test.ts`
- `mise exec -- pnpm --dir=web --filter @unkey/portal build`
- `mise exec -- pnpm --dir=web --filter @unkey/portal typecheck`
- docs/content review for stale tuple-style portal permissions
- `git diff --check`