### PR TITLE
fix: deduplicate migrated logging policies

### DIFF
--- a/web/tools/migrate/logging-policy.test.ts
+++ b/web/tools/migrate/logging-policy.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "vitest";
+import { reconcileLoggingPolicy } from "./logging-policy";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readLoggingPolicy(blob: string | null): Record<string, unknown> {
+  if (blob === null) {
+    throw new Error("expected a patched blob");
+  }
+  const config: unknown = JSON.parse(blob);
+  if (!isRecord(config) || !Array.isArray(config.policies) || !isRecord(config.policies[0])) {
+    throw new Error("expected one policy");
+  }
+  return config.policies[0];
+}
+
+function oldBackfill(policyId: string): string {
+  return JSON.stringify({
+    policies: [
+      {
+        id: policyId,
+        name: "Log everything",
+        enabled: true,
+        logging: {
+          requestHeaders: true,
+          responseHeaders: true,
+          requestBody: true,
+          responseBody: true,
+          query: true,
+        },
+      },
+    ],
+  });
+}
+
+describe("logging policy migration", () => {
+  test("production creates one policy enabled in both environments", () => {
+    const production = reconcileLoggingPolicy("{}", "production#1");
+    const preview = reconcileLoggingPolicy("{}", "production#2", production.policyId);
+
+    const productionPolicy = readLoggingPolicy(production.blob);
+    const previewPolicy = readLoggingPolicy(preview.blob);
+    expect(productionPolicy.id).toBe(previewPolicy.id);
+    expect(productionPolicy.enabled).toBe(true);
+    expect(previewPolicy.enabled).toBe(true);
+  });
+
+  test("canary deduplicates backfills created with different IDs", () => {
+    const production = reconcileLoggingPolicy(oldBackfill("policy_canary_production"), "canary#1");
+    const preview = reconcileLoggingPolicy(
+      oldBackfill("policy_canary_preview"),
+      "canary#2",
+      production.policyId,
+    );
+
+    expect(production.blob).toBeNull();
+    expect(production.policyId).toBe("policy_canary_production");
+    expect(readLoggingPolicy(preview.blob).id).toBe("policy_canary_production");
+
+    const rerun = reconcileLoggingPolicy(preview.blob, "canary#2", production.policyId);
+    expect(rerun.blob).toBeNull();
+  });
+});

