### PR TITLE
fix(dashboard): Put borders on empty states

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/_components/api-list-client.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/_components/api-list-client.tsx
@@ -3,7 +3,7 @@
 import { StatsListCardSkeleton } from "@/components/stats-list-card/skeleton";
 import { routes } from "@/lib/navigation/routes";
 import { trpc } from "@/lib/trpc/client";
-import { Button, Empty } from "@unkey/ui";
+import { Button, Empty, ResourceListContent } from "@unkey/ui";
 import { useRouter, useSearchParams } from "next/navigation";
 import { type PropsWithChildren, useEffect, useMemo, useState } from "react";
 import { ApiListCard } from "./api-list-card";
@@ -121,8 +121,8 @@ export const ApiListClient = ({ workspaceSlug }: { workspaceSlug: string }) => {
 
 const EmptyComponentSpacer = ({ children }: PropsWithChildren) => {
   return (
-    <div className="h-full min-h-[300px] flex items-center justify-center">
-      <div className="flex justify-center items-center">{children}</div>
-    </div>
+    <ResourceListContent>
+      <div className="flex w-full items-center justify-center px-4 py-16">{children}</div>
+    </ResourceListContent>
   );
 };

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/_components/api-list-client.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/_components/api-list-client.tsx
@@ -106,10 +106,10 @@ export const ApiListClient = ({ workspaceSlug }: { workspaceSlug: string }) => {
         </>
       ) : (
         <EmptyComponentSpacer>
-          <Empty className="m-0 p-0">
-            <Empty.Icon />
+          <Empty className="w-[400px] items-start p-0">
+            <Empty.Icon className="w-auto" />
             <Empty.Title>No keyspaces found</Empty.Title>
-            <Empty.Description>
+            <Empty.Description className="text-left">
               No keyspaces match your search criteria. Try a different search term.
             </Empty.Description>
           </Empty>

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/ratelimits/_components/list/index.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/ratelimits/_components/list/index.tsx
@@ -52,14 +52,14 @@ export const NamespaceList = () => {
     return (
       <ResourceListContent>
         <div className="flex w-full items-center justify-center px-4 py-16">
-          <Empty className="w-[600px] flex items-start">
-            <Empty.Icon />
+          <Empty className="w-[600px] items-start p-0">
+            <Empty.Icon className="w-auto" />
             <Empty.Title>No Namespaces found</Empty.Title>
             <Empty.Description className="text-left">
               You haven't created any Namespaces yet. Create one by performing a limit request as
               shown below.
             </Empty.Description>
-            <div className="w-full mt-8 mb-8">
+            <div className="w-full mt-6">
               <div className="flex items-start gap-4 p-4 bg-gray-2 border border-gray-6 rounded-lg">
                 <pre className="flex-1 text-xs text-left overflow-x-auto">
                   <code>{EXAMPLE_SNIPPET}</code>

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/ratelimits/_components/list/index.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/ratelimits/_components/list/index.tsx
@@ -2,7 +2,7 @@ import { StatsListCardSkeleton } from "@/components/stats-list-card/skeleton";
 import { collection } from "@/lib/collections";
 import { ilike, useLiveQuery } from "@tanstack/react-db";
 import { Bookmark } from "@unkey/icons";
-import { Button, CopyButton, Empty } from "@unkey/ui";
+import { Button, CopyButton, Empty, ResourceListContent } from "@unkey/ui";
 import { useMemo } from "react";
 import { useBatchRatelimitTimeseries } from "../hooks/use-batch-timeseries";
 import { useNamespaceListFilters } from "../hooks/use-namespace-list-filters";
@@ -50,36 +50,38 @@ export const NamespaceList = () => {
 
   if (namespaces.length === 0) {
     return (
-      <div className="w-full flex justify-center items-center h-full min-h-[300px]">
-        <Empty className="w-[600px] flex items-start">
-          <Empty.Icon />
-          <Empty.Title>No Namespaces found</Empty.Title>
-          <Empty.Description className="text-left">
-            You haven't created any Namespaces yet. Create one by performing a limit request as
-            shown below.
-          </Empty.Description>
-          <div className="w-full mt-8 mb-8">
-            <div className="flex items-start gap-4 p-4 bg-gray-2 border border-gray-6 rounded-lg">
-              <pre className="flex-1 text-xs text-left overflow-x-auto">
-                <code>{EXAMPLE_SNIPPET}</code>
-              </pre>
-              <CopyButton value={EXAMPLE_SNIPPET} />
+      <ResourceListContent>
+        <div className="flex w-full items-center justify-center px-4 py-16">
+          <Empty className="w-[600px] flex items-start">
+            <Empty.Icon />
+            <Empty.Title>No Namespaces found</Empty.Title>
+            <Empty.Description className="text-left">
+              You haven't created any Namespaces yet. Create one by performing a limit request as
+              shown below.
+            </Empty.Description>
+            <div className="w-full mt-8 mb-8">
+              <div className="flex items-start gap-4 p-4 bg-gray-2 border border-gray-6 rounded-lg">
+                <pre className="flex-1 text-xs text-left overflow-x-auto">
+                  <code>{EXAMPLE_SNIPPET}</code>
+                </pre>
+                <CopyButton value={EXAMPLE_SNIPPET} />
+              </div>
             </div>
-          </div>
-          <Empty.Actions className="mt-4 justify-start">
-            <a
-              href="https://www.unkey.com/docs/platform/ratelimiting/introduction"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <Button className="flex items-center gap-2">
-                <Bookmark className="w-4 h-4" />
-                Read the docs
-              </Button>
-            </a>
-          </Empty.Actions>
-        </Empty>
-      </div>
+            <Empty.Actions className="mt-4 justify-start">
+              <a
+                href="https://www.unkey.com/docs/platform/ratelimiting/introduction"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button className="flex items-center gap-2">
+                  <Bookmark className="w-4 h-4" />
+                  Read the docs
+                </Button>
+              </a>
+            </Empty.Actions>
+          </Empty>
+        </div>
+      </ResourceListContent>
     );
   }
 

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/team/invitations.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/team/invitations.tsx
@@ -40,10 +40,14 @@ export const Invitations = memo<InvitationsProps>(({ organization, isAdmin }) =>
 
   if (!invitations || invitations.length === 0) {
     return (
-      <Empty>
-        <Empty.Title>No pending invitations</Empty.Title>
-        <Empty.Description>Invite members using the form above</Empty.Description>
-      </Empty>
+      <Card>
+        <CardContent className="p-0">
+          <Empty>
+            <Empty.Title>No pending invitations</Empty.Title>
+            <Empty.Description>Invite members using the form above</Empty.Description>
+          </Empty>
+        </CardContent>
+      </Card>
     );
   }
 

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/team/members.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/team/members.tsx
@@ -55,10 +55,14 @@ export const Members = memo<MembersProps>(({ organization, user, userMembership 
 
   if (!memberships || memberships.length === 0) {
     return (
-      <Empty>
-        <Empty.Title>No team members</Empty.Title>
-        <Empty.Description>Invite members using the form above</Empty.Description>
-      </Empty>
+      <Card>
+        <CardContent className="p-0">
+          <Empty>
+            <Empty.Title>No team members</Empty.Title>
+            <Empty.Description>Invite members using the form above</Empty.Description>
+          </Empty>
+        </CardContent>
+      </Card>
     );
   }
 


### PR DESCRIPTION
## What does this PR do?

Fixes this issue:

https://linear.app/unkey/issue/DES-73

And fixes a few other cases I found too. 

## Screenshots

Light mode, 2x. Dark and mobile not captured.

**Ratelimits.** The state Oz reported.

| Before | After |
| --- | --- |
| <img alt="Ratelimits empty state before" src="https://github.com/user-attachments/assets/08e8769f-4ec5-4c06-94ec-3a123023e4c9" /> | <img alt="Ratelimits empty state after" src="https://github.com/user-attachments/assets/b82c08f2-d86b-4626-96ba-7da90d31035b" /> |

**Keyspaces, search matches nothing.**

| Before | After |
| --- | --- |
| <img alt="Keyspace search empty state before" src="https://github.com/user-attachments/assets/774fedaf-703f-4979-ab78-391e1ce31ff7" /> | <img alt="Keyspace search empty state after" src="https://github.com/user-attachments/assets/a05d9ed4-9ac6-4867-a4da-83147b122973" /> |

**Team, Pending Invitations tab.** Now matches the invite card above it.

| Before | After |
| --- | --- |
| <img alt="Pending invitations empty state before" src="https://github.com/user-attachments/assets/73ce35d2-70eb-48f0-b263-8e63c0567dc4" /> | <img alt="Pending invitations empty state after" src="https://github.com/user-attachments/assets/ca794d16-e1e5-4afc-82f0-b7e4574a92dc" /> |

The "No team members" state is changed the same way but has no screenshot, because it cannot render — you are always a member of your own workspace.




## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

Each state needs an empty workspace, or a search that matches nothing.

1. **Ratelimits** — open `/[workspace]/ratelimits` with no namespaces. The empty state sits in a bordered box.
2. **Keyspaces search** — open `/[workspace]/apis`, type something that matches no keyspace. Same box.
3. **Team invitations** — `/[workspace]/settings/team`, Pending Invitations tab with none pending. Boxed, matching the invite card above it.
4. Confirm identities, apps and deployments are unchanged.

Not verified: the "No team members" state. It can never render, because you are always a member of your own workspace. It shares a code path with the invitations tab, which is verified.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary

<img width="3000" height="1900" alt="ratelimits-after-v2" src="https://github.com/user-attachments/assets/f8cba32f-fcd2-4422-bed5-8ca8a9ec1f01" />
<img width="3000" height="1900" alt="keyspace-search-after-v2" src="https://github.com/user-attachments/assets/a7942ce7-7b9a-43ad-88ff-6ec9dc174874" />
