### PR TITLE
chore: configure Amp orbs for tests

### DIFF
--- a/.agents/resume
+++ b/.agents/resume
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+sudo systemctl start docker
+sudo setfacl -m "u:$(id -un):rw" /var/run/docker.sock

--- a/.agents/setup
+++ b/.agents/setup
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v setfacl >/dev/null 2>&1; then
+  sudo apt-get update
+  sudo apt-get install -y acl
+fi
+
+echo "Installing Docker Engine and Compose..."
+if ! command -v docker >/dev/null 2>&1 || ! docker compose version >/dev/null 2>&1; then
+  sudo apt-get update
+  sudo apt-get install -y ca-certificates curl
+  sudo install -m 0755 -d /etc/apt/keyrings
+  sudo curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
+  sudo chmod a+r /etc/apt/keyrings/docker.asc
+
+  . /etc/os-release
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian ${VERSION_CODENAME} stable" \
+    | sudo tee /etc/apt/sources.list.d/docker.list >/dev/null
+
+  sudo apt-get update
+  sudo apt-get install -y \
+    containerd.io \
+    docker-buildx-plugin \
+    docker-ce \
+    docker-ce-cli \
+    docker-compose-plugin
+fi
+
+echo "Starting Docker..."
+sudo systemctl start docker
+sudo usermod -aG docker "$(id -un)"
+# The setup shell predates the group membership change, so grant this user
+# access without requiring the orb to restart before tests can use Docker.
+sudo setfacl -m "u:$(id -un):rw" /var/run/docker.sock
+
+echo "Installing the pinned mise binary and toolchain..."
+./dev/install-mise
+"$HOME/.local/bin/mise" trust .mise/config.toml
+"$HOME/.local/bin/mise" install
+
+echo "Installing web dependencies..."
+"$HOME/.local/bin/mise" run install-web
+
+echo "Orb setup complete. Run the Go suite with 'mise run test'."


### PR DESCRIPTION
**Problem:**

Amp doesn't come with docker pre-installed 

**Solution:**

Use .agents/setup to install docker whenever setting up our repo in a orb 

**Impact:**

None for normal repo clones

**Testing:**

We merge this open a new orb and tests should be instantly runnable