### PR TITLE
fix(dashboard): standardize general settings spacing

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/general/page.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/general/page.tsx
@@ -22,7 +22,7 @@ export default function SettingsPage() {
           {/* <UpdateWorkspaceImage /> */}
           <CopyWorkspaceId workspaceId={workspace.id} />
         </div>
-        <div className="w-full flex flex-col mt-6">
+        <div className="w-full flex flex-col">
           <GithubConnection />
         </div>
       </PageBody>


### PR DESCRIPTION
Spacing fix

| Before: 44 px | After: 20 px |
| --- | --- |
| ![General settings before, with excess space above the GitHub card](https://ampcode.com/user-content/artifacts/dbc24211520051996769fd66701bf750c1e6a4b459e1cc26b4d651ad3525b8af-file.png) | ![General settings after, with the standard page section gap](https://ampcode.com/user-content/artifacts/49cc429c3887fa152c872ff2466315658e90621cf01c760792874404c21439d1-file.png) |

## How should this be tested?

1. Open **Settings → General**.
2. Confirm the GitHub card uses the same vertical spacing as other cards on the settings pages.
