### PR TITLE
Expose all root key permissions in dashboard

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/root-keys/components/dialog/permissions.test.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/root-keys/components/dialog/permissions.test.ts
@@ -1,0 +1,70 @@
+import {
+  apiActions,
+  appActions,
+  environmentActions,
+  identityActions,
+  portalActions,
+  projectActions,
+  ratelimitActions,
+  rbacActions,
+  workspaceActions,
+} from "@unkey/rbac";
+import { describe, expect, it } from "vitest";
+import { appPermissions, projectPermissions, workspacePermissions } from "./permissions";
+import { filterPermissionList, getAllPermissionNames } from "./utils/permissions";
+
+const actionsByResource: Record<string, readonly string[]> = {
+  api: apiActions.options,
+  app: appActions.options,
+  environment: environmentActions.options,
+  identity: identityActions.options,
+  portal: portalActions.options,
+  project: projectActions.options,
+  ratelimit: ratelimitActions.options,
+  rbac: rbacActions.options,
+  workspace: workspaceActions.options,
+};
+
+describe("workspacePermissions", () => {
+  const listedPermissions = new Set<string>(getAllPermissionNames(workspacePermissions));
+
+  for (const [resource, actions] of Object.entries(actionsByResource)) {
+    it(`lists every ${resource} action`, () => {
+      const missingPermissions = actions
+        .map((action) => `${resource}.*.${action}`)
+        .filter((permission) => !listedPermissions.has(permission));
+
+      expect(missingPermissions).toEqual([]);
+    });
+  }
+
+  it("shows role assignment permissions in search results", () => {
+    expect(
+      getAllPermissionNames(filterPermissionList(workspacePermissions, "permission_to_role")),
+    ).toEqual(["rbac.*.add_permission_to_role"]);
+    expect(
+      getAllPermissionNames(
+        filterPermissionList(workspacePermissions, "remove_permission_from_role"),
+      ),
+    ).toEqual(["rbac.*.remove_permission_from_role"]);
+  });
+});
+
+describe("resource permissions", () => {
+  it("lists actions supported for one project", () => {
+    expect(getAllPermissionNames(projectPermissions("proj_12345678"))).toEqual([
+      "project.proj_12345678.read_project",
+      "project.proj_12345678.update_project",
+      "project.proj_12345678.delete_project",
+      "project.proj_12345678.create_app",
+      "project.proj_12345678.create_deployment",
+      "project.proj_12345678.read_deployment",
+    ]);
+  });
+
+  it("lists every action for one app", () => {
+    expect(getAllPermissionNames(appPermissions("app_12345678"))).toEqual(
+      appActions.options.map((action) => `app.app_12345678.${action}`),
+    );
+  });
+});

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/root-keys/components/dialog/permissions.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/root-keys/components/dialog/permissions.ts
@@ -136,6 +136,10 @@ export const workspacePermissions = {
       description: "Read roles in this workspace",
       permission: "rbac.*.read_role",
     },
+    update_role: {
+      description: "Update roles in this workspace",
+      permission: "rbac.*.update_role",
+    },
     delete_role: {
       description: "Delete a role in this workspace",
       permission: "rbac.*.delete_role",
@@ -147,6 +151,10 @@ export const workspacePermissions = {
     read_permission: {
       description: "Read permissions in this workspace",
       permission: "rbac.*.read_permission",
+    },
+    update_permission: {
+      description: "Update permissions in this workspace",
+      permission: "rbac.*.update_permission",
     },
     delete_permission: {
       description: "Delete a permission in this workspace",
@@ -167,6 +175,14 @@ export const workspacePermissions = {
     remove_role_from_key: {
       description: "Remove a role from a key",
       permission: "rbac.*.remove_role_from_key",
+    },
+    add_permission_to_role: {
+      description: "Add permissions to roles in this workspace",
+      permission: "rbac.*.add_permission_to_role",
+    },
+    remove_permission_from_role: {
+      description: "Remove permissions from roles in this workspace",
+      permission: "rbac.*.remove_permission_from_role",
     },
   },
   Identities: {
@@ -211,6 +227,20 @@ export const workspacePermissions = {
     read_runtime_logs: {
       description: "Query deployment runtime logs for all projects in this workspace using SQL.",
       permission: "project.*.read_runtime_logs",
+    },
+  },
+  "Project Deployments": {
+    create_deployment: {
+      description: "Create deployments in any project in this workspace",
+      permission: "project.*.create_deployment",
+    },
+    read_deployment: {
+      description: "Read deployments in any project in this workspace",
+      permission: "project.*.read_deployment",
+    },
+    generate_upload_url: {
+      description: "Generate upload URLs for deployments in this workspace",
+      permission: "project.*.generate_upload_url",
     },
   },
   Portals: {
@@ -402,10 +432,34 @@ export function projectPermissions(projectId: string): {
   [category: string]: UnkeyPermissions;
 } {
   return {
+    Projects: {
+      read_project: {
+        description: "Read this project.",
+        permission: `project.${projectId}.read_project`,
+      },
+      update_project: {
+        description: "Update this project.",
+        permission: `project.${projectId}.update_project`,
+      },
+      delete_project: {
+        description: "Delete this project.",
+        permission: `project.${projectId}.delete_project`,
+      },
+    },
     Apps: {
       create_app: {
         description: "Create new apps in this project.",
         permission: `project.${projectId}.create_app`,
+      },
+    },
+    Deployments: {
+      create_deployment: {
+        description: "Create deployments in this project.",
+        permission: `project.${projectId}.create_deployment`,
+      },
+      read_deployment: {
+        description: "Read deployments in this project.",
+        permission: `project.${projectId}.read_deployment`,
       },
     },
   };
@@ -427,6 +481,10 @@ export function appPermissions(appId: string): {
       delete_app: {
         description: "Delete apps in this project.",
         permission: `app.${appId}.delete_app`,
+      },
+      connect_repository: {
+        description: "Connect or disconnect a GitHub repository for this app.",
+        permission: `app.${appId}.connect_repository`,
       },
     },
   };


### PR DESCRIPTION
## Problem:

Our root key permission picker missed some perms I wanted to grant my root key

## Solution:

Add missing permissions to da dashboard

## Impact:

Shouldnt be any u can grant more perms now

## Testing:

- `mise exec -- pnpm --dir=web --filter @unkey/dashboard exec vitest run 'app/(app)/[workspaceSlug]/settings/root-keys/components/dialog/permissions.test.ts'`
- `mise exec -- pnpm --dir=web --filter @unkey/dashboard typecheck`
- `mise exec -- pnpm --dir=web exec biome check 'apps/dashboard/app/(app)/[workspaceSlug]/settings/root-keys/components/dialog/permissions.ts' 'apps/dashboard/app/(app)/[workspaceSlug]/settings/root-keys/components/dialog/permissions.test.ts'`