### PR TITLE
fix(portal): scope analytics to configured keyspaces

### DIFF
--- a/pkg/clickhouse/interface.go
+++ b/pkg/clickhouse/interface.go
@@ -26,9 +26,9 @@ type Querier interface {
 	GetBillableVerifications(ctx context.Context, workspaceID string, year, month int) (int64, error)
 
 	// GetVerificationsByExternalID returns a zero-filled verification timeseries
-	// for a single end user (workspace_id + external_id), optionally narrowed to
-	// one key. Used by the portal getVerifications endpoint. Bucket granularity
-	// is chosen from the window size.
+	// for a single end user within explicit keyspaces, optionally narrowed to one
+	// key. Used by the portal getVerifications endpoint. Bucket granularity is
+	// chosen from the window size.
 	GetVerificationsByExternalID(ctx context.Context, req VerificationTimeseriesRequest) ([]VerificationTimeseriesDataPoint, error)
 
 	GetBillableRatelimits(ctx context.Context, workspaceID string, year, month int) (int64, error)

--- a/pkg/clickhouse/key_verifications_timeseries.go
+++ b/pkg/clickhouse/key_verifications_timeseries.go
@@ -4,17 +4,21 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 
+	"github.com/unkeyed/unkey/pkg/array"
 	"github.com/unkeyed/unkey/pkg/fault"
 )
 
 // VerificationTimeseriesRequest scopes a verification timeseries to a single
