### PR TITLE
feat(api): submit project deletion to Restate

### DIFF
--- a/pkg/testutil/containers/restate.go
+++ b/pkg/testutil/containers/restate.go
@@ -36,6 +36,8 @@ const (
 type RestateConfig struct {
 	// IngressURL is the Restate ingress endpoint URL.
 	IngressURL string
+	// IngressClient submits requests to the Restate ingress endpoint.
+	IngressClient *ingress.Client
 	// AdminURL is the Restate admin endpoint URL.
 	AdminURL string
 }
@@ -57,9 +59,11 @@ func Restate(t *testing.T, services ...restate.ServiceDefinition) RestateConfig 
 	require.NotEmpty(t, services, "at least one Restate service is required")
 
 	container, removeContainer := startIsolatedService(t, "restate")
+	ingressURL := fmt.Sprintf("http://%s", container.Addr(t, restatePort))
 	cfg := RestateConfig{
-		IngressURL: fmt.Sprintf("http://%s", container.Addr(t, restatePort)),
-		AdminURL:   fmt.Sprintf("http://localhost:%d", container.Port(t, restateAdminPort)),
+		IngressURL:    ingressURL,
+		IngressClient: ingress.NewClient(ingressURL),
+		AdminURL:      fmt.Sprintf("http://localhost:%d", container.Port(t, restateAdminPort)),
 	}
 
 	var worker *httptest.Server
@@ -121,7 +125,7 @@ func Restate(t *testing.T, services ...restate.ServiceDefinition) RestateConfig 
 		requestCtx, requestCancel := context.WithTimeout(readinessCtx, 2*time.Second)
 		defer requestCancel()
 		_, err := ingress.Object[string, string](
-			ingress.NewClient(cfg.IngressURL),
+			cfg.IngressClient,
 			restateReadinessServiceName,
 			"probe",
 			restateReadinessHandlerName,

--- a/pkg/testutil/containers/restate_test.go
+++ b/pkg/testutil/containers/restate_test.go
@@ -46,7 +46,7 @@ func TestRestateIsolatesConcurrentRegistrations(t *testing.T) {
 			defer cancel()
 
 			response, err := ingress.Object[string, string](
-				ingress.NewClient(cfg.IngressURL), serviceName, "same-key", handlerName,
+				cfg.IngressClient, serviceName, "same-key", handlerName,
 			).Request(ctx, "")
 			require.NoError(t, err)
 			require.Equal(t, marker+":1", response)
@@ -75,7 +75,7 @@ func TestRestateCleansUpWithInvocationInFlight(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), 250*time.Millisecond)
 	defer cancel()
 	_, err := ingress.Object[string, string](
-		ingress.NewClient(cfg.IngressURL), serviceName, "key", "sleep",
+		cfg.IngressClient, serviceName, "key", "sleep",
 	).Request(ctx, "")
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 }

--- a/svc/api/internal/testutil/channel.go
+++ b/svc/api/internal/testutil/channel.go
@@ -1,0 +1,45 @@
+package testutil
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Receive waits for one value from channel and fails the test if the channel
+// closes or the timeout expires first.
+func Receive[T any](t testing.TB, channel <-chan T, timeout time.Duration) T {
+	t.Helper()
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case value, open := <-channel:
+		require.True(t, open, "channel closed before sending a value")
+		return value
+	case <-timer.C:
+		require.FailNow(t, "timed out waiting for channel value", "timeout: %s", timeout)
+		var zero T
+		return zero
+	}
+}
+
+// RequireNoReceive fails the test if channel receives a value before the
+// timeout. Use it to verify that asynchronous work was not submitted.
+func RequireNoReceive[T any](t testing.TB, channel <-chan T, timeout time.Duration) {
+	t.Helper()
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case value, open := <-channel:
+		if !open {
+			require.FailNow(t, "channel closed unexpectedly")
+		}
+		require.FailNow(t, "received unexpected channel value", "value: %+v", value)
+	case <-timer.C:
+	}
+}

