### PR TITLE
fix(api): attribute root key usage to key owner

### DIFF
--- a/pkg/auth/principal/principal.go
+++ b/pkg/auth/principal/principal.go
@@ -52,7 +52,8 @@ type Principal struct {
 	// Source carries the method-specific authentication details.
 	Source Source
 
-	// WorkspaceID scopes all handler reads and writes for this principal.
+	// WorkspaceID is the workspace this principal can access. For root keys, it
+	// is keys.for_workspace_id, not the key owner in [KeySource.WorkspaceID].
 	WorkspaceID string
 
 	// Permissions is the flat set of exact or resource-scoped authorization grants.
@@ -109,6 +110,11 @@ type KeySource struct {
 
 	// KeySpaceID is the key space that owns the authenticated key.
 	KeySpaceID string
+
+	// WorkspaceID is the keys.workspace_id value that identifies the key owner.
+	// For root keys, it identifies Unkey's internal workspace, not the customer
+	// workspace in keys.for_workspace_id.
+	WorkspaceID string
 
 	// Permissions are the raw RBAC permission strings attached to the key.
 	Permissions []string

--- a/pkg/auth/root_key/resolver.go
+++ b/pkg/auth/root_key/resolver.go
@@ -47,6 +47,7 @@ func (r *Resolver) Resolve(ctx context.Context, sess *zen.Session) (*principal.P
 		Source: principal.KeySource{
 			KeyID:       key.Key.ID,
 			KeySpaceID:  key.Key.KeyAuthID,
+			WorkspaceID: key.Key.WorkspaceID,
 			Permissions: key.Permissions,
 		},
 		WorkspaceID: key.AuthorizedWorkspaceID,

--- a/pkg/auth/root_key/resolver_test.go
+++ b/pkg/auth/root_key/resolver_test.go
@@ -66,12 +66,13 @@ func TestResolver_ResolveRootKeyPrincipal(t *testing.T) {
 	keyService := &stubKeyService{
 		rootKey: &keys.KeyVerifier{
 			Key: keysdb.FindKeyForVerificationRow{
-				ID:        "key_123",
-				KeyAuthID: "ks_123",
-				Name:      sql.NullString{String: "Production root key", Valid: true},
+				ID:          "key_123",
+				KeyAuthID:   "ks_123",
+				WorkspaceID: "ws_root",
+				Name:        sql.NullString{String: "Production root key", Valid: true},
 			},
 			Permissions:           []string{"api.*.read_key"},
-			AuthorizedWorkspaceID: "ws_123",
+			AuthorizedWorkspaceID: "ws_authorized",
 		},
 	}
 	resolver := NewResolver(keyService)
@@ -85,12 +86,13 @@ func TestResolver_ResolveRootKeyPrincipal(t *testing.T) {
 	require.Equal(t, authprincipal.SubjectTypeRootKey, p.Subject.Type)
 	require.Equal(t, "key_123", p.Subject.ID)
 	require.Equal(t, "Production root key", p.Subject.Name)
-	require.Equal(t, "ws_123", p.WorkspaceID)
+	require.Equal(t, "ws_authorized", p.WorkspaceID)
 	require.Equal(t, []string{"api.*.read_key"}, p.Permissions)
 	source, ok := p.Source.(authprincipal.KeySource)
 	require.True(t, ok)
 	require.Equal(t, "key_123", source.KeyID)
 	require.Equal(t, "ks_123", source.KeySpaceID)
+	require.Equal(t, "ws_root", source.WorkspaceID)
 	require.Equal(t, []string{"api.*.read_key"}, source.Permissions)
 }
 

--- a/svc/api/internal/middleware/authentication.go
+++ b/svc/api/internal/middleware/authentication.go
@@ -62,12 +62,18 @@ func WithAuthentication(config AuthenticationConfig) zen.Middleware {
 			}
 
 			if p.Subject.Type == principalauth.SubjectTypeRootKey && config.KeyVerifications != nil {
-				keySource, _ := p.Source.(principalauth.KeySource)
+				keySource, ok := p.Source.(principalauth.KeySource)
+				if !ok {
+					return fault.New(
+						"root key principal must have a key source",
+						fault.Code(codes.App.Validation.AssertionFailed.URN()),
+					)
+				}
 
 				verification := schema.KeyVerification{
 					RequestID:    sess.RequestID(),
 					Time:         time.Now().UnixMilli(),
-					WorkspaceID:  p.WorkspaceID,
+					WorkspaceID:  keySource.WorkspaceID,
 					KeySpaceID:   keySource.KeySpaceID,
 					IdentityID:   "",
 					ExternalID:   "",

--- a/svc/api/internal/middleware/authentication_test.go
+++ b/svc/api/internal/middleware/authentication_test.go
@@ -105,31 +105,40 @@ func TestWithAuthentication_PublishesPrincipalToHandler(t *testing.T) {
 
 // TestWithAuthentication_RecordsRootKeyUsage guarantees successful root key
 // authentication creates one row and any later authorization denial updates its
-// outcome without adding telemetry code to the handler.
+// outcome without adding telemetry code to the handler. The event belongs to
+// the key owner workspace, not the customer workspace that the key can access.
 func TestWithAuthentication_RecordsRootKeyUsage(t *testing.T) {
 	t.Parallel()
 
+	rootKeySource := principal.KeySource{
+		KeyID:       "key_123",
+		KeySpaceID:  "ks_123",
+		WorkspaceID: "ws_root",
+		Permissions: nil,
+	}
 	tests := []struct {
-		name           string
-		source         principal.Source
-		handler        zen.HandleFunc
-		wantKeySpaceID string
-		wantOutcome    string
-		wantError      bool
+		name            string
+		source          principal.Source
+		handler         zen.HandleFunc
+		wantWorkspaceID string
+		wantKeySpaceID  string
+		wantOutcome     string
+		wantError       bool
 	}{
 		{
 			name:   "records usage without an authorization denial",
-			source: principal.KeySource{KeyID: "key_123", KeySpaceID: "ks_123", Permissions: nil},
+			source: rootKeySource,
 			handler: func(_ context.Context, _ *zen.Session) error {
 				return nil
 			},
-			wantKeySpaceID: "ks_123",
-			wantOutcome:    string(keys.StatusValid),
-			wantError:      false,
+			wantWorkspaceID: "ws_root",
+			wantKeySpaceID:  "ks_123",
+			wantOutcome:     string(keys.StatusValid),
+			wantError:       false,
 		},
 		{
 			name:   "records a returned authorization denial",
-			source: principal.KeySource{KeyID: "key_123", KeySpaceID: "ks_123", Permissions: nil},
+			source: rootKeySource,
 			handler: func(_ context.Context, sess *zen.Session) error {
 				p, err := sess.GetPrincipal()
 				if err != nil {
@@ -142,13 +151,14 @@ func TestWithAuthentication_RecordsRootKeyUsage(t *testing.T) {
 					Action:       rbac.CreateAPI,
 				}))
 			},
-			wantKeySpaceID: "ks_123",
-			wantOutcome:    string(keys.StatusInsufficientPermissions),
-			wantError:      true,
+			wantWorkspaceID: "ws_root",
+			wantKeySpaceID:  "ks_123",
+			wantOutcome:     string(keys.StatusInsufficientPermissions),
+			wantError:       true,
 		},
 		{
 			name:   "records a handled authorization denial",
-			source: principal.KeySource{KeyID: "key_123", KeySpaceID: "ks_123", Permissions: nil},
+			source: rootKeySource,
 			handler: func(_ context.Context, sess *zen.Session) error {
 				p, err := sess.GetPrincipal()
 				if err != nil {
@@ -165,23 +175,10 @@ func TestWithAuthentication_RecordsRootKeyUsage(t *testing.T) {
 				}
 				return nil
 			},
-			wantKeySpaceID: "ks_123",
-			wantOutcome:    string(keys.StatusInsufficientPermissions),
-			wantError:      false,
-		},
-		{
-			name: "records empty key space when key metadata is absent",
-			source: principal.JWTSource{
-				Header:    nil,
-				Payload:   nil,
-				Signature: "",
-			},
-			handler: func(_ context.Context, _ *zen.Session) error {
-				return nil
-			},
-			wantKeySpaceID: "",
-			wantOutcome:    string(keys.StatusValid),
-			wantError:      false,
+			wantWorkspaceID: "ws_root",
+			wantKeySpaceID:  "ks_123",
+			wantOutcome:     string(keys.StatusInsufficientPermissions),
+			wantError:       false,
 		},
 	}
 
@@ -210,7 +207,7 @@ func TestWithAuthentication_RecordsRootKeyUsage(t *testing.T) {
 				0,
 			))
 
-			p := testMiddlewarePrincipal("ws_123")
+			p := testMiddlewarePrincipal("ws_authorized")
 			p.Source = test.source
 			err := WithAuthentication(AuthenticationConfig{
 				Auth:             &fakeAuth{principal: p},
@@ -229,7 +226,7 @@ func TestWithAuthentication_RecordsRootKeyUsage(t *testing.T) {
 				verification := rows[0]
 				require.Equal(t, sess.RequestID(), verification.RequestID)
 				require.Positive(t, verification.Time)
-				require.Equal(t, "ws_123", verification.WorkspaceID)
+				require.Equal(t, test.wantWorkspaceID, verification.WorkspaceID)
 				require.Equal(t, test.wantKeySpaceID, verification.KeySpaceID)
 				require.Equal(t, "root_key_123", verification.KeyID)
 				require.Equal(t, "test-region", verification.Region)
@@ -245,6 +242,46 @@ func TestWithAuthentication_RecordsRootKeyUsage(t *testing.T) {
 				t.Fatal("root key usage did not flush")
 			}
 		})
+	}
+}
+
+// TestWithAuthentication_RejectsRootPrincipalWithoutKeySource guarantees that
+// invalid root principal metadata cannot create telemetry without an owner.
+func TestWithAuthentication_RejectsRootPrincipalWithoutKeySource(t *testing.T) {
+	t.Parallel()
+
+	flushed := make(chan []schema.KeyVerification, 1)
+	verifications := batch.New(batch.Config[schema.KeyVerification]{
+		Name:          "invalid_root_key_source_test",
+		Drop:          false,
+		BatchSize:     1,
+		BufferSize:    1,
+		FlushInterval: time.Hour,
+		Consumers:     1,
+		Flush: func(_ context.Context, rows []schema.KeyVerification) {
+			flushed <- rows
+		},
+	})
+
+	p := testMiddlewarePrincipal("ws_authorized")
+	p.Source = principal.JWTSource{}
+	handlerCalled := false
+	err := WithAuthentication(AuthenticationConfig{
+		Auth:             &fakeAuth{principal: p},
+		KeyVerifications: verifications,
+	})(func(_ context.Context, _ *zen.Session) error {
+		handlerCalled = true
+		return nil
+	})(context.Background(), &zen.Session{})
+	verifications.Close()
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "root key principal must have a key source")
+	require.False(t, handlerCalled)
+	select {
+	case rows := <-flushed:
+		require.Empty(t, rows)
+	default:
 	}
 }
 
@@ -332,13 +369,14 @@ func TestWithAuthentication_EnforcesWorkspaceRateLimit(t *testing.T) {
 	select {
 	case rows := <-flushed:
 		require.Len(t, rows, 1)
+		require.Equal(t, "ws_root", rows[0].WorkspaceID)
 		require.Equal(t, string(keys.StatusValid), rows[0].Outcome)
 	case <-time.After(time.Second):
 		t.Fatal("root key usage did not flush")
 	}
 }
 
-func testMiddlewarePrincipal(workspaceID string) *principal.Principal {
+func testMiddlewarePrincipal(authorizedWorkspaceID string) *principal.Principal {
 	return &principal.Principal{
 		Version: principal.Version,
 		Subject: principal.Subject{
@@ -346,9 +384,13 @@ func testMiddlewarePrincipal(workspaceID string) *principal.Principal {
 			Name: "Root Key",
 			Type: principal.SubjectTypeRootKey,
 		},
-		Type:        principal.TypeAPIKey,
-		Source:      principal.KeySource{KeyID: "key_123", KeySpaceID: "ks_123"},
-		WorkspaceID: workspaceID,
+		Type: principal.TypeAPIKey,
+		Source: principal.KeySource{
+			KeyID:       "key_123",
+			KeySpaceID:  "ks_123",
+			WorkspaceID: "ws_root",
+		},
+		WorkspaceID: authorizedWorkspaceID,
 		Permissions: []string{"api.*.read_key"},
 	}
 }


### PR DESCRIPTION
Log root key verifications under our own workspace, not the users workspace.


We accidentally inserted verification events for root keys with the workspace_id of the authorized workspace, not our special workspace where the root keys live.

So this propagated through clickhouse MVs into billing 