### PR TITLE
feat(api): submit deployment promotions to Restate

### DIFF
--- a/gen/proto/hydra/v1/deploy.pb.go
+++ b/gen/proto/hydra/v1/deploy.pb.go
@@ -761,6 +761,8 @@ func (*RollbackResponse) Descriptor() ([]byte, []int) {
 type PromoteRequest struct {
 	state              protoimpl.MessageState `protogen:"open.v1"`
 	TargetDeploymentId string                 `protobuf:"bytes,1,opt,name=target_deployment_id,json=targetDeploymentId,proto3" json:"target_deployment_id,omitempty"`
+	Actor              *v1.ActorInfo          `protobuf:"bytes,2,opt,name=actor,proto3" json:"actor,omitempty"`
+	CorrelationId      string                 `protobuf:"bytes,3,opt,name=correlation_id,json=correlationId,proto3" json:"correlation_id,omitempty"`
 	unknownFields      protoimpl.UnknownFields
 	sizeCache          protoimpl.SizeCache
 }
@@ -798,6 +800,20 @@ func (*PromoteRequest) Descriptor() ([]byte, []int) {
 func (x *PromoteRequest) GetTargetDeploymentId() string {
 	if x != nil {
 		return x.TargetDeploymentId
+	}
+	return ""
+}
+
+func (x *PromoteRequest) GetActor() *v1.ActorInfo {
+	if x != nil {
+		return x.Actor
+	}
+	return nil
+}
+
+func (x *PromoteRequest) GetCorrelationId() string {
+	if x != nil {
+		return x.CorrelationId
 	}
 	return ""
 }
@@ -1065,9 +1081,11 @@ const file_hydra_v1_deploy_proto_rawDesc = "" +
 	"\x0fRollbackRequest\x120\n" +
 	"\x14source_deployment_id\x18\x01 \x01(\tR\x12sourceDeploymentId\x120\n" +
 	"\x14target_deployment_id\x18\x02 \x01(\tR\x12targetDeploymentId\"\x12\n" +
-	"\x10RollbackResponse\"B\n" +
+	"\x10RollbackResponse\"\x93\x01\n" +
 	"\x0ePromoteRequest\x120\n" +
-	"\x14target_deployment_id\x18\x01 \x01(\tR\x12targetDeploymentId\"\x11\n" +
+	"\x14target_deployment_id\x18\x01 \x01(\tR\x12targetDeploymentId\x12(\n" +
+	"\x05actor\x18\x02 \x01(\v2\x12.ctrl.v1.ActorInfoR\x05actor\x12%\n" +
+	"\x0ecorrelation_id\x18\x03 \x01(\tR\rcorrelationId\"\x11\n" +
 	"\x0fPromoteResponse\"=\n" +
 	"\x0fTeardownRequest\x12*\n" +
 	"\x04mode\x18\x01 \x01(\x0e2\x16.hydra.v1.TeardownModeR\x04mode\"]\n" +
@@ -1134,28 +1152,29 @@ var file_hydra_v1_deploy_proto_depIdxs = []int32{
 	19, // 1: hydra.v1.WakeDeploymentRequest.actor:type_name -> ctrl.v1.ActorInfo
 	8,  // 2: hydra.v1.DeployRequest.git:type_name -> hydra.v1.GitSource
 	7,  // 3: hydra.v1.DeployRequest.docker_image:type_name -> hydra.v1.DockerImage
-	0,  // 4: hydra.v1.TeardownRequest.mode:type_name -> hydra.v1.TeardownMode
-	9,  // 5: hydra.v1.DeployService.Deploy:input_type -> hydra.v1.DeployRequest
-	11, // 6: hydra.v1.DeployService.Rollback:input_type -> hydra.v1.RollbackRequest
-	13, // 7: hydra.v1.DeployService.Promote:input_type -> hydra.v1.PromoteRequest
-	1,  // 8: hydra.v1.DeployService.StopDeployment:input_type -> hydra.v1.StopDeploymentRequest
-	3,  // 9: hydra.v1.DeployService.WakeDeployment:input_type -> hydra.v1.WakeDeploymentRequest
-	5,  // 10: hydra.v1.DeployService.NotifyInstancesReady:input_type -> hydra.v1.NotifyInstancesReadyRequest
-	15, // 11: hydra.v1.DeployTeardownService.Teardown:input_type -> hydra.v1.TeardownRequest
-	17, // 12: hydra.v1.DeployTeardownService.Resume:input_type -> hydra.v1.ResumeRequest
-	10, // 13: hydra.v1.DeployService.Deploy:output_type -> hydra.v1.DeployResponse
-	12, // 14: hydra.v1.DeployService.Rollback:output_type -> hydra.v1.RollbackResponse
-	14, // 15: hydra.v1.DeployService.Promote:output_type -> hydra.v1.PromoteResponse
-	2,  // 16: hydra.v1.DeployService.StopDeployment:output_type -> hydra.v1.StopDeploymentResponse
-	4,  // 17: hydra.v1.DeployService.WakeDeployment:output_type -> hydra.v1.WakeDeploymentResponse
-	6,  // 18: hydra.v1.DeployService.NotifyInstancesReady:output_type -> hydra.v1.NotifyInstancesReadyResponse
-	16, // 19: hydra.v1.DeployTeardownService.Teardown:output_type -> hydra.v1.TeardownResponse
-	18, // 20: hydra.v1.DeployTeardownService.Resume:output_type -> hydra.v1.ResumeResponse
-	13, // [13:21] is the sub-list for method output_type
-	5,  // [5:13] is the sub-list for method input_type
-	5,  // [5:5] is the sub-list for extension type_name
-	5,  // [5:5] is the sub-list for extension extendee
-	0,  // [0:5] is the sub-list for field type_name
+	19, // 4: hydra.v1.PromoteRequest.actor:type_name -> ctrl.v1.ActorInfo
+	0,  // 5: hydra.v1.TeardownRequest.mode:type_name -> hydra.v1.TeardownMode
+	9,  // 6: hydra.v1.DeployService.Deploy:input_type -> hydra.v1.DeployRequest
+	11, // 7: hydra.v1.DeployService.Rollback:input_type -> hydra.v1.RollbackRequest
+	13, // 8: hydra.v1.DeployService.Promote:input_type -> hydra.v1.PromoteRequest
+	1,  // 9: hydra.v1.DeployService.StopDeployment:input_type -> hydra.v1.StopDeploymentRequest
+	3,  // 10: hydra.v1.DeployService.WakeDeployment:input_type -> hydra.v1.WakeDeploymentRequest
+	5,  // 11: hydra.v1.DeployService.NotifyInstancesReady:input_type -> hydra.v1.NotifyInstancesReadyRequest
+	15, // 12: hydra.v1.DeployTeardownService.Teardown:input_type -> hydra.v1.TeardownRequest
+	17, // 13: hydra.v1.DeployTeardownService.Resume:input_type -> hydra.v1.ResumeRequest
+	10, // 14: hydra.v1.DeployService.Deploy:output_type -> hydra.v1.DeployResponse
+	12, // 15: hydra.v1.DeployService.Rollback:output_type -> hydra.v1.RollbackResponse
+	14, // 16: hydra.v1.DeployService.Promote:output_type -> hydra.v1.PromoteResponse
+	2,  // 17: hydra.v1.DeployService.StopDeployment:output_type -> hydra.v1.StopDeploymentResponse
+	4,  // 18: hydra.v1.DeployService.WakeDeployment:output_type -> hydra.v1.WakeDeploymentResponse
+	6,  // 19: hydra.v1.DeployService.NotifyInstancesReady:output_type -> hydra.v1.NotifyInstancesReadyResponse
+	16, // 20: hydra.v1.DeployTeardownService.Teardown:output_type -> hydra.v1.TeardownResponse
+	18, // 21: hydra.v1.DeployTeardownService.Resume:output_type -> hydra.v1.ResumeResponse
+	14, // [14:22] is the sub-list for method output_type
+	6,  // [6:14] is the sub-list for method input_type
+	6,  // [6:6] is the sub-list for extension type_name
+	6,  // [6:6] is the sub-list for extension extendee
+	0,  // [0:6] is the sub-list for field type_name
 }
 
 func init() { file_hydra_v1_deploy_proto_init() }

--- a/svc/api/routes/register.go
+++ b/svc/api/routes/register.go
@@ -403,8 +403,8 @@ func Register(srv *zen.Server, svc *Services, info zen.InstanceInfo) {
 	srv.RegisterRoute(
 		protectedMiddlewares,
 		&v2DeploymentsPromoteDeployment.Handler{
-			DB:         svc.Database,
-			CtrlClient: svc.CtrlDeploymentClient,
+			DB:      svc.Database,
+			Restate: svc.Restate,
 		},
 	)
 

--- a/svc/api/routes/v2_deployments_promote_deployment/202_test.go
+++ b/svc/api/routes/v2_deployments_promote_deployment/202_test.go
@@ -1,12 +1,17 @@
 package handler_test
 
 import (
+	"context"
 	"net/http"
 	"testing"
+	"time"
 
 	mysqltype "github.com/unkeyed/unkey/pkg/mysql/types"
 
 	"github.com/stretchr/testify/require"
+	ctrlv1 "github.com/unkeyed/unkey/gen/proto/ctrl/v1"
+	"github.com/unkeyed/unkey/pkg/db"
+	"github.com/unkeyed/unkey/pkg/hash"
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
@@ -15,8 +20,8 @@ import (
 
 func TestPromoteDeployment(t *testing.T) {
 	h := testutil.NewHarness(t)
-	mock := &testutil.MockDeploymentClient{}
-	route := newRoute(h, mock)
+	restate, promotions := newRecordingRestate(t)
+	route := newRoute(h, restate)
 	h.Register(route)
 
 	setup := h.CreateTestDeploymentSetup(testutil.CreateTestDeploymentSetupOptions{
@@ -47,16 +52,23 @@ func TestPromoteDeployment(t *testing.T) {
 	})
 	require.Equal(t, http.StatusAccepted, res.Status, "expected 202, received: %s", res.RawBody)
 
-	require.Len(t, mock.PromoteCalls, 1)
-	require.Equal(t, target.ID, mock.PromoteCalls[0].GetTargetDeploymentId())
+	rootKeyID, err := db.Query.FindKeyIDByHash(context.Background(), h.DB.RO(), hash.Sha256(setup.RootKey))
+	require.NoError(t, err)
+
+	observed := testutil.Receive(t, promotions, 10*time.Second)
+	require.Equal(t, target.ID, observed.virtualObjectKey)
+	require.Equal(t, target.ID, observed.request.GetTargetDeploymentId())
+	require.Equal(t, ctrlv1.ActorType_ACTOR_TYPE_ROOT_KEY, observed.request.GetActor().GetType())
+	require.Equal(t, rootKeyID, observed.request.GetActor().GetId())
+	require.NotEmpty(t, observed.request.GetCorrelationId())
 }
 
 // Promoting the live deployment while the app is rolled back confirms the
 // rollback, so it must be allowed through to ctrl.
 func TestPromoteDeploymentConfirmRollback(t *testing.T) {
 	h := testutil.NewHarness(t)
-	mock := &testutil.MockDeploymentClient{}
-	route := newRoute(h, mock)
+	restate, promotions := newRecordingRestate(t)
+	route := newRoute(h, restate)
 	h.Register(route)
 
 	setup := h.CreateTestDeploymentSetup(testutil.CreateTestDeploymentSetupOptions{
@@ -78,6 +90,7 @@ func TestPromoteDeploymentConfirmRollback(t *testing.T) {
 	})
 	require.Equal(t, http.StatusAccepted, res.Status, "expected 202, received: %s", res.RawBody)
 
-	require.Len(t, mock.PromoteCalls, 1)
-	require.Equal(t, live.ID, mock.PromoteCalls[0].GetTargetDeploymentId())
+	observed := testutil.Receive(t, promotions, 10*time.Second)
+	require.Equal(t, live.ID, observed.virtualObjectKey)
+	require.Equal(t, live.ID, observed.request.GetTargetDeploymentId())
 }

--- a/svc/api/routes/v2_deployments_promote_deployment/400_test.go
+++ b/svc/api/routes/v2_deployments_promote_deployment/400_test.go
@@ -13,8 +13,7 @@ import (
 
 func TestPromoteDeploymentValidationErrors(t *testing.T) {
 	h := testutil.NewHarness(t)
-	mock := &testutil.MockDeploymentClient{}
-	route := newRoute(h, mock)
+	route := newRoute(h, newUncalledRestate(t))
 	h.Register(route)
 
 	workspace := h.Resources().UserWorkspace
@@ -37,5 +36,4 @@ func TestPromoteDeploymentValidationErrors(t *testing.T) {
 		})
 	}
 
-	require.Empty(t, mock.PromoteCalls, "ctrl must not be called for invalid requests")
 }

--- a/svc/api/routes/v2_deployments_promote_deployment/401_test.go
+++ b/svc/api/routes/v2_deployments_promote_deployment/401_test.go
@@ -13,8 +13,7 @@ import (
 
 func TestPromoteDeploymentUnauthorized(t *testing.T) {
 	h := testutil.NewHarness(t)
-	mock := &testutil.MockDeploymentClient{}
-	route := newRoute(h, mock)
+	route := newRoute(h, newUncalledRestate(t))
 	h.Register(route)
 
 	setup := h.CreateTestDeploymentSetup(testutil.CreateTestDeploymentSetupOptions{
@@ -36,5 +35,4 @@ func TestPromoteDeploymentUnauthorized(t *testing.T) {
 
 	res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{DeploymentId: dep.ID})
 	require.Equal(t, http.StatusUnauthorized, res.Status, "expected 401, received: %s", res.RawBody)
-	require.Empty(t, mock.PromoteCalls, "ctrl must not be called without authentication")
 }

--- a/svc/api/routes/v2_deployments_promote_deployment/404_test.go
+++ b/svc/api/routes/v2_deployments_promote_deployment/404_test.go
@@ -14,8 +14,7 @@ import (
 
 func TestPromoteDeploymentNotFound(t *testing.T) {
 	h := testutil.NewHarness(t)
-	mock := &testutil.MockDeploymentClient{}
-	route := newRoute(h, mock)
+	route := newRoute(h, newUncalledRestate(t))
 	h.Register(route)
 
 	setup := h.CreateTestDeploymentSetup(testutil.CreateTestDeploymentSetupOptions{
@@ -26,15 +25,13 @@ func TestPromoteDeploymentNotFound(t *testing.T) {
 		DeploymentId: uid.New(uid.DeploymentPrefix),
 	})
 	require.Equal(t, http.StatusNotFound, res.Status, "expected 404, received: %s", res.RawBody)
-	require.Empty(t, mock.PromoteCalls, "ctrl must not be called for unknown deployments")
 }
 
 // A key without promote_deployment must not learn whether the deployment
 // exists: the handler masks the authorization failure as a 404.
 func TestPromoteDeploymentInsufficientPermissionsMasked(t *testing.T) {
 	h := testutil.NewHarness(t)
-	mock := &testutil.MockDeploymentClient{}
-	route := newRoute(h, mock)
+	route := newRoute(h, newUncalledRestate(t))
 	h.Register(route)
 
 	setup := h.CreateTestDeploymentSetup(testutil.CreateTestDeploymentSetupOptions{
@@ -51,15 +48,13 @@ func TestPromoteDeploymentInsufficientPermissionsMasked(t *testing.T) {
 
 	res := testutil.CallRoute[handler.Request, openapi.NotFoundErrorResponse](h, route, authHeaders(setup.RootKey), handler.Request{DeploymentId: dep.ID})
 	require.Equal(t, http.StatusNotFound, res.Status, "expected 404, received: %s", res.RawBody)
-	require.Empty(t, mock.PromoteCalls, "ctrl must not be called without promote_deployment")
 }
 
 // A deployment in another workspace must be indistinguishable from one that does
 // not exist, so cross-workspace calls return 404 rather than leaking existence.
 func TestPromoteDeploymentInAnotherWorkspace(t *testing.T) {
 	h := testutil.NewHarness(t)
-	mock := &testutil.MockDeploymentClient{}
-	route := newRoute(h, mock)
+	route := newRoute(h, newUncalledRestate(t))
 	h.Register(route)
 
 	caller := h.CreateTestDeploymentSetup(testutil.CreateTestDeploymentSetupOptions{
@@ -77,5 +72,4 @@ func TestPromoteDeploymentInAnotherWorkspace(t *testing.T) {
 
 	res := testutil.CallRoute[handler.Request, openapi.NotFoundErrorResponse](h, route, authHeaders(caller.RootKey), handler.Request{DeploymentId: dep.ID})
 	require.Equal(t, http.StatusNotFound, res.Status, "expected 404, received: %s", res.RawBody)
-	require.Empty(t, mock.PromoteCalls, "ctrl must not be called for cross-workspace deployments")
 }

--- a/svc/api/routes/v2_deployments_promote_deployment/412_test.go
+++ b/svc/api/routes/v2_deployments_promote_deployment/412_test.go
@@ -1,16 +1,12 @@
 package handler_test
 
 import (
-	"context"
-	"fmt"
 	"net/http"
 	"testing"
 
 	mysqltype "github.com/unkeyed/unkey/pkg/mysql/types"
 
-	"connectrpc.com/connect"
 	"github.com/stretchr/testify/require"
-	ctrlv1 "github.com/unkeyed/unkey/gen/proto/ctrl/v1"
 	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
@@ -22,8 +18,7 @@ import (
 // Promoting a deployment that never became ready fails before ctrl is called.
 func TestPromoteDeploymentNotReady(t *testing.T) {
 	h := testutil.NewHarness(t)
-	mock := &testutil.MockDeploymentClient{}
-	route := newRoute(h, mock)
+	route := newRoute(h, newUncalledRestate(t))
 	h.Register(route)
 
 	setup := h.CreateTestDeploymentSetup(testutil.CreateTestDeploymentSetupOptions{
@@ -43,7 +38,6 @@ func TestPromoteDeploymentNotReady(t *testing.T) {
 	require.Equal(t, http.StatusPreconditionFailed, res.Status, "expected 412, received: %s", res.RawBody)
 	require.Contains(t, res.Body.Error.Detail, "is not ready")
 	require.Contains(t, res.Body.Error.Type, "deployment_not_ready")
-	require.Empty(t, mock.PromoteCalls, "ctrl must not be called for a non-ready deployment")
 }
 
 // A demoted deployment keeps status ready while draining toward standby
@@ -51,8 +45,7 @@ func TestPromoteDeploymentNotReady(t *testing.T) {
 // that is shutting down, so it is rejected before ctrl is called.
 func TestPromoteDeploymentShuttingDown(t *testing.T) {
 	h := testutil.NewHarness(t)
-	mock := &testutil.MockDeploymentClient{}
-	route := newRoute(h, mock)
+	route := newRoute(h, newUncalledRestate(t))
 	h.Register(route)
 
 	setup := h.CreateTestDeploymentSetup(testutil.CreateTestDeploymentSetupOptions{
@@ -78,15 +71,13 @@ func TestPromoteDeploymentShuttingDown(t *testing.T) {
 	require.Equal(t, http.StatusPreconditionFailed, res.Status, "expected 412, received: %s", res.RawBody)
 	require.Contains(t, res.Body.Error.Detail, "shutting down")
 	require.Contains(t, res.Body.Error.Type, "deployment_not_ready")
-	require.Empty(t, mock.PromoteCalls, "ctrl must not be called for a deployment that is shutting down")
 }
 
 // Promotion swaps the app's production live pointer, so it is rejected for
 // non-production environments before ctrl is called.
 func TestPromoteDeploymentNonProduction(t *testing.T) {
 	h := testutil.NewHarness(t)
-	mock := &testutil.MockDeploymentClient{}
-	route := newRoute(h, mock)
+	route := newRoute(h, newUncalledRestate(t))
 	h.Register(route)
 
 	setup := h.CreateTestDeploymentSetup(testutil.CreateTestDeploymentSetupOptions{
@@ -115,14 +106,12 @@ func TestPromoteDeploymentNonProduction(t *testing.T) {
 	require.Equal(t, http.StatusPreconditionFailed, res.Status, "expected 412, received: %s", res.RawBody)
 	require.Contains(t, res.Body.Error.Detail, "Only production deployments")
 	require.Contains(t, res.Body.Error.Type, "deployment_not_production")
-	require.Empty(t, mock.PromoteCalls, "ctrl must not be called for non-production deployments")
 }
 
 // Promoting when the app has no live deployment fails before ctrl is called.
 func TestPromoteDeploymentNoLiveDeployment(t *testing.T) {
 	h := testutil.NewHarness(t)
-	mock := &testutil.MockDeploymentClient{}
-	route := newRoute(h, mock)
+	route := newRoute(h, newUncalledRestate(t))
 	h.Register(route)
 
 	setup := h.CreateTestDeploymentSetup(testutil.CreateTestDeploymentSetupOptions{
@@ -142,15 +131,13 @@ func TestPromoteDeploymentNoLiveDeployment(t *testing.T) {
 	require.Equal(t, http.StatusPreconditionFailed, res.Status, "expected 412, received: %s", res.RawBody)
 	require.Contains(t, res.Body.Error.Detail, "no current deployment")
 	require.Contains(t, res.Body.Error.Type, "deployment_no_current")
-	require.Empty(t, mock.PromoteCalls, "ctrl must not be called when the app has no live deployment")
 }
 
 // Promoting the deployment that is already live (and not rolled back) fails
 // before ctrl is called.
 func TestPromoteDeploymentAlreadyLive(t *testing.T) {
 	h := testutil.NewHarness(t)
-	mock := &testutil.MockDeploymentClient{}
-	route := newRoute(h, mock)
+	route := newRoute(h, newUncalledRestate(t))
 	h.Register(route)
 
 	setup := h.CreateTestDeploymentSetup(testutil.CreateTestDeploymentSetupOptions{
@@ -171,25 +158,16 @@ func TestPromoteDeploymentAlreadyLive(t *testing.T) {
 	require.Equal(t, http.StatusPreconditionFailed, res.Status, "expected 412, received: %s", res.RawBody)
 	require.Contains(t, res.Body.Error.Detail, "already the current deployment")
 	require.Contains(t, res.Body.Error.Type, "deployment_is_current")
-	require.Empty(t, mock.PromoteCalls, "ctrl must not be called when the deployment is already live")
 }
 
-// A ctrl precondition failure (e.g. a concurrent promotion) must surface as a
-// 412, not a 500, and must not leak ctrl's internal error text.
-func TestPromoteDeploymentCtrlPreconditionFailed(t *testing.T) {
+func TestPromoteDeploymentRequiresComputePlan(t *testing.T) {
 	h := testutil.NewHarness(t)
-	mock := &testutil.MockDeploymentClient{
-		PromoteFunc: func(ctx context.Context, req *ctrlv1.PromoteRequest) (*ctrlv1.PromoteResponse, error) {
-			return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("target deployment is already the live deployment"))
-		},
-	}
-	route := newRoute(h, mock)
+	route := newRoute(h, newUncalledRestate(t))
 	h.Register(route)
-
 	setup := h.CreateTestDeploymentSetup(testutil.CreateTestDeploymentSetupOptions{
 		Permissions: []string{"environment.*.promote_deployment"},
 	})
-
+	h.ClearComputePlanOverride(setup.Workspace.ID)
 	live := h.CreateDeployment(seed.CreateDeploymentRequest{
 		ID:            uid.New(uid.DeploymentPrefix),
 		WorkspaceID:   setup.Workspace.ID,
@@ -199,7 +177,6 @@ func TestPromoteDeploymentCtrlPreconditionFailed(t *testing.T) {
 		Status:        mysqltype.DeploymentsStatusReady,
 	})
 	setCurrentDeployment(t, h, setup.App.ID, live.ID)
-
 	target := h.CreateDeployment(seed.CreateDeploymentRequest{
 		ID:            uid.New(uid.DeploymentPrefix),
 		WorkspaceID:   setup.Workspace.ID,
@@ -211,10 +188,5 @@ func TestPromoteDeploymentCtrlPreconditionFailed(t *testing.T) {
 
 	res := testutil.CallRoute[handler.Request, openapi.PreconditionFailedErrorResponse](h, route, authHeaders(setup.RootKey), handler.Request{DeploymentId: target.ID})
 	require.Equal(t, http.StatusPreconditionFailed, res.Status, "expected 412, received: %s", res.RawBody)
-	require.Len(t, mock.PromoteCalls, 1)
-
-	// Only the fixed public message may reach the caller; ctrl's internal error
-	// text must stay in the logs.
-	require.Contains(t, res.Body.Error.Detail, "The deployment could not be promoted.")
-	require.NotContains(t, res.RawBody, "target deployment is already the live deployment")
+	require.Equal(t, "The workspace has no active Compute plan.", res.Body.Error.Detail)
 }

--- a/svc/api/routes/v2_deployments_promote_deployment/500_test.go
+++ b/svc/api/routes/v2_deployments_promote_deployment/500_test.go
@@ -1,0 +1,47 @@
+package handler_test
+
+import (
+	"net/http"
+	"testing"
+
+	restateingress "github.com/restatedev/sdk-go/ingress"
+	"github.com/stretchr/testify/require"
+	mysqltype "github.com/unkeyed/unkey/pkg/mysql/types"
+	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
+	"github.com/unkeyed/unkey/svc/api/openapi"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_deployments_promote_deployment"
+)
+
+func TestPromoteDeploymentRestateFailure(t *testing.T) {
+	t.Run("submission rejected", func(t *testing.T) {
+		assertRestateFailure(t, testutil.NewRestateIngressClient(t, http.StatusInternalServerError))
+	})
+	t.Run("transport unavailable", func(t *testing.T) {
+		assertRestateFailure(t, testutil.NewUnavailableRestateIngressClient(t))
+	})
+}
+
+func assertRestateFailure(t *testing.T, restate *restateingress.Client) {
+	t.Helper()
+	h := testutil.NewHarness(t)
+	route := newRoute(h, restate)
+	h.Register(route)
+	setup := h.CreateTestDeploymentSetup(testutil.CreateTestDeploymentSetupOptions{
+		Permissions: []string{"environment.*.promote_deployment"},
+	})
+	live := h.CreateDeployment(seed.CreateDeploymentRequest{
+		ID: uid.New(uid.DeploymentPrefix), WorkspaceID: setup.Workspace.ID, ProjectID: setup.Project.ID,
+		AppID: setup.App.ID, EnvironmentID: setup.Environment.ID, Status: mysqltype.DeploymentsStatusReady,
+	})
+	setCurrentDeployment(t, h, setup.App.ID, live.ID)
+	target := h.CreateDeployment(seed.CreateDeploymentRequest{
+		ID: uid.New(uid.DeploymentPrefix), WorkspaceID: setup.Workspace.ID, ProjectID: setup.Project.ID,
+		AppID: setup.App.ID, EnvironmentID: setup.Environment.ID, Status: mysqltype.DeploymentsStatusReady,
+	})
+
+	res := testutil.CallRoute[handler.Request, openapi.InternalServerErrorResponse](h, route, authHeaders(setup.RootKey), handler.Request{DeploymentId: target.ID})
+	require.Equal(t, http.StatusInternalServerError, res.Status, "expected 500, received: %s", res.RawBody)
+	require.Equal(t, "Failed to promote deployment.", res.Body.Error.Detail)
+}

--- a/svc/api/routes/v2_deployments_promote_deployment/handler.go
+++ b/svc/api/routes/v2_deployments_promote_deployment/handler.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"net/http"
 
-	ctrlv1 "github.com/unkeyed/unkey/gen/proto/ctrl/v1"
-	"github.com/unkeyed/unkey/gen/rpc/ctrl"
+	restateingress "github.com/restatedev/sdk-go/ingress"
+	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
+	"github.com/unkeyed/unkey/pkg/auditlog"
 	"github.com/unkeyed/unkey/pkg/codes"
 	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/deploy/deploygate"
@@ -25,8 +26,8 @@ type (
 )
 
 type Handler struct {
-	DB         db.Database
-	CtrlClient ctrl.DeployServiceClient
+	DB      db.Database
+	Restate *restateingress.Client
 }
 
 func (h *Handler) Method() string {
@@ -81,7 +82,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	// The current live pointer decides promote eligibility. See
 	// deploygate.CheckPromoteTarget for the invariant the API, ctrl service, and
 	// worker all enforce.
-	app, err := db.Query.FindAppById(ctx, h.DB.RO(), dep.AppID)
+	app, err := db.Query.FindAppById(ctx, h.DB.RW(), dep.AppID)
 	if err != nil {
 		return fault.Wrap(
 			err,
@@ -102,18 +103,41 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
+	billing, err := db.Query.FindWorkspaceBillingByWorkspaceID(ctx, h.DB.RW(), principal.WorkspaceID)
+	if err != nil && !db.IsNotFound(err) {
+		return fault.Wrap(
+			err,
+			fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
+			fault.Internal("database error loading workspace billing"),
+			fault.Public("Failed to retrieve workspace billing state."),
+		)
+	}
+	if err := deploygate.CheckWorkspacePlan(billing.Plan, billing.PlanOverride); err != nil {
+		return err
+	}
+	if err := deploygate.CheckWorkspaceSpend(billing.SpendSuspended); err != nil {
+		return err
+	}
+
 	actor, err := ctrlclient.Actor(s)
 	if err != nil {
 		return err
 	}
 
-	_, err = h.CtrlClient.Promote(ctx, &ctrlv1.PromoteRequest{
-		TargetDeploymentId: dep.ID,
-		Actor:              actor,
-	})
+	_, err = hydrav1.NewDeployServiceIngressClient(h.Restate, dep.ID).
+		Promote().
+		Send(ctx, &hydrav1.PromoteRequest{
+			TargetDeploymentId: dep.ID,
+			Actor:              actor,
+			CorrelationId:      auditlog.NewCorrelationID(),
+		})
 	if err != nil {
-		return deployment.MapCtrlError(err, "promote deployment",
-			"The deployment could not be promoted. It must be ready, belong to the production environment, and not already be live.")
+		return fault.Wrap(
+			err,
+			fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
+			fault.Internal("failed to submit deployment promotion to Restate"),
+			fault.Public("Failed to promote deployment."),
+		)
 	}
 
 	return s.JSON(http.StatusAccepted, Response{

--- a/svc/api/routes/v2_deployments_promote_deployment/helpers_test.go
+++ b/svc/api/routes/v2_deployments_promote_deployment/helpers_test.go
@@ -7,16 +7,17 @@ import (
 	"testing"
 	"time"
 
+	restateingress "github.com/restatedev/sdk-go/ingress"
 	"github.com/stretchr/testify/require"
 	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_deployments_promote_deployment"
 )
 
-func newRoute(h *testutil.Harness, mock *testutil.MockDeploymentClient) *handler.Handler {
+func newRoute(h *testutil.Harness, restate *restateingress.Client) *handler.Handler {
 	return &handler.Handler{
-		DB:         h.DB,
-		CtrlClient: mock,
+		DB:      h.DB,
+		Restate: restate,
 	}
 }
 

--- a/svc/api/routes/v2_deployments_promote_deployment/restate_test.go
+++ b/svc/api/routes/v2_deployments_promote_deployment/restate_test.go
@@ -1,0 +1,55 @@
+package handler_test
+
+import (
+	"testing"
+	"time"
+
+	restate "github.com/restatedev/sdk-go"
+	restateingress "github.com/restatedev/sdk-go/ingress"
+	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
+	"github.com/unkeyed/unkey/pkg/testutil/containers"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+)
+
+// observedPromotion contains the Restate object key and typed request.
+type observedPromotion struct {
+	virtualObjectKey string
+	request          *hydrav1.PromoteRequest
+}
+
+// recordingDeployService captures Promote invocations for assertions.
+type recordingDeployService struct {
+	hydrav1.UnimplementedDeployServiceServer
+	promotions chan observedPromotion
+}
+
+// Promote records the object key and typed payload received through Restate.
+func (service *recordingDeployService) Promote(ctx restate.ObjectContext, request *hydrav1.PromoteRequest) (*hydrav1.PromoteResponse, error) {
+	service.promotions <- observedPromotion{
+		virtualObjectKey: restate.Key(ctx),
+		request:          request,
+	}
+	return &hydrav1.PromoteResponse{}, nil
+}
+
+// newRecordingRestate starts an isolated Restate server whose DeployService
+// reports each Promote invocation to the returned channel.
+func newRecordingRestate(t *testing.T) (*restateingress.Client, <-chan observedPromotion) {
+	t.Helper()
+
+	recorder := &recordingDeployService{
+		promotions: make(chan observedPromotion, 1),
+	}
+	restateConfig := containers.Restate(t, hydrav1.NewDeployServiceServer(recorder))
+
+	return restateingress.NewClient(restateConfig.IngressURL), recorder.promotions
+}
+
+// newUncalledRestate fails during cleanup if DeployService was invoked.
+func newUncalledRestate(t *testing.T) *restateingress.Client {
+	t.Helper()
+
+	client, calls := newRecordingRestate(t)
+	t.Cleanup(func() { testutil.RequireNoReceive(t, calls, time.Second) })
+	return client
+}

--- a/svc/ctrl/proto/hydra/v1/deploy.proto
+++ b/svc/ctrl/proto/hydra/v1/deploy.proto
@@ -156,6 +156,8 @@ message RollbackResponse {}
 // PromoteRequest identifies a ready deployment to promote to live.
 message PromoteRequest {
   string target_deployment_id = 1;
+  ctrl.v1.ActorInfo actor = 2;
+  string correlation_id = 3;
 }
 
 message PromoteResponse {}

--- a/svc/ctrl/worker/deploy/promote_handler.go
+++ b/svc/ctrl/worker/deploy/promote_handler.go
@@ -6,6 +6,7 @@ import (
 
 	restate "github.com/restatedev/sdk-go"
 	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
+	"github.com/unkeyed/unkey/pkg/auditlog"
 	"github.com/unkeyed/unkey/pkg/deploy/deploygate"
 	"github.com/unkeyed/unkey/pkg/fault"
 	"github.com/unkeyed/unkey/pkg/logger"
@@ -176,6 +177,17 @@ func (w *Workflow) Promote(ctx restate.ObjectContext, req *hydrav1.PromoteReques
 		"domains_promoted", len(routeIDs),
 		"confirm_rollback", isConfirmingRollback,
 	)
+
+	if err := w.insertLifecycleAudit(
+		ctx,
+		req.GetActor(),
+		req.GetCorrelationId(),
+		targetDeployment,
+		auditlog.DeploymentPromoteEvent,
+		fmt.Sprintf("Promoted deployment %s", targetDeployment.ID),
+	); err != nil {
+		return nil, fmt.Errorf("insert promote deployment audit log: %w", err)
+	}
 
 	return &hydrav1.PromoteResponse{}, nil
 }


### PR DESCRIPTION
Migrate the deployment promotion api handler talk to restate directly instead of control-api.
