### PR TITLE
Add trimpath to service releases

### DIFF
--- a/.goreleaser.service.yaml
+++ b/.goreleaser.service.yaml
@@ -15,6 +15,8 @@ builds:
     goarch:
       - amd64
       - arm64
+    flags:
+      - -trimpath
     ldflags:
       - -s -w
       - -X 'github.com/unkeyed/unkey/pkg/buildinfo.Version={{.Version}}'


### PR DESCRIPTION
## Problem:

Service releases retained absolute source and toolchain paths in Go runtime metadata. 
The paths made binaries larger and made builds depend on the build machine path.

## Solution:

Add `-trimpath` to the shared GoReleaser service build flags. 
All seven service releases now remove local filesystem paths during compilation.

## Impact:

Removes approx 100kib

## Testing:

- Built all seven Linux amd64 service entrypoints with the release linker flags.
- `mise run build`: passed with 0 lint issues.
- Compared each service with identical source and linker flags, changing only `-trimpath`.