### PR TITLE
Decouple service metrics from Zen

### DIFF
--- a/pkg/prometheus/doc.go
+++ b/pkg/prometheus/doc.go
@@ -21,6 +21,6 @@
 //   - This package: HTTP server that exposes metrics at GET /metrics
 //   - [metrics] subpackage: All metric collectors organized by subsystem
 //
-// This separation allows services to import only the metrics they need without
-// pulling in HTTP server dependencies.
+// The server uses net/http directly so metrics-only services do not link an
+// application HTTP framework and its validation dependencies.
 package prometheus

--- a/pkg/prometheus/server.go
+++ b/pkg/prometheus/server.go
@@ -1,129 +1,90 @@
-/*
-Package prometheus provides utilities for exposing Prometheus metrics over HTTP.
-
-This package makes it easy to integrate Prometheus metrics collection and exposure
-into applications built with the zen framework. It handles the setup of a metrics
-endpoint that Prometheus can scrape to collect runtime metrics from your application.
-
-Common use cases include:
-  - Creating a dedicated metrics server separate from your application server
-  - Adding metrics endpoints to existing zen-based applications
-  - Setting up consistent metrics across multiple microservices
-
-This package is designed to work seamlessly with the zen framework while providing
-all the functionality of the standard Prometheus client library.
-*/
 package prometheus
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net"
 	"net/http"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/unkeyed/unkey/pkg/zen"
 )
 
