### PR TITLE
fix(api): protect default projects

### DIFF
--- a/pkg/db/project_list_by_workspace.sql_generated.go
+++ b/pkg/db/project_list_by_workspace.sql_generated.go
@@ -21,6 +21,8 @@ SELECT
     updated_at
 FROM projects
 WHERE workspace_id = ?
+  -- The default project is an internal ownership container, not a user-visible project.
+  AND BINARY slug != 'default'
   AND id >= ?
   -- search is a pre-escaped LIKE pattern built by mysql.SearchContains; NULL disables the filter
   AND (? IS NULL OR LOWER(id) LIKE LOWER(?) OR LOWER(name) LIKE LOWER(?) OR LOWER(slug) LIKE LOWER(?))
@@ -57,6 +59,8 @@ type ListProjectsByWorkspaceIdRow struct {
 //	    updated_at
 //	FROM projects
 //	WHERE workspace_id = ?
+//	  -- The default project is an internal ownership container, not a user-visible project.
+//	  AND BINARY slug != 'default'
 //	  AND id >= ?
 //	  -- search is a pre-escaped LIKE pattern built by mysql.SearchContains; NULL disables the filter
 //	  AND (? IS NULL OR LOWER(id) LIKE LOWER(?) OR LOWER(name) LIKE LOWER(?) OR LOWER(slug) LIKE LOWER(?))

--- a/pkg/db/querier_generated.go
+++ b/pkg/db/querier_generated.go
@@ -2201,6 +2201,8 @@ type Querier interface {
 	//      updated_at
 	//  FROM projects
 	//  WHERE workspace_id = ?
+	//    -- The default project is an internal ownership container, not a user-visible project.
+	//    AND BINARY slug != 'default'
 	//    AND id >= ?
 	//    -- search is a pre-escaped LIKE pattern built by mysql.SearchContains; NULL disables the filter
 	//    AND (? IS NULL OR LOWER(id) LIKE LOWER(?) OR LOWER(name) LIKE LOWER(?) OR LOWER(slug) LIKE LOWER(?))

--- a/pkg/db/queries/project_list_by_workspace.sql
+++ b/pkg/db/queries/project_list_by_workspace.sql
@@ -9,6 +9,8 @@ SELECT
     updated_at
 FROM projects
 WHERE workspace_id = sqlc.arg(workspace_id)
+  -- The default project is an internal ownership container, not a user-visible project.
+  AND BINARY slug != 'default'
   AND id >= sqlc.arg(id_cursor)
   -- search is a pre-escaped LIKE pattern built by mysql.SearchContains; NULL disables the filter
   AND (sqlc.narg(search) IS NULL OR LOWER(id) LIKE LOWER(sqlc.narg(search)) OR LOWER(name) LIKE LOWER(sqlc.narg(search)) OR LOWER(slug) LIKE LOWER(sqlc.narg(search)))

--- a/pkg/deploy/projectgate/projectgate.go
+++ b/pkg/deploy/projectgate/projectgate.go
@@ -1,0 +1,28 @@
+// Package projectgate holds project rules shared by the public API and ctrl.
+package projectgate
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/unkeyed/unkey/pkg/codes"
+	"github.com/unkeyed/unkey/pkg/fault"
+)
+
+// DefaultSlug identifies the workspace's internal ownership project.
+const DefaultSlug = "default"
+
+// CheckSlug rejects values that collide with the internal default project
+// under MySQL's case-insensitive project-slug collation.
+func CheckSlug(slug string) error {
+	if !strings.EqualFold(slug, DefaultSlug) {
+		return nil
+	}
+
+	return fault.New(
+		"project slug is reserved",
+		fault.Code(codes.App.Validation.InvalidInput.URN()),
+		fault.Internal("default project slug is reserved"),
+		fault.Public(fmt.Sprintf("The project slug '%s' is reserved.", slug)),
+	)
+}

--- a/pkg/deploy/projectgate/projectgate_test.go
+++ b/pkg/deploy/projectgate/projectgate_test.go
@@ -1,0 +1,26 @@
+package projectgate_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/codes"
+	"github.com/unkeyed/unkey/pkg/deploy/projectgate"
+	"github.com/unkeyed/unkey/pkg/fault"
+)
+
+func TestCheckSlug(t *testing.T) {
+	require.NoError(t, projectgate.CheckSlug("default-project"))
+
+	for _, slug := range []string{projectgate.DefaultSlug, "Default"} {
+		t.Run(slug, func(t *testing.T) {
+			err := projectgate.CheckSlug(slug)
+			require.Error(t, err)
+
+			code, ok := fault.GetCode(err)
+			require.True(t, ok)
+			require.Equal(t, codes.App.Validation.InvalidInput.URN(), code)
+			require.Equal(t, "The project slug '"+slug+"' is reserved.", fault.UserFacingMessage(err))
+		})
+	}
+}

