### PR TITLE
Run the Tilt/minikube orb stack on Cursor Cloud

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,27 @@
+{
+  "name": "unkey",
+  "install": "bash .cursor/setup",
+  "start": "bash .cursor/resume",
+  "terminals": [
+    {
+      "name": "tilt",
+      "command": "$HOME/.local/bin/mise run dev-cursor",
+      "description": "Minikube + Tilt orb stack (gvisor, no Cilium). UI at http://localhost:10350. Dashboard, API, Vault, and Control API on 3000, 7070, 8060, and 7091."
+    },
+    {
+      "name": "apps",
+      "command": "$HOME/.local/bin/mise run cursor-apps",
+      "description": "Index of ready Deploy apps at http://localhost:19081. Each app is bridged through Frontline on a dynamic localhost port in 20000-29999."
+    }
+  ],
+  "ports": [
+    { "name": "Tilt", "port": 10350 },
+    { "name": "Dashboard", "port": 3000 },
+    { "name": "Unkey API", "port": 7070 },
+    { "name": "Vault RPC", "port": 8060 },
+    { "name": "Control API", "port": 7091 },
+    { "name": "Frontline HTTP", "port": 9080 },
+    { "name": "Frontline HTTPS", "port": 9443 },
+    { "name": "Deployed apps", "port": 19081 }
+  ]
+}