-// New creates a zen server that exposes Prometheus metrics at the /metrics endpoint.
-// The server is configured to handle GET requests to the /metrics path using the
-// standard Prometheus HTTP handler, which serves metrics in a format that Prometheus
-// can scrape.
-//
-// New is used to create a standalone metrics server that can be started separately
-// from your main application server, which is a common pattern for microservices
-// architectures where concerns are separated.
-//
-// Parameters:
-//   - config: Configuration for the server, including required dependencies.
-//
-// Returns:
-//   - A configured zen.Server ready to be started.
-//   - An error if server creation fails, typically due to invalid configuration.
-//
-// Example usage:
-//
-//	// Create a dedicated metrics server
-//	server, err := prometheus.New(prometheus.Config{
-//	   ,
-//	})
-//	if err != nil {
-//	    log.Fatalf("Failed to create metrics server: %v", err)
-//	}
-//
-//	// Start the metrics server on port 9090
-//	go func() {
-//	    if err := server.Listen(":9090"); err != nil {
-//	        log.Fatalf("Metrics server failed: %v", err)
-//	    }
-//	}()
-//
-// When used with CLI commands, the server can be started with a command like:
-//
-//	myapp metrics --port=9090
-//
-// See [zen.New] for details on the underlying server creation.
-// See [promhttp.Handler] for details on the Prometheus metrics handler.
-func New() (*zen.Server, error) {
-	z, err := zen.New(zen.Config{
-		MaxRequestBodySize: 0,
-		Flags:              nil,
-		TLS:                nil,
-		EnableH2C:          false,
-		StreamRequestBody:  false,
-		ReadTimeout:        0,
-		WriteTimeout:       0,
-	})
-	if err != nil {
-		return nil, err
-	}
+const (
+	readTimeout     = 10 * time.Second
+	writeTimeout    = 20 * time.Second
+	shutdownTimeout = 30 * time.Second
+)
 
-	h := promhttp.Handler()
-
-	// Register the metrics endpoint with the zen server
-	z.RegisterRoute([]zen.Middleware{}, zen.NewRoute("GET", "/metrics", func(ctx context.Context, s *zen.Session) error {
-		h.ServeHTTP(s.ResponseWriter(), s.Request())
-		return nil
-	}))
-
-	return z, nil
+// Server exposes Prometheus metrics over HTTP.
+type Server struct {
+	http *http.Server
 }
 
-// NewWithRegistry creates a zen server that exposes metrics from a custom
+// New creates a server that exposes the default Prometheus registry.
+func New() (*Server, error) {
+	return newServer(promhttp.Handler()), nil
+}
+
+// NewWithRegistry creates a server that exposes metrics from a custom
 // prometheus.Registry at the /metrics endpoint.
-func NewWithRegistry(reg *prometheus.Registry) (*zen.Server, error) {
+func NewWithRegistry(reg *prometheus.Registry) (*Server, error) {
 	if reg == nil {
 		return nil, fmt.Errorf("prometheus: nil registry")
 	}
 
-	z, err := zen.New(zen.Config{
-		MaxRequestBodySize: 0,
-		Flags:              nil,
-		TLS:                nil,
-		EnableH2C:          false,
-		StreamRequestBody:  false,
-		ReadTimeout:        0,
-		WriteTimeout:       0,
-	})
-	if err != nil {
-		return nil, err
+	return newServer(promhttp.HandlerFor(reg, promhttp.HandlerOpts{})), nil
+}
+
+func newServer(metricsHandler http.Handler) *Server {
+	mux := http.NewServeMux()
+	mux.Handle("GET /metrics", metricsHandler)
+
+	return &Server{
+		http: &http.Server{
+			Handler:      mux,
+			ReadTimeout:  readTimeout,
+			WriteTimeout: writeTimeout,
+		},
+	}
+}
+
+// Serve exposes metrics on ln until ctx is canceled or the server stops.
+func (s *Server) Serve(ctx context.Context, ln net.Listener) error {
+	serveDone := make(chan struct{})
+	shutdownErr := make(chan error, 1)
+	go func() {
+		select {
+		case <-ctx.Done():
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+			defer cancel()
+			shutdownErr <- s.Shutdown(shutdownCtx)
+		case <-serveDone:
+			shutdownErr <- nil
+		}
+	}()
+
+	err := s.http.Serve(ln)
+	close(serveDone)
+	if errors.Is(err, http.ErrServerClosed) {
+		err = nil
 	}
 
-	h := promhttp.HandlerFor(reg, promhttp.HandlerOpts{})
+	return errors.Join(err, <-shutdownErr)
+}
 
-	z.RegisterRoute([]zen.Middleware{}, zen.NewRoute("GET", "/metrics", func(ctx context.Context, s *zen.Session) error {
-		h.ServeHTTP(s.ResponseWriter(), s.Request())
-		return nil
-	}))
-
-	return z, nil
+// Shutdown gracefully stops the metrics server.
+func (s *Server) Shutdown(ctx context.Context) error {
+	return s.http.Shutdown(ctx)
 }
 
 // Serve starts a simple HTTP server that exposes Prometheus metrics at GET /metrics.
 // The server listens on the provided address (e.g., ":9090" or "127.0.0.1:9090").
 //
-// This is a simpler alternative to New() that doesn't require the zen framework.
-// It blocks until the server stops or an error occurs.
+// This is a package-level alternative to New(). It blocks until the server
+// stops or an error occurs.
 //
 // Example usage:
 //

--- a/pkg/prometheus/server_test.go
+++ b/pkg/prometheus/server_test.go
@@ -1,0 +1,65 @@
+package prometheus
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	clientprometheus "github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewWithRegistryExposesMetrics(t *testing.T) {
+	reg := clientprometheus.NewRegistry()
+	gauge := clientprometheus.NewGauge(clientprometheus.GaugeOpts{
+		Name: "test_metric",
+		Help: "Test metric.",
+	})
+	gauge.Set(42)
+	reg.MustRegister(gauge)
+
+	server, err := NewWithRegistry(reg)
+	require.NoError(t, err)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if closeErr := listener.Close(); closeErr != nil && !errors.Is(closeErr, net.ErrClosed) {
+			require.NoError(t, closeErr)
+		}
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- server.Serve(ctx, listener)
+	}()
+
+	response, err := http.Get("http://" + listener.Addr().String() + "/metrics")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, response.Body.Close())
+	})
+	body, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, response.StatusCode)
+	require.Contains(t, string(body), "test_metric 42")
+
+	cancel()
+	select {
+	case err := <-serveErr:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		require.FailNow(t, "timed out waiting for metrics server to stop")
+	}
+}
+
+func TestNewWithRegistryRejectsNilRegistry(t *testing.T) {
+	_, err := NewWithRegistry(nil)
+	require.EqualError(t, err, "prometheus: nil registry")
+}

