### PR TITLE
fix(ratelimit): bound namespace renames and match the identifier columns

### DIFF
--- a/svc/api/openapi/gen.go
+++ b/svc/api/openapi/gen.go
@@ -1502,8 +1502,8 @@ type V2AnalyticsGetVerificationsResponseData = []map[string]interface{}
 
 // V2ApisCreateApiRequestBody defines model for V2ApisCreateApiRequestBody.
 type V2ApisCreateApiRequestBody struct {
-	// Name Unique identifier for this API namespace within your workspace.
-	// Use descriptive names like 'payment-service-prod' or 'user-api-dev' to clearly identify purpose and environment.
+	// Name Human-readable name for this API within your workspace.
+	// Use descriptive names like 'Payment Service (prod)' or 'user-api-dev' to clearly identify purpose and environment.
 	Name string `json:"name"`
 }
 

--- a/svc/api/openapi/openapi-generated.yaml
+++ b/svc/api/openapi/openapi-generated.yaml
@@ -3165,7 +3165,7 @@ components:
                     description: The id or name of the namespace containing the override.
                     type: string
                     minLength: 1
-                    maxLength: 255
+                    maxLength: 512
                 identifier:
                     description: |-
                         The exact identifier pattern of the override to delete. This must match exactly as it was specified when creating the override.
@@ -3178,7 +3178,7 @@ components:
                         After deletion, any identifiers previously affected by this override will immediately revert to using the default rate limit for the namespace.
                     type: string
                     minLength: 1
-                    maxLength: 255
+                    maxLength: 512
             required:
                 - namespace
                 - identifier
@@ -3209,7 +3209,7 @@ components:
                     description: The id or name of the namespace containing the override.
                     type: string
                     minLength: 1
-                    maxLength: 255
+                    maxLength: 512
                 identifier:
                     description: |-
                         The exact identifier pattern for the override you want to retrieve. This must match exactly as it was specified when creating the override.
@@ -3222,7 +3222,7 @@ components:
                         This field is used to look up the specific override configuration for this pattern.
                     type: string
                     minLength: 1
-                    maxLength: 255
+                    maxLength: 512
             required:
                 - namespace
                 - identifier
@@ -3243,7 +3243,7 @@ components:
                 namespace:
                     type: string
                     minLength: 1
-                    maxLength: 255
+                    maxLength: 512
                     description: The id or name of the namespace.
                     example: sms.sign_up
                 cost:
@@ -3271,7 +3271,7 @@ components:
                 identifier:
                     type: string
                     minLength: 1
-                    maxLength: 255
+                    maxLength: 512
                     description: |
                         Defines the scope of rate limiting by identifying the entity being limited.
                         Use user IDs for per-user limits, IP addresses for anonymous limiting, or API key IDs for per-key limits.
@@ -3329,7 +3329,7 @@ components:
                     description: The id or name of the rate limit namespace to list overrides for.
                     type: string
                     minLength: 1
-                    maxLength: 255
+                    maxLength: 512
                 cursor:
                     description: Pagination cursor from a previous response. Include this when fetching subsequent pages of results. Each response containing more results than the requested limit will include a cursor value in the pagination object that can be used here.
                     type: string
@@ -3395,7 +3395,7 @@ components:
                     description: The ID or name of the rate limit namespace.
                     type: string
                     minLength: 1
-                    maxLength: 255
+                    maxLength: 512
                 duration:
                     description: |-
                         The duration in milliseconds for the rate limit window. This defines how long the rate limit counter accumulates before resetting to zero.
@@ -3425,7 +3425,7 @@ components:
                         More detailed information on wildcard pattern rules is available at https://www.unkey.com/docs/ratelimiting/overrides#wildcard-rules
                     type: string
                     minLength: 1
-                    maxLength: 255
+                    maxLength: 512
                 limit:
                     description: |-
                         The maximum number of requests allowed for this override. This defines the custom quota for the specified identifier(s).

--- a/svc/api/openapi/openapi-generated.yaml
+++ b/svc/api/openapi/openapi-generated.yaml
@@ -1654,7 +1654,8 @@ components:
                         Any permissions that do not exist will be auto created if the root key has permissions, otherwise this operation will fail with a 403 error.
                     items:
                         type: string
