### PR TITLE
feat(dashboard): Add a Limits page to workspace settings

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/layout.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/layout.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useWorkspaceNavigation } from "@/hooks/use-workspace-navigation";
+import { useBillingUIUpgrades } from "@/lib/flags/use-billing-ui-upgrades";
 import { routes } from "@/lib/navigation/routes";
 import { SecondaryNav, SecondaryNavGroup, SecondaryNavItem, SecondaryNavTitle } from "@unkey/ui";
 import Link from "next/link";
@@ -12,20 +13,27 @@ const ITEMS = [
   { segment: "team", label: "Team", getHref: routes.settings.team },
   { segment: "root-keys", label: "Root Keys", getHref: routes.settings.rootKeys },
   { segment: "billing", label: "Billing", getHref: routes.settings.billing },
+  { segment: "limits", label: "Limits", getHref: routes.settings.limits },
   { segment: "security", label: "Security", getHref: routes.settings.security },
 ] as const;
+
+const BILLING_UPGRADE_SEGMENTS: ReadonlySet<string> = new Set(["limits"]);
 
 export default function SettingsLayout({ children }: { children: ReactNode }) {
   const workspace = useWorkspaceNavigation();
   const segments = useSelectedLayoutSegments();
   const active = segments[0] ?? "general";
+  const billingUpgrades = useBillingUIUpgrades();
+  const items = ITEMS.filter(
+    (item) => billingUpgrades || !BILLING_UPGRADE_SEGMENTS.has(item.segment),
+  );
 
   return (
     <div className="flex flex-col md:flex-row w-full flex-1 min-h-0">
       <SecondaryNav aria-label="Settings">
         <SecondaryNavTitle>Settings</SecondaryNavTitle>
         <SecondaryNavGroup>
-          {ITEMS.map((item) => (
+          {items.map((item) => (
             <SecondaryNavItem
               key={item.segment}
               active={active === item.segment}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/limits/breach-banner.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/limits/breach-banner.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { SUPPORT_MAILTO } from "@/lib/support";
+import { AlertBanner, AlertBannerDescription, AlertBannerTitle } from "@unkey/ui";
+import type { Route } from "next";
+import Link from "next/link";
+import type { ReactNode } from "react";
+import type { GroupKey } from "./limit-groups";
+
+export function BreachBanner({
+  breached,
+  billingHref,
+}: {
+  breached: GroupKey[];
+  billingHref: Route;
+}) {
+  const compute = breached.includes("compute");
+  const api = breached.includes("api");
+
+  if (compute && api) {
+    return (
+      <Banner>
+        Scale down or remove a deployment to free compute capacity. To raise your API operations
+        limit, <BannerLink href={billingHref}>upgrade your plan</BannerLink>.
+      </Banner>
+    );
+  }
+  if (compute) {
+    return (
+      <Banner>
+        Scale down or remove a deployment to free capacity. To request higher capacity limits,{" "}
+        <BannerLink href={SUPPORT_MAILTO}>contact us</BannerLink>.
+      </Banner>
+    );
+  }
+  return (
+    <Banner>
+      You're over your plan's allowed usage. To continue,{" "}
+      <BannerLink href={billingHref}>upgrade your plan</BannerLink>.
+    </Banner>
+  );
+}
+
+function Banner({ children }: { children: ReactNode }) {
+  return (
+    <AlertBanner variant="error">
+      <AlertBannerTitle>You've reached a limit</AlertBannerTitle>
+      <AlertBannerDescription>{children}</AlertBannerDescription>
+    </AlertBanner>
+  );
+}
+
+function BannerLink({ href, children }: { href: Route; children: ReactNode }) {
+  return (
+    <Link href={href} className="underline underline-offset-2 hover:opacity-80">
+      {children}
+    </Link>
+  );
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/limits/limit-groups.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/limits/limit-groups.ts
@@ -1,0 +1,219 @@
+import type { Limits } from "@unkey/db";
+
+export type LimitStatus = "ok" | "at-limit" | "over";
+
+export type GroupKey = "api" | "logs" | "compute";
+
+export type RowUsage =
+  | { state: "loading" }
+  | { state: "error" }
+  | { state: "ready"; value: number; max: number; label: string };
+
+export type LimitRow = {
+  name: string;
+  description?: string;
+  limit: string;
+  usage?: RowUsage;
+  status: LimitStatus;
+};
+
+export type LimitGroup = {
+  key: GroupKey;
+  title: string;
+  description: string;
+  rows: LimitRow[];
+};
+
+export type Measured<T> = { state: "loading" } | { state: "error" } | { state: "ready"; value: T };
+
+export type Allocation = {
+  totalCpuMillicores: number;
+  totalMemoryMib: number;
+  totalStorageMib: number;
+};
+
+const MIB_PER_GIB = 1024;
+const MILLICORES_PER_CORE = 1000;
+
+function count(value: number): string {
+  return new Intl.NumberFormat("en-US").format(value);
+}
+
+function cores(millicores: number): string {
+  const value = millicores / MILLICORES_PER_CORE;
+  return `${Number.isInteger(value) ? value : value.toFixed(2)} vCPU`;
+}
+
+function mib(value: number): string {
+  if (value < MIB_PER_GIB) {
+    return `${count(value)} MiB`;
+  }
+  const gib = value / MIB_PER_GIB;
+  return `${Number.isInteger(gib) ? gib : gib.toFixed(1)} GiB`;
+}
+
+function days(value: number): string {
+  return `${value} day${value === 1 ? "" : "s"}`;
+}
+
+function statusOf(usage: RowUsage | undefined): LimitStatus {
+  if (usage?.state !== "ready") {
+    return "ok";
+  }
+  if (usage.max === 0) {
+    return usage.value > 0 ? "over" : "ok";
+  }
+  if (usage.value > usage.max) {
+    return "over";
+  }
+  if (usage.value === usage.max) {
+    return "at-limit";
+  }
+  return "ok";
+}
+
+function usageOf<T>(
+  measured: Measured<T>,
+  read: (value: T) => number,
+  max: number,
+  format: (value: number) => string,
+): RowUsage {
+  if (measured.state !== "ready") {
+    return measured;
+  }
+  const value = read(measured.value);
+  return { state: "ready", value, max, label: format(value) };
+}
+
+function metered(row: Omit<LimitRow, "status">): LimitRow {
+  return { ...row, status: statusOf(row.usage) };
+}
+
+function ceiling(row: Omit<LimitRow, "status" | "usage">): LimitRow {
+  return { ...row, status: "ok" };
+}
+
+function apiGroup(limits: Limits, apiOperations: Measured<number>): LimitGroup {
+  return {
+    key: "api",
+    title: "API management",
+    description: "Operation and request limits for the Unkey API.",
+    rows: [
+      metered({
+        name: "Monthly API operations",
+        description: "Billable key verifications and rate limit operations each month.",
+        limit: count(limits.apiBillableOperationsCountMaxPerMonth),
+        usage: usageOf(
+          apiOperations,
+          (value) => value,
+          limits.apiBillableOperationsCountMaxPerMonth,
+          count,
+        ),
+      }),
+      ceiling({
+        name: "API requests per minute",
+        limit:
+          limits.apiRequestsCountMaxPerMinute === null
+            ? "Unlimited"
+            : `${count(limits.apiRequestsCountMaxPerMinute)} / min`,
+      }),
+    ],
+  };
+}
+
+function logsGroup(limits: Limits): LimitGroup {
+  return {
+    key: "logs",
+    title: "Logs",
+    description: "Retention periods for operational and audit data.",
+    rows: [
+      ceiling({
+        name: "Log retention",
+        description: "How long request and runtime logs remain available.",
+        limit: days(limits.logsRetentionDaysMax),
+      }),
+      ceiling({
+        name: "Audit log retention",
+        limit: days(limits.logsAuditRetentionDaysMax),
+      }),
+    ],
+  };
+}
+
+function computeGroup(limits: Limits, allocation: Measured<Allocation>): LimitGroup {
+  return {
+    key: "compute",
+    title: "Compute",
+    description: "Workspace and per-instance resource ceilings.",
+    rows: [
+      metered({
+        name: "Workspace CPU",
+        description: "Total CPU across all your apps.",
+        limit: cores(limits.cpuCoresMax * MILLICORES_PER_CORE),
+        usage: usageOf(
+          allocation,
+          (value) => value.totalCpuMillicores,
+          limits.cpuCoresMax * MILLICORES_PER_CORE,
+          cores,
+        ),
+      }),
+      ceiling({
+        name: "CPU per instance",
+        limit: cores(limits.cpuCoresMaxPerInstance * MILLICORES_PER_CORE),
+      }),
+      metered({
+        name: "Workspace memory",
+        description: "Total memory across all your apps.",
+        limit: mib(limits.memoryMibMax),
+        usage: usageOf(allocation, (value) => value.totalMemoryMib, limits.memoryMibMax, mib),
+      }),
+      ceiling({
+        name: "Memory per instance",
+        limit: mib(limits.memoryMibMaxPerInstance),
+      }),
+      metered({
+        name: "Workspace ephemeral disk",
+        description: "Total disk across all your apps.",
+        limit: mib(limits.storageMibMax),
+        usage: usageOf(allocation, (value) => value.totalStorageMib, limits.storageMibMax, mib),
+      }),
+      ceiling({
+        name: "Ephemeral disk per instance",
+        limit: mib(limits.storageMibMaxPerInstance),
+      }),
+      ceiling({
+        name: "Concurrent builds",
+        limit: count(limits.buildsConcurrentMax),
+      }),
+      ceiling({
+        name: "Replicas per region",
+        description: "Instances autoscaling can run for one app in a region.",
+        limit: count(limits.autoscalingReplicasMax),
+      }),
+    ],
+  };
+}
+
+export function buildLimitGroups({
+  limits,
+  hasComputePlan,
+  apiOperations,
+  allocation,
+}: {
+  limits: Limits;
+  hasComputePlan: boolean;
+  apiOperations: Measured<number>;
+  allocation: Measured<Allocation>;
+}): LimitGroup[] {
+  const groups = [apiGroup(limits, apiOperations), logsGroup(limits)];
+  if (hasComputePlan) {
+    groups.push(computeGroup(limits, allocation));
+  }
+  return groups;
+}
+
+export function breachedGroups(groups: LimitGroup[]): GroupKey[] {
+  return groups
+    .filter((group) => group.rows.some((row) => row.status !== "ok"))
+    .map((group) => group.key);
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/limits/limit-item.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/limits/limit-item.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { CircleInfo } from "@unkey/icons";
+import {
+  Badge,
+  InfoTooltip,
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemTitle,
+  Meter,
+  MeterHeader,
+  MeterIndicator,
+  MeterTrack,
+  MeterValue,
+  Skeleton,
+} from "@unkey/ui";
+import type { LimitRow } from "./limit-groups";
+
+export function LimitItem({ row }: { row: LimitRow }) {
+  return (
+    <Item>
+      <ItemContent>
+        <div className="flex h-5 items-center gap-2">
+          <ItemTitle>{row.name}</ItemTitle>
+          {row.description ? (
+            <InfoTooltip content={row.description} position={{ side: "right" }}>
+              <CircleInfo iconSize="sm-regular" className="shrink-0 text-gray-9" />
+            </InfoTooltip>
+          ) : null}
+          {row.status === "ok" ? null : (
+            <Badge variant="error" size="sm">
+              {row.status === "over" ? "Over limit" : "At limit"}
+            </Badge>
+          )}
+        </div>
+      </ItemContent>
+      <ItemActions className="w-64 flex-col items-stretch gap-1.5">
+        <LimitValue row={row} />
+      </ItemActions>
+    </Item>
+  );
+}
+
+function LimitValue({ row }: { row: LimitRow }) {
+  const usage = row.usage;
+
+  if (!usage) {
+    return <span className="text-right tabular-nums">{row.limit}</span>;
+  }
+
+  if (usage.state === "loading") {
+    return (
+      <>
+        <div className="flex items-baseline justify-between gap-3">
+          <Skeleton className="h-3 w-14" />
+          <span className="tabular-nums">{row.limit}</span>
+        </div>
+        <Skeleton className="h-1.5 w-full rounded-full" />
+      </>
+    );
+  }
+
+  if (usage.state === "error") {
+    return (
+      <div className="flex items-baseline justify-between gap-3">
+        <span className="text-xs text-gray-9">Usage unavailable</span>
+        <span className="tabular-nums">{row.limit}</span>
+      </div>
+    );
+  }
+
+  const breached = row.status !== "ok";
+
+  return (
+    <Meter
+      aria-label={row.name}
+      value={usage.value}
+      max={Math.max(usage.max, 1)}
+      className="gap-1.5"
+    >
+      <MeterHeader className="gap-3">
+        <MeterValue className={breached ? "text-error-11" : "font-normal text-gray-11"}>
+          {() => usage.label}
+        </MeterValue>
+        <span className="tabular-nums">{row.limit}</span>
+      </MeterHeader>
+      <MeterTrack>
+        <MeterIndicator className={breached ? "bg-error-9" : undefined} />
+      </MeterTrack>
+    </Meter>
+  );
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/limits/limit-item.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/limits/limit-item.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { CircleInfo } from "@unkey/icons";
+import { P, match } from "@unkey/match";
 import {
   Badge,
   InfoTooltip,
@@ -43,14 +44,11 @@ export function LimitItem({ row }: { row: LimitRow }) {
 }
 
 function LimitValue({ row }: { row: LimitRow }) {
-  const usage = row.usage;
+  const breached = row.status !== "ok";
 
-  if (!usage) {
-    return <span className="text-right tabular-nums">{row.limit}</span>;
-  }
-
-  if (usage.state === "loading") {
-    return (
+  return match(row.usage)
+    .with(P.nullish, () => <span className="text-right tabular-nums">{row.limit}</span>)
+    .with({ state: "loading" }, () => (
       <>
         <div className="flex items-baseline justify-between gap-3">
           <Skeleton className="h-3 w-14" />
@@ -58,36 +56,30 @@ function LimitValue({ row }: { row: LimitRow }) {
         </div>
         <Skeleton className="h-1.5 w-full rounded-full" />
       </>
-    );
-  }
-
-  if (usage.state === "error") {
-    return (
+    ))
+    .with({ state: "error" }, () => (
       <div className="flex items-baseline justify-between gap-3">
         <span className="text-xs text-gray-9">Usage unavailable</span>
         <span className="tabular-nums">{row.limit}</span>
       </div>
-    );
-  }
-
-  const breached = row.status !== "ok";
-
-  return (
-    <Meter
-      aria-label={row.name}
-      value={usage.value}
-      max={Math.max(usage.max, 1)}
-      className="gap-1.5"
-    >
-      <MeterHeader className="gap-3">
-        <MeterValue className={breached ? "text-error-11" : "font-normal text-gray-11"}>
-          {() => usage.label}
-        </MeterValue>
-        <span className="tabular-nums">{row.limit}</span>
-      </MeterHeader>
-      <MeterTrack>
-        <MeterIndicator className={breached ? "bg-error-9" : undefined} />
-      </MeterTrack>
-    </Meter>
-  );
+    ))
+    .with({ state: "ready" }, (usage) => (
+      <Meter
+        aria-label={row.name}
+        value={usage.value}
+        max={Math.max(usage.max, 1)}
+        className="gap-1.5"
+      >
+        <MeterHeader className="gap-3">
+          <MeterValue className={breached ? "text-error-11" : "font-normal text-gray-11"}>
+            {() => usage.label}
+          </MeterValue>
+          <span className="tabular-nums">{row.limit}</span>
+        </MeterHeader>
+        <MeterTrack>
+          <MeterIndicator className={breached ? "bg-error-9" : undefined} />
+        </MeterTrack>
+      </Meter>
+    ))
+    .exhaustive();
 }

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/limits/page.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/limits/page.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { PageLoading } from "@/components/dashboard/page-loading";
+import { useBillingUIUpgrades } from "@/lib/flags/use-billing-ui-upgrades";
+import { routes } from "@/lib/navigation/routes";
+import { SUPPORT_MAILTO } from "@/lib/support";
+import { trpc } from "@/lib/trpc/client";
+import { useWorkspace } from "@/providers/workspace-provider";
+import { Cube, Layers3, Nodes } from "@unkey/icons";
+import {
+  Button,
+  Empty,
+  ItemContent,
+  ItemDescription,
+  ItemGroup,
+  ItemHeader,
+  ItemMedia,
+  ItemSeparator,
+  ItemTitle,
+  PageBody,
+  PageContainer,
+  PageHeader,
+  PageHeaderActions,
+  PageHeaderContent,
+  PageHeaderTitle,
+} from "@unkey/ui";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { Fragment, type ReactNode } from "react";
+import { BreachBanner } from "./breach-banner";
+import {
+  type GroupKey,
+  type LimitGroup,
+  type Measured,
+  breachedGroups,
+  buildLimitGroups,
+} from "./limit-groups";
+import { LimitItem } from "./limit-item";
+
+const CHIPS: Record<GroupKey, { icon: ReactNode; className: string }> = {
+  api: { icon: <Nodes />, className: "bg-infoA-3 text-info-11" },
+  logs: { icon: <Layers3 />, className: "bg-grayA-3 text-gray-11" },
+  compute: { icon: <Cube />, className: "bg-orangeA-3 text-orange-11" },
+};
+
+function measured<T>(query: { data: T | undefined; isError: boolean }): Measured<T> {
+  if (query.isError) {
+    return { state: "error" };
+  }
+  return query.data === undefined ? { state: "loading" } : { state: "ready", value: query.data };
+}
+
+export default function LimitsPage() {
+  const billingUpgrades = useBillingUIUpgrades();
+  const { workspace, limits, isLoading } = useWorkspace();
+  const hasComputePlan = Boolean(workspace?.deployPlan) || Boolean(workspace?.deployPlanOverride);
+
+  const usage = trpc.billing.queryUsage.useQuery(undefined, {
+    enabled: Boolean(workspace) && billingUpgrades,
+    trpc: { context: { skipBatch: true } },
+    retry: 1,
+  });
+  const allocation = trpc.billing.queryComputeAllocation.useQuery(undefined, {
+    enabled: Boolean(workspace) && billingUpgrades && hasComputePlan,
+    trpc: { context: { skipBatch: true } },
+    retry: 1,
+  });
+
+  if (!billingUpgrades) {
+    notFound();
+  }
+
+  if (isLoading) {
+    return (
+      <Shell>
+        <PageLoading message="Loading limits..." />
+      </Shell>
+    );
+  }
+
+  if (!limits || !workspace) {
+    return (
+      <Shell>
+        <Empty>
+          <Empty.Title>Limits unavailable</Empty.Title>
+          <Empty.Description>
+            We could not read the limits for this workspace. Please try again later.
+          </Empty.Description>
+        </Empty>
+      </Shell>
+    );
+  }
+
+  const groups = buildLimitGroups({
+    limits,
+    hasComputePlan,
+    apiOperations: measured({ data: usage.data?.billableTotal, isError: usage.isError }),
+    allocation: measured(allocation),
+  });
+  const breached = breachedGroups(groups);
+
+  return (
+    <Shell>
+      {breached.length > 0 ? (
+        <BreachBanner
+          breached={breached}
+          billingHref={routes.settings.billing({ workspaceSlug: workspace.slug, intent: "api" })}
+        />
+      ) : null}
+      {groups.map((group) => (
+        <Group key={group.key} group={group} />
+      ))}
+    </Shell>
+  );
+}
+
+function Shell({ children }: { children: ReactNode }) {
+  return (
+    <PageContainer>
+      <PageHeader>
+        <PageHeaderContent>
+          <PageHeaderTitle>Limits</PageHeaderTitle>
+        </PageHeaderContent>
+        <PageHeaderActions>
+          <Button variant="primary" render={<Link href={SUPPORT_MAILTO} />}>
+            Request a change
+          </Button>
+        </PageHeaderActions>
+      </PageHeader>
+      <PageBody>{children}</PageBody>
+    </PageContainer>
+  );
+}
+
+function Group({ group }: { group: LimitGroup }) {
+  const chip = CHIPS[group.key];
+
+  return (
+    <ItemGroup variant="outline">
+      <ItemHeader>
+        <ItemMedia className={chip.className}>{chip.icon}</ItemMedia>
+        <ItemContent>
+          <ItemTitle>{group.title}</ItemTitle>
+          <ItemDescription>{group.description}</ItemDescription>
+        </ItemContent>
+      </ItemHeader>
+      {group.rows.map((row) => (
+        <Fragment key={row.name}>
+          <ItemSeparator />
+          <LimitItem row={row} />
+        </Fragment>
+      ))}
+    </ItemGroup>
+  );
+}

--- a/web/apps/dashboard/lib/navigation/routes/settings.test.ts
+++ b/web/apps/dashboard/lib/navigation/routes/settings.test.ts
@@ -10,6 +10,13 @@ describe("settings-scoped paths", () => {
     expect(routes.settings.team(scope)).toBe("/acme/settings/team");
     expect(routes.settings.rootKeys(scope)).toBe("/acme/settings/root-keys");
     expect(routes.settings.billing(scope)).toBe("/acme/settings/billing");
+    expect(routes.settings.limits(scope)).toBe("/acme/settings/limits");
+  });
+
+  it("carries the plan-picker intent onto billing", () => {
+    expect(routes.settings.billing({ workspaceSlug: ws, intent: "api" })).toBe(
+      "/acme/settings/billing?intent=api",
+    );
   });
 
   it("builds the stripe redirect paths", () => {

--- a/web/apps/dashboard/lib/navigation/routes/settings.ts
+++ b/web/apps/dashboard/lib/navigation/routes/settings.ts
@@ -28,8 +28,16 @@ export const settingsRoutes = {
     return buildRoute("/[workspaceSlug]/settings/root-keys", { workspaceSlug });
   },
 
-  billing({ workspaceSlug }: WorkspaceScope): Route {
-    return buildRoute("/[workspaceSlug]/settings/billing", { workspaceSlug });
+  billing({ workspaceSlug, intent }: WorkspaceScope & { intent?: "compute" | "api" }): Route {
+    return buildRoute(
+      "/[workspaceSlug]/settings/billing",
+      { workspaceSlug },
+      intent ? { intent } : undefined,
+    );
+  },
+
+  limits({ workspaceSlug }: WorkspaceScope): Route {
+    return buildRoute("/[workspaceSlug]/settings/limits", { workspaceSlug });
   },
 
   security({ workspaceSlug }: WorkspaceScope): Route {

--- a/web/apps/dashboard/lib/support.ts
+++ b/web/apps/dashboard/lib/support.ts
@@ -1,0 +1,5 @@
+import type { Route } from "next";
+
+// typedRoutes only knows app-router paths, so an off-app destination has to be
+// asserted. Done once here so call sites stay cast-free.
+export const SUPPORT_MAILTO = "mailto:support@unkey.com" as Route;


### PR DESCRIPTION
- A new Limits page in workspace settings, under the `billing-ui-upgrades` flag.
- It shows users their 'product' limits so people can see what they've used out of their plans quota.

## Screenshots

| Limits |
| --- |
| **Pro, healthy** |
| ![limits--pro-healthy](https://github.com/user-attachments/assets/f071bbf2-f28b-491c-8b8d-3be78e70247c) |
| **Starter, over** |
| ![limits--starter-over](https://github.com/user-attachments/assets/5bf5fc64-f2fd-4d44-bfcc-11c448bb6c76) |
| **API over quota** |
| ![limits--api-over-quota](https://github.com/user-attachments/assets/4e5e24d4-b9fd-4133-88a9-099b0be8fbdb) |
| **No plan** |
| ![limits--no-plan](https://github.com/user-attachments/assets/c185077a-3384-4404-a7e2-6baccb377a9e) |

