### PR TITLE
fix(api): bound verification analytics authorization work

### DIFF
--- a/pkg/clickhouse/query-parser/errors_test.go
+++ b/pkg/clickhouse/query-parser/errors_test.go
@@ -2,6 +2,7 @@ package queryparser
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -84,4 +85,26 @@ func TestParser_ErrorCodes(t *testing.T) {
 			require.Contains(t, publicMsg, tt.expectedError)
 		})
 	}
+}
+
+func TestParser_RejectsOversizedQuery(t *testing.T) {
+	// Security guarantee: oversized input is rejected before callers perform authorization lookups.
+	parser := NewParser(Config{})
+	query := "SELECT 1 " + strings.Repeat(" ", 16*1024)
+
+	_, err := parser.Parse(context.Background(), query)
+
+	require.Error(t, err)
+	require.Contains(t, fault.UserFacingMessage(err), "too long")
+}
+
+func TestParser_RejectsComplexAST(t *testing.T) {
+	// Security guarantee: bounded AST work prevents cheap input from triggering unbounded downstream work.
+	parser := NewParser(Config{})
+	query := "SELECT " + strings.Repeat("1,", 600) + "1"
+
+	_, err := parser.Parse(context.Background(), query)
+
+	require.Error(t, err)
+	require.Contains(t, fault.UserFacingMessage(err), "too complex")
 }

--- a/pkg/clickhouse/query-parser/errors_test.go
+++ b/pkg/clickhouse/query-parser/errors_test.go
@@ -87,8 +87,8 @@ func TestParser_ErrorCodes(t *testing.T) {
 	}
 }
 
