### PR TITLE
chore: type test fixtures

### DIFF
--- a/cmd/api/analytics/get_verifications_test.go
+++ b/cmd/api/analytics/get_verifications_test.go
@@ -1,75 +1,12 @@
 package analytics
 
 import (
-	"bytes"
-	"context"
-	"encoding/json"
-	"fmt"
-	"io"
-	"net/http"
-	"net/http/httptest"
-	"os"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/unkeyed/unkey/pkg/cli"
+	"github.com/unkeyed/unkey/cmd/api/util"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
-
-// captureRequest is a local variant of util.CaptureRequest that returns a
-// response with "data" as an empty array instead of an empty object.  The
-// analytics SDK endpoint deserialises "data" as []json.RawMessage, so the
-// generic harness response shape does not work here.
-func captureRequest[T any](t *testing.T, cmd *cli.Command, args string) T {
-	t.Helper()
-
-	var body []byte
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		b, err := io.ReadAll(r.Body)
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-		body = b
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"meta":{"requestId":"test"},"data":[]}`))
-	}))
-	t.Cleanup(srv.Close)
-
-	origStdout := os.Stdout
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("failed to create pipe: %v", err)
-	}
-	os.Stdout = w
-
-	fullArgs := fmt.Sprintf("unkey %s --api-url=%s --root-key=test_key", args, srv.URL)
-	root := &cli.Command{
-		Name:     "unkey",
-		Commands: []*cli.Command{cmd},
-	}
-
-	runErr := root.Run(context.Background(), strings.Fields(fullArgs))
-
-	if closeErr := w.Close(); closeErr != nil {
-		t.Fatalf("failed to close pipe writer: %v", closeErr)
-	}
-	os.Stdout = origStdout
-	var buf bytes.Buffer
-	_, _ = io.Copy(&buf, r)
-
-	if runErr != nil {
-		t.Fatalf("CLI command failed: %v", runErr)
-	}
-
-	var req T
-	if err := json.Unmarshal(body, &req); err != nil {
-		t.Fatalf("failed to unmarshal request body: %v\nbody: %s", err, string(body))
-	}
-
-	return req
-}
 
 func TestGetVerifications(t *testing.T) {
 	// Note: the shared test harness splits args with strings.Fields, so query
@@ -105,7 +42,7 @@ func TestGetVerifications(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := captureRequest[openapi.V2AnalyticsGetVerificationsRequestBody](t, Cmd(), tt.args)
+			req := util.CaptureRequestWithData[openapi.V2AnalyticsGetVerificationsRequestBody](t, Cmd(), tt.args, []any{})
 			require.Equal(t, tt.want, req)
 		})
 	}

--- a/cmd/api/apis/list_keys_test.go
+++ b/cmd/api/apis/list_keys_test.go
@@ -91,11 +91,9 @@ func TestListKeys(t *testing.T) {
 		},
 	}
 
-	listResponse := `{"meta":{"requestId":"test"},"data":[]}`
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := util.CaptureRequestWithResponse[openapi.V2ApisListKeysRequestBody](t, Cmd(), tt.args, listResponse)
+			req := util.CaptureRequestWithData[openapi.V2ApisListKeysRequestBody](t, Cmd(), tt.args, []any{})
 			require.Equal(t, tt.want, req)
 		})
 	}

--- a/cmd/api/identities/list_identities_test.go
+++ b/cmd/api/identities/list_identities_test.go
@@ -41,7 +41,7 @@ func TestListIdentities(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := util.CaptureRequestWithResponse[openapi.V2IdentitiesListIdentitiesRequestBody](t, Cmd(), tt.args, `{"meta":{"requestId":"test"},"data":[]}`)
+			req := util.CaptureRequestWithData[openapi.V2IdentitiesListIdentitiesRequestBody](t, Cmd(), tt.args, []any{})
 			require.Equal(t, tt.want, req)
 		})
 	}

--- a/cmd/api/keys/add_permissions_test.go
+++ b/cmd/api/keys/add_permissions_test.go
@@ -24,11 +24,9 @@ func TestAddPermissions(t *testing.T) {
 		},
 	}
 
-	arrayResponse := `{"meta":{"requestId":"test"},"data":[]}`
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := util.CaptureRequestWithResponse[openapi.V2KeysAddPermissionsRequestBody](t, Cmd(), tt.args, arrayResponse)
+			req := util.CaptureRequestWithData[openapi.V2KeysAddPermissionsRequestBody](t, Cmd(), tt.args, []any{})
 			require.Equal(t, tt.want, req)
 		})
 	}

--- a/cmd/api/keys/add_roles_test.go
+++ b/cmd/api/keys/add_roles_test.go
@@ -32,11 +32,9 @@ func TestAddRoles(t *testing.T) {
 		},
 	}
 
-	arrayResponse := `{"meta":{"requestId":"test"},"data":[]}`
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := util.CaptureRequestWithResponse[openapi.V2KeysAddRolesRequestBody](t, Cmd(), tt.args, arrayResponse)
+			req := util.CaptureRequestWithData[openapi.V2KeysAddRolesRequestBody](t, Cmd(), tt.args, []any{})
 			require.Equal(t, tt.want, req)
 		})
 	}

--- a/cmd/api/keys/remove_permissions_test.go
+++ b/cmd/api/keys/remove_permissions_test.go
@@ -24,11 +24,9 @@ func TestRemovePermissions(t *testing.T) {
 		},
 	}
 
-	arrayResponse := `{"meta":{"requestId":"test"},"data":[]}`
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := util.CaptureRequestWithResponse[openapi.V2KeysRemovePermissionsRequestBody](t, Cmd(), tt.args, arrayResponse)
+			req := util.CaptureRequestWithData[openapi.V2KeysRemovePermissionsRequestBody](t, Cmd(), tt.args, []any{})
 			require.Equal(t, tt.want, req)
 		})
 	}

--- a/cmd/api/keys/remove_roles_test.go
+++ b/cmd/api/keys/remove_roles_test.go
@@ -32,11 +32,9 @@ func TestRemoveRoles(t *testing.T) {
 		},
 	}
 
-	arrayResponse := `{"meta":{"requestId":"test"},"data":[]}`
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := util.CaptureRequestWithResponse[openapi.V2KeysRemoveRolesRequestBody](t, Cmd(), tt.args, arrayResponse)
+			req := util.CaptureRequestWithData[openapi.V2KeysRemoveRolesRequestBody](t, Cmd(), tt.args, []any{})
 			require.Equal(t, tt.want, req)
 		})
 	}

--- a/cmd/api/keys/set_permissions_test.go
+++ b/cmd/api/keys/set_permissions_test.go
@@ -24,11 +24,9 @@ func TestSetPermissions(t *testing.T) {
 		},
 	}
 
-	arrayResponse := `{"meta":{"requestId":"test"},"data":[]}`
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := util.CaptureRequestWithResponse[openapi.V2KeysSetPermissionsRequestBody](t, Cmd(), tt.args, arrayResponse)
+			req := util.CaptureRequestWithData[openapi.V2KeysSetPermissionsRequestBody](t, Cmd(), tt.args, []any{})
 			require.Equal(t, tt.want, req)
 		})
 	}

--- a/cmd/api/keys/set_roles_test.go
+++ b/cmd/api/keys/set_roles_test.go
@@ -32,11 +32,9 @@ func TestSetRoles(t *testing.T) {
 		},
 	}
 
-	arrayResponse := `{"meta":{"requestId":"test"},"data":[]}`
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := util.CaptureRequestWithResponse[openapi.V2KeysSetRolesRequestBody](t, Cmd(), tt.args, arrayResponse)
+			req := util.CaptureRequestWithData[openapi.V2KeysSetRolesRequestBody](t, Cmd(), tt.args, []any{})
 			require.Equal(t, tt.want, req)
 		})
 	}

--- a/cmd/api/permissions/list_permissions_test.go
+++ b/cmd/api/permissions/list_permissions_test.go
@@ -10,8 +10,6 @@ import (
 )
 
 func TestListPermissions(t *testing.T) {
-	listResponse := `{"meta":{"requestId":"test"},"data":[]}`
-
 	tests := []struct {
 		name string
 		args string
@@ -51,7 +49,7 @@ func TestListPermissions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := util.CaptureRequestWithResponse[openapi.V2PermissionsListPermissionsRequestBody](t, Cmd(), tt.args, listResponse)
+			req := util.CaptureRequestWithData[openapi.V2PermissionsListPermissionsRequestBody](t, Cmd(), tt.args, []any{})
 			require.Equal(t, tt.want, req)
 		})
 	}

--- a/cmd/api/permissions/list_roles_test.go
+++ b/cmd/api/permissions/list_roles_test.go
@@ -10,8 +10,6 @@ import (
 )
 
 func TestListRoles(t *testing.T) {
-	listResponse := `{"meta":{"requestId":"test"},"data":[]}`
-
 	tests := []struct {
 		name string
 		args string
@@ -51,7 +49,7 @@ func TestListRoles(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := util.CaptureRequestWithResponse[openapi.V2PermissionsListRolesRequestBody](t, Cmd(), tt.args, listResponse)
+			req := util.CaptureRequestWithData[openapi.V2PermissionsListRolesRequestBody](t, Cmd(), tt.args, []any{})
 			require.Equal(t, tt.want, req)
 		})
 	}

--- a/cmd/api/ratelimit/list_overrides_test.go
+++ b/cmd/api/ratelimit/list_overrides_test.go
@@ -9,10 +9,6 @@ import (
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
 
-// listResponse returns an array-shaped data envelope so the SDK can unmarshal
-// the response without error (list endpoints expect "data":[] not "data":{}).
-const listResponse = `{"meta":{"requestId":"test"},"data":[]}`
-
 func TestListOverrides(t *testing.T) {
 	tests := []struct {
 		name string
@@ -57,7 +53,7 @@ func TestListOverrides(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := util.CaptureRequestWithResponse[openapi.V2RatelimitListOverridesRequestBody](t, Cmd(), tt.args, listResponse)
+			req := util.CaptureRequestWithData[openapi.V2RatelimitListOverridesRequestBody](t, Cmd(), tt.args, []any{})
 			require.Equal(t, tt.want, req)
 		})
 	}

--- a/cmd/api/util/testharness.go
+++ b/cmd/api/util/testharness.go
@@ -15,6 +15,15 @@ import (
 	"github.com/unkeyed/unkey/pkg/cli"
 )
 
+type responseMeta struct {
+	RequestID string `json:"requestId"`
+}
+
+type responseEnvelope struct {
+	Meta responseMeta `json:"meta"`
+	Data any          `json:"data"`
+}
+
 // CaptureRequest runs a CLI command against a local test server, captures the
 // JSON request body, and unmarshals it into T. The test server responds with a
 // minimal valid envelope so the SDK does not error.
@@ -26,14 +35,12 @@ import (
 //	require.Equal(t, handler.Request{ApiId: "api_123"}, req)
 func CaptureRequest[T any](t *testing.T, cmd *cli.Command, args string) T {
 	t.Helper()
-	return CaptureRequestWithResponse[T](t, cmd, args, `{"meta":{"requestId":"test"},"data":{}}`)
+	return CaptureRequestWithData[T](t, cmd, args, struct{}{})
 }
 
-// CaptureRequestWithResponse is like CaptureRequest but lets the caller supply
-// a custom JSON response body. Use this when the default object-shaped data
-// envelope (`"data":{}`) does not match the SDK's expected response type (e.g.
-// endpoints that return an array in `data`).
-func CaptureRequestWithResponse[T any](t *testing.T, cmd *cli.Command, args string, response string) T {
+// CaptureRequestWithData is like CaptureRequest but lets the caller supply the
+// response envelope's data value. Use this for endpoints that return an array.
+func CaptureRequestWithData[T any](t *testing.T, cmd *cli.Command, args string, responseData any) T {
 	t.Helper()
 
 	var body []byte
@@ -45,7 +52,13 @@ func CaptureRequestWithResponse[T any](t *testing.T, cmd *cli.Command, args stri
 		}
 		body = b
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(response))
+		response := responseEnvelope{
+			Meta: responseMeta{RequestID: "test"},
+			Data: responseData,
+		}
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			t.Errorf("failed to encode response: %v", err)
+		}
 	}))
 	t.Cleanup(srv.Close)
 

--- a/pkg/db/key_data_test.go
+++ b/pkg/db/key_data_test.go
@@ -116,12 +116,14 @@ func TestToKeyData_EmptyValues(t *testing.T) {
 
 func TestToKeyData_WithIdentity(t *testing.T) {
 	t.Run("with valid identity data", func(t *testing.T) {
+		meta, err := json.Marshal(map[string]string{"role": "admin"})
+		require.NoError(t, err)
 		row := FindLiveKeyByHashRow{
 			ID:                 "key-with-identity",
 			WorkspaceID:        "workspace-123",
 			IdentityTableID:    sql.NullString{String: "identity-123", Valid: true},
 			IdentityExternalID: sql.NullString{String: "user-456", Valid: true},
-			IdentityMeta:       []byte(`{"role": "admin"}`),
+			IdentityMeta:       meta,
 		}
 
 		result := ToKeyData(row)
@@ -131,7 +133,7 @@ func TestToKeyData_WithIdentity(t *testing.T) {
 		require.Equal(t, "identity-123", result.Identity.ID)
 		require.Equal(t, "user-456", result.Identity.ExternalID)
 		require.Equal(t, "workspace-123", result.Identity.WorkspaceID)
-		require.Equal(t, []byte(`{"role": "admin"}`), result.Identity.Meta)
+		require.Equal(t, meta, result.Identity.Meta)
 	})
 
 	t.Run("without identity data", func(t *testing.T) {

--- a/pkg/email/resend_test.go
+++ b/pkg/email/resend_test.go
@@ -3,7 +3,6 @@ package email
 import (
 	"context"
 	"encoding/json"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -20,7 +19,6 @@ func TestResendSend(t *testing.T) {
 			gotContentType = r.Header.Get("Content-Type")
 			require.NoError(t, json.NewDecoder(r.Body).Decode(&gotBody))
 			w.WriteHeader(http.StatusOK)
-			_, _ = io.WriteString(w, `{"id":"email_1"}`)
 		}))
 		defer srv.Close()
 
@@ -80,7 +78,6 @@ func TestResendSend(t *testing.T) {
 	t.Run("non-2xx is an error", func(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusUnprocessableEntity)
-			_, _ = io.WriteString(w, `{"message":"template not published"}`)
 		}))
 		defer srv.Close()
 

--- a/pkg/restate/admin/client_test.go
+++ b/pkg/restate/admin/client_test.go
@@ -9,10 +9,21 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/uid"
 )
 
 func TestFindLiveInvocations(t *testing.T) {
 	var gotAccept, gotQuery string
+	aliveInvocationID1 := uid.New("inv")
+	aliveInvocationID2 := uid.New("inv")
+	deadInvocationID := uid.New("inv")
+	type invocationRow struct {
+		ID string `json:"id"`
+	}
+	response, err := json.Marshal(struct {
+		Rows []invocationRow `json:"rows"`
+	}{Rows: []invocationRow{{ID: aliveInvocationID1}, {ID: aliveInvocationID2}}})
+	require.NoError(t, err)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, http.MethodPost, r.Method)
@@ -28,20 +39,20 @@ func TestFindLiveInvocations(t *testing.T) {
 		gotQuery = req.Query
 
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"rows":[{"id":"inv_alive_1"},{"id":"inv_alive_2"}]}`))
+		_, _ = w.Write(response)
 	}))
 	t.Cleanup(server.Close)
 
 	client := New(Config{BaseURL: server.URL, APIKey: ""})
 
