### PR TITLE
build: upgrade Go toolchain to 1.26.5

### DIFF
--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -12,7 +12,7 @@ task.run_auto_install = false
 
 [tools]
 node = "24.19.0"
-go = "1.25.10"
+go = "1.26.5"
 "github:dprint/dprint" = "0.51.1"
 "github:bufbuild/buf" = "1.64.0"
 "github:jqlang/jq" = "jq-1.8.1"

--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -12,7 +12,7 @@ task.run_auto_install = false
 
 [tools]
 node = "24.19.0"
-go = "1.25.1"
+go = "1.26.5"
 "github:dprint/dprint" = "0.51.1"
 "github:bufbuild/buf" = "1.64.0"
 "github:jqlang/jq" = "jq-1.8.1"

--- a/.mise/mise.lock
+++ b/.mise/mise.lock
@@ -556,36 +556,36 @@ url = "https://github.com/tilt-dev/tilt/releases/download/v0.37.3/tilt.0.37.3.wi
 url_api = "https://api.github.com/repos/tilt-dev/tilt/releases/assets/409071129"
 
 [[tools.go]]
-version = "1.25.10"
+version = "1.26.5"
 backend = "core:go"
 
 [tools.go."platforms.linux-arm64"]
-checksum = "sha256:654da1f9b50a5d1c2a85ccf8ed405aa89c06e94d18384628bf186f7712677b08"
-url = "https://dl.google.com/go/go1.25.10.linux-arm64.tar.gz"
+checksum = "sha256:fe4789e92b1f33358680864bbe8704289e7bb5fc207d80623c308935bd696d49"
+url = "https://dl.google.com/go/go1.26.5.linux-arm64.tar.gz"
 
 [tools.go."platforms.linux-arm64-musl"]
-checksum = "sha256:654da1f9b50a5d1c2a85ccf8ed405aa89c06e94d18384628bf186f7712677b08"
-url = "https://dl.google.com/go/go1.25.10.linux-arm64.tar.gz"
+checksum = "sha256:fe4789e92b1f33358680864bbe8704289e7bb5fc207d80623c308935bd696d49"
+url = "https://dl.google.com/go/go1.26.5.linux-arm64.tar.gz"
 
 [tools.go."platforms.linux-x64"]
-checksum = "sha256:42d4f7a32316aa66591eca7e89867256057a4264451aca10570a715b3637ba70"
-url = "https://dl.google.com/go/go1.25.10.linux-amd64.tar.gz"
+checksum = "sha256:5c2c3b16caefa1d968a94c1daca04a7ca301a496d9b086e17ad77bb81393f053"
+url = "https://dl.google.com/go/go1.26.5.linux-amd64.tar.gz"
 
 [tools.go."platforms.linux-x64-musl"]
-checksum = "sha256:42d4f7a32316aa66591eca7e89867256057a4264451aca10570a715b3637ba70"
-url = "https://dl.google.com/go/go1.25.10.linux-amd64.tar.gz"
+checksum = "sha256:5c2c3b16caefa1d968a94c1daca04a7ca301a496d9b086e17ad77bb81393f053"
+url = "https://dl.google.com/go/go1.26.5.linux-amd64.tar.gz"
 
 [tools.go."platforms.macos-arm64"]
-checksum = "sha256:795691a425de7e7cdba3544f354dcd2cebcf52e87dc6898193878f34eb6d634f"
-url = "https://dl.google.com/go/go1.25.10.darwin-arm64.tar.gz"
+checksum = "sha256:efb87ff28af9a188d0536ef5d42e63dd52ba8263cd7344a993cc48dd11dedb6a"
+url = "https://dl.google.com/go/go1.26.5.darwin-arm64.tar.gz"
 
 [tools.go."platforms.macos-x64"]
-checksum = "sha256:52321165a3146cd91865ef98371506a846ed4dc4f9f1c9323e5ad90d2a411e06"
-url = "https://dl.google.com/go/go1.25.10.darwin-amd64.tar.gz"
+checksum = "sha256:6231d8d3b8f5552ec6cbf6d685bdd5482e1e703214b120e89b3bf0d7bf1ef725"
+url = "https://dl.google.com/go/go1.26.5.darwin-amd64.tar.gz"
 
 [tools.go."platforms.windows-x64"]
-checksum = "sha256:ca37af2dadd8544464f1a9ca7c3886499d1cdfcb263855d0a1d71f194b2bd222"
-url = "https://dl.google.com/go/go1.25.10.windows-amd64.zip"
+checksum = "sha256:97e6b2a833b6d89f9ff17d25419ac0a7e3b482a044e9ab18cdef834bd834fd38"
+url = "https://dl.google.com/go/go1.26.5.windows-amd64.zip"
 
 [[tools."http:helm"]]
 version = "3.21.0"

--- a/.mise/mise.lock
+++ b/.mise/mise.lock
@@ -556,36 +556,36 @@ url = "https://github.com/tilt-dev/tilt/releases/download/v0.37.3/tilt.0.37.3.wi
 url_api = "https://api.github.com/repos/tilt-dev/tilt/releases/assets/409071129"
 
 [[tools.go]]
-version = "1.25.1"
+version = "1.26.5"
 backend = "core:go"
 
 [tools.go."platforms.linux-arm64"]
-checksum = "sha256:65a3e34fb2126f55b34e1edfc709121660e1be2dee6bdf405fc399a63a95a87d"
-url = "https://dl.google.com/go/go1.25.1.linux-arm64.tar.gz"
+checksum = "sha256:fe4789e92b1f33358680864bbe8704289e7bb5fc207d80623c308935bd696d49"
+url = "https://dl.google.com/go/go1.26.5.linux-arm64.tar.gz"
 
 [tools.go."platforms.linux-arm64-musl"]
-checksum = "sha256:65a3e34fb2126f55b34e1edfc709121660e1be2dee6bdf405fc399a63a95a87d"
-url = "https://dl.google.com/go/go1.25.1.linux-arm64.tar.gz"
+checksum = "sha256:fe4789e92b1f33358680864bbe8704289e7bb5fc207d80623c308935bd696d49"
+url = "https://dl.google.com/go/go1.26.5.linux-arm64.tar.gz"
 
 [tools.go."platforms.linux-x64"]
-checksum = "sha256:7716a0d940a0f6ae8e1f3b3f4f36299dc53e31b16840dbd171254312c41ca12e"
-url = "https://dl.google.com/go/go1.25.1.linux-amd64.tar.gz"
+checksum = "sha256:5c2c3b16caefa1d968a94c1daca04a7ca301a496d9b086e17ad77bb81393f053"
+url = "https://dl.google.com/go/go1.26.5.linux-amd64.tar.gz"
 
 [tools.go."platforms.linux-x64-musl"]
-checksum = "sha256:7716a0d940a0f6ae8e1f3b3f4f36299dc53e31b16840dbd171254312c41ca12e"
-url = "https://dl.google.com/go/go1.25.1.linux-amd64.tar.gz"
+checksum = "sha256:5c2c3b16caefa1d968a94c1daca04a7ca301a496d9b086e17ad77bb81393f053"
+url = "https://dl.google.com/go/go1.26.5.linux-amd64.tar.gz"
 
 [tools.go."platforms.macos-arm64"]
-checksum = "sha256:68deebb214f39d542e518ebb0598a406ab1b5a22bba8ec9ade9f55fb4dd94a6c"
-url = "https://dl.google.com/go/go1.25.1.darwin-arm64.tar.gz"
+checksum = "sha256:efb87ff28af9a188d0536ef5d42e63dd52ba8263cd7344a993cc48dd11dedb6a"
+url = "https://dl.google.com/go/go1.26.5.darwin-arm64.tar.gz"
 
 [tools.go."platforms.macos-x64"]
-checksum = "sha256:1d622468f767a1b9fe1e1e67bd6ce6744d04e0c68712adc689748bbeccb126bb"
-url = "https://dl.google.com/go/go1.25.1.darwin-amd64.tar.gz"
+checksum = "sha256:6231d8d3b8f5552ec6cbf6d685bdd5482e1e703214b120e89b3bf0d7bf1ef725"
+url = "https://dl.google.com/go/go1.26.5.darwin-amd64.tar.gz"
 
 [tools.go."platforms.windows-x64"]
-checksum = "sha256:4a974de310e7ee1d523d2fcedb114ba5fa75408c98eb3652023e55ccf3fa7cab"
-url = "https://dl.google.com/go/go1.25.1.windows-amd64.zip"
+checksum = "sha256:97e6b2a833b6d89f9ff17d25419ac0a7e3b482a044e9ab18cdef834bd834fd38"
+url = "https://dl.google.com/go/go1.26.5.windows-amd64.zip"
 
 [[tools."http:helm"]]
 version = "3.21.0"

--- a/.mise/tasks/test
+++ b/.mise/tasks/test
@@ -49,7 +49,26 @@ trap cleanup_test_containers EXIT
 
 # Warm shared package exports once for full-suite runs. Eight compiler processes
 # were fastest for this cache-bound graph; GOMEMLIMIT bounds memory with GOGC off.
-if [[ $# -eq 0 ]]; then
+full_suite=true
+expect_option_value=false
+for arg in "$@"; do
+  if [[ "${expect_option_value}" == true ]]; then
+    expect_option_value=false
+    continue
+  fi
+
+  case "${arg}" in
+    --concurrency)
+      expect_option_value=true
+      ;;
+    -v | --verbose | --no-cache | --version | -h | --help | --concurrency=* | -v=* | --verbose=* | --no-cache=* | --version=*) ;;
+    *)
+      full_suite=false
+      ;;
+  esac
+done
+
+if [[ "${full_suite}" == true ]]; then
   compile_parallelism="$(getconf _NPROCESSORS_ONLN 2>/dev/null || printf '8')"
   if ((compile_parallelism > 8)); then
     compile_parallelism=8

--- a/.mise/tasks/test
+++ b/.mise/tasks/test
@@ -47,14 +47,8 @@ cleanup_test_containers() {
 }
 trap cleanup_test_containers EXIT
 
-# On a cold cache, Rask starts one `go test` process per package and each process
-# rebuilds the same dependency graph. Populate production package exports once so
-# Rask can keep its package-level test parallelism without multiplying compiler
-# work, linking unused commands, or pre-running test binaries. Targeted runs do
-# not have enough package fan-out to benefit from this extra pass. Cap package
-# compilation at eight processes: the large dependency graph is cache-bound, and
-# higher fan-out made this phase slower on machines with more cores. The compiler
-# can use more memory to avoid garbage collection, but cap each process at 1 GiB.
+# Warm shared package exports once for full-suite runs. Eight compiler processes
+# were fastest for this cache-bound graph; GOMEMLIMIT bounds memory with GOGC off.
 if [[ $# -eq 0 ]]; then
   compile_parallelism="$(getconf _NPROCESSORS_ONLN 2>/dev/null || printf '8')"
   if ((compile_parallelism > 8)); then
@@ -63,10 +57,7 @@ if [[ $# -eq 0 ]]; then
   GOGC=off GOMEMLIMIT=1GiB go list -p "${compile_parallelism}" -deps -export ./... >/dev/null
 fi
 
-# Rask 0.5.0 compiles every package once with `go test -list '^Test'` only to
-# calculate progress totals, then compiles and runs the real test command. Its
-# unknown-total fallback preserves execution and reporting without that duplicate
-# build. Keep all other Go invocations byte-for-byte unchanged.
+# Force Rask's unknown-total path to skip its duplicate `go test -list` compile.
 real_go="$(command -v go)"
 rask_go_wrapper="${test_run_dir}/go-wrapper"
 mkdir -p "${rask_go_wrapper}"

--- a/.mise/tasks/test
+++ b/.mise/tasks/test
@@ -9,9 +9,15 @@ export UNKEY_TEST_CONTAINER_SCOPE="${UNKEY_TEST_CONTAINER_SCOPE:-$PWD}"
 
 test_container_scope_hash="$(printf "%s" "${UNKEY_TEST_CONTAINER_SCOPE}" | shasum -a 256 | cut -c1-12)"
 export UNKEY_TEST_COMPOSE_PROJECT="unkey-test-${test_container_scope_hash}"
+# Shared helpers use this directory to run each Compose reconciliation once per
+# suite rather than once per concurrently executing package.
+test_run_dir="$(mktemp -d)"
+export UNKEY_TEST_RUN_DIR="${test_run_dir}"
 
 cleanup_test_containers() {
   local status=$?
+
+  rm -rf -- "${test_run_dir}"
 
   # The test helpers intentionally reuse containers across Go test processes
   # so integration tests do not pay Docker startup cost for every test target.
@@ -41,4 +47,40 @@ cleanup_test_containers() {
 }
 trap cleanup_test_containers EXIT
 
-rask "$@"
+# On a cold cache, Rask starts one `go test` process per package and each process
+# rebuilds the same dependency graph. Populate production package exports once so
+# Rask can keep its package-level test parallelism without multiplying compiler
+# work, linking unused commands, or pre-running test binaries. Targeted runs do
+# not have enough package fan-out to benefit from this extra pass. Cap package
+# compilation at eight processes: the large dependency graph is cache-bound, and
+# higher fan-out made this phase slower on machines with more cores. The compiler
+# can use more memory to avoid garbage collection, but cap each process at 1 GiB.
+if [[ $# -eq 0 ]]; then
+  compile_parallelism="$(getconf _NPROCESSORS_ONLN 2>/dev/null || printf '8')"
+  if ((compile_parallelism > 8)); then
+    compile_parallelism=8
+  fi
+  GOGC=off GOMEMLIMIT=1GiB go list -p "${compile_parallelism}" -deps -export ./... >/dev/null
+fi
+
+# Rask 0.5.0 compiles every package once with `go test -list '^Test'` only to
+# calculate progress totals, then compiles and runs the real test command. Its
+# unknown-total fallback preserves execution and reporting without that duplicate
+# build. Keep all other Go invocations byte-for-byte unchanged.
+real_go="$(command -v go)"
+rask_go_wrapper="${test_run_dir}/go-wrapper"
+mkdir -p "${rask_go_wrapper}"
+cat > "${rask_go_wrapper}/go" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -eq 4 && "$1" == "test" && "$2" == "-list" && "$3" == "^Test" ]]; then
+  exit 1
+fi
+
+exec "${UNKEY_REAL_GO:?}" "$@"
+EOF
+chmod +x "${rask_go_wrapper}/go"
+
+export UNKEY_REAL_GO="${real_go}"
+PATH="${rask_go_wrapper}:${PATH}" rask "$@"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-FROM golang:1.25@sha256:cd05a378aaf011e8056745363e5c40f4f2bef0fa4d9bf19b9c38316079c332ff AS builder
+FROM golang:1.26.5@sha256:2005724102f45917a63e9d092fc0e4ea56ea575048ce147caad5f5f61502c365 AS builder
 
 WORKDIR /src
 ENV CGO_ENABLED=0

--- a/build/api/main.go
+++ b/build/api/main.go
@@ -4,14 +4,14 @@ import (
 	"context"
 
 	"github.com/unkeyed/unkey/build/util"
-	openapivalidation "github.com/unkeyed/unkey/pkg/openapi/validation"
+	"github.com/unkeyed/unkey/pkg/openapi/validation"
 	"github.com/unkeyed/unkey/svc/api"
 )
 
 func main() {
-	util.RunServiceCommand("api", "Run the Unkey API server", run)
+	util.RunServiceCommand("api", "Run the Unkey API server", runAPI)
 }
 
-func run(ctx context.Context, cfg api.Config) error {
-	return api.Run(ctx, cfg, openapivalidation.NewFromBytes)
+func runAPI(ctx context.Context, cfg api.Config) error {
+	return api.Run(ctx, cfg, validation.NewFromBytes)
 }

--- a/build/api/main.go
+++ b/build/api/main.go
@@ -1,10 +1,17 @@
 package main
 
 import (
+	"context"
+
 	"github.com/unkeyed/unkey/build/util"
+	openapivalidation "github.com/unkeyed/unkey/pkg/openapi/validation"
 	"github.com/unkeyed/unkey/svc/api"
 )
 
 func main() {
-	util.RunServiceCommand("api", "Run the Unkey API server", api.Run)
+	util.RunServiceCommand("api", "Run the Unkey API server", run)
+}
+
+func run(ctx context.Context, cfg api.Config) error {
+	return api.Run(ctx, cfg, openapivalidation.NewFromBytes)
 }

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-FROM golang:1.25.1-alpine@sha256:b6ed3fd0452c0e9bcdef5597f29cc1418f61672e9d3a2f55bf02e7222c014abd AS builder
+FROM golang:1.26.5-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS builder
 
 WORKDIR /src
 ENV CGO_ENABLED=0

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/unkeyed/unkey
 
 go 1.25.10
 
+toolchain go1.26.5
+
 // Yaml parsing errors
 replace github.com/dprotaso/go-yit => github.com/dprotaso/go-yit v0.0.0-20191028211022-135eb7262960
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/unkeyed/unkey
 
 go 1.25.0
 
-toolchain go1.25.1
+toolchain go1.26.5
 
 // Yaml parsing errors
 replace github.com/dprotaso/go-yit => github.com/dprotaso/go-yit v0.0.0-20191028211022-135eb7262960

--- a/internal/services/ratelimit/global.go
+++ b/internal/services/ratelimit/global.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/unkeyed/unkey/pkg/logger"
+	"github.com/unkeyed/unkey/pkg/mysql"
 	"github.com/unkeyed/unkey/pkg/repeat"
 
 	"github.com/unkeyed/unkey/internal/services/ratelimit/db"
@@ -172,7 +173,9 @@ func (s *service) runGlobalPushOnce() {
 		}
 
 		_, err := s.globalCircuitBreaker.Do(ctx, func(ctx context.Context) (any, error) {
-			return nil, s.db.BulkUpsertGlobalCounters(ctx, chunkRows)
+			return mysql.WithRetryContext(ctx, func() (any, error) {
+				return nil, s.db.BulkUpsertGlobalCounters(ctx, chunkRows)
+			})
 		})
 		if err != nil {
 			metrics.RatelimitGlobalPushErrors.Inc()

--- a/internal/services/ratelimit/global_integration_test.go
+++ b/internal/services/ratelimit/global_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	drivermysql "github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/require"
 	rldb "github.com/unkeyed/unkey/internal/services/ratelimit/db"
 	"github.com/unkeyed/unkey/pkg/circuitbreaker"
@@ -313,17 +314,16 @@ func TestGlobalPush_EmitsRowsInUniqueKeyOrder(t *testing.T) {
 	}
 }
 
-// TestGlobalPush_ConcurrentFlushesDoNotDeadlock reproduces the production lock
-// graph with real MySQL transactions. The DB wrapper splits each collected bulk
-// batch into per-row upserts inside one transaction, which turns inconsistent
-// row order into the same 1213 deadlock MySQL can produce under overlapping
-// ON DUPLICATE KEY UPDATE flushes.
-func TestGlobalPush_ConcurrentFlushesDoNotDeadlock(t *testing.T) {
+// TestGlobalPush_ConcurrentFlushesRecoverFromDeadlock reproduces the production
+// lock graph with real MySQL transactions. Even with consistent row order,
+// InnoDB can select one overlapping upsert as a deadlock victim. The idempotent
+// flush must retry that transaction and commit both callers' progress.
+func TestGlobalPush_ConcurrentFlushesRecoverFromDeadlock(t *testing.T) {
 	t.Parallel()
 
 	env := newIntegrationTestEnv(t)
 
-	for attempt := range 30 {
+	for attempt := range 5 {
 		workspaceID := uid.New(uid.WorkspacePrefix)
 		keys := []counterKey{
 			{workspaceID: workspaceID, namespace: "ns-a", identifier: "id-a", durationMs: 60_000, sequence: 1},
@@ -347,13 +347,14 @@ func TestGlobalPush_ConcurrentFlushesDoNotDeadlock(t *testing.T) {
 		}
 
 		svcA := newGlobalPushOnlyService(db, "region-a")
+		entries := make([]*counterEntry, 0, len(keys)*2)
 		for _, key := range keys {
-			storePushableCounter(svcA, key)
+			entries = append(entries, storePushableCounter(svcA, key))
 		}
 
 		svcB := newGlobalPushOnlyService(db, "region-a")
 		for i := len(keys) - 1; i >= 0; i-- {
-			storePushableCounter(svcB, keys[i])
+			entries = append(entries, storePushableCounter(svcB, keys[i]))
 		}
 
 		var wg sync.WaitGroup
@@ -362,12 +363,35 @@ func TestGlobalPush_ConcurrentFlushesDoNotDeadlock(t *testing.T) {
 		wg.Wait()
 		cancel()
 
-		require.Empty(t, db.deadlockErrors(),
-			"attempt %d reproduced a MySQL deadlock during concurrent global counter flushes; row orders: %v",
-			attempt,
-			db.rowOrders(),
-		)
+		for _, entry := range entries {
+			require.Equal(t, int64(10), entry.lastPushed.Load(),
+				"attempt %d did not commit both concurrent flushes; row orders: %v, deadlocks: %v",
+				attempt,
+				db.rowOrders(),
+				db.deadlockErrors(),
+			)
+		}
 	}
+}
+
+func TestGlobalPush_RetriesDeadlock(t *testing.T) {
+	t.Parallel()
+
+	recorder := &deadlockOnceGlobalCounterDB{}
+	svc := newGlobalPushOnlyService(recorder, "region-a")
+	entry := storePushableCounter(svc, counterKey{
+		workspaceID: "ws-a",
+		namespace:   "ns-a",
+		identifier:  "id-a",
+		durationMs:  60_000,
+		sequence:    1,
+	})
+
+	svc.runGlobalPushOnce()
+
+	require.Equal(t, 2, recorder.calls)
+	require.Len(t, recorder.rows, 1)
+	require.Equal(t, int64(10), entry.lastPushed.Load())
 }
 
 func newGlobalPushOnlyService(db rldb.DBTX, region string) *service {
@@ -387,11 +411,12 @@ func newGlobalPullOnlyService(env *integrationTestEnv, clk clock.Clock, region s
 	}
 }
 
-func storePushableCounter(svc *service, key counterKey) {
+func storePushableCounter(svc *service, key counterKey) *counterEntry {
 	entry := &counterEntry{} //nolint:exhaustruct // only push eligibility fields matter here
 	entry.val.Store(10)
 	entry.globalPushThreshold.Store(1)
 	svc.counters.Store(key, entry)
+	return entry
 }
 
 func globalCounterRowForKey(key counterKey, region string, count uint64) rldb.UpsertRatelimitGlobalCountersParams {
@@ -555,6 +580,19 @@ func (db *recordingGlobalCounterDB) QueryContext(context.Context, string, ...int
 
 func (db *recordingGlobalCounterDB) QueryRowContext(context.Context, string, ...interface{}) *sql.Row {
 	return &sql.Row{}
+}
+
+type deadlockOnceGlobalCounterDB struct {
+	recordingGlobalCounterDB
+	calls int
+}
+
+func (db *deadlockOnceGlobalCounterDB) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
+	db.calls++
+	if db.calls == 1 {
+		return nil, &drivermysql.MySQLError{Number: 1213, Message: "Deadlock found when trying to get lock"}
+	}
+	return db.recordingGlobalCounterDB.ExecContext(ctx, query, args...)
 }
 
 func globalCounterRowsFromArgs(args []interface{}) ([]rldb.UpsertRatelimitGlobalCountersParams, error) {

--- a/internal/services/ratelimit/ratelimit_test.go
+++ b/internal/services/ratelimit/ratelimit_test.go
@@ -416,10 +416,11 @@ func TestRatelimit_MultiReplicaMidWindowBurstExceedsLimit(t *testing.T) {
 	db := newTestDB(t)
 
 	const (
-		replicas                   = 5
-		burstRequestsPerNode       = 200
-		limit                int64 = 162000
-		cost                 int64 = 1500
+		replicas                           = 5
+		burstRounds                        = 4
+		burstRequestsPerNodePerRound       = 50
+		limit                        int64 = 162000
+		cost                         int64 = 1500
 	)
 	duration := time.Minute
 
@@ -436,43 +437,68 @@ func TestRatelimit_MultiReplicaMidWindowBurstExceedsLimit(t *testing.T) {
 	workspaceID := uid.New(uid.WorkspacePrefix)
 	namespace := uid.New(uid.TestPrefix)
 	identifier := uid.New(uid.TestPrefix)
-	// Advance request time through the burst so the test exercises replay-updated
-	// freshness and repeated stale refreshes rather than a Redis reservation model.
-	makeReq := func() RatelimitRequest {
+	makeReq := func(requestTime time.Time) RatelimitRequest {
 		return RatelimitRequest{
 			WorkspaceID: workspaceID, Namespace: namespace, Identifier: identifier,
-			Limit: limit, Duration: duration, Cost: cost, Time: clk.Tick(20 * time.Millisecond),
+			Limit: limit, Duration: duration, Cost: cost, Time: requestTime,
 		}
 	}
 
 	for _, svc := range services {
-		resp, err := svc.Ratelimit(ctx, makeReq())
+		resp, err := svc.Ratelimit(ctx, makeReq(clk.Tick(20*time.Millisecond)))
 		require.NoError(t, err)
 		require.True(t, resp.Success, "warmup request at window start must pass")
 	}
 
+	curKey := counterKey{
+		workspaceID: workspaceID,
+		namespace:   namespace,
+		identifier:  identifier,
+		durationMs:  duration.Milliseconds(),
+		sequence:    calculateSequence(clk.Now(), duration),
+	}
+	waitForOrigin := func(expectedTokens int64) {
+		t.Helper()
+		require.Eventually(t, func() bool {
+			originTokens, err := origin.Get(ctx, curKey.redisKey())
+			return err == nil && originTokens == expectedTokens
+		}, 10*time.Second, 10*time.Millisecond,
+			"replay must deliver every accepted request to the shared origin")
+	}
+
+	waitForOrigin(replicas * cost)
 	clk.Tick(30 * time.Second)
 
-	var (
-		passedRequests atomic.Int64
-		wg             sync.WaitGroup
-		start          = make(chan struct{})
-	)
-	for _, svc := range services {
-		wg.Add(1)
-		go func(svc *service) {
-			defer wg.Done()
-			<-start
-			for range burstRequestsPerNode {
-				resp, err := svc.Ratelimit(ctx, makeReq())
-				if err == nil && resp.Success {
-					passedRequests.Add(1)
+	var passedRequests atomic.Int64
+	for round := range burstRounds {
+		if round > 0 {
+			clk.Tick(originFreshDuration)
+		}
+
+		// Freeze simulated time during each concurrent burst. Replay still runs
+		// asynchronously, but its progress can no longer depend on how quickly the
+		// request goroutines advance the test clock relative to wall-clock scheduling.
+		requestTime := clk.Now()
+		var wg sync.WaitGroup
+		start := make(chan struct{})
+		for _, svc := range services {
+			wg.Add(1)
+			go func(svc *service) {
+				defer wg.Done()
+				<-start
+				for range burstRequestsPerNodePerRound {
+					resp, err := svc.Ratelimit(ctx, makeReq(requestTime))
+					if err == nil && resp.Success {
+						passedRequests.Add(1)
+					}
 				}
-			}
-		}(svc)
+			}(svc)
+		}
+		close(start)
+		wg.Wait()
+
+		waitForOrigin((replicas + passedRequests.Load()) * cost)
 	}
-	close(start)
-	wg.Wait()
 
 	passedTokens := passedRequests.Load() * cost
 	require.LessOrEqual(t, passedTokens, 3*limit,

--- a/pkg/clickhouse/ratelimits_test.go
+++ b/pkg/clickhouse/ratelimits_test.go
@@ -18,6 +18,8 @@ import (
 )
 
 func TestRatelimits_ComprehensiveLoadTest(t *testing.T) {
+	t.Parallel()
+
 	chCfg := containers.ClickHouse(t)
 	dsn := chCfg.DSN
 
@@ -26,7 +28,7 @@ func TestRatelimits_ComprehensiveLoadTest(t *testing.T) {
 
 	conn, err := ch.Open(opts)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, conn.Close()) }()
+	t.Cleanup(func() { require.NoError(t, conn.Close()) })
 
 	err = conn.Ping(context.Background())
 	require.NoError(t, err)
@@ -124,36 +126,58 @@ func TestRatelimits_ComprehensiveLoadTest(t *testing.T) {
 	// Wait for raw data to be available
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		rawCount := uint64(0)
-		err = conn.QueryRow(ctx, "SELECT COUNT(*) FROM default.ratelimits_raw_v2 WHERE workspace_id = ?", workspaceID).Scan(&rawCount)
-		require.NoError(c, err)
+		queryErr := conn.QueryRow(ctx, "SELECT COUNT(*) FROM default.ratelimits_raw_v2 WHERE workspace_id = ?", workspaceID).Scan(&rawCount)
+		require.NoError(c, queryErr)
 		require.Equal(c, len(ratelimits), int(rawCount))
 	}, time.Minute, time.Second)
 
-	t.Run("pass/total counts are correct", func(t *testing.T) {
-		// Calculate expected totals from source data
-		totalPassed := array.Reduce(ratelimits, func(acc int, r schema.Ratelimit) int {
-			if r.Passed {
-				return acc + 1
-			}
-			return acc
-		}, 0)
+	type requestStats struct {
+		passed int
+		total  int
+	}
+	totalStats := requestStats{}
+	namespaceStats := make(map[string]requestStats, len(namespaces))
+	identifierStats := make(map[string]requestStats, len(identifiers))
+	for _, ratelimit := range ratelimits {
+		totalStats.total++
+		if ratelimit.Passed {
+			totalStats.passed++
+		}
 
-		totalRequests := len(ratelimits)
+		stats := namespaceStats[ratelimit.NamespaceID]
+		stats.total++
+		if ratelimit.Passed {
+			stats.passed++
+		}
+		namespaceStats[ratelimit.NamespaceID] = stats
+
+		stats = identifierStats[ratelimit.Identifier]
+		stats.total++
+		if ratelimit.Passed {
+			stats.passed++
+		}
+		identifierStats[ratelimit.Identifier] = stats
+	}
+
+	t.Run("pass/total counts are correct", func(t *testing.T) {
+		t.Parallel()
 
 		for _, table := range []string{"default.ratelimits_per_minute_v2", "default.ratelimits_per_hour_v2", "default.ratelimits_per_day_v2", "default.ratelimits_per_month_v2"} {
 			t.Run(table, func(t *testing.T) {
 				require.EventuallyWithT(t, func(c *assert.CollectT) {
 					var queriedPassed, queriedTotal int64
-					err = conn.QueryRow(ctx, fmt.Sprintf("SELECT sum(passed), sum(total) FROM %s WHERE workspace_id = ?", table), workspaceID).Scan(&queriedPassed, &queriedTotal)
-					require.NoError(c, err)
-					require.Equal(c, totalPassed, int(queriedPassed), "passed count should match")
-					require.Equal(c, totalRequests, int(queriedTotal), "total count should match")
+					queryErr := conn.QueryRow(ctx, fmt.Sprintf("SELECT sum(passed), sum(total) FROM %s WHERE workspace_id = ?", table), workspaceID).Scan(&queriedPassed, &queriedTotal)
+					require.NoError(c, queryErr)
+					require.Equal(c, totalStats.passed, int(queriedPassed), "passed count should match")
+					require.Equal(c, totalStats.total, int(queriedTotal), "total count should match")
 				}, time.Minute, time.Second)
 			})
 		}
 	})
 
 	t.Run("latency aggregates are correct", func(t *testing.T) {
+		t.Parallel()
+
 		latencies := array.Map(ratelimits, func(r schema.Ratelimit) float64 {
 			return r.Latency
 		})
@@ -169,8 +193,8 @@ func TestRatelimits_ComprehensiveLoadTest(t *testing.T) {
 						queriedP75 float32
 						queriedP99 float32
 					)
-					err = conn.QueryRow(ctx, fmt.Sprintf("SELECT avgMerge(latency_avg), quantilesTDigestMerge(0.75)(latency_p75)[1], quantilesTDigestMerge(0.99)(latency_p99)[1] FROM %s WHERE workspace_id = ?", table), workspaceID).Scan(&queriedAvg, &queriedP75, &queriedP99)
-					require.NoError(c, err)
+					queryErr := conn.QueryRow(ctx, fmt.Sprintf("SELECT avgMerge(latency_avg), quantilesTDigestMerge(0.75)(latency_p75)[1], quantilesTDigestMerge(0.99)(latency_p99)[1] FROM %s WHERE workspace_id = ?", table), workspaceID).Scan(&queriedAvg, &queriedP75, &queriedP99)
+					require.NoError(c, queryErr)
 
 					require.InDelta(c, avg, queriedAvg, 0.01, "average latency should match")
 					require.InDelta(c, p75, float64(queriedP75), 0.5, "75th percentile should match")
@@ -181,24 +205,15 @@ func TestRatelimits_ComprehensiveLoadTest(t *testing.T) {
 	})
 
 	t.Run("namespace-level aggregation is correct", func(t *testing.T) {
-		// Group by namespace and calculate expected totals
-		namespaceStats := array.Reduce(ratelimits, func(acc map[string]struct{ passed, total int }, r schema.Ratelimit) map[string]struct{ passed, total int } {
-			stats := acc[r.NamespaceID]
-			stats.total++
-			if r.Passed {
-				stats.passed++
-			}
-			acc[r.NamespaceID] = stats
-			return acc
-		}, make(map[string]struct{ passed, total int }))
+		t.Parallel()
 
 		for _, table := range []string{"default.ratelimits_per_minute_v2", "default.ratelimits_per_hour_v2", "default.ratelimits_per_day_v2", "default.ratelimits_per_month_v2"} {
 			t.Run(table, func(t *testing.T) {
 				for namespaceID, expectedStats := range namespaceStats {
 					require.EventuallyWithT(t, func(c *assert.CollectT) {
 						var queriedPassed, queriedTotal int64
-						err = conn.QueryRow(ctx, fmt.Sprintf("SELECT sum(passed), sum(total) FROM %s WHERE workspace_id = ? AND namespace_id = ?", table), workspaceID, namespaceID).Scan(&queriedPassed, &queriedTotal)
-						require.NoError(c, err)
+						queryErr := conn.QueryRow(ctx, fmt.Sprintf("SELECT sum(passed), sum(total) FROM %s WHERE workspace_id = ? AND namespace_id = ?", table), workspaceID, namespaceID).Scan(&queriedPassed, &queriedTotal)
+						require.NoError(c, queryErr)
 						require.Equal(c, expectedStats.passed, int(queriedPassed), "passed count for namespace %s should match", namespaceID)
 						require.Equal(c, expectedStats.total, int(queriedTotal), "total count for namespace %s should match", namespaceID)
 					}, time.Minute, time.Second)
@@ -208,16 +223,7 @@ func TestRatelimits_ComprehensiveLoadTest(t *testing.T) {
 	})
 
 	t.Run("identifier-level aggregation is correct", func(t *testing.T) {
-		// Group by identifier and calculate expected totals
-		identifierStats := array.Reduce(ratelimits, func(acc map[string]struct{ passed, total int }, r schema.Ratelimit) map[string]struct{ passed, total int } {
-			stats := acc[r.Identifier]
-			stats.total++
-			if r.Passed {
-				stats.passed++
-			}
-			acc[r.Identifier] = stats
-			return acc
-		}, make(map[string]struct{ passed, total int }))
+		t.Parallel()
 
 		// Test a sample of identifiers to avoid overwhelming the test
 		sampleIdentifiers := array.Fill(min(50, len(identifierStats)), func() string {
@@ -234,8 +240,8 @@ func TestRatelimits_ComprehensiveLoadTest(t *testing.T) {
 
 					require.EventuallyWithT(t, func(c *assert.CollectT) {
 						var queriedPassed, queriedTotal int64
-						err = conn.QueryRow(ctx, fmt.Sprintf("SELECT sum(passed), sum(total) FROM %s WHERE workspace_id = ? AND identifier = ?", table), workspaceID, identifier).Scan(&queriedPassed, &queriedTotal)
-						require.NoError(c, err)
+						queryErr := conn.QueryRow(ctx, fmt.Sprintf("SELECT sum(passed), sum(total) FROM %s WHERE workspace_id = ? AND identifier = ?", table), workspaceID, identifier).Scan(&queriedPassed, &queriedTotal)
+						require.NoError(c, queryErr)
 						require.Equal(c, expectedStats.passed, int(queriedPassed), "passed count for identifier %s should match", identifier)
 						require.Equal(c, expectedStats.total, int(queriedTotal), "total count for identifier %s should match", identifier)
 					}, time.Minute, time.Second)
@@ -245,24 +251,17 @@ func TestRatelimits_ComprehensiveLoadTest(t *testing.T) {
 	})
 
 	t.Run("pass rate analysis globally", func(t *testing.T) {
-		// Calculate overall pass rate
-		total := 0
-		passed := 0
-		for _, r := range ratelimits {
-			total++
-			if r.Passed {
-				passed += 1
-			}
-		}
+		t.Parallel()
+
 		for _, table := range []string{"default.ratelimits_per_minute_v2", "default.ratelimits_per_hour_v2", "default.ratelimits_per_day_v2", "default.ratelimits_per_month_v2"} {
 			t.Run(table, func(t *testing.T) {
 				require.EventuallyWithT(t, func(c *assert.CollectT) {
 					var queriedPassed, queriedTotal int64
-					err = conn.QueryRow(ctx, fmt.Sprintf("SELECT sum(passed), sum(total) FROM %s WHERE workspace_id = ?", table), workspaceID).Scan(&queriedPassed, &queriedTotal)
-					require.NoError(c, err)
+					queryErr := conn.QueryRow(ctx, fmt.Sprintf("SELECT sum(passed), sum(total) FROM %s WHERE workspace_id = ?", table), workspaceID).Scan(&queriedPassed, &queriedTotal)
+					require.NoError(c, queryErr)
 
-					require.Equal(c, total, int(queriedTotal), "total queries should match")
-					require.Equal(c, passed, int(queriedPassed), "passed queries should match")
+					require.Equal(c, totalStats.total, int(queriedTotal), "total queries should match")
+					require.Equal(c, totalStats.passed, int(queriedPassed), "passed queries should match")
 
 				}, time.Minute, time.Second)
 			})
@@ -270,27 +269,19 @@ func TestRatelimits_ComprehensiveLoadTest(t *testing.T) {
 	})
 
 	t.Run("pass rate analysis per identifier", func(t *testing.T) {
-		// Calculate overall pass rate
+		t.Parallel()
+
 		for _, identifier := range identifiers[:10] {
-			total := 0
-			passed := 0
-			for _, r := range ratelimits {
-				if r.Identifier == identifier {
-					total++
-					if r.Passed {
-						passed += 1
-					}
-				}
-			}
+			expected := identifierStats[identifier]
 			for _, table := range []string{"default.ratelimits_per_minute_v2", "default.ratelimits_per_hour_v2", "default.ratelimits_per_day_v2", "default.ratelimits_per_month_v2"} {
 				t.Run(table, func(t *testing.T) {
 					require.EventuallyWithT(t, func(c *assert.CollectT) {
 						var queriedPassed, queriedTotal int64
-						err = conn.QueryRow(ctx, fmt.Sprintf("SELECT sum(passed), sum(total) FROM %s WHERE workspace_id = ? AND identifier = ?", table), workspaceID, identifier).Scan(&queriedPassed, &queriedTotal)
-						require.NoError(c, err)
+						queryErr := conn.QueryRow(ctx, fmt.Sprintf("SELECT sum(passed), sum(total) FROM %s WHERE workspace_id = ? AND identifier = ?", table), workspaceID, identifier).Scan(&queriedPassed, &queriedTotal)
+						require.NoError(c, queryErr)
 
-						require.Equal(c, total, int(queriedTotal), "total queries should match")
-						require.Equal(c, passed, int(queriedPassed), "passed queries should match")
+						require.Equal(c, expected.total, int(queriedTotal), "total queries should match")
+						require.Equal(c, expected.passed, int(queriedPassed), "passed queries should match")
 
 					}, time.Minute, time.Second)
 				})
@@ -299,28 +290,19 @@ func TestRatelimits_ComprehensiveLoadTest(t *testing.T) {
 	})
 
 	t.Run("pass rate analysis per namespace", func(t *testing.T) {
+		t.Parallel()
 
 		for _, namespace := range namespaces {
-			// Calculate overall pass rate
-			total := 0
-			passed := 0
-			for _, r := range ratelimits {
-				if r.NamespaceID == namespace {
-					total++
-					if r.Passed {
-						passed += 1
-					}
-				}
-			}
+			expected := namespaceStats[namespace]
 			for _, table := range []string{"default.ratelimits_per_minute_v2", "default.ratelimits_per_hour_v2", "default.ratelimits_per_day_v2", "default.ratelimits_per_month_v2"} {
 				t.Run(table, func(t *testing.T) {
 					require.EventuallyWithT(t, func(c *assert.CollectT) {
 						var queriedPassed, queriedTotal int64
-						err = conn.QueryRow(ctx, fmt.Sprintf("SELECT sum(passed), sum(total) FROM %s WHERE workspace_id = ? AND namespace_id = ?", table), workspaceID, namespace).Scan(&queriedPassed, &queriedTotal)
-						require.NoError(c, err)
+						queryErr := conn.QueryRow(ctx, fmt.Sprintf("SELECT sum(passed), sum(total) FROM %s WHERE workspace_id = ? AND namespace_id = ?", table), workspaceID, namespace).Scan(&queriedPassed, &queriedTotal)
+						require.NoError(c, queryErr)
 
-						require.Equal(c, total, int(queriedTotal), "total queries should match")
-						require.Equal(c, passed, int(queriedPassed), "passed queries should match")
+						require.Equal(c, expected.total, int(queriedTotal), "total queries should match")
+						require.Equal(c, expected.passed, int(queriedPassed), "passed queries should match")
 
 					}, time.Minute, time.Second)
 				})

--- a/pkg/clickhouse/ratelimits_test.go
+++ b/pkg/clickhouse/ratelimits_test.go
@@ -18,8 +18,6 @@ import (
 )
 
 func TestRatelimits_ComprehensiveLoadTest(t *testing.T) {
-	t.Parallel()
-
 	chCfg := containers.ClickHouse(t)
 	dsn := chCfg.DSN
 

--- a/pkg/counter/redis_test.go
+++ b/pkg/counter/redis_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/unkeyed/unkey/pkg/testutil/containers"
 	"github.com/unkeyed/unkey/pkg/uid"
@@ -63,13 +64,11 @@ func TestRedisCounter(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, int64(1), val)
 
-		// Wait for the key to expire
-		time.Sleep(2 * time.Second)
-
-		// Key should be gone or zero
-		val, err = ctr.Get(ctx, key)
-		require.NoError(t, err)
-		require.Equal(t, int64(0), val)
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			val, err = ctr.Get(ctx, key)
+			require.NoError(c, err)
+			require.Equal(c, int64(0), val)
+		}, 2*time.Second, 25*time.Millisecond)
 	})
 
 	t.Run("Get", func(t *testing.T) {
@@ -288,13 +287,11 @@ func TestRedisCounter(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, int64(numWorkers), value)
 
-		// Wait for TTL to expire
-		time.Sleep(4 * time.Second)
-
-		// Key should be gone or zero
-		value, err = ctr.Get(ctx, key)
-		require.NoError(t, err)
-		require.Equal(t, int64(0), value, "Counter should be zero after TTL expiry")
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			value, err = ctr.Get(ctx, key)
+			require.NoError(c, err)
+			require.Equal(c, int64(0), value, "Counter should be zero after TTL expiry")
+		}, 4*time.Second, 25*time.Millisecond)
 	})
 }
 
@@ -493,13 +490,11 @@ func TestRedisCounterDecrement(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, int64(-5), val)
 
-		// Wait for the key to expire
-		time.Sleep(2 * time.Second)
-
-		// Key should be gone or zero
-		val, err = ctr.Get(ctx, key)
-		require.NoError(t, err)
-		require.Equal(t, int64(0), val)
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			val, err = ctr.Get(ctx, key)
+			require.NoError(c, err)
+			require.Equal(c, int64(0), val)
+		}, 2*time.Second, 25*time.Millisecond)
 	})
 
 	t.Run("ConcurrentDecrements", func(t *testing.T) {

--- a/pkg/openapi/validation/types/validator.go
+++ b/pkg/openapi/validation/types/validator.go
@@ -1,0 +1,26 @@
+package types
+
+import "net/http"
+
+// ValidationError represents a single field-level validation failure.
+// Fix is non-nil when the validator can suggest a concrete correction.
+type ValidationError struct {
+	Message  string
+	Location string
+	Fix      *string
+}
+
+// Result holds the validation outcome when a request is invalid.
+// A nil *Result means the request passed validation.
+type Result struct {
+	Detail string
+	Errors []ValidationError
+}
+
+// Validator validates HTTP requests against an OpenAPI specification.
+type Validator interface {
+	Validate(r *http.Request) *Result
+}
+
+// Factory creates a Validator from a raw OpenAPI specification.
+type Factory func(spec []byte) (Validator, error)

--- a/pkg/openapi/validation/validator.go
+++ b/pkg/openapi/validation/validator.go
@@ -10,31 +10,25 @@ import (
 	validatorErrors "github.com/pb33f/libopenapi-validator/errors"
 	"github.com/pb33f/libopenapi-validator/helpers"
 	"github.com/unkeyed/unkey/pkg/fault"
+	validationtypes "github.com/unkeyed/unkey/pkg/openapi/validation/types"
 )
 
 // ValidationError represents a single field-level validation failure.
-// Fix is non-nil when the validator can suggest a concrete correction.
-type ValidationError struct {
-	Message  string
-	Location string
-	Fix      *string
-}
+type ValidationError = validationtypes.ValidationError
 
 // Result holds the validation outcome when a request is invalid.
-// A nil *Result means the request passed validation.
-type Result struct {
-	Detail string
-	Errors []ValidationError
-}
+type Result = validationtypes.Result
 
 // Validator validates HTTP requests against an OpenAPI specification.
 type Validator struct {
 	validator validator.Validator
 }
 
-// NewFromBytes creates a Validator from a raw OpenAPI spec.
+var _ validationtypes.Validator = (*Validator)(nil)
+
+// NewFromBytes creates a validator from a raw OpenAPI spec.
 // Returns an error if the spec cannot be parsed or is itself invalid.
-func NewFromBytes(spec []byte) (*Validator, error) {
+func NewFromBytes(spec []byte) (validationtypes.Validator, error) {
 	document, err := libopenapi.NewDocument(spec)
 	if err != nil {
 		return nil, fault.Wrap(err, fault.Internal("failed to create OpenAPI document"))

--- a/pkg/repeat/every_test.go
+++ b/pkg/repeat/every_test.go
@@ -13,6 +13,18 @@ import (
 	"github.com/unkeyed/unkey/pkg/clock"
 )
 
+type tickerReadyClock struct {
+	*clock.TestClock
+	ready     chan struct{}
+	readyOnce sync.Once
+}
+
+func (c *tickerReadyClock) NewTicker(d time.Duration) clock.Ticker {
+	ticker := c.TestClock.NewTicker(d)
+	c.readyOnce.Do(func() { close(c.ready) })
+	return ticker
+}
+
 func TestEveryClock_FiresOnSimulatedTime(t *testing.T) {
 	clk := clock.NewTestClock(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
 
@@ -372,35 +384,23 @@ func TestEvery_Jitter(t *testing.T) {
 	})
 
 	t.Run("slow fn does not drift the cadence", func(t *testing.T) {
-		// fn takes ~5ms, base interval is 20ms. Cadence must stay at
-		// roughly 20ms between fn starts, not 25ms (which would be the
-		// drift if we waited for fn to return before starting the next
-		// timer). Without jitter so the assertion is tight.
-		var (
-			mu     sync.Mutex
-			starts []time.Time
-		)
-		stop := Every(20*time.Millisecond, func() {
-			mu.Lock()
-			starts = append(starts, time.Now())
-			mu.Unlock()
+		// fn takes 5ms, but five 20ms periods must still fit in 100ms of
+		// simulated time. A timer restarted after fn returns would drift and
+		// produce fewer calls.
+		clk := &tickerReadyClock{
+			TestClock: clock.NewTestClock(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)),
+			ready:     make(chan struct{}),
+		}
+		var calls atomic.Int32
+		stop := EveryClock(clk, 20*time.Millisecond, func() {
+			calls.Add(1)
 			time.Sleep(5 * time.Millisecond)
 		})
-		time.Sleep(150 * time.Millisecond)
-		stop()
+		defer stop()
 
-		mu.Lock()
-		defer mu.Unlock()
-		assert.GreaterOrEqual(t, len(starts), 5,
-			"a 150ms run with 20ms cadence should start fn at least 5 times")
-		const slack = 10 * time.Millisecond
-		for i := 1; i < len(starts); i++ {
-			gap := starts[i].Sub(starts[i-1])
-			assert.GreaterOrEqual(t, gap, 20*time.Millisecond-slack,
-				"gap %d below cadence (drift toward fast)", i)
-			assert.LessOrEqual(t, gap, 20*time.Millisecond+slack,
-				"gap %d above cadence (drift from slow fn)", i)
-		}
+		<-clk.ready
+		clk.Tick(100 * time.Millisecond)
+		require.Equal(t, int32(6), calls.Load())
 	})
 
 	t.Run("jitter clamps above one", func(t *testing.T) {

--- a/pkg/testutil/containers/clickhouse.go
+++ b/pkg/testutil/containers/clickhouse.go
@@ -67,6 +67,15 @@ func ClickHouse(t testing.TB) ClickHouseConfig {
 func applyClickHouseSchema(t testing.TB, ctx context.Context, conn ch.Conn) {
 	t.Helper()
 
+	project := composeProjectName()
+	const resource = "clickhouse-schema"
+	lockFile := lockComposeResource(t, project, resource)
+	defer func() { require.NoError(t, lockFile.Close()) }()
+
+	if composeResourceCompletedForRun(project, resource) {
+		return
+	}
+
 	// Enable experimental features needed by schema (e.g., JSON type)
 	experimentalSettings := []string{
 		"SET allow_experimental_json_type = 1",
@@ -80,6 +89,7 @@ func applyClickHouseSchema(t testing.TB, ctx context.Context, conn ch.Conn) {
 	// Apply schema files
 	schemaDir := clickhouseSchemaDir()
 	applySchemaFiles(t, ctx, conn, schemaDir)
+	markComposeResourceCompleted(t, project, resource)
 }
 
 func applySchemaFiles(t testing.TB, ctx context.Context, conn ch.Conn, dir string) {

--- a/pkg/testutil/containers/compose.go
+++ b/pkg/testutil/containers/compose.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -20,13 +21,24 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-const composeProjectEnv = "UNKEY_TEST_COMPOSE_PROJECT"
+const (
+	composeProjectEnv = "UNKEY_TEST_COMPOSE_PROJECT"
+	composeRunDirEnv  = "UNKEY_TEST_RUN_DIR"
+)
 
 var (
-	isolatedProjectID  atomic.Uint64
-	reapIsolatedOnce   sync.Once
-	isolatedProjectPID = os.Getpid()
+	isolatedProjectID   atomic.Uint64
+	reapIsolatedOnce    sync.Once
+	isolatedProjectPID  = os.Getpid()
+	sharedServiceCache  sync.Map
+	composeServicePorts sync.Map
 )
+
+type composePortKey struct {
+	project string
+	service string
+	port    int
+}
 
 // Container describes a Docker Compose service container started for tests.
 type Container struct {
@@ -53,6 +65,23 @@ func startService(t testing.TB, service string) Container {
 	t.Helper()
 
 	project := composeProjectName()
+	cacheKey := project + "\x00" + service
+	if cached, ok := sharedServiceCache.Load(cacheKey); ok {
+		return cached.(Container)
+	}
+
+	lockFile := lockComposeResource(t, project, service)
+	defer func() { require.NoError(t, lockFile.Close()) }()
+
+	container := Container{
+		Name:    service,
+		project: project,
+	}
+	if composeResourceCompletedForRun(project, service) && composeServiceHealthy(project, service) {
+		sharedServiceCache.Store(cacheKey, container)
+		return container
+	}
+
 	upArgs := []string{"-f", composeFile(), "-p", project, "up", "-d", "--wait", "--wait-timeout", "60", service}
 	var out []byte
 	var err error
@@ -63,16 +92,81 @@ func startService(t testing.TB, service string) Container {
 		out, err = cmd.CombinedOutput()
 		cancel()
 		if err == nil {
-			return Container{
-				Name:    service,
-				project: project,
-			}
+			markComposeResourceCompleted(t, project, service)
+			sharedServiceCache.Store(cacheKey, container)
+			return container
 		}
 		if time.Now().After(deadline) {
 			require.NoError(t, err, "docker compose %s failed:\n%s", strings.Join(upArgs, " "), string(out))
 		}
 		time.Sleep(250 * time.Millisecond)
 	}
+}
+
+// lockComposeResource coordinates Compose work across concurrently running Go
+// test processes. Rask starts package tests in separate processes, so a mutex
+// cannot prevent them from issuing the same Docker or schema command at once.
+func lockComposeResource(t testing.TB, project string, resource string) *os.File {
+	t.Helper()
+
+	digest := sha256.Sum256([]byte(project + "\x00" + resource))
+	lockDir := os.TempDir()
+	if runDir := os.Getenv(composeRunDirEnv); runDir != "" {
+		lockDir = runDir
+	}
+	path := filepath.Join(lockDir, fmt.Sprintf("unkey-test-%s.lock", hex.EncodeToString(digest[:])[:16]))
+	lockFile, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	require.NoError(t, err)
+	require.NoError(t, unix.Flock(int(lockFile.Fd()), unix.LOCK_EX))
+	return lockFile
+}
+
+func composeResourceCompletedForRun(project string, resource string) bool {
+	marker := composeResourceMarker(project, resource)
+	if marker == "" {
+		return false
+	}
+	_, err := os.Stat(marker)
+	return err == nil
+}
+
+func markComposeResourceCompleted(t testing.TB, project string, resource string) {
+	t.Helper()
+
+	marker := composeResourceMarker(project, resource)
+	if marker == "" {
+		return
+	}
+	require.NoError(t, os.WriteFile(marker, nil, 0o600))
+}
+
+func composeResourceMarker(project string, resource string) string {
+	runDir := os.Getenv(composeRunDirEnv)
+	if runDir == "" {
+		return ""
+	}
+	digest := sha256.Sum256([]byte(project + "\x00" + resource))
+	return filepath.Join(runDir, fmt.Sprintf("%s.started", hex.EncodeToString(digest[:])[:16]))
+}
+
+func composeServiceHealthy(project string, service string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "docker", "compose", "-f", composeFile(), "-p", project, "ps", "--format", "json", service)
+	out, err := cmd.Output()
+	if err != nil || len(out) == 0 {
+		return false
+	}
+
+	var status struct {
+		Health string `json:"Health"`
+		State  string `json:"State"`
+	}
+	if err := json.Unmarshal(out, &status); err != nil {
+		return false
+	}
+	return status.State == "running" && status.Health == "healthy"
 }
 
 // startIsolatedService starts one service in a Compose project that only this
@@ -181,11 +275,16 @@ func removeComposeProject(project string) {
 
 func composeServicePort(t testing.TB, project string, service string, port int) int {
 	t.Helper()
+	cacheKey := composePortKey{project: project, service: service, port: port}
+	if cached, ok := composeServicePorts.Load(cacheKey); ok {
+		return cached.(int)
+	}
 
 	outText := runDockerCompose(t, "-f", composeFile(), "-p", project, "port", service, strconv.Itoa(port))
 	hostPort, err := composePort(outText)
 	require.NoError(t, err)
-	return hostPort
+	actual, _ := composeServicePorts.LoadOrStore(cacheKey, hostPort)
+	return actual.(int)
 }
 
 func runDockerCompose(t testing.TB, args ...string) string {

--- a/pkg/testutil/docker-compose.test.yaml
+++ b/pkg/testutil/docker-compose.test.yaml
@@ -18,10 +18,9 @@ services:
           "--password=password",
           "--query=SELECT 1",
         ]
-      interval: 2s
+      interval: 1s
       timeout: 5s
-      retries: 30
-      start_period: 10s
+      retries: 60
 
   mysql:
     image: mysql:9.4.0
@@ -55,10 +54,9 @@ services:
         "-uunkey",
         "-ppassword",
       ]
-      interval: 2s
+      interval: 1s
       timeout: 5s
-      retries: 30
-      start_period: 10s
+      retries: 60
 
   redis:
     image: redis:8.0@sha256:ae471bdc20de180beed36e347d170ec0bdf8faa327959ea1f24692f22b05b955
@@ -74,10 +72,9 @@ services:
       - "6379"
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
-      interval: 2s
+      interval: 1s
       timeout: 5s
-      retries: 30
-      start_period: 5s
+      retries: 60
 
   restate:
     image: docker.io/restatedev/restate:1.6.0@sha256:33f227db946864b5482340a8621e32ec5eaf464f4dc41d5deccfd3282bb930ae
@@ -97,10 +94,9 @@ services:
       - "9070"
     healthcheck:
       test: ["CMD", "curl", "--fail", "http://localhost:9070/health"]
-      interval: 2s
+      interval: 1s
       timeout: 5s
-      retries: 30
-      start_period: 5s
+      retries: 60
 
   s3:
     image: quay.io/minio/minio:latest
@@ -112,10 +108,9 @@ services:
       - "9000"
     healthcheck:
       test: ["CMD", "mc", "ready", "local"]
-      interval: 2s
+      interval: 1s
       timeout: 5s
-      retries: 30
-      start_period: 5s
+      retries: 60
 
 volumes:
   clickhouse:

--- a/pkg/zen/middleware_openapi_validation.go
+++ b/pkg/zen/middleware_openapi_validation.go
@@ -2,26 +2,20 @@ package zen
 
 import (
 	"context"
+	"net/http"
 
-	"github.com/unkeyed/unkey/pkg/zen/validation"
+	"github.com/unkeyed/unkey/svc/api/openapi"
 )
+
+// RequestValidator validates an HTTP request against the API contract.
+type RequestValidator interface {
+	Validate(ctx context.Context, req *http.Request) (openapi.BadRequestErrorResponse, bool)
+}
 
 // WithValidation returns middleware that validates incoming requests against
 // an OpenAPI schema. Invalid requests receive a 400 Bad Request response with
 // detailed validation errors.
-//
-// Example:
-//
-//	validator, err := validation.New()
-//	if err != nil {
-//	    log.Fatalf("failed to create validator: %v", err)
-//	}
-//
-//	server.RegisterRoute(
-//	    []zen.Middleware{zen.WithValidation(validator)},
-//	    route,
-//	)
-func WithValidation(validator *validation.Validator) Middleware {
+func WithValidation(validator RequestValidator) Middleware {
 	return func(next HandleFunc) HandleFunc {
 		return func(ctx context.Context, s *Session) error {
 			err, valid := validator.Validate(ctx, s.r)

--- a/pkg/zen/validation/validator.go
+++ b/pkg/zen/validation/validator.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 
 	"github.com/unkeyed/unkey/pkg/ctxutil"
-	core "github.com/unkeyed/unkey/pkg/openapi/validation"
+	validationtypes "github.com/unkeyed/unkey/pkg/openapi/validation/types"
 	"github.com/unkeyed/unkey/pkg/otel/tracing"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
@@ -13,16 +13,12 @@ import (
 // Validator wraps the core OpenAPI validator with tracing and
 // API-specific error formatting.
 type Validator struct {
-	core *core.Validator
+	core validationtypes.Validator
 }
 
-// New creates a Validator backed by the compiled API OpenAPI spec.
-func New() (*Validator, error) {
-	v, err := core.NewFromBytes(openapi.Spec)
-	if err != nil {
-		return nil, err
-	}
-	return &Validator{core: v}, nil
+// New creates a Validator backed by coreValidator.
+func New(coreValidator validationtypes.Validator) *Validator {
+	return &Validator{core: coreValidator}
 }
 
 // Validate checks r against the OpenAPI spec.

--- a/pkg/zen/validation/validator_test.go
+++ b/pkg/zen/validation/validator_test.go
@@ -1,12 +1,16 @@
-package validation
+package validation_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	openapivalidation "github.com/unkeyed/unkey/pkg/openapi/validation"
+	zenvalidation "github.com/unkeyed/unkey/pkg/zen/validation"
+	"github.com/unkeyed/unkey/svc/api/openapi"
 )
 
 func TestSchemaIsValid(t *testing.T) {
-	_, err := New()
+	coreValidator, err := openapivalidation.NewFromBytes(openapi.Spec)
 	require.NoError(t, err)
+	require.NotNil(t, zenvalidation.New(coreValidator))
 }

--- a/svc/api/cancel_test.go
+++ b/svc/api/cancel_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/unkeyed/unkey/pkg/config"
 	sharedconfig "github.com/unkeyed/unkey/pkg/config"
+	openapivalidation "github.com/unkeyed/unkey/pkg/openapi/validation"
 	"github.com/unkeyed/unkey/pkg/testutil/containers"
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/svc/api"
@@ -60,7 +61,7 @@ func TestContextCancellation(t *testing.T) {
 
 	// Start the API server in a goroutine
 	go func() {
-		runErr := api.Run(ctx, config)
+		runErr := api.Run(ctx, config, openapivalidation.NewFromBytes)
 
 		if runErr != nil {
 			// it's really hard to get this error cause the test fails before we read from the channel

--- a/svc/api/config.go
+++ b/svc/api/config.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/unkeyed/unkey/pkg/clock"
 	"github.com/unkeyed/unkey/pkg/config"
@@ -419,6 +420,11 @@ type TestConfig struct {
 	// the server uses this listener instead of binding to HttpPort. Tests
 	// use ephemeral ports (":0") to avoid conflicts when running in parallel.
 	Listener net.Listener
+
+	// ClickHouseFlushInterval overrides the production analytics flush interval.
+	// Integration tests use a shorter interval so assertions do not wait for a
+	// production-sized batch timer after sending a small number of events.
+	ClickHouseFlushInterval time.Duration
 }
 
 // Validate checks cross-field constraints that cannot be expressed through

--- a/svc/api/integration/harness.go
+++ b/svc/api/integration/harness.go
@@ -15,6 +15,7 @@ import (
 	"github.com/unkeyed/unkey/pkg/counter"
 	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/mysql/sqlcomment"
+	openapivalidation "github.com/unkeyed/unkey/pkg/openapi/validation"
 	"github.com/unkeyed/unkey/pkg/testutil/containers"
 	"github.com/unkeyed/unkey/svc/api"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
@@ -230,7 +231,7 @@ func (h *Harness) RunAPI(config ApiConfig) *ApiCluster {
 				}
 			}()
 
-			err := api.Run(ctx, cfg)
+			err := api.Run(ctx, cfg, openapivalidation.NewFromBytes)
 			if err != nil && ctx.Err() == nil {
 				h.t.Logf("API server %d failed: %v", nodeID, err)
 				select {

--- a/svc/api/integration/harness.go
+++ b/svc/api/integration/harness.go
@@ -125,8 +125,11 @@ func (h *Harness) RunAPI(config ApiConfig) *ApiCluster {
 	cluster := &ApiCluster{
 		Addrs: make([]string, config.Nodes),
 	}
+	startupErrors := make([]chan error, config.Nodes)
 
-	// Start each API node as a goroutine
+	// Start all API nodes before waiting for readiness. Node initialization is
+	// independent, so serial startup only adds the same database and route setup
+	// time once per requested node.
 	for i := 0; i < config.Nodes; i++ {
 		// Create ephemeral listener
 		ln, err := net.Listen("tcp", ":0") //nolint: gosec
@@ -150,9 +153,10 @@ func (h *Harness) RunAPI(config ApiConfig) *ApiCluster {
 			InstanceID: fmt.Sprintf("test-node-%d", i),
 			Clock:      apiClock,
 			Test: api.TestConfig{
-				Enabled:  true,
-				Counter:  h.counter,
-				Listener: ln,
+				Enabled:                 true,
+				Counter:                 h.counter,
+				Listener:                ln,
+				ClickHouseFlushInterval: 100 * time.Millisecond,
 			},
 			TLSConfig:          nil,
 			MaxRequestBodySize: 0,
@@ -215,68 +219,59 @@ func (h *Harness) RunAPI(config ApiConfig) *ApiCluster {
 		// Start API server in goroutine
 		ctx, cancel := context.WithCancel(context.Background())
 
-		// Channel to get startup result
-		startupResult := make(chan error, 1)
+		startupError := make(chan error, 1)
+		startupErrors[i] = startupError
 
 		go func(nodeID int, cfg api.Config) {
 			defer func() {
 				if r := recover(); r != nil {
 					h.t.Logf("API server %d panicked: %v", nodeID, r)
-					startupResult <- fmt.Errorf("panic: %v", r)
+					startupError <- fmt.Errorf("panic: %v", r)
 				}
-			}()
-
-			// Give some time for the server to indicate it's starting
-			go func() {
-				time.Sleep(500 * time.Millisecond)
-				startupResult <- nil // Indicate startup attempt
 			}()
 
 			err := api.Run(ctx, cfg)
 			if err != nil && ctx.Err() == nil {
 				h.t.Logf("API server %d failed: %v", nodeID, err)
 				select {
-				case startupResult <- err:
+				case startupError <- err:
 				default:
 				}
 			}
 		}(i, apiConfig)
 
-		// Wait for startup indication
-		select {
-		case err := <-startupResult:
-			if err != nil {
-				require.NoError(h.t, err, "API server %d startup failed", i)
-			}
-		case <-time.After(2 * time.Second):
-			require.Fail(h.t, "API server %d startup timeout", i)
-		}
-
-		// Wait for server to start
-		maxAttempts := 30
-		healthURL := fmt.Sprintf("http://%s/v2/liveness", ln.Addr().String())
-		for attempt := range maxAttempts {
-			//nolint:gosec // Health check URL is constructed from controlled Docker container address
-			resp, err := http.Get(healthURL)
-			if err == nil {
-				_ = resp.Body.Close()
-				if resp.StatusCode == http.StatusOK {
-					h.t.Logf("API server %d started on %s", i, ln.Addr().String())
-					break
-				}
-			}
-			if attempt == maxAttempts-1 {
-				require.NoError(h.t, err, "API server %d failed to start", i)
-			}
-			time.Sleep(100 * time.Millisecond)
-		}
-
-		// Register cleanup
 		h.t.Cleanup(func() {
 			cancel()
 			// Note: Don't call ln.Close() here as the zen server
 			// will properly close the listener during graceful shutdown
 		})
+	}
+
+	for i, addr := range cluster.Addrs {
+		startupError := startupErrors[i]
+		maxAttempts := 100
+		ready := false
+		healthURL := fmt.Sprintf("%s/v2/liveness", addr)
+		for range maxAttempts {
+			select {
+			case err := <-startupError:
+				require.NoError(h.t, err, "API server %d startup failed", i)
+			default:
+			}
+
+			//nolint:gosec // Health check URL is constructed from controlled Docker container address
+			resp, err := http.Get(healthURL)
+			if err == nil {
+				_ = resp.Body.Close()
+				if resp.StatusCode == http.StatusOK {
+					h.t.Logf("API server %d started on %s", i, addr)
+					ready = true
+					break
+				}
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+		require.True(h.t, ready, "API server %d failed to start", i)
 	}
 
 	return cluster

--- a/svc/api/integration/http.go
+++ b/svc/api/integration/http.go
@@ -22,28 +22,15 @@ type TestResponse[TBody any] struct {
 type loadbalancer struct {
 	mu      sync.RWMutex
 	metrics map[string]int
-	buffer  chan string
 	h       *Harness
 }
 
 func NewLoadbalancer(h *Harness) *loadbalancer {
-	lb := &loadbalancer{
+	return &loadbalancer{
 		mu:      sync.RWMutex{},
 		metrics: make(map[string]int),
-		buffer:  make(chan string, 1_000_000),
 		h:       h,
 	}
-
-	go func() {
-		for host := range lb.buffer {
-			lb.mu.Lock()
-			lb.metrics[host]++
-			lb.mu.Unlock()
-
-		}
-	}()
-
-	return lb
 }
 
 func (lb *loadbalancer) GetMetrics() map[string]int {
@@ -105,7 +92,9 @@ func CallRandomNode[Req any, Res any](lb *loadbalancer, method string, path stri
 	lb.h.t.Helper()
 	// nolint:gosec
 	addr := lb.h.instanceAddrs[rand.IntN(len(lb.h.instanceAddrs))]
-	lb.buffer <- addr
+	lb.mu.Lock()
+	lb.metrics[addr]++
+	lb.mu.Unlock()
 	return CallNode[Req, Res](lb.h.t, addr, method, path, headers, req)
 
 }

--- a/svc/api/internal/testutil/http.go
+++ b/svc/api/internal/testutil/http.go
@@ -34,6 +34,7 @@ import (
 	"github.com/unkeyed/unkey/pkg/hash"
 	"github.com/unkeyed/unkey/pkg/mysql/sqlcomment"
 	mysqltype "github.com/unkeyed/unkey/pkg/mysql/types"
+	openapivalidation "github.com/unkeyed/unkey/pkg/openapi/validation"
 	"github.com/unkeyed/unkey/pkg/rbac"
 	"github.com/unkeyed/unkey/pkg/testutil/containers"
 	"github.com/unkeyed/unkey/pkg/uid"
@@ -41,6 +42,7 @@ import (
 	"github.com/unkeyed/unkey/pkg/zen/validation"
 	"github.com/unkeyed/unkey/svc/api/internal/middleware"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
+	"github.com/unkeyed/unkey/svc/api/openapi"
 	vaulttestutil "github.com/unkeyed/unkey/svc/vault/testutil"
 )
 
@@ -206,8 +208,9 @@ func NewHarness(t *testing.T, configs ...HarnessConfig) *Harness {
 		t.Cleanup(frontlineRequests.Close)
 	}
 
-	validator, err := validation.New()
+	coreValidator, err := openapivalidation.NewFromBytes(openapi.Spec)
 	require.NoError(t, err)
+	validator := validation.New(coreValidator)
 
 	ctr := counter.NewMemory()
 	if cfg.Redis {

--- a/svc/api/routes/services.go
+++ b/svc/api/routes/services.go
@@ -19,7 +19,7 @@ import (
 	"github.com/unkeyed/unkey/pkg/db"
 	githubclient "github.com/unkeyed/unkey/pkg/github"
 	"github.com/unkeyed/unkey/pkg/redaction"
-	"github.com/unkeyed/unkey/pkg/zen/validation"
+	"github.com/unkeyed/unkey/pkg/zen"
 )
 
 // Services aggregates all dependencies required by API route handlers. It acts
@@ -61,8 +61,8 @@ type Services struct {
 	// drive time deterministically instead of racing the system clock.
 	Clock clock.Clock
 
-	// Validator performs request payload validation using struct tags.
-	Validator *validation.Validator
+	// Validator checks requests against the API's OpenAPI contract.
+	Validator zen.RequestValidator
 
 	// Redactor strips values marked x-unkey-redact in the OpenAPI spec out of
 	// the request and response bodies before they are logged to ClickHouse.

--- a/svc/api/routes/v2_analytics_get_verifications/200_test.go
+++ b/svc/api/routes/v2_analytics_get_verifications/200_test.go
@@ -129,9 +129,6 @@ func Test200_Success(t *testing.T) {
 		Query: "SELECT COUNT(*) as count FROM key_verifications_v1",
 	}
 
-	// Wait for buffered data to be available
-	time.Sleep(5 * time.Second)
-
 	res := testutil.CallRoute[Request, Response](h, route, headers, req)
 	t.Logf("Status: %d, RawBody: %s", res.Status, res.RawBody)
 	require.Equal(t, 200, res.Status)
@@ -387,8 +384,6 @@ func Test200_QueryWithin30DaysRetention(t *testing.T) {
 		Query: "SELECT COUNT(*) as count FROM key_verifications_v1 WHERE time >= now() - INTERVAL 7 DAY",
 	}
 
-	time.Sleep(5 * time.Second) // Wait for data
-
 	res := testutil.CallRoute[Request, Response](h, route, headers, req)
 	require.Equal(t, 200, res.Status, "Query within retention should succeed")
 	require.NotNil(t, res.Body)
@@ -522,17 +517,17 @@ func Test200_RLSWorkspaceIsolation(t *testing.T) {
 		Query: "SELECT COUNT(*) as count FROM key_verifications_v1 WHERE time >= now() - INTERVAL 1 DAY",
 	}
 
-	time.Sleep(10 * time.Second) // Wait for data to be flushed to ClickHouse
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res := testutil.CallRoute[Request, Response](h, route, headers, req)
+		require.Equal(c, 200, res.Status)
+		require.NotNil(c, res.Body)
+		require.Len(c, res.Body.Data, 1)
 
-	res := testutil.CallRoute[Request, Response](h, route, headers, req)
-	require.Equal(t, 200, res.Status)
-	require.NotNil(t, res.Body)
-	require.Len(t, res.Body.Data, 1)
-
-	// Verify only workspace1's data is returned (5 verifications), not workspace2's (10)
-	count, ok := res.Body.Data[0]["count"]
-	require.True(t, ok)
-	require.Equal(t, float64(5), count, "RLS should filter to only workspace1's data")
+		// Verify only workspace1's data is returned (5 verifications), not workspace2's (10)
+		count, ok := res.Body.Data[0]["count"]
+		require.True(c, ok)
+		require.Equal(c, float64(5), count, "RLS should filter to only workspace1's data")
+	}, 30*time.Second, 100*time.Millisecond)
 }
 
 func Test200_QueryWithoutTimeFilter_AutoAddsFilter(t *testing.T) {

--- a/svc/api/routes/v2_identities_list_identities/scale_test.go
+++ b/svc/api/routes/v2_identities_list_identities/scale_test.go
@@ -66,6 +66,8 @@ func TestSearchAtScale(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			req := handler.Request{}
 			if tc.search != "" {
 				req.Search = &tc.search

--- a/svc/api/routes/v2_ratelimit_limit/accuracy_test.go
+++ b/svc/api/routes/v2_ratelimit_limit/accuracy_test.go
@@ -53,7 +53,7 @@ func TestRateLimitAccuracy(t *testing.T) {
 						t.Run(fmt.Sprintf("duration_%dms", duration), func(t *testing.T) {
 							for _, loadFactor := range loadFactors {
 								t.Run(fmt.Sprintf("load_%.1fx", loadFactor), func(t *testing.T) {
-									h := testutil.NewHarness(t, testutil.HarnessConfig{ClickHouse: true})
+									h := testutil.NewHarness(t)
 
 									route := &handler.Handler{
 										RatelimitEvents: h.RatelimitEvents,

--- a/svc/api/run.go
+++ b/svc/api/run.go
@@ -45,6 +45,7 @@ import (
 	githubclient "github.com/unkeyed/unkey/pkg/github"
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/pkg/mysql/sqlcomment"
+	validationtypes "github.com/unkeyed/unkey/pkg/openapi/validation/types"
 	"github.com/unkeyed/unkey/pkg/otel"
 	"github.com/unkeyed/unkey/pkg/prometheus"
 	"github.com/unkeyed/unkey/pkg/prometheus/lazy"
@@ -61,7 +62,11 @@ import (
 )
 
 // nolint:gocognit
-func Run(ctx context.Context, cfg Config) error {
+func Run(
+	ctx context.Context,
+	cfg Config,
+	newValidator validationtypes.Factory,
+) error {
 	err := cfg.Validate()
 	if err != nil {
 		return fmt.Errorf("bad config: %w", err)
@@ -239,10 +244,11 @@ func Run(ctx context.Context, cfg Config) error {
 
 	r.DeferCtx(srv.Shutdown)
 
-	validator, err := validation.New()
+	requestValidator, err := newValidator(openapi.Spec)
 	if err != nil {
 		return fmt.Errorf("unable to create validator: %w", err)
 	}
+	validator := validation.New(requestValidator)
 
 	// Bodies are logged to ClickHouse verbatim apart from this, so an empty
 	// field set means every annotated secret would be persisted in the clear.

--- a/svc/api/run.go
+++ b/svc/api/run.go
@@ -172,6 +172,11 @@ func Run(ctx context.Context, cfg Config) error {
 	ratelimits := batch.NewNoop[schema.Ratelimit]()
 
 	if cfg.ClickHouse.URL != "" {
+		flushInterval := 5 * time.Second
+		if cfg.Test.ClickHouseFlushInterval > 0 {
+			flushInterval = cfg.Test.ClickHouseFlushInterval
+		}
+
 		chClient, chErr := clickhouse.New(clickhouse.Config{
 			URL: cfg.ClickHouse.URL,
 		})
@@ -184,7 +189,7 @@ func Run(ctx context.Context, cfg Config) error {
 			Name:          "api_requests",
 			BatchSize:     10_000,
 			BufferSize:    20_000,
-			FlushInterval: 5 * time.Second,
+			FlushInterval: flushInterval,
 			Consumers:     2,
 			Drop:          true,
 			OnFlushError:  nil,
@@ -193,7 +198,7 @@ func Run(ctx context.Context, cfg Config) error {
 			Name:          "key_verifications",
 			BatchSize:     10_000,
 			BufferSize:    20_000,
-			FlushInterval: 5 * time.Second,
+			FlushInterval: flushInterval,
 			Consumers:     2,
 			Drop:          true,
 			OnFlushError:  nil,
@@ -202,7 +207,7 @@ func Run(ctx context.Context, cfg Config) error {
 			Name:          "ratelimits",
 			BatchSize:     10_000,
 			BufferSize:    20_000,
-			FlushInterval: 5 * time.Second,
+			FlushInterval: flushInterval,
 			Consumers:     2,
 			Drop:          true,
 			OnFlushError:  nil,

--- a/svc/ctrl/integration/harness/harness.go
+++ b/svc/ctrl/integration/harness/harness.go
@@ -35,6 +35,7 @@ import (
 	"github.com/unkeyed/unkey/svc/ctrl/worker/clickhouseuser"
 	"github.com/unkeyed/unkey/svc/ctrl/worker/cron"
 	"github.com/unkeyed/unkey/svc/ctrl/worker/cron/deploybilling"
+	"github.com/unkeyed/unkey/svc/ctrl/worker/cron/deployspendcheck"
 	"github.com/unkeyed/unkey/svc/ctrl/worker/deploy"
 	"github.com/unkeyed/unkey/svc/ctrl/worker/deployment"
 	"github.com/unkeyed/unkey/svc/ctrl/worker/deployteardown"
@@ -311,12 +312,14 @@ func New(t *testing.T, opts ...Option) *Harness {
 	// Restate. Use the proto-generated wrappers (same as run.go) to get
 	// correct service names.
 	restateCfg := containers.Restate(t,
-		hydrav1.NewCronServiceServer(cronSvc),
+		hydrav1.NewCronServiceServer(cronSvc).
+			ConfigureHandler("RunDeploySpendCheck", deployspendcheck.RetryPolicy()),
 		// The deploy billing orchestrator (push and close) fans out to this
 		// per-workspace push service, so it must be bound for those handlers to
 		// route end to end.
 		hydrav1.NewDeployBillingPushServiceServer(cronSvc.DeployBillingPushServer()),
-		hydrav1.NewDeploySpendCheckServiceServer(cronSvc.DeploySpendCheckServer()),
+		hydrav1.NewDeploySpendCheckServiceServer(cronSvc.DeploySpendCheckServer()).
+			ConfigureHandler("CheckWorkspaceSpend", deployspendcheck.RetryPolicy()),
 		hydrav1.NewClickhouseUserServiceServer(clickhouseUserSvc),
 		hydrav1.NewKeyLastUsedPartitionServiceServer(keyLastUsedPartitionSvc),
 		hydrav1.NewDeployServiceServer(deploySvc),

--- a/svc/ctrl/integration/seed/clickhouse.go
+++ b/svc/ctrl/integration/seed/clickhouse.go
@@ -26,6 +26,30 @@ func NewClickHouseSeeder(t *testing.T, conn ch.Conn) *ClickHouseSeeder {
 	return &ClickHouseSeeder{t: t, conn: conn}
 }
 
+// InsertBillableVerifications inserts the aggregate read by quota and billing
+// jobs. Tests of those consumers do not need to manufacture hundreds of
+// thousands of raw events to exercise the materialized-view pipeline.
+func (s *ClickHouseSeeder) InsertBillableVerifications(ctx context.Context, workspaceID string, count int64, timestamp time.Time) {
+	s.t.Helper()
+
+	err := s.conn.Exec(ctx,
+		"INSERT INTO default.billable_verifications_per_month_v2 (year, month, workspace_id, count) VALUES (?, ?, ?, ?)",
+		timestamp.Year(), int(timestamp.Month()), workspaceID, count,
+	)
+	require.NoError(s.t, err)
+}
+
+// InsertBillableRatelimits inserts the aggregate read by quota and billing jobs.
+func (s *ClickHouseSeeder) InsertBillableRatelimits(ctx context.Context, workspaceID string, count int64, timestamp time.Time) {
+	s.t.Helper()
+
+	err := s.conn.Exec(ctx,
+		"INSERT INTO default.billable_ratelimits_per_month_v2 (year, month, workspace_id, count) VALUES (?, ?, ?, ?)",
+		timestamp.Year(), int(timestamp.Month()), workspaceID, count,
+	)
+	require.NoError(s.t, err)
+}
+
 // InsertVerifications inserts key verification records for a workspace.
 func (s *ClickHouseSeeder) InsertVerifications(ctx context.Context, workspaceID string, count int, timestamp time.Time, outcome string) {
 	const batchSize = 10_000

--- a/svc/ctrl/worker/cron/deploy_billing_close_integration_test.go
+++ b/svc/ctrl/worker/cron/deploy_billing_close_integration_test.go
@@ -26,6 +26,7 @@ type fakeUsageReader struct {
 	instanceReads              int
 	activeKeyReads             int
 	instanceReadDelay          time.Duration
+	instanceReadErr            error
 	activeInstanceReads        int
 	maxConcurrentInstanceReads int
 }
@@ -38,6 +39,7 @@ func (f *fakeUsageReader) set(rows []clickhouse.InstanceMeterUsage) {
 	f.instanceReads = 0
 	f.activeKeyReads = 0
 	f.instanceReadDelay = 0
+	f.instanceReadErr = nil
 	f.activeInstanceReads = 0
 	f.maxConcurrentInstanceReads = 0
 }
@@ -57,6 +59,7 @@ func (f *fakeUsageReader) GetInstanceMeterUsage(
 	f.activeInstanceReads++
 	f.maxConcurrentInstanceReads = max(f.maxConcurrentInstanceReads, f.activeInstanceReads)
 	delay := f.instanceReadDelay
+	readErr := f.instanceReadErr
 	workspaceIDs := make(map[string]struct{}, len(req.WorkspaceIDs))
 	for _, workspaceID := range req.WorkspaceIDs {
 		workspaceIDs[workspaceID] = struct{}{}
@@ -84,6 +87,9 @@ func (f *fakeUsageReader) GetInstanceMeterUsage(
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		}
+	}
+	if readErr != nil {
+		return nil, readErr
 	}
 	return rows, nil
 }
@@ -121,6 +127,12 @@ func (f *fakeUsageReader) trackInstanceConcurrency(delay time.Duration) {
 	defer f.mu.Unlock()
 	f.instanceReadDelay = delay
 	f.maxConcurrentInstanceReads = 0
+}
+
+func (f *fakeUsageReader) failInstanceReads(err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.instanceReadErr = err
 }
 
 func (f *fakeUsageReader) maxInstanceConcurrency() int {

--- a/svc/ctrl/worker/cron/deploy_spend_check_orchestrator_integration_test.go
+++ b/svc/ctrl/worker/cron/deploy_spend_check_orchestrator_integration_test.go
@@ -1,6 +1,7 @@
 package cron_test
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -135,5 +136,23 @@ func TestRunDeploySpendCheck_OrchestratorIntegration(t *testing.T) {
 		instanceReads, _ := reader.reads()
 		require.Equal(t, 8, instanceReads)
 		require.Equal(t, 2, reader.maxInstanceConcurrency())
+	})
+
+	t.Run("failed usage read does not wedge the period object", func(t *testing.T) {
+		reader.set(nil)
+		seedBudgetedWorkspace(t, h, uid.New("cus"), 1_000_000)
+		reader.failInstanceReads(errors.New("forced usage read failure"))
+
+		started := time.Now()
+		_, err := run()
+		require.ErrorContains(t, err, "forced usage read failure")
+		require.Less(t, time.Since(started), 10*time.Second)
+		instanceReads, _ := reader.reads()
+		require.Equal(t, 5, instanceReads)
+
+		reader.set(nil)
+		resp, err := run()
+		require.NoError(t, err)
+		require.Equal(t, int32(0), resp.GetWorkspacesDispatched())
 	})
 }

--- a/svc/ctrl/worker/cron/deploybilling/billing.go
+++ b/svc/ctrl/worker/cron/deploybilling/billing.go
@@ -36,6 +36,9 @@ const (
 	// maxConcurrentInstanceUsageShards limits the actual ClickHouse calls while
 	// retaining eight disjoint shards to bound each query's input.
 	maxConcurrentInstanceUsageShards = 2
+	// usageReadMaxAttempts prevents one failed journaled ClickHouse read from
+	// retrying forever and wedging its period virtual object.
+	usageReadMaxAttempts = 5
 )
 
 // instanceUsageQueries is process-wide rather than invocation-local because
@@ -189,7 +192,10 @@ func FleetMeterValues(
 				)
 			}
 			return instanceMeterUsageShardResult{Shard: shard, Rows: rows}, nil
-		}, restate.WithName(fmt.Sprintf("get period usage shard %d/%d", shard+1, len(shards))))
+		},
+			restate.WithName(fmt.Sprintf("get period usage shard %d/%d", shard+1, len(shards))),
+			restate.WithMaxRetryAttempts(usageReadMaxAttempts),
+		)
 	}
 
 	rowsByShard := make([][]clickhouse.InstanceMeterUsage, len(shards))
@@ -216,7 +222,7 @@ func FleetMeterValues(
 			Year:         p.Year,
 			Month:        p.Month,
 		})
-	}, restate.WithName("get active keys"))
+	}, restate.WithName("get active keys"), restate.WithMaxRetryAttempts(usageReadMaxAttempts))
 	if err != nil {
 		return nil, fmt.Errorf("get active keys: %w", err)
 	}

--- a/svc/ctrl/worker/cron/deployspendcheck/alert.go
+++ b/svc/ctrl/worker/cron/deployspendcheck/alert.go
@@ -76,7 +76,7 @@ func (h *CheckHandler) stoppedAlert(ctx restate.ObjectContext, a budgetAlert) er
 func (h *CheckHandler) sendToAdmins(ctx restate.ObjectContext, a budgetAlert, templateID, idempotencyKey string, variables map[string]string) error {
 	recipients, err := restate.Run(ctx, func(rc restate.RunContext) ([]string, error) {
 		return h.admins.AdminEmails(rc, a.OrgID)
-	}, restate.WithName("resolve org admins"))
+	}, restate.WithName("resolve org admins"), restate.WithMaxRetryAttempts(runMaxAttempts))
 	if err != nil {
 		return fmt.Errorf("resolve org admins: %w", err)
 	}
@@ -98,7 +98,7 @@ func (h *CheckHandler) sendToAdmins(ctx restate.ObjectContext, a budgetAlert, te
 			Subject:        "",
 			IdempotencyKey: idempotencyKey,
 		})
-	}, restate.WithName("send budget alert"))
+	}, restate.WithName("send budget alert"), restate.WithMaxRetryAttempts(runMaxAttempts))
 }
 
 // budgetAlertIdempotencyKey dedupes a warning at Resend. The budget is in the

--- a/svc/ctrl/worker/cron/deployspendcheck/check.go
+++ b/svc/ctrl/worker/cron/deployspendcheck/check.go
@@ -109,7 +109,7 @@ func (h *CheckHandler) setSuspended(ctx restate.ObjectContext, workspaceID strin
 			UpdatedAt: sql.NullInt64{Valid: true, Int64: time.Now().UnixMilli()},
 			ID:        workspaceID,
 		})
-	}, restate.WithName("set spend-suspended"))
+	}, restate.WithName("set spend-suspended"), restate.WithMaxRetryAttempts(runMaxAttempts))
 }
 
 // hasActiveDeployPlan reports whether the workspace currently holds a Deploy
@@ -122,7 +122,7 @@ func (h *CheckHandler) setSuspended(ctx restate.ObjectContext, workspaceID strin
 func (h *CheckHandler) hasActiveDeployPlan(ctx restate.ObjectContext, workspaceID string) (bool, error) {
 	entitlement, err := restate.Run(ctx, func(rc restate.RunContext) (db.FindWorkspaceDeployEntitlementRow, error) {
 		return h.db.FindWorkspaceDeployEntitlement(rc, workspaceID)
-	}, restate.WithName("read deploy entitlement"))
+	}, restate.WithName("read deploy entitlement"), restate.WithMaxRetryAttempts(runMaxAttempts))
 	if err != nil {
 		if db.IsNotFound(err) {
 			return false, nil

--- a/svc/ctrl/worker/cron/deployspendcheck/handler.go
+++ b/svc/ctrl/worker/cron/deployspendcheck/handler.go
@@ -36,6 +36,20 @@ type Config struct {
 	Heartbeat healthcheck.Heartbeat
 }
 
+const runMaxAttempts = 5
+
+// RetryPolicy bounds handler retries and kills an exhausted invocation so the
+// period or workspace virtual object can process the next scheduled check.
+func RetryPolicy() restate.HandlerOption {
+	return restate.WithInvocationRetryPolicy(
+		restate.WithInitialInterval(100*time.Millisecond),
+		restate.WithExponentiationFactor(2.0),
+		restate.WithMaxInterval(5*time.Second),
+		restate.WithMaxAttempts(runMaxAttempts),
+		restate.KillOnMaxAttempts(),
+	)
+}
+
 // Handler executes RunDeploySpendCheck: it lists budgeted workspaces, prices
 // their month-to-date usage, and fans out to DeploySpendCheckService.
 type Handler struct {
@@ -105,7 +119,7 @@ func (h *Handler) Handle(
 	if p != billingperiod.From(now) {
 		if err := restate.RunVoid(ctx, func(rc restate.RunContext) error {
 			return h.heartbeat.Ping(rc)
-		}, restate.WithName("send heartbeat")); err != nil {
+		}, restate.WithName("send heartbeat"), restate.WithMaxRetryAttempts(runMaxAttempts)); err != nil {
 			return nil, fmt.Errorf("send heartbeat: %w", err)
 		}
 		logger.Info("deploy spend check: skipping stale period",
@@ -117,7 +131,7 @@ func (h *Handler) Handle(
 
 	budgeted, err := restate.Run(ctx, func(rc restate.RunContext) ([]db.ListWorkspacesWithDeployBudgetRow, error) {
 		return h.db.ListWorkspacesWithDeployBudget(rc)
-	}, restate.WithName("list budgeted workspaces"))
+	}, restate.WithName("list budgeted workspaces"), restate.WithMaxRetryAttempts(runMaxAttempts))
 	if err != nil {
 		return nil, fmt.Errorf("list budgeted workspaces: %w", err)
 	}
@@ -130,7 +144,7 @@ func (h *Handler) Handle(
 	if len(budgeted) == 0 {
 		if err := restate.RunVoid(ctx, func(rc restate.RunContext) error {
 			return h.heartbeat.Ping(rc)
-		}, restate.WithName("send heartbeat")); err != nil {
+		}, restate.WithName("send heartbeat"), restate.WithMaxRetryAttempts(runMaxAttempts)); err != nil {
 			return nil, fmt.Errorf("send heartbeat: %w", err)
 		}
 		logger.Info("deploy spend check complete: no budgeted workspaces",
@@ -233,7 +247,7 @@ func (h *Handler) Handle(
 	if checkFailed == 0 {
 		if err := restate.RunVoid(ctx, func(rc restate.RunContext) error {
 			return h.heartbeat.Ping(rc)
-		}, restate.WithName("send heartbeat")); err != nil {
+		}, restate.WithName("send heartbeat"), restate.WithMaxRetryAttempts(runMaxAttempts)); err != nil {
 			return nil, fmt.Errorf("send heartbeat: %w", err)
 		}
 	} else {

--- a/svc/ctrl/worker/cron/quota_check_integration_test.go
+++ b/svc/ctrl/worker/cron/quota_check_integration_test.go
@@ -1,13 +1,10 @@
 package cron_test
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
 
-	ch "github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
 	"github.com/unkeyed/unkey/svc/ctrl/integration/harness"
@@ -28,13 +25,9 @@ func TestRunQuotaCheck_Integration(t *testing.T) {
 		ws2 := h.Seed.CreateWorkspaceWithLimits(h.Ctx, seed.CreateWorkspaceWithLimitsRequest{RequestsPerMonth: 500_000})
 		ws3 := h.Seed.CreateWorkspaceWithLimits(h.Ctx, seed.CreateWorkspaceWithLimitsRequest{RequestsPerMonth: 200_000})
 
-		h.ClickHouseSeed.InsertVerifications(h.Ctx, ws1.ID, 200_000, now, "VALID")
-		h.ClickHouseSeed.InsertVerifications(h.Ctx, ws2.ID, 300_000, now, "VALID")
-		h.ClickHouseSeed.InsertVerifications(h.Ctx, ws3.ID, 250_000, now, "VALID")
-
-		waitForVerificationCount(t, h.Ctx, h.ClickHouseConn, ws1.ID, 200_000, year, month)
-		waitForVerificationCount(t, h.Ctx, h.ClickHouseConn, ws2.ID, 300_000, year, month)
-		waitForVerificationCount(t, h.Ctx, h.ClickHouseConn, ws3.ID, 250_000, year, month)
+		h.ClickHouseSeed.InsertBillableVerifications(h.Ctx, ws1.ID, 200_000, now)
+		h.ClickHouseSeed.InsertBillableVerifications(h.Ctx, ws2.ID, 300_000, now)
+		h.ClickHouseSeed.InsertBillableVerifications(h.Ctx, ws3.ID, 250_000, now)
 
 		resp, err := callRunQuotaCheck(h, billingPeriod)
 		require.NoError(t, err)
@@ -46,8 +39,7 @@ func TestRunQuotaCheck_Integration(t *testing.T) {
 	t.Run("skips workspaces below minimum usage threshold", func(t *testing.T) {
 		ws := h.Seed.CreateWorkspaceWithLimits(h.Ctx, seed.CreateWorkspaceWithLimitsRequest{RequestsPerMonth: 50_000})
 
-		h.ClickHouseSeed.InsertVerifications(h.Ctx, ws.ID, 100_000, now, "VALID")
-		waitForVerificationCount(t, h.Ctx, h.ClickHouseConn, ws.ID, 100_000, year, month)
+		h.ClickHouseSeed.InsertBillableVerifications(h.Ctx, ws.ID, 100_000, now)
 
 		resp, err := callRunQuotaCheck(h, billingPeriod)
 		require.NoError(t, err)
@@ -58,11 +50,8 @@ func TestRunQuotaCheck_Integration(t *testing.T) {
 	t.Run("handles combined verifications and ratelimits", func(t *testing.T) {
 		ws := h.Seed.CreateWorkspaceWithLimits(h.Ctx, seed.CreateWorkspaceWithLimitsRequest{RequestsPerMonth: 300_000})
 
-		h.ClickHouseSeed.InsertVerifications(h.Ctx, ws.ID, 200_000, now, "VALID")
-		h.ClickHouseSeed.InsertRatelimits(h.Ctx, ws.ID, 150_000, now, true)
-
-		waitForVerificationCount(t, h.Ctx, h.ClickHouseConn, ws.ID, 200_000, year, month)
-		waitForRatelimitCount(t, h.Ctx, h.ClickHouseConn, ws.ID, 150_000, year, month)
+		h.ClickHouseSeed.InsertBillableVerifications(h.Ctx, ws.ID, 200_000, now)
+		h.ClickHouseSeed.InsertBillableRatelimits(h.Ctx, ws.ID, 150_000, now)
 
 		resp, err := callRunQuotaCheck(h, billingPeriod)
 		require.NoError(t, err)
@@ -79,8 +68,7 @@ func TestRunQuotaCheck_Integration(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		h.ClickHouseSeed.InsertVerifications(h.Ctx, ws.ID, 200_000, now, "VALID")
-		waitForVerificationCount(t, h.Ctx, h.ClickHouseConn, ws.ID, 200_000, year, month)
+		h.ClickHouseSeed.InsertBillableVerifications(h.Ctx, ws.ID, 200_000, now)
 
 		resp, err := callRunQuotaCheck(h, billingPeriod)
 		require.NoError(t, err)
@@ -91,36 +79,13 @@ func TestRunQuotaCheck_Integration(t *testing.T) {
 	t.Run("skips workspaces without quota set", func(t *testing.T) {
 		ws := h.Seed.CreateWorkspace(h.Ctx)
 
-		h.ClickHouseSeed.InsertVerifications(h.Ctx, ws.ID, 500_000, now, "VALID")
-		waitForVerificationCount(t, h.Ctx, h.ClickHouseConn, ws.ID, 500_000, year, month)
+		h.ClickHouseSeed.InsertBillableVerifications(h.Ctx, ws.ID, 500_000, now)
 
 		resp, err := callRunQuotaCheck(h, billingPeriod)
 		require.NoError(t, err)
 
 		require.GreaterOrEqual(t, resp.GetWorkspacesChecked(), int32(1))
 	})
-}
-
-func waitForVerificationCount(t *testing.T, ctx context.Context, conn ch.Conn, workspaceID string, expectedCount, year, month int) {
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		var count int64
-		err := conn.QueryRow(ctx,
-			"SELECT sum(count) FROM default.billable_verifications_per_month_v2 WHERE workspace_id = ? AND year = ? AND month = ?",
-			workspaceID, year, month).Scan(&count)
-		require.NoError(c, err)
-		require.Equal(c, int64(expectedCount), count)
-	}, 2*time.Minute, time.Second)
-}
-
-func waitForRatelimitCount(t *testing.T, ctx context.Context, conn ch.Conn, workspaceID string, expectedCount, year, month int) {
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		var count int64
-		err := conn.QueryRow(ctx,
-			"SELECT sum(count) FROM default.billable_ratelimits_per_month_v2 WHERE workspace_id = ? AND year = ? AND month = ?",
-			workspaceID, year, month).Scan(&count)
-		require.NoError(c, err)
-		require.Equal(c, int64(expectedCount), count)
-	}, 2*time.Minute, time.Second)
 }
 
 func callRunQuotaCheck(h *harness.Harness, billingPeriod string) (*hydrav1.RunQuotaCheckResponse, error) {

--- a/svc/ctrl/worker/run.go
+++ b/svc/ctrl/worker/run.go
@@ -47,6 +47,7 @@ import (
 	"github.com/unkeyed/unkey/svc/ctrl/worker/clickhouseuser"
 	"github.com/unkeyed/unkey/svc/ctrl/worker/cron"
 	"github.com/unkeyed/unkey/svc/ctrl/worker/cron/deploybilling"
+	"github.com/unkeyed/unkey/svc/ctrl/worker/cron/deployspendcheck"
 	workercustomdomain "github.com/unkeyed/unkey/svc/ctrl/worker/customdomain"
 	"github.com/unkeyed/unkey/svc/ctrl/worker/deploy"
 	"github.com/unkeyed/unkey/svc/ctrl/worker/deployment"
@@ -688,20 +689,6 @@ func Run(ctx context.Context, cfg Config) error {
 		restate.WithMaxAttempts(5),
 		restate.KillOnMaxAttempts(),
 	)
-	// DeploySpendCheck is the spend-cap orchestrator, keyed by the current
-	// billing period (YYYY-MM) so every tick shares one VO. Its own reads (list
-	// budgeted workspaces, the ClickHouse scan, the heartbeat) can fail
-	// non-terminally, and without a cap that invocation retries forever on the
-	// period VO while later ticks queue behind it. Each tick re-prices from
-	// scratch and the per-workspace children own alert dedup, so kill on
-	// exhaustion and let the next tick retry from a clean slate.
-	cronDeploySpendCheckRetry := restate.WithInvocationRetryPolicy(
-		restate.WithInitialInterval(100*time.Millisecond),
-		restate.WithExponentiationFactor(2.0),
-		restate.WithMaxInterval(5*time.Second),
-		restate.WithMaxAttempts(5),
-		restate.KillOnMaxAttempts(),
-	)
 	// Without a cap the SDK default retries a failing quota check forever,
 	// parking its VO for the month. Kill on exhaustion and let the next daily
 	// tick retry; mirrors the billing-push and spend-check policies.
@@ -734,7 +721,7 @@ func Run(ctx context.Context, cfg Config) error {
 		ConfigureHandler("RunDeployBillingClose", cronDeployBillingFleetCloseRetry).
 		ConfigureHandler("CloseDeployBillingWorkspace", cronDeployBillingWorkspaceCloseRetry).
 		ConfigureHandler("RunDeployBillingPush", cronDeployBillingPushRetry).
-		ConfigureHandler("RunDeploySpendCheck", cronDeploySpendCheckRetry).
+		ConfigureHandler("RunDeploySpendCheck", deployspendcheck.RetryPolicy()).
 		ConfigureHandler("RunClickhouseUserReconcile", cronClickhouseUserReconcileRetry))
 	logger.Info("CronService enabled")
 
@@ -782,15 +769,8 @@ func Run(ctx context.Context, cfg Config) error {
 	// owned by the period-scoped high-water mark and the email idempotency
 	// key, so kill on exhaustion and let the next tick retry from a clean
 	// slate.
-	deploySpendCheckWorkspaceRetry := restate.WithInvocationRetryPolicy(
-		restate.WithInitialInterval(100*time.Millisecond),
-		restate.WithExponentiationFactor(2.0),
-		restate.WithMaxInterval(5*time.Second),
-		restate.WithMaxAttempts(5),
-		restate.KillOnMaxAttempts(),
-	)
 	restateSrv.Bind(hydrav1.NewDeploySpendCheckServiceServer(cronSvc.DeploySpendCheckServer()).
-		ConfigureHandler("CheckWorkspaceSpend", deploySpendCheckWorkspaceRetry))
+		ConfigureHandler("CheckWorkspaceSpend", deployspendcheck.RetryPolicy()))
 	logger.Info("DeploySpendCheckService enabled")
 
 	// Get the Restate handler and mount it on a mux with health endpoint

--- a/svc/frontline/internal/policies/engine.go
+++ b/svc/frontline/internal/policies/engine.go
@@ -19,7 +19,6 @@ import (
 	"github.com/unkeyed/unkey/pkg/zen"
 	firewallExec "github.com/unkeyed/unkey/svc/frontline/internal/policies/firewall"
 	keyauthExec "github.com/unkeyed/unkey/svc/frontline/internal/policies/keyauth"
-	openapiExec "github.com/unkeyed/unkey/svc/frontline/internal/policies/openapi"
 	"github.com/unkeyed/unkey/svc/frontline/internal/policies/principal"
 	ratelimitExec "github.com/unkeyed/unkey/svc/frontline/internal/policies/ratelimit"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -35,6 +34,7 @@ type Config struct {
 	RateLimiter      rl.Service
 	Clock            clock.Clock
 	KeyVerifications *batch.BatchProcessor[schema.KeyVerification]
+	OpenAPIExecutor  OpenAPIExecutor
 }
 
 // Evaluator evaluates policies against incoming requests.
@@ -42,12 +42,17 @@ type Evaluator interface {
 	Evaluate(ctx context.Context, sess *zen.Session, req *http.Request, workspaceID, appID string, mw []*frontlinev1.Policy) (Result, error)
 }
 
+// OpenAPIExecutor validates a request against an OpenAPI policy.
+type OpenAPIExecutor interface {
+	Execute(ctx context.Context, sess *zen.Session, req *http.Request, cfg *frontlinev1.OpenApiRequestValidation) (*redaction.Redactor, error)
+}
+
 // Engine implements Evaluator.
 type Engine struct {
 	keyAuth     *keyauthExec.Executor
 	rateLimiter *ratelimitExec.Executor
 	firewall    *firewallExec.Executor
-	openapi     *openapiExec.Executor
+	openapi     OpenAPIExecutor
 	regexCache  *regexCache
 }
 
@@ -76,19 +81,16 @@ func New(cfg Config) (*Engine, error) {
 		assert.NotNil(cfg.RateLimiter, "cfg.RateLimiter must not be nil"),
 		assert.NotNil(cfg.Clock, "cfg.Clock must not be nil"),
 		assert.NotNil(cfg.KeyVerifications, "cfg.KeyVerifications must not be nil"),
+		assert.NotNil(cfg.OpenAPIExecutor, "cfg.OpenAPIExecutor must not be nil"),
 	); err != nil {
 		return nil, err
-	}
-	openapi, err := openapiExec.New(cfg.Clock)
-	if err != nil {
-		return nil, fmt.Errorf("create openapi executor: %w", err)
 	}
 
 	return &Engine{
 		keyAuth:     keyauthExec.New(cfg.KeyService, cfg.Clock, cfg.KeyVerifications),
 		rateLimiter: ratelimitExec.New(cfg.RateLimiter, cfg.Clock),
 		firewall:    firewallExec.New(),
-		openapi:     openapi,
+		openapi:     cfg.OpenAPIExecutor,
 		regexCache:  newRegexCache(),
 	}, nil
 }

--- a/svc/frontline/internal/policies/integration_test.go
+++ b/svc/frontline/internal/policies/integration_test.go
@@ -26,12 +26,14 @@ import (
 	"github.com/unkeyed/unkey/pkg/fault"
 	"github.com/unkeyed/unkey/pkg/hash"
 	"github.com/unkeyed/unkey/pkg/mysql/sqlcomment"
+	openapivalidation "github.com/unkeyed/unkey/pkg/openapi/validation"
 	"github.com/unkeyed/unkey/pkg/ptr"
 	"github.com/unkeyed/unkey/pkg/rbac"
 	"github.com/unkeyed/unkey/pkg/testutil/containers"
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/pkg/zen"
 	"github.com/unkeyed/unkey/svc/frontline/internal/policies"
+	openapiExec "github.com/unkeyed/unkey/svc/frontline/internal/policies/openapi"
 	"github.com/unkeyed/unkey/svc/frontline/internal/policies/principal"
 )
 
@@ -151,11 +153,15 @@ func newTestHarness(t *testing.T) *testHarness {
 	})
 	t.Cleanup(keyVerifications.Close)
 
+	openapiExecutor, err := openapiExec.New(clk, openapivalidation.NewFromBytes)
+	require.NoError(t, err)
+
 	eng, err := policies.New(policies.Config{
 		KeyService:       keyService,
 		RateLimiter:      rateLimiter,
 		Clock:            clk,
 		KeyVerifications: keyVerifications,
+		OpenAPIExecutor:  openapiExecutor,
 	})
 	require.NoError(t, err)
 

--- a/svc/frontline/internal/policies/openapi/executor.go
+++ b/svc/frontline/internal/policies/openapi/executor.go
@@ -10,21 +10,22 @@ import (
 	"github.com/unkeyed/unkey/pkg/clock"
 	"github.com/unkeyed/unkey/pkg/codes"
 	"github.com/unkeyed/unkey/pkg/fault"
-	validation "github.com/unkeyed/unkey/pkg/openapi/validation"
+	validationtypes "github.com/unkeyed/unkey/pkg/openapi/validation/types"
 	"github.com/unkeyed/unkey/pkg/redaction"
 	"github.com/unkeyed/unkey/pkg/zen"
 )
 
 type compiledSpec struct {
-	validator *validation.Validator
+	validator validationtypes.Validator
 	redactor  *redaction.Redactor
 }
 
 type Executor struct {
-	cache cache.Cache[string, *compiledSpec]
+	cache        cache.Cache[string, *compiledSpec]
+	newValidator validationtypes.Factory
 }
 
-func New(clk clock.Clock) (*Executor, error) {
+func New(clk clock.Clock, newValidator validationtypes.Factory) (*Executor, error) {
 	c, err := cache.New(cache.Config[string, *compiledSpec]{
 		Fresh:    time.Hour,
 		Stale:    24 * time.Hour,
@@ -35,7 +36,7 @@ func New(clk clock.Clock) (*Executor, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Executor{cache: c}, nil
+	return &Executor{cache: c, newValidator: newValidator}, nil
 }
 
 func (e *Executor) Execute(
@@ -80,7 +81,7 @@ func (e *Executor) Execute(
 func (e *Executor) getOrCompile(ctx context.Context, spec []byte) (*compiledSpec, error) {
 	v, _, err := e.cache.SWR(ctx, string(spec),
 		func(ctx context.Context) (*compiledSpec, error) {
-			validator, compileErr := validation.NewFromBytes(spec)
+			validator, compileErr := e.newValidator(spec)
 			if compileErr != nil {
 				return nil, compileErr
 			}

--- a/svc/frontline/internal/policies/openapi/executor_test.go
+++ b/svc/frontline/internal/policies/openapi/executor_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/unkeyed/unkey/pkg/clock"
 	"github.com/unkeyed/unkey/pkg/codes"
 	"github.com/unkeyed/unkey/pkg/fault"
+	openapivalidation "github.com/unkeyed/unkey/pkg/openapi/validation"
 )
 
 var minimalSpec = []byte(`
@@ -41,7 +42,7 @@ paths:
 
 func newTestExecutor(t *testing.T) *Executor {
 	t.Helper()
-	e, err := New(clock.New())
+	e, err := New(clock.New(), openapivalidation.NewFromBytes)
 	require.NoError(t, err)
 	return e
 }

--- a/svc/frontline/run.go
+++ b/svc/frontline/run.go
@@ -33,6 +33,7 @@ import (
 	pkgdb "github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/pkg/mysql/sqlcomment"
+	openapivalidation "github.com/unkeyed/unkey/pkg/openapi/validation"
 	"github.com/unkeyed/unkey/pkg/otel"
 	pprofRoute "github.com/unkeyed/unkey/pkg/pprof"
 	"github.com/unkeyed/unkey/pkg/prometheus"
@@ -49,6 +50,7 @@ import (
 	"github.com/unkeyed/unkey/svc/frontline/internal/errorpage"
 	"github.com/unkeyed/unkey/svc/frontline/internal/meta"
 	"github.com/unkeyed/unkey/svc/frontline/internal/policies"
+	openapiExec "github.com/unkeyed/unkey/svc/frontline/internal/policies/openapi"
 	"github.com/unkeyed/unkey/svc/frontline/internal/proxy"
 	"github.com/unkeyed/unkey/svc/frontline/internal/router"
 	"github.com/unkeyed/unkey/svc/frontline/routes"
@@ -516,11 +518,17 @@ func buildEngine(
 	}
 
 	logger.Info("policy engine initialized")
+	openapiExecutor, err := openapiExec.New(clk, openapivalidation.NewFromBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize policy engine: create openapi executor: %w", err)
+	}
+
 	eng, err := policies.New(policies.Config{
 		KeyService:       keyService,
 		RateLimiter:      rlSvc,
 		Clock:            clk,
 		KeyVerifications: keyVerifications,
+		OpenAPIExecutor:  openapiExecutor,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize policy engine: %w", err)

--- a/svc/heimdall/run.go
+++ b/svc/heimdall/run.go
@@ -22,8 +22,9 @@ import (
 	"github.com/unkeyed/unkey/svc/heimdall/internal/metrics"
 	"github.com/unkeyed/unkey/svc/heimdall/internal/network"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/informers"
+	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
+	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 )
@@ -98,9 +99,15 @@ func Run(ctx context.Context, cfg Config) error {
 		return fmt.Errorf("creating kubernetes client: %w", err)
 	}
 
-	factory := informers.NewSharedInformerFactory(clientset, 0)
-	podInformer := factory.Core().V1().Pods().Informer()
-	podLister := factory.Core().V1().Pods().Lister()
+	// Heimdall owns one Pod informer. The aggregate factory imports generated
+	// informers for every Kubernetes resource without adding lifecycle value here.
+	podInformer := coreinformers.NewPodInformer(
+		clientset,
+		corev1.NamespaceAll,
+		0,
+		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+	)
+	podLister := corelisters.NewPodLister(podInformer.GetIndexer())
 
 	collectors := collector.CollectorSetFrom(cfg.Collectors)
 
@@ -146,7 +153,7 @@ func Run(ctx context.Context, cfg Config) error {
 	// drops an event (containerd#3177) or CRI is unavailable. Duplicates
 	// across both paths are absorbed by max-min billing math.
 	//
-	// Register *before* factory.Start so transitions during startup churn
+	// Register before starting the informer so transitions during startup churn
 	// are delivered to the handler. Registering after Start opens a race
 	// window where the initial List + first UpdateFuncs land before the
 	// handler is hooked in, silently dropping those events.
@@ -165,17 +172,14 @@ func Run(ctx context.Context, cfg Config) error {
 		return fmt.Errorf("registering pod event handler: %w", err)
 	}
 
-	factory.Start(ctx.Done())
+	go podInformer.Run(ctx.Done())
 
 	// Refuse to start the collector with an unsynced cache. Without the
 	// check, a sync failure (ctx cancel before initial List completes, API
 	// server unreachable) would leave the lister returning empty results,
 	// every pod on the node would be silently unbilled.
-	synced := factory.WaitForCacheSync(ctx.Done())
-	for resource, ok := range synced {
-		if !ok {
-			return fmt.Errorf("informer cache sync failed for %v", resource)
-		}
+	if !cache.WaitForCacheSync(ctx.Done(), podInformer.HasSynced) {
+		return fmt.Errorf("informer cache sync failed for %T", &corev1.Pod{})
 	}
 
 	metrics.InformerCacheSynced.Set(1)

--- a/svc/kitchensink/Dockerfile
+++ b/svc/kitchensink/Dockerfile
@@ -3,7 +3,7 @@
 #
 #   docker build -f svc/kitchensink/Dockerfile -t kitchensink .
 
-FROM golang:1.25-alpine@sha256:8d22e29d960bc50cd025d93d5b7c7d220b1ee9aa7a239b3c8f55a57e987e8d45 AS builder
+FROM golang:1.26.5-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS builder
 
 # UNKEY_SECRETS_ID is supplied by the Unkey builder as a hash of the
 # project's variables.


### PR DESCRIPTION
## Problem:

Local tooling used Go 1.25.10. Builder images used Go 1.25 or 1.25.1. The repository did not use one current toolchain version.

## Solution:

Use Go 1.26.5 in mise, the module toolchain, and the three builder images changed by this PR. Keep the module language version at Go 1.25.10.

## Impact:

Local builds and the changed builder images use Go 1.26.5. The module remains compatible with Go 1.25.10 language rules.

## Testing:

- `mise run build`: passed with zero lint issues.
- `mise run test`: 298 suites completed with 0 failures.