### PR TITLE
Exclude development commands from release CLI

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -21,6 +21,7 @@ before:
 
 builds:
   - id: unkey
+    main: ./build/cli
     env:
       - CGO_ENABLED=0
     goos:

--- a/.mise/tasks/bootstrap
+++ b/.mise/tasks/bootstrap
@@ -29,6 +29,6 @@ cp "$ENV_EXAMPLE_DASHBOARD" "$ENV_FILE_DASHBOARD"
 
 # Add a github app and configure it.
 echo "Configuring the local GitHub app..."
-go run . dev github setup
+go run ./build/cli dev github setup
 
 echo "Bootstrap complete."

--- a/.mise/tasks/build
+++ b/.mise/tasks/build
@@ -6,4 +6,4 @@ set -euo pipefail
 
 go build ./...
 mkdir -p bin
-go build -o bin/unkey .
+go build -o bin/unkey ./build/cli

--- a/.mise/tasks/unkey
+++ b/.mise/tasks/unkey
@@ -23,4 +23,4 @@ if needs_stripe_env "$@"; then
 fi
 set +a
 
-go run . "$@" ${ARGS:-}
+go run ./build/cli "$@" ${ARGS:-}

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 
-RUN go build -o /out/unkey .
+RUN go build -o /out/unkey ./build/cli
 
 FROM gcr.io/distroless/static-debian13:nonroot@sha256:d29e660cc75a5b6b1334e03c5c81ccf9bc0884a002c6000dbf0fb96034814478
 

--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ fuzz: ## Run fuzz tests
 	done
 .PHONY: unkey
 unkey: ## Run unkey CLI (usage: make unkey dev seed local)
-	@set -a; [ -f .env ] && . ./.env; set +a; go run . $(filter-out unkey,$(MAKECMDGOALS)) $(ARGS)
+	@set -a; [ -f .env ] && . ./.env; set +a; go run ./build/cli $(filter-out unkey,$(MAKECMDGOALS)) $(ARGS)
 
 # Catch-all to swallow extra args passed to unkey target (only when unkey is called)
 ifneq ($(filter unkey,$(MAKECMDGOALS)),)

--- a/build/cli/commands_dev.go
+++ b/build/cli/commands_dev.go
@@ -1,0 +1,12 @@
+//go:build !cli_release
+
+package main
+
+import (
+	dev "github.com/unkeyed/unkey/cmd/dev"
+	"github.com/unkeyed/unkey/pkg/cli"
+)
+
+func developmentCommands() []*cli.Command {
+	return []*cli.Command{dev.Cmd}
+}

--- a/build/cli/commands_release.go
+++ b/build/cli/commands_release.go
@@ -1,0 +1,9 @@
+//go:build cli_release
+
+package main
+
+import "github.com/unkeyed/unkey/pkg/cli"
+
+func developmentCommands() []*cli.Command {
+	return nil
+}

