### PR TITLE
fix(api): add missing permissions for dashboard to call api

### DIFF
--- a/pkg/auth/workos/permissions.go
+++ b/pkg/auth/workos/permissions.go
@@ -155,28 +155,28 @@ var permissionMappings = map[string]permissionMapping{
 		name:        "Create domains",
 		description: "Allows attaching a custom domain to an environment.",
 		permissions: []permissionGrant{
-			{resource: "projects/*/apps/*/environments/*", action: action(rbacpermissions.CreateDomain{})},
+			{resource: "projects/*/apps/*/environments/*/domains/*", action: action(rbacpermissions.CreateDomain{})},
 		},
 	},
 	"domains:read": {
 		name:        "Read domains",
 		description: "Allows reading an environment's custom domains.",
 		permissions: []permissionGrant{
-			{resource: "projects/*/apps/*/environments/*", action: action(rbacpermissions.ReadDomain{})},
+			{resource: "projects/*/apps/*/environments/*/domains/*", action: action(rbacpermissions.ReadDomain{})},
 		},
 	},
 	"domains:delete": {
 		name:        "Delete domains",
 		description: "Allows removing a custom domain from an environment.",
 		permissions: []permissionGrant{
-			{resource: "projects/*/apps/*/environments/*", action: action(rbacpermissions.DeleteDomain{})},
+			{resource: "projects/*/apps/*/environments/*/domains/*", action: action(rbacpermissions.DeleteDomain{})},
 		},
 	},
 	"domains:verify": {
 		name:        "Verify domains",
 		description: "Allows restarting verification for a custom domain.",
 		permissions: []permissionGrant{
-			{resource: "projects/*/apps/*/environments/*", action: action(rbacpermissions.VerifyDomain{})},
+			{resource: "projects/*/apps/*/environments/*/domains/*", action: action(rbacpermissions.VerifyDomain{})},
 		},
 	},
 	"identities:create": {

--- a/pkg/auth/workos/permissions.go
+++ b/pkg/auth/workos/permissions.go
@@ -151,6 +151,34 @@ var permissionMappings = map[string]permissionMapping{
 			{resource: "projects/*/apps/*/environments/*", action: action(rbacpermissions.RemoveEnvironmentVariables{})},
 		},
 	},
