### PR TITLE
fix(dashboard): show redeploy banner on new env add

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/env-vars/components/add/add-env-var-expandable.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/env-vars/components/add/add-env-var-expandable.tsx
@@ -25,6 +25,7 @@ import { EnvVarRow } from "./env-var-row";
 import { type EnvVarsFormValues, createEmptyEntry, envVarsSchema, findConflicts } from "./schema";
 
 import { usePreventLeave } from "@/hooks/use-prevent-leave";
+import { trackSave } from "@/lib/collections/deploy/environment-settings";
 
 type AddEnvVarExpandableProps = {
   appId: string;
@@ -202,7 +203,9 @@ export const AddEnvVarExpandable = ({
     );
 
     try {
-      await createBulk.mutateAsync({ variables });
+      // createBulk bypasses the collection, so wrap it in trackSave manually
+      // to surface the pending-redeploy banner like insert/update/delete do.
+      await trackSave(createBulk.mutateAsync({ variables }));
       await collection.envVars.utils.refetch();
       toast.success(`Added ${variables.length} variable(s)`);
     } catch (err) {


### PR DESCRIPTION
## Problem

We regressed redeploy banner for new env add. Customers reported

## Fix

We now run the mutation inside the `trackSave(...)` to track settings/env changes so redeploy banner can appear.

## Test

* Add new env and make sure banner appears
* No regression

### Before

https://github.com/user-attachments/assets/38b69104-ef50-45bf-a2e6-49c9f7862d93

### After

https://github.com/user-attachments/assets/2d52d3a8-4a55-488b-ae95-6525882d3c47