### PR TITLE
fix(ci): pass PlanetScale check without schema changes

### DIFF
--- a/.depot/workflows/job_pscale_pr.yaml
+++ b/.depot/workflows/job_pscale_pr.yaml
@@ -1,6 +1,11 @@
 name: PlanetScale PR Branch
 on:
   workflow_call:
+    inputs:
+      db_schema_changed:
+        description: Whether the pull request changes the Drizzle schema
+        required: true
+        type: boolean
 permissions:
   contents: read
 env:
@@ -13,67 +18,37 @@ jobs:
     name: Validate schema on PlanetScale branch
     runs-on: depot-ubuntu-24.04-4
     timeout-minutes: 15
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: inputs.db_schema_changed == false || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
     env:
       PLANETSCALE_SERVICE_TOKEN_ID: ${{ secrets.PLANETSCALE_SERVICE_TOKEN_ID }}
       PLANETSCALE_SERVICE_TOKEN: ${{ secrets.PLANETSCALE_SERVICE_TOKEN }}
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
 
-      - uses: planetscale/setup-pscale-action@b6a50ee45b4b24944e1d8de6e57b3a5f6476a1af # v1
-
-      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
-        with:
-          package_json_file: web/package.json
-
-      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
-        with:
-          node-version: 24.15.0
-          cache: pnpm
-          cache-dependency-path: web/pnpm-lock.yaml
-
-      - name: install web deps
-        run: pnpm --dir=web install --frozen-lockfile
-
-      - name: ensure planetscale branch
-        # Idempotent: re-runs on PR push reuse the existing branch. Probe with
-        # `branch show` to distinguish "already exists" from real errors.
-        run: |
-          set -euo pipefail
-          if ! pscale branch create "$PSCALE_DB" "$BRANCH" \
-              --org "$PSCALE_ORG" --from "$PSCALE_PARENT" --wait; then
-            pscale branch show "$PSCALE_DB" "$BRANCH" --org "$PSCALE_ORG" >/dev/null
-          fi
-
-      - name: run migration
-        # USER/PASS/HOST are URL-encoded via jq's @uri before composing the DSN
-        # so reserved characters in any field can't break parsing.
-        run: |
-          set -euo pipefail
-          PW=$(pscale password create "$PSCALE_DB" "$BRANCH" "ci-${GITHUB_SHA::8}" \
-                 --org "$PSCALE_ORG" --format json)
-          USER=$(echo "$PW" | jq -r '.username | @uri')
-          PASS=$(echo "$PW" | jq -r '.plain_text | @uri')
-          HOST=$(echo "$PW" | jq -r '.access_host_url | @uri')
-          export DRIZZLE_DATABASE_URL="mysql://$USER:$PASS@$HOST/$PSCALE_DB?ssl={}"
-          pnpm --dir=web/internal/db run migrate
-
-      - name: ensure deploy request
-        # Open a DR into staging so reviewers have a one-click promotion
-        # surface. Reuse existing open DR for repeat runs of the same PR.
-        # PR_NUMBER and PR_TITLE come in via env so untrusted PR title text
-        # can't be interpreted as shell.
+      - name: validate schema
         env:
+          DB_SCHEMA_CHANGED: ${{ inputs.db_schema_changed }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           set -euo pipefail
-          EXISTING=$(pscale deploy-request list "$PSCALE_DB" --org "$PSCALE_ORG" --format json \
-            | jq -r --arg b "$BRANCH" --arg p "$PSCALE_PARENT" \
+          if [ "$DB_SCHEMA_CHANGED" != "true" ]; then
+            echo "No database schema changes to validate."
+            exit 0
+          fi
+
+          ./dev/install-mise
+          export PATH="$HOME/.local/bin:$PATH"
+          mise install --locked --yes node github:pnpm/pnpm github:planetscale/cli github:jqlang/jq
+          FROM="$PSCALE_PARENT" mise run pscale-branch
+
+          EXISTING=$(mise exec -- pscale deploy-request list "$PSCALE_DB" \
+            --org "$PSCALE_ORG" --format json \
+            | mise exec -- jq -r --arg b "$BRANCH" --arg p "$PSCALE_PARENT" \
                 '.[] | select(.branch==$b and .into_branch==$p and .state=="open") | .number' \
             | head -n1)
           if [ -z "$EXISTING" ]; then
-            pscale deploy-request create "$PSCALE_DB" "$BRANCH" \
+            mise exec -- pscale deploy-request create "$PSCALE_DB" "$BRANCH" \
               --org "$PSCALE_ORG" --into "$PSCALE_PARENT" \
               --notes "PR #${PR_NUMBER}: ${PR_TITLE}"
           else

--- a/.depot/workflows/pr.yaml
+++ b/.depot/workflows/pr.yaml
@@ -44,7 +44,9 @@ jobs:
     uses: ./.depot/workflows/job_validate_workflows.yaml
   pscale_pr:
     name: PlanetScale PR Branch
-    if: ((github.event_name == 'pull_request' && github.event.pull_request.draft == false) || github.event_name != 'pull_request') && needs.detect_changes.result == 'success' && needs.detect_changes.outputs.db_schema == 'true'
+    if: ((github.event_name == 'pull_request' && github.event.pull_request.draft == false) || github.event_name != 'pull_request') && needs.detect_changes.result == 'success'
     needs: [detect_changes]
     uses: ./.depot/workflows/job_pscale_pr.yaml
+    with:
+      db_schema_changed: ${{ needs.detect_changes.outputs.db_schema == 'true' }}
     secrets: inherit


### PR DESCRIPTION
## Problem:

The required PlanetScale schema check was skipped when a pull request had no database schema changes. The skipped result could block the merge queue.

## Solution:

Always run the schema check after change detection. Return a successful no-op result when no database schema files changed. Run PlanetScale validation only when schema files changed.

## Impact:

Pull requests without database schema changes get a successful required check without installing tools or contacting PlanetScale. Schema changes continue to use the existing PlanetScale branch workflow.

## Testing:

- Parsed both changed workflow files with PyYAML 6.0.2.
- Checked the validation script with `bash -n`.
- Ran `git diff --check` successfully.