### PR TITLE
feat(api): add list policies endpoint

### DIFF
--- a/pkg/rbac/permissions.go
+++ b/pkg/rbac/permissions.go
@@ -241,6 +241,8 @@ const (
 	// SetPolicies permits creating, updating, reordering, and removing a
 	// specific environment's gateway policies
 	SetPolicies ActionType = "set_policies"
+	// ReadPolicies permits reading a specific environment's gateway policies
+	ReadPolicies ActionType = "read_policies"
 )
 
 // Tuple represents a specific permission as a combination of resource type,

--- a/svc/api/internal/policyconfig/policyconfig.go
+++ b/svc/api/internal/policyconfig/policyconfig.go
@@ -1,0 +1,27 @@
+// Package policyconfig owns the decode rules for stored sentinel config
+// blobs so the storage contract lives in one place. The frontline gateway
+// carries its own copy in internal/policies (ParseMiddleware) - keep the two
+// in sync when the format changes.
+package policyconfig
+
+import (
+	frontlinev1 "github.com/unkeyed/unkey/gen/proto/frontline/v1"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+// Parse decodes a sentinel_config blob. Empty blobs and the legacy "{}" are
+// valid and yield a config with no policies. Unknown fields are discarded:
+// the dashboard stores a client-side `type` discriminator alongside each
+// policy, and newer writers may add fields older readers don't know.
+// Callers wrap the error with their own fault code and public message.
+func Parse(raw []byte) (*frontlinev1.Config, error) {
+	cfg := &frontlinev1.Config{}
+	if len(raw) == 0 || string(raw) == "{}" {
+		return cfg, nil
+	}
+
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(raw, cfg); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}

--- a/svc/api/internal/policyconfig/policyconfig.go
+++ b/svc/api/internal/policyconfig/policyconfig.go
@@ -1,4 +1,4 @@
-// Package policyconfig owns the decode rules for stored sentinel config
+// Package policyconfig owns the decode rules for stored policy config
 // blobs so the storage contract lives in one place. The frontline gateway
 // carries its own copy in internal/policies (ParseMiddleware) - keep the two
 // in sync when the format changes.
@@ -9,8 +9,8 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
-// Parse decodes a sentinel_config blob. Empty blobs and the legacy "{}" are
-// valid and yield a config with no policies. Unknown fields are discarded:
+// Parse decodes a stored policy config blob. Empty blobs and the legacy "{}"
+// are valid and yield a config with no policies. Unknown fields are discarded:
 // the dashboard stores a client-side `type` discriminator alongside each
 // policy, and newer writers may add fields older readers don't know.
 // Callers wrap the error with their own fault code and public message.

--- a/svc/api/openapi/gen.go
+++ b/svc/api/openapi/gen.go
@@ -839,6 +839,37 @@ type Policy struct {
 	Ratelimit *RatelimitPolicy `json:"ratelimit,omitempty"`
 }
 
+// PolicyResponse A stored gateway policy as returned by list endpoints. Exactly one of
+// `keyauth`, `ratelimit`, `firewall` or `openapi` is set.
+type PolicyResponse struct {
+	// Enabled Disabled policies are stored but skipped during evaluation.
+	Enabled bool `json:"enabled"`
+
+	// Firewall Blocks matching requests.
+	Firewall *FirewallPolicy `json:"firewall,omitempty"`
+
+	// Id Server-generated policy id. Regenerated on every `gateway.setPolicies` call, so treat it as stable only until the environment's policies are next replaced.
+	Id string `json:"id"`
+
+	// Keyauth Verifies Unkey API keys on matching requests.
+	Keyauth *KeyauthPolicy `json:"keyauth,omitempty"`
+
+	// Match Optional request matchers. The policy applies only to requests matching
+	// all expressions; omitted when the policy applies to every request.
+	Match *[]MatchExpr `json:"match,omitempty"`
+
+	// Name Human-readable name shown in the dashboard.
+	Name string `json:"name"`
+
+	// Openapi Validates matching requests against the app's uploaded OpenAPI spec. Has no
+	// configuration of its own. If no spec has been uploaded for the deployment,
+	// the policy is a no-op and requests pass through unvalidated.
+	Openapi *OpenapiPolicy `json:"openapi,omitempty"`
+
+	// Ratelimit Rate limits matching requests.
+	Ratelimit *RatelimitPolicy `json:"ratelimit,omitempty"`
+}
+
 // PreconditionFailedErrorResponse Error response when one or more conditions specified in the request headers are not met. This typically occurs when:
 // - Using conditional requests with If-Match or If-None-Match headers
 // - The resource version doesn't match the expected value
@@ -1949,6 +1980,48 @@ type V2EnvironmentsUpdateSettingsResponseBody struct {
 	// Meta Metadata object included in every API response. This provides context about the request and is essential for debugging, audit trails, and support inquiries. The `requestId` is particularly important when troubleshooting issues with the Unkey support team.
 	Meta Meta `json:"meta"`
 }
+
+// V2GatewayListPoliciesRequestBody defines model for V2GatewayListPoliciesRequestBody.
+type V2GatewayListPoliciesRequestBody struct {
+	// App Identifies a resource by either its unique ID or its slug.
+	// Accepts a prefixed ID (such as 'proj_' or 'app_') or a slug.
+	App ResourceIdentifier `json:"app"`
+
+	// Cursor Pagination cursor from a previous response to fetch the next page of
+	// policies. Leave empty or omit this field to start from the beginning.
+	//
+	// Cursors expire whenever the environment's policies are replaced via
+	// `gateway.setPolicies`, which regenerates every policy id. Requests
+	// with an expired cursor fail with a 400 error - restart from the
+	// beginning when that happens.
+	Cursor *string `json:"cursor,omitempty"`
+
+	// Environment Identifies a resource by either its unique ID or its slug.
+	// Accepts a prefixed ID (such as 'proj_' or 'app_') or a slug.
+	Environment ResourceIdentifier `json:"environment"`
+
+	// Limit Maximum number of policies to return in a single response.
+	Limit *int `json:"limit,omitempty"`
+
+	// Project Identifies a resource by either its unique ID or its slug.
+	// Accepts a prefixed ID (such as 'proj_' or 'app_') or a slug.
+	Project ResourceIdentifier `json:"project"`
+}
+
+// V2GatewayListPoliciesResponseBody defines model for V2GatewayListPoliciesResponseBody.
+type V2GatewayListPoliciesResponseBody struct {
+	// Data The environment's gateway policies in evaluation order.
+	Data V2GatewayListPoliciesResponseData `json:"data"`
+
+	// Meta Metadata object included in every API response. This provides context about the request and is essential for debugging, audit trails, and support inquiries. The `requestId` is particularly important when troubleshooting issues with the Unkey support team.
+	Meta Meta `json:"meta"`
+
+	// Pagination Pagination metadata for list endpoints. Provides information necessary to traverse through large result sets efficiently using cursor-based pagination.
+	Pagination Pagination `json:"pagination"`
+}
+
+// V2GatewayListPoliciesResponseData The environment's gateway policies in evaluation order.
+type V2GatewayListPoliciesResponseData = []PolicyResponse
 
 // V2GatewaySetPoliciesRequestBody defines model for V2GatewaySetPoliciesRequestBody.
 type V2GatewaySetPoliciesRequestBody struct {
@@ -3874,6 +3947,9 @@ type EnvironmentsSetEnvironmentVariablesJSONRequestBody = V2EnvironmentsSetEnvir
 
 // EnvironmentsUpdateSettingsJSONRequestBody defines body for EnvironmentsUpdateSettings for application/json ContentType.
 type EnvironmentsUpdateSettingsJSONRequestBody = V2EnvironmentsUpdateSettingsRequestBody
+
+// GatewayListPoliciesJSONRequestBody defines body for GatewayListPolicies for application/json ContentType.
+type GatewayListPoliciesJSONRequestBody = V2GatewayListPoliciesRequestBody
 
 // GatewaySetPoliciesJSONRequestBody defines body for GatewaySetPolicies for application/json ContentType.
 type GatewaySetPoliciesJSONRequestBody = V2GatewaySetPoliciesRequestBody

--- a/svc/api/openapi/gen.go
+++ b/svc/api/openapi/gen.go
@@ -1987,23 +1987,9 @@ type V2GatewayListPoliciesRequestBody struct {
 	// Accepts a prefixed ID (such as 'proj_' or 'app_') or a slug.
 	App ResourceIdentifier `json:"app"`
 
-	// Cursor Pagination cursor from a previous response to fetch the next page of
-	// policies. Leave empty or omit this field to start from the beginning.
-	//
-	// Cursors expire whenever the environment's policies are replaced via
-	// `gateway.setPolicies`, which regenerates every policy id. Requests
-	// with an expired cursor fail with a 400 error - restart from the
-	// beginning when that happens.
-	Cursor *string `json:"cursor,omitempty"`
-
 	// Environment Identifies a resource by either its unique ID or its slug.
 	// Accepts a prefixed ID (such as 'proj_' or 'app_') or a slug.
 	Environment ResourceIdentifier `json:"environment"`
-
-	// Limit Maximum number of policies to return in a single response. The bound
-	// matches the 50-policy cap of `gateway.setPolicies`, so the default
-	// returns every policy in one page.
-	Limit *int `json:"limit,omitempty"`
 
 	// Project Identifies a resource by either its unique ID or its slug.
 	// Accepts a prefixed ID (such as 'proj_' or 'app_') or a slug.
@@ -2017,9 +2003,6 @@ type V2GatewayListPoliciesResponseBody struct {
 
 	// Meta Metadata object included in every API response. This provides context about the request and is essential for debugging, audit trails, and support inquiries. The `requestId` is particularly important when troubleshooting issues with the Unkey support team.
 	Meta Meta `json:"meta"`
-
-	// Pagination Pagination metadata for list endpoints. Provides information necessary to traverse through large result sets efficiently using cursor-based pagination.
-	Pagination Pagination `json:"pagination"`
 }
 
 // V2GatewayListPoliciesResponseData The environment's gateway policies in evaluation order.

--- a/svc/api/openapi/gen.go
+++ b/svc/api/openapi/gen.go
@@ -2000,7 +2000,9 @@ type V2GatewayListPoliciesRequestBody struct {
 	// Accepts a prefixed ID (such as 'proj_' or 'app_') or a slug.
 	Environment ResourceIdentifier `json:"environment"`
 
-	// Limit Maximum number of policies to return in a single response.
+	// Limit Maximum number of policies to return in a single response. The bound
+	// matches the 50-policy cap of `gateway.setPolicies`, so the default
+	// returns every policy in one page.
 	Limit *int `json:"limit,omitempty"`
 
 	// Project Identifies a resource by either its unique ID or its slug.

--- a/svc/api/openapi/openapi-generated.yaml
+++ b/svc/api/openapi/openapi-generated.yaml
@@ -1156,6 +1156,53 @@ components:
                 data:
                     "$ref": "#/components/schemas/EmptyResponse"
             additionalProperties: false
+        V2GatewayListPoliciesRequestBody:
+            type: object
+            required:
+                - project
+                - app
+                - environment
+            properties:
+                project:
+                    "$ref": "#/components/schemas/ResourceIdentifier"
+                app:
+                    "$ref": "#/components/schemas/ResourceIdentifier"
+                environment:
+                    "$ref": "#/components/schemas/ResourceIdentifier"
+                cursor:
+                    type: string
+                    maxLength: 1024
+                    description: |
+                        Pagination cursor from a previous response to fetch the next page of
+                        policies. Leave empty or omit this field to start from the beginning.
+
+                        Cursors expire whenever the environment's policies are replaced via
+                        `gateway.setPolicies`, which regenerates every policy id. Requests
+                        with an expired cursor fail with a 400 error - restart from the
+                        beginning when that happens.
+                    example: pol_2gJbXhAr4
+                limit:
+                    type: integer
+                    minimum: 1
+                    maximum: 100
+                    default: 100
+                    description: Maximum number of policies to return in a single response.
+                    example: 50
+            additionalProperties: false
+        V2GatewayListPoliciesResponseBody:
+            type: object
+            required:
+                - meta
+                - data
+                - pagination
+            properties:
+                meta:
+                    "$ref": "#/components/schemas/Meta"
+                data:
+                    "$ref": "#/components/schemas/V2GatewayListPoliciesResponseData"
+                pagination:
+                    "$ref": "#/components/schemas/Pagination"
+            additionalProperties: false
         V2GatewaySetPoliciesRequestBody:
             type: object
             required:
@@ -4314,12 +4361,23 @@ components:
                         Human-readable description of the variable.
                     example: Primary database connection string
             additionalProperties: false
-        Policy:
+        V2GatewayListPoliciesResponseData:
+            type: array
+            maxItems: 50
+            description: The environment's gateway policies in evaluation order.
+            items:
+                "$ref": "#/components/schemas/PolicyResponse"
+        PolicyResponse:
             type: object
             required:
+                - id
                 - name
                 - enabled
             properties:
+                id:
+                    type: string
+                    description: Server-generated policy id. Regenerated on every `gateway.setPolicies` call, so treat it as stable only until the environment's policies are next replaced.
+                    example: pol_2gJbXhAr4
                 name:
                     type: string
                     minLength: 1
@@ -4335,7 +4393,7 @@ components:
                         "$ref": "#/components/schemas/MatchExpr"
                     description: |-
                         Optional request matchers. The policy applies only to requests matching
-                        all expressions; omit to apply to every request.
+                        all expressions; omitted when the policy applies to every request.
                 keyauth:
                     "$ref": "#/components/schemas/KeyauthPolicy"
                 ratelimit:
@@ -4346,10 +4404,10 @@ components:
                     "$ref": "#/components/schemas/OpenapiPolicy"
             additionalProperties: false
             description: |-
-                A gateway policy. Exactly one of `keyauth`, `ratelimit`, `firewall` or
-                `openapi` must be set. The server generates an id for every policy it
-                stores.
+                A stored gateway policy as returned by list endpoints. Exactly one of
+                `keyauth`, `ratelimit`, `firewall` or `openapi` is set.
             example:
+                id: pol_2gJbXhAr4
                 name: Block internal paths
                 enabled: true
                 match:
@@ -4680,6 +4738,50 @@ components:
                     maxLength: 512
             additionalProperties: false
             description: Rate limit by a field extracted from the authenticated principal.
+        Policy:
+            type: object
+            required:
+                - name
+                - enabled
+            properties:
+                name:
+                    type: string
+                    minLength: 1
+                    maxLength: 256
+                    description: Human-readable name shown in the dashboard.
+                enabled:
+                    type: boolean
+                    description: Disabled policies are stored but skipped during evaluation.
+                match:
+                    type: array
+                    maxItems: 10
+                    items:
+                        "$ref": "#/components/schemas/MatchExpr"
+                    description: |-
+                        Optional request matchers. The policy applies only to requests matching
+                        all expressions; omit to apply to every request.
+                keyauth:
+                    "$ref": "#/components/schemas/KeyauthPolicy"
+                ratelimit:
+                    "$ref": "#/components/schemas/RatelimitPolicy"
+                firewall:
+                    "$ref": "#/components/schemas/FirewallPolicy"
+                openapi:
+                    "$ref": "#/components/schemas/OpenapiPolicy"
+            additionalProperties: false
+            description: |-
+                A gateway policy. Exactly one of `keyauth`, `ratelimit`, `firewall` or
+                `openapi` must be set. The server generates an id for every policy it
+                stores.
+            example:
+                name: Block internal paths
+                enabled: true
+                match:
+                    - path:
+                        path:
+                            prefix: /internal/
+                firewall:
+                    action: ACTION_DENY
         RatelimitRequest:
             type: object
             required:
@@ -8561,6 +8663,102 @@ paths:
             tags:
                 - environments
             x-speakeasy-name-override: updateSettings
+    /v2/gateway.listPolicies:
+        post:
+            description: |
+                Retrieve an environment's gateway policies in evaluation order: the
+                gateway evaluates them top to bottom and the first rejection
+                short-circuits the request.
+
+                Results are paginated in stored order; treat the cursor as an opaque
+                token. Because `gateway.setPolicies` replaces the whole list and
+                regenerates every id, cursors expire whenever the environment's policies
+                change - restart from the beginning when a cursor is rejected.
+
+                **Required Permissions**
+
+                Your root key must have one of the following permissions:
+                - `environment.*.read_policies` (for any environment)
+                - `environment.<environment_id>.read_policies` (for a specific environment)
+            operationId: gateway.listPolicies
+            requestBody:
+                content:
+                    application/json:
+                        examples:
+                            list:
+                                summary: List the environment's policies
+                                value:
+                                    app: payments-api
+                                    environment: production
+                                    project: payments
+                            page:
+                                summary: Fetch the next page
+                                value:
+                                    app: payments-api
+                                    cursor: pol_2gJbXhAr4
+                                    environment: production
+                                    limit: 10
+                                    project: payments
+                        schema:
+                            $ref: '#/components/schemas/V2GatewayListPoliciesRequestBody'
+                required: true
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/V2GatewayListPoliciesResponseBody'
+                    description: Policies retrieved successfully
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/BadRequestErrorResponse'
+                    description: Bad request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/UnauthorizedErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ForbiddenErrorResponse'
+                    description: Forbidden - Insufficient permissions (requires `environment.*.read_policies`)
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/NotFoundErrorResponse'
+                    description: Not Found - The environment does not exist in your workspace
+                "429":
+                    content:
+                        application/problem+json:
+                            schema:
+                                $ref: '#/components/schemas/TooManyRequestsErrorResponse'
+                    description: Too Many Requests
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/InternalServerErrorResponse'
+                    description: Internal server error
+            security:
+                - rootKey: []
+            summary: List policies
+            tags:
+                - gateway
+            x-speakeasy-name-override: listPolicies
+            x-speakeasy-pagination:
+                inputs:
+                    - in: requestBody
+                      name: cursor
+                      type: cursor
+                outputs:
+                    nextCursor: $.pagination.cursor
+                type: cursor
     /v2/gateway.setPolicies:
         post:
             description: |

--- a/svc/api/openapi/openapi-generated.yaml
+++ b/svc/api/openapi/openapi-generated.yaml
@@ -1184,10 +1184,13 @@ components:
                 limit:
                     type: integer
                     minimum: 1
-                    maximum: 100
-                    default: 100
-                    description: Maximum number of policies to return in a single response.
-                    example: 50
+                    maximum: 50
+                    default: 50
+                    description: |-
+                        Maximum number of policies to return in a single response. The bound
+                        matches the 50-policy cap of `gateway.setPolicies`, so the default
+                        returns every policy in one page.
+                    example: 25
             additionalProperties: false
         V2GatewayListPoliciesResponseBody:
             type: object

--- a/svc/api/openapi/openapi-generated.yaml
+++ b/svc/api/openapi/openapi-generated.yaml
@@ -8713,7 +8713,7 @@ paths:
                                 $ref: '#/components/schemas/InternalServerErrorResponse'
                     description: Internal server error
             security:
-                - rootKey: []
+                - bearer: []
             summary: List policies
             tags:
                 - gateway

--- a/svc/api/openapi/openapi-generated.yaml
+++ b/svc/api/openapi/openapi-generated.yaml
@@ -1169,42 +1169,17 @@ components:
                     "$ref": "#/components/schemas/ResourceIdentifier"
                 environment:
                     "$ref": "#/components/schemas/ResourceIdentifier"
-                cursor:
-                    type: string
-                    maxLength: 1024
-                    description: |
-                        Pagination cursor from a previous response to fetch the next page of
-                        policies. Leave empty or omit this field to start from the beginning.
-
-                        Cursors expire whenever the environment's policies are replaced via
-                        `gateway.setPolicies`, which regenerates every policy id. Requests
-                        with an expired cursor fail with a 400 error - restart from the
-                        beginning when that happens.
-                    example: pol_2gJbXhAr4
-                limit:
-                    type: integer
-                    minimum: 1
-                    maximum: 50
-                    default: 50
-                    description: |-
-                        Maximum number of policies to return in a single response. The bound
-                        matches the 50-policy cap of `gateway.setPolicies`, so the default
-                        returns every policy in one page.
-                    example: 25
             additionalProperties: false
         V2GatewayListPoliciesResponseBody:
             type: object
             required:
                 - meta
                 - data
-                - pagination
             properties:
                 meta:
                     "$ref": "#/components/schemas/Meta"
                 data:
                     "$ref": "#/components/schemas/V2GatewayListPoliciesResponseData"
-                pagination:
-                    "$ref": "#/components/schemas/Pagination"
             additionalProperties: false
         V2GatewaySetPoliciesRequestBody:
             type: object
@@ -8673,10 +8648,7 @@ paths:
                 gateway evaluates them top to bottom and the first rejection
                 short-circuits the request.
 
-                Results are paginated in stored order; treat the cursor as an opaque
-                token. Because `gateway.setPolicies` replaces the whole list and
-                regenerates every id, cursors expire whenever the environment's policies
-                change - restart from the beginning when a cursor is rejected.
+                The full policy list is returned in a single response.
 
                 **Required Permissions**
 
@@ -8693,14 +8665,6 @@ paths:
                                 value:
                                     app: payments-api
                                     environment: production
-                                    project: payments
-                            page:
-                                summary: Fetch the next page
-                                value:
-                                    app: payments-api
-                                    cursor: pol_2gJbXhAr4
-                                    environment: production
-                                    limit: 10
                                     project: payments
                         schema:
                             $ref: '#/components/schemas/V2GatewayListPoliciesRequestBody'
@@ -8754,14 +8718,6 @@ paths:
             tags:
                 - gateway
             x-speakeasy-name-override: listPolicies
-            x-speakeasy-pagination:
-                inputs:
-                    - in: requestBody
-                      name: cursor
-                      type: cursor
-                outputs:
-                    nextCursor: $.pagination.cursor
-                type: cursor
     /v2/gateway.setPolicies:
         post:
             description: |

--- a/svc/api/openapi/openapi-split.yaml
+++ b/svc/api/openapi/openapi-split.yaml
@@ -276,6 +276,8 @@ paths:
   # Gateway Endpoints
   /v2/gateway.setPolicies:
     $ref: "./spec/paths/v2/gateway/setPolicies/index.yaml"
+  /v2/gateway.listPolicies:
+    $ref: "./spec/paths/v2/gateway/listPolicies/index.yaml"
 
   # Permissions Endpoints
   /v2/permissions.createRole:

--- a/svc/api/openapi/spec/common/PolicyResponse.yaml
+++ b/svc/api/openapi/spec/common/PolicyResponse.yaml
@@ -1,0 +1,50 @@
+type: object
+required:
+  - id
+  - name
+  - enabled
+properties:
+  id:
+    type: string
+    description: Server-generated policy id. Regenerated on every
+      `gateway.setPolicies` call, so treat it as stable only until the
+      environment's policies are next replaced.
+    example: pol_2gJbXhAr4
+  name:
+    type: string
+    minLength: 1
+    maxLength: 256
+    description: Human-readable name shown in the dashboard.
+  enabled:
+    type: boolean
+    description: Disabled policies are stored but skipped during evaluation.
+  match:
+    type: array
+    maxItems: 10
+    items:
+      "$ref": "./MatchExpr.yaml"
+    description: |-
+      Optional request matchers. The policy applies only to requests matching
+      all expressions; omitted when the policy applies to every request.
+  keyauth:
+    "$ref": "./KeyauthPolicy.yaml"
+  ratelimit:
+    "$ref": "./RatelimitPolicy.yaml"
+  firewall:
+    "$ref": "./FirewallPolicy.yaml"
+  openapi:
+    "$ref": "./OpenapiPolicy.yaml"
+additionalProperties: false
+description: |-
+  A stored gateway policy as returned by list endpoints. Exactly one of
+  `keyauth`, `ratelimit`, `firewall` or `openapi` is set.
+example:
+  id: pol_2gJbXhAr4
+  name: Block internal paths
+  enabled: true
+  match:
+    - path:
+        path:
+          prefix: /internal/
+  firewall:
+    action: ACTION_DENY

--- a/svc/api/openapi/spec/paths/v2/gateway/listPolicies/V2GatewayListPoliciesRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/gateway/listPolicies/V2GatewayListPoliciesRequestBody.yaml
@@ -1,0 +1,32 @@
+type: object
+required:
+  - project
+  - app
+  - environment
+properties:
+  project:
+    "$ref": "../../../../common/ResourceIdentifier.yaml"
+  app:
+    "$ref": "../../../../common/ResourceIdentifier.yaml"
+  environment:
+    "$ref": "../../../../common/ResourceIdentifier.yaml"
+  cursor:
+    type: string
+    maxLength: 1024
+    description: |
+      Pagination cursor from a previous response to fetch the next page of
+      policies. Leave empty or omit this field to start from the beginning.
+
+      Cursors expire whenever the environment's policies are replaced via
+      `gateway.setPolicies`, which regenerates every policy id. Requests
+      with an expired cursor fail with a 400 error - restart from the
+      beginning when that happens.
+    example: pol_2gJbXhAr4
+  limit:
+    type: integer
+    minimum: 1
+    maximum: 100
+    default: 100
+    description: Maximum number of policies to return in a single response.
+    example: 50
+additionalProperties: false

--- a/svc/api/openapi/spec/paths/v2/gateway/listPolicies/V2GatewayListPoliciesRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/gateway/listPolicies/V2GatewayListPoliciesRequestBody.yaml
@@ -25,8 +25,11 @@ properties:
   limit:
     type: integer
     minimum: 1
-    maximum: 100
-    default: 100
-    description: Maximum number of policies to return in a single response.
-    example: 50
+    maximum: 50
+    default: 50
+    description: |-
+      Maximum number of policies to return in a single response. The bound
+      matches the 50-policy cap of `gateway.setPolicies`, so the default
+      returns every policy in one page.
+    example: 25
 additionalProperties: false

--- a/svc/api/openapi/spec/paths/v2/gateway/listPolicies/V2GatewayListPoliciesRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/gateway/listPolicies/V2GatewayListPoliciesRequestBody.yaml
@@ -10,26 +10,4 @@ properties:
     "$ref": "../../../../common/ResourceIdentifier.yaml"
   environment:
     "$ref": "../../../../common/ResourceIdentifier.yaml"
-  cursor:
-    type: string
-    maxLength: 1024
-    description: |
-      Pagination cursor from a previous response to fetch the next page of
-      policies. Leave empty or omit this field to start from the beginning.
-
-      Cursors expire whenever the environment's policies are replaced via
-      `gateway.setPolicies`, which regenerates every policy id. Requests
-      with an expired cursor fail with a 400 error - restart from the
-      beginning when that happens.
-    example: pol_2gJbXhAr4
-  limit:
-    type: integer
-    minimum: 1
-    maximum: 50
-    default: 50
-    description: |-
-      Maximum number of policies to return in a single response. The bound
-      matches the 50-policy cap of `gateway.setPolicies`, so the default
-      returns every policy in one page.
-    example: 25
 additionalProperties: false

--- a/svc/api/openapi/spec/paths/v2/gateway/listPolicies/V2GatewayListPoliciesResponseBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/gateway/listPolicies/V2GatewayListPoliciesResponseBody.yaml
@@ -1,0 +1,13 @@
+type: object
+required:
+  - meta
+  - data
+  - pagination
+properties:
+  meta:
+    "$ref": "../../../../common/Meta.yaml"
+  data:
+    "$ref": "./V2GatewayListPoliciesResponseData.yaml"
+  pagination:
+    "$ref": "../../../../common/Pagination.yaml"
+additionalProperties: false

--- a/svc/api/openapi/spec/paths/v2/gateway/listPolicies/V2GatewayListPoliciesResponseBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/gateway/listPolicies/V2GatewayListPoliciesResponseBody.yaml
@@ -2,12 +2,9 @@ type: object
 required:
   - meta
   - data
-  - pagination
 properties:
   meta:
     "$ref": "../../../../common/Meta.yaml"
   data:
     "$ref": "./V2GatewayListPoliciesResponseData.yaml"
-  pagination:
-    "$ref": "../../../../common/Pagination.yaml"
 additionalProperties: false

--- a/svc/api/openapi/spec/paths/v2/gateway/listPolicies/V2GatewayListPoliciesResponseData.yaml
+++ b/svc/api/openapi/spec/paths/v2/gateway/listPolicies/V2GatewayListPoliciesResponseData.yaml
@@ -1,0 +1,5 @@
+type: array
+maxItems: 50
+description: The environment's gateway policies in evaluation order.
+items:
+  "$ref": "../../../../common/PolicyResponse.yaml"

--- a/svc/api/openapi/spec/paths/v2/gateway/listPolicies/index.yaml
+++ b/svc/api/openapi/spec/paths/v2/gateway/listPolicies/index.yaml
@@ -17,7 +17,7 @@ post:
   operationId: gateway.listPolicies
   x-speakeasy-name-override: listPolicies
   security:
-    - rootKey: []
+    - bearer: []
   requestBody:
     content:
       application/json:

--- a/svc/api/openapi/spec/paths/v2/gateway/listPolicies/index.yaml
+++ b/svc/api/openapi/spec/paths/v2/gateway/listPolicies/index.yaml
@@ -1,0 +1,95 @@
+post:
+  tags:
+    - gateway
+  summary: List policies
+  description: |
+    Retrieve an environment's gateway policies in evaluation order: the
+    gateway evaluates them top to bottom and the first rejection
+    short-circuits the request.
+
+    Results are paginated in stored order; treat the cursor as an opaque
+    token. Because `gateway.setPolicies` replaces the whole list and
+    regenerates every id, cursors expire whenever the environment's policies
+    change - restart from the beginning when a cursor is rejected.
+
+    **Required Permissions**
+
+    Your root key must have one of the following permissions:
+    - `environment.*.read_policies` (for any environment)
+    - `environment.<environment_id>.read_policies` (for a specific environment)
+  operationId: gateway.listPolicies
+  x-speakeasy-name-override: listPolicies
+  security:
+    - rootKey: []
+  requestBody:
+    content:
+      application/json:
+        schema:
+          "$ref": "./V2GatewayListPoliciesRequestBody.yaml"
+        examples:
+          list:
+            summary: List the environment's policies
+            value:
+              project: payments
+              app: payments-api
+              environment: production
+          page:
+            summary: Fetch the next page
+            value:
+              project: payments
+              app: payments-api
+              environment: production
+              cursor: pol_2gJbXhAr4
+              limit: 10
+    required: true
+  responses:
+    "200":
+      description: Policies retrieved successfully
+      content:
+        application/json:
+          schema:
+            "$ref": "./V2GatewayListPoliciesResponseBody.yaml"
+    "400":
+      description: Bad request
+      content:
+        application/json:
+          schema:
+            "$ref": "../../../../error/BadRequestErrorResponse.yaml"
+    "401":
+      description: Unauthorized
+      content:
+        application/json:
+          schema:
+            "$ref": "../../../../error/UnauthorizedErrorResponse.yaml"
+    "403":
+      description: Forbidden - Insufficient permissions (requires `environment.*.read_policies`)
+      content:
+        application/json:
+          schema:
+            "$ref": "../../../../error/ForbiddenErrorResponse.yaml"
+    "404":
+      description: Not Found - The environment does not exist in your workspace
+      content:
+        application/json:
+          schema:
+            "$ref": "../../../../error/NotFoundErrorResponse.yaml"
+    "429":
+      description: Too Many Requests
+      content:
+        application/problem+json:
+          schema:
+            "$ref": "../../../../error/TooManyRequestsErrorResponse.yaml"
+    "500":
+      description: Internal server error
+      content:
+        application/json:
+          schema:
+            "$ref": "../../../../error/InternalServerErrorResponse.yaml"
+  x-speakeasy-pagination:
+    type: cursor
+    inputs:
+      - name: cursor
+        in: requestBody
+        type: cursor
+    outputs:
+      nextCursor: "$.pagination.cursor"

--- a/svc/api/openapi/spec/paths/v2/gateway/listPolicies/index.yaml
+++ b/svc/api/openapi/spec/paths/v2/gateway/listPolicies/index.yaml
@@ -7,10 +7,7 @@ post:
     gateway evaluates them top to bottom and the first rejection
     short-circuits the request.
 
-    Results are paginated in stored order; treat the cursor as an opaque
-    token. Because `gateway.setPolicies` replaces the whole list and
-    regenerates every id, cursors expire whenever the environment's policies
-    change - restart from the beginning when a cursor is rejected.
+    The full policy list is returned in a single response.
 
     **Required Permissions**
 
@@ -33,14 +30,6 @@ post:
               project: payments
               app: payments-api
               environment: production
-          page:
-            summary: Fetch the next page
-            value:
-              project: payments
-              app: payments-api
-              environment: production
-              cursor: pol_2gJbXhAr4
-              limit: 10
     required: true
   responses:
     "200":
@@ -85,11 +74,3 @@ post:
         application/json:
           schema:
             "$ref": "../../../../error/InternalServerErrorResponse.yaml"
-  x-speakeasy-pagination:
-    type: cursor
-    inputs:
-      - name: cursor
-        in: requestBody
-        type: cursor
-    outputs:
-      nextCursor: "$.pagination.cursor"

--- a/svc/api/routes/register.go
+++ b/svc/api/routes/register.go
@@ -82,6 +82,7 @@ import (
 	v2EnvironmentsRemoveEnvironmentVariables "github.com/unkeyed/unkey/svc/api/routes/v2_environments_remove_environment_variables"
 	v2EnvironmentsSetEnvironmentVariables "github.com/unkeyed/unkey/svc/api/routes/v2_environments_set_environment_variables"
 	v2EnvironmentsUpdateSettings "github.com/unkeyed/unkey/svc/api/routes/v2_environments_update_settings"
+	v2GatewayListPolicies "github.com/unkeyed/unkey/svc/api/routes/v2_gateway_list_policies"
 	v2GatewaySetPolicies "github.com/unkeyed/unkey/svc/api/routes/v2_gateway_set_policies"
 	v2ProjectsCreateProject "github.com/unkeyed/unkey/svc/api/routes/v2_projects_create_project"
 	v2ProjectsDeleteProject "github.com/unkeyed/unkey/svc/api/routes/v2_projects_delete_project"
@@ -881,6 +882,14 @@ func Register(srv *zen.Server, svc *Services, info zen.InstanceInfo) {
 		&v2GatewaySetPolicies.Handler{
 			DB:        svc.Database,
 			Auditlogs: svc.Auditlogs,
+		},
+	)
+
+	// v2/gateway.listPolicies
+	srv.RegisterRoute(
+		protectedMiddlewares,
+		&v2GatewayListPolicies.Handler{
+			DB: svc.Database,
 		},
 	)
 

--- a/svc/api/routes/v2_gateway_list_policies/200_test.go
+++ b/svc/api/routes/v2_gateway_list_policies/200_test.go
@@ -36,8 +36,6 @@ func TestListPoliciesSuccessfully(t *testing.T) {
 		env := seedEnvironment(t, h)
 		res := call(t, makeRequest(env))
 		require.Empty(t, res.Body.Data)
-		require.False(t, res.Body.Pagination.HasMore)
-		require.Nil(t, res.Body.Pagination.Cursor)
 		// data must serialize as [], not null.
 		require.Contains(t, string(res.RawBody), `"data":[]`)
 	})
@@ -47,7 +45,6 @@ func TestListPoliciesSuccessfully(t *testing.T) {
 		seedSentinelConfig(t, h, env, `{"policies":[]}`)
 		res := call(t, makeRequest(env))
 		require.Empty(t, res.Body.Data)
-		require.False(t, res.Body.Pagination.HasMore)
 	})
 
 	t.Run("missing runtime settings row returns empty list", func(t *testing.T) {
@@ -59,7 +56,6 @@ func TestListPoliciesSuccessfully(t *testing.T) {
 
 		res := call(t, makeRequest(env))
 		require.Empty(t, res.Body.Data)
-		require.False(t, res.Body.Pagination.HasMore)
 	})
 
 	t.Run("all variants round out of storage with full fidelity", func(t *testing.T) {
@@ -90,8 +86,6 @@ func TestListPoliciesSuccessfully(t *testing.T) {
 
 		res := call(t, makeRequest(env))
 		require.Len(t, res.Body.Data, 4)
-		require.False(t, res.Body.Pagination.HasMore)
-		require.Nil(t, res.Body.Pagination.Cursor)
 
 		keyauth := res.Body.Data[0]
 		require.Equal(t, "pol_keyauth", keyauth.Id)
@@ -182,48 +176,12 @@ func TestListPoliciesSuccessfully(t *testing.T) {
 		require.NotNil(t, res.Body.Data[3].Ratelimit.Identifier.Path)
 	})
 
-	t.Run("paginates in stored order", func(t *testing.T) {
-		env := seedEnvironment(t, h)
-		ids := seedFirewallPolicies(t, h, env, 5)
-
-		page := func(t *testing.T, cursor *string) testutil.TestResponse[handler.Response] {
-			t.Helper()
-			req := makeRequest(env)
-			req.Limit = ptr.P(2)
-			req.Cursor = cursor
-			return call(t, req)
-		}
-
-		// Cursor convention matches the db-backed lists: the returned cursor
-		// is the first policy of the next page, fetched inclusively.
-		first := page(t, nil)
-		require.Len(t, first.Body.Data, 2)
-		require.Equal(t, ids[0], first.Body.Data[0].Id)
-		require.Equal(t, ids[1], first.Body.Data[1].Id)
-		require.True(t, first.Body.Pagination.HasMore)
-		require.Equal(t, ptr.P(ids[2]), first.Body.Pagination.Cursor)
-
-		second := page(t, first.Body.Pagination.Cursor)
-		require.Len(t, second.Body.Data, 2)
-		require.Equal(t, ids[2], second.Body.Data[0].Id)
-		require.Equal(t, ids[3], second.Body.Data[1].Id)
-		require.True(t, second.Body.Pagination.HasMore)
-		require.Equal(t, ptr.P(ids[4]), second.Body.Pagination.Cursor)
-
-		third := page(t, second.Body.Pagination.Cursor)
-		require.Len(t, third.Body.Data, 1)
-		require.Equal(t, ids[4], third.Body.Data[0].Id)
-		require.False(t, third.Body.Pagination.HasMore)
-		require.Nil(t, third.Body.Pagination.Cursor)
-	})
-
-	t.Run("default limit returns everything", func(t *testing.T) {
+	t.Run("returns every policy in stored order", func(t *testing.T) {
 		env := seedEnvironment(t, h)
 		ids := seedFirewallPolicies(t, h, env, 50)
 
 		res := call(t, makeRequest(env))
 		require.Len(t, res.Body.Data, 50)
-		require.False(t, res.Body.Pagination.HasMore)
 		for i, p := range res.Body.Data {
 			require.Equal(t, ids[i], p.Id)
 		}

--- a/svc/api/routes/v2_gateway_list_policies/200_test.go
+++ b/svc/api/routes/v2_gateway_list_policies/200_test.go
@@ -1,0 +1,275 @@
+package handler_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/ptr"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
+	"github.com/unkeyed/unkey/svc/api/openapi"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_gateway_list_policies"
+	setpolicies "github.com/unkeyed/unkey/svc/api/routes/v2_gateway_set_policies"
+)
+
+func TestListPoliciesSuccessfully(t *testing.T) {
+	h := testutil.NewHarness(t)
+
+	route := &handler.Handler{DB: h.DB}
+	h.Register(route)
+
+	workspace := h.Resources().UserWorkspace
+	rootKey := h.CreateRootKey(workspace.ID, "environment.*.read_policies")
+	headers := authHeaders(rootKey)
+
+	call := func(t *testing.T, req handler.Request) testutil.TestResponse[handler.Response] {
+		t.Helper()
+		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, req)
+		require.Equal(t, 200, res.Status, "expected 200, received: %s", res.RawBody)
+		require.NotEmpty(t, res.Body.Meta.RequestId)
+		return res
+	}
+
+	t.Run("legacy empty blob returns empty list", func(t *testing.T) {
+		// The environment seeder creates the runtime settings row with "{}".
+		env := seedEnvironment(t, h)
+		res := call(t, makeRequest(env))
+		require.Empty(t, res.Body.Data)
+		require.False(t, res.Body.Pagination.HasMore)
+		require.Nil(t, res.Body.Pagination.Cursor)
+		// data must serialize as [], not null.
+		require.Contains(t, string(res.RawBody), `"data":[]`)
+	})
+
+	t.Run("explicit empty policies blob returns empty list", func(t *testing.T) {
+		env := seedEnvironment(t, h)
+		seedSentinelConfig(t, h, env, `{"policies":[]}`)
+		res := call(t, makeRequest(env))
+		require.Empty(t, res.Body.Data)
+		require.False(t, res.Body.Pagination.HasMore)
+	})
+
+	t.Run("missing runtime settings row returns empty list", func(t *testing.T) {
+		env := seedEnvironment(t, h)
+		_, err := h.DB.RW().ExecContext(context.Background(),
+			"DELETE FROM app_runtime_settings WHERE app_id = ? AND environment_id = ?",
+			env.appID, env.environmentID)
+		require.NoError(t, err)
+
+		res := call(t, makeRequest(env))
+		require.Empty(t, res.Body.Data)
+		require.False(t, res.Body.Pagination.HasMore)
+	})
+
+	t.Run("all variants round out of storage with full fidelity", func(t *testing.T) {
+		env := seedEnvironment(t, h)
+		// protojson wire shape, including int64-as-string, exactly as the
+		// write path stores it.
+		seedSentinelConfig(t, h, env, `{"policies":[
+			{"id":"pol_keyauth","name":"keyauth KEBAP","enabled":true,
+				"match":[
+					{"path":{"path":{"prefix":"/internal/","ignoreCase":true}}},
+					{"method":{"methods":["GET","POST"]}},
+					{"header":{"name":"X-Debug","present":true}},
+					{"queryParam":{"name":"v","value":{"exact":"1"}}}
+				],
+				"keyauth":{
+					"keySpaceIds":["ks_kebap"],
+					"locations":[{"bearer":{}},{"header":{"name":"X-Api-Key","stripPrefix":"Key "}},{"queryParam":{"name":"api_key"}}],
+					"permissionQuery":"documents.read",
+					"ratelimits":[{"name":"tokens"},{"name":"burst","limit":"100","duration":"60000","cost":"2"}]
+				}},
+			{"id":"pol_ratelimit","name":"ratelimit","enabled":true,
+				"ratelimit":{"limit":"100","windowMs":"60000","identifier":{"principalField":{"path":"sub"}}}},
+			{"id":"pol_firewall","name":"firewall","enabled":false,
+				"firewall":{"action":"ACTION_DENY"}},
+			{"id":"pol_openapi","name":"openapi",
+				"openapi":{}}
+		]}`)
+
+		res := call(t, makeRequest(env))
+		require.Len(t, res.Body.Data, 4)
+		require.False(t, res.Body.Pagination.HasMore)
+		require.Nil(t, res.Body.Pagination.Cursor)
+
+		keyauth := res.Body.Data[0]
+		require.Equal(t, "pol_keyauth", keyauth.Id)
+		require.Equal(t, "keyauth KEBAP", keyauth.Name)
+		require.True(t, keyauth.Enabled)
+		require.NotNil(t, keyauth.Keyauth)
+		require.Nil(t, keyauth.Ratelimit)
+		require.Nil(t, keyauth.Firewall)
+		require.Nil(t, keyauth.Openapi)
+		require.Equal(t, []string{"ks_kebap"}, keyauth.Keyauth.Keyspaces)
+		require.Equal(t, ptr.P("documents.read"), keyauth.Keyauth.PermissionQuery)
+
+		locations := ptr.SafeDeref(keyauth.Keyauth.Locations)
+		require.Len(t, locations, 3)
+		require.NotNil(t, locations[0].Bearer)
+		require.NotNil(t, locations[1].Header)
+		require.Equal(t, "X-Api-Key", locations[1].Header.Name)
+		require.Equal(t, ptr.P("Key "), locations[1].Header.StripPrefix)
+		require.NotNil(t, locations[2].QueryParam)
+		require.Equal(t, "api_key", locations[2].QueryParam.Name)
+
+		ratelimits := ptr.SafeDeref(keyauth.Keyauth.Ratelimits)
+		require.Len(t, ratelimits, 2)
+		require.Equal(t, "tokens", ratelimits[0].Name)
+		require.Nil(t, ratelimits[0].Limit)
+		require.Nil(t, ratelimits[0].Duration)
+		require.Nil(t, ratelimits[0].Cost)
+		require.Equal(t, "burst", ratelimits[1].Name)
+		require.Equal(t, ptr.P(int64(100)), ratelimits[1].Limit)
+		require.Equal(t, ptr.P(int64(60000)), ratelimits[1].Duration)
+		require.Equal(t, ptr.P(int64(2)), ratelimits[1].Cost)
+
+		match := ptr.SafeDeref(keyauth.Match)
+		require.Len(t, match, 4)
+		require.NotNil(t, match[0].Path)
+		require.Equal(t, ptr.P("/internal/"), match[0].Path.Path.Prefix)
+		require.Equal(t, ptr.P(true), match[0].Path.Path.IgnoreCase)
+		require.NotNil(t, match[1].Method)
+		require.Equal(t, []openapi.MethodMatchMethods{"GET", "POST"}, match[1].Method.Methods)
+		require.NotNil(t, match[2].Header)
+		require.Equal(t, "X-Debug", match[2].Header.Name)
+		require.Equal(t, ptr.P(openapi.FieldMatchPresent(true)), match[2].Header.Present)
+		require.Nil(t, match[2].Header.Value)
+		require.NotNil(t, match[3].QueryParam)
+		require.Equal(t, "v", match[3].QueryParam.Name)
+		require.NotNil(t, match[3].QueryParam.Value)
+		require.Equal(t, ptr.P("1"), match[3].QueryParam.Value.Exact)
+		require.Nil(t, match[3].QueryParam.Value.IgnoreCase)
+
+		ratelimit := res.Body.Data[1]
+		require.Equal(t, "pol_ratelimit", ratelimit.Id)
+		require.NotNil(t, ratelimit.Ratelimit)
+		require.Equal(t, int64(100), ratelimit.Ratelimit.Limit)
+		require.Equal(t, int64(60000), ratelimit.Ratelimit.WindowMs)
+		require.NotNil(t, ratelimit.Ratelimit.Identifier.PrincipalField)
+		require.Equal(t, "sub", ratelimit.Ratelimit.Identifier.PrincipalField.Path)
+
+		firewall := res.Body.Data[2]
+		require.Equal(t, "pol_firewall", firewall.Id)
+		require.False(t, firewall.Enabled)
+		require.NotNil(t, firewall.Firewall)
+		require.Equal(t, openapi.FirewallPolicyAction("ACTION_DENY"), firewall.Firewall.Action)
+		require.Nil(t, firewall.Match)
+
+		oa := res.Body.Data[3]
+		require.Equal(t, "pol_openapi", oa.Id)
+		// enabled was absent in the blob: proto optional bool defaults to
+		// false, matching frontline evaluation semantics.
+		require.False(t, oa.Enabled)
+		require.NotNil(t, oa.Openapi)
+	})
+
+	t.Run("every ratelimit identifier source maps", func(t *testing.T) {
+		env := seedEnvironment(t, h)
+		seedSentinelConfig(t, h, env, `{"policies":[
+			{"id":"pol_ip","name":"ip","enabled":true,"ratelimit":{"limit":"1","windowMs":"1000","identifier":{"remoteIp":{}}}},
+			{"id":"pol_hdr","name":"hdr","enabled":true,"ratelimit":{"limit":"1","windowMs":"1000","identifier":{"header":{"name":"X-Tenant"}}}},
+			{"id":"pol_sub","name":"sub","enabled":true,"ratelimit":{"limit":"1","windowMs":"1000","identifier":{"authenticatedSubject":{}}}},
+			{"id":"pol_path","name":"path","enabled":true,"ratelimit":{"limit":"1","windowMs":"1000","identifier":{"path":{}}}}
+		]}`)
+
+		res := call(t, makeRequest(env))
+		require.Len(t, res.Body.Data, 4)
+		require.NotNil(t, res.Body.Data[0].Ratelimit.Identifier.RemoteIp)
+		require.NotNil(t, res.Body.Data[1].Ratelimit.Identifier.Header)
+		require.Equal(t, "X-Tenant", res.Body.Data[1].Ratelimit.Identifier.Header.Name)
+		require.NotNil(t, res.Body.Data[2].Ratelimit.Identifier.AuthenticatedSubject)
+		require.NotNil(t, res.Body.Data[3].Ratelimit.Identifier.Path)
+	})
+
+	t.Run("paginates in stored order", func(t *testing.T) {
+		env := seedEnvironment(t, h)
+		ids := seedFirewallPolicies(t, h, env, 5)
+
+		page := func(t *testing.T, cursor *string) testutil.TestResponse[handler.Response] {
+			t.Helper()
+			req := makeRequest(env)
+			req.Limit = ptr.P(2)
+			req.Cursor = cursor
+			return call(t, req)
+		}
+
+		// Cursor convention matches the db-backed lists: the returned cursor
+		// is the first policy of the next page, fetched inclusively.
+		first := page(t, nil)
+		require.Len(t, first.Body.Data, 2)
+		require.Equal(t, ids[0], first.Body.Data[0].Id)
+		require.Equal(t, ids[1], first.Body.Data[1].Id)
+		require.True(t, first.Body.Pagination.HasMore)
+		require.Equal(t, ptr.P(ids[2]), first.Body.Pagination.Cursor)
+
+		second := page(t, first.Body.Pagination.Cursor)
+		require.Len(t, second.Body.Data, 2)
+		require.Equal(t, ids[2], second.Body.Data[0].Id)
+		require.Equal(t, ids[3], second.Body.Data[1].Id)
+		require.True(t, second.Body.Pagination.HasMore)
+		require.Equal(t, ptr.P(ids[4]), second.Body.Pagination.Cursor)
+
+		third := page(t, second.Body.Pagination.Cursor)
+		require.Len(t, third.Body.Data, 1)
+		require.Equal(t, ids[4], third.Body.Data[0].Id)
+		require.False(t, third.Body.Pagination.HasMore)
+		require.Nil(t, third.Body.Pagination.Cursor)
+	})
+
+	t.Run("default limit returns everything", func(t *testing.T) {
+		env := seedEnvironment(t, h)
+		ids := seedFirewallPolicies(t, h, env, 50)
+
+		res := call(t, makeRequest(env))
+		require.Len(t, res.Body.Data, 50)
+		require.False(t, res.Body.Pagination.HasMore)
+		for i, p := range res.Body.Data {
+			require.Equal(t, ids[i], p.Id)
+		}
+	})
+
+	t.Run("reads back what setPolicies wrote", func(t *testing.T) {
+		writeRoute := &setpolicies.Handler{DB: h.DB, Auditlogs: h.Auditlogs}
+		h.Register(writeRoute)
+
+		env := seedEnvironment(t, h)
+		api := h.CreateApi(seed.CreateApiRequest{WorkspaceID: workspace.ID})
+		writeKey := h.CreateRootKey(workspace.ID, "environment.*.set_policies")
+
+		writeRes := testutil.CallRoute[setpolicies.Request, setpolicies.Response](h, writeRoute, authHeaders(writeKey), setpolicies.Request{
+			Project:     env.projectID,
+			App:         env.appID,
+			Environment: env.environmentID,
+			Policies: []openapi.Policy{
+				{
+					Name:    "require key",
+					Enabled: true,
+					Keyauth: &openapi.KeyauthPolicy{Keyspaces: []string{api.KeyAuthID.String}},
+				},
+				{
+					Name:     "deny",
+					Enabled:  false,
+					Firewall: &openapi.FirewallPolicy{Action: "ACTION_DENY"},
+				},
+			},
+		})
+		require.Equal(t, 200, writeRes.Status, "expected 200, received: %s", writeRes.RawBody)
+
+		res := call(t, makeRequest(env))
+		require.Len(t, res.Body.Data, 2)
+
+		require.Equal(t, "require key", res.Body.Data[0].Name)
+		require.True(t, res.Body.Data[0].Enabled)
+		require.NotNil(t, res.Body.Data[0].Keyauth)
+		require.Equal(t, []string{api.KeyAuthID.String}, res.Body.Data[0].Keyauth.Keyspaces)
+
+		require.Equal(t, "deny", res.Body.Data[1].Name)
+		require.False(t, res.Body.Data[1].Enabled)
+		require.NotNil(t, res.Body.Data[1].Firewall)
+
+		for _, p := range res.Body.Data {
+			require.Regexp(t, `^pol_[a-zA-Z0-9]{9}$`, p.Id)
+		}
+	})
+}

--- a/svc/api/routes/v2_gateway_list_policies/400_test.go
+++ b/svc/api/routes/v2_gateway_list_policies/400_test.go
@@ -1,0 +1,72 @@
+package handler_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/ptr"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	"github.com/unkeyed/unkey/svc/api/openapi"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_gateway_list_policies"
+)
+
+func TestListPoliciesBadRequest(t *testing.T) {
+	h := testutil.NewHarness(t)
+
+	route := &handler.Handler{DB: h.DB}
+	h.Register(route)
+
+	workspace := h.Resources().UserWorkspace
+	rootKey := h.CreateRootKey(workspace.ID, "environment.*.read_policies")
+	headers := authHeaders(rootKey)
+	env := seedEnvironment(t, h)
+	seedFirewallPolicies(t, h, env, 3)
+
+	callTyped := func(t *testing.T, req handler.Request) testutil.TestResponse[openapi.BadRequestErrorResponse] {
+		t.Helper()
+		return testutil.CallRoute[handler.Request, openapi.BadRequestErrorResponse](h, route, headers, req)
+	}
+
+	t.Run("unknown cursor", func(t *testing.T) {
+		req := makeRequest(env)
+		req.Cursor = ptr.P("pol_does_not_exist")
+		res := callTyped(t, req)
+		require.Equal(t, http.StatusBadRequest, res.Status, "received: %s", res.RawBody)
+		require.Contains(t, res.Body.Error.Type, "invalid_input")
+		require.Contains(t, res.Body.Error.Detail, "cursor")
+	})
+
+	t.Run("cursor against empty policy list", func(t *testing.T) {
+		empty := seedEnvironment(t, h)
+		req := makeRequest(empty)
+		req.Cursor = ptr.P("pol_000")
+		res := callTyped(t, req)
+		require.Equal(t, http.StatusBadRequest, res.Status, "received: %s", res.RawBody)
+	})
+
+	t.Run("limit zero", func(t *testing.T) {
+		req := makeRequest(env)
+		req.Limit = ptr.P(0)
+		res := callTyped(t, req)
+		require.Equal(t, http.StatusBadRequest, res.Status, "received: %s", res.RawBody)
+	})
+
+	t.Run("limit above maximum", func(t *testing.T) {
+		req := makeRequest(env)
+		req.Limit = ptr.P(101)
+		res := callTyped(t, req)
+		require.Equal(t, http.StatusBadRequest, res.Status, "received: %s", res.RawBody)
+	})
+
+	t.Run("missing identifiers", func(t *testing.T) {
+		res := callTyped(t, handler.Request{
+			Project:     "",
+			App:         "",
+			Environment: "",
+			Cursor:      nil,
+			Limit:       nil,
+		})
+		require.Equal(t, http.StatusBadRequest, res.Status, "received: %s", res.RawBody)
+	})
+}

--- a/svc/api/routes/v2_gateway_list_policies/400_test.go
+++ b/svc/api/routes/v2_gateway_list_policies/400_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/unkeyed/unkey/pkg/ptr"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_gateway_list_policies"
@@ -20,52 +19,17 @@ func TestListPoliciesBadRequest(t *testing.T) {
 	workspace := h.Resources().UserWorkspace
 	rootKey := h.CreateRootKey(workspace.ID, "environment.*.read_policies")
 	headers := authHeaders(rootKey)
-	env := seedEnvironment(t, h)
-	seedFirewallPolicies(t, h, env, 3)
 
 	callTyped := func(t *testing.T, req handler.Request) testutil.TestResponse[openapi.BadRequestErrorResponse] {
 		t.Helper()
 		return testutil.CallRoute[handler.Request, openapi.BadRequestErrorResponse](h, route, headers, req)
 	}
 
-	t.Run("unknown cursor", func(t *testing.T) {
-		req := makeRequest(env)
-		req.Cursor = ptr.P("pol_does_not_exist")
-		res := callTyped(t, req)
-		require.Equal(t, http.StatusBadRequest, res.Status, "received: %s", res.RawBody)
-		require.Contains(t, res.Body.Error.Type, "invalid_input")
-		require.Contains(t, res.Body.Error.Detail, "cursor")
-	})
-
-	t.Run("cursor against empty policy list", func(t *testing.T) {
-		empty := seedEnvironment(t, h)
-		req := makeRequest(empty)
-		req.Cursor = ptr.P("pol_000")
-		res := callTyped(t, req)
-		require.Equal(t, http.StatusBadRequest, res.Status, "received: %s", res.RawBody)
-	})
-
-	t.Run("limit zero", func(t *testing.T) {
-		req := makeRequest(env)
-		req.Limit = ptr.P(0)
-		res := callTyped(t, req)
-		require.Equal(t, http.StatusBadRequest, res.Status, "received: %s", res.RawBody)
-	})
-
-	t.Run("limit above maximum", func(t *testing.T) {
-		req := makeRequest(env)
-		req.Limit = ptr.P(51)
-		res := callTyped(t, req)
-		require.Equal(t, http.StatusBadRequest, res.Status, "received: %s", res.RawBody)
-	})
-
 	t.Run("missing identifiers", func(t *testing.T) {
 		res := callTyped(t, handler.Request{
 			Project:     "",
 			App:         "",
 			Environment: "",
-			Cursor:      nil,
-			Limit:       nil,
 		})
 		require.Equal(t, http.StatusBadRequest, res.Status, "received: %s", res.RawBody)
 	})

--- a/svc/api/routes/v2_gateway_list_policies/400_test.go
+++ b/svc/api/routes/v2_gateway_list_policies/400_test.go
@@ -54,7 +54,7 @@ func TestListPoliciesBadRequest(t *testing.T) {
 
 	t.Run("limit above maximum", func(t *testing.T) {
 		req := makeRequest(env)
-		req.Limit = ptr.P(101)
+		req.Limit = ptr.P(51)
 		res := callTyped(t, req)
 		require.Equal(t, http.StatusBadRequest, res.Status, "received: %s", res.RawBody)
 	})

--- a/svc/api/routes/v2_gateway_list_policies/401_test.go
+++ b/svc/api/routes/v2_gateway_list_policies/401_test.go
@@ -23,8 +23,6 @@ func TestListPoliciesUnauthorized(t *testing.T) {
 		Project:     "payments",
 		App:         "payments-api",
 		Environment: "env_1234abcd",
-		Cursor:      nil,
-		Limit:       nil,
 	})
 	require.Equal(t, http.StatusUnauthorized, res.Status, "expected 401, received: %s", res.RawBody)
 }

--- a/svc/api/routes/v2_gateway_list_policies/401_test.go
+++ b/svc/api/routes/v2_gateway_list_policies/401_test.go
@@ -1,0 +1,30 @@
+package handler_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_gateway_list_policies"
+)
+
+func TestListPoliciesUnauthorized(t *testing.T) {
+	h := testutil.NewHarness(t)
+
+	route := &handler.Handler{DB: h.DB}
+	h.Register(route)
+
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {"Bearer invalid_token"},
+	}
+	res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{
+		Project:     "payments",
+		App:         "payments-api",
+		Environment: "env_1234abcd",
+		Cursor:      nil,
+		Limit:       nil,
+	})
+	require.Equal(t, http.StatusUnauthorized, res.Status, "expected 401, received: %s", res.RawBody)
+}

--- a/svc/api/routes/v2_gateway_list_policies/403_test.go
+++ b/svc/api/routes/v2_gateway_list_policies/403_test.go
@@ -1,0 +1,50 @@
+package handler_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_gateway_list_policies"
+)
+
+func TestListPoliciesForbidden(t *testing.T) {
+	h := testutil.NewHarness(t)
+
+	route := &handler.Handler{DB: h.DB}
+	h.Register(route)
+
+	env := seedEnvironment(t, h)
+
+	testCases := []struct {
+		name        string
+		permissions []string
+		shouldPass  bool
+	}{
+		{name: "wildcard permission", permissions: []string{"environment.*.read_policies"}, shouldPass: true},
+		{name: "specific permission", permissions: []string{fmt.Sprintf("environment.%s.read_policies", env.environmentID)}, shouldPass: true},
+		{name: "permission and more", permissions: []string{"some.other.permission", "environment.*.read_policies"}, shouldPass: true},
+		{name: "set action is not enough", permissions: []string{"environment.*.set_policies"}, shouldPass: false},
+		{name: "read environment action is not enough", permissions: []string{"environment.*.read_environment"}, shouldPass: false},
+		{name: "other environment id does not match", permissions: []string{fmt.Sprintf("environment.%s.read_policies", uid.New(uid.EnvironmentPrefix))}, shouldPass: false},
+		{name: "unrelated permission", permissions: []string{"api.*.read_api"}, shouldPass: false},
+		{name: "no permissions", permissions: []string{}, shouldPass: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rootKey := h.CreateRootKey(env.workspaceID, tc.permissions...)
+			headers := authHeaders(rootKey)
+
+			res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, makeRequest(env))
+			if tc.shouldPass {
+				require.Equal(t, 200, res.Status, "expected 200 for %v, got: %s", tc.permissions, res.RawBody)
+				return
+			}
+			require.Equal(t, http.StatusForbidden, res.Status, "expected 403 for %v, got: %s", tc.permissions, res.RawBody)
+		})
+	}
+}

--- a/svc/api/routes/v2_gateway_list_policies/404_test.go
+++ b/svc/api/routes/v2_gateway_list_policies/404_test.go
@@ -1,0 +1,50 @@
+package handler_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_gateway_list_policies"
+)
+
+func TestListPoliciesNotFound(t *testing.T) {
+	h := testutil.NewHarness(t)
+
+	route := &handler.Handler{DB: h.DB}
+	h.Register(route)
+
+	env := seedEnvironment(t, h)
+	rootKey := h.CreateRootKey(env.workspaceID, "environment.*.read_policies")
+	headers := authHeaders(rootKey)
+
+	t.Run("nonexistent environment", func(t *testing.T) {
+		req := makeRequest(env)
+		req.Environment = uid.New(uid.EnvironmentPrefix)
+		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, req)
+		require.Equal(t, http.StatusNotFound, res.Status, "expected 404, received: %s", res.RawBody)
+	})
+
+	t.Run("nonexistent project", func(t *testing.T) {
+		req := makeRequest(env)
+		req.Project = uid.New(uid.ProjectPrefix)
+		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, req)
+		require.Equal(t, http.StatusNotFound, res.Status, "expected 404, received: %s", res.RawBody)
+	})
+
+	t.Run("nonexistent app", func(t *testing.T) {
+		req := makeRequest(env)
+		req.App = uid.New(uid.AppPrefix)
+		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, req)
+		require.Equal(t, http.StatusNotFound, res.Status, "expected 404, received: %s", res.RawBody)
+	})
+
+	t.Run("another workspace's environment", func(t *testing.T) {
+		other := h.CreateWorkspace()
+		foreignKey := h.CreateRootKey(other.ID, "environment.*.read_policies")
+		res := testutil.CallRoute[handler.Request, handler.Response](h, route, authHeaders(foreignKey), makeRequest(env))
+		require.Equal(t, http.StatusNotFound, res.Status, "expected 404, received: %s", res.RawBody)
+	})
+}

