### PR TITLE
feat(ui): Add composable Item row primitive

### DIFF
--- a/web/apps/design/src/data/nav.ts
+++ b/web/apps/design/src/data/nav.ts
@@ -12,6 +12,7 @@ export const nav: NavSection[] = [
   {
     title: "Primitives",
     items: [
+      { name: "Item", href: "/primitives/item" },
       { name: "Resource list", href: "/primitives/resource-list" },
       { name: "Skeleton", href: "/primitives/skeleton" },
     ],

--- a/web/apps/design/src/pages/primitives/item/_external-link.tsx
+++ b/web/apps/design/src/pages/primitives/item/_external-link.tsx
@@ -1,0 +1,37 @@
+import { ArrowUpRight, BookOpen } from "@unkey/icons";
+import {
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemDescription,
+  ItemMedia,
+  ItemTitle,
+  VisuallyHidden,
+} from "@unkey/ui";
+
+export function ExternalLink() {
+  return (
+    <div className="w-full max-w-md">
+      <Item
+        variant="outline"
+        render={
+          <a href="https://unkey.com/docs" target="_blank" rel="noopener noreferrer">
+            <ItemMedia>
+              <BookOpen />
+            </ItemMedia>
+            <ItemContent>
+              <ItemTitle>
+                Documentation
+                <VisuallyHidden> (opens in a new tab)</VisuallyHidden>
+              </ItemTitle>
+              <ItemDescription>How plans, usage and invoices work</ItemDescription>
+            </ItemContent>
+            <ItemActions>
+              <ArrowUpRight />
+            </ItemActions>
+          </a>
+        }
+      />
+    </div>
+  );
+}

--- a/web/apps/design/src/pages/primitives/item/_internal-link.tsx
+++ b/web/apps/design/src/pages/primitives/item/_internal-link.tsx
@@ -1,0 +1,26 @@
+import { ChartUsage, ChevronRight } from "@unkey/icons";
+import { Item, ItemActions, ItemContent, ItemDescription, ItemMedia, ItemTitle } from "@unkey/ui";
+
+export function InternalLink() {
+  return (
+    <div className="w-full max-w-md">
+      <Item
+        variant="outline"
+        render={
+          <a href="/primitives/item">
+            <ItemMedia>
+              <ChartUsage />
+            </ItemMedia>
+            <ItemContent>
+              <ItemTitle>Usage</ItemTitle>
+              <ItemDescription>Track your spend and usage across Unkey</ItemDescription>
+            </ItemContent>
+            <ItemActions>
+              <ChevronRight />
+            </ItemActions>
+          </a>
+        }
+      />
+    </div>
+  );
+}

--- a/web/apps/design/src/pages/primitives/item/_item-link.tsx
+++ b/web/apps/design/src/pages/primitives/item/_item-link.tsx
@@ -1,0 +1,60 @@
+import { BookOpen, ChartUsage, ChevronRight } from "@unkey/icons";
+import {
+  Button,
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemDescription,
+  ItemMedia,
+  ItemTitle,
+} from "@unkey/ui";
+
+export function ItemLink() {
+  return (
+    <div className="flex w-full max-w-md flex-col gap-4">
+      <Item>
+        <ItemContent>
+          <ItemTitle>Basic Item</ItemTitle>
+          <ItemDescription>A simple item with title and description.</ItemDescription>
+        </ItemContent>
+        <ItemActions>
+          <Button variant="outline">Action</Button>
+        </ItemActions>
+      </Item>
+      <Item
+        variant="outline"
+        render={
+          <a href="/primitives/item">
+            <ItemMedia>
+              <ChartUsage />
+            </ItemMedia>
+            <ItemContent>
+              <ItemTitle>Usage</ItemTitle>
+              <ItemDescription>Track your spend and usage across Unkey.</ItemDescription>
+            </ItemContent>
+            <ItemActions>
+              <ChevronRight />
+            </ItemActions>
+          </a>
+        }
+      />
+      <Item
+        variant="outline"
+        render={
+          <a href="/primitives/item">
+            <ItemMedia>
+              <BookOpen />
+            </ItemMedia>
+            <ItemContent>
+              <ItemTitle>Docs</ItemTitle>
+              <ItemDescription>How plans, usage and invoices work.</ItemDescription>
+            </ItemContent>
+            <ItemActions>
+              <ChevronRight />
+            </ItemActions>
+          </a>
+        }
+      />
+    </div>
+  );
+}

--- a/web/apps/design/src/pages/primitives/item/index.mdx
+++ b/web/apps/design/src/pages/primitives/item/index.mdx
@@ -1,0 +1,34 @@
+---
+layout: ../../../layouts/layout.astro
+title: Item — Unkey Design
+---
+import { Preview } from "../../../components/preview.tsx";
+import { ItemLink } from "./_item-link.tsx";
+import { InternalLink } from "./_internal-link.tsx";
+import { ExternalLink } from "./_external-link.tsx";
+import itemLinkSource from "./_item-link.tsx?highlight";
+import internalLinkSource from "./_internal-link.tsx?highlight";
+import externalLinkSource from "./_external-link.tsx?highlight";
+
+# Item
+
+A versatile component used for displaying content like media, links and howto information.
+
+
+<Preview client:load code={itemLinkSource}>
+  <ItemLink />
+</Preview>
+
+## Examples
+
+### Internal link
+
+<Preview client:load code={internalLinkSource}>
+  <InternalLink />
+</Preview>
+
+### External link
+
+<Preview client:load code={externalLinkSource}>
+  <ExternalLink />
+</Preview>

--- a/web/internal/ui/src/components/item.tsx
+++ b/web/internal/ui/src/components/item.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useRender } from "@base-ui/react/use-render";
+import { type VariantProps, cva } from "class-variance-authority";
+import type * as React from "react";
+import { cn } from "../lib/utils";
+
+const interactiveClassName =
+  "[a&]:cursor-pointer [a&]:hover:bg-grayA-2 [a&]:focus-visible:ring-2 [a&]:focus-visible:ring-grayA-7 [button&]:cursor-pointer [button&]:hover:bg-grayA-2 [button&]:focus-visible:ring-2 [button&]:focus-visible:ring-grayA-7";
+
+const itemVariants = cva(
+  `group/item flex w-full items-center gap-3 rounded-lg border border-transparent px-4 py-3 text-left transition-colors focus-visible:outline-hidden ${interactiveClassName}`,
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        outline: "border-grayA-4",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+export type ItemProps = React.HTMLAttributes<HTMLElement> &
+  VariantProps<typeof itemVariants> & {
+    render?: React.ReactElement;
+    ref?: React.Ref<HTMLElement>;
+  };
+
+function ItemRenderSlot({
+  render,
+  ref,
+  ...props
+}: {
+  render: React.ReactElement;
+  ref?: React.Ref<HTMLElement>;
+} & React.HTMLAttributes<HTMLElement>) {
+  return useRender({ render, ref, props });
+}
+
+export function Item({ className, variant, render, ref, ...props }: ItemProps) {
+  const itemClassName = cn(itemVariants({ variant, className }));
+
+  if (render) {
+    return <ItemRenderSlot render={render} ref={ref} className={itemClassName} {...props} />;
+  }
+
+  return <div ref={ref as React.Ref<HTMLDivElement>} className={itemClassName} {...props} />;
+}
+
+export function ItemMedia({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      aria-hidden="true"
+      className={cn(
+        "flex size-7 shrink-0 items-center justify-center rounded-md bg-grayA-3 text-gray-11 [&_svg:not([class*='size-'])]:size-3.5",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function ItemContent({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("flex min-w-0 flex-1 flex-col gap-px", className)} {...props} />;
+}
+
+export function ItemTitle({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div className={cn("text-[13px] font-medium leading-4 text-gray-12", className)} {...props} />
+  );
+}
+
+export function ItemDescription({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLParagraphElement>) {
+  return <p className={cn("text-xs leading-4 text-gray-11", className)} {...props} />;
+}
+
+export function ItemActions({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn(
+        "flex shrink-0 items-center gap-2 text-gray-9 transition-colors group-hover/item:text-gray-11 [&_svg:not([class*='size-'])]:size-3.5",
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/web/internal/ui/src/index.ts
+++ b/web/internal/ui/src/index.ts
@@ -25,6 +25,7 @@ export * from "./components/full-screen-layout";
 export * from "./components/id";
 export * from "./components/info-tooltip";
 export * from "./components/inline-link";
+export * from "./components/item";
 export * from "./components/loading";
 export * from "./components/page";
 export * from "./components/resource-list";


### PR DESCRIPTION
## What does this PR do?

Adds a new 'Item' component, based on https://ui.shadcn.com/docs/components/base/item

- We have fewer use cases for item currently, so this isn't as comprehensive as the shadcn example
- The first use of `Item` is intended for the upcoming redesign of the billing page

## Screenshots

<img width="4264" height="2584" alt="CleanShot 2026-08-05 at 15 11 58@2x" src="https://github.com/user-attachments/assets/51e0efaf-7c1d-4cfd-9e02-e7cc3244d131" />
<img width="4264" height="2584" alt="CleanShot 2026-08-05 at 15 11 48@2x" src="https://github.com/user-attachments/assets/ec749758-dc2f-4aca-8d0e-9ed32b4abd01" />
<img width="4264" height="2584" alt="CleanShot 2026-08-05 at 15 43 05@2x" src="https://github.com/user-attachments/assets/10e4565e-6daa-44fe-80ab-b747568d6e81" />



## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

Start the `@unkey/design` docs app (it is separate from the dashboard and serves on port 4321) and open `/primitives/item`.

- Hover one of the link rows: the background fills and the trailing icon lifts. Hover the "Basic Item" row, which is not a link: nothing changes.
- Tab through the first example. Each link row is a single stop with a focus ring. The "Basic Item" row's only stop is its Action button.
- Toggle the theme in the docs header and confirm both rows read correctly in dark.
- The External link example opens in a new tab, and its title carries a visually hidden "(opens in a new tab)" for screen readers.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [x] Updated the Unkey Docs if changes were necessary

_Screenshots to be added — light, dark, and the hover/focus states._
