### PR TITLE
fix(cli): return error instead of panicking when ngrok is missing

### DIFF
--- a/cmd/dev/github/tunnel.go
+++ b/cmd/dev/github/tunnel.go
@@ -55,7 +55,7 @@ func startTunnel(_ context.Context, cmd *cli.Command) error {
 
 	// Fail fast if ngrok is not installed
 	if _, err := exec.LookPath("ngrok"); err != nil {
-		panic("ngrok is not installed or not in PATH\n\nInstall it from: https://ngrok.com/download")
+		return fmt.Errorf("ngrok is not installed or not in PATH, install it from https://ngrok.com/download: %w", err)
 	}
 
 	appID, err := readAppID(envFile)
@@ -101,7 +101,9 @@ func startTunnel(_ context.Context, cmd *cli.Command) error {
 	fmt.Printf("✔ Tunnel running (press Ctrl+C to stop)\n\n")
 	fmt.Printf("Inspect traffic at: http://localhost:4040\n")
 
-	// Keep running until killed
+	// Keep running until killed. Ctrl+C signals the whole process group, so
+	// ngrok's exit status is almost always "signal: interrupt" and carries no
+	// actionable information; the tunnel ending is the expected outcome.
 	_ = ngrok.Wait()
 	return nil
 }


### PR DESCRIPTION
## Problem:

`unkey dev github tunnel` panicked with a stack trace when ngrok was not installed. 

A missing optional tool is a normal user condition and thus shouldnt panic

## Solution:

The tunnel command now returns a wrapped error with the install URL, and the CLI prints it as a normal error message. 

## Impact:

Developers without ngrok get a readable error instead of a stack trace.

## Testing:

- `go build ./cmd/...` passed.
