### PR TITLE
fix(cache): add Close to stop revalidation workers and metrics reporter

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -27,6 +27,9 @@ type cache[K comparable, V any] struct {
 	clock    clock.Clock
 
 	revalidateC chan func()
+	done        chan struct{}
+	closeOnce   sync.Once
+	stopMetrics func()
 
 	inflightMu        sync.Mutex
 	inflightRefreshes map[K]bool
@@ -84,27 +87,51 @@ func New[K comparable, V any](config Config[K, V]) (Cache[K, V], error) {
 		resource:          config.Resource,
 		clock:             config.Clock,
 		revalidateC:       make(chan func(), 1000),
+		done:              make(chan struct{}),
+		closeOnce:         sync.Once{},
+		stopMetrics:       nil, // set below, needs c
 		inflightMu:        sync.Mutex{},
 		inflightRefreshes: make(map[K]bool),
 	}
 
 	for range 10 {
 		go func() {
-			for revalidate := range c.revalidateC {
-				revalidate()
+			for {
+				select {
+				case <-c.done:
+					return
+				case revalidate := <-c.revalidateC:
+					revalidate()
+				}
 			}
 		}()
 	}
 
-	c.registerMetrics()
-	return c, nil
-}
-
-func (c *cache[K, V]) registerMetrics() {
-	repeat.Every(60*time.Second, func() {
+	c.stopMetrics = repeat.Every(60*time.Second, func() {
 		metrics.CacheSize.WithLabelValues(c.resource).Set(float64(c.otter.Size()))
 		metrics.CacheCapacity.WithLabelValues(c.resource).Set(float64(c.otter.Capacity()))
 	})
+	return c, nil
+}
+
+// Close stops the background revalidation workers and the periodic metrics
+// reporter. Queued revalidations that no worker has picked up yet are
+// dropped; cached data stays readable. Close is idempotent.
+func (c *cache[K, V]) Close() {
+	c.closeOnce.Do(func() {
+		close(c.done)
+		c.stopMetrics()
+	})
+}
+
+// enqueueRevalidation hands fn to a background revalidation worker.
+// After Close it drops fn instead of blocking forever on a channel
+// no worker reads anymore.
+func (c *cache[K, V]) enqueueRevalidation(fn func()) {
+	select {
+	case c.revalidateC <- fn:
+	case <-c.done:
+	}
 }
 
 func (c *cache[K, V]) recordTiming(ctx context.Context, name, status string, start time.Time) {
@@ -330,11 +357,11 @@ func (c *cache[K, V]) SWR(
 		}
 
 		if now.Before(e.Stale) {
-			c.revalidateC <- func() {
+			c.enqueueRevalidation(func() {
 				// If we don't uncancel the context, the revalidation will get canceled when
 				// the api response is returned
 				c.revalidate(context.WithoutCancel(ctx), key, refreshFromOrigin, op)
-			}
+			})
 			c.recordTiming(ctx, "cache_swr", "stale", start)
 			return e.Value, e.Hit, nil
 		}
@@ -420,9 +447,9 @@ func (c *cache[K, V]) SWRMany(
 
 	// Queue stale keys for background refresh
 	if len(staleKeys) > 0 {
-		c.revalidateC <- func() {
+		c.enqueueRevalidation(func() {
 			c.revalidateMany(context.WithoutCancel(ctx), staleKeys, refreshFromOrigin, op)
-		}
+		})
 	}
 
 	// Fetch missing keys synchronously
@@ -500,9 +527,9 @@ func (c *cache[K, V]) SWRWithFallback(
 			if !c.inflightRefreshes[key] {
 				c.inflightRefreshes[key] = true
 				dedupeKey := key // capture for closure
-				c.revalidateC <- func() {
+				c.enqueueRevalidation(func() {
 					c.revalidateWithCanonicalKey(context.WithoutCancel(ctx), dedupeKey, refreshFromOrigin, op)
-				}
+				})
 			}
 			c.inflightMu.Unlock()
 			c.recordTiming(ctx, "cache_swr_fallback", "stale", start)

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -28,6 +28,29 @@ func TestWriteRead(t *testing.T) {
 	require.Equal(t, "value", value)
 }
 
+func TestClose(t *testing.T) {
+
+	c, err := cache.New(cache.Config[string, string]{
+		MaxSize:  10_000,
+		Fresh:    time.Minute,
+		Stale:    time.Minute * 5,
+		Resource: "test",
+		Clock:    clock.New(),
+	})
+	require.NoError(t, err)
+
+	c.Set(context.Background(), "key", "value")
+
+	c.Close()
+	// Close must be idempotent.
+	c.Close()
+
+	// Cached data stays readable after Close.
+	value, hit := c.Get(context.Background(), "key")
+	require.Equal(t, cache.Hit, hit)
+	require.Equal(t, "value", value)
+}
+
 func TestEviction(t *testing.T) {
 
 	clk := clock.NewTestClock()

--- a/pkg/cache/interface.go
+++ b/pkg/cache/interface.go
@@ -59,6 +59,11 @@ type Cache[K comparable, V any] interface {
 
 	// Name returns the name of this cache instance.
 	Name() string
+
+	// Close releases background resources such as revalidation workers.
+	// The cache must not be used for SWR operations after Close.
+	// Close is idempotent.
+	Close()
 }
 
 // Key represents a cache key that can be serialized to a string representation.

--- a/pkg/cache/middleware/tracing.go
+++ b/pkg/cache/middleware/tracing.go
@@ -133,6 +133,10 @@ func (mw *tracingMiddleware[K, V]) Name() string {
 	return mw.next.Name()
 }
 
+func (mw *tracingMiddleware[K, V]) Close() {
+	mw.next.Close()
+}
+
 func (mw *tracingMiddleware[K, V]) SWR(ctx context.Context, key K, refreshFromOrigin func(ctx context.Context) (V, error), op func(err error) cache.Op) (V, cache.CacheHit, error) {
 	ctx, span := tracing.Start(ctx, "cache.SWR")
 	defer span.End()

--- a/pkg/cache/noop.go
+++ b/pkg/cache/noop.go
@@ -42,6 +42,8 @@ func (c *noopCache[K, V]) Name() string {
 	return "noop"
 }
 
+func (c *noopCache[K, V]) Close() {}
+
 func (c *noopCache[K, V]) SWR(ctx context.Context, key K, refreshFromOrigin func(context.Context) (V, error), op func(err error) Op) (V, CacheHit, error) {
 	var v V
 	return v, Miss, nil


### PR DESCRIPTION
## Problem:

`cache.New` call starts ten revalidation worker goroutines and a periodic metrics reporter with no way to stop them.

Owners could not release these resources, so caches created outside the process lifetime (tests, short-lived components) leaked goroutines.

## Solution:

The `Cache` interface gains `Close()`. 

Close stops the revalidation workers and the metrics reporter, is idempotent, and keeps cached data readable.

Revalidation enqueue drops work after Close instead of blocking forever. 
The noop cache and the tracing middleware implement and delegate Close.

## Impact:

Interface change: external implementations of `cache.Cache` must add a `Close` method. Call sites are wired in the follow-up PR in this stack ("close caches on shutdown").

## Testing:

- `go build` across dependent packages passed.
- `go vet ./pkg/cache/...` passed.
- `rask ./pkg/cache`: 49 tests passed, including a new Close idempotency and read-after-close test.
- `golangci-lint run ./pkg/cache/...`: 0 issues.
