### PR TITLE
feat(dashboard): Accept URN permissions on the root-key write path

### DIFF
--- a/pkg/mysql/schema/permissions.sql
+++ b/pkg/mysql/schema/permissions.sql
@@ -4,7 +4,7 @@ CREATE TABLE `permissions` (
 	`workspace_id` varchar(48) COLLATE utf8mb4_0900_as_cs NOT NULL,
 	`project_id` varchar(48) COLLATE utf8mb4_0900_as_cs NOT NULL,
 	`name` varchar(512) NOT NULL,
-	`slug` varchar(128) NOT NULL,
+	`slug` varchar(512) NOT NULL,
 	`description` varchar(512),
 	`created_at_m` bigint NOT NULL DEFAULT 0,
 	`updated_at_m` bigint,

--- a/web/apps/dashboard/lib/trpc/routers/key/createRootKey.ts
+++ b/web/apps/dashboard/lib/trpc/routers/key/createRootKey.ts
@@ -4,23 +4,25 @@ import { env } from "@/lib/env";
 import { TRPCError } from "@trpc/server";
 import { newId } from "@unkey/id";
 import { newKey } from "@unkey/keys";
-import { unkeyPermissionValidation } from "@unkey/rbac";
+import { permissionValidation } from "@unkey/rbac";
 import { z } from "zod";
 import { workspaceProcedure } from "../../trpc";
 
 import { insertAuditLogs } from "@/lib/audit";
-import { upsertPermissions } from "../rbac";
+import { assertPermissionsBelongToWorkspace, upsertPermissions } from "../rbac";
 
 export const createRootKey = workspaceProcedure
   .input(
     z.object({
       name: z.string().optional(),
-      permissions: z.array(unkeyPermissionValidation).min(1, {
+      permissions: z.array(permissionValidation).min(1, {
         error: "You need to add at least one permissions.",
       }),
     }),
   )
   .mutation(async ({ ctx, input }) => {
+    assertPermissionsBelongToWorkspace(input.permissions, ctx.workspace.id);
+
     const unkeyApi = await db.query.apis
       .findFirst({
         where: (table, { and, eq }) =>
@@ -96,6 +98,7 @@ export const createRootKey = workspaceProcedure
         });
 
         const { permissions, auditLogs: createPermissionLogs } = await upsertPermissions(
+          tx,
           ctx,
           env().UNKEY_WORKSPACE_ID,
           input.permissions,

--- a/web/apps/dashboard/lib/trpc/routers/key/updateRootKeyPermissions.ts
+++ b/web/apps/dashboard/lib/trpc/routers/key/updateRootKeyPermissions.ts
@@ -1,13 +1,13 @@
 import type { UnkeyAuditLog } from "@/lib/audit";
 import { and, db, eq, inArray, schema } from "@/lib/db";
 import { TRPCError } from "@trpc/server";
-import { unkeyPermissionValidation } from "@unkey/rbac";
+import { permissionValidation } from "@unkey/rbac";
 import { z } from "zod";
 import { workspaceProcedure } from "../../trpc";
 
 import { insertAuditLogs } from "@/lib/audit";
 import { env } from "@/lib/env";
-import { upsertPermissions } from "../rbac";
+import { assertPermissionsBelongToWorkspace, upsertPermissions } from "../rbac";
 
 /**
  * Replaces the full permission set for the root key — clients must submit the complete,
@@ -17,12 +17,14 @@ export const updateRootKeyPermissions = workspaceProcedure
   .input(
     z.object({
       keyId: z.string(),
-      permissions: z.array(unkeyPermissionValidation).min(1, {
+      permissions: z.array(permissionValidation).min(1, {
         error: "You need to add at least one permission.",
       }),
     }),
   )
   .mutation(async ({ ctx, input }) => {
+    assertPermissionsBelongToWorkspace(input.permissions, ctx.workspace.id);
+
     // Verify the key exists and belongs to the workspace
     const key = await db.query.keys
       .findFirst({
@@ -70,7 +72,7 @@ export const updateRootKeyPermissions = workspaceProcedure
 
         // Upsert new permissions
         const { permissions: upsertedPermissions, auditLogs: createPermissionLogs } =
-          await upsertPermissions(ctx, env().UNKEY_WORKSPACE_ID, input.permissions);
+          await upsertPermissions(tx, ctx, env().UNKEY_WORKSPACE_ID, input.permissions);
 
         auditLogs.push(...createPermissionLogs);
 

--- a/web/apps/dashboard/lib/trpc/routers/rbac.ts
+++ b/web/apps/dashboard/lib/trpc/routers/rbac.ts
@@ -1,81 +1,105 @@
-import { type InsertPermission, type Permission, db, schema } from "@/lib/db";
+import { type InsertPermission, type Permission, type Transaction, schema } from "@/lib/db";
 
 import type { UnkeyAuditLog } from "@/lib/audit";
 import { ensureDefaultProjectId } from "@/lib/projects/ensure-default-project-id";
 import { TRPCError } from "@trpc/server";
 import { newId } from "@unkey/id";
+import { urnPermissionWorkspaceId } from "@unkey/rbac";
 import type { Context } from "../context";
 
+export function assertPermissionsBelongToWorkspace(permissions: string[], workspaceId: string) {
+  const foreignPermissions = permissions.filter((permission) => {
+    const permissionWorkspaceId = urnPermissionWorkspaceId(permission);
+    return permissionWorkspaceId !== null && permissionWorkspaceId !== workspaceId;
+  });
+  if (foreignPermissions.length > 0) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: `These permissions are scoped to another workspace than ${workspaceId}: ${foreignPermissions.join(", ")}`,
+    });
+  }
+}
+
 export async function upsertPermissions(
+  tx: Transaction,
   ctx: Context,
   workspaceId: string,
-  slugs: string[],
+  permissionStrings: string[],
 ): Promise<{
   permissions: Omit<Permission, "pk">[];
   auditLogs: UnkeyAuditLog[];
 }> {
-  return await db.transaction(async (tx) => {
-    const projectId = await ensureDefaultProjectId(tx, workspaceId);
-    const existingPermissions = await tx.query.permissions.findMany({
-      where: (table, { inArray, and, eq }) =>
-        and(eq(table.workspaceId, workspaceId), inArray(table.slug, slugs)),
+  const userId = ctx.user?.id;
+  if (!userId) {
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "UserId not found",
     });
+  }
 
-    const newPermissions: InsertPermission[] = [];
-    const auditLogs: UnkeyAuditLog[] = [];
-
-    const userId = ctx.user?.id;
-    if (!userId) {
-      throw new TRPCError({
-        code: "NOT_FOUND",
-        message: "UserId not found",
-      });
+  // The unique index on (workspace_id, slug) is case insensitive, so "Api.x.read"
+  // and "api.x.read" in one request have to collapse to a single row.
+  const slugByLowercase = new Map<string, string>();
+  for (const permissionString of permissionStrings) {
+    const lowercase = permissionString.toLowerCase();
+    if (!slugByLowercase.has(lowercase)) {
+      slugByLowercase.set(lowercase, permissionString);
     }
+  }
+  const slugs = Array.from(slugByLowercase.values());
 
-    const permissions: Omit<Permission, "pk">[] = slugs.map((slug) => {
-      const existingPermission = existingPermissions.find((p) => p.slug === slug);
-
-      if (existingPermission) {
-        return existingPermission;
-      }
-
-      const permission = {
-        id: newId("permission"),
-        workspaceId,
-        projectId,
-        name: slug,
-        slug: slug,
-        description: null,
-        updatedAtM: null,
-        createdAtM: Date.now(),
-      };
-
-      newPermissions.push(permission);
-      auditLogs.push({
-        workspaceId,
-        actor: { type: "user", id: userId },
-        event: "permission.create",
-        description: `Created ${permission.id}`,
-        resources: [
-          {
-            type: "permission",
-            id: permission.id,
-            name: permission.slug,
-          },
-        ],
-        context: {
-          location: ctx.audit.location,
-          userAgent: ctx.audit.userAgent,
-        },
-      });
-
-      return permission;
-    });
-
-    if (newPermissions.length) {
-      await tx.insert(schema.permissions).values(newPermissions);
-    }
-
-    return { permissions, auditLogs };
+  const projectId = await ensureDefaultProjectId(tx, workspaceId);
+  const existingPermissions = await tx.query.permissions.findMany({
+    where: (table, { inArray, and, eq }) =>
+      and(eq(table.workspaceId, workspaceId), inArray(table.slug, slugs)),
   });
+  const existingBySlug = new Map(existingPermissions.map((p) => [p.slug.toLowerCase(), p]));
+
+  const newPermissions: InsertPermission[] = [];
+  const auditLogs: UnkeyAuditLog[] = [];
+
+  const permissions: Omit<Permission, "pk">[] = slugs.map((slug) => {
+    const existingPermission = existingBySlug.get(slug.toLowerCase());
+    if (existingPermission) {
+      return existingPermission;
+    }
+
+    const permission = {
+      id: newId("permission"),
+      workspaceId,
+      projectId,
+      name: slug,
+      slug,
+      description: null,
+      updatedAtM: null,
+      createdAtM: Date.now(),
+    };
+
+    newPermissions.push(permission);
+    auditLogs.push({
+      workspaceId,
+      actor: { type: "user", id: userId },
+      event: "permission.create",
+      description: `Created ${permission.id}`,
+      resources: [
+        {
+          type: "permission",
+          id: permission.id,
+          name: permission.slug,
+        },
+      ],
+      context: {
+        location: ctx.audit.location,
+        userAgent: ctx.audit.userAgent,
+      },
+    });
+
+    return permission;
+  });
+
+  if (newPermissions.length) {
+    await tx.insert(schema.permissions).values(newPermissions);
+  }
+
+  return { permissions, auditLogs };
 }

--- a/web/apps/dashboard/lib/trpc/routers/rbac/upsertPermission.ts
+++ b/web/apps/dashboard/lib/trpc/routers/rbac/upsertPermission.ts
@@ -14,7 +14,7 @@ export async function upsertPermission(
     const existingPermission = await tx.query.permissions
       .findFirst({
         where: (table, { eq, and }) =>
-          and(eq(table.name, name), eq(table.workspaceId, workspaceId)),
+          and(eq(table.slug, name), eq(table.workspaceId, workspaceId)),
         with: {
           workspace: {
             columns: { id: true },

--- a/web/internal/db/src/schema/rbac.ts
+++ b/web/internal/db/src/schema/rbac.ts
@@ -14,7 +14,7 @@ export const permissions = mysqlTable(
     workspaceId: id("workspace_id").notNull(),
     projectId: id("project_id").notNull(),
     name: caseInsensitiveVarchar("name", { length: 512 }).notNull(),
-    slug: varchar("slug", { length: 128 }).notNull(),
+    slug: varchar("slug", { length: 512 }).notNull(),
     description: varchar("description", { length: 512 }),
     createdAtM: bigint("created_at_m", { mode: "number" })
       .notNull()

--- a/web/internal/rbac/src/permissions.test.ts
+++ b/web/internal/rbac/src/permissions.test.ts
@@ -1,10 +1,54 @@
 import { describe, expect, test } from "vitest";
 import {
+  PERMISSION_MAX_LENGTH,
   buildIdSchema,
+  permissionValidation,
   portalActions,
   ratelimitActions,
   unkeyPermissionValidation,
+  urnPermissionWorkspaceId,
+  workosPermissionDefinitions,
 } from "./permissions";
+import urnGrammarCases from "./urn-grammar.fixture.json";
+
+function firstError(input: unknown): string | undefined {
+  const result = permissionValidation.safeParse(input);
+  return result.success ? undefined : result.error.issues[0]?.message;
+}
+
+const ws = "ws_12345678";
+
+const idByParameter: Record<string, string> = {
+  app_id: "app_12345678",
+  deployment_id: "deploy_12345678",
+  domain_id: "domain_12345678",
+  environment_id: "env_12345678",
+  github_app_id: "123456",
+  identity_id: "id_12345678",
+  key_id: "key_12345678",
+  keyspace_id: "ks_12345678",
+  namespace_id: "rlns_12345678",
+  override_id: "ro_12345678",
+  permission_id: "perm_12345678",
+  policy_id: "pol_12345678",
+  project_id: "proj_12345678",
+  role_id: "role_12345678",
+  variable_id: "var_12345678",
+};
+
+function concretePath(path: string): string {
+  return path.replace(/\{([^}]+)\}/g, (_match, parameter: string) => {
+    const id = idByParameter[parameter];
+    if (id === undefined) {
+      throw new Error(`no test id for ${parameter}`);
+    }
+    return id;
+  });
+}
+
+const canonicalPermissions = workosPermissionDefinitions.map(
+  (definition) => `unkey:v1:${ws}:${concretePath(definition.path)}#${definition.action}`,
+);
 
 describe("apiIdSchema", () => {
   const testCases = [
@@ -69,5 +113,210 @@ describe("portal permissions", () => {
       "delete_portal",
       "create_portal_session",
     ]);
+  });
+});
+
+describe("legacy permission validation", () => {
+  test("does not throw on non-string input", () => {
+    expect(() => unkeyPermissionValidation.safeParse(42)).not.toThrow();
+    expect(unkeyPermissionValidation.safeParse(42).success).toBe(false);
+    expect(unkeyPermissionValidation.safeParse(undefined).success).toBe(false);
+  });
+
+  test("accepts the legacy wildcard", () => {
+    expect(unkeyPermissionValidation.safeParse("*").success).toBe(true);
+  });
+});
+
+// The fixture states the grammar alone, in step with pkg/urn. Whether an action
+// belongs on a path is the catalog's business, so these cases drive the grammar
+// parser rather than `permissionValidation`, which asks both questions at once.
+describe("urn grammar", () => {
+  for (const { input, valid, reason } of urnGrammarCases) {
+    test(`${valid ? "accepts" : "rejects"} ${input} (${reason})`, () => {
+      expect(urnPermissionWorkspaceId(input) !== null).toBe(valid);
+    });
+  }
+
+  test("rejects non-string input", () => {
+    expect(permissionValidation.safeParse(42).success).toBe(false);
+  });
+});
+
+describe("permission catalog", () => {
+  test("lists the WorkOS slugs the model grants", () => {
+    expect(workosPermissionDefinitions.map((definition) => definition.slug)).toEqual([
+      "admin:*",
+      "apps:delete",
+      "apps:read",
+      "apps:write",
+      "deployment_logs:read",
+      "deployments:delete",
+      "deployments:read",
+      "deployments:write",
+      "domains:delete",
+      "domains:read",
+      "domains:write",
+      "environment_variables:delete",
+      "environment_variables:read",
+      "environment_variables:write",
+      "environments:delete",
+      "environments:read",
+      "environments:write",
+      "gateway_logs:read",
+      "gateway_policies:delete",
+      "gateway_policies:read",
+      "gateway_policies:write",
+      "github_apps:delete",
+      "github_apps:read",
+      "github_apps:write",
+      "identities:delete",
+      "identities:read",
+      "identities:write",
+      "keys:decrypt",
+      "keys:delete",
+      "keys:read",
+      "keys:verify",
+      "keys:write",
+      "keyspace_logs:read",
+      "keyspaces:delete",
+      "keyspaces:read",
+      "keyspaces:write",
+      "permissions:delete",
+      "permissions:read",
+      "permissions:write",
+      "projects:delete",
+      "projects:read",
+      "projects:write",
+      "ratelimit_logs:read",
+      "ratelimit_namespaces:delete",
+      "ratelimit_namespaces:limit",
+      "ratelimit_namespaces:read",
+      "ratelimit_namespaces:write",
+      "ratelimit_overrides:delete",
+      "ratelimit_overrides:read",
+      "ratelimit_overrides:write",
+      "roles:delete",
+      "roles:read",
+      "roles:write",
+    ]);
+  });
+
+  test("accepts every canonical permission", () => {
+    for (const permission of canonicalPermissions) {
+      expect(permissionValidation.safeParse(permission).success).toBe(true);
+    }
+  });
+
+  test("accepts wildcards from the leaf upwards", () => {
+    const accepted = [
+      `unkey:v1:${ws}:projects/*#read_project`,
+      `unkey:v1:${ws}:projects/*/apps/*#read_app`,
+      `unkey:v1:${ws}:projects/proj_12345678/apps/*#read_app`,
+      `unkey:v1:${ws}:projects/*/keyspaces/*/keys/*#verify_key`,
+      `unkey:v1:${ws}:projects/proj_12345678/keyspaces/ks_12345678/keys/*#decrypt_key`,
+      `unkey:v1:${ws}:**#*`,
+    ];
+
+    for (const permission of accepted) {
+      expect(permissionValidation.safeParse(permission).success).toBe(true);
+    }
+  });
+
+  test("rejects paths, actions and wildcard shapes outside the catalog", () => {
+    const rejected = [
+      // A wildcard parent cannot carry a concrete child.
+      `unkey:v1:${ws}:projects/*/apps/app_12345678#read_app`,
+      `unkey:v1:${ws}:projects/*/keyspaces/ks_12345678#read_keyspace`,
+      // Actions the model collapsed into write, or never had.
+      `unkey:v1:${ws}:projects/proj_12345678/apps/app_12345678/environments/env_12345678/deployments/deploy_12345678#start_deployment`,
+      `unkey:v1:${ws}:projects/proj_12345678/apps/app_12345678/environments/env_12345678/deployments/deploy_12345678#promote_deployment`,
+      `unkey:v1:${ws}:projects/proj_12345678/keyspaces/ks_12345678/keys/key_12345678#create_key`,
+      `unkey:v1:${ws}:projects/proj_12345678/keyspaces/ks_12345678/keys/key_12345678#encrypt_key`,
+      // Paths that lost their project scope or gained a segment.
+      `unkey:v1:${ws}:keyspaces/ks_12345678#read_keyspace`,
+      `unkey:v1:${ws}:identities/id_12345678#read_identity`,
+      `unkey:v1:${ws}:projects/proj_12345678/github/apps/123456#read_github_app`,
+      `unkey:v1:${ws}:projects/proj_12345678/rbac#write_role`,
+      // Right path, wrong action for it.
+      `unkey:v1:${ws}:projects/proj_12345678/keyspaces/ks_12345678/logs#write_keyspace`,
+      // "**" only carries the admin action.
+      `unkey:v1:${ws}:projects/proj_12345678/**#read_keyspace`,
+      `unkey:v1:${ws}:**#read_key`,
+    ];
+
+    for (const permission of rejected) {
+      expect(permissionValidation.safeParse(permission).success).toBe(false);
+    }
+  });
+
+  test("names the action and the path it was refused on", () => {
+    expect(firstError(`unkey:v1:${ws}:projects/proj_12345678#read_keyspace`)).toBe(
+      '"read_keyspace" is not an action on "projects/proj_12345678". See the permission catalog in @unkey/rbac.',
+    );
+  });
+});
+
+describe("urnPermissionWorkspaceId", () => {
+  test("returns the workspace of a urn permission", () => {
+    expect(urnPermissionWorkspaceId("unkey:v1:ws_123:keyspaces/ks_1#read_key")).toBe("ws_123");
+    expect(urnPermissionWorkspaceId("unkey:v1:ws_456:**#*")).toBe("ws_456");
+  });
+
+  test("returns null for anything that is not a urn permission", () => {
+    expect(urnPermissionWorkspaceId("api.api_123.read_api")).toBeNull();
+    expect(urnPermissionWorkspaceId("*")).toBeNull();
+    expect(urnPermissionWorkspaceId("unkey:v1:ws_123:keyspaces/ks_1")).toBeNull();
+  });
+});
+
+describe("permissionValidation", () => {
+  test("accepts both grammars", () => {
+    expect(permissionValidation.safeParse("api.api_12345678.read_api").success).toBe(true);
+    expect(permissionValidation.safeParse("*").success).toBe(true);
+    expect(permissionValidation.safeParse(`unkey:v1:${ws}:projects/*#read_project`).success).toBe(
+      true,
+    );
+  });
+
+  test("rejects strings longer than the slug column", () => {
+    const permission = `unkey:v1:ws_123:keyspaces/${"a".repeat(PERMISSION_MAX_LENGTH)}#read_key`;
+    expect(firstError(permission)).toBe(
+      `Permission must be at most ${PERMISSION_MAX_LENGTH} characters.`,
+    );
+  });
+
+  test("reports the urn grammar rule that failed", () => {
+    expect(firstError("unkey:v1:ws_123:keyspaces/ks_1")).toBe(
+      'Permission must contain exactly one "#" action separator.',
+    );
+    expect(firstError("unkey:v1:ws_123:**/keys/key_1#read_key")).toBe(
+      '"**" must be the last resource path segment.',
+    );
+    expect(firstError("unkey:v1:ws_123:keyspaces/ks_1#read_")).toBe(
+      'Action must not start or end with "_".',
+    );
+    expect(firstError("unkey:v1:ws_123:keyspaces/ks_1#*")).toBe(
+      'Action "*" requires the global resource path "**".',
+    );
+  });
+
+  test("reports the legacy grammar rule that failed", () => {
+    expect(firstError("api.api_12345678")).toBe(
+      'Permission must be a "unkey:v1:<workspace_id>:<resource_path>#<action>" URN or a legacy "resource.id.action" tuple.',
+    );
+    expect(firstError("keyspace.ks_12345678.read_key")).toContain('Unknown resource "keyspace".');
+    expect(firstError("api.nope.read_api")).toContain('Invalid id "nope" for resource "api".');
+    expect(firstError("api.api_12345678.fly")).toContain(
+      'Unknown action "fly" for resource "api".',
+    );
+  });
+
+  test("reports one issue, not a union of two", () => {
+    const result = permissionValidation.safeParse("unkey:v1:ws_123:keyspaces/ks_1#*");
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues).toHaveLength(1);
+    }
   });
 });

--- a/web/internal/rbac/src/permissions.ts
+++ b/web/internal/rbac/src/permissions.ts
@@ -152,30 +152,458 @@ export type Resources = {
 };
 
 export type UnkeyPermission = Flatten<Resources> | "*";
+
+export type UnkeyUrnPermission = `unkey:v1:${string}:${string}#${string}`;
+
+export const PERMISSION_MAX_LENGTH = 512;
+
+// The URN vocabulary: every resource path a root key can name, the action it
+// carries there, and the WorkOS slug that stands for the same grant on a user.
+// A URN permission is only meaningful if it appears here, so this list — not
+// the grammar — decides what the write path accepts.
+//
+// Mutations collapse into `write_<resource>`: create and update are the same
+// privilege, and a deployment start, stop, promote or rollback is a write of
+// that deployment. Delete stays apart because it destroys, and keys keep
+// `verify` and `decrypt` because both are narrower than reading a key.
+export const workosPermissionDefinitions = [
+  { slug: "admin:*", path: "**", action: "*" },
+  { slug: "apps:delete", path: "projects/{project_id}/apps/{app_id}", action: "delete_app" },
+  { slug: "apps:read", path: "projects/{project_id}/apps/{app_id}", action: "read_app" },
+  { slug: "apps:write", path: "projects/{project_id}/apps/{app_id}", action: "write_app" },
+  {
+    slug: "deployment_logs:read",
+    path: "projects/{project_id}/apps/{app_id}/environments/{environment_id}/deployments/{deployment_id}/logs",
+    action: "read_deployment_logs",
+  },
+  {
+    slug: "deployments:delete",
+    path: "projects/{project_id}/apps/{app_id}/environments/{environment_id}/deployments/{deployment_id}",
+    action: "delete_deployment",
+  },
+  {
+    slug: "deployments:read",
+    path: "projects/{project_id}/apps/{app_id}/environments/{environment_id}/deployments/{deployment_id}",
+    action: "read_deployment",
+  },
+  {
+    slug: "deployments:write",
+    path: "projects/{project_id}/apps/{app_id}/environments/{environment_id}/deployments/{deployment_id}",
+    action: "write_deployment",
+  },
+  {
+    slug: "domains:delete",
+    path: "projects/{project_id}/apps/{app_id}/environments/{environment_id}/domains/{domain_id}",
+    action: "delete_domain",
+  },
+  {
+    slug: "domains:read",
+    path: "projects/{project_id}/apps/{app_id}/environments/{environment_id}/domains/{domain_id}",
+    action: "read_domain",
+  },
+  {
+    slug: "domains:write",
+    path: "projects/{project_id}/apps/{app_id}/environments/{environment_id}/domains/{domain_id}",
+    action: "write_domain",
+  },
+  {
+    slug: "environment_variables:delete",
+    path: "projects/{project_id}/apps/{app_id}/environments/{environment_id}/variables/{variable_id}",
+    action: "delete_environment_variable",
+  },
+  {
+    slug: "environment_variables:read",
+    path: "projects/{project_id}/apps/{app_id}/environments/{environment_id}/variables/{variable_id}",
+    action: "read_environment_variable",
+  },
+  {
+    slug: "environment_variables:write",
+    path: "projects/{project_id}/apps/{app_id}/environments/{environment_id}/variables/{variable_id}",
+    action: "write_environment_variable",
+  },
+  {
+    slug: "environments:delete",
+    path: "projects/{project_id}/apps/{app_id}/environments/{environment_id}",
+    action: "delete_environment",
+  },
+  {
+    slug: "environments:read",
+    path: "projects/{project_id}/apps/{app_id}/environments/{environment_id}",
+    action: "read_environment",
+  },
+  {
+    slug: "environments:write",
+    path: "projects/{project_id}/apps/{app_id}/environments/{environment_id}",
+    action: "write_environment",
+  },
+  {
+    slug: "gateway_logs:read",
+    path: "projects/{project_id}/apps/{app_id}/environments/{environment_id}/gateway/logs",
+    action: "read_gateway_logs",
+  },
+  {
+    slug: "gateway_policies:delete",
+    path: "projects/{project_id}/apps/{app_id}/environments/{environment_id}/gateway/policies/{policy_id}",
+    action: "delete_gateway_policy",
+  },
+  {
+    slug: "gateway_policies:read",
+    path: "projects/{project_id}/apps/{app_id}/environments/{environment_id}/gateway/policies/{policy_id}",
+    action: "read_gateway_policy",
+  },
+  {
+    slug: "gateway_policies:write",
+    path: "projects/{project_id}/apps/{app_id}/environments/{environment_id}/gateway/policies/{policy_id}",
+    action: "write_gateway_policy",
+  },
+  { slug: "github_apps:delete", path: "github/apps/{github_app_id}", action: "delete_github_app" },
+  { slug: "github_apps:read", path: "github/apps/{github_app_id}", action: "read_github_app" },
+  { slug: "github_apps:write", path: "github/apps/{github_app_id}", action: "write_github_app" },
+  {
+    slug: "identities:delete",
+    path: "projects/{project_id}/identities/{identity_id}",
+    action: "delete_identity",
+  },
+  {
+    slug: "identities:read",
+    path: "projects/{project_id}/identities/{identity_id}",
+    action: "read_identity",
+  },
+  {
+    slug: "identities:write",
+    path: "projects/{project_id}/identities/{identity_id}",
+    action: "write_identity",
+  },
+  {
+    slug: "keys:decrypt",
+    path: "projects/{project_id}/keyspaces/{keyspace_id}/keys/{key_id}",
+    action: "decrypt_key",
+  },
+  {
+    slug: "keys:delete",
+    path: "projects/{project_id}/keyspaces/{keyspace_id}/keys/{key_id}",
+    action: "delete_key",
+  },
+  {
+    slug: "keys:read",
+    path: "projects/{project_id}/keyspaces/{keyspace_id}/keys/{key_id}",
+    action: "read_key",
+  },
+  {
+    slug: "keys:verify",
+    path: "projects/{project_id}/keyspaces/{keyspace_id}/keys/{key_id}",
+    action: "verify_key",
+  },
+  {
+    slug: "keys:write",
+    path: "projects/{project_id}/keyspaces/{keyspace_id}/keys/{key_id}",
+    action: "write_key",
+  },
+  {
+    slug: "keyspace_logs:read",
+    path: "projects/{project_id}/keyspaces/{keyspace_id}/logs",
+    action: "read_keyspace_logs",
+  },
+  {
+    slug: "keyspaces:delete",
+    path: "projects/{project_id}/keyspaces/{keyspace_id}",
+    action: "delete_keyspace",
+  },
+  {
+    slug: "keyspaces:read",
+    path: "projects/{project_id}/keyspaces/{keyspace_id}",
+    action: "read_keyspace",
+  },
+  {
+    slug: "keyspaces:write",
+    path: "projects/{project_id}/keyspaces/{keyspace_id}",
+    action: "write_keyspace",
+  },
+  {
+    slug: "permissions:delete",
+    path: "projects/{project_id}/rbac/permissions/{permission_id}",
+    action: "delete_permission",
+  },
+  {
+    slug: "permissions:read",
+    path: "projects/{project_id}/rbac/permissions/{permission_id}",
+    action: "read_permission",
+  },
+  {
+    slug: "permissions:write",
+    path: "projects/{project_id}/rbac/permissions/{permission_id}",
+    action: "write_permission",
+  },
+  { slug: "projects:delete", path: "projects/{project_id}", action: "delete_project" },
+  { slug: "projects:read", path: "projects/{project_id}", action: "read_project" },
+  { slug: "projects:write", path: "projects/{project_id}", action: "write_project" },
+  {
+    slug: "ratelimit_logs:read",
+    path: "projects/{project_id}/ratelimits/namespaces/{namespace_id}/logs",
+    action: "read_ratelimit_logs",
+  },
+  {
+    slug: "ratelimit_namespaces:delete",
+    path: "projects/{project_id}/ratelimits/namespaces/{namespace_id}",
+    action: "delete_ratelimit_namespace",
+  },
+  {
+    slug: "ratelimit_namespaces:limit",
+    path: "projects/{project_id}/ratelimits/namespaces/{namespace_id}",
+    action: "limit_ratelimit_namespace",
+  },
+  {
+    slug: "ratelimit_namespaces:read",
+    path: "projects/{project_id}/ratelimits/namespaces/{namespace_id}",
+    action: "read_ratelimit_namespace",
+  },
+  {
+    slug: "ratelimit_namespaces:write",
+    path: "projects/{project_id}/ratelimits/namespaces/{namespace_id}",
+    action: "write_ratelimit_namespace",
+  },
+  {
+    slug: "ratelimit_overrides:delete",
+    path: "projects/{project_id}/ratelimits/namespaces/{namespace_id}/overrides/{override_id}",
+    action: "delete_ratelimit_override",
+  },
+  {
+    slug: "ratelimit_overrides:read",
+    path: "projects/{project_id}/ratelimits/namespaces/{namespace_id}/overrides/{override_id}",
+    action: "read_ratelimit_override",
+  },
+  {
+    slug: "ratelimit_overrides:write",
+    path: "projects/{project_id}/ratelimits/namespaces/{namespace_id}/overrides/{override_id}",
+    action: "write_ratelimit_override",
+  },
+  {
+    slug: "roles:delete",
+    path: "projects/{project_id}/rbac/roles/{role_id}",
+    action: "delete_role",
+  },
+  { slug: "roles:read", path: "projects/{project_id}/rbac/roles/{role_id}", action: "read_role" },
+  {
+    slug: "roles:write",
+    path: "projects/{project_id}/rbac/roles/{role_id}",
+    action: "write_role",
+  },
+] as const;
+
+export type WorkosPermissionSlug = (typeof workosPermissionDefinitions)[number]["slug"];
+
+export type CatalogAction = (typeof workosPermissionDefinitions)[number]["action"];
+
+function legacyPermissionError(value: string): string | null {
+  if (value === "*") {
+    return null;
+  }
+  const parts = value.split(".");
+  if (parts.length !== 3) {
+    return 'Permission must be a "unkey:v1:<workspace_id>:<resource_path>#<action>" URN or a legacy "resource.id.action" tuple.';
+  }
+  const [resource, id, action] = parts;
+  const resourceConfig = scopedResources[resource as keyof typeof scopedResources];
+  if (!resourceConfig) {
+    return `Unknown resource "${resource}". Expected one of: ${Object.keys(scopedResources).join(", ")}.`;
+  }
+  if (!resourceConfig.idSchema.safeParse(id).success) {
+    return `Invalid id "${id}" for resource "${resource}". Expected "*" or an id of the resource.`;
+  }
+  if (!resourceConfig.actionsSchema.safeParse(action).success) {
+    return `Unknown action "${action}" for resource "${resource}". Expected one of: ${resourceConfig.actionsSchema.options.join(", ")}.`;
+  }
+  return null;
+}
+
 /**
  * Validation for roles used for our root keys
  */
