### PR TITLE
Use canonical permissions in platform handlers

### DIFF
--- a/svc/api/routes/v2_apps_create_app/403_test.go
+++ b/svc/api/routes/v2_apps_create_app/403_test.go
@@ -49,11 +49,11 @@ func TestCreateAppForbidden(t *testing.T) {
 		{name: "wrong action", permissions: []string{"project.*.create_project"}, shouldPass: false},
 		{name: "read does not grant create", permissions: []string{"project.*.read_app"}, shouldPass: false},
 		{name: "unrelated permission", permissions: []string{"api.*.read_api"}, shouldPass: false},
-		{name: "urn style wildcard app permission", permissions: []string{"unkey:v1:" + workspace.ID + ":projects/*/apps/*#create_app"}, shouldPass: true},
-		{name: "urn style specific project permission", permissions: []string{"unkey:v1:" + workspace.ID + ":projects/" + project.ID + "/apps/*#create_app"}, shouldPass: true},
+		{name: "urn style wildcard app permission", permissions: []string{"unkey:v1:" + workspace.ID + ":projects/*/apps/*#write_app"}, shouldPass: true},
+		{name: "urn style specific project permission", permissions: []string{"unkey:v1:" + workspace.ID + ":projects/" + project.ID + "/apps/*#write_app"}, shouldPass: true},
 		{name: "urn style wrong action", permissions: []string{"unkey:v1:" + workspace.ID + ":projects/*/apps/*#read_app"}, shouldPass: false},
-		{name: "urn style other project", permissions: []string{"unkey:v1:" + workspace.ID + ":projects/" + uid.New(uid.ProjectPrefix) + "/apps/*#create_app"}, shouldPass: false},
-		{name: "urn style project resource does not grant app create", permissions: []string{"unkey:v1:" + workspace.ID + ":projects/*#create_app"}, shouldPass: false},
+		{name: "urn style other project", permissions: []string{"unkey:v1:" + workspace.ID + ":projects/" + uid.New(uid.ProjectPrefix) + "/apps/*#write_app"}, shouldPass: false},
+		{name: "urn style project resource does not grant app create", permissions: []string{"unkey:v1:" + workspace.ID + ":projects/*#write_app"}, shouldPass: false},
 		{name: "no permissions", permissions: []string{}, shouldPass: false},
 	}
 

--- a/svc/api/routes/v2_apps_create_app/handler.go
+++ b/svc/api/routes/v2_apps_create_app/handler.go
@@ -100,7 +100,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		}),
 		rbac.U(
 			urn.New().Workspace(principal.WorkspaceID).Project(project.ID).App("*"),
-			permissions.CreateApp{},
+			permissions.WriteApp{},
 		),
 	))
 	if err != nil {

--- a/svc/api/routes/v2_deployments_create_deployment/handler.go
+++ b/svc/api/routes/v2_deployments_create_deployment/handler.go
@@ -84,7 +84,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		}),
 		rbac.U(
 			urn.New().Workspace(principal.WorkspaceID).Project(environment.ProjectID).App(environment.AppID).Environment(environment.ID).Deployment("*"),
-			permissions.CreateDeployment{},
+			permissions.WriteDeployment{},
 		),
 	))
 	if err != nil {

--- a/svc/api/routes/v2_deployments_promote_deployment/handler.go
+++ b/svc/api/routes/v2_deployments_promote_deployment/handler.go
@@ -66,8 +66,8 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			Action:       rbac.PromoteDeployment,
 		}),
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project(dep.ProjectID).App(dep.AppID).Environment(dep.EnvironmentID).Deployment(dep.ID),
-			permissions.PromoteDeployment{},
+			urn.New().Workspace(principal.WorkspaceID).Project(dep.ProjectID).App(dep.AppID).Environment(dep.EnvironmentID),
+			permissions.WriteEnvironment{},
 		),
 	))
 	if err != nil {

--- a/svc/api/routes/v2_deployments_rollback_deployment/handler.go
+++ b/svc/api/routes/v2_deployments_rollback_deployment/handler.go
@@ -66,8 +66,8 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			Action:       rbac.RollbackDeployment,
 		}),
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project(dep.ProjectID).App(dep.AppID).Environment(dep.EnvironmentID).Deployment(dep.ID),
-			permissions.RollbackDeployment{},
+			urn.New().Workspace(principal.WorkspaceID).Project(dep.ProjectID).App(dep.AppID).Environment(dep.EnvironmentID),
+			permissions.WriteEnvironment{},
 		),
 	))
 	if err != nil {

--- a/svc/api/routes/v2_deployments_start_deployment/202_test.go
+++ b/svc/api/routes/v2_deployments_start_deployment/202_test.go
@@ -24,9 +24,7 @@ func TestStartDeployment(t *testing.T) {
 	route := newRoute(h, restate)
 	h.Register(route)
 
-	setup := h.CreateTestDeploymentSetup(testutil.CreateTestDeploymentSetupOptions{
-		Permissions: []string{"environment.*.start_deployment"},
-	})
+	setup := h.CreateTestDeploymentSetup()
 
 	preview := h.CreateEnvironment(seed.CreateEnvironmentRequest{
 		ID:          uid.New(uid.EnvironmentPrefix),
@@ -47,13 +45,17 @@ func TestStartDeployment(t *testing.T) {
 		DesiredState:  mysqltype.DeploymentsDesiredStateStopped,
 		GitBranch:     "KEBAP",
 	})
+	rootKey := h.CreateRootKey(
+		setup.Workspace.ID,
+		"unkey:v1:"+setup.Workspace.ID+":projects/*/apps/*/environments/*/deployments/*#write_deployment",
+	)
 
-	res := testutil.CallRoute[handler.Request, handler.Response](h, route, authHeaders(setup.RootKey), handler.Request{
+	res := testutil.CallRoute[handler.Request, handler.Response](h, route, authHeaders(rootKey), handler.Request{
 		DeploymentId: dep.ID,
 	})
 	require.Equal(t, http.StatusAccepted, res.Status, "expected 202, received: %s", res.RawBody)
 
-	rootKeyID, err := db.Query.FindKeyIDByHash(context.Background(), h.DB.RO(), hash.Sha256(setup.RootKey))
+	rootKeyID, err := db.Query.FindKeyIDByHash(context.Background(), h.DB.RO(), hash.Sha256(rootKey))
 	require.NoError(t, err)
 
 	observed := testutil.Receive(t, wakes, 10*time.Second)

--- a/svc/api/routes/v2_deployments_start_deployment/handler.go
+++ b/svc/api/routes/v2_deployments_start_deployment/handler.go
@@ -67,7 +67,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		}),
 		rbac.U(
 			urn.New().Workspace(principal.WorkspaceID).Project(dep.ProjectID).App(dep.AppID).Environment(dep.EnvironmentID).Deployment(dep.ID),
-			permissions.StartDeployment{},
+			permissions.WriteDeployment{},
 		),
 	))
 	if err != nil {

--- a/svc/api/routes/v2_deployments_stop_deployment/202_test.go
+++ b/svc/api/routes/v2_deployments_stop_deployment/202_test.go
@@ -24,9 +24,7 @@ func TestStopDeployment(t *testing.T) {
 	route := newRoute(h, restateClient)
 	h.Register(route)
 
-	setup := h.CreateTestDeploymentSetup(testutil.CreateTestDeploymentSetupOptions{
-		Permissions: []string{"environment.*.stop_deployment"},
-	})
+	setup := h.CreateTestDeploymentSetup()
 
 	preview := h.CreateEnvironment(seed.CreateEnvironmentRequest{
 		ID:          uid.New(uid.EnvironmentPrefix),
@@ -45,13 +43,17 @@ func TestStopDeployment(t *testing.T) {
 		EnvironmentID: preview.ID,
 		Status:        mysqltype.DeploymentsStatusReady,
 	})
+	rootKey := h.CreateRootKey(
+		setup.Workspace.ID,
+		"unkey:v1:"+setup.Workspace.ID+":projects/*/apps/*/environments/*/deployments/*#write_deployment",
+	)
 
-	res := testutil.CallRoute[handler.Request, handler.Response](h, route, authHeaders(setup.RootKey), handler.Request{
+	res := testutil.CallRoute[handler.Request, handler.Response](h, route, authHeaders(rootKey), handler.Request{
 		DeploymentId: dep.ID,
 	})
 	require.Equal(t, http.StatusAccepted, res.Status, "expected 202, received: %s", res.RawBody)
 
-	rootKeyID, err := db.Query.FindKeyIDByHash(context.Background(), h.DB.RO(), hash.Sha256(setup.RootKey))
+	rootKeyID, err := db.Query.FindKeyIDByHash(context.Background(), h.DB.RO(), hash.Sha256(rootKey))
 	require.NoError(t, err)
 
 	observed := testutil.Receive(t, stops, 10*time.Second)

--- a/svc/api/routes/v2_deployments_stop_deployment/handler.go
+++ b/svc/api/routes/v2_deployments_stop_deployment/handler.go
@@ -67,7 +67,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		}),
 		rbac.U(
 			urn.New().Workspace(principal.WorkspaceID).Project(dep.ProjectID).App(dep.AppID).Environment(dep.EnvironmentID).Deployment(dep.ID),
-			permissions.StopDeployment{},
+			permissions.WriteDeployment{},
 		),
 	))
 	if err != nil {

--- a/svc/api/routes/v2_domains_create_domain/403_test.go
+++ b/svc/api/routes/v2_domains_create_domain/403_test.go
@@ -45,7 +45,7 @@ func TestCreateDomainPermissions(t *testing.T) {
 	}{
 		{name: "wildcard permission", permissions: []string{"environment.*.create_domain"}, shouldPass: true},
 		{name: "specific environment permission", permissions: []string{fmt.Sprintf("environment.%s.create_domain", env.environmentID)}, shouldPass: true},
-		{name: "canonical urn grant", permissions: []string{fmt.Sprintf("unkey:v1:%s:projects/%s/apps/%s/environments/%s/domains/*#create_domain", env.workspaceID, env.projectID, env.appID, env.environmentID)}, shouldPass: true},
+		{name: "canonical urn grant", permissions: []string{fmt.Sprintf("unkey:v1:%s:projects/%s/apps/%s/environments/%s/domains/*#write_domain", env.workspaceID, env.projectID, env.appID, env.environmentID)}, shouldPass: true},
 		{name: "permission alongside unrelated grants", permissions: []string{"api.*.read_api", "environment.*.create_domain"}, shouldPass: true},
 		{name: "read action is not enough", permissions: []string{"environment.*.read_environment"}, shouldPass: false},
 		{name: "update action is not enough", permissions: []string{"environment.*.update_environment"}, shouldPass: false},
@@ -53,7 +53,7 @@ func TestCreateDomainPermissions(t *testing.T) {
 		{name: "create_app is not enough", permissions: []string{"project.*.create_app"}, shouldPass: false},
 		{name: "action scoped to the wrong resource type", permissions: []string{"app.*.create_domain"}, shouldPass: false},
 		{name: "other environment id does not match", permissions: []string{fmt.Sprintf("environment.%s.create_domain", uid.New(uid.EnvironmentPrefix))}, shouldPass: false},
-		{name: "urn missing the project and app segments", permissions: []string{fmt.Sprintf("unkey:v1:%s:environments/*#create_domain", env.workspaceID)}, shouldPass: false},
+		{name: "urn missing the project and app segments", permissions: []string{fmt.Sprintf("unkey:v1:%s:environments/*#write_domain", env.workspaceID)}, shouldPass: false},
 		{name: "unrelated permission", permissions: []string{"api.*.read_api"}, shouldPass: false},
 		{name: "no permissions", permissions: []string{}, shouldPass: false},
 	}

--- a/svc/api/routes/v2_domains_create_domain/handler.go
+++ b/svc/api/routes/v2_domains_create_domain/handler.go
@@ -90,7 +90,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		}),
 		rbac.U(
 			urn.New().Workspace(principal.WorkspaceID).Project(env.ProjectID).App(env.AppID).Environment(env.ID).Domain("*"),
-			permissions.CreateDomain{},
+			permissions.WriteDomain{},
 		),
 	)); err != nil {
 		return apierrors.MaskInsufficientPermissionsAsNotFound(

--- a/svc/api/routes/v2_domains_verify_domain/403_test.go
+++ b/svc/api/routes/v2_domains_verify_domain/403_test.go
@@ -28,7 +28,7 @@ func TestVerifyDomainPermissions(t *testing.T) {
 	}{
 		{name: "wildcard permission", permissions: []string{"environment.*.verify_domain"}, shouldPass: true},
 		{name: "specific environment permission", permissions: []string{"environment.<env>.verify_domain"}, shouldPass: true},
-		{name: "canonical urn grant", permissions: []string{"<urn>.verify_domain"}, shouldPass: true},
+		{name: "canonical urn grant", permissions: []string{"<urn>.write_domain"}, shouldPass: true},
 		{name: "permission alongside unrelated grants", permissions: []string{"api.*.read_api", "environment.*.verify_domain"}, shouldPass: true},
 		{name: "create action is not enough", permissions: []string{"environment.*.create_domain"}, shouldPass: false},
 		{name: "read action is not enough", permissions: []string{"environment.*.read_domain"}, shouldPass: false},
@@ -48,8 +48,8 @@ func TestVerifyDomainPermissions(t *testing.T) {
 				switch p {
 				case "environment.<env>.verify_domain":
 					p = fmt.Sprintf("environment.%s.verify_domain", seeded.environmentID)
-				case "<urn>.verify_domain":
-					p = fmt.Sprintf("unkey:v1:%s:projects/%s/apps/%s/environments/%s/domains/*#verify_domain", seeded.workspaceID, seeded.projectID, seeded.appID, seeded.environmentID)
+				case "<urn>.write_domain":
+					p = fmt.Sprintf("unkey:v1:%s:projects/%s/apps/%s/environments/%s/domains/*#write_domain", seeded.workspaceID, seeded.projectID, seeded.appID, seeded.environmentID)
 				}
 				permissions[i] = p
 			}

--- a/svc/api/routes/v2_domains_verify_domain/handler.go
+++ b/svc/api/routes/v2_domains_verify_domain/handler.go
@@ -87,7 +87,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		}),
 		rbac.U(
 			urn.New().Workspace(principal.WorkspaceID).Project(domain.ProjectID).App(domain.AppID).Environment(domain.EnvironmentID).Domain(domain.ID),
-			permissions.VerifyDomain{},
+			permissions.WriteDomain{},
 		),
 	)); err != nil {
 		return apierrors.MaskInsufficientPermissionsAsNotFound(

--- a/svc/api/routes/v2_environments_list_environment_variables/handler.go
+++ b/svc/api/routes/v2_environments_list_environment_variables/handler.go
@@ -82,8 +82,8 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			Action:       rbac.ReadEnvironmentVariables,
 		}),
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project(env.ProjectID).App(env.AppID).Environment(env.ID),
-			permissions.ReadEnvironmentVariables{},
+			urn.New().Workspace(principal.WorkspaceID).Project(env.ProjectID).App(env.AppID).Environment(env.ID).Variable("*"),
+			permissions.ReadEnvironmentVariable{},
 		),
 	))
 	if err != nil {

--- a/svc/api/routes/v2_environments_remove_environment_variables/403_test.go
+++ b/svc/api/routes/v2_environments_remove_environment_variables/403_test.go
@@ -26,6 +26,8 @@ func TestRemoveEnvironmentVariablesForbidden(t *testing.T) {
 	}{
 		{name: "wildcard permission", permissions: []string{"environment.*.remove_environment_variables"}, shouldPass: true},
 		{name: "specific permission", permissions: []string{fmt.Sprintf("environment.%s.remove_environment_variables", env.environmentID)}, shouldPass: true},
+		{name: "canonical delete", permissions: []string{fmt.Sprintf("unkey:v1:%s:projects/%s/apps/%s/environments/%s/variables/*#delete_environment_variable", env.workspaceID, env.projectID, env.appID, env.environmentID)}, shouldPass: true},
+		{name: "canonical write is not enough", permissions: []string{fmt.Sprintf("unkey:v1:%s:projects/%s/apps/%s/environments/%s/variables/*#write_environment_variable", env.workspaceID, env.projectID, env.appID, env.environmentID)}, shouldPass: false},
 		{name: "permission and more", permissions: []string{"some.other.permission", "environment.*.remove_environment_variables"}, shouldPass: true},
 		{name: "update action is not enough", permissions: []string{"environment.*.update_environment"}, shouldPass: false},
 		{name: "read action is not enough", permissions: []string{"environment.*.read_environment"}, shouldPass: false},

--- a/svc/api/routes/v2_environments_remove_environment_variables/handler.go
+++ b/svc/api/routes/v2_environments_remove_environment_variables/handler.go
@@ -82,8 +82,8 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			Action:       rbac.RemoveEnvironmentVariables,
 		}),
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project(env.ProjectID).App(env.AppID).Environment(env.ID),
-			permissions.RemoveEnvironmentVariables{},
+			urn.New().Workspace(principal.WorkspaceID).Project(env.ProjectID).App(env.AppID).Environment(env.ID).Variable("*"),
+			permissions.DeleteEnvironmentVariable{},
 		),
 	))
 	if err != nil {

--- a/svc/api/routes/v2_environments_set_environment_variables/403_test.go
+++ b/svc/api/routes/v2_environments_set_environment_variables/403_test.go
@@ -23,10 +23,15 @@ func TestSetEnvironmentVariablesForbidden(t *testing.T) {
 	testCases := []struct {
 		name        string
 		permissions []string
+		prune       bool
 		shouldPass  bool
 	}{
 		{name: "wildcard permission", permissions: []string{"environment.*.set_environment_variables"}, shouldPass: true},
 		{name: "specific permission", permissions: []string{fmt.Sprintf("environment.%s.set_environment_variables", env.environmentID)}, shouldPass: true},
+		{name: "canonical write", permissions: []string{fmt.Sprintf("unkey:v1:%s:projects/%s/apps/%s/environments/%s/variables/*#write_environment_variable", env.workspaceID, env.projectID, env.appID, env.environmentID)}, shouldPass: true},
+		{name: "canonical write and delete can prune", permissions: []string{fmt.Sprintf("unkey:v1:%s:projects/%s/apps/%s/environments/%s/variables/*#write_environment_variable", env.workspaceID, env.projectID, env.appID, env.environmentID), fmt.Sprintf("unkey:v1:%s:projects/%s/apps/%s/environments/%s/variables/*#delete_environment_variable", env.workspaceID, env.projectID, env.appID, env.environmentID)}, prune: true, shouldPass: true},
+		{name: "canonical write cannot prune", permissions: []string{fmt.Sprintf("unkey:v1:%s:projects/%s/apps/%s/environments/%s/variables/*#write_environment_variable", env.workspaceID, env.projectID, env.appID, env.environmentID)}, prune: true, shouldPass: false},
+		{name: "canonical delete cannot write", permissions: []string{fmt.Sprintf("unkey:v1:%s:projects/%s/apps/%s/environments/%s/variables/*#delete_environment_variable", env.workspaceID, env.projectID, env.appID, env.environmentID)}, shouldPass: false},
 		{name: "permission and more", permissions: []string{"some.other.permission", "environment.*.set_environment_variables"}, shouldPass: true},
 		{name: "update action is not enough", permissions: []string{"environment.*.update_environment"}, shouldPass: false},
 		{name: "read action is not enough", permissions: []string{"environment.*.read_environment"}, shouldPass: false},
@@ -40,9 +45,11 @@ func TestSetEnvironmentVariablesForbidden(t *testing.T) {
 			rootKey := h.CreateRootKey(env.workspaceID, tc.permissions...)
 			headers := authHeaders(rootKey)
 
-			res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, makeRequest(env, []openapi.EnvironmentVariableInput{
+			req := makeRequest(env, []openapi.EnvironmentVariableInput{
 				{Key: "KEY", Value: "value"},
-			}))
+			})
+			req.Prune = ptr(tc.prune)
+			res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, req)
 			if tc.shouldPass {
 				require.Equal(t, 200, res.Status, "expected 200 for %v, got: %s", tc.permissions, res.RawBody)
 				return

--- a/svc/api/routes/v2_environments_set_environment_variables/handler.go
+++ b/svc/api/routes/v2_environments_set_environment_variables/handler.go
@@ -92,6 +92,15 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		)
 	}
 
+	variableURN := urn.New().Workspace(principal.WorkspaceID).Project(env.ProjectID).App(env.AppID).Environment(env.ID).Variable("*")
+	variablePermission := rbac.U(variableURN, permissions.WriteEnvironmentVariable{})
+	if ptr.SafeDeref(req.Prune, false) {
+		variablePermission = rbac.And(
+			variablePermission,
+			rbac.U(variableURN, permissions.DeleteEnvironmentVariable{}),
+		)
+	}
+
 	err = principal.Authorize(rbac.Or(
 		rbac.T(rbac.Tuple{
 			ResourceType: rbac.Environment,
@@ -103,10 +112,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			ResourceID:   env.ID,
 			Action:       rbac.SetEnvironmentVariables,
 		}),
-		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project(env.ProjectID).App(env.AppID).Environment(env.ID),
-			permissions.SetEnvironmentVariables{},
-		),
+		variablePermission,
 	))
 	if err != nil {
 		return err

--- a/svc/api/routes/v2_environments_update_settings/handler.go
+++ b/svc/api/routes/v2_environments_update_settings/handler.go
@@ -110,7 +110,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		}),
 		rbac.U(
 			urn.New().Workspace(principal.WorkspaceID).Project(environment.ProjectID).App(environment.AppID).Environment(environment.ID),
-			permissions.UpdateEnvironment{},
+			permissions.WriteEnvironment{},
 		),
 	))
 	if err != nil {

--- a/svc/api/routes/v2_gateway_list_policies/200_test.go
+++ b/svc/api/routes/v2_gateway_list_policies/200_test.go
@@ -282,7 +282,7 @@ func TestListPoliciesSuccessfully(t *testing.T) {
 		h.Register(writeRoute)
 
 		env := seedEnvironment(t, h)
-		api := h.CreateApi(seed.CreateApiRequest{WorkspaceID: workspace.ID})
+		api := h.CreateApi(seed.CreateApiRequest{WorkspaceID: workspace.ID, ProjectID: env.projectID})
 		writeKey := h.CreateRootKey(workspace.ID, "environment.*.set_policies")
 
 		writeRes := testutil.CallRoute[setpolicies.Request, setpolicies.Response](h, writeRoute, authHeaders(writeKey), setpolicies.Request{

--- a/svc/api/routes/v2_gateway_list_policies/403_test.go
+++ b/svc/api/routes/v2_gateway_list_policies/403_test.go
@@ -26,12 +26,12 @@ func TestListPoliciesForbidden(t *testing.T) {
 	}{
 		{name: "wildcard permission", permissions: []string{"environment.*.read_policies"}, shouldPass: true},
 		{name: "specific permission", permissions: []string{fmt.Sprintf("environment.%s.read_policies", env.environmentID)}, shouldPass: true},
-		{name: "canonical urn grant", permissions: []string{fmt.Sprintf("unkey:v1:%s:projects/%s/apps/%s/environments/%s/gateway/policies/*#read_policy", env.workspaceID, env.projectID, env.appID, env.environmentID)}, shouldPass: true},
+		{name: "canonical urn grant", permissions: []string{fmt.Sprintf("unkey:v1:%s:projects/%s/apps/%s/environments/%s/gateway/policies/*#read_gateway_policy", env.workspaceID, env.projectID, env.appID, env.environmentID)}, shouldPass: true},
 		{name: "permission and more", permissions: []string{"some.other.permission", "environment.*.read_policies"}, shouldPass: true},
 		{name: "set action is not enough", permissions: []string{"environment.*.set_policies"}, shouldPass: false},
 		{name: "read environment action is not enough", permissions: []string{"environment.*.read_environment"}, shouldPass: false},
 		{name: "other environment id does not match", permissions: []string{fmt.Sprintf("environment.%s.read_policies", uid.New(uid.EnvironmentPrefix))}, shouldPass: false},
-		{name: "urn missing the project and app segments", permissions: []string{fmt.Sprintf("unkey:v1:%s:environments/*#read_policy", env.workspaceID)}, shouldPass: false},
+		{name: "urn missing the project and app segments", permissions: []string{fmt.Sprintf("unkey:v1:%s:environments/*#read_gateway_policy", env.workspaceID)}, shouldPass: false},
 		{name: "unrelated permission", permissions: []string{"api.*.read_api"}, shouldPass: false},
 		{name: "no permissions", permissions: []string{}, shouldPass: false},
 	}

--- a/svc/api/routes/v2_gateway_list_policies/handler.go
+++ b/svc/api/routes/v2_gateway_list_policies/handler.go
@@ -79,7 +79,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		}),
 		rbac.U(
 			urn.New().Workspace(principal.WorkspaceID).Project(env.ProjectID).App(env.AppID).Environment(env.ID).Gateway().Policy("*"),
-			permissions.ReadPolicy{},
+			permissions.ReadGatewayPolicy{},
 		),
 	))
 	if err != nil {

--- a/svc/api/routes/v2_gateway_set_policies/200_test.go
+++ b/svc/api/routes/v2_gateway_set_policies/200_test.go
@@ -40,7 +40,7 @@ func TestSetPoliciesSuccessfully(t *testing.T) {
 
 	t.Run("batch of all five variants stores dashboard-compatible wire JSON", func(t *testing.T) {
 		env := seedEnvironment(t, h)
-		api := h.CreateApi(seed.CreateApiRequest{WorkspaceID: workspace.ID})
+		api := h.CreateApi(seed.CreateApiRequest{WorkspaceID: workspace.ID, ProjectID: env.projectID})
 
 		call(t, makeRequest(env, []openapi.Policy{
 			{
@@ -202,8 +202,8 @@ func TestSetPoliciesSuccessfully(t *testing.T) {
 	// in the gateway or the dashboard.
 	t.Run("stores every identifier, matcher and keyauth sub-shape", func(t *testing.T) {
 		env := seedEnvironment(t, h)
-		apiA := h.CreateApi(seed.CreateApiRequest{WorkspaceID: workspace.ID})
-		apiB := h.CreateApi(seed.CreateApiRequest{WorkspaceID: workspace.ID})
+		apiA := h.CreateApi(seed.CreateApiRequest{WorkspaceID: workspace.ID, ProjectID: env.projectID})
+		apiB := h.CreateApi(seed.CreateApiRequest{WorkspaceID: workspace.ID, ProjectID: env.projectID})
 
 		present := openapi.FieldMatchPresent(true)
 		kitchenSink := openapi.Policy{

--- a/svc/api/routes/v2_gateway_set_policies/400_test.go
+++ b/svc/api/routes/v2_gateway_set_policies/400_test.go
@@ -23,7 +23,7 @@ func TestSetPoliciesBadRequest(t *testing.T) {
 
 	workspace := h.Resources().UserWorkspace
 	env := seedEnvironment(t, h)
-	api := h.CreateApi(seed.CreateApiRequest{WorkspaceID: workspace.ID})
+	api := h.CreateApi(seed.CreateApiRequest{WorkspaceID: workspace.ID, ProjectID: env.projectID})
 	rootKey := h.CreateRootKey(workspace.ID, "environment.*.set_policies")
 	headers := authHeaders(rootKey)
 

--- a/svc/api/routes/v2_gateway_set_policies/403_test.go
+++ b/svc/api/routes/v2_gateway_set_policies/403_test.go
@@ -27,12 +27,14 @@ func TestSetPoliciesForbidden(t *testing.T) {
 	}{
 		{name: "wildcard permission", permissions: []string{"environment.*.set_policies"}, shouldPass: true},
 		{name: "specific permission", permissions: []string{fmt.Sprintf("environment.%s.set_policies", env.environmentID)}, shouldPass: true},
-		{name: "canonical urn grant", permissions: []string{fmt.Sprintf("unkey:v1:%s:projects/%s/apps/%s/environments/%s/gateway/policies/*#write_policy", env.workspaceID, env.projectID, env.appID, env.environmentID)}, shouldPass: true},
+		{name: "canonical write and delete", permissions: []string{fmt.Sprintf("unkey:v1:%s:projects/%s/apps/%s/environments/%s/gateway/policies/*#write_gateway_policy", env.workspaceID, env.projectID, env.appID, env.environmentID), fmt.Sprintf("unkey:v1:%s:projects/%s/apps/%s/environments/%s/gateway/policies/*#delete_gateway_policy", env.workspaceID, env.projectID, env.appID, env.environmentID)}, shouldPass: true},
+		{name: "canonical write without delete", permissions: []string{fmt.Sprintf("unkey:v1:%s:projects/%s/apps/%s/environments/%s/gateway/policies/*#write_gateway_policy", env.workspaceID, env.projectID, env.appID, env.environmentID)}, shouldPass: false},
+		{name: "canonical delete without write", permissions: []string{fmt.Sprintf("unkey:v1:%s:projects/%s/apps/%s/environments/%s/gateway/policies/*#delete_gateway_policy", env.workspaceID, env.projectID, env.appID, env.environmentID)}, shouldPass: false},
 		{name: "permission and more", permissions: []string{"some.other.permission", "environment.*.set_policies"}, shouldPass: true},
 		{name: "update action is not enough", permissions: []string{"environment.*.update_environment"}, shouldPass: false},
 		{name: "set variables action is not enough", permissions: []string{"environment.*.set_environment_variables"}, shouldPass: false},
 		{name: "other environment id does not match", permissions: []string{fmt.Sprintf("environment.%s.set_policies", uid.New(uid.EnvironmentPrefix))}, shouldPass: false},
-		{name: "urn missing the project and app segments", permissions: []string{fmt.Sprintf("unkey:v1:%s:environments/*#write_policy", env.workspaceID)}, shouldPass: false},
+		{name: "urn missing the project and app segments", permissions: []string{fmt.Sprintf("unkey:v1:%s:environments/*#write_gateway_policy", env.workspaceID)}, shouldPass: false},
 		{name: "unrelated permission", permissions: []string{"api.*.read_api"}, shouldPass: false},
 		{name: "no permissions", permissions: []string{}, shouldPass: false},
 	}

--- a/svc/api/routes/v2_gateway_set_policies/404_test.go
+++ b/svc/api/routes/v2_gateway_set_policies/404_test.go
@@ -72,8 +72,22 @@ func TestSetPoliciesNotFound(t *testing.T) {
 		require.Contains(t, res.Body.Error.Type, "key_space_not_found")
 	})
 
+	t.Run("keyauth referencing another project's keyspace", func(t *testing.T) {
+		foreign := h.CreateApi(seed.CreateApiRequest{WorkspaceID: env.workspaceID})
+		require.NotEqual(t, env.projectID, foreign.ProjectID)
+
+		res := testutil.CallRoute[handler.Request, openapi.NotFoundErrorResponse](h, route, headers,
+			makeRequest(env, []openapi.Policy{{
+				Name:    "k",
+				Enabled: true,
+				Keyauth: &openapi.KeyauthPolicy{Keyspaces: []string{foreign.KeyAuthID.String}},
+			}}))
+		require.Equal(t, http.StatusNotFound, res.Status, "expected 404, received: %s", res.RawBody)
+		require.Contains(t, res.Body.Error.Type, "key_space_not_found")
+	})
+
 	t.Run("keyauth referencing a soft-deleted keyspace", func(t *testing.T) {
-		api := h.CreateApi(seed.CreateApiRequest{WorkspaceID: env.workspaceID})
+		api := h.CreateApi(seed.CreateApiRequest{WorkspaceID: env.workspaceID, ProjectID: env.projectID})
 		_, err := h.DB.RW().ExecContext(context.Background(),
 			"UPDATE key_auth SET deleted_at_m = ? WHERE id = ?",
 			time.Now().UnixMilli(), api.KeyAuthID.String)

--- a/svc/api/routes/v2_gateway_set_policies/handler.go
+++ b/svc/api/routes/v2_gateway_set_policies/handler.go
@@ -75,6 +75,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		)
 	}
 
+	policyURN := urn.New().Workspace(principal.WorkspaceID).Project(env.ProjectID).App(env.AppID).Environment(env.ID).Gateway().Policy("*")
 	err = principal.Authorize(rbac.Or(
 		rbac.T(rbac.Tuple{
 			ResourceType: rbac.Environment,
@@ -86,9 +87,9 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			ResourceID:   env.ID,
 			Action:       rbac.SetPolicies,
 		}),
-		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project(env.ProjectID).App(env.AppID).Environment(env.ID).Gateway().Policy("*"),
-			permissions.WritePolicy{},
+		rbac.And(
+			rbac.U(policyURN, permissions.WriteGatewayPolicy{}),
+			rbac.U(policyURN, permissions.DeleteGatewayPolicy{}),
 		),
 	))
 	if err != nil {
@@ -119,12 +120,12 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		}
 		for _, id := range keyspaceIDs {
 			if !slices.ContainsFunc(found, func(row db.FindKeyAuthsByIdsAndWorkspaceRow) bool {
-				return row.ID == id
+				return row.ID == id && row.ProjectID == env.ProjectID
 			}) {
 				return fault.New(
 					"keyspace not found",
 					fault.Code(codes.Data.KeySpace.NotFound.URN()),
-					fault.Internal("keyspace not found in workspace"),
+					fault.Internal("keyspace not found in project"),
 					fault.Public(fmt.Sprintf("Keyspace %q does not exist.", id)),
 				)
 			}

--- a/svc/api/routes/v2_gateway_update_policy/200_test.go
+++ b/svc/api/routes/v2_gateway_update_policy/200_test.go
@@ -191,7 +191,7 @@ func TestUpdatePolicySuccessfully(t *testing.T) {
 	t.Run("update keyauth with owned keyspaces", func(t *testing.T) {
 		env := seedEnvironment(t, h)
 		ids := seedFirewallPolicies(t, h, env, 1)
-		api := h.CreateApi(seed.CreateApiRequest{WorkspaceID: workspace.ID})
+		api := h.CreateApi(seed.CreateApiRequest{WorkspaceID: workspace.ID, ProjectID: env.projectID})
 
 		req := makeRequest(env, ids[0])
 		req.Keyauth = &openapi.KeyauthPolicy{

--- a/svc/api/routes/v2_gateway_update_policy/403_test.go
+++ b/svc/api/routes/v2_gateway_update_policy/403_test.go
@@ -28,12 +28,12 @@ func TestUpdatePolicyForbidden(t *testing.T) {
 	}{
 		{name: "wildcard permission", permissions: []string{"environment.*.update_policy"}, shouldPass: true},
 		{name: "specific permission", permissions: []string{fmt.Sprintf("environment.%s.update_policy", env.environmentID)}, shouldPass: true},
-		{name: "canonical urn grant", permissions: []string{fmt.Sprintf("unkey:v1:%s:projects/%s/apps/%s/environments/%s/gateway/policies/*#write_policy", env.workspaceID, env.projectID, env.appID, env.environmentID)}, shouldPass: true},
+		{name: "canonical urn grant", permissions: []string{fmt.Sprintf("unkey:v1:%s:projects/%s/apps/%s/environments/%s/gateway/policies/*#write_gateway_policy", env.workspaceID, env.projectID, env.appID, env.environmentID)}, shouldPass: true},
 		{name: "permission and more", permissions: []string{"some.other.permission", "environment.*.update_policy"}, shouldPass: true},
 		{name: "read action is not enough", permissions: []string{"environment.*.read_policies"}, shouldPass: false},
 		{name: "set_policies action is not enough", permissions: []string{"environment.*.set_policies"}, shouldPass: false},
 		{name: "other environment id does not match", permissions: []string{fmt.Sprintf("environment.%s.update_policy", uid.New(uid.EnvironmentPrefix))}, shouldPass: false},
-		{name: "urn missing the project and app segments", permissions: []string{fmt.Sprintf("unkey:v1:%s:environments/*#write_policy", env.workspaceID)}, shouldPass: false},
+		{name: "urn missing the project and app segments", permissions: []string{fmt.Sprintf("unkey:v1:%s:environments/*#write_gateway_policy", env.workspaceID)}, shouldPass: false},
 		{name: "unrelated permission", permissions: []string{"api.*.read_api"}, shouldPass: false},
 		{name: "no permissions", permissions: []string{}, shouldPass: false},
 	}

--- a/svc/api/routes/v2_gateway_update_policy/404_test.go
+++ b/svc/api/routes/v2_gateway_update_policy/404_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/unkeyed/unkey/pkg/ptr"
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_gateway_update_policy"
 	"google.golang.org/protobuf/proto"
@@ -86,6 +87,16 @@ func TestUpdatePolicyNotFound(t *testing.T) {
 	t.Run("unowned keyspace", func(t *testing.T) {
 		req := makeRequest(env, ids[0])
 		req.Keyauth = &openapi.KeyauthPolicy{Keyspaces: []string{uid.New(uid.KeySpacePrefix)}}
+		res := call(t, req)
+		require.Contains(t, res.Body.Error.Type, "key_space_not_found")
+	})
+
+	t.Run("keyspace from another project", func(t *testing.T) {
+		foreign := h.CreateApi(seed.CreateApiRequest{WorkspaceID: env.workspaceID})
+		require.NotEqual(t, env.projectID, foreign.ProjectID)
+
+		req := makeRequest(env, ids[0])
+		req.Keyauth = &openapi.KeyauthPolicy{Keyspaces: []string{foreign.KeyAuthID.String}}
 		res := call(t, req)
 		require.Contains(t, res.Body.Error.Type, "key_space_not_found")
 	})

--- a/svc/api/routes/v2_gateway_update_policy/handler.go
+++ b/svc/api/routes/v2_gateway_update_policy/handler.go
@@ -101,7 +101,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		}),
 		rbac.U(
 			urn.New().Workspace(principal.WorkspaceID).Project(env.ProjectID).App(env.AppID).Environment(env.ID).Gateway().Policy(req.PolicyId),
-			permissions.WritePolicy{},
+			permissions.WriteGatewayPolicy{},
 		),
 	))
 	if err != nil {
@@ -233,12 +233,12 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			}
 			for _, id := range req.Keyauth.Keyspaces {
 				if !slices.ContainsFunc(found, func(row db.FindKeyAuthsByIdsAndWorkspaceRow) bool {
-					return row.ID == id
+					return row.ID == id && row.ProjectID == env.ProjectID
 				}) {
 					return fault.New(
 						"keyspace not found",
 						fault.Code(codes.Data.KeySpace.NotFound.URN()),
-						fault.Internal("keyspace not found in workspace"),
+						fault.Internal("keyspace not found in project"),
 						fault.Public(fmt.Sprintf("Keyspace %q does not exist.", id)),
 					)
 				}

--- a/svc/api/routes/v2_projects_create_project/handler.go
+++ b/svc/api/routes/v2_projects_create_project/handler.go
@@ -55,7 +55,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		}),
 		rbac.U(
 			urn.New().Workspace(principal.WorkspaceID).Project("*"),
-			permissions.CreateProject{},
+			permissions.WriteProject{},
 		),
 	))
 	if err != nil {

--- a/svc/api/routes/v2_projects_update_project/handler.go
+++ b/svc/api/routes/v2_projects_update_project/handler.go
@@ -94,7 +94,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			}),
 			rbac.U(
 				urn.New().Workspace(principal.WorkspaceID).Project(project.ID),
-				permissions.UpdateProject{},
+				permissions.WriteProject{},
 			),
 		))
 		if err != nil {


### PR DESCRIPTION
## Notes for description (rewrite before review)

### Stack
- Position: 4 of 9. Review wave 2: handler migration.
- Full stack: #7189 → #7190 → #7191 → **#7192** → #7193 → #7195 → #7196 → #7197 → #7198.
- Depends on: #7191. Next: #7193.

### Goal
- Add canonical permissions to project, app, deployment, environment, domain, variable, and gateway policy handlers.

### Approach
- Resolve authorization against each resource's project hierarchy.
- Keep legacy tuple checks during the migration.
- Add focused authorization tests for canonical permissions and project boundaries.

### Decisions
- Use `write_deployment` for create, start, and stop.
- Use `write_environment` for promotion and rollback.
- Authorize environment variables and gateway policies as first-class resources.
- Require write and delete grants for replacement operations that can remove resources.
- Reject gateway policies that reference a keyspace from another project.

### Review order
1. Review project and app handlers.
2. Review environment and deployment handlers.
3. Review domain, environment variable, and gateway policy handlers.
4. Review authorization tests.

### Review focus
- Confirm that every handler derives the URN from persisted ownership data.
- Confirm that cross-project gateway policy references fail.
- Confirm that the legacy tuple arm remains available until #7197.

### Verification
- 550 focused route tests passed.
- `mise run build` passed.
