### PR TITLE
feat(billing): add webhooks url for prod/canary

### DIFF
--- a/tools/pricing/.env.example
+++ b/tools/pricing/.env.example
@@ -8,6 +8,13 @@ AWS_PROFILE_SANDBOX=
 AWS_PROFILE_CANARY=
 AWS_PROFILE_PRODUCTION=
 
+# Vercel "Protection Bypass for Automation" secret, per environment, for
+# webhook hosts behind Vercel deployment protection (currently the canary
+# dashboard). Generate it in the Vercel project under Settings > Deployment
+# Protection > Protection Bypass for Automation; the tool appends it to the
+# Stripe delivery URL as ?x-vercel-protection-bypass=...
+VERCEL_PROTECTION_BYPASS_CANARY=
+
 # Optional overrides (defaults shown):
 # AWS_SSO_SESSION=unkey   # `aws sso login --sso-session <this>`
 # AWS_REGION=us-east-1

--- a/tools/pricing/README.md
+++ b/tools/pricing/README.md
@@ -22,6 +22,12 @@ price, transfers the `lookup_key` onto it, and archives the old one.
 - **API products**: the legacy licensed API tiers and add-ons, with quota
   metadata.
 - **Webhook endpoints**: per environment, declared in [`webhooks.go`](./webhooks.go).
+  A host behind Vercel deployment protection (the canary dashboard) needs the
+  project's "Protection Bypass for Automation" secret in
+  `VERCEL_PROTECTION_BYPASS_<ENV>` (via `.env`); the tool appends it to the
+  delivery URL as a query parameter, since Stripe cannot send headers. Endpoints
+  are matched by base URL ignoring the query string, and a URL update keeps the
+  existing signing secret.
 
 Identity is the `lookup_key` for prices, and `managed_by=unkey-pricing` plus a
 `pricing_key` for products. The tool never keys off the Stripe-generated id.

--- a/tools/pricing/internal/reconcile/reconcile.go
+++ b/tools/pricing/internal/reconcile/reconcile.go
@@ -254,6 +254,14 @@ func (r *reconciler) ensureAPIProduct(a pricing.APIProduct) error {
 // ── Webhooks ─────────────────────────────────────────────────────────────────
 
 func (r *reconciler) ensureWebhook(w pricing.Webhook) error {
+	// The delivery URL may carry the Vercel bypass secret; change lines and
+	// errors only ever show the base URL so the secret stays out of terminal
+	// output and CI logs.
+	deliveryURL, err := w.DeliveryURL(r.sc.VercelBypass)
+	if err != nil {
+		return err
+	}
+
 	existing := r.webhookByURL(w.URL)
 	if existing == nil {
 		r.result.add(Change{ActionCreate, "webhook", w.Key, w.URL})
@@ -261,7 +269,7 @@ func (r *reconciler) ensureWebhook(w pricing.Webhook) error {
 			return nil
 		}
 		created, err := r.sc.V1WebhookEndpoints.Create(r.ctx, &stripe.WebhookEndpointCreateParams{
-			URL:           stripe.String(w.URL),
+			URL:           stripe.String(deliveryURL),
 			EnabledEvents: stripe.StringSlice(w.EnabledEvents),
 			Description:   stripe.String(w.Description),
 		})
@@ -274,15 +282,26 @@ func (r *reconciler) ensureWebhook(w pricing.Webhook) error {
 		return nil
 	}
 
-	if sameStringSet(existing.EnabledEvents, w.EnabledEvents) {
+	// The URL differs when the bypass parameter is missing, stale, or no longer
+	// wanted. Updating the matched endpoint in place keeps its signing secret,
+	// so the app's STRIPE_WEBHOOK_SECRET stays valid.
+	var fields []string
+	if existing.URL != deliveryURL {
+		fields = append(fields, "url")
+	}
+	if !sameStringSet(existing.EnabledEvents, w.EnabledEvents) {
+		fields = append(fields, "enabled_events")
+	}
+	if len(fields) == 0 {
 		r.result.add(Change{ActionNoop, "webhook", w.Key, w.URL})
 		return nil
 	}
-	r.result.add(Change{ActionUpdate, "webhook", w.Key, "enabled_events"})
+	r.result.add(Change{ActionUpdate, "webhook", w.Key, strings.Join(fields, ", ")})
 	if !r.apply {
 		return nil
 	}
-	_, err := r.sc.V1WebhookEndpoints.Update(r.ctx, existing.ID, &stripe.WebhookEndpointUpdateParams{
+	_, err = r.sc.V1WebhookEndpoints.Update(r.ctx, existing.ID, &stripe.WebhookEndpointUpdateParams{
+		URL:           stripe.String(deliveryURL),
 		EnabledEvents: stripe.StringSlice(w.EnabledEvents),
 		Description:   stripe.String(w.Description),
 	})

--- a/tools/pricing/internal/reconcile/stripe.go
+++ b/tools/pricing/internal/reconcile/stripe.go
@@ -5,6 +5,8 @@ package reconcile
 // price, transfer its lookup_key, archive the old one. Never delete.
 
 import (
+	"strings"
+
 	"github.com/stripe/stripe-go/v86"
 
 	"github.com/unkeyed/unkey/tools/pricing"
@@ -94,8 +96,10 @@ func (r *reconciler) loadSnapshot() error {
 		if err != nil {
 			return err
 		}
-		if _, ok := s.webhooksByURL[w.URL]; !ok {
-			s.webhooksByURL[w.URL] = w
+		// Keyed by base URL: query parameters (the Vercel bypass secret) are
+		// mutable delivery details, not identity.
+		if _, ok := s.webhooksByURL[baseURL(w.URL)]; !ok {
+			s.webhooksByURL[baseURL(w.URL)] = w
 		}
 	}
 
@@ -133,7 +137,16 @@ func (r *reconciler) apiProductByKeyOrName(a pricing.APIProduct) *stripe.Product
 }
 
 func (r *reconciler) webhookByURL(url string) *stripe.WebhookEndpoint {
-	return r.snap.webhooksByURL[url]
+	return r.snap.webhooksByURL[baseURL(url)]
+}
+
+// baseURL strips the query string; webhook identity ignores it (see the
+// Webhook doc in the pricing package).
+func baseURL(u string) string {
+	if i := strings.Index(u, "?"); i >= 0 {
+		return u[:i]
+	}
+	return u
 }
 
 // ── Writes ───────────────────────────────────────────────────────────────────

--- a/tools/pricing/internal/stripeenv/client.go
+++ b/tools/pricing/internal/stripeenv/client.go
@@ -36,6 +36,13 @@ func awsProfileEnvVar(env pricing.Environment) string {
 	return "AWS_PROFILE_" + strings.ToUpper(string(env))
 }
 
+// vercelBypassEnvVar is the per-environment Vercel "Protection Bypass for
+// Automation" secret variable, e.g. VERCEL_PROTECTION_BYPASS_CANARY. Like the
+// AWS profiles it is deployment-specific and lives in the untracked .env.
+func vercelBypassEnvVar(env pricing.Environment) string {
+	return "VERCEL_PROTECTION_BYPASS_" + strings.ToUpper(string(env))
+}
+
 // awsProfile resolves the per-account AWS profile for env, used for the Secrets
 // Manager call. Names like unkey-<account>-<role> are deployment-specific, so
 // none is baked into the source. Resolution order:
@@ -82,6 +89,11 @@ func region() string {
 type Client struct {
 	*stripe.Client
 	Env pricing.Environment
+	// VercelBypass is the Protection Bypass for Automation secret for this
+	// environment's Vercel-protected webhook hosts, from
+	// VERCEL_PROTECTION_BYPASS_<ENV>. Empty when unset; reconcile errors only
+	// when a protected endpoint actually needs it.
+	VercelBypass string
 }
 
 // New builds a Stripe client for env. The key is sourced as:
@@ -104,7 +116,11 @@ func New(ctx context.Context, env pricing.Environment) (*Client, error) {
 	if err := guardKeyMatchesEnv(key, env); err != nil {
 		return nil, err
 	}
-	return &Client{Client: stripe.NewClient(key), Env: env}, nil
+	return &Client{
+		Client:       stripe.NewClient(key),
+		Env:          env,
+		VercelBypass: strings.TrimSpace(os.Getenv(vercelBypassEnvVar(env))),
+	}, nil
 }
 
 func resolveKey(ctx context.Context, env pricing.Environment) (string, error) {

--- a/tools/pricing/pricing_test.go
+++ b/tools/pricing/pricing_test.go
@@ -142,6 +142,43 @@ func TestAPIProductRates(t *testing.T) {
 	}
 }
 
+// TestWebhookDeliveryURL pins the Vercel bypass behavior: protected endpoints
+// require a secret and get it appended query-escaped; everything else delivers
+// to the bare URL. Production hosts are public, so nothing there may be marked
+// protected without a deliberate catalog change.
+func TestWebhookDeliveryURL(t *testing.T) {
+	for _, w := range Webhooks(EnvProduction) {
+		if w.VercelProtected {
+			t.Errorf("production webhook %q marked VercelProtected", w.Key)
+		}
+	}
+
+	for _, w := range Webhooks(EnvCanary) {
+		if w.Key != "dashboard" {
+			got, err := w.DeliveryURL("ignored")
+			if err != nil || got != w.URL {
+				t.Errorf("webhook %q delivery = %q, %v; want bare URL", w.Key, got, err)
+			}
+			continue
+		}
+
+		if !w.VercelProtected {
+			t.Fatal("canary dashboard webhook must be VercelProtected")
+		}
+		if _, err := w.DeliveryURL(""); err == nil {
+			t.Error("protected endpoint without a secret must error, not fall back to the bare URL")
+		}
+		got, err := w.DeliveryURL("s3cret/+value")
+		if err != nil {
+			t.Fatalf("DeliveryURL: %v", err)
+		}
+		want := w.URL + "?x-vercel-protection-bypass=s3cret%2F%2Bvalue"
+		if got != want {
+			t.Errorf("delivery URL = %q, want %q", got, want)
+		}
+	}
+}
+
 func TestNoDuplicateKeys(t *testing.T) {
 	c := Desired()
 	seen := map[string]bool{}

--- a/tools/pricing/webhooks.go
+++ b/tools/pricing/webhooks.go
@@ -1,5 +1,10 @@
 package pricing
 
+import (
+	"fmt"
+	"net/url"
+)
+
 // Environment identifies a target Stripe account or sandbox. The plan/meter/API
 // catalog is identical across environments; only webhook endpoints differ.
 type Environment string
@@ -10,14 +15,41 @@ const (
 	EnvSandbox    Environment = "sandbox"
 )
 
-// Webhook is a Stripe webhook endpoint. Identity is the URL: reconcile matches
-// an existing endpoint by URL rather than creating a duplicate, which would add
-// a second signing secret and double-deliver every event.
+// Webhook is a Stripe webhook endpoint. Identity is the URL without its query
+// string: reconcile matches an existing endpoint by base URL rather than
+// creating a duplicate, which would add a second signing secret and
+// double-deliver every event. Query parameters (the Vercel bypass secret) are
+// updated in place on the matched endpoint, which keeps its signing secret.
 type Webhook struct {
 	Key           string // dashboard | control
-	URL           string
+	URL           string // base URL, no query string
 	Description   string
 	EnabledEvents []string
+	// VercelProtected marks a host behind Vercel deployment protection, which
+	// rejects requests before they reach the handler. Stripe cannot send custom
+	// headers, so delivery needs the protection-bypass secret as a query
+	// parameter (see DeliveryURL).
+	VercelProtected bool
+}
+
+// VercelBypassParam is the query parameter Vercel accepts its "Protection
+// Bypass for Automation" secret on, for callers that cannot set headers.
+const VercelBypassParam = "x-vercel-protection-bypass"
+
+// DeliveryURL is the URL Stripe delivers to: the base URL, plus the bypass
+// secret for Vercel-protected hosts. The secret is deployment-local
+// configuration (VERCEL_PROTECTION_BYPASS_<ENV> in tools/pricing/.env), never
+// source. A protected endpoint without a secret is an error rather than a
+// fallback to the bare URL, so an apply can never silently strip the parameter
+// off a live endpoint and break delivery.
+func (w Webhook) DeliveryURL(vercelBypassSecret string) (string, error) {
+	if !w.VercelProtected {
+		return w.URL, nil
+	}
+	if vercelBypassSecret == "" {
+		return "", fmt.Errorf("%s is behind Vercel deployment protection: set VERCEL_PROTECTION_BYPASS_<ENV> in tools/pricing/.env (see .env.example)", w.URL)
+	}
+	return w.URL + "?" + VercelBypassParam + "=" + url.QueryEscape(vercelBypassSecret), nil
 }
 
 // DashboardWebhookEvents are the events the Next.js dashboard billing handler
@@ -30,15 +62,23 @@ var DashboardWebhookEvents = []string{
 	"invoice.payment_succeeded",
 }
 
+// ControlWebhookEvents are the events the Go control-plane billing handler
+// (svc/ctrl/api/webhooks/stripe/stripe.go) acts on. Keep in sync.
+var ControlWebhookEvents = []string{
+	"invoice.created",
+}
+
 // Webhooks returns the endpoints desired for env.
 //
-// Only production has a stable public host. Sandbox and canary have no
-// per-account host (previews get generated names), so they declare no endpoint;
-// point one at a preview deploy out of band when you need to test there.
+// Production and canary have stable public hosts; sandbox has no per-account
+// host (previews get generated names), so it declares no endpoint — point one
+// at a preview deploy out of band when you need to test there.
 //
-// The control-plane endpoint is omitted until the Go control-plane Stripe
-// handler ships: enabling it earlier makes Stripe retry against a 404 and
-// eventually disable the endpoint.
+// The control-plane handler serves /webhooks/stripe (no /api prefix, unlike
+// the dashboard) and only registers the route once its stripe secrets are
+// configured. Don't apply a control endpoint before the handler is live at
+// that host: Stripe retries against the 404 and eventually disables the
+// endpoint.
 func Webhooks(env Environment) []Webhook {
 	switch env {
 	case EnvProduction:
@@ -47,6 +87,24 @@ func Webhooks(env Environment) []Webhook {
 			URL:           "https://app.unkey.com/api/webhooks/stripe",
 			Description:   "Unkey dashboard Stripe webhook (managed by unkey-pricing)",
 			EnabledEvents: DashboardWebhookEvents,
+		}, {
+			Key:           "control",
+			URL:           "https://control.unkey.cloud/webhooks/stripe",
+			Description:   "Unkey control-plane Stripe webhook (managed by unkey-pricing)",
+			EnabledEvents: ControlWebhookEvents,
+		}}
+	case EnvCanary:
+		return []Webhook{{
+			Key:             "dashboard",
+			URL:             "https://app.unkey-canary.com/api/webhooks/stripe",
+			Description:     "Unkey canary dashboard Stripe webhook (managed by unkey-pricing)",
+			EnabledEvents:   DashboardWebhookEvents,
+			VercelProtected: true,
+		}, {
+			Key:           "control",
+			URL:           "https://control.unkey-canary.com/webhooks/stripe",
+			Description:   "Unkey canary control-plane Stripe webhook (managed by unkey-pricing)",
+			EnabledEvents: ControlWebhookEvents,
 		}}
 	default:
 		return nil


### PR DESCRIPTION
### Problem:

Stripe cant deliver events to the canary dashboard as it run under vercel deployment protection

### Solution:

Allow us to specify the `x-vercel-protection-bypass` url param in the webhook url so stripe bypasses it.

### Impact:

None

### Testing:

Canary webhooks in our development stripe account succeed.