### PR TITLE
feat: support multi-line environment variable values end-to-end

### DIFF
--- a/docs/product/builds/dockerfile.mdx
+++ b/docs/product/builds/dockerfile.mdx
@@ -63,12 +63,21 @@ NPM_TOKEN=npm_abc123
 FEATURE_FLAG=true
 ```
 
-The `set -a && . /run/secrets/.env && set +a` pattern loads every variable from the file into the shell environment for that `RUN` step. The secret file is not persisted in the final image.
+Values that contain whitespace, quotes, `$`, `#`, or newlines are emitted quoted so they survive sourcing and dotenv parsing unchanged. Multi-line values such as PEM keys work as-is:
+
+```bash /run/secrets/.env
+DATABASE_URL='postgres://prod db.acme.com/api'
+TLS_KEY='-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQ...
+-----END PRIVATE KEY-----'
+```
+
+The `set -a && . /run/secrets/.env && set +a` pattern loads every variable from the file into the shell environment for that `RUN` step, including quoted and multi-line values. The secret file is not persisted in the final image.
 
 How you consume the file depends on your toolchain:
 
 - **Tools that expect environment variables** (npm, pip, go): use the `set -a` pattern above to load them into the shell.
-- **Frameworks that read `.env` files directly** (Node.js with dotenv, Ruby with dotenv): reference `/run/secrets/.env` in your build script instead of sourcing it.
+- **Frameworks that read `.env` files directly**: reference `/run/secrets/.env` in your build script instead of sourcing it. Dotenv parsers that support quoted multi-line values read the file unchanged. Use a current release: node dotenv 15 or newer, ruby dotenv 2.7 or newer, or python-dotenv. A value that combines a single quote with other shell metacharacters is written double-quoted, which a few dotenv parsers read differently than the shell does; single-quote it or split it if that matters.
 
 ### Why secret mounts instead of ARG or ENV?
 

--- a/pkg/mysql/schema/app_environment_variables.sql
+++ b/pkg/mysql/schema/app_environment_variables.sql
@@ -5,7 +5,7 @@ CREATE TABLE `app_environment_variables` (
 	`app_id` varchar(64) NOT NULL,
 	`environment_id` varchar(128) NOT NULL,
 	`key` varchar(256) NOT NULL,
-	`value` varchar(4096) NOT NULL,
+	`value` text NOT NULL,
 	`type` enum('recoverable','writeonly') NOT NULL,
 	`description` varchar(255),
 	`delete_protection` boolean DEFAULT false,

--- a/svc/api/internal/errors/errors.go
+++ b/svc/api/internal/errors/errors.go
@@ -1,9 +1,57 @@
 package errors
 
 import (
+	"fmt"
+	"math"
+
 	"github.com/unkeyed/unkey/pkg/codes"
 	"github.com/unkeyed/unkey/pkg/fault"
 )
+
+// humanizeBytes formats a byte count using decimal (SI) units, e.g. 16000 ->
+// "16 kB" and 1048576 -> "1.0 MB". Values below 10 bytes render as "N B".
+// Larger values use one decimal place when the mantissa is below 10 and none
+// otherwise, so "1.5 MB" but "16 kB".
+func humanizeBytes(s uint64) string {
+	sizes := []string{"B", "kB", "MB", "GB", "TB", "PB", "EB"}
+	if s < 10 {
+		return fmt.Sprintf("%d B", s)
+	}
+	const base = 1000.0
+	e := math.Floor(math.Log(float64(s)) / math.Log(base))
+	val := math.Floor(float64(s)/math.Pow(base, e)*10+0.5) / 10
+	format := "%.0f %s"
+	if val < 10 {
+		format = "%.1f %s"
+	}
+	return fmt.Sprintf(format, val, sizes[int(e)])
+}
+
+// MaxByteSize returns a 400 validation error when sizeBytes exceeds limitBytes,
+// reporting both sizes human-readably (e.g. "1.0 MB", "16 kB"), and nil when
+// within the limit. subject is the sentence subject placed before "is too
+// large", so pass text that reads naturally there, e.g. "Metadata" or
+// fmt.Sprintf("Variable %q value", key).
+//
+// The budget is UTF-8 bytes, not code points: OpenAPI maxLength counts code
+// points, so a multibyte value can pass schema validation and still overflow a
+// byte-bounded store. Callers pass len(value) or len(marshaled), which are
+// already byte counts.
+func MaxByteSize(subject string, sizeBytes, limitBytes int) error {
+	if sizeBytes <= limitBytes {
+		return nil
+	}
+	return fault.New("value exceeds byte limit",
+		fault.Code(codes.App.Validation.InvalidInput.URN()),
+		fault.Internal("value exceeds byte limit"),
+		fault.Public(fmt.Sprintf(
+			"%s is too large: it must be at most %s, but is %s.",
+			subject,
+			humanizeBytes(uint64(limitBytes)),
+			humanizeBytes(uint64(sizeBytes)),
+		)),
+	)
+}
 
 func MaskInsufficientPermissionsAsNotFound(err error, code codes.URN, public string) error {
 	errCode, ok := fault.GetCode(err)

--- a/svc/api/internal/errors/errors_test.go
+++ b/svc/api/internal/errors/errors_test.go
@@ -1,0 +1,30 @@
+package errors
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHumanizeBytes(t *testing.T) {
+	cases := []struct {
+		in   uint64
+		want string
+	}{
+		{0, "0 B"},
+		{5, "5 B"},
+		{9, "9 B"},
+		{10, "10 B"},
+		{999, "999 B"},
+		{1000, "1.0 kB"},
+		{1500, "1.5 kB"},
+		{16000, "16 kB"},
+		{1000000, "1.0 MB"},
+		{1048576, "1.0 MB"},
+		{1500000, "1.5 MB"},
+		{1000000000, "1.0 GB"},
+	}
+	for _, tc := range cases {
+		require.Equal(t, tc.want, humanizeBytes(tc.in), "humanizeBytes(%d)", tc.in)
+	}
+}

--- a/svc/api/openapi/gen.go
+++ b/svc/api/openapi/gen.go
@@ -469,7 +469,9 @@ type EnvironmentVariableInput struct {
 	// Kind How the value may be read back. Defaults to `writeonly`.
 	Kind *EnvironmentVariableKind `json:"kind,omitempty"`
 
-	// Value The variable value. Always encrypted at rest.
+	// Value The variable value. Always encrypted at rest. The limit is enforced
+	// server-side in UTF-8 bytes, so a multibyte value may be rejected before
+	// it reaches this code-point maximum.
 	Value string `json:"value"`
 }
 

--- a/svc/api/openapi/openapi-generated.yaml
+++ b/svc/api/openapi/openapi-generated.yaml
@@ -4392,8 +4392,11 @@ components:
                 value:
                     type: string
                     minLength: 1
-                    maxLength: 4096
-                    description: The variable value. Always encrypted at rest.
+                    maxLength: 16384
+                    description: |
+                        The variable value. Always encrypted at rest. The limit is enforced
+                        server-side in UTF-8 bytes, so a multibyte value may be rejected before
+                        it reaches this code-point maximum.
                     example: postgresql://user:pass@host:5432/db
                 kind:
                     allOf:

--- a/svc/api/openapi/spec/common/EnvironmentVariableInput.yaml
+++ b/svc/api/openapi/spec/common/EnvironmentVariableInput.yaml
@@ -17,8 +17,11 @@ properties:
   value:
     type: string
     minLength: 1
-    maxLength: 4096
-    description: The variable value. Always encrypted at rest.
+    maxLength: 16384
+    description: |
+      The variable value. Always encrypted at rest. The limit is enforced
+      server-side in UTF-8 bytes, so a multibyte value may be rejected before
+      it reaches this code-point maximum.
     example: postgresql://user:pass@host:5432/db
   kind:
     allOf:

--- a/svc/api/routes/v2_environments_set_environment_variables/200_test.go
+++ b/svc/api/routes/v2_environments_set_environment_variables/200_test.go
@@ -3,6 +3,7 @@ package handler_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -225,5 +226,26 @@ func TestSetEnvironmentVariablesSuccessfully(t *testing.T) {
 		// Separate entries are auto-correlated so one set call is traceable as a unit.
 		require.NotEmpty(t, logs[0].CorrelationID)
 		require.Equal(t, logs[0].CorrelationID, logs[1].CorrelationID)
+	})
+
+	t.Run("multi-line and large values round-trip through vault and the TEXT column", func(t *testing.T) {
+		env := seedEnvironment(t, h)
+
+		// A PEM block carries interior newlines that the previous varchar(4096)
+		// column and 3000-byte cap could not hold; a 16384-byte value sits at
+		// the new plaintext cap. Both must survive encryption, the widened TEXT
+		// column, and decryption byte for byte.
+		pem := "-----BEGIN PRIVATE KEY-----\nMIIabc/def+123==\nghi/JKL+456==\n-----END PRIVATE KEY-----\n"
+		atCap := strings.Repeat("a", 16384)
+
+		call(t, makeRequest(env, []openapi.EnvironmentVariableInput{
+			{Key: "TLS_KEY", Value: pem, Kind: ptr(openapi.Recoverable)},
+			{Key: "BIG_BLOB", Value: atCap, Kind: ptr(openapi.Recoverable)},
+		}))
+
+		raw := listRawVars(t, h, env.environmentID)
+		require.Len(t, raw, 2)
+		require.Equal(t, pem, decrypt(t, env.environmentID, raw["TLS_KEY"].value))
+		require.Equal(t, atCap, decrypt(t, env.environmentID, raw["BIG_BLOB"].value))
 	})
 }

