### PR TITLE
docs: update deployment beta instructions

### DIFF
--- a/docs/product/snippets/deploy-beta.mdx
+++ b/docs/product/snippets/deploy-beta.mdx
@@ -1,7 +1,8 @@
 <Info>
-  Deploying applications on Unkey is in public beta. To try it, open the product switcher in the
-  top-left of the dashboard and select **Deploy**. During beta, deployed
-  resources are free. We're eager for feedback, so let us know what you think
-  on [Discord](https://unkey.com/discord), [X](https://x.com/unkeydev), or
-  email [support@unkey.com](mailto:support@unkey.com).
+  Deploying applications on Unkey is in public beta. To try it, select
+  **Projects** in the dashboard sidebar and create a project. Deployed
+  resources are free until August 1, 2026. We're eager for feedback, so let us
+  know what you think on [Discord](https://unkey.com/discord),
+  [X](https://x.com/unkeydev), or email
+  [support@unkey.com](mailto:support@unkey.com).
 </Info>


### PR DESCRIPTION
## Summary

- direct users to create a project from the dashboard sidebar
- clarify that deployed resources are free until August 1, 2026

## Verification

- `git diff --check`