### PR TITLE
refactor(dashboard): add missing index to deployment/deployments_steps

### DIFF
--- a/pkg/mysql/schema/deployment_steps.sql
+++ b/pkg/mysql/schema/deployment_steps.sql
@@ -15,3 +15,5 @@ CREATE TABLE `deployment_steps` (
 
 CREATE INDEX `workspace_idx` ON `deployment_steps` (`workspace_id`);
 
+CREATE INDEX `step_started_at_idx` ON `deployment_steps` (`step`,`started_at`,`ended_at`);
+

--- a/pkg/mysql/schema/deployments.sql
+++ b/pkg/mysql/schema/deployments.sql
@@ -47,3 +47,5 @@ CREATE INDEX `project_idx` ON `deployments` (`project_id`);
 
 CREATE INDEX `status_idx` ON `deployments` (`status`);
 
+CREATE INDEX `created_at_status_idx` ON `deployments` (`created_at`,`status`);
+

--- a/web/internal/db/src/schema/deployment_steps.ts
+++ b/web/internal/db/src/schema/deployment_steps.ts
@@ -38,6 +38,9 @@ export const deploymentSteps = mysqlTable(
   (table) => [
     index("workspace_idx").on(table.workspaceId),
     uniqueIndex("unique_step_per_deployment").on(table.deploymentId, table.step),
+    // Serves the step-duration average: WHERE step = ? AND started_at >= ?
+    // reading ended_at. All three columns in the index keep it index-only.
+    index("step_started_at_idx").on(table.step, table.startedAt, table.endedAt),
   ],
 );
 

--- a/web/internal/db/src/schema/deployment_steps.ts
+++ b/web/internal/db/src/schema/deployment_steps.ts
@@ -38,8 +38,6 @@ export const deploymentSteps = mysqlTable(
   (table) => [
     index("workspace_idx").on(table.workspaceId),
     uniqueIndex("unique_step_per_deployment").on(table.deploymentId, table.step),
-    // Serves the step-duration average: WHERE step = ? AND started_at >= ?
-    // reading ended_at. All three columns in the index keep it index-only.
     index("step_started_at_idx").on(table.step, table.startedAt, table.endedAt),
   ],
 );

--- a/web/internal/db/src/schema/deployments.ts
+++ b/web/internal/db/src/schema/deployments.ts
@@ -141,6 +141,9 @@ export const deployments = mysqlTable(
     index("workspace_idx").on(table.workspaceId),
     index("project_idx").on(table.projectId),
     index("status_idx").on(table.status),
+    // Serves the recency pollers: ORDER BY created_at DESC LIMIT n, and
+    // 7-day windows aggregating status. status makes those index-only.
+    index("created_at_status_idx").on(table.createdAt, table.status),
   ],
 );
 

--- a/web/internal/db/src/schema/deployments.ts
+++ b/web/internal/db/src/schema/deployments.ts
@@ -141,8 +141,6 @@ export const deployments = mysqlTable(
     index("workspace_idx").on(table.workspaceId),
     index("project_idx").on(table.projectId),
     index("status_idx").on(table.status),
-    // Serves the recency pollers: ORDER BY created_at DESC LIMIT n, and
-    // 7-day windows aggregating status. status makes those index-only.
     index("created_at_status_idx").on(table.createdAt, table.status),
   ],
 );


### PR DESCRIPTION
This PR adds two indexes. PlanetScale Insights shows full table scans from queries, screenshot below. Queries with icon means that those queries lack index. 

<img width="2262" height="676" alt="Screenshot 2026-08-19 at 19 01 25" src="https://github.com/user-attachments/assets/e1233a72-0d2b-474c-8eab-61a20480486f" />

## Verification
I tested it locally with EXPLAIN ANALYZE using 45k deployments and 150k steps, query
goes from 10.9ms to 0.014ms.