--- a/svc/api/routes/v2_environments_set_environment_variables/400_test.go
+++ b/svc/api/routes/v2_environments_set_environment_variables/400_test.go
@@ -3,6 +3,7 @@ package handler_test
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -43,6 +44,16 @@ func TestSetEnvironmentVariablesBadRequest(t *testing.T) {
 		res := testutil.CallRoute[handler.Request, openapi.BadRequestErrorResponse](h, route, headers, makeRequest(env, []openapi.EnvironmentVariableInput{
 			{Key: "DUP", Value: "first"},
 			{Key: "DUP", Value: "second"},
+		}))
+		require.Equal(t, http.StatusBadRequest, res.Status, "expected 400, received: %s", res.RawBody)
+	})
+
+	t.Run("values over the byte cap are rejected even when under the code-point limit", func(t *testing.T) {
+		// 5462 three-byte runes is 16386 UTF-8 bytes but only 5462 code points,
+		// so it passes the spec maxLength (16384 code points) and must be caught
+		// by the handler's server-side byte check.
+		res := testutil.CallRoute[handler.Request, openapi.BadRequestErrorResponse](h, route, headers, makeRequest(env, []openapi.EnvironmentVariableInput{
+			{Key: "TOO_BIG", Value: strings.Repeat("あ", 5462)},
 		}))
 		require.Equal(t, http.StatusBadRequest, res.Status, "expected 400, received: %s", res.RawBody)
 	})

--- a/svc/api/routes/v2_environments_set_environment_variables/handler.go
+++ b/svc/api/routes/v2_environments_set_environment_variables/handler.go
@@ -20,6 +20,7 @@ import (
 	"github.com/unkeyed/unkey/pkg/rbac"
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/pkg/zen"
+	apierrors "github.com/unkeyed/unkey/svc/api/internal/errors"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
 
@@ -27,6 +28,14 @@ type (
 	Request  = openapi.V2EnvironmentsSetEnvironmentVariablesRequestBody
 	Response = openapi.V2EnvironmentsSetEnvironmentVariablesResponseBody
 )
+
+// maxEnvVarValueBytes caps a variable value in UTF-8 bytes. The encrypted
+// ciphertext is a base64 wrapper roughly 4/3 * (bytes + 71) large and must fit
+// the TEXT value column. Enforced server-side via apierrors.MaxByteSize since
+// the spec's maxLength counts code points. Keep in sync with
+// MAX_ENV_VAR_VALUE_BYTES in the dashboard schema
+// (web/apps/dashboard/lib/schemas/env-var.ts).
+const maxEnvVarValueBytes = 16384
 
 type Handler struct {
 	DB        db.Database
@@ -106,6 +115,9 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 				fault.Internal("duplicate variable key in request"),
 				fault.Public(fmt.Sprintf("Variable %q is listed more than once. Each key may appear at most once.", v.Key)),
 			)
+		}
+		if err := apierrors.MaxByteSize(fmt.Sprintf("Variable %q value", v.Key), len(v.Value), maxEnvVarValueBytes); err != nil {
+			return err
 		}
 		byKey[v.Key] = v
 	}

--- a/svc/api/routes/v2_identities_create_identity/handler.go
+++ b/svc/api/routes/v2_identities_create_identity/handler.go
@@ -18,6 +18,7 @@ import (
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/pkg/urn"
 	"github.com/unkeyed/unkey/pkg/zen"
+	apierrors "github.com/unkeyed/unkey/svc/api/internal/errors"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
 
@@ -88,12 +89,8 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			)
 		}
 