--- a/svc/api/internal/projects/default.go
+++ b/svc/api/internal/projects/default.go
@@ -3,12 +3,22 @@ package projects
 import (
 	"context"
 	"database/sql"
+	"strings"
 	"time"
 
 	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/fault"
 	"github.com/unkeyed/unkey/pkg/uid"
 )
+
+// DefaultSlug identifies the workspace's internal ownership project.
+const DefaultSlug = "default"
+
+// IsReservedSlug reports whether slug would collide with the internal default
+// project under MySQL's case-insensitive slug collation.
+func IsReservedSlug(slug string) bool {
+	return strings.EqualFold(slug, DefaultSlug)
+}
 
 // EnsureDefaultProject returns the exact default project owned by workspaceID,
 // creating it in the caller's transaction when it does not exist.
@@ -29,7 +39,7 @@ func EnsureDefaultProject(ctx context.Context, tx db.DBTX, workspaceID string) (
 		ID:               projectID,
 		WorkspaceID:      workspaceID,
 		Name:             "Default",
-		Slug:             "default",
+		Slug:             DefaultSlug,
 		DeleteProtection: sql.NullBool{Bool: true, Valid: true},
 		CreatedAt:        time.Now().UnixMilli(),
 		UpdatedAt:        sql.NullInt64{},

--- a/svc/api/internal/projects/default.go
+++ b/svc/api/internal/projects/default.go
@@ -3,22 +3,13 @@ package projects
 import (
 	"context"
 	"database/sql"
-	"strings"
 	"time"
 
 	"github.com/unkeyed/unkey/pkg/db"
+	"github.com/unkeyed/unkey/pkg/deploy/projectgate"
 	"github.com/unkeyed/unkey/pkg/fault"
 	"github.com/unkeyed/unkey/pkg/uid"
 )
-
-// DefaultSlug identifies the workspace's internal ownership project.
-const DefaultSlug = "default"
-
-// IsReservedSlug reports whether slug would collide with the internal default
-// project under MySQL's case-insensitive slug collation.
-func IsReservedSlug(slug string) bool {
-	return strings.EqualFold(slug, DefaultSlug)
-}
 
 // EnsureDefaultProject returns the exact default project owned by workspaceID,
 // creating it in the caller's transaction when it does not exist.
@@ -39,7 +30,7 @@ func EnsureDefaultProject(ctx context.Context, tx db.DBTX, workspaceID string) (
 		ID:               projectID,
 		WorkspaceID:      workspaceID,
 		Name:             "Default",
-		Slug:             DefaultSlug,
+		Slug:             projectgate.DefaultSlug,
 		DeleteProtection: sql.NullBool{Bool: true, Valid: true},
 		CreatedAt:        time.Now().UnixMilli(),
 		UpdatedAt:        sql.NullInt64{},

--- a/svc/api/internal/projects/default_test.go
+++ b/svc/api/internal/projects/default_test.go
@@ -13,6 +13,12 @@ import (
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 )
 
+func TestIsReservedSlug(t *testing.T) {
+	require.True(t, projects.IsReservedSlug("default"))
+	require.True(t, projects.IsReservedSlug("Default"))
+	require.False(t, projects.IsReservedSlug("default-project"))
+}
+
 // TestEnsureDefaultProject guarantees ownership writers reuse an exact default,
 // create a protected default when absent, and converge after concurrent creation.
 func TestEnsureDefaultProject(t *testing.T) {

--- a/svc/api/internal/projects/default_test.go
+++ b/svc/api/internal/projects/default_test.go
@@ -8,16 +8,11 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/unkeyed/unkey/pkg/db"
+	"github.com/unkeyed/unkey/pkg/deploy/projectgate"
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/svc/api/internal/projects"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 )
-
-func TestIsReservedSlug(t *testing.T) {
-	require.True(t, projects.IsReservedSlug("default"))
-	require.True(t, projects.IsReservedSlug("Default"))
-	require.False(t, projects.IsReservedSlug("default-project"))
-}
 
 // TestEnsureDefaultProject guarantees ownership writers reuse an exact default,
 // create a protected default when absent, and converge after concurrent creation.
@@ -50,7 +45,7 @@ func TestEnsureDefaultProject(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, workspaceID, project.WorkspaceID)
 		require.Equal(t, "Default", project.Name)
-		require.Equal(t, "default", project.Slug)
+		require.Equal(t, projectgate.DefaultSlug, project.Slug)
 		require.Equal(t, sql.NullBool{Bool: true, Valid: true}, project.DeleteProtection)
 	})
 

--- a/svc/api/routes/v2_projects_create_project/400_test.go
+++ b/svc/api/routes/v2_projects_create_project/400_test.go
@@ -16,8 +16,9 @@ import (
 func TestCreateProjectBadRequest(t *testing.T) {
 	h := testutil.NewHarness(t)
 
+	ctrlClient := &testutil.MockProjectClient{}
 	route := &handler.Handler{
-		CtrlClient: &testutil.MockProjectClient{},
+		CtrlClient: ctrlClient,
 	}
 
 	h.Register(route)
@@ -53,6 +54,18 @@ func TestCreateProjectBadRequest(t *testing.T) {
 			require.Greater(t, len(res.Body.Error.Errors), 0)
 		})
 	}
+
+	t.Run("reserved default slug", func(t *testing.T) {
+		for _, slug := range []string{"default", "Default"} {
+			res := testutil.CallRoute[handler.Request, openapi.BadRequestErrorResponse](h, route, headers, handler.Request{
+				Name: "Reserved",
+				Slug: slug,
+			})
+			require.Equal(t, http.StatusBadRequest, res.Status, "expected 400 for reserved slug %q, received: %s", slug, res.RawBody)
+			require.Equal(t, fmt.Sprintf("The project slug '%s' is reserved.", slug), res.Body.Error.Detail)
+		}
+		require.Empty(t, ctrlClient.CreateProjectCalls)
+	})
 
 	t.Run("invalid json", func(t *testing.T) {
 		invalidJSON := `{"name": "Payments", "slug": }`

--- a/svc/api/routes/v2_projects_create_project/handler.go
+++ b/svc/api/routes/v2_projects_create_project/handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/unkeyed/unkey/pkg/rbac"
 	"github.com/unkeyed/unkey/pkg/zen"
 	"github.com/unkeyed/unkey/svc/api/internal/ctrlclient"
+	"github.com/unkeyed/unkey/svc/api/internal/projects"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
 
@@ -51,6 +52,15 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}))
 	if err != nil {
 		return err
+	}
+
+	if projects.IsReservedSlug(req.Slug) {
+		return fault.New(
+			"project slug is reserved",
+			fault.Code(codes.App.Validation.InvalidInput.URN()),
+			fault.Internal("default project slug is reserved"),
+			fault.Public(fmt.Sprintf("The project slug '%s' is reserved.", req.Slug)),
+		)
 	}
 
 	actor, err := ctrlclient.Actor(s)

