### PR TITLE
docs(logdrain): document setup and delivery behavior

### DIFF
--- a/docs/engineering/architecture/services/logdrain/overview.mdx
+++ b/docs/engineering/architecture/services/logdrain/overview.mdx
@@ -1,0 +1,218 @@
+---
+title: "Overview"
+description: "How the logdrain service streams audit logs to customer destinations"
+---
+
+The logdrain service (`svc/logdrain`) streams audit logs from ClickHouse to
+customer-owned destinations: generic HTTP endpoints and Axiom.
+Under one valid lease, it sends events in cursor order. It provides
+at-least-once delivery. MySQL stores configuration and delivery progress. The
+service does not use an external queue or workflow engine.
+
+## How the service works
+
+Each process runs a lease service and a delivery engine. The lease service
+assigns drains to the process and keeps those assignments valid. The delivery
+engine polls for assigned drains that are due, then gives them to a worker
+pool.
+
+A worker first confirms its assignment in MySQL. It then reads the drain's
+configuration and cursor, queries the next audit log batch from ClickHouse,
+and sends that batch to the customer destination. After the destination
+acknowledges the batch, the worker advances the cursor in MySQL. A failed
+delivery leaves the cursor unchanged.
+
+MySQL stores the destination configuration as a serialized
+`logdrain.v1.Config` protobuf. Its provider `oneof` keeps HTTP and Axiom fields
+separate. Secret fields contain Vault ciphertext, so MySQL does not store
+plaintext credentials. The Vault ciphertext includes the key ID that the
+service needs for decryption. HTTP header names stay in plaintext. Each HTTP
+header value has separate Vault ciphertext.
+
+The worker does not hold a MySQL transaction while it calls the customer
+destination. A fencing token protects each state read and write instead.
+
+```plaintext
+svc/logdrain process
+├── lease service
+│   └── acquires and refreshes leases in MySQL
+└── delivery engine
+    ├── polls due leases from MySQL
+    └── workers
+        ├── read config and cursor from MySQL
+        ├── read audit logs from ClickHouse
+        ├── send batches to the customer destination
+        └── write delivery state to MySQL and telemetry to ClickHouse
+```
+
+## Delivery cycle
+
+On each poll, the delivery engine finds enabled, active drains assigned to its
+lease ID that have reached `next_attempt_at`. It passes the drain ID and
+fencing token to a worker. The worker reads the drain only if that token still
+identifies a valid lease. If the lease expired or another process acquired it,
+the worker stops.
+
+For a valid lease, the worker reads events between the committed cursor and a
+safe upper time boundary. It sends the events as one batch. After a successful
+request, a fenced write advances the cursor only if the lease is still valid.
+A failed request records the error and retry time without advancing the
+cursor. If a full batch succeeds, the worker reads the next batch in the same
+delivery cycle. A short batch means the worker reached the safe upper time
+boundary. The worker commits that boundary, returns to the pool, and leaves
+new events for a later poll.
+
+```plaintext
+poll due leases
+      │
+      ▼
+enqueue drain ID and fencing token
+      │
+      ▼
+read drain with fencing token ── stale lease ──▶ stop
+      │
+      ▼
+read next ClickHouse batch ───── no events ───▶ advance safe boundary
+      │
+      ▼
+send batch to destination ────── error ───────▶ retry or pause
+      │
+      ▼
+advance cursor with fencing token
+      │
+      ├── full batch ──▶ read next batch
+      └── short batch ─▶ return worker to pool
+```
+
+## Cursor and watermark
+
+Each drain subscribes to one stream. The supported stream is `audit_logs`,
+backed by the ClickHouse table `audit_logs_raw_v1`. The cursor is the pair
+`(inserted_at, event_id)`. MySQL stores it as
+`committed_offset_inserted_at` and `committed_offset_event_id`.
+
+MySQL and ClickHouse must order `event_id` values the same way. ClickHouse
+compares `String` values byte by byte, so the MySQL
+`committed_offset_event_id` column uses the binary `utf8mb4_0900_bin`
+collation. If the two databases used different ordering, they could disagree
+about which event follows the committed cursor and skip or repeat events.
+
+The event ID is necessary because multiple events can have the same
+`inserted_at` value. For example, assume a batch size of two and these events:
+
+| `inserted_at` | `event_id` |
+| --- | --- |
+| 1,000 | `evt_a` |
+| 1,000 | `evt_b` |
+| 1,000 | `evt_c` |
+| 1,001 | `evt_d` |
+
+The first query returns `evt_a` and `evt_b`, then commits the cursor
+`(1000, evt_b)`. The next query starts after that pair, so it returns `evt_c`
+before `evt_d`. A cursor that stored only `1000` would start the next query
+after that millisecond and skip `evt_c`.
+
+A full batch advances the cursor to its last event. A short or empty batch
+advances the cursor to the safe upper time boundary with an empty event ID.
+The empty event ID keeps events at that exact boundary eligible for the next
+cycle.
+
+The upper boundary stays behind the process clock by `WatermarkLag`. This
+settling period gives late ClickHouse inserts time to arrive before the cursor
+passes their timestamp.
+
+## Leasing and fencing
+
+Leases divide drains between service processes. Each process creates one
+startup-unique `lease_id`. The lease service acquires expired leases for that
+ID and refreshes them before they expire. Database time controls acquisition,
+refresh, and expiry.
+
+Each acquisition also creates a new `fencing_token`. The token identifies one
+specific ownership period, even if the same process loses and later reacquires
+the drain. The poller includes this token with each work item. Every delivery
+state read and write requires the same token and a lease that is still valid.
+As a result, stale workers cannot change the cursor, retry time, or failure
+state.
+
+Fencing protects durable state. It cannot cancel a customer request that
+started before the lease expired.
+
+## Disablement, retries, and pauses
+
+The `logdrains.enabled` Boolean records whether the user enabled the drain.
+The separate `logdrain_state.status` field is `active` or
+`paused_by_failure`. The engine processes a drain only when it is enabled and
+active.
+
+A failed delivery leaves the cursor unchanged. This rule applies to destination
+responses, such as HTTP 400 and HTTP 500, and to operational errors, such as a
+timeout or DNS failure. The engine retries all failures.
+
+The engine calculates an exponential delay from `consecutive_failures`. The
+first retry waits 1 minute. Each later failure doubles the delay through 128
+minutes. Later retries wait 4 hours. With the default failure threshold of 50,
+the 49 retry waits span 7 days and 15 minutes.
+
+A destination can request a longer delay. The HTTP sink reads the standard
+`Retry-After` response header. The Axiom sink reads `Retry-After` first. If that
+header is not valid, it reads `X-RateLimit-Reset` as a UTC Unix timestamp in
+seconds. The engine uses the longer of the local delay and the destination
+delay. It limits a destination delay to 24 hours.
+
+The failure update query increments `consecutive_failures` and writes an
+absolute retry time to `next_attempt_at`. It calculates that timestamp from
+MySQL time, not process time. The due-drain queries return the drain only after
+`next_attempt_at` has passed. A successful cursor update resets both fields so
+the next poll can select the drain immediately.
+
+The engine pauses the drain only after it reaches the configured failure
+threshold. Re-enabling a drain or changing its destination makes it active. The
+change resets its failure count, retry time, and last error. It preserves the
+cursor. Delivery resumes from that cursor, subject to the 90-day ClickHouse
+retention period for audit logs.
+
+## Delivery guarantees
+
+The cursor, lease, and fencing token define the delivery semantics:
+
+- Deliver-then-commit gives at-least-once delivery. If the process crashes
+  after the destination acknowledges a batch but before the cursor update,
+  the next cycle sends that batch again.
+- A failure never advances the cursor. The drain retries the same events until
+  the destination accepts them or the drain pauses.
+- Fencing prevents stale workers from changing durable state after lease
+  expiry, configuration changes, deletion, or reacquisition. It cannot cancel
+  an external request after a worker completes its fenced read.
+
+Customers must handle duplicate events. They can use the audit log event `id`
+as a deduplication key.
+
+## Health telemetry
+
+Each destination attempt writes one row to the ClickHouse table
+`logdrain_deliveries_raw_v1`. The row contains the outcome (`success` or
+`error`), event count, `webhook_duration_ms`, `request_body_bytes`, and a
+truncated error message. `request_body_bytes` contains the uncompressed encoded
+body size. It does not include request headers. A failed HTTP response also
+includes the response status and up to 4 KiB of the response body. The duration
+measures only the destination request. The dashboard reads this table for the
+drain health charts and delivery errors.
+
+### Prometheus metrics
+
+The Prometheus endpoint reports scheduling, delivery, and failure health for
+the service.
+
+| Metric name | Type | Labels | Meaning |
+| --- | --- | --- | --- |
+| `unkey_logdrain_drains` | Gauge | `status`, `stream` | Configured drains by status and stream. |
+| `unkey_logdrain_work_queue_depth` | Gauge | None | Items waiting in the work queue. |
+| `unkey_logdrain_work_queue_capacity` | Gauge | None | Work queue capacity. |
+| `unkey_logdrain_inflight_drains` | Gauge | None | Drains queued or processing. |
+| `unkey_logdrain_polls_total` | Counter | `result` | Poll outcomes. |
+| `unkey_logdrain_deliveries_total` | Counter | `kind`, `stream`, `outcome` | Delivery attempt outcomes. |
+| `unkey_logdrain_events_delivered_total` | Counter | `kind`, `stream` | Events in committed deliveries. |
+| `unkey_logdrain_delivery_duration_seconds` | Histogram | `kind`, `stream`, `outcome` | Delivery attempt latency. |
+| `unkey_logdrain_drain_failures_total` | Counter | `stream` | Failures recorded by the engine. |
+| `unkey_logdrain_drains_paused_total` | Counter | `stream` | Drains paused after they reach the failure threshold. |

