### PR TITLE
fix(frontline): distinguish usage exhaustion

### DIFF
--- a/docs/product/docs.json
+++ b/docs/product/docs.json
@@ -589,7 +589,8 @@
                       "errors/frontline/client/invalid_key",
                       "errors/frontline/client/missing_credentials",
                       "errors/frontline/client/openapi_validation_failed",
-                      "errors/frontline/client/rate_limited"
+                      "errors/frontline/client/rate_limited",
+                      "errors/frontline/client/usage_exceeded"
                     ]
                   },
                   {

--- a/docs/product/errors/frontline/client/usage_exceeded.mdx
+++ b/docs/product/errors/frontline/client/usage_exceeded.mdx
@@ -1,0 +1,6 @@
+---
+title: "usage_exceeded"
+description: "UsageExceeded represents a 429 error - the credential has no remaining credits."
+---
+
+<Danger>`err:frontline:client:usage_exceeded`</Danger>

--- a/pkg/codes/constants_gen.go
+++ b/pkg/codes/constants_gen.go
@@ -310,8 +310,10 @@ const (
 	UnkeyFrontlineErrorsAuthInvalidKey URN = "err:frontline:client:invalid_key"
 	// InsufficientPermissions represents a 403 error - the credential lacks the permissions required by a permission_query.
 	UnkeyFrontlineErrorsAuthInsufficientPermissions URN = "err:frontline:client:insufficient_permissions"
-	// RateLimited represents a 429 error - the credential or its auto-applied rate limit was exceeded.
+	// RateLimited represents a 429 error - a configured request rate limit was exceeded.
 	UnkeyFrontlineErrorsAuthRateLimited URN = "err:frontline:client:rate_limited"
+	// UsageExceeded represents a 429 error - the credential has no remaining credits.
+	UnkeyFrontlineErrorsAuthUsageExceeded URN = "err:frontline:client:usage_exceeded"
 
 	// Firewall
 

--- a/pkg/codes/frontline.go
+++ b/pkg/codes/frontline.go
@@ -65,8 +65,11 @@ type frontlineAuth struct {
 	// InsufficientPermissions represents a 403 error - the credential lacks the permissions required by a permission_query.
 	InsufficientPermissions Code
 
-	// RateLimited represents a 429 error - the credential or its auto-applied rate limit was exceeded.
+	// RateLimited represents a 429 error - a configured request rate limit was exceeded.
 	RateLimited Code
+
+	// UsageExceeded represents a 429 error - the credential has no remaining credits.
+	UsageExceeded Code
 }
 
 // frontlineFirewall defines errors raised by the Firewall policy.
@@ -134,6 +137,7 @@ var Frontline = UnkeyFrontlineErrors{
 		InvalidKey:              Code{SystemFrontline, CategoryClient, "invalid_key"},
 		InsufficientPermissions: Code{SystemFrontline, CategoryClient, "insufficient_permissions"},
 		RateLimited:             Code{SystemFrontline, CategoryClient, "rate_limited"},
+		UsageExceeded:           Code{SystemFrontline, CategoryClient, "usage_exceeded"},
 	},
 	Firewall: frontlineFirewall{
 		Denied: Code{SystemFrontline, CategoryClient, "firewall_denied"},

--- a/pkg/codes/frontline_test.go
+++ b/pkg/codes/frontline_test.go
@@ -36,6 +36,7 @@ func TestFrontlineURNsEncodeAttributionDomain(t *testing.T) {
 		{codes.Frontline.Auth.InvalidKey, "err:frontline:client:invalid_key"},
 		{codes.Frontline.Auth.InsufficientPermissions, "err:frontline:client:insufficient_permissions"},
 		{codes.Frontline.Auth.RateLimited, "err:frontline:client:rate_limited"},
+		{codes.Frontline.Auth.UsageExceeded, "err:frontline:client:usage_exceeded"},
 		{codes.Frontline.Firewall.Denied, "err:frontline:client:firewall_denied"},
 		{codes.Frontline.OpenApi.InvalidRequest, "err:frontline:client:openapi_validation_failed"},
 	}

--- a/svc/frontline/internal/policies/integration_test.go
+++ b/svc/frontline/internal/policies/integration_test.go
@@ -477,6 +477,30 @@ func TestKeyAuth_ValidKey_WithIdentity(t *testing.T) {
 	require.NotNil(t, identity.Meta)
 }
 
+func TestKeyAuth_UsageExceededHasDistinctCode(t *testing.T) {
+	h := newTestHarness(t)
+	ctx := context.Background()
+	s := h.seed(ctx)
+
+	err := db.Query.UpdateKeyCreditsSet(ctx, h.db.RW(), db.UpdateKeyCreditsSetParams{
+		Credits: sql.NullInt64{Int64: 0, Valid: true},
+		ID:      s.KeyID,
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer "+s.RawKey)
+	sess := newSession(t, req)
+
+	_, err = h.engine.Evaluate(ctx, sess, req, s.WorkspaceID, []*frontlinev1.Policy{
+		keyAuthPolicy("auth", []string{s.KeySpaceID}),
+	})
+	require.Error(t, err)
+	urn, ok := fault.GetCode(err)
+	require.True(t, ok)
+	require.Equal(t, codes.Frontline.Auth.UsageExceeded.URN(), urn)
+}
+
 func TestKeyAuth_MissingKey_Reject(t *testing.T) {
 	h := newTestHarness(t)
 	ctx := context.Background()

--- a/svc/frontline/internal/policies/keyauth/executor.go
+++ b/svc/frontline/internal/policies/keyauth/executor.go
@@ -138,9 +138,9 @@ func (e *Executor) Execute(
 		)
 	case keys.StatusUsageExceeded:
 		return nil, fault.New("usage exceeded",
-			fault.Code(codes.Frontline.Auth.RateLimited.URN()),
+			fault.Code(codes.Frontline.Auth.UsageExceeded.URN()),
 			fault.Internal("usage limit exceeded"),
-			fault.Public("Usage limit exceeded. Please try again later."),
+			fault.Public("Usage limit exceeded. No credits remain."),
 		)
 	case keys.StatusNotFound, keys.StatusDisabled, keys.StatusExpired,
 		keys.StatusForbidden, keys.StatusWorkspaceDisabled, keys.StatusWorkspaceNotFound:

--- a/svc/frontline/internal/policies/keyauth/executor.go
+++ b/svc/frontline/internal/policies/keyauth/executor.go
@@ -140,7 +140,7 @@ func (e *Executor) Execute(
 		return nil, fault.New("usage exceeded",
 			fault.Code(codes.Frontline.Auth.UsageExceeded.URN()),
 			fault.Internal("usage limit exceeded"),
-			fault.Public("Usage limit exceeded. No credits remain."),
+			fault.Public("Usage limit exceeded. This API key has no remaining credits."),
 		)
 	case keys.StatusNotFound, keys.StatusDisabled, keys.StatusExpired,
 		keys.StatusForbidden, keys.StatusWorkspaceDisabled, keys.StatusWorkspaceNotFound:

--- a/svc/frontline/internal/policies/metrics.go
+++ b/svc/frontline/internal/policies/metrics.go
@@ -72,7 +72,8 @@ func classifyKeyauthError(err error) string {
 	case codes.Frontline.Auth.MissingCredentials.URN(),
 		codes.Frontline.Auth.InvalidKey.URN(),
 		codes.Frontline.Auth.InsufficientPermissions.URN(),
-		codes.Frontline.Auth.RateLimited.URN():
+		codes.Frontline.Auth.RateLimited.URN(),
+		codes.Frontline.Auth.UsageExceeded.URN():
 		return "denied"
 	default:
 		return "error"

--- a/svc/frontline/middleware/observability.go
+++ b/svc/frontline/middleware/observability.go
@@ -290,7 +290,7 @@ func getErrorPageInfoFrontline(urn codes.URN) errorPageInfo {
 		return errorPageInfo{
 			Status:  http.StatusTooManyRequests,
 			Title:   http.StatusText(http.StatusTooManyRequests),
-			Message: "Usage limit exceeded. No credits remain.",
+			Message: "Usage limit exceeded. This API key has no remaining credits.",
 		}
 	case codes.Frontline.Firewall.Denied.URN():
 		return errorPageInfo{

--- a/svc/frontline/middleware/observability.go
+++ b/svc/frontline/middleware/observability.go
@@ -286,6 +286,12 @@ func getErrorPageInfoFrontline(urn codes.URN) errorPageInfo {
 			Title:   http.StatusText(http.StatusTooManyRequests),
 			Message: "Rate limit exceeded. Please try again later.",
 		}
+	case codes.Frontline.Auth.UsageExceeded.URN():
+		return errorPageInfo{
+			Status:  http.StatusTooManyRequests,
+			Title:   http.StatusText(http.StatusTooManyRequests),
+			Message: "Usage limit exceeded. No credits remain.",
+		}
 	case codes.Frontline.Firewall.Denied.URN():
 		return errorPageInfo{
 			Status:  http.StatusForbidden,

--- a/svc/frontline/middleware/observability_test.go
+++ b/svc/frontline/middleware/observability_test.go
@@ -49,6 +49,7 @@ func TestGetErrorPageInfoFrontline_StatusMapping(t *testing.T) {
 		{codes.Frontline.Auth.InvalidKey.URN(), http.StatusUnauthorized},
 		{codes.Frontline.Auth.InsufficientPermissions.URN(), http.StatusForbidden},
 		{codes.Frontline.Auth.RateLimited.URN(), http.StatusTooManyRequests},
+		{codes.Frontline.Auth.UsageExceeded.URN(), http.StatusTooManyRequests},
 		{codes.Frontline.Firewall.Denied.URN(), http.StatusForbidden},
 		{codes.Frontline.OpenApi.InvalidRequest.URN(), http.StatusBadRequest},
 
@@ -180,6 +181,7 @@ func TestWithObservability_ResponseExposesURN(t *testing.T) {
 	urns := []codes.URN{
 		codes.Frontline.Proxy.GatewayTimeout.URN(),
 		codes.Frontline.Auth.RateLimited.URN(),
+		codes.Frontline.Auth.UsageExceeded.URN(),
 		codes.Frontline.Routing.NoRunningInstances.URN(),
 		codes.Frontline.Internal.InvalidConfiguration.URN(),
 		codes.Frontline.Internal.InternalServerError.URN(),


### PR DESCRIPTION
## Problem:

Frontline returned `err:frontline:client:rate_limited` when an API key had no credits. Clients could not distinguish exhausted usage from a temporary rate limit or prompt users to replenish credits.

## Solution:

Return `err:frontline:client:usage_exceeded` with an explicit credit exhaustion message. Keep HTTP 429 for usage quota exhaustion. True rate limits continue to return `rate_limited`.

## Impact:

Gateway clients can distinguish credit exhaustion and show an upgrade or replenishment action. The HTTP status remains compatible with existing clients.

## Testing:

- `mise exec -- rask ./pkg/codes ./svc/frontline/middleware`: 84 tests passed.
- `mise exec -- rask ./svc/frontline/internal/policies`: 69 tests passed.