-// portal end user. WorkspaceID and ExternalID are required; KeyID optionally
-// narrows to one key. StartTime and EndTime bound the window in unix
-// milliseconds (StartTime inclusive, EndTime exclusive).
+// portal end user within an explicit set of keyspaces. WorkspaceID, ExternalID,
+// and KeyspaceIDs are required; KeyID optionally narrows to one key. StartTime
+// and EndTime bound the window in unix milliseconds (StartTime inclusive,
+// EndTime exclusive).
 type VerificationTimeseriesRequest struct {
 	WorkspaceID string
 	ExternalID  string
+	KeyspaceIDs []string
 	KeyID       string
 	StartTime   int64
 	EndTime     int64
@@ -60,21 +64,22 @@ func selectVerificationInterval(windowMs int64) verificationInterval {
 }
 
 // GetVerificationsByExternalID returns a zero-filled verification timeseries for
-// one end user (workspace_id + external_id), optionally narrowed to a single
+// one end user within the requested keyspaces, optionally narrowed to a single
 // key. Bucket granularity is chosen from the window size. Empty buckets are
 // returned with zero counts so callers get a contiguous series.
 //
 // The query runs on the shared ClickHouse connection (not a per-workspace user)
-// and filters on external_id, which is denormalized onto each event at write
-// time. This is the portal-scoped read: the workspace and identity are pinned by
-// the caller, so no query DSL or per-workspace connection is involved.
+// and filters on key_space_id and external_id, which are denormalized onto each
+// event at write time. This is the portal-scoped read: the workspace, keyspaces,
+// and identity are pinned by the caller, so no query DSL or per-workspace
+// connection is involved.
 func (c *Client) GetVerificationsByExternalID(ctx context.Context, req VerificationTimeseriesRequest) ([]VerificationTimeseriesDataPoint, error) {
 	iv := selectVerificationInterval(req.EndTime - req.StartTime)
 
 	// iv.unit, iv.table and iv.stepMs come from selectVerificationInterval — a
 	// fixed switch over the window size, never caller input — so they are safe to
 	// interpolate. Every caller-supplied value (workspace, identity, key, window
-	// bounds) goes through a typed named parameter instead. SUM results are cast
+	// bounds) goes through a typed query parameter instead. SUM results are cast
 	// to Int64 so they scan into the int64 struct fields. An empty key_id means
 	// "all keys": the OR short-circuits the filter rather than binding it.
 	query := fmt.Sprintf(`
@@ -91,6 +96,7 @@ func (c *Client) GetVerificationsByExternalID(ctx context.Context, req Verificat
 	FROM %[2]s
 	WHERE workspace_id = {workspace_id:String}
 		AND external_id = {external_id:String}
+		AND key_space_id IN {keyspace_ids:Array(String)}
 		AND time >= fromUnixTimestamp64Milli({start:Int64})
 		AND time < fromUnixTimestamp64Milli({end:Int64})
 		AND ({key_id:String} = '' OR key_id = {key_id:String})
@@ -103,9 +109,14 @@ func (c *Client) GetVerificationsByExternalID(ctx context.Context, req Verificat
 		iv.unit, iv.table, iv.stepMs,
 	)
 
+	keyspaceIDs := array.Map(req.KeyspaceIDs, func(keyspaceID string) string {
+		return fmt.Sprintf("'%s'", keyspaceID)
+	})
+
 	results, err := Select[VerificationTimeseriesDataPoint](ctx, c.conn, query, map[string]string{
 		"workspace_id": req.WorkspaceID,
 		"external_id":  req.ExternalID,
+		"keyspace_ids": fmt.Sprintf("[%s]", strings.Join(keyspaceIDs, ",")),
 		"key_id":       req.KeyID,
 		"start":        strconv.FormatInt(req.StartTime, 10),
 		"end":          strconv.FormatInt(req.EndTime, 10),

--- a/pkg/clickhouse/key_verifications_timeseries_test.go
+++ b/pkg/clickhouse/key_verifications_timeseries_test.go
@@ -29,6 +29,7 @@ func TestGetVerificationsByExternalID(t *testing.T) {
 	extA := "ext_" + uid.New("")
 	extB := "ext_" + uid.New("")
 	keySpaceID := uid.New(uid.KeySpacePrefix)
+	otherKeySpaceID := uid.New(uid.KeySpacePrefix)
 	targetKey := uid.New(uid.KeyPrefix)
 	otherKey := uid.New(uid.KeyPrefix)
 
@@ -38,7 +39,7 @@ func TestGetVerificationsByExternalID(t *testing.T) {
 	dayA := base.Add(12 * time.Hour)
 	dayB := base.Add(2*24*time.Hour + 12*time.Hour)
 
-	mk := func(extID, keyID, outcome string, ts time.Time) schema.KeyVerification {
+	mk := func(extID, keySpaceID, keyID, outcome string, ts time.Time) schema.KeyVerification {
 		return schema.KeyVerification{
 			RequestID:   uid.New(uid.RequestPrefix),
 			Time:        ts.UnixMilli(),
@@ -55,19 +56,21 @@ func TestGetVerificationsByExternalID(t *testing.T) {
 
 	rows := []schema.KeyVerification{
 		// extA, day A: 3 VALID (one on targetKey), 2 RATE_LIMITED
-		mk(extA, targetKey, "VALID", dayA),
-		mk(extA, otherKey, "VALID", dayA),
-		mk(extA, otherKey, "VALID", dayA),
-		mk(extA, otherKey, "RATE_LIMITED", dayA),
-		mk(extA, otherKey, "RATE_LIMITED", dayA),
+		mk(extA, keySpaceID, targetKey, "VALID", dayA),
+		mk(extA, keySpaceID, otherKey, "VALID", dayA),
+		mk(extA, keySpaceID, otherKey, "VALID", dayA),
+		mk(extA, keySpaceID, otherKey, "RATE_LIMITED", dayA),
+		mk(extA, keySpaceID, otherKey, "RATE_LIMITED", dayA),
 		// extA, day B: 1 VALID
-		mk(extA, otherKey, "VALID", dayB),
+		mk(extA, keySpaceID, otherKey, "VALID", dayB),
+		// extA in another keyspace: excluded unless explicitly requested.
+		mk(extA, otherKeySpaceID, otherKey, "VALID", dayA),
 		// extB, day A: 5 VALID (must NOT appear in extA results)
-		mk(extB, otherKey, "VALID", dayA),
-		mk(extB, otherKey, "VALID", dayA),
-		mk(extB, otherKey, "VALID", dayA),
-		mk(extB, otherKey, "VALID", dayA),
-		mk(extB, otherKey, "VALID", dayA),
+		mk(extB, keySpaceID, otherKey, "VALID", dayA),
+		mk(extB, keySpaceID, otherKey, "VALID", dayA),
+		mk(extB, keySpaceID, otherKey, "VALID", dayA),
+		mk(extB, keySpaceID, otherKey, "VALID", dayA),
+		mk(extB, keySpaceID, otherKey, "VALID", dayA),
 	}
 
 	batch, err := client.Conn().PrepareBatch(ctx, clickhouse.InsertQuery[schema.KeyVerification]())
@@ -77,7 +80,7 @@ func TestGetVerificationsByExternalID(t *testing.T) {
 	}
 	require.NoError(t, batch.Send())
 
-	// Wait for the per_day materialized view to catch up (extA has 6 events).
+	// Wait for the per_day materialized view to catch up (extA has 7 events).
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		var got int64
 		err := client.Conn().QueryRow(ctx,
@@ -85,7 +88,7 @@ func TestGetVerificationsByExternalID(t *testing.T) {
 			workspaceID, extA,
 		).Scan(&got)
 		assert.NoError(c, err)
-		assert.Equal(c, int64(6), got)
+		assert.Equal(c, int64(7), got)
 	}, time.Minute, time.Second)
 
 	startMs := base.UnixMilli()
@@ -105,6 +108,7 @@ func TestGetVerificationsByExternalID(t *testing.T) {
 		points, err := client.GetVerificationsByExternalID(ctx, clickhouse.VerificationTimeseriesRequest{
 			WorkspaceID: workspaceID,
 			ExternalID:  extA,
+			KeyspaceIDs: []string{keySpaceID},
 			StartTime:   startMs,
 			EndTime:     endMs,
 		})
@@ -129,6 +133,7 @@ func TestGetVerificationsByExternalID(t *testing.T) {
 		points, err := client.GetVerificationsByExternalID(ctx, clickhouse.VerificationTimeseriesRequest{
 			WorkspaceID: workspaceID,
 			ExternalID:  extA,
+			KeyspaceIDs: []string{keySpaceID},
 			StartTime:   startMs,
 			EndTime:     endMs,
 		})
@@ -146,6 +151,7 @@ func TestGetVerificationsByExternalID(t *testing.T) {
 		points, err := client.GetVerificationsByExternalID(ctx, clickhouse.VerificationTimeseriesRequest{
 			WorkspaceID: workspaceID,
 			ExternalID:  extA,
+			KeyspaceIDs: []string{keySpaceID},
 			KeyID:       targetKey,
 			StartTime:   startMs,
 			EndTime:     endMs,
@@ -156,5 +162,39 @@ func TestGetVerificationsByExternalID(t *testing.T) {
 		require.Equal(t, int64(1), m[dayABucket].Total)
 		require.Equal(t, int64(1), m[dayABucket].Valid)
 		require.Equal(t, int64(0), m[dayBBucket].Total)
+	})
+
+	t.Run("multiple keyspaces are unioned", func(t *testing.T) {
+		points, err := client.GetVerificationsByExternalID(ctx, clickhouse.VerificationTimeseriesRequest{
+			WorkspaceID: workspaceID,
+			ExternalID:  extA,
+			KeyspaceIDs: []string{keySpaceID, otherKeySpaceID},
+			StartTime:   startMs,
+			EndTime:     endMs,
+		})
+		require.NoError(t, err)
+
+		var total int64
+		for _, point := range points {
+			total += point.Total
+		}
+		require.Equal(t, int64(7), total)
+	})
+
+	t.Run("empty keyspace scope returns no events", func(t *testing.T) {
+		points, err := client.GetVerificationsByExternalID(ctx, clickhouse.VerificationTimeseriesRequest{
+			WorkspaceID: workspaceID,
+			ExternalID:  extA,
+			KeyspaceIDs: []string{},
+			StartTime:   startMs,
+			EndTime:     endMs,
+		})
+		require.NoError(t, err)
+
+		var total int64
+		for _, point := range points {
+			total += point.Total
+		}
+		require.Zero(t, total)
 	})
 }

--- a/svc/api/routes/v2_portal_get_verifications/200_test.go
+++ b/svc/api/routes/v2_portal_get_verifications/200_test.go
@@ -44,15 +44,18 @@ func sumTotals(points []openapi.V2PortalGetVerificationsDataPoint) int64 {
 }
 
 // TestPortalSessionAnalyticsScopedToOwnKeys verifies a portal session only sees
-// verification events attributed to its own externalId, even when another
-// identity in the same workspace has its own events, and that events for a
-// soft-deleted key still count (scoping is by external_id at write time, not by
-// current key ownership).
+// verification events attributed to its own externalId and configured
+// keyspaces, even when the same identity has keys elsewhere. Events for a
+// soft-deleted key still count because both scope fields are written to the
+// event before deletion.
 func TestPortalSessionAnalyticsScopedToOwnKeys(t *testing.T) {
 	h := testutil.NewHarness(t, testutil.HarnessConfig{ClickHouse: true})
 
 	workspace := h.CreateWorkspace()
 	api := h.CreateApi(seed.CreateApiRequest{
+		WorkspaceID: workspace.ID,
+	})
+	otherApi := h.CreateApi(seed.CreateApiRequest{
 		WorkspaceID: workspace.ID,
 	})
 	h.SetupAnalytics(workspace.ID)
@@ -83,6 +86,11 @@ func TestPortalSessionAnalyticsScopedToOwnKeys(t *testing.T) {
 		Now: sql.NullInt64{Int64: time.Now().UnixMilli(), Valid: true},
 		ID:  keyADeleted.KeyID,
 	}))
+	keyAOtherKeyspace := h.CreateKey(seed.CreateKeyRequest{
+		WorkspaceID: workspace.ID,
+		KeySpaceID:  otherApi.KeyAuthID.String,
+		IdentityID:  ptr.P(identityA.ID),
+	})
 
 	// Identity B owns a different key whose events must never be visible to A.
 	identityB := h.CreateIdentity(seed.CreateIdentityRequest{
@@ -97,13 +105,13 @@ func TestPortalSessionAnalyticsScopedToOwnKeys(t *testing.T) {
 
 	now := time.Now().UnixMilli()
 
-	buffer := func(keyID, externalID, identityID string, n int) {
+	buffer := func(keyID, keyspaceID, externalID, identityID string, n int) {
 		for i := range n {
 			h.KeyVerifications.Buffer(schema.KeyVerification{
 				RequestID:   uid.New(uid.RequestPrefix),
 				Time:        now - int64(i*1000),
 				WorkspaceID: workspace.ID,
-				KeySpaceID:  api.KeyAuthID.String,
+				KeySpaceID:  keyspaceID,
 				KeyID:       keyID,
 				Region:      "us-west-1",
 				Outcome:     "VALID",
@@ -114,9 +122,24 @@ func TestPortalSessionAnalyticsScopedToOwnKeys(t *testing.T) {
 		}
 	}
 
-	buffer(keyA.KeyID, externalA, identityA.ID, 3)            // A live key
-	buffer(keyADeleted.KeyID, externalA, identityA.ID, 2)     // A deleted key
-	buffer(keyB.KeyID, identityB.ExternalID, identityB.ID, 5) // B key (must not leak)
+	buffer(keyA.KeyID, api.KeyAuthID.String, externalA, identityA.ID, 3)                   // A live key
+	buffer(keyADeleted.KeyID, api.KeyAuthID.String, externalA, identityA.ID, 2)            // A deleted key
+	buffer(keyAOtherKeyspace.KeyID, otherApi.KeyAuthID.String, externalA, identityA.ID, 7) // A key outside the session keyspaces
+	buffer(keyB.KeyID, api.KeyAuthID.String, identityB.ExternalID, identityB.ID, 5)        // B key (must not leak)
+
+	// Prove all same-identity events reached the aggregate before testing that the
+	// route excludes the seven events outside the session keyspace.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		var total int64
+		err := h.ClickHouse.Conn().QueryRow(
+			context.Background(),
+			"SELECT SUM(count) FROM default.key_verifications_per_minute_v3 WHERE workspace_id = ? AND external_id = ?",
+			workspace.ID,
+			externalA,
+		).Scan(&total)
+		assert.NoError(c, err)
+		assert.Equal(c, int64(12), total)
+	}, 30*time.Second, time.Second)
 
 	headers := h.CreatePortalSession(workspace.ID, externalA, []string{api.KeyAuthID.String}, []string{"analytics:read"})
 
@@ -126,15 +149,14 @@ func TestPortalSessionAnalyticsScopedToOwnKeys(t *testing.T) {
 		EndTime:   now + int64(time.Minute/time.Millisecond),
 	}
 
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		res := testutil.CallRoute[Request, Response](h, route, headers, req)
-		require.Equal(c, 200, res.Status)
-		require.NotNil(c, res.Body)
+	res := testutil.CallRoute[Request, Response](h, route, headers, req)
+	require.Equal(t, 200, res.Status)
+	require.NotNil(t, res.Body)
 
-		// A's 3 live-key events + 2 deleted-key events = 5, never B's 5.
-		require.Equal(c, int64(5), sumTotals(res.Body.Data),
-			"portal session should see its own keys' events (including deleted keys) but never another identity's")
-	}, 30*time.Second, time.Second)
+	// Only A's events in the session keyspace are visible: 3 live-key events plus
+	// 2 deleted-key events. Neither B's events nor A's other keyspace leak.
+	require.Equal(t, int64(5), sumTotals(res.Body.Data),
+		"portal session analytics must remain within its external identity and configured keyspaces")
 }
 
 // TestPortalSessionAnalyticsKeyIdFilter verifies the optional keyId narrows the

--- a/svc/api/routes/v2_portal_get_verifications/handler.go
+++ b/svc/api/routes/v2_portal_get_verifications/handler.go
@@ -46,7 +46,7 @@ func (h *Handler) Method() string { return "POST" }
 func (h *Handler) Path() string { return "/v2/portal.getVerifications" }
 
 // Handle returns a verification timeseries scoped to the portal session's
-// external identity.
+// external identity and configured keyspaces.
 func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	principal, err := s.GetPrincipal()
 	if err != nil {
@@ -54,6 +54,10 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	externalID, err := portalscope.ExternalID(s)
+	if err != nil {
+		return err
+	}
+	keyspaceIDs, err := portalscope.KeyspaceIDs(s)
 	if err != nil {
 		return err
 	}
@@ -113,6 +117,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	points, err := h.ClickHouse.GetVerificationsByExternalID(ctx, clickhouse.VerificationTimeseriesRequest{
 		WorkspaceID: principal.WorkspaceID,
 		ExternalID:  externalID,
+		KeyspaceIDs: keyspaceIDs,
 		KeyID:       ptr.SafeDeref(req.KeyId),
 		StartTime:   req.StartTime,
 		EndTime:     req.EndTime,


### PR DESCRIPTION
## Summary

- scope portal verification analytics to the keyspaces configured on the authenticated portal session
- filter ClickHouse events by both external identity and explicit `key_space_id` values, preventing same-identity events from unconfigured keyspaces from leaking into results
- preserve the existing wildcard `rbac.T` analytics authorization and portal capability expansion

## Verification

- `DOCKER_HOST=unix:///Users/chronark/.orbstack/run/docker.sock mise exec -- go test -count=1 -run '^TestGetVerificationsByExternalID$' ./pkg/clickhouse`\n- `DOCKER_HOST=unix:///Users/chronark/.orbstack/run/docker.sock mise exec -- rask --no-cache --concurrency 1 ./svc/api/routes/v2_portal_get_verifications`\n- `mise run build`\n- `git diff --check`