--- a/.cursor/lib.sh
+++ b/.cursor/lib.sh
@@ -1,0 +1,380 @@
+# Cursor Cloud helpers. Amp orbs do not source this file.
+# shellcheck shell=bash
+
+wait_for_docker() {
+  local attempts="${1:-60}"
+  local attempt
+  for attempt in $(seq 1 "$attempts"); do
+    grant_docker_sock
+    if docker info >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+install_fuse_overlayfs() {
+  if command -v fuse-overlayfs >/dev/null 2>&1 && command -v setfacl >/dev/null 2>&1; then
+    return 0
+  fi
+  export DEBIAN_FRONTEND=noninteractive
+  sudo apt-get update
+  sudo apt-get install -y -o Dpkg::Options::=--force-confold fuse3 fuse-overlayfs acl
+}
+
+# Cursor Cloud rejects nested overlayfs. Write the host Docker config before
+# the first dockerd start; overlay2 never becomes ready in these VMs.
+write_fuse_overlayfs_daemon_json() {
+  sudo mkdir -p /etc/docker
+  if [ -f /etc/docker/daemon.json ]; then
+    sudo python3 - <<'PY'
+import json
+from pathlib import Path
+
+path = Path("/etc/docker/daemon.json")
+data = json.loads(path.read_text() or "{}")
+if data.get("storage-driver") == "fuse-overlayfs":
+    raise SystemExit(0)
+data["storage-driver"] = "fuse-overlayfs"
+path.write_text(json.dumps(data, indent=2) + "\n")
+PY
+  else
+    echo '{"storage-driver":"fuse-overlayfs"}' | sudo tee /etc/docker/daemon.json >/dev/null
+  fi
+}
+
+print_dockerd_log() {
+  echo "docker diagnostics:" >&2
+  pgrep -a dockerd >&2 || echo "no dockerd process" >&2
+  ls -l /var/run/docker.sock >&2 || echo "no docker.sock" >&2
+  if [ -f /tmp/unkey-dockerd.log ]; then
+    echo "dockerd log:" >&2
+    sudo tail -n 80 /tmp/unkey-dockerd.log >&2 || true
+  fi
+}
+
+stop_stale_dockerd() {
+  local pid
+  for pid in $(pgrep -x dockerd || true); do
+    sudo kill "$pid" || true
+  done
+  sleep 1
+  for pid in $(pgrep -x dockerd || true); do
+    sudo kill -9 "$pid" || true
+  done
+  sleep 1
+}
+
+# Cursor Cloud VMs have no usable systemd. Do not call systemctl or service.
+start_dockerd_directly() {
+  echo "Starting dockerd..."
+  stop_stale_dockerd
+  sudo mkdir -p /var/run
+  sudo dockerd \
+    --host=unix:///var/run/docker.sock \
+    --storage-driver=fuse-overlayfs \
+    >/tmp/unkey-dockerd.log 2>&1 &
+}
+
+start_docker() {
+  if docker info >/dev/null 2>&1; then
+    return 0
+  fi
+
+  install_fuse_overlayfs
+  write_fuse_overlayfs_daemon_json
+  start_dockerd_directly
+  if wait_for_docker; then
+    return 0
+  fi
+
+  echo "Docker did not become ready" >&2
+  print_dockerd_log
+  return 1
+}
+
+grant_docker_sock() {
+  sudo usermod -aG docker "$(id -un)" || true
+  if [ ! -S /var/run/docker.sock ]; then
+    return 0
+  fi
+  if command -v setfacl >/dev/null 2>&1; then
+    sudo setfacl -m "u:$(id -un):rw" /var/run/docker.sock || sudo chmod 666 /var/run/docker.sock
+  else
+    sudo chmod 666 /var/run/docker.sock
+  fi
+}
+
+raise_inotify_quota() {
+  printf '1024\n' | sudo tee /proc/sys/fs/inotify/max_user_instances >/dev/null
+}
+
+install_docker_if_needed() {
+  if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+    return 0
+  fi
+
+  . /etc/os-release
+  local docker_os="$ID"
+  case "$docker_os" in
+    debian | ubuntu) ;;
+    *)
+      echo "Unsupported OS for Docker install: $docker_os" >&2
+      return 1
+      ;;
+  esac
+
+  sudo apt-get update
+  sudo apt-get install -y ca-certificates curl
+  sudo install -m 0755 -d /etc/apt/keyrings
+  sudo curl -fsSL "https://download.docker.com/linux/${docker_os}/gpg" -o /etc/apt/keyrings/docker.asc
+  sudo chmod a+r /etc/apt/keyrings/docker.asc
+
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/${docker_os} ${VERSION_CODENAME} stable" |
+    sudo tee /etc/apt/sources.list.d/docker.list >/dev/null
+
+  sudo apt-get update
+  sudo apt-get install -y \
+    containerd.io \
+    docker-buildx-plugin \
+    docker-ce \
+    docker-ce-cli \
+    docker-compose-plugin
+}
+
+ensure_docker_storage() {
+  install_fuse_overlayfs
+  write_fuse_overlayfs_daemon_json
+
+  local current
+  current="$(docker info --format '{{.Driver}}' 2>/dev/null || true)"
+  if [ "$current" = "fuse-overlayfs" ]; then
+    return 0
+  fi
+
+  start_dockerd_directly
+  if wait_for_docker; then
+    grant_docker_sock
+    return 0
+  fi
+
+  echo "Docker did not become ready after switching to fuse-overlayfs" >&2
+  print_dockerd_log
+  return 1
+}
+
+# Force native snapshotter and at most one gvisor runsc table. minikube start
+# re-enables gvisor and otherwise appends a duplicate table.
+fix_containerd_config() {
+  docker inspect minikube >/dev/null 2>&1 || return 1
+  [ "$(docker inspect -f '{{.State.Running}}' minikube 2>/dev/null)" = "true" ] || return 1
+
+  docker exec -i minikube sh -s <<'EOS'
+cfg=/etc/containerd/config.toml
+[ -f "$cfg" ] || exit 0
+tmp=$(mktemp)
+awk '
+  { line = $0 }
+  line ~ /snapshotter[[:space:]]*=/ {
+    sub(/snapshotter[[:space:]]*=[[:space:]]*"[^"]*"/, "snapshotter = \"native\"", line)
+  }
+  line == "[plugins.\"io.containerd.grpc.v1.cri\".containerd.runtimes.runsc]" {
+    if (++runsc > 1) { drop = 1; next }
+  }
+  drop {
+    if (line ~ /^\[/ && line != "[plugins.\"io.containerd.grpc.v1.cri\".containerd.runtimes.runsc]") {
+      drop = 0
+    } else {
+      next
+    }
+  }
+  { print line }
+' "$cfg" >"$tmp"
+if cmp -s "$cfg" "$tmp"; then
+  rm -f "$tmp"
+  exit 0
+fi
+mv "$tmp" "$cfg"
+pid=$(pidof containerd | awk '{print $1}')
+[ -n "$pid" ] && kill "$pid"
+EOS
+}
+
+# Images pinned by minikube 1.38.1 addons. ImagePullBackOff import below
+# covers version drift when minikube is bumped.
+minikube_addon_images() {
+  cat <<'EOF'
+registry.k8s.io/metrics-server/metrics-server:v0.8.1@sha256:b2d2efaf5ac3b366ed0f839d2412a2c4279d4fc2a2a733f12c52133faed36c41
+registry.k8s.io/minikube/gvisor:v0.0.4@sha256:0f389d92114b6342bcdb971fc8e89e9d60683d49aa5e31b89d744ec420196fd9
+EOF
+}
+
+import_image_into_minikube() {
+  local spec="$1"
+  echo "Importing $spec into minikube..."
+  docker pull "$spec"
+  local id
+  id="$(docker image inspect --format '{{.Id}}' "$spec")"
+  docker save "$id" | docker exec -i minikube ctr -n k8s.io images import -
+}
+
+list_unpulled_pod_images() {
+  local mise="$1"
+  "$mise" exec -- kubectl get pods -A -o json 2>/dev/null | python3 -c '
+import json, sys
+
+data = json.load(sys.stdin)
+images = set()
+waiting = {"ImagePullBackOff", "ErrImagePull"}
+for item in data.get("items", []):
+    status = item.get("status") or {}
+    for key in ("containerStatuses", "initContainerStatuses"):
+        for cs in status.get(key) or []:
+            state = ((cs.get("state") or {}).get("waiting") or {})
+            if state.get("reason") in waiting:
+                image = cs.get("image") or ""
+                if image:
+                    images.add(image)
+print("\n".join(sorted(images)))
+'
+}
+
+import_minikube_images() {
+  local mise="$1"
+  docker inspect minikube >/dev/null 2>&1 || return 0
+
+  local image
+  while IFS= read -r image; do
+    [ -z "$image" ] && continue
+    import_image_into_minikube "$image" || true
+  done < <(minikube_addon_images)
+
+  sleep 8
+
+  local attempt pending
+  for attempt in $(seq 1 12); do
+    pending="$(list_unpulled_pod_images "$mise" || true)"
+    if [ -z "$pending" ] && "$mise" exec -- kubectl get nodes >/dev/null 2>&1; then
+      return 0
+    fi
+    while IFS= read -r image; do
+      [ -z "$image" ] && continue
+      import_image_into_minikube "$image" || true
+    done <<<"$pending"
+    sleep 5
+  done
+}
+
+configure_kube_proxy() {
+  local mise="${1:-$HOME/.local/bin/mise}"
+  "$mise" exec -- kubectl -n kube-system get cm kube-proxy >/dev/null 2>&1 || return 0
+
+  python3 - "$mise" <<'PY'
+import json, subprocess, sys
+
+mise = sys.argv[1]
+raw = subprocess.check_output(
+    [mise, "exec", "--", "kubectl", "-n", "kube-system", "get", "cm", "kube-proxy", "-o", "json"]
+)
+cm = json.loads(raw)
+conf = cm["data"]["config.conf"]
+if "\nmode: nftables" in conf or conf.startswith("mode: nftables"):
+    sys.exit(0)
+lines = []
+found = False
+for line in conf.splitlines():
+    if line.startswith("mode:"):
+        lines.append("mode: nftables")
+        found = True
+    else:
+        lines.append(line)
+if not found:
+    lines.append("mode: nftables")
+cm["data"]["config.conf"] = "\n".join(lines) + "\n"
+subprocess.run(
+    [mise, "exec", "--", "kubectl", "-n", "kube-system", "patch", "cm", "kube-proxy",
+     "--type", "merge", "-p", json.dumps({"data": {"config.conf": cm["data"]["config.conf"]}})],
+    check=True,
+)
+subprocess.run(
+    [mise, "exec", "--", "kubectl", "-n", "kube-system", "delete", "pod", "-l", "k8s-app=kube-proxy"],
+    check=False,
+)
+print("kube-proxy switched to nftables mode")
+PY
+}
+
+configure_insecure_registry() {
+  docker inspect minikube >/dev/null 2>&1 || return 0
+  docker inspect ctlptl-registry >/dev/null 2>&1 || return 0
+
+  local ip first_ip=""
+  for ip in $(docker inspect ctlptl-registry --format '{{range .NetworkSettings.Networks}}{{.IPAddress}} {{end}}'); do
+    [ -n "$ip" ] || continue
+    [ -n "$first_ip" ] || first_ip="$ip"
+    docker exec minikube sh -c "
+      mkdir -p /etc/containerd/certs.d/${ip}:5000
+      printf '%s\n' '[host.\"http://${ip}:5000\"]' > /etc/containerd/certs.d/${ip}:5000/hosts.toml
+    "
+  done
+
+  # kubelet pulls on the node, so cluster DNS for the ctlptl-registry
+  # Service never runs. Bridge-network minikube also cannot resolve that
+  # hostname through Docker DNS. Point it at the registry's docker0 IP.
+  if [ -n "$first_ip" ]; then
+    docker exec minikube sh -c "
+      grep -v '[[:space:]]ctlptl-registry\$' /etc/hosts > /tmp/hosts.cursor
+      printf '%s ctlptl-registry\n' '${first_ip}' >> /tmp/hosts.cursor
+      cat /tmp/hosts.cursor > /etc/hosts
+      mkdir -p /etc/containerd/certs.d/ctlptl-registry:5000
+      printf '%s\n' '[host.\"http://${first_ip}:5000\"]' > /etc/containerd/certs.d/ctlptl-registry:5000/hosts.toml
+    "
+  fi
+}
+
+finish_cluster() {
+  local mise="${1:-$HOME/.local/bin/mise}"
+  fix_containerd_config || true
+  configure_insecure_registry || true
+  configure_kube_proxy "$mise" || true
+  import_minikube_images "$mise"
+}
+
+_apply_cluster_locked() {
+  local mise="${1:-$HOME/.local/bin/mise}"
+  local patch_pid=""
+
+  if [ "$(docker inspect -f '{{.State.Running}}' minikube 2>/dev/null)" = "true" ] &&
+    "$mise" exec -- kubectl get nodes >/dev/null 2>&1; then
+    echo "minikube already reachable"
+    finish_cluster "$mise"
+    return 0
+  fi
+
+  (
+    while true; do
+      fix_containerd_config || true
+      sleep 2
+    done
+  ) &
+  patch_pid=$!
+
+  if ! "$mise" exec -- ctlptl apply -f dev/cluster.cursor.yaml; then
+    kill "$patch_pid" 2>/dev/null || true
+    wait "$patch_pid" 2>/dev/null || true
+    return 1
+  fi
+
+  kill "$patch_pid" 2>/dev/null || true
+  wait "$patch_pid" 2>/dev/null || true
+  finish_cluster "$mise"
+}
+
+apply_cluster() {
+  local mise="${1:-$HOME/.local/bin/mise}"
+  (
+    flock 9
+    _apply_cluster_locked "$mise"
+  ) 9>/tmp/unkey-cursor-cluster.lock
+}

