### PR TITLE
fix: enforce atomic permission replacement

### DIFF
--- a/svc/api/routes/v2_keys_set_permissions/200_test.go
+++ b/svc/api/routes/v2_keys_set_permissions/200_test.go
@@ -1,9 +1,13 @@
 package handler_test
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
+	"slices"
 	"testing"
 	"time"
 
@@ -467,8 +471,8 @@ func TestSuccess(t *testing.T) {
 }
 
 // TestSetPermissionsConcurrent tests that concurrent requests to set permissions
-// on the same key don't deadlock. The handler uses SELECT ... FOR UPDATE
-// on the key row to serialize concurrent modifications.
+// on the same key don't deadlock. The key-row lock must serialize each replacement
+// transaction so the final state is one complete submitted set, never a partial or merge.
 func TestSetPermissionsConcurrent(t *testing.T) {
 	t.Parallel()
 
@@ -521,17 +525,29 @@ func TestSetPermissionsConcurrent(t *testing.T) {
 	})
 	require.Equal(t, 200, warmup.Status, "warmup request should succeed")
 
+	submittedPermissionSets := make([][]string, numConcurrent)
+	for i := range numConcurrent {
+		submittedPermissionSets[i] = []string{permissions[i], permissions[(i+1)%numConcurrent], permissions[(i+2)%numConcurrent]}
+	}
+
 	g := errgroup.Group{}
 	for i := range numConcurrent {
 		g.Go(func() error {
-			// Each request sets a different subset of permissions on the same key
-			req := handler.Request{
+			body, err := json.Marshal(handler.Request{
 				KeyId:       keyResponse.KeyID,
-				Permissions: []string{permissions[i], permissions[(i+1)%numConcurrent], permissions[(i+2)%numConcurrent]},
+				Permissions: submittedPermissionSets[i],
+			})
+			if err != nil {
+				return fmt.Errorf("request %d: marshal body: %w", i, err)
 			}
-			res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, req)
-			if res.Status != 200 {
-				return fmt.Errorf("request %d: unexpected status %d", i, res.Status)
+
+			req := httptest.NewRequest(route.Method(), route.Path(), bytes.NewReader(body))
+			req.Header = headers.Clone()
+			recorder := httptest.NewRecorder()
+			h.Mux().ServeHTTP(recorder, req)
+
+			if recorder.Code != http.StatusOK {
+				return fmt.Errorf("request %d: unexpected status %d: %s", i, recorder.Code, recorder.Body.String())
 			}
 			return nil
 		})
@@ -540,8 +556,19 @@ func TestSetPermissionsConcurrent(t *testing.T) {
 	err := g.Wait()
 	require.NoError(t, err, "All concurrent updates should succeed without deadlock")
 
-	// Verify the key has some permissions (exact count depends on which request won)
 	finalPermissions, err := db.Query.ListDirectPermissionsByKeyID(t.Context(), h.DB.RO(), keyResponse.KeyID)
 	require.NoError(t, err)
-	require.NotEmpty(t, finalPermissions)
+
+	finalPermissionNames := make([]string, len(finalPermissions))
+	for i, permission := range finalPermissions {
+		finalPermissionNames[i] = permission.Name
+	}
+	slices.Sort(finalPermissionNames)
+
+	matchesCompleteReplacement := slices.ContainsFunc(submittedPermissionSets, func(submitted []string) bool {
+		expected := slices.Clone(submitted)
+		slices.Sort(expected)
+		return slices.Equal(expected, finalPermissionNames)
+	})
+	require.Truef(t, matchesCompleteReplacement, "final permissions must exactly match one submitted replacement, got %v", finalPermissionNames)
 }

--- a/svc/api/routes/v2_keys_set_permissions/handler.go
+++ b/svc/api/routes/v2_keys_set_permissions/handler.go
@@ -119,14 +119,6 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	currentPermissions, err := db.Query.ListDirectPermissionsByKeyID(ctx, h.DB.RO(), req.KeyId)
-	if err != nil {
-		return fault.Wrap(err,
-			fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
-			fault.Internal("database error"), fault.Public("Failed to retrieve current permissions."),
-		)
-	}
-
 	foundPermissions, err := db.Query.FindPermissionsBySlugs(ctx, h.DB.RO(), db.FindPermissionsBySlugsParams{
 		WorkspaceID: principal.WorkspaceID,
 		Slugs:       req.Permissions,
@@ -194,31 +186,11 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		})
 	}
 
-	currentPermissionMap := make(map[string]db.Permission)
-	for _, permission := range currentPermissions {
-		currentPermissionMap[permission.ID] = permission
-	}
-
 	requestedPermissionIDs := make(map[string]bool)
 	requestedPermissionMap := make(map[string]db.Permission)
 	for _, permission := range permissionsToSet {
 		requestedPermissionIDs[permission.ID] = true
 		requestedPermissionMap[permission.ID] = permission
-	}
-
-	permissionsToRemove := make([]string, 0)
-	for _, permission := range currentPermissions {
-		if !requestedPermissionIDs[permission.ID] {
-			permissionsToRemove = append(permissionsToRemove, permission.ID)
-		}
-	}
-
-	permissionsToAdd := make([]db.Permission, 0)
-	for _, permission := range permissionsToSet {
-		_, ok := currentPermissionMap[permission.ID]
-		if !ok {
-			permissionsToAdd = append(permissionsToAdd, permission)
-		}
 	}
 
 	err = db.TxRetry(ctx, h.DB.RW(), func(ctx context.Context, tx db.DBTX) error {
@@ -229,6 +201,34 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 				fault.Internal("unable to lock key"),
 				fault.Public("We're unable to update the key."),
 			)
+		}
+
+		currentPermissions, err := db.Query.ListDirectPermissionsByKeyID(ctx, tx, req.KeyId)
+		if err != nil {
+			return fault.Wrap(err,
+				fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
+				fault.Internal("database error"), fault.Public("Failed to retrieve current permissions."),
+			)
+		}
+
+		currentPermissionMap := make(map[string]db.Permission)
+		for _, permission := range currentPermissions {
+			currentPermissionMap[permission.ID] = permission
+		}
+
+		permissionsToRemove := make([]string, 0)
+		for _, permission := range currentPermissions {
+			if !requestedPermissionIDs[permission.ID] {
+				permissionsToRemove = append(permissionsToRemove, permission.ID)
+			}
+		}
+
+		permissionsToAdd := make([]db.Permission, 0)
+		for _, permission := range permissionsToSet {
+			_, ok := currentPermissionMap[permission.ID]
+			if !ok {
+				permissionsToAdd = append(permissionsToAdd, permission)
+			}
 		}
 
 		var auditLogs []auditlog.AuditLog


### PR DESCRIPTION
There was a race when a user would set permissions concurrently

```text
request A wants [A, B, C]
request B wants [D, E, F]
result: [A, B, C, D, E, F]
```

By moving everything into the transaction, we can ensure, that the last writer wins and the resulting permissions are either `[A, B, C]` or `[D, E, F]`


