### PR TITLE
fix(tooling): allow parallel golangci-lint runners

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -120,3 +120,5 @@ formatters:
       - builtin$
       - examples$
       - \.claude/
+run:
+  allow-parallel-runners: true


### PR DESCRIPTION
## Summary

Allow multiple `golangci-lint` processes to run concurrently so lint jobs from separate worktrees do not collide on the runner lock.

## Verification

- `mise exec -- golangci-lint config verify -c .golangci.yaml`
- `mise run lint` (0 issues)