### PR TITLE
fix(db): remove stale key alias

### DIFF
--- a/pkg/db/key_data.go
+++ b/pkg/db/key_data.go
@@ -2,10 +2,6 @@ package db
 
 import "database/sql"
 
-// Key is the application-facing key record. It intentionally excludes
-// deprecated database columns so removing them doesn't change this contract.
-type Key = FindKeyByIDRow
-
 // KeyData represents the complete data for a key including all relationships
 type KeyData struct {
 	Key             Key

--- a/pkg/db/key_find_by_id.sql_generated.go
+++ b/pkg/db/key_find_by_id.sql_generated.go
@@ -7,7 +7,6 @@ package db
 
 import (
 	"context"
-	"database/sql"
 )
 
 const findKeyByID = `-- name: FindKeyByID :one
@@ -20,31 +19,6 @@ FROM ` + "`" + `keys` + "`" + ` k
 WHERE k.id = ?
 `
 
-type FindKeyByIDRow struct {
-	Pk                 uint64         `db:"pk"`
-	ID                 string         `db:"id"`
-	KeyAuthID          string         `db:"key_auth_id"`
-	Hash               string         `db:"hash"`
-	Start              string         `db:"start"`
-	WorkspaceID        string         `db:"workspace_id"`
-	ForWorkspaceID     sql.NullString `db:"for_workspace_id"`
-	Name               sql.NullString `db:"name"`
-	IdentityID         sql.NullString `db:"identity_id"`
-	Meta               sql.NullString `db:"meta"`
-	Expires            sql.NullTime   `db:"expires"`
-	CreatedAtM         int64          `db:"created_at_m"`
-	UpdatedAtM         sql.NullInt64  `db:"updated_at_m"`
-	DeletedAtM         sql.NullInt64  `db:"deleted_at_m"`
-	RefillDay          sql.NullInt16  `db:"refill_day"`
-	RefillAmount       sql.NullInt64  `db:"refill_amount"`
-	LastRefillAt       sql.NullTime   `db:"last_refill_at"`
-	Enabled            bool           `db:"enabled"`
-	RemainingRequests  sql.NullInt64  `db:"remaining_requests"`
-	Environment        sql.NullString `db:"environment"`
-	LastUsedAt         uint64         `db:"last_used_at"`
-	PendingMigrationID sql.NullString `db:"pending_migration_id"`
-}
-
 // FindKeyByID
 //
 //	SELECT
@@ -54,9 +28,9 @@ type FindKeyByIDRow struct {
 //	    k.remaining_requests, k.environment, k.last_used_at, k.pending_migration_id
 //	FROM `keys` k
 //	WHERE k.id = ?
-func (q *Queries) FindKeyByID(ctx context.Context, db DBTX, id string) (FindKeyByIDRow, error) {
+func (q *Queries) FindKeyByID(ctx context.Context, db DBTX, id string) (Key, error) {
 	row := db.QueryRowContext(ctx, findKeyByID, id)
-	var i FindKeyByIDRow
+	var i Key
 	err := row.Scan(
 		&i.Pk,
 		&i.ID,

--- a/pkg/db/models_generated.go
+++ b/pkg/db/models_generated.go
@@ -793,6 +793,31 @@ type Identity struct {
 	UpdatedAt   sql.NullInt64 `db:"updated_at"`
 }
 
+type Key struct {
+	Pk                 uint64         `db:"pk"`
+	ID                 string         `db:"id"`
+	KeyAuthID          string         `db:"key_auth_id"`
+	Hash               string         `db:"hash"`
+	Start              string         `db:"start"`
+	WorkspaceID        string         `db:"workspace_id"`
+	ForWorkspaceID     sql.NullString `db:"for_workspace_id"`
+	Name               sql.NullString `db:"name"`
+	IdentityID         sql.NullString `db:"identity_id"`
+	Meta               sql.NullString `db:"meta"`
+	Expires            sql.NullTime   `db:"expires"`
+	CreatedAtM         int64          `db:"created_at_m"`
+	UpdatedAtM         sql.NullInt64  `db:"updated_at_m"`
+	DeletedAtM         sql.NullInt64  `db:"deleted_at_m"`
+	RefillDay          sql.NullInt16  `db:"refill_day"`
+	RefillAmount       sql.NullInt64  `db:"refill_amount"`
+	LastRefillAt       sql.NullTime   `db:"last_refill_at"`
+	Enabled            bool           `db:"enabled"`
+	RemainingRequests  sql.NullInt64  `db:"remaining_requests"`
+	Environment        sql.NullString `db:"environment"`
+	LastUsedAt         uint64         `db:"last_used_at"`
+	PendingMigrationID sql.NullString `db:"pending_migration_id"`
+}
+
 type KeyAuth struct {
 	Pk                 uint64         `db:"pk"`
 	ID                 string         `db:"id"`

--- a/pkg/db/querier_generated.go
+++ b/pkg/db/querier_generated.go
@@ -466,7 +466,7 @@ type Querier interface {
 	//      k.remaining_requests, k.environment, k.last_used_at, k.pending_migration_id
 	//  FROM `keys` k
 	//  WHERE k.id = ?
-	FindKeyByID(ctx context.Context, db DBTX, id string) (FindKeyByIDRow, error)
+	FindKeyByID(ctx context.Context, db DBTX, id string) (Key, error)
 	//FindKeyCredits
 	//
 	//  SELECT remaining_requests FROM `keys` k WHERE k.id = ?

--- a/svc/ctrl/internal/db/key_find_by_id.sql_generated.go
+++ b/svc/ctrl/internal/db/key_find_by_id.sql_generated.go
@@ -7,7 +7,6 @@ package db
 
 import (
 	"context"
-	"database/sql"
 )
 
 const findKeyByID = `-- name: FindKeyByID :one
@@ -20,31 +19,6 @@ FROM ` + "`" + `keys` + "`" + ` k
 WHERE k.id = ?
 `
 
-type FindKeyByIDRow struct {
-	Pk                 uint64         `db:"pk"`
-	ID                 string         `db:"id"`
-	KeyAuthID          string         `db:"key_auth_id"`
-	Hash               string         `db:"hash"`
-	Start              string         `db:"start"`
-	WorkspaceID        string         `db:"workspace_id"`
-	ForWorkspaceID     sql.NullString `db:"for_workspace_id"`
-	Name               sql.NullString `db:"name"`
-	IdentityID         sql.NullString `db:"identity_id"`
-	Meta               sql.NullString `db:"meta"`
-	Expires            sql.NullTime   `db:"expires"`
-	CreatedAtM         int64          `db:"created_at_m"`
-	UpdatedAtM         sql.NullInt64  `db:"updated_at_m"`
-	DeletedAtM         sql.NullInt64  `db:"deleted_at_m"`
-	RefillDay          sql.NullInt16  `db:"refill_day"`
-	RefillAmount       sql.NullInt64  `db:"refill_amount"`
-	LastRefillAt       sql.NullTime   `db:"last_refill_at"`
-	Enabled            bool           `db:"enabled"`
-	RemainingRequests  sql.NullInt64  `db:"remaining_requests"`
-	Environment        sql.NullString `db:"environment"`
-	LastUsedAt         uint64         `db:"last_used_at"`
-	PendingMigrationID sql.NullString `db:"pending_migration_id"`
-}
-
 // FindKeyByID
 //
 //	SELECT
@@ -54,9 +28,9 @@ type FindKeyByIDRow struct {
 //	    k.remaining_requests, k.environment, k.last_used_at, k.pending_migration_id
 //	FROM `keys` k
 //	WHERE k.id = ?
-func (q *Queries) FindKeyByID(ctx context.Context, id string) (FindKeyByIDRow, error) {
+func (q *Queries) FindKeyByID(ctx context.Context, id string) (Key, error) {
 	row := q.db.QueryRowContext(ctx, findKeyByID, id)
-	var i FindKeyByIDRow
+	var i Key
 	err := row.Scan(
 		&i.Pk,
 		&i.ID,

--- a/svc/ctrl/internal/db/models_generated.go
+++ b/svc/ctrl/internal/db/models_generated.go
@@ -926,6 +926,31 @@ type Instance struct {
 	ContainerStatus mysqltype.ContainerStatus `db:"container_status"`
 }
 
+type Key struct {
+	Pk                 uint64         `db:"pk"`
+	ID                 string         `db:"id"`
+	KeyAuthID          string         `db:"key_auth_id"`
+	Hash               string         `db:"hash"`
+	Start              string         `db:"start"`
+	WorkspaceID        string         `db:"workspace_id"`
+	ForWorkspaceID     sql.NullString `db:"for_workspace_id"`
+	Name               sql.NullString `db:"name"`
+	IdentityID         sql.NullString `db:"identity_id"`
+	Meta               sql.NullString `db:"meta"`
+	Expires            sql.NullTime   `db:"expires"`
+	CreatedAtM         int64          `db:"created_at_m"`
+	UpdatedAtM         sql.NullInt64  `db:"updated_at_m"`
+	DeletedAtM         sql.NullInt64  `db:"deleted_at_m"`
+	RefillDay          sql.NullInt16  `db:"refill_day"`
+	RefillAmount       sql.NullInt64  `db:"refill_amount"`
+	LastRefillAt       sql.NullTime   `db:"last_refill_at"`
+	Enabled            bool           `db:"enabled"`
+	RemainingRequests  sql.NullInt64  `db:"remaining_requests"`
+	Environment        sql.NullString `db:"environment"`
+	LastUsedAt         uint64         `db:"last_used_at"`
+	PendingMigrationID sql.NullString `db:"pending_migration_id"`
+}
+
 type KeyAuth struct {
 	Pk                 uint64         `db:"pk"`
 	ID                 string         `db:"id"`

--- a/svc/ctrl/internal/db/querier_generated.go
+++ b/svc/ctrl/internal/db/querier_generated.go
@@ -553,7 +553,7 @@ type Querier interface {
 	//      k.remaining_requests, k.environment, k.last_used_at, k.pending_migration_id
 	//  FROM `keys` k
 	//  WHERE k.id = ?
-	FindKeyByID(ctx context.Context, id string) (FindKeyByIDRow, error)
+	FindKeyByID(ctx context.Context, id string) (Key, error)
 	// FindKeyIDByHash returns just the key ID for a given hash. Use this when
 	// you only need the ID for a subsequent mutation and do not need the full
 	// verification payload with roles, permissions, and rate limits.


### PR DESCRIPTION

Removes the stale hand-written `Key = FindKeyByIDRow` alias and commits the regenerated sqlc output. Since the `keys` table now exactly matches `FindKeyByID`'s selected columns, sqlc generates and returns the table's `Key` model instead of a bespoke row type.

Fixes [ENG-3132](https://linear.app/unkey/issue/ENG-3132/mise-run-generate-breaks-the-build-key-alias-in-pkgdbkey-datago-is)