-		sizeInMB := float64(len(rawMeta)) / 1024 / 1024
-		if sizeInMB > MAX_META_LENGTH_MB {
-			return fault.New("metadata is too large",
-				fault.Code(codes.App.Validation.InvalidInput.URN()),
-				fault.Internal("metadata is too large"), fault.Public(fmt.Sprintf("Metadata is too large, it must be less than %dMB, got: %.2f", MAX_META_LENGTH_MB, sizeInMB)),
-			)
+		if err := apierrors.MaxByteSize("Metadata", len(rawMeta), MAX_META_LENGTH_MB*1024*1024); err != nil {
+			return err
 		}
 
 		meta = rawMeta

--- a/svc/api/routes/v2_identities_update_identity/handler.go
+++ b/svc/api/routes/v2_identities_update_identity/handler.go
@@ -19,6 +19,7 @@ import (
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/pkg/urn"
 	"github.com/unkeyed/unkey/pkg/zen"
+	apierrors "github.com/unkeyed/unkey/svc/api/internal/errors"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
 
@@ -108,12 +109,8 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			)
 		}
 
-		sizeInMB := float64(len(metaBytes)) / 1024 / 1024
-		if sizeInMB > maxMetaLengthMB {
-			return fault.New("metadata is too large",
-				fault.Code(codes.App.Validation.InvalidInput.URN()),
-				fault.Internal("metadata is too large"), fault.Public(fmt.Sprintf("Metadata is too large, it must be less than %dMB, got: %.2f", maxMetaLengthMB, sizeInMB)),
-			)
+		if err := apierrors.MaxByteSize("Metadata", len(metaBytes), maxMetaLengthMB*1024*1024); err != nil {
+			return err
 		}
 	}
 

--- a/svc/ctrl/worker/deploy/build.go
+++ b/svc/ctrl/worker/deploy/build.go
@@ -2,16 +2,13 @@ package deploy
 
 import (
 	"context"
-	"crypto/sha256"
 	"database/sql"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"maps"
 	"net/http"
 	"regexp"
 	"slices"
-	"sort"
 	"strings"
 	"time"
 
@@ -329,14 +326,10 @@ func (w *Workflow) buildDockerImageFromGit(
 		// repo) the git fetch needs no credentials, so skip the auth secret
 		// entirely.
 		var solverOptions client.SolveOpt
-		var err error
 		if bctx.GithubToken == "" {
-			solverOptions, err = w.buildSolverOptions(platform, bctx.GitContextURL, dockerfilePath, bctx.ImageName, bctx.EnvVars)
+			solverOptions = w.buildSolverOptions(platform, bctx.GitContextURL, dockerfilePath, bctx.ImageName, bctx.EnvVars)
 		} else {
-			solverOptions, err = w.buildGitSolverOptions(platform, bctx.GitContextURL, dockerfilePath, bctx.ImageName, bctx.GithubToken, bctx.EnvVars)
-		}
-		if err != nil {
-			return nil, restate.TerminalError(fmt.Errorf("failed to build solver options: %w", err))
+			solverOptions = w.buildGitSolverOptions(platform, bctx.GitContextURL, dockerfilePath, bctx.ImageName, bctx.GithubToken, bctx.EnvVars)
 		}
 
 		return w.solveOnDepotMachine(runCtx, bctx.DepotProjectID, bctx.ImageName, params, solverOptions)
@@ -557,67 +550,18 @@ func repoOwner(fullName string) string {
 	return owner
 }
 
-// buildEnvFileSecret serializes env vars into a .env-formatted byte slice
-// for injection as a BuildKit secret. Returns (nil, nil) if there are no env
-// vars. Returns an error if any value contains newline or carriage-return
-// characters, which would corrupt the .env line format.
-func buildEnvFileSecret(envVars map[string]string) ([]byte, error) {
-	if len(envVars) == 0 {
-		return nil, nil
-	}
-
-	var badKeys []string
-	for k, v := range envVars {
-		if strings.ContainsAny(v, "\n\r") {
-			badKeys = append(badKeys, k)
-		}
-	}
-	if len(badKeys) != 0 {
-		sort.Strings(badKeys)
-		return nil, fmt.Errorf("environment variables contain newlines which cannot be represented in .env format: %s", strings.Join(badKeys, ", "))
-	}
-
-	var buf strings.Builder
-	for k, v := range envVars {
-		buf.WriteString(k)
-		buf.WriteByte('=')
-		buf.WriteString(v)
-		buf.WriteByte('\n')
-	}
-	return []byte(buf.String()), nil
-}
-
-// hashEnvVars returns a hex-encoded SHA-256 hash of the sorted key=value pairs.
-// The hash is stable across runs and safe to embed in image metadata without
-// exposing secret values. Returns an empty string if there are no env vars.
-func hashEnvVars(envVars map[string]string) string {
-	if len(envVars) == 0 {
-		return ""
-	}
-	pairs := make([]string, 0, len(envVars))
-	for k, v := range envVars {
-		pairs = append(pairs, k+"="+v)
-	}
-	sort.Strings(pairs)
-	h := sha256.Sum256([]byte(strings.Join(pairs, "\n")))
-	return hex.EncodeToString(h[:])
-}
-
 // buildSolverOptions constructs the BuildKit solver configuration for URL-based
 // contexts, including registry auth and image export settings. Use
 // [Workflow.buildGitSolverOptions] when the context requires GitHub credentials.
 func (w *Workflow) buildSolverOptions(
 	platform, contextURL, dockerfilePath, imageName string,
 	envVars map[string]string,
-) (client.SolveOpt, error) {
+) client.SolveOpt {
 	sessionAttachables := []session.Attachable{
 		w.registryAuthProvider(),
 	}
 
-	envFile, err := buildEnvFileSecret(envVars)
-	if err != nil {
-		return client.SolveOpt{}, fmt.Errorf("invalid environment variables: %w", err)
-	}
+	envFile := buildEnvFileSecret(envVars)
 
 	frontendAttrs := map[string]string{
 		"platform": platform,
@@ -655,7 +599,7 @@ func (w *Workflow) buildSolverOptions(
 				},
 			},
 		},
-	}, nil
+	}
 }
 
 // buildGitSolverOptions constructs the buildkit solver configuration for a git context build.
@@ -663,14 +607,11 @@ func (w *Workflow) buildSolverOptions(
 func (w *Workflow) buildGitSolverOptions(
 	platform, gitContextURL, dockerfilePath, imageName, githubToken string,
 	envVars map[string]string,
-) (client.SolveOpt, error) {
+) client.SolveOpt {
 	secrets := map[string][]byte{
 		gitAuthTokenSecretID: []byte(githubToken),
 	}
-	envFile, err := buildEnvFileSecret(envVars)
-	if err != nil {
-		return client.SolveOpt{}, fmt.Errorf("invalid environment variables: %w", err)
-	}
+	envFile := buildEnvFileSecret(envVars)
 
 	frontendAttrs := map[string]string{
 		"platform": platform,
@@ -708,7 +649,7 @@ func (w *Workflow) buildGitSolverOptions(
 				},
 			},
 		},
-	}, nil
+	}
 }
 
 // getOrCreateDepotProject retrieves the Depot project ID for an Unkey project,

