### PR TITLE
fix(dashboard): tear down Compute on a Stripe-side cancel

### DIFF
--- a/dev/k8s/charts/restate-cronjobs/values.yaml
+++ b/dev/k8s/charts/restate-cronjobs/values.yaml
@@ -66,7 +66,10 @@ jobs:
   # normally runs it at the period roll. Keyed by the CLOSED period (yesterday's
   # month, hence the epoch math). The idempotency key carries the run timestamp
   # so this is a fresh retry, not a replay of the webhook's invocation. Runs at
-  # 00:30 UTC to beat Stripe's ~1h draft auto-finalize.
+  # 00:30 UTC so it claims any draft the webhook missed (pushing Stripe's
+  # finalization out to period end + 48h) before Stripe's own ~1h auto-finalize
+  # fires. The claim happens first precisely because the close then sleeps 24h
+  # waiting for late usage, which is far longer than that ~1h window.
   #
   # NOTE: local/test schedule; the production cron lives in the infra repo too.
   deploy-billing-close:

--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/shirou/gopsutil/v4 v4.25.6
 	github.com/sqlc-dev/plugin-sdk-go v1.23.0
 	github.com/stretchr/testify v1.11.1
-	github.com/stripe/stripe-go/v86 v86.0.0
+	github.com/stripe/stripe-go/v86 v86.1.1
 	github.com/tonistiigi/fsutil v0.0.0-20250605211040-586307ad452f
 	github.com/unkeyed/sdks/api/go/v2 v2.6.1
 	github.com/vishvananda/netlink v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -645,8 +645,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/stripe/stripe-go/v86 v86.0.0 h1:CdyHmNj/QnFR222gpRy9wA4LUd71gUXnDFnUPqT0d6o=
-github.com/stripe/stripe-go/v86 v86.0.0/go.mod h1:Co7QRXCKGNOPTugAdvjgRo+KcMtd9hxy+pZMN0yThsQ=
+github.com/stripe/stripe-go/v86 v86.1.1 h1:Mk9thvAC+E/79GlMQbEqmIwNuCfZE1i6izKPhDJkqwc=
+github.com/stripe/stripe-go/v86 v86.1.1/go.mod h1:Co7QRXCKGNOPTugAdvjgRo+KcMtd9hxy+pZMN0yThsQ=
 github.com/testcontainers/testcontainers-go v0.40.0 h1:pSdJYLOVgLE8YdUY2FHQ1Fxu+aMnb6JfVz1mxk7OeMU=
 github.com/testcontainers/testcontainers-go v0.40.0/go.mod h1:FSXV5KQtX2HAMlm7U3APNyLkkap35zNLxukw9oBi/MY=
 github.com/tetratelabs/wazero v1.11.0 h1:+gKemEuKCTevU4d7ZTzlsvgd1uaToIDtlQlmNbwqYhA=

--- a/svc/ctrl/api/webhooks/stripe/invoice_created.go
+++ b/svc/ctrl/api/webhooks/stripe/invoice_created.go
@@ -14,44 +14,72 @@ import (
 	"github.com/unkeyed/unkey/svc/ctrl/internal/db"
 )
 
