### PR TITLE
perf(build): shorten Go compile paths

### DIFF
--- a/build/api/main.go
+++ b/build/api/main.go
@@ -4,14 +4,14 @@ import (
 	"context"
 
 	"github.com/unkeyed/unkey/build/util"
-	openapivalidation "github.com/unkeyed/unkey/pkg/openapi/validation"
+	"github.com/unkeyed/unkey/pkg/openapi/validation"
 	"github.com/unkeyed/unkey/svc/api"
 )
 
 func main() {
-	util.RunServiceCommand("api", "Run the Unkey API server", run)
+	util.RunServiceCommand("api", "Run the Unkey API server", runAPI)
 }
 
-func run(ctx context.Context, cfg api.Config) error {
-	return api.Run(ctx, cfg, openapivalidation.NewFromBytes)
+func runAPI(ctx context.Context, cfg api.Config) error {
+	return api.Run(ctx, cfg, validation.NewFromBytes)
 }

--- a/build/api/main.go
+++ b/build/api/main.go
@@ -1,10 +1,17 @@
 package main
 
 import (
+	"context"
+
 	"github.com/unkeyed/unkey/build/util"
+	openapivalidation "github.com/unkeyed/unkey/pkg/openapi/validation"
 	"github.com/unkeyed/unkey/svc/api"
 )
 
 func main() {
-	util.RunServiceCommand("api", "Run the Unkey API server", api.Run)
+	util.RunServiceCommand("api", "Run the Unkey API server", run)
+}
+
+func run(ctx context.Context, cfg api.Config) error {
+	return api.Run(ctx, cfg, openapivalidation.NewFromBytes)
 }

--- a/pkg/openapi/validation/types/validator.go
+++ b/pkg/openapi/validation/types/validator.go
@@ -1,0 +1,26 @@
+package types
+
+import "net/http"
+
+// ValidationError represents a single field-level validation failure.
+// Fix is non-nil when the validator can suggest a concrete correction.
+type ValidationError struct {
+	Message  string
+	Location string
+	Fix      *string
+}
+
+// Result holds the validation outcome when a request is invalid.
+// A nil *Result means the request passed validation.
+type Result struct {
+	Detail string
+	Errors []ValidationError
+}
+
+// Validator validates HTTP requests against an OpenAPI specification.
+type Validator interface {
+	Validate(r *http.Request) *Result
+}
+
+// Factory creates a Validator from a raw OpenAPI specification.
+type Factory func(spec []byte) (Validator, error)

--- a/pkg/openapi/validation/validator.go
+++ b/pkg/openapi/validation/validator.go
@@ -10,31 +10,25 @@ import (
 	validatorErrors "github.com/pb33f/libopenapi-validator/errors"
 	"github.com/pb33f/libopenapi-validator/helpers"
 	"github.com/unkeyed/unkey/pkg/fault"
+	validationtypes "github.com/unkeyed/unkey/pkg/openapi/validation/types"
 )
 
 // ValidationError represents a single field-level validation failure.
-// Fix is non-nil when the validator can suggest a concrete correction.
-type ValidationError struct {
-	Message  string
-	Location string
-	Fix      *string
-}
+type ValidationError = validationtypes.ValidationError
 
 // Result holds the validation outcome when a request is invalid.
-// A nil *Result means the request passed validation.
-type Result struct {
-	Detail string
-	Errors []ValidationError
-}
+type Result = validationtypes.Result
 
 // Validator validates HTTP requests against an OpenAPI specification.
 type Validator struct {
 	validator validator.Validator
 }
 
-// NewFromBytes creates a Validator from a raw OpenAPI spec.
+var _ validationtypes.Validator = (*Validator)(nil)
+
+// NewFromBytes creates a validator from a raw OpenAPI spec.
 // Returns an error if the spec cannot be parsed or is itself invalid.
-func NewFromBytes(spec []byte) (*Validator, error) {
+func NewFromBytes(spec []byte) (validationtypes.Validator, error) {
 	document, err := libopenapi.NewDocument(spec)
 	if err != nil {
 		return nil, fault.Wrap(err, fault.Internal("failed to create OpenAPI document"))

--- a/pkg/zen/middleware_openapi_validation.go
+++ b/pkg/zen/middleware_openapi_validation.go
@@ -2,26 +2,20 @@ package zen
 
 import (
 	"context"
+	"net/http"
 
-	"github.com/unkeyed/unkey/pkg/zen/validation"
+	"github.com/unkeyed/unkey/svc/api/openapi"
 )
+
+// RequestValidator validates an HTTP request against the API contract.
+type RequestValidator interface {
+	Validate(ctx context.Context, req *http.Request) (openapi.BadRequestErrorResponse, bool)
+}
 
 // WithValidation returns middleware that validates incoming requests against
 // an OpenAPI schema. Invalid requests receive a 400 Bad Request response with
 // detailed validation errors.
-//
-// Example:
-//
-//	validator, err := validation.New()
-//	if err != nil {
-//	    log.Fatalf("failed to create validator: %v", err)
-//	}
-//
-//	server.RegisterRoute(
-//	    []zen.Middleware{zen.WithValidation(validator)},
-//	    route,
-//	)
-func WithValidation(validator *validation.Validator) Middleware {
+func WithValidation(validator RequestValidator) Middleware {
 	return func(next HandleFunc) HandleFunc {
 		return func(ctx context.Context, s *Session) error {
 			err, valid := validator.Validate(ctx, s.r)

--- a/pkg/zen/validation/validator.go
+++ b/pkg/zen/validation/validator.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 
 	"github.com/unkeyed/unkey/pkg/ctxutil"
-	core "github.com/unkeyed/unkey/pkg/openapi/validation"
+	validationtypes "github.com/unkeyed/unkey/pkg/openapi/validation/types"
 	"github.com/unkeyed/unkey/pkg/otel/tracing"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
@@ -13,16 +13,12 @@ import (
 // Validator wraps the core OpenAPI validator with tracing and
 // API-specific error formatting.
 type Validator struct {
-	core *core.Validator
+	core validationtypes.Validator
 }
 
-// New creates a Validator backed by the compiled API OpenAPI spec.
-func New() (*Validator, error) {
-	v, err := core.NewFromBytes(openapi.Spec)
-	if err != nil {
-		return nil, err
-	}
-	return &Validator{core: v}, nil
+// New creates a Validator backed by coreValidator.
+func New(coreValidator validationtypes.Validator) *Validator {
+	return &Validator{core: coreValidator}
 }
 
 // Validate checks r against the OpenAPI spec.

--- a/pkg/zen/validation/validator_test.go
+++ b/pkg/zen/validation/validator_test.go
@@ -1,12 +1,16 @@
-package validation
+package validation_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	openapivalidation "github.com/unkeyed/unkey/pkg/openapi/validation"
+	zenvalidation "github.com/unkeyed/unkey/pkg/zen/validation"
+	"github.com/unkeyed/unkey/svc/api/openapi"
 )
 
 func TestSchemaIsValid(t *testing.T) {
-	_, err := New()
+	coreValidator, err := openapivalidation.NewFromBytes(openapi.Spec)
 	require.NoError(t, err)
+	require.NotNil(t, zenvalidation.New(coreValidator))
 }

--- a/svc/api/cancel_test.go
+++ b/svc/api/cancel_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/unkeyed/unkey/pkg/config"
 	sharedconfig "github.com/unkeyed/unkey/pkg/config"
+	openapivalidation "github.com/unkeyed/unkey/pkg/openapi/validation"
 	"github.com/unkeyed/unkey/pkg/testutil/containers"
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/svc/api"
@@ -60,7 +61,7 @@ func TestContextCancellation(t *testing.T) {
 
 	// Start the API server in a goroutine
 	go func() {
-		runErr := api.Run(ctx, config)
+		runErr := api.Run(ctx, config, openapivalidation.NewFromBytes)
 
 		if runErr != nil {
 			// it's really hard to get this error cause the test fails before we read from the channel

--- a/svc/api/integration/harness.go
+++ b/svc/api/integration/harness.go
@@ -15,6 +15,7 @@ import (
 	"github.com/unkeyed/unkey/pkg/counter"
 	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/mysql/sqlcomment"
+	openapivalidation "github.com/unkeyed/unkey/pkg/openapi/validation"
 	"github.com/unkeyed/unkey/pkg/testutil/containers"
 	"github.com/unkeyed/unkey/svc/api"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
@@ -230,7 +231,7 @@ func (h *Harness) RunAPI(config ApiConfig) *ApiCluster {
 				}
 			}()
 
-			err := api.Run(ctx, cfg)
+			err := api.Run(ctx, cfg, openapivalidation.NewFromBytes)
 			if err != nil && ctx.Err() == nil {
 				h.t.Logf("API server %d failed: %v", nodeID, err)
 				select {

--- a/svc/api/internal/testutil/http.go
+++ b/svc/api/internal/testutil/http.go
@@ -35,6 +35,7 @@ import (
 	"github.com/unkeyed/unkey/pkg/hash"
 	"github.com/unkeyed/unkey/pkg/mysql/sqlcomment"
 	mysqltype "github.com/unkeyed/unkey/pkg/mysql/types"
+	openapivalidation "github.com/unkeyed/unkey/pkg/openapi/validation"
 	"github.com/unkeyed/unkey/pkg/rbac"
 	"github.com/unkeyed/unkey/pkg/testutil/containers"
 	"github.com/unkeyed/unkey/pkg/uid"
@@ -42,6 +43,7 @@ import (
 	"github.com/unkeyed/unkey/pkg/zen/validation"
 	"github.com/unkeyed/unkey/svc/api/internal/middleware"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
+	"github.com/unkeyed/unkey/svc/api/openapi"
 	vaulttestutil "github.com/unkeyed/unkey/svc/vault/testutil"
 )
 
@@ -224,8 +226,9 @@ func NewHarness(t *testing.T, configs ...HarnessConfig) *Harness {
 		t.Cleanup(frontlineRequests.Close)
 	}
 
-	validator, err := validation.New()
+	coreValidator, err := openapivalidation.NewFromBytes(openapi.Spec)
 	require.NoError(t, err)
+	validator := validation.New(coreValidator)
 
 	ctr := counter.NewMemory()
 	if cfg.Redis {

--- a/svc/api/internal/testutil/http.go
+++ b/svc/api/internal/testutil/http.go
@@ -34,6 +34,7 @@ import (
 	"github.com/unkeyed/unkey/pkg/hash"
 	"github.com/unkeyed/unkey/pkg/mysql/sqlcomment"
 	mysqltype "github.com/unkeyed/unkey/pkg/mysql/types"
+	openapivalidation "github.com/unkeyed/unkey/pkg/openapi/validation"
 	"github.com/unkeyed/unkey/pkg/rbac"
 	"github.com/unkeyed/unkey/pkg/testutil/containers"
 	"github.com/unkeyed/unkey/pkg/uid"
@@ -41,6 +42,7 @@ import (
 	"github.com/unkeyed/unkey/pkg/zen/validation"
 	"github.com/unkeyed/unkey/svc/api/internal/middleware"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
+	"github.com/unkeyed/unkey/svc/api/openapi"
 	vaulttestutil "github.com/unkeyed/unkey/svc/vault/testutil"
 )
 
@@ -207,8 +209,9 @@ func NewHarness(t *testing.T, configs ...HarnessConfig) *Harness {
 		t.Cleanup(frontlineRequests.Close)
 	}
 
-	validator, err := validation.New()
+	coreValidator, err := openapivalidation.NewFromBytes(openapi.Spec)
 	require.NoError(t, err)
+	validator := validation.New(coreValidator)
 
 	ctr := counter.NewMemory()
 	if cfg.Redis {

--- a/svc/api/routes/services.go
+++ b/svc/api/routes/services.go
@@ -18,7 +18,7 @@ import (
 	"github.com/unkeyed/unkey/pkg/db"
 	githubclient "github.com/unkeyed/unkey/pkg/github"
 	"github.com/unkeyed/unkey/pkg/redaction"
-	"github.com/unkeyed/unkey/pkg/zen/validation"
+	"github.com/unkeyed/unkey/pkg/zen"
 )
 
 // Services aggregates all dependencies required by API route handlers. It acts
@@ -56,8 +56,8 @@ type Services struct {
 	// by the v2 keys.verifyKey handler.
 	KeyVerifications *batch.BatchProcessor[schema.KeyVerification]
 
-	// Validator performs request payload validation using struct tags.
-	Validator *validation.Validator
+	// Validator checks requests against the API's OpenAPI contract.
+	Validator zen.RequestValidator
 
 	// Redactor strips values marked x-unkey-redact in the OpenAPI spec out of
 	// the request and response bodies before they are logged to ClickHouse.

--- a/svc/api/routes/services.go
+++ b/svc/api/routes/services.go
@@ -20,7 +20,7 @@ import (
 	"github.com/unkeyed/unkey/pkg/db"
 	githubclient "github.com/unkeyed/unkey/pkg/github"
 	"github.com/unkeyed/unkey/pkg/redaction"
-	"github.com/unkeyed/unkey/pkg/zen/validation"
+	"github.com/unkeyed/unkey/pkg/zen"
 )
 
 // Services aggregates all dependencies required by API route handlers. It acts
@@ -64,8 +64,8 @@ type Services struct {
 	// drive time deterministically instead of racing the system clock.
 	Clock clock.Clock
 
-	// Validator performs request payload validation using struct tags.
-	Validator *validation.Validator
+	// Validator checks requests against the API's OpenAPI contract.
+	Validator zen.RequestValidator
 
 	// Redactor strips values marked x-unkey-redact in the OpenAPI spec out of
 	// the request and response bodies before they are logged to ClickHouse.

--- a/svc/api/run.go
+++ b/svc/api/run.go
@@ -46,6 +46,7 @@ import (
 	githubclient "github.com/unkeyed/unkey/pkg/github"
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/pkg/mysql/sqlcomment"
+	validationtypes "github.com/unkeyed/unkey/pkg/openapi/validation/types"
 	"github.com/unkeyed/unkey/pkg/otel"
 	"github.com/unkeyed/unkey/pkg/prometheus"
 	"github.com/unkeyed/unkey/pkg/prometheus/lazy"
@@ -62,7 +63,11 @@ import (
 )
 
 // nolint:gocognit
-func Run(ctx context.Context, cfg Config) error {
+func Run(
+	ctx context.Context,
+	cfg Config,
+	newValidator validationtypes.Factory,
+) error {
 	err := cfg.Validate()
 	if err != nil {
 		return fmt.Errorf("bad config: %w", err)
@@ -251,10 +256,11 @@ func Run(ctx context.Context, cfg Config) error {
 
 	r.DeferCtx(srv.Shutdown)
 
-	validator, err := validation.New()
+	requestValidator, err := newValidator(openapi.Spec)
 	if err != nil {
 		return fmt.Errorf("unable to create validator: %w", err)
 	}
+	validator := validation.New(requestValidator)
 
 	// Bodies are logged to ClickHouse verbatim apart from this, so an empty
 	// field set means every annotated secret would be persisted in the clear.

--- a/svc/api/run.go
+++ b/svc/api/run.go
@@ -44,6 +44,7 @@ import (
 	githubclient "github.com/unkeyed/unkey/pkg/github"
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/pkg/mysql/sqlcomment"
+	validationtypes "github.com/unkeyed/unkey/pkg/openapi/validation/types"
 	"github.com/unkeyed/unkey/pkg/otel"
 	"github.com/unkeyed/unkey/pkg/prometheus"
 	"github.com/unkeyed/unkey/pkg/prometheus/lazy"
@@ -60,7 +61,11 @@ import (
 )
 
 // nolint:gocognit
-func Run(ctx context.Context, cfg Config) error {
+func Run(
+	ctx context.Context,
+	cfg Config,
+	newValidator validationtypes.Factory,
+) error {
 	err := cfg.Validate()
 	if err != nil {
 		return fmt.Errorf("bad config: %w", err)
@@ -238,10 +243,11 @@ func Run(ctx context.Context, cfg Config) error {
 
 	r.DeferCtx(srv.Shutdown)
 
-	validator, err := validation.New()
+	requestValidator, err := newValidator(openapi.Spec)
 	if err != nil {
 		return fmt.Errorf("unable to create validator: %w", err)
 	}
+	validator := validation.New(requestValidator)
 
 	// Bodies are logged to ClickHouse verbatim apart from this, so an empty
 	// field set means every annotated secret would be persisted in the clear.

--- a/svc/frontline/internal/policies/engine.go
+++ b/svc/frontline/internal/policies/engine.go
@@ -19,7 +19,6 @@ import (
 	"github.com/unkeyed/unkey/pkg/zen"
 	firewallExec "github.com/unkeyed/unkey/svc/frontline/internal/policies/firewall"
 	keyauthExec "github.com/unkeyed/unkey/svc/frontline/internal/policies/keyauth"
-	openapiExec "github.com/unkeyed/unkey/svc/frontline/internal/policies/openapi"
 	"github.com/unkeyed/unkey/svc/frontline/internal/policies/principal"
 	ratelimitExec "github.com/unkeyed/unkey/svc/frontline/internal/policies/ratelimit"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -35,6 +34,7 @@ type Config struct {
 	RateLimiter      rl.Service
 	Clock            clock.Clock
 	KeyVerifications *batch.BatchProcessor[schema.KeyVerification]
+	OpenAPIExecutor  OpenAPIExecutor
 }
 
 // Evaluator evaluates policies against incoming requests.
@@ -42,12 +42,17 @@ type Evaluator interface {
 	Evaluate(ctx context.Context, sess *zen.Session, req *http.Request, workspaceID, appID string, mw []*frontlinev1.Policy) (Result, error)
 }
 
+// OpenAPIExecutor validates a request against an OpenAPI policy.
+type OpenAPIExecutor interface {
+	Execute(ctx context.Context, sess *zen.Session, req *http.Request, cfg *frontlinev1.OpenApiRequestValidation) (*redaction.Redactor, error)
+}
+
 // Engine implements Evaluator.
 type Engine struct {
 	keyAuth     *keyauthExec.Executor
 	rateLimiter *ratelimitExec.Executor
 	firewall    *firewallExec.Executor
-	openapi     *openapiExec.Executor
+	openapi     OpenAPIExecutor
 	regexCache  *regexCache
 }
 
@@ -76,19 +81,16 @@ func New(cfg Config) (*Engine, error) {
 		assert.NotNil(cfg.RateLimiter, "cfg.RateLimiter must not be nil"),
 		assert.NotNil(cfg.Clock, "cfg.Clock must not be nil"),
 		assert.NotNil(cfg.KeyVerifications, "cfg.KeyVerifications must not be nil"),
+		assert.NotNil(cfg.OpenAPIExecutor, "cfg.OpenAPIExecutor must not be nil"),
 	); err != nil {
 		return nil, err
-	}
-	openapi, err := openapiExec.New(cfg.Clock)
-	if err != nil {
-		return nil, fmt.Errorf("create openapi executor: %w", err)
 	}
 
 	return &Engine{
 		keyAuth:     keyauthExec.New(cfg.KeyService, cfg.Clock, cfg.KeyVerifications),
 		rateLimiter: ratelimitExec.New(cfg.RateLimiter, cfg.Clock),
 		firewall:    firewallExec.New(),
-		openapi:     openapi,
+		openapi:     cfg.OpenAPIExecutor,
 		regexCache:  newRegexCache(),
 	}, nil
 }

--- a/svc/frontline/internal/policies/integration_test.go
+++ b/svc/frontline/internal/policies/integration_test.go
@@ -26,12 +26,14 @@ import (
 	"github.com/unkeyed/unkey/pkg/fault"
 	"github.com/unkeyed/unkey/pkg/hash"
 	"github.com/unkeyed/unkey/pkg/mysql/sqlcomment"
+	openapivalidation "github.com/unkeyed/unkey/pkg/openapi/validation"
 	"github.com/unkeyed/unkey/pkg/ptr"
 	"github.com/unkeyed/unkey/pkg/rbac"
 	"github.com/unkeyed/unkey/pkg/testutil/containers"
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/pkg/zen"
 	"github.com/unkeyed/unkey/svc/frontline/internal/policies"
+	openapiExec "github.com/unkeyed/unkey/svc/frontline/internal/policies/openapi"
 	"github.com/unkeyed/unkey/svc/frontline/internal/policies/principal"
 )
 
@@ -151,11 +153,15 @@ func newTestHarness(t *testing.T) *testHarness {
 	})
 	t.Cleanup(keyVerifications.Close)
 
+	openapiExecutor, err := openapiExec.New(clk, openapivalidation.NewFromBytes)
+	require.NoError(t, err)
+
 	eng, err := policies.New(policies.Config{
 		KeyService:       keyService,
 		RateLimiter:      rateLimiter,
 		Clock:            clk,
 		KeyVerifications: keyVerifications,
+		OpenAPIExecutor:  openapiExecutor,
 	})
 	require.NoError(t, err)
 

--- a/svc/frontline/internal/policies/openapi/executor.go
+++ b/svc/frontline/internal/policies/openapi/executor.go
@@ -10,21 +10,22 @@ import (
 	"github.com/unkeyed/unkey/pkg/clock"
 	"github.com/unkeyed/unkey/pkg/codes"
 	"github.com/unkeyed/unkey/pkg/fault"
-	validation "github.com/unkeyed/unkey/pkg/openapi/validation"
+	validationtypes "github.com/unkeyed/unkey/pkg/openapi/validation/types"
 	"github.com/unkeyed/unkey/pkg/redaction"
 	"github.com/unkeyed/unkey/pkg/zen"
 )
 
 type compiledSpec struct {
-	validator *validation.Validator
+	validator validationtypes.Validator
 	redactor  *redaction.Redactor
 }
 
 type Executor struct {
-	cache cache.Cache[string, *compiledSpec]
+	cache        cache.Cache[string, *compiledSpec]
+	newValidator validationtypes.Factory
 }
 
-func New(clk clock.Clock) (*Executor, error) {
+func New(clk clock.Clock, newValidator validationtypes.Factory) (*Executor, error) {
 	c, err := cache.New(cache.Config[string, *compiledSpec]{
 		Fresh:    time.Hour,
 		Stale:    24 * time.Hour,
@@ -35,7 +36,7 @@ func New(clk clock.Clock) (*Executor, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Executor{cache: c}, nil
+	return &Executor{cache: c, newValidator: newValidator}, nil
 }
 
 func (e *Executor) Execute(
@@ -80,7 +81,7 @@ func (e *Executor) Execute(
 func (e *Executor) getOrCompile(ctx context.Context, spec []byte) (*compiledSpec, error) {
 	v, _, err := e.cache.SWR(ctx, string(spec),
 		func(ctx context.Context) (*compiledSpec, error) {
-			validator, compileErr := validation.NewFromBytes(spec)
+			validator, compileErr := e.newValidator(spec)
 			if compileErr != nil {
 				return nil, compileErr
 			}

--- a/svc/frontline/internal/policies/openapi/executor_test.go
+++ b/svc/frontline/internal/policies/openapi/executor_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/unkeyed/unkey/pkg/clock"
 	"github.com/unkeyed/unkey/pkg/codes"
 	"github.com/unkeyed/unkey/pkg/fault"
+	openapivalidation "github.com/unkeyed/unkey/pkg/openapi/validation"
 )
 
 var minimalSpec = []byte(`
@@ -41,7 +42,7 @@ paths:
 
 func newTestExecutor(t *testing.T) *Executor {
 	t.Helper()
-	e, err := New(clock.New())
+	e, err := New(clock.New(), openapivalidation.NewFromBytes)
 	require.NoError(t, err)
 	return e
 }

--- a/svc/frontline/run.go
+++ b/svc/frontline/run.go
@@ -33,6 +33,7 @@ import (
 	pkgdb "github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/pkg/mysql/sqlcomment"
+	openapivalidation "github.com/unkeyed/unkey/pkg/openapi/validation"
 	"github.com/unkeyed/unkey/pkg/otel"
 	pprofRoute "github.com/unkeyed/unkey/pkg/pprof"
 	"github.com/unkeyed/unkey/pkg/prometheus"
@@ -49,6 +50,7 @@ import (
 	"github.com/unkeyed/unkey/svc/frontline/internal/errorpage"
 	"github.com/unkeyed/unkey/svc/frontline/internal/meta"
 	"github.com/unkeyed/unkey/svc/frontline/internal/policies"
+	openapiExec "github.com/unkeyed/unkey/svc/frontline/internal/policies/openapi"
 	"github.com/unkeyed/unkey/svc/frontline/internal/proxy"
 	"github.com/unkeyed/unkey/svc/frontline/internal/router"
 	"github.com/unkeyed/unkey/svc/frontline/routes"
@@ -516,11 +518,17 @@ func buildEngine(
 	}
 
 	logger.Info("policy engine initialized")
+	openapiExecutor, err := openapiExec.New(clk, openapivalidation.NewFromBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize policy engine: create openapi executor: %w", err)
+	}
+
 	eng, err := policies.New(policies.Config{
 		KeyService:       keyService,
 		RateLimiter:      rlSvc,
 		Clock:            clk,
 		KeyVerifications: keyVerifications,
+		OpenAPIExecutor:  openapiExecutor,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize policy engine: %w", err)

--- a/svc/frontline/run.go
+++ b/svc/frontline/run.go
@@ -32,6 +32,7 @@ import (
 	pkgdb "github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/pkg/mysql/sqlcomment"
+	openapivalidation "github.com/unkeyed/unkey/pkg/openapi/validation"
 	"github.com/unkeyed/unkey/pkg/otel"
 	pprofRoute "github.com/unkeyed/unkey/pkg/pprof"
 	"github.com/unkeyed/unkey/pkg/prometheus"
@@ -47,6 +48,7 @@ import (
 	"github.com/unkeyed/unkey/svc/frontline/internal/db"
 	"github.com/unkeyed/unkey/svc/frontline/internal/errorpage"
 	"github.com/unkeyed/unkey/svc/frontline/internal/policies"
+	openapiExec "github.com/unkeyed/unkey/svc/frontline/internal/policies/openapi"
 	"github.com/unkeyed/unkey/svc/frontline/internal/proxy"
 	"github.com/unkeyed/unkey/svc/frontline/internal/router"
 	"github.com/unkeyed/unkey/svc/frontline/routes"
@@ -508,11 +510,17 @@ func buildEngine(
 	}
 
 	logger.Info("policy engine initialized")
+	openapiExecutor, err := openapiExec.New(clk, openapivalidation.NewFromBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize policy engine: create openapi executor: %w", err)
+	}
+
 	eng, err := policies.New(policies.Config{
 		KeyService:       keyService,
 		RateLimiter:      rlSvc,
 		Clock:            clk,
 		KeyVerifications: keyVerifications,
+		OpenAPIExecutor:  openapiExecutor,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize policy engine: %w", err)

--- a/svc/heimdall/run.go
+++ b/svc/heimdall/run.go
@@ -22,8 +22,9 @@ import (
 	"github.com/unkeyed/unkey/svc/heimdall/internal/metrics"
 	"github.com/unkeyed/unkey/svc/heimdall/internal/network"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/informers"
+	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
+	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 )
@@ -98,9 +99,15 @@ func Run(ctx context.Context, cfg Config) error {
 		return fmt.Errorf("creating kubernetes client: %w", err)
 	}
 
-	factory := informers.NewSharedInformerFactory(clientset, 0)
-	podInformer := factory.Core().V1().Pods().Informer()
-	podLister := factory.Core().V1().Pods().Lister()
+	// Heimdall owns one Pod informer. The aggregate factory imports generated
+	// informers for every Kubernetes resource without adding lifecycle value here.
+	podInformer := coreinformers.NewPodInformer(
+		clientset,
+		corev1.NamespaceAll,
+		0,
+		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+	)
+	podLister := corelisters.NewPodLister(podInformer.GetIndexer())
 
 	collectors := collector.CollectorSetFrom(cfg.Collectors)
 
@@ -146,7 +153,7 @@ func Run(ctx context.Context, cfg Config) error {
 	// drops an event (containerd#3177) or CRI is unavailable. Duplicates
 	// across both paths are absorbed by max-min billing math.
 	//
-	// Register *before* factory.Start so transitions during startup churn
+	// Register before starting the informer so transitions during startup churn
 	// are delivered to the handler. Registering after Start opens a race
 	// window where the initial List + first UpdateFuncs land before the
 	// handler is hooked in, silently dropping those events.
@@ -165,17 +172,14 @@ func Run(ctx context.Context, cfg Config) error {
 		return fmt.Errorf("registering pod event handler: %w", err)
 	}
 
-	factory.Start(ctx.Done())
+	go podInformer.Run(ctx.Done())
 
 	// Refuse to start the collector with an unsynced cache. Without the
 	// check, a sync failure (ctx cancel before initial List completes, API
 	// server unreachable) would leave the lister returning empty results,
 	// every pod on the node would be silently unbilled.
-	synced := factory.WaitForCacheSync(ctx.Done())
-	for resource, ok := range synced {
-		if !ok {
-			return fmt.Errorf("informer cache sync failed for %v", resource)
-		}
+	if !cache.WaitForCacheSync(ctx.Done(), podInformer.HasSynced) {
+		return fmt.Errorf("informer cache sync failed for %T", &corev1.Pod{})
 	}
 
 	metrics.InformerCacheSynced.Set(1)


### PR DESCRIPTION
## Problem:

Heimdall imported Kubernetes informers for every resource even though it only watches Pods. API and Frontline service code also imported the concrete OpenAPI validator.

## Solution:

Use a Pod-only informer in Heimdall. Pass small validator interfaces into API and Frontline services, and create the existing validator in each service entrypoint.

## Impact:

Heimdall still watches Pods. API and Frontline still use the same OpenAPI validator. The Go compiler has fewer package paths to load for these services.

## Testing:

- `mise run build`: passed with zero lint issues.
- `mise run test`: 298 suites completed with 0 failures.