### PR TITLE
perf(ctrl): shard Deploy billing usage reads

### DIFF
--- a/svc/ctrl/internal/db/querier_generated.go
+++ b/svc/ctrl/internal/db/querier_generated.go
@@ -1446,6 +1446,21 @@ type Querier interface {
 	//    AND b.stripe_customer_id IS NOT NULL
 	//    AND w.deleted_at_m IS NULL
 	ListDeployBillableWorkspaces(ctx context.Context) ([]ListDeployBillableWorkspacesRow, error)
+	// Lists the workspaces whose Deploy usage can be reported to Stripe. This is
+	// intentionally not gated on an active plan or enabled workspace: usage
+	// incurred while a cancelled deployment drains is still owed. The hourly
+	// push uses this set to scope and shard the ClickHouse scan before doing the
+	// expensive checkpoint integration; workspaces without a Stripe customer
+	// could never produce a meter event and must not make that scan more costly.
+	//
+	//  SELECT
+	//     w.id,
+	//     b.stripe_customer_id
+	//  FROM `workspaces` w
+	//  INNER JOIN `workspace_billing` b ON b.workspace_id = w.id
+	//  WHERE b.stripe_customer_id IS NOT NULL
+	//    AND b.stripe_customer_id <> ''
+	ListDeployBillingCustomers(ctx context.Context) ([]ListDeployBillingCustomersRow, error)
 	// ListDeploymentChangesByRegionAll returns all deployment changes for a region with version > after_version.
 	// Used by the unified WatchDeploymentChanges stream. Does not filter by resource_type.
 	//

--- a/svc/ctrl/internal/db/queries/workspace_deploy_billing.sql
+++ b/svc/ctrl/internal/db/queries/workspace_deploy_billing.sql
@@ -15,3 +15,18 @@ SELECT
 FROM `workspaces` w
 LEFT JOIN `workspace_billing` b ON (b.workspace_id = w.id COLLATE utf8mb4_0900_ai_ci AND b.workspace_id = w.id COLLATE utf8mb4_0900_as_cs)
 WHERE w.id IN (sqlc.slice('workspace_ids'));
+
+-- name: ListDeployBillingCustomers :many
+-- Lists the workspaces whose Deploy usage can be reported to Stripe. This is
+-- intentionally not gated on an active plan or enabled workspace: usage
+-- incurred while a cancelled deployment drains is still owed. The hourly
+-- push uses this set to scope and shard the ClickHouse scan before doing the
+-- expensive checkpoint integration; workspaces without a Stripe customer
+-- could never produce a meter event and must not make that scan more costly.
+SELECT
+   w.id,
+   b.stripe_customer_id
+FROM `workspaces` w
+INNER JOIN `workspace_billing` b ON b.workspace_id = w.id
+WHERE b.stripe_customer_id IS NOT NULL
+  AND b.stripe_customer_id <> '';

--- a/svc/ctrl/internal/db/workspace_deploy_billing.sql_generated.go
+++ b/svc/ctrl/internal/db/workspace_deploy_billing.sql_generated.go
@@ -11,6 +11,58 @@ import (
 	"strings"
 )
 
+const listDeployBillingCustomers = `-- name: ListDeployBillingCustomers :many
+SELECT
+   w.id,
+   b.stripe_customer_id
+FROM ` + "`" + `workspaces` + "`" + ` w
+INNER JOIN ` + "`" + `workspace_billing` + "`" + ` b ON b.workspace_id = w.id
+WHERE b.stripe_customer_id IS NOT NULL
+  AND b.stripe_customer_id <> ''
+`
+
+type ListDeployBillingCustomersRow struct {
+	ID               string         `db:"id"`
+	StripeCustomerID sql.NullString `db:"stripe_customer_id"`
+}
+
+// Lists the workspaces whose Deploy usage can be reported to Stripe. This is
+// intentionally not gated on an active plan or enabled workspace: usage
+// incurred while a cancelled deployment drains is still owed. The hourly
+// push uses this set to scope and shard the ClickHouse scan before doing the
+// expensive checkpoint integration; workspaces without a Stripe customer
+// could never produce a meter event and must not make that scan more costly.
+//
+//	SELECT
+//	   w.id,
+//	   b.stripe_customer_id
+//	FROM `workspaces` w
+//	INNER JOIN `workspace_billing` b ON b.workspace_id = w.id
+//	WHERE b.stripe_customer_id IS NOT NULL
+//	  AND b.stripe_customer_id <> ''
+func (q *Queries) ListDeployBillingCustomers(ctx context.Context) ([]ListDeployBillingCustomersRow, error) {
+	rows, err := q.db.QueryContext(ctx, listDeployBillingCustomers)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListDeployBillingCustomersRow
+	for rows.Next() {
+		var i ListDeployBillingCustomersRow
+		if err := rows.Scan(&i.ID, &i.StripeCustomerID); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listWorkspacesForDeployBillingByIDs = `-- name: ListWorkspacesForDeployBillingByIDs :many
 SELECT
    w.id,

--- a/svc/ctrl/worker/cron/deploy_billing_close_integration_test.go
+++ b/svc/ctrl/worker/cron/deploy_billing_close_integration_test.go
@@ -44,22 +44,46 @@ func (f *fakeUsageReader) setActiveKeys(rows []clickhouse.ActiveKeysUsage) {
 
 func (f *fakeUsageReader) GetInstanceMeterUsage(
 	_ context.Context,
-	_ clickhouse.GetInstanceMeterUsageRequest,
+	req clickhouse.GetInstanceMeterUsageRequest,
 ) ([]clickhouse.InstanceMeterUsage, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.instanceReads++
-	return f.rows, nil
+	workspaceIDs := make(map[string]struct{}, len(req.WorkspaceIDs))
+	for _, workspaceID := range req.WorkspaceIDs {
+		workspaceIDs[workspaceID] = struct{}{}
+	}
+	rows := make([]clickhouse.InstanceMeterUsage, 0, len(f.rows))
+	for _, row := range f.rows {
+		_, included := workspaceIDs[row.WorkspaceID]
+		if (req.WorkspaceID == "" || row.WorkspaceID == req.WorkspaceID) &&
+			(req.WorkspaceIDs == nil || included) {
+			rows = append(rows, row)
+		}
+	}
+	return rows, nil
 }
 
 func (f *fakeUsageReader) GetActiveKeysUsage(
 	_ context.Context,
-	_ clickhouse.GetActiveKeysUsageRequest,
+	req clickhouse.GetActiveKeysUsageRequest,
 ) ([]clickhouse.ActiveKeysUsage, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.activeKeyReads++
-	return f.activeKeys, nil
+	workspaceIDs := make(map[string]struct{}, len(req.WorkspaceIDs))
+	for _, workspaceID := range req.WorkspaceIDs {
+		workspaceIDs[workspaceID] = struct{}{}
+	}
+	rows := make([]clickhouse.ActiveKeysUsage, 0, len(f.activeKeys))
+	for _, row := range f.activeKeys {
+		_, included := workspaceIDs[row.WorkspaceID]
+		if (req.WorkspaceID == "" || row.WorkspaceID == req.WorkspaceID) &&
+			(req.WorkspaceIDs == nil || included) {
+			rows = append(rows, row)
+		}
+	}
+	return rows, nil
 }
 
 func (f *fakeUsageReader) reads() (instance, activeKeys int) {

--- a/svc/ctrl/worker/cron/deploybilling/billing.go
+++ b/svc/ctrl/worker/cron/deploybilling/billing.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"sort"
 
 	restate "github.com/restatedev/sdk-go"
 	"github.com/unkeyed/unkey/pkg/billingperiod"
@@ -26,6 +27,11 @@ const (
 	// bytesPerGiB converts egress bytes to binary GiB; the egress meter is
 	// deploy.egress_public_gib (GiB, 2^30), not decimal GB.
 	bytesPerGiB = 1024 * 1024 * 1024
+	// maxInstanceUsageShards works around the ordered ClickHouse window stage,
+	// which processes a fleet query through one read stream. Each shard is a
+	// disjoint workspace-id range, matching the table's leading sort key, so the
+	// reads run in parallel without scanning or billing any row twice.
+	maxInstanceUsageShards = 8
 )
 
 // Per-unit Deploy meter rates in cents, mirroring the canonical catalog in
@@ -101,12 +107,43 @@ func MergeActiveKeys(
 	}
 }
 
-// FleetMeterValues reads instance and active-keys usage for
-// [p.Start(), endMillis) as two journaled steps and returns the aggregated
-// per-workspace MeterValues. workspaceIDs scopes the ClickHouse scan; nil
-// scans the whole fleet. Exported so the spend-cap check prices the exact
-// same values the hourly push bills, scoped to its budgeted set instead of
-// re-aggregating everyone's month at its tight cadence.
+// instanceMeterUsageShards splits a usage request into stable, disjoint
+// workspace-id ranges. Sorting matches the table's leading order key and makes
+// the Restate RunAsync journal entries deterministic across replays.
+func instanceMeterUsageShards(
+	req clickhouse.GetInstanceMeterUsageRequest,
+) []clickhouse.GetInstanceMeterUsageRequest {
+	if len(req.WorkspaceIDs) < 2 {
+		return []clickhouse.GetInstanceMeterUsageRequest{req}
+	}
+
+	workspaceIDs := append([]string(nil), req.WorkspaceIDs...)
+	sort.Strings(workspaceIDs)
+	shardCount := min(len(workspaceIDs), maxInstanceUsageShards)
+	shards := make([]clickhouse.GetInstanceMeterUsageRequest, shardCount)
+
+	for shard := range shardCount {
+		start := shard * len(workspaceIDs) / shardCount
+		end := (shard + 1) * len(workspaceIDs) / shardCount
+		shardReq := req
+		shardReq.WorkspaceIDs = workspaceIDs[start:end]
+		shards[shard] = shardReq
+	}
+
+	return shards
+}
+
+type instanceMeterUsageShardResult struct {
+	Shard int
+	Rows  []clickhouse.InstanceMeterUsage
+}
+
+// FleetMeterValues reads instance usage as independently journaled shards and
+// active-keys usage as one journaled step for [p.Start(), endMillis), then
+// returns the aggregated per-workspace MeterValues. workspaceIDs scopes the
+// ClickHouse scan; nil scans the whole fleet. Exported so the spend-cap check
+// prices the exact same values the hourly push bills, scoped to its budgeted
+// set instead of re-aggregating everyone's month at its tight cadence.
 func FleetMeterValues(
 	ctx restate.ObjectContext,
 	usage UsageReader,
@@ -114,16 +151,47 @@ func FleetMeterValues(
 	endMillis int64,
 	workspaceIDs []string,
 ) (map[string]billingmeter.MeterValues, error) {
-	rows, err := restate.Run(ctx, func(rc restate.RunContext) ([]clickhouse.InstanceMeterUsage, error) {
-		return usage.GetInstanceMeterUsage(rc, clickhouse.GetInstanceMeterUsageRequest{
-			WorkspaceID:  "",
-			WorkspaceIDs: workspaceIDs,
-			Start:        p.Start().UnixMilli(),
-			End:          endMillis,
-		})
-	}, restate.WithName("get period usage"))
-	if err != nil {
-		return nil, fmt.Errorf("get period usage: %w", err)
+	if workspaceIDs != nil && len(workspaceIDs) == 0 {
+		return map[string]billingmeter.MeterValues{}, nil
+	}
+
+	shards := instanceMeterUsageShards(clickhouse.GetInstanceMeterUsageRequest{
+		WorkspaceID:  "",
+		WorkspaceIDs: workspaceIDs,
+		Start:        p.Start().UnixMilli(),
+		End:          endMillis,
+	})
+	futures := make([]restate.Selectable, len(shards))
+	for shard, shardReq := range shards {
+		futures[shard] = restate.RunAsync(ctx, func(rc restate.RunContext) (instanceMeterUsageShardResult, error) {
+			rows, err := usage.GetInstanceMeterUsage(rc, shardReq)
+			if err != nil {
+				return instanceMeterUsageShardResult{}, fmt.Errorf(
+					"query instance usage shard %d/%d: %w",
+					shard+1,
+					len(shards),
+					err,
+				)
+			}
+			return instanceMeterUsageShardResult{Shard: shard, Rows: rows}, nil
+		}, restate.WithName(fmt.Sprintf("get period usage shard %d/%d", shard+1, len(shards))))
+	}
+
+	rowsByShard := make([][]clickhouse.InstanceMeterUsage, len(shards))
+	for future, waitErr := range restate.Wait(ctx, futures...) {
+		if waitErr != nil {
+			return nil, fmt.Errorf("wait for period usage shards: %w", waitErr)
+		}
+		result, resultErr := future.(restate.RunAsyncFuture[instanceMeterUsageShardResult]).Result()
+		if resultErr != nil {
+			return nil, fmt.Errorf("get period usage: %w", resultErr)
+		}
+		rowsByShard[result.Shard] = result.Rows
+	}
+
+	var rows []clickhouse.InstanceMeterUsage
+	for _, shardRows := range rowsByShard {
+		rows = append(rows, shardRows...)
 	}
 
 	keyRows, err := restate.Run(ctx, func(rc restate.RunContext) ([]clickhouse.ActiveKeysUsage, error) {

--- a/svc/ctrl/worker/cron/deploybilling/billing_test.go
+++ b/svc/ctrl/worker/cron/deploybilling/billing_test.go
@@ -1,6 +1,7 @@
 package deploybilling
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -9,6 +10,32 @@ import (
 	"github.com/unkeyed/unkey/pkg/clickhouse"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/billingmeter"
 )
+
+func TestInstanceMeterUsageShardsWorkspaceIDs(t *testing.T) {
+	workspaceIDs := make([]string, 20)
+	for i := range workspaceIDs {
+		workspaceIDs[i] = fmt.Sprintf("ws_%02d", i)
+	}
+
+	requests := instanceMeterUsageShards(clickhouse.GetInstanceMeterUsageRequest{
+		WorkspaceIDs: workspaceIDs,
+		Start:        1,
+		End:          2,
+	})
+	require.Len(t, requests, maxInstanceUsageShards)
+
+	seen := make(map[string]int, len(workspaceIDs))
+	for _, req := range requests {
+		require.Equal(t, int64(1), req.Start)
+		require.Equal(t, int64(2), req.End)
+		for _, workspaceID := range req.WorkspaceIDs {
+			seen[workspaceID]++
+		}
+	}
+	for _, workspaceID := range workspaceIDs {
+		require.Equal(t, 1, seen[workspaceID], "workspace must belong to exactly one shard")
+	}
+}
 
 func TestAggregateUsage(t *testing.T) {
 	const gib = 1 << 30

--- a/svc/ctrl/worker/cron/deploybilling/push.go
+++ b/svc/ctrl/worker/cron/deploybilling/push.go
@@ -171,8 +171,30 @@ func (h *Handler) resolvePushTasks(
 	endMillis int64,
 	eventTimestamp int64,
 ) (tasks []pushTask, workspacesWithUsage int, err error) {
-	// Whole fleet (no id scoping): billable workspaces are filtered below.
-	valuesByWorkspace, err := FleetMeterValues(ctx, h.usage, p, endMillis, nil)
+	// Resolve the only workspaces whose usage can become a Stripe meter event
+	// before reading ClickHouse. Besides avoiding work that would be discarded
+	// below, the stable id set lets FleetMeterValues split the single-threaded
+	// checkpoint window query into disjoint, index-backed shards.
+	workspaces, err := restate.Run(ctx, func(rc restate.RunContext) ([]db.ListDeployBillingCustomersRow, error) {
+		return h.db.ListDeployBillingCustomers(rc)
+	}, restate.WithName("list deploy billing customers"))
+	if err != nil {
+		return nil, 0, fmt.Errorf("list deploy billing customers: %w", err)
+	}
+	if len(workspaces) == 0 {
+		logger.Info("no deploy billing customers", "billing_period", period)
+		return nil, 0, nil
+	}
+	sort.Slice(workspaces, func(i, j int) bool { return workspaces[i].ID < workspaces[j].ID })
+
+	workspaceIDs := make([]string, 0, len(workspaces))
+	workspacesByID := make(map[string]db.ListDeployBillingCustomersRow, len(workspaces))
+	for _, workspace := range workspaces {
+		workspaceIDs = append(workspaceIDs, workspace.ID)
+		workspacesByID[workspace.ID] = workspace
+	}
+
+	valuesByWorkspace, err := FleetMeterValues(ctx, h.usage, p, endMillis, workspaceIDs)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -182,23 +204,11 @@ func (h *Handler) resolvePushTasks(
 	}
 
 	// Stable order so the journaled fan-out steps replay identically.
-	workspaceIDs := make([]string, 0, len(valuesByWorkspace))
+	workspaceIDs = workspaceIDs[:0]
 	for id := range valuesByWorkspace {
 		workspaceIDs = append(workspaceIDs, id)
 	}
 	sort.Strings(workspaceIDs)
-
-	workspaces, err := restate.Run(ctx, func(rc restate.RunContext) ([]db.ListWorkspacesForDeployBillingByIDsRow, error) {
-		return h.db.ListWorkspacesForDeployBillingByIDs(rc, workspaceIDs)
-	}, restate.WithName("fetch workspace billing identities"))
-	if err != nil {
-		return nil, 0, fmt.Errorf("fetch workspace billing identities: %w", err)
-	}
-
-	workspacesByID := make(map[string]db.ListWorkspacesForDeployBillingByIDsRow, len(workspaces))
-	for _, w := range workspaces {
-		workspacesByID[w.ID] = w
-	}
 
 	tasks = make([]pushTask, 0, len(workspaceIDs))
 	for _, id := range workspaceIDs {
@@ -215,10 +225,6 @@ func (h *Handler) resolvePushTasks(
 		// regardless of the workspace's current state. The only blocker is a
 		// missing Stripe customer, since there is nothing to map the usage onto.
 		if !w.StripeCustomerID.Valid || w.StripeCustomerID.String == "" {
-			logger.Info("workspace has deploy usage but no stripe customer; skipping",
-				"workspace_id", id,
-				"billing_period", period,
-			)
 			continue
 		}
 

--- a/svc/ctrl/worker/cron/deployspendcheck/handler.go
+++ b/svc/ctrl/worker/cron/deployspendcheck/handler.go
@@ -20,8 +20,8 @@ import (
 
 // Config holds the orchestrator's dependencies. The per-workspace check
 // (threshold state, alert email) runs in CheckHandler; this handler resolves
-// who to check, prices their usage from one scoped ClickHouse scan, and fans
-// out only to the workspaces that are near or over their budget.
+// who to check, prices their usage from scoped ClickHouse reads, and fans out
+// only to the workspaces that are near or over their budget.
 type Config struct {
 	// DB is the primary application database, used to list workspaces with a
 	// configured Deploy spend budget. Must not be nil.
@@ -57,9 +57,9 @@ func New(cfg Config) (*Handler, error) {
 
 // Handle lists the workspaces that configured a Deploy spend budget (the VO key
 // is the billing period "YYYY-MM"), prices their month-to-date usage from a
-// single ClickHouse scan scoped to that set (the same one-scan shape as the
-// hourly billing push), fans out one check per ACTIONABLE workspace with the
-// priced gross carried in the request, and awaits the outcomes, withholding
+// journaled ClickHouse step scoped to that set (the same sharded-read shape as
+// the hourly billing push), fans out one check per ACTIONABLE workspace with
+// the priced gross carried in the request, and awaits the outcomes, withholding
 // the heartbeat when any check failed.
 //
 // Actionable means gross month-to-date metered spend has reached the lowest
@@ -249,14 +249,13 @@ func (h *Handler) Handle(
 }
 
 // priceUsage reads the period's month-to-date usage for the budgeted
-// workspaces in one grouped ClickHouse scan (two queries: instance meters and
-// active keys, shared with the hourly push via FleetMeterValues) and returns
-// the aggregated MeterValues keyed by workspace id. One grouped scan is how
-// ClickHouse wants to be read; per-workspace point queries at fan-out scale
-// are not, and scoping it to the budgeted set keeps the tight cadence from
-// re-aggregating the whole fleet's month. The read is capped at the period's
-// end so a stale invocation running after the roll cannot fold the next month
-// into this period's decisions.
+// workspaces in two journaled ClickHouse steps (instance meters and active
+// keys, shared with the hourly push via FleetMeterValues) and returns the
+// aggregated MeterValues keyed by workspace id. The expensive instance step
+// splits the scoped IDs across a bounded number of concurrent queries; it
+// avoids both a fleet scan and per-workspace query fan-out at cron cadence. The
+// read is capped at the period's end so a stale invocation running after the
+// roll cannot fold the next month into this period's decisions.
 func (h *Handler) priceUsage(
 	ctx restate.ObjectContext,
 	p billingperiod.Period,


### PR DESCRIPTION
**Problem:**

The hourly Deploy billing run's `get period usage` takes a minute as we scan the whole db basically which is not great performance and will worsen over time.

**Solution:**

Instead we now get all stripe customers first and then divide them into sharts based on our checkpoints order key which is the workspace id.

Then we call out N queries and join everything together and continue on.

**Impact:**

We now scan fewer rows and should process the hourly push faster. Each query can fail independently too.

Billing quantities and Stripe meter events remain unchanged

**Testing:**

Tests should pass