### PR TITLE
feat(rbac): add resource-qualified action catalog

### DIFF
--- a/pkg/rbac/permissions/action.go
+++ b/pkg/rbac/permissions/action.go
@@ -1,16 +1,8 @@
-// Package permissions defines typed actions for Unkey resource permissions.
+// Package permissions defines typed actions for canonical URN resources.
 //
-// Resource permissions combine a URN resource with an action, but not every
-// action is meaningful for every resource. These action structs encode valid
-// resource/action pairs in the type system, so handler code can't accidentally
-// ask for create_key on a key resource or read_key on a keyspace resource.
-//
-// Each action declares the resource type it supports through ActionFor. For
-// example, CreateKey implements ActionFor(urn.Keyspace), so rbac.U accepts it
-// with urn.Keyspace values and rejects it with urn.Key values at compile time.
-//
-// This keeps pkg/urn focused on naming resources while pkg/rbac owns query
-// construction and evaluation.
+// Each action implements ActionFor for exactly one resource type. The compiler
+// rejects invalid resource and action pairs. This package depends on pkg/urn.
+// The URN package does not know about actions.
 package permissions
 
 import "fmt"
@@ -20,3 +12,6 @@ type Action[R fmt.Stringer] interface {
 	ActionFor(R)
 	fmt.Stringer
 }
+
+// Wildcard is the action used by the global admin permission.
+const Wildcard = "*"

--- a/pkg/rbac/permissions/action_test.go
+++ b/pkg/rbac/permissions/action_test.go
@@ -1,0 +1,103 @@
+package permissions_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/rbac"
+	"github.com/unkeyed/unkey/pkg/rbac/permissions"
+	"github.com/unkeyed/unkey/pkg/urn"
+)
+
+// TestActions_BuildPlatformPermissions pins every platform resource and action
+// pair and its serialized form.
+func TestActions_BuildPlatformPermissions(t *testing.T) {
+	t.Parallel()
+
+	workspace := urn.New().Workspace("ws_123")
+	githubApp := workspace.GitHubApp("gh_123")
+	project := workspace.Project("proj_123")
+	app := project.App("app_123")
+	environment := app.Environment("env_123")
+	deployment := environment.Deployment("dep_123")
+	domain := environment.Domain("dom_123")
+	variable := environment.Variable("var_123")
+	gateway := environment.Gateway()
+
+	requirePermission(t, githubApp, permissions.ReadGitHubApp{}, "unkey:v1:ws_123:github/apps/gh_123#read_github_app")
+	requirePermission(t, githubApp, permissions.WriteGitHubApp{}, "unkey:v1:ws_123:github/apps/gh_123#write_github_app")
+	requirePermission(t, githubApp, permissions.DeleteGitHubApp{}, "unkey:v1:ws_123:github/apps/gh_123#delete_github_app")
+	requirePermission(t, project, permissions.ReadProject{}, "unkey:v1:ws_123:projects/proj_123#read_project")
+	requirePermission(t, project, permissions.WriteProject{}, "unkey:v1:ws_123:projects/proj_123#write_project")
+	requirePermission(t, project, permissions.DeleteProject{}, "unkey:v1:ws_123:projects/proj_123#delete_project")
+	requirePermission(t, app, permissions.ReadApp{}, "unkey:v1:ws_123:projects/proj_123/apps/app_123#read_app")
+	requirePermission(t, app, permissions.WriteApp{}, "unkey:v1:ws_123:projects/proj_123/apps/app_123#write_app")
+	requirePermission(t, app, permissions.DeleteApp{}, "unkey:v1:ws_123:projects/proj_123/apps/app_123#delete_app")
+	requirePermission(t, environment, permissions.ReadEnvironment{}, "unkey:v1:ws_123:projects/proj_123/apps/app_123/environments/env_123#read_environment")
+	requirePermission(t, environment, permissions.WriteEnvironment{}, "unkey:v1:ws_123:projects/proj_123/apps/app_123/environments/env_123#write_environment")
+	requirePermission(t, environment, permissions.DeleteEnvironment{}, "unkey:v1:ws_123:projects/proj_123/apps/app_123/environments/env_123#delete_environment")
+	requirePermission(t, deployment, permissions.ReadDeployment{}, "unkey:v1:ws_123:projects/proj_123/apps/app_123/environments/env_123/deployments/dep_123#read_deployment")
+	requirePermission(t, deployment, permissions.WriteDeployment{}, "unkey:v1:ws_123:projects/proj_123/apps/app_123/environments/env_123/deployments/dep_123#write_deployment")
+	requirePermission(t, deployment, permissions.DeleteDeployment{}, "unkey:v1:ws_123:projects/proj_123/apps/app_123/environments/env_123/deployments/dep_123#delete_deployment")
+	requirePermission(t, deployment.Logs(), permissions.ReadDeploymentLogs{}, "unkey:v1:ws_123:projects/proj_123/apps/app_123/environments/env_123/deployments/dep_123/logs#read_deployment_logs")
+	requirePermission(t, domain, permissions.ReadDomain{}, "unkey:v1:ws_123:projects/proj_123/apps/app_123/environments/env_123/domains/dom_123#read_domain")
+	requirePermission(t, domain, permissions.WriteDomain{}, "unkey:v1:ws_123:projects/proj_123/apps/app_123/environments/env_123/domains/dom_123#write_domain")
+	requirePermission(t, domain, permissions.DeleteDomain{}, "unkey:v1:ws_123:projects/proj_123/apps/app_123/environments/env_123/domains/dom_123#delete_domain")
+	requirePermission(t, variable, permissions.ReadEnvironmentVariable{}, "unkey:v1:ws_123:projects/proj_123/apps/app_123/environments/env_123/variables/var_123#read_environment_variable")
+	requirePermission(t, variable, permissions.WriteEnvironmentVariable{}, "unkey:v1:ws_123:projects/proj_123/apps/app_123/environments/env_123/variables/var_123#write_environment_variable")
+	requirePermission(t, variable, permissions.DeleteEnvironmentVariable{}, "unkey:v1:ws_123:projects/proj_123/apps/app_123/environments/env_123/variables/var_123#delete_environment_variable")
+	requirePermission(t, gateway.Logs(), permissions.ReadGatewayLogs{}, "unkey:v1:ws_123:projects/proj_123/apps/app_123/environments/env_123/gateway/logs#read_gateway_logs")
+	requirePermission(t, gateway.Policy("pol_123"), permissions.ReadGatewayPolicy{}, "unkey:v1:ws_123:projects/proj_123/apps/app_123/environments/env_123/gateway/policies/pol_123#read_gateway_policy")
+	requirePermission(t, gateway.Policy("pol_123"), permissions.WriteGatewayPolicy{}, "unkey:v1:ws_123:projects/proj_123/apps/app_123/environments/env_123/gateway/policies/pol_123#write_gateway_policy")
+	requirePermission(t, gateway.Policy("pol_123"), permissions.DeleteGatewayPolicy{}, "unkey:v1:ws_123:projects/proj_123/apps/app_123/environments/env_123/gateway/policies/pol_123#delete_gateway_policy")
+}
+
+// TestActions_BuildDataPermissions pins every data resource and action pair and
+// its serialized form.
+func TestActions_BuildDataPermissions(t *testing.T) {
+	t.Parallel()
+
+	project := urn.New().Workspace("ws_123").Project("proj_123")
+	identity := project.Identity("id_123")
+	keyspace := project.Keyspace("ks_123")
+	key := keyspace.Key("key_123")
+	namespace := project.RatelimitNamespace("ns_123")
+	override := namespace.Override("ov_123")
+	role := project.RBAC().Role("role_123")
+	permission := project.RBAC().Permission("perm_123")
+
+	requirePermission(t, identity, permissions.ReadIdentity{}, "unkey:v1:ws_123:projects/proj_123/identities/id_123#read_identity")
+	requirePermission(t, identity, permissions.WriteIdentity{}, "unkey:v1:ws_123:projects/proj_123/identities/id_123#write_identity")
+	requirePermission(t, identity, permissions.DeleteIdentity{}, "unkey:v1:ws_123:projects/proj_123/identities/id_123#delete_identity")
+	requirePermission(t, keyspace, permissions.ReadKeyspace{}, "unkey:v1:ws_123:projects/proj_123/keyspaces/ks_123#read_keyspace")
+	requirePermission(t, keyspace, permissions.WriteKeyspace{}, "unkey:v1:ws_123:projects/proj_123/keyspaces/ks_123#write_keyspace")
+	requirePermission(t, keyspace, permissions.DeleteKeyspace{}, "unkey:v1:ws_123:projects/proj_123/keyspaces/ks_123#delete_keyspace")
+	requirePermission(t, keyspace.Logs(), permissions.ReadKeyspaceLogs{}, "unkey:v1:ws_123:projects/proj_123/keyspaces/ks_123/logs#read_keyspace_logs")
+	requirePermission(t, key, permissions.ReadKey{}, "unkey:v1:ws_123:projects/proj_123/keyspaces/ks_123/keys/key_123#read_key")
+	requirePermission(t, key, permissions.WriteKey{}, "unkey:v1:ws_123:projects/proj_123/keyspaces/ks_123/keys/key_123#write_key")
+	requirePermission(t, key, permissions.DeleteKey{}, "unkey:v1:ws_123:projects/proj_123/keyspaces/ks_123/keys/key_123#delete_key")
+	requirePermission(t, key, permissions.DecryptKey{}, "unkey:v1:ws_123:projects/proj_123/keyspaces/ks_123/keys/key_123#decrypt_key")
+	requirePermission(t, key, permissions.VerifyKey{}, "unkey:v1:ws_123:projects/proj_123/keyspaces/ks_123/keys/key_123#verify_key")
+	requirePermission(t, namespace, permissions.ReadRatelimitNamespace{}, "unkey:v1:ws_123:projects/proj_123/ratelimits/namespaces/ns_123#read_ratelimit_namespace")
+	requirePermission(t, namespace, permissions.WriteRatelimitNamespace{}, "unkey:v1:ws_123:projects/proj_123/ratelimits/namespaces/ns_123#write_ratelimit_namespace")
+	requirePermission(t, namespace, permissions.DeleteRatelimitNamespace{}, "unkey:v1:ws_123:projects/proj_123/ratelimits/namespaces/ns_123#delete_ratelimit_namespace")
+	requirePermission(t, namespace, permissions.LimitRatelimitNamespace{}, "unkey:v1:ws_123:projects/proj_123/ratelimits/namespaces/ns_123#limit_ratelimit_namespace")
+	requirePermission(t, namespace.Logs(), permissions.ReadRatelimitLogs{}, "unkey:v1:ws_123:projects/proj_123/ratelimits/namespaces/ns_123/logs#read_ratelimit_logs")
+	requirePermission(t, override, permissions.ReadRatelimitOverride{}, "unkey:v1:ws_123:projects/proj_123/ratelimits/namespaces/ns_123/overrides/ov_123#read_ratelimit_override")
+	requirePermission(t, override, permissions.WriteRatelimitOverride{}, "unkey:v1:ws_123:projects/proj_123/ratelimits/namespaces/ns_123/overrides/ov_123#write_ratelimit_override")
+	requirePermission(t, override, permissions.DeleteRatelimitOverride{}, "unkey:v1:ws_123:projects/proj_123/ratelimits/namespaces/ns_123/overrides/ov_123#delete_ratelimit_override")
+	requirePermission(t, role, permissions.ReadRole{}, "unkey:v1:ws_123:projects/proj_123/rbac/roles/role_123#read_role")
+	requirePermission(t, role, permissions.WriteRole{}, "unkey:v1:ws_123:projects/proj_123/rbac/roles/role_123#write_role")
+	requirePermission(t, role, permissions.DeleteRole{}, "unkey:v1:ws_123:projects/proj_123/rbac/roles/role_123#delete_role")
+	requirePermission(t, permission, permissions.ReadPermission{}, "unkey:v1:ws_123:projects/proj_123/rbac/permissions/perm_123#read_permission")
+	requirePermission(t, permission, permissions.WritePermission{}, "unkey:v1:ws_123:projects/proj_123/rbac/permissions/perm_123#write_permission")
+	requirePermission(t, permission, permissions.DeletePermission{}, "unkey:v1:ws_123:projects/proj_123/rbac/permissions/perm_123#delete_permission")
+}
+
+// requirePermission verifies the public query builder output for one valid
+// resource and action pair.
+func requirePermission[R fmt.Stringer, A permissions.Action[R]](t *testing.T, resource R, action A, want string) {
+	t.Helper()
+	require.Equal(t, want, rbac.U(resource, action).Value)
+}

--- a/pkg/rbac/permissions/apps.go
+++ b/pkg/rbac/permissions/apps.go
@@ -2,6 +2,18 @@ package permissions
 
 import "github.com/unkeyed/unkey/pkg/urn"
 
+// ReadApp authorizes reading an app.
+type ReadApp struct{}
+
+func (ReadApp) ActionFor(urn.App) {}
+func (ReadApp) String() string    { return "read_app" }
+
+// WriteApp authorizes creating or updating an app.
+type WriteApp struct{}
+
+func (WriteApp) ActionFor(urn.App) {}
+func (WriteApp) String() string    { return "write_app" }
+
 // CreateApp authorizes creating apps.
 //
 // Valid resource: urn.App. Grants use a wildcard app id because the app does

--- a/pkg/rbac/permissions/deployment_logs.go
+++ b/pkg/rbac/permissions/deployment_logs.go
@@ -1,0 +1,9 @@
+package permissions
+
+import "github.com/unkeyed/unkey/pkg/urn"
+
+// ReadDeploymentLogs authorizes reading deployment logs.
+type ReadDeploymentLogs struct{}
+
+func (ReadDeploymentLogs) ActionFor(urn.DeploymentLogs) {}
+func (ReadDeploymentLogs) String() string               { return "read_deployment_logs" }

