### PR TITLE
fix(dashboard): prevent WorkOS login redirect loop

### DIFF
--- a/web/apps/dashboard/app/auth/actions.ts
+++ b/web/apps/dashboard/app/auth/actions.ts
@@ -366,9 +366,7 @@ export async function completeOrgSelection(
 
   if (result.success) {
     (await cookies()).delete(PENDING_SESSION_COOKIE);
-    for (const cookie of result.cookies) {
-      (await cookies()).set(cookie.name, cookie.value, cookie.options);
-    }
+    await setCookies(result.cookies);
     // Store the last used organization ID in a cookie for auto-selection on next login
     try {
       await setLastUsedOrgCookie({ orgId });

--- a/web/apps/dashboard/lib/auth/cookies.ts
+++ b/web/apps/dashboard/lib/auth/cookies.ts
@@ -10,10 +10,10 @@ import type { NextRequest, NextResponse } from "next/server";
 import { getAuthCookieOptions, getDefaultCookieOptions } from "./cookie-security";
 import { UNKEY_LAST_ORG_COOKIE, UNKEY_SESSION_COOKIE } from "./types";
 
-// WorkOS seals permission and feature claims into the session. Keep each part
-// below the browser's 4096-byte cookie limit after names and attributes.
+// Browsers cap one cookie at 4096 bytes, while Vercel caps the combined Cookie
+// request header at 16KB. Four parts leave space for names and other cookies.
 const SESSION_COOKIE_CHUNK_SIZE = 3500;
-const MAX_SESSION_COOKIE_CHUNKS = 8;
+const MAX_SESSION_COOKIE_CHUNKS = 4;
 
 export interface CookieOptions {
   httpOnly: boolean;
@@ -63,16 +63,17 @@ function getCookieUpdates(cookie: Cookie): Cookie[] {
     chunks.push(sessionCookie.value.slice(offset, offset + SESSION_COOKIE_CHUNK_SIZE));
   }
 
-  Sentry.captureMessage("WorkOS session cookie exceeds browser size limit", {
-    level: "warning",
-    fingerprint: ["workos-session-cookie-oversized"],
-    tags: { component: "authentication" },
-    extra: {
-      sessionSizeBytes: sessionCookie.value.length,
-      chunkCount: chunks.length,
-    },
-  });
   if (chunks.length > MAX_SESSION_COOKIE_CHUNKS) {
+    Sentry.captureMessage("WorkOS session exceeds Vercel cookie capacity", {
+      level: "error",
+      fingerprint: ["workos-session-cookie-capacity-exceeded"],
+      tags: { component: "authentication" },
+      extra: {
+        sessionSizeBytes: sessionCookie.value.length,
+        chunkCount: chunks.length,
+        maxChunkCount: MAX_SESSION_COOKIE_CHUNKS,
+      },
+    });
     throw new Error("Session is too large to store in cookies");
   }
 

--- a/web/apps/dashboard/lib/auth/cookies.ts
+++ b/web/apps/dashboard/lib/auth/cookies.ts
@@ -4,10 +4,16 @@
 // setCookies helpers that accept arbitrary name, value, and option fields.
 // Client components must go through the narrow wrappers in ./cookies-actions.
 
+import * as Sentry from "@sentry/nextjs";
 import { cookies } from "next/headers";
 import type { NextRequest, NextResponse } from "next/server";
 import { getAuthCookieOptions, getDefaultCookieOptions } from "./cookie-security";
 import { UNKEY_LAST_ORG_COOKIE, UNKEY_SESSION_COOKIE } from "./types";
+
+// WorkOS seals permission and feature claims into the session. Keep each part
+// below the browser's 4096-byte cookie limit after names and attributes.
+const SESSION_COOKIE_CHUNK_SIZE = 3500;
+const MAX_SESSION_COOKIE_CHUNKS = 8;
 
 export interface CookieOptions {
   httpOnly: boolean;
@@ -25,12 +31,81 @@ export interface Cookie {
   options?: CookieOptions;
 }
 
+// sessionCookieChunkName keeps chunk naming identical across every cookie API.
+function sessionCookieChunkName(index: number): string {
+  return `${UNKEY_SESSION_COOKIE}.${index}`;
+}
+
+// getCookieUpdates converts one logical session into browser-safe cookie writes.
+// The final expired part stops readers before any stale parts from an older session.
+function getCookieUpdates(cookie: Cookie): Cookie[] {
+  if (cookie.name !== UNKEY_SESSION_COOKIE) {
+    return [cookie];
+  }
+
+  const options = cookie.options ?? getAuthCookieOptions();
+  const sessionCookie: Cookie = {
+    ...cookie,
+    options,
+  };
+  const expired: Cookie = {
+    ...sessionCookie,
+    value: "",
+    options: { ...options, maxAge: 0 },
+  };
+
+  if (sessionCookie.value.length <= SESSION_COOKIE_CHUNK_SIZE) {
+    return [sessionCookie, { ...expired, name: sessionCookieChunkName(0) }];
+  }
+
+  const chunks = [];
+  for (let offset = 0; offset < sessionCookie.value.length; offset += SESSION_COOKIE_CHUNK_SIZE) {
+    chunks.push(sessionCookie.value.slice(offset, offset + SESSION_COOKIE_CHUNK_SIZE));
+  }
+
+  Sentry.captureMessage("WorkOS session cookie exceeds browser size limit", {
+    level: "warning",
+    fingerprint: ["workos-session-cookie-oversized"],
+    tags: { component: "authentication" },
+    extra: {
+      sessionSizeBytes: sessionCookie.value.length,
+      chunkCount: chunks.length,
+    },
+  });
+  if (chunks.length > MAX_SESSION_COOKIE_CHUNKS) {
+    throw new Error("Session is too large to store in cookies");
+  }
+
+  return [
+    expired,
+    ...chunks.map((value, index) => ({
+      ...sessionCookie,
+      name: sessionCookieChunkName(index),
+      value,
+    })),
+    { ...expired, name: sessionCookieChunkName(chunks.length) },
+  ];
+}
+
 /**
  * Get a cookie value by name
  */
 export async function getCookie(name: string, request?: NextRequest): Promise<string | null> {
   const cookieStore = request?.cookies || (await cookies());
-  return cookieStore.get(name)?.value ?? null;
+  const value = cookieStore.get(name)?.value;
+  if (value || name !== UNKEY_SESSION_COOKIE) {
+    return value ?? null;
+  }
+
+  const chunks = [];
+  for (let index = 0; index < MAX_SESSION_COOKIE_CHUNKS; index++) {
+    const chunk = cookieStore.get(sessionCookieChunkName(index))?.value;
+    if (!chunk) {
+      break;
+    }
+    chunks.push(chunk);
+  }
+  return chunks.length > 0 ? chunks.join("") : null;
 }
 
 /**
@@ -38,7 +113,9 @@ export async function getCookie(name: string, request?: NextRequest): Promise<st
  */
 export async function setCookie(cookie: Cookie): Promise<void> {
   const cookieStore = await cookies();
-  cookieStore.set(cookie.name, cookie.value, cookie.options);
+  for (const update of getCookieUpdates(cookie)) {
+    cookieStore.set(update.name, update.value, update.options);
+  }
 }
 
 /**
@@ -47,7 +124,9 @@ export async function setCookie(cookie: Cookie): Promise<void> {
 export async function setCookies(cookieList: Cookie[]): Promise<void> {
   const cookieStore = await cookies();
   for (const cookie of cookieList) {
-    cookieStore.set(cookie.name, cookie.value, cookie.options);
+    for (const update of getCookieUpdates(cookie)) {
+      cookieStore.set(update.name, update.value, update.options);
+    }
   }
 }
 
@@ -57,6 +136,11 @@ export async function setCookies(cookieList: Cookie[]): Promise<void> {
 export async function deleteCookie(name: string): Promise<void> {
   const cookieStore = await cookies();
   cookieStore.delete(name);
+  if (name === UNKEY_SESSION_COOKIE) {
+    for (let index = 0; index <= MAX_SESSION_COOKIE_CHUNKS; index++) {
+      cookieStore.delete(sessionCookieChunkName(index));
+    }
+  }
 }
 
 /**
@@ -95,9 +179,21 @@ export async function setCookiesOnResponse(
   cookieList: Cookie[],
 ): Promise<NextResponse> {
   for (const cookie of cookieList) {
-    response.cookies.set(cookie.name, cookie.value, cookie.options);
+    for (const update of getCookieUpdates(cookie)) {
+      response.cookies.set(update.name, update.value, update.options);
+    }
   }
   return response;
+}
+
+/** Serializes all browser-safe writes for one logical cookie. */
+export async function getSetCookieHeaders(cookie: Cookie): Promise<string[]> {
+  return Promise.all(
+    getCookieUpdates(cookie).map(
+      async (update) =>
+        `${update.name}=${update.value}; ${await getCookieOptionsAsString(update.options)}`,
+    ),
+  );
 }
 
 /**

--- a/web/apps/dashboard/lib/auth/sessions.ts
+++ b/web/apps/dashboard/lib/auth/sessions.ts
@@ -3,7 +3,7 @@
 import { env } from "@/lib/env";
 import type { NextRequest } from "next/server";
 import { getAuthCookieOptions } from "./cookie-security";
-import { getCookie, getCookieOptionsAsString, setSessionCookie } from "./cookies";
+import { type CookieOptions, getCookie, getSetCookieHeaders, setSessionCookie } from "./cookies";
 import { auth } from "./server";
 import { UNKEY_SESSION_COOKIE, type User } from "./types";
 
@@ -23,6 +23,22 @@ type SessionResult = {
   } | null;
   headers: Headers;
 };
+
+// appendSessionCookieHeaders preserves one Set-Cookie field per session part.
+async function appendSessionCookieHeaders(
+  headers: Headers,
+  token: string,
+  options: CookieOptions,
+): Promise<void> {
+  const cookieHeaders = await getSetCookieHeaders({
+    name: UNKEY_SESSION_COOKIE,
+    value: token,
+    options,
+  });
+  for (const cookieHeader of cookieHeaders) {
+    headers.append("Set-Cookie", cookieHeader);
+  }
+}
 
 export async function updateSession(request?: NextRequest): Promise<SessionResult> {
   const UNKEY_SESSION_HEADER = `x-${UNKEY_SESSION_COOKIE}`;
@@ -49,12 +65,10 @@ export async function updateSession(request?: NextRequest): Promise<SessionResul
 
         await setSessionCookie({ token: localSessionToken, expiresAt });
       } catch (_error) {
-        headers.append(
-          "Set-Cookie",
-          `${UNKEY_SESSION_COOKIE}=${localSessionToken}; Path=/; SameSite=Lax; Max-Age=${
-            60 * 60 * 24 * 365 * 10
-          }`,
-        );
+        await appendSessionCookieHeaders(headers, localSessionToken, {
+          ...getAuthCookieOptions(),
+          maxAge: 60 * 60 * 24 * 365 * 10,
+        });
       }
     }
 
@@ -123,15 +137,10 @@ export async function updateSession(request?: NextRequest): Promise<SessionResul
           // Use different methods to set cookies based on whether we have a request
           if (request) {
             // For middleware/trpc routes with request object
-            headers.append(
-              "Set-Cookie",
-              `${UNKEY_SESSION_COOKIE}=${
-                refreshedSession.newToken
-              }; ${await getCookieOptionsAsString({
-                ...getAuthCookieOptions(),
-                expiresAt: refreshedSession.expiresAt,
-              })}`,
-            );
+            await appendSessionCookieHeaders(headers, refreshedSession.newToken, {
+              ...getAuthCookieOptions(),
+              expiresAt: refreshedSession.expiresAt,
+            });
           } else {
             // For client-side or RSC or when no request is available
             // Only use cookies() API when NOT in middleware context
@@ -142,15 +151,10 @@ export async function updateSession(request?: NextRequest): Promise<SessionResul
               });
             } catch (_cookieError) {
               // Fall back to headers approach if cookie setting fails
-              headers.append(
-                "Set-Cookie",
-                `${UNKEY_SESSION_COOKIE}=${
-                  refreshedSession.newToken
-                }; ${await getCookieOptionsAsString({
-                  ...getAuthCookieOptions(),
-                  expiresAt: refreshedSession.expiresAt,
-                })}`,
-              );
+              await appendSessionCookieHeaders(headers, refreshedSession.newToken, {
+                ...getAuthCookieOptions(),
+                expiresAt: refreshedSession.expiresAt,
+              });
             }
           }
 

--- a/web/apps/dashboard/lib/auth/tests/cookies.test.ts
+++ b/web/apps/dashboard/lib/auth/tests/cookies.test.ts
@@ -1,0 +1,91 @@
+import * as Sentry from "@sentry/nextjs";
+import { NextRequest, NextResponse } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getCookie, setCookiesOnResponse } from "../cookies";
+import { UNKEY_SESSION_COOKIE } from "../types";
+
+vi.mock("@sentry/nextjs", () => ({
+  captureMessage: vi.fn(),
+}));
+
+const options = {
+  httpOnly: true,
+  secure: true,
+  sameSite: "lax" as const,
+  path: "/",
+};
+
+function requestWithResponseCookies(response: NextResponse): NextRequest {
+  const cookie = response.headers
+    .getSetCookie()
+    .filter((header) => !header.includes("Max-Age=0"))
+    .map((header) => header.slice(0, header.indexOf(";")))
+    .join("; ");
+
+  return new NextRequest("https://app.unkey.com/apis", {
+    headers: { cookie },
+  });
+}
+
+describe("session cookies", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("stores and reads a session larger than one browser cookie", async () => {
+    const session = "s".repeat(9000);
+    const response = NextResponse.next();
+
+    await setCookiesOnResponse(response, [{ name: UNKEY_SESSION_COOKIE, value: session, options }]);
+
+    const headers = response.headers.getSetCookie();
+    expect(headers).toHaveLength(5);
+    expect(headers).toEqual([
+      expect.stringContaining(`${UNKEY_SESSION_COOKIE}=;`),
+      expect.stringContaining(`${UNKEY_SESSION_COOKIE}.0=`),
+      expect.stringContaining(`${UNKEY_SESSION_COOKIE}.1=`),
+      expect.stringContaining(`${UNKEY_SESSION_COOKIE}.2=`),
+      expect.stringContaining(`${UNKEY_SESSION_COOKIE}.3=;`),
+    ]);
+    expect(headers.every((header) => header.length < 4096)).toBe(true);
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      "WorkOS session cookie exceeds browser size limit",
+      {
+        level: "warning",
+        fingerprint: ["workos-session-cookie-oversized"],
+        tags: { component: "authentication" },
+        extra: { sessionSizeBytes: 9000, chunkCount: 3 },
+      },
+    );
+
+    const request = requestWithResponseCookies(response);
+    await expect(getCookie(UNKEY_SESSION_COOKIE, request)).resolves.toBe(session);
+  });
+
+  it("keeps small sessions compatible with the original cookie name", async () => {
+    const response = NextResponse.next();
+
+    await setCookiesOnResponse(response, [
+      { name: UNKEY_SESSION_COOKIE, value: "small-session", options },
+    ]);
+
+    expect(response.headers.getSetCookie()).toEqual([
+      expect.stringContaining(`${UNKEY_SESSION_COOKIE}=small-session;`),
+      expect.stringContaining(`${UNKEY_SESSION_COOKIE}.0=;`),
+    ]);
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+
+    const request = requestWithResponseCookies(response);
+    await expect(getCookie(UNKEY_SESSION_COOKIE, request)).resolves.toBe("small-session");
+  });
+
+  it("rejects sessions that exceed the bounded cookie set", async () => {
+    const response = NextResponse.next();
+
+    await expect(
+      setCookiesOnResponse(response, [
+        { name: UNKEY_SESSION_COOKIE, value: "s".repeat(28_001), options },
+      ]),
+    ).rejects.toThrow("Session is too large to store in cookies");
+  });
+});

--- a/web/apps/dashboard/lib/auth/tests/cookies.test.ts
+++ b/web/apps/dashboard/lib/auth/tests/cookies.test.ts
@@ -48,15 +48,7 @@ describe("session cookies", () => {
       expect.stringContaining(`${UNKEY_SESSION_COOKIE}.3=;`),
     ]);
     expect(headers.every((header) => header.length < 4096)).toBe(true);
-    expect(Sentry.captureMessage).toHaveBeenCalledWith(
-      "WorkOS session cookie exceeds browser size limit",
-      {
-        level: "warning",
-        fingerprint: ["workos-session-cookie-oversized"],
-        tags: { component: "authentication" },
-        extra: { sessionSizeBytes: 9000, chunkCount: 3 },
-      },
-    );
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
 
     const request = requestWithResponseCookies(response);
     await expect(getCookie(UNKEY_SESSION_COOKIE, request)).resolves.toBe(session);
@@ -84,8 +76,17 @@ describe("session cookies", () => {
 
     await expect(
       setCookiesOnResponse(response, [
-        { name: UNKEY_SESSION_COOKIE, value: "s".repeat(28_001), options },
+        { name: UNKEY_SESSION_COOKIE, value: "s".repeat(14_001), options },
       ]),
     ).rejects.toThrow("Session is too large to store in cookies");
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      "WorkOS session exceeds Vercel cookie capacity",
+      {
+        level: "error",
+        fingerprint: ["workos-session-cookie-capacity-exceeded"],
+        tags: { component: "authentication" },
+        extra: { sessionSizeBytes: 14_001, chunkCount: 5, maxChunkCount: 4 },
+      },
+    );
   });
 });


### PR DESCRIPTION
## Problem:

WorkOS sealed sessions can exceed the browser's 4096-byte cookie limit. The browser drops the session cookie, so users return to workspace selection after they select a workspace.

## Solution:

Store oversized sessions in browser-safe cookie parts and restore the full session before validation. Keep small sessions compatible with the original cookie. Limit the combined session to four parts so requests remain below Vercel's 16KB per-header limit. Send one grouped Sentry error only when a session cannot fit, without session or user data.

## Impact:

Users with large WorkOS sessions can complete login. Existing small sessions remain compatible.

## Testing:

- Dashboard TypeScript type check passed.
- 54 dashboard auth tests passed.
- Biome checks passed for all changed files.
