### PR TITLE
fix(krane): exclude terminal pods from active instance state

### DIFF
--- a/svc/krane/internal/deployment/state.go
+++ b/svc/krane/internal/deployment/state.go
@@ -52,9 +52,6 @@ func (c *Controller) buildDeploymentStatus(ctx context.Context, replicaset *apps
 	}
 
 	for _, pod := range pods.Items {
-		if pod.Status.Phase == corev1.PodFailed || pod.Status.Phase == corev1.PodSucceeded {
-			continue
-		}
 		if pod.Status.PodIP == "" {
 			continue
 		}
@@ -93,6 +90,8 @@ func (c *Controller) buildDeploymentStatus(ctx context.Context, replicaset *apps
 			} else {
 				instance.Status = ctrlv1.ReportDeploymentStatusRequest_Update_Instance_STATUS_PENDING
 			}
+		case corev1.PodFailed, corev1.PodSucceeded:
+			continue
 		case corev1.PodUnknown:
 			instance.Status = ctrlv1.ReportDeploymentStatusRequest_Update_Instance_STATUS_UNSPECIFIED
 		}

--- a/svc/krane/internal/deployment/state.go
+++ b/svc/krane/internal/deployment/state.go
@@ -14,15 +14,17 @@ import (
 // buildDeploymentStatus queries the pods belonging to a ReplicaSet and builds a
 // status report for the control plane.
 //
-// The report includes each pod's cluster-local DNS address, CPU and memory limits,
-// and health status. Pods without an IP address are excluded since they can't
-// receive traffic yet. The address format is "{ip-with-dashes}.{namespace}.pod.cluster.local:{port}"
+// The report includes each active pod's cluster-local DNS address, CPU and memory
+// limits, and health status. Pods without an IP address are excluded since they
+// can't receive traffic yet. Failed and succeeded pods are also excluded because
+// the ReplicaSet replaces them but Kubernetes retains their objects for garbage
+// collection. Reporting them would retain a stale instance for every replacement.
+// The address format is "{ip-with-dashes}.{namespace}.pod.cluster.local:{port}"
 // which enables in-cluster DNS resolution without a headless Service.
 //
 // Pod phase is mapped to instance status: Running pods with ContainersReady=True
 // become STATUS_RUNNING, Pending pods and Running pods whose ContainersReady
-// condition is missing or False become STATUS_PENDING, and Failed pods become
-// STATUS_FAILED.
+// condition is missing or False become STATUS_PENDING.
 func (c *Controller) buildDeploymentStatus(ctx context.Context, replicaset *appsv1.ReplicaSet) (*ctrlv1.ReportDeploymentStatusRequest, error) {
 	selector, err := metav1.LabelSelectorAsSelector(replicaset.Spec.Selector)
 	if err != nil {
@@ -50,6 +52,9 @@ func (c *Controller) buildDeploymentStatus(ctx context.Context, replicaset *apps
 	}
 
 	for _, pod := range pods.Items {
+		if pod.Status.Phase == corev1.PodFailed || pod.Status.Phase == corev1.PodSucceeded {
+			continue
+		}
 		if pod.Status.PodIP == "" {
 			continue
 		}
@@ -88,9 +93,7 @@ func (c *Controller) buildDeploymentStatus(ctx context.Context, replicaset *apps
 			} else {
 				instance.Status = ctrlv1.ReportDeploymentStatusRequest_Update_Instance_STATUS_PENDING
 			}
-		case corev1.PodFailed:
-			instance.Status = ctrlv1.ReportDeploymentStatusRequest_Update_Instance_STATUS_FAILED
-		case corev1.PodSucceeded, corev1.PodUnknown:
+		case corev1.PodUnknown:
 			instance.Status = ctrlv1.ReportDeploymentStatusRequest_Update_Instance_STATUS_UNSPECIFIED
 		}
 

--- a/svc/krane/internal/deployment/state_test.go
+++ b/svc/krane/internal/deployment/state_test.go
@@ -71,9 +71,11 @@ func TestBuildDeploymentStatus_PodStatuses(t *testing.T) {
 
 	failed := podBase("pod-failed")
 	failed.Status.Phase = corev1.PodFailed
+	succeeded := podBase("pod-succeeded")
+	succeeded.Status.Phase = corev1.PodSucceeded
 
 	client := fake.NewSimpleClientset(
-		&runningReady, &runningUnready, &runningNoCondition, &pending, &failed,
+		&runningReady, &runningUnready, &runningNoCondition, &pending, &failed, &succeeded,
 	)
 	ctrl := New(Config{
 		ClientSet:     client,
@@ -110,8 +112,6 @@ func TestBuildDeploymentStatus_PodStatuses(t *testing.T) {
 		ctrlv1.ReportDeploymentStatusRequest_Update_Instance_STATUS_PENDING,
 		byName["pod-pending"],
 	)
-	require.Equal(t,
-		ctrlv1.ReportDeploymentStatusRequest_Update_Instance_STATUS_FAILED,
-		byName["pod-failed"],
-	)
+	require.NotContains(t, byName, "pod-failed", "failed pods must not remain active instances")
+	require.NotContains(t, byName, "pod-succeeded", "succeeded pods must not remain active instances")
 }


### PR DESCRIPTION
## Problem:

When k8s replaces a failed pod of our RS it retains the termial pods, which krane reports as active instances which is not true and we dont really want to show them.

## Solution:

We now exclude failed/succeeded pods in our instance table and only show instances that are actually running,

## Impact:

The deployment network view only shows active instances. Replica scheduling and Kubernetes pod garbage collection do not change.

## Testing:

- `mise exec -- rask ./svc/krane/internal/deployment`
- 45 tests passed.