### PR TITLE
fix compute plan resource quotas

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/settings/components/runtime-settings/cpu.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/settings/components/runtime-settings/cpu.tsx
@@ -14,7 +14,6 @@ const CPU_OPTIONS = [
   { label: "4 vCPU", value: 4000 },
   { label: "8 vCPU", value: 8000 },
   { label: "16 vCPU", value: 16000 },
-  { label: "32 vCPU", value: 32000 },
 ] as const;
 
 const cpuConfig = defineResourceSlider({

--- a/web/apps/dashboard/app/api/webhooks/stripe/route.ts
+++ b/web/apps/dashboard/app/api/webhooks/stripe/route.ts
@@ -13,6 +13,7 @@ import { detectDeployPlan } from "@/lib/stripe/deployPlan";
 import { linkDeploySubscription } from "@/lib/stripe/linkDeploySubscription";
 import { isPaymentRecovery, isPaymentRecoveryUpdate } from "@/lib/stripe/paymentUtils";
 import { validateAndParseQuotas } from "@/lib/stripe/productUtils";
+import { setComputeQuotas } from "@/lib/stripe/setComputeQuotas";
 import {
   isAutomatedBillingRenewal,
   isCardUpdateOnly,
@@ -55,10 +56,13 @@ async function mirrorDeployPlan(
   const plan = cancelling ? null : detectDeployPlan(sub);
   const changed = plan !== billing.plan;
   if (changed) {
-    await db
-      .update(schema.workspaceBilling)
-      .set({ plan })
-      .where(eq(schema.workspaceBilling.workspaceId, billing.workspaceId));
+    await db.transaction(async (tx) => {
+      await tx
+        .update(schema.workspaceBilling)
+        .set({ plan })
+        .where(eq(schema.workspaceBilling.workspaceId, billing.workspaceId));
+      await setComputeQuotas(tx, { workspaceId: billing.workspaceId, plan });
+    });
   }
 }
 
@@ -576,9 +580,11 @@ export const POST = async (req: Request): Promise<Response> => {
               .where(eq(schema.workspaceBilling.workspaceId, ws.id));
             await deleteBillingSubscription(tx, { workspaceId: ws.id, product: "compute" });
 
-            // Only reset quotas when nothing paid remains; a paid API tier keeps
-            // its own quotas, so leave them untouched.
-            if (!keepsTeam) {
+            // Reset the Compute-owned ceilings even when a paid API plan remains;
+            // in that case the API-owned quota fields and team access stay intact.
+            if (keepsTeam) {
+              await setComputeQuotas(tx, { workspaceId: ws.id, plan: null });
+            } else {
               await tx
                 .insert(schema.quotas)
                 .values({ workspaceId: ws.id, ...freeTierQuotas })

--- a/web/apps/dashboard/lib/stripe/deployPlan.test.ts
+++ b/web/apps/dashboard/lib/stripe/deployPlan.test.ts
@@ -1,6 +1,6 @@
 import type Stripe from "stripe";
 import { describe, expect, it, vi } from "vitest";
-import { detectDeployPlan } from "./deployPlan";
+import { computeQuotasForPlan, detectDeployPlan } from "./deployPlan";
 
 // Minimal subscription stub. detectDeployPlan reads items[].price.metadata.plan.
 function subWithItems(...items: Array<{ id?: string; plan?: string }>): Stripe.Subscription {
@@ -52,5 +52,29 @@ describe("detectDeployPlan", () => {
     expect(detectDeployPlan(subWithItems({ plan: "enterprise" }))).toBeNull();
     expect(warn).toHaveBeenCalledOnce();
     warn.mockRestore();
+  });
+});
+
+describe("computeQuotasForPlan", () => {
+  it("returns the advertised per-instance CPU and memory limits", () => {
+    expect(computeQuotasForPlan("starter")).toEqual({
+      maxCpuMillicoresPerInstance: 2_000,
+      maxMemoryMibPerInstance: 2_048,
+    });
+    expect(computeQuotasForPlan("pro")).toEqual({
+      maxCpuMillicoresPerInstance: 8_000,
+      maxMemoryMibPerInstance: 8_192,
+    });
+    expect(computeQuotasForPlan("business")).toEqual({
+      maxCpuMillicoresPerInstance: 16_000,
+      maxMemoryMibPerInstance: 32_768,
+    });
+  });
+
+  it("returns the default Compute limits without a plan", () => {
+    expect(computeQuotasForPlan(null)).toEqual({
+      maxCpuMillicoresPerInstance: 2_000,
+      maxMemoryMibPerInstance: 4_096,
+    });
   });
 });

--- a/web/apps/dashboard/lib/stripe/deployPlan.ts
+++ b/web/apps/dashboard/lib/stripe/deployPlan.ts
@@ -1,3 +1,5 @@
+import { freeTierQuotas } from "@/lib/quotas";
+import type { Quotas } from "@unkey/db";
 import type Stripe from "stripe";
 
 /**
@@ -11,6 +13,32 @@ import type Stripe from "stripe";
  */
 export const DEPLOY_PLANS = ["starter", "pro", "business"] as const;
 export type DeployPlan = (typeof DEPLOY_PLANS)[number];
+
+type ComputeQuotas = Pick<Quotas, "maxCpuMillicoresPerInstance" | "maxMemoryMibPerInstance">;
+
+const COMPUTE_PLAN_QUOTAS = {
+  starter: {
+    maxCpuMillicoresPerInstance: 2_000,
+    maxMemoryMibPerInstance: 2_048,
+  },
+  pro: {
+    maxCpuMillicoresPerInstance: 8_000,
+    maxMemoryMibPerInstance: 8_192,
+  },
+  business: {
+    maxCpuMillicoresPerInstance: 16_000,
+    maxMemoryMibPerInstance: 32_768,
+  },
+} satisfies Record<DeployPlan, ComputeQuotas>;
+
+const DEFAULT_COMPUTE_QUOTAS = {
+  maxCpuMillicoresPerInstance: freeTierQuotas.maxCpuMillicoresPerInstance,
+  maxMemoryMibPerInstance: freeTierQuotas.maxMemoryMibPerInstance,
+} satisfies ComputeQuotas;
+
+export function computeQuotasForPlan(plan: DeployPlan | null): ComputeQuotas {
+  return plan ? COMPUTE_PLAN_QUOTAS[plan] : DEFAULT_COMPUTE_QUOTAS;
+}
 
 function isDeployPlan(value: string): value is DeployPlan {
   return (DEPLOY_PLANS as readonly string[]).includes(value);

--- a/web/apps/dashboard/lib/stripe/linkDeploySubscription.test.ts
+++ b/web/apps/dashboard/lib/stripe/linkDeploySubscription.test.ts
@@ -29,14 +29,25 @@ const h = vi.hoisted(() => {
 });
 
 vi.mock("@/lib/db", () => ({
-  db: { query: { workspaces: { findFirst: h.findFirst } }, transaction: h.transaction },
+  db: {
+    query: { workspaces: { findFirst: h.findFirst } },
+    transaction: h.transaction,
+    insert: h.insert,
+  },
   eq: vi.fn(),
-  schema: { workspaces: { id: {} }, workspaceBilling: { workspaceId: {} } },
+  schema: {
+    workspaces: { id: {} },
+    workspaceBilling: { workspaceId: {} },
+    quotas: { workspaceId: {} },
+  },
 }));
 vi.mock("@unkey/db", () => ({
   and: vi.fn(),
   eq: vi.fn(),
-  schema: { billingSubscriptions: { workspaceId: {}, product: {} } },
+  schema: {
+    billingSubscriptions: { workspaceId: {}, product: {} },
+    quotas: { workspaceId: {} },
+  },
 }));
 vi.mock("@/lib/audit", () => ({ insertAuditLogs: h.insertAuditLogs }));
 
@@ -254,10 +265,15 @@ describe("linkDeploySubscription", () => {
       product: "compute",
       stripeSubscriptionId: "sub_1",
     });
+    expect(h.values).toHaveBeenCalledWith({
+      workspaceId: WORKSPACE_ID,
+      maxCpuMillicoresPerInstance: 2_000,
+      maxMemoryMibPerInstance: 2_048,
+    });
     expect(h.insertAuditLogs).toHaveBeenCalledOnce();
   });
 
-  it("is an idempotent no-op when the same subscription+plan is already linked", async () => {
+  it("repairs quotas without relinking when the same subscription and plan are linked", async () => {
     h.findFirst.mockResolvedValue({
       id: WORKSPACE_ID,
       orgId: "org_1",
@@ -272,6 +288,11 @@ describe("linkDeploySubscription", () => {
     });
     expect(result).toEqual({ ok: true, plan: "starter", alreadyLinked: true });
     expect(h.transaction).not.toHaveBeenCalled();
+    expect(h.values).toHaveBeenCalledWith({
+      workspaceId: WORKSPACE_ID,
+      maxCpuMillicoresPerInstance: 2_000,
+      maxMemoryMibPerInstance: 2_048,
+    });
   });
 
   it("hard-fails rather than repoint a workspace with a different LIVE subscription", async () => {

--- a/web/apps/dashboard/lib/stripe/linkDeploySubscription.ts
+++ b/web/apps/dashboard/lib/stripe/linkDeploySubscription.ts
@@ -3,6 +3,7 @@ import { db, eq, schema } from "@/lib/db";
 import Stripe from "stripe";
 import { subscriptionIdsByProduct, upsertBillingSubscription } from "./billingSubscriptions";
 import { type DeployPlan, detectDeployPlan } from "./deployPlan";
+import { setComputeQuotas } from "./setComputeQuotas";
 import { isDeadSubscription } from "./subscriptionUtils";
 
 /**
@@ -44,9 +45,9 @@ export type LinkDeployResult =
  * Shared by `/success` (fast-path when the user returns) and the
  * `checkout.session.completed` webhook (guaranteed, fires even if the user
  * never returns). Both entry points call this with the same session, so it is
- * idempotent: a matching already-linked subscription is a success no-op, and a
- * *different* existing subscription is a hard failure (never repoint/orphan a
- * live subscription).
+ * idempotent: a matching already-linked subscription only reasserts its Compute
+ * quotas, and a *different* existing subscription is a hard failure (never
+ * repoint/orphan a live subscription).
  *
  * The session and subscription are resolved server-side; no id is trusted from
  * the caller beyond the session id and the workspace id to check ownership
@@ -137,13 +138,14 @@ export async function linkDeploySubscription(
   ).stripeDeploySubscriptionId;
 
   // Idempotency + conflict: re-entry (webhook + /success, refresh, redelivery)
-  // for the same subscription is a success no-op; a *different* LIVE existing
-  // subscription is a hard failure so we never orphan a live one by repointing.
+  // for the same subscription only repairs its quota fields; a *different* LIVE
+  // existing subscription is a hard failure so we never orphan a live one by repointing.
   // A dead recorded subscription (cancelDeploy cancels the Compute subscription
   // outright, and the deleted-webhook that clears the column may lag) is safe to
   // repoint away from — refusing would strand this checkout's paid subscription.
   if (recordedSubscriptionId === subscriptionId) {
     if (ws.billing?.plan === plan) {
+      await setComputeQuotas(db, { workspaceId: ws.id, plan });
       return { ok: true, plan, alreadyLinked: true };
     }
   } else if (recordedSubscriptionId) {
@@ -169,6 +171,7 @@ export async function linkDeploySubscription(
       .update(schema.workspaceBilling)
       .set({ stripeCustomerId, plan })
       .where(eq(schema.workspaceBilling.workspaceId, ws.id));
+    await setComputeQuotas(tx, { workspaceId: ws.id, plan });
     await upsertBillingSubscription(tx, {
       workspaceId: ws.id,
       product: "compute",

--- a/web/apps/dashboard/lib/stripe/setComputeQuotas.ts
+++ b/web/apps/dashboard/lib/stripe/setComputeQuotas.ts
@@ -1,0 +1,14 @@
+import { type Database, type Transaction, schema } from "@unkey/db";
+import { type DeployPlan, computeQuotasForPlan } from "./deployPlan";
+
+/** Applies only Compute-owned quota fields, preserving any active API plan's quotas. */
+export async function setComputeQuotas(
+  db: Transaction | Database,
+  params: { workspaceId: string; plan: DeployPlan | null },
+): Promise<void> {
+  const quotas = computeQuotasForPlan(params.plan);
+  await db
+    .insert(schema.quotas)
+    .values({ workspaceId: params.workspaceId, ...quotas })
+    .onDuplicateKeyUpdate({ set: quotas });
+}

--- a/web/apps/dashboard/lib/trpc/routers/stripe/cancelDeploy.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/cancelDeploy.ts
@@ -4,6 +4,7 @@ import { createCtrlClient } from "@/lib/ctrl-client";
 import { db } from "@/lib/db";
 import { getStripeClient } from "@/lib/stripe";
 import { cancelDeploySubscription } from "@/lib/stripe/cancelDeploySubscription";
+import { setComputeQuotas } from "@/lib/stripe/setComputeQuotas";
 import { TRPCError } from "@trpc/server";
 import { requireWorkspaceAdmin, workspaceProcedure } from "../../trpc";
 
@@ -13,7 +14,8 @@ import { requireWorkspaceAdmin, workspaceProcedure } from "../../trpc";
  * mixed one, never refunding), then calls ctrl to tear down the workspace's
  * running compute and clear the deploy_plan entitlement. The Stripe logic lives
  * here alongside subscribe and change-plan so subscription knowledge is not
- * duplicated in Go. The audit log stays here so the user actor is recorded.
+ * duplicated in Go. Compute-owned quotas return to their defaults, while any API
+ * plan quotas remain intact. The audit log stays here so the user actor is recorded.
  */
 export const cancelDeploy = workspaceProcedure
   .use(requireWorkspaceAdmin)
@@ -54,12 +56,15 @@ export const cancelDeploy = workspaceProcedure
       });
     }
 
-    await insertAuditLogs(db, {
-      workspaceId: ctx.workspace.id,
-      actor: { type: "user", id: ctx.user.id },
-      event: "workspace.update",
-      description: "Cancelled Compute.",
-      resources: [],
-      context: { location: ctx.audit.location, userAgent: ctx.audit.userAgent },
+    await db.transaction(async (tx) => {
+      await setComputeQuotas(tx, { workspaceId: ctx.workspace.id, plan: null });
+      await insertAuditLogs(tx, {
+        workspaceId: ctx.workspace.id,
+        actor: { type: "user", id: ctx.user.id },
+        event: "workspace.update",
+        description: "Cancelled Compute.",
+        resources: [],
+        context: { location: ctx.audit.location, userAgent: ctx.audit.userAgent },
+      });
     });
   });

--- a/web/apps/dashboard/lib/trpc/routers/stripe/changeDeployPlan.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/changeDeployPlan.ts
@@ -3,6 +3,7 @@ import { db, eq, schema } from "@/lib/db";
 import { getStripeClient } from "@/lib/stripe";
 import { deployBillingConfig, findPlanFeeItem } from "@/lib/stripe/deployBilling";
 import { DEPLOY_PLANS } from "@/lib/stripe/deployPlan";
+import { setComputeQuotas } from "@/lib/stripe/setComputeQuotas";
 import { TRPCError } from "@trpc/server";
 import Stripe from "stripe";
 import { z } from "zod";
@@ -109,6 +110,7 @@ export const changeDeployPlan = workspaceProcedure
         .update(schema.workspaceBilling)
         .set({ plan: input.plan })
         .where(eq(schema.workspaceBilling.workspaceId, ctx.workspace.id));
+      await setComputeQuotas(tx, { workspaceId: ctx.workspace.id, plan: input.plan });
       await insertAuditLogs(tx, {
         workspaceId: ctx.workspace.id,
         actor: { type: "user", id: ctx.user.id },

--- a/web/apps/dashboard/lib/trpc/routers/stripe/subscribeDeploy.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/subscribeDeploy.ts
@@ -8,6 +8,7 @@ import {
   findPlanFeeItem,
 } from "@/lib/stripe/deployBilling";
 import { DEPLOY_PLANS } from "@/lib/stripe/deployPlan";
+import { setComputeQuotas } from "@/lib/stripe/setComputeQuotas";
 import { isDeadSubscription } from "@/lib/stripe/subscriptionUtils";
 import { TRPCError } from "@trpc/server";
 import Stripe from "stripe";
@@ -277,6 +278,7 @@ export const subscribeDeploy = workspaceProcedure
           .update(schema.workspaceBilling)
           .set(workspaceUpdate)
           .where(eq(schema.workspaceBilling.workspaceId, ctx.workspace.id));
+        await setComputeQuotas(tx, { workspaceId: ctx.workspace.id, plan: input.plan });
         if (createdDeploySubscriptionId) {
           await upsertBillingSubscription(tx, {
             workspaceId: ctx.workspace.id,


### PR DESCRIPTION
**Problem:**

When someone updates their plan they have different compute quotas which we dont set yet
 

**Solution:**

 Actually set the quoats we have on our billing page

**Impact:**

People who subscribe will be able to choose correct instance sizes 

**Testing:**

Tests should pass