### PR TITLE
docs: align permission slug guidance

### DIFF
--- a/docs/product/cli/permissions/create-permission.mdx
+++ b/docs/product/cli/permissions/create-permission.mdx
@@ -29,7 +29,7 @@ Human-readable name describing the permission's purpose. Names must be unique wi
 </ParamField>
 
 <ParamField body="--slug" type="string" required>
-URL-safe identifier for use in APIs and integrations. Must start with a letter and contain only letters, numbers, periods, underscores, and hyphens. Slugs are often used in REST endpoints, configuration files, and external integrations. Must be unique within your workspace. Must be 1-128 characters.
+Identifier for use in APIs and integrations. Must be 1-128 characters and contain only letters, numbers, underscores, colons, hyphens, periods, and asterisks. Slugs are often used in REST endpoints, configuration files, and external integrations. Must be unique within your workspace.
 </ParamField>
 
 <ParamField body="--description" type="string">

--- a/docs/product/cli/permissions/delete-permission.mdx
+++ b/docs/product/cli/permissions/delete-permission.mdx
@@ -23,7 +23,7 @@ unkey api permissions delete-permission [flags]
 ## Flags
 
 <ParamField body="--permission" type="string" required>
-The permission ID or slug to permanently delete from your workspace. Must be 3-255 characters, start with a letter, and contain only letters, numbers, dots, hyphens, and underscores.
+The permission ID or slug to permanently delete from your workspace. Must be 1-128 characters and contain only letters, numbers, underscores, colons, hyphens, periods, and asterisks.
 
 WARNING: Deleting a permission has immediate and irreversible consequences:
 - All API keys with this permission will lose that access immediately

--- a/docs/product/cli/permissions/get-permission.mdx
+++ b/docs/product/cli/permissions/get-permission.mdx
@@ -23,7 +23,7 @@ unkey api permissions get-permission [flags]
 ## Flags
 
 <ParamField body="--permission" type="string" required>
-The unique identifier of the permission to retrieve. Must be a valid permission ID that begins with `perm_` and exists within your workspace.
+The ID or slug of the permission to retrieve. Must be 1-128 characters and refer to a permission that exists within your workspace.
 </ParamField>
 
 ## Global Flags

--- a/svc/api/openapi/gen.go
+++ b/svc/api/openapi/gen.go
@@ -3525,8 +3525,8 @@ type V2PermissionsCreatePermissionRequestBody struct {
 	// Examples: 'users.read', 'billing.write', 'analytics.view', 'admin.manage'
 	Name string `json:"name"`
 
-	// Slug Creates a URL-safe identifier for this permission that can be used in APIs and integrations.
-	// Must start with a letter and contain only letters, numbers, periods, underscores, and hyphens.
+	// Slug Creates an identifier for this permission that can be used in APIs and integrations.
+	// Must contain only letters, numbers, underscores, colons, hyphens, periods, and asterisks.
 	// Slugs are often used in REST endpoints, configuration files, and external integrations.
 	// Should closely match the name but in a format suitable for technical usage.
 	// Must be unique within your workspace to ensure reliable permission lookups.
@@ -3652,7 +3652,7 @@ type V2PermissionsDeleteRoleResponseBody struct {
 
 // V2PermissionsGetPermissionRequestBody defines model for V2PermissionsGetPermissionRequestBody.
 type V2PermissionsGetPermissionRequestBody struct {
-	// Permission The unique identifier of the permission to retrieve. Must be a valid permission ID that begins with 'perm_' and exists within your workspace.
+	// Permission The ID or slug of the permission to retrieve. It must refer to a permission that exists within your workspace.
 	Permission string `json:"permission"`
 }
 

--- a/svc/api/openapi/openapi-generated.yaml
+++ b/svc/api/openapi/openapi-generated.yaml
@@ -2549,8 +2549,8 @@ components:
                     maxLength: 128
                     pattern: ^[a-zA-Z0-9_:\-\.\*]+$
                     description: |
-                        Creates a URL-safe identifier for this permission that can be used in APIs and integrations.
-                        Must start with a letter and contain only letters, numbers, periods, underscores, and hyphens.
+                        Creates an identifier for this permission that can be used in APIs and integrations.
+                        Must contain only letters, numbers, underscores, colons, hyphens, periods, and asterisks.
                         Slugs are often used in REST endpoints, configuration files, and external integrations.
                         Should closely match the name but in a format suitable for technical usage.
                         Must be unique within your workspace to ensure reliable permission lookups.
@@ -2723,7 +2723,7 @@ components:
                     maxLength: 128
                     pattern: ^[a-zA-Z0-9_:\-\.\*]+$
                     description: |
-                        The unique identifier of the permission to retrieve. Must be a valid permission ID that begins with 'perm_' and exists within your workspace.
+                        The ID or slug of the permission to retrieve. It must refer to a permission that exists within your workspace.
                     example: perm_1234567890abcdef
             additionalProperties: false
         V2PermissionsGetPermissionResponseBody:

--- a/svc/api/openapi/spec/paths/v2/permissions/createPermission/V2PermissionsCreatePermissionRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/permissions/createPermission/V2PermissionsCreatePermissionRequestBody.yaml
@@ -23,8 +23,8 @@ properties:
     maxLength: 128
     pattern: ^[a-zA-Z0-9_:\-\.\*]+$
     description: |
-      Creates a URL-safe identifier for this permission that can be used in APIs and integrations.
-      Must start with a letter and contain only letters, numbers, periods, underscores, and hyphens.
+      Creates an identifier for this permission that can be used in APIs and integrations.
+      Must contain only letters, numbers, underscores, colons, hyphens, periods, and asterisks.
       Slugs are often used in REST endpoints, configuration files, and external integrations.
       Should closely match the name but in a format suitable for technical usage.
       Must be unique within your workspace to ensure reliable permission lookups.

--- a/svc/api/openapi/spec/paths/v2/permissions/getPermission/V2PermissionsGetPermissionRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/permissions/getPermission/V2PermissionsGetPermissionRequestBody.yaml
@@ -10,7 +10,7 @@ properties:
     maxLength: 128
     pattern: ^[a-zA-Z0-9_:\-\.\*]+$
     description: |
-      The unique identifier of the permission to retrieve. Must be a valid permission ID that begins with 'perm_' and exists within your workspace.
+      The ID or slug of the permission to retrieve. It must refer to a permission that exists within your workspace.
     example: perm_1234567890abcdef
 additionalProperties: false
 examples:


### PR DESCRIPTION
## Summary

- document the full supported permission slug character set
- clarify that permission lookup accepts an ID or slug
- regenerate the bundled OpenAPI schema and Go models

## Verification

- `mise exec -- go generate ./svc/api/openapi`
- `mise exec -- go test ./svc/api/openapi`
- `git diff --check`