### PR TITLE
Remove UPX from CLI releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,11 +30,6 @@ jobs:
         uses: ./.depot/actions/setup-go
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install UPX
-        if: matrix.goos == 'linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y upx-ucl
       - name: Run GoReleaser (split)
         uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -32,20 +32,17 @@ builds:
       - arm64
     binary: unkey
 
+    flags:
+      - -trimpath
+
+    tags:
+      - cli_release
+
     ldflags:
       - -s -w
       - -X 'github.com/unkeyed/unkey/pkg/buildinfo.Version={{.Version}}'
       - -X 'github.com/unkeyed/unkey/pkg/buildinfo.Revision={{.FullCommit}}'
       - -X 'github.com/unkeyed/unkey/pkg/buildinfo.BuildTime={{.Date}}'
-
-upx:
-  - enabled: true
-    ids:
-      - unkey
-    goos:
-      - linux # UPX doesn't support macOS
-    compress: best
-    lzma: true
 
 archives:
   - id: unkey

--- a/.mise/tasks/benchmark-cli
+++ b/.mise/tasks/benchmark-cli
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#MISE description="Benchmark release CLI binary size and warm startup"
+set -euo pipefail
+
+binary="$(mktemp "${TMPDIR:-/tmp}/unkey-cli-benchmark.XXXXXX")"
+trap 'rm -f "${binary}"' EXIT
+
+CGO_ENABLED=0 go build \
+  -tags=cli_release \
+  -trimpath \
+  -ldflags='-s -w' \
+  -o "${binary}" \
+  ./build/cli
+
+node --input-type=module - "${binary}" "${RUNS:-200}" <<'JS'
+import { statSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+
+const binary = process.argv[2];
+const runs = Number.parseInt(process.argv[3], 10);
+if (!Number.isSafeInteger(runs) || runs < 1) {
+  throw new Error("RUNS must be a positive integer");
+}
+
+const env = Object.fromEntries(
+  Object.entries(process.env).filter(([name]) => !name.startsWith("UNKEY_")),
+);
+
+function run() {
+  const started = process.hrtime.bigint();
+  const result = spawnSync(binary, ["--version"], {
+    env,
+    stdio: "ignore",
+  });
+  const elapsedNs = process.hrtime.bigint() - started;
+
+  if (result.status !== 0) {
+    throw new Error(`CLI exited with status ${result.status}`);
+  }
+
+  return Number(elapsedNs) / 1_000_000;
+}
+
+for (let i = 0; i < 10; i++) {
+  run();
+}
+
+const samplesMs = Array.from({ length: runs }, run).sort((a, b) => a - b);
+const middle = Math.floor(samplesMs.length / 2);
+const medianMs =
+  samplesMs.length % 2 === 0
+    ? (samplesMs[middle - 1] + samplesMs[middle]) / 2
+    : samplesMs[middle];
+const p95Ms = samplesMs[Math.ceil(samplesMs.length * 0.95) - 1];
+const sizeBytes = statSync(binary).size;
+
+console.log("binary_packing=none");
+console.log(`binary_size_bytes=${sizeBytes}`);
+console.log(`binary_size_mib=${(sizeBytes / 1024 / 1024).toFixed(2)}`);
+console.log(`startup_runs=${runs}`);
+console.log(`startup_median_ms=${medianMs.toFixed(2)}`);
+console.log(`startup_p95_ms=${p95Ms.toFixed(2)}`);
+JS

--- a/pkg/cli/docs.go
+++ b/pkg/cli/docs.go
@@ -1,3 +1,5 @@
+//go:build !cli_release
+
 package cli
 
 import (

--- a/pkg/cli/docs_handler.go
+++ b/pkg/cli/docs_handler.go
@@ -1,3 +1,5 @@
+//go:build !cli_release
+
 package cli
 
 import (

--- a/pkg/cli/docs_release.go
+++ b/pkg/cli/docs_release.go
@@ -1,0 +1,8 @@
+//go:build cli_release
+
+package cli
+
+// Release binaries omit runtime MDX generation to avoid linking the template engine.
+func (*Command) handleMDXGeneration(_ []string) (bool, error) {
+	return false, nil
+}

--- a/pkg/cli/docs_template.go
+++ b/pkg/cli/docs_template.go
@@ -1,3 +1,5 @@
+//go:build !cli_release
+
 package cli
 
 // Template for parent commands (commands with subcommands)


### PR DESCRIPTION
## Problem:

Using UPX reduced the installed CLI size but it decompressed the binary on every launch, which is slower than just not unpacking it

## Solution:

We now build GoReleaser artifacts with `cli_release`, `-trimpath`, and the existing `-s -w` linker flags, and remove upx. 

## Impact:

- Median startup: 530.7 ms → 3.48 ms. Measured p95: 571.9 ms → 4.39 ms.
- Installed binary: 6.47 MiB UPX-packed → 8.13 MiB unpacked. This is a 1.66 MiB installed-size tradeoff.
- Compressed download: about 6.47 MiB → 3.18 MiB, about 51% smaller because normal gzip can compress the unpacked Go binary better.

## Testing:

- `mise run benchmark-cli`: 8.13 MiB unpacked binary. Repeated runs measured about 3–4 ms median startup.
- `mise run build`: passed with 0 lint issues.
- `mise exec -- go test -tags=cli_release ./pkg/cli`: passed.
- The comparable layer benchmark used Linux amd64 builds with CGO disabled, `-trimpath`, `-s -w`, and 300 interleaved, warmed `--version` process launches.

## Full stack result

The stack changes both the CLI dependency graph and the release packaging. Two comparisons show the complete result:

| Metric | Before stack | After stack | Change |
| --- | ---: | ---: | ---: |
| Normalized unpacked binary | 25.68 MiB | 8.13 MiB | 68.3% smaller |
| Normalized unpacked median startup | 14.09 ms | 3.48 ms | 75.3% faster |
| Released median startup | 530.7 ms | 3.48 ms | about 153× faster |
| Released p95 startup | 571.9 ms | 4.39 ms | about 130× faster |
| Compressed download | about 6.47 MiB | 3.18 MiB | about 51% smaller |
| Installed release binary | 6.47 MiB | 8.13 MiB | 1.66 MiB larger |

The installed binary grows because the old release was UPX-packed. Removing UPX makes process startup much faster and lets the release archive compress better.

### Stack progression

| Layer | Binary | Median startup | How the layer achieves the result |
| --- | ---: | ---: | --- |
| Base | 25.68 MiB | 14.09 ms | Existing CLI with development and release code linked together. |
| #7126 | 25.64 MiB | 14.10 ms | Moves `testing` and `httptest` helpers out of the production API package. |
| #7127 | 25.64 MiB | 14.01 ms | Separates Prometheus metrics from the build metadata imported by the CLI. |
| #7128 | 9.71 MiB | 3.56 ms | Uses `cli_release` to omit `unkey dev` and its transitive service dependencies. |
| #7129 | 8.13 MiB | 3.49 ms | Uses `cli_release` to omit runtime MDX generation and templates. |
| This PR | 8.13 MiB | 3.48 ms | Activates `cli_release` in GoReleaser, removes UPX, enables `-trimpath`, and adds the repeatable benchmark. |

Small startup differences in the first two layers are within process-launch noise. The benchmark used Linux amd64 builds with CGO disabled, `-trimpath`, `-s -w`, and 300 interleaved, warmed `--version` process launches.