-	live, err := client.FindLiveInvocations(context.Background(), []string{"inv_alive_1", "inv_alive_2", "inv_dead_1"})
+	live, err := client.FindLiveInvocations(context.Background(), []string{aliveInvocationID1, aliveInvocationID2, deadInvocationID})
 	require.NoError(t, err)
 
 	// The endpoint compares the Accept header literally. Any value other
 	// than "application/json" returns binary Arrow.
 	require.Equal(t, "application/json", gotAccept)
 	require.Contains(t, gotQuery, "sys_invocation")
-	require.Contains(t, gotQuery, "'inv_dead_1'")
+	require.Contains(t, gotQuery, "'"+deadInvocationID+"'")
 	// concat(id, '') prevents Restate from parsing the literals as
 	// invocation IDs; an unparseable ID would fail the whole query.
 	require.Contains(t, gotQuery, "concat(id, '')")
@@ -50,9 +61,9 @@ func TestFindLiveInvocations(t *testing.T) {
 	require.Contains(t, gotQuery, "status <> 'completed'")
 
 	require.Equal(t, map[string]bool{
-		"inv_alive_1": true,
-		"inv_alive_2": true,
-		"inv_dead_1":  false,
+		aliveInvocationID1: true,
+		aliveInvocationID2: true,
+		deadInvocationID:   false,
 	}, live)
 }
 

--- a/pkg/webhook/verifiers/github/github_test.go
+++ b/pkg/webhook/verifiers/github/github_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -11,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/uid"
 )
 
 // sign produces an X-Hub-Signature-256 header for body: sha256=<hmac-sha256
