### PR TITLE
feat(db): require project ownership on inserts

### DIFF
--- a/pkg/mysql/schema/apis.sql
+++ b/pkg/mysql/schema/apis.sql
@@ -3,7 +3,7 @@ CREATE TABLE `apis` (
 	`id` varchar(256) NOT NULL,
 	`name` varchar(256) NOT NULL,
 	`workspace_id` varchar(256) NOT NULL,
-	`project_id` varchar(64) NOT NULL DEFAULT '',
+	`project_id` varchar(64) NOT NULL,
 	`ip_whitelist` varchar(512),
 	`auth_type` enum('key','jwt'),
 	`key_auth_id` varchar(256),

--- a/pkg/mysql/schema/identities.sql
+++ b/pkg/mysql/schema/identities.sql
@@ -3,7 +3,7 @@ CREATE TABLE `identities` (
 	`id` varchar(256) NOT NULL,
 	`external_id` varchar(256) NOT NULL,
 	`workspace_id` varchar(256) NOT NULL,
-	`project_id` varchar(64) NOT NULL DEFAULT '',
+	`project_id` varchar(64) NOT NULL,
 	`environment` varchar(256) NOT NULL DEFAULT 'default',
 	`meta` json,
 	`deleted` boolean NOT NULL DEFAULT false,

--- a/pkg/mysql/schema/key_auth.sql
+++ b/pkg/mysql/schema/key_auth.sql
@@ -2,7 +2,7 @@ CREATE TABLE `key_auth` (
 	`pk` bigint unsigned AUTO_INCREMENT NOT NULL,
 	`id` varchar(256) NOT NULL,
 	`workspace_id` varchar(256) NOT NULL,
-	`project_id` varchar(64) NOT NULL DEFAULT '',
+	`project_id` varchar(64) NOT NULL,
 	`created_at_m` bigint NOT NULL DEFAULT 0,
 	`updated_at_m` bigint,
 	`deleted_at_m` bigint,

--- a/pkg/mysql/schema/permissions.sql
+++ b/pkg/mysql/schema/permissions.sql
@@ -2,7 +2,7 @@ CREATE TABLE `permissions` (
 	`pk` bigint unsigned AUTO_INCREMENT NOT NULL,
 	`id` varchar(256) NOT NULL,
 	`workspace_id` varchar(256) NOT NULL,
-	`project_id` varchar(64) NOT NULL DEFAULT '',
+	`project_id` varchar(64) NOT NULL,
 	`name` varchar(512) NOT NULL,
 	`slug` varchar(128) NOT NULL,
 	`description` varchar(512),

--- a/pkg/mysql/schema/ratelimit_namespaces.sql
+++ b/pkg/mysql/schema/ratelimit_namespaces.sql
@@ -2,7 +2,7 @@ CREATE TABLE `ratelimit_namespaces` (
 	`pk` bigint unsigned AUTO_INCREMENT NOT NULL,
 	`id` varchar(256) NOT NULL,
 	`workspace_id` varchar(256) NOT NULL,
-	`project_id` varchar(64) NOT NULL DEFAULT '',
+	`project_id` varchar(64) NOT NULL,
 	`name` varchar(512) NOT NULL,
 	`created_at_m` bigint NOT NULL DEFAULT 0,
 	`updated_at_m` bigint,

--- a/pkg/mysql/schema/roles.sql
+++ b/pkg/mysql/schema/roles.sql
@@ -2,7 +2,7 @@ CREATE TABLE `roles` (
 	`pk` bigint unsigned AUTO_INCREMENT NOT NULL,
 	`id` varchar(256) NOT NULL,
 	`workspace_id` varchar(256) NOT NULL,
-	`project_id` varchar(64) NOT NULL DEFAULT '',
+	`project_id` varchar(64) NOT NULL,
 	`name` varchar(512) NOT NULL,
 	`description` varchar(512),
 	`created_at_m` bigint NOT NULL DEFAULT 0,

--- a/svc/api/routes/v2_identities_list_identities/scale_test.go
+++ b/svc/api/routes/v2_identities_list_identities/scale_test.go
@@ -18,6 +18,7 @@ import (
 
 const (
 	scaleWorkspaceID = "ws_bench_identity_search"
+	scaleProjectID   = "proj_bench_identity_search"
 	scaleIdentities  = 1_000_000
 
 	// The LIKE '%...%' filter cannot use an index, so any search returning
@@ -112,6 +113,8 @@ func seedScaleIdentities(t *testing.T, ctx context.Context, h *testutil.Harness)
 	// Drop leftovers from an interrupted run before reseeding
 	_, err = tx.ExecContext(ctx, "DELETE FROM identities WHERE workspace_id = ?", scaleWorkspaceID)
 	require.NoError(t, err)
+	_, err = tx.ExecContext(ctx, "DELETE FROM projects WHERE workspace_id = ?", scaleWorkspaceID)
+	require.NoError(t, err)
 	_, err = tx.ExecContext(ctx, "DELETE FROM workspaces WHERE id = ?", scaleWorkspaceID)
 	require.NoError(t, err)
 
@@ -124,6 +127,16 @@ func seedScaleIdentities(t *testing.T, ctx context.Context, h *testutil.Harness)
 	})
 	require.NoError(t, err)
 
+	err = db.Query.InsertProject(ctx, tx, db.InsertProjectParams{
+		ID:               scaleProjectID,
+		WorkspaceID:      scaleWorkspaceID,
+		Name:             "Default",
+		Slug:             "default",
+		DeleteProtection: sql.NullBool{Bool: true, Valid: true},
+		CreatedAt:        time.Now().UnixMilli(),
+	})
+	require.NoError(t, err)
+
 	// The recursion depth override applies to the transaction's connection,
 	// which is the one running the CTE
 	_, err = tx.ExecContext(ctx,
@@ -132,7 +145,7 @@ func seedScaleIdentities(t *testing.T, ctx context.Context, h *testutil.Harness)
 	require.NoError(t, err)
 
 	_, err = tx.ExecContext(ctx, `
-		INSERT INTO identities (id, external_id, workspace_id, environment, deleted, created_at)
+		INSERT INTO identities (id, external_id, workspace_id, project_id, environment, deleted, created_at)
 		WITH RECURSIVE seq (n) AS (
 			SELECT 1
 			UNION ALL
@@ -142,12 +155,14 @@ func seedScaleIdentities(t *testing.T, ctx context.Context, h *testutil.Harness)
 			CONCAT('id_bench_', LPAD(n, 9, '0')),
 			CONCAT('user_bench_', LPAD(n, 9, '0')),
 			?,
+			?,
 			'default',
 			false,
 			0
 		FROM seq`,
 		scaleIdentities,
 		scaleWorkspaceID,
+		scaleProjectID,
 	)
 	require.NoError(t, err)
 

--- a/web/internal/db/src/schema/apis.ts
+++ b/web/internal/db/src/schema/apis.ts
@@ -12,7 +12,7 @@ export const apis = mysqlTable(
     id: varchar("id", { length: 256 }).notNull().unique(),
     name: varchar("name", { length: 256 }).notNull(),
     workspaceId: varchar("workspace_id", { length: 256 }).notNull(),
-    projectId: varchar("project_id", { length: 64 }).notNull().default(""),
+    projectId: varchar("project_id", { length: 64 }).notNull(),
     /**
      * comma separated ips
      */

--- a/web/internal/db/src/schema/identity.ts
+++ b/web/internal/db/src/schema/identity.ts
@@ -23,7 +23,7 @@ export const identities = mysqlTable(
      */
     externalId: varchar("external_id", { length: 256 }).notNull(),
     workspaceId: varchar("workspace_id", { length: 256 }).notNull(),
-    projectId: varchar("project_id", { length: 64 }).notNull().default(""),
+    projectId: varchar("project_id", { length: 64 }).notNull(),
     environment: varchar("environment", { length: 256 }).notNull().default("default"),
     meta: json("meta").$type<Record<string, unknown>>(),
     deleted: boolean("deleted").notNull().default(false),

--- a/web/internal/db/src/schema/keyAuth.ts
+++ b/web/internal/db/src/schema/keyAuth.ts
@@ -11,7 +11,7 @@ export const keyAuth = mysqlTable(
     pk: bigint("pk", { mode: "number", unsigned: true }).autoincrement().primaryKey(),
     id: varchar("id", { length: 256 }).notNull().unique(),
     workspaceId: varchar("workspace_id", { length: 256 }).notNull(),
-    projectId: varchar("project_id", { length: 64 }).notNull().default(""),
+    projectId: varchar("project_id", { length: 64 }).notNull(),
 
     ...lifecycleDatesMigration,
 

--- a/web/internal/db/src/schema/ratelimit.ts
+++ b/web/internal/db/src/schema/ratelimit.ts
@@ -9,7 +9,7 @@ export const ratelimitNamespaces = mysqlTable(
     pk: bigint("pk", { mode: "number", unsigned: true }).autoincrement().primaryKey(),
     id: varchar("id", { length: 256 }).notNull().unique(),
     workspaceId: varchar("workspace_id", { length: 256 }).notNull(),
-    projectId: varchar("project_id", { length: 64 }).notNull().default(""),
+    projectId: varchar("project_id", { length: 64 }).notNull(),
     name: varchar("name", { length: 512 }).notNull(),
 
     ...lifecycleDatesMigration,

--- a/web/internal/db/src/schema/rbac.ts
+++ b/web/internal/db/src/schema/rbac.ts
@@ -9,7 +9,7 @@ export const permissions = mysqlTable(
     pk: bigint("pk", { mode: "number", unsigned: true }).autoincrement().primaryKey(),
     id: varchar("id", { length: 256 }).notNull().unique(),
     workspaceId: varchar("workspace_id", { length: 256 }).notNull(),
-    projectId: varchar("project_id", { length: 64 }).notNull().default(""),
+    projectId: varchar("project_id", { length: 64 }).notNull(),
     name: varchar("name", { length: 512 }).notNull(),
     slug: varchar("slug", { length: 128 }).notNull(),
     description: varchar("description", { length: 512 }),
@@ -79,7 +79,7 @@ export const roles = mysqlTable(
     pk: bigint("pk", { mode: "number", unsigned: true }).autoincrement().primaryKey(),
     id: varchar("id", { length: 256 }).notNull().unique(),
     workspaceId: varchar("workspace_id", { length: 256 }).notNull(),
-    projectId: varchar("project_id", { length: 64 }).notNull().default(""),
+    projectId: varchar("project_id", { length: 64 }).notNull(),
     name: varchar("name", { length: 512 }).notNull(),
     description: varchar("description", { length: 512 }),
     createdAtM: bigint("created_at_m", { mode: "number" })


### PR DESCRIPTION
## Summary

- remove empty-string defaults from project-owned resource `project_id` columns
- regenerate the MySQL test schemas
- make the identity scale fixture provide explicit project ownership

## Stack

Depends on #6853.

## Verification

- `mise run generate`
- `mise run build`
- dashboard typecheck
- full Go suite reached completion with one unrelated Ctrl rollback timeout; `mise exec -- rask ./svc/ctrl/api` passed on rerun (29 tests)