--- a/.cursor/resume
+++ b/.cursor/resume
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+# shellcheck source=lib.sh
+. "$(dirname "$0")/lib.sh"
+
+echo "Restoring Docker access..."
+start_docker
+ensure_docker_storage
+grant_docker_sock
+raise_inotify_quota
+
+mise="$HOME/.local/bin/mise"
+if [ ! -x "$mise" ]; then
+  echo "mise is missing; running full setup..."
+  bash "$(dirname "$0")/setup"
+fi
+
+echo "Cursor Cloud resume complete."

--- a/.cursor/setup
+++ b/.cursor/setup
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+# shellcheck source=lib.sh
+. "$(dirname "$0")/lib.sh"
+
+if ! command -v setfacl >/dev/null 2>&1; then
+  export DEBIAN_FRONTEND=noninteractive
+  sudo apt-get update
+  sudo apt-get install -y -o Dpkg::Options::=--force-confold acl
+fi
+
+echo "Installing Docker Engine and Compose..."
+install_docker_if_needed
+
+echo "Starting Docker..."
+start_docker
+ensure_docker_storage
+grant_docker_sock
+raise_inotify_quota
+
+echo "Installing the pinned mise binary and toolchain..."
+./dev/install-mise
+mise="$HOME/.local/bin/mise"
+"$mise" trust .mise/config.toml
+"$mise" install --locked --yes
+
+echo "Installing web dependencies..."
+"$mise" run install-web
+
+echo "Creating local web environment files when missing..."
+if [ ! -f web/apps/dashboard/.env ]; then
+  cp -- web/apps/dashboard/dev/.env.example web/apps/dashboard/.env
+fi
+if [ ! -f web/apps/portal/.env ]; then
+  cp -- web/apps/portal/.env.example web/apps/portal/.env
+fi
+
+if [ ! -f dev/.env.depot ] && [ -n "${UNKEY_DEPOT_TOKEN:-}" ]; then
+  echo "Creating Depot credentials from the sandbox secret..."
+  (
+    umask 077
+    printf 'UNKEY_DEPOT_TOKEN=%s\nUNKEY_REGISTRY_PASSWORD=%s\n' \
+      "$UNKEY_DEPOT_TOKEN" \
+      "$UNKEY_DEPOT_TOKEN" >dev/.env.depot
+  )
+fi
+
+echo "Cursor Cloud setup complete."

