### PR TITLE
feat(dashboard): Show compute and API usage in the sidebar

### DIFF
--- a/web/apps/dashboard/components/navigation/sidebar-v2/index.tsx
+++ b/web/apps/dashboard/components/navigation/sidebar-v2/index.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { Sidebar, SidebarContent, SidebarFooter, useSidebar } from "@/components/ui/sidebar";
+import { useBillingUIUpgrades } from "@/lib/flags/use-billing-ui-upgrades";
 import { cn } from "@/lib/utils";
 import { SidebarLeftHide, SidebarLeftShow } from "@unkey/icons";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@unkey/ui";
 import { SidebarBody } from "./sidebar-body";
 import { UsageBanner } from "./usage-banner";
+import { UsageCard } from "./usage-card";
 
 export const SIDEBAR_WIDTH_VARS: React.CSSProperties & {
   "--sidebar-width": string;
@@ -19,6 +21,7 @@ type Props = React.ComponentProps<typeof Sidebar>;
 
 export function SidebarV2(props: Props) {
   const { isMobile } = useSidebar();
+  const billingUpgrades = useBillingUIUpgrades();
   if (isMobile) {
     return null;
   }
@@ -34,7 +37,7 @@ export function SidebarV2(props: Props) {
         <SidebarBody />
       </SidebarContent>
       <SidebarFooter className="mx-0 gap-2 border-t-0 p-2">
-        <UsageBanner />
+        {billingUpgrades ? <UsageCard /> : <UsageBanner />}
         <CollapseButton />
       </SidebarFooter>
     </Sidebar>

--- a/web/apps/dashboard/components/navigation/sidebar-v2/usage-card/index.tsx
+++ b/web/apps/dashboard/components/navigation/sidebar-v2/usage-card/index.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useSidebar } from "@/components/ui/sidebar";
+import { cn } from "@/lib/utils";
+import { UsagePanel } from "./usage-panel";
+import { useUsageSummary } from "./use-usage-summary";
+
+export function UsageCard() {
+  const { state } = useSidebar();
+  const summary = useUsageSummary();
+  const railed = state === "collapsed";
+
+  if (summary === null) {
+    return null;
+  }
+
+  // `inert`, not `aria-hidden`: the links inside are focusable while hidden.
+  return (
+    <div
+      inert={railed || undefined}
+      className={cn(
+        "transition-[opacity,transform] duration-200 ease-out motion-reduce:transition-none",
+        railed && "-translate-x-1 opacity-0",
+      )}
+    >
+      <UsagePanel summary={summary} />
+    </div>
+  );
+}

--- a/web/apps/dashboard/components/navigation/sidebar-v2/usage-card/usage-panel.tsx
+++ b/web/apps/dashboard/components/navigation/sidebar-v2/usage-card/usage-panel.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { Plus } from "@unkey/icons";
+import { motion } from "framer-motion";
+import Link from "next/link";
+import { useId } from "react";
+import { ApiRow, ComputeRow } from "./usage-rows";
+import { useMinimised } from "./use-minimised";
+import type { UsageSummary } from "./use-usage-summary";
+
+const TOGGLE = { duration: 0.2, ease: "easeInOut" } as const;
+
+export function UsagePanel({ summary }: { summary: UsageSummary }) {
+  const [minimised, setMinimised] = useMinimised();
+  const folded = minimised && !summary.atRisk;
+  const bodyId = useId();
+
+  return (
+    <div className="group overflow-hidden rounded-lg border border-grayA-4 bg-white shadow-xs dark:bg-grayA-3">
+      <div
+        className={cn(
+          "flex items-center gap-2 font-medium text-[11px]",
+          !folded && "px-2.5 pt-2 pb-1.5",
+        )}
+      >
+        {folded ? null : (
+          <Link href={summary.href} className="flex min-w-0 items-center gap-1 text-gray-12">
+            <span className="truncate">Usage</span>
+            <span
+              aria-hidden="true"
+              className="-translate-x-1 shrink-0 text-gray-11 opacity-0 transition-[opacity,transform] duration-150 ease-out group-hover:translate-x-0 group-hover:opacity-100 motion-reduce:transition-none"
+            >
+              ↗
+            </span>
+          </Link>
+        )}
+        {summary.atRisk ? null : (
+          <button
+            type="button"
+            onClick={() => setMinimised(!folded)}
+            aria-expanded={!folded}
+            aria-controls={bodyId}
+            aria-label={folded ? "Show usage detail" : "Hide usage detail"}
+            className={cn(
+              "flex items-center rounded text-gray-9 hover:text-gray-12",
+              folded
+                ? "w-full gap-2 px-2.5 pt-2 pb-1.5 text-left font-medium text-[11px] transition-colors hover:bg-grayA-2"
+                : "-mr-1 h-5 flex-1 justify-end pr-1 pl-2",
+            )}
+          >
+            {folded ? <span className="flex-1 truncate text-gray-12">Usage</span> : null}
+            <Toggle rotated={!folded} />
+          </button>
+        )}
+      </div>
+
+      <motion.div
+        id={bodyId}
+        inert={folded || undefined}
+        initial={false}
+        animate={{ height: folded ? 0 : "auto", opacity: folded ? 0 : 1 }}
+        transition={TOGGLE}
+        className="overflow-hidden"
+      >
+        <Link href={summary.href} className="block">
+          <div className="flex flex-col gap-2.5 px-2.5 pt-1 pb-2.5">
+            {summary.compute === null ? null : <ComputeRow measured={summary.compute} />}
+            {summary.api === null ? null : <ApiRow measured={summary.api} />}
+          </div>
+        </Link>
+      </motion.div>
+    </div>
+  );
+}
+
+function Toggle({ rotated }: { rotated: boolean }) {
+  return (
+    <motion.span
+      className="flex shrink-0"
+      initial={false}
+      animate={{ rotate: rotated ? 45 : 0 }}
+      transition={TOGGLE}
+    >
+      <Plus iconSize="sm-regular" />
+    </motion.span>
+  );
+}

--- a/web/apps/dashboard/components/navigation/sidebar-v2/usage-card/usage-rows.tsx
+++ b/web/apps/dashboard/components/navigation/sidebar-v2/usage-card/usage-rows.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { formatCompactQuantity, formatDollars } from "@/lib/fmt";
+import { cn } from "@/lib/utils";
+import { Skeleton } from "@unkey/ui";
+import type { ReactNode } from "react";
+import {
+  AT_RISK,
+  type ApiUsage,
+  type ComputeUsage,
+  type Measured,
+  apiRatio,
+  computeRatio,
+} from "./use-usage-summary";
+
+export function ComputeRow({ measured }: { measured: Measured<ComputeUsage> }) {
+  return (
+    <Row
+      label="Compute"
+      measured={measured}
+      ratioOf={computeRatio}
+      renderValue={(value, ratio) =>
+        value.budgetCents === null || value.budgetCents <= 0 ? (
+          <span className="text-gray-12">{formatDollars(value.grossCents)}</span>
+        ) : (
+          <Fraction
+            used={formatDollars(value.grossCents)}
+            ceiling={formatDollars(value.budgetCents)}
+            ratio={ratio}
+          />
+        )
+      }
+    />
+  );
+}
+
+export function ApiRow({ measured }: { measured: Measured<ApiUsage> }) {
+  return (
+    <Row
+      label="API"
+      measured={measured}
+      ratioOf={apiRatio}
+      renderValue={(value, ratio) => (
+        <Fraction
+          used={formatCompactQuantity(value.used)}
+          ceiling={formatCompactQuantity(value.max)}
+          ratio={ratio}
+        />
+      )}
+    />
+  );
+}
+
+function Row<T>({
+  label,
+  measured,
+  ratioOf,
+  renderValue,
+}: {
+  label: string;
+  measured: Measured<T>;
+  ratioOf: (value: T) => number | null;
+  renderValue: (value: T, ratio: number | null) => ReactNode;
+}) {
+  switch (measured.state) {
+    case "loading":
+      return (
+        <Shell label={label} atRisk={false} value={<Skeleton className="h-3 w-16" />}>
+          <Skeleton className="h-1 w-full rounded-full" />
+        </Shell>
+      );
+    case "error":
+      return <Shell label={label} atRisk={false} value={<span className="text-gray-8">—</span>} />;
+    case "ready": {
+      const ratio = ratioOf(measured.value);
+      const atRisk = ratio !== null && ratio >= AT_RISK;
+      return (
+        <Shell label={label} atRisk={atRisk} value={renderValue(measured.value, ratio)}>
+          {ratio === null ? null : <Bar ratio={ratio} atRisk={atRisk} />}
+        </Shell>
+      );
+    }
+    default:
+      return measured satisfies never;
+  }
+}
+
+function Shell({
+  label,
+  atRisk,
+  value,
+  children,
+}: {
+  label: string;
+  atRisk: boolean;
+  value: ReactNode;
+  children?: ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-baseline gap-2">
+        <span
+          className={cn(
+            "flex-1 truncate font-mono text-[10px] uppercase tracking-wider transition-colors duration-150 ease-out motion-reduce:transition-none",
+            atRisk ? "text-error-9" : "text-gray-9 group-hover:text-gray-12",
+          )}
+        >
+          {label}
+        </span>
+        <span className="whitespace-nowrap font-mono text-[11px] tabular-nums">{value}</span>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function Fraction({
+  used,
+  ceiling,
+  ratio,
+}: {
+  used: string;
+  ceiling: string;
+  ratio: number | null;
+}) {
+  if (ratio !== null && ratio >= AT_RISK) {
+    return (
+      <span className="text-error-9">
+        {used} / {ceiling}
+      </span>
+    );
+  }
+  return (
+    <>
+      <span className="text-gray-12">{used}</span>
+      <span className="text-gray-7"> / </span>
+      <span className="text-gray-12">{ceiling}</span>
+    </>
+  );
+}
+
+function Bar({ ratio, atRisk }: { ratio: number; atRisk: boolean }) {
+  return (
+    <div className="h-1 w-full overflow-hidden rounded-full bg-grayA-4">
+      <div
+        className={cn("h-full rounded-full", atRisk ? "bg-error-9" : "bg-gray-12")}
+        style={{ width: `${Math.min(Math.max(ratio, 0), 1) * 100}%` }}
+      />
+    </div>
+  );
+}

--- a/web/apps/dashboard/components/navigation/sidebar-v2/usage-card/use-minimised.ts
+++ b/web/apps/dashboard/components/navigation/sidebar-v2/usage-card/use-minimised.ts
@@ -1,0 +1,28 @@
+"use client";
+
+import { useCallback, useState } from "react";
+
+const STORAGE_KEY = "unkey-sidebar-usage-minimised";
+
+function read(): boolean {
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+// Reading storage in the initialiser is only safe because the sidebar first
+// renders after hydration — `(app)/layout.tsx` gates on the workspace query.
+export function useMinimised(): [boolean, (next: boolean) => void] {
+  const [minimised, setState] = useState(read);
+
+  const setMinimised = useCallback((next: boolean) => {
+    setState(next);
+    try {
+      window.localStorage.setItem(STORAGE_KEY, String(next));
+    } catch {}
+  }, []);
+
+  return [minimised, setMinimised];
+}

--- a/web/apps/dashboard/components/navigation/sidebar-v2/usage-card/use-usage-summary.ts
+++ b/web/apps/dashboard/components/navigation/sidebar-v2/usage-card/use-usage-summary.ts
@@ -1,0 +1,115 @@
+"use client";
+
+import { routes } from "@/lib/navigation/routes";
+import { trpc } from "@/lib/trpc/client";
+import { useWorkspace } from "@/providers/workspace-provider";
+import type { Route } from "next";
+
+export type Measured<T> = { state: "loading" } | { state: "error" } | { state: "ready"; value: T };
+
+export type ComputeUsage = {
+  grossCents: number;
+  budgetCents: number | null;
+};
+
+export type ApiUsage = {
+  used: number;
+  max: number;
+};
+
+export type UsageSummary = {
+  href: Route;
+  compute: Measured<ComputeUsage> | null;
+  api: Measured<ApiUsage> | null;
+  atRisk: boolean;
+};
+
+export const AT_RISK = 0.9;
+
+const STALE_MS = 5 * 60 * 1000;
+
+export function useUsageSummary(): UsageSummary | null {
+  const { workspace, limits } = useWorkspace();
+  const hasComputePlan = Boolean(workspace?.deployPlan) || Boolean(workspace?.deployPlanOverride);
+
+  const deployUsage = trpc.billing.queryDeployUsage.useQuery(undefined, {
+    enabled: hasComputePlan,
+    staleTime: STALE_MS,
+    refetchOnWindowFocus: false,
+    trpc: { context: { skipBatch: true } },
+  });
+  const apiUsage = trpc.billing.queryUsage.useQuery(undefined, {
+    staleTime: STALE_MS,
+    refetchOnWindowFocus: false,
+    trpc: { context: { skipBatch: true } },
+  });
+
+  if (!workspace) {
+    return null;
+  }
+
+  const compute = hasComputePlan
+    ? measureCompute(deployUsage, workspace.deploySpendBudgetCents ?? null)
+    : null;
+  const api = measureApi(apiUsage, limits?.apiBillableOperationsCountMaxPerMonth ?? null);
+
+  return {
+    href: routes.settings.billing({ workspaceSlug: workspace.slug }),
+    compute,
+    api,
+    atRisk: overCeiling(compute, computeRatio) || overCeiling(api, apiRatio),
+  };
+}
+
+export function computeRatio(value: ComputeUsage): number | null {
+  if (value.budgetCents === null || value.budgetCents <= 0) {
+    return null;
+  }
+  return value.grossCents / value.budgetCents;
+}
+
+export function apiRatio(value: ApiUsage): number {
+  return value.used / value.max;
+}
+
+function overCeiling<T>(
+  measured: Measured<T> | null,
+  ratioOf: (value: T) => number | null,
+): boolean {
+  if (measured === null || measured.state !== "ready") {
+    return false;
+  }
+  const ratio = ratioOf(measured.value);
+  return ratio !== null && ratio >= AT_RISK;
+}
+
+type Query<T> = { data: T | undefined; isError: boolean };
+
+function measureCompute(
+  usage: Query<{ grossCents: number }>,
+  budgetCents: number | null,
+): Measured<ComputeUsage> {
+  if (usage.isError) {
+    return { state: "error" };
+  }
+  if (usage.data === undefined) {
+    return { state: "loading" };
+  }
+  return { state: "ready", value: { grossCents: usage.data.grossCents, budgetCents } };
+}
+
+function measureApi(
+  usage: Query<{ billableTotal: number }>,
+  max: number | null,
+): Measured<ApiUsage> | null {
+  if (max === null || max <= 0) {
+    return null;
+  }
+  if (usage.isError) {
+    return { state: "error" };
+  }
+  if (usage.data === undefined) {
+    return { state: "loading" };
+  }
+  return { state: "ready", value: { used: usage.data.billableTotal, max } };
+}


### PR DESCRIPTION
## What does this PR do?

- Removes the old 'api management only' usage card
- Adds a new usage card that tracks api management and compute. 
- Behind the new 'billing ui updates' flag

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

1. Open any dashboard route and look at the sidebar footer. The card shows Compute and API rows and links to billing settings.
2. Click the plus to fold it to the header, reload, and confirm it comes back folded without animating shut.
3. Collapse the sidebar to the icon rail. The card fades out and its links leave the tab order.
4. Tab through the sidebar with the keyboard. Focus should stay on the toggle across folding, and the folded rows should not be reachable.
5. A workspace with a compute spend budget set shows a bar on the Compute row; one without shows the dollar figure alone.

6. Flag off: the old one-line "Usage NN%" item, unchanged.

## Screenshots

| Sidebar |
| --- |
| **Pro, healthy** |
| ![sidebar-card--pro-healthy](https://github.com/user-attachments/assets/d9ea108e-625c-43cf-ae4b-5cb9ce1788ae) |
| **Budget, alerts only** |
| ![sidebar-card--budget-no-stop](https://github.com/user-attachments/assets/c9cfdb7b-5792-4210-8732-45a094e6f9ba) |
| **API over quota** |
| ![sidebar-card--api-over-quota](https://github.com/user-attachments/assets/83b97311-8073-4453-97c3-8215838001b6) |
| **Suspended** |
| ![sidebar-card--suspended](https://github.com/user-attachments/assets/5a39b427-ad42-4b2a-822d-bdf0fd7cb734) |

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary
