### PR TITLE
feat(dashboard): show compute quota allocation

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/deploy-product-card.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/deploy-product-card.tsx
@@ -19,15 +19,27 @@ import {
 import { ADMIN_ONLY_TOOLTIP } from "./constants";
 import { ProductCard } from "./product-card";
 import { SpendManagement } from "./spend-management";
+import { UsageMeter } from "./usage-meter";
 
 /** Matches the billing summary strip's period formatting, e.g. "Aug 1". */
 function formatRenewalDate(millis: number): string {
   return new Date(millis).toLocaleDateString("en-US", { month: "short", day: "numeric" });
 }
 
+function formatMibQuota(usedMib: number, limitMib: number): string {
+  if (limitMib >= 1024 * 1024) {
+    return `${formatCompactQuantity(usedMib / 1024 / 1024)} / ${formatCompactQuantity(limitMib / 1024 / 1024)} TiB`;
+  }
+  if (limitMib >= 1024) {
+    return `${formatCompactQuantity(usedMib / 1024)} / ${formatCompactQuantity(limitMib / 1024)} GiB`;
+  }
+  return `${formatCompactQuantity(usedMib)} / ${formatCompactQuantity(limitMib)} MiB`;
+}
+
 type DeployProductCardProps = {
   isAdmin: boolean;
   hasPaymentMethod: boolean;
+  workspaceId: string;
   workspaceSlug: string;
   /** Open the plan picker on mount (post-checkout intent hand-off). */
   autoOpenPlanModal?: boolean;
@@ -42,6 +54,7 @@ type DeployProductCardProps = {
 export const DeployProductCard: React.FC<DeployProductCardProps> = ({
   isAdmin,
   hasPaymentMethod,
+  workspaceId,
   workspaceSlug,
   autoOpenPlanModal = false,
 }) => {
@@ -59,6 +72,22 @@ export const DeployProductCard: React.FC<DeployProductCardProps> = ({
   );
 
   const currentPlan = subscription?.plan ?? null;
+  const quotaIncreaseMailto = `mailto:support@unkey.com?subject=${encodeURIComponent(
+    "Compute quota increase request",
+  )}&body=${encodeURIComponent(`Hi Unkey Support,
+
+I'd like to request an increase to my Compute resource quotas.
+
+Workspace ID: ${workspaceId}
+
+Requested quota increases:
+- CPU:
+- Memory:
+- Disk:
+
+Reason and expected workload:
+
+`)}`;
 
   const { data: budget } = trpc.billing.getDeployBudget.useQuery(undefined, { staleTime: 30_000 });
   const suspended = budget?.suspended ?? false;
@@ -79,7 +108,6 @@ export const DeployProductCard: React.FC<DeployProductCardProps> = ({
   const { data: usage } = trpc.billing.queryDeployUsage.useQuery(undefined, {
     enabled: Boolean(currentPlan),
     staleTime: 30_000,
-    trpc: { context: { skipBatch: true } },
     retry: 1,
   });
 
@@ -238,6 +266,8 @@ export const DeployProductCard: React.FC<DeployProductCardProps> = ({
           },
         ]
       : null;
+
+  const allocatedResources = usage?.allocatedResources ?? null;
 
   const submittingPlan = isStartingCheckout
     ? pendingPlan
@@ -499,6 +529,81 @@ export const DeployProductCard: React.FC<DeployProductCardProps> = ({
               </div>
             ) : null}
             <SpendManagement usageCents={usageAmount} isAdmin={isAdmin} />
+            <div className="-mx-5 flex flex-col gap-4 border-grayA-3 border-t px-5 pt-4">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
+                <div className="flex flex-col gap-0.5">
+                  <span className="font-medium text-[13px] text-gray-12">Resource quotas</span>
+                  <span className="text-[12px] text-gray-10">
+                    Maximum resources all of your running deployments across this workspace can
+                    allocate at their autoscaling limits.{" "}
+                    <a
+                      href="https://unkey.com/docs/limits#calculate-workspace-allocation"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="font-medium text-gray-11 underline decoration-grayA-6 underline-offset-2 hover:text-gray-12 hover:decoration-grayA-8"
+                    >
+                      Learn how quotas are calculated.
+                    </a>
+                  </span>
+                </div>
+                <Button
+                  variant="outline"
+                  size="md"
+                  className="self-start sm:self-auto"
+                  render={<a href={quotaIncreaseMailto}>Request an increase</a>}
+                />
+              </div>
+              <div className="grid gap-4 sm:grid-cols-3">
+                <UsageMeter
+                  label="CPU allocated"
+                  value={
+                    allocatedResources
+                      ? `${formatCompactQuantity(allocatedResources.cpuMillicores / 1000)} / ${formatCompactQuantity(allocatedResources.cpuMillicoresLimit / 1000)} vCPU`
+                      : "—"
+                  }
+                  fraction={
+                    allocatedResources && allocatedResources.cpuMillicoresLimit > 0
+                      ? allocatedResources.cpuMillicores / allocatedResources.cpuMillicoresLimit
+                      : null
+                  }
+                  fillClassName="bg-orange-9"
+                />
+                <UsageMeter
+                  label="Memory allocated"
+                  value={
+                    allocatedResources
+                      ? formatMibQuota(
+                          allocatedResources.memoryMib,
+                          allocatedResources.memoryMibLimit,
+                        )
+                      : "—"
+                  }
+                  fraction={
+                    allocatedResources && allocatedResources.memoryMibLimit > 0
+                      ? allocatedResources.memoryMib / allocatedResources.memoryMibLimit
+                      : null
+                  }
+                  fillClassName="bg-orange-9"
+                />
+                <UsageMeter
+                  label="Disk allocated"
+                  value={
+                    allocatedResources
+                      ? formatMibQuota(
+                          allocatedResources.storageMib,
+                          allocatedResources.storageMibLimit,
+                        )
+                      : "—"
+                  }
+                  fraction={
+                    allocatedResources && allocatedResources.storageMibLimit > 0
+                      ? allocatedResources.storageMib / allocatedResources.storageMibLimit
+                      : null
+                  }
+                  fillClassName="bg-orange-9"
+                />
+              </div>
+            </div>
           </div>
         ) : null}
       </ProductCard>

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/deploy-billing-client.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/deploy-billing-client.tsx
@@ -149,6 +149,7 @@ export const DeployBillingClient: React.FC = () => {
         <DeployProductCard
           isAdmin={isAdmin}
           hasPaymentMethod={hasPaymentMethod}
+          workspaceId={workspace.id}
           workspaceSlug={workspace.slug}
           autoOpenPlanModal={checkoutIntent === "compute" && hasPaymentMethod}
         />

--- a/web/apps/dashboard/lib/trpc/routers/billing/query-deploy-usage/index.ts
+++ b/web/apps/dashboard/lib/trpc/routers/billing/query-deploy-usage/index.ts
@@ -1,5 +1,7 @@
 import { projectDeployUsage, sumDeployMeterCents } from "@/lib/billing/deployPricing";
 import { clickhouse } from "@/lib/clickhouse";
+import { and, db, eq, schema, sql } from "@/lib/db";
+import { freeTierQuotas } from "@/lib/quotas";
 import { ratelimit, withRatelimit, workspaceProcedure } from "@/lib/trpc/trpc";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
@@ -27,6 +29,14 @@ export const queryDeployUsageResponse = z.object({
    * display, not a billed figure.
    */
   projectedGrossCents: z.number(),
+  allocatedResources: z.object({
+    cpuMillicores: z.number(),
+    memoryMib: z.number(),
+    storageMib: z.number(),
+    cpuMillicoresLimit: z.number(),
+    memoryMibLimit: z.number(),
+    storageMibLimit: z.number(),
+  }),
 });
 
 export type DeployUsageResponse = z.infer<typeof queryDeployUsageResponse>;
@@ -47,7 +57,7 @@ export const queryDeployUsage = workspaceProcedure
     const monthEnd = Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1);
 
     try {
-      const [meters, keys, trailing] = await Promise.all([
+      const [meters, keys, trailing, quota, [allocatedResources]] = await Promise.all([
         clickhouse.billing.deployMeterUsage({
           workspaceId: ctx.workspace.id,
           start: monthStart,
@@ -66,6 +76,31 @@ export const queryDeployUsage = workspaceProcedure
           start: nowMs - TRAILING_WINDOW_MS,
           end: nowMs,
         }),
+        db.query.quotas.findFirst({
+          where: eq(schema.quotas.workspaceId, ctx.workspace.id),
+          columns: {
+            allocatedCpuMillicoresTotal: true,
+            allocatedMemoryMibTotal: true,
+            allocatedStorageMibTotal: true,
+          },
+        }),
+        db
+          .select({
+            cpuMillicores: sql<number>`cast(coalesce(sum(${schema.deployments.cpuMillicores} * ${schema.deploymentTopology.autoscalingReplicasMax}), 0) as signed)`,
+            memoryMib: sql<number>`cast(coalesce(sum(${schema.deployments.memoryMib} * ${schema.deploymentTopology.autoscalingReplicasMax}), 0) as signed)`,
+            storageMib: sql<number>`cast(coalesce(sum(${schema.deployments.storageMib} * ${schema.deploymentTopology.autoscalingReplicasMax}), 0) as signed)`,
+          })
+          .from(schema.deploymentTopology)
+          .innerJoin(
+            schema.deployments,
+            eq(schema.deployments.id, schema.deploymentTopology.deploymentId),
+          )
+          .where(
+            and(
+              eq(schema.deploymentTopology.workspaceId, ctx.workspace.id),
+              eq(schema.deploymentTopology.desiredStatus, "running"),
+            ),
+          ),
       ]);
 
       const monthToDate = {
@@ -90,6 +125,16 @@ export const queryDeployUsage = workspaceProcedure
         activeKeys: keys.activeKeys,
         grossCents: sumDeployMeterCents(monthToDate),
         projectedGrossCents: sumDeployMeterCents(projected),
+        allocatedResources: {
+          cpuMillicores: allocatedResources?.cpuMillicores ?? 0,
+          memoryMib: allocatedResources?.memoryMib ?? 0,
+          storageMib: allocatedResources?.storageMib ?? 0,
+          cpuMillicoresLimit:
+            quota?.allocatedCpuMillicoresTotal ?? freeTierQuotas.allocatedCpuMillicoresTotal,
+          memoryMibLimit: quota?.allocatedMemoryMibTotal ?? freeTierQuotas.allocatedMemoryMibTotal,
+          storageMibLimit:
+            quota?.allocatedStorageMibTotal ?? freeTierQuotas.allocatedStorageMibTotal,
+        },
       };
     } catch (err) {
       console.error("Failed to query deploy usage", err);


### PR DESCRIPTION
Adds a new section to the billing page to show the overall resource quota usage for your workspace.

<img width="2448" height="2156" alt="CleanShot 2026-07-31 at 12 17 04@2x" src="https://github.com/user-attachments/assets/f52fdb09-8572-4a89-9b87-a383ad5fc615" />


I'm working on the docs separately right now, do not merge this before the docs aren't merged, else the link goes to a 404