### PR TITLE
feat(api): add update policy endpoint

### DIFF
--- a/docs/product/docs.json
+++ b/docs/product/docs.json
@@ -500,6 +500,7 @@
                       "errors/unkey/data/migration_not_found",
                       "errors/unkey/data/permission_already_exists",
                       "errors/unkey/data/permission_not_found",
+                      "errors/unkey/data/policy_not_found",
                       "errors/unkey/data/portal_config_not_found",
                       "errors/unkey/data/project_already_exists",
                       "errors/unkey/data/project_not_found",

--- a/docs/product/errors/unkey/data/policy_not_found.mdx
+++ b/docs/product/errors/unkey/data/policy_not_found.mdx
@@ -1,0 +1,7 @@
+---
+title: "policy_not_found"
+description: "NotFound indicates the requested policy does not exist."
+---
+
+<Danger>`err:unkey:data:policy_not_found`</Danger>
+

--- a/pkg/codes/constants_gen.go
+++ b/pkg/codes/constants_gen.go
@@ -119,6 +119,11 @@ const (
 	// NotFound indicates the requested deployment does not exist.
 	UnkeyDataErrorsDeploymentNotFound URN = "err:unkey:data:deployment_not_found"
 
+	// Policy
+
+	// NotFound indicates the requested policy does not exist.
+	UnkeyDataErrorsPolicyNotFound URN = "err:unkey:data:policy_not_found"
+
 	// Migration
 
 	// NotFound indicates the requested migration was not found.

--- a/pkg/codes/unkey_data.go
+++ b/pkg/codes/unkey_data.go
@@ -61,6 +61,12 @@ type dataDeployment struct {
 	NotFound Code
 }
 
+// dataPolicy defines errors related to gateway policy operations.
+type dataPolicy struct {
+	// NotFound indicates the requested policy does not exist.
+	NotFound Code
+}
+
 // dataPermission defines errors related to permission operations.
 type dataPermission struct {
 	// Duplicate indicates the requested permission already exists.
@@ -140,6 +146,7 @@ type UnkeyDataErrors struct {
 	App                dataApp
 	Environment        dataEnvironment
 	Deployment         dataDeployment
+	Policy             dataPolicy
 	Migration          dataMigration
 	KeySpace           dataKeySpace
 	Permission         dataPermission
@@ -193,6 +200,10 @@ var Data = UnkeyDataErrors{
 
 	Deployment: dataDeployment{
 		NotFound: Code{SystemUnkey, CategoryUnkeyData, "deployment_not_found"},
+	},
+
+	Policy: dataPolicy{
+		NotFound: Code{SystemUnkey, CategoryUnkeyData, "policy_not_found"},
 	},
 
 	Permission: dataPermission{

--- a/pkg/rbac/permissions.go
+++ b/pkg/rbac/permissions.go
@@ -238,9 +238,12 @@ const (
 	RemoveEnvironmentVariables ActionType = "remove_environment_variables"
 	// ReadEnvironmentVariables permits reading a specific environment's variables
 	ReadEnvironmentVariables ActionType = "read_environment_variables"
-	// SetPolicies permits creating, updating, reordering, and removing a
-	// specific environment's gateway policies
+	// SetPolicies permits replacing a specific environment's entire gateway
+	// policy list in one call
 	SetPolicies ActionType = "set_policies"
+	// UpdatePolicy permits updating a single gateway policy in place within a
+	// specific environment
+	UpdatePolicy ActionType = "update_policy"
 	// ReadPolicies permits reading a specific environment's gateway policies
 	ReadPolicies ActionType = "read_policies"
 )

--- a/svc/api/internal/middleware/errors.go
+++ b/svc/api/internal/middleware/errors.go
@@ -83,6 +83,7 @@ func WithErrorHandling() zen.Middleware {
 				codes.UnkeyDataErrorsAppNotFound,
 				codes.UnkeyDataErrorsEnvironmentNotFound,
 				codes.UnkeyDataErrorsDeploymentNotFound,
+				codes.UnkeyDataErrorsPolicyNotFound,
 				codes.UnkeyDataErrorsMigrationNotFound,
 				codes.UnkeyDataErrorsKeySpaceNotFound,
 				codes.UnkeyDataErrorsPermissionNotFound,

--- a/svc/api/internal/policyconfig/from_proto.go
+++ b/svc/api/internal/policyconfig/from_proto.go
@@ -1,4 +1,4 @@
-package handler
+package policyconfig
 
 import (
 	frontlinev1 "github.com/unkeyed/unkey/gen/proto/frontline/v1"
@@ -8,16 +8,16 @@ import (
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
 
-// mapPoliciesFromProto is the read-side inverse of setPolicies' mapping:
+// FromProto is the read-side inverse of setPolicies' mapping:
 // stored protos back into response types. Stored data already passed write
 // validation, so any unmappable shape (unknown oneof variant, empty oneof,
 // a value the response schema cannot express) is corrupt or out-of-band
 // state and surfaces as an internal error rather than being silently
 // dropped from a list that claims to be complete.
-func mapPoliciesFromProto(policies []*frontlinev1.Policy) ([]openapi.PolicyResponse, error) {
+func FromProto(policies []*frontlinev1.Policy) ([]openapi.PolicyResponse, error) {
 	out := make([]openapi.PolicyResponse, 0, len(policies))
 	for _, p := range policies {
-		converted, err := mapPolicyFromProto(p)
+		converted, err := PolicyFromProto(p)
 		if err != nil {
 			return nil, err
 		}
@@ -26,7 +26,7 @@ func mapPoliciesFromProto(policies []*frontlinev1.Policy) ([]openapi.PolicyRespo
 	return out, nil
 }
 
-func mapPolicyFromProto(p *frontlinev1.Policy) (openapi.PolicyResponse, error) {
+func PolicyFromProto(p *frontlinev1.Policy) (openapi.PolicyResponse, error) {
 	out := openapi.PolicyResponse{
 		Id:        p.GetId(),
 		Name:      p.GetName(),
@@ -261,6 +261,6 @@ func unmappable(policyID, what string) error {
 		"unmappable stored policy",
 		fault.Code(codes.App.Internal.UnexpectedError.URN()),
 		fault.Internal(internal),
-		fault.Public("We're unable to list the policies."),
+		fault.Public("We're unable to read the stored policies."),
 	)
 }

--- a/svc/api/internal/policyconfig/from_proto_test.go
+++ b/svc/api/internal/policyconfig/from_proto_test.go
@@ -1,4 +1,4 @@
-package handler
+package policyconfig
 
 import (
 	"testing"
@@ -12,7 +12,7 @@ import (
 
 func TestMapPolicyFromProtoVariants(t *testing.T) {
 	t.Run("keyauth with all fields", func(t *testing.T) {
-		got, err := mapPolicyFromProto(&frontlinev1.Policy{
+		got, err := PolicyFromProto(&frontlinev1.Policy{
 			Id:      "pol_KEBAP1234",
 			Name:    "keyauth",
 			Enabled: proto.Bool(true),
@@ -53,7 +53,7 @@ func TestMapPolicyFromProtoVariants(t *testing.T) {
 	})
 
 	t.Run("keyauth without optionals omits pointers", func(t *testing.T) {
-		got, err := mapPolicyFromProto(&frontlinev1.Policy{
+		got, err := PolicyFromProto(&frontlinev1.Policy{
 			Id:      "pol_1",
 			Name:    "minimal",
 			Enabled: proto.Bool(true),
@@ -69,7 +69,7 @@ func TestMapPolicyFromProtoVariants(t *testing.T) {
 	})
 
 	t.Run("unset enabled maps to false", func(t *testing.T) {
-		got, err := mapPolicyFromProto(&frontlinev1.Policy{
+		got, err := PolicyFromProto(&frontlinev1.Policy{
 			Id:     "pol_1",
 			Name:   "legacy",
 			Config: &frontlinev1.Policy_Openapi{Openapi: &frontlinev1.OpenApiRequestValidation{}},
@@ -122,7 +122,7 @@ func TestMapPolicyFromProtoVariants(t *testing.T) {
 
 		for _, tc := range sources {
 			t.Run(tc.name, func(t *testing.T) {
-				got, err := mapPolicyFromProto(&frontlinev1.Policy{
+				got, err := PolicyFromProto(&frontlinev1.Policy{
 					Id:      "pol_1",
 					Name:    "rl",
 					Enabled: proto.Bool(true),
@@ -142,7 +142,7 @@ func TestMapPolicyFromProtoVariants(t *testing.T) {
 	})
 
 	t.Run("firewall action renders by enum name", func(t *testing.T) {
-		got, err := mapPolicyFromProto(&frontlinev1.Policy{
+		got, err := PolicyFromProto(&frontlinev1.Policy{
 			Id:      "pol_1",
 			Name:    "deny",
 			Enabled: proto.Bool(false),
@@ -153,7 +153,7 @@ func TestMapPolicyFromProtoVariants(t *testing.T) {
 	})
 
 	t.Run("jwtauth is unmappable", func(t *testing.T) {
-		_, err := mapPolicyFromProto(&frontlinev1.Policy{
+		_, err := PolicyFromProto(&frontlinev1.Policy{
 			Id:     "pol_1",
 			Name:   "jwt",
 			Config: &frontlinev1.Policy_Jwtauth{Jwtauth: &frontlinev1.JWTAuth{}},
@@ -162,12 +162,12 @@ func TestMapPolicyFromProtoVariants(t *testing.T) {
 	})
 
 	t.Run("missing config is unmappable", func(t *testing.T) {
-		_, err := mapPolicyFromProto(&frontlinev1.Policy{Id: "pol_1", Name: "empty"})
+		_, err := PolicyFromProto(&frontlinev1.Policy{Id: "pol_1", Name: "empty"})
 		require.Error(t, err)
 	})
 
 	t.Run("keyauth without keyspaces is unmappable", func(t *testing.T) {
-		_, err := mapPolicyFromProto(&frontlinev1.Policy{
+		_, err := PolicyFromProto(&frontlinev1.Policy{
 			Id:      "pol_1",
 			Name:    "no-keyspaces",
 			Enabled: proto.Bool(true),
@@ -177,7 +177,7 @@ func TestMapPolicyFromProtoVariants(t *testing.T) {
 	})
 
 	t.Run("key location without variant is unmappable", func(t *testing.T) {
-		_, err := mapPolicyFromProto(&frontlinev1.Policy{
+		_, err := PolicyFromProto(&frontlinev1.Policy{
 			Id:      "pol_1",
 			Name:    "empty-location",
 			Enabled: proto.Bool(true),

--- a/svc/api/internal/policyconfig/policyconfig.go
+++ b/svc/api/internal/policyconfig/policyconfig.go
@@ -1,13 +1,23 @@
-// Package policyconfig owns the decode rules for stored policy config
-// blobs so the storage contract lives in one place. The frontline gateway
-// carries its own copy in internal/policies (ParseMiddleware) - keep the two
-// in sync when the format changes.
+// Package policyconfig owns the encode and decode rules for stored policy
+// config blobs so the storage contract lives in one place. The frontline
+// gateway carries its own decoder in internal/policies (ParseMiddleware) -
+// keep the two in sync when the format changes.
 package policyconfig
 
 import (
 	frontlinev1 "github.com/unkeyed/unkey/gen/proto/frontline/v1"
 	"google.golang.org/protobuf/encoding/protojson"
 )
+
+// Marshal encodes policies into the stored blob format. protojson omits
+// empty repeated fields but the dashboard's strict schema requires the
+// `policies` key, so an empty config is written literally.
+func Marshal(policies []*frontlinev1.Policy) ([]byte, error) {
+	if len(policies) == 0 {
+		return []byte(`{"policies":[]}`), nil
+	}
+	return protojson.Marshal(&frontlinev1.Config{Policies: policies})
+}
 
 // Parse decodes a stored policy config blob. Empty blobs and the legacy "{}"
 // are valid and yield a config with no policies. Unknown fields are discarded:

--- a/svc/api/internal/policyconfig/to_proto.go
+++ b/svc/api/internal/policyconfig/to_proto.go
@@ -26,6 +26,7 @@ func ToProto(policies []openapi.Policy) ([]*frontlinev1.Policy, error) {
 		if err != nil {
 			return nil, err
 		}
+		converted.Id = uid.New(uid.PolicyPrefix)
 		out = append(out, converted)
 	}
 	return out, nil
@@ -47,6 +48,9 @@ func VariantName(p *frontlinev1.Policy) string {
 	}
 }
 
+// PolicyToProto converts and validates a single policy. It leaves Id unset;
+// callers own identity (ToProto generates fresh ids, updatePolicy keeps the
+// stored one).
 func PolicyToProto(path string, p openapi.Policy) (*frontlinev1.Policy, error) {
 	if err := exactlyOne(path, "keyauth, ratelimit, firewall or openapi",
 		p.Keyauth != nil, p.Ratelimit != nil, p.Firewall != nil, p.Openapi != nil); err != nil {
@@ -54,7 +58,6 @@ func PolicyToProto(path string, p openapi.Policy) (*frontlinev1.Policy, error) {
 	}
 
 	out := &frontlinev1.Policy{
-		Id:      uid.New(uid.PolicyPrefix),
 		Name:    p.Name,
 		Enabled: proto.Bool(p.Enabled),
 	}

--- a/svc/api/internal/policyconfig/to_proto.go
+++ b/svc/api/internal/policyconfig/to_proto.go
@@ -1,4 +1,4 @@
-package handler
+package policyconfig
 
 import (
 	"fmt"
@@ -14,15 +14,15 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-// mapPoliciesToProto parses request policies into the protos frontline evaluates,
+// ToProto parses request policies into the protos frontline evaluates,
 // generating an id per policy. Conversion is also the validation pass: it
 // enforces the rules the OpenAPI schema cannot express (exactly-one variants,
 // valid regex and permission queries), and its errors are user-facing,
 // naming the offending field.
-func mapPoliciesToProto(policies []openapi.Policy) ([]*frontlinev1.Policy, error) {
+func ToProto(policies []openapi.Policy) ([]*frontlinev1.Policy, error) {
 	out := make([]*frontlinev1.Policy, 0, len(policies))
 	for i, p := range policies {
-		converted, err := mapPolicyToProto(fmt.Sprintf("policies[%d]", i), p)
+		converted, err := PolicyToProto(fmt.Sprintf("policies[%d]", i), p)
 		if err != nil {
 			return nil, err
 		}
@@ -31,8 +31,8 @@ func mapPoliciesToProto(policies []openapi.Policy) ([]*frontlinev1.Policy, error
 	return out, nil
 }
 
-// variantName names the set variant for audit metadata.
-func variantName(p *frontlinev1.Policy) string {
+// VariantName names the set variant for audit metadata.
+func VariantName(p *frontlinev1.Policy) string {
 	switch p.Config.(type) {
 	case *frontlinev1.Policy_Keyauth:
 		return "keyauth"
@@ -47,7 +47,7 @@ func variantName(p *frontlinev1.Policy) string {
 	}
 }
 
-func mapPolicyToProto(path string, p openapi.Policy) (*frontlinev1.Policy, error) {
+func PolicyToProto(path string, p openapi.Policy) (*frontlinev1.Policy, error) {
 	if err := exactlyOne(path, "keyauth, ratelimit, firewall or openapi",
 		p.Keyauth != nil, p.Ratelimit != nil, p.Firewall != nil, p.Openapi != nil); err != nil {
 		return nil, err

--- a/svc/api/internal/policyconfig/to_proto_test.go
+++ b/svc/api/internal/policyconfig/to_proto_test.go
@@ -1,4 +1,4 @@
-package handler
+package policyconfig
 
 import (
 	"testing"
@@ -159,7 +159,7 @@ func TestMapPoliciesToProtoValidation(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := mapPoliciesToProto(tc.policies)
+			_, err := ToProto(tc.policies)
 			if tc.wantErr == "" {
 				require.NoError(t, err)
 				return

--- a/svc/api/openapi/gen.go
+++ b/svc/api/openapi/gen.go
@@ -2039,6 +2039,63 @@ type V2GatewaySetPoliciesResponseBody struct {
 	Meta Meta `json:"meta"`
 }
 
+// V2GatewayUpdatePolicyRequestBody Partial update of a single policy. Omitted fields keep their stored
+// values; at least one updatable field must be provided. Providing one of
+// `keyauth`, `ratelimit`, `firewall` or `openapi` replaces the policy's
+// rule entirely, including switching its type; at most one may be set.
+type V2GatewayUpdatePolicyRequestBody struct {
+	// App Identifies a resource by either its unique ID or its slug.
+	// Accepts a prefixed ID (such as 'proj_' or 'app_') or a slug.
+	App ResourceIdentifier `json:"app"`
+
+	// Enabled Enable or disable the policy. Disabled policies are stored but skipped
+	// during evaluation. Omit to keep the current setting.
+	Enabled *bool `json:"enabled,omitempty"`
+
+	// Environment Identifies a resource by either its unique ID or its slug.
+	// Accepts a prefixed ID (such as 'proj_' or 'app_') or a slug.
+	Environment ResourceIdentifier `json:"environment"`
+
+	// Firewall Blocks matching requests.
+	Firewall *FirewallPolicy `json:"firewall,omitempty"`
+
+	// Keyauth Verifies Unkey API keys on matching requests.
+	Keyauth *KeyauthPolicy `json:"keyauth,omitempty"`
+
+	// Match Replaces all match expressions. Set null to remove them so the policy
+	// applies to every request. Omit to keep the current expressions.
+	Match nullable.Nullable[[]MatchExpr] `json:"match,omitempty"`
+
+	// Name New human-readable name. Omit to keep the current name.
+	Name *string `json:"name,omitempty"`
+
+	// Openapi Validates matching requests against the app's uploaded OpenAPI spec. Has no
+	// configuration of its own. If no spec has been uploaded for the deployment,
+	// the policy is a no-op and requests pass through unvalidated.
+	Openapi *OpenapiPolicy `json:"openapi,omitempty"`
+
+	// PolicyId Id of the policy to update, as returned by `gateway.listPolicies`.
+	// Ids are regenerated whenever `gateway.setPolicies` replaces the list,
+	// so list the policies first if you are unsure the id is current.
+	PolicyId string `json:"policyId"`
+
+	// Project Identifies a resource by either its unique ID or its slug.
+	// Accepts a prefixed ID (such as 'proj_' or 'app_') or a slug.
+	Project ResourceIdentifier `json:"project"`
+
+	// Ratelimit Rate limits matching requests.
+	Ratelimit *RatelimitPolicy `json:"ratelimit,omitempty"`
+}
+
+// V2GatewayUpdatePolicyResponseBody defines model for V2GatewayUpdatePolicyResponseBody.
+type V2GatewayUpdatePolicyResponseBody struct {
+	// Data Empty response object by design. A successful response indicates this operation was successfully executed.
+	Data EmptyResponse `json:"data"`
+
+	// Meta Metadata object included in every API response. This provides context about the request and is essential for debugging, audit trails, and support inquiries. The `requestId` is particularly important when troubleshooting issues with the Unkey support team.
+	Meta Meta `json:"meta"`
+}
+
 // V2IdentitiesCreateIdentityRequestBody defines model for V2IdentitiesCreateIdentityRequestBody.
 type V2IdentitiesCreateIdentityRequestBody struct {
 	// ExternalId Creates an identity using your system's unique identifier for a user, organization, or entity.
@@ -3938,6 +3995,9 @@ type GatewayListPoliciesJSONRequestBody = V2GatewayListPoliciesRequestBody
 
 // GatewaySetPoliciesJSONRequestBody defines body for GatewaySetPolicies for application/json ContentType.
 type GatewaySetPoliciesJSONRequestBody = V2GatewaySetPoliciesRequestBody
+
+// GatewayUpdatePolicyJSONRequestBody defines body for GatewayUpdatePolicy for application/json ContentType.
+type GatewayUpdatePolicyJSONRequestBody = V2GatewayUpdatePolicyRequestBody
 
 // IdentitiesCreateIdentityJSONRequestBody defines body for IdentitiesCreateIdentity for application/json ContentType.
 type IdentitiesCreateIdentityJSONRequestBody = V2IdentitiesCreateIdentityRequestBody

--- a/svc/api/openapi/openapi-generated.yaml
+++ b/svc/api/openapi/openapi-generated.yaml
@@ -9018,7 +9018,7 @@ paths:
                                 $ref: '#/components/schemas/InternalServerErrorResponse'
                     description: Internal server error
             security:
-                - rootKey: []
+                - bearer: []
             summary: Update policy
             tags:
                 - gateway

--- a/svc/api/openapi/openapi-generated.yaml
+++ b/svc/api/openapi/openapi-generated.yaml
@@ -8930,8 +8930,8 @@ paths:
                 **Required Permissions**
 
                 Your root key must have one of the following permissions:
-                - `environment.*.set_policies` (for any environment)
-                - `environment.<environment_id>.set_policies` (for a specific environment)
+                - `environment.*.update_policy` (for any environment)
+                - `environment.<environment_id>.update_policy` (for a specific environment)
             operationId: gateway.updatePolicy
             requestBody:
                 content:
@@ -8998,7 +8998,7 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/ForbiddenErrorResponse'
-                    description: Forbidden - Insufficient permissions (requires `environment.*.set_policies`)
+                    description: Forbidden - Insufficient permissions (requires `environment.*.update_policy`)
                 "404":
                     content:
                         application/json:

--- a/svc/api/openapi/openapi-generated.yaml
+++ b/svc/api/openapi/openapi-generated.yaml
@@ -1218,6 +1218,75 @@ components:
                 data:
                     "$ref": "#/components/schemas/EmptyResponse"
             additionalProperties: false
+        V2GatewayUpdatePolicyRequestBody:
+            type: object
+            required:
+                - project
+                - app
+                - environment
+                - policyId
+            properties:
+                project:
+                    "$ref": "#/components/schemas/ResourceIdentifier"
+                app:
+                    "$ref": "#/components/schemas/ResourceIdentifier"
+                environment:
+                    "$ref": "#/components/schemas/ResourceIdentifier"
+                policyId:
+                    type: string
+                    minLength: 1
+                    maxLength: 512
+                    description: |-
+                        Id of the policy to update, as returned by `gateway.listPolicies`.
+                        Ids are regenerated whenever `gateway.setPolicies` replaces the list,
+                        so list the policies first if you are unsure the id is current.
+                    example: pol_9d2Fk1LmQ
+                name:
+                    type: string
+                    minLength: 1
+                    maxLength: 256
+                    description: |-
+                        New human-readable name. Omit to keep the current name.
+                enabled:
+                    type: boolean
+                    description: |-
+                        Enable or disable the policy. Disabled policies are stored but skipped
+                        during evaluation. Omit to keep the current setting.
+                match:
+                    type:
+                        - array
+                        - "null"
+                    maxItems: 10
+                    items:
+                        "$ref": "#/components/schemas/MatchExpr"
+                    description: |-
+                        Replaces all match expressions. Set null to remove them so the policy
+                        applies to every request. Omit to keep the current expressions.
+                keyauth:
+                    "$ref": "#/components/schemas/KeyauthPolicy"
+                ratelimit:
+                    "$ref": "#/components/schemas/RatelimitPolicy"
+                firewall:
+                    "$ref": "#/components/schemas/FirewallPolicy"
+                openapi:
+                    "$ref": "#/components/schemas/OpenapiPolicy"
+            additionalProperties: false
+            description: |-
+                Partial update of a single policy. Omitted fields keep their stored
+                values; at least one updatable field must be provided. Providing one of
+                `keyauth`, `ratelimit`, `firewall` or `openapi` replaces the policy's
+                rule entirely, including switching its type; at most one may be set.
+        V2GatewayUpdatePolicyResponseBody:
+            type: object
+            required:
+                - meta
+                - data
+            properties:
+                meta:
+                    "$ref": "#/components/schemas/Meta"
+                data:
+                    "$ref": "#/components/schemas/EmptyResponse"
+            additionalProperties: false
         V2IdentitiesCreateIdentityRequestBody:
             type: object
             required:
@@ -8842,6 +8911,118 @@ paths:
             tags:
                 - gateway
             x-speakeasy-name-override: setPolicies
+    /v2/gateway.updatePolicy:
+        post:
+            description: |
+                Update a single policy in place without resending the environment's full
+                policy list. The policy keeps its id and its position in the evaluation
+                order, and all other policies are untouched.
+
+                Omitted fields keep their stored values; at least one updatable field
+                must be provided. Setting `match` to null removes all match expressions
+                so the policy applies to every request. Providing one of `keyauth`,
+                `ratelimit`, `firewall` or `openapi` replaces the policy's rule
+                entirely, including switching its type; at most one may be set.
+
+                Policy ids are regenerated whenever `gateway.setPolicies` replaces the
+                list, so fetch current ids via `gateway.listPolicies` first.
+
+                **Required Permissions**
+
+                Your root key must have one of the following permissions:
+                - `environment.*.set_policies` (for any environment)
+                - `environment.<environment_id>.set_policies` (for a specific environment)
+            operationId: gateway.updatePolicy
+            requestBody:
+                content:
+                    application/json:
+                        examples:
+                            clearMatch:
+                                summary: Remove all match expressions
+                                value:
+                                    app: payments-api
+                                    environment: production
+                                    match: null
+                                    policyId: pol_9d2Fk1LmQ
+                                    project: payments
+                            disable:
+                                summary: Disable a policy without touching its rule
+                                value:
+                                    app: payments-api
+                                    enabled: false
+                                    environment: production
+                                    policyId: pol_9d2Fk1LmQ
+                                    project: payments
+                            rename:
+                                summary: Rename a policy
+                                value:
+                                    app: payments-api
+                                    environment: production
+                                    name: Require API key (v2)
+                                    policyId: pol_9d2Fk1LmQ
+                                    project: payments
+                            switchRule:
+                                summary: Replace the policy's rule with a firewall deny
+                                value:
+                                    app: payments-api
+                                    environment: production
+                                    firewall:
+                                        action: ACTION_DENY
+                                    policyId: pol_9d2Fk1LmQ
+                                    project: payments
+                        schema:
+                            $ref: '#/components/schemas/V2GatewayUpdatePolicyRequestBody'
+                required: true
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/V2GatewayUpdatePolicyResponseBody'
+                    description: |
+                        Successfully updated the policy.
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/BadRequestErrorResponse'
+                    description: Bad request
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/UnauthorizedErrorResponse'
+                    description: Unauthorized
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ForbiddenErrorResponse'
+                    description: Forbidden - Insufficient permissions (requires `environment.*.set_policies`)
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/NotFoundErrorResponse'
+                    description: Not Found - The environment, policy, or a referenced keyspace does not exist in your workspace
+                "429":
+                    content:
+                        application/problem+json:
+                            schema:
+                                $ref: '#/components/schemas/TooManyRequestsErrorResponse'
+                    description: Too Many Requests
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/InternalServerErrorResponse'
+                    description: Internal server error
+            security:
+                - rootKey: []
+            summary: Update policy
+            tags:
+                - gateway
+            x-speakeasy-name-override: updatePolicy
     /v2/identities.createIdentity:
         post:
             description: |

--- a/svc/api/openapi/openapi-split.yaml
+++ b/svc/api/openapi/openapi-split.yaml
@@ -278,6 +278,8 @@ paths:
     $ref: "./spec/paths/v2/gateway/setPolicies/index.yaml"
   /v2/gateway.listPolicies:
     $ref: "./spec/paths/v2/gateway/listPolicies/index.yaml"
+  /v2/gateway.updatePolicy:
+    $ref: "./spec/paths/v2/gateway/updatePolicy/index.yaml"
 
   # Permissions Endpoints
   /v2/permissions.createRole:

--- a/svc/api/openapi/overlay.yaml
+++ b/svc/api/openapi/overlay.yaml
@@ -51,6 +51,11 @@ actions:
   - target: $["components"]["schemas"]["UpdateKeyCreditsRefill"]
     update:
       nullable: true
+  - target: $["components"]["schemas"]["V2GatewayUpdatePolicyRequestBody"]["properties"]["match"]["type"]
+    update: array
+  - target: $["components"]["schemas"]["V2GatewayUpdatePolicyRequestBody"]["properties"]["match"]
+    update:
+      nullable: true
   - target: $["components"]["schemas"]["V2EnvironmentsUpdateSettingsRequestBody"]["properties"]["healthcheck"]["anyOf"]
     remove: true
   - target: $["components"]["schemas"]["V2EnvironmentsUpdateSettingsRequestBody"]["properties"]["healthcheck"]

--- a/svc/api/openapi/spec/paths/v2/gateway/updatePolicy/V2GatewayUpdatePolicyRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/gateway/updatePolicy/V2GatewayUpdatePolicyRequestBody.yaml
@@ -1,0 +1,57 @@
+type: object
+required:
+  - project
+  - app
+  - environment
+  - policyId
+properties:
+  project:
+    "$ref": "../../../../common/ResourceIdentifier.yaml"
+  app:
+    "$ref": "../../../../common/ResourceIdentifier.yaml"
+  environment:
+    "$ref": "../../../../common/ResourceIdentifier.yaml"
+  policyId:
+    type: string
+    minLength: 1
+    maxLength: 512
+    description: |-
+      Id of the policy to update, as returned by `gateway.listPolicies`.
+      Ids are regenerated whenever `gateway.setPolicies` replaces the list,
+      so list the policies first if you are unsure the id is current.
+    example: pol_9d2Fk1LmQ
+  name:
+    type: string
+    minLength: 1
+    maxLength: 256
+    description: |-
+      New human-readable name. Omit to keep the current name.
+  enabled:
+    type: boolean
+    description: |-
+      Enable or disable the policy. Disabled policies are stored but skipped
+      during evaluation. Omit to keep the current setting.
+  match:
+    type:
+      - array
+      - "null"
+    maxItems: 10
+    items:
+      "$ref": "../../../../common/MatchExpr.yaml"
+    description: |-
+      Replaces all match expressions. Set null to remove them so the policy
+      applies to every request. Omit to keep the current expressions.
+  keyauth:
+    "$ref": "../../../../common/KeyauthPolicy.yaml"
+  ratelimit:
+    "$ref": "../../../../common/RatelimitPolicy.yaml"
+  firewall:
+    "$ref": "../../../../common/FirewallPolicy.yaml"
+  openapi:
+    "$ref": "../../../../common/OpenapiPolicy.yaml"
+additionalProperties: false
+description: |-
+  Partial update of a single policy. Omitted fields keep their stored
+  values; at least one updatable field must be provided. Providing one of
+  `keyauth`, `ratelimit`, `firewall` or `openapi` replaces the policy's
+  rule entirely, including switching its type; at most one may be set.

--- a/svc/api/openapi/spec/paths/v2/gateway/updatePolicy/V2GatewayUpdatePolicyResponseBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/gateway/updatePolicy/V2GatewayUpdatePolicyResponseBody.yaml
@@ -1,0 +1,10 @@
+type: object
+required:
+  - meta
+  - data
+properties:
+  meta:
+    "$ref": "../../../../common/Meta.yaml"
+  data:
+    "$ref": "../../../../common/EmptyResponse.yaml"
+additionalProperties: false

--- a/svc/api/openapi/spec/paths/v2/gateway/updatePolicy/index.yaml
+++ b/svc/api/openapi/spec/paths/v2/gateway/updatePolicy/index.yaml
@@ -1,0 +1,111 @@
+post:
+  tags:
+    - gateway
+  summary: Update policy
+  description: |
+    Update a single policy in place without resending the environment's full
+    policy list. The policy keeps its id and its position in the evaluation
+    order, and all other policies are untouched.
+
+    Omitted fields keep their stored values; at least one updatable field
+    must be provided. Setting `match` to null removes all match expressions
+    so the policy applies to every request. Providing one of `keyauth`,
+    `ratelimit`, `firewall` or `openapi` replaces the policy's rule
+    entirely, including switching its type; at most one may be set.
+
+    Policy ids are regenerated whenever `gateway.setPolicies` replaces the
+    list, so fetch current ids via `gateway.listPolicies` first.
+
+    **Required Permissions**
+
+    Your root key must have one of the following permissions:
+    - `environment.*.set_policies` (for any environment)
+    - `environment.<environment_id>.set_policies` (for a specific environment)
+  operationId: gateway.updatePolicy
+  x-speakeasy-name-override: updatePolicy
+  security:
+    - rootKey: []
+  requestBody:
+    content:
+      application/json:
+        schema:
+          "$ref": "./V2GatewayUpdatePolicyRequestBody.yaml"
+        examples:
+          disable:
+            summary: Disable a policy without touching its rule
+            value:
+              project: payments
+              app: payments-api
+              environment: production
+              policyId: pol_9d2Fk1LmQ
+              enabled: false
+          rename:
+            summary: Rename a policy
+            value:
+              project: payments
+              app: payments-api
+              environment: production
+              policyId: pol_9d2Fk1LmQ
+              name: Require API key (v2)
+          switchRule:
+            summary: Replace the policy's rule with a firewall deny
+            value:
+              project: payments
+              app: payments-api
+              environment: production
+              policyId: pol_9d2Fk1LmQ
+              firewall:
+                action: ACTION_DENY
+          clearMatch:
+            summary: Remove all match expressions
+            value:
+              project: payments
+              app: payments-api
+              environment: production
+              policyId: pol_9d2Fk1LmQ
+              match: null
+    required: true
+  responses:
+    "200":
+      description: |
+        Successfully updated the policy.
+      content:
+        application/json:
+          schema:
+            "$ref": "./V2GatewayUpdatePolicyResponseBody.yaml"
+    "400":
+      description: Bad request
+      content:
+        application/json:
+          schema:
+            "$ref": "../../../../error/BadRequestErrorResponse.yaml"
+    "401":
+      description: Unauthorized
+      content:
+        application/json:
+          schema:
+            "$ref": "../../../../error/UnauthorizedErrorResponse.yaml"
+    "403":
+      description: Forbidden - Insufficient permissions (requires `environment.*.set_policies`)
+      content:
+        application/json:
+          schema:
+            "$ref": "../../../../error/ForbiddenErrorResponse.yaml"
+    "404":
+      description: Not Found - The environment, policy, or a referenced keyspace does not exist in your workspace
+      content:
+        application/json:
+          schema:
+            "$ref": "../../../../error/NotFoundErrorResponse.yaml"
+    "429":
+      description: Too Many Requests
+      content:
+        application/problem+json:
+          schema:
+            "$ref": "../../../../error/TooManyRequestsErrorResponse.yaml"
+    "500":
+      description: Internal server error
+      content:
+        application/json:
+          schema:
+            "$ref": "../../../../error/InternalServerErrorResponse.yaml"

--- a/svc/api/openapi/spec/paths/v2/gateway/updatePolicy/index.yaml
+++ b/svc/api/openapi/spec/paths/v2/gateway/updatePolicy/index.yaml
@@ -19,8 +19,8 @@ post:
     **Required Permissions**
 
     Your root key must have one of the following permissions:
-    - `environment.*.set_policies` (for any environment)
-    - `environment.<environment_id>.set_policies` (for a specific environment)
+    - `environment.*.update_policy` (for any environment)
+    - `environment.<environment_id>.update_policy` (for a specific environment)
   operationId: gateway.updatePolicy
   x-speakeasy-name-override: updatePolicy
   security:
@@ -86,7 +86,7 @@ post:
           schema:
             "$ref": "../../../../error/UnauthorizedErrorResponse.yaml"
     "403":
-      description: Forbidden - Insufficient permissions (requires `environment.*.set_policies`)
+      description: Forbidden - Insufficient permissions (requires `environment.*.update_policy`)
       content:
         application/json:
           schema:

--- a/svc/api/openapi/spec/paths/v2/gateway/updatePolicy/index.yaml
+++ b/svc/api/openapi/spec/paths/v2/gateway/updatePolicy/index.yaml
@@ -24,7 +24,7 @@ post:
   operationId: gateway.updatePolicy
   x-speakeasy-name-override: updatePolicy
   security:
-    - rootKey: []
+    - bearer: []
   requestBody:
     content:
       application/json:

--- a/svc/api/routes/register.go
+++ b/svc/api/routes/register.go
@@ -84,6 +84,7 @@ import (
 	v2EnvironmentsUpdateSettings "github.com/unkeyed/unkey/svc/api/routes/v2_environments_update_settings"
 	v2GatewayListPolicies "github.com/unkeyed/unkey/svc/api/routes/v2_gateway_list_policies"
 	v2GatewaySetPolicies "github.com/unkeyed/unkey/svc/api/routes/v2_gateway_set_policies"
+	v2GatewayUpdatePolicy "github.com/unkeyed/unkey/svc/api/routes/v2_gateway_update_policy"
 	v2ProjectsCreateProject "github.com/unkeyed/unkey/svc/api/routes/v2_projects_create_project"
 	v2ProjectsDeleteProject "github.com/unkeyed/unkey/svc/api/routes/v2_projects_delete_project"
 	v2ProjectsGetProject "github.com/unkeyed/unkey/svc/api/routes/v2_projects_get_project"
@@ -890,6 +891,15 @@ func Register(srv *zen.Server, svc *Services, info zen.InstanceInfo) {
 		protectedMiddlewares,
 		&v2GatewayListPolicies.Handler{
 			DB: svc.Database,
+		},
+	)
+
+	// v2/gateway.updatePolicy
+	srv.RegisterRoute(
+		protectedMiddlewares,
+		&v2GatewayUpdatePolicy.Handler{
+			DB:        svc.Database,
+			Auditlogs: svc.Auditlogs,
 		},
 	)
 

--- a/svc/api/routes/v2_gateway_list_policies/handler.go
+++ b/svc/api/routes/v2_gateway_list_policies/handler.go
@@ -111,7 +111,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		)
 	}
 
-	all, err := mapPoliciesFromProto(cfg.GetPolicies())
+	all, err := policyconfig.FromProto(cfg.GetPolicies())
 	if err != nil {
 		return err
 	}

--- a/svc/api/routes/v2_gateway_set_policies/handler.go
+++ b/svc/api/routes/v2_gateway_set_policies/handler.go
@@ -17,6 +17,7 @@ import (
 	"github.com/unkeyed/unkey/pkg/fault"
 	"github.com/unkeyed/unkey/pkg/rbac"
 	"github.com/unkeyed/unkey/pkg/zen"
+	"github.com/unkeyed/unkey/svc/api/internal/policyconfig"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 	"google.golang.org/protobuf/encoding/protojson"
 )
@@ -89,7 +90,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	policies, err := mapPoliciesToProto(req.Policies)
+	policies, err := policyconfig.ToProto(req.Policies)
 	if err != nil {
 		return err
 	}
@@ -164,7 +165,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			fmt.Sprintf("Set policy %s (%s) for environment %s", p.GetName(), p.GetId(), env.ID),
 			map[string]any{
 				"policyId":   p.GetId(),
-				"policyType": variantName(p),
+				"policyType": policyconfig.VariantName(p),
 				"policy":     json.RawMessage(doc),
 			},
 		))

--- a/svc/api/routes/v2_gateway_set_policies/handler.go
+++ b/svc/api/routes/v2_gateway_set_policies/handler.go
@@ -9,7 +9,6 @@ import (
 	"slices"
 	"time"
 
-	frontlinev1 "github.com/unkeyed/unkey/gen/proto/frontline/v1"
 	"github.com/unkeyed/unkey/internal/services/auditlogs"
 	"github.com/unkeyed/unkey/pkg/auditlog"
 	"github.com/unkeyed/unkey/pkg/codes"
@@ -180,19 +179,14 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		))
 	}
 
-	// protojson omits empty repeated fields but the dashboard's strict schema
-	// requires the `policies` key, so an empty config is written literally.
-	blob := []byte(`{"policies":[]}`)
-	if len(policies) > 0 {
-		blob, err = protojson.Marshal(&frontlinev1.Config{Policies: policies})
-		if err != nil {
-			return fault.Wrap(
-				err,
-				fault.Code(codes.App.Internal.UnexpectedError.URN()),
-				fault.Internal("policy serialization failed"),
-				fault.Public("We're unable to set the policies."),
-			)
-		}
+	blob, err := policyconfig.Marshal(policies)
+	if err != nil {
+		return fault.Wrap(
+			err,
+			fault.Code(codes.App.Internal.UnexpectedError.URN()),
+			fault.Internal("policy serialization failed"),
+			fault.Public("We're unable to set the policies."),
+		)
 	}
 
 	now := time.Now().UnixMilli()

--- a/svc/api/routes/v2_gateway_update_policy/200_test.go
+++ b/svc/api/routes/v2_gateway_update_policy/200_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
 	"github.com/unkeyed/unkey/svc/api/openapi"
-	handler "github.com/unkeyed/unkey/svc/api/routes/v2_gateway_update_policy"
 	listpolicies "github.com/unkeyed/unkey/svc/api/routes/v2_gateway_list_policies"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_gateway_update_policy"
 )
 
 func TestUpdatePolicySuccessfully(t *testing.T) {

--- a/svc/api/routes/v2_gateway_update_policy/200_test.go
+++ b/svc/api/routes/v2_gateway_update_policy/200_test.go
@@ -1,0 +1,187 @@
+package handler_test
+
+import (
+	"testing"
+
+	"github.com/oapi-codegen/nullable"
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/ptr"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
+	"github.com/unkeyed/unkey/svc/api/openapi"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_gateway_update_policy"
+	listpolicies "github.com/unkeyed/unkey/svc/api/routes/v2_gateway_list_policies"
+)
+
+func TestUpdatePolicySuccessfully(t *testing.T) {
+	h := testutil.NewHarness(t)
+
+	route := &handler.Handler{DB: h.DB, Auditlogs: h.Auditlogs}
+	h.Register(route)
+	listRoute := &listpolicies.Handler{DB: h.DB}
+	h.Register(listRoute)
+
+	workspace := h.Resources().UserWorkspace
+	rootKey := h.CreateRootKey(workspace.ID, "environment.*.set_policies", "environment.*.read_policies")
+	headers := authHeaders(rootKey)
+
+	call := func(t *testing.T, req handler.Request) {
+		t.Helper()
+		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, req)
+		require.Equal(t, 200, res.Status, "expected 200, received: %s", res.RawBody)
+		require.NotEmpty(t, res.Body.Meta.RequestId)
+	}
+
+	list := func(t *testing.T, env seededEnv) []openapi.PolicyResponse {
+		t.Helper()
+		res := testutil.CallRoute[listpolicies.Request, listpolicies.Response](h, listRoute, headers, listpolicies.Request{
+			Project:     env.projectID,
+			App:         env.appID,
+			Environment: env.environmentID,
+			Cursor:      nil,
+			Limit:       nil,
+		})
+		require.Equal(t, 200, res.Status, "expected 200, received: %s", res.RawBody)
+		return res.Body.Data
+	}
+
+	t.Run("rename keeps id, rule and siblings", func(t *testing.T) {
+		env := seedEnvironment(t, h)
+		ids := seedFirewallPolicies(t, h, env, 3)
+
+		req := makeRequest(env, ids[1])
+		req.Name = ptr.P("KEBAP renamed")
+		call(t, req)
+
+		policies := list(t, env)
+		require.Len(t, policies, 3)
+		for i, p := range policies {
+			require.Equal(t, ids[i], p.Id, "order and ids must be stable")
+			require.NotNil(t, p.Firewall)
+			require.True(t, p.Enabled)
+		}
+		require.Equal(t, "KEBAP 0", policies[0].Name)
+		require.Equal(t, "KEBAP renamed", policies[1].Name)
+		require.Equal(t, "KEBAP 2", policies[2].Name)
+	})
+
+	t.Run("disable survives storage roundtrip", func(t *testing.T) {
+		env := seedEnvironment(t, h)
+		ids := seedFirewallPolicies(t, h, env, 1)
+
+		req := makeRequest(env, ids[0])
+		req.Enabled = ptr.P(false)
+		call(t, req)
+
+		policies := list(t, env)
+		require.Len(t, policies, 1)
+		require.False(t, policies[0].Enabled)
+		require.Equal(t, "KEBAP 0", policies[0].Name, "name must be untouched")
+		// The dashboard's strict schema requires the key to be present.
+		require.Contains(t, readStoredBlob(t, h, env), `"enabled":false`)
+	})
+
+	t.Run("replace match expressions", func(t *testing.T) {
+		env := seedEnvironment(t, h)
+		ids := seedFirewallPolicies(t, h, env, 1)
+
+		req := makeRequest(env, ids[0])
+		req.Match = nullable.NewNullableWithValue([]openapi.MatchExpr{
+			{Path: &openapi.PathMatch{Path: openapi.StringMatch{Prefix: ptr.P("/internal/")}}},
+			{Method: &openapi.MethodMatch{Methods: []openapi.MethodMatchMethods{"GET"}}},
+		})
+		call(t, req)
+
+		policies := list(t, env)
+		match := ptr.SafeDeref(policies[0].Match)
+		require.Len(t, match, 2)
+		require.Equal(t, ptr.P("/internal/"), match[0].Path.Path.Prefix)
+		require.Equal(t, []openapi.MethodMatchMethods{"GET"}, match[1].Method.Methods)
+	})
+
+	t.Run("null match clears expressions", func(t *testing.T) {
+		env := seedEnvironment(t, h)
+		seedSentinelConfig(t, h, env,
+			`{"policies":[{"id":"pol_kebap","name":"KEBAP","enabled":true,`+
+				`"match":[{"path":{"path":{"prefix":"/internal/"}}}],`+
+				`"firewall":{"action":"ACTION_DENY"}}]}`)
+
+		req := makeRequest(env, "pol_kebap")
+		req.Match = nullable.NewNullNullable[[]openapi.MatchExpr]()
+		call(t, req)
+
+		policies := list(t, env)
+		require.Len(t, policies, 1)
+		require.Nil(t, policies[0].Match)
+		require.NotNil(t, policies[0].Firewall, "rule must be untouched")
+	})
+
+	t.Run("switch rule variant preserves id and match", func(t *testing.T) {
+		env := seedEnvironment(t, h)
+		seedSentinelConfig(t, h, env,
+			`{"policies":[{"id":"pol_kebap","name":"KEBAP","enabled":true,`+
+				`"match":[{"path":{"path":{"prefix":"/api/"}}}],`+
+				`"ratelimit":{"limit":"100","windowMs":"60000","identifier":{"remoteIp":{}}}}]}`)
+
+		req := makeRequest(env, "pol_kebap")
+		req.Firewall = &openapi.FirewallPolicy{Action: "ACTION_DENY"}
+		call(t, req)
+
+		policies := list(t, env)
+		require.Len(t, policies, 1)
+		require.Equal(t, "pol_kebap", policies[0].Id)
+		require.NotNil(t, policies[0].Firewall)
+		require.Nil(t, policies[0].Ratelimit, "old rule must be gone")
+		require.Len(t, ptr.SafeDeref(policies[0].Match), 1)
+	})
+
+	t.Run("update keyauth with owned keyspaces", func(t *testing.T) {
+		env := seedEnvironment(t, h)
+		ids := seedFirewallPolicies(t, h, env, 1)
+		api := h.CreateApi(seed.CreateApiRequest{WorkspaceID: workspace.ID})
+
+		req := makeRequest(env, ids[0])
+		req.Keyauth = &openapi.KeyauthPolicy{
+			Keyspaces:       []string{api.KeyAuthID.String},
+			PermissionQuery: ptr.P("documents.read"),
+		}
+		call(t, req)
+
+		policies := list(t, env)
+		require.NotNil(t, policies[0].Keyauth)
+		require.Equal(t, []string{api.KeyAuthID.String}, policies[0].Keyauth.Keyspaces)
+		require.Equal(t, ptr.P("documents.read"), policies[0].Keyauth.PermissionQuery)
+		require.Nil(t, policies[0].Firewall)
+	})
+
+	t.Run("combined patch in one call", func(t *testing.T) {
+		env := seedEnvironment(t, h)
+		ids := seedFirewallPolicies(t, h, env, 2)
+
+		req := makeRequest(env, ids[0])
+		req.Name = ptr.P("KEBAP combined")
+		req.Enabled = ptr.P(false)
+		req.Match = nullable.NewNullableWithValue([]openapi.MatchExpr{
+			{Path: &openapi.PathMatch{Path: openapi.StringMatch{Exact: ptr.P("/health")}}},
+		})
+		req.Openapi = &openapi.OpenapiPolicy{}
+		call(t, req)
+
+		policies := list(t, env)
+		require.Len(t, policies, 2)
+		updated := policies[0]
+		require.Equal(t, ids[0], updated.Id)
+		require.Equal(t, "KEBAP combined", updated.Name)
+		require.False(t, updated.Enabled)
+		require.NotNil(t, updated.Openapi)
+		require.Nil(t, updated.Firewall)
+		require.Len(t, ptr.SafeDeref(updated.Match), 1)
+
+		sibling := policies[1]
+		require.Equal(t, ids[1], sibling.Id)
+		require.Equal(t, "KEBAP 1", sibling.Name)
+		require.True(t, sibling.Enabled)
+		require.NotNil(t, sibling.Firewall)
+		require.Nil(t, sibling.Match)
+	})
+}

--- a/svc/api/routes/v2_gateway_update_policy/200_test.go
+++ b/svc/api/routes/v2_gateway_update_policy/200_test.go
@@ -38,8 +38,6 @@ func TestUpdatePolicySuccessfully(t *testing.T) {
 			Project:     env.projectID,
 			App:         env.appID,
 			Environment: env.environmentID,
-			Cursor:      nil,
-			Limit:       nil,
 		})
 		require.Equal(t, 200, res.Status, "expected 200, received: %s", res.RawBody)
 		return res.Body.Data

--- a/svc/api/routes/v2_gateway_update_policy/200_test.go
+++ b/svc/api/routes/v2_gateway_update_policy/200_test.go
@@ -22,7 +22,7 @@ func TestUpdatePolicySuccessfully(t *testing.T) {
 	h.Register(listRoute)
 
 	workspace := h.Resources().UserWorkspace
-	rootKey := h.CreateRootKey(workspace.ID, "environment.*.set_policies", "environment.*.read_policies")
+	rootKey := h.CreateRootKey(workspace.ID, "environment.*.update_policy", "environment.*.read_policies")
 	headers := authHeaders(rootKey)
 
 	call := func(t *testing.T, req handler.Request) {

--- a/svc/api/routes/v2_gateway_update_policy/400_test.go
+++ b/svc/api/routes/v2_gateway_update_policy/400_test.go
@@ -19,7 +19,7 @@ func TestUpdatePolicyBadRequest(t *testing.T) {
 	h.Register(route)
 
 	workspace := h.Resources().UserWorkspace
-	rootKey := h.CreateRootKey(workspace.ID, "environment.*.set_policies")
+	rootKey := h.CreateRootKey(workspace.ID, "environment.*.update_policy")
 	headers := authHeaders(rootKey)
 	env := seedEnvironment(t, h)
 	ids := seedFirewallPolicies(t, h, env, 1)

--- a/svc/api/routes/v2_gateway_update_policy/400_test.go
+++ b/svc/api/routes/v2_gateway_update_policy/400_test.go
@@ -43,7 +43,7 @@ func TestUpdatePolicyBadRequest(t *testing.T) {
 		req.Openapi = &openapi.OpenapiPolicy{}
 		res := callTyped(t, req)
 		require.Contains(t, res.Body.Error.Type, "invalid_input")
-		require.Contains(t, res.Body.Error.Detail, "At most one of")
+		require.Contains(t, res.Body.Error.Detail, "exactly one of keyauth, ratelimit, firewall or openapi; 2 are set")
 	})
 
 	t.Run("invalid regex in match", func(t *testing.T) {

--- a/svc/api/routes/v2_gateway_update_policy/400_test.go
+++ b/svc/api/routes/v2_gateway_update_policy/400_test.go
@@ -1,0 +1,98 @@
+package handler_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/oapi-codegen/nullable"
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/ptr"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	"github.com/unkeyed/unkey/svc/api/openapi"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_gateway_update_policy"
+)
+
+func TestUpdatePolicyBadRequest(t *testing.T) {
+	h := testutil.NewHarness(t)
+
+	route := &handler.Handler{DB: h.DB, Auditlogs: h.Auditlogs}
+	h.Register(route)
+
+	workspace := h.Resources().UserWorkspace
+	rootKey := h.CreateRootKey(workspace.ID, "environment.*.set_policies")
+	headers := authHeaders(rootKey)
+	env := seedEnvironment(t, h)
+	ids := seedFirewallPolicies(t, h, env, 1)
+
+	callTyped := func(t *testing.T, req handler.Request) testutil.TestResponse[openapi.BadRequestErrorResponse] {
+		t.Helper()
+		res := testutil.CallRoute[handler.Request, openapi.BadRequestErrorResponse](h, route, headers, req)
+		require.Equal(t, http.StatusBadRequest, res.Status, "expected 400, received: %s", res.RawBody)
+		return res
+	}
+
+	t.Run("no updatable fields", func(t *testing.T) {
+		res := callTyped(t, makeRequest(env, ids[0]))
+		require.Contains(t, res.Body.Error.Type, "invalid_input")
+		require.Contains(t, res.Body.Error.Detail, "at least one field")
+	})
+
+	t.Run("more than one rule variant", func(t *testing.T) {
+		req := makeRequest(env, ids[0])
+		req.Firewall = &openapi.FirewallPolicy{Action: "ACTION_DENY"}
+		req.Openapi = &openapi.OpenapiPolicy{}
+		res := callTyped(t, req)
+		require.Contains(t, res.Body.Error.Type, "invalid_input")
+		require.Contains(t, res.Body.Error.Detail, "At most one of")
+	})
+
+	t.Run("invalid regex in match", func(t *testing.T) {
+		req := makeRequest(env, ids[0])
+		req.Match = nullable.NewNullableWithValue([]openapi.MatchExpr{
+			{Path: &openapi.PathMatch{Path: openapi.StringMatch{Regex: ptr.P("(unclosed")}}},
+		})
+		res := callTyped(t, req)
+		require.Contains(t, res.Body.Error.Detail, "regular expression")
+	})
+
+	t.Run("match expression with no variant", func(t *testing.T) {
+		req := makeRequest(env, ids[0])
+		req.Match = nullable.NewNullableWithValue([]openapi.MatchExpr{{}})
+		res := callTyped(t, req)
+		require.Contains(t, res.Body.Error.Detail, "exactly one")
+	})
+
+	t.Run("invalid permission query", func(t *testing.T) {
+		req := makeRequest(env, ids[0])
+		req.Keyauth = &openapi.KeyauthPolicy{
+			Keyspaces:       []string{"ks_kebap"},
+			PermissionQuery: ptr.P("documents.read AND NOT other"),
+		}
+		res := callTyped(t, req)
+		require.Contains(t, res.Body.Error.Detail, "permission query")
+	})
+
+	t.Run("keyauth ratelimit limit without duration", func(t *testing.T) {
+		req := makeRequest(env, ids[0])
+		req.Keyauth = &openapi.KeyauthPolicy{
+			Keyspaces:  []string{"ks_kebap"},
+			Ratelimits: ptr.P([]openapi.KeyRatelimit{{Name: "burst", Limit: ptr.P(int64(10))}}),
+		}
+		res := callTyped(t, req)
+		require.Contains(t, res.Body.Error.Detail, "limit and duration together")
+	})
+
+	t.Run("missing identifiers", func(t *testing.T) {
+		req := makeRequest(seededEnv{}, "")
+		req.Enabled = ptr.P(false)
+		callTyped(t, req)
+	})
+
+	t.Run("stored policies stay untouched after rejected update", func(t *testing.T) {
+		blob := readStoredBlob(t, h, env)
+		req := makeRequest(env, ids[0])
+		req.Firewall = &openapi.FirewallPolicy{Action: "ACTION_UNKNOWN"}
+		callTyped(t, req)
+		require.Equal(t, blob, readStoredBlob(t, h, env))
+	})
+}

--- a/svc/api/routes/v2_gateway_update_policy/401_test.go
+++ b/svc/api/routes/v2_gateway_update_policy/401_test.go
@@ -1,0 +1,32 @@
+package handler_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/ptr"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_gateway_update_policy"
+)
+
+func TestUpdatePolicyUnauthorized(t *testing.T) {
+	h := testutil.NewHarness(t)
+
+	route := &handler.Handler{DB: h.DB, Auditlogs: h.Auditlogs}
+	h.Register(route)
+
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {"Bearer invalid_token"},
+	}
+	req := makeRequest(seededEnv{
+		workspaceID:   "",
+		projectID:     "payments",
+		appID:         "payments-api",
+		environmentID: "env_1234abcd",
+	}, "pol_000")
+	req.Name = ptr.P("KEBAP")
+	res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, req)
+	require.Equal(t, http.StatusUnauthorized, res.Status, "expected 401, received: %s", res.RawBody)
+}

--- a/svc/api/routes/v2_gateway_update_policy/403_test.go
+++ b/svc/api/routes/v2_gateway_update_policy/403_test.go
@@ -1,0 +1,53 @@
+package handler_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/ptr"
+	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_gateway_update_policy"
+)
+
+func TestUpdatePolicyForbidden(t *testing.T) {
+	h := testutil.NewHarness(t)
+
+	route := &handler.Handler{DB: h.DB, Auditlogs: h.Auditlogs}
+	h.Register(route)
+
+	env := seedEnvironment(t, h)
+	ids := seedFirewallPolicies(t, h, env, 1)
+
+	testCases := []struct {
+		name        string
+		permissions []string
+		shouldPass  bool
+	}{
+		{name: "wildcard permission", permissions: []string{"environment.*.set_policies"}, shouldPass: true},
+		{name: "specific permission", permissions: []string{fmt.Sprintf("environment.%s.set_policies", env.environmentID)}, shouldPass: true},
+		{name: "permission and more", permissions: []string{"some.other.permission", "environment.*.set_policies"}, shouldPass: true},
+		{name: "read action is not enough", permissions: []string{"environment.*.read_policies"}, shouldPass: false},
+		{name: "other environment id does not match", permissions: []string{fmt.Sprintf("environment.%s.set_policies", uid.New(uid.EnvironmentPrefix))}, shouldPass: false},
+		{name: "unrelated permission", permissions: []string{"api.*.read_api"}, shouldPass: false},
+		{name: "no permissions", permissions: []string{}, shouldPass: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rootKey := h.CreateRootKey(env.workspaceID, tc.permissions...)
+			headers := authHeaders(rootKey)
+
+			req := makeRequest(env, ids[0])
+			req.Name = ptr.P("KEBAP")
+			res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, req)
+			if tc.shouldPass {
+				require.Equal(t, 200, res.Status, "expected 200 for %v, got: %s", tc.permissions, res.RawBody)
+				return
+			}
+			require.Equal(t, http.StatusForbidden, res.Status, "expected 403 for %v, got: %s", tc.permissions, res.RawBody)
+		})
+	}
+}

--- a/svc/api/routes/v2_gateway_update_policy/403_test.go
+++ b/svc/api/routes/v2_gateway_update_policy/403_test.go
@@ -26,11 +26,12 @@ func TestUpdatePolicyForbidden(t *testing.T) {
 		permissions []string
 		shouldPass  bool
 	}{
-		{name: "wildcard permission", permissions: []string{"environment.*.set_policies"}, shouldPass: true},
-		{name: "specific permission", permissions: []string{fmt.Sprintf("environment.%s.set_policies", env.environmentID)}, shouldPass: true},
-		{name: "permission and more", permissions: []string{"some.other.permission", "environment.*.set_policies"}, shouldPass: true},
+		{name: "wildcard permission", permissions: []string{"environment.*.update_policy"}, shouldPass: true},
+		{name: "specific permission", permissions: []string{fmt.Sprintf("environment.%s.update_policy", env.environmentID)}, shouldPass: true},
+		{name: "permission and more", permissions: []string{"some.other.permission", "environment.*.update_policy"}, shouldPass: true},
 		{name: "read action is not enough", permissions: []string{"environment.*.read_policies"}, shouldPass: false},
-		{name: "other environment id does not match", permissions: []string{fmt.Sprintf("environment.%s.set_policies", uid.New(uid.EnvironmentPrefix))}, shouldPass: false},
+		{name: "set_policies action is not enough", permissions: []string{"environment.*.set_policies"}, shouldPass: false},
+		{name: "other environment id does not match", permissions: []string{fmt.Sprintf("environment.%s.update_policy", uid.New(uid.EnvironmentPrefix))}, shouldPass: false},
 		{name: "unrelated permission", permissions: []string{"api.*.read_api"}, shouldPass: false},
 		{name: "no permissions", permissions: []string{}, shouldPass: false},
 	}

--- a/svc/api/routes/v2_gateway_update_policy/404_test.go
+++ b/svc/api/routes/v2_gateway_update_policy/404_test.go
@@ -1,0 +1,94 @@
+package handler_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/ptr"
+	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	"github.com/unkeyed/unkey/svc/api/openapi"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_gateway_update_policy"
+)
+
+func TestUpdatePolicyNotFound(t *testing.T) {
+	h := testutil.NewHarness(t)
+
+	route := &handler.Handler{DB: h.DB, Auditlogs: h.Auditlogs}
+	h.Register(route)
+
+	env := seedEnvironment(t, h)
+	ids := seedFirewallPolicies(t, h, env, 1)
+	rootKey := h.CreateRootKey(env.workspaceID, "environment.*.set_policies")
+	headers := authHeaders(rootKey)
+
+	call := func(t *testing.T, req handler.Request) testutil.TestResponse[openapi.NotFoundErrorResponse] {
+		t.Helper()
+		if req.Name == nil {
+			req.Name = ptr.P("KEBAP")
+		}
+		res := testutil.CallRoute[handler.Request, openapi.NotFoundErrorResponse](h, route, headers, req)
+		require.Equal(t, http.StatusNotFound, res.Status, "expected 404, received: %s", res.RawBody)
+		return res
+	}
+
+	t.Run("nonexistent environment", func(t *testing.T) {
+		req := makeRequest(env, ids[0])
+		req.Environment = uid.New(uid.EnvironmentPrefix)
+		call(t, req)
+	})
+
+	t.Run("nonexistent project", func(t *testing.T) {
+		req := makeRequest(env, ids[0])
+		req.Project = uid.New(uid.ProjectPrefix)
+		call(t, req)
+	})
+
+	t.Run("nonexistent app", func(t *testing.T) {
+		req := makeRequest(env, ids[0])
+		req.App = uid.New(uid.AppPrefix)
+		call(t, req)
+	})
+
+	t.Run("unknown policy id", func(t *testing.T) {
+		res := call(t, makeRequest(env, "pol_doesnotexist"))
+		require.Contains(t, res.Body.Error.Type, "policy_not_found")
+		require.Contains(t, res.Body.Error.Detail, "policy ids change")
+	})
+
+	t.Run("policy id from another environment", func(t *testing.T) {
+		other := seedEnvironment(t, h)
+		seedSentinelConfig(t, h, other,
+			`{"policies":[{"id":"pol_foreign","name":"KEBAP","enabled":true,"firewall":{"action":"ACTION_DENY"}}]}`)
+		call(t, makeRequest(env, "pol_foreign"))
+	})
+
+	t.Run("missing runtime settings row", func(t *testing.T) {
+		bare := seedEnvironment(t, h)
+		_, err := h.DB.RW().ExecContext(context.Background(),
+			"DELETE FROM app_runtime_settings WHERE app_id = ? AND environment_id = ?",
+			bare.appID, bare.environmentID)
+		require.NoError(t, err)
+
+		res := call(t, makeRequest(bare, "pol_000"))
+		require.Contains(t, res.Body.Error.Type, "policy_not_found")
+	})
+
+	t.Run("unowned keyspace", func(t *testing.T) {
+		req := makeRequest(env, ids[0])
+		req.Keyauth = &openapi.KeyauthPolicy{Keyspaces: []string{"ks_kebap_unowned"}}
+		res := call(t, req)
+		require.Contains(t, res.Body.Error.Type, "key_space_not_found")
+	})
+
+	t.Run("another workspace's environment", func(t *testing.T) {
+		other := h.CreateWorkspace()
+		foreignKey := h.CreateRootKey(other.ID, "environment.*.set_policies")
+		req := makeRequest(env, ids[0])
+		req.Name = ptr.P("KEBAP")
+		res := testutil.CallRoute[handler.Request, openapi.NotFoundErrorResponse](h, route, authHeaders(foreignKey), req)
+		require.Equal(t, http.StatusNotFound, res.Status, "expected 404, received: %s", res.RawBody)
+	})
+}

--- a/svc/api/routes/v2_gateway_update_policy/404_test.go
+++ b/svc/api/routes/v2_gateway_update_policy/404_test.go
@@ -21,7 +21,7 @@ func TestUpdatePolicyNotFound(t *testing.T) {
 
 	env := seedEnvironment(t, h)
 	ids := seedFirewallPolicies(t, h, env, 1)
-	rootKey := h.CreateRootKey(env.workspaceID, "environment.*.set_policies")
+	rootKey := h.CreateRootKey(env.workspaceID, "environment.*.update_policy")
 	headers := authHeaders(rootKey)
 
 	call := func(t *testing.T, req handler.Request) testutil.TestResponse[openapi.NotFoundErrorResponse] {
@@ -85,7 +85,7 @@ func TestUpdatePolicyNotFound(t *testing.T) {
 
 	t.Run("another workspace's environment", func(t *testing.T) {
 		other := h.CreateWorkspace()
-		foreignKey := h.CreateRootKey(other.ID, "environment.*.set_policies")
+		foreignKey := h.CreateRootKey(other.ID, "environment.*.update_policy")
 		req := makeRequest(env, ids[0])
 		req.Name = ptr.P("KEBAP")
 		res := testutil.CallRoute[handler.Request, openapi.NotFoundErrorResponse](h, route, authHeaders(foreignKey), req)

--- a/svc/api/routes/v2_gateway_update_policy/handler.go
+++ b/svc/api/routes/v2_gateway_update_policy/handler.go
@@ -51,21 +51,10 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	rules := 0
-	for _, set := range []bool{req.Keyauth != nil, req.Ratelimit != nil, req.Firewall != nil, req.Openapi != nil} {
-		if set {
-			rules++
-		}
-	}
-	if rules > 1 {
-		return fault.New(
-			"multiple rule variants",
-			fault.Code(codes.App.Validation.InvalidInput.URN()),
-			fault.Internal("more than one rule variant in update"),
-			fault.Public("At most one of keyauth, ratelimit, firewall or openapi may be set."),
-		)
-	}
-	if rules == 0 && req.Name == nil && req.Enabled == nil && !req.Match.IsSpecified() {
+	// Multi-variant requests are rejected by the exactly-one check when the
+	// merged policy is validated below.
+	ruleProvided := req.Keyauth != nil || req.Ratelimit != nil || req.Firewall != nil || req.Openapi != nil
+	if !ruleProvided && req.Name == nil && req.Enabled == nil && !req.Match.IsSpecified() {
 		return fault.New(
 			"empty update",
 			fault.Code(codes.App.Validation.InvalidInput.URN()),
@@ -199,7 +188,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 				patched.Match = &match
 			}
 		}
-		if rules == 1 {
+		if ruleProvided {
 			patched.Keyauth = req.Keyauth
 			patched.Ratelimit = req.Ratelimit
 			patched.Firewall = req.Firewall
@@ -241,7 +230,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			}
 		}
 
-		blob, marshalErr := protojson.Marshal(&frontlinev1.Config{Policies: policies})
+		blob, marshalErr := policyconfig.Marshal(policies)
 		if marshalErr != nil {
 			return fault.Wrap(
 				marshalErr,

--- a/svc/api/routes/v2_gateway_update_policy/handler.go
+++ b/svc/api/routes/v2_gateway_update_policy/handler.go
@@ -90,12 +90,12 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		rbac.T(rbac.Tuple{
 			ResourceType: rbac.Environment,
 			ResourceID:   "*",
-			Action:       rbac.SetPolicies,
+			Action:       rbac.UpdatePolicy,
 		}),
 		rbac.T(rbac.Tuple{
 			ResourceType: rbac.Environment,
 			ResourceID:   env.ID,
-			Action:       rbac.SetPolicies,
+			Action:       rbac.UpdatePolicy,
 		}),
 	))
 	if err != nil {

--- a/svc/api/routes/v2_gateway_update_policy/handler.go
+++ b/svc/api/routes/v2_gateway_update_policy/handler.go
@@ -1,0 +1,312 @@
+package handler
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"slices"
+	"time"
+
+	frontlinev1 "github.com/unkeyed/unkey/gen/proto/frontline/v1"
+	"github.com/unkeyed/unkey/internal/services/auditlogs"
+	"github.com/unkeyed/unkey/pkg/auditlog"
+	"github.com/unkeyed/unkey/pkg/codes"
+	"github.com/unkeyed/unkey/pkg/db"
+	"github.com/unkeyed/unkey/pkg/fault"
+	"github.com/unkeyed/unkey/pkg/rbac"
+	"github.com/unkeyed/unkey/pkg/zen"
+	"github.com/unkeyed/unkey/svc/api/internal/policyconfig"
+	"github.com/unkeyed/unkey/svc/api/openapi"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+type (
+	Request  = openapi.V2GatewayUpdatePolicyRequestBody
+	Response = openapi.V2GatewayUpdatePolicyResponseBody
+)
+
+type Handler struct {
+	DB        db.Database
+	Auditlogs auditlogs.AuditLogService
+}
+
+func (h *Handler) Method() string {
+	return "POST"
+}
+
+func (h *Handler) Path() string {
+	return "/v2/gateway.updatePolicy"
+}
+
+func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
+	principal, err := s.GetPrincipal()
+	if err != nil {
+		return err
+	}
+
+	req, err := zen.BindBody[Request](s)
+	if err != nil {
+		return err
+	}
+
+	rules := 0
+	for _, set := range []bool{req.Keyauth != nil, req.Ratelimit != nil, req.Firewall != nil, req.Openapi != nil} {
+		if set {
+			rules++
+		}
+	}
+	if rules > 1 {
+		return fault.New(
+			"multiple rule variants",
+			fault.Code(codes.App.Validation.InvalidInput.URN()),
+			fault.Internal("more than one rule variant in update"),
+			fault.Public("At most one of keyauth, ratelimit, firewall or openapi may be set."),
+		)
+	}
+	if rules == 0 && req.Name == nil && req.Enabled == nil && !req.Match.IsSpecified() {
+		return fault.New(
+			"empty update",
+			fault.Code(codes.App.Validation.InvalidInput.URN()),
+			fault.Internal("no updatable fields in request"),
+			fault.Public("Provide at least one field to update."),
+		)
+	}
+
+	env, err := db.Query.FindEnvironmentByIdentifiers(ctx, h.DB.RO(), db.FindEnvironmentByIdentifiersParams{
+		WorkspaceID: principal.WorkspaceID,
+		Project:     req.Project,
+		App:         req.App,
+		Environment: req.Environment,
+	})
+	if err != nil {
+		if db.IsNotFound(err) {
+			return fault.New(
+				"environment not found",
+				fault.Code(codes.Data.Environment.NotFound.URN()),
+				fault.Internal("environment not found"),
+				fault.Public("The requested environment does not exist."),
+			)
+		}
+		return fault.Wrap(
+			err,
+			fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
+			fault.Internal("database error"),
+			fault.Public("Failed to retrieve environment."),
+		)
+	}
+
+	err = principal.Authorize(rbac.Or(
+		rbac.T(rbac.Tuple{
+			ResourceType: rbac.Environment,
+			ResourceID:   "*",
+			Action:       rbac.SetPolicies,
+		}),
+		rbac.T(rbac.Tuple{
+			ResourceType: rbac.Environment,
+			ResourceID:   env.ID,
+			Action:       rbac.SetPolicies,
+		}),
+	))
+	if err != nil {
+		return err
+	}
+
+	// Read-modify-write on the config blob: the environment lock serializes
+	// this against concurrent updatePolicy calls so neither overwrites the
+	// other's change. setPolicies doesn't lock because it never reads first.
+	err = db.TxRetry(ctx, h.DB.RW(), func(ctx context.Context, tx db.DBTX) error {
+		if _, lockErr := db.Query.LockEnvironmentForUpdate(ctx, tx, env.ID); lockErr != nil {
+			if db.IsNotFound(lockErr) {
+				// Deleted between the read above and acquiring the lock.
+				return fault.New(
+					"environment not found",
+					fault.Code(codes.Data.Environment.NotFound.URN()),
+					fault.Internal("environment deleted before lock"),
+					fault.Public("The requested environment does not exist."),
+				)
+			}
+			return fault.Wrap(
+				lockErr,
+				fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
+				fault.Internal("unable to lock environment"),
+				fault.Public("We're unable to update the policy."),
+			)
+		}
+
+		settings, findErr := db.Query.FindAppRuntimeSettingsByAppAndEnv(ctx, tx, db.FindAppRuntimeSettingsByAppAndEnvParams{
+			AppID:         env.AppID,
+			EnvironmentID: env.ID,
+		})
+		if findErr != nil && !db.IsNotFound(findErr) {
+			return fault.Wrap(
+				findErr,
+				fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
+				fault.Internal("unable to read sentinel config"),
+				fault.Public("We're unable to update the policy."),
+			)
+		}
+		cfg, parseErr := policyconfig.Parse(settings.AppRuntimeSetting.SentinelConfig)
+		if parseErr != nil {
+			return fault.Wrap(
+				parseErr,
+				fault.Code(codes.App.Internal.UnexpectedError.URN()),
+				fault.Internal("stored sentinel config is not valid protojson"),
+				fault.Public("We're unable to update the policy."),
+			)
+		}
+
+		// A missing settings row and an empty config both mean the id can't
+		// exist, so they collapse into the same not-found below.
+		policies := cfg.GetPolicies()
+		idx := slices.IndexFunc(policies, func(p *frontlinev1.Policy) bool { return p.GetId() == req.PolicyId })
+		if idx < 0 {
+			return fault.New(
+				"policy not found",
+				fault.Code(codes.Data.Policy.NotFound.URN()),
+				fault.Internal("policy id not present in stored policies"),
+				fault.Public("The requested policy does not exist. Note that policy ids change when the policy list is replaced."),
+			)
+		}
+
+		// Patch at the API level and reconvert: the openapi->proto pass is
+		// the validation pass, so the merged policy is checked exactly like
+		// a policy arriving via setPolicies.
+		existing, mapErr := policyconfig.PolicyFromProto(policies[idx])
+		if mapErr != nil {
+			return mapErr
+		}
+		patched := openapi.Policy{
+			Name:      existing.Name,
+			Enabled:   existing.Enabled,
+			Match:     existing.Match,
+			Keyauth:   existing.Keyauth,
+			Ratelimit: existing.Ratelimit,
+			Firewall:  existing.Firewall,
+			Openapi:   existing.Openapi,
+		}
+		if req.Name != nil {
+			patched.Name = *req.Name
+		}
+		if req.Enabled != nil {
+			patched.Enabled = *req.Enabled
+		}
+		if req.Match.IsSpecified() {
+			patched.Match = nil
+			if !req.Match.IsNull() {
+				match := req.Match.MustGet()
+				patched.Match = &match
+			}
+		}
+		if rules == 1 {
+			patched.Keyauth = req.Keyauth
+			patched.Ratelimit = req.Ratelimit
+			patched.Firewall = req.Firewall
+			patched.Openapi = req.Openapi
+		}
+
+		updated, convErr := policyconfig.PolicyToProto("policy", patched)
+		if convErr != nil {
+			return convErr
+		}
+		updated.Id = req.PolicyId
+		policies[idx] = updated
+
+		// A keyauth kept from storage was verified when it was written; only
+		// a keyauth arriving with this request needs its keyspaces checked.
+		// After validation, matching setPolicies' validate-then-verify order.
+		if req.Keyauth != nil && len(req.Keyauth.Keyspaces) > 0 {
+			found, keyspaceErr := db.Query.FindKeyAuthsByIdsAndWorkspace(ctx, tx, db.FindKeyAuthsByIdsAndWorkspaceParams{
+				WorkspaceID: principal.WorkspaceID,
+				KeyAuthIds:  req.Keyauth.Keyspaces,
+			})
+			if keyspaceErr != nil {
+				return fault.Wrap(
+					keyspaceErr,
+					fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
+					fault.Internal("unable to verify keyspaces"),
+					fault.Public("We're unable to update the policy."),
+				)
+			}
+			for _, id := range req.Keyauth.Keyspaces {
+				if !slices.Contains(found, id) {
+					return fault.New(
+						"keyspace not found",
+						fault.Code(codes.Data.KeySpace.NotFound.URN()),
+						fault.Internal("keyspace not found in workspace"),
+						fault.Public(fmt.Sprintf("Keyspace %q does not exist.", id)),
+					)
+				}
+			}
+		}
+
+		blob, marshalErr := protojson.Marshal(&frontlinev1.Config{Policies: policies})
+		if marshalErr != nil {
+			return fault.Wrap(
+				marshalErr,
+				fault.Code(codes.App.Internal.UnexpectedError.URN()),
+				fault.Internal("policy serialization failed"),
+				fault.Public("We're unable to update the policy."),
+			)
+		}
+
+		now := time.Now().UnixMilli()
+		if upsertErr := db.Query.UpsertAppRuntimeSettingsSentinelConfig(ctx, tx, db.UpsertAppRuntimeSettingsSentinelConfigParams{
+			WorkspaceID:    env.WorkspaceID,
+			AppID:          env.AppID,
+			EnvironmentID:  env.ID,
+			SentinelConfig: blob,
+			CreatedAt:      now,
+			UpdatedAt:      sql.NullInt64{Valid: true, Int64: now},
+		}); upsertErr != nil {
+			return fault.Wrap(
+				upsertErr,
+				fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
+				fault.Internal("unable to write sentinel config"),
+				fault.Public("We're unable to update the policy."),
+			)
+		}
+
+		// The exact document as stored, so the audit trail alone
+		// reconstructs every configuration the policy had.
+		doc, docErr := protojson.Marshal(updated)
+		if docErr != nil {
+			return fault.Wrap(
+				docErr,
+				fault.Code(codes.App.Internal.UnexpectedError.URN()),
+				fault.Internal("policy serialization failed"),
+				fault.Public("We're unable to update the policy."),
+			)
+		}
+		return h.Auditlogs.Insert(ctx, tx, []auditlog.AuditLog{{
+			WorkspaceID:   principal.WorkspaceID,
+			Event:         auditlog.EnvironmentUpdateEvent,
+			Display:       fmt.Sprintf("Updated policy %s (%s) for environment %s", updated.GetName(), updated.GetId(), env.ID),
+			ActorID:       principal.Subject.ID,
+			ActorName:     principal.Subject.Name,
+			ActorMeta:     map[string]any{},
+			ActorType:     auditlog.AuditLogActor(principal.Subject.Type),
+			RemoteIP:      s.Location(),
+			UserAgent:     s.UserAgent(),
+			CorrelationID: "",
+			Resources: []auditlog.AuditLogResource{
+				{
+					ID:          env.ID,
+					Type:        auditlog.EnvironmentResourceType,
+					Meta:        map[string]any{"policyId": updated.GetId(), "policyType": policyconfig.VariantName(updated), "policy": json.RawMessage(doc)},
+					Name:        env.Slug,
+					DisplayName: env.Slug,
+				},
+			},
+		}})
+	})
+	if err != nil {
+		return err
+	}
+
+	return s.JSON(http.StatusOK, Response{
+		Meta: openapi.Meta{RequestId: s.RequestID()},
+		Data: openapi.EmptyResponse{},
+	})
+}

--- a/svc/api/routes/v2_gateway_update_policy/handler.go
+++ b/svc/api/routes/v2_gateway_update_policy/handler.go
@@ -102,9 +102,8 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	// Read-modify-write on the config blob: the environment lock serializes
-	// this against concurrent updatePolicy calls so neither overwrites the
-	// other's change. setPolicies doesn't lock because it never reads first.
+	// Read-modify-write on the config blob: lock the environment so
+	// concurrent updates serialize instead of overwriting each other.
 	err = db.TxRetry(ctx, h.DB.RW(), func(ctx context.Context, tx db.DBTX) error {
 		if _, lockErr := db.Query.LockEnvironmentForUpdate(ctx, tx, env.ID); lockErr != nil {
 			if db.IsNotFound(lockErr) {
@@ -124,13 +123,21 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			)
 		}
 
-		settings, findErr := db.Query.FindAppRuntimeSettingsByAppAndEnv(ctx, tx, db.FindAppRuntimeSettingsByAppAndEnvParams{
+		settings, err := db.Query.FindAppRuntimeSettingsByAppAndEnv(ctx, tx, db.FindAppRuntimeSettingsByAppAndEnvParams{
 			AppID:         env.AppID,
 			EnvironmentID: env.ID,
 		})
-		if findErr != nil && !db.IsNotFound(findErr) {
+		if err != nil {
+			if db.IsNotFound(err) {
+				return fault.New(
+					"policy not found",
+					fault.Code(codes.Data.Policy.NotFound.URN()),
+					fault.Internal("no sentinel config for environment"),
+					fault.Public("The requested policy does not exist. Note that policy ids change when the policy list is replaced."),
+				)
+			}
 			return fault.Wrap(
-				findErr,
+				err,
 				fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
 				fault.Internal("unable to read sentinel config"),
 				fault.Public("We're unable to update the policy."),
@@ -146,8 +153,6 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			)
 		}
 
-		// A missing settings row and an empty config both mean the id can't
-		// exist, so they collapse into the same not-found below.
 		policies := cfg.GetPolicies()
 		idx := slices.IndexFunc(policies, func(p *frontlinev1.Policy) bool { return p.GetId() == req.PolicyId })
 		if idx < 0 {
@@ -182,8 +187,9 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			patched.Enabled = *req.Enabled
 		}
 		if req.Match.IsSpecified() {
-			patched.Match = nil
-			if !req.Match.IsNull() {
+			if req.Match.IsNull() {
+				patched.Match = nil
+			} else {
 				match := req.Match.MustGet()
 				patched.Match = &match
 			}
@@ -202,9 +208,8 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		updated.Id = req.PolicyId
 		policies[idx] = updated
 
-		// A keyauth kept from storage was verified when it was written, so
-		// only a keyauth arriving with this request needs its keyspaces
-		// checked. Verify after validation, matching setPolicies' order.
+		// Stored keyauth was verified at write time; only keyspaces
+		// arriving with this request need checking.
 		if req.Keyauth != nil && len(req.Keyauth.Keyspaces) > 0 {
 			found, keyspaceErr := db.Query.FindKeyAuthsByIdsAndWorkspace(ctx, tx, db.FindKeyAuthsByIdsAndWorkspaceParams{
 				WorkspaceID: principal.WorkspaceID,

--- a/svc/api/routes/v2_gateway_update_policy/handler.go
+++ b/svc/api/routes/v2_gateway_update_policy/handler.go
@@ -202,9 +202,9 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		updated.Id = req.PolicyId
 		policies[idx] = updated
 
-		// A keyauth kept from storage was verified when it was written; only
-		// a keyauth arriving with this request needs its keyspaces checked.
-		// After validation, matching setPolicies' validate-then-verify order.
+		// A keyauth kept from storage was verified when it was written, so
+		// only a keyauth arriving with this request needs its keyspaces
+		// checked. Verify after validation, matching setPolicies' order.
 		if req.Keyauth != nil && len(req.Keyauth.Keyspaces) > 0 {
 			found, keyspaceErr := db.Query.FindKeyAuthsByIdsAndWorkspace(ctx, tx, db.FindKeyAuthsByIdsAndWorkspaceParams{
 				WorkspaceID: principal.WorkspaceID,

--- a/svc/api/routes/v2_gateway_update_policy/helpers_test.go
+++ b/svc/api/routes/v2_gateway_update_policy/helpers_test.go
@@ -1,0 +1,123 @@
+package handler_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_gateway_update_policy"
+)
+
+func makeRequest(env seededEnv, policyID string) handler.Request {
+	var req handler.Request
+	req.Project = env.projectID
+	req.App = env.appID
+	req.Environment = env.environmentID
+	req.PolicyId = policyID
+	return req
+}
+
+type seededEnv struct {
+	workspaceID   string
+	projectID     string
+	appID         string
+	environmentID string
+}
+
+func seedEnvironment(t *testing.T, h *testutil.Harness) seededEnv {
+	t.Helper()
+
+	workspace := h.Resources().UserWorkspace
+
+	project := h.CreateProject(seed.CreateProjectRequest{
+		ID:          uid.New(uid.ProjectPrefix),
+		WorkspaceID: workspace.ID,
+		Name:        "Payments Service",
+		Slug:        strings.ToLower(strings.ReplaceAll(uid.New("test"), "_", "-")),
+	})
+
+	app := h.CreateApp(seed.CreateAppRequest{
+		ID:            uid.New(uid.AppPrefix),
+		WorkspaceID:   workspace.ID,
+		ProjectID:     project.ID,
+		Name:          "Payments API",
+		Slug:          strings.ToLower(strings.ReplaceAll(uid.New("test"), "_", "-")),
+		DefaultBranch: "main",
+	})
+
+	environment := h.CreateEnvironment(seed.CreateEnvironmentRequest{
+		ID:          uid.New(uid.EnvironmentPrefix),
+		WorkspaceID: workspace.ID,
+		ProjectID:   project.ID,
+		AppID:       app.ID,
+		Slug:        "production",
+		Description: "Production environment",
+	})
+
+	return seededEnv{
+		workspaceID:   workspace.ID,
+		projectID:     project.ID,
+		appID:         app.ID,
+		environmentID: environment.ID,
+	}
+}
+
+// seedSentinelConfig overwrites the seeded runtime settings row's blob
+// directly, bypassing the write handler, so tests can set up pre-existing
+// state with deterministic policy ids. The environment seeder always
+// creates the row (with the legacy "{}" blob).
+func seedSentinelConfig(t *testing.T, h *testutil.Harness, env seededEnv, blob string) {
+	t.Helper()
+	_, err := h.DB.RW().ExecContext(context.Background(),
+		"UPDATE app_runtime_settings SET sentinel_config = ? WHERE app_id = ? AND environment_id = ?",
+		blob, env.appID, env.environmentID)
+	require.NoError(t, err)
+
+	// MySQL reports 0 affected rows when the value is unchanged, so verify by
+	// reading back instead.
+	var stored []byte
+	err = h.DB.RO().QueryRowContext(context.Background(),
+		"SELECT sentinel_config FROM app_runtime_settings WHERE app_id = ? AND environment_id = ?",
+		env.appID, env.environmentID).Scan(&stored)
+	require.NoError(t, err)
+	require.Equal(t, blob, string(stored))
+}
+
+// seedFirewallPolicies stores n firewall policies with deterministic ids
+// pol_000, pol_001, ... and returns those ids in stored order.
+func seedFirewallPolicies(t *testing.T, h *testutil.Harness, env seededEnv, n int) []string {
+	t.Helper()
+	ids := make([]string, 0, n)
+	docs := make([]string, 0, n)
+	for i := range n {
+		id := fmt.Sprintf("pol_%03d", i)
+		ids = append(ids, id)
+		docs = append(docs, fmt.Sprintf(
+			`{"id":%q,"name":"KEBAP %d","enabled":true,"firewall":{"action":"ACTION_DENY"}}`, id, i))
+	}
+	seedSentinelConfig(t, h, env, fmt.Sprintf(`{"policies":[%s]}`, strings.Join(docs, ",")))
+	return ids
+}
+
+func readStoredBlob(t *testing.T, h *testutil.Harness, env seededEnv) string {
+	t.Helper()
+	var blob []byte
+	err := h.DB.RO().QueryRowContext(context.Background(),
+		"SELECT sentinel_config FROM app_runtime_settings WHERE app_id = ? AND environment_id = ?",
+		env.appID, env.environmentID).Scan(&blob)
+	require.NoError(t, err)
+	return string(blob)
+}
+
+func authHeaders(rootKey string) http.Header {
+	return http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/root-keys/components/dialog/permissions.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/root-keys/components/dialog/permissions.ts
@@ -242,8 +242,12 @@ export const workspacePermissions = {
     },
     set_policies: {
       description:
-        "Create, update, reorder, and remove gateway policies for any environment in this workspace",
+        "Replace the entire gateway policy list for any environment in this workspace",
       permission: "environment.*.set_policies",
+    },
+    update_policy: {
+      description: "Update a single gateway policy in place for any environment in this workspace",
+      permission: "environment.*.update_policy",
     },
     read_policies: {
       description: "Read gateway policies for any environment in this workspace",
@@ -395,8 +399,12 @@ export function environmentPermissions(environmentId: string): {
         permission: `environment.${environmentId}.read_environment_variables`,
       },
       set_policies: {
-        description: "Create, update, reorder, and remove gateway policies for this environment.",
+        description: "Replace the entire gateway policy list for this environment.",
         permission: `environment.${environmentId}.set_policies`,
+      },
+      update_policy: {
+        description: "Update a single gateway policy in place for this environment.",
+        permission: `environment.${environmentId}.update_policy`,
       },
       read_policies: {
         description: "Read gateway policies for this environment.",

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/root-keys/components/dialog/permissions.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/root-keys/components/dialog/permissions.ts
@@ -241,8 +241,7 @@ export const workspacePermissions = {
       permission: "environment.*.read_environment_variables",
     },
     set_policies: {
-      description:
-        "Replace the entire gateway policy list for any environment in this workspace",
+      description: "Replace the entire gateway policy list for any environment in this workspace",
       permission: "environment.*.set_policies",
     },
     update_policy: {

--- a/web/internal/rbac/src/permissions.ts
+++ b/web/internal/rbac/src/permissions.ts
@@ -95,6 +95,7 @@ export const environmentActions = z.enum([
   "promote_deployment",
   "rollback_deployment",
   "set_policies",
+  "update_policy",
   "read_policies",
 ]);
 


### PR DESCRIPTION
> [!IMPORTANT]
> Unkey is not accepting external pull requests at this time. Pull requests from people outside the Unkey team will not be reviewed or merged.

## What does this PR do?

Adds a `POST /v2/gateway.updatePolicy` endpoint that allows updating a single gateway policy in place without replacing the environment's full policy list. The policy retains its id and position in the evaluation order, and all other policies remain untouched.

The update is a partial patch: omitted fields keep their stored values. Setting `match` to `null` removes all match expressions so the policy applies to every request. Providing one of `keyauth`, `ratelimit`, `firewall`, or `openapi` replaces the policy's rule entirely, including switching its type; at most one may be set. A read-modify-write with an environment-level lock serializes concurrent `updatePolicy` calls so neither overwrites the other's change.

A new `err:unkey:data:policy_not_found` error code is introduced, documented, and wired into the error-handling middleware. It is returned when the requested policy id is not present in the stored config, including when the runtime settings row is missing entirely.

The proto-to-API and API-to-proto mapping functions previously scoped to the `v2_gateway_list_policies` and `v2_gateway_set_policies` route packages have been promoted to a shared `policyconfig` internal package, exporting `FromProto`, `ToProto`, `PolicyFromProto`, `PolicyToProto`, `VariantName`, and `Marshal`. Both existing handlers have been updated to use the shared package. Id generation has been moved out of `PolicyToProto` so callers own identity assignment — `ToProto` generates fresh ids for `setPolicies`, while `updatePolicy` preserves the stored id.

A new `update_policy` RBAC action is introduced alongside `set_policies`, scoped to individual environments or all environments via wildcard, and surfaced in the dashboard root-key permissions dialog.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How should this be tested?

- Rename a policy and verify its id, rule, and sibling policies are unchanged and in the same order
- Disable a policy and confirm `"enabled":false` is persisted in the stored blob
- Replace match expressions and verify the new expressions are returned by `listPolicies`
- Set `match` to `null` and confirm match expressions are cleared while the rule is preserved
- Switch a policy's rule variant (e.g. ratelimit → firewall) and verify the old rule is gone and the id and match are retained
- Update a keyauth rule with owned keyspaces and verify the keyspaces and permission query round-trip correctly
- Submit a request with no updatable fields and expect a `400` citing at least one field must be provided
- Submit a request with two rule variants set and expect a `400` citing the exactly-one constraint
- Submit a request with an invalid regex in a match expression and expect a `400`
- Submit a request with an invalid permission query and expect a `400`
- Submit a request referencing a non-existent policy id and expect a `404` with `policy_not_found`
- Submit a request referencing a keyspace not owned by the workspace and expect a `404` with `key_space_not_found`
- Verify that a rejected update leaves the stored blob unchanged
- Verify `403` is returned for keys with `read_policies` or `set_policies` but not `update_policy`, and for keys scoped to a different environment id
- Verify `401` is returned for an invalid bearer token
- Verify a policy from another environment's config cannot be updated via a different environment's request

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `mise run fmt`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary