### PR TITLE
fix(dashboard): harden Stripe webhook handlers against out of ordering

### DIFF
--- a/web/apps/dashboard/app/api/webhooks/stripe/route.ts
+++ b/web/apps/dashboard/app/api/webhooks/stripe/route.ts
@@ -6,7 +6,11 @@ import { db, eq, schema } from "@/lib/db";
 import { stripeEnv } from "@/lib/env";
 import { formatPrice } from "@/lib/fmt";
 import { freeTierQuotas } from "@/lib/quotas";
-import { deployBillingConfig, findApiItem } from "@/lib/stripe/deployBilling";
+import {
+  deployBillingConfig,
+  deployBillingConfigured,
+  findApiItem,
+} from "@/lib/stripe/deployBilling";
 import { grantDeployCreditsForInvoice } from "@/lib/stripe/deployCredits";
 import { detectDeployPlan } from "@/lib/stripe/deployPlan";
 import { linkDeploySubscription } from "@/lib/stripe/linkDeploySubscription";
@@ -19,6 +23,7 @@ import {
   isPaymentFailureRelatedUpdate,
 } from "@/lib/stripe/subscriptionUtils";
 import {
+  alertInvalidProductQuotaMetadata,
   alertIsCancellingSubscription,
   alertOrphanedDeploySubscription,
   alertPaymentFailed,
@@ -95,11 +100,8 @@ async function downgradeAfterScheduledApiCancel(
   };
   const downgradedQuotas = keepsTeam ? { ...apiFreeQuotas, team: true } : freeTierQuotas;
 
-  await db
-    .update(schema.workspaceBilling)
-    .set({ tier: "Free" })
-    .where(eq(schema.workspaceBilling.workspaceId, ws.id));
-
+  // The redelivery guard returns early on tier === "Free", so the tier
+  // write must come last or a partial failure would never be retried.
   await db
     .insert(schema.quotas)
     .values({
@@ -127,6 +129,11 @@ async function downgradeAfterScheduledApiCancel(
     await deactivateNonCreatorMemberships(ws.orgId);
   }
 
+  await db
+    .update(schema.workspaceBilling)
+    .set({ tier: "Free" })
+    .where(eq(schema.workspaceBilling.workspaceId, ws.id));
+
   return new Response("OK", { status: 200 });
 }
 
@@ -151,10 +158,20 @@ async function linkComputeCheckoutSession(
   if (session.mode !== "subscription" || !session.subscription) {
     return new Response("OK", { status: 200 });
   }
+  const subscriptionId =
+    typeof session.subscription === "string" ? session.subscription : session.subscription.id;
   if (!session.client_reference_id) {
+    // A paid checkout with no workspace ref can never be linked and bills
+    // forever; no retry fixes it, so page a human.
     console.error("Compute checkout link event missing client_reference_id", {
       sessionId: session.id,
       eventId,
+    });
+    await alertOrphanedDeploySubscription({
+      subscriptionId,
+      sessionId: session.id,
+      eventId,
+      reason: "missing_client_reference_id",
     });
     return new Response("OK", { status: 200 });
   }
@@ -171,13 +188,14 @@ async function linkComputeCheckoutSession(
       eventId,
       reason: result.reason,
     });
-    if (result.reason === "subscription_conflict") {
-      const subscriptionId =
-        typeof session.subscription === "string" ? session.subscription : session.subscription.id;
+    // Either way a paid subscription bills with no workspace attached and
+    // no retry fixes it; page a human.
+    if (result.reason === "subscription_conflict" || result.reason === "workspace_not_found") {
       await alertOrphanedDeploySubscription({
         workspaceId: session.client_reference_id,
         subscriptionId,
         sessionId: session.id,
+        eventId,
         reason: result.reason,
       });
     }
@@ -202,7 +220,15 @@ async function resolveApiSubscriptionContext(
   customer: Stripe.Customer | Stripe.DeletedCustomer;
   product: Stripe.Product;
 } | null> {
-  const apiItem = findApiItem(await deployBillingConfig(), sub.items?.data ?? []);
+  const config = await deployBillingConfig();
+  // Config resolution failure would let findApiItem misclassify a Compute
+  // item and ack a scheduled downgrade away; throw so Stripe retries. An
+  // unconfigured deployment keeps the legacy items[0] behavior.
+  if (!config && deployBillingConfigured()) {
+    throw new Error("Deploy billing configured but unresolved; retrying webhook");
+  }
+
+  const apiItem = findApiItem(config, sub.items?.data ?? []);
   if (!apiItem?.price?.id || !sub.customer) {
     return null;
   }
@@ -310,19 +336,43 @@ export const POST = async (req: Request): Promise<Response> => {
   switch (event.type) {
     case "customer.subscription.updated": {
       try {
-        const sub = event.data.object as Stripe.Subscription;
+        // The event snapshot only feeds the previous_attributes skip heuristics;
+        // every DB write derives from a freshly retrieved subscription.
+        const eventSub = event.data.object as Stripe.Subscription;
 
         const billing = await db.query.workspaceBilling.findFirst({
-          where: (table, { eq }) => eq(table.stripeSubscriptionId, sub.id),
+          where: (table, { eq }) => eq(table.stripeSubscriptionId, eventSub.id),
           with: { workspace: true },
         });
         const ws = billing?.workspace ?? null;
         if (!billing || !ws || ws.deletedAtM !== null) {
           console.error("Workspace not found for subscription:", {
-            subscriptionId: sub.id,
+            subscriptionId: eventSub.id,
             eventId: event.id,
           });
+          // A live subscription nothing points at keeps billing; page a human.
+          await alertOrphanedDeploySubscription({
+            subscriptionId: eventSub.id,
+            eventId: event.id,
+            reason: "workspace_not_found",
+          });
           return new Response("OK", { status: 200 });
+        }
+
+        // Stripe does not guarantee event ordering, so the snapshot can be stale;
+        // derive every write from the live subscription. resource_missing means
+        // the deleted handler owns it: ack.
+        let sub: Stripe.Subscription;
+        try {
+          sub = await stripe.subscriptions.retrieve(eventSub.id);
+        } catch (retrieveError) {
+          if (
+            retrieveError instanceof Stripe.errors.StripeError &&
+            retrieveError.code === "resource_missing"
+          ) {
+            return new Response("OK", { status: 200 });
+          }
+          throw retrieveError;
         }
 
         // Sync before the skip-paths below: a plan add/change/remove must be
@@ -333,27 +383,32 @@ export const POST = async (req: Request): Promise<Response> => {
 
         const previousAttributes = event.data.previous_attributes;
 
-        // Skip database updates and notifications for automated billing renewals
-        if (isAutomatedBillingRenewal(sub, previousAttributes)) {
+        // Skip heuristics correlate with previous_attributes, so they read eventSub.
+        if (isAutomatedBillingRenewal(eventSub, previousAttributes)) {
           return new Response("OK", { status: 201 });
         }
 
         // Skip database updates and notifications for payment failure related updates
         // Payment failures are handled by the invoice.payment_failed webhook
-        if (isPaymentFailureRelatedUpdate(sub, previousAttributes)) {
+        if (isPaymentFailureRelatedUpdate(eventSub, previousAttributes)) {
           return new Response("OK", { status: 201 });
         }
 
         // Skip database updates and notifications for payment recovery scenarios
         // Payment recoveries are handled by the invoice.payment_succeeded webhook
-        const isRecovery = await isPaymentRecoveryUpdate(stripe, sub, previousAttributes, event);
+        const isRecovery = await isPaymentRecoveryUpdate(
+          stripe,
+          eventSub,
+          previousAttributes,
+          event,
+        );
         if (isRecovery) {
           return new Response("OK", { status: 201 });
         }
 
         // Skip database updates and notifications for card/payment method updates only
         // These don't affect subscription pricing, quotas, or other business logic
-        if (isCardUpdateOnly(sub, previousAttributes)) {
+        if (isCardUpdateOnly(eventSub, previousAttributes)) {
           return new Response("OK", { status: 201 });
         }
 
@@ -377,6 +432,9 @@ export const POST = async (req: Request): Promise<Response> => {
          * So we get a subscription updated event, which we should handle accordingly.
          */
         if (sub.cancel_at) {
+          // Alert only when an email exists, but return unconditionally: the tier
+          // and quota update below is for active plan changes, never a cancelling
+          // subscription.
           if (customer && !customer.deleted && customer.email) {
             const formattedPrice = formatPrice(unitAmount);
             await alertIsCancellingSubscription(
@@ -385,14 +443,27 @@ export const POST = async (req: Request): Promise<Response> => {
               customer.email,
               customer.name || "Unknown",
             );
-
-            return new Response("OK");
           }
+          return new Response("OK");
         }
 
         // Validate and parse quotas
         const quotas = validateAndParseQuotas(product);
         if (!quotas.valid) {
+          // Without valid quota metadata the tier sync is skipped while Stripe
+          // bills the new plan; page a human to fix the product.
+          console.error("Subscription update skipped: invalid product quota metadata", {
+            productId: product.id,
+            productName: product.name,
+            subscriptionId: sub.id,
+            eventId: event.id,
+          });
+          await alertInvalidProductQuotaMetadata({
+            productId: product.id,
+            productName: product.name,
+            subscriptionId: sub.id,
+            eventId: event.id,
+          });
           return new Response("OK", { status: 200 });
         }
 
@@ -528,6 +599,13 @@ export const POST = async (req: Request): Promise<Response> => {
             subscriptionId: sub.id,
             eventId: event.id,
           });
+          // No ongoing billing on a terminated subscription, but the lost billing
+          // link needs a human to reconcile.
+          await alertOrphanedDeploySubscription({
+            subscriptionId: sub.id,
+            eventId: event.id,
+            reason: "workspace_not_found",
+          });
           return new Response("OK", { status: 200 });
         }
 
@@ -552,39 +630,44 @@ export const POST = async (req: Request): Promise<Response> => {
           }
         }
 
-        await db
-          .update(schema.workspaceBilling)
-          .set({
-            stripeSubscriptionId: null,
-            tier: "Free",
-            // The subscription is gone, so the Deploy plan goes with it.
-            plan: null,
-          })
-          .where(eq(schema.workspaceBilling.workspaceId, ws.id));
+        // One transaction: the link clear is the retry lookup key, so committing
+        // it alone would strand the redelivered event. Same shape as workspace
+        // creation.
+        await db.transaction(async (tx) => {
+          await tx
+            .update(schema.workspaceBilling)
+            .set({
+              stripeSubscriptionId: null,
+              tier: "Free",
+              // The subscription is gone, so the Deploy plan goes with it.
+              plan: null,
+            })
+            .where(eq(schema.workspaceBilling.workspaceId, ws.id));
 
-        await db
-          .insert(schema.quotas)
-          .values({
+          await tx
+            .insert(schema.quotas)
+            .values({
+              workspaceId: ws.id,
+              ...freeTierQuotas,
+            })
+            .onDuplicateKeyUpdate({
+              set: freeTierQuotas,
+            });
+
+          await insertAuditLogs(tx, {
             workspaceId: ws.id,
-            ...freeTierQuotas,
-          })
-          .onDuplicateKeyUpdate({
-            set: freeTierQuotas,
+            actor: {
+              type: "system",
+              id: "stripe",
+            },
+            event: "workspace.update",
+            description: "Cancelled subscription.",
+            resources: [],
+            context: {
+              location: "",
+              userAgent: undefined,
+            },
           });
-
-        await insertAuditLogs(db, {
-          workspaceId: ws.id,
-          actor: {
-            type: "system",
-            id: "stripe",
-          },
-          event: "workspace.update",
-          description: "Cancelled subscription.",
-          resources: [],
-          context: {
-            location: "",
-            userAgent: undefined,
-          },
         });
 
         // Free tier doesn't include team access — deactivate all members except the
@@ -815,6 +898,55 @@ export const POST = async (req: Request): Promise<Response> => {
         // Return 200 to prevent Stripe from retrying, but log the error
         // This ensures payment processing errors don't affect other webhook types
         return new Response("Error processing payment failure", { status: 200 });
+      }
+    }
+
+    // invoice.paid also covers out-of-band and fully-credit-covered
+    // settlements. The grant is idempotent per invoice, so double-firing
+    // no-ops; recovery alerts stay on payment_succeeded.
+    case "invoice.paid": {
+      try {
+        const invoice = event.data.object as Stripe.Invoice;
+
+        if (!invoice || typeof invoice !== "object" || !invoice.customer) {
+          return new Response("OK", { status: 200 });
+        }
+
+        try {
+          const grant = await grantDeployCreditsForInvoice(stripe, invoice);
+          if (grant.granted) {
+            console.info("Granted Deploy usage credits", {
+              invoiceId: invoice.id,
+              grantId: grant.grantId,
+              amountCents: grant.amountCents,
+            });
+          } else {
+            console.info("Did not grant Deploy usage credits", {
+              invoiceId: invoice.id,
+              reason: grant.reason,
+            });
+          }
+        } catch (grantError) {
+          console.error("Failed to grant Deploy usage credits:", {
+            error: grantError,
+            invoiceId: invoice.id,
+            eventId: event.id,
+          });
+          return new Response("Error granting Deploy credits", { status: 500 });
+        }
+
+        return new Response("OK", { status: 200 });
+      } catch (error) {
+        console.error("Error processing invoice.paid webhook:", {
+          error:
+            error instanceof Error
+              ? { message: error.message, stack: error.stack, name: error.name }
+              : error,
+          eventId: event.id,
+          eventType: event.type,
+        });
+        // The only work here is the idempotent grant, so a retry is safe.
+        return new Response("Error processing invoice.paid", { status: 500 });
       }
     }
 

--- a/web/apps/dashboard/app/success/page.tsx
+++ b/web/apps/dashboard/app/success/page.tsx
@@ -192,9 +192,11 @@ function SuccessContent() {
           return;
         }
 
-        // Update customer with default payment method
+        // Pass sessionId: the workspace has no bound customer yet, so the server
+        // resolves and verifies it from the session.
         try {
           await updateCustomerFn({
+            sessionId,
             customerId: customer.id,
             paymentMethod: setupIntent.payment_method,
           });

--- a/web/apps/dashboard/lib/stripe/deployCredits.test.ts
+++ b/web/apps/dashboard/lib/stripe/deployCredits.test.ts
@@ -168,6 +168,37 @@ describe("grantDeployCreditsForInvoice", () => {
     expect(result.granted).toBe(false);
   });
 
+  it("paginates the invoice lines when the webhook payload has more pages", async () => {
+    vi.mocked(deployBillingConfig).mockResolvedValue(config);
+    const periodEnd = Math.floor(Date.now() / 1000) + 7 * 24 * 3600;
+    const create = vi.fn().mockResolvedValue({ id: "credgrant_paged" });
+    const grantsList = vi.fn().mockReturnValue((async function* () {})());
+    // The webhook payload's first page has only a metered line; the fee line
+    // lands on page 2, so netDeployFee must see the paginated set to size the
+    // grant. listLineItems returns the full set as an async iterable.
+    const listLineItems = vi.fn().mockReturnValue(
+      (async function* () {
+        yield line("price_cpu", 123, periodEnd);
+        yield line("price_fee_business", 5000, periodEnd);
+      })(),
+    );
+    const stripe = {
+      billing: { creditGrants: { create, list: grantsList } },
+      invoices: { listLineItems },
+    } as unknown as Stripe;
+
+    const invoice = invoiceStub({
+      lines: {
+        has_more: true,
+        data: [line("price_cpu", 123, periodEnd)],
+      } as unknown as Stripe.Invoice["lines"],
+    });
+
+    const result = await grantDeployCreditsForInvoice(stripe, invoice);
+    expect(listLineItems).toHaveBeenCalledWith("in_test", { limit: 100 });
+    expect(result).toMatchObject({ granted: true, amountCents: 5000 });
+  });
+
   it("skips duplicate grants for the same invoice", async () => {
     vi.mocked(deployBillingConfig).mockResolvedValue(config);
     const periodEnd = Math.floor(Date.now() / 1000) + 7 * 24 * 3600;

--- a/web/apps/dashboard/lib/stripe/deployCredits.ts
+++ b/web/apps/dashboard/lib/stripe/deployCredits.ts
@@ -121,16 +121,21 @@ export async function grantDeployCreditsForInvoice(
   }
   const customerId = typeof invoice.customer === "string" ? invoice.customer : invoice.customer.id;
 
-  // The webhook payload carries the first page of lines. Our subscriptions
-  // have well under a page of items, so more pages means something unexpected;
-  // log it rather than silently miscounting the fee.
+  // The payload carries only the first page of lines; a fee line split
+  // onto page 2 would under-count the grant, so fetch every line.
+  let lines = invoice.lines.data;
   if (invoice.lines.has_more) {
-    console.warn("Invoice has more lines than the webhook payload carries", {
+    console.warn("Invoice has more lines than the webhook payload carries; paginating", {
       invoiceId: invoice.id,
     });
+    const allLines: Stripe.InvoiceLineItem[] = [];
+    for await (const line of stripe.invoices.listLineItems(invoice.id, { limit: 100 })) {
+      allLines.push(line);
+    }
+    lines = allLines;
   }
 
-  const fee = netDeployFee(config, invoice.lines.data);
+  const fee = netDeployFee(config, lines);
   if (!fee) {
     return { granted: false, reason: "no deploy plan-fee lines" };
   }

--- a/web/apps/dashboard/lib/trpc/routers/stripe/getBillingInfo.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/getBillingInfo.ts
@@ -4,6 +4,7 @@ import { deployBillingConfig, findApiItem } from "@/lib/stripe/deployBilling";
 import { getApiCancelSchedule } from "@/lib/stripe/subscriptionUtils";
 import { ratelimit, withRatelimit, workspaceProcedure } from "@/lib/trpc/trpc";
 import { TRPCError } from "@trpc/server";
+import Stripe from "stripe";
 import { z } from "zod";
 import { mapProduct } from "../utils/stripe";
 
@@ -47,7 +48,17 @@ export const getBillingInfo = workspaceProcedure
 
     const [subscription, hasPreviousSubscriptions] = await Promise.all([
       ctx.workspace.stripeSubscriptionId
-        ? await stripe.subscriptions.retrieve(ctx.workspace.stripeSubscriptionId)
+        ? // A stale recorded subscription id (cancelled and pruned from Stripe,
+          // A stale id (lost deleted-webhook) 404s; treat as no subscription
+          // instead of breaking the billing page. Anything else propagates.
+          stripe.subscriptions
+            .retrieve(ctx.workspace.stripeSubscriptionId)
+            .catch((err: unknown) => {
+              if (err instanceof Stripe.errors.StripeError && err.code === "resource_missing") {
+                return undefined;
+              }
+              throw err;
+            })
         : undefined,
 
       ctx.workspace.stripeCustomerId

--- a/web/apps/dashboard/lib/trpc/routers/stripe/updateCustomer.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/updateCustomer.ts
@@ -1,12 +1,22 @@
 import { getStripeClient } from "@/lib/stripe";
 import { handleStripeError } from "@/lib/trpc/routers/utils/stripe";
-import { ratelimit, withRatelimit, workspaceProcedure } from "@/lib/trpc/trpc";
+import {
+  ratelimit,
+  requireWorkspaceAdmin,
+  withRatelimit,
+  workspaceProcedure,
+} from "@/lib/trpc/trpc";
 import { TRPCError } from "@trpc/server";
 import Stripe from "stripe";
 import { z } from "zod";
 
 const updateCustomerInputSchema = z.object({
-  customerId: z.string(),
+  // Either the workspace's bound customer id, or a checkout session whose
+  // client_reference_id matches. During initial card-vault setup no
+  // customer is bound yet, so callers pass sessionId and ownership is
+  // verified from the session.
+  customerId: z.string().optional(),
+  sessionId: z.string().optional(),
   paymentMethod: z.string(),
 });
 
@@ -15,14 +25,44 @@ const customerSchema = z.object({
 });
 
 export const updateCustomer = workspaceProcedure
+  .use(requireWorkspaceAdmin)
   .use(withRatelimit(ratelimit.update))
   .input(updateCustomerInputSchema)
   .output(customerSchema)
-  .mutation(async ({ input }) => {
+  .mutation(async ({ ctx, input }) => {
     const stripe = getStripeClient();
 
+    // Resolve and verify ownership server-side; never trust a caller-supplied id.
+    let resolvedCustomerId: string | null = null;
+    if (input.sessionId) {
+      const session = await stripe.checkout.sessions.retrieve(input.sessionId);
+      if (!session || session.client_reference_id !== ctx.workspace.id) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Customer not found",
+        });
+      }
+      resolvedCustomerId =
+        typeof session.customer === "string" ? session.customer : (session.customer?.id ?? null);
+    } else if (input.customerId && ctx.workspace.stripeCustomerId) {
+      if (input.customerId !== ctx.workspace.stripeCustomerId) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Customer not found",
+        });
+      }
+      resolvedCustomerId = input.customerId;
+    }
+
+    if (!resolvedCustomerId) {
+      throw new TRPCError({
+        code: "NOT_FOUND",
+        message: "Customer not found",
+      });
+    }
+
     try {
-      const customer = await stripe.customers.update(input.customerId, {
+      const customer = await stripe.customers.update(resolvedCustomerId, {
         invoice_settings: {
           default_payment_method: input.paymentMethod,
         },

--- a/web/apps/dashboard/lib/utils/slackAlerts.ts
+++ b/web/apps/dashboard/lib/utils/slackAlerts.ts
@@ -271,23 +271,38 @@ export async function alertPaymentRecovered(
 }
 
 /**
- * High-severity ops alert for a paid Compute checkout whose subscription could
- * not be linked to its workspace and cannot be reconciled automatically — most
- * importantly a `subscription_conflict`, where a race created a second live,
- * charged subscription while the workspace is already served by another. The
- * subscription keeps billing until an operator cancels/refunds it, so this must
- * page a human rather than sit in logs.
+ * High-severity ops alert for a live Stripe subscription that could not be
+ * linked to (or resolved from) a workspace and cannot be reconciled
+ * automatically. Covers a `subscription_conflict` (a race created a second
+ * live, charged subscription while the workspace is already served by
+ * another), a checkout whose workspace or `client_reference_id` is missing,
+ * and a subscription.updated/deleted event whose subscription no workspace row
+ * points at. Such a subscription keeps billing until an operator
+ * cancels/refunds it, so this must page a human rather than sit in logs.
+ *
+ * workspaceId and sessionId are optional because the event-driven callers
+ * (updated/deleted with no matching workspace, or a checkout missing its
+ * client_reference_id) do not have both.
  */
 export async function alertOrphanedDeploySubscription(details: {
-  workspaceId: string;
+  workspaceId?: string;
   subscriptionId: string;
-  sessionId: string;
+  sessionId?: string;
+  eventId?: string;
   reason: string;
 }): Promise<void> {
   const url = process.env.SLACK_WEBHOOK_CUSTOMERS;
   if (!url) {
     return;
   }
+
+  // Include only the fields provided so the message never shows undefined.
+  const detailLines = [
+    details.workspaceId ? `Workspace: \`${details.workspaceId}\`` : null,
+    `Subscription: \`${details.subscriptionId}\``,
+    details.sessionId ? `Checkout session: \`${details.sessionId}\`` : null,
+    details.eventId ? `Event: \`${details.eventId}\`` : null,
+  ].filter((line): line is string => line !== null);
 
   try {
     const response = await fetch(url, {
@@ -306,7 +321,7 @@ export async function alertOrphanedDeploySubscription(details: {
             type: "section",
             text: {
               type: "mrkdwn",
-              text: `A paid Compute checkout could not be linked to its workspace. The subscription is billing but unlinked — cancel/refund it manually.\nWorkspace: \`${details.workspaceId}\`\nSubscription: \`${details.subscriptionId}\`\nCheckout session: \`${details.sessionId}\``,
+              text: `A live subscription could not be linked to its workspace. The subscription is billing but unlinked — cancel/refund it manually.\n${detailLines.join("\n")}`,
             },
           },
         ],
@@ -322,6 +337,62 @@ export async function alertOrphanedDeploySubscription(details: {
     }
   } catch (err: unknown) {
     console.error("Error sending orphaned-subscription alert:", {
+      error: err instanceof Error ? { message: err.message, name: err.name } : err,
+      ...details,
+    });
+  }
+}
+
+/**
+ * Ops alert for a subscription.updated whose product carries invalid or
+ * missing quota metadata. The handler cannot derive the tier/quota values, so
+ * it skips the sync and the workspace silently stays on its old tier while
+ * Stripe bills the new plan. Page a human so the product metadata gets fixed.
+ */
+export async function alertInvalidProductQuotaMetadata(details: {
+  productId: string;
+  productName: string;
+  subscriptionId: string;
+  eventId: string;
+}): Promise<void> {
+  const url = process.env.SLACK_WEBHOOK_CUSTOMERS;
+  if (!url) {
+    return;
+  }
+
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        blocks: [
+          {
+            type: "section",
+            text: {
+              type: "mrkdwn",
+              text: ":rotating_light: Product has invalid quota metadata; tier sync skipped",
+            },
+          },
+          {
+            type: "section",
+            text: {
+              type: "mrkdwn",
+              text: `A subscription.updated could not sync the workspace tier because the product's quota metadata is invalid or missing. Fix the product metadata in Stripe.\nProduct: \`${details.productName}\` (\`${details.productId}\`)\nSubscription: \`${details.subscriptionId}\`\nEvent: \`${details.eventId}\``,
+            },
+          },
+        ],
+      }),
+    });
+
+    if (!response.ok) {
+      console.error("Failed to send invalid-quota-metadata alert to Slack:", {
+        status: response.status,
+        statusText: response.statusText,
+        ...details,
+      });
+    }
+  } catch (err: unknown) {
+    console.error("Error sending invalid-quota-metadata alert:", {
       error: err instanceof Error ? { message: err.message, name: err.name } : err,
       ...details,
     });


### PR DESCRIPTION
**Problem**:

Webhooks can come in out of order and we do action based on it which means we could revoke something that we granted before

Also we have an trpc endpoint with missing admin/security checks.


**Solution**:

Before doing any db writes we retriebe the subscription from stripe and do work based on it.

Make sure that whoever updates the stripe customerId is actually admin in the workspace and that the customer belongs to said workspace.

**Impact**:

New Slack pages for unlinked/orphaned subscriptions

We need to run the anchor alignment script before deploying this or we get a few slack webhooks

**Testing**:

existing test pass