### PR TITLE
feat(api): wire Restate ingress client

### DIFF
--- a/dev/k8s/manifests/api.yaml
+++ b/dev/k8s/manifests/api.yaml
@@ -45,6 +45,11 @@ data:
     url = "http://ctrl-api:7091"
     token = "your-local-dev-key"
 
+    [restate]
+    url = "http://restate:8080"
+    # Local Restate runs without ingress authentication and ignores this key.
+    api_key = "local-restate-auth-disabled"
+
     # Populated from the github-credentials secret (created by `dev github setup`).
     # Empty when GitHub is not set up locally, which disables github.installApp
     # and app repo connection (the `git` field on apps.createApp / apps.updateApp).

--- a/svc/api/cancel_test.go
+++ b/svc/api/cancel_test.go
@@ -46,6 +46,10 @@ func TestContextCancellation(t *testing.T) {
 			Primary: dbDsn,
 		},
 		Observability: config.Observability{},
+		Restate: api.RestateConfig{
+			URL:    "http://restate:8080",
+			APIKey: "test-restate-auth-disabled",
+		},
 		Auth: api.AuthConfigs{
 			api.RootKeyAuthConfig{Enabled: nil},
 		},

--- a/svc/api/config.go
+++ b/svc/api/config.go
@@ -53,6 +53,17 @@ type GitHubConfig struct {
 	PrivateKeyPEM string `toml:"private_key_pem"`
 }
 
+// RestateConfig configures the Restate ingress used to submit durable
+// workflows.
+type RestateConfig struct {
+	// URL is the Restate ingress endpoint.
+	URL string `toml:"url" config:"required,nonempty"`
+
+	// APIKey authenticates every ingress request. Local Restate ignores the
+	// configured dummy key because ingress authentication is disabled there.
+	APIKey string `toml:"api_key" config:"required,nonempty"`
+}
+
 const (
 	authTypeJWT           = "jwt"
 	authTypePortalSession = "portal_session"
@@ -356,6 +367,9 @@ type Config struct {
 	// Control configures the deployment management service. See [config.ControlConfig].
 	Control config.ControlConfig `toml:"control"`
 
+	// Restate configures durable workflow ingress. See [RestateConfig].
+	Restate RestateConfig `toml:"restate"`
+
 	// PortalBaseURL is the base URL for the customer portal.
 	// Example: "https://portal.unkey.com"
 	// Used to construct session redirect URLs in portal.createSession responses.
@@ -476,6 +490,25 @@ func (c *Config) Validate() error {
 		default:
 			return fmt.Errorf("auth[%d] has unsupported auth config type", i)
 		}
+	}
+
+	// Run also accepts programmatically constructed configs and calls Validate
+	// directly, so enforce these requirements here as well as in struct tags.
+	if strings.TrimSpace(c.Restate.URL) == "" {
+		return fmt.Errorf("restate.url is required")
+	}
+	restateURL, err := url.Parse(c.Restate.URL)
+	if err != nil || restateURL.Host == "" || (restateURL.Scheme != "http" && restateURL.Scheme != "https") {
+		return fmt.Errorf("restate.url must be an absolute HTTP(S) URL")
+	}
+	if restateURL.Path != "" || strings.ContainsAny(c.Restate.URL, "?#") {
+		return fmt.Errorf("restate.url must not include a path, query, or fragment")
+	}
+	if strings.TrimSpace(c.Restate.APIKey) == "" {
+		return fmt.Errorf("restate.api_key is required")
+	}
+	if c.Restate.APIKey != strings.TrimSpace(c.Restate.APIKey) {
+		return fmt.Errorf("restate.api_key must not have surrounding whitespace")
 	}
 	return nil
 }

--- a/svc/api/config_test.go
+++ b/svc/api/config_test.go
@@ -22,6 +22,16 @@ func jwtJWKSAuth(jwksURL string) AuthConfig {
 	}
 }
 
+func configWithAuth(auth AuthConfig) *Config {
+	return &Config{
+		Auth: AuthConfigs{auth},
+		Restate: RestateConfig{
+			URL:    "https://restate.example.com",
+			APIKey: "restate-test-key",
+		},
+	}
+}
+
 // TestConfig_ValidateJWTSecretMinimumLength verifies the API rejects JWT
 // secrets shorter than the HS256 entropy requirement (256 bits). Accepting a
 // shorter secret would weaken signature security across every token signed or