+// TestParser_RejectsOversizedQuery guarantees oversized input is rejected before authorization lookups.
 func TestParser_RejectsOversizedQuery(t *testing.T) {
-	// Security guarantee: oversized input is rejected before callers perform authorization lookups.
 	parser := NewParser(Config{})
 	query := "SELECT 1 " + strings.Repeat(" ", 16*1024)
 
@@ -98,8 +98,8 @@ func TestParser_RejectsOversizedQuery(t *testing.T) {
 	require.Contains(t, fault.UserFacingMessage(err), "too long")
 }
 
+// TestParser_RejectsComplexAST guarantees cheap input cannot trigger unbounded downstream work.
 func TestParser_RejectsComplexAST(t *testing.T) {
-	// Security guarantee: bounded AST work prevents cheap input from triggering unbounded downstream work.
 	parser := NewParser(Config{})
 	query := "SELECT " + strings.Repeat("1,", 600) + "1"
 

--- a/pkg/clickhouse/query-parser/extract.go
+++ b/pkg/clickhouse/query-parser/extract.go
@@ -10,18 +10,18 @@ import (
 
 // ExtractColumnValues parses bounded query input and extracts its original column assertions.
 func ExtractColumnValues(query string, columnName string) ([]string, error) {
-	stmts, err := parseBoundedStatements(query)
+	statements, err := parseStatementsBounded(query)
 	if err != nil {
 		return nil, err
 	}
-	if len(stmts) == 0 {
+	if len(statements) == 0 {
 		return nil, fault.New("no statements found",
 			fault.Code(codes.User.BadRequest.InvalidAnalyticsQuery.URN()),
 			fault.Public("No SQL statements found"),
 		)
 	}
 
-	stmt, ok := stmts[0].(*clickhouse.SelectQuery)
+	stmt, ok := statements[0].(*clickhouse.SelectQuery)
 	if !ok {
 		return nil, fault.New("only SELECT queries allowed",
 			fault.Code(codes.User.BadRequest.InvalidAnalyticsQueryType.URN()),
@@ -38,7 +38,7 @@ func ExtractColumnValues(query string, columnName string) ([]string, error) {
 		MaxQueryRangeDays: 0,
 	})
 	parser.stmt = stmt
-	parser.collectExtractedColumns()
+	parser.collectColumnValues()
 	return parser.ExtractColumn(columnName), nil
 }
 
@@ -47,23 +47,23 @@ func ExtractColumnValues(query string, columnName string) ([]string, error) {
 // Returns a deduplicated slice of values found for the column. Returns empty slice if no values found.
 // Must be called after Parse().
 func (p *Parser) ExtractColumn(columnName string) []string {
-	uniqueValues := p.extractedColumns[strings.ToLower(columnName)]
+	columnValuesUnique := p.columnValues[strings.ToLower(columnName)]
 
-	if len(uniqueValues) == 0 {
+	if len(columnValuesUnique) == 0 {
 		return []string{}
 	}
 
 	// Convert map to slice
-	result := make([]string, 0, len(uniqueValues))
-	for value := range uniqueValues {
-		result = append(result, value)
+	columnValues := make([]string, 0, len(columnValuesUnique))
+	for value := range columnValuesUnique {
+		columnValues = append(columnValues, value)
 	}
 
-	return result
+	return columnValues
 }
 
-func (p *Parser) collectExtractedColumns() {
-	p.extractedColumns = make(map[string]map[string]struct{})
+func (p *Parser) collectColumnValues() {
+	p.columnValues = make(map[string]map[string]struct{})
 	clickhouse.Walk(p.stmt, func(node clickhouse.Expr) bool {
 		binOp, ok := node.(*clickhouse.BinaryOperation)
 		if !ok {
@@ -88,10 +88,10 @@ func (p *Parser) collectBinaryOperation(columnExpr clickhouse.Expr, valueExpr cl
 	}
 
 	columnName = strings.ToLower(columnName)
-	values, ok := p.extractedColumns[columnName]
+	values, ok := p.columnValues[columnName]
 	if !ok {
 		values = make(map[string]struct{})
-		p.extractedColumns[columnName] = values
+		p.columnValues[columnName] = values
 	}
 	extractValues(valueExpr, values)
 	return true

--- a/pkg/clickhouse/query-parser/extract.go
+++ b/pkg/clickhouse/query-parser/extract.go
@@ -4,43 +4,50 @@ import (
 	"strings"
 
 	clickhouse "github.com/AfterShip/clickhouse-sql-parser/parser"
+	"github.com/unkeyed/unkey/pkg/codes"
+	"github.com/unkeyed/unkey/pkg/fault"
 )
 
-// ExtractColumn extracts all string literal values for a given column name from WHERE and HAVING clauses.
-// Only extracts from positive assertions (= and IN operators), ignores negative conditions (!=, NOT IN, <, >, etc).
+// ExtractColumnValues parses bounded query input and extracts its original column assertions.
+func ExtractColumnValues(query string, columnName string) ([]string, error) {
+	stmts, err := parseBoundedStatements(query)
+	if err != nil {
+		return nil, err
+	}
+	if len(stmts) == 0 {
+		return nil, fault.New("no statements found",
+			fault.Code(codes.User.BadRequest.InvalidAnalyticsQuery.URN()),
+			fault.Public("No SQL statements found"),
+		)
+	}
+
+	stmt, ok := stmts[0].(*clickhouse.SelectQuery)
+	if !ok {
+		return nil, fault.New("only SELECT queries allowed",
+			fault.Code(codes.User.BadRequest.InvalidAnalyticsQueryType.URN()),
+			fault.Public("Only SELECT queries are allowed"),
+		)
+	}
+
+	parser := NewParser(Config{
+		WorkspaceID:       "",
+		TableAliases:      nil,
+		AllowedTables:     nil,
+		SecurityFilters:   nil,
+		Limit:             0,
+		MaxQueryRangeDays: 0,
+	})
+	parser.stmt = stmt
+	parser.collectExtractedColumns()
+	return parser.ExtractColumn(columnName), nil
+}
+
+// ExtractColumn extracts string literals asserted against a column throughout the original query AST.
+// It handles =, ==, IN, and GLOBAL IN while ignoring negative conditions.
 // Returns a deduplicated slice of values found for the column. Returns empty slice if no values found.
 // Must be called after Parse().
 func (p *Parser) ExtractColumn(columnName string) []string {
-	uniqueValues := make(map[string]bool)
-
-	extractFunc := func(node clickhouse.Expr) bool {
-		binOp, ok := node.(*clickhouse.BinaryOperation)
-		if !ok {
-			return true
-		}
-
-		// Check if left side is our column
-		leftIdent, ok := binOp.LeftExpr.(*clickhouse.Ident)
-		if !ok || !strings.EqualFold(leftIdent.Name, columnName) {
-			return true
-		}
-
-		// Only extract from positive assertions (= or IN)
-		// Ignore negative operators: !=, NOT IN, <, >, <=, >=
-		if binOp.Operation == clickhouse.TokenKindSingleEQ || strings.EqualFold(string(binOp.Operation), "IN") {
-			extractValues(binOp.RightExpr, uniqueValues)
-		}
-
-		return true
-	}
-
-	if p.stmt.Where != nil {
-		clickhouse.Walk(p.stmt.Where.Expr, extractFunc)
-	}
-
-	if p.stmt.Having != nil {
-		clickhouse.Walk(p.stmt.Having.Expr, extractFunc)
-	}
+	uniqueValues := p.extractedColumns[strings.ToLower(columnName)]
 
 	if len(uniqueValues) == 0 {
 		return []string{}
@@ -55,11 +62,65 @@ func (p *Parser) ExtractColumn(columnName string) []string {
 	return result
 }
 
-func extractValues(expr clickhouse.Expr, values map[string]bool) {
+func (p *Parser) collectExtractedColumns() {
+	p.extractedColumns = make(map[string]map[string]struct{})
+	clickhouse.Walk(p.stmt, func(node clickhouse.Expr) bool {
+		binOp, ok := node.(*clickhouse.BinaryOperation)
+		if !ok {
+			return true
+		}
+		switch string(binOp.Operation) {
+		case string(clickhouse.TokenKindSingleEQ), string(clickhouse.TokenKindDoubleEQ):
+			if !p.collectBinaryOperation(binOp.LeftExpr, binOp.RightExpr) {
+				p.collectBinaryOperation(binOp.RightExpr, binOp.LeftExpr)
+			}
+		case "IN", "GLOBAL IN":
+			p.collectBinaryOperation(binOp.LeftExpr, binOp.RightExpr)
+		}
+		return true
+	})
+}
+
+func (p *Parser) collectBinaryOperation(columnExpr clickhouse.Expr, valueExpr clickhouse.Expr) bool {
+	columnName, ok := extractedColumnName(columnExpr)
+	if !ok {
+		return false
+	}
+
+	columnName = strings.ToLower(columnName)
+	values, ok := p.extractedColumns[columnName]
+	if !ok {
+		values = make(map[string]struct{})
+		p.extractedColumns[columnName] = values
+	}
+	extractValues(valueExpr, values)
+	return true
+}
+
+func extractedColumnName(expr clickhouse.Expr) (string, bool) {
+	switch column := expr.(type) {
+	case *clickhouse.Ident:
+		return column.Name, true
+	case *clickhouse.NestedIdentifier:
+		if column.DotIdent != nil {
+			return column.DotIdent.Name, true
+		}
+		return column.Ident.Name, true
+	case *clickhouse.Path:
+		if len(column.Fields) > 0 {
+			return column.Fields[len(column.Fields)-1].Name, true
+		}
+		return "", false
+	default:
+		return "", false
+	}
+}
+
+func extractValues(expr clickhouse.Expr, values map[string]struct{}) {
 	// Handle single string literal (for = operator)
 	strLit, ok := expr.(*clickhouse.StringLiteral)
 	if ok {
-		values[strLit.Literal] = true
+		values[strLit.Literal] = struct{}{}
 		return
 	}
 
@@ -85,6 +146,6 @@ func extractValues(expr clickhouse.Expr, values map[string]bool) {
 			continue
 		}
 
-		values[strLit.Literal] = true
+		values[strLit.Literal] = struct{}{}
 	}
 }

--- a/pkg/clickhouse/query-parser/extract_test.go
+++ b/pkg/clickhouse/query-parser/extract_test.go
@@ -82,6 +82,42 @@ func TestExtractColumnValues(t *testing.T) {
 			expected:   []string{"ks_1234"},
 		},
 		{
+			name:       "qualified column",
+			query:      "SELECT COUNT(*) FROM key_verifications AS v WHERE v.key_space_id IN ('ks_owned', 'ks_missing')",
+			columnName: "key_space_id",
+			expected:   []string{"ks_owned", "ks_missing"},
+		},
+		{
+			name:       "reversed equality",
+			query:      "SELECT COUNT(*) FROM key_verifications AS v WHERE 'ks_missing' = v.key_space_id",
+			columnName: "key_space_id",
+			expected:   []string{"ks_missing"},
+		},
+		{
+			name:       "double equality",
+			query:      "SELECT COUNT(*) FROM key_verifications WHERE key_space_id == 'ks_missing'",
+			columnName: "key_space_id",
+			expected:   []string{"ks_missing"},
+		},
+		{
+			name:       "global IN",
+			query:      "SELECT COUNT(*) FROM key_verifications WHERE key_space_id GLOBAL IN ('ks_owned', 'ks_missing')",
+			columnName: "key_space_id",
+			expected:   []string{"ks_owned", "ks_missing"},
+		},
+		{
+			name:       "nested CTE predicate",
+			query:      "WITH filtered AS (SELECT * FROM key_verifications WHERE key_space_id IN ('ks_owned', 'ks_missing')) SELECT COUNT(*) FROM filtered",
+			columnName: "key_space_id",
+			expected:   []string{"ks_owned", "ks_missing"},
+		},
+		{
+			name:       "join predicate",
+			query:      "SELECT COUNT(*) FROM key_verifications AS a INNER JOIN key_verifications AS b ON b.key_space_id = 'ks_missing'",
+			columnName: "key_space_id",
+			expected:   []string{"ks_missing"},
+		},
+		{
 			name:       "negative operator != ignored",
 			query:      "SELECT COUNT(*) FROM key_verifications WHERE key_space_id != 'ks_bad'",
 			columnName: "key_space_id",

--- a/pkg/clickhouse/query-parser/parser.go
+++ b/pkg/clickhouse/query-parser/parser.go
@@ -9,25 +9,58 @@ import (
 	"github.com/unkeyed/unkey/pkg/fault"
 )
 
+const (
+	maxQueryBytes = 16 * 1024
+	maxASTNodes   = 1_000
+)
+
 // NewParser creates a new parser
 func NewParser(config Config) *Parser {
 	return &Parser{
-		stmt:     nil,
-		config:   config,
-		cteNames: make(map[string]bool),
+		stmt:             nil,
+		config:           config,
+		cteNames:         make(map[string]bool),
+		extractedColumns: make(map[string]map[string]struct{}),
+		hasFromSubquery:  false,
 	}
+}
+
+func parseBoundedStatements(query string) ([]clickhouse.Expr, error) {
+	if len(query) > maxQueryBytes {
+		return nil, fault.New("analytics query is too long",
+			fault.Code(codes.User.BadRequest.InvalidAnalyticsQuery.URN()),
+			fault.Public(fmt.Sprintf("Analytics query is too long; maximum length is %d bytes", maxQueryBytes)),
+		)
+	}
+
+	parser := clickhouse.NewParser(query)
+	stmts, err := parser.ParseStmts()
+	if err != nil {
+		return nil, invalidSyntaxError(err)
+	}
+
+	nodes := 0
+	for _, stmt := range stmts {
+		withinLimit := clickhouse.Walk(stmt, func(clickhouse.Expr) bool {
+			nodes++
+			return nodes <= maxASTNodes
+		})
+		if !withinLimit {
+			return nil, fault.New("analytics query AST is too complex",
+				fault.Code(codes.User.BadRequest.InvalidAnalyticsQuery.URN()),
+				fault.Public(fmt.Sprintf("Analytics query is too complex; maximum AST node count is %d", maxASTNodes)),
+			)
+		}
+	}
+
+	return stmts, nil
 }
 
 // Parse parses and rewrites a query
 func (p *Parser) Parse(ctx context.Context, query string) (string, error) {
-	// Parse SQL
-	parser := clickhouse.NewParser(query)
-	stmts, err := parser.ParseStmts()
+	stmts, err := parseBoundedStatements(query)
 	if err != nil {
-		return "", fault.Wrap(err,
-			fault.Code(codes.User.BadRequest.InvalidAnalyticsQuery.URN()),
-			fault.Public(fmt.Sprintf("Invalid SQL syntax: %v", err)),
-		)
+		return "", err
 	}
 
 	if len(stmts) == 0 {
@@ -50,6 +83,8 @@ func (p *Parser) Parse(ctx context.Context, query string) (string, error) {
 	if err := p.validateSettings(); err != nil {
 		return "", err
 	}
+	p.collectExtractedColumns()
+	p.collectFromSubqueries()
 
 	// Build CTE registry FIRST so we know which table references are CTEs
 	p.buildCTERegistry()
@@ -73,4 +108,34 @@ func (p *Parser) Parse(ctx context.Context, query string) (string, error) {
 	}
 
 	return p.stmt.String(), nil
+}
+
+// HasFromSubquery reports whether any FROM clause contains a nested SELECT.
+func (p *Parser) HasFromSubquery() bool {
+	return p.hasFromSubquery
+}
+
+func (p *Parser) collectFromSubqueries() {
+	p.hasFromSubquery = false
+	clickhouse.Walk(p.stmt, func(node clickhouse.Expr) bool {
+		selectQuery, ok := node.(*clickhouse.SelectQuery)
+		if !ok || selectQuery.From == nil {
+			return true
+		}
+		clickhouse.Walk(selectQuery.From, func(fromNode clickhouse.Expr) bool {
+			if _, nested := fromNode.(*clickhouse.SelectQuery); nested {
+				p.hasFromSubquery = true
+				return false
+			}
+			return true
+		})
+		return !p.hasFromSubquery
+	})
+}
+
+func invalidSyntaxError(err error) error {
+	return fault.Wrap(err,
+		fault.Code(codes.User.BadRequest.InvalidAnalyticsQuery.URN()),
+		fault.Public(fmt.Sprintf("Invalid SQL syntax: %v", err)),
+	)
 }

--- a/pkg/clickhouse/query-parser/parser.go
+++ b/pkg/clickhouse/query-parser/parser.go
@@ -10,60 +10,60 @@ import (
 )
 
 const (
-	maxQueryBytes = 16 * 1024
-	maxASTNodes   = 1_000
+	queryBytesMax = 16 * 1024
+	astNodesMax   = 1_000
 )
 
 // NewParser creates a new parser
 func NewParser(config Config) *Parser {
 	return &Parser{
-		stmt:             nil,
-		config:           config,
-		cteNames:         make(map[string]bool),
-		extractedColumns: make(map[string]map[string]struct{}),
-		hasFromSubquery:  false,
+		stmt:                nil,
+		config:              config,
+		cteNames:            make(map[string]bool),
+		columnValues:        make(map[string]map[string]struct{}),
+		fromSubqueryPresent: false,
 	}
 }
 
-func parseBoundedStatements(query string) ([]clickhouse.Expr, error) {
-	if len(query) > maxQueryBytes {
+func parseStatementsBounded(query string) ([]clickhouse.Expr, error) {
+	if len(query) > queryBytesMax {
 		return nil, fault.New("analytics query is too long",
 			fault.Code(codes.User.BadRequest.InvalidAnalyticsQuery.URN()),
-			fault.Public(fmt.Sprintf("Analytics query is too long; maximum length is %d bytes", maxQueryBytes)),
+			fault.Public(fmt.Sprintf("Analytics query is too long; maximum length is %d bytes", queryBytesMax)),
 		)
 	}
 
 	parser := clickhouse.NewParser(query)
-	stmts, err := parser.ParseStmts()
+	statements, err := parser.ParseStmts()
 	if err != nil {
 		return nil, invalidSyntaxError(err)
 	}
 
-	nodes := 0
-	for _, stmt := range stmts {
-		withinLimit := clickhouse.Walk(stmt, func(clickhouse.Expr) bool {
-			nodes++
-			return nodes <= maxASTNodes
+	astNodesCount := 0
+	for _, stmt := range statements {
+		astNodesLimitValid := clickhouse.Walk(stmt, func(clickhouse.Expr) bool {
+			astNodesCount++
+			return astNodesCount <= astNodesMax
 		})
-		if !withinLimit {
+		if !astNodesLimitValid {
 			return nil, fault.New("analytics query AST is too complex",
 				fault.Code(codes.User.BadRequest.InvalidAnalyticsQuery.URN()),
-				fault.Public(fmt.Sprintf("Analytics query is too complex; maximum AST node count is %d", maxASTNodes)),
+				fault.Public(fmt.Sprintf("Analytics query is too complex; maximum AST node count is %d", astNodesMax)),
 			)
 		}
 	}
 
-	return stmts, nil
+	return statements, nil
 }
 
 // Parse parses and rewrites a query
 func (p *Parser) Parse(ctx context.Context, query string) (string, error) {
-	stmts, err := parseBoundedStatements(query)
+	statements, err := parseStatementsBounded(query)
 	if err != nil {
 		return "", err
 	}
 
-	if len(stmts) == 0 {
+	if len(statements) == 0 {
 		return "", fault.New("no statements found",
 			fault.Code(codes.User.BadRequest.InvalidAnalyticsQuery.URN()),
 			fault.Public("No SQL statements found"),
@@ -71,7 +71,7 @@ func (p *Parser) Parse(ctx context.Context, query string) (string, error) {
 	}
 
 	// Only allow SELECT
-	stmt, ok := stmts[0].(*clickhouse.SelectQuery)
+	stmt, ok := statements[0].(*clickhouse.SelectQuery)
 	if !ok {
 		return "", fault.New("only SELECT queries allowed",
 			fault.Code(codes.User.BadRequest.InvalidAnalyticsQueryType.URN()),
@@ -83,7 +83,7 @@ func (p *Parser) Parse(ctx context.Context, query string) (string, error) {
 	if err := p.validateSettings(); err != nil {
 		return "", err
 	}
-	p.collectExtractedColumns()
+	p.collectColumnValues()
 	p.collectFromSubqueries()
 
 	// Build CTE registry FIRST so we know which table references are CTEs
@@ -110,13 +110,13 @@ func (p *Parser) Parse(ctx context.Context, query string) (string, error) {
 	return p.stmt.String(), nil
 }
 
-// HasFromSubquery reports whether any FROM clause contains a nested SELECT.
-func (p *Parser) HasFromSubquery() bool {
-	return p.hasFromSubquery
+// FromSubqueryPresent reports whether any FROM clause contains a nested SELECT.
+func (p *Parser) FromSubqueryPresent() bool {
+	return p.fromSubqueryPresent
 }
 
 func (p *Parser) collectFromSubqueries() {
-	p.hasFromSubquery = false
+	p.fromSubqueryPresent = false
 	clickhouse.Walk(p.stmt, func(node clickhouse.Expr) bool {
 		selectQuery, ok := node.(*clickhouse.SelectQuery)
 		if !ok || selectQuery.From == nil {
@@ -124,12 +124,12 @@ func (p *Parser) collectFromSubqueries() {
 		}
 		clickhouse.Walk(selectQuery.From, func(fromNode clickhouse.Expr) bool {
 			if _, nested := fromNode.(*clickhouse.SelectQuery); nested {
-				p.hasFromSubquery = true
+				p.fromSubqueryPresent = true
 				return false
 			}
 			return true
 		})
-		return !p.hasFromSubquery
+		return !p.fromSubqueryPresent
 	})
 }
 

--- a/pkg/clickhouse/query-parser/types.go
+++ b/pkg/clickhouse/query-parser/types.go
@@ -22,7 +22,9 @@ type Config struct {
 
 // Parser rewrites ClickHouse queries
 type Parser struct {
-	config   Config
-	stmt     *clickhouse.SelectQuery
-	cteNames map[string]bool // Tracks CTE names defined in WITH clause
+	config           Config
+	stmt             *clickhouse.SelectQuery
+	cteNames         map[string]bool // Tracks CTE names defined in WITH clause
+	extractedColumns map[string]map[string]struct{}
+	hasFromSubquery  bool
 }

--- a/pkg/clickhouse/query-parser/types.go
+++ b/pkg/clickhouse/query-parser/types.go
@@ -22,9 +22,9 @@ type Config struct {
 
 // Parser rewrites ClickHouse queries
 type Parser struct {
-	config           Config
-	stmt             *clickhouse.SelectQuery
-	cteNames         map[string]bool // Tracks CTE names defined in WITH clause
-	extractedColumns map[string]map[string]struct{}
-	hasFromSubquery  bool
+	config              Config
+	stmt                *clickhouse.SelectQuery
+	cteNames            map[string]bool // Tracks CTE names defined in WITH clause
+	columnValues        map[string]map[string]struct{}
+	fromSubqueryPresent bool
 }

--- a/svc/api/routes/v2_analytics_get_verifications/200_test.go
+++ b/svc/api/routes/v2_analytics_get_verifications/200_test.go
@@ -7,11 +7,38 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/cache"
 	"github.com/unkeyed/unkey/pkg/clickhouse/schema"
+	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
 )
+
+func Test200_WildcardPermissionSkipsKeySpaceLookups(t *testing.T) {
+	h := testutil.NewHarness(t, testutil.HarnessConfig{ClickHouse: true})
+	workspace := h.CreateWorkspace()
+	h.SetupAnalytics(workspace.ID)
+	rootKey := h.CreateRootKey(workspace.ID, "api.*.read_analytics")
+
+	apiLookups := &countingCache[cache.ScopedKey, db.FindKeyAuthsByIdsRow]{Cache: h.Caches.ApiToKeyAuthRow}
+	keySpaceLookups := &countingCache[cache.ScopedKey, db.FindKeyAuthsByKeyAuthIdsRow]{Cache: h.Caches.KeyAuthToApiRow}
+	routeCaches := h.Caches
+	routeCaches.ApiToKeyAuthRow = apiLookups
+	routeCaches.KeyAuthToApiRow = keySpaceLookups
+	route := &Handler{DB: h.DB, AnalyticsConnectionManager: h.AnalyticsConnectionManager, Caches: routeCaches}
+	h.Register(route)
+
+	// Security guarantee: wildcard authorization never fans out into attacker-controlled key-space lookups.
+	res := testutil.CallRoute[Request, Response](h, route, http.Header{
+		"Authorization": []string{"Bearer " + rootKey},
+		"Content-Type":  []string{"application/json"},
+	}, Request{Query: "SELECT COUNT(*) AS count FROM key_verifications_v1 WHERE key_space_id = 'ks_not_looked_up'"})
+
+	require.Equal(t, http.StatusOK, res.Status)
+	require.Zero(t, apiLookups.swrManyCalls)
+	require.Zero(t, keySpaceLookups.swrManyCalls)
+}
 
 func Test200_Success(t *testing.T) {
 	h := testutil.NewHarness(t, testutil.HarnessConfig{ClickHouse: true})

--- a/svc/api/routes/v2_analytics_get_verifications/200_test.go
+++ b/svc/api/routes/v2_analytics_get_verifications/200_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
 )
 
+// Test200_WildcardPermissionSkipsKeySpaceLookups guarantees wildcard authorization never fans out into key-space lookups.
 func Test200_WildcardPermissionSkipsKeySpaceLookups(t *testing.T) {
 	h := testutil.NewHarness(t, testutil.HarnessConfig{ClickHouse: true})
 	workspace := h.CreateWorkspace()
@@ -29,7 +30,6 @@ func Test200_WildcardPermissionSkipsKeySpaceLookups(t *testing.T) {
 	route := &Handler{DB: h.DB, AnalyticsConnectionManager: h.AnalyticsConnectionManager, Caches: routeCaches}
 	h.Register(route)
 
-	// Security guarantee: wildcard authorization never fans out into attacker-controlled key-space lookups.
 	res := testutil.CallRoute[Request, Response](h, route, http.Header{
 		"Authorization": []string{"Bearer " + rootKey},
 		"Content-Type":  []string{"application/json"},

--- a/svc/api/routes/v2_analytics_get_verifications/400_test.go
+++ b/svc/api/routes/v2_analytics_get_verifications/400_test.go
@@ -41,6 +41,7 @@ func (c *countingCache[K, V]) SWRMany(
 	return c.Cache.SWRMany(ctx, keys, refreshFromOrigin, op)
 }
 
+// Test400_KeySpaceLimitPrecedesAuthorizationLookups guarantees the eleventh unique ID is rejected before cache or database fan-out.
 func Test400_KeySpaceLimitPrecedesAuthorizationLookups(t *testing.T) {
 	h := testutil.NewHarness(t, testutil.HarnessConfig{ClickHouse: true})
 	workspace := h.CreateWorkspace()
@@ -60,7 +61,6 @@ func Test400_KeySpaceLimitPrecedesAuthorizationLookups(t *testing.T) {
 	for i := range ids {
 		ids[i] = fmt.Sprintf("'ks_%d' = v.key_space_id", i)
 	}
-	// Security guarantee: the eleventh unique ID is rejected before authorization cache or database fan-out.
 	res := testutil.CallRoute[Request, openapi.BadRequestErrorResponse](h, route, http.Header{
 		"Authorization": []string{"Bearer " + rootKey},
 		"Content-Type":  []string{"application/json"},
@@ -72,6 +72,7 @@ func Test400_KeySpaceLimitPrecedesAuthorizationLookups(t *testing.T) {
 	require.Zero(t, keySpaceLookups.swrManyCalls)
 }
 
+// Test400_QueryWorkBoundsPrecedeAuthorizationLookups guarantees invalid query work is bounded before cache or database lookups.
 func Test400_QueryWorkBoundsPrecedeAuthorizationLookups(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -103,7 +104,6 @@ func Test400_QueryWorkBoundsPrecedeAuthorizationLookups(t *testing.T) {
 			route := &Handler{DB: h.DB, AnalyticsConnectionManager: connectionLookups, Caches: routeCaches}
 			h.Register(route)
 
-			// Security guarantee: invalid query work is bounded before any key-space cache or database lookup.
 			res := testutil.CallRoute[Request, openapi.BadRequestErrorResponse](h, route, http.Header{
 				"Authorization": []string{"Bearer " + rootKey},
 				"Content-Type":  []string{"application/json"},

--- a/svc/api/routes/v2_analytics_get_verifications/400_test.go
+++ b/svc/api/routes/v2_analytics_get_verifications/400_test.go
@@ -1,13 +1,121 @@
 package handler
 
 import (
+	"context"
+	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/internal/services/analytics"
+	"github.com/unkeyed/unkey/pkg/cache"
+	"github.com/unkeyed/unkey/pkg/clickhouse"
+	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
+
+type countingCache[K comparable, V any] struct {
+	cache.Cache[K, V]
+	swrManyCalls int
+}
+
+type countingConnectionManager struct {
+	analytics.ConnectionManager
+	calls int
+}
+
+func (m *countingConnectionManager) GetConnection(ctx context.Context, workspaceID string) (clickhouse.ClickHouse, db.FindClickhouseWorkspaceSettingsByWorkspaceIDRow, error) {
+	m.calls++
+	return m.ConnectionManager.GetConnection(ctx, workspaceID)
+}
+
+func (c *countingCache[K, V]) SWRMany(
+	ctx context.Context,
+	keys []K,
+	refreshFromOrigin func(context.Context, []K) (map[K]V, error),
+	op func(error) cache.Op,
+) (map[K]V, map[K]cache.CacheHit, error) {
+	c.swrManyCalls++
+	return c.Cache.SWRMany(ctx, keys, refreshFromOrigin, op)
+}
+
+func Test400_KeySpaceLimitPrecedesAuthorizationLookups(t *testing.T) {
+	h := testutil.NewHarness(t, testutil.HarnessConfig{ClickHouse: true})
+	workspace := h.CreateWorkspace()
+	h.SetupAnalytics(workspace.ID)
+	rootKey := h.CreateRootKey(workspace.ID, "api.api_test.read_analytics")
+
+	apiLookups := &countingCache[cache.ScopedKey, db.FindKeyAuthsByIdsRow]{Cache: h.Caches.ApiToKeyAuthRow}
+	keySpaceLookups := &countingCache[cache.ScopedKey, db.FindKeyAuthsByKeyAuthIdsRow]{Cache: h.Caches.KeyAuthToApiRow}
+	connectionLookups := &countingConnectionManager{ConnectionManager: h.AnalyticsConnectionManager}
+	routeCaches := h.Caches
+	routeCaches.ApiToKeyAuthRow = apiLookups
+	routeCaches.KeyAuthToApiRow = keySpaceLookups
+	route := &Handler{DB: h.DB, AnalyticsConnectionManager: connectionLookups, Caches: routeCaches}
+	h.Register(route)
+
+	ids := make([]string, 11)
+	for i := range ids {
+		ids[i] = fmt.Sprintf("'ks_%d' = v.key_space_id", i)
+	}
+	// Security guarantee: the eleventh unique ID is rejected before authorization cache or database fan-out.
+	res := testutil.CallRoute[Request, openapi.BadRequestErrorResponse](h, route, http.Header{
+		"Authorization": []string{"Bearer " + rootKey},
+		"Content-Type":  []string{"application/json"},
+	}, Request{Query: "SELECT COUNT(*) FROM key_verifications_v1 AS v WHERE " + strings.Join(ids, " OR ")})
+
+	require.Equal(t, http.StatusBadRequest, res.Status)
+	require.Zero(t, connectionLookups.calls)
+	require.Zero(t, apiLookups.swrManyCalls)
+	require.Zero(t, keySpaceLookups.swrManyCalls)
+}
+
+func Test400_QueryWorkBoundsPrecedeAuthorizationLookups(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+	}{
+		{
+			name:  "query length",
+			query: "SELECT 1 " + strings.Repeat(" ", 16*1024),
+		},
+		{
+			name:  "AST complexity",
+			query: "SELECT " + strings.Repeat("1,", 600) + "1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := testutil.NewHarness(t, testutil.HarnessConfig{ClickHouse: true})
+			workspace := h.CreateWorkspace()
+			h.SetupAnalytics(workspace.ID)
+			rootKey := h.CreateRootKey(workspace.ID, "api.api_test.read_analytics")
+
+			apiLookups := &countingCache[cache.ScopedKey, db.FindKeyAuthsByIdsRow]{Cache: h.Caches.ApiToKeyAuthRow}
+			keySpaceLookups := &countingCache[cache.ScopedKey, db.FindKeyAuthsByKeyAuthIdsRow]{Cache: h.Caches.KeyAuthToApiRow}
+			connectionLookups := &countingConnectionManager{ConnectionManager: h.AnalyticsConnectionManager}
+			routeCaches := h.Caches
+			routeCaches.ApiToKeyAuthRow = apiLookups
+			routeCaches.KeyAuthToApiRow = keySpaceLookups
+			route := &Handler{DB: h.DB, AnalyticsConnectionManager: connectionLookups, Caches: routeCaches}
+			h.Register(route)
+
+			// Security guarantee: invalid query work is bounded before any key-space cache or database lookup.
+			res := testutil.CallRoute[Request, openapi.BadRequestErrorResponse](h, route, http.Header{
+				"Authorization": []string{"Bearer " + rootKey},
+				"Content-Type":  []string{"application/json"},
+			}, Request{Query: tt.query})
+
+			require.Equal(t, http.StatusBadRequest, res.Status)
+			require.Zero(t, connectionLookups.calls)
+			require.Zero(t, apiLookups.swrManyCalls)
+			require.Zero(t, keySpaceLookups.swrManyCalls)
+		})
+	}
+}
 
 func Test400_EmptyQuery(t *testing.T) {
 	h := testutil.NewHarness(t, testutil.HarnessConfig{ClickHouse: true})

--- a/svc/api/routes/v2_analytics_get_verifications/403_test.go
+++ b/svc/api/routes/v2_analytics_get_verifications/403_test.go
@@ -3,12 +3,39 @@ package handler
 import (
 	"fmt"
 	"net/http"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
 )
+
+func TestKeySpaceAuthorizationWorkLimit(t *testing.T) {
+	tests := []struct {
+		name    string
+		ids     []string
+		wantErr bool
+	}{
+		{name: "zero", ids: nil},
+		{name: "one", ids: []string{"ks_1"}},
+		{name: "ten", ids: []string{"ks_1", "ks_2", "ks_3", "ks_4", "ks_5", "ks_6", "ks_7", "ks_8", "ks_9", "ks_10"}},
+		{name: "eleven", ids: []string{"ks_1", "ks_2", "ks_3", "ks_4", "ks_5", "ks_6", "ks_7", "ks_8", "ks_9", "ks_10", "ks_11"}, wantErr: true},
+		{name: "duplicates count once", ids: slices.Concat([]string{"ks_1", "ks_2", "ks_3", "ks_4", "ks_5", "ks_6", "ks_7", "ks_8", "ks_9", "ks_10"}, []string{"ks_1", "ks_2", "ks_3", "ks_4", "ks_5", "ks_6", "ks_7", "ks_8", "ks_9", "ks_10"})},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Security guarantee: authorization fan-out is capped by unique key-space IDs.
+			err := validateKeySpaceAuthorizationWork(tt.ids)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
 
 func Test403_NoAnalyticsPermission(t *testing.T) {
 	h := testutil.NewHarness(t, testutil.HarnessConfig{ClickHouse: true})
@@ -76,4 +103,22 @@ func Test403_WrongApiPermission(t *testing.T) {
 
 	res := testutil.CallRoute[Request, Response](h, route, headers, req)
 	require.Equal(t, 403, res.Status)
+}
+
+func Test403_ScopedPermissionRequiresInjectedSecurityFilter(t *testing.T) {
+	h := testutil.NewHarness(t, testutil.HarnessConfig{ClickHouse: true})
+	workspace := h.CreateWorkspace()
+	api := h.CreateApi(seed.CreateApiRequest{WorkspaceID: workspace.ID})
+	h.SetupAnalytics(workspace.ID)
+	rootKey := h.CreateRootKey(workspace.ID, "api."+api.ID+".read_analytics")
+	route := &Handler{DB: h.DB, AnalyticsConnectionManager: h.AnalyticsConnectionManager, Caches: h.Caches}
+	h.Register(route)
+
+	// Security guarantee: scoped access fails closed when the query shape prevents RLS injection.
+	res := testutil.CallRoute[Request, Response](h, route, http.Header{
+		"Authorization": []string{"Bearer " + rootKey},
+		"Content-Type":  []string{"application/json"},
+	}, Request{Query: "SELECT COUNT(*) FROM key_verifications_v1 AS v CROSS JOIN (SELECT 1) AS x"})
+
+	require.Equal(t, http.StatusForbidden, res.Status)
 }

--- a/svc/api/routes/v2_analytics_get_verifications/403_test.go
+++ b/svc/api/routes/v2_analytics_get_verifications/403_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
 )
 
+// TestKeySpaceAuthorizationWorkLimit guarantees authorization fan-out is capped by unique key-space IDs.
 func TestKeySpaceAuthorizationWorkLimit(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -26,7 +27,6 @@ func TestKeySpaceAuthorizationWorkLimit(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Security guarantee: authorization fan-out is capped by unique key-space IDs.
 			err := validateKeySpaceAuthorizationWork(tt.ids)
 			if tt.wantErr {
 				require.Error(t, err)
@@ -105,6 +105,7 @@ func Test403_WrongApiPermission(t *testing.T) {
 	require.Equal(t, 403, res.Status)
 }
 
+// Test403_ScopedPermissionRequiresInjectedSecurityFilter guarantees scoped access fails closed when RLS cannot be injected.
 func Test403_ScopedPermissionRequiresInjectedSecurityFilter(t *testing.T) {
 	h := testutil.NewHarness(t, testutil.HarnessConfig{ClickHouse: true})
 	workspace := h.CreateWorkspace()
@@ -114,7 +115,6 @@ func Test403_ScopedPermissionRequiresInjectedSecurityFilter(t *testing.T) {
 	route := &Handler{DB: h.DB, AnalyticsConnectionManager: h.AnalyticsConnectionManager, Caches: h.Caches}
 	h.Register(route)
 
-	// Security guarantee: scoped access fails closed when the query shape prevents RLS injection.
 	res := testutil.CallRoute[Request, Response](h, route, http.Header{
 		"Authorization": []string{"Bearer " + rootKey},
 		"Content-Type":  []string{"application/json"},

--- a/svc/api/routes/v2_analytics_get_verifications/404_test.go
+++ b/svc/api/routes/v2_analytics_get_verifications/404_test.go
@@ -42,6 +42,7 @@ func Test404_KeySpaceNotFound(t *testing.T) {
 	require.Equal(t, 404, res.Status) // Key space not found
 }
 
+// Test404_MixedKeySpacesFailClosed guarantees mixed invalid IDs fail closed and foreign IDs remain indistinguishable from missing IDs.
 func Test404_MixedKeySpacesFailClosed(t *testing.T) {
 	h := testutil.NewHarness(t, testutil.HarnessConfig{ClickHouse: true})
 	workspace := h.CreateWorkspace()
@@ -58,7 +59,6 @@ func Test404_MixedKeySpacesFailClosed(t *testing.T) {
 		"Content-Type":  []string{"application/json"},
 	}
 
-	// Security guarantee: one foreign, missing, or unauthorized ID makes the complete request fail closed.
 	query := fmt.Sprintf(
 		"SELECT COUNT(*) FROM key_verifications_v1 AS v WHERE v.key_space_id IN ('%s', '%s', '%s', '%s')",
 		owned.KeyAuthID.String,
@@ -69,7 +69,6 @@ func Test404_MixedKeySpacesFailClosed(t *testing.T) {
 	res := testutil.CallRoute[Request, openapi.NotFoundErrorResponse](h, route, headers, Request{Query: query})
 	require.Equal(t, http.StatusNotFound, res.Status)
 
-	// Security guarantee: a foreign key space is externally indistinguishable from a missing one.
 	foreignRes := testutil.CallRoute[Request, openapi.NotFoundErrorResponse](h, route, headers, Request{Query: fmt.Sprintf(
 		"SELECT COUNT(*) FROM key_verifications_v1 WHERE key_space_id = '%s'", foreign.KeyAuthID.String,
 	)})

--- a/svc/api/routes/v2_analytics_get_verifications/404_test.go
+++ b/svc/api/routes/v2_analytics_get_verifications/404_test.go
@@ -8,17 +8,18 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
+	"github.com/unkeyed/unkey/svc/api/openapi"
 )
 
 func Test404_KeySpaceNotFound(t *testing.T) {
 	h := testutil.NewHarness(t, testutil.HarnessConfig{ClickHouse: true})
 
 	workspace := h.CreateWorkspace()
-	_ = h.CreateApi(seed.CreateApiRequest{
+	api := h.CreateApi(seed.CreateApiRequest{
 		WorkspaceID: workspace.ID,
 	})
 	h.SetupAnalytics(workspace.ID)
-	rootKey := h.CreateRootKey(workspace.ID, "api.*.read_analytics")
+	rootKey := h.CreateRootKey(workspace.ID, "api."+api.ID+".read_analytics")
 
 	route := &Handler{
 		DB:                         h.DB,
@@ -39,4 +40,41 @@ func Test404_KeySpaceNotFound(t *testing.T) {
 
 	res := testutil.CallRoute[Request, Response](h, route, headers, req)
 	require.Equal(t, 404, res.Status) // Key space not found
+}
+
+func Test404_MixedKeySpacesFailClosed(t *testing.T) {
+	h := testutil.NewHarness(t, testutil.HarnessConfig{ClickHouse: true})
+	workspace := h.CreateWorkspace()
+	owned := h.CreateApi(seed.CreateApiRequest{WorkspaceID: workspace.ID})
+	unauthorized := h.CreateApi(seed.CreateApiRequest{WorkspaceID: workspace.ID})
+	foreignWorkspace := h.CreateWorkspace()
+	foreign := h.CreateApi(seed.CreateApiRequest{WorkspaceID: foreignWorkspace.ID})
+	h.SetupAnalytics(workspace.ID)
+	rootKey := h.CreateRootKey(workspace.ID, "api."+owned.ID+".read_analytics")
+	route := &Handler{DB: h.DB, AnalyticsConnectionManager: h.AnalyticsConnectionManager, Caches: h.Caches}
+	h.Register(route)
+	headers := http.Header{
+		"Authorization": []string{"Bearer " + rootKey},
+		"Content-Type":  []string{"application/json"},
+	}
+
+	// Security guarantee: one foreign, missing, or unauthorized ID makes the complete request fail closed.
+	query := fmt.Sprintf(
+		"SELECT COUNT(*) FROM key_verifications_v1 AS v WHERE v.key_space_id IN ('%s', '%s', '%s', '%s')",
+		owned.KeyAuthID.String,
+		unauthorized.KeyAuthID.String,
+		foreign.KeyAuthID.String,
+		"ks_missing",
+	)
+	res := testutil.CallRoute[Request, openapi.NotFoundErrorResponse](h, route, headers, Request{Query: query})
+	require.Equal(t, http.StatusNotFound, res.Status)
+
+	// Security guarantee: a foreign key space is externally indistinguishable from a missing one.
+	foreignRes := testutil.CallRoute[Request, openapi.NotFoundErrorResponse](h, route, headers, Request{Query: fmt.Sprintf(
+		"SELECT COUNT(*) FROM key_verifications_v1 WHERE key_space_id = '%s'", foreign.KeyAuthID.String,
+	)})
+	missingRes := testutil.CallRoute[Request, openapi.NotFoundErrorResponse](h, route, headers, Request{Query: "SELECT COUNT(*) FROM key_verifications_v1 WHERE key_space_id = 'ks_also_missing'"})
+	require.Equal(t, http.StatusNotFound, foreignRes.Status)
+	require.Equal(t, missingRes.Status, foreignRes.Status)
+	require.Equal(t, missingRes.Body.Error.Type, foreignRes.Body.Error.Type)
 }

--- a/svc/api/routes/v2_analytics_get_verifications/handler.go
+++ b/svc/api/routes/v2_analytics_get_verifications/handler.go
@@ -45,7 +45,7 @@ var (
 	}
 )
 
-const maxKeySpaceAuthorizationIDs = 10
+const keySpaceAuthorizationIDsMax = 10
 
 // Handler implements zen.Route interface for the v2 Analytics get verifications endpoint
 type Handler struct {
@@ -76,11 +76,11 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	keySpaceIds, err := chquery.ExtractColumnValues(req.Query, "key_space_id")
+	keySpaceIDs, err := chquery.ExtractColumnValues(req.Query, "key_space_id")
 	if err != nil {
 		return err
 	}
-	if err := validateKeySpaceAuthorizationWork(keySpaceIds); err != nil {
+	if err := validateKeySpaceAuthorizationWork(keySpaceIDs); err != nil {
 		return err
 	}
 
@@ -90,8 +90,8 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		Action:       rbac.ReadAnalytics,
 	})
 	wildcardAuthorized := slices.Contains(principal.Permissions, "api.*.read_analytics")
-	allowedAPIIDs := extractAllowedAPIIds(principal.Permissions)
-	if !wildcardAuthorized && len(keySpaceIds) == 0 && len(allowedAPIIDs) == 0 {
+	apiIDsAllowed := extractAllowedAPIIds(principal.Permissions)
+	if !wildcardAuthorized && len(keySpaceIDs) == 0 && len(apiIDsAllowed) == 0 {
 		return principal.Authorize(wildcardPermission)
 	}
 
@@ -115,7 +115,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	if err != nil {
 		return err
 	}
-	if !wildcardAuthorized && parser.HasFromSubquery() {
+	if !wildcardAuthorized && parser.FromSubqueryPresent() {
 		return principal.Authorize(wildcardPermission)
 	}
 
@@ -131,8 +131,8 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			return err
 		}
 
-		if len(keySpaceIds) > 0 {
-			apiPermissions, permErr := h.buildAPIPermissionsFromKeySpaces(ctx, principal, keySpaceIds)
+		if len(keySpaceIDs) > 0 {
+			apiPermissions, permErr := h.buildAPIPermissionsFromKeySpaces(ctx, principal, keySpaceIDs)
 			if permErr != nil {
 				return permErr
 			}
@@ -159,13 +159,13 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 }
 
 func validateKeySpaceAuthorizationWork(keySpaceIDs []string) error {
-	uniqueIDs := make(map[string]struct{}, len(keySpaceIDs))
+	keySpaceIDsUnique := make(map[string]struct{}, len(keySpaceIDs))
 	for _, keySpaceID := range keySpaceIDs {
-		uniqueIDs[keySpaceID] = struct{}{}
-		if len(uniqueIDs) > maxKeySpaceAuthorizationIDs {
+		keySpaceIDsUnique[keySpaceID] = struct{}{}
+		if len(keySpaceIDsUnique) > keySpaceAuthorizationIDsMax {
 			return fault.New("too many key spaces in analytics query",
 				fault.Code(codes.User.BadRequest.InvalidAnalyticsQuery.URN()),
-				fault.Public(fmt.Sprintf("Analytics query references too many key spaces; maximum is %d", maxKeySpaceAuthorizationIDs)),
+				fault.Public(fmt.Sprintf("Analytics query references too many key spaces; maximum is %d", keySpaceAuthorizationIDsMax)),
 			)
 		}
 	}

--- a/svc/api/routes/v2_analytics_get_verifications/handler.go
+++ b/svc/api/routes/v2_analytics_get_verifications/handler.go
@@ -45,6 +45,8 @@ var (
 	}
 )
 
+const maxKeySpaceAuthorizationIDs = 10
+
 // Handler implements zen.Route interface for the v2 Analytics get verifications endpoint
 type Handler struct {
 	DB                         db.Database
@@ -74,56 +76,70 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
+	keySpaceIds, err := chquery.ExtractColumnValues(req.Query, "key_space_id")
+	if err != nil {
+		return err
+	}
+	if err := validateKeySpaceAuthorizationWork(keySpaceIds); err != nil {
+		return err
+	}
+
+	wildcardPermission := rbac.T(rbac.Tuple{
+		ResourceType: rbac.Api,
+		ResourceID:   "*",
+		Action:       rbac.ReadAnalytics,
+	})
+	wildcardAuthorized := slices.Contains(principal.Permissions, "api.*.read_analytics")
+	allowedAPIIDs := extractAllowedAPIIds(principal.Permissions)
+	if !wildcardAuthorized && len(keySpaceIds) == 0 && len(allowedAPIIDs) == 0 {
+		return principal.Authorize(wildcardPermission)
+	}
+
 	// Get workspace-specific ClickHouse connection and settings first
 	conn, settings, err := h.AnalyticsConnectionManager.GetConnection(ctx, principal.WorkspaceID)
 	if err != nil {
 		return err
 	}
 
-	// Build a list of keySpaceIds that the root key has permissions for.
-	securityFilters, err := h.buildSecurityFilters(ctx, principal)
-	if err != nil {
-		return err
-	}
-
-	parser := chquery.NewParser(chquery.Config{
+	parserConfig := chquery.Config{
 		WorkspaceID:       principal.WorkspaceID,
 		Limit:             int(settings.ClickhouseWorkspaceSetting.MaxQueryResultRows),
-		SecurityFilters:   securityFilters,
+		SecurityFilters:   nil,
 		TableAliases:      tableAliases,
 		AllowedTables:     allowedTables,
 		MaxQueryRangeDays: settings.Quotas.LogsRetentionDays,
-	})
+	}
 
+	parser := chquery.NewParser(parserConfig)
 	parsedQuery, err := parser.Parse(ctx, req.Query)
 	if err != nil {
 		return err
 	}
-
-	// Now we build permission checks based on the key_space_id(s) one specified in the query itself
-	// If none are specified, we will just check if there is wildcard read_analytics permission set
-	permissionChecks := []rbac.PermissionQuery{
-		// Wildcard API analytics access
-		rbac.T(rbac.Tuple{
-			ResourceType: rbac.Api,
-			ResourceID:   "*",
-			Action:       rbac.ReadAnalytics,
-		}),
+	if !wildcardAuthorized && parser.HasFromSubquery() {
+		return principal.Authorize(wildcardPermission)
 	}
 
-	keySpaceIds := parser.ExtractColumn("key_space_id")
-	if len(keySpaceIds) > 0 {
-		apiPermissions, permErr := h.buildAPIPermissionsFromKeySpaces(ctx, principal, keySpaceIds)
-		if permErr != nil {
-			return permErr
+	if !wildcardAuthorized {
+		securityFilters, filterErr := h.buildSecurityFilters(ctx, principal)
+		if filterErr != nil {
+			return filterErr
 		}
-		permissionChecks = append(permissionChecks, rbac.And(apiPermissions...))
-	}
+		parserConfig.SecurityFilters = securityFilters
+		parser = chquery.NewParser(parserConfig)
+		parsedQuery, err = parser.Parse(ctx, req.Query)
+		if err != nil {
+			return err
+		}
 
-	// Verify user has at least one of: api.*.read_analytics OR (api.<api_id1>.read_analytics AND api.<api_id2>.read_analytics)
-	err = principal.Authorize(rbac.Or(permissionChecks...))
-	if err != nil {
-		return err
+		if len(keySpaceIds) > 0 {
+			apiPermissions, permErr := h.buildAPIPermissionsFromKeySpaces(ctx, principal, keySpaceIds)
+			if permErr != nil {
+				return permErr
+			}
+			if err := principal.Authorize(rbac.And(apiPermissions...)); err != nil {
+				return err
+			}
+		}
 	}
 
 	logger.Debug("executing query", "original", req.Query, "parsed", parsedQuery)
@@ -140,6 +156,21 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		},
 		Data: verifications,
 	})
+}
+
+func validateKeySpaceAuthorizationWork(keySpaceIDs []string) error {
+	uniqueIDs := make(map[string]struct{}, len(keySpaceIDs))
+	for _, keySpaceID := range keySpaceIDs {
+		uniqueIDs[keySpaceID] = struct{}{}
+		if len(uniqueIDs) > maxKeySpaceAuthorizationIDs {
+			return fault.New("too many key spaces in analytics query",
+				fault.Code(codes.User.BadRequest.InvalidAnalyticsQuery.URN()),
+				fault.Public(fmt.Sprintf("Analytics query references too many key spaces; maximum is %d", maxKeySpaceAuthorizationIDs)),
+			)
+		}
+	}
+
+	return nil
 }
 
 // buildSecurityFilters creates ClickHouse security filters based on user permissions.

--- a/svc/api/routes/v2_analytics_get_verifications/handler.go
+++ b/svc/api/routes/v2_analytics_get_verifications/handler.go
@@ -90,7 +90,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		Action:       rbac.ReadAnalytics,
 	})
 	wildcardAuthorized := slices.Contains(principal.Permissions, "api.*.read_analytics")
-	apiIDsAllowed := extractAllowedAPIIds(principal.Permissions)
+	apiIDsAllowed := extractAPIIDsAllowed(principal.Permissions)
 	if !wildcardAuthorized && len(keySpaceIDs) == 0 && len(apiIDsAllowed) == 0 {
 		return principal.Authorize(wildcardPermission)
 	}
@@ -101,10 +101,15 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
+	securityFilters, err := h.buildSecurityFilters(ctx, principal)
+	if err != nil {
+		return err
+	}
+
 	parserConfig := chquery.Config{
 		WorkspaceID:       principal.WorkspaceID,
 		Limit:             int(settings.ClickhouseWorkspaceSetting.MaxQueryResultRows),
-		SecurityFilters:   nil,
+		SecurityFilters:   securityFilters,
 		TableAliases:      tableAliases,
 		AllowedTables:     allowedTables,
 		MaxQueryRangeDays: settings.Quotas.LogsRetentionDays,
@@ -119,26 +124,13 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return principal.Authorize(wildcardPermission)
 	}
 
-	if !wildcardAuthorized {
-		securityFilters, filterErr := h.buildSecurityFilters(ctx, principal)
-		if filterErr != nil {
-			return filterErr
+	if !wildcardAuthorized && len(keySpaceIDs) > 0 {
+		apiPermissions, permissionErr := h.buildAPIPermissionsFromKeySpaces(ctx, principal, keySpaceIDs)
+		if permissionErr != nil {
+			return permissionErr
 		}
-		parserConfig.SecurityFilters = securityFilters
-		parser = chquery.NewParser(parserConfig)
-		parsedQuery, err = parser.Parse(ctx, req.Query)
-		if err != nil {
+		if err := principal.Authorize(rbac.And(apiPermissions...)); err != nil {
 			return err
-		}
-
-		if len(keySpaceIDs) > 0 {
-			apiPermissions, permErr := h.buildAPIPermissionsFromKeySpaces(ctx, principal, keySpaceIDs)
-			if permErr != nil {
-				return permErr
-			}
-			if err := principal.Authorize(rbac.And(apiPermissions...)); err != nil {
-				return err
-			}
 		}
 	}
 
@@ -176,33 +168,33 @@ func validateKeySpaceAuthorizationWork(keySpaceIDs []string) error {
 // buildSecurityFilters creates ClickHouse security filters based on user permissions.
 // Returns filters that restrict queries to only the key_space_ids the user has access to.
 func (h *Handler) buildSecurityFilters(ctx context.Context, principal *authprincipal.Principal) ([]chquery.SecurityFilter, error) {
-	allowedAPIIds := extractAllowedAPIIds(principal.Permissions)
-	if len(allowedAPIIds) == 0 {
-		return []chquery.SecurityFilter{}, nil
+	apiIDsAllowed := extractAPIIDsAllowed(principal.Permissions)
+	if len(apiIDsAllowed) == 0 {
+		return nil, nil
 	}
 
 	// Fetch key auths for the allowed API IDs
-	apis, err := h.fetchKeyAuthsByAPIIds(ctx, principal.WorkspaceID, allowedAPIIds)
+	apis, err := h.fetchKeyAuthsByAPIIDs(ctx, principal.WorkspaceID, apiIDsAllowed)
 	if err != nil {
 		return nil, err
 	}
 
 	// Extract key space IDs from the fetched APIs
-	keySpaceIds := make([]string, 0, len(apis))
+	keySpaceIDs := make([]string, 0, len(apis))
 	for _, api := range apis {
-		keySpaceIds = append(keySpaceIds, api.KeyAuthID)
+		keySpaceIDs = append(keySpaceIDs, api.KeyAuthID)
 	}
 
 	return []chquery.SecurityFilter{
 		{
 			Column:        "key_space_id",
-			AllowedValues: keySpaceIds,
+			AllowedValues: keySpaceIDs,
 		},
 	}, nil
 }
 
-// fetchKeyAuthsByAPIIds fetches key auth rows for the given API IDs using the cache.
-func (h *Handler) fetchKeyAuthsByAPIIds(ctx context.Context, workspaceID string, apiIDs []string) (map[cache.ScopedKey]db.FindKeyAuthsByIdsRow, error) {
+// fetchKeyAuthsByAPIIDs fetches key auth rows for the given API IDs using the cache.
+func (h *Handler) fetchKeyAuthsByAPIIDs(ctx context.Context, workspaceID string, apiIDs []string) (map[cache.ScopedKey]db.FindKeyAuthsByIdsRow, error) {
 	cacheKeys := array.Map(apiIDs, func(apiID string) cache.ScopedKey {
 		return cache.ScopedKey{
 			WorkspaceID: workspaceID,
@@ -239,8 +231,8 @@ func (h *Handler) fetchKeyAuthsByAPIIds(ctx context.Context, workspaceID string,
 
 // buildAPIPermissionsFromKeySpaces fetches key spaces and builds RBAC permissions for them.
 // Returns an error if any key space is not found.
-func (h *Handler) buildAPIPermissionsFromKeySpaces(ctx context.Context, principal *authprincipal.Principal, keySpaceIds []string) ([]rbac.PermissionQuery, error) {
-	keySpaces, keySpaceHits, err := h.fetchKeyAuthsByKeyAuthIds(ctx, principal.WorkspaceID, keySpaceIds)
+func (h *Handler) buildAPIPermissionsFromKeySpaces(ctx context.Context, principal *authprincipal.Principal, keySpaceIDs []string) ([]rbac.PermissionQuery, error) {
+	keySpaces, keySpaceHits, err := h.fetchKeyAuthsByKeyAuthIDs(ctx, principal.WorkspaceID, keySpaceIDs)
 	if err != nil {
 		return nil, err
 	}
@@ -265,8 +257,8 @@ func (h *Handler) buildAPIPermissionsFromKeySpaces(ctx context.Context, principa
 	return apiPermissions, nil
 }
 
-// fetchKeyAuthsByKeyAuthIds fetches key auth rows for the given key auth IDs using the cache.
-func (h *Handler) fetchKeyAuthsByKeyAuthIds(ctx context.Context, workspaceID string, keyAuthIDs []string) (map[cache.ScopedKey]db.FindKeyAuthsByKeyAuthIdsRow, map[cache.ScopedKey]cache.CacheHit, error) {
+// fetchKeyAuthsByKeyAuthIDs fetches key auth rows for the given key auth IDs using the cache.
+func (h *Handler) fetchKeyAuthsByKeyAuthIDs(ctx context.Context, workspaceID string, keyAuthIDs []string) (map[cache.ScopedKey]db.FindKeyAuthsByKeyAuthIdsRow, map[cache.ScopedKey]cache.CacheHit, error) {
 	cacheKeys := array.Map(keyAuthIDs, func(keyAuthID string) cache.ScopedKey {
 		return cache.ScopedKey{
 			WorkspaceID: workspaceID,
@@ -301,10 +293,10 @@ func (h *Handler) fetchKeyAuthsByKeyAuthIds(ctx context.Context, workspaceID str
 	)
 }
 
-// extractAllowedAPIIds extracts API IDs from permissions
+// extractAPIIDsAllowed extracts API IDs from permissions
 // Returns empty slice if user has wildcard access (api.*.read_analytics)
 // Returns specific API IDs if user has limited access (api.api_123.read_analytics, etc.)
-func extractAllowedAPIIds(permissions []string) []string {
+func extractAPIIDsAllowed(permissions []string) []string {
 	if slices.Contains(permissions, "api.*.read_analytics") {
 		return nil
 	}


### PR DESCRIPTION
## Summary
- reject verification analytics queries above 16 KiB or 1,000 AST nodes before connection, cache, MySQL, or RBAC work
- cap user-controlled authorization fan-out at 10 unique key-space IDs and skip key-space resolution for wildcard principals
- extract literals from the complete original AST, including qualified, CTE, JOIN, reversed equality, `==`, and `GLOBAL IN` predicates
- fail closed for mixed missing/foreign/unauthorized IDs and query shapes where scoped RLS cannot be injected

## Security guarantees
- duplicates count once toward the 10-ID cap
- wildcard principals perform no API-to-key-space or key-space-to-API lookups
- foreign and missing key-space IDs remain externally indistinguishable
- scoped zero-ID analytics queries retain existing RLS-filtered behavior

## TDD evidence
Red failures were captured before implementation for parser complexity/extraction, the missing authorization-work validator, wildcard lookup behavior, pre-lookup 11-ID rejection, reversed equality bypasses, and scoped subquery RLS failure.

Green verification:
- `mise exec -- rask ./pkg/clickhouse/query-parser ./svc/api/routes/v2_analytics_get_verifications` (236 passed)
- `mise run build` (lint: 0 issues; build passed)

## Dependency / rebase note
This draft is based on `main`. It overlaps parser hardening in #6794 and should be rebased after that prior security PR lands; resolve parser conflicts while preserving both settings hardening and these pre-authorization bounds. This PR does not modify #6792.