### PR TITLE
fix(dashboard): apply compute plan entitlements

### DIFF
--- a/web/apps/dashboard/app/api/webhooks/stripe/route.ts
+++ b/web/apps/dashboard/app/api/webhooks/stripe/route.ts
@@ -1,6 +1,6 @@
 import { DeployService } from "@/gen/proto/ctrl/v1/deployment_pb";
 import { insertAuditLogs } from "@/lib/audit";
-import { auth } from "@/lib/auth/server";
+import { deactivateNonCreatorMemberships } from "@/lib/auth/deactivateNonCreatorMemberships";
 import { createCtrlClient } from "@/lib/ctrl-client";
 import { db, eq, schema } from "@/lib/db";
 import { stripeEnv } from "@/lib/env";
@@ -14,7 +14,7 @@ import {
 } from "@/lib/stripe/computeAlerts";
 import { deployBillingConfig, findApiItem } from "@/lib/stripe/deployBilling";
 import { grantDeployCreditsForInvoice } from "@/lib/stripe/deployCredits";
-import { detectDeployPlan } from "@/lib/stripe/deployPlan";
+import { deployPlanGrantsTeam, detectDeployPlan, parseDeployPlan } from "@/lib/stripe/deployPlan";
 import { linkApiSubscription } from "@/lib/stripe/linkApiSubscription";
 import { linkDeploySubscription } from "@/lib/stripe/linkDeploySubscription";
 import { isPaymentRecovery, isPaymentRecoveryUpdate } from "@/lib/stripe/paymentUtils";
@@ -52,20 +52,30 @@ import Stripe from "stripe";
  * updated handler already returns early on a cancelling subscription.
  */
 async function mirrorDeployPlan(
-  billing: { workspaceId: string; plan: string | null },
+  billing: { workspaceId: string; plan: string | null; tier: string | null },
+  orgId: string,
   sub: Stripe.Subscription,
 ): Promise<void> {
   const cancelling = Boolean(sub.cancel_at_period_end) || Boolean(sub.cancel_at);
   const plan = cancelling ? null : detectDeployPlan(sub);
   const changed = plan !== billing.plan;
   if (changed) {
+    const preserveApiQuotas = (billing.tier ?? "Free") !== "Free";
     await db.transaction(async (tx) => {
       await tx
         .update(schema.workspaceBilling)
         .set({ plan })
         .where(eq(schema.workspaceBilling.workspaceId, billing.workspaceId));
-      await setComputeQuotas(tx, { workspaceId: billing.workspaceId, plan });
+      await setComputeQuotas(tx, {
+        workspaceId: billing.workspaceId,
+        plan,
+        preserveApiQuotas,
+      });
     });
+
+    if (!preserveApiQuotas && deployPlanGrantsTeam(billing.plan) && !deployPlanGrantsTeam(plan)) {
+      await deactivateNonCreatorMemberships(orgId);
+    }
   }
 }
 
@@ -323,43 +333,6 @@ async function resolveApiSubscriptionContext(
   return { unitAmount: price.unit_amount, customer, product };
 }
 
