### PR TITLE
refactor(api): add connect fields to read domain endpoints

### DIFF
--- a/pkg/db/bulk_custom_domain_insert.sql_generated.go
+++ b/pkg/db/bulk_custom_domain_insert.sql_generated.go
@@ -9,7 +9,7 @@ import (
 )
 
 // bulkInsertCustomDomain is the base query for bulk insert
-const bulkInsertCustomDomain = `INSERT INTO custom_domains ( id, workspace_id, project_id, app_id, environment_id, domain, challenge_type, verification_status, verification_token, ownership_verified, cname_verified, target_cname, verification_error, last_checked_at, created_at ) VALUES %s`
+const bulkInsertCustomDomain = `INSERT INTO custom_domains ( id, workspace_id, project_id, app_id, environment_id, domain, challenge_type, verification_status, verification_token, ownership_verified, cname_verified, target_cname, verification_error, domain_connect_provider, domain_connect_url, last_checked_at, created_at ) VALUES %s`
 
 // InsertCustomDomains performs bulk insert in a single query
 func (q *BulkQueries) InsertCustomDomains(ctx context.Context, db DBTX, args []InsertCustomDomainParams) error {
@@ -21,7 +21,7 @@ func (q *BulkQueries) InsertCustomDomains(ctx context.Context, db DBTX, args []I
 	// Build the bulk insert query
 	valueClauses := make([]string, len(args))
 	for i := range args {
-		valueClauses[i] = "( ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? )"
+		valueClauses[i] = "( ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? )"
 	}
 
 	bulkQuery := fmt.Sprintf(bulkInsertCustomDomain, strings.Join(valueClauses, ", "))
@@ -42,6 +42,8 @@ func (q *BulkQueries) InsertCustomDomains(ctx context.Context, db DBTX, args []I
 		allArgs = append(allArgs, arg.CnameVerified)
 		allArgs = append(allArgs, arg.TargetCname)
 		allArgs = append(allArgs, arg.VerificationError)
+		allArgs = append(allArgs, arg.DomainConnectProvider)
+		allArgs = append(allArgs, arg.DomainConnectUrl)
 		allArgs = append(allArgs, arg.LastCheckedAt)
 		allArgs = append(allArgs, arg.CreatedAt)
 	}

--- a/pkg/db/custom_domain_find_by_identifier.sql_generated.go
+++ b/pkg/db/custom_domain_find_by_identifier.sql_generated.go
@@ -23,6 +23,8 @@ const findCustomDomainByIdentifier = `-- name: FindCustomDomainByIdentifier :one
     cd_by_id.cname_verified,
     cd_by_id.target_cname,
     cd_by_id.verification_error,
+    cd_by_id.domain_connect_provider,
+    cd_by_id.domain_connect_url,
     cd_by_id.last_checked_at,
     cd_by_id.created_at,
     cd_by_id.updated_at
@@ -42,6 +44,8 @@ UNION ALL
     cd_by_name.cname_verified,
     cd_by_name.target_cname,
     cd_by_name.verification_error,
+    cd_by_name.domain_connect_provider,
+    cd_by_name.domain_connect_url,
     cd_by_name.last_checked_at,
     cd_by_name.created_at,
     cd_by_name.updated_at
@@ -57,20 +61,22 @@ type FindCustomDomainByIdentifierParams struct {
 }
 
 type FindCustomDomainByIdentifierRow struct {
-	ID                 string                          `db:"id"`
-	ProjectID          string                          `db:"project_id"`
-	AppID              string                          `db:"app_id"`
-	EnvironmentID      string                          `db:"environment_id"`
-	Domain             string                          `db:"domain"`
-	VerificationStatus CustomDomainsVerificationStatus `db:"verification_status"`
-	VerificationToken  string                          `db:"verification_token"`
-	OwnershipVerified  bool                            `db:"ownership_verified"`
-	CnameVerified      bool                            `db:"cname_verified"`
-	TargetCname        string                          `db:"target_cname"`
-	VerificationError  sql.NullString                  `db:"verification_error"`
-	LastCheckedAt      sql.NullInt64                   `db:"last_checked_at"`
-	CreatedAt          int64                           `db:"created_at"`
-	UpdatedAt          sql.NullInt64                   `db:"updated_at"`
+	ID                    string                          `db:"id"`
+	ProjectID             string                          `db:"project_id"`
+	AppID                 string                          `db:"app_id"`
+	EnvironmentID         string                          `db:"environment_id"`
+	Domain                string                          `db:"domain"`
+	VerificationStatus    CustomDomainsVerificationStatus `db:"verification_status"`
+	VerificationToken     string                          `db:"verification_token"`
+	OwnershipVerified     bool                            `db:"ownership_verified"`
+	CnameVerified         bool                            `db:"cname_verified"`
+	TargetCname           string                          `db:"target_cname"`
+	VerificationError     sql.NullString                  `db:"verification_error"`
+	DomainConnectProvider sql.NullString                  `db:"domain_connect_provider"`
+	DomainConnectUrl      sql.NullString                  `db:"domain_connect_url"`
+	LastCheckedAt         sql.NullInt64                   `db:"last_checked_at"`
+	CreatedAt             int64                           `db:"created_at"`
+	UpdatedAt             sql.NullInt64                   `db:"updated_at"`
 }
 
 // Identifier is either a domain id or a domain name. Each UNION branch hits its own
@@ -91,6 +97,8 @@ type FindCustomDomainByIdentifierRow struct {
 //	    cd_by_id.cname_verified,
 //	    cd_by_id.target_cname,
 //	    cd_by_id.verification_error,
+//	    cd_by_id.domain_connect_provider,
+//	    cd_by_id.domain_connect_url,
 //	    cd_by_id.last_checked_at,
 //	    cd_by_id.created_at,
 //	    cd_by_id.updated_at
@@ -110,6 +118,8 @@ type FindCustomDomainByIdentifierRow struct {
 //	    cd_by_name.cname_verified,
 //	    cd_by_name.target_cname,
 //	    cd_by_name.verification_error,
+//	    cd_by_name.domain_connect_provider,
+//	    cd_by_name.domain_connect_url,
 //	    cd_by_name.last_checked_at,
 //	    cd_by_name.created_at,
 //	    cd_by_name.updated_at
@@ -137,6 +147,8 @@ func (q *Queries) FindCustomDomainByIdentifier(ctx context.Context, db DBTX, arg
 		&i.CnameVerified,
 		&i.TargetCname,
 		&i.VerificationError,
+		&i.DomainConnectProvider,
+		&i.DomainConnectUrl,
 		&i.LastCheckedAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,

--- a/pkg/db/custom_domain_insert.sql_generated.go
+++ b/pkg/db/custom_domain_insert.sql_generated.go
@@ -25,9 +25,13 @@ INSERT INTO custom_domains (
     cname_verified,
     target_cname,
     verification_error,
+    domain_connect_provider,
+    domain_connect_url,
     last_checked_at,
     created_at
 ) VALUES (
+    ?,
+    ?,
     ?,
     ?,
     ?,
@@ -47,21 +51,23 @@ INSERT INTO custom_domains (
 `
 
 type InsertCustomDomainParams struct {
-	ID                 string                          `db:"id"`
-	WorkspaceID        string                          `db:"workspace_id"`
-	ProjectID          string                          `db:"project_id"`
-	AppID              string                          `db:"app_id"`
-	EnvironmentID      string                          `db:"environment_id"`
-	Domain             string                          `db:"domain"`
-	ChallengeType      CustomDomainsChallengeType      `db:"challenge_type"`
-	VerificationStatus CustomDomainsVerificationStatus `db:"verification_status"`
-	VerificationToken  string                          `db:"verification_token"`
-	OwnershipVerified  bool                            `db:"ownership_verified"`
-	CnameVerified      bool                            `db:"cname_verified"`
-	TargetCname        string                          `db:"target_cname"`
-	VerificationError  sql.NullString                  `db:"verification_error"`
-	LastCheckedAt      sql.NullInt64                   `db:"last_checked_at"`
-	CreatedAt          int64                           `db:"created_at"`
+	ID                    string                          `db:"id"`
+	WorkspaceID           string                          `db:"workspace_id"`
+	ProjectID             string                          `db:"project_id"`
+	AppID                 string                          `db:"app_id"`
+	EnvironmentID         string                          `db:"environment_id"`
+	Domain                string                          `db:"domain"`
+	ChallengeType         CustomDomainsChallengeType      `db:"challenge_type"`
+	VerificationStatus    CustomDomainsVerificationStatus `db:"verification_status"`
+	VerificationToken     string                          `db:"verification_token"`
+	OwnershipVerified     bool                            `db:"ownership_verified"`
+	CnameVerified         bool                            `db:"cname_verified"`
+	TargetCname           string                          `db:"target_cname"`
+	VerificationError     sql.NullString                  `db:"verification_error"`
+	DomainConnectProvider sql.NullString                  `db:"domain_connect_provider"`
+	DomainConnectUrl      sql.NullString                  `db:"domain_connect_url"`
+	LastCheckedAt         sql.NullInt64                   `db:"last_checked_at"`
+	CreatedAt             int64                           `db:"created_at"`
 }
 
 // InsertCustomDomain
@@ -80,9 +86,13 @@ type InsertCustomDomainParams struct {
 //	    cname_verified,
 //	    target_cname,
 //	    verification_error,
+//	    domain_connect_provider,
+//	    domain_connect_url,
 //	    last_checked_at,
 //	    created_at
 //	) VALUES (
+//	    ?,
+//	    ?,
 //	    ?,
 //	    ?,
 //	    ?,
@@ -114,6 +124,8 @@ func (q *Queries) InsertCustomDomain(ctx context.Context, db DBTX, arg InsertCus
 		arg.CnameVerified,
 		arg.TargetCname,
 		arg.VerificationError,
+		arg.DomainConnectProvider,
+		arg.DomainConnectUrl,
 		arg.LastCheckedAt,
 		arg.CreatedAt,
 	)

--- a/pkg/db/custom_domain_list_by_environment.sql_generated.go
+++ b/pkg/db/custom_domain_list_by_environment.sql_generated.go
@@ -23,6 +23,8 @@ SELECT
     cname_verified,
     target_cname,
     verification_error,
+    domain_connect_provider,
+    domain_connect_url,
     last_checked_at,
     created_at,
     updated_at
@@ -47,20 +49,22 @@ type ListCustomDomainsByEnvironmentParams struct {
 }
 
 type ListCustomDomainsByEnvironmentRow struct {
-	ID                 string                          `db:"id"`
-	ProjectID          string                          `db:"project_id"`
-	AppID              string                          `db:"app_id"`
-	EnvironmentID      string                          `db:"environment_id"`
-	Domain             string                          `db:"domain"`
-	VerificationStatus CustomDomainsVerificationStatus `db:"verification_status"`
-	VerificationToken  string                          `db:"verification_token"`
-	OwnershipVerified  bool                            `db:"ownership_verified"`
-	CnameVerified      bool                            `db:"cname_verified"`
-	TargetCname        string                          `db:"target_cname"`
-	VerificationError  sql.NullString                  `db:"verification_error"`
-	LastCheckedAt      sql.NullInt64                   `db:"last_checked_at"`
-	CreatedAt          int64                           `db:"created_at"`
-	UpdatedAt          sql.NullInt64                   `db:"updated_at"`
+	ID                    string                          `db:"id"`
+	ProjectID             string                          `db:"project_id"`
+	AppID                 string                          `db:"app_id"`
+	EnvironmentID         string                          `db:"environment_id"`
+	Domain                string                          `db:"domain"`
+	VerificationStatus    CustomDomainsVerificationStatus `db:"verification_status"`
+	VerificationToken     string                          `db:"verification_token"`
+	OwnershipVerified     bool                            `db:"ownership_verified"`
+	CnameVerified         bool                            `db:"cname_verified"`
+	TargetCname           string                          `db:"target_cname"`
+	VerificationError     sql.NullString                  `db:"verification_error"`
+	DomainConnectProvider sql.NullString                  `db:"domain_connect_provider"`
+	DomainConnectUrl      sql.NullString                  `db:"domain_connect_url"`
+	LastCheckedAt         sql.NullInt64                   `db:"last_checked_at"`
+	CreatedAt             int64                           `db:"created_at"`
+	UpdatedAt             sql.NullInt64                   `db:"updated_at"`
 }
 
 // ListCustomDomainsByEnvironment
@@ -77,6 +81,8 @@ type ListCustomDomainsByEnvironmentRow struct {
 //	    cname_verified,
 //	    target_cname,
 //	    verification_error,
+//	    domain_connect_provider,
+//	    domain_connect_url,
 //	    last_checked_at,
 //	    created_at,
 //	    updated_at
@@ -119,6 +125,8 @@ func (q *Queries) ListCustomDomainsByEnvironment(ctx context.Context, db DBTX, a
 			&i.CnameVerified,
 			&i.TargetCname,
 			&i.VerificationError,
+			&i.DomainConnectProvider,
+			&i.DomainConnectUrl,
 			&i.LastCheckedAt,
 			&i.CreatedAt,
 			&i.UpdatedAt,

--- a/pkg/db/querier_generated.go
+++ b/pkg/db/querier_generated.go
@@ -299,6 +299,8 @@ type Querier interface {
 	//      cd_by_id.cname_verified,
 	//      cd_by_id.target_cname,
 	//      cd_by_id.verification_error,
+	//      cd_by_id.domain_connect_provider,
+	//      cd_by_id.domain_connect_url,
 	//      cd_by_id.last_checked_at,
 	//      cd_by_id.created_at,
 	//      cd_by_id.updated_at
@@ -318,6 +320,8 @@ type Querier interface {
 	//      cd_by_name.cname_verified,
 	//      cd_by_name.target_cname,
 	//      cd_by_name.verification_error,
+	//      cd_by_name.domain_connect_provider,
+	//      cd_by_name.domain_connect_url,
 	//      cd_by_name.last_checked_at,
 	//      cd_by_name.created_at,
 	//      cd_by_name.updated_at
@@ -1165,9 +1169,13 @@ type Querier interface {
 	//      cname_verified,
 	//      target_cname,
 	//      verification_error,
+	//      domain_connect_provider,
+	//      domain_connect_url,
 	//      last_checked_at,
 	//      created_at
 	//  ) VALUES (
+	//      ?,
+	//      ?,
 	//      ?,
 	//      ?,
 	//      ?,
@@ -1849,6 +1857,8 @@ type Querier interface {
 	//      cname_verified,
 	//      target_cname,
 	//      verification_error,
+	//      domain_connect_provider,
+	//      domain_connect_url,
 	//      last_checked_at,
 	//      created_at,
 	//      updated_at

--- a/pkg/db/queries/custom_domain_find_by_identifier.sql
+++ b/pkg/db/queries/custom_domain_find_by_identifier.sql
@@ -16,6 +16,8 @@
     cd_by_id.cname_verified,
     cd_by_id.target_cname,
     cd_by_id.verification_error,
+    cd_by_id.domain_connect_provider,
+    cd_by_id.domain_connect_url,
     cd_by_id.last_checked_at,
     cd_by_id.created_at,
     cd_by_id.updated_at
@@ -35,6 +37,8 @@ UNION ALL
     cd_by_name.cname_verified,
     cd_by_name.target_cname,
     cd_by_name.verification_error,
+    cd_by_name.domain_connect_provider,
+    cd_by_name.domain_connect_url,
     cd_by_name.last_checked_at,
     cd_by_name.created_at,
     cd_by_name.updated_at

--- a/pkg/db/queries/custom_domain_insert.sql
+++ b/pkg/db/queries/custom_domain_insert.sql
@@ -13,6 +13,8 @@ INSERT INTO custom_domains (
     cname_verified,
     target_cname,
     verification_error,
+    domain_connect_provider,
+    domain_connect_url,
     last_checked_at,
     created_at
 ) VALUES (
@@ -29,6 +31,8 @@ INSERT INTO custom_domains (
     sqlc.arg(cname_verified),
     sqlc.arg(target_cname),
     sqlc.arg(verification_error),
+    sqlc.arg(domain_connect_provider),
+    sqlc.arg(domain_connect_url),
     sqlc.arg(last_checked_at),
     sqlc.arg(created_at)
 );

--- a/pkg/db/queries/custom_domain_list_by_environment.sql
+++ b/pkg/db/queries/custom_domain_list_by_environment.sql
@@ -11,6 +11,8 @@ SELECT
     cname_verified,
     target_cname,
     verification_error,
+    domain_connect_provider,
+    domain_connect_url,
     last_checked_at,
     created_at,
     updated_at

--- a/svc/api/internal/testutil/seed/seed.go
+++ b/svc/api/internal/testutil/seed/seed.go
@@ -332,19 +332,21 @@ func (s *Seeder) CreateEnvironment(ctx context.Context, req CreateEnvironmentReq
 }
 
 type CreateCustomDomainRequest struct {
-	ID                 string
-	WorkspaceID        string
-	ProjectID          string
-	AppID              string
-	EnvironmentID      string
-	Domain             string
-	VerificationStatus db.CustomDomainsVerificationStatus
-	VerificationToken  string
-	TargetCname        string
-	OwnershipVerified  bool
-	CnameVerified      bool
-	VerificationError  string
-	LastCheckedAt      int64
+	ID                    string
+	WorkspaceID           string
+	ProjectID             string
+	AppID                 string
+	EnvironmentID         string
+	Domain                string
+	VerificationStatus    db.CustomDomainsVerificationStatus
+	VerificationToken     string
+	TargetCname           string
+	OwnershipVerified     bool
+	CnameVerified         bool
+	VerificationError     string
+	LastCheckedAt         int64
+	DomainConnectProvider string
+	DomainConnectURL      string
 }
 
 // CreateCustomDomain attaches a custom domain to an environment. Production writes go
@@ -371,21 +373,23 @@ func (s *Seeder) CreateCustomDomain(ctx context.Context, req CreateCustomDomainR
 
 	now := time.Now().UnixMilli()
 	err := db.Query.InsertCustomDomain(ctx, s.DB.RW(), db.InsertCustomDomainParams{
-		ID:                 req.ID,
-		WorkspaceID:        req.WorkspaceID,
-		ProjectID:          req.ProjectID,
-		AppID:              req.AppID,
-		EnvironmentID:      req.EnvironmentID,
-		Domain:             req.Domain,
-		ChallengeType:      db.CustomDomainsChallengeTypeHTTP01,
-		VerificationStatus: status,
-		VerificationToken:  verificationToken,
-		OwnershipVerified:  req.OwnershipVerified,
-		CnameVerified:      req.CnameVerified,
-		TargetCname:        targetCname,
-		VerificationError:  sql.NullString{String: req.VerificationError, Valid: req.VerificationError != ""},
-		LastCheckedAt:      sql.NullInt64{Int64: req.LastCheckedAt, Valid: req.LastCheckedAt != 0},
-		CreatedAt:          now,
+		ID:                    req.ID,
+		WorkspaceID:           req.WorkspaceID,
+		ProjectID:             req.ProjectID,
+		AppID:                 req.AppID,
+		EnvironmentID:         req.EnvironmentID,
+		Domain:                req.Domain,
+		ChallengeType:         db.CustomDomainsChallengeTypeHTTP01,
+		VerificationStatus:    status,
+		VerificationToken:     verificationToken,
+		OwnershipVerified:     req.OwnershipVerified,
+		CnameVerified:         req.CnameVerified,
+		TargetCname:           targetCname,
+		VerificationError:     sql.NullString{String: req.VerificationError, Valid: req.VerificationError != ""},
+		DomainConnectProvider: sql.NullString{String: req.DomainConnectProvider, Valid: req.DomainConnectProvider != ""},
+		DomainConnectUrl:      sql.NullString{String: req.DomainConnectURL, Valid: req.DomainConnectURL != ""},
+		LastCheckedAt:         sql.NullInt64{Int64: req.LastCheckedAt, Valid: req.LastCheckedAt != 0},
+		CreatedAt:             now,
 	})
 	require.NoError(s.t, err)
 

--- a/svc/api/openapi/gen.go
+++ b/svc/api/openapi/gen.go
@@ -513,6 +513,11 @@ type Domain struct {
 	// Domain Fully qualified domain name attached to the environment.
 	Domain string `json:"domain"`
 
+	// DomainConnect One-click setup at the domain's DNS provider. Omitted entirely when the provider does not support
+	// Domain Connect or discovery failed, so the object's presence is the signal that the shortcut is
+	// available and both of its fields are filled.
+	DomainConnect *DomainConnect `json:"domainConnect,omitempty"`
+
 	// EnvironmentId The environment this domain serves. Traffic to the domain reaches whatever is currently
 	// deployed to this environment.
 	EnvironmentId string `json:"environmentId"`

--- a/svc/api/openapi/openapi-generated.yaml
+++ b/svc/api/openapi/openapi-generated.yaml
@@ -4909,6 +4909,8 @@ components:
                         The DNS records this domain needs. Create each record at your DNS provider.
                         Each record has a `verified` flag. The flag shows whether Unkey has read that record back,
                         so it tells you which records are still missing.
+                domainConnect:
+                    "$ref": "#/components/schemas/DomainConnect"
                 createdAt:
                     type: integer
                     format: int64

--- a/svc/api/openapi/spec/common/Domain.yaml
+++ b/svc/api/openapi/spec/common/Domain.yaml
@@ -77,6 +77,8 @@ properties:
       The DNS records this domain needs. Create each record at your DNS provider.
       Each record has a `verified` flag. The flag shows whether Unkey has read that record back,
       so it tells you which records are still missing.
+  domainConnect:
+    "$ref": "./DomainConnect.yaml"
   createdAt:
     type: integer
     format: int64

--- a/svc/api/routes/v2_domains_get_domain/200_test.go
+++ b/svc/api/routes/v2_domains_get_domain/200_test.go
@@ -271,8 +271,61 @@ func TestGetDomainOmitsUnsetOptionalFields(t *testing.T) {
 	require.Equal(t, http.StatusOK, res.Status, "expected 200, received: %s", res.RawBody)
 	require.Nil(t, res.Body.Data.VerificationError)
 	require.Nil(t, res.Body.Data.UpdatedAt)
+	require.Nil(t, res.Body.Data.DomainConnect)
 	require.NotContains(t, res.RawBody, "lastCheckedAt", "unset optional fields must be absent, received: %s", res.RawBody)
 	require.NotContains(t, res.RawBody, "verificationError", "unset optional fields must be absent, received: %s", res.RawBody)
+	require.NotContains(t, res.RawBody, "domainConnect", "unset optional fields must be absent, received: %s", res.RawBody)
+}
+
+func TestGetDomainReportsDomainConnect(t *testing.T) {
+	h := testutil.NewHarness(t)
+	route := &handler.Handler{DB: h.DB}
+	h.Register(route)
+
+	seeded := seedDomain(t, h, func(req *seed.CreateCustomDomainRequest) {
+		req.DomainConnectProvider = "Cloudflare"
+		req.DomainConnectURL = "https://dash.cloudflare.com/domainconnect?domain=acme.com"
+	})
+	rootKey := h.CreateRootKey(seeded.workspaceID, "environment.*.read_domain")
+
+	res := testutil.CallRoute[handler.Request, handler.Response](h, route, authHeaders(rootKey), handler.Request{
+		Domain: seeded.domain,
+	})
+	require.Equal(t, http.StatusOK, res.Status, "expected 200, received: %s", res.RawBody)
+	require.NotNil(t, res.Body.Data.DomainConnect, "received: %s", res.RawBody)
+	require.Equal(t, "Cloudflare", res.Body.Data.DomainConnect.Provider)
+	require.Equal(t, "https://dash.cloudflare.com/domainconnect?domain=acme.com", res.Body.Data.DomainConnect.Url)
+}
+
+func TestGetDomainOmitsHalfFilledDomainConnect(t *testing.T) {
+	h := testutil.NewHarness(t)
+	route := &handler.Handler{DB: h.DB}
+	h.Register(route)
+
+	testCases := []struct {
+		name     string
+		provider string
+		url      string
+	}{
+		{name: "provider without url", provider: "Cloudflare", url: ""},
+		{name: "url without provider", provider: "", url: "https://dash.cloudflare.com/domainconnect"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			seeded := seedDomain(t, h, func(req *seed.CreateCustomDomainRequest) {
+				req.DomainConnectProvider = tc.provider
+				req.DomainConnectURL = tc.url
+			})
+			rootKey := h.CreateRootKey(seeded.workspaceID, "environment.*.read_domain")
+
+			res := testutil.CallRoute[handler.Request, handler.Response](h, route, authHeaders(rootKey), handler.Request{
+				Domain: seeded.domain,
+			})
+			require.Equal(t, http.StatusOK, res.Status, "expected 200, received: %s", res.RawBody)
+			require.Nil(t, res.Body.Data.DomainConnect, "received: %s", res.RawBody)
+		})
+	}
 }
 
 func TestGetDomainWithSpecificEnvironmentPermission(t *testing.T) {

--- a/svc/api/routes/v2_domains_get_domain/handler.go
+++ b/svc/api/routes/v2_domains_get_domain/handler.go
@@ -107,8 +107,15 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			RoutingVerified:   row.CnameVerified,
 			OwnershipVerified: row.OwnershipVerified,
 		}),
-		CreatedAt: row.CreatedAt,
-		UpdatedAt: nil,
+		DomainConnect: nil,
+		CreatedAt:     row.CreatedAt,
+		UpdatedAt:     nil,
+	}
+	if row.DomainConnectProvider.Valid && row.DomainConnectUrl.Valid {
+		data.DomainConnect = &openapi.DomainConnect{
+			Provider: row.DomainConnectProvider.String,
+			Url:      row.DomainConnectUrl.String,
+		}
 	}
 	if row.VerificationError.Valid && row.VerificationError.String != "" {
 		data.VerificationError = ptr.P(row.VerificationError.String)

--- a/svc/api/routes/v2_domains_list_domains/200_test.go
+++ b/svc/api/routes/v2_domains_list_domains/200_test.go
@@ -328,6 +328,36 @@ func TestListDomainsDnsRecordsPerEntry(t *testing.T) {
 	require.Equal(t, "unkey-domain-verify="+apex.VerificationToken, ap.DnsRecords[1].Value)
 }
 
+func TestListDomainsDomainConnectPerEntry(t *testing.T) {
+	h := testutil.NewHarness(t)
+	route := &handler.Handler{DB: h.DB}
+	h.Register(route)
+
+	env := seedEnvironment(t, h)
+	withConnect := attachDomain(t, h, env, func(req *seed.CreateCustomDomainRequest) {
+		req.DomainConnectProvider = "Cloudflare"
+		req.DomainConnectURL = "https://dash.cloudflare.com/domainconnect?domain=acme.com"
+	})
+	withoutConnect := attachDomain(t, h, env, nil)
+	rootKey := h.CreateRootKey(env.workspaceID, "environment.*.read_domain")
+
+	res := testutil.CallRoute[handler.Request, handler.Response](h, route, authHeaders(rootKey), makeRequest(env))
+	require.Equal(t, http.StatusOK, res.Status, "expected 200, received: %s", res.RawBody)
+	require.Len(t, res.Body.Data, 2, "received: %s", res.RawBody)
+
+	byID := map[string]openapi.Domain{}
+	for _, d := range res.Body.Data {
+		byID[d.Id] = d
+	}
+
+	connected := byID[withConnect.ID]
+	require.NotNil(t, connected.DomainConnect, "received: %s", res.RawBody)
+	require.Equal(t, "Cloudflare", connected.DomainConnect.Provider)
+	require.Equal(t, withConnect.DomainConnectURL, connected.DomainConnect.Url)
+
+	require.Nil(t, byID[withoutConnect.ID].DomainConnect, "received: %s", res.RawBody)
+}
+
 // A list mixes domains that verified through their routing record with ones that verified
 // through TXT because the record could not be read back, so the flag has to be per entry
 // and cannot be folded into status.

--- a/svc/api/routes/v2_domains_list_domains/handler.go
+++ b/svc/api/routes/v2_domains_list_domains/handler.go
@@ -133,8 +133,15 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 				RoutingVerified:   row.CnameVerified,
 				OwnershipVerified: row.OwnershipVerified,
 			}),
-			CreatedAt: row.CreatedAt,
-			UpdatedAt: nil,
+			DomainConnect: nil,
+			CreatedAt:     row.CreatedAt,
+			UpdatedAt:     nil,
+		}
+		if row.DomainConnectProvider.Valid && row.DomainConnectUrl.Valid {
+			d.DomainConnect = &openapi.DomainConnect{
+				Provider: row.DomainConnectProvider.String,
+				Url:      row.DomainConnectUrl.String,
+			}
 		}
 		if row.VerificationError.Valid && row.VerificationError.String != "" {
 			d.VerificationError = ptr.P(row.VerificationError.String)

--- a/web/internal/api/src/models/components/domain.ts
+++ b/web/internal/api/src/models/components/domain.ts
@@ -8,6 +8,7 @@ import { ClosedEnum } from "../../types/enums.js";
 import { Result as SafeParseResult } from "../../types/fp.js";
 import { SDKValidationError } from "../errors/sdkvalidationerror.js";
 import { DnsRecord, DnsRecord$inboundSchema } from "./dnsrecord.js";
+import { DomainConnect, DomainConnect$inboundSchema } from "./domainconnect.js";
 
 /**
  * The verification status of the domain.
@@ -91,6 +92,14 @@ export type Domain = {
    */
   dnsRecords: Array<DnsRecord>;
   /**
+   * One-click setup at the domain's DNS provider. Omitted entirely when the provider does not support
+   *
+   * @remarks
+   * Domain Connect or discovery failed, so the object's presence is the signal that the shortcut is
+   * available and both of its fields are filled.
+   */
+  domainConnect?: DomainConnect | undefined;
+  /**
    * Unix timestamp in milliseconds when the domain was created. The 24 hour verification window runs from here.
    */
   createdAt: number;
@@ -115,6 +124,7 @@ export const Domain$inboundSchema: z.ZodType<Domain, z.ZodTypeDef, unknown> = z
     status: DomainStatus$inboundSchema,
     verificationError: z.string().optional(),
     dnsRecords: z.array(DnsRecord$inboundSchema),
+    domainConnect: DomainConnect$inboundSchema.optional(),
     createdAt: z.number().int(),
     updatedAt: z.number().int().optional(),
   });


### PR DESCRIPTION
## Problem

Domain read endpoints don't return `domainConnect` field back so users are stuck with whatever we return from `createDomain` endpoint. if they ever refresh/reload or kill the terminal there is no way to read it back.

## Fix

We add this field to read endpoints too. So both our dashboard and read it back whenever they need it.

## How to test

- API test should pass