### PR TITLE
Fix api context build

### DIFF
--- a/docs/product/platform/apps/settings.mdx
+++ b/docs/product/platform/apps/settings.mdx
@@ -27,6 +27,21 @@ The directory your application is built from. It is the directory Unkey [analyze
 
 Set this when your application lives in a subdirectory, for example `services/api`.
 
+The root directory must be relative to the repository root. Use `.` for the repository root, or enter a slash-separated directory such as `api` or `services/api`. Don't start the path with `/` or `./`, and don't end it with `/`.
+
+Each directory name can contain letters, digits, periods (`.`), underscores (`_`), and hyphens (`-`). Empty directory names, `.` segments, `..` segments, whitespace, backslashes, and other characters aren't supported.
+
+| Value             | Valid | Reason                                 |
+| ----------------- | ----- | -------------------------------------- |
+| `.`               | Yes   | Selects the repository root            |
+| `api`             | Yes   | Selects a top-level directory          |
+| `services/api`    | Yes   | Selects a nested directory             |
+| `/api`            | No    | Starts with `/`                        |
+| `./api`           | No    | Starts with `./`                       |
+| `services/api/`   | No    | Ends with `/`                          |
+| `services/../api` | No    | Contains a `..` path traversal segment |
+| `services/api v2` | No    | Contains whitespace                    |
+
 ### Dockerfile
 
 By default this is set to **Automatic (no Dockerfile)**: Unkey detects your language and [builds the image for you](/builds/overview). Configure a path only when you want [full control over the image with a Dockerfile](/builds/dockerfile).

--- a/svc/api/routes/v2_environments_update_settings/200_test.go
+++ b/svc/api/routes/v2_environments_update_settings/200_test.go
@@ -40,7 +40,7 @@ func TestUpdateSettingsSuccessfully(t *testing.T) {
 			App:           env.appID,
 			Environment:   env.environmentID,
 			Dockerfile:    nullable.NewNullableWithValue("Dockerfile.prod"),
-			RootDirectory: ptr("./app"),
+			RootDirectory: ptr("app"),
 			WatchPaths:    ptr([]string{"src/**"}),
 			AutoDeploy:    ptr(false),
 		})
@@ -51,7 +51,7 @@ func TestUpdateSettingsSuccessfully(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, got.Dockerfile.Valid)
 		require.Equal(t, "Dockerfile.prod", got.Dockerfile.String)
-		require.Equal(t, "./app", got.DockerContext)
+		require.Equal(t, "app", got.DockerContext)
 		require.Equal(t, []string{"src/**"}, []string(got.WatchPaths))
 		require.False(t, got.AutoDeploy)
 	})

--- a/svc/api/routes/v2_environments_update_settings/400_test.go
+++ b/svc/api/routes/v2_environments_update_settings/400_test.go
@@ -53,10 +53,14 @@ func TestUpdateSettings400(t *testing.T) {
 		{name: "memory off step", req: handler.Request{MemoryMib: ptr(1000)}},
 		{name: "storage off step", req: handler.Request{StorageMib: ptr(1000)}},
 
-		// Path patterns (spec). dockerfile/rootDirectory are unconstrained strings;
-		// only openapiSpecPath and the healthcheck path are guarded.
+		// Path validation. Dockerfile is constrained by the spec; rootDirectory is
+		// additionally checked by the handler against the control-plane contract.
 		{name: "dockerfile empty", req: handler.Request{Dockerfile: nullable.NewNullableWithValue("")}},
 		{name: "rootDirectory empty", req: handler.Request{RootDirectory: ptr("")}},
+		{name: "rootDirectory absolute", req: handler.Request{RootDirectory: ptr("/api")}},
+		{name: "rootDirectory dot prefix", req: handler.Request{RootDirectory: ptr("./api")}},
+		{name: "rootDirectory traversal", req: handler.Request{RootDirectory: ptr("services/../api")}},
+		{name: "rootDirectory fragment", req: handler.Request{RootDirectory: ptr("services/api#main")}},
 		{name: "buildCommand empty", req: handler.Request{BuildCommand: nullable.NewNullableWithValue("")}},
 		{name: "buildCommand over maxLength", req: handler.Request{BuildCommand: nullable.NewNullableWithValue(strings.Repeat("x", 1001))}},
 		{name: "openapiSpecPath no slash", req: handler.Request{OpenapiSpecPath: nullable.NewNullableWithValue("openapi.yaml")}},

--- a/svc/api/routes/v2_environments_update_settings/handler.go
+++ b/svc/api/routes/v2_environments_update_settings/handler.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"math"
 	"net/http"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/unkeyed/unkey/internal/services/auditlogs"
@@ -34,6 +36,9 @@ const platform = "aws"
 const cpuThreshold = 80
 
 const minReplicasPerRegion = 1
+
+// dockerContextSegmentRegex allows only portable repository path segment characters.
+var dockerContextSegmentRegex = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
 
 type Handler struct {
 	DB          db.Database
@@ -259,6 +264,14 @@ func (h *Handler) applyBuildSettings(ctx context.Context, tx db.DBTX, workspaceI
 		}
 	}
 	if req.RootDirectory != nil {
+		if !isValidDockerContext(*req.RootDirectory) {
+			return fault.New(
+				"invalid root directory",
+				fault.Code(codes.App.Validation.InvalidInput.URN()),
+				fault.Internal("root directory is not a valid repository-relative path"),
+				fault.Public("Root directory must be a relative path like 'api' or 'services/api'."),
+			)
+		}
 		params.DockerContextSpecified = 1
 		params.DockerContext = *req.RootDirectory
 	}
@@ -286,6 +299,24 @@ func (h *Handler) applyBuildSettings(ctx context.Context, tx db.DBTX, workspaceI
 		)
 	}
 	return nil
+}
+
+func isValidDockerContext(path string) bool {
+	if path != strings.TrimSpace(path) {
+		return false
+	}
+	if path == "." {
+		return true
+	}
+	if path == "" || strings.HasPrefix(path, "/") || strings.Contains(path, `\`) {
+		return false
+	}
+	for _, segment := range strings.Split(path, "/") {
+		if segment == "." || segment == ".." || !dockerContextSegmentRegex.MatchString(segment) {
+			return false
+		}
+	}
+	return true
 }
 
 func (h *Handler) applyRuntimeSettings(ctx context.Context, tx db.DBTX, workspaceID, appID, environmentID string, req Request, now int64) error {

--- a/svc/ctrl/worker/deploy/build_test.go
+++ b/svc/ctrl/worker/deploy/build_test.go
@@ -159,6 +159,11 @@ func TestValidateGitBuildParams(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:    "context path dot prefix",
+			params:  gitBuildParams{Repository: "acme/app", CommitSHA: "deadbeef", ContextPath: "./services/api"},
+			wantErr: true,
+		},
+		{
 			name:    "context path with url fragment",
 			params:  gitBuildParams{Repository: "acme/app", CommitSHA: "deadbeef", ContextPath: "services/api#main"},
 			wantErr: true,

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/settings/components/build-settings/root-directory-settings.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/settings/components/build-settings/root-directory-settings.tsx
@@ -9,8 +9,26 @@ import { SettingField } from "../shared/form-blocks";
 import { FormSettingCard, resolveSaveState } from "../shared/form-setting-card";
 import { useRepoTree } from "./use-repo-tree";
 
+const dockerContextSegment = /^[A-Za-z0-9._-]+$/;
+
 const rootDirectorySchema = z.object({
-  dockerContext: z.string(),
+  dockerContext: z
+    .string()
+    .min(1, "Enter a root directory or use '.' for the repository root.")
+    .refine(
+      (path) =>
+        path === "." ||
+        (path === path.trim() &&
+          !path.startsWith("/") &&
+          !path.includes("\\") &&
+          path
+            .split("/")
+            .every(
+              (segment) =>
+                segment !== "." && segment !== ".." && dockerContextSegment.test(segment),
+            )),
+      "Enter a relative path like 'api' or 'services/api'. Do not start with '/' or './'.",
+    ),
 });
 
 export const RootDirectory = () => {

--- a/web/apps/dashboard/lib/trpc/routers/deploy/environment-settings/build/update-docker-context.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/environment-settings/build/update-docker-context.ts
@@ -4,11 +4,30 @@ import { appBuildSettings, environments } from "@unkey/db/src/schema";
 import { z } from "zod";
 import { workspaceProcedure } from "../../../../trpc";
 
+const dockerContextSegment = /^[A-Za-z0-9._-]+$/;
+
+const dockerContextSchema = z
+  .string()
+  .min(1)
+  .refine(
+    (path) =>
+      path === "." ||
+      (path === path.trim() &&
+        !path.startsWith("/") &&
+        !path.includes("\\") &&
+        path
+          .split("/")
+          .every(
+            (segment) => segment !== "." && segment !== ".." && dockerContextSegment.test(segment),
+          )),
+    "Docker context must be a repository-relative path like 'api' or 'services/api'.",
+  );
+
 export const updateDockerContext = workspaceProcedure
   .input(
     z.object({
       environmentId: z.string(),
-      dockerContext: z.string(),
+      dockerContext: dockerContextSchema,
     }),
   )
   .mutation(async ({ ctx, input }) => {


### PR DESCRIPTION
docker buildkit is quite sensitive to what context paths it understands. Paths can't be prefixed with `/` or `./` for example.

This just adds more validation and docs, so that users configure it correctly.

I'm not too concerned about the duplication in the dashboard and trpc, cause trpc will be removed soon anyways.

___


I found a few configs in the db that use a leading `/` and I'll just fix those manually.