### PR TITLE
Optimize global counter imports

### DIFF
--- a/internal/services/ratelimit/db/global_counters_imported.sql_generated.go
+++ b/internal/services/ratelimit/db/global_counters_imported.sql_generated.go
@@ -88,3 +88,118 @@ func (q *Queries) GlobalCountersImported(ctx context.Context, arg GlobalCounters
 	}
 	return items, nil
 }
+
+const globalCountersImportedSince = `-- name: GlobalCountersImportedSince :many
+SELECT
+    counters.workspace_id,
+    counters.namespace,
+    counters.identifier,
+    counters.duration_ms,
+    counters.sequence,
+    CAST(SUM(CASE WHEN counters.region = ? THEN counters.count ELSE 0 END) AS SIGNED) AS regional,
+    CAST(SUM(CASE WHEN counters.region != ? THEN counters.count ELSE 0 END) AS SIGNED) AS imported
+FROM ratelimit_global_counters AS counters
+INNER JOIN (
+    SELECT DISTINCT
+        recent.workspace_id,
+        recent.namespace,
+        recent.identifier,
+        recent.duration_ms,
+        recent.sequence
+    FROM ratelimit_global_counters AS recent
+    WHERE recent.expires_at > ?
+      AND recent.updated_at >= ?
+) AS changed
+    ON changed.workspace_id = counters.workspace_id
+    AND changed.namespace = counters.namespace
+    AND changed.identifier = counters.identifier
+    AND changed.duration_ms = counters.duration_ms
+    AND changed.sequence = counters.sequence
+WHERE counters.expires_at > ?
+GROUP BY counters.workspace_id, counters.namespace, counters.identifier, counters.duration_ms, counters.sequence
+`
+
+type GlobalCountersImportedSinceParams struct {
+	SelfRegion   string `db:"self_region"`
+	Now          uint64 `db:"now"`
+	UpdatedAfter uint64 `db:"updated_after"`
+}
+
+type GlobalCountersImportedSinceRow struct {
+	WorkspaceID string `db:"workspace_id"`
+	Namespace   string `db:"namespace"`
+	Identifier  string `db:"identifier"`
+	DurationMs  uint64 `db:"duration_ms"`
+	Sequence    int64  `db:"sequence"`
+	Regional    int64  `db:"regional"`
+	Imported    int64  `db:"imported"`
+}
+
+// GlobalCountersImportedSince first identifies logical window cells with an
+// active region row updated inside the overlapped watermark, then aggregates
+// every active region row for those cells. Filtering only the changed physical
+// rows would omit unchanged regions and undercount the imported total.
+//
+//	SELECT
+//	    counters.workspace_id,
+//	    counters.namespace,
+//	    counters.identifier,
+//	    counters.duration_ms,
+//	    counters.sequence,
+//	    CAST(SUM(CASE WHEN counters.region = ? THEN counters.count ELSE 0 END) AS SIGNED) AS regional,
+//	    CAST(SUM(CASE WHEN counters.region != ? THEN counters.count ELSE 0 END) AS SIGNED) AS imported
+//	FROM ratelimit_global_counters AS counters
+//	INNER JOIN (
+//	    SELECT DISTINCT
+//	        recent.workspace_id,
+//	        recent.namespace,
+//	        recent.identifier,
+//	        recent.duration_ms,
+//	        recent.sequence
+//	    FROM ratelimit_global_counters AS recent
+//	    WHERE recent.expires_at > ?
+//	      AND recent.updated_at >= ?
+//	) AS changed
+//	    ON changed.workspace_id = counters.workspace_id
+//	    AND changed.namespace = counters.namespace
+//	    AND changed.identifier = counters.identifier
+//	    AND changed.duration_ms = counters.duration_ms
+//	    AND changed.sequence = counters.sequence
+//	WHERE counters.expires_at > ?
+//	GROUP BY counters.workspace_id, counters.namespace, counters.identifier, counters.duration_ms, counters.sequence
+func (q *Queries) GlobalCountersImportedSince(ctx context.Context, arg GlobalCountersImportedSinceParams) ([]GlobalCountersImportedSinceRow, error) {
+	rows, err := q.db.QueryContext(ctx, globalCountersImportedSince,
+		arg.SelfRegion,
+		arg.SelfRegion,
+		arg.Now,
+		arg.UpdatedAfter,
+		arg.Now,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []GlobalCountersImportedSinceRow
+	for rows.Next() {
+		var i GlobalCountersImportedSinceRow
+		if err := rows.Scan(
+			&i.WorkspaceID,
+			&i.Namespace,
+			&i.Identifier,
+			&i.DurationMs,
+			&i.Sequence,
+			&i.Regional,
+			&i.Imported,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}

--- a/internal/services/ratelimit/db/querier_generated.go
+++ b/internal/services/ratelimit/db/querier_generated.go
@@ -46,6 +46,39 @@ type Querier interface {
 	//  WHERE expires_at > ?
 	//  GROUP BY workspace_id, namespace, identifier, duration_ms, sequence
 	GlobalCountersImported(ctx context.Context, arg GlobalCountersImportedParams) ([]GlobalCountersImportedRow, error)
+	// GlobalCountersImportedSince first identifies logical window cells with an
+	// active region row updated inside the overlapped watermark, then aggregates
+	// every active region row for those cells. Filtering only the changed physical
+	// rows would omit unchanged regions and undercount the imported total.
+	//
+	//  SELECT
+	//      counters.workspace_id,
+	//      counters.namespace,
+	//      counters.identifier,
+	//      counters.duration_ms,
+	//      counters.sequence,
+	//      CAST(SUM(CASE WHEN counters.region = ? THEN counters.count ELSE 0 END) AS SIGNED) AS regional,
+	//      CAST(SUM(CASE WHEN counters.region != ? THEN counters.count ELSE 0 END) AS SIGNED) AS imported
+	//  FROM ratelimit_global_counters AS counters
+	//  INNER JOIN (
+	//      SELECT DISTINCT
+	//          recent.workspace_id,
+	//          recent.namespace,
+	//          recent.identifier,
+	//          recent.duration_ms,
+	//          recent.sequence
+	//      FROM ratelimit_global_counters AS recent
+	//      WHERE recent.expires_at > ?
+	//        AND recent.updated_at >= ?
+	//  ) AS changed
+	//      ON changed.workspace_id = counters.workspace_id
+	//      AND changed.namespace = counters.namespace
+	//      AND changed.identifier = counters.identifier
+	//      AND changed.duration_ms = counters.duration_ms
+	//      AND changed.sequence = counters.sequence
+	//  WHERE counters.expires_at > ?
+	//  GROUP BY counters.workspace_id, counters.namespace, counters.identifier, counters.duration_ms, counters.sequence
+	GlobalCountersImportedSince(ctx context.Context, arg GlobalCountersImportedSinceParams) ([]GlobalCountersImportedSinceRow, error)
 	// GlobalCountersListAll returns raw per-region global counter rows for tests
 	// that need to assert which region wrote which observation. Production callers
 	// should use GlobalCountersImported instead so MySQL does the aggregation.

--- a/internal/services/ratelimit/db/queries/global_counters_imported.sql
+++ b/internal/services/ratelimit/db/queries/global_counters_imported.sql
@@ -18,3 +18,36 @@ SELECT
 FROM ratelimit_global_counters
 WHERE expires_at > sqlc.arg("now")
 GROUP BY workspace_id, namespace, identifier, duration_ms, sequence;
+
+-- name: GlobalCountersImportedSince :many
+-- GlobalCountersImportedSince first identifies logical window cells with an
+-- active region row updated inside the overlapped watermark, then aggregates
+-- every active region row for those cells. Filtering only the changed physical
+-- rows would omit unchanged regions and undercount the imported total.
+SELECT
+    counters.workspace_id,
+    counters.namespace,
+    counters.identifier,
+    counters.duration_ms,
+    counters.sequence,
+    CAST(SUM(CASE WHEN counters.region = sqlc.arg("self_region") THEN counters.count ELSE 0 END) AS SIGNED) AS regional,
+    CAST(SUM(CASE WHEN counters.region != sqlc.arg("self_region") THEN counters.count ELSE 0 END) AS SIGNED) AS imported
+FROM ratelimit_global_counters AS counters
+INNER JOIN (
+    SELECT DISTINCT
+        recent.workspace_id,
+        recent.namespace,
+        recent.identifier,
+        recent.duration_ms,
+        recent.sequence
+    FROM ratelimit_global_counters AS recent
+    WHERE recent.expires_at > sqlc.arg("now")
+      AND recent.updated_at >= sqlc.arg("updated_after")
+) AS changed
+    ON changed.workspace_id = counters.workspace_id
+    AND changed.namespace = counters.namespace
+    AND changed.identifier = counters.identifier
+    AND changed.duration_ms = counters.duration_ms
+    AND changed.sequence = counters.sequence
+WHERE counters.expires_at > sqlc.arg("now")
+GROUP BY counters.workspace_id, counters.namespace, counters.identifier, counters.duration_ms, counters.sequence;

--- a/internal/services/ratelimit/global.go
+++ b/internal/services/ratelimit/global.go
@@ -19,12 +19,23 @@ import (
 // propagation latency at the cost of more writes.
 const globalPushInterval = 5 * time.Second
 
-// globalPullInterval is how often each region pulls the active set of counts
-// from ratelimit_global_counters. Own-region rows merge into val as an
+// globalPullInterval is how often each region pulls changed logical counter
+// cells from ratelimit_global_counters. Own-region rows merge into val as an
 // intra-region safety net; foreign-region rows merge into globalCount for
 // cross-region decisions. Lower values tighten propagation latency at the cost
 // of more reads; higher values let local state lag during bursts.
 const globalPullInterval = 5 * time.Second
+
+// globalPullWatermarkOverlap moves each incremental read one poll interval
+// behind the last successful watermark. Re-reading boundary updates tolerates
+// timestamp collisions and short replica-visibility delays; atomicMax makes the
+// duplicate aggregates idempotent.
+const globalPullWatermarkOverlap = globalPullInterval
+
+// globalPullReconciliationInterval bounds how long replica lag, clock skew, or
+// a delayed update outside the overlap can remain invisible. Reconciliation
+// uses the unfiltered active-set query, including after clock moves backward.
+const globalPullReconciliationInterval = time.Minute
 
 // globalUtilizationFloor is the fraction of the per-row limit that an
 // entry's local count must reach before its state is shared with other
@@ -197,24 +208,28 @@ func compareGlobalPushRows(a, b db.UpsertRatelimitGlobalCountersParams) int {
 	return cmp.Compare(a.Region, b.Region)
 }
 
-// startGlobalPull schedules runGlobalPullOnce on the package sync cadence. Each
-// tick pulls per-key sums from ratelimit_global_counters. Own-region rows merge
-// into counterEntry.val; foreign-region rows merge into counterEntry.globalCount.
-// Jitter desynchronizes reads across the fleet so the database is not hit by
-// every region's sync at the same instant.
+// startGlobalPull schedules runGlobalPullOnce on the package sync cadence. The
+// immediate first tick performs a full startup hydration; later ticks pull
+// changed logical cells, with periodic full reconciliation. Own-region rows
+// merge into counterEntry.val; foreign-region rows merge into
+// counterEntry.globalCount. Jitter desynchronizes reads across the fleet so the
+// database is not hit by every region's sync at the same instant.
 func (s *service) startGlobalPull() {
 	stop := repeat.Every(globalPullInterval, s.runGlobalPullOnce, globalJitter)
 	s.stopBackground = append(s.stopBackground, stop)
 }
 
 // runGlobalPullOnce fetches the per-key own-region count and foreign-region sum.
+// The first successful pull and periodic reconciliations read the complete
+// active set. Other pulls identify logical keys with a physical row changed in
+// the overlapped watermark, then aggregate every active region row for those
+// keys. Filtering physical rows directly would omit unchanged regions.
+//
 // Own-region count is an opportunistic intra-region safety net and merges into
 // val. Foreign-region count merges into globalCount and must stay separate from
-// val so it does not feed back into this region's next push. Aggregation runs in
-// MySQL via GROUP BY + SUM, so this loop is one pair of atomicMax operations per
-// active window cell rather than one per (region, cell) pair. Sums are
-// monotonic per cell (each region's contribution only grows within a sequence),
-// so atomicMax is sufficient and idempotent across overlapping ticks.
+// val so it does not feed back into this region's next push. Sums are monotonic
+// per cell (each region's contribution only grows within a sequence), so
+// atomicMax is sufficient and idempotent across overlapping ticks.
 //
 // When no local entry exists for a key seen in the result set, one is
 // created on demand via findOrCreateCounter. These entries are attributed
@@ -222,36 +237,78 @@ func (s *service) startGlobalPull() {
 // so the traffic-driven cardinality signal is not polluted by
 // cross-region propagation.
 func (s *service) runGlobalPullOnce() {
+	s.globalPullMu.Lock()
+	defer s.globalPullMu.Unlock()
+
 	ctx, cancel := context.WithTimeout(context.Background(), globalPullTimeout)
 	defer cancel()
 
 	nowMs := s.clock.Now().UnixMilli()
+	fullPull := !s.globalPullInitialized ||
+		nowMs < s.globalPullWatermarkMs ||
+		nowMs-s.globalPullLastReconciledMs >= globalPullReconciliationInterval.Milliseconds()
 
-	rows, err := s.db.RO().GlobalCountersImported(ctx, db.GlobalCountersImportedParams{
-		Now:        uint64(nowMs),
-		SelfRegion: s.region,
-	})
-	if err != nil {
+	rowsApplied := 0
+	var pullErr error
+	if fullPull {
+		rows, err := s.db.RO().GlobalCountersImported(ctx, db.GlobalCountersImportedParams{
+			Now:        uint64(nowMs),
+			SelfRegion: s.region,
+		})
+		pullErr = err
+		if err == nil {
+			rowsApplied = len(rows)
+			for _, r := range rows {
+				s.applyGlobalCounterImport(counterKey{
+					workspaceID: r.WorkspaceID,
+					namespace:   r.Namespace,
+					identifier:  r.Identifier,
+					durationMs:  int64(r.DurationMs),
+					sequence:    r.Sequence,
+				}, r.Regional, r.Imported)
+			}
+		}
+	} else {
+		updatedAfterMs := max(int64(0), s.globalPullWatermarkMs-globalPullWatermarkOverlap.Milliseconds())
+		rows, err := s.db.RO().GlobalCountersImportedSince(ctx, db.GlobalCountersImportedSinceParams{
+			Now:          uint64(nowMs),
+			SelfRegion:   s.region,
+			UpdatedAfter: uint64(updatedAfterMs),
+		})
+		pullErr = err
+		if err == nil {
+			rowsApplied = len(rows)
+			for _, r := range rows {
+				s.applyGlobalCounterImport(counterKey{
+					workspaceID: r.WorkspaceID,
+					namespace:   r.Namespace,
+					identifier:  r.Identifier,
+					durationMs:  int64(r.DurationMs),
+					sequence:    r.Sequence,
+				}, r.Regional, r.Imported)
+			}
+		}
+	}
+	if pullErr != nil {
 		metrics.RatelimitGlobalPullErrors.Inc()
-		logger.Error("ratelimit cross-region pull failed", "error", err.Error())
+		logger.Error("ratelimit cross-region pull failed", "error", pullErr.Error())
 		return
 	}
-	metrics.RatelimitGlobalPullRowsLastPoll.Set(float64(len(rows)))
 
-	for _, r := range rows {
-		key := counterKey{
-			workspaceID: r.WorkspaceID,
-			namespace:   r.Namespace,
-			identifier:  r.Identifier,
-			durationMs:  int64(r.DurationMs),
-			sequence:    r.Sequence,
-		}
-		entry, created := s.findOrCreateCounter(key)
-		atomicMax(&entry.val, r.Regional)
-		atomicMax(&entry.globalCount, r.Imported)
-		if created {
-			metrics.RatelimitGlobalEntriesCreated.Inc()
-		}
+	s.globalPullInitialized = true
+	s.globalPullWatermarkMs = nowMs
+	if fullPull {
+		s.globalPullLastReconciledMs = nowMs
 	}
-	metrics.RatelimitGlobalPullRowsApplied.Add(float64(len(rows)))
+	metrics.RatelimitGlobalPullRowsLastPoll.Set(float64(rowsApplied))
+	metrics.RatelimitGlobalPullRowsApplied.Add(float64(rowsApplied))
+}
+
+func (s *service) applyGlobalCounterImport(key counterKey, regional, imported int64) {
+	entry, created := s.findOrCreateCounter(key)
+	atomicMax(&entry.val, regional)
+	atomicMax(&entry.globalCount, imported)
+	if created {
+		metrics.RatelimitGlobalEntriesCreated.Inc()
+	}
 }

--- a/internal/services/ratelimit/global_integration_test.go
+++ b/internal/services/ratelimit/global_integration_test.go
@@ -73,6 +73,13 @@ func (e *integrationTestEnv) hasRow(workspaceID, namespace, identifier, region s
 	return ok
 }
 
+func (e *integrationTestEnv) upsertGlobalCounterRows(rows ...rldb.UpsertRatelimitGlobalCountersParams) {
+	e.t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	require.NoError(e.t, e.rldb.BulkUpsertGlobalCounters(ctx, rows))
+}
+
 // TestGlobal_PropagatesCountAcrossRegions is the headline scenario:
 // region A consumes part of the limit and flushes its count; region B
 // reads the row and folds it into its sliding-window math. A request to
@@ -139,6 +146,126 @@ func TestGlobal_PropagatesCountAcrossRegions(t *testing.T) {
 	resp, err = regionB.Ratelimit(ctx, denyReq)
 	require.NoError(t, err)
 	require.False(t, resp.Success, "B must deny when combined effective exceeds limit; without sharing this would have passed")
+}
+
+func TestGlobalPull_StartupFullSync(t *testing.T) {
+	t.Parallel()
+
+	env := newIntegrationTestEnv(t)
+	start := time.UnixMilli(2_000_000_000_000)
+	clk := clock.NewTestClock(start)
+	key := counterKey{
+		workspaceID: uid.New(uid.WorkspacePrefix),
+		namespace:   "ns",
+		identifier:  "user",
+		durationMs:  time.Hour.Milliseconds(),
+		sequence:    calculateSequence(start, time.Hour),
+	}
+	env.upsertGlobalCounterRows(globalCounterRowForKeyAt(key, "region-a", 6, start.Add(-time.Hour)))
+
+	regionB := env.newRegionAs(clk, "region-b")
+
+	require.Eventually(t, func() bool {
+		entry, ok := regionB.counters.Load(key)
+		return ok && entry.(*counterEntry).globalCount.Load() == 6
+	}, 3*time.Second, 25*time.Millisecond, "startup pull must fully hydrate old active rows")
+}
+
+func TestGlobalPull_IncrementalAggregatesUnchangedRegions(t *testing.T) {
+	t.Parallel()
+
+	env := newIntegrationTestEnv(t)
+	start := time.UnixMilli(2_000_000_000_000)
+	clk := clock.NewTestClock(start)
+	regionC := newGlobalPullOnlyService(env, clk, "region-c")
+	key := counterKey{
+		workspaceID: uid.New(uid.WorkspacePrefix),
+		namespace:   "ns",
+		identifier:  "user",
+		durationMs:  time.Hour.Milliseconds(),
+		sequence:    calculateSequence(start, time.Hour),
+	}
+
+	env.upsertGlobalCounterRows(
+		globalCounterRowForKeyAt(key, "region-a", 2, start),
+		globalCounterRowForKeyAt(key, "region-b", 3, start.Add(-time.Minute)),
+	)
+	regionC.runGlobalPullOnce()
+	entryValue, ok := regionC.counters.Load(key)
+	require.True(t, ok)
+	entry := entryValue.(*counterEntry)
+	require.Equal(t, int64(5), entry.globalCount.Load())
+
+	clk.Tick(time.Second)
+	env.upsertGlobalCounterRows(globalCounterRowForKeyAt(key, "region-a", 7, clk.Now()))
+	regionC.runGlobalPullOnce()
+
+	require.Equal(t, int64(10), entry.globalCount.Load(),
+		"incremental pull must aggregate changed region A with unchanged region B")
+}
+
+func TestGlobalPull_OverlapRecoversDelayedVisibilityWithoutDoubleCount(t *testing.T) {
+	t.Parallel()
+
+	env := newIntegrationTestEnv(t)
+	start := time.UnixMilli(2_000_000_000_000)
+	clk := clock.NewTestClock(start)
+	regionB := newGlobalPullOnlyService(env, clk, "region-b")
+	key := counterKey{
+		workspaceID: uid.New(uid.WorkspacePrefix),
+		namespace:   "ns",
+		identifier:  "user",
+		durationMs:  time.Hour.Milliseconds(),
+		sequence:    calculateSequence(start, time.Hour),
+	}
+
+	regionB.runGlobalPullOnce()
+	clk.Tick(globalPullInterval)
+	regionB.runGlobalPullOnce()
+
+	// Model a row that becomes visible only after the receiver advanced past its
+	// timestamp. The inclusive overlap must recover the boundary update.
+	env.upsertGlobalCounterRows(globalCounterRowForKeyAt(key, "region-a", 4, start))
+	regionB.runGlobalPullOnce()
+	entryValue, ok := regionB.counters.Load(key)
+	require.True(t, ok)
+	entry := entryValue.(*counterEntry)
+	require.Equal(t, int64(4), entry.globalCount.Load())
+
+	regionB.runGlobalPullOnce()
+	require.Equal(t, int64(4), entry.globalCount.Load(),
+		"overlap may return the same aggregate repeatedly but must not add it twice")
+}
+
+func TestGlobalPull_PeriodicReconciliationRepairsMissedUpdate(t *testing.T) {
+	t.Parallel()
+
+	env := newIntegrationTestEnv(t)
+	start := time.UnixMilli(2_000_000_000_000)
+	clk := clock.NewTestClock(start)
+	regionB := newGlobalPullOnlyService(env, clk, "region-b")
+	key := counterKey{
+		workspaceID: uid.New(uid.WorkspacePrefix),
+		namespace:   "ns",
+		identifier:  "user",
+		durationMs:  time.Hour.Milliseconds(),
+		sequence:    calculateSequence(start, time.Hour),
+	}
+
+	regionB.runGlobalPullOnce()
+	clk.Tick(globalPullInterval)
+	regionB.runGlobalPullOnce()
+
+	env.upsertGlobalCounterRows(globalCounterRowForKeyAt(key, "region-a", 9, start.Add(-time.Hour)))
+	regionB.runGlobalPullOnce()
+	_, ok := regionB.counters.Load(key)
+	require.False(t, ok, "incremental pull should miss an update older than its overlap")
+
+	clk.Tick(globalPullReconciliationInterval - globalPullInterval)
+	regionB.runGlobalPullOnce()
+	entryValue, ok := regionB.counters.Load(key)
+	require.True(t, ok, "periodic full reconciliation must recover the missed update")
+	require.Equal(t, int64(9), entryValue.(*counterEntry).globalCount.Load())
 }
 
 // TestGlobalPush_EmitsRowsInUniqueKeyOrder guarantees that a flush batch
@@ -252,6 +379,14 @@ func newGlobalPushOnlyService(db rldb.DBTX, region string) *service {
 	}
 }
 
+func newGlobalPullOnlyService(env *integrationTestEnv, clk clock.Clock, region string) *service {
+	return &service{ //nolint:exhaustruct // test only needs global pull dependencies
+		clock:  clk,
+		region: region,
+		db:     env.rldb,
+	}
+}
+
 func storePushableCounter(svc *service, key counterKey) {
 	entry := &counterEntry{} //nolint:exhaustruct // only push eligibility fields matter here
 	entry.val.Store(10)
@@ -260,6 +395,10 @@ func storePushableCounter(svc *service, key counterKey) {
 }
 
 func globalCounterRowForKey(key counterKey, region string, count uint64) rldb.UpsertRatelimitGlobalCountersParams {
+	return globalCounterRowForKeyAt(key, region, count, time.Now())
+}
+
+func globalCounterRowForKeyAt(key counterKey, region string, count uint64, updatedAt time.Time) rldb.UpsertRatelimitGlobalCountersParams {
 	return rldb.UpsertRatelimitGlobalCountersParams{
 		WorkspaceID: key.workspaceID,
 		Namespace:   key.namespace,
@@ -269,7 +408,7 @@ func globalCounterRowForKey(key counterKey, region string, count uint64) rldb.Up
 		Region:      region,
 		Count:       count,
 		ExpiresAt:   uint64((key.sequence + 2) * key.durationMs),
-		UpdatedAt:   uint64(time.Now().UnixMilli()),
+		UpdatedAt:   uint64(updatedAt.UnixMilli()),
 	}
 }
 

--- a/internal/services/ratelimit/service.go
+++ b/internal/services/ratelimit/service.go
@@ -312,6 +312,18 @@ type service struct {
 	// subsequent ticks or back-pressure denials on the request path.
 	globalCircuitBreaker circuitbreaker.CircuitBreaker[any]
 
+	// globalPullMu serializes full and incremental pulls. repeat.Every invokes
+	// them sequentially in production, while the lock also keeps manual pulls in
+	// tests from racing the background startup hydration and regressing cursors.
+	globalPullMu sync.Mutex
+
+	// globalPullInitialized becomes true only after a successful full startup
+	// hydration. The watermark and reconciliation time advance only after all
+	// returned rows have been applied.
+	globalPullInitialized      bool
+	globalPullWatermarkMs      int64
+	globalPullLastReconciledMs int64
+
 	// stopBackground holds the stop functions returned by repeat.Every for
 	// every periodic goroutine the service starts. Close invokes each one
 	// so the push, pull, and janitor loops do not outlive the database
@@ -366,7 +378,7 @@ func New(config Config) (*service, error) {
 		config.Clock = clock.New()
 	}
 
-	s := &service{ //nolint:exhaustruct // stopBackground is appended to as goroutines start
+	s := &service{ //nolint:exhaustruct // background state zero-initializes before goroutines start
 		clock:        config.Clock,
 		counters:     sync.Map{}, //nolint:exhaustruct // sync.Map zero value is ready to use
 		strictUntils: sync.Map{}, //nolint:exhaustruct // sync.Map zero value is ready to use

--- a/pkg/mysql/schema/ratelimit_global_counters.sql
+++ b/pkg/mysql/schema/ratelimit_global_counters.sql
@@ -15,3 +15,5 @@ CREATE TABLE `ratelimit_global_counters` (
 
 CREATE INDEX `expires_at_idx` ON `ratelimit_global_counters` (`expires_at`);
 
+CREATE INDEX `updated_at_expires_at_idx` ON `ratelimit_global_counters` (`updated_at`,`expires_at`);
+

--- a/web/internal/db/src/schema/ratelimit.ts
+++ b/web/internal/db/src/schema/ratelimit.ts
@@ -145,5 +145,6 @@ export const ratelimitGlobalCounters = mysqlTable(
       table.region,
     ),
     index("expires_at_idx").on(table.expiresAt),
+    index("updated_at_expires_at_idx").on(table.updatedAt, table.expiresAt),
   ],
 );


### PR DESCRIPTION
## Problem:

Every API and Frontline process polls the complete active all-tenant global-counter set every 5 seconds which is unnecessary... 
In a 24hour range that is about 46GiB egress and close to 500million rows read

Instead we should read incremental changes instead based on updatedAt + reconcile every N interval.
For incremental changes we do need an index.

## Solution:

We get all rows at ste start and then use `updated_at` as a watermark, To Repair missing rows due to replica lag or clock skew once a minute we perform a full reconilliaton.

Add `updated_at_expires_at_idx` on (`updated_at`, `expires_at`). 
This helps us to scan trough less rows for the incremental range scans

## Impact:

We should now query faster and less rows.

## Testing:

Tests pass

Adds new tests that ensures we dont read outdated data but data within a lag window.
