### PR TITLE
Keep CLI test helpers out of release builds

### DIFF
--- a/cmd/api/analytics/get_verifications_test.go
+++ b/cmd/api/analytics/get_verifications_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/unkeyed/unkey/cmd/api/util"
+	"github.com/unkeyed/unkey/cmd/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
 
@@ -42,7 +42,7 @@ func TestGetVerifications(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := util.CaptureRequestWithData[openapi.V2AnalyticsGetVerificationsRequestBody](t, Cmd(), tt.args, []any{})
+			req := testutil.CaptureRequestWithData[openapi.V2AnalyticsGetVerificationsRequestBody](t, Cmd(), tt.args, []any{})
 			require.Equal(t, tt.want, req)
 		})
 	}

--- a/cmd/api/apis/create_api_test.go
+++ b/cmd/api/apis/create_api_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/unkeyed/unkey/cmd/api/util"
+	"github.com/unkeyed/unkey/cmd/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
 
@@ -39,7 +39,7 @@ func TestCreateAPI(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := util.CaptureRequest[openapi.V2ApisCreateApiRequestBody](t, Cmd(), tt.args)
+			req := testutil.CaptureRequest[openapi.V2ApisCreateApiRequestBody](t, Cmd(), tt.args)
 			require.Equal(t, tt.want, req)
 		})
 	}

--- a/cmd/api/apis/delete_api_test.go
+++ b/cmd/api/apis/delete_api_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/unkeyed/unkey/cmd/api/util"
+	"github.com/unkeyed/unkey/cmd/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
 
@@ -25,7 +25,7 @@ func TestDeleteAPI(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := util.CaptureRequest[openapi.V2ApisDeleteApiRequestBody](t, Cmd(), tt.args)
+			req := testutil.CaptureRequest[openapi.V2ApisDeleteApiRequestBody](t, Cmd(), tt.args)
 			require.Equal(t, tt.want, req)
 		})
 	}

--- a/cmd/api/apis/get_api_test.go
+++ b/cmd/api/apis/get_api_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/unkeyed/unkey/cmd/api/util"
+	"github.com/unkeyed/unkey/cmd/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
 
@@ -32,7 +32,7 @@ func TestGetAPI(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := util.CaptureRequest[openapi.V2ApisGetApiRequestBody](t, Cmd(), tt.args)
+			req := testutil.CaptureRequest[openapi.V2ApisGetApiRequestBody](t, Cmd(), tt.args)
 			require.Equal(t, tt.want, req)
 		})
 	}

--- a/cmd/api/apis/list_keys_test.go
+++ b/cmd/api/apis/list_keys_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/unkeyed/unkey/cmd/api/util"
+	"github.com/unkeyed/unkey/cmd/api/internal/testutil"
 	"github.com/unkeyed/unkey/pkg/ptr"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
@@ -93,7 +93,7 @@ func TestListKeys(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := util.CaptureRequestWithData[openapi.V2ApisListKeysRequestBody](t, Cmd(), tt.args, []any{})
+			req := testutil.CaptureRequestWithData[openapi.V2ApisListKeysRequestBody](t, Cmd(), tt.args, []any{})
 			require.Equal(t, tt.want, req)
 		})
 	}

--- a/cmd/api/identities/create_identity_test.go
+++ b/cmd/api/identities/create_identity_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/unkeyed/unkey/cmd/api/util"
+	"github.com/unkeyed/unkey/cmd/api/internal/testutil"
 	"github.com/unkeyed/unkey/pkg/ptr"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
@@ -55,7 +55,7 @@ func TestCreateIdentity(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := util.CaptureRequest[openapi.V2IdentitiesCreateIdentityRequestBody](t, Cmd(), tt.args)
+			req := testutil.CaptureRequest[openapi.V2IdentitiesCreateIdentityRequestBody](t, Cmd(), tt.args)
 			require.Equal(t, tt.want, req)
 		})
 	}

--- a/cmd/api/identities/delete_identity_test.go
+++ b/cmd/api/identities/delete_identity_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/unkeyed/unkey/cmd/api/util"
+	"github.com/unkeyed/unkey/cmd/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
 
@@ -39,7 +39,7 @@ func TestDeleteIdentity(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := util.CaptureRequest[openapi.V2IdentitiesDeleteIdentityRequestBody](t, Cmd(), tt.args)
+			req := testutil.CaptureRequest[openapi.V2IdentitiesDeleteIdentityRequestBody](t, Cmd(), tt.args)
 			require.Equal(t, tt.want, req)
 		})
 	}

--- a/cmd/api/identities/get_identity_test.go
+++ b/cmd/api/identities/get_identity_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/unkeyed/unkey/cmd/api/util"
+	"github.com/unkeyed/unkey/cmd/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
 
@@ -39,7 +39,7 @@ func TestGetIdentity(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := util.CaptureRequest[openapi.V2IdentitiesGetIdentityRequestBody](t, Cmd(), tt.args)
+			req := testutil.CaptureRequest[openapi.V2IdentitiesGetIdentityRequestBody](t, Cmd(), tt.args)
 			require.Equal(t, tt.want, req)
 		})
 	}

--- a/cmd/api/identities/list_identities_test.go
+++ b/cmd/api/identities/list_identities_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/unkeyed/unkey/cmd/api/util"
+	"github.com/unkeyed/unkey/cmd/api/internal/testutil"
 	"github.com/unkeyed/unkey/pkg/ptr"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
@@ -41,7 +41,7 @@ func TestListIdentities(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := util.CaptureRequestWithData[openapi.V2IdentitiesListIdentitiesRequestBody](t, Cmd(), tt.args, []any{})
+			req := testutil.CaptureRequestWithData[openapi.V2IdentitiesListIdentitiesRequestBody](t, Cmd(), tt.args, []any{})
 			require.Equal(t, tt.want, req)
 		})
 	}

--- a/cmd/api/identities/update_identity_test.go
+++ b/cmd/api/identities/update_identity_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/unkeyed/unkey/cmd/api/util"
+	"github.com/unkeyed/unkey/cmd/api/internal/testutil"
 	"github.com/unkeyed/unkey/pkg/ptr"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
@@ -65,7 +65,7 @@ func TestUpdateIdentity(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := util.CaptureRequest[openapi.V2IdentitiesUpdateIdentityRequestBody](t, Cmd(), tt.args)
+			req := testutil.CaptureRequest[openapi.V2IdentitiesUpdateIdentityRequestBody](t, Cmd(), tt.args)
 			require.Equal(t, tt.want, req)
 		})
 	}

--- a/cmd/api/internal/testutil/testharness.go
+++ b/cmd/api/internal/testutil/testharness.go
@@ -1,4 +1,5 @@
-package util
+// Package testutil provides shared test helpers for CLI API commands.
+package testutil
 
 import (
 	"bytes"
@@ -30,8 +31,7 @@ type responseEnvelope struct {
 //
 // Example:
 //
-//	req, err := util.CaptureRequest[handler.Request](t, Cmd(), "keys create-key --api-id=api_123")
-//	require.NoError(t, err)
+//	req := testutil.CaptureRequest[handler.Request](t, Cmd(), "keys create-key --api-id=api_123")
 //	require.Equal(t, handler.Request{ApiId: "api_123"}, req)
 func CaptureRequest[T any](t *testing.T, cmd *cli.Command, args string) T {
 	t.Helper()

--- a/cmd/api/keys/add_permissions_test.go
+++ b/cmd/api/keys/add_permissions_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/unkeyed/unkey/cmd/api/util"
+	"github.com/unkeyed/unkey/cmd/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
 
@@ -26,7 +26,7 @@ func TestAddPermissions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := util.CaptureRequestWithData[openapi.V2KeysAddPermissionsRequestBody](t, Cmd(), tt.args, []any{})
+			req := testutil.CaptureRequestWithData[openapi.V2KeysAddPermissionsRequestBody](t, Cmd(), tt.args, []any{})
 			require.Equal(t, tt.want, req)
 		})
 	}

--- a/cmd/api/keys/add_roles_test.go
+++ b/cmd/api/keys/add_roles_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/unkeyed/unkey/cmd/api/util"
+	"github.com/unkeyed/unkey/cmd/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
 
@@ -34,7 +34,7 @@ func TestAddRoles(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := util.CaptureRequestWithData[openapi.V2KeysAddRolesRequestBody](t, Cmd(), tt.args, []any{})
+			req := testutil.CaptureRequestWithData[openapi.V2KeysAddRolesRequestBody](t, Cmd(), tt.args, []any{})
 			require.Equal(t, tt.want, req)
 		})
 	}

--- a/cmd/api/keys/create_key_test.go
+++ b/cmd/api/keys/create_key_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/oapi-codegen/nullable"
 	"github.com/stretchr/testify/require"
-	"github.com/unkeyed/unkey/cmd/api/util"
+	"github.com/unkeyed/unkey/cmd/api/internal/testutil"
 	"github.com/unkeyed/unkey/pkg/ptr"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
@@ -166,7 +166,7 @@ func TestCreateKey(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := util.CaptureRequest[openapi.V2KeysCreateKeyRequestBody](t, Cmd(), tt.args)
+			req := testutil.CaptureRequest[openapi.V2KeysCreateKeyRequestBody](t, Cmd(), tt.args)
 			require.Equal(t, tt.want, req)
 		})
 	}

--- a/cmd/api/keys/delete_key_test.go
+++ b/cmd/api/keys/delete_key_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/unkeyed/unkey/cmd/api/util"
+	"github.com/unkeyed/unkey/cmd/api/internal/testutil"
 	"github.com/unkeyed/unkey/pkg/ptr"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
@@ -35,7 +35,7 @@ func TestDeleteKey(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := util.CaptureRequest[openapi.V2KeysDeleteKeyRequestBody](t, Cmd(), tt.args)
+			req := testutil.CaptureRequest[openapi.V2KeysDeleteKeyRequestBody](t, Cmd(), tt.args)
 			require.Equal(t, tt.want, req)
 		})
 	}

--- a/cmd/api/keys/get_key_test.go
+++ b/cmd/api/keys/get_key_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/unkeyed/unkey/cmd/api/util"
+	"github.com/unkeyed/unkey/cmd/api/internal/testutil"
 	"github.com/unkeyed/unkey/pkg/ptr"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
@@ -35,7 +35,7 @@ func TestGetKey(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := util.CaptureRequest[openapi.V2KeysGetKeyRequestBody](t, Cmd(), tt.args)
+			req := testutil.CaptureRequest[openapi.V2KeysGetKeyRequestBody](t, Cmd(), tt.args)
 			require.Equal(t, tt.want, req)
 		})
 	}

--- a/cmd/api/keys/migrate_keys_test.go
+++ b/cmd/api/keys/migrate_keys_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/unkeyed/unkey/cmd/api/util"
+	"github.com/unkeyed/unkey/cmd/api/internal/testutil"
 	"github.com/unkeyed/unkey/pkg/ptr"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
@@ -33,7 +33,7 @@ func TestMigrateKeys(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := util.CaptureRequest[openapi.V2KeysMigrateKeysRequestBody](t, Cmd(), tt.args)
+			req := testutil.CaptureRequest[openapi.V2KeysMigrateKeysRequestBody](t, Cmd(), tt.args)
 			require.Equal(t, tt.want, req)
 		})
 	}

--- a/cmd/api/keys/remove_permissions_test.go
+++ b/cmd/api/keys/remove_permissions_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/unkeyed/unkey/cmd/api/util"
+	"github.com/unkeyed/unkey/cmd/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
 
@@ -26,7 +26,7 @@ func TestRemovePermissions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := util.CaptureRequestWithData[openapi.V2KeysRemovePermissionsRequestBody](t, Cmd(), tt.args, []any{})
+			req := testutil.CaptureRequestWithData[openapi.V2KeysRemovePermissionsRequestBody](t, Cmd(), tt.args, []any{})
 			require.Equal(t, tt.want, req)
 		})
 	}

--- a/cmd/api/keys/remove_roles_test.go
+++ b/cmd/api/keys/remove_roles_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/unkeyed/unkey/cmd/api/util"
+	"github.com/unkeyed/unkey/cmd/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
 
@@ -34,7 +34,7 @@ func TestRemoveRoles(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := util.CaptureRequestWithData[openapi.V2KeysRemoveRolesRequestBody](t, Cmd(), tt.args, []any{})
+			req := testutil.CaptureRequestWithData[openapi.V2KeysRemoveRolesRequestBody](t, Cmd(), tt.args, []any{})
 			require.Equal(t, tt.want, req)
 		})
 	}

--- a/cmd/api/keys/reroll_key_test.go
+++ b/cmd/api/keys/reroll_key_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/unkeyed/unkey/cmd/api/util"
+	"github.com/unkeyed/unkey/cmd/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
 
@@ -34,7 +34,7 @@ func TestRerollKey(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := util.CaptureRequest[openapi.V2KeysRerollKeyRequestBody](t, Cmd(), tt.args)
+			req := testutil.CaptureRequest[openapi.V2KeysRerollKeyRequestBody](t, Cmd(), tt.args)
 			require.Equal(t, tt.want, req)
 		})
 	}

--- a/cmd/api/keys/set_permissions_test.go
+++ b/cmd/api/keys/set_permissions_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/unkeyed/unkey/cmd/api/util"
+	"github.com/unkeyed/unkey/cmd/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
 
@@ -26,7 +26,7 @@ func TestSetPermissions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := util.CaptureRequestWithData[openapi.V2KeysSetPermissionsRequestBody](t, Cmd(), tt.args, []any{})
+			req := testutil.CaptureRequestWithData[openapi.V2KeysSetPermissionsRequestBody](t, Cmd(), tt.args, []any{})
 			require.Equal(t, tt.want, req)
 		})
 	}

--- a/cmd/api/keys/set_roles_test.go
+++ b/cmd/api/keys/set_roles_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/unkeyed/unkey/cmd/api/util"
+	"github.com/unkeyed/unkey/cmd/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
 
@@ -34,7 +34,7 @@ func TestSetRoles(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := util.CaptureRequestWithData[openapi.V2KeysSetRolesRequestBody](t, Cmd(), tt.args, []any{})
+			req := testutil.CaptureRequestWithData[openapi.V2KeysSetRolesRequestBody](t, Cmd(), tt.args, []any{})
 			require.Equal(t, tt.want, req)
 		})
 	}

--- a/cmd/api/keys/update_credits_test.go
+++ b/cmd/api/keys/update_credits_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/oapi-codegen/nullable"
 	"github.com/stretchr/testify/require"
-	"github.com/unkeyed/unkey/cmd/api/util"
+	"github.com/unkeyed/unkey/cmd/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
 
@@ -54,7 +54,7 @@ func TestUpdateCredits(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := util.CaptureRequest[openapi.V2KeysUpdateCreditsRequestBody](t, Cmd(), tt.args)
+			req := testutil.CaptureRequest[openapi.V2KeysUpdateCreditsRequestBody](t, Cmd(), tt.args)
 			require.Equal(t, tt.want, req)
 		})
 	}

--- a/cmd/api/keys/update_key_test.go
+++ b/cmd/api/keys/update_key_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/oapi-codegen/nullable"
 	"github.com/stretchr/testify/require"
-	"github.com/unkeyed/unkey/cmd/api/util"
+	"github.com/unkeyed/unkey/cmd/api/internal/testutil"
 	"github.com/unkeyed/unkey/pkg/ptr"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
@@ -87,7 +87,7 @@ func TestUpdateKey(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := util.CaptureRequest[openapi.V2KeysUpdateKeyRequestBody](t, Cmd(), tt.args)
+			req := testutil.CaptureRequest[openapi.V2KeysUpdateKeyRequestBody](t, Cmd(), tt.args)
 			require.Equal(t, tt.want, req)
 		})
 	}

--- a/cmd/api/keys/verify_key_test.go
+++ b/cmd/api/keys/verify_key_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/unkeyed/unkey/cmd/api/util"
+	"github.com/unkeyed/unkey/cmd/api/internal/testutil"
 	"github.com/unkeyed/unkey/pkg/ptr"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
@@ -62,7 +62,7 @@ func TestVerifyKey(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := util.CaptureRequest[openapi.V2KeysVerifyKeyRequestBody](t, Cmd(), tt.args)
+			req := testutil.CaptureRequest[openapi.V2KeysVerifyKeyRequestBody](t, Cmd(), tt.args)
 			require.Equal(t, tt.want, req)
 		})
 	}

--- a/cmd/api/keys/whoami_test.go
+++ b/cmd/api/keys/whoami_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/unkeyed/unkey/cmd/api/util"
+	"github.com/unkeyed/unkey/cmd/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
 
@@ -25,7 +25,7 @@ func TestWhoami(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := util.CaptureRequest[openapi.V2KeysWhoamiRequestBody](t, Cmd(), tt.args)
+			req := testutil.CaptureRequest[openapi.V2KeysWhoamiRequestBody](t, Cmd(), tt.args)
 			require.Equal(t, tt.want, req)
 		})
 	}

--- a/cmd/api/permissions/create_permission_test.go
+++ b/cmd/api/permissions/create_permission_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/unkeyed/unkey/cmd/api/util"
+	"github.com/unkeyed/unkey/cmd/api/internal/testutil"
 	"github.com/unkeyed/unkey/pkg/ptr"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
@@ -52,7 +52,7 @@ func TestCreatePermission(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := util.CaptureRequest[openapi.V2PermissionsCreatePermissionRequestBody](t, Cmd(), tt.args)
+			req := testutil.CaptureRequest[openapi.V2PermissionsCreatePermissionRequestBody](t, Cmd(), tt.args)
 			require.Equal(t, tt.want, req)
 		})
 	}

--- a/cmd/api/permissions/create_role_test.go
+++ b/cmd/api/permissions/create_role_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/unkeyed/unkey/cmd/api/util"
+	"github.com/unkeyed/unkey/cmd/api/internal/testutil"
 	"github.com/unkeyed/unkey/pkg/ptr"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
@@ -48,7 +48,7 @@ func TestCreateRole(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := util.CaptureRequest[openapi.V2PermissionsCreateRoleRequestBody](t, Cmd(), tt.args)
+			req := testutil.CaptureRequest[openapi.V2PermissionsCreateRoleRequestBody](t, Cmd(), tt.args)
 			require.Equal(t, tt.want, req)
 		})
 	}

--- a/cmd/api/permissions/delete_permission_test.go
+++ b/cmd/api/permissions/delete_permission_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/unkeyed/unkey/cmd/api/util"
+	"github.com/unkeyed/unkey/cmd/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
 
@@ -39,7 +39,7 @@ func TestDeletePermission(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := util.CaptureRequest[openapi.V2PermissionsDeletePermissionRequestBody](t, Cmd(), tt.args)
+			req := testutil.CaptureRequest[openapi.V2PermissionsDeletePermissionRequestBody](t, Cmd(), tt.args)
 			require.Equal(t, tt.want, req)
 		})
 	}

--- a/cmd/api/permissions/delete_role_test.go
+++ b/cmd/api/permissions/delete_role_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/unkeyed/unkey/cmd/api/util"
+	"github.com/unkeyed/unkey/cmd/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
 