-/**
- * Deactivates every active membership in `orgId` except the earliest one (the original
- * creator). Determining the creator from membership createdAt avoids storing extra DB
- * state. Errors per-membership are logged but don't fail the webhook — partial revocation
- * is preferable to leaving the workspace stuck in an inconsistent paid state.
- */
-async function deactivateNonCreatorMemberships(orgId: string): Promise<void> {
-  let memberships: Awaited<ReturnType<typeof auth.getOrganizationMemberList>>;
-  try {
-    memberships = await auth.getOrganizationMemberList(orgId);
-  } catch (err) {
-    console.error("Failed to list memberships for deactivation:", { orgId, error: err });
-    return;
-  }
-
-  if (memberships.data.length <= 1) {
-    return;
-  }
-
-  const sorted = [...memberships.data].sort((a, b) => a.createdAt.localeCompare(b.createdAt));
-  const [, ...nonCreators] = sorted;
-
-  await Promise.all(
-    nonCreators.map(async (member) => {
-      try {
-        await auth.deactivateMembership(member.id, orgId);
-      } catch (err) {
-        console.error("Failed to deactivate membership:", {
-          orgId,
-          membershipId: member.id,
-          error: err,
-        });
-      }
-    }),
-  );
-}
-
 export const runtime = "nodejs";
 
 export const POST = async (req: Request): Promise<Response> => {
@@ -479,7 +452,7 @@ export const POST = async (req: Request): Promise<Response> => {
         // dashboard mutations write the plan optimistically before this fires).
         if (column === "compute") {
           await deprovisionOnCancel(billing, sub);
-          await mirrorDeployPlan(billing, sub);
+          await mirrorDeployPlan(billing, ws.orgId, sub);
           const deployConfig = await deployBillingConfig();
           await sendComputeAlert(
             stripe,
@@ -769,7 +742,7 @@ export const POST = async (req: Request): Promise<Response> => {
             }
           }
 
-          // Team follows any live paid product, so a paid API tier keeps it.
+          // A paid API tier keeps team access after Compute ends.
           const keepsTeam = keepsTeamAfterDelete("compute", billing);
 
           // One transaction. Deleting the billing_subscriptions row is what the
@@ -786,7 +759,11 @@ export const POST = async (req: Request): Promise<Response> => {
             // Reset the Compute-owned ceilings even when a paid API plan remains;
             // in that case the API-owned quota fields and team access stay intact.
             if (keepsTeam) {
-              await setComputeQuotas(tx, { workspaceId: ws.id, plan: null });
+              await setComputeQuotas(tx, {
+                workspaceId: ws.id,
+                plan: null,
+                preserveApiQuotas: true,
+              });
             } else {
               await tx
                 .insert(schema.quotas)
@@ -838,21 +815,18 @@ export const POST = async (req: Request): Promise<Response> => {
           break;
         }
 
-        // API-matched: downgrade the API tier. An active Deploy plan keeps team.
+        // API-matched: downgrade the API tier. Pro/Business Compute keeps team.
+        const deployPlan = parseDeployPlan(billing.plan);
         const keepsTeam = keepsTeamAfterDelete("api", billing);
 
-        // When a Compute plan survives, reset only the API-scoped quota fields:
-        // the Compute resource ceilings belong to the surviving plan, so
-        // spreading all of freeTierQuotas would clamp them to Free the moment
-        // Compute tiers diverge from the Free defaults.
+        // When a Compute plan survives, reset the API-only fields and then
+        // reapply that plan's shared and resource entitlements. Without a
+        // Compute plan, restore the complete free quota record.
         const apiFreeQuotas = {
           requestsPerMonth: freeTierQuotas.requestsPerMonth,
-          logsRetentionDays: freeTierQuotas.logsRetentionDays,
-          auditLogsRetentionDays: freeTierQuotas.auditLogsRetentionDays,
           ratelimitApiLimit: freeTierQuotas.ratelimitApiLimit,
           ratelimitApiDuration: freeTierQuotas.ratelimitApiDuration,
         };
-        const downgradedQuotas = keepsTeam ? { ...apiFreeQuotas, team: true } : freeTierQuotas;
 
         // One transaction. Deleting the billing_subscriptions row is what the
         // retry lookup keys on, so if it committed alone and a later write
@@ -867,10 +841,22 @@ export const POST = async (req: Request): Promise<Response> => {
             .where(eq(schema.workspaceBilling.workspaceId, ws.id));
           await deleteBillingSubscription(tx, { workspaceId: ws.id, product: "api" });
 
-          await tx
-            .insert(schema.quotas)
-            .values({ workspaceId: ws.id, ...downgradedQuotas })
-            .onDuplicateKeyUpdate({ set: downgradedQuotas });
+          if (deployPlan) {
+            await tx
+              .insert(schema.quotas)
+              .values({ workspaceId: ws.id, ...apiFreeQuotas })
+              .onDuplicateKeyUpdate({ set: apiFreeQuotas });
+            await setComputeQuotas(tx, {
+              workspaceId: ws.id,
+              plan: deployPlan,
+              preserveApiQuotas: false,
+            });
+          } else {
+            await tx
+              .insert(schema.quotas)
+              .values({ workspaceId: ws.id, ...freeTierQuotas })
+              .onDuplicateKeyUpdate({ set: freeTierQuotas });
+          }
 
           await insertAuditLogs(tx, {
             workspaceId: ws.id,
@@ -967,8 +953,8 @@ export const POST = async (req: Request): Promise<Response> => {
         // never carries Compute plan metadata, so this cannot misfire an API
         // create as a Compute alert.
         if (detectDeployPlan(sub)) {
-          if (billing) {
-            await mirrorDeployPlan(billing, sub);
+          if (billing && ws) {
+            await mirrorDeployPlan(billing, ws.orgId, sub);
           }
           await sendComputeAlert(stripe, sub, computeCreatedAlert(sub), ws);
           return new Response("OK");

--- a/web/apps/dashboard/lib/auth/deactivateNonCreatorMemberships.test.ts
+++ b/web/apps/dashboard/lib/auth/deactivateNonCreatorMemberships.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getOrganizationMemberList: vi.fn(),
+  getInvitationList: vi.fn(),
+  deactivateMembership: vi.fn(),
+  revokeOrgInvitation: vi.fn(),
+}));
+
+vi.mock("./server", () => ({ auth: mocks }));
+
+import { deactivateNonCreatorMemberships } from "./deactivateNonCreatorMemberships";
+
+describe("deactivateNonCreatorMemberships", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getOrganizationMemberList.mockResolvedValue({ data: [], metadata: {} });
+    mocks.getInvitationList.mockResolvedValue({ data: [], metadata: {} });
+  });
+
+  it("preserves the earliest member, deactivates teammates, and revokes pending invites", async () => {
+    mocks.getOrganizationMemberList.mockResolvedValue({
+      data: [
+        { id: "member_2", createdAt: "2026-02-01T00:00:00.000Z" },
+        { id: "creator", createdAt: "2026-01-01T00:00:00.000Z" },
+      ],
+      metadata: {},
+    });
+    mocks.getInvitationList.mockResolvedValue({
+      data: [
+        { id: "pending", state: "pending" },
+        { id: "expired", state: "expired" },
+      ],
+      metadata: {},
+    });
+
+    await deactivateNonCreatorMemberships("org_1");
+
+    expect(mocks.deactivateMembership).toHaveBeenCalledOnce();
+    expect(mocks.deactivateMembership).toHaveBeenCalledWith("member_2", "org_1");
+    expect(mocks.revokeOrgInvitation).toHaveBeenCalledOnce();
+    expect(mocks.revokeOrgInvitation).toHaveBeenCalledWith("pending", "org_1");
+  });
+
+  it("still revokes invitations when membership listing fails", async () => {
+    mocks.getOrganizationMemberList.mockRejectedValue(new Error("unavailable"));
+    mocks.getInvitationList.mockResolvedValue({
+      data: [{ id: "pending", state: "pending" }],
+      metadata: {},
+    });
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await deactivateNonCreatorMemberships("org_1");
+
+    expect(mocks.deactivateMembership).not.toHaveBeenCalled();
+    expect(mocks.revokeOrgInvitation).toHaveBeenCalledWith("pending", "org_1");
+    error.mockRestore();
+  });
+});

--- a/web/apps/dashboard/lib/auth/deactivateNonCreatorMemberships.ts
+++ b/web/apps/dashboard/lib/auth/deactivateNonCreatorMemberships.ts
@@ -1,0 +1,48 @@
+import { auth } from "./server";
+
+/** Removes team access while preserving the original workspace creator. */
+export async function deactivateNonCreatorMemberships(orgId: string): Promise<void> {
+  const [memberships, invitations] = await Promise.all([
+    auth.getOrganizationMemberList(orgId).catch((error: unknown) => {
+      console.error("Failed to list memberships for deactivation:", { orgId, error });
+      return null;
+    }),
+    auth.getInvitationList(orgId).catch((error: unknown) => {
+      console.error("Failed to list invitations for revocation:", { orgId, error });
+      return null;
+    }),
+  ]);
+
+  const sorted = [...(memberships?.data ?? [])].sort((a, b) =>
+    a.createdAt.localeCompare(b.createdAt),
+  );
+  const [, ...nonCreators] = sorted;
+  const pendingInvitations = (invitations?.data ?? []).filter(
+    (invitation) => invitation.state === "pending",
+  );
+
+  await Promise.all([
+    ...nonCreators.map(async (member) => {
+      try {
+        await auth.deactivateMembership(member.id, orgId);
+      } catch (error) {
+        console.error("Failed to deactivate membership:", {
+          orgId,
+          membershipId: member.id,
+          error,
+        });
+      }
+    }),
+    ...pendingInvitations.map(async (invitation) => {
+      try {
+        await auth.revokeOrgInvitation(invitation.id, orgId);
+      } catch (error) {
+        console.error("Failed to revoke invitation:", {
+          orgId,
+          invitationId: invitation.id,
+          error,
+        });
+      }
+    }),
+  ]);
+}

--- a/web/apps/dashboard/lib/stripe/deployPlan.test.ts
+++ b/web/apps/dashboard/lib/stripe/deployPlan.test.ts
@@ -1,6 +1,12 @@
 import type Stripe from "stripe";
 import { describe, expect, it, vi } from "vitest";
-import { computeQuotasForPlan, detectDeployPlan } from "./deployPlan";
+import {
+  computeQuotaUpdateForPlan,
+  computeQuotasForPlan,
+  deployPlanGrantsTeam,
+  detectDeployPlan,
+  parseDeployPlan,
+} from "./deployPlan";
 
 // Minimal subscription stub. detectDeployPlan reads items[].price.metadata.plan.
 function subWithItems(...items: Array<{ id?: string; plan?: string }>): Stripe.Subscription {
@@ -56,25 +62,69 @@ describe("detectDeployPlan", () => {
 });
 
 describe("computeQuotasForPlan", () => {
-  it("returns the advertised per-instance CPU and memory limits", () => {
+  it("returns the advertised plan quotas", () => {
     expect(computeQuotasForPlan("starter")).toEqual({
+      logsRetentionDays: 3,
+      auditLogsRetentionDays: 7,
+      team: false,
       maxCpuMillicoresPerInstance: 2_000,
       maxMemoryMibPerInstance: 2_048,
+      maxStorageMibPerInstance: 10_240,
+      maxConcurrentBuilds: 1,
     });
     expect(computeQuotasForPlan("pro")).toEqual({
+      logsRetentionDays: 7,
+      auditLogsRetentionDays: 14,
+      team: true,
       maxCpuMillicoresPerInstance: 8_000,
       maxMemoryMibPerInstance: 8_192,
+      maxStorageMibPerInstance: 10_240,
+      maxConcurrentBuilds: 1,
     });
     expect(computeQuotasForPlan("business")).toEqual({
+      logsRetentionDays: 14,
+      auditLogsRetentionDays: 30,
+      team: true,
       maxCpuMillicoresPerInstance: 16_000,
       maxMemoryMibPerInstance: 32_768,
+      maxStorageMibPerInstance: 10_240,
+      maxConcurrentBuilds: 1,
     });
   });
 
   it("returns the default Compute limits without a plan", () => {
     expect(computeQuotasForPlan(null)).toEqual({
+      logsRetentionDays: 7,
+      auditLogsRetentionDays: 30,
+      team: false,
       maxCpuMillicoresPerInstance: 2_000,
       maxMemoryMibPerInstance: 4_096,
+      maxStorageMibPerInstance: 10_240,
+      maxConcurrentBuilds: 1,
     });
+  });
+
+  it("preserves API-owned team and retention quotas when an API plan is paid", () => {
+    expect(computeQuotaUpdateForPlan("business", true)).toEqual({
+      maxCpuMillicoresPerInstance: 16_000,
+      maxMemoryMibPerInstance: 32_768,
+      maxStorageMibPerInstance: 10_240,
+      maxConcurrentBuilds: 1,
+    });
+  });
+});
+
+describe("Deploy plan entitlement helpers", () => {
+  it("grants team access only to Pro and Business", () => {
+    expect(deployPlanGrantsTeam("starter")).toBe(false);
+    expect(deployPlanGrantsTeam("pro")).toBe(true);
+    expect(deployPlanGrantsTeam("business")).toBe(true);
+    expect(deployPlanGrantsTeam(null)).toBe(false);
+  });
+
+  it("fails closed when parsing persisted plan values", () => {
+    expect(parseDeployPlan("starter")).toBe("starter");
+    expect(parseDeployPlan("enterprise")).toBeNull();
+    expect(parseDeployPlan(null)).toBeNull();
   });
 });

--- a/web/apps/dashboard/lib/stripe/deployPlan.ts
+++ b/web/apps/dashboard/lib/stripe/deployPlan.ts
@@ -14,30 +14,96 @@ import type Stripe from "stripe";
 export const DEPLOY_PLANS = ["starter", "pro", "business"] as const;
 export type DeployPlan = (typeof DEPLOY_PLANS)[number];
 
-type ComputeQuotas = Pick<Quotas, "maxCpuMillicoresPerInstance" | "maxMemoryMibPerInstance">;
+type ComputeQuotas = Pick<
+  Quotas,
+  | "logsRetentionDays"
+  | "auditLogsRetentionDays"
+  | "team"
+  | "maxCpuMillicoresPerInstance"
+  | "maxMemoryMibPerInstance"
+  | "maxStorageMibPerInstance"
+  | "maxConcurrentBuilds"
+>;
+
+type ComputeOnlyQuotas = Pick<
+  ComputeQuotas,
+  | "maxCpuMillicoresPerInstance"
+  | "maxMemoryMibPerInstance"
+  | "maxStorageMibPerInstance"
+  | "maxConcurrentBuilds"
+>;
 
 const COMPUTE_PLAN_QUOTAS = {
   starter: {
+    logsRetentionDays: 3,
+    auditLogsRetentionDays: 7,
+    team: false,
     maxCpuMillicoresPerInstance: 2_000,
     maxMemoryMibPerInstance: 2_048,
+    maxStorageMibPerInstance: 10_240,
+    maxConcurrentBuilds: 1,
   },
   pro: {
+    logsRetentionDays: 7,
+    auditLogsRetentionDays: 14,
+    team: true,
     maxCpuMillicoresPerInstance: 8_000,
     maxMemoryMibPerInstance: 8_192,
+    maxStorageMibPerInstance: 10_240,
+    maxConcurrentBuilds: 1,
   },
   business: {
+    logsRetentionDays: 14,
+    auditLogsRetentionDays: 30,
+    team: true,
     maxCpuMillicoresPerInstance: 16_000,
     maxMemoryMibPerInstance: 32_768,
+    maxStorageMibPerInstance: 10_240,
+    maxConcurrentBuilds: 1,
   },
 } satisfies Record<DeployPlan, ComputeQuotas>;
 
 const DEFAULT_COMPUTE_QUOTAS = {
+  logsRetentionDays: freeTierQuotas.logsRetentionDays,
+  auditLogsRetentionDays: freeTierQuotas.auditLogsRetentionDays,
+  team: freeTierQuotas.team,
   maxCpuMillicoresPerInstance: freeTierQuotas.maxCpuMillicoresPerInstance,
   maxMemoryMibPerInstance: freeTierQuotas.maxMemoryMibPerInstance,
+  maxStorageMibPerInstance: freeTierQuotas.maxStorageMibPerInstance,
+  maxConcurrentBuilds: freeTierQuotas.maxConcurrentBuilds,
 } satisfies ComputeQuotas;
 
 export function computeQuotasForPlan(plan: DeployPlan | null): ComputeQuotas {
   return plan ? COMPUTE_PLAN_QUOTAS[plan] : DEFAULT_COMPUTE_QUOTAS;
+}
+
+/**
+ * Returns the quota fields a Compute subscription may safely update. A paid
+ * API plan owns the shared retention and team fields, so Compute must preserve
+ * those while still applying its resource limits.
+ */
+export function computeQuotaUpdateForPlan(
+  plan: DeployPlan | null,
+  preserveApiQuotas: boolean,
+): ComputeQuotas | ComputeOnlyQuotas {
+  const quotas = computeQuotasForPlan(plan);
+  if (!preserveApiQuotas) {
+    return quotas;
+  }
+  return {
+    maxCpuMillicoresPerInstance: quotas.maxCpuMillicoresPerInstance,
+    maxMemoryMibPerInstance: quotas.maxMemoryMibPerInstance,
+    maxStorageMibPerInstance: quotas.maxStorageMibPerInstance,
+    maxConcurrentBuilds: quotas.maxConcurrentBuilds,
+  };
+}
+
+export function deployPlanGrantsTeam(plan: string | null): boolean {
+  return plan === "pro" || plan === "business";
+}
+
+export function parseDeployPlan(plan: string | null): DeployPlan | null {
+  return plan !== null && isDeployPlan(plan) ? plan : null;
 }
 
 function isDeployPlan(value: string): value is DeployPlan {

--- a/web/apps/dashboard/lib/stripe/linkDeploySubscription.test.ts
+++ b/web/apps/dashboard/lib/stripe/linkDeploySubscription.test.ts
@@ -267,8 +267,13 @@ describe("linkDeploySubscription", () => {
     });
     expect(h.values).toHaveBeenCalledWith({
       workspaceId: WORKSPACE_ID,
+      logsRetentionDays: 3,
+      auditLogsRetentionDays: 7,
+      team: false,
       maxCpuMillicoresPerInstance: 2_000,
       maxMemoryMibPerInstance: 2_048,
+      maxStorageMibPerInstance: 10_240,
+      maxConcurrentBuilds: 1,
     });
     expect(h.insertAuditLogs).toHaveBeenCalledOnce();
   });
@@ -290,8 +295,13 @@ describe("linkDeploySubscription", () => {
     expect(h.transaction).not.toHaveBeenCalled();
     expect(h.values).toHaveBeenCalledWith({
       workspaceId: WORKSPACE_ID,
+      logsRetentionDays: 3,
+      auditLogsRetentionDays: 7,
+      team: false,
       maxCpuMillicoresPerInstance: 2_000,
       maxMemoryMibPerInstance: 2_048,
+      maxStorageMibPerInstance: 10_240,
+      maxConcurrentBuilds: 1,
     });
   });
 

--- a/web/apps/dashboard/lib/stripe/linkDeploySubscription.ts
+++ b/web/apps/dashboard/lib/stripe/linkDeploySubscription.ts
@@ -132,6 +132,7 @@ export async function linkDeploySubscription(
   if (!ws) {
     return { ok: false, reason: "workspace_not_found", message: "Workspace not found." };
   }
+  const preserveApiQuotas = (ws.billing?.tier ?? "Free") !== "Free";
 
   const recordedSubscriptionId = subscriptionIdsByProduct(
     ws.billingSubscriptions ?? [],
@@ -145,7 +146,7 @@ export async function linkDeploySubscription(
   // repoint away from — refusing would strand this checkout's paid subscription.
   if (recordedSubscriptionId === subscriptionId) {
     if (ws.billing?.plan === plan) {
-      await setComputeQuotas(db, { workspaceId: ws.id, plan });
+      await setComputeQuotas(db, { workspaceId: ws.id, plan, preserveApiQuotas });
       return { ok: true, plan, alreadyLinked: true };
     }
   } else if (recordedSubscriptionId) {
@@ -171,7 +172,7 @@ export async function linkDeploySubscription(
       .update(schema.workspaceBilling)
       .set({ stripeCustomerId, plan })
       .where(eq(schema.workspaceBilling.workspaceId, ws.id));
-    await setComputeQuotas(tx, { workspaceId: ws.id, plan });
+    await setComputeQuotas(tx, { workspaceId: ws.id, plan, preserveApiQuotas });
     await upsertBillingSubscription(tx, {
       workspaceId: ws.id,
       product: "compute",

--- a/web/apps/dashboard/lib/stripe/setComputeQuotas.ts
+++ b/web/apps/dashboard/lib/stripe/setComputeQuotas.ts
@@ -1,12 +1,12 @@
 import { type Database, type Transaction, schema } from "@unkey/db";
-import { type DeployPlan, computeQuotasForPlan } from "./deployPlan";
+import { type DeployPlan, computeQuotaUpdateForPlan } from "./deployPlan";
 
-/** Applies only Compute-owned quota fields, preserving any active API plan's quotas. */
+/** Applies Compute plan quotas without weakening a paid API plan's shared entitlements. */
 export async function setComputeQuotas(
   db: Transaction | Database,
-  params: { workspaceId: string; plan: DeployPlan | null },
+  params: { workspaceId: string; plan: DeployPlan | null; preserveApiQuotas: boolean },
 ): Promise<void> {
-  const quotas = computeQuotasForPlan(params.plan);
+  const quotas = computeQuotaUpdateForPlan(params.plan, params.preserveApiQuotas);
   await db
     .insert(schema.quotas)
     .values({ workspaceId: params.workspaceId, ...quotas })

--- a/web/apps/dashboard/lib/stripe/webhookRouting.test.ts
+++ b/web/apps/dashboard/lib/stripe/webhookRouting.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, it } from "vitest";
 import { keepsTeamAfterDelete } from "./webhookRouting";
 
 describe("keepsTeamAfterDelete", () => {
-  it("API delete keeps team while a Deploy plan is active", () => {
+  it("API delete keeps team while a team-enabled Deploy plan is active", () => {
     expect(keepsTeamAfterDelete("api", { tier: "Free", plan: "pro" })).toBe(true);
+    expect(keepsTeamAfterDelete("api", { tier: "Free", plan: "business" })).toBe(true);
   });
 
-  it("API delete drops team when no Deploy plan remains", () => {
+  it("API delete drops team on Starter or when no Deploy plan remains", () => {
+    expect(keepsTeamAfterDelete("api", { tier: "Pro", plan: "starter" })).toBe(false);
     expect(keepsTeamAfterDelete("api", { tier: "Pro", plan: null })).toBe(false);
   });
 

--- a/web/apps/dashboard/lib/stripe/webhookRouting.ts
+++ b/web/apps/dashboard/lib/stripe/webhookRouting.ts
@@ -1,11 +1,10 @@
 import type { SubscriptionProduct } from "./billingSubscriptions";
+import { deployPlanGrantsTeam } from "./deployPlan";
 
 /**
  * Whether a workspace keeps team access after one product's subscription is
- * deleted. Team follows any live paid product, so a delete only strips it when
- * nothing paid remains: an ending API subscription keeps team while a Deploy
- * plan is active, and an ending Deploy subscription keeps team while the API
- * tier is paid.
+ * deleted. Paid API tiers and the Compute Pro/Business plans grant team access;
+ * Compute Starter does not.
  *
  * The product is read straight from the deleted subscription's
  * billing_subscriptions row now, so the webhook no longer inspects columns or
@@ -15,5 +14,7 @@ export function keepsTeamAfterDelete(
   product: SubscriptionProduct,
   billing: { tier: string | null; plan: string | null },
 ): boolean {
-  return product === "api" ? billing.plan !== null : (billing.tier ?? "Free") !== "Free";
+  return product === "api"
+    ? deployPlanGrantsTeam(billing.plan)
+    : (billing.tier ?? "Free") !== "Free";
 }

--- a/web/apps/dashboard/lib/trpc/routers/org/inviteMember.ts
+++ b/web/apps/dashboard/lib/trpc/routers/org/inviteMember.ts
@@ -20,12 +20,21 @@ export const inviteMember = workspaceProcedure
           message: "Invalid organization ID",
         });
       }
+      if (!ctx.workspace.quotas?.team) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "Upgrade to Pro or Business to invite team members.",
+        });
+      }
       return await authProvider.inviteMember({
         email: input.email,
         role: input.role,
         orgId: input.orgId,
       });
     } catch (error) {
+      if (error instanceof TRPCError) {
+        throw error;
+      }
       throw new TRPCError({
         code: "INTERNAL_SERVER_ERROR",
         message: "Failed to invite member",

--- a/web/apps/dashboard/lib/trpc/routers/stripe/cancelDeploy.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/cancelDeploy.ts
@@ -1,9 +1,11 @@
 import { DeployService } from "@/gen/proto/ctrl/v1/deployment_pb";
 import { insertAuditLogs } from "@/lib/audit";
+import { deactivateNonCreatorMemberships } from "@/lib/auth/deactivateNonCreatorMemberships";
 import { createCtrlClient } from "@/lib/ctrl-client";
 import { db } from "@/lib/db";
 import { getStripeClient } from "@/lib/stripe";
 import { cancelDeploySubscription } from "@/lib/stripe/cancelDeploySubscription";
+import { deployPlanGrantsTeam } from "@/lib/stripe/deployPlan";
 import { setComputeQuotas } from "@/lib/stripe/setComputeQuotas";
 import { TRPCError } from "@trpc/server";
 import { requireWorkspaceAdmin, workspaceProcedure } from "../../trpc";
@@ -57,7 +59,11 @@ export const cancelDeploy = workspaceProcedure
     }
 
     await db.transaction(async (tx) => {
-      await setComputeQuotas(tx, { workspaceId: ctx.workspace.id, plan: null });
+      await setComputeQuotas(tx, {
+        workspaceId: ctx.workspace.id,
+        plan: null,
+        preserveApiQuotas: ctx.workspace.tier !== "Free",
+      });
       await insertAuditLogs(tx, {
         workspaceId: ctx.workspace.id,
         actor: { type: "user", id: ctx.user.id },
@@ -67,4 +73,8 @@ export const cancelDeploy = workspaceProcedure
         context: { location: ctx.audit.location, userAgent: ctx.audit.userAgent },
       });
     });
+
+    if (ctx.workspace.tier === "Free" && deployPlanGrantsTeam(ctx.workspace.deployPlan)) {
+      await deactivateNonCreatorMemberships(ctx.workspace.orgId);
+    }
   });

--- a/web/apps/dashboard/lib/trpc/routers/stripe/changeDeployPlan.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/changeDeployPlan.ts
@@ -1,9 +1,10 @@
 import { insertAuditLogs } from "@/lib/audit";
+import { deactivateNonCreatorMemberships } from "@/lib/auth/deactivateNonCreatorMemberships";
 import { db, eq, schema } from "@/lib/db";
 import { getStripeClient } from "@/lib/stripe";
 import { changeSubscriptionPrice } from "@/lib/stripe/changeSubscriptionPrice";
 import { deployBillingConfig, findPlanFeeItem } from "@/lib/stripe/deployBilling";
-import { DEPLOY_PLANS } from "@/lib/stripe/deployPlan";
+import { DEPLOY_PLANS, deployPlanGrantsTeam } from "@/lib/stripe/deployPlan";
 import { setComputeQuotas } from "@/lib/stripe/setComputeQuotas";
 import { TRPCError } from "@trpc/server";
 import Stripe from "stripe";
@@ -117,7 +118,11 @@ export const changeDeployPlan = workspaceProcedure
         .update(schema.workspaceBilling)
         .set({ plan: input.plan })
         .where(eq(schema.workspaceBilling.workspaceId, ctx.workspace.id));
-      await setComputeQuotas(tx, { workspaceId: ctx.workspace.id, plan: input.plan });
+      await setComputeQuotas(tx, {
+        workspaceId: ctx.workspace.id,
+        plan: input.plan,
+        preserveApiQuotas: ctx.workspace.tier !== "Free",
+      });
       await insertAuditLogs(tx, {
         workspaceId: ctx.workspace.id,
         actor: { type: "user", id: ctx.user.id },
@@ -127,6 +132,14 @@ export const changeDeployPlan = workspaceProcedure
         context: { location: ctx.audit.location, userAgent: ctx.audit.userAgent },
       });
     });
+
+    const losesTeam =
+      ctx.workspace.tier === "Free" &&
+      deployPlanGrantsTeam(planFeeItem.plan) &&
+      !deployPlanGrantsTeam(input.plan);
+    if (losesTeam) {
+      await deactivateNonCreatorMemberships(ctx.workspace.orgId);
+    }
 
     return result;
   });

--- a/web/apps/dashboard/lib/trpc/routers/stripe/subscribeDeploy.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/subscribeDeploy.ts
@@ -278,7 +278,11 @@ export const subscribeDeploy = workspaceProcedure
           .update(schema.workspaceBilling)
           .set(workspaceUpdate)
           .where(eq(schema.workspaceBilling.workspaceId, ctx.workspace.id));
-        await setComputeQuotas(tx, { workspaceId: ctx.workspace.id, plan: input.plan });
+        await setComputeQuotas(tx, {
+          workspaceId: ctx.workspace.id,
+          plan: input.plan,
+          preserveApiQuotas: ctx.workspace.tier !== "Free",
+        });
         if (createdDeploySubscriptionId) {
           await upsertBillingSubscription(tx, {
             workspaceId: ctx.workspace.id,


### PR DESCRIPTION
## Summary
- apply the advertised Compute retention, team, CPU, memory, disk, and build quotas for Starter, Pro, and Business
- preserve stronger shared quotas when a workspace also has a paid API subscription
- enforce team invitations server-side and remove members plus pending invitations when team access ends
- keep subscription, plan-change, cancellation, and Stripe webhook paths consistent

## Testing
- `mise exec -- pnpm --dir=web --filter @unkey/dashboard test` (672 tests)
- `mise exec -- pnpm --dir=web --filter @unkey/dashboard typecheck`
- `mise exec -- pnpm --dir=web biome check ...` on all changed TypeScript files

## Rollout
- no Compute subscribers exist in production, so no quota backfill is required