--- a/svc/api/routes/v2_projects_create_project/handler.go
+++ b/svc/api/routes/v2_projects_create_project/handler.go
@@ -9,11 +9,11 @@ import (
 	ctrlv1 "github.com/unkeyed/unkey/gen/proto/ctrl/v1"
 	"github.com/unkeyed/unkey/gen/rpc/ctrl"
 	"github.com/unkeyed/unkey/pkg/codes"
+	"github.com/unkeyed/unkey/pkg/deploy/projectgate"
 	"github.com/unkeyed/unkey/pkg/fault"
 	"github.com/unkeyed/unkey/pkg/rbac"
 	"github.com/unkeyed/unkey/pkg/zen"
 	"github.com/unkeyed/unkey/svc/api/internal/ctrlclient"
-	"github.com/unkeyed/unkey/svc/api/internal/projects"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
 
@@ -54,13 +54,8 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	if projects.IsReservedSlug(req.Slug) {
-		return fault.New(
-			"project slug is reserved",
-			fault.Code(codes.App.Validation.InvalidInput.URN()),
-			fault.Internal("default project slug is reserved"),
-			fault.Public(fmt.Sprintf("The project slug '%s' is reserved.", req.Slug)),
-		)
+	if err = projectgate.CheckSlug(req.Slug); err != nil {
+		return err
 	}
 
 	actor, err := ctrlclient.Actor(s)

--- a/svc/api/routes/v2_projects_delete_project/404_test.go
+++ b/svc/api/routes/v2_projects_delete_project/404_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/projects"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_projects_delete_project"
@@ -16,9 +17,10 @@ import (
 func TestDeleteProjectNotFound(t *testing.T) {
 	h := testutil.NewHarness(t)
 
+	ctrlClient := &testutil.MockProjectClient{}
 	route := &handler.Handler{
 		DB:         h.DB,
-		CtrlClient: &testutil.MockProjectClient{},
+		CtrlClient: ctrlClient,
 	}
 	h.Register(route)
 
@@ -46,5 +48,22 @@ func TestDeleteProjectNotFound(t *testing.T) {
 
 		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{Project: project.ID})
 		require.Equal(t, http.StatusNotFound, res.Status, "expected 404 for cross-workspace project, received: %s", res.RawBody)
+	})
+
+	t.Run("default project returns 404 by id or slug", func(t *testing.T) {
+		project := h.CreateProject(seed.CreateProjectRequest{
+			ID:               uid.New(uid.ProjectPrefix),
+			WorkspaceID:      workspace.ID,
+			Name:             "Default",
+			Slug:             projects.DefaultSlug,
+			DeleteProtection: true,
+		})
+
+		for _, identifier := range []string{project.ID, project.Slug} {
+			res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{Project: identifier})
+			require.Equal(t, http.StatusNotFound, res.Status, "expected 404 for default project %q, received: %s", identifier, res.RawBody)
+		}
+
+		require.Empty(t, ctrlClient.DeleteProjectCalls)
 	})
 }

