### PR TITLE
fix(dev): bump the dev image Go toolchain to match go.mod

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-FROM golang:1.25.1-alpine@sha256:b6ed3fd0452c0e9bcdef5597f29cc1418f61672e9d3a2f55bf02e7222c014abd AS builder
+FROM golang:1.25.10-alpine@sha256:8d22e29d960bc50cd025d93d5b7c7d220b1ee9aa7a239b3c8f55a57e987e8d45 AS builder
 
 WORKDIR /src
 ENV CGO_ENABLED=0


### PR DESCRIPTION
go.mod has required go >= 1.25.10 since #7200, but dev/Dockerfile still pinned 1.25.1, so `docker compose build` failed with a GOTOOLCHAIN error and the local api/ctrl/vault images could not be rebuilt at all.
