### PR TITLE
feat: return OCI app sources from listApps

### DIFF
--- a/pkg/db/app_list_by_project.sql_generated.go
+++ b/pkg/db/app_list_by_project.sql_generated.go
@@ -11,9 +11,26 @@ import (
 )
 
 const listAppsByProject = `-- name: ListAppsByProject :many
-SELECT apps.pk, apps.id, apps.workspace_id, apps.project_id, apps.name, apps.slug, apps.source_type, apps.default_branch, apps.current_deployment_id, apps.is_rolled_back, apps.delete_protection, apps.created_at, apps.updated_at, grc.repository_full_name AS repository_full_name
+SELECT
+  apps.pk,
+  apps.id,
+  apps.workspace_id,
+  apps.project_id,
+  apps.name,
+  apps.slug,
+  apps.source_type,
+  apps.default_branch,
+  apps.current_deployment_id,
+  apps.is_rolled_back,
+  apps.delete_protection,
+  apps.created_at,
+  apps.updated_at,
+  grc.repository_full_name AS repository_full_name,
+  grc.default_branch AS github_default_branch,
+  aso.image_reference AS oci_image_reference
 FROM apps
 LEFT JOIN github_repo_connections grc ON grc.app_id = apps.id
+LEFT JOIN app_source_oci aso ON aso.app_id = apps.id
 WHERE apps.project_id = ?
   AND apps.id >= ?
   -- search is a pre-escaped LIKE pattern built by mysql.SearchContains; NULL disables the filter
@@ -44,13 +61,32 @@ type ListAppsByProjectRow struct {
 	CreatedAt           int64          `db:"created_at"`
 	UpdatedAt           sql.NullInt64  `db:"updated_at"`
 	RepositoryFullName  sql.NullString `db:"repository_full_name"`
+	GithubDefaultBranch sql.NullString `db:"github_default_branch"`
+	OciImageReference   sql.NullString `db:"oci_image_reference"`
 }
 
 // ListAppsByProject
 //
-//	SELECT apps.pk, apps.id, apps.workspace_id, apps.project_id, apps.name, apps.slug, apps.source_type, apps.default_branch, apps.current_deployment_id, apps.is_rolled_back, apps.delete_protection, apps.created_at, apps.updated_at, grc.repository_full_name AS repository_full_name
+//	SELECT
+//	  apps.pk,
+//	  apps.id,
+//	  apps.workspace_id,
+//	  apps.project_id,
+//	  apps.name,
+//	  apps.slug,
+//	  apps.source_type,
+//	  apps.default_branch,
+//	  apps.current_deployment_id,
+//	  apps.is_rolled_back,
+//	  apps.delete_protection,
+//	  apps.created_at,
+//	  apps.updated_at,
+//	  grc.repository_full_name AS repository_full_name,
+//	  grc.default_branch AS github_default_branch,
+//	  aso.image_reference AS oci_image_reference
 //	FROM apps
 //	LEFT JOIN github_repo_connections grc ON grc.app_id = apps.id
+//	LEFT JOIN app_source_oci aso ON aso.app_id = apps.id
 //	WHERE apps.project_id = ?
 //	  AND apps.id >= ?
 //	  -- search is a pre-escaped LIKE pattern built by mysql.SearchContains; NULL disables the filter
@@ -89,6 +125,8 @@ func (q *Queries) ListAppsByProject(ctx context.Context, db DBTX, arg ListAppsBy
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.RepositoryFullName,
+			&i.GithubDefaultBranch,
+			&i.OciImageReference,
 		); err != nil {
 			return nil, err
 		}

--- a/pkg/db/querier_generated.go
+++ b/pkg/db/querier_generated.go
@@ -2049,9 +2049,26 @@ type Querier interface {
 	ListAppRuntimeSettingsByApp(ctx context.Context, db DBTX, appID string) ([]AppRuntimeSetting, error)
 	//ListAppsByProject
 	//
-	//  SELECT apps.pk, apps.id, apps.workspace_id, apps.project_id, apps.name, apps.slug, apps.source_type, apps.default_branch, apps.current_deployment_id, apps.is_rolled_back, apps.delete_protection, apps.created_at, apps.updated_at, grc.repository_full_name AS repository_full_name
+	//  SELECT
+	//    apps.pk,
+	//    apps.id,
+	//    apps.workspace_id,
+	//    apps.project_id,
+	//    apps.name,
+	//    apps.slug,
+	//    apps.source_type,
+	//    apps.default_branch,
+	//    apps.current_deployment_id,
+	//    apps.is_rolled_back,
+	//    apps.delete_protection,
+	//    apps.created_at,
+	//    apps.updated_at,
+	//    grc.repository_full_name AS repository_full_name,
+	//    grc.default_branch AS github_default_branch,
+	//    aso.image_reference AS oci_image_reference
 	//  FROM apps
 	//  LEFT JOIN github_repo_connections grc ON grc.app_id = apps.id
+	//  LEFT JOIN app_source_oci aso ON aso.app_id = apps.id
 	//  WHERE apps.project_id = ?
 	//    AND apps.id >= ?
 	//    -- search is a pre-escaped LIKE pattern built by mysql.SearchContains; NULL disables the filter

--- a/pkg/db/queries/app_list_by_project.sql
+++ b/pkg/db/queries/app_list_by_project.sql
@@ -1,7 +1,24 @@
 -- name: ListAppsByProject :many
-SELECT apps.pk, apps.id, apps.workspace_id, apps.project_id, apps.name, apps.slug, apps.source_type, apps.default_branch, apps.current_deployment_id, apps.is_rolled_back, apps.delete_protection, apps.created_at, apps.updated_at, grc.repository_full_name AS repository_full_name
+SELECT
+  apps.pk,
+  apps.id,
+  apps.workspace_id,
+  apps.project_id,
+  apps.name,
+  apps.slug,
+  apps.source_type,
+  apps.default_branch,
+  apps.current_deployment_id,
+  apps.is_rolled_back,
+  apps.delete_protection,
+  apps.created_at,
+  apps.updated_at,
+  grc.repository_full_name AS repository_full_name,
+  grc.default_branch AS github_default_branch,
+  aso.image_reference AS oci_image_reference
 FROM apps
 LEFT JOIN github_repo_connections grc ON grc.app_id = apps.id
+LEFT JOIN app_source_oci aso ON aso.app_id = apps.id
 WHERE apps.project_id = sqlc.arg(project_id)
   AND apps.id >= sqlc.arg(id_cursor)
   -- search is a pre-escaped LIKE pattern built by mysql.SearchContains; NULL disables the filter

--- a/svc/api/routes/v2_apps_list_apps/200_test.go
+++ b/svc/api/routes/v2_apps_list_apps/200_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/ptr"
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
@@ -75,12 +76,14 @@ func TestListAppsSuccessfully(t *testing.T) {
 		require.NotEmpty(t, res.Body.Meta.RequestId)
 		require.Len(t, res.Body.Data, len(seeded))
 		require.False(t, res.Body.Pagination.HasMore)
+		require.NotContains(t, res.RawBody, `"sourceType"`)
 
 		for _, a := range res.Body.Data {
 			slug, ok := seeded[a.Id]
 			require.True(t, ok, "unexpected app %s in response", a.Id)
 			require.True(t, strings.HasPrefix(a.Id, "app_"), "id should have app_ prefix: %s", a.Id)
 			require.Equal(t, slug, a.Slug)
+			require.Empty(t, a.SourceType)
 			require.Nil(t, a.Git, "seeded app has no repo connection")
 			require.NotEmpty(t, a.Name)
 			require.Empty(t, a.CurrentDeploymentId, "freshly seeded app has no active deployment")
@@ -157,6 +160,47 @@ func TestListAppsSuccessfully(t *testing.T) {
 		}
 		require.NotContains(t, res.RawBody, foreignProject.ID, "response must not leak the foreign project ID")
 	})
+}
+
+func TestListAppsReturnsConfiguredOCISource(t *testing.T) {
+	h := testutil.NewHarness(t)
+	route := &handler.Handler{DB: h.DB}
+	h.Register(route)
+
+	workspace := h.Resources().UserWorkspace
+	project := h.CreateProject(seed.CreateProjectRequest{
+		ID:          uid.New(uid.ProjectPrefix),
+		WorkspaceID: workspace.ID,
+		Name:        "OCI Project",
+		Slug:        strings.ToLower(strings.ReplaceAll(uid.New("test"), "_", "-")),
+	})
+	app := h.CreateApp(seed.CreateAppRequest{
+		ID:             uid.New(uid.AppPrefix),
+		WorkspaceID:    workspace.ID,
+		ProjectID:      project.ID,
+		Name:           "OCI API",
+		Slug:           strings.ToLower(strings.ReplaceAll(uid.New("test"), "_", "-")),
+		SourceType:     db.AppsSourceTypeOci,
+		ImageReference: "ghcr.io/acme/api:v1.2.3",
+	})
+	rootKey := h.CreateRootKey(workspace.ID, "app.*.read_app")
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}
+
+	res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{Project: project.ID})
+	require.Equal(t, http.StatusOK, res.Status, "expected 200, received: %s", res.RawBody)
+	require.Len(t, res.Body.Data, 1)
+	require.Equal(t, app.ID, res.Body.Data[0].Id)
+	require.Equal(t, "oci", string(res.Body.Data[0].SourceType))
+	require.Nil(t, res.Body.Data[0].Git)
+	require.NotNil(t, res.Body.Data[0].Oci)
+	require.Equal(t, "ghcr.io/acme/api:v1.2.3", res.Body.Data[0].Oci.Image)
+
+	require.NoError(t, db.Query.DeleteAppSourceOciByAppId(t.Context(), h.DB.RW(), app.ID))
+	res = testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{Project: project.ID})
+	require.Equal(t, http.StatusInternalServerError, res.Status, "missing OCI source must not produce an empty image")
 }
 
 func TestListAppsPagination(t *testing.T) {

--- a/svc/api/routes/v2_apps_list_apps/handler.go
+++ b/svc/api/routes/v2_apps_list_apps/handler.go
@@ -100,15 +100,37 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	rows, pg := pagination.Paginate(rows, p, func(r db.ListAppsByProjectRow) string { return r.ID })
+	for _, row := range rows {
+		if row.SourceType == db.AppsSourceTypeOci && !row.OciImageReference.Valid {
+			return fault.New(
+				"OCI app source is missing",
+				fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
+				fault.Internal("OCI app has no configured image source"),
+				fault.Public("Failed to retrieve apps."),
+			)
+		}
+	}
 
 	data := array.Map(rows, func(row db.ListAppsByProjectRow) openapi.App {
+		var oci *openapi.AppOCI
+		if row.SourceType == db.AppsSourceTypeOci {
+			oci = &openapi.AppOCI{Image: row.OciImageReference.String}
+		}
+		sourceType := openapi.AppSourceType("")
+		switch row.SourceType {
+		case db.AppsSourceTypeGit:
+			sourceType = openapi.Git
+		case db.AppsSourceTypeOci:
+			sourceType = openapi.Oci
+		case db.AppsSourceTypeUnknown:
+		}
 		return openapi.App{
 			Id:                  row.ID,
 			Name:                row.Name,
 			Slug:                row.Slug,
-			SourceType:          "",
-			Git:                 githubapp.GitResponse(row.RepositoryFullName.String, row.DefaultBranch),
-			Oci:                 nil,
+			SourceType:          sourceType,
+			Git:                 githubapp.GitResponse(row.RepositoryFullName.String, row.GithubDefaultBranch.String),
+			Oci:                 oci,
 			CurrentDeploymentId: row.CurrentDeploymentID.String,
 			IsRolledBack:        row.IsRolledBack,
 			DeleteProtection:    row.DeleteProtection.Bool,

--- a/svc/api/routes/v2_apps_list_apps/handler.go
+++ b/svc/api/routes/v2_apps_list_apps/handler.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/unkeyed/unkey/pkg/array"
 	"github.com/unkeyed/unkey/pkg/codes"
 	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/fault"
@@ -100,31 +99,27 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	rows, pg := pagination.Paginate(rows, p, func(r db.ListAppsByProjectRow) string { return r.ID })
-	for _, row := range rows {
-		if row.SourceType == db.AppsSourceTypeOci && !row.OciImageReference.Valid {
-			return fault.New(
-				"OCI app source is missing",
-				fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
-				fault.Internal("OCI app has no configured image source"),
-				fault.Public("Failed to retrieve apps."),
-			)
-		}
-	}
-
-	data := array.Map(rows, func(row db.ListAppsByProjectRow) openapi.App {
+	data := make([]openapi.App, len(rows))
+	for i, row := range rows {
 		var oci *openapi.AppOCI
-		if row.SourceType == db.AppsSourceTypeOci {
-			oci = &openapi.AppOCI{Image: row.OciImageReference.String}
-		}
 		sourceType := openapi.AppSourceType("")
 		switch row.SourceType {
 		case db.AppsSourceTypeGit:
 			sourceType = openapi.Git
 		case db.AppsSourceTypeOci:
+			if !row.OciImageReference.Valid {
+				return fault.New(
+					"OCI app source is missing",
+					fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
+					fault.Internal("OCI app has no configured image source"),
+					fault.Public("Failed to retrieve apps."),
+				)
+			}
 			sourceType = openapi.Oci
+			oci = &openapi.AppOCI{Image: row.OciImageReference.String}
 		case db.AppsSourceTypeUnknown:
 		}
-		return openapi.App{
+		data[i] = openapi.App{
 			Id:                  row.ID,
 			Name:                row.Name,
 			Slug:                row.Slug,
@@ -137,7 +132,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			CreatedAt:           row.CreatedAt,
 			UpdatedAt:           row.UpdatedAt.Int64,
 		}
-	})
+	}
 
 	return s.JSON(http.StatusOK, Response{
 		Meta: openapi.Meta{


### PR DESCRIPTION
## Summary
- select app source and configured OCI image in the app list query
- return source-aware records from apps.listApps
- cover OCI and Git list responses

## Stack
Depends on #7082.

## Testing
- `mise exec -- rask ./svc/api/routes/v2_apps_list_apps`