+	"domains:create": {
+		name:        "Create domains",
+		description: "Allows attaching a custom domain to an environment.",
+		permissions: []permissionGrant{
+			{resource: "projects/*/apps/*/environments/*", action: action(rbacpermissions.CreateDomain{})},
+		},
+	},
+	"domains:read": {
+		name:        "Read domains",
+		description: "Allows reading an environment's custom domains.",
+		permissions: []permissionGrant{
+			{resource: "projects/*/apps/*/environments/*", action: action(rbacpermissions.ReadDomain{})},
+		},
+	},
+	"domains:delete": {
+		name:        "Delete domains",
+		description: "Allows removing a custom domain from an environment.",
+		permissions: []permissionGrant{
+			{resource: "projects/*/apps/*/environments/*", action: action(rbacpermissions.DeleteDomain{})},
+		},
+	},
+	"domains:verify": {
+		name:        "Verify domains",
+		description: "Allows restarting verification for a custom domain.",
+		permissions: []permissionGrant{
+			{resource: "projects/*/apps/*/environments/*", action: action(rbacpermissions.VerifyDomain{})},
+		},
+	},
 	"identities:create": {
 		name:        "Create identities",
 		description: "Allows creating identities.",

--- a/pkg/auth/workos/permissions_test.go
+++ b/pkg/auth/workos/permissions_test.go
@@ -120,22 +120,22 @@ func TestTranslatePermissionsKnownMappings(t *testing.T) {
 		{
 			name: "domain create",
 			in:   "domains:create",
-			want: "unkey:v1:ws_123:projects/*/apps/*/environments/*#create_domain",
+			want: "unkey:v1:ws_123:projects/*/apps/*/environments/*/domains/*#create_domain",
 		},
 		{
 			name: "domain read",
 			in:   "domains:read",
-			want: "unkey:v1:ws_123:projects/*/apps/*/environments/*#read_domain",
+			want: "unkey:v1:ws_123:projects/*/apps/*/environments/*/domains/*#read_domain",
 		},
 		{
 			name: "domain delete",
 			in:   "domains:delete",
-			want: "unkey:v1:ws_123:projects/*/apps/*/environments/*#delete_domain",
+			want: "unkey:v1:ws_123:projects/*/apps/*/environments/*/domains/*#delete_domain",
 		},
 		{
 			name: "domain verify",
 			in:   "domains:verify",
-			want: "unkey:v1:ws_123:projects/*/apps/*/environments/*#verify_domain",
+			want: "unkey:v1:ws_123:projects/*/apps/*/environments/*/domains/*#verify_domain",
 		},
 		{
 			name: "admin",

--- a/pkg/auth/workos/permissions_test.go
+++ b/pkg/auth/workos/permissions_test.go
@@ -118,6 +118,26 @@ func TestTranslatePermissionsKnownMappings(t *testing.T) {
 			want: "unkey:v1:ws_123:projects/*/identities/*#delete_identity",
 		},
 		{
+			name: "domain create",
+			in:   "domains:create",
+			want: "unkey:v1:ws_123:projects/*/apps/*/environments/*#create_domain",
+		},
+		{
+			name: "domain read",
+			in:   "domains:read",
+			want: "unkey:v1:ws_123:projects/*/apps/*/environments/*#read_domain",
+		},
+		{
+			name: "domain delete",
+			in:   "domains:delete",
+			want: "unkey:v1:ws_123:projects/*/apps/*/environments/*#delete_domain",
+		},
+		{
+			name: "domain verify",
+			in:   "domains:verify",
+			want: "unkey:v1:ws_123:projects/*/apps/*/environments/*#verify_domain",
+		},
+		{
 			name: "admin",
 			in:   "admin:*",
 			want: "unkey:v1:ws_123:**#*",

--- a/pkg/auth/workos/testdata/permissions.golden
+++ b/pkg/auth/workos/testdata/permissions.golden
@@ -6,10 +6,10 @@ unkey:v1:ws_123:projects/*/apps/*/environments/*/deployments/*#promote_deploymen
 unkey:v1:ws_123:projects/*/apps/*/environments/*/deployments/*#rollback_deployment
 unkey:v1:ws_123:projects/*/apps/*/environments/*/deployments/*#start_deployment
 unkey:v1:ws_123:projects/*/apps/*/environments/*/deployments/*#stop_deployment
-unkey:v1:ws_123:projects/*/apps/*/environments/*#create_domain
-unkey:v1:ws_123:projects/*/apps/*/environments/*#delete_domain
-unkey:v1:ws_123:projects/*/apps/*/environments/*#read_domain
-unkey:v1:ws_123:projects/*/apps/*/environments/*#verify_domain
+unkey:v1:ws_123:projects/*/apps/*/environments/*/domains/*#create_domain
+unkey:v1:ws_123:projects/*/apps/*/environments/*/domains/*#delete_domain
+unkey:v1:ws_123:projects/*/apps/*/environments/*/domains/*#read_domain
+unkey:v1:ws_123:projects/*/apps/*/environments/*/domains/*#verify_domain
 unkey:v1:ws_123:projects/*/apps/*/environments/*#read_environment_variables
 unkey:v1:ws_123:projects/*/apps/*/environments/*#remove_environment_variables
 unkey:v1:ws_123:projects/*/apps/*/environments/*#set_environment_variables

--- a/pkg/auth/workos/testdata/permissions.golden
+++ b/pkg/auth/workos/testdata/permissions.golden
@@ -6,6 +6,10 @@ unkey:v1:ws_123:projects/*/apps/*/environments/*/deployments/*#promote_deploymen
 unkey:v1:ws_123:projects/*/apps/*/environments/*/deployments/*#rollback_deployment
 unkey:v1:ws_123:projects/*/apps/*/environments/*/deployments/*#start_deployment
 unkey:v1:ws_123:projects/*/apps/*/environments/*/deployments/*#stop_deployment
+unkey:v1:ws_123:projects/*/apps/*/environments/*#create_domain
+unkey:v1:ws_123:projects/*/apps/*/environments/*#delete_domain
+unkey:v1:ws_123:projects/*/apps/*/environments/*#read_domain
+unkey:v1:ws_123:projects/*/apps/*/environments/*#verify_domain
 unkey:v1:ws_123:projects/*/apps/*/environments/*#read_environment_variables
 unkey:v1:ws_123:projects/*/apps/*/environments/*#remove_environment_variables
 unkey:v1:ws_123:projects/*/apps/*/environments/*#set_environment_variables

--- a/pkg/rbac/permissions/domains.go
+++ b/pkg/rbac/permissions/domains.go
@@ -1,0 +1,36 @@
+package permissions
+
+import "github.com/unkeyed/unkey/pkg/urn"
+
+// CreateDomain authorizes attaching a custom domain to an environment.
+//
+// Valid resource: urn.Domain. Grants use a wildcard domain id because the domain
+// does not exist when the request is authorized.
+type CreateDomain struct{}
+
+func (CreateDomain) ActionFor(urn.Domain) {}
+func (CreateDomain) String() string       { return "create_domain" }
+
+// ReadDomain authorizes reading a custom domain.
+//
+// Valid resource: urn.Domain.
+type ReadDomain struct{}
+
+func (ReadDomain) ActionFor(urn.Domain) {}
+func (ReadDomain) String() string       { return "read_domain" }
+
+// DeleteDomain authorizes removing a custom domain.
+//
+// Valid resource: urn.Domain.
+type DeleteDomain struct{}
+
+func (DeleteDomain) ActionFor(urn.Domain) {}
+func (DeleteDomain) String() string       { return "delete_domain" }
+
+// VerifyDomain authorizes restarting verification for a custom domain.
+//
+// Valid resource: urn.Domain.
+type VerifyDomain struct{}
+
+func (VerifyDomain) ActionFor(urn.Domain) {}
+func (VerifyDomain) String() string       { return "verify_domain" }

--- a/pkg/rbac/permissions/environments.go
+++ b/pkg/rbac/permissions/environments.go
@@ -18,38 +18,6 @@ type UpdateEnvironment struct{}
 func (UpdateEnvironment) ActionFor(urn.Environment) {}
 func (UpdateEnvironment) String() string            { return "update_environment" }
 
-// CreateDomain authorizes creating domains in an environment.
-//
-// Valid resource: urn.Environment.
-type CreateDomain struct{}
-
-func (CreateDomain) ActionFor(urn.Environment) {}
-func (CreateDomain) String() string            { return "create_domain" }
-
-// ReadDomain authorizes reading an environment's domains.
-//
-// Valid resource: urn.Environment.
-type ReadDomain struct{}
-
-func (ReadDomain) ActionFor(urn.Environment) {}
-func (ReadDomain) String() string            { return "read_domain" }
-
-// DeleteDomain authorizes removing a domain from an environment.
-//
-// Valid resource: urn.Environment.
-type DeleteDomain struct{}
-
-func (DeleteDomain) ActionFor(urn.Environment) {}
-func (DeleteDomain) String() string            { return "delete_domain" }
-
-// VerifyDomain authorizes restarting verification for an environment's domains.
-//
-// Valid resource: urn.Environment.
-type VerifyDomain struct{}
-
-func (VerifyDomain) ActionFor(urn.Environment) {}
-func (VerifyDomain) String() string            { return "verify_domain" }
-
 // CreateVariable authorizes creating variables in an environment.
 //
 // Valid resource: urn.Environment.

--- a/pkg/rbac/permissions/environments.go
+++ b/pkg/rbac/permissions/environments.go
@@ -26,6 +26,30 @@ type CreateDomain struct{}
 func (CreateDomain) ActionFor(urn.Environment) {}
 func (CreateDomain) String() string            { return "create_domain" }
 
+// ReadDomain authorizes reading an environment's domains.
+//
+// Valid resource: urn.Environment.
+type ReadDomain struct{}
+
+func (ReadDomain) ActionFor(urn.Environment) {}
+func (ReadDomain) String() string            { return "read_domain" }
+
+// DeleteDomain authorizes removing a domain from an environment.
+//
+// Valid resource: urn.Environment.
+type DeleteDomain struct{}
+
+func (DeleteDomain) ActionFor(urn.Environment) {}
+func (DeleteDomain) String() string            { return "delete_domain" }
+
+// VerifyDomain authorizes restarting verification for an environment's domains.
+//
+// Valid resource: urn.Environment.
+type VerifyDomain struct{}
+
+func (VerifyDomain) ActionFor(urn.Environment) {}
+func (VerifyDomain) String() string            { return "verify_domain" }
+
 // CreateVariable authorizes creating variables in an environment.
 //
 // Valid resource: urn.Environment.

--- a/pkg/urn/resources_domain.go
+++ b/pkg/urn/resources_domain.go
@@ -1,0 +1,33 @@
+package urn
+
+// Domain builds custom domain resource paths.
+//
+// Hierarchy:
+//
+//	workspace
+//	└── projects/{project_id}
+//	    └── apps/{app_id}
+//	        └── environments/{environment_id}
+//	            └── domains/{domain_id}
+type Domain struct {
+	workspaceID string
+	path        string
+}
+
+// String returns this domain resource path.
+//
+// Subresource:
+//
+//	environments/{environment_id}
+//	└── domains/{domain_id}
+func (d Domain) String() string {
+	return V1{WorkspaceID: d.workspaceID, Resource: d.path}.String()
+}
+
+// Any returns a descendant pattern below this domain.
+func (d Domain) Any() V1 {
+	return V1{
+		WorkspaceID: d.workspaceID,
+		Resource:    d.path + "/**",
+	}
+}

--- a/pkg/urn/resources_environment.go
+++ b/pkg/urn/resources_environment.go
@@ -41,11 +41,8 @@ func (e Environment) Deployment(deploymentID string) Deployment {
 //
 //	environments/{environment_id}
 //	└── domains/{domain_id}
-func (e Environment) Domain(domainID string) V1 {
-	return V1{
-		WorkspaceID: e.workspaceID,
-		Resource:    fmt.Sprintf("%s/domains/%s", e.path, domainID),
-	}
+func (e Environment) Domain(domainID string) Domain {
+	return Domain{workspaceID: e.workspaceID, path: fmt.Sprintf("%s/domains/%s", e.path, domainID)}
 }
 
 // Variable returns a variable resource path.

--- a/svc/api/routes/v2_domains_create_domain/403_test.go
+++ b/svc/api/routes/v2_domains_create_domain/403_test.go
@@ -45,7 +45,7 @@ func TestCreateDomainPermissions(t *testing.T) {
 	}{
 		{name: "wildcard permission", permissions: []string{"environment.*.create_domain"}, shouldPass: true},
 		{name: "specific environment permission", permissions: []string{fmt.Sprintf("environment.%s.create_domain", env.environmentID)}, shouldPass: true},
-		{name: "canonical urn grant", permissions: []string{fmt.Sprintf("unkey:v1:%s:projects/%s/apps/%s/environments/%s#create_domain", env.workspaceID, env.projectID, env.appID, env.environmentID)}, shouldPass: true},
+		{name: "canonical urn grant", permissions: []string{fmt.Sprintf("unkey:v1:%s:projects/%s/apps/%s/environments/%s/domains/*#create_domain", env.workspaceID, env.projectID, env.appID, env.environmentID)}, shouldPass: true},
 		{name: "permission alongside unrelated grants", permissions: []string{"api.*.read_api", "environment.*.create_domain"}, shouldPass: true},
 		{name: "read action is not enough", permissions: []string{"environment.*.read_environment"}, shouldPass: false},
 		{name: "update action is not enough", permissions: []string{"environment.*.update_environment"}, shouldPass: false},

--- a/svc/api/routes/v2_domains_create_domain/403_test.go
+++ b/svc/api/routes/v2_domains_create_domain/403_test.go
@@ -45,6 +45,7 @@ func TestCreateDomainPermissions(t *testing.T) {
 	}{
 		{name: "wildcard permission", permissions: []string{"environment.*.create_domain"}, shouldPass: true},
 		{name: "specific environment permission", permissions: []string{fmt.Sprintf("environment.%s.create_domain", env.environmentID)}, shouldPass: true},
+		{name: "canonical urn grant", permissions: []string{fmt.Sprintf("unkey:v1:%s:projects/%s/apps/%s/environments/%s#create_domain", env.workspaceID, env.projectID, env.appID, env.environmentID)}, shouldPass: true},
 		{name: "permission alongside unrelated grants", permissions: []string{"api.*.read_api", "environment.*.create_domain"}, shouldPass: true},
 		{name: "read action is not enough", permissions: []string{"environment.*.read_environment"}, shouldPass: false},
 		{name: "update action is not enough", permissions: []string{"environment.*.update_environment"}, shouldPass: false},
@@ -52,7 +53,7 @@ func TestCreateDomainPermissions(t *testing.T) {
 		{name: "create_app is not enough", permissions: []string{"project.*.create_app"}, shouldPass: false},
 		{name: "action scoped to the wrong resource type", permissions: []string{"app.*.create_domain"}, shouldPass: false},
 		{name: "other environment id does not match", permissions: []string{fmt.Sprintf("environment.%s.create_domain", uid.New(uid.EnvironmentPrefix))}, shouldPass: false},
-		{name: "legacy urn is not accepted", permissions: []string{fmt.Sprintf("unkey:v1:%s:environments/*#create_domain", env.workspaceID)}, shouldPass: false},
+		{name: "urn missing the project and app segments", permissions: []string{fmt.Sprintf("unkey:v1:%s:environments/*#create_domain", env.workspaceID)}, shouldPass: false},
 		{name: "unrelated permission", permissions: []string{"api.*.read_api"}, shouldPass: false},
 		{name: "no permissions", permissions: []string{}, shouldPass: false},
 	}

--- a/svc/api/routes/v2_domains_create_domain/handler.go
+++ b/svc/api/routes/v2_domains_create_domain/handler.go
@@ -89,7 +89,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			Action:       rbac.CreateDomain,
 		}),
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project(env.ProjectID).App(env.AppID).Environment(env.ID),
+			urn.New().Workspace(principal.WorkspaceID).Project(env.ProjectID).App(env.AppID).Environment(env.ID).Domain("*"),
 			permissions.CreateDomain{},
 		),
 	)); err != nil {

--- a/svc/api/routes/v2_domains_create_domain/handler.go
+++ b/svc/api/routes/v2_domains_create_domain/handler.go
@@ -14,6 +14,8 @@ import (
 	"github.com/unkeyed/unkey/pkg/domain/domaingate"
 	"github.com/unkeyed/unkey/pkg/fault"
 	"github.com/unkeyed/unkey/pkg/rbac"
+	"github.com/unkeyed/unkey/pkg/rbac/permissions"
+	"github.com/unkeyed/unkey/pkg/urn"
 	"github.com/unkeyed/unkey/pkg/zen"
 	"github.com/unkeyed/unkey/svc/api/internal/ctrlclient"
 	"github.com/unkeyed/unkey/svc/api/internal/customdomain"
@@ -86,6 +88,10 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			ResourceID:   env.ID,
 			Action:       rbac.CreateDomain,
 		}),
+		rbac.U(
+			urn.New().Workspace(principal.WorkspaceID).Project(env.ProjectID).App(env.AppID).Environment(env.ID),
+			permissions.CreateDomain{},
+		),
 	)); err != nil {
 		return apierrors.MaskInsufficientPermissionsAsNotFound(
 			err,

--- a/svc/api/routes/v2_domains_delete_domain/403_test.go
+++ b/svc/api/routes/v2_domains_delete_domain/403_test.go
@@ -28,6 +28,7 @@ func TestDeleteDomainPermissions(t *testing.T) {
 	}{
 		{name: "wildcard permission", permissions: []string{"environment.*.delete_domain"}, shouldPass: true},
 		{name: "specific environment permission", permissions: []string{"environment.<env>.delete_domain"}, shouldPass: true},
+		{name: "canonical urn grant", permissions: []string{"<urn>.delete_domain"}, shouldPass: true},
 		{name: "permission alongside unrelated grants", permissions: []string{"api.*.read_api", "environment.*.delete_domain"}, shouldPass: true},
 		{name: "create action is not enough", permissions: []string{"environment.*.create_domain"}, shouldPass: false},
 		{name: "read action is not enough", permissions: []string{"environment.*.read_domain"}, shouldPass: false},
@@ -44,8 +45,11 @@ func TestDeleteDomainPermissions(t *testing.T) {
 			seeded := seedDomain(t, h, nil)
 			permissions := make([]string, len(tc.permissions))
 			for i, p := range tc.permissions {
-				if p == "environment.<env>.delete_domain" {
+				switch p {
+				case "environment.<env>.delete_domain":
 					p = fmt.Sprintf("environment.%s.delete_domain", seeded.environmentID)
+				case "<urn>.delete_domain":
+					p = fmt.Sprintf("unkey:v1:%s:projects/%s/apps/%s/environments/%s#delete_domain", seeded.workspaceID, seeded.projectID, seeded.appID, seeded.environmentID)
 				}
 				permissions[i] = p
 			}

--- a/svc/api/routes/v2_domains_delete_domain/403_test.go
+++ b/svc/api/routes/v2_domains_delete_domain/403_test.go
@@ -49,7 +49,7 @@ func TestDeleteDomainPermissions(t *testing.T) {
 				case "environment.<env>.delete_domain":
 					p = fmt.Sprintf("environment.%s.delete_domain", seeded.environmentID)
 				case "<urn>.delete_domain":
-					p = fmt.Sprintf("unkey:v1:%s:projects/%s/apps/%s/environments/%s#delete_domain", seeded.workspaceID, seeded.projectID, seeded.appID, seeded.environmentID)
+					p = fmt.Sprintf("unkey:v1:%s:projects/%s/apps/%s/environments/%s/domains/*#delete_domain", seeded.workspaceID, seeded.projectID, seeded.appID, seeded.environmentID)
 				}
 				permissions[i] = p
 			}

--- a/svc/api/routes/v2_domains_delete_domain/handler.go
+++ b/svc/api/routes/v2_domains_delete_domain/handler.go
@@ -85,7 +85,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			Action:       rbac.DeleteDomain,
 		}),
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project(row.ProjectID).App(row.AppID).Environment(row.EnvironmentID),
+			urn.New().Workspace(principal.WorkspaceID).Project(row.ProjectID).App(row.AppID).Environment(row.EnvironmentID).Domain(row.ID),
 			permissions.DeleteDomain{},
 		),
 	)); err != nil {

--- a/svc/api/routes/v2_domains_delete_domain/handler.go
+++ b/svc/api/routes/v2_domains_delete_domain/handler.go
@@ -12,6 +12,8 @@ import (
 	"github.com/unkeyed/unkey/pkg/domain/domaingate"
 	"github.com/unkeyed/unkey/pkg/fault"
 	"github.com/unkeyed/unkey/pkg/rbac"
+	"github.com/unkeyed/unkey/pkg/rbac/permissions"
+	"github.com/unkeyed/unkey/pkg/urn"
 	"github.com/unkeyed/unkey/pkg/zen"
 	"github.com/unkeyed/unkey/svc/api/internal/ctrlclient"
 	"github.com/unkeyed/unkey/svc/api/internal/customdomain"
@@ -82,6 +84,10 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			ResourceID:   row.EnvironmentID,
 			Action:       rbac.DeleteDomain,
 		}),
+		rbac.U(
+			urn.New().Workspace(principal.WorkspaceID).Project(row.ProjectID).App(row.AppID).Environment(row.EnvironmentID),
+			permissions.DeleteDomain{},
+		),
 	)); err != nil {
 		return apierrors.MaskInsufficientPermissionsAsNotFound(
 			err,

--- a/svc/api/routes/v2_domains_get_domain/403_test.go
+++ b/svc/api/routes/v2_domains_get_domain/403_test.go
@@ -29,6 +29,7 @@ func TestGetDomainPermissions(t *testing.T) {
 	}{
 		{name: "wildcard permission", permissions: []string{"environment.*.read_domain"}, shouldPass: true},
 		{name: "specific environment permission", permissions: []string{fmt.Sprintf("environment.%s.read_domain", seeded.environmentID)}, shouldPass: true},
+		{name: "canonical urn grant", permissions: []string{fmt.Sprintf("unkey:v1:%s:projects/%s/apps/%s/environments/%s#read_domain", seeded.workspaceID, seeded.projectID, seeded.appID, seeded.environmentID)}, shouldPass: true},
 		{name: "permission alongside unrelated grants", permissions: []string{"api.*.read_api", "environment.*.read_domain"}, shouldPass: true},
 		{name: "create action is not enough", permissions: []string{"environment.*.create_domain"}, shouldPass: false},
 		{name: "read_environment is not enough", permissions: []string{"environment.*.read_environment"}, shouldPass: false},
@@ -37,7 +38,7 @@ func TestGetDomainPermissions(t *testing.T) {
 		{name: "action scoped to the wrong resource type", permissions: []string{"app.*.read_domain"}, shouldPass: false},
 		{name: "parent-scoped grant does not cascade", permissions: []string{fmt.Sprintf("app.%s.read_app", seeded.appID)}, shouldPass: false},
 		{name: "other environment id does not match", permissions: []string{fmt.Sprintf("environment.%s.read_domain", uid.New(uid.EnvironmentPrefix))}, shouldPass: false},
-		{name: "legacy urn is not accepted", permissions: []string{fmt.Sprintf("unkey:v1:%s:environments/*#read_domain", seeded.workspaceID)}, shouldPass: false},
+		{name: "urn missing the project and app segments", permissions: []string{fmt.Sprintf("unkey:v1:%s:environments/*#read_domain", seeded.workspaceID)}, shouldPass: false},
 		{name: "unrelated permission", permissions: []string{"api.*.read_api"}, shouldPass: false},
 		{name: "no permissions", permissions: []string{}, shouldPass: false},
 	}

--- a/svc/api/routes/v2_domains_get_domain/403_test.go
+++ b/svc/api/routes/v2_domains_get_domain/403_test.go
@@ -29,7 +29,7 @@ func TestGetDomainPermissions(t *testing.T) {
 	}{
 		{name: "wildcard permission", permissions: []string{"environment.*.read_domain"}, shouldPass: true},
 		{name: "specific environment permission", permissions: []string{fmt.Sprintf("environment.%s.read_domain", seeded.environmentID)}, shouldPass: true},
-		{name: "canonical urn grant", permissions: []string{fmt.Sprintf("unkey:v1:%s:projects/%s/apps/%s/environments/%s#read_domain", seeded.workspaceID, seeded.projectID, seeded.appID, seeded.environmentID)}, shouldPass: true},
+		{name: "canonical urn grant", permissions: []string{fmt.Sprintf("unkey:v1:%s:projects/%s/apps/%s/environments/%s/domains/*#read_domain", seeded.workspaceID, seeded.projectID, seeded.appID, seeded.environmentID)}, shouldPass: true},
 		{name: "permission alongside unrelated grants", permissions: []string{"api.*.read_api", "environment.*.read_domain"}, shouldPass: true},
 		{name: "create action is not enough", permissions: []string{"environment.*.create_domain"}, shouldPass: false},
 		{name: "read_environment is not enough", permissions: []string{"environment.*.read_environment"}, shouldPass: false},

--- a/svc/api/routes/v2_domains_get_domain/handler.go
+++ b/svc/api/routes/v2_domains_get_domain/handler.go
@@ -81,7 +81,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			Action:       rbac.ReadDomain,
 		}),
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project(row.ProjectID).App(row.AppID).Environment(row.EnvironmentID),
+			urn.New().Workspace(principal.WorkspaceID).Project(row.ProjectID).App(row.AppID).Environment(row.EnvironmentID).Domain(row.ID),
 			permissions.ReadDomain{},
 		),
 	)); err != nil {

--- a/svc/api/routes/v2_domains_get_domain/handler.go
+++ b/svc/api/routes/v2_domains_get_domain/handler.go
@@ -10,6 +10,8 @@ import (
 	"github.com/unkeyed/unkey/pkg/fault"
 	"github.com/unkeyed/unkey/pkg/ptr"
 	"github.com/unkeyed/unkey/pkg/rbac"
+	"github.com/unkeyed/unkey/pkg/rbac/permissions"
+	"github.com/unkeyed/unkey/pkg/urn"
 	"github.com/unkeyed/unkey/pkg/zen"
 	"github.com/unkeyed/unkey/svc/api/internal/domain"
 	apierrors "github.com/unkeyed/unkey/svc/api/internal/errors"
@@ -78,6 +80,10 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			ResourceID:   row.EnvironmentID,
 			Action:       rbac.ReadDomain,
 		}),
+		rbac.U(
+			urn.New().Workspace(principal.WorkspaceID).Project(row.ProjectID).App(row.AppID).Environment(row.EnvironmentID),
+			permissions.ReadDomain{},
+		),
 	)); err != nil {
 		return apierrors.MaskInsufficientPermissionsAsNotFound(
 			err,

--- a/svc/api/routes/v2_domains_list_domains/403_test.go
+++ b/svc/api/routes/v2_domains_list_domains/403_test.go
@@ -30,6 +30,7 @@ func TestListDomainsPermissions(t *testing.T) {
 	}{
 		{name: "wildcard permission", permissions: []string{"environment.*.read_domain"}, shouldPass: true},
 		{name: "specific environment permission", permissions: []string{fmt.Sprintf("environment.%s.read_domain", env.environmentID)}, shouldPass: true},
+		{name: "canonical urn grant", permissions: []string{fmt.Sprintf("unkey:v1:%s:projects/%s/apps/%s/environments/%s#read_domain", env.workspaceID, env.projectID, env.appID, env.environmentID)}, shouldPass: true},
 		{name: "permission alongside unrelated grants", permissions: []string{"api.*.read_api", "environment.*.read_domain"}, shouldPass: true},
 		{name: "create action is not enough", permissions: []string{"environment.*.create_domain"}, shouldPass: false},
 		{name: "read_environment is not enough", permissions: []string{"environment.*.read_environment"}, shouldPass: false},
@@ -38,7 +39,7 @@ func TestListDomainsPermissions(t *testing.T) {
 		{name: "action scoped to the wrong resource type", permissions: []string{"app.*.read_domain"}, shouldPass: false},
 		{name: "parent-scoped grant does not cascade", permissions: []string{fmt.Sprintf("app.%s.read_app", env.appID)}, shouldPass: false},
 		{name: "other environment id does not match", permissions: []string{fmt.Sprintf("environment.%s.read_domain", uid.New(uid.EnvironmentPrefix))}, shouldPass: false},
-		{name: "legacy urn is not accepted", permissions: []string{fmt.Sprintf("unkey:v1:%s:environments/*#read_domain", env.workspaceID)}, shouldPass: false},
+		{name: "urn missing the project and app segments", permissions: []string{fmt.Sprintf("unkey:v1:%s:environments/*#read_domain", env.workspaceID)}, shouldPass: false},
 		{name: "unrelated permission", permissions: []string{"api.*.read_api"}, shouldPass: false},
 		{name: "no permissions", permissions: []string{}, shouldPass: false},
 	}

--- a/svc/api/routes/v2_domains_list_domains/403_test.go
+++ b/svc/api/routes/v2_domains_list_domains/403_test.go
@@ -30,7 +30,7 @@ func TestListDomainsPermissions(t *testing.T) {
 	}{
 		{name: "wildcard permission", permissions: []string{"environment.*.read_domain"}, shouldPass: true},
 		{name: "specific environment permission", permissions: []string{fmt.Sprintf("environment.%s.read_domain", env.environmentID)}, shouldPass: true},
-		{name: "canonical urn grant", permissions: []string{fmt.Sprintf("unkey:v1:%s:projects/%s/apps/%s/environments/%s#read_domain", env.workspaceID, env.projectID, env.appID, env.environmentID)}, shouldPass: true},
+		{name: "canonical urn grant", permissions: []string{fmt.Sprintf("unkey:v1:%s:projects/%s/apps/%s/environments/%s/domains/*#read_domain", env.workspaceID, env.projectID, env.appID, env.environmentID)}, shouldPass: true},
 		{name: "permission alongside unrelated grants", permissions: []string{"api.*.read_api", "environment.*.read_domain"}, shouldPass: true},
 		{name: "create action is not enough", permissions: []string{"environment.*.create_domain"}, shouldPass: false},
 		{name: "read_environment is not enough", permissions: []string{"environment.*.read_environment"}, shouldPass: false},

--- a/svc/api/routes/v2_domains_list_domains/handler.go
+++ b/svc/api/routes/v2_domains_list_domains/handler.go
@@ -84,7 +84,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			Action:       rbac.ReadDomain,
 		}),
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project(env.ProjectID).App(env.AppID).Environment(env.ID),
+			urn.New().Workspace(principal.WorkspaceID).Project(env.ProjectID).App(env.AppID).Environment(env.ID).Domain("*"),
 			permissions.ReadDomain{},
 		),
 	)); err != nil {

--- a/svc/api/routes/v2_domains_list_domains/handler.go
+++ b/svc/api/routes/v2_domains_list_domains/handler.go
@@ -12,6 +12,8 @@ import (
 	"github.com/unkeyed/unkey/pkg/mysql"
 	"github.com/unkeyed/unkey/pkg/ptr"
 	"github.com/unkeyed/unkey/pkg/rbac"
+	"github.com/unkeyed/unkey/pkg/rbac/permissions"
+	"github.com/unkeyed/unkey/pkg/urn"
 	"github.com/unkeyed/unkey/pkg/zen"
 	"github.com/unkeyed/unkey/svc/api/internal/domain"
 	apierrors "github.com/unkeyed/unkey/svc/api/internal/errors"
@@ -81,6 +83,10 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			ResourceID:   env.ID,
 			Action:       rbac.ReadDomain,
 		}),
+		rbac.U(
+			urn.New().Workspace(principal.WorkspaceID).Project(env.ProjectID).App(env.AppID).Environment(env.ID),
+			permissions.ReadDomain{},
+		),
 	)); err != nil {
 		return apierrors.MaskInsufficientPermissionsAsNotFound(
 			err,

--- a/svc/api/routes/v2_domains_verify_domain/403_test.go
+++ b/svc/api/routes/v2_domains_verify_domain/403_test.go
@@ -28,6 +28,7 @@ func TestVerifyDomainPermissions(t *testing.T) {
 	}{
 		{name: "wildcard permission", permissions: []string{"environment.*.verify_domain"}, shouldPass: true},
 		{name: "specific environment permission", permissions: []string{"environment.<env>.verify_domain"}, shouldPass: true},
+		{name: "canonical urn grant", permissions: []string{"<urn>.verify_domain"}, shouldPass: true},
 		{name: "permission alongside unrelated grants", permissions: []string{"api.*.read_api", "environment.*.verify_domain"}, shouldPass: true},
 		{name: "create action is not enough", permissions: []string{"environment.*.create_domain"}, shouldPass: false},
 		{name: "read action is not enough", permissions: []string{"environment.*.read_domain"}, shouldPass: false},
@@ -44,8 +45,11 @@ func TestVerifyDomainPermissions(t *testing.T) {
 			seeded := seedDomain(t, h, nil)
 			permissions := make([]string, len(tc.permissions))
 			for i, p := range tc.permissions {
-				if p == "environment.<env>.verify_domain" {
+				switch p {
+				case "environment.<env>.verify_domain":
 					p = fmt.Sprintf("environment.%s.verify_domain", seeded.environmentID)
+				case "<urn>.verify_domain":
+					p = fmt.Sprintf("unkey:v1:%s:projects/%s/apps/%s/environments/%s#verify_domain", seeded.workspaceID, seeded.projectID, seeded.appID, seeded.environmentID)
 				}
 				permissions[i] = p
 			}

--- a/svc/api/routes/v2_domains_verify_domain/403_test.go
+++ b/svc/api/routes/v2_domains_verify_domain/403_test.go
@@ -49,7 +49,7 @@ func TestVerifyDomainPermissions(t *testing.T) {
 				case "environment.<env>.verify_domain":
 					p = fmt.Sprintf("environment.%s.verify_domain", seeded.environmentID)
 				case "<urn>.verify_domain":
-					p = fmt.Sprintf("unkey:v1:%s:projects/%s/apps/%s/environments/%s#verify_domain", seeded.workspaceID, seeded.projectID, seeded.appID, seeded.environmentID)
+					p = fmt.Sprintf("unkey:v1:%s:projects/%s/apps/%s/environments/%s/domains/*#verify_domain", seeded.workspaceID, seeded.projectID, seeded.appID, seeded.environmentID)
 				}
 				permissions[i] = p
 			}

--- a/svc/api/routes/v2_domains_verify_domain/handler.go
+++ b/svc/api/routes/v2_domains_verify_domain/handler.go
@@ -86,7 +86,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			Action:       rbac.VerifyDomain,
 		}),
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project(domain.ProjectID).App(domain.AppID).Environment(domain.EnvironmentID),
+			urn.New().Workspace(principal.WorkspaceID).Project(domain.ProjectID).App(domain.AppID).Environment(domain.EnvironmentID).Domain(domain.ID),
 			permissions.VerifyDomain{},
 		),
 	)); err != nil {

--- a/svc/api/routes/v2_domains_verify_domain/handler.go
+++ b/svc/api/routes/v2_domains_verify_domain/handler.go
@@ -13,6 +13,8 @@ import (
 	"github.com/unkeyed/unkey/pkg/domain/domaingate"
 	"github.com/unkeyed/unkey/pkg/fault"
 	"github.com/unkeyed/unkey/pkg/rbac"
+	"github.com/unkeyed/unkey/pkg/rbac/permissions"
+	"github.com/unkeyed/unkey/pkg/urn"
 	"github.com/unkeyed/unkey/pkg/zen"
 	"github.com/unkeyed/unkey/svc/api/internal/ctrlclient"
 	"github.com/unkeyed/unkey/svc/api/internal/customdomain"
@@ -83,6 +85,10 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			ResourceID:   domain.EnvironmentID,
 			Action:       rbac.VerifyDomain,
 		}),
+		rbac.U(
+			urn.New().Workspace(principal.WorkspaceID).Project(domain.ProjectID).App(domain.AppID).Environment(domain.EnvironmentID),
+			permissions.VerifyDomain{},
+		),
 	)); err != nil {
 		return apierrors.MaskInsufficientPermissionsAsNotFound(
 			err,


### PR DESCRIPTION
This PR adds required permissions for dashboard to call our API using the SDK instead. Following PRs will kill ugly tRPC routes and replace rest of the logic with our SDK.


### Heads up

- I not so sure about if I should wrap them with `domains` subresource instead of putting them in `environments` permissions. So if anyone wants to do it differently we can discuss that option. Basically,

`unkey:v1:ws_123:projects/*/apps/*/environments/*#create_domain` vs `unkey:v1:ws_123:projects/*/apps/*/environments/*/domains#create_domain` 