-                        minLength: 3
+                        minLength: 1
+                        maxLength: 128
                         pattern: ^[a-zA-Z0-9_:\-\.\*]+$
                         description: Specify the permission by its slug.
             additionalProperties: false
@@ -1806,8 +1807,8 @@ components:
                     items:
                         type: string
                         minLength: 1
-                        maxLength: 100
-                    pattern: "^[a-zA-Z][a-zA-Z0-9._-]*$"
+                        maxLength: 128
+                        pattern: ^[a-zA-Z0-9_:\-\.\*]+$
                     description: |
                         Grants specific permissions directly to this key without requiring role membership.
                         Wildcard permissions like `documents.*` grant access to all sub-permissions including `documents.read` and `documents.write`.
@@ -2025,7 +2026,8 @@ components:
                         After removal, verification checks for these permissions will fail unless granted through roles.
                     items:
                         type: string
-                        minLength: 3
+                        minLength: 1
+                        maxLength: 128
                         pattern: ^[a-zA-Z0-9_:\-\.\*]+$
                         description: Specify the permission by its slug.
             additionalProperties: false
@@ -2163,7 +2165,8 @@ components:
                         Any permissions that do not exist will be auto created if the root key has permissions, otherwise this operation will fail with a 403 error.
                     items:
                         type: string
-                        minLength: 3
+                        minLength: 1
+                        maxLength: 128
                         pattern: ^[a-zA-Z0-9_:\-\.\*]+$
                         description: Specify the permission by its slug.
             additionalProperties: false
@@ -2377,8 +2380,7 @@ components:
                     items:
                         type: string
                         minLength: 1
-                        maxLength: 100
-                        pattern: ^[a-zA-Z0-9_:\-\.\*]+$
+                        maxLength: 128
                         description: |
                             Assigns existing roles to this key for permission management through role-based access control.
                             Roles must already exist in your workspace before assignment.
@@ -2392,8 +2394,8 @@ components:
                     maxItems: 1000
                     items:
                         type: string
-                        minLength: 3
-                        maxLength: 100
+                        minLength: 1
+                        maxLength: 128
                         pattern: ^[a-zA-Z0-9_:\-\.\*]+$
                         description: |
                             Grants specific permissions directly to this key without requiring role membership.
@@ -2546,7 +2548,7 @@ components:
                     type: string
                     minLength: 1
                     maxLength: 128
-                    pattern: "^[a-zA-Z][a-zA-Z0-9._-]*$"
+                    pattern: ^[a-zA-Z0-9_:\-\.\*]+$
                     description: |
                         Creates a URL-safe identifier for this permission that can be used in APIs and integrations.
                         Must start with a letter and contain only letters, numbers, periods, underscores, and hyphens.
@@ -2632,9 +2634,9 @@ components:
             properties:
                 permission:
                     type: string
-                    minLength: 3
-                    maxLength: 255
-                    pattern: "^[a-zA-Z][a-zA-Z0-9._-]*$"
+                    minLength: 1
+                    maxLength: 128
+                    pattern: ^[a-zA-Z0-9_:\-\.\*]+$
                     description: |
                         Specifies which permission to permanently delete from your workspace.
 
@@ -2706,9 +2708,9 @@ components:
             properties:
                 permission:
                     type: string
-                    minLength: 3
-                    maxLength: 255
-                    pattern: "^[a-zA-Z][a-zA-Z0-9._-]*$"
+                    minLength: 1
+                    maxLength: 128
+                    pattern: ^[a-zA-Z0-9_:\-\.\*]+$
                     description: |
                         The unique identifier of the permission to retrieve. Must be a valid permission ID that begins with 'perm_' and exists within your workspace.
                     example: perm_1234567890abcdef
@@ -5724,7 +5726,7 @@ components:
                     items:
                         type: string
                         minLength: 1
-                        maxLength: 100
+                        maxLength: 128
                     description: |
                         Assigns existing roles to this key for permission management through role-based access control.
                         Roles must already exist in your workspace before assignment.
@@ -5739,7 +5741,8 @@ components:
                     items:
                         type: string
                         minLength: 1
