### PR TITLE
fix(ci): isolate PlanetScale PR schema changes

### DIFF
--- a/.depot/workflows/job_pscale_pr.yaml
+++ b/.depot/workflows/job_pscale_pr.yaml
@@ -8,6 +8,9 @@ on:
         type: boolean
 permissions:
   contents: read
+concurrency:
+  group: planetscale-pr-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 env:
   PSCALE_ORG: unkey
   PSCALE_DB: unkey
@@ -18,7 +21,6 @@ jobs:
     name: Validate schema on PlanetScale branch
     runs-on: depot-ubuntu-24.04-4
     timeout-minutes: 15
-    if: inputs.db_schema_changed == false || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
     env:
       PLANETSCALE_SERVICE_TOKEN_ID: ${{ secrets.PLANETSCALE_SERVICE_TOKEN_ID }}
       PLANETSCALE_SERVICE_TOKEN: ${{ secrets.PLANETSCALE_SERVICE_TOKEN }}
@@ -28,6 +30,10 @@ jobs:
       - name: validate schema
         env:
           DB_SCHEMA_CHANGED: ${{ inputs.db_schema_changed }}
+          PR_BASE: ${{ github.event.pull_request.base.ref }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_DRAFT: ${{ github.event.pull_request.draft }}
+          PR_HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
@@ -36,21 +42,144 @@ jobs:
             echo "No database schema changes to validate."
             exit 0
           fi
+          if [ "$GITHUB_EVENT_NAME" != "pull_request" ]; then
+            echo "Per-PR PlanetScale branches are not created for $GITHUB_EVENT_NAME events."
+            exit 0
+          fi
+          if [ "$PR_DRAFT" == "true" ]; then
+            echo "PlanetScale validation waits until the pull request is ready for review."
+            exit 0
+          fi
+          if [ "$PR_HEAD_REPOSITORY" != "$GITHUB_REPOSITORY" ]; then
+            echo "PlanetScale validation is not available to fork pull requests."
+            exit 0
+          fi
+          if [ "$PR_BASE" != "main" ]; then
+            echo "PlanetScale validation waits until this stacked pull request targets main."
+            exit 0
+          fi
 
           ./dev/install-mise
           export PATH="$HOME/.local/bin:$PATH"
           mise install --locked --yes node github:pnpm/pnpm github:planetscale/cli github:jqlang/jq
-          FROM="$PSCALE_PARENT" mise run pscale-branch
 
-          EXISTING=$(mise exec -- pscale deploy-request list "$PSCALE_DB" \
-            --org "$PSCALE_ORG" --format json \
-            | mise exec -- jq -r --arg b "$BRANCH" --arg p "$PSCALE_PARENT" \
-                '.[] | select(.branch==$b and .into_branch==$p and .state=="open") | .number' \
-            | head -n1)
-          if [ -z "$EXISTING" ]; then
+          if ! git cat-file -e "${PR_BASE_SHA}^{commit}"; then
+            git fetch --no-tags --depth=1 origin "$PR_BASE_SHA"
+          fi
+          DELTA_ROOT=$(mktemp -d web/internal/db/.pscale-delta.XXXXXX)
+          DELTA_REL=${DELTA_ROOT#web/internal/db/}
+          trap 'rm -rf "$DELTA_ROOT"' EXIT
+          mkdir -p "$DELTA_ROOT/base"
+          git archive "$PR_BASE_SHA" web/internal/db/src/schema \
+            | tar -x -C "$DELTA_ROOT/base"
+
+          mise exec -- pnpm --dir=web/internal/db drizzle-kit generate \
+            --schema="$DELTA_REL/base/web/internal/db/src/schema/index.ts" \
+            --dialect=mysql --out="$DELTA_REL/migrations" --name=base \
+            --prefix=index --breakpoints
+          BASE_MIGRATION_COUNT=$(find "$DELTA_ROOT/migrations" -maxdepth 1 \
+            -type f -name '*.sql' | wc -l)
+          if [ "$BASE_MIGRATION_COUNT" -ne 1 ]; then
+            echo "::error::Expected one generated base migration, found $BASE_MIGRATION_COUNT."
+            exit 1
+          fi
+
+          mise exec -- pnpm --dir=web/internal/db drizzle-kit generate \
+            --schema=src/schema/index.ts --dialect=mysql \
+            --out="$DELTA_REL/migrations" --name=pr --prefix=index --breakpoints
+          MIGRATION_COUNT=$(find "$DELTA_ROOT/migrations" -maxdepth 1 \
+            -type f -name '*.sql' | wc -l)
+          DELTA_COUNT=$((MIGRATION_COUNT - BASE_MIGRATION_COUNT))
+          if [ "$DELTA_COUNT" -lt 0 ] || [ "$DELTA_COUNT" -gt 1 ]; then
+            echo "::error::Expected at most one PR migration, found $DELTA_COUNT."
+            exit 1
+          fi
+
+          DEPLOY_REQUESTS=$(mise exec -- pscale deploy-request list "$PSCALE_DB" \
+            --org "$PSCALE_ORG" --format json)
+          if ! mise exec -- jq -e 'type == "array"' <<< "$DEPLOY_REQUESTS" >/dev/null; then
+            echo "::error::PlanetScale returned an invalid deploy request list."
+            exit 1
+          fi
+          mapfile -t OPEN_REQUESTS < <(
+            mise exec -- jq -r --arg b "$BRANCH" \
+              '.[] | select(.branch==$b and .state=="open") | .number' \
+              <<< "$DEPLOY_REQUESTS"
+          )
+          for request in "${OPEN_REQUESTS[@]}"; do
+            echo "Closing outdated deploy request #$request."
+            mise exec -- pscale deploy-request close "$PSCALE_DB" "$request" \
+              --org "$PSCALE_ORG"
+          done
+
+          BRANCHES=$(mise exec -- pscale branch list "$PSCALE_DB" \
+            --org "$PSCALE_ORG" --format json)
+          if ! mise exec -- jq -e 'type == "array"' <<< "$BRANCHES" >/dev/null; then
+            echo "::error::PlanetScale returned an invalid branch list."
+            exit 1
+          fi
+          if mise exec -- jq -e --arg b "$BRANCH" \
+              'any(.[]; .name == $b)' <<< "$BRANCHES" >/dev/null; then
+            echo "Deleting outdated PlanetScale branch $BRANCH."
+            mise exec -- pscale branch delete "$PSCALE_DB" "$BRANCH" \
+              --org "$PSCALE_ORG" --force
+            for attempt in $(seq 1 30); do
+              BRANCHES=$(mise exec -- pscale branch list "$PSCALE_DB" \
+                --org "$PSCALE_ORG" --format json)
+              if ! mise exec -- jq -e 'type == "array"' \
+                  <<< "$BRANCHES" >/dev/null; then
+                echo "::error::PlanetScale returned an invalid branch list."
+                exit 1
+              fi
+              if ! mise exec -- jq -e --arg b "$BRANCH" \
+                  'any(.[]; .name == $b)' <<< "$BRANCHES" >/dev/null; then
+                break
+              fi
+              if [ "$attempt" -eq 30 ]; then
+                echo "::error::Timed out waiting for $BRANCH to be deleted."
+                exit 1
+              fi
+              sleep 2
+            done
+          fi
+
+          if [ "$DELTA_COUNT" -eq 0 ]; then
+            echo "The pull request has no database schema delta."
+            exit 0
+          fi
+
+          DELTA_FILE=$(find "$DELTA_ROOT/migrations" -maxdepth 1 \
+            -type f -name '*.sql' | sort | tail -n1)
+          echo "Applying only the pull request migration from $PR_BASE_SHA."
+          MIGRATION_FILE="$DELTA_FILE" FROM="$PSCALE_PARENT" mise run pscale-branch
+
+          # PlanetScale can take a few seconds to expose a branch schema diff.
+          DIFF_COUNT=0
+          for attempt in $(seq 1 7); do
+            BRANCH_DIFF=$(mise exec -- pscale branch diff "$PSCALE_DB" "$BRANCH" \
+              --org "$PSCALE_ORG" --format json)
+            if ! DIFF_COUNT=$(mise exec -- jq -e \
+                'if type == "array" then length else error("expected an array") end' \
+                <<< "$BRANCH_DIFF"); then
+              echo "::error::PlanetScale returned an invalid branch diff."
+              exit 1
+            fi
+            echo "Diff check $attempt/7 found $DIFF_COUNT change(s)."
+            if [ "$DIFF_COUNT" -gt 0 ]; then
+              break
+            fi
+            if [ "$attempt" -lt 7 ]; then
+              sleep 5
+            fi
+          done
+
+          if [ "$DIFF_COUNT" -eq 0 ]; then
+            echo "The applied schema has no changes relative to $PSCALE_PARENT."
+            echo "Deleting empty PlanetScale branch $BRANCH."
+            mise exec -- pscale branch delete "$PSCALE_DB" "$BRANCH" \
+              --org "$PSCALE_ORG" --force
+          else
             mise exec -- pscale deploy-request create "$PSCALE_DB" "$BRANCH" \
               --org "$PSCALE_ORG" --into "$PSCALE_PARENT" \
               --notes "PR #${PR_NUMBER}: ${PR_TITLE}"
-          else
-            echo "Reusing existing deploy request #$EXISTING"
           fi

--- a/.depot/workflows/job_pscale_pr.yaml
+++ b/.depot/workflows/job_pscale_pr.yaml
@@ -32,7 +32,6 @@ jobs:
           DB_SCHEMA_CHANGED: ${{ inputs.db_schema_changed }}
           PR_BASE: ${{ github.event.pull_request.base.ref }}
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          PR_DRAFT: ${{ github.event.pull_request.draft }}
           PR_HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
@@ -44,10 +43,6 @@ jobs:
           fi
           if [ "$GITHUB_EVENT_NAME" != "pull_request" ]; then
             echo "Per-PR PlanetScale branches are not created for $GITHUB_EVENT_NAME events."
-            exit 0
-          fi
-          if [ "$PR_DRAFT" == "true" ]; then
-            echo "PlanetScale validation waits until the pull request is ready for review."
             exit 0
           fi
           if [ "$PR_HEAD_REPOSITORY" != "$GITHUB_REPOSITORY" ]; then

--- a/.depot/workflows/job_pscale_pr.yaml
+++ b/.depot/workflows/job_pscale_pr.yaml
@@ -37,10 +37,6 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           set -euo pipefail
-          if [ "$DB_SCHEMA_CHANGED" != "true" ]; then
-            echo "No database schema changes to validate."
-            exit 0
-          fi
           if [ "$GITHUB_EVENT_NAME" != "pull_request" ]; then
             echo "Per-PR PlanetScale branches are not created for $GITHUB_EVENT_NAME events."
             exit 0
@@ -49,45 +45,71 @@ jobs:
             echo "PlanetScale validation is not available to fork pull requests."
             exit 0
           fi
-          if [ "$PR_BASE" != "main" ]; then
-            echo "PlanetScale validation waits until this stacked pull request targets main."
-            exit 0
-          fi
 
           ./dev/install-mise
           export PATH="$HOME/.local/bin:$PATH"
           mise install --locked --yes node github:pnpm/pnpm github:planetscale/cli github:jqlang/jq
 
-          if ! git cat-file -e "${PR_BASE_SHA}^{commit}"; then
-            git fetch --no-tags --depth=1 origin "$PR_BASE_SHA"
-          fi
-          DELTA_ROOT=$(mktemp -d web/internal/db/.pscale-delta.XXXXXX)
-          DELTA_REL=${DELTA_ROOT#web/internal/db/}
-          trap 'rm -rf "$DELTA_ROOT"' EXIT
-          mkdir -p "$DELTA_ROOT/base"
-          git archive "$PR_BASE_SHA" web/internal/db/src/schema \
-            | tar -x -C "$DELTA_ROOT/base"
+          if [ "$DB_SCHEMA_CHANGED" == "true" ] && [ "$PR_BASE" == "main" ]; then
+            if ! git cat-file -e "${PR_BASE_SHA}^{commit}"; then
+              git fetch --no-tags --depth=1 origin "$PR_BASE_SHA"
+            fi
+            DELTA_ROOT=$(mktemp -d web/internal/db/.pscale-delta.XXXXXX)
+            DELTA_REL=${DELTA_ROOT#web/internal/db/}
+            trap 'rm -rf "$DELTA_ROOT"' EXIT
+            mkdir -p "$DELTA_ROOT/base"
+            git archive "$PR_BASE_SHA" web/internal/db/src/schema \
+              | tar -x -C "$DELTA_ROOT/base"
 
-          mise exec -- pnpm --dir=web/internal/db drizzle-kit generate \
-            --schema="$DELTA_REL/base/web/internal/db/src/schema/index.ts" \
-            --dialect=mysql --out="$DELTA_REL/migrations" --name=base \
-            --prefix=index --breakpoints
-          BASE_MIGRATION_COUNT=$(find "$DELTA_ROOT/migrations" -maxdepth 1 \
-            -type f -name '*.sql' | wc -l)
-          if [ "$BASE_MIGRATION_COUNT" -ne 1 ]; then
-            echo "::error::Expected one generated base migration, found $BASE_MIGRATION_COUNT."
-            exit 1
-          fi
+            mise exec -- pnpm --dir=web/internal/db drizzle-kit generate \
+              --schema="$DELTA_REL/base/web/internal/db/src/schema/index.ts" \
+              --dialect=mysql --out="$DELTA_REL/migrations" --name=base \
+              --prefix=index --breakpoints
+            BASE_MIGRATION_COUNT=$(find "$DELTA_ROOT/migrations" -maxdepth 1 \
+              -type f -name '*.sql' | wc -l)
+            if [ "$BASE_MIGRATION_COUNT" -ne 1 ]; then
+              echo "::error::Expected one generated base migration, found $BASE_MIGRATION_COUNT."
+              exit 1
+            fi
 
-          mise exec -- pnpm --dir=web/internal/db drizzle-kit generate \
-            --schema=src/schema/index.ts --dialect=mysql \
-            --out="$DELTA_REL/migrations" --name=pr --prefix=index --breakpoints
-          MIGRATION_COUNT=$(find "$DELTA_ROOT/migrations" -maxdepth 1 \
-            -type f -name '*.sql' | wc -l)
-          DELTA_COUNT=$((MIGRATION_COUNT - BASE_MIGRATION_COUNT))
-          if [ "$DELTA_COUNT" -lt 0 ] || [ "$DELTA_COUNT" -gt 1 ]; then
-            echo "::error::Expected at most one PR migration, found $DELTA_COUNT."
-            exit 1
+            GENERATE_LOG="$DELTA_ROOT/generate-pr.log"
+            if ! timeout 120s mise exec -- pnpm --dir=web/internal/db drizzle-kit generate \
+                --schema=src/schema/index.ts --dialect=mysql \
+                --out="$DELTA_REL/migrations" --name=pr --prefix=index --breakpoints \
+                </dev/null >"$GENERATE_LOG" 2>&1; then
+              cat "$GENERATE_LOG"
+              echo "::error::Drizzle could not generate the pull request migration non-interactively."
+              echo "::error::If the change adds and removes columns on one table, split it into separate additive and drop pull requests."
+              exit 1
+            fi
+            cat "$GENERATE_LOG"
+
+            MIGRATION_COUNT=$(find "$DELTA_ROOT/migrations" -maxdepth 1 \
+              -type f -name '*.sql' | wc -l)
+            DELTA_COUNT=$((MIGRATION_COUNT - BASE_MIGRATION_COUNT))
+            if [ "$DELTA_COUNT" -lt 0 ] || [ "$DELTA_COUNT" -gt 1 ]; then
+              echo "::error::Expected at most one PR migration, found $DELTA_COUNT."
+              exit 1
+            fi
+            if [ "$DELTA_COUNT" -eq 0 ] \
+                && ! grep -Fq 'No schema changes, nothing to migrate' "$GENERATE_LOG"; then
+              echo "::error::Drizzle wrote no migration and did not report an empty schema diff."
+              echo "::error::If the change adds and removes columns on one table, split it into separate additive and drop pull requests."
+              exit 1
+            fi
+
+            if [ "$DELTA_COUNT" -eq 1 ]; then
+              mapfile -t SNAPSHOTS < <(
+                find "$DELTA_ROOT/migrations/meta" -maxdepth 1 \
+                  -type f -name '*_snapshot.json' | sort
+              )
+              if [ "${#SNAPSHOTS[@]}" -ne 2 ]; then
+                echo "::error::Expected two schema snapshots, found ${#SNAPSHOTS[@]}."
+                exit 1
+              fi
+              BASE_SNAPSHOT="${SNAPSHOTS[0]}"
+              HEAD_SNAPSHOT="${SNAPSHOTS[1]}"
+            fi
           fi
 
           DEPLOY_REQUESTS=$(mise exec -- pscale deploy-request list "$PSCALE_DB" \
@@ -138,15 +160,34 @@ jobs:
             done
           fi
 
+          if [ "$DB_SCHEMA_CHANGED" != "true" ]; then
+            echo "No database schema changes to validate."
+            exit 0
+          fi
+          if [ "$PR_BASE" != "main" ]; then
+            echo "PlanetScale validation waits until this stacked pull request targets main."
+            exit 0
+          fi
           if [ "$DELTA_COUNT" -eq 0 ]; then
             echo "The pull request has no database schema delta."
             exit 0
           fi
 
-          DELTA_FILE=$(find "$DELTA_ROOT/migrations" -maxdepth 1 \
-            -type f -name '*.sql' | sort | tail -n1)
-          echo "Applying only the pull request migration from $PR_BASE_SHA."
-          MIGRATION_FILE="$DELTA_FILE" FROM="$PSCALE_PARENT" mise run pscale-branch
+          RESULT_FILE="$DELTA_ROOT/effective-result"
+          echo "Applying only the effective pull request migration from $PR_BASE_SHA."
+          BASE_SNAPSHOT="$BASE_SNAPSHOT" HEAD_SNAPSHOT="$HEAD_SNAPSHOT" \
+            RESULT_FILE="$RESULT_FILE" FROM="$PSCALE_PARENT" mise run pscale-branch
+          if [ ! -f "$RESULT_FILE" ]; then
+            echo "::error::PlanetScale branch setup did not report its migration result."
+            exit 1
+          fi
+          if [ "$(cat "$RESULT_FILE")" != "true" ]; then
+            echo "The pull request schema is already present in $PSCALE_PARENT."
+            echo "Deleting empty PlanetScale branch $BRANCH."
+            mise exec -- pscale branch delete "$PSCALE_DB" "$BRANCH" \
+              --org "$PSCALE_ORG" --force
+            exit 0
+          fi
 
           # PlanetScale can take a few seconds to expose a branch schema diff.
           DIFF_COUNT=0
@@ -169,12 +210,9 @@ jobs:
           done
 
           if [ "$DIFF_COUNT" -eq 0 ]; then
-            echo "The applied schema has no changes relative to $PSCALE_PARENT."
-            echo "Deleting empty PlanetScale branch $BRANCH."
-            mise exec -- pscale branch delete "$PSCALE_DB" "$BRANCH" \
-              --org "$PSCALE_ORG" --force
-          else
-            mise exec -- pscale deploy-request create "$PSCALE_DB" "$BRANCH" \
-              --org "$PSCALE_ORG" --into "$PSCALE_PARENT" \
-              --notes "PR #${PR_NUMBER}: ${PR_TITLE}"
+            echo "::error::Applied a non-empty migration but $BRANCH shows no diff against $PSCALE_PARENT."
+            exit 1
           fi
+          mise exec -- pscale deploy-request create "$PSCALE_DB" "$BRANCH" \
+            --org "$PSCALE_ORG" --into "$PSCALE_PARENT" \
+            --notes "PR #${PR_NUMBER}: ${PR_TITLE}"

--- a/.depot/workflows/pscale_cleanup.yaml
+++ b/.depot/workflows/pscale_cleanup.yaml
@@ -1,10 +1,10 @@
 name: PlanetScale Cleanup
-# Tears down the per-PR PlanetScale branch when a PR returns to draft or closes WITHOUT merging.
+# Tears down the per-PR PlanetScale branch when a PR closes WITHOUT merging.
 # Merged PRs intentionally leave the branch + deploy request alive so the
 # schema change can still be promoted into staging from the PlanetScale UI.
 on:
   pull_request:
-    types: [closed, converted_to_draft]
+    types: [closed]
 permissions:
   contents: read
 concurrency:
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 5
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository &&
-      (github.event.action == 'converted_to_draft' || github.event.pull_request.merged == false)
+      github.event.pull_request.merged == false
     env:
       PLANETSCALE_SERVICE_TOKEN_ID: ${{ secrets.PLANETSCALE_SERVICE_TOKEN_ID }}
       PLANETSCALE_SERVICE_TOKEN: ${{ secrets.PLANETSCALE_SERVICE_TOKEN }}

--- a/.depot/workflows/pscale_cleanup.yaml
+++ b/.depot/workflows/pscale_cleanup.yaml
@@ -1,12 +1,15 @@
 name: PlanetScale Cleanup
-# Tears down the per-PR PlanetScale branch when a PR closes WITHOUT merging.
+# Tears down the per-PR PlanetScale branch when a PR returns to draft or closes WITHOUT merging.
 # Merged PRs intentionally leave the branch + deploy request alive so the
 # schema change can still be promoted into staging from the PlanetScale UI.
 on:
   pull_request:
-    types: [closed]
+    types: [closed, converted_to_draft]
 permissions:
   contents: read
+concurrency:
+  group: planetscale-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 env:
   PSCALE_ORG: unkey
   PSCALE_DB: unkey
@@ -18,23 +21,42 @@ jobs:
     timeout-minutes: 5
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository &&
-      github.event.pull_request.merged == false
+      (github.event.action == 'converted_to_draft' || github.event.pull_request.merged == false)
     env:
       PLANETSCALE_SERVICE_TOKEN_ID: ${{ secrets.PLANETSCALE_SERVICE_TOKEN_ID }}
       PLANETSCALE_SERVICE_TOKEN: ${{ secrets.PLANETSCALE_SERVICE_TOKEN }}
     steps:
       - uses: planetscale/setup-pscale-action@b6a50ee45b4b24944e1d8de6e57b3a5f6476a1af # v1
 
-      - name: close open deploy requests
-        # Branch deletion fails while a DR is open, so close them first.
+      - name: delete PlanetScale resources
         run: |
           set -euo pipefail
-          pscale deploy-request list "$PSCALE_DB" --org "$PSCALE_ORG" --format json \
-            | jq -r --arg b "$BRANCH" \
-                '.[] | select(.branch==$b and .state=="open") | .number' \
-            | while read -r num; do
-                pscale deploy-request close "$PSCALE_DB" "$num" --org "$PSCALE_ORG" || true
-              done
 
-      - name: delete branch
-        run: pscale branch delete "$PSCALE_DB" "$BRANCH" --org "$PSCALE_ORG" --force || true
+          BRANCHES=$(pscale branch list "$PSCALE_DB" --org "$PSCALE_ORG" --format json)
+          if ! jq -e 'type == "array"' <<< "$BRANCHES" >/dev/null; then
+            echo "::error::PlanetScale returned an invalid branch list."
+            exit 1
+          fi
+          if ! jq -e --arg b "$BRANCH" 'any(.[]; .name == $b)' <<< "$BRANCHES" >/dev/null; then
+            echo "PlanetScale branch $BRANCH does not exist."
+            exit 0
+          fi
+
+          DEPLOY_REQUESTS=$(pscale deploy-request list "$PSCALE_DB" \
+            --org "$PSCALE_ORG" --format json)
+          if ! jq -e 'type == "array"' <<< "$DEPLOY_REQUESTS" >/dev/null; then
+            echo "::error::PlanetScale returned an invalid deploy request list."
+            exit 1
+          fi
+          mapfile -t OPEN_REQUESTS < <(
+            jq -r --arg b "$BRANCH" \
+              '.[] | select(.branch==$b and .state=="open") | .number' \
+              <<< "$DEPLOY_REQUESTS"
+          )
+          for request in "${OPEN_REQUESTS[@]}"; do
+            echo "Closing deploy request #$request."
+            pscale deploy-request close "$PSCALE_DB" "$request" --org "$PSCALE_ORG"
+          done
+
+          echo "Deleting PlanetScale branch $BRANCH."
+          pscale branch delete "$PSCALE_DB" "$BRANCH" --org "$PSCALE_ORG" --force

--- a/.depot/workflows/pscale_retarget.yaml
+++ b/.depot/workflows/pscale_retarget.yaml
@@ -1,0 +1,21 @@
+name: PlanetScale PR Retarget
+on:
+  pull_request:
+    types: [edited]
+permissions:
+  contents: read
+concurrency:
+  group: planetscale-retarget-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+jobs:
+  detect_changes:
+    if: github.event.changes.base != null && github.event.pull_request.draft == false
+    uses: ./.depot/workflows/job_detect_changes.yaml
+  pscale_pr:
+    name: PlanetScale PR Branch
+    if: needs.detect_changes.result == 'success'
+    needs: [detect_changes]
+    uses: ./.depot/workflows/job_pscale_pr.yaml
+    with:
+      db_schema_changed: ${{ needs.detect_changes.outputs.db_schema == 'true' }}
+    secrets: inherit

--- a/.mise/tasks/pscale-branch
+++ b/.mise/tasks/pscale-branch
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#MISE description="Create PlanetScale branch and run drizzle migration (BRANCH=name [FROM=staging])"
+#MISE description="Create PlanetScale branch and apply schema (BRANCH=name [FROM=staging] [MIGRATION_FILE=path])"
 #MISE depends=["install-web"]
 set -euo pipefail
 
@@ -11,8 +11,60 @@ fi
 FROM="${FROM:-staging}"
 pscale branch create unkey "$BRANCH" --org unkey --from "$FROM" --wait \
   || pscale branch show unkey "$BRANCH" --org unkey >/dev/null
-PW="$(pscale password create unkey "$BRANCH" "local-$(date +%s)" --org unkey --format json)"
-USER="$(echo "$PW" | jq -r '.username | @uri')"
-PASS="$(echo "$PW" | jq -r '.plain_text | @uri')"
-HOST="$(echo "$PW" | jq -r '.access_host_url | @uri')"
-DRIZZLE_DATABASE_URL="mysql://$USER:$PASS@$HOST/unkey?ssl={}" pnpm --dir=web/internal/db run migrate
+PW="$(pscale password create unkey "$BRANCH" "local-$(date +%s)" \
+  --org unkey --ttl 1h --format json)"
+PASSWORD_ID="$(jq -er '.id' <<< "$PW")"
+USER="$(jq -er '.username | @uri' <<< "$PW")"
+PASS="$(jq -er '.plain_text | @uri' <<< "$PW")"
+HOST="$(jq -er '.access_host_url | @uri' <<< "$PW")"
+
+cleanup_password() {
+  status=$?
+  trap - EXIT
+  if ! pscale password delete unkey "$BRANCH" "$PASSWORD_ID" \
+      --org unkey --force >/dev/null; then
+    echo "Warning: failed to delete temporary PlanetScale password $PASSWORD_ID" >&2
+  fi
+  exit "$status"
+}
+trap cleanup_password EXIT
+
+DRIZZLE_DATABASE_URL="mysql://$USER:$PASS@$HOST/unkey?ssl={}"
+if [ -z "${MIGRATION_FILE:-}" ]; then
+  DRIZZLE_DATABASE_URL="$DRIZZLE_DATABASE_URL" pnpm --dir=web/internal/db run migrate
+  exit 0
+fi
+
+if [ ! -f "$MIGRATION_FILE" ]; then
+  echo "Error: migration file does not exist: $MIGRATION_FILE" >&2
+  exit 1
+fi
+MIGRATION_FILE="$(realpath "$MIGRATION_FILE")"
+DRIZZLE_DATABASE_URL="$DRIZZLE_DATABASE_URL" MIGRATION_FILE="$MIGRATION_FILE" \
+  pnpm --dir=web/internal/db exec node --input-type=module <<'NODE'
+import { readFile } from "node:fs/promises";
+import mysql from "mysql2/promise";
+
+const databaseUrl = process.env.DRIZZLE_DATABASE_URL;
+const migrationFile = process.env.MIGRATION_FILE;
+if (!databaseUrl || !migrationFile) {
+  throw new Error("DRIZZLE_DATABASE_URL and MIGRATION_FILE are required");
+}
+
+const sql = await readFile(migrationFile, "utf8");
+const statements = sql
+  .split("--> statement-breakpoint")
+  .map((statement) => statement.trim())
+  .filter(Boolean);
+const connection = await mysql.createConnection({
+  uri: databaseUrl,
+  multipleStatements: true,
+});
+try {
+  for (const statement of statements) {
+    await connection.query(statement);
+  }
+} finally {
+  await connection.end();
+}
+NODE

--- a/.mise/tasks/pscale-branch
+++ b/.mise/tasks/pscale-branch
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#MISE description="Create PlanetScale branch and apply schema (BRANCH=name [FROM=staging] [MIGRATION_FILE=path])"
+#MISE description="Create PlanetScale branch and apply schema (BRANCH=name [FROM=staging] [MIGRATION_FILE=path] [BASE_SNAPSHOT=path HEAD_SNAPSHOT=path RESULT_FILE=path])"
 #MISE depends=["install-web"]
 set -euo pipefail
 
@@ -9,6 +9,26 @@ if [ -z "${BRANCH:-}" ]; then
 fi
 
 FROM="${FROM:-staging}"
+SNAPSHOT_MODE=false
+if [ -n "${BASE_SNAPSHOT:-}" ] || [ -n "${HEAD_SNAPSHOT:-}" ] || [ -n "${RESULT_FILE:-}" ]; then
+  if [ -z "${BASE_SNAPSHOT:-}" ] || [ -z "${HEAD_SNAPSHOT:-}" ] || [ -z "${RESULT_FILE:-}" ]; then
+    echo "Error: BASE_SNAPSHOT, HEAD_SNAPSHOT, and RESULT_FILE must be provided together" >&2
+    exit 1
+  fi
+  if [ -n "${MIGRATION_FILE:-}" ]; then
+    echo "Error: MIGRATION_FILE cannot be combined with schema snapshots" >&2
+    exit 1
+  fi
+  if [ ! -f "$BASE_SNAPSHOT" ] || [ ! -f "$HEAD_SNAPSHOT" ]; then
+    echo "Error: base and head snapshot files must exist" >&2
+    exit 1
+  fi
+  BASE_SNAPSHOT="$(realpath "$BASE_SNAPSHOT")"
+  HEAD_SNAPSHOT="$(realpath "$HEAD_SNAPSHOT")"
+  RESULT_FILE="$(realpath -m "$RESULT_FILE")"
+  SNAPSHOT_MODE=true
+fi
+
 pscale branch create unkey "$BRANCH" --org unkey --from "$FROM" --wait \
   || pscale branch show unkey "$BRANCH" --org unkey >/dev/null
 PW="$(pscale password create unkey "$BRANCH" "local-$(date +%s)" \
@@ -18,9 +38,13 @@ USER="$(jq -er '.username | @uri' <<< "$PW")"
 PASS="$(jq -er '.plain_text | @uri' <<< "$PW")"
 HOST="$(jq -er '.access_host_url | @uri' <<< "$PW")"
 
+WORK_ROOT=""
 cleanup_password() {
   status=$?
   trap - EXIT
+  if [ -n "$WORK_ROOT" ]; then
+    rm -rf "$WORK_ROOT"
+  fi
   if ! pscale password delete unkey "$BRANCH" "$PASSWORD_ID" \
       --org unkey --force >/dev/null; then
     echo "Warning: failed to delete temporary PlanetScale password $PASSWORD_ID" >&2
@@ -30,6 +54,40 @@ cleanup_password() {
 trap cleanup_password EXIT
 
 DRIZZLE_DATABASE_URL="mysql://$USER:$PASS@$HOST/unkey?ssl={}"
+if [ "$SNAPSHOT_MODE" == "true" ]; then
+  WORK_ROOT="$(mktemp -d web/internal/db/.pscale-merge.XXXXXX)"
+  WORK_REL="${WORK_ROOT#web/internal/db/}"
+  DRIZZLE_DATABASE_URL="$DRIZZLE_DATABASE_URL" pnpm --dir=web/internal/db drizzle-kit introspect \
+    --config=drizzle.config.ts --out="$WORK_REL/introspected" --introspect-casing=preserve
+  if [ ! -f "$WORK_ROOT/introspected/schema.ts" ]; then
+    echo "Error: Drizzle did not generate the current branch schema" >&2
+    exit 1
+  fi
+  pnpm --dir=web/internal/db drizzle-kit generate \
+    --schema="$WORK_REL/introspected/schema.ts" --dialect=mysql \
+    --out="$WORK_REL/current" --name=current --prefix=index --breakpoints
+  mapfile -t CURRENT_SNAPSHOTS < <(
+    find "$WORK_ROOT/current/meta" -maxdepth 1 -type f -name '*_snapshot.json' | sort
+  )
+  if [ "${#CURRENT_SNAPSHOTS[@]}" -ne 1 ]; then
+    echo "Error: expected one current branch snapshot, found ${#CURRENT_SNAPSHOTS[@]}" >&2
+    exit 1
+  fi
+
+  MIGRATION_FILE="$WORK_ROOT/effective.sql"
+  node web/internal/db/scripts/merge-mysql-snapshots.mjs \
+    "$BASE_SNAPSHOT" "$HEAD_SNAPSHOT" "${CURRENT_SNAPSHOTS[0]}" "$MIGRATION_FILE"
+  if [ ! -f "$MIGRATION_FILE" ]; then
+    echo "Error: effective migration generation did not produce an output file" >&2
+    exit 1
+  fi
+  if [ ! -s "$MIGRATION_FILE" ]; then
+    echo "The pull request schema is already present in $FROM."
+    printf 'false\n' > "$RESULT_FILE"
+    exit 0
+  fi
+fi
+
 if [ -z "${MIGRATION_FILE:-}" ]; then
   DRIZZLE_DATABASE_URL="$DRIZZLE_DATABASE_URL" pnpm --dir=web/internal/db run migrate
   exit 0
@@ -68,3 +126,7 @@ try {
   await connection.end();
 }
 NODE
+
+if [ "$SNAPSHOT_MODE" == "true" ]; then
+  printf 'true\n' > "$RESULT_FILE"
+fi

--- a/docs/engineering/infra/planetscale/schema-changes.mdx
+++ b/docs/engineering/infra/planetscale/schema-changes.mdx
@@ -24,9 +24,15 @@ mise run generate-sql
 Review and commit all generated files. Push the branch, then open a non-draft GitHub pull request from the Unkey repository.
 
 The <a href="https://github.com/unkeyed/unkey/blob/main/.depot/workflows/job_pscale_pr.yaml" target="_blank"><code>PlanetScale PR Branch</code></a>
-job runs automatically and creates a new branch on planetscale for you.
-For example pull request 1234 would create branch a PlanetScale branch `pr-1234` from `staging`.
-The CI job applies the schema, and opens a deploy request from `pr-1234` into `staging`.
+job runs automatically. It computes the migration from the pull request's Git
+base to its head, creates a PlanetScale branch from the latest `staging` schema,
+and applies only that migration. Unrelated changes in `staging` remain unchanged.
+
+For example, pull request 1234 creates `pr-1234` from `staging` and opens a
+deploy request from `pr-1234` into `staging`. CI doesn't create PlanetScale
+resources when the migration is empty. A stacked pull request waits until it
+targets `main`, which prevents inherited schema changes from entering its
+deploy request.
 
 <Note>
   The
@@ -44,9 +50,10 @@ Usually you want to merge the deploy request right away, because otherwise you c
 
 A bad migration here is recoverable, but due diligence can prevent canary disruption and cleanup work.
 
-If you update the GitHub pull request, CI reapplies its Drizzle schema to the
-same `pr-<number>` branch and reuses the open deploy request. Review the latest
-diff before continuing.
+If you update the GitHub pull request, CI closes its old deploy request,
+recreates `pr-<number>` from the latest `staging` schema, applies the updated
+pull request migration, and opens a new deploy request. Review the new diff
+before continuing.
 
 ## 3. Merge the deploy request into staging
 

--- a/docs/engineering/infra/planetscale/schema-changes.mdx
+++ b/docs/engineering/infra/planetscale/schema-changes.mdx
@@ -25,14 +25,16 @@ Review and commit all generated files. Push the branch, then open a non-draft Gi
 
 The <a href="https://github.com/unkeyed/unkey/blob/main/.depot/workflows/job_pscale_pr.yaml" target="_blank"><code>PlanetScale PR Branch</code></a>
 job runs automatically. It computes the migration from the pull request's Git
-base to its head, creates a PlanetScale branch from the latest `staging` schema,
-and applies only that migration. Unrelated changes in `staging` remain unchanged.
+base to its head and merges that change into the latest `staging` schema. The
+job creates a PlanetScale branch and applies only the effective migration.
+Unrelated changes in `staging` remain unchanged.
 
 For example, pull request 1234 creates `pr-1234` from `staging` and opens a
 deploy request from `pr-1234` into `staging`. CI doesn't create PlanetScale
 resources when the migration is empty. A stacked pull request waits until it
 targets `main`, which prevents inherited schema changes from entering its
-deploy request.
+deploy request. If the pull request change is already present in `staging`, CI
+deletes the empty branch and doesn't create another deploy request.
 
 <Note>
   The
@@ -51,9 +53,9 @@ Usually you want to merge the deploy request right away, because otherwise you c
 A bad migration here is recoverable, but due diligence can prevent canary disruption and cleanup work.
 
 If you update the GitHub pull request, CI closes its old deploy request,
-recreates `pr-<number>` from the latest `staging` schema, applies the updated
-pull request migration, and opens a new deploy request. Review the new diff
-before continuing.
+recreates `pr-<number>` from the latest `staging` schema, merges the updated
+pull request change, and opens a new deploy request for the effective diff.
+Review the new diff before continuing.
 
 ## 3. Merge the deploy request into staging
 

--- a/web/internal/db/scripts/merge-mysql-snapshots.mjs
+++ b/web/internal/db/scripts/merge-mysql-snapshots.mjs
@@ -1,0 +1,122 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { pathToFileURL } from "node:url";
+import { isDeepStrictEqual } from "node:util";
+
+const require = createRequire(import.meta.url);
+const { generateMySQLMigration } = require("drizzle-kit/api");
+
+const absent = Symbol("absent");
+const identityKeys = new Set(["id", "prevId"]);
+
+export class SnapshotMergeConflict extends Error {
+  constructor(path) {
+    super(`Conflicting schema changes at ${path.join(".")}`);
+    this.name = "SnapshotMergeConflict";
+  }
+}
+
+function isRecord(value) {
+  return value !== absent && value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function same(left, right) {
+  if (left === absent || right === absent) {
+    return left === right;
+  }
+  return isDeepStrictEqual(left, right);
+}
+
+function clone(value) {
+  return value === absent ? absent : structuredClone(value);
+}
+
+// Merge the pull request's base-to-head change into the current database value.
+// A value changed differently on both sides is a conflict rather than a guess.
+function mergeValue(base, head, current, path) {
+  if (same(head, base)) {
+    return clone(current);
+  }
+  if (same(current, base) || same(current, head)) {
+    return clone(head);
+  }
+  if (base === absent || head === absent || current === absent) {
+    throw new SnapshotMergeConflict(path);
+  }
+  if (!isRecord(base) || !isRecord(head) || !isRecord(current)) {
+    throw new SnapshotMergeConflict(path);
+  }
+
+  const merged = {};
+  const keys = new Set([...Object.keys(base), ...Object.keys(head), ...Object.keys(current)]);
+  for (const key of keys) {
+    const value = mergeValue(
+      Object.hasOwn(base, key) ? base[key] : absent,
+      Object.hasOwn(head, key) ? head[key] : absent,
+      Object.hasOwn(current, key) ? current[key] : absent,
+      [...path, key],
+    );
+    if (value !== absent) {
+      merged[key] = value;
+    }
+  }
+  return merged;
+}
+
+export function mergeSnapshots(base, head, current) {
+  for (const key of ["version", "dialect"]) {
+    if (!same(base[key], head[key]) || !same(base[key], current[key])) {
+      throw new SnapshotMergeConflict([key]);
+    }
+  }
+
+  const merged = structuredClone(current);
+  const keys = new Set([...Object.keys(base), ...Object.keys(head), ...Object.keys(current)]);
+  for (const key of keys) {
+    if (identityKeys.has(key) || key === "version" || key === "dialect") {
+      continue;
+    }
+    const value = mergeValue(
+      Object.hasOwn(base, key) ? base[key] : absent,
+      Object.hasOwn(head, key) ? head[key] : absent,
+      Object.hasOwn(current, key) ? current[key] : absent,
+      [key],
+    );
+    if (value === absent) {
+      delete merged[key];
+    } else {
+      merged[key] = value;
+    }
+  }
+  return merged;
+}
+
+export async function generateEffectiveStatements(base, head, current) {
+  const merged = mergeSnapshots(base, head, current);
+  if (isDeepStrictEqual(current, merged)) {
+    return [];
+  }
+
+  const statements = await generateMySQLMigration(current, merged);
+  if (statements.length === 0) {
+    throw new Error("Drizzle generated no SQL for a non-empty merged schema");
+  }
+  return statements;
+}
+
+async function main() {
+  const [basePath, headPath, currentPath, outputPath] = process.argv.slice(2);
+  if (!basePath || !headPath || !currentPath || !outputPath) {
+    throw new Error("Usage: merge-mysql-snapshots <base> <head> <current> <output>");
+  }
+
+  const [base, head, current] = await Promise.all(
+    [basePath, headPath, currentPath].map(async (path) => JSON.parse(await readFile(path, "utf8"))),
+  );
+  const statements = await generateEffectiveStatements(base, head, current);
+  await writeFile(outputPath, statements.map((statement) => statement.trim()).join("\n--> statement-breakpoint\n"));
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main();
+}

--- a/web/internal/db/scripts/merge-mysql-snapshots.test.mjs
+++ b/web/internal/db/scripts/merge-mysql-snapshots.test.mjs
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  SnapshotMergeConflict,
+  generateEffectiveStatements,
+  mergeSnapshots,
+} from "./merge-mysql-snapshots.mjs";
+
+function column(name, type = "int") {
+  return {
+    name,
+    type,
+    primaryKey: false,
+    notNull: true,
+    autoincrement: false,
+  };
+}
+
+function snapshot() {
+  return {
+    version: "5",
+    dialect: "mysql",
+    id: "00000000-0000-0000-0000-000000000001",
+    prevId: "00000000-0000-0000-0000-000000000000",
+    tables: {
+      users: {
+        name: "users",
+        columns: { id: column("id") },
+        indexes: {},
+        foreignKeys: {},
+        compositePrimaryKeys: {},
+        uniqueConstraints: {},
+        checkConstraint: {},
+      },
+    },
+    views: {},
+    _meta: { schemas: {}, tables: {}, columns: {} },
+    internal: { tables: {}, indexes: {} },
+  };
+}
+
+test("preserves unrelated current changes", () => {
+  const base = snapshot();
+  const head = structuredClone(base);
+  head.tables.users.columns.name = column("name", "varchar(255)");
+  const current = structuredClone(base);
+  current.tables.users.indexes.id_idx = {
+    name: "id_idx",
+    columns: ["id"],
+    isUnique: false,
+  };
+
+  const merged = mergeSnapshots(base, head, current);
+
+  assert.deepEqual(merged.tables.users.columns.name, head.tables.users.columns.name);
+  assert.deepEqual(merged.tables.users.indexes.id_idx, current.tables.users.indexes.id_idx);
+});
+
+test("treats an applied pull request change as a no-op", async () => {
+  const base = snapshot();
+  const head = structuredClone(base);
+  head.tables.users.columns.name = column("name", "varchar(255)");
+  const current = structuredClone(head);
+  current.tables.users.indexes.staging_idx = {
+    name: "staging_idx",
+    columns: ["id"],
+    isUnique: false,
+  };
+
+  assert.deepEqual(await generateEffectiveStatements(base, head, current), []);
+});
+
+test("rejects conflicting changes to the same schema value", () => {
+  const base = snapshot();
+  const head = structuredClone(base);
+  head.tables.users.columns.id.type = "bigint";
+  const current = structuredClone(base);
+  current.tables.users.columns.id.type = "varchar(48)";
+
+  assert.throws(
+    () => mergeSnapshots(base, head, current),
+    (error) =>
+      error instanceof SnapshotMergeConflict &&
+      error.message === "Conflicting schema changes at tables.users.columns.id.type",
+  );
+});
+
+test("generates SQL only for the effective pull request change", async () => {
+  const base = snapshot();
+  const head = structuredClone(base);
+  head.tables.users.columns.name = column("name", "varchar(255)");
+  const current = structuredClone(base);
+  current.tables.users.indexes.id_idx = {
+    name: "id_idx",
+    columns: ["id"],
+    isUnique: false,
+  };
+
+  const statements = await generateEffectiveStatements(base, head, current);
+
+  assert.equal(statements.length, 1);
+  assert.match(statements[0], /ALTER TABLE `users` ADD `name` varchar\(255\) NOT NULL;/);
+  assert.doesNotMatch(statements[0], /id_idx/);
+});
+
+test("preserves unrelated current changes when the pull request removes a column", async () => {
+  const base = snapshot();
+  base.tables.users.columns.old_name = column("old_name", "varchar(255)");
+  const head = structuredClone(base);
+  delete head.tables.users.columns.old_name;
+  const current = structuredClone(base);
+  current.tables.users.indexes.id_idx = {
+    name: "id_idx",
+    columns: ["id"],
+    isUnique: false,
+  };
+
+  const statements = await generateEffectiveStatements(base, head, current);
+
+  assert.equal(statements.length, 1);
+  assert.match(statements[0], /ALTER TABLE `users` DROP COLUMN `old_name`;/);
+  assert.doesNotMatch(statements[0], /id_idx/);
+});


### PR DESCRIPTION
## Problem:

The planetscale workflow that we use to throw up dev branches wasnt fully to my liking

A) if our staging db has changes that are not in the branch it tries to remove them again...
B) if we have no changes at all we still create a branch e.g when just changing a comment in the db folder or doing something schema unrelated 
C) when stacking pr's it does a branch for every single pr since they all change it even tho only on of the prs adds/changes the db

## Solution:

We now start the pr from staging so any changes we do on there wont instantly get dropped if their code is not merged yet.

We skip empty deltas or prs that dont target main

## Impact:

our passwords now use a 1hr ttl so they dont work forever + get deleted after use.
and whatever else we have abvve.

## Testing:

- `actionlint` passed for the affected workflows.
- `dprint check` passed for the affected workflows and documentation.
- Bash syntax checks passed for the task and embedded workflow scripts.
- Mocked workflow checks covered empty deltas, stale resources, stack layers, forks, and non-PR events.
- A schema delta generated for pull request #7132 contained only the intended index creation and no unrelated `ALTER` or `DROP` statement.