### PR TITLE
Golangci parallel runners

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -120,3 +120,5 @@ formatters:
       - builtin$
       - examples$
       - \.claude/
+run:
+  allow-parallel-runners: true


### PR DESCRIPTION
Allow linting to run in parallel, across worktrees for example.