### PR TITLE
fix(analytics): reject table-backed IN operands

### DIFF
--- a/pkg/clickhouse/query-parser/parser.go
+++ b/pkg/clickhouse/query-parser/parser.go
@@ -51,6 +51,10 @@ func (p *Parser) Parse(ctx context.Context, query string) (string, error) {
 	// Build CTE registry FIRST so we know which table references are CTEs
 	p.buildCTERegistry()
 
+	if err := p.validateMembershipOperands(); err != nil {
+		return "", err
+	}
+
 	// Inject security filters
 	p.injectSecurityFilters()
 	if err := p.rewriteTables(); err != nil {

--- a/pkg/clickhouse/query-parser/tables.go
+++ b/pkg/clickhouse/query-parser/tables.go
@@ -10,6 +10,82 @@ import (
 	"github.com/unkeyed/unkey/pkg/fault"
 )
 
+func (p *Parser) validateMembershipOperands() error {
+	var validationErr error
+
+	clickhouse.WalkWithBreak(p.stmt, func(node clickhouse.Expr) bool {
+		operation, ok := node.(*clickhouse.BinaryOperation)
+		if !ok || !isMembershipOperation(operation.Operation) {
+			return true
+		}
+
+		if rhs, ok := operation.RightExpr.(*clickhouse.ParamExprList); ok {
+			if isLiteralList(rhs) {
+				return true
+			}
+		}
+
+		validationErr = fault.New("IN-family right-hand operand not allowed",
+			fault.Code(codes.User.BadRequest.InvalidAnalyticsTable.URN()),
+			fault.Public("IN-family operators require a literal list; table, dynamic, and subquery operands are not allowed"),
+		)
+		return false
+	})
+
+	return validationErr
+}
+
+func isMembershipOperation(operation clickhouse.TokenKind) bool {
+	switch strings.ToUpper(string(operation)) {
+	case "IN", "NOT IN", "GLOBAL IN", "GLOBAL NOT IN":
+		return true
+	default:
+		return false
+	}
+}
+
+func isLiteralList(list *clickhouse.ParamExprList) bool {
+	if list.Items == nil || list.ColumnArgList != nil {
+		return false
+	}
+
+	for _, item := range list.Items.Items {
+		column, ok := item.(*clickhouse.ColumnExpr)
+		if !ok || column.Alias != nil || !isLiteral(column.Expr) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func isLiteral(expr clickhouse.Expr) bool {
+	switch literal := expr.(type) {
+	case *clickhouse.StringLiteral, *clickhouse.NumberLiteral, *clickhouse.BoolLiteral, *clickhouse.NullLiteral:
+		return true
+	case *clickhouse.Ident:
+		if literal.QuoteType != clickhouse.Unquoted {
+			return false
+		}
+		switch strings.ToUpper(literal.Name) {
+		case "TRUE", "FALSE", "NULL":
+			return true
+		default:
+			return false
+		}
+	case *clickhouse.UnaryExpr:
+		if literal.Kind != clickhouse.TokenKindPlus && literal.Kind != clickhouse.TokenKindMinus {
+			return false
+		}
+		_, ok := literal.Expr.(*clickhouse.NumberLiteral)
+		return ok
+	case *clickhouse.ParamExprList:
+		return isLiteralList(literal)
+	default:
+		return false
+	}
+}
+
 func (p *Parser) rewriteTables() error {
 	if p.stmt.From == nil || p.stmt.From.Expr == nil {
 		return fault.New("query must have FROM clause",

--- a/pkg/clickhouse/query-parser/tables_test.go
+++ b/pkg/clickhouse/query-parser/tables_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/codes"
+	"github.com/unkeyed/unkey/pkg/fault"
 )
 
 func TestParser_TableAliases(t *testing.T) {
@@ -80,6 +82,200 @@ func TestParser_AllowedTables(t *testing.T) {
 	_, err = p.Parse(context.Background(), "SELECT * FROM default.other_table")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "not allowed")
+}
+
+func TestParser_RejectsTableBackedMembershipOperands(t *testing.T) {
+	p := NewParser(Config{
+		WorkspaceID: "ws_123",
+		AllowedTables: []string{
+			"default.key_verifications_raw_v2",
+		},
+	})
+
+	for _, operator := range []string{"IN", "NOT IN", "GLOBAL IN", "GLOBAL NOT IN"} {
+		for _, table := range []string{"ratelimits_raw_v2", "default.ratelimits_raw_v2"} {
+			t.Run(operator+"_"+table, func(t *testing.T) {
+				query := "SELECT key_id FROM default.key_verifications_raw_v2 WHERE key_id " + operator + " " + table
+				_, err := p.Parse(context.Background(), query)
+
+				// A physical table on an IN-family RHS must be rejected before ClickHouse can read it.
+				require.Error(t, err)
+				code, ok := fault.GetCode(err)
+				require.True(t, ok)
+				if operator == "GLOBAL NOT IN" {
+					require.Equal(t, codes.User.BadRequest.InvalidAnalyticsQuery.URN(), code)
+				} else {
+					require.Equal(t, codes.User.BadRequest.InvalidAnalyticsTable.URN(), code)
+					require.Contains(t, err.Error(), "right-hand operand not allowed")
+				}
+			})
+		}
+	}
+}
+
+func TestParser_TableFamiliesCannotCrossViaMembershipRHS(t *testing.T) {
+	tests := map[string]struct {
+		allowedTable string
+		rhsTable     string
+	}{
+		"verifications cannot read ratelimits": {
+			allowedTable: "default.key_verifications_raw_v2",
+			rhsTable:     "default.ratelimits_raw_v2",
+		},
+		"ratelimits cannot read verifications": {
+			allowedTable: "default.ratelimits_raw_v2",
+			rhsTable:     "default.key_verifications_raw_v2",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			p := NewParser(Config{
+				WorkspaceID:   "ws_123",
+				AllowedTables: []string{test.allowedTable},
+			})
+
+			_, err := p.Parse(context.Background(), "SELECT workspace_id FROM "+test.allowedTable+" WHERE workspace_id IN "+test.rhsTable)
+
+			// Each analytics route's physical table family must remain isolated.
+			require.Error(t, err)
+			code, ok := fault.GetCode(err)
+			require.True(t, ok)
+			require.Equal(t, codes.User.BadRequest.InvalidAnalyticsTable.URN(), code)
+		})
+	}
+}
+
+func TestParser_RejectsTableBackedMembershipOperandsInEveryQueryShape(t *testing.T) {
+	p := NewParser(Config{
+		WorkspaceID: "ws_123",
+		AllowedTables: []string{
+			"default.key_verifications_raw_v2",
+		},
+	})
+
+	tests := map[string]string{
+		"nested": "SELECT * FROM (SELECT key_id FROM default.key_verifications_raw_v2 WHERE key_id IN default.ratelimits_raw_v2)",
+		"CTE":    "WITH ids AS (SELECT key_id FROM default.key_verifications_raw_v2 WHERE key_id NOT IN default.ratelimits_raw_v2) SELECT * FROM ids",
+		"UNION":  "SELECT key_id FROM default.key_verifications_raw_v2 UNION ALL SELECT key_id FROM default.key_verifications_raw_v2 WHERE key_id GLOBAL IN default.ratelimits_raw_v2",
+	}
+
+	for name, query := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := p.Parse(context.Background(), query)
+
+			// Nesting, CTEs, and UNION branches must not hide a table-backed RHS.
+			require.Error(t, err)
+			code, ok := fault.GetCode(err)
+			require.True(t, ok)
+			require.Equal(t, codes.User.BadRequest.InvalidAnalyticsTable.URN(), code)
+		})
+	}
+}
+
+func TestParser_RejectsDynamicMembershipOperands(t *testing.T) {
+	p := NewParser(Config{
+		WorkspaceID: "ws_123",
+		AllowedTables: []string{
+			"default.key_verifications_raw_v2",
+		},
+	})
+
+	for name, operand := range map[string]string{
+		"identifier":               "other_ids",
+		"path":                     "default.other_ids",
+		"placeholder":              "?",
+		"placeholder list":         "(?)",
+		"parameter":                "{ids:Array(String)}",
+		"backtick identifier":      "(`TRUE`)",
+		"double quoted identifier": `("FALSE")`,
+		"identifier in tuple":      "((`NULL`, 'VALID'))",
+	} {
+		t.Run(name, func(t *testing.T) {
+			query := "SELECT key_id FROM default.key_verifications_raw_v2 WHERE key_id IN " + operand
+			_, err := p.Parse(context.Background(), query)
+
+			// Dynamic RHS operands must not defer table selection or authorization to execution time.
+			require.Error(t, err)
+			code, ok := fault.GetCode(err)
+			require.True(t, ok)
+			require.Equal(t, codes.User.BadRequest.InvalidAnalyticsTable.URN(), code)
+		})
+	}
+}
+
+func TestParser_PreservesLiteralMembershipLists(t *testing.T) {
+	p := NewParser(Config{
+		WorkspaceID: "ws_123",
+		AllowedTables: []string{
+			"default.key_verifications_raw_v2",
+		},
+	})
+
+	tests := map[string]string{
+		"strings":        "key_id IN ('key_1', 'key_2')",
+		"numbers":        "key_id NOT IN (1, 2)",
+		"signed numbers": "key_id GLOBAL IN (-1, 0, 1)",
+		"booleans":       "key_id IN (TRUE, FALSE)",
+		"null":           "key_id IN (NULL, 'key_1')",
+		"tuples":         "(key_id, outcome) IN (('key_1', 'VALID'), ('key_2', 'INVALID'))",
+	}
+
+	for name, predicate := range tests {
+		t.Run(name, func(t *testing.T) {
+			output, err := p.Parse(context.Background(), "SELECT key_id FROM default.key_verifications_raw_v2 WHERE "+predicate)
+
+			// Literal lists are values, not table sources, and must remain supported.
+			require.NoError(t, err)
+			require.Contains(t, output, predicate)
+		})
+	}
+}
+
+func TestParser_RejectsMembershipSubqueries(t *testing.T) {
+	p := NewParser(Config{
+		WorkspaceID: "ws_123",
+		AllowedTables: []string{
+			"default.key_verifications_raw_v2",
+		},
+	})
+
+	tests := map[string]struct {
+		query        string
+		expectedCode codes.URN
+	}{
+		"SELECT": {
+			query:        "SELECT key_id FROM default.key_verifications_raw_v2",
+			expectedCode: codes.User.BadRequest.InvalidAnalyticsTable.URN(),
+		},
+		"nested": {
+			query:        "SELECT key_id FROM (SELECT key_id FROM default.key_verifications_raw_v2)",
+			expectedCode: codes.User.BadRequest.InvalidAnalyticsTable.URN(),
+		},
+		"CTE": {
+			query:        "WITH ids AS (SELECT key_id FROM default.key_verifications_raw_v2) SELECT key_id FROM ids",
+			expectedCode: codes.User.BadRequest.InvalidAnalyticsQuery.URN(),
+		},
+		"UNION": {
+			query:        "SELECT key_id FROM default.key_verifications_raw_v2 UNION ALL SELECT key_id FROM default.key_verifications_raw_v2",
+			expectedCode: codes.User.BadRequest.InvalidAnalyticsTable.URN(),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := p.Parse(context.Background(), "SELECT key_id FROM default.key_verifications_raw_v2 WHERE key_id IN ("+test.query+")")
+
+			// Subquery RHS sources are rejected until each source can be independently filtered.
+			require.Error(t, err)
+			code, ok := fault.GetCode(err)
+			require.True(t, ok)
+			require.Equal(t, test.expectedCode, code)
+			if code == codes.User.BadRequest.InvalidAnalyticsTable.URN() {
+				require.Contains(t, err.Error(), "right-hand operand not allowed")
+			}
+		})
+	}
 }
 
 func TestParser_BlockInformationSchema(t *testing.T) {

--- a/svc/api/routes/v2_analytics_get_verifications/400_test.go
+++ b/svc/api/routes/v2_analytics_get_verifications/400_test.go
@@ -131,6 +131,35 @@ func Test400_InvalidTable(t *testing.T) {
 	require.NotEmpty(t, res.Body.Error.Detail, "Error should have a descriptive message")
 }
 
+func Test400_TableBackedInRejectedBeforeExecution(t *testing.T) {
+	h := testutil.NewHarness(t, testutil.HarnessConfig{ClickHouse: true})
+
+	workspace := h.CreateWorkspace()
+	h.SetupAnalytics(workspace.ID)
+	rootKey := h.CreateRootKey(workspace.ID, "api.*.read_analytics")
+
+	route := &Handler{
+		DB:                         h.DB,
+		AnalyticsConnectionManager: h.AnalyticsConnectionManager,
+		Caches:                     h.Caches,
+	}
+	h.Register(route)
+
+	headers := http.Header{
+		"Authorization": []string{"Bearer " + rootKey},
+		"Content-Type":  []string{"application/json"},
+	}
+
+	res := testutil.CallRoute[Request, openapi.BadRequestErrorResponse](h, route, headers, Request{
+		Query: "SELECT key_id FROM key_verifications_v1 WHERE key_id IN default.ratelimits_raw_v2",
+	})
+
+	// The production-version ClickHouse test route must reject cross-family reads in the parser.
+	require.Equal(t, 400, res.Status)
+	require.NotNil(t, res.Body)
+	require.Contains(t, res.Body.Error.Type, "invalid_analytics_table")
+}
+
 func Test400_NonSelectQuery(t *testing.T) {
 	h := testutil.NewHarness(t, testutil.HarnessConfig{ClickHouse: true})
 


### PR DESCRIPTION
## Summary

- reject identifier, path, table, placeholder, parameter, and subquery RHS operands for IN-family operators before ClickHouse execution
- preserve scalar and tuple literal lists for IN, NOT IN, and GLOBAL IN; GLOBAL NOT IN remains rejected by the pinned SQL parser
- cover qualified/unqualified physical tables, nested/CTE/UNION placements, verification/rate-limit family isolation, and a live ClickHouse route rejection

## Why this matters

Each analytics endpoint is restricted to its own family of tables. ClickHouse treats `value IN table_name` like `value IN (SELECT * FROM table_name)`. Our parser validated tables used in `FROM`, but missed table names used after `IN`, so the route-specific table restriction could be bypassed.

An attacker could use that behavior as a blind existence check against another table. For example:

```sql
SELECT count()
FROM key_verifications_v1
WHERE (
  'req_123',
  1720000000000,
  'ws_victim',
  'ns_123',
  'customer@example.com',
  true,
  3.5,
  '',
  100,
  99,
  1720000060000,
  1
) IN default.ratelimits_raw_v2
```

The injected workspace and resource filters apply to `key_verifications_v1`, but previously did not apply to the table after `IN`. If the guessed rate-limit event exists, the condition is true and the query returns a nonzero count; otherwise it returns zero. Repeating this with different values lets an attacker probe data from a table the verification endpoint is not supposed to access. It also forces ClickHouse to read that unauthorized table.

This change rejects the table-backed operand before ClickHouse executes it. Normal literal lists remain valid:

```sql
SELECT key_id
FROM key_verifications_v1
WHERE key_id IN ('key_1', 'key_2')
```

## Security guarantee

Table-backed RHS expressions can no longer bypass the route-specific allowed-table family or injected resource filters. RHS subqueries are rejected explicitly until every source can be independently validated and filtered.

## TDD evidence

Red on main: the new parser exploit cases accepted IN, NOT IN, and GLOBAL IN table/path/identifier/placeholder/parameter operands; quoted identifiers also bypassed literal validation. Green on this branch: 228 parser tests and 25 verification analytics route tests pass.

## Verification

- `mise exec -- rask ./pkg/clickhouse/query-parser`
- `mise exec -- rask ./svc/api/routes/v2_analytics_get_verifications`
- `mise run build`

## Dependency and scope

This draft depends on SQL-SEC-001 being merged and this branch being rebased first if parser files overlap. PR #6792 is intentionally unchanged; its rate-limit route should inherit this shared parser guard after integration.