--- a/.mise/tasks/cursor-apps
+++ b/.mise/tasks/cursor-apps
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+#MISE description="Expose ready Deploy apps on localhost through Frontline"
+#MISE raw=true
+set -euo pipefail
+exec "${MISE_BIN:-$HOME/.local/bin/mise}" exec -- go run ./tools/amp-orb-services local-apps "${PORT:-19081}"

--- a/.mise/tasks/dev-cursor
+++ b/.mise/tasks/dev-cursor
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#MISE description="Start the reduced Kubernetes development environment for Cursor Cloud"
+#MISE depends=["install-web"]
+#MISE raw=true
+set -euo pipefail
+
+# shellcheck source=../../.cursor/lib.sh
+. .cursor/lib.sh
+
+mise="${MISE_BIN:-$HOME/.local/bin/mise}"
+apply_cluster "$mise"
+minikube addons enable metrics-server
+"$mise" exec -- minikube cp dev/k8s/topolvm/setup-vg.sh /tmp/topolvm-setup-vg.sh
+"$mise" exec -- minikube ssh -- sudo bash /tmp/topolvm-setup-vg.sh 20G
+tilt up \
+  --file ./dev/Tiltfile \
+  --host 0.0.0.0 \
+  --port "${PORT:-10350}" \
+  --stream \
+  -- \
+  --orb=true

--- a/dev/cluster.cursor.yaml
+++ b/dev/cluster.cursor.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=ctlptl.schema.json
+apiVersion: ctlptl.dev/v1alpha1
+kind: Cluster
+product: minikube
+minikube:
+  startFlags:
+    - "--driver=docker"
+    - "--cpus=no-limit"
+    - "--memory=no-limit"
+    - "--container-runtime=containerd"
+    - "--docker-opt=containerd=/var/run/containerd/containerd.sock"
+    # Cursor Cloud VMs do not include the eBPF JIT required by Cilium.
+    - "--cni=bridge"
+    # Only docker0 (172.17.0.0/16) has internet NAT in Cursor Cloud.
+    # minikube's default 192.168.49.0/24 network cannot pull images or apt.
+    - "--network=bridge"
+    # Tilt pushes to the registry by docker0 IP. Allow HTTP pulls from that
+    # subnet; ctlptl only marks the ctlptl-registry hostname insecure.
+    - "--insecure-registry=172.17.0.0/16"
+    # Cursor Cloud's kernel has no xt_statistic, so kube-proxy iptables
+    # cannot program ClusterIP rules. nftables mode does not need it.
+    - "--extra-config=kube-proxy.mode=nftables"
+    # Same as Amp orb: no Cilium/eBPF, gvisor + metrics-server.
+    # Extra Cursor flags: docker0 NAT, insecure registry, kube-proxy nftables.
+    - "--addons=gvisor,metrics-server"
+    # Wait only for the API server so a slow first-time addon pull cannot
+    # hang ctlptl the way --wait=all does.
+    - "--wait=apiserver"
+registry: ctlptl-registry
+kubernetesVersion: v1.34.0

--- a/tools/amp-orb-services/host_frontline.go
+++ b/tools/amp-orb-services/host_frontline.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"time"
+)
+
+// runHostFrontline exposes one deployment on a localhost port. Cursor has no
+// Amp portal hostname, so the proxy restores the *.unkey.local Host header
+// Frontline uses for route lookup and then TLS-dials the local Frontline.
+func runHostFrontline(args []string) error {
+	if len(args) != 2 {
+		return fmt.Errorf("usage: amp-orb-services host-frontline <listen-port> <source-hostname>")
+	}
+	listenPort, err := parsePort(args[0])
+	if err != nil {
+		return err
+	}
+	sourceHostname := args[1]
+	if !hostnamePattern.MatchString(sourceHostname) {
+		return fmt.Errorf("source route must be a valid hostname")
+	}
+
+	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", listenPort))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = listener.Close() }()
+
+	tlsConfig := &tls.Config{ //nolint:exhaustruct,gosec
+		MinVersion:         tls.VersionTLS12,
+		ServerName:         sourceHostname,
+		InsecureSkipVerify: true,
+	}
+
+	for {
+		client, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			fmt.Printf("Unable to accept app connection: %s\n", acceptErr)
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+		go handleHostFrontline(client, sourceHostname, tlsConfig)
+	}
+}
+
+func handleHostFrontline(client net.Conn, sourceHostname string, tlsConfig *tls.Config) {
+	defer func() { _ = client.Close() }()
+
+	request, err := readInitialRequest(client)
+	if err != nil || len(request) == 0 {
+		return
+	}
+	request = rewriteHostHeader(request, sourceHostname)
+
+	rawUpstream, err := net.DialTimeout(
+		"tcp",
+		fmt.Sprintf("127.0.0.1:%d", frontlineUpstreamPort),
+		5*time.Second,
+	)
+	if err != nil {
+		body := []byte("Waiting for Frontline on localhost:9443\n")
+		_, _ = fmt.Fprintf(
+			client,
+			"HTTP/1.1 503 Service Unavailable\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s",
+			len(body),
+			body,
+		)
+		return
+	}
+	upstream := tls.Client(rawUpstream, tlsConfig)
+	if err = upstream.SetDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		_ = upstream.Close()
+		return
+	}
+	if err = upstream.Handshake(); err != nil {
+		_ = upstream.Close()
+		return
+	}
+	if err = upstream.SetDeadline(time.Time{}); err != nil {
+		_ = upstream.Close()
+		return
+	}
+	if _, err = upstream.Write(request); err != nil {
+		_ = upstream.Close()
+		return
+	}
+	bridgeConnections(client, upstream)
+}
+
+func rewriteHostHeader(request []byte, hostname string) []byte {
+	lines := bytes.Split(request, []byte("\r\n"))
+	hostLine := []byte("Host: " + hostname)
+	replaced := false
+	for i, line := range lines {
+		name, _, ok := bytes.Cut(line, []byte(":"))
+		if !ok || !bytes.EqualFold(name, []byte("host")) {
+			continue
+		}
+		lines[i] = hostLine
+		replaced = true
+		break
+	}
+	if !replaced && len(lines) > 0 {
+		inserted := make([][]byte, 0, len(lines)+1)
+		inserted = append(inserted, lines[0], hostLine)
+		inserted = append(inserted, lines[1:]...)
+		lines = inserted
+	}
+	return bytes.Join(lines, []byte("\r\n"))
+}

