### PR TITLE
feat(ctrl): add deployment garbage collection protocol

### DIFF
--- a/gen/proto/hydra/v1/cron.pb.go
+++ b/gen/proto/hydra/v1/cron.pb.go
@@ -960,6 +960,110 @@ func (x *RunDeploySpendCheckResponse) GetWorkspacesDispatched() int32 {
 	return 0
 }
 
+type RunDeploymentGarbageCollectionRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RunDeploymentGarbageCollectionRequest) Reset() {
+	*x = RunDeploymentGarbageCollectionRequest{}
+	mi := &file_hydra_v1_cron_proto_msgTypes[22]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RunDeploymentGarbageCollectionRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RunDeploymentGarbageCollectionRequest) ProtoMessage() {}
+
+func (x *RunDeploymentGarbageCollectionRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_hydra_v1_cron_proto_msgTypes[22]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RunDeploymentGarbageCollectionRequest.ProtoReflect.Descriptor instead.
+func (*RunDeploymentGarbageCollectionRequest) Descriptor() ([]byte, []int) {
+	return file_hydra_v1_cron_proto_rawDescGZIP(), []int{22}
+}
+
+type RunDeploymentGarbageCollectionResponse struct {
+	state                         protoimpl.MessageState `protogen:"open.v1"`
+	DeploymentsDispatched         int32                  `protobuf:"varint,1,opt,name=deployments_dispatched,json=deploymentsDispatched,proto3" json:"deployments_dispatched,omitempty"`
+	MissingDepotImages            int32                  `protobuf:"varint,2,opt,name=missing_depot_images,json=missingDepotImages,proto3" json:"missing_depot_images,omitempty"`
+	StaleProjectReferencesCleared int32                  `protobuf:"varint,3,opt,name=stale_project_references_cleared,json=staleProjectReferencesCleared,proto3" json:"stale_project_references_cleared,omitempty"`
+	DepotResourcesDeleted         int32                  `protobuf:"varint,4,opt,name=depot_resources_deleted,json=depotResourcesDeleted,proto3" json:"depot_resources_deleted,omitempty"`
+	unknownFields                 protoimpl.UnknownFields
+	sizeCache                     protoimpl.SizeCache
+}
+
+func (x *RunDeploymentGarbageCollectionResponse) Reset() {
+	*x = RunDeploymentGarbageCollectionResponse{}
+	mi := &file_hydra_v1_cron_proto_msgTypes[23]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RunDeploymentGarbageCollectionResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RunDeploymentGarbageCollectionResponse) ProtoMessage() {}
+
+func (x *RunDeploymentGarbageCollectionResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_hydra_v1_cron_proto_msgTypes[23]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RunDeploymentGarbageCollectionResponse.ProtoReflect.Descriptor instead.
+func (*RunDeploymentGarbageCollectionResponse) Descriptor() ([]byte, []int) {
+	return file_hydra_v1_cron_proto_rawDescGZIP(), []int{23}
+}
+
+func (x *RunDeploymentGarbageCollectionResponse) GetDeploymentsDispatched() int32 {
+	if x != nil {
+		return x.DeploymentsDispatched
+	}
+	return 0
+}
+
+func (x *RunDeploymentGarbageCollectionResponse) GetMissingDepotImages() int32 {
+	if x != nil {
+		return x.MissingDepotImages
+	}
+	return 0
+}
+
+func (x *RunDeploymentGarbageCollectionResponse) GetStaleProjectReferencesCleared() int32 {
+	if x != nil {
+		return x.StaleProjectReferencesCleared
+	}
+	return 0
+}
+
+func (x *RunDeploymentGarbageCollectionResponse) GetDepotResourcesDeleted() int32 {
+	if x != nil {
+		return x.DepotResourcesDeleted
+	}
+	return 0
+}
+
 var File_hydra_v1_cron_proto protoreflect.FileDescriptor
 
 const file_hydra_v1_cron_proto_rawDesc = "" +
@@ -1006,7 +1110,14 @@ const file_hydra_v1_cron_proto_rawDesc = "" +
 	"#CloseDeployBillingWorkspaceResponse\"\x1c\n" +
 	"\x1aRunDeploySpendCheckRequest\"R\n" +
 	"\x1bRunDeploySpendCheckResponse\x123\n" +
-	"\x15workspaces_dispatched\x18\x01 \x01(\x05R\x14workspacesDispatched2\xce\t\n" +
+	"\x15workspaces_dispatched\x18\x01 \x01(\x05R\x14workspacesDispatched\"'\n" +
+	"%RunDeploymentGarbageCollectionRequest\"\x92\x02\n" +
+	"&RunDeploymentGarbageCollectionResponse\x125\n" +
+	"\x16deployments_dispatched\x18\x01 \x01(\x05R\x15deploymentsDispatched\x120\n" +
+	"\x14missing_depot_images\x18\x02 \x01(\x05R\x12missingDepotImages\x12G\n" +
+	" stale_project_references_cleared\x18\x03 \x01(\x05R\x1dstaleProjectReferencesCleared\x126\n" +
+	"\x17depot_resources_deleted\x18\x04 \x01(\x05R\x15depotResourcesDeleted2\xd6\n" +
+	"\n" +
 	"\vCronService\x12R\n" +
 	"\rRunQuotaCheck\x12\x1e.hydra.v1.RunQuotaCheckRequest\x1a\x1f.hydra.v1.RunQuotaCheckResponse\"\x00\x12O\n" +
 	"\fRunKeyRefill\x12\x1d.hydra.v1.RunKeyRefillRequest\x1a\x1e.hydra.v1.RunKeyRefillResponse\"\x00\x12a\n" +
@@ -1018,7 +1129,8 @@ const file_hydra_v1_cron_proto_rawDesc = "" +
 	"\"RunScaleDownIdlePreviewDeployments\x123.hydra.v1.RunScaleDownIdlePreviewDeploymentsRequest\x1a4.hydra.v1.RunScaleDownIdlePreviewDeploymentsResponse\"\x00\x12j\n" +
 	"\x15RunDeployBillingClose\x12&.hydra.v1.RunDeployBillingCloseRequest\x1a'.hydra.v1.RunDeployBillingCloseResponse\"\x00\x12|\n" +
 	"\x1bCloseDeployBillingWorkspace\x12,.hydra.v1.CloseDeployBillingWorkspaceRequest\x1a-.hydra.v1.CloseDeployBillingWorkspaceResponse\"\x00\x12d\n" +
-	"\x13RunDeploySpendCheck\x12$.hydra.v1.RunDeploySpendCheckRequest\x1a%.hydra.v1.RunDeploySpendCheckResponse\"\x00\x1a\x04\x98\x80\x01\x01B\x8f\x01\n" +
+	"\x13RunDeploySpendCheck\x12$.hydra.v1.RunDeploySpendCheckRequest\x1a%.hydra.v1.RunDeploySpendCheckResponse\"\x00\x12\x85\x01\n" +
+	"\x1eRunDeploymentGarbageCollection\x12/.hydra.v1.RunDeploymentGarbageCollectionRequest\x1a0.hydra.v1.RunDeploymentGarbageCollectionResponse\"\x00\x1a\x04\x98\x80\x01\x01B\x8f\x01\n" +
 	"\fcom.hydra.v1B\tCronProtoP\x01Z3github.com/unkeyed/unkey/gen/proto/hydra/v1;hydrav1\xa2\x02\x03HXX\xaa\x02\bHydra.V1\xca\x02\bHydra\\V1\xe2\x02\x14Hydra\\V1\\GPBMetadata\xea\x02\tHydra::V1b\x06proto3"
 
 var (
@@ -1033,7 +1145,7 @@ func file_hydra_v1_cron_proto_rawDescGZIP() []byte {
 	return file_hydra_v1_cron_proto_rawDescData
 }
 
-var file_hydra_v1_cron_proto_msgTypes = make([]protoimpl.MessageInfo, 22)
+var file_hydra_v1_cron_proto_msgTypes = make([]protoimpl.MessageInfo, 24)
 var file_hydra_v1_cron_proto_goTypes = []any{
 	(*RunQuotaCheckRequest)(nil),                       // 0: hydra.v1.RunQuotaCheckRequest
 	(*RunQuotaCheckResponse)(nil),                      // 1: hydra.v1.RunQuotaCheckResponse
@@ -1057,6 +1169,8 @@ var file_hydra_v1_cron_proto_goTypes = []any{
 	(*CloseDeployBillingWorkspaceResponse)(nil),        // 19: hydra.v1.CloseDeployBillingWorkspaceResponse
 	(*RunDeploySpendCheckRequest)(nil),                 // 20: hydra.v1.RunDeploySpendCheckRequest
 	(*RunDeploySpendCheckResponse)(nil),                // 21: hydra.v1.RunDeploySpendCheckResponse
+	(*RunDeploymentGarbageCollectionRequest)(nil),      // 22: hydra.v1.RunDeploymentGarbageCollectionRequest
+	(*RunDeploymentGarbageCollectionResponse)(nil),     // 23: hydra.v1.RunDeploymentGarbageCollectionResponse
 }
 var file_hydra_v1_cron_proto_depIdxs = []int32{
 	0,  // 0: hydra.v1.CronService.RunQuotaCheck:input_type -> hydra.v1.RunQuotaCheckRequest
@@ -1070,19 +1184,21 @@ var file_hydra_v1_cron_proto_depIdxs = []int32{
 	16, // 8: hydra.v1.CronService.RunDeployBillingClose:input_type -> hydra.v1.RunDeployBillingCloseRequest
 	18, // 9: hydra.v1.CronService.CloseDeployBillingWorkspace:input_type -> hydra.v1.CloseDeployBillingWorkspaceRequest
 	20, // 10: hydra.v1.CronService.RunDeploySpendCheck:input_type -> hydra.v1.RunDeploySpendCheckRequest
-	1,  // 11: hydra.v1.CronService.RunQuotaCheck:output_type -> hydra.v1.RunQuotaCheckResponse
-	3,  // 12: hydra.v1.CronService.RunKeyRefill:output_type -> hydra.v1.RunKeyRefillResponse
-	5,  // 13: hydra.v1.CronService.RunKeyLastUsedSync:output_type -> hydra.v1.RunKeyLastUsedSyncResponse
-	7,  // 14: hydra.v1.CronService.RunAuditLogExport:output_type -> hydra.v1.RunAuditLogExportResponse
-	9,  // 15: hydra.v1.CronService.RunRatelimitGlobalCountersCleanup:output_type -> hydra.v1.RunRatelimitGlobalCountersCleanupResponse
-	11, // 16: hydra.v1.CronService.RunAuditLogOutboxCleanup:output_type -> hydra.v1.RunAuditLogOutboxCleanupResponse
-	13, // 17: hydra.v1.CronService.RunDeployBillingPush:output_type -> hydra.v1.RunDeployBillingPushResponse
-	15, // 18: hydra.v1.CronService.RunScaleDownIdlePreviewDeployments:output_type -> hydra.v1.RunScaleDownIdlePreviewDeploymentsResponse
-	17, // 19: hydra.v1.CronService.RunDeployBillingClose:output_type -> hydra.v1.RunDeployBillingCloseResponse
-	19, // 20: hydra.v1.CronService.CloseDeployBillingWorkspace:output_type -> hydra.v1.CloseDeployBillingWorkspaceResponse
-	21, // 21: hydra.v1.CronService.RunDeploySpendCheck:output_type -> hydra.v1.RunDeploySpendCheckResponse
-	11, // [11:22] is the sub-list for method output_type
-	0,  // [0:11] is the sub-list for method input_type
+	22, // 11: hydra.v1.CronService.RunDeploymentGarbageCollection:input_type -> hydra.v1.RunDeploymentGarbageCollectionRequest
+	1,  // 12: hydra.v1.CronService.RunQuotaCheck:output_type -> hydra.v1.RunQuotaCheckResponse
+	3,  // 13: hydra.v1.CronService.RunKeyRefill:output_type -> hydra.v1.RunKeyRefillResponse
+	5,  // 14: hydra.v1.CronService.RunKeyLastUsedSync:output_type -> hydra.v1.RunKeyLastUsedSyncResponse
+	7,  // 15: hydra.v1.CronService.RunAuditLogExport:output_type -> hydra.v1.RunAuditLogExportResponse
+	9,  // 16: hydra.v1.CronService.RunRatelimitGlobalCountersCleanup:output_type -> hydra.v1.RunRatelimitGlobalCountersCleanupResponse
+	11, // 17: hydra.v1.CronService.RunAuditLogOutboxCleanup:output_type -> hydra.v1.RunAuditLogOutboxCleanupResponse
+	13, // 18: hydra.v1.CronService.RunDeployBillingPush:output_type -> hydra.v1.RunDeployBillingPushResponse
+	15, // 19: hydra.v1.CronService.RunScaleDownIdlePreviewDeployments:output_type -> hydra.v1.RunScaleDownIdlePreviewDeploymentsResponse
+	17, // 20: hydra.v1.CronService.RunDeployBillingClose:output_type -> hydra.v1.RunDeployBillingCloseResponse
+	19, // 21: hydra.v1.CronService.CloseDeployBillingWorkspace:output_type -> hydra.v1.CloseDeployBillingWorkspaceResponse
+	21, // 22: hydra.v1.CronService.RunDeploySpendCheck:output_type -> hydra.v1.RunDeploySpendCheckResponse
+	23, // 23: hydra.v1.CronService.RunDeploymentGarbageCollection:output_type -> hydra.v1.RunDeploymentGarbageCollectionResponse
+	12, // [12:24] is the sub-list for method output_type
+	0,  // [0:12] is the sub-list for method input_type
 	0,  // [0:0] is the sub-list for extension type_name
 	0,  // [0:0] is the sub-list for extension extendee
 	0,  // [0:0] is the sub-list for field type_name
@@ -1099,7 +1215,7 @@ func file_hydra_v1_cron_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_hydra_v1_cron_proto_rawDesc), len(file_hydra_v1_cron_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   22,
+			NumMessages:   24,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/proto/hydra/v1/cron_restate.pb.go
+++ b/gen/proto/hydra/v1/cron_restate.pb.go
@@ -95,6 +95,10 @@ type CronServiceClient interface {
 	// per-workspace work prices usage locally from ClickHouse, so the tight
 	// cadence costs no Stripe calls.
 	RunDeploySpendCheck(opts ...sdk_go.ClientOption) sdk_go.Client[*RunDeploySpendCheckRequest, *RunDeploySpendCheckResponse]
+	// RunDeploymentGarbageCollection removes expired deployment records and
+	// reconciles Depot images and build projects against MySQL. Key is the fixed
+	// slug "deployment-garbage-collection". Daily schedule.
+	RunDeploymentGarbageCollection(opts ...sdk_go.ClientOption) sdk_go.Client[*RunDeploymentGarbageCollectionRequest, *RunDeploymentGarbageCollectionResponse]
 }
 
 type cronServiceClient struct {
@@ -199,6 +203,14 @@ func (c *cronServiceClient) RunDeploySpendCheck(opts ...sdk_go.ClientOption) sdk
 	return sdk_go.WithRequestType[*RunDeploySpendCheckRequest](sdk_go.Object[*RunDeploySpendCheckResponse](c.ctx, "hydra.v1.CronService", c.key, "RunDeploySpendCheck", cOpts...))
 }
 
+func (c *cronServiceClient) RunDeploymentGarbageCollection(opts ...sdk_go.ClientOption) sdk_go.Client[*RunDeploymentGarbageCollectionRequest, *RunDeploymentGarbageCollectionResponse] {
+	cOpts := c.options
+	if len(opts) > 0 {
+		cOpts = append(append([]sdk_go.ClientOption{}, cOpts...), opts...)
+	}
+	return sdk_go.WithRequestType[*RunDeploymentGarbageCollectionRequest](sdk_go.Object[*RunDeploymentGarbageCollectionResponse](c.ctx, "hydra.v1.CronService", c.key, "RunDeploymentGarbageCollection", cOpts...))
+}
+
 // CronServiceIngressClient is the ingress client API for hydra.v1.CronService service.
 //
 // This client is used to call the service from outside of a Restate context.
@@ -266,6 +278,10 @@ type CronServiceIngressClient interface {
 	// per-workspace work prices usage locally from ClickHouse, so the tight
 	// cadence costs no Stripe calls.
 	RunDeploySpendCheck() ingress.Requester[*RunDeploySpendCheckRequest, *RunDeploySpendCheckResponse]
+	// RunDeploymentGarbageCollection removes expired deployment records and
+	// reconciles Depot images and build projects against MySQL. Key is the fixed
+	// slug "deployment-garbage-collection". Daily schedule.
+	RunDeploymentGarbageCollection() ingress.Requester[*RunDeploymentGarbageCollectionRequest, *RunDeploymentGarbageCollectionResponse]
 }
 
 type cronServiceIngressClient struct {
@@ -335,6 +351,11 @@ func (c *cronServiceIngressClient) CloseDeployBillingWorkspace() ingress.Request
 func (c *cronServiceIngressClient) RunDeploySpendCheck() ingress.Requester[*RunDeploySpendCheckRequest, *RunDeploySpendCheckResponse] {
 	codec := encoding.ProtoJSONCodec
 	return ingress.NewRequester[*RunDeploySpendCheckRequest, *RunDeploySpendCheckResponse](c.client, c.serviceName, "RunDeploySpendCheck", &c.key, &codec)
+}
+
+func (c *cronServiceIngressClient) RunDeploymentGarbageCollection() ingress.Requester[*RunDeploymentGarbageCollectionRequest, *RunDeploymentGarbageCollectionResponse] {
+	codec := encoding.ProtoJSONCodec
+	return ingress.NewRequester[*RunDeploymentGarbageCollectionRequest, *RunDeploymentGarbageCollectionResponse](c.client, c.serviceName, "RunDeploymentGarbageCollection", &c.key, &codec)
 }
 
 // CronServiceServer is the server API for hydra.v1.CronService service.
@@ -421,6 +442,10 @@ type CronServiceServer interface {
 	// per-workspace work prices usage locally from ClickHouse, so the tight
 	// cadence costs no Stripe calls.
 	RunDeploySpendCheck(ctx sdk_go.ObjectContext, req *RunDeploySpendCheckRequest) (*RunDeploySpendCheckResponse, error)
+	// RunDeploymentGarbageCollection removes expired deployment records and
+	// reconciles Depot images and build projects against MySQL. Key is the fixed
+	// slug "deployment-garbage-collection". Daily schedule.
+	RunDeploymentGarbageCollection(ctx sdk_go.ObjectContext, req *RunDeploymentGarbageCollectionRequest) (*RunDeploymentGarbageCollectionResponse, error)
 }
 
 // UnimplementedCronServiceServer should be embedded to have
@@ -463,6 +488,9 @@ func (UnimplementedCronServiceServer) CloseDeployBillingWorkspace(ctx sdk_go.Obj
 func (UnimplementedCronServiceServer) RunDeploySpendCheck(ctx sdk_go.ObjectContext, req *RunDeploySpendCheckRequest) (*RunDeploySpendCheckResponse, error) {
 	return nil, sdk_go.TerminalError(fmt.Errorf("method RunDeploySpendCheck not implemented"), 501)
 }
+func (UnimplementedCronServiceServer) RunDeploymentGarbageCollection(ctx sdk_go.ObjectContext, req *RunDeploymentGarbageCollectionRequest) (*RunDeploymentGarbageCollectionResponse, error) {
+	return nil, sdk_go.TerminalError(fmt.Errorf("method RunDeploymentGarbageCollection not implemented"), 501)
+}
 func (UnimplementedCronServiceServer) testEmbeddedByValue() {}
 
 // UnsafeCronServiceServer may be embedded to opt out of forward compatibility for this service.
@@ -493,5 +521,6 @@ func NewCronServiceServer(srv CronServiceServer, opts ...sdk_go.ServiceDefinitio
 	router = router.Handler("RunDeployBillingClose", sdk_go.NewObjectHandler(srv.RunDeployBillingClose))
 	router = router.Handler("CloseDeployBillingWorkspace", sdk_go.NewObjectHandler(srv.CloseDeployBillingWorkspace))
 	router = router.Handler("RunDeploySpendCheck", sdk_go.NewObjectHandler(srv.RunDeploySpendCheck))
+	router = router.Handler("RunDeploymentGarbageCollection", sdk_go.NewObjectHandler(srv.RunDeploymentGarbageCollection))
 	return router
 }

--- a/gen/proto/hydra/v1/deploy.pb.go
+++ b/gen/proto/hydra/v1/deploy.pb.go
@@ -272,6 +272,94 @@ func (*WakeDeploymentResponse) Descriptor() ([]byte, []int) {
 	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{3}
 }
 
+type GarbageCollectDeploymentRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	DeploymentId  string                 `protobuf:"bytes,1,opt,name=deployment_id,json=deploymentId,proto3" json:"deployment_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GarbageCollectDeploymentRequest) Reset() {
+	*x = GarbageCollectDeploymentRequest{}
+	mi := &file_hydra_v1_deploy_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GarbageCollectDeploymentRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GarbageCollectDeploymentRequest) ProtoMessage() {}
+
+func (x *GarbageCollectDeploymentRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_hydra_v1_deploy_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GarbageCollectDeploymentRequest.ProtoReflect.Descriptor instead.
+func (*GarbageCollectDeploymentRequest) Descriptor() ([]byte, []int) {
+	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *GarbageCollectDeploymentRequest) GetDeploymentId() string {
+	if x != nil {
+		return x.DeploymentId
+	}
+	return ""
+}
+
+type GarbageCollectDeploymentResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Deleted       bool                   `protobuf:"varint,1,opt,name=deleted,proto3" json:"deleted,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GarbageCollectDeploymentResponse) Reset() {
+	*x = GarbageCollectDeploymentResponse{}
+	mi := &file_hydra_v1_deploy_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GarbageCollectDeploymentResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GarbageCollectDeploymentResponse) ProtoMessage() {}
+
+func (x *GarbageCollectDeploymentResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_hydra_v1_deploy_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GarbageCollectDeploymentResponse.ProtoReflect.Descriptor instead.
+func (*GarbageCollectDeploymentResponse) Descriptor() ([]byte, []int) {
+	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *GarbageCollectDeploymentResponse) GetDeleted() bool {
+	if x != nil {
+		return x.Deleted
+	}
+	return false
+}
+
 type NotifyInstancesReadyRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	DeploymentId  string                 `protobuf:"bytes,1,opt,name=deployment_id,json=deploymentId,proto3" json:"deployment_id,omitempty"`
@@ -281,7 +369,7 @@ type NotifyInstancesReadyRequest struct {
 
 func (x *NotifyInstancesReadyRequest) Reset() {
 	*x = NotifyInstancesReadyRequest{}
-	mi := &file_hydra_v1_deploy_proto_msgTypes[4]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -293,7 +381,7 @@ func (x *NotifyInstancesReadyRequest) String() string {
 func (*NotifyInstancesReadyRequest) ProtoMessage() {}
 
 func (x *NotifyInstancesReadyRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_hydra_v1_deploy_proto_msgTypes[4]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -306,7 +394,7 @@ func (x *NotifyInstancesReadyRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NotifyInstancesReadyRequest.ProtoReflect.Descriptor instead.
 func (*NotifyInstancesReadyRequest) Descriptor() ([]byte, []int) {
-	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{4}
+	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *NotifyInstancesReadyRequest) GetDeploymentId() string {
@@ -325,7 +413,7 @@ type NotifyInstancesReadyResponse struct {
 
 func (x *NotifyInstancesReadyResponse) Reset() {
 	*x = NotifyInstancesReadyResponse{}
-	mi := &file_hydra_v1_deploy_proto_msgTypes[5]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -337,7 +425,7 @@ func (x *NotifyInstancesReadyResponse) String() string {
 func (*NotifyInstancesReadyResponse) ProtoMessage() {}
 
 func (x *NotifyInstancesReadyResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_hydra_v1_deploy_proto_msgTypes[5]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -350,7 +438,7 @@ func (x *NotifyInstancesReadyResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NotifyInstancesReadyResponse.ProtoReflect.Descriptor instead.
 func (*NotifyInstancesReadyResponse) Descriptor() ([]byte, []int) {
-	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{5}
+	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *NotifyInstancesReadyResponse) GetResolved() bool {
@@ -371,7 +459,7 @@ type DockerImage struct {
 
 func (x *DockerImage) Reset() {
 	*x = DockerImage{}
-	mi := &file_hydra_v1_deploy_proto_msgTypes[6]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -383,7 +471,7 @@ func (x *DockerImage) String() string {
 func (*DockerImage) ProtoMessage() {}
 
 func (x *DockerImage) ProtoReflect() protoreflect.Message {
-	mi := &file_hydra_v1_deploy_proto_msgTypes[6]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -396,7 +484,7 @@ func (x *DockerImage) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DockerImage.ProtoReflect.Descriptor instead.
 func (*DockerImage) Descriptor() ([]byte, []int) {
-	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{6}
+	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *DockerImage) GetImage() string {
@@ -439,7 +527,7 @@ type GitSource struct {
 
 func (x *GitSource) Reset() {
 	*x = GitSource{}
-	mi := &file_hydra_v1_deploy_proto_msgTypes[7]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -451,7 +539,7 @@ func (x *GitSource) String() string {
 func (*GitSource) ProtoMessage() {}
 
 func (x *GitSource) ProtoReflect() protoreflect.Message {
-	mi := &file_hydra_v1_deploy_proto_msgTypes[7]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -464,7 +552,7 @@ func (x *GitSource) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GitSource.ProtoReflect.Descriptor instead.
 func (*GitSource) Descriptor() ([]byte, []int) {
-	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{7}
+	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *GitSource) GetInstallationId() int64 {
@@ -546,7 +634,7 @@ type DeployRequest struct {
 
 func (x *DeployRequest) Reset() {
 	*x = DeployRequest{}
-	mi := &file_hydra_v1_deploy_proto_msgTypes[8]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -558,7 +646,7 @@ func (x *DeployRequest) String() string {
 func (*DeployRequest) ProtoMessage() {}
 
 func (x *DeployRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_hydra_v1_deploy_proto_msgTypes[8]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -571,7 +659,7 @@ func (x *DeployRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeployRequest.ProtoReflect.Descriptor instead.
 func (*DeployRequest) Descriptor() ([]byte, []int) {
-	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{8}
+	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *DeployRequest) GetDeploymentId() string {
@@ -637,7 +725,7 @@ type DeployResponse struct {
 
 func (x *DeployResponse) Reset() {
 	*x = DeployResponse{}
-	mi := &file_hydra_v1_deploy_proto_msgTypes[9]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -649,7 +737,7 @@ func (x *DeployResponse) String() string {
 func (*DeployResponse) ProtoMessage() {}
 
 func (x *DeployResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_hydra_v1_deploy_proto_msgTypes[9]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -662,7 +750,7 @@ func (x *DeployResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeployResponse.ProtoReflect.Descriptor instead.
 func (*DeployResponse) Descriptor() ([]byte, []int) {
-	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{9}
+	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{11}
 }
 
 // RollbackRequest identifies the deployment to roll back from and the
@@ -681,7 +769,7 @@ type RollbackRequest struct {
 
 func (x *RollbackRequest) Reset() {
 	*x = RollbackRequest{}
-	mi := &file_hydra_v1_deploy_proto_msgTypes[10]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -693,7 +781,7 @@ func (x *RollbackRequest) String() string {
 func (*RollbackRequest) ProtoMessage() {}
 
 func (x *RollbackRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_hydra_v1_deploy_proto_msgTypes[10]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -706,7 +794,7 @@ func (x *RollbackRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RollbackRequest.ProtoReflect.Descriptor instead.
 func (*RollbackRequest) Descriptor() ([]byte, []int) {
-	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{10}
+	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *RollbackRequest) GetSourceDeploymentId() string {
@@ -745,7 +833,7 @@ type RollbackResponse struct {
 
 func (x *RollbackResponse) Reset() {
 	*x = RollbackResponse{}
-	mi := &file_hydra_v1_deploy_proto_msgTypes[11]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -757,7 +845,7 @@ func (x *RollbackResponse) String() string {
 func (*RollbackResponse) ProtoMessage() {}
 
 func (x *RollbackResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_hydra_v1_deploy_proto_msgTypes[11]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -770,7 +858,7 @@ func (x *RollbackResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RollbackResponse.ProtoReflect.Descriptor instead.
 func (*RollbackResponse) Descriptor() ([]byte, []int) {
-	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{11}
+	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{13}
 }
 
 // PromoteRequest identifies a ready deployment to promote to live.
@@ -785,7 +873,7 @@ type PromoteRequest struct {
 
 func (x *PromoteRequest) Reset() {
 	*x = PromoteRequest{}
-	mi := &file_hydra_v1_deploy_proto_msgTypes[12]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -797,7 +885,7 @@ func (x *PromoteRequest) String() string {
 func (*PromoteRequest) ProtoMessage() {}
 
 func (x *PromoteRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_hydra_v1_deploy_proto_msgTypes[12]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -810,7 +898,7 @@ func (x *PromoteRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PromoteRequest.ProtoReflect.Descriptor instead.
 func (*PromoteRequest) Descriptor() ([]byte, []int) {
-	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{12}
+	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *PromoteRequest) GetTargetDeploymentId() string {
@@ -842,7 +930,7 @@ type PromoteResponse struct {
 
 func (x *PromoteResponse) Reset() {
 	*x = PromoteResponse{}
-	mi := &file_hydra_v1_deploy_proto_msgTypes[13]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -854,7 +942,7 @@ func (x *PromoteResponse) String() string {
 func (*PromoteResponse) ProtoMessage() {}
 
 func (x *PromoteResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_hydra_v1_deploy_proto_msgTypes[13]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -867,7 +955,7 @@ func (x *PromoteResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PromoteResponse.ProtoReflect.Descriptor instead.
 func (*PromoteResponse) Descriptor() ([]byte, []int) {
-	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{13}
+	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{15}
 }
 
 type TeardownRequest struct {
@@ -880,7 +968,7 @@ type TeardownRequest struct {
 
 func (x *TeardownRequest) Reset() {
 	*x = TeardownRequest{}
-	mi := &file_hydra_v1_deploy_proto_msgTypes[14]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -892,7 +980,7 @@ func (x *TeardownRequest) String() string {
 func (*TeardownRequest) ProtoMessage() {}
 
 func (x *TeardownRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_hydra_v1_deploy_proto_msgTypes[14]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -905,7 +993,7 @@ func (x *TeardownRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TeardownRequest.ProtoReflect.Descriptor instead.
 func (*TeardownRequest) Descriptor() ([]byte, []int) {
-	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{14}
+	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *TeardownRequest) GetMode() TeardownMode {
@@ -930,7 +1018,7 @@ type TeardownResponse struct {
 
 func (x *TeardownResponse) Reset() {
 	*x = TeardownResponse{}
-	mi := &file_hydra_v1_deploy_proto_msgTypes[15]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -942,7 +1030,7 @@ func (x *TeardownResponse) String() string {
 func (*TeardownResponse) ProtoMessage() {}
 
 func (x *TeardownResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_hydra_v1_deploy_proto_msgTypes[15]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -955,7 +1043,7 @@ func (x *TeardownResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TeardownResponse.ProtoReflect.Descriptor instead.
 func (*TeardownResponse) Descriptor() ([]byte, []int) {
-	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{15}
+	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *TeardownResponse) GetDeploymentsStopped() int32 {
@@ -980,7 +1068,7 @@ type ResumeRequest struct {
 
 func (x *ResumeRequest) Reset() {
 	*x = ResumeRequest{}
-	mi := &file_hydra_v1_deploy_proto_msgTypes[16]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -992,7 +1080,7 @@ func (x *ResumeRequest) String() string {
 func (*ResumeRequest) ProtoMessage() {}
 
 func (x *ResumeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_hydra_v1_deploy_proto_msgTypes[16]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1005,7 +1093,7 @@ func (x *ResumeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResumeRequest.ProtoReflect.Descriptor instead.
 func (*ResumeRequest) Descriptor() ([]byte, []int) {
-	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{16}
+	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{18}
 }
 
 type ResumeResponse struct {
@@ -1018,7 +1106,7 @@ type ResumeResponse struct {
 
 func (x *ResumeResponse) Reset() {
 	*x = ResumeResponse{}
-	mi := &file_hydra_v1_deploy_proto_msgTypes[17]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1030,7 +1118,7 @@ func (x *ResumeResponse) String() string {
 func (*ResumeResponse) ProtoMessage() {}
 
 func (x *ResumeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_hydra_v1_deploy_proto_msgTypes[17]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1043,7 +1131,7 @@ func (x *ResumeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResumeResponse.ProtoReflect.Descriptor instead.
 func (*ResumeResponse) Descriptor() ([]byte, []int) {
-	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{17}
+	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *ResumeResponse) GetDeploymentsResumed() int32 {
@@ -1067,7 +1155,11 @@ const file_hydra_v1_deploy_proto_rawDesc = "" +
 	"\rdeployment_id\x18\x01 \x01(\tR\fdeploymentId\x12(\n" +
 	"\x05actor\x18\x02 \x01(\v2\x12.ctrl.v1.ActorInfoR\x05actor\x12%\n" +
 	"\x0ecorrelation_id\x18\x03 \x01(\tR\rcorrelationId\"\x18\n" +
-	"\x16WakeDeploymentResponse\"B\n" +
+	"\x16WakeDeploymentResponse\"F\n" +
+	"\x1fGarbageCollectDeploymentRequest\x12#\n" +
+	"\rdeployment_id\x18\x01 \x01(\tR\fdeploymentId\"<\n" +
+	" GarbageCollectDeploymentResponse\x12\x18\n" +
+	"\adeleted\x18\x01 \x01(\bR\adeleted\"B\n" +
 	"\x1bNotifyInstancesReadyRequest\x12#\n" +
 	"\rdeployment_id\x18\x01 \x01(\tR\fdeploymentId\":\n" +
 	"\x1cNotifyInstancesReadyResponse\x12\x1a\n" +
@@ -1116,13 +1208,14 @@ const file_hydra_v1_deploy_proto_rawDesc = "" +
 	"\fTeardownMode\x12\x1d\n" +
 	"\x19TEARDOWN_MODE_UNSPECIFIED\x10\x00\x12\x19\n" +
 	"\x15TEARDOWN_MODE_ARCHIVE\x10\x01\x12\x19\n" +
-	"\x15TEARDOWN_MODE_SUSPEND\x10\x022\xf6\x03\n" +
+	"\x15TEARDOWN_MODE_SUSPEND\x10\x022\xe1\x04\n" +
 	"\rDeployService\x12=\n" +
 	"\x06Deploy\x12\x17.hydra.v1.DeployRequest\x1a\x18.hydra.v1.DeployResponse\"\x00\x12C\n" +
 	"\bRollback\x12\x19.hydra.v1.RollbackRequest\x1a\x1a.hydra.v1.RollbackResponse\"\x00\x12@\n" +
 	"\aPromote\x12\x18.hydra.v1.PromoteRequest\x1a\x19.hydra.v1.PromoteResponse\"\x00\x12U\n" +
 	"\x0eStopDeployment\x12\x1f.hydra.v1.StopDeploymentRequest\x1a .hydra.v1.StopDeploymentResponse\"\x00\x12U\n" +
-	"\x0eWakeDeployment\x12\x1f.hydra.v1.WakeDeploymentRequest\x1a .hydra.v1.WakeDeploymentResponse\"\x00\x12k\n" +
+	"\x0eWakeDeployment\x12\x1f.hydra.v1.WakeDeploymentRequest\x1a .hydra.v1.WakeDeploymentResponse\"\x00\x12i\n" +
+	"\x0eGarbageCollect\x12).hydra.v1.GarbageCollectDeploymentRequest\x1a*.hydra.v1.GarbageCollectDeploymentResponse\"\x00\x12k\n" +
 	"\x14NotifyInstancesReady\x12%.hydra.v1.NotifyInstancesReadyRequest\x1a&.hydra.v1.NotifyInstancesReadyResponse\"\x04\x98\x80\x01\x02\x1a\x04\x98\x80\x01\x012\xa1\x01\n" +
 	"\x15DeployTeardownService\x12C\n" +
 	"\bTeardown\x12\x19.hydra.v1.TeardownRequest\x1a\x1a.hydra.v1.TeardownResponse\"\x00\x12=\n" +
@@ -1142,55 +1235,59 @@ func file_hydra_v1_deploy_proto_rawDescGZIP() []byte {
 }
 
 var file_hydra_v1_deploy_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_hydra_v1_deploy_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
+var file_hydra_v1_deploy_proto_msgTypes = make([]protoimpl.MessageInfo, 20)
 var file_hydra_v1_deploy_proto_goTypes = []any{
-	(TeardownMode)(0),                    // 0: hydra.v1.TeardownMode
-	(*StopDeploymentRequest)(nil),        // 1: hydra.v1.StopDeploymentRequest
-	(*StopDeploymentResponse)(nil),       // 2: hydra.v1.StopDeploymentResponse
-	(*WakeDeploymentRequest)(nil),        // 3: hydra.v1.WakeDeploymentRequest
-	(*WakeDeploymentResponse)(nil),       // 4: hydra.v1.WakeDeploymentResponse
-	(*NotifyInstancesReadyRequest)(nil),  // 5: hydra.v1.NotifyInstancesReadyRequest
-	(*NotifyInstancesReadyResponse)(nil), // 6: hydra.v1.NotifyInstancesReadyResponse
-	(*DockerImage)(nil),                  // 7: hydra.v1.DockerImage
-	(*GitSource)(nil),                    // 8: hydra.v1.GitSource
-	(*DeployRequest)(nil),                // 9: hydra.v1.DeployRequest
-	(*DeployResponse)(nil),               // 10: hydra.v1.DeployResponse
-	(*RollbackRequest)(nil),              // 11: hydra.v1.RollbackRequest
-	(*RollbackResponse)(nil),             // 12: hydra.v1.RollbackResponse
-	(*PromoteRequest)(nil),               // 13: hydra.v1.PromoteRequest
-	(*PromoteResponse)(nil),              // 14: hydra.v1.PromoteResponse
-	(*TeardownRequest)(nil),              // 15: hydra.v1.TeardownRequest
-	(*TeardownResponse)(nil),             // 16: hydra.v1.TeardownResponse
-	(*ResumeRequest)(nil),                // 17: hydra.v1.ResumeRequest
-	(*ResumeResponse)(nil),               // 18: hydra.v1.ResumeResponse
-	(*v1.ActorInfo)(nil),                 // 19: ctrl.v1.ActorInfo
+	(TeardownMode)(0),                        // 0: hydra.v1.TeardownMode
+	(*StopDeploymentRequest)(nil),            // 1: hydra.v1.StopDeploymentRequest
+	(*StopDeploymentResponse)(nil),           // 2: hydra.v1.StopDeploymentResponse
+	(*WakeDeploymentRequest)(nil),            // 3: hydra.v1.WakeDeploymentRequest
+	(*WakeDeploymentResponse)(nil),           // 4: hydra.v1.WakeDeploymentResponse
+	(*GarbageCollectDeploymentRequest)(nil),  // 5: hydra.v1.GarbageCollectDeploymentRequest
+	(*GarbageCollectDeploymentResponse)(nil), // 6: hydra.v1.GarbageCollectDeploymentResponse
+	(*NotifyInstancesReadyRequest)(nil),      // 7: hydra.v1.NotifyInstancesReadyRequest
+	(*NotifyInstancesReadyResponse)(nil),     // 8: hydra.v1.NotifyInstancesReadyResponse
+	(*DockerImage)(nil),                      // 9: hydra.v1.DockerImage
+	(*GitSource)(nil),                        // 10: hydra.v1.GitSource
+	(*DeployRequest)(nil),                    // 11: hydra.v1.DeployRequest
+	(*DeployResponse)(nil),                   // 12: hydra.v1.DeployResponse
+	(*RollbackRequest)(nil),                  // 13: hydra.v1.RollbackRequest
+	(*RollbackResponse)(nil),                 // 14: hydra.v1.RollbackResponse
+	(*PromoteRequest)(nil),                   // 15: hydra.v1.PromoteRequest
+	(*PromoteResponse)(nil),                  // 16: hydra.v1.PromoteResponse
+	(*TeardownRequest)(nil),                  // 17: hydra.v1.TeardownRequest
+	(*TeardownResponse)(nil),                 // 18: hydra.v1.TeardownResponse
+	(*ResumeRequest)(nil),                    // 19: hydra.v1.ResumeRequest
+	(*ResumeResponse)(nil),                   // 20: hydra.v1.ResumeResponse
+	(*v1.ActorInfo)(nil),                     // 21: ctrl.v1.ActorInfo
 }
 var file_hydra_v1_deploy_proto_depIdxs = []int32{
-	19, // 0: hydra.v1.StopDeploymentRequest.actor:type_name -> ctrl.v1.ActorInfo
-	19, // 1: hydra.v1.WakeDeploymentRequest.actor:type_name -> ctrl.v1.ActorInfo
-	8,  // 2: hydra.v1.DeployRequest.git:type_name -> hydra.v1.GitSource
-	7,  // 3: hydra.v1.DeployRequest.docker_image:type_name -> hydra.v1.DockerImage
-	19, // 4: hydra.v1.RollbackRequest.actor:type_name -> ctrl.v1.ActorInfo
-	19, // 5: hydra.v1.PromoteRequest.actor:type_name -> ctrl.v1.ActorInfo
+	21, // 0: hydra.v1.StopDeploymentRequest.actor:type_name -> ctrl.v1.ActorInfo
+	21, // 1: hydra.v1.WakeDeploymentRequest.actor:type_name -> ctrl.v1.ActorInfo
+	10, // 2: hydra.v1.DeployRequest.git:type_name -> hydra.v1.GitSource
+	9,  // 3: hydra.v1.DeployRequest.docker_image:type_name -> hydra.v1.DockerImage
+	21, // 4: hydra.v1.RollbackRequest.actor:type_name -> ctrl.v1.ActorInfo
+	21, // 5: hydra.v1.PromoteRequest.actor:type_name -> ctrl.v1.ActorInfo
 	0,  // 6: hydra.v1.TeardownRequest.mode:type_name -> hydra.v1.TeardownMode
-	9,  // 7: hydra.v1.DeployService.Deploy:input_type -> hydra.v1.DeployRequest
-	11, // 8: hydra.v1.DeployService.Rollback:input_type -> hydra.v1.RollbackRequest
-	13, // 9: hydra.v1.DeployService.Promote:input_type -> hydra.v1.PromoteRequest
+	11, // 7: hydra.v1.DeployService.Deploy:input_type -> hydra.v1.DeployRequest
+	13, // 8: hydra.v1.DeployService.Rollback:input_type -> hydra.v1.RollbackRequest
+	15, // 9: hydra.v1.DeployService.Promote:input_type -> hydra.v1.PromoteRequest
 	1,  // 10: hydra.v1.DeployService.StopDeployment:input_type -> hydra.v1.StopDeploymentRequest
 	3,  // 11: hydra.v1.DeployService.WakeDeployment:input_type -> hydra.v1.WakeDeploymentRequest
-	5,  // 12: hydra.v1.DeployService.NotifyInstancesReady:input_type -> hydra.v1.NotifyInstancesReadyRequest
-	15, // 13: hydra.v1.DeployTeardownService.Teardown:input_type -> hydra.v1.TeardownRequest
-	17, // 14: hydra.v1.DeployTeardownService.Resume:input_type -> hydra.v1.ResumeRequest
-	10, // 15: hydra.v1.DeployService.Deploy:output_type -> hydra.v1.DeployResponse
-	12, // 16: hydra.v1.DeployService.Rollback:output_type -> hydra.v1.RollbackResponse
-	14, // 17: hydra.v1.DeployService.Promote:output_type -> hydra.v1.PromoteResponse
-	2,  // 18: hydra.v1.DeployService.StopDeployment:output_type -> hydra.v1.StopDeploymentResponse
-	4,  // 19: hydra.v1.DeployService.WakeDeployment:output_type -> hydra.v1.WakeDeploymentResponse
-	6,  // 20: hydra.v1.DeployService.NotifyInstancesReady:output_type -> hydra.v1.NotifyInstancesReadyResponse
-	16, // 21: hydra.v1.DeployTeardownService.Teardown:output_type -> hydra.v1.TeardownResponse
-	18, // 22: hydra.v1.DeployTeardownService.Resume:output_type -> hydra.v1.ResumeResponse
-	15, // [15:23] is the sub-list for method output_type
-	7,  // [7:15] is the sub-list for method input_type
+	5,  // 12: hydra.v1.DeployService.GarbageCollect:input_type -> hydra.v1.GarbageCollectDeploymentRequest
+	7,  // 13: hydra.v1.DeployService.NotifyInstancesReady:input_type -> hydra.v1.NotifyInstancesReadyRequest
+	17, // 14: hydra.v1.DeployTeardownService.Teardown:input_type -> hydra.v1.TeardownRequest
+	19, // 15: hydra.v1.DeployTeardownService.Resume:input_type -> hydra.v1.ResumeRequest
+	12, // 16: hydra.v1.DeployService.Deploy:output_type -> hydra.v1.DeployResponse
+	14, // 17: hydra.v1.DeployService.Rollback:output_type -> hydra.v1.RollbackResponse
+	16, // 18: hydra.v1.DeployService.Promote:output_type -> hydra.v1.PromoteResponse
+	2,  // 19: hydra.v1.DeployService.StopDeployment:output_type -> hydra.v1.StopDeploymentResponse
+	4,  // 20: hydra.v1.DeployService.WakeDeployment:output_type -> hydra.v1.WakeDeploymentResponse
+	6,  // 21: hydra.v1.DeployService.GarbageCollect:output_type -> hydra.v1.GarbageCollectDeploymentResponse
+	8,  // 22: hydra.v1.DeployService.NotifyInstancesReady:output_type -> hydra.v1.NotifyInstancesReadyResponse
+	18, // 23: hydra.v1.DeployTeardownService.Teardown:output_type -> hydra.v1.TeardownResponse
+	20, // 24: hydra.v1.DeployTeardownService.Resume:output_type -> hydra.v1.ResumeResponse
+	16, // [16:25] is the sub-list for method output_type
+	7,  // [7:16] is the sub-list for method input_type
 	7,  // [7:7] is the sub-list for extension type_name
 	7,  // [7:7] is the sub-list for extension extendee
 	0,  // [0:7] is the sub-list for field type_name
@@ -1201,7 +1298,7 @@ func file_hydra_v1_deploy_proto_init() {
 	if File_hydra_v1_deploy_proto != nil {
 		return
 	}
-	file_hydra_v1_deploy_proto_msgTypes[8].OneofWrappers = []any{
+	file_hydra_v1_deploy_proto_msgTypes[10].OneofWrappers = []any{
 		(*DeployRequest_Git)(nil),
 		(*DeployRequest_DockerImage)(nil),
 	}
@@ -1211,7 +1308,7 @@ func file_hydra_v1_deploy_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_hydra_v1_deploy_proto_rawDesc), len(file_hydra_v1_deploy_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   18,
+			NumMessages:   20,
 			NumExtensions: 0,
 			NumServices:   2,
 		},

--- a/gen/proto/hydra/v1/deploy_restate.pb.go
+++ b/gen/proto/hydra/v1/deploy_restate.pb.go
@@ -19,13 +19,10 @@ import (
 // durable Restate workflows. Each RPC is idempotent and can safely resume from
 // any step after a crash.
 //
-// Deploy, Rollback, and Promote are keyed by {app_id}:{environment_id} so
-// that lifecycle operations within a single environment are serialized
-// (preventing e.g. a rollback from racing with an in-flight deploy) while
-// different environments of the same app — e.g. production vs preview — can
-// deploy in parallel. This means a production push never waits behind a
-// preview build. Workspace-wide concurrency is separately enforced by
-// BuildSlotService.
+// Each object is keyed by deployment ID, so lifecycle operations for one
+// deployment are serialized while separate deployments can run in parallel.
+// Shared app routing state is serialized by RoutingService. Workspace-wide
+// build concurrency is enforced separately by BuildSlotService.
 //
 // Deploy handles the full pipeline from building Docker images through
 // provisioning containers and configuring domain routing. Rollback and Promote
@@ -52,6 +49,9 @@ type DeployServiceClient interface {
 	// WakeDeployment schedules desired_state=running for a stopped deployment
 	// and waits until enough instances are running again.
 	WakeDeployment(opts ...sdk_go.ClientOption) sdk_go.Client[*WakeDeploymentRequest, *WakeDeploymentResponse]
+	// GarbageCollect deletes a terminal deployment after rechecking its
+	// retention policy. The request ID must match the deployment-keyed object.
+	GarbageCollect(opts ...sdk_go.ClientOption) sdk_go.Client[*GarbageCollectDeploymentRequest, *GarbageCollectDeploymentResponse]
 	// NotifyInstancesReady is called by the control plane when enough instances
 	// have become healthy across the required regions. It resolves the awakeable
 	// stored by a suspended deploy or wake workflow so it can continue.
@@ -112,6 +112,14 @@ func (c *deployServiceClient) WakeDeployment(opts ...sdk_go.ClientOption) sdk_go
 	return sdk_go.WithRequestType[*WakeDeploymentRequest](sdk_go.Object[*WakeDeploymentResponse](c.ctx, "hydra.v1.DeployService", c.key, "WakeDeployment", cOpts...))
 }
 
+func (c *deployServiceClient) GarbageCollect(opts ...sdk_go.ClientOption) sdk_go.Client[*GarbageCollectDeploymentRequest, *GarbageCollectDeploymentResponse] {
+	cOpts := c.options
+	if len(opts) > 0 {
+		cOpts = append(append([]sdk_go.ClientOption{}, cOpts...), opts...)
+	}
+	return sdk_go.WithRequestType[*GarbageCollectDeploymentRequest](sdk_go.Object[*GarbageCollectDeploymentResponse](c.ctx, "hydra.v1.DeployService", c.key, "GarbageCollect", cOpts...))
+}
+
 func (c *deployServiceClient) NotifyInstancesReady(opts ...sdk_go.ClientOption) sdk_go.Client[*NotifyInstancesReadyRequest, *NotifyInstancesReadyResponse] {
 	cOpts := c.options
 	if len(opts) > 0 {
@@ -144,6 +152,9 @@ type DeployServiceIngressClient interface {
 	// WakeDeployment schedules desired_state=running for a stopped deployment
 	// and waits until enough instances are running again.
 	WakeDeployment() ingress.Requester[*WakeDeploymentRequest, *WakeDeploymentResponse]
+	// GarbageCollect deletes a terminal deployment after rechecking its
+	// retention policy. The request ID must match the deployment-keyed object.
+	GarbageCollect() ingress.Requester[*GarbageCollectDeploymentRequest, *GarbageCollectDeploymentResponse]
 	// NotifyInstancesReady is called by the control plane when enough instances
 	// have become healthy across the required regions. It resolves the awakeable
 	// stored by a suspended deploy or wake workflow so it can continue.
@@ -189,6 +200,11 @@ func (c *deployServiceIngressClient) WakeDeployment() ingress.Requester[*WakeDep
 	return ingress.NewRequester[*WakeDeploymentRequest, *WakeDeploymentResponse](c.client, c.serviceName, "WakeDeployment", &c.key, &codec)
 }
 
+func (c *deployServiceIngressClient) GarbageCollect() ingress.Requester[*GarbageCollectDeploymentRequest, *GarbageCollectDeploymentResponse] {
+	codec := encoding.ProtoJSONCodec
+	return ingress.NewRequester[*GarbageCollectDeploymentRequest, *GarbageCollectDeploymentResponse](c.client, c.serviceName, "GarbageCollect", &c.key, &codec)
+}
+
 func (c *deployServiceIngressClient) NotifyInstancesReady() ingress.Requester[*NotifyInstancesReadyRequest, *NotifyInstancesReadyResponse] {
 	codec := encoding.ProtoJSONCodec
 	return ingress.NewRequester[*NotifyInstancesReadyRequest, *NotifyInstancesReadyResponse](c.client, c.serviceName, "NotifyInstancesReady", &c.key, &codec)
@@ -202,13 +218,10 @@ func (c *deployServiceIngressClient) NotifyInstancesReady() ingress.Requester[*N
 // durable Restate workflows. Each RPC is idempotent and can safely resume from
 // any step after a crash.
 //
-// Deploy, Rollback, and Promote are keyed by {app_id}:{environment_id} so
-// that lifecycle operations within a single environment are serialized
-// (preventing e.g. a rollback from racing with an in-flight deploy) while
-// different environments of the same app — e.g. production vs preview — can
-// deploy in parallel. This means a production push never waits behind a
-// preview build. Workspace-wide concurrency is separately enforced by
-// BuildSlotService.
+// Each object is keyed by deployment ID, so lifecycle operations for one
+// deployment are serialized while separate deployments can run in parallel.
+// Shared app routing state is serialized by RoutingService. Workspace-wide
+// build concurrency is enforced separately by BuildSlotService.
 //
 // Deploy handles the full pipeline from building Docker images through
 // provisioning containers and configuring domain routing. Rollback and Promote
@@ -235,6 +248,9 @@ type DeployServiceServer interface {
 	// WakeDeployment schedules desired_state=running for a stopped deployment
 	// and waits until enough instances are running again.
 	WakeDeployment(ctx sdk_go.ObjectContext, req *WakeDeploymentRequest) (*WakeDeploymentResponse, error)
+	// GarbageCollect deletes a terminal deployment after rechecking its
+	// retention policy. The request ID must match the deployment-keyed object.
+	GarbageCollect(ctx sdk_go.ObjectContext, req *GarbageCollectDeploymentRequest) (*GarbageCollectDeploymentResponse, error)
 	// NotifyInstancesReady is called by the control plane when enough instances
 	// have become healthy across the required regions. It resolves the awakeable
 	// stored by a suspended deploy or wake workflow so it can continue.
@@ -263,6 +279,9 @@ func (UnimplementedDeployServiceServer) StopDeployment(ctx sdk_go.ObjectContext,
 func (UnimplementedDeployServiceServer) WakeDeployment(ctx sdk_go.ObjectContext, req *WakeDeploymentRequest) (*WakeDeploymentResponse, error) {
 	return nil, sdk_go.TerminalError(fmt.Errorf("method WakeDeployment not implemented"), 501)
 }
+func (UnimplementedDeployServiceServer) GarbageCollect(ctx sdk_go.ObjectContext, req *GarbageCollectDeploymentRequest) (*GarbageCollectDeploymentResponse, error) {
+	return nil, sdk_go.TerminalError(fmt.Errorf("method GarbageCollect not implemented"), 501)
+}
 func (UnimplementedDeployServiceServer) NotifyInstancesReady(ctx sdk_go.ObjectSharedContext, req *NotifyInstancesReadyRequest) (*NotifyInstancesReadyResponse, error) {
 	return nil, sdk_go.TerminalError(fmt.Errorf("method NotifyInstancesReady not implemented"), 501)
 }
@@ -290,6 +309,7 @@ func NewDeployServiceServer(srv DeployServiceServer, opts ...sdk_go.ServiceDefin
 	router = router.Handler("Promote", sdk_go.NewObjectHandler(srv.Promote))
 	router = router.Handler("StopDeployment", sdk_go.NewObjectHandler(srv.StopDeployment))
 	router = router.Handler("WakeDeployment", sdk_go.NewObjectHandler(srv.WakeDeployment))
+	router = router.Handler("GarbageCollect", sdk_go.NewObjectHandler(srv.GarbageCollect))
 	router = router.Handler("NotifyInstancesReady", sdk_go.NewObjectSharedHandler(srv.NotifyInstancesReady))
 	return router
 }

--- a/svc/ctrl/proto/hydra/v1/cron.proto
+++ b/svc/ctrl/proto/hydra/v1/cron.proto
@@ -98,6 +98,11 @@ service CronService {
   // per-workspace work prices usage locally from ClickHouse, so the tight
   // cadence costs no Stripe calls.
   rpc RunDeploySpendCheck(RunDeploySpendCheckRequest) returns (RunDeploySpendCheckResponse) {}
+
+  // RunDeploymentGarbageCollection removes expired deployment records and
+  // reconciles Depot images and build projects against MySQL. Key is the fixed
+  // slug "deployment-garbage-collection". Daily schedule.
+  rpc RunDeploymentGarbageCollection(RunDeploymentGarbageCollectionRequest) returns (RunDeploymentGarbageCollectionResponse) {}
 }
 
 message RunQuotaCheckRequest {}
@@ -176,4 +181,12 @@ message RunDeploySpendCheckRequest {}
 message RunDeploySpendCheckResponse {
   // Number of budgeted workspaces the orchestrator fanned out a check for.
   int32 workspaces_dispatched = 1;
+}
+
+message RunDeploymentGarbageCollectionRequest {}
+message RunDeploymentGarbageCollectionResponse {
+  int32 deployments_dispatched = 1;
+  int32 missing_depot_images = 2;
+  int32 stale_project_references_cleared = 3;
+  int32 depot_resources_deleted = 4;
 }

--- a/svc/ctrl/proto/hydra/v1/deploy.proto
+++ b/svc/ctrl/proto/hydra/v1/deploy.proto
@@ -10,13 +10,10 @@ option go_package = "github.com/unkeyed/unkey/gen/proto/hydra/v1;hydrav1";
 // durable Restate workflows. Each RPC is idempotent and can safely resume from
 // any step after a crash.
 //
-// Deploy, Rollback, and Promote are keyed by {app_id}:{environment_id} so
-// that lifecycle operations within a single environment are serialized
-// (preventing e.g. a rollback from racing with an in-flight deploy) while
-// different environments of the same app — e.g. production vs preview — can
-// deploy in parallel. This means a production push never waits behind a
-// preview build. Workspace-wide concurrency is separately enforced by
-// BuildSlotService.
+// Each object is keyed by deployment ID, so lifecycle operations for one
+// deployment are serialized while separate deployments can run in parallel.
+// Shared app routing state is serialized by RoutingService. Workspace-wide
+// build concurrency is enforced separately by BuildSlotService.
 //
 // Deploy handles the full pipeline from building Docker images through
 // provisioning containers and configuring domain routing. Rollback and Promote
@@ -50,6 +47,10 @@ service DeployService {
   // and waits until enough instances are running again.
   rpc WakeDeployment(WakeDeploymentRequest) returns (WakeDeploymentResponse) {}
 
+  // GarbageCollect deletes a terminal deployment after rechecking its
+  // retention policy. The request ID must match the deployment-keyed object.
+  rpc GarbageCollect(GarbageCollectDeploymentRequest) returns (GarbageCollectDeploymentResponse) {}
+
   // NotifyInstancesReady is called by the control plane when enough instances
   // have become healthy across the required regions. It resolves the awakeable
   // stored by a suspended deploy or wake workflow so it can continue.
@@ -73,6 +74,14 @@ message WakeDeploymentRequest {
 }
 
 message WakeDeploymentResponse {}
+
+message GarbageCollectDeploymentRequest {
+  string deployment_id = 1;
+}
+
+message GarbageCollectDeploymentResponse {
+  bool deleted = 1;
+}
 
 message NotifyInstancesReadyRequest {
   string deployment_id = 1;


### PR DESCRIPTION
## Problem:

We never cleanup any old deployments or old images but we pay for them in storage 

## Solution:

Adda new  Cronjob for garbage collecting both deployments and docker images in depot.dev

## Impact:

Add RPC/proto's for said thing

## Testing:

- `mise run build`
- Result: passed with 0 lint issues.
