### PR TITLE
chore(agents): update AGENTS.md for clarity around code standards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,10 +12,13 @@ typed, verified, and routed through `mise`.
 
 ## Source of truth
 
-- Tooling and task runner: `mise.toml`, `mise.lock`, and `.mise/tasks/*`.
-- Engineering docs: `docs/engineering/contributing/`.
+- Tooling and task runner: `.mise/config.toml`, `.mise/mise.lock`, and
+  `.mise/tasks/*`.
+- Engineering docs: `docs/engineering/contributing/`. These are normative
+  standards for writing code, not only reference material for the docs site.
 - Product docs: `docs/product/`.
-- Go tooling: `go.mod`, `go.sum`, `rask.toml`, and `.golangci.yaml`.
+- Go tooling: `go.mod`, `go.sum`, and `.golangci.yaml`. Rask is pinned as a
+  tool in `.mise/config.toml`; it has no config file of its own.
 - Web workspace: `web/package.json`, `web/pnpm-workspace.yaml`, and
   `web/pnpm-lock.yaml`.
 
@@ -24,10 +27,13 @@ typed, verified, and routed through `mise`.
 - `cmd/`: Unkey CLI commands and service entrypoints.
 - `svc/`: Go services (`api`, `ctrl`, `frontline`, `heimdall`, `krane`, `vault`).
 - `pkg/`: shared Go libraries.
-- `internal/`: shared internal Go services.
+- `internal/services/`: shared internal Go services.
 - `proto/` and `gen/`: protobuf definitions and generated code.
-- `web/`: TypeScript apps, packages, database schema, and tooling.
+- `web/`: TypeScript apps (`web/apps/`) and shared packages, database schema,
+  and tooling. Shared code lives in `web/internal/`; there is no
+  `web/packages/`.
 - `docs/`: Mintlify product and engineering documentation.
+  `docs/engineering/contributing/` holds the coding standards themselves.
 - `dev/`: local development, Tilt, Kubernetes, and formatting config.
 
 ## Tooling rules
@@ -145,6 +151,9 @@ Unkey runs on PlanetScale Vitess. Every production MySQL query should carry SQLC
 - Full guide: [`docs/engineering/infra/planetscale/query-insights-tags.mdx`](docs/engineering/infra/planetscale/query-insights-tags.mdx).
 
 ## High-signal references
+
+Read the page that covers the area before writing code in it. These pages define
+how Unkey code is written; this file only summarizes them.
 
 - Local development: `docs/engineering/contributing/local/development.mdx`.
 - Build workflow: `docs/engineering/contributing/tooling/builds.mdx`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,13 @@ mise exec -- go test -fuzz=FuzzParseConfig -fuzztime=30s ./pkg/config/
 - Avoid new dependencies unless the local implementation would be worse.
 - Keep variable scope small. Use clear names with units or bounds where useful.
 - Handle every error. If a state is impossible, assert it rather than ignoring it.
-- Document why non-obvious code exists, not what each line does.
+- Document why non-obvious code exists, not what each line does. Code comments
+  follow `docs/engineering/contributing/quality/documentation.mdx`, which is the
+  standard for code comments as well as for the docs sites. In short: why not
+  what, depth matches complexity, prose over bullet lists, and a clearer name
+  beats a comment. Every sentence must carry non-obvious information; a sentence
+  restating the line below it is noise. A comment that no longer matches the code
+  it describes is a defect, not a nit.
 
 ## Go conventions
 
@@ -106,7 +112,8 @@ mise exec -- go test -fuzz=FuzzParseConfig -fuzztime=30s ./pkg/config/
 
 ## Documentation conventions
 
-- Follow `docs/engineering/contributing/quality/documentation.mdx`.
+- Follow `docs/engineering/contributing/quality/documentation.mdx`. It governs
+  code comments too, not only the pages under `docs/`; see **Code standards**.
 - Product docs live in `docs/product/` and need `docs/product/docs.json` nav
   entries when adding pages.
 - Engineering docs live in `docs/engineering/` and need


### PR DESCRIPTION
agents are dumb and thought the /docs/engineering applied to docs-only sites, and not actual coding standards. 

standardizing the instructions here so there's some sort of consistency since everyone is doing their own workflow anyway and at least this is a good starting point for someone who still fine-tuning their workflow