### PR TITLE
ci: enforce explicit database projections

### DIFF
--- a/.mise/tasks/lint
+++ b/.mise/tasks/lint
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #MISE description="Run Go lint checks"
-#MISE depends=["lint-sql-wildcards-test"]
+#MISE depends=["lint-sql-wildcards-test", "lint-sql-wildcards"]
 set -euo pipefail
 
 export GOLANGCI_LINT_CACHE="${PWD}/.cache/golangci-lint"


### PR DESCRIPTION
Actually run the wildcard linter when running our mise lint task