--- a/tools/amp-orb-services/local_apps.go
+++ b/tools/amp-orb-services/local_apps.go
@@ -1,0 +1,261 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"html"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	localAppPortStart = 20_000
+	localAppPortCount = 10_000
+)
+
+// runLocalApps is the Cursor Cloud counterpart to Amp deployment portals.
+// It does not call `amp orb portal`. Ready *.unkey.local deployments get a
+// localhost port that reaches Frontline with the deployment Host header.
+func runLocalApps(args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("usage: amp-orb-services local-apps <listen-port>")
+	}
+	listenPort, err := parsePort(args[0])
+	if err != nil {
+		return err
+	}
+
+	manager := &localAppManager{
+		portals: make(map[string]managedPortal),
+	}
+	go manager.watch()
+
+	handler := http.HandlerFunc(manager.handleStatus)
+	return http.ListenAndServe(fmt.Sprintf(":%d", listenPort), handler) //nolint:gosec
+}
+
+type localAppManager struct {
+	mu        sync.Mutex
+	portals   map[string]managedPortal
+	lastError string
+}
+
+func (m *localAppManager) watch() {
+	for {
+		routes, err := listDeploymentRoutes()
+		if err == nil {
+			err = m.reconcile(routes)
+		}
+		m.setError(err)
+		time.Sleep(pollInterval)
+	}
+}
+
+func (m *localAppManager) reconcile(routes []deploymentRoute) error {
+	desired := make(map[string]deploymentRoute, len(routes))
+	for _, route := range routes {
+		desired[route.deploymentID] = route
+	}
+
+	m.mu.Lock()
+	current := make(map[string]managedPortal, len(m.portals))
+	for deploymentID, portal := range m.portals {
+		current[deploymentID] = portal
+	}
+	m.mu.Unlock()
+
+	for deploymentID, managed := range current {
+		route, ok := desired[deploymentID]
+		if ok && route.sourceHostname == managed.portal.SourceHostname && managed.process.alive() {
+			continue
+		}
+		stopPortalProcess(managed.process)
+		m.mu.Lock()
+		delete(m.portals, deploymentID)
+		m.mu.Unlock()
+	}
+
+	m.mu.Lock()
+	usedPorts := make(map[int]struct{}, len(m.portals))
+	activeIDs := make(map[string]struct{}, len(m.portals))
+	for deploymentID, managed := range m.portals {
+		usedPorts[managed.portal.Port] = struct{}{}
+		activeIDs[deploymentID] = struct{}{}
+	}
+	m.mu.Unlock()
+
+	sort.Slice(routes, func(i, j int) bool {
+		return routes[i].deploymentID < routes[j].deploymentID
+	})
+	for _, route := range routes {
+		if _, ok := activeIDs[route.deploymentID]; ok {
+			continue
+		}
+		port, err := allocateLocalAppPort(route.deploymentID, usedPorts)
+		if err != nil {
+			return err
+		}
+		managed, err := startLocalApp(route, port)
+		if err != nil {
+			return err
+		}
+		usedPorts[port] = struct{}{}
+		m.mu.Lock()
+		m.portals[route.deploymentID] = managed
+		m.mu.Unlock()
+	}
+	return nil
+}
+
+func startLocalApp(route deploymentRoute, port int) (managedPortal, error) {
+	executable, err := os.Executable()
+	if err != nil {
+		return managedPortal{}, err
+	}
+	command := exec.Command(executable, "host-frontline", fmt.Sprint(port), route.sourceHostname)
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
+	if err = command.Start(); err != nil {
+		return managedPortal{}, err
+	}
+	process := &portalProcess{command: command, done: make(chan struct{})}
+	go func() {
+		_ = command.Wait()
+		close(process.done)
+	}()
+
+	if err = waitUntilListening(port, process); err != nil {
+		stopPortalProcess(process)
+		return managedPortal{}, err
+	}
+
+	title := portalTitle(route)
+	localURL := fmt.Sprintf("http://127.0.0.1:%d/", port)
+	fmt.Printf("Deployment app ready: %s -> %s (%s)\n", title, localURL, route.sourceHostname)
+	return managedPortal{
+		portal: activePortal{
+			DeploymentID:   route.deploymentID,
+			SourceHostname: route.sourceHostname,
+			Name:           portalName(route.deploymentID),
+			Port:           port,
+			URL:            localURL,
+			Title:          title,
+		},
+		process: process,
+	}, nil
+}
+
+func allocateLocalAppPort(deploymentID string, used map[int]struct{}) (int, error) {
+	digest := sha256.Sum256([]byte(deploymentID))
+	offset := int(binary.BigEndian.Uint32(digest[:4])) % localAppPortCount
+	for step := range localAppPortCount {
+		port := localAppPortStart + (offset+step)%localAppPortCount
+		if _, ok := used[port]; ok {
+			continue
+		}
+		listener, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+		if err != nil {
+			continue
+		}
+		_ = listener.Close()
+		return port, nil
+	}
+	return 0, fmt.Errorf("no local app ports are available in %d-%d", localAppPortStart, localAppPortStart+localAppPortCount-1)
+}
+
+func (m *localAppManager) setError(err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	message := ""
+	if err != nil {
+		message = err.Error()
+	}
+	if message != "" && message != m.lastError {
+		fmt.Printf("Unable to reconcile local apps: %s\n", message)
+	}
+	m.lastError = message
+}
+
+func (m *localAppManager) snapshot() ([]activePortal, string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	portals := make([]activePortal, 0, len(m.portals))
+	for _, managed := range m.portals {
+		portals = append(portals, managed.portal)
+	}
+	sort.Slice(portals, func(i, j int) bool {
+		return portals[i].DeploymentID < portals[j].DeploymentID
+	})
+	return portals, m.lastError
+}
+
+func (m *localAppManager) handleStatus(response http.ResponseWriter, request *http.Request) {
+	portals, errorMessage := m.snapshot()
+	listed := make([]activePortal, len(portals))
+	for i, portal := range portals {
+		portal.URL = appPublicURL(request, portal.Port)
+		listed[i] = portal
+	}
+	if request.URL.Path == "/json" || request.Header.Get("Accept") == "application/json" {
+		response.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(response).Encode(map[string]any{
+			"status": "ok",
+			"apps":   listed,
+			"error":  errorMessage,
+		})
+		return
+	}
+
+	response.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = fmt.Fprint(response, `<!doctype html><html lang="en"><head><meta charset="utf-8"><title>Deployed apps</title>`)
+	_, _ = fmt.Fprint(response, `<meta http-equiv="refresh" content="5">`)
+	_, _ = fmt.Fprint(response, `<style>body{font:16px/1.4 sans-serif;margin:2rem;max-width:52rem}a{color:#0b57d0}li{margin:.4rem 0}.err{color:#a40000}code{font-size:.95em}</style></head><body>`)
+	_, _ = fmt.Fprint(response, `<h1>Deployed apps</h1>`)
+	_, _ = fmt.Fprint(response, `<p>Each ready <code>*.unkey.local</code> deployment is bridged through Frontline on a localhost port, the Cursor counterpart to Amp deployment portals.</p>`)
+	if errorMessage != "" {
+		_, _ = fmt.Fprintf(response, `<p class="err">%s</p>`, html.EscapeString(errorMessage))
+	}
+	if len(listed) == 0 {
+		_, _ = fmt.Fprint(response, `<p>No ready deployments yet.</p>`)
+	} else {
+		_, _ = fmt.Fprint(response, `<ul>`)
+		for _, portal := range listed {
+			_, _ = fmt.Fprintf(
+				response,
+				`<li><a href="%s">%s</a> on <code>localhost:%d</code> → <code>%s</code></li>`,
+				html.EscapeString(portal.URL),
+				html.EscapeString(portal.Title),
+				portal.Port,
+				html.EscapeString(portal.SourceHostname),
+			)
+		}
+		_, _ = fmt.Fprint(response, `</ul>`)
+	}
+	_, _ = fmt.Fprint(response, `</body></html>`)
+}
+
+func appPublicURL(request *http.Request, port int) string {
+	scheme := "http"
+	if request.TLS != nil || strings.EqualFold(request.Header.Get("X-Forwarded-Proto"), "https") {
+		scheme = "https"
+	}
+	host := request.Host
+	if host == "" {
+		return fmt.Sprintf("http://127.0.0.1:%d/", port)
+	}
+	hostname, _, err := net.SplitHostPort(host)
+	if err != nil {
+		return fmt.Sprintf("http://127.0.0.1:%d/", port)
+	}
+	return fmt.Sprintf("%s://%s/", scheme, net.JoinHostPort(hostname, fmt.Sprint(port)))
+}

