### PR TITLE
perf(api): batch credit updates with results

### DIFF
--- a/pkg/db/clickhouse_outbox_insert.sql_generated.go
+++ b/pkg/db/clickhouse_outbox_insert.sql_generated.go
@@ -67,3 +67,81 @@ func (q *Queries) InsertClickhouseOutbox(ctx context.Context, db DBTX, arg Inser
 	)
 	return err
 }
+
+const insertClickhouseOutboxForCreditUpdate = `-- name: InsertClickhouseOutboxForCreditUpdate :exec
+INSERT INTO ` + "`" + `clickhouse_outbox` + "`" + ` (
+    version,
+    workspace_id,
+    event_id,
+    payload,
+    created_at
+)
+SELECT
+    ?,
+    ?,
+    ?,
+    JSON_SET(
+        CAST(? AS JSON),
+        '$.description',
+        CONCAT(
+            'Updated Key ', ?, ', set remaining to ',
+            IF(k.remaining_requests IS NULL, 'unlimited', CAST(k.remaining_requests AS CHAR)),
+            '.'
+        )
+    ),
+    ?
+FROM ` + "`" + `keys` + "`" + ` k
+WHERE k.id = ?
+  AND ROW_COUNT() = 1
+`
+
+type InsertClickhouseOutboxForCreditUpdateParams struct {
+	Version     string          `db:"version"`
+	WorkspaceID string          `db:"workspace_id"`
+	EventID     string          `db:"event_id"`
+	Payload     json.RawMessage `db:"payload"`
+	KeyID       string          `db:"key_id"`
+	CreatedAt   int64           `db:"created_at"`
+}
+
+// transactional-batch-statement
+// This statement must immediately follow the guarded credit UPDATE. With
+// clientFoundRows enabled on the batch pool, ROW_COUNT() is one for every
+// valid update, including no-ops, and zero for deletion/unlimited/overflow.
+//
+//	INSERT INTO `clickhouse_outbox` (
+//	    version,
+//	    workspace_id,
+//	    event_id,
+//	    payload,
+//	    created_at
+//	)
+//	SELECT
+//	    ?,
+//	    ?,
+//	    ?,
+//	    JSON_SET(
+//	        CAST(? AS JSON),
+//	        '$.description',
+//	        CONCAT(
+//	            'Updated Key ', ?, ', set remaining to ',
+//	            IF(k.remaining_requests IS NULL, 'unlimited', CAST(k.remaining_requests AS CHAR)),
+//	            '.'
+//	        )
+//	    ),
+//	    ?
+//	FROM `keys` k
+//	WHERE k.id = ?
+//	  AND ROW_COUNT() = 1
+func (q *Queries) InsertClickhouseOutboxForCreditUpdate(ctx context.Context, db DBTX, arg InsertClickhouseOutboxForCreditUpdateParams) error {
+	_, err := db.ExecContext(ctx, insertClickhouseOutboxForCreditUpdate,
+		arg.Version,
+		arg.WorkspaceID,
+		arg.EventID,
+		arg.Payload,
+		arg.KeyID,
+		arg.CreatedAt,
+		arg.KeyID,
+	)
+	return err
+}

--- a/pkg/db/database.go
+++ b/pkg/db/database.go
@@ -49,6 +49,9 @@ func open(dsn string, enableMultiStatementBatches bool) (db *sql.DB, err error) 
 	if enableMultiStatementBatches {
 		dsnConfig.MultiStatements = true
 		dsnConfig.InterpolateParams = true
+		// Batch result classification needs matched rows so valid no-op updates
+		// remain distinguishable from guarded updates that matched no key.
+		dsnConfig.ClientFoundRows = true
 	}
 
 	// sql.Open only validates the DSN, it doesn't actually connect.

--- a/pkg/db/key_credits_batch.go
+++ b/pkg/db/key_credits_batch.go
@@ -1,0 +1,158 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/unkeyed/unkey/pkg/logger"
+	"github.com/unkeyed/unkey/pkg/otel/tracing"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+type KeyCreditsBatchResult struct {
+	Applied           bool
+	KeyID             sql.NullString
+	DeletedAtM        sql.NullInt64
+	RemainingRequests sql.NullInt64
+	RefillAmount      sql.NullInt64
+	RefillDay         sql.NullInt16
+}
+
+func (r *Replica) UpdateKeyCreditsIncrementWithAuditBatch(
+	ctx context.Context,
+	update UpdateKeyCreditsIncrementReturningParams,
+	outbox InsertClickhouseOutboxForCreditUpdateParams,
+) (KeyCreditsBatchResult, error) {
+	return r.executeKeyCreditsBatch(ctx, "UpdateKeyCreditsIncrementWithAuditBatch", updateKeyCreditsIncrementReturningTransactionBatchStatement(update), outbox)
+}
+
+func (r *Replica) UpdateKeyCreditsDecrementWithAuditBatch(
+	ctx context.Context,
+	update UpdateKeyCreditsDecrementReturningParams,
+	outbox InsertClickhouseOutboxForCreditUpdateParams,
+) (KeyCreditsBatchResult, error) {
+	return r.executeKeyCreditsBatch(ctx, "UpdateKeyCreditsDecrementWithAuditBatch", updateKeyCreditsDecrementReturningTransactionBatchStatement(update), outbox)
+}
+
+func (r *Replica) UpdateKeyCreditsSetWithAuditBatch(
+	ctx context.Context,
+	update UpdateKeyCreditsSetParams,
+	outbox InsertClickhouseOutboxForCreditUpdateParams,
+) (KeyCreditsBatchResult, error) {
+	return r.executeKeyCreditsBatch(ctx, "UpdateKeyCreditsSetWithAuditBatch", updateKeyCreditsSetTransactionBatchStatement(update), outbox)
+}
+
+// executeKeyCreditsBatch returns the in-transaction credit state from a
+// diagnostic result set before consuming the terminal commit marker. This is
+// one MySQL protocol exchange, including the mutation and audit outbox write.
+func (r *Replica) executeKeyCreditsBatch(
+	ctx context.Context,
+	operation string,
+	update transactionBatchStatement,
+	outbox InsertClickhouseOutboxForCreditUpdateParams,
+) (result KeyCreditsBatchResult, err error) {
+	ctx, span := tracing.Start(ctx, operation)
+	defer span.End()
+	span.SetAttributes(attribute.String("mode", r.mode))
+
+	outboxStatement := insertClickhouseOutboxForCreditUpdateTransactionBatchStatement(outbox)
+	queries := []string{
+		"-- name: " + operation + "Start :exec\nSTART TRANSACTION",
+		update.query,
+		outboxStatement.query,
+		findKeyCreditsBatchResult,
+		"-- name: " + operation + "Commit :exec\nCOMMIT",
+		"-- name: " + operation + "Marker :one\nSELECT '" + transactionBatchMarker + "'",
+	}
+	for i := range queries {
+		queries[i] = r.annotate(ctx, queries[i])
+	}
+	args := append(update.args, outboxStatement.args...)
+	args = append(args, outbox.KeyID)
+
+	conn, err := r.db.Conn(ctx)
+	if err != nil {
+		recordBatchMetrics(r.mode, 0, err)
+		tracing.RecordErrorUnless(span, err)
+		return result, err
+	}
+	defer func() { _ = conn.Close() }()
+
+	start := time.Now()
+	rows, err := conn.QueryContext(ctx, strings.Join(queries, ";\n")+";", args...)
+	if err != nil {
+		cleanupTransactionBatchConnection(conn)
+		recordBatchMetrics(r.mode, time.Since(start), err)
+		tracing.RecordErrorUnless(span, err)
+		return result, err
+	}
+
+	var diagnosticErr error
+	if !rows.Next() {
+		diagnosticErr = errors.New("credit batch returned no diagnostic row")
+	} else {
+		var outboxRows int64
+		diagnosticErr = rows.Scan(
+			&outboxRows,
+			&result.KeyID,
+			&result.DeletedAtM,
+			&result.RemainingRequests,
+			&result.RefillAmount,
+			&result.RefillDay,
+		)
+		result.Applied = outboxRows == 1
+		if diagnosticErr == nil && outboxRows != 0 && outboxRows != 1 {
+			diagnosticErr = fmt.Errorf("credit batch inserted unexpected audit row count: %d", outboxRows)
+		}
+	}
+	for rows.Next() {
+		diagnosticErr = errors.New("credit batch returned multiple diagnostic rows")
+	}
+
+	committed := false
+	if rows.NextResultSet() && rows.Next() {
+		var marker string
+		if scanErr := rows.Scan(&marker); scanErr == nil && marker == transactionBatchMarker {
+			committed = true
+		}
+	}
+	for rows.Next() {
+	}
+	for rows.NextResultSet() {
+		for rows.Next() {
+		}
+	}
+	rowsErr := rows.Err()
+	closeErr := rows.Close()
+
+	if committed {
+		if rowsErr != nil || closeErr != nil {
+			discardConnection(conn)
+			logger.Warn("discarding database connection after committed credit batch", "operation", operation, "rows_error", rowsErr, "close_error", closeErr)
+		}
+		if diagnosticErr != nil {
+			recordBatchMetrics(r.mode, time.Since(start), diagnosticErr)
+			tracing.RecordErrorUnless(span, diagnosticErr)
+			return result, diagnosticErr
+		}
+		recordBatchMetrics(r.mode, time.Since(start), nil)
+		return result, nil
+	}
+
+	cleanupTransactionBatchConnection(conn)
+	switch {
+	case rowsErr != nil:
+		err = rowsErr
+	case closeErr != nil:
+		err = closeErr
+	default:
+		err = errTransactionBatchNotConfirmed
+	}
+	recordBatchMetrics(r.mode, time.Since(start), err)
+	tracing.RecordErrorUnless(span, err)
+	return result, err
+}

