### PR TITLE
feat(krane): store ips instead of service names

### DIFF
--- a/svc/krane/internal/deployment/state.go
+++ b/svc/krane/internal/deployment/state.go
@@ -3,7 +3,8 @@ package deployment
 import (
 	"context"
 	"fmt"
-	"strings"
+	"net"
+	"strconv"
 
 	ctrlv1 "github.com/unkeyed/unkey/gen/proto/ctrl/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -14,13 +15,13 @@ import (
 // buildDeploymentStatus queries the pods belonging to a ReplicaSet and builds a
 // status report for the control plane.
 //
-// The report includes each active pod's cluster-local DNS address, CPU and memory
+// The report includes each active pod's IP address, CPU and memory
 // limits, and health status. Pods without an IP address are excluded since they
 // can't receive traffic yet. Failed and succeeded pods are also excluded because
 // the ReplicaSet replaces them but Kubernetes retains their objects for garbage
 // collection. Reporting them would retain a stale instance for every replacement.
-// The address format is "{ip-with-dashes}.{namespace}.pod.cluster.local:{port}"
-// which enables in-cluster DNS resolution without a headless Service.
+// The address format is "{pod-ip}:{port}" so instances are reachable from peered
+// clusters without relying on cluster-local DNS.
 //
 // Pod phase is mapped to instance status: Running pods with ContainersReady=True
 // become STATUS_RUNNING, Pending pods and Running pods whose ContainersReady
@@ -58,7 +59,7 @@ func (c *Controller) buildDeploymentStatus(ctx context.Context, replicaset *apps
 
 		instance := &ctrlv1.ReportDeploymentStatusRequest_Update_Instance{
 			K8SName:       pod.GetName(),
-			Address:       fmt.Sprintf("%s.%s.pod.cluster.local:%d", strings.ReplaceAll(pod.Status.PodIP, ".", "-"), pod.Namespace, containerPort),
+			Address:       net.JoinHostPort(pod.Status.PodIP, strconv.Itoa(int(containerPort))),
 			CpuMillicores: 0,
 			MemoryMib:     0,
 			Status:        ctrlv1.ReportDeploymentStatusRequest_Update_Instance_STATUS_UNSPECIFIED,

--- a/svc/krane/internal/deployment/state_test.go
+++ b/svc/krane/internal/deployment/state_test.go
@@ -89,9 +89,12 @@ func TestBuildDeploymentStatus_PodStatuses(t *testing.T) {
 	require.NoError(t, err)
 
 	byName := map[string]ctrlv1.ReportDeploymentStatusRequest_Update_Instance_Status{}
+	addressesByName := map[string]string{}
 	for _, inst := range status.GetUpdate().GetInstances() {
 		byName[inst.GetK8SName()] = inst.GetStatus()
+		addressesByName[inst.GetK8SName()] = inst.GetAddress()
 	}
+	require.Equal(t, "10.0.0.1:8080", addressesByName["pod-ready"])
 
 	require.Equal(t,
 		ctrlv1.ReportDeploymentStatusRequest_Update_Instance_STATUS_RUNNING,


### PR DESCRIPTION
This changes krane to store `<ip>:<port>` addresses instead of kubernetes service names and is necessary to do cross-cluster routing without messing with cluster meshing.

This works within the same cluster, so should be safe. Ian tells me this should work cross cluster in aws too, but we'll see.

