### PR TITLE
fix(api): align permission slug validation across all endpoints

### DIFF
--- a/svc/api/openapi/openapi-generated.yaml
+++ b/svc/api/openapi/openapi-generated.yaml
@@ -1654,7 +1654,8 @@ components:
                         Any permissions that do not exist will be auto created if the root key has permissions, otherwise this operation will fail with a 403 error.
                     items:
                         type: string
-                        minLength: 3
+                        minLength: 1
+                        maxLength: 128
                         pattern: ^[a-zA-Z0-9_:\-\.\*]+$
                         description: Specify the permission by its slug.
             additionalProperties: false
@@ -1806,8 +1807,8 @@ components:
                     items:
                         type: string
                         minLength: 1
-                        maxLength: 100
-                    pattern: "^[a-zA-Z][a-zA-Z0-9._-]*$"
+                        maxLength: 128
+                        pattern: ^[a-zA-Z0-9_:\-\.\*]+$
                     description: |
                         Grants specific permissions directly to this key without requiring role membership.
                         Wildcard permissions like `documents.*` grant access to all sub-permissions including `documents.read` and `documents.write`.
@@ -2025,7 +2026,8 @@ components:
                         After removal, verification checks for these permissions will fail unless granted through roles.
                     items:
                         type: string
-                        minLength: 3
+                        minLength: 1
+                        maxLength: 128
                         pattern: ^[a-zA-Z0-9_:\-\.\*]+$
                         description: Specify the permission by its slug.
             additionalProperties: false
@@ -2163,7 +2165,8 @@ components:
                         Any permissions that do not exist will be auto created if the root key has permissions, otherwise this operation will fail with a 403 error.
                     items:
                         type: string
-                        minLength: 3
+                        minLength: 1
+                        maxLength: 128
                         pattern: ^[a-zA-Z0-9_:\-\.\*]+$
                         description: Specify the permission by its slug.
             additionalProperties: false
@@ -2377,8 +2380,7 @@ components:
                     items:
                         type: string
                         minLength: 1
-                        maxLength: 100
-                        pattern: ^[a-zA-Z0-9_:\-\.\*]+$
+                        maxLength: 128
                         description: |
                             Assigns existing roles to this key for permission management through role-based access control.
                             Roles must already exist in your workspace before assignment.
@@ -2392,8 +2394,8 @@ components:
                     maxItems: 1000
                     items:
                         type: string
-                        minLength: 3
-                        maxLength: 100
+                        minLength: 1
+                        maxLength: 128
                         pattern: ^[a-zA-Z0-9_:\-\.\*]+$
                         description: |
                             Grants specific permissions directly to this key without requiring role membership.
@@ -2546,7 +2548,7 @@ components:
                     type: string
                     minLength: 1
                     maxLength: 128
-                    pattern: "^[a-zA-Z][a-zA-Z0-9._-]*$"
+                    pattern: ^[a-zA-Z0-9_:\-\.\*]+$
                     description: |
                         Creates a URL-safe identifier for this permission that can be used in APIs and integrations.
                         Must start with a letter and contain only letters, numbers, periods, underscores, and hyphens.
@@ -2632,9 +2634,9 @@ components:
             properties:
                 permission:
                     type: string
-                    minLength: 3
-                    maxLength: 255
-                    pattern: "^[a-zA-Z][a-zA-Z0-9._-]*$"
+                    minLength: 1
+                    maxLength: 128
+                    pattern: ^[a-zA-Z0-9_:\-\.\*]+$
                     description: |
                         Specifies which permission to permanently delete from your workspace.
 
@@ -2706,9 +2708,9 @@ components:
             properties:
                 permission:
                     type: string
-                    minLength: 3
-                    maxLength: 255
-                    pattern: "^[a-zA-Z][a-zA-Z0-9._-]*$"
+                    minLength: 1
+                    maxLength: 128
+                    pattern: ^[a-zA-Z0-9_:\-\.\*]+$
                     description: |
                         The unique identifier of the permission to retrieve. Must be a valid permission ID that begins with 'perm_' and exists within your workspace.
                     example: perm_1234567890abcdef
@@ -5724,7 +5726,7 @@ components:
                     items:
                         type: string
                         minLength: 1
-                        maxLength: 100
+                        maxLength: 128
                     description: |
                         Assigns existing roles to this key for permission management through role-based access control.
                         Roles must already exist in your workspace before assignment.
@@ -5739,7 +5741,8 @@ components:
                     items:
                         type: string
                         minLength: 1
-                        maxLength: 100
+                        maxLength: 128
+                        pattern: ^[a-zA-Z0-9_:\-\.\*]+$
                     description: |
                         Grants specific permissions directly to this key without requiring role membership.
                         Wildcard permissions like `documents.*` grant access to all sub-permissions including `documents.read` and `documents.write`.

--- a/svc/api/openapi/spec/paths/v2/keys/addPermissions/V2KeysAddPermissionsRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/keys/addPermissions/V2KeysAddPermissionsRequestBody.yaml
@@ -25,7 +25,10 @@ properties:
       Any permissions that do not exist will be auto created if the root key has permissions, otherwise this operation will fail with a 403 error.
     items:
       type: string
-      minLength: 3
+      minLength: 1
+      # Matches the permissions.slug column (varchar(128)). See createKey for
+      # the shared permission slug rule.
+      maxLength: 128
       pattern: ^[a-zA-Z0-9_:\-\.\*]+$
       description: Specify the permission by its slug.
 additionalProperties: false

--- a/svc/api/openapi/spec/paths/v2/keys/createKey/V2KeysCreateKeyRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/keys/createKey/V2KeysCreateKeyRequestBody.yaml
@@ -100,8 +100,15 @@ properties:
     items:
       type: string
       minLength: 1
-      maxLength: 100 # Keep permission names concise and readable
-    pattern: "^[a-zA-Z][a-zA-Z0-9._-]*$"
+      # Matches the permissions.slug column (varchar(128)).
+      maxLength: 128
+      # Slugs are machine identifiers, so unlike role names they do carry a
+      # pattern. The character set covers what customers actually create:
+      # dotted slugs (documents.read), wildcards (documents.*), colons
+      # (api:read) and leading digits (2fa.read). Keep this rule identical
+      # across every endpoint that accepts a permission slug and in the
+      # dashboard.
+      pattern: ^[a-zA-Z0-9_:\-\.\*]+$
     description: |
       Grants specific permissions directly to this key without requiring role membership.
       Wildcard permissions like `documents.*` grant access to all sub-permissions including `documents.read` and `documents.write`.

--- a/svc/api/openapi/spec/paths/v2/keys/migrateKeys/V2KeysMigrateKeyData.yaml
+++ b/svc/api/openapi/spec/paths/v2/keys/migrateKeys/V2KeysMigrateKeyData.yaml
@@ -49,7 +49,8 @@ properties:
     items:
       type: string
       minLength: 1
-      maxLength: 100 # Keep role names concise and readable
+      # See createKey for the shared role name rule.
+      maxLength: 128
     description: |
       Assigns existing roles to this key for permission management through role-based access control.
       Roles must already exist in your workspace before assignment.
@@ -64,7 +65,9 @@ properties:
     items:
       type: string
       minLength: 1
-      maxLength: 100 # Keep permission names concise and readable
+      # See createKey for the shared permission slug rule.
+      maxLength: 128
+      pattern: ^[a-zA-Z0-9_:\-\.\*]+$
     description: |
       Grants specific permissions directly to this key without requiring role membership.
       Wildcard permissions like `documents.*` grant access to all sub-permissions including `documents.read` and `documents.write`.

--- a/svc/api/openapi/spec/paths/v2/keys/removePermissions/V2KeysRemovePermissionsRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/keys/removePermissions/V2KeysRemovePermissionsRequestBody.yaml
@@ -24,7 +24,10 @@ properties:
       After removal, verification checks for these permissions will fail unless granted through roles.
     items:
       type: string