--- a/svc/ctrl/worker/deploy/build_test.go
+++ b/svc/ctrl/worker/deploy/build_test.go
@@ -209,15 +209,13 @@ func TestBuildGitSolverOptions_EnvSecretGating(t *testing.T) {
 	}
 
 	t.Run("nil env registers no env secret", func(t *testing.T) {
-		opts, err := w.buildGitSolverOptions("linux/amd64", "https://github.com/acme/app.git#refs/pull/1/head", "Dockerfile", "img:tag", "ghs_token", nil)
-		require.NoError(t, err)
+		opts := w.buildGitSolverOptions("linux/amd64", "https://github.com/acme/app.git#refs/pull/1/head", "Dockerfile", "img:tag", "ghs_token", nil)
 		require.NotContains(t, opts.FrontendAttrs, "label:org.unkey.env-hash")
 		require.NotContains(t, opts.FrontendAttrs, "build-arg:UNKEY_SECRETS_ID")
 	})
 
 	t.Run("non-empty env registers env secret", func(t *testing.T) {
-		opts, err := w.buildGitSolverOptions("linux/amd64", "https://github.com/acme/app.git#deadbeef", "Dockerfile", "img:tag", "ghs_token", map[string]string{"FOO": "bar"})
-		require.NoError(t, err)
+		opts := w.buildGitSolverOptions("linux/amd64", "https://github.com/acme/app.git#deadbeef", "Dockerfile", "img:tag", "ghs_token", map[string]string{"FOO": "bar"})
 		require.Contains(t, opts.FrontendAttrs, "label:org.unkey.env-hash")
 		require.Contains(t, opts.FrontendAttrs, "build-arg:UNKEY_SECRETS_ID")
 	})

