### PR TITLE
fix: roundtrip latency

### DIFF
--- a/pkg/db/api_find_by_id.sql_generated.go
+++ b/pkg/db/api_find_by_id.sql_generated.go
@@ -7,7 +7,64 @@ package db
 
 import (
 	"context"
+	"database/sql"
 )
+
+const findApiAndKeySpaceByID = `-- name: FindApiAndKeySpaceByID :one
+SELECT
+    a.id AS api_id,
+    a.workspace_id,
+    a.key_auth_id,
+    a.name AS api_name,
+    COALESCE(ka.id, '') AS key_space_id,
+    COALESCE(ka.store_encrypted_keys, false) AS store_encrypted_keys,
+    ka.default_prefix,
+    ka.default_bytes
+FROM apis a
+LEFT JOIN key_auth ka ON ka.id = a.key_auth_id
+WHERE a.id = ?
+`
+
+type FindApiAndKeySpaceByIDRow struct {
+	ApiID              string         `db:"api_id"`
+	WorkspaceID        string         `db:"workspace_id"`
+	KeyAuthID          sql.NullString `db:"key_auth_id"`
+	ApiName            string         `db:"api_name"`
+	KeySpaceID         string         `db:"key_space_id"`
+	StoreEncryptedKeys bool           `db:"store_encrypted_keys"`
+	DefaultPrefix      sql.NullString `db:"default_prefix"`
+	DefaultBytes       sql.NullInt32  `db:"default_bytes"`
+}
+
+// FindApiAndKeySpaceByID
+//
+//	SELECT
+//	    a.id AS api_id,
+//	    a.workspace_id,
+//	    a.key_auth_id,
+//	    a.name AS api_name,
+//	    COALESCE(ka.id, '') AS key_space_id,
+//	    COALESCE(ka.store_encrypted_keys, false) AS store_encrypted_keys,
+//	    ka.default_prefix,
+//	    ka.default_bytes
+//	FROM apis a
+//	LEFT JOIN key_auth ka ON ka.id = a.key_auth_id
+//	WHERE a.id = ?
+func (q *Queries) FindApiAndKeySpaceByID(ctx context.Context, db DBTX, id string) (FindApiAndKeySpaceByIDRow, error) {
+	row := db.QueryRowContext(ctx, findApiAndKeySpaceByID, id)
+	var i FindApiAndKeySpaceByIDRow
+	err := row.Scan(
+		&i.ApiID,
+		&i.WorkspaceID,
+		&i.KeyAuthID,
+		&i.ApiName,
+		&i.KeySpaceID,
+		&i.StoreEncryptedKeys,
+		&i.DefaultPrefix,
+		&i.DefaultBytes,
+	)
+	return i, err
+}
 
 const findApiByID = `-- name: FindApiByID :one
 SELECT pk, id, name, workspace_id, project_id, ip_whitelist, auth_type, key_auth_id, created_at_m, updated_at_m, deleted_at_m, delete_protection FROM apis WHERE id = ?

--- a/pkg/db/bulk_key_insert_ratelimit.sql_generated.go
+++ b/pkg/db/bulk_key_insert_ratelimit.sql_generated.go
@@ -10,6 +10,7 @@ import (
 
 // bulkInsertKeyRatelimit is the base query for bulk insert
 const bulkInsertKeyRatelimit = `INSERT INTO ` + "`" + `ratelimits` + "`" + ` ( id, workspace_id, key_id, name, ` + "`" + `limit` + "`" + `, duration, auto_apply, created_at ) VALUES %s ON DUPLICATE KEY UPDATE
+name = VALUES(name),
 ` + "`" + `limit` + "`" + ` = VALUES(` + "`" + `limit` + "`" + `),
 duration = VALUES(duration),
 auto_apply = VALUES(auto_apply),

--- a/pkg/db/key_delete_by_id.sql_generated.go
+++ b/pkg/db/key_delete_by_id.sql_generated.go
@@ -9,6 +9,26 @@ import (
 	"context"
 )
 
+const deleteAllKeyPermissionsAndRolesByKeyID = `-- name: DeleteAllKeyPermissionsAndRolesByKeyID :exec
+DELETE kp, kr
+FROM ` + "`" + `keys` + "`" + ` k
+LEFT JOIN keys_permissions kp ON k.id = kp.key_id
+LEFT JOIN keys_roles kr ON k.id = kr.key_id
+WHERE k.id = ?
+`
+
+// DeleteAllKeyPermissionsAndRolesByKeyID
+//
+//	DELETE kp, kr
+//	FROM `keys` k
+//	LEFT JOIN keys_permissions kp ON k.id = kp.key_id
+//	LEFT JOIN keys_roles kr ON k.id = kr.key_id
+//	WHERE k.id = ?
+func (q *Queries) DeleteAllKeyPermissionsAndRolesByKeyID(ctx context.Context, db DBTX, keyID string) error {
+	_, err := db.ExecContext(ctx, deleteAllKeyPermissionsAndRolesByKeyID, keyID)
+	return err
+}
+
 const deleteKeyByID = `-- name: DeleteKeyByID :exec
 DELETE k, kp, kr, rl, ek
 FROM ` + "`" + `keys` + "`" + ` k

--- a/pkg/db/key_find_credits.sql_generated.go
+++ b/pkg/db/key_find_credits.sql_generated.go
@@ -23,3 +23,23 @@ func (q *Queries) FindKeyCredits(ctx context.Context, db DBTX, id string) (sql.N
 	err := row.Scan(&remaining_requests)
 	return remaining_requests, err
 }
+
+const findLiveKeyCredits = `-- name: FindLiveKeyCredits :one
+SELECT remaining_requests
+FROM ` + "`" + `keys` + "`" + `
+WHERE id = ?
+  AND deleted_at_m IS NULL
+`
+
+// FindLiveKeyCredits
+//
+//	SELECT remaining_requests
+//	FROM `keys`
+//	WHERE id = ?
+//	  AND deleted_at_m IS NULL
+func (q *Queries) FindLiveKeyCredits(ctx context.Context, db DBTX, id string) (sql.NullInt64, error) {
+	row := db.QueryRowContext(ctx, findLiveKeyCredits, id)
+	var remaining_requests sql.NullInt64
+	err := row.Scan(&remaining_requests)
+	return remaining_requests, err
+}

--- a/pkg/db/key_find_live_by_id.sql_generated.go
+++ b/pkg/db/key_find_live_by_id.sql_generated.go
@@ -8,7 +8,204 @@ package db
 import (
 	"context"
 	"database/sql"
+	"strings"
 )
+
+const findKeyMutationResources = `-- name: FindKeyMutationResources :many
+SELECT
+    'identity' AS resource_type,
+    i.id AS identity_id,
+    i.external_id AS identity_external_id,
+    '' AS permission_id,
+    '' AS permission_slug,
+    '' AS role_id,
+    '' AS role_name,
+    '' AS project_id,
+    '' AS project_slug
+FROM identities i
+WHERE CAST(? AS UNSIGNED) = 1
+    AND i.workspace_id = ?
+    AND i.external_id = ?
+    AND i.deleted = false
+UNION ALL
+SELECT
+    'permission' AS resource_type,
+    '' AS identity_id,
+    '' AS identity_external_id,
+    p.id AS permission_id,
+    p.slug AS permission_slug,
+    '' AS role_id,
+    '' AS role_name,
+    '' AS project_id,
+    '' AS project_slug
+FROM permissions p
+WHERE p.workspace_id = ?
+    AND p.slug IN (/*SLICE:permission_slugs*/?)
+UNION ALL
+SELECT
+    'role' AS resource_type,
+    '' AS identity_id,
+    '' AS identity_external_id,
+    '' AS permission_id,
+    '' AS permission_slug,
+    r.id AS role_id,
+    r.name AS role_name,
+    '' AS project_id,
+    '' AS project_slug
+FROM roles r
+WHERE r.workspace_id = ?
+    AND r.name IN (/*SLICE:role_names*/?)
+UNION ALL
+SELECT
+    'project' AS resource_type,
+    '' AS identity_id,
+    '' AS identity_external_id,
+    '' AS permission_id,
+    '' AS permission_slug,
+    '' AS role_id,
+    '' AS role_name,
+    p.id AS project_id,
+    p.slug AS project_slug
+FROM projects p
+WHERE p.workspace_id = ?
+    AND BINARY p.slug = 'default'
+`
+
+type FindKeyMutationResourcesParams struct {
+	FindIdentity    int64    `db:"find_identity"`
+	WorkspaceID     string   `db:"workspace_id"`
+	ExternalID      string   `db:"external_id"`
+	PermissionSlugs []string `db:"permission_slugs"`
+	RoleNames       []string `db:"role_names"`
+}
+
+type FindKeyMutationResourcesRow struct {
+	ResourceType       string `db:"resource_type"`
+	IdentityID         string `db:"identity_id"`
+	IdentityExternalID string `db:"identity_external_id"`
+	PermissionID       string `db:"permission_id"`
+	PermissionSlug     string `db:"permission_slug"`
+	RoleID             string `db:"role_id"`
+	RoleName           string `db:"role_name"`
+	ProjectID          string `db:"project_id"`
+	ProjectSlug        string `db:"project_slug"`
+}
+
+// Resolve optional identity, permission, role, and project references in one round trip.
+//
+//	SELECT
+//	    'identity' AS resource_type,
+//	    i.id AS identity_id,
+//	    i.external_id AS identity_external_id,
+//	    '' AS permission_id,
+//	    '' AS permission_slug,
+//	    '' AS role_id,
+//	    '' AS role_name,
+//	    '' AS project_id,
+//	    '' AS project_slug
+//	FROM identities i
+//	WHERE CAST(? AS UNSIGNED) = 1
+//	    AND i.workspace_id = ?
+//	    AND i.external_id = ?
+//	    AND i.deleted = false
+//	UNION ALL
+//	SELECT
+//	    'permission' AS resource_type,
+//	    '' AS identity_id,
+//	    '' AS identity_external_id,
+//	    p.id AS permission_id,
+//	    p.slug AS permission_slug,
+//	    '' AS role_id,
+//	    '' AS role_name,
+//	    '' AS project_id,
+//	    '' AS project_slug
+//	FROM permissions p
+//	WHERE p.workspace_id = ?
+//	    AND p.slug IN (/*SLICE:permission_slugs*/?)
+//	UNION ALL
+//	SELECT
+//	    'role' AS resource_type,
+//	    '' AS identity_id,
+//	    '' AS identity_external_id,
+//	    '' AS permission_id,
+//	    '' AS permission_slug,
+//	    r.id AS role_id,
+//	    r.name AS role_name,
+//	    '' AS project_id,
+//	    '' AS project_slug
+//	FROM roles r
+//	WHERE r.workspace_id = ?
+//	    AND r.name IN (/*SLICE:role_names*/?)
+//	UNION ALL
+//	SELECT
+//	    'project' AS resource_type,
+//	    '' AS identity_id,
+//	    '' AS identity_external_id,
+//	    '' AS permission_id,
+//	    '' AS permission_slug,
+//	    '' AS role_id,
+//	    '' AS role_name,
+//	    p.id AS project_id,
+//	    p.slug AS project_slug
+//	FROM projects p
+//	WHERE p.workspace_id = ?
+//	    AND BINARY p.slug = 'default'
+func (q *Queries) FindKeyMutationResources(ctx context.Context, db DBTX, arg FindKeyMutationResourcesParams) ([]FindKeyMutationResourcesRow, error) {
+	query := findKeyMutationResources
+	var queryParams []interface{}
+	queryParams = append(queryParams, arg.FindIdentity)
+	queryParams = append(queryParams, arg.WorkspaceID)
+	queryParams = append(queryParams, arg.ExternalID)
+	queryParams = append(queryParams, arg.WorkspaceID)
+	if len(arg.PermissionSlugs) > 0 {
+		for _, v := range arg.PermissionSlugs {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:permission_slugs*/?", strings.Repeat(",?", len(arg.PermissionSlugs))[1:], 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:permission_slugs*/?", "NULL", 1)
+	}
+	queryParams = append(queryParams, arg.WorkspaceID)
+	if len(arg.RoleNames) > 0 {
+		for _, v := range arg.RoleNames {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:role_names*/?", strings.Repeat(",?", len(arg.RoleNames))[1:], 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:role_names*/?", "NULL", 1)
+	}
+	queryParams = append(queryParams, arg.WorkspaceID)
+	rows, err := db.QueryContext(ctx, query, queryParams...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []FindKeyMutationResourcesRow
+	for rows.Next() {
+		var i FindKeyMutationResourcesRow
+		if err := rows.Scan(
+			&i.ResourceType,
+			&i.IdentityID,
+			&i.IdentityExternalID,
+			&i.PermissionID,
+			&i.PermissionSlug,
+			&i.RoleID,
+			&i.RoleName,
+			&i.ProjectID,
+			&i.ProjectSlug,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
 
 const findLiveKeyByID = `-- name: FindLiveKeyByID :one
 SELECT
@@ -304,6 +501,153 @@ func (q *Queries) FindLiveKeyByID(ctx context.Context, db DBTX, id string) (Find
 		&i.Permissions,
 		&i.RolePermissions,
 		&i.Ratelimits,
+	)
+	return i, err
+}
+
+const findLiveKeyForCreditsByID = `-- name: FindLiveKeyForCreditsByID :one
+SELECT
+    k.id,
+    k.key_auth_id,
+    k.hash,
+    k.workspace_id,
+    k.name,
+    k.refill_day,
+    k.refill_amount,
+    k.remaining_requests,
+    a.id AS api_id
+FROM ` + "`" + `keys` + "`" + ` k
+JOIN apis a ON a.key_auth_id = k.key_auth_id
+JOIN key_auth ka ON ka.id = k.key_auth_id
+JOIN workspaces ws ON k.workspace_id = ws.id
+WHERE k.id = ?
+    AND k.deleted_at_m IS NULL
+    AND a.deleted_at_m IS NULL
+    AND ka.deleted_at_m IS NULL
+    AND ws.deleted_at_m IS NULL
+`
+
+type FindLiveKeyForCreditsByIDRow struct {
+	ID                string         `db:"id"`
+	KeyAuthID         string         `db:"key_auth_id"`
+	Hash              string         `db:"hash"`
+	WorkspaceID       string         `db:"workspace_id"`
+	Name              sql.NullString `db:"name"`
+	RefillDay         sql.NullInt16  `db:"refill_day"`
+	RefillAmount      sql.NullInt64  `db:"refill_amount"`
+	RemainingRequests sql.NullInt64  `db:"remaining_requests"`
+	ApiID             string         `db:"api_id"`
+}
+
+// Credit updates only need authorization, audit, cache, and credit state.
+//
+//	SELECT
+//	    k.id,
+//	    k.key_auth_id,
+//	    k.hash,
+//	    k.workspace_id,
+//	    k.name,
+//	    k.refill_day,
+//	    k.refill_amount,
+//	    k.remaining_requests,
+//	    a.id AS api_id
+//	FROM `keys` k
+//	JOIN apis a ON a.key_auth_id = k.key_auth_id
+//	JOIN key_auth ka ON ka.id = k.key_auth_id
+//	JOIN workspaces ws ON k.workspace_id = ws.id
+//	WHERE k.id = ?
+//	    AND k.deleted_at_m IS NULL
+//	    AND a.deleted_at_m IS NULL
+//	    AND ka.deleted_at_m IS NULL
+//	    AND ws.deleted_at_m IS NULL
+func (q *Queries) FindLiveKeyForCreditsByID(ctx context.Context, db DBTX, id string) (FindLiveKeyForCreditsByIDRow, error) {
+	row := db.QueryRowContext(ctx, findLiveKeyForCreditsByID, id)
+	var i FindLiveKeyForCreditsByIDRow
+	err := row.Scan(
+		&i.ID,
+		&i.KeyAuthID,
+		&i.Hash,
+		&i.WorkspaceID,
+		&i.Name,
+		&i.RefillDay,
+		&i.RefillAmount,
+		&i.RemainingRequests,
+		&i.ApiID,
+	)
+	return i, err
+}
+
+const findLiveKeyForUpdateByID = `-- name: FindLiveKeyForUpdateByID :one
+SELECT
+    k.id,
+    k.key_auth_id,
+    k.hash,
+    k.workspace_id,
+    k.name,
+    k.identity_id,
+    a.id AS api_id,
+    a.name AS api_name,
+    i.external_id AS identity_external_id
+FROM ` + "`" + `keys` + "`" + ` k
+JOIN apis a ON a.key_auth_id = k.key_auth_id
+JOIN key_auth ka ON ka.id = k.key_auth_id
+JOIN workspaces ws ON k.workspace_id = ws.id
+LEFT JOIN identities i ON k.identity_id = i.id AND i.deleted = false
+WHERE k.id = ?
+    AND k.deleted_at_m IS NULL
+    AND a.deleted_at_m IS NULL
+    AND ka.deleted_at_m IS NULL
+    AND ws.deleted_at_m IS NULL
+`
+
+type FindLiveKeyForUpdateByIDRow struct {
+	ID                 string         `db:"id"`
+	KeyAuthID          string         `db:"key_auth_id"`
+	Hash               string         `db:"hash"`
+	WorkspaceID        string         `db:"workspace_id"`
+	Name               sql.NullString `db:"name"`
+	IdentityID         sql.NullString `db:"identity_id"`
+	ApiID              string         `db:"api_id"`
+	ApiName            string         `db:"api_name"`
+	IdentityExternalID sql.NullString `db:"identity_external_id"`
+}
+
+// Keep this projection small: key updates do not need the RBAC and ratelimit
+// aggregates returned by FindLiveKeyByID.
+//
+//	SELECT
+//	    k.id,
+//	    k.key_auth_id,
+//	    k.hash,
+//	    k.workspace_id,
+//	    k.name,
+//	    k.identity_id,
+//	    a.id AS api_id,
+//	    a.name AS api_name,
+//	    i.external_id AS identity_external_id
+//	FROM `keys` k
+//	JOIN apis a ON a.key_auth_id = k.key_auth_id
+//	JOIN key_auth ka ON ka.id = k.key_auth_id
+//	JOIN workspaces ws ON k.workspace_id = ws.id
+//	LEFT JOIN identities i ON k.identity_id = i.id AND i.deleted = false
+//	WHERE k.id = ?
+//	    AND k.deleted_at_m IS NULL
+//	    AND a.deleted_at_m IS NULL
+//	    AND ka.deleted_at_m IS NULL
+//	    AND ws.deleted_at_m IS NULL
+func (q *Queries) FindLiveKeyForUpdateByID(ctx context.Context, db DBTX, id string) (FindLiveKeyForUpdateByIDRow, error) {
+	row := db.QueryRowContext(ctx, findLiveKeyForUpdateByID, id)
+	var i FindLiveKeyForUpdateByIDRow
+	err := row.Scan(
+		&i.ID,
+		&i.KeyAuthID,
+		&i.Hash,
+		&i.WorkspaceID,
+		&i.Name,
+		&i.IdentityID,
+		&i.ApiID,
+		&i.ApiName,
+		&i.IdentityExternalID,
 	)
 	return i, err
 }

--- a/pkg/db/key_insert_ratelimit.sql_generated.go
+++ b/pkg/db/key_insert_ratelimit.sql_generated.go
@@ -30,6 +30,7 @@ INSERT INTO ` + "`" + `ratelimits` + "`" + ` (
     ?,
     ?
 ) ON DUPLICATE KEY UPDATE
+name = VALUES(name),
 ` + "`" + `limit` + "`" + ` = VALUES(` + "`" + `limit` + "`" + `),
 duration = VALUES(duration),
 auto_apply = VALUES(auto_apply),
@@ -69,6 +70,7 @@ type InsertKeyRatelimitParams struct {
 //	    ?,
 //	    ?
 //	) ON DUPLICATE KEY UPDATE
+//	name = VALUES(name),
 //	`limit` = VALUES(`limit`),
 //	duration = VALUES(duration),
 //	auto_apply = VALUES(auto_apply),

--- a/pkg/db/key_update_credits_decrement.sql_generated.go
+++ b/pkg/db/key_update_credits_decrement.sql_generated.go
@@ -36,3 +36,37 @@ func (q *Queries) UpdateKeyCreditsDecrement(ctx context.Context, db DBTX, arg Up
 	_, err := db.ExecContext(ctx, updateKeyCreditsDecrement, arg.Credits, arg.Credits, arg.ID)
 	return err
 }
+
+const updateKeyCreditsDecrementReturning = `-- name: UpdateKeyCreditsDecrementReturning :execresult
+UPDATE ` + "`" + `keys` + "`" + `
+SET
+    remaining_requests = LAST_INSERT_ID(CASE
+        WHEN remaining_requests >= ? THEN remaining_requests - ?
+        ELSE 0
+    END)
+WHERE id = ?
+  AND deleted_at_m IS NULL
+  AND remaining_requests IS NOT NULL
+`
+
+type UpdateKeyCreditsDecrementReturningParams struct {
+	Credits sql.NullInt64 `db:"credits"`
+	ID      string        `db:"id"`
+}
+
+// LAST_INSERT_ID(expr) returns expr in this UPDATE's OK packet, so
+// sql.Result.LastInsertId reads the new balance without another query.
+// https://dev.mysql.com/doc/refman/8.4/en/information-functions.html#function_last-insert-id
+//
+//	UPDATE `keys`
+//	SET
+//	    remaining_requests = LAST_INSERT_ID(CASE
+//	        WHEN remaining_requests >= ? THEN remaining_requests - ?
+//	        ELSE 0
+//	    END)
+//	WHERE id = ?
+//	  AND deleted_at_m IS NULL
+//	  AND remaining_requests IS NOT NULL
+func (q *Queries) UpdateKeyCreditsDecrementReturning(ctx context.Context, db DBTX, arg UpdateKeyCreditsDecrementReturningParams) (sql.Result, error) {
+	return db.ExecContext(ctx, updateKeyCreditsDecrementReturning, arg.Credits, arg.Credits, arg.ID)
+}

--- a/pkg/db/key_update_credits_increment.sql_generated.go
+++ b/pkg/db/key_update_credits_increment.sql_generated.go
@@ -30,3 +30,33 @@ func (q *Queries) UpdateKeyCreditsIncrement(ctx context.Context, db DBTX, arg Up
 	_, err := db.ExecContext(ctx, updateKeyCreditsIncrement, arg.Credits, arg.ID)
 	return err
 }
+
+const updateKeyCreditsIncrementReturning = `-- name: UpdateKeyCreditsIncrementReturning :execresult
+UPDATE ` + "`" + `keys` + "`" + `
+SET
+    remaining_requests = LAST_INSERT_ID(remaining_requests + ?)
+WHERE id = ?
+  AND deleted_at_m IS NULL
+  AND remaining_requests IS NOT NULL
+  AND remaining_requests <= 9223372036854775807 - ?
+`
+
+type UpdateKeyCreditsIncrementReturningParams struct {
+	Credits sql.NullInt64 `db:"credits"`
+	ID      string        `db:"id"`
+}
+
+// LAST_INSERT_ID(expr) returns expr in this UPDATE's OK packet, so
+// sql.Result.LastInsertId reads the new balance without another query.
+// https://dev.mysql.com/doc/refman/8.4/en/information-functions.html#function_last-insert-id
+//
+//	UPDATE `keys`
+//	SET
+//	    remaining_requests = LAST_INSERT_ID(remaining_requests + ?)
+//	WHERE id = ?
+//	  AND deleted_at_m IS NULL
+//	  AND remaining_requests IS NOT NULL
+//	  AND remaining_requests <= 9223372036854775807 - ?
+func (q *Queries) UpdateKeyCreditsIncrementReturning(ctx context.Context, db DBTX, arg UpdateKeyCreditsIncrementReturningParams) (sql.Result, error) {
+	return db.ExecContext(ctx, updateKeyCreditsIncrementReturning, arg.Credits, arg.ID, arg.Credits)
+}

--- a/pkg/db/key_update_credits_set.sql_generated.go
+++ b/pkg/db/key_update_credits_set.sql_generated.go
@@ -10,23 +10,49 @@ import (
 	"database/sql"
 )
 
-const updateKeyCreditsSet = `-- name: UpdateKeyCreditsSet :exec
+const updateKeyCreditsSet = `-- name: UpdateKeyCreditsSet :execresult
 UPDATE ` + "`" + `keys` + "`" + `
-SET remaining_requests = ?
+SET
+    remaining_requests = ?,
+    refill_amount = CASE
+        WHEN CAST(? AS UNSIGNED) = 1 THEN NULL
+        ELSE refill_amount
+    END,
+    refill_day = CASE
+        WHEN CAST(? AS UNSIGNED) = 1 THEN NULL
+        ELSE refill_day
+    END
 WHERE id = ?
+  AND deleted_at_m IS NULL
 `
 
 type UpdateKeyCreditsSetParams struct {
-	Credits sql.NullInt64 `db:"credits"`
-	ID      string        `db:"id"`
+	Credits           sql.NullInt64 `db:"credits"`
+	ClearRefillAmount int64         `db:"clear_refill_amount"`
+	ClearRefillDay    int64         `db:"clear_refill_day"`
+	ID                string        `db:"id"`
 }
 
 // UpdateKeyCreditsSet
 //
 //	UPDATE `keys`
-//	SET remaining_requests = ?
+//	SET
+//	    remaining_requests = ?,
+//	    refill_amount = CASE
+//	        WHEN CAST(? AS UNSIGNED) = 1 THEN NULL
+//	        ELSE refill_amount
+//	    END,
+//	    refill_day = CASE
+//	        WHEN CAST(? AS UNSIGNED) = 1 THEN NULL
+//	        ELSE refill_day
+//	    END
 //	WHERE id = ?
-func (q *Queries) UpdateKeyCreditsSet(ctx context.Context, db DBTX, arg UpdateKeyCreditsSetParams) error {
-	_, err := db.ExecContext(ctx, updateKeyCreditsSet, arg.Credits, arg.ID)
-	return err
+//	  AND deleted_at_m IS NULL
+func (q *Queries) UpdateKeyCreditsSet(ctx context.Context, db DBTX, arg UpdateKeyCreditsSetParams) (sql.Result, error) {
+	return db.ExecContext(ctx, updateKeyCreditsSet,
+		arg.Credits,
+		arg.ClearRefillAmount,
+		arg.ClearRefillDay,
+		arg.ID,
+	)
 }

--- a/pkg/db/permission_delete_by_id.sql_generated.go
+++ b/pkg/db/permission_delete_by_id.sql_generated.go
@@ -10,14 +10,20 @@ import (
 )
 
 const deletePermission = `-- name: DeletePermission :exec
-DELETE FROM permissions
-WHERE id = ?
+DELETE p, rp, kp
+FROM permissions p
+LEFT JOIN roles_permissions rp ON rp.permission_id = p.id
+LEFT JOIN keys_permissions kp ON kp.permission_id = p.id
+WHERE p.id = ?
 `
 
 // DeletePermission
 //
-//	DELETE FROM permissions
-//	WHERE id = ?
+//	DELETE p, rp, kp
+//	FROM permissions p
+//	LEFT JOIN roles_permissions rp ON rp.permission_id = p.id
+//	LEFT JOIN keys_permissions kp ON kp.permission_id = p.id
+//	WHERE p.id = ?
 func (q *Queries) DeletePermission(ctx context.Context, db DBTX, permissionID string) error {
 	_, err := db.ExecContext(ctx, deletePermission, permissionID)
 	return err

--- a/pkg/db/querier_generated.go
+++ b/pkg/db/querier_generated.go
@@ -10,6 +10,14 @@ import (
 )
 
 type Querier interface {
+	//DeleteAllKeyPermissionsAndRolesByKeyID
+	//
+	//  DELETE kp, kr
+	//  FROM `keys` k
+	//  LEFT JOIN keys_permissions kp ON k.id = kp.key_id
+	//  LEFT JOIN keys_roles kr ON k.id = kr.key_id
+	//  WHERE k.id = ?
+	DeleteAllKeyPermissionsAndRolesByKeyID(ctx context.Context, db DBTX, keyID string) error
 	//DeleteAllKeyPermissionsByKeyID
 	//
 	//  DELETE FROM keys_permissions
@@ -20,6 +28,11 @@ type Querier interface {
 	//  DELETE FROM keys_roles
 	//  WHERE key_id = ?
 	DeleteAllKeyRolesByKeyID(ctx context.Context, db DBTX, keyID string) error
+	//DeleteAllRatelimitsByKeyID
+	//
+	//  DELETE FROM ratelimits
+	//  WHERE key_id = ?
+	DeleteAllRatelimitsByKeyID(ctx context.Context, db DBTX, keyID sql.NullString) error
 	//DeleteAppBuildSettingsByEnvironmentId
 	//
 	//  DELETE FROM app_build_settings WHERE environment_id = ?
@@ -112,13 +125,25 @@ type Querier interface {
 	DeleteOldIdentityByExternalID(ctx context.Context, db DBTX, arg DeleteOldIdentityByExternalIDParams) error
 	//DeletePermission
 	//
-	//  DELETE FROM permissions
-	//  WHERE id = ?
+	//  DELETE p, rp, kp
+	//  FROM permissions p
+	//  LEFT JOIN roles_permissions rp ON rp.permission_id = p.id
+	//  LEFT JOIN keys_permissions kp ON kp.permission_id = p.id
+	//  WHERE p.id = ?
 	DeletePermission(ctx context.Context, db DBTX, permissionID string) error
+	//DeleteRatelimitsByKeyIDExceptNames
+	//
+	//  DELETE FROM ratelimits
+	//  WHERE key_id = ?
+	//    AND name NOT IN (/*SLICE:ratelimit_names*/?)
+	DeleteRatelimitsByKeyIDExceptNames(ctx context.Context, db DBTX, arg DeleteRatelimitsByKeyIDExceptNamesParams) error
 	//DeleteRoleByID
 	//
-	//  DELETE FROM roles
-	//  WHERE id = ?
+	//  DELETE r, rp, kr
+	//  FROM roles r
+	//  LEFT JOIN roles_permissions rp ON rp.role_id = r.id
+	//  LEFT JOIN keys_roles kr ON kr.role_id = r.id
+	//  WHERE r.id = ?
 	DeleteRoleByID(ctx context.Context, db DBTX, roleID string) error
 	// Removes every Stripe subscription row for a workspace. Paired with
 	// ResetWorkspaceBilling by the `unkey dev stripe reset` tooling.
@@ -139,6 +164,21 @@ type Querier interface {
 	//    AND exchanged_at IS NULL
 	//    AND expires_at > ?
 	ExchangePortalSessionToken(ctx context.Context, db DBTX, arg ExchangePortalSessionTokenParams) (sql.Result, error)
+	//FindApiAndKeySpaceByID
+	//
+	//  SELECT
+	//      a.id AS api_id,
+	//      a.workspace_id,
+	//      a.key_auth_id,
+	//      a.name AS api_name,
+	//      COALESCE(ka.id, '') AS key_space_id,
+	//      COALESCE(ka.store_encrypted_keys, false) AS store_encrypted_keys,
+	//      ka.default_prefix,
+	//      ka.default_bytes
+	//  FROM apis a
+	//  LEFT JOIN key_auth ka ON ka.id = a.key_auth_id
+	//  WHERE a.id = ?
+	FindApiAndKeySpaceByID(ctx context.Context, db DBTX, id string) (FindApiAndKeySpaceByIDRow, error)
 	//FindApiByID
 	//
 	//  SELECT pk, id, name, workspace_id, project_id, ip_whitelist, auth_type, key_auth_id, created_at_m, updated_at_m, deleted_at_m, delete_protection FROM apis WHERE id = ?
@@ -399,6 +439,66 @@ type Querier interface {
 	//  WHERE id = ?
 	//  and workspace_id = ?
 	FindKeyMigrationByID(ctx context.Context, db DBTX, arg FindKeyMigrationByIDParams) (FindKeyMigrationByIDRow, error)
+	// Resolve optional identity, permission, role, and project references in one round trip.
+	//
+	//  SELECT
+	//      'identity' AS resource_type,
+	//      i.id AS identity_id,
+	//      i.external_id AS identity_external_id,
+	//      '' AS permission_id,
+	//      '' AS permission_slug,
+	//      '' AS role_id,
+	//      '' AS role_name,
+	//      '' AS project_id,
+	//      '' AS project_slug
+	//  FROM identities i
+	//  WHERE CAST(? AS UNSIGNED) = 1
+	//      AND i.workspace_id = ?
+	//      AND i.external_id = ?
+	//      AND i.deleted = false
+	//  UNION ALL
+	//  SELECT
+	//      'permission' AS resource_type,
+	//      '' AS identity_id,
+	//      '' AS identity_external_id,
+	//      p.id AS permission_id,
+	//      p.slug AS permission_slug,
+	//      '' AS role_id,
+	//      '' AS role_name,
+	//      '' AS project_id,
+	//      '' AS project_slug
+	//  FROM permissions p
+	//  WHERE p.workspace_id = ?
+	//      AND p.slug IN (/*SLICE:permission_slugs*/?)
+	//  UNION ALL
+	//  SELECT
+	//      'role' AS resource_type,
+	//      '' AS identity_id,
+	//      '' AS identity_external_id,
+	//      '' AS permission_id,
+	//      '' AS permission_slug,
+	//      r.id AS role_id,
+	//      r.name AS role_name,
+	//      '' AS project_id,
+	//      '' AS project_slug
+	//  FROM roles r
+	//  WHERE r.workspace_id = ?
+	//      AND r.name IN (/*SLICE:role_names*/?)
+	//  UNION ALL
+	//  SELECT
+	//      'project' AS resource_type,
+	//      '' AS identity_id,
+	//      '' AS identity_external_id,
+	//      '' AS permission_id,
+	//      '' AS permission_slug,
+	//      '' AS role_id,
+	//      '' AS role_name,
+	//      p.id AS project_id,
+	//      p.slug AS project_slug
+	//  FROM projects p
+	//  WHERE p.workspace_id = ?
+	//      AND BINARY p.slug = 'default'
+	FindKeyMutationResources(ctx context.Context, db DBTX, arg FindKeyMutationResourcesParams) ([]FindKeyMutationResourcesRow, error)
 	//FindKeyRoleByKeyAndRoleID
 	//
 	//  SELECT pk, key_id, role_id, workspace_id, created_at_m, updated_at_m
@@ -614,6 +714,59 @@ type Querier interface {
 	//      AND ka.deleted_at_m IS NULL
 	//      AND ws.deleted_at_m IS NULL
 	FindLiveKeyByID(ctx context.Context, db DBTX, id string) (FindLiveKeyByIDRow, error)
+	//FindLiveKeyCredits
+	//
+	//  SELECT remaining_requests
+	//  FROM `keys`
+	//  WHERE id = ?
+	//    AND deleted_at_m IS NULL
+	FindLiveKeyCredits(ctx context.Context, db DBTX, id string) (sql.NullInt64, error)
+	// Credit updates only need authorization, audit, cache, and credit state.
+	//
+	//  SELECT
+	//      k.id,
+	//      k.key_auth_id,
+	//      k.hash,
+	//      k.workspace_id,
+	//      k.name,
+	//      k.refill_day,
+	//      k.refill_amount,
+	//      k.remaining_requests,
+	//      a.id AS api_id
+	//  FROM `keys` k
+	//  JOIN apis a ON a.key_auth_id = k.key_auth_id
+	//  JOIN key_auth ka ON ka.id = k.key_auth_id
+	//  JOIN workspaces ws ON k.workspace_id = ws.id
+	//  WHERE k.id = ?
+	//      AND k.deleted_at_m IS NULL
+	//      AND a.deleted_at_m IS NULL
+	//      AND ka.deleted_at_m IS NULL
+	//      AND ws.deleted_at_m IS NULL
+	FindLiveKeyForCreditsByID(ctx context.Context, db DBTX, id string) (FindLiveKeyForCreditsByIDRow, error)
+	// Keep this projection small: key updates do not need the RBAC and ratelimit
+	// aggregates returned by FindLiveKeyByID.
+	//
+	//  SELECT
+	//      k.id,
+	//      k.key_auth_id,
+	//      k.hash,
+	//      k.workspace_id,
+	//      k.name,
+	//      k.identity_id,
+	//      a.id AS api_id,
+	//      a.name AS api_name,
+	//      i.external_id AS identity_external_id
+	//  FROM `keys` k
+	//  JOIN apis a ON a.key_auth_id = k.key_auth_id
+	//  JOIN key_auth ka ON ka.id = k.key_auth_id
+	//  JOIN workspaces ws ON k.workspace_id = ws.id
+	//  LEFT JOIN identities i ON k.identity_id = i.id AND i.deleted = false
+	//  WHERE k.id = ?
+	//      AND k.deleted_at_m IS NULL
+	//      AND a.deleted_at_m IS NULL
+	//      AND ka.deleted_at_m IS NULL
+	//      AND ws.deleted_at_m IS NULL
+	FindLiveKeyForUpdateByID(ctx context.Context, db DBTX, id string) (FindLiveKeyForUpdateByIDRow, error)
 	//FindManyRatelimitNamespaces
 	//
 	//  SELECT pk, id, workspace_id, project_id, name, created_at_m, updated_at_m, deleted_at_m,
@@ -1338,6 +1491,7 @@ type Querier interface {
 	//      ?,
 	//      ?
 	//  ) ON DUPLICATE KEY UPDATE
+	//  name = VALUES(name),
 	//  `limit` = VALUES(`limit`),
 	//  duration = VALUES(duration),
 	//  auto_apply = VALUES(auto_apply),
@@ -2431,12 +2585,38 @@ type Querier interface {
 	//  END
 	//  WHERE id = ?
 	UpdateKeyCreditsDecrement(ctx context.Context, db DBTX, arg UpdateKeyCreditsDecrementParams) error
+	// LAST_INSERT_ID(expr) returns expr in this UPDATE's OK packet, so
+	// sql.Result.LastInsertId reads the new balance without another query.
+	// https://dev.mysql.com/doc/refman/8.4/en/information-functions.html#function_last-insert-id
+	//
+	//  UPDATE `keys`
+	//  SET
+	//      remaining_requests = LAST_INSERT_ID(CASE
+	//          WHEN remaining_requests >= ? THEN remaining_requests - ?
+	//          ELSE 0
+	//      END)
+	//  WHERE id = ?
+	//    AND deleted_at_m IS NULL
+	//    AND remaining_requests IS NOT NULL
+	UpdateKeyCreditsDecrementReturning(ctx context.Context, db DBTX, arg UpdateKeyCreditsDecrementReturningParams) (sql.Result, error)
 	//UpdateKeyCreditsIncrement
 	//
 	//  UPDATE `keys`
 	//  SET remaining_requests = remaining_requests + ?
 	//  WHERE id = ?
 	UpdateKeyCreditsIncrement(ctx context.Context, db DBTX, arg UpdateKeyCreditsIncrementParams) error
+	// LAST_INSERT_ID(expr) returns expr in this UPDATE's OK packet, so
+	// sql.Result.LastInsertId reads the new balance without another query.
+	// https://dev.mysql.com/doc/refman/8.4/en/information-functions.html#function_last-insert-id
+	//
+	//  UPDATE `keys`
+	//  SET
+	//      remaining_requests = LAST_INSERT_ID(remaining_requests + ?)
+	//  WHERE id = ?
+	//    AND deleted_at_m IS NULL
+	//    AND remaining_requests IS NOT NULL
+	//    AND remaining_requests <= 9223372036854775807 - ?
+	UpdateKeyCreditsIncrementReturning(ctx context.Context, db DBTX, arg UpdateKeyCreditsIncrementReturningParams) (sql.Result, error)
 	//UpdateKeyCreditsRefill
 	//
 	//  UPDATE `keys` SET refill_amount = ?, refill_day = ? WHERE id = ?
@@ -2444,9 +2624,19 @@ type Querier interface {
 	//UpdateKeyCreditsSet
 	//
 	//  UPDATE `keys`
-	//  SET remaining_requests = ?
+	//  SET
+	//      remaining_requests = ?,
+	//      refill_amount = CASE
+	//          WHEN CAST(? AS UNSIGNED) = 1 THEN NULL
+	//          ELSE refill_amount
+	//      END,
+	//      refill_day = CASE
+	//          WHEN CAST(? AS UNSIGNED) = 1 THEN NULL
+	//          ELSE refill_day
+	//      END
 	//  WHERE id = ?
-	UpdateKeyCreditsSet(ctx context.Context, db DBTX, arg UpdateKeyCreditsSetParams) error
+	//    AND deleted_at_m IS NULL
+	UpdateKeyCreditsSet(ctx context.Context, db DBTX, arg UpdateKeyCreditsSetParams) (sql.Result, error)
 	//UpdateKeySpaceKeyEncryption
 	//
 	//  UPDATE `key_auth` SET store_encrypted_keys = ? WHERE id = ?

--- a/pkg/db/queries/api_find_by_id.sql
+++ b/pkg/db/queries/api_find_by_id.sql
@@ -1,2 +1,16 @@
 -- name: FindApiByID :one
 SELECT * FROM apis WHERE id = ?;
+
+-- name: FindApiAndKeySpaceByID :one
+SELECT
+    a.id AS api_id,
+    a.workspace_id,
+    a.key_auth_id,
+    a.name AS api_name,
+    COALESCE(ka.id, '') AS key_space_id,
+    COALESCE(ka.store_encrypted_keys, false) AS store_encrypted_keys,
+    ka.default_prefix,
+    ka.default_bytes
+FROM apis a
+LEFT JOIN key_auth ka ON ka.id = a.key_auth_id
+WHERE a.id = sqlc.arg(id);

--- a/pkg/db/queries/key_delete_by_id.sql
+++ b/pkg/db/queries/key_delete_by_id.sql
@@ -6,3 +6,10 @@ LEFT JOIN keys_roles kr ON k.id = kr.key_id
 LEFT JOIN ratelimits rl ON k.id = rl.key_id
 LEFT JOIN encrypted_keys ek ON k.id = ek.key_id
 WHERE k.id = ?;
+
+-- name: DeleteAllKeyPermissionsAndRolesByKeyID :exec
+DELETE kp, kr
+FROM `keys` k
+LEFT JOIN keys_permissions kp ON k.id = kp.key_id
+LEFT JOIN keys_roles kr ON k.id = kr.key_id
+WHERE k.id = sqlc.arg(key_id);

--- a/pkg/db/queries/key_find_credits.sql
+++ b/pkg/db/queries/key_find_credits.sql
@@ -1,2 +1,8 @@
 -- name: FindKeyCredits :one
 SELECT remaining_requests FROM `keys` k WHERE k.id = ?;
+
+-- name: FindLiveKeyCredits :one
+SELECT remaining_requests
+FROM `keys`
+WHERE id = sqlc.arg(id)
+  AND deleted_at_m IS NULL;

--- a/pkg/db/queries/key_find_live_by_id.sql
+++ b/pkg/db/queries/key_find_live_by_id.sql
@@ -88,3 +88,109 @@ WHERE k.id = sqlc.arg(id)
     AND a.deleted_at_m IS NULL
     AND ka.deleted_at_m IS NULL
     AND ws.deleted_at_m IS NULL;
+
+-- name: FindKeyMutationResources :many
+-- Resolve optional identity, permission, role, and project references in one round trip.
+SELECT
+    'identity' AS resource_type,
+    i.id AS identity_id,
+    i.external_id AS identity_external_id,
+    '' AS permission_id,
+    '' AS permission_slug,
+    '' AS role_id,
+    '' AS role_name,
+    '' AS project_id,
+    '' AS project_slug
+FROM identities i
+WHERE CAST(sqlc.arg(find_identity) AS UNSIGNED) = 1
+    AND i.workspace_id = sqlc.arg(workspace_id)
+    AND i.external_id = sqlc.arg(external_id)
+    AND i.deleted = false
+UNION ALL
+SELECT
+    'permission' AS resource_type,
+    '' AS identity_id,
+    '' AS identity_external_id,
+    p.id AS permission_id,
+    p.slug AS permission_slug,
+    '' AS role_id,
+    '' AS role_name,
+    '' AS project_id,
+    '' AS project_slug
+FROM permissions p
+WHERE p.workspace_id = sqlc.arg(workspace_id)
+    AND p.slug IN (sqlc.slice('permission_slugs'))
+UNION ALL
+SELECT
+    'role' AS resource_type,
+    '' AS identity_id,
+    '' AS identity_external_id,
+    '' AS permission_id,
+    '' AS permission_slug,
+    r.id AS role_id,
+    r.name AS role_name,
+    '' AS project_id,
+    '' AS project_slug
+FROM roles r
+WHERE r.workspace_id = sqlc.arg(workspace_id)
+    AND r.name IN (sqlc.slice('role_names'))
+UNION ALL
+SELECT
+    'project' AS resource_type,
+    '' AS identity_id,
+    '' AS identity_external_id,
+    '' AS permission_id,
+    '' AS permission_slug,
+    '' AS role_id,
+    '' AS role_name,
+    p.id AS project_id,
+    p.slug AS project_slug
+FROM projects p
+WHERE p.workspace_id = sqlc.arg(workspace_id)
+    AND BINARY p.slug = 'default';
+
+-- name: FindLiveKeyForUpdateByID :one
+-- Keep this projection small: key updates do not need the RBAC and ratelimit
+-- aggregates returned by FindLiveKeyByID.
+SELECT
+    k.id,
+    k.key_auth_id,
+    k.hash,
+    k.workspace_id,
+    k.name,
+    k.identity_id,
+    a.id AS api_id,
+    a.name AS api_name,
+    i.external_id AS identity_external_id
+FROM `keys` k
+JOIN apis a ON a.key_auth_id = k.key_auth_id
+JOIN key_auth ka ON ka.id = k.key_auth_id
+JOIN workspaces ws ON k.workspace_id = ws.id
+LEFT JOIN identities i ON k.identity_id = i.id AND i.deleted = false
+WHERE k.id = sqlc.arg(id)
+    AND k.deleted_at_m IS NULL
+    AND a.deleted_at_m IS NULL
+    AND ka.deleted_at_m IS NULL
+    AND ws.deleted_at_m IS NULL;
+
+-- name: FindLiveKeyForCreditsByID :one
+-- Credit updates only need authorization, audit, cache, and credit state.
+SELECT
+    k.id,
+    k.key_auth_id,
+    k.hash,
+    k.workspace_id,
+    k.name,
+    k.refill_day,
+    k.refill_amount,
+    k.remaining_requests,
+    a.id AS api_id
+FROM `keys` k
+JOIN apis a ON a.key_auth_id = k.key_auth_id
+JOIN key_auth ka ON ka.id = k.key_auth_id
+JOIN workspaces ws ON k.workspace_id = ws.id
+WHERE k.id = sqlc.arg(id)
+    AND k.deleted_at_m IS NULL
+    AND a.deleted_at_m IS NULL
+    AND ka.deleted_at_m IS NULL
+    AND ws.deleted_at_m IS NULL;

--- a/pkg/db/queries/key_insert_ratelimit.sql
+++ b/pkg/db/queries/key_insert_ratelimit.sql
@@ -18,6 +18,7 @@ INSERT INTO `ratelimits` (
     sqlc.arg('auto_apply'),
     sqlc.arg('created_at')
 ) ON DUPLICATE KEY UPDATE
+name = VALUES(name),
 `limit` = VALUES(`limit`),
 duration = VALUES(duration),
 auto_apply = VALUES(auto_apply),

--- a/pkg/db/queries/key_update_credits_decrement.sql
+++ b/pkg/db/queries/key_update_credits_decrement.sql
@@ -5,3 +5,17 @@ SET remaining_requests = CASE
     ELSE 0
 END
 WHERE id = ?;
+
+-- LAST_INSERT_ID(expr) returns expr in this UPDATE's OK packet, so
+-- sql.Result.LastInsertId reads the new balance without another query.
+-- https://dev.mysql.com/doc/refman/8.4/en/information-functions.html#function_last-insert-id
+-- name: UpdateKeyCreditsDecrementReturning :execresult
+UPDATE `keys`
+SET
+    remaining_requests = LAST_INSERT_ID(CASE
+        WHEN remaining_requests >= sqlc.arg('credits') THEN remaining_requests - sqlc.arg('credits')
+        ELSE 0
+    END)
+WHERE id = ?
+  AND deleted_at_m IS NULL
+  AND remaining_requests IS NOT NULL;

--- a/pkg/db/queries/key_update_credits_increment.sql
+++ b/pkg/db/queries/key_update_credits_increment.sql
@@ -2,3 +2,15 @@
 UPDATE `keys`
 SET remaining_requests = remaining_requests + sqlc.arg('credits')
 WHERE id = ?;
+
+-- LAST_INSERT_ID(expr) returns expr in this UPDATE's OK packet, so
+-- sql.Result.LastInsertId reads the new balance without another query.
+-- https://dev.mysql.com/doc/refman/8.4/en/information-functions.html#function_last-insert-id
+-- name: UpdateKeyCreditsIncrementReturning :execresult
+UPDATE `keys`
+SET
+    remaining_requests = LAST_INSERT_ID(remaining_requests + sqlc.arg('credits'))
+WHERE id = ?
+  AND deleted_at_m IS NULL
+  AND remaining_requests IS NOT NULL
+  AND remaining_requests <= 9223372036854775807 - sqlc.arg('credits');

--- a/pkg/db/queries/key_update_credits_set.sql
+++ b/pkg/db/queries/key_update_credits_set.sql
@@ -1,4 +1,14 @@
--- name: UpdateKeyCreditsSet :exec
+-- name: UpdateKeyCreditsSet :execresult
 UPDATE `keys`
-SET remaining_requests = sqlc.narg('credits')
-WHERE id = ?;
+SET
+    remaining_requests = sqlc.narg('credits'),
+    refill_amount = CASE
+        WHEN CAST(sqlc.arg('clear_refill_amount') AS UNSIGNED) = 1 THEN NULL
+        ELSE refill_amount
+    END,
+    refill_day = CASE
+        WHEN CAST(sqlc.arg('clear_refill_day') AS UNSIGNED) = 1 THEN NULL
+        ELSE refill_day
+    END
+WHERE id = ?
+  AND deleted_at_m IS NULL;

--- a/pkg/db/queries/permission_delete_by_id.sql
+++ b/pkg/db/queries/permission_delete_by_id.sql
@@ -1,3 +1,6 @@
 -- name: DeletePermission :exec
-DELETE FROM permissions
-WHERE id = sqlc.arg(permission_id);
+DELETE p, rp, kp
+FROM permissions p
+LEFT JOIN roles_permissions rp ON rp.permission_id = p.id
+LEFT JOIN keys_permissions kp ON kp.permission_id = p.id
+WHERE p.id = sqlc.arg(permission_id);

--- a/pkg/db/queries/ratelimit_delete_many_by_ids.sql
+++ b/pkg/db/queries/ratelimit_delete_many_by_ids.sql
@@ -1,2 +1,11 @@
 -- name: DeleteManyRatelimitsByIDs :exec
 DELETE FROM ratelimits WHERE id IN (sqlc.slice(ids));
+
+-- name: DeleteAllRatelimitsByKeyID :exec
+DELETE FROM ratelimits
+WHERE key_id = sqlc.arg(key_id);
+
+-- name: DeleteRatelimitsByKeyIDExceptNames :exec
+DELETE FROM ratelimits
+WHERE key_id = ?
+  AND name NOT IN (sqlc.slice('ratelimit_names'));

--- a/pkg/db/queries/role_delete_by_id.sql
+++ b/pkg/db/queries/role_delete_by_id.sql
@@ -1,3 +1,6 @@
 -- name: DeleteRoleByID :exec
-DELETE FROM roles
-WHERE id = sqlc.arg(role_id);
+DELETE r, rp, kr
+FROM roles r
+LEFT JOIN roles_permissions rp ON rp.role_id = r.id
+LEFT JOIN keys_roles kr ON kr.role_id = r.id
+WHERE r.id = sqlc.arg(role_id);

--- a/pkg/db/ratelimit_delete_many_by_ids.sql_generated.go
+++ b/pkg/db/ratelimit_delete_many_by_ids.sql_generated.go
@@ -7,8 +7,23 @@ package db
 
 import (
 	"context"
+	"database/sql"
 	"strings"
 )
+
+const deleteAllRatelimitsByKeyID = `-- name: DeleteAllRatelimitsByKeyID :exec
+DELETE FROM ratelimits
+WHERE key_id = ?
+`
+
+// DeleteAllRatelimitsByKeyID
+//
+//	DELETE FROM ratelimits
+//	WHERE key_id = ?
+func (q *Queries) DeleteAllRatelimitsByKeyID(ctx context.Context, db DBTX, keyID sql.NullString) error {
+	_, err := db.ExecContext(ctx, deleteAllRatelimitsByKeyID, keyID)
+	return err
+}
 
 const deleteManyRatelimitsByIDs = `-- name: DeleteManyRatelimitsByIDs :exec
 DELETE FROM ratelimits WHERE id IN (/*SLICE:ids*/?)
@@ -27,6 +42,38 @@ func (q *Queries) DeleteManyRatelimitsByIDs(ctx context.Context, db DBTX, ids []
 		query = strings.Replace(query, "/*SLICE:ids*/?", strings.Repeat(",?", len(ids))[1:], 1)
 	} else {
 		query = strings.Replace(query, "/*SLICE:ids*/?", "NULL", 1)
+	}
+	_, err := db.ExecContext(ctx, query, queryParams...)
+	return err
+}
+
+const deleteRatelimitsByKeyIDExceptNames = `-- name: DeleteRatelimitsByKeyIDExceptNames :exec
+DELETE FROM ratelimits
+WHERE key_id = ?
+  AND name NOT IN (/*SLICE:ratelimit_names*/?)
+`
+
+type DeleteRatelimitsByKeyIDExceptNamesParams struct {
+	KeyID          sql.NullString `db:"key_id"`
+	RatelimitNames []string       `db:"ratelimit_names"`
+}
+
+// DeleteRatelimitsByKeyIDExceptNames
+//
+//	DELETE FROM ratelimits
+//	WHERE key_id = ?
+//	  AND name NOT IN (/*SLICE:ratelimit_names*/?)
+func (q *Queries) DeleteRatelimitsByKeyIDExceptNames(ctx context.Context, db DBTX, arg DeleteRatelimitsByKeyIDExceptNamesParams) error {
+	query := deleteRatelimitsByKeyIDExceptNames
+	var queryParams []interface{}
+	queryParams = append(queryParams, arg.KeyID)
+	if len(arg.RatelimitNames) > 0 {
+		for _, v := range arg.RatelimitNames {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:ratelimit_names*/?", strings.Repeat(",?", len(arg.RatelimitNames))[1:], 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:ratelimit_names*/?", "NULL", 1)
 	}
 	_, err := db.ExecContext(ctx, query, queryParams...)
 	return err

--- a/pkg/db/role_delete_by_id.sql_generated.go
+++ b/pkg/db/role_delete_by_id.sql_generated.go
@@ -10,14 +10,20 @@ import (
 )
 
 const deleteRoleByID = `-- name: DeleteRoleByID :exec
-DELETE FROM roles
-WHERE id = ?
+DELETE r, rp, kr
+FROM roles r
+LEFT JOIN roles_permissions rp ON rp.role_id = r.id
+LEFT JOIN keys_roles kr ON kr.role_id = r.id
+WHERE r.id = ?
 `
 
 // DeleteRoleByID
 //
-//	DELETE FROM roles
-//	WHERE id = ?
+//	DELETE r, rp, kr
+//	FROM roles r
+//	LEFT JOIN roles_permissions rp ON rp.role_id = r.id
+//	LEFT JOIN keys_roles kr ON kr.role_id = r.id
+//	WHERE r.id = ?
 func (q *Queries) DeleteRoleByID(ctx context.Context, db DBTX, roleID string) error {
 	_, err := db.ExecContext(ctx, deleteRoleByID, roleID)
 	return err

--- a/svc/api/openapi/gen.go
+++ b/svc/api/openapi/gen.go
@@ -2937,6 +2937,8 @@ type V2KeysUpdateCreditsRequestBody struct {
 	//
 	// Set to null when using 'set' operation to make the key unlimited (removes usage restrictions entirely). When decrementing, if the result would be negative, remaining credits are automatically set to zero. Credits are consumed during successful key verification, and when credits reach zero, verification fails with `code=USAGE_EXCEEDED`.
 	//
+	// An increment is rejected if the resulting balance would exceed 9223372036854775807 credits.
+	//
 	// Required when using 'increment' or 'decrement' operations. Optional for 'set' operation (null creates unlimited usage).
 	Value nullable.Nullable[int64] `json:"value,omitempty"`
 }

--- a/svc/api/openapi/openapi-generated.yaml
+++ b/svc/api/openapi/openapi-generated.yaml
@@ -2112,6 +2112,8 @@ components:
 
                         Set to null when using 'set' operation to make the key unlimited (removes usage restrictions entirely). When decrementing, if the result would be negative, remaining credits are automatically set to zero. Credits are consumed during successful key verification, and when credits reach zero, verification fails with `code=USAGE_EXCEEDED`.
 
+                        An increment is rejected if the resulting balance would exceed 9223372036854775807 credits.
+
                         Required when using 'increment' or 'decrement' operations. Optional for 'set' operation (null creates unlimited usage).
                     example: 1000
                 operation:

--- a/svc/api/openapi/spec/paths/v2/keys/updateCredits/V2KeysUpdateCreditsRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/keys/updateCredits/V2KeysUpdateCreditsRequestBody.yaml
@@ -23,6 +23,8 @@ properties:
 
       Set to null when using 'set' operation to make the key unlimited (removes usage restrictions entirely). When decrementing, if the result would be negative, remaining credits are automatically set to zero. Credits are consumed during successful key verification, and when credits reach zero, verification fails with `code=USAGE_EXCEEDED`.
 
+      An increment is rejected if the resulting balance would exceed 9223372036854775807 credits.
+
       Required when using 'increment' or 'decrement' operations. Optional for 'set' operation (null creates unlimited usage).
     example: 1000
   operation:

--- a/svc/api/routes/v2_keys_create_key/200_test.go
+++ b/svc/api/routes/v2_keys_create_key/200_test.go
@@ -331,9 +331,7 @@ func TestCreateRecoverableKeyWithURNPermissions(t *testing.T) {
 }
 
 // TestCreateKeyConcurrentWithSameExternalId tests that concurrent key creation
-// with the same externalId doesn't deadlock. This was previously possible due to
-// gap locks when inserting identities. The fix uses INSERT ... ON DUPLICATE KEY
-// UPDATE (upsert) to avoid gap lock deadlocks.
+// with the same externalId recovers from the identity unique-key race.
 func TestCreateKeyConcurrentWithSameExternalId(t *testing.T) {
 	t.Parallel()
 
@@ -363,6 +361,11 @@ func TestCreateKeyConcurrentWithSameExternalId(t *testing.T) {
 	numConcurrent := 20
 	externalID := "user_concurrent_test"
 
+	// Warm the validator's schema cache without creating the shared identity so
+	// the burst below isolates the database race this test covers.
+	warmup := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{ApiId: api.ID})
+	require.Equal(t, http.StatusOK, warmup.Status, warmup.RawBody)
+
 	var mu sync.Mutex
 	keyIDs := make([]string, 0, numConcurrent)
 
@@ -375,7 +378,7 @@ func TestCreateKeyConcurrentWithSameExternalId(t *testing.T) {
 			}
 			res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, req)
 			if res.Status != 200 {
-				return fmt.Errorf("unexpected status code: %d", res.Status)
+				return fmt.Errorf("unexpected status code %d: %s", res.Status, res.RawBody)
 			}
 			mu.Lock()
 			keyIDs = append(keyIDs, res.Body.Data.KeyId)

--- a/svc/api/routes/v2_keys_create_key/handler.go
+++ b/svc/api/routes/v2_keys_create_key/handler.go
@@ -75,7 +75,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	api, err := db.Query.FindApiByID(ctx, h.DB.RO(), req.ApiId)
+	apiAndKeySpace, err := db.Query.FindApiAndKeySpaceByID(ctx, h.DB.RO(), req.ApiId)
 	if err != nil {
 		if db.IsNotFound(err) {
 			return fault.New("api not found",
@@ -89,8 +89,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			fault.Internal("database error"), fault.Public("Failed to retrieve API."),
 		)
 	}
-
-	if api.WorkspaceID != principal.WorkspaceID {
+	if apiAndKeySpace.WorkspaceID != principal.WorkspaceID {
 		return fault.New("api not found",
 			fault.Code(codes.Data.Api.NotFound.URN()),
 			fault.Internal("api belongs to different workspace"), fault.Public("The specified API was not found."),
@@ -112,7 +111,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			Action:       rbac.CreateKey,
 		}),
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Keyspace(api.KeyAuthID.String),
+			urn.New().Workspace(principal.WorkspaceID).Keyspace(apiAndKeySpace.KeyAuthID.String),
 			permissions.CreateKey{},
 		),
 	))
@@ -143,18 +142,10 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 	actor := auditactor.FromPrincipal(principal)
 
-	keySpace, err := db.Query.FindKeySpaceByID(ctx, h.DB.RO(), api.KeyAuthID.String)
-	if err != nil {
-		if db.IsNotFound(err) {
-			return fault.New("api not set up for keys",
-				fault.Code(codes.App.Precondition.PreconditionFailed.URN()),
-				fault.Internal("api not set up for keys, keyspace not found"), fault.Public("The requested API is not set up to handle keys."),
-			)
-		}
-
-		return fault.Wrap(err,
-			fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
-			fault.Internal("database error"), fault.Public("Failed to retrieve API information."),
+	if apiAndKeySpace.KeySpaceID == "" {
+		return fault.New("api not set up for keys",
+			fault.Code(codes.App.Precondition.PreconditionFailed.URN()),
+			fault.Internal("api not set up for keys, keyspace not found"), fault.Public("The requested API is not set up to handle keys."),
 		)
 	}
 
@@ -166,13 +157,13 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	switch {
 	case req.Prefix != nil:
 		prefix = *req.Prefix
-	case keySpace.DefaultPrefix.Valid:
-		prefix = keySpace.DefaultPrefix.String
+	case apiAndKeySpace.DefaultPrefix.Valid:
+		prefix = apiAndKeySpace.DefaultPrefix.String
 	}
 
 	byteLength := ptr.SafeDeref(req.ByteLength)
-	if byteLength == 0 && keySpace.DefaultBytes.Valid {
-		byteLength = int(keySpace.DefaultBytes.Int32)
+	if byteLength == 0 && apiAndKeySpace.DefaultBytes.Valid {
+		byteLength = int(apiAndKeySpace.DefaultBytes.Int32)
 	}
 	if byteLength == 0 {
 		byteLength = 16
@@ -208,10 +199,10 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			}),
 			rbac.T(rbac.Tuple{
 				ResourceType: rbac.Api,
-				ResourceID:   api.ID,
+				ResourceID:   apiAndKeySpace.ApiID,
 				Action:       rbac.EncryptKey,
 			}),
-			rbac.U(urn.New().Workspace(principal.WorkspaceID).Keyspace(keySpace.ID).Key("*"), permissions.EncryptKey{}),
+			rbac.U(urn.New().Workspace(principal.WorkspaceID).Keyspace(apiAndKeySpace.KeySpaceID).Key("*"), permissions.EncryptKey{}),
 		))
 		if err != nil {
 			return apierrors.MaskInsufficientPermissionsAsNotFound(
@@ -221,7 +212,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			)
 		}
 
-		if !keySpace.StoreEncryptedKeys {
+		if !apiAndKeySpace.StoreEncryptedKeys {
 			return fault.New("api not set up for key encryption",
 				fault.Code(codes.App.Precondition.PreconditionFailed.URN()),
 				fault.Internal("api not set up for key encryption"), fault.Public("This API does not support key encryption."),
@@ -240,11 +231,6 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		}
 	}
 
-	projectID, err := projects.EnsureDefaultProject(ctx, h.DB.RW(), principal.WorkspaceID)
-	if err != nil {
-		return err
-	}
-
 	now := time.Now().UnixMilli()
 
 	txErr := retry.New(
@@ -255,9 +241,56 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		// keys.id unique index can be recovered by regenerating the ID.
 		keyID = uid.New(uid.KeyPrefix)
 		return db.TxRetry(ctx, h.DB.RW(), func(ctx context.Context, tx db.DBTX) error {
+			projectID := ""
+			attemptIdentityID := sql.NullString{}
+			existingPermissionsBySlug := make(map[string]db.Permission)
+			existingRolesByName := make(map[string]db.FindRolesByNamesRow)
+			permissionSlugs := []string{}
+			if req.Permissions != nil {
+				permissionSlugs = *req.Permissions
+			}
+			roleNames := []string{}
+			if req.Roles != nil {
+				roleNames = *req.Roles
+			}
+			findIdentity := int64(0)
+			externalID := ""
+			if req.ExternalId != nil {
+				findIdentity = 1
+				externalID = *req.ExternalId
+			}
+			if findIdentity == 1 || len(permissionSlugs) > 0 || len(roleNames) > 0 {
+				resources, findErr := db.Query.FindKeyMutationResources(ctx, tx, db.FindKeyMutationResourcesParams{
+					FindIdentity:    findIdentity,
+					WorkspaceID:     principal.WorkspaceID,
+					ExternalID:      externalID,
+					PermissionSlugs: permissionSlugs,
+					RoleNames:       roleNames,
+				})
+				if findErr != nil {
+					return fault.Wrap(findErr,
+						fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
+						fault.Internal("failed to find key mutation resources"),
+						fault.Public("Failed to retrieve key resources."),
+					)
+				}
+				for _, resource := range resources {
+					switch resource.ResourceType {
+					case "identity":
+						attemptIdentityID = sql.NullString{String: resource.IdentityID, Valid: true}
+					case "permission":
+						existingPermissionsBySlug[resource.PermissionSlug] = db.Permission{ID: resource.PermissionID, Slug: resource.PermissionSlug} //nolint:exhaustruct
+					case "role":
+						existingRolesByName[resource.RoleName] = db.FindRolesByNamesRow{ID: resource.RoleID, Name: resource.RoleName}
+					case "project":
+						projectID = resource.ProjectID
+					}
+				}
+			}
+
 			insertKeyParams := db.InsertKeyParams{
 				ID:                 keyID,
-				KeySpaceID:         api.KeyAuthID.String,
+				KeySpaceID:         apiAndKeySpace.KeyAuthID.String,
 				Hash:               keyResult.Hash,
 				Start:              keyResult.Start,
 				WorkspaceID:        principal.WorkspaceID,
@@ -283,39 +316,35 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			if req.ExternalId != nil {
 				externalID := *req.ExternalId
 
-				// Upsert identity - inserts if not exists, no-op if exists
-				err = db.Query.UpsertIdentity(ctx, tx, db.UpsertIdentityParams{
-					ID:          uid.New(uid.IdentityPrefix),
-					ExternalID:  externalID,
-					WorkspaceID: principal.WorkspaceID,
-					ProjectID:   projectID,
-					Environment: "default",
-					CreatedAt:   now,
-					Meta:        []byte("{}"),
-				})
-				if err != nil {
-					return fault.Wrap(err,
-						fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
-						fault.Internal("failed to upsert identity"),
-						fault.Public("Failed to create identity."),
-					)
+				if !attemptIdentityID.Valid {
+					if projectID == "" {
+						projectID, err = projects.EnsureDefaultProject(ctx, tx, principal.WorkspaceID)
+						if err != nil {
+							return err
+						}
+					}
+
+					identityID := uid.New(uid.IdentityPrefix)
+					err = db.Query.InsertIdentity(ctx, tx, db.InsertIdentityParams{
+						ID:          identityID,
+						ExternalID:  externalID,
+						WorkspaceID: principal.WorkspaceID,
+						ProjectID:   projectID,
+						Environment: "default",
+						CreatedAt:   now,
+						Meta:        []byte("{}"),
+					})
+					if err != nil {
+						return fault.Wrap(err,
+							fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
+							fault.Internal("failed to insert identity"),
+							fault.Public("Failed to create identity."),
+						)
+					}
+					attemptIdentityID = sql.NullString{Valid: true, String: identityID}
 				}
 
-				// Fetch the identity ID (either just created or already existed)
-				identity, err := db.Query.FindIdentityByExternalID(ctx, tx, db.FindIdentityByExternalIDParams{
-					WorkspaceID: principal.WorkspaceID,
-					ExternalID:  externalID,
-					Deleted:     false,
-				})
-				if err != nil {
-					return fault.Wrap(err,
-						fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
-						fault.Internal("failed to find identity after upsert"),
-						fault.Public("Failed to find identity."),
-					)
-				}
-
-				insertKeyParams.IdentityID = sql.NullString{Valid: true, String: identity.ID}
+				insertKeyParams.IdentityID = attemptIdentityID
 			}
 
 			if req.Meta != nil {
@@ -433,42 +462,36 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			}
 
 			var auditLogs []auditlog.AuditLog
-			if req.Permissions != nil {
-				var existingPermissions []db.Permission
-				existingPermissions, err = db.Query.FindPermissionsBySlugs(ctx, tx, db.FindPermissionsBySlugsParams{
-					WorkspaceID: principal.WorkspaceID,
-					Slugs:       *req.Permissions,
-				})
-				if err != nil {
-					return fault.Wrap(err,
-						fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
-						fault.Internal("database error"),
-						fault.Public("Failed to retrieve permissions."),
-					)
-				}
-
-				existingPermMap := make(map[string]db.Permission)
-				for _, p := range existingPermissions {
-					existingPermMap[p.Slug] = p
-				}
-
-				permissionsToCreate := []db.InsertPermissionParams{}
+			if req.Permissions != nil && len(*req.Permissions) > 0 {
 				requestedPermissions := []db.Permission{}
+				permissionSlugsToCreate := []string{}
 
 				for _, requestedSlug := range *req.Permissions {
-					existingPerm, exists := existingPermMap[requestedSlug]
+					existingPerm, exists := existingPermissionsBySlug[requestedSlug]
 					if exists {
 						requestedPermissions = append(requestedPermissions, existingPerm)
 						continue
 					}
 
+					permissionSlugsToCreate = append(permissionSlugsToCreate, requestedSlug)
+				}
+
+				if len(permissionSlugsToCreate) > 0 && projectID == "" {
+					projectID, err = projects.EnsureDefaultProject(ctx, tx, principal.WorkspaceID)
+					if err != nil {
+						return err
+					}
+				}
+
+				permissionsToCreate := make([]db.InsertPermissionParams, 0, len(permissionSlugsToCreate))
+				for _, permissionSlug := range permissionSlugsToCreate {
 					newPermID := uid.New(uid.PermissionPrefix)
 					permissionsToCreate = append(permissionsToCreate, db.InsertPermissionParams{
 						PermissionID: newPermID,
 						WorkspaceID:  principal.WorkspaceID,
 						ProjectID:    projectID,
-						Name:         requestedSlug,
-						Slug:         requestedSlug,
+						Name:         permissionSlug,
+						Slug:         permissionSlug,
 						Description:  dbtype.NullString{String: "", Valid: false},
 						CreatedAtM:   now,
 					})
@@ -476,8 +499,8 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 					requestedPermissions = append(requestedPermissions, db.Permission{
 						Pk:          0, // only here to make the linter happy
 						ID:          newPermID,
-						Name:        requestedSlug,
-						Slug:        requestedSlug,
+						Name:        permissionSlug,
+						Slug:        permissionSlug,
 						CreatedAtM:  now,
 						WorkspaceID: principal.WorkspaceID,
 						ProjectID:   projectID,
@@ -549,31 +572,12 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 				}
 			}
 
-			if req.Roles != nil {
-				var existingRoles []db.FindRolesByNamesRow
-				existingRoles, err = db.Query.FindRolesByNames(ctx, tx, db.FindRolesByNamesParams{
-					WorkspaceID: principal.WorkspaceID,
-					Names:       *req.Roles,
-				})
-				if err != nil {
-					return fault.Wrap(err,
-						fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
-						fault.Internal("database error"),
-						fault.Public("Failed to retrieve roles."),
-					)
-				}
-
-				// Find which roles need to be created
-				existingRoleMap := make(map[string]db.FindRolesByNamesRow)
-				for _, r := range existingRoles {
-					existingRoleMap[r.Name] = r
-				}
-
+			if req.Roles != nil && len(*req.Roles) > 0 {
 				// Create missing roles in bulk and build final list
 				requestedRoles := []db.FindRolesByNamesRow{}
 
 				for _, requestedName := range *req.Roles {
-					existingRole, exists := existingRoleMap[requestedName]
+					existingRole, exists := existingRolesByName[requestedName]
 					if exists {
 						requestedRoles = append(requestedRoles, existingRole)
 						continue
@@ -659,8 +663,8 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 					{
 						Type:        auditlog.APIResourceType,
 						ID:          req.ApiId,
-						DisplayName: api.Name,
-						Name:        api.Name,
+						DisplayName: apiAndKeySpace.ApiName,
+						Name:        apiAndKeySpace.ApiName,
 						Meta:        map[string]any{},
 					},
 				},

--- a/svc/api/routes/v2_keys_update_credits/200_test.go
+++ b/svc/api/routes/v2_keys_update_credits/200_test.go
@@ -104,6 +104,19 @@ func TestKeyUpdateCreditsSuccess(t *testing.T) {
 		require.EqualValues(t, key.RemainingRequests.Int64, setTo)
 	})
 
+	t.Run("setting the current value succeeds as a no-op", func(t *testing.T) {
+		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{
+			KeyId:     keyID,
+			Operation: openapi.Set,
+			Value:     nullable.NewNullableWithValue(setTo),
+		})
+
+		require.Equal(t, http.StatusOK, res.Status)
+		remaining, err := res.Body.Data.Remaining.Get()
+		require.NoError(t, err)
+		require.Equal(t, setTo, remaining)
+	})
+
 	increaseBy := int64(rand.IntN(50) + 1)
 	t.Run(fmt.Sprintf("increase credits by %d", increaseBy), func(t *testing.T) {
 		// Get current credits before decrement

--- a/svc/api/routes/v2_keys_update_credits/400_test.go
+++ b/svc/api/routes/v2_keys_update_credits/400_test.go
@@ -1,12 +1,16 @@
 package handler_test
 
 import (
+	"context"
+	"database/sql"
 	"fmt"
+	"math"
 	"net/http"
 	"testing"
 
 	"github.com/oapi-codegen/nullable"
 	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
 	"github.com/unkeyed/unkey/svc/api/openapi"
@@ -120,5 +124,31 @@ func TestKeyUpdateCreditsBadRequest(t *testing.T) {
 		require.Equal(t, 400, res.Status)
 		require.NotNil(t, res.Body)
 		require.NotNil(t, res.Body.Error)
+	})
+
+	t.Run("increment cannot overflow the supported credit balance", func(t *testing.T) {
+		_, err := db.Query.UpdateKeyCreditsSet(context.Background(), h.DB.RW(), db.UpdateKeyCreditsSetParams{
+			ID:                keyID,
+			Credits:           sql.NullInt64{Int64: math.MaxInt64, Valid: true},
+			ClearRefillAmount: 0,
+			ClearRefillDay:    0,
+		})
+		require.NoError(t, err)
+
+		req := handler.Request{
+			KeyId:     keyID,
+			Operation: openapi.Increment,
+			Value:     nullable.NewNullableWithValue(int64(1)),
+		}
+
+		res := testutil.CallRoute[handler.Request, openapi.BadRequestErrorResponse](h, route, headers, req)
+		require.Equal(t, http.StatusBadRequest, res.Status)
+		require.NotNil(t, res.Body)
+		require.Contains(t, res.Body.Error.Detail, "exceeds the maximum supported value")
+
+		key, err := db.Query.FindKeyByID(context.Background(), h.DB.RO(), keyID)
+		require.NoError(t, err)
+		require.True(t, key.RemainingRequests.Valid)
+		require.Equal(t, int64(math.MaxInt64), key.RemainingRequests.Int64)
 	})
 }

--- a/svc/api/routes/v2_keys_update_credits/handler.go
+++ b/svc/api/routes/v2_keys_update_credits/handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"math"
 	"net/http"
 
 	"github.com/oapi-codegen/nullable"
@@ -57,7 +58,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	key, err := db.Query.FindLiveKeyByID(ctx, h.DB.RO(), req.KeyId)
+	key, err := db.Query.FindLiveKeyForCreditsByID(ctx, h.DB.RO(), req.KeyId)
 	if err != nil {
 		if db.IsNotFound(err) {
 			return fault.Wrap(
@@ -93,7 +94,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		}),
 		rbac.T(rbac.Tuple{
 			ResourceType: rbac.Api,
-			ResourceID:   key.Api.ID,
+			ResourceID:   key.ApiID,
 			Action:       rbac.UpdateKey,
 		}),
 		rbac.U(
@@ -129,71 +130,102 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	if !req.Value.IsNull() && req.Value.IsSpecified() {
 		credits = sql.NullInt64{Int64: reqVal, Valid: true}
 	}
+	clearRefill := int64(0)
+	if !credits.Valid {
+		clearRefill = 1
+	}
 
-	key, err = db.TxWithResultRetry(ctx, h.DB.RW(), func(ctx context.Context, tx db.DBTX) (db.FindLiveKeyByIDRow, error) {
+	keyAfterUpdate := key
+	err = db.TxRetry(ctx, h.DB.RW(), func(ctx context.Context, tx db.DBTX) error {
+		var updateResult sql.Result
 		switch req.Operation {
 		case openapi.Set:
-			err = db.Query.UpdateKeyCreditsSet(ctx, tx, db.UpdateKeyCreditsSetParams{
-				ID:      key.ID,
-				Credits: credits,
+			updateResult, err = db.Query.UpdateKeyCreditsSet(ctx, tx, db.UpdateKeyCreditsSetParams{
+				ID:                key.ID,
+				Credits:           credits,
+				ClearRefillAmount: clearRefill,
+				ClearRefillDay:    clearRefill,
 			})
+			keyAfterUpdate.RemainingRequests = credits
+			if !credits.Valid {
+				keyAfterUpdate.RefillAmount = sql.NullInt64{}
+				keyAfterUpdate.RefillDay = sql.NullInt16{}
+			}
 		case openapi.Increment:
-			err = db.Query.UpdateKeyCreditsIncrement(ctx, tx, db.UpdateKeyCreditsIncrementParams{
+			updateResult, err = db.Query.UpdateKeyCreditsIncrementReturning(ctx, tx, db.UpdateKeyCreditsIncrementReturningParams{
 				ID:      key.ID,
 				Credits: credits,
 			})
 		case openapi.Decrement:
-			err = db.Query.UpdateKeyCreditsDecrement(ctx, tx, db.UpdateKeyCreditsDecrementParams{
+			updateResult, err = db.Query.UpdateKeyCreditsDecrementReturning(ctx, tx, db.UpdateKeyCreditsDecrementReturningParams{
 				ID:      key.ID,
 				Credits: credits,
 			})
 		default:
-			return db.FindLiveKeyByIDRow{}, fault.New("invalid operation",
+			return fault.New("invalid operation",
 				fault.Code(codes.App.Validation.InvalidInput.URN()),
 				fault.Internal(fmt.Sprintf("invalid operation: %s", req.Operation)),
 				fault.Public("Invalid operation specified."),
 			)
 		}
 		if err != nil {
-			return db.FindLiveKeyByIDRow{}, fault.Wrap(err,
+			return fault.Wrap(err,
 				fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
 				fault.Internal("database error"),
 				fault.Public("Failed to update key credits."),
 			)
 		}
 
-		// Reset the Refill data since it's not needed anymore
-		if req.Value.IsNull() {
-			err = db.Query.UpdateKeyCreditsRefill(ctx, tx, db.UpdateKeyCreditsRefillParams{
-				ID:           key.ID,
-				RefillAmount: sql.NullInt64{Int64: 0, Valid: false},
-				RefillDay:    sql.NullInt16{Int16: 0, Valid: false},
-			})
-			if err != nil {
-				return db.FindLiveKeyByIDRow{}, fault.Wrap(err,
-					fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
-					fault.Internal("database error"),
-					fault.Public("Failed to reset key refill data."),
+		rowsAffected, rowsAffectedErr := updateResult.RowsAffected()
+		if rowsAffectedErr != nil {
+			return fault.Wrap(rowsAffectedErr,
+				fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
+				fault.Internal("unable to verify updated key credits"),
+				fault.Public("Failed to update key credits."),
+			)
+		}
+		if rowsAffected == 0 {
+			currentCredits, findErr := db.Query.FindLiveKeyCredits(ctx, tx, key.ID)
+			switch {
+			case db.IsNotFound(findErr):
+				return fault.New("key got deleted before credits update",
+					fault.Code(codes.Data.Key.NotFound.URN()),
+					fault.Internal("key got deleted before update"),
+					fault.Public("We could not find the requested key."),
 				)
+			case findErr != nil:
+				return fault.Wrap(findErr,
+					fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
+					fault.Internal("unable to verify key after credits update matched no rows"),
+					fault.Public("Failed to update key credits."),
+				)
+			case req.Operation != openapi.Set && !currentCredits.Valid:
+				return fault.New("key credits became unlimited before update",
+					fault.Code(codes.App.Validation.InvalidInput.URN()),
+					fault.Public("You cannot increment or decrement a key with unlimited credits."),
+				)
+			case req.Operation == openapi.Increment && credits.Int64 > math.MaxInt64-currentCredits.Int64:
+				return fault.New("credits increment exceeds maximum",
+					fault.Code(codes.App.Validation.InvalidInput.URN()),
+					fault.Internal("credits increment would exceed max int64"),
+					fault.Public("The resulting credit balance exceeds the maximum supported value."),
+				)
+			default:
+				// MySQL reports changed rows, so a valid no-op can report zero.
+				keyAfterUpdate.RemainingRequests = currentCredits
 			}
 		}
 
-		keyAfterUpdate, keyErr := db.Query.FindLiveKeyByID(ctx, tx, req.KeyId)
-		if keyErr != nil {
-			if db.IsNotFound(keyErr) {
-				return db.FindLiveKeyByIDRow{}, fault.Wrap(
-					keyErr,
-					fault.Code(codes.Data.Key.NotFound.URN()),
-					fault.Internal("key got deleted after update"),
-					fault.Public("We could not find the requested key."),
+		if req.Operation != openapi.Set && rowsAffected > 0 {
+			keyAfterUpdate.RemainingRequests.Int64, err = updateResult.LastInsertId()
+			if err != nil {
+				return fault.Wrap(err,
+					fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
+					fault.Internal("unable to read updated key credits"),
+					fault.Public("Failed to update key credits."),
 				)
 			}
-
-			return db.FindLiveKeyByIDRow{}, fault.Wrap(keyErr,
-				fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
-				fault.Internal("database error"),
-				fault.Public("Failed to retrieve key information."),
-			)
+			keyAfterUpdate.RemainingRequests.Valid = true
 		}
 
 		remaining := "unlimited"
@@ -232,7 +264,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			},
 		})
 
-		return keyAfterUpdate, err
+		return err
 	})
 
 	if err != nil {
@@ -247,21 +279,21 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		Remaining: null,
 	}
 
-	if key.RemainingRequests.Valid {
-		responseData.Remaining = nullable.NewNullableWithValue(int64(key.RemainingRequests.Int64))
+	if keyAfterUpdate.RemainingRequests.Valid {
+		responseData.Remaining = nullable.NewNullableWithValue(keyAfterUpdate.RemainingRequests.Int64)
 	}
 
-	if key.RefillAmount.Valid {
+	if keyAfterUpdate.RefillAmount.Valid {
 		var day int
 		interval := openapi.KeyCreditsRefillIntervalDaily
 
-		if key.RefillDay.Valid {
+		if keyAfterUpdate.RefillDay.Valid {
 			interval = openapi.KeyCreditsRefillIntervalMonthly
-			day = int(key.RefillDay.Int16)
+			day = int(keyAfterUpdate.RefillDay.Int16)
 		}
 
 		responseData.Refill = &openapi.KeyCreditsRefill{
-			Amount:    int64(key.RefillAmount.Int64),
+			Amount:    keyAfterUpdate.RefillAmount.Int64,
 			Interval:  interval,
 			RefillDay: day,
 		}

--- a/svc/api/routes/v2_keys_update_key/200_test.go
+++ b/svc/api/routes/v2_keys_update_key/200_test.go
@@ -96,6 +96,7 @@ func TestUpdateKeySuccess(t *testing.T) {
 		require.Equal(t, ratelimit.AutoApply, ratelimits[0].AutoApply)
 		require.EqualValues(t, ratelimit.Duration, ratelimits[0].Duration)
 		require.EqualValues(t, ratelimit.Limit, ratelimits[0].Limit)
+		ratelimitID := ratelimits[0].ID
 
 		ratelimit = openapi.RatelimitRequest{
 			AutoApply: true,
@@ -117,10 +118,34 @@ func TestUpdateKeySuccess(t *testing.T) {
 		ratelimits, err = db.Query.ListRatelimitsByKeyID(ctx, h.DB.RO(), sql.NullString{String: keyResponse.KeyID, Valid: true})
 		require.NoError(t, err)
 		require.Len(t, ratelimits, 1)
+		require.Equal(t, ratelimitID, ratelimits[0].ID)
 		require.Equal(t, ratelimit.Name, ratelimits[0].Name)
 		require.Equal(t, ratelimit.AutoApply, ratelimits[0].AutoApply)
 		require.EqualValues(t, ratelimit.Duration, ratelimits[0].Duration)
 		require.EqualValues(t, ratelimit.Limit, ratelimits[0].Limit)
+
+		replacement := ratelimit
+		replacement.Name = "replacement"
+		res = testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{
+			KeyId:      keyResponse.KeyID,
+			Ratelimits: ptr.P([]openapi.RatelimitRequest{replacement}),
+		})
+		require.Equal(t, http.StatusOK, res.Status)
+
+		ratelimits, err = db.Query.ListRatelimitsByKeyID(ctx, h.DB.RO(), sql.NullString{String: keyResponse.KeyID, Valid: true})
+		require.NoError(t, err)
+		require.Len(t, ratelimits, 1)
+		require.Equal(t, replacement.Name, ratelimits[0].Name)
+
+		res = testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{
+			KeyId:      keyResponse.KeyID,
+			Ratelimits: ptr.P([]openapi.RatelimitRequest{}),
+		})
+		require.Equal(t, http.StatusOK, res.Status)
+
+		ratelimits, err = db.Query.ListRatelimitsByKeyID(ctx, h.DB.RO(), sql.NullString{String: keyResponse.KeyID, Valid: true})
+		require.NoError(t, err)
+		require.Empty(t, ratelimits)
 	})
 }
 
@@ -248,6 +273,25 @@ func TestUpdateKeyUpdateAllFields(t *testing.T) {
 
 	h.CreateRole(seed.CreateRoleRequest{WorkspaceID: api.WorkspaceID, Name: "admin"})
 	h.CreateRole(seed.CreateRoleRequest{WorkspaceID: api.WorkspaceID, Name: "user"})
+	oldRole := h.CreateRole(seed.CreateRoleRequest{WorkspaceID: api.WorkspaceID, Name: "old-role"})
+	oldPermission := h.CreatePermission(seed.CreatePermissionRequest{
+		WorkspaceID: api.WorkspaceID,
+		Name:        "old-permission",
+		Slug:        "old-permission",
+	})
+	require.NoError(t, db.Query.InsertKeyRole(ctx, h.DB.RW(), db.InsertKeyRoleParams{
+		KeyID:       keyResponse.KeyID,
+		RoleID:      oldRole.ID,
+		WorkspaceID: api.WorkspaceID,
+		CreatedAtM:  time.Now().UnixMilli(),
+	}))
+	require.NoError(t, db.Query.InsertKeyPermission(ctx, h.DB.RW(), db.InsertKeyPermissionParams{
+		KeyID:        keyResponse.KeyID,
+		PermissionID: oldPermission.ID,
+		WorkspaceID:  api.WorkspaceID,
+		CreatedAt:    time.Now().UnixMilli(),
+		UpdatedAt:    sql.NullInt64{},
+	}))
 
 	req := handler.Request{
 		KeyId:      keyResponse.KeyID,
@@ -287,6 +331,22 @@ func TestUpdateKeyUpdateAllFields(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, "newExternalId", identity.ExternalID)
+
+	directPermissions, err := db.Query.ListDirectPermissionsByKeyID(ctx, h.DB.RO(), keyResponse.KeyID)
+	require.NoError(t, err)
+	directPermissionSlugs := make([]string, len(directPermissions))
+	for i, permission := range directPermissions {
+		directPermissionSlugs[i] = permission.Slug
+	}
+	require.ElementsMatch(t, []string{"read", "write"}, directPermissionSlugs)
+
+	roles, err := db.Query.ListRolesByKeyID(ctx, h.DB.RO(), keyResponse.KeyID)
+	require.NoError(t, err)
+	roleNames := make([]string, len(roles))
+	for i, role := range roles {
+		roleNames[i] = role.Name
+	}
+	require.ElementsMatch(t, []string{"admin", "user"}, roleNames)
 }
 
 func TestKeyUpdateCreditsInvalidatesCache(t *testing.T) {
@@ -368,9 +428,8 @@ func TestKeyUpdateCreditsInvalidatesCache(t *testing.T) {
 }
 
 // TestUpdateKeyConcurrentWithSameExternalId tests that concurrent updates
-// to different keys with the same new externalId don't deadlock.
-// This was previously possible due to gap locks when inserting identities.
-// The fix uses INSERT ... ON DUPLICATE KEY UPDATE (upsert) to avoid deadlocks.
+// to different keys with the same new externalId recover from the identity
+// unique-key race.
 func TestUpdateKeyConcurrentWithSameExternalId(t *testing.T) {
 	t.Parallel()
 
@@ -463,9 +522,77 @@ func TestUpdateKeyConcurrentWithSameExternalId(t *testing.T) {
 	require.Equal(t, sharedIdentityID, identity.ID)
 }
 
+// TestUpdateKeyConcurrentWithSameNewPermission verifies that concurrent
+// auto-creation of one permission slug recovers from the unique-key race and
+// assigns the winning permission row to every key.
+func TestUpdateKeyConcurrentWithSameNewPermission(t *testing.T) {
+	t.Parallel()
+
+	h := testutil.NewHarness(t)
+	ctx := t.Context()
+
+	route := &handler.Handler{
+		DB:           h.DB,
+		Auditlogs:    h.Auditlogs,
+		KeyCache:     h.Caches.VerificationKeyByHash,
+		UsageLimiter: h.UsageLimiter,
+	}
+	h.Register(route)
+
+	workspaceID := h.Resources().UserWorkspace.ID
+	api := h.CreateApi(seed.CreateApiRequest{WorkspaceID: workspaceID})
+
+	const numKeys = 10
+	keyIDs := make([]string, numKeys)
+	for i := range numKeys {
+		keyResponse := h.CreateKey(seed.CreateKeyRequest{
+			WorkspaceID: workspaceID,
+			KeySpaceID:  api.KeyAuthID.String,
+			Name:        ptr.P(fmt.Sprintf("permission-race-key-%d", i)),
+		})
+		keyIDs[i] = keyResponse.KeyID
+	}
+
+	rootKey := h.CreateRootKey(workspaceID, "api.*.update_key")
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}
+
+	permissionSlug := "documents.read"
+	g := errgroup.Group{}
+	for _, keyID := range keyIDs {
+		g.Go(func() error {
+			res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{
+				KeyId:       keyID,
+				Permissions: ptr.P([]string{permissionSlug}),
+			})
+			if res.Status != http.StatusOK {
+				return fmt.Errorf("key %s: unexpected status %d: %s", keyID, res.Status, res.RawBody)
+			}
+			return nil
+		})
+	}
+	require.NoError(t, g.Wait())
+
+	permissionRows, err := db.Query.FindPermissionsBySlugs(ctx, h.DB.RO(), db.FindPermissionsBySlugsParams{
+		WorkspaceID: workspaceID,
+		Slugs:       []string{permissionSlug},
+	})
+	require.NoError(t, err)
+	require.Len(t, permissionRows, 1, "only the winning permission row should exist")
+
+	for _, keyID := range keyIDs {
+		keyPermissions, listErr := db.Query.ListDirectPermissionsByKeyID(ctx, h.DB.RO(), keyID)
+		require.NoError(t, listErr)
+		require.Len(t, keyPermissions, 1)
+		require.Equal(t, permissionRows[0].ID, keyPermissions[0].ID)
+	}
+}
+
 // TestUpdateKeyConcurrentRatelimits tests that concurrent updates to the
-// same key's ratelimits don't deadlock. The handler uses SELECT ... FOR UPDATE
-// on the key row to serialize concurrent modifications.
+// same key's ratelimits don't deadlock. Updating the key row serializes the
+// replacement statements that follow.
 func TestUpdateKeyConcurrentRatelimits(t *testing.T) {
 	t.Parallel()
 

--- a/svc/api/routes/v2_keys_update_key/handler.go
+++ b/svc/api/routes/v2_keys_update_key/handler.go
@@ -23,6 +23,7 @@ import (
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/pkg/rbac"
 	"github.com/unkeyed/unkey/pkg/rbac/permissions"
+	"github.com/unkeyed/unkey/pkg/retry"
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/pkg/urn"
 	"github.com/unkeyed/unkey/pkg/zen"
@@ -67,7 +68,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	key, err := db.Query.FindLiveKeyByID(ctx, h.DB.RO(), req.KeyId)
+	key, err := db.Query.FindLiveKeyForUpdateByID(ctx, h.DB.RO(), req.KeyId)
 	if err != nil {
 		if db.IsNotFound(err) {
 			return fault.Wrap(
@@ -101,7 +102,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		}),
 		rbac.T(rbac.Tuple{
 			ResourceType: rbac.Api,
-			ResourceID:   key.Api.ID,
+			ResourceID:   key.ApiID,
 			Action:       rbac.UpdateKey,
 		}),
 		rbac.U(
@@ -113,497 +114,521 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	projectID, err := projects.EnsureDefaultProject(ctx, h.DB.RW(), principal.WorkspaceID)
-	if err != nil {
-		return err
-	}
+	needsIdentity := req.ExternalId.IsSpecified() && !req.ExternalId.IsNull()
 
-	txErr := db.TxRetry(ctx, h.DB.RW(), func(ctx context.Context, tx db.DBTX) error {
-		auditLogs := []auditlog.AuditLog{}
-
-		update := db.UpdateKeyParams{
-			ID:                         key.ID,
-			Now:                        sql.NullInt64{Valid: true, Int64: time.Now().UnixMilli()},
-			NameSpecified:              0,
-			Name:                       sql.NullString{Valid: false, String: ""},
-			IdentityIDSpecified:        0,
-			IdentityID:                 sql.NullString{Valid: false, String: ""},
-			EnabledSpecified:           0,
-			Enabled:                    sql.NullBool{Valid: false, Bool: false},
-			MetaSpecified:              0,
-			Meta:                       sql.NullString{Valid: false, String: ""},
-			ExpiresSpecified:           0,
-			Expires:                    sql.NullTime{Valid: false, Time: time.Time{}},
-			RemainingRequestsSpecified: 0,
-			RemainingRequests:          sql.NullInt64{Valid: false, Int64: 0},
-			RefillAmountSpecified:      0,
-			RefillAmount:               sql.NullInt64{Valid: false, Int64: 0},
-			RefillDaySpecified:         0,
-			RefillDay:                  sql.NullInt16{Valid: false, Int16: 0},
-		}
-
-		if req.Name.IsSpecified() {
-			update.NameSpecified = 1
-			if req.Name.IsNull() {
-				update.Name = sql.NullString{Valid: false, String: ""}
-			} else {
-				update.Name = sql.NullString{Valid: true, String: req.Name.MustGet()}
-			}
-		}
-
-		if req.ExternalId.IsSpecified() {
-			update.IdentityIDSpecified = 1
-			if req.ExternalId.IsNull() {
-				update.IdentityID = sql.NullString{Valid: false, String: ""}
-			} else {
-				externalID := req.ExternalId.MustGet()
-
-				// Upsert identity - inserts if not exists, no-op if exists
-				err = db.Query.UpsertIdentity(ctx, tx, db.UpsertIdentityParams{
-					ID:          uid.New(uid.IdentityPrefix),
-					ExternalID:  externalID,
-					WorkspaceID: principal.WorkspaceID,
-					ProjectID:   projectID,
-					Environment: "default",
-					CreatedAt:   time.Now().UnixMilli(),
-					Meta:        []byte("{}"),
-				})
-				if err != nil {
-					return fault.Wrap(err,
-						fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
-						fault.Internal("failed to upsert identity"),
-						fault.Public("Failed to create identity."),
-					)
-				}
-
-				// Fetch the identity ID (either just created or already existed)
-				identity, err := db.Query.FindIdentityByExternalID(ctx, tx, db.FindIdentityByExternalIDParams{
-					WorkspaceID: principal.WorkspaceID,
-					ExternalID:  externalID,
-					Deleted:     false,
-				})
-				if err != nil {
-					return fault.Wrap(err,
-						fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
-						fault.Internal("failed to find identity after upsert"),
-						fault.Public("Failed to find identity."),
-					)
-				}
-
-				update.IdentityID = sql.NullString{Valid: true, String: identity.ID}
-			}
-		}
-
-		if req.Enabled != nil {
-			update.EnabledSpecified = 1
-			update.Enabled = sql.NullBool{Valid: true, Bool: *req.Enabled}
-		}
-
-		if req.Meta.IsSpecified() {
-			update.MetaSpecified = 1
-			if req.Meta.IsNull() {
-				update.Meta = sql.NullString{Valid: false, String: ""}
-			} else {
-				metaBytes, marshalErr := json.Marshal(req.Meta.MustGet())
-				if marshalErr != nil {
-					return fault.Wrap(marshalErr,
-						fault.Code(codes.App.Validation.InvalidInput.URN()),
-						fault.Internal("failed to marshal meta"),
-						fault.Public("Invalid metadata format."),
-					)
-				}
-				update.Meta = sql.NullString{Valid: true, String: string(metaBytes)}
-			}
-		}
-
-		if req.Expires.IsSpecified() {
-			update.ExpiresSpecified = 1
-			if req.Expires.IsNull() {
-				update.Expires = sql.NullTime{Valid: false, Time: time.Time{}}
-			} else {
-				update.Expires = sql.NullTime{Valid: true, Time: time.UnixMilli(req.Expires.MustGet())}
-			}
-		}
-
-		//nolint:nestif
-		if req.Credits.IsSpecified() {
-			if req.Credits.IsNull() {
-				update.RemainingRequestsSpecified = 1
-				update.RefillAmountSpecified = 1
-				update.RefillDaySpecified = 1
-				update.RefillAmount = sql.NullInt64{Valid: false, Int64: 0}
-				update.RefillDay = sql.NullInt16{Valid: false, Int16: 0}
-				update.RemainingRequests = sql.NullInt64{Valid: false, Int64: 0}
-			} else {
-				credits := req.Credits.MustGet()
-				if credits.Remaining.IsSpecified() {
-					update.RemainingRequestsSpecified = 1
-					if credits.Remaining.IsNull() {
-						// This also clears refilling
-						update.RefillAmountSpecified = 1
-						update.RefillDaySpecified = 1
-						update.RemainingRequests = sql.NullInt64{Valid: false, Int64: 0}
-						update.RefillAmount = sql.NullInt64{Valid: false, Int64: 0}
-						update.RefillDay = sql.NullInt16{Valid: false, Int16: 0}
-					} else {
-						update.RemainingRequests = sql.NullInt64{
-							Valid: true,
-							Int64: credits.Remaining.MustGet(),
-						}
-					}
-				}
-
-				if credits.Refill.IsSpecified() {
-					if credits.Refill.IsNull() {
-						update.RefillAmountSpecified = 1
-						update.RefillDaySpecified = 1
-						update.RefillAmount = sql.NullInt64{Valid: false, Int64: 0}
-						update.RefillDay = sql.NullInt16{Valid: false, Int16: 0}
-					} else {
-						refill := credits.Refill.MustGet()
-						update.RefillAmountSpecified = 1
-						update.RefillAmount = sql.NullInt64{
-							Valid: true,
-							Int64: refill.Amount,
-						}
-
-						update.RefillDaySpecified = 1
-						switch refill.Interval {
-						case openapi.UpdateKeyCreditsRefillIntervalMonthly:
-							if refill.RefillDay == nil {
-								return fault.New("missing refillDay",
-									fault.Code(codes.App.Validation.InvalidInput.URN()),
-									fault.Internal("refillDay required for monthly interval"),
-									fault.Public("`refillDay` must be provided when the refill interval is `monthly`."),
-								)
-							}
-
-							update.RefillDay = sql.NullInt16{
-								Valid: true,
-								Int16: int16(*refill.RefillDay), // nolint:gosec
-							}
-						case openapi.UpdateKeyCreditsRefillIntervalDaily:
-							if refill.RefillDay != nil {
-								return fault.New("invalid refillDay",
-									fault.Code(codes.App.Validation.InvalidInput.URN()),
-									fault.Internal("refillDay cannot be set for daily interval"),
-									fault.Public("`refillDay` must not be provided when the refill interval is `daily`."),
-								)
-							}
-
-							// For daily, refill_day should remain NULL
-							update.RefillDay = sql.NullInt16{Valid: false, Int16: 0}
-						}
-					}
-				}
-			}
-		}
-
-		err = db.Query.UpdateKey(ctx, tx, update)
-		if err != nil {
-			return fault.Wrap(err,
-				fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
-				fault.Internal("database error"),
-				fault.Public("Failed to update key."),
-			)
-		}
-
-		if req.Ratelimits != nil {
-			var existingRatelimits []db.ListRatelimitsByKeyIDRow
-			existingRatelimits, err = db.Query.ListRatelimitsByKeyID(ctx, tx, sql.NullString{String: key.ID, Valid: true})
-			if err != nil && !db.IsNotFound(err) {
-				return fault.Wrap(err,
-					fault.Internal("unable to fetch ratelimits"),
-					fault.Public("Failed to retrieve key ratelimits."),
-				)
-			}
-
-			// Create map of existing ratelimits by name
-			existingRatelimitMap := make(map[string]db.ListRatelimitsByKeyIDRow)
-			for _, rl := range existingRatelimits {
-				existingRatelimitMap[rl.Name] = rl
-			}
-
-			// Create map of new ratelimits
-			newRatelimitMap := make(map[string]openapi.RatelimitRequest)
-			for _, rl := range *req.Ratelimits {
-				newRatelimitMap[rl.Name] = rl
-			}
-
-			// Delete ratelimits that are not in the new list
-			rateLimitsToDelete := []string{}
-			for _, existingRL := range existingRatelimits {
-				if _, exists := newRatelimitMap[existingRL.Name]; !exists {
-					rateLimitsToDelete = append(rateLimitsToDelete, existingRL.ID)
-				}
-			}
-
-			if len(rateLimitsToDelete) > 0 {
-				err = db.Query.DeleteManyRatelimitsByIDs(ctx, tx, rateLimitsToDelete)
-				if err != nil {
-					return fault.Wrap(err,
-						fault.Internal("unable to delete ratelimits"),
-						fault.Public("Failed to delete ratelimits."),
-					)
-				}
-			}
-
-			// Insert or update ratelimits
-			ratelimitsToInsert := []db.InsertKeyRatelimitParams{}
-			now := time.Now().UnixMilli()
-			for name, newRL := range newRatelimitMap {
-				_, exists := existingRatelimitMap[name]
-
-				var rlID string
-				if exists {
-					rlID = existingRatelimitMap[name].ID
+	// Concurrent requests can race while auto-creating the same identity or permission.
+	// Retry the whole transaction so the loser observes and assigns the winner.
+	txErr := retry.New(
+		retry.Attempts(5),
+		retry.ShouldRetry(db.IsDuplicateKeyError),
+	).DoContext(ctx, func() error {
+		return db.TxRetry(ctx, h.DB.RW(), func(ctx context.Context, tx db.DBTX) error {
+			projectID := ""
+			attemptIdentityID := sql.NullString{}
+			existingPermissionsBySlug := make(map[string]db.Permission)
+			existingRolesByName := make(map[string]db.FindRolesByNamesRow)
+			findIdentity := int64(0)
+			externalID := ""
+			if needsIdentity {
+				externalID = req.ExternalId.MustGet()
+				if key.IdentityID.Valid && key.IdentityExternalID.Valid && key.IdentityExternalID.String == externalID {
+					attemptIdentityID = key.IdentityID
 				} else {
-					rlID = uid.New(uid.RatelimitPrefix)
+					findIdentity = 1
 				}
-
-				ratelimitsToInsert = append(ratelimitsToInsert, db.InsertKeyRatelimitParams{
-					ID:          rlID,
-					WorkspaceID: principal.WorkspaceID,
-					KeyID:       sql.NullString{String: key.ID, Valid: true},
-					Name:        newRL.Name,
-					Limit:       uint64(newRL.Limit),
-					Duration:    uint64(newRL.Duration),
-					CreatedAt:   now,
-					UpdatedAt:   sql.NullInt64{Int64: now, Valid: true},
-					AutoApply:   newRL.AutoApply,
-				})
 			}
-
-			if len(ratelimitsToInsert) > 0 {
-				err = db.BulkQuery.InsertKeyRatelimits(ctx, tx, ratelimitsToInsert)
-				if err != nil {
-					return fault.Wrap(err,
+			permissionSlugs := []string{}
+			if req.Permissions != nil {
+				permissionSlugs = *req.Permissions
+			}
+			roleNames := []string{}
+			if req.Roles != nil {
+				roleNames = *req.Roles
+			}
+			if findIdentity == 1 || len(permissionSlugs) > 0 || len(roleNames) > 0 {
+				resources, findErr := db.Query.FindKeyMutationResources(ctx, tx, db.FindKeyMutationResourcesParams{
+					FindIdentity:    findIdentity,
+					WorkspaceID:     principal.WorkspaceID,
+					ExternalID:      externalID,
+					PermissionSlugs: permissionSlugs,
+					RoleNames:       roleNames,
+				})
+				if findErr != nil {
+					return fault.Wrap(findErr,
 						fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
-						fault.Internal("database error"),
-						fault.Public("Failed to update rate limits."),
+						fault.Internal("failed to find key mutation resources"),
+						fault.Public("Failed to retrieve key resources."),
 					)
 				}
+				for _, resource := range resources {
+					switch resource.ResourceType {
+					case "identity":
+						attemptIdentityID = sql.NullString{String: resource.IdentityID, Valid: true}
+					case "permission":
+						existingPermissionsBySlug[resource.PermissionSlug] = db.Permission{ID: resource.PermissionID, Slug: resource.PermissionSlug} //nolint:exhaustruct
+					case "role":
+						existingRolesByName[resource.RoleName] = db.FindRolesByNamesRow{ID: resource.RoleID, Name: resource.RoleName}
+					case "project":
+						projectID = resource.ProjectID
+					}
+				}
 			}
-		}
 
-		if req.Permissions != nil {
-			var existingPermissions []db.Permission
-			existingPermissions, err = db.Query.FindPermissionsBySlugs(ctx, tx, db.FindPermissionsBySlugsParams{
-				WorkspaceID: principal.WorkspaceID,
-				Slugs:       *req.Permissions,
-			})
+			auditLogs := []auditlog.AuditLog{}
+
+			update := db.UpdateKeyParams{
+				ID:                         key.ID,
+				Now:                        sql.NullInt64{Valid: true, Int64: time.Now().UnixMilli()},
+				NameSpecified:              0,
+				Name:                       sql.NullString{Valid: false, String: ""},
+				IdentityIDSpecified:        0,
+				IdentityID:                 sql.NullString{Valid: false, String: ""},
+				EnabledSpecified:           0,
+				Enabled:                    sql.NullBool{Valid: false, Bool: false},
+				MetaSpecified:              0,
+				Meta:                       sql.NullString{Valid: false, String: ""},
+				ExpiresSpecified:           0,
+				Expires:                    sql.NullTime{Valid: false, Time: time.Time{}},
+				RemainingRequestsSpecified: 0,
+				RemainingRequests:          sql.NullInt64{Valid: false, Int64: 0},
+				RefillAmountSpecified:      0,
+				RefillAmount:               sql.NullInt64{Valid: false, Int64: 0},
+				RefillDaySpecified:         0,
+				RefillDay:                  sql.NullInt16{Valid: false, Int16: 0},
+			}
+
+			if req.Name.IsSpecified() {
+				update.NameSpecified = 1
+				if req.Name.IsNull() {
+					update.Name = sql.NullString{Valid: false, String: ""}
+				} else {
+					update.Name = sql.NullString{Valid: true, String: req.Name.MustGet()}
+				}
+			}
+
+			if req.ExternalId.IsSpecified() {
+				update.IdentityIDSpecified = 1
+				if req.ExternalId.IsNull() {
+					update.IdentityID = sql.NullString{Valid: false, String: ""}
+				} else {
+					externalID := req.ExternalId.MustGet()
+
+					if !attemptIdentityID.Valid {
+						if projectID == "" {
+							projectID, err = projects.EnsureDefaultProject(ctx, tx, principal.WorkspaceID)
+							if err != nil {
+								return err
+							}
+						}
+
+						identityID := uid.New(uid.IdentityPrefix)
+						err = db.Query.InsertIdentity(ctx, tx, db.InsertIdentityParams{
+							ID:          identityID,
+							ExternalID:  externalID,
+							WorkspaceID: principal.WorkspaceID,
+							ProjectID:   projectID,
+							Environment: "default",
+							CreatedAt:   time.Now().UnixMilli(),
+							Meta:        []byte("{}"),
+						})
+						if err != nil {
+							return fault.Wrap(err,
+								fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
+								fault.Internal("failed to insert identity"),
+								fault.Public("Failed to create identity."),
+							)
+						}
+						attemptIdentityID = sql.NullString{Valid: true, String: identityID}
+					}
+
+					update.IdentityID = attemptIdentityID
+				}
+			}
+
+			if req.Enabled != nil {
+				update.EnabledSpecified = 1
+				update.Enabled = sql.NullBool{Valid: true, Bool: *req.Enabled}
+			}
+
+			if req.Meta.IsSpecified() {
+				update.MetaSpecified = 1
+				if req.Meta.IsNull() {
+					update.Meta = sql.NullString{Valid: false, String: ""}
+				} else {
+					metaBytes, marshalErr := json.Marshal(req.Meta.MustGet())
+					if marshalErr != nil {
+						return fault.Wrap(marshalErr,
+							fault.Code(codes.App.Validation.InvalidInput.URN()),
+							fault.Internal("failed to marshal meta"),
+							fault.Public("Invalid metadata format."),
+						)
+					}
+					update.Meta = sql.NullString{Valid: true, String: string(metaBytes)}
+				}
+			}
+
+			if req.Expires.IsSpecified() {
+				update.ExpiresSpecified = 1
+				if req.Expires.IsNull() {
+					update.Expires = sql.NullTime{Valid: false, Time: time.Time{}}
+				} else {
+					update.Expires = sql.NullTime{Valid: true, Time: time.UnixMilli(req.Expires.MustGet())}
+				}
+			}
+
+			//nolint:nestif
+			if req.Credits.IsSpecified() {
+				if req.Credits.IsNull() {
+					update.RemainingRequestsSpecified = 1
+					update.RefillAmountSpecified = 1
+					update.RefillDaySpecified = 1
+					update.RefillAmount = sql.NullInt64{Valid: false, Int64: 0}
+					update.RefillDay = sql.NullInt16{Valid: false, Int16: 0}
+					update.RemainingRequests = sql.NullInt64{Valid: false, Int64: 0}
+				} else {
+					credits := req.Credits.MustGet()
+					if credits.Remaining.IsSpecified() {
+						update.RemainingRequestsSpecified = 1
+						if credits.Remaining.IsNull() {
+							// This also clears refilling
+							update.RefillAmountSpecified = 1
+							update.RefillDaySpecified = 1
+							update.RemainingRequests = sql.NullInt64{Valid: false, Int64: 0}
+							update.RefillAmount = sql.NullInt64{Valid: false, Int64: 0}
+							update.RefillDay = sql.NullInt16{Valid: false, Int16: 0}
+						} else {
+							update.RemainingRequests = sql.NullInt64{
+								Valid: true,
+								Int64: credits.Remaining.MustGet(),
+							}
+						}
+					}
+
+					if credits.Refill.IsSpecified() {
+						if credits.Refill.IsNull() {
+							update.RefillAmountSpecified = 1
+							update.RefillDaySpecified = 1
+							update.RefillAmount = sql.NullInt64{Valid: false, Int64: 0}
+							update.RefillDay = sql.NullInt16{Valid: false, Int16: 0}
+						} else {
+							refill := credits.Refill.MustGet()
+							update.RefillAmountSpecified = 1
+							update.RefillAmount = sql.NullInt64{
+								Valid: true,
+								Int64: refill.Amount,
+							}
+
+							update.RefillDaySpecified = 1
+							switch refill.Interval {
+							case openapi.UpdateKeyCreditsRefillIntervalMonthly:
+								if refill.RefillDay == nil {
+									return fault.New("missing refillDay",
+										fault.Code(codes.App.Validation.InvalidInput.URN()),
+										fault.Internal("refillDay required for monthly interval"),
+										fault.Public("`refillDay` must be provided when the refill interval is `monthly`."),
+									)
+								}
+
+								update.RefillDay = sql.NullInt16{
+									Valid: true,
+									Int16: int16(*refill.RefillDay), // nolint:gosec
+								}
+							case openapi.UpdateKeyCreditsRefillIntervalDaily:
+								if refill.RefillDay != nil {
+									return fault.New("invalid refillDay",
+										fault.Code(codes.App.Validation.InvalidInput.URN()),
+										fault.Internal("refillDay cannot be set for daily interval"),
+										fault.Public("`refillDay` must not be provided when the refill interval is `daily`."),
+									)
+								}
+
+								// For daily, refill_day should remain NULL
+								update.RefillDay = sql.NullInt16{Valid: false, Int16: 0}
+							}
+						}
+					}
+				}
+			}
+
+			err = db.Query.UpdateKey(ctx, tx, update)
 			if err != nil {
 				return fault.Wrap(err,
 					fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
 					fault.Internal("database error"),
-					fault.Public("Failed to retrieve permissions."),
+					fault.Public("Failed to update key."),
 				)
 			}
 
-			existingPermMap := make(map[string]db.Permission)
-			for _, p := range existingPermissions {
-				existingPermMap[p.Slug] = p
-			}
-
-			permissionsToCreate := []db.InsertPermissionParams{}
-			requestedPermissions := []db.Permission{}
-
-			for _, requestedSlug := range *req.Permissions {
-				existingPerm, exists := existingPermMap[requestedSlug]
-				if exists {
-					requestedPermissions = append(requestedPermissions, existingPerm)
-					continue
+			if req.Ratelimits != nil {
+				newRatelimitMap := make(map[string]openapi.RatelimitRequest)
+				for _, rl := range *req.Ratelimits {
+					newRatelimitMap[rl.Name] = rl
 				}
 
-				newPermID := uid.New(uid.PermissionPrefix)
-				permissionsToCreate = append(permissionsToCreate, db.InsertPermissionParams{
-					PermissionID: newPermID,
-					WorkspaceID:  principal.WorkspaceID,
-					ProjectID:    projectID,
-					Name:         requestedSlug,
-					Slug:         requestedSlug,
-					Description:  dbtype.NullString{String: fmt.Sprintf("Auto-created permission: %s", requestedSlug), Valid: true},
-					CreatedAtM:   time.Now().UnixMilli(),
-				})
+				if len(newRatelimitMap) == 0 {
+					err = db.Query.DeleteAllRatelimitsByKeyID(ctx, tx, sql.NullString{String: key.ID, Valid: true})
+					if err != nil {
+						return fault.Wrap(err,
+							fault.Internal("unable to delete key ratelimits"),
+							fault.Public("Failed to delete ratelimits."),
+						)
+					}
+				} else {
+					ratelimitNames := make([]string, 0, len(newRatelimitMap))
+					for name := range newRatelimitMap {
+						ratelimitNames = append(ratelimitNames, name)
+					}
+					err = db.Query.DeleteRatelimitsByKeyIDExceptNames(ctx, tx, db.DeleteRatelimitsByKeyIDExceptNamesParams{
+						KeyID:          sql.NullString{String: key.ID, Valid: true},
+						RatelimitNames: ratelimitNames,
+					})
+					if err != nil {
+						return fault.Wrap(err,
+							fault.Internal("unable to delete stale key ratelimits"),
+							fault.Public("Failed to delete ratelimits."),
+						)
+					}
+				}
 
-				//nolint: exhaustruct
-				requestedPermissions = append(requestedPermissions, db.Permission{
-					ID:   newPermID,
-					Slug: requestedSlug,
-				})
+				ratelimitsToInsert := make([]db.InsertKeyRatelimitParams, 0, len(newRatelimitMap))
+				now := time.Now().UnixMilli()
+				for _, ratelimit := range newRatelimitMap {
+					ratelimitsToInsert = append(ratelimitsToInsert, db.InsertKeyRatelimitParams{
+						ID:          uid.New(uid.RatelimitPrefix),
+						WorkspaceID: principal.WorkspaceID,
+						KeyID:       sql.NullString{String: key.ID, Valid: true},
+						Name:        ratelimit.Name,
+						Limit:       uint64(ratelimit.Limit),
+						Duration:    uint64(ratelimit.Duration),
+						CreatedAt:   now,
+						UpdatedAt:   sql.NullInt64{Int64: now, Valid: true},
+						AutoApply:   ratelimit.AutoApply,
+					})
+				}
+				if len(ratelimitsToInsert) > 0 {
+					err = db.BulkQuery.InsertKeyRatelimits(ctx, tx, ratelimitsToInsert)
+					if err != nil {
+						return fault.Wrap(err,
+							fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
+							fault.Internal("database error"),
+							fault.Public("Failed to update rate limits."),
+						)
+					}
+				}
 			}
 
-			if len(permissionsToCreate) > 0 {
-				for _, toCreate := range permissionsToCreate {
-					auditLogs = append(auditLogs, auditlog.AuditLog{
-						WorkspaceID:   principal.WorkspaceID,
-						Event:         auditlog.PermissionCreateEvent,
-						ActorType:     auditlog.AuditLogActor(principal.Subject.Type),
-						ActorID:       principal.Subject.ID,
-						ActorName:     principal.Subject.Name,
-						ActorMeta:     map[string]any{},
-						Display:       fmt.Sprintf("Created %s (%s)", toCreate.Slug, toCreate.PermissionID),
-						RemoteIP:      s.Location(),
-						UserAgent:     s.UserAgent(),
-						CorrelationID: "",
-						Resources: []auditlog.AuditLogResource{
-							{
-								Type:        auditlog.PermissionResourceType,
-								ID:          toCreate.PermissionID,
-								Name:        toCreate.Slug,
-								DisplayName: toCreate.Name,
-								Meta: map[string]any{
-									"name": toCreate.Name,
-									"slug": toCreate.Slug,
+			clearedKeyPermissionsAndRoles := req.Permissions != nil && req.Roles != nil
+			if clearedKeyPermissionsAndRoles {
+				err = db.Query.DeleteAllKeyPermissionsAndRolesByKeyID(ctx, tx, key.ID)
+				if err != nil {
+					return fault.Wrap(err,
+						fault.Internal("unable to clear permissions and roles"),
+						fault.Public("Failed to clear key permissions and roles."),
+					)
+				}
+			}
+
+			if req.Permissions != nil {
+				requestedPermissions := []db.Permission{}
+				if len(*req.Permissions) > 0 {
+					for _, requestedSlug := range *req.Permissions {
+						if _, exists := existingPermissionsBySlug[requestedSlug]; !exists {
+							if projectID == "" {
+								projectID, err = projects.EnsureDefaultProject(ctx, tx, principal.WorkspaceID)
+								if err != nil {
+									return err
+								}
+							}
+							break
+						}
+					}
+
+					permissionsToCreate := []db.InsertPermissionParams{}
+					for _, requestedSlug := range *req.Permissions {
+						existingPerm, exists := existingPermissionsBySlug[requestedSlug]
+						if exists {
+							requestedPermissions = append(requestedPermissions, existingPerm)
+							continue
+						}
+
+						newPermID := uid.New(uid.PermissionPrefix)
+						permissionsToCreate = append(permissionsToCreate, db.InsertPermissionParams{
+							PermissionID: newPermID,
+							WorkspaceID:  principal.WorkspaceID,
+							ProjectID:    projectID,
+							Name:         requestedSlug,
+							Slug:         requestedSlug,
+							Description:  dbtype.NullString{String: fmt.Sprintf("Auto-created permission: %s", requestedSlug), Valid: true},
+							CreatedAtM:   time.Now().UnixMilli(),
+						})
+
+						//nolint: exhaustruct
+						requestedPermissions = append(requestedPermissions, db.Permission{
+							ID:   newPermID,
+							Slug: requestedSlug,
+						})
+					}
+
+					if len(permissionsToCreate) > 0 {
+						for _, toCreate := range permissionsToCreate {
+							auditLogs = append(auditLogs, auditlog.AuditLog{
+								WorkspaceID:   principal.WorkspaceID,
+								Event:         auditlog.PermissionCreateEvent,
+								ActorType:     auditlog.AuditLogActor(principal.Subject.Type),
+								ActorID:       principal.Subject.ID,
+								ActorName:     principal.Subject.Name,
+								ActorMeta:     map[string]any{},
+								Display:       fmt.Sprintf("Created %s (%s)", toCreate.Slug, toCreate.PermissionID),
+								RemoteIP:      s.Location(),
+								UserAgent:     s.UserAgent(),
+								CorrelationID: "",
+								Resources: []auditlog.AuditLogResource{
+									{
+										Type:        auditlog.PermissionResourceType,
+										ID:          toCreate.PermissionID,
+										Name:        toCreate.Slug,
+										DisplayName: toCreate.Name,
+										Meta: map[string]any{
+											"name": toCreate.Name,
+											"slug": toCreate.Slug,
+										},
+									},
 								},
-							},
-						},
+							})
+						}
+
+						err = db.BulkQuery.InsertPermissions(ctx, tx, permissionsToCreate)
+						if err != nil {
+							return fault.Wrap(err,
+								fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
+								fault.Internal("database error"),
+								fault.Public("Failed to create permissions."),
+							)
+						}
+					}
+				}
+
+				if !clearedKeyPermissionsAndRoles {
+					err = db.Query.DeleteAllKeyPermissionsByKeyID(ctx, tx, key.ID)
+					if err != nil {
+						return fault.Wrap(err,
+							fault.Internal("unable to clear permissions"),
+							fault.Public("Failed to clear key permissions."),
+						)
+					}
+				}
+
+				permissionsToInsert := []db.InsertKeyPermissionParams{}
+				now := time.Now().UnixMilli()
+				for _, reqPerm := range requestedPermissions {
+					permissionsToInsert = append(permissionsToInsert, db.InsertKeyPermissionParams{
+						KeyID:        key.ID,
+						PermissionID: reqPerm.ID,
+						WorkspaceID:  principal.WorkspaceID,
+						CreatedAt:    now,
+						UpdatedAt:    sql.NullInt64{Int64: now, Valid: true},
 					})
 				}
 
-				err = db.BulkQuery.InsertPermissions(ctx, tx, permissionsToCreate)
-				if err != nil {
-					return fault.Wrap(err,
-						fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
-						fault.Internal("database error"),
-						fault.Public("Failed to create permissions."),
-					)
+				if len(permissionsToInsert) > 0 {
+					err = db.BulkQuery.InsertKeyPermissions(ctx, tx, permissionsToInsert)
+					if err != nil {
+						return fault.Wrap(err,
+							fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
+							fault.Internal("database error"),
+							fault.Public("Failed to assign permissions."),
+						)
+					}
 				}
 			}
 
-			err = db.Query.DeleteAllKeyPermissionsByKeyID(ctx, tx, key.ID)
-			if err != nil {
-				return fault.Wrap(err,
-					fault.Internal("unable to clear permissions"),
-					fault.Public("Failed to clear key permissions."),
-				)
-			}
+			if req.Roles != nil {
+				requestedRoles := []db.FindRolesByNamesRow{}
+				if len(*req.Roles) > 0 {
+					for _, requestedName := range *req.Roles {
+						existingRole, exists := existingRolesByName[requestedName]
+						if exists {
+							requestedRoles = append(requestedRoles, existingRole)
+							continue
+						}
 
-			permissionsToInsert := []db.InsertKeyPermissionParams{}
-			now := time.Now().UnixMilli()
-			for _, reqPerm := range requestedPermissions {
-				permissionsToInsert = append(permissionsToInsert, db.InsertKeyPermissionParams{
-					KeyID:        key.ID,
-					PermissionID: reqPerm.ID,
-					WorkspaceID:  principal.WorkspaceID,
-					CreatedAt:    now,
-					UpdatedAt:    sql.NullInt64{Int64: now, Valid: true},
-				})
-			}
+						return fault.New("role not found",
+							fault.Code(codes.Data.Role.NotFound.URN()),
+							fault.Internal("role not found"),
+							fault.Public(fmt.Sprintf("Role '%s' was not found.", requestedName)),
+						)
+					}
+				}
 
-			if len(permissionsToInsert) > 0 {
-				err = db.BulkQuery.InsertKeyPermissions(ctx, tx, permissionsToInsert)
-				if err != nil {
-					return fault.Wrap(err,
-						fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
-						fault.Internal("database error"),
-						fault.Public("Failed to assign permissions."),
-					)
+				if !clearedKeyPermissionsAndRoles {
+					err = db.Query.DeleteAllKeyRolesByKeyID(ctx, tx, key.ID)
+					if err != nil {
+						return fault.Wrap(err,
+							fault.Internal("unable to clear roles"),
+							fault.Public("Failed to clear key roles."),
+						)
+					}
+				}
+
+				// Insert all requested roles
+				rolesToInsert := []db.InsertKeyRoleParams{}
+				for _, reqRole := range requestedRoles {
+					rolesToInsert = append(rolesToInsert, db.InsertKeyRoleParams{
+						KeyID:       key.ID,
+						RoleID:      reqRole.ID,
+						WorkspaceID: principal.WorkspaceID,
+						CreatedAtM:  time.Now().UnixMilli(),
+					})
+				}
+
+				if len(rolesToInsert) > 0 {
+					err = db.BulkQuery.InsertKeyRoles(ctx, tx, rolesToInsert)
+					if err != nil {
+						return fault.Wrap(err,
+							fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
+							fault.Internal("database error"),
+							fault.Public("Failed to assign roles."),
+						)
+					}
 				}
 			}
-		}
 
-		if req.Roles != nil {
-			var existingRoles []db.FindRolesByNamesRow
-			existingRoles, err = db.Query.FindRolesByNames(ctx, tx, db.FindRolesByNamesParams{
-				WorkspaceID: principal.WorkspaceID,
-				Names:       *req.Roles,
+			auditLogs = append(auditLogs, auditlog.AuditLog{
+				WorkspaceID:   principal.WorkspaceID,
+				Event:         auditlog.KeyUpdateEvent,
+				ActorType:     auditlog.AuditLogActor(principal.Subject.Type),
+				ActorID:       principal.Subject.ID,
+				ActorName:     principal.Subject.Name,
+				ActorMeta:     map[string]any{},
+				Display:       fmt.Sprintf("Updated key %s", key.ID),
+				RemoteIP:      s.Location(),
+				UserAgent:     s.UserAgent(),
+				CorrelationID: "",
+				Resources: []auditlog.AuditLogResource{
+					{
+						Type:        auditlog.KeyResourceType,
+						ID:          key.ID,
+						DisplayName: key.Name.String,
+						Name:        key.Name.String,
+						Meta:        map[string]any{},
+					},
+					{
+						Type:        auditlog.APIResourceType,
+						ID:          key.ApiID,
+						DisplayName: key.ApiName,
+						Name:        key.ApiName,
+						Meta:        map[string]any{},
+					},
+				},
 			})
+
+			err = h.Auditlogs.Insert(ctx, tx, auditLogs)
 			if err != nil {
-				return fault.Wrap(err,
-					fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
-					fault.Internal("database error"),
-					fault.Public("Failed to retrieve roles."),
-				)
+				return err
 			}
 
-			// Find which roles need to be created
-			existingRoleMap := make(map[string]db.FindRolesByNamesRow)
-			for _, r := range existingRoles {
-				existingRoleMap[r.Name] = r
-			}
-
-			requestedRoles := []db.FindRolesByNamesRow{}
-			for _, requestedName := range *req.Roles {
-				existingRole, exists := existingRoleMap[requestedName]
-				if exists {
-					requestedRoles = append(requestedRoles, existingRole)
-					continue
-				}
-
-				return fault.New("role not found",
-					fault.Code(codes.Data.Role.NotFound.URN()),
-					fault.Internal("role not found"),
-					fault.Public(fmt.Sprintf("Role '%s' was not found.", requestedName)),
-				)
-			}
-
-			err = db.Query.DeleteAllKeyRolesByKeyID(ctx, tx, key.ID)
-			if err != nil {
-				return fault.Wrap(err,
-					fault.Internal("unable to clear roles"),
-					fault.Public("Failed to clear key roles."),
-				)
-			}
-
-			// Insert all requested roles
-			rolesToInsert := []db.InsertKeyRoleParams{}
-			for _, reqRole := range requestedRoles {
-				rolesToInsert = append(rolesToInsert, db.InsertKeyRoleParams{
-					KeyID:       key.ID,
-					RoleID:      reqRole.ID,
-					WorkspaceID: principal.WorkspaceID,
-					CreatedAtM:  time.Now().UnixMilli(),
-				})
-			}
-
-			if len(rolesToInsert) > 0 {
-				err = db.BulkQuery.InsertKeyRoles(ctx, tx, rolesToInsert)
-				if err != nil {
-					return fault.Wrap(err,
-						fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
-						fault.Internal("database error"),
-						fault.Public("Failed to assign roles."),
-					)
-				}
-			}
-		}
-
-		auditLogs = append(auditLogs, auditlog.AuditLog{
-			WorkspaceID:   principal.WorkspaceID,
-			Event:         auditlog.KeyUpdateEvent,
-			ActorType:     auditlog.AuditLogActor(principal.Subject.Type),
-			ActorID:       principal.Subject.ID,
-			ActorName:     principal.Subject.Name,
-			ActorMeta:     map[string]any{},
-			Display:       fmt.Sprintf("Updated key %s", key.ID),
-			RemoteIP:      s.Location(),
-			UserAgent:     s.UserAgent(),
-			CorrelationID: "",
-			Resources: []auditlog.AuditLogResource{
-				{
-					Type:        auditlog.KeyResourceType,
-					ID:          key.ID,
-					DisplayName: key.Name.String,
-					Name:        key.Name.String,
-					Meta:        map[string]any{},
-				},
-				{
-					Type:        auditlog.APIResourceType,
-					ID:          key.Api.ID,
-					DisplayName: key.Api.Name,
-					Name:        key.Api.Name,
-					Meta:        map[string]any{},
-				},
-			},
+			return nil
 		})
-
-		err = h.Auditlogs.Insert(ctx, tx, auditLogs)
-		if err != nil {
-			return err
-		}
-
-		return nil
 	})
 
 	if txErr != nil {

--- a/svc/api/routes/v2_permissions_delete_permission/200_test.go
+++ b/svc/api/routes/v2_permissions_delete_permission/200_test.go
@@ -2,6 +2,7 @@ package handler_test
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"net/http"
 	"testing"
@@ -10,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/unkeyed/unkey/pkg/db"
 	dbtype "github.com/unkeyed/unkey/pkg/db/types"
+	"github.com/unkeyed/unkey/pkg/hash"
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_permissions_delete_permission"
@@ -55,6 +57,58 @@ func TestSuccess(t *testing.T) {
 		})
 		require.NoError(t, err)
 
+		unrelatedPermissionID := uid.New(uid.PermissionPrefix)
+		err = db.Query.InsertPermission(ctx, h.DB.RW(), db.InsertPermissionParams{
+			PermissionID: unrelatedPermissionID,
+			WorkspaceID:  workspace.ID,
+			Name:         "unrelated.permission",
+			Slug:         "unrelated-permission",
+			Description:  dbtype.NullString{},
+			CreatedAtM:   time.Now().UnixMilli(),
+		})
+		require.NoError(t, err)
+
+		roleID := uid.New(uid.TestPrefix)
+		err = db.Query.InsertRole(ctx, h.DB.RW(), db.InsertRoleParams{
+			RoleID:      roleID,
+			WorkspaceID: workspace.ID,
+			Name:        "permission deletion test role",
+			Description: sql.NullString{},
+		})
+		require.NoError(t, err)
+
+		keyID := uid.New(uid.KeyPrefix)
+		err = db.Query.InsertKey(ctx, h.DB.RW(), db.InsertKeyParams{
+			ID:          keyID,
+			KeySpaceID:  workspace.ID,
+			Hash:        hash.Sha256(uid.New(uid.TestPrefix)),
+			Start:       "test_",
+			WorkspaceID: workspace.ID,
+			Name:        sql.NullString{Valid: true, String: "permission deletion test key"},
+			CreatedAtM:  time.Now().UnixMilli(),
+			Enabled:     true,
+		})
+		require.NoError(t, err)
+
+		for _, relationshipPermissionID := range []string{permissionID, unrelatedPermissionID} {
+			err = db.Query.InsertRolePermission(ctx, h.DB.RW(), db.InsertRolePermissionParams{
+				RoleID:       roleID,
+				PermissionID: relationshipPermissionID,
+				WorkspaceID:  workspace.ID,
+				CreatedAtM:   time.Now().UnixMilli(),
+			})
+			require.NoError(t, err)
+
+			err = db.Query.InsertKeyPermission(ctx, h.DB.RW(), db.InsertKeyPermissionParams{
+				KeyID:        keyID,
+				PermissionID: relationshipPermissionID,
+				WorkspaceID:  workspace.ID,
+				CreatedAt:    time.Now().UnixMilli(),
+				UpdatedAt:    sql.NullInt64{},
+			})
+			require.NoError(t, err)
+		}
+
 		// Verify the permission exists before deletion
 		perm, err := db.Query.FindPermissionByID(ctx, h.DB.RO(), permissionID)
 		require.NoError(t, err)
@@ -80,6 +134,30 @@ func TestSuccess(t *testing.T) {
 		_, err = db.Query.FindPermissionByID(ctx, h.DB.RO(), permissionID)
 		require.Error(t, err, "Permission should no longer exist")
 		require.True(t, db.IsNotFound(err), "Error should be 'not found'")
+
+		rolePermissions, err := db.Query.FindRolePermissionByRoleAndPermissionID(ctx, h.DB.RO(), db.FindRolePermissionByRoleAndPermissionIDParams{
+			RoleID:       roleID,
+			PermissionID: permissionID,
+		})
+		require.NoError(t, err)
+		require.Empty(t, rolePermissions, "role-permission relationship should be deleted")
+
+		rolePermissions, err = db.Query.FindRolePermissionByRoleAndPermissionID(ctx, h.DB.RO(), db.FindRolePermissionByRoleAndPermissionIDParams{
+			RoleID:       roleID,
+			PermissionID: unrelatedPermissionID,
+		})
+		require.NoError(t, err)
+		require.Len(t, rolePermissions, 1, "unrelated role-permission relationship should remain")
+
+		keyPermissions, err := db.Query.ListDirectPermissionsByKeyID(ctx, h.DB.RO(), keyID)
+		require.NoError(t, err)
+		require.Len(t, keyPermissions, 1)
+		require.Equal(t, unrelatedPermissionID, keyPermissions[0].ID, "unrelated key-permission relationship should remain")
+
+		_, err = db.Query.FindRoleByID(ctx, h.DB.RO(), roleID)
+		require.NoError(t, err, "related role should remain")
+		_, err = db.Query.FindKeyByID(ctx, h.DB.RO(), keyID)
+		require.NoError(t, err, "related key should remain")
 
 		// Verify the audit log was queued in clickhouse_outbox.
 		auditLogs := h.FindAuditLogsByTargetID(ctx, t, permissionID)

--- a/svc/api/routes/v2_permissions_delete_permission/handler.go
+++ b/svc/api/routes/v2_permissions_delete_permission/handler.go
@@ -77,22 +77,6 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	err = db.TxRetry(ctx, h.DB.RW(), func(ctx context.Context, tx db.DBTX) error {
-		err = db.Query.DeleteManyRolePermissionsByPermissionID(ctx, tx, permission.ID)
-		if err != nil {
-			return fault.Wrap(err,
-				fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
-				fault.Internal("database error"), fault.Public("Failed to delete role-permission relationships."),
-			)
-		}
-
-		err = db.Query.DeleteManyKeyPermissionsByPermissionID(ctx, tx, permission.ID)
-		if err != nil {
-			return fault.Wrap(err,
-				fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
-				fault.Internal("database error"), fault.Public("Failed to delete key-permission relationships."),
-			)
-		}
-
 		err = db.Query.DeletePermission(ctx, tx, permission.ID)
 		if err != nil {
 			return fault.Wrap(err,

--- a/svc/api/routes/v2_permissions_delete_role/200_test.go
+++ b/svc/api/routes/v2_permissions_delete_role/200_test.go
@@ -78,6 +78,22 @@ func TestSuccess(t *testing.T) {
 			require.NoError(t, err)
 		}
 
+		unrelatedRoleID := uid.New(uid.TestPrefix)
+		err = db.Query.InsertRole(ctx, h.DB.RW(), db.InsertRoleParams{
+			RoleID:      unrelatedRoleID,
+			WorkspaceID: workspace.ID,
+			Name:        "unrelated.delete.role",
+			Description: sql.NullString{},
+		})
+		require.NoError(t, err)
+		err = db.Query.InsertRolePermission(ctx, h.DB.RW(), db.InsertRolePermissionParams{
+			RoleID:       unrelatedRoleID,
+			PermissionID: permIDs[0],
+			WorkspaceID:  workspace.ID,
+			CreatedAtM:   time.Now().UnixMilli(),
+		})
+		require.NoError(t, err)
+
 		// Create a key with this role assigned
 		keyID := uid.New(uid.KeyPrefix)
 		err = db.Query.InsertKey(ctx, h.DB.RW(), db.InsertKeyParams{
@@ -96,6 +112,13 @@ func TestSuccess(t *testing.T) {
 		err = db.Query.InsertKeyRole(ctx, h.DB.RW(), db.InsertKeyRoleParams{
 			KeyID:       keyID,
 			RoleID:      roleID,
+			WorkspaceID: workspace.ID,
+			CreatedAtM:  time.Now().UnixMilli(),
+		})
+		require.NoError(t, err)
+		err = db.Query.InsertKeyRole(ctx, h.DB.RW(), db.InsertKeyRoleParams{
+			KeyID:       keyID,
+			RoleID:      unrelatedRoleID,
 			WorkspaceID: workspace.ID,
 			CreatedAtM:  time.Now().UnixMilli(),
 		})
@@ -143,6 +166,26 @@ func TestSuccess(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Empty(t, keyRoles, "Key-Role relationships should be deleted")
+
+		for _, permID := range permIDs {
+			_, err = db.Query.FindPermissionByID(ctx, h.DB.RO(), permID)
+			require.NoError(t, err, "permissions assigned to the deleted role should remain")
+		}
+		_, err = db.Query.FindKeyByID(ctx, h.DB.RO(), keyID)
+		require.NoError(t, err, "key assigned to the deleted role should remain")
+
+		unrelatedRolePermissions, err := db.Query.FindRolePermissionByRoleAndPermissionID(ctx, h.DB.RO(), db.FindRolePermissionByRoleAndPermissionIDParams{
+			RoleID:       unrelatedRoleID,
+			PermissionID: permIDs[0],
+		})
+		require.NoError(t, err)
+		require.Len(t, unrelatedRolePermissions, 1, "unrelated role-permission relationship should remain")
+		unrelatedKeyRoles, err := db.Query.FindKeyRoleByKeyAndRoleID(ctx, h.DB.RO(), db.FindKeyRoleByKeyAndRoleIDParams{
+			KeyID:  keyID,
+			RoleID: unrelatedRoleID,
+		})
+		require.NoError(t, err)
+		require.Len(t, unrelatedKeyRoles, 1, "unrelated key-role relationship should remain")
 	})
 
 	// Test case for deleting a role without permissions or key assignments

--- a/svc/api/routes/v2_permissions_delete_role/handler.go
+++ b/svc/api/routes/v2_permissions_delete_role/handler.go
@@ -78,22 +78,6 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	err = db.TxRetry(ctx, h.DB.RW(), func(ctx context.Context, tx db.DBTX) error {
-		err = db.Query.DeleteManyRolePermissionsByRoleID(ctx, tx, role.ID)
-		if err != nil {
-			return fault.Wrap(err,
-				fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
-				fault.Internal("database error"), fault.Public("Failed to delete role-permission relationships."),
-			)
-		}
-
-		err = db.Query.DeleteManyKeyRolesByRoleID(ctx, tx, role.ID)
-		if err != nil {
-			return fault.Wrap(err,
-				fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
-				fault.Internal("database error"), fault.Public("Failed to delete key-role relationships."),
-			)
-		}
-
 		err = db.Query.DeleteRoleByID(ctx, tx, role.ID)
 		if err != nil {
 			return fault.Wrap(err,


### PR DESCRIPTION
## Problem:

Key create, update, and credit mutations made several sequential MySQL requests. This is inexpensive near the primary, but each request pays the full network round-trip time from another region. At 230 ms RTT, a small mutation can take seconds even when MySQL execution itself takes only milliseconds.

## Solution:

Reduce database exchanges without changing authorization, transaction, audit, cache, or credit semantics:

- Use focused preflight queries for create, update, and credit routes instead of heavyweight key aggregation reads.
- Combine optional identity, permission, role, and default-project lookup for rich key mutations.
- Bulk permission, role, and rate-limit writes. Use multi-table deletes for related permission and role cleanup.
- Preserve rate-limit IDs when replacing a rate limit with the same name.
- Use `LAST_INSERT_ID(expr)` and `sql.Result.LastInsertId()` to return an atomic credit balance in the UPDATE response packet. This removes a follow-up SELECT and avoids connection-pool state.
- Keep the credit no-op disambiguation read because it distinguishes a valid no-op from deletion, unlimited credits, or overflow.
- Batch deterministic basic create, name/enabled-only update, and credit mutations with their audit outbox insert and COMMIT in one MySQL `COM_QUERY` after authorization preflight.

The transactional batch executor uses an isolated primary pool with multi-statements enabled. Every statement keeps SQLCommenter attribution. A terminal marker confirms COMMIT. If the marker is missing, the outcome is ambiguous: the connection is discarded and the mutation is not retried. Basic create retries only an explicit duplicate-key server response, which proves the insert failed before COMMIT.

sqlc query comments opt statements into generated, typed batch adapters:

```sql
-- transactional-batch-statement
```

The plugin generates SQL constants and parameter ordering. Small Go methods still define the reviewed business order. `sqlc.json` does not contain route-specific batch composition.

Alternatives considered:

- Regional writers or a write proxy reduce RTT broadly, but add infrastructure and do not fit the current single-primary data model.
- Stored procedures reduce exchanges, but move route behavior and deployment ownership into the database.
- A custom MySQL wire client adds substantial protocol and safety risk for behavior the existing driver already supports.
- Fully generated batches in `sqlc.json` or whole-batch SQL comments hide business composition in generator configuration or SQL metadata.
- Rich creates and updates still require intermediate results and conditional writes, so those paths remain explicit transactions. Credit updates use a specialized result-aware batch that reads diagnostic state before COMMIT.

## Impact:

Warm local endpoint benchmarks, before to after the original round-trip changes:

| Operation | Before | After | Improvement |
|---|---:|---:|---:|
| Basic create | 1.763 ms | 1.091 ms | 38.1% |
| Rich create | 3.197 ms | 2.368 ms | 25.9% |
| Basic update | 1.722 ms | 1.277 ms | 25.9% |
| Rich update | 4.193 ms | 2.793 ms | 33.4% |
| Rate-limit replacement | 2.690 ms | 1.900 ms | 29.4% |
| Credit increment | 1.893 ms | 1.035 ms | 45.3% |

The basic update transactional batch measured:

| Environment | Regular transaction | Batched | Improvement |
|---|---:|---:|---:|
| Local MySQL | 2.383 ms | 1.064 ms | 55.3% |
| Simulated 230 ms RTT | 2.043 s | 0.559 s | 72.6% |

The basic create batch measured 2.292 ms to 1.373 ms locally, 40.1% faster. It reduces endpoint database exchanges from five to two: one authorization preflight and one atomic mutation batch. At 230 ms RTT, that removes about 690 ms of network RTT floor. This last figure is a round-trip model, not a hosted PlanetScale benchmark.
Credit updates now also use two endpoint database exchanges: one authorization preflight and one atomic result-aware mutation batch. The batch returns the committed balance and refill state, keeps the audit write atomic, and classifies overflow, deletion, and unlimited transitions from an in-transaction diagnostic read.

Transactional audit outbox writes remain atomic. Information-hiding behavior remains unchanged. Credit increments remain signed, atomic, overflow-safe, and do not mutate `updated_at_m`.

## Testing:

Local validation on the unpushed rebased branch:

- create key route suite
- update key route suite
- update credits route suite
- permission delete route suite
- role delete route suite
- transactional-batch plugin tests
- `pkg/db` tests
- targeted lint: 0 issues
- repository build
- generated SQL is idempotent
- `git diff --check`
- injected audit insert failures verify batched create and update rollback the mutation

Hosted GitHub CI has not run for the local continuation because it has not been pushed.