### PR TITLE
ci: persist Go build and reset Rask caches

### DIFF
--- a/.depot/workflows/job_go.yaml
+++ b/.depot/workflows/job_go.yaml
@@ -9,27 +9,31 @@ jobs:
     runs-on: depot-ubuntu-24.04-8
     timeout-minutes: 30
     env:
-      RASK_CACHE_DIR: ./.rask-cache #/mnt/depot-cache/rask
+      RASK_CACHE_DIR: ./.rask-cache
       RASK_REMOTE_CACHE_BUCKET: rask
-      RASK_REMOTE_CACHE_PREFIX: ""
+      RASK_REMOTE_CACHE_PREFIX: v2
       RASK_REMOTE_CACHE_REGION: auto
       RASK_REMOTE_CACHE_ENDPOINT: ${{ secrets.RASK_REMOTE_CACHE_ENDPOINT }}
       RASK_REMOTE_CACHE_ACCESS_KEY_ID: ${{ secrets.RASK_REMOTE_CACHE_ACCESS_KEY_ID }}
       RASK_REMOTE_CACHE_SECRET_ACCESS_KEY: ${{ secrets.RASK_REMOTE_CACHE_SECRET_ACCESS_KEY }}
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
-      # - name: Mount Rask cache disk
-      #   uses: depot/cache-mount@v1
-      #   with:
-      #     name: unkey-rask-cache
-      #     path: /mnt/depot-cache
-      #     write-lock: /mnt/depot-cache/rask
       - name: Install mise
         run: |
           ./dev/install-mise
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: Install toolchain
         run: mise install --locked --yes
+      - name: Cache Go build artifacts
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: go-build-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('go.mod') }}-${{ hashFiles('go.sum') }}-${{ github.sha }}
+          restore-keys: |
+            go-build-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('go.mod') }}-${{ hashFiles('go.sum') }}-
+            go-build-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('go.mod') }}-
       - name: Build
         run: mise run build
       - name: Run tests


### PR DESCRIPTION
## Problem:

The Go CI job did not restore compiler output or downloaded modules from earlier runs. Rask also used the old remote test-cache namespace.

## Solution:

Cache the Go build and module directories. Use module files in the restore keys. Move Rask test results to the `v2` namespace.

## Impact:

Compatible CI runs can reuse Go build data. Rask no longer reads old cached test results.

## Testing:

- No local runtime check applies to this CI-only change. GitHub CI will run on the rebased head.