@@ -39,7 +39,7 @@ func TestDeleteRole(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := util.CaptureRequest[openapi.V2PermissionsDeleteRoleRequestBody](t, Cmd(), tt.args)
+			req := testutil.CaptureRequest[openapi.V2PermissionsDeleteRoleRequestBody](t, Cmd(), tt.args)
 			require.Equal(t, tt.want, req)
 		})
 	}

--- a/cmd/api/permissions/get_permission_test.go
+++ b/cmd/api/permissions/get_permission_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/unkeyed/unkey/cmd/api/util"
+	"github.com/unkeyed/unkey/cmd/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
 
@@ -39,7 +39,7 @@ func TestGetPermission(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := util.CaptureRequest[openapi.V2PermissionsGetPermissionRequestBody](t, Cmd(), tt.args)
+			req := testutil.CaptureRequest[openapi.V2PermissionsGetPermissionRequestBody](t, Cmd(), tt.args)
 			require.Equal(t, tt.want, req)
 		})
 	}

--- a/cmd/api/permissions/get_role_test.go
+++ b/cmd/api/permissions/get_role_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/unkeyed/unkey/cmd/api/util"
+	"github.com/unkeyed/unkey/cmd/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
 
@@ -39,7 +39,7 @@ func TestGetRole(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := util.CaptureRequest[openapi.V2PermissionsGetRoleRequestBody](t, Cmd(), tt.args)
+			req := testutil.CaptureRequest[openapi.V2PermissionsGetRoleRequestBody](t, Cmd(), tt.args)
 			require.Equal(t, tt.want, req)
 		})
 	}

--- a/cmd/api/permissions/list_permissions_test.go
+++ b/cmd/api/permissions/list_permissions_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/unkeyed/unkey/cmd/api/util"
+	"github.com/unkeyed/unkey/cmd/api/internal/testutil"
 	"github.com/unkeyed/unkey/pkg/ptr"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
@@ -49,7 +49,7 @@ func TestListPermissions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := util.CaptureRequestWithData[openapi.V2PermissionsListPermissionsRequestBody](t, Cmd(), tt.args, []any{})
+			req := testutil.CaptureRequestWithData[openapi.V2PermissionsListPermissionsRequestBody](t, Cmd(), tt.args, []any{})
 			require.Equal(t, tt.want, req)
 		})
 	}

--- a/cmd/api/permissions/list_roles_test.go
+++ b/cmd/api/permissions/list_roles_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/unkeyed/unkey/cmd/api/util"
+	"github.com/unkeyed/unkey/cmd/api/internal/testutil"
 	"github.com/unkeyed/unkey/pkg/ptr"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
@@ -49,7 +49,7 @@ func TestListRoles(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := util.CaptureRequestWithData[openapi.V2PermissionsListRolesRequestBody](t, Cmd(), tt.args, []any{})
+			req := testutil.CaptureRequestWithData[openapi.V2PermissionsListRolesRequestBody](t, Cmd(), tt.args, []any{})
 			require.Equal(t, tt.want, req)
 		})
 	}

--- a/cmd/api/ratelimit/delete_override_test.go
+++ b/cmd/api/ratelimit/delete_override_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/unkeyed/unkey/cmd/api/util"
+	"github.com/unkeyed/unkey/cmd/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
 
@@ -42,7 +42,7 @@ func TestDeleteOverride(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := util.CaptureRequest[openapi.V2RatelimitDeleteOverrideRequestBody](t, Cmd(), tt.args)
+			req := testutil.CaptureRequest[openapi.V2RatelimitDeleteOverrideRequestBody](t, Cmd(), tt.args)
 			require.Equal(t, tt.want, req)
 		})
 	}

--- a/cmd/api/ratelimit/get_override_test.go
+++ b/cmd/api/ratelimit/get_override_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/unkeyed/unkey/cmd/api/util"
+	"github.com/unkeyed/unkey/cmd/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
 