--- a/pkg/db/key_find_credits.sql_generated.go
+++ b/pkg/db/key_find_credits.sql_generated.go
@@ -23,3 +23,73 @@ func (q *Queries) FindKeyCredits(ctx context.Context, db DBTX, id string) (sql.N
 	err := row.Scan(&remaining_requests)
 	return remaining_requests, err
 }
+
+const findKeyCreditsBatchResult = `-- name: FindKeyCreditsBatchResult :one
+SELECT
+    ROW_COUNT() AS outbox_rows,
+    k.id AS key_id,
+    k.deleted_at_m,
+    k.remaining_requests,
+    k.refill_amount,
+    k.refill_day
+FROM (SELECT 1) singleton
+LEFT JOIN ` + "`" + `keys` + "`" + ` k ON k.id = ?
+FOR UPDATE
+`
+
+type FindKeyCreditsBatchResultRow struct {
+	OutboxRows        int64          `db:"outbox_rows"`
+	KeyID             sql.NullString `db:"key_id"`
+	DeletedAtM        sql.NullInt64  `db:"deleted_at_m"`
+	RemainingRequests sql.NullInt64  `db:"remaining_requests"`
+	RefillAmount      sql.NullInt64  `db:"refill_amount"`
+	RefillDay         sql.NullInt16  `db:"refill_day"`
+}
+
+// This current locking read runs before COMMIT in the same multi-statement
+// command. outbox_rows mirrors whether the immediately preceding conditional
+// audit insert ran, and the key fields classify a guarded update miss.
+//
+//	SELECT
+//	    ROW_COUNT() AS outbox_rows,
+//	    k.id AS key_id,
+//	    k.deleted_at_m,
+//	    k.remaining_requests,
+//	    k.refill_amount,
+//	    k.refill_day
+//	FROM (SELECT 1) singleton
+//	LEFT JOIN `keys` k ON k.id = ?
+//	FOR UPDATE
+func (q *Queries) FindKeyCreditsBatchResult(ctx context.Context, db DBTX, id string) (FindKeyCreditsBatchResultRow, error) {
+	row := db.QueryRowContext(ctx, findKeyCreditsBatchResult, id)
+	var i FindKeyCreditsBatchResultRow
+	err := row.Scan(
+		&i.OutboxRows,
+		&i.KeyID,
+		&i.DeletedAtM,
+		&i.RemainingRequests,
+		&i.RefillAmount,
+		&i.RefillDay,
+	)
+	return i, err
+}
+
+const findLiveKeyCredits = `-- name: FindLiveKeyCredits :one
+SELECT remaining_requests
+FROM ` + "`" + `keys` + "`" + `
+WHERE id = ?
+  AND deleted_at_m IS NULL
+`
+
+// FindLiveKeyCredits
+//
+//	SELECT remaining_requests
+//	FROM `keys`
+//	WHERE id = ?
+//	  AND deleted_at_m IS NULL
+func (q *Queries) FindLiveKeyCredits(ctx context.Context, db DBTX, id string) (sql.NullInt64, error) {
+	row := db.QueryRowContext(ctx, findLiveKeyCredits, id)
+	var remaining_requests sql.NullInt64
+	err := row.Scan(&remaining_requests)
+	return remaining_requests, err
+}

--- a/pkg/db/key_find_live_by_id.sql_generated.go
+++ b/pkg/db/key_find_live_by_id.sql_generated.go
@@ -509,6 +509,78 @@ func (q *Queries) FindLiveKeyByID(ctx context.Context, db DBTX, id string) (Find
 	return i, err
 }
 
