### PR TITLE
Document the canonical permission model

### DIFF
--- a/docs/engineering/architecture/authorization/resource-permission-catalog.mdx
+++ b/docs/engineering/architecture/authorization/resource-permission-catalog.mdx
@@ -1,0 +1,151 @@
+---
+title: "Resource permission catalog"
+description: "Canonical resource hierarchy, paths, and actions"
+---
+
+The resource permission catalog lists every public resource path and its
+supported actions. Every resource is project-scoped except the GitHub app. The
+project is the scope root inside a workspace.
+
+Read [Unkey Resource Names](/architecture/resources/unkey-resource-names) for
+URN format and pattern rules. Read
+[Resource permissions](/architecture/authorization/resource-permissions) for
+permission matching and action rules.
+
+## Canonical catalog
+
+Each resource shows its actions in brackets. The next line shows its canonical
+resource path. Add `unkey:v1:{workspace_id}:` before the path and `#{action}`
+after it to form a permission.
+
+```plaintext
+Workspace
+│
+├── GitHub app [read_github_app, write_github_app, delete_github_app]
+│   github/apps/{github_app_id}
+│
+└── Project [read_project, write_project, delete_project]
+    projects/{project_id}
+    │
+    ├── App [read_app, write_app, delete_app]
+    │   projects/{project_id}/apps/{app_id}
+    │   │
+    │   └── Environment [read_environment, write_environment, delete_environment]
+    │       projects/{project_id}/apps/{app_id}/environments/{environment_id}
+    │       │
+    │       ├── Deployment [read_deployment, write_deployment, delete_deployment]
+    │       │   projects/{project_id}/apps/{app_id}/environments/{environment_id}/deployments/{deployment_id}
+    │       │   │
+    │       │   └── Logs [read_deployment_logs]
+    │       │       projects/{project_id}/apps/{app_id}/environments/{environment_id}/deployments/{deployment_id}/logs
+    │       │
+    │       ├── Domain [read_domain, write_domain, delete_domain]
+    │       │   projects/{project_id}/apps/{app_id}/environments/{environment_id}/domains/{domain_id}
+    │       │
+    │       ├── Environment variable [read_environment_variable, write_environment_variable, delete_environment_variable]
+    │       │   projects/{project_id}/apps/{app_id}/environments/{environment_id}/variables/{variable_id}
+    │       │
+    │       └── Gateway
+    │           projects/{project_id}/apps/{app_id}/environments/{environment_id}/gateway
+    │           │
+    │           ├── Logs [read_gateway_logs]
+    │           │   projects/{project_id}/apps/{app_id}/environments/{environment_id}/gateway/logs
+    │           │
+    │           └── Policy [read_gateway_policy, write_gateway_policy, delete_gateway_policy]
+    │               projects/{project_id}/apps/{app_id}/environments/{environment_id}/gateway/policies/{policy_id}
+    │
+    ├── Identity [read_identity, write_identity, delete_identity]
+    │   projects/{project_id}/identities/{identity_id}
+    │
+    ├── Keyspace [read_keyspace, write_keyspace, delete_keyspace]
+    │   projects/{project_id}/keyspaces/{keyspace_id}
+    │   │
+    │   ├── Logs [read_keyspace_logs]
+    │   │   projects/{project_id}/keyspaces/{keyspace_id}/logs
+    │   │
+    │   └── Key [read_key, write_key, delete_key, decrypt_key, verify_key]
+    │       projects/{project_id}/keyspaces/{keyspace_id}/keys/{key_id}
+    │
+    ├── Rate limit namespace [read_ratelimit_namespace, write_ratelimit_namespace, delete_ratelimit_namespace, limit_ratelimit_namespace]
+    │   projects/{project_id}/ratelimits/namespaces/{namespace_id}
+    │   │
+    │   ├── Logs [read_ratelimit_logs]
+    │   │   projects/{project_id}/ratelimits/namespaces/{namespace_id}/logs
+    │   │
+    │   └── Override [read_ratelimit_override, write_ratelimit_override, delete_ratelimit_override]
+    │       projects/{project_id}/ratelimits/namespaces/{namespace_id}/overrides/{override_id}
+    │
+    └── RBAC
+        projects/{project_id}/rbac
+        │
+        ├── Role [read_role, write_role, delete_role]
+        │   projects/{project_id}/rbac/roles/{role_id}
+        │
+        └── Permission [read_permission, write_permission, delete_permission]
+            projects/{project_id}/rbac/permissions/{permission_id}
+```
+
+`gateway` and `rbac` are path containers. They organize child paths. They are
+not concrete resources and cannot be permission targets.
+
+## Examples
+
+These examples show how concrete IDs and wildcards use the same catalog.
+
+### Create a key
+
+Use `write_key` with a wildcard key ID because the key does not exist yet.
+
+```plaintext
+unkey:v1:ws_123:projects/proj_123/keyspaces/ks_123/keys/*#write_key
+```
+
+### Change an environment
+
+`write_environment` covers settings changes, deployment promotion, and
+deployment rollback.
+
+```plaintext
+unkey:v1:ws_123:projects/proj_123/apps/app_123/environments/env_123#write_environment
+```
+
+### Start or stop a deployment
+
+`write_deployment` covers deployment creation, updates, starts, and stops.
+
+```plaintext
+unkey:v1:ws_123:projects/proj_123/apps/app_123/environments/env_123/deployments/dep_123#write_deployment
+```
+
+### Read deployment logs
+
+Logs are first-class resources. `read_deployment` does not grant access to
+deployment logs. Use `read_deployment_logs`.
+
+```plaintext
+unkey:v1:ws_123:projects/proj_123/apps/app_123/environments/env_123/deployments/dep_123/logs#read_deployment_logs
+```
+
+### Read gateway logs
+
+Gateway logs belong to an environment's gateway.
+
+```plaintext
+unkey:v1:ws_123:projects/proj_123/apps/app_123/environments/env_123/gateway/logs#read_gateway_logs
+```
+
+### Verify a key
+
+Key verification uses `verify_key`, not `read_key`.
+
+```plaintext
+unkey:v1:ws_123:projects/proj_123/keyspaces/ks_123/keys/key_123#verify_key
+```
+
+## Related pages
+
+Use these pages for URN rules, permission rules, and WorkOS translation.
+
+- [Unkey Resource Names](/architecture/resources/unkey-resource-names)
+- [Resource permissions](/architecture/authorization/resource-permissions)
+- [WorkOS permissions](/architecture/authorization/workos-permissions)

