### PR TITLE
fix(dashboard): allow GitHub installations in multiple workspaces

### DIFF
--- a/web/apps/dashboard/app/(app)/integrations/github/callback/page.tsx
+++ b/web/apps/dashboard/app/(app)/integrations/github/callback/page.tsx
@@ -26,6 +26,11 @@ export default function Page() {
 
   const mutation = trpc.github.registerInstallation.useMutation({
     onSuccess: (data) => {
+      if (data.status === "authorization_required") {
+        window.location.replace(data.authorizationUrl);
+        return;
+      }
+
       if (data.flow === "app" && data.projectId && data.appId) {
         // Return to the app: its settings, or the repo picker when the wizard
         // hasn't chosen a repo yet.
@@ -55,17 +60,17 @@ export default function Page() {
   // strict-mode remount reads before the first mutate flips it), blocks a re-submit.
   const submittedRef = useRef(false);
   useEffect(() => {
-    if (!state || installationIdNumber === null || submittedRef.current) {
+    if (!state || (installationIdNumber === null && !code) || submittedRef.current) {
       return;
     }
     submittedRef.current = true;
 
-    // `code` is absent when an existing user returns from editing an
-    // already-authorized installation. The server only requires it when
-    // binding an installation the workspace does not already own.
+    // `code` is absent when GitHub returns from editing an existing
+    // installation. The server starts an authorization round-trip if this
+    // workspace has not linked the installation yet.
     mutation.mutate({
       state,
-      installationId: installationIdNumber,
+      installationId: installationIdNumber ?? undefined,
       code: code ?? undefined,
     });
   }, [mutation, state, installationIdNumber, code]);
@@ -81,7 +86,7 @@ export default function Page() {
     );
   }
 
-  if (installationIdNumber === null) {
+  if (installationIdNumber === null && !code) {
     return (
       <div className="w-full min-h-[60vh] flex justify-center items-center">
         <Empty>

--- a/web/apps/dashboard/lib/trpc/routers/github.test.ts
+++ b/web/apps/dashboard/lib/trpc/routers/github.test.ts
@@ -1,0 +1,344 @@
+import type { TRPCError } from "@trpc/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type Context = {
+  workspace: { id: string; slug: string };
+  user: { id: string };
+  audit: { location: string; userAgent: string };
+};
+
+type RegisterInput = {
+  state: string;
+  installationId?: number;
+  code?: string;
+};
+
+type RegisterResult =
+  | { status: "authorization_required"; authorizationUrl: string }
+  | {
+      status: "registered";
+      workspaceSlug: string;
+      flow: "api" | "workspace" | "app";
+      projectId: string | null;
+      appId: string | null;
+      returnTo: "settings" | null;
+    };
+
+type RegisterResolver = (opts: {
+  ctx: Context;
+  input: RegisterInput;
+}) => Promise<RegisterResult>;
+
+type PrepareWorkspaceResolver = (opts: { ctx: Context }) => Promise<{ state: string }>;
+
+type InstallationRow = {
+  pk: number;
+  workspaceId: string;
+  installationId: number;
+};
+
+type InstallationColumn = keyof InstallationRow;
+type Predicate = { column: InstallationColumn; value: unknown } | { predicates: Predicate[] };
+
+const state = vi.hoisted(() => ({
+  prepareWorkspaceResolver: null as PrepareWorkspaceResolver | null,
+  inputMutationResolvers: [] as RegisterResolver[],
+  rows: [] as InstallationRow[],
+  inserted: [] as Array<{ workspaceId: string; installationId: number }>,
+  exchangedCodes: [] as string[],
+  checkedInstallationIds: [] as number[],
+  canAccessInstallation: true,
+  exchangeError: null as Error | null,
+}));
+
+vi.mock("@/lib/db", () => {
+  const installationTable = {
+    pk: "pk",
+    workspaceId: "workspaceId",
+    installationId: "installationId",
+  } as const;
+
+  const eq = (column: InstallationColumn, value: unknown): Predicate => ({ column, value });
+  const and = (...predicates: Predicate[]): Predicate => ({ predicates });
+  const matches = (row: InstallationRow, predicate: Predicate): boolean =>
+    "predicates" in predicate
+      ? predicate.predicates.every((nested) => matches(row, nested))
+      : row[predicate.column] === predicate.value;
+
+  return {
+    and,
+    eq,
+    schema: {
+      githubAppInstallations: installationTable,
+      githubRepoConnections: {},
+      apps: {},
+    },
+    db: {
+      query: {
+        githubAppInstallations: {
+          findFirst: async ({
+            where,
+          }: {
+            where: (
+              table: typeof installationTable,
+              operators: { and: typeof and; eq: typeof eq },
+            ) => Predicate;
+          }) => state.rows.find((row) => matches(row, where(installationTable, { and, eq }))),
+        },
+        projects: {
+          findFirst: async () => undefined,
+        },
+        apps: {
+          findFirst: async () => undefined,
+        },
+      },
+      transaction: async <T>(fn: (tx: unknown) => Promise<T>): Promise<T> => {
+        const tx = {
+          insert: () => ({
+            values: (binding: { workspaceId: string; installationId: number }) => ({
+              onDuplicateKeyUpdate: async () => {
+                state.inserted.push({
+                  workspaceId: binding.workspaceId,
+                  installationId: binding.installationId,
+                });
+              },
+            }),
+          }),
+        };
+        return fn(tx);
+      },
+    },
+  };
+});
+
+vi.mock("@/lib/audit", () => ({
+  insertAuditLogs: async () => undefined,
+}));
+
+vi.mock("@/lib/env", () => ({
+  githubAppEnv: () => ({
+    GITHUB_APP_ID: 1,
+    UNKEY_GITHUB_PRIVATE_KEY_PEM: "test-private-key",
+  }),
+  githubOAuthEnv: () => ({
+    GITHUB_CLIENT_ID: "github-client-id",
+    GITHUB_CLIENT_SECRET: "github-client-secret",
+  }),
+}));
+
+vi.mock("@/lib/github", () => ({
+  MAX_BRANCHES: 20,
+  exchangeInstallationOAuthCode: async (code: string) => {
+    state.exchangedCodes.push(code);
+    if (state.exchangeError) {
+      throw state.exchangeError;
+    }
+    return "user-token";
+  },
+  userCanAccessInstallation: async (_userToken: string, installationId: number) => {
+    state.checkedInstallationIds.push(installationId);
+    return state.canAccessInstallation;
+  },
+  getInstallationRepositories: async () => [],
+  getMostActiveBranches: async () => [],
+  getRepository: async () => null,
+  getRepositoryBranches: async () => [],
+  getRepositoryById: async () => null,
+  getRepositoryTree: async () => ({ tree: [], truncated: false }),
+  searchBranchesByPrefix: async () => [],
+}));
+
+vi.mock("../trpc", () => ({
+  t: {
+    router: <T>(routes: T): T => routes,
+  },
+  workspaceProcedure: {
+    query: <T>(resolver: T): T => resolver,
+    mutation: (resolver: PrepareWorkspaceResolver) => {
+      state.prepareWorkspaceResolver = resolver;
+      return resolver;
+    },
+    input: () => ({
+      query: <T>(resolver: T): T => resolver,
+      mutation: (resolver: RegisterResolver) => {
+        state.inputMutationResolvers.push(resolver);
+        return resolver;
+      },
+    }),
+  },
+}));
+
+import "./github";
+
+const context: Context = {
+  workspace: { id: "ws_destination", slug: "destination" },
+  user: { id: "user_1" },
+  audit: { location: "127.0.0.1", userAgent: "vitest" },
+};
+
+function prepareWorkspaceState(): Promise<{ state: string }> {
+  if (!state.prepareWorkspaceResolver) {
+    throw new Error("prepareWorkspaceInstall resolver was not registered");
+  }
+  return state.prepareWorkspaceResolver({ ctx: context });
+}
+
+function registerInstallation(input: RegisterInput): Promise<RegisterResult> {
+  const resolver = state.inputMutationResolvers[1];
+  if (!resolver) {
+    throw new Error("registerInstallation resolver was not registered");
+  }
+  return resolver({ ctx: context, input });
+}
+
+describe("registerInstallation", () => {
+  beforeEach(() => {
+    state.rows = [{ pk: 1, workspaceId: "ws_source", installationId: 42 }];
+    state.inserted = [];
+    state.exchangedCodes = [];
+    state.checkedInstallationIds = [];
+    state.canAccessInstallation = true;
+    state.exchangeError = null;
+  });
+
+  it("binds one GitHub installation to another workspace after verifying the user", async () => {
+    const signedState = await prepareWorkspaceState();
+
+    await registerInstallation({
+      state: signedState.state,
+      installationId: 42,
+      code: "oauth-code",
+    });
+
+    expect(state.exchangedCodes).toEqual(["oauth-code"]);
+    expect(state.checkedInstallationIds).toEqual([42]);
+    expect(state.inserted).toEqual([{ workspaceId: "ws_destination", installationId: 42 }]);
+  });
+
+  it("requests authorization when GitHub edits an existing installation without a code", async () => {
+    const signedState = await prepareWorkspaceState();
+
+    const authorization = await registerInstallation({
+      state: signedState.state,
+      installationId: 42,
+    });
+    if (authorization.status !== "authorization_required") {
+      throw new Error("Expected GitHub authorization URL");
+    }
+
+    expect(state.inserted).toEqual([]);
+    const authorizationUrl = new URL(authorization.authorizationUrl);
+    expect(authorizationUrl.origin).toBe("https://github.com");
+    expect(authorizationUrl.pathname).toBe("/login/oauth/authorize");
+    expect(authorizationUrl.searchParams.get("client_id")).toBe("github-client-id");
+
+    const refreshedState = authorizationUrl.searchParams.get("state");
+    if (!refreshedState) {
+      throw new Error("Authorization URL did not include state");
+    }
+
+    await registerInstallation({ state: refreshedState, code: "fresh-oauth-code" });
+
+    expect(state.checkedInstallationIds).toEqual([42]);
+    expect(state.inserted).toEqual([{ workspaceId: "ws_destination", installationId: 42 }]);
+  });
+
+  it("does not reauthorize an installation already linked to the workspace", async () => {
+    state.rows = [{ pk: 1, workspaceId: "ws_destination", installationId: 42 }];
+    const signedState = await prepareWorkspaceState();
+
+    await registerInstallation({ state: signedState.state, installationId: 42 });
+
+    expect(state.exchangedCodes).toEqual([]);
+    expect(state.checkedInstallationIds).toEqual([]);
+    expect(state.inserted).toEqual([{ workspaceId: "ws_destination", installationId: 42 }]);
+  });
+
+  it("rejects a new workspace binding when the GitHub user cannot access the installation", async () => {
+    state.canAccessInstallation = false;
+    const signedState = await prepareWorkspaceState();
+
+    await expect(
+      registerInstallation({
+        state: signedState.state,
+        installationId: 42,
+        code: "oauth-code",
+      }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" } satisfies Partial<TRPCError>);
+    expect(state.inserted).toEqual([]);
+  });
+
+  it("rejects a forged installation id in signed authorization state", async () => {
+    const signedState = await prepareWorkspaceState();
+    const authorization = await registerInstallation({
+      state: signedState.state,
+      installationId: 42,
+    });
+    if (authorization.status !== "authorization_required") {
+      throw new Error("Expected GitHub authorization URL");
+    }
+
+    const authorizationUrl = new URL(authorization.authorizationUrl);
+    const refreshedState = authorizationUrl.searchParams.get("state");
+    if (!refreshedState) {
+      throw new Error("Authorization URL did not include state");
+    }
+    const forgedState = refreshedState.replace('"installationId":42', '"installationId":99');
+    if (forgedState === refreshedState) {
+      throw new Error("Signed state did not include the installation id");
+    }
+
+    await expect(
+      registerInstallation({ state: forgedState, code: "oauth-code" }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" } satisfies Partial<TRPCError>);
+    expect(state.exchangedCodes).toEqual([]);
+    expect(state.inserted).toEqual([]);
+  });
+
+  it("rejects an installation id swapped after authorization", async () => {
+    const signedState = await prepareWorkspaceState();
+    const authorization = await registerInstallation({
+      state: signedState.state,
+      installationId: 42,
+    });
+    if (authorization.status !== "authorization_required") {
+      throw new Error("Expected GitHub authorization URL");
+    }
+
+    const authorizationUrl = new URL(authorization.authorizationUrl);
+    const refreshedState = authorizationUrl.searchParams.get("state");
+    if (!refreshedState) {
+      throw new Error("Authorization URL did not include state");
+    }
+
+    await expect(
+      registerInstallation({
+        state: refreshedState,
+        installationId: 99,
+        code: "oauth-code",
+      }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" } satisfies Partial<TRPCError>);
+    expect(state.exchangedCodes).toEqual([]);
+    expect(state.inserted).toEqual([]);
+  });
+
+  it("rejects a fake OAuth authorization code", async () => {
+    state.exchangeError = new Error("bad verification code");
+    const signedState = await prepareWorkspaceState();
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    try {
+      await expect(
+        registerInstallation({
+          state: signedState.state,
+          installationId: 42,
+          code: "fake-code",
+        }),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" } satisfies Partial<TRPCError>);
+    } finally {
+      consoleError.mockRestore();
+    }
+    expect(state.checkedInstallationIds).toEqual([]);
+    expect(state.inserted).toEqual([]);
+  });
+});

--- a/web/apps/dashboard/lib/trpc/routers/github.ts
+++ b/web/apps/dashboard/lib/trpc/routers/github.ts
@@ -37,6 +37,7 @@ const stateBaseFields = {
   workspaceId: z.string().min(1),
   nonce: z.string().min(1),
   exp: z.number().int().positive(),
+  installationId: z.number().int().positive().optional(),
 };
 
 // Each variant is strict: a state may carry ONLY the fields its flow declares.
@@ -334,14 +335,13 @@ export const githubRouter = t.router({
     .input(
       z.object({
         state: z.string(),
-        installationId: z.number().int(),
+        installationId: z.number().int().positive().optional(),
         // OAuth `code` returned alongside installation_id when the GitHub App
         // requests user authorization during installation. Used to prove the
-        // caller can access the supplied installation before binding it for the
-        // first time. GitHub only issues it on the initial authorization, not
-        // when an already-authorized user returns from editing an existing
-        // installation, so it is optional and only required on first bind
-        // (see the mutation body).
+        // caller can access the supplied installation before binding it to a
+        // workspace. It is optional because GitHub does not issue one when an
+        // existing installation is edited; the mutation starts an explicit
+        // authorization round-trip when a new workspace binding needs proof.
         code: z.string().min(1).optional(),
       }),
     )
@@ -375,6 +375,19 @@ export const githubRouter = t.router({
         });
       }
 
+      const installationId = parsedState.installationId ?? input.installationId;
+      if (
+        !installationId ||
+        (parsedState.installationId !== undefined &&
+          input.installationId !== undefined &&
+          parsedState.installationId !== input.installationId)
+      ) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Invalid GitHub installation",
+        });
+      }
+
       // The app to land back on, or null for a workspace-wide install.
       const target =
         parsedState.flow === "app"
@@ -385,52 +398,51 @@ export const githubRouter = t.router({
             }
           : null;
 
-      // Look up any existing binding for this installation id up front; whether
-      // we must re-prove ownership depends on who (if anyone) already owns it.
+      // A GitHub installation belongs to a GitHub account, not an Unkey
+      // workspace. Multiple workspaces may use it, but each new workspace
+      // binding must independently prove that the caller can access it.
       const existing = await db.query.githubAppInstallations.findFirst({
-        where: (table, { eq }) => eq(table.installationId, input.installationId),
-        columns: { workspaceId: true },
+        where: (table, { and, eq }) =>
+          and(eq(table.installationId, installationId), eq(table.workspaceId, ctx.workspace.id)),
+        columns: { pk: true },
       });
 
-      // Refuse to bind the same installation id to multiple workspaces. An
-      // attacker who already owns a workspace could otherwise re-register a
-      // victim org's installation id under their workspace, and use the
-      // resulting Unkey-minted access token to read the victim's repos.
-      if (existing && existing.workspaceId !== ctx.workspace.id) {
-        throw new TRPCError({
-          code: "CONFLICT",
-          message: "GitHub installation is already bound to another workspace",
-        });
-      }
-
       // Verify the caller actually owns/can access this installation on GitHub
-      // before binding it for the first time. installationId comes straight
+      // before binding it to this workspace. installationId comes straight
       // from the callback query string and is a small, enumerable, sequential
       // integer exposed in webhooks/URLs; the signed state only proves who the
       // caller is, not that they performed this installation. Without this a
-      // caller could bind a victim org's unregistered installation to their own
-      // workspace and read its private repos via the app-minted access token.
+      // caller could bind a victim org's installation to their own workspace
+      // and read its private repos via the app-minted access token.
       //
-      // We only require this proof when the installation is not already bound
-      // to the caller's workspace. GitHub issues a fresh OAuth `code` only on
-      // the initial authorization, not when an existing user returns from
-      // editing an already-authorized installation (adding or restricting
-      // repos). Re-demanding a code there would break every existing user and
-      // buys no security: the installation already belongs to this workspace,
-      // so there is nothing to hijack.
-      const alreadyOwnedByCaller = existing?.workspaceId === ctx.workspace.id;
-      if (!alreadyOwnedByCaller) {
-        if (!githubOAuthEnv()) {
+      // GitHub does not return a fresh OAuth code when an existing installation
+      // is edited. Start the normal web authorization flow in that case and
+      // bind the installation id into the refreshed signed state. The next
+      // callback can then prove both user access and callback integrity.
+      if (!existing) {
+        const oauthEnv = githubOAuthEnv();
+        if (!oauthEnv) {
           throw new TRPCError({
             code: "INTERNAL_SERVER_ERROR",
             message: "GitHub App not configured",
           });
         }
         if (!input.code) {
-          throw new TRPCError({
-            code: "BAD_REQUEST",
-            message: "Missing GitHub authorization",
-          });
+          const authorizationUrl = new URL("https://github.com/login/oauth/authorize");
+          authorizationUrl.searchParams.set("client_id", oauthEnv.GITHUB_CLIENT_ID);
+          authorizationUrl.searchParams.set(
+            "state",
+            signState({
+              ...parsedState,
+              installationId,
+              nonce: crypto.randomBytes(16).toString("base64url"),
+              exp: Date.now() + STATE_TTL_MS,
+            }),
+          );
+          return {
+            status: "authorization_required" as const,
+            authorizationUrl: authorizationUrl.toString(),
+          };
         }
 
         let userToken: string;
@@ -446,7 +458,7 @@ export const githubRouter = t.router({
 
         let canAccessInstallation: boolean;
         try {
-          canAccessInstallation = await userCanAccessInstallation(userToken, input.installationId);
+          canAccessInstallation = await userCanAccessInstallation(userToken, installationId);
         } catch (err) {
           console.error(err);
           throw new TRPCError({
@@ -469,7 +481,7 @@ export const githubRouter = t.router({
         const projectInstallation = await fetchProjectInstallation(
           ctx.workspace.id,
           target.projectId,
-          input.installationId,
+          installationId,
         ).catch((err) => {
           console.error(err);
           throw new TRPCError({
@@ -495,7 +507,7 @@ export const githubRouter = t.router({
             .insert(schema.githubAppInstallations)
             .values({
               workspaceId: ctx.workspace.id,
-              installationId: input.installationId,
+              installationId,
               createdAt: Date.now(),
               updatedAt: null,
             })
@@ -506,14 +518,14 @@ export const githubRouter = t.router({
               workspaceId: ctx.workspace.id,
               actor: { type: "user", id: ctx.user.id },
               event: "workspace.install_github",
-              description: `Bound GitHub installation ${input.installationId}`,
+              description: `Bound GitHub installation ${installationId}`,
               resources: [
                 {
                   type: "workspace",
                   id: ctx.workspace.id,
                   meta: {
                     flow: parsedState.flow,
-                    installationId: input.installationId,
+                    installationId,
                     appId: target?.appId,
                   },
                 },
@@ -534,6 +546,7 @@ export const githubRouter = t.router({
         });
 
       return {
+        status: "registered" as const,
         workspaceSlug: ctx.workspace.slug,
         flow: parsedState.flow,
         projectId: target?.projectId ?? null,


### PR DESCRIPTION
## Problem:

I want to deploy Flo4604/test123 in my flo private workspace but also a different Flo4604/xyz repo in my @unkey account account

currently I cant which is annoying and seems like an arbitrary limitation. 

## Solution:

Allow a github installation to be connected to multiple unkey workspaces, this requires a new authorization for each workspace connection.

## Impact:

A user can now connect their github acc/orgas to seperate workspaces and every workspace still conitnues to work.

## Testing:

- `mise exec -- pnpm --dir=web/apps/dashboard vitest run lib/trpc/routers/github.test.ts` (7 tests passed)
- `mise exec -- pnpm --dir=web/apps/dashboard typecheck` (passed)