### PR TITLE
fix(ci): upgrade Node past CJS lexer crash

### DIFF
--- a/.depot/actions/setup-node/action.yaml
+++ b/.depot/actions/setup-node/action.yaml
@@ -21,7 +21,7 @@ runs:
     - name: Setup Node with pnpm cache
       uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
       with:
-        node-version: 24.15.0
+        node-version: 24.19.0
         cache: "pnpm"
         cache-dependency-path: "**/pnpm-lock.yaml"
     - name: Enable Corepack

--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -11,7 +11,7 @@ provenance_api_failures_fatal = true
 task.run_auto_install = false
 
 [tools]
-node = "24.16.0"
+node = "24.19.0"
 go = "1.25.1"
 "github:dprint/dprint" = "0.51.1"
 "github:bufbuild/buf" = "1.64.0"

--- a/.mise/mise.lock
+++ b/.mise/mise.lock
@@ -684,33 +684,33 @@ checksum = "sha256:9028276a33809a94fcf46a35733a21f013a6cc3b4a155ee849563af65dc11
 url = "https://bin.equinox.io/a/gK2xcZtiEuC/ngrok-v3-3.39.4-windows-amd64.zip"
 
 [[tools.node]]
-version = "24.16.0"
+version = "24.19.0"
 backend = "core:node"
 
 [tools.node."platforms.linux-arm64"]
-checksum = "sha256:589f5b6dd4fcfee4dfda73013903c966abaa8abd93dbc9d436544e472b4f0e74"
-url = "https://nodejs.org/dist/v24.16.0/node-v24.16.0-linux-arm64.tar.gz"
+checksum = "sha256:d28c8a5bf0a808f0ed434a1dce8c54ae98f0371c0bd86ac58abc613f73e6643f"
+url = "https://nodejs.org/dist/v24.19.0/node-v24.19.0-linux-arm64.tar.gz"
 
 [tools.node."platforms.linux-arm64-musl"]
-checksum = "sha256:85dde27aa73503b03dadfa0410a800067b4e3f702fb7fcaa3beaf284dfcc69e9"
-url = "https://unofficial-builds.nodejs.org/download/release/v24.16.0/node-v24.16.0-linux-arm64-musl.tar.gz"
+checksum = "sha256:20824e4d35948fae5b337dccef47813b04d8995312f59df7386f2256d9f9ab7e"
+url = "https://unofficial-builds.nodejs.org/download/release/v24.19.0/node-v24.19.0-linux-arm64-musl.tar.gz"
 
 [tools.node."platforms.linux-x64"]
-checksum = "sha256:2faf6a387e9b62b888e21c54f01249fb27537ffecf1842f29f4c919d0a59a0ff"
-url = "https://nodejs.org/dist/v24.16.0/node-v24.16.0-linux-x64.tar.gz"
+checksum = "sha256:f625d97cd707df4ff96254916fbc5ff014f09c09effe5a1e0ca8f6d41a8789d4"
+url = "https://nodejs.org/dist/v24.19.0/node-v24.19.0-linux-x64.tar.gz"
 
 [tools.node."platforms.linux-x64-musl"]
-checksum = "sha256:50df5d8d474892d4f7b906167df36f77f5b93908f63dc532dc568219cab65841"
-url = "https://unofficial-builds.nodejs.org/download/release/v24.16.0/node-v24.16.0-linux-x64-musl.tar.gz"
+checksum = "sha256:c60223786df14a5d23e220ebb8e60318f5322640a62f90e6d9e54d3a18da532e"
+url = "https://unofficial-builds.nodejs.org/download/release/v24.19.0/node-v24.19.0-linux-x64-musl.tar.gz"
 
 [tools.node."platforms.macos-arm64"]
-checksum = "sha256:39189dab4eeb15706c424af0ac08a3044c9e48f7db12a7d77f6b7aafc7dd5df6"
-url = "https://nodejs.org/dist/v24.16.0/node-v24.16.0-darwin-arm64.tar.gz"
+checksum = "sha256:8294b7aa9b03997481c06babf1e8b270c859358f27da57a11509afe537ac381d"
+url = "https://nodejs.org/dist/v24.19.0/node-v24.19.0-darwin-arm64.tar.gz"
 
 [tools.node."platforms.macos-x64"]
-checksum = "sha256:298b4c7b3cb80765c8703e42b90324a4ece3b6634947b89e769c3c980ab55185"
-url = "https://nodejs.org/dist/v24.16.0/node-v24.16.0-darwin-x64.tar.gz"
+checksum = "sha256:d1b5e999db158c62fe8f7267a4476b035d8bd93b1a605bac24a3f0dd166e3316"
+url = "https://nodejs.org/dist/v24.19.0/node-v24.19.0-darwin-x64.tar.gz"
 
 [tools.node."platforms.windows-x64"]
-checksum = "sha256:edaca9bd58ec8e92037dac4e877d52f6b8f430b81c18b57e264b4e2fb111cd56"
-url = "https://nodejs.org/dist/v24.16.0/node-v24.16.0-win-x64.zip"
+checksum = "sha256:57f71ab3652e797d84acddc79c81cc9ff1c6ddb2a1974cdb83f00fee9bff4c73"
+url = "https://nodejs.org/dist/v24.19.0/node-v24.19.0-win-x64.zip"

--- a/docs/engineering/contributing/tooling/mise.mdx
+++ b/docs/engineering/contributing/tooling/mise.mdx
@@ -50,7 +50,7 @@ of floating versions like `latest`.
 
 ```toml
 [tools]
-node = "24.16.0"
+node = "24.19.0"
 "npm:pnpm" = "8.6.9"
 "github:depot/cli" = "2.101.63"
 ```


### PR DESCRIPTION
Our CI failed a few times and it looks like that's a bug in the node version we were using. Upgrading to the latest LTS should fix it.


# AI SLOP BELOW




## Summary

- upgrade Depot CI and mise from affected Node 24.15.0/24.16.0 pins to Node 24.19.0
- regenerate the mise lockfile and align the tooling documentation
- keep existing Vitest and Turbo concurrency because it only exposes the native runtime defect

## Evidence

The CI abort signature, `v8::ToLocalChecked Empty MaybeLocal` in `node::cjs_lexer::Parse`, matches [nodejs/node#63323](https://github.com/nodejs/node/issues/63323). The regression affects Node 24.14.0 and newer after the native CJS lexer replaced the prior WASM implementation.

Observed CI failures:

- `@unkey/rbac#test` on `3caf1b02`: [failed GitHub check](https://github.com/unkeyed/unkey/runs/93454046702) and [Depot attempt](https://depot.dev/orgs/25j3k7j1zw/workflows/2jsk48j4cf?job=336dwc6ltd&attempt=kw6n6w074w). All 39 RBAC tests passed before Node aborted; the [identical-SHA retry](https://depot.dev/orgs/25j3k7j1zw/workflows/2jsk48j4cf?job=336dwc6ltd&attempt=l6f73k131k) succeeded.
- `@unkey/dashboard#test` on merge SHA `3c02acd2`: [failed GitHub check](https://github.com/unkeyed/unkey/runs/92662297801) and [Depot attempt](https://depot.dev/orgs/25j3k7j1zw/workflows/tqg29tb4w1?job=h1fcpj99r2&attempt=l35n7pdcsx). All 755 dashboard tests passed before the same Node abort.

Node fixed the unchecked `MaybeLocal` path in [nodejs/node#63885](https://github.com/nodejs/node/pull/63885), followed by [nodejs/node#63943](https://github.com/nodejs/node/pull/63943). Node 24.16.0 predates those fixes, and the 24.17/24.18 changelogs do not include them. Node 24.19.0 is the first 24.x release whose changelog contains both backports, so aligning CI on 24.16.0 would retain the crash.

## Validation

- `MISE_LOCKED=1 mise install node` installed Node v24.19.0 from the regenerated lockfile
- five uncached runs of `CI=1 mise exec -- pnpm --dir=web turbo run test --filter=@unkey/rbac --filter=@unkey/dashboard` passed
  - 39 RBAC tests per run
  - 776 dashboard tests per run
- `git diff --check` passed

The failure is probabilistic, so repeated passing runs cannot prove absence, but Node 24.19.0 removes the exact upstream fatal path.