### PR TITLE
fix(ctrl): isolate shared Restate test registrations

### DIFF
--- a/docs/engineering/contributing/quality/testing/integration-tests.mdx
+++ b/docs/engineering/contributing/quality/testing/integration-tests.mdx
@@ -26,6 +26,14 @@ Compose project per worktree, so tests only start the services they need.
 `mise run test` removes the shared containers for that worktree after the test
 suite exits.
 
+All registrations against the shared Restate container must go through
+`containers.Restate`. Restate service registration changes routing for the whole
+server, so the helper leases the supplied service names across test processes.
+Tests with disjoint service sets can run concurrently. Tests with overlapping
+service names wait for the current owner to drain its invocations and remove its
+deployment. The helper also clears persisted state before handing a service to
+the next test.
+
 For full-suite runs, use `mise run test`. Direct `rask` does not run the
 cleanup trap from the mise task.
 

--- a/pkg/testutil/containers/doc.go
+++ b/pkg/testutil/containers/doc.go
@@ -1,9 +1,9 @@
 // Package containers provides Docker Compose-backed containers for integration tests.
 //
-// This package manages shared Docker services for integration tests.
 // Containers are reused through one Docker Compose project per worktree, so
 // separate Go test processes share backing services without colliding with
-// other worktrees.
+// other worktrees. Restate service registrations are leased and cleaned by
+// service name because registration changes routing for the whole server.
 //
 // # Requirements
 //
@@ -27,10 +27,12 @@
 //
 // # Design
 //
-// Containers are created on demand by pkg/testutil/docker-compose.test.yaml and
-// reused by later test requests in the same worktree. Compose assigns random
+// Containers are created on demand by pkg/testutil/docker-compose.test.yaml
+// and reused by later test requests in the same worktree. Compose assigns random
 // host ports to avoid conflicts and waits for container healthchecks before the
-// helpers return connection information.
+// helpers return connection information. [Restate] additionally serializes
+// overlapping service registrations across test processes and resets their
+// invocations, state, and deployments between registrations.
 //
 // # Available Services
 //

--- a/pkg/testutil/containers/restate.go
+++ b/pkg/testutil/containers/restate.go
@@ -1,14 +1,42 @@
 package containers
 
 import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
+
+	restate "github.com/restatedev/sdk-go"
+	"github.com/restatedev/sdk-go/ingress"
+	restateServer "github.com/restatedev/sdk-go/server"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
+	"golang.org/x/sys/unix"
 )
 
 const (
-	restatePort      = 8080
-	restateAdminPort = 9070
+	restatePort                 = 8080
+	restateAdminPort            = 9070
+	restateReadinessHandlerName = "ping"
 )
