### PR TITLE
fix(api): support null key ratelimits

### DIFF
--- a/svc/api/openapi/gen.go
+++ b/svc/api/openapi/gen.go
@@ -3492,8 +3492,8 @@ type V2KeysUpdateKeyRequestBody struct {
 	// Omitting this field preserves existing rate limits, while setting null removes all rate limits.
 	// Unlike credits which track total usage, rate limits reset automatically after each window expires.
 	// Multiple rate limits can control different operation types with separate thresholds and windows.
-	Ratelimits *[]RatelimitRequest `json:"ratelimits,omitempty"`
-	Roles      *[]string           `json:"roles,omitempty"`
+	Ratelimits nullable.Nullable[[]RatelimitRequest] `json:"ratelimits,omitempty"`
+	Roles      *[]string                             `json:"roles,omitempty"`
 }
 
 // V2KeysUpdateKeyResponseBody defines model for V2KeysUpdateKeyResponseBody.

--- a/svc/api/openapi/openapi-generated.yaml
+++ b/svc/api/openapi/openapi-generated.yaml
@@ -2463,7 +2463,9 @@ components:
                         Cannot configure refill settings when credits is null, and refillDay requires monthly interval.
                         Essential for implementing usage-based pricing and subscription quotas.
                 ratelimits:
-                    type: array
+                    type:
+                        - array
+                        - "null"
                     maxItems: 50
                     items:
                         "$ref": "#/components/schemas/RatelimitRequest"

--- a/svc/api/openapi/overlay.yaml
+++ b/svc/api/openapi/overlay.yaml
@@ -31,6 +31,11 @@ actions:
   - target: $["components"]["schemas"]["V2KeysUpdateKeyRequestBody"]["properties"]["expires"]
     update:
       nullable: true
+  - target: $["components"]["schemas"]["V2KeysUpdateKeyRequestBody"]["properties"]["ratelimits"]["type"]
+    update: array
+  - target: $["components"]["schemas"]["V2KeysUpdateKeyRequestBody"]["properties"]["ratelimits"]
+    update:
+      nullable: true
   - target: $["components"]["schemas"]["KeyCreditsData"]["properties"]["remaining"]["type"]
     update: integer
   - target: $["components"]["schemas"]["KeyCreditsData"]["properties"]["remaining"]

--- a/svc/api/openapi/spec/paths/v2/keys/updateKey/V2KeysUpdateKeyRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/keys/updateKey/V2KeysUpdateKeyRequestBody.yaml
@@ -84,7 +84,9 @@ properties:
       Cannot configure refill settings when credits is null, and refillDay requires monthly interval.
       Essential for implementing usage-based pricing and subscription quotas.
   ratelimits:
-    type: array
+    type:
+      - array
+      - "null"
     maxItems: 50 # Reasonable limit for rate limit configurations per key
     items:
       "$ref": "../../../../common/RatelimitRequest.yaml"

--- a/svc/api/routes/v2_keys_update_key/200_test.go
+++ b/svc/api/routes/v2_keys_update_key/200_test.go
@@ -81,7 +81,7 @@ func TestUpdateKeySuccess(t *testing.T) {
 
 		req := handler.Request{
 			KeyId:      keyResponse.KeyID,
-			Ratelimits: ptr.P([]openapi.RatelimitRequest{ratelimit}),
+			Ratelimits: nullable.NewNullableWithValue([]openapi.RatelimitRequest{ratelimit}),
 		}
 
 		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, req)
@@ -106,7 +106,7 @@ func TestUpdateKeySuccess(t *testing.T) {
 
 		req = handler.Request{
 			KeyId:      keyResponse.KeyID,
-			Ratelimits: ptr.P([]openapi.RatelimitRequest{ratelimit}),
+			Ratelimits: nullable.NewNullableWithValue([]openapi.RatelimitRequest{ratelimit}),
 		}
 
 		res = testutil.CallRoute[handler.Request, handler.Response](h, route, headers, req)
@@ -121,6 +121,26 @@ func TestUpdateKeySuccess(t *testing.T) {
 		require.Equal(t, ratelimit.AutoApply, ratelimits[0].AutoApply)
 		require.EqualValues(t, ratelimit.Duration, ratelimits[0].Duration)
 		require.EqualValues(t, ratelimit.Limit, ratelimits[0].Limit)
+
+		res = testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{
+			KeyId:   keyResponse.KeyID,
+			Enabled: ptr.P(false),
+		})
+		require.Equal(t, 200, res.Status)
+
+		ratelimits, err = db.Query.ListRatelimitsByKeyID(ctx, h.DB.RO(), sql.NullString{String: keyResponse.KeyID, Valid: true})
+		require.NoError(t, err)
+		require.Len(t, ratelimits, 1, "omitting ratelimits must preserve them")
+
+		res = testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{
+			KeyId:      keyResponse.KeyID,
+			Ratelimits: nullable.NewNullNullable[[]openapi.RatelimitRequest](),
+		})
+		require.Equal(t, 200, res.Status)
+
+		ratelimits, err = db.Query.ListRatelimitsByKeyID(ctx, h.DB.RO(), sql.NullString{String: keyResponse.KeyID, Valid: true})
+		require.NoError(t, err)
+		require.Empty(t, ratelimits, "null ratelimits must remove them")
 	})
 }
 
@@ -511,7 +531,7 @@ func TestUpdateKeyConcurrentRatelimits(t *testing.T) {
 			}
 			req := handler.Request{
 				KeyId:      keyResponse.KeyID,
-				Ratelimits: ptr.P(ratelimits),
+				Ratelimits: nullable.NewNullableWithValue(ratelimits),
 			}
 			res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, req)
 			if res.Status != 200 {

--- a/svc/api/routes/v2_keys_update_key/handler.go
+++ b/svc/api/routes/v2_keys_update_key/handler.go
@@ -308,7 +308,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			)
 		}
 
-		if req.Ratelimits != nil {
+		if req.Ratelimits.IsSpecified() {
 			var existingRatelimits []db.ListRatelimitsByKeyIDRow
 			existingRatelimits, err = db.Query.ListRatelimitsByKeyID(ctx, tx, sql.NullString{String: key.ID, Valid: true})
 			if err != nil && !db.IsNotFound(err) {
@@ -326,8 +326,10 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 			// Create map of new ratelimits
 			newRatelimitMap := make(map[string]openapi.RatelimitRequest)
-			for _, rl := range *req.Ratelimits {
-				newRatelimitMap[rl.Name] = rl
+			if !req.Ratelimits.IsNull() {
+				for _, rl := range req.Ratelimits.MustGet() {
+					newRatelimitMap[rl.Name] = rl
+				}
 			}
 
 			// Delete ratelimits that are not in the new list


### PR DESCRIPTION
## Problem:

`keys.updateKey` documented `ratelimits: null` as a way to remove all key rate limits.

But our OpenAPI schema and generated Go model could not distinguish null from an omitted field, so null preserved the existing limits instead.

## Solution:

Make `ratelimits` optional and nullable in the API contract. 
The endpoint now preserves limits when the field is omitted, removes all limits when the field is null, and replaces all limits when an array is provided.

## Impact:

The endpoint now matches its documented behavior. Existing omitted and array requests keep their current behavior. SDK generators can expose all three request states.

## Testing:

- `mise exec -- rask ./svc/api/routes/v2_keys_update_key` — 37 passed
- `mise exec -- rask ./svc/api/openapi` — 14 passed