### PR TITLE
fix(cache): deduplicate concurrent origin loads

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -302,7 +302,7 @@ func (c *cache[K, V]) SWR(
 		}
 
 		if now.Before(e.Stale) {
-			c.origin.Schedule(
+			c.origin.DoAsync(
 				context.WithoutCancel(ctx),
 				key,
 				c.scheduleRevalidation,
@@ -417,7 +417,7 @@ func (c *cache[K, V]) SWRMany(
 
 	// Queue stale keys for background refresh
 	if len(staleKeys) > 0 {
-		c.origin.ScheduleMany(
+		c.origin.DoManyAsync(
 			context.WithoutCancel(ctx),
 			staleKeys,
 			c.scheduleRevalidation,
@@ -512,7 +512,7 @@ func (c *cache[K, V]) SWRWithFallback(
 
 		if now.Before(e.Stale) {
 			// Stale - return but queue background revalidation with deduplication
-			c.origin.Schedule(
+			c.origin.DoAsync(
 				context.WithoutCancel(ctx),
 				key,
 				c.scheduleRevalidation,

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/maypok86/otter"
@@ -26,10 +27,15 @@ type cache[K comparable, V any] struct {
 	resource string
 	clock    clock.Clock
 
-	revalidateC chan func()
-
-	// Origin deduplicates concurrent cache misses for the same key.
+	// origin deduplicates concurrent cache misses for the same key.
 	origin *singleflight.Group[K, missResult[V]]
+
+	// revalidateC carries background refreshes to the fixed worker pool.
+	revalidateC chan func()
+	// revalidationMutex protects revalidating.
+	revalidationMutex sync.Mutex
+	// revalidating contains keys with a queued or running background refresh.
+	revalidating map[K]struct{}
 }
 
 type Config[K comparable, V any] struct {
@@ -89,13 +95,15 @@ func New[K comparable, V any](config Config[K, V]) (Cache[K, V], error) {
 		return nil, err
 	}
 	c := &cache[K, V]{
-		otter:       otter,
-		fresh:       config.Fresh,
-		stale:       config.Stale,
-		resource:    config.Resource,
-		clock:       config.Clock,
-		revalidateC: make(chan func(), 1000),
-		origin:      singleflight.New[K, missResult[V]](),
+		otter:             otter,
+		fresh:             config.Fresh,
+		stale:             config.Stale,
+		resource:          config.Resource,
+		clock:             config.Clock,
+		origin:            singleflight.New[K, missResult[V]](),
+		revalidateC:       make(chan func(), 1000),
+		revalidationMutex: sync.Mutex{},
+		revalidating:      make(map[K]struct{}),
 	}
 
 	for range 10 {
@@ -302,22 +310,17 @@ func (c *cache[K, V]) SWR(
 		}
 
 		if now.Before(e.Stale) {
-			c.origin.DoAsync(
-				context.WithoutCancel(ctx),
-				key,
-				c.scheduleRevalidation,
-				func(ctx context.Context) (missResult[V], error) {
-					if entry, ok := c.get(ctx, key); ok && c.clock.Now().Before(entry.Fresh) {
-						return missResult[V]{value: entry.Value, hit: entry.Hit, err: nil}, nil
-					}
-					metrics.CacheRevalidations.WithLabelValues(c.resource).Inc()
-					result := c.loadFromOrigin(ctx, key, refreshFromOrigin, op)
-					if result.err != nil && !db.IsNotFound(result.err) {
-						logger.Warn("failed to revalidate", "error", result.err.Error(), "key", key)
-					}
-					return result, nil
-				},
-			)
+			c.queueRevalidation(key, func() {
+				revalidationCtx := context.WithoutCancel(ctx)
+				if entry, found := c.get(revalidationCtx, key); found && c.clock.Now().Before(entry.Fresh) {
+					return
+				}
+				metrics.CacheRevalidations.WithLabelValues(c.resource).Inc()
+				result := c.loadFromOrigin(revalidationCtx, key, refreshFromOrigin, op)
+				if result.err != nil && !db.IsNotFound(result.err) {
+					logger.Warn("failed to revalidate", "error", result.err.Error(), "key", key)
+				}
+			})
 			c.recordTiming(ctx, "cache_swr", "stale", start)
 			return e.Value, e.Hit, nil
 		}
@@ -419,17 +422,13 @@ func (c *cache[K, V]) SWRMany(
 	metrics.CacheSWRManyStaleKeys.WithLabelValues(c.resource).Observe(float64(len(staleKeys)))
 	if len(staleKeys) > 0 {
 		for _, key := range staleKeys {
-			c.origin.DoAsync(
-				context.WithoutCancel(ctx),
-				key,
-				c.scheduleRevalidation,
-				func(ctx context.Context) (missResult[V], error) {
-					if entry, ok := c.get(ctx, key); ok && c.clock.Now().Before(entry.Fresh) {
-						return missResult[V]{value: entry.Value, hit: entry.Hit, err: nil}, nil
-					}
-					return c.revalidateMany(ctx, []K{key}, refreshFromOrigin, op)[key], nil
-				},
-			)
+			c.queueRevalidation(key, func() {
+				revalidationCtx := context.WithoutCancel(ctx)
+				if entry, found := c.get(revalidationCtx, key); found && c.clock.Now().Before(entry.Fresh) {
+					return
+				}
+				c.revalidateMany(revalidationCtx, []K{key}, refreshFromOrigin, op)
+			})
 		}
 	}
 
@@ -504,19 +503,15 @@ func (c *cache[K, V]) SWRWithFallback(
 
 		if now.Before(e.Stale) {
 			// Stale - return but queue background revalidation with deduplication
-			c.origin.DoAsync(
-				context.WithoutCancel(ctx),
-				key,
-				c.scheduleRevalidation,
-				func(ctx context.Context) (missResult[V], error) {
-					for _, candidate := range candidates {
-						if entry, ok := c.get(ctx, candidate); ok && c.clock.Now().Before(entry.Fresh) {
-							return missResult[V]{value: entry.Value, hit: entry.Hit, err: nil}, nil
-						}
+			c.queueRevalidation(key, func() {
+				revalidationCtx := context.WithoutCancel(ctx)
+				for _, candidate := range candidates {
+					if entry, found := c.get(revalidationCtx, candidate); found && c.clock.Now().Before(entry.Fresh) {
+						return
 					}
-					return c.revalidateWithCanonicalKey(ctx, refreshFromOrigin, op), nil
-				},
-			)
+				}
+				c.revalidateWithCanonicalKey(revalidationCtx, refreshFromOrigin, op)
+			})
 			c.recordTiming(ctx, "cache_swr_fallback", "stale", start)
 			return e.Value, e.Hit, nil
 		}
@@ -555,30 +550,23 @@ func (c *cache[K, V]) revalidateWithCanonicalKey(
 	ctx context.Context,
 	refreshFromOrigin func(context.Context) (V, K, error),
 	op func(error) Op,
-) missResult[V] {
+) {
 	metrics.CacheRevalidations.WithLabelValues(c.resource).Inc()
 	v, canonicalKey, err := refreshFromOrigin(ctx)
 
 	if err != nil && !db.IsNotFound(err) {
 		logger.Warn("failed to revalidate with canonical key", "error", err.Error())
-		return missResult[V]{value: v, hit: Miss, err: err}
+		return
 	}
 
-	hit := Miss
 	switch op(err) {
 	case WriteValue:
 		c.Set(ctx, canonicalKey, v)
-		hit = Hit
 	case WriteNull:
 		c.SetNull(ctx, canonicalKey)
-		hit = Null
 	case Noop:
 		break
 	}
-	if err != nil {
-		hit = Miss
-	}
-	return missResult[V]{value: v, hit: hit, err: err}
 }
 
 func (c *cache[K, V]) revalidateMany(
@@ -586,7 +574,7 @@ func (c *cache[K, V]) revalidateMany(
 	keys []K,
 	refreshFromOrigin func(context.Context, []K) (map[K]V, error),
 	op func(error) Op,
-) map[K]missResult[V] {
+) {
 	metrics.CacheRevalidations.WithLabelValues(c.resource).Add(float64(len(keys)))
 	values, err := refreshFromOrigin(ctx, keys)
 
@@ -594,9 +582,7 @@ func (c *cache[K, V]) revalidateMany(
 		logger.Warn("failed to revalidate many", "error", err.Error(), "keys", keys)
 	}
 
-	operation := op(err)
-	results := make(map[K]missResult[V], len(keys))
-	switch operation {
+	switch op(err) {
 	case WriteValue:
 		if values != nil {
 			// Write the values we got
@@ -618,34 +604,23 @@ func (c *cache[K, V]) revalidateMany(
 	case Noop:
 		// Don't cache anything
 	}
-
-	var zero V
-	for _, key := range keys {
-		value, found := values[key]
-		hit := Miss
-		if err == nil {
-			switch operation {
-			case WriteValue:
-				if found {
-					hit = Hit
-				} else if values != nil {
-					hit = Null
-				}
-			case WriteNull:
-				hit = Null
-			case Noop:
-				break
-			}
-		}
-		if !found {
-			value = zero
-		}
-		results[key] = missResult[V]{value: value, hit: hit, err: err}
-	}
-	return results
 }
 
-// scheduleRevalidation adds reserved origin work to the bounded worker queue.
-func (c *cache[K, V]) scheduleRevalidation(revalidate func()) {
-	c.revalidateC <- revalidate
+// queueRevalidation reserves key before adding work to the bounded worker
+// queue, preventing duplicate jobs from accumulating while workers are busy.
+func (c *cache[K, V]) queueRevalidation(key K, revalidate func()) {
+	c.revalidationMutex.Lock()
+	if _, ok := c.revalidating[key]; ok {
+		c.revalidationMutex.Unlock()
+		return
+	}
+	c.revalidating[key] = struct{}{}
+	c.revalidationMutex.Unlock()
+
+	c.revalidateC <- func() {
+		revalidate()
+		c.revalidationMutex.Lock()
+		delete(c.revalidating, key)
+		c.revalidationMutex.Unlock()
+	}
 }

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -16,6 +16,7 @@ import (
 	"github.com/unkeyed/unkey/pkg/fault"
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/pkg/repeat"
+	"github.com/unkeyed/unkey/pkg/singleflight"
 	"github.com/unkeyed/unkey/pkg/timing"
 )
 
@@ -30,6 +31,8 @@ type cache[K comparable, V any] struct {
 
 	inflightMu        sync.Mutex
 	inflightRefreshes map[K]bool
+	// Origin deduplicates concurrent cache misses for the same key.
+	origin *singleflight.Group[K, missResult[V]]
 }
 
 type Config[K comparable, V any] struct {
@@ -47,6 +50,17 @@ type Config[K comparable, V any] struct {
 	Resource string
 
 	Clock clock.Clock
+}
+
+// missResult carries the outcome returned to callers sharing cache-miss work.
+type missResult[V any] struct {
+	// Value is returned to every caller sharing the cache miss.
+	value V
+	// Hit is the cache status returned with value. Origin errors always report a
+	// miss, even when the selected operation writes a cache entry.
+	hit CacheHit
+	// Err is returned to every caller sharing the cache miss.
+	err error
 }
 
 var _ Cache[any, any] = (*cache[any, any])(nil)
@@ -86,6 +100,7 @@ func New[K comparable, V any](config Config[K, V]) (Cache[K, V], error) {
 		revalidateC:       make(chan func(), 1000),
 		inflightMu:        sync.Mutex{},
 		inflightRefreshes: make(map[K]bool),
+		origin:            singleflight.New[K, missResult[V]](),
 	}
 
 	for range 10 {
@@ -296,19 +311,10 @@ func (c *cache[K, V]) revalidate(
 	}()
 
 	metrics.CacheRevalidations.WithLabelValues(c.resource).Inc()
-	v, err := refreshFromOrigin(ctx)
+	result := c.loadFromOrigin(ctx, key, refreshFromOrigin, op)
 
-	if err != nil && !db.IsNotFound(err) {
-		logger.Warn("failed to revalidate", "error", err.Error(), "key", key)
-	}
-
-	switch op(err) {
-	case WriteValue:
-		c.Set(ctx, key, v)
-	case WriteNull:
-		c.SetNull(ctx, key)
-	case Noop:
-		break
+	if result.err != nil && !db.IsNotFound(result.err) {
+		logger.Warn("failed to revalidate", "error", result.err.Error(), "key", key)
 	}
 }
 
@@ -332,7 +338,7 @@ func (c *cache[K, V]) SWR(
 		if now.Before(e.Stale) {
 			c.revalidateC <- func() {
 				// If we don't uncancel the context, the revalidation will get canceled when
-				// the api response is returned
+				// the api response is returned.
 				c.revalidate(context.WithoutCancel(ctx), key, refreshFromOrigin, op)
 			}
 			c.recordTiming(ctx, "cache_swr", "stale", start)
@@ -343,38 +349,52 @@ func (c *cache[K, V]) SWR(
 		c.otter.Delete(key)
 	}
 
-	// Cache Miss - measure total time including all overhead
-	v, err := refreshFromOrigin(ctx)
+	// A cache miss includes time spent waiting for an existing origin load.
+	result, waitErr := c.origin.Do(ctx, key, func(ctx context.Context) (missResult[V], error) {
+		// Another caller may have filled the cache after this caller observed the
+		// miss but before it entered the singleflight group.
+		if entry, ok := c.get(ctx, key); ok && c.clock.Now().Before(entry.Stale) {
+			return missResult[V]{value: entry.Value, hit: entry.Hit, err: nil}, nil
+		}
+		return c.loadFromOrigin(ctx, key, refreshFromOrigin, op), nil
+	})
 	c.recordTiming(ctx, "cache_swr", "miss", start)
+	if waitErr != nil {
+		var zero V
+		return zero, Miss, waitErr
+	}
 
-	switch op(err) {
+	return result.value, result.hit, result.err
+}
+
+// loadFromOrigin loads one value and applies the requested cache operation.
+// The returned result preserves the origin error while describing any cache
+// entry written by operationForError.
+func (c *cache[K, V]) loadFromOrigin(
+	ctx context.Context,
+	key K,
+	refreshFromOrigin func(context.Context) (V, error),
+	operationForError func(error) Op,
+) missResult[V] {
+	v, err := refreshFromOrigin(ctx)
+	operation := operationForError(err)
+	hit := Miss
+
+	switch operation {
 	case WriteValue:
 		c.Set(ctx, key, v)
+		hit = Hit
 	case WriteNull:
 		c.SetNull(ctx, key)
+		hit = Null
 	case Noop:
 		break
 	}
 
 	if err != nil {
-		// Error occurred, return Miss as the cache hit status
-		return v, Miss, err
-	}
-
-	// Determine cache hit status based on the operation
-	var hit CacheHit
-	switch op(err) {
-	case Noop:
-		// Skip
-	case WriteValue:
-		hit = Hit
-	case WriteNull:
-		hit = Null
-	default:
 		hit = Miss
 	}
-
-	return v, hit, err
+	return missResult[V]{value: v, hit: hit, err: err}
 }
 
 func (c *cache[K, V]) SWRMany(

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/maypok86/otter"
@@ -29,8 +28,6 @@ type cache[K comparable, V any] struct {
 
 	revalidateC chan func()
 
-	inflightMu        sync.Mutex
-	inflightRefreshes map[K]bool
 	// Origin deduplicates concurrent cache misses for the same key.
 	origin *singleflight.Group[K, missResult[V]]
 }
@@ -92,15 +89,13 @@ func New[K comparable, V any](config Config[K, V]) (Cache[K, V], error) {
 		return nil, err
 	}
 	c := &cache[K, V]{
-		otter:             otter,
-		fresh:             config.Fresh,
-		stale:             config.Stale,
-		resource:          config.Resource,
-		clock:             config.Clock,
-		revalidateC:       make(chan func(), 1000),
-		inflightMu:        sync.Mutex{},
-		inflightRefreshes: make(map[K]bool),
-		origin:            singleflight.New[K, missResult[V]](),
+		otter:       otter,
+		fresh:       config.Fresh,
+		stale:       config.Stale,
+		resource:    config.Resource,
+		clock:       config.Clock,
+		revalidateC: make(chan func(), 1000),
+		origin:      singleflight.New[K, missResult[V]](),
 	}
 
 	for range 10 {
@@ -289,35 +284,6 @@ func (c *cache[K, V]) Name() string {
 	return c.resource
 }
 
-func (c *cache[K, V]) revalidate(
-	ctx context.Context,
-	key K, refreshFromOrigin func(context.Context) (V, error),
-	op func(error) Op,
-) {
-	c.inflightMu.Lock()
-	_, ok := c.inflightRefreshes[key]
-	if ok {
-		c.inflightMu.Unlock()
-		return
-	}
-
-	c.inflightRefreshes[key] = true
-	c.inflightMu.Unlock()
-
-	defer func() {
-		c.inflightMu.Lock()
-		delete(c.inflightRefreshes, key)
-		c.inflightMu.Unlock()
-	}()
-
-	metrics.CacheRevalidations.WithLabelValues(c.resource).Inc()
-	result := c.loadFromOrigin(ctx, key, refreshFromOrigin, op)
-
-	if result.err != nil && !db.IsNotFound(result.err) {
-		logger.Warn("failed to revalidate", "error", result.err.Error(), "key", key)
-	}
-}
-
 func (c *cache[K, V]) SWR(
 	ctx context.Context,
 	key K,
@@ -336,11 +302,22 @@ func (c *cache[K, V]) SWR(
 		}
 
 		if now.Before(e.Stale) {
-			c.revalidateC <- func() {
-				// If we don't uncancel the context, the revalidation will get canceled when
-				// the api response is returned.
-				c.revalidate(context.WithoutCancel(ctx), key, refreshFromOrigin, op)
-			}
+			c.origin.Schedule(
+				context.WithoutCancel(ctx),
+				key,
+				c.scheduleRevalidation,
+				func(ctx context.Context) (missResult[V], error) {
+					if entry, ok := c.get(ctx, key); ok && c.clock.Now().Before(entry.Fresh) {
+						return missResult[V]{value: entry.Value, hit: entry.Hit, err: nil}, nil
+					}
+					metrics.CacheRevalidations.WithLabelValues(c.resource).Inc()
+					result := c.loadFromOrigin(ctx, key, refreshFromOrigin, op)
+					if result.err != nil && !db.IsNotFound(result.err) {
+						logger.Warn("failed to revalidate", "error", result.err.Error(), "key", key)
+					}
+					return result, nil
+				},
+			)
 			c.recordTiming(ctx, "cache_swr", "stale", start)
 			return e.Value, e.Hit, nil
 		}
@@ -440,9 +417,28 @@ func (c *cache[K, V]) SWRMany(
 
 	// Queue stale keys for background refresh
 	if len(staleKeys) > 0 {
-		c.revalidateC <- func() {
-			c.revalidateMany(context.WithoutCancel(ctx), staleKeys, refreshFromOrigin, op)
-		}
+		c.origin.ScheduleMany(
+			context.WithoutCancel(ctx),
+			staleKeys,
+			c.scheduleRevalidation,
+			func(ctx context.Context, keys []K) (map[K]missResult[V], error) {
+				results := make(map[K]missResult[V], len(keys))
+				keysToRefresh := make([]K, 0, len(keys))
+				for _, key := range keys {
+					if entry, ok := c.get(ctx, key); ok && c.clock.Now().Before(entry.Fresh) {
+						results[key] = missResult[V]{value: entry.Value, hit: entry.Hit, err: nil}
+						continue
+					}
+					keysToRefresh = append(keysToRefresh, key)
+				}
+				if len(keysToRefresh) > 0 {
+					for key, result := range c.revalidateMany(ctx, keysToRefresh, refreshFromOrigin, op) {
+						results[key] = result
+					}
+				}
+				return results, nil
+			},
+		)
 	}
 
 	// Fetch missing keys synchronously
@@ -516,15 +512,19 @@ func (c *cache[K, V]) SWRWithFallback(
 
 		if now.Before(e.Stale) {
 			// Stale - return but queue background revalidation with deduplication
-			c.inflightMu.Lock()
-			if !c.inflightRefreshes[key] {
-				c.inflightRefreshes[key] = true
-				dedupeKey := key // capture for closure
-				c.revalidateC <- func() {
-					c.revalidateWithCanonicalKey(context.WithoutCancel(ctx), dedupeKey, refreshFromOrigin, op)
-				}
-			}
-			c.inflightMu.Unlock()
+			c.origin.Schedule(
+				context.WithoutCancel(ctx),
+				key,
+				c.scheduleRevalidation,
+				func(ctx context.Context) (missResult[V], error) {
+					for _, candidate := range candidates {
+						if entry, ok := c.get(ctx, candidate); ok && c.clock.Now().Before(entry.Fresh) {
+							return missResult[V]{value: entry.Value, hit: entry.Hit, err: nil}, nil
+						}
+					}
+					return c.revalidateWithCanonicalKey(ctx, refreshFromOrigin, op), nil
+				},
+			)
 			c.recordTiming(ctx, "cache_swr_fallback", "stale", start)
 			return e.Value, e.Hit, nil
 		}
@@ -561,32 +561,32 @@ func (c *cache[K, V]) SWRWithFallback(
 
 func (c *cache[K, V]) revalidateWithCanonicalKey(
 	ctx context.Context,
-	dedupeKey K,
 	refreshFromOrigin func(context.Context) (V, K, error),
 	op func(error) Op,
-) {
-	defer func() {
-		c.inflightMu.Lock()
-		delete(c.inflightRefreshes, dedupeKey)
-		c.inflightMu.Unlock()
-	}()
-
+) missResult[V] {
 	metrics.CacheRevalidations.WithLabelValues(c.resource).Inc()
 	v, canonicalKey, err := refreshFromOrigin(ctx)
 
 	if err != nil && !db.IsNotFound(err) {
 		logger.Warn("failed to revalidate with canonical key", "error", err.Error())
-		return
+		return missResult[V]{value: v, hit: Miss, err: err}
 	}
 
+	hit := Miss
 	switch op(err) {
 	case WriteValue:
 		c.Set(ctx, canonicalKey, v)
+		hit = Hit
 	case WriteNull:
 		c.SetNull(ctx, canonicalKey)
+		hit = Null
 	case Noop:
 		break
 	}
+	if err != nil {
+		hit = Miss
+	}
+	return missResult[V]{value: v, hit: hit, err: err}
 }
 
 func (c *cache[K, V]) revalidateMany(
@@ -594,38 +594,17 @@ func (c *cache[K, V]) revalidateMany(
 	keys []K,
 	refreshFromOrigin func(context.Context, []K) (map[K]V, error),
 	op func(error) Op,
-) {
-	// Lock to prevent duplicate revalidations
-	c.inflightMu.Lock()
-	var keysToRefresh []K
-	for _, key := range keys {
-		if !c.inflightRefreshes[key] {
-			c.inflightRefreshes[key] = true
-			keysToRefresh = append(keysToRefresh, key)
-		}
-	}
-	c.inflightMu.Unlock()
-
-	if len(keysToRefresh) == 0 {
-		return
-	}
-
-	defer func() {
-		c.inflightMu.Lock()
-		for _, key := range keysToRefresh {
-			delete(c.inflightRefreshes, key)
-		}
-		c.inflightMu.Unlock()
-	}()
-
-	metrics.CacheRevalidations.WithLabelValues(c.resource).Add(float64(len(keysToRefresh)))
-	values, err := refreshFromOrigin(ctx, keysToRefresh)
+) map[K]missResult[V] {
+	metrics.CacheRevalidations.WithLabelValues(c.resource).Add(float64(len(keys)))
+	values, err := refreshFromOrigin(ctx, keys)
 
 	if err != nil && !db.IsNotFound(err) {
-		logger.Warn("failed to revalidate many", "error", err.Error(), "keys", keysToRefresh)
+		logger.Warn("failed to revalidate many", "error", err.Error(), "keys", keys)
 	}
 
-	switch op(err) {
+	operation := op(err)
+	results := make(map[K]missResult[V], len(keys))
+	switch operation {
 	case WriteValue:
 		if values != nil {
 			// Write the values we got
@@ -633,7 +612,7 @@ func (c *cache[K, V]) revalidateMany(
 
 			// Automatically write NULL for keys that weren't returned
 			var notFoundKeys []K
-			for _, key := range keysToRefresh {
+			for _, key := range keys {
 				if _, found := values[key]; !found {
 					notFoundKeys = append(notFoundKeys, key)
 				}
@@ -643,8 +622,38 @@ func (c *cache[K, V]) revalidateMany(
 			}
 		}
 	case WriteNull:
-		c.SetNullMany(ctx, keysToRefresh)
+		c.SetNullMany(ctx, keys)
 	case Noop:
 		// Don't cache anything
 	}
+
+	var zero V
+	for _, key := range keys {
+		value, found := values[key]
+		hit := Miss
+		if err == nil {
+			switch operation {
+			case WriteValue:
+				if found {
+					hit = Hit
+				} else if values != nil {
+					hit = Null
+				}
+			case WriteNull:
+				hit = Null
+			case Noop:
+				break
+			}
+		}
+		if !found {
+			value = zero
+		}
+		results[key] = missResult[V]{value: value, hit: hit, err: err}
+	}
+	return results
+}
+
+// scheduleRevalidation adds reserved origin work to the bounded worker queue.
+func (c *cache[K, V]) scheduleRevalidation(revalidate func()) {
+	c.revalidateC <- revalidate
 }

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -417,7 +417,7 @@ func (c *cache[K, V]) SWRMany(
 
 	// Queue stale keys for background refresh
 	if len(staleKeys) > 0 {
-		c.origin.DoManyAsync(
+		c.origin.DoAsyncMany(
 			context.WithoutCancel(ctx),
 			staleKeys,
 			c.scheduleRevalidation,

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -416,29 +416,21 @@ func (c *cache[K, V]) SWRMany(
 	}
 
 	// Queue stale keys for background refresh
+	metrics.CacheSWRManyStaleKeys.WithLabelValues(c.resource).Observe(float64(len(staleKeys)))
 	if len(staleKeys) > 0 {
-		c.origin.DoAsyncMany(
-			context.WithoutCancel(ctx),
-			staleKeys,
-			c.scheduleRevalidation,
-			func(ctx context.Context, keys []K) (map[K]missResult[V], error) {
-				results := make(map[K]missResult[V], len(keys))
-				keysToRefresh := make([]K, 0, len(keys))
-				for _, key := range keys {
+		for _, key := range staleKeys {
+			c.origin.DoAsync(
+				context.WithoutCancel(ctx),
+				key,
+				c.scheduleRevalidation,
+				func(ctx context.Context) (missResult[V], error) {
 					if entry, ok := c.get(ctx, key); ok && c.clock.Now().Before(entry.Fresh) {
-						results[key] = missResult[V]{value: entry.Value, hit: entry.Hit, err: nil}
-						continue
+						return missResult[V]{value: entry.Value, hit: entry.Hit, err: nil}, nil
 					}
-					keysToRefresh = append(keysToRefresh, key)
-				}
-				if len(keysToRefresh) > 0 {
-					for key, result := range c.revalidateMany(ctx, keysToRefresh, refreshFromOrigin, op) {
-						results[key] = result
-					}
-				}
-				return results, nil
-			},
-		)
+					return c.revalidateMany(ctx, []K{key}, refreshFromOrigin, op)[key], nil
+				},
+			)
+		}
 	}
 
 	// Fetch missing keys synchronously

--- a/pkg/cache/many_test.go
+++ b/pkg/cache/many_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -520,4 +521,57 @@ func TestSWRMany(t *testing.T) {
 		require.Equal(t, cache.Null, hits2["missing2"]) // Cached as null
 		require.Equal(t, "", values2["missing2"])
 	})
+}
+
+// TestSWRMany_BatchesStaleRevalidation guarantees that one request containing
+// stale and duplicate keys starts only one background origin load.
+func TestSWRMany_BatchesStaleRevalidation(t *testing.T) {
+	ctx := context.Background()
+	mockClock := clock.NewTestClock()
+	c, err := cache.New(cache.Config[string, string]{
+		Fresh:    time.Minute,
+		Stale:    5 * time.Minute,
+		MaxSize:  100,
+		Resource: "test",
+		Clock:    mockClock,
+	})
+	require.NoError(t, err)
+
+	keys := []string{"a", "b", "c"}
+	for _, key := range keys {
+		c.Set(ctx, key, "old_"+key)
+	}
+	mockClock.Tick(2 * time.Minute)
+
+	var loadCount atomic.Int32
+	loadedKeys := make(chan []string, 1)
+	releaseLoad := make(chan struct{})
+	loader := func(_ context.Context, keysToFetch []string) (map[string]string, error) {
+		loadCount.Add(1)
+		loadedKeys <- append([]string(nil), keysToFetch...)
+		<-releaseLoad
+		return map[string]string{"a": "new_a", "b": "new_b"}, nil
+	}
+	cacheOperation := func(error) cache.Op { return cache.WriteValue }
+
+	values, hits, err := c.SWRMany(ctx, append(keys, "a"), loader, cacheOperation)
+	require.NoError(t, err)
+	for _, key := range keys {
+		require.Equal(t, "old_"+key, values[key])
+		require.Equal(t, cache.Hit, hits[key])
+	}
+	require.Equal(t, keys, <-loadedKeys)
+
+	_, _, err = c.SWRMany(ctx, keys, loader, cacheOperation)
+	require.NoError(t, err)
+	require.Equal(t, int32(1), loadCount.Load())
+
+	close(releaseLoad)
+	require.Eventually(t, func() bool {
+		valueA, hitA := c.Get(ctx, "a")
+		valueB, hitB := c.Get(ctx, "b")
+		_, hitC := c.Get(ctx, "c")
+		return valueA == "new_a" && hitA == cache.Hit &&
+			valueB == "new_b" && hitB == cache.Hit && hitC == cache.Null
+	}, time.Second, time.Millisecond)
 }

--- a/pkg/cache/many_test.go
+++ b/pkg/cache/many_test.go
@@ -523,9 +523,9 @@ func TestSWRMany(t *testing.T) {
 	})
 }
 
-// TestSWRMany_BatchesStaleRevalidation guarantees that one request containing
-// stale and duplicate keys starts only one background origin load.
-func TestSWRMany_BatchesStaleRevalidation(t *testing.T) {
+// TestSWRMany_DeduplicatesStaleRevalidationByKey guarantees that duplicate
+// stale keys reserve only one background origin load per key.
+func TestSWRMany_DeduplicatesStaleRevalidationByKey(t *testing.T) {
 	ctx := context.Background()
 	mockClock := clock.NewTestClock()
 	c, err := cache.New(cache.Config[string, string]{
@@ -544,7 +544,7 @@ func TestSWRMany_BatchesStaleRevalidation(t *testing.T) {
 	mockClock.Tick(2 * time.Minute)
 
 	var loadCount atomic.Int32
-	loadedKeys := make(chan []string, 1)
+	loadedKeys := make(chan []string, len(keys))
 	releaseLoad := make(chan struct{})
 	loader := func(_ context.Context, keysToFetch []string) (map[string]string, error) {
 		loadCount.Add(1)
@@ -560,11 +560,17 @@ func TestSWRMany_BatchesStaleRevalidation(t *testing.T) {
 		require.Equal(t, "old_"+key, values[key])
 		require.Equal(t, cache.Hit, hits[key])
 	}
-	require.Equal(t, keys, <-loadedKeys)
+	loaded := make(map[string]bool, len(keys))
+	for range keys {
+		keysToFetch := <-loadedKeys
+		require.Len(t, keysToFetch, 1)
+		loaded[keysToFetch[0]] = true
+	}
+	require.Equal(t, map[string]bool{"a": true, "b": true, "c": true}, loaded)
 
 	_, _, err = c.SWRMany(ctx, keys, loader, cacheOperation)
 	require.NoError(t, err)
-	require.Equal(t, int32(1), loadCount.Load())
+	require.Equal(t, int32(len(keys)), loadCount.Load())
 
 	close(releaseLoad)
 	require.Eventually(t, func() bool {

--- a/pkg/cache/metrics/prometheus.go
+++ b/pkg/cache/metrics/prometheus.go
@@ -100,6 +100,20 @@ var (
 		[]string{"resource"},
 	)
 
+	// CacheSWRManyStaleKeys tracks how many stale keys are found by each SWRMany call.
+	// The distribution shows whether batching stale background refreshes would
+	// combine enough keys to justify the additional coordination complexity.
+	CacheSWRManyStaleKeys = lazy.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "unkey",
+			Subsystem: "cache",
+			Name:      "swr_many_stale_keys",
+			Help:      "Distribution of stale key counts observed by SWRMany calls.",
+			Buckets:   []float64{0, 1, 2, 5, 10, 20, 50, 100, 200, 500, 1000},
+		},
+		[]string{"resource"},
+	)
+
 	// CacheReadsErrorsTotal tracks the total number of cache read errors,
 	// labeled by resource type. Use this counter to monitor cache read error rates.
 	//

--- a/pkg/cache/swr_test.go
+++ b/pkg/cache/swr_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -151,4 +153,137 @@ func TestSWR_CacheHit(t *testing.T) {
 		require.Equal(t, "", value)
 		require.Equal(t, cache.Miss, hit)
 	})
+}
+
+// TestSWR_DeduplicatesConcurrentMisses guarantees that concurrent misses for
+// one key produce one origin load and share its result.
+func TestSWR_DeduplicatesConcurrentMisses(t *testing.T) {
+	ctx := context.Background()
+	c, err := cache.New(cache.Config[string, string]{
+		Fresh:    time.Minute,
+		Stale:    5 * time.Minute,
+		MaxSize:  100,
+		Resource: "test",
+		Clock:    clock.NewTestClock(),
+	})
+	require.NoError(t, err)
+
+	var loadCount atomic.Int32
+	loadStarted := make(chan struct{})
+	releaseLoad := make(chan struct{})
+	var loadStartedOnce sync.Once
+
+	load := func(context.Context) (string, error) {
+		loadCount.Add(1)
+		loadStartedOnce.Do(func() { close(loadStarted) })
+		<-releaseLoad
+		return "value", nil
+	}
+
+	type swrResult struct {
+		value string
+		hit   cache.CacheHit
+		err   error
+	}
+	firstDone := make(chan swrResult, 1)
+	go func() {
+		value, hit, loadErr := c.SWR(ctx, "key", load, func(error) cache.Op {
+			return cache.WriteValue
+		})
+		firstDone <- swrResult{value: value, hit: hit, err: loadErr}
+	}()
+
+	require.Eventually(t, func() bool {
+		select {
+		case <-loadStarted:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond)
+
+	const waiterCount = 16
+	var waitGroup sync.WaitGroup
+	waitGroup.Add(waiterCount)
+	callErrors := make(chan error, waiterCount)
+	for range waiterCount {
+		go func() {
+			defer waitGroup.Done()
+			value, hit, loadErr := c.SWR(ctx, "key", load, func(error) cache.Op {
+				return cache.WriteValue
+			})
+			if loadErr != nil {
+				callErrors <- loadErr
+				return
+			}
+			if hit != cache.Hit || value != "value" {
+				callErrors <- errors.New("unexpected cache result")
+			}
+		}()
+	}
+
+	require.Equal(t, int32(1), loadCount.Load())
+	close(releaseLoad)
+
+	first := <-firstDone
+	require.NoError(t, first.err)
+	require.Equal(t, cache.Hit, first.hit)
+	require.Equal(t, "value", first.value)
+	waitGroup.Wait()
+	close(callErrors)
+	require.Empty(t, callErrors)
+	require.Equal(t, int32(1), loadCount.Load())
+}
+
+// TestSWR_CanceledMissDoesNotStartAnotherLoad guarantees that an already
+// canceled miss returns without duplicating an active origin load.
+func TestSWR_CanceledMissDoesNotStartAnotherLoad(t *testing.T) {
+	ctx := context.Background()
+	c, err := cache.New(cache.Config[string, string]{
+		Fresh:    time.Minute,
+		Stale:    5 * time.Minute,
+		MaxSize:  100,
+		Resource: "test",
+		Clock:    clock.NewTestClock(),
+	})
+	require.NoError(t, err)
+
+	var loadCount atomic.Int32
+	loadStarted := make(chan struct{})
+	releaseLoad := make(chan struct{})
+	var loadStartedOnce sync.Once
+	load := func(context.Context) (string, error) {
+		loadCount.Add(1)
+		loadStartedOnce.Do(func() { close(loadStarted) })
+		<-releaseLoad
+		return "value", nil
+	}
+
+	executingDone := make(chan error, 1)
+	go func() {
+		_, _, loadErr := c.SWR(ctx, "key", load, func(error) cache.Op {
+			return cache.WriteValue
+		})
+		executingDone <- loadErr
+	}()
+	require.Eventually(t, func() bool {
+		select {
+		case <-loadStarted:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond)
+
+	canceledCtx, cancel := context.WithCancel(ctx)
+	cancel()
+	_, hit, err := c.SWR(canceledCtx, "key", load, func(error) cache.Op {
+		return cache.WriteValue
+	})
+	require.ErrorIs(t, err, context.Canceled)
+	require.Equal(t, cache.Miss, hit)
+	require.Equal(t, int32(1), loadCount.Load())
+
+	close(releaseLoad)
+	require.NoError(t, <-executingDone)
 }

--- a/pkg/singleflight/doc.go
+++ b/pkg/singleflight/doc.go
@@ -1,0 +1,7 @@
+// Package singleflight deduplicates concurrent function calls by key while
+// allowing calls for different keys to proceed independently.
+//
+// Waiting callers can cancel independently without canceling the executing
+// caller. If that caller is canceled or panics, waiters retry with their own
+// function and context. Groups must be constructed with [New].
+package singleflight

--- a/pkg/singleflight/singleflight.go
+++ b/pkg/singleflight/singleflight.go
@@ -64,10 +64,10 @@ func (g *Group[K, V]) Do(
 	}
 }
 
-// Schedule reserves key before passing its work to schedule. It returns true
+// DoAsync reserves key before passing its work to schedule. It returns true
 // when work was scheduled and false when another call already reserved key.
-// Schedule must accept the work without executing it before returning.
-func (g *Group[K, V]) Schedule(
+// DoAsync must accept the work without executing it before returning.
+func (g *Group[K, V]) DoAsync(
 	ctx context.Context,
 	key K,
 	schedule func(func()),
@@ -99,11 +99,11 @@ func (g *Group[K, V]) Schedule(
 	return true
 }
 
-// ScheduleMany reserves every currently inactive key before passing one batch
+// DoManyAsync reserves every currently inactive key before passing one batch
 // to schedule. It returns true when at least one key was scheduled. The
 // function must return a result for each key that it receives.
-// ScheduleMany must accept the work without executing it before returning.
-func (g *Group[K, V]) ScheduleMany(
+// DoManyAsync must accept the work without executing it before returning.
+func (g *Group[K, V]) DoManyAsync(
 	ctx context.Context,
 	keys []K,
 	schedule func(func()),

--- a/pkg/singleflight/singleflight.go
+++ b/pkg/singleflight/singleflight.go
@@ -99,41 +99,6 @@ func (g *Group[K, V]) DoAsync(
 	return true
 }
 
-// DoAsyncMany reserves every currently inactive key before passing one batch
-// to schedule. It returns true when at least one key was scheduled. The
-// function must return a result for each key that it receives.
-// DoAsyncMany must accept the work without executing it before returning.
-func (g *Group[K, V]) DoAsyncMany(
-	ctx context.Context,
-	keys []K,
-	schedule func(func()),
-	function func(context.Context, []K) (map[K]V, error),
-) bool {
-	if g == nil || g.calls == nil {
-		panic("singleflight: Group must be constructed with New")
-	}
-	if ctx.Err() != nil {
-		return false
-	}
-
-	activeCalls, keysToExecute := g.acquireMany(keys)
-	if len(keysToExecute) == 0 {
-		return false
-	}
-
-	scheduled := false
-	defer func() {
-		if !scheduled {
-			g.finishMany(activeCalls, nil, nil, true)
-		}
-	}()
-	schedule(func() {
-		g.executeMany(ctx, activeCalls, keysToExecute, function)
-	})
-	scheduled = true
-	return true
-}
-
 // call represents one in-flight call and its published result. Waiters must
 // read retry, value, and err only after done closes.
 type call[V any] struct {
@@ -170,38 +135,6 @@ func (g *Group[K, V]) acquire(key K) (activeCall *call[V], shouldExecute bool) {
 	return activeCall, true
 }
 
-// acquireMany reserves each unique key that has no active call. Holding one
-// lock preserves the input batch against interleaved reservations.
-func (g *Group[K, V]) acquireMany(keys []K) (map[K]*call[V], []K) {
-	g.mutex.Lock()
-	defer g.mutex.Unlock()
-
-	activeCalls := make(map[K]*call[V], len(keys))
-	keysToExecute := make([]K, 0, len(keys))
-	seen := make(map[K]struct{}, len(keys))
-	for _, key := range keys {
-		if _, ok := seen[key]; ok {
-			continue
-		}
-		seen[key] = struct{}{}
-		if _, ok := g.calls[key]; ok {
-			continue
-		}
-
-		var zero V
-		activeCall := &call[V]{
-			done:  make(chan struct{}),
-			retry: false,
-			value: zero,
-			err:   nil,
-		}
-		g.calls[key] = activeCall
-		activeCalls[key] = activeCall
-		keysToExecute = append(keysToExecute, key)
-	}
-	return activeCalls, keysToExecute
-}
-
 // execute runs one reserved call and always releases its waiters. A panic marks
 // the result for retry before propagating to the executing caller.
 func (g *Group[K, V]) execute(
@@ -230,36 +163,6 @@ func (g *Group[K, V]) execute(
 	return value, err
 }
 
-// executeMany runs one reserved batch and always releases every key. A panic
-// marks every result for retry before propagating to the executing caller.
-func (g *Group[K, V]) executeMany(
-	ctx context.Context,
-	activeCalls map[K]*call[V],
-	keys []K,
-	function func(context.Context, []K) (map[K]V, error),
-) {
-	if ctx.Err() != nil {
-		g.finishMany(activeCalls, nil, nil, true)
-		return
-	}
-
-	functionReturned := false
-	defer func() {
-		if !functionReturned {
-			g.finishMany(activeCalls, nil, nil, true)
-		}
-	}()
-
-	values, err := function(ctx, keys)
-	for _, key := range keys {
-		if _, ok := values[key]; !ok {
-			panic("singleflight: batch function omitted a result")
-		}
-	}
-	functionReturned = true
-	g.finishMany(activeCalls, values, err, ctx.Err() != nil)
-}
-
 // finish publishes a call result, removes its reservation, and releases its
 // waiters. Callers must invoke finish exactly once for each reserved call.
 func (g *Group[K, V]) finish(
@@ -279,32 +182,5 @@ func (g *Group[K, V]) finish(
 	activeCall.err = err
 	delete(g.calls, key)
 	close(activeCall.done)
-	g.mutex.Unlock()
-}
-
-// finishMany publishes one batch, removes its reservations, and releases its
-// waiters as one atomic state transition.
-func (g *Group[K, V]) finishMany(
-	activeCalls map[K]*call[V],
-	values map[K]V,
-	err error,
-	retry bool,
-) {
-	g.mutex.Lock()
-	for key, activeCall := range activeCalls {
-		if g.calls[key] != activeCall {
-			g.mutex.Unlock()
-			panic("singleflight: cannot finish an unregistered call")
-		}
-	}
-	for key, activeCall := range activeCalls {
-		activeCall.retry = retry
-		activeCall.value = values[key]
-		activeCall.err = err
-		delete(g.calls, key)
-	}
-	for _, activeCall := range activeCalls {
-		close(activeCall.done)
-	}
 	g.mutex.Unlock()
 }

--- a/pkg/singleflight/singleflight.go
+++ b/pkg/singleflight/singleflight.go
@@ -1,28 +1,135 @@
 package singleflight
 
-import "golang.org/x/sync/singleflight"
+import (
+	"context"
+	"sync"
+)
 
-// Group is a type-safe wrapper around singleflight.Group.
-// It deduplicates concurrent calls with the same key so only one
-// executes while others wait and share the result.
-type Group[T any] struct {
-	g singleflight.Group
+// Group deduplicates concurrent calls for the same key. Calls for different
+// keys proceed independently. Groups must be constructed with [New] and are safe
+// for concurrent access.
+type Group[K comparable, V any] struct {
+	// The mutex protects calls and result publication.
+	mutex sync.Mutex
+	// Calls contains active calls indexed by key. A call is removed before its
+	// done channel closes so a retry cannot join a completed call.
+	calls map[K]*call[V]
 }
 
-// Do executes fn once for a given key. If a duplicate call comes in
-// while the first is still running, the duplicate caller waits and
-// receives the same result.
-func (g *Group[T]) Do(key string, fn func() (T, error)) (T, error) {
-	v, err, _ := g.g.Do(key, func() (any, error) {
-		return fn()
-	})
-	if err != nil {
-		var zero T
-		return zero, err
+// New returns a Group with no active calls.
+func New[K comparable, V any]() *Group[K, V] {
+	return &Group[K, V]{
+		mutex: sync.Mutex{},
+		calls: make(map[K]*call[V]),
 	}
-	if v == nil {
-		var zero T
-		return zero, nil
+}
+
+// Do runs function once for key and returns the result to concurrent callers
+// waiting on the same key. A waiting caller can stop waiting when its context
+// is canceled without canceling the active call.
+func (g *Group[K, V]) Do(
+	ctx context.Context,
+	key K,
+	function func(context.Context) (V, error),
+) (V, error) {
+	if g == nil || g.calls == nil {
+		panic("singleflight: Group must be constructed with New")
 	}
-	return v.(T), nil
+
+	// If the executing caller is canceled or panics, a waiter retries with its
+	// own function and context rather than reusing an incomplete result.
+	for {
+		if err := ctx.Err(); err != nil {
+			var zero V
+			return zero, err
+		}
+
+		activeCall, shouldExecute := g.acquire(key)
+		if shouldExecute {
+			functionReturned := false
+			// A panic must release the key and wake waiters before propagating.
+			defer func() {
+				if !functionReturned {
+					var zero V
+					g.finish(key, activeCall, zero, nil, true)
+				}
+			}()
+
+			value, err := function(ctx)
+			functionReturned = true
+			g.finish(key, activeCall, value, err, ctx.Err() != nil)
+			return value, err
+		}
+
+		// Another call for this key is already in progress. Wait for its result
+		// or stop when this caller's context is canceled.
+		select {
+		case <-activeCall.done:
+			if activeCall.retry {
+				continue
+			}
+			return activeCall.value, activeCall.err
+		case <-ctx.Done():
+			var zero V
+			return zero, ctx.Err()
+		}
+	}
+}
+
+// call represents one in-flight call and its published result. Waiters must
+// read retry, value, and err only after done closes.
+type call[V any] struct {
+	// Done closes after retry, value, and err have been published.
+	done chan struct{}
+	// Retry tells waiters to execute their own function because this call was
+	// canceled or panicked.
+	retry bool
+	// Value is shared by callers waiting for the same key.
+	value V
+	// Err is the error returned with value.
+	err error
+}
+
+// acquire returns the active call for key. If no call exists, it registers one
+// and instructs the caller to execute the function. Otherwise, the caller waits
+// for the returned call.
+func (g *Group[K, V]) acquire(key K) (activeCall *call[V], shouldExecute bool) {
+	g.mutex.Lock()
+	defer g.mutex.Unlock()
+
+	if activeCall, ok := g.calls[key]; ok {
+		return activeCall, false
+	}
+
+	var zero V
+	activeCall = &call[V]{
+		done:  make(chan struct{}),
+		retry: false,
+		value: zero,
+		err:   nil,
+	}
+	g.calls[key] = activeCall
+	return activeCall, true
+}
+
+// finish publishes a call result, removes its reservation, and releases its
+// waiters. Callers must invoke finish exactly once for each reserved call.
+func (g *Group[K, V]) finish(
+	key K,
+	activeCall *call[V],
+	value V,
+	err error,
+	retry bool,
+) {
+	g.mutex.Lock()
+	if g.calls[key] != activeCall {
+		g.mutex.Unlock()
+		panic("singleflight: cannot finish an unregistered call")
+	}
+	activeCall.retry = retry
+	activeCall.value = value
+	activeCall.err = err
+	delete(g.calls, key)
+	close(activeCall.done)
+	g.mutex.Unlock()
 }

--- a/pkg/singleflight/singleflight.go
+++ b/pkg/singleflight/singleflight.go
@@ -64,41 +64,6 @@ func (g *Group[K, V]) Do(
 	}
 }
 
-// DoAsync reserves key before passing its work to schedule. It returns true
-// when work was scheduled and false when another call already reserved key.
-// DoAsync must accept the work without executing it before returning.
-func (g *Group[K, V]) DoAsync(
-	ctx context.Context,
-	key K,
-	schedule func(func()),
-	function func(context.Context) (V, error),
-) bool {
-	if g == nil || g.calls == nil {
-		panic("singleflight: Group must be constructed with New")
-	}
-	if ctx.Err() != nil {
-		return false
-	}
-
-	activeCall, shouldExecute := g.acquire(key)
-	if !shouldExecute {
-		return false
-	}
-
-	scheduled := false
-	defer func() {
-		if !scheduled {
-			var zero V
-			g.finish(key, activeCall, zero, nil, true)
-		}
-	}()
-	schedule(func() {
-		_, _ = g.execute(ctx, key, activeCall, function)
-	})
-	scheduled = true
-	return true
-}
-
 // call represents one in-flight call and its published result. Waiters must
 // read retry, value, and err only after done closes.
 type call[V any] struct {

--- a/pkg/singleflight/singleflight.go
+++ b/pkg/singleflight/singleflight.go
@@ -46,19 +46,7 @@ func (g *Group[K, V]) Do(
 
 		activeCall, shouldExecute := g.acquire(key)
 		if shouldExecute {
-			functionReturned := false
-			// A panic must release the key and wake waiters before propagating.
-			defer func() {
-				if !functionReturned {
-					var zero V
-					g.finish(key, activeCall, zero, nil, true)
-				}
-			}()
-
-			value, err := function(ctx)
-			functionReturned = true
-			g.finish(key, activeCall, value, err, ctx.Err() != nil)
-			return value, err
+			return g.execute(ctx, key, activeCall, function)
 		}
 
 		// Another call for this key is already in progress. Wait for its result
@@ -74,6 +62,76 @@ func (g *Group[K, V]) Do(
 			return zero, ctx.Err()
 		}
 	}
+}
+
+// Schedule reserves key before passing its work to schedule. It returns true
+// when work was scheduled and false when another call already reserved key.
+// Schedule must accept the work without executing it before returning.
+func (g *Group[K, V]) Schedule(
+	ctx context.Context,
+	key K,
+	schedule func(func()),
+	function func(context.Context) (V, error),
+) bool {
+	if g == nil || g.calls == nil {
+		panic("singleflight: Group must be constructed with New")
+	}
+	if ctx.Err() != nil {
+		return false
+	}
+
+	activeCall, shouldExecute := g.acquire(key)
+	if !shouldExecute {
+		return false
+	}
+
+	scheduled := false
+	defer func() {
+		if !scheduled {
+			var zero V
+			g.finish(key, activeCall, zero, nil, true)
+		}
+	}()
+	schedule(func() {
+		_, _ = g.execute(ctx, key, activeCall, function)
+	})
+	scheduled = true
+	return true
+}
+
+// ScheduleMany reserves every currently inactive key before passing one batch
+// to schedule. It returns true when at least one key was scheduled. The
+// function must return a result for each key that it receives.
+// ScheduleMany must accept the work without executing it before returning.
+func (g *Group[K, V]) ScheduleMany(
+	ctx context.Context,
+	keys []K,
+	schedule func(func()),
+	function func(context.Context, []K) (map[K]V, error),
+) bool {
+	if g == nil || g.calls == nil {
+		panic("singleflight: Group must be constructed with New")
+	}
+	if ctx.Err() != nil {
+		return false
+	}
+
+	activeCalls, keysToExecute := g.acquireMany(keys)
+	if len(keysToExecute) == 0 {
+		return false
+	}
+
+	scheduled := false
+	defer func() {
+		if !scheduled {
+			g.finishMany(activeCalls, nil, nil, true)
+		}
+	}()
+	schedule(func() {
+		g.executeMany(ctx, activeCalls, keysToExecute, function)
+	})
+	scheduled = true
+	return true
 }
 
 // call represents one in-flight call and its published result. Waiters must
@@ -112,6 +170,96 @@ func (g *Group[K, V]) acquire(key K) (activeCall *call[V], shouldExecute bool) {
 	return activeCall, true
 }
 
+// acquireMany reserves each unique key that has no active call. Holding one
+// lock preserves the input batch against interleaved reservations.
+func (g *Group[K, V]) acquireMany(keys []K) (map[K]*call[V], []K) {
+	g.mutex.Lock()
+	defer g.mutex.Unlock()
+
+	activeCalls := make(map[K]*call[V], len(keys))
+	keysToExecute := make([]K, 0, len(keys))
+	seen := make(map[K]struct{}, len(keys))
+	for _, key := range keys {
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		if _, ok := g.calls[key]; ok {
+			continue
+		}
+
+		var zero V
+		activeCall := &call[V]{
+			done:  make(chan struct{}),
+			retry: false,
+			value: zero,
+			err:   nil,
+		}
+		g.calls[key] = activeCall
+		activeCalls[key] = activeCall
+		keysToExecute = append(keysToExecute, key)
+	}
+	return activeCalls, keysToExecute
+}
+
+// execute runs one reserved call and always releases its waiters. A panic marks
+// the result for retry before propagating to the executing caller.
+func (g *Group[K, V]) execute(
+	ctx context.Context,
+	key K,
+	activeCall *call[V],
+	function func(context.Context) (V, error),
+) (V, error) {
+	if err := ctx.Err(); err != nil {
+		var zero V
+		g.finish(key, activeCall, zero, nil, true)
+		return zero, err
+	}
+
+	functionReturned := false
+	defer func() {
+		if !functionReturned {
+			var zero V
+			g.finish(key, activeCall, zero, nil, true)
+		}
+	}()
+
+	value, err := function(ctx)
+	functionReturned = true
+	g.finish(key, activeCall, value, err, ctx.Err() != nil)
+	return value, err
+}
+
+// executeMany runs one reserved batch and always releases every key. A panic
+// marks every result for retry before propagating to the executing caller.
+func (g *Group[K, V]) executeMany(
+	ctx context.Context,
+	activeCalls map[K]*call[V],
+	keys []K,
+	function func(context.Context, []K) (map[K]V, error),
+) {
+	if ctx.Err() != nil {
+		g.finishMany(activeCalls, nil, nil, true)
+		return
+	}
+
+	functionReturned := false
+	defer func() {
+		if !functionReturned {
+			g.finishMany(activeCalls, nil, nil, true)
+		}
+	}()
+
+	values, err := function(ctx, keys)
+	for _, key := range keys {
+		if _, ok := values[key]; !ok {
+			panic("singleflight: batch function omitted a result")
+		}
+	}
+	functionReturned = true
+	g.finishMany(activeCalls, values, err, ctx.Err() != nil)
+}
+
 // finish publishes a call result, removes its reservation, and releases its
 // waiters. Callers must invoke finish exactly once for each reserved call.
 func (g *Group[K, V]) finish(
@@ -131,5 +279,32 @@ func (g *Group[K, V]) finish(
 	activeCall.err = err
 	delete(g.calls, key)
 	close(activeCall.done)
+	g.mutex.Unlock()
+}
+
+// finishMany publishes one batch, removes its reservations, and releases its
+// waiters as one atomic state transition.
+func (g *Group[K, V]) finishMany(
+	activeCalls map[K]*call[V],
+	values map[K]V,
+	err error,
+	retry bool,
+) {
+	g.mutex.Lock()
+	for key, activeCall := range activeCalls {
+		if g.calls[key] != activeCall {
+			g.mutex.Unlock()
+			panic("singleflight: cannot finish an unregistered call")
+		}
+	}
+	for key, activeCall := range activeCalls {
+		activeCall.retry = retry
+		activeCall.value = values[key]
+		activeCall.err = err
+		delete(g.calls, key)
+	}
+	for _, activeCall := range activeCalls {
+		close(activeCall.done)
+	}
 	g.mutex.Unlock()
 }

--- a/pkg/singleflight/singleflight.go
+++ b/pkg/singleflight/singleflight.go
@@ -99,11 +99,11 @@ func (g *Group[K, V]) DoAsync(
 	return true
 }
 
-// DoManyAsync reserves every currently inactive key before passing one batch
+// DoAsyncMany reserves every currently inactive key before passing one batch
 // to schedule. It returns true when at least one key was scheduled. The
 // function must return a result for each key that it receives.
-// DoManyAsync must accept the work without executing it before returning.
-func (g *Group[K, V]) DoManyAsync(
+// DoAsyncMany must accept the work without executing it before returning.
+func (g *Group[K, V]) DoAsyncMany(
 	ctx context.Context,
 	keys []K,
 	schedule func(func()),

--- a/pkg/singleflight/singleflight_test.go
+++ b/pkg/singleflight/singleflight_test.go
@@ -1,0 +1,180 @@
+package singleflight
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDo(t *testing.T) {
+	group := New[string, string]()
+	value, err := group.Do(context.Background(), "key", func(context.Context) (string, error) {
+		return "bar", nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, "bar", value)
+}
+
+func TestDoReturnsError(t *testing.T) {
+	group := New[string, *struct{}]()
+	expectedErr := errors.New("some error")
+	value, err := group.Do(context.Background(), "key", func(context.Context) (*struct{}, error) {
+		return nil, expectedErr
+	})
+	require.ErrorIs(t, err, expectedErr)
+	require.Nil(t, value)
+}
+
+// TestDoDeduplicatesConcurrentCalls guarantees that all callers already waiting
+// for the same key receive one execution's result.
+func TestDoDeduplicatesConcurrentCalls(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		group := New[string, string]()
+		releaseCall := make(chan struct{})
+		var callCount atomic.Int32
+		function := func(context.Context) (string, error) {
+			callCount.Add(1)
+			<-releaseCall
+			return "bar", nil
+		}
+
+		const callerCount = 10
+		callErrors := make(chan error, callerCount)
+		callValues := make(chan string, callerCount)
+		for range callerCount {
+			go func() {
+				value, err := group.Do(context.Background(), "key", function)
+				callErrors <- err
+				callValues <- value
+			}()
+		}
+
+		synctest.Wait()
+		require.Equal(t, int32(1), callCount.Load())
+		close(releaseCall)
+		synctest.Wait()
+
+		for range callerCount {
+			require.NoError(t, <-callErrors)
+			require.Equal(t, "bar", <-callValues)
+		}
+	})
+}
+
+// TestCanceledWaiterStopsWaiting guarantees that one waiting caller can cancel
+// without interrupting the call shared by other waiters.
+func TestCanceledWaiterStopsWaiting(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		group := New[string, string]()
+		releaseCall := make(chan struct{})
+		executingDone := make(chan error, 1)
+		go func() {
+			_, err := group.Do(context.Background(), "key", func(context.Context) (string, error) {
+				<-releaseCall
+				return "value", nil
+			})
+			executingDone <- err
+		}()
+		synctest.Wait()
+
+		type callResult struct {
+			value string
+			err   error
+		}
+		waitingCtx, cancelWaiting := context.WithCancel(context.Background())
+		waitingDone := make(chan callResult, 1)
+		go func() {
+			value, err := group.Do(waitingCtx, "key", func(context.Context) (string, error) {
+				return "unexpected", errors.New("waiting caller executed")
+			})
+			waitingDone <- callResult{value: value, err: err}
+		}()
+		synctest.Wait()
+
+		cancelWaiting()
+		synctest.Wait()
+		waitingResult := <-waitingDone
+		require.ErrorIs(t, waitingResult.err, context.Canceled)
+		require.Empty(t, waitingResult.value)
+
+		close(releaseCall)
+		synctest.Wait()
+		require.NoError(t, <-executingDone)
+	})
+}
+
+func TestCanceledCallerDoesNotExecute(t *testing.T) {
+	group := New[string, string]()
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	value, err := group.Do(canceledCtx, "key", func(context.Context) (string, error) {
+		t.Fatal("a canceled caller must not execute the function")
+		return "", nil
+	})
+	require.ErrorIs(t, err, context.Canceled)
+	require.Empty(t, value)
+}
+
+// TestCanceledExecutingCallerDoesNotCancelWaiter guarantees that a healthy
+// waiter retries instead of inheriting another caller's cancellation.
+func TestCanceledExecutingCallerDoesNotCancelWaiter(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		group := New[string, string]()
+		executingCtx, cancelExecuting := context.WithCancel(context.Background())
+		executingDone := make(chan error, 1)
+		go func() {
+			_, err := group.Do(executingCtx, "key", func(ctx context.Context) (string, error) {
+				<-ctx.Done()
+				return "", ctx.Err()
+			})
+			executingDone <- err
+		}()
+		synctest.Wait()
+
+		type callResult struct {
+			value string
+			err   error
+		}
+		waitingDone := make(chan callResult, 1)
+		go func() {
+			value, err := group.Do(context.Background(), "key", func(context.Context) (string, error) {
+				return "value", nil
+			})
+			waitingDone <- callResult{value: value, err: err}
+		}()
+		synctest.Wait()
+
+		cancelExecuting()
+		synctest.Wait()
+		require.ErrorIs(t, <-executingDone, context.Canceled)
+		waitingResult := <-waitingDone
+		require.NoError(t, waitingResult.err)
+		require.Equal(t, "value", waitingResult.value)
+	})
+}
+
+// TestPanicReleasesKey guarantees that a panicking call cannot leave future
+// callers permanently blocked on the key.
+func TestPanicReleasesKey(t *testing.T) {
+	group := New[string, string]()
+
+	func() {
+		defer func() {
+			require.Equal(t, "boom", recover())
+		}()
+		_, _ = group.Do(context.Background(), "key", func(context.Context) (string, error) {
+			panic("boom")
+		})
+	}()
+
+	value, err := group.Do(context.Background(), "key", func(context.Context) (string, error) {
+		return "recovered", nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, "recovered", value)
+}

--- a/pkg/singleflight/singleflight_test.go
+++ b/pkg/singleflight/singleflight_test.go
@@ -65,19 +65,19 @@ func TestDoDeduplicatesConcurrentCalls(t *testing.T) {
 	})
 }
 
-// TestScheduleReservesBeforeEnqueue guarantees that queued work remains
+// TestDoAsyncReservesBeforeEnqueue guarantees that queued work remains
 // deduplicated before a worker begins executing it.
-func TestScheduleReservesBeforeEnqueue(t *testing.T) {
+func TestDoAsyncReservesBeforeEnqueue(t *testing.T) {
 	group := New[string, string]()
 	var scheduled func()
 	schedule := func(function func()) {
 		scheduled = function
 	}
 
-	require.True(t, group.Schedule(context.Background(), "key", schedule, func(context.Context) (string, error) {
+	require.True(t, group.DoAsync(context.Background(), "key", schedule, func(context.Context) (string, error) {
 		return "value", nil
 	}))
-	require.False(t, group.Schedule(context.Background(), "key", schedule, func(context.Context) (string, error) {
+	require.False(t, group.DoAsync(context.Background(), "key", schedule, func(context.Context) (string, error) {
 		return "duplicate", nil
 	}))
 	require.NotNil(t, scheduled)
@@ -90,9 +90,9 @@ func TestScheduleReservesBeforeEnqueue(t *testing.T) {
 	require.Equal(t, "next", value)
 }
 
-// TestScheduleManyReservesOverlappingKeys guarantees that overlapping batches
+// TestDoManyAsyncReservesOverlappingKeys guarantees that overlapping batches
 // execute each key at most once while preserving non-overlapping batch work.
-func TestScheduleManyReservesOverlappingKeys(t *testing.T) {
+func TestDoManyAsyncReservesOverlappingKeys(t *testing.T) {
 	group := New[string, string]()
 	var scheduled []func()
 	schedule := func(function func()) {
@@ -108,8 +108,8 @@ func TestScheduleManyReservesOverlappingKeys(t *testing.T) {
 		return values, nil
 	}
 
-	require.True(t, group.ScheduleMany(context.Background(), []string{"a", "b", "a"}, schedule, function))
-	require.True(t, group.ScheduleMany(context.Background(), []string{"b", "c"}, schedule, function))
+	require.True(t, group.DoManyAsync(context.Background(), []string{"a", "b", "a"}, schedule, function))
+	require.True(t, group.DoManyAsync(context.Background(), []string{"b", "c"}, schedule, function))
 	require.Len(t, scheduled, 2)
 	scheduled[0]()
 	scheduled[1]()
@@ -117,10 +117,10 @@ func TestScheduleManyReservesOverlappingKeys(t *testing.T) {
 	require.Equal(t, []string{"c"}, <-executedKeys)
 }
 
-func TestSchedulePanicReleasesKey(t *testing.T) {
+func TestDoAsyncPanicReleasesKey(t *testing.T) {
 	group := New[string, string]()
 	require.Panics(t, func() {
-		group.Schedule(context.Background(), "key", func(func()) {
+		group.DoAsync(context.Background(), "key", func(func()) {
 			panic("scheduler failed")
 		}, func(context.Context) (string, error) {
 			return "unreachable", nil
@@ -134,10 +134,10 @@ func TestSchedulePanicReleasesKey(t *testing.T) {
 	require.Equal(t, "recovered", value)
 }
 
-func TestScheduleManyPanicReleasesKeys(t *testing.T) {
+func TestDoManyAsyncPanicReleasesKeys(t *testing.T) {
 	group := New[string, string]()
 	require.Panics(t, func() {
-		group.ScheduleMany(context.Background(), []string{"a", "b"}, func(func()) {
+		group.DoManyAsync(context.Background(), []string{"a", "b"}, func(func()) {
 			panic("scheduler failed")
 		}, func(context.Context, []string) (map[string]string, error) {
 			return nil, nil

--- a/pkg/singleflight/singleflight_test.go
+++ b/pkg/singleflight/singleflight_test.go
@@ -65,6 +65,94 @@ func TestDoDeduplicatesConcurrentCalls(t *testing.T) {
 	})
 }
 
+// TestScheduleReservesBeforeEnqueue guarantees that queued work remains
+// deduplicated before a worker begins executing it.
+func TestScheduleReservesBeforeEnqueue(t *testing.T) {
+	group := New[string, string]()
+	var scheduled func()
+	schedule := func(function func()) {
+		scheduled = function
+	}
+
+	require.True(t, group.Schedule(context.Background(), "key", schedule, func(context.Context) (string, error) {
+		return "value", nil
+	}))
+	require.False(t, group.Schedule(context.Background(), "key", schedule, func(context.Context) (string, error) {
+		return "duplicate", nil
+	}))
+	require.NotNil(t, scheduled)
+	scheduled()
+
+	value, err := group.Do(context.Background(), "key", func(context.Context) (string, error) {
+		return "next", nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, "next", value)
+}
+
+// TestScheduleManyReservesOverlappingKeys guarantees that overlapping batches
+// execute each key at most once while preserving non-overlapping batch work.
+func TestScheduleManyReservesOverlappingKeys(t *testing.T) {
+	group := New[string, string]()
+	var scheduled []func()
+	schedule := func(function func()) {
+		scheduled = append(scheduled, function)
+	}
+	executedKeys := make(chan []string, 2)
+	function := func(_ context.Context, keys []string) (map[string]string, error) {
+		executedKeys <- append([]string(nil), keys...)
+		values := make(map[string]string, len(keys))
+		for _, key := range keys {
+			values[key] = key
+		}
+		return values, nil
+	}
+
+	require.True(t, group.ScheduleMany(context.Background(), []string{"a", "b", "a"}, schedule, function))
+	require.True(t, group.ScheduleMany(context.Background(), []string{"b", "c"}, schedule, function))
+	require.Len(t, scheduled, 2)
+	scheduled[0]()
+	scheduled[1]()
+	require.Equal(t, []string{"a", "b"}, <-executedKeys)
+	require.Equal(t, []string{"c"}, <-executedKeys)
+}
+
+func TestSchedulePanicReleasesKey(t *testing.T) {
+	group := New[string, string]()
+	require.Panics(t, func() {
+		group.Schedule(context.Background(), "key", func(func()) {
+			panic("scheduler failed")
+		}, func(context.Context) (string, error) {
+			return "unreachable", nil
+		})
+	})
+
+	value, err := group.Do(context.Background(), "key", func(context.Context) (string, error) {
+		return "recovered", nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, "recovered", value)
+}
+
+func TestScheduleManyPanicReleasesKeys(t *testing.T) {
+	group := New[string, string]()
+	require.Panics(t, func() {
+		group.ScheduleMany(context.Background(), []string{"a", "b"}, func(func()) {
+			panic("scheduler failed")
+		}, func(context.Context, []string) (map[string]string, error) {
+			return nil, nil
+		})
+	})
+
+	for _, key := range []string{"a", "b"} {
+		value, err := group.Do(context.Background(), key, func(context.Context) (string, error) {
+			return key, nil
+		})
+		require.NoError(t, err)
+		require.Equal(t, key, value)
+	}
+}
+
 // TestCanceledWaiterStopsWaiting guarantees that one waiting caller can cancel
 // without interrupting the call shared by other waiters.
 func TestCanceledWaiterStopsWaiting(t *testing.T) {

--- a/pkg/singleflight/singleflight_test.go
+++ b/pkg/singleflight/singleflight_test.go
@@ -90,9 +90,9 @@ func TestDoAsyncReservesBeforeEnqueue(t *testing.T) {
 	require.Equal(t, "next", value)
 }
 
-// TestDoManyAsyncReservesOverlappingKeys guarantees that overlapping batches
+// TestDoAsyncManyReservesOverlappingKeys guarantees that overlapping batches
 // execute each key at most once while preserving non-overlapping batch work.
-func TestDoManyAsyncReservesOverlappingKeys(t *testing.T) {
+func TestDoAsyncManyReservesOverlappingKeys(t *testing.T) {
 	group := New[string, string]()
 	var scheduled []func()
 	schedule := func(function func()) {
@@ -108,8 +108,8 @@ func TestDoManyAsyncReservesOverlappingKeys(t *testing.T) {
 		return values, nil
 	}
 
-	require.True(t, group.DoManyAsync(context.Background(), []string{"a", "b", "a"}, schedule, function))
-	require.True(t, group.DoManyAsync(context.Background(), []string{"b", "c"}, schedule, function))
+	require.True(t, group.DoAsyncMany(context.Background(), []string{"a", "b", "a"}, schedule, function))
+	require.True(t, group.DoAsyncMany(context.Background(), []string{"b", "c"}, schedule, function))
 	require.Len(t, scheduled, 2)
 	scheduled[0]()
 	scheduled[1]()
@@ -134,10 +134,10 @@ func TestDoAsyncPanicReleasesKey(t *testing.T) {
 	require.Equal(t, "recovered", value)
 }
 
-func TestDoManyAsyncPanicReleasesKeys(t *testing.T) {
+func TestDoAsyncManyPanicReleasesKeys(t *testing.T) {
 	group := New[string, string]()
 	require.Panics(t, func() {
-		group.DoManyAsync(context.Background(), []string{"a", "b"}, func(func()) {
+		group.DoAsyncMany(context.Background(), []string{"a", "b"}, func(func()) {
 			panic("scheduler failed")
 		}, func(context.Context, []string) (map[string]string, error) {
 			return nil, nil

--- a/pkg/singleflight/singleflight_test.go
+++ b/pkg/singleflight/singleflight_test.go
@@ -65,48 +65,6 @@ func TestDoDeduplicatesConcurrentCalls(t *testing.T) {
 	})
 }
 
-// TestDoAsyncReservesBeforeEnqueue guarantees that queued work remains
-// deduplicated before a worker begins executing it.
-func TestDoAsyncReservesBeforeEnqueue(t *testing.T) {
-	group := New[string, string]()
-	var scheduled func()
-	schedule := func(function func()) {
-		scheduled = function
-	}
-
-	require.True(t, group.DoAsync(context.Background(), "key", schedule, func(context.Context) (string, error) {
-		return "value", nil
-	}))
-	require.False(t, group.DoAsync(context.Background(), "key", schedule, func(context.Context) (string, error) {
-		return "duplicate", nil
-	}))
-	require.NotNil(t, scheduled)
-	scheduled()
-
-	value, err := group.Do(context.Background(), "key", func(context.Context) (string, error) {
-		return "next", nil
-	})
-	require.NoError(t, err)
-	require.Equal(t, "next", value)
-}
-
-func TestDoAsyncPanicReleasesKey(t *testing.T) {
-	group := New[string, string]()
-	require.Panics(t, func() {
-		group.DoAsync(context.Background(), "key", func(func()) {
-			panic("scheduler failed")
-		}, func(context.Context) (string, error) {
-			return "unreachable", nil
-		})
-	})
-
-	value, err := group.Do(context.Background(), "key", func(context.Context) (string, error) {
-		return "recovered", nil
-	})
-	require.NoError(t, err)
-	require.Equal(t, "recovered", value)
-}
-
 // TestCanceledWaiterStopsWaiting guarantees that one waiting caller can cancel
 // without interrupting the call shared by other waiters.
 func TestCanceledWaiterStopsWaiting(t *testing.T) {

--- a/pkg/singleflight/singleflight_test.go
+++ b/pkg/singleflight/singleflight_test.go
@@ -90,33 +90,6 @@ func TestDoAsyncReservesBeforeEnqueue(t *testing.T) {
 	require.Equal(t, "next", value)
 }
 
-// TestDoAsyncManyReservesOverlappingKeys guarantees that overlapping batches
-// execute each key at most once while preserving non-overlapping batch work.
-func TestDoAsyncManyReservesOverlappingKeys(t *testing.T) {
-	group := New[string, string]()
-	var scheduled []func()
-	schedule := func(function func()) {
-		scheduled = append(scheduled, function)
-	}
-	executedKeys := make(chan []string, 2)
-	function := func(_ context.Context, keys []string) (map[string]string, error) {
-		executedKeys <- append([]string(nil), keys...)
-		values := make(map[string]string, len(keys))
-		for _, key := range keys {
-			values[key] = key
-		}
-		return values, nil
-	}
-
-	require.True(t, group.DoAsyncMany(context.Background(), []string{"a", "b", "a"}, schedule, function))
-	require.True(t, group.DoAsyncMany(context.Background(), []string{"b", "c"}, schedule, function))
-	require.Len(t, scheduled, 2)
-	scheduled[0]()
-	scheduled[1]()
-	require.Equal(t, []string{"a", "b"}, <-executedKeys)
-	require.Equal(t, []string{"c"}, <-executedKeys)
-}
-
 func TestDoAsyncPanicReleasesKey(t *testing.T) {
 	group := New[string, string]()
 	require.Panics(t, func() {
@@ -132,25 +105,6 @@ func TestDoAsyncPanicReleasesKey(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, "recovered", value)
-}
-
-func TestDoAsyncManyPanicReleasesKeys(t *testing.T) {
-	group := New[string, string]()
-	require.Panics(t, func() {
-		group.DoAsyncMany(context.Background(), []string{"a", "b"}, func(func()) {
-			panic("scheduler failed")
-		}, func(context.Context, []string) (map[string]string, error) {
-			return nil, nil
-		})
-	})
-
-	for _, key := range []string{"a", "b"} {
-		value, err := group.Do(context.Background(), key, func(context.Context) (string, error) {
-			return key, nil
-		})
-		require.NoError(t, err)
-		require.Equal(t, key, value)
-	}
 }
 
 // TestCanceledWaiterStopsWaiting guarantees that one waiting caller can cancel

--- a/svc/api/routes/v2_ratelimit_limit/handler.go
+++ b/svc/api/routes/v2_ratelimit_limit/handler.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"net/http"
 	"strconv"
-	"sync"
 	"time"
 
 	"github.com/unkeyed/unkey/internal/services/auditlogs"
@@ -24,7 +23,6 @@ import (
 	"github.com/unkeyed/unkey/pkg/match"
 	"github.com/unkeyed/unkey/pkg/ptr"
 	"github.com/unkeyed/unkey/pkg/rbac"
-	"github.com/unkeyed/unkey/pkg/singleflight"
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/pkg/zen"
 	"github.com/unkeyed/unkey/svc/api/internal/projects"
@@ -38,14 +36,12 @@ type (
 
 // Handler implements zen.Route interface for the v2 ratelimit limit endpoint
 type Handler struct {
-	DB               db.Database
-	RatelimitEvents  *batch.BatchProcessor[schema.Ratelimit]
-	Ratelimit        ratelimit.Service
-	NamespaceCache   cache.Cache[cache.ScopedKey, db.FindRatelimitNamespace]
-	Auditlogs        auditlogs.AuditLogService
-	TestMode         bool
-	createFlightOnce sync.Once
-	createFlight     *singleflight.Group[string, db.FindRatelimitNamespace]
+	DB              db.Database
+	RatelimitEvents *batch.BatchProcessor[schema.Ratelimit]
+	Ratelimit       ratelimit.Service
+	NamespaceCache  cache.Cache[cache.ScopedKey, db.FindRatelimitNamespace]
+	Auditlogs       auditlogs.AuditLogService
+	TestMode        bool
 }
 
 // Method returns the HTTP method this route responds to
@@ -60,10 +56,6 @@ func (h *Handler) Path() string {
 
 // Handle processes the HTTP request
 func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
-	h.createFlightOnce.Do(func() {
-		h.createFlight = singleflight.New[string, db.FindRatelimitNamespace]()
-	})
-
 	if s.Request().Header.Get("X-Unkey-Metrics") == "disabled" {
 		s.DisableClickHouseLogging()
 	}
@@ -238,100 +230,97 @@ func (h *Handler) getNamespace(ctx context.Context, workspaceID, nameOrID string
 }
 
 func (h *Handler) createNamespace(ctx context.Context, s *zen.Session, principal *principal.Principal, name string) (db.FindRatelimitNamespace, error) {
-	key := principal.WorkspaceID + ":" + name
-	return h.createFlight.Do(ctx, key, func(ctx context.Context) (db.FindRatelimitNamespace, error) {
-		ns, err := db.TxWithResultRetry(ctx, h.DB.RW(), func(ctx context.Context, tx db.DBTX) (db.FindRatelimitNamespace, error) {
-			projectID, resolveErr := projects.EnsureDefaultProject(ctx, tx, principal.WorkspaceID)
-			if resolveErr != nil {
-				return db.FindRatelimitNamespace{}, resolveErr //nolint:exhaustruct
-			}
+	ns, err := db.TxWithResultRetry(ctx, h.DB.RW(), func(ctx context.Context, tx db.DBTX) (db.FindRatelimitNamespace, error) {
+		projectID, resolveErr := projects.EnsureDefaultProject(ctx, tx, principal.WorkspaceID)
+		if resolveErr != nil {
+			return db.FindRatelimitNamespace{}, resolveErr //nolint:exhaustruct
+		}
 
-			now := time.Now().UnixMilli()
-			id := uid.New(uid.RatelimitNamespacePrefix)
+		now := time.Now().UnixMilli()
+		id := uid.New(uid.RatelimitNamespacePrefix)
 
-			insertErr := db.Query.InsertRatelimitNamespace(ctx, tx, db.InsertRatelimitNamespaceParams{
-				ID:          id,
-				WorkspaceID: principal.WorkspaceID,
-				ProjectID:   projectID,
-				Name:        name,
-				CreatedAt:   now,
-			})
-			if insertErr != nil && !db.IsDuplicateKeyError(insertErr) {
-				return db.FindRatelimitNamespace{}, fault.Wrap(insertErr, //nolint:exhaustruct
-					fault.Code(codes.App.Internal.UnexpectedError.URN()),
-					fault.Public("An unexpected error occurred while creating the namespace."),
-				)
-			}
+		insertErr := db.Query.InsertRatelimitNamespace(ctx, tx, db.InsertRatelimitNamespaceParams{
+			ID:          id,
+			WorkspaceID: principal.WorkspaceID,
+			ProjectID:   projectID,
+			Name:        name,
+			CreatedAt:   now,
+		})
+		if insertErr != nil && !db.IsDuplicateKeyError(insertErr) {
+			return db.FindRatelimitNamespace{}, fault.Wrap(insertErr, //nolint:exhaustruct
+				fault.Code(codes.App.Internal.UnexpectedError.URN()),
+				fault.Public("An unexpected error occurred while creating the namespace."),
+			)
+		}
 
-			if db.IsDuplicateKeyError(insertErr) {
-				// Re-fetch after this transaction closes so a snapshot established by
-				// EnsureDefaultProject cannot hide the concurrently committed row.
-				return db.FindRatelimitNamespace{}, nil //nolint:exhaustruct
-			}
+		if db.IsDuplicateKeyError(insertErr) {
+			// Re-fetch after this transaction closes so a snapshot established by
+			// EnsureDefaultProject cannot hide the concurrently committed row.
+			return db.FindRatelimitNamespace{}, nil //nolint:exhaustruct
+		}
 
-			result := db.FindRatelimitNamespace{
-				ID:                id,
-				WorkspaceID:       principal.WorkspaceID,
-				Name:              name,
-				CreatedAtM:        now,
-				UpdatedAtM:        sql.NullInt64{Valid: false, Int64: 0},
-				DeletedAtM:        sql.NullInt64{Valid: false, Int64: 0},
-				DirectOverrides:   make(map[string]db.FindRatelimitNamespaceLimitOverride),
-				WildcardOverrides: make([]db.FindRatelimitNamespaceLimitOverride, 0),
-			}
+		result := db.FindRatelimitNamespace{
+			ID:                id,
+			WorkspaceID:       principal.WorkspaceID,
+			Name:              name,
+			CreatedAtM:        now,
+			UpdatedAtM:        sql.NullInt64{Valid: false, Int64: 0},
+			DeletedAtM:        sql.NullInt64{Valid: false, Int64: 0},
+			DirectOverrides:   make(map[string]db.FindRatelimitNamespaceLimitOverride),
+			WildcardOverrides: make([]db.FindRatelimitNamespaceLimitOverride, 0),
+		}
 
-			auditErr := h.Auditlogs.Insert(ctx, tx, []auditlog.AuditLog{
-				{
-					WorkspaceID:   principal.WorkspaceID,
-					Event:         auditlog.RatelimitNamespaceCreateEvent,
-					Display:       "Created ratelimit namespace " + name,
-					ActorID:       principal.Subject.ID,
-					ActorName:     principal.Subject.Name,
-					ActorMeta:     map[string]any{},
-					ActorType:     auditlog.AuditLogActor(principal.Subject.Type),
-					RemoteIP:      s.Location(),
-					UserAgent:     s.UserAgent(),
-					CorrelationID: "",
-					Resources: []auditlog.AuditLogResource{
-						{
-							ID:          id,
-							Type:        auditlog.RatelimitNamespaceResourceType,
-							Meta:        nil,
-							Name:        name,
-							DisplayName: name,
-						},
+		auditErr := h.Auditlogs.Insert(ctx, tx, []auditlog.AuditLog{
+			{
+				WorkspaceID:   principal.WorkspaceID,
+				Event:         auditlog.RatelimitNamespaceCreateEvent,
+				Display:       "Created ratelimit namespace " + name,
+				ActorID:       principal.Subject.ID,
+				ActorName:     principal.Subject.Name,
+				ActorMeta:     map[string]any{},
+				ActorType:     auditlog.AuditLogActor(principal.Subject.Type),
+				RemoteIP:      s.Location(),
+				UserAgent:     s.UserAgent(),
+				CorrelationID: "",
+				Resources: []auditlog.AuditLogResource{
+					{
+						ID:          id,
+						Type:        auditlog.RatelimitNamespaceResourceType,
+						Meta:        nil,
+						Name:        name,
+						DisplayName: name,
 					},
 				},
-			})
-			if auditErr != nil {
-				return result, auditErr
-			}
-
-			return result, nil
+			},
 		})
-		if err != nil {
-			return ns, err
-		}
-		if ns.ID == "" {
-			row, fetchErr := db.Query.FindRatelimitNamespace(ctx, h.DB.RW(), db.FindRatelimitNamespaceParams{
-				WorkspaceID: principal.WorkspaceID,
-				Namespace:   name,
-			})
-			if fetchErr != nil {
-				return ns, fault.Wrap(fetchErr,
-					fault.Code(codes.App.Internal.UnexpectedError.URN()),
-					fault.Public("Failed to fetch namespace after race condition."),
-				)
-			}
-			ns = namespace.ParseNamespaceRow(row)
+		if auditErr != nil {
+			return result, auditErr
 		}
 
-		// Warm cache by both name and ID after the transaction has committed
-		h.NamespaceCache.Set(ctx, cache.ScopedKey{WorkspaceID: principal.WorkspaceID, Key: ns.Name}, ns)
-		h.NamespaceCache.Set(ctx, cache.ScopedKey{WorkspaceID: principal.WorkspaceID, Key: ns.ID}, ns)
-
-		return ns, nil
+		return result, nil
 	})
+	if err != nil {
+		return ns, err
+	}
+	if ns.ID == "" {
+		row, fetchErr := db.Query.FindRatelimitNamespace(ctx, h.DB.RW(), db.FindRatelimitNamespaceParams{
+			WorkspaceID: principal.WorkspaceID,
+			Namespace:   name,
+		})
+		if fetchErr != nil {
+			return ns, fault.Wrap(fetchErr,
+				fault.Code(codes.App.Internal.UnexpectedError.URN()),
+				fault.Public("Failed to fetch namespace after race condition."),
+			)
+		}
+		ns = namespace.ParseNamespaceRow(row)
+	}
+
+	// Warm cache by both name and ID after the transaction has committed
+	h.NamespaceCache.Set(ctx, cache.ScopedKey{WorkspaceID: principal.WorkspaceID, Key: ns.Name}, ns)
+	h.NamespaceCache.Set(ctx, cache.ScopedKey{WorkspaceID: principal.WorkspaceID, Key: ns.ID}, ns)
+
+	return ns, nil
 }
 
 func getLimitAndDuration(req Request, namespace db.FindRatelimitNamespace) (int64, int64, string, error) {

--- a/svc/api/routes/v2_ratelimit_limit/handler.go
+++ b/svc/api/routes/v2_ratelimit_limit/handler.go
@@ -23,11 +23,11 @@ import (
 	"github.com/unkeyed/unkey/pkg/match"
 	"github.com/unkeyed/unkey/pkg/ptr"
 	"github.com/unkeyed/unkey/pkg/rbac"
-	sf "github.com/unkeyed/unkey/pkg/singleflight"
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/pkg/zen"
 	"github.com/unkeyed/unkey/svc/api/internal/projects"
 	"github.com/unkeyed/unkey/svc/api/openapi"
+	"golang.org/x/sync/singleflight"
 )
 
 type (
@@ -43,7 +43,7 @@ type Handler struct {
 	NamespaceCache  cache.Cache[cache.ScopedKey, db.FindRatelimitNamespace]
 	Auditlogs       auditlogs.AuditLogService
 	TestMode        bool
-	createFlight    sf.Group[db.FindRatelimitNamespace]
+	createFlight    singleflight.Group
 }
 
 // Method returns the HTTP method this route responds to
@@ -233,7 +233,7 @@ func (h *Handler) getNamespace(ctx context.Context, workspaceID, nameOrID string
 
 func (h *Handler) createNamespace(ctx context.Context, s *zen.Session, principal *principal.Principal, name string) (db.FindRatelimitNamespace, error) {
 	key := principal.WorkspaceID + ":" + name
-	return h.createFlight.Do(key, func() (db.FindRatelimitNamespace, error) {
+	value, err, _ := h.createFlight.Do(key, func() (any, error) {
 		ns, err := db.TxWithResultRetry(ctx, h.DB.RW(), func(ctx context.Context, tx db.DBTX) (db.FindRatelimitNamespace, error) {
 			projectID, resolveErr := projects.EnsureDefaultProject(ctx, tx, principal.WorkspaceID)
 			if resolveErr != nil {
@@ -326,6 +326,17 @@ func (h *Handler) createNamespace(ctx context.Context, s *zen.Session, principal
 
 		return ns, nil
 	})
+	if err != nil {
+		return db.FindRatelimitNamespace{}, err //nolint:exhaustruct
+	}
+	ns, ok := value.(db.FindRatelimitNamespace)
+	if !ok {
+		return db.FindRatelimitNamespace{}, fault.New( //nolint:exhaustruct
+			"singleflight returned an unexpected namespace type",
+			fault.Code(codes.App.Internal.UnexpectedError.URN()),
+		)
+	}
+	return ns, nil
 }
 
 func getLimitAndDuration(req Request, namespace db.FindRatelimitNamespace) (int64, int64, string, error) {

--- a/svc/api/routes/v2_ratelimit_limit/handler.go
+++ b/svc/api/routes/v2_ratelimit_limit/handler.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"net/http"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/unkeyed/unkey/internal/services/auditlogs"
@@ -23,11 +24,11 @@ import (
 	"github.com/unkeyed/unkey/pkg/match"
 	"github.com/unkeyed/unkey/pkg/ptr"
 	"github.com/unkeyed/unkey/pkg/rbac"
+	"github.com/unkeyed/unkey/pkg/singleflight"
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/pkg/zen"
 	"github.com/unkeyed/unkey/svc/api/internal/projects"
 	"github.com/unkeyed/unkey/svc/api/openapi"
-	"golang.org/x/sync/singleflight"
 )
 
 type (
@@ -37,13 +38,14 @@ type (
 
 // Handler implements zen.Route interface for the v2 ratelimit limit endpoint
 type Handler struct {
-	DB              db.Database
-	RatelimitEvents *batch.BatchProcessor[schema.Ratelimit]
-	Ratelimit       ratelimit.Service
-	NamespaceCache  cache.Cache[cache.ScopedKey, db.FindRatelimitNamespace]
-	Auditlogs       auditlogs.AuditLogService
-	TestMode        bool
-	createFlight    singleflight.Group
+	DB               db.Database
+	RatelimitEvents  *batch.BatchProcessor[schema.Ratelimit]
+	Ratelimit        ratelimit.Service
+	NamespaceCache   cache.Cache[cache.ScopedKey, db.FindRatelimitNamespace]
+	Auditlogs        auditlogs.AuditLogService
+	TestMode         bool
+	createFlightOnce sync.Once
+	createFlight     *singleflight.Group[string, db.FindRatelimitNamespace]
 }
 
 // Method returns the HTTP method this route responds to
@@ -58,6 +60,10 @@ func (h *Handler) Path() string {
 
 // Handle processes the HTTP request
 func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
+	h.createFlightOnce.Do(func() {
+		h.createFlight = singleflight.New[string, db.FindRatelimitNamespace]()
+	})
+
 	if s.Request().Header.Get("X-Unkey-Metrics") == "disabled" {
 		s.DisableClickHouseLogging()
 	}
@@ -233,7 +239,7 @@ func (h *Handler) getNamespace(ctx context.Context, workspaceID, nameOrID string
 
 func (h *Handler) createNamespace(ctx context.Context, s *zen.Session, principal *principal.Principal, name string) (db.FindRatelimitNamespace, error) {
 	key := principal.WorkspaceID + ":" + name
-	value, err, _ := h.createFlight.Do(key, func() (any, error) {
+	return h.createFlight.Do(ctx, key, func(ctx context.Context) (db.FindRatelimitNamespace, error) {
 		ns, err := db.TxWithResultRetry(ctx, h.DB.RW(), func(ctx context.Context, tx db.DBTX) (db.FindRatelimitNamespace, error) {
 			projectID, resolveErr := projects.EnsureDefaultProject(ctx, tx, principal.WorkspaceID)
 			if resolveErr != nil {
@@ -326,17 +332,6 @@ func (h *Handler) createNamespace(ctx context.Context, s *zen.Session, principal
 
 		return ns, nil
 	})
-	if err != nil {
-		return db.FindRatelimitNamespace{}, err //nolint:exhaustruct
-	}
-	ns, ok := value.(db.FindRatelimitNamespace)
-	if !ok {
-		return db.FindRatelimitNamespace{}, fault.New( //nolint:exhaustruct
-			"singleflight returned an unexpected namespace type",
-			fault.Code(codes.App.Internal.UnexpectedError.URN()),
-		)
-	}
-	return ns, nil
 }
 
 func getLimitAndDuration(req Request, namespace db.FindRatelimitNamespace) (int64, int64, string, error) {


### PR DESCRIPTION
## Summary

- deduplicate synchronous cache misses through a small typed, context-aware singleflight group
- keep stale revalidation inside the cache: reserve each key, enqueue it onto the bounded channel, and run it on the existing fixed worker pool
- schedule stale `SWRMany` revalidations per key and expose `unkey_cache_swr_many_stale_keys` to measure whether batching would be worthwhile
- keep ratelimit namespace creation simple and rely on the database uniqueness constraint plus re-fetch to resolve creation races across pods

## Verification

- `mise exec -- rask ./pkg/singleflight ./pkg/cache ./svc/api/routes/v2_ratelimit_limit` (111 tests)
- `mise exec -- rask ./pkg/singleflight ./pkg/cache` (58 tests after final simplification)
- `mise exec -- go test -race ./pkg/singleflight ./pkg/cache`
- `mise run build` (includes lint)
- `git diff --check`