### PR TITLE
log warnings for missing healtcheck configs

### DIFF
--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -1,7 +1,9 @@
 package healthcheck
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -64,9 +66,18 @@ func TestHTTPHeartbeat_EmptyURL(t *testing.T) {
 }
 
 func TestNoop_Ping(t *testing.T) {
+	var logs bytes.Buffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, nil)))
+	t.Cleanup(func() {
+		slog.SetDefault(previousLogger)
+	})
+
 	hb := NewNoop()
 	err := hb.Ping(context.Background())
 	require.NoError(t, err)
+	require.Contains(t, logs.String(), "level=WARN")
+	require.Contains(t, logs.String(), "heartbeat not sent (noop heartbeat)")
 }
 
 func TestImplementsHeartbeat(t *testing.T) {

--- a/pkg/healthcheck/noop.go
+++ b/pkg/healthcheck/noop.go
@@ -1,6 +1,10 @@
 package healthcheck
 
-import "context"
+import (
+	"context"
+
+	"github.com/unkeyed/unkey/pkg/logger"
+)
 
 // Noop is a no-op heartbeat implementation for testing or when heartbeats are disabled.
 type Noop struct{}
@@ -10,7 +14,8 @@ func NewNoop() *Noop {
 	return &Noop{}
 }
 
-// Ping does nothing and always returns nil.
+// Ping logs that the heartbeat is disabled and returns nil.
 func (*Noop) Ping(context.Context) error {
+	logger.Warn("heartbeat not sent (noop heartbeat)")
 	return nil
 }


### PR DESCRIPTION
We always want to have healthchecks configured in prod and canary, so let's just log when they're not :)

I spent 30min earlier trying to figure out if a healtcheck was configured or not and I don't want to do that again.