### PR TITLE
fix(portal): update page layout to use dave's designs properly

### DIFF
--- a/web/apps/portal/src/components/portal-footer.tsx
+++ b/web/apps/portal/src/components/portal-footer.tsx
@@ -3,7 +3,7 @@ import { UnkeyLogo } from "~/components/ui/unkey-logo";
 export function PortalFooter() {
   return (
     <footer className="w-full bg-gray-3/50">
-      <div className="flex items-center justify-between px-8 py-5 text-gray-11 text-xs">
+      <div className="flex items-center justify-between px-4 py-5 text-gray-11 text-xs sm:px-8">
         <span className="inline-flex items-center gap-1.5">
           Powered by
           <a

--- a/web/apps/portal/src/components/portal-header.tsx
+++ b/web/apps/portal/src/components/portal-header.tsx
@@ -4,45 +4,60 @@ import { deriveVisibleTabs } from "~/lib/permissions";
 type PortalHeaderProps = {
   permissions: string[];
   logoUrl?: string;
+  returnUrl?: string;
+  appName?: string;
 };
 
 /**
- * Branded portal header with permission-derived navigation tabs.
+ * Branded portal header: a colored bar (customer's primary color, dark
+ * fallback) carrying the logo and permission-derived navigation on the left and
+ * a return-to-application link on the right.
  */
-export function PortalHeader({ permissions, logoUrl }: PortalHeaderProps) {
+export function PortalHeader({ permissions, logoUrl, returnUrl, appName }: PortalHeaderProps) {
   const location = useLocation();
   const tabs = deriveVisibleTabs(permissions);
 
   return (
-    <header className="border-gray-6 border-b bg-background">
-      <div className="mx-auto flex h-14 max-w-5xl items-center gap-6 px-4">
-        {logoUrl && <img src={logoUrl} alt="" className="h-8 w-auto" aria-hidden="true" />}
-        <nav className="flex items-center gap-1" aria-label="Portal navigation">
-          {tabs.map((tab) => {
-            const isActive = location.pathname.startsWith(tab.href);
-            return (
-              <Link
-                key={tab.id}
-                to={tab.href}
-                aria-current={isActive ? "page" : undefined}
-                className={`rounded-md px-3 py-1.5 font-medium text-sm transition-colors ${
-                  isActive ? "text-gray-12" : "text-gray-11 hover:bg-gray-3 hover:text-gray-12"
-                }`}
-                style={
-                  isActive
-                    ? {
-                        backgroundColor:
-                          "color-mix(in srgb, var(--portal-primary, #6366f1) 10%, transparent)",
-                        color: "var(--portal-primary, #6366f1)",
-                      }
-                    : undefined
-                }
-              >
-                {tab.label}
-              </Link>
-            );
-          })}
-        </nav>
+    <header
+      className="w-full text-[var(--portal-primary-foreground,#ffffff)]"
+      style={{ backgroundColor: "var(--portal-primary, var(--color-gray-12))" }}
+    >
+      <div className="flex h-14 items-center justify-between gap-6 px-4 sm:px-8">
+        <div className="flex items-center gap-6">
+          {(logoUrl || appName) && (
+            <div className="flex items-center gap-2.5">
+              {logoUrl && <img src={logoUrl} alt="" className="h-6 w-auto" aria-hidden="true" />}
+              {appName && <span className="font-medium text-sm">{appName}</span>}
+            </div>
+          )}
+          <nav className="flex items-center gap-1" aria-label="Portal navigation">
+            {tabs.map((tab) => {
+              const isActive = location.pathname.startsWith(tab.href);
+              return (
+                <Link
+                  key={tab.id}
+                  to={tab.href}
+                  aria-current={isActive ? "page" : undefined}
+                  className={`rounded-md px-3 py-1.5 font-medium text-sm transition-colors ${
+                    isActive
+                      ? "bg-[color-mix(in_srgb,var(--portal-primary-foreground,#ffffff)_15%,transparent)]"
+                      : "text-[color-mix(in_srgb,var(--portal-primary-foreground,#ffffff)_80%,transparent)] hover:bg-[color-mix(in_srgb,var(--portal-primary-foreground,#ffffff)_10%,transparent)] hover:text-[var(--portal-primary-foreground,#ffffff)]"
+                  }`}
+                >
+                  {tab.label}
+                </Link>
+              );
+            })}
+          </nav>
+        </div>
+        {returnUrl && (
+          <a
+            href={returnUrl}
+            className="whitespace-nowrap text-[color-mix(in_srgb,var(--portal-primary-foreground,#ffffff)_85%,transparent)] text-sm transition-colors hover:text-[var(--portal-primary-foreground,#ffffff)]"
+          >
+            ← Return to {appName ?? "application"}
+          </a>
+        )}
       </div>
     </header>
   );

--- a/web/apps/portal/src/lib/branding.ts
+++ b/web/apps/portal/src/lib/branding.ts
@@ -1,0 +1,50 @@
+/**
+ * Readable text color to place on top of a brand color background.
+ *
+ * The header, footer, and keys table header paint their background with the
+ * customer's `--portal-primary`. A fixed `white` breaks on light brand colors
+ * (yellow, pale gray), so choose dark or light text from the background's
+ * relative luminance using the WCAG threshold (~0.179) that maximizes contrast
+ * against black vs. white.
+ *
+ * Returns the light color for missing/unparseable input, since the bar then
+ * falls back to the dark `--color-gray-12`.
+ */
+const ON_PRIMARY_LIGHT = "#ffffff";
+const ON_PRIMARY_DARK = "#0a0a0a";
+
+export function onPrimaryColor(primaryColor: string | null | undefined): string {
+  const rgb = parseHexColor(primaryColor);
+  if (!rgb) {
+    return ON_PRIMARY_LIGHT;
+  }
+  return relativeLuminance(rgb) > 0.179 ? ON_PRIMARY_DARK : ON_PRIMARY_LIGHT;
+}
+
+type Rgb = { r: number; g: number; b: number };
+
+/** Parse `#rgb` / `#rrggbb` (case-insensitive) into 0–255 channels. */
+function parseHexColor(value: string | null | undefined): Rgb | null {
+  if (!value) {
+    return null;
+  }
+  const hex = value.trim().replace(/^#/, "");
+  const full = hex.length === 3 ? hex.replace(/./g, (c) => c + c) : hex;
+  if (!/^[0-9a-fA-F]{6}$/.test(full)) {
+    return null;
+  }
+  return {
+    r: Number.parseInt(full.slice(0, 2), 16),
+    g: Number.parseInt(full.slice(2, 4), 16),
+    b: Number.parseInt(full.slice(4, 6), 16),
+  };
+}
+
+/** WCAG relative luminance in [0, 1] for an sRGB color. */
+function relativeLuminance({ r, g, b }: Rgb): number {
+  const [rl, gl, bl] = [r, g, b].map((channel) => {
+    const c = channel / 255;
+    return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * rl + 0.7152 * gl + 0.0722 * bl;
+}

--- a/web/apps/portal/src/lib/portal-config.ts
+++ b/web/apps/portal/src/lib/portal-config.ts
@@ -9,6 +9,7 @@ export type PortalBranding = {
 
 export type PortalConfig = {
   id: string;
+  slug: string;
   enabled: boolean;
   returnUrl: string | null;
   branding: PortalBranding | null;
@@ -23,6 +24,7 @@ export async function loadPortalConfig(portalConfigId: string): Promise<PortalCo
     where: eq(schema.portalConfigurations.id, portalConfigId),
     columns: {
       id: true,
+      slug: true,
       enabled: true,
       returnUrl: true,
     },
@@ -42,6 +44,7 @@ export async function loadPortalConfig(portalConfigId: string): Promise<PortalCo
 
   return {
     id: config.id,
+    slug: config.slug,
     enabled: config.enabled,
     returnUrl: config.returnUrl,
     branding: config.branding ?? null,

--- a/web/apps/portal/src/routes/_portal.tsx
+++ b/web/apps/portal/src/routes/_portal.tsx
@@ -1,6 +1,8 @@
 import { Outlet, createFileRoute, redirect } from "@tanstack/react-router";
+import { PortalFooter } from "~/components/portal-footer";
 import { PortalHeader } from "~/components/portal-header";
 import { PreviewBanner } from "~/components/preview-banner";
+import { onPrimaryColor } from "~/lib/branding";
 import { getSessionWithConfig } from "~/lib/session";
 
 export const Route = createFileRoute("/_portal")({
@@ -21,20 +23,29 @@ export const Route = createFileRoute("/_portal")({
 function PortalLayout() {
   const { session, portalConfig } = Route.useRouteContext();
 
-  // Inject branding CSS variables so components can use them.
-  const brandingStyle: Record<string, string> = {};
+  // Inject branding CSS variables so components can use them. The foreground is
+  // always set (even without a brand color) so surfaces painted with
+  // --portal-primary — which falls back to the dark gray-12 — get readable text.
+  const brandingStyle: Record<string, string> = {
+    "--portal-primary-foreground": onPrimaryColor(portalConfig?.branding?.primaryColor),
+  };
   if (portalConfig?.branding?.primaryColor) {
     brandingStyle["--portal-primary"] = portalConfig.branding.primaryColor;
   }
 
   return (
-    <div style={brandingStyle}>
+    <div style={brandingStyle} className="flex min-h-screen flex-col bg-background">
       {session.preview && <PreviewBanner />}
       <PortalHeader
         permissions={session.permissions}
         logoUrl={portalConfig?.branding?.logoUrl ?? undefined}
+        returnUrl={portalConfig?.returnUrl ?? undefined}
+        appName={portalConfig?.slug ?? undefined}
       />
-      <Outlet />
+      <div className="flex-1">
+        <Outlet />
+      </div>
+      <PortalFooter />
     </div>
   );
 }

--- a/web/apps/portal/src/routes/_portal/analytics.tsx
+++ b/web/apps/portal/src/routes/_portal/analytics.tsx
@@ -56,8 +56,13 @@ function AnalyticsPage() {
 
   return (
     <main className="mx-auto max-w-5xl px-4 pt-8 pb-12 sm:px-8">
-      <div className="mb-6 flex items-center justify-between gap-4">
-        <h1 className="font-semibold text-2xl text-gray-12">Analytics</h1>
+      <header className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+        <div className="flex flex-col gap-1">
+          <h1 className="font-semibold text-gray-12 text-xl">Analytics</h1>
+          <p className="text-gray-11 text-sm">
+            Monitor verification activity and usage trends for your API keys.
+          </p>
+        </div>
         {periodOptions.length > 1 && (
           <Select
             value={String(days)}
@@ -79,7 +84,7 @@ function AnalyticsPage() {
             </SelectContent>
           </Select>
         )}
-      </div>
+      </header>
 
       {isInitialLoading ? (
         <AnalyticsLoading />
@@ -110,7 +115,7 @@ function AnalyticsPage() {
             <MetricCard label="Success Rate" value={formatPercent(metrics.successRate)} />
             <MetricCard label="Error Rate" value={formatPercent(metrics.errorRate)} />
           </div>
-          <div className="rounded-lg border border-gray-6 bg-background p-4">
+          <div className="rounded-lg border border-primary/10 bg-background p-4">
             <VerificationsChart buckets={buckets} days={days} />
           </div>
         </div>
@@ -126,7 +131,7 @@ function formatPercent(fraction: number): string {
 
 function MetricCard({ label, value }: { label: string; value: string }) {
   return (
-    <div className="rounded-md border border-gray-6 bg-background p-4">
+    <div className="rounded-lg border border-primary/10 bg-background p-4">
       <span className="text-gray-11 text-xs">{label}</span>
       <div className="mt-1 font-semibold text-2xl text-gray-12 tabular-nums">{value}</div>
     </div>
@@ -146,7 +151,7 @@ function AnalyticsLoading() {
 
 function AnalyticsEmpty() {
   return (
-    <div className="rounded-lg border border-gray-6 bg-background">
+    <div className="rounded-lg border border-primary/10 bg-background">
       <Empty>
         <EmptyHeader>
           <EmptyMedia variant="icon">

--- a/web/apps/portal/src/routes/_portal/keys.tsx
+++ b/web/apps/portal/src/routes/_portal/keys.tsx
@@ -48,6 +48,7 @@ function KeysPage() {
       ) : (
         <TooltipProvider delay={300}>
           <KeysTable
+            appName={portalConfig?.slug ?? undefined}
             keys={keys}
             searchValue={search}
             onSearchChange={setSearch}


### PR DESCRIPTION
> [!IMPORTANT]
> Unkey is not accepting external pull requests at this time. Pull requests from people outside the Unkey team will not be reviewed or merged.

## What does this PR do?

When Keys and Analytics page was implemented, not all of Dave's designs were part of it. This implements the page layouts properly according to dave-initial-designs.

It also handles branding, and edge cases for branding including:

- implementing branding color and logo
- adaptive text color for contrast
- default branding if no customer provided brand colors or logo

Right now, we're just showing the slug for the app name until the DB schema change PR lands.
### ⚠️ Also, ignore Analytics styling docs, we're punting that into v2 in another PR ⚠️ 

| screenshot | description | 
| ---- | ---- | 
| <img width="2142" height="1668" alt="nobrand3" src="https://github.com/user-attachments/assets/7a75e61d-1b55-432a-8fb9-8186fbeeb49d" />  | Keys page, Default no branding color, no logo |
| <img width="2142" height="1668" alt="analytics_data" src="https://github.com/user-attachments/assets/a7070851-e025-41fd-9431-f55e40507895" /> | Analytics page, blue branding, with logo |
| <img width="2142" height="1668" alt="pink" src="https://github.com/user-attachments/assets/49b672ba-f86b-4668-94ea-12c2fc8b9045" /> | Analytics page, pink eyesore to show adaptive text, with logo | 
 

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Manual testing:
- Run the portal app
- Seed a portal session with keys:read, keys:reroll, analytics:read permissions
- seed some keys
- Either:
A. hit POST /v2/portal.exchangeSession with the session id to get the httpOnly cookie set for you, then open /keys; or
B. Set the cookie manually: in devtools console on the portal origin, document.cookie = "portal_session=<sessionId>; path=/", 
- Then navigate to /keys or /analytics.

## Checklist

<!-- Complete this checklist before requesting review. -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [x] Ran `mise run fmt`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary
