### PR TITLE
fix(api): stop validating the API name as if it were a slug

### DIFF
--- a/svc/api/openapi/gen.go
+++ b/svc/api/openapi/gen.go
@@ -1502,8 +1502,8 @@ type V2AnalyticsGetVerificationsResponseData = []map[string]interface{}
 
 // V2ApisCreateApiRequestBody defines model for V2ApisCreateApiRequestBody.
 type V2ApisCreateApiRequestBody struct {
-	// Name Unique identifier for this API namespace within your workspace.
-	// Use descriptive names like 'payment-service-prod' or 'user-api-dev' to clearly identify purpose and environment.
+	// Name Human-readable name for this API within your workspace.
+	// Use descriptive names like 'Payment Service (prod)' or 'user-api-dev' to clearly identify purpose and environment.
 	Name string `json:"name"`
 }
 

--- a/svc/api/openapi/openapi-generated.yaml
+++ b/svc/api/openapi/openapi-generated.yaml
@@ -1654,7 +1654,8 @@ components:
                         Any permissions that do not exist will be auto created if the root key has permissions, otherwise this operation will fail with a 403 error.
                     items:
                         type: string
-                        minLength: 3
+                        minLength: 1
+                        maxLength: 128
                         pattern: ^[a-zA-Z0-9_:\-\.\*]+$
                         description: Specify the permission by its slug.
             additionalProperties: false
@@ -1806,8 +1807,8 @@ components:
                     items:
                         type: string
                         minLength: 1
-                        maxLength: 100
-                    pattern: "^[a-zA-Z][a-zA-Z0-9._-]*$"
+                        maxLength: 128
+                        pattern: ^[a-zA-Z0-9_:\-\.\*]+$
                     description: |
                         Grants specific permissions directly to this key without requiring role membership.
                         Wildcard permissions like `documents.*` grant access to all sub-permissions including `documents.read` and `documents.write`.
@@ -2025,7 +2026,8 @@ components:
                         After removal, verification checks for these permissions will fail unless granted through roles.
                     items:
                         type: string
-                        minLength: 3
+                        minLength: 1
+                        maxLength: 128
                         pattern: ^[a-zA-Z0-9_:\-\.\*]+$
                         description: Specify the permission by its slug.
             additionalProperties: false
@@ -2163,7 +2165,8 @@ components:
                         Any permissions that do not exist will be auto created if the root key has permissions, otherwise this operation will fail with a 403 error.
                     items:
                         type: string
-                        minLength: 3
+                        minLength: 1
+                        maxLength: 128
                         pattern: ^[a-zA-Z0-9_:\-\.\*]+$
                         description: Specify the permission by its slug.
             additionalProperties: false
@@ -2377,8 +2380,7 @@ components:
                     items:
                         type: string
                         minLength: 1
-                        maxLength: 100
-                        pattern: ^[a-zA-Z0-9_:\-\.\*]+$
+                        maxLength: 128
                         description: |
                             Assigns existing roles to this key for permission management through role-based access control.
                             Roles must already exist in your workspace before assignment.
@@ -2392,8 +2394,8 @@ components:
                     maxItems: 1000
                     items:
                         type: string
-                        minLength: 3
-                        maxLength: 100
+                        minLength: 1
+                        maxLength: 128
                         pattern: ^[a-zA-Z0-9_:\-\.\*]+$
                         description: |
                             Grants specific permissions directly to this key without requiring role membership.
@@ -2546,7 +2548,7 @@ components:
                     type: string
                     minLength: 1
                     maxLength: 128
-                    pattern: "^[a-zA-Z][a-zA-Z0-9._-]*$"
+                    pattern: ^[a-zA-Z0-9_:\-\.\*]+$
                     description: |
                         Creates a URL-safe identifier for this permission that can be used in APIs and integrations.
                         Must start with a letter and contain only letters, numbers, periods, underscores, and hyphens.
@@ -2632,9 +2634,9 @@ components:
             properties:
                 permission:
                     type: string
-                    minLength: 3
-                    maxLength: 255
-                    pattern: "^[a-zA-Z][a-zA-Z0-9._-]*$"
+                    minLength: 1
+                    maxLength: 128
+                    pattern: ^[a-zA-Z0-9_:\-\.\*]+$
                     description: |
                         Specifies which permission to permanently delete from your workspace.
 
@@ -2706,9 +2708,9 @@ components:
             properties:
                 permission:
                     type: string
-                    minLength: 3
-                    maxLength: 255
-                    pattern: "^[a-zA-Z][a-zA-Z0-9._-]*$"
+                    minLength: 1
+                    maxLength: 128
+                    pattern: ^[a-zA-Z0-9_:\-\.\*]+$
                     description: |
                         The unique identifier of the permission to retrieve. Must be a valid permission ID that begins with 'perm_' and exists within your workspace.
                     example: perm_1234567890abcdef
@@ -5724,7 +5726,7 @@ components:
                     items:
                         type: string
                         minLength: 1
-                        maxLength: 100
+                        maxLength: 128
                     description: |
                         Assigns existing roles to this key for permission management through role-based access control.
                         Roles must already exist in your workspace before assignment.
@@ -5739,7 +5741,8 @@ components:
                     items:
                         type: string
                         minLength: 1
-                        maxLength: 100
+                        maxLength: 128
+                        pattern: ^[a-zA-Z0-9_:\-\.\*]+$
                     description: |
                         Grants specific permissions directly to this key without requiring role membership.
                         Wildcard permissions like `documents.*` grant access to all sub-permissions including `documents.read` and `documents.write`.

--- a/svc/api/openapi/openapi-generated.yaml
+++ b/svc/api/openapi/openapi-generated.yaml
@@ -217,12 +217,11 @@ components:
                 name:
                     type: string
                     minLength: 3
-                    maxLength: 255
-                    pattern: "^[a-zA-Z][a-zA-Z0-9._-]*$"
+                    maxLength: 256
                     description: |
-                        Unique identifier for this API namespace within your workspace.
-                        Use descriptive names like 'payment-service-prod' or 'user-api-dev' to clearly identify purpose and environment.
-                    example: payment-service-production
+                        Human-readable name for this API within your workspace.
+                        Use descriptive names like 'Payment Service (prod)' or 'user-api-dev' to clearly identify purpose and environment.
+                    example: Payment Service (prod)
             additionalProperties: false
         V2ApisCreateApiResponseBody:
             type: object
@@ -3602,7 +3601,7 @@ components:
                 name:
                     type: string
                     minLength: 3
-                    maxLength: 255
+                    maxLength: 256
                     description: |
                         The internal name of this API as specified during creation.
                         Used for organization and identification within your workspace.

--- a/svc/api/openapi/spec/paths/v2/apis/createApi/V2ApisCreateApiRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/apis/createApi/V2ApisCreateApiRequestBody.yaml
@@ -5,12 +5,17 @@ properties:
   name:
     type: string
     minLength: 3
-    maxLength: 255 # Reasonable upper bound for API names
-    pattern: "^[a-zA-Z][a-zA-Z0-9._-]*$" # Must start with letter, then alphanumeric/underscore/dot/hyphen
+    # Matches the apis.name column (varchar(256)). No character pattern: the
+    # name is a human-readable label, not an identifier. There is no slug
+    # column and no uniqueness constraint behind it, and no endpoint resolves
+    # an API by name — createApi, getApi, deleteApi and listKeys all take an
+    # apiId — so a slug-shaped rule here only rejects names the dashboard
+    # already lets people create.
+    maxLength: 256
     description: |
-      Unique identifier for this API namespace within your workspace.
-      Use descriptive names like 'payment-service-prod' or 'user-api-dev' to clearly identify purpose and environment.
-    example: payment-service-production
+      Human-readable name for this API within your workspace.
+      Use descriptive names like 'Payment Service (prod)' or 'user-api-dev' to clearly identify purpose and environment.
+    example: Payment Service (prod)
 additionalProperties: false
 examples:
   basic:

--- a/svc/api/openapi/spec/paths/v2/apis/getApi/V2ApisGetApiResponseData.yaml
+++ b/svc/api/openapi/spec/paths/v2/apis/getApi/V2ApisGetApiResponseData.yaml
@@ -14,7 +14,8 @@ properties:
   name:
     type: string
     minLength: 3
-    maxLength: 255
+    # Matches the apis.name column (varchar(256)). See createApi.
+    maxLength: 256
     description: |
       The internal name of this API as specified during creation.
       Used for organization and identification within your workspace.

--- a/svc/api/openapi/spec/paths/v2/keys/addPermissions/V2KeysAddPermissionsRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/keys/addPermissions/V2KeysAddPermissionsRequestBody.yaml
@@ -25,7 +25,10 @@ properties:
       Any permissions that do not exist will be auto created if the root key has permissions, otherwise this operation will fail with a 403 error.
     items:
       type: string
-      minLength: 3
+      minLength: 1
+      # Matches the permissions.slug column (varchar(128)). See createKey for
+      # the shared permission slug rule.
+      maxLength: 128
       pattern: ^[a-zA-Z0-9_:\-\.\*]+$
       description: Specify the permission by its slug.
 additionalProperties: false

--- a/svc/api/openapi/spec/paths/v2/keys/createKey/V2KeysCreateKeyRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/keys/createKey/V2KeysCreateKeyRequestBody.yaml
@@ -100,8 +100,15 @@ properties:
     items:
       type: string
       minLength: 1
-      maxLength: 100 # Keep permission names concise and readable
-    pattern: "^[a-zA-Z][a-zA-Z0-9._-]*$"
+      # Matches the permissions.slug column (varchar(128)).
+      maxLength: 128
+      # Slugs are machine identifiers, so unlike role names they do carry a
+      # pattern. The character set covers what customers actually create:
+      # dotted slugs (documents.read), wildcards (documents.*), colons
+      # (api:read) and leading digits (2fa.read). Keep this rule identical
+      # across every endpoint that accepts a permission slug and in the
+      # dashboard.
+      pattern: ^[a-zA-Z0-9_:\-\.\*]+$
     description: |
       Grants specific permissions directly to this key without requiring role membership.
       Wildcard permissions like `documents.*` grant access to all sub-permissions including `documents.read` and `documents.write`.

--- a/svc/api/openapi/spec/paths/v2/keys/migrateKeys/V2KeysMigrateKeyData.yaml
+++ b/svc/api/openapi/spec/paths/v2/keys/migrateKeys/V2KeysMigrateKeyData.yaml
@@ -49,7 +49,8 @@ properties:
     items:
       type: string
       minLength: 1
-      maxLength: 100 # Keep role names concise and readable
+      # See createKey for the shared role name rule.
+      maxLength: 128
     description: |
       Assigns existing roles to this key for permission management through role-based access control.
       Roles must already exist in your workspace before assignment.
@@ -64,7 +65,9 @@ properties:
     items:
       type: string
       minLength: 1
-      maxLength: 100 # Keep permission names concise and readable
+      # See createKey for the shared permission slug rule.
+      maxLength: 128
+      pattern: ^[a-zA-Z0-9_:\-\.\*]+$
     description: |
       Grants specific permissions directly to this key without requiring role membership.
       Wildcard permissions like `documents.*` grant access to all sub-permissions including `documents.read` and `documents.write`.

--- a/svc/api/openapi/spec/paths/v2/keys/removePermissions/V2KeysRemovePermissionsRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/keys/removePermissions/V2KeysRemovePermissionsRequestBody.yaml
@@ -24,7 +24,10 @@ properties:
       After removal, verification checks for these permissions will fail unless granted through roles.
     items:
       type: string
-      minLength: 3
+      minLength: 1
+      # Matches the permissions.slug column (varchar(128)). See createKey for
+      # the shared permission slug rule.
+      maxLength: 128
       pattern: ^[a-zA-Z0-9_:\-\.\*]+$
       description: Specify the permission by its slug.
 additionalProperties: false

--- a/svc/api/openapi/spec/paths/v2/keys/setPermissions/V2KeysSetPermissionsRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/keys/setPermissions/V2KeysSetPermissionsRequestBody.yaml
@@ -27,7 +27,10 @@ properties:
       Any permissions that do not exist will be auto created if the root key has permissions, otherwise this operation will fail with a 403 error.
     items:
       type: string
-      minLength: 3
+      minLength: 1
+      # Matches the permissions.slug column (varchar(128)). See createKey for
+      # the shared permission slug rule.
+      maxLength: 128
       pattern: ^[a-zA-Z0-9_:\-\.\*]+$
       description: Specify the permission by its slug.
 additionalProperties: false

--- a/svc/api/openapi/spec/paths/v2/keys/updateKey/V2KeysUpdateKeyRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/keys/updateKey/V2KeysUpdateKeyRequestBody.yaml
@@ -107,8 +107,10 @@ properties:
     items:
       type: string
       minLength: 1
-      maxLength: 100 # Keep role names concise and readable
-      pattern: ^[a-zA-Z0-9_:\-\.\*]+$
+      # 128 matches permissions.slug (varchar(128)) so this field does not have
+      # to narrow later when roles start accepting slugs. See createKey for why
+      # no character pattern is applied to role names.
+      maxLength: 128
       description: |
         Assigns existing roles to this key for permission management through role-based access control.
         Roles must already exist in your workspace before assignment.
@@ -122,8 +124,10 @@ properties:
     maxItems: 1000 # Allow extensive permission sets for complex applications
     items:
       type: string