--- a/svc/api/routes/v2_projects_delete_project/404_test.go
+++ b/svc/api/routes/v2_projects_delete_project/404_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/deploy/projectgate"
 	"github.com/unkeyed/unkey/pkg/uid"
-	"github.com/unkeyed/unkey/svc/api/internal/projects"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_projects_delete_project"
@@ -55,7 +55,7 @@ func TestDeleteProjectNotFound(t *testing.T) {
 			ID:               uid.New(uid.ProjectPrefix),
 			WorkspaceID:      workspace.ID,
 			Name:             "Default",
-			Slug:             projects.DefaultSlug,
+			Slug:             projectgate.DefaultSlug,
 			DeleteProtection: true,
 		})
 

--- a/svc/api/routes/v2_projects_delete_project/handler.go
+++ b/svc/api/routes/v2_projects_delete_project/handler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/unkeyed/unkey/pkg/rbac"
 	"github.com/unkeyed/unkey/pkg/zen"
 	"github.com/unkeyed/unkey/svc/api/internal/ctrlclient"
+	"github.com/unkeyed/unkey/svc/api/internal/projects"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
 
@@ -63,6 +64,15 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
 			fault.Internal("database error"),
 			fault.Public("Failed to retrieve project."),
+		)
+	}
+
+	if project.Slug == projects.DefaultSlug {
+		return fault.New(
+			"project not found",
+			fault.Code(codes.Data.Project.NotFound.URN()),
+			fault.Internal("default project is not exposed by the projects API"),
+			fault.Public("The requested project does not exist."),
 		)
 	}
 

--- a/svc/api/routes/v2_projects_delete_project/handler.go
+++ b/svc/api/routes/v2_projects_delete_project/handler.go
@@ -8,11 +8,11 @@ import (
 	"github.com/unkeyed/unkey/gen/rpc/ctrl"
 	"github.com/unkeyed/unkey/pkg/codes"
 	"github.com/unkeyed/unkey/pkg/db"
+	"github.com/unkeyed/unkey/pkg/deploy/projectgate"
 	"github.com/unkeyed/unkey/pkg/fault"
 	"github.com/unkeyed/unkey/pkg/rbac"
 	"github.com/unkeyed/unkey/pkg/zen"
 	"github.com/unkeyed/unkey/svc/api/internal/ctrlclient"
-	"github.com/unkeyed/unkey/svc/api/internal/projects"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
 
@@ -67,7 +67,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		)
 	}
 
-	if project.Slug == projects.DefaultSlug {
+	if project.Slug == projectgate.DefaultSlug {
 		return fault.New(
 			"project not found",
 			fault.Code(codes.Data.Project.NotFound.URN()),

--- a/svc/api/routes/v2_projects_get_project/404_test.go
+++ b/svc/api/routes/v2_projects_get_project/404_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/projects"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_projects_get_project"
@@ -43,5 +44,20 @@ func TestGetProjectNotFound(t *testing.T) {
 
 		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{Project: project.ID})
 		require.Equal(t, http.StatusNotFound, res.Status, "expected 404 for cross-workspace project, received: %s", res.RawBody)
+	})
+
+	t.Run("default project returns 404 by id or slug", func(t *testing.T) {
+		project := h.CreateProject(seed.CreateProjectRequest{
+			ID:               uid.New(uid.ProjectPrefix),
+			WorkspaceID:      workspace.ID,
+			Name:             "Default",
+			Slug:             projects.DefaultSlug,
+			DeleteProtection: true,
+		})
+
+		for _, identifier := range []string{project.ID, project.Slug} {
+			res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{Project: identifier})
+			require.Equal(t, http.StatusNotFound, res.Status, "expected 404 for default project %q, received: %s", identifier, res.RawBody)
+		}
 	})
 }

--- a/svc/api/routes/v2_projects_get_project/404_test.go
+++ b/svc/api/routes/v2_projects_get_project/404_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/deploy/projectgate"
 	"github.com/unkeyed/unkey/pkg/uid"
-	"github.com/unkeyed/unkey/svc/api/internal/projects"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_projects_get_project"
@@ -51,7 +51,7 @@ func TestGetProjectNotFound(t *testing.T) {
 			ID:               uid.New(uid.ProjectPrefix),
 			WorkspaceID:      workspace.ID,
 			Name:             "Default",
-			Slug:             projects.DefaultSlug,
+			Slug:             projectgate.DefaultSlug,
 			DeleteProtection: true,
 		})
 

--- a/svc/api/routes/v2_projects_get_project/handler.go
+++ b/svc/api/routes/v2_projects_get_project/handler.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/unkeyed/unkey/pkg/codes"
 	"github.com/unkeyed/unkey/pkg/db"
+	"github.com/unkeyed/unkey/pkg/deploy/projectgate"
 	"github.com/unkeyed/unkey/pkg/fault"
 	"github.com/unkeyed/unkey/pkg/rbac"
 	"github.com/unkeyed/unkey/pkg/zen"
