### PR TITLE
feat(dashboard): Add the projects-nav feature flag

### DIFF
--- a/web/apps/dashboard/lib/flags/index.ts
+++ b/web/apps/dashboard/lib/flags/index.ts
@@ -32,6 +32,19 @@ export const deployBilling = flag<boolean, Entities>({
   adapter: adapter(),
 });
 
+export const projectsNav = flag<boolean, Entities>({
+  key: "projects-nav",
+  description:
+    "Use the projects-first navigation (sidebar, breadcrumbs, landing redirect). Off until rollout.",
+  defaultValue: false,
+  options: [
+    { value: false, label: "Off" },
+    { value: true, label: "On" },
+  ],
+  identify,
+  adapter: adapter(),
+});
+
 // portalManagement gates the portal configuration page and its sidebar nav
 // item. Off until portal GA so it can be developed and merged without being
 // visible. Enable per-workspace to roll out to internal workspaces first.

--- a/web/apps/dashboard/lib/flags/resolve.ts
+++ b/web/apps/dashboard/lib/flags/resolve.ts
@@ -5,12 +5,13 @@ import * as flags from ".";
 // from this function's return shape, so any flag missing from this list will
 // fail to type-check at every useFlag(key) call site.
 export async function resolveAll() {
-  const [helloWorld, deployBilling, portalManagement] = await Promise.all([
+  const [helloWorld, deployBilling, portalManagement, projectsNav] = await Promise.all([
     flags.helloWorld(),
     flags.deployBilling(),
     flags.portalManagement(),
+    flags.projectsNav(),
   ]);
-  return { helloWorld, deployBilling, portalManagement };
+  return { helloWorld, deployBilling, portalManagement, projectsNav };
 }
 
 export type Flags = Awaited<ReturnType<typeof resolveAll>>;


### PR DESCRIPTION
## What does this PR do?

- Created a new `projects-nav` flag for #projects-everything-project
- No consumer atm, just wanted to add the flag and be able to access it in future! 

https://linear.app/unkey/issue/ENG-3095

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- `pnpm build` from `web/` passes, and no route or rendered output changes anywhere in the dashboard.
- `useFlag("projectsNav")` type-checks in a client component, since the `Flags` type derives from `resolveAll`.
- Locally, `FLAGS_LOCAL_OVERRIDES="projects-nav"` resolves it `true`; without it, `false`.
- `/.well-known/vercel/flags` lists `projects-nav` (the route does `import * as flags`, so it needed no change).

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [ ] Ran `mise run fmt`
- [ ] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary