### PR TITLE
refactor(ctrl,api): add image validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/containerd/containerd/v2 v2.2.0
 	github.com/containerd/typeurl/v2 v2.2.3
 	github.com/depot/depot-go v0.5.2
+	github.com/distribution/reference v0.6.0
 	github.com/docker/cli v29.2.0+incompatible
 	github.com/getkin/kin-openapi v0.133.0
 	github.com/go-acme/lego/v4 v4.31.0
@@ -168,7 +169,6 @@ require (
 	github.com/cyphar/filepath-securejoin v0.5.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
-	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect
 	github.com/docker/docker v28.5.2+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.9.5 // indirect

--- a/pkg/deploy/imageref/imageref.go
+++ b/pkg/deploy/imageref/imageref.go
@@ -7,8 +7,6 @@
 package imageref
 
 import (
-	// go-digest verifies a digest only for algorithms whose hash is linked in, so
-	// without these a valid sha256 reference fails as an unsupported algorithm.
 	_ "crypto/sha256"
 	_ "crypto/sha512"
 	"fmt"
@@ -49,9 +47,6 @@ func Validate(image string) error {
 	}
 
 	if _, err := reference.ParseDockerRef(image); err != nil {
-		// The parser answers most malformed input with a sentinel built at init, so
-		// its text names neither the input nor the rule that was broken. It is kept
-		// internal for debugging and the caller is told the shape expected instead.
 		return fault.Wrap(
 			err,
 			fault.Code(codes.App.Validation.InvalidInput.URN()),

--- a/pkg/deploy/imageref/imageref.go
+++ b/pkg/deploy/imageref/imageref.go
@@ -33,7 +33,9 @@ func Validate(image string) error {
 		return fmt.Errorf("docker image reference must not be more than %d characters", MaxLength)
 	}
 	if _, err := reference.ParseDockerRef(image); err != nil {
-		return fmt.Errorf("invalid docker image reference %q: %w", image, err)
+		// The parser's message already opens with "invalid reference format", so
+		// prefixing it again reads as a stutter. Only the input is added.
+		return fmt.Errorf("%w (%q)", err, image)
 	}
 	return nil
 }

--- a/pkg/deploy/imageref/imageref.go
+++ b/pkg/deploy/imageref/imageref.go
@@ -1,0 +1,39 @@
+// Package imageref validates Docker image references before a deployment is
+// created, so a bad one is refused up front rather than failing a pull after a
+// build slot has been spent on it.
+package imageref
+
+import (
+	// go-digest verifies a digest only for algorithms whose hash is linked in, so
+	// without these a valid sha256 reference fails as an unsupported algorithm.
+	_ "crypto/sha256"
+	_ "crypto/sha512"
+	"fmt"
+
+	"github.com/distribution/reference"
+)
+
+// MaxLength is the width of deployments.image. The grammar allows roughly 456
+// characters, so this limit is ours rather than Docker's. The row is written only
+// after the build, so without it an oversized reference fails the insert with a
+// build already paid for.
+const MaxLength = 256
+
+// Validate rejects a reference no registry could serve. Parsing goes through the
+// same library the pull path uses, so what passes here is what containerd accepts,
+// and the message returned is safe to show a caller.
+//
+// It does not check that the host serves images at all: github.com/acme/api is
+// well-formed and fails at pull time.
+func Validate(image string) error {
+	if image == "" {
+		return fmt.Errorf("docker image reference is required")
+	}
+	if len(image) > MaxLength {
+		return fmt.Errorf("docker image reference must not be more than %d characters", MaxLength)
+	}
+	if _, err := reference.ParseDockerRef(image); err != nil {
+		return fmt.Errorf("invalid docker image reference %q: %w", image, err)
+	}
+	return nil
+}

--- a/pkg/deploy/imageref/imageref.go
+++ b/pkg/deploy/imageref/imageref.go
@@ -1,6 +1,9 @@
 // Package imageref validates Docker image references before a deployment is
 // created, so a bad one is refused up front rather than failing a pull after a
 // build slot has been spent on it.
+//
+// Validate returns nil when the reference is well-formed, or a fault carrying
+// the validation code and a caller-facing message.
 package imageref
 
 import (
@@ -11,31 +14,51 @@ import (
 	"fmt"
 
 	"github.com/distribution/reference"
+	"github.com/unkeyed/unkey/pkg/codes"
+	"github.com/unkeyed/unkey/pkg/fault"
 )
 
-// MaxLength is the width of deployments.image. The grammar allows roughly 456
-// characters, so this limit is ours rather than Docker's. The row is written only
-// after the build, so without it an oversized reference fails the insert with a
-// build already paid for.
-const MaxLength = 256
+// deployments.image is a varchar(256). The parser puts no bound on a reference's
+// total length, so a valid one can still be too long for the column, and the row
+// is written only after the build: without this an oversized reference fails the
+// insert with a build already paid for.
+const imageLengthMax = 256
 
 // Validate rejects a reference no registry could serve. Parsing goes through the
-// same library the pull path uses, so what passes here is what containerd accepts,
-// and the message returned is safe to show a caller.
+// same library the pull path uses, so what passes here is what containerd accepts.
 //
 // It does not check that the host serves images at all: github.com/acme/api is
 // well-formed and fails at pull time.
 func Validate(image string) error {
 	if image == "" {
-		return fmt.Errorf("docker image reference is required")
+		return fault.New(
+			"docker image reference is empty",
+			fault.Code(codes.App.Validation.InvalidInput.URN()),
+			fault.Internal("imageref rejected reference: empty"),
+			fault.Public("The docker image reference is required."),
+		)
 	}
-	if len(image) > MaxLength {
-		return fmt.Errorf("docker image reference must not be more than %d characters", MaxLength)
+
+	if len(image) > imageLengthMax {
+		return fault.New(
+			"docker image reference is too long",
+			fault.Code(codes.App.Validation.InvalidInput.URN()),
+			fault.Internal(fmt.Sprintf("imageref rejected reference: %d characters", len(image))),
+			fault.Public(fmt.Sprintf("The docker image reference must not be more than %d characters.", imageLengthMax)),
+		)
 	}
+
 	if _, err := reference.ParseDockerRef(image); err != nil {
-		// The parser's message already opens with "invalid reference format", so
-		// prefixing it again reads as a stutter. Only the input is added.
-		return fmt.Errorf("%w (%q)", err, image)
+		// The parser answers most malformed input with a sentinel built at init, so
+		// its text names neither the input nor the rule that was broken. It is kept
+		// internal for debugging and the caller is told the shape expected instead.
+		return fault.Wrap(
+			err,
+			fault.Code(codes.App.Validation.InvalidInput.URN()),
+			fault.Internal(fmt.Sprintf("imageref rejected reference: %q", image)),
+			fault.Public(fmt.Sprintf("The docker image reference %q is not valid. Expected [registry/]repository[:tag][@digest], for example ghcr.io/acme/api:v1.2.3.", image)),
+		)
 	}
+
 	return nil
 }

--- a/pkg/deploy/imageref/imageref_test.go
+++ b/pkg/deploy/imageref/imageref_test.go
@@ -1,0 +1,58 @@
+package imageref
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidate(t *testing.T) {
+	t.Parallel()
+
+	digest := "sha256:" + strings.Repeat("a", 64)
+
+	valid := []string{
+		"kebap",
+		"nginx:1.27",
+		"library/redis:7",
+		"ghcr.io/acme/api:v1.2.3",
+		"docker.io/library/mysql:8.0.36",
+		"localhost:5000/acme/api:dev",
+		"registry.internal:5000/team/api",
+		"ghcr.io/acme/api@" + digest,
+		"ghcr.io/acme/api:v1@" + digest,
+		// A tag is case sensitive, so uppercase in one is legal.
+		"ghcr.io/acme/api:V1.2-RC1",
+	}
+	for _, image := range valid {
+		require.NoError(t, Validate(image), image)
+	}
+
+	invalid := []string{
+		"",
+		"Acme/Api:v1",
+		"ghcr.io/Acme/api",
+		"my image:v1",
+		"https://ghcr.io/acme/api",
+		"ghcr.io/acme/api:",
+		"ghcr.io/acme/api@sha256:abc123",
+		"ghcr.io//acme/api",
+		// One character over what deployments.image holds.
+		"ghcr.io/acme/" + strings.Repeat("a", 244),
+	}
+	for _, image := range invalid {
+		require.Error(t, Validate(image), image)
+	}
+}
+
+// TestValidateLengthBoundary pins the cap to the column width rather
+// than to whatever the grammar allows.
+func TestValidateLengthBoundary(t *testing.T) {
+	t.Parallel()
+
+	fits := "ghcr.io/acme/" + strings.Repeat("a", MaxLength-len("ghcr.io/acme/"))
+	require.Len(t, fits, MaxLength)
+	require.NoError(t, Validate(fits))
+	require.Error(t, Validate(fits+"a"))
+}

--- a/pkg/deploy/imageref/imageref_test.go
+++ b/pkg/deploy/imageref/imageref_test.go
@@ -4,7 +4,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/distribution/reference"
 	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/codes"
+	"github.com/unkeyed/unkey/pkg/fault"
 )
 
 func TestValidate(t *testing.T) {
@@ -51,8 +54,42 @@ func TestValidate(t *testing.T) {
 func TestValidateLengthBoundary(t *testing.T) {
 	t.Parallel()
 
-	fits := "ghcr.io/acme/" + strings.Repeat("a", MaxLength-len("ghcr.io/acme/"))
-	require.Len(t, fits, MaxLength)
+	fits := "ghcr.io/acme/" + strings.Repeat("a", imageLengthMax-len("ghcr.io/acme/"))
+	require.Len(t, fits, imageLengthMax)
 	require.NoError(t, Validate(fits))
 	require.Error(t, Validate(fits+"a"))
+}
+
+// TestValidateMessages pins the caller-facing text, which handlers render
+// straight into an API response, and keeps the parser's own wording internal.
+func TestValidateMessages(t *testing.T) {
+	t.Parallel()
+
+	err := Validate("ghcr.io/acme/api:v1 KEBAP")
+	require.Equal(t,
+		`The docker image reference "ghcr.io/acme/api:v1 KEBAP" is not valid. Expected [registry/]repository[:tag][@digest], for example ghcr.io/acme/api:v1.2.3.`,
+		fault.UserFacingMessage(err))
+	require.NotContains(t, fault.UserFacingMessage(err), "invalid reference format")
+	require.ErrorIs(t, err, reference.ErrReferenceInvalidFormat)
+
+	code, ok := fault.GetCode(err)
+	require.True(t, ok)
+	require.Equal(t, codes.App.Validation.InvalidInput.URN(), code)
+
+	require.Equal(t, "The docker image reference is required.", fault.UserFacingMessage(Validate("")))
+	require.Equal(t,
+		"The docker image reference must not be more than 256 characters.",
+		fault.UserFacingMessage(Validate(strings.Repeat("a", imageLengthMax+1))))
+}
+
+// TestValidateAlwaysFaults keeps every rejection on the fault path, so a caller
+// rendering UserFacingMessage never falls back to an empty string.
+func TestValidateAlwaysFaults(t *testing.T) {
+	t.Parallel()
+
+	for _, image := range []string{"", "Acme/Api:v1", "my image:v1", strings.Repeat("a", imageLengthMax+1)} {
+		err := Validate(image)
+		require.Error(t, err, image)
+		require.NotEmpty(t, fault.UserFacingMessage(err), image)
+	}
 }

--- a/svc/api/openapi/gen.go
+++ b/svc/api/openapi/gen.go
@@ -442,7 +442,7 @@ type DeploymentSourceGit struct {
 
 // DeploymentSourceImage Deploy a prebuilt Docker image as-is.
 type DeploymentSourceImage struct {
-	// DockerImage Docker image to deploy as-is. Accepts a tag or a digest.
+	// DockerImage Full image reference to deploy as-is. Qualify the version with a tag (ghcr.io/acme/api:v1.2.3) or with a digest (ghcr.io/acme/api@sha256:...). Without either, the registry serves the latest tag.
 	DockerImage string `json:"dockerImage"`
 }
 
@@ -1970,7 +1970,7 @@ type V2DeployCreateDeploymentRequestBody struct {
 	// Branch Git branch name
 	Branch string `json:"branch"`
 
-	// DockerImage Docker image reference to deploy. Accepts a tag or a digest.
+	// DockerImage Full image reference to deploy. Qualify the version with a tag (ghcr.io/user/app:v1.0.0) or with a digest (ghcr.io/user/app@sha256:...). Without either, the registry serves the latest tag.
 	DockerImage string `json:"dockerImage"`
 
 	// EnvironmentSlug Environment slug (e.g., "production", "staging")

--- a/svc/api/openapi/gen.go
+++ b/svc/api/openapi/gen.go
@@ -442,7 +442,7 @@ type DeploymentSourceGit struct {
 
 // DeploymentSourceImage Deploy a prebuilt Docker image as-is.
 type DeploymentSourceImage struct {
-	// DockerImage Docker image to deploy as-is.
+	// DockerImage Docker image to deploy as-is. Accepts a tag or a digest.
 	DockerImage string `json:"dockerImage"`
 }
 
@@ -1970,7 +1970,7 @@ type V2DeployCreateDeploymentRequestBody struct {
 	// Branch Git branch name
 	Branch string `json:"branch"`
 
-	// DockerImage Docker image reference to deploy
+	// DockerImage Docker image reference to deploy. Accepts a tag or a digest.
 	DockerImage string `json:"dockerImage"`
 
 	// EnvironmentSlug Environment slug (e.g., "production", "staging")

--- a/svc/api/openapi/openapi-generated.yaml
+++ b/svc/api/openapi/openapi-generated.yaml
@@ -644,7 +644,8 @@ components:
                     type: string
                     minLength: 1
                     maxLength: 256
-                    description: Docker image reference to deploy. Accepts a tag or a digest.
+                    description: >-
+                        Full image reference to deploy. Qualify the version with a tag (ghcr.io/user/app:v1.0.0) or with a digest (ghcr.io/user/app@sha256:...). Without either, the registry serves the latest tag.
                     example: "ghcr.io/user/app:v1.0.0"
                 gitCommit:
                     $ref: "#/components/schemas/V2DeployGitCommit"
@@ -4555,7 +4556,8 @@ components:
                     minLength: 1
                     maxLength: 256
                     pattern: "\\S"
-                    description: Docker image to deploy as-is. Accepts a tag or a digest.
+                    description: >-
+                        Full image reference to deploy as-is. Qualify the version with a tag (ghcr.io/acme/api:v1.2.3) or with a digest (ghcr.io/acme/api@sha256:...). Without either, the registry serves the latest tag.
                     example: "ghcr.io/acme/api:v1.2.3"
             description: Deploy a prebuilt Docker image as-is.
         DeploymentSourceDeployment:

--- a/svc/api/openapi/openapi-generated.yaml
+++ b/svc/api/openapi/openapi-generated.yaml
@@ -643,7 +643,8 @@ components:
                 dockerImage:
                     type: string
                     minLength: 1
-                    description: Docker image reference to deploy
+                    maxLength: 256
+                    description: Docker image reference to deploy. Accepts a tag or a digest.
                     example: "ghcr.io/user/app:v1.0.0"
                 gitCommit:
                     $ref: "#/components/schemas/V2DeployGitCommit"
@@ -4552,8 +4553,9 @@ components:
                 dockerImage:
                     type: string
                     minLength: 1
+                    maxLength: 256
                     pattern: "\\S"
-                    description: Docker image to deploy as-is.
+                    description: Docker image to deploy as-is. Accepts a tag or a digest.
                     example: "ghcr.io/acme/api:v1.2.3"
             description: Deploy a prebuilt Docker image as-is.
         DeploymentSourceDeployment:

--- a/svc/api/openapi/spec/paths/v2/deploy/createDeployment/V2DeployCreateDeploymentRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/deploy/createDeployment/V2DeployCreateDeploymentRequestBody.yaml
@@ -33,7 +33,8 @@ properties:
   dockerImage:
     type: string
     minLength: 1
-    description: Docker image reference to deploy
+    maxLength: 256
+    description: Docker image reference to deploy. Accepts a tag or a digest.
     example: "ghcr.io/user/app:v1.0.0"
   gitCommit:
     $ref: "./V2DeployGitCommit.yaml"

--- a/svc/api/openapi/spec/paths/v2/deploy/createDeployment/V2DeployCreateDeploymentRequestBody.yaml
+++ b/svc/api/openapi/spec/paths/v2/deploy/createDeployment/V2DeployCreateDeploymentRequestBody.yaml
@@ -34,7 +34,11 @@ properties:
     type: string
     minLength: 1
     maxLength: 256
-    description: Docker image reference to deploy. Accepts a tag or a digest.
+    description: >-
+      Full image reference to deploy. Qualify the version with a tag
+      (ghcr.io/user/app:v1.0.0) or with a digest
+      (ghcr.io/user/app@sha256:...). Without either, the registry serves the
+      latest tag.
     example: "ghcr.io/user/app:v1.0.0"
   gitCommit:
     $ref: "./V2DeployGitCommit.yaml"

--- a/svc/api/openapi/spec/paths/v2/deployments/createDeployment/DeploymentSourceImage.yaml
+++ b/svc/api/openapi/spec/paths/v2/deployments/createDeployment/DeploymentSourceImage.yaml
@@ -5,7 +5,8 @@ properties:
   dockerImage:
     type: string
     minLength: 1
+    maxLength: 256
     pattern: "\\S"
-    description: Docker image to deploy as-is.
+    description: Docker image to deploy as-is. Accepts a tag or a digest.
     example: "ghcr.io/acme/api:v1.2.3"
 description: Deploy a prebuilt Docker image as-is.

--- a/svc/api/openapi/spec/paths/v2/deployments/createDeployment/DeploymentSourceImage.yaml
+++ b/svc/api/openapi/spec/paths/v2/deployments/createDeployment/DeploymentSourceImage.yaml
@@ -7,6 +7,10 @@ properties:
     minLength: 1
     maxLength: 256
     pattern: "\\S"
-    description: Docker image to deploy as-is. Accepts a tag or a digest.
+    description: >-
+      Full image reference to deploy as-is. Qualify the version with a tag
+      (ghcr.io/acme/api:v1.2.3) or with a digest
+      (ghcr.io/acme/api@sha256:...). Without either, the registry serves the
+      latest tag.
     example: "ghcr.io/acme/api:v1.2.3"
 description: Deploy a prebuilt Docker image as-is.

--- a/svc/api/routes/v2_deploy_create_deployment/handler.go
+++ b/svc/api/routes/v2_deploy_create_deployment/handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/unkeyed/unkey/gen/rpc/ctrl"
 	"github.com/unkeyed/unkey/pkg/codes"
 	"github.com/unkeyed/unkey/pkg/db"
+	"github.com/unkeyed/unkey/pkg/deploy/imageref"
 	"github.com/unkeyed/unkey/pkg/fault"
 	"github.com/unkeyed/unkey/pkg/rbac"
 	"github.com/unkeyed/unkey/pkg/zen"
@@ -83,6 +84,17 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	trigger := ctrlv1.DeploymentTrigger_DEPLOYMENT_TRIGGER_API
 	if strings.HasPrefix(s.Request().Header.Get("X-Unkey-Client"), "unkey-cli/") {
 		trigger = ctrlv1.DeploymentTrigger_DEPLOYMENT_TRIGGER_CLI
+	}
+
+	// ctrl rejects these too, but ctrlclient.HandleError replaces its message with a
+	// generic one, so the reason reaches the caller only if the check also runs here.
+	if err := imageref.Validate(req.DockerImage); err != nil {
+		return fault.New(
+			"invalid docker image reference",
+			fault.Code(codes.App.Validation.InvalidInput.URN()),
+			fault.Internal(err.Error()),
+			fault.Public(err.Error()),
+		)
 	}
 
 	// nolint: exhaustruct // optional proto fields, only setting whats provided

--- a/svc/api/routes/v2_deploy_create_deployment/handler.go
+++ b/svc/api/routes/v2_deploy_create_deployment/handler.go
@@ -89,12 +89,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	// ctrl rejects these too, but ctrlclient.HandleError replaces its message with a
 	// generic one, so the reason reaches the caller only if the check also runs here.
 	if err := imageref.Validate(req.DockerImage); err != nil {
-		return fault.New(
-			"invalid docker image reference",
-			fault.Code(codes.App.Validation.InvalidInput.URN()),
-			fault.Internal(err.Error()),
-			fault.Public(err.Error()),
-		)
+		return err
 	}
 
 	// nolint: exhaustruct // optional proto fields, only setting whats provided

--- a/svc/api/routes/v2_deployments_create_deployment/400_test.go
+++ b/svc/api/routes/v2_deployments_create_deployment/400_test.go
@@ -2,6 +2,7 @@ package handler_test
 
 import (
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -42,6 +43,10 @@ func TestValidationErrors(t *testing.T) {
 	}{
 		{"image missing dockerImage", body(map[string]any{"image": map[string]any{}})},
 		{"image whitespace dockerImage", body(map[string]any{"image": map[string]any{"dockerImage": "   "}})},
+		{"image uppercase name", body(map[string]any{"image": map[string]any{"dockerImage": "Acme/Api:v1"}})},
+		{"image empty tag", body(map[string]any{"image": map[string]any{"dockerImage": "acme/api:"}})},
+		{"image truncated digest", body(map[string]any{"image": map[string]any{"dockerImage": "acme/api@sha256:abc123"}})},
+		{"image over the column width", body(map[string]any{"image": map[string]any{"dockerImage": "ghcr.io/acme/" + strings.Repeat("a", 244)}})},
 		{"git fork without commitSha", body(map[string]any{"git": map[string]any{"repository": "contributor/acme-api"}})},
 		{"git fork bad charset", body(map[string]any{"git": map[string]any{"commitSha": "abc123", "repository": "bad repo!"}})},
 		{"git fork path traversal", body(map[string]any{"git": map[string]any{"commitSha": "abc123", "repository": "../../etc/passwd"}})},

--- a/svc/api/routes/v2_deployments_create_deployment/handler.go
+++ b/svc/api/routes/v2_deployments_create_deployment/handler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/unkeyed/unkey/pkg/codes"
 	"github.com/unkeyed/unkey/pkg/db"
 	"github.com/unkeyed/unkey/pkg/deploy/deployfail"
+	"github.com/unkeyed/unkey/pkg/deploy/imageref"
 	"github.com/unkeyed/unkey/pkg/fault"
 	"github.com/unkeyed/unkey/pkg/ptr"
 	"github.com/unkeyed/unkey/pkg/rbac"
@@ -120,6 +121,17 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 	switch {
 	case req.Image != nil:
+		// ctrl refuses an unpullable reference too, but its message is replaced by a
+		// generic one on the way back, so the reason only reaches the caller if the
+		// check runs here as well.
+		if err := imageref.Validate(req.Image.DockerImage); err != nil {
+			return fault.New(
+				"invalid docker image reference",
+				fault.Code(codes.App.Validation.InvalidInput.URN()),
+				fault.Internal(err.Error()),
+				fault.Public(err.Error()),
+			)
+		}
 		ctrlReq.DockerImage = req.Image.DockerImage
 
 	case req.Git != nil:

--- a/svc/api/routes/v2_deployments_create_deployment/handler.go
+++ b/svc/api/routes/v2_deployments_create_deployment/handler.go
@@ -121,9 +121,6 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 	switch {
 	case req.Image != nil:
-		// ctrl refuses an unpullable reference too, but its message is replaced by a
-		// generic one on the way back, so the reason only reaches the caller if the
-		// check runs here as well.
 		if err := imageref.Validate(req.Image.DockerImage); err != nil {
 			return err
 		}

--- a/svc/api/routes/v2_deployments_create_deployment/handler.go
+++ b/svc/api/routes/v2_deployments_create_deployment/handler.go
@@ -125,12 +125,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		// generic one on the way back, so the reason only reaches the caller if the
 		// check runs here as well.
 		if err := imageref.Validate(req.Image.DockerImage); err != nil {
-			return fault.New(
-				"invalid docker image reference",
-				fault.Code(codes.App.Validation.InvalidInput.URN()),
-				fault.Internal(err.Error()),
-				fault.Public(err.Error()),
-			)
+			return err
 		}
 		ctrlReq.DockerImage = req.Image.DockerImage
 

--- a/svc/ctrl/internal/gatefault/gatefault.go
+++ b/svc/ctrl/internal/gatefault/gatefault.go
@@ -1,7 +1,5 @@
 // Package gatefault converts a fault raised by the shared precondition and
-// validation packages into ctrl's error surfaces. It surfaces only
-// fault.UserFacingMessage, never err.Error(), which carries internal detail, so
-// callers can't leak it by mistake.
+// validation packages into ctrl's error surfaces.
 package gatefault
 
 import (

--- a/svc/ctrl/internal/gatefault/gatefault.go
+++ b/svc/ctrl/internal/gatefault/gatefault.go
@@ -1,6 +1,7 @@
-// Package gatefault converts a deploygate precondition fault into ctrl's error
-// surfaces. It surfaces only fault.UserFacingMessage — never err.Error(), which
-// carries internal detail — so callers can't leak it by mistake.
+// Package gatefault converts a fault raised by the shared precondition and
+// validation packages into ctrl's error surfaces. It surfaces only
+// fault.UserFacingMessage, never err.Error(), which carries internal detail, so
+// callers can't leak it by mistake.
 package gatefault
 
 import (
@@ -11,14 +12,14 @@ import (
 	"github.com/unkeyed/unkey/pkg/fault"
 )
 
-// Connect converts a deploygate fault into a connect FailedPrecondition error,
+// Connect converts a fault into a connect FailedPrecondition error,
 // or nil when err is nil. For ctrl RPC services.
 func Connect(err error) error {
 	return ConnectWith(connect.CodeFailedPrecondition, err)
 }
 
-// ConnectWith is [Connect] for gates whose outcomes are not all preconditions, so
-// the caller picks the matching connect code. Returns nil when err is nil.
+// ConnectWith is [Connect] for faults that are not all preconditions, so the
+// caller picks the matching connect code. Returns nil when err is nil.
 func ConnectWith(code connect.Code, err error) error {
 	if err == nil {
 		return nil
@@ -26,7 +27,7 @@ func ConnectWith(code connect.Code, err error) error {
 	return connect.NewError(code, errors.New(fault.UserFacingMessage(err)))
 }
 
-// Terminal converts a deploygate fault into a restate terminal error (400), or
+// Terminal converts a fault into a restate terminal error (400), or
 // nil when err is nil. For ctrl Restate workers.
 func Terminal(err error) error {
 	if err == nil {

--- a/svc/ctrl/services/deployment/create_deployment.go
+++ b/svc/ctrl/services/deployment/create_deployment.go
@@ -16,6 +16,7 @@ import (
 	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
 	"github.com/unkeyed/unkey/pkg/auditlog"
 	"github.com/unkeyed/unkey/pkg/deploy/deployfail"
+	"github.com/unkeyed/unkey/pkg/deploy/imageref"
 	githubclient "github.com/unkeyed/unkey/pkg/github"
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/pkg/uid"
@@ -380,6 +381,10 @@ func (s *Service) createAndDeploy(ctx context.Context, p createParams) (string, 
 
 	switch {
 	case p.dockerImage != "":
+		if err := imageref.Validate(p.dockerImage); err != nil {
+			return "", connect.NewError(connect.CodeInvalidArgument, err)
+		}
+
 		// Explicit docker image (CLI, REST API): skip rebuild, redeploy as-is.
 		// Don't touch git metadata — the caller owns whatever they passed.
 		logger.Info("deployment will use prebuilt image",

--- a/svc/ctrl/services/deployment/create_deployment.go
+++ b/svc/ctrl/services/deployment/create_deployment.go
@@ -25,6 +25,7 @@ import (
 	"github.com/unkeyed/unkey/svc/ctrl/internal/actor"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/auth"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/db"
+	"github.com/unkeyed/unkey/svc/ctrl/internal/gatefault"
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
@@ -382,7 +383,7 @@ func (s *Service) createAndDeploy(ctx context.Context, p createParams) (string, 
 	switch {
 	case p.dockerImage != "":
 		if err := imageref.Validate(p.dockerImage); err != nil {
-			return "", connect.NewError(connect.CodeInvalidArgument, err)
+			return "", gatefault.ConnectWith(connect.CodeInvalidArgument, err)
 		}
 
 		// Explicit docker image (CLI, REST API): skip rebuild, redeploy as-is.

--- a/web/internal/api/src/models/components/deploymentsourceimage.ts
+++ b/web/internal/api/src/models/components/deploymentsourceimage.ts
@@ -9,7 +9,7 @@ import * as z from "zod/v3";
  */
 export type DeploymentSourceImage = {
   /**
-   * Docker image to deploy as-is.
+   * Docker image to deploy as-is. Accepts a tag or a digest.
    */
   dockerImage: string;
 };

--- a/web/internal/api/src/models/components/v2deploycreatedeploymentrequestbody.ts
+++ b/web/internal/api/src/models/components/v2deploycreatedeploymentrequestbody.ts
@@ -34,7 +34,7 @@ export type V2DeployCreateDeploymentRequestBody = {
    */
   environmentSlug: string;
   /**
-   * Docker image reference to deploy
+   * Docker image reference to deploy. Accepts a tag or a digest.
    */
   dockerImage: string;
   /**


### PR DESCRIPTION
This PR mirrors for our ctrl and API https://github.com/unkeyed/unkey/pull/7199.


## Note

I'm not sure if making the direct is the right choice if we want we can vendor it ourselves. So its open to a discussion