### PR TITLE
feat(ui): Add an alert dialog and keep slide panels open under nested dialogs

### DIFF
--- a/web/internal/icons/src/icons/media-pause.tsx
+++ b/web/internal/icons/src/icons/media-pause.tsx
@@ -1,0 +1,54 @@
+/**
+ * Copyright © Nucleo
+ * Version 1.3, January 3, 2024
+ * Nucleo Icons
+ * https://nucleoapp.com/
+ * - Redistribution of icons is prohibited.
+ * - Icons are restricted for use only within the product they are bundled with.
+ *
+ * For more details:
+ * https://nucleoapp.com/license
+ */
+
+import { type IconProps, sizeMap } from "../props";
+
+export function MediaPause({ iconSize = "xl-thin", ...props }: IconProps) {
+  const { iconSize: pixelSize, strokeWidth } = sizeMap[iconSize];
+
+  return (
+    <svg
+      height={pixelSize}
+      width={pixelSize}
+      viewBox="0 0 18 18"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <rect
+        x="2.75"
+        y="2.75"
+        width="3.5"
+        height="12.5"
+        rx="1"
+        ry="1"
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+      <rect
+        x="11.75"
+        y="2.75"
+        width="3.5"
+        height="12.5"
+        rx="1"
+        ry="1"
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+    </svg>
+  );
+}

--- a/web/internal/icons/src/index.ts
+++ b/web/internal/icons/src/index.ts
@@ -120,6 +120,7 @@ export * from "./icons/lock";
 export * from "./icons/magnifier";
 export * from "./icons/math-function";
 export * from "./icons/maximize";
+export * from "./icons/media-pause";
 export * from "./icons/menu";
 export * from "./icons/message-writing";
 export * from "./icons/minus";

--- a/web/internal/ui/src/components/card.tsx
+++ b/web/internal/ui/src/components/card.tsx
@@ -10,7 +10,7 @@ function Card({
   return (
     <div
       ref={ref}
-      className={cn("w-full rounded-lg border bg-background border-border ", className)}
+      className={cn("w-full rounded-lg border border-gray-4 bg-background", className)}
       {...props}
     />
   );
@@ -64,7 +64,7 @@ function CardFooter({
   return (
     <div
       ref={ref}
-      className={cn(" flex items-center px-6 py-3 mt-3 border-t border-border", className)}
+      className={cn("flex items-center px-6 py-3 mt-3 border-t border-gray-4", className)}
       {...props}
     />
   );

--- a/web/internal/ui/src/components/dialog/alert-dialog.tsx
+++ b/web/internal/ui/src/components/dialog/alert-dialog.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { AlertDialog as AlertDialogPrimitive } from "@base-ui/react/alert-dialog";
+// biome-ignore lint/style/useImportType: the package compiles JSX with the classic runtime, so React must be in scope as a value.
+import * as React from "react";
+import { cn } from "../../lib/utils";
+import { Button, type ButtonProps } from "../buttons/button";
+
+function AlertDialog(props: AlertDialogPrimitive.Root.Props) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />;
+}
+
+function AlertDialogTrigger(props: AlertDialogPrimitive.Trigger.Props) {
+  return <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />;
+}
+
+function AlertDialogOverlay({ className, ...props }: AlertDialogPrimitive.Backdrop.Props) {
+  return (
+    <AlertDialogPrimitive.Backdrop
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "fixed inset-0 z-52 bg-black/30 backdrop-blur-xs duration-100 transition-opacity",
+        "data-starting-style:opacity-0 data-ending-style:opacity-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogContent({
+  className,
+  size = "default",
+  ...props
+}: AlertDialogPrimitive.Popup.Props & { size?: "default" | "sm" }) {
+  return (
+    <AlertDialogPrimitive.Portal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Popup
+        data-slot="alert-dialog-content"
+        data-size={size}
+        className={cn(
+          "group/alert-dialog-content fixed top-1/2 left-1/2 z-53 grid w-full -translate-x-1/2 -translate-y-1/2",
+          "gap-4 rounded-xl bg-background p-6 text-gray-12 ring-1 ring-gray-5 shadow-lg outline-none",
+          "duration-100 transition-[opacity,scale,translate] motion-reduce:transition-none",
+          "data-starting-style:opacity-0 data-starting-style:scale-95",
+          "data-ending-style:opacity-0 data-ending-style:scale-95",
+          "data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-md",
+          className,
+        )}
+        {...props}
+      />
+    </AlertDialogPrimitive.Portal>
+  );
+}
+
+function AlertDialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn(
+        "grid grid-rows-[auto_1fr] place-items-center gap-1.5 text-center",
+        "has-data-[slot=alert-dialog-media]:grid-rows-[auto_auto_1fr] has-data-[slot=alert-dialog-media]:gap-x-4",
+        "sm:group-data-[size=default]/alert-dialog-content:place-items-start",
+        "sm:group-data-[size=default]/alert-dialog-content:text-left",
+        "sm:group-data-[size=default]/alert-dialog-content:has-data-[slot=alert-dialog-media]:grid-rows-[auto_1fr]",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "-mx-6 -mb-6 flex flex-col-reverse gap-2 rounded-b-xl border-t border-gray-5 bg-grayA-1 px-6 py-4",
+        "group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2",
+        "sm:flex-row sm:justify-end",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogTitle({ className, ...props }: AlertDialogPrimitive.Title.Props) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn(
+        "text-[18px] font-semibold leading-tight tracking-tight text-gray-12",
+        "sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogDescription({ className, ...props }: AlertDialogPrimitive.Description.Props) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn(
+        "text-[13px] leading-5 text-balance text-gray-11 md:text-pretty",
+        "*:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-gray-12",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogMedia({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-media"
+      className={cn(
+        "mb-2 inline-flex size-16 items-center justify-center rounded-md bg-grayA-3",
+        "sm:group-data-[size=default]/alert-dialog-content:row-span-2",
+        "*:[svg:not([class*='size-'])]:size-8",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+type AlertDialogButtonProps = AlertDialogPrimitive.Close.Props &
+  Pick<ButtonProps, "variant" | "size" | "color" | "loading">;
+
+function AlertDialogAction({
+  variant = "primary",
+  size = "md",
+  color,
+  loading,
+  ...props
+}: AlertDialogButtonProps) {
+  return (
+    <AlertDialogPrimitive.Close
+      data-slot="alert-dialog-action"
+      render={<Button variant={variant} size={size} color={color} loading={loading} />}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogCancel({
+  variant = "ghost",
+  size = "md",
+  color,
+  loading,
+  ...props
+}: AlertDialogButtonProps) {
+  return (
+    <AlertDialogPrimitive.Close
+      data-slot="alert-dialog-cancel"
+      render={<Button variant={variant} size={size} color={color} loading={loading} />}
+      {...props}
+    />
+  );
+}
+
+export {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogOverlay,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+};

--- a/web/internal/ui/src/components/slide-panel.tsx
+++ b/web/internal/ui/src/components/slide-panel.tsx
@@ -35,10 +35,17 @@ export function SlidePanel({
       open={isOpen}
       modal={false}
       disablePointerDismissal
-      onOpenChange={(open) => {
-        if (!open) {
-          onClose();
+      onOpenChange={(open, eventDetails) => {
+        if (open) {
+          return;
         }
+        // Opening a dialog from inside the panel moves focus out of it, which Base UI reports
+        // as a dismissal. The panel should outlive anything it opens.
+        if (eventDetails.reason === "focus-out") {
+          eventDetails.cancel();
+          return;
+        }
+        onClose();
       }}
       onOpenChangeComplete={(open) => {
         if (!open) {

--- a/web/internal/ui/src/index.ts
+++ b/web/internal/ui/src/index.ts
@@ -13,6 +13,7 @@ export * from "./components/code";
 export * from "./components/logs/control-cloud";
 export * from "./validation/utils/transform-structured-output-filter-format";
 export * from "./components/date-time/date-time";
+export * from "./components/dialog/alert-dialog";
 export * from "./components/dialog/dialog";
 export * from "./components/dialog/dialog-container";
 export * from "./components/dialog/confirmation-popover";


### PR DESCRIPTION
## What does this PR do?

Adds `AlertDialog` to `@unkey/ui`: shadcn's alert dialog on Base UI's primitive.

Fixed an issue with `SlidePanel` so that it no longer closes when a dialog opened from inside it takes focus.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

Open any slide panel that opens a dialog from inside it (log drain settings, once the stack lands) and confirm the panel stays open while the dialog is up and closes normally afterwards. Check a few `Card` surfaces (team members, projects list) for the border change. Not tested: other `SlidePanel` consumers (policy form, env vars, node details) were not clicked through.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary

_Screenshots to be added: light, dark._