### PR TITLE
perf(test): run pnpm tests concurrently

### DIFF
--- a/web/apps/dashboard/vitest.config.ts
+++ b/web/apps/dashboard/vitest.config.ts
@@ -2,7 +2,14 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    environment: "jsdom",
+    environment: "node",
+    environmentMatchGlobs: [
+      ["**/*.test.tsx", "jsdom"],
+      ["**/hooks/*.test.ts", "jsdom"],
+      ["**/lib/collections/*.test.ts", "jsdom"],
+      ["**/lib/identities-query.test.ts", "jsdom"],
+      ["**/lib/unkey-client.test.ts", "jsdom"],
+    ],
     alias: { "@/": new URL("./", import.meta.url).pathname },
   },
 });

--- a/web/apps/dashboard/vitest.config.ts
+++ b/web/apps/dashboard/vitest.config.ts
@@ -2,7 +2,15 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    environment: "jsdom",
+    environment: "node",
+    environmentMatchGlobs: [
+      ["**/*.test.tsx", "jsdom"],
+      ["**/hooks/*.test.ts", "jsdom"],
+      ["**/lib/collections/**/*.test.ts", "jsdom"],
+      ["**/lib/identities-query.test.ts", "jsdom"],
+      ["**/lib/portal/use-portal.test.ts", "jsdom"],
+      ["**/lib/unkey-client.test.ts", "jsdom"],
+    ],
     alias: { "@/": new URL("./", import.meta.url).pathname },
   },
 });

--- a/web/internal/api/tsconfig.json
+++ b/web/internal/api/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "incremental": false,
+    "incremental": true,
+    "tsBuildInfoFile": "esm/.tsbuildinfo",
     "target": "ES2020",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "jsx": "react-jsx",

--- a/web/package.json
+++ b/web/package.json
@@ -9,7 +9,7 @@
     "dev": "turbo run dev",
     "build": "pnpm turbo run build",
     "fmt": "pnpm biome format . --write && pnpm biome check . --write",
-    "test": "turbo run test --concurrency=1",
+    "test": "turbo run test",
     "bootstrap": "turbo run bootstrap",
     "up": "docker compose -f ./dev/docker-compose.yaml up",
     "migrate": "pnpm turbo run migrate"


### PR DESCRIPTION
## Problem:

The root web test command ran one Turbo task at a time. Every dashboard test also loaded jsdom, including tests that only need Node.js. The internal API TypeScript build did not keep incremental build data.

## Solution:

Let Turbo run independent test tasks together. Use Node.js by default and jsdom only for browser-dependent dashboard tests. Keep TypeScript build data for the internal API.

## Impact:

Independent web tests can run together. Dashboard tests load jsdom only when required. Later internal API builds can reuse TypeScript build data.

## Testing:

- `mise exec -- pnpm --dir=web test`: all 11 Turbo tasks passed.
- Dashboard: 924 tests passed.