### PR TITLE
fix: Client-controlled X-Forwarded-For stored as audit location

### DIFF
--- a/web/apps/dashboard/app/auth/actions.ts
+++ b/web/apps/dashboard/app/auth/actions.ts
@@ -21,6 +21,7 @@ import {
   type VerificationResult,
   errorMessages,
 } from "@/lib/auth/types";
+import { getClientIp } from "@/lib/client-ip";
 import { env } from "@/lib/env";
 import { Ratelimit } from "@unkey/ratelimit";
 import type { Route } from "next";
@@ -30,10 +31,7 @@ import { redirect } from "next/navigation";
 // Helper to extract request metadata for Radar
 async function getRequestMetadata() {
   const headersList = await headers();
-  const ipAddress =
-    headersList.get("x-forwarded-for")?.split(",")[0].trim() ||
-    headersList.get("x-real-ip") ||
-    undefined;
+  const ipAddress = getClientIp(headersList);
   const userAgent = headersList.get("user-agent") || undefined;
 
   return { ipAddress, userAgent };

--- a/web/apps/dashboard/lib/auth/workos.ts
+++ b/web/apps/dashboard/lib/auth/workos.ts
@@ -10,6 +10,7 @@ import {
   type Invitation as WorkOSInvitation,
   type Organization as WorkOSOrganization,
 } from "@workos-inc/node";
+import { getClientIp } from "../client-ip";
 import { getBaseUrl } from "../utils";
 import { BaseAuthProvider } from "./base-provider";
 import { getAuthCookieOptions } from "./cookie-security";
@@ -1378,8 +1379,7 @@ export class WorkOSAuthProvider extends BaseAuthProvider {
       const { sealedSession } = await this.provider.userManagement.authenticateWithCode({
         clientId: this.clientId,
         code,
-        ipAddress:
-          callbackRequest.headers.get("x-forwarded-for")?.split(",")[0].trim() || undefined,
+        ipAddress: getClientIp(callbackRequest.headers),
         userAgent: callbackRequest.headers.get("user-agent") || undefined,
         signalsId: parsedState.signalsId,
         session: {

--- a/web/apps/dashboard/lib/client-ip.test.ts
+++ b/web/apps/dashboard/lib/client-ip.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { getClientIp } from "./client-ip";
+
+describe("getClientIp", () => {
+  it("returns undefined when no forwarding header is present", () => {
+    expect(getClientIp(new Headers())).toBeUndefined();
+  });
+
+  it("reads the client IP from x-forwarded-for", () => {
+    expect(getClientIp(new Headers({ "x-forwarded-for": "203.0.113.7" }))).toBe("203.0.113.7");
+  });
+
+  it("takes only the leftmost entry of a forwarding chain", () => {
+    expect(
+      getClientIp(new Headers({ "x-forwarded-for": "203.0.113.7, 198.51.100.1, 10.0.0.1" })),
+    ).toBe("203.0.113.7");
+  });
+
+  it("prefers x-vercel-forwarded-for over every other forwarding header", () => {
+    const headers = new Headers({
+      "x-vercel-forwarded-for": "203.0.113.7",
+      "x-forwarded-for": "198.51.100.1",
+      "x-real-ip": "192.0.2.1",
+    });
+
+    expect(getClientIp(headers)).toBe("203.0.113.7");
+  });
+
+  it("prefers x-forwarded-for over x-real-ip", () => {
+    expect(
+      getClientIp(new Headers({ "x-forwarded-for": "198.51.100.1", "x-real-ip": "192.0.2.1" })),
+    ).toBe("198.51.100.1");
+  });
+
+  it("falls back to x-real-ip when no other header resolves", () => {
+    expect(
+      getClientIp(new Headers({ "x-forwarded-for": "not-an-ip", "x-real-ip": "192.0.2.1" })),
+    ).toBe("192.0.2.1");
+  });
+
+  it("handles IPv6 addresses", () => {
+    expect(getClientIp(new Headers({ "x-forwarded-for": "2001:db8::1" }))).toBe("2001:db8::1");
+  });
+
+  it("handles the IPv4-mapped IPv6 form a dual-stack socket produces", () => {
+    expect(getClientIp(new Headers({ "x-forwarded-for": "::ffff:203.0.113.7" }))).toBe(
+      "::ffff:203.0.113.7",
+    );
+  });
+
+  it.each([
+    { name: "IPv4 with a port", value: "203.0.113.7:8080", want: "203.0.113.7" },
+    { name: "bracketed IPv6 with a port", value: "[2001:db8::1]:8080", want: "2001:db8::1" },
+    { name: "bracketed IPv6 without a port", value: "[2001:db8::1]", want: "2001:db8::1" },
+  ])("normalizes $name to a bare address", ({ value, want }) => {
+    expect(getClientIp(new Headers({ "x-forwarded-for": value }))).toBe(want);
+  });
+
+  // Every one of these would previously have been written to the audit log verbatim as the client's
+  // remote_ip. Discarding them is the guarantee ENG-3019 asks for.
+  it.each([
+    { name: "arbitrary text", value: "not-an-ip" },
+    { name: "the literal 'unknown'", value: "unknown" },
+    { name: "a SQL payload", value: "'; DROP TABLE audit_log; --" },
+    { name: "a log-forging payload", value: 'admin" location="1.2.3.4' },
+    { name: "an out-of-range IPv4", value: "999.999.999.999" },
+    { name: "an empty value", value: "" },
+  ])("discards $name", ({ value }) => {
+    expect(getClientIp(new Headers({ "x-forwarded-for": value }))).toBeUndefined();
+  });
+
+  it("discards a value carrying a log-injection payload", () => {
+    // `Headers` itself rejects control characters, so this goes through a bare header lookup to
+    // cover deployments where the header reaches us from something more permissive.
+    const headers = {
+      get: (name: string) => {
+        return name === "x-forwarded-for" ? "203.0.113.7\nlocation=192.0.2.1" : null;
+      },
+    };
+
+    expect(getClientIp(headers)).toBeUndefined();
+  });
+
+  it("does not fall through to a later chain entry when the leftmost one is forged", () => {
+    // A client that prepends junk must not be able to have the next entry read as its address.
+    expect(getClientIp(new Headers({ "x-forwarded-for": "spoofed, 203.0.113.7" }))).toBeUndefined();
+  });
+
+  it("ignores a forged x-forwarded-for when x-vercel-forwarded-for is present", () => {
+    const headers = new Headers({
+      "x-vercel-forwarded-for": "198.51.100.1",
+      "x-forwarded-for": "attacker-supplied",
+    });
+
+    expect(getClientIp(headers)).toBe("198.51.100.1");
+  });
+});

--- a/web/apps/dashboard/lib/client-ip.ts
+++ b/web/apps/dashboard/lib/client-ip.ts
@@ -1,0 +1,68 @@
+import { z } from "zod";
+
+const ipSchema = z.union([z.ipv4(), z.ipv6()]);
+
+/**
+ * Header precedence, most trustworthy first.
+ *
+ * On Vercel all three are set by the platform from the connecting IP and carry the same value, so
+ * the order only decides anything on a deployment Vercel does not front. There, no forwarding
+ * header is authoritative on its own, and precedence is a judgement call rather than a guarantee:
+ * `x-vercel-forwarded-for` leads because nothing but Vercel has cause to send it, and
+ * `x-forwarded-for` outranks `x-real-ip` because it is the header a reverse proxy conventionally
+ * rewrites, and the one the dashboard already preferred before this list existed.
+ *
+ * Precedence is the weaker half of the defense. What actually stops a client from choosing its own
+ * address is that the value must parse as an IP, which `getClientIp` enforces below. A deployment
+ * that genuinely sits behind a proxy needs a trusted-hop count to be correct, not a header ranking.
+ */
+const IP_HEADERS = ["x-vercel-forwarded-for", "x-forwarded-for", "x-real-ip"] as const;
+
+/** An IPv6 literal wrapped in brackets, with an optional port: `[::1]:8080` -> `::1`. */
+const BRACKETED_IPV6 = /^\[(.+?)\](?::\d+)?$/;
+
+/** An address carrying a port, where the address itself holds no colon: `1.2.3.4:8080` -> `1.2.3.4`. */
+const ADDRESS_WITH_PORT = /^([^:]+):\d+$/;
+
+/**
+ * Removes the port, and the brackets an IPv6 literal is wrapped in when it carries one.
+ *
+ * A bare IPv6 address is returned untouched, because its colons separate groups rather than a port
+ * and only the bracketed form can express one unambiguously.
+ */
+function stripPort(value: string): string {
+  const bracketed = value.match(BRACKETED_IPV6);
+  if (bracketed) {
+    return bracketed[1];
+  }
+
+  const withPort = value.match(ADDRESS_WITH_PORT);
+  if (withPort) {
+    return withPort[1];
+  }
+
+  return value;
+}
+
+/**
+ * Resolves the IP of the client that made the request.
+ *
+ * Only the leftmost entry of a forwarding chain is considered, and it must parse as an IP address.
+ * Anything else is discarded rather than passed through, so a client that injects a value into a
+ * forwarding header cannot get arbitrary text recorded as its address.
+ */
+export function getClientIp(headers: Pick<Headers, "get">): string | undefined {
+  for (const header of IP_HEADERS) {
+    const value = headers.get(header);
+    if (!value) {
+      continue;
+    }
+
+    const parsed = ipSchema.safeParse(stripPort(value.split(",")[0].trim()));
+    if (parsed.success) {
+      return parsed.data;
+    }
+  }
+
+  return undefined;
+}

--- a/web/apps/dashboard/lib/trpc/context.ts
+++ b/web/apps/dashboard/lib/trpc/context.ts
@@ -3,6 +3,7 @@ import type { FetchCreateContextFnOptions } from "@trpc/server/adapters/fetch";
 import type { NextRequest } from "next/server";
 
 import { getAuth } from "../auth/get-auth";
+import { getClientIp } from "../client-ip";
 import { db } from "../db";
 
 export async function createContext({ req }: FetchCreateContextFnOptions) {
@@ -39,7 +40,9 @@ export async function createContext({ req }: FetchCreateContextFnOptions) {
     req,
     audit: {
       userAgent: req.headers.get("user-agent") ?? undefined,
-      location: req.headers.get("x-forwarded-for") ?? process.env.VERCEL_REGION ?? "unknown",
+      // Recorded as `remote_ip` on every audit log, so it must be an address we trust rather than
+      // whatever the client put in a forwarding header.
+      location: getClientIp(req.headers) ?? "unknown",
     },
     user: authResult.userId
       ? {


### PR DESCRIPTION
> [!IMPORTANT]
> Unkey is not accepting external pull requests at this time. Pull requests from people outside the Unkey team will not be reviewed or merged.

## What does this PR do?

Client-controlled forwarding headers (x-forwarded-for, x-real-ip) were being recorded verbatim — most notably as the   remote_ip / location on every audit log via the tRPC context. Because a client can set these headers to anything, that let arbitrary text (including SQL/log-injection payloads and the literal "unknown") land in the audit trail as if it were the caller's address.

This adds a shared getClientIp helper that validates the value before it's ever recorded, and routes all three call sites through it.

Fixes # (issue)
ENG-3019

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

1. Audit log — perform any auditable dashboard action and confirm the entry's remote_ip/location is either a valid IP or "unknown", never raw header text.
2. Spoof rejection — send a request with x-forwarded-for: not-an-ip (or '; DROP TABLE audit_log; --) and confirm the audit location records "unknown", not the payload.
3. Chain handling — with x-forwarded-for: 203.0.113.7, 10.0.0.1, confirm only 203.0.113.7 is recorded.
4. Vercel deploy — verify a real request still records the connecting IP (Vercel sets x-vercel-forwarded-for).
5. Auth flows — complete a WorkOS sign-in and confirm the login still succeeds with the IP passed through to Radar/WorkOS.

## Checklist

<!-- Complete this checklist before requesting review. -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [x] Ran `mise run fmt`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary
