### PR TITLE
refactor(dashboard): prevents sdk from retrying 5xx errors

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/components/table/components/actions/promotion-dialog.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/components/table/components/actions/promotion-dialog.tsx
@@ -3,7 +3,7 @@
 import { type Deployment, collection } from "@/lib/collections";
 import { shortenId } from "@/lib/shorten-id";
 import { trpc } from "@/lib/trpc/client";
-import { getErrorMessage, getUnkeyClient } from "@/lib/unkey-client";
+import { getErrorMessage, getUnkeyClient, noRetry } from "@/lib/unkey-client";
 import { eq, inArray, useLiveQuery } from "@tanstack/react-db";
 import { useMutation } from "@tanstack/react-query";
 import { Button, DialogContainer, toast } from "@unkey/ui";
@@ -35,7 +35,7 @@ export const PromotionDialog = ({
   );
   const promote = useMutation({
     mutationFn: (deploymentId: string) =>
-      getUnkeyClient().deployments.promoteDeployment({ deploymentId }),
+      getUnkeyClient().deployments.promoteDeployment({ deploymentId }, noRetry),
     onSuccess: () => {
       utils.invalidate();
       toast.success("Promotion completed", {

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/components/table/components/actions/redeploy-dialog.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/components/table/components/actions/redeploy-dialog.tsx
@@ -4,7 +4,7 @@ import { useWorkspaceNavigation } from "@/hooks/use-workspace-navigation";
 import type { Deployment } from "@/lib/collections";
 import { queryClient } from "@/lib/collections/client";
 import { routes } from "@/lib/navigation/routes";
-import { getErrorMessage, getUnkeyClient } from "@/lib/unkey-client";
+import { getErrorMessage, getUnkeyClient, noRetry } from "@/lib/unkey-client";
 import { useMutation } from "@tanstack/react-query";
 import { Button, DialogContainer, toast } from "@unkey/ui";
 import { useRouter } from "next/navigation";
@@ -24,12 +24,15 @@ export const RedeployDialog = ({ isOpen, onClose, selectedDeployment }: Redeploy
 
   const redeploy = useMutation({
     mutationFn: async () => {
-      const res = await getUnkeyClient().deployments.createDeployment({
-        project: selectedDeployment.projectId,
-        app: selectedDeployment.appId,
-        environment: selectedDeployment.environmentId,
-        deployment: { deploymentId: selectedDeployment.id },
-      });
+      const res = await getUnkeyClient().deployments.createDeployment(
+        {
+          project: selectedDeployment.projectId,
+          app: selectedDeployment.appId,
+          environment: selectedDeployment.environmentId,
+          deployment: { deploymentId: selectedDeployment.id },
+        },
+        noRetry,
+      );
       return { deploymentId: res.data.deploymentId };
     },
     onSuccess: async (data) => {

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/components/table/components/actions/rollback-dialog.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/components/table/components/actions/rollback-dialog.tsx
@@ -6,7 +6,7 @@ import {
 } from "@/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/data-provider";
 import { type Deployment, collection } from "@/lib/collections";
 import { trpc } from "@/lib/trpc/client";
-import { getErrorMessage, getUnkeyClient } from "@/lib/unkey-client";
+import { getErrorMessage, getUnkeyClient, noRetry } from "@/lib/unkey-client";
 import { and, eq, inArray, useLiveQuery } from "@tanstack/react-db";
 import { useMutation } from "@tanstack/react-query";
 import { Button, DialogContainer, toast } from "@unkey/ui";
@@ -41,7 +41,7 @@ export const RollbackDialog = ({
 
   const rollback = useMutation({
     mutationFn: (deploymentId: string) =>
-      getUnkeyClient().deployments.rollbackDeployment({ deploymentId }),
+      getUnkeyClient().deployments.rollbackDeployment({ deploymentId }, noRetry),
     onSuccess: () => {
       utils.invalidate();
       toast.success("Rollback completed", {

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/components/table/components/actions/stop-dialog.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/components/table/components/actions/stop-dialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { type Deployment, collection } from "@/lib/collections";
-import { getErrorMessage, getUnkeyClient } from "@/lib/unkey-client";
+import { getErrorMessage, getUnkeyClient, noRetry } from "@/lib/unkey-client";
 import { useMutation } from "@tanstack/react-query";
 import { Button, DialogContainer, toast } from "@unkey/ui";
 import { DeploymentCard } from "./components/deployment-card";
@@ -15,7 +15,7 @@ type StopDialogProps = {
 export const StopDialog = ({ isOpen, onClose, deployment }: StopDialogProps) => {
   const stop = useMutation({
     mutationFn: (deploymentId: string) =>
-      getUnkeyClient().deployments.stopDeployment({ deploymentId }),
+      getUnkeyClient().deployments.stopDeployment({ deploymentId }, noRetry),
     onSuccess: () => {
       collection.deployments.utils.refetch();
       onClose();

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/components/table/components/actions/wake-dialog.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/components/table/components/actions/wake-dialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { type Deployment, collection } from "@/lib/collections";
-import { getErrorMessage, getUnkeyClient } from "@/lib/unkey-client";
+import { getErrorMessage, getUnkeyClient, noRetry } from "@/lib/unkey-client";
 import { useMutation } from "@tanstack/react-query";
 import { Button, DialogContainer, toast } from "@unkey/ui";
 import { DeploymentCard } from "./components/deployment-card";
@@ -15,7 +15,7 @@ type WakeDialogProps = {
 export const WakeDialog = ({ isOpen, onClose, deployment }: WakeDialogProps) => {
   const wake = useMutation({
     mutationFn: (deploymentId: string) =>
-      getUnkeyClient().deployments.startDeployment({ deploymentId }),
+      getUnkeyClient().deployments.startDeployment({ deploymentId }, noRetry),
     onSuccess: () => {
       collection.deployments.utils.refetch();
       onClose();

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/navigations/create-deployment-button.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/navigations/create-deployment-button.tsx
@@ -9,7 +9,7 @@ import { UnsupportedDeployRefError, parseDeployRef } from "@/lib/deploy-ref";
 import { githubUrl } from "@/lib/github-url";
 import { routes } from "@/lib/navigation/routes";
 import { trpc } from "@/lib/trpc/client";
-import { getErrorMessage, getUnkeyClient } from "@/lib/unkey-client";
+import { getErrorMessage, getUnkeyClient, noRetry } from "@/lib/unkey-client";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { and, eq, useLiveQuery } from "@tanstack/react-db";
 import { useMutation } from "@tanstack/react-query";
@@ -194,12 +194,15 @@ export const CreateDeploymentButton = ({
       git?: ReturnType<typeof parseDeployRef>;
       image?: string;
     }) => {
-      const res = await getUnkeyClient().deployments.createDeployment({
-        project: projectId,
-        app: appId,
-        environment: source.environment,
-        ...(source.image ? { image: { dockerImage: source.image } } : { git: source.git ?? {} }),
-      });
+      const res = await getUnkeyClient().deployments.createDeployment(
+        {
+          project: projectId,
+          app: appId,
+          environment: source.environment,
+          ...(source.image ? { image: { dockerImage: source.image } } : { git: source.git ?? {} }),
+        },
+        noRetry,
+      );
       return { deploymentId: res.data.deploymentId };
     },
     async onSuccess(data) {

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/overview/components/undo-rollback-dialog.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/overview/components/undo-rollback-dialog.tsx
@@ -2,7 +2,7 @@
 
 import { type Deployment, collection } from "@/lib/collections";
 import { shortenId } from "@/lib/shorten-id";
-import { getErrorMessage, getUnkeyClient } from "@/lib/unkey-client";
+import { getErrorMessage, getUnkeyClient, noRetry } from "@/lib/unkey-client";
 import { cn } from "@/lib/utils";
 import { useMutation } from "@tanstack/react-query";
 import { CodeBranch } from "@unkey/icons";
@@ -36,7 +36,7 @@ export function UndoRollbackDialog({
 
   const promote = useMutation({
     mutationFn: (deploymentId: string) =>
-      getUnkeyClient().deployments.promoteDeployment({ deploymentId }),
+      getUnkeyClient().deployments.promoteDeployment({ deploymentId }, noRetry),
     onSuccess: () => {
       toast.success("Rollback undone", {
         description: "Automatic production deploys have resumed.",

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/components/pending-redeploy-banner.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/components/pending-redeploy-banner.tsx
@@ -8,7 +8,7 @@ import {
   useSettingsBannerVisible,
 } from "@/lib/collections/deploy/environment-settings";
 import { routes } from "@/lib/navigation/routes";
-import { getErrorMessage, getUnkeyClient } from "@/lib/unkey-client";
+import { getErrorMessage, getUnkeyClient, noRetry } from "@/lib/unkey-client";
 import { cn } from "@/lib/utils";
 import { useMutation } from "@tanstack/react-query";
 import { Hammer2, XMark } from "@unkey/icons";
@@ -39,12 +39,15 @@ export function PendingRedeployBanner() {
       appId: string;
       environmentId: string;
     }) => {
-      const res = await getUnkeyClient().deployments.createDeployment({
-        project: deployment.projectId,
-        app: deployment.appId,
-        environment: deployment.environmentId,
-        deployment: { deploymentId: deployment.id },
-      });
+      const res = await getUnkeyClient().deployments.createDeployment(
+        {
+          project: deployment.projectId,
+          app: deployment.appId,
+          environment: deployment.environmentId,
+          deployment: { deploymentId: deployment.id },
+        },
+        noRetry,
+      );
       return { deploymentId: res.data.deploymentId };
     },
     onSuccess: async (data) => {

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/new/steps/deploy-action.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/new/steps/deploy-action.tsx
@@ -2,7 +2,7 @@
 
 import { useDeployActionGate } from "@/app/(app)/[workspaceSlug]/projects/_components/hooks/use-deploy-action-gate";
 import { queryClient } from "@/lib/collections/client";
-import { getErrorMessage, getUnkeyClient } from "@/lib/unkey-client";
+import { getErrorMessage, getUnkeyClient, noRetry } from "@/lib/unkey-client";
 import { useMutation } from "@tanstack/react-query";
 import { Button, toast, useStepWizard } from "@unkey/ui";
 import { useProjectData } from "../../[appId]/(overview)/data-provider";
@@ -29,13 +29,16 @@ export const DeployAction = ({
 
   const deploy = useMutation({
     mutationFn: async (environment: string) => {
-      const res = await getUnkeyClient().deployments.createDeployment({
-        project: projectId,
-        app: appId,
-        environment,
-        // No branch or commitSha: the API builds the app's default branch.
-        git: {},
-      });
+      const res = await getUnkeyClient().deployments.createDeployment(
+        {
+          project: projectId,
+          app: appId,
+          environment,
+          // No branch or commitSha: the API builds the app's default branch.
+          git: {},
+        },
+        noRetry,
+      );
       return { deploymentId: res.data.deploymentId };
     },
     onSuccess: async (data) => {

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/new/steps/deploy-image-card.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/new/steps/deploy-image-card.tsx
@@ -5,7 +5,7 @@ import { useWorkspaceNavigation } from "@/hooks/use-workspace-navigation";
 import { queryClient } from "@/lib/collections/client";
 import { routes } from "@/lib/navigation/routes";
 import { trpc } from "@/lib/trpc/client";
-import { getErrorMessage, getUnkeyClient } from "@/lib/unkey-client";
+import { getErrorMessage, getUnkeyClient, noRetry } from "@/lib/unkey-client";
 import { useMutation } from "@tanstack/react-query";
 import { ChevronLeft, Docker } from "@unkey/icons";
 import { Button, Input, toast } from "@unkey/ui";
@@ -40,12 +40,15 @@ export const DeployImageCard = ({
 
   const createDeployment = useMutation({
     mutationFn: async (source: { environment: string; image: string }) => {
-      const res = await getUnkeyClient().deployments.createDeployment({
-        project: projectId,
-        app: appId,
-        environment: source.environment,
-        image: { dockerImage: source.image },
-      });
+      const res = await getUnkeyClient().deployments.createDeployment(
+        {
+          project: projectId,
+          app: appId,
+          environment: source.environment,
+          image: { dockerImage: source.image },
+        },
+        noRetry,
+      );
       return { deploymentId: res.data.deploymentId };
     },
     async onSuccess(data) {

--- a/web/apps/dashboard/lib/unkey-client.test.ts
+++ b/web/apps/dashboard/lib/unkey-client.test.ts
@@ -5,7 +5,7 @@ import {
   PreconditionFailedErrorResponse,
 } from "@unkey/api/models/errors";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { getErrorMessage, getErrorToast, getUnkeyClient } from "./unkey-client";
+import { getErrorMessage, getErrorToast, getUnkeyClient, noRetry } from "./unkey-client";
 
 function makeErrorResponse<T>(
   Ctor: new (
@@ -56,6 +56,48 @@ describe("getUnkeyClient", () => {
     expect(request.method).toBe("POST");
     expect(request.headers.has("Authorization")).toBe(false);
     await expect(request.clone().json()).resolves.toEqual({ keyId: "key_1234abcd" });
+  });
+
+  it("sends a deployment create once when the API returns 500", async () => {
+    const requests = stubServerError();
+
+    await expect(
+      getUnkeyClient().deployments.createDeployment(
+        {
+          project: "proj_kebap",
+          app: "app_kebap",
+          environment: "production",
+          image: { dockerImage: "kebap:latest" },
+        },
+        noRetry,
+      ),
+    ).rejects.toThrow();
+
+    expect(requests).toHaveLength(1);
+  });
+
+  it("retries a 500 when a backoff strategy is configured", async () => {
+    const requests = stubServerError();
+
+    await expect(
+      getUnkeyClient().deployments.createDeployment(
+        {
+          project: "proj_kebap",
+          app: "app_kebap",
+          environment: "production",
+          image: { dockerImage: "kebap:latest" },
+        },
+        {
+          retries: {
+            strategy: "backoff",
+            backoff: { initialInterval: 1, maxInterval: 2, exponent: 1, maxElapsedTime: 20 },
+            retryConnectionErrors: true,
+          },
+        },
+      ),
+    ).rejects.toThrow();
+
+    expect(requests.length).toBeGreaterThan(1);
   });
 });
 
@@ -134,3 +176,28 @@ describe("getErrorToast", () => {
     });
   });
 });
+
+// Counts the requests the SDK actually put on the wire while every attempt
+// fails, so a test can tell one attempt from a retry storm.
+function stubServerError(): Request[] {
+  const requests: Request[] = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      requests.push(input instanceof Request ? input : new Request(input, init));
+      return new Response(
+        JSON.stringify({
+          meta: { requestId: "req_123" },
+          error: {
+            detail: "Something went wrong.",
+            status: 500,
+            title: "Internal Server Error",
+            type: "https://unkey.com/docs/errors/unkey/application/internal_server_error",
+          },
+        }),
+        { status: 500, headers: { "Content-Type": "application/json" } },
+      );
+    }),
+  );
+  return requests;
+}

--- a/web/apps/dashboard/lib/unkey-client.ts
+++ b/web/apps/dashboard/lib/unkey-client.ts
@@ -19,6 +19,15 @@ export function getUnkeyClient(): Unkey {
 }
 
 /**
+ * Per-call options for operations that start real work in the control plane:
+ * deployment create, promote, rollback, start, and stop. The SDK otherwise
+ * retries every 5XX with backoff, and a 5XX does not prove the operation did
+ * not run, so a retry can start a second deployment. The user retries from the
+ * UI instead. Reads keep the SDK default.
+ */
+export const noRetry = { retries: { strategy: "none" } } as const;
+
+/**
  * Maps an SDK error to a toast title and description. `fallbackMessage` names
  * the failed operation, e.g. "Failed to Delete App", and `fallbackDescription`
  * replaces the generic description. Both apply only to errors we don't classify.


### PR DESCRIPTION
This PR prevents the SDK from retrying 5XX errors. Otherwise SDK sends lots of retry requests and causes redundant traffic for our API.