### PR TITLE
Prepare project-scoped authorization data

### DIFF
--- a/internal/services/keys/db/key_find_for_verification.sql_generated.go
+++ b/internal/services/keys/db/key_find_for_verification.sql_generated.go
@@ -27,6 +27,7 @@ select k.id,
        k.pending_migration_id,
        a.ip_whitelist,
        a.workspace_id  as api_workspace_id,
+       ka.project_id   as project_id,
        a.id            as api_id,
        a.deleted_at_m  as api_deleted_at_m,
 
@@ -113,6 +114,7 @@ type FindKeyForVerificationRow struct {
 	PendingMigrationID  sql.NullString `db:"pending_migration_id"`
 	IpWhitelist         sql.NullString `db:"ip_whitelist"`
 	ApiWorkspaceID      string         `db:"api_workspace_id"`
+	ProjectID           string         `db:"project_id"`
 	ApiID               string         `db:"api_id"`
 	ApiDeletedAtM       sql.NullInt64  `db:"api_deleted_at_m"`
 	Roles               interface{}    `db:"roles"`
@@ -149,6 +151,7 @@ type FindKeyForVerificationRow struct {
 //	       k.pending_migration_id,
 //	       a.ip_whitelist,
 //	       a.workspace_id  as api_workspace_id,
+//	       ka.project_id   as project_id,
 //	       a.id            as api_id,
 //	       a.deleted_at_m  as api_deleted_at_m,
 //
@@ -236,6 +239,7 @@ func (q *Queries) FindKeyForVerification(ctx context.Context, db DBTX, hash stri
 		&i.PendingMigrationID,
 		&i.IpWhitelist,
 		&i.ApiWorkspaceID,
+		&i.ProjectID,
 		&i.ApiID,
 		&i.ApiDeletedAtM,
 		&i.Roles,

--- a/internal/services/keys/db/querier_generated.go
+++ b/internal/services/keys/db/querier_generated.go
@@ -32,6 +32,7 @@ type Querier interface {
 	//         k.pending_migration_id,
 	//         a.ip_whitelist,
 	//         a.workspace_id  as api_workspace_id,
+	//         ka.project_id   as project_id,
 	//         a.id            as api_id,
 	//         a.deleted_at_m  as api_deleted_at_m,
 	//

--- a/internal/services/keys/db/queries/key_find_for_verification.sql
+++ b/internal/services/keys/db/queries/key_find_for_verification.sql
@@ -21,6 +21,7 @@ select k.id,
        k.pending_migration_id,
        a.ip_whitelist,
        a.workspace_id  as api_workspace_id,
+       ka.project_id   as project_id,
        a.id            as api_id,
        a.deleted_at_m  as api_deleted_at_m,
 

--- a/internal/services/ratelimit/namespace/parse.go
+++ b/internal/services/ratelimit/namespace/parse.go
@@ -11,6 +11,7 @@ func ParseNamespaceRow(row db.FindRatelimitNamespaceRow) db.FindRatelimitNamespa
 	result := db.FindRatelimitNamespace{
 		ID:                row.ID,
 		WorkspaceID:       row.WorkspaceID,
+		ProjectID:         row.ProjectID,
 		Name:              row.Name,
 		CreatedAtM:        row.CreatedAtM,
 		UpdatedAtM:        row.UpdatedAtM,
@@ -39,6 +40,7 @@ func RowToNamespace(row db.FindManyRatelimitNamespacesRow) db.FindRatelimitNames
 	result := db.FindRatelimitNamespace{
 		ID:                row.ID,
 		WorkspaceID:       row.WorkspaceID,
+		ProjectID:         row.ProjectID,
 		Name:              row.Name,
 		CreatedAtM:        row.CreatedAtM,
 		UpdatedAtM:        row.UpdatedAtM,

--- a/pkg/db/api_find_by_key_auth_ids.sql_generated.go
+++ b/pkg/db/api_find_by_key_auth_ids.sql_generated.go
@@ -11,7 +11,7 @@ import (
 )
 
 const findApisByKeyAuthIds = `-- name: FindApisByKeyAuthIds :many
-SELECT ka.id as key_auth_id, a.id as api_id
+SELECT ka.id as key_auth_id, ka.project_id, a.id as api_id
 FROM apis a
 JOIN key_auth as ka ON ka.id = a.key_auth_id
 WHERE a.workspace_id = ?
@@ -27,13 +27,14 @@ type FindApisByKeyAuthIdsParams struct {
 
 type FindApisByKeyAuthIdsRow struct {
 	KeyAuthID string `db:"key_auth_id"`
+	ProjectID string `db:"project_id"`
 	ApiID     string `db:"api_id"`
 }
 
 // Maps keyspace ids back to the api that owns them, scoped to a workspace.
-// apis.key_auth_id is unique, so each keyspace resolves to at most one api.
+// apis.key_auth_id is unique, so each keyspace resolves to at most one api and project.
 //
-//	SELECT ka.id as key_auth_id, a.id as api_id
+//	SELECT ka.id as key_auth_id, ka.project_id, a.id as api_id
 //	FROM apis a
 //	JOIN key_auth as ka ON ka.id = a.key_auth_id
 //	WHERE a.workspace_id = ?
@@ -60,7 +61,7 @@ func (q *Queries) FindApisByKeyAuthIds(ctx context.Context, db DBTX, arg FindApi
 	var items []FindApisByKeyAuthIdsRow
 	for rows.Next() {
 		var i FindApisByKeyAuthIdsRow
-		if err := rows.Scan(&i.KeyAuthID, &i.ApiID); err != nil {
+		if err := rows.Scan(&i.KeyAuthID, &i.ProjectID, &i.ApiID); err != nil {
 			return nil, err
 		}
 		items = append(items, i)

--- a/pkg/db/identity_list.sql_generated.go
+++ b/pkg/db/identity_list.sql_generated.go
@@ -15,6 +15,7 @@ SELECT
     i.id,
     i.external_id,
     i.workspace_id,
+    i.project_id,
     i.environment,
     i.meta,
     i.deleted,
@@ -55,6 +56,7 @@ type ListIdentitiesRow struct {
 	ID          string        `db:"id"`
 	ExternalID  string        `db:"external_id"`
 	WorkspaceID string        `db:"workspace_id"`
+	ProjectID   string        `db:"project_id"`
 	Environment string        `db:"environment"`
 	Meta        []byte        `db:"meta"`
 	Deleted     bool          `db:"deleted"`
@@ -73,6 +75,7 @@ type ListIdentitiesRow struct {
 //	    i.id,
 //	    i.external_id,
 //	    i.workspace_id,
+//	    i.project_id,
 //	    i.environment,
 //	    i.meta,
 //	    i.deleted,
@@ -120,6 +123,7 @@ func (q *Queries) ListIdentities(ctx context.Context, db DBTX, arg ListIdentitie
 			&i.ID,
 			&i.ExternalID,
 			&i.WorkspaceID,
+			&i.ProjectID,
 			&i.Environment,
 			&i.Meta,
 			&i.Deleted,

--- a/pkg/db/key_auth_find_by_ids_and_workspace.sql_generated.go
+++ b/pkg/db/key_auth_find_by_ids_and_workspace.sql_generated.go
@@ -11,7 +11,7 @@ import (
 )
 
 const findKeyAuthsByIdsAndWorkspace = `-- name: FindKeyAuthsByIdsAndWorkspace :many
-SELECT id, store_encrypted_keys FROM key_auth
+SELECT id, project_id, store_encrypted_keys FROM key_auth
 WHERE workspace_id = ?
   AND id IN (/*SLICE:key_auth_ids*/?)
   AND deleted_at_m IS NULL
@@ -24,13 +24,14 @@ type FindKeyAuthsByIdsAndWorkspaceParams struct {
 
 type FindKeyAuthsByIdsAndWorkspaceRow struct {
 	ID                 string `db:"id"`
+	ProjectID          string `db:"project_id"`
 	StoreEncryptedKeys bool   `db:"store_encrypted_keys"`
 }
 
 // Returns the subset of the given keyspace ids that exist in this workspace
-// and are not soft-deleted, along with each keyspace's encryption setting.
+// and are not soft-deleted, along with each keyspace's project and encryption setting.
 //
-//	SELECT id, store_encrypted_keys FROM key_auth
+//	SELECT id, project_id, store_encrypted_keys FROM key_auth
 //	WHERE workspace_id = ?
 //	  AND id IN (/*SLICE:key_auth_ids*/?)
 //	  AND deleted_at_m IS NULL
@@ -54,7 +55,7 @@ func (q *Queries) FindKeyAuthsByIdsAndWorkspace(ctx context.Context, db DBTX, ar
 	var items []FindKeyAuthsByIdsAndWorkspaceRow
 	for rows.Next() {
 		var i FindKeyAuthsByIdsAndWorkspaceRow
-		if err := rows.Scan(&i.ID, &i.StoreEncryptedKeys); err != nil {
+		if err := rows.Scan(&i.ID, &i.ProjectID, &i.StoreEncryptedKeys); err != nil {
 			return nil, err
 		}
 		items = append(items, i)

--- a/pkg/db/querier_generated.go
+++ b/pkg/db/querier_generated.go
@@ -178,9 +178,9 @@ type Querier interface {
 	//  SELECT pk, id, name, workspace_id, project_id, ip_whitelist, auth_type, key_auth_id, created_at_m, updated_at_m, deleted_at_m, delete_protection FROM apis WHERE id = ?
 	FindApiByID(ctx context.Context, db DBTX, id string) (Api, error)
 	// Maps keyspace ids back to the api that owns them, scoped to a workspace.
-	// apis.key_auth_id is unique, so each keyspace resolves to at most one api.
+	// apis.key_auth_id is unique, so each keyspace resolves to at most one api and project.
 	//
-	//  SELECT ka.id as key_auth_id, a.id as api_id
+	//  SELECT ka.id as key_auth_id, ka.project_id, a.id as api_id
 	//  FROM apis a
 	//  JOIN key_auth as ka ON ka.id = a.key_auth_id
 	//  WHERE a.workspace_id = ?
@@ -498,9 +498,9 @@ type Querier interface {
 	//      AND a.deleted_at_m IS NULL
 	FindKeyAuthsByIds(ctx context.Context, db DBTX, arg FindKeyAuthsByIdsParams) ([]FindKeyAuthsByIdsRow, error)
 	// Returns the subset of the given keyspace ids that exist in this workspace
-	// and are not soft-deleted, along with each keyspace's encryption setting.
+	// and are not soft-deleted, along with each keyspace's project and encryption setting.
 	//
-	//  SELECT id, store_encrypted_keys FROM key_auth
+	//  SELECT id, project_id, store_encrypted_keys FROM key_auth
 	//  WHERE workspace_id = ?
 	//    AND id IN (/*SLICE:key_auth_ids*/?)
 	//    AND deleted_at_m IS NULL
@@ -2049,6 +2049,7 @@ type Querier interface {
 	//      i.id,
 	//      i.external_id,
 	//      i.workspace_id,
+	//      i.project_id,
 	//      i.environment,
 	//      i.meta,
 	//      i.deleted,
@@ -2451,9 +2452,10 @@ type Querier interface {
 	//  WHERE id = ?
 	//  FOR UPDATE
 	LockKeyForUpdate(ctx context.Context, db DBTX, id string) (string, error)
-	//LockRoleByIDAndWorkspaceID
+	// LockRoleByIDAndWorkspaceID serializes role permission changes. It returns
+	// the project ID so authorization can use the role's project-scoped URN.
 	//
-	//  SELECT id, name
+	//  SELECT id, project_id, name
 	//  FROM roles
 	//  WHERE id = ? AND workspace_id = ?
 	//  FOR UPDATE

--- a/pkg/db/queries/api_find_by_key_auth_ids.sql
+++ b/pkg/db/queries/api_find_by_key_auth_ids.sql
@@ -1,7 +1,7 @@
 -- name: FindApisByKeyAuthIds :many
 -- Maps keyspace ids back to the api that owns them, scoped to a workspace.
--- apis.key_auth_id is unique, so each keyspace resolves to at most one api.
-SELECT ka.id as key_auth_id, a.id as api_id
+-- apis.key_auth_id is unique, so each keyspace resolves to at most one api and project.
+SELECT ka.id as key_auth_id, ka.project_id, a.id as api_id
 FROM apis a
 JOIN key_auth as ka ON ka.id = a.key_auth_id
 WHERE a.workspace_id = sqlc.arg(workspace_id)

--- a/pkg/db/queries/identity_list.sql
+++ b/pkg/db/queries/identity_list.sql
@@ -7,6 +7,7 @@ SELECT
     i.id,
     i.external_id,
     i.workspace_id,
+    i.project_id,
     i.environment,
     i.meta,
     i.deleted,

--- a/pkg/db/queries/key_auth_find_by_ids_and_workspace.sql
+++ b/pkg/db/queries/key_auth_find_by_ids_and_workspace.sql
@@ -1,7 +1,7 @@
 -- name: FindKeyAuthsByIdsAndWorkspace :many
 -- Returns the subset of the given keyspace ids that exist in this workspace
--- and are not soft-deleted, along with each keyspace's encryption setting.
-SELECT id, store_encrypted_keys FROM key_auth
+-- and are not soft-deleted, along with each keyspace's project and encryption setting.
+SELECT id, project_id, store_encrypted_keys FROM key_auth
 WHERE workspace_id = sqlc.arg(workspace_id)
   AND id IN (sqlc.slice(key_auth_ids))
   AND deleted_at_m IS NULL;

--- a/pkg/db/queries/role_lock_by_id_and_workspace_id.sql
+++ b/pkg/db/queries/role_lock_by_id_and_workspace_id.sql
@@ -1,5 +1,7 @@
 -- name: LockRoleByIDAndWorkspaceID :one
-SELECT id, name
+-- LockRoleByIDAndWorkspaceID serializes role permission changes. It returns
+-- the project ID so authorization can use the role's project-scoped URN.
+SELECT id, project_id, name
 FROM roles
 WHERE id = sqlc.arg(role_id) AND workspace_id = sqlc.arg(workspace_id)
 FOR UPDATE;

--- a/pkg/db/ratelimit_namespace_find.sql.go
+++ b/pkg/db/ratelimit_namespace_find.sql.go
@@ -14,6 +14,7 @@ type FindRatelimitNamespaceLimitOverride struct {
 type FindRatelimitNamespace struct {
 	ID                string                                         `db:"id"`
 	WorkspaceID       string                                         `db:"workspace_id"`
+	ProjectID         string                                         `db:"project_id"`
 	Name              string                                         `db:"name"`
 	CreatedAtM        int64                                          `db:"created_at_m"`
 	UpdatedAtM        sql.NullInt64                                  `db:"updated_at_m"`

--- a/pkg/db/role_lock_by_id_and_workspace_id.sql_generated.go
+++ b/pkg/db/role_lock_by_id_and_workspace_id.sql_generated.go
@@ -10,7 +10,7 @@ import (
 )
 
 const lockRoleByIDAndWorkspaceID = `-- name: LockRoleByIDAndWorkspaceID :one
-SELECT id, name
+SELECT id, project_id, name
 FROM roles
 WHERE id = ? AND workspace_id = ?
 FOR UPDATE
@@ -22,19 +22,21 @@ type LockRoleByIDAndWorkspaceIDParams struct {
 }
 
 type LockRoleByIDAndWorkspaceIDRow struct {
-	ID   string `db:"id"`
-	Name string `db:"name"`
+	ID        string `db:"id"`
+	ProjectID string `db:"project_id"`
+	Name      string `db:"name"`
 }
 
-// LockRoleByIDAndWorkspaceID
+// LockRoleByIDAndWorkspaceID serializes role permission changes. It returns
+// the project ID so authorization can use the role's project-scoped URN.
 //
-//	SELECT id, name
+//	SELECT id, project_id, name
 //	FROM roles
 //	WHERE id = ? AND workspace_id = ?
 //	FOR UPDATE
 func (q *Queries) LockRoleByIDAndWorkspaceID(ctx context.Context, db DBTX, arg LockRoleByIDAndWorkspaceIDParams) (LockRoleByIDAndWorkspaceIDRow, error) {
 	row := db.QueryRowContext(ctx, lockRoleByIDAndWorkspaceID, arg.RoleID, arg.WorkspaceID)
 	var i LockRoleByIDAndWorkspaceIDRow
-	err := row.Scan(&i.ID, &i.Name)
+	err := row.Scan(&i.ID, &i.ProjectID, &i.Name)
 	return i, err
 }

--- a/pkg/mysql/schema/permissions.sql
+++ b/pkg/mysql/schema/permissions.sql
@@ -4,7 +4,7 @@ CREATE TABLE `permissions` (
 	`workspace_id` varchar(48) COLLATE utf8mb4_0900_as_cs NOT NULL,
 	`project_id` varchar(48) COLLATE utf8mb4_0900_as_cs NOT NULL,
 	`name` varchar(512) NOT NULL,
-	`slug` varchar(128) NOT NULL,
+	`slug` varchar(512) NOT NULL,
 	`description` varchar(512),
 	`created_at_m` bigint NOT NULL DEFAULT 0,
 	`updated_at_m` bigint,
@@ -14,4 +14,3 @@ CREATE TABLE `permissions` (
 );
 
 CREATE INDEX `permissions_project_id_idx` ON `permissions` (`project_id`);
-

--- a/svc/api/internal/testutil/seed/seed.go
+++ b/svc/api/internal/testutil/seed/seed.go
@@ -104,6 +104,7 @@ func (s *Seeder) Seed(ctx context.Context) {
 	s.Resources.RootWorkspace = s.CreateWorkspace(ctx)
 	s.Resources.RootApi = s.CreateAPI(ctx, CreateApiRequest{
 		WorkspaceID:   s.Resources.RootWorkspace.ID,
+		ProjectID:     "",
 		IpWhitelist:   "",
 		EncryptedKeys: false,
 		Name:          nil,
@@ -119,6 +120,7 @@ func (s *Seeder) Seed(ctx context.Context) {
 // CreateApiRequest configures the API to create.
 type CreateApiRequest struct {
 	WorkspaceID   string
+	ProjectID     string
 	IpWhitelist   string
 	EncryptedKeys bool
 	Name          *string
@@ -128,10 +130,14 @@ type CreateApiRequest struct {
 }
 
 // CreateAPI creates an API and its associated key space. The key space is created
-// first since the API references it. Returns the created API which includes the
-// KeyAuthID linking to the key space.
+// first since the API references it. An empty ProjectID uses the workspace's
+// default project. The returned API includes the KeyAuthID that links to the key
+// space.
 func (s *Seeder) CreateAPI(ctx context.Context, req CreateApiRequest) db.Api {
-	projectID := s.defaultProjectID(ctx, req.WorkspaceID)
+	projectID := req.ProjectID
+	if projectID == "" {
+		projectID = s.defaultProjectID(ctx, req.WorkspaceID)
+	}
 	keySpaceID := uid.New(uid.KeySpacePrefix)
 	err := db.Query.InsertKeySpace(ctx, s.DB.RW(), db.InsertKeySpaceParams{
 		ID:                 keySpaceID,

--- a/svc/api/routes/v2_portal_create_session/queries_test.go
+++ b/svc/api/routes/v2_portal_create_session/queries_test.go
@@ -48,6 +48,7 @@ func TestFindApisByKeyAuthIds(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
 	require.Equal(t, api.KeyAuthID.String, rows[0].KeyAuthID)
+	require.Equal(t, api.ProjectID, rows[0].ProjectID)
 	require.Equal(t, api.ID, rows[0].ApiID)
 
 	// Workspace-scoped: another workspace's keyspace resolves to nothing.
@@ -105,6 +106,7 @@ func TestFindKeyAuthsByIdsAndWorkspaceReportsEncryption(t *testing.T) {
 
 	byID := make(map[string]bool, len(rows))
 	for _, row := range rows {
+		require.Equal(t, plain.ProjectID, row.ProjectID)
 		byID[row.ID] = row.StoreEncryptedKeys
 	}
 	require.False(t, byID[plain.KeyAuthID.String])

--- a/svc/api/routes/v2_ratelimit_limit/handler.go
+++ b/svc/api/routes/v2_ratelimit_limit/handler.go
@@ -266,6 +266,7 @@ func (h *Handler) createNamespace(ctx context.Context, s *zen.Session, principal
 			result := db.FindRatelimitNamespace{
 				ID:                id,
 				WorkspaceID:       principal.WorkspaceID,
+				ProjectID:         projectID,
 				Name:              name,
 				CreatedAtM:        now,
 				UpdatedAtM:        sql.NullInt64{Valid: false, Int64: 0},

--- a/svc/api/routes/v2_ratelimit_multi_limit/handler.go
+++ b/svc/api/routes/v2_ratelimit_multi_limit/handler.go
@@ -375,6 +375,7 @@ func (h *Handler) createNamespaces(ctx context.Context, s *zen.Session, principa
 				result[name] = db.FindRatelimitNamespace{
 					ID:                id,
 					WorkspaceID:       principal.WorkspaceID,
+					ProjectID:         projectID,
 					Name:              name,
 					CreatedAtM:        now,
 					UpdatedAtM:        sql.NullInt64{Valid: false, Int64: 0},

--- a/web/internal/db/src/schema/rbac.ts
+++ b/web/internal/db/src/schema/rbac.ts
@@ -14,7 +14,7 @@ export const permissions = mysqlTable(
     workspaceId: id("workspace_id").notNull(),
     projectId: id("project_id").notNull(),
     name: caseInsensitiveVarchar("name", { length: 512 }).notNull(),
-    slug: varchar("slug", { length: 128 }).notNull(),
+    slug: varchar("slug", { length: 512 }).notNull(),
     description: varchar("description", { length: 512 }),
     createdAtM: bigint("created_at_m", { mode: "number" })
       .notNull()


### PR DESCRIPTION
## Notes for description (rewrite before review)

### Stack
- Position: 3 of 9. Review wave 1: model and data.
- Full stack: #7189 → #7190 → **#7191** → #7192 → #7193 → #7195 → #7196 → #7197 → #7198.
- Depends on: #7190. Next: #7192.

### Goal
- Expose the project ownership data required by project-scoped authorization.

### Approach
- Return `project_id` from key, identity, role, and keyspace authorization lookups.
- Preserve `project_id` when rate limit namespace rows enter service models.
- Let API test fixtures create APIs and keyspaces in a selected project.
- Increase permission slug capacity because canonical URNs can exceed 128 characters.

### Decisions
- Keep query selection behavior unchanged.
- Only expose existing project ownership and update its storage contract.
- Keep OpenAPI files unchanged.

### Review order
1. Review source SQL queries and schema changes.
2. Review project data propagation into service models.
3. Review fixture support.
4. Review generated SQL last.

### Review focus
- Confirm that each lookup returns the owning project without changing row selection.
- Confirm that the permission slug capacity covers the canonical permission format.

### Verification
- Focused Rask suites passed.
- `mise run build` passed.