@@ -60,7 +70,7 @@ func TestConfig_ValidateJWTSecretMinimumLength(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			cfg := &Config{Auth: AuthConfigs{jwtSecretsAuth(tt.secrets)}}
+			cfg := configWithAuth(jwtSecretsAuth(tt.secrets))
 			err := cfg.Validate()
 			if tt.wantErr {
 				require.Error(t, err)
@@ -113,7 +123,7 @@ func TestConfig_ValidateJWTJWKSURL(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			cfg := &Config{Auth: AuthConfigs{jwtJWKSAuth(tt.url)}}
+			cfg := configWithAuth(jwtJWKSAuth(tt.url))
 			err := cfg.Validate()
 			if tt.wantErr {
 				require.Error(t, err)
@@ -146,10 +156,10 @@ func TestConfig_ValidateJWTIssuer(t *testing.T) {
 func TestConfig_ValidateJWTJWKSAcceptsAnyIssuer(t *testing.T) {
 	t.Parallel()
 
-	cfg := &Config{Auth: AuthConfigs{JWTAuthConfig{
+	cfg := configWithAuth(JWTAuthConfig{
 		Issuer:  "https://auth.acme.com",
 		JWKSURL: "https://auth.acme.com/.well-known/jwks.json",
-	}}}
+	})
 
 	require.NoError(t, cfg.Validate())
 }
@@ -160,11 +170,11 @@ func TestConfig_ValidateJWTJWKSAcceptsAnyIssuer(t *testing.T) {
 func TestConfig_ValidateAcceptsWorkOSProvider(t *testing.T) {
 	t.Parallel()
 
-	cfg := &Config{Auth: AuthConfigs{JWTAuthConfig{
+	cfg := configWithAuth(JWTAuthConfig{
 		Issuer:   "https://auth.acme.com/user_management/client_123",
 		JWKSURL:  "https://auth.acme.com/sso/jwks/client_123",
 		Provider: "workos",
-	}}}
+	})
 
 	require.NoError(t, cfg.Validate())
 }
@@ -267,6 +277,10 @@ primary = "unkey:password@tcp(mysql:3306)/unkey"
 [control]
 url = "http://control:7091"
 token = "control-token"
+
+[restate]
+url = "https://restate.example.com"
+api_key = "restate-test-key"
 `))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unknown is not valid")
@@ -317,6 +331,10 @@ primary = "unkey:password@tcp(mysql:3306)/unkey"
 [control]
 url = "http://control:7091"
 token = "control-token"
+
+[restate]
+url = "https://restate.example.com"
+api_key = "restate-test-key"
 `))
 
 	require.NoError(t, err)
@@ -332,4 +350,91 @@ token = "control-token"
 	rootKeyAuth, ok := cfg.Auth[2].(RootKeyAuthConfig)
 	require.True(t, ok)
 	require.True(t, rootKeyAuth.enabled())
+}
+
+// TestConfig_ValidateRequiresRestateCredentials guarantees the API cannot
+// start with the local ingress default or silently omit production ingress
+// authentication. Local configurations use an explicit dummy key because
+// their Restate server has authentication disabled.
+func TestConfig_ValidateRequiresRestateCredentials(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		restate RestateConfig
+		wantErr string
+	}{
+		{
+			name:    "missing URL",
+			restate: RestateConfig{URL: "", APIKey: "restate-key"},
+			wantErr: "restate.url is required",
+		},
+		{
+			name:    "missing API key",
+			restate: RestateConfig{URL: "https://restate.example.com", APIKey: ""},
+			wantErr: "restate.api_key is required",
+		},
+		{
+			name:    "relative URL",
+			restate: RestateConfig{URL: "restate:8080", APIKey: "restate-key"},
+			wantErr: "restate.url must be an absolute HTTP(S) URL",
+		},
+		{
+			name:    "unsupported URL scheme",
+			restate: RestateConfig{URL: "ftp://restate.example.com", APIKey: "restate-key"},
+			wantErr: "restate.url must be an absolute HTTP(S) URL",
+		},
+		{
+			name:    "URL with trailing slash",
+			restate: RestateConfig{URL: "https://restate.example.com/", APIKey: "restate-key"},
+			wantErr: "restate.url must not include a path, query, or fragment",
+		},
+		{
+			name:    "URL with query",
+			restate: RestateConfig{URL: "https://restate.example.com?region=us", APIKey: "restate-key"},
+			wantErr: "restate.url must not include a path, query, or fragment",
+		},
+		{
+			name:    "URL with empty query",
+			restate: RestateConfig{URL: "https://restate.example.com?", APIKey: "restate-key"},
+			wantErr: "restate.url must not include a path, query, or fragment",
+		},
+		{
+			name:    "URL with empty fragment",
+			restate: RestateConfig{URL: "https://restate.example.com#", APIKey: "restate-key"},
+			wantErr: "restate.url must not include a path, query, or fragment",
+		},
+		{
+			name:    "whitespace API key",
+			restate: RestateConfig{URL: "https://restate.example.com", APIKey: "  "},
+			wantErr: "restate.api_key is required",
+		},
+		{
+			name:    "API key with surrounding whitespace",
+			restate: RestateConfig{URL: "https://restate.example.com", APIKey: " restate-key "},
+			wantErr: "restate.api_key must not have surrounding whitespace",
+		},
+		{
+			name:    "configured",
+			restate: RestateConfig{URL: "https://restate.example.com", APIKey: "restate-key"},
+			wantErr: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := &Config{
+				Auth:    AuthConfigs{RootKeyAuthConfig{Enabled: nil}},
+				Restate: test.restate,
+			}
+			err := cfg.Validate()
+			if test.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, test.wantErr)
+		})
+	}
 }