-	"github.com/unkeyed/unkey/svc/api/internal/projects"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
 
@@ -67,7 +67,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		)
 	}
 
-	if project.Slug == projects.DefaultSlug {
+	if project.Slug == projectgate.DefaultSlug {
 		return fault.New(
 			"project not found",
 			fault.Code(codes.Data.Project.NotFound.URN()),

--- a/svc/api/routes/v2_projects_get_project/handler.go
+++ b/svc/api/routes/v2_projects_get_project/handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/unkeyed/unkey/pkg/fault"
 	"github.com/unkeyed/unkey/pkg/rbac"
 	"github.com/unkeyed/unkey/pkg/zen"
+	"github.com/unkeyed/unkey/svc/api/internal/projects"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
 
@@ -63,6 +64,15 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
 			fault.Internal("database error"),
 			fault.Public("Failed to retrieve project."),
+		)
+	}
+
+	if project.Slug == projects.DefaultSlug {
+		return fault.New(
+			"project not found",
+			fault.Code(codes.Data.Project.NotFound.URN()),
+			fault.Internal("default project is not exposed by the projects API"),
+			fault.Public("The requested project does not exist."),
 		)
 	}
 

--- a/svc/api/routes/v2_projects_list_projects/200_test.go
+++ b/svc/api/routes/v2_projects_list_projects/200_test.go
@@ -3,12 +3,14 @@ package handler_test
 import (
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"github.com/unkeyed/unkey/pkg/ptr"
 	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/projects"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_projects_list_projects"
@@ -77,6 +79,75 @@ func TestListProjectsSuccessfully(t *testing.T) {
 		})
 		require.Equal(t, 200, res.Status, "expected 200, received: %s", res.RawBody)
 		require.NotNil(t, res.Body.Pagination)
+	})
+}
+
+func TestListProjectsHidesDefaultProject(t *testing.T) {
+	h := testutil.NewHarness(t)
+
+	route := &handler.Handler{DB: h.DB}
+	h.Register(route)
+
+	workspace := h.CreateWorkspace()
+	rootKey := h.CreateRootKey(workspace.ID, "project.*.read_project")
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}
+
+	ids := []string{
+		uid.New(uid.ProjectPrefix),
+		uid.New(uid.ProjectPrefix),
+		uid.New(uid.ProjectPrefix),
+	}
+	sort.Strings(ids)
+
+	h.CreateProject(seed.CreateProjectRequest{
+		ID:          ids[0],
+		WorkspaceID: workspace.ID,
+		Name:        "First",
+		Slug:        "first",
+	})
+	h.CreateProject(seed.CreateProjectRequest{
+		ID:               ids[1],
+		WorkspaceID:      workspace.ID,
+		Name:             "Default",
+		Slug:             projects.DefaultSlug,
+		DeleteProtection: true,
+	})
+	h.CreateProject(seed.CreateProjectRequest{
+		ID:          ids[2],
+		WorkspaceID: workspace.ID,
+		Name:        "Last",
+		Slug:        "last",
+	})
+
+	t.Run("omits default without breaking pagination", func(t *testing.T) {
+		firstPage := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{
+			Limit: ptr.P(1),
+		})
+		require.Equal(t, http.StatusOK, firstPage.Status, "expected 200, received: %s", firstPage.RawBody)
+		require.Len(t, firstPage.Body.Data, 1)
+		require.Equal(t, ids[0], firstPage.Body.Data[0].Id)
+		require.True(t, firstPage.Body.Pagination.HasMore)
+		require.NotNil(t, firstPage.Body.Pagination.Cursor)
+
+		secondPage := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{
+			Limit:  ptr.P(1),
+			Cursor: firstPage.Body.Pagination.Cursor,
+		})
+		require.Equal(t, http.StatusOK, secondPage.Status, "expected 200, received: %s", secondPage.RawBody)
+		require.Len(t, secondPage.Body.Data, 1)
+		require.Equal(t, ids[2], secondPage.Body.Data[0].Id)
+		require.False(t, secondPage.Body.Pagination.HasMore)
+	})
+
+	t.Run("does not return default in search", func(t *testing.T) {
+		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{
+			Search: ptr.P(projects.DefaultSlug),
+		})
+		require.Equal(t, http.StatusOK, res.Status, "expected 200, received: %s", res.RawBody)
+		require.Empty(t, res.Body.Data)
 	})
 }
 

--- a/svc/api/routes/v2_projects_list_projects/200_test.go
+++ b/svc/api/routes/v2_projects_list_projects/200_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/deploy/projectgate"
 	"github.com/unkeyed/unkey/pkg/ptr"
 	"github.com/unkeyed/unkey/pkg/uid"
