### PR TITLE
chore(db): add project-scoped permission index

### DIFF
--- a/pkg/mysql/schema/permissions.sql
+++ b/pkg/mysql/schema/permissions.sql
@@ -10,7 +10,10 @@ CREATE TABLE `permissions` (
 	`updated_at_m` bigint,
 	CONSTRAINT `permissions_pk` PRIMARY KEY(`pk`),
 	CONSTRAINT `permissions_id_unique` UNIQUE(`id`),
-	CONSTRAINT `unique_slug_per_workspace_idx` UNIQUE(`workspace_id`,`slug`)
+	CONSTRAINT `unique_slug_per_workspace_idx` UNIQUE(`workspace_id`,`slug`),
+	CONSTRAINT `unique_slug_per_project_idx` UNIQUE(`project_id`,`slug`)
 );
+
+CREATE INDEX `permissions_workspace_id_idx` ON `permissions` (`workspace_id`);
 
 CREATE INDEX `permissions_project_id_idx` ON `permissions` (`project_id`);

--- a/web/internal/db/src/schema/rbac.ts
+++ b/web/internal/db/src/schema/rbac.ts
@@ -24,6 +24,8 @@ export const permissions = mysqlTable(
   },
   (table) => [
     unique("unique_slug_per_workspace_idx").on(table.workspaceId, table.slug),
+    unique("unique_slug_per_project_idx").on(table.projectId, table.slug),
+    index("permissions_workspace_id_idx").on(table.workspaceId),
     index("permissions_project_id_idx").on(table.projectId),
   ],
 );


### PR DESCRIPTION
## Notes for description (rewrite before review)

- Goal: Add project-scoped permission slug uniqueness before removing workspace-scoped uniqueness.
- Add `UNIQUE(project_id, slug)`.
- Keep `UNIQUE(workspace_id, slug)` during the transition.
- Add regular indexes for `workspace_id` and `project_id` lookups.
- Trade-off: Permission slugs must stay unique across a workspace until the final stack PR removes the old unique index.
- Verification: `mise run generate-sql` and `mise run build` passed.
- Stack: First PR. Base this PR on `main`.
