### PR TITLE
refactor(auth): clarify authorized workspace

### DIFF
--- a/internal/services/keys/get_migrated.go
+++ b/internal/services/keys/get_migrated.go
@@ -37,7 +37,7 @@ func (s *service) GetMigrated(ctx context.Context, sess *zen.Session, rawKey str
 
 	migration, err := keysdb.Query.FindKeyMigrationByID(ctx, s.db.RO(), keysdb.FindKeyMigrationByIDParams{
 		ID:          migrationID,
-		WorkspaceID: principal.WorkspaceID,
+		WorkspaceID: principal.AuthorizedWorkspaceID,
 	})
 	if err != nil {
 		if mysql.IsNotFound(err) {

--- a/pkg/auth/jwt/resolver.go
+++ b/pkg/auth/jwt/resolver.go
@@ -205,8 +205,8 @@ func (r *Resolver) Resolve(ctx context.Context, sess *zen.Session) (*principal.P
 			Roles:     claims.Roles,
 			Signature: segments[2],
 		},
-		WorkspaceID: workspaceID,
-		Permissions: nil,
+		AuthorizedWorkspaceID: workspaceID,
+		Permissions:           nil,
 	}, nil
 }
 

--- a/pkg/auth/jwt/resolver_test.go
+++ b/pkg/auth/jwt/resolver_test.go
@@ -106,7 +106,7 @@ func TestResolver_ResolveJWT(t *testing.T) {
 	require.Equal(t, authprincipal.TypeJWT, principal.Type)
 	require.Equal(t, "user_123", principal.Subject.ID)
 	require.Equal(t, "Dashboard User", principal.Subject.Name)
-	require.Equal(t, "ws_123", principal.WorkspaceID)
+	require.Equal(t, "ws_123", principal.AuthorizedWorkspaceID)
 	source, ok := principal.Source.(authprincipal.JWTSource)
 	require.True(t, ok)
 	require.Equal(t, map[string]any{"id": "org_123"}, source.Payload["org"])
@@ -165,7 +165,7 @@ func TestResolver_ResolveJWTWithJWKSURL(t *testing.T) {
 	require.Equal(t, authprincipal.TypeJWT, principal.Type)
 	require.Equal(t, "user_123", principal.Subject.ID)
 	require.Equal(t, "JWKS User", principal.Subject.Name)
-	require.Equal(t, "ws_123", principal.WorkspaceID)
+	require.Equal(t, "ws_123", principal.AuthorizedWorkspaceID)
 	source, ok := principal.Source.(authprincipal.JWTSource)
 	require.True(t, ok)
 	require.Equal(t, "RS256", source.Header["alg"])
@@ -214,7 +214,7 @@ func TestResolver_ResolveWorkOSAccessTokenClaims(t *testing.T) {
 	require.Equal(t, authprincipal.TypeJWT, principal.Type)
 	require.Equal(t, "user_123", principal.Subject.ID)
 	require.Equal(t, "user@example.test", principal.Subject.Name)
-	require.Equal(t, "ws_123", principal.WorkspaceID)
+	require.Equal(t, "ws_123", principal.AuthorizedWorkspaceID)
 	source, ok := principal.Source.(authprincipal.JWTSource)
 	require.True(t, ok)
 	org, ok := source.Payload["org"].(map[string]any)
@@ -260,7 +260,7 @@ func TestResolver_ResolveJWTWithRotatedSecret(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, authprincipal.TypeJWT, principal.Type)
 	require.Equal(t, "user_123", principal.Subject.ID)
-	require.Equal(t, "ws_123", principal.WorkspaceID)
+	require.Equal(t, "ws_123", principal.AuthorizedWorkspaceID)
 }
 
 // TestResolver_RejectsJWTWithUnexpectedIssuer guarantees a validly signed token

--- a/pkg/auth/portal_session/resolver.go
+++ b/pkg/auth/portal_session/resolver.go
@@ -62,7 +62,7 @@ func (r *Resolver) Resolve(ctx context.Context, sess *zen.Session) (*principal.P
 			KeyspaceIDs: session.KeyspaceIDs,
 			Scopes:      session.Scopes,
 		},
-		WorkspaceID: session.WorkspaceID,
-		Permissions: session.Scopes,
+		AuthorizedWorkspaceID: session.WorkspaceID,
+		Permissions:           session.Scopes,
 	}, nil
 }

--- a/pkg/auth/portal_session/resolver_test.go
+++ b/pkg/auth/portal_session/resolver_test.go
@@ -52,7 +52,7 @@ func TestResolver_ResolvePortalCookie(t *testing.T) {
 	require.Equal(t, authprincipal.Version, principal.Version)
 	require.Equal(t, authprincipal.TypePortalSession, principal.Type)
 	require.Equal(t, "customer_123", principal.Subject.ID)
-	require.Equal(t, "ws_123", principal.WorkspaceID)
+	require.Equal(t, "ws_123", principal.AuthorizedWorkspaceID)
 	source, ok := principal.Source.(authprincipal.PortalSessionSource)
 	require.True(t, ok)
 	// The row handle, not the cookie value: the cookie carries the bearer token.

--- a/pkg/auth/principal/principal.go
+++ b/pkg/auth/principal/principal.go
@@ -52,9 +52,9 @@ type Principal struct {
 	// Source carries the method-specific authentication details.
 	Source Source
 
-	// WorkspaceID is the workspace this principal can access. For root keys, it
-	// is keys.for_workspace_id, not the key owner in [KeySource.WorkspaceID].
-	WorkspaceID string
+	// AuthorizedWorkspaceID is the workspace this principal can access. For root
+	// keys, it is keys.for_workspace_id, not the key owner in [KeySource.WorkspaceID].
+	AuthorizedWorkspaceID string
 
 	// Permissions is the flat set of exact or resource-scoped authorization grants.
 	Permissions []string
@@ -74,7 +74,7 @@ func (p *Principal) Authorize(query rbac.PermissionQuery) error {
 	if err != nil {
 		p.authorizationError = err
 		logger.Warn("principal authorization denied",
-			slog.String("workspace_id", p.WorkspaceID),
+			slog.String("workspace_id", p.AuthorizedWorkspaceID),
 			slog.String("principal_type", string(p.Type)),
 			slog.String("subject_type", string(p.Subject.Type)),
 			slog.String("subject_id", p.Subject.ID),

--- a/pkg/auth/principal/principal_test.go
+++ b/pkg/auth/principal/principal_test.go
@@ -12,12 +12,12 @@ func TestAuthorizeChecksPrincipalPermissions(t *testing.T) {
 
 	// Authorize must accept a principal whose permissions satisfy the query.
 	p := &Principal{
-		Version:     "",
-		Subject:     Subject{ID: "", Name: "", Type: ""},
-		Type:        TypeAPIKey,
-		Source:      KeySource{},
-		WorkspaceID: "",
-		Permissions: []string{"api.*.create_api"},
+		Version:               "",
+		Subject:               Subject{ID: "", Name: "", Type: ""},
+		Type:                  TypeAPIKey,
+		Source:                KeySource{},
+		AuthorizedWorkspaceID: "",
+		Permissions:           []string{"api.*.create_api"},
 	}
 
 	err := p.Authorize(rbac.T(rbac.Tuple{
@@ -35,12 +35,12 @@ func TestAuthorizationErrorReturnsDenial(t *testing.T) {
 	t.Parallel()
 
 	p := &Principal{
-		Version:     "",
-		Subject:     Subject{ID: "", Name: "", Type: ""},
-		Type:        TypeAPIKey,
-		Source:      KeySource{},
-		WorkspaceID: "",
-		Permissions: []string{},
+		Version:               "",
+		Subject:               Subject{ID: "", Name: "", Type: ""},
+		Type:                  TypeAPIKey,
+		Source:                KeySource{},
+		AuthorizedWorkspaceID: "",
+		Permissions:           []string{},
 	}
 
 	err := p.Authorize(rbac.T(rbac.Tuple{

--- a/pkg/auth/resolver.go
+++ b/pkg/auth/resolver.go
@@ -12,8 +12,9 @@ import (
 // Implementations must return (nil, nil) when the request does not contain a
 // credential they understand. They must return an error when the request does
 // contain their credential type but verification fails. A non-nil principal
-// means the resolver fully authenticated the request, populated WorkspaceID,
-// Subject, Type, Source, and Permissions, and no later resolver will run.
+// means the resolver fully authenticated the request, populated
+// AuthorizedWorkspaceID, Subject, Type, Source, and Permissions, and no later
+// resolver will run.
 type Resolver interface {
 	Resolve(ctx context.Context, sess *zen.Session) (*principal.Principal, error)
 }

--- a/pkg/auth/root_key/resolver.go
+++ b/pkg/auth/root_key/resolver.go
@@ -50,7 +50,7 @@ func (r *Resolver) Resolve(ctx context.Context, sess *zen.Session) (*principal.P
 			WorkspaceID: key.Key.WorkspaceID,
 			Permissions: key.Permissions,
 		},
-		WorkspaceID: key.AuthorizedWorkspaceID,
-		Permissions: key.Permissions,
+		AuthorizedWorkspaceID: key.AuthorizedWorkspaceID,
+		Permissions:           key.Permissions,
 	}, nil
 }

--- a/pkg/auth/root_key/resolver_test.go
+++ b/pkg/auth/root_key/resolver_test.go
@@ -86,7 +86,7 @@ func TestResolver_ResolveRootKeyPrincipal(t *testing.T) {
 	require.Equal(t, authprincipal.SubjectTypeRootKey, p.Subject.Type)
 	require.Equal(t, "key_123", p.Subject.ID)
 	require.Equal(t, "Production root key", p.Subject.Name)
-	require.Equal(t, "ws_authorized", p.WorkspaceID)
+	require.Equal(t, "ws_authorized", p.AuthorizedWorkspaceID)
 	require.Equal(t, []string{"api.*.read_key"}, p.Permissions)
 	source, ok := p.Source.(authprincipal.KeySource)
 	require.True(t, ok)

--- a/pkg/auth/service.go
+++ b/pkg/auth/service.go
@@ -69,7 +69,7 @@ func (c chain) Authenticate(ctx context.Context, sess *zen.Session) (*principal.
 		sess.SetPrincipal(principal)
 		logger.Set(ctx, slog.Group("auth",
 			slog.String("type", string(principal.Type)),
-			slog.String("workspace_id", principal.WorkspaceID),
+			slog.String("workspace_id", principal.AuthorizedWorkspaceID),
 			slog.String("subject", principal.Subject.ID),
 			slog.String("subject_name", principal.Subject.Name),
 			slog.Int("permission_count", len(principal.Permissions)),

--- a/pkg/auth/service_test.go
+++ b/pkg/auth/service_test.go
@@ -283,9 +283,9 @@ func testPrincipal(workspaceID string) *principal.Principal {
 			Name: "Dashboard User",
 			Type: principal.SubjectTypeUser,
 		},
-		Type:        principal.TypeJWT,
-		Source:      principal.JWTSource{},
-		WorkspaceID: workspaceID,
-		Permissions: []string{"api.*.create_api"},
+		Type:                  principal.TypeJWT,
+		Source:                principal.JWTSource{},
+		AuthorizedWorkspaceID: workspaceID,
+		Permissions:           []string{"api.*.create_api"},
 	}
 }

--- a/pkg/auth/workos/resolver.go
+++ b/pkg/auth/workos/resolver.go
@@ -35,6 +35,6 @@ func (r resolverWithRoles) Resolve(ctx context.Context, sess *zen.Session) (*pri
 		return nil, err
 	}
 
-	p.Permissions = permissionsForRoles(p.WorkspaceID, source.Roles)
+	p.Permissions = permissionsForRoles(p.AuthorizedWorkspaceID, source.Roles)
 	return p, nil
 }

--- a/pkg/auth/workos/resolver_test.go
+++ b/pkg/auth/workos/resolver_test.go
@@ -28,8 +28,8 @@ func TestResolverWithRolesMapsRoles(t *testing.T) {
 	resolver := resolverWithRoles{
 		resolver: stubResolver{
 			principal: &principal.Principal{
-				Type:        principal.TypeJWT,
-				WorkspaceID: "ws_123",
+				Type:                  principal.TypeJWT,
+				AuthorizedWorkspaceID: "ws_123",
 				Source: principal.JWTSource{
 					Roles: []string{"viewer", "admin"},
 				},
@@ -51,9 +51,9 @@ func TestResolverWithRolesLeavesNonJWTPrincipalsAlone(t *testing.T) {
 	resolver := resolverWithRoles{
 		resolver: stubResolver{
 			principal: &principal.Principal{
-				Type:        principal.TypeAPIKey,
-				WorkspaceID: "ws_123",
-				Permissions: []string{"api.*.read_api"},
+				Type:                  principal.TypeAPIKey,
+				AuthorizedWorkspaceID: "ws_123",
+				Permissions:           []string{"api.*.read_api"},
 			},
 		},
 	}

--- a/pkg/zen/middleware_metrics.go
+++ b/pkg/zen/middleware_metrics.go
@@ -98,7 +98,7 @@ func WithMetrics(apiRequestBuffer ApiRequestBuffer, info InstanceInfo, redactor 
 
 				workspaceID := ""
 				if principal, err := s.GetPrincipal(); err == nil {
-					workspaceID = principal.WorkspaceID
+					workspaceID = principal.AuthorizedWorkspaceID
 				}
 
 				apiRequestBuffer.Buffer(schema.ApiRequest{

--- a/pkg/zen/session_principal_test.go
+++ b/pkg/zen/session_principal_test.go
@@ -30,12 +30,12 @@ func TestSession_PrincipalScopesWorkspaceMetadata(t *testing.T) {
 	t.Parallel()
 
 	want := &principal.Principal{
-		Version:     principal.Version,
-		Subject:     principal.Subject{ID: "root_key_123", Name: "Root Key", Type: principal.SubjectTypeRootKey},
-		Type:        principal.TypeAPIKey,
-		Source:      principal.KeySource{KeyID: "key_123", KeySpaceID: "ks_123"},
-		WorkspaceID: "ws_123",
-		Permissions: []string{"api.*.read_key"},
+		Version:               principal.Version,
+		Subject:               principal.Subject{ID: "root_key_123", Name: "Root Key", Type: principal.SubjectTypeRootKey},
+		Type:                  principal.TypeAPIKey,
+		Source:                principal.KeySource{KeyID: "key_123", KeySpaceID: "ks_123"},
+		AuthorizedWorkspaceID: "ws_123",
+		Permissions:           []string{"api.*.read_key"},
 	}
 	sess := &Session{}
 
@@ -55,12 +55,12 @@ func TestSession_ResetClearsPrincipal(t *testing.T) {
 
 	sess := &Session{}
 	sess.SetPrincipal(&principal.Principal{
-		Version:     principal.Version,
-		Subject:     principal.Subject{ID: "root_key_123", Name: "Root Key", Type: principal.SubjectTypeRootKey},
-		Type:        principal.TypeAPIKey,
-		Source:      principal.KeySource{KeyID: "key_123", KeySpaceID: "ks_123"},
-		WorkspaceID: "ws_123",
-		Permissions: []string{"api.*.read_key"},
+		Version:               principal.Version,
+		Subject:               principal.Subject{ID: "root_key_123", Name: "Root Key", Type: principal.SubjectTypeRootKey},
+		Type:                  principal.TypeAPIKey,
+		Source:                principal.KeySource{KeyID: "key_123", KeySpaceID: "ks_123"},
+		AuthorizedWorkspaceID: "ws_123",
+		Permissions:           []string{"api.*.read_key"},
 	})
 
 	sess.reset()

--- a/svc/api/internal/middleware/authentication.go
+++ b/svc/api/internal/middleware/authentication.go
@@ -95,7 +95,7 @@ func WithAuthentication(config AuthenticationConfig) zen.Middleware {
 				}()
 			}
 
-			if err := checkWorkspaceRateLimit(ctx, sess, config, p.WorkspaceID); err != nil {
+			if err := checkWorkspaceRateLimit(ctx, sess, config, p.AuthorizedWorkspaceID); err != nil {
 				return err
 			}
 

--- a/svc/api/internal/middleware/authentication_test.go
+++ b/svc/api/internal/middleware/authentication_test.go
@@ -390,7 +390,7 @@ func testMiddlewarePrincipal(authorizedWorkspaceID string) *principal.Principal 
 			KeySpaceID:  "ks_123",
 			WorkspaceID: "ws_root",
 		},
-		WorkspaceID: authorizedWorkspaceID,
-		Permissions: []string{"api.*.read_key"},
+		AuthorizedWorkspaceID: authorizedWorkspaceID,
+		Permissions:           []string{"api.*.read_key"},
 	}
 }

--- a/svc/api/internal/middleware/errors.go
+++ b/svc/api/internal/middleware/errors.go
@@ -27,7 +27,7 @@ import (
 func errorLogAttrs(s *zen.Session, err error, status int, urn codes.URN) []any {
 	workspaceID := ""
 	if principal, principalErr := s.GetPrincipal(); principalErr == nil {
-		workspaceID = principal.WorkspaceID
+		workspaceID = principal.AuthorizedWorkspaceID
 	}
 
 	return []any{

--- a/svc/api/internal/middleware/errors_test.go
+++ b/svc/api/internal/middleware/errors_test.go
@@ -40,11 +40,11 @@ func TestErrorMiddleware_500_LogsRichContextAndHidesInternalDetails(t *testing.T
 
 	sess, rec := newSession(t, http.MethodPost, "/v2/keys.verifyKey?debug=1")
 	sess.SetPrincipal(&principal.Principal{
-		Version:     principal.Version,
-		Subject:     principal.Subject{ID: "key_test", Name: "Test Key", Type: principal.SubjectTypeRootKey},
-		Type:        principal.TypeAPIKey,
-		Source:      principal.KeySource{KeyID: "key_test", KeySpaceID: "ks_test"},
-		WorkspaceID: "ws_test_123",
+		Version:               principal.Version,
+		Subject:               principal.Subject{ID: "key_test", Name: "Test Key", Type: principal.SubjectTypeRootKey},
+		Type:                  principal.TypeAPIKey,
+		Source:                principal.KeySource{KeyID: "key_test", KeySpaceID: "ks_test"},
+		AuthorizedWorkspaceID: "ws_test_123",
 	})
 
 	rootErr := fault.New("db connection refused",

--- a/svc/api/routes/v2_analytics_get_gateway_requests/handler.go
+++ b/svc/api/routes/v2_analytics_get_gateway_requests/handler.go
@@ -59,7 +59,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 	rows, err := analytics.Execute(ctx, h.AnalyticsConnectionManager, analytics.ExecuteRequest{
 		Query:           req.Query,
-		WorkspaceID:     p.WorkspaceID,
+		WorkspaceID:     p.AuthorizedWorkspaceID,
 		TableAliases:    tableAliases,
 		AllowedTables:   allowedTables,
 		SecurityFilters: nil,

--- a/svc/api/routes/v2_analytics_get_ratelimits/handler.go
+++ b/svc/api/routes/v2_analytics_get_ratelimits/handler.go
@@ -66,7 +66,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 	rows, err := analytics.Execute(ctx, h.AnalyticsConnectionManager, analytics.ExecuteRequest{
 		Query:           req.Query,
-		WorkspaceID:     p.WorkspaceID,
+		WorkspaceID:     p.AuthorizedWorkspaceID,
 		TableAliases:    tableAliases,
 		AllowedTables:   allowedTables,
 		SecurityFilters: securityFilters,

--- a/svc/api/routes/v2_analytics_get_runtime_logs/handler.go
+++ b/svc/api/routes/v2_analytics_get_runtime_logs/handler.go
@@ -59,7 +59,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 	rows, err := analytics.Execute(ctx, h.AnalyticsConnectionManager, analytics.ExecuteRequest{
 		Query:           req.Query,
-		WorkspaceID:     p.WorkspaceID,
+		WorkspaceID:     p.AuthorizedWorkspaceID,
 		TableAliases:    tableAliases,
 		AllowedTables:   allowedTables,
 		SecurityFilters: nil,

--- a/svc/api/routes/v2_analytics_get_verifications/handler.go
+++ b/svc/api/routes/v2_analytics_get_verifications/handler.go
@@ -81,7 +81,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 	securityFilters := make([]chquery.SecurityFilter, 0, 1)
 	if !hasWildcard {
-		keySpaces, fetchErr := h.fetchKeyAuthsByAPIIDs(ctx, principal.WorkspaceID, allowedAPIIDs)
+		keySpaces, fetchErr := h.fetchKeyAuthsByAPIIDs(ctx, principal.AuthorizedWorkspaceID, allowedAPIIDs)
 		if fetchErr != nil {
 			return fetchErr
 		}
@@ -94,7 +94,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 	verifications, err := analytics.Execute(ctx, h.AnalyticsConnectionManager, analytics.ExecuteRequest{
 		Query:           req.Query,
-		WorkspaceID:     principal.WorkspaceID,
+		WorkspaceID:     principal.AuthorizedWorkspaceID,
 		TableAliases:    tableAliases,
 		AllowedTables:   allowedTables,
 		SecurityFilters: securityFilters,

--- a/svc/api/routes/v2_apis_create_api/handler.go
+++ b/svc/api/routes/v2_apis_create_api/handler.go
@@ -58,7 +58,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	apiId, err := db.TxWithResultRetry(ctx, h.DB.RW(), func(ctx context.Context, tx db.DBTX) (string, error) {
-		projectID, resolveErr := projects.EnsureDefaultProject(ctx, tx, principal.WorkspaceID)
+		projectID, resolveErr := projects.EnsureDefaultProject(ctx, tx, principal.AuthorizedWorkspaceID)
 		if resolveErr != nil {
 			return "", resolveErr
 		}
@@ -66,7 +66,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		keySpaceId := uid.New(uid.KeySpacePrefix)
 		err = db.Query.InsertKeySpace(ctx, tx, db.InsertKeySpaceParams{
 			ID:                 keySpaceId,
-			WorkspaceID:        principal.WorkspaceID,
+			WorkspaceID:        principal.AuthorizedWorkspaceID,
 			ProjectID:          projectID,
 			CreatedAtM:         time.Now().UnixMilli(),
 			DefaultPrefix:      sql.NullString{Valid: false, String: ""},
@@ -84,7 +84,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		err = db.Query.InsertApi(ctx, tx, db.InsertApiParams{
 			ID:          apiId,
 			Name:        req.Name,
-			WorkspaceID: principal.WorkspaceID,
+			WorkspaceID: principal.AuthorizedWorkspaceID,
 			ProjectID:   projectID,
 			AuthType:    db.NullApisAuthType{Valid: true, ApisAuthType: db.ApisAuthTypeKey},
 			KeyAuthID:   sql.NullString{Valid: true, String: keySpaceId},
@@ -100,7 +100,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 		err = h.Auditlogs.Insert(ctx, tx, []auditlog.AuditLog{
 			{
-				WorkspaceID:   principal.WorkspaceID,
+				WorkspaceID:   principal.AuthorizedWorkspaceID,
 				Event:         auditlog.APICreateEvent,
 				Display:       fmt.Sprintf("Created API %s", apiId),
 				ActorID:       principal.Subject.ID,

--- a/svc/api/routes/v2_apis_delete_api/handler.go
+++ b/svc/api/routes/v2_apis_delete_api/handler.go
@@ -83,7 +83,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	// Check if API belongs to the authorized workspace
-	if api.WorkspaceID != principal.WorkspaceID {
+	if api.WorkspaceID != principal.AuthorizedWorkspaceID {
 		return fault.New("wrong workspace",
 			fault.Code(codes.Data.Api.NotFound.URN()),
 			fault.Internal("wrong workspace, masking as 404"), fault.Public("The requested API does not exist or has been deleted."),
@@ -123,7 +123,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 		// Create audit log for API deletion
 		err = h.Auditlogs.Insert(ctx, tx, []auditlog.AuditLog{{
-			WorkspaceID: principal.WorkspaceID,
+			WorkspaceID: principal.AuthorizedWorkspaceID,
 			Event:       auditlog.APIDeleteEvent,
 			ActorType:   auditlog.AuditLogActor(principal.Subject.Type),
 			ActorID:     principal.Subject.ID,
@@ -153,7 +153,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	h.Caches.LiveApiByID.SetNull(ctx, cache.ScopedKey{WorkspaceID: principal.WorkspaceID, Key: req.ApiId})
+	h.Caches.LiveApiByID.SetNull(ctx, cache.ScopedKey{WorkspaceID: principal.AuthorizedWorkspaceID, Key: req.ApiId})
 
 	return s.JSON(http.StatusOK, Response{
 		Meta: openapi.Meta{

--- a/svc/api/routes/v2_apis_get_api/handler.go
+++ b/svc/api/routes/v2_apis_get_api/handler.go
@@ -61,7 +61,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	api, hit, err := h.Caches.LiveApiByID.SWR(ctx, cache.ScopedKey{WorkspaceID: principal.WorkspaceID, Key: req.ApiId}, func(ctx context.Context) (db.FindLiveApiByIDRow, error) {
+	api, hit, err := h.Caches.LiveApiByID.SWR(ctx, cache.ScopedKey{WorkspaceID: principal.AuthorizedWorkspaceID, Key: req.ApiId}, func(ctx context.Context) (db.FindLiveApiByIDRow, error) {
 		return db.Query.FindLiveApiByID(ctx, h.DB.RO(), req.ApiId)
 	}, caches.DefaultFindFirstOp)
 
@@ -88,7 +88,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	// Check if API belongs to the authorized workspace
-	if api.ApiWorkspaceID != principal.WorkspaceID {
+	if api.ApiWorkspaceID != principal.AuthorizedWorkspaceID {
 		return fault.New("wrong workspace",
 			fault.Code(codes.Data.Api.NotFound.URN()),
 			fault.Internal("wrong workspace, masking as 404"), fault.Public("The requested API does not exist or has been deleted."),

--- a/svc/api/routes/v2_apis_list_keys/handler.go
+++ b/svc/api/routes/v2_apis_list_keys/handler.go
@@ -61,7 +61,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	api, hit, err := h.ApiCache.SWR(ctx, cache.ScopedKey{
-		WorkspaceID: principal.WorkspaceID,
+		WorkspaceID: principal.AuthorizedWorkspaceID,
 		Key:         req.ApiId,
 	}, func(ctx context.Context) (db.FindLiveApiByIDRow, error) {
 		return db.Query.FindLiveApiByID(ctx, h.DB.RO(), req.ApiId)
@@ -93,7 +93,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	// Check if API belongs to the authorized workspace
-	if api.ApiWorkspaceID != principal.WorkspaceID {
+	if api.ApiWorkspaceID != principal.AuthorizedWorkspaceID {
 		return fault.New(
 			"wrong workspace",
 			fault.Code(codes.Data.Api.NotFound.URN()),
@@ -113,11 +113,11 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	err = principal.Authorize(rbac.Or(
 		rbac.And(
 			rbac.U(
-				urn.New().Workspace(principal.WorkspaceID).Project(api.KeyAuthProjectID).Keyspace(api.ApiKeyAuthID.String).Key("*"),
+				urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(api.KeyAuthProjectID).Keyspace(api.ApiKeyAuthID.String).Key("*"),
 				permissions.Read,
 			),
 			rbac.U(
-				urn.New().Workspace(principal.WorkspaceID).Project(api.KeyAuthProjectID).Keyspace(api.ApiKeyAuthID.String),
+				urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(api.KeyAuthProjectID).Keyspace(api.ApiKeyAuthID.String),
 				permissions.Read,
 			),
 		),
@@ -156,7 +156,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 				Action:       rbac.DecryptKey,
 			}),
 			rbac.U(
-				urn.New().Workspace(principal.WorkspaceID).Project(api.KeyAuthProjectID).Keyspace(api.ApiKeyAuthID.String).Key("*"),
+				urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(api.KeyAuthProjectID).Keyspace(api.ApiKeyAuthID.String).Key("*"),
 				permissions.Decrypt,
 			),
 		))
@@ -201,7 +201,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	var identityID sql.NullString
 	if req.ExternalId != nil && *req.ExternalId != "" {
 		identity, identityErr := db.Query.FindIdentityByExternalID(ctx, h.DB.RO(), db.FindIdentityByExternalIDParams{
-			WorkspaceID: principal.WorkspaceID,
+			WorkspaceID: principal.AuthorizedWorkspaceID,
 			ExternalID:  *req.ExternalId,
 			Deleted:     false,
 		})
@@ -261,7 +261,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		})
 	}
 
-	plaintextMap := h.decryptKeys(ctx, req, keyResults, principal.WorkspaceID)
+	plaintextMap := h.decryptKeys(ctx, req, keyResults, principal.AuthorizedWorkspaceID)
 
 	responseData := array.Map(keyResults, func(key db.ListLiveKeysByKeySpaceIDRow) openapi.KeyResponseData {
 		return BuildKeyResponseData(db.ToKeyData(key), plaintextMap[key.ID])

--- a/svc/api/routes/v2_apps_create_app/handler.go
+++ b/svc/api/routes/v2_apps_create_app/handler.go
@@ -67,7 +67,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	ctx = auditlog.WithCorrelation(ctx, auditlog.NewCorrelationID())
 
 	project, err := db.Query.FindProjectByIdOrSlug(ctx, h.DB.RO(), db.FindProjectByIdOrSlugParams{
-		WorkspaceID: principal.WorkspaceID,
+		WorkspaceID: principal.AuthorizedWorkspaceID,
 		Project:     req.Project,
 	})
 	if err != nil {
@@ -99,7 +99,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			Action:       rbac.CreateApp,
 		}),
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project(project.ID).App("*"),
+			urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(project.ID).App("*"),
 			permissions.Write,
 		),
 	))
@@ -126,7 +126,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			)
 		}
 
-		installations, iErr := db.Query.FindGithubAppInstallationsByWorkspaceId(ctx, h.DB.RO(), principal.WorkspaceID)
+		installations, iErr := db.Query.FindGithubAppInstallationsByWorkspaceId(ctx, h.DB.RO(), principal.AuthorizedWorkspaceID)
 		if iErr != nil {
 			return fault.Wrap(
 				iErr,
@@ -147,7 +147,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 	res, err := h.CtrlClient.CreateApp(ctx, &ctrlv1.CreateAppRequest{
-		WorkspaceId: principal.WorkspaceID,
+		WorkspaceId: principal.AuthorizedWorkspaceID,
 		ProjectId:   project.ID,
 		Name:        req.Name,
 		Slug:        req.Slug,
@@ -178,7 +178,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		err = db.TxRetry(ctx, h.DB.RW(), func(ctx context.Context, tx db.DBTX) error {
 			now := time.Now().UnixMilli()
 			if txErr := db.Query.UpsertGithubRepoConnection(ctx, tx, db.UpsertGithubRepoConnectionParams{
-				WorkspaceID:        principal.WorkspaceID,
+				WorkspaceID:        principal.AuthorizedWorkspaceID,
 				ProjectID:          project.ID,
 				AppID:              appID,
 				InstallationID:     resolved.InstallationID,
@@ -196,7 +196,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			}
 
 			if txErr := db.Query.UpdateApp(ctx, tx, db.UpdateAppParams{
-				WorkspaceID:               principal.WorkspaceID,
+				WorkspaceID:               principal.AuthorizedWorkspaceID,
 				ID:                        appID,
 				UpdatedAt:                 sql.NullInt64{Valid: true, Int64: now},
 				NameSpecified:             0,
@@ -218,7 +218,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 			return h.Auditlogs.Insert(ctx, tx, []auditlog.AuditLog{
 				{
-					WorkspaceID:   principal.WorkspaceID,
+					WorkspaceID:   principal.AuthorizedWorkspaceID,
 					Event:         auditlog.AppConnectRepositoryEvent,
 					Display:       fmt.Sprintf("Connected app %s to %s", appID, resolved.Repository.FullName),
 					ActorID:       principal.Subject.ID,

--- a/svc/api/routes/v2_apps_delete_app/handler.go
+++ b/svc/api/routes/v2_apps_delete_app/handler.go
@@ -48,7 +48,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	app, err := db.Query.FindAppByProjectAndIdOrSlug(ctx, h.DB.RW(), db.FindAppByProjectAndIdOrSlugParams{
-		WorkspaceID: principal.WorkspaceID,
+		WorkspaceID: principal.AuthorizedWorkspaceID,
 		Project:     req.Project,
 		App:         req.App,
 	})
@@ -82,7 +82,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			Action:       rbac.DeleteApp,
 		}),
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project(app.ProjectID).App(app.ID),
+			urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(app.ProjectID).App(app.ID),
 			permissions.Delete,
 		),
 	))

--- a/svc/api/routes/v2_apps_get_app/handler.go
+++ b/svc/api/routes/v2_apps_get_app/handler.go
@@ -42,7 +42,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	app, err := db.Query.FindAppByProjectAndIdOrSlug(ctx, h.DB.RO(), db.FindAppByProjectAndIdOrSlugParams{
-		WorkspaceID: principal.WorkspaceID,
+		WorkspaceID: principal.AuthorizedWorkspaceID,
 		Project:     req.Project,
 		App:         req.App,
 	})

--- a/svc/api/routes/v2_apps_list_apps/handler.go
+++ b/svc/api/routes/v2_apps_list_apps/handler.go
@@ -47,7 +47,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	project, err := db.Query.FindProjectByIdOrSlug(ctx, h.DB.RO(), db.FindProjectByIdOrSlugParams{
-		WorkspaceID: principal.WorkspaceID,
+		WorkspaceID: principal.AuthorizedWorkspaceID,
 		Project:     req.Project,
 	})
 	if err != nil {

--- a/svc/api/routes/v2_apps_update_app/handler.go
+++ b/svc/api/routes/v2_apps_update_app/handler.go
@@ -61,7 +61,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 	data, err := db.TxWithResultRetry(ctx, h.DB.RW(), func(ctx context.Context, tx db.DBTX) (openapi.App, error) {
 		app, err := db.Query.FindAppByProjectAndIdOrSlug(ctx, tx, db.FindAppByProjectAndIdOrSlugParams{
-			WorkspaceID: principal.WorkspaceID,
+			WorkspaceID: principal.AuthorizedWorkspaceID,
 			Project:     req.Project,
 			App:         req.App,
 		})
@@ -121,7 +121,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 		updatedAt := time.Now().UnixMilli()
 		update := db.UpdateAppParams{
-			WorkspaceID:               principal.WorkspaceID,
+			WorkspaceID:               principal.AuthorizedWorkspaceID,
 			ID:                        app.ID,
 			UpdatedAt:                 sql.NullInt64{Valid: true, Int64: updatedAt},
 			NameSpecified:             0,
@@ -194,7 +194,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		logs := make([]auditlog.AuditLog, 0, 2)
 		if appColumnsChanged {
 			logs = append(logs, auditlog.AuditLog{
-				WorkspaceID:   principal.WorkspaceID,
+				WorkspaceID:   principal.AuthorizedWorkspaceID,
 				Event:         auditlog.AppUpdateEvent,
 				Display:       fmt.Sprintf("Updated app %s", app.ID),
 				ActorID:       principal.Subject.ID,
@@ -230,7 +230,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 				resourceName = gitState.Repository
 			}
 			logs = append(logs, auditlog.AuditLog{
-				WorkspaceID:   principal.WorkspaceID,
+				WorkspaceID:   principal.AuthorizedWorkspaceID,
 				Event:         event,
 				Display:       display,
 				ActorID:       principal.Subject.ID,

--- a/svc/api/routes/v2_deploy_create_deployment/handler.go
+++ b/svc/api/routes/v2_deploy_create_deployment/handler.go
@@ -48,7 +48,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 	// Resolve project + app in a single query by workspace + slugs
 	row, err := db.Query.FindAppByWorkspaceAndSlugs(ctx, h.DB.RO(), db.FindAppByWorkspaceAndSlugsParams{
-		WorkspaceID: principal.WorkspaceID,
+		WorkspaceID: principal.AuthorizedWorkspaceID,
 		ProjectSlug: req.Project,
 		AppSlug:     req.App,
 	})
@@ -122,7 +122,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			return fault.Wrap(err, fault.Internal("failed to find keyspace"))
 		}
 
-		if keySpace.WorkspaceID != principal.WorkspaceID {
+		if keySpace.WorkspaceID != principal.AuthorizedWorkspaceID {
 			return fault.New("keyspace not found",
 				fault.Code(codes.Data.KeyAuth.NotFound.URN()),
 				fault.Internal("keyspace belongs to different workspace, masking as 404"),

--- a/svc/api/routes/v2_deploy_get_deployment/handler.go
+++ b/svc/api/routes/v2_deploy_get_deployment/handler.go
@@ -55,7 +55,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	// Verify deployment belongs to the authenticated workspace
-	if deployment.WorkspaceID != principal.WorkspaceID {
+	if deployment.WorkspaceID != principal.AuthorizedWorkspaceID {
 		return fault.New("wrong workspace",
 			fault.Code(codes.Data.Project.NotFound.URN()),
 			fault.Internal("wrong workspace, masking as 404"),

--- a/svc/api/routes/v2_deployments_create_deployment/handler.go
+++ b/svc/api/routes/v2_deployments_create_deployment/handler.go
@@ -55,7 +55,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	environment, err := db.Query.FindEnvironmentByIdentifiers(ctx, h.DB.RO(), db.FindEnvironmentByIdentifiersParams{
-		WorkspaceID: principal.WorkspaceID,
+		WorkspaceID: principal.AuthorizedWorkspaceID,
 		Project:     req.Project,
 		App:         req.App,
 		Environment: req.Environment,
@@ -84,7 +84,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			Action:       rbac.CreateDeployment,
 		}),
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project(environment.ProjectID).App(environment.AppID).Environment(environment.ID).Deployment("*"),
+			urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(environment.ProjectID).App(environment.AppID).Environment(environment.ID).Deployment("*"),
 			permissions.Write,
 		),
 	))
@@ -158,7 +158,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		}
 
 	case req.Deployment != nil:
-		gitCommit, dockerImage, err := h.resolveRedeploy(ctx, principal.WorkspaceID, environment.AppID, environment.ID, req.Deployment.DeploymentId)
+		gitCommit, dockerImage, err := h.resolveRedeploy(ctx, principal.AuthorizedWorkspaceID, environment.AppID, environment.ID, req.Deployment.DeploymentId)
 		if err != nil {
 			return err
 		}

--- a/svc/api/routes/v2_deployments_get_deployment/handler.go
+++ b/svc/api/routes/v2_deployments_get_deployment/handler.go
@@ -55,7 +55,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 	// FindDeploymentById is not workspace-scoped, so a match in another workspace
 	// is masked as not found to avoid leaking a deployment's existence.
-	if db.IsNotFound(err) || dep.WorkspaceID != principal.WorkspaceID {
+	if db.IsNotFound(err) || dep.WorkspaceID != principal.AuthorizedWorkspaceID {
 		return fault.New(
 			"deployment not found",
 			fault.Code(codes.Data.Deployment.NotFound.URN()),
@@ -86,7 +86,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	states, err := db.Query.ListDeploymentEnvAndAppState(ctx, h.DB.RO(), db.ListDeploymentEnvAndAppStateParams{
-		WorkspaceID:   principal.WorkspaceID,
+		WorkspaceID:   principal.AuthorizedWorkspaceID,
 		DeploymentIds: []string{dep.ID},
 	})
 	if err != nil {
@@ -105,7 +105,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	var steps []db.DeploymentStep
 	if dep.Status == mysqltype.DeploymentsStatusFailed {
 		steps, err = db.Query.ListFailedDeploymentStepsByIds(ctx, h.DB.RO(), db.ListFailedDeploymentStepsByIdsParams{
-			WorkspaceID:   principal.WorkspaceID,
+			WorkspaceID:   principal.AuthorizedWorkspaceID,
 			DeploymentIds: []string{dep.ID},
 		})
 		if err != nil {
@@ -119,7 +119,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	domains, err := db.Query.ListDeploymentDomains(ctx, h.DB.RO(), db.ListDeploymentDomainsParams{
-		WorkspaceID:  principal.WorkspaceID,
+		WorkspaceID:  principal.AuthorizedWorkspaceID,
 		DeploymentID: dep.ID,
 	})
 	if err != nil {
@@ -132,7 +132,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	regions, err := db.Query.ListDeploymentRegions(ctx, h.DB.RO(), db.ListDeploymentRegionsParams{
-		WorkspaceID:  principal.WorkspaceID,
+		WorkspaceID:  principal.AuthorizedWorkspaceID,
 		DeploymentID: dep.ID,
 	})
 	if err != nil {

--- a/svc/api/routes/v2_deployments_list_deployments/handler.go
+++ b/svc/api/routes/v2_deployments_list_deployments/handler.go
@@ -78,7 +78,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	var projectID, appID, environmentID string
 	if req.Project != nil {
 		scope, err := db.Query.ResolveDeploymentScope(ctx, h.DB.RO(), db.ResolveDeploymentScopeParams{
-			WorkspaceID: principal.WorkspaceID,
+			WorkspaceID: principal.AuthorizedWorkspaceID,
 			Project:     *req.Project,
 			App:         ptr.SafeDeref(req.App, ""),
 			Environment: ptr.SafeDeref(req.Environment, ""),
@@ -134,7 +134,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	rows, err := db.Query.ListDeployments(ctx, h.DB.RO(), db.ListDeploymentsParams{
-		WorkspaceID:     principal.WorkspaceID,
+		WorkspaceID:     principal.AuthorizedWorkspaceID,
 		ProjectID:       projectID,
 		AppID:           appID,
 		EnvironmentID:   environmentID,
@@ -161,7 +161,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			ids[i] = row.ID
 		}
 		state, err := db.Query.ListDeploymentEnvAndAppState(ctx, h.DB.RO(), db.ListDeploymentEnvAndAppStateParams{
-			WorkspaceID:   principal.WorkspaceID,
+			WorkspaceID:   principal.AuthorizedWorkspaceID,
 			DeploymentIds: ids,
 		})
 		if err != nil {
@@ -178,7 +178,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		}
 
 		regionRows, err := db.Query.ListDeploymentRegionsByIds(ctx, h.DB.RO(), db.ListDeploymentRegionsByIdsParams{
-			WorkspaceID:   principal.WorkspaceID,
+			WorkspaceID:   principal.AuthorizedWorkspaceID,
 			DeploymentIds: ids,
 		})
 		if err != nil {
@@ -195,7 +195,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		}
 
 		stepRows, err := db.Query.ListFailedDeploymentStepsByIds(ctx, h.DB.RO(), db.ListFailedDeploymentStepsByIdsParams{
-			WorkspaceID:   principal.WorkspaceID,
+			WorkspaceID:   principal.AuthorizedWorkspaceID,
 			DeploymentIds: ids,
 		})
 		if err != nil {
@@ -212,7 +212,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		}
 
 		domainRows, err := db.Query.ListDeploymentDomainsByIds(ctx, h.DB.RO(), db.ListDeploymentDomainsByIdsParams{
-			WorkspaceID:   principal.WorkspaceID,
+			WorkspaceID:   principal.AuthorizedWorkspaceID,
 			DeploymentIds: ids,
 		})
 		if err != nil {

--- a/svc/api/routes/v2_deployments_promote_deployment/handler.go
+++ b/svc/api/routes/v2_deployments_promote_deployment/handler.go
@@ -49,7 +49,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	dep, err := deployment.FindDeployment(ctx, h.DB, principal.WorkspaceID, req.DeploymentId)
+	dep, err := deployment.FindDeployment(ctx, h.DB, principal.AuthorizedWorkspaceID, req.DeploymentId)
 	if err != nil {
 		return err
 	}
@@ -66,7 +66,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			Action:       rbac.PromoteDeployment,
 		}),
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project(dep.ProjectID).App(dep.AppID).Environment(dep.EnvironmentID),
+			urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(dep.ProjectID).App(dep.AppID).Environment(dep.EnvironmentID),
 			permissions.Write,
 		),
 	))
@@ -103,7 +103,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	billing, err := db.Query.FindWorkspaceBillingByWorkspaceID(ctx, h.DB.RW(), principal.WorkspaceID)
+	billing, err := db.Query.FindWorkspaceBillingByWorkspaceID(ctx, h.DB.RW(), principal.AuthorizedWorkspaceID)
 	if err != nil && !db.IsNotFound(err) {
 		return fault.Wrap(
 			err,

--- a/svc/api/routes/v2_deployments_rollback_deployment/handler.go
+++ b/svc/api/routes/v2_deployments_rollback_deployment/handler.go
@@ -49,7 +49,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	dep, err := deployment.FindDeployment(ctx, h.DB, principal.WorkspaceID, req.DeploymentId)
+	dep, err := deployment.FindDeployment(ctx, h.DB, principal.AuthorizedWorkspaceID, req.DeploymentId)
 	if err != nil {
 		return err
 	}
@@ -66,7 +66,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			Action:       rbac.RollbackDeployment,
 		}),
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project(dep.ProjectID).App(dep.AppID).Environment(dep.EnvironmentID),
+			urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(dep.ProjectID).App(dep.AppID).Environment(dep.EnvironmentID),
 			permissions.Write,
 		),
 	))
@@ -103,7 +103,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	source, err := deployment.FindDeployment(ctx, h.DB, principal.WorkspaceID, app.CurrentDeploymentID.String)
+	source, err := deployment.FindDeployment(ctx, h.DB, principal.AuthorizedWorkspaceID, app.CurrentDeploymentID.String)
 	if err != nil {
 		return err
 	}
@@ -115,7 +115,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		)
 	}
 
-	billing, err := db.Query.FindWorkspaceBillingByWorkspaceID(ctx, h.DB.RW(), principal.WorkspaceID)
+	billing, err := db.Query.FindWorkspaceBillingByWorkspaceID(ctx, h.DB.RW(), principal.AuthorizedWorkspaceID)
 	if err != nil && !db.IsNotFound(err) {
 		return fault.Wrap(
 			err,

--- a/svc/api/routes/v2_deployments_start_deployment/handler.go
+++ b/svc/api/routes/v2_deployments_start_deployment/handler.go
@@ -49,7 +49,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	dep, err := deployment.FindDeployment(ctx, h.DB, principal.WorkspaceID, req.DeploymentId)
+	dep, err := deployment.FindDeployment(ctx, h.DB, principal.AuthorizedWorkspaceID, req.DeploymentId)
 	if err != nil {
 		return err
 	}
@@ -66,7 +66,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			Action:       rbac.StartDeployment,
 		}),
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project(dep.ProjectID).App(dep.AppID).Environment(dep.EnvironmentID).Deployment(dep.ID),
+			urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(dep.ProjectID).App(dep.AppID).Environment(dep.EnvironmentID).Deployment(dep.ID),
 			permissions.Write,
 		),
 	))
@@ -81,7 +81,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 	// A missing billing row means the workspace was never linked to billing and
 	// is not suspended.
-	billing, err := db.Query.FindWorkspaceBillingByWorkspaceID(ctx, h.DB.RW(), principal.WorkspaceID)
+	billing, err := db.Query.FindWorkspaceBillingByWorkspaceID(ctx, h.DB.RW(), principal.AuthorizedWorkspaceID)
 	if err != nil && !db.IsNotFound(err) {
 		return fault.Wrap(
 			err,

--- a/svc/api/routes/v2_deployments_stop_deployment/handler.go
+++ b/svc/api/routes/v2_deployments_stop_deployment/handler.go
@@ -49,7 +49,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	dep, err := deployment.FindDeployment(ctx, h.DB, principal.WorkspaceID, req.DeploymentId)
+	dep, err := deployment.FindDeployment(ctx, h.DB, principal.AuthorizedWorkspaceID, req.DeploymentId)
 	if err != nil {
 		return err
 	}
@@ -66,7 +66,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			Action:       rbac.StopDeployment,
 		}),
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project(dep.ProjectID).App(dep.AppID).Environment(dep.EnvironmentID).Deployment(dep.ID),
+			urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(dep.ProjectID).App(dep.AppID).Environment(dep.EnvironmentID).Deployment(dep.ID),
 			permissions.Write,
 		),
 	))

--- a/svc/api/routes/v2_domains_create_domain/handler.go
+++ b/svc/api/routes/v2_domains_create_domain/handler.go
@@ -55,7 +55,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	env, err := db.Query.FindEnvironmentByIdentifiers(ctx, h.DB.RO(), db.FindEnvironmentByIdentifiersParams{
-		WorkspaceID: principal.WorkspaceID,
+		WorkspaceID: principal.AuthorizedWorkspaceID,
 		Project:     req.Project,
 		App:         req.App,
 		Environment: req.Environment,
@@ -89,7 +89,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			Action:       rbac.CreateDomain,
 		}),
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project(env.ProjectID).App(env.AppID).Environment(env.ID).Domain("*"),
+			urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(env.ProjectID).App(env.AppID).Environment(env.ID).Domain("*"),
 			permissions.Write,
 		),
 	)); err != nil {
@@ -113,7 +113,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	// A found row means the domain is taken, so a nil error is the rejection here
 	// and NotFound is the path that proceeds.
 	_, err = db.Query.FindCustomDomainIDByWorkspaceAndDomain(ctx, h.DB.RO(), db.FindCustomDomainIDByWorkspaceAndDomainParams{
-		WorkspaceID: principal.WorkspaceID,
+		WorkspaceID: principal.AuthorizedWorkspaceID,
 		Domain:      domainName,
 	})
 	if err == nil {
@@ -128,8 +128,8 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		)
 	}
 
-	limits, hit, err := h.LimitsCache.SWR(ctx, principal.WorkspaceID, func(ctx context.Context) (keysdb.Limit, error) {
-		return keysdb.Query.FindLimitsByWorkspaceID(ctx, h.DB.RO(), principal.WorkspaceID)
+	limits, hit, err := h.LimitsCache.SWR(ctx, principal.AuthorizedWorkspaceID, func(ctx context.Context) (keysdb.Limit, error) {
+		return keysdb.Query.FindLimitsByWorkspaceID(ctx, h.DB.RO(), principal.AuthorizedWorkspaceID)
 	}, caches.DefaultFindFirstOp)
 	if err != nil && !db.IsNotFound(err) {
 		return fault.Wrap(
@@ -140,10 +140,10 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		)
 	}
 	if db.IsNotFound(err) || hit == cache.Null {
-		return domaingate.LimitsNotConfigured(principal.WorkspaceID)
+		return domaingate.LimitsNotConfigured(principal.AuthorizedWorkspaceID)
 	}
 
-	attached, err := db.Query.CountCustomDomainsByWorkspace(ctx, h.DB.RO(), principal.WorkspaceID)
+	attached, err := db.Query.CountCustomDomainsByWorkspace(ctx, h.DB.RO(), principal.AuthorizedWorkspaceID)
 	if err != nil {
 		return fault.Wrap(
 			err,
@@ -158,7 +158,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	res, err := h.CtrlClient.AddCustomDomain(ctx, &ctrlv1.AddCustomDomainRequest{
-		WorkspaceId:   principal.WorkspaceID,
+		WorkspaceId:   principal.AuthorizedWorkspaceID,
 		ProjectId:     env.ProjectID,
 		AppId:         env.AppID,
 		EnvironmentId: env.ID,

--- a/svc/api/routes/v2_domains_delete_domain/handler.go
+++ b/svc/api/routes/v2_domains_delete_domain/handler.go
@@ -53,7 +53,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	identifier := domaingate.CanonicalizeIdentifier(req.Domain)
 
 	row, err := db.Query.FindCustomDomainByIdentifier(ctx, h.DB.RO(), db.FindCustomDomainByIdentifierParams{
-		WorkspaceID: principal.WorkspaceID,
+		WorkspaceID: principal.AuthorizedWorkspaceID,
 		Domain:      identifier,
 	})
 	if err != nil {
@@ -85,7 +85,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			Action:       rbac.DeleteDomain,
 		}),
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project(row.ProjectID).App(row.AppID).Environment(row.EnvironmentID).Domain(row.ID),
+			urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(row.ProjectID).App(row.AppID).Environment(row.EnvironmentID).Domain(row.ID),
 			permissions.Delete,
 		),
 	)); err != nil {
@@ -102,7 +102,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	_, err = h.CtrlClient.DeleteCustomDomain(ctx, &ctrlv1.DeleteCustomDomainRequest{
-		WorkspaceId: principal.WorkspaceID,
+		WorkspaceId: principal.AuthorizedWorkspaceID,
 		ProjectId:   row.ProjectID,
 		Domain:      row.Domain,
 		Actor:       actor,

--- a/svc/api/routes/v2_domains_get_domain/handler.go
+++ b/svc/api/routes/v2_domains_get_domain/handler.go
@@ -49,7 +49,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	identifier := domaingate.CanonicalizeIdentifier(req.Domain)
 
 	row, err := db.Query.FindCustomDomainByIdentifier(ctx, h.DB.RO(), db.FindCustomDomainByIdentifierParams{
-		WorkspaceID: principal.WorkspaceID,
+		WorkspaceID: principal.AuthorizedWorkspaceID,
 		Domain:      identifier,
 	})
 	if err != nil {
@@ -81,7 +81,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			Action:       rbac.ReadDomain,
 		}),
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project(row.ProjectID).App(row.AppID).Environment(row.EnvironmentID).Domain(row.ID),
+			urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(row.ProjectID).App(row.AppID).Environment(row.EnvironmentID).Domain(row.ID),
 			permissions.Read,
 		),
 	)); err != nil {

--- a/svc/api/routes/v2_domains_list_domains/handler.go
+++ b/svc/api/routes/v2_domains_list_domains/handler.go
@@ -50,7 +50,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	env, err := db.Query.FindEnvironmentByIdentifiers(ctx, h.DB.RO(), db.FindEnvironmentByIdentifiersParams{
-		WorkspaceID: principal.WorkspaceID,
+		WorkspaceID: principal.AuthorizedWorkspaceID,
 		Project:     req.Project,
 		App:         req.App,
 		Environment: req.Environment,
@@ -84,7 +84,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			Action:       rbac.ReadDomain,
 		}),
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project(env.ProjectID).App(env.AppID).Environment(env.ID).Domain("*"),
+			urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(env.ProjectID).App(env.AppID).Environment(env.ID).Domain("*"),
 			permissions.Read,
 		),
 	)); err != nil {
@@ -99,7 +99,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	search := mysql.SearchContains(strings.TrimSpace(ptr.SafeDeref(req.Search)))
 
 	rows, err := db.Query.ListCustomDomainsByEnvironment(ctx, h.DB.RO(), db.ListCustomDomainsByEnvironmentParams{
-		WorkspaceID:   principal.WorkspaceID,
+		WorkspaceID:   principal.AuthorizedWorkspaceID,
 		ProjectID:     env.ProjectID,
 		EnvironmentID: env.ID,
 		IDCursor:      p.Cursor,

--- a/svc/api/routes/v2_domains_verify_domain/handler.go
+++ b/svc/api/routes/v2_domains_verify_domain/handler.go
@@ -54,7 +54,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	identifier := domaingate.CanonicalizeIdentifier(req.Domain)
 
 	domain, err := db.Query.FindCustomDomainByIdentifier(ctx, h.DB.RO(), db.FindCustomDomainByIdentifierParams{
-		WorkspaceID: principal.WorkspaceID,
+		WorkspaceID: principal.AuthorizedWorkspaceID,
 		Domain:      identifier,
 	})
 	if err != nil {
@@ -62,7 +62,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			return fault.Wrap(
 				err,
 				fault.Code(codes.Data.Domain.NotFound.URN()),
-				fault.Internal(fmt.Sprintf("no custom domain %q in workspace %s", identifier, principal.WorkspaceID)),
+				fault.Internal(fmt.Sprintf("no custom domain %q in workspace %s", identifier, principal.AuthorizedWorkspaceID)),
 				fault.Public("The requested domain does not exist."),
 			)
 		}
@@ -86,7 +86,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			Action:       rbac.VerifyDomain,
 		}),
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project(domain.ProjectID).App(domain.AppID).Environment(domain.EnvironmentID).Domain(domain.ID),
+			urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(domain.ProjectID).App(domain.AppID).Environment(domain.EnvironmentID).Domain(domain.ID),
 			permissions.Write,
 		),
 	)); err != nil {
@@ -107,7 +107,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	_, err = h.CtrlClient.RetryVerification(ctx, &ctrlv1.RetryVerificationRequest{
-		WorkspaceId: principal.WorkspaceID,
+		WorkspaceId: principal.AuthorizedWorkspaceID,
 		ProjectId:   domain.ProjectID,
 		Domain:      domain.Domain,
 		Actor:       actor,

--- a/svc/api/routes/v2_environments_get_environment/handler.go
+++ b/svc/api/routes/v2_environments_get_environment/handler.go
@@ -44,7 +44,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	environment, err := db.Query.FindEnvironmentByIdentifiers(ctx, h.DB.RO(), db.FindEnvironmentByIdentifiersParams{
-		WorkspaceID: principal.WorkspaceID,
+		WorkspaceID: principal.AuthorizedWorkspaceID,
 		Project:     req.Project,
 		App:         req.App,
 		Environment: req.Environment,
@@ -78,7 +78,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			Action:       rbac.ReadEnvironment,
 		}),
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project(environment.ProjectID).App(environment.AppID).Environment(environment.ID),
+			urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(environment.ProjectID).App(environment.AppID).Environment(environment.ID),
 			permissions.Read,
 		),
 	))

--- a/svc/api/routes/v2_environments_list_environment_variables/handler.go
+++ b/svc/api/routes/v2_environments_list_environment_variables/handler.go
@@ -48,7 +48,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	env, err := db.Query.FindEnvironmentByIdentifiers(ctx, h.DB.RO(), db.FindEnvironmentByIdentifiersParams{
-		WorkspaceID: principal.WorkspaceID,
+		WorkspaceID: principal.AuthorizedWorkspaceID,
 		Project:     req.Project,
 		App:         req.App,
 		Environment: req.Environment,
@@ -82,7 +82,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			Action:       rbac.ReadEnvironmentVariables,
 		}),
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project(env.ProjectID).App(env.AppID).Environment(env.ID).Variable("*"),
+			urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(env.ProjectID).App(env.AppID).Environment(env.ID).Variable("*"),
 			permissions.Read,
 		),
 	))

--- a/svc/api/routes/v2_environments_list_environments/handler.go
+++ b/svc/api/routes/v2_environments_list_environments/handler.go
@@ -44,7 +44,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	app, err := db.Query.FindAppByProjectAndIdOrSlug(ctx, h.DB.RO(), db.FindAppByProjectAndIdOrSlugParams{
-		WorkspaceID: principal.WorkspaceID,
+		WorkspaceID: principal.AuthorizedWorkspaceID,
 		Project:     req.Project,
 		App:         req.App,
 	})
@@ -72,7 +72,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			Action:       rbac.ReadEnvironment,
 		}),
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project(app.ProjectID).App(app.ID).Environment("*"),
+			urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(app.ProjectID).App(app.ID).Environment("*"),
 			permissions.Read,
 		),
 	))

--- a/svc/api/routes/v2_environments_remove_environment_variables/handler.go
+++ b/svc/api/routes/v2_environments_remove_environment_variables/handler.go
@@ -48,7 +48,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	env, err := db.Query.FindEnvironmentByIdentifiers(ctx, h.DB.RO(), db.FindEnvironmentByIdentifiersParams{
-		WorkspaceID: principal.WorkspaceID,
+		WorkspaceID: principal.AuthorizedWorkspaceID,
 		Project:     req.Project,
 		App:         req.App,
 		Environment: req.Environment,
@@ -82,7 +82,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			Action:       rbac.RemoveEnvironmentVariables,
 		}),
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project(env.ProjectID).App(env.AppID).Environment(env.ID).Variable("*"),
+			urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(env.ProjectID).App(env.AppID).Environment(env.ID).Variable("*"),
 			permissions.Delete,
 		),
 	))
@@ -131,7 +131,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		auditLogs := make([]auditlog.AuditLog, 0, len(keys))
 		for _, key := range keys {
 			auditLogs = append(auditLogs, auditlog.AuditLog{
-				WorkspaceID:   principal.WorkspaceID,
+				WorkspaceID:   principal.AuthorizedWorkspaceID,
 				Event:         auditlog.EnvironmentUpdateEvent,
 				Display:       fmt.Sprintf("Removed environment variable %s from environment %s", key, env.ID),
 				ActorID:       principal.Subject.ID,

--- a/svc/api/routes/v2_environments_set_environment_variables/handler.go
+++ b/svc/api/routes/v2_environments_set_environment_variables/handler.go
@@ -70,7 +70,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	env, err := db.Query.FindEnvironmentByIdentifiers(ctx, h.DB.RO(), db.FindEnvironmentByIdentifiersParams{
-		WorkspaceID: principal.WorkspaceID,
+		WorkspaceID: principal.AuthorizedWorkspaceID,
 		Project:     req.Project,
 		App:         req.App,
 		Environment: req.Environment,
@@ -92,7 +92,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		)
 	}
 
-	variableURN := urn.New().Workspace(principal.WorkspaceID).Project(env.ProjectID).App(env.AppID).Environment(env.ID).Variable("*")
+	variableURN := urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(env.ProjectID).App(env.AppID).Environment(env.ID).Variable("*")
 	variablePermission := rbac.U(variableURN, permissions.Write)
 	if ptr.SafeDeref(req.Prune, false) {
 		variablePermission = rbac.And(
@@ -228,7 +228,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		auditLogs := make([]auditlog.AuditLog, 0, len(keys))
 		for _, key := range keys {
 			auditLogs = append(auditLogs, auditlog.AuditLog{
-				WorkspaceID:   principal.WorkspaceID,
+				WorkspaceID:   principal.AuthorizedWorkspaceID,
 				Event:         auditlog.EnvironmentUpdateEvent,
 				Display:       fmt.Sprintf("Set environment variable %s for environment %s", key, env.ID),
 				ActorID:       principal.Subject.ID,
@@ -254,7 +254,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		// logs, so record the destructive action on its own.
 		if len(auditLogs) == 0 && pruned {
 			auditLogs = append(auditLogs, auditlog.AuditLog{
-				WorkspaceID:   principal.WorkspaceID,
+				WorkspaceID:   principal.AuthorizedWorkspaceID,
 				Event:         auditlog.EnvironmentUpdateEvent,
 				Display:       fmt.Sprintf("Pruned all environment variables for environment %s", env.ID),
 				ActorID:       principal.Subject.ID,

--- a/svc/api/routes/v2_environments_update_settings/handler.go
+++ b/svc/api/routes/v2_environments_update_settings/handler.go
@@ -76,7 +76,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	environment, err := db.Query.FindEnvironmentByIdentifiers(ctx, h.DB.RO(), db.FindEnvironmentByIdentifiersParams{
-		WorkspaceID: principal.WorkspaceID,
+		WorkspaceID: principal.AuthorizedWorkspaceID,
 		Project:     req.Project,
 		App:         req.App,
 		Environment: req.Environment,
@@ -110,7 +110,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			Action:       rbac.UpdateEnvironment,
 		}),
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project(environment.ProjectID).App(environment.AppID).Environment(environment.ID),
+			urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(environment.ProjectID).App(environment.AppID).Environment(environment.ID),
 			permissions.Write,
 		),
 	))
@@ -134,8 +134,8 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	var limits keysdb.Limit
 	if hasRuntime || req.Regions != nil {
 		var hit cache.CacheHit
-		limits, hit, err = h.LimitsCache.SWR(ctx, principal.WorkspaceID, func(ctx context.Context) (keysdb.Limit, error) {
-			return keysdb.Query.FindLimitsByWorkspaceID(ctx, h.DB.RO(), principal.WorkspaceID)
+		limits, hit, err = h.LimitsCache.SWR(ctx, principal.AuthorizedWorkspaceID, func(ctx context.Context) (keysdb.Limit, error) {
+			return keysdb.Query.FindLimitsByWorkspaceID(ctx, h.DB.RO(), principal.AuthorizedWorkspaceID)
 		}, caches.DefaultFindFirstOp)
 		if err != nil && !db.IsNotFound(err) {
 			return fault.Wrap(
@@ -195,26 +195,26 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		}
 
 		if hasBuild {
-			if err := h.applyBuildSettings(ctx, tx, principal.WorkspaceID, environment.AppID, environment.ID, req, now); err != nil {
+			if err := h.applyBuildSettings(ctx, tx, principal.AuthorizedWorkspaceID, environment.AppID, environment.ID, req, now); err != nil {
 				return err
 			}
 		}
 
 		if hasRuntime {
-			if err := h.applyRuntimeSettings(ctx, tx, principal.WorkspaceID, environment.AppID, environment.ID, req, now); err != nil {
+			if err := h.applyRuntimeSettings(ctx, tx, principal.AuthorizedWorkspaceID, environment.AppID, environment.ID, req, now); err != nil {
 				return err
 			}
 		}
 
 		if req.Regions != nil {
-			if err := h.applyRegions(ctx, tx, principal.WorkspaceID, environment.AppID, environment.ID, desired, now); err != nil {
+			if err := h.applyRegions(ctx, tx, principal.AuthorizedWorkspaceID, environment.AppID, environment.ID, desired, now); err != nil {
 				return err
 			}
 		}
 
 		return h.Auditlogs.Insert(ctx, tx, []auditlog.AuditLog{
 			{
-				WorkspaceID:   principal.WorkspaceID,
+				WorkspaceID:   principal.AuthorizedWorkspaceID,
 				Event:         auditlog.EnvironmentUpdateEvent,
 				Display:       fmt.Sprintf("Updated settings for environment %s", environment.ID),
 				ActorID:       principal.Subject.ID,

--- a/svc/api/routes/v2_gateway_list_policies/handler.go
+++ b/svc/api/routes/v2_gateway_list_policies/handler.go
@@ -44,7 +44,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	env, err := db.Query.FindEnvironmentByIdentifiers(ctx, h.DB.RO(), db.FindEnvironmentByIdentifiersParams{
-		WorkspaceID: principal.WorkspaceID,
+		WorkspaceID: principal.AuthorizedWorkspaceID,
 		Project:     req.Project,
 		App:         req.App,
 		Environment: req.Environment,
@@ -78,7 +78,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			Action:       rbac.ReadPolicies,
 		}),
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project(env.ProjectID).App(env.AppID).Environment(env.ID).Gateway().Policy("*"),
+			urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(env.ProjectID).App(env.AppID).Environment(env.ID).Gateway().Policy("*"),
 			permissions.Read,
 		),
 	))

--- a/svc/api/routes/v2_gateway_set_policies/handler.go
+++ b/svc/api/routes/v2_gateway_set_policies/handler.go
@@ -53,7 +53,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	env, err := db.Query.FindEnvironmentByIdentifiers(ctx, h.DB.RO(), db.FindEnvironmentByIdentifiersParams{
-		WorkspaceID: principal.WorkspaceID,
+		WorkspaceID: principal.AuthorizedWorkspaceID,
 		Project:     req.Project,
 		App:         req.App,
 		Environment: req.Environment,
@@ -75,7 +75,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		)
 	}
 
-	policyURN := urn.New().Workspace(principal.WorkspaceID).Project(env.ProjectID).App(env.AppID).Environment(env.ID).Gateway().Policy("*")
+	policyURN := urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(env.ProjectID).App(env.AppID).Environment(env.ID).Gateway().Policy("*")
 	err = principal.Authorize(rbac.Or(
 		rbac.T(rbac.Tuple{
 			ResourceType: rbac.Environment,
@@ -107,7 +107,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 	if len(keyspaceIDs) > 0 {
 		found, err := db.Query.FindKeyAuthsByIdsAndWorkspace(ctx, h.DB.RO(), db.FindKeyAuthsByIdsAndWorkspaceParams{
-			WorkspaceID: principal.WorkspaceID,
+			WorkspaceID: principal.AuthorizedWorkspaceID,
 			KeyAuthIds:  keyspaceIDs,
 		})
 		if err != nil {
@@ -134,7 +134,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 	newLog := func(display string, meta map[string]any) auditlog.AuditLog {
 		return auditlog.AuditLog{
-			WorkspaceID:   principal.WorkspaceID,
+			WorkspaceID:   principal.AuthorizedWorkspaceID,
 			Event:         auditlog.EnvironmentUpdateEvent,
 			Display:       display,
 			ActorID:       principal.Subject.ID,

--- a/svc/api/routes/v2_gateway_update_policy/handler.go
+++ b/svc/api/routes/v2_gateway_update_policy/handler.go
@@ -66,7 +66,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	env, err := db.Query.FindEnvironmentByIdentifiers(ctx, h.DB.RO(), db.FindEnvironmentByIdentifiersParams{
-		WorkspaceID: principal.WorkspaceID,
+		WorkspaceID: principal.AuthorizedWorkspaceID,
 		Project:     req.Project,
 		App:         req.App,
 		Environment: req.Environment,
@@ -100,7 +100,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			Action:       rbac.UpdatePolicy,
 		}),
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project(env.ProjectID).App(env.AppID).Environment(env.ID).Gateway().Policy(req.PolicyId),
+			urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(env.ProjectID).App(env.AppID).Environment(env.ID).Gateway().Policy(req.PolicyId),
 			permissions.Write,
 		),
 	))
@@ -220,7 +220,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		// arriving with this request need checking.
 		if req.Keyauth != nil && len(req.Keyauth.Keyspaces) > 0 {
 			found, keyspaceErr := db.Query.FindKeyAuthsByIdsAndWorkspace(ctx, tx, db.FindKeyAuthsByIdsAndWorkspaceParams{
-				WorkspaceID: principal.WorkspaceID,
+				WorkspaceID: principal.AuthorizedWorkspaceID,
 				KeyAuthIds:  req.Keyauth.Keyspaces,
 			})
 			if keyspaceErr != nil {
@@ -284,7 +284,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			)
 		}
 		return h.Auditlogs.Insert(ctx, tx, []auditlog.AuditLog{{
-			WorkspaceID:   principal.WorkspaceID,
+			WorkspaceID:   principal.AuthorizedWorkspaceID,
 			Event:         auditlog.EnvironmentUpdateEvent,
 			Display:       fmt.Sprintf("Updated policy %s (%s) for environment %s", updated.GetName(), updated.GetId(), env.ID),
 			ActorID:       principal.Subject.ID,

--- a/svc/api/routes/v2_github_install_app/handler.go
+++ b/svc/api/routes/v2_github_install_app/handler.go
@@ -82,7 +82,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	expiresAtMs := time.Now().Add(stateTTL).UnixMilli()
 
 	state, err := newSigner(h.GitHubPrivateKeyPEM).sign(payload{
-		WorkspaceID: principal.WorkspaceID,
+		WorkspaceID: principal.AuthorizedWorkspaceID,
 		Nonce:       base64.RawURLEncoding.EncodeToString(nonceBytes),
 		ExpMs:       expiresAtMs,
 		// "api" flow: a workspace-wide install with no user binding, verified by

--- a/svc/api/routes/v2_identities_create_identity/handler.go
+++ b/svc/api/routes/v2_identities_create_identity/handler.go
@@ -85,7 +85,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	identityID := uid.New(uid.IdentityPrefix)
 
 	err = db.TxRetry(ctx, h.DB.RW(), func(ctx context.Context, tx db.DBTX) error {
-		projectID, resolveErr := projects.EnsureDefaultProject(ctx, tx, principal.WorkspaceID)
+		projectID, resolveErr := projects.EnsureDefaultProject(ctx, tx, principal.AuthorizedWorkspaceID)
 		if resolveErr != nil {
 			return resolveErr
 		}
@@ -97,7 +97,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 				Action:       rbac.CreateIdentity,
 			}),
 			rbac.U(
-				urn.New().Workspace(principal.WorkspaceID).Project(projectID).Identity("*"),
+				urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(projectID).Identity("*"),
 				permissions.Write,
 			),
 		))
@@ -108,7 +108,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		args := db.InsertIdentityParams{
 			ID:          identityID,
 			ExternalID:  req.ExternalId,
-			WorkspaceID: principal.WorkspaceID,
+			WorkspaceID: principal.AuthorizedWorkspaceID,
 			ProjectID:   projectID,
 			Environment: "default",
 			CreatedAt:   time.Now().UnixMilli(),
@@ -131,7 +131,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 		auditLogs := []auditlog.AuditLog{
 			{
-				WorkspaceID:   principal.WorkspaceID,
+				WorkspaceID:   principal.AuthorizedWorkspaceID,
 				Event:         auditlog.IdentityCreateEvent,
 				Display:       fmt.Sprintf("Created identity %s.", identityID),
 				ActorID:       principal.Subject.ID,
@@ -159,7 +159,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 				ratelimitID := uid.New(uid.RatelimitPrefix)
 				rateLimitsToInsert[i] = db.InsertIdentityRatelimitParams{
 					ID:          ratelimitID,
-					WorkspaceID: principal.WorkspaceID,
+					WorkspaceID: principal.AuthorizedWorkspaceID,
 					IdentityID:  sql.NullString{String: identityID, Valid: true},
 					Name:        ratelimit.Name,
 					Limit:       uint64(ratelimit.Limit),
@@ -169,7 +169,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 				}
 
 				auditLogs = append(auditLogs, auditlog.AuditLog{
-					WorkspaceID:   principal.WorkspaceID,
+					WorkspaceID:   principal.AuthorizedWorkspaceID,
 					Event:         auditlog.RatelimitCreateEvent,
 					Display:       fmt.Sprintf("Created ratelimit %s.", ratelimitID),
 					ActorID:       principal.Subject.ID,

--- a/svc/api/routes/v2_identities_delete_identity/handler.go
+++ b/svc/api/routes/v2_identities_delete_identity/handler.go
@@ -59,7 +59,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	identity, err := db.Query.FindIdentity(ctx, h.DB.RO(), db.FindIdentityParams{
-		WorkspaceID: principal.WorkspaceID,
+		WorkspaceID: principal.AuthorizedWorkspaceID,
 		Identity:    req.Identity,
 		Deleted:     false,
 	})
@@ -87,7 +87,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 				},
 			),
 			rbac.U(
-				urn.New().Workspace(principal.WorkspaceID).Project(identity.ProjectID).Identity(identity.ID),
+				urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(identity.ProjectID).Identity(identity.ID),
 				permissions.Delete,
 			),
 		),
@@ -108,7 +108,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 	err = db.TxRetry(ctx, h.DB.RW(), func(ctx context.Context, tx db.DBTX) error {
 		err = db.Query.SoftDeleteIdentity(ctx, tx, db.SoftDeleteIdentityParams{
-			WorkspaceID: principal.WorkspaceID,
+			WorkspaceID: principal.AuthorizedWorkspaceID,
 			IdentityID:  identity.ID,
 		})
 
@@ -117,7 +117,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		if db.IsDuplicateKeyError(err) {
 			// Check if this identity is already soft-deleted (could happen with concurrent requests)
 			alreadyDeleted, checkErr := db.Query.FindIdentityByID(ctx, tx, db.FindIdentityByIDParams{
-				WorkspaceID: principal.WorkspaceID,
+				WorkspaceID: principal.AuthorizedWorkspaceID,
 				IdentityID:  identity.ID,
 				Deleted:     true,
 			})
@@ -129,7 +129,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 			// Delete the old soft-deleted identity with the same external_id, excluding the current one
 			err = db.Query.DeleteOldIdentityByExternalID(ctx, tx, db.DeleteOldIdentityByExternalIDParams{
-				WorkspaceID:       principal.WorkspaceID,
+				WorkspaceID:       principal.AuthorizedWorkspaceID,
 				ExternalID:        identity.ExternalID,
 				CurrentIdentityID: identity.ID,
 			})
@@ -143,7 +143,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 			// Re-apply the soft delete operation
 			err = db.Query.SoftDeleteIdentity(ctx, tx, db.SoftDeleteIdentityParams{
-				WorkspaceID: principal.WorkspaceID,
+				WorkspaceID: principal.AuthorizedWorkspaceID,
 				IdentityID:  identity.ID,
 			})
 			if err != nil {
@@ -166,7 +166,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 		auditLogs := []auditlog.AuditLog{
 			{
-				WorkspaceID:   principal.WorkspaceID,
+				WorkspaceID:   principal.AuthorizedWorkspaceID,
 				Event:         auditlog.IdentityDeleteEvent,
 				Display:       fmt.Sprintf("Deleted identity %s.", identity.ID),
 				ActorID:       principal.Subject.ID,
@@ -190,7 +190,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 		for _, rl := range ratelimits {
 			auditLogs = append(auditLogs, auditlog.AuditLog{
-				WorkspaceID:   principal.WorkspaceID,
+				WorkspaceID:   principal.AuthorizedWorkspaceID,
 				Event:         auditlog.RatelimitDeleteEvent,
 				Display:       fmt.Sprintf("Deleted ratelimit %s.", rl.ID),
 				ActorID:       principal.Subject.ID,

--- a/svc/api/routes/v2_identities_get_identity/handler.go
+++ b/svc/api/routes/v2_identities_get_identity/handler.go
@@ -48,7 +48,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	identity, err := db.Query.FindIdentity(ctx, h.DB.RO(), db.FindIdentityParams{
-		WorkspaceID: principal.WorkspaceID,
+		WorkspaceID: principal.AuthorizedWorkspaceID,
 		Identity:    req.Identity,
 		Deleted:     false,
 	})
@@ -88,7 +88,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			Action:       rbac.ReadIdentity,
 		}),
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project(identity.ProjectID).Identity(identity.ID),
+			urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(identity.ProjectID).Identity(identity.ID),
 			permissions.Read,
 		),
 	))

--- a/svc/api/routes/v2_identities_list_identities/handler.go
+++ b/svc/api/routes/v2_identities_list_identities/handler.go
@@ -55,13 +55,13 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	p := pagination.Parse(req.Limit, req.Cursor, 100)
 	search := mysql.SearchContains(strings.TrimSpace(ptr.SafeDeref(req.Search)))
 
-	projectID, err := projects.EnsureDefaultProject(ctx, h.DB.RW(), principal.WorkspaceID)
+	projectID, err := projects.EnsureDefaultProject(ctx, h.DB.RW(), principal.AuthorizedWorkspaceID)
 	if err != nil {
 		return err
 	}
 
 	identities, err := db.Query.ListIdentities(ctx, h.DB.RO(), db.ListIdentitiesParams{
-		WorkspaceID: principal.WorkspaceID,
+		WorkspaceID: principal.AuthorizedWorkspaceID,
 		ProjectID:   projectID,
 		Deleted:     false,
 		IDCursor:    p.Cursor,
@@ -84,7 +84,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 				Action:       rbac.ReadIdentity,
 			}),
 			rbac.U(
-				urn.New().Workspace(principal.WorkspaceID).Project(projectID).Identity("*"),
+				urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(projectID).Identity("*"),
 				permissions.Read,
 			),
 		))
@@ -108,7 +108,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 				Action:       rbac.ReadIdentity,
 			}),
 			rbac.U(
-				urn.New().Workspace(principal.WorkspaceID).Project(id.ProjectID).Identity(id.ID),
+				urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(id.ProjectID).Identity(id.ID),
 				permissions.Read,
 			),
 		)

--- a/svc/api/routes/v2_identities_update_identity/handler.go
+++ b/svc/api/routes/v2_identities_update_identity/handler.go
@@ -100,7 +100,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	identityRow, err := db.Query.FindIdentity(ctx, h.DB.RO(), db.FindIdentityParams{
-		WorkspaceID: principal.WorkspaceID,
+		WorkspaceID: principal.AuthorizedWorkspaceID,
 		Identity:    req.Identity,
 		Deleted:     false,
 	})
@@ -125,7 +125,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			Action:       rbac.UpdateIdentity,
 		}),
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project(identityRow.ProjectID).Identity(identityRow.ID),
+			urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(identityRow.ProjectID).Identity(identityRow.ID),
 			permissions.Write,
 		),
 	))
@@ -162,7 +162,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 		auditLogs := []auditlog.AuditLog{
 			{
-				WorkspaceID:   principal.WorkspaceID,
+				WorkspaceID:   principal.AuthorizedWorkspaceID,
 				Event:         auditlog.IdentityUpdateEvent,
 				Display:       fmt.Sprintf("Updated identity %s", identityRow.ID),
 				ActorID:       principal.Subject.ID,
@@ -229,7 +229,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 				// Add audit log for deletion
 				auditLogs = append(auditLogs, auditlog.AuditLog{
-					WorkspaceID:   principal.WorkspaceID,
+					WorkspaceID:   principal.AuthorizedWorkspaceID,
 					Event:         auditlog.RatelimitDeleteEvent,
 					Display:       fmt.Sprintf("Deleted ratelimit %s", existingRL.ID),
 					ActorID:       principal.Subject.ID,
@@ -297,7 +297,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 					}
 
 					auditLogs = append(auditLogs, auditlog.AuditLog{
-						WorkspaceID:   principal.WorkspaceID,
+						WorkspaceID:   principal.AuthorizedWorkspaceID,
 						Event:         auditlog.RatelimitUpdateEvent,
 						Display:       fmt.Sprintf("Updated ratelimit %s", existingRL.ID),
 						ActorID:       principal.Subject.ID,
@@ -329,7 +329,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 					ratelimitID = uid.New(uid.RatelimitPrefix)
 					rateLimitsToInsert = append(rateLimitsToInsert, db.InsertIdentityRatelimitParams{
 						ID:          ratelimitID,
-						WorkspaceID: principal.WorkspaceID,
+						WorkspaceID: principal.AuthorizedWorkspaceID,
 						IdentityID:  sql.NullString{String: identityRow.ID, Valid: true},
 						Name:        newRL.Name,
 						Limit:       uint64(newRL.Limit),
@@ -340,7 +340,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 					// Add audit log for creation
 					auditLogs = append(auditLogs, auditlog.AuditLog{
-						WorkspaceID:   principal.WorkspaceID,
+						WorkspaceID:   principal.AuthorizedWorkspaceID,
 						Event:         auditlog.RatelimitCreateEvent,
 						Display:       fmt.Sprintf("Created ratelimit %s", ratelimitID),
 						ActorID:       principal.Subject.ID,

--- a/svc/api/routes/v2_keys_add_permissions/handler.go
+++ b/svc/api/routes/v2_keys_add_permissions/handler.go
@@ -77,7 +77,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 	key := db.ToKeyData(keyRow)
 
-	if key.Key.WorkspaceID != principal.WorkspaceID {
+	if key.Key.WorkspaceID != principal.AuthorizedWorkspaceID {
 		return fault.New("key not found",
 			fault.Code(codes.Data.Key.NotFound.URN()),
 			fault.Internal("key belongs to different workspace"),
@@ -88,7 +88,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	err = principal.Authorize(
 		rbac.Or(
 			rbac.U(
-				urn.New().Workspace(principal.WorkspaceID).Project(key.KeyAuth.ProjectID).Keyspace(key.Key.KeyAuthID).Key(key.Key.ID),
+				urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(key.KeyAuth.ProjectID).Keyspace(key.Key.KeyAuthID).Key(key.Key.ID),
 				permissions.Write,
 			),
 			rbac.And(
@@ -125,7 +125,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	foundPermissions, err := db.Query.FindPermissionsBySlugs(ctx, h.DB.RO(), db.FindPermissionsBySlugsParams{
-		WorkspaceID: principal.WorkspaceID,
+		WorkspaceID: principal.AuthorizedWorkspaceID,
 		ProjectID:   key.KeyAuth.ProjectID,
 		Slugs:       req.Permissions,
 	})
@@ -166,7 +166,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	for perm := range missingPermissions {
 		err = principal.Authorize(rbac.Or(
 			rbac.U(
-				urn.New().Workspace(principal.WorkspaceID).Project(key.KeyAuth.ProjectID).RBAC().Permission("*"),
+				urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(key.KeyAuth.ProjectID).RBAC().Permission("*"),
 				permissions.Write,
 			),
 			rbac.T(rbac.Tuple{
@@ -184,7 +184,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		permissionsToInsert = append(permissionsToInsert, db.UpsertPermissionParams{
 			PermissionID: permissionID,
 			Name:         perm,
-			WorkspaceID:  principal.WorkspaceID,
+			WorkspaceID:  principal.AuthorizedWorkspaceID,
 			ProjectID:    key.KeyAuth.ProjectID,
 			Slug:         perm,
 			Description:  dbtype.NullString{String: "", Valid: false},
@@ -219,7 +219,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		}
 
 		foundPermissions, err = db.Query.FindPermissionsBySlugs(ctx, tx, db.FindPermissionsBySlugsParams{
-			WorkspaceID: principal.WorkspaceID,
+			WorkspaceID: principal.AuthorizedWorkspaceID,
 			ProjectID:   key.KeyAuth.ProjectID,
 			Slugs:       req.Permissions,
 		})
@@ -238,7 +238,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			candidate, exists := createdPermissionIDs[normalizedSlug]
 			if exists && candidate.PermissionID == permission.ID {
 				auditLogs = append(auditLogs, auditlog.AuditLog{
-					WorkspaceID:   principal.WorkspaceID,
+					WorkspaceID:   principal.AuthorizedWorkspaceID,
 					Event:         auditlog.PermissionCreateEvent,
 					ActorType:     auditlog.AuditLogActor(principal.Subject.Type),
 					ActorID:       principal.Subject.ID,
@@ -287,13 +287,13 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 				toAdd[idx] = db.InsertKeyPermissionParams{
 					KeyID:        req.KeyId,
 					PermissionID: permission.ID,
-					WorkspaceID:  principal.WorkspaceID,
+					WorkspaceID:  principal.AuthorizedWorkspaceID,
 					CreatedAt:    now,
 					UpdatedAt:    sql.NullInt64{Valid: true, Int64: now},
 				}
 
 				auditLogs = append(auditLogs, auditlog.AuditLog{
-					WorkspaceID:   principal.WorkspaceID,
+					WorkspaceID:   principal.AuthorizedWorkspaceID,
 					Event:         auditlog.AuthConnectPermissionKeyEvent,
 					ActorType:     auditlog.AuditLogActor(principal.Subject.Type),
 					ActorID:       principal.Subject.ID,

--- a/svc/api/routes/v2_keys_add_roles/handler.go
+++ b/svc/api/routes/v2_keys_add_roles/handler.go
@@ -71,7 +71,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	// Validate key belongs to authorized workspace
 	key := db.ToKeyData(keyRow)
 
-	if key.Key.WorkspaceID != principal.WorkspaceID {
+	if key.Key.WorkspaceID != principal.AuthorizedWorkspaceID {
 		return fault.New("key not found",
 			fault.Code(codes.Data.Key.NotFound.URN()),
 			fault.Internal("key belongs to different workspace"), fault.Public("The specified key was not found."),
@@ -81,7 +81,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	err = principal.Authorize(
 		rbac.Or(
 			rbac.U(
-				urn.New().Workspace(principal.WorkspaceID).Project(key.KeyAuth.ProjectID).Keyspace(key.Key.KeyAuthID).Key(key.Key.ID),
+				urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(key.KeyAuth.ProjectID).Keyspace(key.Key.KeyAuthID).Key(key.Key.ID),
 				permissions.Write,
 			),
 			rbac.And(
@@ -118,7 +118,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	foundRoles, err := db.Query.FindManyRolesByNamesWithPerms(ctx, h.DB.RO(), db.FindManyRolesByNamesWithPermsParams{
-		WorkspaceID: principal.WorkspaceID,
+		WorkspaceID: principal.AuthorizedWorkspaceID,
 		ProjectID:   key.KeyAuth.ProjectID,
 		Names:       req.Roles,
 	})
@@ -178,12 +178,12 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 				rolesToInsert = append(rolesToInsert, db.InsertKeyRoleParams{
 					KeyID:       req.KeyId,
 					RoleID:      role.ID,
-					WorkspaceID: principal.WorkspaceID,
+					WorkspaceID: principal.AuthorizedWorkspaceID,
 					CreatedAtM:  time.Now().UnixMilli(),
 				})
 
 				auditLogs = append(auditLogs, auditlog.AuditLog{
-					WorkspaceID:   principal.WorkspaceID,
+					WorkspaceID:   principal.AuthorizedWorkspaceID,
 					Event:         auditlog.AuthConnectRoleKeyEvent,
 					ActorType:     auditlog.AuditLogActor(principal.Subject.Type),
 					ActorID:       principal.Subject.ID,

--- a/svc/api/routes/v2_keys_create_key/handler.go
+++ b/svc/api/routes/v2_keys_create_key/handler.go
@@ -91,7 +91,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		)
 	}
 
-	if api.WorkspaceID != principal.WorkspaceID {
+	if api.WorkspaceID != principal.AuthorizedWorkspaceID {
 		return fault.New("api not found",
 			fault.Code(codes.Data.Api.NotFound.URN()),
 			fault.Internal("api belongs to different workspace"), fault.Public("The specified API was not found."),
@@ -126,7 +126,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			Action:       rbac.CreateKey,
 		}),
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project(keySpaceProjectID).Keyspace(api.KeyAuthID.String).Key("*"),
+			urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(keySpaceProjectID).Keyspace(api.KeyAuthID.String).Key("*"),
 			permissions.Write,
 		),
 	))
@@ -218,7 +218,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 				Action:       rbac.EncryptKey,
 			}),
 			rbac.U(
-				urn.New().Workspace(principal.WorkspaceID).Project(keySpace.ProjectID).Keyspace(keySpace.ID).Key("*"),
+				urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(keySpace.ProjectID).Keyspace(keySpace.ID).Key("*"),
 				permissions.Write,
 			),
 		))
@@ -238,7 +238,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		}
 
 		encryption, err = h.Vault.Encrypt(ctx, &vaultv1.EncryptRequest{
-			Keyring: principal.WorkspaceID,
+			Keyring: principal.AuthorizedWorkspaceID,
 			Data:    keyResult.Key,
 		})
 		if err != nil {
@@ -268,7 +268,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 				Prefix:             prefix,
 				Start:              keyResult.Start,
 				End:                keyResult.Key[len(keyResult.Key)-4:],
-				WorkspaceID:        principal.WorkspaceID,
+				WorkspaceID:        principal.AuthorizedWorkspaceID,
 				ForWorkspaceID:     sql.NullString{String: "", Valid: false},
 				CreatedAtM:         now,
 				Enabled:            true,
@@ -295,7 +295,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 				err = db.Query.UpsertIdentity(ctx, tx, db.UpsertIdentityParams{
 					ID:          uid.New(uid.IdentityPrefix),
 					ExternalID:  externalID,
-					WorkspaceID: principal.WorkspaceID,
+					WorkspaceID: principal.AuthorizedWorkspaceID,
 					ProjectID:   projectID,
 					Environment: "default",
 					CreatedAt:   now,
@@ -311,7 +311,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 				// Fetch the identity ID (either just created or already existed)
 				identity, err := db.Query.FindIdentityByExternalID(ctx, tx, db.FindIdentityByExternalIDParams{
-					WorkspaceID: principal.WorkspaceID,
+					WorkspaceID: principal.AuthorizedWorkspaceID,
 					ExternalID:  externalID,
 					Deleted:     false,
 				})
@@ -407,7 +407,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 			if encryption != nil {
 				err = db.Query.InsertKeyEncryption(ctx, tx, db.InsertKeyEncryptionParams{
-					WorkspaceID:     principal.WorkspaceID,
+					WorkspaceID:     principal.AuthorizedWorkspaceID,
 					KeyID:           keyID,
 					CreatedAt:       now,
 					Encrypted:       encryption.GetEncrypted(),
@@ -427,7 +427,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 					ratelimitID := uid.New(uid.RatelimitPrefix)
 					ratelimitsToInsert[i] = db.InsertKeyRatelimitParams{
 						ID:          ratelimitID,
-						WorkspaceID: principal.WorkspaceID,
+						WorkspaceID: principal.AuthorizedWorkspaceID,
 						KeyID:       sql.NullString{String: keyID, Valid: true},
 						Name:        ratelimit.Name,
 						Limit:       uint64(ratelimit.Limit),
@@ -451,7 +451,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			if req.Permissions != nil {
 				var existingPermissions []db.Permission
 				existingPermissions, err = db.Query.FindPermissionsBySlugs(ctx, tx, db.FindPermissionsBySlugsParams{
-					WorkspaceID: principal.WorkspaceID,
+					WorkspaceID: principal.AuthorizedWorkspaceID,
 					ProjectID:   projectID,
 					Slugs:       *req.Permissions,
 				})
@@ -485,7 +485,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 				for _, slug := range missingSlugs {
 					err = db.Query.UpsertPermission(ctx, tx, db.UpsertPermissionParams{
 						PermissionID: uid.New(uid.PermissionPrefix),
-						WorkspaceID:  principal.WorkspaceID,
+						WorkspaceID:  principal.AuthorizedWorkspaceID,
 						ProjectID:    projectID,
 						Name:         slug,
 						Slug:         slug,
@@ -502,7 +502,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 				}
 
 				existingPermissions, err = db.Query.FindPermissionsBySlugs(ctx, tx, db.FindPermissionsBySlugsParams{
-					WorkspaceID: principal.WorkspaceID,
+					WorkspaceID: principal.AuthorizedWorkspaceID,
 					ProjectID:   projectID,
 					Slugs:       *req.Permissions,
 				})
@@ -537,13 +537,13 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 					permissionsToInsert = append(permissionsToInsert, db.InsertKeyPermissionParams{
 						KeyID:        keyID,
 						PermissionID: reqPerm.ID,
-						WorkspaceID:  principal.WorkspaceID,
+						WorkspaceID:  principal.AuthorizedWorkspaceID,
 						CreatedAt:    now,
 						UpdatedAt:    sql.NullInt64{Valid: false, Int64: 0},
 					})
 
 					auditLogs = append(auditLogs, auditlog.AuditLog{
-						WorkspaceID:   principal.WorkspaceID,
+						WorkspaceID:   principal.AuthorizedWorkspaceID,
 						Event:         auditlog.AuthConnectPermissionKeyEvent,
 						ActorType:     actor.Type,
 						ActorID:       actor.ID,
@@ -587,7 +587,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			if req.Roles != nil {
 				var existingRoles []db.FindRolesByNamesRow
 				existingRoles, err = db.Query.FindRolesByNames(ctx, tx, db.FindRolesByNamesParams{
-					WorkspaceID: principal.WorkspaceID,
+					WorkspaceID: principal.AuthorizedWorkspaceID,
 					ProjectID:   projectID,
 					Names:       *req.Roles,
 				})
@@ -627,12 +627,12 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 					rolesToInsert = append(rolesToInsert, db.InsertKeyRoleParams{
 						KeyID:       keyID,
 						RoleID:      reqRole.ID,
-						WorkspaceID: principal.WorkspaceID,
+						WorkspaceID: principal.AuthorizedWorkspaceID,
 						CreatedAtM:  now,
 					})
 
 					auditLogs = append(auditLogs, auditlog.AuditLog{
-						WorkspaceID:   principal.WorkspaceID,
+						WorkspaceID:   principal.AuthorizedWorkspaceID,
 						Event:         auditlog.AuthConnectRoleKeyEvent,
 						ActorType:     actor.Type,
 						ActorID:       actor.ID,
@@ -674,7 +674,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			}
 
 			auditLogs = append(auditLogs, auditlog.AuditLog{
-				WorkspaceID:   principal.WorkspaceID,
+				WorkspaceID:   principal.AuthorizedWorkspaceID,
 				Event:         auditlog.KeyCreateEvent,
 				ActorType:     actor.Type,
 				ActorID:       actor.ID,

--- a/svc/api/routes/v2_keys_delete_key/handler.go
+++ b/svc/api/routes/v2_keys_delete_key/handler.go
@@ -78,7 +78,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	// Validate key belongs to authorized workspace
 	key := db.ToKeyData(keyRow)
 
-	if key.Key.WorkspaceID != principal.WorkspaceID {
+	if key.Key.WorkspaceID != principal.AuthorizedWorkspaceID {
 		return fault.New("key not found",
 			fault.Code(codes.Data.Key.NotFound.URN()),
 			fault.Internal("key belongs to different workspace"),
@@ -132,7 +132,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			Action:       rbac.DeleteKey,
 		}),
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project(key.KeyAuth.ProjectID).Keyspace(key.Key.KeyAuthID).Key(req.KeyId),
+			urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(key.KeyAuth.ProjectID).Keyspace(key.Key.KeyAuthID).Key(req.KeyId),
 			permissions.Delete,
 		),
 	))
@@ -163,7 +163,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		err = h.Auditlogs.Insert(ctx, tx, []auditlog.AuditLog{
 			{
 				Event:         auditlog.KeyDeleteEvent,
-				WorkspaceID:   principal.WorkspaceID,
+				WorkspaceID:   principal.AuthorizedWorkspaceID,
 				ActorType:     actor.Type,
 				ActorID:       actor.ID,
 				ActorName:     actor.Name,

--- a/svc/api/routes/v2_keys_get_key/handler.go
+++ b/svc/api/routes/v2_keys_get_key/handler.go
@@ -75,7 +75,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	keyData := db.ToKeyData(key)
 
 	// Validate key belongs to authorized workspace
-	if keyData.Key.WorkspaceID != principal.WorkspaceID {
+	if keyData.Key.WorkspaceID != principal.AuthorizedWorkspaceID {
 		return fault.New("key not found",
 			fault.Code(codes.Data.Key.NotFound.URN()),
 			fault.Internal("key belongs to different workspace"),
@@ -96,7 +96,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			Action:       rbac.ReadKey,
 		}),
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project(keyData.KeyAuth.ProjectID).Keyspace(keyData.Key.KeyAuthID).Key(keyData.Key.ID),
+			urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(keyData.KeyAuth.ProjectID).Keyspace(keyData.Key.KeyAuthID).Key(keyData.Key.ID),
 			permissions.Read,
 		),
 	))
@@ -274,7 +274,7 @@ func (h *Handler) decryptKey(ctx context.Context, principal *principal.Principal
 			Action:       rbac.DecryptKey,
 		}),
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project(keyData.KeyAuth.ProjectID).Keyspace(keyData.Key.KeyAuthID).Key(keyData.Key.ID),
+			urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(keyData.KeyAuth.ProjectID).Keyspace(keyData.Key.KeyAuthID).Key(keyData.Key.ID),
 			permissions.Decrypt,
 		),
 	))

--- a/svc/api/routes/v2_keys_migrate_keys/handler.go
+++ b/svc/api/routes/v2_keys_migrate_keys/handler.go
@@ -63,7 +63,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	api, hit, err := h.ApiCache.SWR(ctx, cache.ScopedKey{WorkspaceID: principal.WorkspaceID, Key: req.ApiId}, func(ctx context.Context) (db.FindLiveApiByIDRow, error) {
+	api, hit, err := h.ApiCache.SWR(ctx, cache.ScopedKey{WorkspaceID: principal.AuthorizedWorkspaceID, Key: req.ApiId}, func(ctx context.Context) (db.FindLiveApiByIDRow, error) {
 		return db.Query.FindLiveApiByID(ctx, h.DB.RO(), req.ApiId)
 	}, caches.DefaultFindFirstOp)
 	if err != nil {
@@ -92,7 +92,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	// Check if API belongs to the authorized workspace
-	if api.ApiWorkspaceID != principal.WorkspaceID {
+	if api.ApiWorkspaceID != principal.AuthorizedWorkspaceID {
 		return fault.New("wrong workspace",
 			fault.Code(codes.Data.Api.NotFound.URN()),
 			fault.Internal("wrong workspace, masking as 404"),
@@ -113,7 +113,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			Action:       rbac.CreateKey,
 		}),
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project(projectID).Keyspace(api.KeyAuthID).Key("*"),
+			urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(projectID).Keyspace(api.KeyAuthID).Key("*"),
 			permissions.Write,
 		),
 	))
@@ -121,7 +121,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	migration, err := db.Query.FindKeyMigrationByID(ctx, h.DB.RO(), db.FindKeyMigrationByIDParams{ID: req.MigrationId, WorkspaceID: principal.WorkspaceID})
+	migration, err := db.Query.FindKeyMigrationByID(ctx, h.DB.RO(), db.FindKeyMigrationByIDParams{ID: req.MigrationId, WorkspaceID: principal.AuthorizedWorkspaceID})
 	if err != nil {
 		if db.IsNotFound(err) {
 			return fault.Wrap(
@@ -184,7 +184,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 				Prefix:             "",
 				Start:              "", // Unknown at this point
 				End:                "",
-				WorkspaceID:        principal.WorkspaceID,
+				WorkspaceID:        principal.AuthorizedWorkspaceID,
 				Name:               sql.NullString{Valid: name != "", String: name},
 				Meta:               sql.NullString{Valid: false, String: ""},
 				PendingMigrationID: sql.NullString{Valid: true, String: migration.ID},
@@ -294,7 +294,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 		if len(identitiesToFind) > 0 {
 			identities, err := db.Query.FindIdentitiesByExternalId(ctx, tx, db.FindIdentitiesByExternalIdParams{
-				WorkspaceID: principal.WorkspaceID,
+				WorkspaceID: principal.AuthorizedWorkspaceID,
 				ExternalIds: identitiesToFind,
 				Deleted:     false,
 			})
@@ -320,7 +320,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 		if len(permissionsToFind) > 0 {
 			permissions, err := db.Query.FindPermissionsBySlugsInWorkspace(ctx, tx, db.FindPermissionsBySlugsInWorkspaceParams{
-				WorkspaceID: principal.WorkspaceID,
+				WorkspaceID: principal.AuthorizedWorkspaceID,
 				Slugs:       permissionsToFind,
 			})
 			if err != nil && !db.IsNotFound(err) {
@@ -345,7 +345,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 		if len(rolesToFind) > 0 {
 			roles, err := db.Query.FindRolesByNamesInWorkspace(ctx, tx, db.FindRolesByNamesInWorkspaceParams{
-				WorkspaceID: principal.WorkspaceID,
+				WorkspaceID: principal.AuthorizedWorkspaceID,
 				Names:       rolesToFind,
 			})
 			if err != nil && !db.IsNotFound(err) {
@@ -378,7 +378,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			identitiesToInsert = append(identitiesToInsert, db.InsertIdentityParams{
 				ID:          id,
 				ExternalID:  externalId,
-				WorkspaceID: principal.WorkspaceID,
+				WorkspaceID: principal.AuthorizedWorkspaceID,
 				ProjectID:   projectID,
 				Environment: "default",
 				CreatedAt:   now,
@@ -396,7 +396,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			id := uid.New(uid.PermissionPrefix)
 			permissionsToInsert = append(permissionsToInsert, db.InsertPermissionParams{
 				PermissionID: id,
-				WorkspaceID:  principal.WorkspaceID,
+				WorkspaceID:  principal.AuthorizedWorkspaceID,
 				ProjectID:    projectID,
 				Name:         slug,
 				Slug:         slug,
@@ -415,7 +415,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			id := uid.New(uid.RolePrefix)
 			rolesToInsert = append(rolesToInsert, db.InsertRoleParams{
 				RoleID:      id,
-				WorkspaceID: principal.WorkspaceID,
+				WorkspaceID: principal.AuthorizedWorkspaceID,
 				ProjectID:   projectID,
 				Name:        name,
 				Description: sql.NullString{Valid: false, String: ""},
@@ -436,7 +436,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 				for _, ratelimit := range *key.Ratelimits {
 					ratelimitsToInsert = append(ratelimitsToInsert, db.InsertKeyRatelimitParams{
 						ID:          uid.New(uid.RatelimitPrefix),
-						WorkspaceID: principal.WorkspaceID,
+						WorkspaceID: principal.AuthorizedWorkspaceID,
 						KeyID:       sql.NullString{String: keyParams.ID, Valid: true},
 						Name:        ratelimit.Name,
 						Limit:       uint64(ratelimit.Limit),
@@ -465,13 +465,13 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 					keyPermissionsToInsert = append(keyPermissionsToInsert, db.InsertKeyPermissionParams{
 						KeyID:        keyParams.ID,
 						PermissionID: *permissionID,
-						WorkspaceID:  principal.WorkspaceID,
+						WorkspaceID:  principal.AuthorizedWorkspaceID,
 						CreatedAt:    now,
 						UpdatedAt:    sql.NullInt64{Valid: false, Int64: 0},
 					})
 
 					auditLogs = append(auditLogs, auditlog.AuditLog{
-						WorkspaceID:   principal.WorkspaceID,
+						WorkspaceID:   principal.AuthorizedWorkspaceID,
 						Event:         auditlog.AuthConnectPermissionKeyEvent,
 						ActorType:     auditlog.AuditLogActor(principal.Subject.Type),
 						ActorID:       principal.Subject.ID,
@@ -511,12 +511,12 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 					keyRolesToInsert = append(keyRolesToInsert, db.InsertKeyRoleParams{
 						KeyID:       keyParams.ID,
 						RoleID:      *roleID,
-						WorkspaceID: principal.WorkspaceID,
+						WorkspaceID: principal.AuthorizedWorkspaceID,
 						CreatedAtM:  now,
 					})
 
 					auditLogs = append(auditLogs, auditlog.AuditLog{
-						WorkspaceID:   principal.WorkspaceID,
+						WorkspaceID:   principal.AuthorizedWorkspaceID,
 						Event:         auditlog.AuthConnectRoleKeyEvent,
 						ActorType:     auditlog.AuditLogActor(principal.Subject.Type),
 						ActorID:       principal.Subject.ID,
@@ -547,7 +547,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			}
 
 			auditLogs = append(auditLogs, auditlog.AuditLog{
-				WorkspaceID:   principal.WorkspaceID,
+				WorkspaceID:   principal.AuthorizedWorkspaceID,
 				Event:         auditlog.KeyCreateEvent,
 				ActorType:     auditlog.AuditLogActor(principal.Subject.Type),
 				ActorID:       principal.Subject.ID,

--- a/svc/api/routes/v2_keys_remove_permissions/handler.go
+++ b/svc/api/routes/v2_keys_remove_permissions/handler.go
@@ -69,7 +69,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	// Validate key belongs to authorized workspace
 	key := db.ToKeyData(keyRow)
 
-	if key.Key.WorkspaceID != principal.WorkspaceID {
+	if key.Key.WorkspaceID != principal.AuthorizedWorkspaceID {
 		return fault.New("key not found",
 			fault.Code(codes.Data.Key.NotFound.URN()),
 			fault.Internal("key belongs to different workspace"),
@@ -80,7 +80,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	err = principal.Authorize(
 		rbac.Or(
 			rbac.U(
-				urn.New().Workspace(principal.WorkspaceID).Project(key.KeyAuth.ProjectID).Keyspace(key.Key.KeyAuthID).Key(key.Key.ID),
+				urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(key.KeyAuth.ProjectID).Keyspace(key.Key.KeyAuthID).Key(key.Key.ID),
 				permissions.Write,
 			),
 			rbac.And(
@@ -123,7 +123,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	foundPermissions, err := db.Query.FindPermissionsBySlugs(ctx, h.DB.RO(), db.FindPermissionsBySlugsParams{
-		WorkspaceID: principal.WorkspaceID,
+		WorkspaceID: principal.AuthorizedWorkspaceID,
 		ProjectID:   key.KeyAuth.ProjectID,
 		Slugs:       req.Permissions,
 	})
@@ -170,7 +170,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			for _, permission := range permissionsToRemove {
 				idsToRemove = append(idsToRemove, permission.ID)
 				auditLogs = append(auditLogs, auditlog.AuditLog{
-					WorkspaceID:   principal.WorkspaceID,
+					WorkspaceID:   principal.AuthorizedWorkspaceID,
 					Event:         auditlog.AuthDisconnectPermissionKeyEvent,
 					ActorType:     auditlog.AuditLogActor(principal.Subject.Type),
 					ActorID:       principal.Subject.ID,

--- a/svc/api/routes/v2_keys_remove_roles/handler.go
+++ b/svc/api/routes/v2_keys_remove_roles/handler.go
@@ -71,7 +71,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 	key := db.ToKeyData(keyRow)
 
-	if key.Key.WorkspaceID != principal.WorkspaceID {
+	if key.Key.WorkspaceID != principal.AuthorizedWorkspaceID {
 		return fault.New("key not found",
 			fault.Code(codes.Data.Key.NotFound.URN()),
 			fault.Internal("key belongs to different workspace"), fault.Public("The specified key was not found."),
@@ -90,7 +90,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			Action:       rbac.UpdateKey,
 		}),
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project(key.KeyAuth.ProjectID).Keyspace(key.Key.KeyAuthID).Key(key.Key.ID),
+			urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(key.KeyAuth.ProjectID).Keyspace(key.Key.KeyAuthID).Key(key.Key.ID),
 			permissions.Write,
 		),
 	))
@@ -112,7 +112,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	foundRoles, err := db.Query.FindManyRolesByNamesWithPerms(ctx, h.DB.RO(), db.FindManyRolesByNamesWithPermsParams{
-		WorkspaceID: principal.WorkspaceID,
+		WorkspaceID: principal.AuthorizedWorkspaceID,
 		ProjectID:   key.KeyAuth.ProjectID,
 		Names:       req.Roles,
 	})
@@ -158,7 +158,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			for _, role := range rolesToRemove {
 				roleIds = append(roleIds, role.ID)
 				auditLogs = append(auditLogs, auditlog.AuditLog{
-					WorkspaceID:   principal.WorkspaceID,
+					WorkspaceID:   principal.AuthorizedWorkspaceID,
 					Event:         auditlog.AuthDisconnectRoleKeyEvent,
 					ActorType:     auditlog.AuditLogActor(principal.Subject.Type),
 					ActorID:       principal.Subject.ID,

--- a/svc/api/routes/v2_keys_reroll_key/handler.go
+++ b/svc/api/routes/v2_keys_reroll_key/handler.go
@@ -67,7 +67,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	if key.KeyWorkspaceID != principal.WorkspaceID {
+	if key.KeyWorkspaceID != principal.AuthorizedWorkspaceID {
 		return fault.New("key not found",
 			fault.Code(codes.Data.Key.NotFound.URN()),
 			fault.Internal("key belongs to different workspace"),
@@ -119,7 +119,7 @@ func (h *Handler) RerollKey(
 		return err
 	}
 	if err := assert.All(
-		assert.Equal(key.KeyWorkspaceID, principal.WorkspaceID, "reroll key workspace must match principal"),
+		assert.Equal(key.KeyWorkspaceID, principal.AuthorizedWorkspaceID, "reroll key workspace must match principal"),
 		assert.Equal(key.KeyID, req.KeyId, "preloaded reroll key must match request"),
 	); err != nil {
 		return err
@@ -224,7 +224,7 @@ func (h *Handler) RerollKey(
 
 			if encryption != nil {
 				err = db.Query.InsertKeyEncryption(ctx, tx, db.InsertKeyEncryptionParams{
-					WorkspaceID:     principal.WorkspaceID,
+					WorkspaceID:     principal.AuthorizedWorkspaceID,
 					KeyID:           keyID,
 					CreatedAt:       now,
 					Encrypted:       encryption.GetEncrypted(),
@@ -341,7 +341,7 @@ func (h *Handler) RerollKey(
 
 			var auditLogs []auditlog.AuditLog
 			auditLogs = append(auditLogs, auditlog.AuditLog{
-				WorkspaceID:   principal.WorkspaceID,
+				WorkspaceID:   principal.AuthorizedWorkspaceID,
 				Event:         auditlog.KeyRerollEvent,
 				ActorType:     actor.Type,
 				ActorID:       actor.ID,

--- a/svc/api/routes/v2_keys_set_permissions/handler.go
+++ b/svc/api/routes/v2_keys_set_permissions/handler.go
@@ -79,7 +79,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 	key := db.ToKeyData(keyRow)
 
-	if key.Key.WorkspaceID != principal.WorkspaceID {
+	if key.Key.WorkspaceID != principal.AuthorizedWorkspaceID {
 		return fault.New("key not found",
 			fault.Code(codes.Data.Key.NotFound.URN()),
 			fault.Internal("key belongs to different workspace"), fault.Public("The specified key was not found."),
@@ -89,7 +89,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	err = principal.Authorize(
 		rbac.Or(
 			rbac.U(
-				urn.New().Workspace(principal.WorkspaceID).Project(key.KeyAuth.ProjectID).Keyspace(key.Key.KeyAuthID).Key(key.Key.ID),
+				urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(key.KeyAuth.ProjectID).Keyspace(key.Key.KeyAuthID).Key(key.Key.ID),
 				permissions.Write,
 			),
 			rbac.And(
@@ -123,7 +123,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	foundPermissions, err := db.Query.FindPermissionsBySlugs(ctx, h.DB.RO(), db.FindPermissionsBySlugsParams{
-		WorkspaceID: principal.WorkspaceID,
+		WorkspaceID: principal.AuthorizedWorkspaceID,
 		ProjectID:   key.KeyAuth.ProjectID,
 		Slugs:       req.Permissions,
 	})
@@ -150,7 +150,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	if len(missingPermissions) > 0 {
 		err = principal.Authorize(rbac.Or(
 			rbac.U(
-				urn.New().Workspace(principal.WorkspaceID).Project(key.KeyAuth.ProjectID).RBAC().Permission("*"),
+				urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(key.KeyAuth.ProjectID).RBAC().Permission("*"),
 				permissions.Write,
 			),
 			rbac.T(rbac.Tuple{
@@ -170,7 +170,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		permissionsToInsert = append(permissionsToInsert, db.UpsertPermissionParams{
 			PermissionID: permissionID,
 			Name:         perm,
-			WorkspaceID:  principal.WorkspaceID,
+			WorkspaceID:  principal.AuthorizedWorkspaceID,
 			ProjectID:    key.KeyAuth.ProjectID,
 			Slug:         perm,
 			Description:  dbtype.NullString{String: "", Valid: false},
@@ -210,7 +210,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		}
 
 		foundPermissions, err = db.Query.FindPermissionsBySlugs(ctx, tx, db.FindPermissionsBySlugsParams{
-			WorkspaceID: principal.WorkspaceID,
+			WorkspaceID: principal.AuthorizedWorkspaceID,
 			ProjectID:   key.KeyAuth.ProjectID,
 			Slugs:       req.Permissions,
 		})
@@ -229,7 +229,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			candidate, exists := createdPermissionIDs[normalizedSlug]
 			if exists && candidate.PermissionID == permission.ID {
 				auditLogs = append(auditLogs, auditlog.AuditLog{
-					WorkspaceID:   principal.WorkspaceID,
+					WorkspaceID:   principal.AuthorizedWorkspaceID,
 					Event:         auditlog.PermissionCreateEvent,
 					ActorType:     auditlog.AuditLogActor(principal.Subject.Type),
 					ActorID:       principal.Subject.ID,
@@ -309,7 +309,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			for _, permissionID := range permissionsToRemove {
 				perm := currentPermissionMap[permissionID]
 				auditLogs = append(auditLogs, auditlog.AuditLog{
-					WorkspaceID:   principal.WorkspaceID,
+					WorkspaceID:   principal.AuthorizedWorkspaceID,
 					Event:         auditlog.AuthDisconnectPermissionKeyEvent,
 					ActorType:     auditlog.AuditLogActor(principal.Subject.Type),
 					ActorID:       principal.Subject.ID,
@@ -347,13 +347,13 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 				toAdd[idx] = db.InsertKeyPermissionParams{
 					KeyID:        req.KeyId,
 					PermissionID: permission.ID,
-					WorkspaceID:  principal.WorkspaceID,
+					WorkspaceID:  principal.AuthorizedWorkspaceID,
 					CreatedAt:    now,
 					UpdatedAt:    sql.NullInt64{Valid: true, Int64: now},
 				}
 
 				auditLogs = append(auditLogs, auditlog.AuditLog{
-					WorkspaceID:   principal.WorkspaceID,
+					WorkspaceID:   principal.AuthorizedWorkspaceID,
 					Event:         auditlog.AuthConnectPermissionKeyEvent,
 					ActorType:     auditlog.AuditLogActor(principal.Subject.Type),
 					ActorID:       principal.Subject.ID,

--- a/svc/api/routes/v2_keys_set_roles/handler.go
+++ b/svc/api/routes/v2_keys_set_roles/handler.go
@@ -77,7 +77,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	// Validate key belongs to authorized workspace
 	key := db.ToKeyData(keyRow)
 
-	if key.Key.WorkspaceID != principal.WorkspaceID {
+	if key.Key.WorkspaceID != principal.AuthorizedWorkspaceID {
 		return fault.New("key not found",
 			fault.Code(codes.Data.Key.NotFound.URN()),
 			fault.Internal("key belongs to different workspace"), fault.Public("The specified key was not found."),
@@ -96,7 +96,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			Action:       rbac.UpdateKey,
 		}),
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project(key.KeyAuth.ProjectID).Keyspace(key.Key.KeyAuthID).Key(key.Key.ID),
+			urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(key.KeyAuth.ProjectID).Keyspace(key.Key.KeyAuthID).Key(key.Key.ID),
 			permissions.Write,
 		),
 	))
@@ -125,7 +125,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		// All reads happen inside the transaction after acquiring the lock
 		// to prevent TOCTOU races with concurrent requests.
 		foundRoles, err := db.Query.FindManyRolesByNamesWithPerms(ctx, tx, db.FindManyRolesByNamesWithPermsParams{
-			WorkspaceID: principal.WorkspaceID,
+			WorkspaceID: principal.AuthorizedWorkspaceID,
 			ProjectID:   key.KeyAuth.ProjectID,
 			Names:       req.Roles,
 		})
@@ -194,7 +194,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 				roleIds = append(roleIds, role.ID)
 
 				auditLogs = append(auditLogs, auditlog.AuditLog{
-					WorkspaceID:   principal.WorkspaceID,
+					WorkspaceID:   principal.AuthorizedWorkspaceID,
 					Event:         auditlog.AuthDisconnectRoleKeyEvent,
 					ActorType:     auditlog.AuditLogActor(principal.Subject.Type),
 					ActorID:       principal.Subject.ID,
@@ -243,12 +243,12 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 				keyRolesToInsert = append(keyRolesToInsert, db.InsertKeyRoleParams{
 					KeyID:       req.KeyId,
 					RoleID:      role.ID,
-					WorkspaceID: principal.WorkspaceID,
+					WorkspaceID: principal.AuthorizedWorkspaceID,
 					CreatedAtM:  time.Now().UnixMilli(),
 				})
 
 				auditLogs = append(auditLogs, auditlog.AuditLog{
-					WorkspaceID:   principal.WorkspaceID,
+					WorkspaceID:   principal.AuthorizedWorkspaceID,
 					Event:         auditlog.AuthConnectRoleKeyEvent,
 					ActorType:     auditlog.AuditLogActor(principal.Subject.Type),
 					ActorID:       principal.Subject.ID,

--- a/svc/api/routes/v2_keys_update_credits/handler.go
+++ b/svc/api/routes/v2_keys_update_credits/handler.go
@@ -78,7 +78,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	// Validate key belongs to authorized workspace
 	keyData := db.ToKeyData(key)
 
-	if keyData.Key.WorkspaceID != principal.WorkspaceID {
+	if keyData.Key.WorkspaceID != principal.AuthorizedWorkspaceID {
 		return fault.New("key not found",
 			fault.Code(codes.Data.Key.NotFound.URN()),
 			fault.Internal("key belongs to different workspace"),
@@ -99,7 +99,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			Action:       rbac.UpdateKey,
 		}),
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project(keyData.KeyAuth.ProjectID).Keyspace(keyData.Key.KeyAuthID).Key(req.KeyId),
+			urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(keyData.KeyAuth.ProjectID).Keyspace(keyData.Key.KeyAuthID).Key(req.KeyId),
 			permissions.Write,
 		),
 	))
@@ -205,7 +205,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 		err = h.Auditlogs.Insert(ctx, tx, []auditlog.AuditLog{
 			{
-				WorkspaceID:   principal.WorkspaceID,
+				WorkspaceID:   principal.AuthorizedWorkspaceID,
 				Event:         auditlog.KeyUpdateEvent,
 				Display:       fmt.Sprintf("Updated Key %s, set remaining to %s.", keyData.Key.ID, remaining),
 				ActorID:       principal.Subject.ID,

--- a/svc/api/routes/v2_keys_update_key/handler.go
+++ b/svc/api/routes/v2_keys_update_key/handler.go
@@ -88,7 +88,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 	key := db.ToKeyData(keyRow)
 
-	if key.Key.WorkspaceID != principal.WorkspaceID {
+	if key.Key.WorkspaceID != principal.AuthorizedWorkspaceID {
 		return fault.New("key not found",
 			fault.Code(codes.Data.Key.NotFound.URN()),
 			fault.Internal("key belongs to different workspace"),
@@ -108,7 +108,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			Action:       rbac.UpdateKey,
 		}),
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project(key.KeyAuth.ProjectID).Keyspace(key.Key.KeyAuthID).Key(req.KeyId),
+			urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(key.KeyAuth.ProjectID).Keyspace(key.Key.KeyAuthID).Key(req.KeyId),
 			permissions.Write,
 		),
 	))
@@ -162,7 +162,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 				err = db.Query.UpsertIdentity(ctx, tx, db.UpsertIdentityParams{
 					ID:          uid.New(uid.IdentityPrefix),
 					ExternalID:  externalID,
-					WorkspaceID: principal.WorkspaceID,
+					WorkspaceID: principal.AuthorizedWorkspaceID,
 					ProjectID:   projectID,
 					Environment: "default",
 					CreatedAt:   time.Now().UnixMilli(),
@@ -178,7 +178,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 				// Fetch the identity ID (either just created or already existed)
 				identity, err := db.Query.FindIdentityByExternalID(ctx, tx, db.FindIdentityByExternalIDParams{
-					WorkspaceID: principal.WorkspaceID,
+					WorkspaceID: principal.AuthorizedWorkspaceID,
 					ExternalID:  externalID,
 					Deleted:     false,
 				})
@@ -372,7 +372,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 				ratelimitsToInsert = append(ratelimitsToInsert, db.InsertKeyRatelimitParams{
 					ID:          rlID,
-					WorkspaceID: principal.WorkspaceID,
+					WorkspaceID: principal.AuthorizedWorkspaceID,
 					KeyID:       sql.NullString{String: key.Key.ID, Valid: true},
 					Name:        newRL.Name,
 					Limit:       uint64(newRL.Limit),
@@ -398,7 +398,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		if req.Permissions != nil {
 			var existingPermissions []db.Permission
 			existingPermissions, err = db.Query.FindPermissionsBySlugs(ctx, tx, db.FindPermissionsBySlugsParams{
-				WorkspaceID: principal.WorkspaceID,
+				WorkspaceID: principal.AuthorizedWorkspaceID,
 				ProjectID:   projectID,
 				Slugs:       *req.Permissions,
 			})
@@ -433,7 +433,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			for _, slug := range missingSlugs {
 				candidate := db.UpsertPermissionParams{
 					PermissionID: uid.New(uid.PermissionPrefix),
-					WorkspaceID:  principal.WorkspaceID,
+					WorkspaceID:  principal.AuthorizedWorkspaceID,
 					ProjectID:    projectID,
 					Name:         slug,
 					Slug:         slug,
@@ -452,7 +452,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			}
 
 			existingPermissions, err = db.Query.FindPermissionsBySlugs(ctx, tx, db.FindPermissionsBySlugsParams{
-				WorkspaceID: principal.WorkspaceID,
+				WorkspaceID: principal.AuthorizedWorkspaceID,
 				ProjectID:   projectID,
 				Slugs:       *req.Permissions,
 			})
@@ -491,7 +491,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			if len(createdPermissions) > 0 {
 				for _, toCreate := range createdPermissions {
 					auditLogs = append(auditLogs, auditlog.AuditLog{
-						WorkspaceID:   principal.WorkspaceID,
+						WorkspaceID:   principal.AuthorizedWorkspaceID,
 						Event:         auditlog.PermissionCreateEvent,
 						ActorType:     auditlog.AuditLogActor(principal.Subject.Type),
 						ActorID:       principal.Subject.ID,
@@ -531,7 +531,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 				permissionsToInsert = append(permissionsToInsert, db.InsertKeyPermissionParams{
 					KeyID:        key.Key.ID,
 					PermissionID: reqPerm.ID,
-					WorkspaceID:  principal.WorkspaceID,
+					WorkspaceID:  principal.AuthorizedWorkspaceID,
 					CreatedAt:    now,
 					UpdatedAt:    sql.NullInt64{Int64: now, Valid: true},
 				})
@@ -552,7 +552,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		if req.Roles != nil {
 			var existingRoles []db.FindRolesByNamesRow
 			existingRoles, err = db.Query.FindRolesByNames(ctx, tx, db.FindRolesByNamesParams{
-				WorkspaceID: principal.WorkspaceID,
+				WorkspaceID: principal.AuthorizedWorkspaceID,
 				ProjectID:   projectID,
 				Names:       *req.Roles,
 			})
@@ -599,7 +599,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 				rolesToInsert = append(rolesToInsert, db.InsertKeyRoleParams{
 					KeyID:       key.Key.ID,
 					RoleID:      reqRole.ID,
-					WorkspaceID: principal.WorkspaceID,
+					WorkspaceID: principal.AuthorizedWorkspaceID,
 					CreatedAtM:  time.Now().UnixMilli(),
 				})
 			}
@@ -617,7 +617,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		}
 
 		auditLogs = append(auditLogs, auditlog.AuditLog{
-			WorkspaceID:   principal.WorkspaceID,
+			WorkspaceID:   principal.AuthorizedWorkspaceID,
 			Event:         auditlog.KeyUpdateEvent,
 			ActorType:     auditlog.AuditLogActor(principal.Subject.Type),
 			ActorID:       principal.Subject.ID,

--- a/svc/api/routes/v2_keys_verify_key/audit_log_internal_test.go
+++ b/svc/api/routes/v2_keys_verify_key/audit_log_internal_test.go
@@ -60,8 +60,8 @@ func TestBufferAuditLog_SkipsNonRootPrincipal(t *testing.T) {
 			Payload:   nil,
 			Signature: "",
 		},
-		WorkspaceID: "ws_123",
-		Permissions: nil,
+		AuthorizedWorkspaceID: "ws_123",
+		Permissions:           nil,
 	}
 	key := &keys.KeyVerifier{ //nolint:exhaustruct
 		Key: keysdb.FindKeyForVerificationRow{ID: "key_123"}, //nolint:exhaustruct

--- a/svc/api/routes/v2_keys_verify_key/handler.go
+++ b/svc/api/routes/v2_keys_verify_key/handler.go
@@ -78,7 +78,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	// Validate key belongs to authorized workspace
-	if key.Key.WorkspaceID != principal.WorkspaceID {
+	if key.Key.WorkspaceID != principal.AuthorizedWorkspaceID {
 		return s.JSON(http.StatusOK, Response{
 			Meta: openapi.Meta{
 				RequestId: s.RequestID(),
@@ -117,7 +117,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			Action:       rbac.VerifyKey,
 		}),
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project(key.Key.ProjectID).Keyspace(key.Key.KeyAuthID).Key(key.Key.ID),
+			urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(key.Key.ProjectID).Keyspace(key.Key.KeyAuthID).Key(key.Key.ID),
 			permissions.Verify,
 		),
 	))
@@ -311,7 +311,7 @@ func (h *Handler) bufferAuditLog(
 	h.DirectAuditLogs.Buffer(auditlog.Event{
 		EventID:     uid.New(uid.AuditLogPrefix),
 		Time:        verificationTimeMillis,
-		WorkspaceID: principal.WorkspaceID,
+		WorkspaceID: principal.AuthorizedWorkspaceID,
 		Bucket:      auditlogs.DefaultBucket,
 		Source:      auditlog.EventSourcePlatform,
 		Event:       string(auditlog.KeyVerifyEvent),

--- a/svc/api/routes/v2_keys_whoami/handler.go
+++ b/svc/api/routes/v2_keys_whoami/handler.go
@@ -73,7 +73,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	keyData := db.ToKeyData(key)
 
 	// Validate key belongs to authorized workspace
-	if keyData.Key.WorkspaceID != principal.WorkspaceID {
+	if keyData.Key.WorkspaceID != principal.AuthorizedWorkspaceID {
 		return fault.New("key not found",
 			fault.Code(codes.Data.Key.NotFound.URN()),
 			fault.Internal("key belongs to different workspace"),
@@ -94,7 +94,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			Action:       rbac.ReadKey,
 		}),
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project(keyData.KeyAuth.ProjectID).Keyspace(keyData.Key.KeyAuthID).Key(keyData.Key.ID),
+			urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(keyData.KeyAuth.ProjectID).Keyspace(keyData.Key.KeyAuthID).Key(keyData.Key.ID),
 			permissions.Read,
 		),
 	))

--- a/svc/api/routes/v2_permissions_create_permission/handler.go
+++ b/svc/api/routes/v2_permissions_create_permission/handler.go
@@ -59,14 +59,14 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 	// Create permission in a transaction with audit log
 	err = db.TxRetry(ctx, h.DB.RW(), func(ctx context.Context, tx db.DBTX) error {
-		projectID, resolveErr := projects.EnsureDefaultProject(ctx, tx, principal.WorkspaceID)
+		projectID, resolveErr := projects.EnsureDefaultProject(ctx, tx, principal.AuthorizedWorkspaceID)
 		if resolveErr != nil {
 			return resolveErr
 		}
 
 		if authorizeErr := principal.Authorize(rbac.Or(
 			rbac.U(
-				urn.New().Workspace(principal.WorkspaceID).Project(projectID).RBAC().Permission("*"),
+				urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(projectID).RBAC().Permission("*"),
 				permissions.Write,
 			),
 			rbac.T(rbac.Tuple{
@@ -81,7 +81,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		// Insert the permission
 		err = db.Query.InsertPermission(ctx, tx, db.InsertPermissionParams{
 			PermissionID: permissionID,
-			WorkspaceID:  principal.WorkspaceID,
+			WorkspaceID:  principal.AuthorizedWorkspaceID,
 			ProjectID:    projectID,
 			Name:         req.Name,
 			Slug:         req.Slug,
@@ -105,7 +105,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		// Create audit log
 		err = h.Auditlogs.Insert(ctx, tx, []auditlog.AuditLog{
 			{
-				WorkspaceID:   principal.WorkspaceID,
+				WorkspaceID:   principal.AuthorizedWorkspaceID,
 				Event:         auditlog.PermissionCreateEvent,
 				ActorType:     auditlog.AuditLogActor(principal.Subject.Type),
 				ActorID:       principal.Subject.ID,

--- a/svc/api/routes/v2_permissions_create_role/handler.go
+++ b/svc/api/routes/v2_permissions_create_role/handler.go
@@ -84,7 +84,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	description := ptr.SafeDeref(req.Description)
 
 	err = db.TxRetry(ctx, h.DB.RW(), func(ctx context.Context, tx db.DBTX) error {
-		projectID, resolveErr := projects.EnsureDefaultProject(ctx, tx, principal.WorkspaceID)
+		projectID, resolveErr := projects.EnsureDefaultProject(ctx, tx, principal.AuthorizedWorkspaceID)
 		if resolveErr != nil {
 			return resolveErr
 		}
@@ -106,7 +106,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		}
 		if authorizeErr := principal.Authorize(rbac.Or(
 			rbac.U(
-				urn.New().Workspace(principal.WorkspaceID).Project(projectID).RBAC().Role("*"),
+				urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(projectID).RBAC().Role("*"),
 				rbacpermissions.Write,
 			),
 			legacyAuthorization,
@@ -120,7 +120,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 		if len(permissionSlugs) > 0 {
 			foundPermissions, findErr := db.Query.FindPermissionsBySlugsForUpdate(ctx, tx, db.FindPermissionsBySlugsForUpdateParams{
-				WorkspaceID: principal.WorkspaceID,
+				WorkspaceID: principal.AuthorizedWorkspaceID,
 				ProjectID:   projectID,
 				Slugs:       permissionSlugs,
 			})
@@ -148,7 +148,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			if len(missingSlugs) > 0 {
 				if authorizeErr := principal.Authorize(rbac.Or(
 					rbac.U(
-						urn.New().Workspace(principal.WorkspaceID).Project(projectID).RBAC().Permission("*"),
+						urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(projectID).RBAC().Permission("*"),
 						rbacpermissions.Write,
 					),
 					rbac.T(rbac.Tuple{
@@ -164,7 +164,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 				for _, slug := range missingSlugs {
 					candidate := db.UpsertPermissionParams{
 						PermissionID: uid.New(uid.PermissionPrefix),
-						WorkspaceID:  principal.WorkspaceID,
+						WorkspaceID:  principal.AuthorizedWorkspaceID,
 						ProjectID:    projectID,
 						Name:         slug,
 						Slug:         slug,
@@ -181,7 +181,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 				}
 
 				foundPermissions, findErr = db.Query.FindPermissionsBySlugsForUpdate(ctx, tx, db.FindPermissionsBySlugsForUpdateParams{
-					WorkspaceID: principal.WorkspaceID,
+					WorkspaceID: principal.AuthorizedWorkspaceID,
 					ProjectID:   projectID,
 					Slugs:       permissionSlugs,
 				})
@@ -221,7 +221,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 		err = db.Query.InsertRole(ctx, tx, db.InsertRoleParams{
 			RoleID:      roleID,
-			WorkspaceID: principal.WorkspaceID,
+			WorkspaceID: principal.AuthorizedWorkspaceID,
 			ProjectID:   projectID,
 			Name:        req.Name,
 			Description: sql.NullString{Valid: description != "", String: description},
@@ -245,7 +245,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			rolePermissions[i] = db.InsertRolePermissionParams{
 				RoleID:       roleID,
 				PermissionID: permission.ID,
-				WorkspaceID:  principal.WorkspaceID,
+				WorkspaceID:  principal.AuthorizedWorkspaceID,
 				CreatedAtM:   now,
 			}
 		}
@@ -263,7 +263,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 		auditLogs := []auditlog.AuditLog{
 			{
-				WorkspaceID:   principal.WorkspaceID,
+				WorkspaceID:   principal.AuthorizedWorkspaceID,
 				Event:         auditlog.RoleCreateEvent,
 				ActorType:     auditlog.AuditLogActor(principal.Subject.Type),
 				ActorID:       principal.Subject.ID,
@@ -287,7 +287,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 		for _, permission := range createdPermissions {
 			auditLogs = append(auditLogs, auditlog.AuditLog{
-				WorkspaceID:   principal.WorkspaceID,
+				WorkspaceID:   principal.AuthorizedWorkspaceID,
 				Event:         auditlog.PermissionCreateEvent,
 				ActorType:     auditlog.AuditLogActor(principal.Subject.Type),
 				ActorID:       principal.Subject.ID,
@@ -314,7 +314,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 		for _, permission := range permissions {
 			auditLogs = append(auditLogs, auditlog.AuditLog{
-				WorkspaceID:   principal.WorkspaceID,
+				WorkspaceID:   principal.AuthorizedWorkspaceID,
 				Event:         auditlog.AuthConnectRolePermissionEvent,
 				ActorType:     auditlog.AuditLogActor(principal.Subject.Type),
 				ActorID:       principal.Subject.ID,

--- a/svc/api/routes/v2_permissions_delete_permission/handler.go
+++ b/svc/api/routes/v2_permissions_delete_permission/handler.go
@@ -48,7 +48,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	permission, err := db.Query.FindPermissionByIdOrSlug(ctx, h.DB.RO(), db.FindPermissionByIdOrSlugParams{
-		WorkspaceID: principal.WorkspaceID,
+		WorkspaceID: principal.AuthorizedWorkspaceID,
 		Search:      req.Permission,
 	})
 	if err != nil {
@@ -67,7 +67,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	deletePermission := rbac.U(
-		urn.New().Workspace(principal.WorkspaceID).Project(permission.ProjectID).RBAC().Permission(permission.ID),
+		urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(permission.ProjectID).RBAC().Permission(permission.ID),
 		permissions.Delete,
 	)
 	err = principal.Authorize(rbac.Or(
@@ -113,7 +113,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 		err = h.Auditlogs.Insert(ctx, tx, []auditlog.AuditLog{
 			{
-				WorkspaceID:   principal.WorkspaceID,
+				WorkspaceID:   principal.AuthorizedWorkspaceID,
 				Event:         auditlog.PermissionDeleteEvent,
 				ActorType:     auditlog.AuditLogActor(principal.Subject.Type),
 				ActorID:       principal.Subject.ID,

--- a/svc/api/routes/v2_permissions_delete_role/handler.go
+++ b/svc/api/routes/v2_permissions_delete_role/handler.go
@@ -52,7 +52,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	role, err := db.Query.FindRoleByIdOrNameWithPerms(ctx, h.DB.RO(), db.FindRoleByIdOrNameWithPermsParams{
-		WorkspaceID: principal.WorkspaceID,
+		WorkspaceID: principal.AuthorizedWorkspaceID,
 		Search:      req.Role,
 	})
 	if err != nil {
@@ -69,7 +69,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	deleteRole := rbac.U(
-		urn.New().Workspace(principal.WorkspaceID).Project(role.ProjectID).RBAC().Role(role.ID),
+		urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(role.ProjectID).RBAC().Role(role.ID),
 		permissions.Delete,
 	)
 	err = principal.Authorize(rbac.Or(
@@ -115,7 +115,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 		err = h.Auditlogs.Insert(ctx, tx, []auditlog.AuditLog{
 			{
-				WorkspaceID:   principal.WorkspaceID,
+				WorkspaceID:   principal.AuthorizedWorkspaceID,
 				Event:         auditlog.RoleDeleteEvent,
 				ActorType:     auditlog.AuditLogActor(principal.Subject.Type),
 				ActorID:       principal.Subject.ID,

--- a/svc/api/routes/v2_permissions_get_permission/handler.go
+++ b/svc/api/routes/v2_permissions_get_permission/handler.go
@@ -47,7 +47,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	permission, err := db.Query.FindPermissionByIdOrSlug(ctx, h.DB.RO(), db.FindPermissionByIdOrSlugParams{
-		WorkspaceID: principal.WorkspaceID,
+		WorkspaceID: principal.AuthorizedWorkspaceID,
 		Search:      req.Permission,
 	})
 	if err != nil {
@@ -64,7 +64,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	readPermission := rbac.U(
-		urn.New().Workspace(principal.WorkspaceID).Project(permission.ProjectID).RBAC().Permission(permission.ID),
+		urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(permission.ProjectID).RBAC().Permission(permission.ID),
 		permissions.Read,
 	)
 	err = principal.Authorize(rbac.Or(

--- a/svc/api/routes/v2_permissions_get_role/handler.go
+++ b/svc/api/routes/v2_permissions_get_role/handler.go
@@ -51,7 +51,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	role, err := db.Query.FindRoleByIdOrNameWithPerms(ctx, h.DB.RO(), db.FindRoleByIdOrNameWithPermsParams{
-		WorkspaceID: principal.WorkspaceID,
+		WorkspaceID: principal.AuthorizedWorkspaceID,
 		Search:      req.Role,
 	})
 	if err != nil {
@@ -69,7 +69,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	readRole := rbac.U(
-		urn.New().Workspace(principal.WorkspaceID).Project(role.ProjectID).RBAC().Role(role.ID),
+		urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(role.ProjectID).RBAC().Role(role.ID),
 		permissions.Read,
 	)
 	err = principal.Authorize(rbac.Or(

--- a/svc/api/routes/v2_permissions_list_permissions/handler.go
+++ b/svc/api/routes/v2_permissions_list_permissions/handler.go
@@ -55,7 +55,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	p := pagination.Parse(req.Limit, req.Cursor, 100)
 	search := mysql.SearchContains(strings.TrimSpace(ptr.SafeDeref(req.Search)))
 
-	projectID, projectFound, err := projects.FindDefaultProject(ctx, h.DB.RW(), principal.WorkspaceID)
+	projectID, projectFound, err := projects.FindDefaultProject(ctx, h.DB.RW(), principal.AuthorizedWorkspaceID)
 	if err != nil {
 		return err
 	}
@@ -68,7 +68,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 	err = principal.Authorize(rbac.Or(
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project(projectIDRequired).RBAC().Permission("*"),
+			urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(projectIDRequired).RBAC().Permission("*"),
 			permissions.Read,
 		),
 		rbac.T(rbac.Tuple{
@@ -82,7 +82,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	if !projectFound {
-		projectID, err = projects.EnsureDefaultProject(ctx, h.DB.RW(), principal.WorkspaceID)
+		projectID, err = projects.EnsureDefaultProject(ctx, h.DB.RW(), principal.AuthorizedWorkspaceID)
 		if err != nil {
 			return err
 		}
@@ -92,7 +92,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		ctx,
 		h.DB.RO(),
 		db.ListPermissionsParams{
-			WorkspaceID:       principal.WorkspaceID,
+			WorkspaceID:       principal.AuthorizedWorkspaceID,
 			ProjectID:         projectID,
 			IDCursor:          p.Cursor,
 			Search:            search,

--- a/svc/api/routes/v2_permissions_list_roles/handler.go
+++ b/svc/api/routes/v2_permissions_list_roles/handler.go
@@ -58,7 +58,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	p := pagination.Parse(req.Limit, req.Cursor, 100)
 	search := mysql.SearchContains(strings.TrimSpace(ptr.SafeDeref(req.Search)))
 
-	projectID, projectFound, err := projects.FindDefaultProject(ctx, h.DB.RW(), principal.WorkspaceID)
+	projectID, projectFound, err := projects.FindDefaultProject(ctx, h.DB.RW(), principal.AuthorizedWorkspaceID)
 	if err != nil {
 		return err
 	}
@@ -71,7 +71,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 	err = principal.Authorize(rbac.Or(
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project(projectIDRequired).RBAC().Role("*"),
+			urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(projectIDRequired).RBAC().Role("*"),
 			permissions.Read,
 		),
 		rbac.T(rbac.Tuple{
@@ -85,7 +85,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	if !projectFound {
-		projectID, err = projects.EnsureDefaultProject(ctx, h.DB.RW(), principal.WorkspaceID)
+		projectID, err = projects.EnsureDefaultProject(ctx, h.DB.RW(), principal.AuthorizedWorkspaceID)
 		if err != nil {
 			return err
 		}
@@ -95,7 +95,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		ctx,
 		h.DB.RO(),
 		db.ListRolesParams{
-			WorkspaceID: principal.WorkspaceID,
+			WorkspaceID: principal.AuthorizedWorkspaceID,
 			ProjectID:   projectID,
 			IDCursor:    p.Cursor,
 			Search:      search,

--- a/svc/api/routes/v2_permissions_set_role_permissions/handler.go
+++ b/svc/api/routes/v2_permissions_set_role_permissions/handler.go
@@ -68,7 +68,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	result := make([]rolePermission, 0, len(requestedSlugs))
 	err = db.TxRetry(ctx, h.DB.RW(), func(ctx context.Context, tx db.DBTX) error {
 		role, lockErr := db.Query.LockRoleByIDAndWorkspaceID(ctx, tx, db.LockRoleByIDAndWorkspaceIDParams{
-			RoleID: req.RoleId, WorkspaceID: principal.WorkspaceID,
+			RoleID: req.RoleId, WorkspaceID: principal.AuthorizedWorkspaceID,
 		})
 		if lockErr != nil {
 			if db.IsNotFound(lockErr) {
@@ -79,7 +79,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 		authorizeErr := principal.Authorize(rbac.Or(
 			rbac.U(
-				urn.New().Workspace(principal.WorkspaceID).Project(role.ProjectID).RBAC().Role(role.ID),
+				urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(role.ProjectID).RBAC().Role(role.ID),
 				permissions.Write,
 			),
 			rbac.And(
@@ -94,7 +94,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		found := make([]db.FindPermissionsBySlugsForUpdateRow, 0)
 		if len(requestedSlugs) > 0 {
 			found, err = db.Query.FindPermissionsBySlugsForUpdate(ctx, tx, db.FindPermissionsBySlugsForUpdateParams{
-				WorkspaceID: principal.WorkspaceID,
+				WorkspaceID: principal.AuthorizedWorkspaceID,
 				ProjectID:   role.ProjectID,
 				Slugs:       requestedSlugs,
 			})
@@ -117,7 +117,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		if len(missing) > 0 {
 			if authErr := principal.Authorize(rbac.Or(
 				rbac.U(
-					urn.New().Workspace(principal.WorkspaceID).Project(role.ProjectID).RBAC().Permission("*"),
+					urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(role.ProjectID).RBAC().Permission("*"),
 					permissions.Write,
 				),
 				rbac.T(rbac.Tuple{ResourceType: rbac.Rbac, ResourceID: "*", Action: rbac.CreatePermission}),
@@ -129,7 +129,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 				now := time.Now().UnixMilli()
 				candidate := db.UpsertPermissionParams{
 					PermissionID: uid.New(uid.PermissionPrefix),
-					WorkspaceID:  principal.WorkspaceID,
+					WorkspaceID:  principal.AuthorizedWorkspaceID,
 					ProjectID:    role.ProjectID,
 					Name:         slug,
 					Slug:         slug,
@@ -143,7 +143,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			}
 
 			found, err = db.Query.FindPermissionsBySlugsForUpdate(ctx, tx, db.FindPermissionsBySlugsForUpdateParams{
-				WorkspaceID: principal.WorkspaceID,
+				WorkspaceID: principal.AuthorizedWorkspaceID,
 				ProjectID:   role.ProjectID,
 				Slugs:       requestedSlugs,
 			})
@@ -212,7 +212,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			if _, ok := currentByID[permission.ID]; ok {
 				continue
 			}
-			toAdd = append(toAdd, db.InsertRolePermissionParams{RoleID: req.RoleId, PermissionID: permission.ID, WorkspaceID: principal.WorkspaceID, CreatedAtM: time.Now().UnixMilli()})
+			toAdd = append(toAdd, db.InsertRolePermissionParams{RoleID: req.RoleId, PermissionID: permission.ID, WorkspaceID: principal.AuthorizedWorkspaceID, CreatedAtM: time.Now().UnixMilli()})
 			logs = append(logs, audit(principal, s, auditlog.AuthConnectRolePermissionEvent, fmt.Sprintf("Added permission %s to role %s", permission.Name, role.Name), roleResource(role.ID, role.Name), permissionResource(permission.ID, permission.Slug, permission.Name)))
 		}
 		if err = db.BulkQuery.InsertRolePermissions(ctx, tx, toAdd); err != nil {
@@ -242,5 +242,5 @@ func permissionResource(id, slug, name string) auditlog.AuditLogResource {
 }
 
 func audit(principal *principal.Principal, s *zen.Session, event auditlog.AuditLogEvent, display string, resources ...auditlog.AuditLogResource) auditlog.AuditLog {
-	return auditlog.AuditLog{WorkspaceID: principal.WorkspaceID, Event: event, ActorType: auditlog.AuditLogActor(principal.Subject.Type), ActorID: principal.Subject.ID, ActorName: principal.Subject.Name, ActorMeta: map[string]any{}, Display: display, RemoteIP: s.Location(), UserAgent: s.UserAgent(), CorrelationID: "", Resources: resources}
+	return auditlog.AuditLog{WorkspaceID: principal.AuthorizedWorkspaceID, Event: event, ActorType: auditlog.AuditLogActor(principal.Subject.Type), ActorID: principal.Subject.ID, ActorName: principal.Subject.Name, ActorMeta: map[string]any{}, Display: display, RemoteIP: s.Location(), UserAgent: s.UserAgent(), CorrelationID: "", Resources: resources}
 }

--- a/svc/api/routes/v2_portal_create_portal/handler.go
+++ b/svc/api/routes/v2_portal_create_portal/handler.go
@@ -98,7 +98,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			ResourceID:   "*",
 			Action:       rbac.CreatePortal,
 		}),
-		rbac.S(fmt.Sprintf("unkey:v1:%s:**#*", principal.WorkspaceID)),
+		rbac.S(fmt.Sprintf("unkey:v1:%s:**#*", principal.AuthorizedWorkspaceID)),
 	))
 	if err != nil {
 		// Returned as-is rather than masked as a 404: there is no portal yet whose
@@ -111,21 +111,21 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	ctx = auditlog.WithCorrelation(ctx, auditlog.NewCorrelationID())
 
 	err = db.Tx(ctx, h.DB.RW(), func(ctx context.Context, tx db.DBTX) error {
-		if err := portal.VerifyMappingOwned(ctx, tx, principal.WorkspaceID, mapping); err != nil {
+		if err := portal.VerifyMappingOwned(ctx, tx, principal.AuthorizedWorkspaceID, mapping); err != nil {
 			return err
 		}
 
-		if err := portal.AuthorizeMappingTarget(ctx, tx, principal, principal.WorkspaceID, mapping); err != nil {
+		if err := portal.AuthorizeMappingTarget(ctx, tx, principal, principal.AuthorizedWorkspaceID, mapping); err != nil {
 			return err
 		}
 
-		if err := h.checkSlugAndResourceFree(ctx, tx, principal.WorkspaceID, req.Slug, mapping); err != nil {
+		if err := h.checkSlugAndResourceFree(ctx, tx, principal.AuthorizedWorkspaceID, req.Slug, mapping); err != nil {
 			return err
 		}
 
 		err := db.Query.InsertPortal(ctx, tx, db.InsertPortalParams{
 			ID:           portalID,
-			WorkspaceID:  principal.WorkspaceID,
+			WorkspaceID:  principal.AuthorizedWorkspaceID,
 			Slug:         req.Slug,
 			DisplayName:  req.DisplayName,
 			AppID:        appID,
@@ -158,7 +158,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 		return h.Auditlogs.Insert(ctx, tx, []auditlog.AuditLog{
 			{
-				WorkspaceID:   principal.WorkspaceID,
+				WorkspaceID:   principal.AuthorizedWorkspaceID,
 				Event:         auditlog.PortalCreateEvent,
 				Display:       fmt.Sprintf("Created portal %s", portalID),
 				ActorID:       principal.Subject.ID,

--- a/svc/api/routes/v2_portal_create_session/handler.go
+++ b/svc/api/routes/v2_portal_create_session/handler.go
@@ -149,7 +149,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	workspaceID := principal.WorkspaceID
+	workspaceID := principal.AuthorizedWorkspaceID
 
 	portal, err := db.Query.FindPortalByIdOrSlug(ctx, h.DB.RO(), db.FindPortalByIdOrSlugParams{
 		WorkspaceID: workspaceID,

--- a/svc/api/routes/v2_portal_delete_portal/handler.go
+++ b/svc/api/routes/v2_portal_delete_portal/handler.go
@@ -63,7 +63,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	err = db.Tx(ctx, h.DB.RW(), func(ctx context.Context, tx db.DBTX) error {
 		found, err := db.Query.FindPortalByIdOrSlug(ctx, tx, db.FindPortalByIdOrSlugParams{
 			Portal:      req.Portal,
-			WorkspaceID: principal.WorkspaceID,
+			WorkspaceID: principal.AuthorizedWorkspaceID,
 		})
 		if err != nil {
 			if db.IsNotFound(err) {
@@ -101,7 +101,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 				ResourceID:   found.ID,
 				Action:       rbac.DeletePortal,
 			}),
-			rbac.S(fmt.Sprintf("unkey:v1:%s:**#*", principal.WorkspaceID)),
+			rbac.S(fmt.Sprintf("unkey:v1:%s:**#*", principal.AuthorizedWorkspaceID)),
 		))
 		if err != nil {
 			// A fresh chain, not a wrap: UserFacingMessage concatenates every public
@@ -124,7 +124,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		// a second delete here.
 		affected, err := db.Query.DeletePortal(ctx, tx, db.DeletePortalParams{
 			ID:          found.ID,
-			WorkspaceID: principal.WorkspaceID,
+			WorkspaceID: principal.AuthorizedWorkspaceID,
 		})
 		if err != nil {
 			return fault.Wrap(err,
@@ -157,7 +157,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		revoked, err := db.Query.RevokePortalSessionsByPortal(ctx, tx, db.RevokePortalSessionsByPortalParams{
 			RevokedAt:   sql.NullInt64{Valid: true, Int64: now},
 			PortalID:    found.ID,
-			WorkspaceID: principal.WorkspaceID,
+			WorkspaceID: principal.AuthorizedWorkspaceID,
 		})
 		if err != nil {
 			return fault.Wrap(err,
@@ -171,7 +171,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 		return h.Auditlogs.Insert(ctx, tx, []auditlog.AuditLog{
 			{
-				WorkspaceID:   principal.WorkspaceID,
+				WorkspaceID:   principal.AuthorizedWorkspaceID,
 				Event:         auditlog.PortalDeleteEvent,
 				Display:       fmt.Sprintf("Deleted portal %s", found.ID),
 				ActorID:       principal.Subject.ID,

--- a/svc/api/routes/v2_portal_get_portal/handler.go
+++ b/svc/api/routes/v2_portal_get_portal/handler.go
@@ -55,7 +55,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	found, err := h.resolve(ctx, principal.WorkspaceID, target)
+	found, err := h.resolve(ctx, principal.AuthorizedWorkspaceID, target)
 	if err != nil {
 		return err
 	}
@@ -81,7 +81,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			ResourceID:   found.ID,
 			Action:       rbac.ReadPortal,
 		}),
-		rbac.S(fmt.Sprintf("unkey:v1:%s:**#*", principal.WorkspaceID)),
+		rbac.S(fmt.Sprintf("unkey:v1:%s:**#*", principal.AuthorizedWorkspaceID)),
 	))
 	if err != nil {
 		// A fresh chain, not a wrap: UserFacingMessage concatenates every public

--- a/svc/api/routes/v2_portal_get_verifications/handler.go
+++ b/svc/api/routes/v2_portal_get_verifications/handler.go
@@ -85,8 +85,8 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	// zero-filled series. We use the same log retention limit that the protected
 	// analytics.getVerifications path uses as MaxQueryRangeDays, so the portal
 	// cannot query a wider range than the workspace itself.
-	limits, _, err := h.LimitsCache.SWR(ctx, principal.WorkspaceID, func(ctx context.Context) (keysdb.Limit, error) {
-		return keysdb.Query.FindLimitsByWorkspaceID(ctx, h.DB.RO(), principal.WorkspaceID)
+	limits, _, err := h.LimitsCache.SWR(ctx, principal.AuthorizedWorkspaceID, func(ctx context.Context) (keysdb.Limit, error) {
+		return keysdb.Query.FindLimitsByWorkspaceID(ctx, h.DB.RO(), principal.AuthorizedWorkspaceID)
 	}, caches.DefaultFindFirstOp)
 	if err != nil {
 		return fault.Wrap(err,
@@ -105,7 +105,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	points, err := h.ClickHouse.GetVerificationsByExternalID(ctx, clickhouse.VerificationTimeseriesRequest{
-		WorkspaceID: principal.WorkspaceID,
+		WorkspaceID: principal.AuthorizedWorkspaceID,
 		ExternalID:  externalID,
 		KeyID:       ptr.SafeDeref(req.KeyId),
 		StartTime:   req.StartTime,

--- a/svc/api/routes/v2_portal_list_keys/handler.go
+++ b/svc/api/routes/v2_portal_list_keys/handler.go
@@ -84,7 +84,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	// Scope to the end user's own keys. If the identity does not exist yet, the
 	// user simply has no keys.
 	identity, err := db.Query.FindIdentityByExternalID(ctx, h.DB.RO(), db.FindIdentityByExternalIDParams{
-		WorkspaceID: principal.WorkspaceID,
+		WorkspaceID: principal.AuthorizedWorkspaceID,
 		ExternalID:  externalID,
 		Deleted:     false,
 	})

--- a/svc/api/routes/v2_portal_reroll_key/handler.go
+++ b/svc/api/routes/v2_portal_reroll_key/handler.go
@@ -73,7 +73,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	// Ownership guard: a portal caller may only reroll a key that belongs to its
 	// own external identity within its own workspace. Fail closed with a 404 so
 	// the caller cannot probe for keys it does not own.
-	if key.KeyWorkspaceID != principal.WorkspaceID ||
+	if key.KeyWorkspaceID != principal.AuthorizedWorkspaceID ||
 		!slices.Contains(keyspaceIDs, key.KeyAuthID) ||
 		!key.IdentityExternalID.Valid ||
 		key.IdentityExternalID.String != externalID {

--- a/svc/api/routes/v2_portal_update_portal/handler.go
+++ b/svc/api/routes/v2_portal_update_portal/handler.go
@@ -132,7 +132,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 		found, err := db.Query.FindPortalByIdOrSlug(ctx, tx, db.FindPortalByIdOrSlugParams{
 			Portal:      req.Portal,
-			WorkspaceID: principal.WorkspaceID,
+			WorkspaceID: principal.AuthorizedWorkspaceID,
 		})
 		if err != nil {
 			if db.IsNotFound(err) {
@@ -170,7 +170,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 				ResourceID:   found.ID,
 				Action:       rbac.UpdatePortal,
 			}),
-			rbac.S(fmt.Sprintf("unkey:v1:%s:**#*", principal.WorkspaceID)),
+			rbac.S(fmt.Sprintf("unkey:v1:%s:**#*", principal.AuthorizedWorkspaceID)),
 		))
 		if err != nil {
 			// A fresh chain, not a wrap: UserFacingMessage concatenates every public
@@ -187,21 +187,21 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		}
 
 		if repoint {
-			if err = portal.VerifyMappingOwned(ctx, tx, principal.WorkspaceID, mapping); err != nil {
+			if err = portal.VerifyMappingOwned(ctx, tx, principal.AuthorizedWorkspaceID, mapping); err != nil {
 				return empty, err
 			}
 
-			if err = portal.AuthorizeMappingTarget(ctx, tx, principal, principal.WorkspaceID, mapping); err != nil {
+			if err = portal.AuthorizeMappingTarget(ctx, tx, principal, principal.AuthorizedWorkspaceID, mapping); err != nil {
 				return empty, err
 			}
 		}
 
-		if err = h.checkPortalConflicts(ctx, tx, principal.WorkspaceID, found, req, repoint, mapping); err != nil {
+		if err = h.checkPortalConflicts(ctx, tx, principal.AuthorizedWorkspaceID, found, req, repoint, mapping); err != nil {
 			return empty, err
 		}
 
 		params := db.UpdatePortalParams{
-			WorkspaceID:           principal.WorkspaceID,
+			WorkspaceID:           principal.AuthorizedWorkspaceID,
 			ID:                    found.ID,
 			UpdatedAt:             sql.NullInt64{Valid: true, Int64: now},
 			SlugSpecified:         0,
@@ -304,7 +304,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		if affected == 0 {
 			if _, err := db.Query.FindPortalByIdOrSlug(ctx, tx, db.FindPortalByIdOrSlugParams{
 				Portal:      found.ID,
-				WorkspaceID: principal.WorkspaceID,
+				WorkspaceID: principal.AuthorizedWorkspaceID,
 			}); err != nil {
 				if !db.IsNotFound(err) {
 					return empty, fault.Wrap(err,
@@ -332,7 +332,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			revoked, err = db.Query.RevokePortalSessionsByPortal(ctx, tx, db.RevokePortalSessionsByPortalParams{
 				RevokedAt:   sql.NullInt64{Valid: true, Int64: now},
 				PortalID:    found.ID,
-				WorkspaceID: principal.WorkspaceID,
+				WorkspaceID: principal.AuthorizedWorkspaceID,
 			})
 			if err != nil {
 				return empty, fault.Wrap(err,
@@ -348,7 +348,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 		err = h.Auditlogs.Insert(ctx, tx, []auditlog.AuditLog{
 			{
-				WorkspaceID:   principal.WorkspaceID,
+				WorkspaceID:   principal.AuthorizedWorkspaceID,
 				Event:         auditlog.PortalUpdateEvent,
 				Display:       fmt.Sprintf("Updated portal %s", found.ID),
 				ActorID:       principal.Subject.ID,

--- a/svc/api/routes/v2_projects_create_project/handler.go
+++ b/svc/api/routes/v2_projects_create_project/handler.go
@@ -54,7 +54,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			Action:       rbac.CreateProject,
 		}),
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project("*"),
+			urn.New().Workspace(principal.AuthorizedWorkspaceID).Project("*"),
 			permissions.Write,
 		),
 	))
@@ -72,7 +72,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	ctrlResp, err := h.CtrlClient.CreateProject(ctx, &ctrlv1.CreateProjectRequest{
-		WorkspaceId: principal.WorkspaceID,
+		WorkspaceId: principal.AuthorizedWorkspaceID,
 		Name:        req.Name,
 		Slug:        req.Slug,
 		Actor:       actor,

--- a/svc/api/routes/v2_projects_delete_project/handler.go
+++ b/svc/api/routes/v2_projects_delete_project/handler.go
@@ -49,7 +49,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	project, err := db.Query.FindProjectByIdOrSlug(ctx, h.DB.RW(), db.FindProjectByIdOrSlugParams{
-		WorkspaceID: principal.WorkspaceID,
+		WorkspaceID: principal.AuthorizedWorkspaceID,
 		Project:     req.Project,
 	})
 	if err != nil {
@@ -91,7 +91,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			Action:       rbac.DeleteProject,
 		}),
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project(project.ID),
+			urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(project.ID),
 			permissions.Delete,
 		),
 	))

--- a/svc/api/routes/v2_projects_get_project/handler.go
+++ b/svc/api/routes/v2_projects_get_project/handler.go
@@ -46,7 +46,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	project, err := db.Query.FindProjectByIdOrSlug(ctx, h.DB.RO(), db.FindProjectByIdOrSlugParams{
-		WorkspaceID: principal.WorkspaceID,
+		WorkspaceID: principal.AuthorizedWorkspaceID,
 		Project:     req.Project,
 	})
 	if err != nil {

--- a/svc/api/routes/v2_projects_list_projects/handler.go
+++ b/svc/api/routes/v2_projects_list_projects/handler.go
@@ -62,7 +62,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	search := mysql.SearchContains(strings.TrimSpace(ptr.SafeDeref(req.Search)))
 
 	rows, err := db.Query.ListProjectsByWorkspaceId(ctx, h.DB.RO(), db.ListProjectsByWorkspaceIdParams{
-		WorkspaceID: principal.WorkspaceID,
+		WorkspaceID: principal.AuthorizedWorkspaceID,
 		IDCursor:    p.Cursor,
 		Search:      search,
 		Limit:       p.FetchLimit(),

--- a/svc/api/routes/v2_projects_update_project/handler.go
+++ b/svc/api/routes/v2_projects_update_project/handler.go
@@ -51,7 +51,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 	data, err := db.TxWithResultRetry(ctx, h.DB.RW(), func(ctx context.Context, tx db.DBTX) (openapi.Project, error) {
 		project, err := db.Query.FindProjectByIdOrSlug(ctx, tx, db.FindProjectByIdOrSlugParams{
-			WorkspaceID: principal.WorkspaceID,
+			WorkspaceID: principal.AuthorizedWorkspaceID,
 			Project:     req.Project,
 		})
 		if err != nil {
@@ -93,7 +93,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 				Action:       rbac.UpdateProject,
 			}),
 			rbac.U(
-				urn.New().Workspace(principal.WorkspaceID).Project(project.ID),
+				urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(project.ID),
 				permissions.Write,
 			),
 		))
@@ -109,7 +109,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 		updatedAt := time.Now().UnixMilli()
 		update := db.UpdateProjectParams{
-			WorkspaceID:               principal.WorkspaceID,
+			WorkspaceID:               principal.AuthorizedWorkspaceID,
 			ID:                        project.ID,
 			UpdatedAt:                 sql.NullInt64{Valid: true, Int64: updatedAt},
 			NameSpecified:             0,
@@ -171,7 +171,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 		err = h.Auditlogs.Insert(ctx, tx, []auditlog.AuditLog{
 			{
-				WorkspaceID:   principal.WorkspaceID,
+				WorkspaceID:   principal.AuthorizedWorkspaceID,
 				Event:         auditlog.ProjectUpdateEvent,
 				Display:       fmt.Sprintf("Updated project %s", project.ID),
 				ActorID:       principal.Subject.ID,

--- a/svc/api/routes/v2_ratelimit_delete_override/handler.go
+++ b/svc/api/routes/v2_ratelimit_delete_override/handler.go
@@ -53,7 +53,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	ns, found, err := h.getNamespace(ctx, principal.WorkspaceID, req.Namespace)
+	ns, found, err := h.getNamespace(ctx, principal.AuthorizedWorkspaceID, req.Namespace)
 	if err != nil {
 		return fault.Wrap(err,
 			fault.Code(codes.App.Internal.UnexpectedError.URN()),
@@ -88,7 +88,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 	err = principal.Authorize(rbac.Or(
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project(ns.ProjectID).RatelimitNamespace(ns.ID).Override(override.ID),
+			urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(ns.ProjectID).RatelimitNamespace(ns.ID).Override(override.ID),
 			permissions.Delete,
 		),
 		rbac.T(rbac.Tuple{
@@ -125,7 +125,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 		err = h.Auditlogs.Insert(ctx, tx, []auditlog.AuditLog{
 			{
-				WorkspaceID:   principal.WorkspaceID,
+				WorkspaceID:   principal.AuthorizedWorkspaceID,
 				Event:         auditlog.RatelimitDeleteOverrideEvent,
 				Display:       fmt.Sprintf("Deleted override %s.", override.ID),
 				ActorID:       principal.Subject.ID,
@@ -164,8 +164,8 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	h.NamespaceCache.Remove(ctx,
-		cache.ScopedKey{WorkspaceID: principal.WorkspaceID, Key: ns.ID},
-		cache.ScopedKey{WorkspaceID: principal.WorkspaceID, Key: ns.Name},
+		cache.ScopedKey{WorkspaceID: principal.AuthorizedWorkspaceID, Key: ns.ID},
+		cache.ScopedKey{WorkspaceID: principal.AuthorizedWorkspaceID, Key: ns.Name},
 	)
 
 	return s.JSON(http.StatusOK, Response{

--- a/svc/api/routes/v2_ratelimit_get_override/handler.go
+++ b/svc/api/routes/v2_ratelimit_get_override/handler.go
@@ -51,7 +51,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	ns, found, err := h.getNamespace(ctx, principal.WorkspaceID, req.Namespace)
+	ns, found, err := h.getNamespace(ctx, principal.AuthorizedWorkspaceID, req.Namespace)
 	if err != nil {
 		return fault.Wrap(err,
 			fault.Code(codes.App.Internal.UnexpectedError.URN()),
@@ -101,7 +101,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		rbac.Or(
 			rbac.U(
 				urn.New().
-					Workspace(principal.WorkspaceID).
+					Workspace(principal.AuthorizedWorkspaceID).
 					Project(ns.ProjectID).
 					RatelimitNamespace(ns.ID).
 					Override(override.ID),

--- a/svc/api/routes/v2_ratelimit_limit/audit_log_internal_test.go
+++ b/svc/api/routes/v2_ratelimit_limit/audit_log_internal_test.go
@@ -59,8 +59,8 @@ func TestBufferAuditLog_SkipsNonRootPrincipal(t *testing.T) {
 			Payload:   nil,
 			Signature: "",
 		},
-		WorkspaceID: "ws_123",
-		Permissions: nil,
+		AuthorizedWorkspaceID: "ws_123",
+		Permissions:           nil,
 	}
 	namespace := db.FindRatelimitNamespace{ //nolint:exhaustruct
 		ID:          "rlns_123",

--- a/svc/api/routes/v2_ratelimit_limit/handler.go
+++ b/svc/api/routes/v2_ratelimit_limit/handler.go
@@ -75,7 +75,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	ns, found, err := h.getNamespace(ctx, principal.WorkspaceID, req.Namespace)
+	ns, found, err := h.getNamespace(ctx, principal.AuthorizedWorkspaceID, req.Namespace)
 	if err != nil {
 		return fault.Wrap(err,
 			fault.Code(codes.App.Internal.UnexpectedError.URN()),
@@ -85,14 +85,14 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 	if !found {
 		projectID, resolveErr := db.TxWithResultRetry(ctx, h.DB.RW(), func(ctx context.Context, tx db.DBTX) (string, error) {
-			return projects.EnsureDefaultProject(ctx, tx, principal.WorkspaceID)
+			return projects.EnsureDefaultProject(ctx, tx, principal.AuthorizedWorkspaceID)
 		})
 		if resolveErr != nil {
 			return resolveErr
 		}
 		err = principal.Authorize(rbac.Or(
 			rbac.U(
-				urn.New().Workspace(principal.WorkspaceID).Project(projectID).RatelimitNamespace("*"),
+				urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(projectID).RatelimitNamespace("*"),
 				permissions.Write,
 			),
 			rbac.T(rbac.Tuple{
@@ -120,7 +120,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 	err = principal.Authorize(rbac.Or(
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project(ns.ProjectID).RatelimitNamespace(ns.ID),
+			urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(ns.ProjectID).RatelimitNamespace(ns.ID),
 			permissions.Limit,
 		),
 		rbac.T(rbac.Tuple{
@@ -151,7 +151,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	// Apply rate limit
 	cost := ptr.SafeDeref(req.Cost, 1)
 	limitReq := ratelimit.RatelimitRequest{
-		WorkspaceID: principal.WorkspaceID,
+		WorkspaceID: principal.AuthorizedWorkspaceID,
 		Namespace:   ns.ID,
 		Identifier:  req.Identifier,
 		Duration:    time.Duration(duration) * time.Millisecond,
@@ -187,7 +187,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	if s.ShouldLogRequestToClickHouse() {
 		h.RatelimitEvents.Buffer(schema.Ratelimit{
 			RequestID:   s.RequestID(),
-			WorkspaceID: principal.WorkspaceID,
+			WorkspaceID: principal.AuthorizedWorkspaceID,
 			Time:        nowMillis,
 			NamespaceID: ns.ID,
 			Identifier:  req.Identifier,
@@ -252,7 +252,7 @@ func (h *Handler) bufferAuditLog(
 	h.DirectAuditLogs.Buffer(auditlog.Event{
 		EventID:     uid.New(uid.AuditLogPrefix),
 		Time:        timeMillis,
-		WorkspaceID: p.WorkspaceID,
+		WorkspaceID: p.AuthorizedWorkspaceID,
 		Bucket:      auditlogs.DefaultBucket,
 		Source:      auditlog.EventSourcePlatform,
 		Event:       string(auditlog.RatelimitLimitEvent),
@@ -302,7 +302,7 @@ func (h *Handler) getNamespace(ctx context.Context, workspaceID, nameOrID string
 }
 
 func (h *Handler) createNamespace(ctx context.Context, s *zen.Session, principal *principal.Principal, projectID, name string) (db.FindRatelimitNamespace, error) {
-	key := principal.WorkspaceID + ":" + name
+	key := principal.AuthorizedWorkspaceID + ":" + name
 	return h.createFlight.Do(key, func() (db.FindRatelimitNamespace, error) {
 		ns, err := db.TxWithResultRetry(ctx, h.DB.RW(), func(ctx context.Context, tx db.DBTX) (db.FindRatelimitNamespace, error) {
 			now := time.Now().UnixMilli()
@@ -310,7 +310,7 @@ func (h *Handler) createNamespace(ctx context.Context, s *zen.Session, principal
 
 			insertErr := db.Query.InsertRatelimitNamespace(ctx, tx, db.InsertRatelimitNamespaceParams{
 				ID:          id,
-				WorkspaceID: principal.WorkspaceID,
+				WorkspaceID: principal.AuthorizedWorkspaceID,
 				ProjectID:   projectID,
 				Name:        name,
 				CreatedAt:   now,
@@ -330,7 +330,7 @@ func (h *Handler) createNamespace(ctx context.Context, s *zen.Session, principal
 
 			result := db.FindRatelimitNamespace{
 				ID:                id,
-				WorkspaceID:       principal.WorkspaceID,
+				WorkspaceID:       principal.AuthorizedWorkspaceID,
 				ProjectID:         projectID,
 				Name:              name,
 				CreatedAtM:        now,
@@ -342,7 +342,7 @@ func (h *Handler) createNamespace(ctx context.Context, s *zen.Session, principal
 
 			auditErr := h.Auditlogs.Insert(ctx, tx, []auditlog.AuditLog{
 				{
-					WorkspaceID:   principal.WorkspaceID,
+					WorkspaceID:   principal.AuthorizedWorkspaceID,
 					Event:         auditlog.RatelimitNamespaceCreateEvent,
 					Display:       "Created ratelimit namespace " + name,
 					ActorID:       principal.Subject.ID,
@@ -374,7 +374,7 @@ func (h *Handler) createNamespace(ctx context.Context, s *zen.Session, principal
 		}
 		if ns.ID == "" {
 			row, fetchErr := db.Query.FindRatelimitNamespace(ctx, h.DB.RW(), db.FindRatelimitNamespaceParams{
-				WorkspaceID: principal.WorkspaceID,
+				WorkspaceID: principal.AuthorizedWorkspaceID,
 				Namespace:   name,
 			})
 			if fetchErr != nil {
@@ -387,8 +387,8 @@ func (h *Handler) createNamespace(ctx context.Context, s *zen.Session, principal
 		}
 
 		// Warm cache by both name and ID after the transaction has committed
-		h.NamespaceCache.Set(ctx, cache.ScopedKey{WorkspaceID: principal.WorkspaceID, Key: ns.Name}, ns)
-		h.NamespaceCache.Set(ctx, cache.ScopedKey{WorkspaceID: principal.WorkspaceID, Key: ns.ID}, ns)
+		h.NamespaceCache.Set(ctx, cache.ScopedKey{WorkspaceID: principal.AuthorizedWorkspaceID, Key: ns.Name}, ns)
+		h.NamespaceCache.Set(ctx, cache.ScopedKey{WorkspaceID: principal.AuthorizedWorkspaceID, Key: ns.ID}, ns)
 
 		return ns, nil
 	})

--- a/svc/api/routes/v2_ratelimit_list_overrides/handler.go
+++ b/svc/api/routes/v2_ratelimit_list_overrides/handler.go
@@ -50,7 +50,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 	// Use the namespace field directly - it can be either name or ID
 	namespace, err := db.Query.FindRatelimitNamespace(ctx, h.DB.RO(), db.FindRatelimitNamespaceParams{
-		WorkspaceID: principal.WorkspaceID,
+		WorkspaceID: principal.AuthorizedWorkspaceID,
 		Namespace:   req.Namespace,
 	})
 	if err != nil {
@@ -66,7 +66,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		)
 	}
 
-	if namespace.WorkspaceID != principal.WorkspaceID {
+	if namespace.WorkspaceID != principal.AuthorizedWorkspaceID {
 		return fault.New("namespace not found",
 			fault.Code(codes.Data.RatelimitNamespace.NotFound.URN()),
 			fault.Internal("namespace was deleted"), fault.Public("This namespace does not exist."),
@@ -75,7 +75,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 	err = principal.Authorize(rbac.Or(
 		rbac.U(
-			urn.New().Workspace(principal.WorkspaceID).Project(namespace.ProjectID).RatelimitNamespace(namespace.ID).Override("*"),
+			urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(namespace.ProjectID).RatelimitNamespace(namespace.ID).Override("*"),
 			permissions.Read,
 		),
 		rbac.T(rbac.Tuple{
@@ -96,7 +96,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	p := pagination.Parse(req.Limit, req.Cursor, 50)
 
 	overrides, err := db.Query.ListRatelimitOverridesByNamespaceID(ctx, h.DB.RO(), db.ListRatelimitOverridesByNamespaceIDParams{
-		WorkspaceID: principal.WorkspaceID,
+		WorkspaceID: principal.AuthorizedWorkspaceID,
 		NamespaceID: namespace.ID,
 		Limit:       p.FetchLimit(),
 		CursorID:    p.Cursor,

--- a/svc/api/routes/v2_ratelimit_multi_limit/handler.go
+++ b/svc/api/routes/v2_ratelimit_multi_limit/handler.go
@@ -79,7 +79,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	}
 
 	// Batch load all namespaces
-	namespaces, missing, err := h.getNamespaces(ctx, principal.WorkspaceID, names)
+	namespaces, missing, err := h.getNamespaces(ctx, principal.AuthorizedWorkspaceID, names)
 	if err != nil {
 		return fault.Wrap(err,
 			fault.Code(codes.App.Internal.UnexpectedError.URN()),
@@ -90,14 +90,14 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	// Auto-create any missing namespaces
 	if len(missing) > 0 {
 		projectID, resolveErr := db.TxWithResultRetry(ctx, h.DB.RW(), func(ctx context.Context, tx db.DBTX) (string, error) {
-			return projects.EnsureDefaultProject(ctx, tx, principal.WorkspaceID)
+			return projects.EnsureDefaultProject(ctx, tx, principal.AuthorizedWorkspaceID)
 		})
 		if resolveErr != nil {
 			return resolveErr
 		}
 		err = principal.Authorize(rbac.Or(
 			rbac.U(
-				urn.New().Workspace(principal.WorkspaceID).Project(projectID).RatelimitNamespace("*"),
+				urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(projectID).RatelimitNamespace("*"),
 				permissions.Write,
 			),
 			rbac.T(rbac.Tuple{
@@ -126,7 +126,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		ns := namespaces[check.Namespace]
 		requiredPerms = append(requiredPerms, rbac.Or(
 			rbac.U(
-				urn.New().Workspace(principal.WorkspaceID).Project(ns.ProjectID).RatelimitNamespace(ns.ID),
+				urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(ns.ProjectID).RatelimitNamespace(ns.ID),
 				permissions.Limit,
 			),
 			rbac.T(rbac.Tuple{
@@ -186,7 +186,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 		cost := ptr.SafeDeref(check.Cost, 1)
 		ratelimitReqs[i] = ratelimit.RatelimitRequest{
-			WorkspaceID: principal.WorkspaceID,
+			WorkspaceID: principal.AuthorizedWorkspaceID,
 			Namespace:   ns.ID,
 			Identifier:  check.Identifier,
 			Duration:    time.Duration(duration) * time.Millisecond,
@@ -224,7 +224,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			meta := checkMetadata[i]
 			h.RatelimitEvents.Buffer(schema.Ratelimit{
 				RequestID:   s.RequestID(),
-				WorkspaceID: principal.WorkspaceID,
+				WorkspaceID: principal.AuthorizedWorkspaceID,
 				Time:        startMillis,
 				NamespaceID: meta.namespaceID,
 				Identifier:  meta.identifier,
@@ -344,14 +344,14 @@ func (h *Handler) createNamespaces(ctx context.Context, s *zen.Session, principa
 
 			insertParams[i] = db.InsertRatelimitNamespaceParams{
 				ID:          id,
-				WorkspaceID: principal.WorkspaceID,
+				WorkspaceID: principal.AuthorizedWorkspaceID,
 				ProjectID:   projectID,
 				Name:        name,
 				CreatedAt:   now,
 			}
 
 			auditLogs[i] = auditlog.AuditLog{
-				WorkspaceID:   principal.WorkspaceID,
+				WorkspaceID:   principal.AuthorizedWorkspaceID,
 				Event:         auditlog.RatelimitNamespaceCreateEvent,
 				Display:       "Created ratelimit namespace " + name,
 				ActorID:       principal.Subject.ID,
@@ -387,7 +387,7 @@ func (h *Handler) createNamespaces(ctx context.Context, s *zen.Session, principa
 				id := nameToID[name]
 				result[name] = db.FindRatelimitNamespace{
 					ID:                id,
-					WorkspaceID:       principal.WorkspaceID,
+					WorkspaceID:       principal.AuthorizedWorkspaceID,
 					ProjectID:         projectID,
 					Name:              name,
 					CreatedAtM:        now,
@@ -417,12 +417,12 @@ func (h *Handler) createNamespaces(ctx context.Context, s *zen.Session, principa
 	// For any names not in the result (due to race), re-fetch from DB.
 	for _, name := range names {
 		if ns, ok := created[name]; ok {
-			h.NamespaceCache.Set(ctx, cache.ScopedKey{WorkspaceID: principal.WorkspaceID, Key: name}, ns)
-			h.NamespaceCache.Set(ctx, cache.ScopedKey{WorkspaceID: principal.WorkspaceID, Key: ns.ID}, ns)
+			h.NamespaceCache.Set(ctx, cache.ScopedKey{WorkspaceID: principal.AuthorizedWorkspaceID, Key: name}, ns)
+			h.NamespaceCache.Set(ctx, cache.ScopedKey{WorkspaceID: principal.AuthorizedWorkspaceID, Key: ns.ID}, ns)
 		} else {
 			// Race: re-fetch from the primary to avoid replica lag
 			row, fetchErr := db.Query.FindRatelimitNamespace(ctx, h.DB.RW(), db.FindRatelimitNamespaceParams{
-				WorkspaceID: principal.WorkspaceID,
+				WorkspaceID: principal.AuthorizedWorkspaceID,
 				Namespace:   name,
 			})
 			if fetchErr != nil {
@@ -433,8 +433,8 @@ func (h *Handler) createNamespaces(ctx context.Context, s *zen.Session, principa
 			}
 			ns := namespace.ParseNamespaceRow(row)
 			created[name] = ns
-			h.NamespaceCache.Set(ctx, cache.ScopedKey{WorkspaceID: principal.WorkspaceID, Key: name}, ns)
-			h.NamespaceCache.Set(ctx, cache.ScopedKey{WorkspaceID: principal.WorkspaceID, Key: ns.ID}, ns)
+			h.NamespaceCache.Set(ctx, cache.ScopedKey{WorkspaceID: principal.AuthorizedWorkspaceID, Key: name}, ns)
+			h.NamespaceCache.Set(ctx, cache.ScopedKey{WorkspaceID: principal.AuthorizedWorkspaceID, Key: ns.ID}, ns)
 		}
 	}
 

--- a/svc/api/routes/v2_ratelimit_set_override/handler.go
+++ b/svc/api/routes/v2_ratelimit_set_override/handler.go
@@ -65,7 +65,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	result, err := db.TxWithResultRetry(ctx, h.DB.RW(), func(ctx context.Context, tx db.DBTX) (setOverrideResult, error) {
 		var zero setOverrideResult
 		nsRow, txErr := db.Query.FindRatelimitNamespace(ctx, tx, db.FindRatelimitNamespaceParams{
-			WorkspaceID: principal.WorkspaceID,
+			WorkspaceID: principal.AuthorizedWorkspaceID,
 			Namespace:   req.Namespace,
 		})
 		if txErr != nil {
@@ -86,7 +86,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		}
 
 		override, txErr := db.Query.FindRatelimitOverrideByIdentifier(ctx, tx, db.FindRatelimitOverrideByIdentifierParams{
-			WorkspaceID: principal.WorkspaceID,
+			WorkspaceID: principal.AuthorizedWorkspaceID,
 			NamespaceID: nsRow.ID,
 			Identifier:  req.Identifier,
 		})
@@ -106,7 +106,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 		txErr = principal.Authorize(rbac.Or(
 			rbac.U(
-				urn.New().Workspace(principal.WorkspaceID).Project(nsRow.ProjectID).RatelimitNamespace(nsRow.ID).Override(ovrID),
+				urn.New().Workspace(principal.AuthorizedWorkspaceID).Project(nsRow.ProjectID).RatelimitNamespace(nsRow.ID).Override(ovrID),
 				permissions.Write,
 			),
 			rbac.T(rbac.Tuple{
@@ -128,7 +128,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 		txErr = db.Query.InsertRatelimitOverride(ctx, tx, db.InsertRatelimitOverrideParams{
 			ID:          ovrID,
-			WorkspaceID: principal.WorkspaceID,
+			WorkspaceID: principal.AuthorizedWorkspaceID,
 			NamespaceID: nsRow.ID,
 			Identifier:  req.Identifier,
 			Limit:       uint64(req.Limit),    // nolint:gosec
@@ -146,7 +146,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 		txErr = h.Auditlogs.Insert(ctx, tx, []auditlog.AuditLog{
 			{
-				WorkspaceID:   principal.WorkspaceID,
+				WorkspaceID:   principal.AuthorizedWorkspaceID,
 				Event:         auditlog.RatelimitSetOverrideEvent,
 				ActorID:       principal.Subject.ID,
 				ActorType:     auditlog.AuditLogActor(principal.Subject.Type),
@@ -183,8 +183,8 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 	// Invalidate cache for this namespace after the transaction commits
 	h.NamespaceCache.Remove(ctx,
-		cache.ScopedKey{WorkspaceID: principal.WorkspaceID, Key: result.namespaceID},
-		cache.ScopedKey{WorkspaceID: principal.WorkspaceID, Key: result.namespaceName},
+		cache.ScopedKey{WorkspaceID: principal.AuthorizedWorkspaceID, Key: result.namespaceID},
+		cache.ScopedKey{WorkspaceID: principal.AuthorizedWorkspaceID, Key: result.namespaceName},
 	)
 
 	return s.JSON(http.StatusOK, Response{


### PR DESCRIPTION
This should make it much harder in the future to accidentally use the principal's workspace ID for the wrong thing.

context on what happened: https://unkey.slack.com/archives/C05SYU6P2DC/p1788423135059549?thread_ts=1788398071.071159&cid=C05SYU6P2DC