### PR TITLE
fix: newline validation in env var value schema to catch real newlines.

### DIFF
--- a/web/apps/dashboard/lib/schemas/env-var.test.ts
+++ b/web/apps/dashboard/lib/schemas/env-var.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { z } from "zod";
 import { envVarKeySchema, envVarValueSchema } from "./env-var";
 
 describe("envVarKeySchema", () => {
@@ -30,9 +31,60 @@ describe("envVarValueSchema", () => {
     expect(envVarValueSchema.safeParse(multibyte).success).toBe(false);
   });
 
-  it("still requires a non-empty value and rejects literal newline escapes", () => {
+  it("still requires a non-empty value", () => {
     expect(envVarValueSchema.safeParse("ok").success).toBe(true);
     expect(envVarValueSchema.safeParse("").success).toBe(false);
-    expect(envVarValueSchema.safeParse("line\\nbreak").success).toBe(false);
+  });
+
+  it("rejects embedded newlines, which would corrupt the .env file the build shell-sources", () => {
+    expect(envVarValueSchema.safeParse("line\nbreak").success).toBe(false);
+    expect(envVarValueSchema.safeParse("line\rbreak").success).toBe(false);
+    expect(envVarValueSchema.safeParse("line\r\nbreak").success).toBe(false);
+
+    // A multi-line PEM key is the realistic case: it passed validation before,
+    // then failed the build as a non-retryable terminal error.
+    const pem = "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADAN\n-----END PRIVATE KEY-----";
+    expect(envVarValueSchema.safeParse(pem).success).toBe(false);
+  });
+
+  it("tells the user to replace the value, since an <input> hides the newlines being complained about", () => {
+    // Values with real newlines predate this check, so the edit row can load one
+    // and reject it. The input strips CR/LF from display, so a message stating
+    // only the rule would point at a field that looks clean.
+    const parsed = envVarValueSchema.safeParse("line\nbreak");
+    expect(parsed.success).toBe(false);
+    expect(parsed.success === false && parsed.error.issues[0].message).toBe(
+      "Newline characters are not allowed. Replace this with a single-line value.",
+    );
+  });
+
+  it("keeps that message intact through the .or(literal('')) union the edit row composes", () => {
+    // The edit row (env-var-edit-row.tsx) wraps this schema in a union to allow
+    // an untouched empty field. A union whose branches all fail can report a
+    // generic "Invalid input" instead of the branch's own message, which would
+    // strand the replacement instruction in the one UI that most needs it.
+    const editRowValueSchema = envVarValueSchema.or(z.literal(""));
+
+    expect(editRowValueSchema.safeParse("").success).toBe(true);
+
+    const parsed = editRowValueSchema.safeParse("line\nbreak");
+    expect(parsed.success).toBe(false);
+    expect(parsed.success === false && parsed.error.issues[0].message).toBe(
+      "Newline characters are not allowed. Replace this with a single-line value.",
+    );
+  });
+
+  it("accepts the two-character sequence \\n, which is not a newline", () => {
+    // These were wrongly rejected with "Newline characters are not allowed"
+    // because the check tested for a literal backslash followed by n.
+    expect(envVarValueSchema.safeParse("C:\\new\\folder").success).toBe(true);
+    expect(envVarValueSchema.safeParse("split on \\n").success).toBe(true);
+    expect(envVarValueSchema.safeParse('{"sep":"\\r\\n"}').success).toBe(true);
+  });
+
+  it("accepts values whose only newlines are leading or trailing, since trim removes them", () => {
+    const parsed = envVarValueSchema.safeParse("\n  token  \n");
+    expect(parsed.success).toBe(true);
+    expect(parsed.success && parsed.data).toBe("token");
   });
 });

--- a/web/apps/dashboard/lib/schemas/env-var.ts
+++ b/web/apps/dashboard/lib/schemas/env-var.ts
@@ -37,7 +37,24 @@ export const envVarValueSchema = z
     (val) => utf8Encoder.encode(val).length <= MAX_ENV_VAR_VALUE_BYTES,
     `Variable value must be at most ${MAX_ENV_VAR_VALUE_BYTES} bytes`,
   )
+  // Builds serialize env vars into a line-oriented .env file that the Dockerfile
+  // shell-sources, so an embedded newline corrupts the format. Nothing rejects
+  // this on write: the v2 setEnvironmentVariables handler encrypts and stores
+  // the value unexamined, and buildEnvFileSecret in svc/ctrl/worker/deploy/
+  // build.go only sees it at deploy time, where it fails as a non-retryable
+  // terminal error. So this is not a client mirror of a server rule: it is the
+  // only pre-build guard, and only on the dashboard path. Values written through
+  // the API still reach the build unchecked.
+  //
+  // Matches actual 0x0A/0x0D, not the two-character sequence \n, which is
+  // legitimate in Windows paths and regexes. .trim() above already removes
+  // leading and trailing newlines, so only embedded ones reach here.
+  //
+  // The message names replacement because values with real newlines predate this
+  // check: an <input> strips CR/LF from display, so in the edit row the rejected
+  // characters are invisible and the rule alone would point at a clean-looking
+  // field.
   .refine(
-    (val) => !val.includes("\\n") && !val.includes("\\r"),
-    "Newline characters are not allowed",
+    (val) => !/[\n\r]/.test(val),
+    "Newline characters are not allowed. Replace this with a single-line value.",
   );


### PR DESCRIPTION
> [!IMPORTANT]
> Unkey is not accepting external pull requests at this time. Pull requests from people outside the Unkey team will not be reviewed or merged.

## What does this PR do?

envVarValueSchema checked val.includes("\\n"), which matches a literal backslash followed by n, not a newline (0x0A). The check was the exact inverse of its stated intent: real multi-line values like a pasted PEM key passed validation, while legitimate values containing a literal backslash-n — Windows paths like C:\new\folder, regexes, JSON blobs — were rejected with the misleading message "Newline characters are not allowed." This fixes the refine to match actual 0x0A/0x0D characters.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

ENG-3062

_If there is not an issue for this, create one first. This is used for tracking purposes and helps us understand why this PR exists._

<!-- If there isn't an issue for this PR, review the internal workflow guide and create an issue. -->

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- 9 unit tests in web/apps/dashboard/lib/schemas/env-var.test.ts, covering real \n/\r/\r\n and a multi-line PEM (rejected); literal backslash-n values (accepted); leading/trailing newlines (accepted, since .trim() strips them); and the exact error message text.

- Add new line characters and see if they are rejected
- Add a variable with value C:\new\folder, and another with split on \n.

## Checklist

<!-- Complete this checklist before requesting review. -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [x] Ran `mise run fmt`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary
