### PR TITLE
feat(ui): Slide Panel -> Base UI upgrade, button font weight change

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/[deploymentId]/network/unkey-flow/components/overlay/node-details-panel.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/[deploymentId]/network/unkey-flow/components/overlay/node-details-panel.tsx
@@ -1,6 +1,6 @@
 import { LastExitBadge } from "@/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/components/active-deployment-card";
 import { Layers3, TriangleWarning2 } from "@unkey/icons";
-import { SlidePanel, TimestampInfo } from "@unkey/ui";
+import { SlidePanel, SlidePanelContent, TimestampInfo } from "@unkey/ui";
 import { useDeployment } from "../../../../layout-provider";
 import { type DeploymentNode, type InstanceNode, isInstanceNode } from "../nodes/types";
 import { NodeDetailsPanelHeader } from "./node-details-panel/components/header";
@@ -92,20 +92,19 @@ export function NodeDetailsPanel({ node, deploymentId, onClose }: Props) {
   const isOpen = Boolean(node?.id) && node !== null && isInstanceNode(node);
 
   return (
-    <SlidePanel.Root
+    <SlidePanel
       isOpen={isOpen}
       onClose={onClose}
       side="right"
       widthClassName="w-[600px]"
-      backdrop={false}
-      topOffset={140}
+      backdrop="none"
       fitContent
     >
-      <SlidePanel.Content className="overflow-y-auto pb-6" stagger={false}>
+      <SlidePanelContent className="overflow-y-auto pb-6">
         {node && isInstanceNode(node) && (
           <InstanceNodeDetails node={node} deploymentId={deploymentId} onClose={onClose} />
         )}
-      </SlidePanel.Content>
-    </SlidePanel.Root>
+      </SlidePanelContent>
+    </SlidePanel>
   );
 }

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/env-vars/components/add/add-env-var-expandable.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/env-vars/components/add/add-env-var-expandable.tsx
@@ -9,7 +9,7 @@ import {
 } from "@/lib/collections/deploy/env-vars";
 import { getErrorMessage } from "@/lib/unkey-client";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { ChevronDown, CircleInfo, CloudUp, DoubleChevronRight, Plus } from "@unkey/icons";
+import { ChevronDown, CircleInfo, CloudUp, Plus } from "@unkey/icons";
 import {
   Button,
   InfoTooltip,
@@ -19,6 +19,11 @@ import {
   SelectTrigger,
   SelectValue,
   SlidePanel,
+  SlidePanelCloseButton,
+  SlidePanelContent,
+  SlidePanelDescription,
+  SlidePanelHeader,
+  SlidePanelTitle,
   toast,
 } from "@unkey/ui";
 import { cn } from "@unkey/ui/src/lib/utils";
@@ -34,7 +39,6 @@ import { trackSave } from "@/lib/collections/deploy/environment-settings";
 type AddEnvVarExpandableProps = {
   projectId: string;
   appId: string;
-  tableDistanceToTop: number;
   isOpen: boolean;
   onClose: () => void;
 };
@@ -42,7 +46,6 @@ type AddEnvVarExpandableProps = {
 export const AddEnvVarExpandable = ({
   projectId,
   appId,
-  tableDistanceToTop,
   isOpen,
   onClose,
 }: AddEnvVarExpandableProps) => {
@@ -224,28 +227,16 @@ export const AddEnvVarExpandable = ({
   };
 
   return (
-    <SlidePanel.Root isOpen={isOpen} onClose={onClose} topOffset={tableDistanceToTop}>
-      <SlidePanel.Header>
-        <div className="flex flex-col">
-          <span className="text-gray-12 font-medium text-base leading-8">
-            Add Environment Variable
-          </span>
-          <span className="text-gray-11 text-[13px] leading-5">
-            Set a key-value pair for your app.
-          </span>
+    <SlidePanel isOpen={isOpen} onClose={onClose}>
+      <SlidePanelHeader>
+        <div className="flex flex-col gap-0.5">
+          <SlidePanelTitle>Add Environment Variable</SlidePanelTitle>
+          <SlidePanelDescription>Set a key-value pair for your app.</SlidePanelDescription>
         </div>
-        <SlidePanel.Close
-          aria-label="Close panel"
-          className="mt-0.5 inline-flex items-center justify-center size-9 rounded-md hover:bg-grayA-3 transition-colors cursor-pointer"
-        >
-          <DoubleChevronRight
-            iconSize="lg-medium"
-            className="text-gray-10 transition-transform duration-300 ease-out group-hover:text-gray-12"
-          />
-        </SlidePanel.Close>
-      </SlidePanel.Header>
+        <SlidePanelCloseButton className="mt-0.5" />
+      </SlidePanelHeader>
 
-      <SlidePanel.Content>
+      <SlidePanelContent>
         <form
           ref={formRef}
           onSubmit={handleSubmit(onSubmit, onInvalid)}
@@ -282,8 +273,8 @@ export const AddEnvVarExpandable = ({
             </div>
           </div>
 
-          <div className="flex-1 overflow-y-auto pt-6 bg-grayA-2">
-            <div className="flex flex-col gap-4 px-8">
+          <div className="flex-1 overflow-y-auto pt-6">
+            <div className="flex flex-col gap-4 px-6">
               {fields.map((field, index) => (
                 <EnvVarRow
                   key={field.id}
@@ -300,7 +291,7 @@ export const AddEnvVarExpandable = ({
               ))}
             </div>
 
-            <div className="flex py-6 px-8">
+            <div className="flex py-6 px-6">
               <Button
                 type="button"
                 variant="outline"
@@ -315,7 +306,7 @@ export const AddEnvVarExpandable = ({
           </div>
 
           <div className="border-t border-grayA-4">
-            <div className="px-8 py-6 space-y-6">
+            <div className="px-6 py-6 space-y-6">
               <Controller
                 control={control}
                 name="environmentId"
@@ -380,7 +371,7 @@ export const AddEnvVarExpandable = ({
             </div>
           </div>
 
-          <div className="border-t border-gray-4 bg-white dark:bg-black px-8 py-5 flex items-center justify-between">
+          <div className="border-t border-gray-4 bg-white dark:bg-black px-6 py-5 flex items-center justify-between">
             <div className="hidden md:flex items-center gap-3">
               <input
                 ref={fileInputRef}
@@ -414,7 +405,7 @@ export const AddEnvVarExpandable = ({
             </Button>
           </div>
         </form>
-      </SlidePanel.Content>
-    </SlidePanel.Root>
+      </SlidePanelContent>
+    </SlidePanel>
   );
 };

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/env-vars/deployment-env-vars.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/env-vars/deployment-env-vars.tsx
@@ -14,10 +14,9 @@ import {
 type EnvVarsBodyProps = {
   isAddOpen: boolean;
   onCloseAdd: () => void;
-  panelTopOffset: number;
 };
 
-export function EnvVarsBody({ isAddOpen, onCloseAdd, panelTopOffset }: EnvVarsBodyProps) {
+export function EnvVarsBody({ isAddOpen, onCloseAdd }: EnvVarsBodyProps) {
   const { projectId, appId, environments } = useProjectData();
   const [searchQuery, setSearchQuery] = useState("");
   const [environmentFilter, setEnvironmentFilter] = useState<EnvironmentFilter>("all");
@@ -32,7 +31,6 @@ export function EnvVarsBody({ isAddOpen, onCloseAdd, panelTopOffset }: EnvVarsBo
       <AddEnvVarExpandable
         projectId={projectId}
         appId={appId}
-        tableDistanceToTop={panelTopOffset}
         isOpen={isAddOpen}
         onClose={onCloseAdd}
       />
@@ -68,11 +66,7 @@ export function DeploymentEnvVars() {
   return (
     <div className="flex flex-col gap-5">
       <EnvVarsHeader isAddOpen={isAddOpen} onToggleAdd={() => setIsAddOpen((prev) => !prev)} />
-      <EnvVarsBody
-        isAddOpen={isAddOpen}
-        onCloseAdd={() => setIsAddOpen(false)}
-        panelTopOffset={0}
-      />
+      <EnvVarsBody isAddOpen={isAddOpen} onCloseAdd={() => setIsAddOpen(false)} />
     </div>
   );
 }

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/env-vars/page.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/env-vars/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { TOP_NAV_HEIGHT } from "@/components/navigation/top-nav";
 import { Plus } from "@unkey/icons";
 import {
   Button,
@@ -39,11 +38,7 @@ export default function EnvVarsPage() {
         </PageHeaderActions>
       </PageHeader>
       <PageBody>
-        <EnvVarsBody
-          isAddOpen={isAddOpen}
-          onCloseAdd={() => setIsAddOpen(false)}
-          panelTopOffset={TOP_NAV_HEIGHT}
-        />
+        <EnvVarsBody isAddOpen={isAddOpen} onCloseAdd={() => setIsAddOpen(false)} />
       </PageBody>
     </PageContainer>
   );

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/policies/components/add-panel/index.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/policies/components/add-panel/index.tsx
@@ -31,7 +31,6 @@ type CommonProps = {
   productionSlug: string;
   previewSlug: string;
   isOpen: boolean;
-  topOffset: number;
   onClose: () => void;
   /**
    * `policyMatchKey` of every policy on the page. `mergePolicies` pairs the
@@ -56,7 +55,7 @@ type EditProps = CommonProps & {
 export type PolicyPanelProps = AddProps | EditProps;
 
 export function PolicyPanel(props: PolicyPanelProps) {
-  const { productionSlug, previewSlug, isOpen, topOffset, onClose, existingMatchKeys } = props;
+  const { productionSlug, previewSlug, isOpen, onClose, existingMatchKeys } = props;
   const isEdit = props.mode === "edit";
 
   const envOptions = [
@@ -119,7 +118,6 @@ export function PolicyPanel(props: PolicyPanelProps) {
         </div>
       }
       isOpen={isOpen}
-      topOffset={topOffset}
       onClose={onClose}
       form={form}
       onSubmit={onSubmit}
@@ -216,7 +214,7 @@ export function PolicyPanel(props: PolicyPanelProps) {
       </PolicyForm.Accordion>
       <PolicyForm.Footer>
         <div className="border-t border-grayA-4">
-          <div className="px-8 py-6">
+          <div className="px-6 py-6">
             <Controller
               control={control}
               name="environmentId"
@@ -236,7 +234,7 @@ export function PolicyPanel(props: PolicyPanelProps) {
           </div>
         </div>
 
-        <div className="border-t border-gray-4 bg-white dark:bg-black px-8 py-5 flex items-center justify-end">
+        <div className="border-t border-gray-4 bg-white dark:bg-black px-6 py-5 flex items-center justify-end">
           <Button type="submit" variant="primary" size="md" className="px-3">
             {isEdit ? "Save Changes" : "Add Policy"}
           </Button>

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/policies/components/add-panel/policy-form.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/policies/components/add-panel/policy-form.tsx
@@ -1,7 +1,15 @@
 "use client";
 
-import { ChevronDown, CircleInfo, DoubleChevronRight } from "@unkey/icons";
-import { InfoTooltip, SlidePanel } from "@unkey/ui";
+import { ChevronDown, CircleInfo } from "@unkey/icons";
+import {
+  InfoTooltip,
+  SlidePanel,
+  SlidePanelCloseButton,
+  SlidePanelContent,
+  SlidePanelDescription,
+  SlidePanelHeader,
+  SlidePanelTitle,
+} from "@unkey/ui";
 import { cn } from "@unkey/ui/src/lib/utils";
 import {
   Children,
@@ -25,7 +33,6 @@ type PolicyFormRootProps<T extends FieldValues> = {
   title: string;
   description: ReactNode;
   isOpen: boolean;
-  topOffset: number;
   onClose: () => void;
   form: UseFormReturn<T>;
   onSubmit: (values: T) => void;
@@ -45,7 +52,6 @@ function PolicyFormRoot<T extends FieldValues>({
   title,
   description,
   isOpen,
-  topOffset,
   onClose,
   form,
   onSubmit,
@@ -107,42 +113,34 @@ function PolicyFormRoot<T extends FieldValues>({
   );
 
   return (
-    <SlidePanel.Root isOpen={isOpen} onClose={onClose} topOffset={topOffset}>
-      <SlidePanel.Header>
-        <div className="flex flex-col">
-          <span className="text-gray-12 font-medium text-base leading-8">{title}</span>
-          <span className="text-gray-11 text-[13px] leading-5">{description}</span>
+    <SlidePanel isOpen={isOpen} onClose={onClose}>
+      <SlidePanelHeader>
+        <div className="flex flex-col gap-0.5">
+          <SlidePanelTitle>{title}</SlidePanelTitle>
+          <SlidePanelDescription>{description}</SlidePanelDescription>
         </div>
-        <SlidePanel.Close
-          aria-label="Close panel"
-          className="mt-0.5 inline-flex items-center justify-center size-9 rounded-md hover:bg-grayA-3 transition-colors cursor-pointer"
-        >
-          <DoubleChevronRight
-            iconSize="lg-medium"
-            className="text-gray-10 transition-transform duration-300 ease-out group-hover:text-gray-12"
-          />
-        </SlidePanel.Close>
-      </SlidePanel.Header>
+        <SlidePanelCloseButton className="mt-0.5" />
+      </SlidePanelHeader>
 
-      <SlidePanel.Content>
+      <SlidePanelContent>
         <PolicyFormContext.Provider value={ctxValue}>
           <FormProvider {...form}>
             <form
               onSubmit={form.handleSubmit(onSubmit, handleInvalid)}
               className="h-full flex flex-col"
             >
-              <div className="flex-1 overflow-y-auto pt-6 bg-grayA-2">{body}</div>
+              <div className="flex-1 overflow-y-auto pt-6">{body}</div>
               {footer}
             </form>
           </FormProvider>
         </PolicyFormContext.Provider>
-      </SlidePanel.Content>
-    </SlidePanel.Root>
+      </SlidePanelContent>
+    </SlidePanel>
   );
 }
 
 function Fields({ children }: { children: ReactNode }) {
-  return <div className="flex flex-col gap-5 px-8">{children}</div>;
+  return <div className="flex flex-col gap-5 px-6">{children}</div>;
 }
 
 function Accordion({
@@ -201,7 +199,7 @@ function Section({
         <button
           type="button"
           onClick={() => toggle(id)}
-          className="flex-1 min-w-0 px-8 py-3 flex items-center justify-between gap-4 cursor-pointer"
+          className="flex-1 min-w-0 px-6 py-3 flex items-center justify-between gap-4 cursor-pointer"
         >
           <span className="flex items-center gap-2 text-[13px] text-gray-11 font-medium">
             <ChevronDown
@@ -225,10 +223,10 @@ function Section({
           <span className="text-[12px] text-gray-11 truncate">{summary}</span>
         </button>
         {!isActive && collapsedAction && (
-          <div className="pr-8 shrink-0 flex items-center">{collapsedAction}</div>
+          <div className="pr-6 shrink-0 flex items-center">{collapsedAction}</div>
         )}
       </div>
-      {isActive && <div className="px-8 pb-6 pt-3">{children}</div>}
+      {isActive && <div className="px-6 pb-6 pt-3">{children}</div>}
     </div>
   );
 }

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/policies/page.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/policies/page.tsx
@@ -1,5 +1,4 @@
 "use client";
-import { TOP_NAV_HEIGHT } from "@/components/navigation/top-nav";
 import { policyMatchKey } from "@/lib/collections/deploy/policies.schema";
 import { Plus } from "@unkey/icons";
 import {
@@ -112,7 +111,6 @@ export default function PoliciesPage() {
           productionSlug={productionSlug}
           previewSlug={previewSlug}
           isOpen={panels.isAddPanelOpen}
-          topOffset={TOP_NAV_HEIGHT}
           onClose={panels.closeAdd}
           existingMatchKeys={existingMatchKeys}
           onSave={actions.save}
@@ -124,7 +122,6 @@ export default function PoliciesPage() {
             productionSlug={productionSlug}
             previewSlug={previewSlug}
             isOpen={panels.isEditPanelOpen}
-            topOffset={TOP_NAV_HEIGHT}
             onClose={panels.closeEdit}
             existingMatchKeys={existingMatchKeys}
             initialPolicy={editingPolicy}

--- a/web/apps/dashboard/styles/tailwind.css
+++ b/web/apps/dashboard/styles/tailwind.css
@@ -792,6 +792,6 @@ code .line::before {
 
 /* While a SlidePanel is open, lift Radix-portaled floating UI (tooltips,
    selects, popovers) above the panel (z-51) so they aren't clipped behind it. */
-body[data-slide-panel-open] [data-radix-popper-content-wrapper] {
+body:has([data-slide-panel-open]) [data-radix-popper-content-wrapper] {
   z-index: 60 !important;
 }

--- a/web/internal/ui/src/components/buttons/button.tsx
+++ b/web/internal/ui/src/components/buttons/button.tsx
@@ -66,14 +66,14 @@ export type DocumentedButtonProps = VariantProps<typeof buttonVariants> & {
 };
 
 const buttonVariants = cva(
-  "inline-flex group relative duration-150 items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm transition-colors focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 disabled:cursor-not-allowed cursor-pointer",
+  "inline-flex group relative duration-150 items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-normal transition-colors focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 disabled:cursor-not-allowed cursor-pointer",
   {
     variants: {
       variant: {
         default: "", // This is only required for mapping from default -> primary. We rely on this for type generation because CVA types are hard to mutate.
         destructive: "", // This is only required for mapping from destructive-> danger. We rely on this for type generation because CVA types are hard to mutate.
         primary: [
-          "p-2 text-white dark:text-black bg-accent-12 hover:bg-accent-12/90 focus:hover:bg-accent-12 rounded-md font-medium border border-grayA-4",
+          "p-2 text-white dark:text-black bg-accent-12 hover:bg-accent-12/90 focus:hover:bg-accent-12 rounded-md border border-grayA-4",
           "focus:ring-3 focus:ring-gray-5 focus-visible:outline-hidden focus:ring-offset-0 drop-shadow-button transform-gpu",
           "disabled:border disabled:border-solid disabled:bg-grayA-6 disabled:border-grayA-4 disabled:text-white/85 dark:disabled:text-white/85",
           "active:bg-accent-12/80",
@@ -123,7 +123,7 @@ const buttonVariants = cva(
         variant: "primary",
         color: "danger",
         className: [
-          "dark:text-white/95 bg-error-9 hover:bg-error-10 rounded-md font-medium focus:hover:bg-error-10 ",
+          "dark:text-white/95 bg-error-9 hover:bg-error-10 rounded-md focus:hover:bg-error-10 ",
           "focus:border-error-11 focus:ring-3 focus:ring-error-4 focus-visible:outline-hidden focus:ring-offset-0",
           "disabled:bg-error-6 disabled:text-white/80  dark:disabled:text-white/80",
           "active:bg-error-11",
@@ -133,7 +133,7 @@ const buttonVariants = cva(
         variant: "outline",
         color: "danger",
         className: [
-          "text-error-11 bg-background border border-grayA-6 hover:bg-grayA-2 font-medium focus:hover:bg-background",
+          "text-error-11 bg-background border border-grayA-6 hover:bg-grayA-2 focus:hover:bg-background",
           "focus:border-error-11 focus:ring-3 focus:ring-error-4 focus-visible:outline-hidden focus:ring-offset-0",
           "disabled:text-errorA-7 disabled:border-grayA-5",
           "active:bg-error-3",
@@ -154,7 +154,7 @@ const buttonVariants = cva(
         variant: "primary",
         color: "warning",
         className: [
-          "dark:text-white/95 bg-warning-8 hover:bg-warning-8/90 rounded-md font-medium focus:hover:bg-warning-8/90",
+          "dark:text-white/95 bg-warning-8 hover:bg-warning-8/90 rounded-md focus:hover:bg-warning-8/90",
           "focus:border-warning-11 focus:ring-3 focus:ring-warning-4 focus-visible:outline-hidden focus:ring-offset-0",
           "disabled:bg-warning-7 disabled:text-white/80  dark:disabled:text-white/80",
           "active:bg-warning-9",
@@ -164,7 +164,7 @@ const buttonVariants = cva(
         variant: "outline",
         color: "warning",
         className: [
-          "text-warningA-11 bg-background border border-grayA-6 hover:bg-grayA-2 font-medium focus:hover:bg-background",
+          "text-warningA-11 bg-background border border-grayA-6 hover:bg-grayA-2 focus:hover:bg-background",
           "focus:border-warning-11 focus:ring-3 focus:ring-warning-4 focus-visible:outline-hidden focus:ring-offset-0",
           "disabled:text-warningA-7 disabled:border-grayA-5",
           "active:bg-warning-3",
@@ -185,7 +185,7 @@ const buttonVariants = cva(
         variant: "primary",
         color: "success",
         className: [
-          "dark:text-white/95 bg-success-9 hover:bg-success-10 rounded-md font-medium focus:hover:bg-success-10",
+          "dark:text-white/95 bg-success-9 hover:bg-success-10 rounded-md focus:hover:bg-success-10",
           "focus:border-success-11 focus:ring-3 focus:ring-success-4 focus-visible:outline-hidden focus:ring-offset-0",
           "disabled:bg-success-7 disabled:text-white/80  dark:disabled:text-white/80",
           "active:bg-success-11",
@@ -195,7 +195,7 @@ const buttonVariants = cva(
         variant: "outline",
         color: "success",
         className: [
-          "text-success-11 bg-background border border-grayA-6 hover:bg-grayA-2 font-medium focus:hover:bg-background",
+          "text-success-11 bg-background border border-grayA-6 hover:bg-grayA-2 focus:hover:bg-background",
           "focus:border-success-11 focus:ring-3 focus:ring-success-4 focus-visible:outline-hidden focus:ring-offset-0",
           "disabled:text-successA-7 disabled:border-grayA-5",
           "active:bg-success-3",
@@ -217,7 +217,7 @@ const buttonVariants = cva(
         variant: "primary",
         color: "info",
         className: [
-          "dark:text-white/95 bg-info-9 hover:bg-info-10 rounded-md font-medium focus:hover:bg-info-10",
+          "dark:text-white/95 bg-info-9 hover:bg-info-10 rounded-md focus:hover:bg-info-10",
           "focus:border-info-11 focus:ring-3 focus:ring-info-4 focus-visible:outline-hidden focus:ring-offset-0",
           "disabled:bg-info-7 disabled:text-white/80  dark:disabled:text-white/80",
           "active:bg-info-11",
@@ -227,7 +227,7 @@ const buttonVariants = cva(
         variant: "outline",
         color: "info",
         className: [
-          "text-info-11 bg-background border border-grayA-6 hover:bg-grayA-2 font-medium focus:hover:bg-background",
+          "text-info-11 bg-background border border-grayA-6 hover:bg-grayA-2 focus:hover:bg-background",
           "focus:border-info-11 focus:ring-3 focus:ring-info-4 focus-visible:outline-hidden focus:ring-offset-0",
           "disabled:text-infoA-7 disabled:border-grayA-5",
           "active:bg-info-3",

--- a/web/internal/ui/src/components/slide-panel.tsx
+++ b/web/internal/ui/src/components/slide-panel.tsx
@@ -1,235 +1,167 @@
 "use client";
 
-import * as React from "react";
-import { createPortal } from "react-dom";
-import { createContext } from "../lib/create-context";
+import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
+import { XMark } from "@unkey/icons";
+import type * as React from "react";
 import { cn } from "../lib/utils";
 
-type SlidePanelContextValue = {
-  isOpen: boolean;
-  onClose: () => void;
-};
+type SlidePanelBackdrop = "blur" | "dim" | "none";
 
-const [SlidePanelProvider, useSlidePanelContext] =
-  createContext<SlidePanelContextValue>("SlidePanel");
-
-type SlidePanelRootProps = {
+export type SlidePanelProps = {
   children: React.ReactNode;
   isOpen: boolean;
   onClose: () => void;
+  onExitComplete?: () => void;
   side?: "left" | "right";
-  topOffset?: number;
   widthClassName?: string;
   className?: string;
-  backdrop?: boolean | "blur" | "dim";
+  backdrop?: SlidePanelBackdrop;
   fitContent?: boolean;
 };
 
-const SlidePanelRoot = ({
+export function SlidePanel({
   children,
   isOpen,
   onClose,
+  onExitComplete,
   side = "right",
-  topOffset = 0,
   widthClassName = "w-175",
   className,
   backdrop = "blur",
   fitContent = false,
-}: SlidePanelRootProps) => {
-  React.useEffect(
-    function closeOnEscape() {
-      if (!isOpen) {
-        return;
-      }
-      const handler = (e: KeyboardEvent) => {
-        if (e.key === "Escape") {
+}: SlidePanelProps) {
+  return (
+    <DialogPrimitive.Root
+      open={isOpen}
+      modal={false}
+      disablePointerDismissal
+      onOpenChange={(open) => {
+        if (!open) {
           onClose();
         }
-      };
-      document.addEventListener("keydown", handler);
-      return () => document.removeEventListener("keydown", handler);
-    },
-    [isOpen, onClose],
-  );
-
-  React.useEffect(
-    function markBodyWhileOpen() {
-      if (!isOpen) {
-        return;
-      }
-      // Signal to global CSS that a SlidePanel is open so portaled
-      // floating UI (tooltips) can be lifted above the panel.
-      // Reference-counted to handle nested/sibling panels correctly.
-      const prev = document.body.dataset.slidePanelOpen;
-      const count = prev ? Number.parseInt(prev, 10) + 1 : 1;
-      document.body.dataset.slidePanelOpen = String(count);
-      return () => {
-        const next = Number.parseInt(document.body.dataset.slidePanelOpen ?? "1", 10) - 1;
-        if (next <= 0) {
-          delete document.body.dataset.slidePanelOpen;
-        } else {
-          document.body.dataset.slidePanelOpen = String(next);
+      }}
+      onOpenChangeComplete={(open) => {
+        if (!open) {
+          onExitComplete?.();
         }
-      };
-    },
-    [isOpen],
-  );
-
-  const panel = (
-    <SlidePanelProvider isOpen={isOpen} onClose={onClose}>
-      {/* Backdrop */}
-      {backdrop !== false && (
-        // biome-ignore lint/a11y/useKeyWithClickEvents: backdrop dismiss doesn't need keyboard equivalent
-        <div
-          className={cn(
-            "fixed inset-0 z-50 transition-opacity duration-300",
-            backdrop === "blur" && "bg-background/5",
-            backdrop === "dim" && "bg-background/20",
-            backdrop === true && "bg-background/5",
-            isOpen
-              ? cn("opacity-100", backdrop === "blur" && "backdrop-blur-[2px]")
-              : "opacity-0 pointer-events-none",
-          )}
-          onClick={onClose}
-          aria-hidden="true"
-        />
-      )}
-      {/* Panel */}
-      <div
-        aria-hidden={!isOpen}
-        inert={!isOpen || undefined}
-        className={cn(
-          "fixed dark:bg-black bg-white border border-gray-4 rounded-xl overflow-hidden z-51",
-          "transition-transform duration-350 ease-[cubic-bezier(0.32,0.72,0,1)]",
-          "shadow-md",
-          "flex flex-col",
-          side === "right" ? "right-3" : "left-3",
-          isOpen
-            ? "translate-x-0"
-            : side === "right"
-              ? "translate-x-[calc(100%+0.75rem)]"
-              : "-translate-x-[calc(100%+0.75rem)]",
-          widthClassName,
-          className,
-        )}
-        style={{
-          top: `${topOffset + 12}px`,
-          ...(fitContent
-            ? { maxHeight: `calc(100vh - ${topOffset + 24}px)` }
-            : { height: `calc(100vh - ${topOffset + 24}px)` }),
-          willChange: isOpen ? "transform, opacity" : "auto",
-        }}
-      >
-        {children}
-      </div>
-    </SlidePanelProvider>
-  );
-
-  return createPortal(panel, document.body);
-};
-
-SlidePanelRoot.displayName = "SlidePanelRoot";
-
-type SlidePanelHeaderProps = {
-  children: React.ReactNode;
-  className?: string;
-};
-
-const SlidePanelHeader = ({ children, className }: SlidePanelHeaderProps) => (
-  <div
-    className={cn(
-      "flex items-start justify-between border-b border-gray-4 px-8 py-5 bg-white dark:bg-black ",
-      className,
-    )}
-  >
-    {children}
-  </div>
-);
-
-SlidePanelHeader.displayName = "SlidePanelHeader";
-
-type SlidePanelContentProps = {
-  children: React.ReactNode;
-  className?: string;
-  stagger?: boolean;
-  staggerDelay?: number;
-};
-
-const SlidePanelContent = ({
-  children,
-  className,
-  stagger = true,
-  staggerDelay = 150,
-}: SlidePanelContentProps) => {
-  const { isOpen } = useSlidePanelContext("SlidePanelContent");
-
-  return (
-    <div
-      className={cn(
-        "flex-1 min-h-0",
-        stagger && "transition-[transform,opacity] duration-500 ease-out",
-        stagger && (isOpen ? "translate-x-0 opacity-100" : "translate-x-6 opacity-0"),
-        className,
-      )}
-      style={stagger ? { transitionDelay: isOpen ? `${staggerDelay}ms` : "0ms" } : undefined}
+      }}
     >
+      <DialogPrimitive.Portal>
+        {backdrop !== "none" && (
+          <DialogPrimitive.Backdrop
+            onClick={onClose}
+            className={cn(
+              "fixed inset-0 z-50 transition-opacity duration-300 ease-[cubic-bezier(0.4,0,0.2,1)] motion-reduce:transition-none",
+              "data-starting-style:opacity-0 data-ending-style:opacity-0",
+              backdrop === "blur" ? "bg-background/5 backdrop-blur-[2px]" : "bg-background/20",
+            )}
+          />
+        )}
+        <DialogPrimitive.Popup
+          data-slide-panel-open=""
+          className={cn(
+            "[--slide-panel-inset:0.75rem] [--slide-panel-radius:0.75rem]",
+            "fixed z-51 flex flex-col p-px shadow-lg",
+            "rounded-(--slide-panel-radius) bg-grayA-4",
+            "top-(--slide-panel-inset) bottom-(--slide-panel-inset)",
+            "max-w-[calc(100dvw_-_var(--slide-panel-inset)_*_2)]",
+            side === "right" ? "right-(--slide-panel-inset)" : "left-(--slide-panel-inset)",
+            fitContent && "bottom-auto max-h-[calc(100dvh_-_var(--slide-panel-inset)_*_2)]",
+            "transition-[opacity,translate] duration-200 ease-[cubic-bezier(0.4,0,0.2,1)] motion-reduce:transition-none",
+            "data-starting-style:opacity-0 data-ending-style:opacity-0",
+            side === "right"
+              ? "data-starting-style:translate-x-5 data-ending-style:translate-x-10"
+              : "data-starting-style:-translate-x-5 data-ending-style:-translate-x-10",
+            widthClassName,
+            className,
+          )}
+        >
+          <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-[calc(var(--slide-panel-radius)_-_1px)] bg-background">
+            {children}
+          </div>
+        </DialogPrimitive.Popup>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+}
+
+export type SlidePanelHeaderProps = {
+  children: React.ReactNode;
+  className?: string;
+};
+
+export function SlidePanelHeader({ children, className }: SlidePanelHeaderProps) {
+  return (
+    <div className={cn("flex items-start justify-between px-6 pt-6 pb-2", className)}>
       {children}
     </div>
   );
+}
+
+export type SlidePanelTitleProps = DialogPrimitive.Title.Props & {
+  ref?: React.Ref<HTMLHeadingElement>;
 };
 
-SlidePanelContent.displayName = "SlidePanelContent";
+export function SlidePanelTitle({ className, ...props }: SlidePanelTitleProps) {
+  return (
+    <DialogPrimitive.Title
+      className={cn(
+        "text-[18px] font-semibold leading-tight tracking-tight text-gray-12",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
 
-type SlidePanelFooterProps = {
+export type SlidePanelDescriptionProps = DialogPrimitive.Description.Props & {
+  ref?: React.Ref<HTMLParagraphElement>;
+};
+
+export function SlidePanelDescription({ className, ...props }: SlidePanelDescriptionProps) {
+  return (
+    <DialogPrimitive.Description
+      className={cn("text-[13px] leading-5 text-gray-11", className)}
+      {...props}
+    />
+  );
+}
+
+export type SlidePanelContentProps = {
   children: React.ReactNode;
   className?: string;
 };
 
-const SlidePanelFooter = ({ children, className }: SlidePanelFooterProps) => (
-  <div className={cn("bg-white dark:bg-black border-t border-gray-4 px-8 py-5", className)}>
-    {children}
-  </div>
-);
+export function SlidePanelContent({ children, className }: SlidePanelContentProps) {
+  return <div className={cn("min-h-0 flex-1", className)}>{children}</div>;
+}
 
-SlidePanelFooter.displayName = "SlidePanelFooter";
-
-type SlidePanelCloseProps = React.ComponentPropsWithoutRef<"button">;
-
-const SlidePanelClose = React.forwardRef<HTMLButtonElement, SlidePanelCloseProps>(
-  ({ onClick, ...props }, ref) => {
-    const { onClose } = useSlidePanelContext("SlidePanelClose");
-
-    const handleClick = React.useCallback(
-      (e: React.MouseEvent<HTMLButtonElement>) => {
-        onClick?.(e);
-        if (!e.defaultPrevented) {
-          onClose();
-        }
-      },
-      [onClick, onClose],
-    );
-
-    return <button ref={ref} type="button" {...props} onClick={handleClick} />;
-  },
-);
-
-SlidePanelClose.displayName = "SlidePanelClose";
-
-export const SlidePanel = Object.assign(
-  {},
-  {
-    Root: SlidePanelRoot,
-    Header: SlidePanelHeader,
-    Content: SlidePanelContent,
-    Footer: SlidePanelFooter,
-    Close: SlidePanelClose,
-  },
-);
-
-export type {
-  SlidePanelRootProps,
-  SlidePanelHeaderProps,
-  SlidePanelContentProps,
-  SlidePanelFooterProps,
-  SlidePanelCloseProps,
+export type SlidePanelFooterProps = {
+  children: React.ReactNode;
+  className?: string;
 };
+
+export function SlidePanelFooter({ children, className }: SlidePanelFooterProps) {
+  return <div className={cn("border-t border-gray-4 px-6 py-4", className)}>{children}</div>;
+}
+
+export type SlidePanelCloseButtonProps = DialogPrimitive.Close.Props & {
+  ref?: React.Ref<HTMLButtonElement>;
+};
+
+export function SlidePanelCloseButton({ className, ...props }: SlidePanelCloseButtonProps) {
+  return (
+    <DialogPrimitive.Close
+      aria-label="Close panel"
+      className={cn(
+        "inline-flex size-9 shrink-0 cursor-pointer items-center justify-center rounded-md text-gray-10 transition-colors hover:bg-grayA-3 hover:text-gray-12",
+        className,
+      )}
+      {...props}
+    >
+      <XMark iconSize="lg-medium" />
+    </DialogPrimitive.Close>
+  );
+}
+
+export type { SlidePanelBackdrop };


### PR DESCRIPTION
## What does this PR do?

I have rebuilt the SlidePanel on the Base UI Dialog, and redesigned it a bit. Please lmk if you disagree with any of the design choices.

I've also made a sneaky change to the button component in this PR, I noticed that our buttons are inconsistently using `font-medium` for some cases, so i've removed that and all buttons now use `font-normal` instead. 

## Screenshots

**App policies — add policy panel (light)**

<img width="3120" height="1800" alt="10-app-policies-add-policy-panel-light" src="https://github.com/user-attachments/assets/b630e9bc-7138-4590-bf53-77246fc6fa11" />

**App policies — add policy panel (dark)**

<img width="3120" height="1800" alt="10-app-policies-add-policy-panel-dark" src="https://github.com/user-attachments/assets/85466dee-e239-43dc-9816-830abf68c7d2" />

**Env vars panel (light)**

<img width="3120" height="1800" alt="11-env-vars-panel-light" src="https://github.com/user-attachments/assets/cf6c723c-43c3-4caf-9513-d7d70374942e" />

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

Open any panel consumer — app policies Add Policy, env-vars Add variable, the deployment network node panel. Check: floating card geometry, enter/exit motion (the slide never actually rendered before — Tailwind v4 puts translate on its own property, so `transition-transform` silently only faded), escape/backdrop close, selects and tooltips inside the panel render above it and don't dismiss it, focus moves into the panel on open and restores on close. Untested: nothing known; the node panel deliberately keeps `backdrop="none"`.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary


