### PR TITLE
fix(clickhouse): use errors.Is(sql.ErrNoRows) instead of error-string matching

### DIFF
--- a/pkg/clickhouse/billable_ratelimits.go
+++ b/pkg/clickhouse/billable_ratelimits.go
@@ -2,6 +2,8 @@ package clickhouse
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 
 	"github.com/unkeyed/unkey/pkg/fault"
 )
@@ -38,7 +40,7 @@ func (c *Client) GetBillableRatelimits(ctx context.Context, workspaceID string, 
 	).Scan(&count)
 
 	// If there are no results, return 0 without an error
-	if err != nil && err.Error() == "sql: no rows in result set" {
+	if errors.Is(err, sql.ErrNoRows) {
 		return 0, nil
 	}
 

--- a/pkg/clickhouse/billable_verifications.go
+++ b/pkg/clickhouse/billable_verifications.go
@@ -2,6 +2,8 @@ package clickhouse
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 
 	"github.com/unkeyed/unkey/pkg/fault"
 )
@@ -38,7 +40,7 @@ func (c *Client) GetBillableVerifications(ctx context.Context, workspaceID strin
 	).Scan(&count)
 
 	// If there are no results, return 0 without an error
-	if err != nil && err.Error() == "sql: no rows in result set" {
+	if errors.Is(err, sql.ErrNoRows) {
 		return 0, nil
 	}
 


### PR DESCRIPTION
## Problem:

`GetBillableVerifications` and `GetBillableRatelimits` detected empty query results with `err.Error() == "sql: no rows in result set"`. 

We dont want to check errs based on strings.

## Solution:

Both functions now use `errors.Is(err, sql.ErrNoRows)`, since clickhouse-go v2 returns `sql.ErrNoRows` from `Row.Scan` when a query has no result rows, so behavior is unchanged.

## Impact:

No behavior change. Billing queries for workspaces with no usage still return 0 without an error.

## Testing:

- `go build ./pkg/clickhouse/...` passed.
- `golangci-lint run ./pkg/clickhouse/...`: 0 issues.
- `rask ./pkg/clickhouse`: 935 tests passed.