--- a/build/cli/main.go
+++ b/build/cli/main.go
@@ -8,7 +8,6 @@ import (
 	"github.com/unkeyed/unkey/cmd/api"
 	"github.com/unkeyed/unkey/cmd/auth"
 	"github.com/unkeyed/unkey/cmd/deploy"
-	dev "github.com/unkeyed/unkey/cmd/dev"
 	"github.com/unkeyed/unkey/cmd/healthcheck"
 	"github.com/unkeyed/unkey/cmd/version"
 	"github.com/unkeyed/unkey/pkg/buildinfo"
@@ -24,14 +23,13 @@ func main() {
 		Usage:       "Run unkey",
 		Description: `Unkey CLI – deploy, run and administer Unkey services.`,
 		Version:     buildinfo.Version,
-		Commands: []*cli.Command{
+		Commands: append([]*cli.Command{
 			api.Cmd(),
 			auth.Cmd,
 			version.Cmd,
 			deploy.Cmd,
 			healthcheck.Cmd,
-			dev.Cmd,
-		},
+		}, developmentCommands()...),
 	}
 
 	err := app.Run(context.Background(), os.Args)

--- a/cmd/dev/github/README.md
+++ b/cmd/dev/github/README.md
@@ -4,9 +4,9 @@ Local development tools for setting up and testing GitHub App-triggered deployme
 
 ## Commands
 
-- `go run . dev github setup`: create a GitHub App via manifest flow and write all credentials automatically
-- `go run . dev github tunnel`: start an ngrok tunnel and update the GitHub App webhook URL automatically
-- `go run . dev github trigger-webhook`: simulate a GitHub push webhook to trigger a deployment
+- `go run ./build/cli dev github setup`: create a GitHub App via manifest flow and write all credentials automatically
+- `go run ./build/cli dev github tunnel`: start an ngrok tunnel and update the GitHub App webhook URL automatically
+- `go run ./build/cli dev github trigger-webhook`: simulate a GitHub push webhook to trigger a deployment
 
 ---
 
@@ -15,7 +15,7 @@ Local development tools for setting up and testing GitHub App-triggered deployme
 ### Step 1: Create the GitHub App
 
 ```bash
-go run . dev github setup --app-name my-unkey-dev
+go run ./build/cli dev github setup --app-name my-unkey-dev
 ```
 
 This opens a browser, walks you through GitHub's App creation UI, then writes:
@@ -36,13 +36,13 @@ Tilt spins up a `github-tunnel` resource that runs ngrok against ctrl-api and pa
 ### Step 3: Seed the database
 
 ```bash
-go run . dev seed local
+go run ./build/cli dev seed local
 ```
 
 ### Step 4: Trigger a deployment
 
 ```bash
-go run . dev github trigger-webhook \
+go run ./build/cli dev github trigger-webhook \
   --project local-api \
   --repository owner/repo
 ```

--- a/cmd/dev/github/setup.go
+++ b/cmd/dev/github/setup.go
@@ -199,11 +199,11 @@ func setupGitHubApp(_ context.Context, cmd *cli.Command) error {
 	fmt.Println()
 	fmt.Println("Next steps:")
 	fmt.Println("  1. mise run dev")
-	fmt.Println("  2. go run . dev seed local")
-	fmt.Println("  3. go run . dev github tunnel   # each session — starts ngrok and patches the webhook URL")
+	fmt.Println("  2. go run ./build/cli dev seed local")
+	fmt.Println("  3. go run ./build/cli dev github tunnel   # each session — starts ngrok and patches the webhook URL")
 	fmt.Println()
 	fmt.Println("To replay a specific commit manually:")
-	fmt.Println("  go run . dev github trigger-webhook --project <slug> --repository <owner/repo>")
+	fmt.Println("  go run ./build/cli dev github trigger-webhook --project <slug> --repository <owner/repo>")
 
 	return nil
 }
@@ -278,7 +278,7 @@ func writeCredentials(outDir string, app *manifestResponse) error {
 	}
 
 	dashboardVars := fmt.Sprintf(
-		"\n# GitHub App (written by `go run . dev github setup`)\nGITHUB_APP_ID=%d\nNEXT_PUBLIC_GITHUB_APP_NAME=%q\nGITHUB_CLIENT_ID=%q\nGITHUB_CLIENT_SECRET=%q\n",
+		"\n# GitHub App (written by `go run ./build/cli dev github setup`)\nGITHUB_APP_ID=%d\nNEXT_PUBLIC_GITHUB_APP_NAME=%q\nGITHUB_CLIENT_ID=%q\nGITHUB_CLIENT_SECRET=%q\n",
 		app.ID,
 		app.Slug,
 		app.ClientID,

--- a/cmd/dev/github/trigger_webhook.go
+++ b/cmd/dev/github/trigger_webhook.go
@@ -100,7 +100,7 @@ func triggerWebhook(ctx context.Context, cmd *cli.Command) error {
 	if webhookSecret == "" {
 		secret, err := readEnvFileValue("dev/.env.github", "UNKEY_GITHUB_APP_WEBHOOK_SECRET")
 		if err != nil {
-			return fmt.Errorf("no --webhook-secret provided and failed to read dev/.env.github: %w\n\nRun `go run . dev github setup` first, or pass --webhook-secret", err)
+			return fmt.Errorf("no --webhook-secret provided and failed to read dev/.env.github: %w\n\nRun `go run ./build/cli dev github setup` first, or pass --webhook-secret", err)
 		}
 		webhookSecret = secret
 	}
@@ -127,7 +127,7 @@ func triggerWebhook(ctx context.Context, cmd *cli.Command) error {
 	fmt.Printf("Looking up project %q...\n", projectSlug)
 	project, err := db.Query.FindProjectBySlug(ctx, database.RO(), projectSlug)
 	if err != nil {
-		return fmt.Errorf("failed to find project with slug %q: %w\n\nMake sure you've run `go run . dev seed local`", projectSlug, err)
+		return fmt.Errorf("failed to find project with slug %q: %w\n\nMake sure you've run `go run ./build/cli dev seed local`", projectSlug, err)
 	}
 	workspace, err := db.Query.FindWorkspaceByID(ctx, database.RO(), project.WorkspaceID)
 	if err != nil {
@@ -249,7 +249,7 @@ func triggerWebhook(ctx context.Context, cmd *cli.Command) error {
 		return nil
 
 	case http.StatusUnauthorized:
-		return fmt.Errorf("✗ Webhook rejected: invalid signature\n\nThe webhook secret used to sign this request does not match the one ctrl-api is validating against. Make sure dev/.env.github (UNKEY_GITHUB_APP_WEBHOOK_SECRET) is the one written by `go run . dev github setup` and that the github-credentials k8s secret is up to date")
+		return fmt.Errorf("✗ Webhook rejected: invalid signature\n\nThe webhook secret used to sign this request does not match the one ctrl-api is validating against. Make sure dev/.env.github (UNKEY_GITHUB_APP_WEBHOOK_SECRET) is the one written by `go run ./build/cli dev github setup` and that the github-credentials k8s secret is up to date")
 
 	case http.StatusBadRequest:
 		return fmt.Errorf("✗ Webhook rejected: invalid payload\n\n%s", string(bodyBytes))

--- a/cmd/dev/github/tunnel.go
+++ b/cmd/dev/github/tunnel.go
@@ -146,7 +146,7 @@ func waitForNgrokURL() (string, error) {
 func readAppID(envFile string) (int64, error) {
 	val, err := readEnvFileValue(envFile, "UNKEY_GITHUB_APP_ID")
 	if err != nil {
-		return 0, fmt.Errorf("%w\n\nRun `go run . dev github setup` first", err)
+		return 0, fmt.Errorf("%w\n\nRun `go run ./build/cli dev github setup` first", err)
 	}
 	id, err := strconv.ParseInt(val, 10, 64)
 	if err != nil {

--- a/dev/Tiltfile
+++ b/dev/Tiltfile
@@ -316,7 +316,7 @@ k8s_resource('mysql', port_forwards='3306:3306', resource_deps=[], labels=['data
 
 local_resource(
     'seed',
-    'cd .. && go run . dev seed local',
+    'cd .. && go run ./build/cli dev seed local',
     resource_deps=['mysql'],
     labels=['setup'],
 )
@@ -571,7 +571,7 @@ k8s_resource(
 if has_github_credentials:
     local_resource(
         'github-tunnel',
-        serve_cmd='cd .. && go run . dev github tunnel',
+        serve_cmd='cd .. && go run ./build/cli dev github tunnel',
         resource_deps=['ctrl-api'],
         labels=['unkey'],
         auto_init=True,

--- a/dev/portal-local-testing.md
+++ b/dev/portal-local-testing.md
@@ -39,14 +39,14 @@ Seeding requires MySQL to be running. Start infra first, then seed.
 For Docker Compose:
 ```bash
 make up
-go run . dev seed local --slug awesome --portal
+go run ./build/cli dev seed local --slug awesome --portal
 ```
 
 For Tilt:
 ```bash
 make dev
 # wait for MySQL to be healthy in the Tilt UI
-go run . dev seed local --slug awesome --portal
+go run ./build/cli dev seed local --slug awesome --portal
 ```
 
 Save the root key printed at the end (e.g. `unkey_xxx`).
@@ -162,7 +162,7 @@ insert them manually or via the dashboard (once the config UI is built).
 
 For staging, you can run the seed tool against the staging DB:
 ```bash
-go run . dev seed local \
+go run ./build/cli dev seed local \
   --slug awesome \
   --portal \
   --database-primary "<STAGING_DSN>"
@@ -200,7 +200,7 @@ domain if configured). Open it in the browser.
 ## Troubleshooting
 
 - **Session creation fails with 400**: Make sure `slug` is included in the request body
-- **Session creation fails with 401**: Re-run `go run . dev seed local --slug awesome --portal`
+- **Session creation fails with 401**: Re-run `go run ./build/cli dev seed local --slug awesome --portal`
 - **Session creation fails with 403**: Check `portal_configurations.enabled = TRUE`
 - **Session creation fails with 404**: The `slug` doesn't exist in the authenticated workspace. Verify the portal config was seeded and the root key matches the same workspace.
 - **"Invalid access" with session param**: Session may be expired (15 min TTL) or already exchanged (single-use). Create a fresh one.
@@ -210,7 +210,7 @@ domain if configured). Open it in the browser.
 
 ## What the Seed Script Creates
 
-`go run . dev seed local --slug <slug> --portal` sets up a complete local
+`go run ./build/cli dev seed local --slug <slug> --portal` sets up a complete local
 environment in a single transaction. The `--slug` flag (default: `local`)
 drives all generated IDs.
 


### PR DESCRIPTION
## Problem:

Our released CLI build included `unkey dev` and its Kubernetes, Docker, telemetry, and service dependencies, thse are really only  useful for local dev.

## Solution:

Move development command registration behind the `cli_release` build tag. 

Normal builds register `unkey dev`
Release-tagged builds return no development commands, so Go can remove the full transitive dependency graph.

## Impact:

- Stripped release-tagged binary: 25.64 MiB → 9.71 MiB, a 15.93 MiB or 62.1% reduction.
- Median startup: 14.11 ms → 3.56 ms, a 74.8% reduction.
- Normal developer builds keep `unkey dev` and remain unchanged.

## Testing:

- `mise run build`: passed with 0 lint issues.
- A default build accepts `unkey dev`.
- A `cli_release` build rejects `unkey dev` as an unknown command.
- Size used Linux amd64 builds with CGO disabled, `-trimpath`, and `-s -w`. Startup used 300 interleaved, warmed `--version` process launches.