### PR TITLE
fix(ctrl): register DeployTeardownService in integration harness

### DIFF
--- a/svc/ctrl/integration/harness/harness.go
+++ b/svc/ctrl/integration/harness/harness.go
@@ -37,6 +37,7 @@ import (
 	"github.com/unkeyed/unkey/svc/ctrl/worker/cron/deploybilling"
 	"github.com/unkeyed/unkey/svc/ctrl/worker/deploy"
 	"github.com/unkeyed/unkey/svc/ctrl/worker/deployment"
+	"github.com/unkeyed/unkey/svc/ctrl/worker/deployteardown"
 	"github.com/unkeyed/unkey/svc/ctrl/worker/keylastusedsync"
 	vaulttestutil "github.com/unkeyed/unkey/svc/vault/testutil"
 )
@@ -285,6 +286,16 @@ func New(t *testing.T, opts ...Option) *Harness {
 		DB: database,
 	})
 
+	// CheckWorkspaceSpend sends Teardown/Resume to this service. Restate
+	// retries calls to unregistered services indefinitely, so it must be
+	// registered here or a dispatched check never completes.
+	teardownSvc, err := deployteardown.New(deployteardown.Config{
+		DB:                database,
+		DrainPollInterval: 200 * time.Millisecond,
+		DrainGraceTimeout: 2 * time.Second,
+	})
+	require.NoError(t, err)
+
 	// The build slot service audits slot occupancy against the Restate
 	// admin API, but the admin URL is only known after containers.Restate
 	// starts below, and that start needs the constructed services. The
@@ -310,6 +321,7 @@ func New(t *testing.T, opts ...Option) *Harness {
 		hydrav1.NewKeyLastUsedPartitionServiceServer(keyLastUsedPartitionSvc),
 		hydrav1.NewDeployServiceServer(deploySvc),
 		hydrav1.NewDeploymentServiceServer(deploymentSvc),
+		hydrav1.NewDeployTeardownServiceServer(teardownSvc),
 		hydrav1.NewBuildSlotServiceServer(buildSlotSvc),
 	)
 	buildSlotLiveness.set(restateadmin.New(restateadmin.Config{

--- a/svc/ctrl/worker/cron/deploy_spend_check_orchestrator_integration_test.go
+++ b/svc/ctrl/worker/cron/deploy_spend_check_orchestrator_integration_test.go
@@ -52,11 +52,13 @@ func TestRunDeploySpendCheck_OrchestratorIntegration(t *testing.T) {
 	reader := &fakeUsageReader{} //nolint:exhaustruct // set per subtest
 	h := harness.New(t, harness.WithDeployBilling(reader, newFakePusher(), newFakeCloser()))
 
-	// The harness database persists across test runs, and earlier runs (or
-	// other tests) can leave budgeted workspaces behind. The orchestrator
-	// counts below are asserted exactly, so start from an empty opt-in set.
+	// The harness database is shared across test processes, and other tests
+	// leave budgeted or spend-suspended workspaces behind. Both are scanned by
+	// the orchestrator, and the counts below are asserted exactly, so start
+	// from an empty set.
 	_, err := h.DB.RW().ExecContext(h.Ctx,
-		`UPDATE workspace_billing SET spend_budget_cents = NULL WHERE spend_budget_cents IS NOT NULL`)
+		`UPDATE workspace_billing SET spend_budget_cents = NULL, spend_suspended = false
+		WHERE spend_budget_cents IS NOT NULL OR spend_suspended = true`)
 	require.NoError(t, err)
 
 	period := time.Now().UTC().Format("2006-01")
@@ -90,6 +92,34 @@ func TestRunDeploySpendCheck_OrchestratorIntegration(t *testing.T) {
 		resp, err := run()
 		require.NoError(t, err)
 		require.Equal(t, int32(0), resp.GetWorkspacesDispatched())
+	})
+
+	// Regression: a suspended workspace without a budget always dispatches,
+	// and its check sends Resume to DeployTeardownService. This hung forever
+	// while the harness did not register that service.
+	t.Run("resolves suspended workspace without budget", func(t *testing.T) {
+		reader.set(nil)
+		ws := h.Seed.CreateWorkspace(h.Ctx)
+		_, err := h.DB.RW().ExecContext(h.Ctx,
+			`UPDATE workspace_billing SET spend_suspended = true WHERE workspace_id = ?`, ws.ID)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			_, err := h.DB.RW().ExecContext(h.Ctx,
+				`UPDATE workspace_billing SET spend_suspended = false WHERE workspace_id = ?`, ws.ID)
+			require.NoError(t, err)
+		})
+
+		resp, err := run()
+		require.NoError(t, err)
+		require.Equal(t, int32(1), resp.GetWorkspacesDispatched())
+
+		// The check resumed the workspace: budget removed while suspended clears
+		// the flag, so the row cannot skew later subtests either.
+		var suspended bool
+		require.NoError(t, h.DB.RO().QueryRowContext(h.Ctx,
+			`SELECT spend_suspended FROM workspace_billing WHERE workspace_id = ?`, ws.ID).
+			Scan(&suspended))
+		require.False(t, suspended, "check must clear spend_suspended after the budget was removed")
 	})
 
 	t.Run("limits concurrent instance usage shards", func(t *testing.T) {


### PR DESCRIPTION
Fix the flaky `TestRunDeploySpendCheck_OrchestratorIntegration` failure seen in this Depot job: https://depot.dev/orgs/25j3k7j1zw/workflows/wz7786ktqw/jobs/bbck1m6cdq?repo=unkeyed%2Funkey

> `Post .../hydra.v1.CronService/deploy-spend-check-.../RunDeploySpendCheck: context deadline exceeded`



```mermaid
sequenceDiagram
    participant T as Test (RunDeploySpendCheck)
    participant O as Orchestrator
    participant C as CheckWorkspaceSpend
    participant D as DeployTeardownService
    T->>O: run()
    O->>C: dispatch (suspended row, NULL budget)
    C->>D: Resume()
    Note over C,D: Before: service unregistered.<br/>Restate retries forever, test hangs.
    Note over C,D: After: service registered in harness.<br/>Resume succeeds, flag cleared.
    C-->>O: done
    O-->>T: counts
```

### Root cause
- All test binaries in a CI job share one MySQL database. Other suites (`svc/api/routes/v2_deployments_start_deployment/412_test.go`, `svc/ctrl/integration/deploy_spend_*`) leave `workspace_billing.spend_suspended = TRUE` rows behind, some with NULL budget.
- The orchestrator scan (`ListWorkspacesWithDeployBudget`) selects suspended rows and dispatches `CheckWorkspaceSpend` for each.
- For a suspended row without a budget, the check sends `Resume()` to `hydra.v1.DeployTeardownService`. The integration harness did not register that service.
- Restate treats a call to an unregistered service as retryable and retries forever (verified in restatedev/restate source: `invoker_integration.rs`, `errors.rs`). The child retried until the test context expired.