-                        maxLength: 100
+                        maxLength: 128
+                        pattern: ^[a-zA-Z0-9_:\-\.\*]+$
                     description: |
                         Grants specific permissions directly to this key without requiring role membership.
                         Wildcard permissions like `documents.*` grant access to all sub-permissions including `documents.read` and `documents.write`.

--- a/svc/api/openapi/openapi-generated.yaml
+++ b/svc/api/openapi/openapi-generated.yaml
@@ -217,12 +217,11 @@ components:
                 name:
                     type: string
                     minLength: 3
-                    maxLength: 255
-                    pattern: "^[a-zA-Z][a-zA-Z0-9._-]*$"
+                    maxLength: 256
                     description: |
-                        Unique identifier for this API namespace within your workspace.
-                        Use descriptive names like 'payment-service-prod' or 'user-api-dev' to clearly identify purpose and environment.
-                    example: payment-service-production
+                        Human-readable name for this API within your workspace.
+                        Use descriptive names like 'Payment Service (prod)' or 'user-api-dev' to clearly identify purpose and environment.
+                    example: Payment Service (prod)
             additionalProperties: false
         V2ApisCreateApiResponseBody:
             type: object
@@ -3602,7 +3601,7 @@ components:
                 name:
                     type: string
                     minLength: 3
-                    maxLength: 255
+                    maxLength: 256
                     description: |
                         The internal name of this API as specified during creation.
                         Used for organization and identification within your workspace.

--- a/svc/api/openapi/spec/paths/v2/apis/createApi/V2ApisCreateApiRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/apis/createApi/V2ApisCreateApiRequestBody.yaml
@@ -5,12 +5,17 @@ properties:
   name:
     type: string
     minLength: 3
-    maxLength: 255 # Reasonable upper bound for API names
-    pattern: "^[a-zA-Z][a-zA-Z0-9._-]*$" # Must start with letter, then alphanumeric/underscore/dot/hyphen
+    # Matches the apis.name column (varchar(256)). No character pattern: the
+    # name is a human-readable label, not an identifier. There is no slug
+    # column and no uniqueness constraint behind it, and no endpoint resolves
+    # an API by name — createApi, getApi, deleteApi and listKeys all take an
+    # apiId — so a slug-shaped rule here only rejects names the dashboard
+    # already lets people create.
+    maxLength: 256
     description: |
-      Unique identifier for this API namespace within your workspace.
-      Use descriptive names like 'payment-service-prod' or 'user-api-dev' to clearly identify purpose and environment.
-    example: payment-service-production
+      Human-readable name for this API within your workspace.
+      Use descriptive names like 'Payment Service (prod)' or 'user-api-dev' to clearly identify purpose and environment.
+    example: Payment Service (prod)
 additionalProperties: false
 examples:
   basic:

--- a/svc/api/openapi/spec/paths/v2/apis/getApi/V2ApisGetApiResponseData.yaml
+++ b/svc/api/openapi/spec/paths/v2/apis/getApi/V2ApisGetApiResponseData.yaml
@@ -14,7 +14,8 @@ properties:
   name:
     type: string
     minLength: 3
-    maxLength: 255
+    # Matches the apis.name column (varchar(256)). See createApi.
+    maxLength: 256
     description: |
       The internal name of this API as specified during creation.
       Used for organization and identification within your workspace.

--- a/svc/api/openapi/spec/paths/v2/keys/addPermissions/V2KeysAddPermissionsRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/keys/addPermissions/V2KeysAddPermissionsRequestBody.yaml
@@ -25,7 +25,10 @@ properties:
       Any permissions that do not exist will be auto created if the root key has permissions, otherwise this operation will fail with a 403 error.
     items:
       type: string
-      minLength: 3
+      minLength: 1
+      # Matches the permissions.slug column (varchar(128)). See createKey for
+      # the shared permission slug rule.
+      maxLength: 128
       pattern: ^[a-zA-Z0-9_:\-\.\*]+$
       description: Specify the permission by its slug.
 additionalProperties: false

--- a/svc/api/openapi/spec/paths/v2/keys/createKey/V2KeysCreateKeyRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/keys/createKey/V2KeysCreateKeyRequestBody.yaml
@@ -100,8 +100,15 @@ properties:
     items:
       type: string
       minLength: 1