-      minLength: 3
-      maxLength: 100
+      minLength: 1
+      # Matches the permissions.slug column (varchar(128)). See createKey for
+      # the shared permission slug rule.
+      maxLength: 128
       pattern: ^[a-zA-Z0-9_:\-\.\*]+$
       description: |
         Grants specific permissions directly to this key without requiring role membership.

--- a/svc/api/openapi/spec/paths/v2/permissions/createPermission/V2PermissionsCreatePermissionRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/permissions/createPermission/V2PermissionsCreatePermissionRequestBody.yaml
@@ -18,8 +18,10 @@ properties:
   slug:
     type: string
     minLength: 1
+    # Matches the permissions.slug column (varchar(128)). See createKey for
+    # the shared permission slug rule.
     maxLength: 128
-    pattern: "^[a-zA-Z][a-zA-Z0-9._-]*$"
+    pattern: ^[a-zA-Z0-9_:\-\.\*]+$
     description: |
       Creates a URL-safe identifier for this permission that can be used in APIs and integrations.
       Must start with a letter and contain only letters, numbers, periods, underscores, and hyphens.

--- a/svc/api/openapi/spec/paths/v2/permissions/deletePermission/V2PermissionsDeletePermissionRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/permissions/deletePermission/V2PermissionsDeletePermissionRequestBody.yaml
@@ -4,9 +4,11 @@ required:
 properties:
   permission:
     type: string
-    minLength: 3
-    maxLength: 255
-    pattern: "^[a-zA-Z][a-zA-Z0-9._-]*$"
+    minLength: 1
+    # Accepts a permission ID or slug. Matches the permissions.slug column
+    # (varchar(128)). See createKey for the shared permission slug rule.
+    maxLength: 128
+    pattern: ^[a-zA-Z0-9_:\-\.\*]+$
     description: |
       Specifies which permission to permanently delete from your workspace.
 

--- a/svc/api/openapi/spec/paths/v2/permissions/getPermission/V2PermissionsGetPermissionRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/permissions/getPermission/V2PermissionsGetPermissionRequestBody.yaml
@@ -4,9 +4,11 @@ required:
 properties:
   permission:
     type: string
-    minLength: 3
-    maxLength: 255
-    pattern: "^[a-zA-Z][a-zA-Z0-9._-]*$"
+    minLength: 1
+    # Accepts a permission ID or slug. Matches the permissions.slug column
+    # (varchar(128)). See createKey for the shared permission slug rule.
+    maxLength: 128
+    pattern: ^[a-zA-Z0-9_:\-\.\*]+$
     description: |
       The unique identifier of the permission to retrieve. Must be a valid permission ID that begins with 'perm_' and exists within your workspace.
     example: perm_1234567890abcdef

--- a/svc/api/routes/v2_keys_create_key/200_test.go
+++ b/svc/api/routes/v2_keys_create_key/200_test.go
@@ -641,7 +641,12 @@ func TestCreateKeyWithRolesAndPermissions(t *testing.T) {
 		h.CreateRole(seed.CreateRoleRequest{Name: name, WorkspaceID: workspaceID})
 	}
 
-	permissionSlugs := []string{"documents.read", "settings.view", "billing_reports.view"}
+	// Slug shapes the spec used to disagree on across endpoints: a plain dotted
+	// slug, a wildcard, a leading digit, and a colon. createKey accepted all of
+	// them only because its `pattern` was indented at the array level and so
+	// ignored entirely; the sibling permission endpoints rejected the last
+	// three outright.
+	permissionSlugs := []string{"documents.read", "documents.*", "2fa.read", "api:read"}
 
 	res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{
 		ApiId:       api.ID,

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/_components/create-key/create-key.schema.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/_components/create-key/create-key.schema.ts
@@ -1,3 +1,4 @@
+import { permissionSlugPattern } from "@/app/(app)/[workspaceSlug]/authorization/permissions/components/upsert-permission/upsert-permission.schema";
 import { createConditionalSchema, metadataSchema } from "@/lib/schemas/metadata";
 import { z } from "zod";
 
@@ -262,10 +263,16 @@ export const expirationSchema = z.object({
 // so role names do not have to narrow later when roles start accepting slugs.
 // Keep in step with roleNameSchema on the role editor.
 //
-// Permission slugs are still capped at 100 by the spec even though
-// permissions.slug is varchar(128); keep this in step when that is widened.
+// Permission slugs are machine identifiers and do carry a pattern. Keep both
+// the pattern and the 128 cap in step with permissionSlugSchema on the
+// permission editor.
 const roleNameItemSchema = z.string().trim().min(1).max(128);
-const permissionSlugItemSchema = z.string().trim().min(1).max(100);
+const permissionSlugItemSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(128)
+  .refine((slug) => permissionSlugPattern.test(slug));
 
 const uniqueStrings = (items: string[]) => [...new Set(items)];
 

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/authorization/permissions/components/upsert-permission/upsert-permission.schema.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/authorization/permissions/components/upsert-permission/upsert-permission.schema.ts
@@ -11,11 +11,20 @@ export const permissionNameSchema = z
     error: "Permission name cannot contain consecutive spaces",
   });
 
+// Mirrors the shared permission slug rule in the OpenAPI spec, so a slug
+// created here can always be assigned to a key. Allows dotted slugs
+// (documents.read), wildcards (documents.*), colons (api:read) and leading
+// digits (2fa.read); rejects whitespace. 128 matches permissions.slug.
+export const permissionSlugPattern = /^[a-zA-Z0-9_:\-.*]+$/;
+
 export const permissionSlugSchema = z
   .string()
   .trim()
   .min(2, { message: "Permission slug must be at least 2 characters long" })
-  .max(128, { message: "Permission slug cannot exceed 128 characters" });
+  .max(128, { message: "Permission slug cannot exceed 128 characters" })
+  .refine((slug) => permissionSlugPattern.test(slug), {
+    error: "Permission slug can only contain letters, numbers, and the characters _ : - . *",
+  });
 
 export const permissionDescriptionSchema = z
   .string()

--- a/web/apps/dashboard/lib/trpc/routers/api/create.ts
+++ b/web/apps/dashboard/lib/trpc/routers/api/create.ts
@@ -12,7 +12,8 @@ export const createApi = workspaceProcedure
       name: z
         .string()
         .min(3, "Keyspace names must contain at least 3 characters")
-        .max(50, "Keyspace names must contain at most 50 characters"),
+        // 256 matches the apis.name column and apis.createApi in the API.
+        .max(256, "Keyspace names cannot exceed 256 characters"),
     }),
   )
   .mutation(async ({ input, ctx }) => {

--- a/web/apps/dashboard/lib/trpc/routers/workspace/onboarding.ts
+++ b/web/apps/dashboard/lib/trpc/routers/workspace/onboarding.ts
@@ -10,7 +10,8 @@ const createWorkspaceWithApiAndKeyInputSchema = z.object({
   apiName: z
     .string()
     .min(3, "Keyspace name must be at least 3 characters")
-    .max(50, "Keyspace name must not exceed 50 characters"),
+    // 256 matches the apis.name column and apis.createApi in the API.
+    .max(256, "Keyspace name cannot exceed 256 characters"),
   ...createKeyInputSchema.omit({ keyAuthId: true }).shape,
 });
 


### PR DESCRIPTION
Third instance of the pattern behind #6976 and #6977: a slug-shaped rule applied to a human-readable name, with the dashboard and the API disagreeing about what is valid.

Found by the constraint audit — surfaced when a live test against production failed on `apis.createApi` for a name containing a space.

## The problem

`apis.createApi` constrained the name with `^[a-zA-Z][a-zA-Z0-9._-]*$`, so **you cannot create an API called "My API" through the API** — while the dashboard happily creates exactly that.

The pattern has nothing to protect. `apis.name` is a display label:

- there is no slug column
- there is no uniqueness constraint
- **no endpoint resolves an API by name** — `createApi`, `getApi`, `deleteApi` and `listKeys` all take an `apiId`

Renaming through the dashboard applies no pattern either, so an API created through the API could already be renamed into a state `createApi` would refuse. The constraint wasn't even enforced across one resource's lifecycle.

The caps disagreed four ways against a single `varchar(256)` column:

| where | min | max | pattern |
|---|---|---|---|
| `apis.createApi` (API) | 3 | 255 | `^[a-zA-Z][a-zA-Z0-9._-]*$` |
| `api.create` (dashboard) | 3 | **50** | none |
| `api.updateName` (dashboard) | 3 | 256 | none |
| onboarding (dashboard) | 3 | **50** | none |

## The fix

Drop the pattern; settle all four on `min 3, max 256` to match the column. The `getApi` response schema, which still advertised 255, is aligned too.

## Verification

```
createApi 'My API'                 ok
createApi 'payment-service-prod'   ok
createApi 60 chars                 ok      (was rejected by the dashboard's 50)
createApi 256 chars                ok
createApi 257 chars                REJECT  maxLength: got 257, want 256
createApi 2 chars                  REJECT  minLength: got 2, want 3
```

`v2_apis_create_api` and `v2_apis_get_api` pass; dashboard typecheck and biome clean.

## Breaking change surface

None — every change here is a widening, so nothing that validates today stops validating.

Stacked on #6977.