--- a/pkg/rbac/permissions/deployments.go
+++ b/pkg/rbac/permissions/deployments.go
@@ -2,6 +2,24 @@ package permissions
 
 import "github.com/unkeyed/unkey/pkg/urn"
 
+// ReadDeployment authorizes reading a deployment.
+type ReadDeployment struct{}
+
+func (ReadDeployment) ActionFor(urn.Deployment) {}
+func (ReadDeployment) String() string           { return "read_deployment" }
+
+// WriteDeployment authorizes creating, updating, starting, or stopping a deployment.
+type WriteDeployment struct{}
+
+func (WriteDeployment) ActionFor(urn.Deployment) {}
+func (WriteDeployment) String() string           { return "write_deployment" }
+
+// DeleteDeployment authorizes deleting a deployment.
+type DeleteDeployment struct{}
+
+func (DeleteDeployment) ActionFor(urn.Deployment) {}
+func (DeleteDeployment) String() string           { return "delete_deployment" }
+
 // CreateDeployment authorizes creating deployments.
 //
 // Valid resource: urn.Deployment. Grants use a wildcard deployment id because

--- a/pkg/rbac/permissions/domains.go
+++ b/pkg/rbac/permissions/domains.go
@@ -19,6 +19,12 @@ type ReadDomain struct{}
 func (ReadDomain) ActionFor(urn.Domain) {}
 func (ReadDomain) String() string       { return "read_domain" }
 
+// WriteDomain authorizes creating or updating a domain.
+type WriteDomain struct{}
+
+func (WriteDomain) ActionFor(urn.Domain) {}
+func (WriteDomain) String() string       { return "write_domain" }
+
 // DeleteDomain authorizes removing a custom domain.
 //
 // Valid resource: urn.Domain.

--- a/pkg/rbac/permissions/environment_variables.go
+++ b/pkg/rbac/permissions/environment_variables.go
@@ -1,0 +1,21 @@
+package permissions
+
+import "github.com/unkeyed/unkey/pkg/urn"
+
+// ReadEnvironmentVariable authorizes reading an environment variable.
+type ReadEnvironmentVariable struct{}
+
+func (ReadEnvironmentVariable) ActionFor(urn.EnvironmentVariable) {}
+func (ReadEnvironmentVariable) String() string                    { return "read_environment_variable" }
+
+// WriteEnvironmentVariable authorizes creating or updating an environment variable.
+type WriteEnvironmentVariable struct{}
+
+func (WriteEnvironmentVariable) ActionFor(urn.EnvironmentVariable) {}
+func (WriteEnvironmentVariable) String() string                    { return "write_environment_variable" }
+
+// DeleteEnvironmentVariable authorizes deleting an environment variable.
+type DeleteEnvironmentVariable struct{}
+
+func (DeleteEnvironmentVariable) ActionFor(urn.EnvironmentVariable) {}
+func (DeleteEnvironmentVariable) String() string                    { return "delete_environment_variable" }

--- a/pkg/rbac/permissions/environments.go
+++ b/pkg/rbac/permissions/environments.go
@@ -10,6 +10,19 @@ type ReadEnvironment struct{}
 func (ReadEnvironment) ActionFor(urn.Environment) {}
 func (ReadEnvironment) String() string            { return "read_environment" }
 
+// WriteEnvironment authorizes creating or updating an environment, including
+// promotion and rollback.
+type WriteEnvironment struct{}
+
+func (WriteEnvironment) ActionFor(urn.Environment) {}
+func (WriteEnvironment) String() string            { return "write_environment" }
+
+// DeleteEnvironment authorizes deleting an environment.
+type DeleteEnvironment struct{}
+
+func (DeleteEnvironment) ActionFor(urn.Environment) {}
+func (DeleteEnvironment) String() string            { return "delete_environment" }
+
 // UpdateEnvironment authorizes updating a specific environment's settings.
 //
 // Valid resource: urn.Environment.

--- a/pkg/rbac/permissions/gateway_logs.go
+++ b/pkg/rbac/permissions/gateway_logs.go
@@ -1,0 +1,9 @@
+package permissions
+
+import "github.com/unkeyed/unkey/pkg/urn"
+
+// ReadGatewayLogs authorizes reading gateway logs.
+type ReadGatewayLogs struct{}
+
+func (ReadGatewayLogs) ActionFor(urn.GatewayLogs) {}
+func (ReadGatewayLogs) String() string            { return "read_gateway_logs" }

--- a/pkg/rbac/permissions/gateway_policies.go
+++ b/pkg/rbac/permissions/gateway_policies.go
@@ -2,6 +2,24 @@ package permissions
 
 import "github.com/unkeyed/unkey/pkg/urn"
 
+// ReadGatewayPolicy authorizes reading a gateway policy.
+type ReadGatewayPolicy struct{}
+
+func (ReadGatewayPolicy) ActionFor(urn.GatewayPolicy) {}
+func (ReadGatewayPolicy) String() string              { return "read_gateway_policy" }
+
+// WriteGatewayPolicy authorizes creating or updating a gateway policy.
+type WriteGatewayPolicy struct{}
+
+func (WriteGatewayPolicy) ActionFor(urn.GatewayPolicy) {}
+func (WriteGatewayPolicy) String() string              { return "write_gateway_policy" }
+
+// DeleteGatewayPolicy authorizes deleting a gateway policy.
+type DeleteGatewayPolicy struct{}
+
+func (DeleteGatewayPolicy) ActionFor(urn.GatewayPolicy) {}
+func (DeleteGatewayPolicy) String() string              { return "delete_gateway_policy" }
+
 // ReadPolicy authorizes reading an environment's gateway policies.
 //
 // Valid resource: urn.GatewayPolicy.

--- a/pkg/rbac/permissions/github_apps.go
+++ b/pkg/rbac/permissions/github_apps.go
@@ -1,0 +1,21 @@
+package permissions
+
+import "github.com/unkeyed/unkey/pkg/urn"
+
+// ReadGitHubApp authorizes reading a GitHub app installation.
+type ReadGitHubApp struct{}
+
+func (ReadGitHubApp) ActionFor(urn.GitHubApp) {}
+func (ReadGitHubApp) String() string          { return "read_github_app" }
+
+// WriteGitHubApp authorizes creating or updating a GitHub app installation.
+type WriteGitHubApp struct{}
+
+func (WriteGitHubApp) ActionFor(urn.GitHubApp) {}
+func (WriteGitHubApp) String() string          { return "write_github_app" }
+
+// DeleteGitHubApp authorizes deleting a GitHub app installation.
+type DeleteGitHubApp struct{}
+
+func (DeleteGitHubApp) ActionFor(urn.GitHubApp) {}
+func (DeleteGitHubApp) String() string          { return "delete_github_app" }

--- a/pkg/rbac/permissions/identities.go
+++ b/pkg/rbac/permissions/identities.go
@@ -18,6 +18,12 @@ type ReadIdentity struct{}
 func (ReadIdentity) ActionFor(urn.Identity) {}
 func (ReadIdentity) String() string         { return "read_identity" }
 
+// WriteIdentity authorizes creating or updating an identity.
+type WriteIdentity struct{}
+
+func (WriteIdentity) ActionFor(urn.Identity) {}
+func (WriteIdentity) String() string         { return "write_identity" }
+
 // UpdateIdentity authorizes updating identity resources.
 //
 // Valid resource: urn.Identity.

--- a/pkg/rbac/permissions/keys.go
+++ b/pkg/rbac/permissions/keys.go
@@ -10,6 +10,12 @@ type ReadKey struct{}
 func (ReadKey) ActionFor(urn.Key) {}
 func (ReadKey) String() string    { return "read_key" }
 
+// WriteKey authorizes creating or updating a key and its role or permission assignments.
+type WriteKey struct{}
+
+func (WriteKey) ActionFor(urn.Key) {}
+func (WriteKey) String() string    { return "write_key" }
+
 // UpdateKey authorizes updating key resources.
 //
 // Valid resource: urn.Key.

--- a/pkg/rbac/permissions/keyspace_logs.go
+++ b/pkg/rbac/permissions/keyspace_logs.go
@@ -1,0 +1,9 @@
+package permissions
+
+import "github.com/unkeyed/unkey/pkg/urn"
+
+// ReadKeyspaceLogs authorizes reading keyspace logs.
+type ReadKeyspaceLogs struct{}
+
+func (ReadKeyspaceLogs) ActionFor(urn.KeyspaceLogs) {}
+func (ReadKeyspaceLogs) String() string             { return "read_keyspace_logs" }

--- a/pkg/rbac/permissions/keyspaces.go
+++ b/pkg/rbac/permissions/keyspaces.go
@@ -10,6 +10,18 @@ type ReadKeyspace struct{}
 func (ReadKeyspace) ActionFor(urn.Keyspace) {}
 func (ReadKeyspace) String() string         { return "read_keyspace" }
 
+// WriteKeyspace authorizes creating or updating a keyspace.
+type WriteKeyspace struct{}
+
+func (WriteKeyspace) ActionFor(urn.Keyspace) {}
+func (WriteKeyspace) String() string         { return "write_keyspace" }
+
+// DeleteKeyspace authorizes deleting a keyspace.
+type DeleteKeyspace struct{}
+
+func (DeleteKeyspace) ActionFor(urn.Keyspace) {}
+func (DeleteKeyspace) String() string         { return "delete_keyspace" }
+
 // CreateKey authorizes creating keys in a keyspace.
 //
 // Valid resource: urn.Keyspace.

--- a/pkg/rbac/permissions/permissions.go
+++ b/pkg/rbac/permissions/permissions.go
@@ -1,0 +1,21 @@
+package permissions
+
+import "github.com/unkeyed/unkey/pkg/urn"
+
+// ReadPermission authorizes reading a permission definition.
+type ReadPermission struct{}
+
+func (ReadPermission) ActionFor(urn.Permission) {}
+func (ReadPermission) String() string           { return "read_permission" }
+
+// WritePermission authorizes creating or updating a permission definition.
+type WritePermission struct{}
+
+func (WritePermission) ActionFor(urn.Permission) {}
+func (WritePermission) String() string           { return "write_permission" }
+
+// DeletePermission authorizes deleting a permission definition.
+type DeletePermission struct{}
+
+func (DeletePermission) ActionFor(urn.Permission) {}
+func (DeletePermission) String() string           { return "delete_permission" }

--- a/pkg/rbac/permissions/projects.go
+++ b/pkg/rbac/permissions/projects.go
@@ -2,6 +2,18 @@ package permissions
 
 import "github.com/unkeyed/unkey/pkg/urn"
 
+// ReadProject authorizes reading a project.
+type ReadProject struct{}
+
+func (ReadProject) ActionFor(urn.Project) {}
+func (ReadProject) String() string        { return "read_project" }
+
+// WriteProject authorizes creating or updating a project.
+type WriteProject struct{}
+
+func (WriteProject) ActionFor(urn.Project) {}
+func (WriteProject) String() string        { return "write_project" }
+
 // CreateProject authorizes creating projects in a workspace.
 //
 // Valid resource: urn.Project.

--- a/pkg/rbac/permissions/ratelimit_logs.go
+++ b/pkg/rbac/permissions/ratelimit_logs.go
@@ -1,0 +1,9 @@
+package permissions
+
+import "github.com/unkeyed/unkey/pkg/urn"
+
+// ReadRatelimitLogs authorizes reading rate limit logs.
+type ReadRatelimitLogs struct{}
+
+func (ReadRatelimitLogs) ActionFor(urn.RatelimitLogs) {}
+func (ReadRatelimitLogs) String() string              { return "read_ratelimit_logs" }

--- a/pkg/rbac/permissions/ratelimit_namespaces.go
+++ b/pkg/rbac/permissions/ratelimit_namespaces.go
@@ -2,6 +2,30 @@ package permissions
 
 import "github.com/unkeyed/unkey/pkg/urn"
 
+// ReadRatelimitNamespace authorizes reading a rate limit namespace.
+type ReadRatelimitNamespace struct{}
+
+func (ReadRatelimitNamespace) ActionFor(urn.RatelimitNamespace) {}
+func (ReadRatelimitNamespace) String() string                   { return "read_ratelimit_namespace" }
+
+// WriteRatelimitNamespace authorizes creating or updating a rate limit namespace.
+type WriteRatelimitNamespace struct{}
+
+func (WriteRatelimitNamespace) ActionFor(urn.RatelimitNamespace) {}
+func (WriteRatelimitNamespace) String() string                   { return "write_ratelimit_namespace" }
+
+// DeleteRatelimitNamespace authorizes deleting a rate limit namespace.
+type DeleteRatelimitNamespace struct{}
+
+func (DeleteRatelimitNamespace) ActionFor(urn.RatelimitNamespace) {}
+func (DeleteRatelimitNamespace) String() string                   { return "delete_ratelimit_namespace" }
+
+// LimitRatelimitNamespace authorizes checking or using a rate limit namespace.
+type LimitRatelimitNamespace struct{}
+
+func (LimitRatelimitNamespace) ActionFor(urn.RatelimitNamespace) {}
+func (LimitRatelimitNamespace) String() string                   { return "limit_ratelimit_namespace" }
+
 // SetOverride authorizes setting overrides in a rate limit namespace.
 //
 // Valid resource: urn.RatelimitNamespace.