--- a/docs/engineering/architecture/services/logdrain/overview.mdx
+++ b/docs/engineering/architecture/services/logdrain/overview.mdx
@@ -56,11 +56,12 @@ the worker stops.
 For a valid lease, the worker reads events between the committed cursor and a
 safe upper time boundary. It sends the events as one batch. After a successful
 request, a fenced write advances the cursor only if the lease is still valid.
-A failed request records the error and retry time without advancing the
-cursor. If a full batch succeeds, the worker reads the next batch in the same
-delivery cycle. A short batch means the worker reached the safe upper time
-boundary. The worker commits that boundary, returns to the pool, and leaves
-new events for a later poll.
+An unacknowledged response records its status and body in delivery telemetry.
+An unexpected delivery failure records its error in delivery telemetry. Both
+cases schedule a retry without advancing the cursor. If a full batch succeeds,
+the worker reads the next batch immediately. A short or empty batch means the
+worker reached the safe upper time boundary. The worker commits that boundary,
+schedules the next attempt after `PollInterval`, and returns to the pool.
 
 ```plaintext
 poll due leases
@@ -75,13 +76,13 @@ read drain with fencing token ── stale lease ──▶ stop
 read next ClickHouse batch ───── no events ───▶ advance safe boundary
       │
       ▼
-send batch to destination ────── error ───────▶ retry or pause
+send batch to destination ── rejected or error ──▶ retry or pause
       │
       ▼
 advance cursor with fencing token
       │
       ├── full batch ──▶ read next batch
-      └── short batch ─▶ return worker to pool
+      └── short or empty batch ──▶ wait PollInterval
 ```
 
 ## Cursor and watermark
