### PR TITLE
Flo billing split schema

### DIFF
--- a/dev/k8s/charts/restate-cronjobs/values.yaml
+++ b/dev/k8s/charts/restate-cronjobs/values.yaml
@@ -16,9 +16,15 @@ jobs:
     urlPath: "hydra.v1.CronService/$(date -u +%Y-%m-%d)/RunKeyRefill/send"
     idempotencyKey: "key-refill-$(date -u +%Y-%m-%d)"
 
+  # VO key is prefixed with the task slug so the monthly quota check does not
+  # share a serialization queue with the hourly billing push and the per-minute
+  # spend check, which are also keyed by billing period. A bare "YYYY-MM" key
+  # made all three serialize on one virtual object. The handler strips the
+  # prefix back to "YYYY-MM"; it also still accepts a bare key, so an in-flight
+  # invocation keyed the old way during a deploy keeps parsing.
   quota-check:
     schedule: "0 15 * * *"
-    urlPath: "hydra.v1.CronService/$(date -u +%Y-%m)/RunQuotaCheck/send"
+    urlPath: "hydra.v1.CronService/quota-check-$(date -u +%Y-%m)/RunQuotaCheck/send"
     idempotencyKey: "quota-check-$(date -u +%Y-%m-%d)"
 
   audit-log-export:
@@ -39,13 +45,16 @@ jobs:
     urlPath: "hydra.v1.CronService/audit-log-outbox-cleanup/RunAuditLogOutboxCleanup/send"
     idempotencyKey: "audit-log-outbox-cleanup-$(date -u +%Y-%m-%d)"
 
-  # Hourly month-to-date Deploy usage push to Stripe. Keyed by billing period
-  # (YYYY-MM) so ticks for the same month serialize; the pushed quantity is the
+  # Hourly month-to-date Deploy usage push to Stripe. VO key is the billing
+  # period behind a task-slug prefix ("deploy-billing-push-YYYY-MM") so ticks
+  # for the same month serialize with each other but not with the quota check or
+  # the spend check, which are also period-keyed. The pushed quantity is the
   # absolute month-to-date total (Stripe meters aggregate with formula "last"),
-  # so retries and overlapping ticks are harmless.
+  # so retries and overlapping ticks are harmless. The handler strips the prefix
+  # and still accepts a bare key for backward compatibility during a deploy.
   deploy-billing-push:
     schedule: "0 * * * *"
-    urlPath: "hydra.v1.CronService/$(date -u +%Y-%m)/RunDeployBillingPush/send"
+    urlPath: "hydra.v1.CronService/deploy-billing-push-$(date -u +%Y-%m)/RunDeployBillingPush/send"
     idempotencyKey: "deploy-billing-push-$(date -u +%Y-%m-%dT%H)"
 
   idle-preview-deployments:
@@ -67,17 +76,21 @@ jobs:
 
   # Deploy spend-cap check: prices each budgeted workspace's month-to-date
   # usage, emails budget alerts (50/75/100%), and stops compute at 100% when
-  # the workspace opted in. Keyed by the CURRENT billing
-  # period (YYYY-MM) so the per-workspace checks serialize on one orchestrator
-  # VO. The idempotency key is distinct PER TICK (down to the minute), not per
-  # period: a per-period key
+  # the workspace opted in. VO key is the CURRENT billing period behind a
+  # task-slug prefix ("deploy-spend-check-YYYY-MM") so the per-workspace checks
+  # serialize on one orchestrator VO for the month without sharing that VO with
+  # the quota check or the billing push (both also period-keyed); a bare
+  # "YYYY-MM" key made all three collide on one virtual object. The handler
+  # strips the prefix and still accepts a bare key for backward compatibility
+  # during a deploy. The idempotency key is distinct PER TICK (down to the
+  # minute), not per period: a per-period key
   # would dedupe every run in the month onto one invocation, so the check would
   # fire once a month instead of every cadence.
   #
   # NOTE: local/test schedule runs every 3 minutes so spend-cap behavior is
   # observable in dev without hammering the cluster every minute. Production
-  # cadence (15 minutes) lives in the infra repo.
+  # cadence (every minute) lives in the infra repo.
   deploy-spend-check:
     schedule: "*/3 * * * *"
-    urlPath: "hydra.v1.CronService/$(date -u +%Y-%m)/RunDeploySpendCheck/send"
+    urlPath: "hydra.v1.CronService/deploy-spend-check-$(date -u +%Y-%m)/RunDeploySpendCheck/send"
     idempotencyKey: "deploy-spend-check-$(date -u +%Y-%m-%dT%H:%M)"

--- a/pkg/billingperiod/billingperiod.go
+++ b/pkg/billingperiod/billingperiod.go
@@ -43,6 +43,26 @@ func Parse(key string) (Period, error) {
 	return Period{Year: year, Month: time.Month(month)}, nil
 }
 
