### PR TITLE
Suggest root directories and watch paths

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/settings/components/build-settings/root-directory-settings.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/settings/components/build-settings/root-directory-settings.tsx
@@ -1,6 +1,7 @@
+import { FormCombobox } from "@/components/ui/form-combobox";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { FolderLink } from "@unkey/icons";
-import { FormInput } from "@unkey/ui";
+import { useMemo } from "react";
 import { useForm, useWatch } from "react-hook-form";
 import { z } from "zod";
 import { useEnvironmentSettings } from "../../environment-provider";
@@ -35,10 +36,10 @@ export const RootDirectory = () => {
   const { settings, variant } = useEnvironmentSettings();
   const { dockerContext: defaultValue } = settings;
   const updateAllEnvironments = useUpdateAllEnvironments();
-  const { branch, validatePath, findCaseInsensitiveMatch } = useRepoTree();
+  const { branch, validatePath, findCaseInsensitiveMatch, rootDirectorySuggestions } =
+    useRepoTree();
 
   const {
-    register,
     handleSubmit,
     formState: { isValid, isSubmitting, errors },
     control,
@@ -49,11 +50,26 @@ export const RootDirectory = () => {
     defaultValues: { dockerContext: defaultValue },
   });
 
-  const currentDockerContext = useWatch({ control, name: "dockerContext" });
+  const currentDockerContext = useWatch({ control, name: "dockerContext", defaultValue });
 
   const validation = validatePath(currentDockerContext, "tree");
   const caseMatch =
     validation === "invalid" ? findCaseInsensitiveMatch(currentDockerContext, "tree") : null;
+  const options = useMemo(
+    () =>
+      rootDirectorySuggestions.map(({ path, marker }) => ({
+        label: (
+          <span className="flex w-full items-center justify-between gap-4">
+            <span className="truncate">{path}</span>
+            <span className="shrink-0 text-gray-9">{marker}</span>
+          </span>
+        ),
+        selectedLabel: path,
+        value: path,
+        searchValue: path === "." ? ". repository root" : path,
+      })),
+    [rootDirectorySuggestions],
+  );
 
   const saveState = resolveSaveState([
     [isSubmitting, { status: "saving" }],
@@ -107,17 +123,24 @@ export const RootDirectory = () => {
       autoSave={variant === "onboarding"}
     >
       <SettingField>
-        <FormInput
+        <FormCombobox
           label="Root directory"
           requirement="required"
           description={
             warningMessage ??
-            "Unkey detects and builds your app from this directory. For Dockerfile builds it is the build context. Changes apply on next deploy."
+            "Select a suggested app directory or enter any repository-relative path. Changes apply on next deploy."
           }
-          placeholder="."
           error={errors.dockerContext?.message}
           variant={inputVariant}
-          {...register("dockerContext")}
+          options={options}
+          wrapperClassName="max-w-[calc(var(--setting-w)-1rem)]"
+          className="max-w-[calc(var(--setting-w)-1rem)]"
+          value={currentDockerContext}
+          onSelect={(value) => setValue("dockerContext", value, { shouldValidate: true })}
+          creatable
+          searchPlaceholder="Search or enter a directory..."
+          emptyMessage={<div className="mt-2">No app directories detected</div>}
+          placeholder={<span className="text-grayA-8">.</span>}
         />
       </SettingField>
     </FormSettingCard>

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/settings/components/build-settings/use-repo-tree.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/settings/components/build-settings/use-repo-tree.ts
@@ -7,6 +7,36 @@ import { useMemo } from "react";
 
 type ValidationResult = "valid" | "invalid" | "unknown";
 
+const rootDirectoryMarkers = new Set([
+  "build.gradle",
+  "build.gradle.kts",
+  "cargo.toml",
+  "composer.json",
+  "gemfile",
+  "go.mod",
+  "mix.exs",
+  "package.json",
+  "pipfile",
+  "pom.xml",
+  "pyproject.toml",
+  "requirements.txt",
+]);
+
+const workspaceWatchFiles = new Set([
+  "bun.lock",
+  "bun.lockb",
+  "cargo.lock",
+  "go.work",
+  "go.work.sum",
+  "nx.json",
+  "package-lock.json",
+  "package.json",
+  "pnpm-lock.yaml",
+  "pnpm-workspace.yaml",
+  "turbo.json",
+  "yarn.lock",
+]);
+
 /** Strip leading "./", leading/trailing slashes so `./svc/api/` and `svc/api` match the same tree entry. */
 function normalizePath(path: string): string {
   return path.replace(/^(\.\/)+/, "").replace(/^\/+|\/+$/g, "");
@@ -48,6 +78,68 @@ export function useRepoTree() {
     }
     return set;
   }, [tree]);
+
+  const rootDirectorySuggestions = useMemo(() => {
+    if (!tree) {
+      return [{ path: ".", marker: "Repository root" }];
+    }
+
+    // Suggest likely app roots instead of rendering every directory in a large monorepo.
+    // Any repository-relative path can still be entered manually.
+    const suggestions = new Map<string, string>();
+    for (const entry of tree) {
+      if (entry.type !== "blob") {
+        continue;
+      }
+
+      const fileName = entry.path.split("/").pop() ?? "";
+      const normalizedFileName = fileName.toLowerCase();
+      if (
+        !rootDirectoryMarkers.has(normalizedFileName) &&
+        !normalizedFileName.includes("dockerfile")
+      ) {
+        continue;
+      }
+
+      const separatorIndex = entry.path.lastIndexOf("/");
+      const path = separatorIndex === -1 ? "." : entry.path.slice(0, separatorIndex);
+      if (!suggestions.has(path)) {
+        suggestions.set(path, fileName);
+      }
+    }
+
+    return [
+      { path: ".", marker: "Repository root" },
+      ...Array.from(suggestions, ([path, marker]) => ({ path, marker }))
+        .filter((suggestion) => suggestion.path !== ".")
+        .sort((a, b) => a.path.localeCompare(b.path)),
+    ];
+  }, [tree]);
+
+  const watchPathSuggestions = useMemo(() => {
+    if (!tree) {
+      return [];
+    }
+
+    const suggestions = rootDirectorySuggestions
+      .filter((suggestion) => suggestion.path !== ".")
+      .map((suggestion) => ({
+        path: `${suggestion.path}/**`,
+        marker: suggestion.marker,
+      }));
+
+    for (const entry of tree) {
+      if (
+        entry.type === "blob" &&
+        !entry.path.includes("/") &&
+        workspaceWatchFiles.has(entry.path.toLowerCase())
+      ) {
+        suggestions.push({ path: entry.path, marker: "Workspace file" });
+      }
+    }
+
+    return suggestions;
+  }, [rootDirectorySuggestions, tree]);
 
   function validatePath(path: string, type: "blob" | "tree"): ValidationResult {
     if (!isReady || !treeSet) {
@@ -132,6 +224,8 @@ export function useRepoTree() {
     branch,
     validatePath,
     findCaseInsensitiveMatch,
+    rootDirectorySuggestions,
+    watchPathSuggestions,
     validateDockerfilePath,
     findDockerfileCaseMatch,
     getDockerfilesForContext,

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/settings/components/build-settings/watch-paths-settings.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/settings/components/build-settings/watch-paths-settings.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { FormCombobox } from "@/components/ui/form-combobox";
 import { cn } from "@/lib/utils";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Eye, Plus } from "@unkey/icons";
@@ -12,6 +13,7 @@ import { useUpdateAllEnvironments } from "../../hooks/use-update-all-environment
 import { SettingDescription, SettingField } from "../shared/form-blocks";
 import { FormSettingCard, resolveSaveState } from "../shared/form-setting-card";
 import { RemoveButton } from "../shared/remove-button";
+import { useRepoTree } from "./use-repo-tree";
 
 const watchPathsSchema = z.object({
   paths: z.array(
@@ -24,7 +26,7 @@ const watchPathsSchema = z.object({
 type WatchPathsForm = z.infer<typeof watchPathsSchema>;
 
 function toFormPaths(paths: string[]): { value: string }[] {
-  return paths.length > 0 ? paths.map((p) => ({ value: p })) : [{ value: "" }];
+  return paths.map((p) => ({ value: p }));
 }
 
 function fromFormPaths(paths: { value: string }[]): string[] {
@@ -39,6 +41,7 @@ export const WatchPaths = () => {
   const { settings } = useEnvironmentSettings();
   const defaultPaths = settings.watchPaths ?? [];
   const updateAllEnvironments = useUpdateAllEnvironments();
+  const { watchPathSuggestions } = useRepoTree();
 
   const {
     register,
@@ -46,6 +49,7 @@ export const WatchPaths = () => {
     formState: { isValid, isSubmitting, errors },
     control,
     reset,
+    setValue,
   } = useForm<WatchPathsForm>({
     resolver: zodResolver(watchPathsSchema),
     mode: "onChange",
@@ -85,6 +89,50 @@ export const WatchPaths = () => {
   const currentPaths = useWatch({ control, name: "paths" });
   const currentValues = fromFormPaths(currentPaths ?? []);
   const hasChanges = changed(defaultPaths, currentValues);
+  const rootWatchPath =
+    settings.dockerContext && settings.dockerContext !== "."
+      ? `${settings.dockerContext}/**`
+      : null;
+  const options = [...watchPathSuggestions]
+    .sort((a, b) => {
+      if (a.path === rootWatchPath) {
+        return -1;
+      }
+      if (b.path === rootWatchPath) {
+        return 1;
+      }
+      return a.path.localeCompare(b.path);
+    })
+    .map(({ path, marker }) => ({
+      label: (
+        <span className="flex w-full items-center justify-between gap-4">
+          <span className="truncate font-mono">{path}</span>
+          <span className="shrink-0 text-gray-9">
+            {path === rootWatchPath ? "Root directory" : marker}
+          </span>
+        </span>
+      ),
+      selectedLabel: path,
+      value: path,
+      searchValue: path,
+      disabled: currentValues.includes(path),
+    }));
+
+  const addWatchPath = useCallback(
+    (value: string) => {
+      if (!value || currentValues.includes(value)) {
+        return;
+      }
+
+      const emptyIndex = currentPaths?.findIndex((path) => !path.value) ?? -1;
+      if (emptyIndex >= 0) {
+        setValue(`paths.${emptyIndex}.value`, value, { shouldValidate: true });
+        return;
+      }
+      append({ value });
+    },
+    [append, currentPaths, currentValues, setValue],
+  );
 
   const saveState = resolveSaveState([
     [isSubmitting, { status: "saving" }],
@@ -154,14 +202,16 @@ export const WatchPaths = () => {
             </div>
           );
         })}
-        <button
-          type="button"
-          className="flex items-center gap-1.5 text-gray-11 hover:text-gray-12 text-sm transition-colors w-fit cursor-pointer"
-          onClick={appendAndFocus}
-        >
-          <Plus iconSize="sm-regular" />
-          Add pattern
-        </button>
+        <FormCombobox
+          options={options}
+          value=""
+          onSelect={addWatchPath}
+          creatable
+          leftIcon={<Plus iconSize="sm-regular" />}
+          searchPlaceholder="Search suggestions or enter a glob..."
+          emptyMessage={<div className="mt-2">No suggested watch paths detected</div>}
+          placeholder={<span className="text-grayA-8">Add a watch path...</span>}
+        />
       </SettingField>
       <SettingDescription>
         Glob patterns (e.g. src/**, **/*.go). Deployments are skipped when no changed files match.


### PR DESCRIPTION
## Problem:

Large monorepos can contain many valid app roots. A plain text field gives no guidance, but a list of every directory would be difficult to use. Watch paths have the same setup problem.

## Solution:

Root directory settings now provide searchable suggestions for likely app directories and keep manual path entry. Watch path settings now suggest app globs and workspace files, prioritize the selected root directory, and keep manual glob entry.

**Root directory picker**

https://ampcode.com/user-content/artifacts/8f7971a98e197ea0a9da2c8151092a8822a2ec08a63707980be35a22c1c732aa-file.mp4

**Watch path suggestions**

https://ampcode.com/user-content/artifacts/6ec80200a666ec9562b1f29a4c7d74a25ff4a4ca10f4820b97c3cd7b4b8bfd71-file.mp4

## Impact:

Dashboard users can configure build roots and watch paths faster in large repositories. Existing paths remain valid. Suggestions do not change saved settings until the user selects and saves them.

## Testing:

- Biome check passed for the three changed files.
- Dashboard TypeScript typecheck passed.
- `git diff --check` passed.