### PR TITLE
fix(billing): bound deploy invoice finalization

### DIFF
--- a/svc/ctrl/api/webhooks/stripe/invoice_created.go
+++ b/svc/ctrl/api/webhooks/stripe/invoice_created.go
@@ -64,12 +64,29 @@ func (h *handler) invoiceCreated(
 			webhook.ErrIgnore, invoice.Subscription, ws.StripeSubscriptionID.String)
 	}
 
-	// Stop Stripe auto-finalizing ~1h later with stale usage. Webhook must
-	// succeed or Stripe redelivers.
+	// Replace Stripe's ~1h auto-finalization with a scheduled one at period end
+	// plus 48 hours. That holds the draft open through the close's 24h usage
+	// ingest wait, but unlike a bare auto_advance=false it bounds the failure
+	// mode where the close never runs: the invoice then finalizes with the last
+	// hourly push's usage (at most an hour stale, still inside the credit
+	// expiry window) instead of sitting open forever with the customer never
+	// billed. The close's manual finalize normally wins the race; the schedule
+	// only fires on a draft. Stripe couples the two fields: setting
+	// automatically_finalizes_at implies auto_advance=true, and auto_advance=
+	// false would clear the schedule. Webhook must succeed or Stripe redelivers.
+	backstopAt := invoice.PeriodEnd + int64((48 * time.Hour).Seconds())
 	if _, err := h.stripe.V1Invoices.Update(ctx, invoice.ID, &stripesdk.InvoiceUpdateParams{
-		AutoAdvance: stripesdk.Bool(false),
+		AutomaticallyFinalizesAt: stripesdk.Int64(backstopAt),
 	}); err != nil {
-		return fmt.Errorf("disable auto_advance on invoice %s: %w", invoice.ID, err)
+		// automatically_finalizes_at is draft-only. A redelivery arriving after
+		// the invoice finalized must not error forever; the close path already
+		// handles finalized invoices, so skip the claim and continue.
+		live, getErr := h.stripe.V1Invoices.Retrieve(ctx, invoice.ID, nil)
+		if getErr != nil || live.Status == stripesdk.InvoiceStatusDraft {
+			return fmt.Errorf("schedule backstop finalization on invoice %s: %w", invoice.ID, err)
+		}
+		logger.Info("invoice already finalized, skipping backstop claim",
+			"invoice_id", invoice.ID, "status", live.Status)
 	}
 
 	// Closed month from period_start: always inside the billed period, unlike

--- a/svc/ctrl/worker/cron/deploybilling/close.go
+++ b/svc/ctrl/worker/cron/deploybilling/close.go
@@ -189,6 +189,7 @@ func (h *Handler) finalizeDrafts(
 			}
 		},
 	)
+
 	// Each failed step defers just its own workspace; the rest still finalize.
 	for _, stepErr := range stepErrs {
 		logger.Error("deploy billing close step failed; deferring workspace", "error", stepErr)

--- a/svc/ctrl/worker/cron/deploybilling/waits.go
+++ b/svc/ctrl/worker/cron/deploybilling/waits.go
@@ -8,11 +8,24 @@ import (
 	"github.com/unkeyed/unkey/pkg/billingperiod"
 )
 
-const usageIngestLateness = 15 * time.Minute
+// usageIngestLateness is how long the close waits after period end before the
+// final usage read, so late ClickHouse rows (buffered flushes, ingestion
+// backpressure during an outage) are included in the closed invoice. The
+// invoice.created webhook already claimed the draft (backstop finalization
+// scheduled at period end plus 48h), so Stripe cannot finalize underneath the
+// wait, and the final read happens after the sleep, so anything ingested in
+// the meantime is picked up. Sized to the top of the industry's 12-24h
+// grace-window range so even a day-long ingestion outage lands inside the
+// closed invoice.
+const usageIngestLateness = 24 * time.Hour
 
 // DefaultFinalizeDelay is the production wait between the close's final meter
-// push and invoice finalization. See waitForMeterAggregation.
-const DefaultFinalizeDelay = 20 * time.Minute
+// push and invoice finalization, giving Stripe's asynchronous meter
+// aggregation time to fold the final push into the draft's lines. Finalizing
+// too early silently locks in the previous hourly value, so this is sized to
+// Stripe's own ~1h draft-settling window; the budget is large (finalize at
+// period end +25h vs the +48h backstop). See waitForMeterAggregation.
+const DefaultFinalizeDelay = time.Hour
 
 // waitForUsageIngestion blocks until late ClickHouse rows for the closed period
 // are likely ingested. Both close paths (HandleClose and HandleCloseWorkspace)
@@ -23,12 +36,14 @@ func waitForUsageIngestion(ctx restate.ObjectContext, p billingperiod.Period, no
 	if now.Before(p.End()) {
 		return nil
 	}
+
 	ingestSafe := p.End().Add(usageIngestLateness)
 	if now.Before(ingestSafe) {
 		if err := restate.Sleep(ctx, ingestSafe.Sub(now)); err != nil {
 			return fmt.Errorf("wait for usage ingestion: %w", err)
 		}
 	}
+
 	return nil
 }
 
@@ -38,8 +53,10 @@ func (h *Handler) waitForMeterAggregation(ctx restate.ObjectContext, pushed bool
 	if !pushed || h.finalizeDelay <= 0 {
 		return nil
 	}
+
 	if err := restate.Sleep(ctx, h.finalizeDelay); err != nil {
 		return fmt.Errorf("wait for meter aggregation: %w", err)
 	}
+
 	return nil
 }


### PR DESCRIPTION
**Problem:**

In theory it could be possible for us to never send an invoice close and thus never get money

**Solution:**

We now tell stripe to auto close the invoice after 48hours if we do not manually close it which would be after 24hours of the billing period end.

**Impact:**

None

**Testing:**

---