### PR TITLE
chore: backfill OCI app source provenance

### DIFF
--- a/web/tools/migrate/oci-image-app-sources.sql
+++ b/web/tools/migrate/oci-image-app-sources.sql
@@ -1,0 +1,102 @@
+-- Run after the additive schema and dual-writing binaries are deployed, and
+-- after older binaries that only write deployments.image have drained.
+-- These updates are idempotent and intentionally leave ambiguous rows alone.
+
+UPDATE `github_repo_connections` AS `connection`
+INNER JOIN `apps` AS `app` ON `app`.`id` = `connection`.`app_id`
+SET `connection`.`default_branch` = COALESCE(NULLIF(`app`.`default_branch`, ''), 'main')
+WHERE `connection`.`default_branch` IS NULL;
+
+-- A repository connection unambiguously identifies an existing app as Git-sourced.
+UPDATE `apps` AS `app`
+INNER JOIN `github_repo_connections` AS `connection` ON `connection`.`app_id` = `app`.`id`
+SET `app`.`source_type` = 'git'
+WHERE `app`.`source_type` = 'unknown';
+
+-- A durable build ID is written only by the Git build path.
+UPDATE `deployments`
+SET `source` = 'git'
+WHERE `source` = 'unknown'
+  AND `build_id` IS NOT NULL
+  AND `build_id` <> '';
+
+-- A deployment is safely identifiable as OCI-sourced when it has no Depot
+-- build ID and its image is outside Unkey's Depot registry. Both checks are
+-- required: failed Git builds can lack a build ID, while old Git redeployments
+-- can reuse a Depot image without copying the original build ID.
+UPDATE `deployments`
+SET `source` = 'oci'
+WHERE `source` = 'unknown'
+  AND (`build_id` IS NULL OR `build_id` = '')
+  AND COALESCE(NULLIF(`image_requested`, ''), NULLIF(`image`, ''), NULLIF(`image_resolved`, '')) IS NOT NULL
+  AND COALESCE(NULLIF(`image_requested`, ''), NULLIF(`image`, ''), NULLIF(`image_resolved`, '')) NOT LIKE 'registry.depot.dev/%';
+
+-- Use the newest safely classified OCI deployment as the app's configured
+-- default image. Repository-connected apps remain Git-sourced even if they
+-- previously received an explicit OCI deployment.
+INSERT INTO `app_source_oci` (
+  `workspace_id`,
+  `app_id`,
+  `image_reference`,
+  `created_at`,
+  `updated_at`
+)
+SELECT
+  `app`.`workspace_id`,
+  `app`.`id`,
+  `candidate`.`image_reference`,
+  `candidate`.`created_at`,
+  `candidate`.`updated_at`
+FROM `apps` AS `app`
+INNER JOIN (
+  SELECT
+    `deployment`.`app_id`,
+    COALESCE(NULLIF(`deployment`.`image_requested`, ''), NULLIF(`deployment`.`image`, ''), NULLIF(`deployment`.`image_resolved`, '')) AS `image_reference`,
+    `deployment`.`created_at`,
+    `deployment`.`updated_at`,
+    ROW_NUMBER() OVER (
+      PARTITION BY `deployment`.`app_id`
+      ORDER BY `deployment`.`created_at` DESC, `deployment`.`pk` DESC
+    ) AS `row_number`
+  FROM `deployments` AS `deployment`
+  WHERE `deployment`.`source` = 'oci'
+    -- A ready deployment proves the registry accepted and resolved the
+    -- reference. Failed or interrupted deployments are not source defaults.
+    AND `deployment`.`status` = 'ready'
+) AS `candidate` ON `candidate`.`app_id` = `app`.`id` AND `candidate`.`row_number` = 1
+LEFT JOIN `github_repo_connections` AS `connection` ON `connection`.`app_id` = `app`.`id`
+LEFT JOIN `app_source_oci` AS `oci_source` ON `oci_source`.`app_id` = `app`.`id`
+WHERE `app`.`source_type` = 'unknown'
+  AND `connection`.`app_id` IS NULL
+  AND `oci_source`.`app_id` IS NULL
+  -- New OCI app sources require a complete explicit tag or SHA-256 digest.
+  -- Leave implicit or malformed historical references unknown; SQL cannot
+  -- safely reproduce full OCI reference normalization.
+  AND (
+    (
+      `candidate`.`image_reference`
+        REGEXP '^(([a-z0-9]+([.-][a-z0-9]+)*)(:[0-9]+)?/)?([a-z0-9]+([._-][a-z0-9]+)*/)*[a-z0-9]+([._-][a-z0-9]+)*@sha256:[0-9a-fA-F]{64}$'
+      AND CHAR_LENGTH(SUBSTRING_INDEX(`candidate`.`image_reference`, '@', 1)) BETWEEN 2 AND 255
+    )
+    OR (
+      `candidate`.`image_reference`
+        REGEXP '^(([a-z0-9]+([.-][a-z0-9]+)*)(:[0-9]+)?/)?([a-z0-9]+([._-][a-z0-9]+)*/)*[a-z0-9]+([._-][a-z0-9]+)*:[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$'
+      AND CHAR_LENGTH(`candidate`.`image_reference`)
+        - CHAR_LENGTH(SUBSTRING_INDEX(`candidate`.`image_reference`, ':', -1))
+        - 1 BETWEEN 2 AND 255
+    )
+  );
+
+UPDATE `apps` AS `app`
+INNER JOIN `app_source_oci` AS `oci_source` ON `oci_source`.`app_id` = `app`.`id`
+LEFT JOIN `github_repo_connections` AS `connection` ON `connection`.`app_id` = `app`.`id`
+SET `app`.`source_type` = 'oci'
+WHERE `app`.`source_type` = 'unknown'
+  AND `connection`.`app_id` IS NULL;
+
+-- Backfill the additive resolved-image column. Verify no legacy-only values
+-- remain before removing the image column in a later schema change.
+UPDATE `deployments`
+SET `image_resolved` = `image`
+WHERE `image` IS NOT NULL
+  AND NOT (`image_resolved` <=> `image`);


### PR DESCRIPTION
Backfill all the tables we need once we have deployed schema and are dual writing

## Summary
- classify unambiguous historical Git and OCI deployments
- configure OCI app defaults only from ready deployments with explicit valid-looking references
- leave implicit, malformed, one-character, and overlong repositories unknown
- backfill resolved deployment images for the additive rollout

Run only after the additive schema and dual-writing binaries deploy and older binaries drain.

## Stack
Depends on #7089. This operational migration is intentionally last.

## Testing
MySQL 8 fixture verified:
- valid `ab:t` and full SHA-256 digest backfilled
- `a:t`, 256-character repository, `nginx`, `nginx:`, and `nginx@` remained unknown