--- a/web/tools/migrate/logging-policy.ts
+++ b/web/tools/migrate/logging-policy.ts
@@ -1,3 +1,4 @@
+import { pathToFileURL } from "node:url";
 import {
   type Database,
   createCommentedPool,
@@ -27,7 +28,11 @@ import { newUid } from "@unkey/id";
  *    deployments and rollback targets never re-read the live config, so the
  *    snapshots must be patched too.
  *
- * Safe to rerun: rows that already contain a logging policy are skipped.
+ * Both environments for an app receive the same policy ID so the dashboard
+ * presents them as one policy enabled in both environments.
+ *
+ * Safe to rerun: logging policies created by an earlier version of this
+ * migration are reconciled to the same ID. Other logging policies are skipped.
  *
  * Run from the repository root with `DRIZZLE_DATABASE_URL` set:
  * `mise exec -- pnpm --dir=web/tools/migrate logging-policy`
@@ -38,11 +43,45 @@ const READ_BATCH_SIZE = 1_000;
 // dashboard can no longer read back and edit the patched config.
 const MAX_POLICIES = 50;
 
+type ReconcileResult = {
+  blob: string | null;
+  policyId: string | undefined;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isBackfilledLoggingPolicy(policy: unknown): policy is Record<string, unknown> & {
+  id: string;
+} {
+  if (!isRecord(policy) || typeof policy.id !== "string") {
+    return false;
+  }
+  if (policy.name !== "Log everything" || policy.enabled !== true || "match" in policy) {
+    return false;
+  }
+  if (!isRecord(policy.logging) || Object.keys(policy.logging).length !== 5) {
+    return false;
+  }
+  return (
+    policy.logging.requestHeaders === true &&
+    policy.logging.responseHeaders === true &&
+    policy.logging.requestBody === true &&
+    policy.logging.responseBody === true &&
+    policy.logging.query === true
+  );
+}
+
 /**
- * Returns the patched blob, or null when the row must not change (already has
- * a logging policy, config is unreadable, or the policy list is full).
+ * Adds the backfill policy or reconciles an earlier backfill to policyId.
+ * Returns a null blob when the row must not change.
  */
-export function addLoggingPolicy(blob: string | null, rowRef: string): string | null {
+export function reconcileLoggingPolicy(
+  blob: string | null,
+  rowRef: string,
+  policyId?: string,
+): ReconcileResult {
   // The column is a longblob; mysql2 may hand back a Buffer at runtime, so
   // normalize through toString like the dashboard's loadPolicies does.
   const text = blob?.length ? blob.toString() : "{}";
@@ -52,29 +91,43 @@ export function addLoggingPolicy(blob: string | null, rowRef: string): string | 
     parsed = JSON.parse(text);
   } catch {
     console.error("skipping corrupt sentinel config", { rowRef });
-    return null;
+    return { blob: null, policyId };
   }
-  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+  if (!isRecord(parsed)) {
     console.error("skipping non-object sentinel config", { rowRef });
-    return null;
+    return { blob: null, policyId };
   }
 
-  const config = parsed as { policies?: unknown };
-  const policies = Array.isArray(config.policies) ? config.policies : [];
+  const policies = Array.isArray(parsed.policies) ? parsed.policies : [];
+
+  const backfilledPolicy = policies.find(isBackfilledLoggingPolicy);
+  if (backfilledPolicy) {
+    const canonicalPolicyId = policyId ?? backfilledPolicy.id;
+    if (backfilledPolicy.id === canonicalPolicyId) {
+      return { blob: null, policyId: canonicalPolicyId };
+    }
+
+    policies[policies.indexOf(backfilledPolicy)] = { ...backfilledPolicy, id: canonicalPolicyId };
+    return {
+      blob: JSON.stringify({ ...parsed, policies }),
+      policyId: canonicalPolicyId,
+    };
+  }
 
   const hasLoggingPolicy = policies.some(
     (p: unknown) => typeof p === "object" && p !== null && "logging" in p,
   );
   if (hasLoggingPolicy) {
-    return null;
+    return { blob: null, policyId };
   }
   if (policies.length >= MAX_POLICIES) {
     console.error("skipping full policy list", { rowRef, count: policies.length });
-    return null;
+    return { blob: null, policyId };
   }
 
+  const canonicalPolicyId = policyId ?? newUid("policy");
   policies.push({
-    id: newUid("policy"),
+    id: canonicalPolicyId,
     name: "Log everything",
     enabled: true,
     logging: {
@@ -86,19 +139,27 @@ export function addLoggingPolicy(blob: string | null, rowRef: string): string | 
     },
   });
 
-  return JSON.stringify({ ...config, policies });
+  return {
+    blob: JSON.stringify({ ...parsed, policies }),
+    policyId: canonicalPolicyId,
+  };
 }
 
 type SentinelTable = typeof schema.appRuntimeSettings | typeof schema.deployments;
 
-async function patchTable(db: Database, table: SentinelTable, tableName: string): Promise<void> {
+async function patchTable(
+  db: Database,
+  table: SentinelTable,
+  tableName: string,
+  policyIdsByApp: Map<string, string>,
+): Promise<void> {
   let cursor = 0;
   let scanned = 0;
   let patched = 0;
 
   while (true) {
     const rows = await db
-      .select({ pk: table.pk, sentinelConfig: table.sentinelConfig })
+      .select({ pk: table.pk, appId: table.appId, sentinelConfig: table.sentinelConfig })
       .from(table)
       .where(gt(table.pk, cursor))
       .orderBy(table.pk)
@@ -110,17 +171,33 @@ async function patchTable(db: Database, table: SentinelTable, tableName: string)
     cursor = rows[rows.length - 1].pk;
     scanned += rows.length;
 
+    const pendingUpdates: { pk: number; sentinelConfig: string }[] = [];
     for (const row of rows) {
-      const blob = addLoggingPolicy(row.sentinelConfig, `${tableName}#${row.pk}`);
-      if (blob === null) {
+      const result = reconcileLoggingPolicy(
+        row.sentinelConfig,
+        `${tableName}#${row.pk}`,
+        policyIdsByApp.get(row.appId),
+      );
+      if (result.policyId) {
+        policyIdsByApp.set(row.appId, result.policyId);
+      }
+      if (result.blob === null) {
         continue;
       }
-      await db
-        .update(table)
-        .set({ sentinelConfig: blob, updatedAt: Date.now() })
-        .where(eq(table.pk, row.pk));
-      patched++;
+      pendingUpdates.push({ pk: row.pk, sentinelConfig: result.blob });
     }
+
+    // The pool bounds active connections, so enqueue the batch together rather
+    // than waiting for every database round trip in sequence.
+    await Promise.all(
+      pendingUpdates.map((update) =>
+        db
+          .update(table)
+          .set({ sentinelConfig: update.sentinelConfig, updatedAt: Date.now() })
+          .where(eq(table.pk, update.pk)),
+      ),
+    );
+    patched += pendingUpdates.length;
 
     console.info("progress", { table: tableName, scanned, patched });
   }
@@ -141,14 +218,18 @@ async function main() {
   const db = drizzle(pool, { schema, mode: "default" });
 
   try {
-    await patchTable(db, schema.appRuntimeSettings, "app_runtime_settings");
-    await patchTable(db, schema.deployments, "deployments");
+    const policyIdsByApp = new Map<string, string>();
+    await patchTable(db, schema.appRuntimeSettings, "app_runtime_settings", policyIdsByApp);
+    await patchTable(db, schema.deployments, "deployments", policyIdsByApp);
   } finally {
     await pool.end();
   }
 }
 
-main().catch((error: unknown) => {
-  console.error("Logging policy migration failed", error);
-  process.exitCode = 1;
-});
+const scriptPath = process.argv[1];
+if (scriptPath && import.meta.url === pathToFileURL(scriptPath).href) {
+  main().catch((error: unknown) => {
+    console.error("Logging policy migration failed", error);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Problem:

The logging policy migration created a different policy ID for each environment. The dashboard displayed two rows instead of one policy enabled in both environments.

A rerun skipped policies already written to canary, so it could not correct the duplicate rows. Serial database updates could also exceed the lifetime of short-lived database credentials.

## Solution:

The migration now uses one logging policy ID for every environment in an app. A rerun aligns policies created by the earlier migration while leaving other logging policies unchanged.

Database updates now run concurrently through the bounded connection pool.

## Impact:

New production migrations show one logging policy enabled in both environments. A canary rerun corrects existing duplicate rows and keeps deployment snapshots aligned.

## Testing:

- Ran 2 migration regression tests. Both passed.
- Ran the migration against an isolated MySQL database with 2,008 runtime-setting and deployment rows. Fresh production migration, canary deduplication, and snapshot alignment passed in 1.918 seconds.
- Ran the migration a second time. Both tables reported 0 patched rows.
- Ran targeted TypeScript and Biome checks. Both passed.