### PR TITLE
Use project-scoped permissions for data handlers

### DIFF
--- a/pkg/db/identity_list.sql_generated.go
+++ b/pkg/db/identity_list.sql_generated.go
@@ -37,6 +37,7 @@ SELECT
     ) as ratelimits
 FROM identities i
 WHERE i.workspace_id = ?
+AND i.project_id = ?
 AND i.deleted = ?
 AND i.id >= ?
 AND (? IS NULL OR LOWER(i.id) LIKE LOWER(?) OR LOWER(i.external_id) LIKE LOWER(?))
@@ -46,6 +47,7 @@ LIMIT ?
 
 type ListIdentitiesParams struct {
 	WorkspaceID string         `db:"workspace_id"`
+	ProjectID   string         `db:"project_id"`
 	Deleted     bool           `db:"deleted"`
 	IDCursor    string         `db:"id_cursor"`
 	Search      sql.NullString `db:"search"`
@@ -65,7 +67,7 @@ type ListIdentitiesRow struct {
 	Ratelimits  interface{}   `db:"ratelimits"`
 }
 
-// ListIdentities returns one page of a workspace's identities with their
+// ListIdentities returns one page of a project's identities with their
 // ratelimits aggregated into a JSON array (empty array when none exist).
 // Pagination is cursor-based: ORDER BY i.id ASC with i.id >= id_cursor makes
 // pages deterministic, and the empty-string cursor starts from the first row.
@@ -97,6 +99,7 @@ type ListIdentitiesRow struct {
 //	    ) as ratelimits
 //	FROM identities i
 //	WHERE i.workspace_id = ?
+//	AND i.project_id = ?
 //	AND i.deleted = ?
 //	AND i.id >= ?
 //	AND (? IS NULL OR LOWER(i.id) LIKE LOWER(?) OR LOWER(i.external_id) LIKE LOWER(?))
@@ -105,6 +108,7 @@ type ListIdentitiesRow struct {
 func (q *Queries) ListIdentities(ctx context.Context, db DBTX, arg ListIdentitiesParams) ([]ListIdentitiesRow, error) {
 	rows, err := db.QueryContext(ctx, listIdentities,
 		arg.WorkspaceID,
+		arg.ProjectID,
 		arg.Deleted,
 		arg.IDCursor,
 		arg.Search,

--- a/pkg/db/permission_find_by_id_or_slug.sql_generated.go
+++ b/pkg/db/permission_find_by_id_or_slug.sql_generated.go
@@ -12,7 +12,8 @@ import (
 const findPermissionByIdOrSlug = `-- name: FindPermissionByIdOrSlug :one
 SELECT pk, id, workspace_id, project_id, name, slug, description, created_at_m, updated_at_m
 FROM permissions
-WHERE workspace_id = ? AND (id = ? OR slug = ?)
+WHERE workspace_id = ?
+  AND (id = ? OR slug = ?)
 `
 
 type FindPermissionByIdOrSlugParams struct {
@@ -20,11 +21,13 @@ type FindPermissionByIdOrSlugParams struct {
 	Search      string `db:"search"`
 }
 
-// FindPermissionByIdOrSlug
+// FindPermissionByIdOrSlug resolves a permission within a workspace so the
+// caller can authorize access against the permission's actual project.
 //
 //	SELECT pk, id, workspace_id, project_id, name, slug, description, created_at_m, updated_at_m
 //	FROM permissions
-//	WHERE workspace_id = ? AND (id = ? OR slug = ?)
+//	WHERE workspace_id = ?
+//	  AND (id = ? OR slug = ?)
 func (q *Queries) FindPermissionByIdOrSlug(ctx context.Context, db DBTX, arg FindPermissionByIdOrSlugParams) (Permission, error) {
 	row := db.QueryRowContext(ctx, findPermissionByIdOrSlug, arg.WorkspaceID, arg.Search, arg.Search)
 	var i Permission

--- a/pkg/db/permission_find_by_slugs_for_update.sql_generated.go
+++ b/pkg/db/permission_find_by_slugs_for_update.sql_generated.go
@@ -16,6 +16,7 @@ const findPermissionsBySlugsForUpdate = `-- name: FindPermissionsBySlugsForUpdat
 SELECT id, name, slug, description
 FROM permissions
 WHERE workspace_id = ?
+  AND project_id = ?
   AND slug IN (/*SLICE:slugs*/?)
 ORDER BY slug
 FOR UPDATE
@@ -23,6 +24,7 @@ FOR UPDATE
 
 type FindPermissionsBySlugsForUpdateParams struct {
 	WorkspaceID string   `db:"workspace_id"`
+	ProjectID   string   `db:"project_id"`
 	Slugs       []string `db:"slugs"`
 }
 
@@ -33,11 +35,13 @@ type FindPermissionsBySlugsForUpdateRow struct {
 	Description dbtype.NullString `db:"description"`
 }
 
-// FindPermissionsBySlugsForUpdate
+// FindPermissionsBySlugsForUpdate locks matching permissions in one project so
+// role assignment cannot attach permissions owned by another project.
 //
 //	SELECT id, name, slug, description
 //	FROM permissions
 //	WHERE workspace_id = ?
+//	  AND project_id = ?
 //	  AND slug IN (/*SLICE:slugs*/?)
 //	ORDER BY slug
 //	FOR UPDATE
@@ -45,6 +49,7 @@ func (q *Queries) FindPermissionsBySlugsForUpdate(ctx context.Context, db DBTX, 
 	query := findPermissionsBySlugsForUpdate
 	var queryParams []interface{}
 	queryParams = append(queryParams, arg.WorkspaceID)
+	queryParams = append(queryParams, arg.ProjectID)
 	if len(arg.Slugs) > 0 {
 		for _, v := range arg.Slugs {
 			queryParams = append(queryParams, v)

--- a/pkg/db/permission_list.sql_generated.go
+++ b/pkg/db/permission_list.sql_generated.go
@@ -14,6 +14,7 @@ const listPermissions = `-- name: ListPermissions :many
 SELECT p.pk, p.id, p.workspace_id, p.project_id, p.name, p.slug, p.description, p.created_at_m, p.updated_at_m
 FROM permissions p
 WHERE p.workspace_id = ?
+  AND p.project_id = ?
   AND p.id >= ?
   -- search and description_search carry the same pre-escaped LIKE pattern built
   -- by mysql.SearchContains; NULL disables the filter. They are separate params
@@ -26,6 +27,7 @@ LIMIT ?
 
 type ListPermissionsParams struct {
 	WorkspaceID       string         `db:"workspace_id"`
+	ProjectID         string         `db:"project_id"`
 	IDCursor          string         `db:"id_cursor"`
 	Search            sql.NullString `db:"search"`
 	DescriptionSearch sql.NullString `db:"description_search"`
@@ -37,6 +39,7 @@ type ListPermissionsParams struct {
 //	SELECT p.pk, p.id, p.workspace_id, p.project_id, p.name, p.slug, p.description, p.created_at_m, p.updated_at_m
 //	FROM permissions p
 //	WHERE p.workspace_id = ?
+//	  AND p.project_id = ?
 //	  AND p.id >= ?
 //	  -- search and description_search carry the same pre-escaped LIKE pattern built
 //	  -- by mysql.SearchContains; NULL disables the filter. They are separate params
@@ -48,6 +51,7 @@ type ListPermissionsParams struct {
 func (q *Queries) ListPermissions(ctx context.Context, db DBTX, arg ListPermissionsParams) ([]Permission, error) {
 	rows, err := db.QueryContext(ctx, listPermissions,
 		arg.WorkspaceID,
+		arg.ProjectID,
 		arg.IDCursor,
 		arg.Search,
 		arg.Search,

--- a/pkg/db/permission_upsert.sql_generated.go
+++ b/pkg/db/permission_upsert.sql_generated.go
@@ -43,8 +43,10 @@ type UpsertPermissionParams struct {
 	CreatedAtM   int64             `db:"created_at_m"`
 }
 
-// Inserts a permission or leaves the existing workspace/slug row unchanged.
-// Use FindPermissionsBySlugsForUpdate after this to get the canonical row.
+// UpsertPermission inserts a permission or leaves the existing workspace/slug
+// row unchanged.
+// Use FindPermissionsBySlugsForUpdate after this to get the canonical row from
+// the requested project.
 //
 //	INSERT INTO permissions (
 //	  id,

--- a/pkg/db/querier_generated.go
+++ b/pkg/db/querier_generated.go
@@ -807,11 +807,13 @@ type Querier interface {
 	//  WHERE id = ?
 	//  LIMIT 1
 	FindPermissionByID(ctx context.Context, db DBTX, permissionID string) (Permission, error)
-	//FindPermissionByIdOrSlug
+	// FindPermissionByIdOrSlug resolves a permission within a workspace so the
+	// caller can authorize access against the permission's actual project.
 	//
 	//  SELECT pk, id, workspace_id, project_id, name, slug, description, created_at_m, updated_at_m
 	//  FROM permissions
-	//  WHERE workspace_id = ? AND (id = ? OR slug = ?)
+	//  WHERE workspace_id = ?
+	//    AND (id = ? OR slug = ?)
 	FindPermissionByIdOrSlug(ctx context.Context, db DBTX, arg FindPermissionByIdOrSlugParams) (Permission, error)
 	//FindPermissionByNameAndWorkspaceID
 	//
@@ -833,11 +835,13 @@ type Querier interface {
 	//
 	//  SELECT pk, id, workspace_id, project_id, name, slug, description, created_at_m, updated_at_m FROM permissions WHERE workspace_id = ? AND slug IN (/*SLICE:slugs*/?)
 	FindPermissionsBySlugs(ctx context.Context, db DBTX, arg FindPermissionsBySlugsParams) ([]Permission, error)
-	//FindPermissionsBySlugsForUpdate
+	// FindPermissionsBySlugsForUpdate locks matching permissions in one project so
+	// role assignment cannot attach permissions owned by another project.
 	//
 	//  SELECT id, name, slug, description
 	//  FROM permissions
 	//  WHERE workspace_id = ?
+	//    AND project_id = ?
 	//    AND slug IN (/*SLICE:slugs*/?)
 	//  ORDER BY slug
 	//  FOR UPDATE
@@ -1009,7 +1013,8 @@ type Querier interface {
 	//  WHERE id = ?
 	//  LIMIT 1
 	FindRoleByID(ctx context.Context, db DBTX, roleID string) (Role, error)
-	//FindRoleByIdOrNameWithPerms
+	// FindRoleByIdOrNameWithPerms resolves a role within a workspace so the caller
+	// can authorize access against the role's actual project.
 	//
 	//  SELECT pk, id, workspace_id, project_id, name, description, created_at_m, updated_at_m, COALESCE(
 	//          (SELECT JSON_ARRAYAGG(
@@ -1027,7 +1032,8 @@ type Querier interface {
 	//          JSON_ARRAY()
 	//  ) as permissions
 	//  FROM roles r
-	//  WHERE r.workspace_id = ? AND (
+	//  WHERE r.workspace_id = ?
+	//    AND (
 	//      r.id = ?
 	//      OR r.name = ?
 	//  )
@@ -2039,7 +2045,7 @@ type Querier interface {
 	//    AND error IS NOT NULL AND error != ''
 	//  ORDER BY deployment_id, started_at ASC
 	ListFailedDeploymentStepsByIds(ctx context.Context, db DBTX, arg ListFailedDeploymentStepsByIdsParams) ([]DeploymentStep, error)
-	// ListIdentities returns one page of a workspace's identities with their
+	// ListIdentities returns one page of a project's identities with their
 	// ratelimits aggregated into a JSON array (empty array when none exist).
 	// Pagination is cursor-based: ORDER BY i.id ASC with i.id >= id_cursor makes
 	// pages deterministic, and the empty-string cursor starts from the first row.
@@ -2071,6 +2077,7 @@ type Querier interface {
 	//      ) as ratelimits
 	//  FROM identities i
 	//  WHERE i.workspace_id = ?
+	//  AND i.project_id = ?
 	//  AND i.deleted = ?
 	//  AND i.id >= ?
 	//  AND (? IS NULL OR LOWER(i.id) LIKE LOWER(?) OR LOWER(i.external_id) LIKE LOWER(?))
@@ -2283,6 +2290,7 @@ type Querier interface {
 	//  SELECT p.pk, p.id, p.workspace_id, p.project_id, p.name, p.slug, p.description, p.created_at_m, p.updated_at_m
 	//  FROM permissions p
 	//  WHERE p.workspace_id = ?
+	//    AND p.project_id = ?
 	//    AND p.id >= ?
 	//    -- search and description_search carry the same pre-escaped LIKE pattern built
 	//    -- by mysql.SearchContains; NULL disables the filter. They are separate params
@@ -2379,6 +2387,7 @@ type Querier interface {
 	//  ) as permissions
 	//  FROM roles r
 	//  WHERE r.workspace_id = ?
+	//  AND r.project_id = ?
 	//  AND r.id >= ?
 	//  AND (? IS NULL OR LOWER(r.id) LIKE LOWER(?) OR LOWER(r.name) LIKE LOWER(?) OR LOWER(r.description) LIKE LOWER(?))
 	//  ORDER BY r.id
@@ -3089,8 +3098,10 @@ type Querier interface {
 	//      custom_domains_max = VALUES(custom_domains_max),
 	//      autoscaling_replicas_max = VALUES(autoscaling_replicas_max)
 	UpsertLimit(ctx context.Context, db DBTX, arg UpsertLimitParams) error
-	// Inserts a permission or leaves the existing workspace/slug row unchanged.
-	// Use FindPermissionsBySlugsForUpdate after this to get the canonical row.
+	// UpsertPermission inserts a permission or leaves the existing workspace/slug
+	// row unchanged.
+	// Use FindPermissionsBySlugsForUpdate after this to get the canonical row from
+	// the requested project.
 	//
 	//  INSERT INTO permissions (
 	//    id,

--- a/pkg/db/queries/identity_list.sql
+++ b/pkg/db/queries/identity_list.sql
@@ -1,5 +1,5 @@
 -- name: ListIdentities :many
--- ListIdentities returns one page of a workspace's identities with their
+-- ListIdentities returns one page of a project's identities with their
 -- ratelimits aggregated into a JSON array (empty array when none exist).
 -- Pagination is cursor-based: ORDER BY i.id ASC with i.id >= id_cursor makes
 -- pages deterministic, and the empty-string cursor starts from the first row.
@@ -29,6 +29,7 @@ SELECT
     ) as ratelimits
 FROM identities i
 WHERE i.workspace_id = sqlc.arg(workspace_id)
+AND i.project_id = sqlc.arg(project_id)
 AND i.deleted = sqlc.arg(deleted)
 AND i.id >= sqlc.arg(id_cursor)
 -- search is a pre-escaped LIKE pattern built by mysql.SearchContains; NULL disables the filter

--- a/pkg/db/queries/permission_find_by_id_or_slug.sql
+++ b/pkg/db/queries/permission_find_by_id_or_slug.sql
@@ -1,4 +1,7 @@
 -- name: FindPermissionByIdOrSlug :one
+-- FindPermissionByIdOrSlug resolves a permission within a workspace so the
+-- caller can authorize access against the permission's actual project.
 SELECT *
 FROM permissions
-WHERE workspace_id = ? AND (id = sqlc.arg('search') OR slug = sqlc.arg('search'));
+WHERE workspace_id = sqlc.arg(workspace_id)
+  AND (id = sqlc.arg(search) OR slug = sqlc.arg(search));

--- a/pkg/db/queries/permission_find_by_slugs_for_update.sql
+++ b/pkg/db/queries/permission_find_by_slugs_for_update.sql
@@ -1,7 +1,10 @@
 -- name: FindPermissionsBySlugsForUpdate :many
+-- FindPermissionsBySlugsForUpdate locks matching permissions in one project so
+-- role assignment cannot attach permissions owned by another project.
 SELECT id, name, slug, description
 FROM permissions
 WHERE workspace_id = sqlc.arg(workspace_id)
+  AND project_id = sqlc.arg(project_id)
   AND slug IN (sqlc.slice('slugs'))
 ORDER BY slug
 FOR UPDATE;

--- a/pkg/db/queries/permission_list.sql
+++ b/pkg/db/queries/permission_list.sql
@@ -2,6 +2,7 @@
 SELECT p.*
 FROM permissions p
 WHERE p.workspace_id = sqlc.arg(workspace_id)
+  AND p.project_id = sqlc.arg(project_id)
   AND p.id >= sqlc.arg(id_cursor)
   -- search and description_search carry the same pre-escaped LIKE pattern built
   -- by mysql.SearchContains; NULL disables the filter. They are separate params

--- a/pkg/db/queries/permission_upsert.sql
+++ b/pkg/db/queries/permission_upsert.sql
@@ -1,6 +1,8 @@
 -- name: UpsertPermission :exec
--- Inserts a permission or leaves the existing workspace/slug row unchanged.
--- Use FindPermissionsBySlugsForUpdate after this to get the canonical row.
+-- UpsertPermission inserts a permission or leaves the existing workspace/slug
+-- row unchanged.
+-- Use FindPermissionsBySlugsForUpdate after this to get the canonical row from
+-- the requested project.
 INSERT INTO permissions (
   id,
   workspace_id,

--- a/pkg/db/queries/role_find_by_id_or_name_with_perms.sql
+++ b/pkg/db/queries/role_find_by_id_or_name_with_perms.sql
@@ -1,4 +1,6 @@
 -- name: FindRoleByIdOrNameWithPerms :one
+-- FindRoleByIdOrNameWithPerms resolves a role within a workspace so the caller
+-- can authorize access against the role's actual project.
 SELECT *, COALESCE(
         (SELECT JSON_ARRAYAGG(
             json_object(
@@ -15,7 +17,8 @@ SELECT *, COALESCE(
         JSON_ARRAY()
 ) as permissions
 FROM roles r
-WHERE r.workspace_id = ? AND (
+WHERE r.workspace_id = sqlc.arg(workspace_id)
+  AND (
     r.id = sqlc.arg('search')
     OR r.name = sqlc.arg('search')
 );

--- a/pkg/db/queries/role_list.sql
+++ b/pkg/db/queries/role_list.sql
@@ -16,6 +16,7 @@ SELECT r.*, COALESCE(
 ) as permissions
 FROM roles r
 WHERE r.workspace_id = sqlc.arg(workspace_id)
+AND r.project_id = sqlc.arg(project_id)
 AND r.id >= sqlc.arg(id_cursor)
 -- search is a pre-escaped LIKE pattern built by mysql.SearchContains; NULL disables the filter
 AND (sqlc.narg(search) IS NULL OR LOWER(r.id) LIKE LOWER(sqlc.narg(search)) OR LOWER(r.name) LIKE LOWER(sqlc.narg(search)) OR LOWER(r.description) LIKE LOWER(sqlc.narg(search)))

--- a/pkg/db/role_find_by_id_or_name_with_perms.sql_generated.go
+++ b/pkg/db/role_find_by_id_or_name_with_perms.sql_generated.go
@@ -27,7 +27,8 @@ SELECT pk, id, workspace_id, project_id, name, description, created_at_m, update
         JSON_ARRAY()
 ) as permissions
 FROM roles r
-WHERE r.workspace_id = ? AND (
+WHERE r.workspace_id = ?
+  AND (
     r.id = ?
     OR r.name = ?
 )
@@ -50,7 +51,8 @@ type FindRoleByIdOrNameWithPermsRow struct {
 	Permissions interface{}    `db:"permissions"`
 }
 
-// FindRoleByIdOrNameWithPerms
+// FindRoleByIdOrNameWithPerms resolves a role within a workspace so the caller
+// can authorize access against the role's actual project.
 //
 //	SELECT pk, id, workspace_id, project_id, name, description, created_at_m, updated_at_m, COALESCE(
 //	        (SELECT JSON_ARRAYAGG(
@@ -68,7 +70,8 @@ type FindRoleByIdOrNameWithPermsRow struct {
 //	        JSON_ARRAY()
 //	) as permissions
 //	FROM roles r
-//	WHERE r.workspace_id = ? AND (
+//	WHERE r.workspace_id = ?
+//	  AND (
 //	    r.id = ?
 //	    OR r.name = ?
 //	)

--- a/pkg/db/role_list.sql_generated.go
+++ b/pkg/db/role_list.sql_generated.go
@@ -28,6 +28,7 @@ SELECT r.pk, r.id, r.workspace_id, r.project_id, r.name, r.description, r.create
 ) as permissions
 FROM roles r
 WHERE r.workspace_id = ?
+AND r.project_id = ?
 AND r.id >= ?
 AND (? IS NULL OR LOWER(r.id) LIKE LOWER(?) OR LOWER(r.name) LIKE LOWER(?) OR LOWER(r.description) LIKE LOWER(?))
 ORDER BY r.id
@@ -36,6 +37,7 @@ LIMIT ?
 
 type ListRolesParams struct {
 	WorkspaceID string         `db:"workspace_id"`
+	ProjectID   string         `db:"project_id"`
 	IDCursor    string         `db:"id_cursor"`
 	Search      sql.NullString `db:"search"`
 	Limit       int32          `db:"limit"`
@@ -72,6 +74,7 @@ type ListRolesRow struct {
 //	) as permissions
 //	FROM roles r
 //	WHERE r.workspace_id = ?
+//	AND r.project_id = ?
 //	AND r.id >= ?
 //	AND (? IS NULL OR LOWER(r.id) LIKE LOWER(?) OR LOWER(r.name) LIKE LOWER(?) OR LOWER(r.description) LIKE LOWER(?))
 //	ORDER BY r.id
@@ -79,6 +82,7 @@ type ListRolesRow struct {
 func (q *Queries) ListRoles(ctx context.Context, db DBTX, arg ListRolesParams) ([]ListRolesRow, error) {
 	rows, err := db.QueryContext(ctx, listRoles,
 		arg.WorkspaceID,
+		arg.ProjectID,
 		arg.IDCursor,
 		arg.Search,
 		arg.Search,

--- a/svc/api/routes/v2_identities_create_identity/handler.go
+++ b/svc/api/routes/v2_identities_create_identity/handler.go
@@ -65,21 +65,6 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	err = principal.Authorize(rbac.Or(
-		rbac.T(rbac.Tuple{
-			ResourceType: rbac.Identity,
-			ResourceID:   "*",
-			Action:       rbac.CreateIdentity,
-		}),
-		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project("*").Identity("*"),
-			permissions.CreateIdentity{},
-		),
-	))
-	if err != nil {
-		return err
-	}
-
 	meta := []byte("{}")
 	if req.Meta != nil {
 		rawMeta, metaErr := json.Marshal(req.Meta)
@@ -103,6 +88,21 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		projectID, resolveErr := projects.EnsureDefaultProject(ctx, tx, principal.WorkspaceID)
 		if resolveErr != nil {
 			return resolveErr
+		}
+
+		authorizeErr := principal.Authorize(rbac.Or(
+			rbac.T(rbac.Tuple{
+				ResourceType: rbac.Identity,
+				ResourceID:   "*",
+				Action:       rbac.CreateIdentity,
+			}),
+			rbac.U(
+				urn.New().Workspace(principal.WorkspaceID).Project(projectID).Identity("*"),
+				permissions.WriteIdentity{},
+			),
+		))
+		if authorizeErr != nil {
+			return authorizeErr
 		}
 
 		args := db.InsertIdentityParams{

--- a/svc/api/routes/v2_identities_create_identity/urn_permissions_test.go
+++ b/svc/api/routes/v2_identities_create_identity/urn_permissions_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_identities_create_identity"
 )
 
@@ -19,7 +20,8 @@ func TestCreateIdentity_AuthorizesCanonicalURNPermission(t *testing.T) {
 	h.Register(route)
 
 	workspaceID := h.Resources().UserWorkspace.ID
-	rootKey := h.CreateRootKey(workspaceID, fmt.Sprintf("unkey:v1:%s:projects/*/identities/*#create_identity", workspaceID))
+	projectID := h.CreateApi(seed.CreateApiRequest{WorkspaceID: workspaceID}).ProjectID
+	rootKey := h.CreateRootKey(workspaceID, fmt.Sprintf("unkey:v1:%s:projects/%s/identities/*#write_identity", workspaceID, projectID))
 	headers := http.Header{
 		"Content-Type":  {"application/json"},
 		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},

--- a/svc/api/routes/v2_identities_delete_identity/403_test.go
+++ b/svc/api/routes/v2_identities_delete_identity/403_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_identities_delete_identity"
 )
@@ -21,6 +22,11 @@ func TestDeleteIdentityForbidden(t *testing.T) {
 	}
 
 	h.Register(route)
+	externalID := uid.New(uid.TestPrefix)
+	h.CreateIdentity(seed.CreateIdentityRequest{
+		WorkspaceID: h.Resources().UserWorkspace.ID,
+		ExternalID:  externalID,
+	})
 
 	t.Run("insufficient permissions - no permissions", func(t *testing.T) {
 		rootKey := h.CreateRootKey(h.Resources().UserWorkspace.ID) // No permissions
@@ -29,7 +35,7 @@ func TestDeleteIdentityForbidden(t *testing.T) {
 			"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
 		}
 
-		req := handler.Request{Identity: uid.New("test")}
+		req := handler.Request{Identity: externalID}
 		res := testutil.CallRoute[handler.Request, openapi.ForbiddenErrorResponse](h, route, headers, req)
 		require.Equal(t, http.StatusForbidden, res.Status, "expected 403, sent: %+v, received: %s", req, res.RawBody)
 		require.NotNil(t, res.Body)
@@ -48,7 +54,7 @@ func TestDeleteIdentityForbidden(t *testing.T) {
 			"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
 		}
 
-		req := handler.Request{Identity: uid.New("test")}
+		req := handler.Request{Identity: externalID}
 		res := testutil.CallRoute[handler.Request, openapi.ForbiddenErrorResponse](h, route, headers, req)
 		require.Equal(t, http.StatusForbidden, res.Status, "expected 403, sent: %+v, received: %s", req, res.RawBody)
 		require.NotNil(t, res.Body)
@@ -67,7 +73,7 @@ func TestDeleteIdentityForbidden(t *testing.T) {
 			"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
 		}
 
-		req := handler.Request{Identity: uid.New("test")}
+		req := handler.Request{Identity: externalID}
 		res := testutil.CallRoute[handler.Request, openapi.ForbiddenErrorResponse](h, route, headers, req)
 		require.Equal(t, http.StatusForbidden, res.Status, "expected 403, sent: %+v, received: %s", req, res.RawBody)
 		require.NotNil(t, res.Body)
@@ -86,7 +92,7 @@ func TestDeleteIdentityForbidden(t *testing.T) {
 			"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
 		}
 
-		req := handler.Request{Identity: uid.New("test")}
+		req := handler.Request{Identity: externalID}
 		res := testutil.CallRoute[handler.Request, openapi.ForbiddenErrorResponse](h, route, headers, req)
 		require.Equal(t, http.StatusForbidden, res.Status, "expected 403, sent: %+v, received: %s", req, res.RawBody)
 		require.NotNil(t, res.Body)
@@ -105,7 +111,7 @@ func TestDeleteIdentityForbidden(t *testing.T) {
 			"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
 		}
 
-		req := handler.Request{Identity: uid.New("test")}
+		req := handler.Request{Identity: externalID}
 		res := testutil.CallRoute[handler.Request, openapi.ForbiddenErrorResponse](h, route, headers, req)
 		require.Equal(t, http.StatusForbidden, res.Status, "expected 403, sent: %+v, received: %s", req, res.RawBody)
 		require.NotNil(t, res.Body)
@@ -128,7 +134,7 @@ func TestDeleteIdentityForbidden(t *testing.T) {
 		}
 
 		req := handler.Request{
-			Identity: uid.New("test"),
+			Identity: externalID,
 		}
 		res := testutil.CallRoute[handler.Request, openapi.ForbiddenErrorResponse](h, route, headers, req)
 		require.Equal(t, http.StatusForbidden, res.Status, "expected 403, sent: %+v, received: %s", req, res.RawBody)
@@ -148,7 +154,7 @@ func TestDeleteIdentityForbidden(t *testing.T) {
 			"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
 		}
 
-		req := handler.Request{Identity: uid.New("test")}
+		req := handler.Request{Identity: externalID}
 		res := testutil.CallRoute[handler.Request, openapi.ForbiddenErrorResponse](h, route, headers, req)
 		require.Equal(t, http.StatusForbidden, res.Status, "expected 403, sent: %+v, received: %s", req, res.RawBody)
 		require.NotNil(t, res.Body)

--- a/svc/api/routes/v2_identities_delete_identity/handler.go
+++ b/svc/api/routes/v2_identities_delete_identity/handler.go
@@ -57,25 +57,6 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	err = principal.Authorize(
-		rbac.Or(
-			rbac.T(
-				rbac.Tuple{
-					ResourceType: rbac.Identity,
-					ResourceID:   "*",
-					Action:       rbac.DeleteIdentity,
-				},
-			),
-			rbac.U(
-				urn.New().Workspace(principal.WorkspaceID).Project("*").Identity("*"),
-				permissions.DeleteIdentity{},
-			),
-		),
-	)
-	if err != nil {
-		return err
-	}
-
 	identity, err := db.Query.FindIdentity(ctx, h.DB.RO(), db.FindIdentityParams{
 		WorkspaceID: principal.WorkspaceID,
 		Identity:    req.Identity,
@@ -93,6 +74,25 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
 			fault.Internal("database failed to find the identity"), fault.Public("Error finding the identity."),
 		)
+	}
+
+	err = principal.Authorize(
+		rbac.Or(
+			rbac.T(
+				rbac.Tuple{
+					ResourceType: rbac.Identity,
+					ResourceID:   "*",
+					Action:       rbac.DeleteIdentity,
+				},
+			),
+			rbac.U(
+				urn.New().Workspace(principal.WorkspaceID).Project(identity.ProjectID).Identity(identity.ID),
+				permissions.DeleteIdentity{},
+			),
+		),
+	)
+	if err != nil {
+		return err
 	}
 
 	// Parse ratelimits JSON

--- a/svc/api/routes/v2_identities_delete_identity/urn_permissions_test.go
+++ b/svc/api/routes/v2_identities_delete_identity/urn_permissions_test.go
@@ -21,8 +21,8 @@ func TestDeleteIdentity_AuthorizesCanonicalURNPermission(t *testing.T) {
 
 	workspaceID := h.Resources().UserWorkspace.ID
 	externalID := uid.New(uid.TestPrefix)
-	h.CreateIdentity(seed.CreateIdentityRequest{WorkspaceID: workspaceID, ExternalID: externalID})
-	rootKey := h.CreateRootKey(workspaceID, fmt.Sprintf("unkey:v1:%s:projects/*/identities/*#delete_identity", workspaceID))
+	identity := h.CreateIdentity(seed.CreateIdentityRequest{WorkspaceID: workspaceID, ExternalID: externalID})
+	rootKey := h.CreateRootKey(workspaceID, fmt.Sprintf("unkey:v1:%s:projects/%s/identities/%s#delete_identity", workspaceID, identity.ProjectID, identity.ID))
 	headers := http.Header{
 		"Content-Type":  {"application/json"},
 		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},

--- a/svc/api/routes/v2_identities_get_identity/handler.go
+++ b/svc/api/routes/v2_identities_get_identity/handler.go
@@ -88,7 +88,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			Action:       rbac.ReadIdentity,
 		}),
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project("*").Identity("*"),
+			urn.New().Workspace(principal.WorkspaceID).Project(identity.ProjectID).Identity(identity.ID),
 			permissions.ReadIdentity{},
 		),
 	))

--- a/svc/api/routes/v2_identities_get_identity/urn_permissions_test.go
+++ b/svc/api/routes/v2_identities_get_identity/urn_permissions_test.go
@@ -21,8 +21,8 @@ func TestGetIdentity_AuthorizesCanonicalURNPermission(t *testing.T) {
 
 	workspaceID := h.Resources().UserWorkspace.ID
 	externalID := uid.New(uid.TestPrefix)
-	h.CreateIdentity(seed.CreateIdentityRequest{WorkspaceID: workspaceID, ExternalID: externalID})
-	rootKey := h.CreateRootKey(workspaceID, fmt.Sprintf("unkey:v1:%s:projects/*/identities/*#read_identity", workspaceID))
+	identity := h.CreateIdentity(seed.CreateIdentityRequest{WorkspaceID: workspaceID, ExternalID: externalID})
+	rootKey := h.CreateRootKey(workspaceID, fmt.Sprintf("unkey:v1:%s:projects/%s/identities/%s#read_identity", workspaceID, identity.ProjectID, identity.ID))
 	headers := http.Header{
 		"Content-Type":  {"application/json"},
 		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},

--- a/svc/api/routes/v2_identities_list_identities/200_test.go
+++ b/svc/api/routes/v2_identities_list_identities/200_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/projects"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_identities_list_identities"
 )
@@ -42,6 +43,8 @@ func TestSuccess(t *testing.T) {
 	}()
 
 	workspaceID := h.Resources().UserWorkspace.ID
+	projectID, err := projects.EnsureDefaultProject(ctx, tx, workspaceID)
+	require.NoError(t, err)
 
 	// Create metadata
 	metaMap := map[string]interface{}{
@@ -63,6 +66,7 @@ func TestSuccess(t *testing.T) {
 			ID:          identityID,
 			ExternalID:  externalID,
 			WorkspaceID: workspaceID,
+			ProjectID:   projectID,
 			Environment: "default",
 			CreatedAt:   time.Now().UnixMilli(),
 			Meta:        metaBytes,
@@ -194,6 +198,7 @@ func TestSuccess(t *testing.T) {
 			ID:          deletedIdentityID,
 			ExternalID:  deletedExternalID,
 			WorkspaceID: workspaceID,
+			ProjectID:   projectID,
 			Environment: "default",
 			CreatedAt:   time.Now().UnixMilli(),
 			Meta:        metaBytes,
@@ -247,6 +252,7 @@ func TestSuccess(t *testing.T) {
 			ID:          unicodeIdentityID,
 			ExternalID:  unicodeExternalID,
 			WorkspaceID: workspaceID,
+			ProjectID:   projectID,
 			Environment: "default",
 			CreatedAt:   time.Now().UnixMilli(),
 			Meta:        unicodeMetaBytes,
@@ -307,11 +313,15 @@ func TestSuccess(t *testing.T) {
 		})
 		require.NoError(t, err)
 
+		singleProjectID, err := projects.EnsureDefaultProject(ctx, tx, singleWorkspaceID)
+		require.NoError(t, err)
+
 		// Create a single identity in this workspace
 		err = db.Query.InsertIdentity(ctx, tx, db.InsertIdentityParams{
 			ID:          singleIdentityID,
 			ExternalID:  singleExternalID,
 			WorkspaceID: singleWorkspaceID,
+			ProjectID:   singleProjectID,
 			Environment: "default",
 			CreatedAt:   time.Now().UnixMilli(),
 			Meta:        metaBytes,
@@ -362,6 +372,9 @@ func TestSuccess(t *testing.T) {
 		})
 		require.NoError(t, err)
 
+		searchProjectID, err := projects.EnsureDefaultProject(ctx, tx, searchWorkspaceID)
+		require.NoError(t, err)
+
 		identityIDs := make(map[string]string)
 		for _, externalID := range []string{"acme_alice", "acme_bob", "discount_100%_user"} {
 			identityID := uid.New(uid.IdentityPrefix)
@@ -370,6 +383,7 @@ func TestSuccess(t *testing.T) {
 				ID:          identityID,
 				ExternalID:  externalID,
 				WorkspaceID: searchWorkspaceID,
+				ProjectID:   searchProjectID,
 				Environment: "default",
 				CreatedAt:   time.Now().UnixMilli(),
 				Meta:        nil,

--- a/svc/api/routes/v2_identities_list_identities/403_test.go
+++ b/svc/api/routes/v2_identities_list_identities/403_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/projects"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_identities_list_identities"
@@ -40,6 +41,8 @@ func TestForbidden(t *testing.T) {
 	}()
 
 	workspaceID := h.Resources().UserWorkspace.ID
+	projectID, err := projects.EnsureDefaultProject(ctx, tx, workspaceID)
+	require.NoError(t, err)
 
 	// Insert identity in default environment
 	defaultIdentityID := uid.New(uid.IdentityPrefix)
@@ -47,6 +50,7 @@ func TestForbidden(t *testing.T) {
 		ID:          defaultIdentityID,
 		ExternalID:  "test_user_default",
 		WorkspaceID: workspaceID,
+		ProjectID:   projectID,
 		Environment: "default",
 		CreatedAt:   time.Now().UnixMilli(),
 		Meta:        []byte("{}"),
@@ -59,6 +63,7 @@ func TestForbidden(t *testing.T) {
 		ID:          prodIdentityID,
 		ExternalID:  "test_user_prod",
 		WorkspaceID: workspaceID,
+		ProjectID:   projectID,
 		Environment: "production",
 		CreatedAt:   time.Now().UnixMilli(),
 		Meta:        []byte("{}"),
@@ -71,6 +76,7 @@ func TestForbidden(t *testing.T) {
 		ID:          stagingIdentityID,
 		ExternalID:  "test_user_staging",
 		WorkspaceID: workspaceID,
+		ProjectID:   projectID,
 		Environment: "staging",
 		CreatedAt:   time.Now().UnixMilli(),
 		Meta:        []byte("{}"),
@@ -90,6 +96,18 @@ func TestForbidden(t *testing.T) {
 		require.Equal(t, http.StatusForbidden, res.Status)
 		require.Equal(t, "https://unkey.com/docs/errors/unkey/authorization/insufficient_permissions", res.Body.Error.Type)
 		require.Contains(t, res.Body.Error.Detail, "Missing one of these permissions")
+	})
+
+	t.Run("no permission to read an empty result", func(t *testing.T) {
+		search := uid.New(uid.TestPrefix)
+		res := testutil.CallRoute[handler.Request, openapi.ForbiddenErrorResponse](
+			h,
+			route,
+			headers,
+			handler.Request{Search: &search},
+		)
+		require.Equal(t, http.StatusForbidden, res.Status)
+		require.Equal(t, "https://unkey.com/docs/errors/unkey/authorization/insufficient_permissions", res.Body.Error.Type)
 	})
 
 	// Create a new key with specific permissions for certain environments

--- a/svc/api/routes/v2_identities_list_identities/cross_workspace_test.go
+++ b/svc/api/routes/v2_identities_list_identities/cross_workspace_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/projects"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_identities_list_identities"
 )
@@ -55,6 +56,9 @@ func TestCrossWorkspaceForbidden(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	projectB, err := projects.EnsureDefaultProject(ctx, tx, workspaceB)
+	require.NoError(t, err)
+
 	// Create an identity in workspace B
 	identityB := uid.New(uid.IdentityPrefix)
 	externalID := "user_in_workspace_b"
@@ -62,6 +66,7 @@ func TestCrossWorkspaceForbidden(t *testing.T) {
 		ID:          identityB,
 		ExternalID:  externalID,
 		WorkspaceID: workspaceB,
+		ProjectID:   projectB,
 		Environment: "default",
 		CreatedAt:   time.Now().UnixMilli(),
 		Meta:        []byte("{}"),

--- a/svc/api/routes/v2_identities_list_identities/handler.go
+++ b/svc/api/routes/v2_identities_list_identities/handler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/unkeyed/unkey/pkg/urn"
 	"github.com/unkeyed/unkey/pkg/zen"
 	"github.com/unkeyed/unkey/svc/api/internal/pagination"
+	"github.com/unkeyed/unkey/svc/api/internal/projects"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
 
@@ -54,8 +55,14 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	p := pagination.Parse(req.Limit, req.Cursor, 100)
 	search := mysql.SearchContains(strings.TrimSpace(ptr.SafeDeref(req.Search)))
 
+	projectID, err := projects.EnsureDefaultProject(ctx, h.DB.RW(), principal.WorkspaceID)
+	if err != nil {
+		return err
+	}
+
 	identities, err := db.Query.ListIdentities(ctx, h.DB.RO(), db.ListIdentitiesParams{
 		WorkspaceID: principal.WorkspaceID,
+		ProjectID:   projectID,
 		Deleted:     false,
 		IDCursor:    p.Cursor,
 		Search:      search,
@@ -68,6 +75,23 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	identities, pg := pagination.Paginate(identities, p, func(r db.ListIdentitiesRow) string { return r.ID })
+
+	if len(identities) == 0 {
+		err = principal.Authorize(rbac.Or(
+			rbac.T(rbac.Tuple{
+				ResourceType: rbac.Identity,
+				ResourceID:   "*",
+				Action:       rbac.ReadIdentity,
+			}),
+			rbac.U(
+				urn.New().Workspace(principal.WorkspaceID).Project(projectID).Identity("*"),
+				permissions.ReadIdentity{},
+			),
+		))
+		if err != nil {
+			return err
+		}
+	}
 
 	// Check permissions for all identities before processing
 	for _, id := range identities {
@@ -84,7 +108,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 				Action:       rbac.ReadIdentity,
 			}),
 			rbac.U(
-				urn.New().Workspace(principal.WorkspaceID).Project("*").Identity("*"),
+				urn.New().Workspace(principal.WorkspaceID).Project(id.ProjectID).Identity(id.ID),
 				permissions.ReadIdentity{},
 			),
 		)

--- a/svc/api/routes/v2_identities_list_identities/urn_permissions_test.go
+++ b/svc/api/routes/v2_identities_list_identities/urn_permissions_test.go
@@ -1,11 +1,14 @@
 package handler_test
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
@@ -20,8 +23,26 @@ func TestListIdentities_AuthorizesCanonicalURNPermission(t *testing.T) {
 	h.Register(route)
 
 	workspaceID := h.Resources().UserWorkspace.ID
-	h.CreateIdentity(seed.CreateIdentityRequest{WorkspaceID: workspaceID, ExternalID: uid.New(uid.TestPrefix)})
-	rootKey := h.CreateRootKey(workspaceID, fmt.Sprintf("unkey:v1:%s:projects/*/identities/*#read_identity", workspaceID))
+	identity := h.CreateIdentity(seed.CreateIdentityRequest{WorkspaceID: workspaceID, ExternalID: uid.New(uid.TestPrefix)})
+	otherProjectID := uid.New(uid.ProjectPrefix)
+	h.CreateProject(seed.CreateProjectRequest{
+		ID:          otherProjectID,
+		WorkspaceID: workspaceID,
+		Name:        "Other",
+		Slug:        uid.New("other"),
+	})
+	otherExternalID := uid.New(uid.TestPrefix)
+	err := db.Query.InsertIdentity(context.Background(), h.DB.RW(), db.InsertIdentityParams{
+		ID:          uid.New(uid.IdentityPrefix),
+		ExternalID:  otherExternalID,
+		WorkspaceID: workspaceID,
+		ProjectID:   otherProjectID,
+		Environment: "default",
+		CreatedAt:   time.Now().UnixMilli(),
+		Meta:        []byte("{}"),
+	})
+	require.NoError(t, err)
+	rootKey := h.CreateRootKey(workspaceID, fmt.Sprintf("unkey:v1:%s:projects/%s/identities/*#read_identity", workspaceID, identity.ProjectID))
 	headers := http.Header{
 		"Content-Type":  {"application/json"},
 		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
@@ -29,4 +50,10 @@ func TestListIdentities_AuthorizesCanonicalURNPermission(t *testing.T) {
 
 	res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{})
 	require.Equal(t, http.StatusOK, res.Status, "got: %s", res.RawBody)
+	found := false
+	for _, listedIdentity := range res.Body.Data {
+		found = found || listedIdentity.ExternalId == identity.ExternalID
+		require.NotEqual(t, otherExternalID, listedIdentity.ExternalId)
+	}
+	require.True(t, found)
 }

--- a/svc/api/routes/v2_identities_update_identity/403_test.go
+++ b/svc/api/routes/v2_identities_update_identity/403_test.go
@@ -1,18 +1,14 @@
 package handler_test
 
 import (
-	"context"
-	"database/sql"
-	"errors"
 	"fmt"
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
-	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_identities_update_identity"
 )
@@ -27,6 +23,12 @@ func TestForbidden(t *testing.T) {
 	h.Register(route)
 
 	t.Run("no permission to update identity", func(t *testing.T) {
+		externalID := uid.New(uid.TestPrefix)
+		h.CreateIdentity(seed.CreateIdentityRequest{
+			WorkspaceID: h.Resources().UserWorkspace.ID,
+			ExternalID:  externalID,
+		})
+
 		// Create root key without permissions
 		rootKeyID := h.CreateRootKey(h.Resources().UserWorkspace.ID)
 		headers := http.Header{
@@ -34,7 +36,6 @@ func TestForbidden(t *testing.T) {
 			"Authorization": {fmt.Sprintf("Bearer %s", rootKeyID)},
 		}
 
-		externalID := uid.New(uid.TestPrefix)
 		meta := map[string]interface{}{
 			"test": "value",
 		}
@@ -49,6 +50,12 @@ func TestForbidden(t *testing.T) {
 	})
 
 	t.Run("wrong permission type", func(t *testing.T) {
+		externalID := uid.New(uid.TestPrefix)
+		h.CreateIdentity(seed.CreateIdentityRequest{
+			WorkspaceID: h.Resources().UserWorkspace.ID,
+			ExternalID:  externalID,
+		})
+
 		// Create root key with wrong permission
 		rootKeyID := h.CreateRootKey(h.Resources().UserWorkspace.ID, "identity.*.create_identity")
 		headers := http.Header{
@@ -56,7 +63,6 @@ func TestForbidden(t *testing.T) {
 			"Authorization": {fmt.Sprintf("Bearer %s", rootKeyID)},
 		}
 
-		externalID := uid.New(uid.TestPrefix)
 		meta := map[string]interface{}{
 			"test": "value",
 		}
@@ -71,31 +77,12 @@ func TestForbidden(t *testing.T) {
 	})
 
 	t.Run("with permission to update identity", func(t *testing.T) {
-		// Create test identity first
-		ctx := context.Background()
-		tx, err := h.DB.RW().Begin(ctx)
-		require.NoError(t, err)
-		defer func() {
-			err := tx.Rollback()
-			require.True(t, err == nil || errors.Is(err, sql.ErrTxDone), "unexpected rollback error: %v", err)
-		}()
-
 		workspaceID := h.Resources().UserWorkspace.ID
-		identityID := uid.New(uid.IdentityPrefix)
 		externalID := "test_user_403"
-
-		// Insert test identity
-		err = db.Query.InsertIdentity(ctx, tx, db.InsertIdentityParams{
-			ID:          identityID,
-			ExternalID:  externalID,
+		h.CreateIdentity(seed.CreateIdentityRequest{
 			WorkspaceID: workspaceID,
-			Environment: "default",
-			CreatedAt:   time.Now().UnixMilli(),
-			Meta:        []byte("{}"),
+			ExternalID:  externalID,
 		})
-		require.NoError(t, err)
-		err = tx.Commit()
-		require.NoError(t, err)
 
 		// Create root key with correct permission
 		rootKeyID := h.CreateRootKey(workspaceID, "identity.*.update_identity")

--- a/svc/api/routes/v2_identities_update_identity/handler.go
+++ b/svc/api/routes/v2_identities_update_identity/handler.go
@@ -67,21 +67,6 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	err = principal.Authorize(rbac.Or(
-		rbac.T(rbac.Tuple{
-			ResourceType: rbac.Identity,
-			ResourceID:   "*",
-			Action:       rbac.UpdateIdentity,
-		}),
-		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project("*").Identity("*"),
-			permissions.UpdateIdentity{},
-		),
-	))
-	if err != nil {
-		return err
-	}
-
 	// Check ratelimits for unique names
 	if req.Ratelimits != nil {
 		nameSet := make(map[string]bool)
@@ -131,6 +116,21 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			fault.Internal("unable to find identity"),
 			fault.Public("We're unable to retrieve the identity."),
 		)
+	}
+
+	err = principal.Authorize(rbac.Or(
+		rbac.T(rbac.Tuple{
+			ResourceType: rbac.Identity,
+			ResourceID:   "*",
+			Action:       rbac.UpdateIdentity,
+		}),
+		rbac.U(
+			urn.New().Workspace(principal.WorkspaceID).Project(identityRow.ProjectID).Identity(identityRow.ID),
+			permissions.WriteIdentity{},
+		),
+	))
+	if err != nil {
+		return err
 	}
 
 	// Parse existing ratelimits from JSON

--- a/svc/api/routes/v2_identities_update_identity/urn_permissions_test.go
+++ b/svc/api/routes/v2_identities_update_identity/urn_permissions_test.go
@@ -21,8 +21,8 @@ func TestUpdateIdentity_AuthorizesCanonicalURNPermission(t *testing.T) {
 
 	workspaceID := h.Resources().UserWorkspace.ID
 	externalID := uid.New(uid.TestPrefix)
-	h.CreateIdentity(seed.CreateIdentityRequest{WorkspaceID: workspaceID, ExternalID: externalID})
-	rootKey := h.CreateRootKey(workspaceID, fmt.Sprintf("unkey:v1:%s:projects/*/identities/*#update_identity", workspaceID))
+	identity := h.CreateIdentity(seed.CreateIdentityRequest{WorkspaceID: workspaceID, ExternalID: externalID})
+	rootKey := h.CreateRootKey(workspaceID, fmt.Sprintf("unkey:v1:%s:projects/%s/identities/%s#write_identity", workspaceID, identity.ProjectID, identity.ID))
 	headers := http.Header{
 		"Content-Type":  {"application/json"},
 		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},

--- a/svc/api/routes/v2_permissions_create_permission/403_test.go
+++ b/svc/api/routes/v2_permissions_create_permission/403_test.go
@@ -49,7 +49,8 @@ func TestAuthorizationErrors(t *testing.T) {
 		require.Equal(t, http.StatusForbidden, res.Status)
 		require.NotNil(t, res.Body)
 		require.NotNil(t, res.Body.Error)
-		require.Equal(t, "Missing permission: 'rbac.*.create_permission'", res.Body.Error.Detail)
+		require.Contains(t, res.Body.Error.Detail, "Missing one of these permissions")
+		require.Contains(t, res.Body.Error.Detail, "#write_permission")
 	})
 
 	// Test case for wrong workspace

--- a/svc/api/routes/v2_permissions_create_permission/handler.go
+++ b/svc/api/routes/v2_permissions_create_permission/handler.go
@@ -14,7 +14,9 @@ import (
 	"github.com/unkeyed/unkey/pkg/fault"
 	"github.com/unkeyed/unkey/pkg/ptr"
 	"github.com/unkeyed/unkey/pkg/rbac"
+	"github.com/unkeyed/unkey/pkg/rbac/permissions"
 	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/pkg/urn"
 	"github.com/unkeyed/unkey/pkg/zen"
 	"github.com/unkeyed/unkey/svc/api/internal/projects"
 	"github.com/unkeyed/unkey/svc/api/openapi"
@@ -51,15 +53,6 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	err = principal.Authorize(rbac.T(rbac.Tuple{
-		ResourceType: rbac.Rbac,
-		ResourceID:   "*",
-		Action:       rbac.CreatePermission,
-	}))
-	if err != nil {
-		return err
-	}
-
 	permissionID := uid.New(uid.PermissionPrefix)
 
 	description := ptr.SafeDeref(req.Description)
@@ -69,6 +62,20 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		projectID, resolveErr := projects.EnsureDefaultProject(ctx, tx, principal.WorkspaceID)
 		if resolveErr != nil {
 			return resolveErr
+		}
+
+		if authorizeErr := principal.Authorize(rbac.Or(
+			rbac.U(
+				urn.New().Workspace(principal.WorkspaceID).Project(projectID).RBAC().Permission("*"),
+				permissions.WritePermission{},
+			),
+			rbac.T(rbac.Tuple{
+				ResourceType: rbac.Rbac,
+				ResourceID:   "*",
+				Action:       rbac.CreatePermission,
+			}),
+		)); authorizeErr != nil {
+			return authorizeErr
 		}
 
 		// Insert the permission
@@ -133,7 +140,6 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	// 5. Return success response
 	return s.JSON(http.StatusOK, Response{
 		Meta: openapi.Meta{
 			RequestId: s.RequestID(),

--- a/svc/api/routes/v2_permissions_create_permission/urn_permissions_test.go
+++ b/svc/api/routes/v2_permissions_create_permission/urn_permissions_test.go
@@ -1,0 +1,39 @@
+package handler_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_permissions_create_permission"
+)
+
+// TestCreatePermissionAuthorizesCanonicalWritePermission guarantees the
+// project-scoped write action can create permissions without a legacy grant.
+func TestCreatePermissionAuthorizesCanonicalWritePermission(t *testing.T) {
+	h := testutil.NewHarness(t)
+	route := &handler.Handler{DB: h.DB, Auditlogs: h.Auditlogs}
+	h.Register(route)
+
+	workspaceID := h.Resources().UserWorkspace.ID
+	projectID := h.CreateApi(seed.CreateApiRequest{WorkspaceID: workspaceID}).ProjectID
+	rootKey := h.CreateRootKey(
+		workspaceID,
+		fmt.Sprintf("unkey:v1:%s:projects/%s/rbac/permissions/*#write_permission", workspaceID, projectID),
+	)
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}
+
+	res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{
+		Name: "canonical.permission",
+		Slug: "canonical.permission",
+	})
+
+	require.Equal(t, http.StatusOK, res.Status, res.RawBody)
+	require.NotEmpty(t, res.Body.Data.PermissionId)
+}

--- a/svc/api/routes/v2_permissions_create_role/404_test.go
+++ b/svc/api/routes/v2_permissions_create_role/404_test.go
@@ -1,0 +1,63 @@
+package handler_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/db"
+	dbtype "github.com/unkeyed/unkey/pkg/db/types"
+	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
+	"github.com/unkeyed/unkey/svc/api/openapi"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_permissions_create_role"
+)
+
+// TestPermissionFromAnotherProjectIsNotAttached guarantees role creation does
+// not attach a permission owned by another project in the same workspace.
+func TestPermissionFromAnotherProjectIsNotAttached(t *testing.T) {
+	ctx := context.Background()
+	h := testutil.NewHarness(t)
+	route := &handler.Handler{DB: h.DB, Auditlogs: h.Auditlogs}
+	h.Register(route)
+	workspace := h.Resources().UserWorkspace
+	otherProject := h.CreateProject(seed.CreateProjectRequest{
+		ID:          uid.New(uid.ProjectPrefix),
+		WorkspaceID: workspace.ID,
+		Name:        "Other Create Role Project",
+		Slug:        "other-create-role-project",
+	})
+	permissionSlug := "other.project.create.role.permission"
+	require.NoError(t, db.Query.InsertPermission(ctx, h.DB.RW(), db.InsertPermissionParams{
+		PermissionID: uid.New(uid.PermissionPrefix),
+		WorkspaceID:  workspace.ID,
+		ProjectID:    otherProject.ID,
+		Name:         permissionSlug,
+		Slug:         permissionSlug,
+		Description:  dbtype.NullString{Valid: false},
+		CreatedAtM:   time.Now().UnixMilli(),
+	}))
+	rootKey := h.CreateRootKey(
+		workspace.ID,
+		"rbac.*.create_role",
+		"rbac.*.add_permission_to_role",
+		"rbac.*.create_permission",
+	)
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}
+	permissions := []string{permissionSlug}
+
+	res := testutil.CallRoute[handler.Request, openapi.NotFoundErrorResponse](h, route, headers, handler.Request{
+		Name:        "role-with-other-project-permission",
+		Permissions: &permissions,
+	})
+
+	require.Equal(t, http.StatusNotFound, res.Status, res.RawBody)
+	require.Equal(t, "https://unkey.com/docs/errors/unkey/data/permission_not_found", res.Body.Error.Type)
+}

--- a/svc/api/routes/v2_permissions_create_role/409_test.go
+++ b/svc/api/routes/v2_permissions_create_role/409_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/projects"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_permissions_create_role"
@@ -27,6 +28,8 @@ func TestConflictErrors(t *testing.T) {
 
 	// Create a workspace
 	workspace := h.Resources().UserWorkspace
+	projectID, err := projects.EnsureDefaultProject(ctx, h.DB.RW(), workspace.ID)
+	require.NoError(t, err)
 
 	// Create a root key with appropriate permissions
 	rootKey := h.CreateRootKey(workspace.ID, "rbac.*.create_role")
@@ -125,6 +128,7 @@ func TestConflictErrors(t *testing.T) {
 		err := db.Query.InsertRole(ctx, h.DB.RW(), db.InsertRoleParams{
 			RoleID:      roleID,
 			WorkspaceID: workspace.ID,
+			ProjectID:   projectID,
 			Name:        roleName,
 		})
 		require.NoError(t, err)

--- a/svc/api/routes/v2_permissions_create_role/handler.go
+++ b/svc/api/routes/v2_permissions_create_role/handler.go
@@ -18,7 +18,9 @@ import (
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/pkg/ptr"
 	"github.com/unkeyed/unkey/pkg/rbac"
+	rbacpermissions "github.com/unkeyed/unkey/pkg/rbac/permissions"
 	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/pkg/urn"
 	"github.com/unkeyed/unkey/pkg/zen"
 	"github.com/unkeyed/unkey/svc/api/internal/projects"
 	"github.com/unkeyed/unkey/svc/api/openapi"
@@ -54,26 +56,12 @@ func (h *Handler) Path() string {
 func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	logger.Debug("handling request", "requestId", s.RequestID(), "path", "/v2/permissions.createRole")
 
-	// 1. Authentication
 	principal, err := s.GetPrincipal()
 	if err != nil {
 		return err
 	}
 
-	// 2. Request validation
 	req, err := zen.BindBody[Request](s)
-	if err != nil {
-		return err
-	}
-
-	// 3. Permission check
-	err = principal.Authorize(rbac.Or(
-		rbac.T(rbac.Tuple{
-			ResourceType: rbac.Rbac,
-			ResourceID:   "*",
-			Action:       rbac.CreateRole,
-		}),
-	))
 	if err != nil {
 		return err
 	}
@@ -92,23 +80,40 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 	slices.Sort(permissionSlugs)
 
-	if len(permissionSlugs) > 0 {
-		err = principal.Authorize(rbac.T(rbac.Tuple{
-			ResourceType: rbac.Rbac,
-			ResourceID:   "*",
-			Action:       rbac.AddPermissionToRole,
-		}))
-		if err != nil {
-			return err
-		}
-	}
-
-	// 4. Prepare role creation
 	roleID := uid.New(uid.RolePrefix)
 	description := ptr.SafeDeref(req.Description)
 
-	// 5. Create role and permissions in a transaction with audit logs
 	err = db.TxRetry(ctx, h.DB.RW(), func(ctx context.Context, tx db.DBTX) error {
+		projectID, resolveErr := projects.EnsureDefaultProject(ctx, tx, principal.WorkspaceID)
+		if resolveErr != nil {
+			return resolveErr
+		}
+
+		legacyAuthorization := rbac.T(rbac.Tuple{
+			ResourceType: rbac.Rbac,
+			ResourceID:   "*",
+			Action:       rbac.CreateRole,
+		})
+		if len(permissionSlugs) > 0 {
+			legacyAuthorization = rbac.And(
+				legacyAuthorization,
+				rbac.T(rbac.Tuple{
+					ResourceType: rbac.Rbac,
+					ResourceID:   "*",
+					Action:       rbac.AddPermissionToRole,
+				}),
+			)
+		}
+		if authorizeErr := principal.Authorize(rbac.Or(
+			rbac.U(
+				urn.New().Workspace(principal.WorkspaceID).Project(projectID).RBAC().Role("*"),
+				rbacpermissions.WriteRole{},
+			),
+			legacyAuthorization,
+		)); authorizeErr != nil {
+			return authorizeErr
+		}
+
 		permissions := make([]rolePermission, 0, len(permissionSlugs))
 		createdPermissions := make([]rolePermission, 0)
 		var missingSlugs []string
@@ -116,6 +121,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		if len(permissionSlugs) > 0 {
 			foundPermissions, findErr := db.Query.FindPermissionsBySlugsForUpdate(ctx, tx, db.FindPermissionsBySlugsForUpdateParams{
 				WorkspaceID: principal.WorkspaceID,
+				ProjectID:   projectID,
 				Slugs:       permissionSlugs,
 			})
 			if findErr != nil {
@@ -140,17 +146,18 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			}
 
 			if len(missingSlugs) > 0 {
-				if authorizeErr := principal.Authorize(rbac.T(rbac.Tuple{
-					ResourceType: rbac.Rbac,
-					ResourceID:   "*",
-					Action:       rbac.CreatePermission,
-				})); authorizeErr != nil {
+				if authorizeErr := principal.Authorize(rbac.Or(
+					rbac.U(
+						urn.New().Workspace(principal.WorkspaceID).Project(projectID).RBAC().Permission("*"),
+						rbacpermissions.WritePermission{},
+					),
+					rbac.T(rbac.Tuple{
+						ResourceType: rbac.Rbac,
+						ResourceID:   "*",
+						Action:       rbac.CreatePermission,
+					}),
+				)); authorizeErr != nil {
 					return authorizeErr
-				}
-
-				projectID, projectErr := projects.EnsureDefaultProject(ctx, tx, principal.WorkspaceID)
-				if projectErr != nil {
-					return projectErr
 				}
 
 				candidates := make(map[string]db.UpsertPermissionParams, len(missingSlugs))
@@ -175,6 +182,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 				foundPermissions, findErr = db.Query.FindPermissionsBySlugsForUpdate(ctx, tx, db.FindPermissionsBySlugsForUpdateParams{
 					WorkspaceID: principal.WorkspaceID,
+					ProjectID:   projectID,
 					Slugs:       permissionSlugs,
 				})
 				if findErr != nil {
@@ -198,17 +206,19 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 			permissions = permissions[:0]
 			for _, slug := range permissionSlugs {
-				permissions = append(permissions, permissionsBySlug[strings.ToLower(slug)])
+				permission, ok := permissionsBySlug[strings.ToLower(slug)]
+				if !ok {
+					return fault.New("permission not found",
+						fault.Code(codes.Data.Permission.NotFound.URN()),
+						fault.Internal("permission belongs to a different project"),
+						fault.Public(fmt.Sprintf("Permission '%s' was not found.", slug)),
+					)
+				}
+				permissions = append(permissions, permission)
 			}
-		}
-
-		projectID, resolveErr := projects.EnsureDefaultProject(ctx, tx, principal.WorkspaceID)
-		if resolveErr != nil {
-			return resolveErr
 		}
 		now := time.Now().UnixMilli()
 
-		// Insert the role
 		err = db.Query.InsertRole(ctx, tx, db.InsertRoleParams{
 			RoleID:      roleID,
 			WorkspaceID: principal.WorkspaceID,
@@ -246,7 +256,6 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			)
 		}
 
-		// Create audit logs
 		metaData := map[string]interface{}{
 			"name":        req.Name,
 			"description": description,
@@ -345,7 +354,6 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	// 7. Return success response
 	return s.JSON(http.StatusOK, Response{
 		Meta: openapi.Meta{
 			RequestId: s.RequestID(),

--- a/svc/api/routes/v2_permissions_create_role/urn_permissions_test.go
+++ b/svc/api/routes/v2_permissions_create_role/urn_permissions_test.go
@@ -1,0 +1,75 @@
+package handler_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_permissions_create_role"
+)
+
+// TestCreateRoleAuthorizesCanonicalURNPermissions guarantees write_role covers
+// role creation and attachment while new permissions still require write_permission.
+func TestCreateRoleAuthorizesCanonicalURNPermissions(t *testing.T) {
+	h := testutil.NewHarness(t)
+	route := &handler.Handler{DB: h.DB, Auditlogs: h.Auditlogs}
+	h.Register(route)
+
+	workspaceID := h.Resources().UserWorkspace.ID
+	projectID := h.CreateApi(seed.CreateApiRequest{WorkspaceID: workspaceID}).ProjectID
+	existingPermission := h.CreatePermission(seed.CreatePermissionRequest{
+		WorkspaceID: workspaceID,
+		Name:        "existing.canonical.permission",
+		Slug:        "existing.canonical.permission",
+	})
+
+	tests := []struct {
+		name        string
+		permissions []string
+		grants      []string
+	}{
+		{
+			name:        "create role",
+			permissions: []string{},
+			grants: []string{
+				fmt.Sprintf("unkey:v1:%s:projects/%s/rbac/roles/*#write_role", workspaceID, projectID),
+			},
+		},
+		{
+			name:        "attach existing permission",
+			permissions: []string{existingPermission.Slug},
+			grants: []string{
+				fmt.Sprintf("unkey:v1:%s:projects/%s/rbac/roles/*#write_role", workspaceID, projectID),
+			},
+		},
+		{
+			name:        "create and attach permission",
+			permissions: []string{"missing.canonical.permission"},
+			grants: []string{
+				fmt.Sprintf("unkey:v1:%s:projects/%s/rbac/roles/*#write_role", workspaceID, projectID),
+				fmt.Sprintf("unkey:v1:%s:projects/%s/rbac/permissions/*#write_permission", workspaceID, projectID),
+			},
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			rootKey := h.CreateRootKey(workspaceID, test.grants...)
+			headers := http.Header{
+				"Content-Type":  {"application/json"},
+				"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+			}
+			permissions := test.permissions
+
+			res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{
+				Name:        fmt.Sprintf("canonical-role-%d", i),
+				Permissions: &permissions,
+			})
+
+			require.Equal(t, http.StatusOK, res.Status, res.RawBody)
+		})
+	}
+}

--- a/svc/api/routes/v2_permissions_delete_permission/200_test.go
+++ b/svc/api/routes/v2_permissions_delete_permission/200_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/unkeyed/unkey/pkg/db"
 	dbtype "github.com/unkeyed/unkey/pkg/db/types"
 	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/projects"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_permissions_delete_permission"
 )
@@ -28,6 +29,8 @@ func TestSuccess(t *testing.T) {
 
 	// Create a workspace
 	workspace := h.Resources().UserWorkspace
+	projectID, err := projects.EnsureDefaultProject(ctx, h.DB.RW(), workspace.ID)
+	require.NoError(t, err)
 
 	// Create a root key with appropriate permissions
 	rootKey := h.CreateRootKey(workspace.ID, "rbac.*.delete_permission")
@@ -48,6 +51,7 @@ func TestSuccess(t *testing.T) {
 		err := db.Query.InsertPermission(ctx, h.DB.RW(), db.InsertPermissionParams{
 			PermissionID: permissionID,
 			WorkspaceID:  workspace.ID,
+			ProjectID:    projectID,
 			Name:         permissionName,
 			Slug:         "test-delete-permission",
 			Description:  dbtype.NullString{Valid: true, String: permissionDesc},
@@ -104,6 +108,7 @@ func TestSuccess(t *testing.T) {
 		err := db.Query.InsertPermission(ctx, h.DB.RW(), db.InsertPermissionParams{
 			PermissionID: permissionID,
 			WorkspaceID:  workspace.ID,
+			ProjectID:    projectID,
 			Name:         permissionName,
 			Slug:         "test-delete-permission-with-description",
 			Description:  dbtype.NullString{Valid: true, String: permissionDesc},

--- a/svc/api/routes/v2_permissions_delete_permission/403_test.go
+++ b/svc/api/routes/v2_permissions_delete_permission/403_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/unkeyed/unkey/pkg/db"
 	dbtype "github.com/unkeyed/unkey/pkg/db/types"
 	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/projects"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_permissions_delete_permission"
@@ -29,14 +30,17 @@ func TestAuthorizationErrors(t *testing.T) {
 
 	// Create a workspace
 	workspace := h.Resources().UserWorkspace
+	projectID, err := projects.EnsureDefaultProject(ctx, h.DB.RW(), workspace.ID)
+	require.NoError(t, err)
 
 	// Create a test permission to try to delete
 	permissionID := uid.New(uid.PermissionPrefix)
 	permissionName := "test.permission.delete.auth"
 
-	err := db.Query.InsertPermission(ctx, h.DB.RW(), db.InsertPermissionParams{
+	err = db.Query.InsertPermission(ctx, h.DB.RW(), db.InsertPermissionParams{
 		PermissionID: permissionID,
 		WorkspaceID:  workspace.ID,
+		ProjectID:    projectID,
 		Name:         permissionName,
 		Slug:         "test-permission-delete-auth",
 		Description:  dbtype.NullString{Valid: true, String: "Test permission for authorization tests"},

--- a/svc/api/routes/v2_permissions_delete_permission/404_test.go
+++ b/svc/api/routes/v2_permissions_delete_permission/404_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/unkeyed/unkey/pkg/db"
 	dbtype "github.com/unkeyed/unkey/pkg/db/types"
 	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/projects"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_permissions_delete_permission"
@@ -29,6 +30,8 @@ func TestNotFoundErrors(t *testing.T) {
 
 	// Create a workspace
 	workspace := h.Resources().UserWorkspace
+	projectID, err := projects.EnsureDefaultProject(ctx, h.DB.RW(), workspace.ID)
+	require.NoError(t, err)
 
 	// Create a root key with appropriate permissions
 	rootKey := h.CreateRootKey(workspace.ID, "rbac.*.delete_permission")
@@ -86,6 +89,7 @@ func TestNotFoundErrors(t *testing.T) {
 		err := db.Query.InsertPermission(ctx, h.DB.RW(), db.InsertPermissionParams{
 			PermissionID: permissionID,
 			WorkspaceID:  workspace.ID,
+			ProjectID:    projectID,
 			Name:         "test.permission.to.delete",
 			Slug:         "test-permission-to-delete",
 			Description:  dbtype.NullString{Valid: false},

--- a/svc/api/routes/v2_permissions_delete_permission/handler.go
+++ b/svc/api/routes/v2_permissions_delete_permission/handler.go
@@ -10,6 +10,8 @@ import (
 	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/fault"
 	"github.com/unkeyed/unkey/pkg/rbac"
+	"github.com/unkeyed/unkey/pkg/rbac/permissions"
+	"github.com/unkeyed/unkey/pkg/urn"
 	"github.com/unkeyed/unkey/pkg/zen"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
@@ -35,24 +37,11 @@ func (h *Handler) Path() string {
 
 // Handle processes the HTTP request
 func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
-	// 1. Authentication
 	principal, err := s.GetPrincipal()
 	if err != nil {
 		return err
 	}
-	// 2. Request validation
 	req, err := zen.BindBody[Request](s)
-	if err != nil {
-		return err
-	}
-
-	err = principal.Authorize(rbac.Or(
-		rbac.T(rbac.Tuple{
-			ResourceType: rbac.Rbac,
-			ResourceID:   "*",
-			Action:       rbac.DeletePermission,
-		}),
-	))
 	if err != nil {
 		return err
 	}
@@ -74,6 +63,22 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			fault.Internal("database error"),
 			fault.Public("Failed to retrieve permission information."),
 		)
+	}
+
+	deletePermission := rbac.U(
+		urn.New().Workspace(principal.WorkspaceID).Project(permission.ProjectID).RBAC().Permission(permission.ID),
+		permissions.DeletePermission{},
+	)
+	err = principal.Authorize(rbac.Or(
+		deletePermission,
+		rbac.T(rbac.Tuple{
+			ResourceType: rbac.Rbac,
+			ResourceID:   "*",
+			Action:       rbac.DeletePermission,
+		}),
+	))
+	if err != nil {
+		return err
 	}
 
 	err = db.TxRetry(ctx, h.DB.RW(), func(ctx context.Context, tx db.DBTX) error {

--- a/svc/api/routes/v2_permissions_delete_permission/urn_permissions_test.go
+++ b/svc/api/routes/v2_permissions_delete_permission/urn_permissions_test.go
@@ -1,0 +1,42 @@
+package handler_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/db"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_permissions_delete_permission"
+)
+
+// TestDeletePermissionAuthorizesCanonicalDeletePermission guarantees an exact
+// project-scoped permission grant can delete its permission.
+func TestDeletePermissionAuthorizesCanonicalDeletePermission(t *testing.T) {
+	h := testutil.NewHarness(t)
+	route := &handler.Handler{DB: h.DB, Auditlogs: h.Auditlogs}
+	h.Register(route)
+
+	workspaceID := h.Resources().UserWorkspace.ID
+	permission := h.CreatePermission(seed.CreatePermissionRequest{
+		WorkspaceID: workspaceID,
+		Name:        "canonical.permission",
+		Slug:        "canonical.permission",
+	})
+	rootKey := h.CreateRootKey(
+		workspaceID,
+		fmt.Sprintf("unkey:v1:%s:projects/%s/rbac/permissions/%s#delete_permission", workspaceID, permission.ProjectID, permission.ID),
+	)
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}
+
+	res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{Permission: permission.ID})
+
+	require.Equal(t, http.StatusOK, res.Status, res.RawBody)
+	_, err := db.Query.FindPermissionByID(t.Context(), h.DB.RO(), permission.ID)
+	require.True(t, db.IsNotFound(err))
+}

--- a/svc/api/routes/v2_permissions_delete_role/200_test.go
+++ b/svc/api/routes/v2_permissions_delete_role/200_test.go
@@ -13,6 +13,7 @@ import (
 	dbtype "github.com/unkeyed/unkey/pkg/db/types"
 	"github.com/unkeyed/unkey/pkg/hash"
 	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/projects"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_permissions_delete_role"
 )
@@ -30,6 +31,8 @@ func TestSuccess(t *testing.T) {
 
 	// Create a workspace
 	workspace := h.Resources().UserWorkspace
+	projectID, err := projects.EnsureDefaultProject(ctx, h.DB.RW(), workspace.ID)
+	require.NoError(t, err)
 
 	// Create a root key with appropriate permissions
 	rootKey := h.CreateRootKey(workspace.ID, "rbac.*.delete_role")
@@ -50,6 +53,7 @@ func TestSuccess(t *testing.T) {
 		err := db.Query.InsertRole(ctx, h.DB.RW(), db.InsertRoleParams{
 			RoleID:      roleID,
 			WorkspaceID: workspace.ID,
+			ProjectID:   projectID,
 			Name:        roleName,
 			Description: sql.NullString{Valid: true, String: roleDesc},
 		})
@@ -61,6 +65,7 @@ func TestSuccess(t *testing.T) {
 			err = db.Query.InsertPermission(ctx, h.DB.RW(), db.InsertPermissionParams{
 				PermissionID: permID,
 				WorkspaceID:  workspace.ID,
+				ProjectID:    projectID,
 				Name:         fmt.Sprintf("test.perm.%d", i),
 				Slug:         fmt.Sprintf("test-perm-%d", i),
 				Description:  dbtype.NullString{Valid: true, String: fmt.Sprintf("Test permission %d", i)},
@@ -155,6 +160,7 @@ func TestSuccess(t *testing.T) {
 		err := db.Query.InsertRole(ctx, h.DB.RW(), db.InsertRoleParams{
 			RoleID:      roleID,
 			WorkspaceID: workspace.ID,
+			ProjectID:   projectID,
 			Name:        roleName,
 			Description: sql.NullString{Valid: true, String: roleDesc},
 		})

--- a/svc/api/routes/v2_permissions_delete_role/403_test.go
+++ b/svc/api/routes/v2_permissions_delete_role/403_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/projects"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_permissions_delete_role"
@@ -28,6 +29,8 @@ func TestPermissionErrors(t *testing.T) {
 
 	// Create a workspace
 	workspace := h.Resources().UserWorkspace
+	projectID, err := projects.EnsureDefaultProject(ctx, h.DB.RW(), workspace.ID)
+	require.NoError(t, err)
 
 	// Create a role for testing
 	// Create a role to attempt to delete (in the same workspace)
@@ -35,9 +38,10 @@ func TestPermissionErrors(t *testing.T) {
 	roleName := "test.forbidden.role"
 	roleDesc := "Test role for forbidden access"
 
-	err := db.Query.InsertRole(ctx, h.DB.RW(), db.InsertRoleParams{
+	err = db.Query.InsertRole(ctx, h.DB.RW(), db.InsertRoleParams{
 		RoleID:      roleID,
 		WorkspaceID: workspace.ID,
+		ProjectID:   projectID,
 		Name:        roleName,
 		Description: sql.NullString{Valid: true, String: roleDesc},
 	})

--- a/svc/api/routes/v2_permissions_delete_role/404_test.go
+++ b/svc/api/routes/v2_permissions_delete_role/404_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/projects"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_permissions_delete_role"
@@ -67,10 +68,13 @@ func TestNotFound(t *testing.T) {
 		roleID := uid.New(uid.TestPrefix)
 		roleName := "test.role.other.workspace"
 		roleDesc := "Test role in another workspace"
+		projectID, err := projects.EnsureDefaultProject(ctx, h.DB.RW(), anotherWorkspace.ID)
+		require.NoError(t, err)
 
-		err := db.Query.InsertRole(ctx, h.DB.RW(), db.InsertRoleParams{
+		err = db.Query.InsertRole(ctx, h.DB.RW(), db.InsertRoleParams{
 			RoleID:      roleID,
 			WorkspaceID: anotherWorkspace.ID,
+			ProjectID:   projectID,
 			Name:        roleName,
 			Description: sql.NullString{Valid: true, String: roleDesc},
 		})

--- a/svc/api/routes/v2_permissions_delete_role/handler.go
+++ b/svc/api/routes/v2_permissions_delete_role/handler.go
@@ -11,6 +11,8 @@ import (
 	"github.com/unkeyed/unkey/pkg/fault"
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/pkg/rbac"
+	"github.com/unkeyed/unkey/pkg/rbac/permissions"
+	"github.com/unkeyed/unkey/pkg/urn"
 	"github.com/unkeyed/unkey/pkg/zen"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
@@ -38,24 +40,12 @@ func (h *Handler) Path() string {
 func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	logger.Debug("handling request", "requestId", s.RequestID(), "path", "/v2/permissions.deleteRole")
 
-	// 1. Authentication
 	principal, err := s.GetPrincipal()
 	if err != nil {
 		return err
 	}
 
 	req, err := zen.BindBody[Request](s)
-	if err != nil {
-		return err
-	}
-
-	err = principal.Authorize(rbac.Or(
-		rbac.T(rbac.Tuple{
-			ResourceType: rbac.Rbac,
-			ResourceID:   "*",
-			Action:       rbac.DeleteRole,
-		}),
-	))
 	if err != nil {
 		return err
 	}
@@ -75,6 +65,22 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
 			fault.Internal("database error"), fault.Public("Failed to retrieve role information."),
 		)
+	}
+
+	deleteRole := rbac.U(
+		urn.New().Workspace(principal.WorkspaceID).Project(role.ProjectID).RBAC().Role(role.ID),
+		permissions.DeleteRole{},
+	)
+	err = principal.Authorize(rbac.Or(
+		deleteRole,
+		rbac.T(rbac.Tuple{
+			ResourceType: rbac.Rbac,
+			ResourceID:   "*",
+			Action:       rbac.DeleteRole,
+		}),
+	))
+	if err != nil {
+		return err
 	}
 
 	err = db.TxRetry(ctx, h.DB.RW(), func(ctx context.Context, tx db.DBTX) error {
@@ -138,7 +144,6 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	// 7. Return success response
 	return s.JSON(http.StatusOK, Response{
 		Meta: openapi.Meta{
 			RequestId: s.RequestID(),

--- a/svc/api/routes/v2_permissions_delete_role/urn_permissions_test.go
+++ b/svc/api/routes/v2_permissions_delete_role/urn_permissions_test.go
@@ -1,0 +1,38 @@
+package handler_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/db"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_permissions_delete_role"
+)
+
+// TestDeleteRoleAuthorizesCanonicalDeleteRole guarantees an exact
+// project-scoped role grant can delete its role.
+func TestDeleteRoleAuthorizesCanonicalDeleteRole(t *testing.T) {
+	h := testutil.NewHarness(t)
+	route := &handler.Handler{DB: h.DB, Auditlogs: h.Auditlogs}
+	h.Register(route)
+
+	workspaceID := h.Resources().UserWorkspace.ID
+	role := h.CreateRole(seed.CreateRoleRequest{WorkspaceID: workspaceID, Name: "canonical-role"})
+	rootKey := h.CreateRootKey(
+		workspaceID,
+		fmt.Sprintf("unkey:v1:%s:projects/%s/rbac/roles/%s#delete_role", workspaceID, role.ProjectID, role.ID),
+	)
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}
+
+	res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{Role: role.ID})
+
+	require.Equal(t, http.StatusOK, res.Status, res.RawBody)
+	_, err := db.Query.FindRoleByID(t.Context(), h.DB.RO(), role.ID)
+	require.True(t, db.IsNotFound(err))
+}

--- a/svc/api/routes/v2_permissions_get_permission/200_test.go
+++ b/svc/api/routes/v2_permissions_get_permission/200_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/unkeyed/unkey/pkg/db"
 	dbtype "github.com/unkeyed/unkey/pkg/db/types"
 	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/projects"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_permissions_get_permission"
 )
@@ -27,6 +28,8 @@ func TestSuccess(t *testing.T) {
 
 	// Create a workspace
 	workspace := h.Resources().UserWorkspace
+	projectID, err := projects.EnsureDefaultProject(ctx, h.DB.RW(), workspace.ID)
+	require.NoError(t, err)
 
 	// Create a root key with appropriate permissions
 	rootKey := h.CreateRootKey(workspace.ID, "rbac.*.read_permission")
@@ -43,9 +46,10 @@ func TestSuccess(t *testing.T) {
 	permissionDesc := "Test permission for get endpoint"
 	permissionSlug := "test-get-permission"
 
-	err := db.Query.InsertPermission(ctx, h.DB.RW(), db.InsertPermissionParams{
+	err = db.Query.InsertPermission(ctx, h.DB.RW(), db.InsertPermissionParams{
 		PermissionID: permissionID,
 		WorkspaceID:  workspace.ID,
+		ProjectID:    projectID,
 		Name:         permissionName,
 		Slug:         permissionSlug,
 		Description:  dbtype.NullString{Valid: true, String: permissionDesc},
@@ -110,6 +114,7 @@ func TestSuccess(t *testing.T) {
 		err := db.Query.InsertPermission(ctx, h.DB.RW(), db.InsertPermissionParams{
 			PermissionID: permissionID,
 			WorkspaceID:  workspace.ID,
+			ProjectID:    projectID,
 			Name:         permissionName,
 			Slug:         "test-get-permission-no-desc",
 			Description:  dbtype.NullString{}, // Empty description

--- a/svc/api/routes/v2_permissions_get_permission/403_test.go
+++ b/svc/api/routes/v2_permissions_get_permission/403_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/unkeyed/unkey/pkg/db"
 	dbtype "github.com/unkeyed/unkey/pkg/db/types"
 	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/projects"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_permissions_get_permission"
@@ -28,14 +29,17 @@ func TestPermissionErrors(t *testing.T) {
 
 	// Create a workspace
 	workspace := h.Resources().UserWorkspace
+	projectID, err := projects.EnsureDefaultProject(ctx, h.DB.RW(), workspace.ID)
+	require.NoError(t, err)
 
 	// Create a test permission to try to retrieve
 	permissionID := uid.New(uid.PermissionPrefix)
 	permissionName := "test.permission.access"
 
-	err := db.Query.InsertPermission(ctx, h.DB.RW(), db.InsertPermissionParams{
+	err = db.Query.InsertPermission(ctx, h.DB.RW(), db.InsertPermissionParams{
 		PermissionID: permissionID,
 		WorkspaceID:  workspace.ID,
+		ProjectID:    projectID,
 		Name:         permissionName,
 		Slug:         "test-permission-access",
 		Description:  dbtype.NullString{Valid: true, String: "Test permission for authorization tests"},

--- a/svc/api/routes/v2_permissions_get_permission/handler.go
+++ b/svc/api/routes/v2_permissions_get_permission/handler.go
@@ -2,13 +2,16 @@ package handler
 
 import (
 	"context"
+	"net/http"
+
 	"github.com/unkeyed/unkey/pkg/codes"
 	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/fault"
 	"github.com/unkeyed/unkey/pkg/rbac"
+	"github.com/unkeyed/unkey/pkg/rbac/permissions"
+	"github.com/unkeyed/unkey/pkg/urn"
 	"github.com/unkeyed/unkey/pkg/zen"
 	"github.com/unkeyed/unkey/svc/api/openapi"
-	"net/http"
 )
 
 type Request = openapi.V2PermissionsGetPermissionRequestBody
@@ -32,24 +35,12 @@ func (h *Handler) Path() string {
 // Handle processes the HTTP request
 func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
-	// 1. Authentication
 	principal, err := s.GetPrincipal()
 	if err != nil {
 		return err
 	}
 
 	req, err := zen.BindBody[Request](s)
-	if err != nil {
-		return err
-	}
-
-	err = principal.Authorize(rbac.Or(
-		rbac.T(rbac.Tuple{
-			ResourceType: rbac.Rbac,
-			ResourceID:   "*",
-			Action:       rbac.ReadPermission,
-		}),
-	))
 	if err != nil {
 		return err
 	}
@@ -69,6 +60,22 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
 			fault.Internal("database error"), fault.Public("Failed to retrieve permission information."),
 		)
+	}
+
+	readPermission := rbac.U(
+		urn.New().Workspace(principal.WorkspaceID).Project(permission.ProjectID).RBAC().Permission(permission.ID),
+		permissions.ReadPermission{},
+	)
+	err = principal.Authorize(rbac.Or(
+		readPermission,
+		rbac.T(rbac.Tuple{
+			ResourceType: rbac.Rbac,
+			ResourceID:   "*",
+			Action:       rbac.ReadPermission,
+		}),
+	))
+	if err != nil {
+		return err
 	}
 
 	permissionResponse := openapi.Permission{

--- a/svc/api/routes/v2_permissions_get_permission/urn_permissions_test.go
+++ b/svc/api/routes/v2_permissions_get_permission/urn_permissions_test.go
@@ -1,0 +1,84 @@
+package handler_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/db"
+	dbtype "github.com/unkeyed/unkey/pkg/db/types"
+	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_permissions_get_permission"
+)
+
+// TestGetPermissionAuthorizesCanonicalReadPermission guarantees an exact
+// project-scoped permission grant can read its permission.
+func TestGetPermissionAuthorizesCanonicalReadPermission(t *testing.T) {
+	h := testutil.NewHarness(t)
+	route := &handler.Handler{DB: h.DB}
+	h.Register(route)
+
+	workspaceID := h.Resources().UserWorkspace.ID
+	permission := h.CreatePermission(seed.CreatePermissionRequest{
+		WorkspaceID: workspaceID,
+		Name:        "canonical.permission",
+		Slug:        "canonical.permission",
+	})
+	rootKey := h.CreateRootKey(
+		workspaceID,
+		fmt.Sprintf("unkey:v1:%s:projects/%s/rbac/permissions/%s#read_permission", workspaceID, permission.ProjectID, permission.ID),
+	)
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}
+
+	res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{Permission: permission.ID})
+
+	require.Equal(t, http.StatusOK, res.Status, res.RawBody)
+	require.Equal(t, permission.ID, res.Body.Data.Id)
+}
+
+// TestGetPermissionUsesActualProject guarantees a permission grant can read a
+// permission in its actual project instead of the workspace's default project.
+func TestGetPermissionUsesActualProject(t *testing.T) {
+	h := testutil.NewHarness(t)
+	route := &handler.Handler{DB: h.DB}
+	h.Register(route)
+
+	workspaceID := h.Resources().UserWorkspace.ID
+	projectID := uid.New(uid.ProjectPrefix)
+	h.CreateProject(seed.CreateProjectRequest{
+		ID:          projectID,
+		WorkspaceID: workspaceID,
+		Name:        "Other",
+		Slug:        uid.New("other"),
+	})
+	permissionID := uid.New(uid.PermissionPrefix)
+	require.NoError(t, db.Query.InsertPermission(t.Context(), h.DB.RW(), db.InsertPermissionParams{
+		PermissionID: permissionID,
+		WorkspaceID:  workspaceID,
+		ProjectID:    projectID,
+		Name:         "other.permission",
+		Slug:         "other.permission",
+		Description:  dbtype.NullString{Valid: false},
+		CreatedAtM:   time.Now().UnixMilli(),
+	}))
+	rootKey := h.CreateRootKey(
+		workspaceID,
+		fmt.Sprintf("unkey:v1:%s:projects/%s/rbac/permissions/%s#read_permission", workspaceID, projectID, permissionID),
+	)
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}
+
+	res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{Permission: permissionID})
+
+	require.Equal(t, http.StatusOK, res.Status, res.RawBody)
+	require.Equal(t, permissionID, res.Body.Data.Id)
+}

--- a/svc/api/routes/v2_permissions_get_role/200_test.go
+++ b/svc/api/routes/v2_permissions_get_role/200_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/unkeyed/unkey/pkg/db"
 	dbtype "github.com/unkeyed/unkey/pkg/db/types"
 	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/projects"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_permissions_get_role"
 )
@@ -28,6 +29,8 @@ func TestSuccess(t *testing.T) {
 
 	// Create a workspace
 	workspace := h.Resources().UserWorkspace
+	projectID, err := projects.EnsureDefaultProject(ctx, h.DB.RW(), workspace.ID)
+	require.NoError(t, err)
 
 	// Create a root key with appropriate permissions
 	rootKey := h.CreateRootKey(workspace.ID, "rbac.*.read_role")
@@ -48,6 +51,7 @@ func TestSuccess(t *testing.T) {
 		err := db.Query.InsertRole(ctx, h.DB.RW(), db.InsertRoleParams{
 			RoleID:      roleID,
 			WorkspaceID: workspace.ID,
+			ProjectID:   projectID,
 			Name:        roleName,
 			Description: sql.NullString{Valid: true, String: roleDesc},
 			CreatedAt:   time.Now().UnixMilli(),
@@ -60,6 +64,7 @@ func TestSuccess(t *testing.T) {
 			err := db.Query.InsertPermission(ctx, h.DB.RW(), db.InsertPermissionParams{
 				PermissionID: permID,
 				WorkspaceID:  workspace.ID,
+				ProjectID:    projectID,
 				Name:         fmt.Sprintf("test.perm.%d", i),
 				Slug:         fmt.Sprintf("test-perm-%d", i),
 				Description:  dbtype.NullString{Valid: true, String: fmt.Sprintf("Test permission %d", i)},
@@ -127,6 +132,7 @@ func TestSuccess(t *testing.T) {
 		err := db.Query.InsertRole(ctx, h.DB.RW(), db.InsertRoleParams{
 			RoleID:      roleID,
 			WorkspaceID: workspace.ID,
+			ProjectID:   projectID,
 			Name:        roleName,
 			Description: sql.NullString{Valid: true, String: roleDesc},
 		})

--- a/svc/api/routes/v2_permissions_get_role/403_test.go
+++ b/svc/api/routes/v2_permissions_get_role/403_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/projects"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_permissions_get_role"
@@ -27,14 +28,17 @@ func TestPermissionErrors(t *testing.T) {
 
 	// Create a workspace
 	workspace := h.Resources().UserWorkspace
+	projectID, err := projects.EnsureDefaultProject(ctx, h.DB.RW(), workspace.ID)
+	require.NoError(t, err)
 
 	// Create a test role to try to retrieve
 	roleID := uid.New(uid.TestPrefix)
 	roleName := "test.role.access"
 
-	err := db.Query.InsertRole(ctx, h.DB.RW(), db.InsertRoleParams{
+	err = db.Query.InsertRole(ctx, h.DB.RW(), db.InsertRoleParams{
 		RoleID:      roleID,
 		WorkspaceID: workspace.ID,
+		ProjectID:   projectID,
 		Name:        roleName,
 		Description: sql.NullString{Valid: true, String: "Test role for authorization tests"},
 	})

--- a/svc/api/routes/v2_permissions_get_role/handler.go
+++ b/svc/api/routes/v2_permissions_get_role/handler.go
@@ -2,14 +2,17 @@ package handler
 
 import (
 	"context"
+	"net/http"
+
 	"github.com/unkeyed/unkey/pkg/codes"
 	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/fault"
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/pkg/rbac"
+	"github.com/unkeyed/unkey/pkg/rbac/permissions"
+	"github.com/unkeyed/unkey/pkg/urn"
 	"github.com/unkeyed/unkey/pkg/zen"
 	"github.com/unkeyed/unkey/svc/api/openapi"
-	"net/http"
 )
 
 type (
@@ -36,24 +39,12 @@ func (h *Handler) Path() string {
 func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	logger.Debug("handling request", "requestId", s.RequestID(), "path", "/v2/permissions.getRole")
 
-	// 1. Authentication
 	principal, err := s.GetPrincipal()
 	if err != nil {
 		return err
 	}
 
 	req, err := zen.BindBody[Request](s)
-	if err != nil {
-		return err
-	}
-
-	err = principal.Authorize(rbac.Or(
-		rbac.T(rbac.Tuple{
-			ResourceType: rbac.Rbac,
-			ResourceID:   "*",
-			Action:       rbac.ReadRole,
-		}),
-	))
 	if err != nil {
 		return err
 	}
@@ -74,6 +65,22 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
 			fault.Internal("database error"), fault.Public("Failed to retrieve role information."),
 		)
+	}
+
+	readRole := rbac.U(
+		urn.New().Workspace(principal.WorkspaceID).Project(role.ProjectID).RBAC().Role(role.ID),
+		permissions.ReadRole{},
+	)
+	err = principal.Authorize(rbac.Or(
+		readRole,
+		rbac.T(rbac.Tuple{
+			ResourceType: rbac.Rbac,
+			ResourceID:   "*",
+			Action:       rbac.ReadRole,
+		}),
+	))
+	if err != nil {
+		return err
 	}
 
 	roleResponse := openapi.Role{

--- a/svc/api/routes/v2_permissions_get_role/urn_permissions_test.go
+++ b/svc/api/routes/v2_permissions_get_role/urn_permissions_test.go
@@ -1,0 +1,79 @@
+package handler_test
+
+import (
+	"database/sql"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/db"
+	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_permissions_get_role"
+)
+
+// TestGetRoleAuthorizesCanonicalReadRole guarantees an exact project-scoped
+// role grant can read its role.
+func TestGetRoleAuthorizesCanonicalReadRole(t *testing.T) {
+	h := testutil.NewHarness(t)
+	route := &handler.Handler{DB: h.DB}
+	h.Register(route)
+
+	workspaceID := h.Resources().UserWorkspace.ID
+	role := h.CreateRole(seed.CreateRoleRequest{WorkspaceID: workspaceID, Name: "canonical-role"})
+	rootKey := h.CreateRootKey(
+		workspaceID,
+		fmt.Sprintf("unkey:v1:%s:projects/%s/rbac/roles/%s#read_role", workspaceID, role.ProjectID, role.ID),
+	)
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}
+
+	res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{Role: role.ID})
+
+	require.Equal(t, http.StatusOK, res.Status, res.RawBody)
+	require.Equal(t, role.ID, res.Body.Data.Id)
+}
+
+// TestGetRoleUsesActualProject guarantees a role grant can read a role in its
+// actual project instead of the workspace's default project.
+func TestGetRoleUsesActualProject(t *testing.T) {
+	h := testutil.NewHarness(t)
+	route := &handler.Handler{DB: h.DB}
+	h.Register(route)
+
+	workspaceID := h.Resources().UserWorkspace.ID
+	projectID := uid.New(uid.ProjectPrefix)
+	h.CreateProject(seed.CreateProjectRequest{
+		ID:          projectID,
+		WorkspaceID: workspaceID,
+		Name:        "Other",
+		Slug:        uid.New("other"),
+	})
+	roleID := uid.New(uid.RolePrefix)
+	require.NoError(t, db.Query.InsertRole(t.Context(), h.DB.RW(), db.InsertRoleParams{
+		RoleID:      roleID,
+		WorkspaceID: workspaceID,
+		ProjectID:   projectID,
+		Name:        "other-role",
+		Description: sql.NullString{Valid: false},
+		CreatedAt:   time.Now().UnixMilli(),
+	}))
+	rootKey := h.CreateRootKey(
+		workspaceID,
+		fmt.Sprintf("unkey:v1:%s:projects/%s/rbac/roles/%s#read_role", workspaceID, projectID, roleID),
+	)
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}
+
+	res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{Role: roleID})
+
+	require.Equal(t, http.StatusOK, res.Status, res.RawBody)
+	require.Equal(t, roleID, res.Body.Data.Id)
+}

--- a/svc/api/routes/v2_permissions_list_permissions/200_test.go
+++ b/svc/api/routes/v2_permissions_list_permissions/200_test.go
@@ -13,6 +13,7 @@ import (
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_permissions_list_permissions"
 
 	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/projects"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 )
 
@@ -28,6 +29,8 @@ func TestSuccess(t *testing.T) {
 
 	// Create a workspace
 	workspace := h.Resources().UserWorkspace
+	projectID, err := projects.EnsureDefaultProject(ctx, h.DB.RW(), workspace.ID)
+	require.NoError(t, err)
 
 	// Create a root key with appropriate permissions
 	rootKey := h.CreateRootKey(workspace.ID, "rbac.*.read_permission")
@@ -53,9 +56,10 @@ func TestSuccess(t *testing.T) {
 
 	// Insert test permissions into the database
 	for i, perm := range testPermissions {
-		err := db.Query.InsertPermission(ctx, h.DB.RW(), db.InsertPermissionParams{
+		err = db.Query.InsertPermission(ctx, h.DB.RW(), db.InsertPermissionParams{
 			PermissionID: perm.ID,
 			WorkspaceID:  workspace.ID,
+			ProjectID:    projectID,
 			Name:         perm.Name,
 			Slug:         fmt.Sprintf("test-permission-%d", i+1),
 			Description:  dbtype.NullString{Valid: true, String: perm.Description},
@@ -66,9 +70,12 @@ func TestSuccess(t *testing.T) {
 
 	// Create permissions in a different workspace to test isolation
 	otherWorkspace := h.CreateWorkspace()
-	err := db.Query.InsertPermission(ctx, h.DB.RW(), db.InsertPermissionParams{
+	otherProjectID, err := projects.EnsureDefaultProject(ctx, h.DB.RW(), otherWorkspace.ID)
+	require.NoError(t, err)
+	err = db.Query.InsertPermission(ctx, h.DB.RW(), db.InsertPermissionParams{
 		PermissionID: uid.New(uid.PermissionPrefix),
 		WorkspaceID:  otherWorkspace.ID,
+		ProjectID:    otherProjectID,
 		Name:         "other.workspace.permission",
 		Slug:         "other-workspace-permission",
 		Description:  dbtype.NullString{Valid: true, String: "This permission is in a different workspace"},
@@ -143,6 +150,7 @@ func TestSuccess(t *testing.T) {
 			err := db.Query.InsertPermission(ctx, h.DB.RW(), db.InsertPermissionParams{
 				PermissionID: permID,
 				WorkspaceID:  workspace.ID,
+				ProjectID:    projectID,
 				Name:         fmt.Sprintf("bulk.permission.%d", i),
 				Slug:         fmt.Sprintf("bulk-permission-%d", i),
 				Description:  dbtype.NullString{Valid: true, String: fmt.Sprintf("Bulk permission %d", i)},
@@ -194,6 +202,8 @@ func TestSuccess(t *testing.T) {
 	t.Run("search", func(t *testing.T) {
 		// Fresh workspace so search results are not polluted by other subtests
 		searchWorkspace := h.CreateWorkspace()
+		searchProjectID, projectErr := projects.EnsureDefaultProject(ctx, h.DB.RW(), searchWorkspace.ID)
+		require.NoError(t, projectErr)
 		searchKey := h.CreateRootKey(searchWorkspace.ID, "rbac.*.read_permission")
 		searchHeaders := http.Header{
 			"Content-Type":  {"application/json"},
@@ -216,6 +226,7 @@ func TestSuccess(t *testing.T) {
 			err := db.Query.InsertPermission(ctx, h.DB.RW(), db.InsertPermissionParams{
 				PermissionID: permissionID,
 				WorkspaceID:  searchWorkspace.ID,
+				ProjectID:    searchProjectID,
 				Name:         perm.Name,
 				Slug:         perm.Slug,
 				Description:  dbtype.NullString{Valid: true, String: perm.Description},

--- a/svc/api/routes/v2_permissions_list_permissions/403_test.go
+++ b/svc/api/routes/v2_permissions_list_permissions/403_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/unkeyed/unkey/pkg/db"
 	dbtype "github.com/unkeyed/unkey/pkg/db/types"
 	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/projects"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_permissions_list_permissions"
@@ -28,11 +29,14 @@ func TestAuthorizationErrors(t *testing.T) {
 
 	// Create a workspace
 	workspace := h.Resources().UserWorkspace
+	projectID, err := projects.EnsureDefaultProject(ctx, h.DB.RW(), workspace.ID)
+	require.NoError(t, err)
 
 	// Create some test permissions to later try to list
-	err := db.Query.InsertPermission(ctx, h.DB.RW(), db.InsertPermissionParams{
+	err = db.Query.InsertPermission(ctx, h.DB.RW(), db.InsertPermissionParams{
 		PermissionID: uid.New(uid.PermissionPrefix),
 		WorkspaceID:  workspace.ID,
+		ProjectID:    projectID,
 		Name:         "test.permission.auth",
 		Slug:         "test-permission-auth",
 		Description:  dbtype.NullString{Valid: true, String: "Test permission for authorization tests"},
@@ -69,11 +73,14 @@ func TestAuthorizationErrors(t *testing.T) {
 	t.Run("wrong workspace", func(t *testing.T) {
 		// Create a different workspace
 		otherWorkspace := h.CreateWorkspace()
+		otherProjectID, projectErr := projects.EnsureDefaultProject(ctx, h.DB.RW(), otherWorkspace.ID)
+		require.NoError(t, projectErr)
 
 		// Create permissions in the other workspace
 		err := db.Query.InsertPermission(ctx, h.DB.RW(), db.InsertPermissionParams{
 			PermissionID: uid.New(uid.PermissionPrefix),
 			WorkspaceID:  otherWorkspace.ID,
+			ProjectID:    otherProjectID,
 			Name:         "other.workspace.permission",
 			Slug:         "other-workspace-permission",
 			Description:  dbtype.NullString{Valid: true, String: "This permission is in a different workspace"},

--- a/svc/api/routes/v2_permissions_list_permissions/handler.go
+++ b/svc/api/routes/v2_permissions_list_permissions/handler.go
@@ -12,8 +12,11 @@ import (
 	"github.com/unkeyed/unkey/pkg/mysql"
 	"github.com/unkeyed/unkey/pkg/ptr"
 	"github.com/unkeyed/unkey/pkg/rbac"
+	"github.com/unkeyed/unkey/pkg/rbac/permissions"
+	"github.com/unkeyed/unkey/pkg/urn"
 	"github.com/unkeyed/unkey/pkg/zen"
 	"github.com/unkeyed/unkey/svc/api/internal/pagination"
+	"github.com/unkeyed/unkey/svc/api/internal/projects"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
 
@@ -39,13 +42,11 @@ func (h *Handler) Path() string {
 
 // Handle processes the HTTP request
 func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
-	// 1. Authentication
 	principal, err := s.GetPrincipal()
 	if err != nil {
 		return err
 	}
 
-	// 2. Request validation
 	req, err := zen.BindBody[Request](s)
 	if err != nil {
 		return err
@@ -54,22 +55,17 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	p := pagination.Parse(req.Limit, req.Cursor, 100)
 	search := mysql.SearchContains(strings.TrimSpace(ptr.SafeDeref(req.Search)))
 
-	err = principal.Authorize(rbac.Or(
-		rbac.T(rbac.Tuple{
-			ResourceType: rbac.Rbac,
-			ResourceID:   "*",
-			Action:       rbac.ReadPermission,
-		}),
-	))
+	projectID, err := projects.EnsureDefaultProject(ctx, h.DB.RW(), principal.WorkspaceID)
 	if err != nil {
 		return err
 	}
 
-	permissions, err := db.Query.ListPermissions(
+	rows, err := db.Query.ListPermissions(
 		ctx,
 		h.DB.RO(),
 		db.ListPermissionsParams{
 			WorkspaceID:       principal.WorkspaceID,
+			ProjectID:         projectID,
 			IDCursor:          p.Cursor,
 			Search:            search,
 			DescriptionSearch: search,
@@ -83,9 +79,25 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		)
 	}
 
-	permissions, pg := pagination.Paginate(permissions, p, func(r db.Permission) string { return r.ID })
+	readPermissions := rbac.U(
+		urn.New().Workspace(principal.WorkspaceID).Project(projectID).RBAC().Permission("*"),
+		permissions.ReadPermission{},
+	)
+	err = principal.Authorize(rbac.Or(
+		readPermissions,
+		rbac.T(rbac.Tuple{
+			ResourceType: rbac.Rbac,
+			ResourceID:   "*",
+			Action:       rbac.ReadPermission,
+		}),
+	))
+	if err != nil {
+		return err
+	}
 
-	responsePermissions := array.Map(permissions, func(perm db.Permission) openapi.Permission {
+	rows, pg := pagination.Paginate(rows, p, func(r db.Permission) string { return r.ID })
+
+	responsePermissions := array.Map(rows, func(perm db.Permission) openapi.Permission {
 		return openapi.Permission{
 			Id:          perm.ID,
 			Name:        perm.Name,
@@ -94,7 +106,6 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		}
 	})
 
-	// 7. Return success response
 	return s.JSON(http.StatusOK, Response{
 		Meta: openapi.Meta{
 			RequestId: s.RequestID(),

--- a/svc/api/routes/v2_permissions_list_permissions/urn_permissions_test.go
+++ b/svc/api/routes/v2_permissions_list_permissions/urn_permissions_test.go
@@ -1,0 +1,61 @@
+package handler_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/db"
+	dbtype "github.com/unkeyed/unkey/pkg/db/types"
+	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_permissions_list_permissions"
+)
+
+// TestListPermissionsAuthorizesCanonicalReadPermission guarantees a wildcard
+// project-scoped permission grant can list permissions in its project.
+func TestListPermissionsAuthorizesCanonicalReadPermission(t *testing.T) {
+	h := testutil.NewHarness(t)
+	route := &handler.Handler{DB: h.DB}
+	h.Register(route)
+
+	workspaceID := h.Resources().UserWorkspace.ID
+	permission := h.CreatePermission(seed.CreatePermissionRequest{
+		WorkspaceID: workspaceID,
+		Name:        "canonical.permission",
+		Slug:        "canonical.permission",
+	})
+	otherProjectID := uid.New(uid.ProjectPrefix)
+	h.CreateProject(seed.CreateProjectRequest{
+		ID:          otherProjectID,
+		WorkspaceID: workspaceID,
+		Name:        "Other",
+		Slug:        uid.New("other"),
+	})
+	require.NoError(t, db.Query.InsertPermission(t.Context(), h.DB.RW(), db.InsertPermissionParams{
+		PermissionID: uid.New(uid.PermissionPrefix),
+		WorkspaceID:  workspaceID,
+		ProjectID:    otherProjectID,
+		Name:         "other.permission",
+		Slug:         "other.permission",
+		Description:  dbtype.NullString{Valid: false},
+		CreatedAtM:   time.Now().UnixMilli(),
+	}))
+	rootKey := h.CreateRootKey(
+		workspaceID,
+		fmt.Sprintf("unkey:v1:%s:projects/%s/rbac/permissions/*#read_permission", workspaceID, permission.ProjectID),
+	)
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}
+
+	res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{})
+
+	require.Equal(t, http.StatusOK, res.Status, res.RawBody)
+	require.Len(t, res.Body.Data, 1)
+	require.Equal(t, permission.ID, res.Body.Data[0].Id)
+}

--- a/svc/api/routes/v2_permissions_list_roles/200_test.go
+++ b/svc/api/routes/v2_permissions_list_roles/200_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/unkeyed/unkey/pkg/db"
 	dbtype "github.com/unkeyed/unkey/pkg/db/types"
 	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/projects"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_permissions_list_roles"
 )
@@ -28,6 +29,8 @@ func TestSuccess(t *testing.T) {
 
 	// Create a workspace
 	workspace := h.Resources().UserWorkspace
+	projectID, err := projects.EnsureDefaultProject(ctx, h.DB.RW(), workspace.ID)
+	require.NoError(t, err)
 
 	// Create a root key with appropriate permissions
 	rootKey := h.CreateRootKey(workspace.ID, "rbac.*.read_role")
@@ -51,9 +54,10 @@ func TestSuccess(t *testing.T) {
 
 	// Insert test permissions into the database
 	for i, perm := range testPermissions {
-		err := db.Query.InsertPermission(ctx, h.DB.RW(), db.InsertPermissionParams{
+		err = db.Query.InsertPermission(ctx, h.DB.RW(), db.InsertPermissionParams{
 			PermissionID: perm.ID,
 			WorkspaceID:  workspace.ID,
+			ProjectID:    projectID,
 			Name:         perm.Name,
 			Slug:         fmt.Sprintf("test-permission-%d", i+1),
 			Description:  dbtype.NullString{Valid: true, String: perm.Description},
@@ -77,9 +81,10 @@ func TestSuccess(t *testing.T) {
 
 	// Insert test roles into the database
 	for _, role := range testRoles {
-		err := db.Query.InsertRole(ctx, h.DB.RW(), db.InsertRoleParams{
+		err = db.Query.InsertRole(ctx, h.DB.RW(), db.InsertRoleParams{
 			RoleID:      role.ID,
 			WorkspaceID: workspace.ID,
+			ProjectID:   projectID,
 			Name:        role.Name,
 			Description: sql.NullString{Valid: true, String: role.Description},
 		})
@@ -99,9 +104,12 @@ func TestSuccess(t *testing.T) {
 
 	// Create roles in a different workspace to test isolation
 	otherWorkspace := h.CreateWorkspace()
-	err := db.Query.InsertRole(ctx, h.DB.RW(), db.InsertRoleParams{
+	otherProjectID, err := projects.EnsureDefaultProject(ctx, h.DB.RW(), otherWorkspace.ID)
+	require.NoError(t, err)
+	err = db.Query.InsertRole(ctx, h.DB.RW(), db.InsertRoleParams{
 		RoleID:      uid.New(uid.TestPrefix),
 		WorkspaceID: otherWorkspace.ID,
+		ProjectID:   otherProjectID,
 		Name:        "other.workspace.role",
 		Description: sql.NullString{Valid: true, String: "This role is in a different workspace"},
 	})
@@ -182,6 +190,7 @@ func TestSuccess(t *testing.T) {
 			err := db.Query.InsertRole(ctx, h.DB.RW(), db.InsertRoleParams{
 				RoleID:      roleID,
 				WorkspaceID: workspace.ID,
+				ProjectID:   projectID,
 				Name:        fmt.Sprintf("bulk.role.%d", i),
 				Description: sql.NullString{Valid: true, String: fmt.Sprintf("Bulk role %d", i)},
 			})
@@ -243,6 +252,8 @@ func TestSuccess(t *testing.T) {
 	t.Run("search", func(t *testing.T) {
 		// Fresh workspace so search results are not polluted by other subtests
 		searchWorkspace := h.CreateWorkspace()
+		searchProjectID, projectErr := projects.EnsureDefaultProject(ctx, h.DB.RW(), searchWorkspace.ID)
+		require.NoError(t, projectErr)
 		searchKey := h.CreateRootKey(searchWorkspace.ID, "rbac.*.read_role")
 		searchHeaders := http.Header{
 			"Content-Type":  {"application/json"},
@@ -264,6 +275,7 @@ func TestSuccess(t *testing.T) {
 			err := db.Query.InsertRole(ctx, h.DB.RW(), db.InsertRoleParams{
 				RoleID:      roleID,
 				WorkspaceID: searchWorkspace.ID,
+				ProjectID:   searchProjectID,
 				Name:        role.Name,
 				Description: sql.NullString{Valid: true, String: role.Description},
 			})

--- a/svc/api/routes/v2_permissions_list_roles/403_test.go
+++ b/svc/api/routes/v2_permissions_list_roles/403_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/projects"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_permissions_list_roles"
@@ -27,11 +28,14 @@ func TestAuthorizationErrors(t *testing.T) {
 
 	// Create a workspace
 	workspace := h.Resources().UserWorkspace
+	projectID, err := projects.EnsureDefaultProject(ctx, h.DB.RW(), workspace.ID)
+	require.NoError(t, err)
 
 	// Create some test roles to later try to list
-	err := db.Query.InsertRole(ctx, h.DB.RW(), db.InsertRoleParams{
+	err = db.Query.InsertRole(ctx, h.DB.RW(), db.InsertRoleParams{
 		RoleID:      uid.New(uid.TestPrefix),
 		WorkspaceID: workspace.ID,
+		ProjectID:   projectID,
 		Name:        "test.role.auth",
 		Description: sql.NullString{Valid: true, String: "Test role for authorization tests"},
 	})
@@ -66,11 +70,14 @@ func TestAuthorizationErrors(t *testing.T) {
 	t.Run("wrong workspace", func(t *testing.T) {
 		// Create a different workspace
 		otherWorkspace := h.CreateWorkspace()
+		otherProjectID, projectErr := projects.EnsureDefaultProject(ctx, h.DB.RW(), otherWorkspace.ID)
+		require.NoError(t, projectErr)
 
 		// Create roles in the other workspace
 		err := db.Query.InsertRole(ctx, h.DB.RW(), db.InsertRoleParams{
 			RoleID:      uid.New(uid.TestPrefix),
 			WorkspaceID: otherWorkspace.ID,
+			ProjectID:   otherProjectID,
 			Name:        "other.workspace.role",
 			Description: sql.NullString{Valid: true, String: "This role is in a different workspace"},
 		})

--- a/svc/api/routes/v2_permissions_list_roles/handler.go
+++ b/svc/api/routes/v2_permissions_list_roles/handler.go
@@ -13,8 +13,11 @@ import (
 	"github.com/unkeyed/unkey/pkg/mysql"
 	"github.com/unkeyed/unkey/pkg/ptr"
 	"github.com/unkeyed/unkey/pkg/rbac"
+	"github.com/unkeyed/unkey/pkg/rbac/permissions"
+	"github.com/unkeyed/unkey/pkg/urn"
 	"github.com/unkeyed/unkey/pkg/zen"
 	"github.com/unkeyed/unkey/svc/api/internal/pagination"
+	"github.com/unkeyed/unkey/svc/api/internal/projects"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
 
@@ -42,7 +45,6 @@ func (h *Handler) Path() string {
 func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	logger.Debug("handling request", "requestId", s.RequestID(), "path", "/v2/permissions.listRoles")
 
-	// 1. Authentication
 	principal, err := s.GetPrincipal()
 	if err != nil {
 		return err
@@ -56,22 +58,17 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	p := pagination.Parse(req.Limit, req.Cursor, 100)
 	search := mysql.SearchContains(strings.TrimSpace(ptr.SafeDeref(req.Search)))
 
-	err = principal.Authorize(rbac.Or(
-		rbac.T(rbac.Tuple{
-			ResourceType: rbac.Rbac,
-			ResourceID:   "*",
-			Action:       rbac.ReadRole,
-		}),
-	))
+	projectID, err := projects.EnsureDefaultProject(ctx, h.DB.RW(), principal.WorkspaceID)
 	if err != nil {
 		return err
 	}
 
-	roles, err := db.Query.ListRoles(
+	rows, err := db.Query.ListRoles(
 		ctx,
 		h.DB.RO(),
 		db.ListRolesParams{
 			WorkspaceID: principal.WorkspaceID,
+			ProjectID:   projectID,
 			IDCursor:    p.Cursor,
 			Search:      search,
 			Limit:       p.FetchLimit(),
@@ -84,9 +81,25 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		)
 	}
 
-	roles, pg := pagination.Paginate(roles, p, func(r db.ListRolesRow) string { return r.ID })
+	readRoles := rbac.U(
+		urn.New().Workspace(principal.WorkspaceID).Project(projectID).RBAC().Role("*"),
+		permissions.ReadRole{},
+	)
+	err = principal.Authorize(rbac.Or(
+		readRoles,
+		rbac.T(rbac.Tuple{
+			ResourceType: rbac.Rbac,
+			ResourceID:   "*",
+			Action:       rbac.ReadRole,
+		}),
+	))
+	if err != nil {
+		return err
+	}
 
-	roleResponses := array.Map(roles, func(role db.ListRolesRow) openapi.Role {
+	rows, pg := pagination.Paginate(rows, p, func(r db.ListRolesRow) string { return r.ID })
+
+	roleResponses := array.Map(rows, func(role db.ListRolesRow) openapi.Role {
 		perms, err := db.UnmarshalNullableJSONTo[[]db.Permission](role.Permissions)
 		if err != nil {
 			logger.Error("Failed to unmarshal permissions", "error", err)

--- a/svc/api/routes/v2_permissions_list_roles/urn_permissions_test.go
+++ b/svc/api/routes/v2_permissions_list_roles/urn_permissions_test.go
@@ -1,0 +1,56 @@
+package handler_test
+
+import (
+	"database/sql"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/db"
+	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_permissions_list_roles"
+)
+
+// TestListRolesAuthorizesCanonicalReadRole guarantees a wildcard project-scoped
+// role grant can list roles in its project.
+func TestListRolesAuthorizesCanonicalReadRole(t *testing.T) {
+	h := testutil.NewHarness(t)
+	route := &handler.Handler{DB: h.DB}
+	h.Register(route)
+
+	workspaceID := h.Resources().UserWorkspace.ID
+	role := h.CreateRole(seed.CreateRoleRequest{WorkspaceID: workspaceID, Name: "canonical-role"})
+	otherProjectID := uid.New(uid.ProjectPrefix)
+	h.CreateProject(seed.CreateProjectRequest{
+		ID:          otherProjectID,
+		WorkspaceID: workspaceID,
+		Name:        "Other",
+		Slug:        uid.New("other"),
+	})
+	require.NoError(t, db.Query.InsertRole(t.Context(), h.DB.RW(), db.InsertRoleParams{
+		RoleID:      uid.New(uid.RolePrefix),
+		WorkspaceID: workspaceID,
+		ProjectID:   otherProjectID,
+		Name:        "other-role",
+		Description: sql.NullString{Valid: false},
+		CreatedAt:   time.Now().UnixMilli(),
+	}))
+	rootKey := h.CreateRootKey(
+		workspaceID,
+		fmt.Sprintf("unkey:v1:%s:projects/%s/rbac/roles/*#read_role", workspaceID, role.ProjectID),
+	)
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}
+
+	res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{})
+
+	require.Equal(t, http.StatusOK, res.Status, res.RawBody)
+	require.Len(t, res.Body.Data, 1)
+	require.Equal(t, role.ID, res.Body.Data[0].Id)
+}

--- a/svc/api/routes/v2_permissions_set_role_permissions/handler.go
+++ b/svc/api/routes/v2_permissions_set_role_permissions/handler.go
@@ -20,7 +20,6 @@ import (
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/pkg/urn"
 	"github.com/unkeyed/unkey/pkg/zen"
-	"github.com/unkeyed/unkey/svc/api/internal/projects"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
 
@@ -54,14 +53,6 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	err = principal.Authorize(rbac.And(
-		rbac.T(rbac.Tuple{ResourceType: rbac.Rbac, ResourceID: "*", Action: rbac.AddPermissionToRole}),
-		rbac.T(rbac.Tuple{ResourceType: rbac.Rbac, ResourceID: "*", Action: rbac.RemovePermissionFromRole}),
-	))
-	if err != nil {
-		return err
-	}
-
 	requestedSlugs := make([]string, 0, len(req.Permissions))
 	seen := make(map[string]struct{}, len(req.Permissions))
 	for _, slug := range req.Permissions {
@@ -86,9 +77,27 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			return fault.Wrap(lockErr, fault.Code(codes.App.Internal.ServiceUnavailable.URN()), fault.Internal("unable to lock role"), fault.Public("Failed to retrieve role."))
 		}
 
+		authorizeErr := principal.Authorize(rbac.Or(
+			rbac.U(
+				urn.New().Workspace(principal.WorkspaceID).Project(role.ProjectID).RBAC().Role(role.ID),
+				permissions.WriteRole{},
+			),
+			rbac.And(
+				rbac.T(rbac.Tuple{ResourceType: rbac.Rbac, ResourceID: "*", Action: rbac.AddPermissionToRole}),
+				rbac.T(rbac.Tuple{ResourceType: rbac.Rbac, ResourceID: "*", Action: rbac.RemovePermissionFromRole}),
+			),
+		))
+		if authorizeErr != nil {
+			return authorizeErr
+		}
+
 		found := make([]db.FindPermissionsBySlugsForUpdateRow, 0)
 		if len(requestedSlugs) > 0 {
-			found, err = db.Query.FindPermissionsBySlugsForUpdate(ctx, tx, db.FindPermissionsBySlugsForUpdateParams{WorkspaceID: principal.WorkspaceID, Slugs: requestedSlugs})
+			found, err = db.Query.FindPermissionsBySlugsForUpdate(ctx, tx, db.FindPermissionsBySlugsForUpdateParams{
+				WorkspaceID: principal.WorkspaceID,
+				ProjectID:   role.ProjectID,
+				Slugs:       requestedSlugs,
+			})
 			if err != nil {
 				return fault.Wrap(err, fault.Code(codes.App.Internal.ServiceUnavailable.URN()), fault.Internal("database error"), fault.Public("Failed to lookup permissions to set."))
 			}
@@ -107,14 +116,13 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 		if len(missing) > 0 {
 			if authErr := principal.Authorize(rbac.Or(
-				rbac.U(urn.New().Workspace(principal.WorkspaceID).RBAC.Permission("*"), permissions.CreatePermission{}),
+				rbac.U(
+					urn.New().Workspace(principal.WorkspaceID).Project(role.ProjectID).RBAC().Permission("*"),
+					permissions.WritePermission{},
+				),
 				rbac.T(rbac.Tuple{ResourceType: rbac.Rbac, ResourceID: "*", Action: rbac.CreatePermission}),
 			)); authErr != nil {
 				return authErr
-			}
-			projectID, projectErr := projects.EnsureDefaultProject(ctx, tx, principal.WorkspaceID)
-			if projectErr != nil {
-				return projectErr
 			}
 			candidates := make(map[string]db.UpsertPermissionParams, len(missing))
 			for _, slug := range missing {
@@ -122,7 +130,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 				candidate := db.UpsertPermissionParams{
 					PermissionID: uid.New(uid.PermissionPrefix),
 					WorkspaceID:  principal.WorkspaceID,
-					ProjectID:    projectID,
+					ProjectID:    role.ProjectID,
 					Name:         slug,
 					Slug:         slug,
 					Description:  dbtype.NullString{String: "", Valid: false},
@@ -134,7 +142,11 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 				}
 			}
 
-			found, err = db.Query.FindPermissionsBySlugsForUpdate(ctx, tx, db.FindPermissionsBySlugsForUpdateParams{WorkspaceID: principal.WorkspaceID, Slugs: requestedSlugs})
+			found, err = db.Query.FindPermissionsBySlugsForUpdate(ctx, tx, db.FindPermissionsBySlugsForUpdateParams{
+				WorkspaceID: principal.WorkspaceID,
+				ProjectID:   role.ProjectID,
+				Slugs:       requestedSlugs,
+			})
 			if err != nil {
 				return fault.Wrap(err, fault.Code(codes.App.Internal.ServiceUnavailable.URN()), fault.Internal("database error"), fault.Public("Failed to lookup created permissions."))
 			}
@@ -153,6 +165,15 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			}
 			if err != nil {
 				return err
+			}
+		}
+		for _, slug := range requestedSlugs {
+			if _, ok := bySlug[strings.ToLower(slug)]; !ok {
+				return fault.New("permission not found",
+					fault.Code(codes.Data.Permission.NotFound.URN()),
+					fault.Internal("permission belongs to a different project"),
+					fault.Public(fmt.Sprintf("Permission '%s' was not found.", slug)),
+				)
 			}
 		}
 

--- a/svc/api/routes/v2_permissions_set_role_permissions/handler_test.go
+++ b/svc/api/routes/v2_permissions_set_role_permissions/handler_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/unkeyed/unkey/pkg/db"
+	dbtype "github.com/unkeyed/unkey/pkg/db/types"
+	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
 	"github.com/unkeyed/unkey/svc/api/openapi"
@@ -69,6 +71,37 @@ func TestSetRolePermissions(t *testing.T) {
 			res := testutil.CallRoute[handler.Request, openapi.NotFoundErrorResponse](h, route, headers, handler.Request{RoleId: roleID, Permissions: []string{}})
 			require.Equal(t, http.StatusNotFound, res.Status, res.RawBody)
 		}
+	})
+
+	t.Run("permission from another project is not attached", func(t *testing.T) {
+		role := h.CreateRole(seed.CreateRoleRequest{WorkspaceID: workspace.ID, Name: "project-role"})
+		otherProject := h.CreateProject(seed.CreateProjectRequest{
+			ID:          uid.New(uid.ProjectPrefix),
+			WorkspaceID: workspace.ID,
+			Name:        "Other Role Permission Project",
+			Slug:        "other-role-permission-project",
+		})
+		permissionSlug := "other.project.role.permission"
+		require.NoError(t, db.Query.InsertPermission(ctx, h.DB.RW(), db.InsertPermissionParams{
+			PermissionID: uid.New(uid.PermissionPrefix),
+			WorkspaceID:  workspace.ID,
+			ProjectID:    otherProject.ID,
+			Name:         permissionSlug,
+			Slug:         permissionSlug,
+			Description:  dbtype.NullString{Valid: false},
+			CreatedAtM:   time.Now().UnixMilli(),
+		}))
+
+		res := testutil.CallRoute[handler.Request, openapi.NotFoundErrorResponse](h, route, headers, handler.Request{
+			RoleId:      role.ID,
+			Permissions: []string{permissionSlug},
+		})
+
+		require.Equal(t, http.StatusNotFound, res.Status, res.RawBody)
+		require.Equal(t, "https://unkey.com/docs/errors/unkey/data/permission_not_found", res.Body.Error.Type)
+		assigned, err := db.Query.ListDirectPermissionsByRoleID(ctx, h.DB.RO(), role.ID)
+		require.NoError(t, err)
+		require.Empty(t, assigned)
 	})
 
 	t.Run("requires add, remove, and create authorization", func(t *testing.T) {

--- a/svc/api/routes/v2_permissions_set_role_permissions/urn_permissions_test.go
+++ b/svc/api/routes/v2_permissions_set_role_permissions/urn_permissions_test.go
@@ -1,0 +1,42 @@
+package handler_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_permissions_set_role_permissions"
+)
+
+// TestSetRolePermissionsAuthorizesCanonicalWriteRole guarantees write_role can
+// replace a role's existing permission attachments.
+func TestSetRolePermissionsAuthorizesCanonicalWriteRole(t *testing.T) {
+	h := testutil.NewHarness(t)
+	route := &handler.Handler{DB: h.DB, Auditlogs: h.Auditlogs}
+	h.Register(route)
+	workspaceID := h.Resources().UserWorkspace.ID
+	role := h.CreateRole(seed.CreateRoleRequest{WorkspaceID: workspaceID, Name: "canonical-role"})
+	permission := h.CreatePermission(seed.CreatePermissionRequest{
+		WorkspaceID: workspaceID,
+		Name:        "canonical.role.permission",
+		Slug:        "canonical.role.permission",
+	})
+	rootKey := h.CreateRootKey(
+		workspaceID,
+		fmt.Sprintf("unkey:v1:%s:projects/%s/rbac/roles/%s#write_role", workspaceID, role.ProjectID, role.ID),
+	)
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}
+
+	res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{
+		RoleId:      role.ID,
+		Permissions: []string{permission.Slug},
+	})
+
+	require.Equal(t, http.StatusOK, res.Status, res.RawBody)
+}

--- a/svc/api/routes/v2_ratelimit_delete_override/handler.go
+++ b/svc/api/routes/v2_ratelimit_delete_override/handler.go
@@ -16,6 +16,8 @@ import (
 	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/fault"
 	"github.com/unkeyed/unkey/pkg/rbac"
+	"github.com/unkeyed/unkey/pkg/rbac/permissions"
+	"github.com/unkeyed/unkey/pkg/urn"
 	"github.com/unkeyed/unkey/pkg/zen"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
@@ -74,7 +76,20 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		)
 	}
 
+	override, ok := ns.DirectOverrides[req.Identifier]
+	if !ok {
+		return fault.New("override not found",
+			fault.Code(codes.Data.RatelimitOverride.NotFound.URN()),
+			fault.Internal("override not found"),
+			fault.Public("This override does not exist."),
+		)
+	}
+
 	err = principal.Authorize(rbac.Or(
+		rbac.U(
+			urn.New().Workspace(principal.WorkspaceID).Project(ns.ProjectID).RatelimitNamespace(ns.ID).Override(override.ID),
+			permissions.DeleteRatelimitOverride{},
+		),
 		rbac.T(rbac.Tuple{
 			ResourceType: rbac.Ratelimit,
 			ResourceID:   ns.ID,
@@ -88,15 +103,6 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	))
 	if err != nil {
 		return err
-	}
-
-	override, ok := ns.DirectOverrides[req.Identifier]
-	if !ok {
-		return fault.New("override not found",
-			fault.Code(codes.Data.RatelimitOverride.NotFound.URN()),
-			fault.Internal("override not found"),
-			fault.Public("This override does not exist."),
-		)
 	}
 
 	err = db.TxRetry(ctx, h.DB.RW(), func(ctx context.Context, tx db.DBTX) error {

--- a/svc/api/routes/v2_ratelimit_delete_override/urn_permissions_test.go
+++ b/svc/api/routes/v2_ratelimit_delete_override/urn_permissions_test.go
@@ -1,0 +1,67 @@
+package handler_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/db"
+	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_ratelimit_delete_override"
+)
+
+// TestDeleteOverrideAuthorizesCanonicalDeleteRatelimitOverride guarantees an
+// exact project-scoped override grant can delete its override.
+func TestDeleteOverrideAuthorizesCanonicalDeleteRatelimitOverride(t *testing.T) {
+	h := testutil.NewHarness(t)
+	workspaceID := h.Resources().UserWorkspace.ID
+	projectID := h.CreateApi(seed.CreateApiRequest{WorkspaceID: workspaceID}).ProjectID
+	namespaceID := uid.New(uid.RatelimitNamespacePrefix)
+	namespaceName := uid.New("namespace")
+	require.NoError(t, db.Query.InsertRatelimitNamespace(t.Context(), h.DB.RW(), db.InsertRatelimitNamespaceParams{
+		ID:          namespaceID,
+		WorkspaceID: workspaceID,
+		ProjectID:   projectID,
+		Name:        namespaceName,
+		CreatedAt:   time.Now().UnixMilli(),
+	}))
+	overrideID := uid.New(uid.RatelimitOverridePrefix)
+	identifier := "canonical-identifier"
+	require.NoError(t, db.Query.InsertRatelimitOverride(t.Context(), h.DB.RW(), db.InsertRatelimitOverrideParams{
+		ID:          overrideID,
+		WorkspaceID: workspaceID,
+		NamespaceID: namespaceID,
+		Identifier:  identifier,
+		Limit:       10,
+		Duration:    1_000,
+		CreatedAt:   time.Now().UnixMilli(),
+	}))
+
+	route := &handler.Handler{DB: h.DB, Auditlogs: h.Auditlogs, NamespaceCache: h.Caches.RatelimitNamespace}
+	h.Register(route)
+	rootKey := h.CreateRootKey(
+		workspaceID,
+		fmt.Sprintf("unkey:v1:%s:projects/%s/ratelimits/namespaces/%s/overrides/%s#delete_ratelimit_override", workspaceID, projectID, namespaceID, overrideID),
+	)
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}
+
+	res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{
+		Namespace:  namespaceName,
+		Identifier: identifier,
+	})
+
+	require.Equal(t, http.StatusOK, res.Status, res.RawBody)
+	override, err := db.Query.FindRatelimitOverrideByID(t.Context(), h.DB.RO(), db.FindRatelimitOverrideByIDParams{
+		WorkspaceID: workspaceID,
+		OverrideID:  overrideID,
+	})
+	require.NoError(t, err)
+	require.True(t, override.DeletedAtM.Valid)
+}

--- a/svc/api/routes/v2_ratelimit_get_override/200_test.go
+++ b/svc/api/routes/v2_ratelimit_get_override/200_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_ratelimit_get_override"
 )
 
@@ -19,6 +20,7 @@ import (
 func TestGetOverrideSuccessfully(t *testing.T) {
 	ctx := context.Background()
 	h := testutil.NewHarness(t)
+	projectID := h.CreateApi(seed.CreateApiRequest{WorkspaceID: h.Resources().UserWorkspace.ID}).ProjectID
 
 	// Create a namespace
 	namespaceID := uid.New("test_ns")
@@ -26,6 +28,7 @@ func TestGetOverrideSuccessfully(t *testing.T) {
 	err := db.Query.InsertRatelimitNamespace(ctx, h.DB.RW(), db.InsertRatelimitNamespaceParams{
 		ID:          namespaceID,
 		WorkspaceID: h.Resources().UserWorkspace.ID,
+		ProjectID:   projectID,
 		Name:        namespaceName,
 		CreatedAt:   time.Now().UnixMilli(),
 	})
@@ -57,7 +60,7 @@ func TestGetOverrideSuccessfully(t *testing.T) {
 
 	rootKey := h.CreateRootKey(
 		h.Resources().UserWorkspace.ID,
-		fmt.Sprintf("unkey:v1:%s:ratelimits/namespaces/%s/overrides/*#read_override", h.Resources().UserWorkspace.ID, namespaceID),
+		fmt.Sprintf("unkey:v1:%s:projects/%s/ratelimits/namespaces/%s/overrides/*#read_ratelimit_override", h.Resources().UserWorkspace.ID, projectID, namespaceID),
 	)
 
 	headers := http.Header{

--- a/svc/api/routes/v2_ratelimit_get_override/handler.go
+++ b/svc/api/routes/v2_ratelimit_get_override/handler.go
@@ -102,9 +102,10 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			rbac.U(
 				urn.New().
 					Workspace(principal.WorkspaceID).
+					Project(ns.ProjectID).
 					RatelimitNamespace(ns.ID).
 					Override(override.ID),
-				permissions.ReadOverride{},
+				permissions.ReadRatelimitOverride{},
 			),
 			rbac.T(rbac.Tuple{
 				ResourceType: rbac.Ratelimit,

--- a/svc/api/routes/v2_ratelimit_get_override/urn_permissions_test.go
+++ b/svc/api/routes/v2_ratelimit_get_override/urn_permissions_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 	handler "github.com/unkeyed/unkey/svc/api/routes/v2_ratelimit_get_override"
 )
@@ -28,8 +29,9 @@ func TestGetOverride_AuthorizesURNPermissions(t *testing.T) {
 		{
 			name: "exact override permission",
 			permission: fmt.Sprintf(
-				"unkey:v1:%s:ratelimits/namespaces/%s/overrides/%s#read_override",
+				"unkey:v1:%s:projects/%s/ratelimits/namespaces/%s/overrides/%s#read_ratelimit_override",
 				setup.workspaceID,
+				setup.projectID,
 				setup.namespaceID,
 				setup.overrideID,
 			),
@@ -37,30 +39,33 @@ func TestGetOverride_AuthorizesURNPermissions(t *testing.T) {
 		{
 			name: "namespace override wildcard permission",
 			permission: fmt.Sprintf(
-				"unkey:v1:%s:ratelimits/namespaces/%s/overrides/*#read_override",
+				"unkey:v1:%s:projects/%s/ratelimits/namespaces/%s/overrides/*#read_ratelimit_override",
 				setup.workspaceID,
+				setup.projectID,
 				setup.namespaceID,
 			),
 		},
 		{
 			name: "namespace descendant wildcard permission",
 			permission: fmt.Sprintf(
-				"unkey:v1:%s:ratelimits/namespaces/%s/**#read_override",
+				"unkey:v1:%s:projects/%s/ratelimits/namespaces/%s/**#read_ratelimit_override",
 				setup.workspaceID,
+				setup.projectID,
 				setup.namespaceID,
 			),
 		},
 		{
-			name: "ratelimits descendant wildcard permission",
+			name: "project descendant wildcard permission",
 			permission: fmt.Sprintf(
-				"unkey:v1:%s:ratelimits/**#read_override",
+				"unkey:v1:%s:projects/%s/**#read_ratelimit_override",
 				setup.workspaceID,
+				setup.projectID,
 			),
 		},
 		{
 			name: "workos wildcard namespace permission",
 			permission: fmt.Sprintf(
-				"unkey:v1:%s:ratelimits/namespaces/*/overrides/*#read_override",
+				"unkey:v1:%s:projects/*/ratelimits/namespaces/*/overrides/*#read_ratelimit_override",
 				setup.workspaceID,
 			),
 		},
@@ -104,15 +109,17 @@ func TestGetOverride_RejectsNonCoveringURNPermissions(t *testing.T) {
 		{
 			name: "sibling namespace wildcard permission",
 			permission: fmt.Sprintf(
-				"unkey:v1:%s:ratelimits/namespaces/ns_other/overrides/*#read_override",
+				"unkey:v1:%s:projects/%s/ratelimits/namespaces/ns_other/overrides/*#read_ratelimit_override",
 				setup.workspaceID,
+				setup.projectID,
 			),
 		},
 		{
 			name: "wrong action permission",
 			permission: fmt.Sprintf(
-				"unkey:v1:%s:ratelimits/namespaces/%s/overrides/%s#delete_override",
+				"unkey:v1:%s:projects/%s/ratelimits/namespaces/%s/overrides/%s#delete_ratelimit_override",
 				setup.workspaceID,
+				setup.projectID,
 				setup.namespaceID,
 				setup.overrideID,
 			),
@@ -120,7 +127,8 @@ func TestGetOverride_RejectsNonCoveringURNPermissions(t *testing.T) {
 		{
 			name: "wrong workspace permission",
 			permission: fmt.Sprintf(
-				"unkey:v1:ws_other:ratelimits/namespaces/%s/overrides/%s#read_override",
+				"unkey:v1:ws_other:projects/%s/ratelimits/namespaces/%s/overrides/%s#read_ratelimit_override",
+				setup.projectID,
 				setup.namespaceID,
 				setup.overrideID,
 			),
@@ -148,6 +156,7 @@ type getOverrideURNPermissionTest struct {
 	route       *handler.Handler
 	req         handler.Request
 	workspaceID string
+	projectID   string
 	namespaceID string
 	overrideID  string
 }
@@ -157,12 +166,20 @@ func setupGetOverrideURNPermissionTest(t *testing.T, ctx context.Context) getOve
 
 	h := testutil.NewHarness(t)
 	workspaceID := h.Resources().UserWorkspace.ID
+	projectID := uid.New(uid.ProjectPrefix)
+	h.CreateProject(seed.CreateProjectRequest{
+		ID:          projectID,
+		WorkspaceID: workspaceID,
+		Name:        uid.New("project"),
+		Slug:        uid.New("project"),
+	})
 
-	namespaceID := uid.New("test_ns")
+	namespaceID := uid.New(uid.RatelimitNamespacePrefix)
 	namespaceName := uid.New("test")
 	err := db.Query.InsertRatelimitNamespace(ctx, h.DB.RW(), db.InsertRatelimitNamespaceParams{
 		ID:          namespaceID,
 		WorkspaceID: workspaceID,
+		ProjectID:   projectID,
 		Name:        namespaceName,
 		CreatedAt:   time.Now().UnixMilli(),
 	})
@@ -192,6 +209,7 @@ func setupGetOverrideURNPermissionTest(t *testing.T, ctx context.Context) getOve
 		route:       route,
 		req:         handler.Request{Namespace: namespaceName, Identifier: identifier},
 		workspaceID: workspaceID,
+		projectID:   projectID,
 		namespaceID: namespaceID,
 		overrideID:  overrideID,
 	}

--- a/svc/api/routes/v2_ratelimit_limit/handler.go
+++ b/svc/api/routes/v2_ratelimit_limit/handler.go
@@ -23,8 +23,10 @@ import (
 	"github.com/unkeyed/unkey/pkg/match"
 	"github.com/unkeyed/unkey/pkg/ptr"
 	"github.com/unkeyed/unkey/pkg/rbac"
+	"github.com/unkeyed/unkey/pkg/rbac/permissions"
 	sf "github.com/unkeyed/unkey/pkg/singleflight"
 	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/pkg/urn"
 	"github.com/unkeyed/unkey/pkg/zen"
 	"github.com/unkeyed/unkey/svc/api/internal/projects"
 	"github.com/unkeyed/unkey/svc/api/openapi"
@@ -81,18 +83,28 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	if !found {
-		err = principal.Authorize(
+		projectID, resolveErr := db.TxWithResultRetry(ctx, h.DB.RW(), func(ctx context.Context, tx db.DBTX) (string, error) {
+			return projects.EnsureDefaultProject(ctx, tx, principal.WorkspaceID)
+		})
+		if resolveErr != nil {
+			return resolveErr
+		}
+		err = principal.Authorize(rbac.Or(
+			rbac.U(
+				urn.New().Workspace(principal.WorkspaceID).Project(projectID).RatelimitNamespace("*"),
+				permissions.WriteRatelimitNamespace{},
+			),
 			rbac.T(rbac.Tuple{
 				ResourceType: rbac.Ratelimit,
 				ResourceID:   "*",
 				Action:       rbac.CreateNamespace,
 			}),
-		)
+		))
 		if err != nil {
 			return err
 		}
 
-		ns, err = h.createNamespace(ctx, s, principal, req.Namespace)
+		ns, err = h.createNamespace(ctx, s, principal, projectID, req.Namespace)
 		if err != nil {
 			return err
 		}
@@ -106,6 +118,10 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	err = principal.Authorize(rbac.Or(
+		rbac.U(
+			urn.New().Workspace(principal.WorkspaceID).Project(ns.ProjectID).RatelimitNamespace(ns.ID),
+			permissions.LimitRatelimitNamespace{},
+		),
 		rbac.T(rbac.Tuple{
 			ResourceType: rbac.Ratelimit,
 			ResourceID:   ns.ID,
@@ -231,15 +247,10 @@ func (h *Handler) getNamespace(ctx context.Context, workspaceID, nameOrID string
 	return ns, true, nil
 }
 
-func (h *Handler) createNamespace(ctx context.Context, s *zen.Session, principal *principal.Principal, name string) (db.FindRatelimitNamespace, error) {
+func (h *Handler) createNamespace(ctx context.Context, s *zen.Session, principal *principal.Principal, projectID, name string) (db.FindRatelimitNamespace, error) {
 	key := principal.WorkspaceID + ":" + name
 	return h.createFlight.Do(key, func() (db.FindRatelimitNamespace, error) {
 		ns, err := db.TxWithResultRetry(ctx, h.DB.RW(), func(ctx context.Context, tx db.DBTX) (db.FindRatelimitNamespace, error) {
-			projectID, resolveErr := projects.EnsureDefaultProject(ctx, tx, principal.WorkspaceID)
-			if resolveErr != nil {
-				return db.FindRatelimitNamespace{}, resolveErr //nolint:exhaustruct
-			}
-
 			now := time.Now().UnixMilli()
 			id := uid.New(uid.RatelimitNamespacePrefix)
 

--- a/svc/api/routes/v2_ratelimit_limit/urn_permissions_test.go
+++ b/svc/api/routes/v2_ratelimit_limit/urn_permissions_test.go
@@ -1,0 +1,89 @@
+package v2RatelimitLimit_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/db"
+	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_ratelimit_limit"
+)
+
+// TestLimitAuthorizesCanonicalRatelimitNamespacePermissions guarantees the
+// canonical catalog covers existing and automatically created namespaces.
+func TestLimitAuthorizesCanonicalRatelimitNamespacePermissions(t *testing.T) {
+	h := testutil.NewHarness(t)
+	workspaceID := h.Resources().UserWorkspace.ID
+	projectID := h.CreateApi(seed.CreateApiRequest{WorkspaceID: workspaceID}).ProjectID
+	route := &handler.Handler{
+		DB:              h.DB,
+		RatelimitEvents: h.RatelimitEvents,
+		Ratelimit:       h.Ratelimit,
+		NamespaceCache:  h.Caches.RatelimitNamespace,
+		Auditlogs:       h.Auditlogs,
+	}
+	h.Register(route)
+
+	t.Run("existing namespace", func(t *testing.T) {
+		namespaceID := uid.New(uid.RatelimitNamespacePrefix)
+		namespaceName := uid.New("namespace")
+		require.NoError(t, db.Query.InsertRatelimitNamespace(t.Context(), h.DB.RW(), db.InsertRatelimitNamespaceParams{
+			ID:          namespaceID,
+			WorkspaceID: workspaceID,
+			ProjectID:   projectID,
+			Name:        namespaceName,
+			CreatedAt:   time.Now().UnixMilli(),
+		}))
+		rootKey := h.CreateRootKey(
+			workspaceID,
+			fmt.Sprintf("unkey:v1:%s:projects/%s/ratelimits/namespaces/%s#limit_ratelimit_namespace", workspaceID, projectID, namespaceID),
+		)
+		headers := http.Header{
+			"Content-Type":  {"application/json"},
+			"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+		}
+
+		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{
+			Namespace:  namespaceName,
+			Identifier: "canonical-identifier",
+			Limit:      10,
+			Duration:   1_000,
+		})
+
+		require.Equal(t, http.StatusOK, res.Status, res.RawBody)
+		require.True(t, res.Body.Data.Success)
+	})
+
+	t.Run("create namespace", func(t *testing.T) {
+		namespaceName := uid.New("namespace")
+		rootKey := h.CreateRootKey(
+			workspaceID,
+			fmt.Sprintf("unkey:v1:%s:projects/%s/ratelimits/namespaces/*#write_ratelimit_namespace", workspaceID, projectID),
+			fmt.Sprintf("unkey:v1:%s:projects/%s/ratelimits/namespaces/*#limit_ratelimit_namespace", workspaceID, projectID),
+		)
+		headers := http.Header{
+			"Content-Type":  {"application/json"},
+			"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+		}
+
+		res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{
+			Namespace:  namespaceName,
+			Identifier: "canonical-identifier",
+			Limit:      10,
+			Duration:   1_000,
+		})
+
+		require.Equal(t, http.StatusOK, res.Status, res.RawBody)
+		namespace, err := db.Query.FindRatelimitNamespaceByName(t.Context(), h.DB.RO(), db.FindRatelimitNamespaceByNameParams{
+			WorkspaceID: workspaceID,
+			Name:        namespaceName,
+		})
+		require.NoError(t, err)
+		require.Equal(t, projectID, namespace.ProjectID)
+	})
+}

--- a/svc/api/routes/v2_ratelimit_list_overrides/handler.go
+++ b/svc/api/routes/v2_ratelimit_list_overrides/handler.go
@@ -2,15 +2,18 @@ package handler
 
 import (
 	"context"
+	"net/http"
+
 	"github.com/unkeyed/unkey/pkg/array"
 	"github.com/unkeyed/unkey/pkg/codes"
 	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/fault"
 	"github.com/unkeyed/unkey/pkg/rbac"
+	"github.com/unkeyed/unkey/pkg/rbac/permissions"
+	"github.com/unkeyed/unkey/pkg/urn"
 	"github.com/unkeyed/unkey/pkg/zen"
 	"github.com/unkeyed/unkey/svc/api/internal/pagination"
 	"github.com/unkeyed/unkey/svc/api/openapi"
-	"net/http"
 )
 
 type (
@@ -71,6 +74,10 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	err = principal.Authorize(rbac.Or(
+		rbac.U(
+			urn.New().Workspace(principal.WorkspaceID).Project(namespace.ProjectID).RatelimitNamespace(namespace.ID).Override("*"),
+			permissions.ReadRatelimitOverride{},
+		),
 		rbac.T(rbac.Tuple{
 			ResourceType: rbac.Ratelimit,
 			ResourceID:   namespace.ID,

--- a/svc/api/routes/v2_ratelimit_list_overrides/urn_permissions_test.go
+++ b/svc/api/routes/v2_ratelimit_list_overrides/urn_permissions_test.go
@@ -1,0 +1,59 @@
+package handler_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/db"
+	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_ratelimit_list_overrides"
+)
+
+// TestListOverridesAuthorizesCanonicalReadRatelimitOverride guarantees a
+// project-scoped override wildcard can list the namespace's overrides.
+func TestListOverridesAuthorizesCanonicalReadRatelimitOverride(t *testing.T) {
+	h := testutil.NewHarness(t)
+	workspaceID := h.Resources().UserWorkspace.ID
+	projectID := h.CreateApi(seed.CreateApiRequest{WorkspaceID: workspaceID}).ProjectID
+	namespaceID := uid.New(uid.RatelimitNamespacePrefix)
+	namespaceName := uid.New("namespace")
+	require.NoError(t, db.Query.InsertRatelimitNamespace(t.Context(), h.DB.RW(), db.InsertRatelimitNamespaceParams{
+		ID:          namespaceID,
+		WorkspaceID: workspaceID,
+		ProjectID:   projectID,
+		Name:        namespaceName,
+		CreatedAt:   time.Now().UnixMilli(),
+	}))
+	overrideID := uid.New(uid.RatelimitOverridePrefix)
+	require.NoError(t, db.Query.InsertRatelimitOverride(t.Context(), h.DB.RW(), db.InsertRatelimitOverrideParams{
+		ID:          overrideID,
+		WorkspaceID: workspaceID,
+		NamespaceID: namespaceID,
+		Identifier:  "canonical-identifier",
+		Limit:       10,
+		Duration:    1_000,
+		CreatedAt:   time.Now().UnixMilli(),
+	}))
+
+	route := &handler.Handler{DB: h.DB}
+	h.Register(route)
+	rootKey := h.CreateRootKey(
+		workspaceID,
+		fmt.Sprintf("unkey:v1:%s:projects/%s/ratelimits/namespaces/%s/overrides/*#read_ratelimit_override", workspaceID, projectID, namespaceID),
+	)
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}
+
+	res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{Namespace: namespaceName})
+
+	require.Equal(t, http.StatusOK, res.Status, res.RawBody)
+	require.Len(t, res.Body.Data, 1)
+	require.Equal(t, overrideID, res.Body.Data[0].OverrideId)
+}

--- a/svc/api/routes/v2_ratelimit_multi_limit/handler.go
+++ b/svc/api/routes/v2_ratelimit_multi_limit/handler.go
@@ -23,7 +23,9 @@ import (
 	"github.com/unkeyed/unkey/pkg/match"
 	"github.com/unkeyed/unkey/pkg/ptr"
 	"github.com/unkeyed/unkey/pkg/rbac"
+	"github.com/unkeyed/unkey/pkg/rbac/permissions"
 	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/pkg/urn"
 	"github.com/unkeyed/unkey/pkg/zen"
 	"github.com/unkeyed/unkey/svc/api/internal/projects"
 	"github.com/unkeyed/unkey/svc/api/openapi"
@@ -87,18 +89,28 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 	// Auto-create any missing namespaces
 	if len(missing) > 0 {
-		err = principal.Authorize(
+		projectID, resolveErr := db.TxWithResultRetry(ctx, h.DB.RW(), func(ctx context.Context, tx db.DBTX) (string, error) {
+			return projects.EnsureDefaultProject(ctx, tx, principal.WorkspaceID)
+		})
+		if resolveErr != nil {
+			return resolveErr
+		}
+		err = principal.Authorize(rbac.Or(
+			rbac.U(
+				urn.New().Workspace(principal.WorkspaceID).Project(projectID).RatelimitNamespace("*"),
+				permissions.WriteRatelimitNamespace{},
+			),
 			rbac.T(rbac.Tuple{
 				ResourceType: rbac.Ratelimit,
 				ResourceID:   "*",
 				Action:       rbac.CreateNamespace,
 			}),
-		)
+		))
 		if err != nil {
 			return err
 		}
 
-		created, createErr := h.createNamespaces(ctx, s, principal, missing)
+		created, createErr := h.createNamespaces(ctx, s, principal, projectID, missing)
 		if createErr != nil {
 			return createErr
 		}
@@ -112,11 +124,17 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	requiredPerms := make([]rbac.PermissionQuery, 0, len(req))
 	for _, check := range req {
 		ns := namespaces[check.Namespace]
-		requiredPerms = append(requiredPerms, rbac.T(rbac.Tuple{
-			ResourceType: rbac.Ratelimit,
-			ResourceID:   ns.ID,
-			Action:       rbac.Limit,
-		}))
+		requiredPerms = append(requiredPerms, rbac.Or(
+			rbac.U(
+				urn.New().Workspace(principal.WorkspaceID).Project(ns.ProjectID).RatelimitNamespace(ns.ID),
+				permissions.LimitRatelimitNamespace{},
+			),
+			rbac.T(rbac.Tuple{
+				ResourceType: rbac.Ratelimit,
+				ResourceID:   ns.ID,
+				Action:       rbac.Limit,
+			}),
+		))
 	}
 
 	wildcardPermission := rbac.T(rbac.Tuple{
@@ -311,13 +329,8 @@ func (h *Handler) getNamespaces(ctx context.Context, workspaceID string, names [
 	return found, missing, nil
 }
 
-func (h *Handler) createNamespaces(ctx context.Context, s *zen.Session, principal *principal.Principal, names []string) (map[string]db.FindRatelimitNamespace, error) {
+func (h *Handler) createNamespaces(ctx context.Context, s *zen.Session, principal *principal.Principal, projectID string, names []string) (map[string]db.FindRatelimitNamespace, error) {
 	created, err := db.TxWithResultRetry(ctx, h.DB.RW(), func(ctx context.Context, tx db.DBTX) (map[string]db.FindRatelimitNamespace, error) {
-		projectID, resolveErr := projects.EnsureDefaultProject(ctx, tx, principal.WorkspaceID)
-		if resolveErr != nil {
-			return nil, resolveErr
-		}
-
 		now := time.Now().UnixMilli()
 		result := make(map[string]db.FindRatelimitNamespace, len(names))
 

--- a/svc/api/routes/v2_ratelimit_multi_limit/urn_permissions_test.go
+++ b/svc/api/routes/v2_ratelimit_multi_limit/urn_permissions_test.go
@@ -1,0 +1,59 @@
+package v2_ratelimit_multi_limit_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/db"
+	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_ratelimit_multi_limit"
+)
+
+// TestMultiLimitAuthorizesCanonicalRatelimitNamespacePermissions guarantees
+// canonical write and limit actions cover namespace creation in a batch.
+func TestMultiLimitAuthorizesCanonicalRatelimitNamespacePermissions(t *testing.T) {
+	h := testutil.NewHarness(t)
+	workspaceID := h.Resources().UserWorkspace.ID
+	projectID := h.CreateApi(seed.CreateApiRequest{WorkspaceID: workspaceID}).ProjectID
+	route := &handler.Handler{
+		DB:              h.DB,
+		RatelimitEvents: h.RatelimitEvents,
+		Ratelimit:       h.Ratelimit,
+		NamespaceCache:  h.Caches.RatelimitNamespace,
+		Auditlogs:       h.Auditlogs,
+	}
+	h.Register(route)
+
+	namespaceName := uid.New("namespace")
+	rootKey := h.CreateRootKey(
+		workspaceID,
+		fmt.Sprintf("unkey:v1:%s:projects/%s/ratelimits/namespaces/*#write_ratelimit_namespace", workspaceID, projectID),
+		fmt.Sprintf("unkey:v1:%s:projects/%s/ratelimits/namespaces/*#limit_ratelimit_namespace", workspaceID, projectID),
+	)
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}
+
+	res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{
+		{
+			Namespace:  namespaceName,
+			Identifier: "canonical-identifier",
+			Limit:      10,
+			Duration:   1_000,
+		},
+	})
+
+	require.Equal(t, http.StatusOK, res.Status, res.RawBody)
+	require.True(t, res.Body.Data.Passed)
+	namespace, err := db.Query.FindRatelimitNamespaceByName(t.Context(), h.DB.RO(), db.FindRatelimitNamespaceByNameParams{
+		WorkspaceID: workspaceID,
+		Name:        namespaceName,
+	})
+	require.NoError(t, err)
+	require.Equal(t, projectID, namespace.ProjectID)
+}

--- a/svc/api/routes/v2_ratelimit_set_override/handler.go
+++ b/svc/api/routes/v2_ratelimit_set_override/handler.go
@@ -14,7 +14,9 @@ import (
 	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/fault"
 	"github.com/unkeyed/unkey/pkg/rbac"
+	"github.com/unkeyed/unkey/pkg/rbac/permissions"
 	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/pkg/urn"
 	"github.com/unkeyed/unkey/pkg/zen"
 	"github.com/unkeyed/unkey/svc/api/openapi"
 )
@@ -83,22 +85,6 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			)
 		}
 
-		txErr = principal.Authorize(rbac.Or(
-			rbac.T(rbac.Tuple{
-				ResourceType: rbac.Ratelimit,
-				ResourceID:   nsRow.ID,
-				Action:       rbac.SetOverride,
-			}),
-			rbac.T(rbac.Tuple{
-				ResourceType: rbac.Ratelimit,
-				ResourceID:   "*",
-				Action:       rbac.SetOverride,
-			}),
-		))
-		if txErr != nil {
-			return zero, txErr
-		}
-
 		override, txErr := db.Query.FindRatelimitOverrideByIdentifier(ctx, tx, db.FindRatelimitOverrideByIdentifierParams{
 			WorkspaceID: principal.WorkspaceID,
 			NamespaceID: nsRow.ID,
@@ -116,6 +102,26 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		ovrID := uid.New(uid.RatelimitOverridePrefix)
 		if txErr == nil {
 			ovrID = override.ID
+		}
+
+		txErr = principal.Authorize(rbac.Or(
+			rbac.U(
+				urn.New().Workspace(principal.WorkspaceID).Project(nsRow.ProjectID).RatelimitNamespace(nsRow.ID).Override(ovrID),
+				permissions.WriteRatelimitOverride{},
+			),
+			rbac.T(rbac.Tuple{
+				ResourceType: rbac.Ratelimit,
+				ResourceID:   nsRow.ID,
+				Action:       rbac.SetOverride,
+			}),
+			rbac.T(rbac.Tuple{
+				ResourceType: rbac.Ratelimit,
+				ResourceID:   "*",
+				Action:       rbac.SetOverride,
+			}),
+		))
+		if txErr != nil {
+			return zero, txErr
 		}
 
 		now := time.Now().UnixMilli()

--- a/svc/api/routes/v2_ratelimit_set_override/urn_permissions_test.go
+++ b/svc/api/routes/v2_ratelimit_set_override/urn_permissions_test.go
@@ -1,0 +1,53 @@
+package handler_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/db"
+	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_ratelimit_set_override"
+)
+
+// TestSetOverrideAuthorizesCanonicalWriteRatelimitOverride guarantees a
+// project-scoped override wildcard can create an override.
+func TestSetOverrideAuthorizesCanonicalWriteRatelimitOverride(t *testing.T) {
+	h := testutil.NewHarness(t)
+	workspaceID := h.Resources().UserWorkspace.ID
+	projectID := h.CreateApi(seed.CreateApiRequest{WorkspaceID: workspaceID}).ProjectID
+	namespaceID := uid.New(uid.RatelimitNamespacePrefix)
+	namespaceName := uid.New("namespace")
+	require.NoError(t, db.Query.InsertRatelimitNamespace(t.Context(), h.DB.RW(), db.InsertRatelimitNamespaceParams{
+		ID:          namespaceID,
+		WorkspaceID: workspaceID,
+		ProjectID:   projectID,
+		Name:        namespaceName,
+		CreatedAt:   time.Now().UnixMilli(),
+	}))
+
+	route := &handler.Handler{DB: h.DB, Auditlogs: h.Auditlogs, NamespaceCache: h.Caches.RatelimitNamespace}
+	h.Register(route)
+	rootKey := h.CreateRootKey(
+		workspaceID,
+		fmt.Sprintf("unkey:v1:%s:projects/%s/ratelimits/namespaces/%s/overrides/*#write_ratelimit_override", workspaceID, projectID, namespaceID),
+	)
+	headers := http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}
+
+	res := testutil.CallRoute[handler.Request, handler.Response](h, route, headers, handler.Request{
+		Namespace:  namespaceName,
+		Identifier: "canonical-identifier",
+		Limit:      10,
+		Duration:   1_000,
+	})
+
+	require.Equal(t, http.StatusOK, res.Status, res.RawBody)
+	require.NotEmpty(t, res.Body.Data.OverrideId)
+}


### PR DESCRIPTION
## Notes for description (rewrite before review)

### Stack
- Position: 5 of 9. Review wave 2: handler migration.
- Full stack: #7189 → #7190 → #7191 → #7192 → **#7193** → #7195 → #7196 → #7197 → #7198.
- Depends on: #7192. Next: #7195.

### Goal
- Add canonical project-scoped permissions to identity, RBAC, and rate limit handlers.

### Approach
- Accept canonical URN permissions and legacy tuples during the migration.
- Resolve the actual project for existing resources.
- Use the default project for create and list requests without a project selector.
- Keep identity, role, and permission list queries within one project.
- Prevent cross-project permission attachment to roles.

### Decisions
- `write_role` controls role creation and permission attachment.
- Missing permission definitions also require `write_permission`.
- Rate limit overrides use first-class override URNs.
- Keep old authorization arms until the WorkOS cutover.
- Leave OpenAPI files unchanged.

### Review order
1. Review identity handlers and identity list queries.
2. Review role and permission handlers, locks, and project filters.
3. Review rate limit namespace and override handlers.
4. Review source SQL before generated SQL.
5. Review route tests within each resource section.

### Review focus
- Treat the three resource sections as independent review units.
- Confirm that get, update, and delete operations use the resource's actual project.
- Confirm that empty identity lists still require authorization.
- Confirm that role assignment locks and filters permissions by `project_id`.

### Verification
- 152 focused identity tests passed.
- 164 final RBAC tests passed.
- 172 focused rate limit tests passed.
- `mise run build` passed, including lint.
- `git diff --check` passed.