@@ -141,13 +142,12 @@ started before the lease expired.
 ## Disablement, retries, and pauses
 
 The `logdrains.enabled` Boolean records whether the user enabled the drain.
-The separate `logdrain_state.status` field is `active` or
-`paused_by_failure`. The engine processes a drain only when it is enabled and
-active.
+The `logdrains.status` field is `active` or `paused_by_failure`. The engine
+processes a drain only when it is enabled and active.
 
-A failed delivery leaves the cursor unchanged. This rule applies to destination
-responses, such as HTTP 400 and HTTP 500, and to operational errors, such as a
-timeout or DNS failure. The engine retries all failures.
+A destination rejection, such as HTTP 400 or HTTP 500, leaves the cursor
+unchanged. An unexpected delivery error, such as a timeout or DNS failure,
+also leaves the cursor unchanged. The engine retries both cases.
 
 The engine calculates an exponential delay from `consecutive_failures`. The
 first retry waits 1 minute. Each later failure doubles the delay through 128
@@ -163,14 +163,15 @@ delay. It limits a destination delay to 24 hours.
 The failure update query increments `consecutive_failures` and writes an
 absolute retry time to `next_attempt_at`. It calculates that timestamp from
 MySQL time, not process time. The due-drain queries return the drain only after
-`next_attempt_at` has passed. A successful cursor update resets both fields so
-the next poll can select the drain immediately.
+`next_attempt_at` has passed. A successful cursor update resets the failure
+count. A full batch remains due immediately. A short or empty batch becomes due
+after `PollInterval`.
 
 The engine pauses the drain only after it reaches the configured failure
 threshold. Re-enabling a drain or changing its destination makes it active. The