--- a/docs/engineering/architecture/authorization/resource-permissions.mdx
+++ b/docs/engineering/architecture/authorization/resource-permissions.mdx
@@ -1,378 +1,151 @@
 ---
 title: "Resource permissions"
-description: "Authorization permissions built from Unkey Resource Names"
+description: "Permission format, matching, and action rules"
 ---
 
-Resource permissions attach an action to a Unkey Resource Name. They are the
-canonical authorization primitive for root keys, users, service tokens, and any
-other principal that needs scoped access to Unkey resources.
+Resource permissions combine a URN pattern with an action. The resource
+pattern selects the scope. The action identifies the operation and target
+resource type.
 
-The resource portion follows the [Unkey Resource Names](/architecture/resources/unkey-resource-names)
-contract, including resource-name patterns and their matching semantics. The
-permission layer adds only the action suffix.
+Read [Unkey Resource Names](/architecture/resources/unkey-resource-names) for
+URN format and pattern rules. Use the
+[resource permission catalog](/architecture/authorization/resource-permission-catalog)
+to find each canonical resource path and its supported actions.
 
-Resource parsing and pattern matching, the rules deciding whether a stored
-resource pattern covers a requested concrete URN, live in
-[`pkg/urn`](https://github.com/unkeyed/unkey/tree/main/pkg/urn). Action
-validation and permission evaluation live in
-[`pkg/rbac`](https://github.com/unkeyed/unkey/tree/main/pkg/rbac), which
-delegates resource comparison to `pkg/urn` instead of defining its own.
+## Permission format
 
-Creation actions live on the nearest parent resource that already exists when
-the operation runs. For example, `create_key` applies to the keyspace, while
-`read_key`, `update_key`, and `delete_key` apply to concrete key resources or
-key-resource patterns. This avoids inventing collection URNs only for create
-operations.
-
-Top-level resources are the exception. Their parent is the workspace itself,
-which isn't an expressible resource path in `v1`. For those actions, use the
-top-level collection wildcard as the closest expressible scope. For example,
-`create_keyspace` uses `keyspaces/*`, and `create_role` uses `rbac/roles/*`.
-
-## Format
-
-A permission has a URN, a `#` separator, and an action.
+A permission has two parts separated by `#`.
 
 ```plaintext
-unkey:v1:{workspace_id}:{resource_path}#{action}
+{resource_urn_pattern}#{action}
 ```
 
-For example:
+This permission grants read access to one key:
 
 ```plaintext
-unkey:v1:ws_123:keyspaces/ks_123#read_keyspace
-unkey:v1:ws_123:keyspaces/ks_123#create_key
-unkey:v1:ws_123:keyspaces/ks_123/keys/key_456#delete_key
-unkey:v1:ws_123:projects/proj_123/apps/app_456#update_app
+unkey:v1:ws_123:projects/proj_123/keyspaces/ks_123/keys/key_456#read_key
 ```
 
-The action is not part of the URN. Code that evaluates permissions must parse
-the resource and action separately.
-
-## Actions
-
-Actions are explicit operation names. They use lowercase words separated by
-underscores.
+This permission grants read access to every key below one project:
 
 ```plaintext
-read_keyspace
-create_key
-delete_deployment
-add_role
-remove_permission
+unkey:v1:ws_123:projects/proj_123/**#read_key
 ```
 
-Most permissions name one explicit action. The only action wildcard is `*`,
-which is reserved for the `admin:*` migration escape hatch and is valid only on
-the global resource pattern `**`. There is no shorter global form: `*` matches
-exactly one path segment everywhere it appears, so only `**` covers every
-resource in a workspace.
+The same resource pattern with `read_environment` grants read access to
+environments instead. It does not grant read access to keys.
+
+## Permission matching
+
+A permission grants access when both of these conditions are true:
+
+1. The permission resource pattern matches the request resource URN.
+2. The permission action matches the request action.
+
+Match resource patterns with the URN rules. Match actions with exact text. The
+only action wildcard is the global admin permission
+`unkey:v1:{workspace_id}:**#*`.
 
 ```plaintext
-unkey:v1:ws_123:**#*
+Permission: unkey:v1:ws_123:projects/proj_123/**#read_key
+Request:    unkey:v1:ws_123:projects/proj_123/keyspaces/ks_123/keys/key_456#read_key
+Result:     granted
 ```
 
-Do not add action wildcards to normal product permissions.
-
-## Create actions
-
-Create actions authorize the parent resource that receives the child resource.
-Handlers must query the parent resource because the child ID may not exist until
-after the operation succeeds.
-
-For example, creating a key in a keyspace uses the keyspace resource:
+The same resource pattern does not grant access to a different resource type:
 
 ```plaintext
-unkey:v1:ws_123:keyspaces/ks_123#create_key
+Permission: unkey:v1:ws_123:projects/proj_123/**#write_app
+Request:    unkey:v1:ws_123:projects/proj_123/apps/app_123/environments/env_123#write_environment
+Result:     denied
 ```
 
-Creating nested deploy resources follows the same parent-resource rule:
+This distinction keeps recursive patterns precise. A permission such as
+`projects/proj_123/apps/app_123/**#write_app` can write that app. It cannot
+write environments or deployments below the app.
+
+## Action rules
+
+Most resources use three operations. Each canonical action includes the target
+resource type.
+
+| Operation | Canonical action | Grants access to |
+| --- | --- | --- |
+| Read | `read_{resource}` | Get or list the resource |
+| Write | `write_{resource}` | Create or update the resource |
+| Delete | `delete_{resource}` | Delete the resource |
+
+Use a special action only when the operation has a separate security effect.
+
+| Resource | Canonical action | Grants access to |
+| --- | --- | --- |
+| Key | `decrypt_key` | Decrypt key data |
+| Key | `verify_key` | Verify a key |
+| Rate limit namespace | `limit_ratelimit_namespace` | Check or use the limit |
+
+## Create and update rules
+
+Use the resource's `write_{resource}` action for create and update operations.
+Do not define separate create or update actions.
+
+Use the concrete resource ID when the resource exists:
 
 ```plaintext
-unkey:v1:ws_123:projects/proj_123#create_app
-unkey:v1:ws_123:projects/proj_123/apps/app_456#create_environment
-unkey:v1:ws_123:projects/proj_123/apps/app_456/environments/env_789#create_domain
-unkey:v1:ws_123:projects/proj_123/apps/app_456/environments/env_789#create_variable
+unkey:v1:ws_123:projects/proj_123/keyspaces/ks_123/keys/key_456#write_key
 ```
 
-Deployment actions are an exception. They always target the deployment resource,
-so `create_deployment` uses a wildcard deployment id:
+Use `*` in the target resource ID position when the resource does not exist:
 
 ```plaintext
-unkey:v1:ws_123:projects/proj_123/apps/app_456/environments/env_789/deployments/*#create_deployment
-unkey:v1:ws_123:projects/proj_123/apps/app_456/environments/env_789/deployments/dep_123#stop_deployment
-unkey:v1:ws_123:projects/proj_123/apps/app_456/environments/env_789/deployments/dep_123#start_deployment
+unkey:v1:ws_123:projects/proj_123/keyspaces/ks_123/keys/*#write_key
 ```
 
-The same parent can still hold non-create actions that target the parent itself,
-such as `read_keyspace` on `keyspaces/ks_123`. The action name determines which
-operation is authorized.
+The wildcard applies only to that path segment. It does not grant access to
+other keyspaces or projects.
 
-Top-level create actions target the collection wildcard because there is no
-workspace resource path to attach the action to:
+## Resource-owned operations
+
+Check an operation against the resource that owns the resulting state change.
+Do not add an action for each API endpoint.
+
+| Operation | Resource | Action |
+| --- | --- | --- |
+| Connect or disconnect a GitHub repository | App | `write_app` |
+| Promote or roll back a deployment | Environment | `write_environment` |
+| Start or stop a deployment | Deployment | `write_deployment` |
+| Restart domain verification | Domain | `write_domain` |
+| Reroll a key or update its credits | Key | `write_key` |
+| Attach or detach a role or permission on a key | Key | `write_key` |
+| Attach or detach a permission on a role | Role | `write_role` |
+| Create or edit a permission definition | Permission | `write_permission` |
+
+## Log rules
+
+Logs are first-class resources. Each log resource supports one read action. The
+action identifies the log source, such as `read_deployment_logs` or
+`read_gateway_logs`.
+
+Read access to a parent resource does not grant read access to its logs. Grant
+the log resource directly. You can also use a recursive pattern with the log
+action, such as `projects/proj_123/**#read_deployment_logs`.
+
+Find all log resource paths in the
+[resource permission catalog](/architecture/authorization/resource-permission-catalog).
+
+## Global admin
+
+This permission grants every action on every resource in a workspace:
 
 ```plaintext
-unkey:v1:ws_123:keyspaces/*#create_keyspace
-unkey:v1:ws_123:rbac/roles/*#create_role
+unkey:v1:{workspace_id}:**#*
 ```
 
-Go handlers can pass typed URN builders directly to `rbac.U` when the builder
-represents the parent resource. Use typed actions from `pkg/rbac/permissions`,
-where action structs are split by resource type:
+Use this permission only for workspace administrators.
 
-```go
-import "github.com/unkeyed/unkey/pkg/rbac/permissions"
+## Related pages
 
-rbac.U(
-	urn.New().Workspace(workspaceID).Keyspace(keyspaceID),
-	permissions.CreateKey{},
-)
+Use these pages for URN rules, the canonical catalog, and WorkOS translation.
 
-rbac.U(
-	urn.New().Workspace(workspaceID).Project(projectID),
-	permissions.CreateApp{},
-)
-
-rbac.U(
-	urn.New().Workspace(workspaceID).Project(projectID).App(appID),
-	permissions.CreateEnvironment{},
-)
-```
-
-## Patterns
-
-Stored permissions can contain resource patterns. Requested resources in audit
-logs and authorization checks must always use concrete URNs.
-
-`v1` supports two resource-pattern operators.
-
-| Operator | Meaning |
-| --- | --- |
-| `*` | Matches exactly one complete path segment. |
-| `/**` | Matches descendants below the preceding path. |
-
-The `/**` operator is valid only at the end of a resource path. It matches the
-path before `/**` and all descendants below that path.
-
-## Matching rules
-
-Permission evaluation compares a requested `{resource, action}` tuple with the
-permissions assigned to the principal.
-
-A permission matches when all rules are true:
-
-1. The version matches.
-2. The workspace ID matches.
-3. The resource path matches exactly or by a valid resource pattern.
-4. The action matches exactly.
-
-The matcher is segment-aware. It must split resource paths on `/` before
-matching wildcards. Rules 2 and 3, workspace and resource matching, are
-implemented by `pkg/urn`; `pkg/rbac` parses the action suffix and adds rule 4.
-
-For example, this permission:
-
-```plaintext
-unkey:v1:ws_123:keyspaces/*/keys/*#read_key
-```
-
-matches this request:
-
-```plaintext
-unkey:v1:ws_123:keyspaces/ks_123/keys/key_456#read_key
-```
-
-It does not match these requests:
-
-```plaintext
-unkey:v1:ws_123:keyspaces/ks_123#read_key
-unkey:v1:ws_123:keyspaces/ks_123/keys/key_456#delete_key
-unkey:v1:ws_123:keyspaces/ks_123/keys/key_456#update_key
-```
-
-## Descendant grants
-
-Use trailing `/**` when a permission must apply to any public descendant of a
-resource.
-
-This permission grants `delete_deployment` for deployments below one project:
-
-```plaintext
-unkey:v1:ws_123:projects/proj_123/**#delete_deployment
-```
-
-It matches:
-
-```plaintext
-unkey:v1:ws_123:projects/proj_123/apps/app_456/environments/env_789/deployments/d_abc#delete_deployment
-```
-
-It also matches the project itself:
-
-```plaintext
-unkey:v1:ws_123:projects/proj_123#delete_deployment
-```
-
-It also does not grant unrelated actions on descendants:
-
-```plaintext
-unkey:v1:ws_123:projects/proj_123/apps/app_456#delete_app
-```
-
-The action still has to match exactly.
-
-## Common permissions
-
-These examples show how broad and narrow permissions use the same grammar.
-
-<AccordionGroup>
-  <Accordion title="Delete one deployment">
-
-    ```plaintext
-    unkey:v1:ws_123:projects/proj_123/apps/app_456/environments/env_789/deployments/d_abc#delete_deployment
-    ```
-
-  </Accordion>
-  <Accordion title="Delete deployments in one environment">
-
-    ```plaintext
-    unkey:v1:ws_123:projects/proj_123/apps/app_456/environments/env_789/deployments/*#delete_deployment
-    ```
-
-  </Accordion>
-  <Accordion title="Delete deployments in one project">
-
-    ```plaintext
-    unkey:v1:ws_123:projects/proj_123/**#delete_deployment
-    ```
-
-  </Accordion>
-  <Accordion title="Read all keys in one keyspace">
-
-    ```plaintext
-    unkey:v1:ws_123:keyspaces/ks_123/keys/*#read_key
-    ```
-
-  </Accordion>
-  <Accordion title="Manage one role">
-
-    ```plaintext
-    unkey:v1:ws_123:rbac/roles/role_123#update_role
-    ```
-
-  </Accordion>
-  <Accordion title="Portal session grammar (not yet honored)">
-
-    ```plaintext
-    unkey:v1:ws_123:projects/proj_123/portals/pc_123#create_portal_session
-    unkey:v1:ws_123:projects/proj_123/portals/*#create_portal_session
-    ```
-
-    These show the intended grammar only, and neither the path nor the
-    evaluation is live yet: `portal.createSession` matches legacy tuples today,
-    and `pkg/urn` still builds portal paths directly under the workspace. Grant
-    `portal.pc_123.create_portal_session` until the URN migration lands.
-
-  </Accordion>
-</AccordionGroup>
-
-### Portal resource
-
-Portals are moving under projects, so a portal path is expected to read
-`projects/{projectID}/portals/{portalID}`. `pkg/urn` still builds them directly
-under the workspace today, so treat the project segment as the target shape
-rather than what the builder currently emits. Either way, a `projects/*/apps/*`
-grant does not imply portal access, even when the portal is bound to that app.
-
-| Action | Authorizes |
-| --- | --- |
-| `create_portal` | Creating a portal. Granted with a wildcard id, since the portal does not exist when the request is authorized. |
-| `read_portal` | Reading portal configuration. |
-| `update_portal` | Updating portal configuration. |
-| `delete_portal` | Deleting a portal. |
-| `create_portal_session` | Minting a portal session for an end user. Deliberately separate from the management actions above: it is the sensitive capability and the one a production backend needs. |
-
-Session minting is additionally bounded at mint time by the caller's own key and
-analytics permissions, so a session can never carry a capability the calling root
-key does not hold. That second stage is enforced with legacy tuples today, so a
-URN grant does not currently satisfy it, including the `**#*` admin form.
-Revisit when the URN migration lands; the route ships a test pinning the current
-denial so the migration has a signal to flip.
-
-## Audit logs
-
-Audit logs store concrete resources and actions. They can also store the
-permission that authorized the action when authorization was evaluated.
-
-```json
-{
-  "actor": {
-    "type": "key",
-    "id": "key_root_123",
-    "urn": "unkey:v1:ws_123:keyspaces/ks_123/keys/key_root_123"
-  },
-  "resource": {
-    "urn": "unkey:v1:ws_123:projects/proj_123/apps/app_456/environments/env_789/deployments/d_abc",
-    "type": "deployment"
-  },
-  "action": "delete_deployment",
-  "authorization": {
-    "permission": "unkey:v1:ws_123:projects/proj_123/**#delete_deployment",
-    "matched": true
-  }
-}
-```
-
-Relationship changes can include multiple concrete resources. For example,
-adding a role to a key can log the key as the primary resource and the role as a
-target resource.
-
-```json
-{
-  "resource": {
-    "urn": "unkey:v1:ws_123:keyspaces/ks_123/keys/key_456",
-    "type": "key"
-  },
-  "targets": [
-    {
-      "urn": "unkey:v1:ws_123:rbac/roles/role_123",
-      "type": "role"
-    }
-  ],
-  "action": "add_role"
-}
-```
-
-## Migration from tuple permissions
-
-Existing tuple permissions map to resource permissions by expanding the old
-resource type, resource ID, and action into a URN path. Legacy API permissions
-map through the keyspace that replaces the API.
-
-| Existing permission | Resource permission |
-| --- | --- |
-| `api.*.create_api` | `unkey:v1:{workspace_id}:keyspaces/*#create_keyspace` |
-| `api.{api_id}.read_api` | `unkey:v1:{workspace_id}:keyspaces/{keyspace_id}#read_keyspace` |
-| `api.{api_id}.create_key` | `unkey:v1:{workspace_id}:keyspaces/{keyspace_id}#create_key` |
-| `api.{api_id}.read_key` | `unkey:v1:{workspace_id}:keyspaces/{keyspace_id}/keys/*#read_key` |
-| `api.{api_id}.verify_key` | `unkey:v1:{workspace_id}:keyspaces/{keyspace_id}/keys/*#verify_key` |
-| `identity.*.read_identity` | `unkey:v1:{workspace_id}:identities/*#read_identity` |
-| `ratelimit.*.delete_override` | `unkey:v1:{workspace_id}:ratelimits/namespaces/*/overrides/*#delete_override` |
-| `rbac.*.create_role` | `unkey:v1:{workspace_id}:rbac/roles/*#create_role` |
-
-Migration code must preserve the authorized workspace. The old permission string
-does not contain a workspace ID, so the workspace has to come from the owning
-key, role, user, or session.
-
-## Invalid examples
-
-These permissions are invalid.
-
-| Value | Reason |
-| --- | --- |
-| `unkey:v1:ws_123:keyspaces/ks_123` | Missing the action suffix. |
-| `unkey:v1:ws_123:keyspaces/ks_123.read_keyspace` | Uses the old tuple separator. |
-| `unkey:v1:ws_123:keyspaces/ks_123#*` | Uses an action wildcard outside the global resource pattern. |
-| `unkey:v1:ws_123:**/deployments/*#delete_deployment` | Uses recursive wildcard outside the trailing position. |
-| `unkey:v1:ws_123:projects/proj_123/**/deployments/*#delete_deployment` | Uses recursive wildcard in the middle of the path. |
-| `unkey:v1:ws_123:keyspaces/*/keys#read_key` | Does not match a catalog path shape. |
+- [Unkey Resource Names](/architecture/resources/unkey-resource-names)
+- [Resource permission catalog](/architecture/authorization/resource-permission-catalog)
+- [WorkOS permissions](/architecture/authorization/workos-permissions)

--- a/docs/engineering/architecture/authorization/workos-permissions.mdx
+++ b/docs/engineering/architecture/authorization/workos-permissions.mdx
@@ -9,20 +9,25 @@ strings from the access token into canonical Unkey resource permissions before
 the API constructs the principal.
 
 This translation exists because WorkOS permission strings cannot represent
-Unkey resource permissions directly. WorkOS permission slugs are capped at 48
-characters and cannot contain `/`, so they cannot encode canonical Unkey
-resource paths. The WorkOS permission model is intentionally much smaller than
-Unkey's resource permission model.
+concrete Unkey resources. WorkOS permission slugs are capped at 48 characters
+and cannot contain `/`. Each slug identifies one resource type and action from
+the [resource permission catalog](/architecture/authorization/resource-permission-catalog).
+The slug grants that action for every matching resource in the workspace.
 
-The exact list of supported WorkOS permissions and their Unkey translations is
-defined in
-[`pkg/auth/workos/permissions.go`](https://github.com/unkeyed/unkey/blob/main/pkg/auth/workos/permissions.go).
-That Go file is the source of truth.
+Define the WorkOS permission mappings in
+<a
+  href="https://github.com/unkeyed/unkey/blob/main/pkg/auth/workos/permissions.go"
+  target="_blank"
+>
+  `pkg/auth/workos/permissions.go`
+</a>.
+The mapping table defines one WorkOS slug for every catalog resource and action,
+plus `admin:*`.
 
 ## Permission shape
 
 WorkOS recommends clear, concise permission slugs with a resource and action
-delimiter. Unkey follows that shape and keeps WorkOS permissions broad:
+delimiter. Unkey uses this format:
 
 ```plaintext
 {area}:{action}
@@ -31,12 +36,12 @@ delimiter. Unkey follows that shape and keeps WorkOS permissions broad:
 For example:
 
 ```plaintext
-keys:create
+keys:write
 ```
 
-The WorkOS slug is intentionally not a Unkey resource permission. It is stable
-input from the identity provider. The API translates it after token verification
-because only Unkey owns the resource-name contract.
+The WorkOS slug identifies a resource type, not one resource instance. It is
+stable input from the identity provider. The API translates it after token
+verification because only Unkey owns the resource-name contract.
 
 ## Translation
 
@@ -49,16 +54,20 @@ strings with canonical permissions in this format:
 unkey:v1:{workspace_id}:{resource_path}#{action}
 ```
 
+The canonical action includes its target resource type. The WorkOS slug keeps
+the shorter operation name because its area already identifies the resource
+type.
+
 A WorkOS permission string such as:
 
 ```plaintext
-deployments:create
+deployments:write
 ```
 
 becomes a resource permission for the principal's workspace:
 
 ```plaintext
-unkey:v1:{workspace_id}:projects/**#create_deployment
+unkey:v1:{workspace_id}:projects/*/apps/*/environments/*/deployments/*#write_deployment
 ```
 
 The translated permission is the only value handlers see. Handler authorization
@@ -67,7 +76,7 @@ does not depend on WorkOS permission names.
 ## Unknown permissions
 
 Unknown WorkOS permission strings are ignored during translation. They don't
-grant access, and they don't fall back to legacy wildcard permissions.
+grant access, and they don't produce fallback permissions.
 
 This makes WorkOS safe to contain permissions that are not yet understood by
 the API. Adding a new permission requires updating the mapping table in

--- a/docs/engineering/architecture/resources/unkey-resource-names.mdx
+++ b/docs/engineering/architecture/resources/unkey-resource-names.mdx
@@ -14,7 +14,9 @@ defined here. A permission attaches an action to a URN, but the URN itself names
 only the resource.
 
 The Go implementation lives in
-[`pkg/urn`](https://github.com/unkeyed/unkey/tree/main/pkg/urn).
+<a href="https://github.com/unkeyed/unkey/tree/main/pkg/urn" target="_blank">
+  `pkg/urn`
+</a>.
 
 ## Format
 
@@ -61,8 +63,8 @@ URNs must follow these rules.
 
 Concrete URNs identify one resource. Resource-name patterns identify a set of
 resources and are part of the `v1` URN grammar. Callers that need one exact
-resource, such as audit logs and authorization requests, must use concrete
-URNs. Stored authorization grants can use patterns.
+resource, such as audit logs, must use concrete URNs. Stored authorization
+grants can use patterns.
 
 ## Resource-name patterns
 
@@ -105,13 +107,13 @@ unkey:v1:ws_123:projects/proj_123/apps/*/environments/*/deployments/dep_123
 For example, this pattern:
 
 ```plaintext
-unkey:v1:ws_123:keyspaces/*/keys/*
+unkey:v1:ws_123:projects/*/keyspaces/*/keys/*
 ```
 
 matches this concrete URN:
 
 ```plaintext
-unkey:v1:ws_123:keyspaces/ks_123/keys/key_456
+unkey:v1:ws_123:projects/proj_123/keyspaces/ks_123/keys/key_456
 ```
 
 This descendant pattern:
@@ -132,156 +134,12 @@ unkey:v1:ws_123:**
 covers another. The permission system adds the action suffix and decides what a
 covered resource authorizes. It doesn't define its own path matching.
 
-## Resource catalog
+## Canonical catalog
 
-The public catalog defines every concrete resource path that can appear in a
-`v1` URN. Implementation code must reject concrete URNs that don't match one of
-these path shapes. Pattern grants must still be built from these path shapes,
-with `*` replacing complete ID segments or trailing `/**` covering descendants.
-
-### Team
-
-Team resources are rooted under `team`.
-
-| Resource | Path |
-| --- | --- |
-| Membership | `team/memberships/{membership_id}` |
-| Invitation | `team/invitations/{invitation_id}` |
-
-Examples:
-
-```plaintext
-unkey:v1:ws_123:team/memberships/mbr_123
-unkey:v1:ws_123:team/invitations/inv_456
-```
-
-### Billing
-
-Billing resources are rooted under `billing`. Workspace quota is a singleton
-resource because quota applies to the workspace billing state.
-
-| Resource | Path |
-| --- | --- |
-| Billing state | `billing` |
-| Invoice | `billing/invoices/{invoice_id}` |
-| Quota | `billing/quotas` |
-
-Examples:
-
-```plaintext
-unkey:v1:ws_123:billing
-unkey:v1:ws_123:billing/invoices/inv_123
-unkey:v1:ws_123:billing/quotas
-```
-
-### Keyspaces
-
-Key resources are rooted under the keyspace that owns the key.
-
-| Resource | Path |
-| --- | --- |
-| Keyspace | `keyspaces/{keyspace_id}` |
-| Key | `keyspaces/{keyspace_id}/keys/{key_id}` |
-
-Examples:
-
-```plaintext
-unkey:v1:ws_123:keyspaces/ks_123
-unkey:v1:ws_123:keyspaces/ks_123/keys/key_456
-```
-
-### Identities
-
-Identity resources are rooted under `identities`.
-
-| Resource | Path |
-| --- | --- |
-| Identity | `identities/{identity_id}` |
-
-Example:
-
-```plaintext
-unkey:v1:ws_123:identities/id_123
-```
-
-### Rate limits
-
-Standalone rate limiting resources are rooted under `ratelimits`. Overrides
-belong to the namespace they modify.
-
-| Resource | Path |
-| --- | --- |
-| Namespace | `ratelimits/namespaces/{namespace_id}` |
-| Override | `ratelimits/namespaces/{namespace_id}/overrides/{override_id}` |
-
-Examples:
-
-```plaintext
-unkey:v1:ws_123:ratelimits/namespaces/rlns_123
-unkey:v1:ws_123:ratelimits/namespaces/rlns_123/overrides/rlor_456
-```
-
-### RBAC
-
-RBAC resources are rooted under `rbac`. Relationship changes, such as adding a
-role to a key, are audited against both affected resources rather than by
-creating a separate join-table URN.
-
-| Resource | Path |
-| --- | --- |
-| Role | `rbac/roles/{role_id}` |
-| Permission | `rbac/permissions/{permission_id}` |
-
-Examples:
-
-```plaintext
-unkey:v1:ws_123:rbac/roles/role_123
-unkey:v1:ws_123:rbac/permissions/perm_456
-```
-
-### Deploy
-
-Deploy resources use the full product hierarchy. A deployment belongs to one
-environment, which belongs to one app, which belongs to one project.
-
-| Resource | Path |
-| --- | --- |
-| Project | `projects/{project_id}` |
-| App | `projects/{project_id}/apps/{app_id}` |
-| Environment | `projects/{project_id}/apps/{app_id}/environments/{environment_id}` |
-| Deployment | `projects/{project_id}/apps/{app_id}/environments/{environment_id}/deployments/{deployment_id}` |
-| Deployment instance | `projects/{project_id}/apps/{app_id}/environments/{environment_id}/deployments/{deployment_id}/instances/{instance_id}` |
-| Domain | `projects/{project_id}/apps/{app_id}/environments/{environment_id}/domains/{domain_id}` |
-| Variable | `projects/{project_id}/apps/{app_id}/environments/{environment_id}/variables/{variable_id}` |
-| Gateway policy | `projects/{project_id}/apps/{app_id}/environments/{environment_id}/gateway/policies/{policy_id}` |
-
-Examples:
-
-```plaintext
-unkey:v1:ws_123:projects/proj_123
-unkey:v1:ws_123:projects/proj_123/apps/app_456
-unkey:v1:ws_123:projects/proj_123/apps/app_456/environments/env_789
-unkey:v1:ws_123:projects/proj_123/apps/app_456/environments/env_789/deployments/d_abc
-```
-
-### Portal
-
-Portal resources are rooted under `portals`. Session tokens and sessions belong
-to the portal that created them.
-
-| Resource | Path |
-| --- | --- |
-| Portal | `portals/{portal_id}` |
-| Portal session token | `portals/{portal_id}/session_tokens/{portal_session_token_id}` |
-| Portal session | `portals/{portal_id}/sessions/{portal_session_id}` |
-| Portal branding | `portals/{portal_id}/branding` |
-
-Examples:
-
-```plaintext
-unkey:v1:ws_123:portals/portal_123
-unkey:v1:ws_123:portals/portal_123/sessions/ps_456
-```
+The
+[resource permission catalog](/architecture/authorization/resource-permission-catalog)
+defines every public resource path and its supported actions. Use those paths
+when you construct a concrete URN or a resource pattern.
 
 ## Internal resources
 
@@ -305,15 +163,20 @@ These strings are invalid URNs or invalid concrete URNs.
 
 | Value | Reason |
 | --- | --- |
-| `urn:unkey:v1:ws_123:keyspaces/ks_123` | Uses the wrong prefix. |
+| `urn:unkey:v1:ws_123:projects/proj_123/keyspaces/ks_123` | Uses the wrong prefix. |
 | `unkey:v1:ws_123` | Missing the resource path. |
-| `unkey:v1:ws_123:keyspaces/ks_123#read_keyspace` | Contains a permission action. |
-| `unkey:v1:ws_123:keyspaces/ks_*` | Uses `*` inside a path segment. |
+| `unkey:v1:ws_123:projects/proj_123/keyspaces/ks_123#read_keyspace` | Contains a permission action. |
+| `unkey:v1:ws_123:projects/proj_123/keyspaces/ks_*` | Uses `*` inside a path segment. |
 | `unkey:v1:ws_123:projects/**/deployments/*` | Uses `**` before the end of the path. |
 | `unkey:v1:ws_123:projects/*/apps/app_123` | Selects a specific child under a wildcard parent. |
-| `unkey:v1:ws_123:keyspace/ks_123` | Uses an unknown path shape. |
+| `unkey:v1:ws_123:keyspaces/ks_123` | Omits the owning project. |
+| `unkey:v1:ws_123:projects/proj_123/keyspace/ks_123` | Uses an unknown path shape. |
 
 ## Related pages
 
+Use these pages for permission rules and the canonical catalog.
+
 - [Resource permissions](/architecture/authorization/resource-permissions)
   defines how actions attach to URNs for authorization.
+- [Resource permission catalog](/architecture/authorization/resource-permission-catalog)
+  lists canonical resource paths and actions.

--- a/docs/engineering/docs.json
+++ b/docs/engineering/docs.json
@@ -67,6 +67,7 @@
                 "pages": [
                   "architecture/resources/unkey-resource-names",
                   "architecture/authorization/resource-permissions",
+                  "architecture/authorization/resource-permission-catalog",
                   "architecture/authorization/workos-permissions"
                 ]
               },


### PR DESCRIPTION
## Notes for description (rewrite before review)

### Stack
- Position: 9 of 9. Review wave 3: cutover and documentation.
- Full stack: #7189 → #7190 → #7191 → #7192 → #7193 → #7195 → #7196 → #7197 → **#7198**.
- Depends on: #7197. This is the final PR in the stack.

### Goal
- Give URN rules, permission rules, and the canonical permission catalog one clear page each.

### Approach
- Keep the full 52-action catalog in one hierarchical ASCII tree.
- Show canonical paths and focused examples without repeating the catalog in tables.
- Update the engineering documentation navigation.

### Decisions
- Document logs as first-class resources, including gateway logs under an environment gateway.
- Document resource-qualified actions so recursive URN scopes remain unambiguous.
- Keep `gateway` and `rbac` as path containers without actions.
- Write the documentation as the canonical model without legacy migration guidance.

### Review order
1. Review URN grammar and wildcard rules.
2. Review permission matching and action ownership rules.
3. Compare the ASCII catalog with #7197.
4. Review WorkOS translation guidance and navigation.

### Review focus
- Confirm that the catalog lists every resource path once.
- Confirm that all resources except GitHub apps are project-scoped.
- Confirm that log paths and special actions match the implementation.

### Verification
- The catalog contains the same 52 actions as the WorkOS permission golden file.
- All 19 implementation resource paths appear in the catalog.
- The only extra paths are the `gateway` and `rbac` containers.
- `docs/engineering/docs.json` parses and all navigation targets exist.
- No OpenAPI descriptions, OpenAPI specs, generated API files, or web files changed.