+const findLiveKeyForCreditsByID = `-- name: FindLiveKeyForCreditsByID :one
+SELECT
+    k.id,
+    k.key_auth_id,
+    k.hash,
+    k.workspace_id,
+    k.name,
+    k.refill_day,
+    k.refill_amount,
+    k.remaining_requests,
+    a.id AS api_id
+FROM ` + "`" + `keys` + "`" + ` k
+JOIN apis a ON a.key_auth_id = k.key_auth_id
+JOIN key_auth ka ON ka.id = k.key_auth_id
+JOIN workspaces ws ON k.workspace_id = ws.id
+WHERE k.id = ?
+    AND k.deleted_at_m IS NULL
+    AND a.deleted_at_m IS NULL
+    AND ka.deleted_at_m IS NULL
+    AND ws.deleted_at_m IS NULL
+`
+
+type FindLiveKeyForCreditsByIDRow struct {
+	ID                string         `db:"id"`
+	KeyAuthID         string         `db:"key_auth_id"`
+	Hash              string         `db:"hash"`
+	WorkspaceID       string         `db:"workspace_id"`
+	Name              sql.NullString `db:"name"`
+	RefillDay         sql.NullInt16  `db:"refill_day"`
+	RefillAmount      sql.NullInt64  `db:"refill_amount"`
+	RemainingRequests sql.NullInt64  `db:"remaining_requests"`
+	ApiID             string         `db:"api_id"`
+}
+
+// Credit updates only need authorization, audit, cache, and credit state.
+//
+//	SELECT
+//	    k.id,
+//	    k.key_auth_id,
+//	    k.hash,
+//	    k.workspace_id,
+//	    k.name,
+//	    k.refill_day,
+//	    k.refill_amount,
+//	    k.remaining_requests,
+//	    a.id AS api_id
+//	FROM `keys` k
+//	JOIN apis a ON a.key_auth_id = k.key_auth_id
+//	JOIN key_auth ka ON ka.id = k.key_auth_id
+//	JOIN workspaces ws ON k.workspace_id = ws.id
+//	WHERE k.id = ?
+//	    AND k.deleted_at_m IS NULL
+//	    AND a.deleted_at_m IS NULL
+//	    AND ka.deleted_at_m IS NULL
+//	    AND ws.deleted_at_m IS NULL
+func (q *Queries) FindLiveKeyForCreditsByID(ctx context.Context, db DBTX, id string) (FindLiveKeyForCreditsByIDRow, error) {
+	row := db.QueryRowContext(ctx, findLiveKeyForCreditsByID, id)
+	var i FindLiveKeyForCreditsByIDRow
+	err := row.Scan(
+		&i.ID,
+		&i.KeyAuthID,
+		&i.Hash,
+		&i.WorkspaceID,
+		&i.Name,
+		&i.RefillDay,
+		&i.RefillAmount,
+		&i.RemainingRequests,
+		&i.ApiID,
+	)
+	return i, err
+}
+
 const findLiveKeyForUpdateByID = `-- name: FindLiveKeyForUpdateByID :one
 SELECT
     k.id,

--- a/pkg/db/key_update_credits_decrement.sql_generated.go
+++ b/pkg/db/key_update_credits_decrement.sql_generated.go
@@ -36,3 +36,38 @@ func (q *Queries) UpdateKeyCreditsDecrement(ctx context.Context, db DBTX, arg Up
 	_, err := db.ExecContext(ctx, updateKeyCreditsDecrement, arg.Credits, arg.Credits, arg.ID)
 	return err
 }
+
+const updateKeyCreditsDecrementReturning = `-- name: UpdateKeyCreditsDecrementReturning :execresult
+UPDATE ` + "`" + `keys` + "`" + `
+SET
+    remaining_requests = LAST_INSERT_ID(CASE
+        WHEN remaining_requests >= ? THEN remaining_requests - ?
+        ELSE 0
+    END)
+WHERE id = ?
+  AND deleted_at_m IS NULL
+  AND remaining_requests IS NOT NULL
+`
+
+type UpdateKeyCreditsDecrementReturningParams struct {
+	Credits sql.NullInt64 `db:"credits"`
+	ID      string        `db:"id"`
+}
+
+// LAST_INSERT_ID(expr) returns expr in this UPDATE's OK packet, so
+// sql.Result.LastInsertId reads the new balance without another query.
+// https://dev.mysql.com/doc/refman/8.4/en/information-functions.html#function_last-insert-id
+// transactional-batch-statement
+//
+//	UPDATE `keys`
+//	SET
+//	    remaining_requests = LAST_INSERT_ID(CASE
+//	        WHEN remaining_requests >= ? THEN remaining_requests - ?
+//	        ELSE 0
+//	    END)
+//	WHERE id = ?
+//	  AND deleted_at_m IS NULL
+//	  AND remaining_requests IS NOT NULL
+func (q *Queries) UpdateKeyCreditsDecrementReturning(ctx context.Context, db DBTX, arg UpdateKeyCreditsDecrementReturningParams) (sql.Result, error) {
+	return db.ExecContext(ctx, updateKeyCreditsDecrementReturning, arg.Credits, arg.Credits, arg.ID)
+}

--- a/pkg/db/key_update_credits_increment.sql_generated.go
+++ b/pkg/db/key_update_credits_increment.sql_generated.go
@@ -30,3 +30,34 @@ func (q *Queries) UpdateKeyCreditsIncrement(ctx context.Context, db DBTX, arg Up
 	_, err := db.ExecContext(ctx, updateKeyCreditsIncrement, arg.Credits, arg.ID)
 	return err
 }
+
+const updateKeyCreditsIncrementReturning = `-- name: UpdateKeyCreditsIncrementReturning :execresult
+UPDATE ` + "`" + `keys` + "`" + `
+SET
+    remaining_requests = LAST_INSERT_ID(remaining_requests + ?)
+WHERE id = ?
+  AND deleted_at_m IS NULL
+  AND remaining_requests IS NOT NULL
+  AND remaining_requests <= 9223372036854775807 - ?
+`
+
+type UpdateKeyCreditsIncrementReturningParams struct {
+	Credits sql.NullInt64 `db:"credits"`
+	ID      string        `db:"id"`
+}
+
+// LAST_INSERT_ID(expr) returns expr in this UPDATE's OK packet, so
+// sql.Result.LastInsertId reads the new balance without another query.
+// https://dev.mysql.com/doc/refman/8.4/en/information-functions.html#function_last-insert-id
+// transactional-batch-statement
+//
+//	UPDATE `keys`
+//	SET
+//	    remaining_requests = LAST_INSERT_ID(remaining_requests + ?)
+//	WHERE id = ?
+//	  AND deleted_at_m IS NULL
+//	  AND remaining_requests IS NOT NULL
+//	  AND remaining_requests <= 9223372036854775807 - ?
+func (q *Queries) UpdateKeyCreditsIncrementReturning(ctx context.Context, db DBTX, arg UpdateKeyCreditsIncrementReturningParams) (sql.Result, error) {
+	return db.ExecContext(ctx, updateKeyCreditsIncrementReturning, arg.Credits, arg.ID, arg.Credits)
+}

--- a/pkg/db/key_update_credits_set.sql_generated.go
+++ b/pkg/db/key_update_credits_set.sql_generated.go
@@ -10,23 +10,49 @@ import (
 	"database/sql"
 )
 
-const updateKeyCreditsSet = `-- name: UpdateKeyCreditsSet :exec
+const updateKeyCreditsSet = `-- name: UpdateKeyCreditsSet :execresult
 UPDATE ` + "`" + `keys` + "`" + `
-SET remaining_requests = ?
+SET
+    remaining_requests = ?,
+    refill_amount = CASE
+        WHEN CAST(? AS UNSIGNED) = 1 THEN NULL
+        ELSE refill_amount
+    END,
+    refill_day = CASE
+        WHEN CAST(? AS UNSIGNED) = 1 THEN NULL
+        ELSE refill_day
+    END
 WHERE id = ?
+  AND deleted_at_m IS NULL
 `
 
 type UpdateKeyCreditsSetParams struct {
-	Credits sql.NullInt64 `db:"credits"`
-	ID      string        `db:"id"`
+	Credits           sql.NullInt64 `db:"credits"`
+	ClearRefillAmount int64         `db:"clear_refill_amount"`
+	ClearRefillDay    int64         `db:"clear_refill_day"`
+	ID                string        `db:"id"`
 }
 
-// UpdateKeyCreditsSet
+// transactional-batch-statement
 //
 //	UPDATE `keys`
-//	SET remaining_requests = ?
+//	SET
+//	    remaining_requests = ?,
+//	    refill_amount = CASE
+//	        WHEN CAST(? AS UNSIGNED) = 1 THEN NULL
+//	        ELSE refill_amount
+//	    END,
+//	    refill_day = CASE
+//	        WHEN CAST(? AS UNSIGNED) = 1 THEN NULL
+//	        ELSE refill_day
+//	    END
 //	WHERE id = ?