-      minLength: 3
+      minLength: 1
+      # Matches the permissions.slug column (varchar(128)). See createKey for
+      # the shared permission slug rule.
+      maxLength: 128
       pattern: ^[a-zA-Z0-9_:\-\.\*]+$
       description: Specify the permission by its slug.
 additionalProperties: false

--- a/svc/api/openapi/spec/paths/v2/keys/setPermissions/V2KeysSetPermissionsRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/keys/setPermissions/V2KeysSetPermissionsRequestBody.yaml
@@ -27,7 +27,10 @@ properties:
       Any permissions that do not exist will be auto created if the root key has permissions, otherwise this operation will fail with a 403 error.
     items:
       type: string
-      minLength: 3
+      minLength: 1
+      # Matches the permissions.slug column (varchar(128)). See createKey for
+      # the shared permission slug rule.
+      maxLength: 128
       pattern: ^[a-zA-Z0-9_:\-\.\*]+$
       description: Specify the permission by its slug.
 additionalProperties: false

--- a/svc/api/openapi/spec/paths/v2/keys/updateKey/V2KeysUpdateKeyRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/keys/updateKey/V2KeysUpdateKeyRequestBody.yaml
@@ -107,8 +107,10 @@ properties:
     items:
       type: string
       minLength: 1
-      maxLength: 100 # Keep role names concise and readable
-      pattern: ^[a-zA-Z0-9_:\-\.\*]+$
+      # 128 matches permissions.slug (varchar(128)) so this field does not have
+      # to narrow later when roles start accepting slugs. See createKey for why
+      # no character pattern is applied to role names.
+      maxLength: 128
       description: |
         Assigns existing roles to this key for permission management through role-based access control.
         Roles must already exist in your workspace before assignment.
@@ -122,8 +124,10 @@ properties:
     maxItems: 1000 # Allow extensive permission sets for complex applications
     items:
       type: string
-      minLength: 3
-      maxLength: 100
+      minLength: 1
+      # Matches the permissions.slug column (varchar(128)). See createKey for
+      # the shared permission slug rule.
+      maxLength: 128
       pattern: ^[a-zA-Z0-9_:\-\.\*]+$
       description: |
         Grants specific permissions directly to this key without requiring role membership.

--- a/svc/api/openapi/spec/paths/v2/permissions/createPermission/V2PermissionsCreatePermissionRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/permissions/createPermission/V2PermissionsCreatePermissionRequestBody.yaml
@@ -18,8 +18,10 @@ properties:
   slug:
     type: string
     minLength: 1
+    # Matches the permissions.slug column (varchar(128)). See createKey for
+    # the shared permission slug rule.
     maxLength: 128
-    pattern: "^[a-zA-Z][a-zA-Z0-9._-]*$"
+    pattern: ^[a-zA-Z0-9_:\-\.\*]+$
     description: |
       Creates a URL-safe identifier for this permission that can be used in APIs and integrations.
       Must start with a letter and contain only letters, numbers, periods, underscores, and hyphens.

--- a/svc/api/openapi/spec/paths/v2/permissions/deletePermission/V2PermissionsDeletePermissionRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/permissions/deletePermission/V2PermissionsDeletePermissionRequestBody.yaml
@@ -4,9 +4,11 @@ required:
 properties:
   permission:
     type: string
-    minLength: 3
-    maxLength: 255
-    pattern: "^[a-zA-Z][a-zA-Z0-9._-]*$"
+    minLength: 1
+    # Accepts a permission ID or slug. Matches the permissions.slug column
+    # (varchar(128)). See createKey for the shared permission slug rule.
+    maxLength: 128
+    pattern: ^[a-zA-Z0-9_:\-\.\*]+$
     description: |
       Specifies which permission to permanently delete from your workspace.
 

--- a/svc/api/openapi/spec/paths/v2/permissions/getPermission/V2PermissionsGetPermissionRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/permissions/getPermission/V2PermissionsGetPermissionRequestBody.yaml
@@ -4,9 +4,11 @@ required:
 properties:
   permission:
     type: string
