### PR TITLE
feat: return OCI app sources from getApp

### DIFF
--- a/svc/api/internal/testutil/http.go
+++ b/svc/api/internal/testutil/http.go
@@ -650,6 +650,8 @@ func (h *Harness) CreateTestDeploymentSetup(opts ...CreateTestDeploymentSetupOpt
 		ProjectID:        project.ID,
 		Name:             "Default",
 		Slug:             "default",
+		SourceType:       db.AppsSourceTypeUnknown,
+		ImageReference:   "",
 		DefaultBranch:    "main",
 		DeleteProtection: false,
 	})

--- a/svc/api/internal/testutil/seed/seed.go
+++ b/svc/api/internal/testutil/seed/seed.go
@@ -222,6 +222,8 @@ type CreateAppRequest struct {
 	ProjectID        string
 	Name             string
 	Slug             string
+	SourceType       db.AppsSourceType
+	ImageReference   string
 	DefaultBranch    string
 	DeleteProtection bool
 }
@@ -229,6 +231,10 @@ type CreateAppRequest struct {
 // CreateApp creates an app within a project.
 func (s *Seeder) CreateApp(ctx context.Context, req CreateAppRequest) db.App {
 	now := time.Now().UnixMilli()
+	sourceType := req.SourceType
+	if sourceType == "" {
+		sourceType = db.AppsSourceTypeUnknown
+	}
 
 	err := db.Query.InsertApp(ctx, s.DB.RW(), db.InsertAppParams{
 		ID:               req.ID,
@@ -236,13 +242,23 @@ func (s *Seeder) CreateApp(ctx context.Context, req CreateAppRequest) db.App {
 		ProjectID:        req.ProjectID,
 		Name:             req.Name,
 		Slug:             req.Slug,
-		SourceType:       db.AppsSourceTypeUnknown,
+		SourceType:       sourceType,
 		DefaultBranch:    req.DefaultBranch,
 		DeleteProtection: sql.NullBool{Valid: true, Bool: req.DeleteProtection},
 		CreatedAt:        now,
 		UpdatedAt:        sql.NullInt64{Valid: false},
 	})
 	require.NoError(s.t, err)
+	if sourceType == db.AppsSourceTypeOci && req.ImageReference != "" {
+		err = db.Query.InsertAppSourceOci(ctx, s.DB.RW(), db.InsertAppSourceOciParams{
+			WorkspaceID:    req.WorkspaceID,
+			AppID:          req.ID,
+			ImageReference: req.ImageReference,
+			CreatedAt:      now,
+			UpdatedAt:      sql.NullInt64{},
+		})
+		require.NoError(s.t, err)
+	}
 
 	app, err := db.Query.FindAppById(ctx, s.DB.RO(), req.ID)
 	require.NoError(s.t, err)

--- a/svc/api/routes/v2_apps_get_app/200_test.go
+++ b/svc/api/routes/v2_apps_get_app/200_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
@@ -65,6 +66,8 @@ func TestGetAppSuccessfully(t *testing.T) {
 			require.True(t, strings.HasPrefix(res.Body.Data.Id, "app_"), "id should have app_ prefix: %s", res.Body.Data.Id)
 			require.Equal(t, "Payments API", res.Body.Data.Name)
 			require.Equal(t, appSlug, res.Body.Data.Slug)
+			require.Empty(t, res.Body.Data.SourceType)
+			require.NotContains(t, res.RawBody, `"sourceType"`)
 			require.Nil(t, res.Body.Data.Git, "seeded app has no repo connection")
 			require.Empty(t, res.Body.Data.CurrentDeploymentId, "freshly seeded app has no active deployment")
 			require.False(t, res.Body.Data.IsRolledBack)
@@ -73,4 +76,42 @@ func TestGetAppSuccessfully(t *testing.T) {
 			require.Zero(t, res.Body.Data.UpdatedAt, "never-updated app should have zero (omitted) updatedAt")
 		})
 	}
+}
+
+func TestGetOCIAppReturnsConfiguredSource(t *testing.T) {
+	h := testutil.NewHarness(t)
+	route := &handler.Handler{DB: h.DB}
+	h.Register(route)
+
+	workspace := h.Resources().UserWorkspace
+	project := h.CreateProject(seed.CreateProjectRequest{
+		ID:          uid.New(uid.ProjectPrefix),
+		WorkspaceID: workspace.ID,
+		Name:        "OCI Project",
+		Slug:        strings.ToLower(strings.ReplaceAll(uid.New("test"), "_", "-")),
+	})
+	app := h.CreateApp(seed.CreateAppRequest{
+		ID:             uid.New(uid.AppPrefix),
+		WorkspaceID:    workspace.ID,
+		ProjectID:      project.ID,
+		Name:           "OCI API",
+		Slug:           strings.ToLower(strings.ReplaceAll(uid.New("test"), "_", "-")),
+		SourceType:     db.AppsSourceTypeOci,
+		ImageReference: "ghcr.io/acme/api:v1.2.3",
+	})
+	rootKey := h.CreateRootKey(workspace.ID, "app.*.read_app")
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}
+
+	res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{
+		Project: project.ID,
+		App:     app.ID,
+	})
+	require.Equal(t, http.StatusOK, res.Status, "expected 200, received: %s", res.RawBody)
+	require.Equal(t, "oci", string(res.Body.Data.SourceType))
+	require.Nil(t, res.Body.Data.Git)
+	require.NotNil(t, res.Body.Data.Oci)
+	require.Equal(t, "ghcr.io/acme/api:v1.2.3", res.Body.Data.Oci.Image)
 }

