### PR TITLE
feat(ssrf): SSRF-guarded HTTP client for customer-supplied endpoints

### DIFF
--- a/pkg/dns/domainconnect/client.go
+++ b/pkg/dns/domainconnect/client.go
@@ -13,6 +13,8 @@ import (
 	"time"
 
 	"golang.org/x/net/publicsuffix"
+
+	"github.com/unkeyed/unkey/pkg/ssrf"
 )
 
 // The _domainconnect TXT value is set by whoever controls DNS for the user-
@@ -163,14 +165,11 @@ func lookupDomainConnectRecord(ctx context.Context, domain string) (string, erro
 	return strings.Join(records, ""), nil
 }
 
-// domainConnectHTTPClient refuses redirects so an allowlisted provider host
-// cannot bounce the request to a non-allowlisted destination.
-var domainConnectHTTPClient = &http.Client{
-	Timeout: 10 * time.Second,
-	CheckRedirect: func(*http.Request, []*http.Request) error {
-		return http.ErrUseLastResponse
-	},
-}
+// domainConnectHTTPClient hardens the settings fetch beyond the host
+// allowlist: [ssrf.New] refuses redirects, so an allowlisted provider host
+// cannot bounce the request to a non-allowlisted destination, and it rejects
+// hosts that resolve to private or loopback addresses.
+var domainConnectHTTPClient = ssrf.New(ssrf.WithTimeout(10 * time.Second))
 
 // doJSON performs a GET request and decodes the JSON response.
 func doJSON(ctx context.Context, url string, result any) error {

--- a/pkg/ssrf/doc.go
+++ b/pkg/ssrf/doc.go
@@ -1,0 +1,24 @@
+// Package ssrf builds HTTP clients for requests to customer-supplied
+// endpoints (logdrains, outbound webhooks, and similar integrations).
+//
+// URLs that customers control are untrusted input: a hostname can resolve to
+// our own infrastructure (cloud metadata services, internal services,
+// loopback). Clients from [New] therefore guard against SSRF at dial time:
+// every resolved IP is checked with [IsForbiddenIP], redirects are not
+// followed unless [FollowRedirects] is set (and then only to https targets),
+// and response header size is capped. The guard runs after DNS resolution,
+// so DNS-rebinding to a private address is also caught.
+//
+// Use [ValidateEndpoint] at configuration time to reject non-https URLs
+// early, and [New] for the actual requests:
+//
+//	if err := ssrf.ValidateEndpoint(endpoint); err != nil {
+//		return err
+//	}
+//	client := ssrf.New(ssrf.WithTimeout(30 * time.Second))
+//	resp, err := client.Do(req)
+//
+// The guard is not the right tool for calls that legitimately target private
+// addresses, such as in-cluster service traffic; it protects egress to
+// endpoints outside our infrastructure.
+package ssrf

--- a/pkg/ssrf/ssrf.go
+++ b/pkg/ssrf/ssrf.go
@@ -1,0 +1,150 @@
+package ssrf
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// config collects the option values applied by [New] and [ValidateEndpoint].
+// The zero value is the safe default: guards on, no timeout, no redirects.
+type config struct {
+	timeout        time.Duration
+	unsafeAllowAll bool
+	redirectsMax   int
+}
+
+// Option configures [New] and [ValidateEndpoint].
+type Option func(*config)
+
+// WithTimeout bounds the whole request, including connect, redirects, and
+// reading the response body. Zero means no timeout.
+func WithTimeout(timeout time.Duration) Option {
+	return func(c *config) {
+		c.timeout = timeout
+	}
+}
+
+// UnsafeAllowAll disables every guard: the SSRF check on resolved IPs, the
+// https requirement on endpoints, and the https requirement on redirect
+// targets. Development and tests only.
+func UnsafeAllowAll() Option {
+	return func(c *config) {
+		c.unsafeAllowAll = true
+	}
+}
+
+// FollowRedirects lets the client follow up to redirectsMax redirects.
+// Redirect targets must use https unless [UnsafeAllowAll] is set. Without
+// this option the client does not follow redirects: the first redirect
+// response fails the request.
+func FollowRedirects(redirectsMax int) Option {
+	return func(c *config) {
+		c.redirectsMax = redirectsMax
+	}
+}
+
+// New returns an HTTP client hardened for customer-supplied endpoints.
+func New(opts ...Option) *http.Client {
+	cfg := applyOptions(opts)
+	dialer := new(net.Dialer)
+	dialer.Timeout = 30 * time.Second
+	dialer.KeepAlive = 30 * time.Second
+	transport := &http.Transport{
+		DialContext:            dialContext(dialer, cfg),
+		ForceAttemptHTTP2:      false,
+		MaxIdleConns:           100,
+		IdleConnTimeout:        90 * time.Second,
+		TLSHandshakeTimeout:    10 * time.Second,
+		ExpectContinueTimeout:  time.Second,
+		ResponseHeaderTimeout:  30 * time.Second,
+		MaxResponseHeaderBytes: 1 << 20,
+	}
+	return &http.Client{Transport: transport, Timeout: cfg.timeout, CheckRedirect: checkRedirect(cfg)}
+}
+
+// ValidateEndpoint rejects endpoints that are not absolute https URLs.
+// [UnsafeAllowAll] additionally permits plain http, for development and
+// tests only.
+func ValidateEndpoint(raw string, opts ...Option) error {
+	cfg := applyOptions(opts)
+	endpoint, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("parse endpoint: %w", err)
+	}
+	if endpoint.Host == "" || (endpoint.Scheme != "https" && !(cfg.unsafeAllowAll && endpoint.Scheme == "http")) {
+		return errors.New("endpoint must be an absolute https URL")
+	}
+	return nil
+}
+
+// IsForbiddenIP reports whether the SSRF guard rejects the resolved address.
+// It rejects nil, loopback, private (RFC 1918 and ULA), link-local,
+// unspecified, and multicast addresses.
+func IsForbiddenIP(ip net.IP) bool {
+	return ip == nil || ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() || ip.IsUnspecified() || ip.IsMulticast()
+}
+
+// applyOptions folds opts into a config, starting from the safe zero value.
+func applyOptions(opts []Option) config {
+	var cfg config
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return cfg
+}
+
+// dialContext returns the transport dial function that enforces the SSRF
+// guard. It resolves the host itself and dials resolved IPs directly, so the
+// address that passed the check is the address that is dialed; checking
+// before a separate dial would leave a DNS-rebinding window.
+func dialContext(dialer *net.Dialer, cfg config) func(context.Context, string, string) (net.Conn, error) {
+	return func(ctx context.Context, network, address string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(address)
+		if err != nil {
+			return nil, fmt.Errorf("split dial address: %w", err)
+		}
+		ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+		if err != nil {
+			return nil, fmt.Errorf("resolve endpoint host: %w", err)
+		}
+		var dialErr error
+		for _, resolved := range ips {
+			if !cfg.unsafeAllowAll && IsForbiddenIP(resolved.IP) {
+				continue
+			}
+			conn, err := dialer.DialContext(ctx, network, net.JoinHostPort(resolved.IP.String(), port))
+			if err == nil {
+				return conn, nil
+			}
+			dialErr = err
+		}
+		if dialErr != nil {
+			return nil, fmt.Errorf("dial endpoint: %w", dialErr)
+		}
+		return nil, errors.New("endpoint host resolved only to forbidden IP addresses")
+	}
+}
+
+// checkRedirect returns the client redirect policy for cfg: refuse all
+// redirects by default, and with [FollowRedirects] allow up to the configured
+// number of https-only hops. The dial guard still applies to every hop.
+func checkRedirect(cfg config) func(*http.Request, []*http.Request) error {
+	return func(req *http.Request, via []*http.Request) error {
+		if cfg.redirectsMax <= 0 {
+			return errors.New("redirects are not allowed")
+		}
+		if !cfg.unsafeAllowAll && req.URL.Scheme != "https" {
+			return errors.New("redirect endpoint must use https")
+		}
+		if len(via) > cfg.redirectsMax {
+			return fmt.Errorf("stopped after %d redirects", cfg.redirectsMax)
+		}
+		return nil
+	}
+}

--- a/pkg/ssrf/ssrf.go
+++ b/pkg/ssrf/ssrf.go
@@ -102,14 +102,6 @@ func applyOptions(opts []Option) config {
 // dialContext returns the transport dial function that enforces the SSRF
 // guard. It resolves the host itself and dials resolved IPs directly, so the
 // address that passed the check is exactly the address that is dialed.
-//
-// This closes the DNS-rebinding hole: the attacker controls the DNS server
-// for their own hostname, so they can answer the first lookup with a harmless
-// public IP and the next lookup with a private one (a TTL of zero forces the
-// re-lookup). If we checked the first answer and then handed the hostname to
-// a separate dial step, that step would resolve again and could connect to
-// the private address that was never checked. Resolving once and dialing the
-// checked IP leaves no second lookup to exploit.
 func dialContext(dialer *net.Dialer, cfg config) func(context.Context, string, string) (net.Conn, error) {
 	return func(ctx context.Context, network, address string) (net.Conn, error) {
 		host, port, err := net.SplitHostPort(address)
@@ -125,6 +117,14 @@ func dialContext(dialer *net.Dialer, cfg config) func(context.Context, string, s
 			if !cfg.unsafeAllowAll && IsForbiddenIP(resolved.IP) {
 				continue
 			}
+
+			// We must dial the IP directly because the attacker controls the DNS server
+			// for their own hostname, so they can answer the first lookup with a harmless
+			// public IP and the next lookup with a private one (a TTL of zero forces the
+			// re-lookup). If we checked the first answer and then handed the hostname to
+			// a separate dial step, that step would resolve again and could connect to
+			// the private address that was never checked. Resolving once and dialing the
+			// checked IP leaves no second lookup to exploit.
 			conn, err := dialer.DialContext(ctx, network, net.JoinHostPort(resolved.IP.String(), port))
 			if err == nil {
 				return conn, nil

--- a/pkg/ssrf/ssrf.go
+++ b/pkg/ssrf/ssrf.go
@@ -101,8 +101,15 @@ func applyOptions(opts []Option) config {
 
 // dialContext returns the transport dial function that enforces the SSRF
 // guard. It resolves the host itself and dials resolved IPs directly, so the
-// address that passed the check is the address that is dialed; checking
-// before a separate dial would leave a DNS-rebinding window.
+// address that passed the check is exactly the address that is dialed.
+//
+// This closes the DNS-rebinding hole: the attacker controls the DNS server
+// for their own hostname, so they can answer the first lookup with a harmless
+// public IP and the next lookup with a private one (a TTL of zero forces the
+// re-lookup). If we checked the first answer and then handed the hostname to
+// a separate dial step, that step would resolve again and could connect to
+// the private address that was never checked. Resolving once and dialing the
+// checked IP leaves no second lookup to exploit.
 func dialContext(dialer *net.Dialer, cfg config) func(context.Context, string, string) (net.Conn, error) {
 	return func(ctx context.Context, network, address string) (net.Conn, error) {
 		host, port, err := net.SplitHostPort(address)

--- a/pkg/ssrf/ssrf_test.go
+++ b/pkg/ssrf/ssrf_test.go
@@ -1,0 +1,85 @@
+package ssrf
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestIsForbiddenIP guarantees the SSRF guard rejects every address class
+// that reaches our own infrastructure (loopback, RFC 1918, link-local
+// including the cloud metadata range, ULA) while allowing public addresses.
+func TestIsForbiddenIP(t *testing.T) {
+	tests := map[string]bool{
+		"127.0.0.1": true, "10.0.0.1": true, "172.16.0.1": true,
+		"192.168.1.1": true, "169.254.169.254": true, "::1": true,
+		"fe80::1": true, "fc00::1": true, "93.184.216.34": false,
+		"2606:2800:220:1:248:1893:25c8:1946": false,
+	}
+	for raw, forbidden := range tests {
+		t.Run(raw, func(t *testing.T) {
+			require.Equal(t, forbidden, IsForbiddenIP(net.ParseIP(raw)))
+		})
+	}
+}
+
+// TestRedirectsAreNotFollowedByDefault guarantees that a redirecting endpoint
+// cannot bounce a client from [New] to another destination unless the caller
+// opted in with [FollowRedirects].
+func TestRedirectsAreNotFollowedByDefault(t *testing.T) {
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(target.Close)
+	redirecting := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL, http.StatusFound)
+	}))
+	t.Cleanup(redirecting.Close)
+
+	// Servers listen on loopback over plain http, so the guards must be off.
+	client := New(UnsafeAllowAll())
+	//nolint:noctx // Direct Get keeps the redirect-policy test minimal.
+	resp, err := client.Get(redirecting.URL)
+	if resp != nil {
+		require.NoError(t, resp.Body.Close())
+	}
+	require.ErrorContains(t, err, "redirects are not allowed")
+
+	client = New(UnsafeAllowAll(), FollowRedirects(3))
+	//nolint:noctx // Direct Get keeps the redirect-policy test minimal.
+	resp, err = client.Get(redirecting.URL)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+// TestValidateEndpoint guarantees that configuration-time validation only
+// accepts absolute https URLs, with plain http permitted solely behind
+// [UnsafeAllowAll].
+func TestValidateEndpoint(t *testing.T) {
+	tests := []struct {
+		name     string
+		endpoint string
+		opts     []Option
+		wantErr  bool
+	}{
+		{name: "accepts https", endpoint: "https://example.com/logs", wantErr: false},
+		{name: "rejects http", endpoint: "http://example.com/logs", wantErr: true},
+		{name: "accepts http with UnsafeAllowAll", endpoint: "http://example.com/logs", opts: []Option{UnsafeAllowAll()}, wantErr: false},
+		{name: "rejects relative URL", endpoint: "example.com/logs", wantErr: true},
+		{name: "rejects empty string", endpoint: "", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateEndpoint(tt.endpoint, tt.opts...)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds a new `pkg/ssrf` package to centralise the logic for preventing SSRF attacks.
We already needed this before in the `domainconnect` package and I recall @ogzhanolguncu needed it for something and also we need it soon for logdrains.


`pkg/ssrf` exports two main methods:

`ValidateEndpoint(..)` to just validate a url, which we can use in create/update handlers in the api:

```go
err := ssrf.ValidateEndpoint(endpoint)
```

And `New(..)` to create an `http.Client` with the validation baked in:

```go
client := ssrf.New(
  ssrf.WithTimeout(30 * time.Second), // defaults to `http.Client` defaults
  FollowRedirects(3),                 // default is to not follow redirects at all
  UnsafeAllowAll(),                   // just for testing
)
resp, err := client.Do(req)
```
