### PR TITLE
Scope Krane Kubernetes clients

### DIFF
--- a/svc/krane/internal/deployment/client.go
+++ b/svc/krane/internal/deployment/client.go
@@ -1,0 +1,89 @@
+package deployment
+
+import (
+	"errors"
+
+	appsv1client "k8s.io/client-go/kubernetes/typed/apps/v1"
+	autoscalingv2client "k8s.io/client-go/kubernetes/typed/autoscaling/v2"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	policyv1client "k8s.io/client-go/kubernetes/typed/policy/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/flowcontrol"
+)
+
+// ClientSet provides the typed Kubernetes API clients used by Controller.
+type ClientSet interface {
+	CoreV1() corev1client.CoreV1Interface
+	AppsV1() appsv1client.AppsV1Interface
+	AutoscalingV2() autoscalingv2client.AutoscalingV2Interface
+	PolicyV1() policyv1client.PolicyV1Interface
+}
+
+type clientSet struct {
+	coreV1        corev1client.CoreV1Interface
+	appsV1        appsv1client.AppsV1Interface
+	autoscalingV2 autoscalingv2client.AutoscalingV2Interface
+	policyV1      policyv1client.PolicyV1Interface
+}
+
+// NewClientSet constructs the typed Kubernetes API clients used by Controller.
+func NewClientSet(config *rest.Config) (ClientSet, error) {
+	configCopy := *config
+	if configCopy.UserAgent == "" {
+		configCopy.UserAgent = rest.DefaultKubernetesUserAgent()
+	}
+	if configCopy.RateLimiter == nil && configCopy.QPS > 0 {
+		if configCopy.Burst <= 0 {
+			return nil, errors.New("burst is required to be greater than 0 when RateLimiter is not set and QPS is set to greater than 0")
+		}
+		configCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configCopy.QPS, configCopy.Burst)
+	}
+
+	httpClient, err := rest.HTTPClientFor(&configCopy)
+	if err != nil {
+		return nil, err
+	}
+
+	coreV1, err := corev1client.NewForConfigAndClient(&configCopy, httpClient)
+	if err != nil {
+		return nil, err
+	}
+
+	appsV1, err := appsv1client.NewForConfigAndClient(&configCopy, httpClient)
+	if err != nil {
+		return nil, err
+	}
+
+	autoscalingV2, err := autoscalingv2client.NewForConfigAndClient(&configCopy, httpClient)
+	if err != nil {
+		return nil, err
+	}
+
+	policyV1, err := policyv1client.NewForConfigAndClient(&configCopy, httpClient)
+	if err != nil {
+		return nil, err
+	}
+
+	return &clientSet{
+		coreV1:        coreV1,
+		appsV1:        appsV1,
+		autoscalingV2: autoscalingV2,
+		policyV1:      policyV1,
+	}, nil
+}
+
+func (c *clientSet) CoreV1() corev1client.CoreV1Interface {
+	return c.coreV1
+}
+
+func (c *clientSet) AppsV1() appsv1client.AppsV1Interface {
+	return c.appsV1
+}
+
+func (c *clientSet) AutoscalingV2() autoscalingv2client.AutoscalingV2Interface {
+	return c.autoscalingV2
+}
+
+func (c *clientSet) PolicyV1() policyv1client.PolicyV1Interface {
+	return c.policyV1
+}

--- a/svc/krane/internal/deployment/controller.go
+++ b/svc/krane/internal/deployment/controller.go
@@ -19,7 +19,6 @@ import (
 	"github.com/unkeyed/unkey/svc/krane/pkg/metrics"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/kubernetes"
 )
 
 // Controller manages deployment ReplicaSets in a Kubernetes cluster by maintaining
@@ -31,7 +30,7 @@ import (
 // Create a Controller with [New] and start it with [Controller.Start]. The controller
 // runs until the context is cancelled or [Controller.Stop] is called.
 type Controller struct {
-	clientSet        kubernetes.Interface
+	clientSet        ClientSet
 	dynamicClient    dynamic.Interface
 	cluster          ctrl.ClusterServiceClient
 	vault            vault.VaultServiceClient
@@ -75,7 +74,7 @@ type Controller struct {
 // synchronization. Region determines which deployments this controller manages.
 type Config struct {
 	// ClientSet provides typed Kubernetes API access for ReplicaSet and Pod operations.
-	ClientSet kubernetes.Interface
+	ClientSet ClientSet
 
 	// DynamicClient provides unstructured Kubernetes API access for CiliumNetworkPolicy
 	// resources that don't have generated Go types.

--- a/svc/krane/run.go
+++ b/svc/krane/run.go
@@ -30,7 +30,6 @@ import (
 	"github.com/unkeyed/unkey/svc/krane/internal/watcher"
 	"github.com/unkeyed/unkey/svc/krane/pkg/controlplane"
 	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
 
@@ -120,7 +119,7 @@ func Run(ctx context.Context, cfg Config) error {
 		"burst", inClusterConfig.Burst,
 	)
 
-	clientset, err := kubernetes.NewForConfig(inClusterConfig)
+	clientset, err := deployment.NewClientSet(inClusterConfig)
 	if err != nil {
 		return fmt.Errorf("failed to create k8s clientset: %w", err)
 	}


### PR DESCRIPTION
## Problem:

Krane used the root Kubernetes clientset. Krane only uses Core V1, Apps V1, Autoscaling V2, and Policy V1. The root clientset linked generated clients for every Kubernetes API group.

## Solution:

Construct only the four typed clients that the deployment controller uses. The clients share one HTTP transport and one configured rate limiter, which preserves the previous QPS and burst behavior. The controller keeps a narrow clientset contract, so existing fake clientset tests remain valid.

## Impact:

| Measurement | Before | After | Change |
| --- | ---: | ---: | ---: |
| Binary | 51.33 MiB | 43.78 MiB | -7.55 MiB (-14.70%) |
| Gzip | 14.55 MiB | 13.41 MiB | -1.14 MiB (-7.83%) |
| Compile packages | 829 | 732 | -97 |
| `--help` median | 16.05 ms | 15.15 ms | -0.90 ms (-5.60%) |

The release dependency graph no longer contains the root `k8s.io/client-go/kubernetes` package. Dynamic client behavior and Kubernetes controller behavior do not change.

Startup used fresh processes with a warm page cache, 5 warmups, and 50 interleaved runs per binary.

## Testing:

- `mise exec -- rask ./svc/krane/internal/deployment`: 45 passed.
- `mise run build`: passed with 0 lint issues.
- Built Linux amd64 before and after binaries with the release `-trimpath` and linker flags.
- Verified the final production dependency list contains only Core V1, Apps V1, Autoscaling V2, and Policy V1 typed clients.