### PR TITLE
dashboard: keep key request drawer open without HTTP logs

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/keys/[keyAuthId]/[keyId]/logs-client.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/keys/[keyAuthId]/[keyId]/logs-client.tsx
@@ -51,6 +51,9 @@ export const KeyDetailsLogsClient = ({
           distanceToTop={tableDistanceToTop}
           onLogSelect={handleSelectedLog}
           selectedLog={selectedLog}
+          keyId={keyId}
+          keyspaceId={keyspaceId}
+          apiId={apiId}
         />
       </div>
     </KeyDetailsLogsProvider>

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/identities/[identityId]/components/table/components/log-details/index.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/identities/[identityId]/components/table/components/log-details/index.tsx
@@ -1,9 +1,8 @@
 "use client";
-import { useEffect, useState } from "react";
 
 import { LogDetails } from "@/components/logs/details/log-details";
+import { VerificationLogFallback } from "@/components/logs/details/log-details/components/verification-log-fallback";
 import type { IdentityLog } from "@/lib/trpc/routers/identity/query-logs";
-import { toast } from "@unkey/ui";
 import { useFetchRequestDetails } from "./components/hooks/use-logs-query";
 
 type Props = {
@@ -13,35 +12,9 @@ type Props = {
 };
 
 export const IdentityDetailsDrawer = ({ distanceToTop, onLogSelect, selectedLog }: Props) => {
-  const { log, error, isLoading } = useFetchRequestDetails({
+  const { log, isLoading } = useFetchRequestDetails({
     requestId: selectedLog?.request_id,
   });
-
-  const [errorShown, setErrorShown] = useState(false);
-
-  useEffect(() => {
-    if (!errorShown && selectedLog && !isLoading) {
-      if (error) {
-        toast.error("Error Loading Log Details", {
-          description: `${
-            error.message ||
-            "An unexpected error occurred while fetching log data. Please try again."
-          }`,
-        });
-        setErrorShown(true);
-      } else if (!log) {
-        toast.error("Log Data Unavailable", {
-          description:
-            "Could not retrieve log information for this identity. The log may have been deleted or is still processing.",
-        });
-        setErrorShown(true);
-      }
-    }
-
-    if (!selectedLog) {
-      setErrorShown(false);
-    }
-  }, [error, log, selectedLog, errorShown, isLoading]);
 
   const handleClose = () => {
     onLogSelect(null);
@@ -51,16 +24,33 @@ export const IdentityDetailsDrawer = ({ distanceToTop, onLogSelect, selectedLog 
     return null;
   }
 
-  if (error || !log) {
-    return null;
+  if (log) {
+    return (
+      <LogDetails distanceToTop={distanceToTop} log={log} onClose={handleClose}>
+        <LogDetails.Header onClose={handleClose} />
+        <LogDetails.Sections />
+        <LogDetails.Spacer />
+        <LogDetails.Footer />
+      </LogDetails>
+    );
   }
 
+  const extraFields = [
+    { label: "Key ID", content: selectedLog.keyId },
+    ...(selectedLog.keyName ? [{ label: "Key Name", content: selectedLog.keyName }] : []),
+    { label: "API", content: selectedLog.apiName },
+  ];
+
   return (
-    <LogDetails distanceToTop={distanceToTop} log={log} onClose={handleClose}>
-      <LogDetails.Header onClose={handleClose} />
-      <LogDetails.Sections />
-      <LogDetails.Spacer />
-      <LogDetails.Footer />
+    <LogDetails distanceToTop={distanceToTop} log={selectedLog} onClose={handleClose}>
+      <LogDetails.Header onClose={handleClose}>
+        <VerificationLogFallback
+          log={selectedLog}
+          extraFields={extraFields}
+          isLoading={isLoading}
+          onClose={handleClose}
+        />
+      </LogDetails.Header>
     </LogDetails>
   );
 };

--- a/web/apps/dashboard/components/key-details-logs-table/components/key-details-drawer.test.tsx
+++ b/web/apps/dashboard/components/key-details-logs-table/components/key-details-drawer.test.tsx
@@ -1,0 +1,147 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { KeyDetailsLog } from "@unkey/clickhouse/src/verifications";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { KeyDetailsDrawer } from "./key-details-drawer";
+
+const useFetchRequestDetails = vi.fn();
+
+vi.mock("../hooks/use-fetch-request-details", () => ({
+  useFetchRequestDetails: (args: { requestId?: string }) => useFetchRequestDetails(args),
+}));
+
+vi.mock("@unkey/ui", () => ({
+  Badge: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <span className={className}>{children}</span>
+  ),
+  Button: ({
+    children,
+    onClick,
+    "aria-label": ariaLabel,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    "aria-label"?: string;
+  }) => (
+    <button type="button" onClick={onClick} aria-label={ariaLabel}>
+      {children}
+    </button>
+  ),
+  CopyButton: () => null,
+  TimestampInfo: ({ value }: { value: number }) => <span>{value}</span>,
+  InfoTooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("@unkey/icons", () => ({
+  XMark: () => <span>close</span>,
+}));
+
+const selectedLog: KeyDetailsLog = {
+  request_id: "req_123",
+  time: 1_700_000_000_000,
+  region: "us-east-1",
+  outcome: "VALID",
+  tags: ["prod"],
+};
+
+describe("KeyDetailsDrawer", () => {
+  beforeEach(() => {
+    useFetchRequestDetails.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders verification details when the HTTP request log is missing", () => {
+    useFetchRequestDetails.mockReturnValue({
+      log: undefined,
+      isLoading: false,
+      error: null,
+    });
+
+    render(
+      <KeyDetailsDrawer
+        distanceToTop={0}
+        selectedLog={selectedLog}
+        onLogSelect={vi.fn()}
+        keyId="key_123"
+        keyspaceId="ks_123"
+        apiId="api_123"
+      />,
+    );
+
+    expect(screen.getAllByText("VALID").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("req_123").length).toBeGreaterThan(0);
+    expect(screen.getByText("key_123")).not.toBeNull();
+    expect(screen.getByText("ks_123")).not.toBeNull();
+    expect(screen.getByText("api_123")).not.toBeNull();
+    expect(screen.getByText("us-east-1")).not.toBeNull();
+    expect(
+      screen.getByText("No request headers or body were logged for this verification."),
+    ).not.toBeNull();
+  });
+
+  it("renders HTTP request details when the request log exists", () => {
+    useFetchRequestDetails.mockReturnValue({
+      log: {
+        request_id: "req_123",
+        time: 1_700_000_000_000,
+        workspace_id: "ws_123",
+        host: "api.unkey.com",
+        method: "POST",
+        path: "/v2/keys.verifyKey",
+        request_headers: ["content-type: application/json"],
+        request_body: "{}",
+        response_status: 200,
+        response_headers: ["content-type: application/json"],
+        response_body: '{"data":{"code":"VALID","permissions":[]}}',
+        error: "",
+        service_latency: 12,
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    render(
+      <KeyDetailsDrawer
+        distanceToTop={0}
+        selectedLog={selectedLog}
+        onLogSelect={vi.fn()}
+        keyId="key_123"
+        keyspaceId="ks_123"
+        apiId="api_123"
+      />,
+    );
+
+    expect(screen.getByText("POST")).not.toBeNull();
+    expect(screen.getAllByText("/v2/keys.verifyKey").length).toBeGreaterThan(0);
+    expect(screen.getByText("Request Header")).not.toBeNull();
+    expect(
+      screen.queryByText("No request headers or body were logged for this verification."),
+    ).toBeNull();
+  });
+
+  it("closes the drawer from the fallback header", () => {
+    useFetchRequestDetails.mockReturnValue({
+      log: undefined,
+      isLoading: false,
+      error: null,
+    });
+    const onLogSelect = vi.fn();
+
+    render(
+      <KeyDetailsDrawer
+        distanceToTop={0}
+        selectedLog={selectedLog}
+        onLogSelect={onLogSelect}
+        keyId="key_123"
+        keyspaceId="ks_123"
+        apiId="api_123"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    expect(onLogSelect).toHaveBeenCalledWith(null);
+  });
+});

--- a/web/apps/dashboard/components/key-details-logs-table/components/key-details-drawer.tsx
+++ b/web/apps/dashboard/components/key-details-logs-table/components/key-details-drawer.tsx
@@ -1,58 +1,30 @@
 "use client";
-import { useEffect, useRef } from "react";
 
 import { LogDetails } from "@/components/logs/details/log-details";
+import { VerificationLogFallback } from "@/components/logs/details/log-details/components/verification-log-fallback";
 import type { KeyDetailsLog } from "@unkey/clickhouse/src/verifications";
-import { toast } from "@unkey/ui";
 import { useFetchRequestDetails } from "../hooks/use-fetch-request-details";
 
 type Props = {
   distanceToTop: number;
   selectedLog: KeyDetailsLog | null;
   onLogSelect: (log: KeyDetailsLog | null) => void;
+  keyId: string;
+  keyspaceId: string;
+  apiId: string;
 };
 
-export const KeyDetailsDrawer = ({ distanceToTop, onLogSelect, selectedLog }: Props) => {
-  const { log, error, isLoading } = useFetchRequestDetails({
+export const KeyDetailsDrawer = ({
+  distanceToTop,
+  onLogSelect,
+  selectedLog,
+  keyId,
+  keyspaceId,
+  apiId,
+}: Props) => {
+  const { log, isLoading } = useFetchRequestDetails({
     requestId: selectedLog?.request_id,
   });
-
-  // Track which request we have already toasted for so we surface at most one
-  // toast per selected log, while still re-toasting when the user picks a
-  // different row (selecting another row swaps request_id without closing).
-  const toastedRequestIdRef = useRef<string | null>(null);
-
-  useEffect(() => {
-    const requestId = selectedLog?.request_id;
-
-    // Drawer closed: clear so reopening the same log can toast again, since the
-    // drawer renders nothing on failure and the toast is the only feedback.
-    if (!requestId) {
-      toastedRequestIdRef.current = null;
-      return;
-    }
-
-    // Wait for the fetch to settle before judging the result, otherwise the
-    // in-flight state (no log, no error yet) looks like a failure.
-    if (isLoading || toastedRequestIdRef.current === requestId) {
-      return;
-    }
-
-    if (error) {
-      toast.error("Error Loading Log Details", {
-        description: `${
-          error.message || "An unexpected error occurred while fetching log data. Please try again."
-        }`,
-      });
-      toastedRequestIdRef.current = requestId;
-    } else if (!log) {
-      toast.error("Log Data Unavailable", {
-        description:
-          "Could not retrieve log information for this key. The log may have been deleted or is still processing.",
-      });
-      toastedRequestIdRef.current = requestId;
-    }
-  }, [error, log, selectedLog?.request_id, isLoading]);
 
   const handleClose = () => {
     onLogSelect(null);
@@ -62,16 +34,31 @@ export const KeyDetailsDrawer = ({ distanceToTop, onLogSelect, selectedLog }: Pr
     return null;
   }
 
-  if (error || !log) {
-    return null;
+  if (log) {
+    return (
+      <LogDetails distanceToTop={distanceToTop} log={log} onClose={handleClose}>
+        <LogDetails.Header onClose={handleClose} />
+        <LogDetails.Sections />
+        <LogDetails.Spacer />
+        <LogDetails.Footer />
+      </LogDetails>
+    );
   }
 
   return (
-    <LogDetails distanceToTop={distanceToTop} log={log} onClose={handleClose}>
-      <LogDetails.Header onClose={handleClose} />
-      <LogDetails.Sections />
-      <LogDetails.Spacer />
-      <LogDetails.Footer />
+    <LogDetails distanceToTop={distanceToTop} log={selectedLog} onClose={handleClose}>
+      <LogDetails.Header onClose={handleClose}>
+        <VerificationLogFallback
+          log={selectedLog}
+          extraFields={[
+            { label: "Key ID", content: keyId },
+            { label: "Keyspace ID", content: keyspaceId },
+            { label: "API ID", content: apiId },
+          ]}
+          isLoading={isLoading}
+          onClose={handleClose}
+        />
+      </LogDetails.Header>
     </LogDetails>
   );
 };

--- a/web/apps/dashboard/components/logs/details/log-details/components/log-footer.test.tsx
+++ b/web/apps/dashboard/components/logs/details/log-details/components/log-footer.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { LogFooter } from "./log-footer";
+
+vi.mock("@unkey/ui", () => ({
+  Badge: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  TimestampInfo: ({ value }: { value: number }) => <span>{value}</span>,
+  InfoTooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+describe("LogFooter", () => {
+  it("renders without crashing when the response body has no permissions", () => {
+    render(
+      <LogFooter
+        log={{
+          request_id: "req_123",
+          time: 1_700_000_000_000,
+          workspace_id: "ws_123",
+          host: "api.example.com",
+          method: "POST",
+          path: "/v2/keys.verifyKey",
+          request_headers: [],
+          request_body: "",
+          response_status: 200,
+          response_headers: [],
+          response_body: "",
+          error: "",
+          service_latency: 1,
+        }}
+      />,
+    );
+
+    expect(screen.getByText("req_123")).not.toBeNull();
+    expect(screen.getByText("api.example.com")).not.toBeNull();
+    expect(screen.queryByText("Permissions")).toBeNull();
+  });
+});

--- a/web/apps/dashboard/components/logs/details/log-details/components/log-footer.tsx
+++ b/web/apps/dashboard/components/logs/details/log-details/components/log-footer.tsx
@@ -99,7 +99,7 @@ export const LogFooter = ({ log }: Props) => {
               ))}
             </div>
           ),
-          content: extractResponseField(log, "permissions"),
+          content: extractResponseField(log, "permissions") ?? [],
           tooltipContent: "Copy Permissions",
           tooltipSuccessMessage: "Permissions copied to clipboard",
         },

--- a/web/apps/dashboard/components/logs/details/log-details/components/verification-log-fallback.tsx
+++ b/web/apps/dashboard/components/logs/details/log-details/components/verification-log-fallback.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { RequestResponseDetails } from "@/components/logs/details/request-response-details";
+import { cn } from "@/lib/utils";
+import { XMark } from "@unkey/icons";
+import { Badge, Button, TimestampInfo } from "@unkey/ui";
+import type { ReactNode } from "react";
+import { YELLOW_STATES } from "./log-footer";
+
+type VerificationLog = {
+  request_id: string;
+  time: number;
+  region: string;
+  outcome: string;
+  tags: string[];
+};
+
+type ExtraField = {
+  label: string;
+  content: string;
+};
+
+type Props = {
+  log: VerificationLog;
+  extraFields?: ExtraField[];
+  isLoading: boolean;
+  onClose: () => void;
+};
+
+const RED_OUTCOMES = ["DISABLED", "FORBIDDEN", "INSUFFICIENT_PERMISSIONS"];
+
+export const VerificationLogFallback = ({ log, extraFields, isLoading, onClose }: Props) => {
+  return (
+    <>
+      <div className="border-b flex justify-between items-center border-gray-4 h-[50px] px-4 py-2">
+        <div className="flex gap-2 items-center min-w-0">
+          <Badge
+            className={cn("uppercase px-[6px] rounded-md font-mono text-xs", {
+              "bg-success-3 text-success-11 hover:bg-success-4": log.outcome === "VALID",
+              "bg-warning-3 text-warning-11 hover:bg-warning-4": YELLOW_STATES.includes(
+                log.outcome,
+              ),
+              "bg-error-3 text-error-11 hover:bg-error-4": RED_OUTCOMES.includes(log.outcome),
+            })}
+          >
+            {log.outcome || "UNKNOWN"}
+          </Badge>
+          <p className="text-xs text-accent-12 truncate flex-1 font-mono">{log.request_id}</p>
+        </div>
+        <Button
+          size="icon"
+          variant="ghost"
+          onClick={onClose}
+          className="[&_svg]:size-3"
+          aria-label="Close"
+        >
+          <XMark className="text-grayA-9 stroke-2" iconSize="sm-regular" />
+        </Button>
+      </div>
+      <p className="px-4 pt-4 text-xs text-accent-11">{availabilityCopy(isLoading)}</p>
+      <div className="px-4">
+        <RequestResponseDetails
+          fields={[
+            {
+              label: "Time",
+              description: (content: number) => (
+                <TimestampInfo value={content} className="underline decoration-dotted" />
+              ),
+              content: log.time,
+              tooltipContent: "Copy Time",
+              tooltipSuccessMessage: "Time copied to clipboard",
+              skipTooltip: true,
+            },
+            ...(extraFields ?? []).map((field) => ({
+              label: field.label,
+              description: (content: string) => <span className="text-xs font-mono">{content}</span>,
+              content: field.content,
+              tooltipContent: `Copy ${field.label}`,
+              tooltipSuccessMessage: `${field.label} copied to clipboard`,
+            })),
+            {
+              label: "Request ID",
+              description: (content: string) => <span className="text-xs font-mono">{content}</span>,
+              content: log.request_id,
+              tooltipContent: "Copy Request ID",
+              tooltipSuccessMessage: "Request ID copied to clipboard",
+            },
+            {
+              label: "Outcome",
+              description: (content: string) => (
+                <span className="text-xs font-mono uppercase">{content}</span>
+              ),
+              content: log.outcome || "UNKNOWN",
+              tooltipContent: "Copy Outcome",
+              tooltipSuccessMessage: "Outcome copied to clipboard",
+            },
+            {
+              label: "Region",
+              description: (content: string) => <span className="text-xs font-mono">{content}</span>,
+              content: log.region,
+              tooltipContent: "Copy Region",
+              tooltipSuccessMessage: "Region copied to clipboard",
+            },
+            {
+              label: "Tags",
+              description: (content: string) => <span className="text-xs font-mono">{content}</span>,
+              content: log.tags.length > 0 ? log.tags.join(", ") : null,
+              tooltipContent: "Copy Tags",
+              tooltipSuccessMessage: "Tags copied to clipboard",
+            },
+          ]}
+        />
+      </div>
+    </>
+  );
+};
+
+function availabilityCopy(isLoading: boolean): ReactNode {
+  if (isLoading) {
+    return "Loading request headers and body.";
+  }
+
+  return "No request headers or body were logged for this verification.";
+}

--- a/web/apps/dashboard/components/logs/details/log-details/index.tsx
+++ b/web/apps/dashboard/components/logs/details/log-details/index.tsx
@@ -4,9 +4,11 @@ import { ResizablePanel } from "@/components/logs/details/resizable-panel";
 import type { EnrichedRatelimitLog } from "@/components/ratelimit-logs-table";
 import type { RuntimeLog } from "@/lib/schemas/runtime-logs.schema";
 import type { AuditLog } from "@/lib/trpc/routers/audit/schema";
+import type { IdentityLog } from "@/lib/trpc/routers/identity/query-logs";
 import type { RequestLogsResponse } from "@unkey/clickhouse/src/frontline";
 import type { KeysOverviewLog } from "@unkey/clickhouse/src/keys/keys";
 import type { Log } from "@unkey/clickhouse/src/logs";
+import type { KeyDetailsLog } from "@unkey/clickhouse/src/verifications";
 import { type ReactNode, createContext, useContext, useMemo } from "react";
 import { LogFooter } from "./components/log-footer";
 import { LogHeader } from "./components/log-header";
@@ -26,6 +28,8 @@ export type StandardLogTypes = Log | EnrichedRatelimitLog;
 export type SupportedLogTypes =
   | StandardLogTypes
   | KeysOverviewLog
+  | KeyDetailsLog
+  | IdentityLog
   | AuditLog
   | RuntimeLog
   | RequestLogsResponse;
@@ -45,7 +49,7 @@ const useLogDetailsContext = () => useContext(LogDetailsContext);
 const createLogSections = (log: Log | EnrichedRatelimitLog) => [
   {
     title: "Request Header",
-    content: log.request_headers.length ? log.request_headers : EMPTY_TEXT,
+    content: log.request_headers?.length ? log.request_headers : EMPTY_TEXT,
   },
   {
     title: "Request Body",
@@ -58,7 +62,7 @@ const createLogSections = (log: Log | EnrichedRatelimitLog) => [
   },
   {
     title: "Response Header",
-    content: log.response_headers.length ? log.response_headers : EMPTY_TEXT,
+    content: log.response_headers?.length ? log.response_headers : EMPTY_TEXT,
   },
   {
     title: "Response Body",

--- a/web/apps/dashboard/lib/trpc/routers/logs/query-logs/index.ts
+++ b/web/apps/dashboard/lib/trpc/routers/logs/query-logs/index.ts
@@ -6,7 +6,27 @@ import {
 } from "@/lib/schemas/logs.schema";
 import { ratelimit, withRatelimit, workspaceProcedure } from "@/lib/trpc/trpc";
 import { TRPCError } from "@trpc/server";
+import type { RequestLogsResponse } from "@unkey/clickhouse/src/frontline";
+import type { Log } from "@unkey/clickhouse/src/logs";
 import { transformFilters } from "./utils";
+
+function toApiLog(frontlineLog: RequestLogsResponse, workspaceId: string): Log {
+  return {
+    request_id: frontlineLog.request_id,
+    time: frontlineLog.time,
+    workspace_id: workspaceId,
+    host: frontlineLog.host,
+    method: frontlineLog.method,
+    path: frontlineLog.path,
+    request_headers: frontlineLog.request_headers,
+    request_body: frontlineLog.request_body,
+    response_status: frontlineLog.response_status,
+    response_headers: frontlineLog.response_headers,
+    response_body: frontlineLog.response_body,
+    error: "",
+    service_latency: frontlineLog.total_latency,
+  };
+}
 
 export const queryLogs = workspaceProcedure
   .use(withRatelimit(ratelimit.read))
@@ -40,7 +60,20 @@ export const queryLogs = workspaceProcedure
       });
     }
 
-    const logs = logsResult.val;
+    let logs = logsResult.val;
+
+    if (logs.length === 0 && isSingleRequestIdLookup) {
+      const requestId = transformedInputs.requestIds?.[0];
+      if (requestId) {
+        const frontlineResult = await clickhouse.frontline.requestById({
+          workspaceId: ctx.workspace.id,
+          requestId,
+        });
+        if (!frontlineResult.err && frontlineResult.val.length > 0) {
+          logs = [toApiLog(frontlineResult.val[0], ctx.workspace.id)];
+        }
+      }
+    }
 
     // Prepare the response with pagination info
     const response: LogsResponseSchema = {

--- a/web/internal/clickhouse/src/frontline.test.ts
+++ b/web/internal/clickhouse/src/frontline.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { type RequestLogsRequest, getRequestLogs, requestLogsRequestSchema } from "./frontline";
+import {
+  type RequestLogsRequest,
+  getRequestLogById,
+  getRequestLogs,
+  requestLogsRequestSchema,
+} from "./frontline";
 import { CapturingQuerier } from "./test-utils";
 
 const baseRequest: RequestLogsRequest = {
@@ -72,6 +77,27 @@ describe("getRequestLogs", () => {
       expect(query).not.toContain("path LIKE");
       expect(query).not.toContain("startsWith(path");
     }
+  });
+});
+
+describe("getRequestLogById", () => {
+  it("looks up one request by workspace and request id", async () => {
+    const ch = new CapturingQuerier();
+
+    await getRequestLogById(ch)({
+      workspaceId: "ws_123",
+      requestId: "req_123",
+    });
+
+    expect(ch.queries).toHaveLength(1);
+    expect(ch.queries[0]).toContain("FROM default.frontline_requests_raw_v1");
+    expect(ch.queries[0]).toContain("workspace_id = {workspaceId: String}");
+    expect(ch.queries[0]).toContain("request_id = {requestId: String}");
+    expect(ch.queries[0]).not.toContain("project_id");
+    expect(ch.params[0]).toEqual({
+      workspaceId: "ws_123",
+      requestId: "req_123",
+    });
   });
 });
 

--- a/web/internal/clickhouse/src/frontline.ts
+++ b/web/internal/clickhouse/src/frontline.ts
@@ -128,6 +128,37 @@ export const requestLogsResponseSchema = z.object({
 
 export type RequestLogsResponse = z.infer<typeof requestLogsResponseSchema>;
 
+export const requestLogByIdParams = z.object({
+  workspaceId: z.string(),
+  requestId: z.string(),
+});
+
+export type RequestLogByIdParams = z.infer<typeof requestLogByIdParams>;
+
+const REQUEST_LOG_COLUMNS = `
+  request_id, time, deployment_id, region, method, path, host,
+  response_status, total_latency, instance_latency, gateway_latency,
+  query_string, query_params, request_headers, request_body,
+  response_headers, response_body, user_agent, ip_address`;
+
+export function getRequestLogById(ch: Querier) {
+  return async (args: RequestLogByIdParams) => {
+    const query = ch.query({
+      query: `
+        SELECT ${REQUEST_LOG_COLUMNS}
+        FROM ${TABLE}
+        WHERE workspace_id = {workspaceId: String}
+          AND request_id = {requestId: String}
+        ORDER BY time DESC
+        LIMIT 1`,
+      params: requestLogByIdParams,
+      schema: requestLogsResponseSchema,
+    });
+
+    return query(args);
+  };
+}
+
 export function getRequestLogs(ch: Querier) {
   return async (args: RequestLogsRequest) => {
     let pathConditions = "TRUE";
@@ -209,10 +240,7 @@ export function getRequestLogs(ch: Querier) {
     // https://clickhouse.com/docs/optimize/lazy-materialization
     const logsQuery = ch.query({
       query: `
-        SELECT request_id, time, deployment_id, region, method, path, host,
-               response_status, total_latency, instance_latency, gateway_latency,
-               query_string, query_params, request_headers, request_body,
-               response_headers, response_body, user_agent, ip_address
+        SELECT ${REQUEST_LOG_COLUMNS}
         FROM ${TABLE}
         WHERE ${filterConditions}
         ORDER BY time DESC, request_id DESC

--- a/web/internal/clickhouse/src/index.ts
+++ b/web/internal/clickhouse/src/index.ts
@@ -121,6 +121,7 @@ import {
   getDeploymentRpsTimeseries,
   getInstanceRps,
   getRegionRps,
+  getRequestLogById,
   getRequestLogs,
 } from "./frontline";
 import { getEnvironmentRequests } from "./frontline/environment-requests";
@@ -396,6 +397,7 @@ export class ClickHouse {
   public get frontline() {
     return {
       logs: getRequestLogs(this.querier),
+      requestById: getRequestLogById(this.querier),
       rps: {
         byInstance: getInstanceRps(this.querier),
         byRegion: getRegionRps(this.querier),


### PR DESCRIPTION
## Problem:

Clicking a key verification log with no `api_requests_raw_v2` row closed the request drawer. Deploy and sentinel traffic often never writes that table. The panel then showed nothing, or it crashed if a partial HTTP log was missing headers or permissions.

Fixes #5409

## Solution:

The drawer stays open from the verification row. When Frontline logged the request, the panel shows those HTTP details. When it did not, the panel shows the verification fields plus Key ID, Keyspace ID, and API ID.

## Impact:

Key and identity log detail panels no longer go blank for deploy/sentinel verifications. Workspaces without Frontline request logging still see verification details. There is one extra ClickHouse lookup only when a single request ID has no API request row.

## Testing:

- `mise exec -- pnpm --dir=web/apps/dashboard exec vitest run components/key-details-logs-table/components/key-details-drawer.test.tsx components/logs/details/log-details/components/log-footer.test.tsx` — 4 passed
- `mise exec -- pnpm --dir=web/internal/clickhouse exec vitest run src/frontline.test.ts` — 5 passed
- Local dashboard: selected a verification with no HTTP log. The drawer stayed open and showed Key ID, Keyspace ID, API ID, request ID, outcome, region, and tags.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots / recordings

**Before.** Selected verification with no HTTP request log. The drawer does not open.

![Before: selected log, no drawer](https://ampcode.com/user-content/artifacts/3afb6705467a7c76b6d29d2c9cfe0053079f947047a164fbff88492a82fc4864-file.png)

**After.** Same verification. The drawer stays open and shows Key ID, Keyspace ID, API ID, request ID, outcome, region, and tags.

![After: fallback drawer with key IDs](https://ampcode.com/user-content/artifacts/a2c0d4695a36b2fab4c524cc3aeffc48d8e1606f141f55308775865ab27b5913-file.png)

## How should this be tested?

- Open a key that has deploy/sentinel verification logs and no API request row.
- Click a log. The drawer must stay open and show verification details and the key IDs.
- If Frontline logged that request ID, the drawer must show the HTTP headers and body from Frontline.
- Confirm a missing permissions array in an HTTP response body does not crash the footer.

## Checklist

### Required

- [x] Filled out the \"How to test\" section in this PR
- [ ] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `mise run fmt`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [x] If I made a visual change: Filled out the \"Screenshots / recordings\" section, as shown in the [screenshot and recording guide](../docs/engineering/contributing/quality/screenshots-and-recordings.mdx)
