### PR TITLE
Scope control worker Kubernetes clients

### DIFF
--- a/svc/ctrl/worker/deploy/build_kubernetes.go
+++ b/svc/ctrl/worker/deploy/build_kubernetes.go
@@ -13,6 +13,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	batchv1client "k8s.io/client-go/kubernetes/typed/batch/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
 
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/pkg/ptr"
@@ -42,6 +45,37 @@ const (
 // name. Deployment IDs contain underscores, which must become hyphens.
 var k8sNameInvalidChars = regexp.MustCompile(`[^a-z0-9-]+`)
 
+type kubernetesClient struct {
+	core  *corev1client.CoreV1Client
+	batch *batchv1client.BatchV1Client
+}
+
+// NewKubernetesClient creates the Kubernetes clients used by the build backend.
+func NewKubernetesClient(cfg *rest.Config) (KubernetesClient, error) {
+	httpClient, err := rest.HTTPClientFor(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	core, err := corev1client.NewForConfigAndClient(cfg, httpClient)
+	if err != nil {
+		return nil, err
+	}
+	batch, err := batchv1client.NewForConfigAndClient(cfg, httpClient)
+	if err != nil {
+		return nil, err
+	}
+	return &kubernetesClient{core: core, batch: batch}, nil
+}
+
+func (c *kubernetesClient) Pods(namespace string) corev1client.PodInterface {
+	return c.core.Pods(namespace)
+}
+
+func (c *kubernetesClient) Jobs(namespace string) batchv1client.JobInterface {
+	return c.batch.Jobs(namespace)
+}
+
 // sanitizeK8sName converts an arbitrary identifier into a valid RFC 1123
 // name fragment.
 func sanitizeK8sName(s string) string {
@@ -62,7 +96,7 @@ func (w *Workflow) withKubernetesBuildkit(
 	params gitBuildParams,
 	fn func(buildClient *client.Client) error,
 ) (string, error) {
-	jobs := w.k8s.BatchV1().Jobs(w.buildConfig.Kubernetes.Namespace)
+	jobs := w.k8s.Jobs(w.buildConfig.Kubernetes.Namespace)
 
 	//nolint: exhaustruct
 	job := &batchv1.Job{
@@ -176,7 +210,7 @@ func (w *Workflow) withKubernetesBuildkit(
 // IP. Terminal pod states (image pull failures, config errors) fail fast
 // instead of burning the full timeout.
 func (w *Workflow) waitForBuildkitPod(runCtx context.Context, jobName string) (string, error) {
-	pods := w.k8s.CoreV1().Pods(w.buildConfig.Kubernetes.Namespace)
+	pods := w.k8s.Pods(w.buildConfig.Kubernetes.Namespace)
 
 	var podIP string
 	err := wait.PollUntilContextTimeout(runCtx, 2*time.Second, buildkitPodTimeout, true, func(ctx context.Context) (bool, error) {

--- a/svc/ctrl/worker/deploy/service.go
+++ b/svc/ctrl/worker/deploy/service.go
@@ -1,7 +1,8 @@
 package deploy
 
 import (
-	"k8s.io/client-go/kubernetes"
+	batchv1client "k8s.io/client-go/kubernetes/typed/batch/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 
 	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
 	"github.com/unkeyed/unkey/gen/rpc/vault"
@@ -43,6 +44,12 @@ type KubernetesBuildConfig struct {
 
 	// Image is the BuildKit daemon image each build Job runs.
 	Image string
+}
+
+// KubernetesClient provides the Kubernetes APIs used by the build backend.
+type KubernetesClient interface {
+	Pods(namespace string) corev1client.PodInterface
+	Jobs(namespace string) batchv1client.JobInterface
 }
 
 // BuildPlatform specifies the target platform for container builds.
@@ -92,7 +99,7 @@ type Workflow struct {
 
 	// Build dependencies
 	buildConfig                     BuildConfig
-	k8s                             kubernetes.Interface
+	k8s                             KubernetesClient
 	registryConfig                  RegistryConfig
 	buildPlatform                   BuildPlatform
 	clickhouse                      clickhouse.ClickHouse
@@ -126,7 +133,7 @@ type Config struct {
 	// K8s is the cluster client used by the kubernetes build backend to run
 	// build Jobs. Required when Build.Backend is [BuildBackendKubernetes],
 	// unused otherwise.
-	K8s kubernetes.Interface
+	K8s KubernetesClient
 
 	// RegistryConfig provides credentials for the container registry.
 	RegistryConfig RegistryConfig

--- a/svc/ctrl/worker/run.go
+++ b/svc/ctrl/worker/run.go
@@ -63,7 +63,6 @@ import (
 	"github.com/unkeyed/unkey/svc/ctrl/worker/routing"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
 
@@ -261,13 +260,13 @@ func Run(ctx context.Context, cfg Config) error {
 
 	// The kubernetes build backend runs build Jobs in the worker's own
 	// cluster, so it only works when the worker itself runs in-cluster.
-	var k8sClient kubernetes.Interface
+	var k8sClient deploy.KubernetesClient
 	if buildConfig.Backend == deploy.BuildBackendKubernetes {
 		restCfg, restErr := rest.InClusterConfig()
 		if restErr != nil {
 			return fmt.Errorf("kubernetes build backend requires in-cluster credentials: %w", restErr)
 		}
-		k8sClient, err = kubernetes.NewForConfig(restCfg)
+		k8sClient, err = deploy.NewKubernetesClient(restCfg)
 		if err != nil {
 			return fmt.Errorf("failed to create kubernetes client: %w", err)
 		}


### PR DESCRIPTION
## Problem:

Control worker used the root Kubernetes clientset. The worker only uses Pods and Jobs for its optional Kubernetes BuildKit backend. The root clientset linked every generated Kubernetes API client into the release binary.

## Solution:

Construct only the typed Core V1 and Batch V1 clients. Expose only the Pod and Job operations that the build backend uses. Both clients share one HTTP transport, which preserves the previous clientset connection behavior.

## Impact:

| Measurement | Before | After | Change |
| --- | ---: | ---: | ---: |
| Binary | 87.39 MiB | 79.47 MiB | -7.92 MiB (-9.06%) |
| Gzip | 23.81 MiB | 22.61 MiB | -1.21 MiB (-5.07%) |
| Compile packages | 1,280 | 1,178 | -102 |

The release dependency graph no longer contains the root `k8s.io/client-go/kubernetes` package. Kubernetes build behavior does not change.

Fresh-process, warm-page-cache `--help` startup had no measurable improvement. The median was 450.87 ms before and 458.45 ms after across 50 interleaved runs. Restate shared-core compilation still dominates control worker startup.

## Testing:

- `mise exec -- rask ./svc/ctrl/worker/deploy ./svc/ctrl/worker`: 93 passed.
- `mise run build`: passed with 0 lint issues.
- Built Linux amd64 before and after binaries with the release `-trimpath` and linker flags.
- Verified the final production dependency list contains only the typed Core V1 and Batch V1 Kubernetes clients.