### PR TITLE
test(ctrl): cover spend-check retry recovery

### DIFF
--- a/svc/ctrl/worker/cron/deploy_billing_close_integration_test.go
+++ b/svc/ctrl/worker/cron/deploy_billing_close_integration_test.go
@@ -26,6 +26,7 @@ type fakeUsageReader struct {
 	instanceReads              int
 	activeKeyReads             int
 	instanceReadDelay          time.Duration
+	instanceReadErr            error
 	activeInstanceReads        int
 	maxConcurrentInstanceReads int
 }
@@ -38,6 +39,7 @@ func (f *fakeUsageReader) set(rows []clickhouse.InstanceMeterUsage) {
 	f.instanceReads = 0
 	f.activeKeyReads = 0
 	f.instanceReadDelay = 0
+	f.instanceReadErr = nil
 	f.activeInstanceReads = 0
 	f.maxConcurrentInstanceReads = 0
 }
@@ -57,6 +59,7 @@ func (f *fakeUsageReader) GetInstanceMeterUsage(
 	f.activeInstanceReads++
 	f.maxConcurrentInstanceReads = max(f.maxConcurrentInstanceReads, f.activeInstanceReads)
 	delay := f.instanceReadDelay
+	readErr := f.instanceReadErr
 	workspaceIDs := make(map[string]struct{}, len(req.WorkspaceIDs))
 	for _, workspaceID := range req.WorkspaceIDs {
 		workspaceIDs[workspaceID] = struct{}{}
@@ -84,6 +87,9 @@ func (f *fakeUsageReader) GetInstanceMeterUsage(
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		}
+	}
+	if readErr != nil {
+		return nil, readErr
 	}
 	return rows, nil
 }
@@ -121,6 +127,12 @@ func (f *fakeUsageReader) trackInstanceConcurrency(delay time.Duration) {
 	defer f.mu.Unlock()
 	f.instanceReadDelay = delay
 	f.maxConcurrentInstanceReads = 0
+}
+
+func (f *fakeUsageReader) failInstanceReads(err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.instanceReadErr = err
 }
 
 func (f *fakeUsageReader) maxInstanceConcurrency() int {

--- a/svc/ctrl/worker/cron/deploy_spend_check_orchestrator_integration_test.go
+++ b/svc/ctrl/worker/cron/deploy_spend_check_orchestrator_integration_test.go
@@ -1,6 +1,7 @@
 package cron_test
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -135,5 +136,23 @@ func TestRunDeploySpendCheck_OrchestratorIntegration(t *testing.T) {
 		instanceReads, _ := reader.reads()
 		require.Equal(t, 8, instanceReads)
 		require.Equal(t, 2, reader.maxInstanceConcurrency())
+	})
+
+	t.Run("failed usage read does not wedge the period object", func(t *testing.T) {
+		reader.set(nil)
+		seedBudgetedWorkspace(t, h, uid.New("cus"), 1_000_000)
+		reader.failInstanceReads(errors.New("forced usage read failure"))
+
+		started := time.Now()
+		_, err := run()
+		require.ErrorContains(t, err, "forced usage read failure")
+		require.Less(t, time.Since(started), 10*time.Second)
+		instanceReads, _ := reader.reads()
+		require.Equal(t, 5, instanceReads)
+
+		reader.set(nil)
+		resp, err := run()
+		require.NoError(t, err)
+		require.Equal(t, int32(0), resp.GetWorkspacesDispatched())
 	})
 }

--- a/svc/ctrl/worker/cron/deploy_spend_check_orchestrator_integration_test.go
+++ b/svc/ctrl/worker/cron/deploy_spend_check_orchestrator_integration_test.go
@@ -1,6 +1,7 @@
 package cron_test
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -52,11 +53,13 @@ func TestRunDeploySpendCheck_OrchestratorIntegration(t *testing.T) {
 	reader := &fakeUsageReader{} //nolint:exhaustruct // set per subtest
 	h := harness.New(t, harness.WithDeployBilling(reader, newFakePusher(), newFakeCloser()))
 
-	// The harness database persists across test runs, and earlier runs (or
-	// other tests) can leave budgeted workspaces behind. The orchestrator
-	// counts below are asserted exactly, so start from an empty opt-in set.
+	// The harness database persists across test runs, and earlier runs can leave
+	// budgeted or spend-suspended workspaces behind. Both are in the
+	// orchestrator's dispatch set, so clear both before exact count assertions.
 	_, err := h.DB.RW().ExecContext(h.Ctx,
-		`UPDATE workspace_billing SET spend_budget_cents = NULL WHERE spend_budget_cents IS NOT NULL`)
+		`UPDATE workspace_billing
+		SET spend_budget_cents = NULL, spend_suspended = FALSE
+		WHERE spend_budget_cents IS NOT NULL OR spend_suspended = TRUE`)
 	require.NoError(t, err)
 
 	period := time.Now().UTC().Format("2006-01")
@@ -105,5 +108,23 @@ func TestRunDeploySpendCheck_OrchestratorIntegration(t *testing.T) {
 		instanceReads, _ := reader.reads()
 		require.Equal(t, 8, instanceReads)
 		require.Equal(t, 2, reader.maxInstanceConcurrency())
+	})
+
+	t.Run("failed usage read does not wedge the period object", func(t *testing.T) {
+		reader.set(nil)
+		seedBudgetedWorkspace(t, h, uid.New("cus"), 1_000_000)
+		reader.failInstanceReads(errors.New("forced usage read failure"))
+
+		started := time.Now()
+		_, err := run()
+		require.ErrorContains(t, err, "forced usage read failure")
+		require.Less(t, time.Since(started), 10*time.Second)
+		instanceReads, _ := reader.reads()
+		require.Equal(t, 5, instanceReads)
+
+		reader.set(nil)
+		resp, err := run()
+		require.NoError(t, err)
+		require.Equal(t, int32(0), resp.GetWorkspacesDispatched())
 	})
 }


### PR DESCRIPTION
## Problem:

The spend-check integration tests did not prove what happens after all five usage-read attempts fail.

## Solution:

Make the test usage reader fail on demand. Add a test that confirms five failed reads and then confirms that the next check can run.

## Impact:

Production code does not change. The integration test now covers retry exhaustion and recovery of the same queue.

## Testing:

- `svc/ctrl/worker/cron` in the full Go suite: 46 passed.