--- a/pkg/timing/doc.go
+++ b/pkg/timing/doc.go
@@ -1,5 +1,5 @@
 // Package timing defines a small, strict header format for server-side timing
-// data and provides helpers to record it through zen sessions.
+// data and provides helpers to record it on HTTP responses.
 //
 // The package exists because Server-Timing is standardized but too limited for
 // Unkey's debugging needs. We want a header that remains readable in raw HTTP
@@ -44,10 +44,10 @@
 //
 // # Usage
 //
-// Callers record entries directly on the current request context. If a zen
-// session is present, the entry is serialized and added to the response headers.
-// This keeps observability wiring close to the request without exposing sessions
-// to application code.
+// Callers record entries directly on the current request context. If a response
+// writer is present, the entry is serialized and added to the response headers.
+// This keeps observability wiring close to the request without exposing HTTP
+// internals to application code.
 //
 //	 timing.Record(ctx, timing.Entry{
 //		Name:     "cache_get",

--- a/pkg/timing/entry.go
+++ b/pkg/timing/entry.go
@@ -8,9 +8,9 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/unkeyed/unkey/pkg/zen"
 )
+
+type responseWriterKey struct{}
 
 // HeaderName is the HTTP header name used for timing entries. This custom header
 // was chosen over the standard Server-Timing header because it supports a stricter
@@ -143,31 +143,31 @@ func formatDurationUnit(duration time.Duration, unit time.Duration, suffix strin
 	return strconv.FormatFloat(value, 'f', -1, 64) + suffix
 }
 
-// Record writes a timing entry to the response headers via the [zen.Session]
-// associated with the context. If no session is present or the entry fails
-// validation, the call is silently ignored. This allows instrumentation code
-// to be added unconditionally without error handling.
+// WithResponseWriter stores the response writer used by [Record].
+func WithResponseWriter(ctx context.Context, w http.ResponseWriter) context.Context {
+	return context.WithValue(ctx, responseWriterKey{}, w)
+}
+
+// Record writes a timing entry to the response writer associated with the
+// context. If no writer is present or the entry fails validation, the call is
+// silently ignored. This allows instrumentation code to be added
+// unconditionally without error handling.
 //
 // Use [Write] when you have direct access to an [http.ResponseWriter] instead
-// of a context with a session.
+// of a context carrying one.
 func Record(ctx context.Context, entry Entry) {
-	if err := entry.Validate(); err != nil {
-		return
-	}
-
-	session, ok := zen.SessionFromContext(ctx)
+	w, ok := ctx.Value(responseWriterKey{}).(http.ResponseWriter)
 	if !ok {
 		return
 	}
 
-	session.AddHeader(HeaderName, entry.String())
+	Write(w, entry)
 }
 
 // Write adds a timing entry directly to the response headers. If the entry
 // fails validation, the call is silently ignored.
 //
