### PR TITLE
fix dashboard production domain filtering

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/overview/components/app-production-card.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/overview/components/app-production-card.tsx
@@ -10,7 +10,7 @@ import { and, eq, useLiveQuery } from "@tanstack/react-db";
 import dynamic from "next/dynamic";
 import { useState } from "react";
 import { ActiveDeploymentCardEmpty } from "../../../components/active-deployment-card/components/active-deployment-card-empty";
-import { getAppOverviewDomains, getDomainPriority } from "../../../components/domain-priority";
+import { getDomainPriority } from "../../../components/domain-priority";
 import { Card } from "../../components/card";
 import { useAppId, useProjectData } from "../../data-provider";
 import { CreateDeploymentButton } from "../../navigations/create-deployment-button";
@@ -37,7 +37,7 @@ const UndoRollbackDialog = dynamic(
 );
 
 export function AppProductionCard() {
-  const { projectId, deployments, environments, customDomains, domains, isDeploymentsLoading } =
+  const { projectId, deployments, environments, customDomains, isDeploymentsLoading } =
     useProjectData();
   const appId = useAppId();
   const workspace = useWorkspaceNavigation();
@@ -78,6 +78,20 @@ export function AppProductionCard() {
 
   const deployment = currentDeployment ?? latestProductionDeployment;
   const isCurrent = Boolean(currentDeployment);
+  const liveDomainsQuery = useLiveQuery(
+    (q) =>
+      q
+        .from({ domain: collection.domains })
+        .where(({ domain }) =>
+          and(
+            eq(domain.projectId, projectId),
+            eq(domain.appId, appId),
+            eq(domain.deploymentId, deployment?.id ?? ""),
+            eq(domain.sticky, "live"),
+          ),
+        ),
+    [projectId, appId, deployment?.id],
+  );
 
   const metrics = trpc.deploy.metrics.getAppRpsMetrics.useQuery(
     { appId },
@@ -93,7 +107,12 @@ export function AppProductionCard() {
   const isResolvingCurrentDeployment =
     currentDeploymentId != null && currentDeploymentQuery.isLoading;
 
-  if (isDeploymentsLoading || appsQuery.isLoading || isResolvingCurrentDeployment) {
+  if (
+    isDeploymentsLoading ||
+    appsQuery.isLoading ||
+    liveDomainsQuery.isLoading ||
+    isResolvingCurrentDeployment
+  ) {
     return <AppProductionCardSkeleton />;
   }
 
@@ -116,7 +135,7 @@ export function AppProductionCard() {
   const sourceRepo = deployment.forkRepositoryFullName || repoFullName;
 
   const { primary, additional } = getDomainPriority({
-    domains: getAppOverviewDomains(domains, deployment.id),
+    domains: liveDomainsQuery.data ?? [],
     customDomains,
     environmentId: deployment.environmentId,
     deploymentId: deployment.id,

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/overview/components/app-production-card.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/overview/components/app-production-card.tsx
@@ -83,14 +83,9 @@ export function AppProductionCard() {
       q
         .from({ domain: collection.domains })
         .where(({ domain }) =>
-          and(
-            eq(domain.projectId, projectId),
-            eq(domain.appId, appId),
-            eq(domain.deploymentId, deployment?.id ?? ""),
-            eq(domain.sticky, "live"),
-          ),
+          and(eq(domain.projectId, projectId), eq(domain.appId, appId), eq(domain.sticky, "live")),
         ),
-    [projectId, appId, deployment?.id],
+    [projectId, appId],
   );
 
   const metrics = trpc.deploy.metrics.getAppRpsMetrics.useQuery(

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/components/domain-priority.test.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/components/domain-priority.test.ts
@@ -1,6 +1,6 @@
 import type { CustomDomain, Domain } from "@/lib/collections";
 import { describe, expect, test } from "vitest";
-import { getAppOverviewDomains, getDomainPriority } from "./domain-priority";
+import { getDomainPriority } from "./domain-priority";
 
 function makeDomain(overrides: Partial<Domain> = {}): Domain {
   return {
@@ -42,27 +42,6 @@ const baseCtx = {
   deploymentId: "dep-current",
   currentDeploymentId: "dep-current" as string | null,
 };
-
-test("getAppOverviewDomains includes only live routes attached to the displayed deployment", () => {
-  const domains = [
-    makeDomain({ id: "current-live-1", deploymentId: "dep-current", sticky: "live" }),
-    makeDomain({ id: "current-live-2", deploymentId: "dep-current", sticky: "live" }),
-    makeDomain({ id: "current-commit", deploymentId: "dep-current", sticky: "none" }),
-    makeDomain({ id: "current-deployment", deploymentId: "dep-current", sticky: "deployment" }),
-    makeDomain({ id: "current-branch", deploymentId: "dep-current", sticky: "branch" }),
-    makeDomain({ id: "current-environment", deploymentId: "dep-current", sticky: "environment" }),
-    makeDomain({ id: "other-branch", deploymentId: "dep-other", sticky: "branch" }),
-    makeDomain({ id: "other-environment", deploymentId: "dep-other", sticky: "environment" }),
-    makeDomain({ id: "other-live", deploymentId: "dep-other", sticky: "live" }),
-    makeDomain({ id: "other-commit", deploymentId: "dep-other", sticky: "none" }),
-    makeDomain({ id: "other-deployment", deploymentId: "dep-other", sticky: "deployment" }),
-  ];
-
-  expect(getAppOverviewDomains(domains, "dep-current").map((domain) => domain.id)).toEqual([
-    "current-live-1",
-    "current-live-2",
-  ]);
-});
 
 describe("getDomainPriority", () => {
   const cases = [

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/components/domain-priority.test.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/components/domain-priority.test.ts
@@ -43,10 +43,14 @@ const baseCtx = {
   currentDeploymentId: "dep-current" as string | null,
 };
 
-test("getAppOverviewDomains includes app aliases and the displayed deployment's immutable URLs", () => {
+test("getAppOverviewDomains includes only live routes attached to the displayed deployment", () => {
   const domains = [
+    makeDomain({ id: "current-live-1", deploymentId: "dep-current", sticky: "live" }),
+    makeDomain({ id: "current-live-2", deploymentId: "dep-current", sticky: "live" }),
     makeDomain({ id: "current-commit", deploymentId: "dep-current", sticky: "none" }),
     makeDomain({ id: "current-deployment", deploymentId: "dep-current", sticky: "deployment" }),
+    makeDomain({ id: "current-branch", deploymentId: "dep-current", sticky: "branch" }),
+    makeDomain({ id: "current-environment", deploymentId: "dep-current", sticky: "environment" }),
     makeDomain({ id: "other-branch", deploymentId: "dep-other", sticky: "branch" }),
     makeDomain({ id: "other-environment", deploymentId: "dep-other", sticky: "environment" }),
     makeDomain({ id: "other-live", deploymentId: "dep-other", sticky: "live" }),
@@ -55,11 +59,8 @@ test("getAppOverviewDomains includes app aliases and the displayed deployment's 
   ];
 
   expect(getAppOverviewDomains(domains, "dep-current").map((domain) => domain.id)).toEqual([
-    "current-commit",
-    "current-deployment",
-    "other-branch",
-    "other-environment",
-    "other-live",
+    "current-live-1",
+    "current-live-2",
   ]);
 });
 

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/components/domain-priority.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/components/domain-priority.ts
@@ -32,19 +32,6 @@ export type DomainPriorityResult = {
   all: ReadonlyArray<DisplayDomain>;
 };
 
-/**
- * Returns the live routes attached to the production deployment shown on the
- * app overview. Other route types can belong to stopped preview deployments.
- */
-export function getAppOverviewDomains(
-  domains: ReadonlyArray<Domain>,
-  deploymentId: string,
-): ReadonlyArray<Domain> {
-  return domains.filter(
-    (domain) => domain.deploymentId === deploymentId && domain.sticky === "live",
-  );
-}
-
 export function getDomainPriority(ctx: DomainPriorityContext): DomainPriorityResult {
   const isCurrentDeployment = ctx.deploymentId === ctx.currentDeploymentId;
 

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/components/domain-priority.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/components/domain-priority.ts
@@ -33,18 +33,15 @@ export type DomainPriorityResult = {
 };
 
 /**
- * Returns the app-level aliases shown on the overview together with immutable
- * URLs for the displayed deployment. The `deployment` sticky value identifies
- * an immutable URL, so routes of that type from older deployments are excluded.
+ * Returns the live routes attached to the production deployment shown on the
+ * app overview. Other route types can belong to stopped preview deployments.
  */
 export function getAppOverviewDomains(
   domains: ReadonlyArray<Domain>,
   deploymentId: string,
 ): ReadonlyArray<Domain> {
   return domains.filter(
-    (domain) =>
-      domain.deploymentId === deploymentId ||
-      (domain.sticky !== "none" && domain.sticky !== "deployment"),
+    (domain) => domain.deploymentId === deploymentId && domain.sticky === "live",
   );
 }
 


### PR DESCRIPTION
ctx: https://unkey.slack.com/archives/C0A7JD8HKMY/p1787740931072649

Prevent showing preview urls in the app's overview 

| Before | After |
|--------|--------|
| <img width="1002" height="870" alt="image" src="https://github.com/user-attachments/assets/509c250d-80ba-4593-a01f-ed0137248123" /> | Idk, hopefully fewer | 
