### PR TITLE
feat(ui): add resource list components

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/components/controls/index.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/components/controls/index.tsx
@@ -1,3 +1,4 @@
+import { ResourceListHeader } from "@unkey/ui";
 import { BranchSelect } from "./components/branch-select";
 import { DeploymentListDatetime } from "./components/deployment-list-datetime";
 import { EnvironmentSelect } from "./components/environment-select";
@@ -5,7 +6,7 @@ import { StatusSelect } from "./components/status-select";
 
 export function DeploymentsListControls() {
   return (
-    <div className="flex flex-col md:flex-row items-stretch gap-2">
+    <ResourceListHeader>
       <div className="w-full md:flex-1">
         <EnvironmentSelect />
       </div>
@@ -18,6 +19,6 @@ export function DeploymentsListControls() {
       <div className="w-full md:flex-1">
         <DeploymentListDatetime />
       </div>
-    </div>
+    </ResourceListHeader>
   );
 }

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/components/deployment-row.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/components/deployment-row.tsx
@@ -6,7 +6,7 @@ import { Avatar } from "@/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[a
 import type { Deployment, Environment } from "@/lib/collections";
 import { shortenId } from "@/lib/shorten-id";
 import { CodeBranch, CodeCommit, Layers2 } from "@unkey/icons";
-import { TimestampInfo } from "@unkey/ui";
+import { ResourceListItem, TimestampInfo } from "@unkey/ui";
 import type { Route } from "next";
 import dynamic from "next/dynamic";
 import Link from "next/link";
@@ -47,7 +47,7 @@ export function DeploymentRow({
   const needsApproval = deployment.status === "awaiting_approval";
 
   return (
-    <li className="relative flex flex-col gap-3 px-4 py-3 transition-colors hover:bg-grayA-2 md:flex-row md:items-center md:gap-0">
+    <ResourceListItem className="flex flex-col gap-3 px-4 py-3 transition-colors hover:bg-grayA-2 md:flex-row md:items-center md:gap-0">
       {needsApproval ? (
         <button
           type="button"
@@ -191,6 +191,6 @@ export function DeploymentRow({
           <DeploymentListTableActions selectedDeployment={deployment} environment={environment} />
         </div>
       </div>
-    </li>
+    </ResourceListItem>
   );
 }

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/components/deployment-row.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/components/deployment-row.tsx
@@ -47,7 +47,7 @@ export function DeploymentRow({
   const needsApproval = deployment.status === "awaiting_approval";
 
   return (
-    <div className="relative flex flex-col md:flex-row md:items-center px-4 py-3 gap-3 md:gap-0 transition-colors hover:bg-grayA-2">
+    <li className="relative flex flex-col gap-3 px-4 py-3 transition-colors hover:bg-grayA-2 md:flex-row md:items-center md:gap-0">
       {needsApproval ? (
         <button
           type="button"
@@ -191,6 +191,6 @@ export function DeploymentRow({
           <DeploymentListTableActions selectedDeployment={deployment} environment={environment} />
         </div>
       </div>
-    </div>
+    </li>
   );
 }

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/components/deployments-card-list.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/components/deployments-card-list.tsx
@@ -5,29 +5,17 @@ import { collection } from "@/lib/collections";
 import { routes } from "@/lib/navigation/routes";
 import { and, eq, useLiveQuery } from "@tanstack/react-db";
 import { BookBookmark } from "@unkey/icons";
-import { Button, Empty, ResourceListContent } from "@unkey/ui";
-import type { ReactNode } from "react";
+import { Button, Empty, ResourceListBody, ResourceListContent } from "@unkey/ui";
 import { useAppId, useProjectData } from "../../data-provider";
 import { useDeployments } from "../hooks/use-deployments";
 import { DeploymentRow } from "./deployment-row";
 import { DeploymentsSkeleton } from "./deployments-skeleton";
 
-function ListHeader({ title, action }: { title: string; action?: ReactNode }) {
-  return (
-    <div className="flex items-center justify-between gap-2 border-grayA-4 border-b px-4 py-3">
-      <h2 className="font-medium text-accent-12 text-sm">{title}</h2>
-      {action}
-    </div>
-  );
-}
-
 type DeploymentsCardListProps = {
   limit?: number;
-  title?: string;
-  headerAction?: ReactNode;
 };
 
-export function DeploymentsCardList({ limit, title, headerAction }: DeploymentsCardListProps = {}) {
+export function DeploymentsCardList({ limit }: DeploymentsCardListProps = {}) {
   const { deployments } = useDeployments();
   const { projectId } = useProjectData();
   const appId = useAppId();
@@ -51,7 +39,6 @@ export function DeploymentsCardList({ limit, title, headerAction }: DeploymentsC
   if (data.length === 0) {
     return (
       <ResourceListContent>
-        {title ? <ListHeader title={title} action={headerAction} /> : null}
         <div className="flex w-full items-center justify-center px-4 py-16">
           <Empty className="w-[400px] flex items-start">
             <Empty.Icon className="w-auto" />
@@ -80,8 +67,7 @@ export function DeploymentsCardList({ limit, title, headerAction }: DeploymentsC
 
   return (
     <ResourceListContent>
-      {title ? <ListHeader title={title} action={headerAction} /> : null}
-      <ul className="divide-y divide-grayA-4">
+      <ResourceListBody>
         {data.map(({ deployment, environment }) => {
           const isCurrent = currentDeploymentId === deployment.id;
           return (
@@ -100,7 +86,7 @@ export function DeploymentsCardList({ limit, title, headerAction }: DeploymentsC
             />
           );
         })}
-      </ul>
+      </ResourceListBody>
     </ResourceListContent>
   );
 }

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/components/deployments-card-list.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/components/deployments-card-list.tsx
@@ -5,7 +5,7 @@ import { collection } from "@/lib/collections";
 import { routes } from "@/lib/navigation/routes";
 import { and, eq, useLiveQuery } from "@tanstack/react-db";
 import { BookBookmark } from "@unkey/icons";
-import { Button, Empty } from "@unkey/ui";
+import { Button, Empty, ResourceListContent } from "@unkey/ui";
 import type { ReactNode } from "react";
 import { useAppId, useProjectData } from "../../data-provider";
 import { useDeployments } from "../hooks/use-deployments";
@@ -14,8 +14,8 @@ import { DeploymentsSkeleton } from "./deployments-skeleton";
 
 function ListHeader({ title, action }: { title: string; action?: ReactNode }) {
   return (
-    <div className="px-4 py-3 border-b border-grayA-4 flex items-center justify-between gap-2">
-      <h2 className="text-sm font-medium text-accent-12">{title}</h2>
+    <div className="flex items-center justify-between gap-2 border-grayA-4 border-b px-4 py-3">
+      <h2 className="font-medium text-accent-12 text-sm">{title}</h2>
       {action}
     </div>
   );
@@ -50,9 +50,9 @@ export function DeploymentsCardList({ limit, title, headerAction }: DeploymentsC
 
   if (data.length === 0) {
     return (
-      <div className="border border-grayA-4 rounded-lg overflow-hidden">
-        {title && <ListHeader title={title} action={headerAction} />}
-        <div className="w-full flex justify-center items-center py-16 px-4">
+      <ResourceListContent>
+        {title ? <ListHeader title={title} action={headerAction} /> : null}
+        <div className="flex w-full items-center justify-center px-4 py-16">
           <Empty className="w-[400px] flex items-start">
             <Empty.Icon className="w-auto" />
             <Empty.Title>No Deployments Found</Empty.Title>
@@ -74,14 +74,14 @@ export function DeploymentsCardList({ limit, title, headerAction }: DeploymentsC
             </Empty.Actions>
           </Empty>
         </div>
-      </div>
+      </ResourceListContent>
     );
   }
 
   return (
-    <div className="border border-grayA-4 rounded-lg overflow-hidden">
-      {title && <ListHeader title={title} action={headerAction} />}
-      <div className="divide-y divide-grayA-4">
+    <ResourceListContent>
+      {title ? <ListHeader title={title} action={headerAction} /> : null}
+      <ul className="divide-y divide-grayA-4">
         {data.map(({ deployment, environment }) => {
           const isCurrent = currentDeploymentId === deployment.id;
           return (
@@ -100,7 +100,7 @@ export function DeploymentsCardList({ limit, title, headerAction }: DeploymentsC
             />
           );
         })}
-      </div>
-    </div>
+      </ul>
+    </ResourceListContent>
   );
 }

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/components/deployments-skeleton.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/components/deployments-skeleton.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Dots } from "@unkey/icons";
-import { ResourceListContent } from "@unkey/ui";
+import { ResourceListBody, ResourceListContent, ResourceListItem } from "@unkey/ui";
 
 const SKELETON_ROWS = [
   "deployment-1",
@@ -18,11 +18,11 @@ export function DeploymentsSkeleton() {
   return (
     <ResourceListContent aria-busy="true">
       <output className="sr-only">Loading deployments...</output>
-      <ul className="divide-y divide-grayA-4" aria-hidden="true">
+      <ResourceListBody aria-hidden="true">
         {SKELETON_ROWS.map((row) => (
-          <li
+          <ResourceListItem
             key={row}
-            className="relative flex flex-col gap-3 px-4 py-3 md:flex-row md:items-center md:gap-0"
+            className="flex flex-col gap-3 px-4 py-3 md:flex-row md:items-center md:gap-0"
           >
             {/* Identity + Status */}
             <div className="flex items-center justify-between md:contents">
@@ -54,9 +54,9 @@ export function DeploymentsSkeleton() {
               <div className="size-5 bg-grayA-3 rounded-full animate-pulse" />
               <Dots iconSize="sm-regular" className="text-gray-11 opacity-50" />
             </div>
-          </li>
+          </ResourceListItem>
         ))}
-      </ul>
+      </ResourceListBody>
     </ResourceListContent>
   );
 }

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/components/deployments-skeleton.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/components/deployments-skeleton.tsx
@@ -3,25 +3,15 @@
 import { Dots } from "@unkey/icons";
 import { ResourceListBody, ResourceListContent, ResourceListItem } from "@unkey/ui";
 
-const SKELETON_ROWS = [
-  "deployment-1",
-  "deployment-2",
-  "deployment-3",
-  "deployment-4",
-  "deployment-5",
-  "deployment-6",
-  "deployment-7",
-  "deployment-8",
-];
-
 export function DeploymentsSkeleton() {
   return (
     <ResourceListContent aria-busy="true">
       <output className="sr-only">Loading deployments...</output>
       <ResourceListBody aria-hidden="true">
-        {SKELETON_ROWS.map((row) => (
+        {Array.from({ length: 8 }).map((_, index) => (
           <ResourceListItem
-            key={row}
+            // biome-ignore lint/suspicious/noArrayIndexKey: skeleton rows are static and never reorder
+            key={index}
             className="flex flex-col gap-3 px-4 py-3 md:flex-row md:items-center md:gap-0"
           >
             {/* Identity + Status */}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/components/deployments-skeleton.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/components/deployments-skeleton.tsx
@@ -1,45 +1,62 @@
 "use client";
 
 import { Dots } from "@unkey/icons";
+import { ResourceListContent } from "@unkey/ui";
+
+const SKELETON_ROWS = [
+  "deployment-1",
+  "deployment-2",
+  "deployment-3",
+  "deployment-4",
+  "deployment-5",
+  "deployment-6",
+  "deployment-7",
+  "deployment-8",
+];
 
 export function DeploymentsSkeleton() {
   return (
-    <div className="border border-grayA-4 rounded-lg overflow-hidden divide-y divide-grayA-4">
-      {Array.from({ length: 8 }).map((_, i) => (
-        // biome-ignore lint/suspicious/noArrayIndexKey: skeleton items don't need stable keys
-        <div key={i} className="flex flex-col md:flex-row md:items-center px-4 py-3 gap-3 md:gap-0">
-          {/* Identity + Status */}
-          <div className="flex items-center justify-between md:contents">
-            <div className="md:w-[20%] md:shrink-0 flex flex-col gap-1 min-w-0">
-              <div className="h-[14px] w-20 bg-grayA-3 rounded-sm animate-pulse" />
-              <div className="h-3 w-16 bg-grayA-3 rounded-sm animate-pulse" />
+    <ResourceListContent aria-busy="true">
+      <output className="sr-only">Loading deployments...</output>
+      <ul className="divide-y divide-grayA-4" aria-hidden="true">
+        {SKELETON_ROWS.map((row) => (
+          <li
+            key={row}
+            className="relative flex flex-col gap-3 px-4 py-3 md:flex-row md:items-center md:gap-0"
+          >
+            {/* Identity + Status */}
+            <div className="flex items-center justify-between md:contents">
+              <div className="md:w-[20%] md:shrink-0 flex flex-col gap-1 min-w-0">
+                <div className="h-[14px] w-20 bg-grayA-3 rounded-sm animate-pulse" />
+                <div className="h-3 w-16 bg-grayA-3 rounded-sm animate-pulse" />
+              </div>
+              <div className="md:w-[20%] md:shrink-0">
+                <div className="h-5.5 w-20 bg-grayA-3 rounded-md animate-pulse" />
+              </div>
             </div>
-            <div className="md:w-[20%] md:shrink-0">
-              <div className="h-5.5 w-20 bg-grayA-3 rounded-md animate-pulse" />
-            </div>
-          </div>
 
-          {/* Source */}
-          <div className="md:w-[30%] md:shrink-0 flex flex-col gap-1 min-w-0">
-            <div className="flex items-center gap-2 min-w-0">
-              <div className="size-4 bg-grayA-3 rounded animate-pulse shrink-0" />
-              <div className="h-[14px] w-20 bg-grayA-3 rounded-sm animate-pulse" />
-              <div className="h-[14px] w-14 bg-grayA-3 rounded-sm animate-pulse" />
+            {/* Source */}
+            <div className="md:w-[30%] md:shrink-0 flex flex-col gap-1 min-w-0">
+              <div className="flex items-center gap-2 min-w-0">
+                <div className="size-4 bg-grayA-3 rounded animate-pulse shrink-0" />
+                <div className="h-[14px] w-20 bg-grayA-3 rounded-sm animate-pulse" />
+                <div className="h-[14px] w-14 bg-grayA-3 rounded-sm animate-pulse" />
+              </div>
+              <div className="flex items-center gap-2 min-w-0">
+                <div className="size-4 bg-grayA-3 rounded animate-pulse shrink-0" />
+                <div className="h-3 w-32 bg-grayA-3 rounded-sm animate-pulse" />
+              </div>
             </div>
-            <div className="flex items-center gap-2 min-w-0">
-              <div className="size-4 bg-grayA-3 rounded animate-pulse shrink-0" />
-              <div className="h-3 w-32 bg-grayA-3 rounded-sm animate-pulse" />
-            </div>
-          </div>
 
-          {/* Meta */}
-          <div className="md:w-[30%] md:shrink-0 flex items-center md:justify-end gap-3">
-            <div className="h-[14px] w-12 bg-grayA-3 rounded-sm animate-pulse" />
-            <div className="size-5 bg-grayA-3 rounded-full animate-pulse" />
-            <Dots iconSize="sm-regular" className="text-gray-11 opacity-50" />
-          </div>
-        </div>
-      ))}
-    </div>
+            {/* Meta */}
+            <div className="md:w-[30%] md:shrink-0 flex items-center md:justify-end gap-3">
+              <div className="h-[14px] w-12 bg-grayA-3 rounded-sm animate-pulse" />
+              <div className="size-5 bg-grayA-3 rounded-full animate-pulse" />
+              <Dots iconSize="sm-regular" className="text-gray-11 opacity-50" />
+            </div>
+          </li>
+        ))}
+      </ul>
+    </ResourceListContent>
   );
 }

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/page.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/page.tsx
@@ -10,6 +10,7 @@ import {
   PageHeaderActions,
   PageHeaderContent,
   PageHeaderTitle,
+  ResourceList,
 } from "@unkey/ui";
 import { CreateDeploymentButton } from "../navigations/create-deployment-button";
 import { DeploymentsListControls } from "./components/controls";
@@ -39,8 +40,10 @@ export default function Deployments() {
         </PageHeaderActions>
       </PageHeader>
       <PageBody>
-        <DeploymentsListControls />
-        <DeploymentsCardList />
+        <ResourceList>
+          <DeploymentsListControls />
+          <DeploymentsCardList />
+        </ResourceList>
       </PageBody>
     </PageContainer>
   );

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/overview/components/recent-deployments.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/overview/components/recent-deployments.tsx
@@ -2,7 +2,7 @@
 
 import { useWorkspaceNavigation } from "@/hooks/use-workspace-navigation";
 import { routes } from "@/lib/navigation/routes";
-import { ResourceList } from "@unkey/ui";
+import { ResourceList, ResourceListHeader } from "@unkey/ui";
 import Link from "next/link";
 import { useAppId, useProjectData } from "../../data-provider";
 import { DeploymentsCardList } from "../../deployments/components/deployments-card-list";
@@ -16,22 +16,20 @@ export function RecentDeployments() {
 
   return (
     <ResourceList>
-      <DeploymentsCardList
-        limit={RECENT_LIMIT}
-        title="Deployments"
-        headerAction={
-          <Link
-            href={routes.projects.apps.deployments({
-              workspaceSlug: workspace.slug,
-              projectId,
-              appId,
-            })}
-            className="text-[13px] text-gray-11 hover:text-gray-12 transition-colors"
-          >
-            View all deployments
-          </Link>
-        }
-      />
+      <ResourceListHeader className="flex-row items-center justify-between">
+        <h2 className="font-medium text-accent-12 text-sm">Deployments</h2>
+        <Link
+          href={routes.projects.apps.deployments({
+            workspaceSlug: workspace.slug,
+            projectId,
+            appId,
+          })}
+          className="text-[13px] text-gray-11 transition-colors hover:text-gray-12"
+        >
+          View all deployments
+        </Link>
+      </ResourceListHeader>
+      <DeploymentsCardList limit={RECENT_LIMIT} />
     </ResourceList>
   );
 }

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/overview/components/recent-deployments.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/overview/components/recent-deployments.tsx
@@ -2,6 +2,7 @@
 
 import { useWorkspaceNavigation } from "@/hooks/use-workspace-navigation";
 import { routes } from "@/lib/navigation/routes";
+import { ResourceList } from "@unkey/ui";
 import Link from "next/link";
 import { useAppId, useProjectData } from "../../data-provider";
 import { DeploymentsCardList } from "../../deployments/components/deployments-card-list";
@@ -14,21 +15,23 @@ export function RecentDeployments() {
   const appId = useAppId();
 
   return (
-    <DeploymentsCardList
-      limit={RECENT_LIMIT}
-      title="Deployments"
-      headerAction={
-        <Link
-          href={routes.projects.apps.deployments({
-            workspaceSlug: workspace.slug,
-            projectId,
-            appId,
-          })}
-          className="text-[13px] text-gray-11 hover:text-gray-12 transition-colors"
-        >
-          View all deployments
-        </Link>
-      }
-    />
+    <ResourceList>
+      <DeploymentsCardList
+        limit={RECENT_LIMIT}
+        title="Deployments"
+        headerAction={
+          <Link
+            href={routes.projects.apps.deployments({
+              workspaceSlug: workspace.slug,
+              projectId,
+              appId,
+            })}
+            className="text-[13px] text-gray-11 hover:text-gray-12 transition-colors"
+          >
+            View all deployments
+          </Link>
+        }
+      />
+    </ResourceList>
   );
 }

--- a/web/apps/design/src/data/nav.ts
+++ b/web/apps/design/src/data/nav.ts
@@ -11,10 +11,16 @@ export interface NavSection {
 export const nav: NavSection[] = [
   {
     title: "Primitives",
-    items: [{ name: "Skeleton", href: "/primitives/skeleton" }],
+    items: [
+      { name: "Resource list", href: "/primitives/resource-list" },
+      { name: "Skeleton", href: "/primitives/skeleton" },
+    ],
   },
   {
     title: "Patterns",
-    items: [{ name: "Layout", href: "/patterns/layout" }],
+    items: [
+      { name: "Layout", href: "/patterns/layout" },
+      { name: "Resource list page", href: "/patterns/resource-list-page" },
+    ],
   },
 ];

--- a/web/apps/design/src/pages/patterns/resource-list-page/_basic.tsx
+++ b/web/apps/design/src/pages/patterns/resource-list-page/_basic.tsx
@@ -7,9 +7,11 @@ import {
   PageHeaderActions,
   PageHeaderContent,
   ResourceList,
+  ResourceListBody,
   ResourceListContent,
   ResourceListFooter,
   ResourceListHeader,
+  ResourceListItem,
 } from "@unkey/ui";
 import { useState } from "react";
 
@@ -41,7 +43,10 @@ export function ResourceListPageExample() {
             variant="outline"
             onClick={() =>
               setIdentities((current) => [
-                { externalId: `customer_${1000 + current.length}`, rateLimits: 0 },
+                {
+                  externalId: `customer_${1000 + current.length}`,
+                  rateLimits: 0,
+                },
                 ...current,
               ])
             }
@@ -61,20 +66,22 @@ export function ResourceListPageExample() {
             />
           </ResourceListHeader>
           <ResourceListContent>
-            <ul className="divide-y divide-grayA-4">
+            <ResourceListBody>
               {visibleIdentities.map((identity) => (
-                <li
+                <ResourceListItem
                   key={identity.externalId}
-                  className="relative flex items-center justify-between px-4 py-3"
+                  className="flex items-center justify-between px-4 py-3"
                 >
                   <span className="font-mono text-accent-12 text-sm">{identity.externalId}</span>
                   <span className="text-gray-10 text-xs">{identity.rateLimits} rate limits</span>
-                </li>
+                </ResourceListItem>
               ))}
               {visibleIdentities.length === 0 ? (
-                <li className="px-4 py-8 text-center text-gray-10 text-sm">No identities found</li>
+                <ResourceListItem className="px-4 py-8 text-center text-gray-10 text-sm">
+                  No identities found
+                </ResourceListItem>
               ) : null}
-            </ul>
+            </ResourceListBody>
             {visibleIdentities.length < filteredIdentities.length ? (
               <ResourceListFooter>
                 <Button

--- a/web/apps/design/src/pages/patterns/resource-list-page/_basic.tsx
+++ b/web/apps/design/src/pages/patterns/resource-list-page/_basic.tsx
@@ -6,6 +6,7 @@ import {
   PageHeader,
   PageHeaderActions,
   PageHeaderContent,
+  PageHeaderTitle,
   ResourceList,
   ResourceListBody,
   ResourceListContent,
@@ -34,9 +35,7 @@ export function ResourceListPageExample() {
     <PageContainer>
       <PageHeader>
         <PageHeaderContent>
-          <h2 className="m-0 font-semibold text-[22px] text-accent-12 leading-tight tracking-tight">
-            Identities
-          </h2>
+          <PageHeaderTitle>Identities</PageHeaderTitle>
         </PageHeaderContent>
         <PageHeaderActions>
           <Button

--- a/web/apps/design/src/pages/patterns/resource-list-page/_basic.tsx
+++ b/web/apps/design/src/pages/patterns/resource-list-page/_basic.tsx
@@ -1,0 +1,93 @@
+import {
+  Button,
+  Input,
+  PageBody,
+  PageContainer,
+  PageHeader,
+  PageHeaderActions,
+  PageHeaderContent,
+  ResourceList,
+  ResourceListContent,
+  ResourceListFooter,
+  ResourceListHeader,
+} from "@unkey/ui";
+import { useState } from "react";
+
+const initialIdentities = [
+  { externalId: "customer_123", rateLimits: 2 },
+  { externalId: "customer_456", rateLimits: 1 },
+  { externalId: "customer_789", rateLimits: 4 },
+];
+
+export function ResourceListPageExample() {
+  const [identities, setIdentities] = useState(initialIdentities);
+  const [query, setQuery] = useState("");
+  const [visibleCount, setVisibleCount] = useState(2);
+  const filteredIdentities = identities.filter((identity) =>
+    identity.externalId.toLowerCase().includes(query.trim().toLowerCase()),
+  );
+  const visibleIdentities = filteredIdentities.slice(0, visibleCount);
+
+  return (
+    <PageContainer>
+      <PageHeader>
+        <PageHeaderContent>
+          <h2 className="m-0 font-semibold text-[22px] text-accent-12 leading-tight tracking-tight">
+            Identities
+          </h2>
+        </PageHeaderContent>
+        <PageHeaderActions>
+          <Button
+            variant="outline"
+            onClick={() =>
+              setIdentities((current) => [
+                { externalId: `customer_${1000 + current.length}`, rateLimits: 0 },
+                ...current,
+              ])
+            }
+          >
+            Create identity
+          </Button>
+        </PageHeaderActions>
+      </PageHeader>
+      <PageBody>
+        <ResourceList>
+          <ResourceListHeader>
+            <Input
+              aria-label="Search identities"
+              placeholder="Search identities"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+            />
+          </ResourceListHeader>
+          <ResourceListContent>
+            <ul className="divide-y divide-grayA-4">
+              {visibleIdentities.map((identity) => (
+                <li
+                  key={identity.externalId}
+                  className="relative flex items-center justify-between px-4 py-3"
+                >
+                  <span className="font-mono text-accent-12 text-sm">{identity.externalId}</span>
+                  <span className="text-gray-10 text-xs">{identity.rateLimits} rate limits</span>
+                </li>
+              ))}
+              {visibleIdentities.length === 0 ? (
+                <li className="px-4 py-8 text-center text-gray-10 text-sm">No identities found</li>
+              ) : null}
+            </ul>
+            {visibleIdentities.length < filteredIdentities.length ? (
+              <ResourceListFooter>
+                <Button
+                  variant="outline"
+                  onClick={() => setVisibleCount(filteredIdentities.length)}
+                >
+                  Load more
+                </Button>
+              </ResourceListFooter>
+            ) : null}
+          </ResourceListContent>
+        </ResourceList>
+      </PageBody>
+    </PageContainer>
+  );
+}

--- a/web/apps/design/src/pages/patterns/resource-list-page/index.mdx
+++ b/web/apps/design/src/pages/patterns/resource-list-page/index.mdx
@@ -1,6 +1,6 @@
 ---
 layout: ../../../layouts/layout.astro
-title: Resource list page | Unkey Design
+title: Resource list page — Unkey Design
 ---
 import { Preview } from "../../../components/preview.tsx";
 import { ResourceListPageExample } from "./_basic.tsx";

--- a/web/apps/design/src/pages/patterns/resource-list-page/index.mdx
+++ b/web/apps/design/src/pages/patterns/resource-list-page/index.mdx
@@ -17,5 +17,3 @@ Use this pattern when a centered dashboard page is primarily a searchable or fil
 ## Structure
 
 Put the resource name and primary creation action in `PageHeader`. Put search, filters, and sorting in `ResourceListHeader`. If more results are available, put a right-aligned Load more button in `ResourceListFooter`. Do not add a result count.
-
-The feature owns its item content, loading state, and empty state.

--- a/web/apps/design/src/pages/patterns/resource-list-page/index.mdx
+++ b/web/apps/design/src/pages/patterns/resource-list-page/index.mdx
@@ -1,0 +1,21 @@
+---
+layout: ../../../layouts/layout.astro
+title: Resource list page | Unkey Design
+---
+import { Preview } from "../../../components/preview.tsx";
+import { ResourceListPageExample } from "./_basic.tsx";
+import basicSource from "./_basic.tsx?highlight";
+
+# Resource list page
+
+Use this pattern when a centered dashboard page is primarily a searchable or filterable list.
+
+<Preview client:load bleed code={basicSource}>
+  <ResourceListPageExample client:load />
+</Preview>
+
+## Structure
+
+Put the resource name and primary creation action in `PageHeader`. Put search, filters, and sorting in `ResourceListHeader`. If more results are available, put a right-aligned Load more button in `ResourceListFooter`. Do not add a result count.
+
+The feature owns its item content, loading state, and empty state.

--- a/web/apps/design/src/pages/primitives/resource-list/_basic.tsx
+++ b/web/apps/design/src/pages/primitives/resource-list/_basic.tsx
@@ -1,0 +1,72 @@
+import {
+  Button,
+  Input,
+  ResourceList,
+  ResourceListContent,
+  ResourceListFooter,
+  ResourceListHeader,
+} from "@unkey/ui";
+import { useState } from "react";
+
+const keys = [
+  { name: "Production API", id: "key_2tQx8", status: "Active" },
+  { name: "Preview API", id: "key_7mLp3", status: "Active" },
+  { name: "Legacy integration", id: "key_4nWs1", status: "Disabled" },
+];
+
+export function ResourceListExample() {
+  const [query, setQuery] = useState("");
+  const [activeOnly, setActiveOnly] = useState(false);
+  const [visibleCount, setVisibleCount] = useState(2);
+  const filteredKeys = keys.filter(
+    (key) =>
+      (!activeOnly || key.status === "Active") &&
+      `${key.name} ${key.id}`.toLowerCase().includes(query.trim().toLowerCase()),
+  );
+  const visibleKeys = filteredKeys.slice(0, visibleCount);
+
+  return (
+    <ResourceList className="max-w-2xl">
+      <ResourceListHeader>
+        <Input
+          aria-label="Search API keys"
+          placeholder="Search API keys"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+        />
+        <Button
+          variant="outline"
+          size="lg"
+          aria-pressed={activeOnly}
+          className={activeOnly ? "bg-grayA-3" : undefined}
+          onClick={() => setActiveOnly((current) => !current)}
+        >
+          Active only
+        </Button>
+      </ResourceListHeader>
+      <ResourceListContent>
+        <ul className="divide-y divide-grayA-4">
+          {visibleKeys.map((key) => (
+            <li key={key.id} className="relative flex items-center gap-4 px-4 py-3">
+              <div className="min-w-0 flex-1">
+                <div className="truncate font-medium text-accent-12 text-sm">{key.name}</div>
+                <div className="font-mono text-gray-9 text-xs">{key.id}</div>
+              </div>
+              <span className="text-gray-11 text-xs">{key.status}</span>
+            </li>
+          ))}
+          {visibleKeys.length === 0 ? (
+            <li className="px-4 py-8 text-center text-gray-10 text-sm">No API keys found</li>
+          ) : null}
+        </ul>
+        {visibleKeys.length < filteredKeys.length ? (
+          <ResourceListFooter>
+            <Button variant="outline" onClick={() => setVisibleCount(filteredKeys.length)}>
+              Load more
+            </Button>
+          </ResourceListFooter>
+        ) : null}
+      </ResourceListContent>
+    </ResourceList>
+  );
+}

--- a/web/apps/design/src/pages/primitives/resource-list/_basic.tsx
+++ b/web/apps/design/src/pages/primitives/resource-list/_basic.tsx
@@ -2,9 +2,11 @@ import {
   Button,
   Input,
   ResourceList,
+  ResourceListBody,
   ResourceListContent,
   ResourceListFooter,
   ResourceListHeader,
+  ResourceListItem,
 } from "@unkey/ui";
 import { useState } from "react";
 
@@ -45,20 +47,22 @@ export function ResourceListExample() {
         </Button>
       </ResourceListHeader>
       <ResourceListContent>
-        <ul className="divide-y divide-grayA-4">
+        <ResourceListBody>
           {visibleKeys.map((key) => (
-            <li key={key.id} className="relative flex items-center gap-4 px-4 py-3">
+            <ResourceListItem key={key.id} className="flex items-center gap-4 px-4 py-3">
               <div className="min-w-0 flex-1">
                 <div className="truncate font-medium text-accent-12 text-sm">{key.name}</div>
                 <div className="font-mono text-gray-9 text-xs">{key.id}</div>
               </div>
               <span className="text-gray-11 text-xs">{key.status}</span>
-            </li>
+            </ResourceListItem>
           ))}
           {visibleKeys.length === 0 ? (
-            <li className="px-4 py-8 text-center text-gray-10 text-sm">No API keys found</li>
+            <ResourceListItem className="px-4 py-8 text-center text-gray-10 text-sm">
+              No API keys found
+            </ResourceListItem>
           ) : null}
-        </ul>
+        </ResourceListBody>
         {visibleKeys.length < filteredKeys.length ? (
           <ResourceListFooter>
             <Button variant="outline" onClick={() => setVisibleCount(filteredKeys.length)}>

--- a/web/apps/design/src/pages/primitives/resource-list/index.mdx
+++ b/web/apps/design/src/pages/primitives/resource-list/index.mdx
@@ -1,6 +1,6 @@
 ---
 layout: ../../../layouts/layout.astro
-title: Resource list | Unkey Design
+title: Resource list — Unkey Design
 ---
 import { Preview } from "../../../components/preview.tsx";
 import { ResourceListExample } from "./_basic.tsx";

--- a/web/apps/design/src/pages/primitives/resource-list/index.mdx
+++ b/web/apps/design/src/pages/primitives/resource-list/index.mdx
@@ -1,0 +1,42 @@
+---
+layout: ../../../layouts/layout.astro
+title: Resource list | Unkey Design
+---
+import { Preview } from "../../../components/preview.tsx";
+import { ResourceListExample } from "./_basic.tsx";
+import basicSource from "./_basic.tsx?highlight";
+
+# Resource list
+
+Resource list components provide the shared layout for filterable lists. The feature still owns data fetching, item markup, empty states, and loading states.
+
+<Preview client:load code={basicSource}>
+  <ResourceListExample client:load />
+</Preview>
+
+## Anatomy
+
+- `ResourceList` sets the vertical spacing between controls and content.
+- `ResourceListHeader` lays out search and filter controls.
+- `ResourceListContent` draws the bordered list frame.
+- `ResourceListFooter` holds a right-aligned Load more button without a result count.
+
+Keep the resource title and primary action in `PageHeader`.
+
+## Usage
+
+```tsx
+<ResourceList>
+  <ResourceListHeader>{controls}</ResourceListHeader>
+  <ResourceListContent>
+    <ul className="divide-y divide-grayA-4">
+      {items.map((item) => (
+        <li key={item.id}>{item.name}</li>
+      ))}
+    </ul>
+    <ResourceListFooter>
+      <Button variant="outline">Load more</Button>
+    </ResourceListFooter>
+  </ResourceListContent>
+</ResourceList>
+```

--- a/web/apps/design/src/pages/primitives/resource-list/index.mdx
+++ b/web/apps/design/src/pages/primitives/resource-list/index.mdx
@@ -19,6 +19,8 @@ Resource list components provide the shared layout for filterable lists. The fea
 - `ResourceList` sets the vertical spacing between controls and content.
 - `ResourceListHeader` lays out search and filter controls.
 - `ResourceListContent` draws the bordered list frame.
+- `ResourceListBody` renders a semantic list and separates its items.
+- `ResourceListItem` renders a semantic list item.
 - `ResourceListFooter` holds a right-aligned Load more button without a result count.
 
 Keep the resource title and primary action in `PageHeader`.
@@ -29,11 +31,11 @@ Keep the resource title and primary action in `PageHeader`.
 <ResourceList>
   <ResourceListHeader>{controls}</ResourceListHeader>
   <ResourceListContent>
-    <ul className="divide-y divide-grayA-4">
+    <ResourceListBody>
       {items.map((item) => (
-        <li key={item.id}>{item.name}</li>
+        <ResourceListItem key={item.id}>{item.name}</ResourceListItem>
       ))}
-    </ul>
+    </ResourceListBody>
     <ResourceListFooter>
       <Button variant="outline">Load more</Button>
     </ResourceListFooter>

--- a/web/apps/design/src/pages/primitives/resource-list/index.mdx
+++ b/web/apps/design/src/pages/primitives/resource-list/index.mdx
@@ -8,7 +8,7 @@ import basicSource from "./_basic.tsx?highlight";
 
 # Resource list
 
-Resource list components provide the shared layout for filterable lists. The feature still owns data fetching, item markup, empty states, and loading states.
+Resource list components provide the shared layout for filterable lists.
 
 <Preview client:load code={basicSource}>
   <ResourceListExample client:load />

--- a/web/internal/ui/src/components/resource-list/index.ts
+++ b/web/internal/ui/src/components/resource-list/index.ts
@@ -1,0 +1,1 @@
+export * from "./resource-list";

--- a/web/internal/ui/src/components/resource-list/resource-list.tsx
+++ b/web/internal/ui/src/components/resource-list/resource-list.tsx
@@ -17,6 +17,14 @@ function ResourceListContent({ className, ...props }: React.ComponentProps<"div"
   );
 }
 
+function ResourceListBody({ className, ...props }: React.ComponentProps<"ul">) {
+  return <ul className={cn("divide-y divide-grayA-4", className)} {...props} />;
+}
+
+function ResourceListItem({ className, ...props }: React.ComponentProps<"li">) {
+  return <li className={cn("relative", className)} {...props} />;
+}
+
 function ResourceListFooter({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
@@ -26,4 +34,11 @@ function ResourceListFooter({ className, ...props }: React.ComponentProps<"div">
   );
 }
 
-export { ResourceList, ResourceListContent, ResourceListFooter, ResourceListHeader };
+export {
+  ResourceList,
+  ResourceListBody,
+  ResourceListContent,
+  ResourceListFooter,
+  ResourceListHeader,
+  ResourceListItem,
+};

--- a/web/internal/ui/src/components/resource-list/resource-list.tsx
+++ b/web/internal/ui/src/components/resource-list/resource-list.tsx
@@ -1,0 +1,29 @@
+import type * as React from "react";
+import { cn } from "../../lib/utils";
+
+function ResourceList({ className, ...props }: React.ComponentProps<"div">) {
+  return <div className={cn("flex w-full flex-col gap-3", className)} {...props} />;
+}
+
+function ResourceListHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div className={cn("flex flex-col items-stretch gap-2 md:flex-row", className)} {...props} />
+  );
+}
+
+function ResourceListContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div className={cn("overflow-hidden rounded-lg border border-grayA-4", className)} {...props} />
+  );
+}
+
+function ResourceListFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn("flex items-center justify-end border-grayA-4 border-t px-4 py-3", className)}
+      {...props}
+    />
+  );
+}
+
+export { ResourceList, ResourceListContent, ResourceListFooter, ResourceListHeader };

--- a/web/internal/ui/src/index.ts
+++ b/web/internal/ui/src/index.ts
@@ -27,6 +27,7 @@ export * from "./components/info-tooltip";
 export * from "./components/inline-link";
 export * from "./components/loading";
 export * from "./components/page";
+export * from "./components/resource-list";
 export * from "./components/logo";
 export * from "./components/llm-search";
 export * from "./components/llm-search/components/search-icon";


### PR DESCRIPTION
Refactor our deployments list page into a reusable component and add it to the design docs.

<img width="1572" height="1508" alt="CleanShot 2026-07-14 at 16 14 13@2x" src="https://github.com/user-attachments/assets/1b5845e4-a148-40f8-8d5a-b916e13e3b43" />


The deployments list page still looks tight
<img width="4516" height="2668" alt="CleanShot 2026-07-14 at 16 32 57@2x" src="https://github.com/user-attachments/assets/6c5e8dda-6322-4329-9a9e-4123dbcdd439" />