--- a/svc/api/routes/v2_gateway_list_policies/handler.go
+++ b/svc/api/routes/v2_gateway_list_policies/handler.go
@@ -118,7 +118,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	// Policies live in one ordered blob, so pagination is a slice window:
 	// the cursor resolves to its index and the window over-fetches one item,
 	// matching the id >= cursor look-ahead convention of the db-backed lists.
-	p := pagination.Parse(req.Limit, req.Cursor, 100)
+	p := pagination.Parse(req.Limit, req.Cursor, 50)
 	start := 0
 	if p.Cursor != "" {
 		start = slices.IndexFunc(all, func(policy openapi.PolicyResponse) bool { return policy.Id == p.Cursor })

--- a/svc/api/routes/v2_gateway_list_policies/handler.go
+++ b/svc/api/routes/v2_gateway_list_policies/handler.go
@@ -3,14 +3,12 @@ package handler
 import (
 	"context"
 	"net/http"
-	"slices"
 
 	"github.com/unkeyed/unkey/pkg/codes"
 	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/fault"
 	"github.com/unkeyed/unkey/pkg/rbac"
 	"github.com/unkeyed/unkey/pkg/zen"
-	"github.com/unkeyed/unkey/svc/api/internal/pagination"
 	"github.com/unkeyed/unkey/svc/api/internal/policyconfig"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
@@ -82,14 +80,17 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	// A missing settings row means the environment was never configured;
-	// that's an empty policy list, not an error. On NotFound the row is its
-	// zero value, so the blob comes back nil either way.
 	settings, err := db.Query.FindAppRuntimeSettingsByAppAndEnv(ctx, h.DB.RO(), db.FindAppRuntimeSettingsByAppAndEnvParams{
 		AppID:         env.AppID,
 		EnvironmentID: env.ID,
 	})
-	if err != nil && !db.IsNotFound(err) {
+	if err != nil {
+		if db.IsNotFound(err) {
+			return s.JSON(http.StatusOK, Response{
+				Meta: openapi.Meta{RequestId: s.RequestID()},
+				Data: []openapi.PolicyResponse{},
+			})
+		}
 		return fault.Wrap(
 			err,
 			fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
@@ -97,9 +98,9 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			fault.Public("We're unable to list the policies."),
 		)
 	}
-	// An undecodable blob is an error: frontline skips broken configs to
-	// keep serving traffic, but a management API must not report "no
-	// policies" for an environment whose config it cannot read.
+	// Frontline tolerates a broken blob by skipping it to stay up, but we
+	// must surface the failure rather than pass an unreadable
+	// config off as "no policies".
 	cfg, err := policyconfig.Parse(settings.AppRuntimeSetting.SentinelConfig)
 	if err != nil {
 		return fault.Wrap(
@@ -115,29 +116,8 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	// Policies live in one ordered blob, so pagination is a slice window:
-	// the cursor resolves to its index and the window over-fetches one item,
-	// matching the id >= cursor look-ahead convention of the db-backed lists.
-	p := pagination.Parse(req.Limit, req.Cursor, 50)
-	start := 0
-	if p.Cursor != "" {
-		start = slices.IndexFunc(all, func(policy openapi.PolicyResponse) bool { return policy.Id == p.Cursor })
-		if start < 0 {
-			return fault.New(
-				"cursor not found",
-				fault.Code(codes.App.Validation.InvalidInput.URN()),
-				fault.Internal("cursor id not present in stored policies"),
-				fault.Public("The provided cursor is invalid or has expired."),
-			)
-		}
-	}
-
-	window := all[start:min(start+int(p.FetchLimit()), len(all))]
-	page, pg := pagination.Paginate(window, p, func(policy openapi.PolicyResponse) string { return policy.Id })
-
 	return s.JSON(http.StatusOK, Response{
-		Meta:       openapi.Meta{RequestId: s.RequestID()},
-		Data:       page,
-		Pagination: pg,
+		Meta: openapi.Meta{RequestId: s.RequestID()},
+		Data: all,
 	})
 }

--- a/svc/api/routes/v2_gateway_list_policies/handler.go
+++ b/svc/api/routes/v2_gateway_list_policies/handler.go
@@ -1,0 +1,143 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"slices"
+
+	"github.com/unkeyed/unkey/pkg/codes"
+	"github.com/unkeyed/unkey/pkg/db"
+	"github.com/unkeyed/unkey/pkg/fault"
+	"github.com/unkeyed/unkey/pkg/rbac"
+	"github.com/unkeyed/unkey/pkg/zen"
+	"github.com/unkeyed/unkey/svc/api/internal/pagination"
+	"github.com/unkeyed/unkey/svc/api/internal/policyconfig"
+	"github.com/unkeyed/unkey/svc/api/openapi"
+)
+
+type (
+	Request  = openapi.V2GatewayListPoliciesRequestBody
+	Response = openapi.V2GatewayListPoliciesResponseBody
+)
+
+type Handler struct {
+	DB db.Database
+}
+
+func (h *Handler) Method() string {
+	return "POST"
+}
+
+func (h *Handler) Path() string {
+	return "/v2/gateway.listPolicies"
+}
+
+func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
+	principal, err := s.GetPrincipal()
+	if err != nil {
+		return err
+	}
+
+	req, err := zen.BindBody[Request](s)
+	if err != nil {
+		return err
+	}
+
+	env, err := db.Query.FindEnvironmentByIdentifiers(ctx, h.DB.RO(), db.FindEnvironmentByIdentifiersParams{
+		WorkspaceID: principal.WorkspaceID,
+		Project:     req.Project,
+		App:         req.App,
+		Environment: req.Environment,
+	})
+	if err != nil {
+		if db.IsNotFound(err) {
+			return fault.New(
+				"environment not found",
+				fault.Code(codes.Data.Environment.NotFound.URN()),
+				fault.Internal("environment not found"),
+				fault.Public("The requested environment does not exist."),
+			)
+		}
+		return fault.Wrap(
+			err,
+			fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
+			fault.Internal("database error"),
+			fault.Public("Failed to retrieve environment."),
+		)
+	}
+
+	err = principal.Authorize(rbac.Or(
+		rbac.T(rbac.Tuple{
+			ResourceType: rbac.Environment,
+			ResourceID:   "*",
+			Action:       rbac.ReadPolicies,
+		}),
+		rbac.T(rbac.Tuple{
+			ResourceType: rbac.Environment,
+			ResourceID:   env.ID,
+			Action:       rbac.ReadPolicies,
+		}),
+	))
+	if err != nil {
+		return err
+	}
+
+	// A missing settings row means the environment was never configured;
+	// that's an empty policy list, not an error. On NotFound the row is its
+	// zero value, so the blob comes back nil either way.
+	settings, err := db.Query.FindAppRuntimeSettingsByAppAndEnv(ctx, h.DB.RO(), db.FindAppRuntimeSettingsByAppAndEnvParams{
+		AppID:         env.AppID,
+		EnvironmentID: env.ID,
+	})
+	if err != nil && !db.IsNotFound(err) {
+		return fault.Wrap(
+			err,
+			fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
+			fault.Internal("unable to read sentinel config"),
+			fault.Public("We're unable to list the policies."),
+		)
+	}
+	// An undecodable blob is an error: frontline skips broken configs to
+	// keep serving traffic, but a management API must not report "no
+	// policies" for an environment whose config it cannot read.
+	cfg, err := policyconfig.Parse(settings.AppRuntimeSetting.SentinelConfig)
+	if err != nil {
+		return fault.Wrap(
+			err,
+			fault.Code(codes.App.Internal.UnexpectedError.URN()),
+			fault.Internal("stored sentinel config is not valid protojson"),
+			fault.Public("We're unable to list the policies."),
+		)
+	}
+
+	all, err := mapPoliciesFromProto(cfg.GetPolicies())
+	if err != nil {
+		return err
+	}
+
+	// Policies live in one ordered blob, so pagination is a slice window:
+	// the cursor resolves to its index and the window over-fetches one item,
+	// matching the id >= cursor look-ahead convention of the db-backed lists.
+	p := pagination.Parse(req.Limit, req.Cursor, 100)
+	start := 0
+	if p.Cursor != "" {
+		start = slices.IndexFunc(all, func(policy openapi.PolicyResponse) bool { return policy.Id == p.Cursor })
+		if start < 0 {
+			return fault.New(
+				"cursor not found",
+				fault.Code(codes.App.Validation.InvalidInput.URN()),
+				fault.Internal("cursor id not present in stored policies"),
+				fault.Public("The provided cursor is invalid or has expired."),
+			)
+		}
+	}
+
+	window := all[start:min(start+int(p.FetchLimit()), len(all))]
+	page, pg := pagination.Paginate(window, p, func(policy openapi.PolicyResponse) string { return policy.Id })
+
+	return s.JSON(http.StatusOK, Response{
+		Meta:       openapi.Meta{RequestId: s.RequestID()},
+		Data:       page,
+		Pagination: pg,
+	})
+}

--- a/svc/api/routes/v2_gateway_list_policies/helpers_test.go
+++ b/svc/api/routes/v2_gateway_list_policies/helpers_test.go
@@ -1,0 +1,114 @@
+package handler_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_gateway_list_policies"
+)
+
+func makeRequest(env seededEnv) handler.Request {
+	return handler.Request{
+		Project:     env.projectID,
+		App:         env.appID,
+		Environment: env.environmentID,
+		Cursor:      nil,
+		Limit:       nil,
+	}
+}
+
+type seededEnv struct {
+	workspaceID   string
+	projectID     string
+	appID         string
+	environmentID string
+}
+
+func seedEnvironment(t *testing.T, h *testutil.Harness) seededEnv {
+	t.Helper()
+
+	workspace := h.Resources().UserWorkspace
+
+	project := h.CreateProject(seed.CreateProjectRequest{
+		ID:          uid.New(uid.ProjectPrefix),
+		WorkspaceID: workspace.ID,
+		Name:        "Payments Service",
+		Slug:        strings.ToLower(strings.ReplaceAll(uid.New("test"), "_", "-")),
+	})
+
+	app := h.CreateApp(seed.CreateAppRequest{
+		ID:            uid.New(uid.AppPrefix),
+		WorkspaceID:   workspace.ID,
+		ProjectID:     project.ID,
+		Name:          "Payments API",
+		Slug:          strings.ToLower(strings.ReplaceAll(uid.New("test"), "_", "-")),
+		DefaultBranch: "main",
+	})
+
+	environment := h.CreateEnvironment(seed.CreateEnvironmentRequest{
+		ID:          uid.New(uid.EnvironmentPrefix),
+		WorkspaceID: workspace.ID,
+		ProjectID:   project.ID,
+		AppID:       app.ID,
+		Slug:        "production",
+		Description: "Production environment",
+	})
+
+	return seededEnv{
+		workspaceID:   workspace.ID,
+		projectID:     project.ID,
+		appID:         app.ID,
+		environmentID: environment.ID,
+	}
+}
+
+// seedSentinelConfig overwrites the seeded runtime settings row's blob
+// directly, bypassing the write handler, so tests can set up pre-existing
+// state including shapes the API cannot create. The environment seeder
+// always creates the row (with the legacy "{}" blob).
+func seedSentinelConfig(t *testing.T, h *testutil.Harness, env seededEnv, blob string) {
+	t.Helper()
+	_, err := h.DB.RW().ExecContext(context.Background(),
+		"UPDATE app_runtime_settings SET sentinel_config = ? WHERE app_id = ? AND environment_id = ?",
+		blob, env.appID, env.environmentID)
+	require.NoError(t, err)
+
+	// MySQL reports 0 affected rows when the value is unchanged, so verify by
+	// reading back instead.
+	var stored []byte
+	err = h.DB.RO().QueryRowContext(context.Background(),
+		"SELECT sentinel_config FROM app_runtime_settings WHERE app_id = ? AND environment_id = ?",
+		env.appID, env.environmentID).Scan(&stored)
+	require.NoError(t, err)
+	require.Equal(t, blob, string(stored))
+}
+
+// seedFirewallPolicies stores n firewall policies with deterministic ids
+// pol_000, pol_001, ... and returns those ids in stored order.
+func seedFirewallPolicies(t *testing.T, h *testutil.Harness, env seededEnv, n int) []string {
+	t.Helper()
+	ids := make([]string, 0, n)
+	docs := make([]string, 0, n)
+	for i := range n {
+		id := fmt.Sprintf("pol_%03d", i)
+		ids = append(ids, id)
+		docs = append(docs, fmt.Sprintf(
+			`{"id":%q,"name":"KEBAP %d","enabled":true,"firewall":{"action":"ACTION_DENY"}}`, id, i))
+	}
+	seedSentinelConfig(t, h, env, fmt.Sprintf(`{"policies":[%s]}`, strings.Join(docs, ",")))
+	return ids
+}
+
+func authHeaders(rootKey string) http.Header {
+	return http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}
+}