+// From returns the Period that a given instant falls in (its calendar month in
+// UTC). Callers derive "the current period" from a journaled Now() so a stale
+// invocation can tell it is running outside the month it was keyed for.
+func From(t time.Time) Period {
+	u := t.UTC()
+	return Period{Year: u.Year(), Month: u.Month()}
+}
+
+// Key renders the Period back to its "YYYY-MM" string form, the inverse of
+// Parse. Used to address period-scoped virtual-object state keys.
+func (p Period) Key() string {
+	return fmt.Sprintf("%04d-%02d", p.Year, int(p.Month))
+}
+
+// Prev returns the calendar month before p. Used to reclaim the previous
+// period's period-scoped state keys once a new period begins.
+func (p Period) Prev() Period {
+	return From(p.Start().AddDate(0, -1, 0))
+}
+
 // Start is midnight UTC on the first day of the month.
 func (p Period) Start() time.Time {
 	return time.Date(p.Year, p.Month, 1, 0, 0, 0, 0, time.UTC)

--- a/pkg/billingperiod/billingperiod_test.go
+++ b/pkg/billingperiod/billingperiod_test.go
@@ -40,6 +40,27 @@ func TestPeriodCloseAllowed(t *testing.T) {
 	require.False(t, p.CloseAllowed(p.End().Add(-time.Second), roll-1))
 }
 
+func TestFromKeyPrev(t *testing.T) {
+	t.Run("From uses UTC calendar month", func(t *testing.T) {
+		// An instant late on the last day of June in a positive offset would be
+		// July locally but is still June in UTC; From must key by UTC.
+		p := From(time.Date(2026, time.June, 30, 23, 30, 0, 0, time.UTC))
+		require.Equal(t, Period{Year: 2026, Month: time.June}, p)
+	})
+
+	t.Run("Key is the inverse of Parse", func(t *testing.T) {
+		p, err := Parse("2026-03")
+		require.NoError(t, err)
+		require.Equal(t, "2026-03", p.Key())
+		require.Equal(t, "2026-11", Period{Year: 2026, Month: time.November}.Key())
+	})
+
+	t.Run("Prev steps back a month across year boundary", func(t *testing.T) {
+		require.Equal(t, "2026-06", Period{Year: 2026, Month: time.July}.Prev().Key())
+		require.Equal(t, "2025-12", Period{Year: 2026, Month: time.January}.Prev().Key())
+	})
+}
+
 func TestPeriodEnd(t *testing.T) {
 	p, err := Parse("2026-06")
 	require.NoError(t, err)

--- a/pkg/db/models_generated.go
+++ b/pkg/db/models_generated.go
@@ -1488,17 +1488,18 @@ type Workspace struct {
 }
 
 type WorkspaceBilling struct {
-	Pk                   uint64         `db:"pk"`
-	WorkspaceID          string         `db:"workspace_id"`
-	Tier                 sql.NullString `db:"tier"`
-	StripeCustomerID     sql.NullString `db:"stripe_customer_id"`
-	StripeSubscriptionID sql.NullString `db:"stripe_subscription_id"`
-	Plan                 sql.NullString `db:"plan"`
-	PlanOverride         sql.NullString `db:"plan_override"`
-	SpendBudgetCents     sql.NullInt64  `db:"spend_budget_cents"`
-	SpendBudgetStop      bool           `db:"spend_budget_stop"`
-	SpendSuspended       bool           `db:"spend_suspended"`
-	CreatedAtM           int64          `db:"created_at_m"`
-	UpdatedAtM           sql.NullInt64  `db:"updated_at_m"`
-	DeletedAtM           sql.NullInt64  `db:"deleted_at_m"`
+	Pk                         uint64         `db:"pk"`
+	WorkspaceID                string         `db:"workspace_id"`
+	Tier                       sql.NullString `db:"tier"`
+	StripeCustomerID           sql.NullString `db:"stripe_customer_id"`
+	StripeSubscriptionID       sql.NullString `db:"stripe_subscription_id"`
+	StripeDeploySubscriptionID sql.NullString `db:"stripe_deploy_subscription_id"`
+	Plan                       sql.NullString `db:"plan"`
+	PlanOverride               sql.NullString `db:"plan_override"`
+	SpendBudgetCents           sql.NullInt64  `db:"spend_budget_cents"`
+	SpendBudgetStop            bool           `db:"spend_budget_stop"`
+	SpendSuspended             bool           `db:"spend_suspended"`
+	CreatedAtM                 int64          `db:"created_at_m"`
+	UpdatedAtM                 sql.NullInt64  `db:"updated_at_m"`
+	DeletedAtM                 sql.NullInt64  `db:"deleted_at_m"`
 }

--- a/pkg/db/querier_generated.go
+++ b/pkg/db/querier_generated.go
@@ -1348,7 +1348,7 @@ type Querier interface {
 	// when a workspace is already being fetched, prefer joining workspace_billing in
 	// that query rather than a second round trip.
 	//
-	//  SELECT pk, workspace_id, tier, stripe_customer_id, stripe_subscription_id, plan, plan_override, spend_budget_cents, spend_budget_stop, spend_suspended, created_at_m, updated_at_m, deleted_at_m FROM `workspace_billing`
+	//  SELECT pk, workspace_id, tier, stripe_customer_id, stripe_subscription_id, stripe_deploy_subscription_id, plan, plan_override, spend_budget_cents, spend_budget_stop, spend_suspended, created_at_m, updated_at_m, deleted_at_m FROM `workspace_billing`
 	//  WHERE workspace_id = ?
 	FindWorkspaceBillingByWorkspaceID(ctx context.Context, db DBTX, workspaceID string) (WorkspaceBilling, error)
 	//FindWorkspaceByID
@@ -3160,6 +3160,7 @@ type Querier interface {
 	//  UPDATE `workspace_billing`
 	//  SET stripe_customer_id = NULL,
 	//      stripe_subscription_id = NULL,
+	//      stripe_deploy_subscription_id = NULL,
 	//      plan = NULL,
 	//      tier = 'Free'
 	//  WHERE workspace_id = ?

--- a/pkg/db/queries/workspace_reset_billing.sql
+++ b/pkg/db/queries/workspace_reset_billing.sql
@@ -6,6 +6,7 @@
 UPDATE `workspace_billing`
 SET stripe_customer_id = NULL,
     stripe_subscription_id = NULL,
+    stripe_deploy_subscription_id = NULL,
     plan = NULL,
     tier = 'Free'
 WHERE workspace_id = sqlc.arg(id);

--- a/pkg/db/workspace_billing_find_by_workspace_id.sql_generated.go
+++ b/pkg/db/workspace_billing_find_by_workspace_id.sql_generated.go
@@ -10,7 +10,7 @@ import (
 )
 
 const findWorkspaceBillingByWorkspaceID = `-- name: FindWorkspaceBillingByWorkspaceID :one
-SELECT pk, workspace_id, tier, stripe_customer_id, stripe_subscription_id, plan, plan_override, spend_budget_cents, spend_budget_stop, spend_suspended, created_at_m, updated_at_m, deleted_at_m FROM ` + "`" + `workspace_billing` + "`" + `
+SELECT pk, workspace_id, tier, stripe_customer_id, stripe_subscription_id, stripe_deploy_subscription_id, plan, plan_override, spend_budget_cents, spend_budget_stop, spend_suspended, created_at_m, updated_at_m, deleted_at_m FROM ` + "`" + `workspace_billing` + "`" + `
 WHERE workspace_id = ?
 `
 
@@ -19,7 +19,7 @@ WHERE workspace_id = ?
 // when a workspace is already being fetched, prefer joining workspace_billing in
 // that query rather than a second round trip.
 //
-//	SELECT pk, workspace_id, tier, stripe_customer_id, stripe_subscription_id, plan, plan_override, spend_budget_cents, spend_budget_stop, spend_suspended, created_at_m, updated_at_m, deleted_at_m FROM `workspace_billing`
+//	SELECT pk, workspace_id, tier, stripe_customer_id, stripe_subscription_id, stripe_deploy_subscription_id, plan, plan_override, spend_budget_cents, spend_budget_stop, spend_suspended, created_at_m, updated_at_m, deleted_at_m FROM `workspace_billing`
 //	WHERE workspace_id = ?
 func (q *Queries) FindWorkspaceBillingByWorkspaceID(ctx context.Context, db DBTX, workspaceID string) (WorkspaceBilling, error) {
 	row := db.QueryRowContext(ctx, findWorkspaceBillingByWorkspaceID, workspaceID)
@@ -30,6 +30,7 @@ func (q *Queries) FindWorkspaceBillingByWorkspaceID(ctx context.Context, db DBTX
 		&i.Tier,
 		&i.StripeCustomerID,
 		&i.StripeSubscriptionID,
+		&i.StripeDeploySubscriptionID,
 		&i.Plan,
 		&i.PlanOverride,
 		&i.SpendBudgetCents,

--- a/pkg/db/workspace_reset_billing.sql_generated.go
+++ b/pkg/db/workspace_reset_billing.sql_generated.go
@@ -13,6 +13,7 @@ const resetWorkspaceBilling = `-- name: ResetWorkspaceBilling :exec
 UPDATE ` + "`" + `workspace_billing` + "`" + `
 SET stripe_customer_id = NULL,
     stripe_subscription_id = NULL,
+    stripe_deploy_subscription_id = NULL,
     plan = NULL,
     tier = 'Free'
 WHERE workspace_id = ?
@@ -26,6 +27,7 @@ WHERE workspace_id = ?
 //	UPDATE `workspace_billing`
 //	SET stripe_customer_id = NULL,
 //	    stripe_subscription_id = NULL,
+//	    stripe_deploy_subscription_id = NULL,
 //	    plan = NULL,
 //	    tier = 'Free'
 //	WHERE workspace_id = ?

--- a/pkg/email/capture.go
+++ b/pkg/email/capture.go
@@ -1,0 +1,60 @@
+package email
+
+import (
+	"context"
+	"sync"
+)
+
+// Capture is a Sender for tests: it records delivered emails and simulates the
+// provider's idempotency-key dedup, so a test can distinguish an email never
+// attempted from one attempted but deduped. Safe for concurrent use.
+type Capture struct {
+	mu   sync.Mutex
+	sent []Email
+	seen map[string]struct{}
+}
+
+// NewCapture returns an empty capturing sender.
+func NewCapture() *Capture {
+	return &Capture{
+		mu:   sync.Mutex{},
+		sent: nil,
+		seen: make(map[string]struct{}),
+	}
+}
+
+func (c *Capture) Send(_ context.Context, e Email) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if e.IdempotencyKey != "" {
+		if _, dup := c.seen[e.IdempotencyKey]; dup {
+			return nil
+		}
+		c.seen[e.IdempotencyKey] = struct{}{}
+	}
+	c.sent = append(c.sent, e)
+	return nil
+}
+
+// Sent returns a copy of the emails delivered so far in send order, excluding
+// sends dropped by dedup.
+func (c *Capture) Sent() []Email {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]Email, len(c.sent))
+	copy(out, c.sent)
+	return out
+}
+
+// CountByTemplate returns how many emails of a template were delivered.
+func (c *Capture) CountByTemplate(templateID string) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	n := 0
+	for _, e := range c.sent {
+		if e.TemplateID == templateID {
+			n++
+		}
+	}
+	return n
+}

--- a/pkg/mysql/schema/workspace_billing.sql
+++ b/pkg/mysql/schema/workspace_billing.sql
@@ -4,6 +4,7 @@ CREATE TABLE `workspace_billing` (
 	`tier` varchar(256) DEFAULT 'Free',
 	`stripe_customer_id` varchar(256),
 	`stripe_subscription_id` varchar(256),
+	`stripe_deploy_subscription_id` varchar(256),
 	`plan` varchar(64),
 	`plan_override` varchar(64),
 	`spend_budget_cents` bigint unsigned,
@@ -19,4 +20,8 @@ CREATE TABLE `workspace_billing` (
 CREATE INDEX `spend_budget_cents_idx` ON `workspace_billing` (`spend_budget_cents`);
 
 CREATE INDEX `spend_suspended_idx` ON `workspace_billing` (`spend_suspended`);
+
+CREATE INDEX `stripe_subscription_id_idx` ON `workspace_billing` (`stripe_subscription_id`);
+
+CREATE INDEX `stripe_deploy_subscription_id_idx` ON `workspace_billing` (`stripe_deploy_subscription_id`);
 

--- a/svc/ctrl/api/webhooks/stripe/invoice_created.go
+++ b/svc/ctrl/api/webhooks/stripe/invoice_created.go
@@ -56,12 +56,12 @@ func (h *handler) invoiceCreated(
 
 	// Same customer can hold multiple Stripe subscriptions. Only claim and
 	// close renewals for this workspace's Deploy subscription.
-	if !ws.StripeSubscriptionID.Valid || ws.StripeSubscriptionID.String == "" {
+	if !ws.StripeDeploySubscriptionID.Valid || ws.StripeDeploySubscriptionID.String == "" {
 		return fmt.Errorf("%w: deploy workspace %s has no stripe subscription id", webhook.ErrIgnore, ws.ID)
 	}
-	if invoice.Subscription != ws.StripeSubscriptionID.String {
+	if invoice.Subscription != ws.StripeDeploySubscriptionID.String {
 		return fmt.Errorf("%w: invoice subscription %s is not workspace deploy subscription %s",
-			webhook.ErrIgnore, invoice.Subscription, ws.StripeSubscriptionID.String)
+			webhook.ErrIgnore, invoice.Subscription, ws.StripeDeploySubscriptionID.String)
 	}
 
 	// Replace Stripe's ~1h auto-finalization with a scheduled one at period end

--- a/svc/ctrl/api/webhooks/stripe/invoice_created.go
+++ b/svc/ctrl/api/webhooks/stripe/invoice_created.go
@@ -64,12 +64,29 @@ func (h *handler) invoiceCreated(
 			webhook.ErrIgnore, invoice.Subscription, ws.StripeSubscriptionID.String)
 	}
 
-	// Stop Stripe auto-finalizing ~1h later with stale usage. Webhook must
-	// succeed or Stripe redelivers.
+	// Replace Stripe's ~1h auto-finalization with a scheduled one at period end
+	// plus 48 hours. That holds the draft open through the close's 24h usage
+	// ingest wait, but unlike a bare auto_advance=false it bounds the failure
+	// mode where the close never runs: the invoice then finalizes with the last
+	// hourly push's usage (at most an hour stale, still inside the credit
+	// expiry window) instead of sitting open forever with the customer never
+	// billed. The close's manual finalize normally wins the race; the schedule
+	// only fires on a draft. Stripe couples the two fields: setting
+	// automatically_finalizes_at implies auto_advance=true, and auto_advance=
+	// false would clear the schedule. Webhook must succeed or Stripe redelivers.
+	backstopAt := invoice.PeriodEnd + int64((48 * time.Hour).Seconds())
 	if _, err := h.stripe.V1Invoices.Update(ctx, invoice.ID, &stripesdk.InvoiceUpdateParams{
-		AutoAdvance: stripesdk.Bool(false),
+		AutomaticallyFinalizesAt: stripesdk.Int64(backstopAt),
 	}); err != nil {
-		return fmt.Errorf("disable auto_advance on invoice %s: %w", invoice.ID, err)
+		// automatically_finalizes_at is draft-only. A redelivery arriving after
+		// the invoice finalized must not error forever; the close path already
+		// handles finalized invoices, so skip the claim and continue.
+		live, getErr := h.stripe.V1Invoices.Retrieve(ctx, invoice.ID, nil)
+		if getErr != nil || live.Status == stripesdk.InvoiceStatusDraft {
+			return fmt.Errorf("schedule backstop finalization on invoice %s: %w", invoice.ID, err)
+		}
+		logger.Info("invoice already finalized, skipping backstop claim",
+			"invoice_id", invoice.ID, "status", live.Status)
 	}
 
 	// Closed month from period_start: always inside the billed period, unlike

--- a/svc/ctrl/api/webhooks/stripe/invoice_created_test.go
+++ b/svc/ctrl/api/webhooks/stripe/invoice_created_test.go
@@ -119,7 +119,7 @@ func TestInvoiceCreated_IgnoresMismatchedSubscription(t *testing.T) {
 	)
 	require.NoError(t, err)
 	_, err = database.RW().ExecContext(context.Background(),
-		`INSERT INTO workspace_billing (workspace_id, plan, stripe_customer_id, stripe_subscription_id) VALUES (?, ?, ?, ?)`,
+		`INSERT INTO workspace_billing (workspace_id, plan, stripe_customer_id, stripe_deploy_subscription_id) VALUES (?, ?, ?, ?)`,
 		"ws_deploy", "pro", "cus_deploy", "sub_deploy",
 	)
 	require.NoError(t, err)

--- a/svc/ctrl/integration/deploy_spend_realert_test.go
+++ b/svc/ctrl/integration/deploy_spend_realert_test.go
@@ -1,0 +1,260 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	restatetest "github.com/restatedev/sdk-go/testing"
+	"github.com/stretchr/testify/require"
+	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
+	"github.com/unkeyed/unkey/pkg/email"
+	"github.com/unkeyed/unkey/svc/ctrl/internal/db"
+	"github.com/unkeyed/unkey/svc/ctrl/worker/cron/deploybilling"
+	"github.com/unkeyed/unkey/svc/ctrl/worker/cron/deployspendcheck"
+	"github.com/unkeyed/unkey/svc/ctrl/worker/deployment"
+	"github.com/unkeyed/unkey/svc/ctrl/worker/deployteardown"
+)
+
+// These template aliases mirror the unexported constants in deployspendcheck's
+// alert.go; the capturing sender classifies emails by them.
+const (
+	templateBudgetAlert   = "compute-budget-alert"
+	templateBudgetStopped = "compute-budget-stopped"
+)
+
+// countWarnings returns how many warning emails were sent for a given budget
+// (as the rendered BUDGET string) and percent.
+func countWarnings(c *email.Capture, budget, percent string) int {
+	n := 0
+	for _, e := range c.Sent() {
+		if e.TemplateID == templateBudgetAlert &&
+			e.Variables["BUDGET"] == budget &&
+			e.Variables["PERCENT"] == percent {
+			n++
+		}
+	}
+	return n
+}
+
+// fixedAdmins resolves one admin email for any org, so the check has a recipient
+// to send to (workos.NewNoop resolves none, which would suppress every send).
+type fixedAdmins struct{ email string }
+
+func (f fixedAdmins) AdminEmails(_ context.Context, _ string) ([]string, error) {
+	return []string{f.email}, nil
+}
+
+// startSpendCheckCapturing wires the check with a capturing email sender and a
+// resolver that returns one admin, so the tests can assert on emails.
+func startSpendCheckCapturing(t *testing.T, database db.Database, sender email.Sender) *restatetest.TestEnvironment {
+	t.Helper()
+
+	checkH, err := deployspendcheck.NewCheckHandler(deployspendcheck.CheckConfig{
+		DB:             database,
+		Admins:         fixedAdmins{email: "admin@example.com"},
+		Email:          sender,
+		BillingBaseURL: "https://app.unkey.com",
+	})
+	require.NoError(t, err)
+
+	teardownSvc, err := deployteardown.New(deployteardown.Config{
+		DB:                database,
+		DrainPollInterval: 200 * time.Millisecond,
+		DrainGraceTimeout: 2 * time.Second,
+	})
+	require.NoError(t, err)
+
+	return restatetest.Start(t,
+		hydrav1.NewDeploymentServiceServer(deployment.New(deployment.Config{DB: database})),
+		hydrav1.NewDeployTeardownServiceServer(teardownSvc),
+		hydrav1.NewDeploySpendCheckServiceServer(checkH),
+	)
+}
+
+// TestDeploySpendCheck_ReAlertAfterBudgetChange walks the user's reported flow:
+// spend hits a $100 budget with stop set (stopped email, suspend), the budget is
+// raised to $200 (compute resumes), then spend climbs into the new budget's
+// thresholds. The warning at 75% of the raised budget and the second stopped
+// email must both fire. On the pre-fix code the raised-budget warning never fires
+// because the high-water mark is pinned at 100% from the first suspension, and
+// even if it did the idempotency key (period+threshold only) would dedup it
+// against the old budget's 75% warning.
+func TestDeploySpendCheck_ReAlertAfterBudgetChange(t *testing.T) {
+	h := New(t)
+	ctx := h.Context()
+
+	dep := h.CreateDeployment(ctx, CreateDeploymentRequest{
+		Region:       "us-east-1",
+		DesiredState: db.DeploymentsDesiredStateRunning,
+	}).Deployment
+
+	// Make the deployment its app's current deployment so suspend/resume have
+	// something to act on, mirroring the suspend/resume test.
+	require.NoError(t, h.DB.UpdateAppDeployments(ctx, db.UpdateAppDeploymentsParams{
+		CurrentDeploymentID: sql.NullString{Valid: true, String: dep.ID},
+		IsRolledBack:        false,
+		UpdatedAt:           sql.NullInt64{Valid: true, Int64: h.Now()},
+		AppID:               dep.AppID,
+	}))
+
+	sender := email.NewCapture()
+	tEnv := startSpendCheckCapturing(t, h.DB, sender)
+	client := hydrav1.NewDeploySpendCheckServiceIngressClient(tEnv.Ingress(), dep.WorkspaceID)
+	period := time.Now().UTC().Format("2006-01")
+
+	// grossMicroCents converts a whole-cent gross into micro-cents the way the
+	// orchestrator would have priced it.
+	grossMicroCents := func(cents int64) int64 { return cents * deploybilling.MicroCentsPerCent }
+
+	suspended := false
+	tick := func(budgetCents, grossCents int64, stop bool) {
+		t.Helper()
+		resp, err := client.CheckWorkspaceSpend().Request(ctx, &hydrav1.CheckWorkspaceSpendRequest{
+			Period:             period,
+			BudgetCents:        budgetCents,
+			Stop:               stop,
+			OrgId:              "org_test",
+			WorkspaceName:      "test",
+			WorkspaceSlug:      "test",
+			SpendMicroCents:    grossMicroCents(grossCents),
+			CurrentlySuspended: suspended,
+		})
+		require.NoError(t, err)
+		suspended = resp.GetSuspended()
+	}
+
+	const (
+		budgetLow  = 10_000 // $100
+		budgetHigh = 20_000 // $200
+	)
+
+	// Budget $100, stop set: climb through the thresholds into a suspension.
+	tick(budgetLow, 5_000, true)  // 50% of $100 -> 50% warning
+	tick(budgetLow, 7_500, true)  // 75% of $100 -> 75% warning
+	tick(budgetLow, 10_000, true) // 100% of $100 -> stopped email #1, suspend
+	require.True(t, suspended, "spend at budget with stop set should suspend")
+
+	// Raise the budget to $200: spend ($100) is now under it, so compute resumes.
+	tick(budgetHigh, 10_000, true) // 50% of $200 -> resume, no email
+	require.False(t, suspended, "raising the budget above spend should resume")
+
+	// Spend climbs into the raised budget's thresholds.
+	tick(budgetHigh, 15_000, true) // 75% of $200 -> 75% warning at the NEW budget
+	tick(budgetHigh, 20_000, true) // 100% of $200 -> stopped email #2, suspend
+	require.True(t, suspended, "spend reaching the raised budget with stop set should suspend again")
+
+	// The user's missing email: a 75% warning against the raised $200 budget.
+	require.GreaterOrEqual(t, countWarnings(sender, "$200", "75"), 1,
+		"a 75%% warning must fire after the budget is raised and re-crossed")
+
+	// Both suspensions must email; the stopped email's idempotency key carries the
+	// suspension generation, so the second suspension is not deduped against the
+	// first.
+	require.Equal(t, 2, sender.CountByTemplate(templateBudgetStopped),
+		"each suspension should send a stopped email")
+
+	// Sanity: the original budget's warnings fired too, so this is a re-arm, not a
+	// wholesale change of behavior.
+	require.Equal(t, 1, countWarnings(sender, "$100", "50"))
+	require.Equal(t, 1, countWarnings(sender, "$100", "75"))
+}
+
+// TestDeploySpendCheck_BudgetChurnDoesNotSpam guards the anti-spam property: once
+// a threshold has been alerted at a spend level, churning the budget (raise,
+// lower, raise back) at constant spend must not send another warning. The cron
+// ticks every minute, so a design that re-alerted per distinct budget value would
+// let a one-cent-per-tick script emit dozens of emails an hour.
+func TestDeploySpendCheck_BudgetChurnDoesNotSpam(t *testing.T) {
+	h := New(t)
+	ctx := h.Context()
+
+	dep := h.CreateDeployment(ctx, CreateDeploymentRequest{
+		Region:       "us-east-1",
+		DesiredState: db.DeploymentsDesiredStateRunning,
+	}).Deployment
+
+	sender := email.NewCapture()
+	tEnv := startSpendCheckCapturing(t, h.DB, sender)
+	client := hydrav1.NewDeploySpendCheckServiceIngressClient(tEnv.Ingress(), dep.WorkspaceID)
+	period := time.Now().UTC().Format("2006-01")
+
+	grossMicroCents := func(cents int64) int64 { return cents * deploybilling.MicroCentsPerCent }
+
+	// stop=false throughout so no suspension interferes; spend is fixed at $80.
+	tick := func(budgetCents int64) {
+		t.Helper()
+		_, err := client.CheckWorkspaceSpend().Request(ctx, &hydrav1.CheckWorkspaceSpendRequest{
+			Period:             period,
+			BudgetCents:        budgetCents,
+			Stop:               false,
+			OrgId:              "org_test",
+			WorkspaceName:      "test",
+			WorkspaceSlug:      "test",
+			SpendMicroCents:    grossMicroCents(8_000), // $80
+			CurrentlySuspended: false,
+		})
+		require.NoError(t, err)
+	}
+
+	tick(10_000) // $80 is 80% of $100 -> one 75% warning
+	// Churn the budget without spend moving: none of these may send.
+	tick(20_000) // 40% of $200
+	tick(10_000) // back to 80% of $100
+	tick(20_000) // 40% of $200 again
+	tick(10_001) // one-cent nudge, still ~80%
+	tick(10_000) // and back
+
+	require.Equal(t, 1, sender.CountByTemplate(templateBudgetAlert),
+		"budget churn at constant spend must not re-send the warning")
+	require.Equal(t, 1, countWarnings(sender, "$100", "75"))
+}
+
+// TestDeploySpendCheck_SuspendedDoesNotWarn guards the torn-state gap: a
+// workspace whose suspended column is set but whose high-water mark was never
+// recorded (a suspend tick that died after writing the column) must not send a
+// stale threshold warning on the next tick. An already-suspended workspace over
+// budget stays suspended and emails nothing.
+func TestDeploySpendCheck_SuspendedDoesNotWarn(t *testing.T) {
+	h := New(t)
+	ctx := h.Context()
+
+	dep := h.CreateDeployment(ctx, CreateDeploymentRequest{
+		Region:       "us-east-1",
+		DesiredState: db.DeploymentsDesiredStateStopped,
+	}).Deployment
+
+	// Column says suspended, but the VO carries no high-water state (fresh key),
+	// exactly the torn state a killed suspend tick would leave behind.
+	require.NoError(t, h.DB.SetWorkspaceDeploySpendSuspended(ctx, db.SetWorkspaceDeploySpendSuspendedParams{
+		Suspended: true,
+		UpdatedAt: sql.NullInt64{Valid: true, Int64: h.Now()},
+		ID:        dep.WorkspaceID,
+	}))
+
+	sender := email.NewCapture()
+	tEnv := startSpendCheckCapturing(t, h.DB, sender)
+	client := hydrav1.NewDeploySpendCheckServiceIngressClient(tEnv.Ingress(), dep.WorkspaceID)
+	period := time.Now().UTC().Format("2006-01")
+
+	resp, err := client.CheckWorkspaceSpend().Request(ctx, &hydrav1.CheckWorkspaceSpendRequest{
+		Period:             period,
+		BudgetCents:        10_000,
+		Stop:               true,
+		OrgId:              "org_test",
+		WorkspaceName:      "test",
+		WorkspaceSlug:      "test",
+		SpendMicroCents:    20_000 * deploybilling.MicroCentsPerCent, // 200% of budget
+		CurrentlySuspended: true,
+	})
+	require.NoError(t, err)
+	require.True(t, resp.GetSuspended(), "an over-budget suspended workspace stays suspended")
+
+	require.Equal(t, 0, sender.CountByTemplate(templateBudgetAlert),
+		"a suspended workspace must not receive a threshold warning")
+	require.Equal(t, 0, sender.CountByTemplate(templateBudgetStopped),
+		"no new suspension transition, so no stopped email")
+}

--- a/svc/ctrl/integration/deploy_spend_reenforce_test.go
+++ b/svc/ctrl/integration/deploy_spend_reenforce_test.go
@@ -1,0 +1,229 @@
+//go:build integration
+
+package integration
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
+	"github.com/unkeyed/unkey/pkg/billingperiod"
+	"github.com/unkeyed/unkey/pkg/email"
+	"github.com/unkeyed/unkey/svc/ctrl/internal/db"
+	"github.com/unkeyed/unkey/svc/ctrl/worker/cron/deploybilling"
+)
+
+// setAppCurrent points an app's current deployment at dep, the precondition a
+// SUSPEND teardown needs to record (and Resume to restore) that deployment.
+func setAppCurrent(t *testing.T, h *Harness, appID, deploymentID string) {
+	t.Helper()
+	require.NoError(t, h.DB.UpdateAppDeployments(h.Context(), db.UpdateAppDeploymentsParams{
+		CurrentDeploymentID: sql.NullString{Valid: true, String: deploymentID},
+		IsRolledBack:        false,
+		UpdatedAt:           sql.NullInt64{Valid: true, Int64: h.Now()},
+		AppID:               appID,
+	}))
+}
+
+// TestDeploySpendCheck_ReEnforcesLeakedCompute covers re-enforcement: once
+// deploy_spend_suspended is true the pre-fix check never re-sent Teardown, so a
+// deployment left running (a kill between the flag write and the first teardown,
+// a drain-grace timeout, or a create racing the gate) kept accruing spend while
+// the dashboard said stopped. A tick that finds the workspace suspended, still
+// over budget, and stop still enabled must re-enforce by re-sending Teardown,
+// and must not re-send the stopped email (it is not a new suspension).
+func TestDeploySpendCheck_ReEnforcesLeakedCompute(t *testing.T) {
+	h := New(t)
+	ctx := h.Context()
+
+	dep := h.CreateDeployment(ctx, CreateDeploymentRequest{
+		Region:       "us-east-1",
+		DesiredState: db.DeploymentsDesiredStateRunning,
+	}).Deployment
+	setAppCurrent(t, h, dep.AppID, dep.ID)
+
+	// Torn state: the column says suspended but compute is still running.
+	require.NoError(t, h.DB.SetWorkspaceDeploySpendSuspended(ctx, db.SetWorkspaceDeploySpendSuspendedParams{
+		Suspended: true,
+		UpdatedAt: sql.NullInt64{Valid: true, Int64: h.Now()},
+		ID:        dep.WorkspaceID,
+	}))
+
+	sender := email.NewCapture()
+	tEnv := startSpendCheckCapturing(t, h.DB, sender)
+	client := hydrav1.NewDeploySpendCheckServiceIngressClient(tEnv.Ingress(), dep.WorkspaceID)
+	period := time.Now().UTC().Format("2006-01")
+
+	resp, err := client.CheckWorkspaceSpend().Request(ctx, &hydrav1.CheckWorkspaceSpendRequest{
+		Period:             period,
+		BudgetCents:        1,
+		Stop:               true,
+		OrgId:              "org_test",
+		WorkspaceName:      "test",
+		WorkspaceSlug:      "test",
+		SpendMicroCents:    200 * deploybilling.MicroCentsPerCent,
+		CurrentlySuspended: true,
+	})
+	require.NoError(t, err)
+	require.True(t, resp.GetSuspended(), "an over-budget suspended workspace stays suspended")
+
+	// Re-enforcement re-sent Teardown, which stops the leaked deployment
+	// (current cleared, desired_state stopped), exactly as the first suspend would.
+	require.Eventually(t, func() bool {
+		app, e := h.DB.FindAppById(ctx, dep.AppID)
+		if e != nil || app.CurrentDeploymentID.Valid {
+			return false
+		}
+		got, e := h.DB.FindDeploymentById(ctx, dep.ID)
+		return e == nil && got.DesiredState == db.DeploymentsDesiredStateStopped
+	}, 15*time.Second, 200*time.Millisecond, "re-enforcement should stop leaked compute")
+
+	// Re-enforcement is not a new suspension transition, so no email fires.
+	require.Equal(t, 0, sender.CountByTemplate(templateBudgetStopped),
+		"re-enforcement must not resend the stopped email")
+	require.Equal(t, 0, sender.CountByTemplate(templateBudgetAlert),
+		"a suspended workspace gets no threshold warning")
+}
+
+// TestDeploySpendCheck_ReEnforceMergesSuspensionRecord is the critical half of
+// when a re-teardown finds compute that leaked past the first suspension, it
+// must MERGE the newly stopped app into the recorded suspension state, not
+// replace it. Otherwise the apps the first teardown stopped are lost from the
+// restore map and Resume never brings them back. The merge is observed through
+// Resume: with the record merged both apps come back; a replace would drop the
+// first app and only the second would resume.
+func TestDeploySpendCheck_ReEnforceMergesSuspensionRecord(t *testing.T) {
+	h := New(t)
+	ctx := h.Context()
+
+	// App 1, running and current.
+	dep1 := h.CreateDeployment(ctx, CreateDeploymentRequest{
+		Region:       "us-east-1",
+		DesiredState: db.DeploymentsDesiredStateRunning,
+	}).Deployment
+	setAppCurrent(t, h, dep1.AppID, dep1.ID)
+
+	tEnv := startSpendCheck(t, h.DB)
+	client := hydrav1.NewDeploySpendCheckServiceIngressClient(tEnv.Ingress(), dep1.WorkspaceID)
+	period := time.Now().UTC().Format("2006-01")
+
+	overBudget := func(suspended bool) *hydrav1.CheckWorkspaceSpendRequest {
+		return &hydrav1.CheckWorkspaceSpendRequest{
+			Period:             period,
+			BudgetCents:        1,
+			Stop:               true,
+			OrgId:              "org_test",
+			WorkspaceName:      "test",
+			WorkspaceSlug:      "test",
+			SpendMicroCents:    200 * deploybilling.MicroCentsPerCent,
+			CurrentlySuspended: suspended,
+		}
+	}
+
+	// 1) Suspend: records {app1: dep1} and stops dep1.
+	r, err := client.CheckWorkspaceSpend().Request(ctx, overBudget(false))
+	require.NoError(t, err)
+	require.True(t, r.GetSuspended())
+	require.Eventually(t, func() bool {
+		app, e := h.DB.FindAppById(ctx, dep1.AppID)
+		if e != nil || app.CurrentDeploymentID.Valid {
+			return false
+		}
+		got, e := h.DB.FindDeploymentById(ctx, dep1.ID)
+		return e == nil && got.DesiredState == db.DeploymentsDesiredStateStopped
+	}, 15*time.Second, 200*time.Millisecond, "first suspend should stop app1")
+
+	// 2) Leaked compute: a deployment in a second app, created after the first
+	//    teardown's snapshot (the gate-read to row-insert race).
+	dep2 := h.CreateDeployment(ctx, CreateDeploymentRequest{
+		Region:       "us-east-1",
+		DesiredState: db.DeploymentsDesiredStateRunning,
+	}).Deployment
+	require.NotEqual(t, dep1.AppID, dep2.AppID, "second deployment must be a distinct app")
+	setAppCurrent(t, h, dep2.AppID, dep2.ID)
+
+	// 3) Re-enforce: the re-teardown finds dep2 running and MERGES {app2: dep2}
+	//    into the recorded {app1: dep1}.
+	r, err = client.CheckWorkspaceSpend().Request(ctx, overBudget(true))
+	require.NoError(t, err)
+	require.True(t, r.GetSuspended())
+	require.Eventually(t, func() bool {
+		app, e := h.DB.FindAppById(ctx, dep2.AppID)
+		if e != nil || app.CurrentDeploymentID.Valid {
+			return false
+		}
+		got, e := h.DB.FindDeploymentById(ctx, dep2.ID)
+		return e == nil && got.DesiredState == db.DeploymentsDesiredStateStopped
+	}, 15*time.Second, 200*time.Millisecond, "re-enforcement should stop the leaked app2")
+
+	// 4) Resume with the budget raised above spend. The merged record restores
+	//    BOTH apps; a replace bug would have dropped app1.
+	r, err = client.CheckWorkspaceSpend().Request(ctx, &hydrav1.CheckWorkspaceSpendRequest{
+		Period:             period,
+		BudgetCents:        1_000_000,
+		Stop:               true,
+		OrgId:              "org_test",
+		WorkspaceName:      "test",
+		WorkspaceSlug:      "test",
+		SpendMicroCents:    200 * deploybilling.MicroCentsPerCent,
+		CurrentlySuspended: true,
+	})
+	require.NoError(t, err)
+	require.False(t, r.GetSuspended(), "budget raised above spend should resume")
+	require.Eventually(t, func() bool {
+		a1, e1 := h.DB.FindAppById(ctx, dep1.AppID)
+		a2, e2 := h.DB.FindAppById(ctx, dep2.AppID)
+		if e1 != nil || e2 != nil {
+			return false
+		}
+		return a1.CurrentDeploymentID.Valid && a1.CurrentDeploymentID.String == dep1.ID &&
+			a2.CurrentDeploymentID.Valid && a2.CurrentDeploymentID.String == dep2.ID
+	}, 15*time.Second, 200*time.Millisecond,
+		"merge must restore BOTH apps on resume; a replace would drop app1")
+}
+
+// TestDeploySpendCheck_StalePeriodNoOp: an invocation whose request
+// period is not the current period (a July tick executing after Aug 1, from a
+// cron delay or retries spanning midnight UTC) must enforce nothing. It would
+// otherwise suspend a workspace in the new month on the old month's spend.
+func TestDeploySpendCheck_StalePeriodNoOp(t *testing.T) {
+	h := New(t)
+	ctx := h.Context()
+
+	dep := h.CreateDeployment(ctx, CreateDeploymentRequest{
+		Region:       "us-east-1",
+		DesiredState: db.DeploymentsDesiredStateRunning,
+	}).Deployment
+	setAppCurrent(t, h, dep.AppID, dep.ID)
+
+	tEnv := startSpendCheck(t, h.DB)
+	client := hydrav1.NewDeploySpendCheckServiceIngressClient(tEnv.Ingress(), dep.WorkspaceID)
+
+	// Last month: a valid period, but not the one the journaled Now() falls in.
+	stalePeriod := billingperiod.From(time.Now().UTC()).Prev().Key()
+
+	resp, err := client.CheckWorkspaceSpend().Request(ctx, &hydrav1.CheckWorkspaceSpendRequest{
+		Period:             stalePeriod,
+		BudgetCents:        1,
+		Stop:               true,
+		OrgId:              "org_test",
+		WorkspaceName:      "test",
+		WorkspaceSlug:      "test",
+		SpendMicroCents:    200 * deploybilling.MicroCentsPerCent,
+		CurrentlySuspended: false,
+	})
+	require.NoError(t, err)
+	require.False(t, resp.GetSuspended(), "a stale-period tick must not suspend")
+
+	// No teardown was dispatched, so compute keeps running.
+	require.Never(t, func() bool {
+		got, e := h.DB.FindDeploymentById(ctx, dep.ID)
+		return e == nil && got.DesiredState == db.DeploymentsDesiredStateStopped
+	}, 2*time.Second, 200*time.Millisecond, "a stale-period tick must not dispatch a teardown")
+
+	billing, err := h.DB.FindWorkspaceBillingByWorkspaceID(ctx, dep.WorkspaceID)
+	require.NoError(t, err)
+	require.False(t, billing.SpendSuspended, "a stale-period tick must not set the suspended column")
+}

--- a/svc/ctrl/internal/db/models_generated.go
+++ b/svc/ctrl/internal/db/models_generated.go
@@ -1488,17 +1488,18 @@ type Workspace struct {
 }
 
 type WorkspaceBilling struct {
-	Pk                   uint64         `db:"pk"`
-	WorkspaceID          string         `db:"workspace_id"`
-	Tier                 sql.NullString `db:"tier"`
-	StripeCustomerID     sql.NullString `db:"stripe_customer_id"`
-	StripeSubscriptionID sql.NullString `db:"stripe_subscription_id"`
-	Plan                 sql.NullString `db:"plan"`
-	PlanOverride         sql.NullString `db:"plan_override"`
-	SpendBudgetCents     sql.NullInt64  `db:"spend_budget_cents"`
-	SpendBudgetStop      bool           `db:"spend_budget_stop"`
-	SpendSuspended       bool           `db:"spend_suspended"`
-	CreatedAtM           int64          `db:"created_at_m"`
-	UpdatedAtM           sql.NullInt64  `db:"updated_at_m"`
-	DeletedAtM           sql.NullInt64  `db:"deleted_at_m"`
+	Pk                         uint64         `db:"pk"`
+	WorkspaceID                string         `db:"workspace_id"`
+	Tier                       sql.NullString `db:"tier"`
+	StripeCustomerID           sql.NullString `db:"stripe_customer_id"`
+	StripeSubscriptionID       sql.NullString `db:"stripe_subscription_id"`
+	StripeDeploySubscriptionID sql.NullString `db:"stripe_deploy_subscription_id"`
+	Plan                       sql.NullString `db:"plan"`
+	PlanOverride               sql.NullString `db:"plan_override"`
+	SpendBudgetCents           sql.NullInt64  `db:"spend_budget_cents"`
+	SpendBudgetStop            bool           `db:"spend_budget_stop"`
+	SpendSuspended             bool           `db:"spend_suspended"`
+	CreatedAtM                 int64          `db:"created_at_m"`
+	UpdatedAtM                 sql.NullInt64  `db:"updated_at_m"`
+	DeletedAtM                 sql.NullInt64  `db:"deleted_at_m"`
 }

--- a/svc/ctrl/internal/db/querier_generated.go
+++ b/svc/ctrl/internal/db/querier_generated.go
@@ -324,7 +324,7 @@ type Querier interface {
 	//
 	//  SELECT
 	//     w.id,
-	//     b.stripe_subscription_id
+	//     b.stripe_deploy_subscription_id
 	//  FROM `workspace_billing` b
 	//  JOIN `workspaces` w ON w.id = b.workspace_id
 	//  WHERE b.stripe_customer_id = ?
@@ -572,7 +572,7 @@ type Querier interface {
 	// fetched, prefer joining workspace_billing in that query over a second round
 	// trip.
 	//
-	//  SELECT pk, workspace_id, tier, stripe_customer_id, stripe_subscription_id, plan, plan_override, spend_budget_cents, spend_budget_stop, spend_suspended, created_at_m, updated_at_m, deleted_at_m FROM `workspace_billing`
+	//  SELECT pk, workspace_id, tier, stripe_customer_id, stripe_subscription_id, stripe_deploy_subscription_id, plan, plan_override, spend_budget_cents, spend_budget_stop, spend_suspended, created_at_m, updated_at_m, deleted_at_m FROM `workspace_billing`
 	//  WHERE workspace_id = ?
 	FindWorkspaceBillingByWorkspaceID(ctx context.Context, workspaceID string) (WorkspaceBilling, error)
 	//FindWorkspaceByID
@@ -1341,7 +1341,7 @@ type Querier interface {
 	//  SELECT
 	//     w.id,
 	//     b.stripe_customer_id,
-	//     b.stripe_subscription_id
+	//     b.stripe_deploy_subscription_id
 	//  FROM `workspaces` w
 	//  LEFT JOIN `workspace_billing` b ON b.workspace_id = w.id
 	//  WHERE b.plan IS NOT NULL

--- a/svc/ctrl/internal/db/queries/workspace_find_deploy_by_stripe_customer_id.sql
+++ b/svc/ctrl/internal/db/queries/workspace_find_deploy_by_stripe_customer_id.sql
@@ -5,7 +5,7 @@
 -- finalization.
 SELECT
    w.id,
-   b.stripe_subscription_id
+   b.stripe_deploy_subscription_id
 FROM `workspace_billing` b
 JOIN `workspaces` w ON w.id = b.workspace_id
 WHERE b.stripe_customer_id = sqlc.arg(stripe_customer_id)

--- a/svc/ctrl/internal/db/queries/workspace_list_deploy_billable.sql
+++ b/svc/ctrl/internal/db/queries/workspace_list_deploy_billable.sql
@@ -12,7 +12,7 @@
 SELECT
    w.id,
    b.stripe_customer_id,
-   b.stripe_subscription_id
+   b.stripe_deploy_subscription_id
 FROM `workspaces` w
 LEFT JOIN `workspace_billing` b ON b.workspace_id = w.id
 WHERE b.plan IS NOT NULL

--- a/svc/ctrl/internal/db/workspace_billing_find_by_workspace_id.sql_generated.go
+++ b/svc/ctrl/internal/db/workspace_billing_find_by_workspace_id.sql_generated.go
@@ -10,7 +10,7 @@ import (
 )
 
 const findWorkspaceBillingByWorkspaceID = `-- name: FindWorkspaceBillingByWorkspaceID :one
-SELECT pk, workspace_id, tier, stripe_customer_id, stripe_subscription_id, plan, plan_override, spend_budget_cents, spend_budget_stop, spend_suspended, created_at_m, updated_at_m, deleted_at_m FROM ` + "`" + `workspace_billing` + "`" + `
+SELECT pk, workspace_id, tier, stripe_customer_id, stripe_subscription_id, stripe_deploy_subscription_id, plan, plan_override, spend_budget_cents, spend_budget_stop, spend_suspended, created_at_m, updated_at_m, deleted_at_m FROM ` + "`" + `workspace_billing` + "`" + `
 WHERE workspace_id = ?
 `
 
@@ -20,7 +20,7 @@ WHERE workspace_id = ?
 // fetched, prefer joining workspace_billing in that query over a second round
 // trip.
 //
-//	SELECT pk, workspace_id, tier, stripe_customer_id, stripe_subscription_id, plan, plan_override, spend_budget_cents, spend_budget_stop, spend_suspended, created_at_m, updated_at_m, deleted_at_m FROM `workspace_billing`
+//	SELECT pk, workspace_id, tier, stripe_customer_id, stripe_subscription_id, stripe_deploy_subscription_id, plan, plan_override, spend_budget_cents, spend_budget_stop, spend_suspended, created_at_m, updated_at_m, deleted_at_m FROM `workspace_billing`
 //	WHERE workspace_id = ?
 func (q *Queries) FindWorkspaceBillingByWorkspaceID(ctx context.Context, workspaceID string) (WorkspaceBilling, error) {
 	row := q.db.QueryRowContext(ctx, findWorkspaceBillingByWorkspaceID, workspaceID)
@@ -31,6 +31,7 @@ func (q *Queries) FindWorkspaceBillingByWorkspaceID(ctx context.Context, workspa
 		&i.Tier,
 		&i.StripeCustomerID,
 		&i.StripeSubscriptionID,
+		&i.StripeDeploySubscriptionID,
 		&i.Plan,
 		&i.PlanOverride,
 		&i.SpendBudgetCents,

--- a/svc/ctrl/internal/db/workspace_find_deploy_by_stripe_customer_id.sql_generated.go
+++ b/svc/ctrl/internal/db/workspace_find_deploy_by_stripe_customer_id.sql_generated.go
@@ -13,7 +13,7 @@ import (
 const findDeployWorkspaceByStripeCustomerID = `-- name: FindDeployWorkspaceByStripeCustomerID :one
 SELECT
    w.id,
-   b.stripe_subscription_id
+   b.stripe_deploy_subscription_id
 FROM ` + "`" + `workspace_billing` + "`" + ` b
 JOIN ` + "`" + `workspaces` + "`" + ` w ON w.id = b.workspace_id
 WHERE b.stripe_customer_id = ?
@@ -22,8 +22,8 @@ WHERE b.stripe_customer_id = ?
 `
 
 type FindDeployWorkspaceByStripeCustomerIDRow struct {
-	ID                   string         `db:"id"`
-	StripeSubscriptionID sql.NullString `db:"stripe_subscription_id"`
+	ID                         string         `db:"id"`
+	StripeDeploySubscriptionID sql.NullString `db:"stripe_deploy_subscription_id"`
 }
 
 // Resolves a Stripe customer to its Deploy workspace. The ctrl Stripe webhook
@@ -33,7 +33,7 @@ type FindDeployWorkspaceByStripeCustomerIDRow struct {
 //
 //	SELECT
 //	   w.id,
-//	   b.stripe_subscription_id
+//	   b.stripe_deploy_subscription_id
 //	FROM `workspace_billing` b
 //	JOIN `workspaces` w ON w.id = b.workspace_id
 //	WHERE b.stripe_customer_id = ?
@@ -42,6 +42,6 @@ type FindDeployWorkspaceByStripeCustomerIDRow struct {
 func (q *Queries) FindDeployWorkspaceByStripeCustomerID(ctx context.Context, stripeCustomerID sql.NullString) (FindDeployWorkspaceByStripeCustomerIDRow, error) {
 	row := q.db.QueryRowContext(ctx, findDeployWorkspaceByStripeCustomerID, stripeCustomerID)
 	var i FindDeployWorkspaceByStripeCustomerIDRow
-	err := row.Scan(&i.ID, &i.StripeSubscriptionID)
+	err := row.Scan(&i.ID, &i.StripeDeploySubscriptionID)
 	return i, err
 }

--- a/svc/ctrl/internal/db/workspace_list_deploy_billable.sql_generated.go
+++ b/svc/ctrl/internal/db/workspace_list_deploy_billable.sql_generated.go
@@ -14,7 +14,7 @@ const listDeployBillableWorkspaces = `-- name: ListDeployBillableWorkspaces :man
 SELECT
    w.id,
    b.stripe_customer_id,
-   b.stripe_subscription_id
+   b.stripe_deploy_subscription_id
 FROM ` + "`" + `workspaces` + "`" + ` w
 LEFT JOIN ` + "`" + `workspace_billing` + "`" + ` b ON b.workspace_id = w.id
 WHERE b.plan IS NOT NULL
@@ -23,9 +23,9 @@ WHERE b.plan IS NOT NULL
 `
 
 type ListDeployBillableWorkspacesRow struct {
-	ID                   string         `db:"id"`
-	StripeCustomerID     sql.NullString `db:"stripe_customer_id"`
-	StripeSubscriptionID sql.NullString `db:"stripe_subscription_id"`
+	ID                         string         `db:"id"`
+	StripeCustomerID           sql.NullString `db:"stripe_customer_id"`
+	StripeDeploySubscriptionID sql.NullString `db:"stripe_deploy_subscription_id"`
 }
 
 // Lists every workspace with an active Deploy plan and a Stripe customer:
@@ -42,7 +42,7 @@ type ListDeployBillableWorkspacesRow struct {
 //	SELECT
 //	   w.id,
 //	   b.stripe_customer_id,
-//	   b.stripe_subscription_id
+//	   b.stripe_deploy_subscription_id
 //	FROM `workspaces` w
 //	LEFT JOIN `workspace_billing` b ON b.workspace_id = w.id
 //	WHERE b.plan IS NOT NULL
@@ -57,7 +57,7 @@ func (q *Queries) ListDeployBillableWorkspaces(ctx context.Context) ([]ListDeplo
 	var items []ListDeployBillableWorkspacesRow
 	for rows.Next() {
 		var i ListDeployBillableWorkspacesRow
-		if err := rows.Scan(&i.ID, &i.StripeCustomerID, &i.StripeSubscriptionID); err != nil {
+		if err := rows.Scan(&i.ID, &i.StripeCustomerID, &i.StripeDeploySubscriptionID); err != nil {
 			return nil, err
 		}
 		items = append(items, i)

--- a/svc/ctrl/services/deployment/deprovision_compute.go
+++ b/svc/ctrl/services/deployment/deprovision_compute.go
@@ -59,11 +59,19 @@ func (s *Service) DeprovisionCompute(ctx context.Context, req *connect.Request[c
 	// Tear down before clearing deploy_plan: the idempotency guard above keys on
 	// deploy_plan, so clearing first then crashing would skip teardown on retry.
 	// The Send is keyed and idempotent, so a re-dispatch is harmless.
+	//
+	// The key carries the subscription id and updated_at, not just the workspace
+	// id: a constant key let a cancel/resubscribe/deploy/cancel cycle dedupe the
+	// second teardown against the first inside Restate's retention window,
+	// leaving resubscribed compute running unbilled. A retry of the same call
+	// (row unchanged) still dedupes.
+	idempotencyKey := fmt.Sprintf("deploy-teardown-archive-%s-%s-%d",
+		workspaceID, billing.StripeSubscriptionID.String, billing.UpdatedAtM.Int64)
 	_, err = hydrav1.NewDeployTeardownServiceIngressClient(s.restate, workspaceID).
 		Teardown().
 		Send(ctx, &hydrav1.TeardownRequest{
 			Mode: hydrav1.TeardownMode_TEARDOWN_MODE_ARCHIVE,
-		}, restate.WithIdempotencyKey("deploy-teardown-archive-"+workspaceID))
+		}, restate.WithIdempotencyKey(idempotencyKey))
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to dispatch teardown: %w", err))
 	}
@@ -72,6 +80,11 @@ func (s *Service) DeprovisionCompute(ctx context.Context, req *connect.Request[c
 	// later resubscribe starts blocked. Runs before the deploy_plan clear because
 	// the idempotency guard keys on deploy_plan; a crash after the clear would
 	// strand the suspension with no retry path.
+	//
+	// Accepted race: a spend-check child dispatched from a pre-cancel snapshot
+	// can re-suspend after this clear. A complete fix needs deploy_plan plumbed
+	// into CheckWorkspaceSpendRequest (proto change, deferred); the window is a
+	// single tick and support can clear the flag.
 	if err := s.db.SetWorkspaceDeploySpendSuspended(ctx, db.SetWorkspaceDeploySpendSuspendedParams{
 		Suspended: false,
 		UpdatedAt: sql.NullInt64{Valid: true, Int64: time.Now().UnixMilli()},

--- a/svc/ctrl/services/deployment/deprovision_compute.go
+++ b/svc/ctrl/services/deployment/deprovision_compute.go
@@ -66,7 +66,7 @@ func (s *Service) DeprovisionCompute(ctx context.Context, req *connect.Request[c
 	// leaving resubscribed compute running unbilled. A retry of the same call
 	// (row unchanged) still dedupes.
 	idempotencyKey := fmt.Sprintf("deploy-teardown-archive-%s-%s-%d",
-		workspaceID, billing.StripeSubscriptionID.String, billing.UpdatedAtM.Int64)
+		workspaceID, billing.StripeDeploySubscriptionID.String, billing.UpdatedAtM.Int64)
 	_, err = hydrav1.NewDeployTeardownServiceIngressClient(s.restate, workspaceID).
 		Teardown().
 		Send(ctx, &hydrav1.TeardownRequest{

--- a/svc/ctrl/worker/cron/deploy_billing_close_integration_test.go
+++ b/svc/ctrl/worker/cron/deploy_billing_close_integration_test.go
@@ -149,7 +149,7 @@ func seedBillableWorkspace(t *testing.T, h *harness.Harness, customerID, subscri
 	}
 	_, err := h.DB.RW().ExecContext(
 		h.Ctx,
-		"UPDATE workspace_billing SET plan = ?, stripe_customer_id = ?, stripe_subscription_id = ? WHERE workspace_id = ?",
+		"UPDATE workspace_billing SET plan = ?, stripe_customer_id = ?, stripe_deploy_subscription_id = ? WHERE workspace_id = ?",
 		"pro", customerID, sub, ws.ID,
 	)
 	require.NoError(t, err)

--- a/svc/ctrl/worker/cron/deploybilling/close.go
+++ b/svc/ctrl/worker/cron/deploybilling/close.go
@@ -189,6 +189,7 @@ func (h *Handler) finalizeDrafts(
 			}
 		},
 	)
+
 	// Each failed step defers just its own workspace; the rest still finalize.
 	for _, stepErr := range stepErrs {
 		logger.Error("deploy billing close step failed; deferring workspace", "error", stepErr)

--- a/svc/ctrl/worker/cron/deploybilling/close.go
+++ b/svc/ctrl/worker/cron/deploybilling/close.go
@@ -260,7 +260,7 @@ func (h *Handler) closeWorkspace(
 		return result, nil
 	}
 
-	if !ws.StripeSubscriptionID.Valid || ws.StripeSubscriptionID.String == "" {
+	if !ws.StripeDeploySubscriptionID.Valid || ws.StripeDeploySubscriptionID.String == "" {
 		logger.Error("deploy workspace has no stripe subscription id; deferring close",
 			"workspace_id", ws.ID,
 			"stripe_customer_id", ws.StripeCustomerID.String,
@@ -269,11 +269,11 @@ func (h *Handler) closeWorkspace(
 		return result, nil
 	}
 
-	drafts, err := h.closer.ListDraftInvoices(rc, ws.StripeSubscriptionID.String)
+	drafts, err := h.closer.ListDraftInvoices(rc, ws.StripeDeploySubscriptionID.String)
 	if err != nil {
 		logger.Error("list draft invoices failed; deferring close",
 			"workspace_id", ws.ID,
-			"stripe_subscription_id", ws.StripeSubscriptionID.String,
+			"stripe_subscription_id", ws.StripeDeploySubscriptionID.String,
 			"error", err,
 		)
 		result.Deferred++

--- a/svc/ctrl/worker/cron/deploybilling/push.go
+++ b/svc/ctrl/worker/cron/deploybilling/push.go
@@ -3,6 +3,7 @@ package deploybilling
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	restate "github.com/restatedev/sdk-go"
 	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
@@ -22,7 +23,10 @@ func (h *Handler) Handle(
 	ctx restate.ObjectContext,
 	_ *hydrav1.RunDeployBillingPushRequest,
 ) (*hydrav1.RunDeployBillingPushResponse, error) {
-	period := restate.Key(ctx)
+	// Task-prefixed VO key ("deploy-billing-push-YYYY-MM") keeps this off the
+	// other period-keyed tasks' virtual object. TrimPrefix is a no-op on a bare
+	// key, so old in-flight invocations still parse during a rolling deploy.
+	period := strings.TrimPrefix(restate.Key(ctx), "deploy-billing-push-")
 	logger.Info("running deploy billing push", "billing_period", period)
 
 	if h.usage == nil {

--- a/svc/ctrl/worker/cron/deploybilling/waits.go
+++ b/svc/ctrl/worker/cron/deploybilling/waits.go
@@ -8,11 +8,24 @@ import (
 	"github.com/unkeyed/unkey/pkg/billingperiod"
 )
 
-const usageIngestLateness = 15 * time.Minute
+// usageIngestLateness is how long the close waits after period end before the
+// final usage read, so late ClickHouse rows (buffered flushes, ingestion
+// backpressure during an outage) are included in the closed invoice. The
+// invoice.created webhook already claimed the draft (backstop finalization
+// scheduled at period end plus 48h), so Stripe cannot finalize underneath the
+// wait, and the final read happens after the sleep, so anything ingested in
+// the meantime is picked up. Sized to the top of the industry's 12-24h
+// grace-window range so even a day-long ingestion outage lands inside the
+// closed invoice.
+const usageIngestLateness = 24 * time.Hour
 
 // DefaultFinalizeDelay is the production wait between the close's final meter
-// push and invoice finalization. See waitForMeterAggregation.
-const DefaultFinalizeDelay = 20 * time.Minute
+// push and invoice finalization, giving Stripe's asynchronous meter
+// aggregation time to fold the final push into the draft's lines. Finalizing
+// too early silently locks in the previous hourly value, so this is sized to
+// Stripe's own ~1h draft-settling window; the budget is large (finalize at
+// period end +25h vs the +48h backstop). See waitForMeterAggregation.
+const DefaultFinalizeDelay = time.Hour
 
 // waitForUsageIngestion blocks until late ClickHouse rows for the closed period
 // are likely ingested. Both close paths (HandleClose and HandleCloseWorkspace)
@@ -23,12 +36,14 @@ func waitForUsageIngestion(ctx restate.ObjectContext, p billingperiod.Period, no
 	if now.Before(p.End()) {
 		return nil
 	}
+
 	ingestSafe := p.End().Add(usageIngestLateness)
 	if now.Before(ingestSafe) {
 		if err := restate.Sleep(ctx, ingestSafe.Sub(now)); err != nil {
 			return fmt.Errorf("wait for usage ingestion: %w", err)
 		}
 	}
+
 	return nil
 }
 
@@ -38,8 +53,10 @@ func (h *Handler) waitForMeterAggregation(ctx restate.ObjectContext, pushed bool
 	if !pushed || h.finalizeDelay <= 0 {
 		return nil
 	}
+
 	if err := restate.Sleep(ctx, h.finalizeDelay); err != nil {
 		return fmt.Errorf("wait for meter aggregation: %w", err)
 	}
+
 	return nil
 }

--- a/svc/ctrl/worker/cron/deployspendcheck/alert.go
+++ b/svc/ctrl/worker/cron/deployspendcheck/alert.go
@@ -34,38 +34,46 @@ type budgetAlert struct {
 	SpendMicroCents int64
 	BudgetCents     int64
 	Year            int
+	// Suspension is the per-period suspension counter; only the stopped email
+	// keys on it, so retries dedupe but a second suspension still sends.
+	Suspension int32
 }
 
 // alert emails the org admins the budget threshold warning for a newly crossed
 // 50/75/100% level.
 func (h *CheckHandler) alert(ctx restate.ObjectContext, a budgetAlert) error {
-	return h.sendToAdmins(ctx, a, budgetAlertTemplate, map[string]string{
-		"PERCENT":        strconv.Itoa(int(a.Threshold)),
-		"USAGE":          deploybilling.FormatDollars(a.SpendMicroCents),
-		"BUDGET":         deploybilling.FormatDollars(a.BudgetCents * deploybilling.MicroCentsPerCent),
-		"WORKSPACE_NAME": a.WorkspaceName,
-		"BILLING_URL":    fmt.Sprintf("%s/%s/settings/billing", h.billingBaseURL, a.WorkspaceSlug),
-		"YEAR":           strconv.Itoa(a.Year),
-	})
+	return h.sendToAdmins(ctx, a, budgetAlertTemplate,
+		budgetAlertIdempotencyKey(a.WorkspaceID, a.Period, a.BudgetCents, a.Threshold),
+		map[string]string{
+			"PERCENT":        strconv.Itoa(int(a.Threshold)),
+			"USAGE":          deploybilling.FormatDollars(a.SpendMicroCents),
+			"BUDGET":         deploybilling.FormatDollars(a.BudgetCents * deploybilling.MicroCentsPerCent),
+			"WORKSPACE_NAME": a.WorkspaceName,
+			"BILLING_URL":    fmt.Sprintf("%s/%s/settings/billing", h.billingBaseURL, a.WorkspaceSlug),
+			"YEAR":           strconv.Itoa(a.Year),
+		})
 }
 
 // stoppedAlert emails the org admins that the spend cap has stopped their
 // Compute. It replaces the 100% threshold warning when stopping is enabled: the
 // action, not the warning, is what they need to see.
 func (h *CheckHandler) stoppedAlert(ctx restate.ObjectContext, a budgetAlert) error {
-	return h.sendToAdmins(ctx, a, budgetStoppedTemplate, map[string]string{
-		"USAGE":          deploybilling.FormatDollars(a.SpendMicroCents),
-		"BUDGET":         deploybilling.FormatDollars(a.BudgetCents * deploybilling.MicroCentsPerCent),
-		"WORKSPACE_NAME": a.WorkspaceName,
-		"BILLING_URL":    fmt.Sprintf("%s/%s/settings/billing", h.billingBaseURL, a.WorkspaceSlug),
-		"YEAR":           strconv.Itoa(a.Year),
-	})
+	return h.sendToAdmins(ctx, a, budgetStoppedTemplate,
+		stoppedAlertIdempotencyKey(a.WorkspaceID, a.Period, a.Suspension),
+		map[string]string{
+			"USAGE":          deploybilling.FormatDollars(a.SpendMicroCents),
+			"BUDGET":         deploybilling.FormatDollars(a.BudgetCents * deploybilling.MicroCentsPerCent),
+			"WORKSPACE_NAME": a.WorkspaceName,
+			"BILLING_URL":    fmt.Sprintf("%s/%s/settings/billing", h.billingBaseURL, a.WorkspaceSlug),
+			"YEAR":           strconv.Itoa(a.Year),
+		})
 }
 
 // sendToAdmins resolves the workspace's org admins and sends them one template
-// email. The WorkOS lookup and the send are each journaled, so a replay repeats
-// neither. A workspace with no resolvable admins sends nothing.
-func (h *CheckHandler) sendToAdmins(ctx restate.ObjectContext, a budgetAlert, templateID string, variables map[string]string) error {
+// email under the given Resend idempotency key. The WorkOS lookup and the send
+// are each journaled, so a replay repeats neither. A workspace with no resolvable
+// admins sends nothing.
+func (h *CheckHandler) sendToAdmins(ctx restate.ObjectContext, a budgetAlert, templateID, idempotencyKey string, variables map[string]string) error {
 	recipients, err := restate.Run(ctx, func(rc restate.RunContext) ([]string, error) {
 		return h.admins.AdminEmails(rc, a.OrgID)
 	}, restate.WithName("resolve org admins"))
@@ -82,21 +90,25 @@ func (h *CheckHandler) sendToAdmins(ctx restate.ObjectContext, a budgetAlert, te
 	}
 
 	return restate.RunVoid(ctx, func(rc restate.RunContext) error {
-		msg := email.Email{
+		return h.email.Send(rc, email.Email{
 			To:             recipients,
 			TemplateID:     templateID,
 			Variables:      variables,
 			From:           "",
 			Subject:        "",
-			IdempotencyKey: "",
-		}
-		if templateID == budgetAlertTemplate {
-			msg.IdempotencyKey = budgetAlertIdempotencyKey(a.WorkspaceID, a.Period, a.Threshold)
-		}
-		return h.email.Send(rc, msg)
+			IdempotencyKey: idempotencyKey,
+		})
 	}, restate.WithName("send budget alert"))
 }
 
-func budgetAlertIdempotencyKey(workspaceID, period string, threshold int32) string {
-	return fmt.Sprintf("budget-alert/%s/%s/%d", workspaceID, period, threshold)
+// budgetAlertIdempotencyKey dedupes a warning at Resend. The budget is in the
+// key so a threshold re-crossed after a budget change is a distinct send.
+func budgetAlertIdempotencyKey(workspaceID, period string, budgetCents int64, threshold int32) string {
+	return fmt.Sprintf("budget-alert/%s/%s/%d/%d", workspaceID, period, budgetCents, threshold)
+}
+
+// stoppedAlertIdempotencyKey dedupes a "compute stopped" email at Resend, keyed
+// by the suspension counter so retries dedupe but a second suspension sends.
+func stoppedAlertIdempotencyKey(workspaceID, period string, suspension int32) string {
+	return fmt.Sprintf("budget-stopped/%s/%s/%d", workspaceID, period, suspension)
 }

--- a/svc/ctrl/worker/cron/deployspendcheck/alert_test.go
+++ b/svc/ctrl/worker/cron/deployspendcheck/alert_test.go
@@ -4,8 +4,45 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/billingperiod"
 )
 
 func TestBudgetAlertIdempotencyKey(t *testing.T) {
-	require.Equal(t, "budget-alert/ws_abc/2026-06/75", budgetAlertIdempotencyKey("ws_abc", "2026-06", 75))
+	require.Equal(t, "budget-alert/ws_abc/2026-06/10000/75", budgetAlertIdempotencyKey("ws_abc", "2026-06", 10000, 75))
+	// A different budget yields a different key, so a threshold re-crossed after a
+	// budget change is not deduped against the old budget's send.
+	require.NotEqual(t,
+		budgetAlertIdempotencyKey("ws_abc", "2026-06", 10000, 75),
+		budgetAlertIdempotencyKey("ws_abc", "2026-06", 20000, 75),
+	)
+}
+
+// TestPreviousPeriodStateKeys locks the key derivation: the check clears the
+// previous period's period-scoped VO state keys on each in-period tick so an
+// alerted or suspended workspace does not accrue an immortal key pair per month.
+// The keys cleared must be exactly the prior period's, including across a year
+// boundary. (The full month-rollover behavior is not exercised end to end
+// because the integration harness runs on a real container clock, so a January
+// tick cannot synthesize December state; this pins the derivation the clear
+// relies on.)
+func TestPreviousPeriodStateKeys(t *testing.T) {
+	jul, err := billingperiod.Parse("2026-07")
+	require.NoError(t, err)
+	require.Equal(t, "spend_alert_high_water:2026-06", alertHighWaterKey(jul.Prev().Key()))
+	require.Equal(t, "spend_suspend_generation:2026-06", suspendGenerationKey(jul.Prev().Key()))
+
+	jan, err := billingperiod.Parse("2026-01")
+	require.NoError(t, err)
+	require.Equal(t, "spend_alert_high_water:2025-12", alertHighWaterKey(jan.Prev().Key()))
+	require.Equal(t, "spend_suspend_generation:2025-12", suspendGenerationKey(jan.Prev().Key()))
+}
+
+func TestStoppedAlertIdempotencyKey(t *testing.T) {
+	require.Equal(t, "budget-stopped/ws_abc/2026-06/1", stoppedAlertIdempotencyKey("ws_abc", "2026-06", 1))
+	// A later suspension (higher generation) is a distinct send, not a dedup of
+	// the first suspension.
+	require.NotEqual(t,
+		stoppedAlertIdempotencyKey("ws_abc", "2026-06", 1),
+		stoppedAlertIdempotencyKey("ws_abc", "2026-06", 2),
+	)
 }

--- a/svc/ctrl/worker/cron/deployspendcheck/check.go
+++ b/svc/ctrl/worker/cron/deployspendcheck/check.go
@@ -8,6 +8,7 @@ import (
 	restate "github.com/restatedev/sdk-go"
 	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
 	"github.com/unkeyed/unkey/pkg/assert"
+	"github.com/unkeyed/unkey/pkg/billingperiod"
 	"github.com/unkeyed/unkey/pkg/email"
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/pkg/restate/restateutil"
@@ -64,12 +65,21 @@ func NewCheckHandler(cfg CheckConfig) (*CheckHandler, error) {
 	}, nil
 }
 
-// alertHighWaterKey is the VO state key for the highest budget threshold already
-// alerted, scoped to a billing period. Scoping by period means the zero value is
-// "nothing alerted yet this period", so a new month starts clean with no reset
-// bookkeeping.
+// alertHighWaterKey is the VO state key for the gross spend (micro-cents) at
+// which we last alerted, scoped to a billing period. Storing spend instead of a
+// threshold keeps alerting correct across budget edits: the effective threshold
+// is recomputed against the current budget each tick, and spend only grows
+// within a period, so a budget edit alone can never re-alert. Zero value means
+// nothing alerted this period.
 func alertHighWaterKey(period string) string {
 	return "spend_alert_high_water:" + period
+}
+
+// suspendGenerationKey counts suspension transitions this period. It feeds the
+// stopped email's idempotency key: retries of one suspension dedupe, a later
+// suspension sends.
+func suspendGenerationKey(period string) string {
+	return "spend_suspend_generation:" + period
 }
 
 // setSuspended persists the workspace's deploy_spend_suspended column on a
@@ -101,6 +111,33 @@ func (h *CheckHandler) CheckWorkspaceSpend(
 ) (*hydrav1.CheckWorkspaceSpendResponse, error) {
 	workspaceID := restate.Key(ctx)
 
+	now, err := restateutil.Now(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get current time: %w", err)
+	}
+
+	// Enforce nothing outside the period this tick was priced for: a check
+	// delayed across the month roll would otherwise act on the new month with
+	// old spend. Journaled Now() so replays agree.
+	reqPeriod, err := billingperiod.Parse(req.GetPeriod())
+	if err != nil {
+		return nil, restate.TerminalError(fmt.Errorf("invalid period %q: %w", req.GetPeriod(), err))
+	}
+	if reqPeriod != billingperiod.From(now) {
+		logger.Info("deploy spend cap: skipping stale-period tick",
+			"workspace_id", workspaceID,
+			"request_period", req.GetPeriod(),
+			"current_period", billingperiod.From(now).Key(),
+		)
+		return &hydrav1.CheckWorkspaceSpendResponse{}, nil
+	}
+
+	// Clear the previous period's keys so workspaces don't accrue an immortal
+	// key pair per month. Clear is idempotent, so no first-tick bookkeeping.
+	prev := reqPeriod.Prev()
+	restate.Clear(ctx, alertHighWaterKey(prev.Key()))
+	restate.Clear(ctx, suspendGenerationKey(prev.Key()))
+
 	if req.GetBudgetCents() <= 0 {
 		if req.GetCurrentlySuspended() {
 			// Budget was removed while suspended: nothing caps spend anymore, so
@@ -117,11 +154,6 @@ func (h *CheckHandler) CheckWorkspaceSpend(
 		// A non-positive budget can't define a meaningful threshold; nothing else
 		// to do.
 		return &hydrav1.CheckWorkspaceSpendResponse{}, nil
-	}
-
-	now, err := restateutil.Now(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("get current time: %w", err)
 	}
 
 	// All spend math is integer micro-cents: the orchestrator quantized the
@@ -142,18 +174,23 @@ func (h *CheckHandler) CheckWorkspaceSpend(
 	// implies crossed == 100.
 	willSuspend := req.GetStop() && !suspended && gross >= budgetMicroCents
 
-	// crossed: highest threshold gross spend reaches now. alerted: highest we've
-	// already emailed this period. We email only when spend has climbed to a
-	// higher threshold than we've alerted, then raise the high-water mark.
+	// crossed: highest threshold gross reaches now. alerted: recomputed from the
+	// spend we last alerted at, against the current budget, so raising the
+	// budget re-arms higher thresholds and lowering it suppresses re-sends. Only
+	// real spend growth into a new bucket emails; budget churn alone never does.
 	crossed := crossedThreshold(gross, budgetMicroCents)
 	stateKey := alertHighWaterKey(req.GetPeriod())
-	alerted, err := restate.Get[int32](ctx, stateKey)
+	alertedSpend, err := restate.Get[int64](ctx, stateKey)
 	if err != nil {
 		return nil, fmt.Errorf("get alert high-water: %w", err)
 	}
+	alerted := crossedThreshold(alertedSpend, budgetMicroCents)
 
+	// No threshold warnings while suspended: the stopped email owns that
+	// messaging, and a suspend tick that died before recording the mark must not
+	// yield a stale 100% warning on the next tick.
 	sentAlert := false
-	if crossed > alerted && !willSuspend {
+	if crossed > alerted && !willSuspend && !suspended {
 		logger.Info("deploy spend threshold crossed",
 			"workspace_id", workspaceID,
 			"billing_period", req.GetPeriod(),
@@ -173,12 +210,14 @@ func (h *CheckHandler) CheckWorkspaceSpend(
 			SpendMicroCents: gross,
 			BudgetCents:     req.GetBudgetCents(),
 			Year:            now.Year(),
+			// Only the stopped email keys on Suspension.
+			Suspension: 0,
 		})
 		if err != nil {
 			return nil, err
 		}
 		sentAlert = true
-		restate.Set(ctx, stateKey, crossed)
+		restate.Set(ctx, stateKey, gross)
 		alerted = crossed
 	}
 
@@ -211,6 +250,16 @@ func (h *CheckHandler) CheckWorkspaceSpend(
 			"workspace_id", workspaceID, "billing_period", req.GetPeriod(),
 			"gross_cents", gross/deploybilling.MicroCentsPerCent, "budget_cents", req.GetBudgetCents())
 
+		// Journaled read+write: a replay reuses this generation and dedupes at
+		// Resend; a later suspension reads a higher value and sends.
+		genKey := suspendGenerationKey(req.GetPeriod())
+		generation, err := restate.Get[int32](ctx, genKey)
+		if err != nil {
+			return nil, fmt.Errorf("get suspend generation: %w", err)
+		}
+		generation++
+		restate.Set(ctx, genKey, generation)
+
 		err = h.stoppedAlert(ctx, budgetAlert{
 			WorkspaceID:     workspaceID,
 			Period:          req.GetPeriod(),
@@ -221,12 +270,26 @@ func (h *CheckHandler) CheckWorkspaceSpend(
 			SpendMicroCents: gross,
 			BudgetCents:     req.GetBudgetCents(),
 			Year:            now.Year(),
+			Suspension:      generation,
 		})
 		if err != nil {
 			return nil, err
 		}
-		restate.Set(ctx, stateKey, crossed)
+		restate.Set(ctx, stateKey, gross)
 		alerted = crossed
+
+	case suspended && req.GetStop() && gross >= budgetMicroCents:
+		// The flag can say stopped while compute still runs (kill before the
+		// teardown send, drain grace expired, create racing the gate). Re-send
+		// Teardown: it early-returns when nothing runs and merges into the
+		// recorded suspension state so previously stopped apps stay resumable.
+		// No email, no flag change: enforcement catching up, not a transition.
+		hydrav1.NewDeployTeardownServiceClient(ctx, workspaceID).
+			Teardown().
+			Send(&hydrav1.TeardownRequest{Mode: hydrav1.TeardownMode_TEARDOWN_MODE_SUSPEND})
+		logger.Info("deploy spend cap: re-enforced suspension",
+			"workspace_id", workspaceID, "billing_period", req.GetPeriod(),
+			"gross_cents", gross/deploybilling.MicroCentsPerCent, "budget_cents", req.GetBudgetCents())
 
 	case suspended && (!req.GetStop() || gross < budgetMicroCents):
 		// Budget raised above gross spend, period reset, or stopping turned

--- a/svc/ctrl/worker/cron/deployspendcheck/handler.go
+++ b/svc/ctrl/worker/cron/deployspendcheck/handler.go
@@ -3,6 +3,8 @@ package deployspendcheck
 import (
 	"fmt"
 	"sort"
+	"strings"
+	"time"
 
 	restate "github.com/restatedev/sdk-go"
 	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
@@ -76,12 +78,39 @@ func (h *Handler) Handle(
 	ctx restate.ObjectContext,
 	_ *hydrav1.RunDeploySpendCheckRequest,
 ) (*hydrav1.RunDeploySpendCheckResponse, error) {
-	period := restate.Key(ctx)
+	// Task-prefixed VO key ("deploy-spend-check-YYYY-MM") keeps this off the
+	// other period-keyed tasks' virtual object. TrimPrefix is a no-op on a bare
+	// key, so old in-flight invocations still parse during a rolling deploy.
+	period := strings.TrimPrefix(restate.Key(ctx), "deploy-spend-check-")
 	logger.Info("running deploy spend check", "billing_period", period)
 
 	if h.usage == nil {
 		logger.Info("deploy spend check disabled (no usage reader configured)",
 			"billing_period", period,
+		)
+		return &hydrav1.RunDeploySpendCheckResponse{}, nil
+	}
+
+	// A stale-period orchestrator (delayed across the month roll) must not fan
+	// out: its checks would enforce old spend against the new month, racing the
+	// live VO. Journaled Now() so replays agree; heartbeat still pings.
+	p, err := billingperiod.Parse(period)
+	if err != nil {
+		return nil, restate.TerminalError(fmt.Errorf("invalid billing period %q: %w", period, err))
+	}
+	now, err := restateutil.Now(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get current time: %w", err)
+	}
+	if p != billingperiod.From(now) {
+		if err := restate.RunVoid(ctx, func(rc restate.RunContext) error {
+			return h.heartbeat.Ping(rc)
+		}, restate.WithName("send heartbeat")); err != nil {
+			return nil, fmt.Errorf("send heartbeat: %w", err)
+		}
+		logger.Info("deploy spend check: skipping stale period",
+			"billing_period", period,
+			"current_period", billingperiod.From(now).Key(),
 		)
 		return &hydrav1.RunDeploySpendCheckResponse{}, nil
 	}
@@ -119,7 +148,7 @@ func (h *Handler) Handle(
 	for _, ws := range budgeted {
 		budgetedIDs = append(budgetedIDs, ws.ID)
 	}
-	values, err := h.priceUsage(ctx, period, budgetedIDs)
+	values, err := h.priceUsage(ctx, p, now, budgetedIDs)
 	if err != nil {
 		return nil, err
 	}
@@ -137,8 +166,11 @@ func (h *Handler) Handle(
 		// never is quiet.
 		suspended := ws.SpendSuspended.Bool
 
-		if !ws.SpendBudgetCents.Valid && !suspended {
-			continue // query filters these out; guard against a future query change
+		// Skip non-suspended workspaces without a positive budget: a zero budget
+		// reads as 100% crossed and would dispatch a no-op every tick forever.
+		// Suspended workspaces always dispatch so the check can resume them.
+		if !suspended && (!ws.SpendBudgetCents.Valid || ws.SpendBudgetCents.Int64 <= 0) {
+			continue
 		}
 
 		// All spend math is integer micro-cents: the pricing quantized once in
@@ -227,18 +259,10 @@ func (h *Handler) Handle(
 // into this period's decisions.
 func (h *Handler) priceUsage(
 	ctx restate.ObjectContext,
-	period string,
+	p billingperiod.Period,
+	now time.Time,
 	workspaceIDs []string,
 ) (map[string]billingmeter.MeterValues, error) {
-	p, err := billingperiod.Parse(period)
-	if err != nil {
-		return nil, restate.TerminalError(fmt.Errorf("invalid billing period %q: %w", period, err))
-	}
-	now, err := restateutil.Now(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("get current time: %w", err)
-	}
-
 	endMillis := now.UnixMilli()
 	if periodEndMillis := p.End().UnixMilli(); endMillis > periodEndMillis {
 		endMillis = periodEndMillis

--- a/svc/ctrl/worker/cron/deployspendcheck/thresholds.go
+++ b/svc/ctrl/worker/cron/deployspendcheck/thresholds.go
@@ -1,19 +1,28 @@
 package deployspendcheck
 
+import "math/bits"
+
 // thresholds are the budget fractions, as percentages, that trigger an alert,
 // ascending. Vercel's model: one budget, alerts at fixed percentages of it.
 var thresholds = []int32{50, 75, 100}
 
 // crossedThreshold returns the highest alert threshold (0, 50, 75 or 100) the
 // gross spend has reached against the budget. 0 means no threshold reached yet.
-// budget is assumed positive (the query filters out null budgets; the caller
-// skips non-positive ones). Both amounts are integer micro-cents and the
-// comparison cross-multiplies, so it is exact: no division, no floats, and a
-// single micro-cent past a threshold still counts.
+// A non-positive budget defines no threshold and returns 0 (the dashboard
+// blocks it, a direct DB write does not). The comparison is the exact
+// cross-multiplied spend*100 >= threshold*budget in 128 bits: at micro-cent
+// scale the products overflow int64 past roughly $922M/month, and a silent
+// overflow would flip the comparison into instant 100% at zero spend.
 func crossedThreshold(spendMicroCents, budgetMicroCents int64) int32 {
+	if budgetMicroCents <= 0 || spendMicroCents < 0 {
+		return 0
+	}
+	spendHi, spendLo := bits.Mul64(uint64(spendMicroCents), 100)
 	var highest int32
 	for _, t := range thresholds {
-		if spendMicroCents*100 >= int64(t)*budgetMicroCents {
+		budgetHi, budgetLo := bits.Mul64(uint64(budgetMicroCents), uint64(t))
+		// 128-bit spend*100 >= threshold*budget.
+		if spendHi > budgetHi || (spendHi == budgetHi && spendLo >= budgetLo) {
 			highest = t
 		}
 	}

--- a/svc/ctrl/worker/cron/deployspendcheck/thresholds_test.go
+++ b/svc/ctrl/worker/cron/deployspendcheck/thresholds_test.go
@@ -34,3 +34,55 @@ func TestThresholdLevel(t *testing.T) {
 		})
 	}
 }
+
+// TestThresholdDegenerateBudget covers the degenerate budgets: a non-positive budget
+// defines no threshold, and huge budgets must not overflow the cross-multiply
+// into a false 100%.
+func TestThresholdDegenerateBudget(t *testing.T) {
+	t.Run("zero budget reports nothing crossed even at spend", func(t *testing.T) {
+		// The pre-fix code returned 100 here (spend*100 >= 0 is always true),
+		// which dispatched the workspace every tick forever as a no-op.
+		if got := crossedThreshold(0, 0); got != 0 {
+			t.Fatalf("crossedThreshold(0, 0) = %d, want 0", got)
+		}
+		if got := crossedThreshold(5_000*deploybilling.MicroCentsPerCent, 0); got != 0 {
+			t.Fatalf("crossedThreshold(spend, 0) = %d, want 0", got)
+		}
+	})
+
+	t.Run("negative operands report nothing crossed", func(t *testing.T) {
+		if got := crossedThreshold(-1, 10_000*deploybilling.MicroCentsPerCent); got != 0 {
+			t.Fatalf("crossedThreshold(-1, budget) = %d, want 0", got)
+		}
+	})
+
+	// Budget past the int64 overflow bound for the cross-multiply. At micro-cent
+	// scale threshold*budget and spend*100 overflow int64 once budgetMicroCents
+	// exceeds math.MaxInt64/100 (roughly $922M/month). The pre-fix int64 math
+	// wrapped there, so the comparison read as crossed at any spend, including
+	// zero; the 128-bit math stays exact.
+	t.Run("huge budget does not overflow into false 100", func(t *testing.T) {
+		// 2e17 micro-cents == $2B/month, comfortably past the overflow bound and
+		// even, so 50% is exact. 100*budget == 2e19 overflows int64 (max 9.22e18).
+		const overflowBudget int64 = 200_000_000_000_000_000
+
+		// Zero spend against an enormous budget: nothing crossed. This is the
+		// exact regression: the pre-fix code returned 100 here.
+		if got := crossedThreshold(0, overflowBudget); got != 0 {
+			t.Fatalf("crossedThreshold(0, huge) = %d, want 0", got)
+		}
+		// A tiny spend against the enormous budget is still far below 50%.
+		if got := crossedThreshold(1_000_000, overflowBudget); got != 0 {
+			t.Fatalf("crossedThreshold(tiny, huge) = %d, want 0", got)
+		}
+		// Exactly 50% of the enormous budget must read as 50 and no higher: this
+		// exercises the 128-bit compare at the scale the old code overflowed.
+		if got := crossedThreshold(overflowBudget/2, overflowBudget); got != 50 {
+			t.Fatalf("crossedThreshold(half, huge) = %d, want 50", got)
+		}
+		// One micro-cent short of 100% must still read 75, not 100.
+		if got := crossedThreshold(overflowBudget-1, overflowBudget); got != 75 {
+			t.Fatalf("crossedThreshold(just under full, huge) = %d, want 75", got)
+		}
+	})
+}

--- a/svc/ctrl/worker/cron/quotacheck/handler.go
+++ b/svc/ctrl/worker/cron/quotacheck/handler.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	restate "github.com/restatedev/sdk-go"
@@ -99,7 +100,10 @@ func (h *Handler) Handle(
 	ctx restate.ObjectContext,
 	_ *hydrav1.RunQuotaCheckRequest,
 ) (*hydrav1.RunQuotaCheckResponse, error) {
-	billingPeriod := restate.Key(ctx)
+	// Task-prefixed VO key ("quota-check-YYYY-MM") keeps this off the other
+	// period-keyed tasks' virtual object. TrimPrefix is a no-op on a bare key,
+	// so old in-flight invocations still parse during a rolling deploy.
+	billingPeriod := strings.TrimPrefix(restate.Key(ctx), "quota-check-")
 	logger.Info("running quota check", "billing_period", billingPeriod)
 
 	p, err := billingperiod.Parse(billingPeriod)

--- a/svc/ctrl/worker/deployteardown/teardown.go
+++ b/svc/ctrl/worker/deployteardown/teardown.go
@@ -113,7 +113,24 @@ func (v *VirtualObject) Teardown(
 	switch req.GetMode() {
 	case hydrav1.TeardownMode_TEARDOWN_MODE_SUSPEND:
 		if len(appCurrent) > 0 {
-			restate.Set(ctx, suspensionKey, &suspension{AppCurrent: appCurrent})
+			// Merge into any existing suspension record: a re-enforcing teardown
+			// only sees deployments running now, and replacing would drop the apps
+			// the first teardown stopped from the restore map, so Resume would
+			// never bring them back. New entries win on collision.
+			existing, err := restate.Get[*suspension](ctx, suspensionKey)
+			if err != nil {
+				return nil, fmt.Errorf("read suspension record: %w", err)
+			}
+			merged := make(map[string]string, len(appCurrent))
+			if existing != nil {
+				for appID, deploymentID := range existing.AppCurrent {
+					merged[appID] = deploymentID
+				}
+			}
+			for appID, deploymentID := range appCurrent {
+				merged[appID] = deploymentID
+			}
+			restate.Set(ctx, suspensionKey, &suspension{AppCurrent: merged})
 		}
 	case hydrav1.TeardownMode_TEARDOWN_MODE_ARCHIVE:
 		restate.Clear(ctx, suspensionKey)

--- a/svc/ctrl/worker/run.go
+++ b/svc/ctrl/worker/run.go
@@ -599,11 +599,22 @@ func Run(ctx context.Context, cfg Config) error {
 		restate.WithMaxAttempts(5),
 		restate.KillOnMaxAttempts(),
 	)
+	// Without a cap the SDK default retries a failing quota check forever,
+	// parking its VO for the month. Kill on exhaustion and let the next daily
+	// tick retry; mirrors the billing-push and spend-check policies.
+	cronQuotaCheckRetry := restate.WithInvocationRetryPolicy(
+		restate.WithInitialInterval(100*time.Millisecond),
+		restate.WithExponentiationFactor(2.0),
+		restate.WithMaxInterval(5*time.Second),
+		restate.WithMaxAttempts(5),
+		restate.KillOnMaxAttempts(),
+	)
 	restateSrv.Bind(hydrav1.NewCronServiceServer(cronSvc).
 		ConfigureHandler("RunKeyLastUsedSync", cronKeyLastUsedRetry).
 		ConfigureHandler("RunRatelimitGlobalCountersCleanup", cronRatelimitGCCRetry).
 		ConfigureHandler("RunAuditLogOutboxCleanup", cronAuditLogCleanupRetry).
 		ConfigureHandler("RunAuditLogExport", restate.WithJournalRetention(1*time.Hour)).
+		ConfigureHandler("RunQuotaCheck", cronQuotaCheckRetry).
 		ConfigureHandler("RunDeployBillingClose", cronDeployBillingCloseRetry).
 		ConfigureHandler("CloseDeployBillingWorkspace", cronDeployBillingCloseRetry).
 		ConfigureHandler("RunDeployBillingPush", cronDeployBillingPushRetry).

--- a/svc/frontline/internal/db/models_generated.go
+++ b/svc/frontline/internal/db/models_generated.go
@@ -1488,17 +1488,18 @@ type Workspace struct {
 }
 
 type WorkspaceBilling struct {
-	Pk                   uint64         `db:"pk"`
-	WorkspaceID          string         `db:"workspace_id"`
-	Tier                 sql.NullString `db:"tier"`
-	StripeCustomerID     sql.NullString `db:"stripe_customer_id"`
-	StripeSubscriptionID sql.NullString `db:"stripe_subscription_id"`
-	Plan                 sql.NullString `db:"plan"`
-	PlanOverride         sql.NullString `db:"plan_override"`
-	SpendBudgetCents     sql.NullInt64  `db:"spend_budget_cents"`
-	SpendBudgetStop      bool           `db:"spend_budget_stop"`
-	SpendSuspended       bool           `db:"spend_suspended"`
-	CreatedAtM           int64          `db:"created_at_m"`
-	UpdatedAtM           sql.NullInt64  `db:"updated_at_m"`
-	DeletedAtM           sql.NullInt64  `db:"deleted_at_m"`
+	Pk                         uint64         `db:"pk"`
+	WorkspaceID                string         `db:"workspace_id"`
+	Tier                       sql.NullString `db:"tier"`
+	StripeCustomerID           sql.NullString `db:"stripe_customer_id"`
+	StripeSubscriptionID       sql.NullString `db:"stripe_subscription_id"`
+	StripeDeploySubscriptionID sql.NullString `db:"stripe_deploy_subscription_id"`
+	Plan                       sql.NullString `db:"plan"`
+	PlanOverride               sql.NullString `db:"plan_override"`
+	SpendBudgetCents           sql.NullInt64  `db:"spend_budget_cents"`
+	SpendBudgetStop            bool           `db:"spend_budget_stop"`
+	SpendSuspended             bool           `db:"spend_suspended"`
+	CreatedAtM                 int64          `db:"created_at_m"`
+	UpdatedAtM                 sql.NullInt64  `db:"updated_at_m"`
+	DeletedAtM                 sql.NullInt64  `db:"deleted_at_m"`
 }

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/stripe/checkout/page.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/stripe/checkout/page.tsx
@@ -173,7 +173,7 @@ export default async function StripeRedirect(props: {
         // which Checkout does not accept; "create_prorations" is the closest
         // Checkout-valid behavior and still collects the prorated partial period
         // on the first invoice at checkout.
-        billing_cycle_anchor_config: { day_of_month: 1 },
+        billing_cycle_anchor_config: { day_of_month: 1, hour: 0, minute: 0, second: 0 },
         billing_mode: { type: "classic" },
         proration_behavior: "create_prorations",
       },

--- a/web/apps/dashboard/lib/stripe/cancelDeploySubscription.test.ts
+++ b/web/apps/dashboard/lib/stripe/cancelDeploySubscription.test.ts
@@ -2,6 +2,7 @@ import type Stripe from "stripe";
 import { describe, expect, it, vi } from "vitest";
 import { cancelDeploySubscription } from "./cancelDeploySubscription";
 import type { DeployBillingConfig } from "./deployBilling";
+import { API_CANCEL_SCHEDULE_MARKER } from "./subscriptionUtils";
 
 const CONFIG: DeployBillingConfig = {
   planFeePriceIds: { starter: "price_starter", pro: "price_pro", business: "price_business" },
@@ -66,5 +67,48 @@ describe("cancelDeploySubscription", () => {
       items: [{ id: "si_fee", deleted: true }],
       proration_behavior: "none",
     });
+  });
+
+  it("releases a pending API-cancel schedule and cancels the whole subscription when both products are cancelled", async () => {
+    // Mixed subscription whose API plan is already being cancelled via a marked
+    // schedule. Cancelling Compute now must not edit items directly (the schedule
+    // would reinstate the plan fee at the boundary): release the schedule and end
+    // the whole subscription at period end.
+    const update = vi.fn().mockResolvedValue({});
+    const release = vi.fn().mockResolvedValue({});
+    const stripe = {
+      subscriptions: {
+        retrieve: vi.fn().mockResolvedValue({
+          id: "sub_1",
+          schedule: "sched_1",
+          items: {
+            data: [
+              item("si_api", "price_api"),
+              item("si_fee", "price_pro"),
+              item("si_cpu", "price_cpu"),
+            ],
+          },
+        }),
+        update,
+      },
+      subscriptionSchedules: {
+        retrieve: vi.fn().mockResolvedValue({
+          id: "sched_1",
+          status: "active",
+          metadata: { [API_CANCEL_SCHEDULE_MARKER]: "true" },
+        }),
+        release,
+      },
+    } as unknown as Stripe;
+
+    const result = await cancelDeploySubscription(stripe, "sub_1", CONFIG);
+    expect(result).toBe("mixed");
+    expect(release).toHaveBeenCalledWith("sched_1");
+    expect(update).toHaveBeenCalledWith("sub_1", { cancel_at_period_end: true });
+    // Must NOT fall through to the direct item-delete edit.
+    expect(update).not.toHaveBeenCalledWith(
+      "sub_1",
+      expect.objectContaining({ proration_behavior: "none" }),
+    );
   });
 });

--- a/web/apps/dashboard/lib/stripe/cancelDeploySubscription.ts
+++ b/web/apps/dashboard/lib/stripe/cancelDeploySubscription.ts
@@ -1,5 +1,6 @@
 import type Stripe from "stripe";
 import type { DeployBillingConfig } from "./deployBilling";
+import { getApiCancelSchedule, isPendingSchedule } from "./subscriptionUtils";
 
 /** The subscription shape a cancel encountered, for logging and tests. */
 export type DeployCancelTopology = "none" | "deploy_only" | "mixed";
@@ -38,6 +39,23 @@ export async function cancelDeploySubscription(
   if (deployItems === sub.items.data.length) {
     await stripe.subscriptions.update(subscriptionId, { cancel_at_period_end: true });
     return "deploy_only";
+  }
+
+  // Mixed subscription. A pending API-cancel schedule (created by
+  // cancelSubscription) already ends the API plan at period end, and its phase 2
+  // snapshots the CURRENT items including the Compute plan fee. Editing items
+  // directly here would either be rejected (Stripe forbids item-level edits on a
+  // scheduled subscription) or silently undone when phase 2 reinstates the plan
+  // fee at the boundary, re-billing Compute and re-entitling a workspace whose
+  // compute was already torn down. Since the API plan is already cancelling and
+  // the user is now cancelling Compute, both products are gone: release the
+  // schedule and cancel the whole subscription at period end. Metered usage bills
+  // to the boundary then stops; neither plan fee renews.
+  const apiCancelSchedule = await getApiCancelSchedule(stripe, sub);
+  if (apiCancelSchedule && isPendingSchedule(apiCancelSchedule)) {
+    await stripe.subscriptionSchedules.release(apiCancelSchedule.id);
+    await stripe.subscriptions.update(subscriptionId, { cancel_at_period_end: true });
+    return "mixed";
   }
 
   await stripe.subscriptions.update(subscriptionId, {

--- a/web/apps/dashboard/lib/trpc/context.ts
+++ b/web/apps/dashboard/lib/trpc/context.ts
@@ -58,6 +58,7 @@ export async function createContext({ req }: FetchCreateContextFnOptions) {
           tier: ws.billing?.tier ?? "Free",
           stripeCustomerId: ws.billing?.stripeCustomerId ?? null,
           stripeSubscriptionId: ws.billing?.stripeSubscriptionId ?? null,
+          stripeDeploySubscriptionId: ws.billing?.stripeDeploySubscriptionId ?? null,
           deployPlan: ws.billing?.plan ?? null,
           deployPlanOverride: ws.billing?.planOverride ?? null,
           deploySpendBudgetCents: ws.billing?.spendBudgetCents ?? null,

--- a/web/apps/dashboard/lib/trpc/routers/stripe/cancelSubscription.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/cancelSubscription.ts
@@ -1,5 +1,5 @@
 import { getStripeClient } from "@/lib/stripe";
-import { deployBillingConfig, findDeployItems } from "@/lib/stripe/deployBilling";
+import { deployBillingConfig, findDeployItems, findPlanFeeItem } from "@/lib/stripe/deployBilling";
 import { createApiCancelSchedule, getApiCancelSchedule } from "@/lib/stripe/subscriptionUtils";
 import { TRPCError } from "@trpc/server";
 import { requireWorkspaceAdmin, workspaceProcedure } from "../../trpc";
@@ -79,6 +79,22 @@ export const cancelSubscription = workspaceProcedure
         message:
           "This subscription is managed by a billing schedule. Contact support@unkey.com to cancel.",
       });
+    }
+
+    // The Deploy items still on a mixed subscription are usually the plan fee
+    // plus its metered prices. If the plan fee is already gone (Compute was
+    // cancelled earlier this period, which drops the fee and keeps only the
+    // metered items), there is no live Compute to carry past the boundary: a
+    // Compute-only phase would just renew empty metered items forever as a $0
+    // zombie subscription. Both products are effectively cancelled, so cancel the
+    // whole subscription at period end instead. No schedule exists here (the
+    // sub.schedule branch above returned), so cancel_at_period_end is safe.
+    const planFeeItem = findPlanFeeItem(config, sub.items.data);
+    if (!planFeeItem) {
+      await stripe.subscriptions.update(ctx.workspace.stripeSubscriptionId, {
+        cancel_at_period_end: true,
+      });
+      return;
     }
 
     const deployItemIds = new Set(deployItems.map((item) => item.id));

--- a/web/apps/dashboard/lib/trpc/routers/stripe/changeDeployPlan.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/changeDeployPlan.ts
@@ -70,6 +70,20 @@ export const changeDeployPlan = workspaceProcedure
       return;
     }
 
+    // The whole subscription is set to cancel at period end (a Deploy-only or
+    // both-products cancel). Repricing the fee would charge an upgrade proration
+    // for a plan that ends this period anyway, or repoint a plan that is on its
+    // way out. Refuse rather than take money for a plan that will not renew; the
+    // user should resume before changing tiers. (Note: a mixed API cancel is a
+    // schedule, handled below, not cancel_at_period_end.)
+    if (sub.cancel_at_period_end) {
+      throw new TRPCError({
+        code: "PRECONDITION_FAILED",
+        message:
+          "Your Compute plan is set to cancel at the end of this period. Resume it before changing plans.",
+      });
+    }
+
     // A pending API-plan cancellation is a schedule whose next phase snapshots
     // the CURRENT Compute items — left in place, it would revert the plan
     // change at the period boundary. Release it, apply the change, then

--- a/web/apps/dashboard/lib/trpc/routers/stripe/createSubscription.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/createSubscription.ts
@@ -8,6 +8,7 @@ import {
   findApiItem,
 } from "@/lib/stripe/deployBilling";
 import { validateAndParseQuotas } from "@/lib/stripe/productUtils";
+import { isDeadSubscription } from "@/lib/stripe/subscriptionUtils";
 import { TRPCError } from "@trpc/server";
 import Stripe from "stripe";
 import { z } from "zod";
@@ -90,29 +91,48 @@ export const createSubscription = workspaceProcedure
     // already carries an API plan item is refused.
     let existingSub: Stripe.Subscription | undefined;
     if (ctx.workspace.stripeSubscriptionId) {
-      existingSub = await stripe.subscriptions.retrieve(ctx.workspace.stripeSubscriptionId);
-      // Fail closed when Deploy is configured but unresolved: findApiItem(null)
-      // falls back to items[0], which on a Compute-first subscription is a
-      // Deploy item, so the check below would wrongly report "already has an API
-      // plan". Unconfigured (no Deploy) still uses the items[0] fallback safely.
-      const deployConfig = await deployBillingConfig();
-      if (!deployConfig && deployBillingConfigured()) {
-        throw new TRPCError({
-          code: "INTERNAL_SERVER_ERROR",
-          message: "Billing is temporarily unavailable. Please try again in a moment.",
+      // The recorded subscription can be a corpse (cancelDeploy cancels a
+      // Compute-only subscription outright, and the deleted-webhook that clears
+      // the column may lag or be missed) or already gone from Stripe. A dead one
+      // still carries its old items, so without treating it as absent a
+      // workspace whose API subscription ended gets a permanent "already has an
+      // API plan" error and can never resubscribe without support. resource_missing
+      // is the same "dead recorded subscription counts as absent" case, not a 500;
+      // anything else propagates so a transient failure never silently downgrades
+      // a live subscription to "absent".
+      const recorded = await stripe.subscriptions
+        .retrieve(ctx.workspace.stripeSubscriptionId)
+        .catch((err: unknown) => {
+          if (err instanceof Stripe.errors.StripeError && err.code === "resource_missing") {
+            return null;
+          }
+          throw err;
         });
+      if (recorded && !isDeadSubscription(recorded)) {
+        existingSub = recorded;
+        // Fail closed when Deploy is configured but unresolved: findApiItem(null)
+        // falls back to items[0], which on a Compute-first subscription is a
+        // Deploy item, so the check below would wrongly report "already has an API
+        // plan". Unconfigured (no Deploy) still uses the items[0] fallback safely.
+        const deployConfig = await deployBillingConfig();
+        if (!deployConfig && deployBillingConfigured()) {
+          throw new TRPCError({
+            code: "INTERNAL_SERVER_ERROR",
+            message: "Billing is temporarily unavailable. Please try again in a moment.",
+          });
+        }
+        if (findApiItem(deployConfig, existingSub.items.data)) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message: `Customer ${ctx.workspace.stripeCustomerId} already has an API plan.`,
+          });
+        }
+        // Same guards subscribeDeploy applies to its append path: don't attach
+        // the API item to a subscription that is delinquent, scheduled to cancel,
+        // or non-USD. cancel_at_period_end especially is accepted silently by
+        // Stripe, so the item would never bill next cycle.
+        assertSubscriptionAttachable(existingSub);
       }
-      if (findApiItem(deployConfig, existingSub.items.data)) {
-        throw new TRPCError({
-          code: "PRECONDITION_FAILED",
-          message: `Customer ${ctx.workspace.stripeCustomerId} already has an API plan.`,
-        });
-      }
-      // Same guards subscribeDeploy applies to its append path: don't attach
-      // the API item to a subscription that is delinquent, scheduled to cancel,
-      // or non-USD. cancel_at_period_end especially is accepted silently by
-      // Stripe, so the item would never bill next cycle.
-      assertSubscriptionAttachable(existingSub);
     }
 
     const customer = await stripe.customers.retrieve(ctx.workspace.stripeCustomerId);
@@ -123,6 +143,33 @@ export const createSubscription = workspaceProcedure
       });
     }
 
+    // Create path only (the append path reuses the existing subscription's
+    // default): resolve an explicit default payment method. subscriptions.create
+    // only consults the customer's DEFAULT payment method, and a card that
+    // arrived via subscription-mode Checkout is attached but recorded as the
+    // (now possibly cancelled) subscription's default, not the customer's — so a
+    // cancel-then-resubscribe would die with "no attached payment source" while
+    // the user sees a card on file. Use the customer default when set, else the
+    // most recently attached method.
+    let defaultPaymentMethod: string | undefined;
+    if (!existingSub) {
+      const hasCustomerDefault =
+        !customer.deleted &&
+        Boolean(customer.invoice_settings?.default_payment_method || customer.default_source);
+      if (!hasCustomerDefault) {
+        const attached = await stripe.customers.listPaymentMethods(ctx.workspace.stripeCustomerId, {
+          limit: 1,
+        });
+        defaultPaymentMethod = attached.data[0]?.id;
+        if (!defaultPaymentMethod) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "No payment method on file. Add one to subscribe.",
+          });
+        }
+      }
+    }
+
     /**
      * `error_if_incomplete` makes Stripe reject the call with a 402 if the first
      * invoice cannot be paid (e.g. card declined). We rely on this to keep the workspace
@@ -131,37 +178,66 @@ export const createSubscription = workspaceProcedure
      */
     let sub: Stripe.Subscription;
     try {
-      sub = existingSub
-        ? await stripe.subscriptions.update(existingSub.id, {
-            items: [
-              {
-                price: product.default_price.toString(),
-              },
-            ],
-            proration_behavior: "always_invoice",
-            payment_behavior: "error_if_incomplete",
-          })
-        : await stripe.subscriptions.create({
-            customer: customer.id,
-            items: [
-              {
-                price: product.default_price.toString(),
-              },
-            ],
-            // Anchor at midnight UTC on the 1st, not just the 1st: the month-end
-            // closing flow and the "last"-formula meters require billing periods
-            // to be exact calendar months. Without the time fields the anchor
-            // keeps the creation time-of-day, and the renewal invoice's usage
-            // window would swallow the next month's early meter events.
-            billing_cycle_anchor_config: { day_of_month: 1, hour: 0, minute: 0, second: 0 },
-            // Stripe API 2025-09-30 (clover) and later default new
-            // subscriptions to the "flexible" billing mode, which itemizes
-            // prorations differently and would change the Deploy
-            // credit-grant net-fee math. Stay on classic.
-            billing_mode: { type: "classic" },
-            proration_behavior: "always_invoice",
-            payment_behavior: "error_if_incomplete",
-          });
+      if (existingSub) {
+        sub = await stripe.subscriptions.update(existingSub.id, {
+          items: [
+            {
+              price: product.default_price.toString(),
+            },
+          ],
+          proration_behavior: "always_invoice",
+          payment_behavior: "error_if_incomplete",
+        });
+      } else {
+        const createParams: Stripe.SubscriptionCreateParams = {
+          customer: customer.id,
+          items: [
+            {
+              price: product.default_price.toString(),
+            },
+          ],
+          ...(defaultPaymentMethod ? { default_payment_method: defaultPaymentMethod } : {}),
+          // Anchor at midnight UTC on the 1st, not just the 1st: the month-end
+          // closing flow and the "last"-formula meters require billing periods
+          // to be exact calendar months. Without the time fields the anchor
+          // keeps the creation time-of-day, and the renewal invoice's usage
+          // window would swallow the next month's early meter events.
+          billing_cycle_anchor_config: { day_of_month: 1, hour: 0, minute: 0, second: 0 },
+          // Stripe API 2025-09-30 (clover) and later default new
+          // subscriptions to the "flexible" billing mode, which itemizes
+          // prorations differently and would change the Deploy
+          // credit-grant net-fee math. Stay on classic.
+          billing_mode: { type: "classic" },
+          proration_behavior: "always_invoice",
+          payment_behavior: "error_if_incomplete",
+        };
+
+        // Deterministic idempotency key: if Stripe created (and charged) the
+        // subscription but the workspace write below failed, or two admins click
+        // concurrently, a retry replays the SAME subscription instead of charging
+        // a second one. There is no webhook backstop for this create —
+        // customer.subscription.created resolves the workspace by
+        // stripeSubscriptionId, which is only written after this succeeds. Keyed
+        // by product so a genuine switch to a different plan is not blocked.
+        //
+        // Stripe's idempotency layer replays the CREATION-TIME response, so after
+        // a full subscribe→cancel cycle inside the key window a replay hands back
+        // the canceled subscription still claiming to be active. Re-retrieve the
+        // live status and, on a corpse, chain a fresh key off its id and mint a
+        // new subscription (a retry of THIS request replays that same fresh
+        // subscription) — mirroring subscribeDeploy and stripe/checkout/page.tsx.
+        let idempotencyKey = `api-subscribe:${ctx.workspace.id}:${input.productId}`;
+        sub = await stripe.subscriptions.create(createParams, { idempotencyKey });
+        for (let attempt = 0; attempt < 3; attempt++) {
+          const live = await stripe.subscriptions.retrieve(sub.id);
+          if (!isDeadSubscription(live)) {
+            sub = live;
+            break;
+          }
+          idempotencyKey = `${idempotencyKey}:${live.id}`;
+          sub = await stripe.subscriptions.create(createParams, { idempotencyKey });
+        }
+      }
     } catch (err) {
       if (err instanceof Stripe.errors.StripeCardError) {
         throw new TRPCError({

--- a/web/apps/dashboard/lib/trpc/routers/stripe/subscribeDeploy.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/subscribeDeploy.ts
@@ -1,5 +1,5 @@
 import { insertAuditLogs } from "@/lib/audit";
-import { db, eq, schema } from "@/lib/db";
+import { and, db, eq, isNull, schema } from "@/lib/db";
 import { getStripeClient } from "@/lib/stripe";
 import {
   deployBillingConfig,
@@ -58,196 +58,276 @@ export const subscribeDeploy = workspaceProcedure
     const stripe = getStripeClient();
     const items = deploySubscriptionItems(config, input.plan);
 
-    // Columns to write once the Stripe mutation below succeeds, set in whichever
-    // branch runs. Written optimistically so the UI reflects the new plan now;
-    // the customer.subscription.* webhook reconciles them (a no-op, since it
-    // derives the same value from the subscription we just mutated).
-    let workspaceUpdate: { plan: string; stripeSubscriptionId?: string };
-
-    // The recorded subscription can be a corpse (cancelDeploy cancels a
-    // Compute-only subscription outright, and the deleted-webhook that clears
-    // the column may not have landed yet). A dead one still carries its old
-    // Compute items, so without this check a mid-month resubscribe dies on the
-    // "already has Compute items" guard below. Treat it as absent and create a
-    // fresh subscription instead.
-    let existingSub: Stripe.Subscription | null = null;
-    if (ctx.workspace.stripeSubscriptionId) {
-      const recorded = await stripe.subscriptions.retrieve(ctx.workspace.stripeSubscriptionId);
-      if (!isDeadSubscription(recorded)) {
-        existingSub = recorded;
-      }
+    // Claim the Compute plan slot before touching Stripe. Two admins racing with
+    // different plans both pass the deployPlan guard above (it reads a possibly
+    // stale request snapshot) and Stripe only rejects duplicate SAME-price items,
+    // so without this both plan-fee items would attach and both bill. The
+    // compare-and-set on plan IS NULL serializes them: exactly one write matches a
+    // row, the loser gets zero and bails before any Stripe charge. This also
+    // writes the plan optimistically (the transaction below re-commits the same
+    // value), so the UI reflects it immediately.
+    const claim = await db
+      .update(schema.workspaceBilling)
+      .set({ plan: input.plan })
+      .where(
+        and(
+          eq(schema.workspaceBilling.workspaceId, ctx.workspace.id),
+          isNull(schema.workspaceBilling.plan),
+        ),
+      );
+    if (claim[0].affectedRows !== 1) {
+      throw new TRPCError({
+        code: "PRECONDITION_FAILED",
+        message: "Workspace already has a Compute plan. Use change instead.",
+      });
     }
 
-    if (existingSub) {
-      // Existing subscription (e.g. a paid API plan): append the Deploy items.
-      // Items not listed here are left untouched, so API items are preserved.
-      const sub = existingSub;
+    // Release the claim if anything below fails, so a genuine retry can proceed.
+    // Conditioned on the plan we set, so a webhook that reconciled a different
+    // value in the meantime is never clobbered. Best-effort: on the create path a
+    // charged-but-unrecorded subscription is recovered by the workspace-scoped
+    // idempotency key on retry, and the customer.subscription.* webhook reconciles
+    // the plan regardless.
+    const releaseClaim = async () => {
+      await db
+        .update(schema.workspaceBilling)
+        .set({ plan: null })
+        .where(
+          and(
+            eq(schema.workspaceBilling.workspaceId, ctx.workspace.id),
+            eq(schema.workspaceBilling.plan, input.plan),
+          ),
+        );
+    };
 
-      const planFeeItem = findPlanFeeItem(config, sub.items.data);
+    try {
+      // Columns to write once the Stripe mutation below succeeds, set in whichever
+      // branch runs. Written optimistically so the UI reflects the new plan now;
+      // the customer.subscription.* webhook reconciles them (a no-op, since it
+      // derives the same value from the subscription we just mutated).
+      let workspaceUpdate: { plan: string; stripeSubscriptionId?: string };
 
-      // A plan-fee item on a subscription that is NOT cancelling means the
-      // workspace is actually subscribed; the deployPlan guard above should have
-      // caught it, so it is a state mismatch, not something to double-attach
-      // onto. A plan-fee item on a subscription set to cancel at period end is
-      // the leftover of a Deploy-only cancel this period, which re-subscribing
-      // resumes rather than rejecting.
-      if (planFeeItem && !sub.cancel_at_period_end) {
-        throw new TRPCError({
-          code: "PRECONDITION_FAILED",
-          message: "Workspace already has a Compute plan fee on its subscription.",
-        });
+      // The recorded subscription can be a corpse (cancelDeploy cancels a
+      // Compute-only subscription outright, and the deleted-webhook that clears
+      // the column may not have landed yet). A dead one still carries its old
+      // Compute items, so without this check a mid-month resubscribe dies on the
+      // "already has Compute items" guard below. Treat it as absent and create a
+      // fresh subscription instead.
+      let existingSub: Stripe.Subscription | null = null;
+      if (ctx.workspace.stripeSubscriptionId) {
+        const recorded = await stripe.subscriptions.retrieve(ctx.workspace.stripeSubscriptionId);
+        if (!isDeadSubscription(recorded)) {
+          existingSub = recorded;
+        }
       }
 
-      // Build the item set to attach without stranding a workspace whose cancel
-      // left items behind. A Deploy-only cancel sets cancel_at_period_end and
-      // keeps every item, so point the existing plan-fee item at the chosen
-      // tier. A mixed cancel drops the plan fee but keeps the metered items, so
-      // add the plan fee back. Either way, only add metered prices not already
-      // present so they are never duplicated.
-      const existingPriceIds = new Set(
-        findDeployItems(config, sub.items.data).map((item) => item.priceId),
-      );
-      const itemsToAttach: Stripe.SubscriptionUpdateParams.Item[] = [
-        planFeeItem
-          ? { id: planFeeItem.id, price: config.planFeePriceIds[input.plan] }
-          : { price: config.planFeePriceIds[input.plan] },
-        ...config.meteredPriceIds
-          .filter((price) => !existingPriceIds.has(price))
-          .map((price) => ({ price })),
-      ];
+      if (existingSub) {
+        // Existing subscription (e.g. a paid API plan): append the Deploy items.
+        // Items not listed here are left untouched, so API items are preserved.
+        const sub = existingSub;
 
-      // Resuming a subscription that was cancelling this period just clears the
-      // pending cancellation. A fresh attach onto another subscription (e.g. a
-      // paid API plan) must first be attachable, so we don't attach Deploy items
-      // to something that ends at the period roll.
-      const resuming = sub.cancel_at_period_end;
-      if (!resuming) {
-        assertSubscriptionAttachable(sub);
-      }
+        const planFeeItem = findPlanFeeItem(config, sub.items.data);
 
-      try {
-        await stripe.subscriptions.update(sub.id, {
-          cancel_at_period_end: false,
-          items: itemsToAttach,
-          // Resuming keeps the plan fee already paid this period (cancel never
-          // refunded it), so it must not invoice again; a fresh attach bills it.
-          proration_behavior: resuming ? "none" : "always_invoice",
-          payment_behavior: "error_if_incomplete",
-        });
-      } catch (err) {
-        throw toBillingError(err);
-      }
-
-      workspaceUpdate = { plan: input.plan };
-    } else {
-      // Free tier: create a subscription whose initial items are the Deploy set.
-      // error_if_incomplete keeps us off a half-paid state if the card declines.
-      //
-      // subscriptions.create only consults the customer's DEFAULT payment
-      // method, and a card that arrived via subscription-mode Checkout is
-      // attached but recorded as the (now possibly cancelled) subscription's
-      // default, not the customer's — so a cancel-then-resubscribe would die
-      // with "no attached payment source". Resolve one explicitly: use the
-      // customer default when set, else the most recently attached method.
-      let defaultPaymentMethod: string | undefined;
-      const customer = await stripe.customers.retrieve(ctx.workspace.stripeCustomerId);
-      const hasCustomerDefault =
-        !customer.deleted &&
-        Boolean(customer.invoice_settings?.default_payment_method || customer.default_source);
-      if (!hasCustomerDefault) {
-        const attached = await stripe.customers.listPaymentMethods(ctx.workspace.stripeCustomerId, {
-          limit: 1,
-        });
-        defaultPaymentMethod = attached.data[0]?.id;
-        if (!defaultPaymentMethod) {
-          // BAD_REQUEST on purpose: the projects-landing subscriber treats it
-          // as "card problem" and routes the user to Stripe checkout to add one.
+        // A plan-fee item on a subscription that is NOT cancelling means the
+        // workspace is actually subscribed; the deployPlan guard above should have
+        // caught it, so it is a state mismatch, not something to double-attach
+        // onto. A plan-fee item on a subscription set to cancel at period end is
+        // the leftover of a Deploy-only cancel this period, which re-subscribing
+        // resumes rather than rejecting.
+        if (planFeeItem && !sub.cancel_at_period_end) {
           throw new TRPCError({
-            code: "BAD_REQUEST",
-            message: "No payment method on file. Add one to subscribe.",
+            code: "PRECONDITION_FAILED",
+            message: "Workspace already has a Compute plan fee on its subscription.",
           });
         }
-      }
 
-      const createParams: Stripe.SubscriptionCreateParams = {
-        customer: ctx.workspace.stripeCustomerId,
-        items,
-        ...(defaultPaymentMethod ? { default_payment_method: defaultPaymentMethod } : {}),
-        billing_cycle_anchor_config: { day_of_month: 1 },
-        // Pin classic billing mode (clover defaults new subscriptions to
-        // "flexible", which itemizes prorations differently); see the same
-        // pin in createSubscription.
-        billing_mode: { type: "classic" },
-        proration_behavior: "always_invoice",
-        payment_behavior: "error_if_incomplete",
-      };
-
-      let sub: Stripe.Subscription;
-      try {
-        // Deterministic idempotency key: if Stripe created (and charged) the
-        // subscription but the workspace write below failed, a retry replays
-        // the SAME subscription instead of charging a second one. Unlike the
-        // checkout-session path there is no webhook backstop for this create —
-        // customer.subscription.created resolves the workspace by
-        // stripeSubscriptionId, which was never written.
-        //
-        // Stripe's idempotency layer replays the CREATION-TIME response, so
-        // after a full subscribe→cancel cycle inside the key window a replay
-        // hands back the canceled subscription still claiming to be active.
-        // Re-retrieve the live status and, on a corpse, chain a fresh key off
-        // its id and mint a new subscription (a retry of THIS request replays
-        // that same fresh subscription) — mirroring stripe/checkout/page.tsx.
-        let idempotencyKey = `deploy-subscribe:${ctx.workspace.id}:${input.plan}`;
-        sub = await stripe.subscriptions.create(createParams, { idempotencyKey });
-        for (let attempt = 0; attempt < 3; attempt++) {
-          const live = await stripe.subscriptions.retrieve(sub.id);
-          if (!isDeadSubscription(live)) {
-            sub = live;
-            break;
-          }
-          idempotencyKey = `${idempotencyKey}:${live.id}`;
-          sub = await stripe.subscriptions.create(createParams, { idempotencyKey });
+        // A genuine resume keeps the plan fee already paid this period, so it must
+        // not re-invoice (proration "none" below). That only holds when the
+        // resumed tier is the SAME one that was cancelled: repointing the fee at a
+        // different tier under "none" would grant the new tier for the old tier's
+        // payment, dodging the upgrade proration changeDeployPlan charges. Route a
+        // tier change through changeDeployPlan (resume first, then switch) so the
+        // proration and credit-grant rules apply exactly once, in one place.
+        if (planFeeItem && sub.cancel_at_period_end && planFeeItem.plan !== input.plan) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message: `Your cancelled Compute plan is ${planFeeItem.plan}. Resume it by subscribing to ${planFeeItem.plan} again, then switch to ${input.plan}.`,
+          });
         }
-      } catch (err) {
-        throw toBillingError(err);
-      }
 
-      if (sub.status !== "active" && sub.status !== "trialing") {
+        // Build the item set to attach without stranding a workspace whose cancel
+        // left items behind. A Deploy-only cancel sets cancel_at_period_end and
+        // keeps every item, so point the existing plan-fee item at the chosen
+        // tier. A mixed cancel drops the plan fee but keeps the metered items, so
+        // add the plan fee back. Either way, only add metered prices not already
+        // present so they are never duplicated.
+        const existingPriceIds = new Set(
+          findDeployItems(config, sub.items.data).map((item) => item.priceId),
+        );
+        const itemsToAttach: Stripe.SubscriptionUpdateParams.Item[] = [
+          planFeeItem
+            ? { id: planFeeItem.id, price: config.planFeePriceIds[input.plan] }
+            : { price: config.planFeePriceIds[input.plan] },
+          ...config.meteredPriceIds
+            .filter((price) => !existingPriceIds.has(price))
+            .map((price) => ({ price })),
+        ];
+
+        // Resuming a subscription that was cancelling this period just clears the
+        // pending cancellation. It requires a leftover Compute plan-fee item:
+        // without one (e.g. a cancelling API-only subscription) there is nothing
+        // Compute to resume, so falling through to assertSubscriptionAttachable
+        // rejects the cancelling subscription and tells the user to resume it
+        // first, instead of un-cancelling an API plan they killed and attaching
+        // Compute uninvoiced. A fresh attach onto another subscription must first
+        // be attachable, so we don't attach Deploy items to something that ends at
+        // the period roll.
+        const resuming = sub.cancel_at_period_end && planFeeItem !== undefined;
+        if (!resuming) {
+          assertSubscriptionAttachable(sub);
+        }
+
         try {
-          await stripe.subscriptions.cancel(sub.id);
-        } catch (cancelErr) {
-          console.error(
-            `Failed to cancel non-active subscription ${sub.id} after creation:`,
-            cancelErr,
-          );
+          await stripe.subscriptions.update(sub.id, {
+            cancel_at_period_end: false,
+            items: itemsToAttach,
+            // Resuming keeps the plan fee already paid this period (cancel never
+            // refunded it), so it must not invoice again; a fresh attach bills it.
+            proration_behavior: resuming ? "none" : "always_invoice",
+            payment_behavior: "error_if_incomplete",
+          });
+        } catch (err) {
+          throw toBillingError(err);
         }
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: `Subscription was created but is not active (ID: ${sub.id}). Please contact support.`,
-        });
+
+        workspaceUpdate = { plan: input.plan };
+      } else {
+        // Free tier: create a subscription whose initial items are the Deploy set.
+        // error_if_incomplete keeps us off a half-paid state if the card declines.
+        //
+        // subscriptions.create only consults the customer's DEFAULT payment
+        // method, and a card that arrived via subscription-mode Checkout is
+        // attached but recorded as the (now possibly cancelled) subscription's
+        // default, not the customer's — so a cancel-then-resubscribe would die
+        // with "no attached payment source". Resolve one explicitly: use the
+        // customer default when set, else the most recently attached method.
+        let defaultPaymentMethod: string | undefined;
+        const customer = await stripe.customers.retrieve(ctx.workspace.stripeCustomerId);
+        const hasCustomerDefault =
+          !customer.deleted &&
+          Boolean(customer.invoice_settings?.default_payment_method || customer.default_source);
+        if (!hasCustomerDefault) {
+          const attached = await stripe.customers.listPaymentMethods(
+            ctx.workspace.stripeCustomerId,
+            {
+              limit: 1,
+            },
+          );
+          defaultPaymentMethod = attached.data[0]?.id;
+          if (!defaultPaymentMethod) {
+            // BAD_REQUEST on purpose: the projects-landing subscriber treats it
+            // as "card problem" and routes the user to Stripe checkout to add one.
+            throw new TRPCError({
+              code: "BAD_REQUEST",
+              message: "No payment method on file. Add one to subscribe.",
+            });
+          }
+        }
+
+        const createParams: Stripe.SubscriptionCreateParams = {
+          customer: ctx.workspace.stripeCustomerId,
+          items,
+          ...(defaultPaymentMethod ? { default_payment_method: defaultPaymentMethod } : {}),
+          billing_cycle_anchor_config: { day_of_month: 1, hour: 0, minute: 0, second: 0 },
+          // Pin classic billing mode (clover defaults new subscriptions to
+          // "flexible", which itemizes prorations differently); see the same
+          // pin in createSubscription.
+          billing_mode: { type: "classic" },
+          proration_behavior: "always_invoice",
+          payment_behavior: "error_if_incomplete",
+        };
+
+        let sub: Stripe.Subscription;
+        try {
+          // Deterministic idempotency key: if Stripe created (and charged) the
+          // subscription but the workspace write below failed, a retry replays
+          // the SAME subscription instead of charging a second one. Unlike the
+          // checkout-session path there is no webhook backstop for this create —
+          // customer.subscription.created resolves the workspace by
+          // stripeSubscriptionId, which was never written.
+          //
+          // The key is scoped to the workspace, NOT the plan: a retry that picks
+          // a different plan (or two admins racing on different plans, though the
+          // compare-and-set above already blocks that) must still replay the one
+          // subscription rather than mint a second charged one. The first subscribe
+          // wins the plan; a later tier change goes through changeDeployPlan.
+          //
+          // Stripe's idempotency layer replays the CREATION-TIME response, so
+          // after a full subscribe→cancel cycle inside the key window a replay
+          // hands back the canceled subscription still claiming to be active.
+          // Re-retrieve the live status and, on a corpse, chain a fresh key off
+          // its id and mint a new subscription (a retry of THIS request replays
+          // that same fresh subscription) — mirroring stripe/checkout/page.tsx.
+          let idempotencyKey = `deploy-subscribe:${ctx.workspace.id}`;
+          sub = await stripe.subscriptions.create(createParams, { idempotencyKey });
+          for (let attempt = 0; attempt < 3; attempt++) {
+            const live = await stripe.subscriptions.retrieve(sub.id);
+            if (!isDeadSubscription(live)) {
+              sub = live;
+              break;
+            }
+            idempotencyKey = `${idempotencyKey}:${live.id}`;
+            sub = await stripe.subscriptions.create(createParams, { idempotencyKey });
+          }
+        } catch (err) {
+          throw toBillingError(err);
+        }
+
+        if (sub.status !== "active" && sub.status !== "trialing") {
+          try {
+            await stripe.subscriptions.cancel(sub.id);
+          } catch (cancelErr) {
+            console.error(
+              `Failed to cancel non-active subscription ${sub.id} after creation:`,
+              cancelErr,
+            );
+          }
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: `Subscription was created but is not active (ID: ${sub.id}). Please contact support.`,
+          });
+        }
+
+        // Link the new subscription so the customer.subscription.* webhook can
+        // resolve this workspace.
+        workspaceUpdate = { stripeSubscriptionId: sub.id, plan: input.plan };
       }
 
-      // Link the new subscription so the customer.subscription.* webhook can
-      // resolve this workspace.
-      workspaceUpdate = { stripeSubscriptionId: sub.id, plan: input.plan };
-    }
-
-    // One transaction so the plan write and its audit log commit together; a
-    // failure in either rolls back the other.
-    await db.transaction(async (tx) => {
-      await tx
-        .update(schema.workspaceBilling)
-        .set(workspaceUpdate)
-        .where(eq(schema.workspaceBilling.workspaceId, ctx.workspace.id));
-      await insertAuditLogs(tx, {
-        workspaceId: ctx.workspace.id,
-        actor: { type: "user", id: ctx.user.id },
-        event: "workspace.update",
-        description: `Subscribed to Compute ${input.plan} plan.`,
-        resources: [],
-        context: { location: ctx.audit.location, userAgent: ctx.audit.userAgent },
+      // One transaction so the plan write and its audit log commit together; a
+      // failure in either rolls back the other.
+      await db.transaction(async (tx) => {
+        await tx
+          .update(schema.workspaceBilling)
+          .set(workspaceUpdate)
+          .where(eq(schema.workspaceBilling.workspaceId, ctx.workspace.id));
+        await insertAuditLogs(tx, {
+          workspaceId: ctx.workspace.id,
+          actor: { type: "user", id: ctx.user.id },
+          event: "workspace.update",
+          description: `Subscribed to Compute ${input.plan} plan.`,
+          resources: [],
+          context: { location: ctx.audit.location, userAgent: ctx.audit.userAgent },
+        });
       });
-    });
+    } catch (err) {
+      await releaseClaim().catch((releaseErr) => {
+        console.error("Failed to release Compute plan claim after subscribe error", {
+          workspaceId: ctx.workspace.id,
+          error: releaseErr instanceof Error ? releaseErr.message : releaseErr,
+        });
+      });
+      throw err;
+    }
   });
 
 /**

--- a/web/apps/dashboard/lib/trpc/routers/stripe/subscribeDeploy.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/subscribeDeploy.ts
@@ -173,7 +173,7 @@ export const subscribeDeploy = workspaceProcedure
         customer: ctx.workspace.stripeCustomerId,
         items,
         ...(defaultPaymentMethod ? { default_payment_method: defaultPaymentMethod } : {}),
-        billing_cycle_anchor_config: { day_of_month: 1 },
+        billing_cycle_anchor_config: { day_of_month: 1, hour: 0, minute: 0, second: 0 },
         // Pin classic billing mode (clover defaults new subscriptions to
         // "flexible", which itemizes prorations differently); see the same
         // pin in createSubscription.

--- a/web/apps/dashboard/lib/trpc/routers/stripe/updateSubscription.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/updateSubscription.ts
@@ -8,6 +8,7 @@ import {
   findApiItem,
 } from "@/lib/stripe/deployBilling";
 import { validateAndParseQuotas } from "@/lib/stripe/productUtils";
+import { getApiCancelSchedule, isPendingSchedule } from "@/lib/stripe/subscriptionUtils";
 import { TRPCError } from "@trpc/server";
 import Stripe from "stripe";
 import { z } from "zod";
@@ -86,6 +87,24 @@ export const updateSubscription = workspaceProcedure
       throw new TRPCError({
         code: "NOT_FOUND",
         message: `Could not find subscription ${ctx.workspace.stripeSubscriptionId}.`,
+      });
+    }
+
+    // A mixed-subscription API cancel is a schedule whose next phase snapshots the
+    // CURRENT items (see cancelSubscription), not a cancel_at_period_end. Repricing
+    // the API item under it is rejected (Stripe forbids item-level edits on a
+    // scheduled subscription) or reverted at the boundary, and the cancel_at
+    // un-cancel below never fires because schedule cancels leave cancel_at unset,
+    // so the pending cancellation survives an apparent plan switch. Refuse rather
+    // than silently release the schedule (that would resume an API plan the user
+    // explicitly scheduled to cancel as a side effect of a plan change). The
+    // resume action releases the schedule cleanly first.
+    const apiCancelSchedule = await getApiCancelSchedule(stripe, sub);
+    if (apiCancelSchedule && isPendingSchedule(apiCancelSchedule)) {
+      throw new TRPCError({
+        code: "PRECONDITION_FAILED",
+        message:
+          "Your plan is scheduled to cancel at the end of this period. Resume it before switching plans.",
       });
     }
 

--- a/web/apps/dashboard/lib/trpc/routers/workspace/getCurrent.ts
+++ b/web/apps/dashboard/lib/trpc/routers/workspace/getCurrent.ts
@@ -56,6 +56,7 @@ export const getCurrentWorkspace = protectedProcedure.query(async ({ ctx }) => {
     tier: workspace.billing?.tier ?? "Free",
     stripeCustomerId: workspace.billing?.stripeCustomerId ?? null,
     stripeSubscriptionId: workspace.billing?.stripeSubscriptionId ?? null,
+    stripeDeploySubscriptionId: workspace.billing?.stripeDeploySubscriptionId ?? null,
     deployPlan: workspace.billing?.plan ?? null,
     deployPlanOverride: workspace.billing?.planOverride ?? null,
     deploySpendBudgetCents: workspace.billing?.spendBudgetCents ?? null,

--- a/web/internal/db/src/schema/workspace_billing.ts
+++ b/web/internal/db/src/schema/workspace_billing.ts
@@ -34,7 +34,24 @@ export const workspaceBilling = mysqlTable(
 
     // stripe
     stripeCustomerId: varchar("stripe_customer_id", { length: 256 }),
+
+    /**
+     * The API product's Stripe subscription. Every current prod customer's id
+     * here is an API subscription, so the column keeps its name and existing
+     * rows need no migration. Distinct from stripeDeploySubscriptionId, which
+     * holds the Deploy product's subscription. Both subscriptions live on the
+     * shared stripeCustomerId.
+     */
     stripeSubscriptionId: varchar("stripe_subscription_id", { length: 256 }),
+
+    /**
+     * The Deploy (Compute) product's Stripe subscription, split out from the
+     * API subscription so each product cancels as a native whole-subscription
+     * operation. NULL means no Deploy subscription. Read by the ctrl deploy
+     * billing machinery (invoice close, deprovision). Shares the same
+     * stripeCustomerId as stripeSubscriptionId.
+     */
+    stripeDeploySubscriptionId: varchar("stripe_deploy_subscription_id", { length: 256 }),
 
     /**
      * Local mirror of the workspace's Unkey Deploy plan, synced from Stripe by
@@ -81,6 +98,13 @@ export const workspaceBilling = mysqlTable(
     // no partial index; two single-column indexes let index-merge cover the OR.
     spendBudgetCentsIdx: index("spend_budget_cents_idx").on(table.spendBudgetCents),
     spendSuspendedIdx: index("spend_suspended_idx").on(table.spendSuspended),
+    // Back the webhook subscription-id lookups, which are full scans today. One
+    // index per subscription column, since the API and Deploy webhooks match on
+    // their own column.
+    stripeSubscriptionIdIdx: index("stripe_subscription_id_idx").on(table.stripeSubscriptionId),
+    stripeDeploySubscriptionIdIdx: index("stripe_deploy_subscription_id_idx").on(
+      table.stripeDeploySubscriptionId,
+    ),
   }),
 );
 

--- a/web/tools/migrate/align_billing_cycle_anchor.ts
+++ b/web/tools/migrate/align_billing_cycle_anchor.ts
@@ -1,0 +1,108 @@
+import { Stripe } from "stripe";
+
+/**
+ * Aligns every active Stripe subscription's billing cycle anchor to the 1st of
+ * the month at 00:00:00 UTC, matching what new subscriptions get via
+ * `billing_cycle_anchor_config: { day_of_month: 1, hour: 0, minute: 0, second: 0 }`
+ * (see web/apps/dashboard/lib/trpc/routers/stripe/createSubscription.ts).
+ *
+ * Stripe does not allow changing billing_cycle_anchor_config on an existing
+ * subscription; the documented way to move the anchor is to set `trial_end` to
+ * the desired timestamp: "The billing_cycle_anchor will be updated to the
+ * trial_end value." So for each misaligned subscription this script sets
+ * trial_end to the next 1st-of-month 00:00:00 UTC with proration disabled.
+ *
+ * Side effects to be aware of before running with --apply:
+ * - The subscription's status becomes "trialing" until the 1st. Our code
+ *   treats trialing as subscribed (subscribeDeploy/createSubscription accept
+ *   active and trialing), but anything that special-cases "active" will see a
+ *   temporary status change.
+ * - The current billing period ends at the new trial_end: metered usage
+ *   accrued so far is invoiced on the 1st together with the next plan fee.
+ * - proration_behavior "none" means no credit for the remainder of an already
+ *   paid plan fee; the customer effectively gets the stub period included.
+ *
+ * Usage (from web/tools/migrate):
+ *   dotenv -e .env -- npx tsx ./align_billing_cycle_anchor.ts          # dry run
+ *   dotenv -e .env -- npx tsx ./align_billing_cycle_anchor.ts --apply  # mutate
+ */
+async function main() {
+  const apiKey = process.env.STRIPE_SECRET_KEY;
+  if (!apiKey) {
+    throw new Error("STRIPE_SECRET_KEY is not set");
+  }
+  const apply = process.argv.includes("--apply");
+
+  const stripe = new Stripe(apiKey, {
+    apiVersion: "2023-10-16",
+    typescript: true,
+  });
+
+  let total = 0;
+  let aligned = 0;
+  let skipped = 0;
+  let updated = 0;
+
+  for await (const sub of stripe.subscriptions.list({ status: "active", limit: 100 })) {
+    total++;
+
+    const anchor = new Date(sub.billing_cycle_anchor * 1000);
+    const isAligned =
+      anchor.getUTCDate() === 1 &&
+      anchor.getUTCHours() === 0 &&
+      anchor.getUTCMinutes() === 0 &&
+      anchor.getUTCSeconds() === 0;
+
+    if (isAligned) {
+      aligned++;
+      continue;
+    }
+
+    // Moving the anchor on a subscription that is winding down would shift its
+    // end date; leave those alone and let the cancellation play out.
+    if (sub.cancel_at_period_end || sub.cancel_at !== null) {
+      skipped++;
+      console.log(
+        `skip ${sub.id} (customer ${sub.customer}): cancelling, anchor ${anchor.toISOString()}`,
+      );
+      continue;
+    }
+
+    const trialEnd = nextFirstOfMonthUTC(new Date());
+    console.log(
+      `${apply ? "update" : "would update"} ${sub.id} (customer ${sub.customer}): ` +
+        `anchor ${anchor.toISOString()} -> ${trialEnd.toISOString()}`,
+    );
+
+    if (apply) {
+      await stripe.subscriptions.update(
+        sub.id,
+        {
+          trial_end: Math.floor(trialEnd.getTime() / 1000),
+          proration_behavior: "none",
+        },
+        { idempotencyKey: `align-anchor:${sub.id}:${trialEnd.toISOString()}` },
+      );
+      updated++;
+    }
+  }
+
+  console.log(
+    `done: ${total} active subscriptions, ${aligned} already aligned, ` +
+      `${skipped} skipped (cancelling), ${apply ? `${updated} updated` : "dry run (pass --apply to mutate)"}`,
+  );
+}
+
+/**
+ * First day of the following month at 00:00:00 UTC, strictly in the future so
+ * Stripe accepts it as a trial_end. Running exactly at a month boundary rolls
+ * to the month after, which only delays alignment by one cycle.
+ */
+function nextFirstOfMonthUTC(now: Date): Date {
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1, 0, 0, 0));
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/web/tools/migrate/migrate_subscription.ts
+++ b/web/tools/migrate/migrate_subscription.ts
@@ -51,6 +51,9 @@ async function main() {
     ],
     billing_cycle_anchor_config: {
       day_of_month: 1,
+      hour: 0,
+      minute: 0,
+      second: 0,
     },
     proration_behavior: "always_invoice",
   });


### PR DESCRIPTION
**Problem:**

Having Deploy and API on a single stripe plan is a code mess 

**Solution:**

Seperate deploy from API as 2 seperate stripe subscriptiions so they can be indepndentily cancelled, this makes the code easier with less edge cases.
 
**Impact:**

None as billing is not in prod yet.

**Testing:**