### PR TITLE
fix(services): handle shutdown errors once instead of three times

### DIFF
--- a/svc/api/run.go
+++ b/svc/api/run.go
@@ -558,8 +558,8 @@ func Run(ctx context.Context, cfg Config) error {
 	})
 
 	// Wait for either OS signals or context cancellation, then shutdown
+	// r.Wait already logs shutdown failures; just add context and propagate.
 	if err := r.Wait(ctx, runner.WithTimeout(time.Minute)); err != nil {
-		logger.Error("Shutdown failed", "error", err)
 		return fmt.Errorf("shutdown failed: %w", err)
 	}
 

--- a/svc/ctrl/api/run.go
+++ b/svc/ctrl/api/run.go
@@ -396,9 +396,9 @@ func Run(ctx context.Context, cfg Config) error {
 
 	// Wait for signal and handle shutdown
 	logger.Info("Ctrl server started successfully")
+	// r.Wait already logs shutdown failures; just add context and propagate.
 	if err := r.Wait(ctx); err != nil {
-		logger.Error("Shutdown failed", "error", err)
-		return err
+		return fmt.Errorf("shutdown failed: %w", err)
 	}
 
 	logger.Info("Ctrl server shut down successfully")

--- a/svc/ctrl/worker/run.go
+++ b/svc/ctrl/worker/run.go
@@ -852,9 +852,9 @@ func Run(ctx context.Context, cfg Config) error {
 
 	// Wait for signal and handle shutdown
 	logger.Info("Worker started successfully")
+	// r.Wait already logs shutdown failures; just add context and propagate.
 	if err := r.Wait(ctx); err != nil {
-		logger.Error("Shutdown failed", "error", err)
-		return err
+		return fmt.Errorf("shutdown failed: %w", err)
 	}
 
 	logger.Info("Worker shut down successfully")

--- a/svc/krane/run.go
+++ b/svc/krane/run.go
@@ -288,9 +288,9 @@ func Run(ctx context.Context, cfg Config) error {
 
 	// Wait for signal and handle shutdown
 	logger.Info("Krane server started successfully")
+	// r.Wait already logs shutdown failures; just add context and propagate.
 	if err := r.Wait(ctx); err != nil {
-		logger.Error("Shutdown failed", "error", err)
-		return err
+		return fmt.Errorf("shutdown failed: %w", err)
 	}
 
 	logger.Info("krane server shut down successfully")

--- a/svc/vault/run.go
+++ b/svc/vault/run.go
@@ -130,9 +130,9 @@ func Run(ctx context.Context, cfg Config) error {
 		return nil
 	})
 
+	// r.Wait already logs shutdown failures; just add context and propagate.
 	if err := r.Wait(ctx); err != nil {
-		logger.Error("Shutdown failed", "error", err)
-		return err
+		return fmt.Errorf("shutdown failed: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
## Problem:

`r.Wait` already logs the error that it returns so we dont need to log it 

## Solution:

We now just wrap`shutdown failed: %w` and return

## Impact:

Changes log output only when shutdown fais 

## Testing:

- `go build ./svc/...` passed.
- `golangci-lint run` on the affected packages: 0 issues.