-	"github.com/unkeyed/unkey/svc/api/internal/projects"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_projects_list_projects"
@@ -112,7 +112,7 @@ func TestListProjectsHidesDefaultProject(t *testing.T) {
 		ID:               ids[1],
 		WorkspaceID:      workspace.ID,
 		Name:             "Default",
-		Slug:             projects.DefaultSlug,
+		Slug:             projectgate.DefaultSlug,
 		DeleteProtection: true,
 	})
 	h.CreateProject(seed.CreateProjectRequest{
@@ -144,7 +144,7 @@ func TestListProjectsHidesDefaultProject(t *testing.T) {
 
 	t.Run("does not return default in search", func(t *testing.T) {
 		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{
-			Search: ptr.P(projects.DefaultSlug),
+			Search: ptr.P(projectgate.DefaultSlug),
 		})
 		require.Equal(t, http.StatusOK, res.Status, "expected 200, received: %s", res.RawBody)
 		require.Empty(t, res.Body.Data)

--- a/svc/api/routes/v2_projects_update_project/400_test.go
+++ b/svc/api/routes/v2_projects_update_project/400_test.go
@@ -9,7 +9,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/unkeyed/unkey/pkg/ptr"
+	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/projects"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_projects_update_project"
 )
@@ -55,6 +58,24 @@ func TestUpdateProjectBadRequest(t *testing.T) {
 			require.Greater(t, len(res.Body.Error.Errors), 0)
 		})
 	}
+
+	t.Run("reserved default slug", func(t *testing.T) {
+		project := h.CreateProject(seed.CreateProjectRequest{
+			ID:          uid.New(uid.ProjectPrefix),
+			WorkspaceID: h.Resources().UserWorkspace.ID,
+			Name:        "Payments",
+			Slug:        "payments",
+		})
+
+		for _, slug := range []string{projects.DefaultSlug, "Default"} {
+			res := testutil.CallRoute[handler.Request, openapi.BadRequestErrorResponse](h, route, headers, handler.Request{
+				Project: project.ID,
+				Slug:    &slug,
+			})
+			require.Equal(t, http.StatusBadRequest, res.Status, "expected 400 for reserved slug %q, received: %s", slug, res.RawBody)
+			require.Equal(t, fmt.Sprintf("The project slug '%s' is reserved.", slug), res.Body.Error.Detail)
+		}
+	})
 
 	t.Run("invalid json", func(t *testing.T) {
 		invalidJSON := `{"project": }`

--- a/svc/api/routes/v2_projects_update_project/400_test.go
+++ b/svc/api/routes/v2_projects_update_project/400_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/deploy/projectgate"
 	"github.com/unkeyed/unkey/pkg/ptr"
 	"github.com/unkeyed/unkey/pkg/uid"
-	"github.com/unkeyed/unkey/svc/api/internal/projects"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
 	"github.com/unkeyed/unkey/svc/api/openapi"
@@ -67,7 +67,7 @@ func TestUpdateProjectBadRequest(t *testing.T) {
 			Slug:        "payments",
 		})
 
-		for _, slug := range []string{projects.DefaultSlug, "Default"} {
+		for _, slug := range []string{projectgate.DefaultSlug, "Default"} {
 			res := testutil.CallRoute[handler.Request, openapi.BadRequestErrorResponse](h, route, headers, handler.Request{
 				Project: project.ID,
 				Slug:    &slug,

--- a/svc/api/routes/v2_projects_update_project/404_test.go
+++ b/svc/api/routes/v2_projects_update_project/404_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/unkeyed/unkey/pkg/db"
+	"github.com/unkeyed/unkey/pkg/deploy/projectgate"
 	"github.com/unkeyed/unkey/pkg/uid"
-	"github.com/unkeyed/unkey/svc/api/internal/projects"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_projects_update_project"
@@ -57,7 +57,7 @@ func TestUpdateProjectNotFound(t *testing.T) {
 			ID:               uid.New(uid.ProjectPrefix),
 			WorkspaceID:      workspace.ID,
 			Name:             "Default",
-			Slug:             projects.DefaultSlug,
+			Slug:             projectgate.DefaultSlug,
 			DeleteProtection: true,
 		})
 		newSlug := "renamed-default"
@@ -76,7 +76,7 @@ func TestUpdateProjectNotFound(t *testing.T) {
 		stored, err := db.Query.FindProjectById(t.Context(), h.DB.RO(), project.ID)
 		require.NoError(t, err)
 		require.Equal(t, "Default", stored.Name)
-		require.Equal(t, projects.DefaultSlug, stored.Slug)
+		require.Equal(t, projectgate.DefaultSlug, stored.Slug)
 		require.True(t, stored.DeleteProtection.Bool)
 		require.False(t, stored.UpdatedAt.Valid)
 	})

--- a/svc/api/routes/v2_projects_update_project/404_test.go
+++ b/svc/api/routes/v2_projects_update_project/404_test.go
@@ -7,7 +7,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/projects"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_projects_update_project"
@@ -48,5 +50,34 @@ func TestUpdateProjectNotFound(t *testing.T) {
 
 		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{Project: project.ID, Name: &newName})
 		require.Equal(t, http.StatusNotFound, res.Status, "expected 404 for cross-workspace project, received: %s", res.RawBody)
+	})
+
+	t.Run("default project returns 404 and remains unchanged", func(t *testing.T) {
+		project := h.CreateProject(seed.CreateProjectRequest{
+			ID:               uid.New(uid.ProjectPrefix),
+			WorkspaceID:      workspace.ID,
+			Name:             "Default",
+			Slug:             projects.DefaultSlug,
+			DeleteProtection: true,
+		})
+		newSlug := "renamed-default"
+		unprotect := false
+
+		for _, identifier := range []string{project.ID, project.Slug} {
+			res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{
+				Project:          identifier,
+				Name:             &newName,
+				Slug:             &newSlug,
+				DeleteProtection: &unprotect,
+			})
+			require.Equal(t, http.StatusNotFound, res.Status, "expected 404 for default project %q, received: %s", identifier, res.RawBody)
+		}
+
+		stored, err := db.Query.FindProjectById(t.Context(), h.DB.RO(), project.ID)
+		require.NoError(t, err)
+		require.Equal(t, "Default", stored.Name)
+		require.Equal(t, projects.DefaultSlug, stored.Slug)
+		require.True(t, stored.DeleteProtection.Bool)
+		require.False(t, stored.UpdatedAt.Valid)
 	})
 }

