### PR TITLE
feat(dashboard): send Idempotency-Key on deployment creates

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/components/table/components/actions/redeploy-dialog.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/components/table/components/actions/redeploy-dialog.tsx
@@ -3,6 +3,7 @@
 import { useWorkspaceNavigation } from "@/hooks/use-workspace-navigation";
 import type { Deployment } from "@/lib/collections";
 import { queryClient } from "@/lib/collections/client";
+import { withIdempotencyKey } from "@/lib/idempotency";
 import { routes } from "@/lib/navigation/routes";
 import { getErrorMessage, getUnkeyClient } from "@/lib/unkey-client";
 import { useMutation } from "@tanstack/react-query";
@@ -24,13 +25,19 @@ export const RedeployDialog = ({ isOpen, onClose, selectedDeployment }: Redeploy
 
   const redeploy = useMutation({
     mutationFn: async () => {
-      const res = await getUnkeyClient().deployments.createDeployment({
+      const body = {
         project: selectedDeployment.projectId,
         app: selectedDeployment.appId,
         environment: selectedDeployment.environmentId,
         deployment: { deploymentId: selectedDeployment.id },
-      });
-      return { deploymentId: res.data.deploymentId };
+      };
+      const res = await withIdempotencyKey(body, (idempotencyKey) =>
+        getUnkeyClient().deployments.createDeployment({
+          idempotencyKey,
+          v2DeploymentsCreateDeploymentRequestBody: body,
+        }),
+      );
+      return { deploymentId: res.result.data.deploymentId };
     },
     onSuccess: async (data) => {
       await queryClient.invalidateQueries({ queryKey: ["deployments", projectId] });

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/navigations/create-deployment-button.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/navigations/create-deployment-button.tsx
@@ -7,6 +7,7 @@ import { collection } from "@/lib/collections";
 import { queryClient } from "@/lib/collections/client";
 import { UnsupportedDeployRefError, parseDeployRef } from "@/lib/deploy-ref";
 import { githubUrl } from "@/lib/github-url";
+import { withIdempotencyKey } from "@/lib/idempotency";
 import { routes } from "@/lib/navigation/routes";
 import { trpc } from "@/lib/trpc/client";
 import { getErrorMessage, getUnkeyClient } from "@/lib/unkey-client";
@@ -194,13 +195,19 @@ export const CreateDeploymentButton = ({
       git?: ReturnType<typeof parseDeployRef>;
       image?: string;
     }) => {
-      const res = await getUnkeyClient().deployments.createDeployment({
+      const body = {
         project: projectId,
         app: appId,
         environment: source.environment,
         ...(source.image ? { image: { dockerImage: source.image } } : { git: source.git ?? {} }),
-      });
-      return { deploymentId: res.data.deploymentId };
+      };
+      const res = await withIdempotencyKey(body, (idempotencyKey) =>
+        getUnkeyClient().deployments.createDeployment({
+          idempotencyKey,
+          v2DeploymentsCreateDeploymentRequestBody: body,
+        }),
+      );
+      return { deploymentId: res.result.data.deploymentId };
     },
     async onSuccess(data) {
       toast.success("Deployment has been created");

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/components/pending-redeploy-banner.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/components/pending-redeploy-banner.tsx
@@ -7,6 +7,7 @@ import {
   dismissSettingsBanner,
   useSettingsBannerVisible,
 } from "@/lib/collections/deploy/environment-settings";
+import { withIdempotencyKey } from "@/lib/idempotency";
 import { routes } from "@/lib/navigation/routes";
 import { getErrorMessage, getUnkeyClient } from "@/lib/unkey-client";
 import { cn } from "@/lib/utils";
@@ -39,13 +40,19 @@ export function PendingRedeployBanner() {
       appId: string;
       environmentId: string;
     }) => {
-      const res = await getUnkeyClient().deployments.createDeployment({
+      const body = {
         project: deployment.projectId,
         app: deployment.appId,
         environment: deployment.environmentId,
         deployment: { deploymentId: deployment.id },
-      });
-      return { deploymentId: res.data.deploymentId };
+      };
+      const res = await withIdempotencyKey(body, (idempotencyKey) =>
+        getUnkeyClient().deployments.createDeployment({
+          idempotencyKey,
+          v2DeploymentsCreateDeploymentRequestBody: body,
+        }),
+      );
+      return { deploymentId: res.result.data.deploymentId };
     },
     onSuccess: async (data) => {
       if (!currentDeployment) {

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/new/steps/deploy-action.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/new/steps/deploy-action.tsx
@@ -2,6 +2,7 @@
 
 import { useDeployActionGate } from "@/app/(app)/[workspaceSlug]/projects/_components/hooks/use-deploy-action-gate";
 import { queryClient } from "@/lib/collections/client";
+import { withIdempotencyKey } from "@/lib/idempotency";
 import { getErrorMessage, getUnkeyClient } from "@/lib/unkey-client";
 import { useMutation } from "@tanstack/react-query";
 import { Button, toast, useStepWizard } from "@unkey/ui";
@@ -29,14 +30,20 @@ export const DeployAction = ({
 
   const deploy = useMutation({
     mutationFn: async (environment: string) => {
-      const res = await getUnkeyClient().deployments.createDeployment({
+      const body = {
         project: projectId,
         app: appId,
         environment,
         // No branch or commitSha: the API builds the app's default branch.
         git: {},
-      });
-      return { deploymentId: res.data.deploymentId };
+      };
+      const res = await withIdempotencyKey(body, (idempotencyKey) =>
+        getUnkeyClient().deployments.createDeployment({
+          idempotencyKey,
+          v2DeploymentsCreateDeploymentRequestBody: body,
+        }),
+      );
+      return { deploymentId: res.result.data.deploymentId };
     },
     onSuccess: async (data) => {
       await queryClient.invalidateQueries({ queryKey: ["deployments", projectId] });

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/new/steps/deploy-image-card.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/new/steps/deploy-image-card.tsx
@@ -3,6 +3,7 @@
 import { useDeployActionGate } from "@/app/(app)/[workspaceSlug]/projects/_components/hooks/use-deploy-action-gate";
 import { useWorkspaceNavigation } from "@/hooks/use-workspace-navigation";
 import { queryClient } from "@/lib/collections/client";
+import { withIdempotencyKey } from "@/lib/idempotency";
 import { routes } from "@/lib/navigation/routes";
 import { trpc } from "@/lib/trpc/client";
 import { getErrorMessage, getUnkeyClient } from "@/lib/unkey-client";
@@ -40,13 +41,19 @@ export const DeployImageCard = ({
 
   const createDeployment = useMutation({
     mutationFn: async (source: { environment: string; image: string }) => {
-      const res = await getUnkeyClient().deployments.createDeployment({
+      const body = {
         project: projectId,
         app: appId,
         environment: source.environment,
         image: { dockerImage: source.image },
-      });
-      return { deploymentId: res.data.deploymentId };
+      };
+      const res = await withIdempotencyKey(body, (idempotencyKey) =>
+        getUnkeyClient().deployments.createDeployment({
+          idempotencyKey,
+          v2DeploymentsCreateDeploymentRequestBody: body,
+        }),
+      );
+      return { deploymentId: res.result.data.deploymentId };
     },
     async onSuccess(data) {
       await queryClient.invalidateQueries({ queryKey: ["deployments", projectId] });

--- a/web/apps/dashboard/app/proxy/[...path]/route.test.ts
+++ b/web/apps/dashboard/app/proxy/[...path]/route.test.ts
@@ -178,6 +178,29 @@ describe("dashboard proxy POST", () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
+  it("forwards the Idempotency-Key header to the upstream API", async () => {
+    // Upstream headers are rebuilt from an allowlist; losing this forward
+    // would silently disable deployment dedup for every dashboard deploy
+    // while everything else stays green.
+    mockedGetAuth.mockResolvedValue({
+      userId: "user_1",
+      orgId: "org_1",
+      accessToken: "workos_access_token",
+      role: "owner",
+    });
+
+    const res = await POST(
+      makeRequest({ accept: "application/json", "idempotency-key": "KEBAP-key" }),
+      { params },
+    );
+
+    expect(res.status).toBe(200);
+    expect(fetch).toHaveBeenCalledOnce();
+    const [, init] = vi.mocked(fetch).mock.calls[0];
+    const headers = new Headers(init?.headers);
+    expect(headers.get("idempotency-key")).toBe("KEBAP-key");
+  });
+
   it("keeps the upstream request pinned to the configured origin", async () => {
     mockedGetAuth.mockResolvedValue({
       userId: "user_1",

--- a/web/apps/dashboard/app/proxy/[...path]/route.ts
+++ b/web/apps/dashboard/app/proxy/[...path]/route.ts
@@ -121,6 +121,12 @@ function upstreamRequestHeaders(req: NextRequest): Headers {
   if (contentType) {
     headers.set("content-type", contentType);
   }
+  // Deduplicates deployment creates; the API reads it, so it must survive
+  // the allowlist rebuild.
+  const idempotencyKey = req.headers.get("idempotency-key");
+  if (idempotencyKey) {
+    headers.set("idempotency-key", idempotencyKey);
+  }
   // Identifies the caller to the API so it can attribute deployments to the
   // dashboard rather than to a generic API client.
   headers.set("x-unkey-client", "unkey-dashboard");

--- a/web/apps/dashboard/lib/idempotency.test.ts
+++ b/web/apps/dashboard/lib/idempotency.test.ts
@@ -1,0 +1,135 @@
+import * as errors from "@unkey/api/models/errors";
+import { beforeEach, describe, expect, it } from "vitest";
+import { withIdempotencyKey } from "./idempotency";
+
+function badRequest() {
+  return new errors.BadRequestErrorResponse(
+    {
+      meta: { requestId: "req_KEBAP" },
+      error: {
+        title: "Bad Request",
+        detail: "This Idempotency-Key belongs to a deployment that ended before its build started.",
+        status: 400,
+        type: "https://unkey.com/docs/errors/unkey/application/invalid_input",
+        errors: [],
+      },
+    },
+    {
+      response: new Response(null, { status: 400 }),
+      request: new Request("https://api.unkey.com/v2/deployments.createDeployment"),
+      body: "",
+    },
+  );
+}
+
+function serverError(status: number) {
+  return new errors.UnkeyError("upstream exploded", {
+    response: new Response(null, { status }),
+    request: new Request("https://api.unkey.com/v2/deployments.createDeployment"),
+    body: "",
+  });
+}
+
+// keyOf runs one request and reports the key it was sent with. When failWith
+// is set, the request throws it; withIdempotencyKey rethrows and the test only
+// needs the key.
+async function keyOf(body: unknown, failWith?: unknown): Promise<string> {
+  let sent = "";
+  try {
+    await withIdempotencyKey(body, async (key) => {
+      sent = key;
+      if (failWith !== undefined) {
+        throw failWith;
+      }
+      return "ok";
+    });
+  } catch {
+    // expected for failWith runs
+  }
+  return sent;
+}
+
+const deployBody = { app: "KEBAP", image: "nginx:1" };
+
+describe("withIdempotencyKey", () => {
+  // Keys persist in sessionStorage; isolate tests from each other.
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  // A 5xx or a dropped connection may still have created the deployment, and
+  // only the unchanged key brings it back instead of duplicating it.
+  it("reuses one key across retries of the same body", async () => {
+    const first = await keyOf(deployBody, new Error("network down"));
+    const second = await keyOf(deployBody, new Error("network down"));
+
+    expect(first).toBeTruthy();
+    expect(second).toBe(first);
+  });
+
+  // An edited resubmit is a new deployment intent. Keeping the old key would
+  // make the server replay the old deployment and silently drop the edit.
+  it("rotates when the body changes between attempts", async () => {
+    const first = await keyOf(deployBody, new Error("network down"));
+    const second = await keyOf({ ...deployBody, image: "nginx:2" }, new Error("network down"));
+
+    expect(second).not.toBe(first);
+  });
+
+  // Two in-flight intents must not clobber each other's keys: retrying the
+  // first body has to reuse the first key even after a different body ran.
+  it("keeps a separate key per in-flight body", async () => {
+    const otherBody = { ...deployBody, image: "nginx:2" };
+
+    const first = await keyOf(deployBody, new Error("network down"));
+    const other = await keyOf(otherBody, new Error("network down"));
+    const retry = await keyOf(deployBody, new Error("network down"));
+
+    expect(other).not.toBe(first);
+    expect(retry).toBe(first);
+  });
+
+  it("rotates after a settled success", async () => {
+    const first = await keyOf(deployBody);
+    const second = await keyOf(deployBody);
+
+    expect(second).not.toBe(first);
+  });
+
+  // A rejected request created nothing, so the key is free to discard. It
+  // also covers a key the API considers spent, which is the one error
+  // retrying with the same key can never clear.
+  it("rotates when the API rejected the request", async () => {
+    const first = await keyOf(deployBody, badRequest());
+    const second = await keyOf(deployBody, new Error("network down"));
+
+    expect(second).not.toBe(first);
+  });
+
+  it("returns the request's result and rethrows its error", async () => {
+    await expect(withIdempotencyKey(deployBody, async () => "KEBAP")).resolves.toBe("KEBAP");
+
+    const boom = new Error("KEBAP exploded");
+    await expect(withIdempotencyKey(deployBody, () => Promise.reject(boom))).rejects.toBe(boom);
+  });
+
+  // A 5xx is ambiguous: the deployment may exist, so only the same key can
+  // find it. Rotating here is exactly the duplicate this exists to stop.
+  it("keeps the key after a server error", async () => {
+    const first = await keyOf(deployBody, serverError(503));
+    const second = await keyOf(deployBody, new Error("network down"));
+
+    expect(second).toBe(first);
+  });
+
+  // The failed attempt is often retried after the page reloaded, which only
+  // storage survives: an in-memory key would forge a new one and duplicate
+  // the deployment the failure may have created.
+  it("holds the key in sessionStorage", async () => {
+    const key = await keyOf(deployBody, new Error("network down"));
+
+    expect(sessionStorage.getItem(`unkey:deploy-idempotency:${JSON.stringify(deployBody)}`)).toBe(
+      key,
+    );
+  });
+});

--- a/web/apps/dashboard/lib/idempotency.ts
+++ b/web/apps/dashboard/lib/idempotency.ts
@@ -1,0 +1,72 @@
+import { UnkeyError } from "@unkey/api/models/errors";
+
+/**
+ * Sends a deployment create with an Idempotency-Key so retries of one attempt
+ * (double click, network retry, resubmit after an error) deduplicate
+ * server-side.
+ *
+ * Retrying the same body reuses its key, because only the unchanged key can
+ * return a deployment the failed attempt may still have created. A changed
+ * body is a new deployment intent and gets its own key. A key is discarded
+ * after a settled success, and after any 4xx: a rejected request created
+ * nothing, and a spent key is the one error retrying the same key can never
+ * clear.
+ */
+export async function withIdempotencyKey<T>(
+  body: unknown,
+  request: (idempotencyKey: string) => Promise<T>,
+): Promise<T> {
+  const fingerprint = JSON.stringify(body) ?? "";
+  let key = readKey(fingerprint);
+  if (key === undefined) {
+    key = crypto.randomUUID();
+    writeKey(fingerprint, key);
+  }
+  try {
+    const result = await request(key);
+    clearKey(fingerprint);
+    return result;
+  } catch (error) {
+    if (error instanceof UnkeyError && error.statusCode >= 400 && error.statusCode < 500) {
+      clearKey(fingerprint);
+    }
+    throw error;
+  }
+}
+
+const storagePrefix = "unkey:deploy-idempotency:";
+
+// sessionStorage carries a held key across a reload between attempts. It
+// throws where site data is blocked (private mode), so keys fall back to a
+// page-scoped map, which still survives the dialog unmounting.
+const fallbackKeys = new Map<string, string>();
+
+function readKey(fingerprint: string): string | undefined {
+  try {
+    const key = sessionStorage.getItem(storagePrefix + fingerprint);
+    if (key !== null) {
+      return key;
+    }
+  } catch {
+    // fall through to the in-memory copy
+  }
+  return fallbackKeys.get(fingerprint);
+}
+
+function writeKey(fingerprint: string, key: string): void {
+  try {
+    sessionStorage.setItem(storagePrefix + fingerprint, key);
+    return;
+  } catch {
+    fallbackKeys.set(fingerprint, key);
+  }
+}
+
+function clearKey(fingerprint: string): void {
+  try {
+    sessionStorage.removeItem(storagePrefix + fingerprint);
+  } catch {
+    // a key that never reached storage lives in the map; delete below
+  }
+  fallbackKeys.delete(fingerprint);
+}


### PR DESCRIPTION
## What

Route every deployment create through `withIdempotencyKey`, so a double click, an SDK retry, or a resubmit after an error cannot create a second deployment.

- Keys are held per request body. Retrying the same body reuses its key, which is the only thing that can return a deployment an ambiguous failure may already have created. A changed body is a new intent and gets its own key.
- Keys live in `sessionStorage`, so a retry survives the dialog unmounting or the page reloading between attempts, with a page scoped map fallback where site data is blocked.
- A key is dropped after a settled success and after any 4xx (a rejected request created nothing, and a spent key is the one error retrying the same key can never clear). It is kept after a 5xx or a dropped connection.
- The dashboard proxy forwards the header, which its allowlist rebuild would otherwise strip.

Covers all five call sites: new deployment button, redeploy dialog, pending redeploy banner, and both onboarding deploy cards.

## Why keep the key on 5xx

The proxy aborts upstream at 10s (`AbortSignal.timeout`) and answers 502. A create that resolves a commit, inserts, and sends to Restate can exceed that while the API commits the row anyway. Rotating the key there is exactly the duplicate this exists to prevent.

## Deploy notes

Depends on #7163. Safe to deploy at any time: without the API change the header is ignored, so behavior is unchanged.

## Verification

- `vitest run lib/idempotency.test.ts` — 8 passing, covering key reuse across retries, rotation on body change, per-body isolation, rotation after success, rotation on 4xx, keep on 5xx, and storage survival.
- `tsc --noEmit` clean.
- Proxy route test pins the `idempotency-key` forward.

## Stack

1. #7162 — ctrl
2. #7163 — API
3. **this PR** — dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)