### PR TITLE
chore(mise): pin speakeasy to 1.790.1

### DIFF
--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -24,7 +24,7 @@ go = "1.25.1"
 "github:chronark/rask" = "0.5.0"
 "github:golangci/golangci-lint" = "2.12.2"
 "github:pnpm/pnpm" = "11.5.0"
-"github:speakeasy-api/speakeasy" = "1.783.1"
+"github:speakeasy-api/speakeasy" = "1.790.1"
 # stripe CLI: only used by the local-dev billing-flow runbooks (stripe login /
 # stripe listen). The pricing tool itself is pure SDK and does not need it.
 "aqua:stripe/stripe-cli" = "1.42.13"

--- a/.mise/mise.lock
+++ b/.mise/mise.lock
@@ -439,43 +439,43 @@ url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/433138830"
 provenance = "github-attestations"
 
 [[tools."github:speakeasy-api/speakeasy"]]
-version = "1.783.1"
+version = "1.790.1"
 backend = "github:speakeasy-api/speakeasy"
 
 [tools."github:speakeasy-api/speakeasy"."platforms.linux-arm64"]
-checksum = "sha256:545506c2167d29cdb4abe8af5647a403e1a6216bb2fdb01eb4980598be1e8285"
-url = "https://github.com/speakeasy-api/speakeasy/releases/download/v1.783.1/speakeasy_linux_arm64.zip"
-url_api = "https://api.github.com/repos/speakeasy-api/speakeasy/releases/assets/450931224"
+checksum = "sha256:f85f9d958e0518e5f5aeb94f7e7f040e237bc436e36c800f5a5e7c1dbebf58e6"
+url = "https://github.com/speakeasy-api/speakeasy/releases/download/v1.790.1/speakeasy_linux_arm64.zip"
+url_api = "https://api.github.com/repos/speakeasy-api/speakeasy/releases/assets/476546041"
 
 [tools."github:speakeasy-api/speakeasy"."platforms.linux-arm64-musl"]
-checksum = "sha256:545506c2167d29cdb4abe8af5647a403e1a6216bb2fdb01eb4980598be1e8285"
-url = "https://github.com/speakeasy-api/speakeasy/releases/download/v1.783.1/speakeasy_linux_arm64.zip"
-url_api = "https://api.github.com/repos/speakeasy-api/speakeasy/releases/assets/450931224"
+checksum = "sha256:f85f9d958e0518e5f5aeb94f7e7f040e237bc436e36c800f5a5e7c1dbebf58e6"
+url = "https://github.com/speakeasy-api/speakeasy/releases/download/v1.790.1/speakeasy_linux_arm64.zip"
+url_api = "https://api.github.com/repos/speakeasy-api/speakeasy/releases/assets/476546041"
 
 [tools."github:speakeasy-api/speakeasy"."platforms.linux-x64"]
-checksum = "sha256:701713432ad93cb3686ed6a614e049ba7ba431feabe773bb0d9346dad1b2a3a9"
-url = "https://github.com/speakeasy-api/speakeasy/releases/download/v1.783.1/speakeasy_linux_amd64.zip"
-url_api = "https://api.github.com/repos/speakeasy-api/speakeasy/releases/assets/450931227"
+checksum = "sha256:d7b6f66734040ed3195a4a0c1d34fb66192a95c0d8f97a4ea2ac09acd718f032"
+url = "https://github.com/speakeasy-api/speakeasy/releases/download/v1.790.1/speakeasy_linux_amd64.zip"
+url_api = "https://api.github.com/repos/speakeasy-api/speakeasy/releases/assets/476546033"
 
 [tools."github:speakeasy-api/speakeasy"."platforms.linux-x64-musl"]
-checksum = "sha256:701713432ad93cb3686ed6a614e049ba7ba431feabe773bb0d9346dad1b2a3a9"
-url = "https://github.com/speakeasy-api/speakeasy/releases/download/v1.783.1/speakeasy_linux_amd64.zip"
-url_api = "https://api.github.com/repos/speakeasy-api/speakeasy/releases/assets/450931227"
+checksum = "sha256:d7b6f66734040ed3195a4a0c1d34fb66192a95c0d8f97a4ea2ac09acd718f032"
+url = "https://github.com/speakeasy-api/speakeasy/releases/download/v1.790.1/speakeasy_linux_amd64.zip"
+url_api = "https://api.github.com/repos/speakeasy-api/speakeasy/releases/assets/476546033"
 
 [tools."github:speakeasy-api/speakeasy"."platforms.macos-arm64"]
