### PR TITLE
revert: do not check system.tables or meta permissions

### DIFF
--- a/pkg/clickhouse/user.go
+++ b/pkg/clickhouse/user.go
@@ -171,22 +171,6 @@ func (c *Client) ConfigureUser(ctx context.Context, config UserConfig) error {
 		}
 	}
 
-	// ClickHouse exposes metadata for every table a user can SELECT through
-	// system.tables and system.columns, even without explicit system-table
-	// grants. Empty row policies keep physical schema details behind the API's
-	// public table aliases.
-	metadataPolicyName := fmt.Sprintf("workspace_%s_metadata_rls", config.WorkspaceID)
-	for _, table := range []string{"system.tables", "system.columns"} {
-		createPolicySQL := fmt.Sprintf(
-			"CREATE ROW POLICY OR REPLACE %s ON %s AS RESTRICTIVE FOR SELECT USING 0 TO %s",
-			metadataPolicyName, table, config.Username,
-		)
-		err = c.Exec(ctx, createPolicySQL)
-		if err != nil {
-			return fmt.Errorf("failed to hide metadata from %s: %w", table, err)
-		}
-	}
-
 	// Create or replace quota
 	quotaName := fmt.Sprintf("workspace_%s_quota", config.WorkspaceID)
 	logger.Info("creating/updating quota", "name", quotaName)

--- a/pkg/clickhouse/user_test.go
+++ b/pkg/clickhouse/user_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/unkeyed/unkey/pkg/clickhouse"
 	"github.com/unkeyed/unkey/pkg/testutil/containers"
+	"github.com/unkeyed/unkey/pkg/uid"
 )
 
 // TestConfigureUser_ProtectsPerQueryLimits guarantees workspace users retain
@@ -23,7 +24,7 @@ func TestConfigureUser_ProtectsPerQueryLimits(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, admin.Close()) })
 
-	workspaceID := fmt.Sprintf("ws_sqlsec_%d", time.Now().UnixNano())
+	workspaceID := uid.New(uid.WorkspacePrefix)
 	password := "sqlsec_password"
 	err = admin.ConfigureUser(ctx, clickhouse.UserConfig{
 		WorkspaceID:               workspaceID,
@@ -113,7 +114,7 @@ func TestConfigureUser_HTTPTransport(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, admin.Close()) })
 
-	workspaceID := fmt.Sprintf("ws_http_%d", time.Now().UnixNano())
+	workspaceID := uid.New(uid.WorkspacePrefix)
 	password := "http_password"
 	err = admin.ConfigureUser(ctx, clickhouse.UserConfig{
 		WorkspaceID:               workspaceID,

--- a/pkg/clickhouse/user_test.go
+++ b/pkg/clickhouse/user_test.go
@@ -103,10 +103,9 @@ func TestConfigureUser_ProtectsPerQueryLimits(t *testing.T) {
 	}
 }
 
-// TestConfigureUser_HTTPTransportAndMetadataContracts proves workspace users
-// can query over HTTP with bounded API contexts and cannot inspect physical
-// schema metadata.
-func TestConfigureUser_HTTPTransportAndMetadataContracts(t *testing.T) {
+// TestConfigureUser_HTTPTransport proves workspace users can query over HTTP
+// with bounded API contexts.
+func TestConfigureUser_HTTPTransport(t *testing.T) {
 	ctx := context.Background()
 	clickhouseConfig := containers.ClickHouse(t)
 
@@ -114,8 +113,8 @@ func TestConfigureUser_HTTPTransportAndMetadataContracts(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, admin.Close()) })
 
-	workspaceID := fmt.Sprintf("ws_httpmeta_%d", time.Now().UnixNano())
-	password := "httpmeta_password"
+	workspaceID := fmt.Sprintf("ws_http_%d", time.Now().UnixNano())
+	password := "http_password"
 	err = admin.ConfigureUser(ctx, clickhouse.UserConfig{
 		WorkspaceID:               workspaceID,
 		Username:                  workspaceID,
@@ -130,20 +129,6 @@ func TestConfigureUser_HTTPTransportAndMetadataContracts(t *testing.T) {
 		RetentionDays:             30,
 	})
 	require.NoError(t, err)
-
-	t.Run("admin retains metadata visibility", func(t *testing.T) {
-		// A workspace policy must not change metadata visibility for users that
-		// are not assigned that policy.
-		for _, query := range []string{
-			"SELECT count() FROM system.tables WHERE database = 'default' AND name = 'key_verifications_raw_v2'",
-			"SELECT count() FROM system.columns WHERE database = 'default' AND table = 'key_verifications_raw_v2'",
-		} {
-			var count uint64
-			err := admin.Conn().QueryRow(ctx, query).Scan(&count)
-			require.NoError(t, err)
-			require.Positive(t, count)
-		}
-	})
 
 	t.Run("HTTP transport accepts the API deadline", func(t *testing.T) {
 		// This locks the production client path. The server profile owns the
@@ -170,46 +155,5 @@ func TestConfigureUser_HTTPTransportAndMetadataContracts(t *testing.T) {
 			require.ErrorIs(t, err, context.DeadlineExceeded)
 			require.Less(t, time.Since(startedAt), time.Second)
 		})
-	})
-
-	t.Run("direct user cannot inspect physical schema metadata", func(t *testing.T) {
-		// Table-specific grants must not reveal the physical table and column
-		// inventory through ClickHouse metadata tables.
-		options, err := driver.ParseDSN(clickhouseConfig.DSN)
-		require.NoError(t, err)
-		options.Auth.Username = workspaceID
-		options.Auth.Password = password
-
-		workspaceConn, err := driver.Open(options)
-		require.NoError(t, err)
-		t.Cleanup(func() { require.NoError(t, workspaceConn.Close()) })
-
-		queries := []struct {
-			name  string
-			query string
-		}{
-			{
-				name:  "system.tables",
-				query: "SELECT count() FROM system.tables WHERE database = 'default' AND name = 'key_verifications_raw_v2'",
-			},
-			{
-				name:  "system.columns",
-				query: "SELECT count() FROM system.columns WHERE database = 'default' AND table = 'key_verifications_raw_v2'",
-			},
-		}
-		for _, query := range queries {
-			t.Run(query.name, func(t *testing.T) {
-				var count uint64
-				err := workspaceConn.QueryRow(ctx, query.query).Scan(&count)
-				if err == nil {
-					require.Zero(t, count, "workspace user must not see physical schema metadata through %s", query.name)
-					return
-				}
-
-				var clickhouseErr *driver.Exception
-				require.ErrorAs(t, err, &clickhouseErr, "workspace user must not read %s", query.name)
-				require.Equal(t, int32(497), clickhouseErr.Code)
-			})
-		}
 	})
 }


### PR DESCRIPTION
we have app-level checks in place for it