### PR TITLE
fix(dashboard): show searched permission details

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/authorization/roles/components/upsert-role/components/assign-permission/permissions-field.test.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/authorization/roles/components/upsert-role/components/assign-permission/permissions-field.test.tsx
@@ -1,0 +1,99 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ChangeEvent, ReactNode } from "react";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { PermissionField } from "./permissions-field";
+
+const mocks = vi.hoisted(() => ({
+  searchedPermission: {
+    id: "perm_billing",
+    name: "Manage Billing",
+    slug: "billing.manage",
+    description: "Manage billing settings",
+    roles: [],
+  },
+}));
+
+vi.mock("@/components/roles-table/hooks/use-role-limits", () => ({
+  useRoleLimits: () => ({
+    calculateLimits: () => ({ hasPermWarning: false, totalPerms: 0 }),
+  }),
+}));
+
+vi.mock("./hooks/use-fetch-permissions", () => ({
+  useFetchPermissions: () => ({
+    permissions: [],
+    isFetchingNextPage: false,
+    hasNextPage: false,
+    loadMore: vi.fn(),
+    isLoading: false,
+  }),
+}));
+
+vi.mock("./hooks/use-search-permissions", () => ({
+  useSearchPermissions: (query: string) => ({
+    searchResults: query ? [mocks.searchedPermission] : [],
+    isSearching: false,
+  }),
+}));
+
+vi.mock("@/components/ui/form-combobox", () => ({
+  FormCombobox: ({
+    onChange,
+    onSelect,
+  }: {
+    onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+    onSelect: (value: string) => void;
+  }) => (
+    <div>
+      <input aria-label="Search permissions" onChange={onChange} />
+      <button type="button" onClick={() => onSelect(mocks.searchedPermission.id)}>
+        Select permission
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock("@/components/selected-item-list", () => ({
+  SelectedItemsList: ({
+    items,
+    renderPrimaryText,
+    renderSecondaryText,
+  }: {
+    items: Array<{ id: string; name: string; slug: string | null }>;
+    renderPrimaryText: (item: { id: string; name: string; slug: string | null }) => ReactNode;
+    renderSecondaryText: (item: { id: string; name: string; slug: string | null }) => ReactNode;
+  }) => (
+    <div>
+      {items.map((item) => (
+        <div key={item.id}>
+          <span>{renderPrimaryText(item)}</span>
+          <span>{renderSecondaryText(item)}</span>
+        </div>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock("../warning-callout", () => ({ RoleWarningCallout: () => null }));
+
+describe("PermissionField", () => {
+  it("keeps permission details after clearing a search", () => {
+    const TestField = () => {
+      const [value, setValue] = useState<string[]>([]);
+
+      return <PermissionField value={value} onChange={setValue} assignedPermsDetails={[]} />;
+    };
+
+    render(<TestField />);
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Search permissions" }), {
+      target: { value: "billing" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Select permission" }));
+
+    expect(screen.getByText("Manage Billing")).not.toBeNull();
+    expect(screen.getByText("billing.manage")).not.toBeNull();
+    expect(screen.queryByText("Unnamed Permission")).toBeNull();
+  });
+});

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/authorization/roles/components/upsert-role/components/assign-permission/permissions-field.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/authorization/roles/components/upsert-role/components/assign-permission/permissions-field.tsx
@@ -26,6 +26,7 @@ export const PermissionField = ({
   assignedPermsDetails,
 }: PermissionFieldProps) => {
   const [searchValue, setSearchValue] = useState("");
+  const [selectedPermissionDetails, setSelectedPermissionDetails] = useState<RolePermission[]>([]);
 
   const { calculateLimits } = useRoleLimits(roleId);
   const { hasPermWarning, totalPerms } = calculateLimits(value);
@@ -91,7 +92,6 @@ export const PermissionField = ({
   const selectedPermissions = useMemo(() => {
     return value
       .map((permId) => {
-        // First: check selectedPermissionsData (for pre-loaded edit data)
         const preLoadedPerm = assignedPermsDetails.find((p) => p.id === permId);
         if (preLoadedPerm) {
           return {
@@ -101,13 +101,16 @@ export const PermissionField = ({
           };
         }
 
-        // Second: check loaded permissions (for newly added permissions)
+        const selectedPermission = selectedPermissionDetails.find((p) => p.id === permId);
+        if (selectedPermission) {
+          return selectedPermission;
+        }
+
         const loadedPerm = allPermissions.find((p) => p.id === permId);
         if (loadedPerm) {
           return loadedPerm;
         }
 
-        // Third: fallback
         return {
           id: permId,
           name: null,
@@ -115,14 +118,24 @@ export const PermissionField = ({
         };
       })
       .filter((perm): perm is NonNullable<typeof perm> => perm !== undefined);
-  }, [value, allPermissions, assignedPermsDetails]);
+  }, [value, allPermissions, assignedPermsDetails, selectedPermissionDetails]);
 
   const handleRemovePermission = (permissionId: string) => {
+    setSelectedPermissionDetails((permissions) =>
+      permissions.filter((permission) => permission.id !== permissionId),
+    );
     onChange(value.filter((id) => id !== permissionId));
   };
 
   const handleAddPermission = (permissionId: string) => {
     if (!value.includes(permissionId)) {
+      const permission = allPermissions.find((item) => item.id === permissionId);
+      if (permission) {
+        setSelectedPermissionDetails((permissions) => [
+          ...permissions.filter((item) => item.id !== permission.id),
+          permission,
+        ]);
+      }
       onChange([...value, permissionId]);
     }
     setSearchValue("");
@@ -187,7 +200,6 @@ export const PermissionField = ({
             renderIcon={() => <Page2 iconSize="sm-regular" className="text-grayA-11" />}
             renderPrimaryText={(permission) => permission.name}
             enableTransitions
-            // This can't cannot happen but we need it to make TS happy
             renderSecondaryText={(permission) => permission.slug ?? "Unnamed Slug"}
           />
         )


### PR DESCRIPTION
## Problem:

When creating a role and attaching a permission it appeared as "Unnamed Permission" with an "Unnamed Slug."

## Solution:

The role form now keeps the selected permission name and slug after the search clears. 
A regression test covers selection from search results that are not in the initial permission list.

**Before**

![Selected permission displayed without its name or slug](https://ampcode.com/user-content/artifacts/6c964a9a8e73408cfac67dc2fa7bdc72a6f19504dce0cdf4d2936d268d2151e6-file.png)

**After**

![Selected permission displayed with its name and slug](https://ampcode.com/user-content/artifacts/53943d93106f03553b0835be2c8df62d17b9974802f6b5de67140972ec329042-file.png)

## Impact:

Users who assign permissions to roles can confirm the selected permission before they save the role. The change does not affect API contracts or stored role data.

## Testing:

- Focused Vitest regression test passed.
- Dashboard TypeScript check passed.
- Biome check passed.
- Browser verification passed on the local Authorization roles page. The selected card showed "Billing" and `billing.manage`, and the browser reported no uncaught errors.
