### PR TITLE
feat: return source-aware deployments

### DIFF
--- a/pkg/db/app_list_by_project.sql_generated.go
+++ b/pkg/db/app_list_by_project.sql_generated.go
@@ -11,9 +11,26 @@ import (
 )
 
 const listAppsByProject = `-- name: ListAppsByProject :many
-SELECT apps.pk, apps.id, apps.workspace_id, apps.project_id, apps.name, apps.slug, apps.source_type, apps.default_branch, apps.current_deployment_id, apps.is_rolled_back, apps.delete_protection, apps.created_at, apps.updated_at, grc.repository_full_name AS repository_full_name
+SELECT
+  apps.pk,
+  apps.id,
+  apps.workspace_id,
+  apps.project_id,
+  apps.name,
+  apps.slug,
+  apps.source_type,
+  apps.default_branch,
+  apps.current_deployment_id,
+  apps.is_rolled_back,
+  apps.delete_protection,
+  apps.created_at,
+  apps.updated_at,
+  grc.repository_full_name AS repository_full_name,
+  grc.default_branch AS github_default_branch,
+  aso.image_reference AS oci_image_reference
 FROM apps
 LEFT JOIN github_repo_connections grc ON grc.app_id = apps.id
+LEFT JOIN app_source_oci aso ON aso.app_id = apps.id
 WHERE apps.project_id = ?
   AND apps.id >= ?
   -- search is a pre-escaped LIKE pattern built by mysql.SearchContains; NULL disables the filter
@@ -44,13 +61,32 @@ type ListAppsByProjectRow struct {
 	CreatedAt           int64          `db:"created_at"`
 	UpdatedAt           sql.NullInt64  `db:"updated_at"`
 	RepositoryFullName  sql.NullString `db:"repository_full_name"`
+	GithubDefaultBranch sql.NullString `db:"github_default_branch"`
+	OciImageReference   sql.NullString `db:"oci_image_reference"`
 }
 
 // ListAppsByProject
 //
-//	SELECT apps.pk, apps.id, apps.workspace_id, apps.project_id, apps.name, apps.slug, apps.source_type, apps.default_branch, apps.current_deployment_id, apps.is_rolled_back, apps.delete_protection, apps.created_at, apps.updated_at, grc.repository_full_name AS repository_full_name
+//	SELECT
+//	  apps.pk,
+//	  apps.id,
+//	  apps.workspace_id,
+//	  apps.project_id,
+//	  apps.name,
+//	  apps.slug,
+//	  apps.source_type,
+//	  apps.default_branch,
+//	  apps.current_deployment_id,
+//	  apps.is_rolled_back,
+//	  apps.delete_protection,
+//	  apps.created_at,
+//	  apps.updated_at,
+//	  grc.repository_full_name AS repository_full_name,
+//	  grc.default_branch AS github_default_branch,
+//	  aso.image_reference AS oci_image_reference
 //	FROM apps
 //	LEFT JOIN github_repo_connections grc ON grc.app_id = apps.id
+//	LEFT JOIN app_source_oci aso ON aso.app_id = apps.id
 //	WHERE apps.project_id = ?
 //	  AND apps.id >= ?
 //	  -- search is a pre-escaped LIKE pattern built by mysql.SearchContains; NULL disables the filter
@@ -89,6 +125,8 @@ func (q *Queries) ListAppsByProject(ctx context.Context, db DBTX, arg ListAppsBy
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.RepositoryFullName,
+			&i.GithubDefaultBranch,
+			&i.OciImageReference,
 		); err != nil {
 			return nil, err
 		}

--- a/pkg/db/app_update.sql_generated.go
+++ b/pkg/db/app_update.sql_generated.go
@@ -21,10 +21,6 @@ SET
         WHEN CAST(? AS UNSIGNED) = 1 THEN ?
         ELSE a.slug
     END,
-    default_branch = CASE
-        WHEN CAST(? AS UNSIGNED) = 1 THEN ?
-        ELSE a.default_branch
-    END,
     delete_protection = CASE
         WHEN CAST(? AS UNSIGNED) = 1 THEN ?
         ELSE a.delete_protection
@@ -39,8 +35,6 @@ type UpdateAppParams struct {
 	Name                      string        `db:"name"`
 	SlugSpecified             int64         `db:"slug_specified"`
 	Slug                      string        `db:"slug"`
-	DefaultBranchSpecified    int64         `db:"default_branch_specified"`
-	DefaultBranch             string        `db:"default_branch"`
 	DeleteProtectionSpecified int64         `db:"delete_protection_specified"`
 	DeleteProtection          sql.NullBool  `db:"delete_protection"`
 	UpdatedAt                 sql.NullInt64 `db:"updated_at"`
@@ -60,10 +54,6 @@ type UpdateAppParams struct {
 //	        WHEN CAST(? AS UNSIGNED) = 1 THEN ?
 //	        ELSE a.slug
 //	    END,
-//	    default_branch = CASE
-//	        WHEN CAST(? AS UNSIGNED) = 1 THEN ?
-//	        ELSE a.default_branch
-//	    END,
 //	    delete_protection = CASE
 //	        WHEN CAST(? AS UNSIGNED) = 1 THEN ?
 //	        ELSE a.delete_protection
@@ -77,8 +67,6 @@ func (q *Queries) UpdateApp(ctx context.Context, db DBTX, arg UpdateAppParams) e
 		arg.Name,
 		arg.SlugSpecified,
 		arg.Slug,
-		arg.DefaultBranchSpecified,
-		arg.DefaultBranch,
 		arg.DeleteProtectionSpecified,
 		arg.DeleteProtection,
 		arg.UpdatedAt,

--- a/pkg/db/querier_generated.go
+++ b/pkg/db/querier_generated.go
@@ -2749,10 +2749,6 @@ type Querier interface {
 	//          WHEN CAST(? AS UNSIGNED) = 1 THEN ?
 	//          ELSE a.slug
 	//      END,
-	//      default_branch = CASE
-	//          WHEN CAST(? AS UNSIGNED) = 1 THEN ?
-	//          ELSE a.default_branch
-	//      END,
 	//      delete_protection = CASE
 	//          WHEN CAST(? AS UNSIGNED) = 1 THEN ?
 	//          ELSE a.delete_protection

--- a/pkg/db/querier_generated.go
+++ b/pkg/db/querier_generated.go
@@ -2049,9 +2049,26 @@ type Querier interface {
 	ListAppRuntimeSettingsByApp(ctx context.Context, db DBTX, appID string) ([]AppRuntimeSetting, error)
 	//ListAppsByProject
 	//
-	//  SELECT apps.pk, apps.id, apps.workspace_id, apps.project_id, apps.name, apps.slug, apps.source_type, apps.default_branch, apps.current_deployment_id, apps.is_rolled_back, apps.delete_protection, apps.created_at, apps.updated_at, grc.repository_full_name AS repository_full_name
+	//  SELECT
+	//    apps.pk,
+	//    apps.id,
+	//    apps.workspace_id,
+	//    apps.project_id,
+	//    apps.name,
+	//    apps.slug,
+	//    apps.source_type,
+	//    apps.default_branch,
+	//    apps.current_deployment_id,
+	//    apps.is_rolled_back,
+	//    apps.delete_protection,
+	//    apps.created_at,
+	//    apps.updated_at,
+	//    grc.repository_full_name AS repository_full_name,
+	//    grc.default_branch AS github_default_branch,
+	//    aso.image_reference AS oci_image_reference
 	//  FROM apps
 	//  LEFT JOIN github_repo_connections grc ON grc.app_id = apps.id
+	//  LEFT JOIN app_source_oci aso ON aso.app_id = apps.id
 	//  WHERE apps.project_id = ?
 	//    AND apps.id >= ?
 	//    -- search is a pre-escaped LIKE pattern built by mysql.SearchContains; NULL disables the filter

--- a/pkg/db/queries/app_list_by_project.sql
+++ b/pkg/db/queries/app_list_by_project.sql
@@ -1,7 +1,24 @@
 -- name: ListAppsByProject :many
-SELECT apps.pk, apps.id, apps.workspace_id, apps.project_id, apps.name, apps.slug, apps.source_type, apps.default_branch, apps.current_deployment_id, apps.is_rolled_back, apps.delete_protection, apps.created_at, apps.updated_at, grc.repository_full_name AS repository_full_name
+SELECT
+  apps.pk,
+  apps.id,
+  apps.workspace_id,
+  apps.project_id,
+  apps.name,
+  apps.slug,
+  apps.source_type,
+  apps.default_branch,
+  apps.current_deployment_id,
+  apps.is_rolled_back,
+  apps.delete_protection,
+  apps.created_at,
+  apps.updated_at,
+  grc.repository_full_name AS repository_full_name,
+  grc.default_branch AS github_default_branch,
+  aso.image_reference AS oci_image_reference
 FROM apps
 LEFT JOIN github_repo_connections grc ON grc.app_id = apps.id
+LEFT JOIN app_source_oci aso ON aso.app_id = apps.id
 WHERE apps.project_id = sqlc.arg(project_id)
   AND apps.id >= sqlc.arg(id_cursor)
   -- search is a pre-escaped LIKE pattern built by mysql.SearchContains; NULL disables the filter

--- a/pkg/db/queries/app_update.sql
+++ b/pkg/db/queries/app_update.sql
@@ -9,10 +9,6 @@ SET
         WHEN CAST(sqlc.arg('slug_specified') AS UNSIGNED) = 1 THEN sqlc.arg('slug')
         ELSE a.slug
     END,
-    default_branch = CASE
-        WHEN CAST(sqlc.arg('default_branch_specified') AS UNSIGNED) = 1 THEN sqlc.arg('default_branch')
-        ELSE a.default_branch
-    END,
     delete_protection = CASE
         WHEN CAST(sqlc.arg('delete_protection_specified') AS UNSIGNED) = 1 THEN sqlc.narg('delete_protection')
         ELSE a.delete_protection

--- a/svc/api/internal/deployment/mapper.go
+++ b/svc/api/internal/deployment/mapper.go
@@ -78,18 +78,38 @@ func ToResponse(in Input) openapi.Deployment {
 		Domains: nil,
 	}
 
-	// A deployment is sourced from either git or a prebuilt image. git_commit_sha
-	// is the discriminator: git builds set it (and also fill image with the built
-	// output), image deploys leave it null.
-	switch {
-	case d.GitCommitSha.Valid && d.GitCommitSha.String != "":
+	setGitSource := func() {
 		git := openapi.DeploymentGit{CommitSha: d.GitCommitSha.String, Branch: nil}
 		if d.GitBranch.Valid && d.GitBranch.String != "" {
 			git.Branch = ptr.P(d.GitBranch.String)
 		}
 		dep.Git = &git
-	case d.Image.Valid && d.Image.String != "":
-		dep.Docker = &openapi.DeploymentDocker{Image: d.Image.String}
+	}
+	setOCISource := func() {
+		image := d.ImageRequested
+		if !image.Valid || image.String == "" {
+			image = d.ImageResolved
+		}
+		if !image.Valid || image.String == "" {
+			image = d.Image
+		}
+		if image.Valid && image.String != "" {
+			dep.Docker = &openapi.DeploymentDocker{Image: image.String}
+		}
+	}
+
+	switch d.Source {
+	case db.DeploymentsSourceGit:
+		if d.GitCommitSha.Valid && d.GitCommitSha.String != "" {
+			setGitSource()
+		}
+	case db.DeploymentsSourceOci:
+		setOCISource()
+	case db.DeploymentsSourceUnknown:
+		// Historical provenance is ambiguous. Do not infer it from optional
+		// Git or image metadata.
+	default:
+		// Future source variants remain neutral until mapped explicitly.
 	}
 
 	if failure := deriveError(d.Status, in.Steps); failure != nil {

--- a/svc/api/internal/deployment/mapper.go
+++ b/svc/api/internal/deployment/mapper.go
@@ -78,14 +78,16 @@ func ToResponse(in Input) openapi.Deployment {
 		Domains: nil,
 	}
 
-	setGitSource := func() {
-		git := openapi.DeploymentGit{CommitSha: d.GitCommitSha.String, Branch: nil}
-		if d.GitBranch.Valid && d.GitBranch.String != "" {
-			git.Branch = ptr.P(d.GitBranch.String)
+	switch d.Source {
+	case db.DeploymentsSourceGit:
+		if d.GitCommitSha.Valid && d.GitCommitSha.String != "" {
+			git := openapi.DeploymentGit{CommitSha: d.GitCommitSha.String, Branch: nil}
+			if d.GitBranch.Valid && d.GitBranch.String != "" {
+				git.Branch = ptr.P(d.GitBranch.String)
+			}
+			dep.Git = &git
 		}
-		dep.Git = &git
-	}
-	setOCISource := func() {
+	case db.DeploymentsSourceOci:
 		image := d.ImageRequested
 		if !image.Valid || image.String == "" {
 			image = d.ImageResolved
@@ -96,15 +98,6 @@ func ToResponse(in Input) openapi.Deployment {
 		if image.Valid && image.String != "" {
 			dep.Docker = &openapi.DeploymentDocker{Image: image.String}
 		}
-	}
-
-	switch d.Source {
-	case db.DeploymentsSourceGit:
-		if d.GitCommitSha.Valid && d.GitCommitSha.String != "" {
-			setGitSource()
-		}
-	case db.DeploymentsSourceOci:
-		setOCISource()
 	case db.DeploymentsSourceUnknown:
 		// Historical provenance is ambiguous. Do not infer it from optional
 		// Git or image metadata.

--- a/svc/api/internal/deployment/mapper.go
+++ b/svc/api/internal/deployment/mapper.go
@@ -1,6 +1,3 @@
-// Package deployment maps a stored deployment row onto the openapi.Deployment
-// wire type shared by the deployment read endpoints (getDeployment,
-// listDeployments).
 package deployment
 
 import (
@@ -9,10 +6,6 @@ import (
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
 
-// Input is everything ToResponse needs. State carries the env/app columns the
-// wire type needs but the deployments row does not hold (slugs and the app live
-// pointer); both read handlers resolve them (per-deployment on get, batched on
-// list) so the mapper never queries.
 type Input struct {
 	Deployment db.Deployment
 	State      db.ListDeploymentEnvAndAppStateRow
@@ -43,8 +36,6 @@ func ToResponse(in Input) openapi.Deployment {
 
 	isCurrent := in.State.AppCurrentDeploymentID.String != "" && in.State.AppCurrentDeploymentID.String == d.ID
 
-	// regions is a required field, so it must marshal as [] not null when the
-	// deployment has no scheduled regions yet.
 	regions := in.Regions
 	if regions == nil {
 		regions = []string{}
@@ -98,6 +89,7 @@ func ToResponse(in Input) openapi.Deployment {
 		if image.Valid && image.String != "" {
 			dep.Docker = &openapi.DeploymentDocker{Image: image.String}
 		}
+	case db.DeploymentsSourceUnknown:
 	}
 
 	if failure := deriveError(d.Status, in.Steps); failure != nil {

--- a/svc/api/internal/deployment/mapper.go
+++ b/svc/api/internal/deployment/mapper.go
@@ -98,11 +98,6 @@ func ToResponse(in Input) openapi.Deployment {
 		if image.Valid && image.String != "" {
 			dep.Docker = &openapi.DeploymentDocker{Image: image.String}
 		}
-	case db.DeploymentsSourceUnknown:
-		// Historical provenance is ambiguous. Do not infer it from optional
-		// Git or image metadata.
-	default:
-		// Future source variants remain neutral until mapped explicitly.
 	}
 
 	if failure := deriveError(d.Status, in.Steps); failure != nil {

--- a/svc/api/internal/deployment/mapper_test.go
+++ b/svc/api/internal/deployment/mapper_test.go
@@ -108,6 +108,17 @@ func TestToResponseSource(t *testing.T) {
 		require.Equal(t, "ghcr.io/acme/api@sha256:resolved", got.Docker.Image)
 	})
 
+	t.Run("invalid requested image falls back to resolved image", func(t *testing.T) {
+		got := ToResponse(Input{Deployment: db.Deployment{
+			ID:             uid.New(uid.DeploymentPrefix),
+			Source:         db.DeploymentsSourceOci,
+			ImageRequested: sql.NullString{Valid: false, String: "ghcr.io/acme/api:invalid"},
+			ImageResolved:  sql.NullString{Valid: true, String: "ghcr.io/acme/api@sha256:resolved"},
+		}})
+		require.NotNil(t, got.Docker)
+		require.Equal(t, "ghcr.io/acme/api@sha256:resolved", got.Docker.Image)
+	})
+
 	t.Run("git without branch omits branch", func(t *testing.T) {
 		got := ToResponse(Input{Deployment: db.Deployment{
 			ID:           uid.New(uid.DeploymentPrefix),

--- a/svc/api/internal/deployment/mapper_test.go
+++ b/svc/api/internal/deployment/mapper_test.go
@@ -70,13 +70,13 @@ func TestToResponseRegions(t *testing.T) {
 }
 
 func TestToResponseSource(t *testing.T) {
-	t.Run("git-sourced sets git, not docker", func(t *testing.T) {
+	t.Run("git-sourced sets git, not OCI compatibility field", func(t *testing.T) {
 		got := ToResponse(Input{Deployment: db.Deployment{
 			ID:           uid.New(uid.DeploymentPrefix),
+			Source:       db.DeploymentsSourceGit,
 			GitCommitSha: sql.NullString{Valid: true, String: "9f2c1a7d3b"},
 			GitBranch:    sql.NullString{Valid: true, String: "main"},
-			// git builds also fill image with the built output; must not leak as docker
-			Image: sql.NullString{Valid: true, String: "ghcr.io/built/output:sha"},
+			Image:        sql.NullString{Valid: true, String: "ghcr.io/built/output:sha"},
 		}})
 		require.NotNil(t, got.Git)
 		require.Equal(t, "9f2c1a7d3b", got.Git.CommitSha)
@@ -85,23 +85,61 @@ func TestToResponseSource(t *testing.T) {
 		require.Nil(t, got.Docker)
 	})
 
-	t.Run("image-sourced sets docker, not git", func(t *testing.T) {
+	t.Run("OCI-sourced sets compatibility field, not git", func(t *testing.T) {
 		got := ToResponse(Input{Deployment: db.Deployment{
-			ID:    uid.New(uid.DeploymentPrefix),
-			Image: sql.NullString{Valid: true, String: "ghcr.io/acme/api:v1.2.3"},
+			ID:             uid.New(uid.DeploymentPrefix),
+			Source:         db.DeploymentsSourceOci,
+			ImageRequested: sql.NullString{Valid: true, String: "ghcr.io/acme/api:v1.2.3"},
+			Image:          sql.NullString{Valid: true, String: "ghcr.io/acme/api@sha256:resolved"},
 		}})
 		require.NotNil(t, got.Docker)
 		require.Equal(t, "ghcr.io/acme/api:v1.2.3", got.Docker.Image)
 		require.Nil(t, got.Git)
 	})
 
+	t.Run("resolved image prefers additive column", func(t *testing.T) {
+		got := ToResponse(Input{Deployment: db.Deployment{
+			ID:            uid.New(uid.DeploymentPrefix),
+			Source:        db.DeploymentsSourceOci,
+			Image:         sql.NullString{Valid: true, String: "ghcr.io/acme/api@sha256:legacy"},
+			ImageResolved: sql.NullString{Valid: true, String: "ghcr.io/acme/api@sha256:resolved"},
+		}})
+		require.NotNil(t, got.Docker)
+		require.Equal(t, "ghcr.io/acme/api@sha256:resolved", got.Docker.Image)
+	})
+
 	t.Run("git without branch omits branch", func(t *testing.T) {
 		got := ToResponse(Input{Deployment: db.Deployment{
 			ID:           uid.New(uid.DeploymentPrefix),
+			Source:       db.DeploymentsSourceGit,
 			GitCommitSha: sql.NullString{Valid: true, String: "abc"},
 		}})
 		require.NotNil(t, got.Git)
 		require.Nil(t, got.Git.Branch)
+	})
+
+	t.Run("unknown source remains neutral", func(t *testing.T) {
+		got := ToResponse(Input{Deployment: db.Deployment{
+			ID:             uid.New(uid.DeploymentPrefix),
+			GitCommitSha:   sql.NullString{Valid: true, String: "abc"},
+			Source:         db.DeploymentsSourceUnknown,
+			ImageRequested: sql.NullString{Valid: true, String: "nginx:stable"},
+			Image:          sql.NullString{Valid: true, String: "nginx@sha256:resolved"},
+		}})
+		require.Nil(t, got.Git)
+		require.Nil(t, got.Docker)
+	})
+
+	t.Run("unsupported source remains neutral", func(t *testing.T) {
+		got := ToResponse(Input{Deployment: db.Deployment{
+			ID:             uid.New(uid.DeploymentPrefix),
+			Source:         db.DeploymentsSource("future_source"),
+			GitCommitSha:   sql.NullString{Valid: true, String: "abc"},
+			ImageRequested: sql.NullString{Valid: true, String: "nginx:stable"},
+			Image:          sql.NullString{Valid: true, String: "nginx@sha256:resolved"},
+		}})
+		require.Nil(t, got.Git)
+		require.Nil(t, got.Docker)
 	})
 }
 

--- a/svc/api/openapi/gen.go
+++ b/svc/api/openapi/gen.go
@@ -1959,7 +1959,8 @@ type V2AppsListAppsResponseBody struct {
 	Pagination Pagination `json:"pagination"`
 }
 
-// V2AppsUpdateAppRequestBody Update app settings, or change an OCI app's image in a standalone request.
+// V2AppsUpdateAppRequestBody Provide at least one field to update. Change an OCI app's image in a
+// standalone request; it cannot be combined with other changes.
 type V2AppsUpdateAppRequestBody struct {
 	// App Identifies a resource by either its unique ID or its slug.
 	// Accepts a prefixed ID (such as 'proj_' or 'app_') or a slug.

--- a/svc/api/openapi/gen.go
+++ b/svc/api/openapi/gen.go
@@ -389,7 +389,7 @@ type DeploymentAction string
 
 // DeploymentDocker defines model for DeploymentDocker.
 type DeploymentDocker struct {
-	// Image The Docker image this deployment runs.
+	// Image The OCI image reference requested for this deployment.
 	Image string `json:"image"`
 }
 

--- a/svc/api/openapi/gen.go
+++ b/svc/api/openapi/gen.go
@@ -1959,8 +1959,7 @@ type V2AppsListAppsResponseBody struct {
 	Pagination Pagination `json:"pagination"`
 }
 
-// V2AppsUpdateAppRequestBody Provide at least one field to update. Change an OCI app's image in a
-// standalone request; it cannot be combined with other changes.
+// V2AppsUpdateAppRequestBody Provide at least one field to update. Omitted fields remain unchanged.
 type V2AppsUpdateAppRequestBody struct {
 	// App Identifies a resource by either its unique ID or its slug.
 	// Accepts a prefixed ID (such as 'proj_' or 'app_') or a slug.
@@ -1981,8 +1980,8 @@ type V2AppsUpdateAppRequestBody struct {
 	Name *string `json:"name,omitempty"`
 
 	// Oci Change the default image reference for an OCI-sourced app. This does not
-	// create a deployment. Image updates cannot be combined with other changes,
-	// and source switching is not supported.
+	// create a deployment. It can be combined with other app settings. Source
+	// switching is not supported.
 	Oci *AppOCI `json:"oci,omitempty"`
 
 	// Project Identifies a resource by either its unique ID or its slug.

--- a/svc/api/openapi/gen.go
+++ b/svc/api/openapi/gen.go
@@ -1983,7 +1983,7 @@ type V2AppsUpdateAppRequestBody struct {
 	// Oci Change the default image reference for an OCI-sourced app. This does not
 	// create a deployment. Image updates cannot be combined with other changes,
 	// and source switching is not supported.
-	Oci *AppOCIInput `json:"oci,omitempty"`
+	Oci *AppOCI `json:"oci,omitempty"`
 
 	// Project Identifies a resource by either its unique ID or its slug.
 	// Accepts a prefixed ID (such as 'proj_' or 'app_') or a slug.

--- a/svc/api/openapi/gen.go
+++ b/svc/api/openapi/gen.go
@@ -1959,7 +1959,7 @@ type V2AppsListAppsResponseBody struct {
 	Pagination Pagination `json:"pagination"`
 }
 
-// V2AppsUpdateAppRequestBody defines model for V2AppsUpdateAppRequestBody.
+// V2AppsUpdateAppRequestBody Update app settings, or change an OCI app's image in a standalone request.
 type V2AppsUpdateAppRequestBody struct {
 	// App Identifies a resource by either its unique ID or its slug.
 	// Accepts a prefixed ID (such as 'proj_' or 'app_') or a slug.
@@ -1978,6 +1978,11 @@ type V2AppsUpdateAppRequestBody struct {
 	// Name New human-readable name for the app.
 	// Omit this field to leave the current name unchanged.
 	Name *string `json:"name,omitempty"`
+
+	// Oci Change the default image reference for an OCI-sourced app. This does not
+	// create a deployment. Image updates cannot be combined with other changes,
+	// and source switching is not supported.
+	Oci *AppOCIInput `json:"oci,omitempty"`
 
 	// Project Identifies a resource by either its unique ID or its slug.
 	// Accepts a prefixed ID (such as 'proj_' or 'app_') or a slug.

--- a/svc/api/openapi/openapi-generated.yaml
+++ b/svc/api/openapi/openapi-generated.yaml
@@ -4690,7 +4690,7 @@ components:
                 docker:
                     "$ref": "#/components/schemas/DeploymentDocker"
                     description: |
-                        Present for image-sourced deployments. Mutually exclusive with `git`.
+                        Compatibility field present for OCI image-sourced deployments. Mutually exclusive with `git`.
                 availableActions:
                     type: array
                     items:
@@ -4796,7 +4796,7 @@ components:
             properties:
                 image:
                     type: string
-                    description: The Docker image this deployment runs.
+                    description: The OCI image reference requested for this deployment.
                     example: ghcr.io/acme/api:v1.2.3
             additionalProperties: false
         DeploymentAction:

--- a/svc/api/openapi/openapi-generated.yaml
+++ b/svc/api/openapi/openapi-generated.yaml
@@ -573,38 +573,6 @@ components:
             required:
                 - project
                 - app
-            not:
-                allOf:
-                    - not:
-                        required:
-                            - name
-                    - not:
-                        required:
-                            - slug
-                    - not:
-                        required:
-                            - git
-                    - not:
-                        required:
-                            - oci
-                    - not:
-                        required:
-                            - deleteProtection
-            dependentSchemas:
-                oci:
-                    allOf:
-                        - not:
-                            required:
-                                - name
-                        - not:
-                            required:
-                                - slug
-                        - not:
-                            required:
-                                - git
-                        - not:
-                            required:
-                                - deleteProtection
             properties:
                 project:
                     "$ref": "#/components/schemas/ResourceIdentifier"

--- a/svc/api/openapi/openapi-generated.yaml
+++ b/svc/api/openapi/openapi-generated.yaml
@@ -603,7 +603,7 @@ components:
                         create a deployment. Image updates cannot be combined with other changes,
                         and source switching is not supported.
                     allOf:
-                        - "$ref": "#/components/schemas/AppOCIInput"
+                        - "$ref": "#/components/schemas/AppOCI"
                 deleteProtection:
                     type: boolean
                     description: |

--- a/svc/api/openapi/openapi-generated.yaml
+++ b/svc/api/openapi/openapi-generated.yaml
@@ -600,8 +600,8 @@ components:
                 oci:
                     description: |
                         Change the default image reference for an OCI-sourced app. This does not
-                        create a deployment. Image updates cannot be combined with other changes,
-                        and source switching is not supported.
+                        create a deployment. It can be combined with other app settings. Source
+                        switching is not supported.
                     allOf:
                         - "$ref": "#/components/schemas/AppOCI"
                 deleteProtection:
@@ -611,9 +611,7 @@ components:
                         Omit this field to leave the current setting unchanged.
                     example: true
             additionalProperties: false
-            description: |
-                Provide at least one field to update. Change an OCI app's image in a
-                standalone request; it cannot be combined with other changes.
+            description: Provide at least one field to update. Omitted fields remain unchanged.
         V2AppsUpdateAppResponseBody:
             type: object
             required:

--- a/svc/api/openapi/openapi-generated.yaml
+++ b/svc/api/openapi/openapi-generated.yaml
@@ -573,6 +573,10 @@ components:
             required:
                 - project
                 - app
+            minProperties: 3
+            dependentSchemas:
+                oci:
+                    maxProperties: 3
             properties:
                 project:
                     "$ref": "#/components/schemas/ResourceIdentifier"

--- a/svc/api/openapi/openapi-generated.yaml
+++ b/svc/api/openapi/openapi-generated.yaml
@@ -597,6 +597,13 @@ components:
                     anyOf:
                         - "$ref": "#/components/schemas/AppGitUpdateInput"
                         - type: "null"
+                oci:
+                    description: |
+                        Change the default image reference for an OCI-sourced app. This does not
+                        create a deployment. Image updates cannot be combined with other changes,
+                        and source switching is not supported.
+                    allOf:
+                        - "$ref": "#/components/schemas/AppOCIInput"
                 deleteProtection:
                     type: boolean
                     description: |
@@ -604,6 +611,20 @@ components:
                         Omit this field to leave the current setting unchanged.
                     example: true
             additionalProperties: false
+            oneOf:
+                - required:
+                    - oci
+                - anyOf:
+                    - required:
+                        - name
+                    - required:
+                        - slug
+                    - required:
+                        - git
+                    - required:
+                        - deleteProtection
+            description: |
+                Update app settings, or change an OCI app's image in a standalone request.
         V2AppsUpdateAppResponseBody:
             type: object
             required:

--- a/svc/api/openapi/openapi-generated.yaml
+++ b/svc/api/openapi/openapi-generated.yaml
@@ -611,20 +611,9 @@ components:
                         Omit this field to leave the current setting unchanged.
                     example: true
             additionalProperties: false
-            oneOf:
-                - required:
-                    - oci
-                - anyOf:
-                    - required:
-                        - name
-                    - required:
-                        - slug
-                    - required:
-                        - git
-                    - required:
-                        - deleteProtection
             description: |
-                Update app settings, or change an OCI app's image in a standalone request.
+                Provide at least one field to update. Change an OCI app's image in a
+                standalone request; it cannot be combined with other changes.
         V2AppsUpdateAppResponseBody:
             type: object
             required:

--- a/svc/api/openapi/openapi-generated.yaml
+++ b/svc/api/openapi/openapi-generated.yaml
@@ -573,10 +573,38 @@ components:
             required:
                 - project
                 - app
-            minProperties: 3
+            not:
+                allOf:
+                    - not:
+                        required:
+                            - name
+                    - not:
+                        required:
+                            - slug
+                    - not:
+                        required:
+                            - git
+                    - not:
+                        required:
+                            - oci
+                    - not:
+                        required:
+                            - deleteProtection
             dependentSchemas:
                 oci:
-                    maxProperties: 3
+                    allOf:
+                        - not:
+                            required:
+                                - name
+                        - not:
+                            required:
+                                - slug
+                        - not:
+                            required:
+                                - git
+                        - not:
+                            required:
+                                - deleteProtection
             properties:
                 project:
                     "$ref": "#/components/schemas/ResourceIdentifier"

--- a/svc/api/openapi/overlay.yaml
+++ b/svc/api/openapi/overlay.yaml
@@ -83,10 +83,6 @@ actions:
   - target: $["components"]["schemas"]["V2EnvironmentsUpdateSettingsRequestBody"]["properties"]["buildCommand"]
     update:
       nullable: true
-  # Update operation constraints are enforced by the public schema. The
-  # handler rejects OCI image updates combined with other changes as well.
-  - target: $["components"]["schemas"]["V2AppsUpdateAppRequestBody"]["oneOf"]
-    remove: true
   - target: $["components"]["schemas"]["V2AppsUpdateAppRequestBody"]["properties"]["git"]["anyOf"]
     remove: true
   - target: $["components"]["schemas"]["V2AppsUpdateAppRequestBody"]["properties"]["git"]

--- a/svc/api/openapi/overlay.yaml
+++ b/svc/api/openapi/overlay.yaml
@@ -83,6 +83,10 @@ actions:
   - target: $["components"]["schemas"]["V2EnvironmentsUpdateSettingsRequestBody"]["properties"]["buildCommand"]
     update:
       nullable: true
+  # Update operation constraints are enforced by the public schema. The
+  # handler rejects OCI image updates combined with other changes as well.
+  - target: $["components"]["schemas"]["V2AppsUpdateAppRequestBody"]["oneOf"]
+    remove: true
   - target: $["components"]["schemas"]["V2AppsUpdateAppRequestBody"]["properties"]["git"]["anyOf"]
     remove: true
   - target: $["components"]["schemas"]["V2AppsUpdateAppRequestBody"]["properties"]["git"]

--- a/svc/api/openapi/spec/common/Deployment.yaml
+++ b/svc/api/openapi/spec/common/Deployment.yaml
@@ -45,7 +45,7 @@ properties:
   docker:
     "$ref": "./DeploymentDocker.yaml"
     description: |
-      Present for image-sourced deployments. Mutually exclusive with `git`.
+      Compatibility field present for OCI image-sourced deployments. Mutually exclusive with `git`.
   availableActions:
     type: array
     items:

--- a/svc/api/openapi/spec/common/DeploymentDocker.yaml
+++ b/svc/api/openapi/spec/common/DeploymentDocker.yaml
@@ -4,6 +4,6 @@ required:
 properties:
   image:
     type: string
-    description: The Docker image this deployment runs.
+    description: The OCI image reference requested for this deployment.
     example: ghcr.io/acme/api:v1.2.3
 additionalProperties: false

--- a/svc/api/openapi/spec/paths/v2/apps/updateApp/V2AppsUpdateAppRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/apps/updateApp/V2AppsUpdateAppRequestBody.yaml
@@ -2,29 +2,6 @@ type: object
 required:
   - project
   - app
-not:
-  allOf:
-    - not:
-        required: [name]
-    - not:
-        required: [slug]
-    - not:
-        required: [git]
-    - not:
-        required: [oci]
-    - not:
-        required: [deleteProtection]
-dependentSchemas:
-  oci:
-    allOf:
-      - not:
-          required: [name]
-      - not:
-          required: [slug]
-      - not:
-          required: [git]
-      - not:
-          required: [deleteProtection]
 properties:
   project:
     "$ref": "../../../../common/ResourceIdentifier.yaml"

--- a/svc/api/openapi/spec/paths/v2/apps/updateApp/V2AppsUpdateAppRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/apps/updateApp/V2AppsUpdateAppRequestBody.yaml
@@ -2,6 +2,10 @@ type: object
 required:
   - project
   - app
+minProperties: 3
+dependentSchemas:
+  oci:
+    maxProperties: 3
 properties:
   project:
     "$ref": "../../../../common/ResourceIdentifier.yaml"

--- a/svc/api/openapi/spec/paths/v2/apps/updateApp/V2AppsUpdateAppRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/apps/updateApp/V2AppsUpdateAppRequestBody.yaml
@@ -29,8 +29,8 @@ properties:
   oci:
     description: |
       Change the default image reference for an OCI-sourced app. This does not
-      create a deployment. Image updates cannot be combined with other changes,
-      and source switching is not supported.
+      create a deployment. It can be combined with other app settings. Source
+      switching is not supported.
     allOf:
       - "$ref": "../../../../common/AppOCI.yaml"
   deleteProtection:
@@ -40,9 +40,7 @@ properties:
       Omit this field to leave the current setting unchanged.
     example: true
 additionalProperties: false
-description: |
-  Provide at least one field to update. Change an OCI app's image in a
-  standalone request; it cannot be combined with other changes.
+description: Provide at least one field to update. Omitted fields remain unchanged.
 examples:
   rename:
     summary: Rename an app by ID

--- a/svc/api/openapi/spec/paths/v2/apps/updateApp/V2AppsUpdateAppRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/apps/updateApp/V2AppsUpdateAppRequestBody.yaml
@@ -1,5 +1,7 @@
 type: object
-required: [project, app]
+required:
+  - project
+  - app
 properties:
   project:
     "$ref": "../../../../common/ResourceIdentifier.yaml"
@@ -30,7 +32,7 @@ properties:
       create a deployment. Image updates cannot be combined with other changes,
       and source switching is not supported.
     allOf:
-      - "$ref": "../../../../common/AppOCIInput.yaml"
+      - "$ref": "../../../../common/AppOCI.yaml"
   deleteProtection:
     type: boolean
     description: |

--- a/svc/api/openapi/spec/paths/v2/apps/updateApp/V2AppsUpdateAppRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/apps/updateApp/V2AppsUpdateAppRequestBody.yaml
@@ -38,15 +38,9 @@ properties:
       Omit this field to leave the current setting unchanged.
     example: true
 additionalProperties: false
-oneOf:
-  - required: [oci]
-  - anyOf:
-      - required: [name]
-      - required: [slug]
-      - required: [git]
-      - required: [deleteProtection]
 description: |
-  Update app settings, or change an OCI app's image in a standalone request.
+  Provide at least one field to update. Change an OCI app's image in a
+  standalone request; it cannot be combined with other changes.
 examples:
   rename:
     summary: Rename an app by ID

--- a/svc/api/openapi/spec/paths/v2/apps/updateApp/V2AppsUpdateAppRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/apps/updateApp/V2AppsUpdateAppRequestBody.yaml
@@ -1,7 +1,5 @@
 type: object
-required:
-  - project
-  - app
+required: [project, app]
 properties:
   project:
     "$ref": "../../../../common/ResourceIdentifier.yaml"
@@ -26,6 +24,13 @@ properties:
     anyOf:
       - "$ref": "../../../../common/AppGitUpdateInput.yaml"
       - type: "null"
+  oci:
+    description: |
+      Change the default image reference for an OCI-sourced app. This does not
+      create a deployment. Image updates cannot be combined with other changes,
+      and source switching is not supported.
+    allOf:
+      - "$ref": "../../../../common/AppOCIInput.yaml"
   deleteProtection:
     type: boolean
     description: |
@@ -33,6 +38,15 @@ properties:
       Omit this field to leave the current setting unchanged.
     example: true
 additionalProperties: false
+oneOf:
+  - required: [oci]
+  - anyOf:
+      - required: [name]
+      - required: [slug]
+      - required: [git]
+      - required: [deleteProtection]
+description: |
+  Update app settings, or change an OCI app's image in a standalone request.
 examples:
   rename:
     summary: Rename an app by ID
@@ -79,3 +93,11 @@ examples:
       project: payments
       app: app_1234abcd
       git: null
+  updateOCIImage:
+    summary: Change the default OCI image
+    description: Update an OCI-sourced app without creating a deployment
+    value:
+      project: payments
+      app: app_1234abcd
+      oci:
+        image: ghcr.io/acme/payments:v2.0.0

--- a/svc/api/openapi/spec/paths/v2/apps/updateApp/V2AppsUpdateAppRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/apps/updateApp/V2AppsUpdateAppRequestBody.yaml
@@ -2,10 +2,29 @@ type: object
 required:
   - project
   - app
-minProperties: 3
+not:
+  allOf:
+    - not:
+        required: [name]
+    - not:
+        required: [slug]
+    - not:
+        required: [git]
+    - not:
+        required: [oci]
+    - not:
+        required: [deleteProtection]
 dependentSchemas:
   oci:
-    maxProperties: 3
+    allOf:
+      - not:
+          required: [name]
+      - not:
+          required: [slug]
+      - not:
+          required: [git]
+      - not:
+          required: [deleteProtection]
 properties:
   project:
     "$ref": "../../../../common/ResourceIdentifier.yaml"

--- a/svc/api/routes/register.go
+++ b/svc/api/routes/register.go
@@ -916,6 +916,7 @@ func Register(srv *zen.Server, svc *Services, info zen.InstanceInfo) {
 		&v2AppsUpdateApp.Handler{
 			DB:            svc.Database,
 			Auditlogs:     svc.Auditlogs,
+			CtrlClient:    svc.CtrlAppClient,
 			GitHubClient:  svc.GitHubClient,
 			GitHubAppName: svc.GitHubAppName,
 		},

--- a/svc/api/routes/v2_apps_list_apps/200_test.go
+++ b/svc/api/routes/v2_apps_list_apps/200_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/ptr"
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
@@ -75,12 +76,14 @@ func TestListAppsSuccessfully(t *testing.T) {
 		require.NotEmpty(t, res.Body.Meta.RequestId)
 		require.Len(t, res.Body.Data, len(seeded))
 		require.False(t, res.Body.Pagination.HasMore)
+		require.NotContains(t, res.RawBody, `"sourceType"`)
 
 		for _, a := range res.Body.Data {
 			slug, ok := seeded[a.Id]
 			require.True(t, ok, "unexpected app %s in response", a.Id)
 			require.True(t, strings.HasPrefix(a.Id, "app_"), "id should have app_ prefix: %s", a.Id)
 			require.Equal(t, slug, a.Slug)
+			require.Empty(t, a.SourceType)
 			require.Nil(t, a.Git, "seeded app has no repo connection")
 			require.NotEmpty(t, a.Name)
 			require.Empty(t, a.CurrentDeploymentId, "freshly seeded app has no active deployment")
@@ -157,6 +160,47 @@ func TestListAppsSuccessfully(t *testing.T) {
 		}
 		require.NotContains(t, res.RawBody, foreignProject.ID, "response must not leak the foreign project ID")
 	})
+}
+
+func TestListAppsReturnsConfiguredOCISource(t *testing.T) {
+	h := testutil.NewHarness(t)
+	route := &handler.Handler{DB: h.DB}
+	h.Register(route)
+
+	workspace := h.Resources().UserWorkspace
+	project := h.CreateProject(seed.CreateProjectRequest{
+		ID:          uid.New(uid.ProjectPrefix),
+		WorkspaceID: workspace.ID,
+		Name:        "OCI Project",
+		Slug:        strings.ToLower(strings.ReplaceAll(uid.New("test"), "_", "-")),
+	})
+	app := h.CreateApp(seed.CreateAppRequest{
+		ID:             uid.New(uid.AppPrefix),
+		WorkspaceID:    workspace.ID,
+		ProjectID:      project.ID,
+		Name:           "OCI API",
+		Slug:           strings.ToLower(strings.ReplaceAll(uid.New("test"), "_", "-")),
+		SourceType:     db.AppsSourceTypeOci,
+		ImageReference: "ghcr.io/acme/api:v1.2.3",
+	})
+	rootKey := h.CreateRootKey(workspace.ID, "app.*.read_app")
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}
+
+	res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{Project: project.ID})
+	require.Equal(t, http.StatusOK, res.Status, "expected 200, received: %s", res.RawBody)
+	require.Len(t, res.Body.Data, 1)
+	require.Equal(t, app.ID, res.Body.Data[0].Id)
+	require.Equal(t, "oci", string(res.Body.Data[0].SourceType))
+	require.Nil(t, res.Body.Data[0].Git)
+	require.NotNil(t, res.Body.Data[0].Oci)
+	require.Equal(t, "ghcr.io/acme/api:v1.2.3", res.Body.Data[0].Oci.Image)
+
+	require.NoError(t, db.Query.DeleteAppSourceOciByAppId(t.Context(), h.DB.RW(), app.ID))
+	res = testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{Project: project.ID})
+	require.Equal(t, http.StatusInternalServerError, res.Status, "missing OCI source must not produce an empty image")
 }
 
 func TestListAppsPagination(t *testing.T) {

--- a/svc/api/routes/v2_apps_list_apps/handler.go
+++ b/svc/api/routes/v2_apps_list_apps/handler.go
@@ -100,15 +100,37 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	rows, pg := pagination.Paginate(rows, p, func(r db.ListAppsByProjectRow) string { return r.ID })
+	for _, row := range rows {
+		if row.SourceType == db.AppsSourceTypeOci && !row.OciImageReference.Valid {
+			return fault.New(
+				"OCI app source is missing",
+				fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
+				fault.Internal("OCI app has no configured image source"),
+				fault.Public("Failed to retrieve apps."),
+			)
+		}
+	}
 
 	data := array.Map(rows, func(row db.ListAppsByProjectRow) openapi.App {
+		var oci *openapi.AppOCI
+		if row.SourceType == db.AppsSourceTypeOci {
+			oci = &openapi.AppOCI{Image: row.OciImageReference.String}
+		}
+		sourceType := openapi.AppSourceType("")
+		switch row.SourceType {
+		case db.AppsSourceTypeGit:
+			sourceType = openapi.Git
+		case db.AppsSourceTypeOci:
+			sourceType = openapi.Oci
+		case db.AppsSourceTypeUnknown:
+		}
 		return openapi.App{
 			Id:                  row.ID,
 			Name:                row.Name,
 			Slug:                row.Slug,
-			SourceType:          "",
-			Git:                 githubapp.GitResponse(row.RepositoryFullName.String, row.DefaultBranch),
-			Oci:                 nil,
+			SourceType:          sourceType,
+			Git:                 githubapp.GitResponse(row.RepositoryFullName.String, row.GithubDefaultBranch.String),
+			Oci:                 oci,
 			CurrentDeploymentId: row.CurrentDeploymentID.String,
 			IsRolledBack:        row.IsRolledBack,
 			DeleteProtection:    row.DeleteProtection.Bool,

--- a/svc/api/routes/v2_apps_list_apps/handler.go
+++ b/svc/api/routes/v2_apps_list_apps/handler.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/unkeyed/unkey/pkg/array"
 	"github.com/unkeyed/unkey/pkg/codes"
 	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/fault"
@@ -100,31 +99,27 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	rows, pg := pagination.Paginate(rows, p, func(r db.ListAppsByProjectRow) string { return r.ID })
-	for _, row := range rows {
-		if row.SourceType == db.AppsSourceTypeOci && !row.OciImageReference.Valid {
-			return fault.New(
-				"OCI app source is missing",
-				fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
-				fault.Internal("OCI app has no configured image source"),
-				fault.Public("Failed to retrieve apps."),
-			)
-		}
-	}
-
-	data := array.Map(rows, func(row db.ListAppsByProjectRow) openapi.App {
+	data := make([]openapi.App, len(rows))
+	for i, row := range rows {
 		var oci *openapi.AppOCI
-		if row.SourceType == db.AppsSourceTypeOci {
-			oci = &openapi.AppOCI{Image: row.OciImageReference.String}
-		}
 		sourceType := openapi.AppSourceType("")
 		switch row.SourceType {
 		case db.AppsSourceTypeGit:
 			sourceType = openapi.Git
 		case db.AppsSourceTypeOci:
+			if !row.OciImageReference.Valid {
+				return fault.New(
+					"OCI app source is missing",
+					fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
+					fault.Internal("OCI app has no configured image source"),
+					fault.Public("Failed to retrieve apps."),
+				)
+			}
 			sourceType = openapi.Oci
+			oci = &openapi.AppOCI{Image: row.OciImageReference.String}
 		case db.AppsSourceTypeUnknown:
 		}
-		return openapi.App{
+		data[i] = openapi.App{
 			Id:                  row.ID,
 			Name:                row.Name,
 			Slug:                row.Slug,
@@ -137,7 +132,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			CreatedAt:           row.CreatedAt,
 			UpdatedAt:           row.UpdatedAt.Int64,
 		}
-	})
+	}
 
 	return s.JSON(http.StatusOK, Response{
 		Meta: openapi.Meta{

--- a/svc/api/routes/v2_apps_update_app/200_test.go
+++ b/svc/api/routes/v2_apps_update_app/200_test.go
@@ -187,22 +187,4 @@ func TestUpdateAppSuccessfully(t *testing.T) {
 		require.True(t, app.DeleteProtection.Bool)
 	})
 
-	t.Run("empty body leaves app unchanged", func(t *testing.T) {
-		id, slug := createApp(t, "Unchanged", "main")
-
-		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{
-			Project: project.ID,
-			App:     id,
-		})
-		require.Equal(t, 200, res.Status, "expected 200, received: %s", res.RawBody)
-		require.Equal(t, "Unchanged", res.Body.Data.Name)
-		require.Equal(t, slug, res.Body.Data.Slug)
-		require.Nil(t, res.Body.Data.Git)
-		require.False(t, res.Body.Data.DeleteProtection)
-
-		app := getApp(t, id)
-		require.Equal(t, "Unchanged", app.Name)
-		require.Equal(t, slug, app.Slug)
-		require.Equal(t, "main", app.DefaultBranch)
-	})
 }

--- a/svc/api/routes/v2_apps_update_app/400_test.go
+++ b/svc/api/routes/v2_apps_update_app/400_test.go
@@ -56,7 +56,7 @@ func TestUpdateAppBadRequest(t *testing.T) {
 			req: handler.Request{
 				Project: validProject,
 				App:     validID,
-				Oci:     &openapi.AppOCIInput{Image: strings.Repeat("a", 253) + ":tag"},
+				Oci:     &openapi.AppOCI{Image: strings.Repeat("a", 253) + ":tag"},
 			},
 		},
 		{name: "git empty object", req: handler.Request{Project: validProject, App: validID, Git: nullable.NewNullableWithValue(openapi.AppGitUpdateInput{})}},
@@ -93,7 +93,7 @@ func TestUpdateAppBadRequest(t *testing.T) {
 				Project: validProject,
 				App:     validID,
 				Name:    ptr.P("App"),
-				Oci:     &openapi.AppOCIInput{Image: "nginx:stable"},
+				Oci:     &openapi.AppOCI{Image: "nginx:stable"},
 			},
 			detail: "Update the OCI image in a separate request.",
 		},

--- a/svc/api/routes/v2_apps_update_app/400_test.go
+++ b/svc/api/routes/v2_apps_update_app/400_test.go
@@ -42,6 +42,7 @@ func TestUpdateAppBadRequest(t *testing.T) {
 		{name: "missing project and app", req: handler.Request{}},
 		{name: "missing app", req: handler.Request{Project: validProject}},
 		{name: "missing project", req: handler.Request{App: validID}},
+		{name: "no updates", req: handler.Request{Project: validProject, App: validID}},
 		{name: "app with invalid chars", req: handler.Request{Project: validProject, App: "app.1234"}},
 		{name: "app too long", req: handler.Request{Project: validProject, App: strings.Repeat("a", 256)}},
 		{name: "project with invalid chars", req: handler.Request{Project: "pay.ments", App: validID}},
@@ -51,6 +52,14 @@ func TestUpdateAppBadRequest(t *testing.T) {
 		{name: "slug too long", req: handler.Request{Project: validProject, App: validID, Slug: ptr.P(strings.Repeat("a", 256))}},
 		{name: "empty name", req: handler.Request{Project: validProject, App: validID, Name: &emptyName}},
 		{name: "name too long", req: handler.Request{Project: validProject, App: validID, Name: &longName}},
+		{
+			name: "OCI image too long",
+			req: handler.Request{
+				Project: validProject,
+				App:     validID,
+				Oci:     &openapi.AppOCIInput{Image: strings.Repeat("a", 253) + ":tag"},
+			},
+		},
 		{name: "git empty object", req: handler.Request{Project: validProject, App: validID, Git: nullable.NewNullableWithValue(openapi.AppGitUpdateInput{})}},
 		{name: "git repository empty", req: handler.Request{Project: validProject, App: validID, Git: nullable.NewNullableWithValue(openapi.AppGitUpdateInput{Repository: ptr.P("")})}},
 		{name: "git repository too long", req: handler.Request{Project: validProject, App: validID, Git: nullable.NewNullableWithValue(openapi.AppGitUpdateInput{Repository: ptr.P(strings.Repeat("a", 256))})}},

--- a/svc/api/routes/v2_apps_update_app/400_test.go
+++ b/svc/api/routes/v2_apps_update_app/400_test.go
@@ -42,6 +42,7 @@ func TestUpdateAppBadRequest(t *testing.T) {
 		{name: "missing project and app", req: handler.Request{}},
 		{name: "missing app", req: handler.Request{Project: validProject}},
 		{name: "missing project", req: handler.Request{App: validID}},
+		{name: "no updates", req: handler.Request{Project: validProject, App: validID}},
 		{name: "app with invalid chars", req: handler.Request{Project: validProject, App: "app.1234"}},
 		{name: "app too long", req: handler.Request{Project: validProject, App: strings.Repeat("a", 256)}},
 		{name: "project with invalid chars", req: handler.Request{Project: "pay.ments", App: validID}},
@@ -64,6 +65,15 @@ func TestUpdateAppBadRequest(t *testing.T) {
 		{name: "git repository too long", req: handler.Request{Project: validProject, App: validID, Git: nullable.NewNullableWithValue(openapi.AppGitUpdateInput{Repository: ptr.P(strings.Repeat("a", 256))})}},
 		{name: "git default branch empty", req: handler.Request{Project: validProject, App: validID, Git: nullable.NewNullableWithValue(openapi.AppGitUpdateInput{Repository: ptr.P("unkeyed/unkey"), DefaultBranch: ptr.P("")})}},
 		{name: "git default branch too long", req: handler.Request{Project: validProject, App: validID, Git: nullable.NewNullableWithValue(openapi.AppGitUpdateInput{Repository: ptr.P("unkeyed/unkey"), DefaultBranch: ptr.P(strings.Repeat("a", 257))})}},
+		{
+			name: "OCI image combined with another update",
+			req: handler.Request{
+				Project: validProject,
+				App:     validID,
+				Name:    ptr.P("App"),
+				Oci:     &openapi.AppOCI{Image: "nginx:stable"},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -74,35 +84,6 @@ func TestUpdateAppBadRequest(t *testing.T) {
 			require.Equal(t, "Bad Request", res.Body.Error.Title)
 			require.Equal(t, http.StatusBadRequest, res.Body.Error.Status)
 			require.Greater(t, len(res.Body.Error.Errors), 0)
-		})
-	}
-
-	runtimeTestCases := []struct {
-		name   string
-		req    handler.Request
-		detail string
-	}{
-		{
-			name:   "no updates",
-			req:    handler.Request{Project: validProject, App: validID},
-			detail: "Provide at least one field to update.",
-		},
-		{
-			name: "OCI image combined with another update",
-			req: handler.Request{
-				Project: validProject,
-				App:     validID,
-				Name:    ptr.P("App"),
-				Oci:     &openapi.AppOCI{Image: "nginx:stable"},
-			},
-			detail: "Update the OCI image in a separate request.",
-		},
-	}
-	for _, tc := range runtimeTestCases {
-		t.Run(tc.name, func(t *testing.T) {
-			res := testutil.CallRoute[handler.Request, openapi.BadRequestErrorResponse](h, route, headers, tc.req)
-			require.Equal(t, http.StatusBadRequest, res.Status, "expected 400, sent: %+v, received: %s", tc.req, res.RawBody)
-			require.Equal(t, tc.detail, res.Body.Error.Detail)
 		})
 	}
 

--- a/svc/api/routes/v2_apps_update_app/400_test.go
+++ b/svc/api/routes/v2_apps_update_app/400_test.go
@@ -42,7 +42,6 @@ func TestUpdateAppBadRequest(t *testing.T) {
 		{name: "missing project and app", req: handler.Request{}},
 		{name: "missing app", req: handler.Request{Project: validProject}},
 		{name: "missing project", req: handler.Request{App: validID}},
-		{name: "no updates", req: handler.Request{Project: validProject, App: validID}},
 		{name: "app with invalid chars", req: handler.Request{Project: validProject, App: "app.1234"}},
 		{name: "app too long", req: handler.Request{Project: validProject, App: strings.Repeat("a", 256)}},
 		{name: "project with invalid chars", req: handler.Request{Project: "pay.ments", App: validID}},
@@ -75,6 +74,35 @@ func TestUpdateAppBadRequest(t *testing.T) {
 			require.Equal(t, "Bad Request", res.Body.Error.Title)
 			require.Equal(t, http.StatusBadRequest, res.Body.Error.Status)
 			require.Greater(t, len(res.Body.Error.Errors), 0)
+		})
+	}
+
+	runtimeTestCases := []struct {
+		name   string
+		req    handler.Request
+		detail string
+	}{
+		{
+			name:   "no updates",
+			req:    handler.Request{Project: validProject, App: validID},
+			detail: "Provide at least one field to update.",
+		},
+		{
+			name: "OCI image combined with another update",
+			req: handler.Request{
+				Project: validProject,
+				App:     validID,
+				Name:    ptr.P("App"),
+				Oci:     &openapi.AppOCIInput{Image: "nginx:stable"},
+			},
+			detail: "Update the OCI image in a separate request.",
+		},
+	}
+	for _, tc := range runtimeTestCases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := testutil.CallRoute[handler.Request, openapi.BadRequestErrorResponse](h, route, headers, tc.req)
+			require.Equal(t, http.StatusBadRequest, res.Status, "expected 400, sent: %+v, received: %s", tc.req, res.RawBody)
+			require.Equal(t, tc.detail, res.Body.Error.Detail)
 		})
 	}
 

--- a/svc/api/routes/v2_apps_update_app/400_test.go
+++ b/svc/api/routes/v2_apps_update_app/400_test.go
@@ -36,13 +36,14 @@ func TestUpdateAppBadRequest(t *testing.T) {
 	longName := strings.Repeat("a", 257)
 
 	testCases := []struct {
-		name string
-		req  handler.Request
+		name       string
+		req        handler.Request
+		wantDetail string
 	}{
 		{name: "missing project and app", req: handler.Request{}},
 		{name: "missing app", req: handler.Request{Project: validProject}},
 		{name: "missing project", req: handler.Request{App: validID}},
-		{name: "no updates", req: handler.Request{Project: validProject, App: validID}},
+		{name: "no updates", req: handler.Request{Project: validProject, App: validID}, wantDetail: "Provide at least one field to update."},
 		{name: "app with invalid chars", req: handler.Request{Project: validProject, App: "app.1234"}},
 		{name: "app too long", req: handler.Request{Project: validProject, App: strings.Repeat("a", 256)}},
 		{name: "project with invalid chars", req: handler.Request{Project: "pay.ments", App: validID}},
@@ -73,6 +74,7 @@ func TestUpdateAppBadRequest(t *testing.T) {
 				Name:    ptr.P("App"),
 				Oci:     &openapi.AppOCI{Image: "nginx:stable"},
 			},
+			wantDetail: "Update the OCI image in a separate request.",
 		},
 		{
 			name: "OCI image combined with slug update",
@@ -82,6 +84,7 @@ func TestUpdateAppBadRequest(t *testing.T) {
 				Slug:    ptr.P(openapi.ResourceIdentifier("new-slug")),
 				Oci:     &openapi.AppOCI{Image: "nginx:stable"},
 			},
+			wantDetail: "Update the OCI image in a separate request.",
 		},
 		{
 			name: "OCI image combined with git update",
@@ -91,6 +94,7 @@ func TestUpdateAppBadRequest(t *testing.T) {
 				Git:     nullable.NewNullNullable[openapi.AppGitUpdateInput](),
 				Oci:     &openapi.AppOCI{Image: "nginx:stable"},
 			},
+			wantDetail: "Update the OCI image in a separate request.",
 		},
 		{
 			name: "OCI image combined with delete protection update",
@@ -100,6 +104,7 @@ func TestUpdateAppBadRequest(t *testing.T) {
 				Oci:              &openapi.AppOCI{Image: "nginx:stable"},
 				DeleteProtection: ptr.P(true),
 			},
+			wantDetail: "Update the OCI image in a separate request.",
 		},
 	}
 
@@ -110,7 +115,12 @@ func TestUpdateAppBadRequest(t *testing.T) {
 			require.NotEmpty(t, res.Body.Meta.RequestId)
 			require.Equal(t, "Bad Request", res.Body.Error.Title)
 			require.Equal(t, http.StatusBadRequest, res.Body.Error.Status)
-			require.Greater(t, len(res.Body.Error.Errors), 0)
+			if tc.wantDetail == "" {
+				require.Greater(t, len(res.Body.Error.Errors), 0)
+			} else {
+				require.Equal(t, tc.wantDetail, res.Body.Error.Detail)
+				require.Empty(t, res.Body.Error.Errors)
+			}
 		})
 	}
 

--- a/svc/api/routes/v2_apps_update_app/400_test.go
+++ b/svc/api/routes/v2_apps_update_app/400_test.go
@@ -66,46 +66,6 @@ func TestUpdateAppBadRequest(t *testing.T) {
 		{name: "git repository too long", req: handler.Request{Project: validProject, App: validID, Git: nullable.NewNullableWithValue(openapi.AppGitUpdateInput{Repository: ptr.P(strings.Repeat("a", 256))})}},
 		{name: "git default branch empty", req: handler.Request{Project: validProject, App: validID, Git: nullable.NewNullableWithValue(openapi.AppGitUpdateInput{Repository: ptr.P("unkeyed/unkey"), DefaultBranch: ptr.P("")})}},
 		{name: "git default branch too long", req: handler.Request{Project: validProject, App: validID, Git: nullable.NewNullableWithValue(openapi.AppGitUpdateInput{Repository: ptr.P("unkeyed/unkey"), DefaultBranch: ptr.P(strings.Repeat("a", 257))})}},
-		{
-			name: "OCI image combined with name update",
-			req: handler.Request{
-				Project: validProject,
-				App:     validID,
-				Name:    ptr.P("App"),
-				Oci:     &openapi.AppOCI{Image: "nginx:stable"},
-			},
-			wantDetail: "Update the OCI image in a separate request.",
-		},
-		{
-			name: "OCI image combined with slug update",
-			req: handler.Request{
-				Project: validProject,
-				App:     validID,
-				Slug:    ptr.P(openapi.ResourceIdentifier("new-slug")),
-				Oci:     &openapi.AppOCI{Image: "nginx:stable"},
-			},
-			wantDetail: "Update the OCI image in a separate request.",
-		},
-		{
-			name: "OCI image combined with git update",
-			req: handler.Request{
-				Project: validProject,
-				App:     validID,
-				Git:     nullable.NewNullNullable[openapi.AppGitUpdateInput](),
-				Oci:     &openapi.AppOCI{Image: "nginx:stable"},
-			},
-			wantDetail: "Update the OCI image in a separate request.",
-		},
-		{
-			name: "OCI image combined with delete protection update",
-			req: handler.Request{
-				Project:          validProject,
-				App:              validID,
-				Oci:              &openapi.AppOCI{Image: "nginx:stable"},
-				DeleteProtection: ptr.P(true),
-			},
-			wantDetail: "Update the OCI image in a separate request.",
-		},
 	}
 
 	for _, tc := range testCases {

--- a/svc/api/routes/v2_apps_update_app/400_test.go
+++ b/svc/api/routes/v2_apps_update_app/400_test.go
@@ -66,12 +66,39 @@ func TestUpdateAppBadRequest(t *testing.T) {
 		{name: "git default branch empty", req: handler.Request{Project: validProject, App: validID, Git: nullable.NewNullableWithValue(openapi.AppGitUpdateInput{Repository: ptr.P("unkeyed/unkey"), DefaultBranch: ptr.P("")})}},
 		{name: "git default branch too long", req: handler.Request{Project: validProject, App: validID, Git: nullable.NewNullableWithValue(openapi.AppGitUpdateInput{Repository: ptr.P("unkeyed/unkey"), DefaultBranch: ptr.P(strings.Repeat("a", 257))})}},
 		{
-			name: "OCI image combined with another update",
+			name: "OCI image combined with name update",
 			req: handler.Request{
 				Project: validProject,
 				App:     validID,
 				Name:    ptr.P("App"),
 				Oci:     &openapi.AppOCI{Image: "nginx:stable"},
+			},
+		},
+		{
+			name: "OCI image combined with slug update",
+			req: handler.Request{
+				Project: validProject,
+				App:     validID,
+				Slug:    ptr.P(openapi.ResourceIdentifier("new-slug")),
+				Oci:     &openapi.AppOCI{Image: "nginx:stable"},
+			},
+		},
+		{
+			name: "OCI image combined with git update",
+			req: handler.Request{
+				Project: validProject,
+				App:     validID,
+				Git:     nullable.NewNullNullable[openapi.AppGitUpdateInput](),
+				Oci:     &openapi.AppOCI{Image: "nginx:stable"},
+			},
+		},
+		{
+			name: "OCI image combined with delete protection update",
+			req: handler.Request{
+				Project:          validProject,
+				App:              validID,
+				Oci:              &openapi.AppOCI{Image: "nginx:stable"},
+				DeleteProtection: ptr.P(true),
 			},
 		},
 	}

--- a/svc/api/routes/v2_apps_update_app/git_test.go
+++ b/svc/api/routes/v2_apps_update_app/git_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/oapi-codegen/nullable"
 	"github.com/stretchr/testify/require"
+	ctrlv1 "github.com/unkeyed/unkey/gen/proto/ctrl/v1"
 	"github.com/unkeyed/unkey/pkg/db"
 	github "github.com/unkeyed/unkey/pkg/github"
 	"github.com/unkeyed/unkey/pkg/ptr"
@@ -88,10 +89,7 @@ func TestUpdateAppConnectRepository(t *testing.T) {
 		require.Equal(t, "unkeyed/unkey", conn.RepositoryFullName)
 		require.Equal(t, int64(42), conn.RepositoryID)
 		require.Equal(t, int64(12345), conn.InstallationID)
-
-		app, err := db.Query.FindAppById(ctx, h.DB.RO(), id)
-		require.NoError(t, err)
-		require.Equal(t, "main", app.DefaultBranch)
+		require.Equal(t, "main", conn.DefaultBranch.String)
 
 		requireAuditEvent(ctx, t, h, id, "app.connect_repository")
 	})
@@ -109,9 +107,9 @@ func TestUpdateAppConnectRepository(t *testing.T) {
 		git := res.Body.Data.Git
 		require.Equal(t, "develop", *git.DefaultBranch)
 
-		app, err := db.Query.FindAppById(ctx, h.DB.RO(), id)
+		conn, err := db.Query.FindGithubRepoConnectionByAppId(ctx, h.DB.RO(), id)
 		require.NoError(t, err)
-		require.Equal(t, "develop", app.DefaultBranch)
+		require.Equal(t, "develop", conn.DefaultBranch.String)
 	})
 
 	t.Run("replace keeps the existing branch when none passed", func(t *testing.T) {
@@ -123,7 +121,7 @@ func TestUpdateAppConnectRepository(t *testing.T) {
 			ProjectID:     project.ID,
 			Name:          "App",
 			Slug:          appSlug(),
-			DefaultBranch: "keep-me",
+			DefaultBranch: "stale-app-value",
 		})
 		id := app.ID
 
@@ -134,6 +132,7 @@ func TestUpdateAppConnectRepository(t *testing.T) {
 			InstallationID:     999,
 			RepositoryID:       1,
 			RepositoryFullName: "old/repo",
+			DefaultBranch:      sql.NullString{Valid: true, String: "keep-me"},
 			CreatedAt:          time.Now().UnixMilli(),
 			UpdatedAt:          sql.NullInt64{Valid: false},
 		}))
@@ -152,10 +151,7 @@ func TestUpdateAppConnectRepository(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "unkeyed/unkey", conn.RepositoryFullName)
 		require.Equal(t, int64(12345), conn.InstallationID)
-
-		reloaded, err := db.Query.FindAppById(ctx, h.DB.RO(), id)
-		require.NoError(t, err)
-		require.Equal(t, "keep-me", reloaded.DefaultBranch)
+		require.Equal(t, "keep-me", conn.DefaultBranch.String)
 	})
 
 	t.Run("retarget branch only, repository omitted", func(t *testing.T) {
@@ -167,6 +163,7 @@ func TestUpdateAppConnectRepository(t *testing.T) {
 			InstallationID:     12345,
 			RepositoryID:       42,
 			RepositoryFullName: "unkeyed/unkey",
+			DefaultBranch:      sql.NullString{Valid: true, String: "main"},
 			CreatedAt:          time.Now().UnixMilli(),
 			UpdatedAt:          sql.NullInt64{Valid: false},
 		}))
@@ -181,9 +178,13 @@ func TestUpdateAppConnectRepository(t *testing.T) {
 		require.Equal(t, "unkeyed/unkey", git.Repository, "repository stays connected")
 		require.Equal(t, "release", *git.DefaultBranch)
 
+		conn, err := db.Query.FindGithubRepoConnectionByAppId(ctx, h.DB.RO(), id)
+		require.NoError(t, err)
+		require.Equal(t, "release", conn.DefaultBranch.String)
+
 		app, err := db.Query.FindAppById(ctx, h.DB.RO(), id)
 		require.NoError(t, err)
-		require.Equal(t, "release", app.DefaultBranch)
+		require.Empty(t, app.DefaultBranch, "branch updates must not write the legacy app column")
 	})
 
 	t.Run("retarget branch without a connection fails", func(t *testing.T) {
@@ -224,11 +225,12 @@ func TestUpdateAppDisconnectRepository(t *testing.T) {
 		Slug:        appSlug(),
 	})
 	app := h.CreateApp(seed.CreateAppRequest{
-		ID:          uid.New(uid.AppPrefix),
-		WorkspaceID: workspace.ID,
-		ProjectID:   project.ID,
-		Name:        "App",
-		Slug:        appSlug(),
+		ID:            uid.New(uid.AppPrefix),
+		WorkspaceID:   workspace.ID,
+		ProjectID:     project.ID,
+		Name:          "App",
+		Slug:          appSlug(),
+		DefaultBranch: "stale-app-value",
 	})
 
 	require.NoError(t, db.Query.InsertGithubRepoConnection(ctx, h.DB.RW(), db.InsertGithubRepoConnectionParams{
@@ -238,6 +240,7 @@ func TestUpdateAppDisconnectRepository(t *testing.T) {
 		InstallationID:     555,
 		RepositoryID:       7,
 		RepositoryFullName: "unkeyed/unkey",
+		DefaultBranch:      sql.NullString{Valid: true, String: "main"},
 		CreatedAt:          time.Now().UnixMilli(),
 		UpdatedAt:          sql.NullInt64{Valid: false},
 	}))
@@ -253,9 +256,9 @@ func TestUpdateAppDisconnectRepository(t *testing.T) {
 	_, err := db.Query.FindGithubRepoConnectionByAppId(ctx, h.DB.RO(), app.ID)
 	require.True(t, db.IsNotFound(err), "connection row should be deleted")
 
-	cleared, err := db.Query.FindAppById(ctx, h.DB.RO(), app.ID)
+	unchanged, err := db.Query.FindAppById(ctx, h.DB.RO(), app.ID)
 	require.NoError(t, err)
-	require.Empty(t, cleared.DefaultBranch, "default branch should be cleared on disconnect")
+	require.Equal(t, "stale-app-value", unchanged.DefaultBranch, "disconnect must not write the legacy app column")
 
 	requireAuditEvent(ctx, t, h, app.ID, "app.disconnect_repository")
 }
@@ -339,6 +342,147 @@ func TestUpdateAppConnectRepositoryForbidden(t *testing.T) {
 		Git:     nullable.NewNullableWithValue(openapi.AppGitUpdateInput{Repository: ptr.P("unkeyed/unkey")}),
 	})
 	require.Equal(t, http.StatusForbidden, res.Status, "expected 403, received: %s", res.RawBody)
+}
+
+func TestUpdateAppOCIImage(t *testing.T) {
+	h := testutil.NewHarness(t)
+	ctrlClient := &testutil.MockAppClient{
+		UpdateOciImageSourceFunc: func(_ context.Context, _ *ctrlv1.UpdateOciImageSourceRequest) (*ctrlv1.UpdateOciImageSourceResponse, error) {
+			return &ctrlv1.UpdateOciImageSourceResponse{ImageReference: "index.docker.io/library/nginx:1.27"}, nil
+		},
+	}
+	route := &handler.Handler{
+		DB:         h.DB,
+		Auditlogs:  h.Auditlogs,
+		CtrlClient: ctrlClient,
+	}
+	h.Register(route)
+
+	workspace := h.Resources().UserWorkspace
+	rootKey := h.CreateRootKey(workspace.ID, "app.*.update_app")
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}
+	project := h.CreateProject(seed.CreateProjectRequest{
+		ID:          uid.New(uid.ProjectPrefix),
+		WorkspaceID: workspace.ID,
+		Name:        "OCI",
+		Slug:        appSlug(),
+	})
+	app := h.CreateApp(seed.CreateAppRequest{
+		ID:          uid.New(uid.AppPrefix),
+		WorkspaceID: workspace.ID,
+		ProjectID:   project.ID,
+		Name:        "OCI app",
+		Slug:        appSlug(),
+		SourceType:  db.AppsSourceTypeOci,
+	})
+
+	res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{
+		Project: project.ID,
+		App:     app.ID,
+		Oci: &openapi.AppOCIInput{
+			Image: "nginx:1.27",
+		},
+	})
+	require.Equal(t, http.StatusOK, res.Status, "expected 200, received: %s", res.RawBody)
+	require.Equal(t, "oci", string(res.Body.Data.SourceType))
+	require.NotNil(t, res.Body.Data.Oci)
+	require.Equal(t, "index.docker.io/library/nginx:1.27", res.Body.Data.Oci.Image)
+	require.Nil(t, res.Body.Data.Git)
+	require.Len(t, ctrlClient.UpdateOciImageSourceCalls, 1)
+	call := ctrlClient.UpdateOciImageSourceCalls[0]
+	require.Equal(t, workspace.ID, call.GetWorkspaceId())
+	require.Equal(t, app.ID, call.GetAppId())
+	require.Equal(t, "nginx:1.27", call.GetImageReference())
+	require.NotNil(t, call.GetActor())
+}
+
+func TestUpdateAppRejectsSourceSwitching(t *testing.T) {
+	h := testutil.NewHarness(t)
+	ctrlClient := &testutil.MockAppClient{}
+	route := &handler.Handler{
+		DB:         h.DB,
+		Auditlogs:  h.Auditlogs,
+		CtrlClient: ctrlClient,
+	}
+	h.Register(route)
+
+	workspace := h.Resources().UserWorkspace
+	rootKey := h.CreateRootKey(workspace.ID, "app.*.update_app", "app.*.connect_repository")
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}
+	project := h.CreateProject(seed.CreateProjectRequest{
+		ID:          uid.New(uid.ProjectPrefix),
+		WorkspaceID: workspace.ID,
+		Name:        "Sources",
+		Slug:        appSlug(),
+	})
+	createApp := func(t *testing.T, sourceType db.AppsSourceType) db.App {
+		t.Helper()
+		return h.CreateApp(seed.CreateAppRequest{
+			ID:          uid.New(uid.AppPrefix),
+			WorkspaceID: workspace.ID,
+			ProjectID:   project.ID,
+			Name:        "App",
+			Slug:        appSlug(),
+			SourceType:  sourceType,
+		})
+	}
+
+	t.Run("git update on OCI app", func(t *testing.T) {
+		app := createApp(t, db.AppsSourceTypeOci)
+		res := testutil.CallRoute[handler.Request, openapi.BadRequestErrorResponse](h, route, headers, handler.Request{
+			Project: project.ID,
+			App:     app.ID,
+			Git:     nullable.NewNullNullable[openapi.AppGitUpdateInput](),
+		})
+		require.Equal(t, http.StatusBadRequest, res.Status, "expected 400, received: %s", res.RawBody)
+	})
+
+	for _, sourceType := range []db.AppsSourceType{db.AppsSourceTypeGit, db.AppsSourceTypeUnknown} {
+		t.Run("image update on "+string(sourceType)+" app", func(t *testing.T) {
+			app := createApp(t, sourceType)
+			res := testutil.CallRoute[handler.Request, openapi.BadRequestErrorResponse](h, route, headers, handler.Request{
+				Project: project.ID,
+				App:     app.ID,
+				Oci:     &openapi.AppOCIInput{Image: "ghcr.io/acme/api:v2"},
+			})
+			require.Equal(t, http.StatusBadRequest, res.Status, "expected 400, received: %s", res.RawBody)
+		})
+	}
+
+	t.Run("git and image together", func(t *testing.T) {
+		app := createApp(t, db.AppsSourceTypeOci)
+		res := testutil.CallRoute[handler.Request, openapi.BadRequestErrorResponse](h, route, headers, handler.Request{
+			Project: project.ID,
+			App:     app.ID,
+			Git:     nullable.NewNullNullable[openapi.AppGitUpdateInput](),
+			Oci:     &openapi.AppOCIInput{Image: "ghcr.io/acme/api:v2"},
+		})
+		require.Equal(t, http.StatusBadRequest, res.Status, "expected 400, received: %s", res.RawBody)
+	})
+
+	t.Run("metadata and image together", func(t *testing.T) {
+		app := createApp(t, db.AppsSourceTypeOci)
+		originalName := app.Name
+		newName := "New name"
+		res := testutil.CallRoute[handler.Request, openapi.BadRequestErrorResponse](h, route, headers, handler.Request{
+			Project: project.ID,
+			App:     app.ID,
+			Name:    &newName,
+			Oci:     &openapi.AppOCIInput{Image: "ghcr.io/acme/api:v2"},
+		})
+		require.Equal(t, http.StatusBadRequest, res.Status, "expected 400, received: %s", res.RawBody)
+		reloaded, err := db.Query.FindAppById(context.Background(), h.DB.RO(), app.ID)
+		require.NoError(t, err)
+		require.Equal(t, originalName, reloaded.Name)
+	})
+
+	require.Empty(t, ctrlClient.UpdateOciImageSourceCalls)
 }
 
 func requireAuditEvent(ctx context.Context, t *testing.T, h *testutil.Harness, targetID, event string) {

--- a/svc/api/routes/v2_apps_update_app/git_test.go
+++ b/svc/api/routes/v2_apps_update_app/git_test.go
@@ -344,7 +344,7 @@ func TestUpdateAppConnectRepositoryForbidden(t *testing.T) {
 	require.Equal(t, http.StatusForbidden, res.Status, "expected 403, received: %s", res.RawBody)
 }
 
-func TestUpdateAppOCIImage(t *testing.T) {
+func TestUpdateAppOCIImageWithAppSettings(t *testing.T) {
 	h := testutil.NewHarness(t)
 	ctrlClient := &testutil.MockAppClient{
 		UpdateOciImageSourceFunc: func(_ context.Context, _ *ctrlv1.UpdateOciImageSourceRequest) (*ctrlv1.UpdateOciImageSourceResponse, error) {
@@ -378,10 +378,15 @@ func TestUpdateAppOCIImage(t *testing.T) {
 		Slug:        appSlug(),
 		SourceType:  db.AppsSourceTypeOci,
 	})
+	updatedName := "Updated OCI app"
+	updatedSlug := appSlug()
 
 	res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{
-		Project: project.ID,
-		App:     app.ID,
+		Project:          project.ID,
+		App:              app.ID,
+		Name:             &updatedName,
+		Slug:             &updatedSlug,
+		DeleteProtection: ptr.P(true),
 		Oci: &openapi.AppOCI{
 			Image: "nginx:1.27",
 		},
@@ -391,12 +396,21 @@ func TestUpdateAppOCIImage(t *testing.T) {
 	require.NotNil(t, res.Body.Data.Oci)
 	require.Equal(t, "index.docker.io/library/nginx:1.27", res.Body.Data.Oci.Image)
 	require.Nil(t, res.Body.Data.Git)
+	require.Equal(t, updatedName, res.Body.Data.Name)
+	require.Equal(t, updatedSlug, res.Body.Data.Slug)
+	require.True(t, res.Body.Data.DeleteProtection)
 	require.Len(t, ctrlClient.UpdateOciImageSourceCalls, 1)
 	call := ctrlClient.UpdateOciImageSourceCalls[0]
 	require.Equal(t, workspace.ID, call.GetWorkspaceId())
 	require.Equal(t, app.ID, call.GetAppId())
 	require.Equal(t, "nginx:1.27", call.GetImageReference())
 	require.NotNil(t, call.GetActor())
+
+	updatedApp, err := db.Query.FindAppById(context.Background(), h.DB.RO(), app.ID)
+	require.NoError(t, err)
+	require.Equal(t, updatedName, updatedApp.Name)
+	require.Equal(t, updatedSlug, updatedApp.Slug)
+	require.True(t, updatedApp.DeleteProtection.Bool)
 }
 
 func TestUpdateAppRejectsSourceSwitching(t *testing.T) {
@@ -464,22 +478,6 @@ func TestUpdateAppRejectsSourceSwitching(t *testing.T) {
 			Oci:     &openapi.AppOCI{Image: "ghcr.io/acme/api:v2"},
 		})
 		require.Equal(t, http.StatusBadRequest, res.Status, "expected 400, received: %s", res.RawBody)
-	})
-
-	t.Run("metadata and image together", func(t *testing.T) {
-		app := createApp(t, db.AppsSourceTypeOci)
-		originalName := app.Name
-		newName := "New name"
-		res := testutil.CallRoute[handler.Request, openapi.BadRequestErrorResponse](h, route, headers, handler.Request{
-			Project: project.ID,
-			App:     app.ID,
-			Name:    &newName,
-			Oci:     &openapi.AppOCI{Image: "ghcr.io/acme/api:v2"},
-		})
-		require.Equal(t, http.StatusBadRequest, res.Status, "expected 400, received: %s", res.RawBody)
-		reloaded, err := db.Query.FindAppById(context.Background(), h.DB.RO(), app.ID)
-		require.NoError(t, err)
-		require.Equal(t, originalName, reloaded.Name)
 	})
 
 	require.Empty(t, ctrlClient.UpdateOciImageSourceCalls)

--- a/svc/api/routes/v2_apps_update_app/git_test.go
+++ b/svc/api/routes/v2_apps_update_app/git_test.go
@@ -382,7 +382,7 @@ func TestUpdateAppOCIImage(t *testing.T) {
 	res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{
 		Project: project.ID,
 		App:     app.ID,
-		Oci: &openapi.AppOCIInput{
+		Oci: &openapi.AppOCI{
 			Image: "nginx:1.27",
 		},
 	})
@@ -449,7 +449,7 @@ func TestUpdateAppRejectsSourceSwitching(t *testing.T) {
 			res := testutil.CallRoute[handler.Request, openapi.BadRequestErrorResponse](h, route, headers, handler.Request{
 				Project: project.ID,
 				App:     app.ID,
-				Oci:     &openapi.AppOCIInput{Image: "ghcr.io/acme/api:v2"},
+				Oci:     &openapi.AppOCI{Image: "ghcr.io/acme/api:v2"},
 			})
 			require.Equal(t, http.StatusBadRequest, res.Status, "expected 400, received: %s", res.RawBody)
 		})
@@ -461,7 +461,7 @@ func TestUpdateAppRejectsSourceSwitching(t *testing.T) {
 			Project: project.ID,
 			App:     app.ID,
 			Git:     nullable.NewNullNullable[openapi.AppGitUpdateInput](),
-			Oci:     &openapi.AppOCIInput{Image: "ghcr.io/acme/api:v2"},
+			Oci:     &openapi.AppOCI{Image: "ghcr.io/acme/api:v2"},
 		})
 		require.Equal(t, http.StatusBadRequest, res.Status, "expected 400, received: %s", res.RawBody)
 	})
@@ -474,7 +474,7 @@ func TestUpdateAppRejectsSourceSwitching(t *testing.T) {
 			Project: project.ID,
 			App:     app.ID,
 			Name:    &newName,
-			Oci:     &openapi.AppOCIInput{Image: "ghcr.io/acme/api:v2"},
+			Oci:     &openapi.AppOCI{Image: "ghcr.io/acme/api:v2"},
 		})
 		require.Equal(t, http.StatusBadRequest, res.Status, "expected 400, received: %s", res.RawBody)
 		reloaded, err := db.Query.FindAppById(context.Background(), h.DB.RO(), app.ID)

--- a/svc/api/routes/v2_apps_update_app/handler.go
+++ b/svc/api/routes/v2_apps_update_app/handler.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/oapi-codegen/nullable"
+	ctrlv1 "github.com/unkeyed/unkey/gen/proto/ctrl/v1"
+	"github.com/unkeyed/unkey/gen/rpc/ctrl"
 	"github.com/unkeyed/unkey/internal/services/auditlogs"
 	"github.com/unkeyed/unkey/pkg/auditlog"
 	"github.com/unkeyed/unkey/pkg/codes"
@@ -16,6 +18,7 @@ import (
 	github "github.com/unkeyed/unkey/pkg/github"
 	"github.com/unkeyed/unkey/pkg/rbac"
 	"github.com/unkeyed/unkey/pkg/zen"
+	"github.com/unkeyed/unkey/svc/api/internal/ctrlclient"
 	"github.com/unkeyed/unkey/svc/api/internal/githubapp"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
@@ -26,8 +29,9 @@ type (
 )
 
 type Handler struct {
-	DB        db.Database
-	Auditlogs auditlogs.AuditLogService
+	DB         db.Database
+	Auditlogs  auditlogs.AuditLogService
+	CtrlClient ctrl.AppServiceClient
 
 	// GitHubClient resolves and verifies repositories for the `git` connection.
 	// GitHubAppName is the App slug used to build actionable install URLs in
@@ -53,6 +57,14 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	req, err := zen.BindBody[Request](s)
 	if err != nil {
 		return err
+	}
+	if req.Oci != nil && (req.Git.IsSpecified() || req.Name != nil || req.Slug != nil || req.DeleteProtection != nil) {
+		return fault.New(
+			"OCI image update combined with other changes",
+			fault.Code(codes.App.Validation.InvalidInput.URN()),
+			fault.Internal("image updates must be standalone"),
+			fault.Public("Update the OCI image in a separate request."),
+		)
 	}
 
 	// Group the app.update and repository connect/disconnect events this request
@@ -101,6 +113,22 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 		// connect_repository gates every git change, disconnect included.
 		gitSpecified := req.Git.IsSpecified()
+		if gitSpecified && app.SourceType == db.AppsSourceTypeOci {
+			return openapi.App{}, fault.New(
+				"git update is incompatible with app source",
+				fault.Code(codes.App.Validation.InvalidInput.URN()),
+				fault.Internal("cannot update git configuration for an OCI-sourced app"),
+				fault.Public("Git configuration cannot be updated for OCI-sourced apps."),
+			)
+		}
+		if req.Oci != nil && app.SourceType != db.AppsSourceTypeOci {
+			return openapi.App{}, fault.New(
+				"image update is incompatible with app source",
+				fault.Code(codes.App.Validation.InvalidInput.URN()),
+				fault.Internal("cannot update OCI image configuration for a non-OCI app"),
+				fault.Public("OCI image configuration can only be updated for OCI-sourced apps."),
+			)
+		}
 		if gitSpecified {
 			err = principal.Authorize(rbac.Or(
 				rbac.T(rbac.Tuple{
@@ -128,8 +156,6 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			Name:                      "",
 			SlugSpecified:             0,
 			Slug:                      "",
-			DefaultBranchSpecified:    0,
-			DefaultBranch:             "",
 			DeleteProtectionSpecified: 0,
 			DeleteProtection:          sql.NullBool{Valid: false, Bool: false},
 		}
@@ -157,20 +183,18 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 		// gitState is the connection echoed in the response: current when git is
 		// unspecified, nil on disconnect, the new repository on connect.
-		gitState, err := h.applyGitChange(ctx, tx, app, req.Git, &update)
+		gitState, err := h.applyGitChange(ctx, tx, app, req.Git)
 		if err != nil {
 			return openapi.App{}, err
 		}
 
-		// appColumnsChanged tracks user-facing app fields (an `app.update` event);
-		// a git connect also writes the default branch, but that is audited under
-		// the `app.connect_repository` event instead.
+		// appColumnsChanged tracks user-facing app fields (an `app.update` event).
 		appColumnsChanged := update.NameSpecified == 1 || update.SlugSpecified == 1 || update.DeleteProtectionSpecified == 1
 
-		// Persist the app row only when a user field or the default branch changed.
+		// Persist the app row only when one of its own fields changed.
 		// updatedAt is reflected in the response only when a write actually happened.
 		responseUpdatedAt := app.UpdatedAt.Int64
-		if appColumnsChanged || update.DefaultBranchSpecified == 1 {
+		if appColumnsChanged {
 			if err = db.Query.UpdateApp(ctx, tx, update); err != nil {
 				if db.IsDuplicateKeyError(err) {
 					return openapi.App{}, fault.Wrap(
@@ -257,13 +281,36 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			}
 		}
 
+		var oci *openapi.AppOCI
+		if app.SourceType == db.AppsSourceTypeOci {
+			imageReference := ""
+			if req.Oci != nil {
+				imageReference = req.Oci.Image
+			} else {
+				ociSource, ociErr := db.Query.FindAppSourceOciByAppId(ctx, tx, app.ID)
+				if ociErr != nil {
+					return openapi.App{}, ociErr
+				}
+				imageReference = ociSource.ImageReference
+			}
+			oci = &openapi.AppOCI{Image: imageReference}
+		}
+		sourceType := openapi.AppSourceType("")
+		switch app.SourceType {
+		case db.AppsSourceTypeGit:
+			sourceType = openapi.Git
+		case db.AppsSourceTypeOci:
+			sourceType = openapi.Oci
+		case db.AppsSourceTypeUnknown:
+		}
+
 		return openapi.App{
 			Id:                  app.ID,
 			Name:                name,
 			Slug:                slug,
-			SourceType:          "",
+			SourceType:          sourceType,
 			Git:                 gitState,
-			Oci:                 nil,
+			Oci:                 oci,
 			CurrentDeploymentId: app.CurrentDeploymentID.String,
 			IsRolledBack:        app.IsRolledBack,
 			DeleteProtection:    deleteProtection,
@@ -275,6 +322,23 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
+	if req.Oci != nil {
+		actor, actorErr := ctrlclient.Actor(s)
+		if actorErr != nil {
+			return actorErr
+		}
+		ctrlRes, ctrlErr := h.CtrlClient.UpdateOciImageSource(ctx, &ctrlv1.UpdateOciImageSourceRequest{
+			WorkspaceId:    principal.WorkspaceID,
+			AppId:          data.Id,
+			ImageReference: req.Oci.Image,
+			Actor:          actor,
+		})
+		if ctrlErr != nil {
+			return ctrlclient.HandleError(ctrlErr, "update OCI image source")
+		}
+		data.Oci = &openapi.AppOCI{Image: ctrlRes.GetImageReference()}
+	}
+
 	return s.JSON(http.StatusOK, Response{
 		Meta: openapi.Meta{
 			RequestId: s.RequestID(),
@@ -284,16 +348,12 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 }
 
 // applyGitChange applies the `git` field to the app's repository connection and
-// returns the connection state to reflect in the response. It also stamps the
-// resulting default branch onto `update` (the resolved or overridden branch on
-// connect/retarget, empty on disconnect) so the app row is written in the same
-// transaction.
+// returns the connection state to reflect in the response.
 func (h *Handler) applyGitChange(
 	ctx context.Context,
 	tx db.DBTX,
 	app db.App,
 	git nullable.Nullable[openapi.AppGitUpdateInput],
-	update *db.UpdateAppParams,
 ) (*openapi.AppGit, error) {
 
 	if !git.IsSpecified() {
@@ -310,12 +370,11 @@ func (h *Handler) applyGitChange(
 				fault.Public("Failed to retrieve app."),
 			)
 		}
-		return githubapp.GitResponse(conn.RepositoryFullName, app.DefaultBranch), nil
+		return githubapp.GitResponse(conn.RepositoryFullName, conn.DefaultBranch.String), nil
 	}
 
 	if git.IsNull() {
-		// Disconnect: drop the connection and clear the tracked branch, which has
-		// no meaning without a repository.
+		// Disconnect: drop the connection and its source-owned branch.
 		if err := db.Query.DeleteGithubRepoConnectionsByAppId(ctx, tx, app.ID); err != nil {
 			return nil, fault.Wrap(
 				err,
@@ -324,8 +383,6 @@ func (h *Handler) applyGitChange(
 				fault.Public("Failed to disconnect the GitHub repository."),
 			)
 		}
-		update.DefaultBranch = ""
-		update.DefaultBranchSpecified = 1
 		return githubapp.GitResponse("", ""), nil
 	}
 
@@ -354,8 +411,28 @@ func (h *Handler) applyGitChange(
 		}
 
 		branch := *requested.DefaultBranch
-		update.DefaultBranch = branch
-		update.DefaultBranchSpecified = 1
+		rowsAffected, updateErr := db.Query.UpdateGithubRepoConnectionDefaultBranch(ctx, tx, db.UpdateGithubRepoConnectionDefaultBranchParams{
+			DefaultBranch: sql.NullString{Valid: true, String: branch},
+			UpdatedAt:     sql.NullInt64{Valid: true, Int64: time.Now().UnixMilli()},
+			WorkspaceID:   app.WorkspaceID,
+			AppID:         app.ID,
+		})
+		if updateErr != nil {
+			return nil, fault.Wrap(
+				updateErr,
+				fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
+				fault.Internal("failed to update github connection default branch"),
+				fault.Public("Failed to update the branch tracked by this app."),
+			)
+		}
+		if rowsAffected != 1 {
+			return nil, fault.New(
+				"repository connection changed during update",
+				fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
+				fault.Internal(fmt.Sprintf("expected to update one github connection, updated %d", rowsAffected)),
+				fault.Public("Failed to update the branch tracked by this app."),
+			)
+		}
 		return githubapp.GitResponse(conn.RepositoryFullName, branch), nil
 	}
 
@@ -388,8 +465,10 @@ func (h *Handler) applyGitChange(
 	// swapping the repository never silently retargets it. An explicit
 	// defaultBranch always wins over both.
 	fallback := resolved.Repository.DefaultBranch
-	if _, connErr := db.Query.FindGithubRepoConnectionByAppId(ctx, tx, app.ID); connErr == nil {
-		fallback = app.DefaultBranch
+	if existing, connErr := db.Query.FindGithubRepoConnectionByAppId(ctx, tx, app.ID); connErr == nil {
+		if existing.DefaultBranch.Valid && existing.DefaultBranch.String != "" {
+			fallback = existing.DefaultBranch.String
+		}
 	} else if !db.IsNotFound(connErr) {
 		return nil, fault.Wrap(
 			connErr,
@@ -399,8 +478,6 @@ func (h *Handler) applyGitChange(
 		)
 	}
 	branch := githubapp.DefaultBranch(fallback, requested.DefaultBranch)
-	update.DefaultBranch = branch
-	update.DefaultBranchSpecified = 1
 
 	now := time.Now().UnixMilli()
 	if err = db.Query.UpsertGithubRepoConnection(ctx, tx, db.UpsertGithubRepoConnectionParams{
@@ -410,7 +487,7 @@ func (h *Handler) applyGitChange(
 		InstallationID:     resolved.InstallationID,
 		RepositoryID:       resolved.Repository.ID,
 		RepositoryFullName: resolved.Repository.FullName,
-		DefaultBranch:      sql.NullString{String: branch, Valid: true},
+		DefaultBranch:      sql.NullString{Valid: true, String: branch},
 		CreatedAt:          now,
 		UpdatedAt:          sql.NullInt64{Valid: true, Int64: now},
 	}); err != nil {
@@ -421,9 +498,6 @@ func (h *Handler) applyGitChange(
 			fault.Public("Failed to connect the GitHub repository."),
 		)
 	}
-
-	update.DefaultBranch = branch
-	update.DefaultBranchSpecified = 1
 
 	return githubapp.GitResponse(resolved.Repository.FullName, branch), nil
 }

--- a/svc/api/routes/v2_apps_update_app/handler.go
+++ b/svc/api/routes/v2_apps_update_app/handler.go
@@ -58,6 +58,23 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	if err != nil {
 		return err
 	}
+	gitSpecified := req.Git.IsSpecified()
+	if req.Name == nil && req.Slug == nil && !gitSpecified && req.Oci == nil && req.DeleteProtection == nil {
+		return fault.New(
+			"no app updates provided",
+			fault.Code(codes.App.Validation.InvalidInput.URN()),
+			fault.Internal("request has no update fields"),
+			fault.Public("Provide at least one field to update."),
+		)
+	}
+	if req.Oci != nil && (req.Name != nil || req.Slug != nil || gitSpecified || req.DeleteProtection != nil) {
+		return fault.New(
+			"OCI image update must be standalone",
+			fault.Code(codes.App.Validation.InvalidInput.URN()),
+			fault.Internal("OCI image update was combined with another update field"),
+			fault.Public("Update the OCI image in a separate request."),
+		)
+	}
 
 	// Group the app.update and repository connect/disconnect events this request
 	// emits under one correlation id.
@@ -104,7 +121,6 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		}
 
 		// connect_repository gates every git change, disconnect included.
-		gitSpecified := req.Git.IsSpecified()
 		if gitSpecified && app.SourceType == db.AppsSourceTypeOci {
 			return openapi.App{}, fault.New(
 				"git update is incompatible with app source",

--- a/svc/api/routes/v2_apps_update_app/handler.go
+++ b/svc/api/routes/v2_apps_update_app/handler.go
@@ -58,22 +58,6 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	if err != nil {
 		return err
 	}
-	if req.Oci == nil && !req.Git.IsSpecified() && req.Name == nil && req.Slug == nil && req.DeleteProtection == nil {
-		return fault.New(
-			"empty update",
-			fault.Code(codes.App.Validation.InvalidInput.URN()),
-			fault.Internal("no updatable fields in request"),
-			fault.Public("Provide at least one field to update."),
-		)
-	}
-	if req.Oci != nil && (req.Git.IsSpecified() || req.Name != nil || req.Slug != nil || req.DeleteProtection != nil) {
-		return fault.New(
-			"OCI image update combined with other changes",
-			fault.Code(codes.App.Validation.InvalidInput.URN()),
-			fault.Internal("image updates must be standalone"),
-			fault.Public("Update the OCI image in a separate request."),
-		)
-	}
 
 	// Group the app.update and repository connect/disconnect events this request
 	// emits under one correlation id.

--- a/svc/api/routes/v2_apps_update_app/handler.go
+++ b/svc/api/routes/v2_apps_update_app/handler.go
@@ -325,7 +325,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			return actorErr
 		}
 		ctrlRes, ctrlErr := h.CtrlClient.UpdateOciImageSource(ctx, &ctrlv1.UpdateOciImageSourceRequest{
-			WorkspaceId:    principal.WorkspaceID,
+			WorkspaceId:    principal.AuthorizedWorkspaceID,
 			AppId:          data.Id,
 			ImageReference: req.Oci.Image,
 			Actor:          actor,

--- a/svc/api/routes/v2_apps_update_app/handler.go
+++ b/svc/api/routes/v2_apps_update_app/handler.go
@@ -67,14 +67,6 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			fault.Public("Provide at least one field to update."),
 		)
 	}
-	if req.Oci != nil && (req.Name != nil || req.Slug != nil || gitSpecified || req.DeleteProtection != nil) {
-		return fault.New(
-			"OCI image update must be standalone",
-			fault.Code(codes.App.Validation.InvalidInput.URN()),
-			fault.Internal("OCI image update was combined with another update field"),
-			fault.Public("Update the OCI image in a separate request."),
-		)
-	}
 
 	// Group the app.update and repository connect/disconnect events this request
 	// emits under one correlation id.

--- a/svc/api/routes/v2_apps_update_app/handler.go
+++ b/svc/api/routes/v2_apps_update_app/handler.go
@@ -196,11 +196,8 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			return openapi.App{}, err
 		}
 
-		// appColumnsChanged tracks user-facing app fields (an `app.update` event).
 		appColumnsChanged := update.NameSpecified == 1 || update.SlugSpecified == 1 || update.DeleteProtectionSpecified == 1
 
-		// Persist the app row only when one of its own fields changed.
-		// updatedAt is reflected in the response only when a write actually happened.
 		responseUpdatedAt := app.UpdatedAt.Int64
 		if appColumnsChanged {
 			if err = db.Query.UpdateApp(ctx, tx, update); err != nil {
@@ -355,8 +352,6 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	})
 }
 
-// applyGitChange applies the `git` field to the app's repository connection and
-// returns the connection state to reflect in the response.
 func (h *Handler) applyGitChange(
 	ctx context.Context,
 	tx db.DBTX,
@@ -382,7 +377,6 @@ func (h *Handler) applyGitChange(
 	}
 
 	if git.IsNull() {
-		// Disconnect: drop the connection and its source-owned branch.
 		if err := db.Query.DeleteGithubRepoConnectionsByAppId(ctx, tx, app.ID); err != nil {
 			return nil, fault.Wrap(
 				err,

--- a/svc/api/routes/v2_apps_update_app/handler.go
+++ b/svc/api/routes/v2_apps_update_app/handler.go
@@ -58,6 +58,14 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	if err != nil {
 		return err
 	}
+	if req.Oci == nil && !req.Git.IsSpecified() && req.Name == nil && req.Slug == nil && req.DeleteProtection == nil {
+		return fault.New(
+			"empty update",
+			fault.Code(codes.App.Validation.InvalidInput.URN()),
+			fault.Internal("no updatable fields in request"),
+			fault.Public("Provide at least one field to update."),
+		)
+	}
 	if req.Oci != nil && (req.Git.IsSpecified() || req.Name != nil || req.Slug != nil || req.DeleteProtection != nil) {
 		return fault.New(
 			"OCI image update combined with other changes",

--- a/svc/api/routes/v2_deployments_get_deployment/200_test.go
+++ b/svc/api/routes/v2_deployments_get_deployment/200_test.go
@@ -34,6 +34,7 @@ func TestGetDeployment(t *testing.T) {
 		ProjectID:             setup.Project.ID,
 		AppID:                 setup.App.ID,
 		EnvironmentID:         setup.Environment.ID,
+		Source:                db.DeploymentsSourceGit,
 		GitBranch:             "main",
 		GitCommitSha:          "9f2c1a7",
 		GitCommitMessage:      "add KEBAP endpoint",
@@ -61,7 +62,6 @@ func TestGetDeployment(t *testing.T) {
 	require.Equal(t, setup.Project.Slug, d.Project)
 	require.False(t, d.IsCurrent, "app has no current deployment pointing here")
 
-	// git-sourced: git set from the seeded commit, docker absent.
 	require.NotNil(t, d.Git)
 	require.Equal(t, "9f2c1a7", d.Git.CommitSha)
 	require.NotNil(t, d.Git.Branch)

--- a/svc/api/routes/v2_deployments_list_deployments/200_test.go
+++ b/svc/api/routes/v2_deployments_list_deployments/200_test.go
@@ -8,6 +8,7 @@ import (
 	mysqltype "github.com/unkeyed/unkey/pkg/mysql/types"
 
 	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/ptr"
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
@@ -33,6 +34,7 @@ func TestListWorkspaceWide(t *testing.T) {
 			ProjectID:     setup.Project.ID,
 			AppID:         setup.App.ID,
 			EnvironmentID: setup.Environment.ID,
+			Source:        db.DeploymentsSourceGit,
 			GitBranch:     "main",
 			GitCommitSha:  "abc123",
 		})


### PR DESCRIPTION
Return source type in get/list deployments

## Stack
Depends on #7084.

## Testing
- `mise exec -- rask ./svc/api/internal/deployment ./svc/api/routes/v2_deployments_get_deployment`