@@ -42,7 +42,7 @@ func TestGetOverride(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := util.CaptureRequest[openapi.V2RatelimitGetOverrideRequestBody](t, Cmd(), tt.args)
+			req := testutil.CaptureRequest[openapi.V2RatelimitGetOverrideRequestBody](t, Cmd(), tt.args)
 			require.Equal(t, tt.want, req)
 		})
 	}

--- a/cmd/api/ratelimit/limit_test.go
+++ b/cmd/api/ratelimit/limit_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/unkeyed/unkey/cmd/api/util"
+	"github.com/unkeyed/unkey/cmd/api/internal/testutil"
 	"github.com/unkeyed/unkey/pkg/ptr"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
@@ -41,7 +41,7 @@ func TestLimit(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := util.CaptureRequest[openapi.V2RatelimitLimitRequestBody](t, Cmd(), tt.args)
+			req := testutil.CaptureRequest[openapi.V2RatelimitLimitRequestBody](t, Cmd(), tt.args)
 			require.Equal(t, tt.want, req)
 		})
 	}

--- a/cmd/api/ratelimit/list_overrides_test.go
+++ b/cmd/api/ratelimit/list_overrides_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/unkeyed/unkey/cmd/api/util"
+	"github.com/unkeyed/unkey/cmd/api/internal/testutil"
 	"github.com/unkeyed/unkey/pkg/ptr"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
@@ -53,7 +53,7 @@ func TestListOverrides(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := util.CaptureRequestWithData[openapi.V2RatelimitListOverridesRequestBody](t, Cmd(), tt.args, []any{})
+			req := testutil.CaptureRequestWithData[openapi.V2RatelimitListOverridesRequestBody](t, Cmd(), tt.args, []any{})
 			require.Equal(t, tt.want, req)
 		})
 	}

--- a/cmd/api/ratelimit/multi_limit_test.go
+++ b/cmd/api/ratelimit/multi_limit_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/unkeyed/unkey/cmd/api/util"
+	"github.com/unkeyed/unkey/cmd/api/internal/testutil"
 	"github.com/unkeyed/unkey/pkg/ptr"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
@@ -52,7 +52,7 @@ func TestMultiLimit(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := util.CaptureRequest[[]openapi.V2RatelimitLimitRequestBody](t, Cmd(), tt.args)
+			req := testutil.CaptureRequest[[]openapi.V2RatelimitLimitRequestBody](t, Cmd(), tt.args)
 			require.Equal(t, tt.want, req)
 		})
 	}

--- a/cmd/api/ratelimit/set_override_test.go
+++ b/cmd/api/ratelimit/set_override_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/unkeyed/unkey/cmd/api/util"
+	"github.com/unkeyed/unkey/cmd/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
 
@@ -58,7 +58,7 @@ func TestSetOverride(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := util.CaptureRequest[openapi.V2RatelimitSetOverrideRequestBody](t, Cmd(), tt.args)
+			req := testutil.CaptureRequest[openapi.V2RatelimitSetOverrideRequestBody](t, Cmd(), tt.args)
 			require.Equal(t, tt.want, req)
 		})
 	}


### PR DESCRIPTION
## Problem:

Our API test harness got included in our prod CLI package by importing our testing harness

## Solution:

Moved the harness from `cmd/api/util` to `cmd/api/internal/testutil`. 
Update the 39 API test files that use the harness

## Impact:

- Stripped binary: 25.68 MiB → 25.64 MiB, a 40 KiB reduction.
- Median startup: 14.09 ms → 14.10 ms. No material startup change.
- CLI behavior does not change.

## Testing:

- `mise exec -- rask ./cmd/api/... ./pkg/cli`: 255 passed, 0 failed.
- `mise run build`: passed with 0 lint issues.
- Size used Linux amd64 builds with CGO disabled, `-trimpath`, and `-s -w`. Startup used 300 interleaved, warmed `--version` process launches.