### PR TITLE
fix(ci): queue database schema checks

### DIFF
--- a/.depot/workflows/database_schema_gate.yaml
+++ b/.depot/workflows/database_schema_gate.yaml
@@ -9,6 +9,7 @@ on:
 concurrency:
   group: database-schema-gate
   cancel-in-progress: false
+  queue: max
 permissions:
   contents: read
   pull-requests: read


### PR DESCRIPTION
I noticed with githubs stacked PRs, we can’t really merge them all at once, because of missing required checks.

The problem was that our database-schema check would cancel itself, when multiple concurrent CI runs started (which happens everytime you rebase the stack). Then most of the PRs had a `skipped` required check and that gets treated as `failed`.
And therefore we couldn't add these PRs to the merge queue. I had to go in manually and retry the check, which was quite annoying.

So this should just queue up the checks, rather than cancelling them.