-// invoiceCreatedPayload is the invoice.created fields the close path needs.
-// Kept minimal so any Stripe API version works.
-type invoiceCreatedPayload struct {
-	ID            string `json:"id"`
-	BillingReason string `json:"billing_reason"`
-	Customer      string `json:"customer"`
-	// Deploy subscription that generated this renewal invoice.
-	Subscription string `json:"subscription"`
-	// Billed period bounds (unix seconds).
-	PeriodStart int64 `json:"period_start"`
-	PeriodEnd   int64 `json:"period_end"`
+// deploySubscriptionID returns the subscription that generated this invoice.
+//
+// Read through the SDK's own types rather than a hand-rolled json tag. Stripe
+// moved this from a top-level `subscription` field to
+// `parent.subscription_details.subscription` in API version 2025-03-31.basil, and
+// a plain string tag decodes the new shape to "" without erroring, which silently
+// turned every renewal into an ignored event. Binding to the generated type makes
+// the next such move a compile failure on SDK upgrade instead of a silent empty
+// string.
+//
+// Each level is nil-checked because Stripe only populates `parent` for invoices
+// that have one, and only fills `subscription_details` when the parent is a
+// subscription. The SDK's Subscription unmarshals an unexpanded string id
+// straight into ID, so this needs no expand.
+func deploySubscriptionID(invoice stripesdk.Invoice) string {
+	if invoice.Parent == nil ||
+		invoice.Parent.SubscriptionDetails == nil ||
+		invoice.Parent.SubscriptionDetails.Subscription == nil {
+		return ""
+	}
+	return invoice.Parent.SubscriptionDetails.Subscription.ID
 }
 
+// customerID returns the invoice's customer id, or "" when absent. Customer is
+// an expandable reference, so the unexpanded webhook payload carries only the id.
+func customerID(invoice stripesdk.Invoice) string {
+	if invoice.Customer == nil {
+		return ""
+	}
+	return invoice.Customer.ID
+}
+
+// invoiceCreated closes the Deploy renewal invoice Stripe just created.
+//
+// The payload is decoded as the SDK's stripesdk.Invoice, which is generated from
+// Stripe's OpenAPI spec, so the field set tracks the API version the SDK targets
+// and there are no local json tags to drift out of date.
 func (h *handler) invoiceCreated(
 	ctx context.Context,
 	_ webhook.Event,
-	invoice invoiceCreatedPayload,
+	invoice stripesdk.Invoice,
 ) error {
+	subscriptionID := deploySubscriptionID(invoice)
+	customer := customerID(invoice)
+
 	// Not a renewal invoice. Manual and custom invoices are left to Stripe.
-	if invoice.BillingReason != "subscription_cycle" ||
-		invoice.Customer == "" ||
-		invoice.Subscription == "" ||
+	if invoice.BillingReason != stripesdk.InvoiceBillingReasonSubscriptionCycle ||
+		customer == "" ||
+		subscriptionID == "" ||
 		invoice.PeriodStart == 0 ||
 		invoice.PeriodEnd == 0 {
-		return fmt.Errorf("%w: not a renewal invoice (billing_reason %q)", webhook.ErrIgnore, invoice.BillingReason)
+		return fmt.Errorf("%w: not a renewal invoice (billing_reason %q, subscription %q)",
+			webhook.ErrIgnore, invoice.BillingReason, subscriptionID)
 	}
 
 	// Deploy workspace only: customers without deploy_plan are ignored and
 	// Stripe keeps auto-finalizing on its own schedule.
 	ws, err := h.db.FindDeployWorkspaceByStripeCustomerID(ctx, sql.NullString{
-		String: invoice.Customer,
+		String: customer,
 		Valid:  true,
 	})
 	if err != nil {
 		if db.IsNotFound(err) {
-			return fmt.Errorf("%w: customer %s has no deploy workspace", webhook.ErrIgnore, invoice.Customer)
+			return fmt.Errorf("%w: customer %s has no deploy workspace", webhook.ErrIgnore, customer)
 		}
-		return fmt.Errorf("workspace lookup for %s: %w", invoice.Customer, err)
+		return fmt.Errorf("workspace lookup for %s: %w", customer, err)
 	}
 
 	// Same customer can hold multiple Stripe subscriptions. Only claim and
@@ -59,9 +87,9 @@ func (h *handler) invoiceCreated(
 	if !ws.StripeDeploySubscriptionID.Valid || ws.StripeDeploySubscriptionID.String == "" {
 		return fmt.Errorf("%w: deploy workspace %s has no stripe subscription id", webhook.ErrIgnore, ws.ID)
 	}
-	if invoice.Subscription != ws.StripeDeploySubscriptionID.String {
+	if subscriptionID != ws.StripeDeploySubscriptionID.String {
 		return fmt.Errorf("%w: invoice subscription %s is not workspace deploy subscription %s",
-			webhook.ErrIgnore, invoice.Subscription, ws.StripeDeploySubscriptionID.String)
+			webhook.ErrIgnore, subscriptionID, ws.StripeDeploySubscriptionID.String)
 	}
 
 	// Replace Stripe's ~1h auto-finalization with a scheduled one at period end
@@ -71,11 +99,17 @@ func (h *handler) invoiceCreated(
 	// hourly push's usage (at most an hour stale, still inside the credit
 	// expiry window) instead of sitting open forever with the customer never
 	// billed. The close's manual finalize normally wins the race; the schedule
-	// only fires on a draft. Stripe couples the two fields: setting
-	// automatically_finalizes_at implies auto_advance=true, and auto_advance=
-	// false would clear the schedule. Webhook must succeed or Stripe redelivers.
+	// only fires on a draft. Webhook must succeed or Stripe redelivers.
+	//
+	// auto_advance is set explicitly alongside the deadline. Stripe does NOT
+	// infer it: "If auto_advance isn't already enabled for the invoice, you have
+	// to enable it" (docs.stripe.com/invoicing/scheduled-finalization). Without
+	// it, an invoice that arrived with auto_advance false would take the schedule
+	// and then never act on it, sitting in draft forever with the customer never
+	// billed, which is the exact failure this backstop exists to prevent.
 	backstopAt := invoice.PeriodEnd + int64((48 * time.Hour).Seconds())
 	if _, err := h.stripe.V1Invoices.Update(ctx, invoice.ID, &stripesdk.InvoiceUpdateParams{
+		AutoAdvance:              stripesdk.Bool(true),
 		AutomaticallyFinalizesAt: stripesdk.Int64(backstopAt),
 	}); err != nil {
 		// automatically_finalizes_at is draft-only. A redelivery arriving after

--- a/svc/ctrl/api/webhooks/stripe/invoice_created_test.go
+++ b/svc/ctrl/api/webhooks/stripe/invoice_created_test.go
@@ -3,27 +3,111 @@ package stripe
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	stripesdk "github.com/stripe/stripe-go/v86"
 	"github.com/unkeyed/unkey/pkg/mysql/sqlcomment"
 	"github.com/unkeyed/unkey/pkg/testutil/containers"
+	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/pkg/webhook"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/db"
 )
 
-func renewalInvoice(customer, subscription string) invoiceCreatedPayload {
+// renewalInvoice builds a payload in the CURRENT (2025-03-31.basil and later)
+// shape, carrying the subscription under parent.subscription_details. Building
+// it any other way would not exercise the path production actually receives.
+func renewalInvoice(customer, subscription string) stripesdk.Invoice {
 	now := time.Now().UTC()
 	start := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC).AddDate(0, -1, 0)
 	end := start.AddDate(0, 1, 0)
-	return invoiceCreatedPayload{
+	//nolint:exhaustruct // the handler reads only these fields off the SDK invoice
+	return stripesdk.Invoice{
 		ID:            "in_test",
-		BillingReason: "subscription_cycle",
-		Customer:      customer,
-		Subscription:  subscription,
-		PeriodStart:   start.Unix(),
-		PeriodEnd:     end.Unix(),
+		BillingReason: stripesdk.InvoiceBillingReasonSubscriptionCycle,
+		Customer:      &stripesdk.Customer{ID: customer}, //nolint:exhaustruct // unexpanded id, as delivered
+		Parent: &stripesdk.InvoiceParent{ //nolint:exhaustruct // only the subscription reference is read
+			SubscriptionDetails: &stripesdk.InvoiceParentSubscriptionDetails{ //nolint:exhaustruct // ditto
+				Subscription: &stripesdk.Subscription{ID: subscription}, //nolint:exhaustruct // unexpanded id, as delivered
+			},
+		},
+		PeriodStart: start.Unix(),
+		PeriodEnd:   end.Unix(),
+	}
+}
+
+// invoiceJSON wraps a payload fragment in the fields every invoice.created
+// carries. This is the event's data.object, which is exactly what the verified
+// webhook transport passes to invoiceCreated.
+func invoiceJSON(fragment string) string {
+	return `{"id":"in_1","object":"invoice","billing_reason":"subscription_cycle","customer":"cus_1",` +
+		`"period_start":1750000000,"period_end":1752678400` + fragment + `}`
+}
+
+// TestInvoiceCreated_DecodesSubscription goes through JSON rather than building
+// the struct in Go, because the bug it guards against was a wire-format bug: a
+// hand-rolled struct read a top-level "subscription" field that Stripe removed in
+// 2025-03-31.basil, so every renewal decoded as a non-renewal. A struct literal
+// cannot catch a field moving in the payload, since it asserts only that
+// deploySubscriptionID walks pointers the way it was written to. Feeding it bytes
+// is the only way to put the decode itself under test.
+//
+// Caveat worth knowing: these payloads are hand-authored to match Stripe's
+// documented shape, not captured from a live webhook. If a field name here is
+// wrong in the same way production is wrong, the test passes anyway. Replacing
+// them with a recorded event would close that gap; nothing else in the repo
+// captures Stripe fixtures yet, so there is no pattern to follow.
+func TestInvoiceCreated_DecodesSubscription(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		fragment string
+		want     string
+	}{
+		{
+			name:     "basil and later: parent.subscription_details.subscription",
+			fragment: `,"parent":{"type":"subscription_details","subscription_details":{"subscription":"sub_current"}}`,
+			want:     "sub_current",
+		},
+		{
+			// Deliberately unsupported. The SDK's Invoice has no top-level
+			// subscription field, because Stripe removed it, so reading one would
+			// mean reintroducing exactly the hand-rolled json tag that caused this
+			// bug. An endpoint pinned to a pre-basil API version therefore resolves
+			// to "" and is ignored, which the ErrIgnore message names explicitly
+			// instead of failing silently. Our endpoint is on 2026-06-24.dahlia.
+			name:     "pre-basil top-level subscription is not read",
+			fragment: `,"subscription":"sub_legacy"`,
+			want:     "",
+		},
+		{
+			name:     "parent present but expanded to a full object",
+			fragment: `,"parent":{"type":"subscription_details","subscription_details":{"subscription":{"id":"sub_expanded","object":"subscription"}}}`,
+			want:     "sub_expanded",
+		},
+		{
+			name:     "neither shape present",
+			fragment: ``,
+			want:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var got stripesdk.Invoice
+			require.NoError(t, json.Unmarshal([]byte(invoiceJSON(tt.fragment)), &got))
+			require.Equal(t, "in_1", got.ID)
+			require.Equal(t, "cus_1", customerID(got))
+			require.Equal(t, stripesdk.InvoiceBillingReasonSubscriptionCycle, got.BillingReason)
+			require.Equal(t, int64(1750000000), got.PeriodStart)
+			require.Equal(t, int64(1752678400), got.PeriodEnd)
+			require.Equal(t, tt.want, deploySubscriptionID(got))
+		})
 	}
 }
 
@@ -32,7 +116,7 @@ func TestInvoiceCreated_IgnoresNonRenewal(t *testing.T) {
 
 	h := &handler{} //nolint:exhaustruct // early-return paths need no deps
 	inv := renewalInvoice("cus_test", "sub_test")
-	inv.BillingReason = "subscription_create"
+	inv.BillingReason = stripesdk.InvoiceBillingReasonSubscriptionCreate
 	err := h.invoiceCreated(context.Background(), webhook.Event{}, inv)
 	require.ErrorIs(t, err, webhook.ErrIgnore)
 }
@@ -56,7 +140,7 @@ func TestInvoiceCreated_IgnoresMissingCustomerOrPeriod(t *testing.T) {
 	h := &handler{} //nolint:exhaustruct // early-return paths need no deps
 	inv := renewalInvoice("cus_test", "sub_test")
 
-	inv.Customer = ""
+	inv.Customer = nil
 	err := h.invoiceCreated(context.Background(), webhook.Event{}, inv)
 	require.ErrorIs(t, err, webhook.ErrIgnore)
 
@@ -113,23 +197,30 @@ func TestInvoiceCreated_IgnoresMismatchedSubscription(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, database.Close()) })
 
+	// Unique ids per run. The MySQL container is reused across `go test`
+	// invocations, so hardcoded ids made this pass once and then fail on every
+	// re-run with a duplicate-key error on workspaces.id.
+	wsID := uid.New(uid.WorkspacePrefix)
+	customerID := "cus_" + uid.New("test")
+	subID := "sub_" + uid.New("test")
+
 	_, err = database.RW().ExecContext(context.Background(),
 		`INSERT INTO workspaces (id, org_id, name, slug, beta_features) VALUES (?, ?, ?, ?, ?)`,
-		"ws_deploy", "org_test", "Deploy WS", "deploy-ws", "[]",
+		wsID, "org_"+uid.New("test"), "Deploy WS", wsID, "[]",
 	)
 	require.NoError(t, err)
 	_, err = database.RW().ExecContext(context.Background(),
 		`INSERT INTO workspace_billing (workspace_id, plan, stripe_customer_id) VALUES (?, ?, ?)`,
-		"ws_deploy", "pro", "cus_deploy",
+		wsID, "pro", customerID,
 	)
 	require.NoError(t, err)
 	_, err = database.RW().ExecContext(context.Background(),
 		`INSERT INTO billing_subscriptions (workspace_id, product, stripe_subscription_id) VALUES (?, 'compute', ?)`,
-		"ws_deploy", "sub_deploy",
+		wsID, subID,
 	)
 	require.NoError(t, err)
 
 	h := &handler{db: database} //nolint:exhaustruct // stripe/restate unused on ignore path
-	err = h.invoiceCreated(context.Background(), webhook.Event{}, renewalInvoice("cus_deploy", "sub_other_product"))
+	err = h.invoiceCreated(context.Background(), webhook.Event{}, renewalInvoice(customerID, "sub_other_product"))
 	require.ErrorIs(t, err, webhook.ErrIgnore)
 }

--- a/svc/ctrl/internal/billingmeter/stripe.go
+++ b/svc/ctrl/internal/billingmeter/stripe.go
@@ -98,7 +98,15 @@ func (p *stripePusher) Push(ctx context.Context, req PushRequest) (int, error) {
 		{eventKeys, strconv.FormatInt(req.Values.ActiveKeys, 10), req.Values.ActiveKeys > 0},
 	}
 
+	// Every meter is attempted even after one fails. Returning on the first error
+	// stranded every meter after it in this fixed order: a deterministic rejection
+	// on one meter (an event name archived during a catalog migration, say) fails
+	// at the same index on every retry, so the meters behind it never pushed again
+	// for the rest of the month, silently. The error names which meters failed so
+	// a partial push is diagnosable rather than just a count.
 	pushed := 0
+	var failures []error
+	allTerminal := true
 	for _, m := range meters {
 		if !m.positive {
 			continue
@@ -112,14 +120,31 @@ func (p *stripePusher) Push(ctx context.Context, req PushRequest) (int, error) {
 			},
 		})
 		if err != nil {
-			return pushed, wrapMeterEventErr(err)
+			failures = append(failures, fmt.Errorf("meter %s: %w", m.name, err))
+			if !terminalMeterErr(err) {
+				allTerminal = false
+			}
+			continue
 		}
 		pushed++
+	}
+
+	if len(failures) > 0 {
+		wrapped := fault.Wrap(errors.Join(failures...),
+			fault.Internal("failed to push stripe meter events"))
+		// Terminal only when every failure is unfixable by retrying. One transient
+		// failure alongside a permanent one still deserves a retry, since the push
+		// is idempotent (absolute values under "last" aggregation) and the retry
+		// will re-attempt the transient meter.
+		if allTerminal {
+			return pushed, restate.TerminalError(wrapped)
+		}
+		return pushed, wrapped
 	}
 	return pushed, nil
 }
 
