### PR TITLE
Scope key assignments to projects

### DIFF
--- a/pkg/db/querier_generated.go
+++ b/pkg/db/querier_generated.go
@@ -779,7 +779,9 @@ type Querier interface {
 	//  WHERE ns.workspace_id = ?
 	//    AND (ns.id IN (/*SLICE:namespaces*/?) OR ns.name IN (/*SLICE:namespaces*/?))
 	FindManyRatelimitNamespaces(ctx context.Context, db DBTX, arg FindManyRatelimitNamespacesParams) ([]FindManyRatelimitNamespacesRow, error)
-	//FindManyRolesByNamesWithPerms
+	// FindManyRolesByNamesWithPerms returns the requested roles and their
+	// permissions from one project. The project filter prevents cross-project key
+	// assignments.
 	//
 	//  SELECT pk, id, workspace_id, project_id, name, description, created_at_m, updated_at_m, COALESCE(
 	//          (SELECT JSON_ARRAYAGG(
@@ -797,7 +799,9 @@ type Querier interface {
 	//          JSON_ARRAY()
 	//  ) as permissions
 	//  FROM roles r
-	//  WHERE r.workspace_id = ? AND r.name IN (/*SLICE:names*/?)
+	//  WHERE r.workspace_id = ?
+	//    AND r.project_id = ?
+	//    AND r.name IN (/*SLICE:names*/?)
 	FindManyRolesByNamesWithPerms(ctx context.Context, db DBTX, arg FindManyRolesByNamesWithPermsParams) ([]FindManyRolesByNamesWithPermsRow, error)
 	// Finds a permission record by its ID
 	// Returns: The permission record if found

--- a/pkg/db/queries/role_find_many_by_name_with_perms.sql
+++ b/pkg/db/queries/role_find_many_by_name_with_perms.sql
@@ -1,4 +1,7 @@
 -- name: FindManyRolesByNamesWithPerms :many
+-- FindManyRolesByNamesWithPerms returns the requested roles and their
+-- permissions from one project. The project filter prevents cross-project key
+-- assignments.
 SELECT *, COALESCE(
         (SELECT JSON_ARRAYAGG(
             json_object(
@@ -15,4 +18,6 @@ SELECT *, COALESCE(
         JSON_ARRAY()
 ) as permissions
 FROM roles r
-WHERE r.workspace_id = ? AND r.name IN (sqlc.slice('names'));
+WHERE r.workspace_id = sqlc.arg('workspace_id')
+  AND r.project_id = sqlc.arg('project_id')
+  AND r.name IN (sqlc.slice('names'));

--- a/pkg/db/role_find_many_by_name_with_perms.sql_generated.go
+++ b/pkg/db/role_find_many_by_name_with_perms.sql_generated.go
@@ -28,11 +28,14 @@ SELECT pk, id, workspace_id, project_id, name, description, created_at_m, update
         JSON_ARRAY()
 ) as permissions
 FROM roles r
-WHERE r.workspace_id = ? AND r.name IN (/*SLICE:names*/?)
+WHERE r.workspace_id = ?
+  AND r.project_id = ?
+  AND r.name IN (/*SLICE:names*/?)
 `
 
 type FindManyRolesByNamesWithPermsParams struct {
 	WorkspaceID string   `db:"workspace_id"`
+	ProjectID   string   `db:"project_id"`
 	Names       []string `db:"names"`
 }
 
@@ -48,7 +51,9 @@ type FindManyRolesByNamesWithPermsRow struct {
 	Permissions interface{}    `db:"permissions"`
 }
 
-// FindManyRolesByNamesWithPerms
+// FindManyRolesByNamesWithPerms returns the requested roles and their
+// permissions from one project. The project filter prevents cross-project key
+// assignments.
 //
 //	SELECT pk, id, workspace_id, project_id, name, description, created_at_m, updated_at_m, COALESCE(
 //	        (SELECT JSON_ARRAYAGG(
@@ -66,11 +71,14 @@ type FindManyRolesByNamesWithPermsRow struct {
 //	        JSON_ARRAY()
 //	) as permissions
 //	FROM roles r
-//	WHERE r.workspace_id = ? AND r.name IN (/*SLICE:names*/?)
+//	WHERE r.workspace_id = ?
+//	  AND r.project_id = ?
+//	  AND r.name IN (/*SLICE:names*/?)
 func (q *Queries) FindManyRolesByNamesWithPerms(ctx context.Context, db DBTX, arg FindManyRolesByNamesWithPermsParams) ([]FindManyRolesByNamesWithPermsRow, error) {
 	query := findManyRolesByNamesWithPerms
 	var queryParams []interface{}
 	queryParams = append(queryParams, arg.WorkspaceID)
+	queryParams = append(queryParams, arg.ProjectID)
 	if len(arg.Names) > 0 {
 		for _, v := range arg.Names {
 			queryParams = append(queryParams, v)

--- a/svc/api/routes/v2_keys_add_permissions/200_test.go
+++ b/svc/api/routes/v2_keys_add_permissions/200_test.go
@@ -52,7 +52,7 @@ func TestSuccess(t *testing.T) {
 			Slug:        "documents.write.urn.add",
 		})
 
-		updateKeyPermission := fmt.Sprintf("unkey:v1:%s:keyspaces/%s/keys/%s#update_key", workspace.ID, api.KeyAuthID.String, key.KeyID)
+		updateKeyPermission := fmt.Sprintf("unkey:v1:%s:projects/%s/keyspaces/%s/keys/%s#write_key", workspace.ID, api.ProjectID, api.KeyAuthID.String, key.KeyID)
 		urnRootKey := h.CreateRootKey(workspace.ID, updateKeyPermission)
 		urnHeaders := http.Header{
 			"Content-Type":  {"application/json"},
@@ -81,8 +81,8 @@ func TestSuccess(t *testing.T) {
 			Name:        ptr.P("urn-create-permission-key"),
 		})
 
-		updateKeyPermission := fmt.Sprintf("unkey:v1:%s:keyspaces/%s/keys/%s#update_key", workspace.ID, api.KeyAuthID.String, key.KeyID)
-		createPermissionPermission := fmt.Sprintf("unkey:v1:%s:rbac/permissions/*#create_permission", workspace.ID)
+		updateKeyPermission := fmt.Sprintf("unkey:v1:%s:projects/%s/keyspaces/%s/keys/%s#write_key", workspace.ID, api.ProjectID, api.KeyAuthID.String, key.KeyID)
+		createPermissionPermission := fmt.Sprintf("unkey:v1:%s:projects/%s/rbac/permissions/*#write_permission", workspace.ID, api.ProjectID)
 		urnRootKey := h.CreateRootKey(workspace.ID, updateKeyPermission, createPermissionPermission)
 		urnHeaders := http.Header{
 			"Content-Type":  {"application/json"},

--- a/svc/api/routes/v2_keys_add_permissions/handler.go
+++ b/svc/api/routes/v2_keys_add_permissions/handler.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/unkeyed/unkey/internal/services/auditlogs"
@@ -86,8 +87,8 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	err = principal.Authorize(
 		rbac.Or(
 			rbac.U(
-				urn.New().Workspace(principal.WorkspaceID).Keyspace(key.KeyAuthID).Key(key.ID),
-				permissions.UpdateKey{},
+				urn.New().Workspace(principal.WorkspaceID).Project(key.KeyAuth.ProjectID).Keyspace(key.KeyAuthID).Key(key.ID),
+				permissions.WriteKey{},
 			),
 			rbac.And(
 				rbac.Or(
@@ -114,8 +115,6 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	projectID := key.KeyAuth.ProjectID
-
 	currentPermissions, err := db.Query.ListDirectPermissionsByKeyID(ctx, h.DB.RO(), req.KeyId)
 	if err != nil {
 		return fault.Wrap(err,
@@ -126,7 +125,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 	foundPermissions, err := db.Query.FindPermissionsBySlugs(ctx, h.DB.RO(), db.FindPermissionsBySlugsParams{
 		WorkspaceID: principal.WorkspaceID,
-		ProjectID:   projectID,
+		ProjectID:   key.KeyAuth.ProjectID,
 		Slugs:       req.Permissions,
 	})
 	if err != nil {
@@ -138,7 +137,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 	missingPermissions := make(map[string]struct{})
 	permissionsToSet := make([]db.Permission, 0)
-	permissionsToInsert := make([]db.InsertPermissionParams, 0)
+	permissionsToInsert := make([]db.UpsertPermissionParams, 0)
 	currentPermissionIDs := make(map[string]db.Permission)
 
 	for _, permission := range currentPermissions {
@@ -166,8 +165,8 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	for perm := range missingPermissions {
 		err = principal.Authorize(rbac.Or(
 			rbac.U(
-				urn.New().Workspace(principal.WorkspaceID).RBAC.Permission("*"),
-				permissions.CreatePermission{},
+				urn.New().Workspace(principal.WorkspaceID).Project(key.KeyAuth.ProjectID).RBAC().Permission("*"),
+				permissions.WritePermission{},
 			),
 			rbac.T(rbac.Tuple{
 				ResourceType: rbac.Rbac,
@@ -181,26 +180,14 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 		permissionID := uid.New(uid.PermissionPrefix)
 		now := time.Now().UnixMilli()
-		permissionsToInsert = append(permissionsToInsert, db.InsertPermissionParams{
+		permissionsToInsert = append(permissionsToInsert, db.UpsertPermissionParams{
 			PermissionID: permissionID,
 			Name:         perm,
 			WorkspaceID:  principal.WorkspaceID,
-			ProjectID:    projectID,
+			ProjectID:    key.KeyAuth.ProjectID,
 			Slug:         perm,
 			Description:  dbtype.NullString{String: "", Valid: false},
 			CreatedAtM:   now,
-		})
-
-		permissionsToSet = append(permissionsToSet, db.Permission{
-			Pk:          0, // only here to make the linter happy
-			ID:          permissionID,
-			Name:        perm,
-			WorkspaceID: principal.WorkspaceID,
-			ProjectID:   projectID,
-			Slug:        perm,
-			Description: dbtype.NullString{String: "", Valid: false},
-			CreatedAtM:  now,
-			UpdatedAtM:  sql.NullInt64{Int64: now, Valid: true},
 		})
 	}
 
@@ -216,8 +203,39 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 		var auditLogs []auditlog.AuditLog
 
+		createdPermissionIDs := make(map[string]db.UpsertPermissionParams, len(permissionsToInsert))
 		if len(permissionsToInsert) > 0 {
 			for _, toCreate := range permissionsToInsert {
+				createdPermissionIDs[strings.ToLower(toCreate.Slug)] = toCreate
+				if err = db.Query.UpsertPermission(ctx, tx, toCreate); err != nil {
+					return fault.Wrap(err,
+						fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
+						fault.Internal("database error"),
+						fault.Public("Failed to insert permissions."),
+					)
+				}
+			}
+		}
+
+		foundPermissions, err = db.Query.FindPermissionsBySlugs(ctx, tx, db.FindPermissionsBySlugsParams{
+			WorkspaceID: principal.WorkspaceID,
+			ProjectID:   key.KeyAuth.ProjectID,
+			Slugs:       req.Permissions,
+		})
+		if err != nil {
+			return fault.Wrap(err,
+				fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
+				fault.Internal("database error"),
+				fault.Public("Failed to lookup permissions to add."),
+			)
+		}
+
+		foundBySlug := make(map[string]db.Permission, len(foundPermissions))
+		for _, permission := range foundPermissions {
+			normalizedSlug := strings.ToLower(permission.Slug)
+			foundBySlug[normalizedSlug] = permission
+			candidate, exists := createdPermissionIDs[normalizedSlug]
+			if exists && candidate.PermissionID == permission.ID {
 				auditLogs = append(auditLogs, auditlog.AuditLog{
 					WorkspaceID:   principal.WorkspaceID,
 					Event:         auditlog.PermissionCreateEvent,
@@ -225,32 +243,38 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 					ActorID:       principal.Subject.ID,
 					ActorName:     principal.Subject.Name,
 					ActorMeta:     map[string]any{},
-					Display:       fmt.Sprintf("Created %s (%s)", toCreate.Slug, toCreate.PermissionID),
+					Display:       fmt.Sprintf("Created %s (%s)", candidate.Slug, candidate.PermissionID),
 					RemoteIP:      s.Location(),
 					UserAgent:     s.UserAgent(),
 					CorrelationID: "",
 					Resources: []auditlog.AuditLogResource{
 						{
 							Type:        auditlog.PermissionResourceType,
-							ID:          toCreate.PermissionID,
-							Name:        toCreate.Slug,
-							DisplayName: toCreate.Name,
+							ID:          candidate.PermissionID,
+							Name:        candidate.Slug,
+							DisplayName: candidate.Name,
 							Meta: map[string]interface{}{
-								"name": toCreate.Name,
-								"slug": toCreate.Slug,
+								"name": candidate.Name,
+								"slug": candidate.Slug,
 							},
 						},
 					},
 				})
 			}
+		}
 
-			err = db.BulkQuery.InsertPermissions(ctx, tx, permissionsToInsert)
-			if err != nil {
-				return fault.Wrap(err,
-					fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
-					fault.Internal("database error"),
-					fault.Public("Failed to insert permissions."),
+		permissionsToSet = permissionsToSet[:0]
+		for _, requestedSlug := range req.Permissions {
+			permission, exists := foundBySlug[strings.ToLower(requestedSlug)]
+			if !exists {
+				return fault.New("permission not found",
+					fault.Code(codes.Data.Permission.NotFound.URN()),
+					fault.Internal("permission belongs to a different project"),
+					fault.Public(fmt.Sprintf("Permission '%s' was not found.", requestedSlug)),
 				)
+			}
+			if _, exists = currentPermissionIDs[permission.ID]; !exists {
+				permissionsToSet = append(permissionsToSet, permission)
 			}
 		}
 

--- a/svc/api/routes/v2_keys_add_permissions/project_scope_test.go
+++ b/svc/api/routes/v2_keys_add_permissions/project_scope_test.go
@@ -1,0 +1,75 @@
+package handler_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/db"
+	dbtype "github.com/unkeyed/unkey/pkg/db/types"
+	"github.com/unkeyed/unkey/pkg/ptr"
+	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
+	"github.com/unkeyed/unkey/svc/api/openapi"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_keys_add_permissions"
+)
+
+// TestAddPermissionsRejectsPermissionFromAnotherProject guarantees that a key
+// cannot receive a permission from a different project.
+func TestAddPermissionsRejectsPermissionFromAnotherProject(t *testing.T) {
+	h := testutil.NewHarness(t)
+	route := &handler.Handler{
+		DB:        h.DB,
+		Auditlogs: h.Auditlogs,
+		KeyCache:  h.Caches.VerificationKeyByHash,
+	}
+	h.Register(route)
+
+	workspace := h.Resources().UserWorkspace
+	otherProjectAPI := h.CreateApi(seed.CreateApiRequest{WorkspaceID: workspace.ID})
+	keyProject := h.CreateProject(seed.CreateProjectRequest{
+		ID:          uid.New(uid.ProjectPrefix),
+		WorkspaceID: workspace.ID,
+		Name:        "Key project",
+		Slug:        uid.New("project"),
+	})
+	keyProjectAPI := h.CreateApi(seed.CreateApiRequest{WorkspaceID: workspace.ID, ProjectID: keyProject.ID})
+	key := h.CreateKey(seed.CreateKeyRequest{
+		WorkspaceID: workspace.ID,
+		KeySpaceID:  keyProjectAPI.KeyAuthID.String,
+		Name:        ptr.P("project-scoped-key"),
+	})
+
+	permissionSlug := "documents.read.add.wrong-project"
+	err := db.Query.InsertPermission(t.Context(), h.DB.RW(), db.InsertPermissionParams{
+		PermissionID: uid.New(uid.PermissionPrefix),
+		WorkspaceID:  workspace.ID,
+		ProjectID:    otherProjectAPI.ProjectID,
+		Name:         permissionSlug,
+		Slug:         permissionSlug,
+		Description:  dbtype.NullString{Valid: false},
+		CreatedAtM:   time.Now().UnixMilli(),
+	})
+	require.NoError(t, err)
+
+	writeKey := fmt.Sprintf("unkey:v1:%s:projects/%s/keyspaces/%s/keys/%s#write_key", workspace.ID, keyProject.ID, keyProjectAPI.KeyAuthID.String, key.KeyID)
+	writePermission := fmt.Sprintf("unkey:v1:%s:projects/%s/rbac/permissions/*#write_permission", workspace.ID, keyProject.ID)
+	rootKey := h.CreateRootKey(workspace.ID, writeKey, writePermission)
+	res := testutil.CallRoute[handler.Request, openapi.NotFoundErrorResponse](h, route, http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}, handler.Request{
+		KeyId:       key.KeyID,
+		Permissions: []string{permissionSlug},
+	})
+
+	require.Equal(t, http.StatusNotFound, res.Status, "got: %s", res.RawBody)
+	require.Contains(t, res.Body.Error.Detail, permissionSlug)
+
+	permissions, err := db.Query.ListDirectPermissionsByKeyID(t.Context(), h.DB.RO(), key.KeyID)
+	require.NoError(t, err)
+	require.Empty(t, permissions)
+}

--- a/svc/api/routes/v2_keys_add_roles/200_test.go
+++ b/svc/api/routes/v2_keys_add_roles/200_test.go
@@ -53,7 +53,7 @@ func TestSuccess(t *testing.T) {
 			Description: ptr.P("editor_urn_add_role"),
 		})
 
-		updateKeyPermission := fmt.Sprintf("unkey:v1:%s:keyspaces/%s/keys/%s#update_key", workspace.ID, api.KeyAuthID.String, key.KeyID)
+		updateKeyPermission := fmt.Sprintf("unkey:v1:%s:projects/%s/keyspaces/%s/keys/%s#write_key", workspace.ID, api.ProjectID, api.KeyAuthID.String, key.KeyID)
 		urnRootKey := h.CreateRootKey(workspace.ID, updateKeyPermission)
 		urnHeaders := http.Header{
 			"Content-Type":  {"application/json"},

--- a/svc/api/routes/v2_keys_add_roles/404_test.go
+++ b/svc/api/routes/v2_keys_add_roles/404_test.go
@@ -297,6 +297,7 @@ func TestNotFoundErrors(t *testing.T) {
 		err := db.Query.InsertRole(ctx, h.DB.RW(), db.InsertRoleParams{
 			RoleID:      validRoleID,
 			WorkspaceID: workspace.ID,
+			ProjectID:   api.ProjectID,
 			Name:        validName,
 			Description: sql.NullString{Valid: true, String: "Admin role"},
 		})
@@ -424,5 +425,40 @@ func TestNotFoundErrors(t *testing.T) {
 		require.NotNil(t, res.Body)
 		require.NotNil(t, res.Body.Error)
 		require.Contains(t, res.Body.Error.Detail, "was not found")
+	})
+
+	t.Run("role from another project", func(t *testing.T) {
+		api := h.CreateApi(seed.CreateApiRequest{WorkspaceID: workspace.ID})
+		key := h.CreateKey(seed.CreateKeyRequest{
+			WorkspaceID: workspace.ID,
+			KeySpaceID:  api.KeyAuthID.String,
+		})
+		otherProject := h.CreateProject(seed.CreateProjectRequest{
+			ID:          uid.New(uid.ProjectPrefix),
+			WorkspaceID: workspace.ID,
+			Name:        "Other RBAC Project",
+			Slug:        uid.New("other-rbac-project"),
+		})
+		roleID := uid.New(uid.RolePrefix)
+		err := db.Query.InsertRole(ctx, h.DB.RW(), db.InsertRoleParams{
+			RoleID:      roleID,
+			WorkspaceID: workspace.ID,
+			ProjectID:   otherProject.ID,
+			Name:        "other_project_role",
+			Description: sql.NullString{Valid: true, String: "Other project role"},
+			CreatedAt:   time.Now().UnixMilli(),
+		})
+		require.NoError(t, err)
+
+		res := testutil.CallRoute[handler.Request, openapi.NotFoundErrorResponse](h, route, headers, handler.Request{
+			KeyId: key.KeyID,
+			Roles: []string{"other_project_role"},
+		})
+
+		require.Equal(t, http.StatusNotFound, res.Status)
+		require.Equal(t, "https://unkey.com/docs/errors/unkey/data/role_not_found", res.Body.Error.Type)
+		roles, err := db.Query.ListRolesByKeyID(ctx, h.DB.RO(), key.KeyID)
+		require.NoError(t, err)
+		require.Empty(t, roles)
 	})
 }

--- a/svc/api/routes/v2_keys_add_roles/handler.go
+++ b/svc/api/routes/v2_keys_add_roles/handler.go
@@ -79,8 +79,8 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	err = principal.Authorize(
 		rbac.Or(
 			rbac.U(
-				urn.New().Workspace(principal.WorkspaceID).Keyspace(key.KeyAuthID).Key(key.ID),
-				permissions.UpdateKey{},
+				urn.New().Workspace(principal.WorkspaceID).Project(key.KeyAuth.ProjectID).Keyspace(key.KeyAuthID).Key(key.ID),
+				permissions.WriteKey{},
 			),
 			rbac.And(
 				rbac.Or(
@@ -117,6 +117,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 	foundRoles, err := db.Query.FindManyRolesByNamesWithPerms(ctx, h.DB.RO(), db.FindManyRolesByNamesWithPermsParams{
 		WorkspaceID: principal.WorkspaceID,
+		ProjectID:   key.KeyAuth.ProjectID,
 		Names:       req.Roles,
 	})
 	if err != nil {

--- a/svc/api/routes/v2_keys_remove_permissions/200_test.go
+++ b/svc/api/routes/v2_keys_remove_permissions/200_test.go
@@ -57,7 +57,7 @@ func TestSuccess(t *testing.T) {
 			},
 		})
 
-		updateKeyPermission := fmt.Sprintf("unkey:v1:%s:keyspaces/%s/keys/%s#update_key", workspace.ID, api.KeyAuthID.String, key.KeyID)
+		updateKeyPermission := fmt.Sprintf("unkey:v1:%s:projects/%s/keyspaces/%s/keys/%s#write_key", workspace.ID, api.ProjectID, api.KeyAuthID.String, key.KeyID)
 		urnRootKey := h.CreateRootKey(workspace.ID, updateKeyPermission)
 		urnHeaders := http.Header{
 			"Content-Type":  {"application/json"},

--- a/svc/api/routes/v2_keys_remove_permissions/404_test.go
+++ b/svc/api/routes/v2_keys_remove_permissions/404_test.go
@@ -252,4 +252,40 @@ func TestNotFoundErrors(t *testing.T) {
 		require.NotNil(t, res.Body)
 		require.Contains(t, res.Body.Error.Detail, "key was not found")
 	})
+
+	t.Run("permission from another project", func(t *testing.T) {
+		api := h.CreateApi(seed.CreateApiRequest{WorkspaceID: workspace.ID})
+		key := h.CreateKey(seed.CreateKeyRequest{
+			WorkspaceID: workspace.ID,
+			KeySpaceID:  api.KeyAuthID.String,
+		})
+		otherProject := h.CreateProject(seed.CreateProjectRequest{
+			ID:          uid.New(uid.ProjectPrefix),
+			WorkspaceID: workspace.ID,
+			Name:        "Other Permission Project",
+			Slug:        uid.New("other-permission-project"),
+		})
+		permissionID := uid.New(uid.PermissionPrefix)
+		err := db.Query.InsertPermission(ctx, h.DB.RW(), db.InsertPermissionParams{
+			PermissionID: permissionID,
+			WorkspaceID:  workspace.ID,
+			ProjectID:    otherProject.ID,
+			Name:         "other.project.permission",
+			Slug:         "other.project.permission",
+			Description:  dbtype.NullString{Valid: true, String: "Other project permission"},
+			CreatedAtM:   time.Now().UnixMilli(),
+		})
+		require.NoError(t, err)
+
+		res := testutil.CallRoute[handler.Request, openapi.NotFoundErrorResponse](h, route, headers, handler.Request{
+			KeyId:       key.KeyID,
+			Permissions: []string{"other.project.permission"},
+		})
+
+		require.Equal(t, http.StatusNotFound, res.Status)
+		require.Equal(t, "https://unkey.com/docs/errors/unkey/data/permission_not_found", res.Body.Error.Type)
+		permissions, err := db.Query.ListDirectPermissionsByKeyID(ctx, h.DB.RO(), key.KeyID)
+		require.NoError(t, err)
+		require.Empty(t, permissions)
+	})
 }

--- a/svc/api/routes/v2_keys_remove_permissions/handler.go
+++ b/svc/api/routes/v2_keys_remove_permissions/handler.go
@@ -78,8 +78,8 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	err = principal.Authorize(
 		rbac.Or(
 			rbac.U(
-				urn.New().Workspace(principal.WorkspaceID).Keyspace(key.KeyAuthID).Key(key.ID),
-				permissions.UpdateKey{},
+				urn.New().Workspace(principal.WorkspaceID).Project(key.KeyAuth.ProjectID).Keyspace(key.KeyAuthID).Key(key.ID),
+				permissions.WriteKey{},
 			),
 			rbac.And(
 				rbac.Or(

--- a/svc/api/routes/v2_keys_remove_roles/200_test.go
+++ b/svc/api/routes/v2_keys_remove_roles/200_test.go
@@ -62,6 +62,7 @@ func TestSuccess(t *testing.T) {
 		err := db.Query.InsertRole(ctx, h.DB.RW(), db.InsertRoleParams{
 			RoleID:      roleID,
 			WorkspaceID: workspace.ID,
+			ProjectID:   api.ProjectID,
 			Name:        roleName,
 			Description: sql.NullString{Valid: true, String: "Editor role"},
 		})
@@ -128,6 +129,7 @@ func TestSuccess(t *testing.T) {
 		err := db.Query.InsertRole(ctx, h.DB.RW(), db.InsertRoleParams{
 			RoleID:      roleID,
 			WorkspaceID: workspace.ID,
+			ProjectID:   api.ProjectID,
 			Name:        roleName,
 			Description: sql.NullString{Valid: true, String: "Unassigned role"},
 		})

--- a/svc/api/routes/v2_keys_remove_roles/404_test.go
+++ b/svc/api/routes/v2_keys_remove_roles/404_test.go
@@ -323,6 +323,7 @@ func TestNotFoundErrors(t *testing.T) {
 		err := db.Query.InsertRole(ctx, h.DB.RW(), db.InsertRoleParams{
 			RoleID:      validRoleID,
 			WorkspaceID: workspace.ID,
+			ProjectID:   api.ProjectID,
 			Name:        validName,
 			Description: sql.NullString{Valid: true, String: "Valid role"},
 		})

--- a/svc/api/routes/v2_keys_remove_roles/handler.go
+++ b/svc/api/routes/v2_keys_remove_roles/handler.go
@@ -88,8 +88,8 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			Action:       rbac.UpdateKey,
 		}),
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Keyspace(key.KeyAuthID).Key(key.ID),
-			permissions.UpdateKey{},
+			urn.New().Workspace(principal.WorkspaceID).Project(key.KeyAuth.ProjectID).Keyspace(key.KeyAuthID).Key(key.ID),
+			permissions.WriteKey{},
 		),
 	))
 	if err != nil {
@@ -111,6 +111,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 	foundRoles, err := db.Query.FindManyRolesByNamesWithPerms(ctx, h.DB.RO(), db.FindManyRolesByNamesWithPermsParams{
 		WorkspaceID: principal.WorkspaceID,
+		ProjectID:   key.KeyAuth.ProjectID,
 		Names:       req.Roles,
 	})
 	if err != nil {

--- a/svc/api/routes/v2_keys_set_permissions/200_test.go
+++ b/svc/api/routes/v2_keys_set_permissions/200_test.go
@@ -59,7 +59,7 @@ func TestSuccess(t *testing.T) {
 			Slug:        "documents.write.urn.set",
 		})
 
-		updateKeyPermission := fmt.Sprintf("unkey:v1:%s:keyspaces/%s/keys/%s#update_key", workspace.ID, api.KeyAuthID.String, key.KeyID)
+		updateKeyPermission := fmt.Sprintf("unkey:v1:%s:projects/%s/keyspaces/%s/keys/%s#write_key", workspace.ID, api.ProjectID, api.KeyAuthID.String, key.KeyID)
 		urnRootKey := h.CreateRootKey(workspace.ID, updateKeyPermission)
 		urnHeaders := http.Header{
 			"Content-Type":  {"application/json"},

--- a/svc/api/routes/v2_keys_set_permissions/handler.go
+++ b/svc/api/routes/v2_keys_set_permissions/handler.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/unkeyed/unkey/internal/services/auditlogs"
@@ -86,8 +87,8 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	err = principal.Authorize(
 		rbac.Or(
 			rbac.U(
-				urn.New().Workspace(principal.WorkspaceID).Keyspace(key.KeyAuthID).Key(key.ID),
-				permissions.UpdateKey{},
+				urn.New().Workspace(principal.WorkspaceID).Project(key.KeyAuth.ProjectID).Keyspace(key.KeyAuthID).Key(key.ID),
+				permissions.WriteKey{},
 			),
 			rbac.And(
 				rbac.Or(
@@ -119,11 +120,9 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	projectID := key.KeyAuth.ProjectID
-
 	foundPermissions, err := db.Query.FindPermissionsBySlugs(ctx, h.DB.RO(), db.FindPermissionsBySlugsParams{
 		WorkspaceID: principal.WorkspaceID,
-		ProjectID:   projectID,
+		ProjectID:   key.KeyAuth.ProjectID,
 		Slugs:       req.Permissions,
 	})
 	if err != nil {
@@ -135,7 +134,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 	missingPermissions := make(map[string]struct{})
 	permissionsToSet := make([]db.Permission, 0)
-	permissionsToInsert := make([]db.InsertPermissionParams, 0)
+	permissionsToInsert := make([]db.UpsertPermissionParams, 0)
 
 	for _, permission := range req.Permissions {
 		missingPermissions[permission] = struct{}{}
@@ -146,13 +145,11 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		delete(missingPermissions, permission.Slug)
 	}
 
-	permissionsToSet = append(permissionsToSet, foundPermissions...)
-
 	if len(missingPermissions) > 0 {
 		err = principal.Authorize(rbac.Or(
 			rbac.U(
-				urn.New().Workspace(principal.WorkspaceID).RBAC.Permission("*"),
-				permissions.CreatePermission{},
+				urn.New().Workspace(principal.WorkspaceID).Project(key.KeyAuth.ProjectID).RBAC().Permission("*"),
+				permissions.WritePermission{},
 			),
 			rbac.T(rbac.Tuple{
 				ResourceType: rbac.Rbac,
@@ -168,34 +165,15 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	for perm := range missingPermissions {
 		permissionID := uid.New(uid.PermissionPrefix)
 		now := time.Now().UnixMilli()
-		permissionsToInsert = append(permissionsToInsert, db.InsertPermissionParams{
+		permissionsToInsert = append(permissionsToInsert, db.UpsertPermissionParams{
 			PermissionID: permissionID,
 			Name:         perm,
 			WorkspaceID:  principal.WorkspaceID,
-			ProjectID:    projectID,
+			ProjectID:    key.KeyAuth.ProjectID,
 			Slug:         perm,
 			Description:  dbtype.NullString{String: "", Valid: false},
 			CreatedAtM:   now,
 		})
-
-		permissionsToSet = append(permissionsToSet, db.Permission{
-			Pk:          0, // only here to make the linter happy
-			ID:          permissionID,
-			Name:        perm,
-			WorkspaceID: principal.WorkspaceID,
-			ProjectID:   projectID,
-			Slug:        perm,
-			Description: dbtype.NullString{String: "", Valid: false},
-			CreatedAtM:  now,
-			UpdatedAtM:  sql.NullInt64{Int64: now, Valid: true},
-		})
-	}
-
-	requestedPermissionIDs := make(map[string]bool)
-	requestedPermissionMap := make(map[string]db.Permission)
-	for _, permission := range permissionsToSet {
-		requestedPermissionIDs[permission.ID] = true
-		requestedPermissionMap[permission.ID] = permission
 	}
 
 	err = db.TxRetry(ctx, h.DB.RW(), func(ctx context.Context, tx db.DBTX) error {
@@ -214,6 +192,83 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 				fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
 				fault.Internal("database error"), fault.Public("Failed to retrieve current permissions."),
 			)
+		}
+
+		var auditLogs []auditlog.AuditLog
+		createdPermissionIDs := make(map[string]db.UpsertPermissionParams, len(permissionsToInsert))
+		for _, candidate := range permissionsToInsert {
+			createdPermissionIDs[strings.ToLower(candidate.Slug)] = candidate
+			if err = db.Query.UpsertPermission(ctx, tx, candidate); err != nil {
+				return fault.Wrap(err,
+					fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
+					fault.Internal("database error"),
+					fault.Public("Failed to insert permissions."),
+				)
+			}
+		}
+
+		foundPermissions, err = db.Query.FindPermissionsBySlugs(ctx, tx, db.FindPermissionsBySlugsParams{
+			WorkspaceID: principal.WorkspaceID,
+			ProjectID:   key.KeyAuth.ProjectID,
+			Slugs:       req.Permissions,
+		})
+		if err != nil {
+			return fault.Wrap(err,
+				fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
+				fault.Internal("database error"),
+				fault.Public("Failed to lookup permissions to set."),
+			)
+		}
+
+		foundBySlug := make(map[string]db.Permission, len(foundPermissions))
+		for _, permission := range foundPermissions {
+			normalizedSlug := strings.ToLower(permission.Slug)
+			foundBySlug[normalizedSlug] = permission
+			candidate, exists := createdPermissionIDs[normalizedSlug]
+			if exists && candidate.PermissionID == permission.ID {
+				auditLogs = append(auditLogs, auditlog.AuditLog{
+					WorkspaceID:   principal.WorkspaceID,
+					Event:         auditlog.PermissionCreateEvent,
+					ActorType:     auditlog.AuditLogActor(principal.Subject.Type),
+					ActorID:       principal.Subject.ID,
+					ActorName:     principal.Subject.Name,
+					ActorMeta:     map[string]any{},
+					Display:       fmt.Sprintf("Created %s (%s)", candidate.Slug, candidate.PermissionID),
+					RemoteIP:      s.Location(),
+					UserAgent:     s.UserAgent(),
+					CorrelationID: "",
+					Resources: []auditlog.AuditLogResource{
+						{
+							Type:        auditlog.PermissionResourceType,
+							ID:          candidate.PermissionID,
+							Name:        candidate.Slug,
+							DisplayName: candidate.Name,
+							Meta: map[string]any{
+								"name": candidate.Name,
+								"slug": candidate.Slug,
+							},
+						},
+					},
+				})
+			}
+		}
+
+		permissionsToSet = permissionsToSet[:0]
+		for _, requestedSlug := range req.Permissions {
+			permission, exists := foundBySlug[strings.ToLower(requestedSlug)]
+			if !exists {
+				return fault.New("permission not found",
+					fault.Code(codes.Data.Permission.NotFound.URN()),
+					fault.Internal("permission belongs to a different project"),
+					fault.Public(fmt.Sprintf("Permission '%s' was not found.", requestedSlug)),
+				)
+			}
+			permissionsToSet = append(permissionsToSet, permission)
+		}
+
+		requestedPermissionIDs := make(map[string]bool, len(permissionsToSet))
+		for _, permission := range permissionsToSet {
+			requestedPermissionIDs[permission.ID] = true
 		}
 
 		currentPermissionMap := make(map[string]db.Permission)
@@ -235,8 +290,6 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 				permissionsToAdd = append(permissionsToAdd, permission)
 			}
 		}
-
-		var auditLogs []auditlog.AuditLog
 
 		if len(permissionsToRemove) > 0 {
 			err = db.Query.DeleteManyKeyPermissionByKeyAndPermissionIDs(ctx, tx, db.DeleteManyKeyPermissionByKeyAndPermissionIDsParams{
@@ -281,44 +334,6 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 						},
 					},
 				})
-			}
-		}
-
-		if len(permissionsToInsert) > 0 {
-			for _, toCreate := range permissionsToInsert {
-				auditLogs = append(auditLogs, auditlog.AuditLog{
-					WorkspaceID:   principal.WorkspaceID,
-					Event:         auditlog.PermissionCreateEvent,
-					ActorType:     auditlog.AuditLogActor(principal.Subject.Type),
-					ActorID:       principal.Subject.ID,
-					ActorName:     principal.Subject.Name,
-					ActorMeta:     map[string]any{},
-					Display:       fmt.Sprintf("Created %s (%s)", toCreate.Slug, toCreate.PermissionID),
-					RemoteIP:      s.Location(),
-					UserAgent:     s.UserAgent(),
-					CorrelationID: "",
-					Resources: []auditlog.AuditLogResource{
-						{
-							Type:        auditlog.PermissionResourceType,
-							ID:          toCreate.PermissionID,
-							Name:        toCreate.Slug,
-							DisplayName: toCreate.Name,
-							Meta: map[string]any{
-								"name": toCreate.Name,
-								"slug": toCreate.Slug,
-							},
-						},
-					},
-				})
-			}
-
-			err = db.BulkQuery.InsertPermissions(ctx, tx, permissionsToInsert)
-			if err != nil {
-				return fault.Wrap(err,
-					fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
-					fault.Internal("database error"),
-					fault.Public("Failed to insert permissions."),
-				)
 			}
 		}
 

--- a/svc/api/routes/v2_keys_set_permissions/project_scope_test.go
+++ b/svc/api/routes/v2_keys_set_permissions/project_scope_test.go
@@ -1,0 +1,75 @@
+package handler_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/db"
+	dbtype "github.com/unkeyed/unkey/pkg/db/types"
+	"github.com/unkeyed/unkey/pkg/ptr"
+	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil"
+	"github.com/unkeyed/unkey/svc/api/internal/testutil/seed"
+	"github.com/unkeyed/unkey/svc/api/openapi"
+	handler "github.com/unkeyed/unkey/svc/api/routes/v2_keys_set_permissions"
+)
+
+// TestSetPermissionsRejectsPermissionFromAnotherProject guarantees that a key
+// cannot receive a permission from a different project.
+func TestSetPermissionsRejectsPermissionFromAnotherProject(t *testing.T) {
+	h := testutil.NewHarness(t)
+	route := &handler.Handler{
+		DB:        h.DB,
+		Auditlogs: h.Auditlogs,
+		KeyCache:  h.Caches.VerificationKeyByHash,
+	}
+	h.Register(route)
+
+	workspace := h.Resources().UserWorkspace
+	otherProjectAPI := h.CreateApi(seed.CreateApiRequest{WorkspaceID: workspace.ID})
+	keyProject := h.CreateProject(seed.CreateProjectRequest{
+		ID:          uid.New(uid.ProjectPrefix),
+		WorkspaceID: workspace.ID,
+		Name:        "Key project",
+		Slug:        uid.New("project"),
+	})
+	keyProjectAPI := h.CreateApi(seed.CreateApiRequest{WorkspaceID: workspace.ID, ProjectID: keyProject.ID})
+	key := h.CreateKey(seed.CreateKeyRequest{
+		WorkspaceID: workspace.ID,
+		KeySpaceID:  keyProjectAPI.KeyAuthID.String,
+		Name:        ptr.P("project-scoped-key"),
+	})
+
+	permissionSlug := "documents.read.set.wrong-project"
+	err := db.Query.InsertPermission(t.Context(), h.DB.RW(), db.InsertPermissionParams{
+		PermissionID: uid.New(uid.PermissionPrefix),
+		WorkspaceID:  workspace.ID,
+		ProjectID:    otherProjectAPI.ProjectID,
+		Name:         permissionSlug,
+		Slug:         permissionSlug,
+		Description:  dbtype.NullString{Valid: false},
+		CreatedAtM:   time.Now().UnixMilli(),
+	})
+	require.NoError(t, err)
+
+	writeKey := fmt.Sprintf("unkey:v1:%s:projects/%s/keyspaces/%s/keys/%s#write_key", workspace.ID, keyProject.ID, keyProjectAPI.KeyAuthID.String, key.KeyID)
+	writePermission := fmt.Sprintf("unkey:v1:%s:projects/%s/rbac/permissions/*#write_permission", workspace.ID, keyProject.ID)
+	rootKey := h.CreateRootKey(workspace.ID, writeKey, writePermission)
+	res := testutil.CallRoute[handler.Request, openapi.NotFoundErrorResponse](h, route, http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", rootKey)},
+	}, handler.Request{
+		KeyId:       key.KeyID,
+		Permissions: []string{permissionSlug},
+	})
+
+	require.Equal(t, http.StatusNotFound, res.Status, "got: %s", res.RawBody)
+	require.Contains(t, res.Body.Error.Detail, permissionSlug)
+
+	permissions, err := db.Query.ListDirectPermissionsByKeyID(t.Context(), h.DB.RO(), key.KeyID)
+	require.NoError(t, err)
+	require.Empty(t, permissions)
+}

--- a/svc/api/routes/v2_keys_set_roles/200_test.go
+++ b/svc/api/routes/v2_keys_set_roles/200_test.go
@@ -72,6 +72,7 @@ func TestSuccess(t *testing.T) {
 		err := db.Query.InsertRole(ctx, h.DB.RW(), db.InsertRoleParams{
 			RoleID:      roleID,
 			WorkspaceID: workspace.ID,
+			ProjectID:   api.ProjectID,
 			Name:        roleName,
 			Description: sql.NullString{Valid: true, String: "Editor role"},
 		})
@@ -126,6 +127,7 @@ func TestSuccess(t *testing.T) {
 		err := db.Query.InsertRole(ctx, h.DB.RW(), db.InsertRoleParams{
 			RoleID:      oldRoleID,
 			WorkspaceID: workspace.ID,
+			ProjectID:   api.ProjectID,
 			Name:        "admin_replace_old",
 			Description: sql.NullString{Valid: true, String: "Old admin role"},
 		})
@@ -136,6 +138,7 @@ func TestSuccess(t *testing.T) {
 		err = db.Query.InsertRole(ctx, h.DB.RW(), db.InsertRoleParams{
 			RoleID:      newRoleID,
 			WorkspaceID: workspace.ID,
+			ProjectID:   api.ProjectID,
 			Name:        roleName,
 			Description: sql.NullString{Valid: true, String: "New editor role"},
 		})
@@ -224,6 +227,7 @@ func TestSuccess(t *testing.T) {
 		err := db.Query.InsertRole(ctx, h.DB.RW(), db.InsertRoleParams{
 			RoleID:      roleID,
 			WorkspaceID: workspace.ID,
+			ProjectID:   api.ProjectID,
 			Name:        "admin_remove_all",
 			Description: sql.NullString{Valid: true, String: "Admin role to be removed"},
 		})
@@ -303,6 +307,7 @@ func TestSuccess(t *testing.T) {
 		err := db.Query.InsertRole(ctx, h.DB.RW(), db.InsertRoleParams{
 			RoleID:      roleID,
 			WorkspaceID: workspace.ID,
+			ProjectID:   api.ProjectID,
 			Name:        roleName,
 			Description: sql.NullString{Valid: true, String: "Admin role - no change"},
 		})

--- a/svc/api/routes/v2_keys_set_roles/404_test.go
+++ b/svc/api/routes/v2_keys_set_roles/404_test.go
@@ -65,6 +65,7 @@ func TestNotFoundErrors(t *testing.T) {
 	err := db.Query.InsertRole(ctx, h.DB.RW(), db.InsertRoleParams{
 		RoleID:      validRoleID,
 		WorkspaceID: workspace.ID,
+		ProjectID:   api.ProjectID,
 		Name:        validRoleName,
 		Description: sql.NullString{Valid: true, String: "Valid test role"},
 	})

--- a/svc/api/routes/v2_keys_set_roles/handler.go
+++ b/svc/api/routes/v2_keys_set_roles/handler.go
@@ -94,8 +94,8 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			Action:       rbac.UpdateKey,
 		}),
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Keyspace(key.KeyAuthID).Key(key.ID),
-			permissions.UpdateKey{},
+			urn.New().Workspace(principal.WorkspaceID).Project(key.KeyAuth.ProjectID).Keyspace(key.KeyAuthID).Key(key.ID),
+			permissions.WriteKey{},
 		),
 	))
 	if err != nil {
@@ -124,6 +124,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		// to prevent TOCTOU races with concurrent requests.
 		foundRoles, err := db.Query.FindManyRolesByNamesWithPerms(ctx, tx, db.FindManyRolesByNamesWithPermsParams{
 			WorkspaceID: principal.WorkspaceID,
+			ProjectID:   key.KeyAuth.ProjectID,
 			Names:       req.Roles,
 		})
 		if err != nil {

--- a/svc/api/routes/v2_portal_create_session/permissions.go
+++ b/svc/api/routes/v2_portal_create_session/permissions.go
@@ -12,9 +12,9 @@ import "github.com/unkeyed/unkey/pkg/rbac"
 // row filters, so there is nothing to import. This mirrors what that route
 // matches today, the api wildcard or the specific api.
 //
-// No permissions.ReadAnalytics URN action exists on purpose: the analytics
-// endpoint never evaluates URNs, so a keyspace-scoped URN grant would have let a
-// caller mint a capability it could not exercise itself.
+// Do not add a keyspace log URN arm here yet. The analytics endpoint evaluates
+// legacy tuples only. A keyspace log grant would otherwise let a caller mint a
+// capability it could not exercise.
 func readAnalyticsPermissions(apiID string) rbac.PermissionQuery {
 	return rbac.Or(
 		rbac.T(rbac.Tuple{

--- a/svc/api/routes/v2_portal_create_session/permissions_internal_test.go
+++ b/svc/api/routes/v2_portal_create_session/permissions_internal_test.go
@@ -10,6 +10,7 @@ import (
 
 const (
 	permTestWorkspaceID = "ws_test"
+	permTestProjectID   = "proj_test"
 	permTestKeyspaceID  = "ks_test"
 	permTestAPIID       = "api_test"
 )
@@ -27,8 +28,8 @@ func permAllows(t *testing.T, query rbac.PermissionQuery, grants ...string) bool
 // TestReadAnalyticsPermissionsGrants pins the analytics requirement, which is
 // defined locally because v2_analytics_get_verifications has no query object to
 // borrow. The URN case is the important one: that endpoint never evaluates URNs,
-// so a keyspace-scoped URN grant must not let a caller mint a capability it could
-// not exercise itself.
+// so a keyspace log URN grant must not let a caller mint a capability it cannot
+// exercise itself.
 func TestReadAnalyticsPermissionsGrants(t *testing.T) {
 	query := readAnalyticsPermissions(permTestAPIID)
 
@@ -37,6 +38,11 @@ func TestReadAnalyticsPermissionsGrants(t *testing.T) {
 	require.False(t, permAllows(t, query, "api.api_other.read_analytics"))
 	require.False(t, permAllows(t, query))
 
-	keyspaceURNGrant := urn.New().Workspace(permTestWorkspaceID).Keyspace(permTestKeyspaceID).String() + "#read_analytics"
+	keyspaceURNGrant := urn.New().
+		Workspace(permTestWorkspaceID).
+		Project(permTestProjectID).
+		Keyspace(permTestKeyspaceID).
+		Logs().
+		String() + "#read_keyspace_logs"
 	require.False(t, permAllows(t, query, keyspaceURNGrant))
 }

--- a/svc/api/routes/v2_portal_create_session/urn_permissions_test.go
+++ b/svc/api/routes/v2_portal_create_session/urn_permissions_test.go
@@ -28,9 +28,10 @@ import (
 // they will fail, and each expectation flips from denied to allowed.
 
 // urnDenialFixture seeds a keyspace-mapped portal, under the given slug, whose
-// keyspace has an owning api. Stage 2 needs that api to express its api-scoped
-// checks, so a portal without one would fail for the wrong reason.
-func urnDenialFixture(t *testing.T, h *testutil.Harness, slug string) {
+// keyspace has an owning API. Stage 2 needs that API to express its API-scoped
+// checks, so a portal without one would fail for the wrong reason. It returns
+// the project and keyspace IDs for canonical URN grants.
+func urnDenialFixture(t *testing.T, h *testutil.Harness, slug string) (string, string) {
 	t.Helper()
 
 	workspaceID := h.Resources().UserWorkspace.ID
@@ -44,6 +45,8 @@ func urnDenialFixture(t *testing.T, h *testutil.Harness, slug string) {
 		DefaultBytes:  nil,
 	})
 	insertKeyspacePortal(t, h, workspaceID, slug, api.KeyAuthID.String)
+
+	return api.ProjectID, api.KeyAuthID.String
 }
 
 func TestCreateSessionDeniesURNGrants(t *testing.T) {
@@ -60,7 +63,7 @@ func TestCreateSessionDeniesURNGrants(t *testing.T) {
 
 	t.Run("admin grant cannot mint", func(t *testing.T) {
 		slug := "urn-admin-portal"
-		urnDenialFixture(t, h, slug)
+		_, _ = urnDenialFixture(t, h, slug)
 
 		// This is exactly what WorkOS admin:* translates to, so this case is
 		// also the assertion that dashboard JWT principals cannot mint.
@@ -78,15 +81,15 @@ func TestCreateSessionDeniesURNGrants(t *testing.T) {
 		require.Equal(t, http.StatusNotFound, res.Status, "a stage-1 denial is masked as 404, got: %s", res.RawBody)
 	})
 
-	t.Run("portal URN grant cannot mint", func(t *testing.T) {
+	t.Run("canonical URN grants cannot mint", func(t *testing.T) {
 		slug := "urn-portal-portal"
-		urnDenialFixture(t, h, slug)
+		projectID, keyspaceID := urnDenialFixture(t, h, slug)
 
-		// Both stages named in canonical URN form. Stage 1 refuses first.
+		// Valid project-scoped URN grants do not satisfy the legacy portal tuple.
+		// Stage 1 refuses them first.
 		rootKey := h.CreateRootKey(workspaceID,
-			fmt.Sprintf("unkey:v1:%s:portals/*#create_portal_session", workspaceID),
-			fmt.Sprintf("unkey:v1:%s:keyspaces/*/keys/*#read_key", workspaceID),
-			fmt.Sprintf("unkey:v1:%s:keyspaces/*#read_keyspace", workspaceID),
+			fmt.Sprintf("unkey:v1:%s:projects/%s/keyspaces/%s/keys/*#read_key", workspaceID, projectID, keyspaceID),
+			fmt.Sprintf("unkey:v1:%s:projects/%s/keyspaces/%s#read_keyspace", workspaceID, projectID, keyspaceID),
 		)
 		headers := http.Header{
 			"Content-Type":  {"application/json"},
@@ -103,14 +106,14 @@ func TestCreateSessionDeniesURNGrants(t *testing.T) {
 
 	t.Run("legacy portal tuple with URN-only scope grant is refused at stage 2", func(t *testing.T) {
 		slug := "urn-mixed-portal"
-		urnDenialFixture(t, h, slug)
+		projectID, keyspaceID := urnDenialFixture(t, h, slug)
 
 		// Stage 1 passes on the legacy tuple, so this isolates stage 2 and shows
 		// the two grant forms are not interchangeable there either.
 		rootKey := h.CreateRootKey(workspaceID,
 			"portal.*.create_portal_session",
-			fmt.Sprintf("unkey:v1:%s:keyspaces/*/keys/*#read_key", workspaceID),
-			fmt.Sprintf("unkey:v1:%s:keyspaces/*#read_keyspace", workspaceID),
+			fmt.Sprintf("unkey:v1:%s:projects/%s/keyspaces/%s/keys/*#read_key", workspaceID, projectID, keyspaceID),
+			fmt.Sprintf("unkey:v1:%s:projects/%s/keyspaces/%s#read_keyspace", workspaceID, projectID, keyspaceID),
 		)
 		headers := http.Header{
 			"Content-Type":  {"application/json"},


### PR DESCRIPTION
## Notes for description (rewrite before review)

### Stack
- Position: 7 of 9. Review wave 2: handler migration.
- Full stack: #7189 → #7190 → #7191 → #7192 → #7193 → #7195 → **#7196** → #7197 → #7198.
- Depends on: #7195. Next: #7197.

### Goal
- Keep key role and permission assignments inside the keyspace project.

### Approach
- Authorize all six assignment routes with project-scoped `write_key` URNs.
- Filter permission and role lookups by the keyspace project.
- Upsert auto-created permissions, then re-query the target project before assignment.

### Decisions
- Treat `write_key` as sufficient for role and permission attachments.
- Preserve legacy tuple authorization until the WorkOS cutover.
- Keep portal session minting on legacy tuples through the cutover.
- Do not change OpenAPI files or API descriptions.

### Review order
1. Review project-scoped role and permission queries.
2. Review permission transaction and retry behavior.
3. Review add, remove, and set assignment routes.
4. Review portal session compatibility.
5. Review project boundary tests and generated SQL.

### Review focus
- Confirm that workspace-unique slug conflicts cannot attach a permission from another project.
- Confirm that transaction retries produce the same assignments and audit logs.
- Confirm that role project filters preserve same-project behavior.

### Verification
- `mise exec -- go generate ./pkg/db` regenerated the changed SQL query.
- `mise run build` passed, including lint.
- `mise exec -- go test ./svc/api/routes/v2_portal_create_session -run '^TestReadAnalyticsPermissionsGrants$' -count=1` passed.
- `mise exec -- rask ./svc/api/routes/v2_keys_add_permissions` stopped during MySQL setup because Docker Compose was killed.
- The route integration failure occurred before route execution.
- `git diff --check` passed.