-export const unkeyPermissionValidation = z.custom<UnkeyPermission>().refine((s) => {
-  z.string().parse(s);
-  if (s === "*") {
-    /**
-     * This is a legacy role granting access to everything
-     */
-    return true;
-  }
-  const split = s.split(".");
+export const unkeyPermissionValidation = z
+  .custom<UnkeyPermission>()
+  .refine((s) => typeof s === "string" && legacyPermissionError(s) === null);
 
-  // Handle scoped resource.id.action format (3 parts)
-  if (split.length !== 3) {
+const urnPrefix = "unkey";
+const urnVersion = "v1";
+const urnPermissionPrefix = `${urnPrefix}:${urnVersion}:`;
+const globalResourcePath = "**";
+
+type UrnPermissionParseResult =
+  | { ok: true; workspaceId: string; resourcePath: string; action: string }
+  | { ok: false; error: string };
+
+// validateWorkspaceId, validateResourcePath and validatePermissionAction mirror
+// the helpers of the same name in pkg/urn/urn.go and pkg/rbac/urn.go. The
+// reserved characters below cannot survive the field split, but the rule is
+// stated so both grammars read the same.
+function validateWorkspaceId(value: string): string | null {
+  if (value.length === 0) {
+    return "Workspace id must not be empty.";
+  }
+  if (/[:#/]/.test(value)) {
+    return 'Workspace id must not contain ":", "#" or "/".';
+  }
+  return null;
+}
+
+function validateResourcePath(resourcePath: string): string | null {
+  const segments = resourcePath.split("/");
+  for (const [index, segment] of segments.entries()) {
+    if (segment.length === 0) {
+      return "Resource path must not contain empty segments.";
+    }
+    if (/[:#]/.test(segment)) {
+      return 'Resource path segments must not contain ":" or "#".';
+    }
+    if (segment === "*") {
+      continue;
+    }
+    if (segment === globalResourcePath) {
+      if (index !== segments.length - 1) {
+        return '"**" must be the last resource path segment.';
+      }
+      continue;
+    }
+    if (segment.includes("*")) {
+      return '"*" must be a whole resource path segment.';
+    }
+  }
+  return null;
+}
+
+function validatePermissionAction(action: string): string | null {
+  if (action === "*") {
+    return null;
+  }
+  if (action.length === 0) {
+    return "Action must not be empty.";
+  }
+  if (/[:#/*]/.test(action)) {
+    return 'Action must not contain ":", "#", "/" or "*".';
+  }
+  if (action.startsWith("_") || action.endsWith("_")) {
+    return 'Action must not start or end with "_".';
+  }
+  return null;
+}
+
+function parseUrnPermission(value: string): UrnPermissionParseResult {
+  const [resource, action, ...extra] = value.split("#");
+  if (action === undefined || extra.length > 0) {
+    return { ok: false, error: 'Permission must contain exactly one "#" action separator.' };
+  }
+
+  const fields = resource.split(":");
+  if (fields.length < 4) {
+    return {
+      ok: false,
+      error: 'Permission URN must read "unkey:v1:<workspace_id>:<resource_path>".',
+    };
+  }
+  const [prefix, version, urnWorkspaceId] = fields;
+  const resourcePath = fields.slice(3).join(":");
+
+  if (prefix !== urnPrefix) {
+    return { ok: false, error: `Permission URN prefix must be "${urnPrefix}".` };
+  }
+  if (version !== urnVersion) {
+    return { ok: false, error: `Permission URN version must be "${urnVersion}".` };
+  }
+
+  const workspaceError = validateWorkspaceId(urnWorkspaceId);
+  if (workspaceError) {
+    return { ok: false, error: workspaceError };
+  }
+  const resourcePathError = validateResourcePath(resourcePath);
+  if (resourcePathError) {
+    return { ok: false, error: resourcePathError };
+  }
+  const actionError = validatePermissionAction(action);
+  if (actionError) {
+    return { ok: false, error: actionError };
+  }
+  if (action === "*" && resourcePath !== globalResourcePath) {
+    return {
+      ok: false,
+      error: `Action "*" requires the global resource path "${globalResourcePath}".`,
+    };
+  }
+
+  return { ok: true, workspaceId: urnWorkspaceId, resourcePath, action };
+}
+
+const isParameterSegment = (segment: string): boolean =>
+  segment.startsWith("{") && segment.endsWith("}");
+
+// A catalog path matches a resource path segment for segment. Literal segments
+// must be spelled out; parameter segments take an id or "*". Wildcards are
+// prefix-closed: once a parent id is "*" every id below it must be "*" too,
+// because "the app in every project" names no app anyone can point at.
+function catalogPathMatches(pattern: string, resourcePath: string): boolean {
+  if (pattern === globalResourcePath) {
+    return resourcePath === globalResourcePath;
+  }
+  const patternSegments = pattern.split("/");
+  const resourceSegments = resourcePath.split("/");
+  if (patternSegments.length !== resourceSegments.length) {
     return false;
   }
-  const [resource, id, action] = split;
-  const resourceConfig = scopedResources[resource as keyof typeof scopedResources];
-  if (resourceConfig) {
-    return (
-      resourceConfig.idSchema.safeParse(id).success &&
-      resourceConfig.actionsSchema.safeParse(action).success
-    );
-  }
-  return false;
-});
+  let wildcardSeen = false;
+  return patternSegments.every((patternSegment, index) => {
+    const resourceSegment = resourceSegments[index];
+    if (resourceSegment === undefined || resourceSegment === globalResourcePath) {
+      return false;
+    }
+    if (!isParameterSegment(patternSegment)) {
+      return patternSegment === resourceSegment;
+    }
+    if (resourceSegment === "*") {
+      wildcardSeen = true;
+      return true;
+    }
+    return !wildcardSeen;
+  });
+}
+
+export function catalogPermissionError(resourcePath: string, action: string): string | null {
+  const known = workosPermissionDefinitions.some(
+    (definition) =>
+      definition.action === action && catalogPathMatches(definition.path, resourcePath),
+  );
+  return known
+    ? null
+    : `"${action}" is not an action on "${resourcePath}". See the permission catalog in @unkey/rbac.`;
+}
+
+export function isCatalogPermission(value: string): boolean {
+  const result = parseUrnPermission(value);
+  return result.ok && catalogPermissionError(result.resourcePath, result.action) === null;
+}
+
+// Grammar first, then vocabulary: a URN can be well formed and still name a
+// privilege that does not exist.
+function urnPermissionError(value: string): string | null {
+  const result = parseUrnPermission(value);
+  return result.ok ? catalogPermissionError(result.resourcePath, result.action) : result.error;
+}
+
+export function urnPermissionWorkspaceId(value: string): string | null {
+  const result = parseUrnPermission(value);
+  return result.ok ? result.workspaceId : null;
+}
+
+// Branching on the URN prefix rather than unioning two schemas keeps the error
+// specific to the grammar the caller was reaching for.
+export const permissionValidation = z
+  .string()
+  .max(PERMISSION_MAX_LENGTH, {
+    error: `Permission must be at most ${PERMISSION_MAX_LENGTH} characters.`,
+  })
+  .superRefine((value, ctx) => {
+    const error = value.startsWith(urnPermissionPrefix)
+      ? urnPermissionError(value)
+      : legacyPermissionError(value);
+    if (error) {
+      ctx.addIssue({ code: "custom", message: error });
+    }
+  });

--- a/web/internal/rbac/src/urn-grammar.fixture.json
+++ b/web/internal/rbac/src/urn-grammar.fixture.json
@@ -1,0 +1,172 @@
+[
+  {
+    "input": "unkey:v1:ws_123:keyspaces/ks_123#read_keyspace",
+    "valid": true,
+    "reason": "concrete resource path and action"
+  },
+  {
+    "input": "unkey:v1:ws_123:keyspaces/ks_123/keys/key_456#delete_key",
+    "valid": true,
+    "reason": "nested resource path"
+  },
+  {
+    "input": "unkey:v1:ws_123:keyspaces/*/keys/*#read_key",
+    "valid": true,
+    "reason": "\"*\" as a whole segment, once per segment"
+  },
+  {
+    "input": "unkey:v1:ws_123:keyspaces/*#write_keyspace",
+    "valid": true,
+    "reason": "\"*\" as the final segment"
+  },
+  {
+    "input": "unkey:v1:ws_123:ratelimits/**#write_ratelimit_override",
+    "valid": true,
+    "reason": "\"**\" as the final segment"
+  },
+  {
+    "input": "unkey:v1:ws_123:projects/proj_123/apps/app_456/environments/env_789/deployments/**#read_deployment",
+    "valid": true,
+    "reason": "\"**\" below a deep concrete path"
+  },
+  {
+    "input": "unkey:v1:ws_123:**#read_key",
+    "valid": true,
+    "reason": "global resource path with a concrete action"
+  },
+  {
+    "input": "unkey:v1:ws_123:**#*",
+    "valid": true,
+    "reason": "action wildcard on the global resource path"
+  },
+  {
+    "input": "unkey:v1:ws_123:keyspaces/ks_123#read_remaining_key",
+    "valid": true,
+    "reason": "underscores inside an action"
+  },
+  {
+    "input": "api.api_123.read_api",
+    "valid": false,
+    "reason": "legacy tuple, not a URN"
+  },
+  {
+    "input": "unkey:v1:ws_123:keyspaces/ks_123",
+    "valid": false,
+    "reason": "missing the action separator"
+  },
+  {
+    "input": "unkey:v1:ws_123:keyspaces/ks_123#read#key",
+    "valid": false,
+    "reason": "two action separators"
+  },
+  {
+    "input": "unkey:v1:ws_123#read_key",
+    "valid": false,
+    "reason": "missing the resource path field"
+  },
+  {
+    "input": "aws:v1:ws_123:keyspaces/ks_123#read_keyspace",
+    "valid": false,
+    "reason": "wrong URN prefix"
+  },
+  {
+    "input": "unkey:v2:ws_123:keyspaces/ks_123#read_keyspace",
+    "valid": false,
+    "reason": "wrong URN version"
+  },
+  {
+    "input": "unkey:v1::keyspaces/ks_123#read_keyspace",
+    "valid": false,
+    "reason": "empty workspace id"
+  },
+  {
+    "input": "unkey:v1:ws/123:keyspaces/ks_123#read_keyspace",
+    "valid": false,
+    "reason": "\"/\" in the workspace id"
+  },
+  {
+    "input": "unkey:v1:ws:123:keyspaces/ks_123#read_keyspace",
+    "valid": false,
+    "reason": "\":\" in the workspace id"
+  },
+  {
+    "input": "unkey:v1:ws_123:#read_keyspace",
+    "valid": false,
+    "reason": "empty resource path"
+  },
+  {
+    "input": "unkey:v1:ws_123:keyspaces//ks_123#read_key",
+    "valid": false,
+    "reason": "empty resource path segment"
+  },
+  {
+    "input": "unkey:v1:ws_123:/keyspaces/ks_123#read_key",
+    "valid": false,
+    "reason": "leading \"/\" in the resource path"
+  },
+  {
+    "input": "unkey:v1:ws_123:keyspaces/ks_123/#read_key",
+    "valid": false,
+    "reason": "trailing \"/\" in the resource path"
+  },
+  {
+    "input": "unkey:v1:ws_123:keyspaces/ks:1#read_key",
+    "valid": false,
+    "reason": "\":\" in a resource path segment"
+  },
+  {
+    "input": "unkey:v1:ws_123:keyspaces/ks_*#read_key",
+    "valid": false,
+    "reason": "\"*\" inside a resource path segment"
+  },
+  {
+    "input": "unkey:v1:ws_123:keyspaces/ks_**#read_key",
+    "valid": false,
+    "reason": "\"**\" inside a resource path segment"
+  },
+  {
+    "input": "unkey:v1:ws_123:**/keys/key_1#read_key",
+    "valid": false,
+    "reason": "\"**\" is not the last resource path segment"
+  },
+  {
+    "input": "unkey:v1:ws_123:keyspaces/ks_123#",
+    "valid": false,
+    "reason": "empty action"
+  },
+  {
+    "input": "unkey:v1:ws_123:keyspaces/ks_123#read/key",
+    "valid": false,
+    "reason": "\"/\" in the action"
+  },
+  {
+    "input": "unkey:v1:ws_123:keyspaces/ks_123#read:key",
+    "valid": false,
+    "reason": "\":\" in the action"
+  },
+  {
+    "input": "unkey:v1:ws_123:keyspaces/ks_123#read*",
+    "valid": false,
+    "reason": "\"*\" inside the action"
+  },
+  {
+    "input": "unkey:v1:ws_123:keyspaces/ks_123#_read",
+    "valid": false,
+    "reason": "action starts with \"_\""
+  },
+  {
+    "input": "unkey:v1:ws_123:keyspaces/ks_123#read_",
+    "valid": false,
+    "reason": "action ends with \"_\""
+  },
+  {
+    "input": "unkey:v1:ws_123:keyspaces/ks_123#*",
+    "valid": false,
+    "reason": "action wildcard off the global resource path"
+  },
+  {
+    "input": "unkey:v1:ws_123:*#*",
+    "valid": false,
+    "reason": "action wildcard on a single-segment wildcard path"
+  }
+]


### PR DESCRIPTION
## What does this PR do?

This PR teaches the root-key write path to accept the new URN permission format `(unkey:v1:{workspace}:{path}#{action})` alongside the legacy dot strings. Nothing changes for existing keys — both formats validate.

Three things worth a close look:
- `@unkey/rbac now` validates both formats. The URN grammar helpers are written to mirror Go's pkg/urn one to one, and there's a shared JSON fixture both sides test against so TS and Go can't drift.
- permissions.slug goes from varchar(128) to 512 — slugs derived from URNs overflow 128. This is the bit I'd most like backend eyes on.
- Creating or updating a root key now upserts URN permissions, with a guard that rejects any URN naming a workspace other than the key's own.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

`pnpm --dir=web/internal/rbac test` (98 tests, fixture-driven). Behaviourally this is invisible until the builder UI (next PRs in the stack) calls it; legacy-permission behaviour is byte-for-byte unchanged and the old dialog keeps working. Untested at the router level: the workspace-pin BAD_REQUEST message itself (no DB-backed tRPC harness exists); its logic is covered in `@unkey/rbac`.

## Notes for reviewers

The schema widen (`web/internal/db/src/schema/rbac.ts` + regenerated `pkg/mysql/schema/permissions.sql`) is the piece that wants Andreas' eye. Known follow-up in the Go lane: the OpenAPI spec still caps permission slugs at 128 (`v2_permissions_create_permission`), and `pkg/urn` still uses flat keyspace/ratelimit paths while this vocabulary nests them under projects — the builder flag must not ship to prod before Go aligns.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary