### PR TITLE
perf(test): reuse Go suite setup

### DIFF
--- a/.mise/tasks/test
+++ b/.mise/tasks/test
@@ -49,7 +49,26 @@ trap cleanup_test_containers EXIT
 
 # Warm shared package exports once for full-suite runs. Eight compiler processes
 # were fastest for this cache-bound graph; GOMEMLIMIT bounds memory with GOGC off.
-if [[ $# -eq 0 ]]; then
+full_suite=true
+expect_option_value=false
+for arg in "$@"; do
+  if [[ "${expect_option_value}" == true ]]; then
+    expect_option_value=false
+    continue
+  fi
+
+  case "${arg}" in
+    --concurrency)
+      expect_option_value=true
+      ;;
+    -v | --verbose | --no-cache | --version | -h | --help | --concurrency=* | -v=* | --verbose=* | --no-cache=* | --version=*) ;;
+    *)
+      full_suite=false
+      ;;
+  esac
+done
+
+if [[ "${full_suite}" == true ]]; then
   compile_parallelism="$(getconf _NPROCESSORS_ONLN 2>/dev/null || printf '8')"
   if ((compile_parallelism > 8)); then
     compile_parallelism=8

--- a/.mise/tasks/test
+++ b/.mise/tasks/test
@@ -47,14 +47,8 @@ cleanup_test_containers() {
 }
 trap cleanup_test_containers EXIT
 
