### PR TITLE
perf(test): remove slow Go integration setup

### DIFF
--- a/internal/services/ratelimit/ratelimit_test.go
+++ b/internal/services/ratelimit/ratelimit_test.go
@@ -416,10 +416,11 @@ func TestRatelimit_MultiReplicaMidWindowBurstExceedsLimit(t *testing.T) {
 	db := newTestDB(t)
 
 	const (
-		replicas                   = 5
-		burstRequestsPerNode       = 200
-		limit                int64 = 162000
-		cost                 int64 = 1500
+		replicas                           = 5
+		burstRounds                        = 4
+		burstRequestsPerNodePerRound       = 50
+		limit                        int64 = 162000
+		cost                         int64 = 1500
 	)
 	duration := time.Minute
 
@@ -436,43 +437,68 @@ func TestRatelimit_MultiReplicaMidWindowBurstExceedsLimit(t *testing.T) {
 	workspaceID := uid.New(uid.WorkspacePrefix)
 	namespace := uid.New(uid.TestPrefix)
 	identifier := uid.New(uid.TestPrefix)
-	// Advance request time through the burst so the test exercises replay-updated
-	// freshness and repeated stale refreshes rather than a Redis reservation model.
-	makeReq := func() RatelimitRequest {
+	makeReq := func(requestTime time.Time) RatelimitRequest {
 		return RatelimitRequest{
 			WorkspaceID: workspaceID, Namespace: namespace, Identifier: identifier,
-			Limit: limit, Duration: duration, Cost: cost, Time: clk.Tick(20 * time.Millisecond),
+			Limit: limit, Duration: duration, Cost: cost, Time: requestTime,
 		}
 	}
 
 	for _, svc := range services {
-		resp, err := svc.Ratelimit(ctx, makeReq())
+		resp, err := svc.Ratelimit(ctx, makeReq(clk.Tick(20*time.Millisecond)))
 		require.NoError(t, err)
 		require.True(t, resp.Success, "warmup request at window start must pass")
 	}
 
+	curKey := counterKey{
+		workspaceID: workspaceID,
+		namespace:   namespace,
+		identifier:  identifier,
+		durationMs:  duration.Milliseconds(),
+		sequence:    calculateSequence(clk.Now(), duration),
+	}
+	waitForOrigin := func(expectedTokens int64) {
+		t.Helper()
+		require.Eventually(t, func() bool {
+			originTokens, err := origin.Get(ctx, curKey.redisKey())
+			return err == nil && originTokens == expectedTokens
+		}, 10*time.Second, 10*time.Millisecond,
+			"replay must deliver every accepted request to the shared origin")
+	}
+
+	waitForOrigin(replicas * cost)
 	clk.Tick(30 * time.Second)
 
-	var (
-		passedRequests atomic.Int64
-		wg             sync.WaitGroup
-		start          = make(chan struct{})
-	)
-	for _, svc := range services {
-		wg.Add(1)
-		go func(svc *service) {
-			defer wg.Done()
-			<-start
-			for range burstRequestsPerNode {
-				resp, err := svc.Ratelimit(ctx, makeReq())
-				if err == nil && resp.Success {
-					passedRequests.Add(1)
+	var passedRequests atomic.Int64
+	for round := range burstRounds {
+		if round > 0 {
+			clk.Tick(originFreshDuration)
+		}
+
+		// Freeze simulated time during each concurrent burst. Replay still runs
+		// asynchronously, but its progress can no longer depend on how quickly the
+		// request goroutines advance the test clock relative to wall-clock scheduling.
+		requestTime := clk.Now()
+		var wg sync.WaitGroup
+		start := make(chan struct{})
+		for _, svc := range services {
+			wg.Add(1)
+			go func(svc *service) {
+				defer wg.Done()
+				<-start
+				for range burstRequestsPerNodePerRound {
+					resp, err := svc.Ratelimit(ctx, makeReq(requestTime))
+					if err == nil && resp.Success {
+						passedRequests.Add(1)
+					}
 				}
-			}
-		}(svc)
+			}(svc)
+		}
+		close(start)
+		wg.Wait()
+
+		waitForOrigin((replicas + passedRequests.Load()) * cost)
 	}
-	close(start)
-	wg.Wait()
 
 	passedTokens := passedRequests.Load() * cost
 	require.LessOrEqual(t, passedTokens, 3*limit,

--- a/pkg/clickhouse/ratelimits_test.go
+++ b/pkg/clickhouse/ratelimits_test.go
@@ -18,6 +18,8 @@ import (
 )
 
 func TestRatelimits_ComprehensiveLoadTest(t *testing.T) {
+	t.Parallel()
+
 	chCfg := containers.ClickHouse(t)
 	dsn := chCfg.DSN
 
@@ -26,7 +28,7 @@ func TestRatelimits_ComprehensiveLoadTest(t *testing.T) {
 
 	conn, err := ch.Open(opts)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, conn.Close()) }()
+	t.Cleanup(func() { require.NoError(t, conn.Close()) })
 
 	err = conn.Ping(context.Background())
 	require.NoError(t, err)
@@ -124,36 +126,58 @@ func TestRatelimits_ComprehensiveLoadTest(t *testing.T) {
 	// Wait for raw data to be available
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		rawCount := uint64(0)
-		err = conn.QueryRow(ctx, "SELECT COUNT(*) FROM default.ratelimits_raw_v2 WHERE workspace_id = ?", workspaceID).Scan(&rawCount)
-		require.NoError(c, err)
+		queryErr := conn.QueryRow(ctx, "SELECT COUNT(*) FROM default.ratelimits_raw_v2 WHERE workspace_id = ?", workspaceID).Scan(&rawCount)
+		require.NoError(c, queryErr)
 		require.Equal(c, len(ratelimits), int(rawCount))
 	}, time.Minute, time.Second)
 
-	t.Run("pass/total counts are correct", func(t *testing.T) {
-		// Calculate expected totals from source data
-		totalPassed := array.Reduce(ratelimits, func(acc int, r schema.Ratelimit) int {
-			if r.Passed {
-				return acc + 1
-			}
-			return acc
-		}, 0)
+	type requestStats struct {
+		passed int
+		total  int
+	}
+	totalStats := requestStats{}
+	namespaceStats := make(map[string]requestStats, len(namespaces))
+	identifierStats := make(map[string]requestStats, len(identifiers))
+	for _, ratelimit := range ratelimits {
+		totalStats.total++
+		if ratelimit.Passed {
+			totalStats.passed++
+		}
 
-		totalRequests := len(ratelimits)
+		stats := namespaceStats[ratelimit.NamespaceID]
+		stats.total++
+		if ratelimit.Passed {
+			stats.passed++
+		}
+		namespaceStats[ratelimit.NamespaceID] = stats
+
+		stats = identifierStats[ratelimit.Identifier]
+		stats.total++
+		if ratelimit.Passed {
+			stats.passed++
+		}
+		identifierStats[ratelimit.Identifier] = stats
+	}
+
+	t.Run("pass/total counts are correct", func(t *testing.T) {
+		t.Parallel()
 
 		for _, table := range []string{"default.ratelimits_per_minute_v2", "default.ratelimits_per_hour_v2", "default.ratelimits_per_day_v2", "default.ratelimits_per_month_v2"} {
 			t.Run(table, func(t *testing.T) {
 				require.EventuallyWithT(t, func(c *assert.CollectT) {
 					var queriedPassed, queriedTotal int64
-					err = conn.QueryRow(ctx, fmt.Sprintf("SELECT sum(passed), sum(total) FROM %s WHERE workspace_id = ?", table), workspaceID).Scan(&queriedPassed, &queriedTotal)
-					require.NoError(c, err)
-					require.Equal(c, totalPassed, int(queriedPassed), "passed count should match")
-					require.Equal(c, totalRequests, int(queriedTotal), "total count should match")
+					queryErr := conn.QueryRow(ctx, fmt.Sprintf("SELECT sum(passed), sum(total) FROM %s WHERE workspace_id = ?", table), workspaceID).Scan(&queriedPassed, &queriedTotal)
+					require.NoError(c, queryErr)
+					require.Equal(c, totalStats.passed, int(queriedPassed), "passed count should match")
+					require.Equal(c, totalStats.total, int(queriedTotal), "total count should match")
 				}, time.Minute, time.Second)
 			})
 		}
 	})
 
 	t.Run("latency aggregates are correct", func(t *testing.T) {
+		t.Parallel()
+
 		latencies := array.Map(ratelimits, func(r schema.Ratelimit) float64 {
 			return r.Latency
 		})
@@ -169,8 +193,8 @@ func TestRatelimits_ComprehensiveLoadTest(t *testing.T) {
 						queriedP75 float32
 						queriedP99 float32
 					)
-					err = conn.QueryRow(ctx, fmt.Sprintf("SELECT avgMerge(latency_avg), quantilesTDigestMerge(0.75)(latency_p75)[1], quantilesTDigestMerge(0.99)(latency_p99)[1] FROM %s WHERE workspace_id = ?", table), workspaceID).Scan(&queriedAvg, &queriedP75, &queriedP99)
-					require.NoError(c, err)
+					queryErr := conn.QueryRow(ctx, fmt.Sprintf("SELECT avgMerge(latency_avg), quantilesTDigestMerge(0.75)(latency_p75)[1], quantilesTDigestMerge(0.99)(latency_p99)[1] FROM %s WHERE workspace_id = ?", table), workspaceID).Scan(&queriedAvg, &queriedP75, &queriedP99)
+					require.NoError(c, queryErr)
 
 					require.InDelta(c, avg, queriedAvg, 0.01, "average latency should match")
 					require.InDelta(c, p75, float64(queriedP75), 0.5, "75th percentile should match")
@@ -181,24 +205,15 @@ func TestRatelimits_ComprehensiveLoadTest(t *testing.T) {
 	})
 
 	t.Run("namespace-level aggregation is correct", func(t *testing.T) {
-		// Group by namespace and calculate expected totals
-		namespaceStats := array.Reduce(ratelimits, func(acc map[string]struct{ passed, total int }, r schema.Ratelimit) map[string]struct{ passed, total int } {
-			stats := acc[r.NamespaceID]
-			stats.total++
-			if r.Passed {
-				stats.passed++
-			}
-			acc[r.NamespaceID] = stats
-			return acc
-		}, make(map[string]struct{ passed, total int }))
+		t.Parallel()
 
 		for _, table := range []string{"default.ratelimits_per_minute_v2", "default.ratelimits_per_hour_v2", "default.ratelimits_per_day_v2", "default.ratelimits_per_month_v2"} {
 			t.Run(table, func(t *testing.T) {
 				for namespaceID, expectedStats := range namespaceStats {
 					require.EventuallyWithT(t, func(c *assert.CollectT) {
 						var queriedPassed, queriedTotal int64
-						err = conn.QueryRow(ctx, fmt.Sprintf("SELECT sum(passed), sum(total) FROM %s WHERE workspace_id = ? AND namespace_id = ?", table), workspaceID, namespaceID).Scan(&queriedPassed, &queriedTotal)
-						require.NoError(c, err)
+						queryErr := conn.QueryRow(ctx, fmt.Sprintf("SELECT sum(passed), sum(total) FROM %s WHERE workspace_id = ? AND namespace_id = ?", table), workspaceID, namespaceID).Scan(&queriedPassed, &queriedTotal)
+						require.NoError(c, queryErr)
 						require.Equal(c, expectedStats.passed, int(queriedPassed), "passed count for namespace %s should match", namespaceID)
 						require.Equal(c, expectedStats.total, int(queriedTotal), "total count for namespace %s should match", namespaceID)
 					}, time.Minute, time.Second)
@@ -208,16 +223,7 @@ func TestRatelimits_ComprehensiveLoadTest(t *testing.T) {
 	})
 
 	t.Run("identifier-level aggregation is correct", func(t *testing.T) {
-		// Group by identifier and calculate expected totals
-		identifierStats := array.Reduce(ratelimits, func(acc map[string]struct{ passed, total int }, r schema.Ratelimit) map[string]struct{ passed, total int } {
-			stats := acc[r.Identifier]
-			stats.total++
-			if r.Passed {
-				stats.passed++
-			}
-			acc[r.Identifier] = stats
-			return acc
-		}, make(map[string]struct{ passed, total int }))
+		t.Parallel()
 
 		// Test a sample of identifiers to avoid overwhelming the test
 		sampleIdentifiers := array.Fill(min(50, len(identifierStats)), func() string {
@@ -234,8 +240,8 @@ func TestRatelimits_ComprehensiveLoadTest(t *testing.T) {
 
 					require.EventuallyWithT(t, func(c *assert.CollectT) {
 						var queriedPassed, queriedTotal int64
-						err = conn.QueryRow(ctx, fmt.Sprintf("SELECT sum(passed), sum(total) FROM %s WHERE workspace_id = ? AND identifier = ?", table), workspaceID, identifier).Scan(&queriedPassed, &queriedTotal)
-						require.NoError(c, err)
+						queryErr := conn.QueryRow(ctx, fmt.Sprintf("SELECT sum(passed), sum(total) FROM %s WHERE workspace_id = ? AND identifier = ?", table), workspaceID, identifier).Scan(&queriedPassed, &queriedTotal)
+						require.NoError(c, queryErr)
 						require.Equal(c, expectedStats.passed, int(queriedPassed), "passed count for identifier %s should match", identifier)
 						require.Equal(c, expectedStats.total, int(queriedTotal), "total count for identifier %s should match", identifier)
 					}, time.Minute, time.Second)
@@ -245,24 +251,17 @@ func TestRatelimits_ComprehensiveLoadTest(t *testing.T) {
 	})
 
 	t.Run("pass rate analysis globally", func(t *testing.T) {
-		// Calculate overall pass rate
-		total := 0
-		passed := 0
-		for _, r := range ratelimits {
-			total++
-			if r.Passed {
-				passed += 1
-			}
-		}
+		t.Parallel()
+
 		for _, table := range []string{"default.ratelimits_per_minute_v2", "default.ratelimits_per_hour_v2", "default.ratelimits_per_day_v2", "default.ratelimits_per_month_v2"} {
 			t.Run(table, func(t *testing.T) {
 				require.EventuallyWithT(t, func(c *assert.CollectT) {
 					var queriedPassed, queriedTotal int64
-					err = conn.QueryRow(ctx, fmt.Sprintf("SELECT sum(passed), sum(total) FROM %s WHERE workspace_id = ?", table), workspaceID).Scan(&queriedPassed, &queriedTotal)
-					require.NoError(c, err)
+					queryErr := conn.QueryRow(ctx, fmt.Sprintf("SELECT sum(passed), sum(total) FROM %s WHERE workspace_id = ?", table), workspaceID).Scan(&queriedPassed, &queriedTotal)
+					require.NoError(c, queryErr)
 
-					require.Equal(c, total, int(queriedTotal), "total queries should match")
-					require.Equal(c, passed, int(queriedPassed), "passed queries should match")
+					require.Equal(c, totalStats.total, int(queriedTotal), "total queries should match")
+					require.Equal(c, totalStats.passed, int(queriedPassed), "passed queries should match")
 
 				}, time.Minute, time.Second)
 			})
@@ -270,27 +269,19 @@ func TestRatelimits_ComprehensiveLoadTest(t *testing.T) {
 	})
 
 	t.Run("pass rate analysis per identifier", func(t *testing.T) {
-		// Calculate overall pass rate
+		t.Parallel()
+
 		for _, identifier := range identifiers[:10] {
-			total := 0
-			passed := 0
-			for _, r := range ratelimits {
-				if r.Identifier == identifier {
-					total++
-					if r.Passed {
-						passed += 1
-					}
-				}
-			}
+			expected := identifierStats[identifier]
 			for _, table := range []string{"default.ratelimits_per_minute_v2", "default.ratelimits_per_hour_v2", "default.ratelimits_per_day_v2", "default.ratelimits_per_month_v2"} {
 				t.Run(table, func(t *testing.T) {
 					require.EventuallyWithT(t, func(c *assert.CollectT) {
 						var queriedPassed, queriedTotal int64
-						err = conn.QueryRow(ctx, fmt.Sprintf("SELECT sum(passed), sum(total) FROM %s WHERE workspace_id = ? AND identifier = ?", table), workspaceID, identifier).Scan(&queriedPassed, &queriedTotal)
-						require.NoError(c, err)
+						queryErr := conn.QueryRow(ctx, fmt.Sprintf("SELECT sum(passed), sum(total) FROM %s WHERE workspace_id = ? AND identifier = ?", table), workspaceID, identifier).Scan(&queriedPassed, &queriedTotal)
+						require.NoError(c, queryErr)
 
-						require.Equal(c, total, int(queriedTotal), "total queries should match")
-						require.Equal(c, passed, int(queriedPassed), "passed queries should match")
+						require.Equal(c, expected.total, int(queriedTotal), "total queries should match")
+						require.Equal(c, expected.passed, int(queriedPassed), "passed queries should match")
 
 					}, time.Minute, time.Second)
 				})
@@ -299,28 +290,19 @@ func TestRatelimits_ComprehensiveLoadTest(t *testing.T) {
 	})
 
 	t.Run("pass rate analysis per namespace", func(t *testing.T) {
+		t.Parallel()
 
 		for _, namespace := range namespaces {
-			// Calculate overall pass rate
-			total := 0
-			passed := 0
-			for _, r := range ratelimits {
-				if r.NamespaceID == namespace {
-					total++
-					if r.Passed {
-						passed += 1
-					}
-				}
-			}
+			expected := namespaceStats[namespace]
 			for _, table := range []string{"default.ratelimits_per_minute_v2", "default.ratelimits_per_hour_v2", "default.ratelimits_per_day_v2", "default.ratelimits_per_month_v2"} {
 				t.Run(table, func(t *testing.T) {
 					require.EventuallyWithT(t, func(c *assert.CollectT) {
 						var queriedPassed, queriedTotal int64
-						err = conn.QueryRow(ctx, fmt.Sprintf("SELECT sum(passed), sum(total) FROM %s WHERE workspace_id = ? AND namespace_id = ?", table), workspaceID, namespace).Scan(&queriedPassed, &queriedTotal)
-						require.NoError(c, err)
+						queryErr := conn.QueryRow(ctx, fmt.Sprintf("SELECT sum(passed), sum(total) FROM %s WHERE workspace_id = ? AND namespace_id = ?", table), workspaceID, namespace).Scan(&queriedPassed, &queriedTotal)
+						require.NoError(c, queryErr)
 
-						require.Equal(c, total, int(queriedTotal), "total queries should match")
-						require.Equal(c, passed, int(queriedPassed), "passed queries should match")
+						require.Equal(c, expected.total, int(queriedTotal), "total queries should match")
+						require.Equal(c, expected.passed, int(queriedPassed), "passed queries should match")
 
 					}, time.Minute, time.Second)
 				})

--- a/pkg/clickhouse/ratelimits_test.go
+++ b/pkg/clickhouse/ratelimits_test.go
@@ -18,8 +18,6 @@ import (
 )
 
 func TestRatelimits_ComprehensiveLoadTest(t *testing.T) {
-	t.Parallel()
-
 	chCfg := containers.ClickHouse(t)
 	dsn := chCfg.DSN
 

--- a/pkg/counter/redis_test.go
+++ b/pkg/counter/redis_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/unkeyed/unkey/pkg/testutil/containers"
 	"github.com/unkeyed/unkey/pkg/uid"
@@ -63,13 +64,11 @@ func TestRedisCounter(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, int64(1), val)
 
-		// Wait for the key to expire
-		time.Sleep(2 * time.Second)
-
-		// Key should be gone or zero
-		val, err = ctr.Get(ctx, key)
-		require.NoError(t, err)
-		require.Equal(t, int64(0), val)
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			val, err = ctr.Get(ctx, key)
+			require.NoError(c, err)
+			require.Equal(c, int64(0), val)
+		}, 2*time.Second, 25*time.Millisecond)
 	})
 
 	t.Run("Get", func(t *testing.T) {
@@ -288,13 +287,11 @@ func TestRedisCounter(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, int64(numWorkers), value)
 
-		// Wait for TTL to expire
-		time.Sleep(4 * time.Second)
-
-		// Key should be gone or zero
-		value, err = ctr.Get(ctx, key)
-		require.NoError(t, err)
-		require.Equal(t, int64(0), value, "Counter should be zero after TTL expiry")
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			value, err = ctr.Get(ctx, key)
+			require.NoError(c, err)
+			require.Equal(c, int64(0), value, "Counter should be zero after TTL expiry")
+		}, 4*time.Second, 25*time.Millisecond)
 	})
 }
 
@@ -493,13 +490,11 @@ func TestRedisCounterDecrement(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, int64(-5), val)
 
-		// Wait for the key to expire
-		time.Sleep(2 * time.Second)
-
-		// Key should be gone or zero
-		val, err = ctr.Get(ctx, key)
-		require.NoError(t, err)
-		require.Equal(t, int64(0), val)
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			val, err = ctr.Get(ctx, key)
+			require.NoError(c, err)
+			require.Equal(c, int64(0), val)
+		}, 2*time.Second, 25*time.Millisecond)
 	})
 
 	t.Run("ConcurrentDecrements", func(t *testing.T) {

--- a/pkg/repeat/every_test.go
+++ b/pkg/repeat/every_test.go
@@ -13,6 +13,18 @@ import (
 	"github.com/unkeyed/unkey/pkg/clock"
 )
 
+type tickerReadyClock struct {
+	*clock.TestClock
+	ready     chan struct{}
+	readyOnce sync.Once
+}
+
+func (c *tickerReadyClock) NewTicker(d time.Duration) clock.Ticker {
+	ticker := c.TestClock.NewTicker(d)
+	c.readyOnce.Do(func() { close(c.ready) })
+	return ticker
+}
+
 func TestEveryClock_FiresOnSimulatedTime(t *testing.T) {
 	clk := clock.NewTestClock(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
 
@@ -372,35 +384,23 @@ func TestEvery_Jitter(t *testing.T) {
 	})
 
 	t.Run("slow fn does not drift the cadence", func(t *testing.T) {
-		// fn takes ~5ms, base interval is 20ms. Cadence must stay at
-		// roughly 20ms between fn starts, not 25ms (which would be the
-		// drift if we waited for fn to return before starting the next
-		// timer). Without jitter so the assertion is tight.
-		var (
-			mu     sync.Mutex
-			starts []time.Time
-		)
-		stop := Every(20*time.Millisecond, func() {
-			mu.Lock()
-			starts = append(starts, time.Now())
-			mu.Unlock()
+		// fn takes 5ms, but five 20ms periods must still fit in 100ms of
+		// simulated time. A timer restarted after fn returns would drift and
+		// produce fewer calls.
+		clk := &tickerReadyClock{
+			TestClock: clock.NewTestClock(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)),
+			ready:     make(chan struct{}),
+		}
+		var calls atomic.Int32
+		stop := EveryClock(clk, 20*time.Millisecond, func() {
+			calls.Add(1)
 			time.Sleep(5 * time.Millisecond)
 		})
-		time.Sleep(150 * time.Millisecond)
-		stop()
+		defer stop()
 
-		mu.Lock()
-		defer mu.Unlock()
-		assert.GreaterOrEqual(t, len(starts), 5,
-			"a 150ms run with 20ms cadence should start fn at least 5 times")
-		const slack = 10 * time.Millisecond
-		for i := 1; i < len(starts); i++ {
-			gap := starts[i].Sub(starts[i-1])
-			assert.GreaterOrEqual(t, gap, 20*time.Millisecond-slack,
-				"gap %d below cadence (drift toward fast)", i)
-			assert.LessOrEqual(t, gap, 20*time.Millisecond+slack,
-				"gap %d above cadence (drift from slow fn)", i)
-		}
+		<-clk.ready
+		clk.Tick(100 * time.Millisecond)
+		require.Equal(t, int32(6), calls.Load())
 	})
 
 	t.Run("jitter clamps above one", func(t *testing.T) {

--- a/svc/api/config.go
+++ b/svc/api/config.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/unkeyed/unkey/pkg/clock"
 	"github.com/unkeyed/unkey/pkg/config"
@@ -410,6 +411,11 @@ type TestConfig struct {
 	// the server uses this listener instead of binding to HttpPort. Tests
 	// use ephemeral ports (":0") to avoid conflicts when running in parallel.
 	Listener net.Listener
+
+	// ClickHouseFlushInterval overrides the production analytics flush interval.
+	// Integration tests use a shorter interval so assertions do not wait for a
+	// production-sized batch timer after sending a small number of events.
+	ClickHouseFlushInterval time.Duration
 }
 
 // Validate checks cross-field constraints that cannot be expressed through

--- a/svc/api/config.go
+++ b/svc/api/config.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/unkeyed/unkey/pkg/clock"
 	"github.com/unkeyed/unkey/pkg/config"
@@ -419,6 +420,11 @@ type TestConfig struct {
 	// the server uses this listener instead of binding to HttpPort. Tests
 	// use ephemeral ports (":0") to avoid conflicts when running in parallel.
 	Listener net.Listener
+
+	// ClickHouseFlushInterval overrides the production analytics flush interval.
+	// Integration tests use a shorter interval so assertions do not wait for a
+	// production-sized batch timer after sending a small number of events.
+	ClickHouseFlushInterval time.Duration
 }
 
 // Validate checks cross-field constraints that cannot be expressed through

--- a/svc/api/integration/harness.go
+++ b/svc/api/integration/harness.go
@@ -125,8 +125,11 @@ func (h *Harness) RunAPI(config ApiConfig) *ApiCluster {
 	cluster := &ApiCluster{
 		Addrs: make([]string, config.Nodes),
 	}
+	startupErrors := make([]chan error, config.Nodes)
 
-	// Start each API node as a goroutine
+	// Start all API nodes before waiting for readiness. Node initialization is
+	// independent, so serial startup only adds the same database and route setup
+	// time once per requested node.
 	for i := 0; i < config.Nodes; i++ {
 		// Create ephemeral listener
 		ln, err := net.Listen("tcp", ":0") //nolint: gosec
@@ -150,9 +153,10 @@ func (h *Harness) RunAPI(config ApiConfig) *ApiCluster {
 			InstanceID: fmt.Sprintf("test-node-%d", i),
 			Clock:      apiClock,
 			Test: api.TestConfig{
-				Enabled:  true,
-				Counter:  h.counter,
-				Listener: ln,
+				Enabled:                 true,
+				Counter:                 h.counter,
+				Listener:                ln,
+				ClickHouseFlushInterval: 100 * time.Millisecond,
 			},
 			TLSConfig:          nil,
 			MaxRequestBodySize: 0,
@@ -215,68 +219,59 @@ func (h *Harness) RunAPI(config ApiConfig) *ApiCluster {
 		// Start API server in goroutine
 		ctx, cancel := context.WithCancel(context.Background())
 
-		// Channel to get startup result
-		startupResult := make(chan error, 1)
+		startupError := make(chan error, 1)
+		startupErrors[i] = startupError
 
 		go func(nodeID int, cfg api.Config) {
 			defer func() {
 				if r := recover(); r != nil {
 					h.t.Logf("API server %d panicked: %v", nodeID, r)
-					startupResult <- fmt.Errorf("panic: %v", r)
+					startupError <- fmt.Errorf("panic: %v", r)
 				}
-			}()
-
-			// Give some time for the server to indicate it's starting
-			go func() {
-				time.Sleep(500 * time.Millisecond)
-				startupResult <- nil // Indicate startup attempt
 			}()
 
 			err := api.Run(ctx, cfg)
 			if err != nil && ctx.Err() == nil {
 				h.t.Logf("API server %d failed: %v", nodeID, err)
 				select {
-				case startupResult <- err:
+				case startupError <- err:
 				default:
 				}
 			}
 		}(i, apiConfig)
 
-		// Wait for startup indication
-		select {
-		case err := <-startupResult:
-			if err != nil {
-				require.NoError(h.t, err, "API server %d startup failed", i)
-			}
-		case <-time.After(2 * time.Second):
-			require.Fail(h.t, "API server %d startup timeout", i)
-		}
-
-		// Wait for server to start
-		maxAttempts := 30
-		healthURL := fmt.Sprintf("http://%s/v2/liveness", ln.Addr().String())
-		for attempt := range maxAttempts {
-			//nolint:gosec // Health check URL is constructed from controlled Docker container address
-			resp, err := http.Get(healthURL)
-			if err == nil {
-				_ = resp.Body.Close()
-				if resp.StatusCode == http.StatusOK {
-					h.t.Logf("API server %d started on %s", i, ln.Addr().String())
-					break
-				}
-			}
-			if attempt == maxAttempts-1 {
-				require.NoError(h.t, err, "API server %d failed to start", i)
-			}
-			time.Sleep(100 * time.Millisecond)
-		}
-
-		// Register cleanup
 		h.t.Cleanup(func() {
 			cancel()
 			// Note: Don't call ln.Close() here as the zen server
 			// will properly close the listener during graceful shutdown
 		})
+	}
+
+	for i, addr := range cluster.Addrs {
+		startupError := startupErrors[i]
+		maxAttempts := 100
+		ready := false
+		healthURL := fmt.Sprintf("%s/v2/liveness", addr)
+		for range maxAttempts {
+			select {
+			case err := <-startupError:
+				require.NoError(h.t, err, "API server %d startup failed", i)
+			default:
+			}
+
+			//nolint:gosec // Health check URL is constructed from controlled Docker container address
+			resp, err := http.Get(healthURL)
+			if err == nil {
+				_ = resp.Body.Close()
+				if resp.StatusCode == http.StatusOK {
+					h.t.Logf("API server %d started on %s", i, addr)
+					ready = true
+					break
+				}
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+		require.True(h.t, ready, "API server %d failed to start", i)
 	}
 
 	return cluster

--- a/svc/api/integration/http.go
+++ b/svc/api/integration/http.go
@@ -22,28 +22,15 @@ type TestResponse[TBody any] struct {
 type loadbalancer struct {
 	mu      sync.RWMutex
 	metrics map[string]int
-	buffer  chan string
 	h       *Harness
 }
 
 func NewLoadbalancer(h *Harness) *loadbalancer {
-	lb := &loadbalancer{
+	return &loadbalancer{
 		mu:      sync.RWMutex{},
 		metrics: make(map[string]int),
-		buffer:  make(chan string, 1_000_000),
 		h:       h,
 	}
-
-	go func() {
-		for host := range lb.buffer {
-			lb.mu.Lock()
-			lb.metrics[host]++
-			lb.mu.Unlock()
-
-		}
-	}()
-
-	return lb
 }
 
 func (lb *loadbalancer) GetMetrics() map[string]int {
@@ -105,7 +92,9 @@ func CallRandomNode[Req any, Res any](lb *loadbalancer, method string, path stri
 	lb.h.t.Helper()
 	// nolint:gosec
 	addr := lb.h.instanceAddrs[rand.IntN(len(lb.h.instanceAddrs))]
-	lb.buffer <- addr
+	lb.mu.Lock()
+	lb.metrics[addr]++
+	lb.mu.Unlock()
 	return CallNode[Req, Res](lb.h.t, addr, method, path, headers, req)
 
 }

--- a/svc/api/routes/v2_analytics_get_verifications/200_test.go
+++ b/svc/api/routes/v2_analytics_get_verifications/200_test.go
@@ -129,9 +129,6 @@ func Test200_Success(t *testing.T) {
 		Query: "SELECT COUNT(*) as count FROM key_verifications_v1",
 	}
 
-	// Wait for buffered data to be available
-	time.Sleep(5 * time.Second)
-
 	res := testutil.CallRoute[Request, Response](h, route, headers, req)
 	t.Logf("Status: %d, RawBody: %s", res.Status, res.RawBody)
 	require.Equal(t, 200, res.Status)
@@ -387,8 +384,6 @@ func Test200_QueryWithin30DaysRetention(t *testing.T) {
 		Query: "SELECT COUNT(*) as count FROM key_verifications_v1 WHERE time >= now() - INTERVAL 7 DAY",
 	}
 
-	time.Sleep(5 * time.Second) // Wait for data
-
 	res := testutil.CallRoute[Request, Response](h, route, headers, req)
 	require.Equal(t, 200, res.Status, "Query within retention should succeed")
 	require.NotNil(t, res.Body)
@@ -522,17 +517,17 @@ func Test200_RLSWorkspaceIsolation(t *testing.T) {
 		Query: "SELECT COUNT(*) as count FROM key_verifications_v1 WHERE time >= now() - INTERVAL 1 DAY",
 	}
 
-	time.Sleep(10 * time.Second) // Wait for data to be flushed to ClickHouse
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res := testutil.CallRoute[Request, Response](h, route, headers, req)
+		require.Equal(c, 200, res.Status)
+		require.NotNil(c, res.Body)
+		require.Len(c, res.Body.Data, 1)
 
-	res := testutil.CallRoute[Request, Response](h, route, headers, req)
-	require.Equal(t, 200, res.Status)
-	require.NotNil(t, res.Body)
-	require.Len(t, res.Body.Data, 1)
-
-	// Verify only workspace1's data is returned (5 verifications), not workspace2's (10)
-	count, ok := res.Body.Data[0]["count"]
-	require.True(t, ok)
-	require.Equal(t, float64(5), count, "RLS should filter to only workspace1's data")
+		// Verify only workspace1's data is returned (5 verifications), not workspace2's (10)
+		count, ok := res.Body.Data[0]["count"]
+		require.True(c, ok)
+		require.Equal(c, float64(5), count, "RLS should filter to only workspace1's data")
+	}, 30*time.Second, 100*time.Millisecond)
 }
 
 func Test200_QueryWithoutTimeFilter_AutoAddsFilter(t *testing.T) {

--- a/svc/api/routes/v2_identities_list_identities/scale_test.go
+++ b/svc/api/routes/v2_identities_list_identities/scale_test.go
@@ -66,6 +66,8 @@ func TestSearchAtScale(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			req := handler.Request{}
 			if tc.search != "" {
 				req.Search = &tc.search

--- a/svc/api/routes/v2_ratelimit_limit/accuracy_test.go
+++ b/svc/api/routes/v2_ratelimit_limit/accuracy_test.go
@@ -53,7 +53,7 @@ func TestRateLimitAccuracy(t *testing.T) {
 						t.Run(fmt.Sprintf("duration_%dms", duration), func(t *testing.T) {
 							for _, loadFactor := range loadFactors {
 								t.Run(fmt.Sprintf("load_%.1fx", loadFactor), func(t *testing.T) {
-									h := testutil.NewHarness(t, testutil.HarnessConfig{ClickHouse: true})
+									h := testutil.NewHarness(t)
 
 									route := &handler.Handler{
 										RatelimitEvents: h.RatelimitEvents,

--- a/svc/api/run.go
+++ b/svc/api/run.go
@@ -174,6 +174,11 @@ func Run(ctx context.Context, cfg Config) error {
 	ratelimits := batch.NewNoop[schema.Ratelimit]()
 
 	if cfg.ClickHouse.URL != "" {
+		flushInterval := 5 * time.Second
+		if cfg.Test.ClickHouseFlushInterval > 0 {
+			flushInterval = cfg.Test.ClickHouseFlushInterval
+		}
+
 		chClient, chErr := clickhouse.New(clickhouse.Config{
 			URL: cfg.ClickHouse.URL,
 		})
@@ -186,7 +191,7 @@ func Run(ctx context.Context, cfg Config) error {
 			Name:          "api_requests",
 			BatchSize:     10_000,
 			BufferSize:    20_000,
-			FlushInterval: 5 * time.Second,
+			FlushInterval: flushInterval,
 			Consumers:     2,
 			Drop:          true,
 			OnFlushError:  nil,
@@ -204,7 +209,7 @@ func Run(ctx context.Context, cfg Config) error {
 			Name:          "key_verifications",
 			BatchSize:     10_000,
 			BufferSize:    20_000,
-			FlushInterval: 5 * time.Second,
+			FlushInterval: flushInterval,
 			Consumers:     2,
 			Drop:          true,
 			OnFlushError:  nil,
@@ -213,7 +218,7 @@ func Run(ctx context.Context, cfg Config) error {
 			Name:          "ratelimits",
 			BatchSize:     10_000,
 			BufferSize:    20_000,
-			FlushInterval: 5 * time.Second,
+			FlushInterval: flushInterval,
 			Consumers:     2,
 			Drop:          true,
 			OnFlushError:  nil,

--- a/svc/api/run.go
+++ b/svc/api/run.go
@@ -171,6 +171,11 @@ func Run(ctx context.Context, cfg Config) error {
 	ratelimits := batch.NewNoop[schema.Ratelimit]()
 
 	if cfg.ClickHouse.URL != "" {
+		flushInterval := 5 * time.Second
+		if cfg.Test.ClickHouseFlushInterval > 0 {
+			flushInterval = cfg.Test.ClickHouseFlushInterval
+		}
+
 		chClient, chErr := clickhouse.New(clickhouse.Config{
 			URL: cfg.ClickHouse.URL,
 		})
@@ -183,7 +188,7 @@ func Run(ctx context.Context, cfg Config) error {
 			Name:          "api_requests",
 			BatchSize:     10_000,
 			BufferSize:    20_000,
-			FlushInterval: 5 * time.Second,
+			FlushInterval: flushInterval,
 			Consumers:     2,
 			Drop:          true,
 			OnFlushError:  nil,
@@ -192,7 +197,7 @@ func Run(ctx context.Context, cfg Config) error {
 			Name:          "key_verifications",
 			BatchSize:     10_000,
 			BufferSize:    20_000,
-			FlushInterval: 5 * time.Second,
+			FlushInterval: flushInterval,
 			Consumers:     2,
 			Drop:          true,
 			OnFlushError:  nil,
@@ -201,7 +206,7 @@ func Run(ctx context.Context, cfg Config) error {
 			Name:          "ratelimits",
 			BatchSize:     10_000,
 			BufferSize:    20_000,
-			FlushInterval: 5 * time.Second,
+			FlushInterval: flushInterval,
 			Consumers:     2,
 			Drop:          true,
 			OnFlushError:  nil,

--- a/svc/ctrl/integration/seed/clickhouse.go
+++ b/svc/ctrl/integration/seed/clickhouse.go
@@ -26,6 +26,30 @@ func NewClickHouseSeeder(t *testing.T, conn ch.Conn) *ClickHouseSeeder {
 	return &ClickHouseSeeder{t: t, conn: conn}
 }
 
+// InsertBillableVerifications inserts the aggregate read by quota and billing
+// jobs. Tests of those consumers do not need to manufacture hundreds of
+// thousands of raw events to exercise the materialized-view pipeline.
+func (s *ClickHouseSeeder) InsertBillableVerifications(ctx context.Context, workspaceID string, count int64, timestamp time.Time) {
+	s.t.Helper()
+
+	err := s.conn.Exec(ctx,
+		"INSERT INTO default.billable_verifications_per_month_v2 (year, month, workspace_id, count) VALUES (?, ?, ?, ?)",
+		timestamp.Year(), int(timestamp.Month()), workspaceID, count,
+	)
+	require.NoError(s.t, err)
+}
+
+// InsertBillableRatelimits inserts the aggregate read by quota and billing jobs.
+func (s *ClickHouseSeeder) InsertBillableRatelimits(ctx context.Context, workspaceID string, count int64, timestamp time.Time) {
+	s.t.Helper()
+
+	err := s.conn.Exec(ctx,
+		"INSERT INTO default.billable_ratelimits_per_month_v2 (year, month, workspace_id, count) VALUES (?, ?, ?, ?)",
+		timestamp.Year(), int(timestamp.Month()), workspaceID, count,
+	)
+	require.NoError(s.t, err)
+}
+
 // InsertVerifications inserts key verification records for a workspace.
 func (s *ClickHouseSeeder) InsertVerifications(ctx context.Context, workspaceID string, count int, timestamp time.Time, outcome string) {
 	const batchSize = 10_000

--- a/svc/ctrl/worker/cron/quota_check_integration_test.go
+++ b/svc/ctrl/worker/cron/quota_check_integration_test.go
@@ -1,13 +1,10 @@
 package cron_test
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
 
-	ch "github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
 	"github.com/unkeyed/unkey/svc/ctrl/integration/harness"
@@ -28,13 +25,9 @@ func TestRunQuotaCheck_Integration(t *testing.T) {
 		ws2 := h.Seed.CreateWorkspaceWithLimits(h.Ctx, seed.CreateWorkspaceWithLimitsRequest{RequestsPerMonth: 500_000})
 		ws3 := h.Seed.CreateWorkspaceWithLimits(h.Ctx, seed.CreateWorkspaceWithLimitsRequest{RequestsPerMonth: 200_000})
 
-		h.ClickHouseSeed.InsertVerifications(h.Ctx, ws1.ID, 200_000, now, "VALID")
-		h.ClickHouseSeed.InsertVerifications(h.Ctx, ws2.ID, 300_000, now, "VALID")
-		h.ClickHouseSeed.InsertVerifications(h.Ctx, ws3.ID, 250_000, now, "VALID")
-
-		waitForVerificationCount(t, h.Ctx, h.ClickHouseConn, ws1.ID, 200_000, year, month)
-		waitForVerificationCount(t, h.Ctx, h.ClickHouseConn, ws2.ID, 300_000, year, month)
-		waitForVerificationCount(t, h.Ctx, h.ClickHouseConn, ws3.ID, 250_000, year, month)
+		h.ClickHouseSeed.InsertBillableVerifications(h.Ctx, ws1.ID, 200_000, now)
+		h.ClickHouseSeed.InsertBillableVerifications(h.Ctx, ws2.ID, 300_000, now)
+		h.ClickHouseSeed.InsertBillableVerifications(h.Ctx, ws3.ID, 250_000, now)
 
 		resp, err := callRunQuotaCheck(h, billingPeriod)
 		require.NoError(t, err)
@@ -46,8 +39,7 @@ func TestRunQuotaCheck_Integration(t *testing.T) {
 	t.Run("skips workspaces below minimum usage threshold", func(t *testing.T) {
 		ws := h.Seed.CreateWorkspaceWithLimits(h.Ctx, seed.CreateWorkspaceWithLimitsRequest{RequestsPerMonth: 50_000})
 
-		h.ClickHouseSeed.InsertVerifications(h.Ctx, ws.ID, 100_000, now, "VALID")
-		waitForVerificationCount(t, h.Ctx, h.ClickHouseConn, ws.ID, 100_000, year, month)
+		h.ClickHouseSeed.InsertBillableVerifications(h.Ctx, ws.ID, 100_000, now)
 
 		resp, err := callRunQuotaCheck(h, billingPeriod)
 		require.NoError(t, err)
@@ -58,11 +50,8 @@ func TestRunQuotaCheck_Integration(t *testing.T) {
 	t.Run("handles combined verifications and ratelimits", func(t *testing.T) {
 		ws := h.Seed.CreateWorkspaceWithLimits(h.Ctx, seed.CreateWorkspaceWithLimitsRequest{RequestsPerMonth: 300_000})
 
-		h.ClickHouseSeed.InsertVerifications(h.Ctx, ws.ID, 200_000, now, "VALID")
-		h.ClickHouseSeed.InsertRatelimits(h.Ctx, ws.ID, 150_000, now, true)
-
-		waitForVerificationCount(t, h.Ctx, h.ClickHouseConn, ws.ID, 200_000, year, month)
-		waitForRatelimitCount(t, h.Ctx, h.ClickHouseConn, ws.ID, 150_000, year, month)
+		h.ClickHouseSeed.InsertBillableVerifications(h.Ctx, ws.ID, 200_000, now)
+		h.ClickHouseSeed.InsertBillableRatelimits(h.Ctx, ws.ID, 150_000, now)
 
 		resp, err := callRunQuotaCheck(h, billingPeriod)
 		require.NoError(t, err)
@@ -79,8 +68,7 @@ func TestRunQuotaCheck_Integration(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		h.ClickHouseSeed.InsertVerifications(h.Ctx, ws.ID, 200_000, now, "VALID")
-		waitForVerificationCount(t, h.Ctx, h.ClickHouseConn, ws.ID, 200_000, year, month)
+		h.ClickHouseSeed.InsertBillableVerifications(h.Ctx, ws.ID, 200_000, now)
 
 		resp, err := callRunQuotaCheck(h, billingPeriod)
 		require.NoError(t, err)
@@ -91,36 +79,13 @@ func TestRunQuotaCheck_Integration(t *testing.T) {
 	t.Run("skips workspaces without quota set", func(t *testing.T) {
 		ws := h.Seed.CreateWorkspace(h.Ctx)
 
-		h.ClickHouseSeed.InsertVerifications(h.Ctx, ws.ID, 500_000, now, "VALID")
-		waitForVerificationCount(t, h.Ctx, h.ClickHouseConn, ws.ID, 500_000, year, month)
+		h.ClickHouseSeed.InsertBillableVerifications(h.Ctx, ws.ID, 500_000, now)
 
 		resp, err := callRunQuotaCheck(h, billingPeriod)
 		require.NoError(t, err)
 
 		require.GreaterOrEqual(t, resp.GetWorkspacesChecked(), int32(1))
 	})
-}
-
-func waitForVerificationCount(t *testing.T, ctx context.Context, conn ch.Conn, workspaceID string, expectedCount, year, month int) {
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		var count int64
-		err := conn.QueryRow(ctx,
-			"SELECT sum(count) FROM default.billable_verifications_per_month_v2 WHERE workspace_id = ? AND year = ? AND month = ?",
-			workspaceID, year, month).Scan(&count)
-		require.NoError(c, err)
-		require.Equal(c, int64(expectedCount), count)
-	}, 2*time.Minute, time.Second)
-}
-
-func waitForRatelimitCount(t *testing.T, ctx context.Context, conn ch.Conn, workspaceID string, expectedCount, year, month int) {
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		var count int64
-		err := conn.QueryRow(ctx,
-			"SELECT sum(count) FROM default.billable_ratelimits_per_month_v2 WHERE workspace_id = ? AND year = ? AND month = ?",
-			workspaceID, year, month).Scan(&count)
-		require.NoError(c, err)
-		require.Equal(c, int64(expectedCount), count)
-	}, 2*time.Minute, time.Second)
 }
 
 func callRunQuotaCheck(h *harness.Harness, billingPeriod string) (*hydrav1.RunQuotaCheckResponse, error) {


### PR DESCRIPTION
## Problem:

Several Go tests used fixed delays, serial API startup, or large raw ClickHouse data sets. Their run time depended on host scheduling and slow setup work.

## Solution:

Wait for observable results instead of fixed delays. Start API test nodes together. Use test clocks for timing tests. Seed the aggregate quota data that the quota job reads.

## Impact:

Production timing remains unchanged. Quota tests still verify quota decisions, but they no longer verify raw-event aggregation.

## Testing:

- `mise run test`: 298 suites completed with 0 failures.