--- a/svc/api/routes/v2_gateway_list_policies/helpers_test.go
+++ b/svc/api/routes/v2_gateway_list_policies/helpers_test.go
@@ -19,8 +19,6 @@ func makeRequest(env seededEnv) handler.Request {
 		Project:     env.projectID,
 		App:         env.appID,
 		Environment: env.environmentID,
-		Cursor:      nil,
-		Limit:       nil,
 	}
 }
 

--- a/svc/api/routes/v2_gateway_list_policies/mapping.go
+++ b/svc/api/routes/v2_gateway_list_policies/mapping.go
@@ -1,0 +1,231 @@
+package handler
+
+import (
+	frontlinev1 "github.com/unkeyed/unkey/gen/proto/frontline/v1"
+	"github.com/unkeyed/unkey/pkg/codes"
+	"github.com/unkeyed/unkey/pkg/fault"
+	"github.com/unkeyed/unkey/pkg/ptr"
+	"github.com/unkeyed/unkey/svc/api/openapi"
+)
+
+// mapPoliciesFromProto is the read-side inverse of setPolicies' mapping:
+// stored protos back into response types. Stored data already passed write
+// validation, so any unmappable shape (unknown oneof variant, empty oneof)
+// is corrupt or out-of-band state and surfaces as an internal error rather
+// than being silently dropped from a list that claims to be complete.
+func mapPoliciesFromProto(policies []*frontlinev1.Policy) ([]openapi.PolicyResponse, error) {
+	out := make([]openapi.PolicyResponse, 0, len(policies))
+	for _, p := range policies {
+		converted, err := mapPolicyFromProto(p)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, converted)
+	}
+	return out, nil
+}
+
+func mapPolicyFromProto(p *frontlinev1.Policy) (openapi.PolicyResponse, error) {
+	out := openapi.PolicyResponse{
+		Id:        p.GetId(),
+		Name:      p.GetName(),
+		Enabled:   p.GetEnabled(),
+		Match:     nil,
+		Keyauth:   nil,
+		Ratelimit: nil,
+		Firewall:  nil,
+		Openapi:   nil,
+	}
+
+	if len(p.GetMatch()) > 0 {
+		match := make([]openapi.MatchExpr, 0, len(p.GetMatch()))
+		for _, m := range p.GetMatch() {
+			expr, err := mapMatchExprFromProto(m)
+			if err != nil {
+				return openapi.PolicyResponse{}, err
+			}
+			match = append(match, expr)
+		}
+		out.Match = &match
+	}
+
+	switch config := p.Config.(type) {
+	case *frontlinev1.Policy_Keyauth:
+		out.Keyauth = mapKeyauthFromProto(config.Keyauth)
+
+	case *frontlinev1.Policy_Ratelimit:
+		identifier := openapi.RatelimitIdentifier{
+			RemoteIp:             nil,
+			Header:               nil,
+			AuthenticatedSubject: nil,
+			Path:                 nil,
+			PrincipalField:       nil,
+		}
+		switch source := config.Ratelimit.GetIdentifier().GetSource().(type) {
+		case *frontlinev1.RateLimitIdentifier_RemoteIp:
+			identifier.RemoteIp = &openapi.RemoteIpKey{}
+		case *frontlinev1.RateLimitIdentifier_Header:
+			identifier.Header = &openapi.HeaderKey{Name: source.Header.GetName()}
+		case *frontlinev1.RateLimitIdentifier_AuthenticatedSubject:
+			identifier.AuthenticatedSubject = &openapi.AuthenticatedSubjectKey{}
+		case *frontlinev1.RateLimitIdentifier_Path:
+			identifier.Path = &openapi.PathKey{}
+		case *frontlinev1.RateLimitIdentifier_PrincipalField:
+			identifier.PrincipalField = &openapi.PrincipalFieldKey{Path: source.PrincipalField.GetPath()}
+		default:
+			return openapi.PolicyResponse{}, unmappable(p.GetId(), "ratelimit identifier")
+		}
+		out.Ratelimit = &openapi.RatelimitPolicy{
+			Limit:      config.Ratelimit.GetLimit(),
+			WindowMs:   config.Ratelimit.GetWindowMs(),
+			Identifier: identifier,
+		}
+
+	case *frontlinev1.Policy_Firewall:
+		out.Firewall = &openapi.FirewallPolicy{
+			Action: openapi.FirewallPolicyAction(config.Firewall.GetAction().String()),
+		}
+
+	case *frontlinev1.Policy_Openapi:
+		out.Openapi = ptr.P(openapi.OpenapiPolicy{})
+
+	default:
+		return openapi.PolicyResponse{}, unmappable(p.GetId(), "config variant")
+	}
+
+	return out, nil
+}
+
+func mapKeyauthFromProto(k *frontlinev1.KeyAuth) *openapi.KeyauthPolicy {
+	out := &openapi.KeyauthPolicy{
+		Keyspaces:       k.GetKeySpaceIds(),
+		PermissionQuery: k.PermissionQuery,
+		Locations:       nil,
+		Ratelimits:      nil,
+	}
+
+	if len(k.GetLocations()) > 0 {
+		locations := make([]openapi.KeyLocation, 0, len(k.GetLocations()))
+		for _, loc := range k.GetLocations() {
+			mapped := openapi.KeyLocation{
+				Bearer:     nil,
+				Header:     nil,
+				QueryParam: nil,
+			}
+			switch location := loc.GetLocation().(type) {
+			case *frontlinev1.KeyLocation_Bearer:
+				mapped.Bearer = &openapi.BearerTokenLocation{}
+			case *frontlinev1.KeyLocation_Header:
+				mapped.Header = &openapi.HeaderKeyLocation{Name: location.Header.GetName(), StripPrefix: nil}
+				if prefix := location.Header.GetStripPrefix(); prefix != "" {
+					mapped.Header.StripPrefix = &prefix
+				}
+			case *frontlinev1.KeyLocation_QueryParam:
+				mapped.QueryParam = &openapi.QueryParamKeyLocation{Name: location.QueryParam.GetName()}
+			}
+			locations = append(locations, mapped)
+		}
+		out.Locations = &locations
+	}
+
+	if len(k.GetRatelimits()) > 0 {
+		ratelimits := make([]openapi.KeyRatelimit, 0, len(k.GetRatelimits()))
+		for _, rl := range k.GetRatelimits() {
+			ratelimits = append(ratelimits, openapi.KeyRatelimit{
+				Name:     rl.GetName(),
+				Limit:    rl.Limit,
+				Duration: rl.Duration,
+				Cost:     rl.Cost,
+			})
+		}
+		out.Ratelimits = &ratelimits
+	}
+
+	return out
+}
+
+func mapMatchExprFromProto(m *frontlinev1.MatchExpr) (openapi.MatchExpr, error) {
+	out := openapi.MatchExpr{
+		Path:       nil,
+		Method:     nil,
+		Header:     nil,
+		QueryParam: nil,
+	}
+
+	switch expr := m.GetExpr().(type) {
+	case *frontlinev1.MatchExpr_Path:
+		out.Path = &openapi.PathMatch{Path: mapStringMatchFromProto(expr.Path.GetPath())}
+
+	case *frontlinev1.MatchExpr_Method:
+		methods := make([]openapi.MethodMatchMethods, 0, len(expr.Method.GetMethods()))
+		for _, method := range expr.Method.GetMethods() {
+			methods = append(methods, openapi.MethodMatchMethods(method))
+		}
+		out.Method = &openapi.MethodMatch{Methods: methods}
+
+	case *frontlinev1.MatchExpr_Header:
+		field := openapi.FieldMatch{Name: expr.Header.GetName(), Present: nil, Value: nil}
+		switch match := expr.Header.GetMatch().(type) {
+		case *frontlinev1.HeaderMatch_Present:
+			field.Present = ptr.P(openapi.FieldMatchPresent(match.Present))
+		case *frontlinev1.HeaderMatch_Value:
+			field.Value = ptr.P(mapStringMatchFromProto(match.Value))
+		default:
+			return out, unmappable("", "header match")
+		}
+		out.Header = &field
+
+	case *frontlinev1.MatchExpr_QueryParam:
+		field := openapi.FieldMatch{Name: expr.QueryParam.GetName(), Present: nil, Value: nil}
+		switch match := expr.QueryParam.GetMatch().(type) {
+		case *frontlinev1.QueryParamMatch_Present:
+			field.Present = ptr.P(openapi.FieldMatchPresent(match.Present))
+		case *frontlinev1.QueryParamMatch_Value:
+			field.Value = ptr.P(mapStringMatchFromProto(match.Value))
+		default:
+			return out, unmappable("", "queryParam match")
+		}
+		out.QueryParam = &field
+
+	default:
+		return out, unmappable("", "match expression")
+	}
+
+	return out, nil
+}
+
+func mapStringMatchFromProto(s *frontlinev1.StringMatch) openapi.StringMatch {
+	out := openapi.StringMatch{
+		Exact:      nil,
+		Prefix:     nil,
+		Regex:      nil,
+		IgnoreCase: nil,
+	}
+	// Proto's zero value and an absent flag are indistinguishable; omit
+	// false so responses stay minimal and roundtrip-stable with setPolicies.
+	if s.GetIgnoreCase() {
+		out.IgnoreCase = ptr.P(true)
+	}
+	switch match := s.GetMatch().(type) {
+	case *frontlinev1.StringMatch_Exact:
+		out.Exact = &match.Exact
+	case *frontlinev1.StringMatch_Prefix:
+		out.Prefix = &match.Prefix
+	case *frontlinev1.StringMatch_Regex:
+		out.Regex = &match.Regex
+	}
+	return out
+}
+
+func unmappable(policyID, what string) error {
+	internal := "stored policy has an unmappable " + what
+	if policyID != "" {
+		internal += " (policy " + policyID + ")"
+	}
+	return fault.New(
+		"unmappable stored policy",
+		fault.Code(codes.App.Internal.UnexpectedError.URN()),
+		fault.Internal(internal),
+		fault.Public("We're unable to list the policies."),
+	)
+}

