### PR TITLE
refactor: make heartbeat client provider agnostic

### DIFF
--- a/dev/.env.webhooks.example
+++ b/dev/.env.webhooks.example
@@ -1,5 +1,5 @@
 # Webhooks for health monitoring and notifications (optional)
 # Copy this to .env.webhooks to enable
-UNKEY_QUOTA_CHECK_HEARTBEAT_URL=https://ping.checklyhq.com/your-quota-check-id
-UNKEY_CERT_RENEWAL_HEARTBEAT_URL=https://ping.checklyhq.com/your-cert-renewal-id
+UNKEY_QUOTA_CHECK_HEARTBEAT_URL=https://monitoring.example.com/your-quota-check-id
+UNKEY_CERT_RENEWAL_HEARTBEAT_URL=https://monitoring.example.com/your-cert-renewal-id
 UNKEY_QUOTA_CHECK_SLACK_WEBHOOK_URL=https://hooks.slack.com/services/your/webhook/url

--- a/pkg/healthcheck/doc.go
+++ b/pkg/healthcheck/doc.go
@@ -1,13 +1,12 @@
 // Package healthcheck provides push-based health monitoring for scheduled tasks.
 //
-// This package implements heartbeat clients for external monitoring services like
-// Checkly. Heartbeats are sent after successful task completion to signal that
-// scheduled jobs are running correctly.
+// Heartbeats are sent to external monitoring services after successful task
+// completion to signal that scheduled jobs are running correctly.
 //
 // Basic usage:
 //
-//	// Create a Checkly heartbeat client
-//	hb := healthcheck.NewChecklyHeartbeat("https://ping.checklyhq.com/abc123")
+//	// Create an HTTP heartbeat client
+//	hb := healthcheck.NewHTTPHeartbeat("https://monitoring.example.com/heartbeat")
 //
 //	// Send heartbeat after successful task completion
 //	if err := hb.Ping(ctx); err != nil {
@@ -17,6 +16,6 @@
 //	// Use Noop for testing or when no heartbeat URL is configured
 //	var hb healthcheck.Heartbeat = healthcheck.NewNoop()
 //	if heartbeatURL != "" {
