### PR TITLE
fix: Fix Modal regression

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/_components/create-key/components/credits-setup.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/_components/create-key/components/credits-setup.tsx
@@ -10,7 +10,7 @@ import {
   SelectValue,
 } from "@unkey/ui";
 import { FormDescription } from "@unkey/ui/src/components/form/form-helpers";
-import { Controller, useFormContext, useWatch } from "react-hook-form";
+import { Controller, useController, useFormContext, useWatch } from "react-hook-form";
 import type { CreditsFormValues } from "../create-key.schema";
 
 export const UsageSetup = ({
@@ -27,7 +27,10 @@ export const UsageSetup = ({
     trigger,
   } = useFormContext<CreditsFormValues>();
 
-  const limitEnabled = useWatch({
+  // Keep the discriminator registered independently of portal-mounted DOM refs.
+  const {
+    field: { value: limitEnabled },
+  } = useController({
     control,
     name: "limit.enabled",
   });
@@ -111,7 +114,6 @@ export const UsageSetup = ({
           icon={<ChartPie className="text-gray-12" iconSize="sm-regular" />}
           checked={limitEnabled}
           onCheckedChange={handleSwitchChange}
-          {...register("limit.enabled")}
         />
       )}
 

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/_components/create-key/components/expiration-setup.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/_components/create-key/components/expiration-setup.tsx
@@ -5,7 +5,7 @@ import { Clock } from "@unkey/icons";
 import { FormInput } from "@unkey/ui";
 import { addDays, addMinutes, format } from "date-fns";
 import { useState } from "react";
-import { Controller, useFormContext, useWatch } from "react-hook-form";
+import { Controller, useController, useFormContext, useWatch } from "react-hook-form";
 import type { ExpirationFormValues } from "../create-key.schema";
 
 const EXPIRATION_OPTIONS = [
@@ -45,7 +45,6 @@ export const ExpirationSetup = ({
   overrideEnabled?: boolean;
 }) => {
   const {
-    register,
     formState: { errors },
     control,
     setValue,
@@ -53,7 +52,10 @@ export const ExpirationSetup = ({
 
   const [selectedTitle, setSelectedTitle] = useState<string>("1 day");
 
-  const expirationEnabled = useWatch({
+  // Keep the discriminator registered independently of portal-mounted DOM refs.
+  const {
+    field: { value: expirationEnabled },
+  } = useController({
     control,
     name: "expiration.enabled",
   });
@@ -151,7 +153,6 @@ export const ExpirationSetup = ({
           icon={<Clock className="text-gray-12" iconSize="sm-regular" />}
           checked={expirationEnabled}
           onCheckedChange={handleSwitchChange}
-          {...register("expiration.enabled")}
         />
       )}
 

--- a/web/apps/dashboard/components/dashboard/metadata/metadata-setup.tsx
+++ b/web/apps/dashboard/components/dashboard/metadata/metadata-setup.tsx
@@ -2,7 +2,7 @@
 import type { MetadataFormValues } from "@/lib/schemas/metadata";
 import { Code } from "@unkey/icons";
 import { Button, FormTextarea, toast } from "@unkey/ui";
-import { useFormContext, useWatch } from "react-hook-form";
+import { useController, useFormContext, useWatch } from "react-hook-form";
 import { ProtectionSwitch } from "./protection-switch";
 
 export const EXAMPLE_JSON = {
@@ -48,7 +48,10 @@ export const MetadataSetup = ({ overrideEnabled = false, entityType }: MetadataS
     trigger,
   } = useFormContext<MetadataFormValues>();
 
-  const metadataEnabled = useWatch({
+  // Keep the discriminator registered independently of portal-mounted DOM refs.
+  const {
+    field: { value: metadataEnabled },
+  } = useController({
     control,
     name: "metadata.enabled",
   });
@@ -104,7 +107,6 @@ export const MetadataSetup = ({ overrideEnabled = false, entityType }: MetadataS
           icon={<Code className="text-gray-12" iconSize="sm-regular" />}
           checked={metadataEnabled}
           onCheckedChange={handleSwitchChange}
-          {...register("metadata.enabled")}
         />
       )}
       <div className="flex flex-col gap-2 h-fit duration-300">

--- a/web/apps/dashboard/components/dashboard/ratelimits/ratelimit-setup.tsx
+++ b/web/apps/dashboard/components/dashboard/ratelimits/ratelimit-setup.tsx
@@ -7,7 +7,7 @@ import { Gauge, Trash } from "@unkey/icons";
 import { Button, FormCheckbox, FormInput, InlineLink } from "@unkey/ui";
 import { cn } from "@unkey/ui/src/lib/utils";
 import { useEffect, useState } from "react";
-import { Controller, useFieldArray, useFormContext, useWatch } from "react-hook-form";
+import { Controller, useController, useFieldArray, useFormContext } from "react-hook-form";
 
 // The form's `ratelimit` field is a Zod discriminated union (enabled false/true),
 // which makes react-hook-form collapse the `ratelimit.data` field-array element
@@ -119,7 +119,10 @@ export const RatelimitSetup = ({
     name: "ratelimit.data",
   });
 
-  const ratelimitEnabled = useWatch({
+  // Keep the discriminator registered independently of portal-mounted DOM refs.
+  const {
+    field: { value: ratelimitEnabled },
+  } = useController({
     control,
     name: "ratelimit.enabled",
   });
@@ -173,7 +176,6 @@ export const RatelimitSetup = ({
           icon={<Gauge className="text-gray-12" iconSize="sm-regular" />}
           checked={ratelimitEnabled}
           onCheckedChange={handleSwitchChange}
-          {...register("ratelimit.enabled")}
         />
       )}
 


### PR DESCRIPTION
Problem: Base UI’s portal cleanup disconnected the register(...) ref attached to the wrapper <div>. With shouldUnregister: true, React Hook Form then removed the enabled discriminator and defaulted the feature to disabled. Making users always see a disabled button even when it was enabled on a key. 

Solution: Changed credits, metadata, ratelimits, and expiration to register their enabled state through useController.

Security Impact: zero

Testing: Edit a key and enable the key feature it should work.