### PR TITLE
feat(api): submit app deletion to Restate

### DIFF
--- a/svc/api/routes/register.go
+++ b/svc/api/routes/register.go
@@ -877,8 +877,8 @@ func Register(srv *zen.Server, svc *Services, info zen.InstanceInfo) {
 	srv.RegisterRoute(
 		protectedMiddlewares,
 		&v2AppsDeleteApp.Handler{
-			DB:         svc.Database,
-			CtrlClient: svc.CtrlAppClient,
+			DB:      svc.Database,
+			Restate: svc.Restate,
 		},
 	)
 

--- a/svc/api/routes/v2_apps_delete_app/200_test.go
+++ b/svc/api/routes/v2_apps_delete_app/200_test.go
@@ -6,10 +6,12 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	ctrlv1 "github.com/unkeyed/unkey/gen/proto/ctrl/v1"
 	"github.com/unkeyed/unkey/pkg/db"
+	"github.com/unkeyed/unkey/pkg/hash"
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
@@ -19,16 +21,18 @@ import (
 func TestDeleteAppSuccessfully(t *testing.T) {
 	ctx := context.Background()
 	h := testutil.NewHarness(t)
+	restateClient, deletes := newRecordingRestate(t)
 
-	ctrlClient := &testutil.MockAppClient{}
 	route := &handler.Handler{
-		DB:         h.DB,
-		CtrlClient: ctrlClient,
+		DB:      h.DB,
+		Restate: restateClient,
 	}
 	h.Register(route)
 
 	workspace := h.Resources().UserWorkspace
 	rootKey := h.CreateRootKey(workspace.ID, "app.*.delete_app")
+	rootKeyID, err := db.Query.FindKeyIDByHash(ctx, h.DB.RO(), hash.Sha256(rootKey))
+	require.NoError(t, err)
 	headers := http.Header{
 		"Content-Type":  {"application/json"},
 		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
@@ -59,15 +63,13 @@ func TestDeleteAppSuccessfully(t *testing.T) {
 	require.Equal(t, 202, res.Status, "expected 202, received: %s", res.RawBody)
 	require.NotEmpty(t, res.Body.Meta.RequestId)
 
-	// Deletion is delegated to the control plane, which also writes the audit
-	// log. Assert the RPC carried the resolved app id and the actor. The row is
-	// torn down asynchronously, so we do not assert it is gone here.
-	require.Len(t, ctrlClient.DeleteAppCalls, 1)
-	require.Equal(t, app.ID, ctrlClient.DeleteAppCalls[0].GetAppId())
-	require.Equal(t, ctrlv1.ActorType_ACTOR_TYPE_ROOT_KEY, ctrlClient.DeleteAppCalls[0].GetActor().GetType())
+	observed := testutil.Receive(t, deletes, 10*time.Second)
+	require.Equal(t, app.ID, observed.virtualObjectKey)
+	require.Equal(t, ctrlv1.ActorType_ACTOR_TYPE_ROOT_KEY, observed.request.GetActor().GetType())
+	require.Equal(t, rootKeyID, observed.request.GetActor().GetId())
+	require.NotEmpty(t, observed.request.GetCorrelationId())
 
-	// Sanity: the app still exists in our DB because the cascade runs in the
-	// (mocked) control plane, not in this handler.
-	_, err := db.Query.FindAppById(ctx, h.DB.RO(), app.ID)
+	// The route only submits the asynchronous workflow.
+	_, err = db.Query.FindAppById(ctx, h.DB.RO(), app.ID)
 	require.NoError(t, err)
 }

--- a/svc/api/routes/v2_apps_delete_app/400_test.go
+++ b/svc/api/routes/v2_apps_delete_app/400_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
@@ -15,10 +16,11 @@ import (
 
 func TestDeleteAppBadRequest(t *testing.T) {
 	h := testutil.NewHarness(t)
+	restate, deletes := newRecordingRestate(t)
 
 	route := &handler.Handler{
-		DB:         h.DB,
-		CtrlClient: &testutil.MockAppClient{},
+		DB:      h.DB,
+		Restate: restate,
 	}
 	h.Register(route)
 
@@ -65,4 +67,6 @@ func TestDeleteAppBadRequest(t *testing.T) {
 		require.NotEmpty(t, res.Body.Meta.RequestId)
 		require.Equal(t, "Bad Request", res.Body.Error.Title)
 	})
+
+	testutil.RequireNoReceive(t, deletes, time.Second)
 }

--- a/svc/api/routes/v2_apps_delete_app/401_test.go
+++ b/svc/api/routes/v2_apps_delete_app/401_test.go
@@ -3,6 +3,7 @@ package handler_test
 import (
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
@@ -11,10 +12,11 @@ import (
 
 func TestDeleteAppUnauthorized(t *testing.T) {
 	h := testutil.NewHarness(t)
+	restate, deletes := newRecordingRestate(t)
 
 	route := &handler.Handler{
-		DB:         h.DB,
-		CtrlClient: &testutil.MockAppClient{},
+		DB:      h.DB,
+		Restate: restate,
 	}
 	h.Register(route)
 
@@ -27,4 +29,6 @@ func TestDeleteAppUnauthorized(t *testing.T) {
 		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{Project: "payments", App: "app_1234abcd"})
 		require.Equal(t, http.StatusUnauthorized, res.Status, "expected 401, received: %s", res.RawBody)
 	})
+
+	testutil.RequireNoReceive(t, deletes, time.Second)
 }

--- a/svc/api/routes/v2_apps_delete_app/403_test.go
+++ b/svc/api/routes/v2_apps_delete_app/403_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/unkeyed/unkey/pkg/uid"
@@ -15,10 +16,11 @@ import (
 
 func TestDeleteAppForbidden(t *testing.T) {
 	h := testutil.NewHarness(t)
+	restate, deletes := newRecordingRestate(t)
 
 	route := &handler.Handler{
-		DB:         h.DB,
-		CtrlClient: &testutil.MockAppClient{},
+		DB:      h.DB,
+		Restate: restate,
 	}
 	h.Register(route)
 
@@ -66,8 +68,10 @@ func TestDeleteAppForbidden(t *testing.T) {
 			res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{Project: project.ID, App: app.ID})
 			if tc.shouldPass {
 				require.Equal(t, 202, res.Status, "expected 202 for %v, got: %s", tc.name, res.RawBody)
+				testutil.Receive(t, deletes, 10*time.Second)
 			} else {
 				require.Equal(t, http.StatusForbidden, res.Status, "expected 403 for %v, got: %s", tc.name, res.RawBody)
+				testutil.RequireNoReceive(t, deletes, time.Second)
 			}
 		})
 	}

--- a/svc/api/routes/v2_apps_delete_app/404_test.go
+++ b/svc/api/routes/v2_apps_delete_app/404_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/unkeyed/unkey/pkg/uid"
@@ -15,10 +16,11 @@ import (
 
 func TestDeleteAppNotFound(t *testing.T) {
 	h := testutil.NewHarness(t)
+	restate, deletes := newRecordingRestate(t)
 
 	route := &handler.Handler{
-		DB:         h.DB,
-		CtrlClient: &testutil.MockAppClient{},
+		DB:      h.DB,
+		Restate: restate,
 	}
 	h.Register(route)
 
@@ -56,4 +58,6 @@ func TestDeleteAppNotFound(t *testing.T) {
 		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{Project: otherProject.ID, App: otherApp.ID})
 		require.Equal(t, http.StatusNotFound, res.Status, "expected 404 for cross-workspace app, received: %s", res.RawBody)
 	})
+
+	testutil.RequireNoReceive(t, deletes, time.Second)
 }

--- a/svc/api/routes/v2_apps_delete_app/412_test.go
+++ b/svc/api/routes/v2_apps_delete_app/412_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/unkeyed/unkey/pkg/uid"
@@ -16,11 +17,11 @@ import (
 
 func TestDeleteAppDeleteProtection(t *testing.T) {
 	h := testutil.NewHarness(t)
+	restate, deletes := newRecordingRestate(t)
 
-	ctrlClient := &testutil.MockAppClient{}
 	route := &handler.Handler{
-		DB:         h.DB,
-		CtrlClient: ctrlClient,
+		DB:      h.DB,
+		Restate: restate,
 	}
 	h.Register(route)
 
@@ -57,7 +58,5 @@ func TestDeleteAppDeleteProtection(t *testing.T) {
 	require.Equal(t, 412, res.Status, "expected 412, received: %s", res.RawBody)
 	require.NotNil(t, res.Body.Error)
 	require.Equal(t, "This app has delete protection enabled. Disable it before attempting to delete.", res.Body.Error.Detail)
-
-	// The control plane must not be invoked when delete protection blocks the request.
-	require.Empty(t, ctrlClient.DeleteAppCalls)
+	testutil.RequireNoReceive(t, deletes, time.Second)
 }

--- a/svc/api/routes/v2_apps_delete_app/500_test.go
+++ b/svc/api/routes/v2_apps_delete_app/500_test.go
@@ -1,0 +1,62 @@
+package handler_test
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	restateingress "github.com/restatedev/sdk-go/ingress"
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
+	"github.com/unkeyed/unkey/svc/api/openapi"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_apps_delete_app"
+)
+
+func TestDeleteAppRestateFailure(t *testing.T) {
+	t.Run("submission rejected", func(t *testing.T) {
+		assertRestateFailure(t, testutil.NewRestateIngressClient(t, http.StatusInternalServerError))
+	})
+
+	t.Run("transport unavailable", func(t *testing.T) {
+		assertRestateFailure(t, testutil.NewUnavailableRestateIngressClient(t))
+	})
+}
+
+func assertRestateFailure(t *testing.T, restate *restateingress.Client) {
+	t.Helper()
+
+	h := testutil.NewHarness(t)
+	route := &handler.Handler{DB: h.DB, Restate: restate}
+	h.Register(route)
+
+	workspace := h.Resources().UserWorkspace
+	project := h.CreateProject(seed.CreateProjectRequest{
+		ID:          uid.New(uid.ProjectPrefix),
+		WorkspaceID: workspace.ID,
+		Name:        "Restate Failure",
+		Slug:        strings.ToLower(strings.ReplaceAll(uid.New("project"), "_", "-")),
+	})
+	app := h.CreateApp(seed.CreateAppRequest{
+		ID:            uid.New(uid.AppPrefix),
+		WorkspaceID:   workspace.ID,
+		ProjectID:     project.ID,
+		Name:          "Restate Failure",
+		Slug:          strings.ToLower(strings.ReplaceAll(uid.New("app"), "_", "-")),
+		DefaultBranch: "main",
+	})
+	rootKey := h.CreateRootKey(workspace.ID, "app.*.delete_app")
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}
+
+	res := testutil.CallRoute[handler.Request, openapi.InternalServerErrorResponse](h, route, headers, handler.Request{
+		Project: project.ID,
+		App:     app.ID,
+	})
+	require.Equal(t, http.StatusInternalServerError, res.Status, "expected 500, received: %s", res.RawBody)
+	require.Equal(t, "Failed to delete app.", res.Body.Error.Detail)
+}

--- a/svc/api/routes/v2_apps_delete_app/handler.go
+++ b/svc/api/routes/v2_apps_delete_app/handler.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"net/http"
 
-	ctrlv1 "github.com/unkeyed/unkey/gen/proto/ctrl/v1"
-	"github.com/unkeyed/unkey/gen/rpc/ctrl"
+	restateingress "github.com/restatedev/sdk-go/ingress"
+	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
+	"github.com/unkeyed/unkey/pkg/auditlog"
 	"github.com/unkeyed/unkey/pkg/codes"
 	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/fault"
@@ -23,8 +24,8 @@ type (
 )
 
 type Handler struct {
-	DB         db.Database
-	CtrlClient ctrl.AppServiceClient
+	DB      db.Database
+	Restate *restateingress.Client
 }
 
 func (h *Handler) Method() string {
@@ -46,7 +47,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	app, err := db.Query.FindAppByProjectAndIdOrSlug(ctx, h.DB.RO(), db.FindAppByProjectAndIdOrSlugParams{
+	app, err := db.Query.FindAppByProjectAndIdOrSlug(ctx, h.DB.RW(), db.FindAppByProjectAndIdOrSlugParams{
 		WorkspaceID: principal.WorkspaceID,
 		Project:     req.Project,
 		App:         req.App,
@@ -103,15 +104,22 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	// Deletion cascades through the app's environments and deployments via a
-	// durable Restate workflow. The control plane enqueues the workflow and
-	// returns immediately; teardown is eventually consistent.
-	_, err = h.CtrlClient.DeleteApp(ctx, &ctrlv1.DeleteAppRequest{
-		AppId: app.ID,
-		Actor: actor,
-	})
+	// Deletion cascades through the app's environments and deployments. Send
+	// returns once Restate accepts the durable workflow; teardown remains
+	// eventually consistent.
+	_, err = hydrav1.NewAppServiceIngressClient(h.Restate, app.ID).
+		Delete().
+		Send(ctx, &hydrav1.DeleteAppRequest{
+			Actor:         actor,
+			CorrelationId: auditlog.NewCorrelationID(),
+		})
 	if err != nil {
-		return ctrlclient.HandleError(err, "delete app")
+		return fault.Wrap(
+			err,
+			fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
+			fault.Internal("failed to submit app deletion to Restate"),
+			fault.Public("Failed to delete app."),
+		)
 	}
 
 	return s.JSON(http.StatusAccepted, Response{

--- a/svc/api/routes/v2_apps_delete_app/restate_test.go
+++ b/svc/api/routes/v2_apps_delete_app/restate_test.go
@@ -1,0 +1,45 @@
+package handler_test
+
+import (
+	"testing"
+
+	restate "github.com/restatedev/sdk-go"
+	restateingress "github.com/restatedev/sdk-go/ingress"
+	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
+	"github.com/unkeyed/unkey/pkg/testutil/containers"
+)
+
+// observedAppDelete contains the Restate object key separately from the typed
+// request because the object key is encoded in the ingress path.
+type observedAppDelete struct {
+	virtualObjectKey string
+	request          *hydrav1.DeleteAppRequest
+}
+
+// recordingAppService captures Delete invocations for route assertions.
+type recordingAppService struct {
+	hydrav1.UnimplementedAppServiceServer
+	deletes chan observedAppDelete
+}
+
+// Delete records the object key and typed payload received through Restate.
+func (service *recordingAppService) Delete(ctx restate.ObjectContext, request *hydrav1.DeleteAppRequest) (*hydrav1.DeleteAppResponse, error) {
+	service.deletes <- observedAppDelete{
+		virtualObjectKey: restate.Key(ctx),
+		request:          request,
+	}
+	return &hydrav1.DeleteAppResponse{}, nil
+}
+
+// newRecordingRestate starts an isolated Restate server whose AppService
+// reports each Delete invocation to the returned channel.
+func newRecordingRestate(t *testing.T) (*restateingress.Client, <-chan observedAppDelete) {
+	t.Helper()
+
+	recorder := &recordingAppService{
+		deletes: make(chan observedAppDelete, 1),
+	}
+	restateConfig := containers.Restate(t, hydrav1.NewAppServiceServer(recorder))
+
+	return restateConfig.IngressClient, recorder.deletes
+}


### PR DESCRIPTION
Migrate app deletions from `API -> Control -> Restate` to just `API -> Restate`