### PR TITLE
Isolate build metrics from CLI metadata

### DIFF
--- a/pkg/buildinfo/buildinfo.go
+++ b/pkg/buildinfo/buildinfo.go
@@ -1,10 +1,6 @@
 // Package buildinfo exposes build metadata that is injected at link time
 // via -ldflags -X. Values are populated by the release pipeline (goreleaser).
 // Local builds see the defaults.
-//
-// To emit a Prometheus build_info gauge for a service, call
-// [RegisterBuildInfoMetrics] once during service startup, after the prometheus
-// registry has been installed via lazy.SetRegistry.
 package buildinfo
 
 var (

--- a/pkg/buildinfo/metrics/metrics.go
+++ b/pkg/buildinfo/metrics/metrics.go
@@ -1,9 +1,11 @@
-package buildinfo
+// Package buildinfometrics exposes build metadata as a Prometheus metric.
+package buildinfometrics
 
 import (
 	"runtime"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/unkeyed/unkey/pkg/buildinfo"
 	"github.com/unkeyed/unkey/pkg/prometheus/lazy"
 )
 
@@ -18,12 +20,14 @@ var buildInfo = lazy.NewGaugeVec(prometheus.GaugeOpts{
 	Help:      "Build metadata for the running service. Always 1; identity is in the labels.",
 }, []string{"service", "version", "revision", "goversion", "build_time"})
 
-// RegisterBuildInfoMetrics emits the unkey_build_info gauge for the given
-// service name, tagged with the link-time build identity (Version, Revision,
-// Go runtime version, BuildTime).
-//
-// Call once during service startup, after lazy.SetRegistry has installed the
-// prometheus registry that should receive the metric.
-func RegisterBuildInfoMetrics(service string) {
-	buildInfo.WithLabelValues(service, Version, Revision, runtime.Version(), BuildTime).Set(1)
+// Register emits the unkey_build_info gauge for the given service name. Call
+// it after lazy.SetRegistry installs the service's Prometheus registry.
+func Register(service string) {
+	buildInfo.WithLabelValues(
+		service,
+		buildinfo.Version,
+		buildinfo.Revision,
+		runtime.Version(),
+		buildinfo.BuildTime,
+	).Set(1)
 }

--- a/svc/api/run.go
+++ b/svc/api/run.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/unkeyed/unkey/pkg/batch"
 	"github.com/unkeyed/unkey/pkg/buildinfo"
+	"github.com/unkeyed/unkey/pkg/buildinfo/metrics"
 	"github.com/unkeyed/unkey/pkg/cache"
 	"github.com/unkeyed/unkey/pkg/clickhouse"
 	"github.com/unkeyed/unkey/pkg/clickhouse/schema"
@@ -108,7 +109,7 @@ func Run(ctx context.Context, cfg Config) error {
 	reg.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 	reg.MustRegister(prometheus.NewSystemMetricsCollector())
 	lazy.SetRegistry(reg)
-	buildinfo.RegisterBuildInfoMetrics("api")
+	buildinfometrics.Register("api")
 
 	// This is a little ugly, but the best we can do to resolve the circular dependency until we rework the logger.
 	var shutdownGrafana func(context.Context) error

--- a/svc/ctrl/api/run.go
+++ b/svc/ctrl/api/run.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/unkeyed/unkey/pkg/batch"
 	"github.com/unkeyed/unkey/pkg/buildinfo"
+	"github.com/unkeyed/unkey/pkg/buildinfo/metrics"
 	"github.com/unkeyed/unkey/pkg/cache"
 	"github.com/unkeyed/unkey/pkg/clickhouse"
 	"github.com/unkeyed/unkey/pkg/clickhouse/schema"
@@ -108,7 +109,7 @@ func Run(ctx context.Context, cfg Config) error {
 	reg.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 	reg.MustRegister(prometheus.NewSystemMetricsCollector())
 	lazy.SetRegistry(reg)
-	buildinfo.RegisterBuildInfoMetrics("ctrl")
+	buildinfometrics.Register("ctrl")
 
 	// Initialize database
 	database, err := db.New(cfg.Database, sqlcomment.ForService("ctrl-api", cfg.Region))

--- a/svc/ctrl/worker/run.go
+++ b/svc/ctrl/worker/run.go
@@ -22,6 +22,7 @@ import (
 	"github.com/unkeyed/unkey/gen/rpc/vault"
 	"github.com/unkeyed/unkey/pkg/batch"
 	"github.com/unkeyed/unkey/pkg/buildinfo"
+	"github.com/unkeyed/unkey/pkg/buildinfo/metrics"
 	"github.com/unkeyed/unkey/pkg/cache"
 	"github.com/unkeyed/unkey/pkg/clickhouse"
 	"github.com/unkeyed/unkey/pkg/clickhouse/schema"
@@ -135,7 +136,7 @@ func Run(ctx context.Context, cfg Config) error {
 	reg.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 	reg.MustRegister(prometheus.NewSystemMetricsCollector())
 	lazy.SetRegistry(reg)
-	buildinfo.RegisterBuildInfoMetrics("worker")
+	buildinfometrics.Register("worker")
 
 	// Create vault client for remote vault service
 	var vaultClient vault.VaultServiceClient

--- a/svc/frontline/run.go
+++ b/svc/frontline/run.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/unkeyed/unkey/pkg/batch"
 	"github.com/unkeyed/unkey/pkg/buildinfo"
+	"github.com/unkeyed/unkey/pkg/buildinfo/metrics"
 	"github.com/unkeyed/unkey/pkg/cache"
 	"github.com/unkeyed/unkey/pkg/clickhouse"
 	"github.com/unkeyed/unkey/pkg/clickhouse/schema"
@@ -119,7 +120,7 @@ func Run(ctx context.Context, cfg Config) error {
 	reg.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 	reg.MustRegister(prometheus.NewSystemMetricsCollector())
 	lazy.SetRegistry(reg)
-	buildinfo.RegisterBuildInfoMetrics("frontline")
+	buildinfometrics.Register("frontline")
 
 	if cfg.PrometheusPort > 0 {
 		prom, promErr := prometheus.NewWithRegistry(reg)

--- a/svc/heimdall/run.go
+++ b/svc/heimdall/run.go
@@ -11,7 +11,7 @@ import (
 	promclient "github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/unkeyed/unkey/pkg/buildinfo"
+	"github.com/unkeyed/unkey/pkg/buildinfo/metrics"
 	"github.com/unkeyed/unkey/pkg/clickhouse"
 	"github.com/unkeyed/unkey/pkg/clickhouse/schema"
 	"github.com/unkeyed/unkey/pkg/clock"
@@ -60,7 +60,7 @@ func Run(ctx context.Context, cfg Config) error {
 	//nolint:exhaustruct
 	reg.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 	lazy.SetRegistry(reg)
-	buildinfo.RegisterBuildInfoMetrics("heimdall")
+	buildinfometrics.Register("heimdall")
 
 	ch, err := clickhouse.New(clickhouse.Config{URL: cfg.ClickHouseURL})
 	if err != nil {

--- a/svc/krane/run.go
+++ b/svc/krane/run.go
@@ -16,6 +16,7 @@ import (
 	"github.com/unkeyed/unkey/gen/proto/vault/v1/vaultv1connect"
 	"github.com/unkeyed/unkey/gen/rpc/vault"
 	"github.com/unkeyed/unkey/pkg/buildinfo"
+	"github.com/unkeyed/unkey/pkg/buildinfo/metrics"
 	"github.com/unkeyed/unkey/pkg/cache"
 	"github.com/unkeyed/unkey/pkg/clock"
 	"github.com/unkeyed/unkey/pkg/logger"
@@ -92,7 +93,7 @@ func Run(ctx context.Context, cfg Config) error {
 	reg.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 	reg.MustRegister(prometheus.NewSystemMetricsCollector())
 	lazy.SetRegistry(reg)
-	buildinfo.RegisterBuildInfoMetrics("krane")
+	buildinfometrics.Register("krane")
 
 	cluster := controlplane.NewClient(controlplane.ClientConfig{
 		URL:         cfg.Control.URL,

--- a/svc/vault/run.go
+++ b/svc/vault/run.go
@@ -11,7 +11,7 @@ import (
 	promclient "github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/unkeyed/unkey/gen/proto/vault/v1/vaultv1connect"
-	"github.com/unkeyed/unkey/pkg/buildinfo"
+	"github.com/unkeyed/unkey/pkg/buildinfo/metrics"
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/pkg/otel"
 	"github.com/unkeyed/unkey/pkg/prometheus"
@@ -64,7 +64,7 @@ func Run(ctx context.Context, cfg Config) error {
 	reg.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 	reg.MustRegister(prometheus.NewSystemMetricsCollector())
 	lazy.SetRegistry(reg)
-	buildinfo.RegisterBuildInfoMetrics("vault")
+	buildinfometrics.Register("vault")
 
 	if cfg.Observability.Metrics != nil && cfg.Observability.Metrics.PrometheusPort > 0 {
 		prom, promErr := prometheus.NewWithRegistry(reg)


### PR DESCRIPTION
## Problem:

Our CLI imports build metadata for our version command, that package created a Prometheus gauge during package initialization which we dont need when running the CLI

## Solution:

Move the Prometheus gauge to `pkg/buildinfo/metrics`. Services import the metrics package

## Impact:

None yet but it will help us omit prometheus from the cli entirely.

## Testing:

- `mise run build`: passed with 0 lint issues.
- `mise exec -- rask ./cmd/api/... ./pkg/cli`: 255 passed, 0 failed.
- Size used Linux amd64 builds with CGO disabled, `-trimpath`, and `-s -w`. Startup used 300 interleaved, warmed `--version` process launches.