### PR TITLE
fix(api): schedule plan downgrades at period end

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/api-addon-card.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/billing/components/api-addon-card.tsx
@@ -100,7 +100,11 @@ export const ApiAddOnCard: React.FC<ApiAddOnCardProps> = ({
         return;
       }
       setShowPlanModal(false);
-      toast.success("API plan changed");
+      toast.success(
+        result.kind === "scheduled"
+          ? `API plan downgrade scheduled for ${new Date(result.effectiveAt).toLocaleDateString()}`
+          : "API plan changed",
+      );
       await revalidate();
     },
     onError: (err) => toast.error(err.message),
@@ -273,17 +277,7 @@ export const ApiAddOnCard: React.FC<ApiAddOnCardProps> = ({
             detail: `${formatNumber(product.quotas.requestsPerMonth)} requests/month`,
           }))}
           currentId={currentProduct?.id ?? null}
-          // Informational: downgrading below this month's usage means requests
-          // beyond the smaller quota get rejected once it is exhausted.
-          warningFor={(option) => {
-            const target = products.find((p) => p.id === option.id);
-            return target && used > target.quotas.requestsPerMonth
-              ? `Your usage this month (${formatNumber(used)}) already exceeds the ${formatNumber(
-                  target.quotas.requestsPerMonth,
-                )} requests ${target.name} includes.`
-              : null;
-          }}
-          changeNote="Takes effect immediately; the prorated difference is invoiced right away."
+          changeNote="Upgrades take effect immediately and are prorated. Downgrades start next billing period; your current plan stays active and no refund is issued."
           submittingId={
             createSubscription.isLoading
               ? createSubscription.variables?.productId

--- a/web/apps/dashboard/app/api/webhooks/stripe/route.ts
+++ b/web/apps/dashboard/app/api/webhooks/stripe/route.ts
@@ -23,6 +23,7 @@ import {
   isAutomatedBillingRenewal,
   isCardUpdateOnly,
   isPaymentFailureRelatedUpdate,
+  isScheduleUpdateOnly,
 } from "@/lib/stripe/subscriptionUtils";
 import { keepsTeamAfterDelete } from "@/lib/stripe/webhookRouting";
 import {
@@ -442,6 +443,13 @@ export const POST = async (req: Request): Promise<Response> => {
         // its upgrade/downgrade/cancel alert from it, and the API branch below
         // uses it for its skip heuristics and up/downgrade copy.
         const previousAttributes = event.data.previous_attributes;
+
+        // Creating or releasing a schedule leaves the active price and limits
+        // unchanged. The later phase transition carries the item price change
+        // and is reconciled normally.
+        if (isScheduleUpdateOnly(previousAttributes)) {
+          return new Response("OK", { status: 200 });
+        }
 
         // Deploy-matched: mirror the plan, announce the change, and stop. The
         // Deploy subscription never carries API tier/limit state, so there is

--- a/web/apps/dashboard/lib/stripe/scheduleApiPlanDowngrade.test.ts
+++ b/web/apps/dashboard/lib/stripe/scheduleApiPlanDowngrade.test.ts
@@ -1,0 +1,174 @@
+import type Stripe from "stripe";
+import { describe, expect, it, vi } from "vitest";
+import {
+  SubscriptionScheduleConflictError,
+  releaseScheduledApiPlanDowngrade,
+  scheduleApiPlanDowngrade,
+} from "./scheduleApiPlanDowngrade";
+
+function schedule(
+  overrides: Partial<Stripe.SubscriptionSchedule> = {},
+): Stripe.SubscriptionSchedule {
+  return {
+    id: "sub_sched_1",
+    current_phase: { start_date: 1_700_000_000, end_date: 1_702_678_400 },
+    metadata: {},
+    phases: [
+      {
+        start_date: 1_700_000_000,
+        end_date: 1_702_678_400,
+        items: [
+          {
+            price: "price_current",
+            quantity: 1,
+            metadata: {},
+            discounts: [],
+            tax_rates: [],
+            billing_thresholds: null,
+          },
+          {
+            price: "price_other",
+            quantity: 2,
+            metadata: {},
+            discounts: [],
+            tax_rates: [],
+            billing_thresholds: null,
+          },
+        ],
+        metadata: { workspace_id: "ws_1" },
+        discounts: [],
+        default_tax_rates: [],
+        trial_end: 1_701_000_000,
+      },
+    ],
+    ...overrides,
+  } as unknown as Stripe.SubscriptionSchedule;
+}
+
+function stubStripe(createdSchedule = schedule(), retrievedSchedule = createdSchedule) {
+  const create = vi.fn(async () => createdSchedule);
+  const retrieve = vi.fn(async () => retrievedSchedule);
+  const update = vi.fn(
+    async (_id: string, _params: Stripe.SubscriptionScheduleUpdateParams) => retrievedSchedule,
+  );
+  const release = vi.fn(async () => retrievedSchedule);
+  return {
+    stripe: {
+      subscriptionSchedules: { create, retrieve, update, release },
+    } as unknown as Stripe,
+    create,
+    retrieve,
+    update,
+    release,
+  };
+}
+
+describe("scheduleApiPlanDowngrade", () => {
+  it("keeps the current price until renewal and disables all proration", async () => {
+    const { stripe, create, update } = stubStripe();
+
+    const result = await scheduleApiPlanDowngrade(stripe, {
+      subscriptionId: "sub_1",
+      schedule: null,
+      currentPriceId: "price_current",
+      newPriceId: "price_lower",
+    });
+
+    expect(result).toEqual({ effectiveAt: 1_702_678_400_000 });
+    expect(create).toHaveBeenCalledWith({ from_subscription: "sub_1" });
+    expect(update).toHaveBeenCalledWith("sub_sched_1", {
+      end_behavior: "release",
+      metadata: { unkey_change: "api_plan_downgrade" },
+      proration_behavior: "none",
+      phases: [
+        {
+          items: [
+            {
+              price: "price_current",
+              quantity: 1,
+            },
+            {
+              price: "price_other",
+              quantity: 2,
+            },
+          ],
+          start_date: 1_700_000_000,
+          end_date: 1_702_678_400,
+          proration_behavior: "none",
+        },
+        {
+          items: [
+            {
+              price: "price_lower",
+              quantity: 1,
+            },
+            {
+              price: "price_other",
+              quantity: 2,
+            },
+          ],
+          duration: { interval: "month", interval_count: 1 },
+          proration_behavior: "none",
+        },
+      ],
+    });
+  });
+
+  it("replaces a downgrade previously scheduled by this flow", async () => {
+    const managedSchedule = schedule({ metadata: { unkey_change: "api_plan_downgrade" } });
+    const { stripe, create, retrieve, update } = stubStripe(schedule(), managedSchedule);
+
+    await scheduleApiPlanDowngrade(stripe, {
+      subscriptionId: "sub_1",
+      schedule: "sub_sched_1",
+      currentPriceId: "price_current",
+      newPriceId: "price_different",
+    });
+
+    expect(create).not.toHaveBeenCalled();
+    expect(retrieve).toHaveBeenCalledWith("sub_sched_1");
+    expect(update).toHaveBeenCalledOnce();
+    expect(update.mock.calls[0]?.[1].phases?.[1].items[0]?.price).toBe("price_different");
+  });
+
+  it("does not overwrite a schedule owned by another flow", async () => {
+    const { stripe, update } = stubStripe(schedule(), schedule({ metadata: {} }));
+
+    await expect(
+      scheduleApiPlanDowngrade(stripe, {
+        subscriptionId: "sub_1",
+        schedule: "sub_sched_other",
+        currentPriceId: "price_current",
+        newPriceId: "price_lower",
+      }),
+    ).rejects.toBeInstanceOf(SubscriptionScheduleConflictError);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it("releases a newly created schedule when phase configuration fails", async () => {
+    const { stripe, update, release } = stubStripe();
+    const error = new Error("schedule update failed");
+    update.mockRejectedValueOnce(error);
+
+    await expect(
+      scheduleApiPlanDowngrade(stripe, {
+        subscriptionId: "sub_1",
+        schedule: null,
+        currentPriceId: "price_current",
+        newPriceId: "price_lower",
+      }),
+    ).rejects.toBe(error);
+    expect(release).toHaveBeenCalledWith("sub_sched_1");
+  });
+});
+
+describe("releaseScheduledApiPlanDowngrade", () => {
+  it("releases a downgrade owned by this flow", async () => {
+    const managedSchedule = schedule({ metadata: { unkey_change: "api_plan_downgrade" } });
+    const { stripe, release } = stubStripe(schedule(), managedSchedule);
+
+    await releaseScheduledApiPlanDowngrade(stripe, "sub_sched_1");
+
+    expect(release).toHaveBeenCalledWith("sub_sched_1");
+  });
+});

--- a/web/apps/dashboard/lib/stripe/scheduleApiPlanDowngrade.ts
+++ b/web/apps/dashboard/lib/stripe/scheduleApiPlanDowngrade.ts
@@ -1,0 +1,128 @@
+import type Stripe from "stripe";
+
+const API_PLAN_DOWNGRADE = "api_plan_downgrade";
+
+type ScheduleApiPlanDowngradeInput = {
+  subscriptionId: string;
+  schedule: Stripe.Subscription["schedule"];
+  currentPriceId: string;
+  newPriceId: string;
+};
+
+export class SubscriptionScheduleConflictError extends Error {}
+
+function resourceId(resource: string | { id: string }): string {
+  return typeof resource === "string" ? resource : resource.id;
+}
+
+function phaseItems(
+  items: Stripe.SubscriptionSchedule.Phase.Item[],
+  priceChange?: { from: string; to: string },
+): Stripe.SubscriptionScheduleUpdateParams.Phase.Item[] {
+  return items.map((item) => ({
+    price:
+      priceChange && resourceId(item.price) === priceChange.from
+        ? priceChange.to
+        : resourceId(item.price),
+    ...(item.quantity === undefined ? {} : { quantity: item.quantity }),
+  }));
+}
+
+async function retrieveSchedule(
+  stripe: Stripe,
+  schedule: Exclude<Stripe.Subscription["schedule"], null>,
+): Promise<Stripe.SubscriptionSchedule> {
+  return typeof schedule === "string" ? stripe.subscriptionSchedules.retrieve(schedule) : schedule;
+}
+
+function assertManagedSchedule(schedule: Stripe.SubscriptionSchedule): void {
+  if (schedule.metadata?.unkey_change !== API_PLAN_DOWNGRADE) {
+    throw new SubscriptionScheduleConflictError(
+      "This subscription already has a different scheduled change.",
+    );
+  }
+}
+
+/** Keeps the current price active and changes it at the next billing boundary. */
+export async function scheduleApiPlanDowngrade(
+  stripe: Stripe,
+  input: ScheduleApiPlanDowngradeInput,
+): Promise<{ effectiveAt: number }> {
+  const created = input.schedule === null;
+  const schedule = input.schedule
+    ? await retrieveSchedule(stripe, input.schedule)
+    : await stripe.subscriptionSchedules.create({ from_subscription: input.subscriptionId });
+
+  if (input.schedule) {
+    assertManagedSchedule(schedule);
+  }
+
+  try {
+    const currentPhase = schedule.current_phase
+      ? schedule.phases.find(
+          (phase) =>
+            phase.start_date === schedule.current_phase?.start_date &&
+            phase.end_date === schedule.current_phase.end_date,
+        )
+      : undefined;
+    if (!currentPhase) {
+      throw new Error("Stripe did not return the current subscription schedule phase.");
+    }
+
+    const hasCurrentPrice = currentPhase.items.some(
+      (item) => resourceId(item.price) === input.currentPriceId,
+    );
+    if (!hasCurrentPrice) {
+      throw new Error("The current API price was not found in the subscription schedule.");
+    }
+
+    const currentItems = phaseItems(currentPhase.items);
+    const futureItems = phaseItems(currentPhase.items, {
+      from: input.currentPriceId,
+      to: input.newPriceId,
+    });
+
+    await stripe.subscriptionSchedules.update(schedule.id, {
+      end_behavior: "release",
+      metadata: {
+        ...(schedule.metadata ?? {}),
+        unkey_change: API_PLAN_DOWNGRADE,
+      },
+      // Updating the unchanged current phase must never create a credit/refund.
+      proration_behavior: "none",
+      phases: [
+        {
+          items: currentItems,
+          start_date: currentPhase.start_date,
+          end_date: currentPhase.end_date,
+          proration_behavior: "none",
+        },
+        {
+          items: futureItems,
+          duration: { interval: "month", interval_count: 1 },
+          // The lower price starts on the renewal boundary, without a proration.
+          proration_behavior: "none",
+        },
+      ],
+    });
+
+    return { effectiveAt: currentPhase.end_date * 1000 };
+  } catch (error) {
+    // from_subscription and phase configuration require separate Stripe calls.
+    // Undo the first call if the second fails so the customer can retry.
+    if (created) {
+      await stripe.subscriptionSchedules.release(schedule.id);
+    }
+    throw error;
+  }
+}
+
+/** Removes a pending API downgrade before an immediate plan change. */
+export async function releaseScheduledApiPlanDowngrade(
+  stripe: Stripe,
+  scheduleReference: Exclude<Stripe.Subscription["schedule"], null>,
+): Promise<void> {
+  const schedule = await retrieveSchedule(stripe, scheduleReference);
+  assertManagedSchedule(schedule);
+  await stripe.subscriptionSchedules.release(schedule.id);
+}

--- a/web/apps/dashboard/lib/stripe/subscriptionUtils.test.ts
+++ b/web/apps/dashboard/lib/stripe/subscriptionUtils.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { isScheduleUpdateOnly } from "./subscriptionUtils";
+
+describe("isScheduleUpdateOnly", () => {
+  it("matches a schedule attachment without a plan change", () => {
+    expect(isScheduleUpdateOnly({ schedule: null })).toBe(true);
+  });
+
+  it("does not hide a schedule update that also changes items", () => {
+    expect(isScheduleUpdateOnly({ schedule: null, items: { data: [] } })).toBe(false);
+  });
+
+  it("does not match missing previous attributes", () => {
+    expect(isScheduleUpdateOnly(undefined)).toBe(false);
+  });
+});

--- a/web/apps/dashboard/lib/stripe/subscriptionUtils.ts
+++ b/web/apps/dashboard/lib/stripe/subscriptionUtils.ts
@@ -20,6 +20,7 @@ interface PreviousAttributes {
   cancel_at_period_end?: boolean;
   collection_method?: string;
   latest_invoice?: string | Stripe.Invoice | null;
+  schedule?: string | Stripe.SubscriptionSchedule | null;
 
   // Payment method changes (when users update their card)
   default_payment_method?: string | Stripe.PaymentMethod | null;
@@ -161,6 +162,16 @@ export function isCardUpdateOnly(
   }
 
   return false;
+}
+
+/** Attaching or releasing a schedule does not change the active API plan. */
+export function isScheduleUpdateOnly(previousAttributes: PreviousAttributes | undefined): boolean {
+  if (!previousAttributes) {
+    return false;
+  }
+
+  const changedKeys = Object.keys(previousAttributes);
+  return changedKeys.length === 1 && changedKeys[0] === "schedule";
 }
 
 export type { PreviousAttributes };

--- a/web/apps/dashboard/lib/trpc/routers/stripe/cancelSubscription.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/cancelSubscription.ts
@@ -20,11 +20,22 @@ export const cancelSubscription = workspaceProcedure
       });
     }
 
+    const subscription = await stripe.subscriptions.retrieve(ctx.workspace.stripeSubscriptionId);
+    if (subscription.schedule) {
+      const scheduleId =
+        typeof subscription.schedule === "string"
+          ? subscription.schedule
+          : subscription.schedule.id;
+      // Cancellation supersedes any pending plan change. Release the schedule
+      // first so the native period-end cancellation remains authoritative.
+      await stripe.subscriptionSchedules.release(scheduleId);
+    }
+
     // The API product owns its own subscription, so cancelling is a native
     // whole-subscription cancel at period end. Stripe deletes it at the boundary
     // and the customer.subscription.deleted webhook reverts tier/quotas and
     // deactivates non-creator memberships, so no member-count block is needed here.
-    await stripe.subscriptions.update(ctx.workspace.stripeSubscriptionId, {
+    await stripe.subscriptions.update(subscription.id, {
       cancel_at_period_end: true,
     });
   });

--- a/web/apps/dashboard/lib/trpc/routers/stripe/updateSubscription.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/updateSubscription.ts
@@ -6,6 +6,11 @@ import { changeSubscriptionPrice } from "@/lib/stripe/changeSubscriptionPrice";
 import { deployBillingConfig, findApiItem } from "@/lib/stripe/deployBilling";
 import { parseDeployPlan } from "@/lib/stripe/deployPlan";
 import { validateAndParseQuotas } from "@/lib/stripe/productUtils";
+import {
+  SubscriptionScheduleConflictError,
+  releaseScheduledApiPlanDowngrade,
+  scheduleApiPlanDowngrade,
+} from "@/lib/stripe/scheduleApiPlanDowngrade";
 import { setWorkspaceLimits } from "@/lib/stripe/setWorkspaceLimits";
 import { TRPCError } from "@trpc/server";
 import Stripe from "stripe";
@@ -117,10 +122,14 @@ export const updateSubscription = workspaceProcedure
       typeof newProduct.default_price === "string"
         ? await stripe.prices.retrieve(newPriceId)
         : newProduct.default_price;
-    const upgraded =
+    const isUpgrade =
       item.price.unit_amount !== null &&
       newPrice.unit_amount !== null &&
       newPrice.unit_amount > item.price.unit_amount;
+    const isDowngrade =
+      item.price.unit_amount !== null &&
+      newPrice.unit_amount !== null &&
+      newPrice.unit_amount < item.price.unit_amount;
 
     if (sub.cancel_at_period_end) {
       throw new TRPCError({
@@ -129,15 +138,38 @@ export const updateSubscription = workspaceProcedure
       });
     }
 
-    let result: Awaited<ReturnType<typeof changeSubscriptionPrice>>;
+    let result:
+      | Awaited<ReturnType<typeof changeSubscriptionPrice>>
+      | { kind: "scheduled"; effectiveAt: number };
     try {
-      result = await changeSubscriptionPrice(stripe, {
-        subscriptionId: sub.id,
-        subscriptionItemId: item.id,
-        newPriceId,
-        prorationBehavior: "always_invoice",
-      });
+      if (isDowngrade) {
+        const { effectiveAt } = await scheduleApiPlanDowngrade(stripe, {
+          subscriptionId: sub.id,
+          schedule: sub.schedule,
+          currentPriceId: item.price.id,
+          newPriceId,
+        });
+        result = { kind: "scheduled", effectiveAt };
+      } else {
+        // A new immediate change replaces an API downgrade that was scheduled
+        // through this route. Never release schedules owned by another flow.
+        if (sub.schedule) {
+          await releaseScheduledApiPlanDowngrade(stripe, sub.schedule);
+        }
+        result = await changeSubscriptionPrice(stripe, {
+          subscriptionId: sub.id,
+          subscriptionItemId: item.id,
+          newPriceId,
+          prorationBehavior: "always_invoice",
+        });
+      }
     } catch (err) {
+      if (err instanceof SubscriptionScheduleConflictError) {
+        throw new TRPCError({
+          code: "PRECONDITION_FAILED",
+          message: err.message,
+        });
+      }
       if (err instanceof Stripe.errors.StripeCardError) {
         throw new TRPCError({
           code: "BAD_REQUEST",
@@ -157,6 +189,26 @@ export const updateSubscription = workspaceProcedure
       throw err;
     }
 
+    if (result.kind === "scheduled") {
+      await insertAuditLogs(db, {
+        workspaceId: ctx.workspace.id,
+        actor: {
+          type: "user",
+          id: ctx.user.id,
+        },
+        event: "workspace.update",
+        description: `Scheduled switch to ${newProduct.name} plan for ${new Date(
+          result.effectiveAt,
+        ).toISOString()}.`,
+        resources: [],
+        context: {
+          location: ctx.audit.location,
+          userAgent: ctx.audit.userAgent,
+        },
+      });
+      return result;
+    }
+
     if (result.kind === "payment_required") {
       return result;
     }
@@ -164,7 +216,7 @@ export const updateSubscription = workspaceProcedure
     // Workspace API rate limits are manually applied safety limits, not plan
     // limits. Clear them when a customer pays for a higher tier, but preserve
     // deliberate limits on same-price changes and downgrades.
-    const rateLimitReset = upgraded ? { apiRequestsCountMaxPerMinute: null } : {};
+    const rateLimitReset = isUpgrade ? { apiRequestsCountMaxPerMinute: null } : {};
 
     await db.transaction(async (tx) => {
       await tx


### PR DESCRIPTION
## Problem:

When downgrading api subs we did so immeditally and gave them a refund, which we should just downgrade EOM.

## Solution:

Stripe now downgrades their plan at the start of the next billing period.

## Impact:

API plan upgrades remain immediate and prorated. Compute billing does not change. Customers keep their current API allowance through the paid billing period.

## Testing:

- `mise exec -- pnpm --dir=web --filter @unkey/dashboard typecheck`
- `mise exec -- pnpm --dir=web --filter @unkey/dashboard exec vitest run lib/stripe/scheduleApiPlanDowngrade.test.ts lib/stripe/subscriptionUtils.test.ts` (8 tests passed)