### PR TITLE
fix: support encoded orb portal hostnames

### DIFF
--- a/tools/amp-orb-services/portals.go
+++ b/tools/amp-orb-services/portals.go
@@ -114,6 +114,7 @@ func runDeploymentPortals(args []string) error {
 func findPortalContext(publicURLs []string) (string, string, error) {
 	deadline := time.Now().Add(time.Minute)
 	for {
+		threadID := os.Getenv("AMP_THREAD_ID")
 		urls := append([]string(nil), publicURLs...)
 		if len(urls) == 0 {
 			manifests, err := filepath.Glob(filepath.Join(portalsDirectory, "*.json"))
@@ -144,6 +145,12 @@ func findPortalContext(publicURLs []string) (string, string, error) {
 			match := threadHostPattern.FindStringSubmatch(parsed.Hostname())
 			if len(match) == 3 {
 				return "T-" + match[1], match[2], nil
+			}
+			if threadID != "" {
+				_, domain, found := strings.Cut(parsed.Hostname(), ".")
+				if found && domain != "" {
+					return threadID, domain, nil
+				}
 			}
 		}
 

--- a/tools/amp-orb-services/portals_test.go
+++ b/tools/amp-orb-services/portals_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindPortalContext(t *testing.T) {
+	t.Run("legacy hostname contains thread ID", func(t *testing.T) {
+		t.Setenv("AMP_THREAD_ID", "")
+
+		threadID, domain, err := findPortalContext([]string{
+			"https://t-01a00f14-9206-7742-bf90-7216a37cfc8e-p24324.onamp.dev/",
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, "T-01a00f14-9206-7742-bf90-7216a37cfc8e", threadID)
+		require.Equal(t, "onamp.dev", domain)
+	})
+
+	t.Run("encoded hostname uses service thread ID", func(t *testing.T) {
+		t.Setenv("AMP_THREAD_ID", "T-01a00f14-9206-7742-bf90-7216a37cfc8e")
+
+		threadID, domain, err := findPortalContext([]string{
+			"https://t-03gp4jnwivnge0aab4n5k12tq-p24324.onamp.dev/",
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, "T-01a00f14-9206-7742-bf90-7216a37cfc8e", threadID)
+		require.Equal(t, "onamp.dev", domain)
+	})
+}
+
+func TestFrontlineProxyPortalHostname(t *testing.T) {
+	proxy := &frontlineProxy{
+		publicHostname: "t-01a00f14-9206-7742-bf90-7216a37cfc8e-p25109.onamp.dev",
+		portalDomain:   "onamp.dev",
+	}
+
+	testCases := []struct {
+		name     string
+		hostname string
+		want     bool
+	}{
+		{name: "configured hostname", hostname: proxy.publicHostname, want: true},
+		{name: "encoded portal hostname", hostname: "t-03gp4jnwivnge0aab4n5k12tq-p24324.onamp.dev", want: true},
+		{name: "direct orb hostname", hostname: "24324-sandbox.e2b.app", want: true},
+		{name: "different domain", hostname: "t-03gp4jnwivnge0aab4n5k12tq-p24324.example.com", want: false},
+		{name: "domain suffix attack", hostname: "onamp.dev.example.com", want: false},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			require.Equal(t, testCase.want, proxy.isPortalHostname(testCase.hostname))
+		})
+	}
+}

--- a/tools/amp-orb-services/proxy.go
+++ b/tools/amp-orb-services/proxy.go
@@ -89,6 +89,7 @@ func bridgeConnections(first, second net.Conn) {
 // locally and preserves the public Host header for Frontline route lookup.
 type frontlineProxy struct {
 	publicHostname string
+	portalDomain   string
 	sourceHostname string
 	registered     map[string]struct{}
 	routeMu        sync.Mutex
@@ -114,6 +115,7 @@ func runFrontlineProxy(args []string) error {
 
 	proxy := &frontlineProxy{
 		publicHostname: publicURL.Hostname(),
+		portalDomain:   portalDomain(publicURL.Hostname()),
 		sourceHostname: sourceHostname,
 		registered:     make(map[string]struct{}),
 		routeMu:        sync.Mutex{},
@@ -292,7 +294,14 @@ func (p *frontlineProxy) handle(client net.Conn) {
 }
 
 func (p *frontlineProxy) isPortalHostname(hostname string) bool {
-	return hostname == p.publicHostname || e2bHostnamePattern.MatchString(hostname)
+	return hostname == p.publicHostname ||
+		e2bHostnamePattern.MatchString(hostname) ||
+		(p.portalDomain != "" && strings.HasSuffix(hostname, "."+p.portalDomain))
+}
+
+func portalDomain(hostname string) string {
+	_, domain, _ := strings.Cut(hostname, ".")
+	return domain
 }
 
 // readInitialRequest avoids net/http normalization before Frontline sees the


### PR DESCRIPTION
## Problem:

Amp portals use a new domain that our frontline proxy didnt manage to work with

## Solution:

Now we use the service thread ID to allow said new domains

## Impact:

None 

## Testing:

Works in an orb
