### PR TITLE
chore(db): add project-scoped role index

### DIFF
--- a/pkg/mysql/schema/roles.sql
+++ b/pkg/mysql/schema/roles.sql
@@ -9,7 +9,8 @@ CREATE TABLE `roles` (
 	`updated_at_m` bigint,
 	CONSTRAINT `roles_pk` PRIMARY KEY(`pk`),
 	CONSTRAINT `roles_id_unique` UNIQUE(`id`),
-	CONSTRAINT `unique_name_per_workspace_idx` UNIQUE(`name`,`workspace_id`)
+	CONSTRAINT `unique_name_per_workspace_idx` UNIQUE(`name`,`workspace_id`),
+	CONSTRAINT `unique_name_per_project_idx` UNIQUE(`project_id`,`name`)
 );
 
 CREATE INDEX `workspace_id_idx` ON `roles` (`workspace_id`);

--- a/web/internal/db/src/schema/rbac.ts
+++ b/web/internal/db/src/schema/rbac.ts
@@ -96,6 +96,7 @@ export const roles = mysqlTable(
   (table) => [
     index("workspace_id_idx").on(table.workspaceId),
     unique("unique_name_per_workspace_idx").on(table.name, table.workspaceId),
+    unique("unique_name_per_project_idx").on(table.projectId, table.name),
     index("roles_project_id_idx").on(table.projectId),
   ],
 );


### PR DESCRIPTION
## Notes for description (rewrite before review)

- Goal: Add the project-scoped role name index before removing the current workspace-scoped index.
- Decisions: Keep `unique_name_per_workspace_idx`. Add `UNIQUE(project_id, name)`. Keep the existing regular `workspace_id` index.
- Trade-offs: Both unique indexes remain active. Role names must stay unique across each workspace until a later PR removes the old index. Validate and backfill `project_id` before applying the new unique index.
- Verification: `mise run generate-sql` and `mise run build` passed.
- Stack: Second PR. Base this PR on the permission index branch from #7280.