-    minLength: 3
-    maxLength: 255
-    pattern: "^[a-zA-Z][a-zA-Z0-9._-]*$"
+    minLength: 1
+    # Accepts a permission ID or slug. Matches the permissions.slug column
+    # (varchar(128)). See createKey for the shared permission slug rule.
+    maxLength: 128
+    pattern: ^[a-zA-Z0-9_:\-\.\*]+$
     description: |
       The unique identifier of the permission to retrieve. Must be a valid permission ID that begins with 'perm_' and exists within your workspace.
     example: perm_1234567890abcdef

--- a/svc/api/routes/v2_keys_create_key/200_test.go
+++ b/svc/api/routes/v2_keys_create_key/200_test.go
@@ -641,7 +641,12 @@ func TestCreateKeyWithRolesAndPermissions(t *testing.T) {
 		h.CreateRole(seed.CreateRoleRequest{Name: name, WorkspaceID: workspaceID})
 	}
 
-	permissionSlugs := []string{"documents.read", "settings.view", "billing_reports.view"}
+	// Slug shapes the spec used to disagree on across endpoints: a plain dotted
+	// slug, a wildcard, a leading digit, and a colon. createKey accepted all of
+	// them only because its `pattern` was indented at the array level and so
+	// ignored entirely; the sibling permission endpoints rejected the last
+	// three outright.
+	permissionSlugs := []string{"documents.read", "documents.*", "2fa.read", "api:read"}
 
 	res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{
 		ApiId:       api.ID,

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/_components/create-key/create-key.schema.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/_components/create-key/create-key.schema.ts
@@ -1,3 +1,4 @@
+import { permissionSlugPattern } from "@/app/(app)/[workspaceSlug]/authorization/permissions/components/upsert-permission/upsert-permission.schema";
 import { createConditionalSchema, metadataSchema } from "@/lib/schemas/metadata";
 import { z } from "zod";
 
@@ -262,10 +263,16 @@ export const expirationSchema = z.object({
 // so role names do not have to narrow later when roles start accepting slugs.
 // Keep in step with roleNameSchema on the role editor.
 //
-// Permission slugs are still capped at 100 by the spec even though
-// permissions.slug is varchar(128); keep this in step when that is widened.
+// Permission slugs are machine identifiers and do carry a pattern. Keep both
+// the pattern and the 128 cap in step with permissionSlugSchema on the
+// permission editor.
 const roleNameItemSchema = z.string().trim().min(1).max(128);
-const permissionSlugItemSchema = z.string().trim().min(1).max(100);
+const permissionSlugItemSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(128)
+  .refine((slug) => permissionSlugPattern.test(slug));
 
 const uniqueStrings = (items: string[]) => [...new Set(items)];
 

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/authorization/permissions/components/upsert-permission/upsert-permission.schema.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/authorization/permissions/components/upsert-permission/upsert-permission.schema.ts
@@ -11,11 +11,20 @@ export const permissionNameSchema = z
     error: "Permission name cannot contain consecutive spaces",
   });
 
+// Mirrors the shared permission slug rule in the OpenAPI spec, so a slug
+// created here can always be assigned to a key. Allows dotted slugs
+// (documents.read), wildcards (documents.*), colons (api:read) and leading
+// digits (2fa.read); rejects whitespace. 128 matches permissions.slug.
+export const permissionSlugPattern = /^[a-zA-Z0-9_:\-.*]+$/;
+
 export const permissionSlugSchema = z
   .string()
   .trim()
   .min(2, { message: "Permission slug must be at least 2 characters long" })
-  .max(128, { message: "Permission slug cannot exceed 128 characters" });
+  .max(128, { message: "Permission slug cannot exceed 128 characters" })
+  .refine((slug) => permissionSlugPattern.test(slug), {
+    error: "Permission slug can only contain letters, numbers, and the characters _ : - . *",
+  });
 
 export const permissionDescriptionSchema = z
   .string()


### PR DESCRIPTION
Follow-up to #6976, which fixed the same class of problem for role names.

## The problem

Eight endpoints accept a permission slug, and each carried its own hand-copied
copy of the validation rules. They had drifted into **three different regexes
and three different length caps** against a single `permissions.slug
varchar(128)` column:

| endpoint | `documents.read` | `documents.*` | `2fa.read` | `api:read` | 129 chars |
|---|---|---|---|---|---|
| `keys.createKey` | ok | ok | ok | ok | REJECT (>100) |
| `keys.updateKey` | ok | ok | ok | ok | REJECT (>100) |
| `keys.addPermissions` | ok | ok | ok | ok | ok (unbounded) |
| `keys.setPermissions` | ok | ok | ok | ok | ok (unbounded) |
| `keys.removePermissions` | ok | ok | ok | ok | ok (unbounded) |
| `permissions.getPermission` | ok | **REJECT** | **REJECT** | **REJECT** | ok |
| `permissions.deletePermission` | ok | **REJECT** | **REJECT** | **REJECT** | ok |
| `permissions.createPermission` | ok | **REJECT** | **REJECT** | **REJECT** | REJECT (>128) |

Two things stand out:

- **`permissions.createPermission` rejects `documents.*`** — you cannot create a
  wildcard permission through the API, even though wildcards are core to the
  RBAC model and the field's own description advertises them. `keys.addPermissions`
  meanwhile accepts one and auto-creates it.
- **`keys.createKey` enforces no character rule at all.** Its `pattern` is
  indented at the array level rather than under `items`, so JSON Schema ignores
  it. That bug was load-bearing: it is the only reason wildcards work on the
  create path today.

The practical effect is permissions that are creatable but unassignable, or
assignable on one endpoint and refused by its sibling.

## The fix

One rule, applied everywhere a permission slug is accepted:

- `minLength: 1`
- `maxLength: 128` — matches the `permissions.slug` column
- `pattern: ^[a-zA-Z0-9_:\-\.\*]+$` — dotted slugs, wildcards, colons and
  leading digits; rejects whitespace

Unlike role names in #6976, a pattern *is* justified here: a slug is a machine
identifier, not a display label.

The dashboard gets the same rule. `permissionSlugSchema` had no character rule
at all, so the permission editor was looser than the API and could mint a slug
that key creation would then refuse — exactly the shape of the role name bug.
`permissionSlugItemSchema` on the create-key form also moves 100 to 128.

Root key URN permissions (`unkey:v1:ws_123:keyspaces/ks_456#create_key`) contain
`/` and `#` and are deliberately **not** covered: they are managed through the
dedicated `updateRootKeyPermissions` trpc router and never touch these endpoints.

## Verification

Every endpoint now returns identical verdicts for every slug shape, checked
against the compiled spec through the real `libopenapi-validator`:

```
endpoint                     |documents.read|documents.*|2fa.read|api:read|perm_abc123|space  |len128|len129
keys.createKey               |ok      |ok      |ok      |ok      |ok      |REJ:pat|ok    |REJ:len
keys.updateKey               |ok      |ok      |ok      |ok      |ok      |REJ:pat|ok    |REJ:len
keys.addPermissions          |ok      |ok      |ok      |ok      |ok      |REJ:pat|ok    |REJ:len
keys.setPermissions          |ok      |ok      |ok      |ok      |ok      |REJ:pat|ok    |REJ:len
keys.removePermissions       |ok      |ok      |ok      |ok      |ok      |REJ:pat|ok    |REJ:len
permissions.createPermission |ok      |ok      |ok      |ok      |ok      |REJ:pat|ok    |REJ:len
permissions.getPermission    |ok      |ok      |ok      |ok      |ok      |REJ:pat|ok    |REJ:len
permissions.deletePermission |ok      |ok      |ok      |ok      |ok      |REJ:pat|ok    |REJ:len
```

`TestCreateKeyWithRolesAndPermissions` now exercises a wildcard, a leading digit
and a colon, none of which had passing coverage anywhere before. All 16 role and
permission route packages pass, plus dashboard tests, typecheck and biome.

## Breaking change surface

Narrowing is limited to the add/set/removePermissions trio, which were
previously unbounded and now cap at 128 — the column has always been
`varchar(128)`, so a longer slug could never have been stored anyway.
Everything else is a widening.