### PR TITLE
fix(ci): run database schema gate in merge queue

### DIFF
--- a/.depot/workflows/database_schema_gate.yaml
+++ b/.depot/workflows/database_schema_gate.yaml
@@ -2,6 +2,8 @@ name: Database Schema Gate
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  merge_group:
+    branches: [main]
   schedule:
     - cron: "17 3 * * *"
 concurrency:
@@ -17,7 +19,7 @@ env:
   BRANCH: schema-check-${{ github.run_id }}-${{ github.run_attempt }}
 jobs:
   gate:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     name: Compare production schema
     runs-on: depot-ubuntu-24.04-4
     timeout-minutes: 15


### PR DESCRIPTION
## Problem:

The required database schema gate did not run for merge queue commits. The previous fix added merge queue support to the general PR workflow instead of the required gate workflow.

## Solution:

Run the database schema gate for merge queue commits targeting `main`.

## Impact:

The required schema check can now complete in the merge queue. Commits without schema changes continue to pass without running PlanetScale operations.

## Testing:

- `dprint check --config dev/dprint.json .depot/workflows/database_schema_gate.yaml`
- `git diff --check`