### PR TITLE
fix: harden workspace changeName mutation

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/general/update-workspace-name.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/general/update-workspace-name.tsx
@@ -4,7 +4,6 @@ import { trpc } from "@/lib/trpc/client";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Button, FormInput, InfoTooltip, SettingCard, toast } from "@unkey/ui";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
@@ -12,8 +11,6 @@ export function UpdateWorkspaceName() {
   const workspace = useWorkspaceNavigation();
   const router = useRouter();
   const utils = trpc.useUtils();
-
-  const [name, setName] = useState(workspace?.name);
 
   // Server-side `requireWorkspaceAdmin` enforces this on the changeName
   // mutation; we mirror it on the client purely for UX so non-admin members
@@ -39,48 +36,78 @@ export function UpdateWorkspaceName() {
     register,
     handleSubmit,
     formState: { errors, isValid, isSubmitting },
-    watch,
   } = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
     mode: "onChange",
     defaultValues: {
       workspaceId: workspace?.id,
-      workspaceName: name,
+      workspaceName: workspace?.name,
     },
   });
+
+  // Force immediate refetch of all workspace-related queries
+  const refetchWorkspaceName = async () => {
+    await Promise.all([
+      utils.user.getCurrentUser.refetch(),
+      utils.workspace.getCurrent.refetch(),
+      utils.user.listMemberships.refetch(),
+    ]);
+    router.refresh();
+  };
 
   const updateName = trpc.workspace.updateName.useMutation({
-    async onSuccess() {
-      toast.success("Workspace name updated");
-      // Force immediate refetch of all workspace-related queries
-      await Promise.all([
-        utils.user.getCurrentUser.refetch(),
-        utils.workspace.getCurrent.refetch(),
-        utils.user.listMemberships.refetch(),
-      ]);
-      setName(watch("workspaceName"));
-      router.refresh();
+    async onSuccess(data) {
+      // updated: false means the server verified both sides already agree and
+      // wrote nothing. The refetch still runs: this client's cache may be
+      // exactly what is stale.
+      if (data.updated) {
+        toast.success("Workspace name updated");
+      } else {
+        toast.success("Workspace name is already up to date");
+      }
+      await refetchWorkspaceName();
     },
-    onError(err) {
-      toast.error("Failed to update workspace name", {
-        description: err.message,
-      });
+    async onError(err) {
+      const code = err.data?.code;
+      // PRECONDITION_FAILED means the name is saved but the auth provider has
+      // not confirmed it, so the toast must not claim the update failed.
+      if (code === "PRECONDITION_FAILED") {
+        toast.warning("Workspace name not fully synced", {
+          description: err.message,
+        });
+      } else {
+        toast.error("Failed to update workspace name", {
+          description: err.message,
+        });
+      }
+      // Only these outcomes can leave the cached name stale; pure rejections
+      // (validation, permissions, rate limits) change nothing.
+      if (
+        code === "PRECONDITION_FAILED" ||
+        code === "INTERNAL_SERVER_ERROR" ||
+        code === "CONFLICT"
+      ) {
+        await refetchWorkspaceName();
+      }
     },
   });
 
+  // Same-name submits are allowed on purpose: the server treats them as a
+  // repair attempt that re-syncs the auth-provider org name.
   const onSubmit = async (values: z.infer<typeof formSchema>) => {
-    if (workspace?.name === values.workspaceName || !values.workspaceName) {
-      return toast.error("Please provide a different name before saving.");
-    }
-
     if (!workspace?.id) {
       return toast.error("Workspace not found");
     }
 
-    await updateName.mutateAsync({
-      workspaceId: workspace.id,
-      name: values.workspaceName,
-    });
+    try {
+      await updateName.mutateAsync({
+        workspaceId: workspace.id,
+        name: values.workspaceName,
+      });
+    } catch {
+      // onError already surfaced the failure; catching keeps handleSubmit
+      // from rethrowing it as an unhandled promise rejection.
+    }
   };
 
   return (
@@ -115,13 +142,7 @@ export function UpdateWorkspaceName() {
                 type="submit"
                 variant="primary"
                 size="lg"
-                disabled={
-                  !isAdmin ||
-                  updateName.isLoading ||
-                  isSubmitting ||
-                  !isValid ||
-                  watch("workspaceName") === name
-                }
+                disabled={!isAdmin || updateName.isLoading || isSubmitting || !isValid}
                 loading={updateName.isLoading || isSubmitting}
               >
                 Save

--- a/web/apps/dashboard/lib/trpc/routers/utils/errors.test.ts
+++ b/web/apps/dashboard/lib/trpc/routers/utils/errors.test.ts
@@ -1,0 +1,135 @@
+import { TRPCError } from "@trpc/server";
+import { DrizzleQueryError } from "@unkey/db";
+import { describe, expect, it } from "vitest";
+import { errorLogDetail, wrapUnexpectedError } from "./errors";
+import { catchTrpcError, mysqlServerError } from "./test-helpers";
+
+describe("wrapUnexpectedError", () => {
+  it("re-throws an existing TRPCError unchanged so meaningful codes and messages reach the client", () => {
+    const original = new TRPCError({ code: "NOT_FOUND", message: "Checkout session not found" });
+
+    const thrown = catchTrpcError(() => {
+      wrapUnexpectedError(original, "generic message");
+    });
+
+    expect(thrown).toBe(original);
+  });
+
+  it("wraps an unexpected error in INTERNAL_SERVER_ERROR carrying only the generic message, so internal details never reach the client", () => {
+    const internal = new Error("connect ECONNREFUSED 127.0.0.1:3306");
+
+    const thrown = catchTrpcError(() => {
+      wrapUnexpectedError(internal, "Please try again or contact support@unkey.com");
+    });
+
+    expect(thrown.code).toBe("INTERNAL_SERVER_ERROR");
+    expect(thrown.message).toBe("Please try again or contact support@unkey.com");
+    expect(thrown.message).not.toContain("ECONNREFUSED");
+  });
+
+  it("attaches the original error as `cause` so callers can log its safe detail", () => {
+    const internal = new Error("connect ECONNREFUSED 127.0.0.1:3306");
+
+    const thrown = catchTrpcError(() => {
+      wrapUnexpectedError(internal, "Unable to update workspace");
+    });
+
+    expect(thrown.cause).toBe(internal);
+  });
+});
+
+describe("errorLogDetail", () => {
+  it("returns the message of an ordinary error", () => {
+    expect(errorLogDetail(new Error("boom"))).toBe("boom");
+  });
+
+  it("stringifies a non-Error value", () => {
+    expect(errorLogDetail("string failure")).toBe("string failure");
+  });
+
+  it("extracts the code from a thrown plain object like the auth client's AuthErrorResponse instead of '[object Object]'", () => {
+    const authError = {
+      success: false,
+      code: "ORG_UPDATE_FAILED",
+      message: "Could not update organization 'Acme Corp'",
+    };
+
+    const detail = errorLogDetail(authError);
+
+    expect(detail).toBe("error code: ORG_UPDATE_FAILED");
+    expect(detail).not.toContain("Acme Corp");
+  });
+
+  it("reduces a mysql2 server error to its symbolic code, keeping quoted bound values out of the logs", () => {
+    const driverError = mysqlServerError(
+      "Duplicate entry 'Acme Corp' for key 'name'",
+      "ER_DUP_ENTRY",
+    );
+
+    const detail = errorLogDetail(driverError);
+
+    expect(detail).toBe("database error: ER_DUP_ENTRY");
+    expect(detail).not.toContain("Acme Corp");
+  });
+
+  it("unwraps a DrizzleQueryError, whose own message embeds the failed statement and its params", () => {
+    const driverError = mysqlServerError(
+      "Duplicate entry 'Acme Corp' for key 'name'",
+      "ER_DUP_ENTRY",
+    );
+    const wrapped = new DrizzleQueryError(
+      "update `workspaces` set `name` = ? where `id` = ?",
+      ["Acme Corp", "ws_123"],
+      driverError,
+    );
+
+    const detail = errorLogDetail(wrapped);
+
+    expect(detail).toBe("database error: ER_DUP_ENTRY");
+    expect(detail).not.toContain("Acme Corp");
+    expect(detail).not.toContain("ws_123");
+    expect(detail).not.toContain("workspaces");
+  });
+
+  it("describes a DrizzleQueryError without a cause generically rather than using its statement-bearing message", () => {
+    const wrapped = new DrizzleQueryError("update `workspaces` set `name` = ? where `id` = ?", [
+      "Acme Corp",
+      "ws_123",
+    ]);
+
+    const detail = errorLogDetail(wrapped);
+
+    expect(detail).toBe("database query failed");
+  });
+
+  it("describes a cyclic DrizzleQueryError cause chain generically instead of recursing until the stack overflows", () => {
+    const wrapped = new DrizzleQueryError("update `workspaces` set `name` = ? where `id` = ?", [
+      "Acme Corp",
+    ]);
+    wrapped.cause = wrapped;
+
+    const detail = errorLogDetail(wrapped);
+
+    expect(detail).toBe("database query failed");
+  });
+
+  it("still extracts only the symbolic code after @trpc/server coerces a plain-object auth error attached as `cause` into a real Error", () => {
+    // TRPCError copies every key of a non-Error cause (including the raw
+    // message) onto a synthetic Error; the sanitizer must catch that coerced
+    // copy, not just the bare object.
+    const wrapped = new TRPCError({
+      code: "INTERNAL_SERVER_ERROR",
+      message: "We are unable to update the workspace name",
+      cause: {
+        success: false,
+        code: "ORG_UPDATE_FAILED",
+        message: "Could not update organization 'Acme Corp'",
+      },
+    });
+
+    const detail = errorLogDetail(wrapped.cause);
+
+    expect(detail).toBe("error code: ORG_UPDATE_FAILED");
+    expect(detail).not.toContain("Acme Corp");
+  });
+});

--- a/web/apps/dashboard/lib/trpc/routers/utils/errors.test.ts
+++ b/web/apps/dashboard/lib/trpc/routers/utils/errors.test.ts
@@ -60,6 +60,18 @@ describe("errorLogDetail", () => {
     expect(detail).not.toContain("Acme Corp");
   });
 
+  it("describes a codeless auth failure with a fixed string, keeping its message out of the logs", () => {
+    const authError = {
+      success: false,
+      message: "Could not update organization 'Acme Corp'",
+    };
+
+    const detail = errorLogDetail(authError);
+
+    expect(detail).toBe("auth error: no code");
+    expect(detail).not.toContain("Acme Corp");
+  });
+
   it("reduces a mysql2 server error to its symbolic code, keeping quoted bound values out of the logs", () => {
     const driverError = mysqlServerError(
       "Duplicate entry 'Acme Corp' for key 'name'",

--- a/web/apps/dashboard/lib/trpc/routers/utils/errors.ts
+++ b/web/apps/dashboard/lib/trpc/routers/utils/errors.ts
@@ -35,6 +35,7 @@ export function errorLogDetail(err: unknown): string {
     if (code !== undefined) {
       return `error code: ${code}`;
     }
+    return "auth error: no code";
   }
   if (!(err instanceof Error)) {
     const code = typeof err === "object" && err !== null ? stringCode(err) : undefined;

--- a/web/apps/dashboard/lib/trpc/routers/utils/errors.ts
+++ b/web/apps/dashboard/lib/trpc/routers/utils/errors.ts
@@ -1,0 +1,70 @@
+import { unwrapDrizzleQueryError } from "@/lib/utils/db-errors";
+import { TRPCError } from "@trpc/server";
+import { DrizzleQueryError } from "@unkey/db";
+
+/**
+ * Re-throws a TRPCError unchanged so meaningful codes reach the client;
+ * wraps anything else in a generic INTERNAL_SERVER_ERROR with the original
+ * attached as `cause`. The explicit `never` return lets TypeScript treat a
+ * call as terminal.
+ */
+export function wrapUnexpectedError(err: unknown, message: string): never {
+  if (err instanceof TRPCError) {
+    throw err;
+  }
+  throw new TRPCError({
+    code: "INTERNAL_SERVER_ERROR",
+    message,
+    cause: err,
+  });
+}
+
+/**
+ * Returns a description of an error that is safe to log. Database and
+ * provider errors never contribute their message, which can embed the failed
+ * statement, bound values, or user input; only symbolic codes are logged.
+ */
+export function errorLogDetail(err: unknown): string {
+  // Auth-client failures are plain `{success, code, message}` objects whose
+  // message may quote user input. Checked by shape before any `instanceof`
+  // branch: TRPCError coerces a non-Error `cause` into a real Error with
+  // every key (including the raw message) copied over, and that copy must be
+  // caught too.
+  if (typeof err === "object" && err !== null && "success" in err && err.success === false) {
+    const code = stringCode(err);
+    if (code !== undefined) {
+      return `error code: ${code}`;
+    }
+  }
+  if (!(err instanceof Error)) {
+    const code = typeof err === "object" && err !== null ? stringCode(err) : undefined;
+    if (code !== undefined) {
+      return `error code: ${code}`;
+    }
+    return String(err);
+  }
+  if (err instanceof DrizzleQueryError) {
+    const driverError = unwrapDrizzleQueryError(err);
+    // The instanceof re-check stops infinite recursion on a cyclic cause
+    // chain.
+    if (driverError === undefined || driverError instanceof DrizzleQueryError) {
+      return "database query failed";
+    }
+    return errorLogDetail(driverError);
+  }
+  if ("sqlState" in err || "sqlMessage" in err) {
+    return `database error: ${stringCode(err) ?? err.name}`;
+  }
+  return err.message;
+}
+
+/**
+ * Returns the error's `code` property when it is a string, the shape shared
+ * by auth-client failures, Node system errors, and mysql2 server errors.
+ */
+function stringCode(err: object): string | undefined {
+  if ("code" in err && typeof err.code === "string") {
+    return err.code;
+  }
+  return undefined;
+}

--- a/web/apps/dashboard/lib/trpc/routers/utils/stripe.test.ts
+++ b/web/apps/dashboard/lib/trpc/routers/utils/stripe.test.ts
@@ -1,4 +1,3 @@
-import { TRPCError } from "@trpc/server";
 import Stripe from "stripe";
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -10,6 +9,7 @@ import {
   throwMaskedStripeError,
   throwRedactedStripeError,
 } from "./stripe";
+import { catchTrpcError, rejection } from "./test-helpers";
 
 const WORKSPACE_ID = "ws_victim";
 
@@ -41,25 +41,6 @@ function stubStripe(retrieved: Stripe.Checkout.Session | Error) {
   };
 }
 
-// Runs fn and returns what it throws. Fails the test if it does not throw.
-function caught(fn: () => unknown): unknown {
-  try {
-    fn();
-  } catch (error) {
-    return error;
-  }
-  throw new Error("expected the call to throw");
-}
-
-// Asserts the value is a TRPCError and narrows it for further assertions.
-function asTRPCError(value: unknown): TRPCError {
-  expect(value).toBeInstanceOf(TRPCError);
-  if (!(value instanceof TRPCError)) {
-    throw new Error("unreachable: asserted above");
-  }
-  return value;
-}
-
 // Asserts the value is an Error and narrows it, so `cause` assertions need no
 // cast.
 function asError(value: unknown): Error {
@@ -68,10 +49,6 @@ function asError(value: unknown): Error {
     throw new Error("unreachable: asserted above");
   }
   return value;
-}
-
-async function rejection(promise: Promise<unknown>): Promise<TRPCError> {
-  return asTRPCError(await promise.catch((err: unknown) => err));
 }
 
 async function expectNotFound(promise: Promise<unknown>, message: string) {
@@ -364,9 +341,7 @@ describe("throwMaskedStripeError", () => {
       message: "No such setupintent: 'seti_x'",
     });
 
-    const thrown = asTRPCError(
-      caught(() => throwMaskedStripeError(error, "Setup intent not found")),
-    );
+    const thrown = catchTrpcError(() => throwMaskedStripeError(error, "Setup intent not found"));
     expect(thrown.code).toBe("NOT_FOUND");
     expect(thrown.message).toBe("Setup intent not found");
   });
@@ -379,9 +354,7 @@ describe("throwMaskedStripeError", () => {
       message: "No such setupintent: 'seti_x'",
     });
 
-    const thrown = asTRPCError(
-      caught(() => throwMaskedStripeError(error, "Setup intent not found")),
-    );
+    const thrown = catchTrpcError(() => throwMaskedStripeError(error, "Setup intent not found"));
     expect(thrown.cause).toBe(error);
   });
 
@@ -391,9 +364,7 @@ describe("throwMaskedStripeError", () => {
       message: "Invalid API key provided: sk_live_************************abcd",
     });
 
-    const thrown = asTRPCError(
-      caught(() => throwMaskedStripeError(error, "Setup intent not found")),
-    );
+    const thrown = catchTrpcError(() => throwMaskedStripeError(error, "Setup intent not found"));
     expect(thrown.code).toBe("UNAUTHORIZED");
     expect(thrown.message).not.toContain("sk_live_");
     expect(thrown.message).not.toContain("Invalid API key");
@@ -413,9 +384,7 @@ describe("throwMaskedStripeError", () => {
       message: "This API key does not have access to this resource",
     });
 
-    const thrown = asTRPCError(
-      caught(() => throwMaskedStripeError(error, "Setup intent not found")),
-    );
+    const thrown = catchTrpcError(() => throwMaskedStripeError(error, "Setup intent not found"));
     expect(thrown.code).toBe("FORBIDDEN");
     expect(thrown.message).not.toBe("Setup intent not found");
   });
@@ -430,7 +399,7 @@ describe("throwRedactedStripeError", () => {
       message: "No such PaymentMethod: 'pm_x'",
     });
 
-    const thrown = asTRPCError(caught(() => throwRedactedStripeError(error, "Update failed")));
+    const thrown = catchTrpcError(() => throwRedactedStripeError(error, "Update failed"));
     expect(thrown.code).toBe("BAD_REQUEST");
     expect(thrown.message).toBe("Update failed");
     expect(thrown.message).not.toContain("pm_x");
@@ -443,7 +412,7 @@ describe("throwRedactedStripeError", () => {
       message: "Too many requests",
     });
 
-    expect(asTRPCError(caught(() => throwRedactedStripeError(error, "Update failed"))).code).toBe(
+    expect(catchTrpcError(() => throwRedactedStripeError(error, "Update failed")).code).toBe(
       "TOO_MANY_REQUESTS",
     );
   });

--- a/web/apps/dashboard/lib/trpc/routers/utils/test-helpers.ts
+++ b/web/apps/dashboard/lib/trpc/routers/utils/test-helpers.ts
@@ -1,0 +1,58 @@
+import { TRPCError } from "@trpc/server";
+
+/**
+ * Runs fn and returns what it throws. Fails the test if it does not throw.
+ */
+function caught(fn: () => unknown): unknown {
+  try {
+    fn();
+  } catch (error) {
+    return error;
+  }
+  throw new Error("expected the call to throw");
+}
+
+/**
+ * Asserts the value is a TRPCError and narrows it for further assertions.
+ */
+function asTRPCError(value: unknown): TRPCError {
+  if (!(value instanceof TRPCError)) {
+    throw new Error(`Expected a TRPCError, got: ${String(value)}`);
+  }
+  return value;
+}
+
+/**
+ * Runs fn, which is expected to throw, and returns the thrown TRPCError.
+ * Fails the test if fn does not throw or throws something else.
+ */
+export function catchTrpcError(fn: () => unknown): TRPCError {
+  return asTRPCError(caught(fn));
+}
+
+/**
+ * Awaits the promise's rejection and narrows it to a TRPCError.
+ */
+export async function rejection(promise: Promise<unknown>): Promise<TRPCError> {
+  return asTRPCError(await promise.catch((err: unknown) => err));
+}
+
+/**
+ * Builds an error shaped like a real mysql2 server error: `message` IS the
+ * server's text, so bound values the server quotes back appear in it. The
+ * errno/sqlState defaults are ER_DUP_ENTRY's; pass the matching pair for a
+ * different server error.
+ */
+export function mysqlServerError(
+  serverText: string,
+  code: string,
+  errno = 1062,
+  sqlState = "23000",
+) {
+  return Object.assign(new Error(serverText), {
+    code,
+    errno,
+    sqlState,
+    sqlMessage: serverText,
+  });
+}

--- a/web/apps/dashboard/lib/trpc/routers/workspace/changeName.ts
+++ b/web/apps/dashboard/lib/trpc/routers/workspace/changeName.ts
@@ -4,7 +4,7 @@ import { and, db, eq, isNull, schema } from "@/lib/db";
 import { logOperation } from "@/lib/logging/structured-logger";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
-import { requireWorkspaceAdmin, workspaceProcedure } from "../../trpc";
+import { ratelimit, requireWorkspaceAdmin, withRatelimit, workspaceProcedure } from "../../trpc";
 import { errorLogDetail, wrapUnexpectedError } from "../utils/errors";
 import {
   providerNameMatches,
@@ -19,6 +19,7 @@ const conflictErrorMessage =
   "The workspace name changed while your request was in flight. Refresh to see the current name and try again.";
 
 export const changeWorkspaceName = workspaceProcedure
+  .use(withRatelimit(ratelimit.update))
   .use(requireWorkspaceAdmin)
   .input(
     z.object({
@@ -109,11 +110,28 @@ export const changeWorkspaceName = workspaceProcedure
             .where(
               and(
                 eq(schema.workspaces.id, input.workspaceId),
+                isNull(schema.workspaces.deletedAtM),
                 workspaceNameByteEquals(previousName),
               ),
             );
 
           if (renamed[0].affectedRows === 0) {
+            // Zero rows means either a concurrent rename or a concurrent
+            // soft delete; a re-read tells them apart so a deleted workspace
+            // is not misreported as a name conflict.
+            const live = await tx.query.workspaces.findFirst({
+              columns: { id: true },
+              where: and(
+                eq(schema.workspaces.id, input.workspaceId),
+                isNull(schema.workspaces.deletedAtM),
+              ),
+            });
+            if (live === undefined) {
+              throw new TRPCError({
+                code: "NOT_FOUND",
+                message: "Workspace not found",
+              });
+            }
             throw new TRPCError({
               code: "CONFLICT",
               message: conflictErrorMessage,

--- a/web/apps/dashboard/lib/trpc/routers/workspace/changeName.ts
+++ b/web/apps/dashboard/lib/trpc/routers/workspace/changeName.ts
@@ -1,48 +1,160 @@
 import { insertAuditLogs } from "@/lib/audit";
 import { auth as authClient } from "@/lib/auth/server";
-import { db, eq, schema } from "@/lib/db";
+import { and, db, eq, isNull, schema } from "@/lib/db";
+import { logOperation } from "@/lib/logging/structured-logger";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { requireWorkspaceAdmin, workspaceProcedure } from "../../trpc";
+import { errorLogDetail, wrapUnexpectedError } from "../utils/errors";
+import {
+  providerNameMatches,
+  reconcileFailedOrgRename,
+  workspaceNameByteEquals,
+} from "./reconcile-org-rename";
+
+const genericErrorMessage =
+  "We are unable to update the workspace name. Please try again or contact support@unkey.com";
+
+const conflictErrorMessage =
+  "The workspace name changed while your request was in flight. Refresh to see the current name and try again.";
 
 export const changeWorkspaceName = workspaceProcedure
   .use(requireWorkspaceAdmin)
   .input(
     z.object({
+      // Trimmed before the length checks so whitespace cannot pad a short
+      // name or disguise a same-name repair submit.
       name: z
         .string()
+        .trim()
         .min(3, "Workspace names must contain at least 3 characters")
         .max(50, "Workspace names must contain less than 50 characters"),
       workspaceId: z.string(),
     }),
   )
-  .mutation(async ({ ctx, input }) => {
+  .mutation(async ({ ctx, input }): Promise<{ updated: boolean }> => {
     if (input.workspaceId !== ctx.workspace.id) {
       throw new TRPCError({
         code: "BAD_REQUEST",
         message: "Invalid workspace ID",
       });
     }
-    await db
-      .transaction(async (tx) => {
-        await tx
-          .update(schema.workspaces)
-          .set({
-            name: input.name,
-          })
-          .where(eq(schema.workspaces.id, input.workspaceId))
-          .catch((_err) => {
+
+    const previousName = ctx.workspace.name;
+
+    // A same-name submit is a repair attempt: nothing to write on the DB
+    // side, but the auth-provider org may still be out of sync from an
+    // earlier partial failure.
+    const isRepairAttempt = input.name === previousName;
+
+    // The repair audit's "after an earlier partial rename" wording is only
+    // truthful when the mismatch was actually observed; a failed read proves
+    // nothing.
+    let orgConfirmedOutOfSync = false;
+
+    if (isRepairAttempt) {
+      // No transaction guards the repair push, so re-read the live row: a
+      // stale context must not repair a workspace that was concurrently
+      // renamed or soft-deleted. Runs before the no-op check so "already up
+      // to date" is never claimed from a stale view.
+      const workspace = await db.query.workspaces.findFirst({
+        columns: { name: true },
+        where: and(
+          eq(schema.workspaces.id, input.workspaceId),
+          isNull(schema.workspaces.deletedAtM),
+        ),
+      });
+      if (workspace === undefined) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Workspace not found",
+        });
+      }
+      if (workspace.name !== input.name) {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message: conflictErrorMessage,
+        });
+      }
+
+      // When the org already agrees there is nothing to repair: an idle Save
+      // click becomes a true no-op. An unreadable org falls through to the
+      // push, which is idempotent.
+      try {
+        const org = await authClient.getOrg(ctx.tenant.id);
+        if (providerNameMatches(org.name, input.name)) {
+          return { updated: false };
+        }
+        orgConfirmedOutOfSync = true;
+      } catch (readErr) {
+        logOperation("warn", "Unable to read the auth-provider org before a repair push", {
+          workspace_id: ctx.workspace.id,
+          error_detail: errorLogDetail(readErr),
+        });
+      }
+    } else {
+      // No external call inside the transaction: the row lock would span the
+      // provider's latency, and Vitess kills transactions that outlive its
+      // timeout.
+      await db
+        .transaction(async (tx) => {
+          // Byte-wise guard: a concurrent rename must surface as CONFLICT,
+          // and previousName must be the row's real prior value in case the
+          // reconcile below has to revert to it.
+          const renamed = await tx
+            .update(schema.workspaces)
+            .set({
+              name: input.name,
+            })
+            .where(
+              and(
+                eq(schema.workspaces.id, input.workspaceId),
+                workspaceNameByteEquals(previousName),
+              ),
+            );
+
+          if (renamed[0].affectedRows === 0) {
             throw new TRPCError({
-              code: "INTERNAL_SERVER_ERROR",
-              message:
-                "We are unable to update the workspace name. Please try again or contact support@unkey.com",
+              code: "CONFLICT",
+              message: conflictErrorMessage,
             });
+          }
+
+          await insertAuditLogs(tx, {
+            workspaceId: ctx.workspace.id,
+            actor: { type: "user", id: ctx.user.id },
+            event: "workspace.update",
+            description: `Changed name from ${previousName} to ${input.name}`,
+            resources: [
+              {
+                type: "workspace",
+                id: ctx.workspace.id,
+                name: input.name,
+              },
+            ],
+            context: {
+              location: ctx.audit.location,
+              userAgent: ctx.audit.userAgent,
+            },
           });
-        await insertAuditLogs(tx, {
+        })
+        .catch((err) => {
+          wrapUnexpectedError(err, genericErrorMessage);
+        });
+    }
+
+    // A repair changes only the provider, so this audit entry is its sole
+    // record. Best-effort: the org rename has already applied, and a failed
+    // audit write must not fail the mutation it records.
+    const auditRepairSync = async () => {
+      try {
+        await insertAuditLogs(db, {
           workspaceId: ctx.workspace.id,
           actor: { type: "user", id: ctx.user.id },
           event: "workspace.update",
-          description: `Changed name from ${ctx.workspace.name} to ${input.name}`,
+          description: orgConfirmedOutOfSync
+            ? `Synchronized the organization name to ${input.name} after an earlier partial rename`
+            : `Re-applied the organization name ${input.name} at the auth provider; its previous state could not be read`,
           resources: [
             {
               type: "workspace",
@@ -55,17 +167,86 @@ export const changeWorkspaceName = workspaceProcedure
             userAgent: ctx.audit.userAgent,
           },
         });
+      } catch (auditErr) {
+        logOperation("error", "Failed to write the audit entry for an organization-name repair", {
+          workspace_id: ctx.workspace.id,
+          error_detail: errorLogDetail(auditErr),
+        });
+      }
+    };
 
-        await authClient.updateOrg({
-          id: ctx.tenant.id,
-          name: input.name,
-        });
-      })
-      .catch((_err) => {
-        throw new TRPCError({
-          code: "INTERNAL_SERVER_ERROR",
-          message:
-            "We are unable to update the workspace name. Please try again or contact support@unkey.com",
-        });
+    // The org rename runs only after the DB rename is durable, so a failure
+    // leaves the DB in a known state. Two accepted, self-repairing races
+    // remain: concurrent renames can reach the provider out of commit order,
+    // and a crash between commit and push leaves an unlogged divergence
+    // (closing that needs a durable outbox); the same-name repair path
+    // re-converges both on the next submit.
+    try {
+      await authClient.updateOrg({
+        id: ctx.tenant.id,
+        name: input.name,
       });
+    } catch (err) {
+      // The expected-error path logs only the client-facing message, so the
+      // provider's failure reason is recorded here.
+      logOperation("warn", "Auth-provider org rename failed; reconciling the workspace name", {
+        workspace_id: ctx.workspace.id,
+        error_detail: errorLogDetail(err),
+      });
+      const outcome = await reconcileFailedOrgRename({
+        orgId: ctx.tenant.id,
+        workspaceId: ctx.workspace.id,
+        requestedName: input.name,
+        previousName,
+        actorId: ctx.user.id,
+        audit: ctx.audit,
+      });
+      switch (outcome) {
+        case "rename-in-effect": {
+          // The provider holds the name despite the errored push, so the
+          // sync applied and this mutation is a success.
+          if (isRepairAttempt) {
+            await auditRepairSync();
+          }
+          return { updated: true };
+        }
+        case "reverted": {
+          // Always throws; the `throw` keyword satisfies fallthrough lint.
+          throw wrapUnexpectedError(err, genericErrorMessage);
+        }
+        case "superseded": {
+          // A concurrent rename overwrote this one before the revert ran, so
+          // the race surfaces as a conflict, not as "nothing changed".
+          throw new TRPCError({
+            code: "CONFLICT",
+            message:
+              "The workspace was renamed again while this request was in flight. Refresh to see the current name.",
+            cause: err,
+          });
+        }
+        case "left-at-requested-name": {
+          // The anticipated, retryable split state: DB holds the name, only
+          // the provider sync is unconfirmed. PRECONDITION_FAILED is
+          // classified as expected (warn log, no Sentry). A repair attempt
+          // gets its own message since it wrote nothing new.
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message: isRepairAttempt
+              ? "The workspace name is already saved, but we could not confirm it with our authentication provider. Please retry, or contact support@unkey.com"
+              : "The workspace name was saved, but we could not confirm the update with our authentication provider. Please retry the rename to complete it, or contact support@unkey.com",
+            cause: err,
+          });
+        }
+        default: {
+          // Forces a compile error when a ReconcileOutcome variant is added
+          // but not handled above.
+          return outcome satisfies never;
+        }
+      }
+    }
+
+    if (isRepairAttempt) {
+      await auditRepairSync();
+    }
+    return { updated: true };
   });

--- a/web/apps/dashboard/lib/trpc/routers/workspace/reconcile-org-rename.test.ts
+++ b/web/apps/dashboard/lib/trpc/routers/workspace/reconcile-org-rename.test.ts
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Chainable db mock (as in lib/stripe/linkDeploySubscription.test.ts):
+// transaction(cb) runs cb with a tx whose update().set().where() resolves to
+// the driver's `[{ affectedRows }]` result.
+const h = vi.hoisted(() => {
+  const where = vi.fn();
+  const set = vi.fn().mockReturnValue({ where });
+  const update = vi.fn().mockReturnValue({ set });
+  const transaction = vi.fn(async (cb: (tx: unknown) => unknown) => cb({ update }));
+  const insertAuditLogs = vi.fn();
+  const getOrg = vi.fn();
+  const logOperation = vi.fn();
+  return { where, set, update, transaction, insertAuditLogs, getOrg, logOperation };
+});
+
+vi.mock("@/lib/db", () => ({
+  db: { transaction: h.transaction },
+  and: vi.fn(),
+  eq: vi.fn(),
+  sql: vi.fn(),
+  schema: { workspaces: { id: {}, name: {} } },
+}));
+vi.mock("@/lib/audit", () => ({ insertAuditLogs: h.insertAuditLogs }));
+vi.mock("@/lib/auth/server", () => ({ auth: { getOrg: h.getOrg } }));
+vi.mock("@/lib/logging/structured-logger", () => ({ logOperation: h.logOperation }));
+
+import { mysqlServerError } from "../utils/test-helpers";
+import { reconcileFailedOrgRename } from "./reconcile-org-rename";
+
+const BASE = {
+  orgId: "org_1",
+  workspaceId: "ws_1",
+  requestedName: "NewName",
+  previousName: "OldName",
+  actorId: "user_1",
+  audit: { location: "127.0.0.1", userAgent: "vitest" },
+};
+
+function run(overrides: Partial<typeof BASE> = {}) {
+  return reconcileFailedOrgRename({ ...BASE, ...overrides });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Default: the revert affects the single row it targeted.
+  h.where.mockResolvedValue([{ affectedRows: 1 }]);
+});
+
+describe("reconcileFailedOrgRename", () => {
+  it("leaves the DB at the requested name and does not touch it when the org is unreadable, because reverting could create drift if the rename had in fact applied", async () => {
+    // Auth clients reject with a plain {success, code, message} object whose
+    // message may quote the org name.
+    h.getOrg.mockRejectedValue({
+      success: false,
+      code: "ORG_READ_FAILED",
+      message: "Could not read organization 'Acme Corp'",
+    });
+
+    const outcome = await run();
+
+    expect(outcome).toBe("left-at-requested-name");
+    expect(h.transaction).not.toHaveBeenCalled();
+    expect(h.insertAuditLogs).not.toHaveBeenCalled();
+  });
+
+  it("logs only the auth error's symbolic code when the org read fails, keeping the quoted org name out of the logs", async () => {
+    h.getOrg.mockRejectedValue({
+      success: false,
+      code: "ORG_READ_FAILED",
+      message: "Could not read organization 'Acme Corp'",
+    });
+
+    await run();
+
+    expect(h.logOperation).toHaveBeenCalledTimes(1);
+    const [level, , attributes] = h.logOperation.mock.calls[0];
+    expect(level).toBe("error");
+    expect(attributes).toMatchObject({
+      workspace_id: "ws_1",
+      error_detail: "error code: ORG_READ_FAILED",
+    });
+    expect(JSON.stringify(attributes)).not.toContain("Acme Corp");
+  });
+
+  it("reports rename-in-effect when the org already holds the requested name, so the caller reports success for a rename the provider applied but whose response was lost", async () => {
+    h.getOrg.mockResolvedValue({ id: "org_1", name: "NewName" });
+
+    const outcome = await run();
+
+    expect(outcome).toBe("rename-in-effect");
+    expect(h.transaction).not.toHaveBeenCalled();
+    expect(h.insertAuditLogs).not.toHaveBeenCalled();
+  });
+
+  it("treats a provider-normalized variant of the requested name as rename-in-effect instead of falsely reverting a rename the provider applied", async () => {
+    // NFD (e + combining acute) plus a trailing space vs the NFC form we
+    // sent; escapes keep the two genuinely different in source.
+    h.getOrg.mockResolvedValue({ id: "org_1", name: "Cafe\u0301 " });
+
+    const outcome = await run({ requestedName: "Caf\u00e9" });
+
+    expect(outcome).toBe("rename-in-effect");
+    expect(h.transaction).not.toHaveBeenCalled();
+  });
+
+  it("reports left-at-requested-name for a same-name repair without writing a nonsensical 'reverted X to X' audit entry", async () => {
+    // Org holds some other name, so the rename-in-effect check does not fire;
+    // the same-name guard is what must return here.
+    h.getOrg.mockResolvedValue({ id: "org_1", name: "OldName" });
+
+    const outcome = await run({ requestedName: "SameName", previousName: "SameName" });
+
+    expect(outcome).toBe("left-at-requested-name");
+    expect(h.transaction).not.toHaveBeenCalled();
+    expect(h.insertAuditLogs).not.toHaveBeenCalled();
+  });
+
+  it("checks the org's current name before the same-name guard, so a same-name repair whose org already holds the name still reports success", async () => {
+    // Ordering is load-bearing: a refactor that ran the same-name guard first
+    // would return left-at-requested-name here and mis-report a success.
+    h.getOrg.mockResolvedValue({ id: "org_1", name: "SameName" });
+
+    const outcome = await run({ requestedName: "SameName", previousName: "SameName" });
+
+    expect(outcome).toBe("rename-in-effect");
+  });
+
+  it("reverts the DB to the previous name and audits it when the org never took the rename", async () => {
+    h.getOrg.mockResolvedValue({ id: "org_1", name: "OldName" });
+
+    const outcome = await run();
+
+    expect(outcome).toBe("reverted");
+    expect(h.insertAuditLogs).toHaveBeenCalledTimes(1);
+    const [, auditEntry] = h.insertAuditLogs.mock.calls[0];
+    expect(auditEntry.description).toBe(
+      "Reverted name from NewName back to OldName after the organization rename failed",
+    );
+    expect(auditEntry.resources[0].name).toBe("OldName");
+    expect(h.logOperation).not.toHaveBeenCalled();
+  });
+
+  it("reports superseded when the revert affects no rows, so a concurrent rename that moved the row past the requested name is neither clobbered nor misreported as a completed revert", async () => {
+    h.getOrg.mockResolvedValue({ id: "org_1", name: "OldName" });
+    h.where.mockResolvedValue([{ affectedRows: 0 }]);
+
+    const outcome = await run();
+
+    expect(outcome).toBe("superseded");
+    expect(h.transaction).toHaveBeenCalledTimes(1);
+    expect(h.insertAuditLogs).not.toHaveBeenCalled();
+  });
+
+  it("reports left-at-requested-name and logs a symbolic code when the revert transaction fails, keeping the DB and org knowingly divergent rather than claiming nothing changed", async () => {
+    h.getOrg.mockResolvedValue({ id: "org_1", name: "OldName" });
+    // Once-only: vi.clearAllMocks() clears calls, not implementations, so a
+    // plain mockRejectedValue would leak into later tests.
+    h.transaction.mockRejectedValueOnce(
+      mysqlServerError(
+        "Deadlock found when trying to get lock; 'OldName'",
+        "ER_LOCK_DEADLOCK",
+        1213,
+        "40001",
+      ),
+    );
+
+    const outcome = await run();
+
+    expect(outcome).toBe("left-at-requested-name");
+    expect(h.logOperation).toHaveBeenCalledTimes(1);
+    const [level, , attributes] = h.logOperation.mock.calls[0];
+    expect(level).toBe("error");
+    expect(attributes).toMatchObject({
+      workspace_id: "ws_1",
+      error_detail: "database error: ER_LOCK_DEADLOCK",
+    });
+    expect(JSON.stringify(attributes)).not.toContain("OldName");
+  });
+});

--- a/web/apps/dashboard/lib/trpc/routers/workspace/reconcile-org-rename.ts
+++ b/web/apps/dashboard/lib/trpc/routers/workspace/reconcile-org-rename.ts
@@ -1,0 +1,137 @@
+import { insertAuditLogs } from "@/lib/audit";
+import { auth as authClient } from "@/lib/auth/server";
+import type { Organization } from "@/lib/auth/types";
+import { and, db, eq, schema, sql } from "@/lib/db";
+import { logOperation } from "@/lib/logging/structured-logger";
+import { errorLogDetail } from "../utils/errors";
+
+/**
+ * The state the caller must report on after a failed auth-provider org rename:
+ * - "rename-in-effect": the org holds the requested name (the provider applied
+ *   it and lost the response); report success.
+ * - "reverted": the rename left no effect; a plain failure reply is truthful.
+ * - "superseded": a concurrent rename already overwrote this one, and nothing
+ *   was reverted; report a conflict, not "nothing changed".
+ * - "left-at-requested-name": the DB holds the requested name while the org
+ *   may not (org unreadable, revert failed, or same-name repair); a retry of
+ *   the mutation converges both sides.
+ */
+export type ReconcileOutcome =
+  | "rename-in-effect"
+  | "reverted"
+  | "superseded"
+  | "left-at-requested-name";
+
+/**
+ * Byte-wise equality predicate for workspaces.name. The column's default
+ * collation is case/accent insensitive and utf8mb4_bin is PAD SPACE; either
+ * would let a concurrent rename to a near-variant slip past an optimistic
+ * guard. utf8mb4_0900_bin (NO PAD, byte-ordered) matches the JS strict
+ * equality used everywhere else in the rename flow.
+ */
+export function workspaceNameByteEquals(name: string) {
+  return sql`${schema.workspaces.name} COLLATE utf8mb4_0900_bin = ${name}`;
+}
+
+/**
+ * True when a name read back from the auth provider matches ours, allowing
+ * for Unicode normalization form and edge whitespace. A rename the provider
+ * applied in canonicalized form must not be mistaken for one that never
+ * applied: reverting over a difference the provider will always reintroduce
+ * would leave the two sides permanently divergent.
+ */
+export function providerNameMatches(providerName: string, name: string): boolean {
+  return providerName.normalize("NFC").trim() === name.normalize("NFC").trim();
+}
+
+/**
+ * Repairs the split state left when the DB workspace rename committed but the
+ * auth-provider org rename rejected. Reads the org to decide a safe direction,
+ * then compensates the DB side only, since that is the side we control.
+ */
+export async function reconcileFailedOrgRename(params: {
+  orgId: string;
+  workspaceId: string;
+  requestedName: string;
+  previousName: string;
+  actorId: string;
+  audit: { location: string; userAgent?: string };
+}): Promise<ReconcileOutcome> {
+  const { orgId, workspaceId, requestedName, previousName, actorId, audit } = params;
+
+  let org: Organization;
+  try {
+    org = await authClient.getOrg(orgId);
+  } catch (readErr) {
+    // With the org unreadable there is no safe direction to repair in.
+    logOperation(
+      "error",
+      "Unable to read the auth-provider org after a failed rename; the org name may be out of sync with the workspace name",
+      {
+        workspace_id: workspaceId,
+        error_detail: errorLogDetail(readErr),
+      },
+    );
+    return "left-at-requested-name";
+  }
+
+  if (providerNameMatches(org.name, requestedName)) {
+    return "rename-in-effect";
+  }
+
+  if (previousName === requestedName) {
+    // Same-name repair: nothing to revert, and "reverting" X to X would
+    // write a nonsensical audit entry.
+    return "left-at-requested-name";
+  }
+
+  let reverted: boolean;
+  try {
+    reverted = await db.transaction(async (tx) => {
+      // The byte-wise guard keeps the revert from clobbering a concurrent
+      // rename that already moved the workspace past requestedName.
+      const revert = await tx
+        .update(schema.workspaces)
+        .set({
+          name: previousName,
+        })
+        .where(and(eq(schema.workspaces.id, workspaceId), workspaceNameByteEquals(requestedName)));
+
+      if (revert[0].affectedRows === 0) {
+        return false;
+      }
+
+      await insertAuditLogs(tx, {
+        workspaceId,
+        actor: { type: "user", id: actorId },
+        event: "workspace.update",
+        description: `Reverted name from ${requestedName} back to ${previousName} after the organization rename failed`,
+        resources: [
+          {
+            type: "workspace",
+            id: workspaceId,
+            name: previousName,
+          },
+        ],
+        context: {
+          location: audit.location,
+          userAgent: audit.userAgent,
+        },
+      });
+
+      return true;
+    });
+  } catch (revertErr) {
+    logOperation(
+      "error",
+      "Failed to revert the workspace name after the organization rename failed; it may be out of sync with the org name",
+      {
+        workspace_id: workspaceId,
+        error_detail: errorLogDetail(revertErr),
+      },
+    );
+    return "left-at-requested-name";
+  }
+
+  return reverted ? "reverted" : "superseded";
+}

--- a/web/apps/dashboard/lib/utils/db-errors.ts
+++ b/web/apps/dashboard/lib/utils/db-errors.ts
@@ -2,6 +2,22 @@
  * Database error helpers for the dashboard's drizzle + mysql2 stack.
  */
 
+import { DrizzleQueryError } from "@unkey/db";
+
+/**
+ * Returns the driver error a DrizzleQueryError wraps, or undefined when it
+ * carries none. Kept next to [isDuplicateKeyError] so drizzle's wrapper
+ * shape is encoded in this file only; the walk is bounded in case a future
+ * drizzle nests its wrapper.
+ */
+export function unwrapDrizzleQueryError(err: DrizzleQueryError): unknown {
+  let cause: unknown = err.cause;
+  for (let depth = 0; cause instanceof DrizzleQueryError && depth < 10; depth++) {
+    cause = cause.cause;
+  }
+  return cause;
+}
+
 /**
  * Detects MySQL duplicate-key violations (ER_DUP_ENTRY / errno 1062).
  *

--- a/web/apps/dashboard/lib/utils/error-classification.ts
+++ b/web/apps/dashboard/lib/utils/error-classification.ts
@@ -17,6 +17,7 @@ export const EXPECTED_TRPC_CODES = [
   "TOO_MANY_REQUESTS",
   "BAD_REQUEST", // For validation errors
   "CONFLICT", // For duplicate resource errors (e.g. workspace slug already exists)
+  "PRECONDITION_FAILED",
 ] as const;
 
 /**
@@ -30,6 +31,7 @@ export const ERROR_SEVERITY_MAP = {
   TOO_MANY_REQUESTS: "warn",
   BAD_REQUEST: "warn",
   CONFLICT: "warn",
+  PRECONDITION_FAILED: "warn",
   INTERNAL_SERVER_ERROR: "error",
 } as const;
 


### PR DESCRIPTION
## Problem

`workspace.updateName` ran the WorkOS org rename inside the DB transaction, so a late failure left the DB and the auth
provider showing different names. The outer `.catch` also flattened every failure, including meaningful `TRPCError`s, into one generic 500.

## Solution

- The DB rename and its audit entry commit first, guarded by a byte-wise compare-and-swap so concurrent renames surface as CONFLICT instead of being overwritten; the org push runs after.
- On push failure, new `reconcileFailedOrgRename` reads the org and reports one of four outcomes: success (provider
applied it), reverted, superseded by a concurrent rename (CONFLICT), or a retryable `PRECONDITION_FAILED` split state.
- A same-name submit acts as the repair for that split state: it verifies the live row, no-ops when both sides already
agree, and audits a real re-sync.
- `wrapUnexpectedError` re-throws real `TRPCError`s and wraps only unexpected ones; `errorLogDetail` reduces provider and database errors to symbolic codes in logs.
- Client: honest toasts per outcome ("not fully synced", "already up to date"), refetches only when server state may have changed, and no more unhandled rejections on failed saves.

## Security Impact

- Logs no longer carry user input quoted in WorkOS or mysql2 error messages, including through tRPC's cause coercion.
- The name guards prevent a stale request from destroying a concurrent rename, and audit entries can no longer record reverts or repairs that did not happen.
- Names are trimmed before validation so whitespace cannot bypass length checks.

## Testing

- 9 reconcile tests (all outcomes, normalization, ordering) and 11 error tests (wrapping plus sanitization, including the coerced-cause and cyclic-chain regressions); full dashboard suite, typecheck, and biome pass.

- Change workspace name in different ways (white space, no white space, ect).  WorkOS and DB should always match. 