### PR TITLE
test(api): stabilize key credit cache invalidation

### DIFF
--- a/svc/api/routes/v2_keys_update_credits/200_test.go
+++ b/svc/api/routes/v2_keys_update_credits/200_test.go
@@ -181,11 +181,14 @@ func TestKeyUpdateCreditsSuccess(t *testing.T) {
 		authBefore, err := h.Keys.Get(ctx, &zen.Session{}, hash.Sha256(cacheTestKey.Key))
 		require.NoError(t, err)
 
-		err = authBefore.Verify(ctx, keys.WithCredits(1))
+		// Initialize the usage counter without queueing a nonzero DB decrement. A
+		// nonzero cost is replayed to MySQL asynchronously and can race the credit
+		// update this test is meant to invalidate.
+		err = authBefore.Verify(ctx, keys.WithCredits(0))
 		require.NoError(t, err)
 
 		require.True(t, authBefore.Key.RemainingRequests.Valid)
-		require.Equal(t, initialCredits-1, authBefore.Key.RemainingRequests.Int64)
+		require.Equal(t, initialCredits, authBefore.Key.RemainingRequests.Int64)
 
 		// Update the key's credits
 		newCredits := int64(50)
@@ -207,6 +210,8 @@ func TestKeyUpdateCreditsSuccess(t *testing.T) {
 		// Verify the key again to check if cache was properly invalidated
 		authAfter, err := h.Keys.Get(ctx, &zen.Session{}, hash.Sha256(cacheTestKey.Key))
 		require.NoError(t, err)
+		require.True(t, authAfter.Key.RemainingRequests.Valid)
+		require.Equal(t, newCredits, authAfter.Key.RemainingRequests.Int64)
 
 		err = authAfter.Verify(ctx, keys.WithCredits(1))
 		require.NoError(t, err)

--- a/svc/api/routes/v2_keys_update_key/200_test.go
+++ b/svc/api/routes/v2_keys_update_key/200_test.go
@@ -331,11 +331,14 @@ func TestKeyUpdateCreditsInvalidatesCache(t *testing.T) {
 	authBefore, err := h.Keys.Get(ctx, &zen.Session{}, hash.Sha256(key.Key))
 	require.NoError(t, err)
 
-	err = authBefore.Verify(ctx, keys.WithCredits(1))
+	// Initialize the usage counter without queueing a nonzero DB decrement. A
+	// nonzero cost is replayed to MySQL asynchronously and can race the credit
+	// update this test is meant to invalidate.
+	err = authBefore.Verify(ctx, keys.WithCredits(0))
 	require.NoError(t, err)
 
 	require.True(t, authBefore.Key.RemainingRequests.Valid)
-	require.Equal(t, initialCredits-1, authBefore.Key.RemainingRequests.Int64)
+	require.Equal(t, initialCredits, authBefore.Key.RemainingRequests.Int64)
 
 	// Update the key's credits
 	newCredits := int64(50)
@@ -354,6 +357,8 @@ func TestKeyUpdateCreditsInvalidatesCache(t *testing.T) {
 	// Verify the key again to check if cache was properly invalidated
 	authAfter, err := h.Keys.Get(ctx, &zen.Session{}, hash.Sha256(key.Key))
 	require.NoError(t, err)
+	require.True(t, authAfter.Key.RemainingRequests.Valid)
+	require.Equal(t, newCredits, authAfter.Key.RemainingRequests.Int64)
 
 	err = authAfter.Verify(ctx, keys.WithCredits(1))
 	require.NoError(t, err)


### PR DESCRIPTION

The tests had a race built in. They spent one credit before setting the balance to 50, and depending on the timing that one credit deduction could arrive before or after the reset.

Here's what could happen:

**A**
1. deduct 1 // we're at 49 now
2. set to 50 // we're at 50 now
3. deduct one // we're at 49 now

or **B**
1. set to 50 // we're at 50 now
2. deduct 1 // we're at 49 now
3. deduct one // we're at 48 now

___

As you can imagine, if we assert the value to be 48, we'll have a bad time sometimes


Now we just use a `cost=0` request to prime the cache.