--- a/tools/amp-orb-services/local_apps_test.go
+++ b/tools/amp-orb-services/local_apps_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRewriteHostHeaderReplacesExistingHost(t *testing.T) {
+	t.Parallel()
+
+	request := []byte("GET /health HTTP/1.1\r\nHost: 127.0.0.1:20000\r\nAccept: */*\r\n\r\n")
+	got := rewriteHostHeader(request, "demo.unkey.local")
+
+	require.Equal(t, "GET /health HTTP/1.1\r\nHost: demo.unkey.local\r\nAccept: */*\r\n\r\n", string(got))
+}
+
+func TestRewriteHostHeaderInsertsMissingHost(t *testing.T) {
+	t.Parallel()
+
+	request := []byte("GET / HTTP/1.1\r\nAccept: */*\r\n\r\n")
+	got := rewriteHostHeader(request, "demo.unkey.local")
+
+	require.Equal(t, "GET / HTTP/1.1\r\nHost: demo.unkey.local\r\nAccept: */*\r\n\r\n", string(got))
+}
+
+func TestAllocateLocalAppPortUsesDeclaredRange(t *testing.T) {
+	t.Parallel()
+
+	used := map[int]struct{}{localAppPortStart: {}}
+	port, err := allocateLocalAppPort("d_test", used)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, port, localAppPortStart)
+	require.Less(t, port, localAppPortStart+localAppPortCount)
+}
+
+func TestAllocateLocalAppPortStableForDeployment(t *testing.T) {
+	t.Parallel()
+
+	first, err := allocateLocalAppPort("d_stable", map[int]struct{}{})
+	require.NoError(t, err)
+	second, err := allocateLocalAppPort("d_stable", map[int]struct{}{})
+	require.NoError(t, err)
+	require.Equal(t, first, second)
+}
+
+func TestAppPublicURLRewritesHostPort(t *testing.T) {
+	t.Parallel()
+
+	request := httptest.NewRequest(http.MethodGet, "http://localhost:19081/", nil)
+	require.Equal(t, "http://localhost:20000/", appPublicURL(request, 20000))
+}
+
+func TestAppPublicURLKeepsLoopbackWhenHostHasNoPort(t *testing.T) {
+	t.Parallel()
+
+	request := httptest.NewRequest(http.MethodGet, "https://apps.example.com/", nil)
+	require.Equal(t, "http://127.0.0.1:20000/", appPublicURL(request, 20000))
+}

--- a/tools/amp-orb-services/main.go
+++ b/tools/amp-orb-services/main.go
@@ -1,6 +1,7 @@
-// Command amp-orb-services provides the network adapters used by .amp/services.yaml.
+// Command amp-orb-services provides the network adapters used by .amp/services.yaml
+// and by Cursor Cloud's local app index.
 //
-// Amp can expose only processes that listen directly in the orb. The local Unkey
+// Amp and Cursor can expose only processes that listen in the VM. The local Unkey
 // stack instead exposes some services through minikube loopback ports and routes
 // deployed applications through Frontline. These commands bridge those boundaries
 // without changing the production services or bypassing Frontline behavior.
