### PR TITLE
refactor(dashboard): Billing page UI Update

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/admin-gate.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/admin-gate.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { InfoTooltip } from "@unkey/ui";
+import type { ReactNode } from "react";
+import { ADMIN_ONLY_TOOLTIP } from "./constants";
+
+type AdminGateProps = {
+  isAdmin: boolean | undefined;
+  blocked?: boolean;
+  blockedReason?: string;
+  children: (disabled: boolean) => ReactNode;
+};
+
+export function AdminGate({ isAdmin, blocked = false, blockedReason, children }: AdminGateProps) {
+  const disabled = isAdmin !== true || blocked;
+  const reason = isAdmin === false ? ADMIN_ONLY_TOOLTIP : blockedReason;
+
+  return (
+    <InfoTooltip content={reason} disabled={!disabled || reason === undefined} asChild>
+      <span>{children(disabled)}</span>
+    </InfoTooltip>
+  );
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/api-plan-row.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/api-plan-row.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+import { formatNumber } from "@/lib/fmt";
+import { routes } from "@/lib/navigation/routes";
+import { trpc } from "@/lib/trpc/client";
+import type { Router } from "@/lib/trpc/routers";
+import type { inferRouterOutputs } from "@trpc/server";
+import { Nodes } from "@unkey/icons";
+import {
+  Button,
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemDescription,
+  ItemMedia,
+  ItemTitle,
+  toast,
+} from "@unkey/ui";
+import { useState } from "react";
+import { AdminGate } from "./admin-gate";
+import { FREE_TIER_QUOTA, currentApiProduct } from "./api-plan";
+import { CancelApiDialog, CancelPlanLink } from "./cancel-actions";
+import { PlanChangeModal } from "./plan-change-modal";
+
+const NEEDS_PAYMENT_TOOLTIP = "Add a payment method before upgrading the API plan";
+
+type BillingInfo = inferRouterOutputs<Router>["stripe"]["getBillingInfo"];
+
+type ApiPlanRowProps = {
+  isAdmin: boolean | undefined;
+  hasPaymentMethod: boolean;
+  workspaceSlug: string;
+  emphasize: boolean;
+  products: BillingInfo["products"];
+  subscription?: BillingInfo["subscription"];
+  currentProductId?: BillingInfo["currentProductId"];
+  autoOpenPlanModal?: boolean;
+};
+
+export function ApiPlanRow({
+  isAdmin,
+  hasPaymentMethod,
+  workspaceSlug,
+  emphasize,
+  products,
+  subscription,
+  currentProductId,
+  autoOpenPlanModal = false,
+}: ApiPlanRowProps) {
+  const trpcUtils = trpc.useUtils();
+  const [showPlanModal, setShowPlanModal] = useState(autoOpenPlanModal);
+  const [isCancelOpen, setCancelOpen] = useState(false);
+
+  const { data: usage } = trpc.billing.queryUsage.useQuery(undefined, {
+    staleTime: 30_000,
+    trpc: { context: { skipBatch: true } },
+    retry: 1,
+  });
+
+  const revalidate = async () => {
+    await Promise.all([
+      trpcUtils.workspace.getCurrent.invalidate(),
+      trpcUtils.billing.queryUsage.invalidate(),
+      trpcUtils.stripe.getBillingInfo.invalidate(),
+      trpcUtils.stripe.getUpcomingInvoice.invalidate(),
+    ]);
+  };
+
+  const createSubscription = trpc.stripe.createSubscription.useMutation({
+    onSuccess: async (result) => {
+      if (result.status === "checkout") {
+        window.location.assign(result.checkoutUrl);
+        return;
+      }
+      if (result.status === "payment_required") {
+        window.location.assign(
+          result.paymentUrl ?? routes.settings.stripe.checkout({ workspaceSlug, intent: "api" }),
+        );
+        return;
+      }
+      setShowPlanModal(false);
+      toast.success("Plan activated");
+      await revalidate();
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const updateSubscription = trpc.stripe.updateSubscription.useMutation({
+    onSuccess: async (result) => {
+      if (result.kind === "payment_required") {
+        window.location.assign(result.paymentUrl);
+        return;
+      }
+      setShowPlanModal(false);
+      toast.success(
+        result.kind === "scheduled"
+          ? `API plan downgrade scheduled for ${new Date(result.effectiveAt).toLocaleDateString()}`
+          : "API plan changed",
+      );
+      await revalidate();
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const currentProduct = currentApiProduct({ products, subscription, currentProductId });
+
+  const quota = currentProduct?.quotas.requestsPerMonth ?? FREE_TIER_QUOTA;
+  const used = (usage?.billableVerifications ?? 0) + (usage?.billableRatelimits ?? 0);
+
+  const canCancel = Boolean(
+    subscription && subscription.status === "active" && !subscription.cancelAt,
+  );
+
+  return (
+    <>
+      <Item>
+        <ItemMedia className="bg-infoA-3 text-info-11">
+          <Nodes />
+        </ItemMedia>
+        <ItemContent>
+          <div className="flex h-4 items-center">
+            <ItemTitle>API management</ItemTitle>
+          </div>
+          <ItemDescription>{formatNumber(quota)} requests included</ItemDescription>
+        </ItemContent>
+        <ItemActions className="gap-4">
+          <span className="w-48 text-right tabular-nums">
+            <span className="text-gray-11">{currentProduct ? currentProduct.name : "Free"} - </span>
+            <span className="font-medium text-gray-12">
+              ${currentProduct ? currentProduct.dollar : 0}/month
+            </span>
+          </span>
+          <span className="flex w-32 justify-end">
+            {currentProduct ? (
+              <AdminGate isAdmin={isAdmin}>
+                {(disabled) => (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={disabled}
+                    onClick={() => setShowPlanModal(true)}
+                  >
+                    Change
+                  </Button>
+                )}
+              </AdminGate>
+            ) : (
+              <AdminGate
+                isAdmin={isAdmin}
+                blocked={!hasPaymentMethod}
+                blockedReason={NEEDS_PAYMENT_TOOLTIP}
+              >
+                {(disabled) => (
+                  <Button
+                    variant={emphasize ? "primary" : "outline"}
+                    size="sm"
+                    disabled={disabled}
+                    onClick={() => setShowPlanModal(true)}
+                  >
+                    Upgrade
+                  </Button>
+                )}
+              </AdminGate>
+            )}
+          </span>
+        </ItemActions>
+      </Item>
+
+      {hasPaymentMethod ? (
+        <PlanChangeModal
+          isOpen={showPlanModal}
+          onOpenChange={setShowPlanModal}
+          title={currentProduct ? "Change API plan" : "Choose an API plan"}
+          subTitle="Tiered plans for key verifications and ratelimits."
+          options={products.map((product) => ({
+            id: product.id,
+            name: product.name,
+            amount: product.dollar * 100,
+            interval: "month",
+            detail: `${formatNumber(product.quotas.requestsPerMonth)} requests/month`,
+          }))}
+          currentId={currentProduct?.id ?? null}
+          warningFor={(option) => {
+            const target = products.find((p) => p.id === option.id);
+            return target && used > target.quotas.requestsPerMonth
+              ? `Your usage this month (${formatNumber(used)}) already exceeds the ${formatNumber(
+                  target.quotas.requestsPerMonth,
+                )} requests ${target.name} includes.`
+              : null;
+          }}
+          changeNote="Upgrades take effect immediately and are prorated. Downgrades start next billing period; your current plan stays active and no refund is issued."
+          submittingId={
+            createSubscription.isLoading
+              ? createSubscription.variables?.productId
+              : updateSubscription.isLoading
+                ? updateSubscription.variables?.newProductId
+                : undefined
+          }
+          onSelect={(id) => {
+            if (currentProduct) {
+              updateSubscription.mutate({ newProductId: id });
+              return;
+            }
+            createSubscription.mutate({ productId: id });
+          }}
+          cancelAction={
+            canCancel ? (
+              <CancelPlanLink
+                isAdmin={isAdmin}
+                onClick={() => {
+                  setShowPlanModal(false);
+                  setCancelOpen(true);
+                }}
+              >
+                Cancel API plan
+              </CancelPlanLink>
+            ) : null
+          }
+        />
+      ) : null}
+
+      <CancelApiDialog open={isCancelOpen} onOpenChange={setCancelOpen} />
+    </>
+  );
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/api-plan.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/api-plan.ts
@@ -1,0 +1,24 @@
+import { limitsByPlan } from "@/lib/limits";
+import type { Router } from "@/lib/trpc/routers";
+import type { inferRouterOutputs } from "@trpc/server";
+
+type BillingInfo = inferRouterOutputs<Router>["stripe"]["getBillingInfo"];
+
+export const FREE_TIER_QUOTA = limitsByPlan.free.apiBillableOperationsCountMaxPerMonth;
+
+const BILLING_STATUSES = ["active", "trialing", "past_due"];
+
+export function currentApiProduct({
+  products,
+  subscription,
+  currentProductId,
+}: {
+  products: BillingInfo["products"];
+  subscription?: BillingInfo["subscription"];
+  currentProductId?: BillingInfo["currentProductId"];
+}): BillingInfo["products"][number] | undefined {
+  if (!subscription || !currentProductId || !BILLING_STATUSES.includes(subscription.status)) {
+    return undefined;
+  }
+  return products.find((product) => product.id === currentProductId);
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/billing-notices.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/billing-notices.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { formatMs } from "@/lib/ms";
+import { formatDate } from "@/lib/fmt";
 import { trpc } from "@/lib/trpc/client";
 import type { Router } from "@/lib/trpc/routers";
 import type { inferRouterOutputs } from "@trpc/server";
@@ -98,8 +98,8 @@ function ScheduledCancellation({
     <AlertBanner variant="warning">
       <TriangleWarning2 iconSize="md-regular" />
       <AlertBannerDescription>
-        Your API plan ends in {formatMs(cancelAt - Date.now(), { long: true })} on{" "}
-        {new Date(cancelAt).toLocaleDateString()}; the workspace then downgrades to the free tier.
+        Your API plan ends on {formatDate(cancelAt)}. Afterwards your workspace will move to the
+        free tier.
       </AlertBannerDescription>
       <AlertBannerActions>
         <AdminGate isAdmin={isAdmin}>

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/billing-notices.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/billing-notices.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { formatMs } from "@/lib/ms";
+import { trpc } from "@/lib/trpc/client";
+import type { Router } from "@/lib/trpc/routers";
+import type { inferRouterOutputs } from "@trpc/server";
+import { TriangleWarning2 } from "@unkey/icons";
+import {
+  AlertBanner,
+  AlertBannerActions,
+  AlertBannerDescription,
+  AlertBannerTitle,
+  Button,
+  toast,
+} from "@unkey/ui";
+import { useRouter } from "next/navigation";
+import { AdminGate } from "./admin-gate";
+
+type BillingInfo = inferRouterOutputs<Router>["stripe"]["getBillingInfo"];
+
+const PAYMENT_REQUIRED_STATUSES = ["incomplete", "incomplete_expired", "unpaid", "past_due"];
+
+export function BillingNotices({
+  isAdmin,
+  subscription,
+}: {
+  isAdmin: boolean | undefined;
+  subscription?: BillingInfo["subscription"];
+}) {
+  return (
+    <>
+      {subscription && PAYMENT_REQUIRED_STATUSES.includes(subscription.status) ? (
+        <PaymentRequired status={subscription.status} />
+      ) : null}
+      {subscription?.cancelAt && subscription.cancelAt > Date.now() ? (
+        <ScheduledCancellation isAdmin={isAdmin} cancelAt={subscription.cancelAt} />
+      ) : null}
+    </>
+  );
+}
+
+function PaymentRequired({ status }: { status: string }) {
+  const completePayment = trpc.stripe.getSubscriptionPaymentUrl.useMutation({
+    onSuccess: ({ paymentUrl }) => window.location.assign(paymentUrl),
+    onError: (err) => toast.error(err.message),
+  });
+
+  return (
+    <AlertBanner variant="error">
+      <TriangleWarning2 iconSize="md-regular" />
+      <AlertBannerTitle>Payment required</AlertBannerTitle>
+      <AlertBannerDescription>
+        {status === "incomplete_expired"
+          ? "The previous payment attempt expired. Choose your plan again to retry."
+          : "Complete the payment in Stripe to activate or restore your plan."}
+      </AlertBannerDescription>
+      {status === "incomplete_expired" ? null : (
+        <AlertBannerActions>
+          <Button
+            variant="outline"
+            size="md"
+            loading={completePayment.isLoading}
+            onClick={() => completePayment.mutate()}
+          >
+            Complete payment
+          </Button>
+        </AlertBannerActions>
+      )}
+    </AlertBanner>
+  );
+}
+
+function ScheduledCancellation({
+  isAdmin,
+  cancelAt,
+}: {
+  isAdmin: boolean | undefined;
+  cancelAt: number;
+}) {
+  const router = useRouter();
+  const trpcUtils = trpc.useUtils();
+
+  const uncancel = trpc.stripe.uncancelSubscription.useMutation({
+    onSuccess: async () => {
+      await Promise.all([
+        trpcUtils.workspace.getCurrent.invalidate(),
+        trpcUtils.stripe.getBillingInfo.invalidate(),
+        trpcUtils.stripe.getUpcomingInvoice.invalidate(),
+      ]);
+      router.refresh();
+      toast.info("API plan resumed");
+    },
+    onError: () =>
+      toast.error("Failed to resume the plan. Please try again or contact support@unkey.com."),
+  });
+
+  return (
+    <AlertBanner variant="warning">
+      <TriangleWarning2 iconSize="md-regular" />
+      <AlertBannerDescription>
+        Your API plan ends in {formatMs(cancelAt - Date.now(), { long: true })} on{" "}
+        {new Date(cancelAt).toLocaleDateString()}; the workspace then downgrades to the free tier.
+      </AlertBannerDescription>
+      <AlertBannerActions>
+        <AdminGate isAdmin={isAdmin}>
+          {(disabled) => (
+            <Button
+              variant="outline"
+              size="md"
+              loading={uncancel.isLoading}
+              disabled={disabled || uncancel.isLoading}
+              onClick={() => uncancel.mutate()}
+            >
+              Resubscribe
+            </Button>
+          )}
+        </AdminGate>
+      </AlertBannerActions>
+    </AlertBanner>
+  );
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/billing-summary.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/billing-summary.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { formatDollars } from "@/lib/fmt";
+import { formatPrice } from "@/lib/fmt";
 import { routes } from "@/lib/navigation/routes";
 import { trpc } from "@/lib/trpc/client";
 import { Button, InfoTooltip, toast } from "@unkey/ui";
@@ -137,7 +137,7 @@ export const BillingSummary: React.FC<BillingSummaryProps> = ({
                 </span>
               </div>
               <p className="font-medium text-gray-12 text-sm leading-5 tabular-nums">
-                {formatDollars(row.half.total)}
+                {formatPrice(row.half.total)}
                 {row.showUsage ? (
                   <span className="ml-1.5 font-normal text-gray-9 text-xs">
                     + usage until the period ends

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/cancel-actions.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/cancel-actions.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { trpc } from "@/lib/trpc/client";
+import { TriangleWarning2 } from "@unkey/icons";
+import { Button, DialogContainer, toast } from "@unkey/ui";
+import { useRouter } from "next/navigation";
+import { AdminGate } from "./admin-gate";
+
+export function CancelPlanLink({
+  isAdmin,
+  onClick,
+  children,
+}: {
+  isAdmin: boolean | undefined;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <AdminGate isAdmin={isAdmin}>
+      {(disabled) => (
+        <button
+          type="button"
+          className="text-[13px] text-gray-9 transition-colors hover:text-gray-11 disabled:cursor-not-allowed"
+          disabled={disabled}
+          onClick={onClick}
+        >
+          {children}
+        </button>
+      )}
+    </AdminGate>
+  );
+}
+
+export function CancelComputeDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const trpcUtils = trpc.useUtils();
+
+  const cancel = trpc.stripe.cancelDeploy.useMutation({
+    onSuccess: async () => {
+      onOpenChange(false);
+      toast.info("Compute cancelled");
+      await Promise.all([
+        trpcUtils.stripe.getDeploySubscription.invalidate(),
+        trpcUtils.stripe.getDeployEntitlement.invalidate(),
+        trpcUtils.stripe.getUpcomingInvoice.invalidate(),
+        trpcUtils.billing.queryDeployUsage.invalidate(),
+        trpcUtils.workspace.getCurrent.invalidate(),
+      ]);
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  return (
+    <DialogContainer
+      isOpen={open}
+      onOpenChange={onOpenChange}
+      title="Cancel Compute"
+      subTitle="Turn off Compute for this workspace"
+      footer={
+        <Button
+          type="button"
+          variant="primary"
+          color="danger"
+          size="xlg"
+          className="w-full rounded-lg"
+          loading={cancel.isLoading}
+          onClick={() => cancel.mutate()}
+        >
+          Cancel Compute
+        </Button>
+      }
+    >
+      <div className="text-[13px] text-gray-11 leading-6">
+        Cancelling stops Compute immediately: your deployments stop and no further usage is billed.
+        Usage up to now is still charged, and the plan fee already paid is not refunded.
+      </div>
+    </DialogContainer>
+  );
+}
+
+export function CancelApiDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const router = useRouter();
+  const trpcUtils = trpc.useUtils();
+
+  const cancel = trpc.stripe.cancelSubscription.useMutation({
+    onSuccess: async () => {
+      await Promise.all([
+        trpcUtils.workspace.getCurrent.invalidate(),
+        trpcUtils.billing.queryUsage.invalidate(),
+        trpcUtils.stripe.getBillingInfo.invalidate(),
+        trpcUtils.stripe.getUpcomingInvoice.invalidate(),
+      ]);
+      router.refresh();
+      onOpenChange(false);
+      toast.info("Subscription cancelled");
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  return (
+    <DialogContainer
+      isOpen={open}
+      onOpenChange={onOpenChange}
+      title="Cancel API plan"
+      subTitle="Downgrade your workspace to the free tier"
+      footer={
+        <div className="flex w-full flex-col items-center justify-center gap-2">
+          <Button
+            type="button"
+            variant="primary"
+            color="danger"
+            size="xlg"
+            className="w-full rounded-lg"
+            loading={cancel.isLoading}
+            onClick={() => cancel.mutate()}
+          >
+            Cancel API plan
+          </Button>
+          <div className="text-gray-9 text-xs">
+            You can resume your subscription until the end of the billing period
+          </div>
+        </div>
+      }
+    >
+      <div className="flex items-center gap-4 rounded-xl border border-errorA-3 bg-errorA-2 px-[22px] py-6 dark:bg-black">
+        <div className="flex size-8 shrink-0 items-center justify-center rounded-full bg-error-9">
+          <TriangleWarning2 iconSize="sm-regular" className="text-white" />
+        </div>
+        <div className="text-[13px] text-error-12 leading-6">
+          <span className="font-medium">Warning:</span> cancelling your API plan will downgrade your
+          workspace to the free tier at the end of the current billing period. You will lose access
+          to paid features, usage limits will be reduced, and all team members other than you will
+          be deactivated.
+        </div>
+      </div>
+    </DialogContainer>
+  );
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/compute-plan-copy.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/compute-plan-copy.ts
@@ -1,4 +1,5 @@
 import type { DeployPlan } from "@/lib/stripe/deployPlan";
+import { BILLING_DOCS } from "@/lib/support";
 import { ArrowDottedRotateAnticlockwise, ChartActivity, CodeBranch, Eye } from "@unkey/icons";
 import type { IconProps } from "@unkey/icons";
 
@@ -47,7 +48,5 @@ export const FEATURES: ComputeFeature[] = [
 
 export const CREDITS_INFO = "Every plan includes monthly usage credit.";
 export const CREDITS_LINK_LABEL = "See how credits work";
-// TODO(dave): real docs URL for "how credits work" is not decided yet.
-export const CREDITS_LINK_HREF = "#";
-// TODO(dave): real docs URL for "Compute plans" is not decided yet.
-export const COMPUTE_PLANS_LINK_HREF = "#";
+export const CREDITS_LINK_HREF = BILLING_DOCS;
+export const COMPUTE_PLANS_LINK_HREF = BILLING_DOCS;

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/compute-plan-picker-v2.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/compute-plan-picker-v2.tsx
@@ -1,0 +1,330 @@
+"use client";
+
+import { formatDollars } from "@/lib/fmt";
+import type { DeployPlan } from "@/lib/stripe/deployPlan";
+import type { DeployPlanOption } from "@/lib/trpc/routers/stripe/getDeployPlans";
+import { cn } from "@/lib/utils";
+import { ArrowRight, ArrowUpRight, Check, CircleInfo } from "@unkey/icons";
+import { P, match } from "@unkey/match";
+import {
+  Button,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@unkey/ui";
+import {
+  ALL_PLANS_INCLUDE,
+  COMPUTE_PLANS_LINK_HREF,
+  CREDITS_INFO,
+  CREDITS_LINK_HREF,
+  CREDITS_LINK_LABEL,
+  FEATURES,
+  PLAN_BLURBS,
+} from "./compute-plan-copy";
+import { PlanTierIcon } from "./plan-tier-icons";
+
+type ComputePlanDialogProps = {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  subTitle?: string;
+  children: React.ReactNode;
+};
+
+export function ComputePlanDialog({
+  isOpen,
+  onOpenChange,
+  title,
+  subTitle,
+  children,
+}: ComputePlanDialogProps) {
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent className="flex max-h-[90vh] w-[90%] max-w-[560px] flex-col gap-0 overflow-hidden rounded-2xl! border-gray-4 bg-gray-1 p-0">
+        <div className="flex flex-col gap-1.5 px-[22px] pt-6 pb-3.5">
+          <DialogTitle className="font-semibold text-[22px] text-gray-12 leading-none tracking-[-0.03em]">
+            {title}
+          </DialogTitle>
+          {subTitle ? (
+            <DialogDescription className="text-[14px] text-gray-11 leading-normal">
+              {subTitle}
+            </DialogDescription>
+          ) : null}
+        </div>
+        <div className="flex flex-col gap-2.5 overflow-y-auto scrollbar-hide p-6 pt-0">
+          {children}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+type ComputePlanRowsProps = {
+  plans: DeployPlanOption[];
+  currentPlan?: DeployPlan | null;
+  currentPlanAmount?: number | null;
+  submittingPlan?: DeployPlan | null;
+  onSelect: (plan: DeployPlan) => void;
+  warningFor?: (plan: DeployPlanOption) => string | null;
+  disabledReason?: string;
+};
+
+type RowProps = ComputePlanRowsProps & { plan: DeployPlanOption };
+
+function intervalSuffix(interval: string | null): string {
+  switch (interval) {
+    case "month":
+      return "/mo";
+    case "year":
+      return "/yr";
+    default:
+      return interval ? `/${interval}` : "";
+  }
+}
+
+function planChange(
+  amount: number | null,
+  currentAmount: number | null | undefined,
+): "upgrade" | "downgrade" | null {
+  if (amount === null || currentAmount === null || currentAmount === undefined) {
+    return null;
+  }
+  return amount > currentAmount ? "upgrade" : "downgrade";
+}
+
+function Row({
+  plan,
+  currentPlan,
+  currentPlanAmount,
+  submittingPlan,
+  onSelect,
+  warningFor,
+  disabledReason,
+}: RowProps) {
+  const isCurrent = plan.plan === currentPlan;
+  const isSubmitting = plan.plan === submittingPlan;
+  const disabled = isCurrent || isSubmitting || disabledReason !== undefined;
+  const blurb = PLAN_BLURBS[plan.plan] ?? plan.description ?? "";
+  const warning = !isCurrent && warningFor ? warningFor(plan) : null;
+  const change = planChange(plan.amount, currentPlanAmount);
+  const label = match(change)
+    .with("upgrade", () => "Upgrade")
+    .with("downgrade", () => "Downgrade")
+    .with(P.nullish, () => "Select")
+    .exhaustive();
+
+  const cardClassName =
+    "group flex w-full items-center gap-[13px] rounded-[11px] border border-gray-4 bg-gray-1 px-[15px] py-3 text-left transition-colors";
+
+  const details = (
+    <>
+      <span className="flex size-9 shrink-0 items-center justify-center rounded-[9px] bg-grayA-3 text-gray-12">
+        <PlanTierIcon plan={plan.plan} className="size-[19px]" />
+      </span>
+
+      <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <span className="font-medium text-[15px] text-gray-12">{plan.name}</span>
+        {blurb ? <span className="text-[13px] text-gray-11">{blurb}</span> : null}
+      </span>
+
+      <span className="shrink-0 text-right">
+        {plan.amount !== null ? (
+          <>
+            <span className="font-semibold text-[15px] text-gray-12 tabular-nums">
+              {formatDollars(plan.amount)}
+            </span>
+            <span className="text-[12px] text-gray-11">{intervalSuffix(plan.interval)}</span>
+          </>
+        ) : (
+          <span className="font-semibold text-[15px] text-gray-12">Contact us</span>
+        )}
+      </span>
+    </>
+  );
+
+  return (
+    <div className="flex flex-col gap-2">
+      {isCurrent ? (
+        <div className={cardClassName}>
+          {details}
+          <span className="shrink-0 rounded-md bg-info-3 px-2.5 py-1.5 text-[13px] text-info-11 leading-none">
+            Current
+          </span>
+        </div>
+      ) : (
+        <button
+          type="button"
+          disabled={disabled}
+          aria-busy={isSubmitting}
+          title={disabledReason}
+          onClick={() => onSelect(plan.plan)}
+          className={cn(
+            cardClassName,
+            disabled ? "cursor-not-allowed opacity-70" : "cursor-pointer hover:border-gray-6",
+          )}
+        >
+          {details}
+          <Button
+            render={<span />}
+            variant={change === "downgrade" ? "outline" : "primary"}
+            size="md"
+            className="shrink-0 rounded-lg px-3 text-[13px]"
+          >
+            {isSubmitting ? (
+              <>
+                <span
+                  className="size-4 animate-spin rounded-full border-2 border-current border-t-transparent"
+                  aria-hidden="true"
+                />
+                <span className="sr-only">Working…</span>
+              </>
+            ) : (
+              <>
+                {label}
+                <ArrowRight
+                  iconSize="md-regular"
+                  className="transition-transform group-hover:translate-x-0.5"
+                />
+              </>
+            )}
+          </Button>
+        </button>
+      )}
+
+      {warning ? <p className="text-[13px] text-warning-11 leading-5">{warning}</p> : null}
+    </div>
+  );
+}
+
+export function ComputePlanRows(props: ComputePlanRowsProps) {
+  return (
+    <div className="flex flex-col gap-2.5 pt-2">
+      {props.plans.map((plan) => (
+        <Row key={plan.plan} {...props} plan={plan} />
+      ))}
+    </div>
+  );
+}
+
+export function ComputePlanFeatures() {
+  return (
+    <div className="grid grid-cols-2 gap-x-6 gap-y-6 py-2">
+      {FEATURES.map(({ Icon, title, description }) => (
+        <div key={title}>
+          <div className="flex items-center gap-[9px]">
+            <Icon iconSize="lg-regular" className="shrink-0 text-gray-12" />
+            <span className="font-medium text-[13px] text-gray-12">{title}</span>
+          </div>
+          <p className="mt-1 text-[12.5px] text-gray-11 leading-relaxed">{description}</p>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function ComputePlansMoreInfo() {
+  return (
+    <p className="text-[13px] text-gray-11 leading-normal">
+      Get more information about{" "}
+      <a
+        href={COMPUTE_PLANS_LINK_HREF}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="font-medium text-info-11 hover:underline"
+      >
+        Compute plans
+      </a>
+      .
+    </p>
+  );
+}
+
+export function AllPlansInclude() {
+  return (
+    <div className="rounded-[11px] border border-gray-4 bg-gray-1 px-4 py-3.5">
+      <span className="font-medium text-[13px] text-gray-12">Included in every plan</span>
+      <ul className="mt-3 grid grid-cols-2 gap-x-5 gap-y-2.5">
+        {ALL_PLANS_INCLUDE.map((feature) => (
+          <li key={feature} className="flex items-center gap-2.5 text-[13px] text-gray-11">
+            <Check iconSize="md-regular" className="shrink-0 text-gray-10" />
+            {feature}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export function CreditsInfoStrip() {
+  return (
+    <div className="flex items-start gap-2.5 rounded-[11px] border border-gray-4 bg-gray-1 px-3.5 py-3">
+      <CircleInfo iconSize="lg-regular" className="mt-px shrink-0 text-info-9" />
+      <p className="text-[12.5px] text-gray-11 leading-relaxed">
+        {CREDITS_INFO}{" "}
+        <a
+          href={CREDITS_LINK_HREF}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-0.5 whitespace-nowrap font-medium text-info-11 hover:underline"
+        >
+          {CREDITS_LINK_LABEL}
+          <ArrowUpRight iconSize="sm-regular" className="size-3" />
+        </a>
+      </p>
+    </div>
+  );
+}
+
+type ComputePlanConfirmDialogProps = {
+  plan: DeployPlanOption | null;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+  isLoading: boolean;
+  currentPlanName?: string;
+  note?: string;
+};
+
+export function ComputePlanConfirmDialog({
+  plan,
+  onOpenChange,
+  onConfirm,
+  isLoading,
+  currentPlanName,
+  note,
+}: ComputePlanConfirmDialogProps) {
+  return (
+    <DialogContainer
+      isOpen={plan !== null}
+      onOpenChange={onOpenChange}
+      title={currentPlanName ? `Change to ${plan?.name ?? "this plan"}` : "Confirm plan"}
+      subTitle={
+        plan?.amount !== null && plan?.amount !== undefined
+          ? `${formatDollars(plan.amount)}/${plan.interval ?? "month"}, billed now.`
+          : undefined
+      }
+      footer={
+        <div className="flex w-full flex-col items-center gap-2">
+          <Button
+            type="button"
+            variant="primary"
+            size="xlg"
+            className="w-full rounded-lg"
+            loading={isLoading}
+            onClick={onConfirm}
+          >
+            {currentPlanName ? "Confirm change" : "Subscribe"}
+          </Button>
+          {note ? <p className="text-center text-[12px] text-gray-9 leading-5">{note}</p> : null}
+        </div>
+      }
+    >
+      <div className="text-[13px] text-gray-11 leading-6">
+        {currentPlanName
+          ? `You're moving from ${currentPlanName} to ${plan?.name ?? "the selected plan"}.`
+          : `You're subscribing to ${plan?.name ?? "the selected plan"}.`}
+      </div>
+    </DialogContainer>
+  );
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/compute-plan-row.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/compute-plan-row.tsx
@@ -1,0 +1,290 @@
+"use client";
+
+import { formatDollars, formatPrice } from "@/lib/fmt";
+import { routes } from "@/lib/navigation/routes";
+import type { DeployPlan } from "@/lib/stripe/deployPlan";
+import { trpc } from "@/lib/trpc/client";
+import { Cube } from "@unkey/icons";
+import {
+  Button,
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemDescription,
+  ItemMedia,
+  ItemTitle,
+  Skeleton,
+  toast,
+} from "@unkey/ui";
+import { useState } from "react";
+import { AdminGate } from "./admin-gate";
+import { CancelComputeDialog, CancelPlanLink } from "./cancel-actions";
+import {
+  AllPlansInclude,
+  ComputePlanConfirmDialog,
+  ComputePlanDialog,
+  ComputePlanRows,
+  CreditsInfoStrip,
+} from "./compute-plan-picker-v2";
+import { ADMIN_ONLY_TOOLTIP } from "./constants";
+import { creditLabel, periodCredit } from "./deploy-invoice";
+
+const NEEDS_PAYMENT_TOOLTIP = "Add a payment method first";
+
+type ComputePlanRowProps = {
+  isAdmin: boolean | undefined;
+  hasPaymentMethod: boolean;
+  workspaceSlug: string;
+  emphasize: boolean;
+  autoOpenPlanModal?: boolean;
+};
+
+export function ComputePlanRow({
+  isAdmin,
+  hasPaymentMethod,
+  workspaceSlug,
+  emphasize,
+  autoOpenPlanModal = false,
+}: ComputePlanRowProps) {
+  const trpcUtils = trpc.useUtils();
+  const [isPlanModalOpen, setPlanModalOpen] = useState(autoOpenPlanModal);
+  const [pendingPlan, setPendingPlan] = useState<DeployPlan | null>(null);
+  const [isStartingCheckout, setIsStartingCheckout] = useState(false);
+  const [isCancelOpen, setCancelOpen] = useState(false);
+
+  const {
+    data: subscription,
+    isLoading: subscriptionLoading,
+    isError: subscriptionError,
+  } = trpc.stripe.getDeploySubscription.useQuery(undefined, { staleTime: 30_000 });
+  const {
+    data: plansData,
+    isLoading: plansLoading,
+    isError: plansError,
+  } = trpc.stripe.getDeployPlans.useQuery(undefined, {
+    staleTime: 60_000,
+    trpc: { context: { skipBatch: true } },
+  });
+
+  const currentPlan = subscription?.plan ?? null;
+
+  const { data: deployCredit } = trpc.stripe.getDeployCredit.useQuery(undefined, {
+    enabled: Boolean(currentPlan),
+    staleTime: 30_000,
+    trpc: { context: { skipBatch: true } },
+  });
+  const { data: usage } = trpc.billing.queryDeployUsage.useQuery(undefined, {
+    enabled: Boolean(currentPlan),
+    staleTime: 30_000,
+    trpc: { context: { skipBatch: true } },
+    retry: 1,
+  });
+
+  const change = trpc.stripe.changeDeployPlan.useMutation({
+    onSuccess: async (result) => {
+      if (result.kind === "payment_required") {
+        window.location.assign(result.paymentUrl);
+        return;
+      }
+      setPendingPlan(null);
+      setPlanModalOpen(false);
+      toast.success("Compute plan changed");
+      await Promise.all([
+        trpcUtils.stripe.getDeploySubscription.invalidate(),
+        trpcUtils.stripe.getDeployEntitlement.invalidate(),
+        trpcUtils.stripe.getUpcomingInvoice.invalidate(),
+        trpcUtils.stripe.getDeployCredit.invalidate(),
+        trpcUtils.billing.queryDeployUsage.invalidate(),
+        trpcUtils.workspace.getCurrent.invalidate(),
+      ]);
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  if (subscriptionLoading || plansLoading) {
+    return (
+      <Item>
+        <ItemMedia className="bg-orangeA-3 text-orange-11">
+          <Cube />
+        </ItemMedia>
+        <ItemContent className="gap-1">
+          <Skeleton className="h-3.5 w-20" />
+          <Skeleton className="h-3 w-32" />
+        </ItemContent>
+      </Item>
+    );
+  }
+
+  if (subscriptionError || plansError) {
+    return (
+      <Item>
+        <ItemMedia className="bg-orangeA-3 text-orange-11">
+          <Cube />
+        </ItemMedia>
+        <ItemContent>
+          <ItemTitle>Compute</ItemTitle>
+          <ItemDescription>
+            Compute plans could not be loaded. Reload the page or contact support@unkey.com.
+          </ItemDescription>
+        </ItemContent>
+      </Item>
+    );
+  }
+
+  if (plansData && !plansData.configured) {
+    return null;
+  }
+
+  const plans = plansData?.plans ?? [];
+  const currentPlanOption = plans.find((p) => p.plan === currentPlan);
+  const planFee = currentPlanOption?.amount ?? null;
+  const usageAmount = usage?.grossCents ?? null;
+
+  const credit = periodCredit(planFee, deployCredit?.includedCreditCents ?? null);
+
+  const description = currentPlan
+    ? planFee === null
+      ? "The plan fee includes usage credits; usage beyond them is billed on top."
+      : creditLabel(planFee, credit)
+    : "Choose a plan to start deploying on Unkey";
+
+  const warningFor = (option: (typeof plans)[number]): string | null =>
+    option.amount !== null && usageAmount !== null && usageAmount > option.amount
+      ? `Your usage this period (${formatPrice(usageAmount)}) already exceeds the ${formatDollars(
+          option.amount,
+        )} of monthly credits ${option.name} includes. This period keeps your current credits; from next period, usage at this level is billed as overage.`
+      : null;
+
+  const pendingPlanOption = plans.find((p) => p.plan === pendingPlan);
+  const commitPending = () => {
+    if (!pendingPlan) {
+      return;
+    }
+    if (currentPlan) {
+      change.mutate({ plan: pendingPlan });
+      return;
+    }
+    setIsStartingCheckout(true);
+    window.location.assign(
+      routes.settings.stripe.checkout({
+        workspaceSlug,
+        intent: "deploy",
+        plan: pendingPlan,
+        from: "billing",
+      }),
+    );
+  };
+
+  return (
+    <>
+      <Item>
+        <ItemMedia className="bg-orangeA-3 text-orange-11">
+          <Cube />
+        </ItemMedia>
+        <ItemContent>
+          <ItemTitle>Compute</ItemTitle>
+          <ItemDescription>{description}</ItemDescription>
+        </ItemContent>
+        <ItemActions className="gap-4">
+          {currentPlan && planFee !== null ? (
+            <span className="w-48 text-right tabular-nums">
+              <span className="text-gray-11">{currentPlanOption?.name ?? currentPlan} - </span>
+              <span className="font-medium text-gray-12">
+                {formatDollars(planFee)}/{currentPlanOption?.interval ?? "month"}
+              </span>
+            </span>
+          ) : null}
+          <span className="flex w-32 justify-end">
+            {currentPlan ? (
+              <AdminGate isAdmin={isAdmin}>
+                {(disabled) => (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={disabled}
+                    onClick={() => setPlanModalOpen(true)}
+                  >
+                    Change
+                  </Button>
+                )}
+              </AdminGate>
+            ) : (
+              <AdminGate
+                isAdmin={isAdmin}
+                blocked={!hasPaymentMethod}
+                blockedReason={NEEDS_PAYMENT_TOOLTIP}
+              >
+                {(disabled) => (
+                  <Button
+                    variant={emphasize ? "primary" : "outline"}
+                    size="sm"
+                    disabled={disabled}
+                    onClick={() => setPlanModalOpen(true)}
+                  >
+                    Choose a plan
+                  </Button>
+                )}
+              </AdminGate>
+            )}
+          </span>
+        </ItemActions>
+      </Item>
+
+      <ComputePlanDialog
+        isOpen={isPlanModalOpen}
+        onOpenChange={setPlanModalOpen}
+        title={currentPlan ? "Change Compute plan" : "Choose a Compute plan"}
+        subTitle="The monthly plan fee includes the same amount of usage credits; usage beyond them is billed on top."
+      >
+        <ComputePlanRows
+          plans={plans}
+          currentPlan={currentPlan}
+          currentPlanAmount={currentPlan ? planFee : null}
+          submittingPlan={
+            isStartingCheckout
+              ? pendingPlan
+              : change.isLoading
+                ? (change.variables?.plan ?? null)
+                : null
+          }
+          onSelect={(plan) => {
+            setPendingPlan(plan);
+            setPlanModalOpen(false);
+          }}
+          warningFor={warningFor}
+          disabledReason={isAdmin ? undefined : ADMIN_ONLY_TOOLTIP}
+        />
+        <AllPlansInclude />
+        <CreditsInfoStrip />
+        {currentPlan ? (
+          <div className="flex justify-center pt-1">
+            <CancelPlanLink
+              isAdmin={isAdmin}
+              onClick={() => {
+                setPlanModalOpen(false);
+                setCancelOpen(true);
+              }}
+            >
+              Cancel Compute plan
+            </CancelPlanLink>
+          </div>
+        ) : null}
+      </ComputePlanDialog>
+
+      <CancelComputeDialog open={isCancelOpen} onOpenChange={setCancelOpen} />
+
+      <ComputePlanConfirmDialog
+        plan={pendingPlanOption ?? null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setPendingPlan(null);
+          }
+        }}
+        onConfirm={commitPending}
+        isLoading={isStartingCheckout || change.isLoading}
+        currentPlanName={currentPlan ? (currentPlanOption?.name ?? currentPlan) : undefined}
+        note="Takes effect immediately. Upgrades are charged now and add the difference as usage credits; downgrades keep this period's credits, with the new fee starting next period."
+      />
+    </>
+  );
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/constants.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/constants.ts
@@ -1,1 +1,4 @@
 export const ADMIN_ONLY_TOOLTIP = "Admin access required to manage billing";
+
+// Must match the thresholds in svc/ctrl/worker/cron/deployspendcheck.
+export const ALERT_STEPS = [0.5, 0.75, 1] as const;

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/cost-control.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/cost-control.tsx
@@ -3,6 +3,7 @@
 import { formatDollars } from "@/lib/fmt";
 import { trpc } from "@/lib/trpc/client";
 import { Ban, Cube, Envelope, Nodes } from "@unkey/icons";
+import { P, match } from "@unkey/match";
 import {
   AlertBanner,
   AlertBannerDescription,
@@ -99,23 +100,25 @@ function ComputeBudget({ isAdmin }: { isAdmin: boolean | undefined }) {
         </ItemHeader>
 
         <div className="px-4 pb-4">
-          {isLoading ? (
-            <Skeleton className="h-9 w-28" />
-          ) : isError ? (
-            <AlertBanner variant="warning">
-              <AlertBannerDescription>
-                The spend controls could not be loaded.
-              </AlertBannerDescription>
-            </AlertBanner>
-          ) : budgetCents === null ? (
-            <AlertBanner>
-              <AlertBannerDescription>No spend controls are enabled yet</AlertBannerDescription>
-            </AlertBanner>
-          ) : (
-            <span className="font-semibold text-3xl text-gray-12 tabular-nums tracking-tight">
-              {formatDollars(budgetCents)}
-            </span>
-          )}
+          {match({ isLoading, isError, budgetCents })
+            .with({ isLoading: true }, () => <Skeleton className="h-9 w-28" />)
+            .with({ isError: true }, () => (
+              <AlertBanner variant="warning">
+                <AlertBannerDescription>
+                  The spend controls could not be loaded.
+                </AlertBannerDescription>
+              </AlertBanner>
+            ))
+            .with({ budgetCents: P.number }, ({ budgetCents }) => (
+              <span className="font-semibold text-3xl text-gray-12 tabular-nums tracking-tight">
+                {formatDollars(budgetCents)}
+              </span>
+            ))
+            .otherwise(() => (
+              <AlertBanner>
+                <AlertBannerDescription>No spend controls are enabled yet</AlertBannerDescription>
+              </AlertBanner>
+            ))}
         </div>
 
         {budgetCents !== null ? (

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/cost-control.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/cost-control.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import { formatDollars } from "@/lib/fmt";
+import { trpc } from "@/lib/trpc/client";
+import { Ban, Cube, Envelope, Nodes } from "@unkey/icons";
+import {
+  AlertBanner,
+  AlertBannerDescription,
+  Button,
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemDescription,
+  ItemGroup,
+  ItemHeader,
+  ItemMedia,
+  ItemSeparator,
+  ItemTitle,
+  Skeleton,
+} from "@unkey/ui";
+import { type ReactNode, useState } from "react";
+import { AdminGate } from "./admin-gate";
+import { ALERT_STEPS } from "./constants";
+import { SpendBudgetDialog } from "./spend-budget-v2";
+
+type CostControlProps = {
+  isAdmin: boolean | undefined;
+  apiFeeCents: number | null;
+};
+
+export function CostControl({ isAdmin, apiFeeCents }: CostControlProps) {
+  return (
+    <div className="flex flex-col gap-3">
+      <h2 className="font-medium text-[13px] text-gray-12">Cost control</h2>
+      <ComputeBudget isAdmin={isAdmin} />
+      <ApiFixedFee apiFeeCents={apiFeeCents} />
+    </div>
+  );
+}
+
+function ComputeBudget({ isAdmin }: { isAdmin: boolean | undefined }) {
+  const [open, setOpen] = useState(false);
+
+  const {
+    data: budget,
+    isLoading,
+    isError,
+  } = trpc.billing.getDeployBudget.useQuery(undefined, { staleTime: 30_000 });
+
+  const budgetCents = budget?.budgetCents ?? null;
+  const stopAtBudget = budget?.stopAtBudget ?? false;
+  const suspended = budget?.suspended ?? false;
+
+  return (
+    <>
+      <ItemGroup variant="outline">
+        {suspended ? (
+          <div className="px-4 pt-4">
+            <AlertBanner variant="warning">
+              <AlertBannerDescription>
+                Workloads are currently stopped.{" "}
+                <AdminGate isAdmin={isAdmin}>
+                  {(disabled) => (
+                    <button
+                      type="button"
+                      disabled={disabled}
+                      onClick={() => setOpen(true)}
+                      className="cursor-pointer underline underline-offset-2 hover:opacity-80 disabled:cursor-not-allowed disabled:no-underline"
+                    >
+                      Configure
+                    </button>
+                  )}
+                </AdminGate>
+              </AlertBannerDescription>
+            </AlertBanner>
+          </div>
+        ) : null}
+        <ItemHeader>
+          <ItemMedia className="bg-orangeA-3 text-orange-11">
+            <Cube />
+          </ItemMedia>
+          <ItemContent>
+            <ItemTitle>Compute</ItemTitle>
+          </ItemContent>
+          <ItemActions>
+            <AdminGate isAdmin={isAdmin}>
+              {(disabled) => (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={disabled || isLoading || isError}
+                  onClick={() => setOpen(true)}
+                >
+                  {isLoading || isError || budgetCents !== null ? "Configure" : "Add"}
+                </Button>
+              )}
+            </AdminGate>
+          </ItemActions>
+        </ItemHeader>
+
+        <div className="px-4 pb-4">
+          {isLoading ? (
+            <Skeleton className="h-9 w-28" />
+          ) : isError ? (
+            <AlertBanner variant="warning">
+              <AlertBannerDescription>
+                The spend controls could not be loaded.
+              </AlertBannerDescription>
+            </AlertBanner>
+          ) : budgetCents === null ? (
+            <AlertBanner>
+              <AlertBannerDescription>No spend controls are enabled yet</AlertBannerDescription>
+            </AlertBanner>
+          ) : (
+            <span className="font-semibold text-3xl text-gray-12 tabular-nums tracking-tight">
+              {formatDollars(budgetCents)}
+            </span>
+          )}
+        </div>
+
+        {budgetCents !== null ? (
+          <>
+            <ItemSeparator />
+            <div className="bg-grayA-2 px-4 py-2 font-semibold text-[10px] text-gray-9 uppercase tracking-wider">
+              Alerts
+            </div>
+            {/* The deployspendcheck worker sends the stopped email instead of the 100% warning when stopping is on. */}
+            {ALERT_STEPS.filter((step) => !(stopAtBudget && step === 1)).map((step) => (
+              <AlertRow key={step} icon={<Envelope />}>
+                Email at {step * 100}% ({formatDollars(budgetCents * step)})
+              </AlertRow>
+            ))}
+            {stopAtBudget ? (
+              <AlertRow icon={<Ban />} mediaClassName="bg-errorA-3 text-error-11">
+                Stop workloads and email at 100% ({formatDollars(budgetCents)})
+              </AlertRow>
+            ) : null}
+          </>
+        ) : null}
+      </ItemGroup>
+
+      <SpendBudgetDialog open={open} onOpenChange={setOpen} />
+    </>
+  );
+}
+
+function AlertRow({
+  icon,
+  mediaClassName,
+  children,
+}: {
+  icon: ReactNode;
+  mediaClassName?: string;
+  children: ReactNode;
+}) {
+  return (
+    <>
+      <ItemSeparator />
+      <Item>
+        <ItemMedia className={mediaClassName}>{icon}</ItemMedia>
+        <ItemContent>
+          <ItemTitle className="font-normal">{children}</ItemTitle>
+        </ItemContent>
+      </Item>
+    </>
+  );
+}
+
+function ApiFixedFee({ apiFeeCents }: { apiFeeCents: number | null }) {
+  return (
+    <ItemGroup variant="outline">
+      <ItemHeader>
+        <ItemMedia className="bg-infoA-3 text-info-11">
+          <Nodes />
+        </ItemMedia>
+        <ItemContent>
+          <ItemTitle>API management</ItemTitle>
+        </ItemContent>
+      </ItemHeader>
+      <ItemSeparator />
+      <Item>
+        <ItemContent>
+          <ItemDescription className="text-[13px] leading-5">
+            {apiFeeCents === null
+              ? "Plan fee unavailable."
+              : `Fixed at ${formatDollars(apiFeeCents)}/month.`}
+          </ItemDescription>
+        </ItemContent>
+      </Item>
+    </ItemGroup>
+  );
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/deploy-invoice.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/deploy-invoice.ts
@@ -1,0 +1,22 @@
+import { formatDollars } from "@/lib/fmt";
+
+export function periodCredit(
+  planFeeCents: number | null,
+  grantedCreditCents: number | null,
+): { cents: number; prorated: boolean } | null {
+  const cents = grantedCreditCents ?? planFeeCents;
+  if (planFeeCents === null || cents === null) {
+    return null;
+  }
+  const resolved = cents > 0 ? cents : planFeeCents;
+  return { cents: resolved, prorated: resolved !== planFeeCents };
+}
+
+export function creditLabel(
+  planFeeCents: number,
+  credit: { cents: number; prorated: boolean } | null,
+): string {
+  return credit?.prorated
+    ? `${formatDollars(credit.cents)} usage credit, prorated`
+    : `${formatDollars(planFeeCents)} usage credit`;
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/deploy-product-card.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/deploy-product-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { DEPLOY_METER_RATE_LABELS, priceDeployMetersCents } from "@/lib/billing/deployPricing";
-import { formatCompactQuantity, formatDollars } from "@/lib/fmt";
+import { formatCompactQuantity, formatDollars, formatPrice } from "@/lib/fmt";
 import { routes } from "@/lib/navigation/routes";
 import type { DeployPlan } from "@/lib/stripe/deployPlan";
 import { trpc } from "@/lib/trpc/client";
@@ -259,7 +259,7 @@ export const DeployProductCard: React.FC<DeployProductCardProps> = ({
 
   const warningFor = (option: (typeof plans)[number]): string | null =>
     option.amount !== null && usageAmount !== null && usageAmount > option.amount
-      ? `Your usage this period (${formatDollars(usageAmount)}) already exceeds the ${formatDollars(
+      ? `Your usage this period (${formatPrice(usageAmount)}) already exceeds the ${formatDollars(
           option.amount,
         )} of monthly credits ${option.name} includes. This period keeps your current credits; from next period, usage at this level is billed as overage.`
       : null;
@@ -367,7 +367,7 @@ export const DeployProductCard: React.FC<DeployProductCardProps> = ({
                       {stat.value}
                     </p>
                     <p className="text-[12px] text-gray-10 tabular-nums">
-                      {formatDollars(stat.cost)}
+                      {formatPrice(stat.cost)}
                     </p>
                   </div>
                 ))}
@@ -404,14 +404,14 @@ export const DeployProductCard: React.FC<DeployProductCardProps> = ({
                 <div className="flex items-baseline justify-between gap-4">
                   <span className="text-[13px] text-gray-10">Usage</span>
                   <span className="text-[13px] text-gray-9 tabular-nums">
-                    {formatDollars(usageAmount ?? 0)}
+                    {formatPrice(usageAmount ?? 0)}
                   </span>
                 </div>
                 {includedCreditCents > 0 && creditRemainingCents !== null ? (
                   <div className="flex items-baseline justify-between gap-4">
                     <span className="text-[13px] text-gray-10">Included credit</span>
                     <span className="text-[13px] text-gray-9 tabular-nums">
-                      {formatDollars(creditRemainingCents)} of {formatDollars(includedCreditCents)}{" "}
+                      {formatPrice(creditRemainingCents)} of {formatDollars(includedCreditCents)}{" "}
                       remaining
                     </span>
                   </div>
@@ -423,7 +423,7 @@ export const DeployProductCard: React.FC<DeployProductCardProps> = ({
                       <span className="ml-1.5 text-[12px] text-gray-9">usage past credit</span>
                     </span>
                     <span className="text-[13px] text-gray-11 tabular-nums">
-                      {formatDollars(overageCents)}
+                      {formatPrice(overageCents)}
                     </span>
                   </div>
                 ) : null}
@@ -454,8 +454,8 @@ export const DeployProductCard: React.FC<DeployProductCardProps> = ({
                               period's fee.
                             </p>
                             <p className="text-gray-11 tabular-nums">
-                              {formatDollars(overageCents)} + {formatDollars(planFee)} ={" "}
-                              {formatDollars(nextInvoiceCents ?? overageCents + planFee)}
+                              {formatPrice(overageCents)} + {formatDollars(planFee)} ={" "}
+                              {formatPrice(nextInvoiceCents ?? overageCents + planFee)}
                             </p>
                           </div>
                           <div className="flex flex-col gap-1 border-grayA-4 border-t pt-2">
@@ -488,18 +488,18 @@ export const DeployProductCard: React.FC<DeployProductCardProps> = ({
                     projectedOverageCents > overageCents ? (
                       <span className="ml-1.5 text-[12px] text-gray-9">
                         (~
-                        {formatDollars(nextInvoiceCents + (projectedOverageCents - overageCents))}{" "}
+                        {formatPrice(nextInvoiceCents + (projectedOverageCents - overageCents))}{" "}
                         projected)
                       </span>
                     ) : null}
                   </span>
                   <span className="font-medium text-[15px] text-gray-12 tabular-nums">
-                    {nextInvoiceCents !== null ? formatDollars(nextInvoiceCents) : "—"}
+                    {nextInvoiceCents !== null ? formatPrice(nextInvoiceCents) : "—"}
                   </span>
                 </div>
                 <p className="text-[12px] text-gray-9">
                   This period's {formatDollars(periodFeeCents)} fee is already paid. Total cost for
-                  this period is {formatDollars(currentBillCents)}.
+                  this period is {formatPrice(currentBillCents)}.
                 </p>
               </div>
             ) : null}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/invoice-card.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/invoice-card.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { formatPeriod, formatPrice } from "@/lib/fmt";
+import { routes } from "@/lib/navigation/routes";
+import { trpc } from "@/lib/trpc/client";
+import {
+  Button,
+  ItemActions,
+  ItemContent,
+  ItemDescription,
+  ItemGroup,
+  ItemHeader,
+  ItemTitle,
+  Skeleton,
+  toast,
+} from "@unkey/ui";
+import { useRouter } from "next/navigation";
+import { AdminGate } from "./admin-gate";
+
+type InvoiceCardProps = {
+  workspaceSlug: string;
+  isAdmin: boolean | undefined;
+  hasPaymentMethod: boolean;
+};
+
+export function InvoiceCard({ workspaceSlug, isAdmin, hasPaymentMethod }: InvoiceCardProps) {
+  const {
+    data: invoice,
+    isLoading,
+    isError,
+  } = trpc.stripe.getUpcomingInvoice.useQuery(undefined, {
+    enabled: hasPaymentMethod,
+    staleTime: 30_000,
+    trpc: { context: { skipBatch: true } },
+  });
+
+  if (!hasPaymentMethod) {
+    return <NoPaymentMethod workspaceSlug={workspaceSlug} isAdmin={isAdmin} />;
+  }
+
+  const halves = [
+    invoice?.deploy ? { label: "Compute", half: invoice.deploy } : null,
+    invoice?.api ? { label: "API", half: invoice.api } : null,
+  ].filter((row): row is NonNullable<typeof row> => row !== null);
+
+  const periods = [
+    ...new Set(halves.map((row) => formatPeriod(row.half.periodStart, row.half.periodEnd))),
+  ];
+  const caption = isError
+    ? "The upcoming invoice could not be loaded."
+    : periods.length === 1
+      ? periods[0]
+      : halves
+          .map((row) => `${row.label} ${formatPeriod(row.half.periodStart, row.half.periodEnd)}`)
+          .join(" · ");
+
+  const totalCents = isError ? null : halves.reduce((total, row) => total + row.half.total, 0);
+
+  return (
+    <ItemGroup variant="outline">
+      <ItemHeader>
+        <ItemContent>
+          <ItemTitle>Upcoming invoice</ItemTitle>
+          {caption ? <ItemDescription>{caption}</ItemDescription> : null}
+        </ItemContent>
+        <ItemActions>
+          <AdminGate isAdmin={isAdmin}>
+            {(disabled) => (
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={disabled}
+                onClick={() =>
+                  window.open(
+                    routes.settings.stripe.portal({ workspaceSlug }),
+                    "_blank",
+                    "noopener,noreferrer",
+                  )
+                }
+              >
+                Invoices
+              </Button>
+            )}
+          </AdminGate>
+        </ItemActions>
+      </ItemHeader>
+
+      <div className="px-4 pb-4">
+        {isLoading ? (
+          <Skeleton className="h-9 w-28" />
+        ) : (
+          <span className="font-semibold text-3xl text-gray-12 tabular-nums tracking-tight">
+            {totalCents === null ? "—" : formatPrice(totalCents)}
+          </span>
+        )}
+      </div>
+    </ItemGroup>
+  );
+}
+
+function NoPaymentMethod({
+  workspaceSlug,
+  isAdmin,
+}: {
+  workspaceSlug: string;
+  isAdmin: boolean | undefined;
+}) {
+  const router = useRouter();
+  const trpcUtils = trpc.useUtils();
+
+  const seedStripe = trpc.stripe.seedTestCustomer.useMutation({
+    onSuccess: async () => {
+      toast.success("Seeded a Stripe test customer with the 4242 card");
+      await trpcUtils.invalidate();
+      router.refresh();
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  return (
+    <ItemGroup variant="outline">
+      <ItemHeader>
+        <ItemContent>
+          <ItemTitle>No payment method</ItemTitle>
+          <ItemDescription>
+            Add one to subscribe. Each product bills on its own invoice.
+          </ItemDescription>
+        </ItemContent>
+        <ItemActions>
+          {process.env.NODE_ENV === "development" ? (
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={isAdmin !== true || seedStripe.isLoading}
+              onClick={() => seedStripe.mutate()}
+              title="Dev only: create a Stripe test customer with your email and the 4242 test card"
+            >
+              {seedStripe.isLoading ? "Seeding..." : "Seed test card"}
+            </Button>
+          ) : null}
+          <AdminGate isAdmin={isAdmin}>
+            {(disabled) => (
+              <Button
+                variant="primary"
+                size="sm"
+                disabled={disabled}
+                onClick={() =>
+                  router.push(routes.settings.stripe.checkout({ workspaceSlug, intent: "payment" }))
+                }
+              >
+                Add payment method
+              </Button>
+            )}
+          </AdminGate>
+        </ItemActions>
+      </ItemHeader>
+    </ItemGroup>
+  );
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/plan-change-modal.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/plan-change-modal.tsx
@@ -45,6 +45,7 @@ type PlanChangeModalProps = {
   /** The option whose mutation is in flight, for the CTA loading state. */
   submittingId: string | undefined;
   onSelect: (id: string) => void;
+  cancelAction?: React.ReactNode;
 };
 
 /**
@@ -65,6 +66,7 @@ export const PlanChangeModal: React.FC<PlanChangeModalProps> = ({
   changeNote,
   submittingId,
   onSelect,
+  cancelAction,
 }) => {
   const [selected, setSelected] = useState<string | null>(currentId);
 
@@ -129,6 +131,7 @@ export const PlanChangeModal: React.FC<PlanChangeModalProps> = ({
             {ctaLabel}
           </Button>
           {currentId && changeNote ? <div className="text-gray-9 text-xs">{changeNote}</div> : null}
+          {cancelAction}
         </div>
       }
     >

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/plans-card.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/plans-card.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { trpc } from "@/lib/trpc/client";
+import type { Router } from "@/lib/trpc/routers";
+import type { inferRouterOutputs } from "@trpc/server";
+import { ItemContent, ItemGroup, ItemHeader, ItemSeparator, ItemTitle } from "@unkey/ui";
+import { currentApiProduct } from "./api-plan";
+import { ApiPlanRow } from "./api-plan-row";
+import { ComputePlanRow } from "./compute-plan-row";
+
+type BillingInfo = inferRouterOutputs<Router>["stripe"]["getBillingInfo"];
+
+type PlansCardProps = {
+  isAdmin: boolean | undefined;
+  hasPaymentMethod: boolean;
+  workspaceSlug: string;
+  products: BillingInfo["products"];
+  subscription?: BillingInfo["subscription"];
+  currentProductId?: BillingInfo["currentProductId"];
+  checkoutIntent: "compute" | "api" | null;
+};
+
+export function PlansCard({
+  isAdmin,
+  hasPaymentMethod,
+  workspaceSlug,
+  products,
+  subscription,
+  currentProductId,
+  checkoutIntent,
+}: PlansCardProps) {
+  const { data: deploySubscription } = trpc.stripe.getDeploySubscription.useQuery(undefined, {
+    staleTime: 30_000,
+  });
+
+  const hasPaidApiPlan = Boolean(currentApiProduct({ products, subscription, currentProductId }));
+  const emphasize = !deploySubscription?.plan && !hasPaidApiPlan;
+
+  return (
+    <ItemGroup variant="outline">
+      <ItemHeader>
+        <ItemContent>
+          <ItemTitle>Plans</ItemTitle>
+        </ItemContent>
+      </ItemHeader>
+
+      <ItemSeparator />
+      <ComputePlanRow
+        isAdmin={isAdmin}
+        hasPaymentMethod={hasPaymentMethod}
+        workspaceSlug={workspaceSlug}
+        emphasize={emphasize}
+        autoOpenPlanModal={checkoutIntent === "compute" && hasPaymentMethod}
+      />
+
+      <ItemSeparator />
+      <ApiPlanRow
+        isAdmin={isAdmin}
+        hasPaymentMethod={hasPaymentMethod}
+        workspaceSlug={workspaceSlug}
+        emphasize={emphasize}
+        products={products}
+        subscription={subscription}
+        currentProductId={currentProductId}
+        autoOpenPlanModal={checkoutIntent === "api" && hasPaymentMethod}
+      />
+    </ItemGroup>
+  );
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/related-pages.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/related-pages.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { routes } from "@/lib/navigation/routes";
+import { BILLING_DOCS } from "@/lib/support";
+import { BookOpen, ChartUsage } from "@unkey/icons";
+import { Item, ItemContent, ItemDescription, ItemMedia, ItemTitle } from "@unkey/ui";
+import type { Route } from "next";
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+export function RelatedPages({ workspaceSlug }: { workspaceSlug: string }) {
+  const pages: Array<{
+    href: Route;
+    icon: ReactNode;
+    title: string;
+    description: string;
+    external?: boolean;
+  }> = [
+    {
+      href: routes.settings.usage({ workspaceSlug }),
+      icon: <ChartUsage />,
+      title: "Usage",
+      description: "Track your spend and usage across Unkey",
+    },
+    {
+      href: BILLING_DOCS,
+      icon: <BookOpen />,
+      title: "Documentation",
+      description: "How plans, usage and invoices work",
+      external: true,
+    },
+  ];
+
+  return (
+    <div className="grid gap-3 sm:grid-cols-2">
+      {pages.map((page) => (
+        <Item
+          key={page.title}
+          variant="outline"
+          render={
+            <Link
+              href={page.href}
+              target={page.external ? "_blank" : undefined}
+              rel={page.external ? "noopener noreferrer" : undefined}
+            />
+          }
+        >
+          <ItemMedia>{page.icon}</ItemMedia>
+          <ItemContent>
+            <ItemTitle>{page.title}</ItemTitle>
+            <ItemDescription>{page.description}</ItemDescription>
+          </ItemContent>
+        </Item>
+      ))}
+    </div>
+  );
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/spend-budget-v2.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/spend-budget-v2.tsx
@@ -5,16 +5,12 @@ import { formatDollars } from "@/lib/fmt";
 import { trpc } from "@/lib/trpc/client";
 import { Button, DialogContainer, FormInput, toast } from "@unkey/ui";
 import { useState } from "react";
+import { ALERT_STEPS } from "./constants";
 
-/** Mirrors MAX_BUDGET_CENTS in the deploy-budget router so an over-cap value
- *  fails client-side with a readable message. */
+const ALERT_STEPS_LABEL = ALERT_STEPS.map((step) => `${step * 100}%`).join(", ");
+
 const MAX_BUDGET_CENTS = 1_000_000_000;
 
-/**
- * Parses a whole-dollar form value into cents. Empty = no budget (null);
- * anything non-numeric, non-positive, or above the server's budget cap is
- * invalid (undefined).
- */
 function parseDollars(value: string): number | null | undefined {
   const trimmed = value.trim();
   if (trimmed === "") {
@@ -25,29 +21,6 @@ function parseDollars(value: string): number | null | undefined {
   }
   const cents = Number.parseInt(trimmed, 10) * 100;
   return cents > 0 && cents <= MAX_BUDGET_CENTS ? cents : undefined;
-}
-
-/** The spend bar's fill and severity: neutral, amber from 75%, red at 100%.
- *  Suspended means the cap was reached, so the bar reads full-and-red even
- *  while the usage query lags behind it. */
-export function spendBar(
-  usageCents: number | null,
-  budgetCents: number | null,
-  suspended: boolean,
-): { fraction: number | null; fillClassName: string } {
-  const fraction = suspended
-    ? 1
-    : usageCents !== null && budgetCents
-      ? Math.min(1, Math.max(0, usageCents / budgetCents))
-      : null;
-  const usedFraction = usageCents !== null && budgetCents ? usageCents / budgetCents : 0;
-  const fillClassName =
-    suspended || usedFraction >= 1
-      ? "bg-error-9"
-      : usedFraction >= 0.75
-        ? "bg-warning-9"
-        : "bg-gray-9";
-  return { fraction, fillClassName };
 }
 
 type SpendBudgetDialogProps = {
@@ -65,8 +38,6 @@ export function SpendBudgetDialog({ open, onOpenChange }: SpendBudgetDialogProps
   const currentBudget = budget?.budgetCents ?? null;
   const hasBudget = currentBudget !== null;
 
-  // null = untouched, fall through to the saved budget; only edits are stored,
-  // so a background refetch can't wipe input mid-edit.
   const [budgetDraft, setBudgetDraft] = useState<string | null>(null);
   const [stopDraft, setStopDraft] = useState<boolean | null>(null);
   const budgetInput = budgetDraft ?? (currentBudget != null ? String(currentBudget / 100) : "");
@@ -84,8 +55,6 @@ export function SpendBudgetDialog({ open, onOpenChange }: SpendBudgetDialogProps
     onSuccess: async () => {
       setOpen(false);
       toast.success("Spend budget saved");
-      // workspace.getCurrent carries deploySpendSuspended, which drives the
-      // app-wide paused banner.
       await Promise.all([
         trpcUtils.billing.getDeployBudget.invalidate(),
         trpcUtils.workspace.getCurrent.invalidate(),
@@ -141,7 +110,7 @@ export function SpendBudgetDialog({ open, onOpenChange }: SpendBudgetDialogProps
       <div className="flex flex-col gap-5">
         <FormInput
           label="Monthly budget"
-          description="We email you when your usage spend reaches 50%, 75% and 100% of this amount. Leave empty for no budget."
+          description={`We email you when your usage spend reaches ${ALERT_STEPS_LABEL} of this amount. Leave empty for no budget.`}
           placeholder="300"
           prefix="$"
           inputMode="numeric"
@@ -149,8 +118,6 @@ export function SpendBudgetDialog({ open, onOpenChange }: SpendBudgetDialogProps
           onChange={(e) => {
             const next = e.currentTarget.value;
             setBudgetDraft(next);
-            // Clearing the budget clears the stop too: a stop without a
-            // budget has no trigger point.
             if (parseDollars(next) === null) {
               setStopDraft(false);
             }

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/spend-management.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/spend-management.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import { formatDollars } from "@/lib/fmt";
+import { formatDollars, formatPrice } from "@/lib/fmt";
 import { trpc } from "@/lib/trpc/client";
 import { cn } from "@/lib/utils";
 import { Button, InfoTooltip } from "@unkey/ui";
 import { useState } from "react";
 import { ComputePausedBadge, PausedDocsLink, pausedBody } from "./compute-paused";
-import { ADMIN_ONLY_TOOLTIP } from "./constants";
-import { ALERT_STEPS, SpendBudgetDialog, spendBar } from "./spend-budget";
+import { ADMIN_ONLY_TOOLTIP, ALERT_STEPS } from "./constants";
+import { SpendBudgetDialog, spendBar } from "./spend-budget";
 
 type SpendManagementProps = {
   /** Month-to-date gross usage spend in cents, or null while loading. */
@@ -68,7 +68,7 @@ export function SpendManagement({ usageCents, isAdmin }: SpendManagementProps) {
                 {suspended ? <ComputePausedBadge /> : null}
               </div>
               <span className="font-medium text-[13px] text-gray-12 tabular-nums">
-                {usageCents !== null ? formatDollars(usageCents) : "—"} of{" "}
+                {usageCents !== null ? formatPrice(usageCents) : "—"} of{" "}
                 {formatDollars(currentBudget)}
                 {percent !== null ? ` (${percent}%)` : ""}
               </span>

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/deploy-billing-client-v2.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/deploy-billing-client-v2.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useConsumedSearchParam } from "@/hooks/use-consumed-search-param";
+import { useWorkspaceNavigation } from "@/hooks/use-workspace-navigation";
+import { routes } from "@/lib/navigation/routes";
+import { SUPPORT_MAILTO } from "@/lib/support";
+import { trpc } from "@/lib/trpc/client";
+import { Phone } from "@unkey/icons";
+import {
+  Button,
+  Empty,
+  PageBody,
+  PageContainer,
+  PageHeader,
+  PageHeaderActions,
+  PageHeaderContent,
+  PageHeaderTitle,
+  Skeleton,
+} from "@unkey/ui";
+import Link from "next/link";
+import type { ReactNode } from "react";
+import { currentApiProduct } from "./components/api-plan";
+import { BillingNotices } from "./components/billing-notices";
+import { CostControl } from "./components/cost-control";
+import { InvoiceCard } from "./components/invoice-card";
+import { PlansCard } from "./components/plans-card";
+import { RelatedPages } from "./components/related-pages";
+
+const SALES_CALL_URL = "https://cal.com/james-r-perkins/sales";
+
+function Shell({ children }: { children: ReactNode }) {
+  return (
+    <PageContainer>
+      <PageHeader>
+        <PageHeaderContent>
+          <PageHeaderTitle>Billing</PageHeaderTitle>
+        </PageHeaderContent>
+        <PageHeaderActions>
+          <Button
+            variant="outline"
+            size="md"
+            render={<Link href={SALES_CALL_URL} target="_blank" rel="noopener noreferrer" />}
+          >
+            <Phone iconSize="md-medium" />
+            Schedule a call
+          </Button>
+          <Button variant="outline" size="md" render={<Link href={SUPPORT_MAILTO} />}>
+            Contact us
+          </Button>
+        </PageHeaderActions>
+      </PageHeader>
+      <PageBody>{children}</PageBody>
+    </PageContainer>
+  );
+}
+
+function isCheckoutIntent(value: string | null): value is "compute" | "api" {
+  return value === "compute" || value === "api";
+}
+
+export function DeployBillingClientV2() {
+  const workspace = useWorkspaceNavigation();
+
+  const checkoutIntent = useConsumedSearchParam(
+    "intent",
+    (value) => (isCheckoutIntent(value) ? value : null),
+    routes.settings.billing({ workspaceSlug: workspace.slug }),
+  );
+
+  const { data: currentUser } = trpc.user.getCurrentUser.useQuery();
+  const isAdmin = currentUser ? currentUser.role === "admin" : undefined;
+
+  const { data: billingInfo, error: billingError } = trpc.stripe.getBillingInfo.useQuery(
+    undefined,
+    {
+      staleTime: 30_000,
+      trpc: { context: { skipBatch: true } },
+    },
+  );
+
+  const { data: deploySubscription } = trpc.stripe.getDeploySubscription.useQuery(undefined, {
+    staleTime: 30_000,
+  });
+
+  const subscription = billingInfo?.subscription;
+  const hasPaymentMethod = Boolean(workspace.stripeCustomerId);
+  const apiFeeCents = billingInfo
+    ? (currentApiProduct({
+        products: billingInfo.products,
+        subscription,
+        currentProductId: billingInfo.currentProductId,
+      })?.dollar ?? 0) * 100
+    : null;
+
+  return (
+    <Shell>
+      <BillingNotices isAdmin={isAdmin} subscription={subscription} />
+
+      <InvoiceCard
+        workspaceSlug={workspace.slug}
+        isAdmin={isAdmin}
+        hasPaymentMethod={hasPaymentMethod}
+      />
+
+      {billingError ? (
+        <Empty>
+          <Empty.Title>Failed to load API billing information</Empty.Title>
+          <Empty.Description>
+            There was an error loading your API billing information. Please try again later.
+          </Empty.Description>
+        </Empty>
+      ) : billingInfo ? (
+        <PlansCard
+          isAdmin={isAdmin}
+          hasPaymentMethod={hasPaymentMethod}
+          workspaceSlug={workspace.slug}
+          products={billingInfo.products}
+          subscription={subscription}
+          currentProductId={billingInfo.currentProductId}
+          checkoutIntent={checkoutIntent}
+        />
+      ) : (
+        <Skeleton className="h-[140px] w-full rounded-lg" />
+      )}
+
+      {deploySubscription?.plan ? (
+        <CostControl isAdmin={isAdmin} apiFeeCents={apiFeeCents} />
+      ) : null}
+
+      <RelatedPages workspaceSlug={workspace.slug} />
+    </Shell>
+  );
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/page.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { PageLoading } from "@/components/dashboard/page-loading";
 import { useFlag } from "@/lib/flags/provider";
+import { useBillingUIUpgrades } from "@/lib/flags/use-billing-ui-upgrades";
 import { formatNumber } from "@/lib/fmt";
 import { trpc } from "@/lib/trpc/client";
 import { useWorkspace } from "@/providers/workspace-provider";
@@ -9,10 +10,12 @@ import Link from "next/link";
 import { BillingContainer } from "./billing-container";
 import { Client } from "./client";
 import { DeployBillingClient } from "./deploy-billing-client";
+import { DeployBillingClientV2 } from "./deploy-billing-client-v2";
 
 export default function BillingPage() {
   const { workspace, isLoading: isWorkspaceLoading } = useWorkspace();
   const deployBillingEnabled = useFlag("deployBilling");
+  const billingUpgrades = useBillingUIUpgrades();
 
   // Derive isLegacy from workspace data
   const isLegacy = workspace?.subscriptions && Object.keys(workspace.subscriptions).length > 0;
@@ -120,5 +123,8 @@ export default function BillingPage() {
 
   // For non-legacy workspaces, use the Client component with live data. When the
   // deployBilling flag is on, use the separate two-product (API + Compute) page.
+  if (billingUpgrades) {
+    return <DeployBillingClientV2 />;
+  }
   return deployBillingEnabled ? <DeployBillingClient /> : <Client />;
 }

--- a/web/apps/dashboard/hooks/use-consumed-search-param.ts
+++ b/web/apps/dashboard/hooks/use-consumed-search-param.ts
@@ -1,0 +1,26 @@
+"use client";
+
+import type { Route } from "next";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
+
+export function useConsumedSearchParam<T>(
+  name: string,
+  parse: (value: string | null) => T | null,
+  cleanHref: Route,
+): T | null {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const [value] = useState(() => parse(searchParams?.get(name) ?? null));
+  const consumed = useRef(false);
+
+  useEffect(() => {
+    if (value !== null && !consumed.current) {
+      consumed.current = true;
+      router.replace(cleanHref);
+    }
+  }, [value, router, cleanHref]);
+
+  return value;
+}

--- a/web/apps/dashboard/lib/fmt.ts
+++ b/web/apps/dashboard/lib/fmt.ts
@@ -28,6 +28,15 @@ export function formatPrice(price: number) {
 // Formatted in UTC instead of with date-fns, because billing periods are cut at
 // UTC midnight while date-fns formats in the reader's own timezone, which prints
 // the previous day for anyone west of UTC.
+export function formatDate(millis: number): string {
+  return new Date(millis).toLocaleDateString("en-US", {
+    timeZone: "UTC",
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
 export function formatPeriod(startMillis: number, endMillis: number): string {
   const part = (millis: number, options: Intl.DateTimeFormatOptions) =>
     new Date(millis).toLocaleDateString("en-US", { timeZone: "UTC", ...options });

--- a/web/apps/dashboard/lib/support.ts
+++ b/web/apps/dashboard/lib/support.ts
@@ -3,3 +3,5 @@ import type { Route } from "next";
 // typedRoutes only knows app-router paths, so an off-app destination has to be
 // asserted. Done once here so call sites stay cast-free.
 export const SUPPORT_MAILTO = "mailto:support@unkey.com" as Route;
+
+export const BILLING_DOCS = "https://www.unkey.com/docs/platform/workspaces/billing" as Route;

--- a/web/internal/icons/src/icons/phone.tsx
+++ b/web/internal/icons/src/icons/phone.tsx
@@ -1,0 +1,37 @@
+/**
+ * Copyright © Nucleo
+ * Version 1.3, January 3, 2024
+ * Nucleo Icons
+ * https://nucleoapp.com/
+ * - Redistribution of icons is prohibited.
+ * - Icons are restricted for use only within the product they are bundled with.
+ *
+ * For more details:
+ * https://nucleoapp.com/license
+ */
+
+import { type IconProps, sizeMap } from "../props";
+
+export function Phone({ iconSize = "xl-thin", ...props }: IconProps) {
+  const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
+  return (
+    <svg
+      height={pixelSize}
+      width={pixelSize}
+      viewBox="0 0 18 18"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <g fill="currentColor">
+        <path
+          d="M6.08424 11.9158C8.23984 14.0713 11.0787 15.5432 14.2579 15.9883C14.75 16.0572 15.2109 15.726 15.3356 15.245L15.9651 12.8182C16.0879 12.3447 15.8502 11.8518 15.4031 11.6532L12.5339 10.3789C12.1126 10.1918 11.618 10.3169 11.3364 10.6818L10.4574 11.8206C9.57384 11.3015 8.76404 10.6737 8.04524 9.95481C7.32624 9.23601 6.69846 8.42621 6.17946 7.54261L7.31825 6.6636C7.68315 6.3819 7.80824 5.88741 7.62114 5.46611L6.34685 2.597C6.14825 2.1499 5.65534 1.9121 5.18184 2.0349L2.75505 2.6644C2.27415 2.7892 1.94285 3.25001 2.01175 3.74211C2.45685 6.92121 3.92864 9.76021 6.08424 11.9158Z"
+          fill="none"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={strokeWidth}
+        />
+      </g>
+    </svg>
+  );
+}

--- a/web/internal/icons/src/index.ts
+++ b/web/internal/icons/src/index.ts
@@ -134,6 +134,7 @@ export * from "./icons/nut";
 export * from "./icons/page-2";
 export * from "./icons/paperclip-2";
 export * from "./icons/pen-writing-3";
+export * from "./icons/phone";
 export * from "./icons/plus";
 export * from "./icons/progress-bar";
 export * from "./icons/progress-circle";

--- a/web/internal/ui/src/components/alert-banner.tsx
+++ b/web/internal/ui/src/components/alert-banner.tsx
@@ -4,9 +4,10 @@ import { cn } from "../lib/utils";
 
 const alertBannerVariants = cva(
   [
-    "grid w-full grid-cols-[auto_1fr_auto] items-start rounded-lg border px-4 py-3",
-    "has-[>[data-slot=alert-banner-title]]:p-4",
-    "[&>svg]:col-start-1 [&>svg]:row-start-1 [&>svg]:mr-3 [&>svg]:shrink-0 [&>svg]:translate-y-0.5",
+    "grid w-full grid-cols-[auto_1fr_auto] items-center rounded-lg border px-4 py-3",
+    "has-[>[data-slot=alert-banner-title]]:items-start has-[>[data-slot=alert-banner-title]]:p-4",
+    "[&>svg]:col-start-1 [&>svg]:row-start-1 [&>svg]:mr-3 [&>svg]:shrink-0",
+    "has-[>[data-slot=alert-banner-title]]:[&>svg]:translate-y-0.5",
     "has-[>[data-slot=alert-banner-title]]:has-[>[data-slot=alert-banner-description]]:*:data-[slot=alert-banner-actions]:row-end-3",
   ],
   {


### PR DESCRIPTION
- Rebuilt the billing page to try and better display plans, invoices and cost control in one UI.
- Works under the new `billing-ui-upgrades` flag

## Screenshots

| Billing |
| --- |
| **No plan** |
| ![billing--no-plan](https://github.com/user-attachments/assets/d89689c6-aa20-4fee-92fc-6e6f85b154ba) |
| **Pro, healthy** |
| ![billing--pro-healthy](https://github.com/user-attachments/assets/38ebbf81-d57f-4d9c-bf97-380cf41b7860) |
| **Budget, alerts only** |
| ![billing--budget-no-stop](https://github.com/user-attachments/assets/f9a5fa65-0fc0-4b25-a72c-391770660506) |
| **Budget, stop at 100%** |
| ![billing--budget-stop](https://github.com/user-attachments/assets/89035c76-51e6-43a0-8f5a-0ad0d3c78884) |
| **Suspended** |
| ![billing--suspended](https://github.com/user-attachments/assets/7b0a0406-8b44-4fe8-979a-8ac0be0b4934) |