-// wrapMeterEventErr separates permanent Stripe rejections from transient
+// terminalMeterErr separates permanent Stripe rejections from transient
 // failures. Push runs inside PushWorkspaceUsage's restate.Run, whose retry
 // window (pushRetryDuration) would otherwise hammer an unfixable rejection —
 // a validation 4xx (unknown customer, malformed value, timestamp outside the
@@ -127,15 +152,11 @@ func (p *stripePusher) Push(ctx context.Context, req PushRequest) (int, error) {
 // month-end close every backup run would re-enter the same window. Marking it
 // terminal fails the push invocation immediately instead. Rate limits (429),
 // request timeouts (408), and 5xx/network errors stay retryable.
-func wrapMeterEventErr(err error) error {
-	wrapped := fault.Wrap(err, fault.Internal("failed to push stripe meter event"))
+func terminalMeterErr(err error) bool {
 	var sErr *stripe.Error
-	if errors.As(err, &sErr) &&
+	return errors.As(err, &sErr) &&
 		sErr.HTTPStatusCode >= 400 && sErr.HTTPStatusCode < 500 &&
-		sErr.HTTPStatusCode != 408 && sErr.HTTPStatusCode != 429 {
-		return restate.TerminalError(wrapped)
-	}
-	return wrapped
+		sErr.HTTPStatusCode != 408 && sErr.HTTPStatusCode != 429
 }
 
 // Stripe enforces two separate limits on a meter event payload value, and a

--- a/svc/ctrl/internal/invoicecloser/interface.go
+++ b/svc/ctrl/internal/invoicecloser/interface.go
@@ -1,12 +1,22 @@
 package invoicecloser
 
-import "context"
+import (
+	"context"
+	"errors"
+)
 
 // DraftInvoice is what the close flow needs to pick and finalize a renewal draft.
 type DraftInvoice struct {
 	ID string
+	// Stripe invoice lifecycle status (draft, open, paid, void, or
+	// uncollectible). GetInvoice can return any status; ListDraftInvoices only
+	// returns draft invoices.
+	Status string
 	// "subscription_cycle" vs proration invoices the close must skip.
 	BillingReason string
+	// Invoice period start (unix seconds). Asserted against the calendar-month
+	// start at close so an anchor-misaligned invoice never finalizes.
+	PeriodStart int64
 	// Invoice period end (unix seconds).
 	PeriodEnd int64
 	// false means we claimed the draft and are waiting to close it.
@@ -17,6 +27,24 @@ type DraftInvoice struct {
 type Closer interface {
 	// By subscription so we do not touch another product's drafts.
 	ListDraftInvoices(ctx context.Context, stripeSubscriptionID string) ([]DraftInvoice, error)
+	// GetInvoice reads one invoice's status, billing reason, and period. The
+	// webhook close path is handed an invoice id rather than discovering it by
+	// listing, so it needs this to detect redelivery after finalization and run
+	// the same period-alignment assertion the fleet sweep runs before finalizing.
+	// Returns ErrNotFound when the invoice does not exist.
+	GetInvoice(ctx context.Context, invoiceID string) (DraftInvoice, error)
+	// ClaimInvoice pushes out Stripe's automatic finalization to finalizeAt (unix
+	// seconds), holding the draft open so the close can take its time. Without a
+	// claim Stripe auto-finalizes roughly an hour after creating the invoice, which
+	// is well inside the close's 24h usage-ingestion wait. The invoice.created
+	// webhook claims per invoice; the fleet sweep claims whatever the webhook
+	// missed. Idempotent: setting the same deadline twice is a no-op.
+	ClaimInvoice(ctx context.Context, invoiceID string, finalizeAt int64) error
 	// alreadyDone when someone else finalized between list and act.
 	FinalizeInvoice(ctx context.Context, invoiceID string) (alreadyDone bool, err error)
 }
+
+// ErrNotFound is returned by GetInvoice when Stripe has no such invoice, as
+// distinct from a transient read failure. The caller defers on either, but only
+// this one is terminal.
+var ErrNotFound = errors.New("invoicecloser: invoice not found")

--- a/svc/ctrl/internal/invoicecloser/noop.go
+++ b/svc/ctrl/internal/invoicecloser/noop.go
@@ -14,6 +14,14 @@ func (n *noopCloser) ListDraftInvoices(_ context.Context, _ string) ([]DraftInvo
 	return nil, nil
 }
 
+func (n *noopCloser) GetInvoice(_ context.Context, _ string) (DraftInvoice, error) {
+	return DraftInvoice{}, ErrNotFound //nolint:exhaustruct // nothing exists when Stripe is not configured
+}
+
+func (n *noopCloser) ClaimInvoice(_ context.Context, _ string, _ int64) error {
+	return nil
+}
+
 func (n *noopCloser) FinalizeInvoice(_ context.Context, _ string) (bool, error) {
 	return true, nil
 }

--- a/svc/ctrl/internal/invoicecloser/stripe.go
+++ b/svc/ctrl/internal/invoicecloser/stripe.go
@@ -2,6 +2,7 @@ package invoicecloser
 
 import (
 	"context"
+	"errors"
 
 	stripe "github.com/stripe/stripe-go/v86"
 	"github.com/unkeyed/unkey/pkg/fault"
@@ -33,7 +34,9 @@ func (c *stripeCloser) ListDraftInvoices(ctx context.Context, stripeSubscription
 		}
 		drafts = append(drafts, DraftInvoice{
 			ID:            invoice.ID,
+			Status:        string(invoice.Status),
 			BillingReason: string(invoice.BillingReason),
+			PeriodStart:   invoice.PeriodStart,
 			PeriodEnd:     invoice.PeriodEnd,
 			AutoAdvance:   invoice.AutoAdvance,
 		})
@@ -41,7 +44,69 @@ func (c *stripeCloser) ListDraftInvoices(ctx context.Context, stripeSubscription
 	return drafts, nil
 }
 
+// GetInvoice reads one invoice's status, billing reason, and period.
+func (c *stripeCloser) GetInvoice(ctx context.Context, invoiceID string) (DraftInvoice, error) {
+	invoice, err := c.client.V1Invoices.Retrieve(ctx, invoiceID, nil)
+	if err != nil {
+		var sErr *stripe.Error
+		if errors.As(err, &sErr) && sErr.Code == stripe.ErrorCodeResourceMissing {
+			return DraftInvoice{}, ErrNotFound //nolint:exhaustruct // zero value on the not-found path
+		}
+		return DraftInvoice{}, fault.Wrap(err, fault.Internal("failed to read stripe invoice")) //nolint:exhaustruct // zero value on the error path
+	}
+	return DraftInvoice{
+		ID:            invoice.ID,
+		Status:        string(invoice.Status),
+		BillingReason: string(invoice.BillingReason),
+		PeriodStart:   invoice.PeriodStart,
+		PeriodEnd:     invoice.PeriodEnd,
+		AutoAdvance:   invoice.AutoAdvance,
+	}, nil
+}
+
+// ClaimInvoice pushes Stripe's automatic finalization out to finalizeAt, so the
+// close can take its time without Stripe closing the invoice underneath it.
+//
+// auto_advance is set explicitly. Stripe does not infer it from the deadline:
+// "If auto_advance isn't already enabled for the invoice, you have to enable it"
+// (docs.stripe.com/invoicing/scheduled-finalization). Setting only the deadline
+// on an invoice whose auto_advance is false would leave it in draft forever with
+// the customer never billed, which is worse than the stale-usage case this
+// deadline exists to bound.
+func (c *stripeCloser) ClaimInvoice(ctx context.Context, invoiceID string, finalizeAt int64) error {
+	_, err := c.client.V1Invoices.Update(ctx, invoiceID, &stripe.InvoiceUpdateParams{ //nolint:exhaustruct // only finalization scheduling changes
+		AutoAdvance:              stripe.Bool(true),
+		AutomaticallyFinalizesAt: stripe.Int64(finalizeAt),
+	})
+	if err != nil {
+		return fault.Wrap(err, fault.Internal("failed to claim stripe invoice"))
+	}
+	return nil
+}
+
+// billed reports whether a status means the invoice was actually finalized and
+// charged. draft never went out; void was finalized then reversed (a corrected or
+// cancelled invoice), so it represents no charge at all. Mirrors
+// billingreconcile.InvoiceStatus.Finalized so the closer and the reconcile engine
+// agree on what "billed" means.
+func billed(status stripe.InvoiceStatus) bool {
+	switch status {
+	case stripe.InvoiceStatusOpen, stripe.InvoiceStatusPaid, stripe.InvoiceStatusUncollectible:
+		return true
+	case stripe.InvoiceStatusDraft, stripe.InvoiceStatusVoid:
+		return false
+	}
+	return false
+}
+
 // FinalizeInvoice finalizes a draft. If we lose a race, re-read and return alreadyDone.
+//
+// A finalize failure on an invoice that is no longer a draft is only "already
+// done" when that invoice was genuinely billed. Treating any non-draft status as
+// success counted a VOIDED invoice as a closed month: the caller recorded the
+// workspace as finalized, the heartbeat stayed green, and nothing was ever
+// charged for that period. Void therefore falls through to the error path so the
+// workspace is deferred and logged loudly instead.
 func (c *stripeCloser) FinalizeInvoice(ctx context.Context, invoiceID string) (bool, error) {
 	_, err := c.client.V1Invoices.FinalizeInvoice(ctx, invoiceID, nil)
 	if err == nil {
@@ -49,8 +114,12 @@ func (c *stripeCloser) FinalizeInvoice(ctx context.Context, invoiceID string) (b
 	}
 
 	invoice, getErr := c.client.V1Invoices.Retrieve(ctx, invoiceID, nil)
-	if getErr == nil && invoice.Status != stripe.InvoiceStatusDraft {
+	if getErr == nil && billed(invoice.Status) {
 		return true, nil
+	}
+	if getErr == nil && invoice.Status == stripe.InvoiceStatusVoid {
+		return false, fault.Wrap(err,
+			fault.Internal("stripe invoice was voided, so this period was never billed"))
 	}
 	return false, fault.Wrap(err, fault.Internal("failed to finalize stripe invoice"))
 }

--- a/svc/ctrl/worker/cron/deploy_billing_close_integration_test.go
+++ b/svc/ctrl/worker/cron/deploy_billing_close_integration_test.go
@@ -20,14 +20,26 @@ import (
 
 // fakeUsageReader ignores the query window and returns whatever rows the test sets.
 type fakeUsageReader struct {
-	mu   sync.Mutex
-	rows []clickhouse.InstanceMeterUsage
+	mu             sync.Mutex
+	rows           []clickhouse.InstanceMeterUsage
+	activeKeys     []clickhouse.ActiveKeysUsage
+	instanceReads  int
+	activeKeyReads int
 }
 
 func (f *fakeUsageReader) set(rows []clickhouse.InstanceMeterUsage) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.rows = rows
+	f.activeKeys = nil
+	f.instanceReads = 0
+	f.activeKeyReads = 0
+}
+
+func (f *fakeUsageReader) setActiveKeys(rows []clickhouse.ActiveKeysUsage) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.activeKeys = rows
 }
 
 func (f *fakeUsageReader) GetInstanceMeterUsage(
@@ -36,16 +48,24 @@ func (f *fakeUsageReader) GetInstanceMeterUsage(
 ) ([]clickhouse.InstanceMeterUsage, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.instanceReads++
 	return f.rows, nil
 }
 
-// GetActiveKeysUsage returns no active-keys rows: this suite asserts the
-// instance meters and the finalize behavior, not the active-keys meter.
 func (f *fakeUsageReader) GetActiveKeysUsage(
 	_ context.Context,
 	_ clickhouse.GetActiveKeysUsageRequest,
 ) ([]clickhouse.ActiveKeysUsage, error) {
-	return nil, nil
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.activeKeyReads++
+	return f.activeKeys, nil
+}
+
+func (f *fakeUsageReader) reads() (instance, activeKeys int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.instanceReads, f.activeKeyReads
 }
 
 // fakePusher records the meter totals it is asked to push, keyed by customer,
@@ -91,11 +111,16 @@ type fakeCloser struct {
 	mu           sync.Mutex
 	drafts       map[string][]invoicecloser.DraftInvoice
 	finalized    []string
+	claimed      map[string]int64
 	failFinalize map[string]bool
 }
 
 func newFakeCloser() *fakeCloser {
-	return &fakeCloser{drafts: map[string][]invoicecloser.DraftInvoice{}, failFinalize: map[string]bool{}}
+	return &fakeCloser{
+		drafts:       map[string][]invoicecloser.DraftInvoice{},
+		claimed:      map[string]int64{},
+		failFinalize: map[string]bool{},
+	}
 }
 
 func (f *fakeCloser) reset() {
@@ -103,7 +128,38 @@ func (f *fakeCloser) reset() {
 	defer f.mu.Unlock()
 	f.drafts = map[string][]invoicecloser.DraftInvoice{}
 	f.finalized = nil
+	f.claimed = map[string]int64{}
 	f.failFinalize = map[string]bool{}
+}
+
+// claimedAt reports the finalization deadline the close pushed onto an invoice,
+// or 0 if it was never claimed. The claim has to happen before the ingestion
+// wait, or Stripe's own ~1h auto-finalize closes the invoice while the close is
+// still sleeping.
+func (f *fakeCloser) claimedAt(invoiceID string) int64 {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.claimed[invoiceID]
+}
+
+func (f *fakeCloser) ClaimInvoice(_ context.Context, invoiceID string, finalizeAt int64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.claimed[invoiceID] = finalizeAt
+	return nil
+}
+
+func (f *fakeCloser) GetInvoice(_ context.Context, invoiceID string) (invoicecloser.DraftInvoice, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, drafts := range f.drafts {
+		for _, d := range drafts {
+			if d.ID == invoiceID {
+				return d, nil
+			}
+		}
+	}
+	return invoicecloser.DraftInvoice{}, invoicecloser.ErrNotFound //nolint:exhaustruct // zero value on the not-found path
 }
 
 func (f *fakeCloser) setDrafts(subscriptionID string, drafts []invoicecloser.DraftInvoice) {
@@ -170,10 +226,10 @@ func TestDeployBillingClose_Integration(t *testing.T) {
 
 	h := harness.New(t, harness.WithDeployBilling(reader, pusher, closer))
 
-	// Yesterday's month: End() is in the past.
+	// Two months ago: End() is always beyond the 24-hour ingestion window,
+	// including when this test runs on the first day of a month.
 	now := time.Now().UTC()
-	firstOfThisMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
-	closedPeriod := firstOfThisMonth.AddDate(0, 0, -1).Format("2006-01")
+	closedPeriod := now.AddDate(0, -2, 0).Format("2006-01")
 	p, err := billingperiod.Parse(closedPeriod)
 	require.NoError(t, err)
 	wantTimestamp := p.End().Add(-time.Second).Unix()
@@ -195,9 +251,10 @@ func TestDeployBillingClose_Integration(t *testing.T) {
 		reader.set([]clickhouse.InstanceMeterUsage{
 			{WorkspaceID: wsID, ResourceID: "r1", CPUSeconds: 12, MemoryGiBHours: 2, DiskGiBHours: 1, EgressBytes: 1 << 30},
 		})
+		reader.setActiveKeys([]clickhouse.ActiveKeysUsage{{WorkspaceID: wsID, ActiveKeys: 3}})
 		invoiceID := uid.New("in")
 		closer.setDrafts(subscriptionID, []invoicecloser.DraftInvoice{
-			{ID: invoiceID, BillingReason: "subscription_cycle", PeriodEnd: p.End().Unix()},
+			{ID: invoiceID, Status: "draft", BillingReason: "subscription_cycle", PeriodStart: p.Start().Unix(), PeriodEnd: p.End().Unix()},
 		})
 
 		resp, err := runClose(closedPeriod, 0)
@@ -211,11 +268,13 @@ func TestDeployBillingClose_Integration(t *testing.T) {
 		require.InDelta(t, 12.0, req.Values.CPUSeconds, 1e-9)
 		require.InDelta(t, 2.0*3600, req.Values.MemoryGiBSeconds, 1e-6)
 		require.InDelta(t, 1.0, req.Values.EgressGiB, 1e-9)
+		require.Equal(t, int64(3), req.Values.ActiveKeys)
 
+		require.Equal(t, p.End().Add(48*time.Hour).Unix(), closer.claimedAt(invoiceID))
 		require.True(t, closer.didFinalize(invoiceID), "expected the ended cycle invoice to be finalized")
 	})
 
-	t.Run("skips proration and next-period drafts", func(t *testing.T) {
+	t.Run("old-period close neither claims nor finalizes next-period drafts", func(t *testing.T) {
 		reader.set(nil)
 		pusher.reset()
 		closer.reset()
@@ -229,13 +288,15 @@ func TestDeployBillingClose_Integration(t *testing.T) {
 		proration := uid.New("in")
 		nextPeriod := uid.New("in")
 		closer.setDrafts(subscriptionID, []invoicecloser.DraftInvoice{
-			{ID: proration, BillingReason: "subscription_update", PeriodEnd: p.End().Unix()},
-			{ID: nextPeriod, BillingReason: "subscription_cycle", PeriodEnd: p.End().Unix() + 1},
+			{ID: proration, Status: "draft", BillingReason: "subscription_update", PeriodStart: p.Start().Unix(), PeriodEnd: p.End().Unix()},
+			{ID: nextPeriod, Status: "draft", BillingReason: "subscription_cycle", PeriodStart: p.End().Unix(), PeriodEnd: p.End().AddDate(0, 1, 0).Unix()},
 		})
 
 		resp, err := runClose(closedPeriod, 0)
 		require.NoError(t, err)
 		require.Equal(t, int32(0), resp.GetInvoicesFinalized())
+		require.Equal(t, int32(2), resp.GetInvoicesSkipped())
+		require.Zero(t, closer.claimedAt(nextPeriod))
 		require.False(t, closer.didFinalize(proration))
 		require.False(t, closer.didFinalize(nextPeriod))
 	})
@@ -254,7 +315,7 @@ func TestDeployBillingClose_Integration(t *testing.T) {
 		pusher.failFor[customerID] = true
 		invoiceID := uid.New("in")
 		closer.setDrafts(subscriptionID, []invoicecloser.DraftInvoice{
-			{ID: invoiceID, BillingReason: "subscription_cycle", PeriodEnd: p.End().Unix()},
+			{ID: invoiceID, Status: "draft", BillingReason: "subscription_cycle", PeriodStart: p.Start().Unix(), PeriodEnd: p.End().Unix()},
 		})
 
 		// Push failed: invoice must stay open. We assert that, not whether the
@@ -314,10 +375,10 @@ func TestDeployBillingClose_Integration(t *testing.T) {
 		okInvoice := uid.New("in")
 		failInvoice := uid.New("in")
 		closer.setDrafts(okSub, []invoicecloser.DraftInvoice{
-			{ID: okInvoice, BillingReason: "subscription_cycle", PeriodEnd: p.End().Unix()},
+			{ID: okInvoice, Status: "draft", BillingReason: "subscription_cycle", PeriodStart: p.Start().Unix(), PeriodEnd: p.End().Unix()},
 		})
 		closer.setDrafts(failSub, []invoicecloser.DraftInvoice{
-			{ID: failInvoice, BillingReason: "subscription_cycle", PeriodEnd: p.End().Unix()},
+			{ID: failInvoice, Status: "draft", BillingReason: "subscription_cycle", PeriodStart: p.Start().Unix(), PeriodEnd: p.End().Unix()},
 		})
 		closer.failFinalize[failInvoice] = true
 
@@ -337,8 +398,7 @@ func TestCloseDeployBillingWorkspace_Integration(t *testing.T) {
 	h := harness.New(t, harness.WithDeployBilling(reader, pusher, closer))
 
 	now := time.Now().UTC()
-	firstOfThisMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
-	closedPeriod := firstOfThisMonth.AddDate(0, 0, -1).Format("2006-01")
+	closedPeriod := now.AddDate(0, -2, 0).Format("2006-01")
 	p, err := billingperiod.Parse(closedPeriod)
 	require.NoError(t, err)
 	wantTimestamp := p.End().Add(-time.Second).Unix()
@@ -354,7 +414,11 @@ func TestCloseDeployBillingWorkspace_Integration(t *testing.T) {
 		reader.set([]clickhouse.InstanceMeterUsage{
 			{WorkspaceID: wsID, ResourceID: "r1", CPUSeconds: 9},
 		})
+		reader.setActiveKeys([]clickhouse.ActiveKeysUsage{{WorkspaceID: wsID, ActiveKeys: 3}})
 		invoiceID := uid.New("in")
+		closer.setDrafts(subscriptionID, []invoicecloser.DraftInvoice{
+			{ID: invoiceID, Status: "draft", BillingReason: "subscription_cycle", PeriodStart: p.Start().Unix(), PeriodEnd: p.End().Unix()},
+		})
 
 		_, err := hydrav1.NewCronServiceIngressClient(h.Restate, wsID).
 			CloseDeployBillingWorkspace().
@@ -369,7 +433,30 @@ func TestCloseDeployBillingWorkspace_Integration(t *testing.T) {
 		require.True(t, ok, "expected a push for the workspace")
 		require.Equal(t, wantTimestamp, req.Timestamp)
 		require.InDelta(t, 9.0, req.Values.CPUSeconds, 1e-9)
+		require.Equal(t, int64(3), req.Values.ActiveKeys)
 		require.True(t, closer.didFinalize(invoiceID))
+	})
+
+	t.Run("refuses to finalize a non-renewal invoice", func(t *testing.T) {
+		reader.set(nil)
+		pusher.reset()
+		closer.reset()
+
+		workspaceID := uid.New(uid.WorkspacePrefix)
+		invoiceID := uid.New("in")
+		closer.setDrafts("sub_test", []invoicecloser.DraftInvoice{
+			{ID: invoiceID, Status: "draft", BillingReason: "subscription_update", PeriodStart: p.Start().Unix(), PeriodEnd: p.End().Unix()},
+		})
+
+		_, err := hydrav1.NewCronServiceIngressClient(h.Restate, workspaceID).
+			CloseDeployBillingWorkspace().
+			Request(h.Ctx, &hydrav1.CloseDeployBillingWorkspaceRequest{
+				Period:    closedPeriod,
+				PeriodEnd: 0,
+				InvoiceId: invoiceID,
+			})
+		require.Error(t, err)
+		require.False(t, closer.didFinalize(invoiceID))
 	})
 
 	t.Run("leaves the invoice open when the final push failed", func(t *testing.T) {
@@ -385,6 +472,9 @@ func TestCloseDeployBillingWorkspace_Integration(t *testing.T) {
 		})
 		pusher.failFor[customerID] = true
 		invoiceID := uid.New("in")
+		closer.setDrafts(subscriptionID, []invoicecloser.DraftInvoice{
+			{ID: invoiceID, Status: "draft", BillingReason: "subscription_cycle", PeriodStart: p.Start().Unix(), PeriodEnd: p.End().Unix()},
+		})
 
 		_, err := hydrav1.NewCronServiceIngressClient(h.Restate, wsID).
 			CloseDeployBillingWorkspace().
@@ -394,6 +484,39 @@ func TestCloseDeployBillingWorkspace_Integration(t *testing.T) {
 				InvoiceId: invoiceID,
 			})
 		require.NoError(t, err)
+		require.False(t, closer.didFinalize(invoiceID))
+	})
+
+	t.Run("already finalized invoice skips usage reads and meter pushes", func(t *testing.T) {
+		reader.set(nil)
+		pusher.reset()
+		closer.reset()
+
+		customerID := uid.New("cus")
+		subscriptionID := uid.New("sub")
+		wsID := seedBillableWorkspace(t, h, customerID, subscriptionID)
+		reader.set([]clickhouse.InstanceMeterUsage{
+			{WorkspaceID: wsID, ResourceID: "r1", CPUSeconds: 11},
+		})
+		invoiceID := uid.New("in")
+		closer.setDrafts(subscriptionID, []invoicecloser.DraftInvoice{
+			{ID: invoiceID, Status: "open", BillingReason: "subscription_cycle", PeriodStart: p.Start().Unix(), PeriodEnd: p.End().Unix()},
+		})
+
+		_, err := hydrav1.NewCronServiceIngressClient(h.Restate, wsID).
+			CloseDeployBillingWorkspace().
+			Request(h.Ctx, &hydrav1.CloseDeployBillingWorkspaceRequest{
+				Period:    closedPeriod,
+				PeriodEnd: 0,
+				InvoiceId: invoiceID,
+			})
+		require.NoError(t, err)
+
+		instanceReads, activeKeyReads := reader.reads()
+		require.Zero(t, instanceReads)
+		require.Zero(t, activeKeyReads)
+		_, pushed := pusher.get(customerID)
+		require.False(t, pushed)
 		require.False(t, closer.didFinalize(invoiceID))
 	})
 }

--- a/svc/ctrl/worker/cron/deploybilling/billing_test.go
+++ b/svc/ctrl/worker/cron/deploybilling/billing_test.go
@@ -2,8 +2,10 @@ package deploybilling
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/billingperiod"
 	"github.com/unkeyed/unkey/pkg/clickhouse"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/billingmeter"
 )
@@ -95,4 +97,24 @@ func TestFormatDollars(t *testing.T) {
 	// Sub-cent fractions are truncated for display.
 	require.Equal(t, "$18.75", FormatDollars(1_875*MicroCentsPerCent+499_999))
 	require.Equal(t, "$0", FormatDollars(0))
+}
+
+func TestUsageIngestionDelay(t *testing.T) {
+	p, err := billingperiod.Parse("2026-06")
+	require.NoError(t, err)
+
+	t.Run("waits for the remainder of the lateness window after period end", func(t *testing.T) {
+		now := p.End().Add(2 * time.Hour)
+		require.Equal(t, 22*time.Hour, usageIngestionDelay(p, now))
+	})
+
+	t.Run("small future clock skew still waits through period end", func(t *testing.T) {
+		now := p.End().Add(-time.Second)
+		require.Equal(t, usageIngestLateness+time.Second, usageIngestionDelay(p, now))
+	})
+
+	t.Run("test clock period far ahead of wall time skips the wall-clock wait", func(t *testing.T) {
+		now := p.End().Add(-7 * 24 * time.Hour)
+		require.Zero(t, usageIngestionDelay(p, now))
+	})
 }

--- a/svc/ctrl/worker/cron/deploybilling/close.go
+++ b/svc/ctrl/worker/cron/deploybilling/close.go
@@ -29,8 +29,21 @@ func (h *Handler) HandleClose(
 		return &hydrav1.RunDeployBillingCloseResponse{}, nil
 	}
 
-	p, err := h.closeGuard(ctx, period, req)
+	p, nowTime, err := h.closeAllowed(ctx, period, req)
 	if err != nil {
+		return nil, err
+	}
+
+	// Claim every renewal draft BEFORE the ingestion wait. Stripe auto-finalizes an
+	// unclaimed draft roughly an hour after creating it, and the wait below is 24
+	// hours, so anything the invoice.created webhook failed to claim used to be
+	// closed by Stripe a full day before this sweep took its first look. The sweep
+	// then found no drafts, deferred nothing, logged nothing, and reported success.
+	if err := h.claimDrafts(ctx, period, p); err != nil {
+		return nil, err
+	}
+
+	if err := waitForUsageIngestion(ctx, p, nowTime); err != nil {
 		return nil, err
 	}
 
@@ -63,35 +76,105 @@ type closeFinalizeResult struct {
 	deferred  int
 }
 
-func (h *Handler) closeGuard(
+// closeAllowed parses the period and checks the close may run. It deliberately
+// does NOT wait for usage ingestion: the caller claims drafts first, then waits,
+// so Stripe cannot finalize an unclaimed invoice underneath the sleep.
+func (h *Handler) closeAllowed(
 	ctx restate.ObjectContext,
 	period string,
 	req *hydrav1.RunDeployBillingCloseRequest,
-) (billingperiod.Period, error) {
+) (billingperiod.Period, time.Time, error) {
 	p, err := billingperiod.Parse(period)
 	if err != nil {
-		return billingperiod.Period{}, restate.TerminalError(fmt.Errorf("invalid billing period %q: %w", period, err))
+		return billingperiod.Period{}, time.Time{}, restate.TerminalError(fmt.Errorf("invalid billing period %q: %w", period, err))
 	}
 
 	nowTime, err := restateutil.Now(ctx)
 	if err != nil {
-		return billingperiod.Period{}, fmt.Errorf("get current time: %w", err)
+		return billingperiod.Period{}, time.Time{}, fmt.Errorf("get current time: %w", err)
 	}
 	var stripePeriodEnd int64
 	if req != nil {
 		stripePeriodEnd = req.GetPeriodEnd()
 	}
 	if !p.CloseAllowed(nowTime, stripePeriodEnd) {
-		return billingperiod.Period{}, restate.TerminalError(
+		return billingperiod.Period{}, time.Time{}, restate.TerminalError(
 			fmt.Errorf("billing period %s has not ended yet (ends %s)", period, p.End().Format(time.RFC3339)),
 		)
 	}
 
-	if err := waitForUsageIngestion(ctx, p, nowTime); err != nil {
-		return billingperiod.Period{}, err
+	return p, nowTime, nil
+}
+
+// claimBackstop is how long past period end a claimed draft is allowed to sit
+// before Stripe finalizes it anyway. Matches the invoice.created webhook's
+// backstop so both paths agree, and leaves headroom over the close's own
+// finalize at period end + 25h (24h ingest wait + 1h meter aggregation).
+const claimBackstop = 48 * time.Hour
+
+// claimDrafts extends Stripe's automatic finalization on every renewal draft of
+// every billable workspace, so the ingestion wait cannot be outrun. Best-effort
+// per workspace: a claim failure is logged and the workspace continues, because
+// failing the whole sweep would leave the remaining workspaces unclaimed too.
+func (h *Handler) claimDrafts(
+	ctx restate.ObjectContext,
+	period string,
+	p billingperiod.Period,
+) error {
+	workspaces, err := restate.Run(ctx, func(rc restate.RunContext) ([]db.ListDeployBillableWorkspacesRow, error) {
+		return h.db.ListDeployBillableWorkspaces(rc)
+	}, restate.WithName("list deploy billable workspaces for claim"))
+	if err != nil {
+		return fmt.Errorf("list deploy billable workspaces: %w", err)
+	}
+	sort.Slice(workspaces, func(i, j int) bool { return workspaces[i].ID < workspaces[j].ID })
+
+	finalizeAt := p.End().Add(claimBackstop).Unix()
+	claimed := 0
+
+	stepErrs := runBatched(ctx, workspaces,
+		func(ws db.ListDeployBillableWorkspacesRow) string { return "claim " + ws.ID },
+		func(rc restate.RunContext, ws db.ListDeployBillableWorkspacesRow) (int, error) {
+			if !ws.StripeDeploySubscriptionID.Valid || ws.StripeDeploySubscriptionID.String == "" {
+				return 0, nil
+			}
+			drafts, err := h.closer.ListDraftInvoices(rc, ws.StripeDeploySubscriptionID.String)
+			if err != nil {
+				logger.Error("list draft invoices failed during claim; leaving this workspace to Stripe's schedule",
+					"workspace_id", ws.ID, "error", err)
+				return 0, nil
+			}
+			n := 0
+			for _, draft := range drafts {
+				if draft.BillingReason != "subscription_cycle" {
+					continue
+				}
+				// An old-period rerun can see the current renewal draft. Never
+				// replace its backstop with a deadline derived from the old period.
+				if draft.PeriodStart >= p.End().Unix() {
+					continue
+				}
+				if err := h.closer.ClaimInvoice(rc, draft.ID, finalizeAt); err != nil {
+					logger.Error("claim invoice failed; Stripe may finalize it before the close completes",
+						"workspace_id", ws.ID, "invoice_id", draft.ID, "error", err)
+					continue
+				}
+				n++
+			}
+			return n, nil
+		},
+		func(_ db.ListDeployBillableWorkspacesRow, n int) { claimed += n },
+	)
+	for _, stepErr := range stepErrs {
+		logger.Error("claim step failed", "billing_period", period, "error", stepErr)
 	}
 
-	return p, nil
+	logger.Info("deploy billing close claimed drafts",
+		"billing_period", period,
+		"invoices_claimed", claimed,
+		"finalize_at", finalizeAt,
+	)
+	return nil
 }
 
 func (h *Handler) pushFinalUsage(
@@ -281,8 +364,41 @@ func (h *Handler) closeWorkspace(
 	}
 
 	for _, draft := range drafts {
-		if draft.BillingReason != "subscription_cycle" || draft.PeriodEnd > p.End().Unix() {
+		// Not a renewal at all: proration and manual invoices are Stripe's to
+		// finalize, and skipping them is not a billing problem.
+		if draft.BillingReason != "subscription_cycle" {
 			result.Skipped++
+			continue
+		}
+
+		// An old-period rerun may discover the next renewal draft. Its start
+		// boundary identifies it without hiding an anchor drift in the target
+		// period, whose start remains before p.End().
+		if draft.PeriodStart >= p.End().Unix() {
+			result.Skipped++
+			continue
+		}
+
+		// Period end must land on the calendar-month boundary (a drifted anchor
+		// bills the wrong window); a later start is fine (a mid-month subscribe's
+		// first cycle is [subscribe_date, 1st]). Defer rather than skip: a deferral
+		// withholds the heartbeat and leaves the invoice unbilled until the anchor is
+		// fixed, whereas a skip is silent.
+		//
+		// Do not replace this with a PeriodEnd-based skip. A subscription anchored
+		// to day-of-month 1 but not to midnight (created before the anchor config
+		// pinned hour/minute/second) has PeriodEnd LATER than p.End(), so that skip
+		// would swallow exactly the drift this assertion exists to catch.
+		if draft.PeriodEnd != p.End().Unix() || draft.PeriodStart < p.Start().Unix() {
+			logger.Error("deploy invoice period does not align to the calendar month; refusing to finalize",
+				"workspace_id", ws.ID,
+				"invoice_id", draft.ID,
+				"invoice_period_start", draft.PeriodStart,
+				"invoice_period_end", draft.PeriodEnd,
+				"expected_period_start", p.Start().Unix(),
+				"expected_period_end", p.End().Unix(),
+			)
+			result.Deferred++
 			continue
 		}
 

--- a/svc/ctrl/worker/cron/deploybilling/close_workspace.go
+++ b/svc/ctrl/worker/cron/deploybilling/close_workspace.go
@@ -1,17 +1,18 @@
 package deploybilling
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
 	restate "github.com/restatedev/sdk-go"
 	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
 	"github.com/unkeyed/unkey/pkg/billingperiod"
-	"github.com/unkeyed/unkey/pkg/clickhouse"
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/pkg/restate/restateutil"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/billingmeter"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/db"
+	"github.com/unkeyed/unkey/svc/ctrl/internal/invoicecloser"
 )
 
 // HandleCloseWorkspace closes one workspace's Deploy renewal invoice. The
@@ -52,6 +53,48 @@ func (h *Handler) HandleCloseWorkspace(
 		return nil, restate.TerminalError(
 			fmt.Errorf("billing period %s has not ended yet (ends %s)", period, p.End().Format(time.RFC3339)),
 		)
+	}
+
+	// Same period-alignment assertion the fleet sweep runs (see closeWorkspace).
+	// This path is handed an invoice id by the webhook instead of discovering it by
+	// listing, so without an explicit read it finalized whatever it was given: an
+	// anchor-misaligned invoice was deferred by the sweep and blind-finalized here,
+	// on the primary path. Read before the ingestion wait so a misalignment fails
+	// fast instead of 24 hours later.
+	invoice, err := restate.Run(ctx, func(rc restate.RunContext) (invoicecloser.DraftInvoice, error) {
+		return h.closer.GetInvoice(rc, req.GetInvoiceId())
+	}, restate.WithName("read invoice"))
+	if err != nil {
+		if errors.Is(err, invoicecloser.ErrNotFound) {
+			return nil, restate.TerminalError(fmt.Errorf("invoice %s does not exist", req.GetInvoiceId()))
+		}
+		return nil, fmt.Errorf("read invoice %s: %w", req.GetInvoiceId(), err)
+	}
+	if invoice.BillingReason != "subscription_cycle" {
+		return nil, restate.TerminalError(
+			fmt.Errorf("invoice %s is not a subscription renewal (billing reason %q)", invoice.ID, invoice.BillingReason),
+		)
+	}
+	if invoice.PeriodEnd != p.End().Unix() || invoice.PeriodStart < p.Start().Unix() {
+		logger.Error("deploy invoice period does not align to the calendar month; refusing to finalize",
+			"workspace_id", workspaceID,
+			"invoice_id", invoice.ID,
+			"invoice_period_start", invoice.PeriodStart,
+			"invoice_period_end", invoice.PeriodEnd,
+			"expected_period_start", p.Start().Unix(),
+			"expected_period_end", p.End().Unix(),
+		)
+		return nil, restate.TerminalError(
+			fmt.Errorf("invoice %s period does not align to calendar month %s", invoice.ID, period),
+		)
+	}
+	if invoice.Status != "draft" {
+		logger.Info("deploy renewal invoice already left draft status; skipping close redelivery",
+			"workspace_id", workspaceID,
+			"invoice_id", invoice.ID,
+			"invoice_status", invoice.Status,
+		)
+		return &hydrav1.CloseDeployBillingWorkspaceResponse{}, nil
 	}
 
 	if err := waitForUsageIngestion(ctx, p, nowTime); err != nil {
@@ -117,19 +160,18 @@ func (h *Handler) pushSingleWorkspace(
 	endMillis int64,
 	eventTimestamp int64,
 ) (workspacePushOutcome, error) {
-	rows, err := restate.Run(ctx, func(rc restate.RunContext) ([]clickhouse.InstanceMeterUsage, error) {
-		return h.usage.GetInstanceMeterUsage(rc, clickhouse.GetInstanceMeterUsageRequest{
-			WorkspaceID:  workspaceID,
-			WorkspaceIDs: nil,
-			Start:        p.Start().UnixMilli(),
-			End:          endMillis,
-		})
-	}, restate.WithName("get workspace period usage"))
+	// Shared with the fleet close rather than re-reading here. The previous local
+	// read called only GetInstanceMeterUsage and fed it to AggregateUsage, which
+	// hardcodes ActiveKeys: 0 and expects MergeActiveKeys to fill it in. Nothing
+	// did, so the final push emitted no active_keys event and that meter stayed at
+	// whatever the last hourly push reported, and a workspace whose only usage was
+	// key verifications (compute scaled to zero) failed the Positive() check below
+	// and got no final push at all.
+	valuesByWorkspace, err := FleetMeterValues(ctx, h.usage, p, endMillis, []string{workspaceID})
 	if err != nil {
 		return workspacePushOutcome{}, fmt.Errorf("get workspace period usage: %w", err)
 	}
 
-	valuesByWorkspace := AggregateUsage(rows)
 	values, ok := valuesByWorkspace[workspaceID]
 	if !ok || !values.Positive() {
 		logger.Info("no deploy usage to push for workspace close",

--- a/svc/ctrl/worker/cron/deploybilling/push.go
+++ b/svc/ctrl/worker/cron/deploybilling/push.go
@@ -43,9 +43,40 @@ func (h *Handler) Handle(
 	if err != nil {
 		return nil, fmt.Errorf("get current time: %w", err)
 	}
+
+	// A stale-period push must not run. This handler writes money: the value it
+	// sends becomes the billed quantity under "last" aggregation, and the event
+	// timestamp decides which Stripe period it lands in. An invocation for a
+	// closed month executing after the roll (a manual re-trigger, or a queued tick
+	// crossing midnight UTC on the 1st) would stamp the OLD month's total into the
+	// NEW period, and the zero-skip below means nothing ever corrects it downward.
+	// Mirrors the spend check's guard, which has had this since it was written,
+	// including its heartbeat: the handler ran and correctly decided not to act,
+	// so withholding the ping would page someone for a skip that lost nothing.
+	// Nothing is lost because the next tick pushes absolute month-to-date under
+	// the "last" formula, so a skipped hour is re-covered rather than dropped.
+	if p != billingperiod.From(nowTime) {
+		logger.Info("deploy billing push: skipping stale period",
+			"billing_period", period,
+			"current_period", billingperiod.From(nowTime).Key(),
+		)
+		if err := h.pingHeartbeat(ctx); err != nil {
+			return nil, err
+		}
+		return &hydrav1.RunDeployBillingPushResponse{}, nil
+	}
+
 	// The ClickHouse usage query is bounded in milliseconds; the Stripe meter
-	// event timestamp is unix seconds. Both come from the one journaled "now"
-	// so the window and the event agree.
+	// event timestamp is unix seconds. Both come from the one journaled "now" so
+	// the window and the event agree.
+	//
+	// Deliberately unclamped: the stale-period guard above already establishes
+	// nowTime is inside p, so a clamp to p.End() would be unreachable, and a
+	// clamp is the wrong shape for this anyway. p.End() is the query's exclusive
+	// upper bound but one second INTO the next period as an event timestamp,
+	// which is why the close path stamps p.End().Add(-time.Second) instead.
+	// Clamping both to p.End() would push the month's final total into the next
+	// Stripe period.
 	nowMillis := nowTime.UnixMilli()
 	nowUnixSeconds := nowTime.Unix()
 

--- a/svc/ctrl/worker/cron/deploybilling/waits.go
+++ b/svc/ctrl/worker/cron/deploybilling/waits.go
@@ -19,6 +19,11 @@ import (
 // closed invoice.
 const usageIngestLateness = 24 * time.Hour
 
+// simulatedClockMinimumLead distinguishes a Stripe test clock from ordinary
+// production clock skew. Production Stripe cannot roll a calendar-month
+// renewal an hour before that month ends; test-clock periods can be weeks ahead.
+const simulatedClockMinimumLead = time.Hour
+
 // DefaultFinalizeDelay is the production wait between the close's final meter
 // push and invoice finalization, giving Stripe's asynchronous meter
 // aggregation time to fold the final push into the draft's lines. Finalizing
@@ -29,22 +34,33 @@ const DefaultFinalizeDelay = time.Hour
 
 // waitForUsageIngestion blocks until late ClickHouse rows for the closed period
 // are likely ingested. Both close paths (HandleClose and HandleCloseWorkspace)
-// call this before the final usage read. Skipped when wall clock is still
-// inside the period (CloseAllowed only via a Stripe period-end hint, e.g. test
-// clocks ahead of wall clock).
+// call this before the final usage read. Skipped only when the period is far
+// enough ahead of wall time to prove a Stripe test clock is in use; a small
+// future skew still waits through period end and the full ingestion window.
 func waitForUsageIngestion(ctx restate.ObjectContext, p billingperiod.Period, now time.Time) error {
-	if now.Before(p.End()) {
+	delay := usageIngestionDelay(p, now)
+	if delay <= 0 {
 		return nil
 	}
 
-	ingestSafe := p.End().Add(usageIngestLateness)
-	if now.Before(ingestSafe) {
-		if err := restate.Sleep(ctx, ingestSafe.Sub(now)); err != nil {
-			return fmt.Errorf("wait for usage ingestion: %w", err)
-		}
+	if err := restate.Sleep(ctx, delay); err != nil {
+		return fmt.Errorf("wait for usage ingestion: %w", err)
 	}
 
 	return nil
+}
+
+func usageIngestionDelay(p billingperiod.Period, now time.Time) time.Duration {
+	periodEnd := p.End()
+	if periodEnd.Sub(now) > simulatedClockMinimumLead {
+		return 0
+	}
+
+	ingestSafe := periodEnd.Add(usageIngestLateness)
+	if !now.Before(ingestSafe) {
+		return 0
+	}
+	return ingestSafe.Sub(now)
 }
 
 // waitForMeterAggregation blocks until Stripe can fold the final meter push into

--- a/svc/ctrl/worker/run.go
+++ b/svc/ctrl/worker/run.go
@@ -578,12 +578,23 @@ func Run(ctx context.Context, cfg Config) error {
 		restate.WithMaxAttempts(5),
 		restate.KillOnMaxAttempts(),
 	)
-	// DeployBillingClose is idempotent and cron-backed; per-workspace
-	// failures are journaled as deferred so one bad customer cannot wedge
-	// the period VO. Kill on exhaustion so the backup cron can retry with
-	// a fresh idempotency key instead of sitting behind a wedged webhook
-	// invocation.
-	cronDeployBillingCloseRetry := restate.WithInvocationRetryPolicy(
+	// The fleet close runs once per month and is the fallback for webhook-driven
+	// workspace closes, so a brief infrastructure outage must not exhaust it in
+	// seconds. Nine attempts span roughly 75 minutes while staying well inside
+	// the claimed invoice's 48-hour finalization backstop. Kill on exhaustion so
+	// the period VO never remains wedged.
+	cronDeployBillingFleetCloseRetry := restate.WithInvocationRetryPolicy(
+		restate.WithInitialInterval(1*time.Minute),
+		restate.WithExponentiationFactor(2.0),
+		restate.WithMaxInterval(15*time.Minute),
+		restate.WithMaxAttempts(9),
+		restate.KillOnMaxAttempts(),
+	)
+	// The per-workspace close is dispatched by invoice.created and backed up by
+	// the fleet close. Its handler turns customer-specific push and finalization
+	// failures into deferred work, so this short policy only covers failures that
+	// escape those bounds.
+	cronDeployBillingWorkspaceCloseRetry := restate.WithInvocationRetryPolicy(
 		restate.WithInitialInterval(100*time.Millisecond),
 		restate.WithExponentiationFactor(2.0),
 		restate.WithMaxInterval(5*time.Second),
@@ -637,8 +648,8 @@ func Run(ctx context.Context, cfg Config) error {
 		// ~1440 dead invocations/day.
 		ConfigureHandler("RunAuditLogExport", restate.WithJournalRetention(1*time.Hour), cronAuditLogExportRetry).
 		ConfigureHandler("RunQuotaCheck", cronQuotaCheckRetry).
-		ConfigureHandler("RunDeployBillingClose", cronDeployBillingCloseRetry).
-		ConfigureHandler("CloseDeployBillingWorkspace", cronDeployBillingCloseRetry).
+		ConfigureHandler("RunDeployBillingClose", cronDeployBillingFleetCloseRetry).
+		ConfigureHandler("CloseDeployBillingWorkspace", cronDeployBillingWorkspaceCloseRetry).
 		ConfigureHandler("RunDeployBillingPush", cronDeployBillingPushRetry).
 		ConfigureHandler("RunDeploySpendCheck", cronDeploySpendCheckRetry))
 	logger.Info("CronService enabled")

--- a/tools/pricing/go.mod
+++ b/tools/pricing/go.mod
@@ -3,6 +3,6 @@ module github.com/unkeyed/unkey/tools/pricing
 go 1.25.1
 
 require (
-	github.com/stripe/stripe-go/v86 v86.0.0
+	github.com/stripe/stripe-go/v86 v86.1.1
 	github.com/urfave/cli/v3 v3.10.0
 )

--- a/tools/pricing/go.sum
+++ b/tools/pricing/go.sum
@@ -4,8 +4,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/stripe/stripe-go/v86 v86.0.0 h1:CdyHmNj/QnFR222gpRy9wA4LUd71gUXnDFnUPqT0d6o=
-github.com/stripe/stripe-go/v86 v86.0.0/go.mod h1:Co7QRXCKGNOPTugAdvjgRo+KcMtd9hxy+pZMN0yThsQ=
+github.com/stripe/stripe-go/v86 v86.1.1 h1:Mk9thvAC+E/79GlMQbEqmIwNuCfZE1i6izKPhDJkqwc=
+github.com/stripe/stripe-go/v86 v86.1.1/go.mod h1:Co7QRXCKGNOPTugAdvjgRo+KcMtd9hxy+pZMN0yThsQ=
 github.com/urfave/cli/v3 v3.10.0 h1:0aU8yOObVDMkM13Cj4G+zb4P0PdeJMec65f81Ak1ioM=
 github.com/urfave/cli/v3 v3.10.0/go.mod h1:ysVLtOEmg2tOy6PknnYVhDoouyC/6N42TMeoMzskhso=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/web/apps/dashboard/app/api/webhooks/stripe/route.ts
+++ b/web/apps/dashboard/app/api/webhooks/stripe/route.ts
@@ -127,6 +127,57 @@ async function sendComputeAlert(
 }
 
 /**
+ * Whether a subscription Stripe told us about is still capable of billing.
+ *
+ * Used to decide whether an unresolvable workspace is a real orphan or just a
+ * redelivered terminal event. `canceled` and `incomplete_expired` are Stripe's
+ * end states: nothing further is charged, so losing the local link is untidy but
+ * costs nothing. Any other status on a subscription we cannot resolve is money
+ * moving with no workspace attached, which is worth waking someone for.
+ */
+function subscriptionStillBilling(sub: Stripe.Subscription): boolean {
+  return sub.status !== "canceled" && sub.status !== "incomplete_expired";
+}
+
+/**
+ * Tears down Compute when a subscription becomes cancelling, before
+ * [[mirrorDeployPlan]] clears the plan.
+ *
+ * Ordering is load-bearing. ctrl's DeprovisionCompute keys its idempotency guard
+ * on `workspace_billing.plan` still being set, and deliberately tears down
+ * before clearing it. mirrorDeployPlan writes that same column to null on any
+ * cancelling subscription, which is correct for the dashboard flow (cancelDeploy
+ * has already deprovisioned, so the null is just the mirror catching up) but not
+ * for a cancel made on the Stripe side, in the customer portal or the Stripe
+ * dashboard. There our tRPC endpoint never runs, so the plan went to null with no
+ * teardown, and by the time `customer.subscription.deleted` arrived its
+ * `if (billing.plan)` gate saw null and skipped teardown for good. Workloads kept
+ * running with no subscription, and nothing billed them, because every billable
+ * query and the spend cap all require plan IS NOT NULL.
+ *
+ * Calling deprovision here restores the invariant those guards assume: by the
+ * time plan is null, teardown has been dispatched. On the dashboard path this is
+ * a no-op, since the plan is already null and ctrl returns early. Cancel means
+ * immediate teardown either way, which is the semantics cancelDeploy already
+ * chose (billing runs to the period boundary, no refund).
+ *
+ * Failures propagate so the caller returns 500 and Stripe redelivers: dropping
+ * this is how compute ends up running unbilled.
+ */
+async function deprovisionOnCancel(
+  billing: { workspaceId: string; plan: string | null },
+  sub: Stripe.Subscription,
+): Promise<void> {
+  const cancelling = Boolean(sub.cancel_at_period_end) || Boolean(sub.cancel_at);
+  if (!cancelling || !billing.plan) {
+    return;
+  }
+
+  const ctrl = createCtrlClient(DeployService);
+  await ctrl.deprovisionCompute({ workspaceId: billing.workspaceId });
+}
+
+/**
  * Links a subscription-mode Compute checkout to its workspace via the shared
  * linker, shared by the `checkout.session.completed` and
  * `checkout.session.async_payment_succeeded` events (the latter fires when a
@@ -375,6 +426,7 @@ export const POST = async (req: Request): Promise<Response> => {
         // from the Stripe event (a DB plan diff is unreliable because the
         // dashboard mutations write the plan optimistically before this fires).
         if (column === "compute") {
+          await deprovisionOnCancel(billing, sub);
           await mirrorDeployPlan(billing, sub);
           const deployConfig = await deployBillingConfig();
           await sendComputeAlert(
@@ -613,13 +665,22 @@ export const POST = async (req: Request): Promise<Response> => {
             subscriptionId: sub.id,
             eventId: event.id,
           });
-          // No ongoing billing on a terminated subscription, but the lost billing
-          // link needs a human to reconcile.
-          await alertOrphanedDeploySubscription({
-            subscriptionId: sub.id,
-            eventId: event.id,
-            reason: "workspace_not_found",
-          });
+          // Only page when this is genuinely a lost billing link, not the second
+          // delivery of a cancel we already processed. This handler deletes the
+          // billing_subscriptions row it looks itself up by, and Stripe delivers
+          // at-least-once, so a perfectly successful cancel used to page on
+          // redelivery — as did any `updated` arriving after the `deleted`. That
+          // trained the one alert meaning "a paid subscription is billing with no
+          // workspace attached" to be ignored, which is exactly the signal a
+          // Stripe-side cancel needs. A subscription Stripe reports as fully
+          // ended has no ongoing billing, so silence is correct for it.
+          if (subscriptionStillBilling(sub)) {
+            await alertOrphanedDeploySubscription({
+              subscriptionId: sub.id,
+              eventId: event.id,
+              reason: "workspace_not_found",
+            });
+          }
           return new Response("OK", { status: 200 });
         }
         const column = subscription.product;


### PR DESCRIPTION
**Problem:**

 When someone cancels on stripe's side / we cancel for them compute didnt shut down

**Solution:**

 On stripe's webhook figure out if we're supposed to shut down compute and do it

**Impact:**

 If we cancel a customers compute sub their things will be stopped.

**Testing:**