--- a/svc/api/integration/harness.go
+++ b/svc/api/integration/harness.go
@@ -189,6 +189,10 @@ func (h *Harness) RunAPI(config ApiConfig) *ApiCluster {
 				URL:   "http://control:7091",
 				Token: "your-local-dev-key",
 			},
+			Restate: api.RestateConfig{
+				URL:    "http://restate:8080",
+				APIKey: "test-restate-auth-disabled",
+			},
 			Pprof: &sharedconfig.PprofConfig{
 				Username: "unkey",
 				Password: "password",

--- a/svc/api/routes/services.go
+++ b/svc/api/routes/services.go
@@ -1,6 +1,7 @@
 package routes
 
 import (
+	restateingress "github.com/restatedev/sdk-go/ingress"
 	"github.com/unkeyed/unkey/gen/rpc/ctrl"
 	"github.com/unkeyed/unkey/gen/rpc/vault"
 	"github.com/unkeyed/unkey/internal/services/analytics"
@@ -90,6 +91,9 @@ type Services struct {
 	// CtrlCustomDomainClient communicates with the control plane for custom
 	// domain operations (create starts a durable DNS verification workflow).
 	CtrlCustomDomainClient ctrl.CustomDomainServiceClient
+
+	// Restate submits durable workflows through the Restate ingress.
+	Restate *restateingress.Client
 
 	// PprofEnabled controls whether pprof profiling endpoints are registered.
 	PprofEnabled bool

--- a/svc/api/run.go
+++ b/svc/api/run.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
+	restate "github.com/restatedev/sdk-go"
+	restateingress "github.com/restatedev/sdk-go/ingress"
 	"github.com/unkeyed/unkey/gen/proto/ctrl/v1/ctrlv1connect"
 	"github.com/unkeyed/unkey/gen/proto/vault/v1/vaultv1connect"
 	"github.com/unkeyed/unkey/gen/rpc/ctrl"
@@ -466,6 +468,12 @@ func Run(ctx context.Context, cfg Config) error {
 		),
 	)
 
+	restateClient := restateingress.NewClient(
+		cfg.Restate.URL,
+		restate.WithAuthKey(cfg.Restate.APIKey),
+		restate.WithHttpClient(&http.Client{Timeout: 30 * time.Second}),
+	)
+
 	logger.Info("Control plane clients initialized", "url", cfg.Control.URL)
 
 	pprofEnabled := cfg.Pprof != nil && cfg.Pprof.Username != "" && cfg.Pprof.Password != ""
@@ -511,6 +519,7 @@ func Run(ctx context.Context, cfg Config) error {
 		CtrlDeploymentClient: ctrlDeploymentClient,
 		CtrlProjectClient:    ctrlProjectClient,
 		CtrlAppClient:        ctrlAppClient,
+		Restate:              restateClient,
 
 		CtrlCustomDomainClient: ctrlCustomDomainClient,
 		PprofEnabled:           pprofEnabled,

--- a/web/apps/dashboard/dev/api.toml
+++ b/web/apps/dashboard/dev/api.toml
@@ -28,3 +28,8 @@ token = "vault-test-token-123"
 [control]
 url = "http://ctrl-api:7091"
 token = "your-local-dev-key"
+
+[restate]
+url = "http://restate:8080"
+# Local Restate runs without ingress authentication and ignores this key.
+api_key = "local-restate-auth-disabled"


### PR DESCRIPTION
This sets up our API to receive restate credentials to create an ingress client.
No functionality is changed in this PR but there are plenty of PRs stacked on top of this with 1 PR per rpc to replace.

There's a matching [infra PR](https://github.com/unkeyed/infra/pull/1175) to add the required config.