### PR TITLE
Reset API rate limits on subscription upgrades

### DIFF
--- a/web/apps/dashboard/app/api/webhooks/stripe/route.ts
+++ b/web/apps/dashboard/app/api/webhooks/stripe/route.ts
@@ -394,49 +394,6 @@ export const POST = async (req: Request): Promise<Response> => {
 
         const { requestsPerMonth, logsRetentionDays, auditLogsRetentionDays } = quotas;
 
-        // Update quotas and workspace tier
-        await db.transaction(async (tx) => {
-          await tx
-            .update(schema.workspaceBilling)
-            .set({
-              tier: product.name,
-            })
-            .where(eq(schema.workspaceBilling.workspaceId, ws.id));
-
-          await tx
-            .insert(schema.quotas)
-            .values({
-              workspaceId: ws.id,
-              requestsPerMonth,
-              logsRetentionDays,
-              auditLogsRetentionDays,
-              team: true,
-            })
-            .onDuplicateKeyUpdate({
-              set: {
-                requestsPerMonth,
-                logsRetentionDays,
-                auditLogsRetentionDays,
-                team: true,
-              },
-            });
-
-          await insertAuditLogs(tx, {
-            workspaceId: ws.id,
-            actor: {
-              type: "system",
-              id: "stripe",
-            },
-            event: "workspace.update",
-            description: `Subscription updated to ${product.name} plan.`,
-            resources: [],
-            context: {
-              location: "",
-              userAgent: undefined,
-            },
-          });
-        });
-
         /**
          * To make the updates more useful, we detect if they are downgrading or upgrading their subscription
          * We can then send a good or bad update based upon it.
@@ -480,6 +437,57 @@ export const POST = async (req: Request): Promise<Response> => {
           }
         }
 
+        // The tRPC mutation clears these synchronously. Repeat it here because
+        // Stripe is the source of truth and subscriptions can also be changed
+        // outside the dashboard.
+        const rateLimitReset =
+          changeType === "upgraded" ? { ratelimitApiLimit: null, ratelimitApiDuration: null } : {};
+
+        // Update quotas and workspace tier
+        await db.transaction(async (tx) => {
+          await tx
+            .update(schema.workspaceBilling)
+            .set({
+              tier: product.name,
+            })
+            .where(eq(schema.workspaceBilling.workspaceId, ws.id));
+
+          await tx
+            .insert(schema.quotas)
+            .values({
+              workspaceId: ws.id,
+              requestsPerMonth,
+              logsRetentionDays,
+              auditLogsRetentionDays,
+              team: true,
+              ...rateLimitReset,
+            })
+            .onDuplicateKeyUpdate({
+              set: {
+                requestsPerMonth,
+                logsRetentionDays,
+                auditLogsRetentionDays,
+                team: true,
+                ...rateLimitReset,
+              },
+            });
+
+          await insertAuditLogs(tx, {
+            workspaceId: ws.id,
+            actor: {
+              type: "system",
+              id: "stripe",
+            },
+            event: "workspace.update",
+            description: `Subscription updated to ${product.name} plan.`,
+            resources: [],
+            context: {
+              location: "",
+              userAgent: undefined,
+            },
+          });
+        });
+
         // Send notification for subscription update
         if (customer && !customer.deleted && customer.email) {
           const formattedPrice = formatPrice(unitAmount);
@@ -488,6 +496,7 @@ export const POST = async (req: Request): Promise<Response> => {
             product.name,
             formattedPrice,
             customer.email,
+            ws.id,
             customer.name || "Unknown",
             changeType,
             previousTier,
@@ -707,11 +716,10 @@ export const POST = async (req: Request): Promise<Response> => {
           where: (table, { eq }) => eq(table.stripeSubscriptionId, sub.id),
           with: { workspace: { with: { billing: true } } },
         });
-        const billing = subscription?.workspace?.billing ?? null;
+        const ws = subscription?.workspace ?? null;
+        const billing = ws?.billing ?? null;
         const column =
-          subscription && billing && subscription.workspace?.deletedAtM == null
-            ? subscription.product
-            : null;
+          subscription && ws && billing && ws.deletedAtM == null ? subscription.product : null;
 
         // Deploy-matched: mirror the plan and stop; no alert for Compute.
         if (column === "compute" && billing) {
@@ -723,7 +731,7 @@ export const POST = async (req: Request): Promise<Response> => {
         // tRPC/link write). No-op: the inline write set the plan and a later
         // subscription.updated resyncs. Only an API-matched create alerts, so we
         // never misfire a Compute create as an API subscription alert.
-        if (column !== "api") {
+        if (column !== "api" || !ws) {
           return new Response("OK");
         }
 
@@ -744,6 +752,7 @@ export const POST = async (req: Request): Promise<Response> => {
           product.name,
           formattedPrice,
           customer.email,
+          ws.id,
           customer.name || "Unknown",
         );
         // Return rather than break so this case can never fall through into

--- a/web/apps/dashboard/lib/trpc/routers/stripe/createSubscription.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/createSubscription.ts
@@ -252,6 +252,8 @@ export const createSubscription = workspaceProcedure
           logsRetentionDays: quotas.logsRetentionDays,
           auditLogsRetentionDays: quotas.auditLogsRetentionDays,
           team: true,
+          ratelimitApiLimit: null,
+          ratelimitApiDuration: null,
         })
         .onDuplicateKeyUpdate({
           set: {
@@ -259,6 +261,8 @@ export const createSubscription = workspaceProcedure
             logsRetentionDays: quotas.logsRetentionDays,
             auditLogsRetentionDays: quotas.auditLogsRetentionDays,
             team: true,
+            ratelimitApiLimit: null,
+            ratelimitApiDuration: null,
           },
         });
 

--- a/web/apps/dashboard/lib/trpc/routers/stripe/updateSubscription.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/updateSubscription.ts
@@ -112,12 +112,17 @@ export const updateSubscription = workspaceProcedure
      * be charged. We surface that to the user so they know to fix their payment method
      * before the plan switch is applied.
      */
+    let upgraded = false;
     try {
-      await stripe.subscriptionItems.update(item.id, {
+      const updatedItem = await stripe.subscriptionItems.update(item.id, {
         price: newProduct.default_price.toString(),
         proration_behavior: "always_invoice",
         payment_behavior: "error_if_incomplete",
       });
+      upgraded =
+        item.price.unit_amount !== null &&
+        updatedItem.price.unit_amount !== null &&
+        updatedItem.price.unit_amount > item.price.unit_amount;
     } catch (err) {
       if (err instanceof Stripe.errors.StripeCardError) {
         throw new TRPCError({
@@ -144,6 +149,11 @@ export const updateSubscription = workspaceProcedure
       });
     }
 
+    // Workspace API rate limits are manually applied safety limits, not plan
+    // quotas. Clear them when a customer pays for a higher tier, but preserve
+    // deliberate limits on same-price changes and downgrades.
+    const rateLimitReset = upgraded ? { ratelimitApiLimit: null, ratelimitApiDuration: null } : {};
+
     await db.transaction(async (tx) => {
       await tx
         .update(schema.workspaceBilling)
@@ -160,6 +170,7 @@ export const updateSubscription = workspaceProcedure
           logsRetentionDays: newQuotas.logsRetentionDays,
           auditLogsRetentionDays: newQuotas.auditLogsRetentionDays,
           team: true,
+          ...rateLimitReset,
         })
         .onDuplicateKeyUpdate({
           set: {
@@ -167,6 +178,7 @@ export const updateSubscription = workspaceProcedure
             logsRetentionDays: newQuotas.logsRetentionDays,
             auditLogsRetentionDays: newQuotas.auditLogsRetentionDays,
             team: true,
+            ...rateLimitReset,
           },
         });
 

--- a/web/apps/dashboard/lib/utils/slackAlerts.test.ts
+++ b/web/apps/dashboard/lib/utils/slackAlerts.test.ts
@@ -150,7 +150,8 @@ describe("alerts escape attacker-controlled fields", () => {
   const cases: Array<{ name: string; send: () => Promise<void> }> = [
     {
       name: "alertSubscriptionCreation",
-      send: () => alertSubscriptionCreation(HOSTILE_TIER, "$25", HOSTILE_EMAIL, HOSTILE_NAME),
+      send: () =>
+        alertSubscriptionCreation(HOSTILE_TIER, "$25", HOSTILE_EMAIL, "ws_test", HOSTILE_NAME),
     },
     {
       name: "alertSubscriptionUpdate",
@@ -159,6 +160,7 @@ describe("alerts escape attacker-controlled fields", () => {
           HOSTILE_TIER,
           "$25",
           HOSTILE_EMAIL,
+          "ws_test",
           HOSTILE_NAME,
           "upgraded",
           HOSTILE_TIER,
@@ -210,11 +212,18 @@ describe("alerts escape attacker-controlled fields", () => {
    * billing name of `http://evil.example/rotate` from becoming a live link.
    */
   it("does not let a bare-url billing name become a link", async () => {
-    await alertSubscriptionCreation("Pro", "$25", "jane@acme.com", "http://evil.example/rotate");
+    await alertSubscriptionCreation(
+      "Pro",
+      "$25",
+      "jane@acme.com",
+      "ws_123",
+      "http://evil.example/rotate",
+    );
 
     const text = sentText();
     // The value survives as plain text (nothing to escape) but verbatim keeps it unlinked.
     expect(text).toContain("http://evil.example/rotate");
+    expect(text).toContain("Workspace: ws_123");
     for (const obj of sentTextObjects()) {
       expect(obj.verbatim).toBe(true);
     }
@@ -263,31 +272,56 @@ describe("alertSubscriptionUpdate", () => {
   };
 
   it("describes the tier change when a previous tier is known", async () => {
-    await alertSubscriptionUpdate("Pro", "$25", "jane@acme.com", "Jane", "upgraded", "Free");
+    await alertSubscriptionUpdate(
+      "Pro",
+      "$25",
+      "jane@acme.com",
+      "ws_123",
+      "Jane",
+      "upgraded",
+      "Free",
+    );
 
     expect(blockText(0)).toBe(":stonks: Jane upgraded their subscription");
     expect(blockText(1)).toBe(
       "Jane's subscription upgraded from Free to Pro tier, they are now paying $25. ",
     );
     expect(blockText(2)).toBe("Here is their contact information: jane@acme.com");
+    expect(blockText(3)).toBe("Workspace: ws_123");
   });
 
   it("falls back to the plain message when the previous tier is unknown", async () => {
     // changeType is "upgraded", so only the missing previousTier can select the fallback.
-    await alertSubscriptionUpdate("Pro", "$25", "jane@acme.com", "Jane", "upgraded");
+    await alertSubscriptionUpdate("Pro", "$25", "jane@acme.com", "ws_123", "Jane", "upgraded");
 
     expect(blockText(1)).toBe("Subscription upgraded to the Pro tier");
   });
 
   it("falls back to the plain message for a plain update", async () => {
-    await alertSubscriptionUpdate("Pro", "$25", "jane@acme.com", "Jane", "updated", "Free");
+    await alertSubscriptionUpdate(
+      "Pro",
+      "$25",
+      "jane@acme.com",
+      "ws_123",
+      "Jane",
+      "updated",
+      "Free",
+    );
 
     expect(blockText(0)).toBe(":stonks: Jane updated their subscription");
     expect(blockText(1)).toBe("Subscription updated to the Pro tier");
   });
 
   it("marks downgrades with a different emoji", async () => {
-    await alertSubscriptionUpdate("Free", "$0", "jane@acme.com", "Jane", "downgraded", "Pro");
+    await alertSubscriptionUpdate(
+      "Free",
+      "$0",
+      "jane@acme.com",
+      "ws_123",
+      "Jane",
+      "downgraded",
+      "Pro",
+    );
 
     expect(blockText(0)).toBe(":notstonks: Jane downgraded their subscription");
   });

--- a/web/apps/dashboard/lib/utils/slackAlerts.ts
+++ b/web/apps/dashboard/lib/utils/slackAlerts.ts
@@ -157,6 +157,7 @@ export async function alertSubscriptionCreation(
   product: string,
   price: string,
   email: string,
+  workspaceId: string,
   name?: string,
 ): Promise<void> {
   await postToSlack(process.env.SLACK_WEBHOOK_CUSTOMERS, "subscription_created", {
@@ -165,6 +166,7 @@ export async function alertSubscriptionCreation(
       section(
         mrkdwn`A new subscription for the ${product} tier has started at a price of ${price} by ${email} :moneybag: `,
       ),
+      section(mrkdwn`Workspace: ${workspaceId}`),
     ],
   });
 }
@@ -173,6 +175,7 @@ export async function alertSubscriptionUpdate(
   product: string,
   price: string,
   email: string,
+  workspaceId: string,
   name?: string,
   changeType?: string,
   previousTier?: string,
@@ -199,6 +202,7 @@ export async function alertSubscriptionUpdate(
       section(mrkdwn`${emoji} ${name} ${actionText}`),
       section(subscriptionText),
       section(mrkdwn`Here is their contact information: ${email}`),
+      section(mrkdwn`Workspace: ${workspaceId}`),
     ],
   });
 }


### PR DESCRIPTION
**Problem:**

 When we ratelimit an API user we have to manually clear their quotas after they upgrade

**Solution:**

Automatically reset the api quoats upon upgrade, and now we also log the workspace id in slack for easier searching.

**Impact:**

Its possible for customers to not upgrade to the correct tier and get a free ratelimit reset but we can always manually override the limit again.

**Testing:**