### PR TITLE
refactor(dashboard,ui): Move hero icon stroke scaling into EmptyHero.Icons

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/portal/components/setup-hero.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/apis/[apiId]/portal/components/setup-hero.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { cn } from "@/lib/utils";
-import { Button } from "@unkey/ui";
+import { Button, EmptyHero } from "@unkey/ui";
 import {
   IconEarthOutline18,
   IconKeyOutline18,
@@ -9,63 +8,18 @@ import {
   IconUserOutline18,
   IconWindowLayoutOutline18,
 } from "nucleo-ui-outline-18";
-import type { ReactNode } from "react";
-
-type IconBoxProps = {
-  children?: ReactNode;
-  large?: boolean;
-  className?: string;
-};
-
-const IconBox = ({ children, large, className }: IconBoxProps) => (
-  <div
-    className={cn(
-      "shrink-0 flex items-center justify-center rounded-[10px] bg-transparent ring-1 ring-grayA-4 shadow-sm shadow-grayA-8/20 dark:shadow-none",
-      large ? "size-16" : "size-9",
-      className,
-    )}
-  >
-    {children}
-  </div>
-);
-
-const flankItems: { icon: ReactNode; large?: boolean; opacity: string }[] = [
-  { icon: <IconEarthOutline18 />, opacity: "opacity-50" },
-  { icon: <IconUserOutline18 />, opacity: "opacity-75" },
-  {
-    icon: <IconWindowLayoutOutline18 className="size-9 [&_[stroke-width]]:[stroke-width:0.75]" />,
-    large: true,
-    opacity: "opacity-90",
-  },
-  { icon: <IconKeyOutline18 />, opacity: "opacity-75" },
-  { icon: <IconShieldKeyOutline18 />, opacity: "opacity-50" },
-];
-
-const PortalIconRow = () => (
-  <div
-    aria-hidden="true"
-    className="p-2 mb-8"
-    style={{
-      maskImage: "linear-gradient(to right, transparent, black 20%, black 80%, transparent)",
-      WebkitMaskImage: "linear-gradient(to right, transparent, black 20%, black 80%, transparent)",
-    }}
-  >
-    <div className="flex gap-6 items-center justify-center text-gray-12">
-      {flankItems.map((item, i) => (
-        // biome-ignore lint/suspicious/noArrayIndexKey: static row, index is stable
-        <IconBox key={i} large={item.large} className={item.opacity}>
-          {item.icon}
-        </IconBox>
-      ))}
-    </div>
-  </div>
-);
 
 export function SetupHero({ onEnable }: { onEnable: () => void }) {
   return (
     <div className="flex w-full justify-center rounded-lg border border-grayA-4 p-12">
       <div className="flex flex-col items-center text-center">
-        <PortalIconRow />
+        <EmptyHero.Icons className="mb-8">
+          <IconEarthOutline18 />
+          <IconUserOutline18 />
+          <IconWindowLayoutOutline18 />
+          <IconKeyOutline18 />
+          <IconShieldKeyOutline18 />
+        </EmptyHero.Icons>
 
         <h2 className="text-accent-12 font-semibold text-2xl leading-8 mb-1">Customer portal</h2>
         <p className="text-accent-11 text-sm leading-6 max-w-md text-balance mb-6">

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/_components/list/empty-projects.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/_components/list/empty-projects.tsx
@@ -1,8 +1,7 @@
 import { useWorkspaceNavigation } from "@/hooks/use-workspace-navigation";
 import { useFlag } from "@/lib/flags/provider";
 import { Github } from "@unkey/icons";
-import { Button } from "@unkey/ui";
-import { cn } from "@unkey/ui/src/lib/utils";
+import { Button, EmptyHero } from "@unkey/ui";
 import { useSearchParams } from "next/navigation";
 import {
   IconArrowRightOutline18,
@@ -12,56 +11,10 @@ import {
   IconEarthOutline18,
   IconHeartPulseOutline18,
 } from "nucleo-ui-outline-18";
-import { type ReactNode, useState } from "react";
+import { useState } from "react";
 import { CreateProjectDialog } from "../create-project-dialog";
 import { DeployPlanGateDialog } from "../deploy-plan-gate-dialog";
 import { useDeployGate } from "../hooks/use-deploy-gate";
-
-type IconBoxProps = {
-  children?: ReactNode;
-  large?: boolean;
-  className?: string;
-};
-
-const IconBox = ({ children, large, className }: IconBoxProps) => (
-  <div
-    className={cn(
-      "shrink-0 flex items-center justify-center rounded-[10px] bg-transparent ring-1 ring-grayA-4 shadow-sm shadow-grayA-8/20 dark:shadow-none",
-      large ? "size-16" : "size-9",
-      className,
-    )}
-  >
-    {children}
-  </div>
-);
-
-const flankItems: { icon: ReactNode; large?: boolean; opacity: string }[] = [
-  { icon: <IconEarthOutline18 />, opacity: "opacity-50" },
-  { icon: <Github className="size-[18px]" />, opacity: "opacity-75" },
-  { icon: <IconCubeOutline18 className="size-9 [&_[stroke-width]]:[stroke-width:0.75]" />, large: true, opacity: "opacity-90" },
-  { icon: <IconCodeOutline18 />, opacity: "opacity-75" },
-  { icon: <IconHeartPulseOutline18 />, opacity: "opacity-50" },
-];
-
-const ProjectIconRow = () => (
-  <div
-    aria-hidden="true"
-    className="p-2 mb-8"
-    style={{
-      maskImage: "linear-gradient(to right, transparent, black 20%, black 80%, transparent)",
-      WebkitMaskImage: "linear-gradient(to right, transparent, black 20%, black 80%, transparent)",
-    }}
-  >
-    <div className="flex gap-6 items-center justify-center text-gray-12">
-      {flankItems.map((item, i) => (
-        // biome-ignore lint/suspicious/noArrayIndexKey: static row, index is stable
-        <IconBox key={i} large={item.large} className={item.opacity}>
-          {item.icon}
-        </IconBox>
-      ))}
-    </div>
-  </div>
-);
 
 export function EmptyProjects() {
   const workspace = useWorkspaceNavigation();
@@ -74,7 +27,13 @@ export function EmptyProjects() {
   return (
     <div className="grow w-full flex justify-center items-center p-12">
       <div className="flex flex-col items-center text-center">
-        <ProjectIconRow />
+        <EmptyHero.Icons className="mb-8">
+          <IconEarthOutline18 />
+          <Github />
+          <IconCubeOutline18 />
+          <IconCodeOutline18 />
+          <IconHeartPulseOutline18 />
+        </EmptyHero.Icons>
 
         <h2 className="text-accent-12 font-semibold text-2xl leading-8 mb-1">Projects</h2>
         <p className="text-accent-11 text-sm leading-6 max-w-md text-balance mb-6">

--- a/web/apps/dashboard/components/onboarding/step-header.tsx
+++ b/web/apps/dashboard/components/onboarding/step-header.tsx
@@ -1,6 +1,5 @@
 "use client";
-import { Button, useStepWizard } from "@unkey/ui";
-import { cn } from "@unkey/ui/src/lib/utils";
+import { Button, EmptyHero, useStepWizard } from "@unkey/ui";
 import {
   IconChevronLeftOutline18,
   IconCloudUploadOutline18,
@@ -10,53 +9,6 @@ import {
   IconNodes2Outline18,
 } from "nucleo-ui-outline-18";
 import type { ReactNode } from "react";
-
-type IconBoxProps = {
-  children?: ReactNode;
-  large?: boolean;
-  className?: string;
-};
-
-const IconBox = ({ children, large, className }: IconBoxProps) => (
-  <div
-    className={cn(
-      "shrink-0 flex items-center justify-center rounded-[10px] bg-transparent ring-1 ring-grayA-4 shadow-sm shadow-grayA-8/20 dark:shadow-none",
-      large ? "size-16" : "size-9",
-      className,
-    )}
-  >
-    {children}
-  </div>
-);
-
-const iconItems: { icon: ReactNode; large?: boolean; opacity: string }[] = [
-  { icon: null, opacity: "opacity-60" },
-  { icon: <IconHardDriveOutline18 />, opacity: "opacity-75" },
-  { icon: <IconLocation2Outline18 />, opacity: "opacity-80" },
-  { icon: <IconCloudUploadOutline18 className="size-9 [&_[stroke-width]]:[stroke-width:0.75]" />, large: true, opacity: "opacity-90" },
-  { icon: <IconHeartPulseOutline18 />, opacity: "opacity-80" },
-  { icon: <IconNodes2Outline18 />, opacity: "opacity-75" },
-  { icon: null, opacity: "opacity-60" },
-];
-
-const IconRow = () => (
-  <div
-    className="p-2"
-    style={{
-      maskImage: "linear-gradient(to right, transparent, black 15%, black 85%, transparent)",
-      WebkitMaskImage: "linear-gradient(to right, transparent, black 15%, black 85%, transparent)",
-    }}
-  >
-    <div className="flex gap-6 items-center justify-center text-gray-12">
-      {iconItems.map((item, i) => (
-        // biome-ignore lint/suspicious/noArrayIndexKey: its okay to use index
-        <IconBox key={i} large={item.large} className={item.opacity}>
-          {item.icon}
-        </IconBox>
-      ))}
-    </div>
-  </div>
-);
 
 type OnboardingStepHeaderProps = {
   title: ReactNode;
@@ -75,7 +27,15 @@ export const OnboardingStepHeader = ({
 
   return (
     <div className="flex flex-col items-center">
-      {showIconRow && <IconRow />}
+      {showIconRow && (
+        <EmptyHero.Icons className="mb-0">
+          <IconHardDriveOutline18 />
+          <IconLocation2Outline18 />
+          <IconCloudUploadOutline18 />
+          <IconHeartPulseOutline18 />
+          <IconNodes2Outline18 />
+        </EmptyHero.Icons>
+      )}
       {allowBack && (
         <Button
           variant="ghost"

--- a/web/internal/ui/src/components/empty-hero.tsx
+++ b/web/internal/ui/src/components/empty-hero.tsx
@@ -48,7 +48,9 @@ EmptyHero.Icons = function EmptyHeroIcons({ className, children, ...props }: Emp
               key={index}
               className={cn(
                 "shrink-0 flex items-center justify-center rounded-[10px] bg-transparent ring-1 ring-grayA-4 shadow-sm shadow-grayA-8/20 dark:shadow-none",
-                index === centerIndex ? "size-16 [&_svg]:size-9" : "size-9 [&_svg]:size-[18px]",
+                index === centerIndex
+                  ? "size-16 [&_svg]:size-9 [&_svg_[stroke-width]]:[stroke-width:0.75]"
+                  : "size-9 [&_svg]:size-[18px]",
                 OPACITY_BY_DISTANCE_FROM_CENTER[distanceFromCenter],
               )}
             >


### PR DESCRIPTION
## What does this PR do?

Hero icons in empty states and onboarding kept a 1.5px visual stroke through a class override on each icon. That override now lives in `EmptyHero.Icons`, which thins the stroke on its centre tile the same way `Empty.Icon` already does, so callers pass a bare icon. The projects empty state, the portal setup hero and the onboarding step header drop their hand-rolled icon rows and render `EmptyHero.Icons` instead.

This clears the last stroke overrides from call sites, so the planned lint rule can ban `stroke-width` on icons outright with no allow-list.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

Open a workspace with no projects, the customer portal setup page for an API without a portal, and the deploy onboarding wizard. In each, the centre icon should show the same stroke weight as the 18px icons beside it, not a heavier line.

The onboarding step header previously had seven tiles, two of them empty, with its own opacity ramp. It now has five tiles and the shared ramp, so the outer tiles fade slightly more than before.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary