### PR TITLE
feat(rbac): add project-scoped URN catalog

### DIFF
--- a/pkg/urn/resources_deployment.go
+++ b/pkg/urn/resources_deployment.go
@@ -11,6 +11,7 @@ import "fmt"
 //	    └── apps/{app_id}
 //	        └── environments/{environment_id}
 //	            └── deployments/{deployment_id}
+//	                └── logs
 type Deployment struct {
 	workspaceID string
 	path        string
@@ -24,6 +25,16 @@ type Deployment struct {
 //	└── deployments/{deployment_id}
 func (d Deployment) String() string {
 	return V1{WorkspaceID: d.workspaceID, Resource: d.path}.String()
+}
+
+// Logs returns the deployment log resource path.
+//
+// Subresource:
+//
+//	deployments/{deployment_id}
+//	└── logs
+func (d Deployment) Logs() DeploymentLogs {
+	return DeploymentLogs{workspaceID: d.workspaceID, path: d.path + "/logs"}
 }
 
 // Instance returns a deployment instance resource path.
@@ -45,4 +56,24 @@ func (d Deployment) Any() V1 {
 		WorkspaceID: d.workspaceID,
 		Resource:    d.path + "/**",
 	}
+}
+
+// DeploymentLogs builds deployment log resource paths.
+//
+// Hierarchy:
+//
+//	workspace
+//	└── projects/{project_id}
+//	    └── apps/{app_id}
+//	        └── environments/{environment_id}
+//	            └── deployments/{deployment_id}
+//	                └── logs
+type DeploymentLogs struct {
+	workspaceID string
+	path        string
+}
+
+// String returns this deployment log resource path.
+func (d DeploymentLogs) String() string {
+	return V1{WorkspaceID: d.workspaceID, Resource: d.path}.String()
 }

--- a/pkg/urn/resources_environment.go
+++ b/pkg/urn/resources_environment.go
@@ -10,6 +10,10 @@ import "fmt"
 //	└── projects/{project_id}
 //	    └── apps/{app_id}
 //	        └── environments/{environment_id}
+//	            ├── deployments/{deployment_id}
+//	            ├── domains/{domain_id}
+//	            ├── variables/{variable_id}
+//	            └── gateway
 type Environment struct {
 	workspaceID string
 	path        string
@@ -55,16 +59,16 @@ func (e Environment) Gateway() gateway {
 	return gateway{workspaceID: e.workspaceID, path: e.path + "/gateway"}
 }
 
-// Variable returns a variable resource path.
+// Variable returns an environment variable resource path.
 //
 // Subresource:
 //
 //	environments/{environment_id}
 //	└── variables/{variable_id}
-func (e Environment) Variable(variableID string) V1 {
-	return V1{
-		WorkspaceID: e.workspaceID,
-		Resource:    fmt.Sprintf("%s/variables/%s", e.path, variableID),
+func (e Environment) Variable(variableID string) EnvironmentVariable {
+	return EnvironmentVariable{
+		workspaceID: e.workspaceID,
+		path:        fmt.Sprintf("%s/variables/%s", e.path, variableID),
 	}
 }
 
@@ -74,4 +78,23 @@ func (e Environment) Any() V1 {
 		WorkspaceID: e.workspaceID,
 		Resource:    e.path + "/**",
 	}
+}
+
+// EnvironmentVariable builds environment variable resource paths.
+//
+// Hierarchy:
+//
+//	workspace
+//	└── projects/{project_id}
+//	    └── apps/{app_id}
+//	        └── environments/{environment_id}
+//	            └── variables/{variable_id}
+type EnvironmentVariable struct {
+	workspaceID string
+	path        string
+}
+
+// String returns this environment variable resource path.
+func (e EnvironmentVariable) String() string {
+	return V1{WorkspaceID: e.workspaceID, Resource: e.path}.String()
 }

--- a/pkg/urn/resources_gateway.go
+++ b/pkg/urn/resources_gateway.go
@@ -4,10 +4,8 @@ import "fmt"
 
 // gateway builds gateway resource paths.
 //
-// The gateway segment carries no id and is never granted on its own. It groups
-// what the gateway owns in an environment, such as policies and routes, so a
-// grant can cover them without also covering the environment's build settings,
-// variables, or deployments.
+// The gateway segment has no ID and is not a permission target. It groups the
+// gateway resources in one environment.
 //
 // Hierarchy:
 //
@@ -16,9 +14,21 @@ import "fmt"
 //	    └── apps/{app_id}
 //	        └── environments/{environment_id}
 //	            └── gateway
+//	                ├── logs
+//	                └── policies/{policy_id}
 type gateway struct {
 	workspaceID string
 	path        string
+}
+
+// Logs returns the gateway log resource path.
+//
+// Subresource:
+//
+//	gateway
+//	└── logs
+func (g gateway) Logs() GatewayLogs {
+	return GatewayLogs{workspaceID: g.workspaceID, path: g.path + "/logs"}
 }
 
 // Policy returns a gateway policy resource path.
@@ -29,4 +39,24 @@ type gateway struct {
 //	└── policies/{policy_id}
 func (g gateway) Policy(policyID string) GatewayPolicy {
 	return GatewayPolicy{workspaceID: g.workspaceID, path: fmt.Sprintf("%s/policies/%s", g.path, policyID)}
+}
+
+// GatewayLogs builds gateway log resource paths.
+//
+// Hierarchy:
+//
+//	workspace
+//	└── projects/{project_id}
+//	    └── apps/{app_id}
+//	        └── environments/{environment_id}
+//	            └── gateway
+//	                └── logs
+type GatewayLogs struct {
+	workspaceID string
+	path        string
+}
+
+// String returns this gateway log resource path.
+func (g GatewayLogs) String() string {
+	return V1{WorkspaceID: g.workspaceID, Resource: g.path}.String()
 }

--- a/pkg/urn/resources_github_app.go
+++ b/pkg/urn/resources_github_app.go
@@ -1,0 +1,19 @@
+package urn
+
+// GitHubApp builds GitHub app resource paths.
+//
+// Hierarchy:
+//
+//	workspace
+//	└── github/apps/{github_app_id}
+//
+// A GitHub app is the only public resource that does not belong to a project.
+type GitHubApp struct {
+	workspaceID string
+	path        string
+}
+
+// String returns this GitHub app resource path.
+func (g GitHubApp) String() string {
+	return V1{WorkspaceID: g.workspaceID, Resource: g.path}.String()
+}

--- a/pkg/urn/resources_keyspace.go
+++ b/pkg/urn/resources_keyspace.go
@@ -7,10 +7,10 @@ import "fmt"
 // Hierarchy:
 //
 //	workspace
-//	└── keyspaces/{keyspace_id}
-//
-// A keyspace can also produce a descendant pattern for grants covering every
-// key and future keyspace child.
+//	└── projects/{project_id}
+//	    └── keyspaces/{keyspace_id}
+//	        ├── logs
+//	        └── keys/{key_id}
 type Keyspace struct {
 	workspaceID string
 	path        string
@@ -24,6 +24,16 @@ type Keyspace struct {
 //	└── keyspaces/{keyspace_id}
 func (k Keyspace) String() string {
 	return V1{WorkspaceID: k.workspaceID, Resource: k.path}.String()
+}
+
+// Logs returns the keyspace log resource path.
+//
+// Subresource:
+//
+//	keyspaces/{keyspace_id}
+//	└── logs
+func (k Keyspace) Logs() KeyspaceLogs {
+	return KeyspaceLogs{workspaceID: k.workspaceID, path: k.path + "/logs"}
 }
 
 // Key is a key resource path.
@@ -58,4 +68,22 @@ func (k Keyspace) Any() V1 {
 		WorkspaceID: k.workspaceID,
 		Resource:    k.path + "/**",
 	}
+}
+
+// KeyspaceLogs builds keyspace log resource paths.
+//
+// Hierarchy:
+//
+//	workspace
+//	└── projects/{project_id}
+//	    └── keyspaces/{keyspace_id}
+//	        └── logs
+type KeyspaceLogs struct {
+	workspaceID string
+	path        string
+}
+
+// String returns this keyspace log resource path.
+func (k KeyspaceLogs) String() string {
+	return V1{WorkspaceID: k.workspaceID, Resource: k.path}.String()
 }

--- a/pkg/urn/resources_policies.go
+++ b/pkg/urn/resources_policies.go
@@ -8,7 +8,8 @@ package urn
 //	└── projects/{project_id}
 //	    └── apps/{app_id}
 //	        └── environments/{environment_id}
-//	            └── gateway/policies/{policy_id}
+//	            └── gateway
+//	                └── policies/{policy_id}
 type GatewayPolicy struct {
 	workspaceID string
 	path        string

--- a/pkg/urn/resources_project.go
+++ b/pkg/urn/resources_project.go
@@ -9,9 +9,10 @@ import "fmt"
 //	workspace
 //	└── projects/{project_id}
 //	    ├── apps/{app_id}
-//	    └── identities/{identity_id}
-//
-// Projects are owned by a workspace.
+//	    ├── identities/{identity_id}
+//	    ├── keyspaces/{keyspace_id}
+//	    ├── ratelimits/namespaces/{namespace_id}
+//	    └── rbac
 type Project struct {
 	workspaceID string
 	path        string
@@ -45,6 +46,39 @@ func (p Project) App(appID string) App {
 //	└── identities/{identity_id}
 func (p Project) Identity(identityID string) Identity {
 	return Identity{workspaceID: p.workspaceID, path: fmt.Sprintf("%s/identities/%s", p.path, identityID)}
+}
+
+// Keyspace returns builders for keyspace resource paths.
+//
+// Subresource:
+//
+//	projects/{project_id}
+//	└── keyspaces/{keyspace_id}
+func (p Project) Keyspace(keyspaceID string) Keyspace {
+	return Keyspace{workspaceID: p.workspaceID, path: fmt.Sprintf("%s/keyspaces/%s", p.path, keyspaceID)}
+}
+
+// RatelimitNamespace returns builders for rate limit namespace resource paths.
+//
+// Subresource:
+//
+//	projects/{project_id}
+//	└── ratelimits/namespaces/{namespace_id}
+func (p Project) RatelimitNamespace(namespaceID string) RatelimitNamespace {
+	return RatelimitNamespace{
+		workspaceID: p.workspaceID,
+		path:        fmt.Sprintf("%s/ratelimits/namespaces/%s", p.path, namespaceID),
+	}
+}
+
+// RBAC returns builders for RBAC resource paths.
+//
+// Subresource:
+//
+//	projects/{project_id}
+//	└── rbac
+func (p Project) RBAC() projectRBAC {
+	return projectRBAC{workspaceID: p.workspaceID, path: p.path + "/rbac"}
 }
 
 // Any returns a descendant pattern below this project.

--- a/pkg/urn/resources_ratelimit.go
+++ b/pkg/urn/resources_ratelimit.go
@@ -7,10 +7,10 @@ import "fmt"
 // Hierarchy:
 //
 //	workspace
-//	└── ratelimits/namespaces/{namespace_id}
-//
-// The namespace is intentionally below the literal "ratelimits" segment so all
-// rate limit resources can share one top-level workspace branch.
+//	└── projects/{project_id}
+//	    └── ratelimits/namespaces/{namespace_id}
+//	        ├── logs
+//	        └── overrides/{override_id}
 type RatelimitNamespace struct {
 	workspaceID string
 	path        string
@@ -24,6 +24,16 @@ type RatelimitNamespace struct {
 //	└── ratelimits/namespaces/{namespace_id}
 func (r RatelimitNamespace) String() string {
 	return V1{WorkspaceID: r.workspaceID, Resource: r.path}.String()
+}
+
+// Logs returns the rate limit log resource path.
+//
+// Subresource:
+//
+//	ratelimits/namespaces/{namespace_id}
+//	└── logs
+func (r RatelimitNamespace) Logs() RatelimitLogs {
+	return RatelimitLogs{workspaceID: r.workspaceID, path: r.path + "/logs"}
 }
 
 // RatelimitOverride is a rate limit override resource path.
@@ -58,4 +68,22 @@ func (r RatelimitNamespace) Any() V1 {
 		WorkspaceID: r.workspaceID,
 		Resource:    r.path + "/**",
 	}
+}
+
+// RatelimitLogs builds rate limit log resource paths.
+//
+// Hierarchy:
+//
+//	workspace
+//	└── projects/{project_id}
+//	    └── ratelimits/namespaces/{namespace_id}
+//	        └── logs
+type RatelimitLogs struct {
+	workspaceID string
+	path        string
+}
+
+// String returns this rate limit log resource path.
+func (r RatelimitLogs) String() string {
+	return V1{WorkspaceID: r.workspaceID, Resource: r.path}.String()
 }

--- a/pkg/urn/resources_rbac.go
+++ b/pkg/urn/resources_rbac.go
@@ -38,3 +38,66 @@ func (r rbac) Permission(permissionID string) V1 {
 		Resource:    fmt.Sprintf("%s/permissions/%s", r.path, permissionID),
 	}
 }
+
+// projectRBAC builds project-scoped RBAC resource paths.
+//
+// The rbac segment has no ID and is not a permission target. It groups project
+// roles and permission definitions.
+//
+// Hierarchy:
+//
+//	workspace
+//	└── projects/{project_id}
+//	    └── rbac
+//	        ├── roles/{role_id}
+//	        └── permissions/{permission_id}
+type projectRBAC struct {
+	workspaceID string
+	path        string
+}
+
+// Role returns a project-scoped RBAC role resource path.
+func (r projectRBAC) Role(roleID string) Role {
+	return Role{workspaceID: r.workspaceID, path: fmt.Sprintf("%s/roles/%s", r.path, roleID)}
+}
+
+// Permission returns a project-scoped RBAC permission resource path.
+func (r projectRBAC) Permission(permissionID string) Permission {
+	return Permission{workspaceID: r.workspaceID, path: fmt.Sprintf("%s/permissions/%s", r.path, permissionID)}
+}
+
+// Role builds RBAC role resource paths.
+//
+// Hierarchy:
+//
+//	workspace
+//	└── projects/{project_id}
+//	    └── rbac
+//	        └── roles/{role_id}
+type Role struct {
+	workspaceID string
+	path        string
+}
+
+// String returns this RBAC role resource path.
+func (r Role) String() string {
+	return V1{WorkspaceID: r.workspaceID, Resource: r.path}.String()
+}
+
+// Permission builds RBAC permission resource paths.
+//
+// Hierarchy:
+//
+//	workspace
+//	└── projects/{project_id}
+//	    └── rbac
+//	        └── permissions/{permission_id}
+type Permission struct {
+	workspaceID string
+	path        string
+}
+
+// String returns this RBAC permission resource path.
+func (p Permission) String() string {
+	return V1{WorkspaceID: p.workspaceID, Resource: p.path}.String()
+}

--- a/pkg/urn/resources_workspace.go
+++ b/pkg/urn/resources_workspace.go
@@ -9,6 +9,7 @@ import "fmt"
 //	workspace
 //	├── team
 //	├── billing
+//	├── github/apps/{github_app_id}
 //	├── keyspaces/{keyspace_id}
 //	├── ratelimits/namespaces/{namespace_id}
 //	├── rbac
@@ -35,6 +36,16 @@ type workspace struct {
 //	└── billing
 func (w workspace) Billing() billing {
 	return billing{workspaceID: w.workspaceID, path: "billing"}
+}
+
+// GitHubApp returns a GitHub app resource path.
+//
+// Subresource:
+//
+//	workspace
+//	└── github/apps/{github_app_id}
+func (w workspace) GitHubApp(githubAppID string) GitHubApp {
+	return GitHubApp{workspaceID: w.workspaceID, path: fmt.Sprintf("github/apps/%s", githubAppID)}
 }
 
 // Keyspace returns builders for keyspace resource paths.

--- a/pkg/urn/urn_test.go
+++ b/pkg/urn/urn_test.go
@@ -239,6 +239,31 @@ func TestResourceCatalogHelpers(t *testing.T) {
 	require.Equal(t, "unkey:v1:ws_123:portals/portal_123/**", workspace.Portal("portal_123").Any().String())
 }
 
+// TestProjectResourceCatalogHelpers guarantees the project-scoped builders
+// produce the canonical resource paths for the permission catalog.
+func TestProjectResourceCatalogHelpers(t *testing.T) {
+	t.Parallel()
+
+	workspace := New().Workspace("ws_123")
+	project := workspace.Project("proj_123")
+	environment := project.App("app_123").Environment("env_123")
+	keyspace := project.Keyspace("ks_123")
+	namespace := project.RatelimitNamespace("ns_123")
+
+	require.Equal(t, "unkey:v1:ws_123:github/apps/gh_123", workspace.GitHubApp("gh_123").String())
+	require.Equal(t, "unkey:v1:ws_123:projects/proj_123/keyspaces/ks_123", keyspace.String())
+	require.Equal(t, "unkey:v1:ws_123:projects/proj_123/keyspaces/ks_123/logs", keyspace.Logs().String())
+	require.Equal(t, "unkey:v1:ws_123:projects/proj_123/keyspaces/ks_123/keys/key_123", keyspace.Key("key_123").String())
+	require.Equal(t, "unkey:v1:ws_123:projects/proj_123/ratelimits/namespaces/ns_123", namespace.String())
+	require.Equal(t, "unkey:v1:ws_123:projects/proj_123/ratelimits/namespaces/ns_123/logs", namespace.Logs().String())
+	require.Equal(t, "unkey:v1:ws_123:projects/proj_123/ratelimits/namespaces/ns_123/overrides/ov_123", namespace.Override("ov_123").String())
+	require.Equal(t, "unkey:v1:ws_123:projects/proj_123/rbac/roles/role_123", project.RBAC().Role("role_123").String())
+	require.Equal(t, "unkey:v1:ws_123:projects/proj_123/rbac/permissions/perm_123", project.RBAC().Permission("perm_123").String())
+	require.Equal(t, "unkey:v1:ws_123:projects/proj_123/apps/app_123/environments/env_123/variables/var_123", environment.Variable("var_123").String())
+	require.Equal(t, "unkey:v1:ws_123:projects/proj_123/apps/app_123/environments/env_123/deployments/dep_123/logs", environment.Deployment("dep_123").Logs().String())
+	require.Equal(t, "unkey:v1:ws_123:projects/proj_123/apps/app_123/environments/env_123/gateway/logs", environment.Gateway().Logs().String())
+}
+
 // TestV1Covers_OnlySupportedWildcardsExpandScope guarantees "*" matches one
 // path segment, trailing "**" is the only descendant wildcard, and workspaces
 // must match exactly.


### PR DESCRIPTION
## Notes for description (rewrite before review)

### Stack
- Position: 1 of 9. Review wave 1: model and data.
- Full stack: **#7189** → #7190 → #7191 → #7192 → #7193 → #7195 → #7196 → #7197 → #7198.
- Base: `main`. Next: #7190.

### Goal
- Add typed builders for the project-scoped resource hierarchy.

### Approach
- Add project descendants for apps, environments, deployments, identities, keyspaces, rate limits, and RBAC.
- Add first-class log resources for deployments, gateways, keyspaces, and rate limit namespaces.
- Keep existing workspace-scoped builders until the final cutover.

### Decisions
- Keep `pkg/urn` independent from permission actions.
- Keep `ParseV1` permissive in this PR. #7197 applies strict catalog validation.
- Put hierarchy comments on URN resource types and builders.

### Review order
1. Review the resource hierarchy and path shapes.
2. Review typed builders and `String` output.
3. Review wildcard builders and tests.

### Review focus
- Confirm that every non-GitHub resource can include a project segment.
- Confirm that log resources use their own paths.
- Confirm that this PR does not change authorization behavior.

### Verification
- `mise exec -- rask --no-cache ./pkg/urn` passed.
- `mise run build` passed.