--- a/svc/ctrl/worker/deploy/env_file.go
+++ b/svc/ctrl/worker/deploy/env_file.go
@@ -1,0 +1,138 @@
+package deploy
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// buildEnvFileSecret serializes env vars into a .env-formatted byte slice for
+// injection as a BuildKit secret, mounted at /run/secrets/.env. Returns nil
+// when there are no env vars.
+//
+// Values are POSIX-quoted per quoteEnvValue so the file round-trips exactly
+// through shell sourcing (set -a && . /run/secrets/.env && set +a) and through
+// mainstream dotenv parsers. This is what lets values carry newlines,
+// whitespace, and shell metacharacters that a bare KEY=value line could not
+// represent. Keys are emitted in sorted order so identical inputs produce
+// identical bytes, which the env hash depends on.
+func buildEnvFileSecret(envVars map[string]string) []byte {
+	if len(envVars) == 0 {
+		return nil
+	}
+
+	keys := make([]string, 0, len(envVars))
+	for k := range envVars {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var buf strings.Builder
+	for _, k := range keys {
+		buf.WriteString(k)
+		buf.WriteByte('=')
+		buf.WriteString(quoteEnvValue(envVars[k]))
+		buf.WriteByte('\n')
+	}
+	return []byte(buf.String())
+}
+
+// envValueBareAllowed is the shlex-style safe set: bytes that carry no meaning
+// to the shell or to a dotenv parser, so a value composed only of these can be
+// emitted unquoted and read back byte-identical. Any byte >= 0x80 (multibyte
+// UTF-8) falls outside it, so unicode values take a quoted path.
+func envValueBareAllowed(b byte) bool {
+	switch {
+	case b >= 'A' && b <= 'Z':
+		return true
+	case b >= 'a' && b <= 'z':
+		return true
+	case b >= '0' && b <= '9':
+		return true
+	}
+	switch b {
+	case '_', '@', '%', '+', '=', ':', ',', '.', '/', '-':
+		return true
+	default:
+		return false
+	}
+}
+
+// isBareEnvValue reports whether v can be emitted unquoted. The empty string
+// qualifies so KEY= sets an empty value.
+func isBareEnvValue(v string) bool {
+	for i := 0; i < len(v); i++ {
+		if !envValueBareAllowed(v[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// quoteEnvValue renders a single .env value with the least quoting that
+// survives POSIX sourcing and mainstream dotenv parsers intact:
+//
+//   - bare when every byte is in the safe set (existing simple values stay
+//     byte-identical);
+//   - single-quoted when the value carries metacharacters but no single quote,
+//     so every byte inside is literal (newlines, $, ", \, # included); this is
+//     the exact form for PEM blocks and for JSON, which rarely contains ';
+//   - double-quoted when the value contains a single quote, backslash-escaping
+//     the four bytes the shell still interprets inside double quotes. Literal
+//     newlines stay literal. This is exact in the shell; it diverges from some
+//     dotenv parsers only for values that mix ' with other metacharacters.
+//
+// The close-quote backslash-quote reopen trick that shells accept is
+// deliberately avoided: it is shell-correct but unreadable by every mainstream
+// dotenv parser.
+func quoteEnvValue(v string) string {
+	if isBareEnvValue(v) {
+		return v
+	}
+	if !strings.Contains(v, "'") {
+		return "'" + v + "'"
+	}
+
+	var b strings.Builder
+	b.Grow(len(v) + 2)
+	b.WriteByte('"')
+	for i := 0; i < len(v); i++ {
+		c := v[i]
+		if c == '\\' || c == '"' || c == '$' || c == '`' {
+			b.WriteByte('\\')
+		}
+		b.WriteByte(c)
+	}
+	b.WriteByte('"')
+	return b.String()
+}
+
+// hashEnvVars returns a hex-encoded SHA-256 hash of the env vars, stable across
+// runs and safe to embed in image metadata without exposing values. Returns an
+// empty string when there are no env vars.
+//
+// Each key and value is length-prefixed before hashing so no combination of
+// key and value bytes can encode to the same stream as a different map. A
+// delimiter-joined encoding lets a value that contains the delimiter collide
+// with a different set of pairs, and a collision makes BuildKit silently reuse
+// a RUN layer built with stale secrets, the exact failure this hash prevents.
+func hashEnvVars(envVars map[string]string) string {
+	if len(envVars) == 0 {
+		return ""
+	}
+
+	keys := make([]string, 0, len(envVars))
+	for k := range envVars {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	h := sha256.New()
+	for _, k := range keys {
+		v := envVars[k]
+		fmt.Fprintf(h, "%d:%s=%d:%s;", len(k), k, len(v), v)
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}

--- a/svc/ctrl/worker/deploy/env_file_test.go
+++ b/svc/ctrl/worker/deploy/env_file_test.go
@@ -1,0 +1,147 @@
+package deploy
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildEnvFileSecret_Serialization(t *testing.T) {
+	require.Nil(t, buildEnvFileSecret(nil))
+	require.Nil(t, buildEnvFileSecret(map[string]string{}))
+
+	tests := []struct {
+		name string
+		in   map[string]string
+		want string
+	}{
+		{"bare simple value", map[string]string{"FOO": "bar"}, "FOO=bar\n"},
+		{"bare allowlist chars stay unquoted", map[string]string{"URL": "https://a.b/c:1,d=e+f-g_@%.x"}, "URL=https://a.b/c:1,d=e+f-g_@%.x\n"},
+		{"empty value stays bare", map[string]string{"EMPTY": ""}, "EMPTY=\n"},
+		{"spaces force single quoting", map[string]string{"K": "a b"}, "K='a b'\n"},
+		{"dollar forces single quoting", map[string]string{"K": "a$b"}, "K='a$b'\n"},
+		{"hash forces single quoting", map[string]string{"K": "a#b"}, "K='a#b'\n"},
+		{"newline forces single quoting", map[string]string{"K": "a\nb"}, "K='a\nb'\n"},
+		{"double quote uses single quoting", map[string]string{"K": `a"b`}, "K='a\"b'\n"},
+		{"single quote falls back to double quoting", map[string]string{"K": "a'b"}, "K=\"a'b\"\n"},
+		{"keys are emitted in sorted order", map[string]string{"B": "2", "A": "1"}, "A=1\nB=2\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, string(buildEnvFileSecret(tt.in)))
+		})
+	}
+}
+
+// TestBuildEnvFileSecret_DoubleQuoteEscaping pins the exact escaping of the
+// double-quote fallback: only backslash, double quote, dollar, and backtick
+// gain a leading backslash; a literal single quote inside stays bare.
+func TestBuildEnvFileSecret_DoubleQuoteEscaping(t *testing.T) {
+	input := "a'\"$`\\b"
+	want := "\"" + "a" + "'" + "\\\"" + "\\$" + "\\`" + "\\\\" + "b" + "\"" + "\n"
+	require.Equal(t, "K="+want, string(buildEnvFileSecret(map[string]string{"K": input})))
+}
+
+// TestBuildEnvFileSecret_ShellRoundTrip is the load-bearing correctness check:
+// values written to a .env file and sourced by a POSIX shell must come back
+// byte-identical. Sourcing with the documented set -a pattern and dumping each
+// variable NUL-delimited avoids any newline ambiguity in the comparison.
+func TestBuildEnvFileSecret_ShellRoundTrip(t *testing.T) {
+	envVars := map[string]string{
+		"PEM":         "-----BEGIN PRIVATE KEY-----\nMIIabc/def+123==\nghi/JKL+456==\n-----END PRIVATE KEY-----\n",
+		"JSONVAL":     `{"a":"b","nested":{"x":1,"y":[2,3]}}`,
+		"QUOTEDOLLAR": "it's $HOME and `date` cost",
+		"SPACES":      "hello world  two  spaces",
+		"HASHVAL":     "value#notacomment",
+		"BACKSLASH":   `a\b\c\n`,
+		"CRLF":        "line1\r\nline2",
+		"EMPTY":       "",
+		"UNICODE":     "café ☕ 日本語",
+	}
+
+	out := buildEnvFileSecret(envVars)
+	require.NotNil(t, out)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".env")
+	require.NoError(t, os.WriteFile(path, out, 0o600))
+
+	keys := make([]string, 0, len(envVars))
+	for k := range envVars {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var refs strings.Builder
+	for _, k := range keys {
+		refs.WriteString(` "$`)
+		refs.WriteString(k)
+		refs.WriteString(`"`)
+	}
+	script := `set -a; . "$1"; set +a; printf '%s\0'` + refs.String()
+
+	cmd := exec.Command("sh", "-c", script, "sh", path)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	require.NoErrorf(t, cmd.Run(), "sh failed: %s", stderr.String())
+
+	// printf emits a trailing NUL after the final value, so the split yields one
+	// empty trailing element.
+	got := strings.Split(stdout.String(), "\x00")
+	require.Len(t, got, len(keys)+1)
+	require.Equal(t, "", got[len(keys)])
+	for i, k := range keys {
+		require.Equalf(t, envVars[k], got[i], "value for %s did not round-trip through the shell", k)
+	}
+}
+
+// TestBuildEnvFileSecret_DotenvShape asserts every quoted entry matches the
+// quoted alternative of node dotenv's LINE regex rather than its bare fallback,
+// pinning dotenv compatibility without running Node in CI.
+func TestBuildEnvFileSecret_DotenvShape(t *testing.T) {
+	lineRegex := regexp.MustCompile(`(?m)^\s*(?:export\s+)?([\w.-]+)(?:\s*=\s*?|:\s+?)(\s*'(?:\\'|[^'])*'|\s*"(?:\\"|[^"])*"|\s*` + "`" + `(?:\\` + "`" + `|[^` + "`" + `])*` + "`" + `|[^#\r\n]+)?\s*(?:#.*)?$`)
+
+	quotedValues := map[string]string{
+		"PEM":     "-----BEGIN PRIVATE KEY-----\nMIIabc/def+123==\n-----END PRIVATE KEY-----\n",
+		"JSONVAL": `{"a":"b","n":1}`,
+		"SPACES":  "hello world",
+		"HASHVAL": "value#notacomment",
+		"SQUOTE":  "it's fine",
+	}
+	for k, v := range quotedValues {
+		t.Run(k, func(t *testing.T) {
+			entry := strings.TrimRight(string(buildEnvFileSecret(map[string]string{k: v})), "\n")
+			m := lineRegex.FindStringSubmatch(entry)
+			require.NotNilf(t, m, "entry did not match dotenv LINE regex: %q", entry)
+			require.Equal(t, k, m[1], "key capture mismatch")
+
+			valueGroup := m[2]
+			require.NotEmpty(t, valueGroup, "value capture was empty")
+			first := valueGroup[0]
+			require.Truef(t, first == '\'' || first == '"',
+				"value was matched by the bare fallback, not the quoted alternative: %q", valueGroup)
+		})
+	}
+}
+
+func TestHashEnvVars_Unambiguous(t *testing.T) {
+	require.Empty(t, hashEnvVars(nil))
+	require.Empty(t, hashEnvVars(map[string]string{}))
+
+	// A delimiter-joined encoding would let a newline inside one value collide
+	// with a separate key. Length-prefixing keeps them distinct.
+	collidable := hashEnvVars(map[string]string{"A": "1\nB=2"})
+	separate := hashEnvVars(map[string]string{"A": "1", "B": "2"})
+	require.NotEqual(t, collidable, separate)
+
+	// The hash is stable regardless of map iteration order.
+	require.Equal(t, separate, hashEnvVars(map[string]string{"B": "2", "A": "1"}))
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/env-vars/components/add/add-env-var-expandable.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/env-vars/components/add/add-env-var-expandable.tsx
@@ -292,7 +292,6 @@ export const AddEnvVarExpandable = ({
                   isOnly={fields.length === 1}
                   isLast={index === fields.length - 1}
                   register={register}
-                  control={control}
                   onRemove={remove}
                   onPasteEntries={handlePasteEntries}
                   onAdvanceRow={handleAdvanceRow}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/env-vars/components/add/env-var-row.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/env-vars/components/add/env-var-row.tsx
@@ -1,9 +1,8 @@
 import { Plus, Trash } from "@unkey/icons";
-import { Button, FormInput } from "@unkey/ui";
+import { Button, FormInput, FormTextarea } from "@unkey/ui";
 import type { ClipboardEvent, KeyboardEvent } from "react";
 import { useCallback } from "react";
-import type { Control, FieldErrors, UseFormRegister } from "react-hook-form";
-import { useWatch } from "react-hook-form";
+import type { FieldErrors, UseFormRegister } from "react-hook-form";
 import { parseEnvText } from "../../hooks/use-drop-zone";
 import type { EnvVarsFormValues } from "./schema";
 
@@ -11,7 +10,6 @@ type EnvVarRowProps = {
   index: number;
   isOnly: boolean;
   register: UseFormRegister<EnvVarsFormValues>;
-  control: Control<EnvVarsFormValues>;
   onRemove: (index: number) => void;
   onPasteEntries: (index: number, entries: { key: string; value: string }[]) => void;
   onAdvanceRow: () => void;
@@ -24,7 +22,6 @@ export const EnvVarRow = ({
   index,
   isOnly,
   register,
-  control,
   onRemove,
   onPasteEntries,
   onAdvanceRow,
@@ -33,8 +30,6 @@ export const EnvVarRow = ({
   errors,
 }: EnvVarRowProps) => {
   const fieldErrors = errors?.[index];
-  const value = useWatch({ control, name: `envVars.${index}.value` });
-  const hasSpaces = value?.trim().includes(" ");
 
   const handleKeyPaste = useCallback(
     (e: ClipboardEvent<HTMLInputElement>) => {
@@ -63,8 +58,10 @@ export const EnvVarRow = ({
   );
 
   const handleValueKeyDown = useCallback(
-    (e: KeyboardEvent<HTMLInputElement>) => {
-      if (e.key === "Enter" && !e.shiftKey && isLast) {
+    (e: KeyboardEvent<HTMLTextAreaElement>) => {
+      // Plain Enter inserts a newline so multi-line values are typeable;
+      // Cmd/Ctrl+Enter advances to the next row from the last one.
+      if (e.key === "Enter" && (e.metaKey || e.ctrlKey) && isLast) {
         e.preventDefault();
         onAdvanceRow();
       }
@@ -88,13 +85,12 @@ export const EnvVarRow = ({
           onPaste={handleKeyPaste}
           onKeyDown={handleKeyKeyDown}
         />
-        <FormInput
+        <FormTextarea
           label="Value"
-          className="flex-1 [&_input]:font-mono"
+          rows={1}
+          className="flex-1 [&_textarea]:font-mono [&_textarea]:min-h-9 [&_textarea]:max-h-40 [&_textarea]:resize-y [&_textarea]:overflow-y-auto"
           placeholder="value"
           error={fieldErrors?.value?.message}
-          variant={!fieldErrors?.value && hasSpaces ? "warning" : undefined}
-          description={!fieldErrors?.value && hasSpaces ? "Value contains spaces" : undefined}
           {...valueRegistration}
           onKeyDown={handleValueKeyDown}
         />

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/env-vars/components/list/env-var-edit-row.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/env-vars/components/list/env-var-edit-row.tsx
@@ -6,9 +6,9 @@ import { envVarKeySchema, envVarValueSchema } from "@/lib/schemas/env-var";
 import { trpc } from "@/lib/trpc/client";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { CircleInfo, Plus } from "@unkey/icons";
-import { Button, FormInput, InfoTooltip, toast } from "@unkey/ui";
+import { Button, FormInput, FormTextarea, InfoTooltip, toast } from "@unkey/ui";
 import { type ClipboardEvent, useCallback, useEffect } from "react";
-import { Controller, useForm, useWatch } from "react-hook-form";
+import { Controller, useForm } from "react-hook-form";
 import { z } from "zod";
 import { parseEnvText } from "../../hooks/use-drop-zone";
 
@@ -50,9 +50,6 @@ export function EnvVarEditRow({ envVarId, variableKey, type, note, onClose }: En
       sensitive: isWriteonly,
     },
   });
-
-  const watchedValue = useWatch({ control, name: "value" });
-  const hasSpaces = watchedValue?.trim().includes(" ");
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: decryptMutation is not stable
   useEffect(
@@ -142,9 +139,10 @@ export function EnvVarEditRow({ envVarId, variableKey, type, note, onClose }: En
           {...register("key")}
           onPaste={handleKeyPaste}
         />
-        <FormInput
+        <FormTextarea
           label={isWriteonly ? "New Value" : "Value"}
-          className="[&_input]:font-mono"
+          rows={1}
+          className="[&_textarea]:font-mono [&_textarea]:min-h-9 [&_textarea]:max-h-40 [&_textarea]:resize-y [&_textarea]:overflow-y-auto"
           placeholder={
             isWriteonly
               ? "Enter new value to replace"
@@ -154,8 +152,6 @@ export function EnvVarEditRow({ envVarId, variableKey, type, note, onClose }: En
           }
           disabled={decryptMutation.isLoading}
           error={errors.value?.message}
-          variant={!errors.value && hasSpaces ? "warning" : undefined}
-          description={!errors.value && hasSpaces ? "Value contains spaces" : undefined}
           {...register("value")}
         />
         <details className="group" open={Boolean(note)}>

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/env-vars/hooks/use-drop-zone.test.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/env-vars/hooks/use-drop-zone.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { parseEnvText } from "./use-drop-zone";
+
+describe("parseEnvText", () => {
+  it("parses simple key=value pairs and skips blanks and comments", () => {
+    const { entries } = parseEnvText(
+      ["# a comment", "", "FOO=bar", "  BAZ = qux  ", "# trailing comment"].join("\n"),
+    );
+    expect(entries).toEqual([
+      { key: "FOO", value: "bar" },
+      { key: "BAZ", value: "qux" },
+    ]);
+  });
+
+  it("skips lines without an equals sign instead of failing the whole import", () => {
+    const { entries } = parseEnvText(["FOO=bar", "not a pair", "BAZ=qux"].join("\n"));
+    expect(entries).toEqual([
+      { key: "FOO", value: "bar" },
+      { key: "BAZ", value: "qux" },
+    ]);
+  });
+
+  it("strips matching outer quotes from single-line values", () => {
+    const { entries } = parseEnvText(
+      ['DOUBLE="hello world"', "SINGLE='a b c'", "BARE=plain"].join("\n"),
+    );
+    expect(entries).toEqual([
+      { key: "DOUBLE", value: "hello world" },
+      { key: "SINGLE", value: "a b c" },
+      { key: "BARE", value: "plain" },
+    ]);
+  });
+
+  it("accumulates a multi-line double-quoted value until the closing quote", () => {
+    const { entries } = parseEnvText(
+      ['TLS_KEY="-----BEGIN KEY-----', "line-two", '-----END KEY-----"', "NEXT=ok"].join("\n"),
+    );
+    expect(entries).toEqual([
+      { key: "TLS_KEY", value: "-----BEGIN KEY-----\nline-two\n-----END KEY-----" },
+      { key: "NEXT", value: "ok" },
+    ]);
+  });
+
+  it("accumulates a multi-line single-quoted PEM value", () => {
+    const pem = [
+      "PEM='-----BEGIN PRIVATE KEY-----",
+      "MIIabc/def+123==",
+      "-----END PRIVATE KEY-----'",
+    ].join("\n");
+    const { entries } = parseEnvText(pem);
+    expect(entries).toEqual([
+      {
+        key: "PEM",
+        value: "-----BEGIN PRIVATE KEY-----\nMIIabc/def+123==\n-----END PRIVATE KEY-----",
+      },
+    ]);
+  });
+
+  it("takes the rest of the input when a quoted value is never closed", () => {
+    const { entries } = parseEnvText(["KEY='unterminated", "second line"].join("\n"));
+    expect(entries).toEqual([{ key: "KEY", value: "unterminated\nsecond line" }]);
+  });
+
+  it("normalizes CRLF to LF so multi-line values store canonical newlines", () => {
+    const { entries } = parseEnvText('PEM="line1\r\nline2"\r\nNEXT=ok\r\n');
+    expect(entries).toEqual([
+      { key: "PEM", value: "line1\nline2" },
+      { key: "NEXT", value: "ok" },
+    ]);
+  });
+});

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/env-vars/hooks/use-drop-zone.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/env-vars/hooks/use-drop-zone.ts
@@ -5,30 +5,55 @@ import type { EnvVarsFormValues } from "../components/add/schema";
 
 type ParseEnvResult = {
   entries: Array<{ key: string; value: string }>;
-  hasMultilineValues: boolean;
 };
 
+// parseEnvText reads a .env blob into key/value entries. A value that opens
+// with a quote and does not close on the same line is treated as multi-line:
+// following lines are accumulated (joined with LF) until the closing quote,
+// which is how PEM keys and certs paste in. Outer quotes are stripped without
+// escape expansion, matching how the build serializer emits them.
 export const parseEnvText = (text: string): ParseEnvResult => {
-  const lines = text.trim().split("\n");
+  // Normalize CRLF up front so multi-line values store as canonical LF.
+  const lines = text.replace(/\r\n/g, "\n").trim().split("\n");
   const entries: Array<{ key: string; value: string }> = [];
 
-  for (const line of lines) {
-    const trimmed = line.trim();
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].trim();
     if (!trimmed || trimmed.startsWith("#")) {
       continue;
     }
 
     const eqIndex = trimmed.indexOf("=");
     if (eqIndex === -1) {
-      return { entries: [], hasMultilineValues: true };
+      continue;
     }
 
     const key = trimmed.slice(0, eqIndex).trim();
     let value = trimmed.slice(eqIndex + 1).trim();
 
+    const quote = value[0];
+    if ((quote === '"' || quote === "'") && value.indexOf(quote, 1) === -1) {
+      // Opening quote with no closing quote on this line: gather following
+      // lines until one contains the closing quote.
+      const collected = [value.slice(1)];
+      i++;
+      while (i < lines.length) {
+        const closeIndex = lines[i].indexOf(quote);
+        if (closeIndex !== -1) {
+          collected.push(lines[i].slice(0, closeIndex));
+          break;
+        }
+        collected.push(lines[i]);
+        i++;
+      }
+      entries.push({ key, value: collected.join("\n") });
+      continue;
+    }
+
     if (
-      (value.startsWith('"') && value.endsWith('"')) ||
-      (value.startsWith("'") && value.endsWith("'"))
+      value.length >= 2 &&
+      ((value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'")))
     ) {
       value = value.slice(1, -1);
     }
@@ -36,7 +61,7 @@ export const parseEnvText = (text: string): ParseEnvResult => {
     entries.push({ key, value });
   }
 
-  return { entries, hasMultilineValues: false };
+  return { entries };
 };
 
 const isEnvFile = (file: File) =>
@@ -92,13 +117,7 @@ export function useDropZone(
 
   const importText = useCallback(
     (text: string) => {
-      const { entries, hasMultilineValues } = parseEnvText(text);
-      if (hasMultilineValues) {
-        toast.error(
-          "Import failed: multiline values are not supported. Please ensure each variable is on a single line.",
-        );
-        return;
-      }
+      const { entries } = parseEnvText(text);
       if (entries.length > 0) {
         importParsed(entries);
       } else {

--- a/web/apps/dashboard/lib/schemas/env-var.test.ts
+++ b/web/apps/dashboard/lib/schemas/env-var.test.ts
@@ -16,23 +16,34 @@ describe("envVarKeySchema", () => {
 });
 
 describe("envVarValueSchema", () => {
-  it("bounds the value by UTF-8 bytes, not characters, so the encrypted ciphertext cannot overflow the varchar(4096) column", () => {
-    // A 3000-byte ASCII value is the boundary and must pass.
-    expect(envVarValueSchema.safeParse("a".repeat(3000)).success).toBe(true);
-    expect(envVarValueSchema.safeParse("a".repeat(3001)).success).toBe(false);
+  it("bounds the value by UTF-8 bytes, not characters, so the encrypted ciphertext cannot overflow the TEXT column", () => {
+    // A 16384-byte ASCII value is the boundary and must pass.
+    expect(envVarValueSchema.safeParse("a".repeat(16384)).success).toBe(true);
+    expect(envVarValueSchema.safeParse("a".repeat(16385)).success).toBe(false);
 
     // The guarantee that distinguishes this from .max() on string length:
-    // 1500 three-byte characters is only 1500 chars but 4500 bytes, which would
-    // overflow the column. A character-based cap would wrongly accept it.
-    const multibyte = "あ".repeat(1500);
-    expect(multibyte.length).toBe(1500);
-    expect(new TextEncoder().encode(multibyte).length).toBe(4500);
+    // 5462 three-byte characters is only 5462 chars but 16386 bytes, over the
+    // cap. A character-based cap would wrongly accept it.
+    const multibyte = "あ".repeat(5462);
+    expect(multibyte.length).toBe(5462);
+    expect(new TextEncoder().encode(multibyte).length).toBe(16386);
     expect(envVarValueSchema.safeParse(multibyte).success).toBe(false);
   });
 
-  it("still requires a non-empty value and rejects literal newline escapes", () => {
+  it("allows multi-line LF values but rejects carriage returns", () => {
     expect(envVarValueSchema.safeParse("ok").success).toBe(true);
     expect(envVarValueSchema.safeParse("").success).toBe(false);
-    expect(envVarValueSchema.safeParse("line\\nbreak").success).toBe(false);
+
+    // Real LF newlines are allowed so multi-line PEM keys, certs, and JSON pass.
+    expect(envVarValueSchema.safeParse("line1\nline2").success).toBe(true);
+    const pem = "-----BEGIN PRIVATE KEY-----\nMIIabc/def\n-----END PRIVATE KEY-----";
+    expect(envVarValueSchema.safeParse(pem).success).toBe(true);
+
+    // CRLF is rejected so stored values stay canonical LF.
+    expect(envVarValueSchema.safeParse("a\r\nb").success).toBe(false);
+
+    // A literal backslash-n is plain text, not a newline, so it now passes;
+    // the old refine wrongly rejected it while letting real newlines through.
+    expect(envVarValueSchema.safeParse("line\\nbreak").success).toBe(true);
   });
 });

--- a/web/apps/dashboard/lib/schemas/env-var.ts
+++ b/web/apps/dashboard/lib/schemas/env-var.ts
@@ -19,25 +19,29 @@ export const envVarKeySchema = z
   );
 
 // Values are encrypted before storage and the ciphertext lands in
-// app_environment_variables.value (varchar 4096). Vault base64-encodes a
-// protobuf wrapper around the AES-GCM ciphertext, so the encrypted string is
-// roughly 4/3 * (plaintext_bytes + 71). Capping the plaintext at 3000 *bytes*
-// keeps the encrypted output under the 4096 column limit. The budget is in
-// UTF-8 bytes, not characters: a multibyte value (e.g. CJK/emoji) can be far
-// larger in bytes than in characters, so .max() on string length would not
-// protect the column.
-const MAX_ENV_VAR_VALUE_BYTES = 3000;
+// app_environment_variables.value (TEXT, 65,535-byte capacity). Vault
+// base64-encodes a protobuf wrapper around the AES-GCM ciphertext, so the
+// encrypted string is roughly 4/3 * (plaintext_bytes + 71). Capping the
+// plaintext at 16,384 *bytes* keeps the encrypted output near 22 KiB, well
+// inside the column, and covers RSA-4096 keys and typical cert chains. The
+// budget is in UTF-8 bytes, not characters: a multibyte value (e.g. CJK/emoji)
+// can be far larger in bytes than in characters, so .max() on string length
+// would not protect the column.
+const MAX_ENV_VAR_VALUE_BYTES = 16384;
 const utf8Encoder = new TextEncoder();
 
 export const envVarValueSchema = z
   .string()
+  // .trim() strips leading and trailing whitespace, including the trailing
+  // newline a pasted PEM block usually carries. Interior LF newlines are kept
+  // so multi-line values (PEM keys, certs, JSON) round-trip unchanged.
   .trim()
   .min(1, "Variable value is required")
   .refine(
     (val) => utf8Encoder.encode(val).length <= MAX_ENV_VAR_VALUE_BYTES,
     `Variable value must be at most ${MAX_ENV_VAR_VALUE_BYTES} bytes`,
   )
-  .refine(
-    (val) => !val.includes("\\n") && !val.includes("\\r"),
-    "Newline characters are not allowed",
-  );
+  // Reject carriage returns so stored values are canonical LF. A CRLF value
+  // would otherwise store a stray \r that shell sourcing and dotenv parsers
+  // treat inconsistently.
+  .refine((val) => !val.includes("\r"), "Carriage return characters are not allowed");

--- a/web/internal/db/src/schema/app_environment_variables.ts
+++ b/web/internal/db/src/schema/app_environment_variables.ts
@@ -1,5 +1,5 @@
 import { relations } from "drizzle-orm";
-import { bigint, mysqlEnum, mysqlTable, uniqueIndex, varchar } from "drizzle-orm/mysql-core";
+import { bigint, mysqlEnum, mysqlTable, text, uniqueIndex, varchar } from "drizzle-orm/mysql-core";
 import { apps } from "./apps";
 import { environments } from "./environments";
 import { deleteProtection } from "./util/delete_protection";
@@ -17,8 +17,11 @@ export const appEnvironmentVariables = mysqlTable(
 
     key: varchar("key", { length: 256 }).notNull(),
 
-    // Always encrypted via vault (contains keyId, nonce, ciphertext in the blob)
-    value: varchar("value", { length: 4096 }).notNull(),
+    // Always encrypted via vault (contains keyId, nonce, ciphertext in the blob).
+    // TEXT (65,535-byte capacity) so a 16 KiB plaintext cap fits its base64
+    // ciphertext (~22 KiB); RSA-4096 keys and typical cert chains overflow a
+    // varchar(4096) column.
+    value: text("value").notNull(),
 
     // Both types are encrypted in the database
     // - recoverable: can be decrypted and shown in the UI


### PR DESCRIPTION
**Problem:**

I wanted to deploy unkey vault on unkey, we don't have persistent volumes yet so cool lets use the `UNKEY_CONFIG` env var as it should accept a config as a raw string.

Enter said toml file as raw string, doesnt work since we do not allow newlines in env vars. 

**Solution:**

Allow env vars with newlines in both the frontend and extend krane to properly escape them when injecting them to the container and passing them to the user.

As multiline values can be quite long, we've also extended the encrypted db field to a text to accommodate that

**Impact:**

A user can now add multiline env vars and we inject them properly.

**Testing:**

Create a project + app use a multi line env var and read it back in your app it should still be correctly injected.

Addet tests for this, they should pass