### PR TITLE
Keep MDX generation in development builds

### DIFF
--- a/pkg/cli/docs.go
+++ b/pkg/cli/docs.go
@@ -1,3 +1,5 @@
+//go:build !cli_release
+
 package cli
 
 import (

--- a/pkg/cli/docs_handler.go
+++ b/pkg/cli/docs_handler.go
@@ -1,3 +1,5 @@
+//go:build !cli_release
+
 package cli
 
 import (

--- a/pkg/cli/docs_release.go
+++ b/pkg/cli/docs_release.go
@@ -1,0 +1,8 @@
+//go:build cli_release
+
+package cli
+
+// Release binaries omit runtime MDX generation to avoid linking the template engine.
+func (*Command) handleMDXGeneration(_ []string) (bool, error) {
+	return false, nil
+}

--- a/pkg/cli/docs_template.go
+++ b/pkg/cli/docs_template.go
@@ -1,3 +1,5 @@
+//go:build !cli_release
+
 package cli
 
 // Template for parent commands (commands with subcommands)


### PR DESCRIPTION
## Problem:

Our built CLI included runtime code for  MDX documentation generation, `text/template`, language casing support, and embedded templates. 

None of that is A) Called by endusers and B) useable by endusers

## Solution:

Place MDX generation behind the previously added`cli_release` build flag so its not included anymore

## Impact:

- Stripped release-tagged binary: 9.71 MiB → 8.13 MiB, a 1.58 MiB or 16.3% reduction.
- Median startup: 3.56 ms → 3.49 ms. No material startup change.
- Normal developer builds keep MDX generation.

## Testing:

- `mise exec -- go test -tags=cli_release ./pkg/cli`: passed.
- A default build accepts `unkey mdx`.
- A `cli_release` build rejects `unkey mdx` as an unknown command.
- Size used Linux amd64 builds with CGO disabled, `-trimpath`, and `-s -w`. Startup used 300 interleaved, warmed `--version` process launches.