### PR TITLE
Scope Heimdall Kubernetes client

### DIFF
--- a/svc/heimdall/run.go
+++ b/svc/heimdall/run.go
@@ -22,8 +22,11 @@ import (
 	"github.com/unkeyed/unkey/svc/heimdall/internal/metrics"
 	"github.com/unkeyed/unkey/svc/heimdall/internal/network"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/informers"
-	"k8s.io/client-go/kubernetes"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 )
@@ -93,14 +96,27 @@ func Run(ctx context.Context, cfg Config) error {
 		return fmt.Errorf("getting in-cluster config: %w", err)
 	}
 
-	clientset, err := kubernetes.NewForConfig(k8sCfg)
+	coreClient, err := corev1client.NewForConfig(k8sCfg)
 	if err != nil {
 		return fmt.Errorf("creating kubernetes client: %w", err)
 	}
 
-	factory := informers.NewSharedInformerFactory(clientset, 0)
-	podInformer := factory.Core().V1().Pods().Informer()
-	podLister := factory.Core().V1().Pods().Lister()
+	pods := coreClient.Pods(metav1.NamespaceAll)
+	podInformer := cache.NewSharedIndexInformer(
+		//nolint:exhaustruct
+		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				return pods.List(ctx, options)
+			},
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+				return pods.Watch(ctx, options)
+			},
+		}, coreClient),
+		&corev1.Pod{},
+		0,
+		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+	)
+	podLister := corev1listers.NewPodLister(podInformer.GetIndexer())
 
 	collectors := collector.CollectorSetFrom(cfg.Collectors)
 
@@ -146,7 +162,7 @@ func Run(ctx context.Context, cfg Config) error {
 	// drops an event (containerd#3177) or CRI is unavailable. Duplicates
 	// across both paths are absorbed by max-min billing math.
 	//
-	// Register *before* factory.Start so transitions during startup churn
+	// Register *before* the informer starts so transitions during startup churn
 	// are delivered to the handler. Registering after Start opens a race
 	// window where the initial List + first UpdateFuncs land before the
 	// handler is hooked in, silently dropping those events.
@@ -165,17 +181,14 @@ func Run(ctx context.Context, cfg Config) error {
 		return fmt.Errorf("registering pod event handler: %w", err)
 	}
 
-	factory.Start(ctx.Done())
+	go podInformer.Run(ctx.Done())
 
 	// Refuse to start the collector with an unsynced cache. Without the
 	// check, a sync failure (ctx cancel before initial List completes, API
 	// server unreachable) would leave the lister returning empty results,
 	// every pod on the node would be silently unbilled.
-	synced := factory.WaitForCacheSync(ctx.Done())
-	for resource, ok := range synced {
-		if !ok {
-			return fmt.Errorf("informer cache sync failed for %v", resource)
-		}
+	if !cache.WaitForCacheSync(ctx.Done(), podInformer.HasSynced) {
+		return errors.New("pod informer cache sync failed")
 	}
 
 	metrics.InformerCacheSynced.Set(1)


### PR DESCRIPTION
## Problem:

Heimdall used the root Kubernetes clientset and root shared informer factory. Heimdall only watches Pods. The root packages linked every generated Kubernetes client and informer into the release binary.

## Solution:

Construct only the typed Core V1 client. Build the Pod shared informer and lister directly with the same watch-list semantics, zero resync period, namespace index, startup ordering, cancellation, and cache-sync requirement.

Across the complete service-size stack:

1. Release builds remove local paths with `-trimpath`.
2. The metrics server uses `net/http`, so four services no longer link Zen only for metrics and timing.
3. Control worker, Krane, and Heimdall construct only the Kubernetes clients that they use.

## Impact:

**This PR**

| Measurement | Before | After | Change |
| --- | ---: | ---: | ---: |
| Binary | 59.83 MiB | 49.28 MiB | -10.55 MiB (-17.63%) |
| Gzip | 17.02 MiB | 15.49 MiB | -1.53 MiB (-8.99%) |
| Compile packages | 1,052 | 827 | -225 |

Fresh-process, warm-page-cache `--help` startup did not materially change. The median was 17.33 ms before and 17.20 ms after across 50 interleaved runs.

**Complete five-PR stack, start to finish**

| Service | Binary before → after | Gzip before → after |
| --- | ---: | ---: |
| API | 60.95 → 60.87 MiB | 16.86 → 16.86 MiB |
| Control API | 41.43 → 39.40 MiB | 13.26 → 12.43 MiB |
| Control worker | 89.10 → 79.47 MiB | 24.48 → 22.61 MiB |
| Frontline | 47.09 → 47.01 MiB | 13.64 → 13.65 MiB |
| Heimdall | 59.95 → 49.28 MiB | 17.02 → 15.49 MiB |
| Krane | 53.73 → 43.78 MiB | 15.52 → 13.41 MiB |
| Vault | 28.09 → 25.61 MiB | 9.37 → 8.36 MiB |

The small Frontline gzip increase is compression-layout noise. The binaries remain stripped, static Linux executables. Service behavior and container base images do not change.

## Testing:

- `mise exec -- rask ./svc/heimdall`: 21 passed; 23 platform-specific tests ignored.
- Combined scoped-client checks: 141 passed for control worker, Krane deployment, and Heimdall.
- `mise run build`: passed with 0 lint issues.
- Built all three affected Linux amd64 services with release-equivalent flags.
- Verified Heimdall no longer imports the root Kubernetes clientset or informer factory.