### PR TITLE
Fix region selector layout when tags wrap

### DIFF
--- a/web/apps/dashboard/components/ui/combobox.tsx
+++ b/web/apps/dashboard/components/ui/combobox.tsx
@@ -173,7 +173,9 @@ export function Combobox({
               aria-required={ariaRequired}
               className={cn(
                 comboboxTriggerVariants({ variant }),
-                isMultiSelect ? "min-h-9 h-auto items-start py-1.5 whitespace-normal" : "h-9 items-center py-0",
+                isMultiSelect
+                  ? "min-h-9 h-auto items-start py-1.5 whitespace-normal"
+                  : "h-9 items-center py-0",
                 "px-3",
                 leftIcon && "pl-9",
                 !hideChevron && "pr-9", // Space for the chevron icon when visible

--- a/web/apps/dashboard/components/ui/combobox.tsx
+++ b/web/apps/dashboard/components/ui/combobox.tsx
@@ -15,7 +15,7 @@ import { cva } from "class-variance-authority";
 import * as React from "react";
 
 const comboboxTriggerVariants = cva(
-  "flex h-9 w-full rounded-lg text-[13px] leading-5 transition-colors duration-300 disabled:cursor-not-allowed disabled:opacity-50 placeholder:text-grayA-8 text-grayA-12 items-center justify-between",
+  "flex w-full rounded-lg text-[13px] leading-5 transition-colors duration-300 disabled:cursor-not-allowed disabled:opacity-50 placeholder:text-grayA-8 text-grayA-12 justify-between",
   {
     variants: {
       variant: {
@@ -139,6 +139,8 @@ export function Combobox({
     return !effectiveOptions.some((o) => o.value === search.trim());
   }, [creatable, search, effectiveOptions]);
 
+  const isMultiSelect = !closeOnSelect;
+
   return (
     <Popover
       open={open}
@@ -171,10 +173,11 @@ export function Combobox({
               aria-required={ariaRequired}
               className={cn(
                 comboboxTriggerVariants({ variant }),
-                "px-3 py-0",
+                isMultiSelect ? "min-h-9 h-auto items-start py-1.5 whitespace-normal" : "h-9 items-center py-0",
+                "px-3",
                 leftIcon && "pl-9",
                 !hideChevron && "pr-9", // Space for the chevron icon when visible
-                "justify-between font-normal w-full [&_svg]:size-3",
+                "font-normal w-full [&_svg]:size-3",
                 className,
               )}
               {...otherProps}
@@ -189,7 +192,10 @@ export function Combobox({
                 <div className="text-left w-full">{placeholder}</div>
               )}
               {!hideChevron && (
-                <ChevronExpandY className="absolute right-3" iconSize="sm-regular" />
+                <ChevronExpandY
+                  className="absolute right-3 top-1/2 -translate-y-1/2"
+                  iconSize="sm-regular"
+                />
               )}
             </Button>
           }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the Production/Preview region selectors overflowing their bordered container when four or more regions are selected and tags wrap to a second line.

The combobox trigger used a fixed `h-9` height. Multi-select region pickers pass `closeOnSelect={false}`, so the trigger now grows vertically (`min-h-9 h-auto`) and allows wrapped tag content to stay inside the border.

## Before / After

![Region selector before and after comparison](https://cursor.com/artifacts/c/art-fc69ccd2-86fc-4de3-a222-5aba097c5474)

**Before:** fixed `h-9` height clips wrapped tags outside the border.

**After:** trigger grows with wrapped tags; border contains all selections.

## Changes

- `web/apps/dashboard/components/ui/combobox.tsx`
  - Detect multi-select mode via `closeOnSelect={false}`
  - Use `min-h-9 h-auto` with `whitespace-normal` for multi-select triggers
  - Vertically center the chevron icon within the expanded trigger

## Verification

- Visual before/after comparison captured for four-region selection case
- No other `closeOnSelect={false}` usages in the repo, so the behavior change is scoped to region selectors
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://unkey.slack.com/archives/C0A7JD8HKMY/p1783427985702559?thread_ts=1783427985.702559&cid=C0A7JD8HKMY)

<div><a href="https://cursor.com/agents/bc-eddb8a00-afde-5da5-9b2e-5aaded171b9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eddb8a00-afde-5da5-9b2e-5aaded171b9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

