### PR TITLE
Test deploy spend timeout flake

### DIFF
--- a/svc/ctrl/worker/cron/deploy_spend_check_orchestrator_integration_test.go
+++ b/svc/ctrl/worker/cron/deploy_spend_check_orchestrator_integration_test.go
@@ -61,7 +61,7 @@ func TestRunDeploySpendCheck_OrchestratorIntegration(t *testing.T) {
 
 	period := time.Now().UTC().Format("2006-01")
 	run := func() (*hydrav1.RunDeploySpendCheckResponse, error) {
-		return hydrav1.NewCronServiceIngressClient(h.Restate, period).
+		return hydrav1.NewCronServiceIngressClient(h.Restate, "deploy-spend-check-"+period).
 			RunDeploySpendCheck().
 			Request(h.Ctx, &hydrav1.RunDeploySpendCheckRequest{})
 	}

--- a/svc/ctrl/worker/cron/quota_check_integration_test.go
+++ b/svc/ctrl/worker/cron/quota_check_integration_test.go
@@ -124,6 +124,6 @@ func waitForRatelimitCount(t *testing.T, ctx context.Context, conn ch.Conn, work
 }
 
 func callRunQuotaCheck(h *harness.Harness, billingPeriod string) (*hydrav1.RunQuotaCheckResponse, error) {
-	client := hydrav1.NewCronServiceIngressClient(h.Restate, billingPeriod)
+	client := hydrav1.NewCronServiceIngressClient(h.Restate, "quota-check-"+billingPeriod)
 	return client.RunQuotaCheck().Request(h.Ctx, &hydrav1.RunQuotaCheckRequest{})
 }


### PR DESCRIPTION
both of these tests would accidentally use the same VO key and since they share the same restate container, they could block each other sometimes resulting in flaky tests.

mirroring the production naming solves that