### PR TITLE
test(db): demonstrate production schema gate

### DIFF
--- a/pkg/mysql/schema/quota.sql
+++ b/pkg/mysql/schema/quota.sql
@@ -15,6 +15,7 @@ CREATE TABLE `quota` (
 	`max_storage_mib_per_instance` int unsigned NOT NULL DEFAULT 10240,
 	`max_concurrent_builds` int unsigned NOT NULL DEFAULT 1,
 	`max_replicas_per_region` int unsigned NOT NULL DEFAULT 4,
+	`schema_gate_test` int,
 	CONSTRAINT `quota_pk` PRIMARY KEY(`pk`),
 	CONSTRAINT `quota_workspace_id_unique` UNIQUE(`workspace_id`)
 );

--- a/web/internal/db/src/schema/quota.ts
+++ b/web/internal/db/src/schema/quota.ts
@@ -123,6 +123,9 @@ export const quotas = mysqlTable("quota", {
   })
     .notNull()
     .default(4),
+
+  // Temporary column for proving that the production schema gate fails.
+  schemaGateTest: int("schema_gate_test"),
 });
 export const quotasRelations = relations(quotas, ({ one }) => ({
   workspace: one(workspaces, {


### PR DESCRIPTION
## Purpose

This stacked draft PR adds a temporary nullable `quota.schema_gate_test` column to prove that the database schema gate fails when the proposed Drizzle schema is not deployed to production.

## Expected result

`Database Schema Gate / Compare production schema` must fail and print the PlanetScale diff for `schema_gate_test`.

## Do not merge

This schema change is only a demonstration. Do not deploy it to PlanetScale and do not merge this PR. Close it after the failing check has been verified.

Stacked on #6796.