-//	    hb = healthcheck.NewChecklyHeartbeat(heartbeatURL)
+//	    hb = healthcheck.NewHTTPHeartbeat(heartbeatURL)
 //	}
 package healthcheck

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestChecklyHeartbeat_Ping(t *testing.T) {
+func TestHTTPHeartbeat_Ping(t *testing.T) {
 	tests := []struct {
 		name       string
 		statusCode int
@@ -45,7 +45,7 @@ func TestChecklyHeartbeat_Ping(t *testing.T) {
 			}))
 			defer server.Close()
 
-			hb := NewChecklyHeartbeat(server.URL)
+			hb := NewHTTPHeartbeat(server.URL)
 			err := hb.Ping(context.Background())
 
 			if tt.wantErr {
@@ -57,8 +57,8 @@ func TestChecklyHeartbeat_Ping(t *testing.T) {
 	}
 }
 
-func TestChecklyHeartbeat_EmptyURL(t *testing.T) {
-	hb := NewChecklyHeartbeat("")
+func TestHTTPHeartbeat_EmptyURL(t *testing.T) {
+	hb := NewHTTPHeartbeat("")
 	err := hb.Ping(context.Background())
 	require.Error(t, err)
 }
@@ -70,6 +70,6 @@ func TestNoop_Ping(t *testing.T) {
 }
 
 func TestImplementsHeartbeat(t *testing.T) {
-	var _ Heartbeat = (*ChecklyHeartbeat)(nil)
+	var _ Heartbeat = (*HTTPHeartbeat)(nil)
 	var _ Heartbeat = (*Noop)(nil)
 }

--- a/pkg/healthcheck/http.go
+++ b/pkg/healthcheck/http.go
@@ -7,22 +7,22 @@ import (
 	"time"
 )
 
-// ChecklyHeartbeat sends heartbeats to Checkly monitoring service.
-type ChecklyHeartbeat struct {
+// HTTPHeartbeat sends heartbeats to an HTTP endpoint.
+type HTTPHeartbeat struct {
 	url    string
 	client *http.Client
 }
 
-// NewChecklyHeartbeat creates a new Checkly heartbeat client.
-func NewChecklyHeartbeat(url string) *ChecklyHeartbeat {
-	return &ChecklyHeartbeat{
+// NewHTTPHeartbeat creates a heartbeat client for an HTTP endpoint.
+func NewHTTPHeartbeat(url string) *HTTPHeartbeat {
+	return &HTTPHeartbeat{
 		url:    url,
 		client: &http.Client{Timeout: 10 * time.Second},
 	}
 }
 
-// Ping sends a heartbeat to Checkly.
-func (c *ChecklyHeartbeat) Ping(ctx context.Context) (err error) {
+// Ping sends a heartbeat to the configured endpoint.
+func (c *HTTPHeartbeat) Ping(ctx context.Context) (err error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.url, nil)
 	if err != nil {
 		return fmt.Errorf("create request: %w", err)

--- a/svc/ctrl/worker/config.go
+++ b/svc/ctrl/worker/config.go
@@ -156,48 +156,48 @@ type GitHubConfig struct {
 	AllowUnauthenticatedDeployments bool `toml:"allow_unauthenticated_deployments"`
 }
 
-// HeartbeatConfig holds Checkly heartbeat URLs for health monitoring.
+// HeartbeatConfig holds heartbeat URLs for health monitoring.
 type HeartbeatConfig struct {
-	// CertRenewalURL is the Checkly heartbeat URL for certificate renewal.
+	// CertRenewalURL is the heartbeat URL for certificate renewal.
 	// When set, a heartbeat is sent after successful certificate renewal runs.
 	// Optional - if empty, no heartbeat is sent.
 	CertRenewalURL string `toml:"cert_renewal_url"`
 
-	// QuotaCheckURL is the Checkly heartbeat URL for quota checks.
+	// QuotaCheckURL is the heartbeat URL for quota checks.
 	// When set, a heartbeat is sent after successful quota check runs.
 	// Optional - if empty, no heartbeat is sent.
 	QuotaCheckURL string `toml:"quota_check_url"`
 
-	// KeyRefillURL is the Checkly heartbeat URL for key refill runs.
+	// KeyRefillURL is the heartbeat URL for key refill runs.
 	// When set, a heartbeat is sent after successful key refill runs.
 	// Optional - if empty, no heartbeat is sent.
 	KeyRefillURL string `toml:"key_refill_url"`
 
-	// KeyLastUsedSyncURL is the Checkly heartbeat URL for key last-used sync runs.
+	// KeyLastUsedSyncURL is the heartbeat URL for key last-used sync runs.
 	// When set, a heartbeat is sent after successful sync runs.
 	// Optional - if empty, no heartbeat is sent.
 	KeyLastUsedSyncURL string `toml:"key_last_used_sync_url"`
 
-	// AuditLogExportURL is the Checkly heartbeat URL for audit log export runs.
+	// AuditLogExportURL is the heartbeat URL for audit log export runs.
 	// When set, a heartbeat is sent after successful drains of the MySQL outbox
 	// into ClickHouse. Optional - if empty, no heartbeat is sent.
 	AuditLogExportURL string `toml:"audit_log_export_url"`
 
-	// AuditLogOutboxCleanupURL is the Checkly heartbeat URL for the daily sweep
+	// AuditLogOutboxCleanupURL is the heartbeat URL for the daily sweep
 	// that hard-deletes exported clickhouse_outbox rows past the retention
 	// window. When set, a heartbeat is sent after a successful sweep.
 	// Optional - if empty, no heartbeat is sent.
 	AuditLogOutboxCleanupURL string `toml:"audit_log_outbox_cleanup_url"`
 
-	// DeployBillingPushURL is the Checkly heartbeat URL for the hourly Deploy
+	// DeployBillingPushURL is the heartbeat URL for the hourly Deploy
 	// billing push. When set, a heartbeat is sent after a successful push.
 	// Optional - if empty, no heartbeat is sent.
 	DeployBillingPushURL string `toml:"deploy_billing_push_url"`
-	// DeployBillingCloseURL is the Checkly heartbeat URL for the month-end
+	// DeployBillingCloseURL is the heartbeat URL for the month-end
 	// Deploy billing close. Optional.
 	DeployBillingCloseURL string `toml:"deploy_billing_close_url"`
 
-	// DeploySpendCheckURL is the Checkly heartbeat URL for the Compute spend-cap
+	// DeploySpendCheckURL is the heartbeat URL for the Compute spend-cap
 	// check orchestrator. When set, a heartbeat is sent after a successful run.
 	// Optional - if empty, no heartbeat is sent.
 	DeploySpendCheckURL string `toml:"deploy_spend_check_url"`
@@ -298,7 +298,7 @@ type Config struct {
 	// GitHub configures GitHub App integration for webhook-triggered deployments.
 	GitHub *GitHubConfig `toml:"github"`
 
-	// Heartbeat configures Checkly heartbeat URLs for health monitoring.
+	// Heartbeat configures heartbeat URLs for health monitoring.
 	Heartbeat HeartbeatConfig `toml:"heartbeat"`
 
 	// Slack configures Slack webhook URLs for notifications.

--- a/svc/ctrl/worker/run.go
+++ b/svc/ctrl/worker/run.go
@@ -441,7 +441,7 @@ func Run(ctx context.Context, cfg Config) error {
 	// which can take 5-10 minutes for DNS propagation
 	var certHeartbeat healthcheck.Heartbeat = healthcheck.NewNoop()
 	if cfg.Heartbeat.CertRenewalURL != "" {
-		certHeartbeat = healthcheck.NewChecklyHeartbeat(cfg.Heartbeat.CertRenewalURL)
+		certHeartbeat = healthcheck.NewHTTPHeartbeat(cfg.Heartbeat.CertRenewalURL)
 	}
 	restateSrv.Bind(hydrav1.NewCertificateServiceServer(certificate.New(certificate.Config{
 		DB:            database,
@@ -766,12 +766,12 @@ func Run(ctx context.Context, cfg Config) error {
 	return nil
 }
 
-// cronHeartbeat returns a Checkly heartbeat for url, or a noop if url is
-// empty. Used to wire each cron task's monitoring URL without scattering
-// nil-or-noop branches through the cron service.
+// cronHeartbeat returns an HTTP heartbeat for url, or a noop if url is empty.
+// Used to wire each cron task's monitoring URL without scattering nil-or-noop
+// branches through the cron service.
 func cronHeartbeat(url string) healthcheck.Heartbeat {
 	if url == "" {
 		return healthcheck.NewNoop()
 	}
-	return healthcheck.NewChecklyHeartbeat(url)
+	return healthcheck.NewHTTPHeartbeat(url)
 }


### PR DESCRIPTION
Make heartbeats provider agnostic.

We're moving from checkly to incident.io, so I want to clear these up before it causes confusion.