### PR TITLE
fix(ctrl): debounce spend-cap auto-resume with two under-budget ticks

### DIFF
--- a/svc/ctrl/integration/deploy_spend_check_test.go
+++ b/svc/ctrl/integration/deploy_spend_check_test.go
@@ -53,8 +53,11 @@ func startSpendCheck(t *testing.T, database db.Database) *restatetest.TestEnviro
 
 // TestDeploySpendCheck_SuspendThenResume exercises the enforcement trigger
 // end-to-end: an overage at/over budget with stop set suspends compute (the
-// check dispatches Teardown(SUSPEND)), and a later run with a budget raised
-// above the frozen overage resumes it (the check dispatches Resume).
+// check dispatches Teardown(SUSPEND)), and a budget raised above the frozen
+// overage resumes it (the check dispatches Resume). The spend-driven resume is
+// debounced, so it takes two consecutive under-budget ticks: the first only
+// records the streak (a lone ClickHouse underread looks identical), the second
+// confirms and resumes.
 func TestDeploySpendCheck_SuspendThenResume(t *testing.T) {
 	h := New(t)
 	ctx := h.Context()
@@ -111,9 +114,10 @@ func TestDeploySpendCheck_SuspendThenResume(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, billing.SpendSuspended, "suspend should set spend_suspended")
 
-	// A later run with a budget raised above the frozen overage resumes compute.
-	// The orchestrator would now pass CurrentlySuspended=true from the column.
-	resumeResp, err := client.CheckWorkspaceSpend().Request(ctx, &hydrav1.CheckWorkspaceSpendRequest{
+	// A budget raised above the frozen overage puts gross under budget: the
+	// spend-driven resume path, which is debounced. The orchestrator passes
+	// CurrentlySuspended=true from the column on both ticks.
+	raisedBudget := &hydrav1.CheckWorkspaceSpendRequest{
 		Period:             period,
 		BudgetCents:        1_000_000,
 		Stop:               true,
@@ -122,9 +126,22 @@ func TestDeploySpendCheck_SuspendThenResume(t *testing.T) {
 		WorkspaceSlug:      "test",
 		SpendMicroCents:    200 * deploybilling.MicroCentsPerCent,
 		CurrentlySuspended: true,
-	})
+	}
+
+	// First under-budget tick must NOT resume: a single ClickHouse underread is
+	// indistinguishable from this, so the check only records the streak.
+	firstResp, err := client.CheckWorkspaceSpend().Request(ctx, raisedBudget)
 	require.NoError(t, err)
-	require.False(t, resumeResp.GetSuspended(), "overage under raised budget should resume")
+	require.True(t, firstResp.GetSuspended(), "one under-budget tick must not resume (hysteresis)")
+
+	billing, err = h.DB.FindWorkspaceBillingByWorkspaceID(ctx, dep.WorkspaceID)
+	require.NoError(t, err)
+	require.True(t, billing.SpendSuspended, "one under-budget tick must leave spend_suspended set")
+
+	// Second consecutive under-budget tick confirms the drop and resumes.
+	resumeResp, err := client.CheckWorkspaceSpend().Request(ctx, raisedBudget)
+	require.NoError(t, err)
+	require.False(t, resumeResp.GetSuspended(), "second under-budget tick should resume")
 
 	// Resume restores current_deployment_id and brings desired_state back to
 	// running (the latter via the DeploymentService VO, asynchronously).

--- a/svc/ctrl/worker/cron/deployspendcheck/check.go
+++ b/svc/ctrl/worker/cron/deployspendcheck/check.go
@@ -82,6 +82,22 @@ func suspendGenerationKey(period string) string {
 	return "spend_suspend_generation:" + period
 }
 
+// underBudgetStreakKey counts consecutive ticks seen under budget while
+// suspended (and still stop-enabled), scoped to a billing period. A spend-driven
+// resume waits for resumeConfirmations of them: gross month-to-date only grows
+// within a period, so a genuine dip below a fixed budget means the ClickHouse
+// read moved, not the spend, and trusting one read would teardown/resume flap at
+// the tick cadence. Deliberate resumes (stop toggled off, budget removed) ignore
+// it.
+func underBudgetStreakKey(period string) string {
+	return "spend_under_budget_streak:" + period
+}
+
+// resumeConfirmations is how many consecutive under-budget ticks must be
+// observed before compute auto-resumes. Two absorbs an isolated underread while
+// still resuming within a couple of ticks once spend is genuinely under budget.
+const resumeConfirmations = 2
+
 // setSuspended persists the workspace's deploy_spend_suspended column on a
 // suspend/resume transition. The column (not VO state) is authoritative: it
 // lets the orchestrator keep dispatching a suspended workspace after its budget
@@ -137,6 +153,7 @@ func (h *CheckHandler) CheckWorkspaceSpend(
 	prev := reqPeriod.Prev()
 	restate.Clear(ctx, alertHighWaterKey(prev.Key()))
 	restate.Clear(ctx, suspendGenerationKey(prev.Key()))
+	restate.Clear(ctx, underBudgetStreakKey(prev.Key()))
 
 	if req.GetBudgetCents() <= 0 {
 		if req.GetCurrentlySuspended() {
@@ -148,6 +165,7 @@ func (h *CheckHandler) CheckWorkspaceSpend(
 			if err := h.setSuspended(ctx, workspaceID, false); err != nil {
 				return nil, fmt.Errorf("clear spend-suspended: %w", err)
 			}
+			restate.Clear(ctx, underBudgetStreakKey(req.GetPeriod()))
 			logger.Info("deploy spend cap: resumed after budget removed",
 				"workspace_id", workspaceID)
 		}
@@ -241,6 +259,8 @@ func (h *CheckHandler) CheckWorkspaceSpend(
 			return nil, fmt.Errorf("set spend-suspended: %w", err)
 		}
 		suspended = true
+		// A fresh suspension starts a clean resume streak.
+		restate.Clear(ctx, underBudgetStreakKey(req.GetPeriod()))
 
 		hydrav1.NewDeployTeardownServiceClient(ctx, workspaceID).
 			Teardown().
@@ -278,7 +298,26 @@ func (h *CheckHandler) CheckWorkspaceSpend(
 		restate.Set(ctx, stateKey, gross)
 		alerted = crossed
 
-	case suspended && req.GetStop() && gross >= budgetMicroCents:
+	case suspended && !req.GetStop():
+		// Stopping was turned off while suspended: a deliberate user action, so
+		// resume immediately without waiting for the under-budget streak.
+		hydrav1.NewDeployTeardownServiceClient(ctx, workspaceID).
+			Resume().
+			Send(&hydrav1.ResumeRequest{})
+		if err := h.setSuspended(ctx, workspaceID, false); err != nil {
+			return nil, fmt.Errorf("clear spend-suspended: %w", err)
+		}
+		suspended = false
+		restate.Clear(ctx, underBudgetStreakKey(req.GetPeriod()))
+		logger.Info("deploy spend cap: resumed compute (stop disabled)",
+			"workspace_id", workspaceID, "billing_period", req.GetPeriod(),
+			"gross_cents", gross/deploybilling.MicroCentsPerCent, "budget_cents", req.GetBudgetCents())
+
+	case suspended && gross >= budgetMicroCents:
+		// Still at or over budget (stop is on; the stop-disabled case above ran
+		// otherwise). Reset the resume streak: spend is back over the cap, so any
+		// earlier under-budget tick was a transient underread, not a real drop.
+		restate.Clear(ctx, underBudgetStreakKey(req.GetPeriod()))
 		// The flag can say stopped while compute still runs (kill before the
 		// teardown send, drain grace expired, create racing the gate). Re-send
 		// Teardown: it early-returns when nothing runs and merges into the
@@ -291,9 +330,27 @@ func (h *CheckHandler) CheckWorkspaceSpend(
 			"workspace_id", workspaceID, "billing_period", req.GetPeriod(),
 			"gross_cents", gross/deploybilling.MicroCentsPerCent, "budget_cents", req.GetBudgetCents())
 
-	case suspended && (!req.GetStop() || gross < budgetMicroCents):
-		// Budget raised above gross spend, period reset, or stopping turned
-		// off while suspended. Bring compute back.
+	case suspended && gross < budgetMicroCents:
+		// Spend is under budget with stop still on. Gross only grows within a
+		// period, so against an unchanged budget this can only be a transient
+		// ClickHouse underread (a budget raise is the other reason gross lands
+		// here); require resumeConfirmations consecutive under-budget ticks before
+		// resuming so a one-tick dip cannot teardown/resume flap.
+		streakKey := underBudgetStreakKey(req.GetPeriod())
+		streak, err := restate.Get[int32](ctx, streakKey)
+		if err != nil {
+			return nil, fmt.Errorf("get under-budget streak: %w", err)
+		}
+		streak++
+		if streak < resumeConfirmations {
+			restate.Set(ctx, streakKey, streak)
+			logger.Info("deploy spend cap: under budget, awaiting confirmation before resume",
+				"workspace_id", workspaceID, "billing_period", req.GetPeriod(),
+				"streak", streak, "needed", int32(resumeConfirmations),
+				"gross_cents", gross/deploybilling.MicroCentsPerCent, "budget_cents", req.GetBudgetCents())
+			break
+		}
+
 		hydrav1.NewDeployTeardownServiceClient(ctx, workspaceID).
 			Resume().
 			Send(&hydrav1.ResumeRequest{})
@@ -301,6 +358,7 @@ func (h *CheckHandler) CheckWorkspaceSpend(
 			return nil, fmt.Errorf("clear spend-suspended: %w", err)
 		}
 		suspended = false
+		restate.Clear(ctx, streakKey)
 		logger.Info("deploy spend cap: resumed compute",
 			"workspace_id", workspaceID, "billing_period", req.GetPeriod(),
 			"gross_cents", gross/deploybilling.MicroCentsPerCent, "budget_cents", req.GetBudgetCents())


### PR DESCRIPTION
## Problem:

If a workspace gets their compute suspended and the next tick for some reason underreports to said budget we will resume it again and then on the next tick suspend it again

This is flakey behaviour

## Solution:

We now debounce the resume and require two consecutive ticks to be under budget before bringing compute back. 

## Impact:

Resuming cuz under budget now takes 2 minutes instead of one.

## Testing:

Adjusted test to make this pass