-      maxLength: 100 # Keep permission names concise and readable
-    pattern: "^[a-zA-Z][a-zA-Z0-9._-]*$"
+      # Matches the permissions.slug column (varchar(128)).
+      maxLength: 128
+      # Slugs are machine identifiers, so unlike role names they do carry a
+      # pattern. The character set covers what customers actually create:
+      # dotted slugs (documents.read), wildcards (documents.*), colons
+      # (api:read) and leading digits (2fa.read). Keep this rule identical
+      # across every endpoint that accepts a permission slug and in the
+      # dashboard.
+      pattern: ^[a-zA-Z0-9_:\-\.\*]+$
     description: |
       Grants specific permissions directly to this key without requiring role membership.
       Wildcard permissions like `documents.*` grant access to all sub-permissions including `documents.read` and `documents.write`.

--- a/svc/api/openapi/spec/paths/v2/keys/migrateKeys/V2KeysMigrateKeyData.yaml
+++ b/svc/api/openapi/spec/paths/v2/keys/migrateKeys/V2KeysMigrateKeyData.yaml
@@ -49,7 +49,8 @@ properties:
     items:
       type: string
       minLength: 1
-      maxLength: 100 # Keep role names concise and readable
+      # See createKey for the shared role name rule.
+      maxLength: 128
     description: |
       Assigns existing roles to this key for permission management through role-based access control.
       Roles must already exist in your workspace before assignment.
@@ -64,7 +65,9 @@ properties:
     items:
       type: string
       minLength: 1
-      maxLength: 100 # Keep permission names concise and readable
+      # See createKey for the shared permission slug rule.
+      maxLength: 128
+      pattern: ^[a-zA-Z0-9_:\-\.\*]+$
     description: |
       Grants specific permissions directly to this key without requiring role membership.
       Wildcard permissions like `documents.*` grant access to all sub-permissions including `documents.read` and `documents.write`.

--- a/svc/api/openapi/spec/paths/v2/keys/removePermissions/V2KeysRemovePermissionsRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/keys/removePermissions/V2KeysRemovePermissionsRequestBody.yaml
@@ -24,7 +24,10 @@ properties:
       After removal, verification checks for these permissions will fail unless granted through roles.
     items:
       type: string
-      minLength: 3
+      minLength: 1
+      # Matches the permissions.slug column (varchar(128)). See createKey for
+      # the shared permission slug rule.
+      maxLength: 128
       pattern: ^[a-zA-Z0-9_:\-\.\*]+$
       description: Specify the permission by its slug.
 additionalProperties: false

--- a/svc/api/openapi/spec/paths/v2/keys/setPermissions/V2KeysSetPermissionsRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/keys/setPermissions/V2KeysSetPermissionsRequestBody.yaml
@@ -27,7 +27,10 @@ properties:
       Any permissions that do not exist will be auto created if the root key has permissions, otherwise this operation will fail with a 403 error.
     items:
       type: string
-      minLength: 3
+      minLength: 1
+      # Matches the permissions.slug column (varchar(128)). See createKey for
+      # the shared permission slug rule.
+      maxLength: 128
       pattern: ^[a-zA-Z0-9_:\-\.\*]+$
       description: Specify the permission by its slug.
 additionalProperties: false

--- a/svc/api/openapi/spec/paths/v2/keys/updateKey/V2KeysUpdateKeyRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/keys/updateKey/V2KeysUpdateKeyRequestBody.yaml
@@ -107,8 +107,10 @@ properties:
     items:
       type: string
       minLength: 1
-      maxLength: 100 # Keep role names concise and readable
-      pattern: ^[a-zA-Z0-9_:\-\.\*]+$
+      # 128 matches permissions.slug (varchar(128)) so this field does not have
+      # to narrow later when roles start accepting slugs. See createKey for why
+      # no character pattern is applied to role names.
+      maxLength: 128
       description: |
         Assigns existing roles to this key for permission management through role-based access control.
         Roles must already exist in your workspace before assignment.
@@ -122,8 +124,10 @@ properties:
     maxItems: 1000 # Allow extensive permission sets for complex applications
     items:
       type: string
-      minLength: 3
-      maxLength: 100
+      minLength: 1
+      # Matches the permissions.slug column (varchar(128)). See createKey for
+      # the shared permission slug rule.
+      maxLength: 128
       pattern: ^[a-zA-Z0-9_:\-\.\*]+$
       description: |
         Grants specific permissions directly to this key without requiring role membership.

--- a/svc/api/openapi/spec/paths/v2/permissions/createPermission/V2PermissionsCreatePermissionRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/permissions/createPermission/V2PermissionsCreatePermissionRequestBody.yaml
@@ -18,8 +18,10 @@ properties:
   slug:
     type: string
     minLength: 1
+    # Matches the permissions.slug column (varchar(128)). See createKey for
+    # the shared permission slug rule.
     maxLength: 128
-    pattern: "^[a-zA-Z][a-zA-Z0-9._-]*$"
+    pattern: ^[a-zA-Z0-9_:\-\.\*]+$
     description: |
       Creates a URL-safe identifier for this permission that can be used in APIs and integrations.
       Must start with a letter and contain only letters, numbers, periods, underscores, and hyphens.

--- a/svc/api/openapi/spec/paths/v2/permissions/deletePermission/V2PermissionsDeletePermissionRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/permissions/deletePermission/V2PermissionsDeletePermissionRequestBody.yaml
@@ -4,9 +4,11 @@ required:
 properties:
   permission:
     type: string
-    minLength: 3
-    maxLength: 255
-    pattern: "^[a-zA-Z][a-zA-Z0-9._-]*$"
+    minLength: 1
+    # Accepts a permission ID or slug. Matches the permissions.slug column
+    # (varchar(128)). See createKey for the shared permission slug rule.
+    maxLength: 128
+    pattern: ^[a-zA-Z0-9_:\-\.\*]+$
     description: |
       Specifies which permission to permanently delete from your workspace.
 

--- a/svc/api/openapi/spec/paths/v2/permissions/getPermission/V2PermissionsGetPermissionRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/permissions/getPermission/V2PermissionsGetPermissionRequestBody.yaml
@@ -4,9 +4,11 @@ required:
 properties:
   permission:
     type: string
-    minLength: 3
-    maxLength: 255
-    pattern: "^[a-zA-Z][a-zA-Z0-9._-]*$"
+    minLength: 1
+    # Accepts a permission ID or slug. Matches the permissions.slug column
+    # (varchar(128)). See createKey for the shared permission slug rule.
+    maxLength: 128
+    pattern: ^[a-zA-Z0-9_:\-\.\*]+$
     description: |
       The unique identifier of the permission to retrieve. Must be a valid permission ID that begins with 'perm_' and exists within your workspace.
     example: perm_1234567890abcdef

--- a/svc/api/openapi/spec/paths/v2/ratelimit/deleteOverride/V2RatelimitDeleteOverrideRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/ratelimit/deleteOverride/V2RatelimitDeleteOverrideRequestBody.yaml
@@ -15,7 +15,9 @@ properties:
     description: The id or name of the namespace containing the override.
     type: string
     minLength: 1
-    maxLength: 255
+    # Matches the ratelimit_namespaces.name / ratelimit_overrides.identifier
+    # columns, both varchar(512).
+    maxLength: 512
   identifier:
     description: |-
       The exact identifier pattern of the override to delete. This must match exactly as it was specified when creating the override.
@@ -28,7 +30,9 @@ properties:
       After deletion, any identifiers previously affected by this override will immediately revert to using the default rate limit for the namespace.
     type: string
     minLength: 1
-    maxLength: 255
+    # Matches the ratelimit_namespaces.name / ratelimit_overrides.identifier
+    # columns, both varchar(512).
+    maxLength: 512
 required:
   - namespace
   - identifier

--- a/svc/api/openapi/spec/paths/v2/ratelimit/getOverride/V2RatelimitGetOverrideRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/ratelimit/getOverride/V2RatelimitGetOverrideRequestBody.yaml
@@ -13,7 +13,9 @@ properties:
     description: The id or name of the namespace containing the override.
     type: string
     minLength: 1