-change resets its failure count, retry time, and last error. It preserves the
-cursor. Delivery resumes from that cursor, subject to the 90-day ClickHouse
-retention period for audit logs.
+change resets its failure count and retry time. It preserves the cursor.
+Delivery resumes from that cursor, subject to the 90-day ClickHouse retention
+period for audit logs.
 
 ## Delivery guarantees
 
@@ -194,7 +195,7 @@ Each destination attempt writes one row to the ClickHouse table
 `logdrain_deliveries_raw_v1`. The row contains the outcome (`success` or
 `error`), event count, `webhook_duration_ms`, `request_body_bytes`, and a
 truncated error message. `request_body_bytes` contains the uncompressed encoded
-body size. It does not include request headers. A failed HTTP response also
+body size. It does not include request headers. A rejected HTTP response also
 includes the response status and up to 4 KiB of the response body. The duration
 measures only the destination request. The dashboard reads this table for the
 drain health charts and delivery errors.

--- a/docs/engineering/docs.json
+++ b/docs/engineering/docs.json
@@ -169,6 +169,10 @@
                 ]
               },
               {
+                "group": "Logdrain",
+                "pages": ["architecture/services/logdrain/overview"]
+              },
+              {
                 "group": "Vault",
                 "pages": [
                   "architecture/services/vault/overview",

--- a/docs/product/audit-log/log-drains.mdx
+++ b/docs/product/audit-log/log-drains.mdx
@@ -1,0 +1,232 @@
+---
+title: Log drains
+description: "Stream workspace audit logs to external destinations, configure delivery, and diagnose failed requests."
+---
+
+A log drain sends workspace audit logs to a destination that you control. Use
+log drains to archive security events, send events to a security information
+and event management (SIEM) service, or process events with your own tools.
+
+<Note>
+  Log drains are in private preview. Contact
+  [support@unkey.com](mailto:support@unkey.com) to request access.
+</Note>
+
+Unkey supports generic HTTPS endpoints and
+<a href="https://axiom.co" target="_blank">Axiom</a> datasets. See [Event
+types](/audit-log/types) for the events that Unkey can send.
+
+## Understand delivery
+
+Unkey sends audit logs asynchronously in batches. A destination must accept the
+complete batch before Unkey marks the delivery as successful.
+
+HTTP destinations must return a `2xx` status within 30 seconds. Return a
+non-`2xx` status if your endpoint cannot process the complete batch. Unkey then
+retries the same batch.
+
+Log drains provide at-least-once delivery. A destination can receive an event
+more than once after a retry. Use `event.id` as the deduplication key.
+
+When you create a log drain, choose whether to send new audit logs only or all
+retained audit logs. The available history depends on your workspace's [audit
+log retention](/audit-log/introduction#retention).
+
+| Destination | Use case | Configuration |
+| --- | --- | --- |
+| HTTP | Send audit logs to an HTTP collector | Public HTTPS endpoint, body format, and optional headers |
+| Axiom | Send audit logs directly to an Axiom dataset | Dataset name and an API token with ingest permission |
+
+## Configure a log drain
+
+Create a log drain from your workspace settings.
+
+1. Navigate to your workspace **Settings**.
+2. Select **Log Drains**.
+3. Click **Create log drain**.
+4. Select **HTTP** or **Axiom**.
+5. Enter a descriptive name.
+6. Select **New audit logs only** or **All retained audit logs**.
+7. Enter the destination settings.
+8. Click **Create log drain**.
+
+Delivery is asynchronous and can take several minutes.
+
+## Configure an HTTP destination
+
+An HTTP log drain sends a `POST` request to your endpoint for each batch. The
+endpoint must use HTTPS and resolve to a public IP address. Unkey rejects
+loopback, private, and link-local destinations. Do not include credentials in
+the endpoint URL. Add authentication as a custom header.
+
+Configure these fields in the dashboard:
+
+| Field | Description |
+| --- | --- |
+| **HTTPS endpoint** | The public URL that receives each batch |
+| **Headers** | Optional request headers, such as an `Authorization` header |
+| **Body format** | A JSON array (default) or NDJSON with one event per line |
+
+Unkey stores the endpoint URL in plaintext. It encrypts each custom header
+value at rest.
+
+### Handle HTTP requests
+
+Process the complete request before you acknowledge it.
+
+- Accept `POST` requests at the configured path.
+- Read the body according to the `Content-Type` header.
+- Process every event in the batch.
+- Return a `2xx` status only after you accept the complete batch.
+- Return a non-`2xx` status and a useful response body when processing fails.
+
+Unkey adds these headers to every request:
+
+| Header | Value |
+| --- | --- |
+| `Content-Type` | `application/json` or `application/x-ndjson` |
+| `User-Agent` | `unkey-logdrain/1` |
+| `X-Unkey-Schema-Version` | The payload schema version, such as `v1` |
+| `X-Unkey-Drain-Id` | The ID of the log drain |
+| `X-Unkey-Workspace-Id` | The ID of the workspace that owns the audit logs |
+
+To request a longer retry delay, return a standard `Retry-After` header. Set
+the value to a number of seconds or an HTTP date. Unkey applies the requested
+delay when it is longer than the standard retry delay. The maximum requested
+delay is 24 hours.
+
+### Read the HTTP payload
+
+Choose the format that matches your destination.
+
+<CodeGroup>
+
+```json JSON array
+[
+  {
+    "event": {
+      "id": "evt_01J6Z6X8KZQ1V9X4R7Y2W3ABCD",
+      "action": "key.create",
+      "occurred_at": "2026-08-27T12:34:56.789Z",
+      "actor": {
+        "id": "user_01J6Z6WZ4F8M5N2K7P3Q9RSTUV",
+        "type": "user",
+        "name": "Ada",
+        "metadata": null
+      },
+      "targets": [
+        {
+          "id": "api_01J6Z6VQ9K2T4M8N5P7R3STUVW",
+          "type": "api",
+          "name": "Production API",
+          "metadata": null
+        }
+      ],
+      "context": {
+        "location": "203.0.113.10",
+        "user_agent": "Mozilla/5.0"
+      },
+      "metadata": null,
+      "description": "Created a key for Production API",
+      "correlation_id": "req_01J6Z70J4V9R2K8M5N3P7QSTUW"
+    },
+    "timestamp": "2026-08-27T12:34:56.789Z"
+  }
+]
+```
+
+```json NDJSON
+{"event":{"id":"evt_01J6Z6X8KZQ1V9X4R7Y2W3ABCD","action":"key.create","occurred_at":"2026-08-27T12:34:56.789Z","actor":{"id":"user_01J6Z6WZ4F8M5N2K7P3Q9RSTUV","type":"user","name":"Ada","metadata":null},"targets":[{"id":"api_01J6Z6VQ9K2T4M8N5P7R3STUVW","type":"api","name":"Production API","metadata":null}],"context":{"location":"203.0.113.10","user_agent":"Mozilla/5.0"},"metadata":null,"description":"Created a key for Production API","correlation_id":"req_01J6Z70J4V9R2K8M5N3P7QSTUW"},"timestamp":"2026-08-27T12:34:56.789Z"}
+```
+
+</CodeGroup>
+
+Both `occurred_at` and `timestamp` use RFC 3339 UTC strings with millisecond
+precision.
+
+## Configure an Axiom destination
+
+An Axiom log drain sends Axiom-compatible NDJSON to one dataset.
+
+1. Create or select a dataset in Axiom.
+2. Create an Axiom API token with ingest permission for that dataset.
+3. In Unkey, select **Axiom** as the destination.
+4. Enter the dataset name and API token.
+5. Click **Create log drain**.
+
+Each Axiom row contains `_time`, `stream`, and `event`. Unkey encodes each row
+as one NDJSON line. This example is formatted across lines for readability:
+
+```json
+{
+  "_time": "2026-08-27T12:34:56.789Z",
+  "stream": "audit_logs",
+  "event": {
+    "id": "evt_01J6Z6X8KZQ1V9X4R7Y2W3ABCD",
+    "action": "key.create",
+    "occurred_at": "2026-08-27T12:34:56.789Z",
+    "actor": {
+      "id": "user_01J6Z6WZ4F8M5N2K7P3Q9RSTUV",
+      "type": "user",
+      "name": "Ada",
+      "metadata": null
+    },
+    "targets": [
+      {
+        "id": "api_01J6Z6VQ9K2T4M8N5P7R3STUVW",
+        "type": "api",
+        "name": "Production API",
+        "metadata": null
+      }
+    ],
+    "context": {
+      "location": "203.0.113.10",
+      "user_agent": "Mozilla/5.0"
+    },
+    "metadata": null,
+    "description": "Created a key for Production API",
+    "correlation_id": "req_01J6Z70J4V9R2K8M5N3P7QSTUW"
+  }
+}
+```
+
+Axiom can return `Retry-After` or `X-RateLimit-Reset` to request a longer retry
+delay. Set `Retry-After` to a number of seconds or an HTTP date. Set
+`X-RateLimit-Reset` to a Unix timestamp in seconds. Unkey applies the requested
+delay when it is longer than the standard retry delay. The maximum requested
+delay is 24 hours.
+
+Unkey encrypts the Axiom token before storing it.
+
+## Understand retry behavior
+
+Failed deliveries are retried. This includes `4xx` responses, `5xx` responses,
+timeouts, DNS failures, and connection failures. A failed delivery does not
+skip the affected events.
+
+The first retry waits 1 minute. The delay doubles after each failure, with a
+maximum wait of 4 hours between attempts. After 50 consecutive failures, Unkey
+pauses the log drain. The complete retry period spans approximately 7 days.
+
+A successful delivery resets the failure count. Changing the destination or
+resuming the drain also resets the failure count. Delivery continues from the
+last successful batch.
+
+## Debug a log drain
+
+Open a log drain from **Settings** > **Log Drains**. The detail page shows the
+delivery status and these metrics for the past 24 hours:
+
+- Delivered events.
+- Failed delivery attempts.
+- Average request duration.
+
+If a delivery fails, expand **Some recent deliveries failed**. The table shows
+the failure time, response status, and response body. Unkey stores up to 4 KiB
+of the response body. If the destination did not return an HTTP response, the
+table shows the connection or timeout error instead.
+
+Return a concise error response from your endpoint. Include information that
+helps you identify invalid credentials, invalid payloads, rate limits, and
+service failures. Keep full diagnostic logs in your destination because Unkey
+stores only the first 4 KiB of the response.

--- a/docs/product/docs.json
+++ b/docs/product/docs.json
@@ -361,6 +361,7 @@
             "icon": "scroll",
             "pages": [
               "audit-log/introduction",
+              "audit-log/log-drains",
               "audit-log/types"
             ]
           },


### PR DESCRIPTION
## Notes for description (rewrite before review)

- Goal: Explain log drain setup, payloads, retry behavior, and delivery debugging.
- Product docs: Add the private preview guide and navigation entry.
- Engineering docs: Add the service architecture guide and navigation entry.
- Release docs: Add `logdrain` to the supported service list.
- Dependency: Stack this PR on the log drain dashboard PR.
- Verification: Both navigation JSON files parse. Internal document links resolve. No configured dprint plugin applies to these files.
