### PR TITLE
fix: recover transient integration service failures

### DIFF
--- a/internal/services/ratelimit/global.go
+++ b/internal/services/ratelimit/global.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/unkeyed/unkey/pkg/logger"
+	"github.com/unkeyed/unkey/pkg/mysql"
 	"github.com/unkeyed/unkey/pkg/repeat"
 
 	"github.com/unkeyed/unkey/internal/services/ratelimit/db"
@@ -161,7 +162,9 @@ func (s *service) runGlobalPushOnce() {
 		}
 
 		_, err := s.globalCircuitBreaker.Do(ctx, func(ctx context.Context) (any, error) {
-			return nil, s.db.BulkUpsertGlobalCounters(ctx, chunkRows)
+			return mysql.WithRetryContext(ctx, func() (any, error) {
+				return nil, s.db.BulkUpsertGlobalCounters(ctx, chunkRows)
+			})
 		})
 		if err != nil {
 			metrics.RatelimitGlobalPushErrors.Inc()

--- a/internal/services/ratelimit/global.go
+++ b/internal/services/ratelimit/global.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/unkeyed/unkey/pkg/logger"
+	"github.com/unkeyed/unkey/pkg/mysql"
 	"github.com/unkeyed/unkey/pkg/repeat"
 
 	"github.com/unkeyed/unkey/internal/services/ratelimit/db"
@@ -172,7 +173,9 @@ func (s *service) runGlobalPushOnce() {
 		}
 
 		_, err := s.globalCircuitBreaker.Do(ctx, func(ctx context.Context) (any, error) {
-			return nil, s.db.BulkUpsertGlobalCounters(ctx, chunkRows)
+			return mysql.WithRetryContext(ctx, func() (any, error) {
+				return nil, s.db.BulkUpsertGlobalCounters(ctx, chunkRows)
+			})
 		})
 		if err != nil {
 			metrics.RatelimitGlobalPushErrors.Inc()

--- a/internal/services/ratelimit/global_integration_test.go
+++ b/internal/services/ratelimit/global_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	drivermysql "github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/require"
 	rldb "github.com/unkeyed/unkey/internal/services/ratelimit/db"
 	"github.com/unkeyed/unkey/pkg/circuitbreaker"
@@ -186,17 +187,16 @@ func TestGlobalPush_EmitsRowsInUniqueKeyOrder(t *testing.T) {
 	}
 }
 
-// TestGlobalPush_ConcurrentFlushesDoNotDeadlock reproduces the production lock
-// graph with real MySQL transactions. The DB wrapper splits each collected bulk
-// batch into per-row upserts inside one transaction, which turns inconsistent
-// row order into the same 1213 deadlock MySQL can produce under overlapping
-// ON DUPLICATE KEY UPDATE flushes.
-func TestGlobalPush_ConcurrentFlushesDoNotDeadlock(t *testing.T) {
+// TestGlobalPush_ConcurrentFlushesRecoverFromDeadlock reproduces the production
+// lock graph with real MySQL transactions. Even with consistent row order,
+// InnoDB can select one overlapping upsert as a deadlock victim. The idempotent
+// flush must retry that transaction and commit both callers' progress.
+func TestGlobalPush_ConcurrentFlushesRecoverFromDeadlock(t *testing.T) {
 	t.Parallel()
 
 	env := newIntegrationTestEnv(t)
 
-	for attempt := range 30 {
+	for attempt := range 5 {
 		workspaceID := uid.New(uid.WorkspacePrefix)
 		keys := []counterKey{
 			{workspaceID: workspaceID, namespace: "ns-a", identifier: "id-a", durationMs: 60_000, sequence: 1},
@@ -220,13 +220,14 @@ func TestGlobalPush_ConcurrentFlushesDoNotDeadlock(t *testing.T) {
 		}
 
 		svcA := newGlobalPushOnlyService(db, "region-a")
+		entries := make([]*counterEntry, 0, len(keys)*2)
 		for _, key := range keys {
-			storePushableCounter(svcA, key)
+			entries = append(entries, storePushableCounter(svcA, key))
 		}
 
 		svcB := newGlobalPushOnlyService(db, "region-a")
 		for i := len(keys) - 1; i >= 0; i-- {
-			storePushableCounter(svcB, keys[i])
+			entries = append(entries, storePushableCounter(svcB, keys[i]))
 		}
 
 		var wg sync.WaitGroup
@@ -235,12 +236,35 @@ func TestGlobalPush_ConcurrentFlushesDoNotDeadlock(t *testing.T) {
 		wg.Wait()
 		cancel()
 
-		require.Empty(t, db.deadlockErrors(),
-			"attempt %d reproduced a MySQL deadlock during concurrent global counter flushes; row orders: %v",
-			attempt,
-			db.rowOrders(),
-		)
+		for _, entry := range entries {
+			require.Equal(t, int64(10), entry.lastPushed.Load(),
+				"attempt %d did not commit both concurrent flushes; row orders: %v, deadlocks: %v",
+				attempt,
+				db.rowOrders(),
+				db.deadlockErrors(),
+			)
+		}
 	}
+}
+
+func TestGlobalPush_RetriesDeadlock(t *testing.T) {
+	t.Parallel()
+
+	recorder := &deadlockOnceGlobalCounterDB{}
+	svc := newGlobalPushOnlyService(recorder, "region-a")
+	entry := storePushableCounter(svc, counterKey{
+		workspaceID: "ws-a",
+		namespace:   "ns-a",
+		identifier:  "id-a",
+		durationMs:  60_000,
+		sequence:    1,
+	})
+
+	svc.runGlobalPushOnce()
+
+	require.Equal(t, 2, recorder.calls)
+	require.Len(t, recorder.rows, 1)
+	require.Equal(t, int64(10), entry.lastPushed.Load())
 }
 
 func newGlobalPushOnlyService(db rldb.DBTX, region string) *service {
@@ -252,11 +276,12 @@ func newGlobalPushOnlyService(db rldb.DBTX, region string) *service {
 	}
 }
 
-func storePushableCounter(svc *service, key counterKey) {
+func storePushableCounter(svc *service, key counterKey) *counterEntry {
 	entry := &counterEntry{} //nolint:exhaustruct // only push eligibility fields matter here
 	entry.val.Store(10)
 	entry.globalPushThreshold.Store(1)
 	svc.counters.Store(key, entry)
+	return entry
 }
 
 func globalCounterRowForKey(key counterKey, region string, count uint64) rldb.UpsertRatelimitGlobalCountersParams {
@@ -416,6 +441,19 @@ func (db *recordingGlobalCounterDB) QueryContext(context.Context, string, ...int
 
 func (db *recordingGlobalCounterDB) QueryRowContext(context.Context, string, ...interface{}) *sql.Row {
 	return &sql.Row{}
+}
+
+type deadlockOnceGlobalCounterDB struct {
+	recordingGlobalCounterDB
+	calls int
+}
+
+func (db *deadlockOnceGlobalCounterDB) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
+	db.calls++
+	if db.calls == 1 {
+		return nil, &drivermysql.MySQLError{Number: 1213, Message: "Deadlock found when trying to get lock"}
+	}
+	return db.recordingGlobalCounterDB.ExecContext(ctx, query, args...)
 }
 
 func globalCounterRowsFromArgs(args []interface{}) ([]rldb.UpsertRatelimitGlobalCountersParams, error) {

--- a/internal/services/ratelimit/global_integration_test.go
+++ b/internal/services/ratelimit/global_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	drivermysql "github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/require"
 	rldb "github.com/unkeyed/unkey/internal/services/ratelimit/db"
 	"github.com/unkeyed/unkey/pkg/circuitbreaker"
@@ -313,17 +314,16 @@ func TestGlobalPush_EmitsRowsInUniqueKeyOrder(t *testing.T) {
 	}
 }
 
-// TestGlobalPush_ConcurrentFlushesDoNotDeadlock reproduces the production lock
-// graph with real MySQL transactions. The DB wrapper splits each collected bulk
-// batch into per-row upserts inside one transaction, which turns inconsistent
-// row order into the same 1213 deadlock MySQL can produce under overlapping
-// ON DUPLICATE KEY UPDATE flushes.
-func TestGlobalPush_ConcurrentFlushesDoNotDeadlock(t *testing.T) {
+// TestGlobalPush_ConcurrentFlushesRecoverFromDeadlock reproduces the production
+// lock graph with real MySQL transactions. Even with consistent row order,
+// InnoDB can select one overlapping upsert as a deadlock victim. The idempotent
+// flush must retry that transaction and commit both callers' progress.
+func TestGlobalPush_ConcurrentFlushesRecoverFromDeadlock(t *testing.T) {
 	t.Parallel()
 
 	env := newIntegrationTestEnv(t)
 
-	for attempt := range 30 {
+	for attempt := range 5 {
 		workspaceID := uid.New(uid.WorkspacePrefix)
 		keys := []counterKey{
 			{workspaceID: workspaceID, namespace: "ns-a", identifier: "id-a", durationMs: 60_000, sequence: 1},
@@ -347,13 +347,14 @@ func TestGlobalPush_ConcurrentFlushesDoNotDeadlock(t *testing.T) {
 		}
 
 		svcA := newGlobalPushOnlyService(db, "region-a")
+		entries := make([]*counterEntry, 0, len(keys)*2)
 		for _, key := range keys {
-			storePushableCounter(svcA, key)
+			entries = append(entries, storePushableCounter(svcA, key))
 		}
 
 		svcB := newGlobalPushOnlyService(db, "region-a")
 		for i := len(keys) - 1; i >= 0; i-- {
-			storePushableCounter(svcB, keys[i])
+			entries = append(entries, storePushableCounter(svcB, keys[i]))
 		}
 
 		var wg sync.WaitGroup
@@ -362,12 +363,35 @@ func TestGlobalPush_ConcurrentFlushesDoNotDeadlock(t *testing.T) {
 		wg.Wait()
 		cancel()
 
-		require.Empty(t, db.deadlockErrors(),
-			"attempt %d reproduced a MySQL deadlock during concurrent global counter flushes; row orders: %v",
-			attempt,
-			db.rowOrders(),
-		)
+		for _, entry := range entries {
+			require.Equal(t, int64(10), entry.lastPushed.Load(),
+				"attempt %d did not commit both concurrent flushes; row orders: %v, deadlocks: %v",
+				attempt,
+				db.rowOrders(),
+				db.deadlockErrors(),
+			)
+		}
 	}
+}
+
+func TestGlobalPush_RetriesDeadlock(t *testing.T) {
+	t.Parallel()
+
+	recorder := &deadlockOnceGlobalCounterDB{}
+	svc := newGlobalPushOnlyService(recorder, "region-a")
+	entry := storePushableCounter(svc, counterKey{
+		workspaceID: "ws-a",
+		namespace:   "ns-a",
+		identifier:  "id-a",
+		durationMs:  60_000,
+		sequence:    1,
+	})
+
+	svc.runGlobalPushOnce()
+
+	require.Equal(t, 2, recorder.calls)
+	require.Len(t, recorder.rows, 1)
+	require.Equal(t, int64(10), entry.lastPushed.Load())
 }
 
 func newGlobalPushOnlyService(db rldb.DBTX, region string) *service {
@@ -387,11 +411,12 @@ func newGlobalPullOnlyService(env *integrationTestEnv, clk clock.Clock, region s
 	}
 }
 
-func storePushableCounter(svc *service, key counterKey) {
+func storePushableCounter(svc *service, key counterKey) *counterEntry {
 	entry := &counterEntry{} //nolint:exhaustruct // only push eligibility fields matter here
 	entry.val.Store(10)
 	entry.globalPushThreshold.Store(1)
 	svc.counters.Store(key, entry)
+	return entry
 }
 
 func globalCounterRowForKey(key counterKey, region string, count uint64) rldb.UpsertRatelimitGlobalCountersParams {
@@ -555,6 +580,19 @@ func (db *recordingGlobalCounterDB) QueryContext(context.Context, string, ...int
 
 func (db *recordingGlobalCounterDB) QueryRowContext(context.Context, string, ...interface{}) *sql.Row {
 	return &sql.Row{}
+}
+
+type deadlockOnceGlobalCounterDB struct {
+	recordingGlobalCounterDB
+	calls int
+}
+
+func (db *deadlockOnceGlobalCounterDB) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
+	db.calls++
+	if db.calls == 1 {
+		return nil, &drivermysql.MySQLError{Number: 1213, Message: "Deadlock found when trying to get lock"}
+	}
+	return db.recordingGlobalCounterDB.ExecContext(ctx, query, args...)
 }
 
 func globalCounterRowsFromArgs(args []interface{}) ([]rldb.UpsertRatelimitGlobalCountersParams, error) {

--- a/svc/ctrl/integration/harness/harness.go
+++ b/svc/ctrl/integration/harness/harness.go
@@ -35,6 +35,7 @@ import (
 	"github.com/unkeyed/unkey/svc/ctrl/worker/clickhouseuser"
 	"github.com/unkeyed/unkey/svc/ctrl/worker/cron"
 	"github.com/unkeyed/unkey/svc/ctrl/worker/cron/deploybilling"
+	"github.com/unkeyed/unkey/svc/ctrl/worker/cron/deployspendcheck"
 	"github.com/unkeyed/unkey/svc/ctrl/worker/deploy"
 	"github.com/unkeyed/unkey/svc/ctrl/worker/deployment"
 	"github.com/unkeyed/unkey/svc/ctrl/worker/keylastusedsync"
@@ -299,12 +300,14 @@ func New(t *testing.T, opts ...Option) *Harness {
 	// Restate. Use the proto-generated wrappers (same as run.go) to get
 	// correct service names.
 	restateCfg := containers.Restate(t,
-		hydrav1.NewCronServiceServer(cronSvc),
+		hydrav1.NewCronServiceServer(cronSvc).
+			ConfigureHandler("RunDeploySpendCheck", deployspendcheck.RetryPolicy()),
 		// The deploy billing orchestrator (push and close) fans out to this
 		// per-workspace push service, so it must be bound for those handlers to
 		// route end to end.
 		hydrav1.NewDeployBillingPushServiceServer(cronSvc.DeployBillingPushServer()),
-		hydrav1.NewDeploySpendCheckServiceServer(cronSvc.DeploySpendCheckServer()),
+		hydrav1.NewDeploySpendCheckServiceServer(cronSvc.DeploySpendCheckServer()).
+			ConfigureHandler("CheckWorkspaceSpend", deployspendcheck.RetryPolicy()),
 		hydrav1.NewClickhouseUserServiceServer(clickhouseUserSvc),
 		hydrav1.NewKeyLastUsedPartitionServiceServer(keyLastUsedPartitionSvc),
 		hydrav1.NewDeployServiceServer(deploySvc),

--- a/svc/ctrl/integration/harness/harness.go
+++ b/svc/ctrl/integration/harness/harness.go
@@ -35,6 +35,7 @@ import (
 	"github.com/unkeyed/unkey/svc/ctrl/worker/clickhouseuser"
 	"github.com/unkeyed/unkey/svc/ctrl/worker/cron"
 	"github.com/unkeyed/unkey/svc/ctrl/worker/cron/deploybilling"
+	"github.com/unkeyed/unkey/svc/ctrl/worker/cron/deployspendcheck"
 	"github.com/unkeyed/unkey/svc/ctrl/worker/deploy"
 	"github.com/unkeyed/unkey/svc/ctrl/worker/deployment"
 	"github.com/unkeyed/unkey/svc/ctrl/worker/deployteardown"
@@ -311,12 +312,14 @@ func New(t *testing.T, opts ...Option) *Harness {
 	// Restate. Use the proto-generated wrappers (same as run.go) to get
 	// correct service names.
 	restateCfg := containers.Restate(t,
-		hydrav1.NewCronServiceServer(cronSvc),
+		hydrav1.NewCronServiceServer(cronSvc).
+			ConfigureHandler("RunDeploySpendCheck", deployspendcheck.RetryPolicy()),
 		// The deploy billing orchestrator (push and close) fans out to this
 		// per-workspace push service, so it must be bound for those handlers to
 		// route end to end.
 		hydrav1.NewDeployBillingPushServiceServer(cronSvc.DeployBillingPushServer()),
-		hydrav1.NewDeploySpendCheckServiceServer(cronSvc.DeploySpendCheckServer()),
+		hydrav1.NewDeploySpendCheckServiceServer(cronSvc.DeploySpendCheckServer()).
+			ConfigureHandler("CheckWorkspaceSpend", deployspendcheck.RetryPolicy()),
 		hydrav1.NewClickhouseUserServiceServer(clickhouseUserSvc),
 		hydrav1.NewKeyLastUsedPartitionServiceServer(keyLastUsedPartitionSvc),
 		hydrav1.NewDeployServiceServer(deploySvc),

--- a/svc/ctrl/worker/cron/deploybilling/billing.go
+++ b/svc/ctrl/worker/cron/deploybilling/billing.go
@@ -36,6 +36,9 @@ const (
 	// maxConcurrentInstanceUsageShards limits the actual ClickHouse calls while
 	// retaining eight disjoint shards to bound each query's input.
 	maxConcurrentInstanceUsageShards = 2
+	// usageReadMaxAttempts prevents one failed journaled ClickHouse read from
+	// retrying forever and wedging its period virtual object.
+	usageReadMaxAttempts = 5
 )
 
 // instanceUsageQueries is process-wide rather than invocation-local because
@@ -189,7 +192,10 @@ func FleetMeterValues(
 				)
 			}
 			return instanceMeterUsageShardResult{Shard: shard, Rows: rows}, nil
-		}, restate.WithName(fmt.Sprintf("get period usage shard %d/%d", shard+1, len(shards))))
+		},
+			restate.WithName(fmt.Sprintf("get period usage shard %d/%d", shard+1, len(shards))),
+			restate.WithMaxRetryAttempts(usageReadMaxAttempts),
+		)
 	}
 
 	rowsByShard := make([][]clickhouse.InstanceMeterUsage, len(shards))
@@ -216,7 +222,7 @@ func FleetMeterValues(
 			Year:         p.Year,
 			Month:        p.Month,
 		})
-	}, restate.WithName("get active keys"))
+	}, restate.WithName("get active keys"), restate.WithMaxRetryAttempts(usageReadMaxAttempts))
 	if err != nil {
 		return nil, fmt.Errorf("get active keys: %w", err)
 	}

--- a/svc/ctrl/worker/cron/deployspendcheck/alert.go
+++ b/svc/ctrl/worker/cron/deployspendcheck/alert.go
@@ -76,7 +76,7 @@ func (h *CheckHandler) stoppedAlert(ctx restate.ObjectContext, a budgetAlert) er
 func (h *CheckHandler) sendToAdmins(ctx restate.ObjectContext, a budgetAlert, templateID, idempotencyKey string, variables map[string]string) error {
 	recipients, err := restate.Run(ctx, func(rc restate.RunContext) ([]string, error) {
 		return h.admins.AdminEmails(rc, a.OrgID)
-	}, restate.WithName("resolve org admins"))
+	}, restate.WithName("resolve org admins"), restate.WithMaxRetryAttempts(runMaxAttempts))
 	if err != nil {
 		return fmt.Errorf("resolve org admins: %w", err)
 	}
@@ -98,7 +98,7 @@ func (h *CheckHandler) sendToAdmins(ctx restate.ObjectContext, a budgetAlert, te
 			Subject:        "",
 			IdempotencyKey: idempotencyKey,
 		})
-	}, restate.WithName("send budget alert"))
+	}, restate.WithName("send budget alert"), restate.WithMaxRetryAttempts(runMaxAttempts))
 }
 
 // budgetAlertIdempotencyKey dedupes a warning at Resend. The budget is in the

--- a/svc/ctrl/worker/cron/deployspendcheck/check.go
+++ b/svc/ctrl/worker/cron/deployspendcheck/check.go
@@ -109,7 +109,7 @@ func (h *CheckHandler) setSuspended(ctx restate.ObjectContext, workspaceID strin
 			UpdatedAt: sql.NullInt64{Valid: true, Int64: time.Now().UnixMilli()},
 			ID:        workspaceID,
 		})
-	}, restate.WithName("set spend-suspended"))
+	}, restate.WithName("set spend-suspended"), restate.WithMaxRetryAttempts(runMaxAttempts))
 }
 
 // hasActiveDeployPlan reports whether the workspace currently holds a Deploy