@@ -22,7 +23,7 @@ const commandTimeout = 30 * time.Second
 
 func main() {
 	if len(os.Args) < 2 {
-		fatalf("usage: amp-orb-services <proxy|frontline|deployment-portals> [arguments]")
+		fatalf("usage: amp-orb-services <proxy|frontline|deployment-portals|local-apps|host-frontline> [arguments]")
 	}
 
 	var err error
@@ -33,6 +34,10 @@ func main() {
 		err = runFrontlineProxy(os.Args[2:])
 	case "deployment-portals":
 		err = runDeploymentPortals(os.Args[2:])
+	case "local-apps":
+		err = runLocalApps(os.Args[2:])
+	case "host-frontline":
+		err = runHostFrontline(os.Args[2:])
 	default:
 		err = fmt.Errorf("unknown command %q", os.Args[1])
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
> [!IMPORTANT]
> Unkey is not accepting external pull requests at this time. Pull requests from people outside the Unkey team will not be reviewed or merged.

## What does this PR do?

Run Unkey's minikube + Tilt orb stack on Cursor Cloud.

This is the same stack as `mise run dev-orb`: `tilt up --orb=true`, bridge CNI (no Cilium/eBPF), **gvisor**, and metrics-server. Docker is only the minikube driver (`--driver=docker`). It is not a second cluster.

Cursor Cloud does not run Amp's `.agents` scripts. Those stay Amp-only and match `main`. Cursor only executes `.cursor/environment.json`:

- `install`: `bash .cursor/setup` (dockerd so minikube can run, mise, web deps)
- `start`: `bash .cursor/resume` (bring dockerd back; these VMs have no systemd)
- `tilt` terminal: `mise run dev-cursor` (`ctlptl` apply `dev/cluster.cursor.yaml`, then Tilt)
- `apps` terminal: `mise run cursor-apps` (index of ready Deploy apps at `http://localhost:19081`)

Cursor-only flags in `dev/cluster.cursor.yaml` (Amp still uses `dev/cluster.orb.yaml`):

- fuse-overlayfs on the host and native snapshotter in minikube (nested overlayfs fails)
- `--network=bridge` and `--insecure-registry=172.17.0.0/16` (only docker0 is NATed)
- kube-proxy nftables (no `xt_statistic`)
- `--addons=gvisor,metrics-server` like Amp; a one-shot rewrite keeps a single `runsc` table if minikube start runs twice
- `--wait=apiserver` so addon pulls cannot hang ctlptl

Ready `*.unkey.local` deployments are bridged through Frontline on dynamic localhost ports in `20000-29999`, with an index at `http://localhost:19081`. This is the Cursor counterpart to Amp's `deployment-portals` service. `.amp/services.yaml` is unchanged.

Kubelet image pulls use the minikube node, not cluster DNS, so Cursor also maps `ctlptl-registry` in the node `/etc/hosts` to the registry's docker0 IP. Without that, Deploy apps stay in `ErrImagePull` and never appear on the index.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Screenshots / recordings

Cursor Cloud has no Amp portal CLI, so ready apps are listed at `http://localhost:19081` and opened on dynamic localhost ports through Frontline.

![Deployed apps index listing local-api on localhost](https://cursor.com/artifacts/c/art-570c6260-c09f-42a8-98b7-ac494a2cbc65)
![App response through the Frontline host rewrite](https://cursor.com/artifacts/c/art-a2b8b3d5-8a92-49f3-a09f-35aa154bed24)
<a href="https://cursor.com/agents/bc-321762d5-b04f-42e9-9960-92f97a4fbd80/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdeployed_apps_index_and_frontline_bridge.mp4"><img src="https://cursor.com/artifacts/c/art-04c98b88-1189-49dd-82bc-33e65fdf4b49" alt="deployed_apps_index_and_frontline_bridge.mp4" /></a>

## How should this be tested?

- From a Cursor Cloud agent on this branch, the `tilt` terminal should bring up Tilt at `http://localhost:10350`, the API at `http://localhost:7070/v2/liveness`, and the dashboard at `http://localhost:3000`.
- `kubectl get runtimeclass` should show `gvisor`. kube-proxy should be nftables. Docker should be `fuse-overlayfs`.
- `http://localhost:19081` should list ready Deploy apps (empty until a deployment is running), each with a dynamic localhost port in `20000-29999`.
- After a Deploy app is `ready`, `curl http://localhost:<dynamic-port>/` should reach it through Frontline (`X-Unkey-Frontline-Id` in the response).
- Amp orbs should be unchanged: `.agents/setup` / `.agents/resume` still apply `dev/cluster.orb.yaml`. `.amp/services.yaml` is unchanged.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `mise run fmt`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [x] If I made a visual change: Filled out the "Screenshots / recordings" section, as shown in the [screenshot and recording guide](../docs/engineering/contributing/quality/screenshots-and-recordings.mdx)

### Appreciated

- [x] Updated the Unkey Docs if changes were necessary
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-321762d5-b04f-42e9-9960-92f97a4fbd80?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-321762d5-b04f-42e9-9960-92f97a4fbd80&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