--- a/svc/api/routes/v2_projects_update_project/handler.go
+++ b/svc/api/routes/v2_projects_update_project/handler.go
@@ -11,10 +11,10 @@ import (
 	"github.com/unkeyed/unkey/pkg/auditlog"
 	"github.com/unkeyed/unkey/pkg/codes"
 	"github.com/unkeyed/unkey/pkg/db"
+	"github.com/unkeyed/unkey/pkg/deploy/projectgate"
 	"github.com/unkeyed/unkey/pkg/fault"
 	"github.com/unkeyed/unkey/pkg/rbac"
 	"github.com/unkeyed/unkey/pkg/zen"
-	"github.com/unkeyed/unkey/svc/api/internal/projects"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
 
@@ -70,7 +70,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			)
 		}
 
-		if project.Slug == projects.DefaultSlug {
+		if project.Slug == projectgate.DefaultSlug {
 			return openapi.Project{}, fault.New(
 				"project not found",
 				fault.Code(codes.Data.Project.NotFound.URN()),
@@ -95,13 +95,10 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			return openapi.Project{}, err
 		}
 
-		if req.Slug != nil && projects.IsReservedSlug(*req.Slug) {
-			return openapi.Project{}, fault.New(
-				"project slug is reserved",
-				fault.Code(codes.App.Validation.InvalidInput.URN()),
-				fault.Internal("default project slug is reserved"),
-				fault.Public(fmt.Sprintf("The project slug '%s' is reserved.", *req.Slug)),
-			)
+		if req.Slug != nil {
+			if err = projectgate.CheckSlug(*req.Slug); err != nil {
+				return openapi.Project{}, err
+			}
 		}
 
 		updatedAt := time.Now().UnixMilli()

--- a/svc/api/routes/v2_projects_update_project/handler.go
+++ b/svc/api/routes/v2_projects_update_project/handler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/unkeyed/unkey/pkg/fault"
 	"github.com/unkeyed/unkey/pkg/rbac"
 	"github.com/unkeyed/unkey/pkg/zen"
+	"github.com/unkeyed/unkey/svc/api/internal/projects"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
 
@@ -69,6 +70,15 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			)
 		}
 
+		if project.Slug == projects.DefaultSlug {
+			return openapi.Project{}, fault.New(
+				"project not found",
+				fault.Code(codes.Data.Project.NotFound.URN()),
+				fault.Internal("default project is not exposed by the projects API"),
+				fault.Public("The requested project does not exist."),
+			)
+		}
+
 		err = principal.Authorize(rbac.Or(
 			rbac.T(rbac.Tuple{
 				ResourceType: rbac.Project,
@@ -83,6 +93,15 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		))
 		if err != nil {
 			return openapi.Project{}, err
+		}
+
+		if req.Slug != nil && projects.IsReservedSlug(*req.Slug) {
+			return openapi.Project{}, fault.New(
+				"project slug is reserved",
+				fault.Code(codes.App.Validation.InvalidInput.URN()),
+				fault.Internal("default project slug is reserved"),
+				fault.Public(fmt.Sprintf("The project slug '%s' is reserved.", *req.Slug)),
+			)
 		}
 
 		updatedAt := time.Now().UnixMilli()

--- a/svc/ctrl/services/project/create_project.go
+++ b/svc/ctrl/services/project/create_project.go
@@ -4,21 +4,20 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"strings"
 	"time"
 
 	"connectrpc.com/connect"
 	ctrlv1 "github.com/unkeyed/unkey/gen/proto/ctrl/v1"
 	"github.com/unkeyed/unkey/pkg/assert"
 	"github.com/unkeyed/unkey/pkg/auditlog"
+	"github.com/unkeyed/unkey/pkg/deploy/projectgate"
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/actor"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/auth"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/db"
+	"github.com/unkeyed/unkey/svc/ctrl/internal/gatefault"
 )
-
-const reservedDefaultProjectSlug = "default"
 
 // CreateProject creates an empty project. Apps and their environments are
 // created separately via [app.Service.CreateApp], so a fresh project starts
@@ -34,10 +33,12 @@ func (s *Service) CreateProject(
 		assert.NotEmpty(req.Msg.GetWorkspaceId(), "workspace_id is required"),
 		assert.NotEmpty(req.Msg.GetName(), "name is required"),
 		assert.NotEmpty(req.Msg.GetSlug(), "slug is required"),
-		assert.False(strings.EqualFold(req.Msg.GetSlug(), reservedDefaultProjectSlug), "slug is reserved"),
 		assert.NotNil(req.Msg.GetActor(), "actor is required"),
 	); err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
+	if err := projectgate.CheckSlug(req.Msg.GetSlug()); err != nil {
+		return nil, gatefault.ConnectWith(connect.CodeInvalidArgument, err)
 	}
 
 	workspaceID := req.Msg.GetWorkspaceId()

--- a/svc/ctrl/services/project/create_project.go
+++ b/svc/ctrl/services/project/create_project.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 	"time"
 
 	"connectrpc.com/connect"
@@ -16,6 +17,8 @@ import (
 	"github.com/unkeyed/unkey/svc/ctrl/internal/auth"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/db"
 )
+
+const reservedDefaultProjectSlug = "default"
 
 // CreateProject creates an empty project. Apps and their environments are
 // created separately via [app.Service.CreateApp], so a fresh project starts
@@ -31,6 +34,7 @@ func (s *Service) CreateProject(
 		assert.NotEmpty(req.Msg.GetWorkspaceId(), "workspace_id is required"),
 		assert.NotEmpty(req.Msg.GetName(), "name is required"),
 		assert.NotEmpty(req.Msg.GetSlug(), "slug is required"),
+		assert.False(strings.EqualFold(req.Msg.GetSlug(), reservedDefaultProjectSlug), "slug is reserved"),
 		assert.NotNil(req.Msg.GetActor(), "actor is required"),
 	); err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)

--- a/svc/ctrl/services/project/create_project_test.go
+++ b/svc/ctrl/services/project/create_project_test.go
@@ -25,7 +25,7 @@ func TestCreateProjectRejectsReservedSlug(t *testing.T) {
 			_, err := svc.CreateProject(t.Context(), req)
 			require.Error(t, err)
 			require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
-			require.ErrorContains(t, err, "slug is reserved")
+			require.ErrorContains(t, err, "is reserved")
 		})
 	}
 }

