### PR TITLE
feat(ui): Button text at font-medium (comparison A)

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/portal/components/setup-hero.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/portal/components/setup-hero.tsx
@@ -33,7 +33,7 @@ const flankItems: { icon: ReactNode; large?: boolean; opacity: string }[] = [
   { icon: <IconEarthOutline18 />, opacity: "opacity-50" },
   { icon: <IconUserOutline18 />, opacity: "opacity-75" },
   {
-    icon: <IconWindowLayoutOutline18 className="size-9" />,
+    icon: <IconWindowLayoutOutline18 className="size-9 [&_[stroke-width]]:[stroke-width:0.75]" />,
     large: true,
     opacity: "opacity-90",
   },

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/_components/list/empty-projects.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/_components/list/empty-projects.tsx
@@ -38,7 +38,7 @@ const IconBox = ({ children, large, className }: IconBoxProps) => (
 const flankItems: { icon: ReactNode; large?: boolean; opacity: string }[] = [
   { icon: <IconEarthOutline18 />, opacity: "opacity-50" },
   { icon: <Github className="size-[18px]" />, opacity: "opacity-75" },
-  { icon: <IconCubeOutline18 className="size-9" />, large: true, opacity: "opacity-90" },
+  { icon: <IconCubeOutline18 className="size-9 [&_[stroke-width]]:[stroke-width:0.75]" />, large: true, opacity: "opacity-90" },
   { icon: <IconCodeOutline18 />, opacity: "opacity-75" },
   { icon: <IconHeartPulseOutline18 />, opacity: "opacity-50" },
 ];

--- a/web/apps/dashboard/components/navigation/sidebar-v2/usage-card/usage-panel.tsx
+++ b/web/apps/dashboard/components/navigation/sidebar-v2/usage-card/usage-panel.tsx
@@ -31,7 +31,7 @@ export function UsagePanel({ summary }: { summary: UsageSummary }) {
           !folded && "px-2.5 pt-2 pb-1.5",
         )}
       >
-        {folded ? null : <span className="min-w-0 truncate text-gray-12">Usage</span>}
+        {folded ? null : <span className="min-w-0 truncate font-medium text-gray-12">Usage</span>}
         {summary.atRisk ? null : (
           <button
             type="button"

--- a/web/apps/dashboard/components/navigation/sidebar-v2/usage-card/usage-panel.tsx
+++ b/web/apps/dashboard/components/navigation/sidebar-v2/usage-card/usage-panel.tsx
@@ -46,7 +46,7 @@ export function UsagePanel({ summary }: { summary: UsageSummary }) {
                 : "-mr-1 ml-auto size-5 justify-center",
             )}
           >
-            {folded ? <span className="flex-1 truncate text-gray-12">Usage</span> : null}
+            {folded ? <span className="flex-1 truncate font-medium text-gray-12">Usage</span> : null}
             <Toggle rotated={!folded} />
           </button>
         )}

--- a/web/apps/dashboard/components/onboarding/step-header.tsx
+++ b/web/apps/dashboard/components/onboarding/step-header.tsx
@@ -33,7 +33,7 @@ const iconItems: { icon: ReactNode; large?: boolean; opacity: string }[] = [
   { icon: null, opacity: "opacity-60" },
   { icon: <IconHardDriveOutline18 />, opacity: "opacity-75" },
   { icon: <IconLocation2Outline18 />, opacity: "opacity-80" },
-  { icon: <IconCloudUploadOutline18 className="size-9" />, large: true, opacity: "opacity-90" },
+  { icon: <IconCloudUploadOutline18 className="size-9 [&_[stroke-width]]:[stroke-width:0.75]" />, large: true, opacity: "opacity-90" },
   { icon: <IconHeartPulseOutline18 />, opacity: "opacity-80" },
   { icon: <IconNodes2Outline18 />, opacity: "opacity-75" },
   { icon: null, opacity: "opacity-60" },

--- a/web/internal/ui/src/components/buttons/button.tsx
+++ b/web/internal/ui/src/components/buttons/button.tsx
@@ -66,7 +66,7 @@ export type DocumentedButtonProps = VariantProps<typeof buttonVariants> & {
 };
 
 const buttonVariants = cva(
-  "inline-flex group relative duration-150 items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-normal transition-colors focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 disabled:cursor-not-allowed cursor-pointer",
+  "inline-flex group relative duration-150 items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 disabled:cursor-not-allowed cursor-pointer",
   {
     variants: {
       variant: {

--- a/web/internal/ui/src/components/empty.tsx
+++ b/web/internal/ui/src/components/empty.tsx
@@ -31,7 +31,7 @@ Empty.Icon = function EmptyIcon({ className, children }: EmptyIconProps) {
         <div className="absolute bottom-0 left-1/2 -translate-x-1/2 bg-linear-to-r from-[hsla(240,100%,17%,0.01)] via-[hsla(240,100%,10%,0.06)] to-[hsla(240,100%,17%,0.01)] dark:from-[hsla(0,0%,0%,0)] dark:via-[hsla(211,66%,92%,0.3)] dark:to-[hsla(0,0%,0%,0)] w-32 h-px  " />
         <div className="absolute left-0 top-1/2 -translate-y-1/2 h-32 bg-linear-to-t from-[hsla(240,100%,17%,0.01)] via-[hsla(240,100%,10%,0.06)] to-[hsla(240,100%,17%,0.01)] dark:from-[hsla(0,0%,0%,0)] dark:via-[hsla(211,66%,92%,0.3)] dark:to-[hsla(0,0%,0%,0)] w-px" />
         <div className="absolute right-0 top-1/2 -translate-y-1/2 h-32 bg-linear-to-t from-[hsla(240,100%,17%,0.01)] via-[hsla(240,100%,10%,0.06)] to-[hsla(240,100%,17%,0.01)] dark:from-[hsla(0,0%,0%,0)] dark:via-[hsla(211,66%,92%,0.3)] dark:to-[hsla(0,0%,0%,0)] w-px " />
-        <div className="flex w-16 h-16 items-center justify-center rounded-2xl bg-gray-2 border border-[hsla(240,100%,10%,0.06)] dark:border-[hsla(211,66%,92%,0.2)] text-accent-12 z-50 [&_svg]:pointer-events-none [&_svg]:size-7 [&_svg]:shrink-0">
+        <div className="flex w-16 h-16 items-center justify-center rounded-2xl bg-gray-2 border border-[hsla(240,100%,10%,0.06)] dark:border-[hsla(211,66%,92%,0.2)] text-accent-12 z-50 [&_svg]:pointer-events-none [&_svg]:size-7 [&_svg]:shrink-0 [&_svg_[stroke-width]]:[stroke-width:1]">
           <div>{children || <IconUfoOutline18 className="size-7.5" />}</div>
         </div>
       </div>


### PR DESCRIPTION
## What does this PR do?

Throwaway comparison branch, one of two stacked on #7238, for the button font-weight discussion in https://unkey.slack.com/archives/C0723ESMR9R/p1788276659153069. This one keeps Nucleo's natural 1.5 stroke on every icon and moves `Button` text from 400 to 500. The sidebar usage panel title picks up `font-medium` so it matches. Nothing else changes. Compare against #7240, the 400 version. The winner gets folded into #7238; the loser is closed.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

Open the preview next to the 400 version and compare buttons with icons: create project, create app, feedback, top nav actions. Judge whether 500 text sits balanced against the 1.5 stroke icon. Not a mergeable PR on its own.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary