### PR TITLE
fix(rbac): require URN scope containment

### DIFF
--- a/pkg/rbac/rbac.go
+++ b/pkg/rbac/rbac.go
@@ -2,7 +2,6 @@ package rbac
 
 import (
 	"fmt"
-	"slices"
 	"strings"
 
 	"github.com/unkeyed/unkey/pkg/codes"
@@ -150,14 +149,15 @@ func FormatPermissionQuery(query PermissionQuery) string {
 }
 
 // evaluateLeafPermission is the shared leaf evaluator for the boolean query
-// tree. Exact string matching is always available. Unkey wildcard matching is
-// an explicit opt-in carried by U(), not a behavior inferred from string shape.
+// tree. U() leaves are parsed and matched as canonical Unkey permissions;
+// other leaves retain exact string matching.
 func evaluateLeafPermission(query PermissionQuery, permissions []string) bool {
-	if slices.Contains(permissions, query.Value) {
-		return true
-	}
-
 	if !query.matchUnkeyPermission {
+		for _, permission := range permissions {
+			if permission == query.Value {
+				return true
+			}
+		}
 		return false
 	}
 

--- a/pkg/rbac/urn.go
+++ b/pkg/rbac/urn.go
@@ -11,11 +11,11 @@ import (
 
 var errInvalidURNPermission = errors.New("invalid urn permission")
 
-// UnkeyPermission represents an RBAC permission requirement for a Unkey resource.
+// UnkeyPermission represents an RBAC permission scope for Unkey resources.
 //
 // The resource name itself belongs to [urn.V1]. RBAC only adds the action
-// suffix and evaluates whether a principal's granted permissions cover this
-// concrete requirement.
+// suffix. Its resource may identify one concrete resource, a collection scope,
+// or a descendant scope.
 type UnkeyPermission struct {
 	// Resource is the canonical v1 resource name being protected.
 	Resource urn.V1
@@ -31,9 +31,9 @@ func (u UnkeyPermission) String() string {
 
 // U creates a leaf query for a typed action on a canonical resource name.
 //
-// Handlers should pass the exact resource being accessed. Broader grants such
-// as "unkey:v1:ws_123:ratelimits/**#read_override" are matched during
-// evaluation, not by writing wildcard-heavy queries at call sites.
+// The resource may be concrete or may contain canonical "*" and trailing "**"
+// scopes. Evaluation succeeds only when one granted permission covers every
+// resource and action represented by this requirement.
 func U[R fmt.Stringer, A permissions.Action[R]](resource R, action A) PermissionQuery {
 	return PermissionQuery{
 		Operation:            OperatorNil,
@@ -114,8 +114,8 @@ func parseUrnPermission(value string) (UnkeyPermission, error) {
 }
 
 // permissionCovers reports whether a granted permission satisfies a required
-// permission. Required permissions should be concrete; granted permissions may
-// use resource wildcards or "*" as the action. Resource matching, including
+// permission. Containment is directional: one grant must cover every resource
+// and action represented by the requirement. Resource containment, including
 // workspace equality, is delegated to [urn.V1.Covers].
 func permissionCovers(required UnkeyPermission, granted UnkeyPermission) bool {
 	if granted.Action != "*" && granted.Action != required.Action {

--- a/pkg/rbac/urn_test.go
+++ b/pkg/rbac/urn_test.go
@@ -62,6 +62,25 @@ func TestStringQuery_DoesNotOptIntoUnkeyWildcardMatching(t *testing.T) {
 	require.True(t, typedResult.Valid)
 }
 
+// TestStringQuery_PreservesExactMatchingProvenance guarantees canonical-looking
+// strings only receive URN parsing and containment semantics when created by U.
+func TestStringQuery_PreservesExactMatchingProvenance(t *testing.T) {
+	t.Parallel()
+
+	malformed := "unkey:v1:ws_123:projects/**/apps/*#create_app"
+	result, err := New().EvaluatePermissions(S(malformed), []string{malformed})
+	require.NoError(t, err)
+	require.True(t, result.Valid)
+
+	wildcard := "unkey:v1:ws_123:projects/*#create_app"
+	result, err = New().EvaluatePermissions(S(wildcard), []string{
+		"unkey:v1:ws_123:projects/proj_123#create_app",
+		"unkey:v1:ws_123:projects/**#create_app",
+	})
+	require.NoError(t, err)
+	require.False(t, result.Valid)
+}
+
 // TestParseUrnPermission_AcceptsOnlySupportedGrammar guarantees malformed
 // permission strings cannot accidentally participate in wildcard matching.
 func TestParseUrnPermission_AcceptsOnlySupportedGrammar(t *testing.T) {
@@ -247,6 +266,154 @@ func TestPermissionCovers_GrantedWildcardCoversExactRequiredResource(t *testing.
 			require.Equal(t, tt.want, permissionCovers(required, tt.granted))
 		})
 	}
+}
+
+// TestPermissionCovers_RequiresDirectionalScopeContainment guarantees a grant
+// covers every resource and action represented by a wildcard requirement.
+func TestPermissionCovers_RequiresDirectionalScopeContainment(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		granted  string
+		required string
+		want     bool
+	}{
+		{
+			name:     "collection grant covers same collection requirement",
+			granted:  "unkey:v1:ws_123:projects/*#read_project",
+			required: "unkey:v1:ws_123:projects/*#read_project",
+			want:     true,
+		},
+		{
+			name:     "concrete grant does not cover collection requirement",
+			granted:  "unkey:v1:ws_123:projects/proj_123#read_project",
+			required: "unkey:v1:ws_123:projects/*#read_project",
+			want:     false,
+		},
+		{
+			name:     "collection grant does not cover descendant requirement",
+			granted:  "unkey:v1:ws_123:projects/*#read_project",
+			required: "unkey:v1:ws_123:projects/**#read_project",
+			want:     false,
+		},
+		{
+			name:     "descendant grant covers collection requirement",
+			granted:  "unkey:v1:ws_123:projects/**#read_project",
+			required: "unkey:v1:ws_123:projects/*#read_project",
+			want:     true,
+		},
+		{
+			name:     "narrow descendant grant does not cover broad descendant requirement",
+			granted:  "unkey:v1:ws_123:projects/*/apps/**#read_app",
+			required: "unkey:v1:ws_123:projects/**#read_app",
+			want:     false,
+		},
+		{
+			name:     "concrete action does not cover all actions",
+			granted:  "unkey:v1:ws_123:**#read_project",
+			required: "unkey:v1:ws_123:**#*",
+			want:     false,
+		},
+		{
+			name:     "all actions cover concrete action",
+			granted:  "unkey:v1:ws_123:**#*",
+			required: "unkey:v1:ws_123:projects/**#read_project",
+			want:     true,
+		},
+		{
+			name:     "wildcard descendant alias covers global requirement",
+			granted:  "unkey:v1:ws_123:*/**#read_project",
+			required: "unkey:v1:ws_123:**#read_project",
+			want:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			granted, err := parseUrnPermission(tt.granted)
+			require.NoError(t, err)
+			required, err := parseUrnPermission(tt.required)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, permissionCovers(required, granted))
+		})
+	}
+}
+
+// TestUnkeyPermissionQuery_RequiresScopeContainment guarantees the public
+// evaluator does not treat wildcard requirements as concrete target text.
+func TestUnkeyPermissionQuery_RequiresScopeContainment(t *testing.T) {
+	t.Parallel()
+
+	collectionQuery := U(urn.New().Workspace("ws_123").Project("*"), permissions.CreateApp{})
+	descendantQuery := U(urn.New().Workspace("ws_123").Project("*").Any(), permissions.CreatePermission{})
+
+	tests := []struct {
+		name   string
+		query  PermissionQuery
+		grants []string
+		want   bool
+	}{
+		{
+			name:   "concrete grant does not cover collection requirement",
+			query:  collectionQuery,
+			grants: []string{"unkey:v1:ws_123:projects/proj_123#create_app"},
+			want:   false,
+		},
+		{
+			name:   "collection grant covers collection requirement",
+			query:  collectionQuery,
+			grants: []string{"unkey:v1:ws_123:projects/*#create_app"},
+			want:   true,
+		},
+		{
+			name:  "multiple concrete grants do not collectively cover collection requirement",
+			query: collectionQuery,
+			grants: []string{
+				"unkey:v1:ws_123:projects/proj_123#create_app",
+				"unkey:v1:ws_123:projects/proj_456#create_app",
+			},
+			want: false,
+		},
+		{
+			name:   "collection grant does not cover descendant requirement",
+			query:  descendantQuery,
+			grants: []string{"unkey:v1:ws_123:projects/*#create_permission"},
+			want:   false,
+		},
+		{
+			name:   "descendant grant covers descendant requirement",
+			query:  descendantQuery,
+			grants: []string{"unkey:v1:ws_123:projects/*/**#create_permission"},
+			want:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := New().EvaluatePermissions(tt.query, tt.grants)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, result.Valid, result.Message)
+		})
+	}
+}
+
+// TestUnkeyPermissionQuery_RejectsMalformedExactRequirement guarantees the U
+// marker cannot let an invalid canonical requirement bypass parsing through an
+// identical malformed grant.
+func TestUnkeyPermissionQuery_RejectsMalformedExactRequirement(t *testing.T) {
+	t.Parallel()
+
+	query := U(urn.New().Workspace("ws_123").Project("proj_123"), permissions.CreateApp{})
+	query.Value = "unkey:v1:ws_123:projects/**/apps/*#create_app"
+
+	result, err := New().EvaluatePermissions(query, []string{query.Value})
+	require.NoError(t, err)
+	require.False(t, result.Valid)
 }
 
 // TestUrnPermissionEvaluation_MatchesThroughRBACEvaluator guarantees the public

--- a/pkg/urn/urn.go
+++ b/pkg/urn/urn.go
@@ -25,13 +25,13 @@ func (v V1) String() string {
 	return fmt.Sprintf("%s:%s:%s:%s", prefix, version, v.WorkspaceID, v.Resource)
 }
 
-// Covers reports whether the receiver, treated as a resource-name pattern,
-// covers the target resource name. The workspace must match exactly. In the
-// resource path, "*" matches exactly one path segment and a trailing "**"
-// matches the base path and all descendants. A concrete resource name covers
-// only itself. The standalone path "**" is the global pattern covering every
-// resource in the workspace; the standalone path "*" covers only resources
-// with single-segment paths.
+// Covers reports whether every resource represented by the target scope is
+// also represented by the receiver. The workspace must match exactly. In each
+// resource path, "*" represents any one path segment and a trailing "**"
+// represents the base path and all descendants. A concrete resource name
+// covers only itself. The standalone path "**" is the global scope covering
+// every resource in the workspace; the standalone path "*" covers all
+// single-segment resource names.
 //
 // These patterns cover unkey:v1:ws_1:keyspaces/ks_1/keys/k_1:
 //
@@ -50,24 +50,42 @@ func (v V1) Covers(target V1) bool {
 	if v.WorkspaceID != target.WorkspaceID {
 		return false
 	}
-	patternSegments := strings.Split(v.Resource, "/")
+	coveringSegments := strings.Split(v.Resource, "/")
 	targetSegments := strings.Split(target.Resource, "/")
+	coveringDescendants := coveringSegments[len(coveringSegments)-1] == "**"
+	targetDescendants := targetSegments[len(targetSegments)-1] == "**"
 
-	if len(patternSegments) > 0 && patternSegments[len(patternSegments)-1] == "**" {
-		patternSegments = patternSegments[:len(patternSegments)-1]
-		return len(targetSegments) >= len(patternSegments) &&
-			segmentsMatch(patternSegments, targetSegments[:len(patternSegments)])
+	if coveringDescendants {
+		coveringSegments = coveringSegments[:len(coveringSegments)-1]
+		// Resource paths are non-empty, so */** and ** denote the same scope.
+		if len(coveringSegments) == 1 && coveringSegments[0] == "*" {
+			coveringSegments = coveringSegments[:0]
+		}
+	}
+	if targetDescendants {
+		targetSegments = targetSegments[:len(targetSegments)-1]
+		if len(targetSegments) == 1 && targetSegments[0] == "*" {
+			targetSegments = targetSegments[:0]
+		}
 	}
 
-	return len(patternSegments) == len(targetSegments) &&
-		segmentsMatch(patternSegments, targetSegments)
+	if targetDescendants && !coveringDescendants {
+		return false
+	}
+	if coveringDescendants {
+		return len(targetSegments) >= len(coveringSegments) &&
+			segmentsCover(coveringSegments, targetSegments[:len(coveringSegments)])
+	}
+
+	return len(coveringSegments) == len(targetSegments) &&
+		segmentsCover(coveringSegments, targetSegments)
 }
 
-// segmentsMatch compares equal-length segment slices, treating "*" in the
-// pattern as matching any single target segment.
-func segmentsMatch(pattern []string, target []string) bool {
-	for i := range pattern {
-		if pattern[i] != "*" && pattern[i] != target[i] {
+// segmentsCover compares equal-length scope prefixes. A covering "*" contains
+// every target segment, while a concrete segment cannot contain target "*".
+func segmentsCover(covering []string, target []string) bool {
+	for i := range covering {
+		if covering[i] != "*" && covering[i] != target[i] {
 			return false
 		}
 	}

--- a/pkg/urn/urn_test.go
+++ b/pkg/urn/urn_test.go
@@ -240,9 +240,9 @@ func TestResourceCatalogHelpers(t *testing.T) {
 	require.Equal(t, "unkey:v1:ws_123:portals/portal_123/**", workspace.Portal("portal_123").Any().String())
 }
 
-// TestV1Covers_OnlySupportedWildcardsExpandScope guarantees "*" matches one
-// path segment, trailing "**" is the only descendant wildcard, and workspaces
-// must match exactly.
+// TestV1Covers_OnlySupportedWildcardsExpandScope guarantees Covers performs
+// directional scope containment for concrete, collection, and descendant
+// resource scopes.
 func TestV1Covers_OnlySupportedWildcardsExpandScope(t *testing.T) {
 	t.Parallel()
 
@@ -254,17 +254,39 @@ func TestV1Covers_OnlySupportedWildcardsExpandScope(t *testing.T) {
 	}{
 		{name: "global wildcard", pattern: "**", target: "ratelimits/namespaces/ns_123", want: true},
 		{name: "global wildcard covers single segment", pattern: "**", target: "settings", want: true},
+		{name: "wildcard descendant alias covers global wildcard", pattern: "*/**", target: "**", want: true},
+		{name: "global wildcard covers wildcard descendant alias", pattern: "**", target: "*/**", want: true},
+		{name: "two segment descendant scope does not cover global wildcard", pattern: "*/*/**", target: "**", want: false},
 		{name: "single segment wildcard matches one segment", pattern: "*", target: "settings", want: true},
 		{name: "single segment wildcard does not match nested paths", pattern: "*", target: "ratelimits/namespaces/ns_123", want: false},
 		{name: "exact", pattern: "ratelimits/namespaces/ns_123", target: "ratelimits/namespaces/ns_123", want: true},
 		{name: "segment wildcard", pattern: "ratelimits/namespaces/*", target: "ratelimits/namespaces/ns_123", want: true},
+		{name: "equal segment wildcard scopes", pattern: "ratelimits/namespaces/*", target: "ratelimits/namespaces/*", want: true},
+		{name: "concrete does not cover segment wildcard scope", pattern: "ratelimits/namespaces/ns_123", target: "ratelimits/namespaces/*", want: false},
 		{name: "descendant wildcard", pattern: "ratelimits/**", target: "ratelimits/namespaces/ns_123", want: true},
+		{name: "descendant wildcard covers narrower wildcard scope", pattern: "ratelimits/**", target: "ratelimits/namespaces/*", want: true},
+		{name: "descendant wildcard covers narrower descendant scope", pattern: "ratelimits/**", target: "ratelimits/namespaces/**", want: true},
+		{name: "segment wildcard does not cover descendant scope", pattern: "ratelimits/*", target: "ratelimits/**", want: false},
+		{name: "narrow descendant scope does not cover broader descendant scope", pattern: "ratelimits/namespaces/**", target: "ratelimits/**", want: false},
 		{name: "descendant wildcard covers base", pattern: "ratelimits/**", target: "ratelimits", want: true},
 		{name: "descendant wildcard target shorter than base", pattern: "ratelimits/namespaces/**", target: "ratelimits", want: false},
 		{name: "descendant wildcard wrong prefix", pattern: "identities/**", target: "ratelimits/namespaces/ns_123", want: false},
 		{name: "segment wildcard does not cross segments", pattern: "ratelimits/*", target: "ratelimits/namespaces/ns_123", want: false},
 		{name: "exact shorter", pattern: "ratelimits", target: "ratelimits/namespaces/ns_123", want: false},
 		{name: "exact longer", pattern: "ratelimits/namespaces/ns_123", target: "ratelimits", want: false},
+		{name: "descendant covers sibling collection", pattern: "a/b/**", target: "a/b/*", want: true},
+		{name: "sibling collection does not cover descendant", pattern: "a/b/*", target: "a/b/**", want: false},
+		{name: "wildcard parent descendant covers concrete parent descendant", pattern: "a/*/**", target: "a/b/**", want: true},
+		{name: "concrete parent descendant does not cover wildcard parent descendant", pattern: "a/b/**", target: "a/*/**", want: false},
+		{name: "wildcard parent descendant covers parent collection", pattern: "a/*/**", target: "a/*", want: true},
+		{name: "concrete parent descendant does not cover wildcard collection", pattern: "a/b/**", target: "a/*", want: false},
+		{name: "nested wildcard descendant covers concrete nested collection", pattern: "a/*/c/**", target: "a/b/c/*", want: true},
+		{name: "concrete nested descendant does not cover wildcard nested collection", pattern: "a/b/c/**", target: "a/*/c/*", want: false},
+		{name: "equal nested wildcard collections", pattern: "a/*/c/*", target: "a/*/c/*", want: true},
+		{name: "nested collection does not cover nested descendant", pattern: "a/*/c/*", target: "a/*/c/**", want: false},
+		{name: "wrong prefix descendant scopes", pattern: "a/**", target: "b/**", want: false},
+		{name: "reverse wrong prefix descendant scopes", pattern: "b/**", target: "a/**", want: false},
+		{name: "single segment wildcard does not cover global descendant", pattern: "*", target: "**", want: false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
> [!IMPORTANT]
> Unkey is not accepting external pull requests at this time. Pull requests from people outside the Unkey team will not be reviewed or merged.

## What does this PR do?

API route authorization is moving toward canonical resource permissions. Some routes authorize one resource, while collection and list routes authorize a set of resources: for example, every project selected by `projects/*`, or a resource and all descendants selected by a trailing `**`. Those routes need wildcard requirements because checking one invented point cannot express the full scope the operation may return or affect.

Once both grants and requirements may represent scopes, point matching is unsafe. Treating the required wildcard as target text can allow a narrower grant such as `a/*` to satisfy a broader `a/**` requirement. Authorization instead uses directional set containment: one granted canonical permission must cover every resource and action represented by the requirement. Grants are not combined to approximate that coverage.

Requirements created through `rbac.U` are provenance-marked as canonical Unkey permissions. They are parsed before any exact-string match, so an identical malformed requirement and grant cannot bypass the canonical grammar. `rbac.T` and `rbac.S` preserve the compatibility boundary for legacy tuple permissions and customer-defined strings: even canonical-looking text remains exact-only unless the caller explicitly used `U`.

The ownership boundary follows the domain model. `pkg/urn` owns containment between resource scopes, including workspace isolation, one-segment `*`, and trailing descendant `**`. `pkg/rbac` owns the typed opt-in, action containment, and the rule that a single grant must contain the complete requirement. One subtle scope equivalence is intentional: because canonical resource paths are non-empty, `*/**` covers every possible first segment and its descendants, so it denotes the same global resource set as `**`.

The parser prerequisite #6878, which accepts hierarchical wildcard paths, has landed on main. This PR is now based on main and contains only the scope-containment evaluator changes.

### Review focus

Please focus on the direction of the containment comparisons, especially collection versus descendant scopes, wildcard versus concrete prefixes, the `*/**` equivalence, action containment, and the `U` versus `T`/`S` provenance boundary.

### Non-goals

- Migrating API routes or defining their final permission requirements
- Changing the canonical URN grammar supplied by #6878
- Adding wildcard behavior to legacy tuple or customer-defined permissions
- Combining several narrower grants to satisfy one broader requirement

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- Run `mise exec -- rask ./pkg/urn ./pkg/rbac`: 719 tests, 328 passed, 0 failed, 391 ignored.
- Run `mise exec -- gofmt -d pkg/rbac/urn.go pkg/rbac/urn_test.go pkg/urn/urn.go pkg/urn/urn_test.go pkg/rbac/rbac.go`: no output.
- Run `git diff --check HEAD^ HEAD`: no errors.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `mise run fmt`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary
