### PR TITLE
Fix canceled Compute plan upgrades

### DIFF
--- a/web/apps/dashboard/lib/stripe/deployBilling.test.ts
+++ b/web/apps/dashboard/lib/stripe/deployBilling.test.ts
@@ -9,6 +9,7 @@ import {
   type DeployBillingConfig,
   deployBillingConfig,
   deployCheckoutLineItems,
+  deployResumeSubscriptionParams,
   deploySubscriptionItems,
   findDeployItems,
   findPlanFeeItem,
@@ -161,6 +162,40 @@ describe("deploySubscriptionItems", () => {
       { price: "price_disk" },
       { price: "price_active_keys" },
     ]);
+  });
+});
+
+describe("deployResumeSubscriptionParams", () => {
+  it("atomically resumes a cancelled Starter subscription on Pro", () => {
+    expect(
+      deployResumeSubscriptionParams(CONFIG, { id: "si_plan", plan: "starter" }, "pro"),
+    ).toEqual({
+      cancel_at_period_end: false,
+      items: [{ id: "si_plan", price: "price_pro" }],
+      proration_behavior: "always_invoice",
+      payment_behavior: "error_if_incomplete",
+    });
+  });
+
+  it("resumes the same tier without invoicing it again", () => {
+    expect(
+      deployResumeSubscriptionParams(CONFIG, { id: "si_plan", plan: "starter" }, "starter"),
+    ).toEqual({
+      cancel_at_period_end: false,
+      proration_behavior: "none",
+      payment_behavior: "error_if_incomplete",
+    });
+  });
+
+  it("changes to a lower tier without refunding the paid period", () => {
+    expect(
+      deployResumeSubscriptionParams(CONFIG, { id: "si_plan", plan: "pro" }, "starter"),
+    ).toEqual({
+      cancel_at_period_end: false,
+      items: [{ id: "si_plan", price: "price_starter" }],
+      proration_behavior: "none",
+      payment_behavior: "error_if_incomplete",
+    });
   });
 });
 

--- a/web/apps/dashboard/lib/stripe/deployBilling.ts
+++ b/web/apps/dashboard/lib/stripe/deployBilling.ts
@@ -1,5 +1,6 @@
 import { stripeEnv } from "@/lib/env";
 import { getStripeClient } from "@/lib/stripe";
+import type Stripe from "stripe";
 import { DEPLOY_PLANS, type DeployPlan } from "./deployPlan";
 
 /**
@@ -162,6 +163,38 @@ export function deploySubscriptionItems(
     { price: config.planFeePriceIds[plan] },
     ...config.meteredPriceIds.map((price) => ({ price })),
   ];
+}
+
+/**
+ * deployResumeSubscriptionParams builds the atomic Stripe update that resumes a
+ * cancelled Compute subscription on the selected tier. A failed upgrade charge
+ * must leave both the cancellation and old tier unchanged, while downgrades
+ * preserve the paid period.
+ */
+export function deployResumeSubscriptionParams(
+  config: DeployBillingConfig,
+  currentPlanFee: { id: string; plan: DeployPlan },
+  selectedPlan: DeployPlan,
+): Stripe.SubscriptionUpdateParams {
+  const changesPlan = currentPlanFee.plan !== selectedPlan;
+  const isDowngrade =
+    DEPLOY_PLANS.indexOf(selectedPlan) < DEPLOY_PLANS.indexOf(currentPlanFee.plan);
+
+  return {
+    cancel_at_period_end: false,
+    ...(changesPlan
+      ? {
+          items: [
+            {
+              id: currentPlanFee.id,
+              price: config.planFeePriceIds[selectedPlan],
+            },
+          ],
+        }
+      : {}),
+    proration_behavior: changesPlan && !isDowngrade ? "always_invoice" : "none",
+    payment_behavior: "error_if_incomplete",
+  };
 }
 
 /**

--- a/web/apps/dashboard/lib/trpc/routers/stripe/subscribeDeploy.ts
+++ b/web/apps/dashboard/lib/trpc/routers/stripe/subscribeDeploy.ts
@@ -4,6 +4,7 @@ import { getStripeClient } from "@/lib/stripe";
 import { upsertBillingSubscription } from "@/lib/stripe/billingSubscriptions";
 import {
   deployBillingConfig,
+  deployResumeSubscriptionParams,
   deploySubscriptionItems,
   findPlanFeeItem,
 } from "@/lib/stripe/deployBilling";
@@ -139,30 +140,20 @@ export const subscribeDeploy = workspaceProcedure
           });
         }
 
-        // Resume only at the SAME tier that was cancelled: proration "none" below
-        // keeps the plan fee already paid this period from re-invoicing, so
-        // repointing the fee at a different tier under "none" would grant the new
-        // tier for the old tier's payment. Route a tier change through
-        // changeDeployPlan (resume first, then switch) instead.
         const planFeeItem = findPlanFeeItem(config, sub.items.data);
-        if (!planFeeItem || planFeeItem.plan !== input.plan) {
+        if (!planFeeItem) {
           throw new TRPCError({
             code: "PRECONDITION_FAILED",
-            message: planFeeItem
-              ? `Your cancelled Compute plan is ${planFeeItem.plan}. Resume it by subscribing to ${planFeeItem.plan} again, then switch to ${input.plan}.`
-              : "Your cancelled Compute subscription has no plan fee to resume. Contact support@unkey.com.",
+            message:
+              "Your cancelled Compute subscription has no plan fee to resume. Contact support@unkey.com.",
           });
         }
 
         try {
-          await stripe.subscriptions.update(sub.id, {
-            // Clearing the pending cancellation resumes the plan. All items are
-            // still present (Deploy-only cancel keeps them), so nothing is
-            // re-attached; proration "none" keeps the paid fee from re-invoicing.
-            cancel_at_period_end: false,
-            proration_behavior: "none",
-            payment_behavior: "error_if_incomplete",
-          });
+          await stripe.subscriptions.update(
+            sub.id,
+            deployResumeSubscriptionParams(config, planFeeItem, input.plan),
+          );
         } catch (err) {
           throw toBillingError(err);
         }


### PR DESCRIPTION
## Problem:

If you cancel your compute plan and on a different day upgrade to a new plan and that fails you will get your old plan back even tho that shouldnt happen as it is cancelled.

## Solution:

Allow a canceled Compute subscription to resume on the selected tier. 
A failed upgrade payment leaves the cancellation and old tier unchanged.

## Impact:

Customers can cancel Starter and later select Pro without first restoring Starter. Existing same-tier resumes and downgrades keep their current billing behavior.

## Testing:

- `mise exec -- pnpm --dir=web/apps/dashboard vitest run lib/stripe/deployBilling.test.ts`: 19 tests passed.
- `mise exec -- pnpm --dir=web --filter=@unkey/dashboard test`: 927 tests passed.
- `mise exec -- pnpm --dir=web --filter=@unkey/dashboard typecheck`: passed.