### PR TITLE
fix dashboard branch domain visibility

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/overview/components/app-production-card-skeleton.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/overview/components/app-production-card-skeleton.tsx
@@ -7,7 +7,7 @@ function Bar({ className }: { className?: string }) {
 
 const METADATA_CELLS = ["status", "region", "resources", "instances", "source", "created"];
 
-export function ProductionDeploymentCardSkeleton() {
+export function AppProductionCardSkeleton() {
   return (
     <Card className="flex flex-col">
       <div className="flex items-center justify-between gap-4 px-4 py-3 border-b border-gray-4">

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/overview/components/app-production-card.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/overview/components/app-production-card.tsx
@@ -10,17 +10,17 @@ import { and, eq, useLiveQuery } from "@tanstack/react-db";
 import dynamic from "next/dynamic";
 import { useState } from "react";
 import { ActiveDeploymentCardEmpty } from "../../../components/active-deployment-card/components/active-deployment-card-empty";
-import { getDomainPriority } from "../../../components/domain-priority";
+import { getAppOverviewDomains, getDomainPriority } from "../../../components/domain-priority";
 import { Card } from "../../components/card";
 import { useAppId, useProjectData } from "../../data-provider";
 import { CreateDeploymentButton } from "../../navigations/create-deployment-button";
+import { AppProductionCardSkeleton } from "./app-production-card-skeleton";
 import { BuildInProgressChart, ProductionCardChart } from "./card-chart";
 import { ProductionCardHeader } from "./card-header";
 import { ProductionCardMetadata } from "./card-metadata";
 import { ProductionCardRollbackBanner } from "./card-rollback-banner";
 import { buildPulse } from "./g-pulse";
 import { type ProductionCardContextValue, ProductionCardProvider } from "./production-card-context";
-import { ProductionDeploymentCardSkeleton } from "./production-deployment-card-skeleton";
 import { deriveProductionStatus } from "./status";
 
 const RollbackDialog = dynamic(
@@ -36,15 +36,9 @@ const UndoRollbackDialog = dynamic(
   { ssr: false },
 );
 
-export function ProductionDeploymentCard() {
-  const {
-    projectId,
-    deployments,
-    environments,
-    customDomains,
-    getDomainsForDeployment,
-    isDeploymentsLoading,
-  } = useProjectData();
+export function AppProductionCard() {
+  const { projectId, deployments, environments, customDomains, domains, isDeploymentsLoading } =
+    useProjectData();
   const appId = useAppId();
   const workspace = useWorkspaceNavigation();
   const { gated, openPaywall, planGate } = useDeployActionGate();
@@ -100,7 +94,7 @@ export function ProductionDeploymentCard() {
     currentDeploymentId != null && currentDeploymentQuery.isLoading;
 
   if (isDeploymentsLoading || appsQuery.isLoading || isResolvingCurrentDeployment) {
-    return <ProductionDeploymentCardSkeleton />;
+    return <AppProductionCardSkeleton />;
   }
 
   if (!deployment) {
@@ -122,7 +116,7 @@ export function ProductionDeploymentCard() {
   const sourceRepo = deployment.forkRepositoryFullName || repoFullName;
 
   const { primary, additional } = getDomainPriority({
-    domains: getDomainsForDeployment(deployment.id),
+    domains: getAppOverviewDomains(domains, deployment.id),
     customDomains,
     environmentId: deployment.environmentId,
     deploymentId: deployment.id,

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/overview/components/production-card-context.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/overview/components/production-card-context.tsx
@@ -37,7 +37,7 @@ export const ProductionCardProvider = ProductionCardContext.Provider;
 export function useProductionCard(): ProductionCardContextValue {
   const ctx = use(ProductionCardContext);
   if (!ctx) {
-    throw new Error("useProductionCard must be used within ProductionDeploymentCard");
+    throw new Error("useProductionCard must be used within AppProductionCard");
   }
   return ctx;
 }

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/overview/page.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/overview/page.tsx
@@ -4,8 +4,8 @@ import { PageBody, PageContainer, PageHeader, PageHeaderContent, PageHeaderTitle
 import { ActiveDeploymentCardEmpty } from "../../components/active-deployment-card/components/active-deployment-card-empty";
 import { useProjectData } from "../data-provider";
 import { CreateDeploymentButton } from "../navigations/create-deployment-button";
+import { AppProductionCard } from "./components/app-production-card";
 import { OverviewPageTitle } from "./components/overview-page-title";
-import { ProductionDeploymentCard } from "./components/production-deployment-card";
 import { RecentDeployments } from "./components/recent-deployments";
 
 export default function Overview() {
@@ -30,7 +30,7 @@ export default function Overview() {
           />
         ) : (
           <div className="flex flex-col gap-5">
-            <ProductionDeploymentCard />
+            <AppProductionCard />
             <RecentDeployments />
           </div>
         )}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/components/domain-priority.test.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/components/domain-priority.test.ts
@@ -1,6 +1,6 @@
 import type { CustomDomain, Domain } from "@/lib/collections";
 import { describe, expect, test } from "vitest";
-import { getDomainPriority } from "./domain-priority";
+import { getAppOverviewDomains, getDomainPriority } from "./domain-priority";
 
 function makeDomain(overrides: Partial<Domain> = {}): Domain {
   return {
@@ -48,6 +48,26 @@ const baseCtx = {
   deploymentId: "dep-current",
   currentDeploymentId: "dep-current" as string | null,
 };
+
+test("getAppOverviewDomains includes app aliases and the displayed deployment's immutable URLs", () => {
+  const domains = [
+    makeDomain({ id: "current-commit", deploymentId: "dep-current", sticky: "none" }),
+    makeDomain({ id: "current-deployment", deploymentId: "dep-current", sticky: "deployment" }),
+    makeDomain({ id: "other-branch", deploymentId: "dep-other", sticky: "branch" }),
+    makeDomain({ id: "other-environment", deploymentId: "dep-other", sticky: "environment" }),
+    makeDomain({ id: "other-live", deploymentId: "dep-other", sticky: "live" }),
+    makeDomain({ id: "other-commit", deploymentId: "dep-other", sticky: "none" }),
+    makeDomain({ id: "other-deployment", deploymentId: "dep-other", sticky: "deployment" }),
+  ];
+
+  expect(getAppOverviewDomains(domains, "dep-current").map((domain) => domain.id)).toEqual([
+    "current-commit",
+    "current-deployment",
+    "other-branch",
+    "other-environment",
+    "other-live",
+  ]);
+});
 
 describe("getDomainPriority", () => {
   const cases = [
@@ -218,6 +238,31 @@ describe("getDomainPriority", () => {
     expect(result.all).toHaveLength(2);
     expect(result.all.map((d) => d.id)).toEqual(["cd-1", "d-a"]);
     expect(result.primary?.id).toBe("cd-1");
+  });
+
+  test("verified custom domain route from another environment is not shown as a platform alias", () => {
+    const result = getDomainPriority({
+      ...baseCtx,
+      domains: [
+        makeDomain({
+          id: "d-custom-route",
+          fullyQualifiedDomainName: "custom.example.com",
+          environmentId: "env-other",
+          sticky: "live",
+        }),
+        makeDomain({ id: "d-a", fullyQualifiedDomainName: "a.example.com" }),
+      ],
+      customDomains: [
+        makeCustomDomain({
+          id: "cd-other-env",
+          domain: "custom.example.com",
+          environmentId: "env-other",
+        }),
+      ],
+    });
+
+    expect(result.all.map((domain) => domain.id)).toEqual(["d-a"]);
+    expect(result.primary?.id).toBe("d-a");
   });
 
   test("custom domains hidden when viewing non-current deployment", () => {

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/components/domain-priority.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/components/domain-priority.ts
@@ -32,6 +32,22 @@ export type DomainPriorityResult = {
   all: ReadonlyArray<DisplayDomain>;
 };
 
+/**
+ * Returns the app-level aliases shown on the overview together with immutable
+ * URLs for the displayed deployment. The `deployment` sticky value identifies
+ * an immutable URL, so routes of that type from older deployments are excluded.
+ */
+export function getAppOverviewDomains(
+  domains: ReadonlyArray<Domain>,
+  deploymentId: string,
+): ReadonlyArray<Domain> {
+  return domains.filter(
+    (domain) =>
+      domain.deploymentId === deploymentId ||
+      (domain.sticky !== "none" && domain.sticky !== "deployment"),
+  );
+}
+
 export function getDomainPriority(ctx: DomainPriorityContext): DomainPriorityResult {
   const isCurrentDeployment = ctx.deploymentId === ctx.currentDeploymentId;
 
@@ -50,11 +66,17 @@ export function getDomainPriority(ctx: DomainPriorityContext): DomainPriorityRes
         }))
     : [];
 
-  // Exclude platform domains that match a verified custom domain to avoid duplicates
-  const customHostnames = new Set(customDisplayDomains.map((cd) => cd.hostname));
+  // A verified custom domain also has a live frontline route. Exclude that route
+  // even when the custom domain belongs to another environment; otherwise the
+  // route would be misclassified as a generated platform alias.
+  const verifiedCustomHostnames = new Set(
+    ctx.customDomains
+      .filter((domain) => domain.verificationStatus === "verified")
+      .map((d) => d.domain),
+  );
 
   const platformDisplayDomains: ReadonlyArray<DisplayDomain> = [...ctx.domains]
-    .filter((d) => !customHostnames.has(d.fullyQualifiedDomainName))
+    .filter((d) => !verifiedCustomHostnames.has(d.fullyQualifiedDomainName))
     .sort((a, b) => a.fullyQualifiedDomainName.localeCompare(b.fullyQualifiedDomainName))
     .map((d) => ({
       source: "platform" as const,


### PR DESCRIPTION
## What was the goal?

Branch URLs were being created correctly, but they could be missing from the domain list on the app overview page.

The overview only looked at domains attached to the production deployment shown in the card. A sticky branch URL follows the newest deployment on that branch, so it can point to a different deployment and get left out of that list.

This change makes the app overview show:

- app-level aliases, including branch, environment, and live URLs
- immutable URLs for the production deployment currently shown

It also keeps historical immutable deployment URLs out of the list and prevents custom-domain routes from being shown as generated platform URLs.

Now it shows the `branch`-sticky url correctly:
<img width="1324" height="530" alt="CleanShot 2026-08-05 at 20 30 01@2x" src="https://github.com/user-attachments/assets/7de9afec-2454-4058-8c5a-015adbc30f8a" />


## Renaming some things

While making the change, `ProductionDeploymentCard` turned out to be a misleading name. The card is not a detail view for one deployment. It represents the app's overall production state: domains, traffic metrics, rollback state, and the deployment currently serving production.

It is now named `AppProductionCard` to describe what the UI represents. This is only a naming cleanup; it does not change deployment behavior.

Linear: [ENG-2774](https://linear.app/unkey/issue/ENG-2774/git-branch-url-missing-after-re-deploy)