@@ -23,13 +25,20 @@ func sign(secret, body string) string {
 
 func TestVerifier(t *testing.T) {
 	const secret = "gh_test_secret"
-	body := `{"ref":"refs/heads/main","after":"abc123"}`
+	deliveryID := uid.New(uid.TestPrefix)
+	type pushPayload struct {
+		Ref   string `json:"ref"`
+		After string `json:"after"`
+	}
+	bodyBytes, err := json.Marshal(pushPayload{Ref: "refs/heads/main", After: "abc123"})
+	require.NoError(t, err)
+	body := string(bodyBytes)
 
 	request := func(mutate func(*http.Request)) *http.Request {
 		r := httptest.NewRequest(http.MethodPost, "/webhooks/github", strings.NewReader(body))
 		r.Header.Set("X-Hub-Signature-256", sign(secret, body))
 		r.Header.Set("X-GitHub-Event", "push")
-		r.Header.Set("X-GitHub-Delivery", "delivery-123")
+		r.Header.Set("X-GitHub-Delivery", deliveryID)
 		if mutate != nil {
 			mutate(r)
 		}
@@ -39,7 +48,7 @@ func TestVerifier(t *testing.T) {
 	t.Run("valid signature yields event from headers", func(t *testing.T) {
 		event, err := New(secret).Verify(request(nil))
 		require.NoError(t, err)
-		require.Equal(t, "delivery-123", event.ID)
+		require.Equal(t, deliveryID, event.ID)
 		require.Equal(t, "push", event.Type)
 		require.Equal(t, body, string(event.Payload))
 	})
@@ -58,10 +67,12 @@ func TestVerifier(t *testing.T) {
 
 	t.Run("tampered body is rejected", func(t *testing.T) {
 		// Body differs from what the signature was computed over.
+		tampered, err := json.Marshal(pushPayload{Ref: "refs/heads/evil"})
+		require.NoError(t, err)
 		r := request(func(r *http.Request) {
-			r.Body = io.NopCloser(strings.NewReader(`{"ref":"refs/heads/evil"}`))
+			r.Body = io.NopCloser(strings.NewReader(string(tampered)))
 		})
-		_, err := New(secret).Verify(r)
+		_, err = New(secret).Verify(r)
 		require.Error(t, err)
 	})
 

--- a/pkg/webhook/verifiers/stripe/stripe_test.go
+++ b/pkg/webhook/verifiers/stripe/stripe_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/uid"
 )
 
 // sign produces a Stripe-Signature header for body: t=<ts>,v1=<hmac-sha256
@@ -24,9 +26,32 @@ func sign(secret, body string, ts time.Time) string {
 
 func TestVerifier(t *testing.T) {
 	const secret = "whsec_test"
+	eventID := uid.New("evt")
+	invoiceID := uid.New("in")
+	type invoice struct {
+		ID string `json:"id"`
+	}
+	type eventData struct {
+		Object invoice `json:"object"`
+	}
+	type stripeEvent struct {
+		ID     string    `json:"id"`
+		Object string    `json:"object"`
+		Type   string    `json:"type"`
+		Data   eventData `json:"data"`
+	}
 	// "object":"event" matters: stripe-go v21+ rejects payloads without it as
 	// thin event notifications, which need a different parser.
-	body := `{"id":"evt_123","object":"event","type":"invoice.created","data":{"object":{"id":"in_123"}}}`
+	bodyBytes, err := json.Marshal(stripeEvent{
+		ID:     eventID,
+		Object: "event",
+		Type:   "invoice.created",
+		Data:   eventData{Object: invoice{ID: invoiceID}},
+	})
+	require.NoError(t, err)
+	body := string(bodyBytes)
+	wantPayload, err := json.Marshal(invoice{ID: invoiceID})
+	require.NoError(t, err)
 
 	request := func(signature string) *http.Request {
 		r := httptest.NewRequest(http.MethodPost, "/webhooks/stripe", strings.NewReader(body))
@@ -37,9 +62,9 @@ func TestVerifier(t *testing.T) {
 	t.Run("valid signature yields the unwrapped event", func(t *testing.T) {
 		event, err := New(secret).Verify(request(sign(secret, body, time.Now())))
 		require.NoError(t, err)
-		require.Equal(t, "evt_123", event.ID)
+		require.Equal(t, eventID, event.ID)
 		require.Equal(t, "invoice.created", event.Type)
-		require.JSONEq(t, `{"id":"in_123"}`, string(event.Payload))
+		require.JSONEq(t, string(wantPayload), string(event.Payload))
 	})
 
 	t.Run("wrong secret is rejected", func(t *testing.T) {

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -2,6 +2,7 @@ package webhook
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -11,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/uid"
 )
 
 // staticVerifier returns a fixed event, or an error when the body says so. It
@@ -38,18 +40,19 @@ func post(t *testing.T, rec *Receiver, body string) *httptest.ResponseRecorder {
 }
 
 func TestReceiver(t *testing.T) {
+	eventID := uid.New(uid.TestPrefix)
 	newReceiver := func(eventType string) *Receiver {
-		return New("test", staticVerifier{event: Event{ID: "evt_1", Type: eventType, Payload: []byte(`{}`)}})
+		return New("test", staticVerifier{event: Event{ID: eventID, Type: eventType}})
 	}
 
 	t.Run("handled event returns 200", func(t *testing.T) {
 		called := false
 		rec := newReceiver("thing.created").On([]string{"thing.created"}, func(ctx context.Context, e Event) error {
 			called = true
-			require.Equal(t, "evt_1", e.ID)
+			require.Equal(t, eventID, e.ID)
 			return nil
 		})
-		require.Equal(t, http.StatusOK, post(t, rec, "{}").Code)
+		require.Equal(t, http.StatusOK, post(t, rec, "").Code)
 		require.True(t, called)
 	})
 
@@ -57,21 +60,21 @@ func TestReceiver(t *testing.T) {
 		rec := newReceiver("thing.created").On([]string{"thing.created"}, func(ctx context.Context, e Event) error {
 			return fmt.Errorf("%w: not ours", ErrIgnore)
 		})
-		require.Equal(t, http.StatusOK, post(t, rec, "{}").Code)
+		require.Equal(t, http.StatusOK, post(t, rec, "").Code)
 	})
 
 	t.Run("handler error returns 500 so the provider retries", func(t *testing.T) {
 		rec := newReceiver("thing.created").On([]string{"thing.created"}, func(ctx context.Context, e Event) error {
 			return errors.New("downstream broke")
 		})
-		require.Equal(t, http.StatusInternalServerError, post(t, rec, "{}").Code)
+		require.Equal(t, http.StatusInternalServerError, post(t, rec, "").Code)
 	})
 
 	t.Run("bad request returns 400 without retry", func(t *testing.T) {
 		rec := newReceiver("thing.created").On([]string{"thing.created"}, func(ctx context.Context, e Event) error {
 			return fmt.Errorf("%w: malformed", ErrBadRequest)
 		})
-		require.Equal(t, http.StatusBadRequest, post(t, rec, "{}").Code)
+		require.Equal(t, http.StatusBadRequest, post(t, rec, "").Code)
 	})
 
 	t.Run("unregistered event type is acknowledged", func(t *testing.T) {
@@ -79,7 +82,7 @@ func TestReceiver(t *testing.T) {
 			t.Fatal("handler must not run for other event types")
 			return nil
 		})
-		require.Equal(t, http.StatusOK, post(t, rec, "{}").Code)
+		require.Equal(t, http.StatusOK, post(t, rec, "").Code)
 	})
 
 	t.Run("verification failure returns 401", func(t *testing.T) {
@@ -97,7 +100,7 @@ func TestReceiver(t *testing.T) {
 				called = true
 				return nil
 			})
-			require.Equal(t, http.StatusOK, post(t, rec, "{}").Code)
+			require.Equal(t, http.StatusOK, post(t, rec, "").Code)
 			require.True(t, called, eventType)
 		}
 	})
@@ -119,7 +122,7 @@ func TestReceiver(t *testing.T) {
 				got = e.Type
 				return nil
 			})
-		require.Equal(t, http.StatusOK, post(t, rec, "{}").Code)
+		require.Equal(t, http.StatusOK, post(t, rec, "").Code)
 		require.Equal(t, "thing.deleted", got)
 	})
 
@@ -127,14 +130,14 @@ func TestReceiver(t *testing.T) {
 		rec := newReceiver("thing.deleted").Default(func(ctx context.Context, e Event) error {
 			return errors.New("downstream broke")
 		})
-		require.Equal(t, http.StatusInternalServerError, post(t, rec, "{}").Code)
+		require.Equal(t, http.StatusInternalServerError, post(t, rec, "").Code)
 	})
 
 	t.Run("default handler can ignore via ErrIgnore", func(t *testing.T) {
 		rec := newReceiver("thing.deleted").Default(func(ctx context.Context, e Event) error {
 			return fmt.Errorf("%w: not ours", ErrIgnore)
 		})
-		require.Equal(t, http.StatusOK, post(t, rec, "{}").Code)
+		require.Equal(t, http.StatusOK, post(t, rec, "").Code)
 	})
 
 	t.Run("middleware runs outermost-first in Use order", func(t *testing.T) {
@@ -153,7 +156,7 @@ func TestReceiver(t *testing.T) {
 				order = append(order, "handler")
 				return nil
 			})
-		require.Equal(t, http.StatusOK, post(t, rec, "{}").Code)
+		require.Equal(t, http.StatusOK, post(t, rec, "").Code)
 		// The first Use wraps outermost, so it runs before the second.
 		require.Equal(t, []string{"first", "second", "handler"}, order)
 	})
@@ -167,7 +170,7 @@ func TestReceiver(t *testing.T) {
 
 	t.Run("body over the size limit returns 413", func(t *testing.T) {
 		rec := New("test",
-			staticVerifier{event: Event{ID: "evt_1", Type: "thing.created", Payload: []byte(`{}`)}},
+			staticVerifier{event: Event{ID: eventID, Type: "thing.created"}},
 			WithMaxBodySize(8),
 		).On([]string{"thing.created"}, func(ctx context.Context, e Event) error {
 			t.Fatal("handler must not run for oversized bodies")
@@ -179,7 +182,7 @@ func TestReceiver(t *testing.T) {
 	t.Run("WithMaxBodySize raises the limit", func(t *testing.T) {
 		called := false
 		rec := New("test",
-			staticVerifier{event: Event{ID: "evt_1", Type: "thing.created", Payload: []byte(`{}`)}},
+			staticVerifier{event: Event{ID: eventID, Type: "thing.created"}},
 			WithMaxBodySize(128),
 		).On([]string{"thing.created"}, func(ctx context.Context, e Event) error {
 			called = true
@@ -191,9 +194,10 @@ func TestReceiver(t *testing.T) {
 }
 
 func TestTyped(t *testing.T) {
-	newReceiver := func(payload string) *Receiver {
+	eventID := uid.New(uid.TestPrefix)
+	newReceiver := func(payload []byte) *Receiver {
 		return New("test", staticVerifier{
-			event: Event{ID: "evt_1", Type: "thing.created", Payload: []byte(payload)},
+			event: Event{ID: eventID, Type: "thing.created", Payload: payload},
 		})
 	}
 
@@ -203,25 +207,27 @@ func TestTyped(t *testing.T) {
 
 	t.Run("handler receives the parsed payload", func(t *testing.T) {
 		var got thing
-		rec := newReceiver(`{"name":"box"}`).On(
+		payload, err := json.Marshal(thing{Name: "box"})
+		require.NoError(t, err)
+		rec := newReceiver(payload).On(
 			[]string{"thing.created"},
 			Typed(func(ctx context.Context, e Event, payload thing) error {
 				got = payload
 				return nil
 			}),
 		)
-		require.Equal(t, http.StatusOK, post(t, rec, "{}").Code)
+		require.Equal(t, http.StatusOK, post(t, rec, "").Code)
 		require.Equal(t, "box", got.Name)
 	})
 
 	t.Run("malformed payload is a 400 bad request", func(t *testing.T) {
-		rec := newReceiver(`not json`).On(
+		rec := newReceiver([]byte(`not json`)).On(
 			[]string{"thing.created"},
 			Typed(func(ctx context.Context, e Event, payload thing) error {
 				t.Fatal("handler must not run for unparseable payloads")
 				return nil
 			}),
 		)
-		require.Equal(t, http.StatusBadRequest, post(t, rec, "{}").Code)
+		require.Equal(t, http.StatusBadRequest, post(t, rec, "").Code)
 	})
 }

--- a/svc/api/routes/v2_apis_list_keys/200_test.go
+++ b/svc/api/routes/v2_apis_list_keys/200_test.go
@@ -3,6 +3,7 @@ package handler_test
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
@@ -67,17 +68,21 @@ func TestSuccess(t *testing.T) {
 
 	// Create test identities
 	identity1ExternalID := "test_user_1"
+	identity1Meta, err := json.Marshal(map[string]string{"role": "admin"})
+	require.NoError(t, err)
 	identity1 := h.CreateIdentity(seed.CreateIdentityRequest{
 		WorkspaceID: workspace.ID,
 		ExternalID:  identity1ExternalID,
-		Meta:        []byte(`{"role": "admin"}`),
+		Meta:        identity1Meta,
 	})
 
 	identity2ExternalID := "test_user_2"
+	identity2Meta, err := json.Marshal(map[string]string{"role": "user"})
+	require.NoError(t, err)
 	identity2 := h.CreateIdentity(seed.CreateIdentityRequest{
 		WorkspaceID: workspace.ID,
 		ExternalID:  identity2ExternalID,
-		Meta:        []byte(`{"role": "user"}`),
+		Meta:        identity2Meta,
 	})
 
 	// Create test keys with various configurations
@@ -85,34 +90,40 @@ func TestSuccess(t *testing.T) {
 	encryptedKeys := make(map[string]string) // keyID -> plaintext
 
 	// Key 1: identity1, production metadata
+	key1Meta, err := json.Marshal(map[string]string{"env": "production", "team": "backend"})
+	require.NoError(t, err)
 	key1 := h.CreateKey(seed.CreateKeyRequest{
 		WorkspaceID: workspace.ID,
 		KeySpaceID:  keySpaceID,
 		Name:        ptr.P("Test Key 1"),
 		IdentityID:  ptr.P(identity1.ID),
-		Meta:        ptr.P(`{"env": "production", "team": "backend"}`),
+		Meta:        ptr.P(string(key1Meta)),
 		Recoverable: true,
 	})
 	encryptedKeys[key1.KeyID] = key1.Key
 
 	// Key 2: identity1, staging metadata
+	key2Meta, err := json.Marshal(map[string]string{"env": "staging"})
+	require.NoError(t, err)
 	key2 := h.CreateKey(seed.CreateKeyRequest{
 		WorkspaceID: workspace.ID,
 		KeySpaceID:  keySpaceID,
 		Name:        ptr.P("Test Key 2"),
 		IdentityID:  ptr.P(identity1.ID),
-		Meta:        ptr.P(`{"env": "staging"}`),
+		Meta:        ptr.P(string(key2Meta)),
 		Recoverable: true,
 	})
 	encryptedKeys[key2.KeyID] = key2.Key
 
 	// Key 3: identity2, development metadata
+	key3Meta, err := json.Marshal(map[string]string{"env": "development"})
+	require.NoError(t, err)
 	key3 := h.CreateKey(seed.CreateKeyRequest{
 		WorkspaceID: workspace.ID,
 		KeySpaceID:  keySpaceID,
 		Name:        ptr.P("Test Key 3"),
 		IdentityID:  ptr.P(identity2.ID),
-		Meta:        ptr.P(`{"env": "development"}`),
+		Meta:        ptr.P(string(key3Meta)),
 		Recoverable: true,
 	})
 	encryptedKeys[key3.KeyID] = key3.Key

--- a/svc/api/routes/v2_environments_get_environment/200_test.go
+++ b/svc/api/routes/v2_environments_get_environment/200_test.go
@@ -202,27 +202,26 @@ func TestGetEnvironment(t *testing.T) {
 				Description: "Autoscaling replicas",
 			})
 
-			require.NoError(t, db.Query.UpsertAppRegionalSettings(ctx, h.DB.RW(), db.UpsertAppRegionalSettingsParams{
-				WorkspaceID:   workspace.ID,
-				AppID:         app.ID,
-				EnvironmentID: environment.ID,
-				RegionID:      regionID,
-				Replicas:      2,
-				CreatedAt:     now,
-				UpdatedAt:     sql.NullInt64{Valid: false},
+			policyID := uid.New(uid.AutoscalingPolicyPrefix)
+			require.NoError(t, db.Query.InsertHorizontalAutoscalingPolicy(ctx, h.DB.RW(), db.InsertHorizontalAutoscalingPolicyParams{
+				ID:           policyID,
+				WorkspaceID:  workspace.ID,
+				ReplicasMin:  1,
+				ReplicasMax:  5,
+				CpuThreshold: sql.NullInt16{Int16: 80, Valid: true},
+				CreatedAt:    now,
 			}))
 
-			// No typed query for autoscaling policies on this branch; insert raw and
-			// point the regional setting at it.
-			policyID := uid.New("hap")
-			_, err := h.DB.RW().ExecContext(ctx,
-				"INSERT INTO horizontal_autoscaling_policies (id, workspace_id, replicas_min, replicas_max, cpu_threshold, memory_threshold, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
-				policyID, workspace.ID, 1, 5, 80, 80, now)
-			require.NoError(t, err)
-			_, err = h.DB.RW().ExecContext(ctx,
-				"UPDATE app_regional_settings SET horizontal_autoscaling_policy_id = ? WHERE app_id = ? AND environment_id = ? AND region_id = ?",
-				policyID, app.ID, environment.ID, regionID)
-			require.NoError(t, err)
+			require.NoError(t, db.Query.UpsertAppRegionalSettings(ctx, h.DB.RW(), db.UpsertAppRegionalSettingsParams{
+				WorkspaceID:                   workspace.ID,
+				AppID:                         app.ID,
+				EnvironmentID:                 environment.ID,
+				RegionID:                      regionID,
+				Replicas:                      2,
+				HorizontalAutoscalingPolicyID: sql.NullString{String: policyID, Valid: true},
+				CreatedAt:                     now,
+				UpdatedAt:                     sql.NullInt64{Valid: false},
+			}))
 
 			res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{
 				Project:     project.ID,

--- a/svc/api/routes/v2_environments_list_environment_variables/helpers_test.go
+++ b/svc/api/routes/v2_environments_list_environment_variables/helpers_test.go
@@ -2,6 +2,7 @@ package handler_test
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"net/http"
 	"strings"
@@ -93,14 +94,17 @@ func seedVar(t *testing.T, h *testutil.Harness, env seededEnv, key, value string
 	item, ok := encrypted.GetItems()[id]
 	require.True(t, ok)
 
-	var desc any
-	if description != "" {
-		desc = description
-	}
-	_, err = h.DB.RW().ExecContext(ctx,
-		"INSERT INTO app_environment_variables (id, workspace_id, app_id, environment_id, `key`, value, `type`, description, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-		id, env.workspaceID, env.appID, env.environmentID, key, item.GetEncrypted(), varType, desc, 1)
-	require.NoError(t, err)
+	require.NoError(t, db.Query.InsertAppEnvironmentVariable(ctx, h.DB.RW(), db.InsertAppEnvironmentVariableParams{
+		ID:            id,
+		WorkspaceID:   env.workspaceID,
+		AppID:         env.appID,
+		EnvironmentID: env.environmentID,
+		EnvKey:        key,
+		Value:         item.GetEncrypted(),
+		Type:          varType,
+		Description:   sql.NullString{String: description, Valid: description != ""},
+		CreatedAt:     1,
+	}))
 }
 
 func authHeaders(rootKey string) http.Header {

--- a/svc/api/routes/v2_environments_set_environment_variables/200_test.go
+++ b/svc/api/routes/v2_environments_set_environment_variables/200_test.go
@@ -47,7 +47,7 @@ func TestSetEnvironmentVariablesSuccessfully(t *testing.T) {
 			{Key: "LOG_LEVEL", Value: "debug", Kind: ptr(openapi.Recoverable), Description: ptr("verbosity")},
 		}))
 
-		raw := listRawVars(t, h, env.environmentID)
+		raw := listRawVars(t, h, env)
 		require.Len(t, raw, 2)
 
 		require.Equal(t, db.AppEnvironmentVariablesTypeWriteonly, raw["DATABASE_URL"].varType)
@@ -64,7 +64,7 @@ func TestSetEnvironmentVariablesSuccessfully(t *testing.T) {
 			{Key: "PLAIN", Value: "v"},
 		}))
 
-		raw := listRawVars(t, h, env.environmentID)
+		raw := listRawVars(t, h, env)
 		require.Equal(t, db.AppEnvironmentVariablesTypeWriteonly, raw["PLAIN"].varType)
 	})
 
@@ -77,7 +77,7 @@ func TestSetEnvironmentVariablesSuccessfully(t *testing.T) {
 			{Key: "KEEP_ONE", Value: "updated", Kind: ptr(openapi.Recoverable)},
 		}))
 
-		raw := listRawVars(t, h, env.environmentID)
+		raw := listRawVars(t, h, env)
 		require.Len(t, raw, 2)
 		require.Equal(t, "updated", decrypt(t, env.environmentID, raw["KEEP_ONE"].value))
 		_, ok := raw["KEEP_TWO"]
@@ -92,7 +92,7 @@ func TestSetEnvironmentVariablesSuccessfully(t *testing.T) {
 			{Key: "NEW_ONE", Value: "z"},
 		}))
 
-		raw := listRawVars(t, h, env.environmentID)
+		raw := listRawVars(t, h, env)
 		require.Len(t, raw, 2)
 		_, hasExisting := raw["EXISTING"]
 		_, hasNew := raw["NEW_ONE"]
@@ -108,7 +108,7 @@ func TestSetEnvironmentVariablesSuccessfully(t *testing.T) {
 			{Key: "API_KEY", Value: "new"},
 		}))
 
-		raw := listRawVars(t, h, env.environmentID)
+		raw := listRawVars(t, h, env)
 		require.Len(t, raw, 1)
 		require.Equal(t, "new", decrypt(t, env.environmentID, raw["API_KEY"].value))
 	})
@@ -121,7 +121,7 @@ func TestSetEnvironmentVariablesSuccessfully(t *testing.T) {
 			{Key: "SECRET", Value: "rotated"},
 		}))
 
-		raw := listRawVars(t, h, env.environmentID)
+		raw := listRawVars(t, h, env)
 		require.Len(t, raw, 1)
 		require.Equal(t, "rotated", decrypt(t, env.environmentID, raw["SECRET"].value))
 		// Nothing merged: kind defaults to writeonly and description is cleared.
@@ -140,7 +140,7 @@ func TestSetEnvironmentVariablesSuccessfully(t *testing.T) {
 		req.Prune = ptr(true)
 		call(t, req)
 
-		raw := listRawVars(t, h, env.environmentID)
+		raw := listRawVars(t, h, env)
 		require.Len(t, raw, 1)
 		_, ok := raw["NEW_ONE"]
 		require.True(t, ok)
@@ -157,7 +157,7 @@ func TestSetEnvironmentVariablesSuccessfully(t *testing.T) {
 		req.Prune = ptr(true)
 		call(t, req)
 
-		raw := listRawVars(t, h, env.environmentID)
+		raw := listRawVars(t, h, env)
 		require.Len(t, raw, 1)
 		require.Equal(t, "new", decrypt(t, env.environmentID, raw["KEEP"].value))
 		_, gone := raw["GONE"]
@@ -178,7 +178,7 @@ func TestSetEnvironmentVariablesSuccessfully(t *testing.T) {
 		req.Prune = ptr(true)
 		call(t, req)
 
-		raw := listRawVars(t, h, env.environmentID)
+		raw := listRawVars(t, h, env)
 		require.Empty(t, raw)
 
 		// The wipe has no keys to log per-var, so it emits one summary event.
@@ -195,7 +195,7 @@ func TestSetEnvironmentVariablesSuccessfully(t *testing.T) {
 
 		call(t, makeRequest(env, []openapi.EnvironmentVariableInput{}))
 
-		raw := listRawVars(t, h, env.environmentID)
+		raw := listRawVars(t, h, env)
 		require.Len(t, raw, 2, "an empty payload without prune must not touch existing vars")
 	})
 
@@ -243,7 +243,7 @@ func TestSetEnvironmentVariablesSuccessfully(t *testing.T) {
 			{Key: "BIG_BLOB", Value: atCap, Kind: ptr(openapi.Recoverable)},
 		}))
 
-		raw := listRawVars(t, h, env.environmentID)
+		raw := listRawVars(t, h, env)
 		require.Len(t, raw, 2)
 		require.Equal(t, pem, decrypt(t, env.environmentID, raw["TLS_KEY"].value))
 		require.Equal(t, atCap, decrypt(t, env.environmentID, raw["BIG_BLOB"].value))

--- a/svc/api/routes/v2_environments_set_environment_variables/helpers_test.go
+++ b/svc/api/routes/v2_environments_set_environment_variables/helpers_test.go
@@ -2,6 +2,7 @@ package handler_test
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"net/http"
 	"strings"
@@ -81,22 +82,24 @@ type rawVar struct {
 	description string
 }
 
-func listRawVars(t *testing.T, h *testutil.Harness, environmentID string) map[string]rawVar {
+func listRawVars(t *testing.T, h *testutil.Harness, env seededEnv) map[string]rawVar {
 	t.Helper()
-	rows, err := h.DB.RO().QueryContext(context.Background(),
-		"SELECT `key`, value, `type`, COALESCE(description, '') FROM app_environment_variables WHERE environment_id = ?",
-		environmentID)
+	rows, err := db.Query.ListAppEnvVarsByAppAndEnv(context.Background(), h.DB.RO(), db.ListAppEnvVarsByAppAndEnvParams{
+		AppID:         env.appID,
+		EnvironmentID: env.environmentID,
+		IDCursor:      "",
+		Limit:         100,
+	})
 	require.NoError(t, err)
-	defer func() { _ = rows.Close() }()
 
 	out := make(map[string]rawVar)
-	for rows.Next() {
-		var key string
-		var v rawVar
-		require.NoError(t, rows.Scan(&key, &v.value, &v.varType, &v.description))
-		out[key] = v
+	for _, row := range rows {
+		out[row.Key] = rawVar{
+			value:       row.Value,
+			varType:     row.Type,
+			description: row.Description.String,
+		}
 	}
-	require.NoError(t, rows.Err())
 	return out
 }
 
@@ -110,14 +113,17 @@ func seedVar(t *testing.T, h *testutil.Harness, env seededEnv, key, value string
 // seedVarFull is seedVar with an explicit description (empty string stored as NULL).
 func seedVarFull(t *testing.T, h *testutil.Harness, env seededEnv, key, value string, varType db.AppEnvironmentVariablesType, description string) {
 	t.Helper()
-	var desc any
-	if description != "" {
-		desc = description
-	}
-	_, err := h.DB.RW().ExecContext(context.Background(),
-		"INSERT INTO app_environment_variables (id, workspace_id, app_id, environment_id, `key`, value, `type`, description, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-		uid.New(uid.EnvironmentVariablePrefix), env.workspaceID, env.appID, env.environmentID, key, value, varType, desc, 1)
-	require.NoError(t, err)
+	require.NoError(t, db.Query.InsertAppEnvironmentVariable(context.Background(), h.DB.RW(), db.InsertAppEnvironmentVariableParams{
+		ID:            uid.New(uid.EnvironmentVariablePrefix),
+		WorkspaceID:   env.workspaceID,
+		AppID:         env.appID,
+		EnvironmentID: env.environmentID,
+		EnvKey:        key,
+		Value:         value,
+		Type:          varType,
+		Description:   sql.NullString{String: description, Valid: description != ""},
+		CreatedAt:     1,
+	}))
 }
 
 func authHeaders(rootKey string) http.Header {

--- a/svc/api/routes/v2_gateway_list_policies/200_test.go
+++ b/svc/api/routes/v2_gateway_list_policies/200_test.go
@@ -5,12 +5,16 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	frontlinev1 "github.com/unkeyed/unkey/gen/proto/frontline/v1"
+	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/ptr"
+	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_gateway_list_policies"
 	setpolicies "github.com/unkeyed/unkey/svc/api/routes/v2_gateway_set_policies"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestListPoliciesSuccessfully(t *testing.T) {
@@ -42,17 +46,14 @@ func TestListPoliciesSuccessfully(t *testing.T) {
 
 	t.Run("explicit empty policies blob returns empty list", func(t *testing.T) {
 		env := seedEnvironment(t, h)
-		seedPolicyConfig(t, h, env, `{"policies":[]}`)
+		seedEmptySentinelConfig(t, h, env)
 		res := call(t, makeRequest(env))
 		require.Empty(t, res.Body.Data)
 	})
 
 	t.Run("missing runtime settings row returns empty list", func(t *testing.T) {
 		env := seedEnvironment(t, h)
-		_, err := h.DB.RW().ExecContext(context.Background(),
-			"DELETE FROM app_runtime_settings WHERE app_id = ? AND environment_id = ?",
-			env.appID, env.environmentID)
-		require.NoError(t, err)
+		require.NoError(t, db.Query.DeleteAppRuntimeSettingsByEnvironmentId(context.Background(), h.DB.RW(), env.environmentID))
 
 		res := call(t, makeRequest(env))
 		require.Empty(t, res.Body.Data)
@@ -60,42 +61,88 @@ func TestListPoliciesSuccessfully(t *testing.T) {
 
 	t.Run("all variants round out of storage with full fidelity", func(t *testing.T) {
 		env := seedEnvironment(t, h)
+		keyauthPolicyID := uid.New(uid.PolicyPrefix)
+		ratelimitPolicyID := uid.New(uid.PolicyPrefix)
+		firewallPolicyID := uid.New(uid.PolicyPrefix)
+		openapiPolicyID := uid.New(uid.PolicyPrefix)
+		keySpaceID := uid.New(uid.KeySpacePrefix)
 		// protojson wire shape, including int64-as-string, exactly as the
 		// write path stores it.
-		seedPolicyConfig(t, h, env, `{"policies":[
-			{"id":"pol_keyauth","name":"keyauth KEBAP","enabled":true,
-				"match":[
-					{"path":{"path":{"prefix":"/internal/","ignoreCase":true}}},
-					{"method":{"methods":["GET","POST"]}},
-					{"header":{"name":"X-Debug","present":true}},
-					{"queryParam":{"name":"v","value":{"exact":"1"}}}
-				],
-				"keyauth":{
-					"keySpaceIds":["ks_kebap"],
-					"locations":[{"bearer":{}},{"header":{"name":"X-Api-Key","stripPrefix":"Key "}},{"queryParam":{"name":"api_key"}}],
-					"permissionQuery":"documents.read",
-					"ratelimits":[{"name":"tokens"},{"name":"burst","limit":"100","duration":"60000","cost":"2"}]
+		seedSentinelConfig(t, h, env, &frontlinev1.Config{Policies: []*frontlinev1.Policy{
+			{
+				Id:      keyauthPolicyID,
+				Name:    "keyauth KEBAP",
+				Enabled: proto.Bool(true),
+				Match: []*frontlinev1.MatchExpr{
+					{Expr: &frontlinev1.MatchExpr_Path{Path: &frontlinev1.PathMatch{Path: &frontlinev1.StringMatch{
+						IgnoreCase: true,
+						Match:      &frontlinev1.StringMatch_Prefix{Prefix: "/internal/"},
+					}}}},
+					{Expr: &frontlinev1.MatchExpr_Method{Method: &frontlinev1.MethodMatch{Methods: []string{"GET", "POST"}}}},
+					{Expr: &frontlinev1.MatchExpr_Header{Header: &frontlinev1.HeaderMatch{
+						Name:  "X-Debug",
+						Match: &frontlinev1.HeaderMatch_Present{Present: true},
+					}}},
+					{Expr: &frontlinev1.MatchExpr_QueryParam{QueryParam: &frontlinev1.QueryParamMatch{
+						Name: "v",
+						Match: &frontlinev1.QueryParamMatch_Value{Value: &frontlinev1.StringMatch{
+							Match: &frontlinev1.StringMatch_Exact{Exact: "1"},
+						}},
+					}}},
+				},
+				Config: &frontlinev1.Policy_Keyauth{Keyauth: &frontlinev1.KeyAuth{
+					KeySpaceIds: []string{keySpaceID},
+					Locations: []*frontlinev1.KeyLocation{
+						{Location: &frontlinev1.KeyLocation_Bearer{Bearer: &frontlinev1.BearerTokenLocation{}}},
+						{Location: &frontlinev1.KeyLocation_Header{Header: &frontlinev1.HeaderKeyLocation{Name: "X-Api-Key", StripPrefix: "Key "}}},
+						{Location: &frontlinev1.KeyLocation_QueryParam{QueryParam: &frontlinev1.QueryParamKeyLocation{Name: "api_key"}}},
+					},
+					PermissionQuery: proto.String("documents.read"),
+					Ratelimits: []*frontlinev1.KeyRatelimit{
+						{Name: "tokens"},
+						{Name: "burst", Limit: proto.Int64(100), Duration: proto.Int64(60_000), Cost: proto.Int64(2)},
+					},
 				}},
-			{"id":"pol_ratelimit","name":"ratelimit","enabled":true,
-				"ratelimit":{"limit":"100","windowMs":"60000","identifier":{"principalField":{"path":"sub"}}}},
-			{"id":"pol_firewall","name":"firewall","enabled":false,
-				"firewall":{"action":"ACTION_DENY"}},
-			{"id":"pol_openapi","name":"openapi",
-				"openapi":{}}
-		]}`)
+			},
+			{
+				Id:      ratelimitPolicyID,
+				Name:    "ratelimit",
+				Enabled: proto.Bool(true),
+				Config: &frontlinev1.Policy_Ratelimit{Ratelimit: &frontlinev1.RateLimit{
+					Limit:    100,
+					WindowMs: 60_000,
+					Identifier: &frontlinev1.RateLimitIdentifier{Source: &frontlinev1.RateLimitIdentifier_PrincipalField{
+						PrincipalField: &frontlinev1.PrincipalFieldKey{Path: "sub"},
+					}},
+				}},
+			},
+			{
+				Id:      firewallPolicyID,
+				Name:    "firewall",
+				Enabled: proto.Bool(false),
+				Config: &frontlinev1.Policy_Firewall{Firewall: &frontlinev1.Firewall{
+					Action: frontlinev1.Action_ACTION_DENY,
+				}},
+			},
+			{
+				Id:     openapiPolicyID,
+				Name:   "openapi",
+				Config: &frontlinev1.Policy_Openapi{Openapi: &frontlinev1.OpenApiRequestValidation{}},
+			},
+		}})
 
 		res := call(t, makeRequest(env))
 		require.Len(t, res.Body.Data, 4)
 
 		keyauth := res.Body.Data[0]
-		require.Equal(t, "pol_keyauth", keyauth.Id)
+		require.Equal(t, keyauthPolicyID, keyauth.Id)
 		require.Equal(t, "keyauth KEBAP", keyauth.Name)
 		require.True(t, keyauth.Enabled)
 		require.NotNil(t, keyauth.Keyauth)
 		require.Nil(t, keyauth.Ratelimit)
 		require.Nil(t, keyauth.Firewall)
 		require.Nil(t, keyauth.Openapi)
-		require.Equal(t, []string{"ks_kebap"}, keyauth.Keyauth.Keyspaces)
+		require.Equal(t, []string{keySpaceID}, keyauth.Keyauth.Keyspaces)
 		require.Equal(t, ptr.P("documents.read"), keyauth.Keyauth.PermissionQuery)
 
 		locations := ptr.SafeDeref(keyauth.Keyauth.Locations)
@@ -136,7 +183,7 @@ func TestListPoliciesSuccessfully(t *testing.T) {
 		require.Nil(t, match[3].QueryParam.Value.IgnoreCase)
 
 		ratelimit := res.Body.Data[1]
-		require.Equal(t, "pol_ratelimit", ratelimit.Id)
+		require.Equal(t, ratelimitPolicyID, ratelimit.Id)
 		require.NotNil(t, ratelimit.Ratelimit)
 		require.Equal(t, int64(100), ratelimit.Ratelimit.Limit)
 		require.Equal(t, int64(60000), ratelimit.Ratelimit.WindowMs)
@@ -149,14 +196,14 @@ func TestListPoliciesSuccessfully(t *testing.T) {
 		require.Equal(t, "sub", identifiers[0].PrincipalField.Path)
 
 		firewall := res.Body.Data[2]
-		require.Equal(t, "pol_firewall", firewall.Id)
+		require.Equal(t, firewallPolicyID, firewall.Id)
 		require.False(t, firewall.Enabled)
 		require.NotNil(t, firewall.Firewall)
 		require.Equal(t, openapi.FirewallPolicyAction("ACTION_DENY"), firewall.Firewall.Action)
 		require.Nil(t, firewall.Match)
 
 		oa := res.Body.Data[3]
-		require.Equal(t, "pol_openapi", oa.Id)
+		require.Equal(t, openapiPolicyID, oa.Id)
 		// enabled was absent in the blob: proto optional bool defaults to
 		// false, matching frontline evaluation semantics.
 		require.False(t, oa.Enabled)
@@ -165,12 +212,26 @@ func TestListPoliciesSuccessfully(t *testing.T) {
 
 	t.Run("every ratelimit identifier source maps", func(t *testing.T) {
 		env := seedEnvironment(t, h)
-		seedPolicyConfig(t, h, env, `{"policies":[
-			{"id":"pol_ip","name":"ip","enabled":true,"ratelimit":{"limit":"1","windowMs":"1000","identifier":{"remoteIp":{}}}},
-			{"id":"pol_hdr","name":"hdr","enabled":true,"ratelimit":{"limit":"1","windowMs":"1000","identifier":{"header":{"name":"X-Tenant"}}}},
-			{"id":"pol_sub","name":"sub","enabled":true,"ratelimit":{"limit":"1","windowMs":"1000","identifier":{"authenticatedSubject":{}}}},
-			{"id":"pol_path","name":"path","enabled":true,"ratelimit":{"limit":"1","windowMs":"1000","identifier":{"path":{}}}}
-		]}`)
+		identifiers := []*frontlinev1.RateLimitIdentifier{
+			{Source: &frontlinev1.RateLimitIdentifier_RemoteIp{RemoteIp: &frontlinev1.RemoteIpKey{}}},
+			{Source: &frontlinev1.RateLimitIdentifier_Header{Header: &frontlinev1.HeaderKey{Name: "X-Tenant"}}},
+			{Source: &frontlinev1.RateLimitIdentifier_AuthenticatedSubject{AuthenticatedSubject: &frontlinev1.AuthenticatedSubjectKey{}}},
+			{Source: &frontlinev1.RateLimitIdentifier_Path{Path: &frontlinev1.PathKey{}}},
+		}
+		policies := make([]*frontlinev1.Policy, 0, len(identifiers))
+		for i, name := range []string{"ip", "hdr", "sub", "path"} {
+			policies = append(policies, &frontlinev1.Policy{
+				Id:      uid.New(uid.PolicyPrefix),
+				Name:    name,
+				Enabled: proto.Bool(true),
+				Config: &frontlinev1.Policy_Ratelimit{Ratelimit: &frontlinev1.RateLimit{
+					Limit:      1,
+					WindowMs:   1_000,
+					Identifier: identifiers[i],
+				}},
+			})
+		}
+		seedSentinelConfig(t, h, env, &frontlinev1.Config{Policies: policies})
 
 		res := call(t, makeRequest(env))
 		require.Len(t, res.Body.Data, 4)

--- a/svc/api/routes/v2_gateway_list_policies/helpers_test.go
+++ b/svc/api/routes/v2_gateway_list_policies/helpers_test.go
@@ -2,17 +2,23 @@ package handler_test
 
 import (
 	"context"
+	"database/sql"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	frontlinev1 "github.com/unkeyed/unkey/gen/proto/frontline/v1"
+	"github.com/unkeyed/unkey/pkg/db"
 	mysqltype "github.com/unkeyed/unkey/pkg/mysql/types"
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_gateway_list_policies"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 )
 
 func makeRequest(env seededEnv) handler.Request {
@@ -69,40 +75,66 @@ func seedEnvironment(t *testing.T, h *testutil.Harness) seededEnv {
 	}
 }
 
-// seedPolicyConfig overwrites the seeded runtime settings row's policy blob
+// seedSentinelConfig overwrites the seeded runtime settings row's policy blob
 // directly, bypassing the write handler, so tests can set up pre-existing
 // state including shapes the API cannot create. The environment seeder
 // always creates the row (with the legacy "{}" blob).
-func seedPolicyConfig(t *testing.T, h *testutil.Harness, env seededEnv, blob string) {
+func seedSentinelConfig(t *testing.T, h *testutil.Harness, env seededEnv, config *frontlinev1.Config) {
 	t.Helper()
-	_, err := h.DB.RW().ExecContext(context.Background(),
-		"UPDATE app_runtime_settings SET sentinel_config = ? WHERE app_id = ? AND environment_id = ?",
-		blob, env.appID, env.environmentID)
+	blob, err := protojson.Marshal(config)
 	require.NoError(t, err)
-
-	// MySQL reports 0 affected rows when the value is unchanged, so verify by
-	// reading back instead.
-	var stored []byte
-	err = h.DB.RO().QueryRowContext(context.Background(),
-		"SELECT sentinel_config FROM app_runtime_settings WHERE app_id = ? AND environment_id = ?",
-		env.appID, env.environmentID).Scan(&stored)
-	require.NoError(t, err)
-	require.Equal(t, blob, string(stored))
+	seedSentinelConfigBlob(t, h, env, blob)
 }
 
-// seedFirewallPolicies stores n firewall policies with deterministic ids
-// pol_000, pol_001, ... and returns those ids in stored order.
+func seedEmptySentinelConfig(t *testing.T, h *testutil.Harness, env seededEnv) {
+	t.Helper()
+	blob, err := json.Marshal(struct {
+		Policies []*frontlinev1.Policy `json:"policies"`
+	}{Policies: []*frontlinev1.Policy{}})
+	require.NoError(t, err)
+	seedSentinelConfigBlob(t, h, env, blob)
+}
+
+func seedSentinelConfigBlob(t *testing.T, h *testutil.Harness, env seededEnv, blob []byte) {
+	t.Helper()
+	ctx := context.Background()
+	now := h.Clock.Now().UnixMilli()
+	require.NoError(t, db.Query.UpsertAppRuntimeSettingsPolicyConfig(ctx, h.DB.RW(), db.UpsertAppRuntimeSettingsPolicyConfigParams{
+		WorkspaceID:    env.workspaceID,
+		AppID:          env.appID,
+		EnvironmentID:  env.environmentID,
+		SentinelConfig: blob,
+		CreatedAt:      now,
+		UpdatedAt:      sql.NullInt64{Int64: now, Valid: true},
+	}))
+
+	stored, err := db.Query.FindAppRuntimeSettingsByAppAndEnv(ctx, h.DB.RO(), db.FindAppRuntimeSettingsByAppAndEnvParams{
+		AppID:         env.appID,
+		EnvironmentID: env.environmentID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, blob, stored.AppRuntimeSetting.SentinelConfig)
+}
+
+// seedFirewallPolicies stores n firewall policies and returns their ids in
+// stored order.
 func seedFirewallPolicies(t *testing.T, h *testutil.Harness, env seededEnv, n int) []string {
 	t.Helper()
 	ids := make([]string, 0, n)
-	docs := make([]string, 0, n)
+	policies := make([]*frontlinev1.Policy, 0, n)
 	for i := range n {
-		id := fmt.Sprintf("pol_%03d", i)
+		id := uid.New(uid.PolicyPrefix)
 		ids = append(ids, id)
-		docs = append(docs, fmt.Sprintf(
-			`{"id":%q,"name":"KEBAP %d","enabled":true,"firewall":{"action":"ACTION_DENY"}}`, id, i))
+		policies = append(policies, &frontlinev1.Policy{
+			Id:      id,
+			Name:    fmt.Sprintf("KEBAP %d", i),
+			Enabled: proto.Bool(true),
+			Config: &frontlinev1.Policy_Firewall{Firewall: &frontlinev1.Firewall{
+				Action: frontlinev1.Action_ACTION_DENY,
+			}},
+		})
 	}
-	seedPolicyConfig(t, h, env, fmt.Sprintf(`{"policies":[%s]}`, strings.Join(docs, ",")))
+	seedSentinelConfig(t, h, env, &frontlinev1.Config{Policies: policies})
 	return ids
 }
 

--- a/svc/api/routes/v2_gateway_set_policies/200_test.go
+++ b/svc/api/routes/v2_gateway_set_policies/200_test.go
@@ -11,11 +11,13 @@ import (
 	"github.com/stretchr/testify/require"
 	frontlinev1 "github.com/unkeyed/unkey/gen/proto/frontline/v1"
 	"github.com/unkeyed/unkey/pkg/ptr"
+	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_gateway_set_policies"
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestSetPoliciesSuccessfully(t *testing.T) {
@@ -133,15 +135,20 @@ func TestSetPoliciesSuccessfully(t *testing.T) {
 
 	t.Run("set replaces stored policies including variants this API cannot create", func(t *testing.T) {
 		env := seedEnvironment(t, h)
-		jwtauth := `{"id":"pol_jwt","name":"legacy jwt","enabled":true,"jwtauth":{}}`
-		seedPolicyConfig(t, h, env, fmt.Sprintf(`{"policies":[%s]}`, jwtauth))
+		legacyPolicyID := uid.New(uid.PolicyPrefix)
+		seedSentinelConfig(t, h, env, &frontlinev1.Config{Policies: []*frontlinev1.Policy{{
+			Id:      legacyPolicyID,
+			Name:    "legacy jwt",
+			Enabled: proto.Bool(true),
+			Config:  &frontlinev1.Policy_Jwtauth{Jwtauth: &frontlinev1.JWTAuth{}},
+		}}})
 
 		call(t, makeRequest(env, []openapi.Policy{firewallPolicy("deny", true)}))
 
 		stored := readStoredPolicies(t, h, env)
 		require.Len(t, stored, 1)
 		require.Contains(t, string(stored[0]), `"name":"deny"`)
-		require.NotContains(t, readStoredBlob(t, h, env), "pol_jwt")
+		require.NotContains(t, readStoredBlob(t, h, env), legacyPolicyID)
 	})
 
 	t.Run("second set replaces the first and regenerates ids", func(t *testing.T) {

--- a/svc/api/routes/v2_gateway_set_policies/400_test.go
+++ b/svc/api/routes/v2_gateway_set_policies/400_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/unkeyed/unkey/pkg/ptr"
+	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
 	"github.com/unkeyed/unkey/svc/api/openapi"
@@ -113,7 +114,7 @@ func TestSetPoliciesBadRequest(t *testing.T) {
 
 	t.Run("client-supplied id is rejected by the schema", func(t *testing.T) {
 		res := rawPolicy(t, map[string]any{
-			"name": "with id", "enabled": true, "id": "pol_client",
+			"name": "with id", "enabled": true, "id": uid.New(uid.PolicyPrefix),
 			"firewall": map[string]any{"action": "ACTION_DENY"},
 		})
 		require.Equal(t, http.StatusBadRequest, res.Status, "received: %s", res.RawBody)

--- a/svc/api/routes/v2_gateway_set_policies/helpers_test.go
+++ b/svc/api/routes/v2_gateway_set_policies/helpers_test.go
@@ -2,6 +2,7 @@ package handler_test
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -9,12 +10,15 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	frontlinev1 "github.com/unkeyed/unkey/gen/proto/frontline/v1"
+	"github.com/unkeyed/unkey/pkg/db"
 	mysqltype "github.com/unkeyed/unkey/pkg/mysql/types"
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_gateway_set_policies"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 func makeRequest(env seededEnv, policies []openapi.Policy) handler.Request {
@@ -80,31 +84,37 @@ func seedEnvironment(t *testing.T, h *testutil.Harness) seededEnv {
 	}
 }
 
-// seedPolicyConfig overwrites the seeded runtime settings row's policy blob
+// seedSentinelConfig overwrites the seeded runtime settings row's policy blob
 // directly, bypassing the handler, so tests can set up pre-existing state
 // including policy variants the API cannot create. The environment seeder
 // always creates the row (with the legacy "{}" blob).
-func seedPolicyConfig(t *testing.T, h *testutil.Harness, env seededEnv, blob string) {
+func seedSentinelConfig(t *testing.T, h *testutil.Harness, env seededEnv, config *frontlinev1.Config) {
 	t.Helper()
-	_, err := h.DB.RW().ExecContext(context.Background(),
-		"UPDATE app_runtime_settings SET sentinel_config = ? WHERE app_id = ? AND environment_id = ?",
-		blob, env.appID, env.environmentID)
+	blob, err := protojson.Marshal(config)
 	require.NoError(t, err)
+	ctx := context.Background()
+	now := h.Clock.Now().UnixMilli()
+	require.NoError(t, db.Query.UpsertAppRuntimeSettingsPolicyConfig(ctx, h.DB.RW(), db.UpsertAppRuntimeSettingsPolicyConfigParams{
+		WorkspaceID:    env.workspaceID,
+		AppID:          env.appID,
+		EnvironmentID:  env.environmentID,
+		SentinelConfig: blob,
+		CreatedAt:      now,
+		UpdatedAt:      sql.NullInt64{Int64: now, Valid: true},
+	}))
 
-	// MySQL reports 0 affected rows when the value is unchanged, so verify by
-	// reading back instead.
-	require.Equal(t, blob, readStoredBlob(t, h, env))
+	require.Equal(t, string(blob), readStoredBlob(t, h, env))
 }
 
 // readStoredBlob returns the environment's raw sentinel_config bytes.
 func readStoredBlob(t *testing.T, h *testutil.Harness, env seededEnv) string {
 	t.Helper()
-	var blob []byte
-	err := h.DB.RO().QueryRowContext(context.Background(),
-		"SELECT sentinel_config FROM app_runtime_settings WHERE app_id = ? AND environment_id = ?",
-		env.appID, env.environmentID).Scan(&blob)
+	stored, err := db.Query.FindAppRuntimeSettingsByAppAndEnv(context.Background(), h.DB.RO(), db.FindAppRuntimeSettingsByAppAndEnvParams{
+		AppID:         env.appID,
+		EnvironmentID: env.environmentID,
+	})
 	require.NoError(t, err)
-	return string(blob)
+	return string(stored.AppRuntimeSetting.SentinelConfig)
 }
 
 // readStoredPolicies returns the raw policy documents currently stored for the

--- a/svc/api/routes/v2_gateway_update_policy/200_test.go
+++ b/svc/api/routes/v2_gateway_update_policy/200_test.go
@@ -5,12 +5,15 @@ import (
 
 	"github.com/oapi-codegen/nullable"
 	"github.com/stretchr/testify/require"
+	frontlinev1 "github.com/unkeyed/unkey/gen/proto/frontline/v1"
 	"github.com/unkeyed/unkey/pkg/ptr"
+	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 	listpolicies "github.com/unkeyed/unkey/svc/api/routes/v2_gateway_list_policies"
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_gateway_update_policy"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestUpdatePolicySuccessfully(t *testing.T) {
@@ -99,12 +102,18 @@ func TestUpdatePolicySuccessfully(t *testing.T) {
 
 	t.Run("null match clears expressions", func(t *testing.T) {
 		env := seedEnvironment(t, h)
-		seedPolicyConfig(t, h, env,
-			`{"policies":[{"id":"pol_kebap","name":"KEBAP","enabled":true,`+
-				`"match":[{"path":{"path":{"prefix":"/internal/"}}}],`+
-				`"firewall":{"action":"ACTION_DENY"}}]}`)
+		policyID := uid.New(uid.PolicyPrefix)
+		seedSentinelConfig(t, h, env, &frontlinev1.Config{Policies: []*frontlinev1.Policy{{
+			Id:      policyID,
+			Name:    "KEBAP",
+			Enabled: proto.Bool(true),
+			Match: []*frontlinev1.MatchExpr{{Expr: &frontlinev1.MatchExpr_Path{Path: &frontlinev1.PathMatch{
+				Path: &frontlinev1.StringMatch{Match: &frontlinev1.StringMatch_Prefix{Prefix: "/internal/"}},
+			}}}},
+			Config: &frontlinev1.Policy_Firewall{Firewall: &frontlinev1.Firewall{Action: frontlinev1.Action_ACTION_DENY}},
+		}}})
 
-		req := makeRequest(env, "pol_kebap")
+		req := makeRequest(env, policyID)
 		req.Match = nullable.NewNullNullable[[]openapi.MatchExpr]()
 		call(t, req)
 
@@ -116,18 +125,30 @@ func TestUpdatePolicySuccessfully(t *testing.T) {
 
 	t.Run("switch rule variant preserves id and match", func(t *testing.T) {
 		env := seedEnvironment(t, h)
-		seedPolicyConfig(t, h, env,
-			`{"policies":[{"id":"pol_kebap","name":"KEBAP","enabled":true,`+
-				`"match":[{"path":{"path":{"prefix":"/api/"}}}],`+
-				`"ratelimit":{"limit":"100","windowMs":"60000","identifier":{"remoteIp":{}}}}]}`)
+		policyID := uid.New(uid.PolicyPrefix)
+		seedSentinelConfig(t, h, env, &frontlinev1.Config{Policies: []*frontlinev1.Policy{{
+			Id:      policyID,
+			Name:    "KEBAP",
+			Enabled: proto.Bool(true),
+			Match: []*frontlinev1.MatchExpr{{Expr: &frontlinev1.MatchExpr_Path{Path: &frontlinev1.PathMatch{
+				Path: &frontlinev1.StringMatch{Match: &frontlinev1.StringMatch_Prefix{Prefix: "/api/"}},
+			}}}},
+			Config: &frontlinev1.Policy_Ratelimit{Ratelimit: &frontlinev1.RateLimit{
+				Limit:    100,
+				WindowMs: 60_000,
+				Identifier: &frontlinev1.RateLimitIdentifier{Source: &frontlinev1.RateLimitIdentifier_RemoteIp{
+					RemoteIp: &frontlinev1.RemoteIpKey{},
+				}},
+			}},
+		}}})
 
-		req := makeRequest(env, "pol_kebap")
+		req := makeRequest(env, policyID)
 		req.Firewall = &openapi.FirewallPolicy{Action: "ACTION_DENY"}
 		call(t, req)
 
 		policies := list(t, env)
 		require.Len(t, policies, 1)
-		require.Equal(t, "pol_kebap", policies[0].Id)
+		require.Equal(t, policyID, policies[0].Id)
 		require.NotNil(t, policies[0].Firewall)
 		require.Nil(t, policies[0].Ratelimit, "old rule must be gone")
 		require.Len(t, ptr.SafeDeref(policies[0].Match), 1)

--- a/svc/api/routes/v2_gateway_update_policy/400_test.go
+++ b/svc/api/routes/v2_gateway_update_policy/400_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/oapi-codegen/nullable"
 	"github.com/stretchr/testify/require"
 	"github.com/unkeyed/unkey/pkg/ptr"
+	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_gateway_update_policy"
@@ -65,7 +66,7 @@ func TestUpdatePolicyBadRequest(t *testing.T) {
 	t.Run("invalid permission query", func(t *testing.T) {
 		req := makeRequest(env, ids[0])
 		req.Keyauth = &openapi.KeyauthPolicy{
-			Keyspaces:       []string{"ks_kebap"},
+			Keyspaces:       []string{uid.New(uid.KeySpacePrefix)},
 			PermissionQuery: ptr.P("documents.read AND NOT other"),
 		}
 		res := callTyped(t, req)
@@ -75,7 +76,7 @@ func TestUpdatePolicyBadRequest(t *testing.T) {
 	t.Run("keyauth ratelimit limit without duration", func(t *testing.T) {
 		req := makeRequest(env, ids[0])
 		req.Keyauth = &openapi.KeyauthPolicy{
-			Keyspaces:  []string{"ks_kebap"},
+			Keyspaces:  []string{uid.New(uid.KeySpacePrefix)},
 			Ratelimits: ptr.P([]openapi.KeyRatelimit{{Name: "burst", Limit: ptr.P(int64(10))}}),
 		}
 		res := callTyped(t, req)

--- a/svc/api/routes/v2_gateway_update_policy/401_test.go
+++ b/svc/api/routes/v2_gateway_update_policy/401_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/unkeyed/unkey/pkg/ptr"
+	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_gateway_update_policy"
 )
@@ -22,10 +23,10 @@ func TestUpdatePolicyUnauthorized(t *testing.T) {
 	}
 	req := makeRequest(seededEnv{
 		workspaceID:   "",
-		projectID:     "payments",
-		appID:         "payments-api",
-		environmentID: "env_1234abcd",
-	}, "pol_000")
+		projectID:     uid.New(uid.ProjectPrefix),
+		appID:         uid.New(uid.AppPrefix),
+		environmentID: uid.New(uid.EnvironmentPrefix),
+	}, uid.New(uid.PolicyPrefix))
 	req.Name = ptr.P("KEBAP")
 	res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, req)
 	require.Equal(t, http.StatusUnauthorized, res.Status, "expected 401, received: %s", res.RawBody)

--- a/svc/api/routes/v2_gateway_update_policy/404_test.go
+++ b/svc/api/routes/v2_gateway_update_policy/404_test.go
@@ -6,11 +6,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	frontlinev1 "github.com/unkeyed/unkey/gen/proto/frontline/v1"
+	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/ptr"
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_gateway_update_policy"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestUpdatePolicyNotFound(t *testing.T) {
@@ -53,32 +56,36 @@ func TestUpdatePolicyNotFound(t *testing.T) {
 	})
 
 	t.Run("unknown policy id", func(t *testing.T) {
-		res := call(t, makeRequest(env, "pol_doesnotexist"))
+		res := call(t, makeRequest(env, uid.New(uid.PolicyPrefix)))
 		require.Contains(t, res.Body.Error.Type, "policy_not_found")
 		require.Contains(t, res.Body.Error.Detail, "policy ids change")
 	})
 
 	t.Run("policy id from another environment", func(t *testing.T) {
 		other := seedEnvironment(t, h)
-		seedPolicyConfig(t, h, other,
-			`{"policies":[{"id":"pol_foreign","name":"KEBAP","enabled":true,"firewall":{"action":"ACTION_DENY"}}]}`)
-		call(t, makeRequest(env, "pol_foreign"))
+		foreignPolicyID := uid.New(uid.PolicyPrefix)
+		seedSentinelConfig(t, h, other, &frontlinev1.Config{Policies: []*frontlinev1.Policy{{
+			Id:      foreignPolicyID,
+			Name:    "KEBAP",
+			Enabled: proto.Bool(true),
+			Config: &frontlinev1.Policy_Firewall{Firewall: &frontlinev1.Firewall{
+				Action: frontlinev1.Action_ACTION_DENY,
+			}},
+		}}})
+		call(t, makeRequest(env, foreignPolicyID))
 	})
 
 	t.Run("missing runtime settings row", func(t *testing.T) {
 		bare := seedEnvironment(t, h)
-		_, err := h.DB.RW().ExecContext(context.Background(),
-			"DELETE FROM app_runtime_settings WHERE app_id = ? AND environment_id = ?",
-			bare.appID, bare.environmentID)
-		require.NoError(t, err)
+		require.NoError(t, db.Query.DeleteAppRuntimeSettingsByEnvironmentId(context.Background(), h.DB.RW(), bare.environmentID))
 
-		res := call(t, makeRequest(bare, "pol_000"))
+		res := call(t, makeRequest(bare, uid.New(uid.PolicyPrefix)))
 		require.Contains(t, res.Body.Error.Type, "policy_not_found")
 	})
 
 	t.Run("unowned keyspace", func(t *testing.T) {
 		req := makeRequest(env, ids[0])
-		req.Keyauth = &openapi.KeyauthPolicy{Keyspaces: []string{"ks_kebap_unowned"}}
+		req.Keyauth = &openapi.KeyauthPolicy{Keyspaces: []string{uid.New(uid.KeySpacePrefix)}}
 		res := call(t, req)
 		require.Contains(t, res.Body.Error.Type, "key_space_not_found")
 	})

--- a/svc/api/routes/v2_gateway_update_policy/helpers_test.go
+++ b/svc/api/routes/v2_gateway_update_policy/helpers_test.go
@@ -2,17 +2,22 @@ package handler_test
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"net/http"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	frontlinev1 "github.com/unkeyed/unkey/gen/proto/frontline/v1"
+	"github.com/unkeyed/unkey/pkg/db"
 	mysqltype "github.com/unkeyed/unkey/pkg/mysql/types"
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_gateway_update_policy"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 )
 
 func makeRequest(env seededEnv, policyID string) handler.Request {
@@ -70,51 +75,63 @@ func seedEnvironment(t *testing.T, h *testutil.Harness) seededEnv {
 	}
 }
 
-// seedPolicyConfig overwrites the seeded runtime settings row's policy blob
+// seedSentinelConfig overwrites the seeded runtime settings row's policy blob
 // directly, bypassing the write handler, so tests can set up pre-existing
-// state with deterministic policy ids. The environment seeder always
+// state. The environment seeder always
 // creates the row (with the legacy "{}" blob).
-func seedPolicyConfig(t *testing.T, h *testutil.Harness, env seededEnv, blob string) {
+func seedSentinelConfig(t *testing.T, h *testutil.Harness, env seededEnv, config *frontlinev1.Config) {
 	t.Helper()
-	_, err := h.DB.RW().ExecContext(context.Background(),
-		"UPDATE app_runtime_settings SET sentinel_config = ? WHERE app_id = ? AND environment_id = ?",
-		blob, env.appID, env.environmentID)
+	blob, err := protojson.Marshal(config)
 	require.NoError(t, err)
+	ctx := context.Background()
+	now := h.Clock.Now().UnixMilli()
+	require.NoError(t, db.Query.UpsertAppRuntimeSettingsPolicyConfig(ctx, h.DB.RW(), db.UpsertAppRuntimeSettingsPolicyConfigParams{
+		WorkspaceID:    env.workspaceID,
+		AppID:          env.appID,
+		EnvironmentID:  env.environmentID,
+		SentinelConfig: blob,
+		CreatedAt:      now,
+		UpdatedAt:      sql.NullInt64{Int64: now, Valid: true},
+	}))
 
-	// MySQL reports 0 affected rows when the value is unchanged, so verify by
-	// reading back instead.
-	var stored []byte
-	err = h.DB.RO().QueryRowContext(context.Background(),
-		"SELECT sentinel_config FROM app_runtime_settings WHERE app_id = ? AND environment_id = ?",
-		env.appID, env.environmentID).Scan(&stored)
+	stored, err := db.Query.FindAppRuntimeSettingsByAppAndEnv(ctx, h.DB.RO(), db.FindAppRuntimeSettingsByAppAndEnvParams{
+		AppID:         env.appID,
+		EnvironmentID: env.environmentID,
+	})
 	require.NoError(t, err)
-	require.Equal(t, blob, string(stored))
+	require.Equal(t, blob, stored.AppRuntimeSetting.SentinelConfig)
 }
 
-// seedFirewallPolicies stores n firewall policies with deterministic ids
-// pol_000, pol_001, ... and returns those ids in stored order.
+// seedFirewallPolicies stores n firewall policies and returns their ids in
+// stored order.
 func seedFirewallPolicies(t *testing.T, h *testutil.Harness, env seededEnv, n int) []string {
 	t.Helper()
 	ids := make([]string, 0, n)
-	docs := make([]string, 0, n)
+	policies := make([]*frontlinev1.Policy, 0, n)
 	for i := range n {
-		id := fmt.Sprintf("pol_%03d", i)
+		id := uid.New(uid.PolicyPrefix)
 		ids = append(ids, id)
-		docs = append(docs, fmt.Sprintf(
-			`{"id":%q,"name":"KEBAP %d","enabled":true,"firewall":{"action":"ACTION_DENY"}}`, id, i))
+		policies = append(policies, &frontlinev1.Policy{
+			Id:      id,
+			Name:    fmt.Sprintf("KEBAP %d", i),
+			Enabled: proto.Bool(true),
+			Config: &frontlinev1.Policy_Firewall{Firewall: &frontlinev1.Firewall{
+				Action: frontlinev1.Action_ACTION_DENY,
+			}},
+		})
 	}
-	seedPolicyConfig(t, h, env, fmt.Sprintf(`{"policies":[%s]}`, strings.Join(docs, ",")))
+	seedSentinelConfig(t, h, env, &frontlinev1.Config{Policies: policies})
 	return ids
 }
 
 func readStoredBlob(t *testing.T, h *testutil.Harness, env seededEnv) string {
 	t.Helper()
-	var blob []byte
-	err := h.DB.RO().QueryRowContext(context.Background(),
-		"SELECT sentinel_config FROM app_runtime_settings WHERE app_id = ? AND environment_id = ?",
-		env.appID, env.environmentID).Scan(&blob)
+	stored, err := db.Query.FindAppRuntimeSettingsByAppAndEnv(context.Background(), h.DB.RO(), db.FindAppRuntimeSettingsByAppAndEnvParams{
+		AppID:         env.appID,
+		EnvironmentID: env.environmentID,
+	})
 	require.NoError(t, err)
-	return string(blob)
+	return string(stored.AppRuntimeSetting.SentinelConfig)
 }
 
 func authHeaders(rootKey string) http.Header {

--- a/svc/api/routes/v2_identities_delete_identity/200_test.go
+++ b/svc/api/routes/v2_identities_delete_identity/200_test.go
@@ -3,6 +3,7 @@ package handler_test
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
@@ -250,10 +251,12 @@ func TestDeleteIdentitySuccess(t *testing.T) {
 		externalID := "stripe_user_12345"
 
 		// Step 1: Create initial identity with "Advanced" tier ratelimit (300k/month)
+		advancedMeta, err := json.Marshal(map[string]string{"tier": "advanced"})
+		require.NoError(t, err)
 		identity1 := h.CreateIdentity(seed.CreateIdentityRequest{
 			WorkspaceID: h.Resources().UserWorkspace.ID,
 			ExternalID:  externalID,
-			Meta:        []byte(`{"tier":"advanced"}`),
+			Meta:        advancedMeta,
 			Ratelimits: []seed.CreateRatelimitRequest{
 				{
 					Name:        "per_month",
@@ -270,10 +273,12 @@ func TestDeleteIdentitySuccess(t *testing.T) {
 		require.Equal(t, 200, res1.Status, "first deletion should succeed")
 
 		// Step 3: Create new identity with "Starter" tier ratelimit (20k/month)
+		starterMeta, err := json.Marshal(map[string]string{"tier": "starter"})
+		require.NoError(t, err)
 		identity2 := h.CreateIdentity(seed.CreateIdentityRequest{
 			WorkspaceID: h.Resources().UserWorkspace.ID,
 			ExternalID:  externalID, // Same externalId
-			Meta:        []byte(`{"tier":"starter"}`),
+			Meta:        starterMeta,
 			Ratelimits: []seed.CreateRatelimitRequest{
 				{
 					Name:        "per_month",

--- a/svc/api/routes/v2_keys_get_key/200_test.go
+++ b/svc/api/routes/v2_keys_get_key/200_test.go
@@ -44,10 +44,12 @@ func TestGetKeyByKeyID(t *testing.T) {
 	})
 
 	// Create test identity with ratelimit using testutil helper
+	identityMeta, err := json.Marshal(map[string]string{"role": "admin"})
+	require.NoError(t, err)
 	identity := h.CreateIdentity(seed.CreateIdentityRequest{
 		WorkspaceID: workspace.ID,
 		ExternalID:  "test_user",
-		Meta:        []byte(`{"role": "admin"}`),
+		Meta:        identityMeta,
 		Ratelimits: []seed.CreateRatelimitRequest{
 			{
 				WorkspaceID: workspace.ID,

--- a/svc/api/routes/v2_keys_reroll_key/200_test.go
+++ b/svc/api/routes/v2_keys_reroll_key/200_test.go
@@ -1,6 +1,7 @@
 package handler_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
@@ -43,10 +44,12 @@ func TestRerollKeySuccess(t *testing.T) {
 
 	workspace := h.Resources().UserWorkspace
 
+	identityMeta, err := json.Marshal(map[string]string{"name": "Test User"})
+	require.NoError(t, err)
 	identity := h.CreateIdentity(seed.CreateIdentityRequest{
 		WorkspaceID: workspace.ID,
 		ExternalID:  "test_123",
-		Meta:        []byte(`{"name": "Test User"}`),
+		Meta:        identityMeta,
 		Ratelimits: []seed.CreateRatelimitRequest{
 			{
 				Name:        "default-enterprise",

--- a/svc/api/routes/v2_keys_update_key/three_state_test.go
+++ b/svc/api/routes/v2_keys_update_key/three_state_test.go
@@ -2,6 +2,7 @@ package handler_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
@@ -118,10 +119,12 @@ func TestThreeStateUpdateLogic(t *testing.T) {
 	t.Run("Meta field three-state logic", func(t *testing.T) {
 		t.Parallel()
 		// Create key with initial meta
+		initialMeta, err := json.Marshal(map[string]string{"initial": "value"})
+		require.NoError(t, err)
 		keyResponse := h.CreateKey(seed.CreateKeyRequest{
 			WorkspaceID: h.Resources().UserWorkspace.ID,
 			KeySpaceID:  api.KeyAuthID.String,
-			Meta:        ptr.P(`{"initial": "value"}`),
+			Meta:        ptr.P(string(initialMeta)),
 		})
 
 		// Test 1: Set to specific value
@@ -671,11 +674,13 @@ func TestThreeStateUpdateLogic(t *testing.T) {
 	t.Run("All fields simultaneously", func(t *testing.T) {
 		t.Parallel()
 		// Create key with initial values
+		initialMeta, err := json.Marshal(map[string]string{"initial": "value"})
+		require.NoError(t, err)
 		keyResponse := h.CreateKey(seed.CreateKeyRequest{
 			WorkspaceID: h.Resources().UserWorkspace.ID,
 			KeySpaceID:  api.KeyAuthID.String,
 			Name:        ptr.P("initial-name"),
-			Meta:        ptr.P(`{"initial": "value"}`),
+			Meta:        ptr.P(string(initialMeta)),
 			Expires:     ptr.P(time.Now().Add(24 * time.Hour)),
 		})
 

--- a/svc/api/routes/v2_keys_whoami/200_test.go
+++ b/svc/api/routes/v2_keys_whoami/200_test.go
@@ -44,10 +44,12 @@ func TestGetKeyByKey(t *testing.T) {
 	})
 
 	// Create test identity with ratelimit using testutil helper
+	identityMeta, err := json.Marshal(map[string]string{"role": "admin"})
+	require.NoError(t, err)
 	identity := h.CreateIdentity(seed.CreateIdentityRequest{
 		WorkspaceID: workspace.ID,
 		ExternalID:  "test_user",
-		Meta:        []byte(`{"role": "admin"}`),
+		Meta:        identityMeta,
 		Ratelimits: []seed.CreateRatelimitRequest{
 			{
 				WorkspaceID: workspace.ID,

--- a/svc/ctrl/api/webhooks/stripe/invoice_created_test.go
+++ b/svc/ctrl/api/webhooks/stripe/invoice_created_test.go
@@ -201,14 +201,16 @@ func TestInvoiceCreated_IgnoresMismatchedSubscription(t *testing.T) {
 	// invocations, so hardcoded ids made this pass once and then fail on every
 	// re-run with a duplicate-key error on workspaces.id.
 	wsID := uid.New(uid.WorkspacePrefix)
-	customerID := "cus_" + uid.New("test")
-	subID := "sub_" + uid.New("test")
+	customerID := uid.New("cus")
+	subID := uid.New("sub")
 
-	_, err = database.RW().ExecContext(context.Background(),
-		`INSERT INTO workspaces (id, org_id, name, slug, beta_features) VALUES (?, ?, ?, ?, ?)`,
-		wsID, "org_"+uid.New("test"), "Deploy WS", wsID, "[]",
-	)
-	require.NoError(t, err)
+	require.NoError(t, database.InsertWorkspace(context.Background(), db.InsertWorkspaceParams{
+		ID:        wsID,
+		OrgID:     uid.New(uid.OrgPrefix),
+		Name:      "Deploy WS",
+		Slug:      wsID,
+		CreatedAt: time.Now().UnixMilli(),
+	}))
 	_, err = database.RW().ExecContext(context.Background(),
 		`INSERT INTO workspace_billing (workspace_id, plan, stripe_customer_id) VALUES (?, ?, ?)`,
 		wsID, "pro", customerID,

--- a/svc/ctrl/integration/cleanup_test.go
+++ b/svc/ctrl/integration/cleanup_test.go
@@ -129,6 +129,10 @@ func TestProjectDeletion_CleansUpAllData(t *testing.T) {
 	require.NoError(t, err)
 
 	// Cilium network policy
+	policy, err := json.Marshal(struct {
+		APIVersion string `json:"apiVersion"`
+	}{APIVersion: "cilium.io/v2"})
+	require.NoError(t, err)
 	err = h.DB.InsertCiliumNetworkPolicy(ctx, db.InsertCiliumNetworkPolicyParams{
 		ID:            uid.New("cnp"),
 		WorkspaceID:   workspaceID,
@@ -139,7 +143,7 @@ func TestProjectDeletion_CleansUpAllData(t *testing.T) {
 		K8sName:       uid.New("k8s"),
 		K8sNamespace:  "test-ns",
 		RegionID:      region.ID,
-		Policy:        json.RawMessage(`{"apiVersion":"cilium.io/v2"}`),
+		Policy:        policy,
 		CreatedAt:     now,
 	})
 	require.NoError(t, err)

--- a/svc/ctrl/integration/deploy_teardown_test.go
+++ b/svc/ctrl/integration/deploy_teardown_test.go
@@ -148,10 +148,11 @@ func TestDeployTeardown_NoInstancesDrainsImmediately(t *testing.T) {
 	}).Deployment
 
 	// Model a deployment that never produced instances.
-	_, err := h.DB.RW().ExecContext(ctx,
-		"UPDATE deployments SET status = ? WHERE id = ?",
-		mysqltype.DeploymentsStatusAwaitingApproval, dep.ID)
-	require.NoError(t, err)
+	require.NoError(t, h.DB.UpdateDeploymentStatus(ctx, db.UpdateDeploymentStatusParams{
+		Status:    mysqltype.DeploymentsStatusAwaitingApproval,
+		UpdatedAt: sql.NullInt64{Int64: time.Now().UnixMilli(), Valid: true},
+		ID:        dep.ID,
+	}))
 
 	client := hydrav1.NewDeployTeardownServiceIngressClient(tEnv.Ingress(), dep.WorkspaceID)
 	resp, err := client.Teardown().Request(ctx, &hydrav1.TeardownRequest{})

--- a/svc/ctrl/integration/heartbeat_certificate_test.go
+++ b/svc/ctrl/integration/heartbeat_certificate_test.go
@@ -4,6 +4,7 @@ package integration
 
 import (
 	"context"
+	"database/sql"
 	"testing"
 	"time"
 
@@ -79,8 +80,7 @@ func TestHeartbeatProvisionsCertificates(t *testing.T) {
 	// rather than skip forever. Simulate the partial state by deleting the
 	// challenge, then heartbeat from a fresh replica (cold cache) so the check
 	// hits the DB rather than the first instance's cached "provisioned" entry.
-	_, err = h.DB.RW().ExecContext(ctx, "DELETE FROM acme_challenges WHERE domain_id = ?", domain.ID)
-	require.NoError(t, err)
+	require.NoError(t, h.DB.DeleteAcmeChallengeByDomainID(ctx, domain.ID))
 	require.Equal(t, 0, countAcmeChallenges(ctx, t, h.DB, domain.ID))
 
 	heartbeat(newHeartbeatService(t, h.DB, bearer, regionalDomain))
@@ -92,8 +92,11 @@ func TestHeartbeatProvisionsCertificates(t *testing.T) {
 	// 'waiting'/expiring-'verified') and nothing else resets. A heartbeat from a
 	// fresh replica must flip it back to 'waiting' so issuance is retried rather
 	// than stuck forever.
-	_, err = h.DB.RW().ExecContext(ctx, "UPDATE acme_challenges SET status = 'failed' WHERE domain_id = ?", domain.ID)
-	require.NoError(t, err)
+	require.NoError(t, h.DB.UpdateAcmeChallengeStatus(ctx, db.UpdateAcmeChallengeStatusParams{
+		Status:    db.AcmeChallengesStatusFailed,
+		UpdatedAt: sql.NullInt64{Int64: time.Now().UnixMilli(), Valid: true},
+		DomainID:  domain.ID,
+	}))
 
 	heartbeat(newHeartbeatService(t, h.DB, bearer, regionalDomain))
 	require.Equal(t, 1, countAcmeChallenges(ctx, t, h.DB, domain.ID))

--- a/svc/ctrl/worker/cron/audit_log_outbox_cleanup_integration_test.go
+++ b/svc/ctrl/worker/cron/audit_log_outbox_cleanup_integration_test.go
@@ -49,12 +49,14 @@ func TestRunAuditLogOutboxCleanup_Integration(t *testing.T) {
 // fresh workspace.
 func seedPendingRow(t *testing.T, h *harness.Harness) seededRow {
 	t.Helper()
-	row := seededRow{workspaceID: uid.New("ws"), eventID: uid.New("evt")}
-	err := h.DB.InsertClickhouseOutbox(h.Ctx, db.InsertClickhouseOutboxParams{
+	row := seededRow{workspaceID: uid.New(uid.WorkspacePrefix), eventID: uid.New(uid.AuditLogPrefix)}
+	payload, err := json.Marshal(struct{}{})
+	require.NoError(t, err)
+	err = h.DB.InsertClickhouseOutbox(h.Ctx, db.InsertClickhouseOutboxParams{
 		Version:     "audit_log.v1",
 		WorkspaceID: row.workspaceID,
 		EventID:     row.eventID,
-		Payload:     json.RawMessage(`{}`),
+		Payload:     payload,
 		CreatedAt:   time.Now().UnixMilli(),
 	})
 	require.NoError(t, err)

--- a/svc/ctrl/worker/cron/key_last_used_sync_integration_test.go
+++ b/svc/ctrl/worker/cron/key_last_used_sync_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/svc/ctrl/integration/harness"
 	"github.com/unkeyed/unkey/svc/ctrl/integration/seed"
+	"github.com/unkeyed/unkey/svc/ctrl/internal/db"
 )
 
 func TestRunKeyLastUsedSync_Integration(t *testing.T) {
@@ -85,11 +86,10 @@ func TestRunKeyLastUsedSync_Integration(t *testing.T) {
 		require.NoError(t, err)
 
 		evenNewer := now + 60_000
-		_, err = h.DB.RW().ExecContext(h.Ctx,
-			"UPDATE `keys` SET last_used_at = ? WHERE id = ?",
-			evenNewer, resp.KeyID,
-		)
-		require.NoError(t, err)
+		require.NoError(t, h.DB.UpdateKeysLastUsed(h.Ctx, db.UpdateKeysLastUsedParams{
+			LastUsedAt: uint64(evenNewer),
+			KeyIds:     []string{resp.KeyID},
+		}))
 
 		_, err = callRunKeyLastUsedSync(h)
 		require.NoError(t, err)

--- a/svc/ctrl/worker/deploy/railpack_test.go
+++ b/svc/ctrl/worker/deploy/railpack_test.go
@@ -1,6 +1,7 @@
 package deploy
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -131,7 +132,11 @@ func TestValidateRailpackPlan(t *testing.T) {
 	require.NoError(t, os.WriteFile(planPath, []byte("not json"), 0o644))
 	require.Error(t, validateRailpackPlan(planPath), "invalid JSON must fail")
 
-	require.NoError(t, os.WriteFile(planPath, []byte(`{"steps":{}}`), 0o644))
+	plan, err := json.Marshal(struct {
+		Steps map[string]any `json:"steps"`
+	}{Steps: map[string]any{}})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(planPath, plan, 0o644))
 	require.NoError(t, validateRailpackPlan(planPath))
 }
 

--- a/svc/ctrl/worker/deployment/deployment_state_integration_test.go
+++ b/svc/ctrl/worker/deployment/deployment_state_integration_test.go
@@ -61,10 +61,8 @@ func TestChangeDesiredState_NoOpsWhenDeploymentDeleted(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	_, err = h.DB.RW().ExecContext(h.Ctx, "DELETE FROM deployment_topology WHERE deployment_id = ?", dep.ID)
-	require.NoError(t, err)
-	_, err = h.DB.RW().ExecContext(h.Ctx, "DELETE FROM deployments WHERE id = ?", dep.ID)
-	require.NoError(t, err)
+	require.NoError(t, h.DB.DeleteDeploymentTopologiesByEnvironmentId(h.Ctx, env.ID))
+	require.NoError(t, h.DB.DeleteDeploymentsByEnvironmentId(h.Ctx, env.ID))
 
 	time.Sleep(time.Second)
 

--- a/svc/ctrl/worker/legacybilling/billing_test.go
+++ b/svc/ctrl/worker/legacybilling/billing_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	stripe "github.com/stripe/stripe-go/v86"
 	"github.com/stripe/stripe-go/v86/form"
+	"github.com/unkeyed/unkey/pkg/uid"
 )
 
 // TestBuildInvoiceItemsUsesFullFixedPricesAndTierUsage protects fixed fees from
@@ -224,7 +225,10 @@ func TestReconcileExistingInvoiceLinesResumesPartialDraft(t *testing.T) {
 	require.ErrorContains(t, err, "does not match the expected specification")
 
 	existing.Metadata["charge_spec"] = invoiceItemSpec(expected[0], periodStart, periodEnd)
-	existing.LastResponse.RawJSON = []byte(`{"pricing":{"unit_amount_decimal":"5000"}}`)
+	existing.LastResponse.RawJSON, err = json.Marshal(map[string]any{
+		"pricing": map[string]string{"unit_amount_decimal": "5000"},
+	})
+	require.NoError(t, err)
 	_, err = reconcileExistingInvoiceLines("in_123", "ws_123", "2026-07", periodStart, periodEnd, expected, []*stripe.InvoiceLineItem{existing})
 	require.ErrorContains(t, err, `unit amount is "5000", expected "2500"`)
 }
@@ -267,7 +271,9 @@ func TestValidateConfig(t *testing.T) {
 // TestWorkspaceInputIsJournalSerializable protects billing state from being
 // lost when Restate records and replays the MySQL step result.
 func TestWorkspaceInputIsJournalSerializable(t *testing.T) {
-	expected := workspaceInput{Name: "Acme", CustomerID: "cus_123", Subscriptions: []byte(`{"plan":true}`)}
+	subscriptions, err := json.Marshal(map[string]bool{"plan": true})
+	require.NoError(t, err)
+	expected := workspaceInput{Name: "Acme", CustomerID: uid.New("cus"), Subscriptions: subscriptions}
 
 	encoded, err := json.Marshal(expected)
 	require.NoError(t, err)

--- a/svc/frontline/internal/policies/openapi/executor_test.go
+++ b/svc/frontline/internal/policies/openapi/executor_test.go
@@ -1,9 +1,10 @@
 package openapi
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -44,6 +45,13 @@ func newTestExecutor(t *testing.T) *Executor {
 	return e
 }
 
+func jsonBody(t *testing.T, value any) []byte {
+	t.Helper()
+	body, err := json.Marshal(value)
+	require.NoError(t, err)
+	return body
+}
+
 func TestExecute_EmptySpec(t *testing.T) {
 	t.Parallel()
 
@@ -60,8 +68,8 @@ func TestExecute_ValidRequest(t *testing.T) {
 	t.Parallel()
 
 	e := newTestExecutor(t)
-	body := `{"name":"alice"}`
-	req := httptest.NewRequest("POST", "/users", strings.NewReader(body))
+	body := jsonBody(t, map[string]string{"name": "alice"})
+	req := httptest.NewRequest("POST", "/users", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 
 	_, err := e.Execute(context.Background(), nil, req, &frontlinev1.OpenApiRequestValidation{
@@ -74,8 +82,8 @@ func TestExecute_InvalidRequest(t *testing.T) {
 	t.Parallel()
 
 	e := newTestExecutor(t)
-	body := `{"wrong":"field"}`
-	req := httptest.NewRequest("POST", "/users", strings.NewReader(body))
+	body := jsonBody(t, map[string]string{"wrong": "field"})
+	req := httptest.NewRequest("POST", "/users", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 
 	_, err := e.Execute(context.Background(), nil, req, &frontlinev1.OpenApiRequestValidation{
@@ -110,13 +118,13 @@ func TestExecute_CachesCompiledValidator(t *testing.T) {
 	e := newTestExecutor(t)
 	cfg := &frontlinev1.OpenApiRequestValidation{SpecYaml: minimalSpec}
 
-	body := `{"name":"alice"}`
-	req1 := httptest.NewRequest("POST", "/users", strings.NewReader(body))
+	body := jsonBody(t, map[string]string{"name": "alice"})
+	req1 := httptest.NewRequest("POST", "/users", bytes.NewReader(body))
 	req1.Header.Set("Content-Type", "application/json")
 	_, err := e.Execute(context.Background(), nil, req1, cfg)
 	require.NoError(t, err)
 
-	req2 := httptest.NewRequest("POST", "/users", strings.NewReader(body))
+	req2 := httptest.NewRequest("POST", "/users", bytes.NewReader(body))
 	req2.Header.Set("Content-Type", "application/json")
 	_, err = e.Execute(context.Background(), nil, req2, cfg)
 	require.NoError(t, err)
@@ -152,8 +160,8 @@ paths:
         "200":
           description: ok
 `)
-	body := `{"secret":"hide-me","visible":"keep-me"}`
-	req := httptest.NewRequest("POST", "/secrets", strings.NewReader(body))
+	body := jsonBody(t, map[string]string{"secret": "hide-me", "visible": "keep-me"})
+	req := httptest.NewRequest("POST", "/secrets", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 
 	redactor, err := newTestExecutor(t).Execute(context.Background(), nil, req, &frontlinev1.OpenApiRequestValidation{
@@ -161,5 +169,5 @@ paths:
 	})
 	require.NoError(t, err)
 	require.NotNil(t, redactor)
-	require.Equal(t, `{"secret":"[REDACTED]","visible":"keep-me"}`, string(redactor.Redact([]byte(body))))
+	require.Equal(t, `{"secret":"[REDACTED]","visible":"keep-me"}`, string(redactor.Redact(body)))
 }

--- a/tools/upsert-workos-permissions/main_test.go
+++ b/tools/upsert-workos-permissions/main_test.go
@@ -20,6 +20,16 @@ func TestRunUpsertsPermissions(t *testing.T) {
 		Query  string
 		Body   permissionBody
 	}
+	type permissionResponse struct {
+		Permission permissionBody `json:"permission"`
+	}
+	type errorResponse struct {
+		Message string `json:"message"`
+	}
+	writeJSON := func(w http.ResponseWriter, status int, body any) {
+		w.WriteHeader(status)
+		require.NoError(t, json.NewEncoder(w).Encode(body))
+	}
 
 	requests := []recordedRequest{}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -38,23 +48,20 @@ func TestRunUpsertsPermissions(t *testing.T) {
 
 		switch {
 		case r.Method == http.MethodGet && r.URL.EscapedPath() == "/authorization/permissions" && r.URL.Query().Get("after") == "":
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"data":[{"slug":"projects:read"}],"list_metadata":{"after":"cursor_1"}}`))
+			after := "cursor_1"
+			response := permissionListResponse{Data: []permissionBody{{Slug: "projects:read"}}}
+			response.ListMetadata.After = &after
+			writeJSON(w, http.StatusOK, response)
 		case r.Method == http.MethodGet && r.URL.EscapedPath() == "/authorization/permissions" && r.URL.Query().Get("after") == "cursor_1":
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"data":[{"slug":"legacy:stale"}],"list_metadata":{"after":null}}`))
+			writeJSON(w, http.StatusOK, permissionListResponse{Data: []permissionBody{{Slug: "legacy:stale"}}})
 		case r.Method == http.MethodGet && r.URL.EscapedPath() == "/authorization/permissions/projects:read":
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"permission":{"slug":"projects:read"}}`))
+			writeJSON(w, http.StatusOK, permissionResponse{Permission: permissionBody{Slug: "projects:read"}})
 		case r.Method == http.MethodPatch && r.URL.EscapedPath() == "/authorization/permissions/projects:read":
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"permission":{"slug":"projects:read"}}`))
+			writeJSON(w, http.StatusOK, permissionResponse{Permission: permissionBody{Slug: "projects:read"}})
 		case r.Method == http.MethodGet && r.URL.EscapedPath() == "/authorization/permissions/projects:create":
-			w.WriteHeader(http.StatusNotFound)
-			_, _ = w.Write([]byte(`{"message":"not found"}`))
+			writeJSON(w, http.StatusNotFound, errorResponse{Message: "not found"})
 		case r.Method == http.MethodPost && r.URL.EscapedPath() == "/authorization/permissions":
-			w.WriteHeader(http.StatusCreated)
-			_, _ = w.Write([]byte(`{"permission":{"slug":"projects:create"}}`))
+			writeJSON(w, http.StatusCreated, permissionResponse{Permission: permissionBody{Slug: "projects:create"}})
 		default:
 			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.EscapedPath())
 		}


### PR DESCRIPTION
## Problem:

Tests used many raw JSON documents, direct SQL statements, and fixed resource IDs. These fixtures could drift from generated types and database queries.

## Solution:

- Replace setup-only JSON documents with typed structs, OpenAPI models, or protobuf messages.
- Replace direct database setup statements with existing sqlc methods where the generated API preserves the test behavior.
- Generate resource IDs with `uid.New` and the correct prefix constants.
- Keep raw JSON and SQL only when the text, malformed input, wire format, parser behavior, or unsupported database fields are part of the test.

## Impact:

Production behavior does not change. Test fixtures now follow generated API, protobuf, and database contracts more closely.

## Testing:

- `mise run build`
- Targeted CLI, API route, webhook, billing, Restate, policy, and database test suites
- Integration-tag compile checks for affected control-plane packages
- `git diff --check`