--- a/svc/ctrl/services/project/create_project_test.go
+++ b/svc/ctrl/services/project/create_project_test.go
@@ -1,0 +1,31 @@
+package project
+
+import (
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/require"
+	ctrlv1 "github.com/unkeyed/unkey/gen/proto/ctrl/v1"
+)
+
+func TestCreateProjectRejectsReservedSlug(t *testing.T) {
+	const bearer = "test-token"
+	svc := New(Config{Bearer: bearer})
+
+	for _, slug := range []string{"default", "Default"} {
+		t.Run(slug, func(t *testing.T) {
+			req := connect.NewRequest(&ctrlv1.CreateProjectRequest{
+				WorkspaceId: "ws_test",
+				Name:        "Reserved",
+				Slug:        slug,
+				Actor:       &ctrlv1.ActorInfo{},
+			})
+			req.Header().Set("Authorization", "Bearer "+bearer)
+
+			_, err := svc.CreateProject(t.Context(), req)
+			require.Error(t, err)
+			require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+			require.ErrorContains(t, err, "slug is reserved")
+		})
+	}
+}


### PR DESCRIPTION
## Problem:

Every workspace has a default project that we'll use to store keyspaces ratelimits etc. Currently our API  exposed the project and allowed users to change or delete it. 
Users could also create or rename a project with the reserved `default` slug.

## Solution:

- Hide the default project from project lists, searches, and direct reads.
- Return `404` for update and delete requests that target the default project.
- Reject project create and update requests that use the reserved `default` slug.
- Use one shared project rule for the API and control plane so dashboard and other clients follow the same rule.

## Impact:

API clients no longer receive the default project from project management endpoints. Requests for the internal project return the same response as a missing project. Project create and update requests with any case variant of `default` return `400`.

Internal default-project ownership flows continue to use the project.

## Testing:

- `mise run build` passed. Lint reported 0 issues.
- `mise exec -- go test ./pkg/deploy/projectgate ./svc/ctrl/services/project` passed.
- Affected API route packages compiled successfully.
- Focused API route tests did not run to completion because the shared MySQL test container rejected its configured test credentials.