### PR TITLE
fix: kill cronjobs instead of pause and allow ratelimit cleanup to de…

### DIFF
--- a/.agents/skills/reviewing-restate-handlers/SKILL.md
+++ b/.agents/skills/reviewing-restate-handlers/SKILL.md
@@ -1,19 +1,49 @@
 ---
 name: reviewing-restate-handlers
-description: "Reviews restate handler code in svc/ctrl/worker to find restate client calls (service calls, state access, sleep, etc.) incorrectly placed inside restate.Run, restate.RunVoid, or restate.RunAsync closures. Use when reviewing restate handlers, checking restate.Run usage, or auditing worker service code."
+description: "Reviews restate handler code in svc/ctrl/worker for two classes of defect: restate client calls (service calls, state access, sleep, etc.) incorrectly placed inside restate.Run/RunVoid/RunAsync closures, and cron handlers whose invocation retry policy pauses instead of kills on max attempts. Use when reviewing restate handlers, adding a cron job, checking restate.Run usage, or auditing worker service code."
 ---
 
 # Reviewing Restate Handlers
 
+Two independent audits: [context misuse inside `Run` closures](#context-misuse-inside-run-closures) and [cron retry policy](#cron-retry-policy). Run both when reviewing worker code; run the retry-policy one whenever a cron handler is added or its policy is touched.
+
+## Cron retry policy
+
+**Every cron handler must set an explicit `restate.WithInvocationRetryPolicy` ending in `restate.KillOnMaxAttempts()`. Never `restate.PauseOnMaxAttempts()`, and never leave the policy unset.**
+
+Cron handlers in `svc/ctrl/worker/cron/` are Virtual Object handlers on a fixed or period-derived key, so every tick under that key shares one queue. A paused invocation sits on the key forever waiting for an operator, and every later tick queues behind it, so a single bad run silently stops the whole job until someone notices (this is how the key_last_used_sync incident wedged: partitions hit a Restate 404, sat paused, and suspended the run). Killing lets the invocation finish terminally, the queue drains, and the next tick retries from a clean slate.
+
+Killing is safe for crons specifically because they satisfy all three of:
+
+- **Idempotent or cursor-driven.** A cron re-derives its work each tick (a fresh cutoff, a persisted cursor, an absolute month-to-date total), so dropping one run loses nothing that the next run will not redo.
+- **No compensation to run.** Pausing exists so a handler can be re-entered and its Go `defer`-based compensation can fire; `KILL` tears the invocation down without re-entering the handler, so `defer compensation.Execute` never runs. Cron handlers have no compensations. Workflow-style services that do (e.g. `DeployService`) legitimately pause — do not "fix" those.
+- **Failure is visible another way.** Crons report health through a heartbeat ping, so a missing end-of-run heartbeat surfaces the failure without needing a parked invocation as the signal.
+
+Leaving the policy unset is also wrong: the SDK default retries forever, which parks the VO key indefinitely — the same wedge as pausing, with no attempt cap.
+
+Note that "the DELETE is stateless, so pausing lets an operator inspect it" is not a valid exception. The inspection value is a journal that retention will drop anyway, and the cost is a wedged key.
+
+### What to check
+
+For each handler registered via `ConfigureHandler` on `hydrav1.NewCronServiceServer` in `svc/ctrl/worker/run.go`, and for each standalone service that a cron fans out to (per-partition, per-workspace children):
+
+1. A `restate.WithInvocationRetryPolicy(...)` is passed.
+2. It sets `restate.WithMaxAttempts(...)` — an unbounded policy retries forever.
+3. It ends in `restate.KillOnMaxAttempts()`.
+
+Report `PauseOnMaxAttempts()` on a cron handler, or a cron handler with no policy at all, as a violation.
+
+## Context misuse inside Run closures
+
 Audit restate handler code to ensure the outer restate context is never used inside `restate.Run`, `restate.RunVoid`, or `restate.RunAsync` closures.
 
-## Background
+### Background
 
 Restate journals every interaction with its context for deterministic replay. The `restate.Run` / `restate.RunVoid` / `restate.RunAsync` functions wrap **non-deterministic side effects** (DB queries, HTTP calls, etc.) into a single journaled step. Inside these closures, the only context available is `restate.RunContext`, which is a plain `context.Context` — it has no restate capabilities.
 
 If the **outer** restate context (the handler's `ctx` parameter, typed as `restate.Context`, `restate.ObjectContext`, `restate.WorkflowContext`, `restate.WorkflowSharedContext`, etc.) is used inside a `Run` closure, it can break replay determinism and cause subtle bugs that are very hard to diagnose.
 
-## What to check
+### What to check
 
 Scan all `.go` files under `svc/ctrl/worker/` for closures passed to:
 - `restate.Run(ctx, func(rc restate.RunContext) ...)`
@@ -27,7 +57,7 @@ Inside each closure body, flag any reference to the **outer** restate context va
 - `restate.WorkflowContext`
 - `restate.WorkflowSharedContext`
 
-### Violations — using the outer `ctx` inside the closure
+#### Violations — using the outer `ctx` inside the closure
 
 These are **forbidden** inside `restate.Run` / `restate.RunVoid` / `restate.RunAsync`:
 
@@ -39,7 +69,7 @@ These are **forbidden** inside `restate.Run` / `restate.RunVoid` / `restate.RunA
 6. **Async operations**: `restate.RunAsync(ctx, ...)`, sending messages via `.Send()`
 7. **Any other method or function that takes the outer `ctx`** where `ctx` is a restate context type
 
-### Allowed — using the closure's `RunContext`
+#### Allowed — using the closure's `RunContext`
 
 Inside the closure, code should use the `restate.RunContext` parameter (often named `rc`, `runCtx`, or `stepCtx`) for:
 - Database queries: `db.Query.Something(runCtx, ...)`
@@ -47,13 +77,15 @@ Inside the closure, code should use the `restate.RunContext` parameter (often na
 - External API calls: `s.vault.Encrypt(runCtx, ...)`
 - Any operation that needs a `context.Context`
 
-### Not a violation
+#### Not a violation
 
 - Using the outer `ctx` **outside** of `restate.Run` closures is correct and expected
 - Passing plain values (not the context) captured from outer scope into the closure is fine
 - Using `restate.TerminalError(...)` inside a closure is fine (it doesn't take a context)
 
 ## Procedure
+
+Context misuse:
 
 1. Use `Grep` to find all files containing `restate.Run`, `restate.RunVoid`, or `restate.RunAsync` under `svc/ctrl/worker/`
 2. Read each file
@@ -62,6 +94,13 @@ Inside the closure, code should use the `restate.RunContext` parameter (often na
    - The closure's `RunContext` parameter name
 4. Check if the outer context variable appears anywhere in the closure body
 5. Report each violation with file, line, and what the fix should be (either move the call outside the closure, or replace `ctx` with the closure's `RunContext` if the call only needs a `context.Context`)
+
+Cron retry policy:
+
+1. Read the `hydrav1.NewCronServiceServer(...)` binding in `svc/ctrl/worker/run.go` and list every handler name passed to `ConfigureHandler`, plus every handler declared on `CronService` in `svc/ctrl/proto/hydra/v1/cron.proto`
+2. Any `CronService` handler with no `ConfigureHandler` entry, or whose entry passes no retry policy, is a violation (the SDK default retries forever)
+3. For each policy, check it sets `WithMaxAttempts` and ends in `KillOnMaxAttempts()`
+4. Repeat for the standalone services a cron fans out to (per-partition, per-workspace children bound separately in `run.go`)
 
 ## Output format
 
@@ -73,4 +112,10 @@ FILE:LINE — `ctx` used inside restate.Run/RunVoid/RunAsync
   Violation: `someFunction(ctx, ...)` should use `runCtx` or be moved outside the closure
 ```
 
-If no violations are found, report: "No restate context violations found."
+```
+FILE:LINE — cron handler pauses on retry exhaustion
+  Handler: RunSomething (ConfigureHandler in run.go)
+  Violation: `restate.PauseOnMaxAttempts()` wedges the VO key; use `restate.KillOnMaxAttempts()`
+```
+
+If no violations are found, report: "No restate context violations found." and/or "All cron handlers kill on max attempts."

--- a/internal/services/ratelimit/db/global_counters_delete_expired.sql_generated.go
+++ b/internal/services/ratelimit/db/global_counters_delete_expired.sql_generated.go
@@ -12,17 +12,31 @@ import (
 const globalCountersDeleteExpired = `-- name: GlobalCountersDeleteExpired :execrows
 DELETE FROM ratelimit_global_counters
 WHERE expires_at < ?
+LIMIT ?
 `
 
-// GlobalCountersDeleteExpired removes rows whose grace period has passed and
-// returns the number of rows deleted so the caller can surface it for
-// observability. Called by an external Restate cron, not the ratelimit
-// service itself.
+type GlobalCountersDeleteExpiredParams struct {
+	Cutoff uint64 `db:"cutoff"`
+	Limit  int32  `db:"limit"`
+}
+
+// GlobalCountersDeleteExpired removes a bounded batch of rows whose grace
+// period has passed and returns the number of rows deleted so the caller can
+// loop until the table is drained of expired rows. Called by an external
+// Restate cron, not the ratelimit service itself.
+//
+// LIMIT is required, not an optimization: PlanetScale rejects any single DML
+// statement that would affect more than 100,000 rows, so an unbounded DELETE
+// fails outright once a backlog builds. Bounding each batch below that ceiling
+// also keeps row locks short and replication lag contained.
+//
+// expires_at_idx makes this a range seek rather than a full scan.
 //
 //	DELETE FROM ratelimit_global_counters
 //	WHERE expires_at < ?
-func (q *Queries) GlobalCountersDeleteExpired(ctx context.Context, cutoff uint64) (int64, error) {
-	result, err := q.db.ExecContext(ctx, globalCountersDeleteExpired, cutoff)
+//	LIMIT ?
+func (q *Queries) GlobalCountersDeleteExpired(ctx context.Context, arg GlobalCountersDeleteExpiredParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, globalCountersDeleteExpired, arg.Cutoff, arg.Limit)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/services/ratelimit/db/querier_generated.go
+++ b/internal/services/ratelimit/db/querier_generated.go
@@ -9,14 +9,22 @@ import (
 )
 
 type Querier interface {
-	// GlobalCountersDeleteExpired removes rows whose grace period has passed and
-	// returns the number of rows deleted so the caller can surface it for
-	// observability. Called by an external Restate cron, not the ratelimit
-	// service itself.
+	// GlobalCountersDeleteExpired removes a bounded batch of rows whose grace
+	// period has passed and returns the number of rows deleted so the caller can
+	// loop until the table is drained of expired rows. Called by an external
+	// Restate cron, not the ratelimit service itself.
+	//
+	// LIMIT is required, not an optimization: PlanetScale rejects any single DML
+	// statement that would affect more than 100,000 rows, so an unbounded DELETE
+	// fails outright once a backlog builds. Bounding each batch below that ceiling
+	// also keeps row locks short and replication lag contained.
+	//
+	// expires_at_idx makes this a range seek rather than a full scan.
 	//
 	//  DELETE FROM ratelimit_global_counters
 	//  WHERE expires_at < ?
-	GlobalCountersDeleteExpired(ctx context.Context, cutoff uint64) (int64, error)
+	//  LIMIT ?
+	GlobalCountersDeleteExpired(ctx context.Context, arg GlobalCountersDeleteExpiredParams) (int64, error)
 	// GlobalCountersImported returns the caller's own-region count and the sum of
 	// foreign-region contributions for every still-active window cell. Receivers
 	// fold the own-region count into counterEntry.val and the foreign-region count

--- a/internal/services/ratelimit/db/queries/global_counters_delete_expired.sql
+++ b/internal/services/ratelimit/db/queries/global_counters_delete_expired.sql
@@ -1,7 +1,15 @@
 -- name: GlobalCountersDeleteExpired :execrows
--- GlobalCountersDeleteExpired removes rows whose grace period has passed and
--- returns the number of rows deleted so the caller can surface it for
--- observability. Called by an external Restate cron, not the ratelimit
--- service itself.
+-- GlobalCountersDeleteExpired removes a bounded batch of rows whose grace
+-- period has passed and returns the number of rows deleted so the caller can
+-- loop until the table is drained of expired rows. Called by an external
+-- Restate cron, not the ratelimit service itself.
+--
+-- LIMIT is required, not an optimization: PlanetScale rejects any single DML
+-- statement that would affect more than 100,000 rows, so an unbounded DELETE
+-- fails outright once a backlog builds. Bounding each batch below that ceiling
+-- also keeps row locks short and replication lag contained.
+--
+-- expires_at_idx makes this a range seek rather than a full scan.
 DELETE FROM ratelimit_global_counters
-WHERE expires_at < sqlc.arg("cutoff");
+WHERE expires_at < sqlc.arg("cutoff")
+LIMIT ?;

--- a/svc/ctrl/worker/cron/ratelimit_global_counters_cleanup_integration_test.go
+++ b/svc/ctrl/worker/cron/ratelimit_global_counters_cleanup_integration_test.go
@@ -1,0 +1,86 @@
+package cron_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
+	rldb "github.com/unkeyed/unkey/internal/services/ratelimit/db"
+	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/ctrl/integration/harness"
+)
+
+// TestRunRatelimitGlobalCountersCleanup_Integration checks the cutoff: rows
+// past expires_at are swept, rows still inside their window are not. The
+// handler issues its DELETE in bounded batches (PlanetScale rejects a single
+// DML statement affecting more than 100,000 rows); the batch boundary itself is
+// not exercised here since it would take 25k seeded rows to reach.
+func TestRunRatelimitGlobalCountersCleanup_Integration(t *testing.T) {
+	h := harness.New(t)
+	rl := rldb.New(h.DB.RW(), h.DB.RO())
+
+	now := time.Now()
+	expired := seedGlobalCounters(t, h, rl, now.Add(-time.Hour).UnixMilli(), 5)
+	live := seedGlobalCounters(t, h, rl, now.Add(time.Hour).UnixMilli(), 2)
+
+	client := hydrav1.NewCronServiceIngressClient(h.Restate, "ratelimit-global-counters-cleanup")
+	resp, err := client.RunRatelimitGlobalCountersCleanup().
+		Request(h.Ctx, &hydrav1.RunRatelimitGlobalCountersCleanupRequest{})
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, resp.GetRowsDeleted(), int64(5), "every expired row should be deleted")
+
+	require.Empty(t, globalCountersFor(t, h, rl, expired), "no expired row should survive")
+	require.Len(t, globalCountersFor(t, h, rl, live), 2, "rows still inside their window must not be touched")
+}
+
+// seedGlobalCounters inserts count rows sharing one fresh workspace id, all
+// with the same expires_at. Rows differ only by sequence, which
+// unique_window_region covers, so every row is distinct. Returns the workspace
+// id so the caller can scope assertions to its own rows.
+func seedGlobalCounters(
+	t *testing.T,
+	h *harness.Harness,
+	rl *rldb.Database,
+	expiresAtMs int64,
+	count int,
+) string {
+	t.Helper()
+	workspaceID := uid.New("ws")
+
+	rows := make([]rldb.UpsertRatelimitGlobalCountersParams, 0, count)
+	for i := range count {
+		rows = append(rows, rldb.UpsertRatelimitGlobalCountersParams{
+			WorkspaceID: workspaceID,
+			Namespace:   "cleanup-test",
+			Identifier:  "user-1",
+			DurationMs:  60_000,
+			Sequence:    int64(i),
+			Region:      "test-region",
+			Count:       1,
+			ExpiresAt:   uint64(expiresAtMs),
+			UpdatedAt:   uint64(expiresAtMs),
+		})
+	}
+	require.NoError(t, rl.BulkUpsertGlobalCounters(h.Ctx, rows))
+	return workspaceID
+}
+
+func globalCountersFor(
+	t *testing.T,
+	h *harness.Harness,
+	rl *rldb.Database,
+	workspaceID string,
+) []rldb.GlobalCountersListAllRow {
+	t.Helper()
+	all, err := rl.RO().GlobalCountersListAll(h.Ctx)
+	require.NoError(t, err)
+
+	mine := make([]rldb.GlobalCountersListAllRow, 0, len(all))
+	for _, row := range all {
+		if row.WorkspaceID == workspaceID {
+			mine = append(mine, row)
+		}
+	}
+	return mine
+}

--- a/svc/ctrl/worker/cron/ratelimitcleanup/handler.go
+++ b/svc/ctrl/worker/cron/ratelimitcleanup/handler.go
@@ -15,6 +15,21 @@ import (
 	"github.com/unkeyed/unkey/pkg/logger"
 )
 
+// batchLimit bounds each DELETE. PlanetScale rejects a single DML statement
+// that would affect more than 100,000 rows, so an unbounded DELETE fails
+// outright once a backlog builds; the handler loops until a batch deletes fewer
+// than this. Sized well under the ceiling so row locks stay short and
+// replication lag stays bounded.
+const batchLimit int32 = 25_000
+
+// maxBatches caps how much one invocation drains. The handler is a
+// singleton-keyed VO on an hourly schedule, so an unbounded loop over a large
+// backlog would both grow the journal without limit and keep later ticks queued
+// behind it. Leftover rows are only a storage concern: the hot path filters on
+// expires_at, so they are never read as live counters, and the next tick
+// continues where this one stopped.
+const maxBatches = 40
+
 // Config holds the handler's dependencies.
 type Config struct {
 	// DB is the ratelimit database. Must not be nil.
@@ -40,36 +55,62 @@ func New(cfg Config) (*Handler, error) {
 	return &Handler{db: cfg.DB, clock: cfg.Clock}, nil
 }
 
-// Handle deletes every ratelimit_global_counters row whose expires_at is
-// in the past relative to h.clock. The DELETE is wrapped in restate.Run
-// so a crash or retry replays cleanly: at-least-once delivery on a
-// deterministic DELETE is safe.
+// Handle deletes ratelimit_global_counters rows whose expires_at is in the
+// past relative to h.clock, in bounded batches. Each batch DELETE is wrapped
+// in restate.Run so a crash or retry replays cleanly: at-least-once delivery
+// on a deterministic, cutoff-bounded DELETE is safe — re-running only removes
+// rows that were already eligible.
 //
-// Stateless — the VO key is fixed at "ratelimit-global-counters-cleanup"
-// so a paused/wedged invocation cannot block other cron handlers. Local
-// in-memory state in the ratelimit service is cleaned by its own janitor,
-// and the hot path filters on expires_at, so the lag between this cron
-// firing and rows actually disappearing is only a storage concern, not
-// a correctness one.
+// Stateless — the VO key is fixed at "ratelimit-global-counters-cleanup" so a
+// wedged invocation cannot block other cron handlers. It does block later ticks
+// of this handler, which is why the registered retry policy kills rather than
+// pauses on exhaustion. Local in-memory state in the ratelimit service is
+// cleaned by its own janitor, and the hot path filters on expires_at, so the
+// lag between this cron firing and rows actually disappearing is only a storage
+// concern, not a correctness one.
 func (h *Handler) Handle(
 	ctx restate.ObjectContext,
 	_ *hydrav1.RunRatelimitGlobalCountersCleanupRequest,
 ) (*hydrav1.RunRatelimitGlobalCountersCleanupResponse, error) {
 	cutoff := h.clock.Now().UnixMilli()
 
-	deleted, err := restate.Run(ctx, func(rc restate.RunContext) (int64, error) {
-		return h.db.RW().GlobalCountersDeleteExpired(rc, uint64(cutoff))
-	}, restate.WithName("delete expired"))
-	if err != nil {
-		return nil, fmt.Errorf("delete expired global counter rows: %w", err)
+	var totalDeleted int64
+	drained := false
+	for batchNum := range maxBatches {
+		deleted, err := restate.Run(ctx, func(rc restate.RunContext) (int64, error) {
+			return h.db.RW().GlobalCountersDeleteExpired(rc, rldb.GlobalCountersDeleteExpiredParams{
+				Cutoff: uint64(cutoff),
+				Limit:  batchLimit,
+			})
+		}, restate.WithName(fmt.Sprintf("delete batch-%d", batchNum)))
+		if err != nil {
+			return nil, fmt.Errorf("delete expired global counter rows batch %d: %w", batchNum, err)
+		}
+
+		totalDeleted += deleted
+
+		if deleted < int64(batchLimit) {
+			drained = true
+			break
+		}
+	}
+
+	if !drained {
+		logger.Warn("ratelimit global counters cleanup hit batch cap; expired rows remain for the next tick",
+			"rows_deleted", totalDeleted,
+			"max_batches", maxBatches,
+			"batch_limit", batchLimit,
+			"cutoff_ms", cutoff,
+		)
 	}
 
 	logger.Info("ratelimit global counters cleanup complete",
-		"rows_deleted", deleted,
+		"rows_deleted", totalDeleted,
+		"drained", drained,
 		"cutoff_ms", cutoff,
 	)
 
 	return &hydrav1.RunRatelimitGlobalCountersCleanupResponse{
-		RowsDeleted: deleted,
+		RowsDeleted: totalDeleted,
 	}, nil
 }

--- a/svc/ctrl/worker/run.go
+++ b/svc/ctrl/worker/run.go
@@ -529,35 +529,55 @@ func Run(ctx context.Context, cfg Config) error {
 		restate.WithMaxAttempts(5),
 		restate.KillOnMaxAttempts(),
 	)
-	// Ratelimit global-counters cleanup keeps the pre-consolidation
-	// 5-attempt / 100ms-5s policy with PauseOnMaxAttempts: stateless
-	// DELETE that the hot path doesn't depend on, so pausing for an
-	// operator to inspect a real failure is better than killing silently.
+	// Ratelimit global-counters cleanup: stateless, cutoff-bounded DELETE
+	// that re-derives its work from the clock on every tick. Kill (not
+	// Pause) on exhaustion — a paused invocation parks the fixed
+	// "ratelimit-global-counters-cleanup" key and every later tick queues
+	// behind it, so one bad run silently stops the sweep until an operator
+	// cancels it. There is no compensation to re-enter for, and the handler
+	// drains in batches, so killing just means the next hourly tick picks
+	// up where this one stopped.
 	cronRatelimitGCCRetry := restate.WithInvocationRetryPolicy(
 		restate.WithInitialInterval(100*time.Millisecond),
 		restate.WithExponentiationFactor(2.0),
 		restate.WithMaxInterval(5*time.Second),
 		restate.WithMaxAttempts(5),
-		restate.PauseOnMaxAttempts(),
+		restate.KillOnMaxAttempts(),
 	)
-	// AuditLogOutboxCleanup mirrors the ratelimit cleanup policy: a
-	// stateless, cutoff-bounded DELETE the hot path doesn't depend on, so
-	// pausing for an operator to inspect a real failure beats killing
-	// silently. The daily cadence means a paused run is caught well before
-	// the next tick.
+	// AuditLogOutboxCleanup mirrors the ratelimit cleanup policy for the
+	// same reasons: a stateless, cutoff-bounded, batched DELETE with no
+	// compensation, on a fixed singleton key that a paused invocation would
+	// wedge. Kill on exhaustion and let the next daily tick retry.
 	cronAuditLogCleanupRetry := restate.WithInvocationRetryPolicy(
 		restate.WithInitialInterval(100*time.Millisecond),
 		restate.WithExponentiationFactor(2.0),
 		restate.WithMaxInterval(5*time.Second),
 		restate.WithMaxAttempts(5),
-		restate.PauseOnMaxAttempts(),
+		restate.KillOnMaxAttempts(),
 	)
-	// AuditLogExport runs every minute and is idempotent: any failure is
-	// recovered by the next tick, not by replaying journals from
-	// yesterday. 1h journal retention keeps enough debugging headroom for
-	// an oncall to inspect a recent failure without bloating the journal
-	// store with ~1440 dead invocations/day. No retry override — SDK
-	// default behavior was the pre-consolidation contract.
+	// AuditLogExport drains the outbox every minute on the fixed singleton
+	// key "audit-log-export", so a stuck invocation blocks every later tick.
+	// The SDK default retries forever, which is the same wedge as pausing
+	// with no attempt cap — and the drainer has a known permanent failure
+	// mode (a malformed payload fails its batch until someone fixes the
+	// writer), so retrying it for eternity buys nothing while the outbox
+	// grows unbounded behind a key nobody is watching.
+	//
+	// Kill after 5 attempts instead. The drain is fully idempotent: rows are
+	// soft-deleted only after their ClickHouse insert commits, so a dropped
+	// run leaves them unmarked and the next tick re-reads the same set in
+	// the same order (ClickHouse block dedup collapses any duplicate write).
+	// Failure surfaces through the missing end-of-run heartbeat. The retry
+	// window stays inside a few seconds on purpose: with a tick every minute
+	// the meaningful retry is the next tick, not a longer in-invocation
+	// backoff that would still be running when that tick queues up.
+	cronAuditLogExportRetry := restate.WithInvocationRetryPolicy(
+		restate.WithInitialInterval(100*time.Millisecond),
+		restate.WithExponentiationFactor(2.0),
+		restate.WithMaxInterval(5*time.Second),
+		restate.WithMaxAttempts(5),
+		restate.KillOnMaxAttempts(),
+	)
 	// DeployBillingClose is idempotent and cron-backed; per-workspace
 	// failures are journaled as deferred so one bad customer cannot wedge
 	// the period VO. Kill on exhaustion so the backup cron can retry with
@@ -612,7 +632,10 @@ func Run(ctx context.Context, cfg Config) error {
 		ConfigureHandler("RunKeyLastUsedSync", cronKeyLastUsedRetry).
 		ConfigureHandler("RunRatelimitGlobalCountersCleanup", cronRatelimitGCCRetry).
 		ConfigureHandler("RunAuditLogOutboxCleanup", cronAuditLogCleanupRetry).
-		ConfigureHandler("RunAuditLogExport", restate.WithJournalRetention(1*time.Hour)).
+		// 1h journal retention keeps debugging headroom for an oncall to
+		// inspect a recent failure without bloating the journal store with
+		// ~1440 dead invocations/day.
+		ConfigureHandler("RunAuditLogExport", restate.WithJournalRetention(1*time.Hour), cronAuditLogExportRetry).
 		ConfigureHandler("RunQuotaCheck", cronQuotaCheckRetry).
 		ConfigureHandler("RunDeployBillingClose", cronDeployBillingCloseRetry).
 		ConfigureHandler("CloseDeployBillingWorkspace", cronDeployBillingCloseRetry).


### PR DESCRIPTION
**Problem:**

 Our cronjobs are mostly VO's so if they go into pause they will queue a bajillion jobs behind them.
 Also our ratelimit cleanuper cant deal with 100k+ rows which is the max amount of rows u can select/delete in planetscale vitess.

**Solution:**

Just kill the erroring invocatiion instead of pausing it, if something really doesnt work we will get an alert from our heartbeats.

For the cleanup we now batch delete 25k rows up to 40times if that is not enough the next job will continue onwards. 

**Impact:**

None.
 

**Testing:**

Tests pass.