+
+var restateWorkerID atomic.Uint64
 
 // RestateConfig holds connection information for the Restate test container.
 type RestateConfig struct {
@@ -18,16 +46,464 @@ type RestateConfig struct {
 	AdminURL string
 }
 
-// Restate starts the shared Docker Compose Restate service and returns ingress/admin URLs.
+// Restate registers services on the shared Restate test container.
 //
-// The container is reused through the worktree's Docker Compose project.
-func Restate(t testing.TB) RestateConfig {
+// Every registration against the shared container must use Restate. The helper
+// takes cross-process leases for all supplied service names, resets their
+// invocations and state, registers a temporary worker, and releases the leases
+// only after that worker is drained and deregistered. This keeps one container
+// for the suite without allowing concurrent Go test binaries to change each
+// other's routing.
+// Callers must supply every service that the registered handlers can invoke.
+func Restate(t *testing.T, services ...restate.ServiceDefinition) RestateConfig {
 	t.Helper()
+	require.NotEmpty(t, services, "at least one Restate service is required")
 
 	c := startService(t, "restate")
-
-	return RestateConfig{
+	cfg := RestateConfig{
 		IngressURL: fmt.Sprintf("http://%s", c.Addr(t, restatePort)),
 		AdminURL:   fmt.Sprintf("http://localhost:%d", c.Port(t, restateAdminPort)),
+	}
+
+	serviceNames := sortedServiceNames(services)
+	releaseLeases, err := acquireRestateServiceLeases(serviceNames)
+	require.NoError(t, err)
+
+	admin := restateAdminClient{
+		baseURL: cfg.AdminURL,
+		http:    &http.Client{Timeout: 10 * time.Second},
+	}
+	var worker *httptest.Server
+	var deploymentID string
+	cleanupServiceNames := serviceNames
+	t.Cleanup(func() {
+		defer func() {
+			if releaseErr := releaseLeases(); releaseErr != nil {
+				t.Errorf("release Restate service leases: %v", releaseErr)
+			}
+		}()
+		defer func() {
+			if worker != nil {
+				worker.Close()
+			}
+		}()
+
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cleanupCancel()
+		if cleanupErr := admin.drainInvocations(cleanupCtx, cleanupServiceNames); cleanupErr != nil {
+			t.Errorf("drain Restate test invocations: %v", cleanupErr)
+		}
+		if cleanupErr := admin.purgeCompletedInvocations(cleanupCtx, cleanupServiceNames); cleanupErr != nil {
+			t.Errorf("purge Restate test invocations: %v", cleanupErr)
+		}
+		if deploymentID != "" {
+			if cleanupErr := admin.deleteDeployment(cleanupCtx, deploymentID); cleanupErr != nil {
+				t.Errorf("deregister Restate test worker: %v", cleanupErr)
+			}
+		}
+	})
+
+	resetCtx, resetCancel := context.WithTimeout(t.Context(), 30*time.Second)
+	resetErr := admin.resetServices(resetCtx, serviceNames)
+	resetCancel()
+	require.NoError(t, resetErr)
+
+	readinessServiceName := fmt.Sprintf(
+		"unkey.test.RestateReadiness_%d_%d",
+		os.Getpid(),
+		restateWorkerID.Add(1),
+	)
+	cleanupServiceNames = append(append([]string{}, serviceNames...), readinessServiceName)
+	restateSrv := restateServer.NewRestate()
+	for _, service := range services {
+		restateSrv.Bind(service)
+	}
+	restateSrv.Bind(restate.NewObject(readinessServiceName).
+		Handler(restateReadinessHandlerName, restate.NewObjectHandler(
+			func(_ restate.ObjectContext, in string) (string, error) { return in, nil })))
+
+	restateHandler, err := restateSrv.Handler()
+	require.NoError(t, err)
+	workerListener, err := net.Listen("tcp", "0.0.0.0:0") //nolint:gosec // Restate in Docker must reach the test worker.
+	require.NoError(t, err)
+	worker = httptest.NewUnstartedServer(h2c.NewHandler(restateHandler, &http2.Server{})) //nolint:exhaustruct // Defaults are sufficient for tests.
+	require.NoError(t, worker.Listener.Close())
+	worker.Listener = workerListener
+	worker.Start()
+
+	workerPort := workerListener.Addr().(*net.TCPAddr).Port
+	registerCtx, registerCancel := context.WithTimeout(t.Context(), 30*time.Second)
+	deploymentID, err = admin.registerDeployment(
+		registerCtx,
+		fmt.Sprintf("http://host.docker.internal:%d", workerPort),
+	)
+	registerCancel()
+	require.NoError(t, err)
+
+	readinessCtx, readinessCancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer readinessCancel()
+	require.Eventually(t, func() bool {
+		requestCtx, requestCancel := context.WithTimeout(readinessCtx, 2*time.Second)
+		defer requestCancel()
+		_, err := ingress.Object[string, string](
+			ingress.NewClient(cfg.IngressURL),
+			readinessServiceName,
+			"probe",
+			restateReadinessHandlerName,
+		).Request(requestCtx, "ready")
+		return err == nil
+	}, 30*time.Second, 250*time.Millisecond, "restate never became ready for keyed invocations")
+
+	return cfg
+}
+
+func sortedServiceNames(services []restate.ServiceDefinition) []string {
+	unique := make(map[string]struct{}, len(services))
+	for _, service := range services {
+		unique[service.Name()] = struct{}{}
+	}
+	names := make([]string, 0, len(unique))
+	for name := range unique {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// acquireRestateServiceLeases serializes registrations for overlapping service
+// sets across the separate Go test binaries that Rask runs concurrently.
+func acquireRestateServiceLeases(serviceNames []string) (func() error, error) {
+	files := make([]*os.File, 0, len(serviceNames))
+	release := func() error {
+		var errs []error
+		for i := len(files) - 1; i >= 0; i-- {
+			if err := unix.Flock(int(files[i].Fd()), unix.LOCK_UN); err != nil {
+				errs = append(errs, err)
+			}
+			if err := files[i].Close(); err != nil {
+				errs = append(errs, err)
+			}
+		}
+		if len(errs) > 0 {
+			return fmt.Errorf("release Restate locks: %v", errs)
+		}
+		return nil
+	}
+
+	for _, serviceName := range serviceNames {
+		sum := sha256.Sum256([]byte(composeProjectName() + "\x00" + serviceName))
+		lockPath := filepath.Join(
+			os.TempDir(),
+			"unkey-restate-"+hex.EncodeToString(sum[:8])+".lock",
+		)
+		file, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+		if err != nil {
+			_ = release()
+			return nil, fmt.Errorf("open Restate lock for %s: %w", serviceName, err)
+		}
+		files = append(files, file)
+		if err := unix.Flock(int(file.Fd()), unix.LOCK_EX); err != nil {
+			_ = release()
+			return nil, fmt.Errorf("lock Restate service %s: %w", serviceName, err)
+		}
+	}
+	return release, nil
+}
+
+type restateAdminClient struct {
+	baseURL string
+	http    *http.Client
+}
+
+type restateInvocationRow struct {
+	ID     string `json:"id"`
+	Status string `json:"status"`
+	Target string `json:"target"`
+}
+
+type restateStateRow struct {
+	ServiceName string `json:"service_name"`
+	ServiceKey  string `json:"service_key"`
+}
+
+type restateDeployment struct {
+	ID       string                     `json:"id"`
+	Services []restateDeploymentService `json:"services"`
+}
+
+type restateDeploymentService struct {
+	Name string `json:"name"`
+}
+
+func (a *restateAdminClient) resetServices(ctx context.Context, serviceNames []string) error {
+	if err := a.drainInvocations(ctx, serviceNames); err != nil {
+		return fmt.Errorf("drain stale invocations: %w", err)
+	}
+	if err := a.purgeCompletedInvocations(ctx, serviceNames); err != nil {
+		return fmt.Errorf("purge stale invocations: %w", err)
+	}
+	if err := a.deleteDeploymentsForServices(ctx, serviceNames); err != nil {
+		return fmt.Errorf("delete stale deployments: %w", err)
+	}
+	if err := a.clearState(ctx, serviceNames); err != nil {
+		return fmt.Errorf("clear stale state: %w", err)
+	}
+	return nil
+}
+
+func (a *restateAdminClient) drainInvocations(ctx context.Context, serviceNames []string) error {
+	return a.mutateInvocations(ctx, serviceNames, "status != 'completed'", "kill")
+}
+
+func (a *restateAdminClient) purgeCompletedInvocations(ctx context.Context, serviceNames []string) error {
+	return a.mutateInvocations(ctx, serviceNames, "status = 'completed'", "purge")
+}
+
+func (a *restateAdminClient) mutateInvocations(
+	ctx context.Context,
+	serviceNames []string,
+	statusPredicate string,
+	action string,
+) error {
+	query := fmt.Sprintf(
+		"SELECT id, status, target FROM sys_invocation_status WHERE (%s) AND %s LIMIT 1000",
+		targetPredicate(serviceNames),
+		statusPredicate,
+	)
+	for {
+		rows, err := restateQuery[restateInvocationRow](ctx, a, query)
+		if err != nil {
+			return err
+		}
+		if len(rows) == 0 {
+			return nil
+		}
+		for _, row := range rows {
+			status, err := a.request(ctx, http.MethodPatch, "/invocations/"+url.PathEscape(row.ID)+"/"+action, nil, nil)
+			completedBeforeKill := action == "kill" && status == http.StatusConflict
+			if err != nil && status != http.StatusNotFound && !completedBeforeKill {
+				return fmt.Errorf("%s invocation %s (%s): %w", action, row.ID, row.Target, err)
+			}
+		}
+		if err := waitForRestateMutation(ctx); err != nil {
+			return fmt.Errorf("%s invocations still present: %v: %w", action, rows, err)
+		}
+	}
+}
+
+func (a *restateAdminClient) clearState(ctx context.Context, serviceNames []string) error {
+	query := fmt.Sprintf(
+		"SELECT DISTINCT service_name, service_key FROM state WHERE service_name IN (%s)",
+		serviceList(serviceNames),
+	)
+	for {
+		rows, err := restateQuery[restateStateRow](ctx, a, query)
+		if err != nil {
+			return err
+		}
+		if len(rows) == 0 {
+			return nil
+		}
+		for _, row := range rows {
+			payload := map[string]any{
+				"version":    nil,
+				"object_key": row.ServiceKey,
+				"new_state":  map[string]string{},
+			}
+			_, err := a.request(
+				ctx,
+				http.MethodPost,
+				"/services/"+url.PathEscape(row.ServiceName)+"/state",
+				payload,
+				nil,
+			)
+			if err != nil {
+				return fmt.Errorf("clear state for %s/%s: %w", row.ServiceName, row.ServiceKey, err)
+			}
+		}
+		if err := waitForRestateMutation(ctx); err != nil {
+			return fmt.Errorf("state still present: %v: %w", rows, err)
+		}
+	}
+}
+
+func (a *restateAdminClient) deleteDeploymentsForServices(ctx context.Context, serviceNames []string) error {
+	for {
+		deployments, err := a.deployments(ctx)
+		if err != nil {
+			return err
+		}
+		var deleted bool
+		for _, deployment := range deployments {
+			if !deploymentOverlaps(deployment, serviceNames) {
+				continue
+			}
+			if err := a.deleteDeployment(ctx, deployment.ID); err != nil {
+				return err
+			}
+			deleted = true
+		}
+		if !deleted {
+			return nil
+		}
+	}
+}
+
+func (a *restateAdminClient) deleteDeployment(ctx context.Context, deploymentID string) error {
+	status, err := a.request(
+		ctx,
+		http.MethodDelete,
+		"/deployments/"+url.PathEscape(deploymentID)+"?force=true",
+		nil,
+		nil,
+	)
+	if err != nil && status != http.StatusNotFound {
+		return err
+	}
+	for {
+		deployments, listErr := a.deployments(ctx)
+		if listErr != nil {
+			return listErr
+		}
+		found := false
+		for _, deployment := range deployments {
+			found = found || deployment.ID == deploymentID
+		}
+		if !found {
+			return nil
+		}
+		if err := waitForRestateMutation(ctx); err != nil {
+			return fmt.Errorf("deployment %s still registered: %w", deploymentID, err)
+		}
+	}
+}
+
+func (a *restateAdminClient) deployments(ctx context.Context) ([]restateDeployment, error) {
+	var response struct {
+		Deployments []restateDeployment `json:"deployments"`
+	}
+	_, err := a.request(ctx, http.MethodGet, "/deployments", nil, &response)
+	return response.Deployments, err
+}
+
+func (a *restateAdminClient) registerDeployment(ctx context.Context, uri string) (string, error) {
+	var response struct {
+		ID string `json:"id"`
+	}
+	_, err := a.request(ctx, http.MethodPost, "/deployments", map[string]string{"uri": uri}, &response)
+	if err != nil {
+		return "", err
+	}
+	if response.ID == "" {
+		return "", fmt.Errorf("Restate registration returned an empty deployment id")
+	}
+	return response.ID, nil
+}
+
+func (a *restateAdminClient) request(
+	ctx context.Context,
+	method string,
+	path string,
+	payload any,
+	response any,
+) (int, error) {
+	var body io.Reader
+	if payload != nil {
+		encoded, err := json.Marshal(payload)
+		if err != nil {
+			return 0, err
+		}
+		body = bytes.NewReader(encoded)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, a.baseURL+path, body)
+	if err != nil {
+		return 0, err
+	}
+	if payload != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := a.http.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		message, _ := io.ReadAll(io.LimitReader(resp.Body, 16<<10))
+		return resp.StatusCode, fmt.Errorf("Restate admin %s %s returned %s: %s", method, path, resp.Status, message)
+	}
+	if response != nil {
+		if err := json.NewDecoder(resp.Body).Decode(response); err != nil {
+			return resp.StatusCode, err
+		}
+	}
+	return resp.StatusCode, nil
+}
+
+func restateQuery[T any](ctx context.Context, admin *restateAdminClient, query string) ([]T, error) {
+	var response struct {
+		Rows []T `json:"rows"`
+	}
+	encoded, err := json.Marshal(map[string]string{"query": query})
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, admin.baseURL+"/query", bytes.NewReader(encoded))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	resp, err := admin.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		message, _ := io.ReadAll(io.LimitReader(resp.Body, 16<<10))
+		return nil, fmt.Errorf("Restate query returned %s: %s", resp.Status, message)
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		return nil, err
+	}
+	return response.Rows, nil
+}
+
+func deploymentOverlaps(deployment restateDeployment, serviceNames []string) bool {
+	for _, deployedService := range deployment.Services {
+		if slices.Contains(serviceNames, deployedService.Name) {
+			return true
+		}
+	}
+	return false
+}
+
+func targetPredicate(serviceNames []string) string {
+	predicates := make([]string, 0, len(serviceNames))
+	for _, serviceName := range serviceNames {
+		predicates = append(predicates, "target LIKE "+sqlString(serviceName+"/%"))
+	}
+	return strings.Join(predicates, " OR ")
+}
+
+func serviceList(serviceNames []string) string {
+	quoted := make([]string, len(serviceNames))
+	for i, serviceName := range serviceNames {
+		quoted[i] = sqlString(serviceName)
+	}
+	return strings.Join(quoted, ", ")
+}
+
+func sqlString(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "''") + "'"
+}
+
+func waitForRestateMutation(ctx context.Context) error {
+	timer := time.NewTimer(100 * time.Millisecond)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
 	}
 }