-// Use [Record] when working with a context that contains a [zen.Session],
-// which is the common case in request handlers.
+// Use [Record] when working with a context configured by [WithResponseWriter].
 func Write(w http.ResponseWriter, entry Entry) {
 	if err := entry.Validate(); err != nil {
 		return

--- a/pkg/timing/entry_test.go
+++ b/pkg/timing/entry_test.go
@@ -2,7 +2,6 @@ package timing
 
 import (
 	"context"
-	"net/http"
 	"net/http/httptest"
 	"strconv"
 	"strings"
@@ -10,7 +9,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"github.com/unkeyed/unkey/pkg/zen"
 )
 
 func TestParseEntry(t *testing.T) {
@@ -163,14 +161,9 @@ func TestParseEntries(t *testing.T) {
 }
 
 func TestRecord(t *testing.T) {
-	t.Run("writes header when session exists", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/", nil)
+	t.Run("writes header when response writer exists", func(t *testing.T) {
 		recorder := httptest.NewRecorder()
-		session := &zen.Session{}
-		err := session.Init(recorder, req, 0)
-		require.NoError(t, err)
-
-		ctx := zen.WithSession(context.Background(), session)
+		ctx := WithResponseWriter(context.Background(), recorder)
 		Record(ctx, Entry{Name: "cache_get", Duration: time.Millisecond})
 
 		values := recorder.Header().Values(HeaderName)
@@ -178,18 +171,13 @@ func TestRecord(t *testing.T) {
 		require.Equal(t, "cache_get=1ms", values[0])
 	})
 
-	t.Run("no session is a no-op", func(t *testing.T) {
+	t.Run("no response writer is a no-op", func(t *testing.T) {
 		Record(context.Background(), Entry{Name: "cache_get", Duration: time.Millisecond})
 	})
 
 	t.Run("rejects invalid entry", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		recorder := httptest.NewRecorder()
-		session := &zen.Session{}
-		err := session.Init(recorder, req, 0)
-		require.NoError(t, err)
-
-		ctx := zen.WithSession(context.Background(), session)
+		ctx := WithResponseWriter(context.Background(), recorder)
 		Record(ctx, Entry{Name: "1bad", Duration: time.Millisecond})
 		values := recorder.Header().Values(HeaderName)
 		require.Empty(t, values)

--- a/pkg/zen/context.go
+++ b/pkg/zen/context.go
@@ -1,6 +1,10 @@
 package zen
 
-import "context"
+import (
+	"context"
+
+	"github.com/unkeyed/unkey/pkg/timing"
+)
 
 // ContextKey provides type-safe context storage using generics.
 // It eliminates the need for type assertions and provides compile-time
@@ -65,7 +69,8 @@ var sessionKey = NewContextKey[*Session]("session")
 // debug headers, where cache operations need to write response headers without
 // requiring explicit session passing through all function calls.
 func WithSession(ctx context.Context, session *Session) context.Context {
-	return sessionKey.WithValue(ctx, session)
+	ctx = sessionKey.WithValue(ctx, session)
+	return timing.WithResponseWriter(ctx, session.ResponseWriter())
 }
 
 // SessionFromContext retrieves the session pointer stored by WithSession.

--- a/pkg/zen/context_test.go
+++ b/pkg/zen/context_test.go
@@ -1,0 +1,27 @@
+package zen
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/timing"
+)
+
+func TestWithSessionProvidesTimingResponseWriter(t *testing.T) {
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	response := httptest.NewRecorder()
+	session := &Session{}
+	require.NoError(t, session.Init(response, request, 0))
+
+	ctx := WithSession(context.Background(), session)
+	timing.Record(ctx, timing.Entry{Name: "cache_get", Duration: time.Millisecond})
+
+	require.Equal(t, []string{"cache_get=1ms"}, response.Header().Values(timing.HeaderName))
+	storedSession, ok := SessionFromContext(ctx)
+	require.True(t, ok)
+	require.Same(t, session, storedSession)
+}


### PR DESCRIPTION
## Problem:

The Prometheus server used Zen for one `GET /metrics` route. The timing package also imported Zen only to retrieve an HTTP response writer. Services that imported these helpers linked Zen, OpenAPI validation, and 78–92 unnecessary compile packages.

## Solution:

Run the metrics endpoint on a small `net/http.Server` with the same read, write, and shutdown limits. Store the response writer in the timing context directly. `zen.WithSession` supplies that writer, so existing request timing behavior remains unchanged.

## Impact:

| Service | Binary before → after | Gzip before → after |
| --- | ---: | ---: |
| Control API | 41.35 → 39.40 MiB | 13.26 → 12.43 MiB |
| Control worker | 88.96 → 87.39 MiB | 24.49 → 23.81 MiB |
| Krane | 53.63 → 51.33 MiB | 15.52 → 14.55 MiB |
| Vault | 28.03 → 25.61 MiB | 9.37 → 8.36 MiB |

The other three services already link Zen for application routes, so their dependency graph does not change. Vault readiness measured 16.58 → 9.58 ms. Metrics output and timing headers remain unchanged.

## Testing:

- `mise exec -- rask ./pkg/timing ./pkg/zen ./pkg/cache ./pkg/prometheus`: 239 passed.
- `mise exec -- rask ./svc/ctrl/worker/... ./svc/krane/...`: 279 passed.
- `mise run build`: passed with 0 lint issues.
- Built all seven Linux amd64 service entrypoints with exact release-equivalent flags.
- Verified Vault readiness and `/metrics`, including exactly one `unkey_build_info` sample.