-# On a cold cache, Rask starts one `go test` process per package and each process
-# rebuilds the same dependency graph. Populate production package exports once so
-# Rask can keep its package-level test parallelism without multiplying compiler
-# work, linking unused commands, or pre-running test binaries. Targeted runs do
-# not have enough package fan-out to benefit from this extra pass. Cap package
-# compilation at eight processes: the large dependency graph is cache-bound, and
-# higher fan-out made this phase slower on machines with more cores. The compiler
-# can use more memory to avoid garbage collection, but cap each process at 1 GiB.
+# Warm shared package exports once for full-suite runs. Eight compiler processes
+# were fastest for this cache-bound graph; GOMEMLIMIT bounds memory with GOGC off.
 if [[ $# -eq 0 ]]; then
   compile_parallelism="$(getconf _NPROCESSORS_ONLN 2>/dev/null || printf '8')"
   if ((compile_parallelism > 8)); then
@@ -63,10 +57,7 @@ if [[ $# -eq 0 ]]; then
   GOGC=off GOMEMLIMIT=1GiB go list -p "${compile_parallelism}" -deps -export ./... >/dev/null
 fi
 
-# Rask 0.5.0 compiles every package once with `go test -list '^Test'` only to
-# calculate progress totals, then compiles and runs the real test command. Its
-# unknown-total fallback preserves execution and reporting without that duplicate
-# build. Keep all other Go invocations byte-for-byte unchanged.
+# Force Rask's unknown-total path to skip its duplicate `go test -list` compile.
 real_go="$(command -v go)"
 rask_go_wrapper="${test_run_dir}/go-wrapper"
 mkdir -p "${rask_go_wrapper}"

--- a/.mise/tasks/test
+++ b/.mise/tasks/test
@@ -9,9 +9,15 @@ export UNKEY_TEST_CONTAINER_SCOPE="${UNKEY_TEST_CONTAINER_SCOPE:-$PWD}"
 
 test_container_scope_hash="$(printf "%s" "${UNKEY_TEST_CONTAINER_SCOPE}" | shasum -a 256 | cut -c1-12)"
 export UNKEY_TEST_COMPOSE_PROJECT="unkey-test-${test_container_scope_hash}"
+# Shared helpers use this directory to run each Compose reconciliation once per
+# suite rather than once per concurrently executing package.
+test_run_dir="$(mktemp -d)"
+export UNKEY_TEST_RUN_DIR="${test_run_dir}"
 
 cleanup_test_containers() {
   local status=$?
+
+  rm -rf -- "${test_run_dir}"
 
   # The test helpers intentionally reuse containers across Go test processes
   # so integration tests do not pay Docker startup cost for every test target.
@@ -41,4 +47,40 @@ cleanup_test_containers() {
 }
 trap cleanup_test_containers EXIT
 
-rask "$@"
+# On a cold cache, Rask starts one `go test` process per package and each process
+# rebuilds the same dependency graph. Populate production package exports once so
+# Rask can keep its package-level test parallelism without multiplying compiler
+# work, linking unused commands, or pre-running test binaries. Targeted runs do
+# not have enough package fan-out to benefit from this extra pass. Cap package
+# compilation at eight processes: the large dependency graph is cache-bound, and
+# higher fan-out made this phase slower on machines with more cores. The compiler
+# can use more memory to avoid garbage collection, but cap each process at 1 GiB.
+if [[ $# -eq 0 ]]; then
+  compile_parallelism="$(getconf _NPROCESSORS_ONLN 2>/dev/null || printf '8')"
+  if ((compile_parallelism > 8)); then
+    compile_parallelism=8
+  fi
+  GOGC=off GOMEMLIMIT=1GiB go list -p "${compile_parallelism}" -deps -export ./... >/dev/null
+fi
+
+# Rask 0.5.0 compiles every package once with `go test -list '^Test'` only to
+# calculate progress totals, then compiles and runs the real test command. Its
+# unknown-total fallback preserves execution and reporting without that duplicate
+# build. Keep all other Go invocations byte-for-byte unchanged.
+real_go="$(command -v go)"
+rask_go_wrapper="${test_run_dir}/go-wrapper"
+mkdir -p "${rask_go_wrapper}"
+cat > "${rask_go_wrapper}/go" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -eq 4 && "$1" == "test" && "$2" == "-list" && "$3" == "^Test" ]]; then
+  exit 1
+fi
+
+exec "${UNKEY_REAL_GO:?}" "$@"
+EOF
+chmod +x "${rask_go_wrapper}/go"
+
+export UNKEY_REAL_GO="${real_go}"
+PATH="${rask_go_wrapper}:${PATH}" rask "$@"

--- a/pkg/testutil/containers/clickhouse.go
+++ b/pkg/testutil/containers/clickhouse.go
@@ -67,6 +67,15 @@ func ClickHouse(t testing.TB) ClickHouseConfig {
 func applyClickHouseSchema(t testing.TB, ctx context.Context, conn ch.Conn) {
 	t.Helper()
 
+	project := composeProjectName()
+	const resource = "clickhouse-schema"
+	lockFile := lockComposeResource(t, project, resource)
+	defer func() { require.NoError(t, lockFile.Close()) }()
+
+	if composeResourceCompletedForRun(project, resource) {
+		return
+	}
+
 	// Enable experimental features needed by schema (e.g., JSON type)
 	experimentalSettings := []string{
 		"SET allow_experimental_json_type = 1",
@@ -80,6 +89,7 @@ func applyClickHouseSchema(t testing.TB, ctx context.Context, conn ch.Conn) {
 	// Apply schema files
 	schemaDir := clickhouseSchemaDir()
 	applySchemaFiles(t, ctx, conn, schemaDir)
+	markComposeResourceCompleted(t, project, resource)
 }
 
 func applySchemaFiles(t testing.TB, ctx context.Context, conn ch.Conn, dir string) {

--- a/pkg/testutil/containers/compose.go
+++ b/pkg/testutil/containers/compose.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -20,13 +21,24 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-const composeProjectEnv = "UNKEY_TEST_COMPOSE_PROJECT"
+const (
+	composeProjectEnv = "UNKEY_TEST_COMPOSE_PROJECT"
+	composeRunDirEnv  = "UNKEY_TEST_RUN_DIR"
+)
 
 var (
-	isolatedProjectID  atomic.Uint64
-	reapIsolatedOnce   sync.Once
-	isolatedProjectPID = os.Getpid()
+	isolatedProjectID   atomic.Uint64
+	reapIsolatedOnce    sync.Once
+	isolatedProjectPID  = os.Getpid()
+	sharedServiceCache  sync.Map
+	composeServicePorts sync.Map
 )
+
+type composePortKey struct {
+	project string
+	service string
+	port    int
+}
 
 // Container describes a Docker Compose service container started for tests.
 type Container struct {
@@ -53,6 +65,23 @@ func startService(t testing.TB, service string) Container {
 	t.Helper()
 
 	project := composeProjectName()
+	cacheKey := project + "\x00" + service
+	if cached, ok := sharedServiceCache.Load(cacheKey); ok {
+		return cached.(Container)
+	}
+
+	lockFile := lockComposeResource(t, project, service)
+	defer func() { require.NoError(t, lockFile.Close()) }()
+
+	container := Container{
+		Name:    service,
+		project: project,
+	}
+	if composeResourceCompletedForRun(project, service) && composeServiceHealthy(project, service) {
+		sharedServiceCache.Store(cacheKey, container)
+		return container
+	}
+
 	upArgs := []string{"-f", composeFile(), "-p", project, "up", "-d", "--wait", "--wait-timeout", "60", service}
 	var out []byte
 	var err error
@@ -63,16 +92,81 @@ func startService(t testing.TB, service string) Container {
 		out, err = cmd.CombinedOutput()
 		cancel()
 		if err == nil {
-			return Container{
-				Name:    service,
-				project: project,
-			}
+			markComposeResourceCompleted(t, project, service)
+			sharedServiceCache.Store(cacheKey, container)
+			return container
 		}
 		if time.Now().After(deadline) {
 			require.NoError(t, err, "docker compose %s failed:\n%s", strings.Join(upArgs, " "), string(out))
 		}
 		time.Sleep(250 * time.Millisecond)
 	}
+}
+
+// lockComposeResource coordinates Compose work across concurrently running Go
+// test processes. Rask starts package tests in separate processes, so a mutex
+// cannot prevent them from issuing the same Docker or schema command at once.
+func lockComposeResource(t testing.TB, project string, resource string) *os.File {
+	t.Helper()
+
+	digest := sha256.Sum256([]byte(project + "\x00" + resource))
+	lockDir := os.TempDir()
+	if runDir := os.Getenv(composeRunDirEnv); runDir != "" {
+		lockDir = runDir
+	}
+	path := filepath.Join(lockDir, fmt.Sprintf("unkey-test-%s.lock", hex.EncodeToString(digest[:])[:16]))
+	lockFile, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	require.NoError(t, err)
+	require.NoError(t, unix.Flock(int(lockFile.Fd()), unix.LOCK_EX))
+	return lockFile
+}
+
+func composeResourceCompletedForRun(project string, resource string) bool {
+	marker := composeResourceMarker(project, resource)
+	if marker == "" {
+		return false
+	}
+	_, err := os.Stat(marker)
+	return err == nil
+}
+
+func markComposeResourceCompleted(t testing.TB, project string, resource string) {
+	t.Helper()
+
+	marker := composeResourceMarker(project, resource)
+	if marker == "" {
+		return
+	}
+	require.NoError(t, os.WriteFile(marker, nil, 0o600))
+}
+
+func composeResourceMarker(project string, resource string) string {
+	runDir := os.Getenv(composeRunDirEnv)
+	if runDir == "" {
+		return ""
+	}
+	digest := sha256.Sum256([]byte(project + "\x00" + resource))
+	return filepath.Join(runDir, fmt.Sprintf("%s.started", hex.EncodeToString(digest[:])[:16]))
+}
+
+func composeServiceHealthy(project string, service string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "docker", "compose", "-f", composeFile(), "-p", project, "ps", "--format", "json", service)
+	out, err := cmd.Output()
+	if err != nil || len(out) == 0 {
+		return false
+	}
+
+	var status struct {
+		Health string `json:"Health"`
+		State  string `json:"State"`
+	}
+	if err := json.Unmarshal(out, &status); err != nil {
+		return false
+	}
+	return status.State == "running" && status.Health == "healthy"
 }
 
 // startIsolatedService starts one service in a Compose project that only this
@@ -181,11 +275,16 @@ func removeComposeProject(project string) {
 
 func composeServicePort(t testing.TB, project string, service string, port int) int {
 	t.Helper()
+	cacheKey := composePortKey{project: project, service: service, port: port}
+	if cached, ok := composeServicePorts.Load(cacheKey); ok {
+		return cached.(int)
+	}
 
 	outText := runDockerCompose(t, "-f", composeFile(), "-p", project, "port", service, strconv.Itoa(port))
 	hostPort, err := composePort(outText)
 	require.NoError(t, err)
-	return hostPort
+	actual, _ := composeServicePorts.LoadOrStore(cacheKey, hostPort)
+	return actual.(int)
 }
 
 func runDockerCompose(t testing.TB, args ...string) string {

--- a/pkg/testutil/docker-compose.test.yaml
+++ b/pkg/testutil/docker-compose.test.yaml
@@ -18,10 +18,9 @@ services:
           "--password=password",
           "--query=SELECT 1",
         ]
-      interval: 2s
+      interval: 1s
       timeout: 5s
-      retries: 30
-      start_period: 10s
+      retries: 60
 
   mysql:
     image: mysql:9.4.0
@@ -55,10 +54,9 @@ services:
         "-uunkey",
         "-ppassword",
       ]
-      interval: 2s
+      interval: 1s
       timeout: 5s
-      retries: 30
-      start_period: 10s
+      retries: 60
 
   redis:
     image: redis:8.0@sha256:ae471bdc20de180beed36e347d170ec0bdf8faa327959ea1f24692f22b05b955
@@ -74,10 +72,9 @@ services:
       - "6379"
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
-      interval: 2s
+      interval: 1s
       timeout: 5s
-      retries: 30
-      start_period: 5s
+      retries: 60
 
   restate:
     image: docker.io/restatedev/restate:1.6.0@sha256:33f227db946864b5482340a8621e32ec5eaf464f4dc41d5deccfd3282bb930ae
@@ -97,10 +94,9 @@ services:
       - "9070"
     healthcheck:
       test: ["CMD", "curl", "--fail", "http://localhost:9070/health"]
-      interval: 2s
+      interval: 1s
       timeout: 5s
-      retries: 30
-      start_period: 5s
+      retries: 60
 
   s3:
     image: quay.io/minio/minio:latest
@@ -112,10 +108,9 @@ services:
       - "9000"
     healthcheck:
       test: ["CMD", "mc", "ready", "local"]
-      interval: 2s
+      interval: 1s
       timeout: 5s
-      retries: 30
-      start_period: 5s
+      retries: 60
 
 volumes:
   clickhouse:


### PR DESCRIPTION
## Problem:

The full Go test command compiled the suite once to list tests and again to run them. Concurrent packages also repeated the same container startup and ClickHouse schema setup.

## Solution:

Prepare shared Go build data once for a full-suite run. Skip the preliminary test-list compile. Reuse healthy test containers and one ClickHouse schema setup during the same test command.

## Impact:

The full suite starts without a known test total. Test behavior stays the same, but repeated setup work is removed.

## Testing:

- `mise run test`: 298 suites completed with 24,038 passed, 0 failed, and 7,896 ignored.