-checksum = "sha256:ca84e65f2e59d283d63872fdd42daf25867de24a47ef44b421e1696543ef7c30"
-url = "https://github.com/speakeasy-api/speakeasy/releases/download/v1.783.1/speakeasy_darwin_arm64.zip"
-url_api = "https://api.github.com/repos/speakeasy-api/speakeasy/releases/assets/450931229"
+checksum = "sha256:440c9b48eeaa03739fa32bdd5e162193c663799744600a0b232e28569e55e1e0"
+url = "https://github.com/speakeasy-api/speakeasy/releases/download/v1.790.1/speakeasy_darwin_arm64.zip"
+url_api = "https://api.github.com/repos/speakeasy-api/speakeasy/releases/assets/476546040"
 
 [tools."github:speakeasy-api/speakeasy"."platforms.macos-x64"]
-checksum = "sha256:edc9679f5d7709d8ad829f69b349d551ac9c749426df3fc480f1dd2b6aa26528"
-url = "https://github.com/speakeasy-api/speakeasy/releases/download/v1.783.1/speakeasy_darwin_amd64.zip"
-url_api = "https://api.github.com/repos/speakeasy-api/speakeasy/releases/assets/450931222"
+checksum = "sha256:8d99435775d4d7e9765fbfb729584c6973ee5290921769f0e4f11b81b3dd5938"
+url = "https://github.com/speakeasy-api/speakeasy/releases/download/v1.790.1/speakeasy_darwin_amd64.zip"
+url_api = "https://api.github.com/repos/speakeasy-api/speakeasy/releases/assets/476546039"
 
 [tools."github:speakeasy-api/speakeasy"."platforms.windows-x64"]
-checksum = "sha256:24fafcc7e25fec4a75dbc9f2371157aaca7fe66a7fb199fcd84b7235168b80e0"
-url = "https://github.com/speakeasy-api/speakeasy/releases/download/v1.783.1/speakeasy_windows_amd64.zip"
-url_api = "https://api.github.com/repos/speakeasy-api/speakeasy/releases/assets/450931228"
+checksum = "sha256:736dcecda4ed05df6a6c1981b2a6c05ebf77d2a4671d02923af6f84459eef638"
+url = "https://github.com/speakeasy-api/speakeasy/releases/download/v1.790.1/speakeasy_windows_amd64.zip"
+url_api = "https://api.github.com/repos/speakeasy-api/speakeasy/releases/assets/476546038"
 
 [[tools."github:tilt-dev/ctlptl"]]
 version = "0.9.3"


### PR DESCRIPTION
## What does this PR do?

Bumps the pinned speakeasy version from `1.783.1` to `1.790.1`, and relocks it.

Fixes ENG-3137

The pin was behind the version that actually generated the committed SDK. `web/internal/api/.speakeasy/workflow.lock` records `speakeasyVersion: 1.790.1` and `src/lib/config.ts` records `genVersion: 2.918.1`, but `.mise/config.toml` still pinned `1.783.1`. So anyone regenerating locally rolled the whole SDK backwards a generator version, on every file, not just the ones they meant to touch.

Nobody chose to move off 1.783.1. The newer version arrived incidentally in `19d0bd248` ("feat(api,ctrl): add verifyDomain endpoint", #6941), which bumped both receipts together — the signature of a regeneration picking up whatever was on that machine rather than a deliberate toolchain change. The pin was never updated to match, so the drift has been sitting there since Aug 17.

**Why 1.790.1 and not the latest (1.795.0):** 1.790.1 is what produced the SDK that is checked in, so pinning to it makes regeneration reproduce the committed output exactly. Jumping to latest would introduce generator churn across the whole SDK, which is the problem this is fixing. Moving to a newer version is worth doing deliberately, with the resulting diff reviewed on its own.

Note `.mise/mise.lock` moves 23 lines: the version plus checksums and URLs for all seven platforms already in the lockfile (linux arm64/x64 and their musl variants, macos arm64/x64, windows-x64). `locked = true` means the pin change alone would leave the toolchain uninstallable, and letting `mise install` do the relocking would have written only the platform of whoever ran it — so this uses `mise lock`, which refreshes every platform. The stale `1.783.1` entries are pruned.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots / recordings

_Not applicable: this PR makes no visual change._

## How should this be tested?

The check that matters is that regenerating the SDK is now a no-op, since the pin matches what is committed:

```bash
mise install                     # installs 1.790.1; provenance verification passes
mise exec -- speakeasy --version # speakeasy version 1.790.1
mise run generate-api-sdk        # completes, tsc passes
git status --porcelain           # only .mise/config.toml and .mise/mise.lock
```

That last line is the point. Before this change the same sequence rewrote `workflow.lock`, `src/lib/config.ts`, and generated files across the SDK. Verified locally on macos-arm64.

Worth a second pair of eyes on a Linux machine, since the lockfile carries checksums for platforms I cannot exercise from here — `mise install` there should resolve 1.790.1 without complaint.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build` — not run; no application code changes
- [x] Ran `pnpm fmt`
- [x] Ran `mise run fmt`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [x] If I made a visual change: Filled out the "Screenshots / recordings" section

### Appreciated

- [ ] Updated the Unkey Docs if changes were necessary