-func (q *Queries) UpdateKeyCreditsSet(ctx context.Context, db DBTX, arg UpdateKeyCreditsSetParams) error {
-	_, err := db.ExecContext(ctx, updateKeyCreditsSet, arg.Credits, arg.ID)
-	return err
+//	  AND deleted_at_m IS NULL
+func (q *Queries) UpdateKeyCreditsSet(ctx context.Context, db DBTX, arg UpdateKeyCreditsSetParams) (sql.Result, error) {
+	return db.ExecContext(ctx, updateKeyCreditsSet,
+		arg.Credits,
+		arg.ClearRefillAmount,
+		arg.ClearRefillDay,
+		arg.ID,
+	)
 }

--- a/pkg/db/querier_generated.go
+++ b/pkg/db/querier_generated.go
@@ -514,6 +514,21 @@ type Querier interface {
 	//
 	//  SELECT remaining_requests FROM `keys` k WHERE k.id = ?
 	FindKeyCredits(ctx context.Context, db DBTX, id string) (sql.NullInt64, error)
+	// This current locking read runs before COMMIT in the same multi-statement
+	// command. outbox_rows mirrors whether the immediately preceding conditional
+	// audit insert ran, and the key fields classify a guarded update miss.
+	//
+	//  SELECT
+	//      ROW_COUNT() AS outbox_rows,
+	//      k.id AS key_id,
+	//      k.deleted_at_m,
+	//      k.remaining_requests,
+	//      k.refill_amount,
+	//      k.refill_day
+	//  FROM (SELECT 1) singleton
+	//  LEFT JOIN `keys` k ON k.id = ?
+	//  FOR UPDATE
+	FindKeyCreditsBatchResult(ctx context.Context, db DBTX, id string) (FindKeyCreditsBatchResultRow, error)
 	//FindKeyEncryptionByKeyID
 	//
 	//  SELECT pk, workspace_id, key_id, created_at, updated_at, encrypted, encryption_key_id FROM encrypted_keys WHERE key_id = ?
@@ -815,6 +830,35 @@ type Querier interface {
 	//      AND ka.deleted_at_m IS NULL
 	//      AND ws.deleted_at_m IS NULL
 	FindLiveKeyByID(ctx context.Context, db DBTX, id string) (FindLiveKeyByIDRow, error)
+	//FindLiveKeyCredits
+	//
+	//  SELECT remaining_requests
+	//  FROM `keys`
+	//  WHERE id = ?
+	//    AND deleted_at_m IS NULL
+	FindLiveKeyCredits(ctx context.Context, db DBTX, id string) (sql.NullInt64, error)
+	// Credit updates only need authorization, audit, cache, and credit state.
+	//
+	//  SELECT
+	//      k.id,
+	//      k.key_auth_id,
+	//      k.hash,
+	//      k.workspace_id,
+	//      k.name,
+	//      k.refill_day,
+	//      k.refill_amount,
+	//      k.remaining_requests,
+	//      a.id AS api_id
+	//  FROM `keys` k
+	//  JOIN apis a ON a.key_auth_id = k.key_auth_id
+	//  JOIN key_auth ka ON ka.id = k.key_auth_id
+	//  JOIN workspaces ws ON k.workspace_id = ws.id
+	//  WHERE k.id = ?
+	//      AND k.deleted_at_m IS NULL
+	//      AND a.deleted_at_m IS NULL
+	//      AND ka.deleted_at_m IS NULL
+	//      AND ws.deleted_at_m IS NULL
+	FindLiveKeyForCreditsByID(ctx context.Context, db DBTX, id string) (FindLiveKeyForCreditsByIDRow, error)
 	// Keep this projection small: key updates do not need the RBAC and ratelimit
 	// aggregates returned by FindLiveKeyByID.
 	//
@@ -1228,6 +1272,36 @@ type Querier interface {
 	//      ?
 	//  )
 	InsertClickhouseOutbox(ctx context.Context, db DBTX, arg InsertClickhouseOutboxParams) error
+	// transactional-batch-statement
+	// This statement must immediately follow the guarded credit UPDATE. With
+	// clientFoundRows enabled on the batch pool, ROW_COUNT() is one for every
+	// valid update, including no-ops, and zero for deletion/unlimited/overflow.
+	//
+	//  INSERT INTO `clickhouse_outbox` (
+	//      version,
+	//      workspace_id,
+	//      event_id,
+	//      payload,
+	//      created_at
+	//  )
+	//  SELECT
+	//      ?,
+	//      ?,
+	//      ?,
+	//      JSON_SET(
+	//          CAST(? AS JSON),
+	//          '$.description',
+	//          CONCAT(
+	//              'Updated Key ', ?, ', set remaining to ',
+	//              IF(k.remaining_requests IS NULL, 'unlimited', CAST(k.remaining_requests AS CHAR)),
+	//              '.'
+	//          )
+	//      ),
+	//      ?
+	//  FROM `keys` k
+	//  WHERE k.id = ?
+	//    AND ROW_COUNT() = 1
+	InsertClickhouseOutboxForCreditUpdate(ctx context.Context, db DBTX, arg InsertClickhouseOutboxForCreditUpdateParams) error
 	//InsertClickhouseWorkspaceSettings
 	//
 	//  INSERT INTO `clickhouse_workspace_settings` (
@@ -2767,22 +2841,60 @@ type Querier interface {
 	//  END
 	//  WHERE id = ?
 	UpdateKeyCreditsDecrement(ctx context.Context, db DBTX, arg UpdateKeyCreditsDecrementParams) error
+	// LAST_INSERT_ID(expr) returns expr in this UPDATE's OK packet, so
+	// sql.Result.LastInsertId reads the new balance without another query.
+	// https://dev.mysql.com/doc/refman/8.4/en/information-functions.html#function_last-insert-id
+	// transactional-batch-statement
+	//
+	//  UPDATE `keys`
+	//  SET
+	//      remaining_requests = LAST_INSERT_ID(CASE
+	//          WHEN remaining_requests >= ? THEN remaining_requests - ?
+	//          ELSE 0
+	//      END)
+	//  WHERE id = ?
+	//    AND deleted_at_m IS NULL
+	//    AND remaining_requests IS NOT NULL
+	UpdateKeyCreditsDecrementReturning(ctx context.Context, db DBTX, arg UpdateKeyCreditsDecrementReturningParams) (sql.Result, error)
 	//UpdateKeyCreditsIncrement
 	//
 	//  UPDATE `keys`
 	//  SET remaining_requests = remaining_requests + ?
 	//  WHERE id = ?
 	UpdateKeyCreditsIncrement(ctx context.Context, db DBTX, arg UpdateKeyCreditsIncrementParams) error
+	// LAST_INSERT_ID(expr) returns expr in this UPDATE's OK packet, so
+	// sql.Result.LastInsertId reads the new balance without another query.
+	// https://dev.mysql.com/doc/refman/8.4/en/information-functions.html#function_last-insert-id
+	// transactional-batch-statement
+	//
+	//  UPDATE `keys`
+	//  SET
+	//      remaining_requests = LAST_INSERT_ID(remaining_requests + ?)
+	//  WHERE id = ?
+	//    AND deleted_at_m IS NULL
+	//    AND remaining_requests IS NOT NULL
+	//    AND remaining_requests <= 9223372036854775807 - ?
+	UpdateKeyCreditsIncrementReturning(ctx context.Context, db DBTX, arg UpdateKeyCreditsIncrementReturningParams) (sql.Result, error)
 	//UpdateKeyCreditsRefill
 	//
 	//  UPDATE `keys` SET refill_amount = ?, refill_day = ? WHERE id = ?
 	UpdateKeyCreditsRefill(ctx context.Context, db DBTX, arg UpdateKeyCreditsRefillParams) error
-	//UpdateKeyCreditsSet
+	// transactional-batch-statement
 	//
 	//  UPDATE `keys`
-	//  SET remaining_requests = ?
+	//  SET
+	//      remaining_requests = ?,
+	//      refill_amount = CASE
+	//          WHEN CAST(? AS UNSIGNED) = 1 THEN NULL
+	//          ELSE refill_amount
+	//      END,
+	//      refill_day = CASE
+	//          WHEN CAST(? AS UNSIGNED) = 1 THEN NULL
+	//          ELSE refill_day
+	//      END
 	//  WHERE id = ?
-	UpdateKeyCreditsSet(ctx context.Context, db DBTX, arg UpdateKeyCreditsSetParams) error
+	//    AND deleted_at_m IS NULL
+	UpdateKeyCreditsSet(ctx context.Context, db DBTX, arg UpdateKeyCreditsSetParams) (sql.Result, error)
 	//UpdateKeySpaceKeyEncryption
 	//
 	//  UPDATE `key_auth` SET store_encrypted_keys = ? WHERE id = ?

--- a/pkg/db/queries/clickhouse_outbox_insert.sql
+++ b/pkg/db/queries/clickhouse_outbox_insert.sql
@@ -21,3 +21,33 @@ INSERT INTO `clickhouse_outbox` (
     CAST(sqlc.arg(payload) AS JSON),
     sqlc.arg(created_at)
 );
+
+-- name: InsertClickhouseOutboxForCreditUpdate :exec
+-- transactional-batch-statement
+-- This statement must immediately follow the guarded credit UPDATE. With
+-- clientFoundRows enabled on the batch pool, ROW_COUNT() is one for every
+-- valid update, including no-ops, and zero for deletion/unlimited/overflow.
+INSERT INTO `clickhouse_outbox` (
+    version,
+    workspace_id,
+    event_id,
+    payload,
+    created_at
+)
+SELECT
+    sqlc.arg(version),
+    sqlc.arg(workspace_id),
+    sqlc.arg(event_id),
+    JSON_SET(
+        CAST(sqlc.arg(payload) AS JSON),
+        '$.description',
+        CONCAT(
+            'Updated Key ', sqlc.arg(key_id), ', set remaining to ',
+            IF(k.remaining_requests IS NULL, 'unlimited', CAST(k.remaining_requests AS CHAR)),
+            '.'
+        )
+    ),
+    sqlc.arg(created_at)
+FROM `keys` k
+WHERE k.id = sqlc.arg(key_id)
+  AND ROW_COUNT() = 1;

--- a/pkg/db/queries/key_find_credits.sql
+++ b/pkg/db/queries/key_find_credits.sql
@@ -1,2 +1,23 @@
 -- name: FindKeyCredits :one
 SELECT remaining_requests FROM `keys` k WHERE k.id = ?;
+
+-- name: FindLiveKeyCredits :one
+SELECT remaining_requests
+FROM `keys`
+WHERE id = sqlc.arg(id)
+  AND deleted_at_m IS NULL;
+
+-- name: FindKeyCreditsBatchResult :one
+-- This current locking read runs before COMMIT in the same multi-statement
+-- command. outbox_rows mirrors whether the immediately preceding conditional
+-- audit insert ran, and the key fields classify a guarded update miss.
+SELECT
+    ROW_COUNT() AS outbox_rows,
+    k.id AS key_id,
+    k.deleted_at_m,
+    k.remaining_requests,
+    k.refill_amount,
+    k.refill_day
+FROM (SELECT 1) singleton
+LEFT JOIN `keys` k ON k.id = sqlc.arg(id)
+FOR UPDATE;

--- a/pkg/db/queries/key_find_live_by_id.sql
+++ b/pkg/db/queries/key_find_live_by_id.sql
@@ -175,3 +175,25 @@ WHERE k.id = sqlc.arg(id)
     AND a.deleted_at_m IS NULL
     AND ka.deleted_at_m IS NULL
     AND ws.deleted_at_m IS NULL;
+
+-- name: FindLiveKeyForCreditsByID :one
+-- Credit updates only need authorization, audit, cache, and credit state.
+SELECT
+    k.id,
+    k.key_auth_id,
+    k.hash,
+    k.workspace_id,
+    k.name,
+    k.refill_day,
+    k.refill_amount,
+    k.remaining_requests,
+    a.id AS api_id
+FROM `keys` k
+JOIN apis a ON a.key_auth_id = k.key_auth_id
+JOIN key_auth ka ON ka.id = k.key_auth_id
+JOIN workspaces ws ON k.workspace_id = ws.id
+WHERE k.id = sqlc.arg(id)
+    AND k.deleted_at_m IS NULL
+    AND a.deleted_at_m IS NULL
+    AND ka.deleted_at_m IS NULL
+    AND ws.deleted_at_m IS NULL;

--- a/pkg/db/queries/key_update_credits_decrement.sql
+++ b/pkg/db/queries/key_update_credits_decrement.sql
@@ -5,3 +5,18 @@ SET remaining_requests = CASE
     ELSE 0
 END
 WHERE id = ?;
+
+-- LAST_INSERT_ID(expr) returns expr in this UPDATE's OK packet, so
+-- sql.Result.LastInsertId reads the new balance without another query.
+-- https://dev.mysql.com/doc/refman/8.4/en/information-functions.html#function_last-insert-id
+-- name: UpdateKeyCreditsDecrementReturning :execresult
+-- transactional-batch-statement
+UPDATE `keys`
+SET
+    remaining_requests = LAST_INSERT_ID(CASE
+        WHEN remaining_requests >= sqlc.arg('credits') THEN remaining_requests - sqlc.arg('credits')
+        ELSE 0
+    END)
+WHERE id = ?
+  AND deleted_at_m IS NULL
+  AND remaining_requests IS NOT NULL;

--- a/pkg/db/queries/key_update_credits_increment.sql
+++ b/pkg/db/queries/key_update_credits_increment.sql
@@ -2,3 +2,16 @@
 UPDATE `keys`
 SET remaining_requests = remaining_requests + sqlc.arg('credits')
 WHERE id = ?;
+
+-- LAST_INSERT_ID(expr) returns expr in this UPDATE's OK packet, so
+-- sql.Result.LastInsertId reads the new balance without another query.
+-- https://dev.mysql.com/doc/refman/8.4/en/information-functions.html#function_last-insert-id
+-- name: UpdateKeyCreditsIncrementReturning :execresult
+-- transactional-batch-statement
+UPDATE `keys`
+SET
+    remaining_requests = LAST_INSERT_ID(remaining_requests + sqlc.arg('credits'))
+WHERE id = ?
+  AND deleted_at_m IS NULL
+  AND remaining_requests IS NOT NULL
+  AND remaining_requests <= 9223372036854775807 - sqlc.arg('credits');

--- a/pkg/db/queries/key_update_credits_set.sql
+++ b/pkg/db/queries/key_update_credits_set.sql
@@ -1,4 +1,15 @@
--- name: UpdateKeyCreditsSet :exec
+-- name: UpdateKeyCreditsSet :execresult
+-- transactional-batch-statement
 UPDATE `keys`
-SET remaining_requests = sqlc.narg('credits')
-WHERE id = ?;
+SET
+    remaining_requests = sqlc.narg('credits'),
+    refill_amount = CASE
+        WHEN CAST(sqlc.arg('clear_refill_amount') AS UNSIGNED) = 1 THEN NULL
+        ELSE refill_amount
+    END,
+    refill_day = CASE
+        WHEN CAST(sqlc.arg('clear_refill_day') AS UNSIGNED) = 1 THEN NULL
+        ELSE refill_day
+    END
+WHERE id = ?
+  AND deleted_at_m IS NULL;

--- a/pkg/db/transaction_batch_statements_generated.go
+++ b/pkg/db/transaction_batch_statements_generated.go
@@ -15,6 +15,21 @@ func insertClickhouseOutboxTransactionBatchStatement(params InsertClickhouseOutb
 	}
 }
 
+func insertClickhouseOutboxForCreditUpdateTransactionBatchStatement(params InsertClickhouseOutboxForCreditUpdateParams) transactionBatchStatement {
+	return transactionBatchStatement{
+		query: insertClickhouseOutboxForCreditUpdate,
+		args: []any{
+			params.Version,
+			params.WorkspaceID,
+			params.EventID,
+			params.Payload,
+			params.KeyID,
+			params.CreatedAt,
+			params.KeyID,
+		},
+	}
+}
+
 func insertKeyTransactionBatchStatement(params InsertKeyParams) transactionBatchStatement {
 	return transactionBatchStatement{
 		query: insertKey,
@@ -60,6 +75,40 @@ func updateKeyTransactionBatchStatement(params UpdateKeyParams) transactionBatch
 			params.RefillDaySpecified,
 			params.RefillDay,
 			params.Now,
+			params.ID,
+		},
+	}
+}
+
+func updateKeyCreditsDecrementReturningTransactionBatchStatement(params UpdateKeyCreditsDecrementReturningParams) transactionBatchStatement {
+	return transactionBatchStatement{
+		query: updateKeyCreditsDecrementReturning,
+		args: []any{
+			params.Credits,
+			params.Credits,
+			params.ID,
+		},
+	}
+}
+
+func updateKeyCreditsIncrementReturningTransactionBatchStatement(params UpdateKeyCreditsIncrementReturningParams) transactionBatchStatement {
+	return transactionBatchStatement{
+		query: updateKeyCreditsIncrementReturning,
+		args: []any{
+			params.Credits,
+			params.ID,
+			params.Credits,
+		},
+	}
+}
+
+func updateKeyCreditsSetTransactionBatchStatement(params UpdateKeyCreditsSetParams) transactionBatchStatement {
+	return transactionBatchStatement{
+		query: updateKeyCreditsSet,
+		args: []any{
+			params.Credits,
+			params.ClearRefillAmount,
+			params.ClearRefillDay,
 			params.ID,
 		},
 	}

--- a/pkg/mysql/plugins/bulk-insert/generator.go
+++ b/pkg/mysql/plugins/bulk-insert/generator.go
@@ -107,7 +107,9 @@ func (g *Generator) Generate(req *plugin.GenerateRequest) (*plugin.GenerateRespo
 
 // isInsertQuery checks if a query is an INSERT query that should have a bulk function generated.
 func (g *Generator) isInsertQuery(query *plugin.Query) bool {
-	return query.GetInsertIntoTable() != nil && len(query.GetParams()) > 0
+	return query.GetInsertIntoTable() != nil &&
+		len(query.GetParams()) > 0 &&
+		strings.Contains(strings.ToUpper(NewSQLParser().cleanSQL(query.GetText())), " VALUES")
 }
 
 // generateBulkInsertFunction generates a bulk insert function for the given query.

--- a/pkg/mysql/plugins/bulk-insert/generator_test.go
+++ b/pkg/mysql/plugins/bulk-insert/generator_test.go
@@ -152,8 +152,18 @@ func TestGenerator_isInsertQuery(t *testing.T) {
 			query: &plugin.Query{
 				InsertIntoTable: &plugin.Identifier{Name: "users"},
 				Params:          []*plugin.Parameter{{Column: &plugin.Column{Name: "id"}}},
+				Text:            "INSERT INTO users (id) VALUES (?)",
 			},
 			expected: true,
+		},
+		{
+			name: "insert select query",
+			query: &plugin.Query{
+				InsertIntoTable: &plugin.Identifier{Name: "users"},
+				Params:          []*plugin.Parameter{{Column: &plugin.Column{Name: "id"}}},
+				Text:            "INSERT INTO users (id) SELECT id FROM pending_users",
+			},
+			expected: false,
 		},
 		{
 			name: "insert query without parameters",

--- a/pkg/mysql/plugins/transactional-batch/generator.go
+++ b/pkg/mysql/plugins/transactional-batch/generator.go
@@ -86,8 +86,8 @@ func hasBatchStatementDirective(query *plugin.Query) (bool, error) {
 }
 
 func validateBatchStatement(query *plugin.Query) error {
-	if query.GetCmd() != ":exec" {
-		return fmt.Errorf("transactional batch statement %q must use :exec", query.GetName())
+	if query.GetCmd() != ":exec" && query.GetCmd() != ":execresult" {
+		return fmt.Errorf("transactional batch statement %q must use :exec or :execresult", query.GetName())
 	}
 	if len(query.GetParams()) <= 1 {
 		return fmt.Errorf("transactional batch statement %q must use a parameter struct", query.GetName())

--- a/svc/api/openapi/gen.go
+++ b/svc/api/openapi/gen.go
@@ -3430,6 +3430,8 @@ type V2KeysUpdateCreditsRequestBody struct {
 	//
 	// Set to null when using 'set' operation to make the key unlimited (removes usage restrictions entirely). When decrementing, if the result would be negative, remaining credits are automatically set to zero. Credits are consumed during successful key verification, and when credits reach zero, verification fails with `code=USAGE_EXCEEDED`.
 	//
+	// An increment is rejected if the resulting balance would exceed 9223372036854775807 credits.
+	//
 	// Required when using 'increment' or 'decrement' operations. Optional for 'set' operation (null creates unlimited usage).
 	Value nullable.Nullable[int64] `json:"value,omitempty"`
 }

--- a/svc/api/openapi/openapi-generated.yaml
+++ b/svc/api/openapi/openapi-generated.yaml
@@ -2352,6 +2352,8 @@ components:
 
                         Set to null when using 'set' operation to make the key unlimited (removes usage restrictions entirely). When decrementing, if the result would be negative, remaining credits are automatically set to zero. Credits are consumed during successful key verification, and when credits reach zero, verification fails with `code=USAGE_EXCEEDED`.
 
+                        An increment is rejected if the resulting balance would exceed 9223372036854775807 credits.
+
                         Required when using 'increment' or 'decrement' operations. Optional for 'set' operation (null creates unlimited usage).
                     example: 1000
                 operation:

--- a/svc/api/openapi/spec/paths/v2/keys/updateCredits/V2KeysUpdateCreditsRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/keys/updateCredits/V2KeysUpdateCreditsRequestBody.yaml
@@ -23,6 +23,8 @@ properties:
 
       Set to null when using 'set' operation to make the key unlimited (removes usage restrictions entirely). When decrementing, if the result would be negative, remaining credits are automatically set to zero. Credits are consumed during successful key verification, and when credits reach zero, verification fails with `code=USAGE_EXCEEDED`.
 
+      An increment is rejected if the resulting balance would exceed 9223372036854775807 credits.
+
       Required when using 'increment' or 'decrement' operations. Optional for 'set' operation (null creates unlimited usage).
     example: 1000
   operation:

--- a/svc/api/routes/v2_keys_update_credits/200_test.go
+++ b/svc/api/routes/v2_keys_update_credits/200_test.go
@@ -20,8 +20,13 @@ import (
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_keys_update_credits"
 )
 
+func newUpdateCreditsHarness(t *testing.T) *testutil.Harness {
+	t.Helper()
+	return testutil.NewHarness(t, testutil.HarnessConfig{MultiStatementBatches: true})
+}
+
 func TestKeyUpdateCreditsSuccess(t *testing.T) {
-	h := testutil.NewHarness(t)
+	h := newUpdateCreditsHarness(t)
 	ctx := context.Background()
 
 	route := &handler.Handler{
@@ -104,6 +109,19 @@ func TestKeyUpdateCreditsSuccess(t *testing.T) {
 		require.EqualValues(t, key.RemainingRequests.Int64, setTo)
 	})
 
+	t.Run("setting the current value succeeds as a no-op", func(t *testing.T) {
+		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{
+			KeyId:     keyID,
+			Operation: openapi.Set,
+			Value:     nullable.NewNullableWithValue(setTo),
+		})
+
+		require.Equal(t, http.StatusOK, res.Status)
+		remaining, err := res.Body.Data.Remaining.Get()
+		require.NoError(t, err)
+		require.Equal(t, setTo, remaining)
+	})
+
 	increaseBy := int64(rand.IntN(50) + 1)
 	t.Run(fmt.Sprintf("increase credits by %d", increaseBy), func(t *testing.T) {
 		// Get current credits before decrement
@@ -131,6 +149,17 @@ func TestKeyUpdateCreditsSuccess(t *testing.T) {
 		require.NotNil(t, key)
 		require.Equal(t, key.RemainingRequests.Valid, true)
 		require.EqualValues(t, key.RemainingRequests.Int64, currentCredits+increaseBy)
+
+		expectedDescription := fmt.Sprintf("Updated Key %s, set remaining to %d.", keyID, currentCredits+increaseBy)
+		auditLogs := h.FindAuditLogsByTargetID(ctx, t, keyID)
+		require.Condition(t, func() bool {
+			for _, event := range auditLogs {
+				if event.Description == expectedDescription {
+					return true
+				}
+			}
+			return false
+		}, "expected audit description %q", expectedDescription)
 	})
 
 	decreaseBy := int64(rand.IntN(50) + 1)
@@ -223,7 +252,7 @@ func TestKeyUpdateCreditsSuccess(t *testing.T) {
 }
 
 func TestKeyUpdateCreditsWithURNPermission(t *testing.T) {
-	h := testutil.NewHarness(t)
+	h := newUpdateCreditsHarness(t)
 	ctx := context.Background()
 
 	route := &handler.Handler{

--- a/svc/api/routes/v2_keys_update_credits/400_test.go
+++ b/svc/api/routes/v2_keys_update_credits/400_test.go
@@ -1,12 +1,16 @@
 package handler_test
 
 import (
+	"context"
+	"database/sql"
 	"fmt"
+	"math"
 	"net/http"
 	"testing"
 
 	"github.com/oapi-codegen/nullable"
 	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
 	"github.com/unkeyed/unkey/svc/api/openapi"
@@ -14,7 +18,7 @@ import (
 )
 
 func TestKeyUpdateCreditsBadRequest(t *testing.T) {
-	h := testutil.NewHarness(t)
+	h := newUpdateCreditsHarness(t)
 
 	route := &handler.Handler{
 		DB:           h.DB,
@@ -90,7 +94,6 @@ func TestKeyUpdateCreditsBadRequest(t *testing.T) {
 			Operation: openapi.Increment,
 			Value:     nullable.NewNullableWithValue(int64(1)),
 		}
-
 		res := testutil.CallRoute[handler.Request, openapi.BadRequestErrorResponse](h, route, headers, req)
 		require.Equal(t, 400, res.Status)
 		require.NotNil(t, res.Body)
@@ -120,5 +123,33 @@ func TestKeyUpdateCreditsBadRequest(t *testing.T) {
 		require.Equal(t, 400, res.Status)
 		require.NotNil(t, res.Body)
 		require.NotNil(t, res.Body.Error)
+	})
+
+	t.Run("increment cannot overflow the supported credit balance", func(t *testing.T) {
+		_, err := db.Query.UpdateKeyCreditsSet(context.Background(), h.DB.RW(), db.UpdateKeyCreditsSetParams{
+			ID:                keyID,
+			Credits:           sql.NullInt64{Int64: math.MaxInt64, Valid: true},
+			ClearRefillAmount: 0,
+			ClearRefillDay:    0,
+		})
+		require.NoError(t, err)
+
+		req := handler.Request{
+			KeyId:     keyID,
+			Operation: openapi.Increment,
+			Value:     nullable.NewNullableWithValue(int64(1)),
+		}
+		auditCountBefore := len(h.FindAuditLogsByTargetID(context.Background(), t, keyID))
+
+		res := testutil.CallRoute[handler.Request, openapi.BadRequestErrorResponse](h, route, headers, req)
+		require.Equal(t, http.StatusBadRequest, res.Status)
+		require.NotNil(t, res.Body)
+		require.Contains(t, res.Body.Error.Detail, "exceeds the maximum supported value")
+
+		key, err := db.Query.FindKeyByID(context.Background(), h.DB.RO(), keyID)
+		require.NoError(t, err)
+		require.True(t, key.RemainingRequests.Valid)
+		require.Equal(t, int64(math.MaxInt64), key.RemainingRequests.Int64)
+		require.Len(t, h.FindAuditLogsByTargetID(context.Background(), t, keyID), auditCountBefore)
 	})
 }

--- a/svc/api/routes/v2_keys_update_credits/401_test.go
+++ b/svc/api/routes/v2_keys_update_credits/401_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestKeyUpdateCreditsUnauthorized(t *testing.T) {
-	h := testutil.NewHarness(t)
+	h := newUpdateCreditsHarness(t)
 
 	route := &handler.Handler{
 		DB:           h.DB,

--- a/svc/api/routes/v2_keys_update_credits/403_test.go
+++ b/svc/api/routes/v2_keys_update_credits/403_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestKeyUpdateCreditsForbidden(t *testing.T) {
-	h := testutil.NewHarness(t)
+	h := newUpdateCreditsHarness(t)
 
 	route := &handler.Handler{
 		DB:           h.DB,

--- a/svc/api/routes/v2_keys_update_credits/404_test.go
+++ b/svc/api/routes/v2_keys_update_credits/404_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestUpdateKeyCreditsNotFound(t *testing.T) {
-	h := testutil.NewHarness(t)
+	h := newUpdateCreditsHarness(t)
 
 	route := &handler.Handler{
 		DB:           h.DB,

--- a/svc/api/routes/v2_keys_update_credits/handler.go
+++ b/svc/api/routes/v2_keys_update_credits/handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"math"
 	"net/http"
 
 	"github.com/oapi-codegen/nullable"
@@ -57,7 +58,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	key, err := db.Query.FindLiveKeyByID(ctx, h.DB.RO(), req.KeyId)
+	key, err := db.Query.FindLiveKeyForCreditsByID(ctx, h.DB.RO(), req.KeyId)
 	if err != nil {
 		if db.IsNotFound(err) {
 			return fault.Wrap(
@@ -93,7 +94,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		}),
 		rbac.T(rbac.Tuple{
 			ResourceType: rbac.Api,
-			ResourceID:   key.Api.ID,
+			ResourceID:   key.ApiID,
 			Action:       rbac.UpdateKey,
 		}),
 		rbac.U(
@@ -129,115 +130,120 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	if !req.Value.IsNull() && req.Value.IsSpecified() {
 		credits = sql.NullInt64{Int64: reqVal, Valid: true}
 	}
+	clearRefill := int64(0)
+	if !credits.Valid {
+		clearRefill = 1
+	}
 
-	key, err = db.TxWithResultRetry(ctx, h.DB.RW(), func(ctx context.Context, tx db.DBTX) (db.FindLiveKeyByIDRow, error) {
-		switch req.Operation {
-		case openapi.Set:
-			err = db.Query.UpdateKeyCreditsSet(ctx, tx, db.UpdateKeyCreditsSetParams{
-				ID:      key.ID,
-				Credits: credits,
-			})
-		case openapi.Increment:
-			err = db.Query.UpdateKeyCreditsIncrement(ctx, tx, db.UpdateKeyCreditsIncrementParams{
-				ID:      key.ID,
-				Credits: credits,
-			})
-		case openapi.Decrement:
-			err = db.Query.UpdateKeyCreditsDecrement(ctx, tx, db.UpdateKeyCreditsDecrementParams{
-				ID:      key.ID,
-				Credits: credits,
-			})
-		default:
-			return db.FindLiveKeyByIDRow{}, fault.New("invalid operation",
-				fault.Code(codes.App.Validation.InvalidInput.URN()),
-				fault.Internal(fmt.Sprintf("invalid operation: %s", req.Operation)),
-				fault.Public("Invalid operation specified."),
-			)
-		}
-		if err != nil {
-			return db.FindLiveKeyByIDRow{}, fault.Wrap(err,
-				fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
-				fault.Internal("database error"),
-				fault.Public("Failed to update key credits."),
-			)
-		}
-
-		// Reset the Refill data since it's not needed anymore
-		if req.Value.IsNull() {
-			err = db.Query.UpdateKeyCreditsRefill(ctx, tx, db.UpdateKeyCreditsRefillParams{
-				ID:           key.ID,
-				RefillAmount: sql.NullInt64{Int64: 0, Valid: false},
-				RefillDay:    sql.NullInt16{Int16: 0, Valid: false},
-			})
-			if err != nil {
-				return db.FindLiveKeyByIDRow{}, fault.Wrap(err,
-					fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
-					fault.Internal("database error"),
-					fault.Public("Failed to reset key refill data."),
-				)
-			}
-		}
-
-		keyAfterUpdate, keyErr := db.Query.FindLiveKeyByID(ctx, tx, req.KeyId)
-		if keyErr != nil {
-			if db.IsNotFound(keyErr) {
-				return db.FindLiveKeyByIDRow{}, fault.Wrap(
-					keyErr,
-					fault.Code(codes.Data.Key.NotFound.URN()),
-					fault.Internal("key got deleted after update"),
-					fault.Public("We could not find the requested key."),
-				)
-			}
-
-			return db.FindLiveKeyByIDRow{}, fault.Wrap(keyErr,
-				fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
-				fault.Internal("database error"),
-				fault.Public("Failed to retrieve key information."),
-			)
-		}
-
-		remaining := "unlimited"
-		if keyAfterUpdate.RemainingRequests.Valid {
-			remaining = fmt.Sprintf("%d", keyAfterUpdate.RemainingRequests.Int64)
-		}
-
-		err = h.Auditlogs.Insert(ctx, tx, []auditlog.AuditLog{
+	auditPreparer, ok := h.Auditlogs.(auditlogs.OutboxPreparer)
+	if !ok {
+		return fault.New("audit service cannot prepare outbox rows", fault.Internal("update credits requires an outbox preparer"))
+	}
+	outboxRows, err := auditPreparer.PrepareOutboxRows(ctx, []auditlog.AuditLog{{
+		WorkspaceID:   principal.WorkspaceID,
+		Event:         auditlog.KeyUpdateEvent,
+		Display:       fmt.Sprintf("Updated Key %s, set remaining to pending.", key.ID),
+		ActorID:       principal.Subject.ID,
+		ActorName:     principal.Subject.Name,
+		ActorMeta:     map[string]any{},
+		ActorType:     auditlog.AuditLogActor(principal.Subject.Type),
+		RemoteIP:      s.Location(),
+		UserAgent:     s.UserAgent(),
+		CorrelationID: "",
+		Resources: []auditlog.AuditLogResource{
 			{
-				WorkspaceID:   principal.WorkspaceID,
-				Event:         auditlog.KeyUpdateEvent,
-				Display:       fmt.Sprintf("Updated Key %s, set remaining to %s.", key.ID, remaining),
-				ActorID:       principal.Subject.ID,
-				ActorName:     principal.Subject.Name,
-				ActorMeta:     map[string]any{},
-				ActorType:     auditlog.AuditLogActor(principal.Subject.Type),
-				RemoteIP:      s.Location(),
-				UserAgent:     s.UserAgent(),
-				CorrelationID: "",
-				Resources: []auditlog.AuditLogResource{
-					{
-						ID:          key.KeyAuthID,
-						Type:        auditlog.KeySpaceResourceType,
-						Name:        "",
-						DisplayName: "",
-						Meta:        nil,
-					},
-					{
-						ID:          key.ID,
-						Type:        auditlog.KeyResourceType,
-						Name:        key.Name.String,
-						DisplayName: key.Name.String,
-						Meta:        nil,
-					},
-				},
+				ID:          key.KeyAuthID,
+				Type:        auditlog.KeySpaceResourceType,
+				Name:        "",
+				DisplayName: "",
+				Meta:        nil,
 			},
-		})
-
-		return keyAfterUpdate, err
-	})
-
+			{
+				ID:          key.ID,
+				Type:        auditlog.KeyResourceType,
+				Name:        key.Name.String,
+				DisplayName: key.Name.String,
+				Meta:        nil,
+			},
+		},
+	}})
 	if err != nil {
 		return err
 	}
+	if len(outboxRows) != 1 {
+		return fault.New("invalid audit outbox batch size", fault.Internal("update credits batch requires exactly one audit outbox row"))
+	}
+	outbox := db.InsertClickhouseOutboxForCreditUpdateParams{
+		Version:     outboxRows[0].Version,
+		WorkspaceID: outboxRows[0].WorkspaceID,
+		EventID:     outboxRows[0].EventID,
+		Payload:     outboxRows[0].Payload,
+		KeyID:       key.ID,
+		CreatedAt:   outboxRows[0].CreatedAt,
+	}
+
+	var batchResult db.KeyCreditsBatchResult
+	switch req.Operation {
+	case openapi.Set:
+		batchResult, err = h.DB.BatchRW().UpdateKeyCreditsSetWithAuditBatch(ctx, db.UpdateKeyCreditsSetParams{
+			ID:                key.ID,
+			Credits:           credits,
+			ClearRefillAmount: clearRefill,
+			ClearRefillDay:    clearRefill,
+		}, outbox)
+	case openapi.Increment:
+		batchResult, err = h.DB.BatchRW().UpdateKeyCreditsIncrementWithAuditBatch(ctx, db.UpdateKeyCreditsIncrementReturningParams{
+			ID: key.ID, Credits: credits,
+		}, outbox)
+	case openapi.Decrement:
+		batchResult, err = h.DB.BatchRW().UpdateKeyCreditsDecrementWithAuditBatch(ctx, db.UpdateKeyCreditsDecrementReturningParams{
+			ID: key.ID, Credits: credits,
+		}, outbox)
+	default:
+		return fault.New("invalid operation",
+			fault.Code(codes.App.Validation.InvalidInput.URN()),
+			fault.Internal(fmt.Sprintf("invalid operation: %s", req.Operation)),
+			fault.Public("Invalid operation specified."),
+		)
+	}
+	if err != nil {
+		// A missing marker is an ambiguous commit. Invalidate both caches even
+		// when the endpoint cannot confirm the mutation outcome.
+		h.invalidate(ctx, key.Hash, key.ID)
+		return fault.Wrap(err,
+			fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
+			fault.Internal("database error"),
+			fault.Public("Failed to update key credits."),
+		)
+	}
+	if !batchResult.Applied {
+		switch {
+		case !batchResult.KeyID.Valid || batchResult.DeletedAtM.Valid:
+			return fault.New("key got deleted before credits update",
+				fault.Code(codes.Data.Key.NotFound.URN()),
+				fault.Internal("key got deleted before update"),
+				fault.Public("We could not find the requested key."),
+			)
+		case req.Operation != openapi.Set && !batchResult.RemainingRequests.Valid:
+			return fault.New("key credits became unlimited before update",
+				fault.Code(codes.App.Validation.InvalidInput.URN()),
+				fault.Public("You cannot increment or decrement a key with unlimited credits."),
+			)
+		case req.Operation == openapi.Increment && credits.Int64 > math.MaxInt64-batchResult.RemainingRequests.Int64:
+			return fault.New("credits increment exceeds maximum",
+				fault.Code(codes.App.Validation.InvalidInput.URN()),
+				fault.Internal("credits increment would exceed max int64"),
+				fault.Public("The resulting credit balance exceeds the maximum supported value."),
+			)
+		default:
+			return fault.New("credit update did not apply", fault.Internal("guarded credit update matched no row"))
+		}
+	}
+
+	keyAfterUpdate := key
+	keyAfterUpdate.RemainingRequests = batchResult.RemainingRequests
+	keyAfterUpdate.RefillAmount = batchResult.RefillAmount
+	keyAfterUpdate.RefillDay = batchResult.RefillDay
 
 	null := nullable.Nullable[int64]{}
 	null.SetNull()
@@ -247,33 +253,27 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		Remaining: null,
 	}
 
-	if key.RemainingRequests.Valid {
-		responseData.Remaining = nullable.NewNullableWithValue(int64(key.RemainingRequests.Int64))
+	if keyAfterUpdate.RemainingRequests.Valid {
+		responseData.Remaining = nullable.NewNullableWithValue(keyAfterUpdate.RemainingRequests.Int64)
 	}
 
-	if key.RefillAmount.Valid {
+	if keyAfterUpdate.RefillAmount.Valid {
 		var day int
 		interval := openapi.KeyCreditsRefillIntervalDaily
 
-		if key.RefillDay.Valid {
+		if keyAfterUpdate.RefillDay.Valid {
 			interval = openapi.KeyCreditsRefillIntervalMonthly
-			day = int(key.RefillDay.Int16)
+			day = int(keyAfterUpdate.RefillDay.Int16)
 		}
 
 		responseData.Refill = &openapi.KeyCreditsRefill{
-			Amount:    int64(key.RefillAmount.Int64),
+			Amount:    keyAfterUpdate.RefillAmount.Int64,
 			Interval:  interval,
 			RefillDay: day,
 		}
 	}
 
-	h.KeyCache.Remove(ctx, key.Hash)
-	if err := h.UsageLimiter.Invalidate(ctx, key.ID); err != nil {
-		logger.Error("Failed to invalidate usage limit",
-			"error", err.Error(),
-			"key_id", key.ID,
-		)
-	}
+	h.invalidate(ctx, key.Hash, key.ID)
 
 	return s.JSON(http.StatusOK, Response{
 		Meta: openapi.Meta{
@@ -281,4 +281,14 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		},
 		Data: responseData,
 	})
+}
+
+func (h *Handler) invalidate(ctx context.Context, keyHash, keyID string) {
+	h.KeyCache.Remove(ctx, keyHash)
+	if err := h.UsageLimiter.Invalidate(ctx, keyID); err != nil {
+		logger.Error("Failed to invalidate usage limit",
+			"error", err.Error(),
+			"key_id", keyID,
+		)
+	}
 }

--- a/svc/frontline/internal/policies/integration_test.go
+++ b/svc/frontline/internal/policies/integration_test.go
@@ -485,7 +485,7 @@ func TestKeyAuth_UsageExceededHasDistinctCode(t *testing.T) {
 	ctx := context.Background()
 	s := h.seed(ctx)
 
-	err := db.Query.UpdateKeyCreditsSet(ctx, h.db.RW(), db.UpdateKeyCreditsSetParams{
+	_, err := db.Query.UpdateKeyCreditsSet(ctx, h.db.RW(), db.UpdateKeyCreditsSetParams{
 		Credits: sql.NullInt64{Int64: 0, Valid: true},
 		ID:      s.KeyID,
 	})
@@ -512,7 +512,7 @@ func TestKeyAuth_CreditsOverrideZero_DoesNotSpend(t *testing.T) {
 	ctx := context.Background()
 	s := h.seed(ctx)
 
-	err := db.Query.UpdateKeyCreditsSet(ctx, h.db.RW(), db.UpdateKeyCreditsSetParams{
+	_, err := db.Query.UpdateKeyCreditsSet(ctx, h.db.RW(), db.UpdateKeyCreditsSetParams{
 		Credits: sql.NullInt64{Int64: 0, Valid: true},
 		ID:      s.KeyID,
 	})
@@ -558,7 +558,7 @@ func TestKeyAuth_CreditsOverride_ChargesConfiguredCost(t *testing.T) {
 
 	// Two remaining credits: the default cost of 1 would pass, but a cost of 3
 	// exceeds the balance.
-	err := db.Query.UpdateKeyCreditsSet(ctx, h.db.RW(), db.UpdateKeyCreditsSetParams{
+	_, err := db.Query.UpdateKeyCreditsSet(ctx, h.db.RW(), db.UpdateKeyCreditsSetParams{
 		Credits: sql.NullInt64{Int64: 2, Valid: true},
 		ID:      s.KeyID,
 	})


### PR DESCRIPTION
## Problem:

Credit updates send transaction work as separate MySQL commands. Each command adds a cross-region network wait. The route must also preserve atomic balances, audit writes, overflow protection, and special credit states.

## Solution:

Batch the guarded credit update, conditional audit insert, diagnostic state read, commit, and confirmation marker into one MySQL exchange after authorization.

![Cross-region database exchanges before and after batching](https://ampcode.com/user-content/artifacts/3655c69790254381a8beee36bfc80d63e2e07b0b3ad17790813e1c04cab6aea5-file.png)

## Impact:

This is stack step 4 of 4 and depends on #7074. Credit updates use two endpoint database exchanges. The route retains atomic audit writes and classifies deletion, unlimited balances, no-ops, and overflow.

## Testing:

- `mise exec -- go test ./svc/api/routes/v2_keys_update_credits -count=1`
- `mise exec -- go test ./svc/api/routes/v2_keys_create_key ./svc/api/routes/v2_keys_update_key -count=1`
- `mise exec -- go test ./pkg/db ./pkg/mysql/plugins/bulk-insert ./pkg/mysql/plugins/transactional-batch -count=1`
- `mise exec -- go test ./svc/frontline/internal/policies -run '^$'`
- `mise exec -- go generate ./pkg/db`
- `mise run build`
- lint with 0 issues
- `git diff --check`