--- a/svc/api/routes/v2_gateway_list_policies/mapping.go
+++ b/svc/api/routes/v2_gateway_list_policies/mapping.go
@@ -10,9 +10,10 @@ import (
 
 // mapPoliciesFromProto is the read-side inverse of setPolicies' mapping:
 // stored protos back into response types. Stored data already passed write
-// validation, so any unmappable shape (unknown oneof variant, empty oneof)
-// is corrupt or out-of-band state and surfaces as an internal error rather
-// than being silently dropped from a list that claims to be complete.
+// validation, so any unmappable shape (unknown oneof variant, empty oneof,
+// a value the response schema cannot express) is corrupt or out-of-band
+// state and surfaces as an internal error rather than being silently
+// dropped from a list that claims to be complete.
 func mapPoliciesFromProto(policies []*frontlinev1.Policy) ([]openapi.PolicyResponse, error) {
 	out := make([]openapi.PolicyResponse, 0, len(policies))
 	for _, p := range policies {
@@ -51,7 +52,11 @@ func mapPolicyFromProto(p *frontlinev1.Policy) (openapi.PolicyResponse, error) {
 
 	switch config := p.Config.(type) {
 	case *frontlinev1.Policy_Keyauth:
-		out.Keyauth = mapKeyauthFromProto(config.Keyauth)
+		keyauth, err := mapKeyauthFromProto(p.GetId(), config.Keyauth)
+		if err != nil {
+			return openapi.PolicyResponse{}, err
+		}
+		out.Keyauth = keyauth
 
 	case *frontlinev1.Policy_Ratelimit:
 		identifier := openapi.RatelimitIdentifier{
@@ -96,7 +101,13 @@ func mapPolicyFromProto(p *frontlinev1.Policy) (openapi.PolicyResponse, error) {
 	return out, nil
 }
 
-func mapKeyauthFromProto(k *frontlinev1.KeyAuth) *openapi.KeyauthPolicy {
+func mapKeyauthFromProto(policyID string, k *frontlinev1.KeyAuth) (*openapi.KeyauthPolicy, error) {
+	// The response schema requires at least one keyspace, matching write
+	// validation; a keyspace-less keyauth cannot come from our writers.
+	if len(k.GetKeySpaceIds()) == 0 {
+		return nil, unmappable(policyID, "keyauth without keyspaces")
+	}
+
 	out := &openapi.KeyauthPolicy{
 		Keyspaces:       k.GetKeySpaceIds(),
 		PermissionQuery: k.PermissionQuery,
@@ -122,6 +133,8 @@ func mapKeyauthFromProto(k *frontlinev1.KeyAuth) *openapi.KeyauthPolicy {
 				}
 			case *frontlinev1.KeyLocation_QueryParam:
 				mapped.QueryParam = &openapi.QueryParamKeyLocation{Name: location.QueryParam.GetName()}
+			default:
+				return nil, unmappable(policyID, "key location")
 			}
 			locations = append(locations, mapped)
 		}
@@ -141,7 +154,7 @@ func mapKeyauthFromProto(k *frontlinev1.KeyAuth) *openapi.KeyauthPolicy {
 		out.Ratelimits = &ratelimits
 	}
 
-	return out
+	return out, nil
 }
 
 func mapMatchExprFromProto(m *frontlinev1.MatchExpr) (openapi.MatchExpr, error) {
@@ -154,7 +167,11 @@ func mapMatchExprFromProto(m *frontlinev1.MatchExpr) (openapi.MatchExpr, error) 
 
 	switch expr := m.GetExpr().(type) {
 	case *frontlinev1.MatchExpr_Path:
-		out.Path = &openapi.PathMatch{Path: mapStringMatchFromProto(expr.Path.GetPath())}
+		sm, err := mapStringMatchFromProto(expr.Path.GetPath())
+		if err != nil {
+			return out, err
+		}
+		out.Path = &openapi.PathMatch{Path: sm}
 
 	case *frontlinev1.MatchExpr_Method:
 		methods := make([]openapi.MethodMatchMethods, 0, len(expr.Method.GetMethods()))
@@ -167,9 +184,18 @@ func mapMatchExprFromProto(m *frontlinev1.MatchExpr) (openapi.MatchExpr, error) 
 		field := openapi.FieldMatch{Name: expr.Header.GetName(), Present: nil, Value: nil}
 		switch match := expr.Header.GetMatch().(type) {
 		case *frontlinev1.HeaderMatch_Present:
+			// The schema only admits `present: true`; the gateway's
+			// absent-match (present=false) has no response representation.
+			if !match.Present {
+				return out, unmappable("", "header absent-match")
+			}
 			field.Present = ptr.P(openapi.FieldMatchPresent(match.Present))
 		case *frontlinev1.HeaderMatch_Value:
-			field.Value = ptr.P(mapStringMatchFromProto(match.Value))
+			sm, err := mapStringMatchFromProto(match.Value)
+			if err != nil {
+				return out, err
+			}
+			field.Value = &sm
 		default:
 			return out, unmappable("", "header match")
 		}
@@ -179,9 +205,16 @@ func mapMatchExprFromProto(m *frontlinev1.MatchExpr) (openapi.MatchExpr, error) 
 		field := openapi.FieldMatch{Name: expr.QueryParam.GetName(), Present: nil, Value: nil}
 		switch match := expr.QueryParam.GetMatch().(type) {
 		case *frontlinev1.QueryParamMatch_Present:
+			if !match.Present {
+				return out, unmappable("", "queryParam absent-match")
+			}
 			field.Present = ptr.P(openapi.FieldMatchPresent(match.Present))
 		case *frontlinev1.QueryParamMatch_Value:
-			field.Value = ptr.P(mapStringMatchFromProto(match.Value))
+			sm, err := mapStringMatchFromProto(match.Value)
+			if err != nil {
+				return out, err
+			}
+			field.Value = &sm
 		default:
 			return out, unmappable("", "queryParam match")
 		}
@@ -194,7 +227,7 @@ func mapMatchExprFromProto(m *frontlinev1.MatchExpr) (openapi.MatchExpr, error) 
 	return out, nil
 }
 
-func mapStringMatchFromProto(s *frontlinev1.StringMatch) openapi.StringMatch {
+func mapStringMatchFromProto(s *frontlinev1.StringMatch) (openapi.StringMatch, error) {
 	out := openapi.StringMatch{
 		Exact:      nil,
 		Prefix:     nil,
@@ -213,8 +246,10 @@ func mapStringMatchFromProto(s *frontlinev1.StringMatch) openapi.StringMatch {
 		out.Prefix = &match.Prefix
 	case *frontlinev1.StringMatch_Regex:
 		out.Regex = &match.Regex
+	default:
+		return out, unmappable("", "string match")
 	}
-	return out
+	return out, nil
 }
 
 func unmappable(policyID, what string) error {

--- a/svc/api/routes/v2_gateway_list_policies/mapping_test.go
+++ b/svc/api/routes/v2_gateway_list_policies/mapping_test.go
@@ -1,0 +1,268 @@
+package handler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	frontlinev1 "github.com/unkeyed/unkey/gen/proto/frontline/v1"
+	"github.com/unkeyed/unkey/pkg/ptr"
+	"github.com/unkeyed/unkey/svc/api/openapi"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestMapPolicyFromProtoVariants(t *testing.T) {
+	t.Run("keyauth with all fields", func(t *testing.T) {
+		got, err := mapPolicyFromProto(&frontlinev1.Policy{
+			Id:      "pol_KEBAP1234",
+			Name:    "keyauth",
+			Enabled: proto.Bool(true),
+			Config: &frontlinev1.Policy_Keyauth{Keyauth: &frontlinev1.KeyAuth{
+				KeySpaceIds:     []string{"ks_1", "ks_2"},
+				PermissionQuery: proto.String("documents.read"),
+				Locations: []*frontlinev1.KeyLocation{
+					{Location: &frontlinev1.KeyLocation_Bearer{Bearer: &frontlinev1.BearerTokenLocation{}}},
+					{Location: &frontlinev1.KeyLocation_Header{Header: &frontlinev1.HeaderKeyLocation{Name: "X-Api-Key", StripPrefix: "Key "}}},
+					{Location: &frontlinev1.KeyLocation_QueryParam{QueryParam: &frontlinev1.QueryParamKeyLocation{Name: "api_key"}}},
+				},
+				Ratelimits: []*frontlinev1.KeyRatelimit{
+					{Name: "tokens"},
+					{Name: "burst", Limit: proto.Int64(100), Duration: proto.Int64(60000), Cost: proto.Int64(2)},
+				},
+			}},
+		})
+		require.NoError(t, err)
+
+		require.Equal(t, "pol_KEBAP1234", got.Id)
+		require.Equal(t, "keyauth", got.Name)
+		require.True(t, got.Enabled)
+		require.NotNil(t, got.Keyauth)
+		require.Equal(t, []string{"ks_1", "ks_2"}, got.Keyauth.Keyspaces)
+		require.Equal(t, ptr.P("documents.read"), got.Keyauth.PermissionQuery)
+
+		locations := ptr.SafeDeref(got.Keyauth.Locations)
+		require.Len(t, locations, 3)
+		require.NotNil(t, locations[0].Bearer)
+		require.Equal(t, "X-Api-Key", locations[1].Header.Name)
+		require.Equal(t, ptr.P("Key "), locations[1].Header.StripPrefix)
+		require.Equal(t, "api_key", locations[2].QueryParam.Name)
+
+		ratelimits := ptr.SafeDeref(got.Keyauth.Ratelimits)
+		require.Len(t, ratelimits, 2)
+		require.Nil(t, ratelimits[0].Limit)
+		require.Equal(t, ptr.P(int64(100)), ratelimits[1].Limit)
+	})
+
+	t.Run("keyauth without optionals omits pointers", func(t *testing.T) {
+		got, err := mapPolicyFromProto(&frontlinev1.Policy{
+			Id:      "pol_1",
+			Name:    "minimal",
+			Enabled: proto.Bool(true),
+			Config: &frontlinev1.Policy_Keyauth{Keyauth: &frontlinev1.KeyAuth{
+				KeySpaceIds: []string{"ks_1"},
+			}},
+		})
+		require.NoError(t, err)
+		require.Nil(t, got.Match)
+		require.Nil(t, got.Keyauth.Locations)
+		require.Nil(t, got.Keyauth.Ratelimits)
+		require.Nil(t, got.Keyauth.PermissionQuery)
+	})
+
+	t.Run("unset enabled maps to false", func(t *testing.T) {
+		got, err := mapPolicyFromProto(&frontlinev1.Policy{
+			Id:     "pol_1",
+			Name:   "legacy",
+			Config: &frontlinev1.Policy_Openapi{Openapi: &frontlinev1.OpenApiRequestValidation{}},
+		})
+		require.NoError(t, err)
+		require.False(t, got.Enabled)
+		require.NotNil(t, got.Openapi)
+	})
+
+	t.Run("every ratelimit identifier source", func(t *testing.T) {
+		sources := []struct {
+			name       string
+			identifier *frontlinev1.RateLimitIdentifier
+			check      func(t *testing.T, id openapi.RatelimitIdentifier)
+		}{
+			{
+				name:       "remoteIp",
+				identifier: &frontlinev1.RateLimitIdentifier{Source: &frontlinev1.RateLimitIdentifier_RemoteIp{RemoteIp: &frontlinev1.RemoteIpKey{}}},
+				check:      func(t *testing.T, id openapi.RatelimitIdentifier) { require.NotNil(t, id.RemoteIp) },
+			},
+			{
+				name:       "header",
+				identifier: &frontlinev1.RateLimitIdentifier{Source: &frontlinev1.RateLimitIdentifier_Header{Header: &frontlinev1.HeaderKey{Name: "X-Tenant"}}},
+				check: func(t *testing.T, id openapi.RatelimitIdentifier) {
+					require.NotNil(t, id.Header)
+					require.Equal(t, "X-Tenant", id.Header.Name)
+				},
+			},
+			{
+				name:       "authenticatedSubject",
+				identifier: &frontlinev1.RateLimitIdentifier{Source: &frontlinev1.RateLimitIdentifier_AuthenticatedSubject{AuthenticatedSubject: &frontlinev1.AuthenticatedSubjectKey{}}},
+				check: func(t *testing.T, id openapi.RatelimitIdentifier) {
+					require.NotNil(t, id.AuthenticatedSubject)
+				},
+			},
+			{
+				name:       "path",
+				identifier: &frontlinev1.RateLimitIdentifier{Source: &frontlinev1.RateLimitIdentifier_Path{Path: &frontlinev1.PathKey{}}},
+				check:      func(t *testing.T, id openapi.RatelimitIdentifier) { require.NotNil(t, id.Path) },
+			},
+			{
+				name:       "principalField",
+				identifier: &frontlinev1.RateLimitIdentifier{Source: &frontlinev1.RateLimitIdentifier_PrincipalField{PrincipalField: &frontlinev1.PrincipalFieldKey{Path: "sub"}}},
+				check: func(t *testing.T, id openapi.RatelimitIdentifier) {
+					require.NotNil(t, id.PrincipalField)
+					require.Equal(t, "sub", id.PrincipalField.Path)
+				},
+			},
+		}
+
+		for _, tc := range sources {
+			t.Run(tc.name, func(t *testing.T) {
+				got, err := mapPolicyFromProto(&frontlinev1.Policy{
+					Id:      "pol_1",
+					Name:    "rl",
+					Enabled: proto.Bool(true),
+					Config: &frontlinev1.Policy_Ratelimit{Ratelimit: &frontlinev1.RateLimit{
+						Limit:      100,
+						WindowMs:   60000,
+						Identifier: tc.identifier,
+					}},
+				})
+				require.NoError(t, err)
+				require.NotNil(t, got.Ratelimit)
+				require.Equal(t, int64(100), got.Ratelimit.Limit)
+				require.Equal(t, int64(60000), got.Ratelimit.WindowMs)
+				tc.check(t, got.Ratelimit.Identifier)
+			})
+		}
+	})
+
+	t.Run("firewall action renders by enum name", func(t *testing.T) {
+		got, err := mapPolicyFromProto(&frontlinev1.Policy{
+			Id:      "pol_1",
+			Name:    "deny",
+			Enabled: proto.Bool(false),
+			Config:  &frontlinev1.Policy_Firewall{Firewall: &frontlinev1.Firewall{Action: frontlinev1.Action_ACTION_DENY}},
+		})
+		require.NoError(t, err)
+		require.Equal(t, openapi.FirewallPolicyAction("ACTION_DENY"), got.Firewall.Action)
+	})
+
+	t.Run("jwtauth is unmappable", func(t *testing.T) {
+		_, err := mapPolicyFromProto(&frontlinev1.Policy{
+			Id:     "pol_1",
+			Name:   "jwt",
+			Config: &frontlinev1.Policy_Jwtauth{Jwtauth: &frontlinev1.JWTAuth{}},
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("missing config is unmappable", func(t *testing.T) {
+		_, err := mapPolicyFromProto(&frontlinev1.Policy{Id: "pol_1", Name: "empty"})
+		require.Error(t, err)
+	})
+}
+
+func TestMapMatchExprFromProto(t *testing.T) {
+	t.Run("path with ignoreCase", func(t *testing.T) {
+		got, err := mapMatchExprFromProto(&frontlinev1.MatchExpr{
+			Expr: &frontlinev1.MatchExpr_Path{Path: &frontlinev1.PathMatch{
+				Path: &frontlinev1.StringMatch{
+					IgnoreCase: true,
+					Match:      &frontlinev1.StringMatch_Prefix{Prefix: "/internal/"},
+				},
+			}},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, got.Path)
+		require.Equal(t, ptr.P("/internal/"), got.Path.Path.Prefix)
+		require.Equal(t, ptr.P(true), got.Path.Path.IgnoreCase)
+		require.Nil(t, got.Path.Path.Exact)
+		require.Nil(t, got.Path.Path.Regex)
+	})
+
+	t.Run("ignoreCase false is omitted", func(t *testing.T) {
+		got, err := mapMatchExprFromProto(&frontlinev1.MatchExpr{
+			Expr: &frontlinev1.MatchExpr_Path{Path: &frontlinev1.PathMatch{
+				Path: &frontlinev1.StringMatch{Match: &frontlinev1.StringMatch_Exact{Exact: "/health"}},
+			}},
+		})
+		require.NoError(t, err)
+		require.Nil(t, got.Path.Path.IgnoreCase)
+		require.Equal(t, ptr.P("/health"), got.Path.Path.Exact)
+	})
+
+	t.Run("regex", func(t *testing.T) {
+		got, err := mapMatchExprFromProto(&frontlinev1.MatchExpr{
+			Expr: &frontlinev1.MatchExpr_Path{Path: &frontlinev1.PathMatch{
+				Path: &frontlinev1.StringMatch{Match: &frontlinev1.StringMatch_Regex{Regex: "^/v[0-9]+/"}},
+			}},
+		})
+		require.NoError(t, err)
+		require.Equal(t, ptr.P("^/v[0-9]+/"), got.Path.Path.Regex)
+	})
+
+	t.Run("method", func(t *testing.T) {
+		got, err := mapMatchExprFromProto(&frontlinev1.MatchExpr{
+			Expr: &frontlinev1.MatchExpr_Method{Method: &frontlinev1.MethodMatch{Methods: []string{"GET", "DELETE"}}},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, got.Method)
+		require.Equal(t, []openapi.MethodMatchMethods{"GET", "DELETE"}, got.Method.Methods)
+	})
+
+	t.Run("header present", func(t *testing.T) {
+		got, err := mapMatchExprFromProto(&frontlinev1.MatchExpr{
+			Expr: &frontlinev1.MatchExpr_Header{Header: &frontlinev1.HeaderMatch{
+				Name:  "X-Debug",
+				Match: &frontlinev1.HeaderMatch_Present{Present: true},
+			}},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, got.Header)
+		require.Equal(t, "X-Debug", got.Header.Name)
+		require.Equal(t, ptr.P(openapi.FieldMatchPresent(true)), got.Header.Present)
+		require.Nil(t, got.Header.Value)
+	})
+
+	t.Run("header value", func(t *testing.T) {
+		got, err := mapMatchExprFromProto(&frontlinev1.MatchExpr{
+			Expr: &frontlinev1.MatchExpr_Header{Header: &frontlinev1.HeaderMatch{
+				Name:  "X-Env",
+				Match: &frontlinev1.HeaderMatch_Value{Value: &frontlinev1.StringMatch{Match: &frontlinev1.StringMatch_Exact{Exact: "KEBAP"}}},
+			}},
+		})
+		require.NoError(t, err)
+		require.Nil(t, got.Header.Present)
+		require.Equal(t, ptr.P("KEBAP"), got.Header.Value.Exact)
+	})
+
+	t.Run("queryParam value", func(t *testing.T) {
+		got, err := mapMatchExprFromProto(&frontlinev1.MatchExpr{
+			Expr: &frontlinev1.MatchExpr_QueryParam{QueryParam: &frontlinev1.QueryParamMatch{
+				Name:  "v",
+				Match: &frontlinev1.QueryParamMatch_Value{Value: &frontlinev1.StringMatch{Match: &frontlinev1.StringMatch_Exact{Exact: "1"}}},
+			}},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, got.QueryParam)
+		require.Equal(t, "v", got.QueryParam.Name)
+		require.Equal(t, ptr.P("1"), got.QueryParam.Value.Exact)
+	})
+
+	t.Run("empty expr is unmappable", func(t *testing.T) {
+		_, err := mapMatchExprFromProto(&frontlinev1.MatchExpr{})
+		require.Error(t, err)
+	})
+
+	t.Run("header without match is unmappable", func(t *testing.T) {
+		_, err := mapMatchExprFromProto(&frontlinev1.MatchExpr{
+			Expr: &frontlinev1.MatchExpr_Header{Header: &frontlinev1.HeaderMatch{Name: "X-Debug"}},
+		})
+		require.Error(t, err)
+	})
+}

--- a/svc/api/routes/v2_gateway_list_policies/mapping_test.go
+++ b/svc/api/routes/v2_gateway_list_policies/mapping_test.go
@@ -165,6 +165,29 @@ func TestMapPolicyFromProtoVariants(t *testing.T) {
 		_, err := mapPolicyFromProto(&frontlinev1.Policy{Id: "pol_1", Name: "empty"})
 		require.Error(t, err)
 	})
+
+	t.Run("keyauth without keyspaces is unmappable", func(t *testing.T) {
+		_, err := mapPolicyFromProto(&frontlinev1.Policy{
+			Id:      "pol_1",
+			Name:    "no-keyspaces",
+			Enabled: proto.Bool(true),
+			Config:  &frontlinev1.Policy_Keyauth{Keyauth: &frontlinev1.KeyAuth{}},
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("key location without variant is unmappable", func(t *testing.T) {
+		_, err := mapPolicyFromProto(&frontlinev1.Policy{
+			Id:      "pol_1",
+			Name:    "empty-location",
+			Enabled: proto.Bool(true),
+			Config: &frontlinev1.Policy_Keyauth{Keyauth: &frontlinev1.KeyAuth{
+				KeySpaceIds: []string{"ks_KEBAP"},
+				Locations:   []*frontlinev1.KeyLocation{{}},
+			}},
+		})
+		require.Error(t, err)
+	})
 }
 
 func TestMapMatchExprFromProto(t *testing.T) {
@@ -262,6 +285,36 @@ func TestMapMatchExprFromProto(t *testing.T) {
 	t.Run("header without match is unmappable", func(t *testing.T) {
 		_, err := mapMatchExprFromProto(&frontlinev1.MatchExpr{
 			Expr: &frontlinev1.MatchExpr_Header{Header: &frontlinev1.HeaderMatch{Name: "X-Debug"}},
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("string match without variant is unmappable", func(t *testing.T) {
+		_, err := mapMatchExprFromProto(&frontlinev1.MatchExpr{
+			Expr: &frontlinev1.MatchExpr_Path{Path: &frontlinev1.PathMatch{Path: &frontlinev1.StringMatch{}}},
+		})
+		require.Error(t, err)
+	})
+
+	// The gateway can match on absence (present=false) but the response
+	// schema only admits `present: true`, so such a policy must error
+	// instead of emitting a schema-violating response.
+	t.Run("header absent-match is unmappable", func(t *testing.T) {
+		_, err := mapMatchExprFromProto(&frontlinev1.MatchExpr{
+			Expr: &frontlinev1.MatchExpr_Header{Header: &frontlinev1.HeaderMatch{
+				Name:  "X-Debug",
+				Match: &frontlinev1.HeaderMatch_Present{Present: false},
+			}},
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("queryParam absent-match is unmappable", func(t *testing.T) {
+		_, err := mapMatchExprFromProto(&frontlinev1.MatchExpr{
+			Expr: &frontlinev1.MatchExpr_QueryParam{QueryParam: &frontlinev1.QueryParamMatch{
+				Name:  "debug",
+				Match: &frontlinev1.QueryParamMatch_Present{Present: false},
+			}},
 		})
 		require.Error(t, err)
 	})

--- a/svc/api/routes/v2_portal_create_session/handler.go
+++ b/svc/api/routes/v2_portal_create_session/handler.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"time"
 
-	frontlinev1 "github.com/unkeyed/unkey/gen/proto/frontline/v1"
 	"github.com/unkeyed/unkey/internal/services/auditlogs"
 	"github.com/unkeyed/unkey/pkg/auditlog"
 	"github.com/unkeyed/unkey/pkg/codes"
@@ -16,8 +15,8 @@ import (
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/pkg/validation"
 	"github.com/unkeyed/unkey/pkg/zen"
+	"github.com/unkeyed/unkey/svc/api/internal/policyconfig"
 	"github.com/unkeyed/unkey/svc/api/openapi"
-	"google.golang.org/protobuf/encoding/protojson"
 )
 
 // storedGrant is the JSON shape persisted in the portal session's permissions
@@ -110,15 +109,10 @@ func (h *Handler) resolveKeyspaceIDs(ctx context.Context, workspaceID string, po
 
 // keyspacesFromSentinelConfig parses a deployment's sentinel_config and returns
 // the deduplicated keyspaces declared across its keyauth policies. Empty or
-// legacy empty-object configs yield no keyspaces (mirrors the frontline
-// gateway's lenient parsing).
+// legacy empty-object configs yield no keyspaces.
 func keyspacesFromSentinelConfig(raw []byte) ([]string, error) {
-	if len(raw) == 0 || string(raw) == "{}" {
-		return nil, nil
-	}
-
-	cfg := &frontlinev1.Config{}
-	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(raw, cfg); err != nil {
+	cfg, err := policyconfig.Parse(raw)
+	if err != nil {
 		return nil, fault.Wrap(err,
 			fault.Code(codes.App.Internal.UnexpectedError.URN()),
 			fault.Internal("failed to unmarshal app sentinel config"),

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/root-keys/components/dialog/permissions.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/root-keys/components/dialog/permissions.ts
@@ -245,6 +245,10 @@ export const workspacePermissions = {
         "Create, update, reorder, and remove gateway policies for any environment in this workspace",
       permission: "environment.*.set_policies",
     },
+    read_policies: {
+      description: "Read gateway policies for any environment in this workspace",
+      permission: "environment.*.read_policies",
+    },
   },
   Deployments: {
     create_deployment: {
@@ -393,6 +397,10 @@ export function environmentPermissions(environmentId: string): {
       set_policies: {
         description: "Create, update, reorder, and remove gateway policies for this environment.",
         permission: `environment.${environmentId}.set_policies`,
+      },
+      read_policies: {
+        description: "Read gateway policies for this environment.",
+        permission: `environment.${environmentId}.read_policies`,
       },
     },
     Deployments: {

--- a/web/internal/rbac/src/permissions.ts
+++ b/web/internal/rbac/src/permissions.ts
@@ -95,6 +95,7 @@ export const environmentActions = z.enum([
   "promote_deployment",
   "rollback_deployment",
   "set_policies",
+  "read_policies",
 ]);
 
 // Resources that require an ID (resource.id.action format)


### PR DESCRIPTION
> [!IMPORTANT]
> Unkey is not accepting external pull requests at this time. Pull requests from people outside the Unkey team will not be reviewed or merged.

## What does this PR do?

Adds a `policies.listPolicies` endpoint (`POST /v2/policies.listPolicies`) that retrieves an environment's gateway policies in evaluation order with cursor-based pagination.

Key additions:
- New `read_policies` RBAC action (`environment.*.read_policies` / `environment.<id>.read_policies`) separate from the existing `set_policies` write permission
- `policyconfig` package that centralizes sentinel config blob parsing (empty blobs and legacy `{}` are treated as empty policy lists; unknown fields are discarded). The portal session handler is updated to use this shared parser.
- Proto-to-OpenAPI mapping layer (`mapping.go`) that converts stored `frontlinev1.Policy` protos back into `PolicyResponse` response types, covering all policy variants (keyauth, ratelimit, firewall, openapi) and all match expression types (path, method, header, query param)
- A new `PolicyResponse` schema distinct from the write-side `Policy` schema — it includes the server-generated `id` field and uses read-appropriate descriptions
- Cursor pagination is implemented as a slice window over the in-blob policy list; the cursor is the id of the first policy on the next page. Cursors expire when `setPolicies` replaces the list and regenerates all ids, and an expired/unknown cursor returns a 400
- Dashboard root key permission UI updated to expose `read_policies` for both workspace-wide and per-environment scopes

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- `TestListPoliciesSuccessfully` covers: legacy `{}` blob, explicit empty policies, missing runtime settings row, all policy/match/identifier variants round-tripping through storage, pagination in stored order, default limit, and reading back what `setPolicies` wrote
- `TestListPoliciesBadRequest` covers: unknown cursor, cursor against empty list, limit of zero, limit above maximum, and missing identifiers
- `TestListPoliciesUnauthorized` covers requests with an invalid bearer token
- `TestListPoliciesForbidden` covers wildcard permission, specific environment permission, insufficient action (`set_policies`), wrong environment id, and no permissions
- `TestListPoliciesNotFound` covers nonexistent environment, project, app, and cross-workspace access
- `TestMapPolicyFromProtoVariants` and `TestMapMatchExprFromProto` unit-test the mapping layer directly, including unmappable variants (jwtauth, missing config, empty match expr)

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `mise run fmt`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary