### PR TITLE
fix(dashboard): Make position:sticky work on secondary rails

### DIFF
--- a/web/apps/dashboard/app/(app)/layout.tsx
+++ b/web/apps/dashboard/app/(app)/layout.tsx
@@ -122,7 +122,7 @@ export default function Layout({ children }: LayoutProps) {
               "shakes" and buttons move out from under the cursor (ENG-2884). */}
           <div className="flex-1 overflow-auto" style={{ scrollbarGutter: "stable" }}>
             <div
-              className="isolate bg-base-12 w-full min-h-full overflow-x-auto flex flex-col items-center"
+              className="isolate bg-base-12 w-full min-h-full flex flex-col items-center"
               id="layout-wrapper"
             >
               <WorkspaceContent workspace={workspace}>{children}</WorkspaceContent>

--- a/web/internal/ui/src/components/page/secondary-nav.tsx
+++ b/web/internal/ui/src/components/page/secondary-nav.tsx
@@ -4,16 +4,20 @@ import { type VariantProps, cva } from "class-variance-authority";
 import type * as React from "react";
 import { cn } from "../../lib/utils";
 
-function SecondaryNav({ className, ...props }: React.ComponentProps<"nav">) {
+function SecondaryNav({ className, children, ...props }: React.ComponentProps<"nav">) {
   return (
     <nav
       className={cn(
         "flex shrink-0 gap-1 overflow-x-auto border-b border-grayA-4 px-3 py-2",
-        "md:w-60 md:flex-col md:gap-3 md:overflow-x-visible md:overflow-y-auto md:border-r md:border-b-0 md:px-3 md:py-4",
+        "md:w-60 md:flex-col md:gap-3 md:overflow-x-visible md:border-r md:border-b-0 md:px-3 md:py-4",
         className,
       )}
       {...props}
-    />
+    >
+      <div className="contents md:sticky md:top-4 md:flex md:max-h-dvh md:flex-col md:gap-3 md:overflow-y-auto">
+        {children}
+      </div>
+    </nav>
   );
 }
 


### PR DESCRIPTION
## What does this PR do?

Makes all page layouts with a secondary rail sticky, so when you scroll down a page that has a lot of content, the secondary rail stays in view. 

## Screenshots

### Before

https://github.com/user-attachments/assets/58eedf5b-f827-4863-9690-951027904415


### After
https://github.com/user-attachments/assets/c72485ea-d658-457d-8f73-76b1e512e286



## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

1. Open Settings > Billing at desktop width and scroll the page. The rail stays pinned just under the top nav, and the vertical divider still runs the full page height. Before this PR the rail scrolled away.
2. Repeat on Authorization (needs enough roles or permissions to make the page scroll).
3. Narrow the window below `md` (768px). The rail becomes the horizontal bar again — the wrapper is `display: contents` there, so mobile is unchanged.
4. Horizontal-overflow regression: open a table-heavy page, or a permission with a very long name, and confirm wide content still scrolls sideways inside the content column, that the sidebar is not overlapped, and that the page body gains no horizontal scrollbar. The horizontal scrollbar now sits at the bottom of the viewport instead of at the bottom of the full content height, which is easier to reach on tall pages.

## Screenshots

_To be added — light, dark, mobile._

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary