### PR TITLE
refactor(ui): Pass ref as a prop instead of forwardRef

### DIFF
--- a/web/internal/ui/src/components/alert.tsx
+++ b/web/internal/ui/src/components/alert.tsx
@@ -1,5 +1,5 @@
 import { type VariantProps, cva } from "class-variance-authority";
-import * as React from "react";
+import type * as React from "react";
 
 import { cn } from "../lib/utils";
 
@@ -19,31 +19,38 @@ const alertVariants = cva(
   },
 );
 
-const Alert = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
->(({ className, variant, ...props }, ref) => (
-  <div ref={ref} role="alert" className={cn(alertVariants({ variant }), className)} {...props} />
-));
-Alert.displayName = "Alert";
+function Alert({
+  className,
+  variant,
+  ref,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement> &
+  VariantProps<typeof alertVariants> & { ref?: React.Ref<HTMLDivElement> }) {
+  return (
+    <div ref={ref} role="alert" className={cn(alertVariants({ variant }), className)} {...props} />
+  );
+}
 
-const AlertTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
-  ({ className, ...props }, ref) => (
+function AlertTitle({
+  className,
+  ref,
+  ...props
+}: React.HTMLAttributes<HTMLHeadingElement> & { ref?: React.Ref<HTMLParagraphElement> }) {
+  return (
     <h3
       ref={ref}
       className={cn("mb-1 font-medium leading-none tracking-tight ", className)}
       {...props}
     />
-  ),
-);
-AlertTitle.displayName = "AlertTitle";
+  );
+}
 
-const AlertDescription = React.forwardRef<
-  HTMLParagraphElement,
-  React.HTMLAttributes<HTMLParagraphElement>
->(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("text-sm [&_p]:leading-relaxed ", className)} {...props} />
-));
-AlertDescription.displayName = "AlertDescription";
+function AlertDescription({
+  className,
+  ref,
+  ...props
+}: React.HTMLAttributes<HTMLParagraphElement> & { ref?: React.Ref<HTMLParagraphElement> }) {
+  return <div ref={ref} className={cn("text-sm [&_p]:leading-relaxed ", className)} {...props} />;
+}
 
 export { Alert, AlertTitle, AlertDescription };

--- a/web/internal/ui/src/components/badge.tsx
+++ b/web/internal/ui/src/components/badge.tsx
@@ -1,8 +1,6 @@
-// biome-ignore lint: React in this context is used throughout, so biome will change to types because no APIs are used even though React is needed.
-import React from "react";
 import { type VariantProps, cva } from "class-variance-authority";
+import type * as React from "react";
 
-import { forwardRef } from "react";
 import { cn } from "../lib/utils";
 
 const badgeVariants = cva("inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs", {
@@ -30,18 +28,16 @@ const badgeVariants = cva("inline-flex items-center rounded-md border px-2.5 py-
 
 export interface BadgeProps
   extends React.HTMLAttributes<HTMLSpanElement>,
-    VariantProps<typeof badgeVariants> {}
+    VariantProps<typeof badgeVariants> {
+  ref?: React.Ref<HTMLSpanElement>;
+}
 
-const Badge = forwardRef<HTMLSpanElement, BadgeProps>(
-  ({ className, variant, size, font, children, ...props }, ref) => {
-    return (
-      <span ref={ref} className={cn(badgeVariants({ variant, size, font }), className)} {...props}>
-        {children}
-      </span>
-    );
-  },
-);
-
-Badge.displayName = "Badge";
+function Badge({ className, variant, size, font, children, ref, ...props }: BadgeProps) {
+  return (
+    <span ref={ref} className={cn(badgeVariants({ variant, size, font }), className)} {...props}>
+      {children}
+    </span>
+  );
+}
 
 export { Badge, badgeVariants };

--- a/web/internal/ui/src/components/buttons/button.tsx
+++ b/web/internal/ui/src/components/buttons/button.tsx
@@ -281,6 +281,7 @@ export type ButtonProps = VariantProps<typeof buttonVariants> &
      * Optional label for screen readers when in loading state
      */
     loadingLabel?: string;
+    ref?: React.Ref<HTMLButtonElement>;
   };
 
 const keyboardIconVariants = cva(
@@ -313,94 +314,72 @@ const VARIANT_MAP: Record<string, { variant: ButtonVariant; color?: ButtonColor 
   destructive: { variant: "primary", color: "danger" },
 };
 
-const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  (
-    {
-      className,
-      variant,
-      color = "default",
-      size,
-      render,
-      loading,
-      disabled,
-      loadingLabel = "Loading, please wait",
-      ...props
-    },
-    ref,
-  ) => {
-    let mappedVariant: ButtonVariant = "primary";
-    let mappedColor: ButtonColor = color;
-    if (variant === null || variant === undefined) {
-      mappedVariant = "primary";
-    } else if (VARIANT_MAP[variant as keyof typeof VARIANT_MAP]) {
-      const mapping = VARIANT_MAP[variant as keyof typeof VARIANT_MAP];
-      mappedVariant = mapping.variant;
-      if (mapping.color) {
-        mappedColor = mapping.color;
-      }
-    } else {
-      mappedVariant = variant as ButtonVariant;
+function Button({
+  className,
+  variant,
+  color = "default",
+  size,
+  render,
+  loading,
+  disabled,
+  loadingLabel = "Loading, please wait",
+  ref,
+  ...props
+}: ButtonProps) {
+  let mappedVariant: ButtonVariant = "primary";
+  let mappedColor: ButtonColor = color;
+  if (variant === null || variant === undefined) {
+    mappedVariant = "primary";
+  } else if (VARIANT_MAP[variant as keyof typeof VARIANT_MAP]) {
+    const mapping = VARIANT_MAP[variant as keyof typeof VARIANT_MAP];
+    mappedVariant = mapping.variant;
+    if (mapping.color) {
+      mappedColor = mapping.color;
     }
-    // Only disable the click behavior, not the visual appearance
-    const isClickDisabled = disabled || loading;
-    // Keep separate flag for actual visual disabled state
-    const isVisuallyDisabled = disabled;
-    // Width reference for consistent sizing during loading state
-    const buttonRef = React.useRef<HTMLButtonElement>(null);
-    const [buttonWidth, setButtonWidth] = React.useState<number | undefined>(undefined);
-    // Capture initial width when entering loading state
-    React.useEffect(() => {
-      if (loading && buttonRef.current && !buttonWidth) {
-        setButtonWidth(buttonRef.current.offsetWidth);
-      } else if (!loading) {
-        setButtonWidth(undefined);
-      }
-    }, [loading, buttonWidth]);
-    // Keyboard handler
-    React.useEffect(() => {
-      if (!props.keyboard || isClickDisabled) {
+  } else {
+    mappedVariant = variant as ButtonVariant;
+  }
+  // Only disable the click behavior, not the visual appearance
+  const isClickDisabled = disabled || loading;
+  // Keep separate flag for actual visual disabled state
+  const isVisuallyDisabled = disabled;
+  // Width reference for consistent sizing during loading state
+  const buttonRef = React.useRef<HTMLButtonElement>(null);
+  const [buttonWidth, setButtonWidth] = React.useState<number | undefined>(undefined);
+  // Capture initial width when entering loading state
+  React.useEffect(() => {
+    if (loading && buttonRef.current && !buttonWidth) {
+      setButtonWidth(buttonRef.current.offsetWidth);
+    } else if (!loading) {
+      setButtonWidth(undefined);
+    }
+  }, [loading, buttonWidth]);
+  // Keyboard handler
+  React.useEffect(() => {
+    if (!props.keyboard || isClickDisabled) {
+      return;
+    }
+    const down = (e: KeyboardEvent) => {
+      if (!props.keyboard?.trigger(e)) {
         return;
       }
-      const down = (e: KeyboardEvent) => {
-        if (!props.keyboard?.trigger(e)) {
-          return;
-        }
-        e.preventDefault();
-        props.keyboard?.callback(e);
-      };
-      document.addEventListener("keydown", down);
-      return () => document.removeEventListener("keydown", down);
-    }, [props.keyboard, isClickDisabled]);
+      e.preventDefault();
+      props.keyboard?.callback(e);
+    };
+    document.addEventListener("keydown", down);
+    return () => document.removeEventListener("keydown", down);
+  }, [props.keyboard, isClickDisabled]);
 
-    // When `render` is provided (custom element/component, typically a link),
-    // compose it directly with the button's visual classes — no Base UI Button
-    // primitive, so the link keeps link semantics (no role="button", no
-    // synthetic keyboard handlers, no disabled-button behavior). Only the
-    // children render — the loading spinner and keyboard hint are omitted,
-    // matching the previous `asChild` behavior.
-    if (render) {
-      return (
-        <ButtonRenderSlot
-          render={render as React.ReactElement}
-          className={cn(
-            buttonVariants({
-              variant: mappedVariant,
-              color: mappedColor,
-              size,
-              className,
-            }),
-          )}
-          onClick={loading ? undefined : props.onClick}
-          aria-disabled={isClickDisabled || undefined}
-          aria-busy={loading || undefined}
-          ref={ref as React.Ref<HTMLElement>}
-          {...(props as React.HTMLAttributes<HTMLElement>)}
-        />
-      );
-    }
-
+  // When `render` is provided (custom element/component, typically a link),
+  // compose it directly with the button's visual classes — no Base UI Button
+  // primitive, so the link keeps link semantics (no role="button", no
+  // synthetic keyboard handlers, no disabled-button behavior). Only the
+  // children render — the loading spinner and keyboard hint are omitted,
+  // matching the previous `asChild` behavior.
+  if (render) {
     return (
-      <ButtonPrimitive
+      <ButtonRenderSlot
+        render={render as React.ReactElement}
         className={cn(
           buttonVariants({
             variant: mappedVariant,
@@ -410,48 +389,66 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
           }),
         )}
         onClick={loading ? undefined : props.onClick}
-        disabled={isVisuallyDisabled} // Only apply disabled attribute when explicitly disabled
-        aria-disabled={isClickDisabled} // For accessibility, still indicate it can't be clicked
-        aria-busy={loading}
-        ref={ref}
-        {...props}
-      >
-        {loading && (
-          <div
-            className="absolute inset-0 flex items-center justify-center w-full h-full transition-opacity duration-200"
-            aria-hidden="true"
-          >
-            <AnimatedLoadingSpinner />
-            <span className="sr-only">{loadingLabel}</span>
-          </div>
-        )}
-        <div
-          className={cn(
-            "w-full h-full flex items-center justify-center gap-2 transition-opacity duration-200",
-            {
-              "opacity-0": loading,
-              "opacity-100": !loading,
-            },
-          )}
-        >
-          {props.children}
-          {props.keyboard ? (
-            <kbd
-              className={cn(
-                keyboardIconVariants({
-                  variant:
-                    variant === "primary" ? "primary" : variant === "outline" ? "default" : "ghost",
-                }),
-              )}
-            >
-              {props.keyboard.display}
-            </kbd>
-          ) : null}{" "}
-        </div>
-      </ButtonPrimitive>
+        aria-disabled={isClickDisabled || undefined}
+        aria-busy={loading || undefined}
+        ref={ref as React.Ref<HTMLElement>}
+        {...(props as React.HTMLAttributes<HTMLElement>)}
+      />
     );
-  },
-);
+  }
+
+  return (
+    <ButtonPrimitive
+      className={cn(
+        buttonVariants({
+          variant: mappedVariant,
+          color: mappedColor,
+          size,
+          className,
+        }),
+      )}
+      onClick={loading ? undefined : props.onClick}
+      disabled={isVisuallyDisabled} // Only apply disabled attribute when explicitly disabled
+      aria-disabled={isClickDisabled} // For accessibility, still indicate it can't be clicked
+      aria-busy={loading}
+      ref={ref}
+      {...props}
+    >
+      {loading && (
+        <div
+          className="absolute inset-0 flex items-center justify-center w-full h-full transition-opacity duration-200"
+          aria-hidden="true"
+        >
+          <AnimatedLoadingSpinner />
+          <span className="sr-only">{loadingLabel}</span>
+        </div>
+      )}
+      <div
+        className={cn(
+          "w-full h-full flex items-center justify-center gap-2 transition-opacity duration-200",
+          {
+            "opacity-0": loading,
+            "opacity-100": !loading,
+          },
+        )}
+      >
+        {props.children}
+        {props.keyboard ? (
+          <kbd
+            className={cn(
+              keyboardIconVariants({
+                variant:
+                  variant === "primary" ? "primary" : variant === "outline" ? "default" : "ghost",
+              }),
+            )}
+          >
+            {props.keyboard.display}
+          </kbd>
+        ) : null}{" "}
+      </div>
+    </ButtonPrimitive>
+  );
+}
 
 // Add CSS for respecting reduced motion preference and adding the spin-slow animation
 if (typeof document !== "undefined") {
@@ -479,7 +476,5 @@ if (typeof document !== "undefined") {
   `;
   document.head.appendChild(style);
 }
-
-Button.displayName = "Button";
 
 export { Button, buttonVariants };

--- a/web/internal/ui/src/components/buttons/copy-button.tsx
+++ b/web/internal/ui/src/components/buttons/copy-button.tsx
@@ -18,62 +18,68 @@ type CopyButtonProps = ButtonProps & {
    * toast message to show when copied
    */
   toastMessage?: string;
+  ref?: React.Ref<HTMLButtonElement>;
 };
 
 async function copyToClipboardWithMeta(value: string, _meta?: Record<string, unknown>) {
   await navigator.clipboard.writeText(value);
 }
 
-export const CopyButton = React.forwardRef<HTMLButtonElement, CopyButtonProps>(
-  ({ value, src, variant = "outline", className, toastMessage, onClick, ...props }, ref) => {
-    const [copied, setCopied] = React.useState(false);
+export function CopyButton({
+  value,
+  src,
+  variant = "outline",
+  className,
+  toastMessage,
+  onClick,
+  ref,
+  ...props
+}: CopyButtonProps) {
+  const [copied, setCopied] = React.useState(false);
 
-    React.useEffect(() => {
-      if (!copied) {
-        return;
-      }
-      const timer = setTimeout(() => {
-        setCopied(false);
-      }, 2000);
-      return () => clearTimeout(timer);
-    }, [copied]);
+  React.useEffect(() => {
+    if (!copied) {
+      return;
+    }
+    const timer = setTimeout(() => {
+      setCopied(false);
+    }, 2000);
+    return () => clearTimeout(timer);
+  }, [copied]);
 
-    return (
-      <Button
-        {...props}
-        ref={ref}
-        type="button"
-        variant={variant}
-        title="Copy to clipboard"
-        size="icon"
-        className={cn("focus:ring-0 focus:border-grayA-6 secret p-0", className)}
-        onClick={async (e) => {
-          if (!e.defaultPrevented) {
-            e.stopPropagation(); // Prevent triggering parent button click
-            try {
-              await copyToClipboardWithMeta(value, {
-                component: src,
-              });
-              toast.success("Copied to clipboard", {
-                description: toastMessage,
-              });
-              setCopied(true);
-            } catch (e) {
-              toast.error("Failed to copy to clipboard", {
-                description: e instanceof Error ? e.message : "Unknown error",
-              });
-            }
-            // Call the onClick prop if provided
-            onClick?.(e);
+  return (
+    <Button
+      {...props}
+      ref={ref}
+      type="button"
+      variant={variant}
+      title="Copy to clipboard"
+      size="icon"
+      className={cn("focus:ring-0 focus:border-grayA-6 secret p-0", className)}
+      onClick={async (e) => {
+        if (!e.defaultPrevented) {
+          e.stopPropagation(); // Prevent triggering parent button click
+          try {
+            await copyToClipboardWithMeta(value, {
+              component: src,
+            });
+            toast.success("Copied to clipboard", {
+              description: toastMessage,
+            });
+            setCopied(true);
+          } catch (e) {
+            toast.error("Failed to copy to clipboard", {
+              description: e instanceof Error ? e.message : "Unknown error",
+            });
           }
-        }}
-        aria-label="Copy to clipboard"
-      >
-        <span className="sr-only">Copy</span>
-        {copied ? <TaskChecked /> : <TaskUnchecked />}
-      </Button>
-    );
-  },
-);
-
-CopyButton.displayName = "CopyButton";
+          // Call the onClick prop if provided
+          onClick?.(e);
+        }
+      }}
+      aria-label="Copy to clipboard"
+    >
+      <span className="sr-only">Copy</span>
+      {copied ? <TaskChecked /> : <TaskUnchecked />}
+    </Button>
+  );
+}

--- a/web/internal/ui/src/components/card.tsx
+++ b/web/internal/ui/src/components/card.tsx
@@ -1,58 +1,73 @@
-import * as React from "react";
+import type * as React from "react";
 
 import { cn } from "../lib/utils";
 
-const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
+function Card({
+  className,
+  ref,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement> & { ref?: React.Ref<HTMLDivElement> }) {
+  return (
     <div
       ref={ref}
       className={cn("w-full rounded-lg border bg-background border-border ", className)}
       {...props}
     />
-  ),
-);
-Card.displayName = "Card";
+  );
+}
 
-const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
+function CardHeader({
+  className,
+  ref,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement> & { ref?: React.Ref<HTMLDivElement> }) {
+  return (
     <div ref={ref} className={cn("flex flex-col space-y-1.5 p-6 pb-0", className)} {...props} />
-  ),
-);
-CardHeader.displayName = "CardHeader";
+  );
+}
 
-const CardTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
-  ({ className, ...props }, ref) => (
+function CardTitle({
+  className,
+  ref,
+  ...props
+}: React.HTMLAttributes<HTMLHeadingElement> & { ref?: React.Ref<HTMLParagraphElement> }) {
+  return (
     <h2
       ref={ref}
       className={cn("text-2xl font-semibold leading-none tracking-tight pb-1", className)}
       {...props}
     />
-  ),
-);
-CardTitle.displayName = "CardTitle";
+  );
+}
 
-const CardDescription = React.forwardRef<
-  HTMLParagraphElement,
-  React.HTMLAttributes<HTMLParagraphElement>
->(({ className, ...props }, ref) => (
-  <p ref={ref} className={cn("text-sm text-content-subtle", className)} {...props} />
-));
-CardDescription.displayName = "CardDescription";
+function CardDescription({
+  className,
+  ref,
+  ...props
+}: React.HTMLAttributes<HTMLParagraphElement> & { ref?: React.Ref<HTMLParagraphElement> }) {
+  return <p ref={ref} className={cn("text-sm text-content-subtle", className)} {...props} />;
+}
 
-const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => <div ref={ref} className={cn("p-6", className)} {...props} />,
-);
-CardContent.displayName = "CardContent";
+function CardContent({
+  className,
+  ref,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement> & { ref?: React.Ref<HTMLDivElement> }) {
+  return <div ref={ref} className={cn("p-6", className)} {...props} />;
+}
 
-const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
+function CardFooter({
+  className,
+  ref,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement> & { ref?: React.Ref<HTMLDivElement> }) {
+  return (
     <div
       ref={ref}
       className={cn(" flex items-center px-6 py-3 mt-3 border-t border-border", className)}
       {...props}
     />
-  ),
-);
-CardFooter.displayName = "CardFooter";
+  );
+}
 
 export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent };

--- a/web/internal/ui/src/components/circle-progress.tsx
+++ b/web/internal/ui/src/components/circle-progress.tsx
@@ -1,9 +1,7 @@
-// biome-ignore lint: React in this context is used throughout, so biome will change to types because no APIs are used even though React is needed.
-import * as React from "react";
-import { type VariantProps, cva } from "class-variance-authority";
-import { forwardRef } from "react";
-import { cn } from "../lib/utils";
 import { type iconSize as IconSize, sizeMap } from "@unkey/icons";
+import { type VariantProps, cva } from "class-variance-authority";
+import type * as React from "react";
+import { cn } from "../lib/utils";
 
 const circleProgressVariants = cva("inline-flex items-center justify-center", {
   variants: {
@@ -36,6 +34,7 @@ type CircleProgressProps = React.HTMLAttributes<HTMLDivElement> & {
    * @example "sm-thin", "lg-bold", "xl-medium"
    */
   iconSize?: IconSize;
+  ref?: React.Ref<HTMLDivElement>;
 } & VariantProps<typeof circleProgressVariants>;
 
 /**
@@ -66,96 +65,100 @@ type CircleProgressProps = React.HTMLAttributes<HTMLDivElement> & {
  * />
  * ```
  */
-export const CircleProgress = forwardRef<HTMLDivElement, CircleProgressProps>(
-  ({ value, total, iconSize = "md-regular", className, variant, ...props }, ref) => {
-    // Early error validation
-    if (total <= 0) {
-      throw new Error("CircleProgress: total must be greater than 0");
-    }
-    if (value < 0) {
-      throw new Error("CircleProgress: value cannot be negative");
-    }
-    if (!Number.isFinite(value) || !Number.isFinite(total)) {
-      throw new Error("CircleProgress: value and total must be finite numbers");
-    }
+export function CircleProgress({
+  value,
+  total,
+  iconSize = "md-regular",
+  className,
+  variant,
+  ref,
+  ...props
+}: CircleProgressProps) {
+  // Early error validation
+  if (total <= 0) {
+    throw new Error("CircleProgress: total must be greater than 0");
+  }
+  if (value < 0) {
+    throw new Error("CircleProgress: value cannot be negative");
+  }
+  if (!Number.isFinite(value) || !Number.isFinite(total)) {
+    throw new Error("CircleProgress: value and total must be finite numbers");
+  }
 
-    const { iconSize: actualSize, strokeWidth } = sizeMap[iconSize];
+  const { iconSize: actualSize, strokeWidth } = sizeMap[iconSize];
 
-    const radius = (actualSize - strokeWidth) / 2;
-    const circumference = radius * 2 * Math.PI;
-    const progress = Math.min((value / total) * 100, 100);
-    const strokeDasharray = circumference;
-    const strokeDashoffset = circumference - (progress / 100) * circumference;
-    const isComplete = value >= total;
+  const radius = (actualSize - strokeWidth) / 2;
+  const circumference = radius * 2 * Math.PI;
+  const progress = Math.min((value / total) * 100, 100);
+  const strokeDasharray = circumference;
+  const strokeDashoffset = circumference - (progress / 100) * circumference;
+  const isComplete = value >= total;
 
-    return (
-      <div ref={ref} className={cn(circleProgressVariants({ variant }), className)} {...props}>
-        <svg width={actualSize} height={actualSize} className="transform -rotate-90">
-          {/* Background circle */}
+  return (
+    <div ref={ref} className={cn(circleProgressVariants({ variant }), className)} {...props}>
+      <svg width={actualSize} height={actualSize} className="transform -rotate-90">
+        {/* Background circle */}
+        <circle
+          cx={actualSize / 2}
+          cy={actualSize / 2}
+          r={radius}
+          className="text-grayA-6"
+          stroke="currentColor"
+          strokeWidth={strokeWidth}
+          fill="none"
+        />
+        {/* Progress circle */}
+        <circle
+          cx={actualSize / 2}
+          cy={actualSize / 2}
+          r={radius}
+          className="progress-circle"
+          strokeWidth={strokeWidth}
+          stroke="currentColor"
+          fill="none"
+          strokeDasharray={strokeDasharray}
+          strokeDashoffset={strokeDashoffset}
+          strokeLinecap="round"
+          style={{
+            transition: "stroke-dashoffset 0.3s ease-in-out, opacity 0.2s ease-in-out",
+            opacity: isComplete ? 0 : 1,
+          }}
+        />
+        {/* Checkmark group */}
+        <g
+          style={{
+            transition: "opacity 0.2s ease-in-out",
+            opacity: isComplete ? 1 : 0,
+          }}
+        >
+          {/* Circle background for checkmark */}
           <circle
             cx={actualSize / 2}
             cy={actualSize / 2}
             r={radius}
-            className="text-grayA-6"
+            fill="none"
             stroke="currentColor"
             strokeWidth={strokeWidth}
-            fill="none"
+            strokeLinecap="square"
+            className="complete-circle"
           />
-          {/* Progress circle */}
-          <circle
-            cx={actualSize / 2}
-            cy={actualSize / 2}
-            r={radius}
-            className="progress-circle"
-            strokeWidth={strokeWidth}
+          {/* Checkmark path */}
+          <path
+            d={`M${actualSize * 0.292} ${actualSize * 0.542} l${
+              actualSize * 0.125
+            } ${actualSize * 0.125} l${actualSize * 0.292} -${actualSize * 0.333}`}
+            fill="none"
             stroke="currentColor"
-            fill="none"
-            strokeDasharray={strokeDasharray}
-            strokeDashoffset={strokeDashoffset}
-            strokeLinecap="round"
-            style={{
-              transition: "stroke-dashoffset 0.3s ease-in-out, opacity 0.2s ease-in-out",
-              opacity: isComplete ? 0 : 1,
-            }}
+            strokeWidth={strokeWidth}
+            strokeLinecap="square"
+            transform={`rotate(90 ${actualSize / 2} ${actualSize / 2})`}
+            className="complete-check"
           />
-          {/* Checkmark group */}
-          <g
-            style={{
-              transition: "opacity 0.2s ease-in-out",
-              opacity: isComplete ? 1 : 0,
-            }}
-          >
-            {/* Circle background for checkmark */}
-            <circle
-              cx={actualSize / 2}
-              cy={actualSize / 2}
-              r={radius}
-              fill="none"
-              stroke="currentColor"
-              strokeWidth={strokeWidth}
-              strokeLinecap="square"
-              className="complete-circle"
-            />
-            {/* Checkmark path */}
-            <path
-              d={`M${actualSize * 0.292} ${actualSize * 0.542} l${
-                actualSize * 0.125
-              } ${actualSize * 0.125} l${actualSize * 0.292} -${actualSize * 0.333}`}
-              fill="none"
-              stroke="currentColor"
-              strokeWidth={strokeWidth}
-              strokeLinecap="square"
-              transform={`rotate(90 ${actualSize / 2} ${actualSize / 2})`}
-              className="complete-check"
-            />
-          </g>
-        </svg>
-      </div>
-    );
-  },
-);
-
-CircleProgress.displayName = "CircleProgress";
+        </g>
+      </svg>
+    </div>
+  );
+}
 
 export { circleProgressVariants };
 export type { CircleProgressProps };

--- a/web/internal/ui/src/components/data-table/data-table.tsx
+++ b/web/internal/ui/src/components/data-table/data-table.tsx
@@ -3,10 +3,8 @@ import { flexRender } from "@tanstack/react-table";
 import {
   Fragment,
   type KeyboardEvent,
-  type ReactElement,
   type ReactNode,
   type Ref,
-  forwardRef,
   useCallback,
   useImperativeHandle,
   useMemo,
@@ -34,8 +32,9 @@ export type DataTableRef = {
 /**
  * Main DataTable component with TanStack Table + TanStack Virtual
  */
-function DataTableInner<TData>(props: DataTableProps<TData>, ref: Ref<DataTableRef>) {
+export function DataTable<TData>(props: DataTableProps<TData> & { ref?: Ref<DataTableRef> }) {
   const {
+    ref,
     data: historicData,
     realtimeData = [],
     columns,
@@ -436,10 +435,3 @@ function DataTableInner<TData>(props: DataTableProps<TData>, ref: Ref<DataTableR
     </div>
   );
 }
-
-/**
- * Exported DataTable component with proper generic type support
- */
-export const DataTable = forwardRef(DataTableInner) as <TData>(
-  props: DataTableProps<TData> & { ref?: Ref<DataTableRef> },
-) => ReactElement;

--- a/web/internal/ui/src/components/dialog/dialog.tsx
+++ b/web/internal/ui/src/components/dialog/dialog.tsx
@@ -84,17 +84,18 @@ const DialogPortal = DialogPrimitive.Portal;
 
 const DialogClose = DialogPrimitive.Close;
 
-const DialogOverlay = React.forwardRef<
-  React.ComponentRef<typeof DialogPrimitive.Backdrop>,
-  DialogPrimitive.Backdrop.Props & {
-    showCloseWarning?: boolean;
-    onAttemptClose?: () => void;
-  }
->(
-  (
-    { className, showCloseWarning: _showCloseWarning, onAttemptClose: _onAttemptClose, ...props },
-    ref,
-  ) => (
+function DialogOverlay({
+  className,
+  showCloseWarning: _showCloseWarning,
+  onAttemptClose: _onAttemptClose,
+  ref,
+  ...props
+}: DialogPrimitive.Backdrop.Props & {
+  showCloseWarning?: boolean;
+  onAttemptClose?: () => void;
+  ref?: React.Ref<React.ComponentRef<typeof DialogPrimitive.Backdrop>>;
+}) {
+  return (
     <DialogPrimitive.Backdrop
       ref={ref}
       className={cn(
@@ -103,106 +104,98 @@ const DialogOverlay = React.forwardRef<
       )}
       {...props}
     />
-  ),
-);
-DialogOverlay.displayName = "DialogOverlay";
+  );
+}
 
-const DialogContent = React.forwardRef<
-  React.ComponentRef<typeof DialogPrimitive.Popup>,
-  DialogPrimitive.Popup.Props & {
-    showCloseWarning?: boolean;
-    onAttemptClose?: () => void;
-    xButtonRef?: React.RefObject<HTMLButtonElement>;
-    preventOutsideClose?: boolean;
+function DialogContent({
+  className,
+  children,
+  showCloseWarning = false,
+  onAttemptClose,
+  xButtonRef,
+  preventOutsideClose = false,
+  ref,
+  ...props
+}: DialogPrimitive.Popup.Props & {
+  showCloseWarning?: boolean;
+  onAttemptClose?: () => void;
+  xButtonRef?: React.RefObject<HTMLButtonElement>;
+  preventOutsideClose?: boolean;
+  ref?: React.Ref<React.ComponentRef<typeof DialogPrimitive.Popup>>;
+}) {
+  const dismissRef = React.useContext(DialogDismissContext);
+  // Publish this content's dismiss preferences so the root `onOpenChange`
+  // handler can honour them (escape / outside-press / focus-out).
+  if (dismissRef) {
+    dismissRef.current = { showCloseWarning, onAttemptClose, preventOutsideClose };
   }
->(
-  (
-    {
-      className,
-      children,
-      showCloseWarning = false,
-      onAttemptClose,
-      xButtonRef,
-      preventOutsideClose = false,
-      ...props
-    },
-    ref,
-  ) => {
-    const dismissRef = React.useContext(DialogDismissContext);
-    // Publish this content's dismiss preferences so the root `onOpenChange`
-    // handler can honour them (escape / outside-press / focus-out).
-    if (dismissRef) {
-      dismissRef.current = { showCloseWarning, onAttemptClose, preventOutsideClose };
+
+  const handleCloseAttempt = React.useCallback(() => {
+    // This handler is now only called when showCloseWarning is true
+    if (showCloseWarning) {
+      onAttemptClose?.();
     }
+  }, [showCloseWarning, onAttemptClose]);
 
-    const handleCloseAttempt = React.useCallback(() => {
-      // This handler is now only called when showCloseWarning is true
-      if (showCloseWarning) {
-        onAttemptClose?.();
-      }
-    }, [showCloseWarning, onAttemptClose]);
+  // Common class names for both button types
+  const buttonClassNames =
+    "absolute right-4 top-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:rounded-lg disabled:pointer-events-none data-open:bg-accent text-muted-foreground z-51 [&_svg]:size-[14px] hover:rounded-lg";
 
-    // Common class names for both button types
-    const buttonClassNames =
-      "absolute right-4 top-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:rounded-lg disabled:pointer-events-none data-open:bg-accent text-muted-foreground z-51 [&_svg]:size-[14px] hover:rounded-lg";
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Popup
+        ref={ref}
+        className={cn(
+          "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 transition-[opacity,scale,translate] data-starting-style:opacity-0 data-starting-style:scale-95 data-ending-style:opacity-0 data-ending-style:scale-95 sm:rounded-lg",
+          className,
+        )}
+        onKeyDown={(e) => {
+          // Allow keyboard navigation for nested interactive elements
+          if (e.key === "ArrowDown" || e.key === "ArrowUp" || e.key === "Enter") {
+            // Let these events propagate to nested components like Combobox
+            return;
+          }
+          // Prevent Tab key from closing the dialog
+          if (e.key === "Tab") {
+            e.stopPropagation();
+          }
+        }}
+        {...props}
+      >
+        {children}
 
-    return (
-      <DialogPortal>
-        <DialogOverlay />
-        <DialogPrimitive.Popup
-          ref={ref}
-          className={cn(
-            "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 transition-[opacity,scale,translate] data-starting-style:opacity-0 data-starting-style:scale-95 data-ending-style:opacity-0 data-ending-style:scale-95 sm:rounded-lg",
-            className,
-          )}
-          onKeyDown={(e) => {
-            // Allow keyboard navigation for nested interactive elements
-            if (e.key === "ArrowDown" || e.key === "ArrowUp" || e.key === "Enter") {
-              // Let these events propagate to nested components like Combobox
-              return;
+        {/* Conditionally render the close button */}
+        {showCloseWarning ? (
+          <button
+            ref={xButtonRef} // Attach ref only needed for anchoring the custom popover
+            type="button"
+            onClick={handleCloseAttempt} // Call attempt handler
+            className={buttonClassNames}
+            aria-label="Close dialog with confirmation"
+          >
+            <XMark iconSize="md-medium" />
+          </button>
+        ) : (
+          // Use DialogPrimitive.Close for standard behavior
+          <DialogPrimitive.Close
+            render={
+              <Button
+                size="icon"
+                variant="ghost"
+                type="button"
+                className={buttonClassNames}
+                aria-label="Close dialog"
+              >
+                <XMark iconSize="md-medium" />
+              </Button>
             }
-            // Prevent Tab key from closing the dialog
-            if (e.key === "Tab") {
-              e.stopPropagation();
-            }
-          }}
-          {...props}
-        >
-          {children}
-
-          {/* Conditionally render the close button */}
-          {showCloseWarning ? (
-            <button
-              ref={xButtonRef} // Attach ref only needed for anchoring the custom popover
-              type="button"
-              onClick={handleCloseAttempt} // Call attempt handler
-              className={buttonClassNames}
-              aria-label="Close dialog with confirmation"
-            >
-              <XMark iconSize="md-medium" />
-            </button>
-          ) : (
-            // Use DialogPrimitive.Close for standard behavior
-            <DialogPrimitive.Close
-              render={
-                <Button
-                  size="icon"
-                  variant="ghost"
-                  type="button"
-                  className={buttonClassNames}
-                  aria-label="Close dialog"
-                >
-                  <XMark iconSize="md-medium" />
-                </Button>
-              }
-            />
-          )}
-        </DialogPrimitive.Popup>
-      </DialogPortal>
-    );
-  },
-);
-DialogContent.displayName = "DialogContent";
+          />
+        )}
+      </DialogPrimitive.Popup>
+    </DialogPortal>
+  );
+}
 
 const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
   <div className={cn("flex flex-col space-y-1.5 text-center sm:text-left", className)} {...props} />
@@ -217,29 +210,37 @@ const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivEleme
 );
 DialogFooter.displayName = "DialogFooter";
 
-const DialogTitle = React.forwardRef<
-  React.ComponentRef<typeof DialogPrimitive.Title>,
-  DialogPrimitive.Title.Props
->(({ className, ...props }, ref) => (
-  <DialogPrimitive.Title
-    ref={ref}
-    className={cn("text-lg font-semibold leading-none tracking-tight", className)}
-    {...props}
-  />
-));
-DialogTitle.displayName = "DialogTitle";
+function DialogTitle({
+  className,
+  ref,
+  ...props
+}: DialogPrimitive.Title.Props & {
+  ref?: React.Ref<React.ComponentRef<typeof DialogPrimitive.Title>>;
+}) {
+  return (
+    <DialogPrimitive.Title
+      ref={ref}
+      className={cn("text-lg font-semibold leading-none tracking-tight", className)}
+      {...props}
+    />
+  );
+}
 
-const DialogDescription = React.forwardRef<
-  React.ComponentRef<typeof DialogPrimitive.Description>,
-  DialogPrimitive.Description.Props
->(({ className, ...props }, ref) => (
-  <DialogPrimitive.Description
-    ref={ref}
-    className={cn("text-sm text-content-subtle", className)}
-    {...props}
-  />
-));
-DialogDescription.displayName = "DialogDescription";
+function DialogDescription({
+  className,
+  ref,
+  ...props
+}: DialogPrimitive.Description.Props & {
+  ref?: React.Ref<React.ComponentRef<typeof DialogPrimitive.Description>>;
+}) {
+  return (
+    <DialogPrimitive.Description
+      ref={ref}
+      className={cn("text-sm text-content-subtle", className)}
+      {...props}
+    />
+  );
+}
 
 export {
   Dialog,

--- a/web/internal/ui/src/components/dialog/popover.tsx
+++ b/web/internal/ui/src/components/dialog/popover.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Popover as PopoverPrimitive } from "@base-ui/react/popover";
-import * as React from "react";
+import type * as React from "react";
 import { cn } from "../../lib/utils";
 
 const Popover = PopoverPrimitive.Root;
@@ -17,35 +17,44 @@ type PopoverContentProps = PopoverPrimitive.Popup.Props &
   Pick<
     PopoverPrimitive.Positioner.Props,
     "align" | "alignOffset" | "side" | "sideOffset" | "anchor"
-  >;
+  > & {
+    ref?: React.Ref<React.ComponentRef<typeof PopoverPrimitive.Popup>>;
+  };
 
-const PopoverContent = React.forwardRef<
-  React.ComponentRef<typeof PopoverPrimitive.Popup>,
-  PopoverContentProps
->(({ className, align = "center", alignOffset, side, sideOffset = 4, anchor, ...props }, ref) => (
-  <PopoverPrimitive.Portal>
-    <PopoverPrimitive.Positioner
-      className="isolate z-200"
-      align={align}
-      alignOffset={alignOffset}
-      side={side}
-      sideOffset={sideOffset}
-      anchor={anchor}
-    >
-      <PopoverPrimitive.Popup
-        ref={ref}
-        className={cn(
-          "z-200 w-72 rounded-lg border border-grayA-4 bg-gray-2 p-4 text-gray-12 shadow-md outline-none",
-          "transition-[opacity,scale,translate] data-starting-style:opacity-0 data-starting-style:scale-95 data-ending-style:opacity-0 data-ending-style:scale-95",
-          "data-[side=bottom]:data-starting-style:-translate-y-2 data-[side=left]:data-starting-style:translate-x-2 data-[side=right]:data-starting-style:-translate-x-2 data-[side=top]:data-starting-style:translate-y-2",
-          className,
-        )}
-        {...props}
-      />
-    </PopoverPrimitive.Positioner>
-  </PopoverPrimitive.Portal>
-));
-PopoverContent.displayName = "PopoverContent";
+function PopoverContent({
+  className,
+  align = "center",
+  alignOffset,
+  side,
+  sideOffset = 4,
+  anchor,
+  ref,
+  ...props
+}: PopoverContentProps) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Positioner
+        className="isolate z-200"
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+        anchor={anchor}
+      >
+        <PopoverPrimitive.Popup
+          ref={ref}
+          className={cn(
+            "z-200 w-72 rounded-lg border border-grayA-4 bg-gray-2 p-4 text-gray-12 shadow-md outline-none",
+            "transition-[opacity,scale,translate] data-starting-style:opacity-0 data-starting-style:scale-95 data-ending-style:opacity-0 data-ending-style:scale-95",
+            "data-[side=bottom]:data-starting-style:-translate-y-2 data-[side=left]:data-starting-style:translate-x-2 data-[side=right]:data-starting-style:-translate-x-2 data-[side=top]:data-starting-style:translate-y-2",
+            className,
+          )}
+          {...props}
+        />
+      </PopoverPrimitive.Positioner>
+    </PopoverPrimitive.Portal>
+  );
+}
 
 export { Popover, PopoverTrigger, PopoverClose, PopoverContent };
 export type { PopoverContentProps };

--- a/web/internal/ui/src/components/drawer.tsx
+++ b/web/internal/ui/src/components/drawer.tsx
@@ -4,7 +4,7 @@
  * Imports
  * ----------------------------------------------------------------------------*/
 
-import * as React from "react";
+import type * as React from "react";
 import { Drawer as Vaul } from "vaul";
 import { cn } from "../lib/utils";
 
@@ -24,13 +24,11 @@ const DrawerNested = Vaul.NestedRoot;
  * Drawer - Content
  * ---------------------------------------------------------------------------*/
 
-const CONTENT_NAME = "DrawerContent";
-
 type DrawerContentElement = React.ElementRef<typeof Vaul.Content>;
 type DrawerContentProps = React.ComponentPropsWithoutRef<typeof Vaul.Content>;
 
-const DrawerContent = React.forwardRef<DrawerContentElement, DrawerContentProps>((props, ref) => {
-  const { className, children, ...contentProps } = props;
+function DrawerContent(props: DrawerContentProps & { ref?: React.Ref<DrawerContentElement> }) {
+  const { className, children, ref, ...contentProps } = props;
 
   return (
     <DrawerPortal>
@@ -47,9 +45,7 @@ const DrawerContent = React.forwardRef<DrawerContentElement, DrawerContentProps>
       </Vaul.Content>
     </DrawerPortal>
   );
-});
-
-DrawerContent.displayName = CONTENT_NAME;
+}
 
 /* ----------------------------------------------------------------------------
  * Exports

--- a/web/internal/ui/src/components/drover.tsx
+++ b/web/internal/ui/src/components/drover.tsx
@@ -2,7 +2,7 @@
 
 import { mergeProps } from "@base-ui/react/merge-props";
 import { useRender } from "@base-ui/react/use-render";
-import React from "react";
+import type React from "react";
 import { useControllableState } from "../hooks/use-controllable-state";
 import { useIsMobile } from "../hooks/use-mobile";
 import { createContext } from "../lib/create-context";
@@ -66,8 +66,8 @@ type TriggerProps = PrimitiveButtonProps & {
 };
 const TRIGGER_NAME = "Trigger";
 
-const Trigger = React.forwardRef<PrimitiveButtonElement, TriggerProps>((props, ref) => {
-  const { children, asChild = false, ...triggerProps } = props;
+function Trigger(props: TriggerProps & { ref?: React.Ref<PrimitiveButtonElement> }) {
+  const { children, asChild = false, ref, ...triggerProps } = props;
   const { isMobile } = useDroverContext(TRIGGER_NAME);
 
   // Mobile uses vaul (Radix-style `asChild`); desktop uses Base UI's Popover
@@ -96,9 +96,7 @@ const Trigger = React.forwardRef<PrimitiveButtonElement, TriggerProps>((props, r
       {children}
     </PopoverTrigger>
   );
-});
-
-Trigger.displayName = TRIGGER_NAME;
+}
 
 /* ----------------------------------------------------------------------------
  * Component Drover:Content
@@ -113,8 +111,8 @@ type ContentElement =
   | React.ElementRef<typeof Drawer.Content>;
 const CONTENT_NAME = "Content";
 
-const Content = React.forwardRef<ContentElement, ContentProps>((props, ref) => {
-  const { children, onKeyDown, className, onAnimationEnd, ...contentProps } = props;
+function Content(props: ContentProps & { ref?: React.Ref<ContentElement> }) {
+  const { children, onKeyDown, className, onAnimationEnd, ref, ...contentProps } = props;
   const { isMobile } = useDroverContext(CONTENT_NAME);
   const Component = isMobile ? Drawer.Content : PopoverContent;
 
@@ -132,9 +130,7 @@ const Content = React.forwardRef<ContentElement, ContentProps>((props, ref) => {
       {children}
     </Component>
   );
-});
-
-Content.displayName = CONTENT_NAME;
+}
 
 /* ----------------------------------------------------------------------------
  * Component Drover:Close
@@ -145,8 +141,8 @@ type CloseProps = PrimitiveButtonProps & {
 };
 const CLOSE_NAME = "Close";
 
-const Close = React.forwardRef<PrimitiveButtonElement, CloseProps>((props, ref) => {
-  const { children, asChild = false, ...closeProps } = props;
+function Close(props: CloseProps & { ref?: React.Ref<PrimitiveButtonElement> }) {
+  const { children, asChild = false, ref, ...closeProps } = props;
   const { onOpenChange } = useDroverContext(CLOSE_NAME);
 
   return useRender({
@@ -164,9 +160,7 @@ const Close = React.forwardRef<PrimitiveButtonElement, CloseProps>((props, ref) 
       asChild ? {} : ({ children } as React.ComponentProps<"button">),
     ),
   });
-});
-
-Close.displayName = CLOSE_NAME;
+}
 
 /* ----------------------------------------------------------------------------
  * Component Drover:Nested

--- a/web/internal/ui/src/components/form/checkbox.tsx
+++ b/web/internal/ui/src/components/form/checkbox.tsx
@@ -4,7 +4,7 @@ import { Checkbox as CheckboxPrimitive } from "@base-ui/react/checkbox";
 import { Check, Minus } from "@unkey/icons";
 import type { IconProps } from "@unkey/icons/src/props";
 import { type VariantProps, cva } from "class-variance-authority";
-import * as React from "react";
+import type * as React from "react";
 import { cn } from "../../lib/utils";
 
 const checkboxVariants = cva(
@@ -290,59 +290,64 @@ export type CheckboxProps = VariantProps<typeof checkboxVariants> &
      * Whether the checkbox is checked. Accepts `"indeterminate"` for the mixed state.
      */
     checked?: CheckedState;
+    ref?: React.Ref<React.ComponentRef<typeof CheckboxPrimitive.Root>>;
   };
 
-const Checkbox = React.forwardRef<React.ComponentRef<typeof CheckboxPrimitive.Root>, CheckboxProps>(
-  ({ className, variant, color = "default", size, checked, ...props }, ref) => {
-    let mappedVariant: CheckboxVariant = "primary";
-    let mappedColor: CheckboxColor = color;
+function Checkbox({
+  className,
+  variant,
+  color = "default",
+  size,
+  checked,
+  ref,
+  ...props
+}: CheckboxProps) {
+  let mappedVariant: CheckboxVariant = "primary";
+  let mappedColor: CheckboxColor = color;
 
-    if (variant === null || variant === undefined) {
-      mappedVariant = "primary";
-    } else if (VARIANT_MAP[variant as keyof typeof VARIANT_MAP]) {
-      const mapping = VARIANT_MAP[variant as keyof typeof VARIANT_MAP];
-      mappedVariant = mapping.variant;
-      if (mapping.color) {
-        mappedColor = mapping.color;
-      }
-    } else {
-      mappedVariant = variant as CheckboxVariant;
+  if (variant === null || variant === undefined) {
+    mappedVariant = "primary";
+  } else if (VARIANT_MAP[variant as keyof typeof VARIANT_MAP]) {
+    const mapping = VARIANT_MAP[variant as keyof typeof VARIANT_MAP];
+    mappedVariant = mapping.variant;
+    if (mapping.color) {
+      mappedColor = mapping.color;
     }
+  } else {
+    mappedVariant = variant as CheckboxVariant;
+  }
 
-    const iconSize = getIconSize(size);
+  const iconSize = getIconSize(size);
 
-    const checkmarkColor =
-      mappedColor === "default" && mappedVariant === "primary"
-        ? "text-white dark:text-black"
-        : "text-white";
+  const checkmarkColor =
+    mappedColor === "default" && mappedVariant === "primary"
+      ? "text-white dark:text-black"
+      : "text-white";
 
-    const indeterminate = checked === "indeterminate";
-    const checkedValue = checked === "indeterminate" ? false : checked;
+  const indeterminate = checked === "indeterminate";
+  const checkedValue = checked === "indeterminate" ? false : checked;
 
-    return (
-      <CheckboxPrimitive.Root
-        ref={ref}
-        checked={checkedValue}
-        indeterminate={indeterminate}
-        className={cn(
-          checkboxVariants({
-            variant: mappedVariant,
-            color: mappedColor,
-            size,
-            className,
-          }),
-        )}
-        {...props}
-      >
-        <CheckboxPrimitive.Indicator className={cn(checkmarkVariants(), checkmarkColor)}>
-          <Check iconSize={iconSize} className="hidden group-data-checked:block" />
-          <Minus iconSize={iconSize} className="hidden group-data-indeterminate:block" />
-        </CheckboxPrimitive.Indicator>
-      </CheckboxPrimitive.Root>
-    );
-  },
-);
-
-Checkbox.displayName = "Checkbox";
+  return (
+    <CheckboxPrimitive.Root
+      ref={ref}
+      checked={checkedValue}
+      indeterminate={indeterminate}
+      className={cn(
+        checkboxVariants({
+          variant: mappedVariant,
+          color: mappedColor,
+          size,
+          className,
+        }),
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator className={cn(checkmarkVariants(), checkmarkColor)}>
+        <Check iconSize={iconSize} className="hidden group-data-checked:block" />
+        <Minus iconSize={iconSize} className="hidden group-data-indeterminate:block" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  );
+}
 
 export { Checkbox, checkboxVariants };

--- a/web/internal/ui/src/components/form/form-checkbox.tsx
+++ b/web/internal/ui/src/components/form/form-checkbox.tsx
@@ -15,72 +15,68 @@ type DocumentedFormCheckboxProps = {
   descriptionPosition?: "inline" | "label";
 };
 
-type FormCheckboxProps = Omit<CheckboxProps, "size" | "variant" | "color"> &
-  DocumentedFormCheckboxProps;
+type FormCheckboxProps = Omit<CheckboxProps, "size" | "variant" | "color" | "ref"> &
+  DocumentedFormCheckboxProps & {
+    ref?: React.Ref<HTMLButtonElement>;
+  };
 
-const FormCheckbox = React.forwardRef<HTMLButtonElement, FormCheckboxProps>(
-  (
-    {
-      label,
-      description,
-      error,
-      requirement,
-      id,
-      className,
-      variant = "primary",
-      color,
-      size = "md",
-      descriptionPosition = "inline",
-      ...props
-    },
-    ref,
-  ) => {
-    const descriptionAsTooltip = descriptionPosition === "label";
-    const checkboxVariant = error ? "primary" : variant;
-    const checkboxColor = error ? "danger" : color;
-    const generatedId = React.useId();
-    const checkboxId = id || generatedId;
-    const descriptionId = `${checkboxId}-helper`;
-    const errorId = `${checkboxId}-error`;
+function FormCheckbox({
+  label,
+  description,
+  error,
+  requirement,
+  id,
+  className,
+  variant = "primary",
+  color,
+  size = "md",
+  descriptionPosition = "inline",
+  ref,
+  ...props
+}: FormCheckboxProps) {
+  const descriptionAsTooltip = descriptionPosition === "label";
+  const checkboxVariant = error ? "primary" : variant;
+  const checkboxColor = error ? "danger" : color;
+  const generatedId = React.useId();
+  const checkboxId = id || generatedId;
+  const descriptionId = `${checkboxId}-helper`;
+  const errorId = `${checkboxId}-error`;
 
-    return (
-      <fieldset className={cn("flex flex-col gap-1.5 border-0 m-0 p-0", className)}>
-        <div className="flex items-center gap-2">
-          <Checkbox
-            ref={ref}
-            id={checkboxId}
-            variant={checkboxVariant}
-            color={checkboxColor}
-            size={size}
-            aria-describedby={error ? errorId : description ? descriptionId : undefined}
-            aria-invalid={Boolean(error)}
-            aria-required={requirement === "required"}
-            {...props}
-          />
-          {label && (
-            <div className="flex flex-col gap-1">
-              <FormLabel
-                label={label}
-                requirement={requirement}
-                hasError={Boolean(error)}
-                htmlFor={checkboxId}
-                tooltipContent={descriptionAsTooltip ? description : undefined}
-              />
-            </div>
-          )}
-        </div>
-        <FormDescription
-          description={descriptionAsTooltip ? undefined : description}
-          error={error}
-          variant={color}
-          descriptionId={descriptionId}
-          errorId={errorId}
+  return (
+    <fieldset className={cn("flex flex-col gap-1.5 border-0 m-0 p-0", className)}>
+      <div className="flex items-center gap-2">
+        <Checkbox
+          ref={ref}
+          id={checkboxId}
+          variant={checkboxVariant}
+          color={checkboxColor}
+          size={size}
+          aria-describedby={error ? errorId : description ? descriptionId : undefined}
+          aria-invalid={Boolean(error)}
+          aria-required={requirement === "required"}
+          {...props}
         />
-      </fieldset>
-    );
-  },
-);
-
-FormCheckbox.displayName = "FormCheckbox";
+        {label && (
+          <div className="flex flex-col gap-1">
+            <FormLabel
+              label={label}
+              requirement={requirement}
+              hasError={Boolean(error)}
+              htmlFor={checkboxId}
+              tooltipContent={descriptionAsTooltip ? description : undefined}
+            />
+          </div>
+        )}
+      </div>
+      <FormDescription
+        description={descriptionAsTooltip ? undefined : description}
+        error={error}
+        variant={color}
+        descriptionId={descriptionId}
+        errorId={errorId}
+      />
+    </fieldset>
+  );
+}
 
 export { FormCheckbox, type FormCheckboxProps, type DocumentedFormCheckboxProps };

--- a/web/internal/ui/src/components/form/form-input.tsx
+++ b/web/internal/ui/src/components/form/form-input.tsx
@@ -12,60 +12,57 @@ type DocumentedFormInputProps = DocumentedInputProps & {
   descriptionPosition?: "inline" | "label";
 };
 
-type FormInputProps = InputProps & DocumentedFormInputProps;
+type FormInputProps = InputProps &
+  DocumentedFormInputProps & {
+    ref?: React.Ref<HTMLInputElement>;
+  };
 
-const FormInput = React.forwardRef<HTMLInputElement, FormInputProps>(
-  (
-    {
-      label,
-      description,
-      error,
-      requirement,
-      id,
-      className,
-      variant,
-      descriptionPosition = "inline",
-      ...props
-    },
-    ref,
-  ) => {
-    const descriptionAsTooltip = descriptionPosition === "label";
-    const inputVariant = error ? "error" : variant;
-    const generatedId = React.useId();
-    const inputId = id || generatedId;
-    const descriptionId = `${inputId}-helper`;
-    const errorId = `${inputId}-error`;
+function FormInput({
+  label,
+  description,
+  error,
+  requirement,
+  id,
+  className,
+  variant,
+  descriptionPosition = "inline",
+  ref,
+  ...props
+}: FormInputProps) {
+  const descriptionAsTooltip = descriptionPosition === "label";
+  const inputVariant = error ? "error" : variant;
+  const generatedId = React.useId();
+  const inputId = id || generatedId;
+  const descriptionId = `${inputId}-helper`;
+  const errorId = `${inputId}-error`;
 
-    return (
-      <fieldset className={cn("flex flex-col gap-1.5 border-0 m-0 p-0", className)}>
-        <FormLabel
-          label={label}
-          requirement={requirement}
-          hasError={Boolean(error)}
-          htmlFor={inputId}
-          tooltipContent={descriptionAsTooltip ? description : undefined}
-        />
-        <Input
-          ref={ref}
-          id={inputId}
-          variant={inputVariant}
-          aria-describedby={error ? errorId : description ? descriptionId : undefined}
-          aria-invalid={!!error}
-          aria-required={requirement === "required"}
-          {...props}
-        />
-        <FormDescription
-          description={descriptionAsTooltip ? undefined : description}
-          error={error}
-          variant={variant}
-          descriptionId={descriptionId}
-          errorId={errorId}
-        />
-      </fieldset>
-    );
-  },
-);
-
-FormInput.displayName = "FormInput";
+  return (
+    <fieldset className={cn("flex flex-col gap-1.5 border-0 m-0 p-0", className)}>
+      <FormLabel
+        label={label}
+        requirement={requirement}
+        hasError={Boolean(error)}
+        htmlFor={inputId}
+        tooltipContent={descriptionAsTooltip ? description : undefined}
+      />
+      <Input
+        ref={ref}
+        id={inputId}
+        variant={inputVariant}
+        aria-describedby={error ? errorId : description ? descriptionId : undefined}
+        aria-invalid={!!error}
+        aria-required={requirement === "required"}
+        {...props}
+      />
+      <FormDescription
+        description={descriptionAsTooltip ? undefined : description}
+        error={error}
+        variant={variant}
+        descriptionId={descriptionId}
+        errorId={errorId}
+      />
+    </fieldset>
+  );
+}
 
 export { FormInput, type FormInputProps, type DocumentedFormInputProps };

--- a/web/internal/ui/src/components/form/form-textarea.tsx
+++ b/web/internal/ui/src/components/form/form-textarea.tsx
@@ -12,67 +12,64 @@ type DocumentedFormTextareaProps = DocumentedTextareaProps & {
   descriptionPosition?: "inline" | "label";
 };
 
-type FormTextareaProps = TextareaProps & DocumentedFormTextareaProps;
+type FormTextareaProps = TextareaProps &
+  DocumentedFormTextareaProps & {
+    ref?: React.Ref<HTMLTextAreaElement>;
+  };
 
-const FormTextarea = React.forwardRef<HTMLTextAreaElement, FormTextareaProps>(
-  (
-    {
-      label,
-      description,
-      error,
-      requirement,
-      id,
-      className,
-      variant,
-      leftIcon,
-      rightIcon,
-      wrapperClassName,
-      descriptionPosition = "inline",
-      ...props
-    },
-    ref,
-  ) => {
-    const descriptionAsTooltip = descriptionPosition === "label";
-    const textareaVariant = error ? "error" : variant;
-    const generatedId = React.useId();
-    const textareaId = id || generatedId;
-    const descriptionId = `${textareaId}-helper`;
-    const errorId = `${textareaId}-error`;
+function FormTextarea({
+  label,
+  description,
+  error,
+  requirement,
+  id,
+  className,
+  variant,
+  leftIcon,
+  rightIcon,
+  wrapperClassName,
+  descriptionPosition = "inline",
+  ref,
+  ...props
+}: FormTextareaProps) {
+  const descriptionAsTooltip = descriptionPosition === "label";
+  const textareaVariant = error ? "error" : variant;
+  const generatedId = React.useId();
+  const textareaId = id || generatedId;
+  const descriptionId = `${textareaId}-helper`;
+  const errorId = `${textareaId}-error`;
 
-    return (
-      <fieldset className={cn("flex flex-col gap-1.5 border-0 m-0 p-0", className)}>
-        <FormLabel
-          label={label}
-          requirement={requirement}
-          hasError={!!error}
-          htmlFor={textareaId}
-          tooltipContent={descriptionAsTooltip ? description : undefined}
-        />
+  return (
+    <fieldset className={cn("flex flex-col gap-1.5 border-0 m-0 p-0", className)}>
+      <FormLabel
+        label={label}
+        requirement={requirement}
+        hasError={!!error}
+        htmlFor={textareaId}
+        tooltipContent={descriptionAsTooltip ? description : undefined}
+      />
 
-        <Textarea
-          ref={ref}
-          id={textareaId}
-          variant={textareaVariant}
-          leftIcon={leftIcon}
-          rightIcon={rightIcon}
-          wrapperClassName={wrapperClassName}
-          aria-describedby={error ? errorId : description ? descriptionId : undefined}
-          aria-invalid={!!error}
-          aria-required={requirement === "required"}
-          {...props}
-        />
-        <FormDescription
-          description={descriptionAsTooltip ? undefined : description}
-          error={error}
-          variant={variant}
-          descriptionId={descriptionId}
-          errorId={errorId}
-        />
-      </fieldset>
-    );
-  },
-);
-
-FormTextarea.displayName = "FormTextarea";
+      <Textarea
+        ref={ref}
+        id={textareaId}
+        variant={textareaVariant}
+        leftIcon={leftIcon}
+        rightIcon={rightIcon}
+        wrapperClassName={wrapperClassName}
+        aria-describedby={error ? errorId : description ? descriptionId : undefined}
+        aria-invalid={!!error}
+        aria-required={requirement === "required"}
+        {...props}
+      />
+      <FormDescription
+        description={descriptionAsTooltip ? undefined : description}
+        error={error}
+        variant={variant}
+        descriptionId={descriptionId}
+        errorId={errorId}
+      />
+    </fieldset>
+  );
+}
 
 export { FormTextarea, type FormTextareaProps, type DocumentedFormTextareaProps };

--- a/web/internal/ui/src/components/form/select.tsx
+++ b/web/internal/ui/src/components/form/select.tsx
@@ -3,7 +3,7 @@
 import { Select as SelectPrimitive } from "@base-ui/react/select";
 import { Check, ChevronDown } from "@unkey/icons";
 import { type VariantProps, cva } from "class-variance-authority";
-import * as React from "react";
+import type * as React from "react";
 import { cn } from "../../lib/utils";
 
 const selectTriggerVariants = cva(
@@ -60,61 +60,68 @@ const Select = SelectPrimitive.Root;
 const SelectGroup = SelectPrimitive.Group;
 const SelectValue = SelectPrimitive.Value;
 
-const SelectTrigger = React.forwardRef<
-  React.ComponentRef<typeof SelectPrimitive.Trigger>,
-  SelectPrimitive.Trigger.Props & DocumentedSelectProps
->(({ className, children, variant, leftIcon, wrapperClassName, rightIcon, ...props }, ref) => (
-  <div className={cn(selectWrapperVariants({ variant }), wrapperClassName)}>
-    {leftIcon && (
-      <div className="absolute left-3 flex items-center pointer-events-none">{leftIcon}</div>
-    )}
-    <SelectPrimitive.Trigger
-      ref={ref}
-      className={cn(
-        selectTriggerVariants({ variant, className }),
-        "px-3 py-2",
-        leftIcon && "pl-9",
-        "pr-9", // Always have space for the chevron icon
+function SelectTrigger({
+  className,
+  children,
+  variant,
+  leftIcon,
+  wrapperClassName,
+  rightIcon,
+  ref,
+  ...props
+}: SelectPrimitive.Trigger.Props &
+  DocumentedSelectProps & {
+    ref?: React.Ref<React.ComponentRef<typeof SelectPrimitive.Trigger>>;
+  }) {
+  return (
+    <div className={cn(selectWrapperVariants({ variant }), wrapperClassName)}>
+      {leftIcon && (
+        <div className="absolute left-3 flex items-center pointer-events-none">{leftIcon}</div>
       )}
-      {...props}
-    >
-      {children}
-      <SelectPrimitive.Icon
-        render={
-          (rightIcon as React.ReactElement) || (
-            <ChevronDown className="absolute text-gray-11 right-3 w-4 h-4" iconSize="sm-medium" />
-          )
-        }
-      />
-    </SelectPrimitive.Trigger>
-  </div>
-));
-SelectTrigger.displayName = "SelectTrigger";
+      <SelectPrimitive.Trigger
+        ref={ref}
+        className={cn(
+          selectTriggerVariants({ variant, className }),
+          "px-3 py-2",
+          leftIcon && "pl-9",
+          "pr-9", // Always have space for the chevron icon
+        )}
+        {...props}
+      >
+        {children}
+        <SelectPrimitive.Icon
+          render={
+            (rightIcon as React.ReactElement) || (
+              <ChevronDown className="absolute text-gray-11 right-3 w-4 h-4" iconSize="sm-medium" />
+            )
+          }
+        />
+      </SelectPrimitive.Trigger>
+    </div>
+  );
+}
 
-const SelectContent = React.forwardRef<
-  React.ComponentRef<typeof SelectPrimitive.Popup>,
-  SelectPrimitive.Popup.Props &
-    Pick<
-      SelectPrimitive.Positioner.Props,
-      "align" | "alignOffset" | "side" | "sideOffset" | "alignItemWithTrigger"
-    >
->(
-  (
-    {
-      className,
-      children,
-      align,
-      alignOffset,
-      side,
-      sideOffset = 4,
-      // Radix parity: the old wrapper defaulted to position="popper" (popup
-      // below the trigger). Base UI defaults to item-aligned (popup overlaps
-      // the trigger and ignores side/sideOffset), so default it off.
-      alignItemWithTrigger = false,
-      ...props
-    },
-    ref,
-  ) => (
+function SelectContent({
+  className,
+  children,
+  align,
+  alignOffset,
+  side,
+  sideOffset = 4,
+  // Radix parity: the old wrapper defaulted to position="popper" (popup
+  // below the trigger). Base UI defaults to item-aligned (popup overlaps
+  // the trigger and ignores side/sideOffset), so default it off.
+  alignItemWithTrigger = false,
+  ref,
+  ...props
+}: SelectPrimitive.Popup.Props &
+  Pick<
+    SelectPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset" | "alignItemWithTrigger"
+  > & {
+    ref?: React.Ref<React.ComponentRef<typeof SelectPrimitive.Popup>>;
+  }) {
+  return (
     <SelectPrimitive.Portal>
       <SelectPrimitive.Positioner
         className="isolate z-200"
@@ -138,57 +145,69 @@ const SelectContent = React.forwardRef<
         </SelectPrimitive.Popup>
       </SelectPrimitive.Positioner>
     </SelectPrimitive.Portal>
-  ),
-);
-SelectContent.displayName = "SelectContent";
+  );
+}
 
-const SelectLabel = React.forwardRef<
-  React.ComponentRef<typeof SelectPrimitive.GroupLabel>,
-  SelectPrimitive.GroupLabel.Props
->(({ className, ...props }, ref) => (
-  <SelectPrimitive.GroupLabel
-    ref={ref}
-    className={cn("py-1.5 pl-2 pr-2 text-[13px] font-medium text-gray-11", className)}
-    {...props}
-  />
-));
-SelectLabel.displayName = "SelectLabel";
+function SelectLabel({
+  className,
+  ref,
+  ...props
+}: SelectPrimitive.GroupLabel.Props & {
+  ref?: React.Ref<React.ComponentRef<typeof SelectPrimitive.GroupLabel>>;
+}) {
+  return (
+    <SelectPrimitive.GroupLabel
+      ref={ref}
+      className={cn("py-1.5 pl-2 pr-2 text-[13px] font-medium text-gray-11", className)}
+      {...props}
+    />
+  );
+}
 
-const SelectItem = React.forwardRef<
-  React.ComponentRef<typeof SelectPrimitive.Item>,
-  SelectPrimitive.Item.Props
->(({ className, children, ...props }, ref) => (
-  <SelectPrimitive.Item
-    ref={ref}
-    className={cn(
-      "relative flex w-full cursor-default select-none items-center rounded-md py-1.5 pl-2 pr-8 text-[13px] outline-hidden",
-      "text-gray-12 hover:bg-gray-4 focus:bg-gray-5 data-highlighted:bg-gray-5 data-disabled:opacity-50",
-      className,
-    )}
-    {...props}
-  >
-    <span className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
-      <SelectPrimitive.ItemIndicator>
-        <Check iconSize="sm-medium" className="text-gray-12" />
-      </SelectPrimitive.ItemIndicator>
-    </span>
+function SelectItem({
+  className,
+  children,
+  ref,
+  ...props
+}: SelectPrimitive.Item.Props & {
+  ref?: React.Ref<React.ComponentRef<typeof SelectPrimitive.Item>>;
+}) {
+  return (
+    <SelectPrimitive.Item
+      ref={ref}
+      className={cn(
+        "relative flex w-full cursor-default select-none items-center rounded-md py-1.5 pl-2 pr-8 text-[13px] outline-hidden",
+        "text-gray-12 hover:bg-gray-4 focus:bg-gray-5 data-highlighted:bg-gray-5 data-disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    >
+      <span className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
+        <SelectPrimitive.ItemIndicator>
+          <Check iconSize="sm-medium" className="text-gray-12" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
 
-    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
-  </SelectPrimitive.Item>
-));
-SelectItem.displayName = "SelectItem";
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  );
+}
 
-const SelectSeparator = React.forwardRef<
-  React.ComponentRef<typeof SelectPrimitive.Separator>,
-  SelectPrimitive.Separator.Props
->(({ className, ...props }, ref) => (
-  <SelectPrimitive.Separator
-    ref={ref}
-    className={cn("-mx-1 my-1 h-px bg-gray-5", className)}
-    {...props}
-  />
-));
-SelectSeparator.displayName = "SelectSeparator";
+function SelectSeparator({
+  className,
+  ref,
+  ...props
+}: SelectPrimitive.Separator.Props & {
+  ref?: React.Ref<React.ComponentRef<typeof SelectPrimitive.Separator>>;
+}) {
+  return (
+    <SelectPrimitive.Separator
+      ref={ref}
+      className={cn("-mx-1 my-1 h-px bg-gray-5", className)}
+      {...props}
+    />
+  );
+}
 
 export {
   Select,

--- a/web/internal/ui/src/components/hover-card.tsx
+++ b/web/internal/ui/src/components/hover-card.tsx
@@ -1,38 +1,46 @@
 "use client";
 
 import { PreviewCard as HoverCardPrimitive } from "@base-ui/react/preview-card";
-import * as React from "react";
+import type * as React from "react";
 import { cn } from "../lib/utils";
 
 const HoverCard = HoverCardPrimitive.Root;
 const HoverCardTrigger = HoverCardPrimitive.Trigger;
 
-const HoverCardContent = React.forwardRef<
-  React.ComponentRef<typeof HoverCardPrimitive.Popup>,
-  HoverCardPrimitive.Popup.Props &
-    Pick<HoverCardPrimitive.Positioner.Props, "align" | "alignOffset" | "side" | "sideOffset">
->(({ className, align = "center", alignOffset, side, sideOffset = 4, ...props }, ref) => (
-  <HoverCardPrimitive.Portal>
-    <HoverCardPrimitive.Positioner
-      className="isolate z-200"
-      align={align}
-      alignOffset={alignOffset}
-      side={side}
-      sideOffset={sideOffset}
-    >
-      <HoverCardPrimitive.Popup
-        ref={ref}
-        className={cn(
-          "z-200 w-64 rounded-lg border border-grayA-4 bg-gray-2 p-4 text-gray-12 shadow-md outline-none",
-          "transition-[opacity,scale,translate] data-starting-style:opacity-0 data-starting-style:scale-95 data-ending-style:opacity-0 data-ending-style:scale-95",
-          "data-[side=bottom]:data-starting-style:-translate-y-2 data-[side=left]:data-starting-style:translate-x-2 data-[side=right]:data-starting-style:-translate-x-2 data-[side=top]:data-starting-style:translate-y-2",
-          className,
-        )}
-        {...props}
-      />
-    </HoverCardPrimitive.Positioner>
-  </HoverCardPrimitive.Portal>
-));
-HoverCardContent.displayName = "HoverCardContent";
+function HoverCardContent({
+  className,
+  align = "center",
+  alignOffset,
+  side,
+  sideOffset = 4,
+  ref,
+  ...props
+}: HoverCardPrimitive.Popup.Props &
+  Pick<HoverCardPrimitive.Positioner.Props, "align" | "alignOffset" | "side" | "sideOffset"> & {
+    ref?: React.Ref<React.ComponentRef<typeof HoverCardPrimitive.Popup>>;
+  }) {
+  return (
+    <HoverCardPrimitive.Portal>
+      <HoverCardPrimitive.Positioner
+        className="isolate z-200"
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+      >
+        <HoverCardPrimitive.Popup
+          ref={ref}
+          className={cn(
+            "z-200 w-64 rounded-lg border border-grayA-4 bg-gray-2 p-4 text-gray-12 shadow-md outline-none",
+            "transition-[opacity,scale,translate] data-starting-style:opacity-0 data-starting-style:scale-95 data-ending-style:opacity-0 data-ending-style:scale-95",
+            "data-[side=bottom]:data-starting-style:-translate-y-2 data-[side=left]:data-starting-style:translate-x-2 data-[side=right]:data-starting-style:-translate-x-2 data-[side=top]:data-starting-style:translate-y-2",
+            className,
+          )}
+          {...props}
+        />
+      </HoverCardPrimitive.Positioner>
+    </HoverCardPrimitive.Portal>
+  );
+}
 
 export { HoverCard, HoverCardTrigger, HoverCardContent };

--- a/web/internal/ui/src/components/separator.tsx
+++ b/web/internal/ui/src/components/separator.tsx
@@ -1,25 +1,30 @@
 "use client";
 
 import { Separator as SeparatorPrimitive } from "@base-ui/react/separator";
-import * as React from "react";
+import type * as React from "react";
 
 import { cn } from "../lib/utils";
 
-const Separator = React.forwardRef<
-  React.ComponentRef<typeof SeparatorPrimitive>,
-  React.ComponentPropsWithoutRef<typeof SeparatorPrimitive>
->(({ className, orientation = "horizontal", ...props }, ref) => (
-  <SeparatorPrimitive
-    ref={ref}
-    orientation={orientation}
-    className={cn(
-      "shrink-0 bg-gray-4",
-      orientation === "horizontal" ? "h-px w-full" : "w-px",
-      className,
-    )}
-    {...props}
-  />
-));
-Separator.displayName = "Separator";
+function Separator({
+  className,
+  orientation = "horizontal",
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof SeparatorPrimitive> & {
+  ref?: React.Ref<React.ComponentRef<typeof SeparatorPrimitive>>;
+}) {
+  return (
+    <SeparatorPrimitive
+      ref={ref}
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-gray-4",
+        orientation === "horizontal" ? "h-px w-full" : "w-px",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
 
 export { Separator };

--- a/web/internal/ui/src/components/slider.tsx
+++ b/web/internal/ui/src/components/slider.tsx
@@ -1,5 +1,5 @@
 import { Slider as SliderPrimitive } from "@base-ui/react/slider";
-import * as React from "react";
+import type * as React from "react";
 import { cn } from "../lib/utils";
 
 // Wrapper keeps the Radix-style array value API (`number[]`) so existing
@@ -12,66 +12,59 @@ type SliderProps = SliderPrimitive.Root.Props<number[]> & {
   getAriaLabel?: (index: number) => string;
 };
 
-const Slider = React.forwardRef<HTMLDivElement, SliderProps>(
-  (
-    {
-      className,
-      rangeClassName,
-      rangeStyle,
-      value,
-      defaultValue,
-      onValueChange,
-      onValueCommitted,
-      getAriaLabel,
-      ...props
-    },
-    ref,
-  ) => {
-    const resolved = value ?? defaultValue ?? [0];
-    const thumbCount = Array.isArray(resolved) ? resolved.length : 1;
-    // Base UI emits a bare `number` for single-thumb sliders; the wrapper's
-    // contract is `number[]`, so normalize back to an array for consumers.
-    const toArray = (v: number | number[]): number[] => (Array.isArray(v) ? v : [v]);
-    return (
-      <SliderPrimitive.Root
-        ref={ref}
-        value={value}
-        defaultValue={defaultValue}
-        onValueChange={
-          onValueChange ? (v, details) => onValueChange(toArray(v), details) : undefined
-        }
-        onValueCommitted={
-          onValueCommitted ? (v, details) => onValueCommitted(toArray(v), details) : undefined
-        }
-        thumbAlignment="edge"
-        className={cn("relative w-full", className)}
-        {...props}
-      >
-        <SliderPrimitive.Control className="relative flex w-full touch-none select-none items-center">
-          {/* No overflow-hidden here: Base UI nests the 16px thumbs INSIDE the
+function Slider({
+  className,
+  rangeClassName,
+  rangeStyle,
+  value,
+  defaultValue,
+  onValueChange,
+  onValueCommitted,
+  getAriaLabel,
+  ref,
+  ...props
+}: SliderProps & { ref?: React.Ref<HTMLDivElement> }) {
+  const resolved = value ?? defaultValue ?? [0];
+  const thumbCount = Array.isArray(resolved) ? resolved.length : 1;
+  // Base UI emits a bare `number` for single-thumb sliders; the wrapper's
+  // contract is `number[]`, so normalize back to an array for consumers.
+  const toArray = (v: number | number[]): number[] => (Array.isArray(v) ? v : [v]);
+  return (
+    <SliderPrimitive.Root
+      ref={ref}
+      value={value}
+      defaultValue={defaultValue}
+      onValueChange={onValueChange ? (v, details) => onValueChange(toArray(v), details) : undefined}
+      onValueCommitted={
+        onValueCommitted ? (v, details) => onValueCommitted(toArray(v), details) : undefined
+      }
+      thumbAlignment="edge"
+      className={cn("relative w-full", className)}
+      {...props}
+    >
+      <SliderPrimitive.Control className="relative flex w-full touch-none select-none items-center">
+        {/* No overflow-hidden here: Base UI nests the 16px thumbs INSIDE the
               6px track, so clipping would shrink their visible size and hit area. */}
-          <SliderPrimitive.Track className="relative h-1.5 w-full grow rounded-full bg-grayA-3">
-            <SliderPrimitive.Indicator
-              className={cn("absolute h-full rounded-full bg-accent-12", rangeClassName)}
-              style={rangeStyle}
+        <SliderPrimitive.Track className="relative h-1.5 w-full grow rounded-full bg-grayA-3">
+          <SliderPrimitive.Indicator
+            className={cn("absolute h-full rounded-full bg-accent-12", rangeClassName)}
+            style={rangeStyle}
+          />
+          {Array.from({ length: thumbCount }).map((_, i) => (
+            <SliderPrimitive.Thumb
+              // biome-ignore lint/suspicious/noArrayIndexKey: <explanation>
+              key={i}
+              index={i}
+              getAriaLabel={getAriaLabel ?? ((index) => `Value ${index + 1}`)}
+              // Focus lands on the thumb's nested <input type=range>, so the
+              // visible ring on this outer div keys off has-[:focus-visible].
+              className="block h-4 w-4 rounded-full border border-grayA-6 bg-gray-2 shadow transition-colors duration-300 hover:border-grayA-8 has-[:focus-visible]:ring has-[:focus-visible]:ring-gray-5 outline-none data-disabled:pointer-events-none data-disabled:cursor-not-allowed data-disabled:opacity-50"
             />
-            {Array.from({ length: thumbCount }).map((_, i) => (
-              <SliderPrimitive.Thumb
-                // biome-ignore lint/suspicious/noArrayIndexKey: <explanation>
-                key={i}
-                index={i}
-                getAriaLabel={getAriaLabel ?? ((index) => `Value ${index + 1}`)}
-                // Focus lands on the thumb's nested <input type=range>, so the
-                // visible ring on this outer div keys off has-[:focus-visible].
-                className="block h-4 w-4 rounded-full border border-grayA-6 bg-gray-2 shadow transition-colors duration-300 hover:border-grayA-8 has-[:focus-visible]:ring has-[:focus-visible]:ring-gray-5 outline-none data-disabled:pointer-events-none data-disabled:cursor-not-allowed data-disabled:opacity-50"
-              />
-            ))}
-          </SliderPrimitive.Track>
-        </SliderPrimitive.Control>
-      </SliderPrimitive.Root>
-    );
-  },
-);
-Slider.displayName = "Slider";
+          ))}
+        </SliderPrimitive.Track>
+      </SliderPrimitive.Control>
+    </SliderPrimitive.Root>
+  );
+}
 
 export { Slider };

--- a/web/internal/ui/src/components/tabs.tsx
+++ b/web/internal/ui/src/components/tabs.tsx
@@ -1,55 +1,67 @@
 import { Tabs as TabsPrimitive } from "@base-ui/react/tabs";
-import * as React from "react";
+import type * as React from "react";
 import { cn } from "../lib/utils";
 
 const Tabs = TabsPrimitive.Root;
 
-const TabsList = React.forwardRef<
-  React.ComponentRef<typeof TabsPrimitive.List>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
->(({ className, ...props }, ref) => (
-  <TabsPrimitive.List
-    ref={ref}
-    // Radix parity: Radix activated tabs as arrow-key focus moved; Base UI
-    // defaults to manual activation (Enter/Space). Restore automatic activation.
-    activateOnFocus
-    className={cn(
-      "inline-flex h-9 items-center justify-center rounded-lg bg-gray-2 p-1 text-grayA-11",
-      className,
-    )}
-    {...props}
-  />
-));
-TabsList.displayName = "TabsList";
+function TabsList({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof TabsPrimitive.List> & {
+  ref?: React.Ref<React.ComponentRef<typeof TabsPrimitive.List>>;
+}) {
+  return (
+    <TabsPrimitive.List
+      ref={ref}
+      // Radix parity: Radix activated tabs as arrow-key focus moved; Base UI
+      // defaults to manual activation (Enter/Space). Restore automatic activation.
+      activateOnFocus
+      className={cn(
+        "inline-flex h-9 items-center justify-center rounded-lg bg-gray-2 p-1 text-grayA-11",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
 
-const TabsTrigger = React.forwardRef<
-  React.ComponentRef<typeof TabsPrimitive.Tab>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Tab>
->(({ className, ...props }, ref) => (
-  <TabsPrimitive.Tab
-    ref={ref}
-    className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-0 transition-all duration-150 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-gray-5 disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:cursor-not-allowed aria-disabled:opacity-50 hover:bg-grayA-2 data-active:bg-white dark:data-active:bg-black data-active:text-grayA-12 data-active:shadow-sm",
-      className,
-    )}
-    {...props}
-  />
-));
-TabsTrigger.displayName = "TabsTrigger";
+function TabsTrigger({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof TabsPrimitive.Tab> & {
+  ref?: React.Ref<React.ComponentRef<typeof TabsPrimitive.Tab>>;
+}) {
+  return (
+    <TabsPrimitive.Tab
+      ref={ref}
+      className={cn(
+        "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-0 transition-all duration-150 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-gray-5 disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:cursor-not-allowed aria-disabled:opacity-50 hover:bg-grayA-2 data-active:bg-white dark:data-active:bg-black data-active:text-grayA-12 data-active:shadow-sm",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
 
-const TabsContent = React.forwardRef<
-  React.ComponentRef<typeof TabsPrimitive.Panel>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Panel>
->(({ className, ...props }, ref) => (
-  <TabsPrimitive.Panel
-    ref={ref}
-    className={cn(
-      "mt-2 ring-offset-0 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-gray-5",
-      className,
-    )}
-    {...props}
-  />
-));
-TabsContent.displayName = "TabsContent";
+function TabsContent({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof TabsPrimitive.Panel> & {
+  ref?: React.Ref<React.ComponentRef<typeof TabsPrimitive.Panel>>;
+}) {
+  return (
+    <TabsPrimitive.Panel
+      ref={ref}
+      className={cn(
+        "mt-2 ring-offset-0 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-gray-5",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
 
 export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/web/internal/ui/src/components/tooltip.tsx
+++ b/web/internal/ui/src/components/tooltip.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip";
-import * as React from "react";
+import type * as React from "react";
 
 import { cn } from "../lib/utils";
 
@@ -11,30 +11,38 @@ const Tooltip = TooltipPrimitive.Root;
 
 const TooltipTrigger = TooltipPrimitive.Trigger;
 
-const TooltipContent = React.forwardRef<
-  React.ComponentRef<typeof TooltipPrimitive.Popup>,
-  TooltipPrimitive.Popup.Props &
-    Pick<TooltipPrimitive.Positioner.Props, "align" | "alignOffset" | "side" | "sideOffset">
->(({ className, align, alignOffset, side, sideOffset = 4, ...props }, ref) => (
-  <TooltipPrimitive.Portal>
-    <TooltipPrimitive.Positioner
-      className="isolate z-200"
-      align={align}
-      alignOffset={alignOffset}
-      side={side}
-      sideOffset={sideOffset}
-    >
-      <TooltipPrimitive.Popup
-        ref={ref}
-        className={cn(
-          "z-50 bg-gray-1 text-gray-12 overflow-hidden rounded-md px-3 py-1.5 text-sm shadow-md transition-[opacity,scale,translate] data-starting-style:opacity-0 data-starting-style:scale-95 data-ending-style:opacity-0 data-ending-style:scale-95 data-[side=bottom]:data-starting-style:-translate-y-2 data-[side=left]:data-starting-style:translate-x-2 data-[side=right]:data-starting-style:-translate-x-2 data-[side=top]:data-starting-style:translate-y-2",
-          className,
-        )}
-        {...props}
-      />
-    </TooltipPrimitive.Positioner>
-  </TooltipPrimitive.Portal>
-));
-TooltipContent.displayName = "TooltipContent";
+function TooltipContent({
+  className,
+  align,
+  alignOffset,
+  side,
+  sideOffset = 4,
+  ref,
+  ...props
+}: TooltipPrimitive.Popup.Props &
+  Pick<TooltipPrimitive.Positioner.Props, "align" | "alignOffset" | "side" | "sideOffset"> & {
+    ref?: React.Ref<React.ComponentRef<typeof TooltipPrimitive.Popup>>;
+  }) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Positioner
+        className="isolate z-200"
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+      >
+        <TooltipPrimitive.Popup
+          ref={ref}
+          className={cn(
+            "z-50 bg-gray-1 text-gray-12 overflow-hidden rounded-md px-3 py-1.5 text-sm shadow-md transition-[opacity,scale,translate] data-starting-style:opacity-0 data-starting-style:scale-95 data-ending-style:opacity-0 data-ending-style:scale-95 data-[side=bottom]:data-starting-style:-translate-y-2 data-[side=left]:data-starting-style:translate-x-2 data-[side=right]:data-starting-style:-translate-x-2 data-[side=top]:data-starting-style:translate-y-2",
+            className,
+          )}
+          {...props}
+        />
+      </TooltipPrimitive.Positioner>
+    </TooltipPrimitive.Portal>
+  );
+}
 
 export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/web/internal/ui/src/components/visually-hidden.tsx
+++ b/web/internal/ui/src/components/visually-hidden.tsx
@@ -1,16 +1,17 @@
 "use client";
 
-import * as React from "react";
+import type * as React from "react";
 
 import { cn } from "../lib/utils";
 
 // Base UI has no VisuallyHidden primitive; the idiomatic replacement is the
 // `sr-only` utility on a plain span.
-const VisuallyHidden = React.forwardRef<HTMLSpanElement, React.ComponentPropsWithoutRef<"span">>(
-  ({ className, ...props }, ref) => (
-    <span ref={ref} className={cn("sr-only", className)} {...props} />
-  ),
-);
-VisuallyHidden.displayName = "VisuallyHidden";
+function VisuallyHidden({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<"span"> & { ref?: React.Ref<HTMLSpanElement> }) {
+  return <span ref={ref} className={cn("sr-only", className)} {...props} />;
+}
 
 export { VisuallyHidden };


### PR DESCRIPTION
## What does this PR do?

I've removed any usage of `forwardRef` from `unkey/ui` because as of React 19 you can just pass `ref` as a normal prop.

I left out `form/input.tsx` and `form/textarea.tsx` because i've fixed those in the next stack in this series.

## Type of change

- [x] Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

No behavior or visual change intended.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary