### PR TITLE
fix: use team for Vercel flags

### DIFF
--- a/web/apps/dashboard/lib/flags/plumbing.ts
+++ b/web/apps/dashboard/lib/flags/plumbing.ts
@@ -7,7 +7,7 @@ import { dedupe } from "flags/next";
 // details here unless the flag provider needs them for evaluation.
 export type Entities = {
   user?: { id: string };
-  org?: { id: string };
+  team?: { id: string };
 };
 
 // identify uses the non-redirecting auth helper because flag evaluation can run
@@ -16,7 +16,7 @@ export const identify = dedupe(async (): Promise<Entities> => {
   const { userId, orgId } = await getAuth();
   return {
     user: userId ? { id: userId } : undefined,
-    org: orgId ? { id: orgId } : undefined,
+    team: orgId ? { id: orgId } : undefined,
   };
 });
 


### PR DESCRIPTION
Problem: If you flag a user, then all the workspaces are now flagged versus just the workspace. This is a problem for users who has multiple orgs like agency
Solution: update it to team which is documented
security: none
Testing: add a org_id to team