--- a/pkg/testutil/containers/restate_test.go
+++ b/pkg/testutil/containers/restate_test.go
@@ -1,20 +1,115 @@
-package containers_test
+package containers
 
 import (
-	"net/http"
+	"context"
+	"fmt"
 	"testing"
 	"time"
 
+	restate "github.com/restatedev/sdk-go"
+	"github.com/restatedev/sdk-go/ingress"
 	"github.com/stretchr/testify/require"
-	"github.com/unkeyed/unkey/pkg/testutil/containers"
 )
 
-func TestRestate(t *testing.T) {
-	config := containers.Restate(t)
+func TestRestateResetsServiceBetweenRegistrations(t *testing.T) {
+	const (
+		serviceName = "unkey.test.Isolation"
+		handlerName = "increment"
+	)
 
-	client := &http.Client{Timeout: 5 * time.Second}
-	resp, err := client.Get(config.AdminURL + "/health")
+	service := func(marker string) restate.ServiceDefinition {
+		return restate.NewObject(serviceName).
+			Handler(handlerName, restate.NewObjectHandler(
+				func(ctx restate.ObjectContext, _ string) (string, error) {
+					count, err := restate.Get[int](ctx, "count")
+					if err != nil {
+						return "", err
+					}
+					restate.Set(ctx, "count", count+1)
+					return fmt.Sprintf("%s:%d", marker, count+1), nil
+				}))
+	}
+
+	for _, marker := range []string{"first", "second"} {
+		t.Run(marker, func(t *testing.T) {
+			cfg := Restate(t, service(marker))
+			ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+			defer cancel()
+
+			response, err := ingress.Object[string, string](
+				ingress.NewClient(cfg.IngressURL), serviceName, "same-key", handlerName,
+			).Request(ctx, "")
+			require.NoError(t, err)
+			require.Equal(t, marker+":1", response)
+		})
+	}
+}
+
+func TestRestateDrainsPendingInvocations(t *testing.T) {
+	const serviceName = "unkey.test.PendingInvocation"
+	service := restate.NewObject(serviceName).
+		Handler("sleep", restate.NewObjectHandler(
+			func(ctx restate.ObjectContext, _ string) (string, error) {
+				if err := restate.Sleep(ctx, time.Hour); err != nil {
+					return "", err
+				}
+				return "done", nil
+			}))
+
+	cfg := Restate(t, service)
+	ctx, cancel := context.WithTimeout(t.Context(), 250*time.Millisecond)
+	defer cancel()
+	_, err := ingress.Object[string, string](
+		ingress.NewClient(cfg.IngressURL), serviceName, "key", "sleep",
+	).Request(ctx, "")
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestRestateServiceLeasesSerializeOverlappingRegistrations(t *testing.T) {
+	firstRelease, err := acquireRestateServiceLeases([]string{"unkey.test.Lease"})
 	require.NoError(t, err)
-	require.NoError(t, resp.Body.Close())
-	require.Equal(t, http.StatusOK, resp.StatusCode)
+	firstReleased := false
+	defer func() {
+		if !firstReleased {
+			_ = firstRelease()
+		}
+	}()
+
+	type leaseResult struct {
+		release func() error
+		err     error
+	}
+	second := make(chan leaseResult, 1)
+	go func() {
+		release, acquireErr := acquireRestateServiceLeases([]string{"unkey.test.Lease"})
+		second <- leaseResult{release: release, err: acquireErr}
+	}()
+
+	select {
+	case result := <-second:
+		if result.release != nil {
+			_ = result.release()
+		}
+		require.Fail(t, "overlapping Restate service lease was acquired before its owner released it")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	require.NoError(t, firstRelease())
+	firstReleased = true
+	select {
+	case result := <-second:
+		require.NoError(t, result.err)
+		require.NoError(t, result.release())
+	case <-time.After(5 * time.Second):
+		require.Fail(t, "overlapping Restate service lease was not acquired after its owner released it")
+	}
+}
+
+func TestDeploymentOverlapsMultipleServices(t *testing.T) {
+	deployment := restateDeployment{
+		ID:       "deployment",
+		Services: []restateDeploymentService{{Name: "service.b"}},
+	}
+	require.True(t, deploymentOverlaps(deployment, []string{"service.a", "service.b", "service.c"}))
+	require.False(t, deploymentOverlaps(deployment, []string{"service.c", "service.d"}))
 }

--- a/pkg/testutil/docker-compose.test.yaml
+++ b/pkg/testutil/docker-compose.test.yaml
@@ -82,13 +82,7 @@ services:
   restate:
     image: docker.io/restatedev/restate:1.6.0@sha256:33f227db946864b5482340a8621e32ec5eaf464f4dc41d5deccfd3282bb930ae
     environment:
-      # Provision a single partition. Restate routes keyed invocations to a
-      # partition by hashing the object key, and each partition processor takes
-      # leadership independently on cold start. The harness readiness gate probes
-      # one fixed key, so with the default 24 partitions it only proves that
-      # key's partition is live while a deploy Send keyed by a random
-      # deployment_id targets a different, possibly-cold partition and silently
-      # queues. One partition makes the readiness probe cover every keyed Send.
+      # A keyed readiness invocation covers every key only with one partition.
       RESTATE_DEFAULT_NUM_PARTITIONS: "1"
     extra_hosts:
       - host.docker.internal:host-gateway

--- a/svc/ctrl/api/harness_test.go
+++ b/svc/ctrl/api/harness_test.go
@@ -1,26 +1,19 @@
 package api
 
 import (
-	"bytes"
 	"context"
 	"crypto/tls"
-	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
-	"net/http/httptest"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
 
 	"connectrpc.com/connect"
 	restate "github.com/restatedev/sdk-go"
-	"github.com/restatedev/sdk-go/ingress"
-	restateServer "github.com/restatedev/sdk-go/server"
 	"github.com/stretchr/testify/require"
 	"github.com/unkeyed/unkey/pkg/config"
-	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/pkg/mysql/sqlcomment"
 	"github.com/unkeyed/unkey/pkg/rpc/interceptor"
 	"github.com/unkeyed/unkey/pkg/testutil/containers"
@@ -28,12 +21,6 @@ import (
 	"github.com/unkeyed/unkey/svc/ctrl/integration/seed"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/db"
 	"golang.org/x/net/http2"
-	"golang.org/x/net/http2/h2c"
-)
-
-const (
-	readinessServiceName = "harnessReadiness"
-	readinessHandlerName = "ping"
 )
 
 type webhookHarnessConfig struct {
@@ -56,55 +43,7 @@ func newWebhookHarness(t *testing.T, cfg webhookHarnessConfig) *webhookHarness {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	t.Cleanup(cancel)
 
-	restateCfg := containers.Restate(t)
-
-	restateSrv := restateServer.NewRestate().WithLogger(logger.GetHandler(), false)
-	for _, service := range cfg.Services {
-		restateSrv.Bind(service)
-	}
-
-	// Readiness probe object. Registering a deployment (register below) only
-	// confirms Restate discovered the worker, not that its partition processor
-	// can route invocations to it yet. Until it can, a Send is accepted but
-	// never dispatched, so the first test would time out waiting for its
-	// invocation. This is a virtual object, matching the keyed services under
-	// test: on cold start keyed routing becomes ready later than unkeyed
-	// service routing, so probing a plain service would pass too early. We
-	// invoke it synchronously after registration and only return once it
-	// responds, proving keyed invocations actually reach this worker.
-	restateSrv.Bind(restate.NewObject(readinessServiceName).
-		Handler(readinessHandlerName, restate.NewObjectHandler(
-			func(_ restate.ObjectContext, in string) (string, error) { return in, nil })))
-
-	restateHandler, err := restateSrv.Handler()
-	require.NoError(t, err)
-
-	workerMux := http.NewServeMux()
-	workerMux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
-	workerMux.Handle("/", restateHandler)
-
-	workerListener, err := net.Listen("tcp", "0.0.0.0:0")
-	require.NoError(t, err)
-	workerServer := httptest.NewUnstartedServer(h2c.NewHandler(workerMux, &http2.Server{}))
-	workerServer.Listener = workerListener
-	workerServer.Start()
-	t.Cleanup(workerServer.Close)
-
-	workerPort := workerListener.Addr().(*net.TCPAddr).Port
-	registration := &restateRegistration{adminURL: restateCfg.AdminURL, registerAs: fmt.Sprintf("http://%s:%d", dockerHost(), workerPort)}
-	deploymentID, err := registration.register(ctx)
-	require.NoError(t, err)
-	t.Cleanup(func() { registration.deregister(context.Background(), deploymentID) })
-
-	ingressClient := ingress.NewClient(restateCfg.IngressURL)
-	require.Eventually(t, func() bool {
-		reqCtx, reqCancel := context.WithTimeout(ctx, 2*time.Second)
-		defer reqCancel()
-		_, err := ingress.Object[string, string](ingressClient, readinessServiceName, "probe", readinessHandlerName).Request(reqCtx, "ready")
-		return err == nil
-	}, 30*time.Second, 250*time.Millisecond, "restate never routed an invocation to the test worker")
+	restateCfg := containers.Restate(t, cfg.Services...)
 
 	mysqlCfg := containers.MySQL(t)
 	database, err := db.New(mysqlCfg.DSN, sqlcomment.Disabled())
@@ -144,11 +83,14 @@ func newWebhookHarness(t *testing.T, cfg webhookHarnessConfig) *webhookHarness {
 	}
 
 	ctrlCtx, ctrlCancel := context.WithCancel(ctx)
-	t.Cleanup(ctrlCancel)
-
+	runErr := make(chan error, 1)
 	go func() {
-		require.NoError(t, Run(ctrlCtx, apiConfig))
+		runErr <- Run(ctrlCtx, apiConfig)
 	}()
+	t.Cleanup(func() {
+		ctrlCancel()
+		require.NoError(t, <-runErr)
+	})
 
 	ctrlURL := fmt.Sprintf("http://127.0.0.1:%d", ctrlPort)
 	require.Eventually(t, func() bool {
@@ -217,80 +159,6 @@ func (h *webhookHarness) CreateAppWithSettings(ctx context.Context, req seed.Cre
 	return h.Seed.CreateAppWithSettings(ctx, req, environmentID)
 }
 
-type restateRegistration struct {
-	adminURL   string
-	registerAs string
-}
-
-// register registers the harness's worker as a Restate deployment and returns
-// its deployment id so the caller can deregister it on cleanup.
-func (r *restateRegistration) register(ctx context.Context) (string, error) {
-	registerURL := r.adminURL + "/deployments"
-	payload := []byte("{\"uri\": \"" + r.registerAs + "\"}")
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, registerURL, bytes.NewReader(payload))
-	if err != nil {
-		return "", err
-	}
-	requireJSON(req)
-
-	client := &http.Client{Timeout: 10 * time.Second}
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return "", fmtStatus(resp.StatusCode)
-	}
-
-	var body struct {
-		ID string `json:"id"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
-		return "", err
-	}
-	return body.ID, nil
-}
-
-// deregister removes the deployment from Restate. Each test registers a fresh
-// worker deployment on the shared Restate container; without removing them the
-// container collects one dead deployment per test run. force=true drops it even
-// while invocations reference it. Best effort: cleanup failures must not fail
-// the test.
-func (r *restateRegistration) deregister(ctx context.Context, id string) {
-	if id == "" {
-		return
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, r.adminURL+"/deployments/"+id+"?force=true", nil)
-	if err != nil {
-		return
-	}
-	client := &http.Client{Timeout: 10 * time.Second}
-	resp, err := client.Do(req)
-	if err != nil {
-		return
-	}
-	_ = resp.Body.Close()
-}
-
-func requireJSON(req *http.Request) {
-	req.Header.Set("Content-Type", "application/json")
-}
-
-type statusErr struct {
-	code int
-}
-
-func (e statusErr) Error() string {
-	return fmt.Sprintf("unexpected status code: %d", e.code)
-}
-
-func fmtStatus(code int) error {
-	return statusErr{code: code}
-}
-
 type addrInfo struct {
 	Host string
 	Port int
@@ -305,11 +173,4 @@ func pickAddr(t *testing.T) addrInfo {
 	require.True(t, ok)
 
 	return addrInfo{Host: addr.IP.String(), Port: addr.Port}
-}
-
-func dockerHost() string {
-	if runtime.GOOS == "darwin" {
-		return "host.docker.internal"
-	}
-	return "172.17.0.1"
 }

--- a/svc/ctrl/integration/harness/harness.go
+++ b/svc/ctrl/integration/harness/harness.go
@@ -5,20 +5,14 @@ package harness
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"log/slog"
-	"net"
-	"net/http"
-	"net/http/httptest"
-	"runtime"
 	"sync"
 	"testing"
 	"time"
 
 	ch "github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/restatedev/sdk-go/ingress"
-	restateServer "github.com/restatedev/sdk-go/server"
 	"github.com/stretchr/testify/require"
 	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
 	"github.com/unkeyed/unkey/gen/rpc/vault"
@@ -29,7 +23,6 @@ import (
 	"github.com/unkeyed/unkey/pkg/clock"
 	"github.com/unkeyed/unkey/pkg/healthcheck"
 	"github.com/unkeyed/unkey/pkg/mysql/sqlcomment"
-	restateadmin "github.com/unkeyed/unkey/pkg/restate/admin"
 	"github.com/unkeyed/unkey/pkg/testutil/containers"
 	"github.com/unkeyed/unkey/svc/ctrl/integration/seed"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/billingmeter"
@@ -43,8 +36,6 @@ import (
 	"github.com/unkeyed/unkey/svc/ctrl/worker/deployment"
 	"github.com/unkeyed/unkey/svc/ctrl/worker/keylastusedsync"
 	vaulttestutil "github.com/unkeyed/unkey/svc/vault/testutil"
-	"golang.org/x/net/http2"
-	"golang.org/x/net/http2/h2c"
 )
 
 // Harness holds all test dependencies for ctrl worker integration tests.
@@ -162,21 +153,15 @@ func New(t *testing.T, opts ...Option) *Harness {
 
 	start := time.Now()
 
-	// Start all containers in parallel
+	// Start the passive backing services in parallel. Restate starts after its
+	// handlers are constructed so the helper can lease their service names and
+	// register the complete worker deployment atomically.
 	var wg sync.WaitGroup
-	var restateCfg containers.RestateConfig
 	var mysqlCfg containers.MySQLConfig
 	var chCfg containers.ClickHouseConfig
 	var testVault *vaulttestutil.TestVault
 
-	wg.Add(4)
-
-	go func() {
-		defer wg.Done()
-		s := time.Now()
-		restateCfg = containers.Restate(t)
-		t.Logf("Restate started in %s", time.Since(s))
-	}()
+	wg.Add(3)
 
 	go func() {
 		defer wg.Done()
@@ -200,7 +185,7 @@ func New(t *testing.T, opts ...Option) *Harness {
 	}()
 
 	wg.Wait()
-	t.Logf("All containers started in %s", time.Since(start))
+	t.Logf("Backing containers started in %s", time.Since(start))
 
 	// Connect to MySQL
 	database, err := db.New(mysqlCfg.DSN, sqlcomment.Disabled())
@@ -296,43 +281,21 @@ func New(t *testing.T, opts ...Option) *Harness {
 		DB: database,
 	})
 
-	// Set up Restate server with all services
-	// Use the proto-generated wrappers (same as run.go) to get correct service names
-	restateSrv := restateServer.NewRestate()
-	restateSrv.Bind(hydrav1.NewCronServiceServer(cronSvc))
-	// The deploy billing orchestrator (push and close) fans out to this per-workspace
-	// push service, so it must be bound for those handlers to route end to end.
-	restateSrv.Bind(hydrav1.NewDeployBillingPushServiceServer(cronSvc.DeployBillingPushServer()))
-	restateSrv.Bind(hydrav1.NewDeploySpendCheckServiceServer(cronSvc.DeploySpendCheckServer()))
-	restateSrv.Bind(hydrav1.NewClickhouseUserServiceServer(clickhouseUserSvc))
-	restateSrv.Bind(hydrav1.NewKeyLastUsedPartitionServiceServer(keyLastUsedPartitionSvc))
-	restateSrv.Bind(hydrav1.NewDeployServiceServer(deploySvc))
-	restateSrv.Bind(hydrav1.NewDeploymentServiceServer(deploymentSvc))
-	restateSrv.Bind(hydrav1.NewBuildSlotServiceServer(buildSlotSvc))
-
-	restateHandler, err := restateSrv.Handler()
-	require.NoError(t, err)
-
-	workerMux := http.NewServeMux()
-	workerMux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
-	workerMux.Handle("/", restateHandler)
-
-	workerListener, err := net.Listen("tcp", "0.0.0.0:0") //nolint:gosec // Test server needs to bind all interfaces for Docker access
-	require.NoError(t, err)
-	workerServer := httptest.NewUnstartedServer(h2c.NewHandler(workerMux, &http2.Server{})) //nolint:exhaustruct // Only need default settings for test
-	workerServer.Listener = workerListener
-	workerServer.Start()
-	t.Cleanup(workerServer.Close)
-
-	tcpAddr, ok := workerListener.Addr().(*net.TCPAddr)
-	require.True(t, ok, "listener address must be TCP")
-	workerPort := tcpAddr.Port
-	registerAs := fmt.Sprintf("http://%s:%d", dockerHost(), workerPort)
-
-	adminClient := restateadmin.New(restateadmin.Config{BaseURL: restateCfg.AdminURL, APIKey: ""})
-	require.NoError(t, adminClient.RegisterDeployment(ctx, registerAs))
+	// Lease and register every worker service as one Restate deployment.
+	// Use the proto-generated wrappers (same as run.go) to get correct service names.
+	restateCfg := containers.Restate(t,
+		hydrav1.NewCronServiceServer(cronSvc),
+		// The deploy billing orchestrator (push and close) fans out to this
+		// per-workspace push service, so it must be bound for those handlers to
+		// route end to end.
+		hydrav1.NewDeployBillingPushServiceServer(cronSvc.DeployBillingPushServer()),
+		hydrav1.NewDeploySpendCheckServiceServer(cronSvc.DeploySpendCheckServer()),
+		hydrav1.NewClickhouseUserServiceServer(clickhouseUserSvc),
+		hydrav1.NewKeyLastUsedPartitionServiceServer(keyLastUsedPartitionSvc),
+		hydrav1.NewDeployServiceServer(deploySvc),
+		hydrav1.NewDeploymentServiceServer(deploymentSvc),
+		hydrav1.NewBuildSlotServiceServer(buildSlotSvc),
+	)
 	t.Logf("Total harness setup in %s", time.Since(start))
 
 	return &Harness{
@@ -350,12 +313,4 @@ func New(t *testing.T, opts ...Option) *Harness {
 		RestateAdmin:   restateCfg.AdminURL,
 		Clock:          o.clock,
 	}
-}
-
-// dockerHost returns the hostname to use for connecting from Docker containers.
-func dockerHost() string {
-	if runtime.GOOS == "darwin" {
-		return "host.docker.internal"
-	}
-	return "172.17.0.1"
 }

--- a/svc/ctrl/worker/cron/auditlogexport/handler_test.go
+++ b/svc/ctrl/worker/cron/auditlogexport/handler_test.go
@@ -39,6 +39,21 @@ func TestExportBatch_ClickHouseFailureLeavesOutboxRowPending(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, database.Close()) })
 
+	// A reused container can carry pending outbox rows from earlier runs.
+	// The export batch reads the whole table (ORDER BY pk LIMIT batchLimit),
+	// so enough leftovers would evict this test's freshly-seeded row from the
+	// window and break the Contains assertion below. Drain to a clean slate
+	// first with a noop ClickHouse; this only marks already-pending rows
+	// deleted, so it can't race other processes that share the container.
+	drainer := &Handler{db: database, clickhouse: clickhouse.NewNoop()}
+	for {
+		drained, drainErr := drainer.exportBatch(ctx)
+		require.NoError(t, drainErr)
+		if drained.EventsExported < batchLimit {
+			break
+		}
+	}
+
 	event := auditlog.Event{
 		EventID:     uid.New("evt"),
 		Time:        time.Now().UnixMilli(),


### PR DESCRIPTION
## Problem:

Restate integration tests shared one server while concurrently registering different workers under the same service names. 

This could route requests to another test’s worker or a stale deployment, causing incorrect responses and timeouts which were flakey as hell.

## Solution:

In order to deal with this we now serialize overlapping service registrations across processes. 

Also we drain stale invocations, remove old deployments, clear persisted state, and verify keyed routing before each test proceeds. 

Tests with different service names can still run concurrently, and we keep using a single shared Restate container

## Impact:

Test infrastructure changes slightly.

## Testing:

All tests run correctly