### PR TITLE
style(api): gofmt root_keys integration test

### DIFF
--- a/svc/api/integration/root_keys/root_keys_test.go
+++ b/svc/api/integration/root_keys/root_keys_test.go
@@ -11,17 +11,16 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"github.com/unkeyed/unkey/svc/api/integration"
-	handler "github.com/unkeyed/unkey/svc/api/routes/v2_keys_verify_key"
 	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/hash"
-	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
 	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/integration"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_keys_verify_key"
 )
 
 // TestGetRootKey_Valid tests that a valid root key works correctly
 func TestGetRootKey_Valid(t *testing.T) {
-
 
 	ctx := context.Background()
 	h := integration.New(t, integration.Config{NumNodes: 1})
@@ -56,7 +55,6 @@ func TestGetRootKey_Valid(t *testing.T) {
 // TestGetRootKey_NotFound tests that a non-existent root key returns proper error
 func TestGetRootKey_NotFound(t *testing.T) {
 
-
 	ctx := context.Background()
 	h := integration.New(t, integration.Config{NumNodes: 1})
 
@@ -87,7 +85,6 @@ func TestGetRootKey_NotFound(t *testing.T) {
 
 // TestGetRootKey_Disabled tests that a disabled root key returns proper error
 func TestGetRootKey_Disabled(t *testing.T) {
-
 
 	ctx := context.Background()
 	h := integration.New(t, integration.Config{NumNodes: 1})
@@ -134,7 +131,6 @@ func TestGetRootKey_Disabled(t *testing.T) {
 // TestGetRootKey_Expired tests that an expired root key returns proper error
 func TestGetRootKey_Expired(t *testing.T) {
 
-
 	ctx := context.Background()
 	h := integration.New(t, integration.Config{NumNodes: 1})
 
@@ -178,7 +174,6 @@ func TestGetRootKey_Expired(t *testing.T) {
 // TestGetRootKey_TargetWorkspaceDisabled tests that a root key for a disabled workspace returns proper error
 func TestGetRootKey_TargetWorkspaceDisabled(t *testing.T) {
 
-
 	ctx := context.Background()
 	h := integration.New(t, integration.Config{NumNodes: 1})
 
@@ -216,7 +211,6 @@ func TestGetRootKey_TargetWorkspaceDisabled(t *testing.T) {
 
 // TestGetRootKey_RootWorkspaceDisabled tests that a root key whose owning workspace is disabled returns proper error
 func TestGetRootKey_RootWorkspaceDisabled(t *testing.T) {
-
 
 	ctx := context.Background()
 	h := integration.New(t, integration.Config{NumNodes: 1})
@@ -257,7 +251,6 @@ func TestGetRootKey_RootWorkspaceDisabled(t *testing.T) {
 
 // TestGetRootKey_WorkspaceNotFound tests that a root key pointing to a non-existent workspace returns proper error
 func TestGetRootKey_WorkspaceNotFound(t *testing.T) {
-
 
 	ctx := context.Background()
 	h := integration.New(t, integration.Config{NumNodes: 1})
@@ -301,7 +294,6 @@ func TestGetRootKey_WorkspaceNotFound(t *testing.T) {
 // TestGetRootKey_MissingBearer tests that missing Authorization header returns proper error
 func TestGetRootKey_MissingBearer(t *testing.T) {
 
-
 	ctx := context.Background()
 	h := integration.New(t, integration.Config{NumNodes: 1})
 
@@ -331,7 +323,6 @@ func TestGetRootKey_MissingBearer(t *testing.T) {
 
 // TestGetRootKey_Deleted tests that a soft-deleted root key returns proper error
 func TestGetRootKey_Deleted(t *testing.T) {
-
 
 	ctx := context.Background()
 	h := integration.New(t, integration.Config{NumNodes: 1})
@@ -376,7 +367,6 @@ func TestGetRootKey_Deleted(t *testing.T) {
 // TestGetRootKey_InsufficientPermissions tests that a root key without required permissions returns proper error
 func TestGetRootKey_InsufficientPermissions(t *testing.T) {
 
-
 	ctx := context.Background()
 	h := integration.New(t, integration.Config{NumNodes: 1})
 
@@ -420,7 +410,6 @@ func TestGetRootKey_InsufficientPermissions(t *testing.T) {
 // as a root key even if it has the same permissions. This is a security test to ensure
 // that only keys with ForWorkspaceID set can act as root keys.
 func TestGetRootKey_RegularKeyWithSamePermissions(t *testing.T) {
-
 
 	ctx := context.Background()
 	h := integration.New(t, integration.Config{NumNodes: 1})


### PR DESCRIPTION
## Problem:

`svc/api/integration/root_keys/root_keys_test.go` wasnt fmt 
## Solution:

fmt it

## Impact:

Formatting only. No behavior change.

## Testing:

- `gofmt -l cmd svc pkg internal tools` returns no files.
