### PR TITLE
fix(services): close caches on shutdown

### DIFF
--- a/internal/services/caches/caches.go
+++ b/internal/services/caches/caches.go
@@ -51,8 +51,17 @@ type Caches struct {
 	WorkspaceByOrgID cache.Cache[string, db.Workspace]
 }
 
-// Close shuts down the caches and cleans up resources.
+// Close stops the background revalidation workers and metrics reporters of
+// every cache in the set. The caches must not be used after Close.
 func (c *Caches) Close() error {
+	c.RatelimitNamespace.Close()
+	c.VerificationKeyByHash.Close()
+	c.LiveApiByID.Close()
+	c.ClickhouseSetting.Close()
+	c.ApiToKeyAuthRow.Close()
+	c.WorkspaceLimits.Close()
+	c.PortalSession.Close()
+	c.WorkspaceByOrgID.Close()
 	return nil
 }
 

--- a/svc/api/run.go
+++ b/svc/api/run.go
@@ -323,6 +323,7 @@ func Run(ctx context.Context, cfg Config) error {
 	if err != nil {
 		return fmt.Errorf("unable to create caches: %w", err)
 	}
+	r.Defer(caches.Close)
 
 	keySvc, err := keys.New(keys.Config{
 		DB:           db.ToMySQL(database),

--- a/svc/ctrl/api/run.go
+++ b/svc/ctrl/api/run.go
@@ -142,6 +142,7 @@ func Run(ctx context.Context, cfg Config) error {
 	if err != nil {
 		return fmt.Errorf("failed to create topology cache: %w", err)
 	}
+	r.Defer(func() error { topologyCache.Close(); return nil })
 
 	// Set up the ClickHouse buffer that absorbs container lifecycle events
 	// reported by krane. Falls back to a noop when no URL is configured so
@@ -197,6 +198,7 @@ func Run(ctx context.Context, cfg Config) error {
 	if err != nil {
 		return fmt.Errorf("failed to create domain cache: %w", err)
 	}
+	r.Defer(func() error { domainCache.Close(); return nil })
 
 	challengeCache, err := cache.New(cache.Config[string, db.AcmeChallenge]{
 		Fresh:    10 * time.Second,
@@ -208,6 +210,7 @@ func Run(ctx context.Context, cfg Config) error {
 	if err != nil {
 		return fmt.Errorf("failed to create challenge cache: %w", err)
 	}
+	r.Defer(func() error { challengeCache.Close(); return nil })
 
 	// Create GitHub client for deployment authorization (optional)
 	var ghClient githubclient.GitHubClient = githubclient.NewNoop()

--- a/svc/ctrl/worker/run.go
+++ b/svc/ctrl/worker/run.go
@@ -464,6 +464,7 @@ func Run(ctx context.Context, cfg Config) error {
 	if domainCacheErr != nil {
 		return fmt.Errorf("failed to create domain cache: %w", domainCacheErr)
 	}
+	r.Defer(func() error { domainCache.Close(); return nil })
 
 	// Setup ACME challenge providers
 	var dnsProvider challenge.Provider

--- a/svc/frontline/internal/caches/caches.go
+++ b/svc/frontline/internal/caches/caches.go
@@ -28,8 +28,13 @@ type Caches struct {
 	TLSCertificates cache.Cache[string, tls.Certificate]
 }
 
-// Close shuts down the caches and cleans up resources.
+// Close stops the background revalidation workers and metrics reporters of
+// every cache in the set. The caches must not be used after Close.
 func (c *Caches) Close() error {
+	c.FrontlineRoutes.Close()
+	c.InstancesByDeployment.Close()
+	c.Policies.Close()
+	c.TLSCertificates.Close()
 	return nil
 }
 

--- a/svc/frontline/run.go
+++ b/svc/frontline/run.go
@@ -492,6 +492,7 @@ func buildEngine(
 	if err != nil {
 		return nil, fmt.Errorf("failed to create key cache: %w", err)
 	}
+	r.Defer(func() error { keyCache.Close(); return nil })
 
 	keyService, err := keys.New(keys.Config{
 		DB:           pkgdb.ToMySQL(database),

--- a/svc/krane/run.go
+++ b/svc/krane/run.go
@@ -161,6 +161,7 @@ func Run(ctx context.Context, cfg Config) error {
 	if err != nil {
 		return fmt.Errorf("failed to create fingerprint cache: %w", err)
 	}
+	r.Defer(func() error { fingerprintCache.Close(); return nil })
 
 	// Cache for deduplicating per-container lifecycle events keyed by
 	// (pod_uid, container_name, restart_count, event_kind). The same life
@@ -176,6 +177,7 @@ func Run(ctx context.Context, cfg Config) error {
 	if err != nil {
 		return fmt.Errorf("failed to create instance event dedup cache: %w", err)
 	}
+	r.Defer(func() error { instanceEventDedupCache.Close(); return nil })
 
 	// Cache for deduplicating pod watch lag samples per (pod UID,
 	// transition time). Entries auto-expire so deleted pods don't
@@ -190,6 +192,7 @@ func Run(ctx context.Context, cfg Config) error {
 	if err != nil {
 		return fmt.Errorf("failed to create deployment transitions cache: %w", err)
 	}
+	r.Defer(func() error { deploymentTransitionsCache.Close(); return nil })
 
 	// Start the deployment controller (independent control loop)
 	deploymentCtrl := deployment.New(deployment.Config{


### PR DESCRIPTION
## Problem:

#7018 added `Close` to the cache interface but we never called it in code

## Solution:

We now close it with our normal runner pkg for graceful shutdown

## Impact:

Each service now stops the revalidation workers plus ånd the metrics reporter when shutting down
 
## Testing:

- `go build ./svc/... ./internal/services/caches/... ./pkg/cache/...` passed.
- `golangci-lint run` on the two caches packages: 0 issues.
- `rask ./internal/services/caches`: package has no tests.
