### PR TITLE
feat(dashboard): Add a Usage page to workspace settings

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/layout.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/layout.tsx
@@ -13,11 +13,12 @@ const ITEMS = [
   { segment: "team", label: "Team", getHref: routes.settings.team },
   { segment: "root-keys", label: "Root Keys", getHref: routes.settings.rootKeys },
   { segment: "billing", label: "Billing", getHref: routes.settings.billing },
+  { segment: "usage", label: "Usage", getHref: routes.settings.usage },
   { segment: "limits", label: "Limits", getHref: routes.settings.limits },
   { segment: "security", label: "Security", getHref: routes.settings.security },
 ] as const;
 
-const BILLING_UPGRADE_SEGMENTS: ReadonlySet<string> = new Set(["limits"]);
+const BILLING_UPGRADE_SEGMENTS: ReadonlySet<string> = new Set(["usage", "limits"]);
 
 export default function SettingsLayout({ children }: { children: ReactNode }) {
   const workspace = useWorkspaceNavigation();

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/usage/api-card.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/usage/api-card.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { formatDollars, formatNumber, formatPrice } from "@/lib/fmt";
+import { Gauge, Key2, Nodes } from "@unkey/icons";
+import {
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemDescription,
+  ItemGroup,
+  ItemHeader,
+  ItemMedia,
+  ItemSeparator,
+  ItemTitle,
+  Meter,
+  MeterHeader,
+  MeterIndicator,
+  MeterLabel,
+  MeterTrack,
+  MeterValue,
+  Skeleton,
+} from "@unkey/ui";
+import { Fragment, type ReactNode } from "react";
+
+type ApiCardProps = {
+  verifications: number | null;
+  ratelimits: number | null;
+  quota: number | null;
+  feeCents: number | null;
+  isLoading: boolean;
+};
+
+function fee(feeCents: number | null): string | null {
+  if (feeCents === null) {
+    return null;
+  }
+  return feeCents === 0 ? formatPrice(0) : formatDollars(feeCents);
+}
+
+export function ApiCard({ verifications, ratelimits, quota, feeCents, isLoading }: ApiCardProps) {
+  const rows: Array<{ icon: ReactNode; title: string; value: number | null }> = [
+    { icon: <Key2 />, title: "Key verifications", value: verifications },
+    { icon: <Gauge />, title: "Rate limit operations", value: ratelimits },
+  ];
+  const used = verifications === null || ratelimits === null ? null : verifications + ratelimits;
+
+  return (
+    <ItemGroup variant="outline">
+      <ItemHeader>
+        <ItemMedia className="bg-infoA-3 text-info-11">
+          <Nodes />
+        </ItemMedia>
+        <ItemContent>
+          <ItemTitle>API management</ItemTitle>
+          <ItemDescription>Valid requests this period</ItemDescription>
+        </ItemContent>
+        <ItemActions className="font-semibold text-2xl text-gray-12 leading-tight tracking-tight tabular-nums">
+          <Figure value={fee(feeCents)} isLoading={isLoading} skeletonClassName="h-6 w-16" />
+        </ItemActions>
+      </ItemHeader>
+
+      <div className="px-4 pb-4">
+        <Quota used={used} quota={quota} />
+      </div>
+
+      <div className="flex items-center gap-3 border-grayA-4 border-b bg-grayA-2 px-4 py-2 font-semibold text-[10px] text-gray-9 uppercase tracking-wider">
+        <div className="min-w-0 flex-1">Operation</div>
+        <div className="w-28 text-right">Requests</div>
+      </div>
+      {rows.map((row, index) => (
+        <Fragment key={row.title}>
+          {index === 0 ? null : <ItemSeparator />}
+          <Item>
+            <ItemMedia className="size-5 border border-grayA-4 bg-gray-1">{row.icon}</ItemMedia>
+            <ItemContent>
+              <ItemTitle className="truncate">{row.title}</ItemTitle>
+            </ItemContent>
+            <ItemActions className="w-28 justify-end tabular-nums">
+              <Figure
+                value={row.value === null ? null : row.value.toLocaleString("en-US")}
+                isLoading={isLoading}
+              />
+            </ItemActions>
+          </Item>
+        </Fragment>
+      ))}
+    </ItemGroup>
+  );
+}
+
+function Quota({ used, quota }: { used: number | null; quota: number | null }) {
+  if (used === null || quota === null) {
+    return (
+      <div className="flex flex-col gap-2">
+        <Skeleton className="h-4 w-44" />
+        <Skeleton className="h-1.5 w-full rounded-full" />
+      </div>
+    );
+  }
+
+  const percent = quota === 0 ? (used === 0 ? 0 : 100) : Math.round((used / quota) * 100);
+
+  return (
+    <Meter value={used} max={Math.max(quota, 1)}>
+      <MeterHeader>
+        <MeterLabel className="text-gray-12">
+          {formatNumber(used)} of {formatNumber(quota)} requests
+        </MeterLabel>
+        <MeterValue className="font-normal text-gray-10 text-xs">{() => `${percent}%`}</MeterValue>
+      </MeterHeader>
+      <MeterTrack>
+        <MeterIndicator />
+      </MeterTrack>
+    </Meter>
+  );
+}
+
+function Figure({
+  value,
+  isLoading,
+  skeletonClassName = "h-3 w-14",
+}: {
+  value: string | null;
+  isLoading: boolean;
+  skeletonClassName?: string;
+}) {
+  if (value !== null) {
+    return <>{value}</>;
+  }
+  if (isLoading) {
+    return <Skeleton className={skeletonClassName} />;
+  }
+  return <span className="font-normal text-[13px] text-gray-9">Unavailable</span>;
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/usage/compute-card.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/usage/compute-card.tsx
@@ -1,0 +1,258 @@
+"use client";
+
+import { formatCompactQuantity, formatPrice } from "@/lib/fmt";
+import { ChevronRight, Cube } from "@unkey/icons";
+import {
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemDescription,
+  ItemGroup,
+  ItemHeader,
+  ItemMedia,
+  ItemSeparator,
+  ItemTitle,
+  Skeleton,
+} from "@unkey/ui";
+import { Fragment, type ReactNode, useState } from "react";
+import {
+  type ComputeTree,
+  type UsageApp,
+  type UsageProject,
+  type UsageQuantities,
+  microCentsToDisplayCents,
+} from "./compute-tree";
+
+const QUANTITY_COLUMNS: ReadonlyArray<{
+  key: keyof UsageQuantities;
+  label: string;
+  width: string;
+}> = [
+  { key: "cpuHours", label: "CPU hrs", width: "w-16" },
+  { key: "memoryGiBHours", label: "Memory GiB-hrs", width: "w-24" },
+  { key: "egressGiB", label: "Egress GiB", width: "w-20" },
+  { key: "diskGiBHours", label: "Disk GiB-hrs", width: "w-24" },
+];
+
+const SKELETON_ROWS = ["first", "second", "third"];
+
+export function ComputeCardShell({
+  description,
+  amount,
+  children,
+}: {
+  description: string;
+  amount?: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <ItemGroup variant="outline">
+      <ItemHeader>
+        <ItemMedia className="bg-orangeA-3 text-orange-11">
+          <Cube />
+        </ItemMedia>
+        <ItemContent>
+          <ItemTitle>Compute</ItemTitle>
+          <ItemDescription>{description}</ItemDescription>
+        </ItemContent>
+        {amount === undefined ? null : (
+          <ItemActions className="font-semibold text-2xl text-gray-12 leading-tight tracking-tight tabular-nums">
+            {amount}
+          </ItemActions>
+        )}
+      </ItemHeader>
+      <ItemSeparator />
+      {children}
+    </ItemGroup>
+  );
+}
+
+export function ComputeCardSkeleton() {
+  return (
+    <ComputeCardShell
+      description="Usage per project this period"
+      amount={<Skeleton className="h-6 w-20" />}
+    >
+      {SKELETON_ROWS.map((row, index) => (
+        <Fragment key={row}>
+          {index === 0 ? null : <ItemSeparator />}
+          <Item className="gap-2">
+            <ChevronRight iconSize="sm-regular" className="shrink-0 text-gray-6" />
+            <ItemMedia className="size-5 border border-grayA-4 bg-gray-1">
+              <Cube />
+            </ItemMedia>
+            <ItemContent>
+              <Skeleton className="h-3 w-40" />
+            </ItemContent>
+            <ItemActions className="w-20 justify-end">
+              <Skeleton className="h-3 w-12" />
+            </ItemActions>
+          </Item>
+        </Fragment>
+      ))}
+    </ComputeCardShell>
+  );
+}
+
+type ComputeCardProps = {
+  tree: ComputeTree;
+};
+
+export function ComputeCard({ tree }: ComputeCardProps) {
+  const [open, setOpen] = useState<ReadonlySet<string>>(new Set());
+
+  const toggle = (projectId: string) =>
+    setOpen((current) => {
+      const next = new Set(current);
+      if (!next.delete(projectId)) {
+        next.add(projectId);
+      }
+      return next;
+    });
+
+  return (
+    <ComputeCardShell
+      description="Usage per project this period"
+      amount={formatPrice(microCentsToDisplayCents(tree.microCents))}
+    >
+      {tree.projects.length === 0 ? (
+        <Item>
+          <ItemContent>
+            <ItemDescription>No compute usage recorded this period.</ItemDescription>
+          </ItemContent>
+        </Item>
+      ) : (
+        tree.projects.map((project, index) => (
+          <Fragment key={project.projectId}>
+            {index === 0 ? null : <ItemSeparator className="bg-gray-5" />}
+            <ProjectRow
+              project={project}
+              open={open.has(project.projectId)}
+              onToggle={() => toggle(project.projectId)}
+            />
+          </Fragment>
+        ))
+      )}
+    </ComputeCardShell>
+  );
+}
+
+function ProjectRow({
+  project,
+  open,
+  onToggle,
+}: {
+  project: UsageProject;
+  open: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <div>
+      <Item
+        className="gap-2"
+        render={<button type="button" aria-expanded={open} onClick={onToggle} />}
+      >
+        <ChevronRight
+          iconSize="sm-regular"
+          className={`shrink-0 text-gray-9 transition-transform duration-150 ease-out motion-reduce:transition-none ${open ? "rotate-90" : ""}`}
+        />
+        <ItemMedia className="size-5 border border-grayA-4 bg-gray-1">
+          <Cube />
+        </ItemMedia>
+        <ItemContent>
+          <ItemTitle className="truncate">{project.name}</ItemTitle>
+        </ItemContent>
+        <ItemActions className="w-20 justify-end font-medium tabular-nums">
+          {formatPrice(microCentsToDisplayCents(project.microCents))}
+        </ItemActions>
+      </Item>
+      <div
+        className="grid transition-[grid-template-rows] duration-200 ease-out motion-reduce:transition-none"
+        style={{ gridTemplateRows: open ? "1fr" : "0fr" }}
+      >
+        <div className="overflow-hidden">
+          {project.apps.length === 0 ? null : (
+            <>
+              <Band>
+                <div className="min-w-0 flex-1">App</div>
+                {QUANTITY_COLUMNS.map((column) => (
+                  <div key={column.key} className={`${column.width} text-right`}>
+                    {column.label}
+                  </div>
+                ))}
+                <div className="w-20 text-right">Cost</div>
+              </Band>
+              {project.apps.map((app) => (
+                <AppRows key={app.appId} app={app} />
+              ))}
+            </>
+          )}
+          <Band>
+            <div className="min-w-0 flex-1">Gateway</div>
+            <div className="w-24 text-right">Keys</div>
+            <div className="w-20 text-right">Cost</div>
+          </Band>
+          <div className="flex items-center gap-3 px-4 py-2.5">
+            <span className="min-w-0 flex-1 truncate font-medium text-[13px] text-gray-12">
+              Verified keys
+            </span>
+            <span className="w-24 text-right text-[13px] text-gray-11 tabular-nums">
+              {project.gateway.activeKeys.toLocaleString("en-US")}
+            </span>
+            <span className="w-20 text-right font-medium text-[13px] text-gray-12 tabular-nums">
+              {formatPrice(microCentsToDisplayCents(project.gateway.microCents))}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function AppRows({ app }: { app: UsageApp }) {
+  return (
+    <div>
+      <div className="flex items-center gap-3 px-4 pt-2.5 pb-1">
+        <span className="min-w-0 flex-1 truncate font-medium text-[13px] text-gray-12">
+          {app.name}
+        </span>
+        <Quantities quantities={app} className="text-[13px] text-gray-11" />
+        <span className="w-20 text-right font-medium text-[13px] text-gray-12 tabular-nums">
+          {formatPrice(microCentsToDisplayCents(app.microCents))}
+        </span>
+      </div>
+      {app.environments.map((environment) => (
+        <div
+          key={environment.environmentId}
+          className="flex items-center gap-3 px-4 py-1 last:pb-2.5"
+        >
+          <span className="min-w-0 flex-1 truncate text-gray-10 text-xs">{environment.name}</span>
+          <Quantities quantities={environment} className="text-gray-10 text-xs" />
+          <span className="w-20 text-right text-gray-11 text-xs tabular-nums">
+            {formatPrice(microCentsToDisplayCents(environment.microCents))}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function Band({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex items-center gap-3 border-grayA-4 border-y bg-grayA-2 px-4 py-2 font-semibold text-[10px] text-gray-9 uppercase tracking-wider">
+      {children}
+    </div>
+  );
+}
+
+function Quantities({ quantities, className }: { quantities: UsageQuantities; className: string }) {
+  return (
+    <>
+      {QUANTITY_COLUMNS.map((column) => (
+        <span key={column.key} className={`${column.width} text-right tabular-nums ${className}`}>
+          {formatCompactQuantity(quantities[column.key])}
+        </span>
+      ))}
+    </>
+  );
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/usage/compute-tree.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/usage/compute-tree.ts
@@ -1,0 +1,143 @@
+import { MICRO_CENTS_PER_CENT } from "@/lib/billing/deployPricing";
+import type { DeployUsageBreakdown } from "@/lib/trpc/routers/billing/query-deploy-usage-breakdown";
+
+const SECONDS_PER_HOUR = 3600;
+
+const UNATTRIBUTED = "Unattributed";
+
+export type UsageQuantities = {
+  cpuHours: number;
+  memoryGiBHours: number;
+  egressGiB: number;
+  diskGiBHours: number;
+};
+
+type Priced = UsageQuantities & { microCents: number };
+
+export type UsageEnvironment = Priced & {
+  environmentId: string;
+  name: string;
+};
+
+export type UsageApp = Priced & {
+  appId: string;
+  name: string;
+  environments: UsageEnvironment[];
+};
+
+export type UsageGateway = {
+  activeKeys: number;
+  microCents: number;
+};
+
+/** `microCents` is compute plus gateway, so it equals the rows shown beneath it. */
+export type UsageProject = Priced & {
+  projectId: string;
+  name: string;
+  apps: UsageApp[];
+  gateway: UsageGateway;
+};
+
+export type ComputeTree = {
+  projects: UsageProject[];
+  microCents: number;
+};
+
+function zero(): Priced {
+  return { cpuHours: 0, memoryGiBHours: 0, egressGiB: 0, diskGiBHours: 0, microCents: 0 };
+}
+
+function add(total: Priced, part: Priced): Priced {
+  return {
+    cpuHours: total.cpuHours + part.cpuHours,
+    memoryGiBHours: total.memoryGiBHours + part.memoryGiBHours,
+    egressGiB: total.egressGiB + part.egressGiB,
+    diskGiBHours: total.diskGiBHours + part.diskGiBHours,
+    microCents: total.microCents + part.microCents,
+  };
+}
+
+function rollUp(parts: Priced[]): Priced {
+  return parts.reduce(add, zero());
+}
+
+function label(id: string, name: string | null): string {
+  if (id === "") {
+    return UNATTRIBUTED;
+  }
+  return name === null || name === "" ? id : name;
+}
+
+function byCostDescending(a: Priced, b: Priced): number {
+  return b.microCents - a.microCents;
+}
+
+export function buildComputeTree({ usage, gateway }: DeployUsageBreakdown): ComputeTree {
+  const projects = new Map<string, Map<string, UsageEnvironment[]>>();
+  const projectNames = new Map<string, string>();
+  const appNames = new Map<string, string>();
+  const gateways = new Map<string, UsageGateway>();
+
+  for (const row of gateway) {
+    projectNames.set(row.projectId, label(row.projectId, row.projectName));
+    if (!projects.has(row.projectId)) {
+      projects.set(row.projectId, new Map<string, UsageEnvironment[]>());
+    }
+    const current = gateways.get(row.projectId) ?? { activeKeys: 0, microCents: 0 };
+    gateways.set(row.projectId, {
+      activeKeys: current.activeKeys + row.activeKeys,
+      microCents: current.microCents + row.grossMicroCents,
+    });
+  }
+
+  for (const row of usage) {
+    projectNames.set(row.projectId, label(row.projectId, row.projectName));
+    appNames.set(row.appId, label(row.appId, row.appName));
+
+    const apps = projects.get(row.projectId) ?? new Map<string, UsageEnvironment[]>();
+    const environments = apps.get(row.appId) ?? [];
+    environments.push({
+      environmentId: row.environmentId,
+      name: label(row.environmentId, row.environmentSlug),
+      cpuHours: row.cpuSeconds / SECONDS_PER_HOUR,
+      memoryGiBHours: row.memoryGiBHours,
+      egressGiB: row.egressGiB,
+      diskGiBHours: row.diskGiBHours,
+      microCents: row.grossMicroCents,
+    });
+    apps.set(row.appId, environments);
+    projects.set(row.projectId, apps);
+  }
+
+  const tree = [...projects.entries()].map(([projectId, apps]): UsageProject => {
+    const appNodes = [...apps.entries()].map(([appId, environments]): UsageApp => {
+      environments.sort(byCostDescending);
+      return {
+        appId,
+        name: appNames.get(appId) ?? UNATTRIBUTED,
+        environments,
+        ...rollUp(environments),
+      };
+    });
+    appNodes.sort(byCostDescending);
+
+    const projectGateway = gateways.get(projectId) ?? { activeKeys: 0, microCents: 0 };
+    const compute = rollUp(appNodes);
+
+    return {
+      projectId,
+      name: projectNames.get(projectId) ?? UNATTRIBUTED,
+      apps: appNodes,
+      gateway: projectGateway,
+      ...compute,
+      microCents: compute.microCents + projectGateway.microCents,
+    };
+  });
+  tree.sort(byCostDescending);
+
+  return { projects: tree, microCents: rollUp(tree).microCents };
+}
+
+export function microCentsToDisplayCents(microCents: number): number {
+  return Math.round(microCents / MICRO_CENTS_PER_CENT);
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/usage/compute-tree.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/usage/compute-tree.ts
@@ -73,60 +73,50 @@ function byCostDescending(a: Priced, b: Priced): number {
 }
 
 export function buildComputeTree({ usage, gateway }: DeployUsageBreakdown): ComputeTree {
-  const projects = new Map<string, Map<string, UsageEnvironment[]>>();
-  const projectNames = new Map<string, string>();
-  const appNames = new Map<string, string>();
-  const gateways = new Map<string, UsageGateway>();
+  const gatewayByProject = Map.groupBy(gateway, (row) => row.projectId);
+  const usageByProject = Map.groupBy(usage, (row) => row.projectId);
+  const projectIds = new Set([...gatewayByProject.keys(), ...usageByProject.keys()]);
 
-  for (const row of gateway) {
-    projectNames.set(row.projectId, label(row.projectId, row.projectName));
-    if (!projects.has(row.projectId)) {
-      projects.set(row.projectId, new Map<string, UsageEnvironment[]>());
-    }
-    const current = gateways.get(row.projectId) ?? { activeKeys: 0, microCents: 0 };
-    gateways.set(row.projectId, {
-      activeKeys: current.activeKeys + row.activeKeys,
-      microCents: current.microCents + row.grossMicroCents,
-    });
-  }
+  const tree = [...projectIds].map((projectId): UsageProject => {
+    const usageRows = usageByProject.get(projectId) ?? [];
+    const gatewayRows = gatewayByProject.get(projectId) ?? [];
 
-  for (const row of usage) {
-    projectNames.set(row.projectId, label(row.projectId, row.projectName));
-    appNames.set(row.appId, label(row.appId, row.appName));
+    const appNodes = [...Map.groupBy(usageRows, (row) => row.appId)]
+      .map(([appId, rows]): UsageApp => {
+        const environments = rows
+          .map(
+            (row): UsageEnvironment => ({
+              environmentId: row.environmentId,
+              name: label(row.environmentId, row.environmentSlug),
+              cpuHours: row.cpuSeconds / SECONDS_PER_HOUR,
+              memoryGiBHours: row.memoryGiBHours,
+              egressGiB: row.egressGiB,
+              diskGiBHours: row.diskGiBHours,
+              microCents: row.grossMicroCents,
+            }),
+          )
+          .sort(byCostDescending);
+        return {
+          appId,
+          name: label(appId, rows[0]?.appName ?? null),
+          environments,
+          ...rollUp(environments),
+        };
+      })
+      .sort(byCostDescending);
 
-    const apps = projects.get(row.projectId) ?? new Map<string, UsageEnvironment[]>();
-    const environments = apps.get(row.appId) ?? [];
-    environments.push({
-      environmentId: row.environmentId,
-      name: label(row.environmentId, row.environmentSlug),
-      cpuHours: row.cpuSeconds / SECONDS_PER_HOUR,
-      memoryGiBHours: row.memoryGiBHours,
-      egressGiB: row.egressGiB,
-      diskGiBHours: row.diskGiBHours,
-      microCents: row.grossMicroCents,
-    });
-    apps.set(row.appId, environments);
-    projects.set(row.projectId, apps);
-  }
-
-  const tree = [...projects.entries()].map(([projectId, apps]): UsageProject => {
-    const appNodes = [...apps.entries()].map(([appId, environments]): UsageApp => {
-      environments.sort(byCostDescending);
-      return {
-        appId,
-        name: appNames.get(appId) ?? UNATTRIBUTED,
-        environments,
-        ...rollUp(environments),
-      };
-    });
-    appNodes.sort(byCostDescending);
-
-    const projectGateway = gateways.get(projectId) ?? { activeKeys: 0, microCents: 0 };
+    const projectGateway = gatewayRows.reduce<UsageGateway>(
+      (total, row) => ({
+        activeKeys: total.activeKeys + row.activeKeys,
+        microCents: total.microCents + row.grossMicroCents,
+      }),
+      { activeKeys: 0, microCents: 0 },
+    );
     const compute = rollUp(appNodes);
 
     return {
       projectId,
-      name: projectNames.get(projectId) ?? UNATTRIBUTED,
+      name: label(projectId, usageRows[0]?.projectName ?? gatewayRows[0]?.projectName ?? null),
       apps: appNodes,
       gateway: projectGateway,
       ...compute,

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/usage/page.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/usage/page.tsx
@@ -56,12 +56,16 @@ export default function UsagePage() {
     notFound();
   }
 
-  if (isLoading || !workspace) {
+  if (isLoading) {
     return (
       <Shell>
         <PageLoading message="Loading usage..." />
       </Shell>
     );
+  }
+
+  if (!workspace) {
+    notFound();
   }
 
   const compute = hasComputePlan ? (

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/usage/page.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/usage/page.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { PageLoading } from "@/components/dashboard/page-loading";
+import { useBillingUIUpgrades } from "@/lib/flags/use-billing-ui-upgrades";
+import { formatPeriod } from "@/lib/fmt";
+import { routes } from "@/lib/navigation/routes";
+import { trpc } from "@/lib/trpc/client";
+import { useWorkspace } from "@/providers/workspace-provider";
+import {
+  Button,
+  Empty,
+  PageBody,
+  PageContainer,
+  PageHeader,
+  PageHeaderActions,
+  PageHeaderContent,
+  PageHeaderTitle,
+} from "@unkey/ui";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import type { ReactNode } from "react";
+import { ApiCard } from "./api-card";
+import { ComputeCard, ComputeCardShell, ComputeCardSkeleton } from "./compute-card";
+import { buildComputeTree } from "./compute-tree";
+
+const ACTIVE_SUBSCRIPTION_STATES = ["active", "trialing", "past_due"];
+
+function currentPeriod(): string {
+  const now = new Date();
+  const monthStartMillis = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1);
+  return formatPeriod(monthStartMillis, now.getTime());
+}
+
+export default function UsagePage() {
+  const billingUpgrades = useBillingUIUpgrades();
+  const { workspace, limits, isLoading } = useWorkspace();
+  const hasComputePlan = Boolean(workspace?.deployPlan) || Boolean(workspace?.deployPlanOverride);
+
+  const breakdown = trpc.billing.queryDeployUsageBreakdown.useQuery(undefined, {
+    enabled: Boolean(workspace) && billingUpgrades && hasComputePlan,
+    trpc: { context: { skipBatch: true } },
+    retry: 1,
+  });
+  const apiUsage = trpc.billing.queryUsage.useQuery(undefined, {
+    enabled: Boolean(workspace) && billingUpgrades,
+    trpc: { context: { skipBatch: true } },
+    retry: 1,
+  });
+  const billingInfo = trpc.stripe.getBillingInfo.useQuery(undefined, {
+    enabled: Boolean(workspace) && billingUpgrades,
+    staleTime: 30_000,
+    retry: 1,
+  });
+
+  if (!billingUpgrades) {
+    notFound();
+  }
+
+  if (isLoading || !workspace) {
+    return (
+      <Shell>
+        <PageLoading message="Loading usage..." />
+      </Shell>
+    );
+  }
+
+  const compute = hasComputePlan ? (
+    breakdown.isError ? (
+      <ComputeCardShell description="Usage per project this period">
+        <div className="px-4 py-8">
+          <Empty className="w-full">
+            <Empty.Title>Compute usage unavailable</Empty.Title>
+            <Empty.Description>
+              We could not read the Compute breakdown for this period. Please try again later.
+            </Empty.Description>
+          </Empty>
+        </div>
+      </ComputeCardShell>
+    ) : breakdown.data === undefined ? (
+      <ComputeCardSkeleton />
+    ) : (
+      <ComputeCard tree={buildComputeTree(breakdown.data)} />
+    )
+  ) : (
+    <NoComputePlan workspaceSlug={workspace.slug} />
+  );
+
+  const info = billingInfo.data;
+  const planKnown = info !== undefined;
+  const hasActiveSubscription = Boolean(
+    info?.subscription && ACTIVE_SUBSCRIPTION_STATES.includes(info.subscription.status),
+  );
+  const apiProduct = hasActiveSubscription
+    ? info?.products.find((product) => product.id === info.currentProductId)
+    : undefined;
+
+  let feeCents: number | null;
+  if (!planKnown) {
+    feeCents = null;
+  } else if (!hasActiveSubscription) {
+    feeCents = 0;
+  } else if (apiProduct === undefined) {
+    feeCents = null;
+  } else {
+    feeCents = apiProduct.dollar * 100;
+  }
+
+  // The quota comes from the workspace's resolved limits row, the same source the
+  // Limits page reads. Deriving it from the Stripe catalog would print a different
+  // number on two adjacent pages for any workspace with an overridden limit.
+  const api = (
+    <ApiCard
+      verifications={apiUsage.data?.billableVerifications ?? null}
+      ratelimits={apiUsage.data?.billableRatelimits ?? null}
+      quota={limits?.apiBillableOperationsCountMaxPerMonth ?? null}
+      feeCents={feeCents}
+      isLoading={
+        (apiUsage.data === undefined && !apiUsage.isError) || (!planKnown && !billingInfo.isError)
+      }
+    />
+  );
+
+  return (
+    <Shell>
+      {hasComputePlan ? (
+        <>
+          {compute}
+          {api}
+        </>
+      ) : (
+        <>
+          {api}
+          {compute}
+        </>
+      )}
+    </Shell>
+  );
+}
+
+function Shell({ children }: { children: ReactNode }) {
+  return (
+    <PageContainer>
+      <PageHeader>
+        <PageHeaderContent>
+          <PageHeaderTitle>Usage</PageHeaderTitle>
+        </PageHeaderContent>
+        <PageHeaderActions>
+          <span className="text-[13px] text-gray-10">{currentPeriod()}</span>
+        </PageHeaderActions>
+      </PageHeader>
+      <PageBody>{children}</PageBody>
+    </PageContainer>
+  );
+}
+
+function NoComputePlan({ workspaceSlug }: { workspaceSlug: string }) {
+  return (
+    <ComputeCardShell description="Usage per app and environment this period">
+      <div className="px-4 py-8">
+        <Empty className="w-full">
+          <Empty.Title>No compute plan</Empty.Title>
+          <Empty.Description>Pick a plan to deploy your first app.</Empty.Description>
+          <Empty.Actions>
+            <Button
+              variant="primary"
+              size="md"
+              render={<Link href={routes.settings.billing({ workspaceSlug })} />}
+            >
+              Go to billing
+            </Button>
+          </Empty.Actions>
+        </Empty>
+      </div>
+    </ComputeCardShell>
+  );
+}

--- a/web/apps/dashboard/lib/billing/deployPricing.test.ts
+++ b/web/apps/dashboard/lib/billing/deployPricing.test.ts
@@ -5,6 +5,7 @@ import {
   type DeployUsageQuantities,
   MICRO_CENTS_PER_CENT,
   microCentsToCents,
+  priceActiveKeysMicroCents,
   priceComputeMeterMicroCents,
   priceDeployMetersCents,
   priceDeployUsageMicroCents,
@@ -87,6 +88,31 @@ describe("sumDeployMeterCents", () => {
         activeKeys: 0,
       }),
     ).toBe(0);
+  });
+});
+
+describe("priceActiveKeysMicroCents", () => {
+  it("prices no keys as zero", () => {
+    expect(priceActiveKeysMicroCents(0)).toBe(0);
+  });
+
+  it("splits across apps to the same price as the combined count", () => {
+    expect(priceActiveKeysMicroCents(120) + priceActiveKeysMicroCents(80)).toBe(
+      priceActiveKeysMicroCents(200),
+    );
+  });
+
+  it("adds to the compute meters to give the full usage price", () => {
+    const compute: ComputeMeterQuantities = {
+      cpuSeconds: 1234.5,
+      memoryGiBHours: 7.25,
+      diskGiBHours: 3,
+      egressGiB: 0.4,
+    };
+
+    expect(priceComputeMeterMicroCents(compute) + priceActiveKeysMicroCents(37)).toBe(
+      priceDeployUsageMicroCents({ ...compute, activeKeys: 37 }),
+    );
   });
 });
 

--- a/web/apps/dashboard/lib/billing/deployPricing.ts
+++ b/web/apps/dashboard/lib/billing/deployPricing.ts
@@ -58,6 +58,18 @@ export function priceComputeMeterMicroCents(usage: ComputeMeterQuantities): numb
   return priceDeployUsageMicroCents({ ...usage, activeKeys: 0 });
 }
 
+// The one meter with no project attribution, so it is priced on its own and
+// shown as its own row rather than folded into the per-project totals.
+export function priceActiveKeysMicroCents(activeKeys: number): number {
+  return priceDeployUsageMicroCents({
+    cpuSeconds: 0,
+    memoryGiBHours: 0,
+    diskGiBHours: 0,
+    egressGiB: 0,
+    activeKeys,
+  });
+}
+
 /**
  * Total usage in whole cents the way Stripe invoices it: each meter is priced
  * and rounded to a cent on its own line, then the lines are summed.

--- a/web/apps/dashboard/lib/fmt.ts
+++ b/web/apps/dashboard/lib/fmt.ts
@@ -25,6 +25,30 @@ export function formatPrice(price: number) {
   }).format(price / 100);
 }
 
+// Formatted in UTC instead of with date-fns, because billing periods are cut at
+// UTC midnight while date-fns formats in the reader's own timezone, which prints
+// the previous day for anyone west of UTC.
+export function formatPeriod(startMillis: number, endMillis: number): string {
+  const part = (millis: number, options: Intl.DateTimeFormatOptions) =>
+    new Date(millis).toLocaleDateString("en-US", { timeZone: "UTC", ...options });
+
+  const day = (millis: number) => part(millis, { day: "numeric" });
+  const monthDay = (millis: number) => part(millis, { month: "short", day: "numeric" });
+  const year = (millis: number) => part(millis, { year: "numeric" });
+  const month = (millis: number) => part(millis, { month: "short" });
+
+  if (year(startMillis) !== year(endMillis)) {
+    return `${monthDay(startMillis)}, ${year(startMillis)} – ${monthDay(endMillis)}, ${year(endMillis)}`;
+  }
+  if (month(startMillis) !== month(endMillis)) {
+    return `${monthDay(startMillis)} – ${monthDay(endMillis)}, ${year(endMillis)}`;
+  }
+  if (day(startMillis) === day(endMillis)) {
+    return `${monthDay(endMillis)}, ${year(endMillis)}`;
+  }
+  return `${monthDay(startMillis)} – ${day(endMillis)}, ${year(endMillis)}`;
+}
+
 /**
  * Formats cents as dollars, dropping the cents when the amount is whole:
  * $5 instead of $5.00, but $46.20 stays $46.20. For plan fees and billing

--- a/web/apps/dashboard/lib/navigation/routes/settings.test.ts
+++ b/web/apps/dashboard/lib/navigation/routes/settings.test.ts
@@ -10,6 +10,7 @@ describe("settings-scoped paths", () => {
     expect(routes.settings.team(scope)).toBe("/acme/settings/team");
     expect(routes.settings.rootKeys(scope)).toBe("/acme/settings/root-keys");
     expect(routes.settings.billing(scope)).toBe("/acme/settings/billing");
+    expect(routes.settings.usage(scope)).toBe("/acme/settings/usage");
     expect(routes.settings.limits(scope)).toBe("/acme/settings/limits");
   });
 

--- a/web/apps/dashboard/lib/navigation/routes/settings.ts
+++ b/web/apps/dashboard/lib/navigation/routes/settings.ts
@@ -36,6 +36,10 @@ export const settingsRoutes = {
     );
   },
 
+  usage({ workspaceSlug }: WorkspaceScope): Route {
+    return buildRoute("/[workspaceSlug]/settings/usage", { workspaceSlug });
+  },
+
   limits({ workspaceSlug }: WorkspaceScope): Route {
     return buildRoute("/[workspaceSlug]/settings/limits", { workspaceSlug });
   },

--- a/web/apps/dashboard/lib/trpc/routers/billing/query-deploy-usage-breakdown/index.ts
+++ b/web/apps/dashboard/lib/trpc/routers/billing/query-deploy-usage-breakdown/index.ts
@@ -43,11 +43,14 @@ async function resolveScopeNames(
   usage: Array<{ projectId: string; appId: string; environmentId: string }>,
   keys: Array<{ appId: string }>,
 ) {
-  const ids = (values: Array<string>) =>
-    Array.from(new Set(values.filter((value) => value !== "")));
+  const ids = (...lists: Array<Array<string>>) =>
+    Array.from(new Set(lists.flat().filter((value) => value !== "")));
   // Gateway apps need resolving too: an app can verify keys in a period it ran
   // no compute in, so it appears here without a usage row to carry it.
-  const appIds = ids([...usage.map((row) => row.appId), ...keys.map((row) => row.appId)]);
+  const appIds = ids(
+    usage.map((row) => row.appId),
+    keys.map((row) => row.appId),
+  );
   const environmentIds = ids(usage.map((row) => row.environmentId));
 
   const [apps, environments] = await Promise.all([
@@ -76,10 +79,10 @@ async function resolveScopeNames(
 
   const appProjects = new Map(apps.map((app) => [app.id, app.projectId]));
 
-  const projectIds = ids([
-    ...usage.map((row) => row.projectId),
-    ...keys.map((row) => appProjects.get(row.appId) ?? ""),
-  ]);
+  const projectIds = ids(
+    usage.map((row) => row.projectId),
+    keys.map((row) => appProjects.get(row.appId) ?? ""),
+  );
   const projects =
     projectIds.length === 0
       ? []

--- a/web/apps/dashboard/lib/trpc/routers/billing/query-deploy-usage-breakdown/index.ts
+++ b/web/apps/dashboard/lib/trpc/routers/billing/query-deploy-usage-breakdown/index.ts
@@ -1,4 +1,7 @@
-import { priceComputeMeterMicroCents } from "@/lib/billing/deployPricing";
+import {
+  priceActiveKeysMicroCents,
+  priceComputeMeterMicroCents,
+} from "@/lib/billing/deployPricing";
 import { clickhouse } from "@/lib/clickhouse";
 import { and, db, eq, inArray, schema } from "@/lib/db";
 import { ratelimit, withRatelimit, workspaceProcedure } from "@/lib/trpc/trpc";
@@ -19,72 +22,131 @@ export const deployUsageBreakdownRow = z.object({
   grossMicroCents: z.number(),
 });
 
-export const queryDeployUsageBreakdownResponse = z.array(deployUsageBreakdownRow);
+export const deployGatewayRow = z.object({
+  projectId: z.string(),
+  projectName: z.string().nullable(),
+  appId: z.string(),
+  activeKeys: z.number(),
+  grossMicroCents: z.number(),
+});
+
+export const queryDeployUsageBreakdownResponse = z.object({
+  usage: z.array(deployUsageBreakdownRow),
+  gateway: z.array(deployGatewayRow),
+});
 
 export type DeployUsageBreakdownRow = z.infer<typeof deployUsageBreakdownRow>;
+export type DeployUsageBreakdown = z.infer<typeof queryDeployUsageBreakdownResponse>;
+
+async function resolveScopeNames(
+  workspaceId: string,
+  usage: Array<{ projectId: string; appId: string; environmentId: string }>,
+  keys: Array<{ appId: string }>,
+) {
+  const ids = (values: Array<string>) =>
+    Array.from(new Set(values.filter((value) => value !== "")));
+  // Gateway apps need resolving too: an app can verify keys in a period it ran
+  // no compute in, so it appears here without a usage row to carry it.
+  const appIds = ids([...usage.map((row) => row.appId), ...keys.map((row) => row.appId)]);
+  const environmentIds = ids(usage.map((row) => row.environmentId));
+
+  const [apps, environments] = await Promise.all([
+    appIds.length === 0
+      ? []
+      : db
+          .select({
+            id: schema.apps.id,
+            name: schema.apps.name,
+            projectId: schema.apps.projectId,
+          })
+          .from(schema.apps)
+          .where(and(eq(schema.apps.workspaceId, workspaceId), inArray(schema.apps.id, appIds))),
+    environmentIds.length === 0
+      ? []
+      : db
+          .select({ id: schema.environments.id, slug: schema.environments.slug })
+          .from(schema.environments)
+          .where(
+            and(
+              eq(schema.environments.workspaceId, workspaceId),
+              inArray(schema.environments.id, environmentIds),
+            ),
+          ),
+  ]);
+
+  const appProjects = new Map(apps.map((app) => [app.id, app.projectId]));
+
+  const projectIds = ids([
+    ...usage.map((row) => row.projectId),
+    ...keys.map((row) => appProjects.get(row.appId) ?? ""),
+  ]);
+  const projects =
+    projectIds.length === 0
+      ? []
+      : await db
+          .select({ id: schema.projects.id, name: schema.projects.name })
+          .from(schema.projects)
+          .where(
+            and(
+              eq(schema.projects.workspaceId, workspaceId),
+              inArray(schema.projects.id, projectIds),
+            ),
+          );
+
+  return {
+    appProjects,
+    projectNames: new Map(projects.map((project) => [project.id, project.name])),
+    appNames: new Map(apps.map((app) => [app.id, app.name])),
+    environmentSlugs: new Map(
+      environments.map((environment) => [environment.id, environment.slug]),
+    ),
+  };
+}
 
 export const queryDeployUsageBreakdown = workspaceProcedure
   .use(withRatelimit(ratelimit.read))
   .output(queryDeployUsageBreakdownResponse)
   .query(async ({ ctx }) => {
     const now = new Date();
-    const monthStart = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1);
-    const monthEnd = Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1);
+    const monthStartMillis = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1);
+    const monthEndMillis = Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1);
 
     try {
-      const usage = await clickhouse.billing.deployUsageByScope({
-        workspaceId: ctx.workspace.id,
-        periodStart: monthStart,
-        end: Math.min(now.getTime(), monthEnd),
-      });
-
-      if (usage.length === 0) {
-        return [];
-      }
-
-      const ids = (values: Array<string>) => Array.from(new Set(values.filter((v) => v !== "")));
-      const projectIds = ids(usage.map((row) => row.projectId));
-      const appIds = ids(usage.map((row) => row.appId));
-      const environmentIds = ids(usage.map((row) => row.environmentId));
-
-      const [projects, apps, environments] = await Promise.all([
-        projectIds.length === 0
-          ? []
-          : db
-              .select({ id: schema.projects.id, name: schema.projects.name })
-              .from(schema.projects)
-              .where(
-                and(
-                  eq(schema.projects.workspaceId, ctx.workspace.id),
-                  inArray(schema.projects.id, projectIds),
-                ),
-              ),
-        appIds.length === 0
-          ? []
-          : db
-              .select({ id: schema.apps.id, name: schema.apps.name })
-              .from(schema.apps)
-              .where(
-                and(eq(schema.apps.workspaceId, ctx.workspace.id), inArray(schema.apps.id, appIds)),
-              ),
-        environmentIds.length === 0
-          ? []
-          : db
-              .select({ id: schema.environments.id, slug: schema.environments.slug })
-              .from(schema.environments)
-              .where(
-                and(
-                  eq(schema.environments.workspaceId, ctx.workspace.id),
-                  inArray(schema.environments.id, environmentIds),
-                ),
-              ),
+      const [usage, keys] = await Promise.all([
+        clickhouse.billing.deployUsageByScope({
+          workspaceId: ctx.workspace.id,
+          periodStart: monthStartMillis,
+          end: Math.min(now.getTime(), monthEndMillis),
+        }),
+        clickhouse.billing.activeKeysByApp({
+          workspaceId: ctx.workspace.id,
+          year: now.getUTCFullYear(),
+          month: now.getUTCMonth() + 1,
+        }),
       ]);
 
-      const projectNames = new Map(projects.map((p) => [p.id, p.name]));
-      const appNames = new Map(apps.map((a) => [a.id, a.name]));
-      const environmentSlugs = new Map(environments.map((e) => [e.id, e.slug]));
+      if (usage.length === 0 && keys.length === 0) {
+        return { usage: [], gateway: [] };
+      }
 
-      return usage.map((row) => ({
+      const { appProjects, projectNames, appNames, environmentSlugs } = await resolveScopeNames(
+        ctx.workspace.id,
+        usage,
+        keys,
+      );
+
+      const gateway = keys.map((row) => {
+        const projectId = appProjects.get(row.appId) ?? "";
+        return {
+          projectId,
+          projectName: projectNames.get(projectId) ?? null,
+          appId: row.appId,
+          activeKeys: row.activeKeys,
+          grossMicroCents: priceActiveKeysMicroCents(row.activeKeys),
+        };
+      });
+
+      const usageRows = usage.map((row) => ({
         projectId: row.projectId,
         projectName: projectNames.get(row.projectId) ?? null,
         appId: row.appId,
@@ -102,6 +164,8 @@ export const queryDeployUsageBreakdown = workspaceProcedure
           egressGiB: row.egressGiB,
         }),
       }));
+
+      return { usage: usageRows, gateway };
     } catch (err) {
       console.error("Failed to query deploy usage breakdown", err);
       throw new TRPCError({

--- a/web/internal/clickhouse/src/deploy_billing.ts
+++ b/web/internal/clickhouse/src/deploy_billing.ts
@@ -171,6 +171,55 @@ export function getDeployUsageByScope(ch: Querier) {
   };
 }
 
+export const activeKeysByApp = z.object({
+  appId: z.string(),
+  activeKeys: z.number(),
+});
+
+export type ActiveKeysByApp = z.infer<typeof activeKeysByApp>;
+
+/**
+ * The same distinct-key count getActiveKeysUsage returns, split by the app that
+ * verified the key. uniqExact per app does not sum to the workspace total: a key
+ * verified through two apps counts in both. Attribution, not a split of the bill.
+ *
+ * app_id is only written from the release on 2026-08-11, so verifications before
+ * it carry an empty app_id and group under "".
+ */
+export function getActiveKeysByApp(ch: Querier) {
+  const query = ch.query({
+    query: `
+      SELECT
+        app_id AS appId,
+        toInt64(uniqExact(key_id)) AS activeKeys
+      FROM default.key_verifications_per_month_v3
+      WHERE time = makeDate({year: Int32}, {month: Int32}, 1)
+        AND source = 'gateway'
+        AND workspace_id = {workspaceId: String}
+      GROUP BY app_id
+      ORDER BY activeKeys DESC, appId
+    `,
+    params: z.object({
+      workspaceId: z.string(),
+      year: z.number().int(),
+      month: z.number().int().min(1).max(12),
+    }),
+    schema: activeKeysByApp,
+  });
+
+  return async (args: {
+    workspaceId: string;
+    year: number;
+    month: number;
+  }): Promise<ActiveKeysByApp[]> => {
+    const result = await query(args);
+    if (result.err) {
+      throw new Error(`Failed to query active keys by app: ${result.err.message}`);
+    }
+    return result.val;
+  };
+}
+
 export const activeKeysUsage = z.object({
   activeKeys: z.number(),
 });

--- a/web/internal/clickhouse/src/deploy_billing.ts
+++ b/web/internal/clickhouse/src/deploy_billing.ts
@@ -179,13 +179,16 @@ export const activeKeysByApp = z.object({
 export type ActiveKeysByApp = z.infer<typeof activeKeysByApp>;
 
 /**
- * The same distinct-key count getActiveKeysUsage returns, partitioned by app:
- * each key is assigned to the one app that verified it most this month, so the
- * per-app counts sum to the workspace total the invoice bills.
+ * Counts this month's active keys, per app.
  *
- * app_id is only written from the release on 2026-08-11, so verifications before
- * it carry an empty app_id; a key with any attributed verifications goes to its
- * busiest real app, and only never-attributed keys group under "".
+ * One key can be verified through many apps, but billing only charges it
+ * once. So each key is counted for exactly one app here: the app that
+ * verified it the most. That way the per-app counts add up to the same
+ * total the invoice charges for (the number getActiveKeysUsage returns).
+ *
+ * We only started recording which app verified a key on 2026-08-11, so
+ * older rows have no app on them. A key seen with a real app since then
+ * counts for that app. A key never seen with one counts under "".
  */
 export function getActiveKeysByApp(ch: Querier) {
   const query = ch.query({

--- a/web/internal/clickhouse/src/deploy_billing.ts
+++ b/web/internal/clickhouse/src/deploy_billing.ts
@@ -179,24 +179,38 @@ export const activeKeysByApp = z.object({
 export type ActiveKeysByApp = z.infer<typeof activeKeysByApp>;
 
 /**
- * The same distinct-key count getActiveKeysUsage returns, split by the app that
- * verified the key. uniqExact per app does not sum to the workspace total: a key
- * verified through two apps counts in both. Attribution, not a split of the bill.
+ * The same distinct-key count getActiveKeysUsage returns, partitioned by app:
+ * each key is assigned to the one app that verified it most this month, so the
+ * per-app counts sum to the workspace total the invoice bills.
  *
  * app_id is only written from the release on 2026-08-11, so verifications before
- * it carry an empty app_id and group under "".
+ * it carry an empty app_id; a key with any attributed verifications goes to its
+ * busiest real app, and only never-attributed keys group under "".
  */
 export function getActiveKeysByApp(ch: Querier) {
   const query = ch.query({
     query: `
       SELECT
-        app_id AS appId,
-        toInt64(uniqExact(key_id)) AS activeKeys
-      FROM default.key_verifications_per_month_v3
-      WHERE time = makeDate({year: Int32}, {month: Int32}, 1)
-        AND source = 'gateway'
-        AND workspace_id = {workspaceId: String}
-      GROUP BY app_id
+        assignedAppId AS appId,
+        toInt64(count()) AS activeKeys
+      FROM (
+        SELECT
+          key_id,
+          argMax(app_id, (app_id != '', verifications, app_id)) AS assignedAppId
+        FROM (
+          SELECT
+            key_id,
+            app_id,
+            sum(count) AS verifications
+          FROM default.key_verifications_per_month_v3
+          WHERE time = makeDate({year: Int32}, {month: Int32}, 1)
+            AND source = 'gateway'
+            AND workspace_id = {workspaceId: String}
+          GROUP BY key_id, app_id
+        )
+        GROUP BY key_id
+      )
+      GROUP BY assignedAppId
       ORDER BY activeKeys DESC, appId
     `,
     params: z.object({

--- a/web/internal/clickhouse/src/index.ts
+++ b/web/internal/clickhouse/src/index.ts
@@ -1,7 +1,12 @@
 import { getAuditLogs } from "./audit-logs";
 import { getBillableRatelimits, getBillableVerifications } from "./billing";
 import { getBuildStepLogs, getBuildSteps } from "./build-steps";
-import { getActiveKeysUsage, getDeployMeterUsage, getDeployUsageByScope } from "./deploy_billing";
+import {
+  getActiveKeysByApp,
+  getActiveKeysUsage,
+  getDeployMeterUsage,
+  getDeployUsageByScope,
+} from "./deploy_billing";
 export {
   type ActiveKeysUsage,
   activeKeysUsage,
@@ -9,6 +14,8 @@ export {
   deployMeterUsage,
   type DeployUsageByScope,
   deployUsageByScope,
+  type ActiveKeysByApp,
+  activeKeysByApp,
 } from "./deploy_billing";
 import { Client, type Inserter, Noop, type Querier } from "./client";
 import { getInstanceEvents } from "./instance-events";
@@ -302,6 +309,7 @@ export class ClickHouse {
       billableRatelimits: getBillableRatelimits(this.querier),
       deployMeterUsage: getDeployMeterUsage(this.querier),
       deployUsageByScope: getDeployUsageByScope(this.querier),
+      activeKeysByApp: getActiveKeysByApp(this.querier),
       activeKeysUsage: getActiveKeysUsage(this.querier),
     };
   }


### PR DESCRIPTION
- A new Usage page in workspace settings, under the `billing-ui-upgrades` flag. 
- Breaks users invoice down by usage: Compute per project, app and environment, plus API operation counts.

## Screenshots

| Usage |
| --- |
| **Pro, healthy** |
| ![usage--pro-healthy](https://github.com/user-attachments/assets/751e86c2-4077-47b0-a6bf-d406a34a880b) |
| **Business, high spend** |
| ![usage--business-high](https://github.com/user-attachments/assets/19fbbbb8-56f6-4f72-a21c-49ca97274112) |
| **Business, under credit** |
| ![usage--under-credit](https://github.com/user-attachments/assets/9c186874-6629-4f80-936a-ef0e29d4b3bf) |
| **Pro, zero usage** |
| ![usage--zero-usage](https://github.com/user-attachments/assets/a2190c79-017d-4063-8d58-02ccd8f6b387) |
| **Pro, unattributed** |
| ![usage--unattributed](https://github.com/user-attachments/assets/f1dde87e-7016-4a46-bc7e-7d6e0a9111fa) |