@@ -122,7 +122,7 @@ func (h *CheckHandler) setSuspended(ctx restate.ObjectContext, workspaceID strin
 func (h *CheckHandler) hasActiveDeployPlan(ctx restate.ObjectContext, workspaceID string) (bool, error) {
 	entitlement, err := restate.Run(ctx, func(rc restate.RunContext) (db.FindWorkspaceDeployEntitlementRow, error) {
 		return h.db.FindWorkspaceDeployEntitlement(rc, workspaceID)
-	}, restate.WithName("read deploy entitlement"))
+	}, restate.WithName("read deploy entitlement"), restate.WithMaxRetryAttempts(runMaxAttempts))
 	if err != nil {
 		if db.IsNotFound(err) {
 			return false, nil

--- a/svc/ctrl/worker/cron/deployspendcheck/handler.go
+++ b/svc/ctrl/worker/cron/deployspendcheck/handler.go
@@ -36,6 +36,20 @@ type Config struct {
 	Heartbeat healthcheck.Heartbeat
 }
 
+const runMaxAttempts = 5
+
+// RetryPolicy bounds handler retries and kills an exhausted invocation so the
+// period or workspace virtual object can process the next scheduled check.
+func RetryPolicy() restate.HandlerOption {
+	return restate.WithInvocationRetryPolicy(
+		restate.WithInitialInterval(100*time.Millisecond),
+		restate.WithExponentiationFactor(2.0),
+		restate.WithMaxInterval(5*time.Second),
+		restate.WithMaxAttempts(runMaxAttempts),
+		restate.KillOnMaxAttempts(),
+	)
+}
+
 // Handler executes RunDeploySpendCheck: it lists budgeted workspaces, prices
 // their month-to-date usage, and fans out to DeploySpendCheckService.
 type Handler struct {
@@ -105,7 +119,7 @@ func (h *Handler) Handle(
 	if p != billingperiod.From(now) {
 		if err := restate.RunVoid(ctx, func(rc restate.RunContext) error {
 			return h.heartbeat.Ping(rc)
-		}, restate.WithName("send heartbeat")); err != nil {
+		}, restate.WithName("send heartbeat"), restate.WithMaxRetryAttempts(runMaxAttempts)); err != nil {
 			return nil, fmt.Errorf("send heartbeat: %w", err)
 		}
 		logger.Info("deploy spend check: skipping stale period",
@@ -117,7 +131,7 @@ func (h *Handler) Handle(
 
 	budgeted, err := restate.Run(ctx, func(rc restate.RunContext) ([]db.ListWorkspacesWithDeployBudgetRow, error) {
 		return h.db.ListWorkspacesWithDeployBudget(rc)
-	}, restate.WithName("list budgeted workspaces"))
+	}, restate.WithName("list budgeted workspaces"), restate.WithMaxRetryAttempts(runMaxAttempts))
 	if err != nil {
 		return nil, fmt.Errorf("list budgeted workspaces: %w", err)
 	}
@@ -130,7 +144,7 @@ func (h *Handler) Handle(
 	if len(budgeted) == 0 {
 		if err := restate.RunVoid(ctx, func(rc restate.RunContext) error {
 			return h.heartbeat.Ping(rc)
-		}, restate.WithName("send heartbeat")); err != nil {
+		}, restate.WithName("send heartbeat"), restate.WithMaxRetryAttempts(runMaxAttempts)); err != nil {
 			return nil, fmt.Errorf("send heartbeat: %w", err)
 		}
 		logger.Info("deploy spend check complete: no budgeted workspaces",
@@ -233,7 +247,7 @@ func (h *Handler) Handle(
 	if checkFailed == 0 {
 		if err := restate.RunVoid(ctx, func(rc restate.RunContext) error {
 			return h.heartbeat.Ping(rc)
-		}, restate.WithName("send heartbeat")); err != nil {
+		}, restate.WithName("send heartbeat"), restate.WithMaxRetryAttempts(runMaxAttempts)); err != nil {
 			return nil, fmt.Errorf("send heartbeat: %w", err)
 		}
 	} else {

--- a/svc/ctrl/worker/run.go
+++ b/svc/ctrl/worker/run.go
@@ -46,6 +46,7 @@ import (
 	"github.com/unkeyed/unkey/svc/ctrl/worker/clickhouseuser"
 	"github.com/unkeyed/unkey/svc/ctrl/worker/cron"
 	"github.com/unkeyed/unkey/svc/ctrl/worker/cron/deploybilling"
+	"github.com/unkeyed/unkey/svc/ctrl/worker/cron/deployspendcheck"
 	workercustomdomain "github.com/unkeyed/unkey/svc/ctrl/worker/customdomain"
 	"github.com/unkeyed/unkey/svc/ctrl/worker/deploy"
 	"github.com/unkeyed/unkey/svc/ctrl/worker/deployment"
@@ -676,20 +677,6 @@ func Run(ctx context.Context, cfg Config) error {
 		restate.WithMaxAttempts(5),
 		restate.KillOnMaxAttempts(),
 	)
-	// DeploySpendCheck is the spend-cap orchestrator, keyed by the current
-	// billing period (YYYY-MM) so every tick shares one VO. Its own reads (list
-	// budgeted workspaces, the ClickHouse scan, the heartbeat) can fail
-	// non-terminally, and without a cap that invocation retries forever on the
-	// period VO while later ticks queue behind it. Each tick re-prices from
-	// scratch and the per-workspace children own alert dedup, so kill on
-	// exhaustion and let the next tick retry from a clean slate.
-	cronDeploySpendCheckRetry := restate.WithInvocationRetryPolicy(
-		restate.WithInitialInterval(100*time.Millisecond),
-		restate.WithExponentiationFactor(2.0),
-		restate.WithMaxInterval(5*time.Second),
-		restate.WithMaxAttempts(5),
-		restate.KillOnMaxAttempts(),
-	)
 	// Without a cap the SDK default retries a failing quota check forever,
 	// parking its VO for the month. Kill on exhaustion and let the next daily
 	// tick retry; mirrors the billing-push and spend-check policies.
@@ -712,7 +699,7 @@ func Run(ctx context.Context, cfg Config) error {
 		ConfigureHandler("RunDeployBillingClose", cronDeployBillingFleetCloseRetry).
 		ConfigureHandler("CloseDeployBillingWorkspace", cronDeployBillingWorkspaceCloseRetry).
 		ConfigureHandler("RunDeployBillingPush", cronDeployBillingPushRetry).
-		ConfigureHandler("RunDeploySpendCheck", cronDeploySpendCheckRetry))
+		ConfigureHandler("RunDeploySpendCheck", deployspendcheck.RetryPolicy()))
 	logger.Info("CronService enabled")
 
 	// KeyLastUsedPartitionService is the per-partition VO fanned out from
@@ -759,15 +746,8 @@ func Run(ctx context.Context, cfg Config) error {
 	// owned by the period-scoped high-water mark and the email idempotency
 	// key, so kill on exhaustion and let the next tick retry from a clean
 	// slate.
-	deploySpendCheckWorkspaceRetry := restate.WithInvocationRetryPolicy(
-		restate.WithInitialInterval(100*time.Millisecond),
-		restate.WithExponentiationFactor(2.0),
-		restate.WithMaxInterval(5*time.Second),
-		restate.WithMaxAttempts(5),
-		restate.KillOnMaxAttempts(),
-	)
 	restateSrv.Bind(hydrav1.NewDeploySpendCheckServiceServer(cronSvc.DeploySpendCheckServer()).
-		ConfigureHandler("CheckWorkspaceSpend", deploySpendCheckWorkspaceRetry))
+		ConfigureHandler("CheckWorkspaceSpend", deployspendcheck.RetryPolicy()))
 	logger.Info("DeploySpendCheckService enabled")
 
 	// Get the Restate handler and mount it on a mux with health endpoint

--- a/svc/ctrl/worker/run.go
+++ b/svc/ctrl/worker/run.go
@@ -47,6 +47,7 @@ import (
 	"github.com/unkeyed/unkey/svc/ctrl/worker/clickhouseuser"
 	"github.com/unkeyed/unkey/svc/ctrl/worker/cron"
 	"github.com/unkeyed/unkey/svc/ctrl/worker/cron/deploybilling"
+	"github.com/unkeyed/unkey/svc/ctrl/worker/cron/deployspendcheck"
 	workercustomdomain "github.com/unkeyed/unkey/svc/ctrl/worker/customdomain"
 	"github.com/unkeyed/unkey/svc/ctrl/worker/deploy"
 	"github.com/unkeyed/unkey/svc/ctrl/worker/deployment"
@@ -688,20 +689,6 @@ func Run(ctx context.Context, cfg Config) error {
 		restate.WithMaxAttempts(5),
 		restate.KillOnMaxAttempts(),
 	)
-	// DeploySpendCheck is the spend-cap orchestrator, keyed by the current
-	// billing period (YYYY-MM) so every tick shares one VO. Its own reads (list
-	// budgeted workspaces, the ClickHouse scan, the heartbeat) can fail
-	// non-terminally, and without a cap that invocation retries forever on the
-	// period VO while later ticks queue behind it. Each tick re-prices from
-	// scratch and the per-workspace children own alert dedup, so kill on
-	// exhaustion and let the next tick retry from a clean slate.
-	cronDeploySpendCheckRetry := restate.WithInvocationRetryPolicy(
-		restate.WithInitialInterval(100*time.Millisecond),
-		restate.WithExponentiationFactor(2.0),
-		restate.WithMaxInterval(5*time.Second),
-		restate.WithMaxAttempts(5),
-		restate.KillOnMaxAttempts(),
-	)
 	// Without a cap the SDK default retries a failing quota check forever,
 	// parking its VO for the month. Kill on exhaustion and let the next daily
 	// tick retry; mirrors the billing-push and spend-check policies.
@@ -734,7 +721,7 @@ func Run(ctx context.Context, cfg Config) error {
 		ConfigureHandler("RunDeployBillingClose", cronDeployBillingFleetCloseRetry).
 		ConfigureHandler("CloseDeployBillingWorkspace", cronDeployBillingWorkspaceCloseRetry).
 		ConfigureHandler("RunDeployBillingPush", cronDeployBillingPushRetry).
-		ConfigureHandler("RunDeploySpendCheck", cronDeploySpendCheckRetry).
+		ConfigureHandler("RunDeploySpendCheck", deployspendcheck.RetryPolicy()).
 		ConfigureHandler("RunClickhouseUserReconcile", cronClickhouseUserReconcileRetry))
 	logger.Info("CronService enabled")
 
@@ -782,15 +769,8 @@ func Run(ctx context.Context, cfg Config) error {
 	// owned by the period-scoped high-water mark and the email idempotency
 	// key, so kill on exhaustion and let the next tick retry from a clean
 	// slate.
-	deploySpendCheckWorkspaceRetry := restate.WithInvocationRetryPolicy(
-		restate.WithInitialInterval(100*time.Millisecond),
-		restate.WithExponentiationFactor(2.0),
-		restate.WithMaxInterval(5*time.Second),
-		restate.WithMaxAttempts(5),
-		restate.KillOnMaxAttempts(),
-	)
 	restateSrv.Bind(hydrav1.NewDeploySpendCheckServiceServer(cronSvc.DeploySpendCheckServer()).
-		ConfigureHandler("CheckWorkspaceSpend", deploySpendCheckWorkspaceRetry))
+		ConfigureHandler("CheckWorkspaceSpend", deployspendcheck.RetryPolicy()))
 	logger.Info("DeploySpendCheckService enabled")
 
 	// Get the Restate handler and mount it on a mux with health endpoint


### PR DESCRIPTION
## Problem:

Two workers can update the same global rate-limit rows at the same time. MySQL can abort one update with a deadlock, and the failed push was not retried.

A spend check also had no retry limit. A permanent failure could block later checks for the same billing period or workspace.

## Solution:

Retry global counter writes after transient MySQL errors. Stop a spend check after five failed attempts so the next queued check can run.

## Impact:

A global counter push can recover from a deadlock without waiting for the next scheduled push. A permanently failing spend check stops after five attempts instead of blocking its queue.

## Testing:

- `mise exec -- rask ./internal/services/ratelimit`: 60 passed.
- `svc/ctrl/worker/cron` in the full Go suite: 46 passed.
- `mise run build`: passed with zero lint issues.