--- a/svc/api/routes/v2_apps_get_app/handler.go
+++ b/svc/api/routes/v2_apps_get_app/handler.go
@@ -97,6 +97,29 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		)
 	}
 	repositoryFullName := conn.RepositoryFullName
+	defaultBranch := conn.DefaultBranch.String
+
+	var oci *openapi.AppOCI
+	if app.SourceType == db.AppsSourceTypeOci {
+		ociSource, ociErr := db.Query.FindAppSourceOciByAppId(ctx, h.DB.RO(), app.ID)
+		if ociErr != nil {
+			return fault.Wrap(
+				ociErr,
+				fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
+				fault.Internal("failed to load OCI app source"),
+				fault.Public("Failed to retrieve app."),
+			)
+		}
+		oci = &openapi.AppOCI{Image: ociSource.ImageReference}
+	}
+	sourceType := openapi.AppSourceType("")
+	switch app.SourceType {
+	case db.AppsSourceTypeGit:
+		sourceType = openapi.Git
+	case db.AppsSourceTypeOci:
+		sourceType = openapi.Oci
+	case db.AppsSourceTypeUnknown:
+	}
 
 	return s.JSON(http.StatusOK, Response{
 		Meta: openapi.Meta{
@@ -106,9 +129,9 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			Id:                  app.ID,
 			Name:                app.Name,
 			Slug:                app.Slug,
-			SourceType:          "",
-			Git:                 githubapp.GitResponse(repositoryFullName, app.DefaultBranch),
-			Oci:                 nil,
+			SourceType:          sourceType,
+			Git:                 githubapp.GitResponse(repositoryFullName, defaultBranch),
+			Oci:                 oci,
 			CurrentDeploymentId: app.CurrentDeploymentID.String,
 			IsRolledBack:        app.IsRolledBack,
 			DeleteProtection:    app.DeleteProtection.Bool,

--- a/svc/api/routes/v2_apps_get_app/handler.go
+++ b/svc/api/routes/v2_apps_get_app/handler.go
@@ -84,11 +84,13 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		)
 	}
 
-	// A missing connection is the common "no repo / OCI app" case, so absence
-	// is not an error; any other failure is. On not-found sqlc returns a
-	// zero-valued row, so RepositoryFullName is "" and GitResponse renders null.
+	repositoryFullName := ""
+	defaultBranch := ""
 	conn, err := db.Query.FindGithubRepoConnectionByAppId(ctx, h.DB.RO(), app.ID)
-	if err != nil && !db.IsNotFound(err) {
+	if err == nil {
+		repositoryFullName = conn.RepositoryFullName
+		defaultBranch = conn.DefaultBranch.String
+	} else if !db.IsNotFound(err) {
 		return fault.Wrap(
 			err,
 			fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
@@ -96,8 +98,6 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			fault.Public("Failed to retrieve app."),
 		)
 	}
-	repositoryFullName := conn.RepositoryFullName
-	defaultBranch := conn.DefaultBranch.String
 
 	var oci *openapi.AppOCI
 	if app.SourceType == db.AppsSourceTypeOci {


### PR DESCRIPTION
## Summary
- return sourceType and configured OCI image from apps.getApp
- omit internal unknown source values from the public response
- add OCI app response coverage

## Stack
Depends on #7081.

## Testing
- `mise exec -- rask ./svc/api/routes/v2_apps_get_app`

- `mise run build`