### PR TITLE
fix(config): allow for loading config via envar

### DIFF
--- a/build/util/run.go
+++ b/build/util/run.go
@@ -18,7 +18,7 @@ func RunServiceCommand[T any](name string, usage string, run func(context.Contex
 		Name:  name,
 		Usage: usage,
 		Flags: []cli.Flag{
-			cli.String("config", "Path to a TOML config file",
+			cli.String("config", "Path to a TOML config file, or the raw TOML config itself",
 				cli.Default("unkey.toml"), cli.EnvVar("UNKEY_CONFIG")),
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/BurntSushi/toml"
 	"github.com/unkeyed/unkey/pkg/fault"
@@ -17,22 +18,25 @@ type Validator interface {
 	Validate() error
 }
 
-// Load reads a TOML configuration file at path and returns the validated
-// result. Returns the zero value of T on file-read errors; delegates all
-// other behavior (env expansion, defaults, validation) to [LoadBytes].
-func Load[T any](path string) (T, error) {
+// Load resolves a TOML configuration and returns the validated result. The
+// argument is either a filesystem path to a TOML file or the raw TOML document
+// itself, so a service can be configured from a mounted file or from an inline
+// value such as UNKEY_CONFIG. TOML content always contains a key assignment or
+// spans multiple lines while a path never does, so that split distinguishes the
+// two without a sigil. All other behavior (env expansion, defaults, validation)
+// is delegated to [LoadBytes].
+func Load[T any](pathOrContent string) (T, error) {
 	var zero T
 
-	if filepath.Ext(path) != ".toml" {
-		return zero, fault.New("failed to read config: only .toml files are supported")
+	if !strings.ContainsAny(pathOrContent, "=\n") {
+		data, err := os.ReadFile(pathOrContent)
+		if err != nil {
+			return zero, fault.Wrap(err, fault.Internal("failed to read config file: "+pathOrContent))
+		}
+		return LoadBytes[T](data)
 	}
 
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return zero, fault.Wrap(err, fault.Internal("failed to read config file: "+path))
-	}
-
-	return LoadBytes[T](data)
+	return LoadBytes[T]([]byte(pathOrContent))
 }
 
 // LoadBytes parses raw TOML bytes into T, applies defaults, and validates the

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -351,29 +351,46 @@ func TestLoadBytes_ExpandsEnvVars(t *testing.T) {
 	require.Equal(t, "hunter2", got.Secret)
 }
 
-func TestLoad_DetectsFormatFromExtension(t *testing.T) {
-	t.Run("toml extension", func(t *testing.T) {
-		type tomlCfg struct {
-			Host string `toml:"host"`
-		}
+func TestLoad_AcceptsPathOrInlineContent(t *testing.T) {
+	type cfg struct {
+		Host string `toml:"host"`
+	}
+
+	t.Run("reads a .toml file path", func(t *testing.T) {
 		dir := t.TempDir()
 		path := filepath.Join(dir, "config.toml")
 		require.NoError(t, os.WriteFile(path, []byte("host = \"example.com\""), 0o644))
 
-		got, err := Load[tomlCfg](path)
+		got, err := Load[cfg](path)
 		require.NoError(t, err)
 		require.Equal(t, "example.com", got.Host)
 	})
 
-	t.Run("unsupported extension returns error", func(t *testing.T) {
-		type cfg struct {
-			Host string `toml:"host"`
-		}
+	t.Run("reads an extensionless file path", func(t *testing.T) {
 		dir := t.TempDir()
-		path := filepath.Join(dir, "config.txt")
+		path := filepath.Join(dir, "config")
 		require.NoError(t, os.WriteFile(path, []byte("host = \"example.com\""), 0o644))
 
-		_, err := Load[cfg](path)
+		got, err := Load[cfg](path)
+		require.NoError(t, err)
+		require.Equal(t, "example.com", got.Host)
+	})
+
+	t.Run("parses inline TOML content", func(t *testing.T) {
+		got, err := Load[cfg]("host = \"example.com\"")
+		require.NoError(t, err)
+		require.Equal(t, "example.com", got.Host)
+	})
+
+	t.Run("parses multi-line inline TOML content", func(t *testing.T) {
+		got, err := Load[cfg]("# comment\nhost = \"example.com\"\n")
+		require.NoError(t, err)
+		require.Equal(t, "example.com", got.Host)
+	})
+
+	t.Run("missing file path returns error", func(t *testing.T) {
+		dir := t.TempDir()
+		_, err := Load[cfg](filepath.Join(dir, "does-not-exist.toml"))
 		require.Error(t, err)
 	})
 }

--- a/pkg/config/doc.go
+++ b/pkg/config/doc.go
@@ -48,6 +48,11 @@
 //
 //	cfg, err := config.Load[Config]("/etc/unkey/api.toml")
 //
+// [Load] also accepts the raw TOML document in place of a path, so operators can
+// pass configuration inline through UNKEY_CONFIG rather than mounting a file:
+//
+//	cfg, err := config.Load[Config](os.Getenv("UNKEY_CONFIG"))
+//
 // For programmatic use or testing, [LoadBytes] accepts raw TOML bytes directly:
 //
 //	cfg, err := config.LoadBytes[Config](data)


### PR DESCRIPTION
Problem:

All of our applications require a config but when you dont have a filesystem to write files too persistently you cannot run them.

This allows passing the config as env var and we successfully parse this now. 

Solution:

We check if the passed in value of UNKEY_CONFIG looks like a config instead of an path, and if it does we dont parse the path but try to parse the toml.

Impact:

None, the new path should work and the passing in a filepath should continue to work too.

Testing:

Unit tests