### PR TITLE
perf(dashboard): speed up billing page loads

### DIFF
--- a/pkg/clickhouse/schema/025_instance_checkpoints_v1.sql
+++ b/pkg/clickhouse/schema/025_instance_checkpoints_v1.sql
@@ -12,8 +12,9 @@
 --      agent was down: dropping the interval makes an outage under-count
 --      rather than over-charge. This applies to every meter below.
 --
--- Prefer the `instance_checkpoints` VIEW over this table directly — the view
--- already applies FINAL.
+-- Prefer the `instance_checkpoints` VIEW over this table directly. Ordered
+-- windows that rely on this table's sort key may query it with FINAL explicitly
+-- so the planner retains the physical ordering.
 --
 -- Every meter is summed over the in-gap pairs of one container_uid, so all
 -- four share the leadInFrame(...) OVER (PARTITION BY container_uid ORDER BY

--- a/pkg/clickhouse/schema/026_instance_checkpoints_view.sql
+++ b/pkg/clickhouse/schema/026_instance_checkpoints_view.sql
@@ -1,5 +1,6 @@
--- Regular view that applies FINAL once so callers can't forget it. Query
--- `instance_checkpoints` everywhere instead of `instance_checkpoints_v1 FINAL`.
+-- Regular view that applies FINAL once so callers can't forget it. Prefer
+-- `instance_checkpoints` unless an ordered window must preserve the physical
+-- table's sort metadata; those queries can use `instance_checkpoints_v1 FINAL`.
 --
 -- ClickHouse pushes simple WHERE filters through regular views, so:
 --   SELECT ... FROM instance_checkpoints WHERE ts BETWEEN ? AND ?

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/billing-summary.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/billing-summary.tsx
@@ -32,6 +32,7 @@ export const BillingSummary: React.FC<BillingSummaryProps> = ({
   const { data: invoice, isLoading } = trpc.stripe.getUpcomingInvoice.useQuery(undefined, {
     enabled: hasPaymentMethod,
     staleTime: 30_000,
+    trpc: { context: { skipBatch: true } },
   });
 
   // Dev-only: one-click seed a Stripe test customer + 4242 card so local runs

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/deploy-product-card.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/deploy-product-card.tsx
@@ -55,7 +55,10 @@ export const DeployProductCard: React.FC<DeployProductCardProps> = ({
     trpc.stripe.getDeploySubscription.useQuery(undefined, { staleTime: 30_000 });
   const { data: plansData, isLoading: plansLoading } = trpc.stripe.getDeployPlans.useQuery(
     undefined,
-    { staleTime: 60_000 },
+    {
+      staleTime: 60_000,
+      trpc: { context: { skipBatch: true } },
+    },
   );
 
   const currentPlan = subscription?.plan ?? null;
@@ -66,6 +69,7 @@ export const DeployProductCard: React.FC<DeployProductCardProps> = ({
   const { data: deployCredit } = trpc.stripe.getDeployCredit.useQuery(undefined, {
     enabled: Boolean(currentPlan),
     staleTime: 30_000,
+    trpc: { context: { skipBatch: true } },
   });
 
   // For the renewal date. The billing summary strip already fetches this, so on
@@ -73,6 +77,7 @@ export const DeployProductCard: React.FC<DeployProductCardProps> = ({
   const { data: upcomingInvoice } = trpc.stripe.getUpcomingInvoice.useQuery(undefined, {
     enabled: Boolean(currentPlan) && hasPaymentMethod,
     staleTime: 30_000,
+    trpc: { context: { skipBatch: true } },
   });
 
   // Usage is only worth fetching (and rendering) once there is a plan.

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/deploy-billing-client.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/deploy-billing-client.tsx
@@ -98,39 +98,12 @@ export const DeployBillingClient: React.FC = () => {
     data: billingInfo,
     isLoading: billingLoading,
     error: billingError,
-  } = trpc.stripe.getBillingInfo.useQuery(undefined, { staleTime: 30_000 });
+  } = trpc.stripe.getBillingInfo.useQuery(undefined, {
+    staleTime: 30_000,
+    trpc: { context: { skipBatch: true } },
+  });
 
-  // Error first: on a failed query tRPC returns isLoading=false, data=undefined,
-  // so a leading `billingLoading || !billingInfo` guard would catch the error
-  // case and render the loading skeleton forever instead of this branch.
-  if (billingError) {
-    return (
-      <Shell>
-        <Empty>
-          <Empty.Title>Failed to load billing information</Empty.Title>
-          <Empty.Description>
-            There was an error loading your billing information. Please try again later.
-          </Empty.Description>
-        </Empty>
-      </Shell>
-    );
-  }
-
-  if (billingLoading || !billingInfo) {
-    return (
-      <Shell>
-        <div className="animate-pulse">
-          <div className="flex w-full flex-col items-center gap-4 pt-4 pb-16">
-            <div className="h-[72px] w-full rounded-lg bg-grayA-3" />
-            <div className="h-[180px] w-full rounded-lg bg-grayA-3" />
-            <div className="h-[120px] w-full rounded-lg bg-grayA-3" />
-          </div>
-        </div>
-      </Shell>
-    );
-  }
-
-  const subscription = billingInfo.subscription;
+  const subscription = billingInfo?.subscription;
   const hasPaymentMethod = Boolean(workspace.stripeCustomerId);
 
   return (
@@ -153,15 +126,26 @@ export const DeployBillingClient: React.FC = () => {
           autoOpenPlanModal={checkoutIntent === "compute" && hasPaymentMethod}
         />
 
-        <ApiAddOnCard
-          isAdmin={isAdmin}
-          hasPaymentMethod={hasPaymentMethod}
-          workspaceSlug={workspace.slug}
-          products={billingInfo.products}
-          subscription={subscription}
-          currentProductId={billingInfo.currentProductId}
-          autoOpenPlanModal={checkoutIntent === "api" && hasPaymentMethod}
-        />
+        {billingError ? (
+          <Empty>
+            <Empty.Title>Failed to load API billing information</Empty.Title>
+            <Empty.Description>
+              There was an error loading your API billing information. Please try again later.
+            </Empty.Description>
+          </Empty>
+        ) : billingLoading || !billingInfo ? (
+          <div className="h-[120px] w-full animate-pulse rounded-lg bg-grayA-3" />
+        ) : (
+          <ApiAddOnCard
+            isAdmin={isAdmin}
+            hasPaymentMethod={hasPaymentMethod}
+            workspaceSlug={workspace.slug}
+            products={billingInfo.products}
+            subscription={subscription}
+            currentProductId={billingInfo.currentProductId}
+            autoOpenPlanModal={checkoutIntent === "api" && hasPaymentMethod}
+          />
+        )}
       </div>
     </Shell>
   );

--- a/web/apps/dashboard/lib/stripe/deployBilling.test.ts
+++ b/web/apps/dashboard/lib/stripe/deployBilling.test.ts
@@ -23,6 +23,7 @@ type StripeEnv = NonNullable<ReturnType<typeof stripeEnv>>;
 // lookup_key -> resolved active price id, the mapping Stripe would return.
 const ID: Record<string, string> = {
   lk_starter: "price_starter",
+  lk_starter_concurrent: "price_starter_concurrent",
   lk_pro: "price_pro",
   lk_business: "price_business",
   lk_cpu: "price_cpu",
@@ -52,14 +53,14 @@ function envWith(overrides: Partial<StripeEnv> = {}): StripeEnv {
 
 // Stripe whose prices.list returns the active price for each known lookup_key.
 function stubStripe() {
+  const list = vi.fn(async ({ lookup_keys }: { lookup_keys: string[] }) => ({
+    data: lookup_keys.filter((k) => ID[k]).map((k) => ({ id: ID[k], lookup_key: k })),
+  }));
   mockedGetStripeClient.mockReturnValue({
-    prices: {
-      list: vi.fn(async ({ lookup_keys }: { lookup_keys: string[] }) => ({
-        data: lookup_keys.filter((k) => ID[k]).map((k) => ({ id: ID[k], lookup_key: k })),
-      })),
-    },
+    prices: { list },
     // Test double; only prices.list is exercised here.
   } as unknown as ReturnType<typeof getStripeClient>);
+  return list;
 }
 
 const CONFIG: DeployBillingConfig = {
@@ -82,10 +83,12 @@ function item(id: string, priceId: string) {
 }
 
 describe("deployBillingConfig", () => {
+  let listPrices: ReturnType<typeof stubStripe>;
+
   beforeEach(() => {
     mockedStripeEnv.mockReset();
     mockedGetStripeClient.mockReset();
-    stubStripe();
+    listPrices = stubStripe();
   });
 
   it("resolves lookup_keys to active price ids when fully configured", async () => {
@@ -128,6 +131,23 @@ describe("deployBillingConfig", () => {
       envWith({ STRIPE_LOOKUP_DEPLOY_BUSINESS: "lk_business_archived" }),
     );
     expect(await deployBillingConfig()).toBeNull();
+  });
+
+  it("coalesces concurrent Stripe catalog resolutions", async () => {
+    // Use a distinct key so this test cannot hit the module's successful cache.
+    mockedStripeEnv.mockReturnValue(
+      envWith({ STRIPE_LOOKUP_DEPLOY_STARTER: "lk_starter_concurrent" }),
+    );
+
+    const [first, second, third] = await Promise.all([
+      deployBillingConfig(),
+      deployBillingConfig(),
+      deployBillingConfig(),
+    ]);
+
+    expect(listPrices).toHaveBeenCalledTimes(1);
+    expect(first).toBe(second);
+    expect(second).toBe(third);
   });
 });
 

--- a/web/apps/dashboard/lib/stripe/deployBilling.ts
+++ b/web/apps/dashboard/lib/stripe/deployBilling.ts
@@ -21,6 +21,7 @@ export type DeployBillingConfig = {
 // request, short enough to pick up a reprice without a redeploy.
 const RESOLUTION_TTL_MS = 5 * 60 * 1000;
 let cache: { key: string; expiresAt: number; config: DeployBillingConfig } | null = null;
+let pending: { key: string; promise: Promise<DeployBillingConfig | null> } | null = null;
 
 /**
  * Whether every Deploy lookup_key env var is set. deployBillingConfig() returns
@@ -90,44 +91,62 @@ export async function deployBillingConfig(): Promise<DeployBillingConfig | null>
   if (cache && cache.key === cacheKey && cache.expiresAt > now) {
     return cache.config;
   }
-
-  // One list call: <=10 lookup_keys, one active price each, so no paging.
-  const stripe = getStripeClient();
-  const prices = await stripe.prices.list({ lookup_keys: allLookupKeys, active: true, limit: 100 });
-  const idByLookupKey = new Map<string, string>();
-  for (const price of prices.data) {
-    if (price.lookup_key) {
-      idByLookupKey.set(price.lookup_key, price.id);
-    }
+  if (pending?.key === cacheKey) {
+    return pending.promise;
   }
 
-  // Every declared lookup_key must resolve to an active price, else the set is
-  // incomplete: treat it as unconfigured rather than attach a partial sub.
-  const planFeeEntries: Array<[DeployPlan, string]> = [];
-  for (const plan of DEPLOY_PLANS) {
-    const id = idByLookupKey.get(planFee[plan]);
-    if (!id) {
-      return null;
+  const promise = (async (): Promise<DeployBillingConfig | null> => {
+    // One list call: <=10 lookup_keys, one active price each, so no paging.
+    const stripe = getStripeClient();
+    const prices = await stripe.prices.list({
+      lookup_keys: allLookupKeys,
+      active: true,
+      limit: 100,
+    });
+    const idByLookupKey = new Map<string, string>();
+    for (const price of prices.data) {
+      if (price.lookup_key) {
+        idByLookupKey.set(price.lookup_key, price.id);
+      }
     }
-    planFeeEntries.push([plan, id]);
-  }
-  const meteredPriceIds: string[] = [];
-  for (const key of meters) {
-    const id = idByLookupKey.get(key);
-    if (!id) {
-      return null;
-    }
-    meteredPriceIds.push(id);
-  }
-  const planFeePriceIds = Object.fromEntries(planFeeEntries) as Record<DeployPlan, string>;
 
-  const config: DeployBillingConfig = {
-    planFeePriceIds,
-    meteredPriceIds,
-    allDeployPriceIds: new Set<string>([...Object.values(planFeePriceIds), ...meteredPriceIds]),
-  };
-  cache = { key: cacheKey, expiresAt: now + RESOLUTION_TTL_MS, config };
-  return config;
+    // Every declared lookup_key must resolve to an active price, else the set is
+    // incomplete: treat it as unconfigured rather than attach a partial sub.
+    const planFeeEntries: Array<[DeployPlan, string]> = [];
+    for (const plan of DEPLOY_PLANS) {
+      const id = idByLookupKey.get(planFee[plan]);
+      if (!id) {
+        return null;
+      }
+      planFeeEntries.push([plan, id]);
+    }
+    const meteredPriceIds: string[] = [];
+    for (const key of meters) {
+      const id = idByLookupKey.get(key);
+      if (!id) {
+        return null;
+      }
+      meteredPriceIds.push(id);
+    }
+    const planFeePriceIds = Object.fromEntries(planFeeEntries) as Record<DeployPlan, string>;
+
+    const config: DeployBillingConfig = {
+      planFeePriceIds,
+      meteredPriceIds,
+      allDeployPriceIds: new Set<string>([...Object.values(planFeePriceIds), ...meteredPriceIds]),
+    };
+    cache = { key: cacheKey, expiresAt: Date.now() + RESOLUTION_TTL_MS, config };
+    return config;
+  })();
+  pending = { key: cacheKey, promise };
+
+  try {
+    return await promise;
+  } finally {
+    if (pending?.promise === promise) {
+      pending = null;
+    }
+  }
 }
 
 /**

--- a/web/apps/dashboard/lib/trpc/routers/billing/query-deploy-usage/index.ts
+++ b/web/apps/dashboard/lib/trpc/routers/billing/query-deploy-usage/index.ts
@@ -47,10 +47,11 @@ export const queryDeployUsage = workspaceProcedure
     const monthEnd = Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1);
 
     try {
-      const [meters, keys, trailing] = await Promise.all([
+      const [meters, keys] = await Promise.all([
         clickhouse.billing.deployMeterUsage({
           workspaceId: ctx.workspace.id,
-          start: monthStart,
+          periodStart: monthStart,
+          trailingStart: nowMs - TRAILING_WINDOW_MS,
           end: nowMs,
         }),
         clickhouse.billing.activeKeysUsage({
@@ -58,13 +59,6 @@ export const queryDeployUsage = workspaceProcedure
           year: now.getUTCFullYear(),
           // getUTCMonth is 0-based; the query takes a calendar month.
           month: now.getUTCMonth() + 1,
-        }),
-        // Trailing window for the projection's run-rate; may reach into last
-        // month early in the period, which is fine, it's just a rate estimate.
-        clickhouse.billing.deployMeterUsage({
-          workspaceId: ctx.workspace.id,
-          start: nowMs - TRAILING_WINDOW_MS,
-          end: nowMs,
         }),
       ]);
 
@@ -74,6 +68,12 @@ export const queryDeployUsage = workspaceProcedure
         diskGiBHours: meters.diskGiBHours,
         egressGiB: meters.egressGiB,
         activeKeys: keys.activeKeys,
+      };
+      const trailing = {
+        cpuSeconds: meters.trailingCpuSeconds,
+        memoryGiBHours: meters.trailingMemoryGiBHours,
+        diskGiBHours: meters.trailingDiskGiBHours,
+        egressGiB: meters.trailingEgressGiB,
       };
 
       const projected = projectDeployUsage(
@@ -86,7 +86,10 @@ export const queryDeployUsage = workspaceProcedure
       // Priced per meter and rounded per line, the way the invoice is built, so
       // the card's estimate matches what Stripe charges. See sumDeployMeterCents.
       return {
-        ...meters,
+        cpuSeconds: meters.cpuSeconds,
+        memoryGiBHours: meters.memoryGiBHours,
+        diskGiBHours: meters.diskGiBHours,
+        egressGiB: meters.egressGiB,
         activeKeys: keys.activeKeys,
         grossCents: sumDeployMeterCents(monthToDate),
         projectedGrossCents: sumDeployMeterCents(projected),

--- a/web/apps/dashboard/lib/trpc/routers/stripe/getBillingInfo.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/getBillingInfo.ts
@@ -45,57 +45,68 @@ export const getBillingInfo = workspaceProcedure
       });
     }
 
-    const [subscription, hasPreviousSubscriptions, config] = await Promise.all([
-      ctx.workspace.stripeSubscriptionId
-        ? // A stale recorded subscription id (cancelled and pruned from Stripe,
-          // A stale id (lost deleted-webhook) 404s; treat as no subscription
-          // instead of breaking the billing page. Anything else propagates.
-          stripe.subscriptions
-            .retrieve(ctx.workspace.stripeSubscriptionId)
-            .catch((err: unknown) => {
-              if (err instanceof Stripe.errors.StripeError && err.code === "resource_missing") {
-                return undefined;
-              }
-              throw err;
-            })
-        : undefined,
+    const subscriptionPromise = ctx.workspace.stripeSubscriptionId
+      ? // A stale recorded subscription id (cancelled and pruned from Stripe,
+        // A stale id (lost deleted-webhook) 404s; treat as no subscription
+        // instead of breaking the billing page. Anything else propagates.
+        stripe.subscriptions
+          .retrieve(ctx.workspace.stripeSubscriptionId)
+          .catch((err: unknown) => {
+            if (err instanceof Stripe.errors.StripeError && err.code === "resource_missing") {
+              return undefined;
+            }
+            throw err;
+          })
+      : Promise.resolve(undefined);
 
-      ctx.workspace.stripeCustomerId
-        ? await stripe.subscriptions
-            .list({
-              customer: ctx.workspace.stripeCustomerId,
-              status: "canceled",
-            })
-            .then((res) => res.data.length > 0)
-        : false,
+    const configPromise = ctx.workspace.stripeSubscriptionId
+      ? deployBillingConfig()
+      : Promise.resolve(null);
+    const subscriptionStatePromise = Promise.all([subscriptionPromise, configPromise]).then(
+      ([subscription, config]) => {
+        // Resolve the API plan item specifically, skipping any Deploy price the
+        // subscription might carry; product via the item's price.
+        const apiItem = subscription ? findApiItem(config, subscription.items.data) : undefined;
+        const apiProduct = apiItem?.price.product;
+        const currentProductId = typeof apiProduct === "string" ? apiProduct : apiProduct?.id;
+        return { subscription, currentProductId };
+      },
+    );
 
-      deployBillingConfig(),
-    ]);
+    const hasPreviousSubscriptionsPromise = ctx.workspace.stripeCustomerId
+      ? stripe.subscriptions
+          .list({
+            customer: ctx.workspace.stripeCustomerId,
+            status: "canceled",
+          })
+          .then((res) => res.data.length > 0)
+      : Promise.resolve(false);
 
-    // Resolve the API plan item specifically, skipping any Deploy price the
-    // subscription might carry; product via the item's price.
-    const apiItem = subscription ? findApiItem(config, subscription.items.data) : undefined;
-    const apiProduct = apiItem?.price.product;
-    const currentProductId = typeof apiProduct === "string" ? apiProduct : apiProduct?.id;
+    const productsPromise = subscriptionStatePromise.then(({ currentProductId }) => {
+      const enterpriseProductId =
+        currentProductId && e.STRIPE_PRODUCT_IDS_ENTERPRISE.includes(currentProductId)
+          ? currentProductId
+          : undefined;
+      const productIds = enterpriseProductId
+        ? [...e.STRIPE_PRODUCT_IDS_PRO, enterpriseProductId]
+        : e.STRIPE_PRODUCT_IDS_PRO;
 
-    // Check if user has an active enterprise subscription
-    let enterpriseProductId: string | undefined;
-    if (currentProductId && e.STRIPE_PRODUCT_IDS_ENTERPRISE.includes(currentProductId)) {
-      enterpriseProductId = currentProductId;
-    }
+      return stripe.products
+        .list({
+          active: true,
+          ids: productIds,
+          limit: 100,
+          expand: ["data.default_price"],
+        })
+        .then((res) => res.data.map(mapProduct).sort((a, b) => a.dollar - b.dollar));
+    });
 
-    const productIds = enterpriseProductId
-      ? [...e.STRIPE_PRODUCT_IDS_PRO, enterpriseProductId]
-      : e.STRIPE_PRODUCT_IDS_PRO;
-
-    const products = await stripe.products
-      .list({
-        active: true,
-        ids: productIds,
-        limit: 100,
-        expand: ["data.default_price"],
-      })
-      .then((res) => res.data.map(mapProduct).sort((a, b) => a.dollar - b.dollar));
+    const [{ subscription, currentProductId }, hasPreviousSubscriptions, products] =
+      await Promise.all([
+        subscriptionStatePromise,
+        hasPreviousSubscriptionsPromise,
+        productsPromise,
+      ]);
 
     return {
       products,

--- a/web/apps/dashboard/lib/trpc/routers/stripe/getUpcomingInvoice.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/getUpcomingInvoice.ts
@@ -43,7 +43,6 @@ export const getUpcomingInvoice = workspaceProcedure
     const customerId = ctx.workspace.stripeCustomerId;
 
     const stripe = getStripeClient();
-    const config = await deployBillingConfig();
 
     // Stripe throws when there is no upcoming invoice (e.g. the subscription is
     // fully canceled). That's an empty state, not an error.
@@ -61,7 +60,8 @@ export const getUpcomingInvoice = workspaceProcedure
       }
     };
 
-    const [apiInvoice, deployInvoice] = await Promise.all([
+    const [config, apiInvoice, deployInvoice] = await Promise.all([
+      ctx.workspace.stripeDeploySubscriptionId ? deployBillingConfig() : null,
       ctx.workspace.stripeSubscriptionId ? preview(ctx.workspace.stripeSubscriptionId) : null,
       ctx.workspace.stripeDeploySubscriptionId
         ? preview(ctx.workspace.stripeDeploySubscriptionId)

--- a/web/internal/clickhouse/src/deploy_billing.ts
+++ b/web/internal/clickhouse/src/deploy_billing.ts
@@ -14,6 +14,10 @@ export const deployMeterUsage = z.object({
   memoryGiBHours: z.number(),
   diskGiBHours: z.number(),
   egressGiB: z.number(),
+  trailingCpuSeconds: z.number(),
+  trailingMemoryGiBHours: z.number(),
+  trailingDiskGiBHours: z.number(),
+  trailingEgressGiB: z.number(),
 });
 
 export type DeployMeterUsage = z.infer<typeof deployMeterUsage>;
@@ -22,26 +26,34 @@ export type DeployMeterUsage = z.infer<typeof deployMeterUsage>;
  * Workspace-level billable Deploy usage for a time window, summed across all
  * resources: the same checkpoint-pair aggregation the hourly billing push in
  * svc/ctrl runs (pkg/clickhouse GetInstanceMeterUsage), so the dashboard shows
- * the numbers that are actually billed. Display-only; Stripe meter events
- * remain the billing write path.
+ * the numbers that are actually billed. The trailing window is aggregated from
+ * the same checkpoint scan so projecting usage does not reread the raw table.
+ * Display-only; Stripe meter events remain the billing write path.
  */
 export function getDeployMeterUsage(ch: Querier) {
   return async (args: {
     workspaceId: string;
-    /** Inclusive lower bound, unix millis. */
-    start: number;
+    /** Inclusive lower bound of the billing period, unix millis. */
+    periodStart: number;
+    /** Inclusive lower bound of the projection window, unix millis. */
+    trailingStart: number;
     /** Exclusive upper bound, unix millis. */
     end: number;
   }): Promise<DeployMeterUsage> => {
     const query = ch.query({
       query: `
     SELECT
-      sum(cpu_usec_delta) / 1e6 AS cpuSeconds,
-      sum(memory_byte_ms) / 1000 / 3600 / pow(1024, 3) AS memoryGiBHours,
-      sum(disk_byte_ms) / 1000 / 3600 / pow(1024, 3) AS diskGiBHours,
-      sum(egress_bytes_delta) / pow(1024, 3) AS egressGiB
+      sumIf(cpu_usec_delta, ts >= {periodStart: Int64}) / 1e6 AS cpuSeconds,
+      sumIf(memory_byte_ms, ts >= {periodStart: Int64}) / 1000 / 3600 / pow(1024, 3) AS memoryGiBHours,
+      sumIf(disk_byte_ms, ts >= {periodStart: Int64}) / 1000 / 3600 / pow(1024, 3) AS diskGiBHours,
+      sumIf(egress_bytes_delta, ts >= {periodStart: Int64}) / pow(1024, 3) AS egressGiB,
+      sumIf(cpu_usec_delta, ts >= {trailingStart: Int64}) / 1e6 AS trailingCpuSeconds,
+      sumIf(memory_byte_ms, ts >= {trailingStart: Int64}) / 1000 / 3600 / pow(1024, 3) AS trailingMemoryGiBHours,
+      sumIf(disk_byte_ms, ts >= {trailingStart: Int64}) / 1000 / 3600 / pow(1024, 3) AS trailingDiskGiBHours,
+      sumIf(egress_bytes_delta, ts >= {trailingStart: Int64}) / pow(1024, 3) AS trailingEgressGiB
     FROM (
       SELECT
+        ts,
         leadInFrame(ts) OVER w - ts AS dt,
         greatest(0, leadInFrame(cpu_usage_usec) OVER w - cpu_usage_usec) AS cpu_usec_delta,
         if(
@@ -52,8 +64,8 @@ export function getDeployMeterUsage(ch: Querier) {
         ) AS egress_bytes_delta,
         toFloat64(least(memory_bytes, leadInFrame(memory_bytes) OVER w)) * toFloat64(leadInFrame(ts) OVER w - ts) AS memory_byte_ms,
         toFloat64(least(disk_allocated_bytes, leadInFrame(disk_allocated_bytes) OVER w)) * toFloat64(leadInFrame(ts) OVER w - ts) AS disk_byte_ms
-      FROM default.instance_checkpoints
-      WHERE ts >= {start: Int64}
+      FROM default.instance_checkpoints_v1 FINAL
+      WHERE ts >= {scanStart: Int64}
         AND ts < {end: Int64}
         AND workspace_id = {workspaceId: String}
       WINDOW w AS (
@@ -67,14 +79,20 @@ export function getDeployMeterUsage(ch: Querier) {
     `,
       params: z.object({
         workspaceId: z.string(),
-        start: z.int(),
+        scanStart: z.int(),
+        periodStart: z.int(),
+        trailingStart: z.int(),
         end: z.int(),
         maxGapMs: z.int(),
       }),
       schema: deployMeterUsage,
     });
 
-    const res = await query({ ...args, maxGapMs: MAX_SAMPLE_GAP_MS });
+    const res = await query({
+      ...args,
+      scanStart: Math.min(args.periodStart, args.trailingStart),
+      maxGapMs: MAX_SAMPLE_GAP_MS,
+    });
     if (res.err) {
       throw new Error(`Failed to query deploy meter usage: ${res.err.message}`);
     }
@@ -84,6 +102,10 @@ export function getDeployMeterUsage(ch: Querier) {
         memoryGiBHours: 0,
         diskGiBHours: 0,
         egressGiB: 0,
+        trailingCpuSeconds: 0,
+        trailingMemoryGiBHours: 0,
+        trailingDiskGiBHours: 0,
+        trailingEgressGiB: 0,
       }
     );
   };


### PR DESCRIPTION
## What does this PR do?

Fixes the billing page's usage-query regression and removes unrelated request waterfalls:

- computes month-to-date and trailing Compute usage in one ClickHouse checkpoint scan instead of rereading the raw table
- queries `instance_checkpoints_v1 FINAL` directly so the ordered window can retain the physical table sort metadata
- starts independent Stripe subscription, catalog, billing-config, and invoice reads concurrently
- isolates slow external reads from tRPC batches and renders Compute billing without waiting for API billing
- coalesces concurrent Deploy billing-config resolution into one Stripe request

No linked issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

- `mise exec -- pnpm --dir=web --filter @unkey/dashboard typecheck`
- `mise exec -- pnpm --dir=web --filter @unkey/dashboard exec vitest run lib/stripe/deployBilling.test.ts`
- Load a workspace billing page with a Compute plan and confirm the invoice, Compute usage, and API sections load independently.

The dashboard test run passed 68 files / 689 tests. The focused billing-config suite passed 16 tests after adding the single-flight regression case.

### ClickHouse query benchmark

Tested on ClickHouse 25.6.4 using the production table/view DDL and a seeded dataset of 10,368,000 checkpoints: 20 containers sampled every 15 seconds over 90 days. The table had 91 active daily parts after `OPTIMIZE ... FINAL`. The billing query correctly limited its scan to the month-to-date and trailing seven-day windows.

Seven measured runs followed one warmup run per variant, with execution order rotated between runs. The original month-to-date and trailing queries ran concurrently, matching the old `Promise.all` call path. Server metrics are medians from `system.query_log`.

| Variant | Median wall time | Server query time | Read rows | Read bytes | Peak memory |
| --- | ---: | ---: | ---: | ---: | ---: |
| Original: two view-backed queries | 1,477 ms | 1,687 ms combined | 6.55M | 603.01 MiB | 541.10 + 145.31 MiB |
| Consolidated, still through view | 1,420 ms | 1,262 ms | 5.26M | 484.12 MiB | 540.81 MiB |
| Consolidated, direct table `FINAL` (this PR) | **1,200 ms** | **1,035 ms** | **5.26M** | **443.99 MiB** | **474.36 MiB** |

Compared with the original concurrent pair, the PR query reduced median wall time by 19%, combined server query time by 39%, rows read by 20%, and bytes read by 26%. All three variants returned exactly equal meter totals.

`EXPLAIN PIPELINE` showed why bypassing the view matters for this ordered window: the view-backed form includes `PartialSortingTransform` and `FinishSortingTransform`; direct `instance_checkpoints_v1 FINAL` avoids both. Both forms still use `MergingSortedTransform` to combine ordered streams.

Limitation: generated values repeat and compress unusually well (4.25 MiB on disk), and measured runs used a warm local cache. This exercises millions of rows, the production partitioning/`FINAL` behavior, window processing, and planner shape, but it does not model production object-storage latency or by itself explain the full observed 12-second page load.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `mise run fmt`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary
