### PR TITLE
refactor(api, ctrl): use shared gating against preconditions

### DIFF
--- a/docs/product/errors/unkey/application/deployment_no_current.mdx
+++ b/docs/product/errors/unkey/application/deployment_no_current.mdx
@@ -11,7 +11,7 @@ description: "The app has no current deployment, so there is nothing to promote 
     "requestId": "req_2c9a0jf23l4k567"
   },
   "error": {
-    "detail": "The app has no current deployment to promote over.",
+    "detail": "The app has no current deployment.",
     "status": 412,
     "title": "Precondition Failed",
     "type": "https://unkey.com/docs/errors/unkey/application/deployment_no_current"

--- a/docs/product/errors/unkey/application/deployment_not_production.mdx
+++ b/docs/product/errors/unkey/application/deployment_not_production.mdx
@@ -11,7 +11,7 @@ description: "Promote and rollback change the app's current production deploymen
     "requestId": "req_2c9a0jf23l4k567"
   },
   "error": {
-    "detail": "Only production deployments can be promoted.",
+    "detail": "Only production deployments can be promoted or rolled back.",
     "status": 412,
     "title": "Precondition Failed",
     "type": "https://unkey.com/docs/errors/unkey/application/deployment_not_production"

--- a/pkg/deploy/deploygate/deploygate.go
+++ b/pkg/deploy/deploygate/deploygate.go
@@ -11,23 +11,46 @@ import "github.com/unkeyed/unkey/pkg/db"
 // promote/rollback require it, stop/start reject it.
 const envProduction = "production"
 
-// Input is a deployment's lifecycle-relevant state, typed to the pkg/db enums:
-// the API passes its db row fields directly, ctrl converts from its own db
-// package at the boundary. Fields unused by a check (the current-pointer fields
-// for stop/start) may be left zero.
-type Input struct {
+// Each check takes its own input holding exactly the fields it needs. Status and
+// DesiredState are typed to the pkg/db enums: the API passes its db row fields
+// directly, ctrl converts from its own db package at the boundary.
+
+// PromoteInput is the state CheckPromoteTarget needs.
+type PromoteInput struct {
 	Status              db.DeploymentsStatus
 	DesiredState        db.DeploymentsDesiredState
 	EnvironmentSlug     string
 	CurrentDeploymentID string
 	DeploymentID        string
 	IsRolledBack        bool
-	SpendSuspended      bool
 }
 
-// isCurrent reports whether this deployment is the app's current (live) one.
-func (in Input) isCurrent() bool {
-	return in.CurrentDeploymentID != "" && in.CurrentDeploymentID == in.DeploymentID
+// RollbackInput is the state CheckRollbackTarget needs.
+type RollbackInput struct {
+	Status              db.DeploymentsStatus
+	DesiredState        db.DeploymentsDesiredState
+	EnvironmentSlug     string
+	CurrentDeploymentID string
+	DeploymentID        string
+}
+
+// StopInput is the state CheckStoppable needs.
+type StopInput struct {
+	Status          db.DeploymentsStatus
+	DesiredState    db.DeploymentsDesiredState
+	EnvironmentSlug string
+}
+
+// StartInput is the state CheckStartable needs.
+type StartInput struct {
+	DesiredState    db.DeploymentsDesiredState
+	EnvironmentSlug string
+	SpendSuspended  bool
+}
+
+// isCurrent reports whether the target is the app's current (live) deployment.
+func isCurrent(currentDeploymentID, deploymentID string) bool {
+	return currentDeploymentID != "" && currentDeploymentID == deploymentID
 }
 
 // PromotionReason is why a deployment fails a promote/rollback precondition.
@@ -68,15 +91,19 @@ func (r PromotionReason) Message() string {
 // deployment must be ready, running (not draining), in production, and its app
 // must already have a current deployment. Order matters — it is the order every
 // layer reports failures in.
-func promotionCore(in Input) PromotionReason {
+func promotionCore(
+	status db.DeploymentsStatus,
+	desiredState db.DeploymentsDesiredState,
+	environmentSlug, currentDeploymentID string,
+) PromotionReason {
 	switch {
-	case in.Status != db.DeploymentsStatusReady:
+	case status != db.DeploymentsStatusReady:
 		return PromotionNotReady
-	case in.DesiredState != db.DeploymentsDesiredStateRunning:
+	case desiredState != db.DeploymentsDesiredStateRunning:
 		return PromotionDraining
-	case in.EnvironmentSlug != envProduction:
+	case environmentSlug != envProduction:
 		return PromotionNotProduction
-	case in.CurrentDeploymentID == "":
+	case currentDeploymentID == "":
 		return PromotionNoCurrentDeployment
 	default:
 		return PromotionOK
@@ -86,11 +113,16 @@ func promotionCore(in Input) PromotionReason {
 // CheckPromoteTarget validates a deployment may be promoted to current.
 // Promoting the deployment that is already current is rejected, unless the app
 // is in a rolled-back state (then it is a rollback confirmation, allowed).
-func CheckPromoteTarget(in Input) PromotionReason {
-	if r := promotionCore(in); r != PromotionOK {
+func CheckPromoteTarget(in PromoteInput) PromotionReason {
+	if r := promotionCore(
+		in.Status,
+		in.DesiredState,
+		in.EnvironmentSlug,
+		in.CurrentDeploymentID,
+	); r != PromotionOK {
 		return r
 	}
-	if in.isCurrent() && !in.IsRolledBack {
+	if isCurrent(in.CurrentDeploymentID, in.DeploymentID) && !in.IsRolledBack {
 		return PromotionAlreadyCurrent
 	}
 	return PromotionOK
@@ -98,11 +130,16 @@ func CheckPromoteTarget(in Input) PromotionReason {
 
 // CheckRollbackTarget validates a deployment may be rolled back to. Rolling back
 // to the deployment that is already current is always a no-op, so it is rejected.
-func CheckRollbackTarget(in Input) PromotionReason {
-	if r := promotionCore(in); r != PromotionOK {
+func CheckRollbackTarget(in RollbackInput) PromotionReason {
+	if r := promotionCore(
+		in.Status,
+		in.DesiredState,
+		in.EnvironmentSlug,
+		in.CurrentDeploymentID,
+	); r != PromotionOK {
 		return r
 	}
-	if in.isCurrent() {
+	if isCurrent(in.CurrentDeploymentID, in.DeploymentID) {
 		return PromotionAlreadyCurrent
 	}
 	return PromotionOK
@@ -137,7 +174,7 @@ func (r StopReason) Message() string {
 // CheckStoppable validates a deployment may be stopped: it must be running
 // (ready with a running desired state) and not in production. Order matches the
 // order every layer reports failures in.
-func CheckStoppable(in Input) StopReason {
+func CheckStoppable(in StopInput) StopReason {
 	switch {
 	case in.Status != db.DeploymentsStatusReady:
 		return StopNotRunning
@@ -184,7 +221,7 @@ func (r StartReason) Message() string {
 // any deployment whose intent is stopped (including one still draining), which
 // is what the ctrl service and worker enforce. Starting resumes compute spend,
 // so a workspace suspended by its spend cap is refused last.
-func CheckStartable(in Input) StartReason {
+func CheckStartable(in StartInput) StartReason {
 	switch {
 	case in.DesiredState != db.DeploymentsDesiredStateStopped:
 		return StartNotStopped

--- a/pkg/deploy/deploygate/deploygate.go
+++ b/pkg/deploy/deploygate/deploygate.go
@@ -1,0 +1,199 @@
+// Package deploygate holds the deployment lifecycle preconditions shared by the
+// three layers that each enforce them: the public API handlers, the ctrl RPC
+// services, and the ctrl Restate workflows. Centralizing the invariant here is
+// what stops the three copies from drifting — a promote that is legal at the API
+// is legal at the worker, by construction.
+//
+// Callers pass the deployment's fields as primitives (the API and ctrl use
+// different generated db packages, so the typed enums cannot be shared) and map
+// the returned reason onto their own error surface.
+package deploygate
+
+// These mirror the deployment enum string values. A test pins them to the
+// db-generated constants so a schema rename cannot silently weaken the gates.
+const (
+	statusReady    = "ready"
+	statusStopped  = "stopped"
+	desiredRunning = "running"
+	desiredStopped = "stopped"
+	envProduction  = "production"
+)
+
+// Input is a deployment's lifecycle-relevant state. Callers fill it from their
+// own db row; unused fields (e.g. the live-pointer fields for stop/start) may be
+// left zero.
+type Input struct {
+	Status               string
+	DesiredState         string
+	EnvironmentSlug      string
+	HasCurrentDeployment bool
+	CurrentDeploymentID  string
+	DeploymentID         string
+	IsRolledBack         bool
+}
+
+// isCurrent reports whether this deployment is the app's current (live) one.
+func (in Input) isCurrent() bool {
+	return in.HasCurrentDeployment && in.CurrentDeploymentID == in.DeploymentID
+}
+
+// PromotionReason is why a deployment fails a promote/rollback precondition.
+// PromotionOK means it is eligible to become the app's current deployment.
+type PromotionReason int
+
+const (
+	PromotionOK PromotionReason = iota
+	PromotionNotReady
+	PromotionDraining
+	PromotionNotProduction
+	PromotionNoCurrentDeployment
+	PromotionAlreadyCurrent
+)
+
+// Message returns a caller-facing explanation. It is deliberately generic across
+// promote and rollback so both surface identical wording.
+func (r PromotionReason) Message() string {
+	switch r {
+	case PromotionOK:
+		return ""
+	case PromotionNotReady:
+		return "The deployment is not ready."
+	case PromotionDraining:
+		return "The deployment is shutting down and cannot serve traffic."
+	case PromotionNotProduction:
+		return "Only production deployments can be promoted or rolled back."
+	case PromotionNoCurrentDeployment:
+		return "The app has no current deployment."
+	case PromotionAlreadyCurrent:
+		return "The deployment is already the current deployment."
+	default:
+		return ""
+	}
+}
+
+// promotionCore holds the preconditions common to promote and rollback: the
+// deployment must be ready, running (not draining), in production, and its app
+// must already have a current deployment. Order matters — it is the order every
+// layer reports failures in.
+func promotionCore(in Input) PromotionReason {
+	switch {
+	case in.Status != statusReady:
+		return PromotionNotReady
+	case in.DesiredState != desiredRunning:
+		return PromotionDraining
+	case in.EnvironmentSlug != envProduction:
+		return PromotionNotProduction
+	case !in.HasCurrentDeployment:
+		return PromotionNoCurrentDeployment
+	default:
+		return PromotionOK
+	}
+}
+
+// CheckPromoteTarget validates a deployment may be promoted to current.
+// Promoting the deployment that is already current is rejected, unless the app
+// is in a rolled-back state (then it is a rollback confirmation, allowed).
+func CheckPromoteTarget(in Input) PromotionReason {
+	if r := promotionCore(in); r != PromotionOK {
+		return r
+	}
+	if in.isCurrent() && !in.IsRolledBack {
+		return PromotionAlreadyCurrent
+	}
+	return PromotionOK
+}
+
+// CheckRollbackTarget validates a deployment may be rolled back to. Rolling back
+// to the deployment that is already current is always a no-op, so it is rejected.
+func CheckRollbackTarget(in Input) PromotionReason {
+	if r := promotionCore(in); r != PromotionOK {
+		return r
+	}
+	if in.isCurrent() {
+		return PromotionAlreadyCurrent
+	}
+	return PromotionOK
+}
+
+// StopReason is why a deployment cannot be stopped. StopOK means it can.
+type StopReason int
+
+const (
+	StopOK StopReason = iota
+	StopNotRunning
+	StopAlreadyStopping
+	StopIsProduction
+)
+
+// Message returns a caller-facing explanation.
+func (r StopReason) Message() string {
+	switch r {
+	case StopOK:
+		return ""
+	case StopNotRunning:
+		return "The deployment is not running."
+	case StopAlreadyStopping:
+		return "The deployment is already stopping."
+	case StopIsProduction:
+		return "Production deployments cannot be stopped."
+	default:
+		return ""
+	}
+}
+
+// CheckStoppable validates a deployment may be stopped: it must be running
+// (ready with a running desired state) and not in production. Order matches the
+// order every layer reports failures in.
+func CheckStoppable(in Input) StopReason {
+	switch {
+	case in.Status != statusReady:
+		return StopNotRunning
+	case in.DesiredState != desiredRunning:
+		return StopAlreadyStopping
+	case in.EnvironmentSlug == envProduction:
+		return StopIsProduction
+	default:
+		return StopOK
+	}
+}
+
+// StartReason is why a deployment cannot be started (woken). StartOK means it
+// can.
+type StartReason int
+
+const (
+	StartOK StartReason = iota
+	StartNotStopped
+	StartIsProduction
+)
+
+// Message returns a caller-facing explanation.
+func (r StartReason) Message() string {
+	switch r {
+	case StartOK:
+		return ""
+	case StartNotStopped:
+		return "The deployment is not stopped."
+	case StartIsProduction:
+		return "Production deployments cannot be started."
+	default:
+		return ""
+	}
+}
+
+// CheckStartable validates a deployment may be started (woken). "Stopped" is
+// keyed on desired_state, not status: stopping sets desired_state=stopped
+// immediately, while status only flips to stopped once krane has drained the
+// last instance. Starting flips the intent back to running, so it is valid for
+// any deployment whose intent is stopped (including one still draining), which
+// is what the ctrl service and worker enforce.
+func CheckStartable(in Input) StartReason {
+	switch {
+	case in.DesiredState != desiredStopped:
+		return StartNotStopped
+	case in.EnvironmentSlug == envProduction:
+		return StartIsProduction
+	default:
+		return StartOK
+	}
+}

--- a/pkg/deploy/deploygate/deploygate.go
+++ b/pkg/deploy/deploygate/deploygate.go
@@ -30,6 +30,7 @@ type Input struct {
 	CurrentDeploymentID  string
 	DeploymentID         string
 	IsRolledBack         bool
+	SpendSuspended       bool
 }
 
 // isCurrent reports whether this deployment is the app's current (live) one.
@@ -165,6 +166,7 @@ const (
 	StartOK StartReason = iota
 	StartNotStopped
 	StartIsProduction
+	StartSpendSuspended
 )
 
 // Message returns a caller-facing explanation.
@@ -176,6 +178,8 @@ func (r StartReason) Message() string {
 		return "The deployment is not stopped."
 	case StartIsProduction:
 		return "Production deployments cannot be started."
+	case StartSpendSuspended:
+		return "The workspace is suspended by its Compute spend cap. Raise the spend limit to resume."
 	default:
 		return ""
 	}
@@ -186,13 +190,16 @@ func (r StartReason) Message() string {
 // immediately, while status only flips to stopped once krane has drained the
 // last instance. Starting flips the intent back to running, so it is valid for
 // any deployment whose intent is stopped (including one still draining), which
-// is what the ctrl service and worker enforce.
+// is what the ctrl service and worker enforce. Starting resumes compute spend,
+// so a workspace suspended by its spend cap is refused last.
 func CheckStartable(in Input) StartReason {
 	switch {
 	case in.DesiredState != desiredStopped:
 		return StartNotStopped
 	case in.EnvironmentSlug == envProduction:
 		return StartIsProduction
+	case in.SpendSuspended:
+		return StartSpendSuspended
 	default:
 		return StartOK
 	}

--- a/pkg/deploy/deploygate/deploygate.go
+++ b/pkg/deploy/deploygate/deploygate.go
@@ -3,28 +3,21 @@
 // services, and the ctrl Restate workflows. Centralizing the invariant here is
 // what stops the three copies from drifting — a promote that is legal at the API
 // is legal at the worker, by construction.
-//
-// Callers pass the deployment's fields as primitives (the API and ctrl use
-// different generated db packages, so the typed enums cannot be shared) and map
-// the returned reason onto their own error surface.
 package deploygate
 
-// These mirror the deployment enum string values. A test pins them to the
-// db-generated constants so a schema rename cannot silently weaken the gates.
-const (
-	statusReady    = "ready"
-	statusStopped  = "stopped"
-	desiredRunning = "running"
-	desiredStopped = "stopped"
-	envProduction  = "production"
-)
+import "github.com/unkeyed/unkey/pkg/db"
 
-// Input is a deployment's lifecycle-relevant state. Callers fill it from their
-// own db row; unused fields (e.g. the live-pointer fields for stop/start) may be
-// left zero.
+// envProduction is the environment whose deployment serves production traffic:
+// promote/rollback require it, stop/start reject it.
+const envProduction = "production"
+
+// Input is a deployment's lifecycle-relevant state, typed to the pkg/db enums:
+// the API passes its db row fields directly, ctrl converts from its own db
+// package at the boundary. Fields unused by a check (the current-pointer fields
+// for stop/start) may be left zero.
 type Input struct {
-	Status               string
-	DesiredState         string
+	Status               db.DeploymentsStatus
+	DesiredState         db.DeploymentsDesiredState
 	EnvironmentSlug      string
 	HasCurrentDeployment bool
 	CurrentDeploymentID  string
@@ -78,9 +71,9 @@ func (r PromotionReason) Message() string {
 // layer reports failures in.
 func promotionCore(in Input) PromotionReason {
 	switch {
-	case in.Status != statusReady:
+	case in.Status != db.DeploymentsStatusReady:
 		return PromotionNotReady
-	case in.DesiredState != desiredRunning:
+	case in.DesiredState != db.DeploymentsDesiredStateRunning:
 		return PromotionDraining
 	case in.EnvironmentSlug != envProduction:
 		return PromotionNotProduction
@@ -147,9 +140,9 @@ func (r StopReason) Message() string {
 // order every layer reports failures in.
 func CheckStoppable(in Input) StopReason {
 	switch {
-	case in.Status != statusReady:
+	case in.Status != db.DeploymentsStatusReady:
 		return StopNotRunning
-	case in.DesiredState != desiredRunning:
+	case in.DesiredState != db.DeploymentsDesiredStateRunning:
 		return StopAlreadyStopping
 	case in.EnvironmentSlug == envProduction:
 		return StopIsProduction
@@ -194,7 +187,7 @@ func (r StartReason) Message() string {
 // so a workspace suspended by its spend cap is refused last.
 func CheckStartable(in Input) StartReason {
 	switch {
-	case in.DesiredState != desiredStopped:
+	case in.DesiredState != db.DeploymentsDesiredStateStopped:
 		return StartNotStopped
 	case in.EnvironmentSlug == envProduction:
 		return StartIsProduction

--- a/pkg/deploy/deploygate/deploygate.go
+++ b/pkg/deploy/deploygate/deploygate.go
@@ -16,19 +16,18 @@ const envProduction = "production"
 // package at the boundary. Fields unused by a check (the current-pointer fields
 // for stop/start) may be left zero.
 type Input struct {
-	Status               db.DeploymentsStatus
-	DesiredState         db.DeploymentsDesiredState
-	EnvironmentSlug      string
-	HasCurrentDeployment bool
-	CurrentDeploymentID  string
-	DeploymentID         string
-	IsRolledBack         bool
-	SpendSuspended       bool
+	Status              db.DeploymentsStatus
+	DesiredState        db.DeploymentsDesiredState
+	EnvironmentSlug     string
+	CurrentDeploymentID string
+	DeploymentID        string
+	IsRolledBack        bool
+	SpendSuspended      bool
 }
 
 // isCurrent reports whether this deployment is the app's current (live) one.
 func (in Input) isCurrent() bool {
-	return in.HasCurrentDeployment && in.CurrentDeploymentID == in.DeploymentID
+	return in.CurrentDeploymentID != "" && in.CurrentDeploymentID == in.DeploymentID
 }
 
 // PromotionReason is why a deployment fails a promote/rollback precondition.
@@ -77,7 +76,7 @@ func promotionCore(in Input) PromotionReason {
 		return PromotionDraining
 	case in.EnvironmentSlug != envProduction:
 		return PromotionNotProduction
-	case !in.HasCurrentDeployment:
+	case in.CurrentDeploymentID == "":
 		return PromotionNoCurrentDeployment
 	default:
 		return PromotionOK

--- a/pkg/deploy/deploygate/deploygate.go
+++ b/pkg/deploy/deploygate/deploygate.go
@@ -34,14 +34,14 @@ type RollbackInput struct {
 	DeploymentID        string
 }
 
-// StopInput is the state CheckStoppable needs.
+// StopInput is the state CheckStopTarget needs.
 type StopInput struct {
 	Status          db.DeploymentsStatus
 	DesiredState    db.DeploymentsDesiredState
 	EnvironmentSlug string
 }
 
-// StartInput is the state CheckStartable needs.
+// StartInput is the state CheckStartTarget needs.
 type StartInput struct {
 	DesiredState    db.DeploymentsDesiredState
 	EnvironmentSlug string
@@ -53,110 +53,110 @@ func isCurrent(currentDeploymentID, deploymentID string) bool {
 	return currentDeploymentID != "" && currentDeploymentID == deploymentID
 }
 
-// PromotionReason is why a deployment fails a promote/rollback precondition.
-// PromotionOK means it is eligible to become the app's current deployment.
-type PromotionReason int
+// TargetFailureReason is why a deployment fails a promote/rollback precondition.
+// TargetOK means it is eligible to become the app's current deployment.
+type TargetFailureReason int
 
 const (
-	PromotionOK PromotionReason = iota
-	PromotionNotReady
-	PromotionDraining
-	PromotionNotProduction
-	PromotionNoCurrentDeployment
-	PromotionAlreadyCurrent
+	TargetOK TargetFailureReason = iota
+	TargetNotReady
+	TargetDraining
+	TargetNotProduction
+	TargetNoCurrentDeployment
+	TargetAlreadyCurrent
 )
 
 // Message returns a caller-facing explanation. It is deliberately generic across
 // promote and rollback so both surface identical wording.
-func (r PromotionReason) Message() string {
+func (r TargetFailureReason) Message() string {
 	switch r {
-	case PromotionOK:
+	case TargetOK:
 		return ""
-	case PromotionNotReady:
+	case TargetNotReady:
 		return "The deployment is not ready."
-	case PromotionDraining:
+	case TargetDraining:
 		return "The deployment is shutting down and cannot serve traffic."
-	case PromotionNotProduction:
+	case TargetNotProduction:
 		return "Only production deployments can be promoted or rolled back."
-	case PromotionNoCurrentDeployment:
+	case TargetNoCurrentDeployment:
 		return "The app has no current deployment."
-	case PromotionAlreadyCurrent:
+	case TargetAlreadyCurrent:
 		return "The deployment is already the current deployment."
 	default:
 		return ""
 	}
 }
 
-// promotionCore holds the preconditions common to promote and rollback: the
+// targetCore holds the preconditions common to promote and rollback: the
 // deployment must be ready, running (not draining), in production, and its app
 // must already have a current deployment. Order matters — it is the order every
 // layer reports failures in.
-func promotionCore(
+func targetCore(
 	status db.DeploymentsStatus,
 	desiredState db.DeploymentsDesiredState,
 	environmentSlug, currentDeploymentID string,
-) PromotionReason {
+) TargetFailureReason {
 	switch {
 	case status != db.DeploymentsStatusReady:
-		return PromotionNotReady
+		return TargetNotReady
 	case desiredState != db.DeploymentsDesiredStateRunning:
-		return PromotionDraining
+		return TargetDraining
 	case environmentSlug != envProduction:
-		return PromotionNotProduction
+		return TargetNotProduction
 	case currentDeploymentID == "":
-		return PromotionNoCurrentDeployment
+		return TargetNoCurrentDeployment
 	default:
-		return PromotionOK
+		return TargetOK
 	}
 }
 
 // CheckPromoteTarget validates a deployment may be promoted to current.
 // Promoting the deployment that is already current is rejected, unless the app
 // is in a rolled-back state (then it is a rollback confirmation, allowed).
-func CheckPromoteTarget(in PromoteInput) PromotionReason {
-	if r := promotionCore(
+func CheckPromoteTarget(in PromoteInput) TargetFailureReason {
+	if r := targetCore(
 		in.Status,
 		in.DesiredState,
 		in.EnvironmentSlug,
 		in.CurrentDeploymentID,
-	); r != PromotionOK {
+	); r != TargetOK {
 		return r
 	}
 	if isCurrent(in.CurrentDeploymentID, in.DeploymentID) && !in.IsRolledBack {
-		return PromotionAlreadyCurrent
+		return TargetAlreadyCurrent
 	}
-	return PromotionOK
+	return TargetOK
 }
 
 // CheckRollbackTarget validates a deployment may be rolled back to. Rolling back
 // to the deployment that is already current is always a no-op, so it is rejected.
-func CheckRollbackTarget(in RollbackInput) PromotionReason {
-	if r := promotionCore(
+func CheckRollbackTarget(in RollbackInput) TargetFailureReason {
+	if r := targetCore(
 		in.Status,
 		in.DesiredState,
 		in.EnvironmentSlug,
 		in.CurrentDeploymentID,
-	); r != PromotionOK {
+	); r != TargetOK {
 		return r
 	}
 	if isCurrent(in.CurrentDeploymentID, in.DeploymentID) {
-		return PromotionAlreadyCurrent
+		return TargetAlreadyCurrent
 	}
-	return PromotionOK
+	return TargetOK
 }
 
-// StopReason is why a deployment cannot be stopped. StopOK means it can.
-type StopReason int
+// StopFailureReason is why a deployment cannot be stopped. StopOK means it can.
+type StopFailureReason int
 
 const (
-	StopOK StopReason = iota
+	StopOK StopFailureReason = iota
 	StopNotRunning
 	StopAlreadyStopping
 	StopIsProduction
 )
 
 // Message returns a caller-facing explanation.
-func (r StopReason) Message() string {
+func (r StopFailureReason) Message() string {
 	switch r {
 	case StopOK:
 		return ""
@@ -171,10 +171,10 @@ func (r StopReason) Message() string {
 	}
 }
 
-// CheckStoppable validates a deployment may be stopped: it must be running
+// CheckStopTarget validates a deployment may be stopped: it must be running
 // (ready with a running desired state) and not in production. Order matches the
 // order every layer reports failures in.
-func CheckStoppable(in StopInput) StopReason {
+func CheckStopTarget(in StopInput) StopFailureReason {
 	switch {
 	case in.Status != db.DeploymentsStatusReady:
 		return StopNotRunning
@@ -187,19 +187,19 @@ func CheckStoppable(in StopInput) StopReason {
 	}
 }
 
-// StartReason is why a deployment cannot be started (woken). StartOK means it
+// StartFailureReason is why a deployment cannot be started (woken). StartOK means it
 // can.
-type StartReason int
+type StartFailureReason int
 
 const (
-	StartOK StartReason = iota
+	StartOK StartFailureReason = iota
 	StartNotStopped
 	StartIsProduction
 	StartSpendSuspended
 )
 
 // Message returns a caller-facing explanation.
-func (r StartReason) Message() string {
+func (r StartFailureReason) Message() string {
 	switch r {
 	case StartOK:
 		return ""
@@ -214,14 +214,14 @@ func (r StartReason) Message() string {
 	}
 }
 
-// CheckStartable validates a deployment may be started (woken). "Stopped" is
+// CheckStartTarget validates a deployment may be started (woken). "Stopped" is
 // keyed on desired_state, not status: stopping sets desired_state=stopped
 // immediately, while status only flips to stopped once krane has drained the
 // last instance. Starting flips the intent back to running, so it is valid for
 // any deployment whose intent is stopped (including one still draining), which
 // is what the ctrl service and worker enforce. Starting resumes compute spend,
 // so a workspace suspended by its spend cap is refused last.
-func CheckStartable(in StartInput) StartReason {
+func CheckStartTarget(in StartInput) StartFailureReason {
 	switch {
 	case in.DesiredState != db.DeploymentsDesiredStateStopped:
 		return StartNotStopped

--- a/pkg/deploy/deploygate/deploygate.go
+++ b/pkg/deploy/deploygate/deploygate.go
@@ -3,9 +3,20 @@
 // services, and the ctrl Restate workflows. Centralizing the invariant here is
 // what stops the three copies from drifting — a promote that is legal at the API
 // is legal at the worker, by construction.
+//
+// The Check* functions return nil when the action is allowed, or a fault
+// carrying the precondition code and a caller-facing message. Surface that
+// message with fault.UserFacingMessage(err) — never err.Error(), which also
+// includes internal detail. The API returns the fault directly (its error
+// middleware renders UserFacingMessage); ctrl wraps UserFacingMessage into its
+// connect or restate error.
 package deploygate
 
-import "github.com/unkeyed/unkey/pkg/db"
+import (
+	"github.com/unkeyed/unkey/pkg/codes"
+	"github.com/unkeyed/unkey/pkg/db"
+	"github.com/unkeyed/unkey/pkg/fault"
+)
 
 // envProduction is the environment whose deployment serves production traffic:
 // promote/rollback require it, stop/start reject it.
@@ -34,14 +45,14 @@ type RollbackInput struct {
 	DeploymentID        string
 }
 
-// StopInput is the state CheckStopTarget needs.
+// StopInput is the state CheckStoppable needs.
 type StopInput struct {
 	Status          db.DeploymentsStatus
 	DesiredState    db.DeploymentsDesiredState
 	EnvironmentSlug string
 }
 
-// StartInput is the state CheckStartTarget needs.
+// StartInput is the state CheckStartable needs.
 type StartInput struct {
 	DesiredState    db.DeploymentsDesiredState
 	EnvironmentSlug string
@@ -53,17 +64,20 @@ func isCurrent(currentDeploymentID, deploymentID string) bool {
 	return currentDeploymentID != "" && currentDeploymentID == deploymentID
 }
 
-// TargetFailureReason is why a deployment fails a promote/rollback precondition.
-// TargetOK means it is eligible to become the app's current deployment.
+// The *FailureReason enums are the internal discriminator each Check* builds its
+// fault from; they are also the source of the caller-facing message strings.
+
+// TargetFailureReason is why a deployment cannot become the app's current
+// deployment (promote/rollback). TargetOK means it is eligible.
 type TargetFailureReason int
 
 const (
 	TargetOK TargetFailureReason = iota
 	TargetNotReady
-	TargetDraining
+	TargetIsDraining
 	TargetNotProduction
 	TargetNoCurrentDeployment
-	TargetAlreadyCurrent
+	TargetIsCurrent
 )
 
 // Message returns a caller-facing explanation. It is deliberately generic across
@@ -74,17 +88,43 @@ func (r TargetFailureReason) Message() string {
 		return ""
 	case TargetNotReady:
 		return "The deployment is not ready."
-	case TargetDraining:
+	case TargetIsDraining:
 		return "The deployment is shutting down and cannot serve traffic."
 	case TargetNotProduction:
 		return "Only production deployments can be promoted or rolled back."
 	case TargetNoCurrentDeployment:
 		return "The app has no current deployment."
-	case TargetAlreadyCurrent:
+	case TargetIsCurrent:
 		return "The deployment is already the current deployment."
 	default:
 		return ""
 	}
+}
+
+// targetFault maps a target failure reason onto a fault with its precondition
+// code, or nil for TargetOK.
+func targetFault(r TargetFailureReason) error {
+	var code codes.Code
+	switch r {
+	case TargetNotReady, TargetIsDraining:
+		code = codes.App.Precondition.DeploymentNotReady
+	case TargetNotProduction:
+		code = codes.App.Precondition.DeploymentNotProduction
+	case TargetNoCurrentDeployment:
+		code = codes.App.Precondition.DeploymentNoCurrent
+	case TargetIsCurrent:
+		code = codes.App.Precondition.DeploymentIsCurrent
+	case TargetOK:
+		return nil
+	default:
+		code = codes.App.Precondition.PreconditionFailed
+	}
+	return fault.New(
+		"target precondition failed",
+		fault.Code(code.URN()),
+		fault.Internal("deploygate rejected promote/rollback: "+r.Message()),
+		fault.Public(r.Message()),
+	)
 }
 
 // targetCore holds the preconditions common to promote and rollback: the
@@ -100,7 +140,7 @@ func targetCore(
 	case status != db.DeploymentsStatusReady:
 		return TargetNotReady
 	case desiredState != db.DeploymentsDesiredStateRunning:
-		return TargetDraining
+		return TargetIsDraining
 	case environmentSlug != envProduction:
 		return TargetNotProduction
 	case currentDeploymentID == "":
@@ -113,36 +153,26 @@ func targetCore(
 // CheckPromoteTarget validates a deployment may be promoted to current.
 // Promoting the deployment that is already current is rejected, unless the app
 // is in a rolled-back state (then it is a rollback confirmation, allowed).
-func CheckPromoteTarget(in PromoteInput) TargetFailureReason {
-	if r := targetCore(
-		in.Status,
-		in.DesiredState,
-		in.EnvironmentSlug,
-		in.CurrentDeploymentID,
-	); r != TargetOK {
-		return r
+func CheckPromoteTarget(in PromoteInput) error {
+	if r := targetCore(in.Status, in.DesiredState, in.EnvironmentSlug, in.CurrentDeploymentID); r != TargetOK {
+		return targetFault(r)
 	}
 	if isCurrent(in.CurrentDeploymentID, in.DeploymentID) && !in.IsRolledBack {
-		return TargetAlreadyCurrent
+		return targetFault(TargetIsCurrent)
 	}
-	return TargetOK
+	return nil
 }
 
 // CheckRollbackTarget validates a deployment may be rolled back to. Rolling back
 // to the deployment that is already current is always a no-op, so it is rejected.
-func CheckRollbackTarget(in RollbackInput) TargetFailureReason {
-	if r := targetCore(
-		in.Status,
-		in.DesiredState,
-		in.EnvironmentSlug,
-		in.CurrentDeploymentID,
-	); r != TargetOK {
-		return r
+func CheckRollbackTarget(in RollbackInput) error {
+	if r := targetCore(in.Status, in.DesiredState, in.EnvironmentSlug, in.CurrentDeploymentID); r != TargetOK {
+		return targetFault(r)
 	}
 	if isCurrent(in.CurrentDeploymentID, in.DeploymentID) {
-		return TargetAlreadyCurrent
+		return targetFault(TargetIsCurrent)
 	}
-	return TargetOK
+	return nil
 }
 
 // StopFailureReason is why a deployment cannot be stopped. StopOK means it can.
@@ -151,7 +181,7 @@ type StopFailureReason int
 const (
 	StopOK StopFailureReason = iota
 	StopNotRunning
-	StopAlreadyStopping
+	StopIsStopping
 	StopIsProduction
 )
 
@@ -162,7 +192,7 @@ func (r StopFailureReason) Message() string {
 		return ""
 	case StopNotRunning:
 		return "The deployment is not running."
-	case StopAlreadyStopping:
+	case StopIsStopping:
 		return "The deployment is already stopping."
 	case StopIsProduction:
 		return "Production deployments cannot be stopped."
@@ -171,24 +201,48 @@ func (r StopFailureReason) Message() string {
 	}
 }
 
+// stopFault maps a stop failure reason onto a fault with its precondition code,
+// or nil for StopOK.
+func stopFault(r StopFailureReason) error {
+	var code codes.Code
+	switch r {
+	case StopNotRunning:
+		code = codes.App.Precondition.DeploymentNotRunning
+	case StopIsStopping:
+		code = codes.App.Precondition.DeploymentIsStopping
+	case StopIsProduction:
+		code = codes.App.Precondition.DeploymentIsProduction
+	case StopOK:
+		return nil
+	default:
+		code = codes.App.Precondition.PreconditionFailed
+	}
+	return fault.New(
+		"stop precondition failed",
+		fault.Code(code.URN()),
+		fault.Internal("deploygate rejected stop: "+r.Message()),
+		fault.Public(r.Message()),
+	)
+}
+
 // CheckStopTarget validates a deployment may be stopped: it must be running
 // (ready with a running desired state) and not in production. Order matches the
 // order every layer reports failures in.
-func CheckStopTarget(in StopInput) StopFailureReason {
+func CheckStopTarget(in StopInput) error {
 	switch {
 	case in.Status != db.DeploymentsStatusReady:
-		return StopNotRunning
+		return stopFault(StopNotRunning)
 	case in.DesiredState != db.DeploymentsDesiredStateRunning:
-		return StopAlreadyStopping
+		return stopFault(StopIsStopping)
 	case in.EnvironmentSlug == envProduction:
-		return StopIsProduction
+		return stopFault(StopIsProduction)
 	default:
-		return StopOK
+		return nil
 	}
 }
 
-// StartFailureReason is why a deployment cannot be started (woken). StartOK means it
-// can.
+// StartFailureReason is why a deployment cannot be started (woken). StartOK means
+// it can.
 type StartFailureReason int
 
 const (
@@ -214,6 +268,31 @@ func (r StartFailureReason) Message() string {
 	}
 }
 
+// startFault maps a start failure reason onto a fault with its precondition
+// code, or nil for StartOK. SpendSuspended is a billing state, not a deployment
+// lifecycle one, so it carries the generic precondition code.
+func startFault(r StartFailureReason) error {
+	var code codes.Code
+	switch r {
+	case StartNotStopped:
+		code = codes.App.Precondition.DeploymentNotStopped
+	case StartIsProduction:
+		code = codes.App.Precondition.DeploymentIsProduction
+	case StartSpendSuspended:
+		code = codes.App.Precondition.PreconditionFailed
+	case StartOK:
+		return nil
+	default:
+		code = codes.App.Precondition.PreconditionFailed
+	}
+	return fault.New(
+		"start precondition failed",
+		fault.Code(code.URN()),
+		fault.Internal("deploygate rejected start: "+r.Message()),
+		fault.Public(r.Message()),
+	)
+}
+
 // CheckStartTarget validates a deployment may be started (woken). "Stopped" is
 // keyed on desired_state, not status: stopping sets desired_state=stopped
 // immediately, while status only flips to stopped once krane has drained the
@@ -221,15 +300,15 @@ func (r StartFailureReason) Message() string {
 // any deployment whose intent is stopped (including one still draining), which
 // is what the ctrl service and worker enforce. Starting resumes compute spend,
 // so a workspace suspended by its spend cap is refused last.
-func CheckStartTarget(in StartInput) StartFailureReason {
+func CheckStartTarget(in StartInput) error {
 	switch {
 	case in.DesiredState != db.DeploymentsDesiredStateStopped:
-		return StartNotStopped
+		return startFault(StartNotStopped)
 	case in.EnvironmentSlug == envProduction:
-		return StartIsProduction
+		return startFault(StartIsProduction)
 	case in.SpendSuspended:
-		return StartSpendSuspended
+		return startFault(StartSpendSuspended)
 	default:
-		return StartOK
+		return nil
 	}
 }

--- a/pkg/deploy/deploygate/deploygate_test.go
+++ b/pkg/deploy/deploygate/deploygate_test.go
@@ -30,93 +30,93 @@ func rollbackBase() RollbackInput {
 
 func TestCheckPromoteTarget(t *testing.T) {
 	t.Run("eligible", func(t *testing.T) {
-		require.Equal(t, PromotionOK, CheckPromoteTarget(promoteBase()))
+		require.Equal(t, TargetOK, CheckPromoteTarget(promoteBase()))
 	})
 
 	t.Run("reason order", func(t *testing.T) {
 		in := promoteBase()
 		in.Status = "building"
-		require.Equal(t, PromotionNotReady, CheckPromoteTarget(in))
+		require.Equal(t, TargetNotReady, CheckPromoteTarget(in))
 
 		in = promoteBase()
 		in.DesiredState = "stopped"
-		require.Equal(t, PromotionDraining, CheckPromoteTarget(in))
+		require.Equal(t, TargetDraining, CheckPromoteTarget(in))
 
 		in = promoteBase()
 		in.EnvironmentSlug = "preview"
-		require.Equal(t, PromotionNotProduction, CheckPromoteTarget(in))
+		require.Equal(t, TargetNotProduction, CheckPromoteTarget(in))
 
 		in = promoteBase()
 		in.CurrentDeploymentID = ""
-		require.Equal(t, PromotionNoCurrentDeployment, CheckPromoteTarget(in))
+		require.Equal(t, TargetNoCurrentDeployment, CheckPromoteTarget(in))
 	})
 
 	t.Run("already live is rejected", func(t *testing.T) {
 		in := promoteBase()
 		in.CurrentDeploymentID = in.DeploymentID
-		require.Equal(t, PromotionAlreadyCurrent, CheckPromoteTarget(in))
+		require.Equal(t, TargetAlreadyCurrent, CheckPromoteTarget(in))
 	})
 
 	t.Run("promoting the current deployment while rolled back is allowed", func(t *testing.T) {
 		in := promoteBase()
 		in.CurrentDeploymentID = in.DeploymentID
 		in.IsRolledBack = true
-		require.Equal(t, PromotionOK, CheckPromoteTarget(in), "confirming a rollback")
+		require.Equal(t, TargetOK, CheckPromoteTarget(in), "confirming a rollback")
 	})
 }
 
 func TestCheckRollbackTarget(t *testing.T) {
 	t.Run("eligible", func(t *testing.T) {
-		require.Equal(t, PromotionOK, CheckRollbackTarget(rollbackBase()))
+		require.Equal(t, TargetOK, CheckRollbackTarget(rollbackBase()))
 	})
 
 	t.Run("rolling back to the current deployment is rejected", func(t *testing.T) {
 		in := rollbackBase()
 		in.CurrentDeploymentID = in.DeploymentID
-		require.Equal(t, PromotionAlreadyCurrent, CheckRollbackTarget(in))
+		require.Equal(t, TargetAlreadyCurrent, CheckRollbackTarget(in))
 	})
 
 	t.Run("shares the core preconditions", func(t *testing.T) {
 		in := rollbackBase()
 		in.Status = "failed"
-		require.Equal(t, PromotionNotReady, CheckRollbackTarget(in))
+		require.Equal(t, TargetNotReady, CheckRollbackTarget(in))
 	})
 }
 
-func TestCheckStoppable(t *testing.T) {
+func TestCheckStopTarget(t *testing.T) {
 	running := StopInput{Status: db.DeploymentsStatusReady, DesiredState: db.DeploymentsDesiredStateRunning, EnvironmentSlug: "preview"}
 
-	require.Equal(t, StopOK, CheckStoppable(running))
+	require.Equal(t, StopOK, CheckStopTarget(running))
 
 	notReady := running
 	notReady.Status = db.DeploymentsStatusStopped
-	require.Equal(t, StopNotRunning, CheckStoppable(notReady))
+	require.Equal(t, StopNotRunning, CheckStopTarget(notReady))
 
 	draining := running
 	draining.DesiredState = db.DeploymentsDesiredStateStopped
-	require.Equal(t, StopAlreadyStopping, CheckStoppable(draining))
+	require.Equal(t, StopAlreadyStopping, CheckStopTarget(draining))
 
 	prod := running
 	prod.EnvironmentSlug = envProduction
-	require.Equal(t, StopIsProduction, CheckStoppable(prod))
+	require.Equal(t, StopIsProduction, CheckStopTarget(prod))
 }
 
-func TestCheckStartable(t *testing.T) {
+func TestCheckStartTarget(t *testing.T) {
 	// A stopped deployment is keyed on desired_state, not status: it may still be
 	// draining (status ready) while its intent is stopped.
 	stopped := StartInput{DesiredState: db.DeploymentsDesiredStateStopped, EnvironmentSlug: "preview"}
 
-	require.Equal(t, StartOK, CheckStartable(stopped), "wakeable while draining toward stopped")
+	require.Equal(t, StartOK, CheckStartTarget(stopped), "wakeable while draining toward stopped")
 
 	notStopped := stopped
 	notStopped.DesiredState = db.DeploymentsDesiredStateRunning
-	require.Equal(t, StartNotStopped, CheckStartable(notStopped))
+	require.Equal(t, StartNotStopped, CheckStartTarget(notStopped))
 
 	prod := stopped
 	prod.EnvironmentSlug = envProduction
-	require.Equal(t, StartIsProduction, CheckStartable(prod))
+	require.Equal(t, StartIsProduction, CheckStartTarget(prod))
 
 	suspended := stopped
 	suspended.SpendSuspended = true
-	require.Equal(t, StartSpendSuspended, CheckStartable(suspended))
+	require.Equal(t, StartSpendSuspended, CheckStartTarget(suspended))
 }

--- a/pkg/deploy/deploygate/deploygate_test.go
+++ b/pkg/deploy/deploygate/deploygate_test.go
@@ -7,48 +7,58 @@ import (
 	"github.com/unkeyed/unkey/pkg/db"
 )
 
-func base() Input {
-	return Input{
-		Status:               db.DeploymentsStatusReady,
-		DesiredState:         db.DeploymentsDesiredStateRunning,
-		EnvironmentSlug:      envProduction,
-		CurrentDeploymentID:  "dep_live",
-		DeploymentID:         "dep_target",
-		IsRolledBack:         false,
+func promoteBase() PromoteInput {
+	return PromoteInput{
+		Status:              db.DeploymentsStatusReady,
+		DesiredState:        db.DeploymentsDesiredStateRunning,
+		EnvironmentSlug:     envProduction,
+		CurrentDeploymentID: "dep_live",
+		DeploymentID:        "dep_target",
+		IsRolledBack:        false,
+	}
+}
+
+func rollbackBase() RollbackInput {
+	return RollbackInput{
+		Status:              db.DeploymentsStatusReady,
+		DesiredState:        db.DeploymentsDesiredStateRunning,
+		EnvironmentSlug:     envProduction,
+		CurrentDeploymentID: "dep_live",
+		DeploymentID:        "dep_target",
 	}
 }
 
 func TestCheckPromoteTarget(t *testing.T) {
 	t.Run("eligible", func(t *testing.T) {
-		require.Equal(t, PromotionOK, CheckPromoteTarget(base()))
+		require.Equal(t, PromotionOK, CheckPromoteTarget(promoteBase()))
 	})
 
 	t.Run("reason order", func(t *testing.T) {
-		in := base()
+		in := promoteBase()
 		in.Status = "building"
 		require.Equal(t, PromotionNotReady, CheckPromoteTarget(in))
 
-		in = base()
+		in = promoteBase()
 		in.DesiredState = "stopped"
 		require.Equal(t, PromotionDraining, CheckPromoteTarget(in))
 
-		in = base()
+		in = promoteBase()
 		in.EnvironmentSlug = "preview"
 		require.Equal(t, PromotionNotProduction, CheckPromoteTarget(in))
 
-		in = base()
+		in = promoteBase()
 		in.CurrentDeploymentID = ""
 		require.Equal(t, PromotionNoCurrentDeployment, CheckPromoteTarget(in))
 	})
 
 	t.Run("already live is rejected", func(t *testing.T) {
-		in := base()
+		in := promoteBase()
 		in.CurrentDeploymentID = in.DeploymentID
 		require.Equal(t, PromotionAlreadyCurrent, CheckPromoteTarget(in))
 	})
 
 	t.Run("promoting the current deployment while rolled back is allowed", func(t *testing.T) {
-		in := base()
+		in := promoteBase()
 		in.CurrentDeploymentID = in.DeploymentID
 		in.IsRolledBack = true
 		require.Equal(t, PromotionOK, CheckPromoteTarget(in), "confirming a rollback")
@@ -57,28 +67,24 @@ func TestCheckPromoteTarget(t *testing.T) {
 
 func TestCheckRollbackTarget(t *testing.T) {
 	t.Run("eligible", func(t *testing.T) {
-		require.Equal(t, PromotionOK, CheckRollbackTarget(base()))
+		require.Equal(t, PromotionOK, CheckRollbackTarget(rollbackBase()))
 	})
 
-	t.Run("rolling back to the current deployment is always rejected", func(t *testing.T) {
-		in := base()
+	t.Run("rolling back to the current deployment is rejected", func(t *testing.T) {
+		in := rollbackBase()
 		in.CurrentDeploymentID = in.DeploymentID
-		require.Equal(t, PromotionAlreadyCurrent, CheckRollbackTarget(in))
-
-		// Unlike promote, the rolled-back exception does not apply.
-		in.IsRolledBack = true
 		require.Equal(t, PromotionAlreadyCurrent, CheckRollbackTarget(in))
 	})
 
 	t.Run("shares the core preconditions", func(t *testing.T) {
-		in := base()
+		in := rollbackBase()
 		in.Status = "failed"
 		require.Equal(t, PromotionNotReady, CheckRollbackTarget(in))
 	})
 }
 
 func TestCheckStoppable(t *testing.T) {
-	running := Input{Status: db.DeploymentsStatusReady, DesiredState: db.DeploymentsDesiredStateRunning, EnvironmentSlug: "preview"}
+	running := StopInput{Status: db.DeploymentsStatusReady, DesiredState: db.DeploymentsDesiredStateRunning, EnvironmentSlug: "preview"}
 
 	require.Equal(t, StopOK, CheckStoppable(running))
 
@@ -98,7 +104,7 @@ func TestCheckStoppable(t *testing.T) {
 func TestCheckStartable(t *testing.T) {
 	// A stopped deployment is keyed on desired_state, not status: it may still be
 	// draining (status ready) while its intent is stopped.
-	stopped := Input{Status: db.DeploymentsStatusReady, DesiredState: db.DeploymentsDesiredStateStopped, EnvironmentSlug: "preview"}
+	stopped := StartInput{DesiredState: db.DeploymentsDesiredStateStopped, EnvironmentSlug: "preview"}
 
 	require.Equal(t, StartOK, CheckStartable(stopped), "wakeable while draining toward stopped")
 

--- a/pkg/deploy/deploygate/deploygate_test.go
+++ b/pkg/deploy/deploygate/deploygate_test.go
@@ -12,7 +12,6 @@ func base() Input {
 		Status:               db.DeploymentsStatusReady,
 		DesiredState:         db.DeploymentsDesiredStateRunning,
 		EnvironmentSlug:      envProduction,
-		HasCurrentDeployment: true,
 		CurrentDeploymentID:  "dep_live",
 		DeploymentID:         "dep_target",
 		IsRolledBack:         false,
@@ -38,7 +37,7 @@ func TestCheckPromoteTarget(t *testing.T) {
 		require.Equal(t, PromotionNotProduction, CheckPromoteTarget(in))
 
 		in = base()
-		in.HasCurrentDeployment = false
+		in.CurrentDeploymentID = ""
 		require.Equal(t, PromotionNoCurrentDeployment, CheckPromoteTarget(in))
 	})
 

--- a/pkg/deploy/deploygate/deploygate_test.go
+++ b/pkg/deploy/deploygate/deploygate_test.go
@@ -1,0 +1,123 @@
+package deploygate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/db"
+)
+
+// TestEnumLiterals pins the package's string literals to the db-generated enum
+// values, so a schema rename can't silently weaken the gates. pkg/db and the
+// ctrl db package are generated from the same schema, so pinning one covers both.
+func TestEnumLiterals(t *testing.T) {
+	require.Equal(t, statusReady, string(db.DeploymentsStatusReady))
+	require.Equal(t, statusStopped, string(db.DeploymentsStatusStopped))
+	require.Equal(t, desiredRunning, string(db.DeploymentsDesiredStateRunning))
+	require.Equal(t, desiredStopped, string(db.DeploymentsDesiredStateStopped))
+}
+
+func base() Input {
+	return Input{
+		Status:               statusReady,
+		DesiredState:         desiredRunning,
+		EnvironmentSlug:      envProduction,
+		HasCurrentDeployment: true,
+		CurrentDeploymentID:  "dep_live",
+		DeploymentID:         "dep_target",
+		IsRolledBack:         false,
+	}
+}
+
+func TestCheckPromoteTarget(t *testing.T) {
+	t.Run("eligible", func(t *testing.T) {
+		require.Equal(t, PromotionOK, CheckPromoteTarget(base()))
+	})
+
+	t.Run("reason order", func(t *testing.T) {
+		in := base()
+		in.Status = "building"
+		require.Equal(t, PromotionNotReady, CheckPromoteTarget(in))
+
+		in = base()
+		in.DesiredState = "stopped"
+		require.Equal(t, PromotionDraining, CheckPromoteTarget(in))
+
+		in = base()
+		in.EnvironmentSlug = "preview"
+		require.Equal(t, PromotionNotProduction, CheckPromoteTarget(in))
+
+		in = base()
+		in.HasCurrentDeployment = false
+		require.Equal(t, PromotionNoCurrentDeployment, CheckPromoteTarget(in))
+	})
+
+	t.Run("already live is rejected", func(t *testing.T) {
+		in := base()
+		in.CurrentDeploymentID = in.DeploymentID
+		require.Equal(t, PromotionAlreadyCurrent, CheckPromoteTarget(in))
+	})
+
+	t.Run("promoting the current deployment while rolled back is allowed", func(t *testing.T) {
+		in := base()
+		in.CurrentDeploymentID = in.DeploymentID
+		in.IsRolledBack = true
+		require.Equal(t, PromotionOK, CheckPromoteTarget(in), "confirming a rollback")
+	})
+}
+
+func TestCheckRollbackTarget(t *testing.T) {
+	t.Run("eligible", func(t *testing.T) {
+		require.Equal(t, PromotionOK, CheckRollbackTarget(base()))
+	})
+
+	t.Run("rolling back to the current deployment is always rejected", func(t *testing.T) {
+		in := base()
+		in.CurrentDeploymentID = in.DeploymentID
+		require.Equal(t, PromotionAlreadyCurrent, CheckRollbackTarget(in))
+
+		// Unlike promote, the rolled-back exception does not apply.
+		in.IsRolledBack = true
+		require.Equal(t, PromotionAlreadyCurrent, CheckRollbackTarget(in))
+	})
+
+	t.Run("shares the core preconditions", func(t *testing.T) {
+		in := base()
+		in.Status = "failed"
+		require.Equal(t, PromotionNotReady, CheckRollbackTarget(in))
+	})
+}
+
+func TestCheckStoppable(t *testing.T) {
+	running := Input{Status: statusReady, DesiredState: desiredRunning, EnvironmentSlug: "preview"}
+
+	require.Equal(t, StopOK, CheckStoppable(running))
+
+	notReady := running
+	notReady.Status = statusStopped
+	require.Equal(t, StopNotRunning, CheckStoppable(notReady))
+
+	draining := running
+	draining.DesiredState = desiredStopped
+	require.Equal(t, StopAlreadyStopping, CheckStoppable(draining))
+
+	prod := running
+	prod.EnvironmentSlug = envProduction
+	require.Equal(t, StopIsProduction, CheckStoppable(prod))
+}
+
+func TestCheckStartable(t *testing.T) {
+	// A stopped deployment is keyed on desired_state, not status: it may still be
+	// draining (status ready) while its intent is stopped.
+	stopped := Input{Status: statusReady, DesiredState: desiredStopped, EnvironmentSlug: "preview"}
+
+	require.Equal(t, StartOK, CheckStartable(stopped), "wakeable while draining toward stopped")
+
+	notStopped := stopped
+	notStopped.DesiredState = desiredRunning
+	require.Equal(t, StartNotStopped, CheckStartable(notStopped))
+
+	prod := stopped
+	prod.EnvironmentSlug = envProduction
+	require.Equal(t, StartIsProduction, CheckStartable(prod))
+}

--- a/pkg/deploy/deploygate/deploygate_test.go
+++ b/pkg/deploy/deploygate/deploygate_test.go
@@ -4,7 +4,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/codes"
 	"github.com/unkeyed/unkey/pkg/db"
+	"github.com/unkeyed/unkey/pkg/fault"
 )
 
 func promoteBase() PromoteInput {
@@ -28,77 +30,108 @@ func rollbackBase() RollbackInput {
 	}
 }
 
+// requireCode asserts err is a fault carrying the given precondition code.
+func requireCode(t *testing.T, want codes.Code, err error) {
+	t.Helper()
+	require.Error(t, err)
+	got, ok := fault.GetCode(err)
+	require.True(t, ok, "expected a coded fault")
+	require.Equal(t, want.URN(), got)
+}
+
+// ctrl surfaces fault.UserFacingMessage(err) on its own error surface, so verify
+// the faults deploygate builds expose exactly the public message — not the base
+// "precondition failed" text or the internal detail.
+func TestFaultUserFacingMessage(t *testing.T) {
+	in := promoteBase()
+	in.Status = "building"
+	require.Equal(t, "The deployment is not ready.", fault.UserFacingMessage(CheckPromoteTarget(in)))
+
+	in = promoteBase()
+	in.CurrentDeploymentID = in.DeploymentID
+	require.Equal(t, "The deployment is already the current deployment.", fault.UserFacingMessage(CheckPromoteTarget(in)))
+
+	stop := StopInput{Status: db.DeploymentsStatusReady, DesiredState: db.DeploymentsDesiredStateStopped, EnvironmentSlug: "preview"}
+	require.Equal(t, "The deployment is already stopping.", fault.UserFacingMessage(CheckStopTarget(stop)))
+
+	start := StartInput{DesiredState: db.DeploymentsDesiredStateStopped, EnvironmentSlug: "preview", SpendSuspended: true}
+	require.Equal(t, "The workspace is suspended by its Compute spend cap. Raise the spend limit to resume.", fault.UserFacingMessage(CheckStartTarget(start)))
+
+	// The base and internal strings must never leak into the user-facing message.
+	require.NotContains(t, fault.UserFacingMessage(CheckStopTarget(StopInput{})), "precondition failed")
+}
+
 func TestCheckPromoteTarget(t *testing.T) {
 	t.Run("eligible", func(t *testing.T) {
-		require.Equal(t, TargetOK, CheckPromoteTarget(promoteBase()))
+		require.NoError(t, CheckPromoteTarget(promoteBase()))
 	})
 
 	t.Run("reason order", func(t *testing.T) {
 		in := promoteBase()
 		in.Status = "building"
-		require.Equal(t, TargetNotReady, CheckPromoteTarget(in))
+		requireCode(t, codes.App.Precondition.DeploymentNotReady, CheckPromoteTarget(in))
 
 		in = promoteBase()
 		in.DesiredState = "stopped"
-		require.Equal(t, TargetDraining, CheckPromoteTarget(in))
+		requireCode(t, codes.App.Precondition.DeploymentNotReady, CheckPromoteTarget(in))
 
 		in = promoteBase()
 		in.EnvironmentSlug = "preview"
-		require.Equal(t, TargetNotProduction, CheckPromoteTarget(in))
+		requireCode(t, codes.App.Precondition.DeploymentNotProduction, CheckPromoteTarget(in))
 
 		in = promoteBase()
 		in.CurrentDeploymentID = ""
-		require.Equal(t, TargetNoCurrentDeployment, CheckPromoteTarget(in))
+		requireCode(t, codes.App.Precondition.DeploymentNoCurrent, CheckPromoteTarget(in))
 	})
 
-	t.Run("already live is rejected", func(t *testing.T) {
+	t.Run("already current is rejected", func(t *testing.T) {
 		in := promoteBase()
 		in.CurrentDeploymentID = in.DeploymentID
-		require.Equal(t, TargetAlreadyCurrent, CheckPromoteTarget(in))
+		requireCode(t, codes.App.Precondition.DeploymentIsCurrent, CheckPromoteTarget(in))
 	})
 
 	t.Run("promoting the current deployment while rolled back is allowed", func(t *testing.T) {
 		in := promoteBase()
 		in.CurrentDeploymentID = in.DeploymentID
 		in.IsRolledBack = true
-		require.Equal(t, TargetOK, CheckPromoteTarget(in), "confirming a rollback")
+		require.NoError(t, CheckPromoteTarget(in), "confirming a rollback")
 	})
 }
 
 func TestCheckRollbackTarget(t *testing.T) {
 	t.Run("eligible", func(t *testing.T) {
-		require.Equal(t, TargetOK, CheckRollbackTarget(rollbackBase()))
+		require.NoError(t, CheckRollbackTarget(rollbackBase()))
 	})
 
 	t.Run("rolling back to the current deployment is rejected", func(t *testing.T) {
 		in := rollbackBase()
 		in.CurrentDeploymentID = in.DeploymentID
-		require.Equal(t, TargetAlreadyCurrent, CheckRollbackTarget(in))
+		requireCode(t, codes.App.Precondition.DeploymentIsCurrent, CheckRollbackTarget(in))
 	})
 
 	t.Run("shares the core preconditions", func(t *testing.T) {
 		in := rollbackBase()
 		in.Status = "failed"
-		require.Equal(t, TargetNotReady, CheckRollbackTarget(in))
+		requireCode(t, codes.App.Precondition.DeploymentNotReady, CheckRollbackTarget(in))
 	})
 }
 
 func TestCheckStopTarget(t *testing.T) {
 	running := StopInput{Status: db.DeploymentsStatusReady, DesiredState: db.DeploymentsDesiredStateRunning, EnvironmentSlug: "preview"}
 
-	require.Equal(t, StopOK, CheckStopTarget(running))
+	require.NoError(t, CheckStopTarget(running))
 
 	notReady := running
 	notReady.Status = db.DeploymentsStatusStopped
-	require.Equal(t, StopNotRunning, CheckStopTarget(notReady))
+	requireCode(t, codes.App.Precondition.DeploymentNotRunning, CheckStopTarget(notReady))
 
 	draining := running
 	draining.DesiredState = db.DeploymentsDesiredStateStopped
-	require.Equal(t, StopAlreadyStopping, CheckStopTarget(draining))
+	requireCode(t, codes.App.Precondition.DeploymentIsStopping, CheckStopTarget(draining))
 
 	prod := running
 	prod.EnvironmentSlug = envProduction
-	require.Equal(t, StopIsProduction, CheckStopTarget(prod))
+	requireCode(t, codes.App.Precondition.DeploymentIsProduction, CheckStopTarget(prod))
 }
 
 func TestCheckStartTarget(t *testing.T) {
@@ -106,17 +139,17 @@ func TestCheckStartTarget(t *testing.T) {
 	// draining (status ready) while its intent is stopped.
 	stopped := StartInput{DesiredState: db.DeploymentsDesiredStateStopped, EnvironmentSlug: "preview"}
 
-	require.Equal(t, StartOK, CheckStartTarget(stopped), "wakeable while draining toward stopped")
+	require.NoError(t, CheckStartTarget(stopped), "wakeable while draining toward stopped")
 
 	notStopped := stopped
 	notStopped.DesiredState = db.DeploymentsDesiredStateRunning
-	require.Equal(t, StartNotStopped, CheckStartTarget(notStopped))
+	requireCode(t, codes.App.Precondition.DeploymentNotStopped, CheckStartTarget(notStopped))
 
 	prod := stopped
 	prod.EnvironmentSlug = envProduction
-	require.Equal(t, StartIsProduction, CheckStartTarget(prod))
+	requireCode(t, codes.App.Precondition.DeploymentIsProduction, CheckStartTarget(prod))
 
 	suspended := stopped
 	suspended.SpendSuspended = true
-	require.Equal(t, StartSpendSuspended, CheckStartTarget(suspended))
+	requireCode(t, codes.App.Precondition.PreconditionFailed, CheckStartTarget(suspended))
 }

--- a/pkg/deploy/deploygate/deploygate_test.go
+++ b/pkg/deploy/deploygate/deploygate_test.go
@@ -7,20 +7,10 @@ import (
 	"github.com/unkeyed/unkey/pkg/db"
 )
 
-// TestEnumLiterals pins the package's string literals to the db-generated enum
-// values, so a schema rename can't silently weaken the gates. pkg/db and the
-// ctrl db package are generated from the same schema, so pinning one covers both.
-func TestEnumLiterals(t *testing.T) {
-	require.Equal(t, statusReady, string(db.DeploymentsStatusReady))
-	require.Equal(t, statusStopped, string(db.DeploymentsStatusStopped))
-	require.Equal(t, desiredRunning, string(db.DeploymentsDesiredStateRunning))
-	require.Equal(t, desiredStopped, string(db.DeploymentsDesiredStateStopped))
-}
-
 func base() Input {
 	return Input{
-		Status:               statusReady,
-		DesiredState:         desiredRunning,
+		Status:               db.DeploymentsStatusReady,
+		DesiredState:         db.DeploymentsDesiredStateRunning,
 		EnvironmentSlug:      envProduction,
 		HasCurrentDeployment: true,
 		CurrentDeploymentID:  "dep_live",
@@ -89,16 +79,16 @@ func TestCheckRollbackTarget(t *testing.T) {
 }
 
 func TestCheckStoppable(t *testing.T) {
-	running := Input{Status: statusReady, DesiredState: desiredRunning, EnvironmentSlug: "preview"}
+	running := Input{Status: db.DeploymentsStatusReady, DesiredState: db.DeploymentsDesiredStateRunning, EnvironmentSlug: "preview"}
 
 	require.Equal(t, StopOK, CheckStoppable(running))
 
 	notReady := running
-	notReady.Status = statusStopped
+	notReady.Status = db.DeploymentsStatusStopped
 	require.Equal(t, StopNotRunning, CheckStoppable(notReady))
 
 	draining := running
-	draining.DesiredState = desiredStopped
+	draining.DesiredState = db.DeploymentsDesiredStateStopped
 	require.Equal(t, StopAlreadyStopping, CheckStoppable(draining))
 
 	prod := running
@@ -109,12 +99,12 @@ func TestCheckStoppable(t *testing.T) {
 func TestCheckStartable(t *testing.T) {
 	// A stopped deployment is keyed on desired_state, not status: it may still be
 	// draining (status ready) while its intent is stopped.
-	stopped := Input{Status: statusReady, DesiredState: desiredStopped, EnvironmentSlug: "preview"}
+	stopped := Input{Status: db.DeploymentsStatusReady, DesiredState: db.DeploymentsDesiredStateStopped, EnvironmentSlug: "preview"}
 
 	require.Equal(t, StartOK, CheckStartable(stopped), "wakeable while draining toward stopped")
 
 	notStopped := stopped
-	notStopped.DesiredState = desiredRunning
+	notStopped.DesiredState = db.DeploymentsDesiredStateRunning
 	require.Equal(t, StartNotStopped, CheckStartable(notStopped))
 
 	prod := stopped

--- a/pkg/deploy/deploygate/deploygate_test.go
+++ b/pkg/deploy/deploygate/deploygate_test.go
@@ -120,4 +120,8 @@ func TestCheckStartable(t *testing.T) {
 	prod := stopped
 	prod.EnvironmentSlug = envProduction
 	require.Equal(t, StartIsProduction, CheckStartable(prod))
+
+	suspended := stopped
+	suspended.SpendSuspended = true
+	require.Equal(t, StartSpendSuspended, CheckStartable(suspended))
 }

--- a/svc/api/internal/deployment/preflight.go
+++ b/svc/api/internal/deployment/preflight.go
@@ -12,21 +12,21 @@ import (
 	"github.com/unkeyed/unkey/svc/api/internal/ctrlclient"
 )
 
-// PromotionFault maps a deploygate promote/rollback rejection onto the API
+// TargetFault maps a deploygate promote/rollback rejection onto the API
 // fault with the matching precondition code, so both handlers surface the same
 // code and message for the same reason.
-func PromotionFault(r deploygate.PromotionReason) error {
+func TargetFault(r deploygate.TargetFailureReason) error {
 	var code codes.Code
 	switch r {
-	case deploygate.PromotionNotReady, deploygate.PromotionDraining:
+	case deploygate.TargetNotReady, deploygate.TargetDraining:
 		code = codes.App.Precondition.DeploymentNotReady
-	case deploygate.PromotionNotProduction:
+	case deploygate.TargetNotProduction:
 		code = codes.App.Precondition.DeploymentNotProduction
-	case deploygate.PromotionNoCurrentDeployment:
+	case deploygate.TargetNoCurrentDeployment:
 		code = codes.App.Precondition.DeploymentNoCurrent
-	case deploygate.PromotionAlreadyCurrent:
+	case deploygate.TargetAlreadyCurrent:
 		code = codes.App.Precondition.DeploymentIsCurrent
-	case deploygate.PromotionOK:
+	case deploygate.TargetOK:
 		return nil
 	default:
 		code = codes.App.Precondition.PreconditionFailed
@@ -41,7 +41,7 @@ func PromotionFault(r deploygate.PromotionReason) error {
 
 // StopFault maps a deploygate stop rejection onto the API fault with the
 // matching precondition code.
-func StopFault(r deploygate.StopReason) error {
+func StopFault(r deploygate.StopFailureReason) error {
 	var code codes.Code
 	switch r {
 	case deploygate.StopNotRunning:
@@ -65,7 +65,7 @@ func StopFault(r deploygate.StopReason) error {
 
 // StartFault maps a deploygate start rejection onto the API fault with the
 // matching precondition code.
-func StartFault(r deploygate.StartReason) error {
+func StartFault(r deploygate.StartFailureReason) error {
 	var code codes.Code
 	switch r {
 	case deploygate.StartNotStopped:
@@ -134,18 +134,18 @@ func MapCtrlError(err error, action string, preconditionMsg string) error {
 		switch connectErr.Code() {
 		case connect.CodeFailedPrecondition:
 			msg := connectErr.Message()
-			for _, r := range []deploygate.PromotionReason{
-				deploygate.PromotionNotReady,
-				deploygate.PromotionDraining,
-				deploygate.PromotionNotProduction,
-				deploygate.PromotionNoCurrentDeployment,
-				deploygate.PromotionAlreadyCurrent,
+			for _, r := range []deploygate.TargetFailureReason{
+				deploygate.TargetNotReady,
+				deploygate.TargetDraining,
+				deploygate.TargetNotProduction,
+				deploygate.TargetNoCurrentDeployment,
+				deploygate.TargetAlreadyCurrent,
 			} {
 				if msg == r.Message() {
-					return PromotionFault(r)
+					return TargetFault(r)
 				}
 			}
-			for _, r := range []deploygate.StopReason{
+			for _, r := range []deploygate.StopFailureReason{
 				deploygate.StopNotRunning,
 				deploygate.StopAlreadyStopping,
 				deploygate.StopIsProduction,
@@ -154,7 +154,7 @@ func MapCtrlError(err error, action string, preconditionMsg string) error {
 					return StopFault(r)
 				}
 			}
-			for _, r := range []deploygate.StartReason{
+			for _, r := range []deploygate.StartFailureReason{
 				deploygate.StartNotStopped,
 				deploygate.StartIsProduction,
 				deploygate.StartSpendSuspended,

--- a/svc/api/internal/deployment/preflight.go
+++ b/svc/api/internal/deployment/preflight.go
@@ -7,9 +7,83 @@ import (
 	"connectrpc.com/connect"
 	"github.com/unkeyed/unkey/pkg/codes"
 	"github.com/unkeyed/unkey/pkg/db"
+	"github.com/unkeyed/unkey/pkg/deploy/deploygate"
 	"github.com/unkeyed/unkey/pkg/fault"
 	"github.com/unkeyed/unkey/svc/api/internal/ctrlclient"
 )
+
+// PromotionFault maps a deploygate promote/rollback rejection onto the API
+// fault with the matching precondition code, so both handlers surface the same
+// code and message for the same reason.
+func PromotionFault(r deploygate.PromotionReason) error {
+	var code codes.Code
+	switch r {
+	case deploygate.PromotionNotReady, deploygate.PromotionDraining:
+		code = codes.App.Precondition.DeploymentNotReady
+	case deploygate.PromotionNotProduction:
+		code = codes.App.Precondition.DeploymentNotProduction
+	case deploygate.PromotionNoCurrentDeployment:
+		code = codes.App.Precondition.DeploymentNoCurrent
+	case deploygate.PromotionAlreadyCurrent:
+		code = codes.App.Precondition.DeploymentIsCurrent
+	case deploygate.PromotionOK:
+		return nil
+	default:
+		code = codes.App.Precondition.PreconditionFailed
+	}
+	return fault.New(
+		"deployment lifecycle precondition failed",
+		fault.Code(code.URN()),
+		fault.Internal("deploygate rejected promote/rollback: "+r.Message()),
+		fault.Public(r.Message()),
+	)
+}
+
+// StopFault maps a deploygate stop rejection onto the API fault with the
+// matching precondition code.
+func StopFault(r deploygate.StopReason) error {
+	var code codes.Code
+	switch r {
+	case deploygate.StopNotRunning:
+		code = codes.App.Precondition.DeploymentNotRunning
+	case deploygate.StopAlreadyStopping:
+		code = codes.App.Precondition.DeploymentIsStopping
+	case deploygate.StopIsProduction:
+		code = codes.App.Precondition.DeploymentIsProduction
+	case deploygate.StopOK:
+		return nil
+	default:
+		code = codes.App.Precondition.PreconditionFailed
+	}
+	return fault.New(
+		"stop precondition failed",
+		fault.Code(code.URN()),
+		fault.Internal("deploygate rejected stop: "+r.Message()),
+		fault.Public(r.Message()),
+	)
+}
+
+// StartFault maps a deploygate start rejection onto the API fault with the
+// matching precondition code.
+func StartFault(r deploygate.StartReason) error {
+	var code codes.Code
+	switch r {
+	case deploygate.StartNotStopped:
+		code = codes.App.Precondition.DeploymentNotStopped
+	case deploygate.StartIsProduction:
+		code = codes.App.Precondition.DeploymentIsProduction
+	case deploygate.StartOK:
+		return nil
+	default:
+		code = codes.App.Precondition.PreconditionFailed
+	}
+	return fault.New(
+		"start precondition failed",
+		fault.Code(code.URN()),
+		fault.Internal("deploygate rejected start: "+r.Message()),
+		fault.Public(r.Message()),
+	)
+}
 
 // FindDeployment loads a deployment by ID scoped to the caller's workspace. A
 // cross-workspace match is masked as not found so a caller can't probe for

--- a/svc/api/internal/deployment/preflight.go
+++ b/svc/api/internal/deployment/preflight.go
@@ -116,18 +116,52 @@ func FindDeployment(ctx context.Context, database db.Database, workspaceID, depl
 }
 
 // MapCtrlError converts a ctrl connect error from a lifecycle RPC into an API
-// fault: precondition failures become a 412 with preconditionMsg, not-found
-// stays a 404, and everything else falls through to the generic ctrl mapping.
+// fault. Ctrl re-runs the same deploygate checks the handler already passed, so
+// a precondition message matching a known gate rejection (a race: the state
+// changed between the two checks) is mapped back to its reason and surfaces the
+// identical code and message the local gate would have produced. Unrecognized
+// precondition failures (e.g. a spend-cap suspension) become a generic 412 with
+// preconditionMsg, not-found stays a 404, and everything else falls through to
+// the generic ctrl mapping.
 func MapCtrlError(err error, action string, preconditionMsg string) error {
 	var connectErr *connect.Error
 	if errors.As(err, &connectErr) {
 		//nolint:exhaustive // all other Connect error codes fall through to the generic mapping
 		switch connectErr.Code() {
 		case connect.CodeFailedPrecondition:
+			msg := connectErr.Message()
+			for _, r := range []deploygate.PromotionReason{
+				deploygate.PromotionNotReady,
+				deploygate.PromotionDraining,
+				deploygate.PromotionNotProduction,
+				deploygate.PromotionNoCurrentDeployment,
+				deploygate.PromotionAlreadyCurrent,
+			} {
+				if msg == r.Message() {
+					return PromotionFault(r)
+				}
+			}
+			for _, r := range []deploygate.StopReason{
+				deploygate.StopNotRunning,
+				deploygate.StopAlreadyStopping,
+				deploygate.StopIsProduction,
+			} {
+				if msg == r.Message() {
+					return StopFault(r)
+				}
+			}
+			for _, r := range []deploygate.StartReason{
+				deploygate.StartNotStopped,
+				deploygate.StartIsProduction,
+			} {
+				if msg == r.Message() {
+					return StartFault(r)
+				}
+			}
 			return fault.Wrap(
 				err,
 				fault.Code(codes.App.Precondition.PreconditionFailed.URN()),
-				fault.Internal("ctrl reported a precondition failure: "+connectErr.Message()),
+				fault.Internal("ctrl reported a precondition failure: "+msg),
 				fault.Public(preconditionMsg),
 			)
 		case connect.CodeNotFound:

--- a/svc/api/internal/deployment/preflight.go
+++ b/svc/api/internal/deployment/preflight.go
@@ -72,6 +72,10 @@ func StartFault(r deploygate.StartReason) error {
 		code = codes.App.Precondition.DeploymentNotStopped
 	case deploygate.StartIsProduction:
 		code = codes.App.Precondition.DeploymentIsProduction
+	case deploygate.StartSpendSuspended:
+		// Billing state, not deployment lifecycle; no dedicated code exists, so
+		// the generic precondition code carries the specific message.
+		code = codes.App.Precondition.PreconditionFailed
 	case deploygate.StartOK:
 		return nil
 	default:
@@ -153,6 +157,7 @@ func MapCtrlError(err error, action string, preconditionMsg string) error {
 			for _, r := range []deploygate.StartReason{
 				deploygate.StartNotStopped,
 				deploygate.StartIsProduction,
+				deploygate.StartSpendSuspended,
 			} {
 				if msg == r.Message() {
 					return StartFault(r)

--- a/svc/api/internal/deployment/preflight.go
+++ b/svc/api/internal/deployment/preflight.go
@@ -7,87 +7,9 @@ import (
 	"connectrpc.com/connect"
 	"github.com/unkeyed/unkey/pkg/codes"
 	"github.com/unkeyed/unkey/pkg/db"
-	"github.com/unkeyed/unkey/pkg/deploy/deploygate"
 	"github.com/unkeyed/unkey/pkg/fault"
 	"github.com/unkeyed/unkey/svc/api/internal/ctrlclient"
 )
-
-// TargetFault maps a deploygate promote/rollback rejection onto the API
-// fault with the matching precondition code, so both handlers surface the same
-// code and message for the same reason.
-func TargetFault(r deploygate.TargetFailureReason) error {
-	var code codes.Code
-	switch r {
-	case deploygate.TargetNotReady, deploygate.TargetDraining:
-		code = codes.App.Precondition.DeploymentNotReady
-	case deploygate.TargetNotProduction:
-		code = codes.App.Precondition.DeploymentNotProduction
-	case deploygate.TargetNoCurrentDeployment:
-		code = codes.App.Precondition.DeploymentNoCurrent
-	case deploygate.TargetAlreadyCurrent:
-		code = codes.App.Precondition.DeploymentIsCurrent
-	case deploygate.TargetOK:
-		return nil
-	default:
-		code = codes.App.Precondition.PreconditionFailed
-	}
-	return fault.New(
-		"deployment lifecycle precondition failed",
-		fault.Code(code.URN()),
-		fault.Internal("deploygate rejected promote/rollback: "+r.Message()),
-		fault.Public(r.Message()),
-	)
-}
-
-// StopFault maps a deploygate stop rejection onto the API fault with the
-// matching precondition code.
-func StopFault(r deploygate.StopFailureReason) error {
-	var code codes.Code
-	switch r {
-	case deploygate.StopNotRunning:
-		code = codes.App.Precondition.DeploymentNotRunning
-	case deploygate.StopAlreadyStopping:
-		code = codes.App.Precondition.DeploymentIsStopping
-	case deploygate.StopIsProduction:
-		code = codes.App.Precondition.DeploymentIsProduction
-	case deploygate.StopOK:
-		return nil
-	default:
-		code = codes.App.Precondition.PreconditionFailed
-	}
-	return fault.New(
-		"stop precondition failed",
-		fault.Code(code.URN()),
-		fault.Internal("deploygate rejected stop: "+r.Message()),
-		fault.Public(r.Message()),
-	)
-}
-
-// StartFault maps a deploygate start rejection onto the API fault with the
-// matching precondition code.
-func StartFault(r deploygate.StartFailureReason) error {
-	var code codes.Code
-	switch r {
-	case deploygate.StartNotStopped:
-		code = codes.App.Precondition.DeploymentNotStopped
-	case deploygate.StartIsProduction:
-		code = codes.App.Precondition.DeploymentIsProduction
-	case deploygate.StartSpendSuspended:
-		// Billing state, not deployment lifecycle; no dedicated code exists, so
-		// the generic precondition code carries the specific message.
-		code = codes.App.Precondition.PreconditionFailed
-	case deploygate.StartOK:
-		return nil
-	default:
-		code = codes.App.Precondition.PreconditionFailed
-	}
-	return fault.New(
-		"start precondition failed",
-		fault.Code(code.URN()),
-		fault.Internal("deploygate rejected start: "+r.Message()),
-		fault.Public(r.Message()),
-	)
-}
 
 // FindDeployment loads a deployment by ID scoped to the caller's workspace. A
 // cross-workspace match is masked as not found so a caller can't probe for
@@ -120,53 +42,22 @@ func FindDeployment(ctx context.Context, database db.Database, workspaceID, depl
 }
 
 // MapCtrlError converts a ctrl connect error from a lifecycle RPC into an API
-// fault. Ctrl re-runs the same deploygate checks the handler already passed, so
-// a precondition message matching a known gate rejection (a race: the state
-// changed between the two checks) is mapped back to its reason and surfaces the
-// identical code and message the local gate would have produced. Unrecognized
-// precondition failures (e.g. a spend-cap suspension) become a generic 412 with
-// preconditionMsg, not-found stays a 404, and everything else falls through to
-// the generic ctrl mapping.
+// fault: precondition failures become a 412 with preconditionMsg, not-found
+// stays a 404, and everything else falls through to the generic ctrl mapping.
+// Ctrl re-runs the same deploygate checks the handler already passed, so a
+// precondition failure here means the state changed between the two checks (a
+// race); the caller-supplied preconditionMsg describes the action rather than
+// leaking ctrl's internal message.
 func MapCtrlError(err error, action string, preconditionMsg string) error {
 	var connectErr *connect.Error
 	if errors.As(err, &connectErr) {
 		//nolint:exhaustive // all other Connect error codes fall through to the generic mapping
 		switch connectErr.Code() {
 		case connect.CodeFailedPrecondition:
-			msg := connectErr.Message()
-			for _, r := range []deploygate.TargetFailureReason{
-				deploygate.TargetNotReady,
-				deploygate.TargetDraining,
-				deploygate.TargetNotProduction,
-				deploygate.TargetNoCurrentDeployment,
-				deploygate.TargetAlreadyCurrent,
-			} {
-				if msg == r.Message() {
-					return TargetFault(r)
-				}
-			}
-			for _, r := range []deploygate.StopFailureReason{
-				deploygate.StopNotRunning,
-				deploygate.StopAlreadyStopping,
-				deploygate.StopIsProduction,
-			} {
-				if msg == r.Message() {
-					return StopFault(r)
-				}
-			}
-			for _, r := range []deploygate.StartFailureReason{
-				deploygate.StartNotStopped,
-				deploygate.StartIsProduction,
-				deploygate.StartSpendSuspended,
-			} {
-				if msg == r.Message() {
-					return StartFault(r)
-				}
-			}
 			return fault.Wrap(
 				err,
 				fault.Code(codes.App.Precondition.PreconditionFailed.URN()),
-				fault.Internal("ctrl reported a precondition failure: "+msg),
+				fault.Internal("ctrl reported a precondition failure: "+connectErr.Message()),
 				fault.Public(preconditionMsg),
 			)
 		case connect.CodeNotFound:

--- a/svc/api/internal/testutil/seed/seed.go
+++ b/svc/api/internal/testutil/seed/seed.go
@@ -678,6 +678,7 @@ type CreateDeploymentRequest struct {
 	AppID                  string
 	EnvironmentID          string
 	Status                 db.DeploymentsStatus
+	DesiredState           db.DeploymentsDesiredState
 	GitBranch              string
 	GitCommitSha           string
 	GitCommitMessage       string
@@ -733,6 +734,13 @@ func (s *Seeder) CreateDeployment(ctx context.Context, req CreateDeploymentReque
 		UpdatedAt:                     sql.NullInt64{Valid: false},
 	})
 	require.NoError(s.t, err)
+
+	// InsertDeployment does not take desired_state (it defaults to running), so a
+	// test that needs a stopped deployment sets it here.
+	if req.DesiredState != "" {
+		_, err = s.DB.RW().ExecContext(ctx, "UPDATE deployments SET desired_state = ? WHERE id = ?", req.DesiredState, req.ID)
+		require.NoError(s.t, err)
+	}
 
 	deployment, err := db.Query.FindDeploymentById(ctx, s.DB.RO(), req.ID)
 	require.NoError(s.t, err)

--- a/svc/api/openapi/openapi-generated.yaml
+++ b/svc/api/openapi/openapi-generated.yaml
@@ -8010,8 +8010,9 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/PreconditionFailedErrorResponse'
                     description: |
-                        Precondition failed - The deployment is not stopped, or it belongs to a
-                        production environment.
+                        Precondition failed - The deployment is not stopped, it belongs to a
+                        production environment, or the workspace is suspended by its Compute
+                        spend cap.
                 "429":
                     content:
                         application/problem+json:

--- a/svc/api/openapi/spec/paths/v2/deployments/startDeployment/index.yaml
+++ b/svc/api/openapi/spec/paths/v2/deployments/startDeployment/index.yaml
@@ -74,8 +74,9 @@ post:
             "$ref": "../../../../error/NotFoundErrorResponse.yaml"
     "412":
       description: |
-        Precondition failed - The deployment is not stopped, or it belongs to a
-        production environment.
+        Precondition failed - The deployment is not stopped, it belongs to a
+        production environment, or the workspace is suspended by its Compute
+        spend cap.
       content:
         application/json:
           schema:

--- a/svc/api/routes/v2_deployments_promote_deployment/412_test.go
+++ b/svc/api/routes/v2_deployments_promote_deployment/412_test.go
@@ -111,7 +111,7 @@ func TestPromoteDeploymentNonProduction(t *testing.T) {
 
 	res := testutil.CallRoute[handler.Request, openapi.PreconditionFailedErrorResponse](h, route, authHeaders(setup.RootKey), handler.Request{DeploymentId: dep.ID})
 	require.Equal(t, http.StatusPreconditionFailed, res.Status, "expected 412, received: %s", res.RawBody)
-	require.Contains(t, res.Body.Error.Detail, "Only production deployments can be promoted.")
+	require.Contains(t, res.Body.Error.Detail, "Only production deployments")
 	require.Contains(t, res.Body.Error.Type, "deployment_not_production")
 	require.Empty(t, mock.PromoteCalls, "ctrl must not be called for non-production deployments")
 }

--- a/svc/api/routes/v2_deployments_promote_deployment/412_test.go
+++ b/svc/api/routes/v2_deployments_promote_deployment/412_test.go
@@ -2,6 +2,7 @@ package handler_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"testing"
@@ -10,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	ctrlv1 "github.com/unkeyed/unkey/gen/proto/ctrl/v1"
 	"github.com/unkeyed/unkey/pkg/db"
+	"github.com/unkeyed/unkey/pkg/deploy/deploygate"
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
@@ -215,4 +217,47 @@ func TestPromoteDeploymentCtrlPreconditionFailed(t *testing.T) {
 	// text must stay in the logs.
 	require.Contains(t, res.Body.Error.Detail, "The deployment could not be promoted.")
 	require.NotContains(t, res.RawBody, "target deployment is already the live deployment")
+}
+
+// When ctrl rejects with a deploygate message (a race: the state changed after
+// the handler's own gate passed), the response carries the same specific code
+// and message the local gate would have produced.
+func TestPromoteDeploymentCtrlGateRejection(t *testing.T) {
+	h := testutil.NewHarness(t)
+	mock := &testutil.MockDeploymentClient{
+		PromoteFunc: func(ctx context.Context, req *ctrlv1.PromoteRequest) (*ctrlv1.PromoteResponse, error) {
+			return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New(deploygate.PromotionAlreadyCurrent.Message()))
+		},
+	}
+	route := newRoute(h, mock)
+	h.Register(route)
+
+	setup := h.CreateTestDeploymentSetup(testutil.CreateTestDeploymentSetupOptions{
+		Permissions: []string{"environment.*.promote_deployment"},
+	})
+
+	live := h.CreateDeployment(seed.CreateDeploymentRequest{
+		ID:            uid.New(uid.DeploymentPrefix),
+		WorkspaceID:   setup.Workspace.ID,
+		ProjectID:     setup.Project.ID,
+		AppID:         setup.App.ID,
+		EnvironmentID: setup.Environment.ID,
+		Status:        db.DeploymentsStatusReady,
+	})
+	setCurrentDeployment(t, h, setup.App.ID, live.ID)
+
+	target := h.CreateDeployment(seed.CreateDeploymentRequest{
+		ID:            uid.New(uid.DeploymentPrefix),
+		WorkspaceID:   setup.Workspace.ID,
+		ProjectID:     setup.Project.ID,
+		AppID:         setup.App.ID,
+		EnvironmentID: setup.Environment.ID,
+		Status:        db.DeploymentsStatusReady,
+	})
+
+	res := testutil.CallRoute[handler.Request, openapi.PreconditionFailedErrorResponse](h, route, authHeaders(setup.RootKey), handler.Request{DeploymentId: target.ID})
+	require.Equal(t, http.StatusPreconditionFailed, res.Status, "expected 412, received: %s", res.RawBody)
+	require.Len(t, mock.PromoteCalls, 1)
+	require.Contains(t, res.Body.Error.Type, "deployment_already_live")
+	require.Equal(t, deploygate.PromotionAlreadyCurrent.Message(), res.Body.Error.Detail)
 }

--- a/svc/api/routes/v2_deployments_promote_deployment/412_test.go
+++ b/svc/api/routes/v2_deployments_promote_deployment/412_test.go
@@ -226,7 +226,7 @@ func TestPromoteDeploymentCtrlGateRejection(t *testing.T) {
 	h := testutil.NewHarness(t)
 	mock := &testutil.MockDeploymentClient{
 		PromoteFunc: func(ctx context.Context, req *ctrlv1.PromoteRequest) (*ctrlv1.PromoteResponse, error) {
-			return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New(deploygate.PromotionAlreadyCurrent.Message()))
+			return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New(deploygate.TargetAlreadyCurrent.Message()))
 		},
 	}
 	route := newRoute(h, mock)
@@ -259,5 +259,5 @@ func TestPromoteDeploymentCtrlGateRejection(t *testing.T) {
 	require.Equal(t, http.StatusPreconditionFailed, res.Status, "expected 412, received: %s", res.RawBody)
 	require.Len(t, mock.PromoteCalls, 1)
 	require.Contains(t, res.Body.Error.Type, "deployment_is_current")
-	require.Equal(t, deploygate.PromotionAlreadyCurrent.Message(), res.Body.Error.Detail)
+	require.Equal(t, deploygate.TargetAlreadyCurrent.Message(), res.Body.Error.Detail)
 }

--- a/svc/api/routes/v2_deployments_promote_deployment/412_test.go
+++ b/svc/api/routes/v2_deployments_promote_deployment/412_test.go
@@ -2,7 +2,6 @@ package handler_test
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"testing"
@@ -11,7 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 	ctrlv1 "github.com/unkeyed/unkey/gen/proto/ctrl/v1"
 	"github.com/unkeyed/unkey/pkg/db"
-	"github.com/unkeyed/unkey/pkg/deploy/deploygate"
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
@@ -217,47 +215,4 @@ func TestPromoteDeploymentCtrlPreconditionFailed(t *testing.T) {
 	// text must stay in the logs.
 	require.Contains(t, res.Body.Error.Detail, "The deployment could not be promoted.")
 	require.NotContains(t, res.RawBody, "target deployment is already the live deployment")
-}
-
-// When ctrl rejects with a deploygate message (a race: the state changed after
-// the handler's own gate passed), the response carries the same specific code
-// and message the local gate would have produced.
-func TestPromoteDeploymentCtrlGateRejection(t *testing.T) {
-	h := testutil.NewHarness(t)
-	mock := &testutil.MockDeploymentClient{
-		PromoteFunc: func(ctx context.Context, req *ctrlv1.PromoteRequest) (*ctrlv1.PromoteResponse, error) {
-			return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New(deploygate.TargetAlreadyCurrent.Message()))
-		},
-	}
-	route := newRoute(h, mock)
-	h.Register(route)
-
-	setup := h.CreateTestDeploymentSetup(testutil.CreateTestDeploymentSetupOptions{
-		Permissions: []string{"environment.*.promote_deployment"},
-	})
-
-	live := h.CreateDeployment(seed.CreateDeploymentRequest{
-		ID:            uid.New(uid.DeploymentPrefix),
-		WorkspaceID:   setup.Workspace.ID,
-		ProjectID:     setup.Project.ID,
-		AppID:         setup.App.ID,
-		EnvironmentID: setup.Environment.ID,
-		Status:        db.DeploymentsStatusReady,
-	})
-	setCurrentDeployment(t, h, setup.App.ID, live.ID)
-
-	target := h.CreateDeployment(seed.CreateDeploymentRequest{
-		ID:            uid.New(uid.DeploymentPrefix),
-		WorkspaceID:   setup.Workspace.ID,
-		ProjectID:     setup.Project.ID,
-		AppID:         setup.App.ID,
-		EnvironmentID: setup.Environment.ID,
-		Status:        db.DeploymentsStatusReady,
-	})
-
-	res := testutil.CallRoute[handler.Request, openapi.PreconditionFailedErrorResponse](h, route, authHeaders(setup.RootKey), handler.Request{DeploymentId: target.ID})
-	require.Equal(t, http.StatusPreconditionFailed, res.Status, "expected 412, received: %s", res.RawBody)
-	require.Len(t, mock.PromoteCalls, 1)
-	require.Contains(t, res.Body.Error.Type, "deployment_is_current")
-	require.Equal(t, deploygate.TargetAlreadyCurrent.Message(), res.Body.Error.Detail)
 }

--- a/svc/api/routes/v2_deployments_promote_deployment/412_test.go
+++ b/svc/api/routes/v2_deployments_promote_deployment/412_test.go
@@ -258,6 +258,6 @@ func TestPromoteDeploymentCtrlGateRejection(t *testing.T) {
 	res := testutil.CallRoute[handler.Request, openapi.PreconditionFailedErrorResponse](h, route, authHeaders(setup.RootKey), handler.Request{DeploymentId: target.ID})
 	require.Equal(t, http.StatusPreconditionFailed, res.Status, "expected 412, received: %s", res.RawBody)
 	require.Len(t, mock.PromoteCalls, 1)
-	require.Contains(t, res.Body.Error.Type, "deployment_already_live")
+	require.Contains(t, res.Body.Error.Type, "deployment_is_current")
 	require.Equal(t, deploygate.PromotionAlreadyCurrent.Message(), res.Body.Error.Detail)
 }

--- a/svc/api/routes/v2_deployments_promote_deployment/handler.go
+++ b/svc/api/routes/v2_deployments_promote_deployment/handler.go
@@ -91,8 +91,8 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		CurrentDeploymentID: app.CurrentDeploymentID.String,
 		DeploymentID:        dep.ID,
 		IsRolledBack:        app.IsRolledBack,
-	}); r != deploygate.PromotionOK {
-		return deployment.PromotionFault(r)
+	}); r != deploygate.TargetOK {
+		return deployment.TargetFault(r)
 	}
 
 	_, err = h.CtrlClient.Promote(ctx, &ctrlv1.PromoteRequest{

--- a/svc/api/routes/v2_deployments_promote_deployment/handler.go
+++ b/svc/api/routes/v2_deployments_promote_deployment/handler.go
@@ -8,6 +8,7 @@ import (
 	"github.com/unkeyed/unkey/gen/rpc/ctrl"
 	"github.com/unkeyed/unkey/pkg/codes"
 	"github.com/unkeyed/unkey/pkg/db"
+	"github.com/unkeyed/unkey/pkg/deploy/deploygate"
 	"github.com/unkeyed/unkey/pkg/fault"
 	"github.com/unkeyed/unkey/pkg/rbac"
 	"github.com/unkeyed/unkey/pkg/zen"
@@ -70,66 +71,29 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		)
 	}
 
-	// The deployment starts serving live traffic the moment routes swap, so it
-	// must have completed successfully.
-	if dep.Status != db.DeploymentsStatusReady {
-		return fault.New(
-			"deployment not ready",
-			fault.Code(codes.App.Precondition.DeploymentNotReady.URN()),
-			fault.Internal("promotion target is not in ready status"),
-			fault.Public("The deployment is not ready."),
-		)
-	}
-
-	// A demoted deployment keeps status ready while it drains toward standby
-	// (only krane's final instance report flips it to stopped), so status alone
-	// would let traffic swap onto a deployment that is shutting down.
-	if dep.DesiredState != db.DeploymentsDesiredStateRunning {
-		return fault.New(
-			"deployment shutting down",
-			fault.Code(codes.App.Precondition.DeploymentNotReady.URN()),
-			fault.Internal("promotion target desired_state is not running"),
-			fault.Public("The deployment is shutting down and cannot serve traffic."),
-		)
-	}
-
-	// Promote swaps apps.current_deployment_id, which tracks the current
-	// production deployment, so it only applies to production.
-	if dep.EnvironmentSlug != "production" {
-		return fault.New(
-			"not a production deployment",
-			fault.Code(codes.App.Precondition.DeploymentNotProduction.URN()),
-			fault.Internal("promote is only allowed on production environments"),
-			fault.Public("Only production deployments can be promoted."),
-		)
-	}
-
+	// The current live pointer decides promote eligibility. See
+	// deploygate.CheckPromoteTarget for the invariant the API, ctrl service, and
+	// worker all enforce.
 	app, err := db.Query.FindAppById(ctx, h.DB.RO(), dep.AppID)
 	if err != nil {
 		return fault.Wrap(
 			err,
 			fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
 			fault.Internal("failed to load app for promotion eligibility"),
-			fault.Public("Failed to resolve the current deployment."),
+			fault.Public("Failed to resolve the current live deployment."),
 		)
 	}
-	if !app.CurrentDeploymentID.Valid || app.CurrentDeploymentID.String == "" {
-		return fault.New(
-			"no current deployment",
-			fault.Code(codes.App.Precondition.DeploymentNoCurrent.URN()),
-			fault.Internal("app has no current deployment to promote over"),
-			fault.Public("The app has no current deployment to promote over."),
-		)
-	}
-	// Promoting the current deployment is only meaningful as a rollback
-	// confirmation; otherwise it is a no-op the caller likely did not intend.
-	if app.CurrentDeploymentID.String == dep.ID && !app.IsRolledBack {
-		return fault.New(
-			"deployment is current",
-			fault.Code(codes.App.Precondition.DeploymentIsCurrent.URN()),
-			fault.Internal("promotion target is already the current deployment"),
-			fault.Public("The deployment is already the current deployment."),
-		)
+
+	if r := deploygate.CheckPromoteTarget(deploygate.Input{
+		Status:               string(dep.Status),
+		DesiredState:         string(dep.DesiredState),
+		EnvironmentSlug:      dep.EnvironmentSlug,
+		HasCurrentDeployment: app.CurrentDeploymentID.Valid && app.CurrentDeploymentID.String != "",
+		CurrentDeploymentID:  app.CurrentDeploymentID.String,
+		DeploymentID:         dep.ID,
+		IsRolledBack:         app.IsRolledBack,
+	}); r != deploygate.PromotionOK {
+		return deployment.PromotionFault(r)
 	}
 
 	_, err = h.CtrlClient.Promote(ctx, &ctrlv1.PromoteRequest{
@@ -137,7 +101,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	})
 	if err != nil {
 		return deployment.MapCtrlError(err, "promote deployment",
-			"The deployment could not be promoted. It must be ready, belong to the production environment, and not already be the current deployment.")
+			"The deployment could not be promoted. It must be ready, belong to the production environment, and not already be live.")
 	}
 
 	return s.JSON(http.StatusAccepted, Response{

--- a/svc/api/routes/v2_deployments_promote_deployment/handler.go
+++ b/svc/api/routes/v2_deployments_promote_deployment/handler.go
@@ -84,9 +84,10 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		)
 	}
 
+	//nolint:exhaustruct // SpendSuspended applies to start only
 	if r := deploygate.CheckPromoteTarget(deploygate.Input{
-		Status:               string(dep.Status),
-		DesiredState:         string(dep.DesiredState),
+		Status:               dep.Status,
+		DesiredState:         dep.DesiredState,
 		EnvironmentSlug:      dep.EnvironmentSlug,
 		HasCurrentDeployment: app.CurrentDeploymentID.Valid && app.CurrentDeploymentID.String != "",
 		CurrentDeploymentID:  app.CurrentDeploymentID.String,

--- a/svc/api/routes/v2_deployments_promote_deployment/handler.go
+++ b/svc/api/routes/v2_deployments_promote_deployment/handler.go
@@ -84,15 +84,15 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		)
 	}
 
-	if r := deploygate.CheckPromoteTarget(deploygate.PromoteInput{
+	if err := deploygate.CheckPromoteTarget(deploygate.PromoteInput{
 		Status:              dep.Status,
 		DesiredState:        dep.DesiredState,
 		EnvironmentSlug:     dep.EnvironmentSlug,
 		CurrentDeploymentID: app.CurrentDeploymentID.String,
 		DeploymentID:        dep.ID,
 		IsRolledBack:        app.IsRolledBack,
-	}); r != deploygate.TargetOK {
-		return deployment.TargetFault(r)
+	}); err != nil {
+		return err
 	}
 
 	_, err = h.CtrlClient.Promote(ctx, &ctrlv1.PromoteRequest{

--- a/svc/api/routes/v2_deployments_promote_deployment/handler.go
+++ b/svc/api/routes/v2_deployments_promote_deployment/handler.go
@@ -84,14 +84,13 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		)
 	}
 
-	//nolint:exhaustruct // SpendSuspended applies to start only
-	if r := deploygate.CheckPromoteTarget(deploygate.Input{
-		Status:               dep.Status,
-		DesiredState:         dep.DesiredState,
-		EnvironmentSlug:      dep.EnvironmentSlug,
-		CurrentDeploymentID:  app.CurrentDeploymentID.String,
-		DeploymentID:         dep.ID,
-		IsRolledBack:         app.IsRolledBack,
+	if r := deploygate.CheckPromoteTarget(deploygate.PromoteInput{
+		Status:              dep.Status,
+		DesiredState:        dep.DesiredState,
+		EnvironmentSlug:     dep.EnvironmentSlug,
+		CurrentDeploymentID: app.CurrentDeploymentID.String,
+		DeploymentID:        dep.ID,
+		IsRolledBack:        app.IsRolledBack,
 	}); r != deploygate.PromotionOK {
 		return deployment.PromotionFault(r)
 	}

--- a/svc/api/routes/v2_deployments_promote_deployment/handler.go
+++ b/svc/api/routes/v2_deployments_promote_deployment/handler.go
@@ -89,7 +89,6 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		Status:               dep.Status,
 		DesiredState:         dep.DesiredState,
 		EnvironmentSlug:      dep.EnvironmentSlug,
-		HasCurrentDeployment: app.CurrentDeploymentID.Valid && app.CurrentDeploymentID.String != "",
 		CurrentDeploymentID:  app.CurrentDeploymentID.String,
 		DeploymentID:         dep.ID,
 		IsRolledBack:         app.IsRolledBack,

--- a/svc/api/routes/v2_deployments_rollback_deployment/412_test.go
+++ b/svc/api/routes/v2_deployments_rollback_deployment/412_test.go
@@ -2,6 +2,7 @@ package handler_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"testing"
@@ -10,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	ctrlv1 "github.com/unkeyed/unkey/gen/proto/ctrl/v1"
 	"github.com/unkeyed/unkey/pkg/db"
+	"github.com/unkeyed/unkey/pkg/deploy/deploygate"
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
@@ -213,4 +215,46 @@ func TestRollbackDeploymentCtrlPreconditionFailed(t *testing.T) {
 	// text must stay in the logs.
 	require.Contains(t, res.Body.Error.Detail, "The rollback could not be performed.")
 	require.NotContains(t, res.RawBody, "source deployment is not the current live deployment")
+}
+
+// When ctrl rejects with a deploygate message (a race: the target started
+// draining after the handler's own gate passed), the response carries the same
+// specific code and message the local gate would have produced.
+func TestRollbackDeploymentCtrlGateRejection(t *testing.T) {
+	h := testutil.NewHarness(t)
+	mock := &testutil.MockDeploymentClient{
+		RollbackFunc: func(ctx context.Context, req *ctrlv1.RollbackRequest) (*ctrlv1.RollbackResponse, error) {
+			return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New(deploygate.PromotionDraining.Message()))
+		},
+	}
+	route := newRoute(h, mock)
+	h.Register(route)
+
+	setup := h.CreateTestDeploymentSetup(testutil.CreateTestDeploymentSetupOptions{
+		Permissions: []string{"environment.*.rollback_deployment"},
+	})
+
+	previous := h.CreateDeployment(seed.CreateDeploymentRequest{
+		ID:            uid.New(uid.DeploymentPrefix),
+		WorkspaceID:   setup.Workspace.ID,
+		ProjectID:     setup.Project.ID,
+		AppID:         setup.App.ID,
+		EnvironmentID: setup.Environment.ID,
+		Status:        db.DeploymentsStatusReady,
+	})
+	live := h.CreateDeployment(seed.CreateDeploymentRequest{
+		ID:            uid.New(uid.DeploymentPrefix),
+		WorkspaceID:   setup.Workspace.ID,
+		ProjectID:     setup.Project.ID,
+		AppID:         setup.App.ID,
+		EnvironmentID: setup.Environment.ID,
+		Status:        db.DeploymentsStatusReady,
+	})
+	setCurrentDeployment(t, h, setup.App.ID, live.ID)
+
+	res := testutil.CallRoute[handler.Request, openapi.PreconditionFailedErrorResponse](h, route, authHeaders(setup.RootKey), handler.Request{DeploymentId: previous.ID})
+	require.Equal(t, http.StatusPreconditionFailed, res.Status, "expected 412, received: %s", res.RawBody)
+	require.Len(t, mock.RollbackCalls, 1)
+	require.Contains(t, res.Body.Error.Type, "deployment_not_ready")
+	require.Equal(t, deploygate.PromotionDraining.Message(), res.Body.Error.Detail)
 }

--- a/svc/api/routes/v2_deployments_rollback_deployment/412_test.go
+++ b/svc/api/routes/v2_deployments_rollback_deployment/412_test.go
@@ -112,7 +112,7 @@ func TestRollbackDeploymentNonProduction(t *testing.T) {
 
 	res := testutil.CallRoute[handler.Request, openapi.PreconditionFailedErrorResponse](h, route, authHeaders(setup.RootKey), handler.Request{DeploymentId: dep.ID})
 	require.Equal(t, http.StatusPreconditionFailed, res.Status, "expected 412, received: %s", res.RawBody)
-	require.Contains(t, res.Body.Error.Detail, "Only production deployments can be rolled back.")
+	require.Contains(t, res.Body.Error.Detail, "Only production deployments")
 	require.Contains(t, res.Body.Error.Type, "deployment_not_production")
 	require.Empty(t, mock.RollbackCalls, "ctrl must not be called for non-production deployments")
 }

--- a/svc/api/routes/v2_deployments_rollback_deployment/412_test.go
+++ b/svc/api/routes/v2_deployments_rollback_deployment/412_test.go
@@ -2,7 +2,6 @@ package handler_test
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"testing"
@@ -11,7 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 	ctrlv1 "github.com/unkeyed/unkey/gen/proto/ctrl/v1"
 	"github.com/unkeyed/unkey/pkg/db"
-	"github.com/unkeyed/unkey/pkg/deploy/deploygate"
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
@@ -215,46 +213,4 @@ func TestRollbackDeploymentCtrlPreconditionFailed(t *testing.T) {
 	// text must stay in the logs.
 	require.Contains(t, res.Body.Error.Detail, "The rollback could not be performed.")
 	require.NotContains(t, res.RawBody, "source deployment is not the current live deployment")
-}
-
-// When ctrl rejects with a deploygate message (a race: the target started
-// draining after the handler's own gate passed), the response carries the same
-// specific code and message the local gate would have produced.
-func TestRollbackDeploymentCtrlGateRejection(t *testing.T) {
-	h := testutil.NewHarness(t)
-	mock := &testutil.MockDeploymentClient{
-		RollbackFunc: func(ctx context.Context, req *ctrlv1.RollbackRequest) (*ctrlv1.RollbackResponse, error) {
-			return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New(deploygate.TargetDraining.Message()))
-		},
-	}
-	route := newRoute(h, mock)
-	h.Register(route)
-
-	setup := h.CreateTestDeploymentSetup(testutil.CreateTestDeploymentSetupOptions{
-		Permissions: []string{"environment.*.rollback_deployment"},
-	})
-
-	previous := h.CreateDeployment(seed.CreateDeploymentRequest{
-		ID:            uid.New(uid.DeploymentPrefix),
-		WorkspaceID:   setup.Workspace.ID,
-		ProjectID:     setup.Project.ID,
-		AppID:         setup.App.ID,
-		EnvironmentID: setup.Environment.ID,
-		Status:        db.DeploymentsStatusReady,
-	})
-	live := h.CreateDeployment(seed.CreateDeploymentRequest{
-		ID:            uid.New(uid.DeploymentPrefix),
-		WorkspaceID:   setup.Workspace.ID,
-		ProjectID:     setup.Project.ID,
-		AppID:         setup.App.ID,
-		EnvironmentID: setup.Environment.ID,
-		Status:        db.DeploymentsStatusReady,
-	})
-	setCurrentDeployment(t, h, setup.App.ID, live.ID)
-
-	res := testutil.CallRoute[handler.Request, openapi.PreconditionFailedErrorResponse](h, route, authHeaders(setup.RootKey), handler.Request{DeploymentId: previous.ID})
-	require.Equal(t, http.StatusPreconditionFailed, res.Status, "expected 412, received: %s", res.RawBody)
-	require.Len(t, mock.RollbackCalls, 1)
-	require.Contains(t, res.Body.Error.Type, "deployment_not_ready")
-	require.Equal(t, deploygate.TargetDraining.Message(), res.Body.Error.Detail)
 }

--- a/svc/api/routes/v2_deployments_rollback_deployment/412_test.go
+++ b/svc/api/routes/v2_deployments_rollback_deployment/412_test.go
@@ -224,7 +224,7 @@ func TestRollbackDeploymentCtrlGateRejection(t *testing.T) {
 	h := testutil.NewHarness(t)
 	mock := &testutil.MockDeploymentClient{
 		RollbackFunc: func(ctx context.Context, req *ctrlv1.RollbackRequest) (*ctrlv1.RollbackResponse, error) {
-			return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New(deploygate.PromotionDraining.Message()))
+			return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New(deploygate.TargetDraining.Message()))
 		},
 	}
 	route := newRoute(h, mock)
@@ -256,5 +256,5 @@ func TestRollbackDeploymentCtrlGateRejection(t *testing.T) {
 	require.Equal(t, http.StatusPreconditionFailed, res.Status, "expected 412, received: %s", res.RawBody)
 	require.Len(t, mock.RollbackCalls, 1)
 	require.Contains(t, res.Body.Error.Type, "deployment_not_ready")
-	require.Equal(t, deploygate.PromotionDraining.Message(), res.Body.Error.Detail)
+	require.Equal(t, deploygate.TargetDraining.Message(), res.Body.Error.Detail)
 }

--- a/svc/api/routes/v2_deployments_rollback_deployment/handler.go
+++ b/svc/api/routes/v2_deployments_rollback_deployment/handler.go
@@ -85,14 +85,14 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		)
 	}
 
-	if r := deploygate.CheckRollbackTarget(deploygate.RollbackInput{
+	if err := deploygate.CheckRollbackTarget(deploygate.RollbackInput{
 		Status:              dep.Status,
 		DesiredState:        dep.DesiredState,
 		EnvironmentSlug:     dep.EnvironmentSlug,
 		CurrentDeploymentID: app.CurrentDeploymentID.String,
 		DeploymentID:        dep.ID,
-	}); r != deploygate.TargetOK {
-		return deployment.TargetFault(r)
+	}); err != nil {
+		return err
 	}
 
 	_, err = h.CtrlClient.Rollback(ctx, &ctrlv1.RollbackRequest{

--- a/svc/api/routes/v2_deployments_rollback_deployment/handler.go
+++ b/svc/api/routes/v2_deployments_rollback_deployment/handler.go
@@ -85,9 +85,10 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		)
 	}
 
+	//nolint:exhaustruct // SpendSuspended applies to start only
 	if r := deploygate.CheckRollbackTarget(deploygate.Input{
-		Status:               string(dep.Status),
-		DesiredState:         string(dep.DesiredState),
+		Status:               dep.Status,
+		DesiredState:         dep.DesiredState,
 		EnvironmentSlug:      dep.EnvironmentSlug,
 		HasCurrentDeployment: app.CurrentDeploymentID.Valid && app.CurrentDeploymentID.String != "",
 		CurrentDeploymentID:  app.CurrentDeploymentID.String,

--- a/svc/api/routes/v2_deployments_rollback_deployment/handler.go
+++ b/svc/api/routes/v2_deployments_rollback_deployment/handler.go
@@ -90,7 +90,6 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		Status:               dep.Status,
 		DesiredState:         dep.DesiredState,
 		EnvironmentSlug:      dep.EnvironmentSlug,
-		HasCurrentDeployment: app.CurrentDeploymentID.Valid && app.CurrentDeploymentID.String != "",
 		CurrentDeploymentID:  app.CurrentDeploymentID.String,
 		DeploymentID:         dep.ID,
 		IsRolledBack:         app.IsRolledBack,

--- a/svc/api/routes/v2_deployments_rollback_deployment/handler.go
+++ b/svc/api/routes/v2_deployments_rollback_deployment/handler.go
@@ -91,8 +91,8 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		EnvironmentSlug:     dep.EnvironmentSlug,
 		CurrentDeploymentID: app.CurrentDeploymentID.String,
 		DeploymentID:        dep.ID,
-	}); r != deploygate.PromotionOK {
-		return deployment.PromotionFault(r)
+	}); r != deploygate.TargetOK {
+		return deployment.TargetFault(r)
 	}
 
 	_, err = h.CtrlClient.Rollback(ctx, &ctrlv1.RollbackRequest{

--- a/svc/api/routes/v2_deployments_rollback_deployment/handler.go
+++ b/svc/api/routes/v2_deployments_rollback_deployment/handler.go
@@ -85,14 +85,12 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		)
 	}
 
-	//nolint:exhaustruct // SpendSuspended applies to start only
-	if r := deploygate.CheckRollbackTarget(deploygate.Input{
-		Status:               dep.Status,
-		DesiredState:         dep.DesiredState,
-		EnvironmentSlug:      dep.EnvironmentSlug,
-		CurrentDeploymentID:  app.CurrentDeploymentID.String,
-		DeploymentID:         dep.ID,
-		IsRolledBack:         app.IsRolledBack,
+	if r := deploygate.CheckRollbackTarget(deploygate.RollbackInput{
+		Status:              dep.Status,
+		DesiredState:        dep.DesiredState,
+		EnvironmentSlug:     dep.EnvironmentSlug,
+		CurrentDeploymentID: app.CurrentDeploymentID.String,
+		DeploymentID:        dep.ID,
 	}); r != deploygate.PromotionOK {
 		return deployment.PromotionFault(r)
 	}

--- a/svc/api/routes/v2_deployments_rollback_deployment/handler.go
+++ b/svc/api/routes/v2_deployments_rollback_deployment/handler.go
@@ -8,6 +8,7 @@ import (
 	"github.com/unkeyed/unkey/gen/rpc/ctrl"
 	"github.com/unkeyed/unkey/pkg/codes"
 	"github.com/unkeyed/unkey/pkg/db"
+	"github.com/unkeyed/unkey/pkg/deploy/deploygate"
 	"github.com/unkeyed/unkey/pkg/fault"
 	"github.com/unkeyed/unkey/pkg/rbac"
 	"github.com/unkeyed/unkey/pkg/zen"
@@ -70,69 +71,30 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		)
 	}
 
-	// The target starts serving live traffic the moment routes swap, so it
-	// must have completed successfully.
-	if dep.Status != db.DeploymentsStatusReady {
-		return fault.New(
-			"deployment not ready",
-			fault.Code(codes.App.Precondition.DeploymentNotReady.URN()),
-			fault.Internal("rollback target is not in ready status"),
-			fault.Public("The deployment to roll back to is not ready."),
-		)
-	}
-
-	// A demoted deployment keeps status ready while it drains toward standby
-	// (only krane's final instance report flips it to stopped), so status alone
-	// would let traffic swap onto a deployment that is shutting down.
-	if dep.DesiredState != db.DeploymentsDesiredStateRunning {
-		return fault.New(
-			"deployment shutting down",
-			fault.Code(codes.App.Precondition.DeploymentNotReady.URN()),
-			fault.Internal("rollback target desired_state is not running"),
-			fault.Public("The deployment to roll back to is shutting down and cannot serve traffic."),
-		)
-	}
-
-	// Rollback swaps apps.current_deployment_id, which tracks the current
-	// production deployment, so it only applies to production.
-	if dep.EnvironmentSlug != "production" {
-		return fault.New(
-			"not a production deployment",
-			fault.Code(codes.App.Precondition.DeploymentNotProduction.URN()),
-			fault.Internal("rollback is only allowed on production environments"),
-			fault.Public("Only production deployments can be rolled back."),
-		)
-	}
-
-	// The caller only names the deployment to roll back TO. The rollback source
-	// must be the app's current deployment, so it is derived here rather
-	// than trusted from input. The ctrl workflow re-validates, so a concurrent
-	// promotion that moves the current deployment out from under us fails the
-	// rollback rather than swapping traffic onto a stale source.
+	// The rollback source is derived from the app's current live pointer, not
+	// trusted from input. The ctrl workflow re-validates, so a concurrent promotion
+	// that moves the pointer fails the rollback rather than swapping traffic onto a
+	// stale source.
 	app, err := db.Query.FindAppById(ctx, h.DB.RO(), dep.AppID)
 	if err != nil {
 		return fault.Wrap(
 			err,
 			fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
 			fault.Internal("failed to load app for rollback source derivation"),
-			fault.Public("Failed to resolve the current deployment."),
+			fault.Public("Failed to resolve the current live deployment."),
 		)
 	}
-	if !app.CurrentDeploymentID.Valid || app.CurrentDeploymentID.String == "" {
-		return fault.New(
-			"no current deployment",
-			fault.Code(codes.App.Precondition.DeploymentNoCurrent.URN()),
-			fault.Internal("app has no current deployment to roll back from"),
-			fault.Public("The app has no current deployment to roll back from."),
-		)
-	}
-	if app.CurrentDeploymentID.String == dep.ID {
-		return fault.New(
-			"deployment is current",
-			fault.Code(codes.App.Precondition.DeploymentIsCurrent.URN()),
-			fault.Internal("rollback target is already the current deployment"),
-			fault.Public("The deployment is already the current deployment."),
-		)
+
+	if r := deploygate.CheckRollbackTarget(deploygate.Input{
+		Status:               string(dep.Status),
+		DesiredState:         string(dep.DesiredState),
+		EnvironmentSlug:      dep.EnvironmentSlug,
+		HasCurrentDeployment: app.CurrentDeploymentID.Valid && app.CurrentDeploymentID.String != "",
+		CurrentDeploymentID:  app.CurrentDeploymentID.String,
+		DeploymentID:         dep.ID,
+		IsRolledBack:         app.IsRolledBack,
+	}); r != deploygate.PromotionOK {
+		return deployment.PromotionFault(r)
 	}
 
 	_, err = h.CtrlClient.Rollback(ctx, &ctrlv1.RollbackRequest{
@@ -141,7 +103,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	})
 	if err != nil {
 		return deployment.MapCtrlError(err, "rollback deployment",
-			"The rollback could not be performed. The target must be a ready production deployment in the same app and environment as the current deployment.")
+			"The rollback could not be performed. The target must be a ready production deployment in the same app and environment as the current live deployment.")
 	}
 
 	return s.JSON(http.StatusAccepted, Response{

--- a/svc/api/routes/v2_deployments_start_deployment/202_test.go
+++ b/svc/api/routes/v2_deployments_start_deployment/202_test.go
@@ -40,6 +40,7 @@ func TestStartDeployment(t *testing.T) {
 		AppID:         setup.App.ID,
 		EnvironmentID: preview.ID,
 		Status:        db.DeploymentsStatusStopped,
+		DesiredState:  db.DeploymentsDesiredStateStopped,
 		GitBranch:     "KEBAP",
 	})
 
@@ -77,6 +78,7 @@ func TestStartDeploymentScopedPermission(t *testing.T) {
 		AppID:         setup.App.ID,
 		EnvironmentID: preview.ID,
 		Status:        db.DeploymentsStatusStopped,
+		DesiredState:  db.DeploymentsDesiredStateStopped,
 	})
 
 	rootKey := h.CreateRootKey(setup.Workspace.ID, "environment."+preview.ID+".start_deployment")

--- a/svc/api/routes/v2_deployments_start_deployment/202_test.go
+++ b/svc/api/routes/v2_deployments_start_deployment/202_test.go
@@ -53,6 +53,48 @@ func TestStartDeployment(t *testing.T) {
 	require.Equal(t, dep.ID, mock.WakeDeploymentCalls[0].GetDeploymentId())
 }
 
+// Stopping sets desired_state=stopped immediately while status stays ready
+// until krane drains the last instance. Start keys on the intent, so a
+// deployment still draining is wakeable.
+func TestStartDeploymentWhileDraining(t *testing.T) {
+	h := testutil.NewHarness(t)
+	mock := &testutil.MockDeploymentClient{}
+	route := newRoute(h, mock)
+	h.Register(route)
+
+	setup := h.CreateTestDeploymentSetup(testutil.CreateTestDeploymentSetupOptions{
+		Permissions: []string{"environment.*.start_deployment"},
+	})
+
+	preview := h.CreateEnvironment(seed.CreateEnvironmentRequest{
+		ID:          uid.New(uid.EnvironmentPrefix),
+		WorkspaceID: setup.Workspace.ID,
+		ProjectID:   setup.Project.ID,
+		AppID:       setup.App.ID,
+		Slug:        "preview",
+		Description: "preview environment",
+	})
+
+	dep := h.CreateDeployment(seed.CreateDeploymentRequest{
+		ID:            uid.New(uid.DeploymentPrefix),
+		WorkspaceID:   setup.Workspace.ID,
+		ProjectID:     setup.Project.ID,
+		AppID:         setup.App.ID,
+		EnvironmentID: preview.ID,
+		Status:        db.DeploymentsStatusReady,
+		DesiredState:  db.DeploymentsDesiredStateStopped,
+		GitBranch:     "KEBAP",
+	})
+
+	res := testutil.CallRoute[handler.Request, handler.Response](h, route, authHeaders(setup.RootKey), handler.Request{
+		DeploymentId: dep.ID,
+	})
+	require.Equal(t, http.StatusAccepted, res.Status, "expected 202, received: %s", res.RawBody)
+
+	require.Len(t, mock.WakeDeploymentCalls, 1)
+	require.Equal(t, dep.ID, mock.WakeDeploymentCalls[0].GetDeploymentId())
+}
+
 // The environment-scoped permission must work as well as the wildcard.
 func TestStartDeploymentScopedPermission(t *testing.T) {
 	h := testutil.NewHarness(t)

--- a/svc/api/routes/v2_deployments_start_deployment/412_test.go
+++ b/svc/api/routes/v2_deployments_start_deployment/412_test.go
@@ -2,7 +2,6 @@ package handler_test
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"testing"
@@ -119,49 +118,6 @@ func TestStartDeploymentCtrlPreconditionFailed(t *testing.T) {
 	// text must stay in the logs.
 	require.Contains(t, res.Body.Error.Detail, "The deployment could not be started.")
 	require.NotContains(t, res.RawBody, "deployment is not stopped")
-}
-
-// When ctrl rejects with a deploygate message (a race: the deployment was
-// started concurrently after the handler's own gate passed), the response
-// carries the same specific code and message the local gate would have produced.
-func TestStartDeploymentCtrlGateRejection(t *testing.T) {
-	h := testutil.NewHarness(t)
-	mock := &testutil.MockDeploymentClient{
-		WakeDeploymentFunc: func(ctx context.Context, req *ctrlv1.WakeDeploymentRequest) (*ctrlv1.WakeDeploymentResponse, error) {
-			return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New(deploygate.StartNotStopped.Message()))
-		},
-	}
-	route := newRoute(h, mock)
-	h.Register(route)
-
-	setup := h.CreateTestDeploymentSetup(testutil.CreateTestDeploymentSetupOptions{
-		Permissions: []string{"environment.*.start_deployment"},
-	})
-
-	preview := h.CreateEnvironment(seed.CreateEnvironmentRequest{
-		ID:          uid.New(uid.EnvironmentPrefix),
-		WorkspaceID: setup.Workspace.ID,
-		ProjectID:   setup.Project.ID,
-		AppID:       setup.App.ID,
-		Slug:        "preview",
-		Description: "preview environment",
-	})
-
-	dep := h.CreateDeployment(seed.CreateDeploymentRequest{
-		ID:            uid.New(uid.DeploymentPrefix),
-		WorkspaceID:   setup.Workspace.ID,
-		ProjectID:     setup.Project.ID,
-		AppID:         setup.App.ID,
-		EnvironmentID: preview.ID,
-		Status:        db.DeploymentsStatusStopped,
-		DesiredState:  db.DeploymentsDesiredStateStopped,
-	})
-
-	res := testutil.CallRoute[handler.Request, openapi.PreconditionFailedErrorResponse](h, route, authHeaders(setup.RootKey), handler.Request{DeploymentId: dep.ID})
-	require.Equal(t, http.StatusPreconditionFailed, res.Status, "expected 412, received: %s", res.RawBody)
-	require.Len(t, mock.WakeDeploymentCalls, 1)
-	require.Contains(t, res.Body.Error.Type, "deployment_not_stopped")
-	require.Equal(t, deploygate.StartNotStopped.Message(), res.Body.Error.Detail)
 }
 
 // Starting resumes compute spend, so a workspace suspended by its Compute

--- a/svc/api/routes/v2_deployments_start_deployment/412_test.go
+++ b/svc/api/routes/v2_deployments_start_deployment/412_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"connectrpc.com/connect"
 	"github.com/stretchr/testify/require"
@@ -161,4 +162,49 @@ func TestStartDeploymentCtrlGateRejection(t *testing.T) {
 	require.Len(t, mock.WakeDeploymentCalls, 1)
 	require.Contains(t, res.Body.Error.Type, "deployment_not_stopped")
 	require.Equal(t, deploygate.StartNotStopped.Message(), res.Body.Error.Detail)
+}
+
+// Starting resumes compute spend, so a workspace suspended by its Compute
+// spend cap is rejected before ctrl is called, with the billing reason rather
+// than a misleading lifecycle message.
+func TestStartDeploymentSpendSuspended(t *testing.T) {
+	h := testutil.NewHarness(t)
+	mock := &testutil.MockDeploymentClient{}
+	route := newRoute(h, mock)
+	h.Register(route)
+
+	setup := h.CreateTestDeploymentSetup(testutil.CreateTestDeploymentSetupOptions{
+		Permissions: []string{"environment.*.start_deployment"},
+	})
+
+	preview := h.CreateEnvironment(seed.CreateEnvironmentRequest{
+		ID:          uid.New(uid.EnvironmentPrefix),
+		WorkspaceID: setup.Workspace.ID,
+		ProjectID:   setup.Project.ID,
+		AppID:       setup.App.ID,
+		Slug:        "preview",
+		Description: "preview environment",
+	})
+
+	dep := h.CreateDeployment(seed.CreateDeploymentRequest{
+		ID:            uid.New(uid.DeploymentPrefix),
+		WorkspaceID:   setup.Workspace.ID,
+		ProjectID:     setup.Project.ID,
+		AppID:         setup.App.ID,
+		EnvironmentID: preview.ID,
+		Status:        db.DeploymentsStatusStopped,
+		DesiredState:  db.DeploymentsDesiredStateStopped,
+	})
+
+	_, err := h.DB.RW().ExecContext(context.Background(),
+		"INSERT INTO workspace_billing (workspace_id, spend_suspended, created_at_m) VALUES (?, true, ?) ON DUPLICATE KEY UPDATE spend_suspended = true",
+		setup.Workspace.ID, time.Now().UnixMilli(),
+	)
+	require.NoError(t, err)
+
+	res := testutil.CallRoute[handler.Request, openapi.PreconditionFailedErrorResponse](h, route, authHeaders(setup.RootKey), handler.Request{DeploymentId: dep.ID})
+	require.Equal(t, http.StatusPreconditionFailed, res.Status, "expected 412, received: %s", res.RawBody)
+	require.Contains(t, res.Body.Error.Type, "precondition_failed")
+	require.Equal(t, deploygate.StartSpendSuspended.Message(), res.Body.Error.Detail)
+	require.Empty(t, mock.WakeDeploymentCalls, "ctrl must not be called for a spend-suspended workspace")
 }

--- a/svc/api/routes/v2_deployments_start_deployment/412_test.go
+++ b/svc/api/routes/v2_deployments_start_deployment/412_test.go
@@ -2,6 +2,7 @@ package handler_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"testing"
@@ -10,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	ctrlv1 "github.com/unkeyed/unkey/gen/proto/ctrl/v1"
 	"github.com/unkeyed/unkey/pkg/db"
+	"github.com/unkeyed/unkey/pkg/deploy/deploygate"
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
@@ -116,4 +118,47 @@ func TestStartDeploymentCtrlPreconditionFailed(t *testing.T) {
 	// text must stay in the logs.
 	require.Contains(t, res.Body.Error.Detail, "The deployment could not be started.")
 	require.NotContains(t, res.RawBody, "deployment is not stopped")
+}
+
+// When ctrl rejects with a deploygate message (a race: the deployment was
+// started concurrently after the handler's own gate passed), the response
+// carries the same specific code and message the local gate would have produced.
+func TestStartDeploymentCtrlGateRejection(t *testing.T) {
+	h := testutil.NewHarness(t)
+	mock := &testutil.MockDeploymentClient{
+		WakeDeploymentFunc: func(ctx context.Context, req *ctrlv1.WakeDeploymentRequest) (*ctrlv1.WakeDeploymentResponse, error) {
+			return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New(deploygate.StartNotStopped.Message()))
+		},
+	}
+	route := newRoute(h, mock)
+	h.Register(route)
+
+	setup := h.CreateTestDeploymentSetup(testutil.CreateTestDeploymentSetupOptions{
+		Permissions: []string{"environment.*.start_deployment"},
+	})
+
+	preview := h.CreateEnvironment(seed.CreateEnvironmentRequest{
+		ID:          uid.New(uid.EnvironmentPrefix),
+		WorkspaceID: setup.Workspace.ID,
+		ProjectID:   setup.Project.ID,
+		AppID:       setup.App.ID,
+		Slug:        "preview",
+		Description: "preview environment",
+	})
+
+	dep := h.CreateDeployment(seed.CreateDeploymentRequest{
+		ID:            uid.New(uid.DeploymentPrefix),
+		WorkspaceID:   setup.Workspace.ID,
+		ProjectID:     setup.Project.ID,
+		AppID:         setup.App.ID,
+		EnvironmentID: preview.ID,
+		Status:        db.DeploymentsStatusStopped,
+		DesiredState:  db.DeploymentsDesiredStateStopped,
+	})
+
+	res := testutil.CallRoute[handler.Request, openapi.PreconditionFailedErrorResponse](h, route, authHeaders(setup.RootKey), handler.Request{DeploymentId: dep.ID})
+	require.Equal(t, http.StatusPreconditionFailed, res.Status, "expected 412, received: %s", res.RawBody)
+	require.Len(t, mock.WakeDeploymentCalls, 1)
+	require.Contains(t, res.Body.Error.Type, "deployment_not_stopped")
+	require.Equal(t, deploygate.StartNotStopped.Message(), res.Body.Error.Detail)
 }

--- a/svc/api/routes/v2_deployments_start_deployment/412_test.go
+++ b/svc/api/routes/v2_deployments_start_deployment/412_test.go
@@ -63,6 +63,7 @@ func TestStartDeploymentProduction(t *testing.T) {
 		AppID:         setup.App.ID,
 		EnvironmentID: setup.Environment.ID,
 		Status:        db.DeploymentsStatusStopped,
+		DesiredState:  db.DeploymentsDesiredStateStopped,
 	})
 
 	res := testutil.CallRoute[handler.Request, openapi.PreconditionFailedErrorResponse](h, route, authHeaders(setup.RootKey), handler.Request{DeploymentId: dep.ID})
@@ -104,6 +105,7 @@ func TestStartDeploymentCtrlPreconditionFailed(t *testing.T) {
 		AppID:         setup.App.ID,
 		EnvironmentID: preview.ID,
 		Status:        db.DeploymentsStatusStopped,
+		DesiredState:  db.DeploymentsDesiredStateStopped,
 	})
 
 	res := testutil.CallRoute[handler.Request, openapi.PreconditionFailedErrorResponse](h, route, authHeaders(setup.RootKey), handler.Request{DeploymentId: dep.ID})

--- a/svc/api/routes/v2_deployments_start_deployment/handler.go
+++ b/svc/api/routes/v2_deployments_start_deployment/handler.go
@@ -86,7 +86,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	// "Stopped" is keyed on desired_state, not status: stopping sets
 	// desired_state=stopped immediately while status only flips once krane drains
 	// the last instance.
-	if r := deploygate.CheckStartable(deploygate.StartInput{
+	if r := deploygate.CheckStartTarget(deploygate.StartInput{
 		DesiredState:    dep.DesiredState,
 		EnvironmentSlug: dep.EnvironmentSlug,
 		SpendSuspended:  billing.SpendSuspended,

--- a/svc/api/routes/v2_deployments_start_deployment/handler.go
+++ b/svc/api/routes/v2_deployments_start_deployment/handler.go
@@ -71,13 +71,26 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		)
 	}
 
+	// A missing billing row means the workspace was never linked to billing and
+	// is not suspended.
+	billing, err := db.Query.FindWorkspaceBillingByWorkspaceID(ctx, h.DB.RO(), principal.WorkspaceID)
+	if err != nil && !db.IsNotFound(err) {
+		return fault.Wrap(
+			err,
+			fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
+			fault.Internal("database error loading workspace billing"),
+			fault.Public("Failed to retrieve workspace billing state."),
+		)
+	}
+
 	// "Stopped" is keyed on desired_state, not status: stopping sets
 	// desired_state=stopped immediately while status only flips once krane drains
 	// the last instance.
-	//nolint:exhaustruct // start only uses the desired state and environment fields
+	//nolint:exhaustruct // start only uses the desired state, environment, and spend fields
 	if r := deploygate.CheckStartable(deploygate.Input{
 		DesiredState:    string(dep.DesiredState),
 		EnvironmentSlug: dep.EnvironmentSlug,
+		SpendSuspended:  billing.SpendSuspended,
 	}); r != deploygate.StartOK {
 		return deployment.StartFault(r)
 	}

--- a/svc/api/routes/v2_deployments_start_deployment/handler.go
+++ b/svc/api/routes/v2_deployments_start_deployment/handler.go
@@ -86,12 +86,12 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	// "Stopped" is keyed on desired_state, not status: stopping sets
 	// desired_state=stopped immediately while status only flips once krane drains
 	// the last instance.
-	if r := deploygate.CheckStartTarget(deploygate.StartInput{
+	if err := deploygate.CheckStartTarget(deploygate.StartInput{
 		DesiredState:    dep.DesiredState,
 		EnvironmentSlug: dep.EnvironmentSlug,
 		SpendSuspended:  billing.SpendSuspended,
-	}); r != deploygate.StartOK {
-		return deployment.StartFault(r)
+	}); err != nil {
+		return err
 	}
 
 	_, err = h.CtrlClient.WakeDeployment(ctx, &ctrlv1.WakeDeploymentRequest{

--- a/svc/api/routes/v2_deployments_start_deployment/handler.go
+++ b/svc/api/routes/v2_deployments_start_deployment/handler.go
@@ -8,6 +8,7 @@ import (
 	"github.com/unkeyed/unkey/gen/rpc/ctrl"
 	"github.com/unkeyed/unkey/pkg/codes"
 	"github.com/unkeyed/unkey/pkg/db"
+	"github.com/unkeyed/unkey/pkg/deploy/deploygate"
 	"github.com/unkeyed/unkey/pkg/fault"
 	"github.com/unkeyed/unkey/pkg/rbac"
 	"github.com/unkeyed/unkey/pkg/zen"
@@ -70,23 +71,15 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		)
 	}
 
-	if dep.Status != db.DeploymentsStatusStopped {
-		return fault.New(
-			"deployment not stopped",
-			fault.Code(codes.App.Precondition.DeploymentNotStopped.URN()),
-			fault.Internal("start target is not in stopped status"),
-			fault.Public("The deployment is not stopped."),
-		)
-	}
-
-	// Production deployments are never stopped, so this action does not apply.
-	if dep.EnvironmentSlug == "production" {
-		return fault.New(
-			"production deployment",
-			fault.Code(codes.App.Precondition.DeploymentIsProduction.URN()),
-			fault.Internal("start is not allowed on production environments"),
-			fault.Public("Production deployments cannot be started."),
-		)
+	// "Stopped" is keyed on desired_state, not status: stopping sets
+	// desired_state=stopped immediately while status only flips once krane drains
+	// the last instance.
+	//nolint:exhaustruct // start only uses the desired state and environment fields
+	if r := deploygate.CheckStartable(deploygate.Input{
+		DesiredState:    string(dep.DesiredState),
+		EnvironmentSlug: dep.EnvironmentSlug,
+	}); r != deploygate.StartOK {
+		return deployment.StartFault(r)
 	}
 
 	_, err = h.CtrlClient.WakeDeployment(ctx, &ctrlv1.WakeDeploymentRequest{

--- a/svc/api/routes/v2_deployments_start_deployment/handler.go
+++ b/svc/api/routes/v2_deployments_start_deployment/handler.go
@@ -86,8 +86,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	// "Stopped" is keyed on desired_state, not status: stopping sets
 	// desired_state=stopped immediately while status only flips once krane drains
 	// the last instance.
-	//nolint:exhaustruct // start only uses the desired state, environment, and spend fields
-	if r := deploygate.CheckStartable(deploygate.Input{
+	if r := deploygate.CheckStartable(deploygate.StartInput{
 		DesiredState:    dep.DesiredState,
 		EnvironmentSlug: dep.EnvironmentSlug,
 		SpendSuspended:  billing.SpendSuspended,

--- a/svc/api/routes/v2_deployments_start_deployment/handler.go
+++ b/svc/api/routes/v2_deployments_start_deployment/handler.go
@@ -88,7 +88,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	// the last instance.
 	//nolint:exhaustruct // start only uses the desired state, environment, and spend fields
 	if r := deploygate.CheckStartable(deploygate.Input{
-		DesiredState:    string(dep.DesiredState),
+		DesiredState:    dep.DesiredState,
 		EnvironmentSlug: dep.EnvironmentSlug,
 		SpendSuspended:  billing.SpendSuspended,
 	}); r != deploygate.StartOK {

--- a/svc/api/routes/v2_deployments_stop_deployment/412_test.go
+++ b/svc/api/routes/v2_deployments_stop_deployment/412_test.go
@@ -199,6 +199,6 @@ func TestStopDeploymentCtrlGateRejection(t *testing.T) {
 	res := testutil.CallRoute[handler.Request, openapi.PreconditionFailedErrorResponse](h, route, authHeaders(setup.RootKey), handler.Request{DeploymentId: dep.ID})
 	require.Equal(t, http.StatusPreconditionFailed, res.Status, "expected 412, received: %s", res.RawBody)
 	require.Len(t, mock.StopDeploymentCalls, 1)
-	require.Contains(t, res.Body.Error.Type, "deployment_already_stopping")
+	require.Contains(t, res.Body.Error.Type, "deployment_is_stopping")
 	require.Equal(t, deploygate.StopAlreadyStopping.Message(), res.Body.Error.Detail)
 }

--- a/svc/api/routes/v2_deployments_stop_deployment/412_test.go
+++ b/svc/api/routes/v2_deployments_stop_deployment/412_test.go
@@ -2,6 +2,7 @@ package handler_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"testing"
@@ -10,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	ctrlv1 "github.com/unkeyed/unkey/gen/proto/ctrl/v1"
 	"github.com/unkeyed/unkey/pkg/db"
+	"github.com/unkeyed/unkey/pkg/deploy/deploygate"
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
@@ -157,4 +159,46 @@ func TestStopDeploymentCtrlPreconditionFailed(t *testing.T) {
 	// text must stay in the logs.
 	require.Contains(t, res.Body.Error.Detail, "The deployment could not be stopped.")
 	require.NotContains(t, res.RawBody, "deployment is not running")
+}
+
+// When ctrl rejects with a deploygate message (a race: a stop was already in
+// flight when the handler's own gate passed), the response carries the same
+// specific code and message the local gate would have produced.
+func TestStopDeploymentCtrlGateRejection(t *testing.T) {
+	h := testutil.NewHarness(t)
+	mock := &testutil.MockDeploymentClient{
+		StopDeploymentFunc: func(ctx context.Context, req *ctrlv1.StopDeploymentRequest) (*ctrlv1.StopDeploymentResponse, error) {
+			return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New(deploygate.StopAlreadyStopping.Message()))
+		},
+	}
+	route := newRoute(h, mock)
+	h.Register(route)
+
+	setup := h.CreateTestDeploymentSetup(testutil.CreateTestDeploymentSetupOptions{
+		Permissions: []string{"environment.*.stop_deployment"},
+	})
+
+	preview := h.CreateEnvironment(seed.CreateEnvironmentRequest{
+		ID:          uid.New(uid.EnvironmentPrefix),
+		WorkspaceID: setup.Workspace.ID,
+		ProjectID:   setup.Project.ID,
+		AppID:       setup.App.ID,
+		Slug:        "preview",
+		Description: "preview environment",
+	})
+
+	dep := h.CreateDeployment(seed.CreateDeploymentRequest{
+		ID:            uid.New(uid.DeploymentPrefix),
+		WorkspaceID:   setup.Workspace.ID,
+		ProjectID:     setup.Project.ID,
+		AppID:         setup.App.ID,
+		EnvironmentID: preview.ID,
+		Status:        db.DeploymentsStatusReady,
+	})
+
+	res := testutil.CallRoute[handler.Request, openapi.PreconditionFailedErrorResponse](h, route, authHeaders(setup.RootKey), handler.Request{DeploymentId: dep.ID})
+	require.Equal(t, http.StatusPreconditionFailed, res.Status, "expected 412, received: %s", res.RawBody)
+	require.Len(t, mock.StopDeploymentCalls, 1)
+	require.Contains(t, res.Body.Error.Type, "deployment_already_stopping")
+	require.Equal(t, deploygate.StopAlreadyStopping.Message(), res.Body.Error.Detail)
 }

--- a/svc/api/routes/v2_deployments_stop_deployment/412_test.go
+++ b/svc/api/routes/v2_deployments_stop_deployment/412_test.go
@@ -2,7 +2,6 @@ package handler_test
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"testing"
@@ -11,7 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 	ctrlv1 "github.com/unkeyed/unkey/gen/proto/ctrl/v1"
 	"github.com/unkeyed/unkey/pkg/db"
-	"github.com/unkeyed/unkey/pkg/deploy/deploygate"
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
@@ -159,46 +157,4 @@ func TestStopDeploymentCtrlPreconditionFailed(t *testing.T) {
 	// text must stay in the logs.
 	require.Contains(t, res.Body.Error.Detail, "The deployment could not be stopped.")
 	require.NotContains(t, res.RawBody, "deployment is not running")
-}
-
-// When ctrl rejects with a deploygate message (a race: a stop was already in
-// flight when the handler's own gate passed), the response carries the same
-// specific code and message the local gate would have produced.
-func TestStopDeploymentCtrlGateRejection(t *testing.T) {
-	h := testutil.NewHarness(t)
-	mock := &testutil.MockDeploymentClient{
-		StopDeploymentFunc: func(ctx context.Context, req *ctrlv1.StopDeploymentRequest) (*ctrlv1.StopDeploymentResponse, error) {
-			return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New(deploygate.StopAlreadyStopping.Message()))
-		},
-	}
-	route := newRoute(h, mock)
-	h.Register(route)
-
-	setup := h.CreateTestDeploymentSetup(testutil.CreateTestDeploymentSetupOptions{
-		Permissions: []string{"environment.*.stop_deployment"},
-	})
-
-	preview := h.CreateEnvironment(seed.CreateEnvironmentRequest{
-		ID:          uid.New(uid.EnvironmentPrefix),
-		WorkspaceID: setup.Workspace.ID,
-		ProjectID:   setup.Project.ID,
-		AppID:       setup.App.ID,
-		Slug:        "preview",
-		Description: "preview environment",
-	})
-
-	dep := h.CreateDeployment(seed.CreateDeploymentRequest{
-		ID:            uid.New(uid.DeploymentPrefix),
-		WorkspaceID:   setup.Workspace.ID,
-		ProjectID:     setup.Project.ID,
-		AppID:         setup.App.ID,
-		EnvironmentID: preview.ID,
-		Status:        db.DeploymentsStatusReady,
-	})
-
-	res := testutil.CallRoute[handler.Request, openapi.PreconditionFailedErrorResponse](h, route, authHeaders(setup.RootKey), handler.Request{DeploymentId: dep.ID})
-	require.Equal(t, http.StatusPreconditionFailed, res.Status, "expected 412, received: %s", res.RawBody)
-	require.Len(t, mock.StopDeploymentCalls, 1)
-	require.Contains(t, res.Body.Error.Type, "deployment_is_stopping")
-	require.Equal(t, deploygate.StopAlreadyStopping.Message(), res.Body.Error.Detail)
 }

--- a/svc/api/routes/v2_deployments_stop_deployment/handler.go
+++ b/svc/api/routes/v2_deployments_stop_deployment/handler.go
@@ -8,6 +8,7 @@ import (
 	"github.com/unkeyed/unkey/gen/rpc/ctrl"
 	"github.com/unkeyed/unkey/pkg/codes"
 	"github.com/unkeyed/unkey/pkg/db"
+	"github.com/unkeyed/unkey/pkg/deploy/deploygate"
 	"github.com/unkeyed/unkey/pkg/fault"
 	"github.com/unkeyed/unkey/pkg/rbac"
 	"github.com/unkeyed/unkey/pkg/zen"
@@ -70,36 +71,15 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		)
 	}
 
-	if dep.Status != db.DeploymentsStatusReady {
-		return fault.New(
-			"deployment not running",
-			fault.Code(codes.App.Precondition.DeploymentNotRunning.URN()),
-			fault.Internal("stop target is not in ready status"),
-			fault.Public("The deployment is not running."),
-		)
-	}
-
 	// A draining deployment keeps status ready until krane removes its last
-	// instance, so desired_state is the only signal that a stop is already in
-	// flight. Ctrl enforces the same rule; checking it here avoids a doomed
-	// round-trip and returns a precise message.
-	if dep.DesiredState != db.DeploymentsDesiredStateRunning {
-		return fault.New(
-			"deployment is stopping",
-			fault.Code(codes.App.Precondition.DeploymentIsStopping.URN()),
-			fault.Internal("stop target desired_state is not running"),
-			fault.Public("The deployment is already stopping."),
-		)
-	}
-
-	// Production deployments are never stopped, so this action does not apply.
-	if dep.EnvironmentSlug == "production" {
-		return fault.New(
-			"production deployment",
-			fault.Code(codes.App.Precondition.DeploymentIsProduction.URN()),
-			fault.Internal("stop is not allowed on production environments"),
-			fault.Public("Production deployments cannot be stopped."),
-		)
+	// instance, so desired_state is the signal that a stop is already in flight.
+	//nolint:exhaustruct // stop only uses the runtime status and environment fields
+	if r := deploygate.CheckStoppable(deploygate.Input{
+		Status:          string(dep.Status),
+		DesiredState:    string(dep.DesiredState),
+		EnvironmentSlug: dep.EnvironmentSlug,
+	}); r != deploygate.StopOK {
+		return deployment.StopFault(r)
 	}
 
 	_, err = h.CtrlClient.StopDeployment(ctx, &ctrlv1.StopDeploymentRequest{

--- a/svc/api/routes/v2_deployments_stop_deployment/handler.go
+++ b/svc/api/routes/v2_deployments_stop_deployment/handler.go
@@ -73,8 +73,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 	// A draining deployment keeps status ready until krane removes its last
 	// instance, so desired_state is the signal that a stop is already in flight.
-	//nolint:exhaustruct // stop only uses the runtime status and environment fields
-	if r := deploygate.CheckStoppable(deploygate.Input{
+	if r := deploygate.CheckStoppable(deploygate.StopInput{
 		Status:          dep.Status,
 		DesiredState:    dep.DesiredState,
 		EnvironmentSlug: dep.EnvironmentSlug,

--- a/svc/api/routes/v2_deployments_stop_deployment/handler.go
+++ b/svc/api/routes/v2_deployments_stop_deployment/handler.go
@@ -73,7 +73,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 	// A draining deployment keeps status ready until krane removes its last
 	// instance, so desired_state is the signal that a stop is already in flight.
-	if r := deploygate.CheckStoppable(deploygate.StopInput{
+	if r := deploygate.CheckStopTarget(deploygate.StopInput{
 		Status:          dep.Status,
 		DesiredState:    dep.DesiredState,
 		EnvironmentSlug: dep.EnvironmentSlug,

--- a/svc/api/routes/v2_deployments_stop_deployment/handler.go
+++ b/svc/api/routes/v2_deployments_stop_deployment/handler.go
@@ -75,8 +75,8 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	// instance, so desired_state is the signal that a stop is already in flight.
 	//nolint:exhaustruct // stop only uses the runtime status and environment fields
 	if r := deploygate.CheckStoppable(deploygate.Input{
-		Status:          string(dep.Status),
-		DesiredState:    string(dep.DesiredState),
+		Status:          dep.Status,
+		DesiredState:    dep.DesiredState,
 		EnvironmentSlug: dep.EnvironmentSlug,
 	}); r != deploygate.StopOK {
 		return deployment.StopFault(r)

--- a/svc/api/routes/v2_deployments_stop_deployment/handler.go
+++ b/svc/api/routes/v2_deployments_stop_deployment/handler.go
@@ -73,12 +73,12 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 	// A draining deployment keeps status ready until krane removes its last
 	// instance, so desired_state is the signal that a stop is already in flight.
-	if r := deploygate.CheckStopTarget(deploygate.StopInput{
+	if err := deploygate.CheckStopTarget(deploygate.StopInput{
 		Status:          dep.Status,
 		DesiredState:    dep.DesiredState,
 		EnvironmentSlug: dep.EnvironmentSlug,
-	}); r != deploygate.StopOK {
-		return deployment.StopFault(r)
+	}); err != nil {
+		return err
 	}
 
 	_, err = h.CtrlClient.StopDeployment(ctx, &ctrlv1.StopDeploymentRequest{

--- a/svc/ctrl/api/deployment_promote_rollback_test.go
+++ b/svc/ctrl/api/deployment_promote_rollback_test.go
@@ -12,6 +12,7 @@ import (
 	ctrlv1 "github.com/unkeyed/unkey/gen/proto/ctrl/v1"
 	"github.com/unkeyed/unkey/gen/proto/ctrl/v1/ctrlv1connect"
 	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
+	"github.com/unkeyed/unkey/pkg/deploy/deploygate"
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/svc/ctrl/integration/seed"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/db"
@@ -179,20 +180,20 @@ func TestDeployment_Promote_Validation(t *testing.T) {
 		{"deployment not found", connect.CodeNotFound, "deployment not found", func() string {
 			return uid.New("deployment")
 		}},
-		{"not ready", connect.CodeFailedPrecondition, "deployment is not ready", func() string {
+		{"not ready", connect.CodeFailedPrecondition, deploygate.PromotionNotReady.Message(), func() string {
 			return f.deployment(f.prodEnv, db.DeploymentsStatusPending, db.DeploymentsDesiredStateRunning).ID
 		}},
-		{"shutting down", connect.CodeFailedPrecondition, "deployment is shutting down", func() string {
+		{"shutting down", connect.CodeFailedPrecondition, deploygate.PromotionDraining.Message(), func() string {
 			return f.deployment(f.prodEnv, db.DeploymentsStatusReady, db.DeploymentsDesiredStateStopped).ID
 		}},
-		{"non-production", connect.CodeFailedPrecondition, "only production deployments can be promoted", func() string {
+		{"non-production", connect.CodeFailedPrecondition, deploygate.PromotionNotProduction.Message(), func() string {
 			return f.deployment(f.previewEnv, db.DeploymentsStatusReady, db.DeploymentsDesiredStateRunning).ID
 		}},
-		{"app has no live deployment", connect.CodeFailedPrecondition, "app has no live deployment", func() string {
+		{"app has no live deployment", connect.CodeFailedPrecondition, deploygate.PromotionNoCurrentDeployment.Message(), func() string {
 			f.setLive("", false)
 			return f.deployment(f.prodEnv, db.DeploymentsStatusReady, db.DeploymentsDesiredStateRunning).ID
 		}},
-		{"already live", connect.CodeFailedPrecondition, "deployment is already live", func() string {
+		{"already live", connect.CodeFailedPrecondition, deploygate.PromotionAlreadyCurrent.Message(), func() string {
 			d := f.deployment(f.prodEnv, db.DeploymentsStatusReady, db.DeploymentsDesiredStateRunning)
 			f.setLive(d.ID, false)
 			return d.ID
@@ -243,31 +244,42 @@ func TestDeployment_Rollback_Validation(t *testing.T) {
 			return f.deployment(f.prodEnv, db.DeploymentsStatusReady, db.DeploymentsDesiredStateRunning).ID, uid.New("deployment")
 		}},
 		{"different environment", connect.CodeFailedPrecondition, "same environment", func() (string, string) {
-			return f.deployment(f.prodEnv, db.DeploymentsStatusReady, db.DeploymentsDesiredStateRunning).ID,
-				f.deployment(f.previewEnv, db.DeploymentsStatusReady, db.DeploymentsDesiredStateRunning).ID
+			// The target must pass the shared gate (production, ready, running), so
+			// the source lives in preview to make the environment-mismatch assert fire.
+			source := f.deployment(f.previewEnv, db.DeploymentsStatusReady, db.DeploymentsDesiredStateRunning)
+			target := f.deployment(f.prodEnv, db.DeploymentsStatusReady, db.DeploymentsDesiredStateRunning)
+			f.setLive(source.ID, false)
+			return source.ID, target.ID
 		}},
-		{"target not ready", connect.CodeFailedPrecondition, "target deployment is not ready", func() (string, string) {
+		{"target not ready", connect.CodeFailedPrecondition, deploygate.PromotionNotReady.Message(), func() (string, string) {
 			source := f.deployment(f.prodEnv, db.DeploymentsStatusReady, db.DeploymentsDesiredStateRunning)
 			target := f.deployment(f.prodEnv, db.DeploymentsStatusPending, db.DeploymentsDesiredStateRunning)
 			f.setLive(source.ID, false)
 			return source.ID, target.ID
 		}},
-		{"target shutting down", connect.CodeFailedPrecondition, "target deployment is shutting down", func() (string, string) {
+		{"target shutting down", connect.CodeFailedPrecondition, deploygate.PromotionDraining.Message(), func() (string, string) {
 			source := f.deployment(f.prodEnv, db.DeploymentsStatusReady, db.DeploymentsDesiredStateRunning)
 			target := f.deployment(f.prodEnv, db.DeploymentsStatusReady, db.DeploymentsDesiredStateStopped)
 			f.setLive(source.ID, false)
 			return source.ID, target.ID
 		}},
-		{"non-production", connect.CodeFailedPrecondition, "only production deployments can be rolled back", func() (string, string) {
+		{"non-production", connect.CodeFailedPrecondition, deploygate.PromotionNotProduction.Message(), func() (string, string) {
 			source := f.deployment(f.previewEnv, db.DeploymentsStatusReady, db.DeploymentsDesiredStateRunning)
 			target := f.deployment(f.previewEnv, db.DeploymentsStatusReady, db.DeploymentsDesiredStateRunning)
 			f.setLive(source.ID, false)
 			return source.ID, target.ID
 		}},
-		{"source not current live", connect.CodeFailedPrecondition, "source deployment is not the current live deployment", func() (string, string) {
+		{"target already live", connect.CodeFailedPrecondition, deploygate.PromotionAlreadyCurrent.Message(), func() (string, string) {
 			source := f.deployment(f.prodEnv, db.DeploymentsStatusReady, db.DeploymentsDesiredStateRunning)
 			target := f.deployment(f.prodEnv, db.DeploymentsStatusReady, db.DeploymentsDesiredStateRunning)
 			f.setLive(target.ID, false)
+			return source.ID, target.ID
+		}},
+		{"source not current live", connect.CodeFailedPrecondition, "source deployment is not the current live deployment", func() (string, string) {
+			live := f.deployment(f.prodEnv, db.DeploymentsStatusReady, db.DeploymentsDesiredStateRunning)
+			source := f.deployment(f.prodEnv, db.DeploymentsStatusReady, db.DeploymentsDesiredStateRunning)
+			target := f.deployment(f.prodEnv, db.DeploymentsStatusReady, db.DeploymentsDesiredStateRunning)
+			f.setLive(live.ID, false)
 			return source.ID, target.ID
 		}},
 	}

--- a/svc/ctrl/api/deployment_promote_rollback_test.go
+++ b/svc/ctrl/api/deployment_promote_rollback_test.go
@@ -180,20 +180,20 @@ func TestDeployment_Promote_Validation(t *testing.T) {
 		{"deployment not found", connect.CodeNotFound, "deployment not found", func() string {
 			return uid.New("deployment")
 		}},
-		{"not ready", connect.CodeFailedPrecondition, deploygate.PromotionNotReady.Message(), func() string {
+		{"not ready", connect.CodeFailedPrecondition, deploygate.TargetNotReady.Message(), func() string {
 			return f.deployment(f.prodEnv, db.DeploymentsStatusPending, db.DeploymentsDesiredStateRunning).ID
 		}},
-		{"shutting down", connect.CodeFailedPrecondition, deploygate.PromotionDraining.Message(), func() string {
+		{"shutting down", connect.CodeFailedPrecondition, deploygate.TargetDraining.Message(), func() string {
 			return f.deployment(f.prodEnv, db.DeploymentsStatusReady, db.DeploymentsDesiredStateStopped).ID
 		}},
-		{"non-production", connect.CodeFailedPrecondition, deploygate.PromotionNotProduction.Message(), func() string {
+		{"non-production", connect.CodeFailedPrecondition, deploygate.TargetNotProduction.Message(), func() string {
 			return f.deployment(f.previewEnv, db.DeploymentsStatusReady, db.DeploymentsDesiredStateRunning).ID
 		}},
-		{"app has no live deployment", connect.CodeFailedPrecondition, deploygate.PromotionNoCurrentDeployment.Message(), func() string {
+		{"app has no live deployment", connect.CodeFailedPrecondition, deploygate.TargetNoCurrentDeployment.Message(), func() string {
 			f.setLive("", false)
 			return f.deployment(f.prodEnv, db.DeploymentsStatusReady, db.DeploymentsDesiredStateRunning).ID
 		}},
-		{"already live", connect.CodeFailedPrecondition, deploygate.PromotionAlreadyCurrent.Message(), func() string {
+		{"already live", connect.CodeFailedPrecondition, deploygate.TargetAlreadyCurrent.Message(), func() string {
 			d := f.deployment(f.prodEnv, db.DeploymentsStatusReady, db.DeploymentsDesiredStateRunning)
 			f.setLive(d.ID, false)
 			return d.ID
@@ -251,25 +251,25 @@ func TestDeployment_Rollback_Validation(t *testing.T) {
 			f.setLive(source.ID, false)
 			return source.ID, target.ID
 		}},
-		{"target not ready", connect.CodeFailedPrecondition, deploygate.PromotionNotReady.Message(), func() (string, string) {
+		{"target not ready", connect.CodeFailedPrecondition, deploygate.TargetNotReady.Message(), func() (string, string) {
 			source := f.deployment(f.prodEnv, db.DeploymentsStatusReady, db.DeploymentsDesiredStateRunning)
 			target := f.deployment(f.prodEnv, db.DeploymentsStatusPending, db.DeploymentsDesiredStateRunning)
 			f.setLive(source.ID, false)
 			return source.ID, target.ID
 		}},
-		{"target shutting down", connect.CodeFailedPrecondition, deploygate.PromotionDraining.Message(), func() (string, string) {
+		{"target shutting down", connect.CodeFailedPrecondition, deploygate.TargetDraining.Message(), func() (string, string) {
 			source := f.deployment(f.prodEnv, db.DeploymentsStatusReady, db.DeploymentsDesiredStateRunning)
 			target := f.deployment(f.prodEnv, db.DeploymentsStatusReady, db.DeploymentsDesiredStateStopped)
 			f.setLive(source.ID, false)
 			return source.ID, target.ID
 		}},
-		{"non-production", connect.CodeFailedPrecondition, deploygate.PromotionNotProduction.Message(), func() (string, string) {
+		{"non-production", connect.CodeFailedPrecondition, deploygate.TargetNotProduction.Message(), func() (string, string) {
 			source := f.deployment(f.previewEnv, db.DeploymentsStatusReady, db.DeploymentsDesiredStateRunning)
 			target := f.deployment(f.previewEnv, db.DeploymentsStatusReady, db.DeploymentsDesiredStateRunning)
 			f.setLive(source.ID, false)
 			return source.ID, target.ID
 		}},
-		{"target already live", connect.CodeFailedPrecondition, deploygate.PromotionAlreadyCurrent.Message(), func() (string, string) {
+		{"target already live", connect.CodeFailedPrecondition, deploygate.TargetAlreadyCurrent.Message(), func() (string, string) {
 			source := f.deployment(f.prodEnv, db.DeploymentsStatusReady, db.DeploymentsDesiredStateRunning)
 			target := f.deployment(f.prodEnv, db.DeploymentsStatusReady, db.DeploymentsDesiredStateRunning)
 			f.setLive(target.ID, false)

--- a/svc/ctrl/api/deployment_promote_rollback_test.go
+++ b/svc/ctrl/api/deployment_promote_rollback_test.go
@@ -183,7 +183,7 @@ func TestDeployment_Promote_Validation(t *testing.T) {
 		{"not ready", connect.CodeFailedPrecondition, deploygate.TargetNotReady.Message(), func() string {
 			return f.deployment(f.prodEnv, db.DeploymentsStatusPending, db.DeploymentsDesiredStateRunning).ID
 		}},
-		{"shutting down", connect.CodeFailedPrecondition, deploygate.TargetDraining.Message(), func() string {
+		{"shutting down", connect.CodeFailedPrecondition, deploygate.TargetIsDraining.Message(), func() string {
 			return f.deployment(f.prodEnv, db.DeploymentsStatusReady, db.DeploymentsDesiredStateStopped).ID
 		}},
 		{"non-production", connect.CodeFailedPrecondition, deploygate.TargetNotProduction.Message(), func() string {
@@ -193,7 +193,7 @@ func TestDeployment_Promote_Validation(t *testing.T) {
 			f.setLive("", false)
 			return f.deployment(f.prodEnv, db.DeploymentsStatusReady, db.DeploymentsDesiredStateRunning).ID
 		}},
-		{"already live", connect.CodeFailedPrecondition, deploygate.TargetAlreadyCurrent.Message(), func() string {
+		{"already live", connect.CodeFailedPrecondition, deploygate.TargetIsCurrent.Message(), func() string {
 			d := f.deployment(f.prodEnv, db.DeploymentsStatusReady, db.DeploymentsDesiredStateRunning)
 			f.setLive(d.ID, false)
 			return d.ID
@@ -257,7 +257,7 @@ func TestDeployment_Rollback_Validation(t *testing.T) {
 			f.setLive(source.ID, false)
 			return source.ID, target.ID
 		}},
-		{"target shutting down", connect.CodeFailedPrecondition, deploygate.TargetDraining.Message(), func() (string, string) {
+		{"target shutting down", connect.CodeFailedPrecondition, deploygate.TargetIsDraining.Message(), func() (string, string) {
 			source := f.deployment(f.prodEnv, db.DeploymentsStatusReady, db.DeploymentsDesiredStateRunning)
 			target := f.deployment(f.prodEnv, db.DeploymentsStatusReady, db.DeploymentsDesiredStateStopped)
 			f.setLive(source.ID, false)
@@ -269,7 +269,7 @@ func TestDeployment_Rollback_Validation(t *testing.T) {
 			f.setLive(source.ID, false)
 			return source.ID, target.ID
 		}},
-		{"target already live", connect.CodeFailedPrecondition, deploygate.TargetAlreadyCurrent.Message(), func() (string, string) {
+		{"target already live", connect.CodeFailedPrecondition, deploygate.TargetIsCurrent.Message(), func() (string, string) {
 			source := f.deployment(f.prodEnv, db.DeploymentsStatusReady, db.DeploymentsDesiredStateRunning)
 			target := f.deployment(f.prodEnv, db.DeploymentsStatusReady, db.DeploymentsDesiredStateRunning)
 			f.setLive(target.ID, false)

--- a/svc/ctrl/internal/gatefault/gatefault.go
+++ b/svc/ctrl/internal/gatefault/gatefault.go
@@ -1,0 +1,30 @@
+// Package gatefault converts a deploygate precondition fault into ctrl's error
+// surfaces. It surfaces only fault.UserFacingMessage — never err.Error(), which
+// carries internal detail — so callers can't leak it by mistake.
+package gatefault
+
+import (
+	"errors"
+
+	"connectrpc.com/connect"
+	restate "github.com/restatedev/sdk-go"
+	"github.com/unkeyed/unkey/pkg/fault"
+)
+
+// Connect converts a deploygate fault into a connect FailedPrecondition error,
+// or nil when err is nil. For ctrl RPC services.
+func Connect(err error) error {
+	if err == nil {
+		return nil
+	}
+	return connect.NewError(connect.CodeFailedPrecondition, errors.New(fault.UserFacingMessage(err)))
+}
+
+// Terminal converts a deploygate fault into a restate terminal error (400), or
+// nil when err is nil. For ctrl Restate workers.
+func Terminal(err error) error {
+	if err == nil {
+		return nil
+	}
+	return restate.TerminalError(errors.New(fault.UserFacingMessage(err)), 400)
+}

--- a/svc/ctrl/internal/gatefault/gatefault_test.go
+++ b/svc/ctrl/internal/gatefault/gatefault_test.go
@@ -1,0 +1,35 @@
+package gatefault_test
+
+import (
+	"errors"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/fault"
+	"github.com/unkeyed/unkey/svc/ctrl/internal/gatefault"
+)
+
+func TestConnect(t *testing.T) {
+	require.NoError(t, gatefault.Connect(nil))
+
+	f := fault.New("internal detail", fault.Public("The deployment is not ready."))
+	err := gatefault.Connect(f)
+
+	var ce *connect.Error
+	require.True(t, errors.As(err, &ce))
+	require.Equal(t, connect.CodeFailedPrecondition, ce.Code())
+	require.Equal(t, "The deployment is not ready.", ce.Message())
+	require.NotContains(t, ce.Message(), "internal detail")
+}
+
+func TestTerminal(t *testing.T) {
+	require.NoError(t, gatefault.Terminal(nil))
+
+	f := fault.New("internal detail", fault.Public("The deployment is not ready."))
+	err := gatefault.Terminal(f)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "The deployment is not ready.")
+	require.NotContains(t, err.Error(), "internal detail")
+}

--- a/svc/ctrl/services/deployment/promote.go
+++ b/svc/ctrl/services/deployment/promote.go
@@ -2,7 +2,6 @@ package deployment
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"connectrpc.com/connect"
@@ -13,6 +12,7 @@ import (
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/auth"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/db"
+	"github.com/unkeyed/unkey/svc/ctrl/internal/gatefault"
 )
 
 // Promote reassigns all domains to the target deployment via a Restate workflow.
@@ -40,15 +40,15 @@ func (s *Service) Promote(ctx context.Context, req *connect.Request[ctrlv1.Promo
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to load deployment: %w", err))
 	}
 
-	if r := deploygate.CheckPromoteTarget(deploygate.PromoteInput{
+	if err := deploygate.CheckPromoteTarget(deploygate.PromoteInput{
 		Status:              pkgdb.DeploymentsStatus(deployment.Status),
 		DesiredState:        pkgdb.DeploymentsDesiredState(deployment.DesiredState),
 		EnvironmentSlug:     deployment.EnvironmentSlug,
 		CurrentDeploymentID: deployment.CurrentDeploymentID.String,
 		DeploymentID:        deployment.ID,
 		IsRolledBack:        deployment.IsRolledBack,
-	}); r != deploygate.TargetOK {
-		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New(r.Message()))
+	}); err != nil {
+		return nil, gatefault.Connect(err)
 	}
 
 	logger.Info("initiating promotion via Restate",

--- a/svc/ctrl/services/deployment/promote.go
+++ b/svc/ctrl/services/deployment/promote.go
@@ -40,14 +40,13 @@ func (s *Service) Promote(ctx context.Context, req *connect.Request[ctrlv1.Promo
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to load deployment: %w", err))
 	}
 
-	//nolint:exhaustruct // SpendSuspended applies to start only
-	if r := deploygate.CheckPromoteTarget(deploygate.Input{
-		Status:               pkgdb.DeploymentsStatus(deployment.Status),
-		DesiredState:         pkgdb.DeploymentsDesiredState(deployment.DesiredState),
-		EnvironmentSlug:      deployment.EnvironmentSlug,
-		CurrentDeploymentID:  deployment.CurrentDeploymentID.String,
-		DeploymentID:         deployment.ID,
-		IsRolledBack:         deployment.IsRolledBack,
+	if r := deploygate.CheckPromoteTarget(deploygate.PromoteInput{
+		Status:              pkgdb.DeploymentsStatus(deployment.Status),
+		DesiredState:        pkgdb.DeploymentsDesiredState(deployment.DesiredState),
+		EnvironmentSlug:     deployment.EnvironmentSlug,
+		CurrentDeploymentID: deployment.CurrentDeploymentID.String,
+		DeploymentID:        deployment.ID,
+		IsRolledBack:        deployment.IsRolledBack,
 	}); r != deploygate.PromotionOK {
 		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New(r.Message()))
 	}

--- a/svc/ctrl/services/deployment/promote.go
+++ b/svc/ctrl/services/deployment/promote.go
@@ -45,7 +45,6 @@ func (s *Service) Promote(ctx context.Context, req *connect.Request[ctrlv1.Promo
 		Status:               pkgdb.DeploymentsStatus(deployment.Status),
 		DesiredState:         pkgdb.DeploymentsDesiredState(deployment.DesiredState),
 		EnvironmentSlug:      deployment.EnvironmentSlug,
-		HasCurrentDeployment: deployment.CurrentDeploymentID.Valid && deployment.CurrentDeploymentID.String != "",
 		CurrentDeploymentID:  deployment.CurrentDeploymentID.String,
 		DeploymentID:         deployment.ID,
 		IsRolledBack:         deployment.IsRolledBack,

--- a/svc/ctrl/services/deployment/promote.go
+++ b/svc/ctrl/services/deployment/promote.go
@@ -2,12 +2,13 @@ package deployment
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"connectrpc.com/connect"
 	ctrlv1 "github.com/unkeyed/unkey/gen/proto/ctrl/v1"
 	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
-	"github.com/unkeyed/unkey/pkg/assert"
+	"github.com/unkeyed/unkey/pkg/deploy/deploygate"
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/auth"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/db"
@@ -38,17 +39,16 @@ func (s *Service) Promote(ctx context.Context, req *connect.Request[ctrlv1.Promo
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to load deployment: %w", err))
 	}
 
-	// A demoted deployment keeps status ready while it drains toward standby, so
-	// status alone would let traffic swap onto one shutting down. Promoting the
-	// current live deployment is a no-op unless it is confirming a rollback.
-	if err := assert.All(
-		assert.Equal(deployment.Status, db.DeploymentsStatusReady, "deployment is not ready"),
-		assert.Equal(deployment.DesiredState, db.DeploymentsDesiredStateRunning, "deployment is shutting down"),
-		assert.Equal(deployment.EnvironmentSlug, "production", "only production deployments can be promoted"),
-		assert.True(deployment.CurrentDeploymentID.Valid, "app has no live deployment"),
-		assert.False(deployment.CurrentDeploymentID.String == deployment.ID && !deployment.IsRolledBack, "deployment is already live"),
-	); err != nil {
-		return nil, connect.NewError(connect.CodeFailedPrecondition, err)
+	if r := deploygate.CheckPromoteTarget(deploygate.Input{
+		Status:               string(deployment.Status),
+		DesiredState:         string(deployment.DesiredState),
+		EnvironmentSlug:      deployment.EnvironmentSlug,
+		HasCurrentDeployment: deployment.CurrentDeploymentID.Valid && deployment.CurrentDeploymentID.String != "",
+		CurrentDeploymentID:  deployment.CurrentDeploymentID.String,
+		DeploymentID:         deployment.ID,
+		IsRolledBack:         deployment.IsRolledBack,
+	}); r != deploygate.PromotionOK {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New(r.Message()))
 	}
 
 	logger.Info("initiating promotion via Restate",

--- a/svc/ctrl/services/deployment/promote.go
+++ b/svc/ctrl/services/deployment/promote.go
@@ -8,6 +8,7 @@ import (
 	"connectrpc.com/connect"
 	ctrlv1 "github.com/unkeyed/unkey/gen/proto/ctrl/v1"
 	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
+	pkgdb "github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/deploy/deploygate"
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/auth"
@@ -39,9 +40,10 @@ func (s *Service) Promote(ctx context.Context, req *connect.Request[ctrlv1.Promo
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to load deployment: %w", err))
 	}
 
+	//nolint:exhaustruct // SpendSuspended applies to start only
 	if r := deploygate.CheckPromoteTarget(deploygate.Input{
-		Status:               string(deployment.Status),
-		DesiredState:         string(deployment.DesiredState),
+		Status:               pkgdb.DeploymentsStatus(deployment.Status),
+		DesiredState:         pkgdb.DeploymentsDesiredState(deployment.DesiredState),
 		EnvironmentSlug:      deployment.EnvironmentSlug,
 		HasCurrentDeployment: deployment.CurrentDeploymentID.Valid && deployment.CurrentDeploymentID.String != "",
 		CurrentDeploymentID:  deployment.CurrentDeploymentID.String,

--- a/svc/ctrl/services/deployment/promote.go
+++ b/svc/ctrl/services/deployment/promote.go
@@ -47,7 +47,7 @@ func (s *Service) Promote(ctx context.Context, req *connect.Request[ctrlv1.Promo
 		CurrentDeploymentID: deployment.CurrentDeploymentID.String,
 		DeploymentID:        deployment.ID,
 		IsRolledBack:        deployment.IsRolledBack,
-	}); r != deploygate.PromotionOK {
+	}); r != deploygate.TargetOK {
 		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New(r.Message()))
 	}
 

--- a/svc/ctrl/services/deployment/rollback.go
+++ b/svc/ctrl/services/deployment/rollback.go
@@ -55,14 +55,12 @@ func (s *Service) Rollback(ctx context.Context, req *connect.Request[ctrlv1.Roll
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to load target deployment: %w", err))
 	}
 
-	//nolint:exhaustruct // SpendSuspended applies to start only
-	if r := deploygate.CheckRollbackTarget(deploygate.Input{
-		Status:               pkgdb.DeploymentsStatus(targetDeployment.Status),
-		DesiredState:         pkgdb.DeploymentsDesiredState(targetDeployment.DesiredState),
-		EnvironmentSlug:      targetDeployment.EnvironmentSlug,
-		CurrentDeploymentID:  targetDeployment.CurrentDeploymentID.String,
-		DeploymentID:         targetDeployment.ID,
-		IsRolledBack:         targetDeployment.IsRolledBack,
+	if r := deploygate.CheckRollbackTarget(deploygate.RollbackInput{
+		Status:              pkgdb.DeploymentsStatus(targetDeployment.Status),
+		DesiredState:        pkgdb.DeploymentsDesiredState(targetDeployment.DesiredState),
+		EnvironmentSlug:     targetDeployment.EnvironmentSlug,
+		CurrentDeploymentID: targetDeployment.CurrentDeploymentID.String,
+		DeploymentID:        targetDeployment.ID,
 	}); r != deploygate.PromotionOK {
 		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New(r.Message()))
 	}

--- a/svc/ctrl/services/deployment/rollback.go
+++ b/svc/ctrl/services/deployment/rollback.go
@@ -60,7 +60,6 @@ func (s *Service) Rollback(ctx context.Context, req *connect.Request[ctrlv1.Roll
 		Status:               pkgdb.DeploymentsStatus(targetDeployment.Status),
 		DesiredState:         pkgdb.DeploymentsDesiredState(targetDeployment.DesiredState),
 		EnvironmentSlug:      targetDeployment.EnvironmentSlug,
-		HasCurrentDeployment: targetDeployment.CurrentDeploymentID.Valid && targetDeployment.CurrentDeploymentID.String != "",
 		CurrentDeploymentID:  targetDeployment.CurrentDeploymentID.String,
 		DeploymentID:         targetDeployment.ID,
 		IsRolledBack:         targetDeployment.IsRolledBack,

--- a/svc/ctrl/services/deployment/rollback.go
+++ b/svc/ctrl/services/deployment/rollback.go
@@ -9,6 +9,7 @@ import (
 	ctrlv1 "github.com/unkeyed/unkey/gen/proto/ctrl/v1"
 	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
 	"github.com/unkeyed/unkey/pkg/assert"
+	pkgdb "github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/deploy/deploygate"
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/auth"
@@ -54,9 +55,10 @@ func (s *Service) Rollback(ctx context.Context, req *connect.Request[ctrlv1.Roll
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to load target deployment: %w", err))
 	}
 
+	//nolint:exhaustruct // SpendSuspended applies to start only
 	if r := deploygate.CheckRollbackTarget(deploygate.Input{
-		Status:               string(targetDeployment.Status),
-		DesiredState:         string(targetDeployment.DesiredState),
+		Status:               pkgdb.DeploymentsStatus(targetDeployment.Status),
+		DesiredState:         pkgdb.DeploymentsDesiredState(targetDeployment.DesiredState),
 		EnvironmentSlug:      targetDeployment.EnvironmentSlug,
 		HasCurrentDeployment: targetDeployment.CurrentDeploymentID.Valid && targetDeployment.CurrentDeploymentID.String != "",
 		CurrentDeploymentID:  targetDeployment.CurrentDeploymentID.String,
@@ -77,7 +79,8 @@ func (s *Service) Rollback(ctx context.Context, req *connect.Request[ctrlv1.Roll
 		return nil, connect.NewError(connect.CodeFailedPrecondition, err)
 	}
 
-	logger.Info("initiating rollback via Restate",
+	logger.Info(
+		"initiating rollback via Restate",
 		"source", req.Msg.GetSourceDeploymentId(),
 		"target", req.Msg.GetTargetDeploymentId(),
 	)
@@ -88,9 +91,9 @@ func (s *Service) Rollback(ctx context.Context, req *connect.Request[ctrlv1.Roll
 			SourceDeploymentId: req.Msg.GetSourceDeploymentId(),
 			TargetDeploymentId: req.Msg.GetTargetDeploymentId(),
 		})
-
 	if err != nil {
-		logger.Error("rollback workflow failed",
+		logger.Error(
+			"rollback workflow failed",
 			"source", req.Msg.GetSourceDeploymentId(),
 			"target", req.Msg.GetTargetDeploymentId(),
 			"error", err.Error(),
@@ -98,7 +101,8 @@ func (s *Service) Rollback(ctx context.Context, req *connect.Request[ctrlv1.Roll
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("rollback workflow failed: %w", err))
 	}
 
-	logger.Info("rollback completed successfully via Restate",
+	logger.Info(
+		"rollback completed successfully via Restate",
 		"source", req.Msg.GetSourceDeploymentId(),
 		"target", req.Msg.GetTargetDeploymentId(),
 	)

--- a/svc/ctrl/services/deployment/rollback.go
+++ b/svc/ctrl/services/deployment/rollback.go
@@ -61,7 +61,7 @@ func (s *Service) Rollback(ctx context.Context, req *connect.Request[ctrlv1.Roll
 		EnvironmentSlug:     targetDeployment.EnvironmentSlug,
 		CurrentDeploymentID: targetDeployment.CurrentDeploymentID.String,
 		DeploymentID:        targetDeployment.ID,
-	}); r != deploygate.PromotionOK {
+	}); r != deploygate.TargetOK {
 		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New(r.Message()))
 	}
 

--- a/svc/ctrl/services/deployment/rollback.go
+++ b/svc/ctrl/services/deployment/rollback.go
@@ -2,12 +2,14 @@ package deployment
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"connectrpc.com/connect"
 	ctrlv1 "github.com/unkeyed/unkey/gen/proto/ctrl/v1"
 	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
 	"github.com/unkeyed/unkey/pkg/assert"
+	"github.com/unkeyed/unkey/pkg/deploy/deploygate"
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/auth"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/db"
@@ -52,16 +54,23 @@ func (s *Service) Rollback(ctx context.Context, req *connect.Request[ctrlv1.Roll
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to load target deployment: %w", err))
 	}
 
-	// A demoted deployment keeps status ready while it drains toward standby, so
-	// status alone would let traffic swap onto one shutting down. Same-app is
-	// asserted before the live-pointer check so a mismatched app fails first.
+	if r := deploygate.CheckRollbackTarget(deploygate.Input{
+		Status:               string(targetDeployment.Status),
+		DesiredState:         string(targetDeployment.DesiredState),
+		EnvironmentSlug:      targetDeployment.EnvironmentSlug,
+		HasCurrentDeployment: targetDeployment.CurrentDeploymentID.Valid && targetDeployment.CurrentDeploymentID.String != "",
+		CurrentDeploymentID:  targetDeployment.CurrentDeploymentID.String,
+		DeploymentID:         targetDeployment.ID,
+		IsRolledBack:         targetDeployment.IsRolledBack,
+	}); r != deploygate.PromotionOK {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New(r.Message()))
+	}
+
+	// Rollback-specific checks beyond the shared gate.
 	err = assert.All(
 		assert.Equal(targetDeployment.ProjectID, sourceDeployment.ProjectID, "deployments must be in the same project"),
 		assert.Equal(targetDeployment.AppID, sourceDeployment.AppID, "deployments must be in the same app"),
 		assert.Equal(targetDeployment.EnvironmentID, sourceDeployment.EnvironmentID, "deployments must be in the same environment"),
-		assert.Equal(targetDeployment.Status, db.DeploymentsStatusReady, "target deployment is not ready"),
-		assert.Equal(targetDeployment.DesiredState, db.DeploymentsDesiredStateRunning, "target deployment is shutting down"),
-		assert.Equal(targetDeployment.EnvironmentSlug, "production", "only production deployments can be rolled back"),
 		assert.True(targetDeployment.CurrentDeploymentID.Valid && targetDeployment.CurrentDeploymentID.String == sourceDeployment.ID, "source deployment is not the current live deployment"),
 	)
 	if err != nil {

--- a/svc/ctrl/services/deployment/rollback.go
+++ b/svc/ctrl/services/deployment/rollback.go
@@ -2,7 +2,6 @@ package deployment
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"connectrpc.com/connect"
@@ -14,6 +13,7 @@ import (
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/auth"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/db"
+	"github.com/unkeyed/unkey/svc/ctrl/internal/gatefault"
 )
 
 // Rollback switches traffic from the source deployment to a previous target
@@ -55,14 +55,14 @@ func (s *Service) Rollback(ctx context.Context, req *connect.Request[ctrlv1.Roll
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to load target deployment: %w", err))
 	}
 
-	if r := deploygate.CheckRollbackTarget(deploygate.RollbackInput{
+	if err := deploygate.CheckRollbackTarget(deploygate.RollbackInput{
 		Status:              pkgdb.DeploymentsStatus(targetDeployment.Status),
 		DesiredState:        pkgdb.DeploymentsDesiredState(targetDeployment.DesiredState),
 		EnvironmentSlug:     targetDeployment.EnvironmentSlug,
 		CurrentDeploymentID: targetDeployment.CurrentDeploymentID.String,
 		DeploymentID:        targetDeployment.ID,
-	}); r != deploygate.TargetOK {
-		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New(r.Message()))
+	}); err != nil {
+		return nil, gatefault.Connect(err)
 	}
 
 	// Rollback-specific checks beyond the shared gate.

--- a/svc/ctrl/services/deployment/stop.go
+++ b/svc/ctrl/services/deployment/stop.go
@@ -43,8 +43,7 @@ func (s *Service) StopDeployment(ctx context.Context, req *connect.Request[ctrlv
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to load environment: %w", err))
 	}
 
-	//nolint:exhaustruct // stop only uses the runtime status and environment fields
-	if r := deploygate.CheckStoppable(deploygate.Input{
+	if r := deploygate.CheckStoppable(deploygate.StopInput{
 		Status:          pkgdb.DeploymentsStatus(deployment.Status),
 		DesiredState:    pkgdb.DeploymentsDesiredState(deployment.DesiredState),
 		EnvironmentSlug: environment.Slug,

--- a/svc/ctrl/services/deployment/stop.go
+++ b/svc/ctrl/services/deployment/stop.go
@@ -2,12 +2,13 @@ package deployment
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"connectrpc.com/connect"
 	ctrlv1 "github.com/unkeyed/unkey/gen/proto/ctrl/v1"
 	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
-	"github.com/unkeyed/unkey/pkg/assert"
+	"github.com/unkeyed/unkey/pkg/deploy/deploygate"
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/auth"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/db"
@@ -33,14 +34,6 @@ func (s *Service) StopDeployment(ctx context.Context, req *connect.Request[ctrlv
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to load deployment: %w", err))
 	}
 
-	err = assert.All(
-		assert.Equal(deployment.Status, db.DeploymentsStatusReady, "deployment is not running"),
-		assert.Equal(deployment.DesiredState, db.DeploymentsDesiredStateRunning, "deployment is not running"),
-	)
-	if err != nil {
-		return nil, connect.NewError(connect.CodeFailedPrecondition, err)
-	}
-
 	environment, err := s.db.FindEnvironmentById(ctx, deployment.EnvironmentID)
 	if err != nil {
 		if db.IsNotFound(err) {
@@ -49,11 +42,13 @@ func (s *Service) StopDeployment(ctx context.Context, req *connect.Request[ctrlv
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to load environment: %w", err))
 	}
 
-	err = assert.All(
-		assert.NotEqual(environment.Slug, "production", "production deployments cannot be stopped"),
-	)
-	if err != nil {
-		return nil, connect.NewError(connect.CodeFailedPrecondition, err)
+	//nolint:exhaustruct // stop only uses the runtime status and environment fields
+	if r := deploygate.CheckStoppable(deploygate.Input{
+		Status:          string(deployment.Status),
+		DesiredState:    string(deployment.DesiredState),
+		EnvironmentSlug: environment.Slug,
+	}); r != deploygate.StopOK {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New(r.Message()))
 	}
 
 	logger.Info("stopping deployment", "deployment_id", deploymentID)

--- a/svc/ctrl/services/deployment/stop.go
+++ b/svc/ctrl/services/deployment/stop.go
@@ -8,6 +8,7 @@ import (
 	"connectrpc.com/connect"
 	ctrlv1 "github.com/unkeyed/unkey/gen/proto/ctrl/v1"
 	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
+	pkgdb "github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/deploy/deploygate"
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/auth"
@@ -44,8 +45,8 @@ func (s *Service) StopDeployment(ctx context.Context, req *connect.Request[ctrlv
 
 	//nolint:exhaustruct // stop only uses the runtime status and environment fields
 	if r := deploygate.CheckStoppable(deploygate.Input{
-		Status:          string(deployment.Status),
-		DesiredState:    string(deployment.DesiredState),
+		Status:          pkgdb.DeploymentsStatus(deployment.Status),
+		DesiredState:    pkgdb.DeploymentsDesiredState(deployment.DesiredState),
 		EnvironmentSlug: environment.Slug,
 	}); r != deploygate.StopOK {
 		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New(r.Message()))

--- a/svc/ctrl/services/deployment/stop.go
+++ b/svc/ctrl/services/deployment/stop.go
@@ -2,7 +2,6 @@ package deployment
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"connectrpc.com/connect"
@@ -13,6 +12,7 @@ import (
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/auth"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/db"
+	"github.com/unkeyed/unkey/svc/ctrl/internal/gatefault"
 )
 
 // StopDeployment transitions a running deployment to stopped. The actual
@@ -43,12 +43,12 @@ func (s *Service) StopDeployment(ctx context.Context, req *connect.Request[ctrlv
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to load environment: %w", err))
 	}
 
-	if r := deploygate.CheckStopTarget(deploygate.StopInput{
+	if err := deploygate.CheckStopTarget(deploygate.StopInput{
 		Status:          pkgdb.DeploymentsStatus(deployment.Status),
 		DesiredState:    pkgdb.DeploymentsDesiredState(deployment.DesiredState),
 		EnvironmentSlug: environment.Slug,
-	}); r != deploygate.StopOK {
-		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New(r.Message()))
+	}); err != nil {
+		return nil, gatefault.Connect(err)
 	}
 
 	logger.Info("stopping deployment", "deployment_id", deploymentID)

--- a/svc/ctrl/services/deployment/stop.go
+++ b/svc/ctrl/services/deployment/stop.go
@@ -43,7 +43,7 @@ func (s *Service) StopDeployment(ctx context.Context, req *connect.Request[ctrlv
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to load environment: %w", err))
 	}
 
-	if r := deploygate.CheckStoppable(deploygate.StopInput{
+	if r := deploygate.CheckStopTarget(deploygate.StopInput{
 		Status:          pkgdb.DeploymentsStatus(deployment.Status),
 		DesiredState:    pkgdb.DeploymentsDesiredState(deployment.DesiredState),
 		EnvironmentSlug: environment.Slug,

--- a/svc/ctrl/services/deployment/wake.go
+++ b/svc/ctrl/services/deployment/wake.go
@@ -42,14 +42,6 @@ func (s *Service) WakeDeployment(ctx context.Context, req *connect.Request[ctrlv
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to load environment: %w", err))
 	}
 
-	//nolint:exhaustruct // start only uses the desired state and environment fields
-	if r := deploygate.CheckStartable(deploygate.Input{
-		DesiredState:    string(deployment.DesiredState),
-		EnvironmentSlug: environment.Slug,
-	}); r != deploygate.StartOK {
-		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New(r.Message()))
-	}
-
 	entitlement, err := s.db.FindWorkspaceDeployEntitlement(ctx, deployment.WorkspaceID)
 	if err != nil {
 		if db.IsNotFound(err) {
@@ -57,11 +49,14 @@ func (s *Service) WakeDeployment(ctx context.Context, req *connect.Request[ctrlv
 		}
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to load workspace entitlement: %w", err))
 	}
-	if entitlement.SpendSuspended.Bool {
-		return nil, connect.NewError(
-			connect.CodeFailedPrecondition,
-			fmt.Errorf("workspace %q is suspended by its Compute spend cap; raise the budget to resume", deployment.WorkspaceID),
-		)
+
+	//nolint:exhaustruct // start only uses the desired state, environment, and spend fields
+	if r := deploygate.CheckStartable(deploygate.Input{
+		DesiredState:    string(deployment.DesiredState),
+		EnvironmentSlug: environment.Slug,
+		SpendSuspended:  entitlement.SpendSuspended.Bool,
+	}); r != deploygate.StartOK {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New(r.Message()))
 	}
 
 	logger.Info("waking stopped deployment", "deployment_id", deploymentID)

--- a/svc/ctrl/services/deployment/wake.go
+++ b/svc/ctrl/services/deployment/wake.go
@@ -2,7 +2,6 @@ package deployment
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"connectrpc.com/connect"
@@ -13,6 +12,7 @@ import (
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/auth"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/db"
+	"github.com/unkeyed/unkey/svc/ctrl/internal/gatefault"
 )
 
 // WakeDeployment transitions a stopped deployment back to running. The actual
@@ -51,12 +51,12 @@ func (s *Service) WakeDeployment(ctx context.Context, req *connect.Request[ctrlv
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to load workspace entitlement: %w", err))
 	}
 
-	if r := deploygate.CheckStartTarget(deploygate.StartInput{
+	if err := deploygate.CheckStartTarget(deploygate.StartInput{
 		DesiredState:    pkgdb.DeploymentsDesiredState(deployment.DesiredState),
 		EnvironmentSlug: environment.Slug,
 		SpendSuspended:  entitlement.SpendSuspended.Bool,
-	}); r != deploygate.StartOK {
-		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New(r.Message()))
+	}); err != nil {
+		return nil, gatefault.Connect(err)
 	}
 
 	logger.Info("waking stopped deployment", "deployment_id", deploymentID)

--- a/svc/ctrl/services/deployment/wake.go
+++ b/svc/ctrl/services/deployment/wake.go
@@ -51,7 +51,7 @@ func (s *Service) WakeDeployment(ctx context.Context, req *connect.Request[ctrlv
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to load workspace entitlement: %w", err))
 	}
 
-	if r := deploygate.CheckStartable(deploygate.StartInput{
+	if r := deploygate.CheckStartTarget(deploygate.StartInput{
 		DesiredState:    pkgdb.DeploymentsDesiredState(deployment.DesiredState),
 		EnvironmentSlug: environment.Slug,
 		SpendSuspended:  entitlement.SpendSuspended.Bool,

--- a/svc/ctrl/services/deployment/wake.go
+++ b/svc/ctrl/services/deployment/wake.go
@@ -8,6 +8,7 @@ import (
 	"connectrpc.com/connect"
 	ctrlv1 "github.com/unkeyed/unkey/gen/proto/ctrl/v1"
 	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
+	pkgdb "github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/deploy/deploygate"
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/auth"
@@ -52,7 +53,7 @@ func (s *Service) WakeDeployment(ctx context.Context, req *connect.Request[ctrlv
 
 	//nolint:exhaustruct // start only uses the desired state, environment, and spend fields
 	if r := deploygate.CheckStartable(deploygate.Input{
-		DesiredState:    string(deployment.DesiredState),
+		DesiredState:    pkgdb.DeploymentsDesiredState(deployment.DesiredState),
 		EnvironmentSlug: environment.Slug,
 		SpendSuspended:  entitlement.SpendSuspended.Bool,
 	}); r != deploygate.StartOK {

--- a/svc/ctrl/services/deployment/wake.go
+++ b/svc/ctrl/services/deployment/wake.go
@@ -51,8 +51,7 @@ func (s *Service) WakeDeployment(ctx context.Context, req *connect.Request[ctrlv
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to load workspace entitlement: %w", err))
 	}
 
-	//nolint:exhaustruct // start only uses the desired state, environment, and spend fields
-	if r := deploygate.CheckStartable(deploygate.Input{
+	if r := deploygate.CheckStartable(deploygate.StartInput{
 		DesiredState:    pkgdb.DeploymentsDesiredState(deployment.DesiredState),
 		EnvironmentSlug: environment.Slug,
 		SpendSuspended:  entitlement.SpendSuspended.Bool,

--- a/svc/ctrl/services/deployment/wake.go
+++ b/svc/ctrl/services/deployment/wake.go
@@ -2,11 +2,13 @@ package deployment
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"connectrpc.com/connect"
 	ctrlv1 "github.com/unkeyed/unkey/gen/proto/ctrl/v1"
 	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
+	"github.com/unkeyed/unkey/pkg/deploy/deploygate"
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/auth"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/db"
@@ -32,10 +34,6 @@ func (s *Service) WakeDeployment(ctx context.Context, req *connect.Request[ctrlv
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to load deployment: %w", err))
 	}
 
-	if deployment.DesiredState != db.DeploymentsDesiredStateStopped {
-		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("deployment is not stopped"))
-	}
-
 	environment, err := s.db.FindEnvironmentById(ctx, deployment.EnvironmentID)
 	if err != nil {
 		if db.IsNotFound(err) {
@@ -43,8 +41,13 @@ func (s *Service) WakeDeployment(ctx context.Context, req *connect.Request[ctrlv
 		}
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to load environment: %w", err))
 	}
-	if environment.Slug == "production" {
-		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("production deployments cannot be woken"))
+
+	//nolint:exhaustruct // start only uses the desired state and environment fields
+	if r := deploygate.CheckStartable(deploygate.Input{
+		DesiredState:    string(deployment.DesiredState),
+		EnvironmentSlug: environment.Slug,
+	}); r != deploygate.StartOK {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New(r.Message()))
 	}
 
 	entitlement, err := s.db.FindWorkspaceDeployEntitlement(ctx, deployment.WorkspaceID)

--- a/svc/ctrl/worker/deploy/promote_handler.go
+++ b/svc/ctrl/worker/deploy/promote_handler.go
@@ -79,14 +79,13 @@ func (w *Workflow) Promote(ctx restate.ObjectContext, req *hydrav1.PromoteReques
 		return nil, fault.Wrap(err, fault.Public("Failed to find the environment"))
 	}
 
-	//nolint:exhaustruct // SpendSuspended applies to start only
-	if r := deploygate.CheckPromoteTarget(deploygate.Input{
-		Status:               pkgdb.DeploymentsStatus(targetDeployment.Status),
-		DesiredState:         pkgdb.DeploymentsDesiredState(targetDeployment.DesiredState),
-		EnvironmentSlug:      environment.Slug,
-		CurrentDeploymentID:  app.CurrentDeploymentID.String,
-		DeploymentID:         targetDeployment.ID,
-		IsRolledBack:         app.IsRolledBack,
+	if r := deploygate.CheckPromoteTarget(deploygate.PromoteInput{
+		Status:              pkgdb.DeploymentsStatus(targetDeployment.Status),
+		DesiredState:        pkgdb.DeploymentsDesiredState(targetDeployment.DesiredState),
+		EnvironmentSlug:     environment.Slug,
+		CurrentDeploymentID: app.CurrentDeploymentID.String,
+		DeploymentID:        targetDeployment.ID,
+		IsRolledBack:        app.IsRolledBack,
 	}); r != deploygate.PromotionOK {
 		return nil, fault.Wrap(
 			restate.TerminalError(errors.New(r.Message()), 400),

--- a/svc/ctrl/worker/deploy/promote_handler.go
+++ b/svc/ctrl/worker/deploy/promote_handler.go
@@ -1,7 +1,6 @@
 package deploy
 
 import (
-	"errors"
 	"fmt"
 	"time"
 
@@ -12,6 +11,7 @@ import (
 	"github.com/unkeyed/unkey/pkg/fault"
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/db"
+	"github.com/unkeyed/unkey/svc/ctrl/internal/gatefault"
 )
 
 // Promote reassigns all sticky domains to a deployment and clears the rolled back state.
@@ -79,18 +79,15 @@ func (w *Workflow) Promote(ctx restate.ObjectContext, req *hydrav1.PromoteReques
 		return nil, fault.Wrap(err, fault.Public("Failed to find the environment"))
 	}
 
-	if r := deploygate.CheckPromoteTarget(deploygate.PromoteInput{
+	if err := deploygate.CheckPromoteTarget(deploygate.PromoteInput{
 		Status:              pkgdb.DeploymentsStatus(targetDeployment.Status),
 		DesiredState:        pkgdb.DeploymentsDesiredState(targetDeployment.DesiredState),
 		EnvironmentSlug:     environment.Slug,
 		CurrentDeploymentID: app.CurrentDeploymentID.String,
 		DeploymentID:        targetDeployment.ID,
 		IsRolledBack:        app.IsRolledBack,
-	}); r != deploygate.TargetOK {
-		return nil, fault.Wrap(
-			restate.TerminalError(errors.New(r.Message()), 400),
-			fault.Public(r.Message()),
-		)
+	}); err != nil {
+		return nil, gatefault.Terminal(err)
 	}
 
 	isConfirmingRollback := app.IsRolledBack && targetDeployment.ID == app.CurrentDeploymentID.String

--- a/svc/ctrl/worker/deploy/promote_handler.go
+++ b/svc/ctrl/worker/deploy/promote_handler.go
@@ -86,7 +86,7 @@ func (w *Workflow) Promote(ctx restate.ObjectContext, req *hydrav1.PromoteReques
 		CurrentDeploymentID: app.CurrentDeploymentID.String,
 		DeploymentID:        targetDeployment.ID,
 		IsRolledBack:        app.IsRolledBack,
-	}); r != deploygate.PromotionOK {
+	}); r != deploygate.TargetOK {
 		return nil, fault.Wrap(
 			restate.TerminalError(errors.New(r.Message()), 400),
 			fault.Public(r.Message()),

--- a/svc/ctrl/worker/deploy/promote_handler.go
+++ b/svc/ctrl/worker/deploy/promote_handler.go
@@ -1,11 +1,13 @@
 package deploy
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
 	restate "github.com/restatedev/sdk-go"
 	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
+	"github.com/unkeyed/unkey/pkg/deploy/deploygate"
 	"github.com/unkeyed/unkey/pkg/fault"
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/db"
@@ -33,7 +35,6 @@ import (
 func (w *Workflow) Promote(ctx restate.ObjectContext, req *hydrav1.PromoteRequest) (*hydrav1.PromoteResponse, error) {
 	logger.Info("initiating promotion", "target", req.GetTargetDeploymentId())
 
-	// Get target deployment
 	targetDeployment, err := restate.Run(ctx, func(stepCtx restate.RunContext) (db.Deployment, error) {
 		return w.db.FindDeploymentById(stepCtx, req.GetTargetDeploymentId())
 	}, restate.WithName("finding target deployment"), restate.WithMaxRetryAttempts(runMaxAttempts))
@@ -47,7 +48,6 @@ func (w *Workflow) Promote(ctx restate.ObjectContext, req *hydrav1.PromoteReques
 		return nil, fault.Wrap(err, fault.Public("Failed to find the target deployment"))
 	}
 
-	// Get app from deployment's app_id
 	app, err := restate.Run(ctx, func(stepCtx restate.RunContext) (db.App, error) {
 		return w.db.FindAppById(stepCtx, targetDeployment.AppID)
 	}, restate.WithName("finding app"), restate.WithMaxRetryAttempts(runMaxAttempts))
@@ -61,27 +61,39 @@ func (w *Workflow) Promote(ctx restate.ObjectContext, req *hydrav1.PromoteReques
 		return nil, fault.Wrap(err, fault.Public("Failed to find the app"))
 	}
 
-	// Validate preconditions
-	if targetDeployment.Status != db.DeploymentsStatusReady {
+	// Re-validate at execution time against the same invariant the API and ctrl
+	// service already checked, so a state change between enqueue and execution
+	// (e.g. the target starts draining) fails the promote instead of swapping
+	// traffic onto it. The environment is loaded here only for its slug.
+	environment, err := restate.Run(ctx, func(stepCtx restate.RunContext) (db.Environment, error) {
+		return w.db.FindEnvironmentById(stepCtx, targetDeployment.EnvironmentID)
+	}, restate.WithName("finding environment"), restate.WithMaxRetryAttempts(runMaxAttempts))
+	if err != nil {
+		if db.IsNotFound(err) {
+			return nil, fault.Wrap(
+				restate.TerminalError(fmt.Errorf("environment not found: %s", targetDeployment.EnvironmentID), 404),
+				fault.Public("The environment could not be found"),
+			)
+		}
+		return nil, fault.Wrap(err, fault.Public("Failed to find the environment"))
+	}
+
+	if r := deploygate.CheckPromoteTarget(deploygate.Input{
+		Status:               string(targetDeployment.Status),
+		DesiredState:         string(targetDeployment.DesiredState),
+		EnvironmentSlug:      environment.Slug,
+		HasCurrentDeployment: app.CurrentDeploymentID.Valid && app.CurrentDeploymentID.String != "",
+		CurrentDeploymentID:  app.CurrentDeploymentID.String,
+		DeploymentID:         targetDeployment.ID,
+		IsRolledBack:         app.IsRolledBack,
+	}); r != deploygate.PromotionOK {
 		return nil, fault.Wrap(
-			restate.TerminalError(fmt.Errorf("deployment status must be ready, got: %s", targetDeployment.Status), 400),
-			fault.Public("The deployment is not ready for promotion"),
+			restate.TerminalError(errors.New(r.Message()), 400),
+			fault.Public(r.Message()),
 		)
 	}
-	if !app.CurrentDeploymentID.Valid {
-		return nil, fault.Wrap(
-			restate.TerminalError(fmt.Errorf("app has no live deployment"), 400),
-			fault.Public("The app has no live deployment to promote from"),
-		)
-	}
+
 	isConfirmingRollback := app.IsRolledBack && targetDeployment.ID == app.CurrentDeploymentID.String
-	// This guards against us forcing current deployment to promotion
-	if targetDeployment.ID == app.CurrentDeploymentID.String && !app.IsRolledBack {
-		return nil, fault.Wrap(
-			restate.TerminalError(fmt.Errorf("target deployment is already the live deployment"), 400),
-			fault.Public("This deployment is already live"),
-		)
-	}
 
 	// Resolve routes for normal promotion. Confirm-rollback skips this since
 	// the routes already point at the target.

--- a/svc/ctrl/worker/deploy/promote_handler.go
+++ b/svc/ctrl/worker/deploy/promote_handler.go
@@ -7,6 +7,7 @@ import (
 
 	restate "github.com/restatedev/sdk-go"
 	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
+	pkgdb "github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/deploy/deploygate"
 	"github.com/unkeyed/unkey/pkg/fault"
 	"github.com/unkeyed/unkey/pkg/logger"
@@ -78,9 +79,10 @@ func (w *Workflow) Promote(ctx restate.ObjectContext, req *hydrav1.PromoteReques
 		return nil, fault.Wrap(err, fault.Public("Failed to find the environment"))
 	}
 
+	//nolint:exhaustruct // SpendSuspended applies to start only
 	if r := deploygate.CheckPromoteTarget(deploygate.Input{
-		Status:               string(targetDeployment.Status),
-		DesiredState:         string(targetDeployment.DesiredState),
+		Status:               pkgdb.DeploymentsStatus(targetDeployment.Status),
+		DesiredState:         pkgdb.DeploymentsDesiredState(targetDeployment.DesiredState),
 		EnvironmentSlug:      environment.Slug,
 		HasCurrentDeployment: app.CurrentDeploymentID.Valid && app.CurrentDeploymentID.String != "",
 		CurrentDeploymentID:  app.CurrentDeploymentID.String,

--- a/svc/ctrl/worker/deploy/promote_handler.go
+++ b/svc/ctrl/worker/deploy/promote_handler.go
@@ -84,7 +84,6 @@ func (w *Workflow) Promote(ctx restate.ObjectContext, req *hydrav1.PromoteReques
 		Status:               pkgdb.DeploymentsStatus(targetDeployment.Status),
 		DesiredState:         pkgdb.DeploymentsDesiredState(targetDeployment.DesiredState),
 		EnvironmentSlug:      environment.Slug,
-		HasCurrentDeployment: app.CurrentDeploymentID.Valid && app.CurrentDeploymentID.String != "",
 		CurrentDeploymentID:  app.CurrentDeploymentID.String,
 		DeploymentID:         targetDeployment.ID,
 		IsRolledBack:         app.IsRolledBack,

--- a/svc/ctrl/worker/deploy/rollback_handler.go
+++ b/svc/ctrl/worker/deploy/rollback_handler.go
@@ -7,6 +7,7 @@ import (
 	restate "github.com/restatedev/sdk-go"
 	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
 	"github.com/unkeyed/unkey/pkg/assert"
+	pkgdb "github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/deploy/deploygate"
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/db"
@@ -98,9 +99,10 @@ func (w *Workflow) Rollback(ctx restate.ObjectContext, req *hydrav1.RollbackRequ
 		return nil, fmt.Errorf("failed to get environment: %w", err)
 	}
 
+	//nolint:exhaustruct // SpendSuspended applies to start only
 	if r := deploygate.CheckRollbackTarget(deploygate.Input{
-		Status:               string(targetDeployment.Status),
-		DesiredState:         string(targetDeployment.DesiredState),
+		Status:               pkgdb.DeploymentsStatus(targetDeployment.Status),
+		DesiredState:         pkgdb.DeploymentsDesiredState(targetDeployment.DesiredState),
 		EnvironmentSlug:      environment.Slug,
 		HasCurrentDeployment: app.CurrentDeploymentID.Valid && app.CurrentDeploymentID.String != "",
 		CurrentDeploymentID:  app.CurrentDeploymentID.String,

--- a/svc/ctrl/worker/deploy/rollback_handler.go
+++ b/svc/ctrl/worker/deploy/rollback_handler.go
@@ -99,14 +99,12 @@ func (w *Workflow) Rollback(ctx restate.ObjectContext, req *hydrav1.RollbackRequ
 		return nil, fmt.Errorf("failed to get environment: %w", err)
 	}
 
-	//nolint:exhaustruct // SpendSuspended applies to start only
-	if r := deploygate.CheckRollbackTarget(deploygate.Input{
-		Status:               pkgdb.DeploymentsStatus(targetDeployment.Status),
-		DesiredState:         pkgdb.DeploymentsDesiredState(targetDeployment.DesiredState),
-		EnvironmentSlug:      environment.Slug,
-		CurrentDeploymentID:  app.CurrentDeploymentID.String,
-		DeploymentID:         targetDeployment.ID,
-		IsRolledBack:         app.IsRolledBack,
+	if r := deploygate.CheckRollbackTarget(deploygate.RollbackInput{
+		Status:              pkgdb.DeploymentsStatus(targetDeployment.Status),
+		DesiredState:        pkgdb.DeploymentsDesiredState(targetDeployment.DesiredState),
+		EnvironmentSlug:     environment.Slug,
+		CurrentDeploymentID: app.CurrentDeploymentID.String,
+		DeploymentID:        targetDeployment.ID,
 	}); r != deploygate.PromotionOK {
 		return nil, restate.TerminalError(errors.New(r.Message()), 400)
 	}

--- a/svc/ctrl/worker/deploy/rollback_handler.go
+++ b/svc/ctrl/worker/deploy/rollback_handler.go
@@ -1,11 +1,13 @@
 package deploy
 
 import (
+	"errors"
 	"fmt"
 
 	restate "github.com/restatedev/sdk-go"
 	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
 	"github.com/unkeyed/unkey/pkg/assert"
+	"github.com/unkeyed/unkey/pkg/deploy/deploygate"
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/db"
 )
@@ -35,12 +37,10 @@ func (w *Workflow) Rollback(ctx restate.ObjectContext, req *hydrav1.RollbackRequ
 		"target", req.GetTargetDeploymentId(),
 	)
 
-	// Validate source and target are different
 	if req.GetSourceDeploymentId() == req.GetTargetDeploymentId() {
 		return nil, restate.TerminalError(fmt.Errorf("source and target deployments must be different"), 400)
 	}
 
-	// Get source deployment
 	sourceDeployment, err := restate.Run(ctx, func(stepCtx restate.RunContext) (db.Deployment, error) {
 		return w.db.FindDeploymentById(stepCtx, req.GetSourceDeploymentId())
 	}, restate.WithName("finding source deployment"), restate.WithMaxRetryAttempts(runMaxAttempts))
@@ -51,7 +51,6 @@ func (w *Workflow) Rollback(ctx restate.ObjectContext, req *hydrav1.RollbackRequ
 		return nil, fmt.Errorf("failed to get source deployment: %w", err)
 	}
 
-	// Get target deployment
 	targetDeployment, err := restate.Run(ctx, func(stepCtx restate.RunContext) (db.Deployment, error) {
 		return w.db.FindDeploymentById(stepCtx, req.GetTargetDeploymentId())
 	}, restate.WithName("finding target deployment"), restate.WithMaxRetryAttempts(runMaxAttempts))
@@ -71,7 +70,6 @@ func (w *Workflow) Rollback(ctx restate.ObjectContext, req *hydrav1.RollbackRequ
 		return nil, restate.TerminalError(err, 400)
 	}
 
-	// Get app from deployment's app_id
 	app, err := restate.Run(ctx, func(stepCtx restate.RunContext) (db.App, error) {
 		return w.db.FindAppById(stepCtx, sourceDeployment.AppID)
 	}, restate.WithName("finding app"), restate.WithMaxRetryAttempts(runMaxAttempts))
@@ -82,9 +80,34 @@ func (w *Workflow) Rollback(ctx restate.ObjectContext, req *hydrav1.RollbackRequ
 		return nil, fmt.Errorf("failed to get app: %w", err)
 	}
 
-	// Validate source deployment is the current deployment
 	if !app.CurrentDeploymentID.Valid || app.CurrentDeploymentID.String != sourceDeployment.ID {
 		return nil, restate.TerminalError(fmt.Errorf("source deployment is not the current deployment"), 400)
+	}
+
+	// Re-validate the target against the shared invariant at execution time (the
+	// API and ctrl service already checked it) so a state change between enqueue
+	// and execution fails the rollback instead of swapping traffic onto a target
+	// that is no longer eligible. Environment is loaded only for its slug.
+	environment, err := restate.Run(ctx, func(stepCtx restate.RunContext) (db.Environment, error) {
+		return w.db.FindEnvironmentById(stepCtx, targetDeployment.EnvironmentID)
+	}, restate.WithName("finding environment"), restate.WithMaxRetryAttempts(runMaxAttempts))
+	if err != nil {
+		if db.IsNotFound(err) {
+			return nil, restate.TerminalError(fmt.Errorf("environment not found: %s", targetDeployment.EnvironmentID), 404)
+		}
+		return nil, fmt.Errorf("failed to get environment: %w", err)
+	}
+
+	if r := deploygate.CheckRollbackTarget(deploygate.Input{
+		Status:               string(targetDeployment.Status),
+		DesiredState:         string(targetDeployment.DesiredState),
+		EnvironmentSlug:      environment.Slug,
+		HasCurrentDeployment: app.CurrentDeploymentID.Valid && app.CurrentDeploymentID.String != "",
+		CurrentDeploymentID:  app.CurrentDeploymentID.String,
+		DeploymentID:         targetDeployment.ID,
+		IsRolledBack:         app.IsRolledBack,
+	}); r != deploygate.PromotionOK {
+		return nil, restate.TerminalError(errors.New(r.Message()), 400)
 	}
 
 	// ensure the rolled back deployment does not get spun down from existing scheduled actions
@@ -93,7 +116,6 @@ func (w *Workflow) Rollback(ctx restate.ObjectContext, req *hydrav1.RollbackRequ
 		return nil, err
 	}
 
-	// Get all frontlineRoutes on the current deployment that are sticky
 	frontlineRoutes, err := restate.Run(ctx, func(stepCtx restate.RunContext) ([]db.FindFrontlineRoutesForRollbackRow, error) {
 		return w.db.FindFrontlineRoutesForRollback(stepCtx, db.FindFrontlineRoutesForRollbackParams{
 			EnvironmentID: sourceDeployment.EnvironmentID,
@@ -113,7 +135,6 @@ func (w *Workflow) Rollback(ctx restate.ObjectContext, req *hydrav1.RollbackRequ
 
 	logger.Info("found frontlineRoutes for rollback", "count", len(frontlineRoutes), "deployment_id", sourceDeployment.ID)
 
-	// Collect frontlineRoute IDs
 	var routeIDs []string
 	for _, frontlineRoute := range frontlineRoutes {
 		if frontlineRoute.Sticky == db.FrontlineRoutesStickyLive ||

--- a/svc/ctrl/worker/deploy/rollback_handler.go
+++ b/svc/ctrl/worker/deploy/rollback_handler.go
@@ -104,7 +104,6 @@ func (w *Workflow) Rollback(ctx restate.ObjectContext, req *hydrav1.RollbackRequ
 		Status:               pkgdb.DeploymentsStatus(targetDeployment.Status),
 		DesiredState:         pkgdb.DeploymentsDesiredState(targetDeployment.DesiredState),
 		EnvironmentSlug:      environment.Slug,
-		HasCurrentDeployment: app.CurrentDeploymentID.Valid && app.CurrentDeploymentID.String != "",
 		CurrentDeploymentID:  app.CurrentDeploymentID.String,
 		DeploymentID:         targetDeployment.ID,
 		IsRolledBack:         app.IsRolledBack,

--- a/svc/ctrl/worker/deploy/rollback_handler.go
+++ b/svc/ctrl/worker/deploy/rollback_handler.go
@@ -1,7 +1,6 @@
 package deploy
 
 import (
-	"errors"
 	"fmt"
 
 	restate "github.com/restatedev/sdk-go"
@@ -11,6 +10,7 @@ import (
 	"github.com/unkeyed/unkey/pkg/deploy/deploygate"
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/db"
+	"github.com/unkeyed/unkey/svc/ctrl/internal/gatefault"
 )
 
 // Rollback performs a rollback to a previous deployment.
@@ -99,14 +99,14 @@ func (w *Workflow) Rollback(ctx restate.ObjectContext, req *hydrav1.RollbackRequ
 		return nil, fmt.Errorf("failed to get environment: %w", err)
 	}
 
-	if r := deploygate.CheckRollbackTarget(deploygate.RollbackInput{
+	if err := deploygate.CheckRollbackTarget(deploygate.RollbackInput{
 		Status:              pkgdb.DeploymentsStatus(targetDeployment.Status),
 		DesiredState:        pkgdb.DeploymentsDesiredState(targetDeployment.DesiredState),
 		EnvironmentSlug:     environment.Slug,
 		CurrentDeploymentID: app.CurrentDeploymentID.String,
 		DeploymentID:        targetDeployment.ID,
-	}); r != deploygate.TargetOK {
-		return nil, restate.TerminalError(errors.New(r.Message()), 400)
+	}); err != nil {
+		return nil, gatefault.Terminal(err)
 	}
 
 	// ensure the rolled back deployment does not get spun down from existing scheduled actions

--- a/svc/ctrl/worker/deploy/rollback_handler.go
+++ b/svc/ctrl/worker/deploy/rollback_handler.go
@@ -105,7 +105,7 @@ func (w *Workflow) Rollback(ctx restate.ObjectContext, req *hydrav1.RollbackRequ
 		EnvironmentSlug:     environment.Slug,
 		CurrentDeploymentID: app.CurrentDeploymentID.String,
 		DeploymentID:        targetDeployment.ID,
-	}); r != deploygate.PromotionOK {
+	}); r != deploygate.TargetOK {
 		return nil, restate.TerminalError(errors.New(r.Message()), 400)
 	}
 

--- a/svc/ctrl/worker/deploy/stop_deployment.go
+++ b/svc/ctrl/worker/deploy/stop_deployment.go
@@ -6,6 +6,7 @@ import (
 
 	restate "github.com/restatedev/sdk-go"
 	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
+	pkgdb "github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/deploy/deploygate"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/db"
 )
@@ -41,8 +42,8 @@ func (w *Workflow) StopDeployment(ctx restate.ObjectContext, req *hydrav1.StopDe
 
 	//nolint:exhaustruct // stop only uses the runtime status and environment fields
 	if r := deploygate.CheckStoppable(deploygate.Input{
-		Status:          string(deployment.Status),
-		DesiredState:    string(deployment.DesiredState),
+		Status:          pkgdb.DeploymentsStatus(deployment.Status),
+		DesiredState:    pkgdb.DeploymentsDesiredState(deployment.DesiredState),
 		EnvironmentSlug: environment.Slug,
 	}); r != deploygate.StopOK {
 		return nil, restate.TerminalError(errors.New(r.Message()), 400)

--- a/svc/ctrl/worker/deploy/stop_deployment.go
+++ b/svc/ctrl/worker/deploy/stop_deployment.go
@@ -40,7 +40,7 @@ func (w *Workflow) StopDeployment(ctx restate.ObjectContext, req *hydrav1.StopDe
 		return nil, fmt.Errorf("failed to load environment: %w", err)
 	}
 
-	if r := deploygate.CheckStoppable(deploygate.StopInput{
+	if r := deploygate.CheckStopTarget(deploygate.StopInput{
 		Status:          pkgdb.DeploymentsStatus(deployment.Status),
 		DesiredState:    pkgdb.DeploymentsDesiredState(deployment.DesiredState),
 		EnvironmentSlug: environment.Slug,

--- a/svc/ctrl/worker/deploy/stop_deployment.go
+++ b/svc/ctrl/worker/deploy/stop_deployment.go
@@ -1,7 +1,6 @@
 package deploy
 
 import (
-	"errors"
 	"fmt"
 
 	restate "github.com/restatedev/sdk-go"
@@ -9,6 +8,7 @@ import (
 	pkgdb "github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/deploy/deploygate"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/db"
+	"github.com/unkeyed/unkey/svc/ctrl/internal/gatefault"
 )
 
 // StopDeployment is the public Restate entrypoint for putting a running
@@ -40,12 +40,12 @@ func (w *Workflow) StopDeployment(ctx restate.ObjectContext, req *hydrav1.StopDe
 		return nil, fmt.Errorf("failed to load environment: %w", err)
 	}
 
-	if r := deploygate.CheckStopTarget(deploygate.StopInput{
+	if err := deploygate.CheckStopTarget(deploygate.StopInput{
 		Status:          pkgdb.DeploymentsStatus(deployment.Status),
 		DesiredState:    pkgdb.DeploymentsDesiredState(deployment.DesiredState),
 		EnvironmentSlug: environment.Slug,
-	}); r != deploygate.StopOK {
-		return nil, restate.TerminalError(errors.New(r.Message()), 400)
+	}); err != nil {
+		return nil, gatefault.Terminal(err)
 	}
 
 	_, err = hydrav1.NewDeploymentServiceClient(ctx, deploymentID).

--- a/svc/ctrl/worker/deploy/stop_deployment.go
+++ b/svc/ctrl/worker/deploy/stop_deployment.go
@@ -1,10 +1,12 @@
 package deploy
 
 import (
+	"errors"
 	"fmt"
 
 	restate "github.com/restatedev/sdk-go"
 	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
+	"github.com/unkeyed/unkey/pkg/deploy/deploygate"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/db"
 )
 
@@ -27,10 +29,6 @@ func (w *Workflow) StopDeployment(ctx restate.ObjectContext, req *hydrav1.StopDe
 		return nil, fmt.Errorf("failed to load deployment: %w", err)
 	}
 
-	if deployment.Status != db.DeploymentsStatusReady {
-		return nil, restate.TerminalError(fmt.Errorf("deployment is not ready"), 400)
-	}
-
 	environment, err := restate.Run(ctx, func(runCtx restate.RunContext) (db.Environment, error) {
 		return w.db.FindEnvironmentById(runCtx, deployment.EnvironmentID)
 	}, restate.WithName("find environment for stop"), restate.WithMaxRetryAttempts(runMaxAttempts))
@@ -40,12 +38,14 @@ func (w *Workflow) StopDeployment(ctx restate.ObjectContext, req *hydrav1.StopDe
 		}
 		return nil, fmt.Errorf("failed to load environment: %w", err)
 	}
-	if environment.Slug == "production" {
-		return nil, restate.TerminalError(fmt.Errorf("production deployments cannot be stopped"), 400)
-	}
 
-	if deployment.DesiredState != db.DeploymentsDesiredStateRunning {
-		return nil, restate.TerminalError(fmt.Errorf("deployment is not running"), 400)
+	//nolint:exhaustruct // stop only uses the runtime status and environment fields
+	if r := deploygate.CheckStoppable(deploygate.Input{
+		Status:          string(deployment.Status),
+		DesiredState:    string(deployment.DesiredState),
+		EnvironmentSlug: environment.Slug,
+	}); r != deploygate.StopOK {
+		return nil, restate.TerminalError(errors.New(r.Message()), 400)
 	}
 
 	_, err = hydrav1.NewDeploymentServiceClient(ctx, deploymentID).

--- a/svc/ctrl/worker/deploy/stop_deployment.go
+++ b/svc/ctrl/worker/deploy/stop_deployment.go
@@ -40,8 +40,7 @@ func (w *Workflow) StopDeployment(ctx restate.ObjectContext, req *hydrav1.StopDe
 		return nil, fmt.Errorf("failed to load environment: %w", err)
 	}
 
-	//nolint:exhaustruct // stop only uses the runtime status and environment fields
-	if r := deploygate.CheckStoppable(deploygate.Input{
+	if r := deploygate.CheckStoppable(deploygate.StopInput{
 		Status:          pkgdb.DeploymentsStatus(deployment.Status),
 		DesiredState:    pkgdb.DeploymentsDesiredState(deployment.DesiredState),
 		EnvironmentSlug: environment.Slug,

--- a/svc/ctrl/worker/deploy/wake_deployment.go
+++ b/svc/ctrl/worker/deploy/wake_deployment.go
@@ -45,10 +45,12 @@ func (w *Workflow) WakeDeployment(ctx restate.ObjectContext, req *hydrav1.WakeDe
 		return nil, fmt.Errorf("failed to load environment: %w", err)
 	}
 
-	//nolint:exhaustruct // start only uses the desired state and environment fields
-	if r := deploygate.CheckStartable(deploygate.Input{
+	if r := deploygate.CheckStartable(deploygate.StartInput{
 		DesiredState:    pkgdb.DeploymentsDesiredState(deployment.DesiredState),
 		EnvironmentSlug: environment.Slug,
+		// Spend is gated by the ctrl service before enqueue; the worker only
+		// re-checks lifecycle state.
+		SpendSuspended: false,
 	}); r != deploygate.StartOK {
 		return nil, restate.TerminalError(errors.New(r.Message()), 400)
 	}

--- a/svc/ctrl/worker/deploy/wake_deployment.go
+++ b/svc/ctrl/worker/deploy/wake_deployment.go
@@ -2,7 +2,6 @@ package deploy
 
 import (
 	"database/sql"
-	"errors"
 	"fmt"
 	"time"
 
@@ -13,6 +12,7 @@ import (
 	"github.com/unkeyed/unkey/pkg/fault"
 	"github.com/unkeyed/unkey/pkg/restate/restateutil"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/db"
+	"github.com/unkeyed/unkey/svc/ctrl/internal/gatefault"
 )
 
 // WakeDeployment is the public Restate entrypoint for waking a stopped
@@ -45,14 +45,14 @@ func (w *Workflow) WakeDeployment(ctx restate.ObjectContext, req *hydrav1.WakeDe
 		return nil, fmt.Errorf("failed to load environment: %w", err)
 	}
 
-	if r := deploygate.CheckStartTarget(deploygate.StartInput{
+	if err := deploygate.CheckStartTarget(deploygate.StartInput{
 		DesiredState:    pkgdb.DeploymentsDesiredState(deployment.DesiredState),
 		EnvironmentSlug: environment.Slug,
 		// Spend is gated by the ctrl service before enqueue; the worker only
 		// re-checks lifecycle state.
 		SpendSuspended: false,
-	}); r != deploygate.StartOK {
-		return nil, restate.TerminalError(errors.New(r.Message()), 400)
+	}); err != nil {
+		return nil, gatefault.Terminal(err)
 	}
 
 	_, err = hydrav1.NewDeploymentServiceClient(ctx, deploymentID).

--- a/svc/ctrl/worker/deploy/wake_deployment.go
+++ b/svc/ctrl/worker/deploy/wake_deployment.go
@@ -2,11 +2,13 @@ package deploy
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 
 	restate "github.com/restatedev/sdk-go"
 	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
+	"github.com/unkeyed/unkey/pkg/deploy/deploygate"
 	"github.com/unkeyed/unkey/pkg/fault"
 	"github.com/unkeyed/unkey/pkg/restate/restateutil"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/db"
@@ -32,10 +34,6 @@ func (w *Workflow) WakeDeployment(ctx restate.ObjectContext, req *hydrav1.WakeDe
 		return nil, fmt.Errorf("failed to load deployment: %w", err)
 	}
 
-	if deployment.DesiredState != db.DeploymentsDesiredStateStopped {
-		return nil, restate.TerminalError(fmt.Errorf("deployment is not stopped"), 400)
-	}
-
 	environment, err := restate.Run(ctx, func(runCtx restate.RunContext) (db.Environment, error) {
 		return w.db.FindEnvironmentById(runCtx, deployment.EnvironmentID)
 	}, restate.WithName("find environment for wake"), restate.WithMaxRetryAttempts(runMaxAttempts))
@@ -45,8 +43,13 @@ func (w *Workflow) WakeDeployment(ctx restate.ObjectContext, req *hydrav1.WakeDe
 		}
 		return nil, fmt.Errorf("failed to load environment: %w", err)
 	}
-	if environment.Slug == "production" {
-		return nil, restate.TerminalError(fmt.Errorf("production deployments cannot be woken"), 400)
+
+	//nolint:exhaustruct // start only uses the desired state and environment fields
+	if r := deploygate.CheckStartable(deploygate.Input{
+		DesiredState:    string(deployment.DesiredState),
+		EnvironmentSlug: environment.Slug,
+	}); r != deploygate.StartOK {
+		return nil, restate.TerminalError(errors.New(r.Message()), 400)
 	}
 
 	_, err = hydrav1.NewDeploymentServiceClient(ctx, deploymentID).

--- a/svc/ctrl/worker/deploy/wake_deployment.go
+++ b/svc/ctrl/worker/deploy/wake_deployment.go
@@ -8,6 +8,7 @@ import (
 
 	restate "github.com/restatedev/sdk-go"
 	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
+	pkgdb "github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/deploy/deploygate"
 	"github.com/unkeyed/unkey/pkg/fault"
 	"github.com/unkeyed/unkey/pkg/restate/restateutil"
@@ -46,7 +47,7 @@ func (w *Workflow) WakeDeployment(ctx restate.ObjectContext, req *hydrav1.WakeDe
 
 	//nolint:exhaustruct // start only uses the desired state and environment fields
 	if r := deploygate.CheckStartable(deploygate.Input{
-		DesiredState:    string(deployment.DesiredState),
+		DesiredState:    pkgdb.DeploymentsDesiredState(deployment.DesiredState),
 		EnvironmentSlug: environment.Slug,
 	}); r != deploygate.StartOK {
 		return nil, restate.TerminalError(errors.New(r.Message()), 400)

--- a/svc/ctrl/worker/deploy/wake_deployment.go
+++ b/svc/ctrl/worker/deploy/wake_deployment.go
@@ -45,7 +45,7 @@ func (w *Workflow) WakeDeployment(ctx restate.ObjectContext, req *hydrav1.WakeDe
 		return nil, fmt.Errorf("failed to load environment: %w", err)
 	}
 
-	if r := deploygate.CheckStartable(deploygate.StartInput{
+	if r := deploygate.CheckStartTarget(deploygate.StartInput{
 		DesiredState:    pkgdb.DeploymentsDesiredState(deployment.DesiredState),
 		EnvironmentSlug: environment.Slug,
 		// Spend is gated by the ctrl service before enqueue; the worker only


### PR DESCRIPTION
## Problem

We run preflights for actions(start, stop, promotion, rollback). Each of those have 3 levels in our system API, RPC, and durable workflow. And, currently preflights are scattered across the codebase, every level runs the exact same checks with their own semantics. They are quite vulnerable to drifting, because in the future a new person in the team might forget updating preflights for workflow level and create a mess also its not [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself).

## Fix

We move each action's preconditions to a pkg called `pkg/deploy/deploygate/deploygate.go`. And, every level API, RPC, workflow goes through those set of functions. So whenever we wanna change an error message or add a new condition, we just have to update that specific file and adjust tests of consumer of that file.

  Why does centralized gating matter? Two reasons:

  - **going out of sync**: imagine a new person on the team adds a check at the API level but forgets the workflow level. Now the same deployment gets accepted by one level and rejected by another.
  - **TOCTOU**: even if every level checks the same thing, state can change between the API's check and the workflow actually running. So every level still has to re-check, those deeper rejections came back as raw internal errors instead of something we could show to users.


Note: Previously we didn't have a way to surface RPC errors cleanly due to not classified correctly(they could leak internals), since now everything is properly classified we can easily return the error back to user. So if a racy condition happens like I explained above. We'll be able to error to users cleanly.


##  How to test
If those are passing, we are good to go
 - go test ./pkg/deploy/deploygate
  - Route tests per verb, including ctrl-race tests (Test*CtrlGateRejection), start-while-draining, and spend-suspended rejection.
  - go test ./svc/ctrl/api -run 'TestDeployment_(Promote|Rollback)_Validation' 