### PR TITLE
fix(dashboard): Confine usage card hover to the toggle icon

### DIFF
--- a/web/apps/dashboard/components/navigation/sidebar-v2/usage-card/usage-panel.tsx
+++ b/web/apps/dashboard/components/navigation/sidebar-v2/usage-card/usage-panel.tsx
@@ -17,17 +17,17 @@ export function UsagePanel({ summary }: { summary: UsageSummary }) {
   const bodyId = useId();
 
   return (
-    <div className="group relative overflow-hidden rounded-lg border border-grayA-4 bg-white shadow-xs dark:bg-grayA-3">
+    <div className="relative overflow-hidden rounded-lg border border-grayA-4">
       {folded ? null : (
         <Link
           href={summary.href}
           aria-label="Usage"
-          className="absolute inset-0 rounded-lg outline-hidden hover:bg-grayA-2 focus-visible:ring-2 focus-visible:ring-grayA-7"
+          className="absolute inset-0 rounded-lg outline-hidden focus-visible:ring-2 focus-visible:ring-grayA-7"
         />
       )}
       <div
         className={cn(
-          "pointer-events-none relative flex items-center gap-2 font-medium text-[11px]",
+          "pointer-events-none relative flex items-center gap-2 text-[11px]",
           !folded && "px-2.5 pt-2 pb-1.5",
         )}
       >
@@ -42,8 +42,8 @@ export function UsagePanel({ summary }: { summary: UsageSummary }) {
             className={cn(
               "pointer-events-auto flex items-center rounded text-gray-9 hover:text-gray-12",
               folded
-                ? "w-full gap-2 px-2.5 pt-2 pb-1.5 text-left font-medium text-[11px] transition-colors hover:bg-grayA-2"
-                : "-mr-1 h-5 flex-1 justify-end pr-1 pl-2",
+                ? "w-full gap-2 px-2.5 pt-2 pb-1.5 text-left text-[11px] transition-colors hover:bg-grayA-2"
+                : "-mr-1 ml-auto size-5 justify-center",
             )}
           >
             {folded ? <span className="flex-1 truncate text-gray-12">Usage</span> : null}

--- a/web/apps/dashboard/components/navigation/sidebar-v2/usage-card/usage-rows.tsx
+++ b/web/apps/dashboard/components/navigation/sidebar-v2/usage-card/usage-rows.tsx
@@ -100,10 +100,7 @@ function Shell({
     <div className="flex flex-col gap-1.5">
       <div className="flex items-baseline gap-2">
         <span
-          className={cn(
-            "flex-1 truncate text-[11px] transition-colors duration-150 ease-out motion-reduce:transition-none",
-            atRisk ? "text-error-9" : "text-gray-9 group-hover:text-gray-12",
-          )}
+          className={cn("flex-1 truncate text-[11px]", atRisk ? "text-error-9" : "text-gray-9")}
         >
           {label}
         </span>


### PR DESCRIPTION
## What does this PR do?

Fixes the usage card 'disco' mode https://unkey.slack.com/archives/C0723ESMR9R/p1787745111999449. I've removed the `flex-` so now if you want to close it you have to be more precise. 

I also changed some of the styling of this too, over the last week or so since I shipped it I've realised it's a bit inconsistent with some of the surrounding UI, so cleaned that up slightly too while I was here. 

## Screenshots

<img width="4264" height="2584" alt="CleanShot 2026-08-26 at 13 20 20@2x" src="https://github.com/user-attachments/assets/5c505628-fbc3-424c-8897-815ed62852e2" />


https://github.com/user-attachments/assets/8d375393-169a-4a20-b0db-c1d590ef7e88

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

Open any dashboard page with the sidebar expanded and hover the usage card.

1. Hover the card body, the "Usage" heading, and the gap between heading and icon. Nothing should highlight.
2. Hover the toggle icon itself. Only the icon should change colour.
3. Click the icon to fold and unfold the card. Folded, the whole row is the toggle and still takes a background hover.
4. Collapse the sidebar to the rail and confirm the card hides without layout escape.

Known behaviour changes and gaps, all deliberately left as-is in this PR:

- A near-miss click just outside the icon now navigates to the usage page instead of toggling. The vacated gap is `pointer-events-none`, so the click falls through to the full-card link.
- The at-risk variant renders no toggle, so it has no hover affordance at all.
- The full-card link's `focus-visible` ring is clipped by the parent `overflow-hidden`, and `outline-hidden` removes the native fallback, so keyboard focus on the card is invisible. Pre-existing, not introduced here.
- The toggle target is 20px, under the 24px minimum, and it uses the native focus outline rather than the token ring its sidebar peers use.
- The expanded branch has no `transition-colors`, so the icon hover snaps while the folded branch animates.
- Minor token drift: the folded hover uses `bg-grayA-2` where sibling sidebar controls use `bg-grayA-3`, the heading is no longer typographically distinct from the metric labels, and the progress-bar track shares `bg-grayA-4` with the card border now that the card is transparent.

Not verified in a browser: dark mode, since the card lost its `dark:bg-grayA-3` surface. Mobile is unaffected, the sidebar does not render the usage card there.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary

_Screenshots to be added — light, dark._