### PR TITLE
fix(dashboard): restore sticky secondary navigation

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/layout.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/layout.tsx
@@ -22,20 +22,22 @@ export default function SettingsLayout({ children }: { children: ReactNode }) {
 
   return (
     <div className="flex flex-col md:flex-row w-full flex-1 min-h-0">
-      <SecondaryNav aria-label="Settings">
-        <SecondaryNavTitle>Settings</SecondaryNavTitle>
-        <SecondaryNavGroup>
-          {ITEMS.map((item) => (
-            <SecondaryNavItem
-              key={item.segment}
-              active={active === item.segment}
-              render={<Link href={item.getHref({ workspaceSlug: workspace.slug })} />}
-            >
-              {item.label}
-            </SecondaryNavItem>
-          ))}
-        </SecondaryNavGroup>
-      </SecondaryNav>
+      <div className="shrink-0 md:w-60 md:border-r md:border-grayA-4">
+        <SecondaryNav aria-label="Settings" className="md:sticky md:top-0 md:w-full md:border-r-0">
+          <SecondaryNavTitle>Settings</SecondaryNavTitle>
+          <SecondaryNavGroup>
+            {ITEMS.map((item) => (
+              <SecondaryNavItem
+                key={item.segment}
+                active={active === item.segment}
+                render={<Link href={item.getHref({ workspaceSlug: workspace.slug })} />}
+              >
+                {item.label}
+              </SecondaryNavItem>
+            ))}
+          </SecondaryNavGroup>
+        </SecondaryNav>
+      </div>
       <div className="flex-1 min-w-0">{children}</div>
     </div>
   );

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/layout.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/layout.tsx
@@ -22,22 +22,20 @@ export default function SettingsLayout({ children }: { children: ReactNode }) {
 
   return (
     <div className="flex flex-col md:flex-row w-full flex-1 min-h-0">
-      <div className="shrink-0 md:w-60 md:border-r md:border-grayA-4">
-        <SecondaryNav aria-label="Settings" className="md:sticky md:top-0 md:w-full md:border-r-0">
-          <SecondaryNavTitle>Settings</SecondaryNavTitle>
-          <SecondaryNavGroup>
-            {ITEMS.map((item) => (
-              <SecondaryNavItem
-                key={item.segment}
-                active={active === item.segment}
-                render={<Link href={item.getHref({ workspaceSlug: workspace.slug })} />}
-              >
-                {item.label}
-              </SecondaryNavItem>
-            ))}
-          </SecondaryNavGroup>
-        </SecondaryNav>
-      </div>
+      <SecondaryNav aria-label="Settings">
+        <SecondaryNavTitle>Settings</SecondaryNavTitle>
+        <SecondaryNavGroup>
+          {ITEMS.map((item) => (
+            <SecondaryNavItem
+              key={item.segment}
+              active={active === item.segment}
+              render={<Link href={item.getHref({ workspaceSlug: workspace.slug })} />}
+            >
+              {item.label}
+            </SecondaryNavItem>
+          ))}
+        </SecondaryNavGroup>
+      </SecondaryNav>
       <div className="flex-1 min-w-0">{children}</div>
     </div>
   );

--- a/web/apps/dashboard/app/(app)/layout.tsx
+++ b/web/apps/dashboard/app/(app)/layout.tsx
@@ -116,13 +116,14 @@ export default function Layout({ children }: LayoutProps) {
         <MobileNavDrawer />
         <div className="relative flex flex-1 overflow-hidden">
           {!isAppOnboarding && <SidebarV2 className="bg-gray-1 border-grayA-4" />}
-          {/* Reserve the scrollbar gutter so content doesn't shift horizontally
-              when the scrollbar appears/disappears (e.g. a dialog locking scroll
-              or content height changing). Without this the centered layout
-              "shakes" and buttons move out from under the cursor (ENG-2884). */}
+          {/* Keep overflow on this scrolling parent so sticky descendants use it as
+              their scroll container. Reserve the scrollbar gutter so content doesn't
+              shift horizontally when the scrollbar appears/disappears (e.g. a dialog
+              locking scroll or content height changing). Without this the centered
+              layout "shakes" and buttons move out from under the cursor (ENG-2884). */}
           <div className="flex-1 overflow-auto" style={{ scrollbarGutter: "stable" }}>
             <div
-              className="isolate bg-base-12 w-full min-h-full overflow-x-auto flex flex-col items-center"
+              className="isolate bg-base-12 w-full min-h-full flex flex-col items-center"
               id="layout-wrapper"
             >
               <WorkspaceContent workspace={workspace}>{children}</WorkspaceContent>

--- a/web/internal/ui/src/components/page/secondary-nav.test.tsx
+++ b/web/internal/ui/src/components/page/secondary-nav.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import * as React from "react";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { SecondaryNav } from "./secondary-nav";
+
+describe("SecondaryNav", () => {
+  beforeAll(() => {
+    vi.stubGlobal("React", React);
+  });
+  afterAll(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("provides a full-height rail with sticky navigation", () => {
+    render(
+      React.createElement(SecondaryNav, {
+        "aria-label": "Settings",
+        className: "md:w-56",
+      }),
+    );
+
+    const nav = screen.getByRole("navigation", { name: "Settings" });
+    const rail = nav.parentElement;
+
+    expect(nav.className).toContain("md:sticky");
+    expect(nav.className).toContain("md:top-0");
+    expect(nav.className).toContain("md:w-56");
+    expect(nav.className).not.toContain("md:w-60");
+    expect(rail?.className).toContain("md:self-stretch");
+    expect(rail?.className).toContain("md:border-r");
+    expect(rail?.className).toContain("md:border-grayA-4");
+    expect(rail?.className).not.toContain("md:w-56");
+  });
+});

--- a/web/internal/ui/src/components/page/secondary-nav.tsx
+++ b/web/internal/ui/src/components/page/secondary-nav.tsx
@@ -6,14 +6,16 @@ import { cn } from "../../lib/utils";
 
 function SecondaryNav({ className, ...props }: React.ComponentProps<"nav">) {
   return (
-    <nav
-      className={cn(
-        "flex shrink-0 gap-1 overflow-x-auto border-b border-grayA-4 px-3 py-2",
-        "md:w-60 md:flex-col md:gap-3 md:overflow-x-visible md:overflow-y-auto md:border-r md:border-b-0 md:px-3 md:py-4",
-        className,
-      )}
-      {...props}
-    />
+    <div className="shrink-0 md:self-stretch md:border-r md:border-grayA-4">
+      <nav
+        className={cn(
+          "flex shrink-0 gap-1 overflow-x-auto border-b border-grayA-4 px-3 py-2",
+          "md:sticky md:top-0 md:w-60 md:flex-col md:gap-3 md:overflow-x-visible md:overflow-y-auto md:border-b-0 md:px-3 md:py-4",
+          className,
+        )}
+        {...props}
+      />
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

This is the first foundation change for the billing, usage, and limits pages. Sticky descendants were binding to `#layout-wrapper`, which did not own vertical scrolling, so secondary navigation moved off-screen with the page content.

Overflow now remains on the real app scroll container. The shared `SecondaryNav` component owns sticky positioning and its full-height bordered rail, so settings, authorization, and future callers inherit the behavior without page-specific layout fixes. Existing `className` overrides remain on the semantic navigation element.

## Validation

- Confirmed settings navigation remains at `top: 52px` after scrolling the container to `scrollTop: 391.5px`
- Confirmed settings and authorization render a 1px full-height right rail and computed `position: sticky`
- `@unkey/ui`: 55 tests passed
- `mise exec -- pnpm --dir=web --filter @unkey/dashboard typecheck`
- Biome check on all changed files