--- a/svc/api/internal/testutil/restate.go
+++ b/svc/api/internal/testutil/restate.go
@@ -1,0 +1,36 @@
+package testutil
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	restateingress "github.com/restatedev/sdk-go/ingress"
+)
+
+// NewRestateIngressClient returns an ingress client backed by an HTTP server
+// that responds with statusCode.
+func NewRestateIngressClient(t testing.TB, statusCode int) *restateingress.Client {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(statusCode)
+		if _, err := io.WriteString(w, "{\"invocationId\":\"inv_test\",\"status\":\"Accepted\"}"); err != nil {
+			t.Errorf("write Restate response: %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return restateingress.NewClient(server.URL)
+}
+
+// NewUnavailableRestateIngressClient returns an ingress client whose HTTP
+// endpoint is closed.
+func NewUnavailableRestateIngressClient(t testing.TB) *restateingress.Client {
+	t.Helper()
+
+	server := httptest.NewServer(http.NotFoundHandler())
+	url := server.URL
+	server.Close()
+	return restateingress.NewClient(url)
+}

--- a/svc/api/routes/register.go
+++ b/svc/api/routes/register.go
@@ -810,8 +810,8 @@ func Register(srv *zen.Server, svc *Services, info zen.InstanceInfo) {
 	srv.RegisterRoute(
 		protectedMiddlewares,
 		&v2ProjectsDeleteProject.Handler{
-			DB:         svc.Database,
-			CtrlClient: svc.CtrlProjectClient,
+			DB:      svc.Database,
+			Restate: svc.Restate,
 		},
 	)
 

--- a/svc/api/routes/v2_projects_delete_project/200_test.go
+++ b/svc/api/routes/v2_projects_delete_project/200_test.go
@@ -6,29 +6,35 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	ctrlv1 "github.com/unkeyed/unkey/gen/proto/ctrl/v1"
 	"github.com/unkeyed/unkey/pkg/db"
+	"github.com/unkeyed/unkey/pkg/hash"
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_projects_delete_project"
 )
 
+// TestDeleteProjectSuccessfully guarantees that the API submits the resolved
+// project key and audit payload through a real Restate server.
 func TestDeleteProjectSuccessfully(t *testing.T) {
 	ctx := context.Background()
 	h := testutil.NewHarness(t)
+	restateClient, deletes := newRecordingRestate(t)
 
-	ctrlClient := &testutil.MockProjectClient{}
 	route := &handler.Handler{
-		DB:         h.DB,
-		CtrlClient: ctrlClient,
+		DB:      h.DB,
+		Restate: restateClient,
 	}
 	h.Register(route)
 
 	workspace := h.Resources().UserWorkspace
 	rootKey := h.CreateRootKey(workspace.ID, "project.*.delete_project")
+	rootKeyID, err := db.Query.FindKeyIDByHash(ctx, h.DB.RO(), hash.Sha256(rootKey))
+	require.NoError(t, err)
 	headers := http.Header{
 		"Content-Type":  {"application/json"},
 		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
@@ -46,8 +52,6 @@ func TestDeleteProjectSuccessfully(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctrlClient.DeleteProjectCalls = nil
-
 			slug := strings.ToLower(strings.ReplaceAll(uid.New("kebap"), "_", "-"))
 			project := h.CreateProject(seed.CreateProjectRequest{
 				ID:               uid.New(uid.ProjectPrefix),
@@ -63,12 +67,11 @@ func TestDeleteProjectSuccessfully(t *testing.T) {
 			require.Equal(t, 202, res.Status, "expected 202, received: %s", res.RawBody)
 			require.NotEmpty(t, res.Body.Meta.RequestId)
 
-			// Deletion is delegated to the control plane, which also writes the audit
-			// log. Assert the RPC carried the resolved project id and the actor. The
-			// row is torn down asynchronously, so we do not assert it is gone here.
-			require.Len(t, ctrlClient.DeleteProjectCalls, 1)
-			require.Equal(t, project.ID, ctrlClient.DeleteProjectCalls[0].GetProjectId())
-			require.Equal(t, ctrlv1.ActorType_ACTOR_TYPE_ROOT_KEY, ctrlClient.DeleteProjectCalls[0].GetActor().GetType())
+			observed := testutil.Receive(t, deletes, 10*time.Second)
+			require.Equal(t, project.ID, observed.virtualObjectKey)
+			require.Equal(t, ctrlv1.ActorType_ACTOR_TYPE_ROOT_KEY, observed.request.GetActor().GetType())
+			require.Equal(t, rootKeyID, observed.request.GetActor().GetId())
+			require.NotEmpty(t, observed.request.GetCorrelationId())
 
 			_, err := db.Query.FindProjectByIdOrSlug(ctx, h.DB.RO(), db.FindProjectByIdOrSlugParams{
 				WorkspaceID: workspace.ID,

--- a/svc/api/routes/v2_projects_delete_project/400_test.go
+++ b/svc/api/routes/v2_projects_delete_project/400_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
@@ -15,10 +16,11 @@ import (
 
 func TestDeleteProjectBadRequest(t *testing.T) {
 	h := testutil.NewHarness(t)
+	restate, deletes := newRecordingRestate(t)
 
 	route := &handler.Handler{
-		DB:         h.DB,
-		CtrlClient: &testutil.MockProjectClient{},
+		DB:      h.DB,
+		Restate: restate,
 	}
 	h.Register(route)
 
@@ -60,4 +62,6 @@ func TestDeleteProjectBadRequest(t *testing.T) {
 		require.NotEmpty(t, res.Body.Meta.RequestId)
 		require.Equal(t, "Bad Request", res.Body.Error.Title)
 	})
+
+	testutil.RequireNoReceive(t, deletes, time.Second)
 }

--- a/svc/api/routes/v2_projects_delete_project/401_test.go
+++ b/svc/api/routes/v2_projects_delete_project/401_test.go
@@ -3,6 +3,7 @@ package handler_test
 import (
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
@@ -11,10 +12,11 @@ import (
 
 func TestDeleteProjectUnauthorized(t *testing.T) {
 	h := testutil.NewHarness(t)
+	restate, deletes := newRecordingRestate(t)
 
 	route := &handler.Handler{
-		DB:         h.DB,
-		CtrlClient: &testutil.MockProjectClient{},
+		DB:      h.DB,
+		Restate: restate,
 	}
 	h.Register(route)
 
@@ -27,4 +29,6 @@ func TestDeleteProjectUnauthorized(t *testing.T) {
 		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{Project: "proj_1234abcd"})
 		require.Equal(t, http.StatusUnauthorized, res.Status, "expected 401, received: %s", res.RawBody)
 	})
+
+	testutil.RequireNoReceive(t, deletes, time.Second)
 }

--- a/svc/api/routes/v2_projects_delete_project/403_test.go
+++ b/svc/api/routes/v2_projects_delete_project/403_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/unkeyed/unkey/pkg/uid"
@@ -15,10 +16,11 @@ import (
 
 func TestDeleteProjectForbidden(t *testing.T) {
 	h := testutil.NewHarness(t)
+	restate, deletes := newRecordingRestate(t)
 
 	route := &handler.Handler{
-		DB:         h.DB,
-		CtrlClient: &testutil.MockProjectClient{},
+		DB:      h.DB,
+		Restate: restate,
 	}
 	h.Register(route)
 
@@ -54,8 +56,10 @@ func TestDeleteProjectForbidden(t *testing.T) {
 			res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{Project: project.ID})
 			if tc.shouldPass {
 				require.Equal(t, 202, res.Status, "expected 202 for %v, got: %s", tc.permissions, res.RawBody)
+				testutil.Receive(t, deletes, 10*time.Second)
 			} else {
 				require.Equal(t, http.StatusForbidden, res.Status, "expected 403 for %v, got: %s", tc.permissions, res.RawBody)
+				testutil.RequireNoReceive(t, deletes, time.Second)
 			}
 		})
 	}

--- a/svc/api/routes/v2_projects_delete_project/404_test.go
+++ b/svc/api/routes/v2_projects_delete_project/404_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/unkeyed/unkey/pkg/deploy/projectgate"
@@ -16,11 +17,11 @@ import (
 
 func TestDeleteProjectNotFound(t *testing.T) {
 	h := testutil.NewHarness(t)
+	restate, deletes := newRecordingRestate(t)
 
-	ctrlClient := &testutil.MockProjectClient{}
 	route := &handler.Handler{
-		DB:         h.DB,
-		CtrlClient: ctrlClient,
+		DB:      h.DB,
+		Restate: restate,
 	}
 	h.Register(route)
 
@@ -63,7 +64,7 @@ func TestDeleteProjectNotFound(t *testing.T) {
 			res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{Project: identifier})
 			require.Equal(t, http.StatusNotFound, res.Status, "expected 404 for default project %q, received: %s", identifier, res.RawBody)
 		}
-
-		require.Empty(t, ctrlClient.DeleteProjectCalls)
 	})
+
+	testutil.RequireNoReceive(t, deletes, time.Second)
 }

--- a/svc/api/routes/v2_projects_delete_project/412_test.go
+++ b/svc/api/routes/v2_projects_delete_project/412_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/unkeyed/unkey/pkg/uid"
@@ -16,11 +17,11 @@ import (
 
 func TestDeleteProjectDeleteProtection(t *testing.T) {
 	h := testutil.NewHarness(t)
+	restate, deletes := newRecordingRestate(t)
 
-	ctrlClient := &testutil.MockProjectClient{}
 	route := &handler.Handler{
-		DB:         h.DB,
-		CtrlClient: ctrlClient,
+		DB:      h.DB,
+		Restate: restate,
 	}
 	h.Register(route)
 
@@ -46,7 +47,5 @@ func TestDeleteProjectDeleteProtection(t *testing.T) {
 	require.Equal(t, 412, res.Status, "expected 412, received: %s", res.RawBody)
 	require.NotNil(t, res.Body.Error)
 	require.Equal(t, "This project has delete protection enabled. Disable it before attempting to delete.", res.Body.Error.Detail)
-
-	// The control plane must not be invoked when delete protection blocks the request.
-	require.Empty(t, ctrlClient.DeleteProjectCalls)
+	testutil.RequireNoReceive(t, deletes, time.Second)
 }

--- a/svc/api/routes/v2_projects_delete_project/500_test.go
+++ b/svc/api/routes/v2_projects_delete_project/500_test.go
@@ -1,0 +1,54 @@
+package handler_test
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	restateingress "github.com/restatedev/sdk-go/ingress"
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
+	"github.com/unkeyed/unkey/svc/api/openapi"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_projects_delete_project"
+)
+
+// TestDeleteProjectRestateFailure guarantees that Restate rejections and
+// transport failures do not leak infrastructure details through the public API.
+func TestDeleteProjectRestateFailure(t *testing.T) {
+	t.Run("submission rejected", func(t *testing.T) {
+		assertRestateFailure(t, testutil.NewRestateIngressClient(t, http.StatusInternalServerError))
+	})
+
+	t.Run("transport unavailable", func(t *testing.T) {
+		assertRestateFailure(t, testutil.NewUnavailableRestateIngressClient(t))
+	})
+}
+
+func assertRestateFailure(t *testing.T, restate *restateingress.Client) {
+	t.Helper()
+
+	h := testutil.NewHarness(t)
+	route := &handler.Handler{DB: h.DB, Restate: restate}
+	h.Register(route)
+
+	workspace := h.Resources().UserWorkspace
+	project := h.CreateProject(seed.CreateProjectRequest{
+		ID:               uid.New(uid.ProjectPrefix),
+		WorkspaceID:      workspace.ID,
+		Name:             "Restate Failure",
+		Slug:             strings.ToLower(strings.ReplaceAll(uid.New("failure"), "_", "-")),
+		DeleteProtection: false,
+	})
+	rootKey := h.CreateRootKey(workspace.ID, "project.*.delete_project")
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}
+
+	res := testutil.CallRoute[handler.Request, openapi.InternalServerErrorResponse](h, route, headers, handler.Request{Project: project.ID})
+	require.Equal(t, http.StatusInternalServerError, res.Status, "expected 500, received: %s", res.RawBody)
+	require.Equal(t, "Failed to delete project.", res.Body.Error.Detail)
+}

--- a/svc/api/routes/v2_projects_delete_project/handler.go
+++ b/svc/api/routes/v2_projects_delete_project/handler.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"net/http"
 
-	ctrlv1 "github.com/unkeyed/unkey/gen/proto/ctrl/v1"
-	"github.com/unkeyed/unkey/gen/rpc/ctrl"
+	restateingress "github.com/restatedev/sdk-go/ingress"
+	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
+	"github.com/unkeyed/unkey/pkg/auditlog"
 	"github.com/unkeyed/unkey/pkg/codes"
 	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/deploy/projectgate"
@@ -24,8 +25,8 @@ type (
 )
 
 type Handler struct {
-	DB         db.Database
-	CtrlClient ctrl.ProjectServiceClient
+	DB      db.Database
+	Restate *restateingress.Client
 }
 
 func (h *Handler) Method() string {
@@ -47,7 +48,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	project, err := db.Query.FindProjectByIdOrSlug(ctx, h.DB.RO(), db.FindProjectByIdOrSlugParams{
+	project, err := db.Query.FindProjectByIdOrSlug(ctx, h.DB.RW(), db.FindProjectByIdOrSlugParams{
 		WorkspaceID: principal.WorkspaceID,
 		Project:     req.Project,
 	})
@@ -113,14 +114,24 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	// Deletion cascades through the project's apps, environments, and
-	// deployments via a durable Restate workflow. The control plane enqueues
-	// the workflow and returns immediately; teardown is eventually consistent.
-	_, err = h.CtrlClient.DeleteProject(ctx, &ctrlv1.DeleteProjectRequest{
-		ProjectId: project.ID,
-		Actor:     actor,
-	})
+	// deployments. Send returns once Restate has accepted the durable workflow;
+	// teardown remains eventually consistent.
+	_, err = hydrav1.NewProjectServiceIngressClient(h.Restate, project.ID).
+		Delete().
+		Send(ctx, &hydrav1.DeleteProjectRequest{
+			Actor:         actor,
+			CorrelationId: auditlog.NewCorrelationID(),
+		})
 	if err != nil {
-		return ctrlclient.HandleError(err, "delete project")
+		// Restate authentication, service discovery, capacity, and transport
+		// failures are all internal. Preserve the cause for operators without
+		// exposing infrastructure details or implying the caller can fix them.
+		return fault.Wrap(
+			err,
+			fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
+			fault.Internal("failed to submit project deletion to Restate"),
+			fault.Public("Failed to delete project."),
+		)
 	}
 
 	return s.JSON(http.StatusAccepted, Response{

--- a/svc/api/routes/v2_projects_delete_project/restate_test.go
+++ b/svc/api/routes/v2_projects_delete_project/restate_test.go
@@ -1,0 +1,45 @@
+package handler_test
+
+import (
+	"testing"
+
+	restate "github.com/restatedev/sdk-go"
+	restateingress "github.com/restatedev/sdk-go/ingress"
+	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
+	"github.com/unkeyed/unkey/pkg/testutil/containers"
+)
+
+// observedProjectDelete contains the Restate object key separately from the
+// typed request because the object key is encoded in the ingress path.
+type observedProjectDelete struct {
+	virtualObjectKey string
+	request          *hydrav1.DeleteProjectRequest
+}
+
+// recordingProjectService captures Delete invocations for route assertions.
+type recordingProjectService struct {
+	hydrav1.UnimplementedProjectServiceServer
+	deletes chan observedProjectDelete
+}
+
+// Delete records the object key and typed payload received through Restate.
+func (service *recordingProjectService) Delete(ctx restate.ObjectContext, request *hydrav1.DeleteProjectRequest) (*hydrav1.DeleteProjectResponse, error) {
+	service.deletes <- observedProjectDelete{
+		virtualObjectKey: restate.Key(ctx),
+		request:          request,
+	}
+	return &hydrav1.DeleteProjectResponse{}, nil
+}
+
+// newRecordingRestate starts an isolated Restate server whose ProjectService
+// reports each Delete invocation to the returned channel.
+func newRecordingRestate(t *testing.T) (*restateingress.Client, <-chan observedProjectDelete) {
+	t.Helper()
+
+	recorder := &recordingProjectService{
+		deletes: make(chan observedProjectDelete, 1),
+	}
+	restateConfig := containers.Restate(t, hydrav1.NewProjectServiceServer(recorder))
+
+	return restateConfig.IngressClient, recorder.deletes
+}

--- a/svc/ctrl/integration/harness/harness.go
+++ b/svc/ctrl/integration/harness/harness.go
@@ -331,7 +331,7 @@ func New(t *testing.T, opts ...Option) *Harness {
 		ClickHouseDSN:  chDSN,
 		VaultClient:    vaultClient,
 		VaultToken:     testVault.Token,
-		Restate:        ingress.NewClient(restateCfg.IngressURL),
+		Restate:        restateCfg.IngressClient,
 		RestateIngress: restateCfg.IngressURL,
 		RestateAdmin:   restateCfg.AdminURL,
 		Clock:          o.clock,


### PR DESCRIPTION
Migrate `POST /v2/projects.deleteProject` from API → ctrl → Restate to API → Restate.
We can't delete the buf service yet, because it's used in the dashboard, but once the dashboard calls the api, we will.


I've had to refactor the restate container setup a little and add some utils, so we can test this properly without actually depending on a real service implementation.

We do use a real restate, but use a fake implementation, that just returns the sent request via channel, so we can assert, that our api handler does the correct thing.