--- a/pkg/rbac/permissions/ratelimit_overrides.go
+++ b/pkg/rbac/permissions/ratelimit_overrides.go
@@ -2,6 +2,24 @@ package permissions
 
 import "github.com/unkeyed/unkey/pkg/urn"
 
+// ReadRatelimitOverride authorizes reading a rate limit override.
+type ReadRatelimitOverride struct{}
+
+func (ReadRatelimitOverride) ActionFor(urn.RatelimitOverride) {}
+func (ReadRatelimitOverride) String() string                  { return "read_ratelimit_override" }
+
+// WriteRatelimitOverride authorizes creating or updating a rate limit override.
+type WriteRatelimitOverride struct{}
+
+func (WriteRatelimitOverride) ActionFor(urn.RatelimitOverride) {}
+func (WriteRatelimitOverride) String() string                  { return "write_ratelimit_override" }
+
+// DeleteRatelimitOverride authorizes deleting a rate limit override.
+type DeleteRatelimitOverride struct{}
+
+func (DeleteRatelimitOverride) ActionFor(urn.RatelimitOverride) {}
+func (DeleteRatelimitOverride) String() string                  { return "delete_ratelimit_override" }
+
 // ReadOverride authorizes reading rate limit override resources.
 //
 // Valid resource: urn.RatelimitOverride.

--- a/pkg/rbac/permissions/roles.go
+++ b/pkg/rbac/permissions/roles.go
@@ -1,0 +1,21 @@
+package permissions
+
+import "github.com/unkeyed/unkey/pkg/urn"
+
+// ReadRole authorizes reading a role.
+type ReadRole struct{}
+
+func (ReadRole) ActionFor(urn.Role) {}
+func (ReadRole) String() string     { return "read_role" }
+
+// WriteRole authorizes creating or updating a role and its permission assignments.
+type WriteRole struct{}
+
+func (WriteRole) ActionFor(urn.Role) {}
+func (WriteRole) String() string     { return "write_role" }
+
+// DeleteRole authorizes deleting a role.
+type DeleteRole struct{}
+
+func (DeleteRole) ActionFor(urn.Role) {}
+func (DeleteRole) String() string     { return "delete_role" }


### PR DESCRIPTION
## Notes for description (rewrite before review)

### Stack
- Position: 2 of 9. Review wave 1: model and data.
- Full stack: #7189 → **#7190** → #7191 → #7192 → #7193 → #7195 → #7196 → #7197 → #7198.
- Depends on: #7189. Next: #7191.

### Goal
- Define the 52 canonical resource and action pairs.

### Approach
- Use resource-qualified actions such as `write_app` and `read_deployment_logs`.
- Use one permission file per resource.
- Preserve compile-time resource and action pairing through `ActionFor`.

### Decisions
- Merge create and update into `write_{resource}`.
- Use `write_deployment` for create, update, start, and stop.
- Use `write_environment` for promote and rollback.
- Keep `decrypt_key`, `verify_key`, and `limit_ratelimit_namespace` as separate actions.
- Keep old action types until later PRs migrate their handlers.

### Review order
1. Review the typed `ActionFor` contract.
2. Review resource action names and ownership.
3. Review the 52-pair catalog test.

### Review focus
- Confirm that recursive URNs remain unambiguous because every action names its target resource.
- Confirm that invalid resource and action pairs fail at compile time.

### Verification
- `mise exec -- rask --no-cache ./pkg/rbac ./pkg/urn` passed.
- `mise run build` passed.