-    maxLength: 255
+    # Matches the ratelimit_namespaces.name / ratelimit_overrides.identifier
+    # columns, both varchar(512).
+    maxLength: 512
   identifier:
     description: |-
       The exact identifier pattern for the override you want to retrieve. This must match exactly as it was specified when creating the override.
@@ -26,7 +28,9 @@ properties:
       This field is used to look up the specific override configuration for this pattern.
     type: string
     minLength: 1
-    maxLength: 255
+    # Matches the ratelimit_namespaces.name / ratelimit_overrides.identifier
+    # columns, both varchar(512).
+    maxLength: 512
 required:
   - namespace
   - identifier

--- a/svc/api/openapi/spec/paths/v2/ratelimit/limit/V2RatelimitLimitRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/ratelimit/limit/V2RatelimitLimitRequestBody.yaml
@@ -3,7 +3,9 @@ properties:
   namespace:
     type: string
     minLength: 1
-    maxLength: 255
+    # Matches the ratelimit_namespaces.name / ratelimit_overrides.identifier
+    # columns, both varchar(512).
+    maxLength: 512
     description: The id or name of the namespace.
     example: sms.sign_up
   cost:
@@ -31,7 +33,9 @@ properties:
   identifier:
     type: string
     minLength: 1
-    maxLength: 255 # Reasonable upper bound for identifiers
+    # Matches the ratelimit_namespaces.name / ratelimit_overrides.identifier
+    # columns, both varchar(512).
+    maxLength: 512
     description: |
       Defines the scope of rate limiting by identifying the entity being limited.
       Use user IDs for per-user limits, IP addresses for anonymous limiting, or API key IDs for per-key limits.

--- a/svc/api/openapi/spec/paths/v2/ratelimit/listOverrides/V2RatelimitListOverridesRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/ratelimit/listOverrides/V2RatelimitListOverridesRequestBody.yaml
@@ -4,7 +4,9 @@ properties:
     description: The id or name of the rate limit namespace to list overrides for.
     type: string
     minLength: 1
-    maxLength: 255
+    # Matches the ratelimit_namespaces.name / ratelimit_overrides.identifier
+    # columns, both varchar(512).
+    maxLength: 512
   cursor:
     description: Pagination cursor from a previous response. Include this when
       fetching subsequent pages of results. Each response containing more results

--- a/svc/api/openapi/spec/paths/v2/ratelimit/setOverride/V2RatelimitSetOverrideRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/ratelimit/setOverride/V2RatelimitSetOverrideRequestBody.yaml
@@ -13,7 +13,9 @@ properties:
     description: The ID or name of the rate limit namespace.
     type: string
     minLength: 1
-    maxLength: 255
+    # Matches the ratelimit_namespaces.name / ratelimit_overrides.identifier
+    # columns, both varchar(512).
+    maxLength: 512
   duration:
     description: |-
       The duration in milliseconds for the rate limit window. This defines how long the rate limit counter accumulates before resetting to zero.
@@ -43,7 +45,9 @@ properties:
       More detailed information on wildcard pattern rules is available at https://www.unkey.com/docs/ratelimiting/overrides#wildcard-rules
     type: string
     minLength: 1
-    maxLength: 255
+    # Matches the ratelimit_namespaces.name / ratelimit_overrides.identifier
+    # columns, both varchar(512).
+    maxLength: 512
   limit:
     description: |-
       The maximum number of requests allowed for this override. This defines the custom quota for the specified identifier(s).

--- a/svc/api/routes/v2_keys_create_key/200_test.go
+++ b/svc/api/routes/v2_keys_create_key/200_test.go
@@ -641,7 +641,12 @@ func TestCreateKeyWithRolesAndPermissions(t *testing.T) {
 		h.CreateRole(seed.CreateRoleRequest{Name: name, WorkspaceID: workspaceID})
 	}
 
-	permissionSlugs := []string{"documents.read", "settings.view", "billing_reports.view"}
+	// Slug shapes the spec used to disagree on across endpoints: a plain dotted
+	// slug, a wildcard, a leading digit, and a colon. createKey accepted all of
+	// them only because its `pattern` was indented at the array level and so
+	// ignored entirely; the sibling permission endpoints rejected the last
+	// three outright.
+	permissionSlugs := []string{"documents.read", "documents.*", "2fa.read", "api:read"}
 
 	res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{
 		ApiId:       api.ID,

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/_components/create-key/create-key.schema.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/_components/create-key/create-key.schema.ts
@@ -1,3 +1,4 @@
+import { permissionSlugPattern } from "@/app/(app)/[workspaceSlug]/authorization/permissions/components/upsert-permission/upsert-permission.schema";
 import { createConditionalSchema, metadataSchema } from "@/lib/schemas/metadata";
 import { z } from "zod";
 
@@ -262,10 +263,16 @@ export const expirationSchema = z.object({
 // so role names do not have to narrow later when roles start accepting slugs.
 // Keep in step with roleNameSchema on the role editor.
 //
-// Permission slugs are still capped at 100 by the spec even though
-// permissions.slug is varchar(128); keep this in step when that is widened.
+// Permission slugs are machine identifiers and do carry a pattern. Keep both
+// the pattern and the 128 cap in step with permissionSlugSchema on the
+// permission editor.
 const roleNameItemSchema = z.string().trim().min(1).max(128);
-const permissionSlugItemSchema = z.string().trim().min(1).max(100);
+const permissionSlugItemSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(128)
+  .refine((slug) => permissionSlugPattern.test(slug));
 
 const uniqueStrings = (items: string[]) => [...new Set(items)];
 

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/authorization/permissions/components/upsert-permission/upsert-permission.schema.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/authorization/permissions/components/upsert-permission/upsert-permission.schema.ts
@@ -11,11 +11,20 @@ export const permissionNameSchema = z
     error: "Permission name cannot contain consecutive spaces",
   });
 
+// Mirrors the shared permission slug rule in the OpenAPI spec, so a slug
+// created here can always be assigned to a key. Allows dotted slugs
+// (documents.read), wildcards (documents.*), colons (api:read) and leading
+// digits (2fa.read); rejects whitespace. 128 matches permissions.slug.
+export const permissionSlugPattern = /^[a-zA-Z0-9_:\-.*]+$/;
+
 export const permissionSlugSchema = z
   .string()
   .trim()
   .min(2, { message: "Permission slug must be at least 2 characters long" })
-  .max(128, { message: "Permission slug cannot exceed 128 characters" });
+  .max(128, { message: "Permission slug cannot exceed 128 characters" })
+  .refine((slug) => permissionSlugPattern.test(slug), {
+    error: "Permission slug can only contain letters, numbers, and the characters _ : - . *",
+  });
 
 export const permissionDescriptionSchema = z
   .string()

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/ratelimits/[namespaceId]/_components/identifier-dialog.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/ratelimits/[namespaceId]/_components/identifier-dialog.tsx
@@ -18,7 +18,8 @@ const overrideValidationSchema = z.object({
     .string()
     .trim()
     .min(2, "Name is required and should be at least 2 characters")
-    .max(250),
+    // 512 matches the ratelimit_overrides.identifier column and the API.
+    .max(512),
   limit: z.coerce.number().int().nonnegative().max(10_000, "Limit cannot exceed 10,000"),
   duration: z.coerce
     .number()

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/ratelimits/_components/create-namespace-button.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/ratelimits/_components/create-namespace-button.tsx
@@ -13,7 +13,7 @@ const formSchema = z.object({
     .string()
     .trim()
     .min(1, "Name must not be empty")
-    .max(50, "Name must not exceed 50 characters")
+    .max(512, "Name must not exceed 512 characters")
     .regex(
       /^[a-zA-Z0-9_\-\.]+$/,
       "Only alphanumeric characters, underscores, hyphens, and periods are allowed",

--- a/web/apps/dashboard/lib/trpc/routers/api/create.ts
+++ b/web/apps/dashboard/lib/trpc/routers/api/create.ts
@@ -12,7 +12,8 @@ export const createApi = workspaceProcedure
       name: z
         .string()
         .min(3, "Keyspace names must contain at least 3 characters")
-        .max(50, "Keyspace names must contain at most 50 characters"),
+        // 256 matches the apis.name column and apis.createApi in the API.
+        .max(256, "Keyspace names cannot exceed 256 characters"),
     }),
   )
   .mutation(async ({ input, ctx }) => {

--- a/web/apps/dashboard/lib/trpc/routers/ratelimit/createNamespace.ts
+++ b/web/apps/dashboard/lib/trpc/routers/ratelimit/createNamespace.ts
@@ -9,7 +9,8 @@ import { workspaceProcedure } from "../../trpc";
 export const createNamespace = workspaceProcedure
   .input(
     z.object({
-      name: z.string().min(1).max(50),
+      // 512 matches the ratelimit_namespaces.name column and the API.
+      name: z.string().min(1).max(512),
     }),
   )
   .mutation(async ({ input, ctx }) => {

--- a/web/apps/dashboard/lib/trpc/routers/ratelimit/updateNamespaceName.ts
+++ b/web/apps/dashboard/lib/trpc/routers/ratelimit/updateNamespaceName.ts
@@ -8,7 +8,13 @@ import { workspaceProcedure } from "../../trpc";
 export const updateNamespaceName = workspaceProcedure
   .input(
     z.object({
-      name: z.string().min(3, "namespace names must contain at least 3 characters"),
+      // Bounded to match the ratelimit_namespaces.name column (varchar(512))
+      // and the API. This previously had no maximum at all, so a namespace
+      // could be renamed past what every namespace-taking API call accepts.
+      name: z
+        .string()
+        .min(1, "namespace names must not be empty")
+        .max(512, "namespace names cannot exceed 512 characters"),
       namespaceId: z.string(),
     }),
   )

--- a/web/apps/dashboard/lib/trpc/routers/workspace/onboarding.ts
+++ b/web/apps/dashboard/lib/trpc/routers/workspace/onboarding.ts
@@ -10,7 +10,8 @@ const createWorkspaceWithApiAndKeyInputSchema = z.object({
   apiName: z
     .string()
     .min(3, "Keyspace name must be at least 3 characters")
-    .max(50, "Keyspace name must not exceed 50 characters"),
+    // 256 matches the apis.name column and apis.createApi in the API.
+    .max(256, "Keyspace name cannot exceed 256 characters"),
   ...createKeyInputSchema.omit({ keyAuthId: true }).shape,
 });
 


### PR DESCRIPTION
The second of the two "dashboard looser than the API" findings from the constraint audit, and the only one where a dashboard write is completely unbounded.

## The problem

`updateNamespaceName` sets a minimum and **no maximum at all**:

```ts
name: z.string().min(3, "namespace names must contain at least 3 characters"),
```

So a namespace can be renamed up to the `varchar(512)` column and then fails every API call that takes a namespace name — `ratelimit.limit`, `setOverride`, `getOverride`, `deleteOverride`, `listOverrides` all capped at 255. Create allowed 50 and rename allowed 512: the same field, an order of magnitude apart.

| field | API | dashboard create | dashboard rename | column |
|---|---|---|---|---|
| namespace name | 1–255 | 1–**50** | 3–**unbounded** | `varchar(512)` |
| identifier | 1–255 | 2–**250** | — | `varchar(512)` |

## The fix

Both columns are `varchar(512)` with uniqueness constraints, so the column becomes the source of truth and every layer settles on 512. The rename also gains create's minimum of 1, so a namespace can't be created with a name it could never be renamed back to.

**The identifier is included** because it's the same table, the same defect and the same two-line change — happy to split it into its own PR if you'd rather keep this one to the namespace.

**Charset is deliberately untouched.** The create form applies `^[a-zA-Z0-9_\-\.]+$` that the API does not, which makes the dashboard the stricter side. That's safe, and whether namespace names should be identifiers at all is a separate judgement call — `ratelimit.limit` does resolve a namespace by name, unlike APIs.

## Verification

All six `v2_ratelimit_*` route packages pass. Dashboard typecheck and biome clean.

Worth noting: `v2_ratelimit_multi_limit` failed on first run for an unrelated reason — a stale ClickHouse test container whose `instance_checkpoints_v1` predates the `app_id` column, so migration `027` couldn't apply. Resetting the container's database fixed it. Same class of local-environment staleness as the MySQL `limits` table issue seen while working on #6976; worth knowing if CI or a colleague hits it.

## Breaking change surface

Widening everywhere except the rename gaining an upper bound at 512 — which the column would have rejected anyway.

Stacked on #6978.