### PR TITLE
fix(portal): remove analytics and docs

### DIFF
--- a/web/apps/portal/src/components/portal-header.tsx
+++ b/web/apps/portal/src/components/portal-header.tsx
@@ -1,8 +1,4 @@
-import { Link, useLocation } from "@tanstack/react-router";
-import { deriveVisibleTabs } from "~/lib/permissions";
-
 type PortalHeaderProps = {
-  permissions: string[];
   logoUrl?: string;
   returnUrl?: string;
   appName?: string;
@@ -10,46 +6,23 @@ type PortalHeaderProps = {
 
 /**
  * Branded portal header: a colored bar (customer's primary color, dark
- * fallback) carrying the logo and permission-derived navigation on the left and
- * a return-to-application link on the right.
+ * fallback) carrying the logo on the left and a return-to-application link on
+ * the right. Tabbed navigation was removed while Analytics and Docs are
+ * deferred to v2; the portal currently exposes only the Keys page.
  */
-export function PortalHeader({ permissions, logoUrl, returnUrl, appName }: PortalHeaderProps) {
-  const location = useLocation();
-  const tabs = deriveVisibleTabs(permissions);
-
+export function PortalHeader({ logoUrl, returnUrl, appName }: PortalHeaderProps) {
   return (
     <header
       className="w-full text-[var(--portal-primary-foreground,#ffffff)]"
       style={{ backgroundColor: "var(--portal-primary, var(--color-gray-12))" }}
     >
       <div className="flex h-14 items-center justify-between gap-6 px-4 sm:px-8">
-        <div className="flex items-center gap-6">
-          {(logoUrl || appName) && (
-            <div className="flex items-center gap-2.5">
-              {logoUrl && <img src={logoUrl} alt="" className="h-6 w-auto" aria-hidden="true" />}
-              {appName && <span className="font-medium text-sm">{appName}</span>}
-            </div>
-          )}
-          <nav className="flex items-center gap-1" aria-label="Portal navigation">
-            {tabs.map((tab) => {
-              const isActive = location.pathname.startsWith(tab.href);
-              return (
-                <Link
-                  key={tab.id}
-                  to={tab.href}
-                  aria-current={isActive ? "page" : undefined}
-                  className={`rounded-md px-3 py-1.5 font-medium text-sm transition-colors ${
-                    isActive
-                      ? "bg-[color-mix(in_srgb,var(--portal-primary-foreground,#ffffff)_15%,transparent)]"
-                      : "text-[color-mix(in_srgb,var(--portal-primary-foreground,#ffffff)_80%,transparent)] hover:bg-[color-mix(in_srgb,var(--portal-primary-foreground,#ffffff)_10%,transparent)] hover:text-[var(--portal-primary-foreground,#ffffff)]"
-                  }`}
-                >
-                  {tab.label}
-                </Link>
-              );
-            })}
-          </nav>
-        </div>
+        {(logoUrl || appName) && (
+          <div className="flex items-center gap-2.5">
+            {logoUrl && <img src={logoUrl} alt="" className="h-6 w-auto" aria-hidden="true" />}
+            {appName && <span className="font-medium text-sm">{appName}</span>}
+          </div>
+        )}
         {returnUrl && (
           <a
             href={returnUrl}

--- a/web/apps/portal/src/lib/permissions.test.ts
+++ b/web/apps/portal/src/lib/permissions.test.ts
@@ -1,58 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { canReadAnalytics, canReadKeys, deriveVisibleTabs } from "./permissions";
-
-describe("deriveVisibleTabs", () => {
-  it("shows Keys and Docs tabs for a keys capability", () => {
-    const tabs = deriveVisibleTabs(["keys:read"]);
-    const ids = tabs.map((t) => t.id);
-
-    expect(ids).toContain("keys");
-    expect(ids).toContain("docs");
-    expect(ids).not.toContain("analytics");
-  });
-
-  it("hides Keys tab for a keys capability that can't read (e.g. reroll only)", () => {
-    // The keys page's access guard requires keys:read, so the tab must not show
-    // for a reroll-only session or clicking it would redirect to a dead end.
-    const tabs = deriveVisibleTabs(["keys:reroll"]);
-    const ids = tabs.map((t) => t.id);
-
-    expect(ids).not.toContain("keys");
-    expect(ids).not.toContain("analytics");
-    expect(ids).toContain("docs");
-  });
-
-  it("shows Analytics and Docs tabs for analytics capability", () => {
-    const tabs = deriveVisibleTabs(["analytics:read"]);
-    const ids = tabs.map((t) => t.id);
-
-    expect(ids).toContain("analytics");
-    expect(ids).toContain("docs");
-    expect(ids).not.toContain("keys");
-  });
-
-  it("shows Keys, Analytics, and Docs tabs for all capabilities", () => {
-    const tabs = deriveVisibleTabs(["keys:read", "keys:reroll", "analytics:read"]);
-    const ids = tabs.map((t) => t.id);
-
-    expect(ids).toContain("keys");
-    expect(ids).toContain("analytics");
-    expect(ids).toContain("docs");
-  });
-
-  it("shows only Docs tab for a capability that matches no tab", () => {
-    const tabs = deriveVisibleTabs(["something:else"]);
-    const ids = tabs.map((t) => t.id);
-
-    expect(ids).toEqual(["docs"]);
-  });
-
-  it("returns no tabs for empty permissions array", () => {
-    const tabs = deriveVisibleTabs([]);
-
-    expect(tabs).toHaveLength(0);
-  });
-});
+import { canReadKeys, getDefaultTabHref } from "./permissions";
 
 describe("canReadKeys", () => {
   it("is true when keys:read is present", () => {
@@ -76,20 +23,22 @@ describe("canReadKeys", () => {
   });
 });
 
-describe("canReadAnalytics", () => {
-  it("is true when analytics:read is present", () => {
-    expect(canReadAnalytics(["analytics:read"])).toBe(true);
+describe("getDefaultTabHref", () => {
+  it("lands on the keys page when the session can read keys", () => {
+    expect(getDefaultTabHref(["keys:read"])).toBe("/keys");
   });
 
-  it("is true alongside other capabilities", () => {
-    expect(canReadAnalytics(["keys:read", "analytics:read"])).toBe(true);
+  it("ignores deferred analytics capability when keys is absent", () => {
+    // Analytics is deferred to v2, so analytics:read no longer grants a landing
+    // destination even though the session carries it.
+    expect(getDefaultTabHref(["analytics:read"])).toBeNull();
   });
 
-  it("is false for unrelated capabilities", () => {
-    expect(canReadAnalytics(["keys:read", "keys:reroll"])).toBe(false);
+  it("is null when the session can't read keys", () => {
+    expect(getDefaultTabHref(["keys:reroll"])).toBeNull();
   });
 
-  it("is false for empty permissions", () => {
-    expect(canReadAnalytics([])).toBe(false);
+  it("is null for empty permissions", () => {
+    expect(getDefaultTabHref([])).toBeNull();
   });
 });

--- a/web/apps/portal/src/lib/permissions.ts
+++ b/web/apps/portal/src/lib/permissions.ts
@@ -1,75 +1,23 @@
 /**
- * Portal tab identifiers. Each tab maps to a route in the portal app.
- */
-export type PortalTab = "keys" | "analytics" | "docs";
-
-type TabConfig = {
-  id: PortalTab;
-  label: string;
-  href: string;
-};
-
-const TAB_CONFIGS: ReadonlyArray<TabConfig> = [
-  { id: "keys", label: "API Keys", href: "/keys" },
-  { id: "analytics", label: "Analytics", href: "/analytics" },
-  { id: "docs", label: "Documentation", href: "/docs" },
-] as const;
-
-/**
- * Analytics capability that grants visibility to the Analytics tab.
- */
-const ANALYTICS_READ = "analytics:read";
-
-/**
- * Derive visible portal tabs from a session's capabilities.
- *
- * Capabilities use the portal's colon vocabulary, issued by
- * `portal.createSession` and persisted on the session
- * (e.g. `keys:read`, `keys:reroll`, `analytics:read`). Per the RFC:
- * - Keys tab: `keys:read` (matches the keys page's access guard, so the tab is
- *   never shown to a session the page would redirect away; see {@link canReadKeys})
- * - Analytics tab: `analytics:read`
- * - Docs tab: visible when any capability is present
- */
-export function deriveVisibleTabs(permissions: ReadonlyArray<string>): ReadonlyArray<TabConfig> {
-  const hasKeys = canReadKeys(permissions);
-  const hasAnalytics = canReadAnalytics(permissions);
-  const hasDocs = permissions.length > 0;
-
-  return TAB_CONFIGS.filter((tab) => {
-    switch (tab.id) {
-      case "keys":
-        return hasKeys;
-      case "analytics":
-        return hasAnalytics;
-      case "docs":
-        return hasDocs;
-    }
-  });
-}
-
-/**
  * Whether a session may read keys. The portal keys page lists keys via
  * `portal.listKeys`, which the API authorizes with `read_key`, so the page must
  * only render for sessions granted the `keys:read` capability.
+ *
+ * Capabilities use the portal's colon vocabulary, issued by
+ * `portal.createSession` and persisted on the session (e.g. `keys:read`,
+ * `keys:reroll`).
  */
 export function canReadKeys(permissions: ReadonlyArray<string>): boolean {
   return permissions.includes("keys:read");
 }
 
 /**
- * Whether a session may read analytics. The portal analytics page queries
- * verification analytics via `portal.getVerifications`, so the page must only
- * render for sessions granted the `analytics:read` capability.
- */
-export function canReadAnalytics(permissions: ReadonlyArray<string>): boolean {
-  return permissions.includes(ANALYTICS_READ);
-}
-
-/**
- * Get the first visible tab's href for redirect after session exchange.
+ * Landing destination after session exchange.
+ *
+ * The portal currently exposes only the Keys page; Analytics and Docs are
+ * deferred to v2 and blocked at the route layer. Returns null when the session
+ * can't read keys so the caller can surface an appropriate state.
  */
 export function getDefaultTabHref(permissions: ReadonlyArray<string>): string | null {
-  const tabs = deriveVisibleTabs(permissions);
-  return tabs.length > 0 ? tabs[0].href : null;
+  return canReadKeys(permissions) ? "/keys" : null;
 }

--- a/web/apps/portal/src/routes/_portal.tsx
+++ b/web/apps/portal/src/routes/_portal.tsx
@@ -37,7 +37,6 @@ function PortalLayout() {
     <div style={brandingStyle} className="flex min-h-screen flex-col bg-background">
       {session.preview && <PreviewBanner />}
       <PortalHeader
-        permissions={session.permissions}
         logoUrl={portalConfig?.branding?.logoUrl ?? undefined}
         returnUrl={portalConfig?.returnUrl ?? undefined}
         appName={portalConfig?.slug ?? undefined}

--- a/web/apps/portal/src/routes/_portal/analytics.tsx
+++ b/web/apps/portal/src/routes/_portal/analytics.tsx
@@ -24,17 +24,14 @@ import {
   SelectTrigger,
   SelectValue,
 } from "~/components/ui/select";
-import { canReadAnalytics } from "~/lib/permissions";
 import { isRetentionExceededError, isUnauthorizedError } from "~/lib/portal-api";
 
 export const Route = createFileRoute("/_portal/analytics")({
-  beforeLoad: ({ context }) => {
-    // The page queries verification analytics via portal.getVerifications
-    // (authorized with analytics:read), so it must only render for sessions
-    // that carry that capability.
-    if (!canReadAnalytics(context.session.permissions)) {
-      throw redirect({ to: "/" });
-    }
+  beforeLoad: () => {
+    // Analytics is deferred to v2. The route is kept for reuse but blocked at
+    // the route layer: it must not render even for a session that carries
+    // analytics:read, and direct navigation is redirected away.
+    throw redirect({ to: "/keys" });
   },
   component: AnalyticsPage,
 });

--- a/web/apps/portal/src/routes/_portal/docs.tsx
+++ b/web/apps/portal/src/routes/_portal/docs.tsx
@@ -1,6 +1,11 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, redirect } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/_portal/docs")({
+  beforeLoad: () => {
+    // Docs is deferred to v2. The route is kept for reuse but blocked at the
+    // route layer: direct navigation must not render the page.
+    throw redirect({ to: "/keys" });
+  },
   component: DocsPage,
 });
 


### PR DESCRIPTION
> [!IMPORTANT]
> Unkey is not accepting external pull requests at this time. Pull requests from people outside the Unkey team will not be reviewed or merged.

## What does this PR do?

Analytics and Docs are being de-prioritized to v2. Navigation is removed, and permissions block the routes, even if the permissions are present on the session. The routes are kept since it's really just styling and polishing changes, but they're inaccessible. Going directly to the route will redirect to keys

Fixes ENG-3085

| Screenshot | Description |
| ---- | ----| 
| <img width="1071" height="834" alt="Screenshot 2026-07-23 at 3 13 28 PM" src="https://github.com/user-attachments/assets/736b3429-0175-4e72-b773-59a0d18696d1" /> | No Analytics or Docs tabs, no navigation at all. Portal session created with `analytics:read` permission | 


## Type of change

<!-- Please mark the relevant points by using [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

Manual testing:

- Seed a portal session with keys:read, keys:reroll, analytics:read
- Run the portal, exchange or set your cookie with sessionId 
- Verify analytics is inaccessible. Verify docs is inaccessible. 

## Checklist

<!-- Complete this checklist before requesting review. -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [x] Ran `mise run fmt`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary
