### PR TITLE
feat(dashboard): estimated Compute bill and always-on usage

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/deploy-product-card.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/deploy-product-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { priceDeployMetersCents } from "@/lib/billing/deployPricing";
+import { DEPLOY_METER_RATE_LABELS, priceDeployMetersCents } from "@/lib/billing/deployPricing";
 import { formatCompactQuantity, formatDollars } from "@/lib/fmt";
 import type { DeployPlan } from "@/lib/stripe/deployPlan";
 import { trpc } from "@/lib/trpc/client";
@@ -18,6 +18,11 @@ import {
 import { ADMIN_ONLY_TOOLTIP } from "./constants";
 import { ProductCard } from "./product-card";
 import { SpendManagement } from "./spend-management";
+
+/** Matches the billing summary strip's period formatting, e.g. "Aug 1". */
+function formatRenewalDate(millis: number): string {
+  return new Date(millis).toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
 
 type DeployProductCardProps = {
   isAdmin: boolean;
@@ -56,6 +61,13 @@ export const DeployProductCard: React.FC<DeployProductCardProps> = ({
 
   const { data: deployCredit } = trpc.stripe.getDeployCredit.useQuery(undefined, {
     enabled: Boolean(currentPlan),
+    staleTime: 30_000,
+  });
+
+  // For the renewal date. The billing summary strip already fetches this, so on
+  // this page it's a cache hit.
+  const { data: upcomingInvoice } = trpc.stripe.getUpcomingInvoice.useQuery(undefined, {
+    enabled: Boolean(currentPlan) && hasPaymentMethod,
     staleTime: 30_000,
   });
 
@@ -131,19 +143,63 @@ export const DeployProductCard: React.FC<DeployProductCardProps> = ({
   // which is the steady-state (full clean month) value.
   const includedCreditCents = deployCredit?.includedCreditCents ?? planFee;
 
-  // Estimated bill: the plan fee plus usage beyond the included credits. "This
-  // month" prices month-to-date usage; "projected" prices usage extrapolated to
-  // month end. Both use the same local pricing as the spend bar and the spend
-  // cap, so the numbers on the card never disagree.
+  // The plan fee actually invoiced for THIS period, which after a mid-cycle
+  // change is the prorated amount, not the catalog price. grantDeployCreditsForInvoice
+  // grants credit equal to netDeployFee, so the period's grant is the fee it was
+  // charged for: reading the fee off the grant keeps this period's total honest
+  // without a second Stripe round-trip. Falls back to the catalog fee when there
+  // is no grant to read (query still in flight, or a grant the webhook never
+  // wrote) so a missing grant understates the credit rather than the fee.
+  const periodFeeCents =
+    includedCreditCents !== null && includedCreditCents > 0 ? includedCreditCents : planFee;
+
+  // A mid-cycle plan change prorates both the fee and the credit, so this
+  // period's numbers are not the catalog ones. Say so rather than quoting a full
+  // period the customer has not been billed for yet.
+  const feeProrated = periodFeeCents !== null && planFee !== null && periodFeeCents !== planFee;
+
+  // Usage beyond the included credit: the only usage-driven charge on the bill,
+  // and the only part of this period still to come. The credit is not a discount
+  // applied to usage, it is the allowance the period's fee already paid for.
+  const overageCents =
+    usageAmount !== null && includedCreditCents !== null
+      ? Math.max(0, usageAmount - includedCreditCents)
+      : null;
+  // Headroom left in the allowance. Shown instead of a "credit applied" line:
+  // the credit is not a discount that grows with usage, so the useful number is
+  // what is left of it, and it keeps the plan picker's credit vocabulary on the
+  // card without implying the credit is subtracted from the total.
+  const creditRemainingCents =
+    usageAmount !== null && includedCreditCents !== null
+      ? Math.max(0, includedCreditCents - usageAmount)
+      : null;
+
   const projectedAmount = usage?.projectedGrossCents ?? null;
+  const projectedOverageCents =
+    projectedAmount !== null && includedCreditCents !== null
+      ? Math.max(0, projectedAmount - includedCreditCents)
+      : null;
+
+  // What this period costs in total: the fee it was invoiced plus whatever usage
+  // spills past the included credit. "Projected" prices usage extrapolated to
+  // period end, using the same local pricing as the spend bar and the spend cap,
+  // so the numbers on the card never disagree.
   const currentBillCents =
-    planFee !== null && includedCreditCents !== null && usageAmount !== null
-      ? planFee + Math.max(0, usageAmount - includedCreditCents)
-      : null;
-  const projectedBillCents =
-    planFee !== null && includedCreditCents !== null && projectedAmount !== null
-      ? planFee + Math.max(0, projectedAmount - includedCreditCents)
-      : null;
+    periodFeeCents !== null && overageCents !== null ? periodFeeCents + overageCents : null;
+
+  // The metered usage for a period bills on the invoice that finalizes at the
+  // start of the next one (see EXPIRY_GRACE_SECONDS), so period end is both the
+  // renewal date and when this period's overage lands.
+  const renewsAtMillis = upcomingInvoice?.deploy?.periodEnd ?? null;
+
+  // What the next invoice charges: this period's overage plus the next period's
+  // full fee, the two things that land on the same document. Stripe's own preview
+  // is authoritative (it applies the credit and any proration we don't model), so
+  // prefer it and fall back to the local sum when it hasn't loaded or the
+  // workspace has no payment method yet.
+  const nextInvoiceCents =
+    upcomingInvoice?.deploy?.total ??
+    (overageCents !== null && planFee !== null ? overageCents + planFee : null);
 
   // Price each meter locally (same rates as the spend bar) so every usage line
   // shows what it contributes to the bill; the parts sum to the gross above.
@@ -227,8 +283,10 @@ export const DeployProductCard: React.FC<DeployProductCardProps> = ({
         badge={currentPlan && suspended ? <ComputePausedBadge /> : undefined}
         subtitle={
           currentPlan
-            ? planFee !== null
-              ? `${formatDollars(planFee)}/${currentPlanOption?.interval ?? "month"}, includes ${formatDollars(planFee)} of usage credits`
+            ? planFee !== null && includedCreditCents !== null
+              ? feeProrated
+                ? `${formatDollars(planFee)}/${currentPlanOption?.interval ?? "month"}, prorated to ${formatDollars(includedCreditCents)} of fee and credits for this period`
+                : `${formatDollars(planFee)}/${currentPlanOption?.interval ?? "month"}, includes ${formatDollars(planFee)} of usage credits`
               : "The plan fee includes usage credits; usage beyond them is billed on top."
             : "Run and scale your projects. Every plan includes usage credits equal to its fee."
         }
@@ -303,47 +361,134 @@ export const DeployProductCard: React.FC<DeployProductCardProps> = ({
                 ))}
               </div>
             ) : null}
-            {currentBillCents !== null && planFee !== null && includedCreditCents !== null ? (
+            {currentBillCents !== null &&
+            planFee !== null &&
+            periodFeeCents !== null &&
+            includedCreditCents !== null &&
+            overageCents !== null ? (
               <div className="flex flex-col gap-1.5">
-                {/* Reconcile the bill: plan fee plus gross usage less the
-                    included credit equals the total. Usage is shown gross (the
-                    same figure the spend limit plots) so the card never shows
-                    two different usage numbers; the credit is its own line
-                    instead of being pre-subtracted into usage. */}
+                {/* Reconcile the next invoice, because that is the number people
+                    open this page to find, and it is the one Stripe shows: this
+                    period's overage plus the next period's full fee, the two
+                    charges that land on the same document. Only those two rows are
+                    money owed, so only they carry normal weight. This period's fee
+                    and credit balance are context, dimmed, and marked paid: they
+                    explain where the overage came from without reading as charges,
+                    which is what made a prorated period look like it undercharged.
+                    The credit reads as what is LEFT rather than what was applied,
+                    because a credit subtracted from a total is the reading that
+                    makes a $0 line look like a missing grant. */}
                 <div className="flex items-baseline justify-between gap-4">
-                  <span className="text-[13px] text-gray-10">Plan fee</span>
-                  <span className="text-[13px] text-gray-11 tabular-nums">
-                    {formatDollars(planFee)}
+                  <span className="text-[13px] text-gray-10">
+                    Plan fee
+                    {feeProrated ? (
+                      <span className="ml-1.5 text-[12px] text-gray-9">prorated</span>
+                    ) : null}
+                  </span>
+                  <span className="text-[13px] text-gray-9 tabular-nums">
+                    {formatDollars(periodFeeCents)} paid
                   </span>
                 </div>
                 <div className="flex items-baseline justify-between gap-4">
                   <span className="text-[13px] text-gray-10">Usage</span>
-                  <span className="text-[13px] text-gray-11 tabular-nums">
+                  <span className="text-[13px] text-gray-9 tabular-nums">
                     {formatDollars(usageAmount ?? 0)}
                   </span>
                 </div>
-                {includedCreditCents > 0 ? (
+                {includedCreditCents > 0 && creditRemainingCents !== null ? (
                   <div className="flex items-baseline justify-between gap-4">
                     <span className="text-[13px] text-gray-10">Included credit</span>
-                    <span className="text-[13px] text-gray-11 tabular-nums">
-                      -{formatDollars(Math.min(usageAmount ?? 0, includedCreditCents))}
+                    <span className="text-[13px] text-gray-9 tabular-nums">
+                      {formatDollars(creditRemainingCents)} of {formatDollars(includedCreditCents)}{" "}
+                      remaining
                     </span>
                   </div>
                 ) : null}
-                <div className="mt-1 flex items-baseline justify-between gap-4 border-grayA-3 border-t pt-2">
-                  <span className="text-[13px] text-gray-12">Estimated bill this month</span>
-                  <span className="font-medium text-[15px] text-gray-12 tabular-nums">
-                    {formatDollars(currentBillCents)}
+                {includedCreditCents > 0 ? (
+                  <div className="mt-1 flex items-baseline justify-between gap-4 border-grayA-3 border-t pt-2">
+                    <span className="text-[13px] text-gray-10">
+                      Overage
+                      <span className="ml-1.5 text-[12px] text-gray-9">usage past credit</span>
+                    </span>
+                    <span className="text-[13px] text-gray-11 tabular-nums">
+                      {formatDollars(overageCents)}
+                    </span>
+                  </div>
+                ) : null}
+                <div className="flex items-baseline justify-between gap-4">
+                  <span className="text-[13px] text-gray-10">
+                    Next plan fee
+                    <span className="ml-1.5 text-[12px] text-gray-9">
+                      {currentPlanOption?.interval ?? "month"} ahead
+                    </span>
+                  </span>
+                  <span className="text-[13px] text-gray-11 tabular-nums">
+                    {formatDollars(planFee)}
                   </span>
                 </div>
-                {projectedBillCents !== null && projectedBillCents > currentBillCents ? (
-                  <div className="flex items-baseline justify-between gap-4">
-                    <span className="text-[12px] text-gray-10">Projected by month end</span>
-                    <span className="text-[12px] text-gray-11 tabular-nums">
-                      ~{formatDollars(projectedBillCents)}
-                    </span>
-                  </div>
-                ) : null}
+                <div className="mt-1 flex items-baseline justify-between gap-4 border-grayA-3 border-t pt-2">
+                  <span className="text-[13px] text-gray-12">
+                    <InfoTooltip
+                      asChild
+                      position={{ side: "top", align: "start" }}
+                      content={
+                        <div className="flex max-w-[240px] flex-col gap-2 text-[12px]">
+                          <div className="flex flex-col gap-0.5">
+                            <p className="font-medium text-gray-12">How this is calculated</p>
+                            <p className="text-gray-11">
+                              This period's {formatDollars(periodFeeCents)} fee is already invoiced
+                              and covers {formatDollars(includedCreditCents)} of usage. The next
+                              invoice charges what your usage went past that, plus the coming
+                              period's fee.
+                            </p>
+                            <p className="text-gray-11 tabular-nums">
+                              {formatDollars(overageCents)} + {formatDollars(planFee)} ={" "}
+                              {formatDollars(nextInvoiceCents ?? overageCents + planFee)}
+                            </p>
+                          </div>
+                          <div className="flex flex-col gap-1 border-grayA-4 border-t pt-2">
+                            <p className="font-medium text-gray-12">Usage rates</p>
+                            <ul className="flex flex-col gap-0.5">
+                              {DEPLOY_METER_RATE_LABELS.map((r) => (
+                                <li
+                                  key={r.label}
+                                  className="flex justify-between gap-3 text-gray-11"
+                                >
+                                  <span>{r.label}</span>
+                                  <span className="tabular-nums">{r.rate}</span>
+                                </li>
+                              ))}
+                            </ul>
+                          </div>
+                        </div>
+                      }
+                    >
+                      <span className="cursor-help underline decoration-dotted decoration-grayA-6 underline-offset-2">
+                        Next invoice
+                        {renewsAtMillis !== null ? ` · ${formatRenewalDate(renewsAtMillis)}` : ""}
+                      </span>
+                    </InfoTooltip>
+                    {/* Projected adds the usage still expected before the period
+                        closes, since the overage row only counts what has accrued. */}
+                    {projectedOverageCents !== null &&
+                    overageCents !== null &&
+                    nextInvoiceCents !== null &&
+                    projectedOverageCents > overageCents ? (
+                      <span className="ml-1.5 text-[12px] text-gray-9">
+                        (~
+                        {formatDollars(nextInvoiceCents + (projectedOverageCents - overageCents))}{" "}
+                        projected)
+                      </span>
+                    ) : null}
+                  </span>
+                  <span className="font-medium text-[15px] text-gray-12 tabular-nums">
+                    {nextInvoiceCents !== null ? formatDollars(nextInvoiceCents) : "—"}
+                  </span>
+                </div>
+                <p className="text-[12px] text-gray-9">
+                  This period's {formatDollars(periodFeeCents)} fee is already paid. Total cost for
+                  this period is {formatDollars(currentBillCents)}.
+                </p>
               </div>
             ) : null}
             <SpendManagement usageCents={usageAmount} isAdmin={isAdmin} />

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/deploy-product-card.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/deploy-product-card.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { formatDollars, formatQuantity } from "@/lib/fmt";
+import { priceDeployMetersCents } from "@/lib/billing/deployPricing";
+import { formatCompactQuantity, formatDollars } from "@/lib/fmt";
 import type { DeployPlan } from "@/lib/stripe/deployPlan";
 import { trpc } from "@/lib/trpc/client";
 import { Cube } from "@unkey/icons";
@@ -52,6 +53,11 @@ export const DeployProductCard: React.FC<DeployProductCardProps> = ({
 
   const { data: budget } = trpc.billing.getDeployBudget.useQuery(undefined, { staleTime: 30_000 });
   const suspended = budget?.suspended ?? false;
+
+  const { data: deployCredit } = trpc.stripe.getDeployCredit.useQuery(undefined, {
+    enabled: Boolean(currentPlan),
+    staleTime: 30_000,
+  });
 
   // Usage is only worth fetching (and rendering) once there is a plan.
   const { data: usage } = trpc.billing.queryDeployUsage.useQuery(undefined, {
@@ -115,40 +121,68 @@ export const DeployProductCard: React.FC<DeployProductCardProps> = ({
   // worker prices it, so the budget bar tracks what the cap enforces.
   const usageAmount = usage?.grossCents ?? null;
 
-  // The plan's recurring fee and its equal monthly credits, from the plan
-  // catalog. The fee includes credits of the same amount, so the two are equal.
+  // The plan's recurring fee, from the plan catalog.
   const planFee = currentPlanOption?.amount ?? null;
-  const credits = planFee;
 
-  const meterStats = usage
-    ? [
-        {
-          label: "CPU",
-          value: `${formatQuantity(usage.cpuSeconds / 3600)} hrs`,
-          hint: "vCPU time your workloads ran, totalled across the period.",
-        },
-        {
-          label: "Memory",
-          value: `${formatQuantity(usage.memoryGiBHours)} GiB-hrs`,
-          hint: "Memory allocated over time, in GiB-hours. 1 GiB held for 1 hour is 1 GiB-hour.",
-        },
-        {
-          label: "Egress",
-          value: `${formatQuantity(usage.egressGiB)} GiB`,
-          hint: "Data your workloads sent out over the public network this period.",
-        },
-        {
-          label: "Disk",
-          value: `${formatQuantity(usage.diskGiBHours)} GiB-hrs`,
-          hint: "Disk reserved over time, in GiB-hours. 1 GiB reserved for 1 hour is 1 GiB-hour. Charged on size reserved, not reads, writes, or space used.",
-        },
-        {
-          label: "Active keys",
-          value: formatQuantity(usage.activeKeys),
-          hint: "Distinct keys verified through the Deploy gateway this period.",
-        },
-      ]
-    : null;
+  // Included usage credit for the current period, from Stripe (cached). A
+  // mid-cycle plan change prorates the grant, so the credit is not always equal
+  // to the catalog fee; reading the granted amount is what keeps the estimate
+  // matching the invoice. Falls back to the plan fee before the query resolves,
+  // which is the steady-state (full clean month) value.
+  const includedCreditCents = deployCredit?.includedCreditCents ?? planFee;
+
+  // Estimated bill: the plan fee plus usage beyond the included credits. "This
+  // month" prices month-to-date usage; "projected" prices usage extrapolated to
+  // month end. Both use the same local pricing as the spend bar and the spend
+  // cap, so the numbers on the card never disagree.
+  const projectedAmount = usage?.projectedGrossCents ?? null;
+  const currentBillCents =
+    planFee !== null && includedCreditCents !== null && usageAmount !== null
+      ? planFee + Math.max(0, usageAmount - includedCreditCents)
+      : null;
+  const projectedBillCents =
+    planFee !== null && includedCreditCents !== null && projectedAmount !== null
+      ? planFee + Math.max(0, projectedAmount - includedCreditCents)
+      : null;
+
+  // Price each meter locally (same rates as the spend bar) so every usage line
+  // shows what it contributes to the bill; the parts sum to the gross above.
+  const meterCosts = usage ? priceDeployMetersCents(usage) : null;
+  const meterStats =
+    usage && meterCosts
+      ? [
+          {
+            label: "CPU",
+            value: `${formatCompactQuantity(usage.cpuSeconds / 3600)} hrs`,
+            cost: meterCosts.cpu,
+            hint: "vCPU time your workloads ran, totalled across the period.",
+          },
+          {
+            label: "Memory",
+            value: `${formatCompactQuantity(usage.memoryGiBHours)} GiB-hrs`,
+            cost: meterCosts.memory,
+            hint: "Memory allocated over time, in GiB-hours. 1 GiB held for 1 hour is 1 GiB-hour.",
+          },
+          {
+            label: "Egress",
+            value: `${formatCompactQuantity(usage.egressGiB)} GiB`,
+            cost: meterCosts.egress,
+            hint: "Data your workloads sent out over the public network this period.",
+          },
+          {
+            label: "Disk",
+            value: `${formatCompactQuantity(usage.diskGiBHours)} GiB-hrs`,
+            cost: meterCosts.disk,
+            hint: "Disk reserved over time, in GiB-hours. 1 GiB reserved for 1 hour is 1 GiB-hour. Charged on size reserved, not reads, writes, or space used.",
+          },
+          {
+            label: "Active keys",
+            value: formatCompactQuantity(usage.activeKeys),
+            cost: meterCosts.activeKeys,
+            hint: "Distinct keys verified through the Deploy gateway this period.",
+          },
+        ]
+      : null;
 
   const submittingPlan = subscribe.isLoading
     ? (subscribe.variables?.plan ?? null)
@@ -157,10 +191,10 @@ export const DeployProductCard: React.FC<DeployProductCardProps> = ({
       : null;
 
   const selectLabel = (option: (typeof plans)[number]): string => {
-    if (!currentPlan || credits === null || option.amount === null) {
+    if (!currentPlan || planFee === null || option.amount === null) {
       return "Select";
     }
-    return option.amount > credits ? "Upgrade" : "Downgrade";
+    return option.amount > planFee ? "Upgrade" : "Downgrade";
   };
 
   const warningFor = (option: (typeof plans)[number]): string | null =>
@@ -262,8 +296,54 @@ export const DeployProductCard: React.FC<DeployProductCardProps> = ({
                     <p className="font-medium text-[13px] text-gray-12 tabular-nums">
                       {stat.value}
                     </p>
+                    <p className="text-[12px] text-gray-10 tabular-nums">
+                      {formatDollars(stat.cost)}
+                    </p>
                   </div>
                 ))}
+              </div>
+            ) : null}
+            {currentBillCents !== null && planFee !== null && includedCreditCents !== null ? (
+              <div className="flex flex-col gap-1.5">
+                {/* Reconcile the bill: plan fee plus gross usage less the
+                    included credit equals the total. Usage is shown gross (the
+                    same figure the spend limit plots) so the card never shows
+                    two different usage numbers; the credit is its own line
+                    instead of being pre-subtracted into usage. */}
+                <div className="flex items-baseline justify-between gap-4">
+                  <span className="text-[13px] text-gray-10">Plan fee</span>
+                  <span className="text-[13px] text-gray-11 tabular-nums">
+                    {formatDollars(planFee)}
+                  </span>
+                </div>
+                <div className="flex items-baseline justify-between gap-4">
+                  <span className="text-[13px] text-gray-10">Usage</span>
+                  <span className="text-[13px] text-gray-11 tabular-nums">
+                    {formatDollars(usageAmount ?? 0)}
+                  </span>
+                </div>
+                {includedCreditCents > 0 ? (
+                  <div className="flex items-baseline justify-between gap-4">
+                    <span className="text-[13px] text-gray-10">Included credit</span>
+                    <span className="text-[13px] text-gray-11 tabular-nums">
+                      -{formatDollars(Math.min(usageAmount ?? 0, includedCreditCents))}
+                    </span>
+                  </div>
+                ) : null}
+                <div className="mt-1 flex items-baseline justify-between gap-4 border-grayA-3 border-t pt-2">
+                  <span className="text-[13px] text-gray-12">Estimated bill this month</span>
+                  <span className="font-medium text-[15px] text-gray-12 tabular-nums">
+                    {formatDollars(currentBillCents)}
+                  </span>
+                </div>
+                {projectedBillCents !== null && projectedBillCents > currentBillCents ? (
+                  <div className="flex items-baseline justify-between gap-4">
+                    <span className="text-[12px] text-gray-10">Projected by month end</span>
+                    <span className="text-[12px] text-gray-11 tabular-nums">
+                      ~{formatDollars(projectedBillCents)}
+                    </span>
+                  </div>
+                ) : null}
               </div>
             ) : null}
             <SpendManagement usageCents={usageAmount} isAdmin={isAdmin} />

--- a/web/apps/dashboard/lib/billing/deployPricing.test.ts
+++ b/web/apps/dashboard/lib/billing/deployPricing.test.ts
@@ -1,5 +1,44 @@
 import { describe, expect, it } from "vitest";
-import { microCentsToCents, priceDeployUsageMicroCents } from "./deployPricing";
+import {
+  type DeployMeterRates,
+  type DeployUsageQuantities,
+  MICRO_CENTS_PER_CENT,
+  microCentsToCents,
+  priceDeployMetersCents,
+  priceDeployUsageMicroCents,
+  projectDeployUsage,
+} from "./deployPricing";
+
+describe("priceDeployMetersCents", () => {
+  it("prices each meter on its own", () => {
+    const costs = priceDeployMetersCents({
+      cpuSeconds: 3600,
+      memoryGiBHours: 10,
+      diskGiBHours: 100,
+      egressGiB: 2,
+      activeKeys: 5,
+    });
+    expect(costs.cpu).toBeCloseTo(3600 * 0.0006944, 6);
+    expect(costs.memory).toBeCloseTo(10 * 3600 * 0.0003472, 6);
+    expect(costs.egress).toBeCloseTo(2 * 5.0, 6);
+    expect(costs.disk).toBeCloseTo(100 * 3600 * 0.000006, 6);
+    expect(costs.activeKeys).toBeCloseTo(5 * 0.2, 6);
+  });
+
+  it("parts sum to the gross the spend bar shows, within sub-cent rounding", () => {
+    const usage: DeployUsageQuantities = {
+      cpuSeconds: 12_345,
+      memoryGiBHours: 678.9,
+      diskGiBHours: 2_596.7,
+      egressGiB: 43.3,
+      activeKeys: 7,
+    };
+    const costs = priceDeployMetersCents(usage);
+    const partsSum = costs.cpu + costs.memory + costs.egress + costs.disk + costs.activeKeys;
+    const gross = priceDeployUsageMicroCents(usage) / MICRO_CENTS_PER_CENT;
+    expect(partsSum).toBeCloseTo(gross, 4);
+  });
+});
 
 describe("priceDeployUsageMicroCents", () => {
   it("prices zero usage as zero", () => {
@@ -77,5 +116,57 @@ describe("priceDeployUsageMicroCents", () => {
 describe("microCentsToCents", () => {
   it("truncates sub-cent fractions for display", () => {
     expect(microCentsToCents(4_711_499_999)).toBe(4_711);
+  });
+});
+
+describe("projectDeployUsage", () => {
+  const DAY = 24 * 60 * 60 * 1000;
+  const trailingWindowMs = 7 * DAY;
+
+  const mtd: DeployUsageQuantities = {
+    cpuSeconds: 100,
+    memoryGiBHours: 20,
+    diskGiBHours: 10,
+    egressGiB: 5,
+    activeKeys: 42,
+  };
+  const trailing: DeployMeterRates = {
+    cpuSeconds: 70,
+    memoryGiBHours: 14,
+    diskGiBHours: 7,
+    egressGiB: 3.5,
+  };
+
+  it("adds the trailing run-rate applied over the remaining period", () => {
+    // 21 days remaining is 3x the 7-day trailing window, so add 3x trailing.
+    const projected = projectDeployUsage(mtd, trailing, trailingWindowMs, 21 * DAY);
+    expect(projected.cpuSeconds).toBe(100 + 70 * 3);
+    expect(projected.memoryGiBHours).toBe(20 + 14 * 3);
+    expect(projected.diskGiBHours).toBe(10 + 7 * 3);
+    expect(projected.egressGiB).toBe(5 + 3.5 * 3);
+  });
+
+  it("holds active keys flat, since a distinct count is not a rate", () => {
+    const projected = projectDeployUsage(mtd, trailing, trailingWindowMs, 21 * DAY);
+    expect(projected.activeKeys).toBe(42);
+  });
+
+  it("returns month-to-date unchanged when no time remains", () => {
+    expect(projectDeployUsage(mtd, trailing, trailingWindowMs, 0)).toEqual(mtd);
+    expect(projectDeployUsage(mtd, trailing, trailingWindowMs, -DAY)).toEqual(mtd);
+  });
+
+  it("returns month-to-date unchanged with no trailing window", () => {
+    expect(projectDeployUsage(mtd, trailing, 0, 21 * DAY)).toEqual(mtd);
+  });
+
+  it("adds nothing when the trailing window saw no usage", () => {
+    const idle: DeployMeterRates = {
+      cpuSeconds: 0,
+      memoryGiBHours: 0,
+      diskGiBHours: 0,
+      egressGiB: 0,
+    };
+    expect(projectDeployUsage(mtd, idle, trailingWindowMs, 21 * DAY)).toEqual(mtd);
   });
 });

--- a/web/apps/dashboard/lib/billing/deployPricing.test.ts
+++ b/web/apps/dashboard/lib/billing/deployPricing.test.ts
@@ -7,6 +7,7 @@ import {
   priceDeployMetersCents,
   priceDeployUsageMicroCents,
   projectDeployUsage,
+  sumDeployMeterCents,
 } from "./deployPricing";
 
 describe("priceDeployMetersCents", () => {
@@ -37,6 +38,53 @@ describe("priceDeployMetersCents", () => {
     const partsSum = costs.cpu + costs.memory + costs.egress + costs.disk + costs.activeKeys;
     const gross = priceDeployUsageMicroCents(usage) / MICRO_CENTS_PER_CENT;
     expect(partsSum).toBeCloseTo(gross, 4);
+  });
+});
+
+describe("sumDeployMeterCents", () => {
+  /**
+   * Quantities from a real Stripe invoice preview, whose usage lines rounded to
+   * 794 + 15873 + 265 + 69 cents for a $170.01 subtotal. Rounding each meter
+   * before summing reproduces that; summing the exact amounts and rounding once
+   * lands on $170.00, a cent under the invoice.
+   */
+  const invoiceUsage: DeployUsageQuantities = {
+    cpuSeconds: 1_142_941.51892,
+    memoryGiBHours: 45_717_656.0512 / 3600,
+    diskGiBHours: 11_429_400 / 3600,
+    egressGiB: 52.9138888894,
+    activeKeys: 0,
+  };
+
+  it("rounds each meter before summing, matching the invoice", () => {
+    expect(sumDeployMeterCents(invoiceUsage)).toBe(17_001);
+  });
+
+  it("differs from rounding the exact total once", () => {
+    expect(microCentsToCents(priceDeployUsageMicroCents(invoiceUsage))).toBe(16_999);
+  });
+
+  it("agrees with the per-meter figures shown beside it", () => {
+    const costs = priceDeployMetersCents(invoiceUsage);
+    const shown =
+      Math.round(costs.cpu) +
+      Math.round(costs.memory) +
+      Math.round(costs.egress) +
+      Math.round(costs.disk) +
+      Math.round(costs.activeKeys);
+    expect(sumDeployMeterCents(invoiceUsage)).toBe(shown);
+  });
+
+  it("prices zero usage as zero", () => {
+    expect(
+      sumDeployMeterCents({
+        cpuSeconds: 0,
+        memoryGiBHours: 0,
+        diskGiBHours: 0,
+        egressGiB: 0,
+        activeKeys: 0,
+      }),
+    ).toBe(0);
   });
 });
 

--- a/web/apps/dashboard/lib/billing/deployPricing.ts
+++ b/web/apps/dashboard/lib/billing/deployPricing.ts
@@ -40,3 +40,69 @@ export function priceDeployUsageMicroCents(usage: DeployUsageQuantities): number
 export function microCentsToCents(microCents: number): number {
   return Math.floor(microCents / MICRO_CENTS_PER_CENT);
 }
+
+/** Per-meter spend in cents, so the card can show what each usage line costs. */
+export type DeployMeterCostsCents = {
+  cpu: number;
+  memory: number;
+  egress: number;
+  disk: number;
+  activeKeys: number;
+};
+
+/**
+ * Prices each meter on its own, using the same per-unit rates as
+ * priceDeployUsageMicroCents, so the usage row can attribute a dollar figure to
+ * every line. The parts sum to the gross the spend bar shows within sub-cent
+ * rounding. Cents are kept fractional; formatDollars rounds them for display.
+ */
+export function priceDeployMetersCents(usage: DeployUsageQuantities): DeployMeterCostsCents {
+  return {
+    cpu: usage.cpuSeconds * CENTS_PER_CPU_SECOND,
+    memory: usage.memoryGiBHours * SECONDS_PER_HOUR * CENTS_PER_MEMORY_GIB_SECOND,
+    egress: usage.egressGiB * CENTS_PER_EGRESS_GIB,
+    disk: usage.diskGiBHours * SECONDS_PER_HOUR * CENTS_PER_DISK_GIB_SECOND,
+    activeKeys: usage.activeKeys * CENTS_PER_ACTIVE_KEY,
+  };
+}
+
+/** The duration meters, which accrue at a rate set by what's currently deployed. */
+export type DeployMeterRates = {
+  cpuSeconds: number;
+  memoryGiBHours: number;
+  diskGiBHours: number;
+  egressGiB: number;
+};
+
+/**
+ * Projects usage to the end of the billing period: what has accrued so far plus
+ * a trailing-window run-rate applied over the time remaining. The rate comes
+ * from a recent window rather than the whole period so a mid-period scale-up
+ * isn't diluted by idle early days, and an almost-empty period start doesn't
+ * blow the number up.
+ *
+ * The four duration meters (cpu, memory, disk, egress) project on their rate.
+ * Active keys is a distinct-key count, not a rate, so it is held flat at its
+ * month-to-date value. Returns month-to-date unchanged when there is no time
+ * left or no trailing window to derive a rate from.
+ */
+export function projectDeployUsage(
+  monthToDate: DeployUsageQuantities,
+  trailing: DeployMeterRates,
+  trailingWindowMs: number,
+  remainingMs: number,
+): DeployUsageQuantities {
+  if (trailingWindowMs <= 0 || remainingMs <= 0) {
+    return monthToDate;
+  }
+  // Fraction of the trailing window that the remaining period represents: the
+  // trailing usage scaled to that span is the projected additional usage.
+  const scale = remainingMs / trailingWindowMs;
+  return {
+    cpuSeconds: monthToDate.cpuSeconds + trailing.cpuSeconds * scale,
+    memoryGiBHours: monthToDate.memoryGiBHours + trailing.memoryGiBHours * scale,
+    diskGiBHours: monthToDate.diskGiBHours + trailing.diskGiBHours * scale,
+    egressGiB: monthToDate.egressGiB + trailing.egressGiB * scale,
+    activeKeys: monthToDate.activeKeys,
+  };
+}

--- a/web/apps/dashboard/lib/billing/deployPricing.ts
+++ b/web/apps/dashboard/lib/billing/deployPricing.ts
@@ -10,6 +10,15 @@ const SECONDS_PER_HOUR = 3600;
 /** Same fixed-point scale as deploybilling.MicroCentsPerCent. */
 export const MICRO_CENTS_PER_CENT = 1_000_000;
 
+/** Display rates for the billing tooltip; keep in sync with the constants above. */
+export const DEPLOY_METER_RATE_LABELS = [
+  { label: "CPU", rate: "$0.025 / vCPU-hr" },
+  { label: "Memory", rate: "$0.0125 / GiB-hr" },
+  { label: "Egress", rate: "$0.05 / GiB" },
+  { label: "Disk", rate: "$0.00022 / GiB-hr" },
+  { label: "Active keys", rate: "$0.002 / key" },
+] as const;
+
 export type DeployUsageQuantities = {
   cpuSeconds: number;
   memoryGiBHours: number;
@@ -39,6 +48,30 @@ export function priceDeployUsageMicroCents(usage: DeployUsageQuantities): number
 /** Converts micro-cents to whole cents for formatDollars and the spend budget bar. */
 export function microCentsToCents(microCents: number): number {
   return Math.floor(microCents / MICRO_CENTS_PER_CENT);
+}
+
+/**
+ * Total usage in whole cents the way Stripe invoices it: each meter is priced
+ * and rounded to a cent on its own line, then the lines are summed.
+ *
+ * Summing the exact amounts and rounding once (microCentsToCents over
+ * priceDeployUsageMicroCents) is off by a cent or two against the invoice,
+ * because it never materializes the per-line rounding Stripe applies. The
+ * difference is small but it is the difference between a bill estimate that
+ * matches the invoice and one that is always a hair under it, and it is also
+ * what makes the per-meter figures on the card add up to the total shown beside
+ * them. priceDeployUsageMicroCents stays the fixed-point path for the spend cap,
+ * which compares against a budget rather than reproducing an invoice.
+ */
+export function sumDeployMeterCents(usage: DeployUsageQuantities): number {
+  const costs = priceDeployMetersCents(usage);
+  return (
+    Math.round(costs.cpu) +
+    Math.round(costs.memory) +
+    Math.round(costs.egress) +
+    Math.round(costs.disk) +
+    Math.round(costs.activeKeys)
+  );
 }
 
 /** Per-meter spend in cents, so the card can show what each usage line costs. */

--- a/web/apps/dashboard/lib/fmt.test.ts
+++ b/web/apps/dashboard/lib/fmt.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { formatCompactQuantity } from "./fmt";
+
+describe("formatCompactQuantity", () => {
+  it("compacts thousands with a lowercase k to ~3 significant figures", () => {
+    expect(formatCompactQuantity(10_386.7)).toBe("10.4k");
+    expect(formatCompactQuantity(2_596.7)).toBe("2.6k");
+    expect(formatCompactQuantity(12_345)).toBe("12.3k");
+  });
+
+  it("leaves sub-thousand values as-is", () => {
+    expect(formatCompactQuantity(259.7)).toBe("259.7");
+    expect(formatCompactQuantity(43.3)).toBe("43.3");
+    expect(formatCompactQuantity(0)).toBe("0");
+  });
+
+  it("keeps uppercase M for millions", () => {
+    expect(formatCompactQuantity(1_250_000)).toBe("1.3M");
+  });
+});

--- a/web/apps/dashboard/lib/fmt.ts
+++ b/web/apps/dashboard/lib/fmt.ts
@@ -3,8 +3,19 @@ export function formatNumber(n: number): string {
 }
 
 /** Grouped number with up to one decimal: 1234.5 -> "1,234.5". For usage quantities. */
-export function formatQuantity(value: number): string {
-  return new Intl.NumberFormat("en-US", { maximumFractionDigits: 1 }).format(value);
+/**
+ * Compact quantity for dense usage readouts, kept to ~3 significant figures so
+ * big meters stay legible: 10,386.7 -> "10.4k", 2,596.7 -> "2.6k", while small
+ * values like 43.3 are unchanged. SI-style lowercase "k" for thousands; larger
+ * magnitudes keep Intl's uppercase M/B/T.
+ */
+export function formatCompactQuantity(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    notation: "compact",
+    maximumFractionDigits: 1,
+  })
+    .format(value)
+    .replace(/K$/, "k");
 }
 
 export function formatPrice(price: number) {

--- a/web/apps/dashboard/lib/stripe/deployCredits.test.ts
+++ b/web/apps/dashboard/lib/stripe/deployCredits.test.ts
@@ -1,7 +1,11 @@
 import type Stripe from "stripe";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { DeployBillingConfig } from "./deployBilling";
-import { grantDeployCreditsForInvoice, netDeployFee } from "./deployCredits";
+import {
+  deployIncludedCreditCents,
+  grantDeployCreditsForInvoice,
+  netDeployFee,
+} from "./deployCredits";
 
 vi.mock("./deployBilling", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./deployBilling")>();
@@ -119,6 +123,70 @@ describe("netDeployFee", () => {
     // invoice-level coupons this way): the grant tracks the $40 actually paid.
     const fee = netDeployFee(config, [line("price_fee_business", 5000, 1_700_000_000, 1000)]);
     expect(fee?.amountCents).toBe(4000);
+  });
+});
+
+describe("deployIncludedCreditCents", () => {
+  const future = Math.floor(Date.now() / 1000) + 30 * 24 * 3600;
+  const past = Math.floor(Date.now() / 1000) - 30 * 24 * 3600;
+
+  // A credit grant as creditGrants.list yields it: metered scope, an expiry,
+  // and a monetary value.
+  function grant(value: number, expiresAt: number | null, priceType = "metered") {
+    return {
+      id: `credgrant_${value}_${expiresAt}`,
+      expires_at: expiresAt,
+      amount: { monetary: { value } },
+      applicability_config: { scope: { price_type: priceType } },
+    };
+  }
+
+  function stripeWith(grants: ReturnType<typeof grant>[]): Stripe {
+    return {
+      billing: {
+        creditGrants: {
+          list: vi.fn().mockReturnValue(
+            (async function* () {
+              for (const g of grants) {
+                yield g;
+              }
+            })(),
+          ),
+        },
+      },
+    } as unknown as Stripe;
+  }
+
+  it("returns 0 when the customer has no active credit", async () => {
+    expect(await deployIncludedCreditCents(stripeWith([]), "cus_x")).toBe(0);
+  });
+
+  it("sums the current period's grants (baseline plus upgrade top-up)", async () => {
+    // One period's grants share an expires_at: a subscribe baseline and an
+    // upgrade top-up both expire together and both count.
+    const cents = await deployIncludedCreditCents(
+      stripeWith([grant(3000, future), grant(2000, future)]),
+      "cus_x",
+    );
+    expect(cents).toBe(5000);
+  });
+
+  it("ignores expired grants and other price scopes", async () => {
+    const cents = await deployIncludedCreditCents(
+      stripeWith([grant(5000, future), grant(9999, past), grant(4000, future, "licensed")]),
+      "cus_x",
+    );
+    expect(cents).toBe(5000);
+  });
+
+  it("takes only the latest period during the post-period grace overlap", async () => {
+    // Near a boundary the previous period's grant is briefly still unexpired;
+    // the current period's is the later expiry, so only it counts.
+    const cents = await deployIncludedCreditCents(
+      stripeWith([grant(1672, future - 3 * 24 * 3600), grant(5000, future)]),
+      "cus_x",
+    );
+    expect(cents).toBe(5000);
   });
 });
 

--- a/web/apps/dashboard/lib/stripe/deployCredits.ts
+++ b/web/apps/dashboard/lib/stripe/deployCredits.ts
@@ -230,7 +230,10 @@ export async function deployIncludedCreditCents(
 ): Promise<number> {
   const nowSeconds = Date.now() / 1000;
   const centsByExpiry = new Map<number, number>();
-  for await (const grant of stripe.billing.creditGrants.list({ customer: customerId, limit: 100 })) {
+  for await (const grant of stripe.billing.creditGrants.list({
+    customer: customerId,
+    limit: 100,
+  })) {
     if (grant.applicability_config?.scope?.price_type !== "metered") {
       continue;
     }

--- a/web/apps/dashboard/lib/stripe/deployCredits.ts
+++ b/web/apps/dashboard/lib/stripe/deployCredits.ts
@@ -206,3 +206,44 @@ export async function grantDeployCreditsForInvoice(
     periodTotalCents: periodTotalCents + fee.amountCents,
   };
 }
+
+/**
+ * The Deploy usage credit currently included for a customer, in cents: the sum
+ * of their active metered credit grants for the current plan period.
+ *
+ * This is the allowance the estimated bill nets usage against. Reading it from
+ * Stripe (rather than assuming it equals the catalog plan fee) is what makes
+ * the card's estimate match the invoice: a mid-cycle plan change grants only
+ * the prorated net fee ([[grantDeployCreditsForInvoice]]), so the catalog fee
+ * would overstate the credit and under-report the bill.
+ *
+ * A period's grants (baseline plus any upgrade top-ups) share one expires_at,
+ * and the current period's is the latest among unexpired grants. Summing only
+ * that group avoids double-counting a previous period's grant during the short
+ * post-period grace window, when both are briefly unexpired. Grants are roughly
+ * one per month, so this is a page or two even for long-tenured customers.
+ * Returns 0 when there is no active credit.
+ */
+export async function deployIncludedCreditCents(
+  stripe: Stripe,
+  customerId: string,
+): Promise<number> {
+  const nowSeconds = Date.now() / 1000;
+  const centsByExpiry = new Map<number, number>();
+  for await (const grant of stripe.billing.creditGrants.list({ customer: customerId, limit: 100 })) {
+    if (grant.applicability_config?.scope?.price_type !== "metered") {
+      continue;
+    }
+    const expiresAt = grant.expires_at;
+    if (expiresAt === null || expiresAt <= nowSeconds) {
+      continue;
+    }
+    const value = grant.amount.monetary?.value ?? 0;
+    centsByExpiry.set(expiresAt, (centsByExpiry.get(expiresAt) ?? 0) + value);
+  }
+  if (centsByExpiry.size === 0) {
+    return 0;
+  }
+  const currentPeriodExpiry = Math.max(...centsByExpiry.keys());
+  return centsByExpiry.get(currentPeriodExpiry) ?? 0;
+}

--- a/web/apps/dashboard/lib/trpc/routers/billing/query-deploy-usage/index.ts
+++ b/web/apps/dashboard/lib/trpc/routers/billing/query-deploy-usage/index.ts
@@ -1,8 +1,18 @@
-import { microCentsToCents, priceDeployUsageMicroCents } from "@/lib/billing/deployPricing";
+import {
+  microCentsToCents,
+  priceDeployUsageMicroCents,
+  projectDeployUsage,
+} from "@/lib/billing/deployPricing";
 import { clickhouse } from "@/lib/clickhouse";
 import { ratelimit, withRatelimit, workspaceProcedure } from "@/lib/trpc/trpc";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
+
+/**
+ * Window whose average run-rate we extrapolate to the period end. Recent enough
+ * that it reflects what is currently deployed, long enough to smooth spikes.
+ */
+const TRAILING_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
 
 export const queryDeployUsageResponse = z.object({
   cpuSeconds: z.number(),
@@ -12,6 +22,12 @@ export const queryDeployUsageResponse = z.object({
   activeKeys: z.number(),
   /** Month-to-date gross usage priced locally (cents), same math as the spend-cap worker. */
   grossCents: z.number(),
+  /**
+   * Gross usage projected to the end of the calendar month (cents): month-to-date
+   * plus the trailing-window run-rate over the remaining days. A forecast for
+   * display, not a billed figure.
+   */
+  projectedGrossCents: z.number(),
 });
 
 export type DeployUsageResponse = z.infer<typeof queryDeployUsageResponse>;
@@ -26,14 +42,17 @@ export const queryDeployUsage = workspaceProcedure
   .output(queryDeployUsageResponse)
   .query(async ({ ctx }) => {
     const now = new Date();
+    const nowMs = now.getTime();
     const monthStart = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1);
+    // First instant of next month; the exclusive end of the current one.
+    const monthEnd = Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1);
 
     try {
-      const [meters, keys] = await Promise.all([
+      const [meters, keys, trailing] = await Promise.all([
         clickhouse.billing.deployMeterUsage({
           workspaceId: ctx.workspace.id,
           start: monthStart,
-          end: now.getTime(),
+          end: nowMs,
         }),
         clickhouse.billing.activeKeysUsage({
           workspaceId: ctx.workspace.id,
@@ -41,20 +60,38 @@ export const queryDeployUsage = workspaceProcedure
           // getUTCMonth is 0-based; the query takes a calendar month.
           month: now.getUTCMonth() + 1,
         }),
+        // Trailing window for the projection's run-rate; may reach into last
+        // month early in the period, which is fine, it's just a rate estimate.
+        clickhouse.billing.deployMeterUsage({
+          workspaceId: ctx.workspace.id,
+          start: nowMs - TRAILING_WINDOW_MS,
+          end: nowMs,
+        }),
       ]);
 
-      const grossMicroCents = priceDeployUsageMicroCents({
+      const monthToDate = {
         cpuSeconds: meters.cpuSeconds,
         memoryGiBHours: meters.memoryGiBHours,
         diskGiBHours: meters.diskGiBHours,
         egressGiB: meters.egressGiB,
         activeKeys: keys.activeKeys,
-      });
+      };
+
+      const grossMicroCents = priceDeployUsageMicroCents(monthToDate);
+
+      const projected = projectDeployUsage(
+        monthToDate,
+        trailing,
+        TRAILING_WINDOW_MS,
+        monthEnd - nowMs,
+      );
+      const projectedMicroCents = priceDeployUsageMicroCents(projected);
 
       return {
         ...meters,
         activeKeys: keys.activeKeys,
         grossCents: microCentsToCents(grossMicroCents),
+        projectedGrossCents: microCentsToCents(projectedMicroCents),
       };
     } catch (err) {
       console.error("Failed to query deploy usage", err);

--- a/web/apps/dashboard/lib/trpc/routers/billing/query-deploy-usage/index.ts
+++ b/web/apps/dashboard/lib/trpc/routers/billing/query-deploy-usage/index.ts
@@ -1,8 +1,4 @@
-import {
-  microCentsToCents,
-  priceDeployUsageMicroCents,
-  projectDeployUsage,
-} from "@/lib/billing/deployPricing";
+import { projectDeployUsage, sumDeployMeterCents } from "@/lib/billing/deployPricing";
 import { clickhouse } from "@/lib/clickhouse";
 import { ratelimit, withRatelimit, workspaceProcedure } from "@/lib/trpc/trpc";
 import { TRPCError } from "@trpc/server";
@@ -20,7 +16,10 @@ export const queryDeployUsageResponse = z.object({
   diskGiBHours: z.number(),
   egressGiB: z.number(),
   activeKeys: z.number(),
-  /** Month-to-date gross usage priced locally (cents), same math as the spend-cap worker. */
+  /**
+   * Month-to-date gross usage priced locally (cents), rounded per meter the way
+   * the invoice is, so this matches the usage lines Stripe bills.
+   */
   grossCents: z.number(),
   /**
    * Gross usage projected to the end of the calendar month (cents): month-to-date
@@ -77,21 +76,20 @@ export const queryDeployUsage = workspaceProcedure
         activeKeys: keys.activeKeys,
       };
 
-      const grossMicroCents = priceDeployUsageMicroCents(monthToDate);
-
       const projected = projectDeployUsage(
         monthToDate,
         trailing,
         TRAILING_WINDOW_MS,
         monthEnd - nowMs,
       );
-      const projectedMicroCents = priceDeployUsageMicroCents(projected);
 
+      // Priced per meter and rounded per line, the way the invoice is built, so
+      // the card's estimate matches what Stripe charges. See sumDeployMeterCents.
       return {
         ...meters,
         activeKeys: keys.activeKeys,
-        grossCents: microCentsToCents(grossMicroCents),
-        projectedGrossCents: microCentsToCents(projectedMicroCents),
+        grossCents: sumDeployMeterCents(monthToDate),
+        projectedGrossCents: sumDeployMeterCents(projected),
       };
     } catch (err) {
       console.error("Failed to query deploy usage", err);

--- a/web/apps/dashboard/lib/trpc/routers/index.ts
+++ b/web/apps/dashboard/lib/trpc/routers/index.ts
@@ -193,6 +193,7 @@ import { createSubscription } from "./stripe/createSubscription";
 import { getBillingInfo } from "./stripe/getBillingInfo";
 import { getCheckoutSession } from "./stripe/getCheckoutSession";
 import { getCustomer } from "./stripe/getCustomer";
+import { getDeployCredit } from "./stripe/getDeployCredit";
 import { getDeployEntitlement } from "./stripe/getDeployEntitlement";
 import { getDeployPlans } from "./stripe/getDeployPlans";
 import { getDeploySubscription } from "./stripe/getDeploySubscription";
@@ -315,6 +316,7 @@ export const router = t.router({
     seedTestCustomer,
     getDeploySubscription,
     getDeployPlans,
+    getDeployCredit,
     getDeployEntitlement,
     getUpcomingInvoice,
   }),

--- a/web/apps/dashboard/lib/trpc/routers/stripe/getDeployCredit.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/getDeployCredit.ts
@@ -1,0 +1,48 @@
+import { getStripeClient } from "@/lib/stripe";
+import { deployIncludedCreditCents } from "@/lib/stripe/deployCredits";
+import { ratelimit, withRatelimit, workspaceProcedure } from "@/lib/trpc/trpc";
+import { z } from "zod";
+
+const creditSchema = z.object({
+  /**
+   * Included Deploy usage credit for the current period (cents), or null when
+   * the workspace has no Stripe customer. The Deploy card nets month-to-date
+   * usage against this to estimate the bill.
+   */
+  includedCreditCents: z.number().nullable(),
+});
+
+/**
+ * Included credit changes about once a month (renewal) plus on plan changes, so
+ * a short server-side cache keeps repeated dashboard loads off Stripe's
+ * creditGrants API without letting a plan change read stale for long. Keyed per
+ * customer; the process-local Map mirrors the resolution cache in deployBilling.
+ */
+const CACHE_TTL_MS = 60 * 1000;
+const cache = new Map<string, { expiresAt: number; cents: number }>();
+
+/**
+ * The workspace's currently-included Deploy usage credit, read from Stripe's
+ * credit grants and cached. See [[deployIncludedCreditCents]] for why this is
+ * the granted amount (prorated on mid-cycle changes), not the catalog plan fee.
+ */
+export const getDeployCredit = workspaceProcedure
+  .use(withRatelimit(ratelimit.read))
+  .output(creditSchema)
+  .query(async ({ ctx }) => {
+    const customerId = ctx.workspace.stripeCustomerId;
+    if (!customerId) {
+      return { includedCreditCents: null };
+    }
+
+    const now = Date.now();
+    const hit = cache.get(customerId);
+    if (hit && hit.expiresAt > now) {
+      return { includedCreditCents: hit.cents };
+    }
+
+    const stripe = getStripeClient();
+    const cents = await deployIncludedCreditCents(stripe, customerId);
+    cache.set(customerId, { expiresAt: now + CACHE_TTL_MS, cents });
+    return { includedCreditCents: cents };
+  });


### PR DESCRIPTION
**Problem:**

 We only show current monthly usage when having a spend budget enabled, it would be nice to see how much you spend regardless tho

**Solution:**

 Always show the current monthly spend and also show a predicted monthly usaged based on what we've collected

**Impact:**

UI looks a bit different now breaking down usage and showing an estimation total for eom
<img width="3550" height="1420" alt="CleanShot 2026-07-22 at 17 58 51@2x" src="https://github.com/user-attachments/assets/347f0189-6a4f-40f6-bb01-6e3baf58b779" />
 

**Testing:**

Subscribe to deploy 
Seed some data: 
`mise run unkey -- dev seed checkpoints --workspace <YOUR_WS_ID> --memory 20Gi --disk 5Gi --egress-per-day 2Gi`

you should see usage + predicted usaged.
