### PR TITLE
feat(dashboard): Prototype app-level Metrics tab (DO NOT MERGE)

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/metrics/components/controls.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/metrics/components/controls.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import type { Environment } from "@/lib/collections/deploy/environments";
+import { APP_METRICS_WINDOWS, type AppMetricsWindow } from "@unkey/clickhouse";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@unkey/ui";
+import { cn } from "@unkey/ui/src/lib/utils";
+import { WINDOW_LABELS } from "../lib/series";
+
+export function EnvironmentSelect({
+  environments,
+  value,
+  onChange,
+}: {
+  environments: Environment[];
+  value: string;
+  onChange: (id: string) => void;
+}) {
+  return (
+    <Select value={value} onValueChange={(v) => v && onChange(v)}>
+      <SelectTrigger wrapperClassName="w-fit" className="h-8 min-w-[160px] text-[13px]">
+        <SelectValue>
+          {(v: string) => (
+            <span className="flex items-center gap-2">
+              <span className="size-2 rounded-full bg-success-9" />
+              <span className="capitalize">
+                {environments.find((e) => e.id === v)?.slug ?? "Environment"}
+              </span>
+            </span>
+          )}
+        </SelectValue>
+      </SelectTrigger>
+      <SelectContent>
+        {environments.map((e) => (
+          <SelectItem key={e.id} value={e.id} className="capitalize text-[13px]">
+            {e.slug}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
+// Quick range pills.
+export function WindowPills({
+  value,
+  onChange,
+}: {
+  value: AppMetricsWindow;
+  onChange: (w: AppMetricsWindow) => void;
+}) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Time range"
+      className="inline-flex h-8 items-center rounded-md border border-grayA-4 bg-grayA-2 p-0.5"
+    >
+      {APP_METRICS_WINDOWS.map((w) => {
+        const active = w === value;
+        return (
+          <button
+            key={w}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            onClick={() => onChange(w)}
+            className={cn(
+              "h-7 px-2.5 rounded-[5px] text-[12px] font-medium tabular-nums transition-colors",
+              active
+                ? "bg-gray-1 text-gray-12 shadow-sm border border-grayA-4"
+                : "text-gray-11 hover:text-gray-12",
+            )}
+          >
+            {WINDOW_LABELS[w].short}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+// Range dropdown.
+export function WindowSelect({
+  value,
+  onChange,
+}: {
+  value: AppMetricsWindow;
+  onChange: (w: AppMetricsWindow) => void;
+}) {
+  return (
+    <Select value={value} onValueChange={(v) => v && onChange(v as AppMetricsWindow)}>
+      <SelectTrigger wrapperClassName="w-fit" className="h-8 min-w-[150px] text-[13px]">
+        <SelectValue>{(v: AppMetricsWindow) => WINDOW_LABELS[v]?.long ?? v}</SelectValue>
+      </SelectTrigger>
+      <SelectContent>
+        {APP_METRICS_WINDOWS.map((w) => (
+          <SelectItem key={w} value={w} className="text-[13px]">
+            {WINDOW_LABELS[w].long}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
+export function Legend({
+  items,
+}: {
+  items: { label: string; color: string; value?: string }[];
+}) {
+  return (
+    <div className="flex items-center gap-3 flex-wrap">
+      {items.map((it) => (
+        <div key={it.label} className="flex items-center gap-1.5 text-[11px] text-gray-11">
+          <span className="size-2 rounded-[2px]" style={{ backgroundColor: it.color }} />
+          <span>{it.label}</span>
+          {it.value && <span className="font-mono tabular-nums text-gray-12">{it.value}</span>}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/metrics/components/deployment-picker.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/metrics/components/deployment-picker.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { CodeCommit } from "@unkey/icons";
+import {
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxIcon,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxItemIndicator,
+  ComboboxList,
+  ComboboxRoot,
+  ComboboxTrigger,
+} from "@unkey/ui";
+import { cn } from "@unkey/ui/src/lib/utils";
+import { useMemo, useState } from "react";
+import type { DeploymentInfo } from "../hooks/use-app-metrics";
+import { shortSha } from "../lib/series";
+
+type Props = {
+  deployments: DeploymentInfo[];
+  colorOf: (id: string) => string;
+  selected: string[];
+  onChange: (ids: string[]) => void;
+  inRange: (d: DeploymentInfo) => boolean;
+};
+
+// Top-line multi-select. Nothing picked means the charts show the app total
+// with a marker for every deploy in range. Picking deployments splits every
+// chart into one series per pick and keeps only their markers, so two
+// releases can be compared side by side.
+export function DeploymentPicker({ deployments, colorOf, selected, onChange, inRange }: Props) {
+  const [query, setQuery] = useState("");
+  const byId = useMemo(() => new Map(deployments.map((d) => [d.id, d])), [deployments]);
+  const items = useMemo(() => deployments.map((d) => d.id), [deployments]);
+  const picked = selected.map((id) => byId.get(id)).filter((d): d is DeploymentInfo => !!d);
+
+  const filter = (id: string, q: string) => {
+    const d = byId.get(id);
+    if (!d) {
+      return false;
+    }
+    const haystack = `${d.sha ?? ""} ${d.message ?? ""} ${d.branch} ${d.status}`.toLowerCase();
+    return haystack.includes(q.trim().toLowerCase());
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <ComboboxRoot<string, true>
+        multiple
+        items={items}
+        filter={filter}
+        value={selected}
+        onValueChange={(next) => onChange(next)}
+        inputValue={query}
+        onInputValueChange={setQuery}
+      >
+        <ComboboxTrigger className="h-8 w-auto min-w-[200px] max-w-[520px] text-[13px] [&_svg]:size-3">
+          <CodeCommit iconSize="sm-regular" className="text-gray-11 shrink-0" />
+          {picked.length === 0 ? (
+            <span className="text-gray-11">All deployments</span>
+          ) : (
+            <span className="flex items-center gap-1.5 min-w-0">
+              {picked.slice(0, 3).map((d) => (
+                <span
+                  key={d.id}
+                  className="inline-flex items-center gap-1.5 h-5 px-1.5 rounded bg-grayA-3 text-[12px] text-gray-12 max-w-[160px]"
+                >
+                  <span
+                    className="size-1.5 rounded-full shrink-0"
+                    style={{ backgroundColor: colorOf(d.id) }}
+                  />
+                  <span className="font-mono">{shortSha(d.sha) || d.id.slice(-7)}</span>
+                </span>
+              ))}
+              {picked.length > 3 && (
+                <span className="text-[12px] text-gray-11">+{picked.length - 3}</span>
+              )}
+            </span>
+          )}
+          <ComboboxIcon className="ml-auto" />
+        </ComboboxTrigger>
+        <ComboboxContent className="w-[440px]" align="start">
+          <div className="p-1">
+            <ComboboxInput placeholder="Search deployments…" />
+          </div>
+          <ComboboxEmpty>No deployments match.</ComboboxEmpty>
+          <ComboboxList>
+            {(id: string) => {
+              const d = byId.get(id);
+              if (!d) {
+                return null;
+              }
+              const dim = !inRange(d);
+              return (
+                <ComboboxItem key={id} value={id} className="gap-2.5">
+                  <span
+                    className="size-2 rounded-full shrink-0"
+                    style={{ backgroundColor: colorOf(id) }}
+                  />
+                  <span className="font-mono text-gray-12 shrink-0">
+                    {shortSha(d.sha) || id.slice(-7)}
+                  </span>
+                  <span className={cn("truncate", dim ? "text-gray-10" : "text-gray-11")}>
+                    {d.message ?? id}
+                  </span>
+                  <span className="ml-auto text-[11px] text-gray-9 tabular-nums shrink-0 pl-2">
+                    {new Date(d.createdAt).toLocaleDateString(undefined, {
+                      month: "short",
+                      day: "numeric",
+                    })}
+                  </span>
+                  <ComboboxItemIndicator className="ml-2" />
+                </ComboboxItem>
+              );
+            }}
+          </ComboboxList>
+          {selected.length > 0 && (
+            <div className="border-t border-gray-4 p-1">
+              <button
+                type="button"
+                onClick={() => onChange([])}
+                className="w-full h-7 rounded-sm text-[12px] text-gray-11 hover:bg-grayA-3 hover:text-gray-12 transition-colors"
+              >
+                Clear selection
+              </button>
+            </div>
+          )}
+        </ComboboxContent>
+      </ComboboxRoot>
+    </div>
+  );
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/metrics/components/metrics-chart.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/metrics/components/metrics-chart.tsx
@@ -1,0 +1,307 @@
+"use client";
+
+import { ChartError } from "@/components/charts/components/chart-error";
+import { ChartWaveLoading } from "@/components/charts/components/chart-wave-loading";
+import { ChartEmpty } from "@/components/logs/chart/chart-states";
+import { type ChartConfig, ChartContainer, ChartTooltip } from "@/components/ui/chart";
+import { cn } from "@unkey/ui/src/lib/utils";
+import { useId } from "react";
+import {
+  Area,
+  Bar,
+  CartesianGrid,
+  ComposedChart,
+  Line,
+  ReferenceLine,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { type SeriesKey, type SeriesPoint, formatBucketLabel, formatTickTime } from "../lib/series";
+
+export type DeployMarker = { id: string; x: number; label: string; title?: string };
+
+type Props = {
+  points: SeriesPoint[];
+  series: SeriesKey[];
+  kind: "area" | "bar" | "line";
+  stacked?: boolean;
+  height?: number;
+  domain: [number, number];
+  bucketSeconds: number;
+  markers?: DeployMarker[];
+  showMarkerLabels?: boolean;
+  formatValue: (v: number) => string;
+  formatTick?: (v: number) => string;
+  isLoading?: boolean;
+  isError?: boolean;
+  showAxes?: boolean;
+  yMax?: number;
+  className?: string;
+  emptyMessage?: string;
+  // Charts sharing a syncId show the hover cursor and tooltip at the same
+  // time across all of them. Sparklines pass none.
+  syncId?: string;
+};
+
+const Y_GUTTER_PX = 40;
+
+// One chart for all seven metrics. The kind decides the mark, the series list
+// decides colours, and the marker list draws the deploy lines that every chart
+// on the page shares, so a spike and the deploy that preceded it line up in
+// the same x position across cards.
+export function MetricsChart({
+  points,
+  series,
+  kind,
+  stacked,
+  height = 180,
+  domain,
+  bucketSeconds,
+  markers = [],
+  showMarkerLabels = true,
+  formatValue,
+  formatTick,
+  isLoading,
+  isError,
+  showAxes = true,
+  yMax,
+  className,
+  emptyMessage = "No data in this range",
+  syncId,
+}: Props) {
+  const chartId = useId().replace(/:/g, "");
+
+  if (isError) {
+    return <ChartError height={height} />;
+  }
+  const primaryColor = series[0]?.color;
+  if (isLoading) {
+    return <ChartWaveLoading height={height} color={primaryColor} />;
+  }
+  const keys = series.map((s) => s.key);
+  const hasData = points.some((p) => keys.some((k) => (p[k] ?? 0) > 0));
+  if (!hasData) {
+    return (
+      <ChartEmpty variant="wave" color={primaryColor} height={height} message={emptyMessage} />
+    );
+  }
+
+  const config: ChartConfig = Object.fromEntries(
+    series.map((s) => [s.key, { label: s.label, color: s.color }]),
+  );
+
+  const observedMax = points.reduce((m, p) => {
+    if (stacked) {
+      return Math.max(
+        m,
+        keys.reduce((sum, k) => sum + (p[k] ?? 0), 0),
+      );
+    }
+    return Math.max(m, ...keys.map((k) => p[k] ?? 0));
+  }, 0);
+  const top = yMax ?? observedMax * 1.15;
+  const yTicks = [0, top / 3, (2 * top) / 3, top];
+  const spanMs = domain[1] - domain[0];
+  const xTicks = [0, 1, 2, 3, 4].map((i) => Math.round(domain[0] + (i * spanMs) / 4));
+  const tickFormatter = formatTick ?? formatValue;
+  const bucketMs = bucketSeconds * 1000;
+
+  return (
+    <ChartContainer
+      config={config}
+      className={cn("!flex-col aspect-auto w-full", className)}
+      style={{ height, width: "100%" }}
+    >
+      <ComposedChart
+        data={points}
+        syncId={syncId}
+        syncMethod="value"
+        margin={
+          showAxes
+            ? { top: 12, right: 8, bottom: 0, left: 0 }
+            : { top: 4, right: 0, bottom: 0, left: 0 }
+        }
+        barCategoryGap={1}
+      >
+        <defs>
+          {series.map((s) => (
+            <linearGradient key={s.key} id={`${chartId}-${s.key}`} x1="0" y1="0" x2="0" y2="1">
+              <stop
+                offset="0%"
+                stopColor={s.color}
+                stopOpacity={kind === "bar" ? 0.9 : stacked ? 0.55 : 0.35}
+              />
+              <stop
+                offset="100%"
+                stopColor={s.color}
+                stopOpacity={kind === "bar" ? 0.45 : stacked ? 0.25 : 0.03}
+              />
+            </linearGradient>
+          ))}
+        </defs>
+        {showAxes && (
+          <CartesianGrid
+            vertical={false}
+            stroke="hsl(var(--gray-4))"
+            strokeDasharray="3 3"
+            strokeOpacity={0.6}
+          />
+        )}
+        <XAxis
+          dataKey="x"
+          type="number"
+          scale="time"
+          domain={[domain[0], domain[1]]}
+          allowDataOverflow
+          ticks={xTicks}
+          tickFormatter={(v: number) => formatTickTime(v, spanMs)}
+          tick={showAxes ? { fill: "hsl(var(--gray-10))", fontSize: 10 } : false}
+          tickLine={false}
+          axisLine={false}
+          minTickGap={40}
+          hide={!showAxes}
+        />
+        <YAxis
+          width={showAxes ? Y_GUTTER_PX : 0}
+          domain={[0, top]}
+          ticks={yTicks}
+          tickFormatter={(v: number) => (v <= 0 ? "" : tickFormatter(v))}
+          tick={showAxes ? { fill: "hsl(var(--gray-10))", fontSize: 10 } : false}
+          tickLine={false}
+          axisLine={false}
+          hide={!showAxes}
+        />
+        <ChartTooltip
+          allowEscapeViewBox={{ x: false, y: true }}
+          wrapperStyle={{ zIndex: 1000, pointerEvents: "none" }}
+          cursor={
+            kind === "bar"
+              ? { fill: "hsl(var(--accent-3))", fillOpacity: 0.4 }
+              : {
+                  stroke: "hsl(var(--accent-9))",
+                  strokeWidth: 1,
+                  strokeDasharray: "3 3",
+                  strokeOpacity: 0.5,
+                }
+          }
+          content={({ active, payload }) => {
+            if (!active || !payload?.length) {
+              return null;
+            }
+            const point = payload[0]?.payload as SeriesPoint | undefined;
+            if (!point) {
+              return null;
+            }
+            const rows = series
+              .map((s) => ({ ...s, value: point[s.key] ?? 0 }))
+              .sort((a, b) => b.value - a.value);
+            const deploysHere = markers.filter((m) => m.x >= point.x && m.x < point.x + bucketMs);
+            return (
+              <div
+                role="tooltip"
+                className="grid items-start gap-1.5 rounded-xl border border-gray-4/50 bg-gray-1/80 backdrop-blur-md px-3 py-2.5 text-xs shadow-2xl select-none w-max max-w-[280px]"
+              >
+                <div className="font-medium text-[11px] text-accent-11">
+                  {formatBucketLabel(point.x, bucketSeconds)}
+                </div>
+                <div className="grid gap-1">
+                  {rows.map((r) => (
+                    <div key={r.key} className="flex items-center gap-2">
+                      <div
+                        className="shrink-0 rounded-[2px] h-2 w-2"
+                        style={{ backgroundColor: r.color }}
+                      />
+                      <span className="text-accent-12 truncate max-w-[150px]">{r.label}</span>
+                      <span className="font-mono tabular-nums text-accent-12 ml-auto">
+                        {formatValue(r.value)}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+                {deploysHere.length > 0 && (
+                  <div className="border-t border-gray-4 pt-1.5 mt-0.5 grid gap-0.5">
+                    {deploysHere.map((m) => (
+                      <div key={`${m.x}-${m.label}`} className="flex items-center gap-2">
+                        <span className="text-[10px] text-gray-11">Deployed</span>
+                        <span className="font-mono text-[11px] text-gray-12">{m.label}</span>
+                        {m.title && (
+                          <span className="text-[11px] text-gray-11 truncate max-w-[160px]">
+                            {m.title}
+                          </span>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            );
+          }}
+        />
+        {series.map((s) => {
+          if (kind === "bar") {
+            return (
+              <Bar
+                key={s.key}
+                dataKey={s.key}
+                stackId={stacked ? "stack" : undefined}
+                fill={`url(#${chartId}-${s.key})`}
+                stroke={s.color}
+                strokeWidth={0}
+                isAnimationActive={false}
+              />
+            );
+          }
+          if (kind === "line") {
+            return (
+              <Line
+                key={s.key}
+                dataKey={s.key}
+                type="monotone"
+                stroke={s.color}
+                strokeWidth={1.5}
+                dot={false}
+                isAnimationActive={false}
+              />
+            );
+          }
+          return (
+            <Area
+              key={s.key}
+              dataKey={s.key}
+              type="monotone"
+              stackId={stacked ? "stack" : undefined}
+              stroke={s.color}
+              strokeWidth={stacked ? 0.75 : 1.5}
+              fill={`url(#${chartId}-${s.key})`}
+              fillOpacity={1}
+              dot={false}
+              isAnimationActive={false}
+            />
+          );
+        })}
+        {markers.map((m) => (
+          <ReferenceLine
+            key={`${m.x}-${m.label}`}
+            x={m.x}
+            stroke="hsl(var(--gray-9))"
+            strokeDasharray="2 3"
+            strokeWidth={1}
+            ifOverflow="hidden"
+            label={
+              showMarkerLabels && showAxes
+                ? {
+                    value: m.label,
+                    position: "insideTopLeft",
+                    fill: "hsl(var(--gray-10))",
+                    fontSize: 9,
+                    fontFamily: "ui-monospace, monospace",
+                    offset: 6,
+                  }
+                : undefined
+            }
+          />
+        ))}
+      </ComposedChart>
+    </ChartContainer>
+  );
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/metrics/components/proto-picker.css
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/metrics/components/proto-picker.css
@@ -1,0 +1,96 @@
+.proto-picker {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 2147483647;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 4px;
+  border-radius: 999px;
+  background: rgba(10, 10, 10, 0.82);
+  -webkit-backdrop-filter: blur(12px) saturate(1.4);
+  backdrop-filter: blur(12px) saturate(1.4);
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.08) inset,
+    0 8px 24px rgba(0, 0, 0, 0.24),
+    0 2px 6px rgba(0, 0, 0, 0.12);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 13px;
+  line-height: 1;
+  -webkit-font-smoothing: antialiased;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.proto-picker-highlight {
+  position: absolute;
+  top: 4px;
+  left: 0;
+  height: 28px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.12);
+  will-change: transform;
+}
+
+.proto-picker[data-ready] .proto-picker-highlight {
+  transition:
+    transform 250ms cubic-bezier(0.23, 1, 0.32, 1),
+    width 250ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .proto-picker[data-ready] .proto-picker-highlight {
+    transition: none;
+  }
+}
+
+.proto-picker-item {
+  position: relative;
+  display: flex;
+  align-items: center;
+  height: 28px;
+  padding: 0 12px;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.55);
+  font: inherit;
+  cursor: pointer;
+  transition: color 150ms ease-out;
+}
+
+.proto-picker-item:hover {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.proto-picker-item:active {
+  transform: scale(0.97);
+}
+
+.proto-picker-item:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.4);
+  outline-offset: 2px;
+}
+
+.proto-picker-item[data-active] {
+  color: #fff;
+}
+
+.proto-picker-divider {
+  width: 1px;
+  height: 16px;
+  margin: 0 4px;
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.proto-picker-replay {
+  padding: 0 10px;
+  font-size: 14px;
+}
+
+.proto-picker[data-position="top"] {
+  bottom: auto;
+  top: 24px;
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/metrics/components/proto-picker.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/metrics/components/proto-picker.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import "./proto-picker.css";
+
+type Props = {
+  variants: string[];
+  active: number;
+  onChange: (index: number) => void;
+};
+
+export function ProtoPicker({ variants, active, onChange }: Props) {
+  const navRef = useRef<HTMLElement>(null);
+  const highlightRef = useRef<HTMLSpanElement>(null);
+  const itemRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const [ready, setReady] = useState(false);
+
+  const moveHighlight = useCallback(() => {
+    const el = itemRefs.current[active];
+    const highlight = highlightRef.current;
+    if (!el || !highlight) {
+      return;
+    }
+    highlight.style.width = `${el.offsetWidth}px`;
+    highlight.style.transform = `translateX(${el.offsetLeft}px)`;
+  }, [active]);
+
+  useLayoutEffect(() => {
+    moveHighlight();
+  }, [moveHighlight]);
+
+  useEffect(() => {
+    window.addEventListener("resize", moveHighlight);
+    const raf = requestAnimationFrame(() => requestAnimationFrame(() => setReady(true)));
+    return () => {
+      window.removeEventListener("resize", moveHighlight);
+      cancelAnimationFrame(raf);
+    };
+  }, [moveHighlight]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (
+        target &&
+        (/^(INPUT|TEXTAREA|SELECT)$/.test(target.tagName) || target.isContentEditable)
+      ) {
+        return;
+      }
+      if (e.metaKey || e.ctrlKey || e.altKey) {
+        return;
+      }
+      const num = Number.parseInt(e.key, 10);
+      if (num >= 1 && num <= variants.length) {
+        onChange(num - 1);
+      } else if (e.key === "ArrowRight") {
+        onChange((active + 1) % variants.length);
+      } else if (e.key === "ArrowLeft") {
+        onChange((active - 1 + variants.length) % variants.length);
+      }
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [active, variants.length, onChange]);
+
+  return (
+    <nav
+      ref={navRef}
+      className="proto-picker"
+      aria-label="Prototype variants"
+      data-ready={ready ? "" : undefined}
+    >
+      <span ref={highlightRef} className="proto-picker-highlight" aria-hidden="true" />
+      {variants.map((name, i) => (
+        <button
+          key={name}
+          ref={(el) => {
+            itemRefs.current[i] = el;
+          }}
+          type="button"
+          className="proto-picker-item"
+          data-active={i === active ? "" : undefined}
+          aria-current={i === active ? "true" : undefined}
+          onClick={() => onChange(i)}
+        >
+          {name}
+        </button>
+      ))}
+    </nav>
+  );
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/metrics/hooks/use-app-metrics.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/metrics/hooks/use-app-metrics.ts
@@ -1,0 +1,160 @@
+"use client";
+
+import { ENVIRONMENT_KIND } from "@/lib/collections/deploy/environments";
+import { trpc } from "@/lib/trpc/client";
+import {
+  APP_METRICS_WINDOWS,
+  type AppMetricsGroup,
+  type AppMetricsWindow,
+  type AppResourceMetric,
+} from "@unkey/clickhouse";
+import type { Route } from "next";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useMemo } from "react";
+import { useAppId, useProjectData } from "../../data-provider";
+
+export type MetricsScope = {
+  appId: string;
+  environmentId: string;
+  window: AppMetricsWindow;
+  groupBy: AppMetricsGroup;
+};
+
+const REFETCH_MS = 30_000;
+
+function isWindow(value: string | null): value is AppMetricsWindow {
+  return value !== null && (APP_METRICS_WINDOWS as readonly string[]).includes(value);
+}
+
+// URL is the single source of truth for the page state so a link to a spike
+// carries the environment, window and variant with it.
+export function useMetricsUrlState() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const { environments, isEnvironmentsLoading } = useProjectData();
+  const appId = useAppId();
+
+  const appEnvironments = useMemo(
+    () => environments.filter((e) => e.appId === appId),
+    [environments, appId],
+  );
+
+  const requestedEnvironmentId = searchParams.get("environmentId");
+  const environmentId =
+    appEnvironments.find((e) => e.id === requestedEnvironmentId)?.id ??
+    appEnvironments.find((e) => e.kind === ENVIRONMENT_KIND.production)?.id ??
+    appEnvironments.at(0)?.id;
+
+  const rangeParam = searchParams.get("range");
+  const window: AppMetricsWindow = isWindow(rangeParam) ? rangeParam : "1w";
+  const variant = searchParams.get("v") === "2" ? 2 : 1;
+  const detail = searchParams.get("metric");
+  const selectedDeployments = (searchParams.get("deployments") ?? "").split(",").filter(Boolean);
+
+  const set = useCallback(
+    (patch: Record<string, string | null>) => {
+      const next = new URLSearchParams(searchParams.toString());
+      for (const [k, v] of Object.entries(patch)) {
+        if (v === null) {
+          next.delete(k);
+        } else {
+          next.set(k, v);
+        }
+      }
+      router.replace(`${pathname}?${next.toString()}` as Route, { scroll: false });
+    },
+    [router, pathname, searchParams],
+  );
+
+  return {
+    appId,
+    environments: appEnvironments,
+    isEnvironmentsLoading,
+    environmentId,
+    window,
+    variant,
+    detail,
+    setEnvironmentId: (id: string) => set({ environmentId: id }),
+    setWindow: (w: AppMetricsWindow) => set({ range: w }),
+    setVariant: (v: number) => set({ v: String(v) }),
+    setDetail: (metric: string | null) => set({ metric }),
+    selectedDeployments,
+    setSelectedDeployments: (ids: string[]) =>
+      set({ deployments: ids.length > 0 ? ids.join(",") : null }),
+  };
+}
+
+export function useResourceSeries(scope: MetricsScope, metric: AppResourceMetric) {
+  return trpc.deploy.metrics.getAppResourceTimeseries.useQuery(
+    { ...scope, metric },
+    { refetchInterval: REFETCH_MS, keepPreviousData: true },
+  );
+}
+
+export function useRequestSeries(scope: MetricsScope) {
+  return trpc.deploy.metrics.getAppRequestTimeseries.useQuery(scope, {
+    refetchInterval: REFETCH_MS,
+    keepPreviousData: true,
+  });
+}
+
+export function useLatencySeries(scope: MetricsScope) {
+  return trpc.deploy.metrics.getAppLatencyTimeseries.useQuery(scope, {
+    refetchInterval: REFETCH_MS,
+    keepPreviousData: true,
+  });
+}
+
+export function useDeploymentMarkers(scope: Omit<MetricsScope, "groupBy">) {
+  return trpc.deploy.metrics.getAppDeploymentMarkers.useQuery(
+    { appId: scope.appId, environmentId: scope.environmentId, window: scope.window },
+    { refetchInterval: REFETCH_MS, keepPreviousData: true },
+  );
+}
+
+export type DeploymentInfo = {
+  id: string;
+  environmentId: string;
+  sha: string | null;
+  message: string | null;
+  branch: string;
+  status: string;
+  createdAt: number;
+};
+
+// Deployment metadata for series labels and breakdown rows. Series are keyed
+// by deployment id; anything not in the project collection (very old or
+// deleted) falls back to the raw id.
+export function useDeploymentIndex(): Map<string, DeploymentInfo> {
+  const { deployments } = useProjectData();
+  return useMemo(() => {
+    const map = new Map<string, DeploymentInfo>();
+    for (const d of deployments) {
+      map.set(d.id, {
+        id: d.id,
+        environmentId: d.environmentId,
+        sha: d.gitCommitSha,
+        message: d.gitCommitMessage,
+        branch: d.gitBranch,
+        status: d.status,
+        createdAt: d.createdAt,
+      });
+    }
+    return map;
+  }, [deployments]);
+}
+
+// Deployments of one environment, newest first. The position in this list is
+// also the deployment's colour, so a deployment keeps its colour across every
+// chart and the picker.
+export function useEnvironmentDeployments(environmentId: string): DeploymentInfo[] {
+  const index = useDeploymentIndex();
+  return useMemo(
+    () =>
+      [...index.values()]
+        .filter((d) => d.environmentId === environmentId)
+        .sort((a, b) => b.createdAt - a.createdAt),
+    [index, environmentId],
+  );
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/metrics/hooks/use-metrics-bundle.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/metrics/hooks/use-metrics-bundle.ts
@@ -1,0 +1,43 @@
+"use client";
+
+import { type AppMetricsRange, resolveAppMetricsRange } from "@unkey/clickhouse";
+import type { DeployMarker } from "../components/metrics-chart";
+import { shortSha } from "../lib/series";
+import {
+  type MetricsScope,
+  useDeploymentMarkers,
+  useLatencySeries,
+  useRequestSeries,
+  useResourceSeries,
+} from "./use-app-metrics";
+
+// Every series the page can show, fetched once per scope. Cards read the slice
+// they need; the shared range keeps all x-axes aligned even while some queries
+// are still loading.
+export function useMetricsBundle(scope: MetricsScope) {
+  const cpu = useResourceSeries(scope, "cpu");
+  const memory = useResourceSeries(scope, "memory");
+  const disk = useResourceSeries(scope, "disk");
+  const egress = useResourceSeries(scope, "egress");
+  const ingress = useResourceSeries(scope, "ingress");
+  const requests = useRequestSeries(scope);
+  const latency = useLatencySeries(scope);
+  const markersQuery = useDeploymentMarkers(scope);
+
+  const range: AppMetricsRange =
+    requests.data?.range ??
+    cpu.data?.range ??
+    markersQuery.data?.range ??
+    resolveAppMetricsRange(scope.window, Date.now());
+
+  const markers: DeployMarker[] = (markersQuery.data?.markers ?? []).map((m) => ({
+    id: m.id,
+    x: m.createdAt,
+    label: shortSha(m.gitCommitSha) || m.id.slice(-7),
+    title: m.gitCommitMessage ?? undefined,
+  }));
+
+  return { cpu, memory, disk, egress, ingress, requests, latency, markers, range };
+}
+
+export type MetricsBundle = ReturnType<typeof useMetricsBundle>;

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/metrics/layout.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/metrics/layout.tsx
@@ -1,0 +1,20 @@
+import { appMetrics } from "@/lib/flags";
+import { routes } from "@/lib/navigation/routes";
+import { redirect } from "next/navigation";
+import type { ReactNode } from "react";
+
+// Server-side gate for the app Metrics tab. The flag defaults to off, so the
+// page stays unreachable until app-metrics is enabled for the workspace or
+// through FLAGS_LOCAL_OVERRIDES.
+export default async function MetricsLayout({
+  children,
+  params,
+}: {
+  children: ReactNode;
+  params: Promise<{ workspaceSlug: string; projectId: string; appId: string }>;
+}) {
+  if (!(await appMetrics())) {
+    redirect(routes.projects.apps.overview(await params));
+  }
+  return children;
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/metrics/lib/series.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/metrics/lib/series.ts
@@ -1,0 +1,311 @@
+import type { AppMetricsRange, AppMetricsSeriesPoint, AppMetricsWindow } from "@unkey/clickhouse";
+
+export type SeriesPoint = { x: number } & Record<string, number>;
+
+export type SeriesKey = { key: string; label: string; color: string };
+
+export const WINDOW_LABELS: Record<AppMetricsWindow, { short: string; long: string }> = {
+  "1h": { short: "1h", long: "Last hour" },
+  "6h": { short: "6h", long: "Last 6 hours" },
+  "1d": { short: "24h", long: "Last 24 hours" },
+  "1w": { short: "7d", long: "Last 7 days" },
+  "30d": { short: "30d", long: "Last 30 days" },
+};
+
+export const STATUS_SERIES: SeriesKey[] = [
+  { key: "2xx", label: "2xx", color: "hsl(var(--success-9))" },
+  { key: "3xx", label: "3xx", color: "hsl(var(--info-9))" },
+  { key: "4xx", label: "4xx", color: "hsl(var(--warning-9))" },
+  { key: "5xx", label: "5xx", color: "hsl(var(--error-9))" },
+];
+
+export const PERCENTILE_SERIES: SeriesKey[] = [
+  { key: "p50", label: "p50", color: "hsl(var(--bronze-8))" },
+  { key: "p95", label: "p95", color: "hsl(var(--bronze-10))" },
+  { key: "p99", label: "p99", color: "hsl(var(--bronze-12))" },
+];
+
+export const METRIC_COLORS = {
+  cpu: "hsl(var(--feature-9))",
+  memory: "hsl(var(--info-9))",
+  disk: "hsl(var(--success-9))",
+  egress: "hsl(var(--info-9))",
+  ingress: "hsl(var(--warning-9))",
+  requests: "hsl(var(--success-9))",
+  errors: "hsl(var(--error-9))",
+  latency: "hsl(var(--bronze-9))",
+};
+
+const SPLIT_PALETTE = [
+  "hsl(var(--info-9))",
+  "hsl(var(--feature-9))",
+  "hsl(var(--warning-9))",
+  "hsl(var(--success-9))",
+  "hsl(var(--bronze-9))",
+  "hsl(var(--error-9))",
+  "hsl(var(--accent-9))",
+];
+
+export function paletteColor(index: number): string {
+  return SPLIT_PALETTE[index % SPLIT_PALETTE.length];
+}
+
+export function bucketsOf(range: AppMetricsRange): number[] {
+  const step = range.bucketSeconds * 1000;
+  const out: number[] = [];
+  for (let x = range.startMs; x < range.endMs; x += step) {
+    out.push(x);
+  }
+  return out;
+}
+
+// Distinct series names in order of first appearance, so a deployment that
+// went live earlier lists before its successor.
+export function seriesKeysOf(points: AppMetricsSeriesPoint[]): string[] {
+  const seen = new Set<string>();
+  const keys: string[] = [];
+  for (const p of points) {
+    if (!seen.has(p.series)) {
+      seen.add(p.series);
+      keys.push(p.series);
+    }
+  }
+  return keys;
+}
+
+// Pivots {x, series, y} rows into one dense row per bucket with a column per
+// series, zero-filled. Optional `scale` converts the stored unit (e.g. cpu
+// microseconds per bucket) into the displayed one.
+export function pivot(
+  points: AppMetricsSeriesPoint[],
+  range: AppMetricsRange,
+  keys: string[],
+  scale: (y: number) => number = (y) => y,
+): SeriesPoint[] {
+  const byX = new Map<number, SeriesPoint>();
+  for (const x of bucketsOf(range)) {
+    const row: SeriesPoint = { x };
+    for (const k of keys) {
+      row[k] = 0;
+    }
+    byX.set(x, row);
+  }
+  for (const p of points) {
+    const row = byX.get(p.x);
+    if (row && keys.includes(p.series)) {
+      row[p.series] = scale(p.y);
+    }
+  }
+  return [...byX.values()];
+}
+
+export function sumSeries(points: SeriesPoint[], key: string): number {
+  let total = 0;
+  for (const p of points) {
+    total += p[key] ?? 0;
+  }
+  return total;
+}
+
+export function maxSeries(points: SeriesPoint[], key: string): number {
+  let max = 0;
+  for (const p of points) {
+    max = Math.max(max, p[key] ?? 0);
+  }
+  return max;
+}
+
+export function meanSeries(points: SeriesPoint[], key: string): number {
+  const nonZero = points.filter((p) => (p[key] ?? 0) > 0);
+  if (nonZero.length === 0) {
+    return 0;
+  }
+  return sumSeries(nonZero, key) / nonZero.length;
+}
+
+// Adds a `total` column across the given keys.
+export function withTotal(points: SeriesPoint[], keys: string[]): SeriesPoint[] {
+  return points.map((p) => {
+    let total = 0;
+    for (const k of keys) {
+      total += p[k] ?? 0;
+    }
+    return { ...p, total };
+  });
+}
+
+// ─── Formatting ──────────────────────────────────────────────────────
+
+const KIB = 1024;
+const MIB = KIB * 1024;
+const GIB = MIB * 1024;
+const TIB = GIB * 1024;
+
+export function formatBytes(bytes: number, digits = 1): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) {
+    return "0 B";
+  }
+  if (bytes >= TIB) {
+    return `${(bytes / TIB).toFixed(2)} TiB`;
+  }
+  if (bytes >= GIB) {
+    return `${(bytes / GIB).toFixed(digits)} GiB`;
+  }
+  if (bytes >= MIB) {
+    return `${(bytes / MIB).toFixed(digits)} MiB`;
+  }
+  if (bytes >= KIB) {
+    return `${(bytes / KIB).toFixed(0)} KiB`;
+  }
+  return `${Math.round(bytes)} B`;
+}
+
+export function formatBytesRate(bytesPerSecond: number): string {
+  if (!Number.isFinite(bytesPerSecond) || bytesPerSecond <= 0) {
+    return "0 B/s";
+  }
+  return `${formatBytes(bytesPerSecond)}/s`;
+}
+
+export function formatVcpu(millicores: number): string {
+  if (!Number.isFinite(millicores) || millicores <= 0) {
+    return "0 vCPU";
+  }
+  if (millicores < 100) {
+    return `${millicores.toFixed(1)} mCPU`;
+  }
+  return `${(millicores / 1000).toFixed(2)} vCPU`;
+}
+
+export function formatCpuTime(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds <= 0) {
+    return "0s";
+  }
+  if (seconds < 60) {
+    return `${Math.round(seconds)}s`;
+  }
+  if (seconds < 3600) {
+    return `${(seconds / 60).toFixed(1)}m`;
+  }
+  return `${(seconds / 3600).toFixed(1)}h`;
+}
+
+export function formatCount(n: number): string {
+  if (!Number.isFinite(n) || n <= 0) {
+    return "0";
+  }
+  if (n >= 1_000_000_000) {
+    return `${(n / 1_000_000_000).toFixed(1)}B`;
+  }
+  if (n >= 1_000_000) {
+    return `${(n / 1_000_000).toFixed(1)}M`;
+  }
+  if (n >= 10_000) {
+    return `${Math.round(n / 1000)}K`;
+  }
+  if (n >= 1000) {
+    return `${(n / 1000).toFixed(1)}K`;
+  }
+  return `${Math.round(n)}`;
+}
+
+export function formatRequestRate(perSecond: number): string {
+  if (!Number.isFinite(perSecond) || perSecond <= 0) {
+    return "0 req/s";
+  }
+  if (perSecond < 10) {
+    return `${perSecond.toFixed(2)} req/s`;
+  }
+  return `${formatCount(perSecond)} req/s`;
+}
+
+export function formatMs(ms: number): string {
+  if (!Number.isFinite(ms) || ms <= 0) {
+    return "0 ms";
+  }
+  if (ms < 1000) {
+    return `${ms < 10 ? ms.toFixed(1) : Math.round(ms)} ms`;
+  }
+  return `${(ms / 1000).toFixed(2)} s`;
+}
+
+export function formatPercent(p: number): string {
+  if (!Number.isFinite(p) || p <= 0) {
+    return "0%";
+  }
+  if (p < 0.1) {
+    return `${p.toFixed(2)}%`;
+  }
+  if (p < 10) {
+    return `${p.toFixed(1)}%`;
+  }
+  return `${Math.round(p)}%`;
+}
+
+export function shortSha(sha: string | null | undefined): string {
+  return sha ? sha.slice(0, 7) : "";
+}
+
+export function formatTickTime(x: number, spanMs: number): string {
+  const d = new Date(x);
+  if (spanMs >= 2 * 24 * 60 * 60 * 1000) {
+    return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+  }
+  return d.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" });
+}
+
+export function formatBucketLabel(x: number, bucketSeconds: number): string {
+  const start = new Date(x);
+  const end = new Date(x + bucketSeconds * 1000);
+  const date = start.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+  const time = (d: Date) => d.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" });
+  if (bucketSeconds >= 24 * 3600) {
+    return date;
+  }
+  return `${date}, ${time(start)} – ${time(end)}`;
+}
+
+// Axis ticks drop the unit spacing so they fit the gutter; the tooltip keeps
+// the full form.
+export function tickBytes(v: number): string {
+  if (!Number.isFinite(v) || v <= 0) {
+    return "";
+  }
+  if (v >= GIB) {
+    return `${(v / GIB).toFixed(1)}G`;
+  }
+  if (v >= MIB) {
+    return `${(v / MIB).toFixed(0)}M`;
+  }
+  if (v >= KIB) {
+    return `${(v / KIB).toFixed(0)}K`;
+  }
+  return `${Math.round(v)}B`;
+}
+
+export function tickBytesRate(v: number): string {
+  const t = tickBytes(v);
+  return t ? `${t}/s` : "";
+}
+
+export function tickVcpu(v: number): string {
+  if (!Number.isFinite(v) || v <= 0) {
+    return "";
+  }
+  return v < 100 ? `${v.toFixed(0)}m` : `${(v / 1000).toFixed(2)}`;
+}
+
+export function tickCount(v: number): string {
+  return v > 0 ? formatCount(v) : "";
+}
+
+export function tickMs(v: number): string {
+  if (!Number.isFinite(v) || v <= 0) {
+    return "";
+  }
+  return v < 1000 ? `${Math.round(v)}ms` : `${(v / 1000).toFixed(1)}s`;
+}
+
+export function tickPercent(v: number): string {
+  return v > 0 ? formatPercent(v) : "";
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/metrics/page.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/metrics/page.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { PageBody, PageContainer, PageHeader, PageHeaderContent, PageHeaderTitle } from "@unkey/ui";
+import { ProtoPicker } from "./components/proto-picker";
+import { useMetricsUrlState } from "./hooks/use-app-metrics";
+import { TimelineVariant } from "./variants/timeline";
+import { TotalsVariant } from "./variants/totals";
+
+const VARIANTS = ["Timeline", "Totals"];
+
+export default function MetricsPage() {
+  const state = useMetricsUrlState();
+
+  return (
+    <PageContainer>
+      <PageHeader>
+        <PageHeaderContent>
+          <PageHeaderTitle>Metrics</PageHeaderTitle>
+        </PageHeaderContent>
+      </PageHeader>
+      <PageBody>
+        {state.environmentId ? (
+          state.variant === 2 ? (
+            <TotalsVariant key="totals" state={{ ...state, environmentId: state.environmentId }} />
+          ) : (
+            <TimelineVariant
+              key="timeline"
+              state={{ ...state, environmentId: state.environmentId }}
+            />
+          )
+        ) : (
+          <p className="text-[13px] text-gray-10">
+            {state.isEnvironmentsLoading
+              ? "Loading environments…"
+              : "This app has no environments."}
+          </p>
+        )}
+      </PageBody>
+      <ProtoPicker
+        variants={VARIANTS}
+        active={state.variant - 1}
+        onChange={(i) => state.setVariant(i + 1)}
+      />
+    </PageContainer>
+  );
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/metrics/variants/timeline.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/metrics/variants/timeline.tsx
@@ -1,0 +1,580 @@
+"use client";
+
+import type { AppResourceMetric } from "@unkey/clickhouse";
+import { cn } from "@unkey/ui/src/lib/utils";
+import { type ReactNode, useState } from "react";
+import { EnvironmentSelect, Legend, WindowPills } from "../components/controls";
+import { DeploymentPicker } from "../components/deployment-picker";
+import { type DeployMarker, MetricsChart } from "../components/metrics-chart";
+import {
+  type DeploymentInfo,
+  type MetricsScope,
+  useEnvironmentDeployments,
+  useLatencySeries,
+  type useMetricsUrlState,
+  useRequestSeries,
+  useResourceSeries,
+} from "../hooks/use-app-metrics";
+import { useMetricsBundle } from "../hooks/use-metrics-bundle";
+import {
+  METRIC_COLORS,
+  PERCENTILE_SERIES,
+  STATUS_SERIES,
+  type SeriesKey,
+  type SeriesPoint,
+  formatBytes,
+  formatBytesRate,
+  formatMs,
+  formatPercent,
+  formatRequestRate,
+  formatVcpu,
+  paletteColor,
+  pivot,
+  seriesKeysOf,
+  shortSha,
+  tickBytes,
+  tickBytesRate,
+  tickCount,
+  tickMs,
+  tickPercent,
+  tickVcpu,
+} from "../lib/series";
+
+type UrlState = ReturnType<typeof useMetricsUrlState>;
+
+// Which deployments the charts are split by, with a stable colour each.
+type Selection = {
+  ids: string[];
+  series: SeriesKey[];
+  colorOf: (id: string) => string;
+};
+
+// Timeline direction: a grid of equal charts, one metric each, every chart on
+// the same time axis with dotted deploy lines. Resource cards toggle between
+// the summed line and one line per instance. Picking deployments at the top
+// turns every chart into one line per deployment instead.
+export function TimelineVariant({ state }: { state: UrlState & { environmentId: string } }) {
+  const deployments = useEnvironmentDeployments(state.environmentId);
+  const colorOf = (id: string) =>
+    paletteColor(
+      Math.max(
+        0,
+        deployments.findIndex((d) => d.id === id),
+      ),
+    );
+  const ids = state.selectedDeployments.filter((id) => deployments.some((d) => d.id === id));
+  const selection: Selection = {
+    ids,
+    colorOf,
+    series: ids.map((id) => {
+      const d = deployments.find((x) => x.id === id);
+      return { key: id, label: shortSha(d?.sha) || id.slice(-7), color: colorOf(id) };
+    }),
+  };
+  const split = ids.length > 0;
+
+  const scope: MetricsScope = {
+    appId: state.appId,
+    environmentId: state.environmentId,
+    window: state.window,
+    groupBy: split ? "deployment" : "none",
+  };
+  const bundle = useMetricsBundle(scope);
+  const domain: [number, number] = [bundle.range.startMs, bundle.range.endMs];
+  const markers = split ? bundle.markers.filter((m) => ids.includes(m.id)) : bundle.markers;
+  const chart: ChartShared = {
+    domain,
+    bucketSeconds: bundle.range.bucketSeconds,
+    markers,
+    showMarkerLabels: false,
+    syncId: "app-metrics",
+  };
+  const inRange = (d: DeploymentInfo) => d.createdAt >= domain[0] && d.createdAt < domain[1];
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <div className="flex items-center gap-2">
+          <EnvironmentSelect
+            environments={state.environments}
+            value={state.environmentId}
+            onChange={state.setEnvironmentId}
+          />
+          <DeploymentPicker
+            deployments={deployments}
+            colorOf={colorOf}
+            selected={ids}
+            onChange={state.setSelectedDeployments}
+            inRange={inRange}
+          />
+        </div>
+        <WindowPills value={state.window} onChange={state.setWindow} />
+      </div>
+
+      <div className="grid grid-cols-1 xl:grid-cols-2 gap-4">
+        <ResourceCard title="CPU" metric="cpu" scope={scope} chart={chart} selection={selection} />
+        <ResourceCard
+          title="Memory"
+          metric="memory"
+          scope={scope}
+          chart={chart}
+          selection={selection}
+        />
+        <NetworkCard bundle={bundle} chart={chart} selection={selection} />
+        <RequestsCard scope={scope} chart={chart} selection={selection} />
+        <ErrorRateCard scope={scope} chart={chart} selection={selection} />
+        <LatencyCard scope={scope} chart={chart} selection={selection} />
+        <ResourceCard
+          title="Disk"
+          metric="disk"
+          scope={scope}
+          chart={chart}
+          selection={selection}
+        />
+      </div>
+    </div>
+  );
+}
+
+type ChartShared = {
+  domain: [number, number];
+  bucketSeconds: number;
+  markers: DeployMarker[];
+  showMarkerLabels: boolean;
+  syncId: string;
+};
+
+function Card({
+  title,
+  right,
+  children,
+}: {
+  title: ReactNode;
+  right?: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <section className="border border-gray-4 bg-grayA-1 rounded-lg flex flex-col min-w-0">
+      <header className="flex items-center justify-between gap-3 px-4 pt-3 pb-1">
+        <h3 className="text-[13px] font-medium text-gray-12">{title}</h3>
+        {right}
+      </header>
+      <div className="px-2 pb-2">{children}</div>
+    </section>
+  );
+}
+
+function SplitToggle({
+  value,
+  onChange,
+  labels,
+}: {
+  value: boolean;
+  onChange: (v: boolean) => void;
+  labels: [string, string];
+}) {
+  return (
+    <div role="radiogroup" className="flex items-center gap-3 text-[11px]">
+      {([false, true] as const).map((split, i) => (
+        <button
+          key={labels[i]}
+          type="button"
+          role="radio"
+          aria-checked={value === split}
+          onClick={() => onChange(split)}
+          className={cn(
+            "flex items-center gap-1.5 transition-colors",
+            value === split ? "text-gray-12" : "text-gray-9 hover:text-gray-11",
+          )}
+        >
+          <span
+            className={cn(
+              "size-2 rounded-full border",
+              value === split ? "bg-accent-9 border-accent-9" : "border-gray-8",
+            )}
+          />
+          {labels[i]}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+const RESOURCE_FORMAT: Record<
+  AppResourceMetric,
+  {
+    scale: (y: number, bucketSeconds: number) => number;
+    format: (v: number) => string;
+    tick: (v: number) => string;
+  }
+> = {
+  cpu: { scale: (y, b) => y / b / 1000, format: formatVcpu, tick: tickVcpu },
+  memory: { scale: (y) => y, format: (v) => formatBytes(v), tick: tickBytes },
+  disk: { scale: (y) => y, format: (v) => formatBytes(v), tick: tickBytes },
+  egress: { scale: (y, b) => y / b, format: formatBytesRate, tick: tickBytesRate },
+  ingress: { scale: (y, b) => y / b, format: formatBytesRate, tick: tickBytesRate },
+};
+
+function ResourceCard({
+  title,
+  metric,
+  scope,
+  chart,
+  selection,
+}: {
+  title: string;
+  metric: AppResourceMetric;
+  scope: MetricsScope;
+  chart: ChartShared;
+  selection: Selection;
+}) {
+  const [perInstance, setPerInstance] = useState(false);
+  const byDeployment = selection.ids.length > 0;
+  const query = useResourceSeries(
+    { ...scope, groupBy: byDeployment ? "deployment" : perInstance ? "instance" : "none" },
+    metric,
+  );
+  const rows = query.data?.points ?? [];
+  const range = query.data?.range ?? {
+    startMs: chart.domain[0],
+    endMs: chart.domain[1],
+    bucketSeconds: chart.bucketSeconds,
+  };
+  const series: SeriesKey[] = byDeployment
+    ? selection.series
+    : perInstance
+      ? seriesKeysOf(rows).map((k, i) => ({ key: k, label: k, color: paletteColor(i) }))
+      : [{ key: "sum", label: "Sum", color: METRIC_COLORS[metric] }];
+  const { scale, format, tick } = RESOURCE_FORMAT[metric];
+  const points = pivot(
+    rows.map((r) => ({ ...r, series: r.series || "sum" })),
+    range,
+    series.map((s) => s.key),
+    (y) => scale(y, range.bucketSeconds),
+  );
+
+  return (
+    <Card
+      title={title}
+      right={
+        byDeployment ? (
+          <Legend items={series} />
+        ) : (
+          <SplitToggle
+            value={perInstance}
+            onChange={setPerInstance}
+            labels={["Sum", "Instances"]}
+          />
+        )
+      }
+    >
+      <MetricsChart
+        points={points}
+        series={series}
+        kind={byDeployment || perInstance ? "line" : "area"}
+        {...chart}
+        formatValue={format}
+        formatTick={tick}
+        isLoading={query.isLoading}
+        isError={query.isError}
+      />
+    </Card>
+  );
+}
+
+function NetworkCard({
+  bundle,
+  chart,
+  selection,
+}: {
+  bundle: ReturnType<typeof useMetricsBundle>;
+  chart: ChartShared;
+  selection: Selection;
+}) {
+  const b = bundle.range.bucketSeconds;
+  const byDeployment = selection.ids.length > 0;
+
+  if (byDeployment) {
+    const points = pivot(
+      bundle.egress.data?.points ?? [],
+      bundle.range,
+      selection.ids,
+      (y) => y / b,
+    );
+    return (
+      <Card
+        title={
+          <>
+            Public Network Traffic <span className="text-gray-10 font-normal">egress</span>
+          </>
+        }
+        right={<Legend items={selection.series} />}
+      >
+        <MetricsChart
+          points={points}
+          series={selection.series}
+          kind="line"
+          {...chart}
+          formatValue={formatBytesRate}
+          formatTick={tickBytesRate}
+          isLoading={bundle.egress.isLoading}
+          isError={bundle.egress.isError}
+        />
+      </Card>
+    );
+  }
+
+  const series: SeriesKey[] = [
+    { key: "egress", label: "Egress", color: METRIC_COLORS.egress },
+    { key: "ingress", label: "Ingress", color: METRIC_COLORS.ingress },
+  ];
+  const egress = pivot(
+    (bundle.egress.data?.points ?? []).map((r) => ({ ...r, series: "egress" })),
+    bundle.range,
+    ["egress"],
+    (y) => y / b,
+  );
+  const ingress = pivot(
+    (bundle.ingress.data?.points ?? []).map((r) => ({ ...r, series: "ingress" })),
+    bundle.range,
+    ["ingress"],
+    (y) => y / b,
+  );
+  const points = egress.map((p, i) => ({ ...p, ingress: ingress[i]?.ingress ?? 0 }));
+
+  return (
+    <Card title="Public Network Traffic" right={<Legend items={series} />}>
+      <MetricsChart
+        points={points}
+        series={series}
+        kind="area"
+        {...chart}
+        formatValue={formatBytesRate}
+        formatTick={tickBytesRate}
+        isLoading={bundle.egress.isLoading || bundle.ingress.isLoading}
+        isError={bundle.egress.isError || bundle.ingress.isError}
+      />
+    </Card>
+  );
+}
+
+// Request rows arrive as "deployment:2xx" when grouped by deployment. Folds
+// them into one row per bucket with `<id>` (total) and `<id>:5xx` columns.
+function requestsByDeployment(
+  rows: { x: number; series: string; y: number }[],
+  range: { startMs: number; endMs: number; bucketSeconds: number },
+  ids: string[],
+): SeriesPoint[] {
+  const keys = ids.flatMap((id) => [id, `${id}:5xx`]);
+  const points = pivot([], range, keys);
+  const byX = new Map(points.map((p) => [p.x, p]));
+  for (const r of rows) {
+    const [id, klass] = r.series.split(":");
+    const row = byX.get(r.x);
+    if (!row || !ids.includes(id)) {
+      continue;
+    }
+    row[id] = (row[id] ?? 0) + r.y;
+    if (klass === "5xx") {
+      row[`${id}:5xx`] = (row[`${id}:5xx`] ?? 0) + r.y;
+    }
+  }
+  return points;
+}
+
+function RequestsCard({
+  scope,
+  chart,
+  selection,
+}: {
+  scope: MetricsScope;
+  chart: ChartShared;
+  selection: Selection;
+}) {
+  const query = useRequestSeries(scope);
+  const range = query.data?.range;
+  const b = range?.bucketSeconds ?? chart.bucketSeconds;
+  const byDeployment = selection.ids.length > 0;
+
+  if (byDeployment) {
+    const points = range
+      ? requestsByDeployment(query.data?.points ?? [], range, selection.ids).map((p) => {
+          const out: SeriesPoint = { x: p.x };
+          for (const id of selection.ids) {
+            out[id] = (p[id] ?? 0) / b;
+          }
+          return out;
+        })
+      : [];
+    return (
+      <Card title="Requests" right={<Legend items={selection.series} />}>
+        <MetricsChart
+          points={points}
+          series={selection.series}
+          kind="line"
+          {...chart}
+          formatValue={formatRequestRate}
+          formatTick={(v) => (v > 0 ? `${v < 10 ? v.toFixed(1) : tickCount(v)}/s` : "")}
+          isLoading={query.isLoading}
+          isError={query.isError}
+          emptyMessage="No requests in this range"
+        />
+      </Card>
+    );
+  }
+
+  const points = range
+    ? pivot(
+        query.data?.points ?? [],
+        range,
+        STATUS_SERIES.map((s) => s.key),
+        (y) => y / b,
+      )
+    : [];
+  return (
+    <Card title="Requests" right={<Legend items={STATUS_SERIES} />}>
+      <MetricsChart
+        points={points}
+        series={STATUS_SERIES}
+        kind="area"
+        stacked
+        {...chart}
+        formatValue={formatRequestRate}
+        formatTick={(v) => (v > 0 ? `${v < 10 ? v.toFixed(1) : tickCount(v)}/s` : "")}
+        isLoading={query.isLoading}
+        isError={query.isError}
+        emptyMessage="No requests in this range"
+      />
+    </Card>
+  );
+}
+
+function ErrorRateCard({
+  scope,
+  chart,
+  selection,
+}: {
+  scope: MetricsScope;
+  chart: ChartShared;
+  selection: Selection;
+}) {
+  const query = useRequestSeries(scope);
+  const range = query.data?.range;
+  const byDeployment = selection.ids.length > 0;
+
+  let points: SeriesPoint[] = [];
+  let series: SeriesKey[];
+  if (byDeployment) {
+    series = selection.series;
+    points = range
+      ? requestsByDeployment(query.data?.points ?? [], range, selection.ids).map((p) => {
+          const out: SeriesPoint = { x: p.x };
+          for (const id of selection.ids) {
+            const total = p[id] ?? 0;
+            out[id] = total > 0 ? ((p[`${id}:5xx`] ?? 0) / total) * 100 : 0;
+          }
+          return out;
+        })
+      : [];
+  } else {
+    series = [{ key: "rate", label: "5xx rate", color: METRIC_COLORS.errors }];
+    const counts = range
+      ? pivot(
+          query.data?.points ?? [],
+          range,
+          STATUS_SERIES.map((s) => s.key),
+        )
+      : [];
+    points = counts.map((p) => {
+      const total = STATUS_SERIES.reduce((acc, s) => acc + (p[s.key] ?? 0), 0);
+      return { x: p.x, rate: total > 0 ? ((p["5xx"] ?? 0) / total) * 100 : 0 };
+    });
+  }
+  const maxRate = points.reduce((m, p) => Math.max(m, ...series.map((s) => p[s.key] ?? 0)), 0);
+  return (
+    <Card title="Request Error Rate" right={<Legend items={series} />}>
+      <MetricsChart
+        points={points}
+        series={series}
+        kind="line"
+        {...chart}
+        formatValue={formatPercent}
+        formatTick={tickPercent}
+        yMax={Math.max(1, maxRate) * 1.15}
+        isLoading={query.isLoading}
+        isError={query.isError}
+        emptyMessage="No errors in this range"
+      />
+    </Card>
+  );
+}
+
+function LatencyCard({
+  scope,
+  chart,
+  selection,
+}: {
+  scope: MetricsScope;
+  chart: ChartShared;
+  selection: Selection;
+}) {
+  const query = useLatencySeries(scope);
+  const rows = query.data?.points ?? [];
+  const range = query.data?.range;
+  const byDeployment = selection.ids.length > 0;
+
+  if (byDeployment) {
+    const points = range
+      ? pivot(
+          rows.map((r) => ({ x: r.x, series: r.series, y: r.p99 })),
+          range,
+          selection.ids,
+        )
+      : [];
+    return (
+      <Card
+        title={
+          <>
+            Response Time <span className="text-gray-10 font-normal">p99</span>
+          </>
+        }
+        right={<Legend items={selection.series} />}
+      >
+        <MetricsChart
+          points={points}
+          series={selection.series}
+          kind="line"
+          {...chart}
+          formatValue={formatMs}
+          formatTick={tickMs}
+          isLoading={query.isLoading}
+          isError={query.isError}
+          emptyMessage="No requests in this range"
+        />
+      </Card>
+    );
+  }
+
+  const byX = new Map(rows.map((r) => [r.x, r]));
+  const points = range
+    ? pivot([], range, ["p50", "p95", "p99"]).map((p) => {
+        const r = byX.get(p.x);
+        return { x: p.x, p50: r?.p50 ?? 0, p95: r?.p95 ?? 0, p99: r?.p99 ?? 0 };
+      })
+    : [];
+  return (
+    <Card title="Response Time" right={<Legend items={PERCENTILE_SERIES} />}>
+      <MetricsChart
+        points={points}
+        series={PERCENTILE_SERIES}
+        kind="line"
+        {...chart}
+        formatValue={formatMs}
+        formatTick={tickMs}
+        isLoading={query.isLoading}
+        isError={query.isError}
+        emptyMessage="No requests in this range"
+      />
+    </Card>
+  );
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/metrics/variants/totals.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/metrics/variants/totals.tsx
@@ -1,0 +1,952 @@
+"use client";
+
+import { useWorkspaceNavigation } from "@/hooks/use-workspace-navigation";
+import { routes } from "@/lib/navigation/routes";
+import { ChevronLeft, ChevronRight } from "@unkey/icons";
+import { Badge } from "@unkey/ui";
+import { cn } from "@unkey/ui/src/lib/utils";
+import Link from "next/link";
+import type { ReactNode } from "react";
+import { useProjectData } from "../../data-provider";
+import { EnvironmentSelect, WindowSelect } from "../components/controls";
+import { DeploymentPicker } from "../components/deployment-picker";
+import { MetricsChart } from "../components/metrics-chart";
+import {
+  type DeploymentInfo,
+  type MetricsScope,
+  useDeploymentIndex,
+  useEnvironmentDeployments,
+  type useMetricsUrlState,
+} from "../hooks/use-app-metrics";
+import { type MetricsBundle, useMetricsBundle } from "../hooks/use-metrics-bundle";
+import {
+  METRIC_COLORS,
+  PERCENTILE_SERIES,
+  STATUS_SERIES,
+  type SeriesKey,
+  type SeriesPoint,
+  formatBytes,
+  formatCount,
+  formatCpuTime,
+  formatMs,
+  formatPercent,
+  formatVcpu,
+  maxSeries,
+  meanSeries,
+  paletteColor,
+  pivot,
+  seriesKeysOf,
+  shortSha,
+  sumSeries,
+  tickBytes,
+  tickCount,
+  tickMs,
+  tickPercent,
+  tickVcpu,
+} from "../lib/series";
+
+type UrlState = ReturnType<typeof useMetricsUrlState>;
+
+const DETAILS = ["requests", "transfer", "cpu", "memory", "latency", "errors", "disk"] as const;
+type Detail = (typeof DETAILS)[number];
+
+const DETAIL_TITLES: Record<Detail, string> = {
+  requests: "Requests",
+  transfer: "Data Transfer",
+  cpu: "CPU",
+  memory: "Memory",
+  latency: "Response Time",
+  errors: "Errors",
+  disk: "Disk",
+};
+
+function isDetail(v: string | null): v is Detail {
+  return v !== null && (DETAILS as readonly string[]).includes(v);
+}
+
+// Totals direction: an overview of cards that lead with totals, and a
+// drill-in per metric that splits the chart by deployment and lists every
+// deployment's share in a table. The question "which deploy did this" is
+// answered by a table row, not by reading a marker off a line.
+export function TotalsVariant({ state }: { state: UrlState & { environmentId: string } }) {
+  const detail = isDetail(state.detail) ? state.detail : null;
+  const deployments = useEnvironmentDeployments(state.environmentId);
+  const colorOf = (id: string) =>
+    paletteColor(
+      Math.max(
+        0,
+        deployments.findIndex((d) => d.id === id),
+      ),
+    );
+  const selected = state.selectedDeployments.filter((id) => deployments.some((d) => d.id === id));
+  const scope: MetricsScope = {
+    appId: state.appId,
+    environmentId: state.environmentId,
+    window: state.window,
+    groupBy: detail || selected.length > 0 ? "deployment" : "none",
+  };
+  const rawBundle = useMetricsBundle(scope);
+  const bundle: MetricsBundle =
+    selected.length > 0
+      ? { ...rawBundle, markers: rawBundle.markers.filter((m) => selected.includes(m.id)) }
+      : rawBundle;
+  const domain: [number, number] = [bundle.range.startMs, bundle.range.endMs];
+  const inRange = (d: DeploymentInfo) => d.createdAt >= domain[0] && d.createdAt < domain[1];
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <div className="flex items-center gap-2">
+          {detail && (
+            <button
+              type="button"
+              onClick={() => state.setDetail(null)}
+              className="inline-flex items-center gap-1 h-8 pl-1.5 pr-2.5 rounded-md text-[13px] text-gray-11 hover:text-gray-12 hover:bg-grayA-3 transition-colors"
+            >
+              <ChevronLeft iconSize="sm-regular" />
+              Overview
+            </button>
+          )}
+          <EnvironmentSelect
+            environments={state.environments}
+            value={state.environmentId}
+            onChange={state.setEnvironmentId}
+          />
+          <DeploymentPicker
+            deployments={deployments}
+            colorOf={colorOf}
+            selected={selected}
+            onChange={state.setSelectedDeployments}
+            inRange={inRange}
+          />
+        </div>
+        <WindowSelect value={state.window} onChange={state.setWindow} />
+      </div>
+
+      {detail ? (
+        <DetailView
+          detail={detail}
+          bundle={bundle}
+          appId={state.appId}
+          selected={selected}
+          colorOf={colorOf}
+        />
+      ) : selected.length > 0 ? (
+        <Overview
+          bundle={bundle}
+          onOpen={(d) => state.setDetail(d)}
+          selected={selected}
+          colorOf={colorOf}
+        />
+      ) : (
+        <Overview
+          bundle={bundle}
+          onOpen={(d) => state.setDetail(d)}
+          selected={[]}
+          colorOf={colorOf}
+        />
+      )}
+    </div>
+  );
+}
+
+// ─── Overview ────────────────────────────────────────────────────────
+
+type Shaped = {
+  points: SeriesPoint[];
+  series: SeriesKey[];
+  stats: { label: string; value: string; color?: string }[];
+  kind: "area" | "bar" | "line";
+  stacked?: boolean;
+  format: (v: number) => string;
+  tick: (v: number) => string;
+  isLoading: boolean;
+  isError: boolean;
+  yMax?: number;
+};
+
+// Turns the bundle into what each card draws. Overview totals use the
+// unsplit series; totals per bucket (bars) for counters, levels (areas) for
+// gauges.
+function shape(bundle: MetricsBundle, detail: Detail): Shaped {
+  const { range } = bundle;
+  const b = range.bucketSeconds;
+  const single = (
+    q: MetricsBundle["cpu"],
+    key: string,
+    scale: (y: number) => number = (y) => y,
+  ): SeriesPoint[] =>
+    pivot(
+      (q.data?.points ?? []).map((r) => ({ ...r, series: key })),
+      range,
+      [key],
+      scale,
+    );
+
+  switch (detail) {
+    case "requests": {
+      const points = pivot(
+        bundle.requests.data?.points ?? [],
+        range,
+        STATUS_SERIES.map((s) => s.key),
+      );
+      const total = STATUS_SERIES.reduce((acc, s) => acc + sumSeries(points, s.key), 0);
+      const errors = sumSeries(points, "5xx");
+      return {
+        points,
+        series: STATUS_SERIES,
+        kind: "bar",
+        stacked: true,
+        format: formatCount,
+        tick: tickCount,
+        stats: [
+          { label: "Total", value: formatCount(total) },
+          { label: "5xx", value: formatPercent(total > 0 ? (errors / total) * 100 : 0) },
+        ],
+        isLoading: bundle.requests.isLoading,
+        isError: bundle.requests.isError,
+      };
+    }
+    case "transfer": {
+      const egress = single(bundle.egress, "egress");
+      const ingress = single(bundle.ingress, "ingress");
+      const points = egress.map((p, i) => ({ ...p, ingress: ingress[i]?.ingress ?? 0 }));
+      return {
+        points,
+        series: [
+          { key: "egress", label: "Outgoing", color: METRIC_COLORS.egress },
+          { key: "ingress", label: "Incoming", color: METRIC_COLORS.ingress },
+        ],
+        kind: "bar",
+        format: (v) => formatBytes(v),
+        tick: tickBytes,
+        stats: [
+          {
+            label: "Outgoing",
+            value: formatBytes(sumSeries(points, "egress")),
+            color: METRIC_COLORS.egress,
+          },
+          {
+            label: "Incoming",
+            value: formatBytes(sumSeries(points, "ingress")),
+            color: METRIC_COLORS.ingress,
+          },
+        ],
+        isLoading: bundle.egress.isLoading || bundle.ingress.isLoading,
+        isError: bundle.egress.isError || bundle.ingress.isError,
+      };
+    }
+    case "cpu": {
+      const points = single(bundle.cpu, "cpu", (y) => y / b / 1000);
+      const cpuSeconds = (bundle.cpu.data?.points ?? []).reduce((acc, r) => acc + r.y / 1e6, 0);
+      return {
+        points,
+        series: [{ key: "cpu", label: "CPU", color: METRIC_COLORS.cpu }],
+        kind: "area",
+        format: formatVcpu,
+        tick: tickVcpu,
+        stats: [
+          { label: "CPU time", value: formatCpuTime(cpuSeconds) },
+          { label: "Avg", value: formatVcpu(meanSeries(points, "cpu")) },
+        ],
+        isLoading: bundle.cpu.isLoading,
+        isError: bundle.cpu.isError,
+      };
+    }
+    case "memory": {
+      const points = single(bundle.memory, "memory");
+      return {
+        points,
+        series: [{ key: "memory", label: "Memory", color: METRIC_COLORS.memory }],
+        kind: "area",
+        format: (v) => formatBytes(v),
+        tick: tickBytes,
+        stats: [
+          { label: "Peak", value: formatBytes(maxSeries(points, "memory")) },
+          { label: "Avg", value: formatBytes(meanSeries(points, "memory")) },
+        ],
+        isLoading: bundle.memory.isLoading,
+        isError: bundle.memory.isError,
+      };
+    }
+    case "disk": {
+      const points = single(bundle.disk, "disk");
+      return {
+        points,
+        series: [{ key: "disk", label: "Disk", color: METRIC_COLORS.disk }],
+        kind: "area",
+        format: (v) => formatBytes(v),
+        tick: tickBytes,
+        stats: [{ label: "Peak used", value: formatBytes(maxSeries(points, "disk")) }],
+        isLoading: bundle.disk.isLoading,
+        isError: bundle.disk.isError,
+      };
+    }
+    case "latency": {
+      const byX = new Map((bundle.latency.data?.points ?? []).map((r) => [r.x, r]));
+      const points = pivot([], range, ["p50", "p95", "p99"]).map((p) => {
+        const r = byX.get(p.x);
+        return { x: p.x, p50: r?.p50 ?? 0, p95: r?.p95 ?? 0, p99: r?.p99 ?? 0 };
+      });
+      return {
+        points,
+        series: PERCENTILE_SERIES,
+        kind: "line",
+        format: formatMs,
+        tick: tickMs,
+        stats: [
+          { label: "p50", value: formatMs(meanSeries(points, "p50")) },
+          { label: "p99", value: formatMs(meanSeries(points, "p99")) },
+        ],
+        isLoading: bundle.latency.isLoading,
+        isError: bundle.latency.isError,
+      };
+    }
+    case "errors": {
+      const counts = pivot(
+        bundle.requests.data?.points ?? [],
+        range,
+        STATUS_SERIES.map((s) => s.key),
+      );
+      const points = counts.map((p) => {
+        const total = STATUS_SERIES.reduce((acc, s) => acc + (p[s.key] ?? 0), 0);
+        return {
+          x: p.x,
+          rate: total > 0 ? ((p["5xx"] ?? 0) / total) * 100 : 0,
+          count: p["5xx"] ?? 0,
+        };
+      });
+      const total = STATUS_SERIES.reduce((acc, s) => acc + sumSeries(counts, s.key), 0);
+      const errors = sumSeries(counts, "5xx");
+      return {
+        points,
+        series: [{ key: "rate", label: "5xx rate", color: METRIC_COLORS.errors }],
+        kind: "area",
+        format: formatPercent,
+        tick: tickPercent,
+        yMax: Math.max(1, ...points.map((p) => p.rate)) * 1.15,
+        stats: [
+          { label: "5xx", value: formatCount(errors) },
+          { label: "Rate", value: formatPercent(total > 0 ? (errors / total) * 100 : 0) },
+        ],
+        isLoading: bundle.requests.isLoading,
+        isError: bundle.requests.isError,
+      };
+    }
+  }
+}
+
+// Overview card content when deployments are picked: one series per pick,
+// totals summed over the picks only.
+function shapeSelected(
+  bundle: MetricsBundle,
+  detail: Detail,
+  split: ReturnType<typeof splitByDeployment>,
+  selected: string[],
+  colorOf: (id: string) => string,
+  index: Map<string, DeploymentInfo>,
+): Shaped {
+  const base = shape(bundle, detail);
+  const b = bundle.range.bucketSeconds;
+  const series: SeriesKey[] = selected.map((id) => ({
+    key: id,
+    label: shortSha(index.get(id)?.sha) || id.slice(-7),
+    color: colorOf(id),
+  }));
+  const per = (id: string) => split.perDeployment.get(id) ?? [];
+  const req = (id: string) => split.requestPoints.get(id) ?? [];
+  const value = (id: string, i: number): number => {
+    switch (detail) {
+      case "requests":
+        return STATUS_SERIES.reduce((acc, st) => acc + (req(id)[i]?.[st.key] ?? 0), 0);
+      case "errors": {
+        const p = req(id)[i];
+        const total = STATUS_SERIES.reduce((acc, st) => acc + (p?.[st.key] ?? 0), 0);
+        return total > 0 ? ((p?.["5xx"] ?? 0) / total) * 100 : 0;
+      }
+      case "transfer":
+        return per(id)[i]?.egress ?? 0;
+      case "cpu":
+        return per(id)[i]?.cpu ?? 0;
+      case "memory":
+        return per(id)[i]?.memory ?? 0;
+      case "disk":
+        return per(id)[i]?.disk ?? 0;
+      case "latency": {
+        const rows = bundle.latency.data?.points ?? [];
+        const x = bundle.range.startMs + i * b * 1000;
+        return rows.find((r) => r.series === id && r.x === x)?.p99 ?? 0;
+      }
+    }
+  };
+  const points: SeriesPoint[] = pivot([], bundle.range, []).map((p, i) => {
+    const row: SeriesPoint = { x: p.x };
+    for (const id of selected) {
+      row[id] = value(id, i);
+    }
+    return row;
+  });
+  const isCounter = detail === "requests" || detail === "transfer";
+  const stats: Shaped["stats"] = (() => {
+    switch (detail) {
+      case "requests": {
+        const total = selected.reduce((acc, id) => acc + sumSeries(points, id), 0);
+        const errors = selected.reduce((acc, id) => acc + sumSeries(req(id), "5xx"), 0);
+        return [
+          { label: "Total", value: formatCount(total) },
+          { label: "5xx", value: formatPercent(total > 0 ? (errors / total) * 100 : 0) },
+        ];
+      }
+      case "transfer":
+        return [
+          {
+            label: "Outgoing",
+            value: formatBytes(selected.reduce((acc, id) => acc + sumSeries(points, id), 0)),
+          },
+        ];
+      case "cpu": {
+        const cpuSeconds = (bundle.cpu.data?.points ?? [])
+          .filter((r) => selected.includes(r.series))
+          .reduce((acc, r) => acc + r.y / 1e6, 0);
+        return [{ label: "CPU time", value: formatCpuTime(cpuSeconds) }];
+      }
+      case "memory":
+        return [
+          {
+            label: "Peak",
+            value: formatBytes(Math.max(0, ...selected.map((id) => maxSeries(points, id)))),
+          },
+        ];
+      case "disk":
+        return [
+          {
+            label: "Peak used",
+            value: formatBytes(Math.max(0, ...selected.map((id) => maxSeries(points, id)))),
+          },
+        ];
+      case "latency":
+        return [
+          {
+            label: "p99",
+            value: formatMs(
+              selected.reduce((acc, id) => acc + meanSeries(points, id), 0) / selected.length,
+            ),
+          },
+        ];
+      case "errors": {
+        const total = selected.reduce(
+          (acc, id) => acc + STATUS_SERIES.reduce((a, st) => a + sumSeries(req(id), st.key), 0),
+          0,
+        );
+        const errors = selected.reduce((acc, id) => acc + sumSeries(req(id), "5xx"), 0);
+        return [
+          { label: "5xx", value: formatCount(errors) },
+          { label: "Rate", value: formatPercent(total > 0 ? (errors / total) * 100 : 0) },
+        ];
+      }
+    }
+  })();
+  return {
+    ...base,
+    points,
+    series,
+    kind: isCounter ? "bar" : "line",
+    stacked: isCounter,
+    stats,
+    yMax:
+      detail === "errors"
+        ? Math.max(1, ...points.flatMap((p) => selected.map((id) => p[id] ?? 0))) * 1.15
+        : undefined,
+  };
+}
+
+function Overview({
+  bundle,
+  onOpen,
+  selected,
+  colorOf,
+}: {
+  bundle: MetricsBundle;
+  onOpen: (d: Detail) => void;
+  selected: string[];
+  colorOf: (id: string) => string;
+}) {
+  const domain: [number, number] = [bundle.range.startMs, bundle.range.endMs];
+  const index = useDeploymentIndex();
+  const split = selected.length > 0 ? splitByDeployment(bundle) : null;
+  return (
+    <div className="grid grid-cols-1 xl:grid-cols-2 gap-4">
+      {DETAILS.map((d) => {
+        const s = split
+          ? shapeSelected(bundle, d, split, selected, colorOf, index)
+          : shape(bundle, d);
+        return (
+          <OverviewCard key={d} title={DETAIL_TITLES[d]} stats={s.stats} onOpen={() => onOpen(d)}>
+            <MetricsChart
+              points={s.points}
+              series={s.series}
+              kind={s.kind}
+              stacked={s.stacked}
+              height={150}
+              domain={domain}
+              bucketSeconds={bundle.range.bucketSeconds}
+              markers={bundle.markers}
+              showMarkerLabels={false}
+              syncId="app-metrics"
+              formatValue={s.format}
+              formatTick={s.tick}
+              yMax={s.yMax}
+              isLoading={s.isLoading}
+              isError={s.isError}
+            />
+          </OverviewCard>
+        );
+      })}
+    </div>
+  );
+}
+
+function OverviewCard({
+  title,
+  stats,
+  onOpen,
+  children,
+}: {
+  title: string;
+  stats: Shaped["stats"];
+  onOpen: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <section className="border border-gray-4 bg-grayA-1 rounded-lg flex flex-col min-w-0">
+      <button
+        type="button"
+        onClick={onOpen}
+        className="group flex items-center justify-between gap-3 px-4 pt-3 pb-1 text-left rounded-t-lg hover:bg-grayA-2 transition-colors"
+      >
+        <span className="text-[13px] font-medium text-gray-12">{title}</span>
+        <ChevronRight
+          iconSize="sm-regular"
+          className="text-gray-9 group-hover:text-gray-12 transition-colors"
+        />
+      </button>
+      <div className="flex items-baseline gap-5 px-4 pb-2">
+        {stats.map((st) => (
+          <div key={st.label} className="flex flex-col">
+            <span className="text-[11px] text-gray-10">{st.label}</span>
+            <span className="flex items-center gap-1.5 text-[15px] font-medium text-gray-12 tabular-nums">
+              {st.color && (
+                <span className="size-2 rounded-full" style={{ backgroundColor: st.color }} />
+              )}
+              {st.value}
+            </span>
+          </div>
+        ))}
+      </div>
+      <div className="px-2 pb-2">{children}</div>
+    </section>
+  );
+}
+
+// ─── Detail ──────────────────────────────────────────────────────────
+
+type Row = {
+  id: string;
+  info: DeploymentInfo | undefined;
+  color: string;
+  requests: number;
+  errors: number;
+  egress: number;
+  cpuSeconds: number;
+  peakMemory: number;
+  peakDisk: number;
+  p99: number;
+  spark: SeriesPoint[];
+  sparkKey: string;
+};
+
+// Splits every series by deployment id. Request series arrive as
+// "deployment:2xx", so their id is the part before the colon.
+function splitByDeployment(bundle: MetricsBundle): {
+  ids: string[];
+  perDeployment: Map<string, SeriesPoint[]>;
+  requestPoints: Map<string, SeriesPoint[]>;
+} {
+  const ids: string[] = [];
+  const seen = new Set<string>();
+  const push = (id: string) => {
+    if (!seen.has(id)) {
+      seen.add(id);
+      ids.push(id);
+    }
+  };
+  for (const r of bundle.requests.data?.points ?? []) {
+    push(r.series.split(":")[0]);
+  }
+  for (const q of [bundle.egress, bundle.cpu, bundle.memory, bundle.disk, bundle.ingress]) {
+    for (const k of seriesKeysOf(q.data?.points ?? [])) {
+      push(k);
+    }
+  }
+
+  const perDeployment = new Map<string, SeriesPoint[]>();
+  const requestPoints = new Map<string, SeriesPoint[]>();
+  const b = bundle.range.bucketSeconds;
+  for (const id of ids) {
+    const only = (q: MetricsBundle["cpu"], key: string, scale: (y: number) => number = (y) => y) =>
+      pivot(
+        (q.data?.points ?? []).filter((r) => r.series === id).map((r) => ({ ...r, series: key })),
+        bundle.range,
+        [key],
+        scale,
+      );
+    const egress = only(bundle.egress, "egress");
+    const ingress = only(bundle.ingress, "ingress");
+    const cpu = only(bundle.cpu, "cpu", (y) => y / b / 1000);
+    const memory = only(bundle.memory, "memory");
+    const disk = only(bundle.disk, "disk");
+    const merged = egress.map((p, i) => ({
+      ...p,
+      ingress: ingress[i]?.ingress ?? 0,
+      cpu: cpu[i]?.cpu ?? 0,
+      memory: memory[i]?.memory ?? 0,
+      disk: disk[i]?.disk ?? 0,
+    }));
+    perDeployment.set(id, merged);
+
+    const reqs = pivot(
+      (bundle.requests.data?.points ?? [])
+        .filter((r) => r.series.startsWith(`${id}:`))
+        .map((r) => ({ ...r, series: r.series.split(":")[1] })),
+      bundle.range,
+      STATUS_SERIES.map((s) => s.key),
+    );
+    requestPoints.set(id, reqs);
+  }
+  return { ids, perDeployment, requestPoints };
+}
+
+function DetailView({
+  detail,
+  bundle,
+  appId,
+  selected,
+  colorOf,
+}: {
+  detail: Detail;
+  bundle: MetricsBundle;
+  appId: string;
+  selected: string[];
+  colorOf: (id: string) => string;
+}) {
+  const index = useDeploymentIndex();
+  const all = splitByDeployment(bundle);
+  const ids = selected.length > 0 ? all.ids.filter((id) => selected.includes(id)) : all.ids;
+  const { perDeployment, requestPoints } = all;
+  const b = bundle.range.bucketSeconds;
+  const domain: [number, number] = [bundle.range.startMs, bundle.range.endMs];
+  const latencyByDep = new Map<string, Map<number, number>>();
+  for (const r of bundle.latency.data?.points ?? []) {
+    if (!latencyByDep.has(r.series)) {
+      latencyByDep.set(r.series, new Map());
+    }
+    latencyByDep.get(r.series)?.set(r.x, r.p99);
+  }
+
+  const rows: Row[] = ids.map((id) => {
+    const res = perDeployment.get(id) ?? [];
+    const req = requestPoints.get(id) ?? [];
+    const requests = STATUS_SERIES.reduce((acc, s) => acc + sumSeries(req, s.key), 0);
+    const errors = sumSeries(req, "5xx");
+    const cpuSeconds = (bundle.cpu.data?.points ?? [])
+      .filter((r) => r.series === id)
+      .reduce((acc, r) => acc + r.y / 1e6, 0);
+    const latencyMap = latencyByDep.get(id);
+    const p99Values = [...(latencyMap?.values() ?? [])].filter((v) => v > 0);
+    const p99 = p99Values.length ? p99Values.reduce((a, v) => a + v, 0) / p99Values.length : 0;
+
+    let spark: SeriesPoint[];
+    let sparkKey: string;
+    switch (detail) {
+      case "requests":
+        spark = req.map((p) => ({
+          x: p.x,
+          v: STATUS_SERIES.reduce((acc, s) => acc + (p[s.key] ?? 0), 0),
+        }));
+        sparkKey = "v";
+        break;
+      case "errors":
+        spark = req.map((p) => ({ x: p.x, v: p["5xx"] ?? 0 }));
+        sparkKey = "v";
+        break;
+      case "latency":
+        spark = pivot([], bundle.range, ["v"]).map((p) => ({
+          x: p.x,
+          v: latencyMap?.get(p.x) ?? 0,
+        }));
+        sparkKey = "v";
+        break;
+      case "transfer":
+        spark = res;
+        sparkKey = "egress";
+        break;
+      default:
+        spark = res;
+        sparkKey = detail;
+    }
+
+    return {
+      id,
+      info: index.get(id),
+      color: colorOf(id),
+      requests,
+      errors,
+      egress: sumSeries(res, "egress"),
+      cpuSeconds,
+      peakMemory: maxSeries(res, "memory"),
+      peakDisk: maxSeries(res, "disk"),
+      p99,
+      spark,
+      sparkKey,
+    };
+  });
+
+  const sortValue = (r: Row): number => {
+    switch (detail) {
+      case "requests":
+        return r.requests;
+      case "errors":
+        return r.errors;
+      case "transfer":
+        return r.egress;
+      case "cpu":
+        return r.cpuSeconds;
+      case "memory":
+        return r.peakMemory;
+      case "disk":
+        return r.peakDisk;
+      case "latency":
+        return r.p99;
+    }
+  };
+  rows.sort((a, c) => sortValue(c) - sortValue(a));
+
+  // Big chart: one series per deployment. Counters stack (they add up to
+  // the app total), gauges and latency overlay.
+  const series: SeriesKey[] = rows.map((r) => ({
+    key: r.id,
+    label: r.info ? `${shortSha(r.info.sha) || r.id} ${r.info.message ?? ""}`.trim() : r.id,
+    color: r.color,
+  }));
+  const bigPoints: SeriesPoint[] = pivot([], bundle.range, []).map((p, i) => {
+    const row: SeriesPoint = { x: p.x };
+    for (const r of rows) {
+      row[r.id] = r.spark[i]?.[r.sparkKey] ?? 0;
+    }
+    return row;
+  });
+  const isCounter =
+    detail === "requests" || detail === "errors" || detail === "transfer" || detail === "cpu";
+  const [format, tick] = ((): [(v: number) => string, (v: number) => string] => {
+    switch (detail) {
+      case "requests":
+      case "errors":
+        return [formatCount, tickCount];
+      case "transfer":
+        return [(v: number) => formatBytes(v), tickBytes];
+      case "cpu":
+        return [formatVcpu, tickVcpu];
+      case "latency":
+        return [formatMs, tickMs];
+      default:
+        return [(v: number) => formatBytes(v), tickBytes];
+    }
+  })();
+  const anyLoading = [bundle.requests, bundle.egress, bundle.cpu, bundle.memory, bundle.disk].some(
+    (q) => q.isLoading,
+  );
+
+  return (
+    <div className="flex flex-col gap-4">
+      <section className="border border-gray-4 bg-grayA-1 rounded-lg">
+        <header className="flex items-center justify-between px-4 pt-3 pb-1">
+          <h3 className="text-[13px] font-medium text-gray-12">
+            {DETAIL_TITLES[detail]} <span className="text-gray-10 font-normal">by deployment</span>
+          </h3>
+          <span className="text-[11px] text-gray-10">
+            {detail === "cpu" ? "vCPU per bucket" : detail === "latency" ? "p99" : null}
+          </span>
+        </header>
+        <div className="px-2 pb-2">
+          <MetricsChart
+            points={bigPoints}
+            series={series}
+            kind={isCounter ? "bar" : "line"}
+            stacked={isCounter}
+            height={260}
+            domain={domain}
+            bucketSeconds={b}
+            markers={bundle.markers}
+            showMarkerLabels={false}
+            formatValue={format}
+            formatTick={tick}
+            isLoading={anyLoading}
+            isError={bundle.requests.isError}
+          />
+        </div>
+      </section>
+
+      <BreakdownTable rows={rows} detail={detail} appId={appId} bundle={bundle} />
+    </div>
+  );
+}
+
+function BreakdownTable({
+  rows,
+  detail,
+  appId,
+  bundle,
+}: {
+  rows: Row[];
+  detail: Detail;
+  appId: string;
+  bundle: MetricsBundle;
+}) {
+  const { projectId } = useProjectData();
+  const workspace = useWorkspaceNavigation();
+  const domain: [number, number] = [bundle.range.startMs, bundle.range.endMs];
+  const primary = (r: Row): string => {
+    switch (detail) {
+      case "requests":
+        return formatCount(r.requests);
+      case "errors":
+        return formatCount(r.errors);
+      case "transfer":
+        return formatBytes(r.egress);
+      case "cpu":
+        return formatCpuTime(r.cpuSeconds);
+      case "memory":
+        return formatBytes(r.peakMemory);
+      case "disk":
+        return formatBytes(r.peakDisk);
+      case "latency":
+        return formatMs(r.p99);
+    }
+  };
+
+  const cols: { key: string; label: string; cell: (r: Row) => string }[] = [
+    { key: "requests", label: "Requests", cell: (r) => formatCount(r.requests) },
+    {
+      key: "errors",
+      label: "5xx",
+      cell: (r) => (r.requests > 0 ? formatPercent((r.errors / r.requests) * 100) : "0%"),
+    },
+    { key: "egress", label: "Egress", cell: (r) => formatBytes(r.egress) },
+    { key: "cpu", label: "CPU time", cell: (r) => formatCpuTime(r.cpuSeconds) },
+    { key: "memory", label: "Peak mem", cell: (r) => formatBytes(r.peakMemory) },
+  ];
+
+  return (
+    <section className="border border-gray-4 bg-grayA-1 rounded-lg overflow-hidden">
+      <div className="overflow-x-auto">
+        <table className="w-full text-[12px]">
+          <thead>
+            <tr className="text-left text-gray-10 border-b border-gray-4">
+              <th className="font-normal px-4 py-2">Deployment</th>
+              {cols.map((c) => (
+                <th
+                  key={c.key}
+                  className={cn(
+                    "font-normal px-3 py-2 text-right whitespace-nowrap",
+                    c.key === detail && "text-gray-12",
+                  )}
+                >
+                  {c.label}
+                </th>
+              ))}
+              <th className="font-normal px-3 py-2 text-right whitespace-nowrap text-gray-12">
+                {DETAIL_TITLES[detail]}
+              </th>
+              <th className="px-3 py-2 w-[140px]" />
+            </tr>
+          </thead>
+          <tbody>
+            {rows.length === 0 && (
+              <tr>
+                <td colSpan={cols.length + 3} className="px-4 py-6 text-center text-gray-10">
+                  No deployments served traffic in this range.
+                </td>
+              </tr>
+            )}
+            {rows.map((r) => (
+              <tr key={r.id} className="border-b border-gray-3 last:border-0 hover:bg-grayA-2">
+                <td className="px-4 py-2.5 min-w-[260px]">
+                  <Link
+                    href={routes.projects.apps.deployment({
+                      workspaceSlug: workspace.slug,
+                      projectId,
+                      appId,
+                      deploymentId: r.id,
+                    })}
+                    className="flex items-center gap-2.5 group"
+                  >
+                    <span
+                      className="size-2 rounded-full shrink-0"
+                      style={{ backgroundColor: r.color }}
+                    />
+                    <span className="font-mono text-gray-12">
+                      {shortSha(r.info?.sha) || r.id.slice(-7)}
+                    </span>
+                    <span className="text-gray-11 truncate max-w-[280px] group-hover:text-gray-12">
+                      {r.info?.message ?? r.id}
+                    </span>
+                    {r.info && (
+                      <Badge variant="secondary" size="sm" className="capitalize shrink-0">
+                        {r.info.status}
+                      </Badge>
+                    )}
+                    {r.info && (
+                      <span className="text-gray-9 tabular-nums shrink-0">
+                        {new Date(r.info.createdAt).toLocaleDateString(undefined, {
+                          month: "short",
+                          day: "numeric",
+                        })}
+                      </span>
+                    )}
+                  </Link>
+                </td>
+                {cols.map((c) => (
+                  <td
+                    key={c.key}
+                    className={cn(
+                      "px-3 py-2.5 text-right font-mono tabular-nums text-gray-11",
+                      c.key === detail && "text-gray-12",
+                    )}
+                  >
+                    {c.cell(r)}
+                  </td>
+                ))}
+                <td className="px-3 py-2.5 text-right font-mono tabular-nums text-gray-12 font-medium">
+                  {primary(r)}
+                </td>
+                <td className="px-3 py-1.5">
+                  <MetricsChart
+                    points={r.spark}
+                    series={[{ key: r.sparkKey, label: DETAIL_TITLES[detail], color: r.color }]}
+                    kind="area"
+                    height={28}
+                    domain={domain}
+                    bucketSeconds={bundle.range.bucketSeconds}
+                    showAxes={false}
+                    formatValue={() => ""}
+                    emptyMessage=""
+                  />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/web/apps/dashboard/components/navigation/sidebar-v2/sidebar-body.tsx
+++ b/web/apps/dashboard/components/navigation/sidebar-v2/sidebar-body.tsx
@@ -24,6 +24,7 @@ export function SidebarBody() {
   const { slug } = useWorkspaceNavigation();
   const { keyAuthId } = useApiKeyAuthId(context.type === "api" ? context.apiId : undefined);
   const portalManagement = useFlag("portalManagement");
+  const appMetrics = useFlag("appMetrics");
 
   const links = (() => {
     switch (context.type) {
@@ -37,7 +38,7 @@ export function SidebarBody() {
         return buildWorkspaceSections(slug, segments);
       case "project":
         return context.appId
-          ? buildAppLinks(slug, context.projectId, context.appId, segments)
+          ? buildAppLinks(slug, context.projectId, context.appId, segments, appMetrics)
           : buildProjectLinks(slug, context.projectId, segments);
       case "api":
         return buildApiLinks(slug, context.apiId, keyAuthId, segments, portalManagement);

--- a/web/apps/dashboard/lib/flags/index.ts
+++ b/web/apps/dashboard/lib/flags/index.ts
@@ -97,3 +97,17 @@ export const portalManagement = flag<boolean, Entities>({
   identify,
   adapter: adapter(),
 });
+
+// appMetrics gates the per-app Metrics tab. Off until the page leaves
+// prototype; enable per-workspace to test against real traffic first.
+export const appMetrics = flag<boolean, Entities>({
+  key: "app-metrics",
+  description: "Show the app-level Metrics tab (resources, requests, latency with deploy markers).",
+  defaultValue: false,
+  options: [
+    { value: false, label: "Off" },
+    { value: true, label: "On" },
+  ],
+  identify,
+  adapter: adapter(),
+});

--- a/web/apps/dashboard/lib/flags/resolve.ts
+++ b/web/apps/dashboard/lib/flags/resolve.ts
@@ -13,6 +13,7 @@ export async function resolveAll() {
     logdrains,
     portalManagement,
     projectsNav,
+    appMetrics,
   ] = await Promise.all([
     flags.helloWorld(),
     flags.deployBilling(),
@@ -21,6 +22,7 @@ export async function resolveAll() {
     flags.logdrains(),
     flags.portalManagement(),
     flags.projectsNav(),
+    flags.appMetrics(),
   ]);
   return {
     helloWorld,
@@ -30,6 +32,7 @@ export async function resolveAll() {
     logdrains,
     portalManagement,
     projectsNav,
+    appMetrics,
   };
 }
 

--- a/web/apps/dashboard/lib/navigation/leaves.ts
+++ b/web/apps/dashboard/lib/navigation/leaves.ts
@@ -2,6 +2,7 @@ import {
   ArrowDottedRotateAnticlockwise,
   ArrowOppositeDirectionY,
   BracketsSquareDots,
+  ChartActivity,
   Cube,
   Fingerprint,
   Gauge,
@@ -123,9 +124,21 @@ export function buildAppLinks(
   projectId: string,
   appId: string,
   segments: string[],
+  appMetricsEnabled: boolean,
 ): ResolvedNavLink[] {
   const page = segments[4];
   const scope = { workspaceSlug: slug, projectId, appId };
+  const metricsLink: ResolvedNavLink[] = appMetricsEnabled
+    ? [
+        {
+          key: "metrics",
+          label: "Metrics",
+          href: routes.projects.apps.metrics(scope),
+          icon: ChartActivity,
+          isActive: page === "metrics",
+        },
+      ]
+    : [];
   return [
     {
       key: "overview",
@@ -141,6 +154,7 @@ export function buildAppLinks(
       icon: SquareBulletList,
       isActive: page === "deployments",
     },
+    ...metricsLink,
     {
       key: "env-vars",
       label: "Environment Variables",

--- a/web/apps/dashboard/lib/navigation/routes/projects.ts
+++ b/web/apps/dashboard/lib/navigation/routes/projects.ts
@@ -103,6 +103,18 @@ export const projectRoutes = {
       );
     },
 
+    metrics({
+      environmentId,
+      v,
+      ...scope
+    }: AppScope & { environmentId?: string; v?: string }): Route {
+      return buildRoute(
+        "/[workspaceSlug]/projects/[projectId]/apps/[appId]/metrics",
+        appParams(scope),
+        { environmentId, v },
+      );
+    },
+
     deployment({
       deploymentId,
       build,

--- a/web/apps/dashboard/lib/trpc/routers/deploy/metrics/get-app-metrics.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/metrics/get-app-metrics.ts
@@ -1,0 +1,121 @@
+import { clickhouse } from "@/lib/clickhouse";
+import { db } from "@/lib/db";
+import { ratelimit, withRatelimit, workspaceProcedure } from "@/lib/trpc/trpc";
+import { TRPCError } from "@trpc/server";
+import {
+  APP_METRICS_GROUPS,
+  APP_METRICS_WINDOWS,
+  APP_RESOURCE_METRICS,
+  resolveAppMetricsRange,
+} from "@unkey/clickhouse";
+import { z } from "zod";
+
+const scopeInput = z.object({
+  appId: z.string(),
+  environmentId: z.string(),
+  window: z.enum(APP_METRICS_WINDOWS),
+  groupBy: z.enum(APP_METRICS_GROUPS).default("none"),
+});
+
+type Scope = z.infer<typeof scopeInput>;
+
+// The environment carries the project id and must belong to both the app and
+// the workspace, so one lookup authorizes the whole scope.
+async function resolveScope(workspaceId: string, input: Scope) {
+  const environment = await db.query.environments.findFirst({
+    where: (table, { eq, and }) =>
+      and(
+        eq(table.id, input.environmentId),
+        eq(table.appId, input.appId),
+        eq(table.workspaceId, workspaceId),
+      ),
+    columns: { id: true, projectId: true, appId: true },
+  });
+  if (!environment) {
+    throw new TRPCError({ code: "NOT_FOUND", message: "Environment not found" });
+  }
+  const range = resolveAppMetricsRange(input.window, Date.now());
+  return {
+    range,
+    query: {
+      workspaceId,
+      projectId: environment.projectId,
+      appId: environment.appId,
+      environmentId: environment.id,
+      window: input.window,
+      groupBy: input.groupBy,
+      startMs: range.startMs,
+      endMs: range.endMs,
+    },
+  };
+}
+
+function failed(message: string, cause: unknown): TRPCError {
+  return new TRPCError({ code: "INTERNAL_SERVER_ERROR", message, cause });
+}
+
+export const getAppResourceTimeseries = workspaceProcedure
+  .use(withRatelimit(ratelimit.read))
+  .input(scopeInput.extend({ metric: z.enum(APP_RESOURCE_METRICS) }))
+  .query(async ({ ctx, input }) => {
+    const { range, query } = await resolveScope(ctx.workspace.id, input);
+    const result = await clickhouse.appMetrics.resources({ ...query, metric: input.metric });
+    if (result.err) {
+      throw failed("Failed to fetch resource metrics", result.err);
+    }
+    return { range, points: result.val };
+  });
+
+export const getAppRequestTimeseries = workspaceProcedure
+  .use(withRatelimit(ratelimit.read))
+  .input(scopeInput)
+  .query(async ({ ctx, input }) => {
+    const { range, query } = await resolveScope(ctx.workspace.id, input);
+    const result = await clickhouse.appMetrics.requests(query);
+    if (result.err) {
+      throw failed("Failed to fetch request metrics", result.err);
+    }
+    return { range, points: result.val };
+  });
+
+export const getAppLatencyTimeseries = workspaceProcedure
+  .use(withRatelimit(ratelimit.read))
+  .input(scopeInput)
+  .query(async ({ ctx, input }) => {
+    const { range, query } = await resolveScope(ctx.workspace.id, input);
+    const result = await clickhouse.appMetrics.latency(query);
+    if (result.err) {
+      throw failed("Failed to fetch latency metrics", result.err);
+    }
+    return { range, points: result.val };
+  });
+
+// Deployments created inside the window, for the deploy markers. Deployments
+// that started before the window but still serve traffic are not markers;
+// they show up as series when grouping by deployment instead.
+export const getAppDeploymentMarkers = workspaceProcedure
+  .use(withRatelimit(ratelimit.read))
+  .input(scopeInput.omit({ groupBy: true }))
+  .query(async ({ ctx, input }) => {
+    const { range, query } = await resolveScope(ctx.workspace.id, { ...input, groupBy: "none" });
+    const rows = await db.query.deployments.findMany({
+      where: (table, { eq, and, gte, lt }) =>
+        and(
+          eq(table.workspaceId, ctx.workspace.id),
+          eq(table.appId, query.appId),
+          eq(table.environmentId, query.environmentId),
+          gte(table.createdAt, range.startMs),
+          lt(table.createdAt, range.endMs),
+        ),
+      columns: {
+        id: true,
+        createdAt: true,
+        status: true,
+        gitCommitSha: true,
+        gitCommitMessage: true,
+        gitBranch: true,
+      },
+      orderBy: (table, { asc }) => asc(table.createdAt),
+    });
+    return { range, markers: rows };
+  });

--- a/web/apps/dashboard/lib/trpc/routers/index.ts
+++ b/web/apps/dashboard/lib/trpc/routers/index.ts
@@ -58,6 +58,12 @@ import { getAvailableKeyspaces } from "./deploy/environment-settings/get-availab
 import { getAvailableRegions } from "./deploy/environment-settings/get-available-regions";
 import { generateRegex } from "./deploy/environment-settings/policies/generate-regex";
 import { getAppRpsMetrics } from "./deploy/metrics/get-app-rps-metrics";
+import {
+  getAppDeploymentMarkers,
+  getAppLatencyTimeseries,
+  getAppRequestTimeseries,
+  getAppResourceTimeseries,
+} from "./deploy/metrics/get-app-metrics";
 import { getDeploymentCpuTimeseries } from "./deploy/metrics/get-deployment-cpu-timeseries";
 import { getDeploymentDiskTimeseries } from "./deploy/metrics/get-deployment-disk-timeseries";
 import { getDeploymentInstanceCountTimeseries } from "./deploy/metrics/get-deployment-instance-count-timeseries";
@@ -450,6 +456,10 @@ export const router = t.router({
     }),
     metrics: t.router({
       getAppRpsMetrics,
+      getAppResourceTimeseries,
+      getAppRequestTimeseries,
+      getAppLatencyTimeseries,
+      getAppDeploymentMarkers,
       getDeploymentRpsMetrics,
       getDeploymentLatencyMetrics,
       getDeploymentCpuTimeseries,

--- a/web/internal/clickhouse/src/app-metrics.ts
+++ b/web/internal/clickhouse/src/app-metrics.ts
@@ -1,0 +1,229 @@
+import { z } from "zod";
+import type { Querier } from "./client";
+
+// App-scoped metrics for the app Metrics page: every instance of one app in
+// one environment, bucketed over a fixed window and optionally split by
+// instance or by deployment. Deployment-scoped charts live in resources.ts and
+// frontline.ts; this module differs in scope (app + environment) and in the
+// split dimension, which is what lets a spike be traced to the deploy that
+// caused it.
+
+export const APP_METRICS_WINDOWS = ["1h", "6h", "1d", "1w", "30d"] as const;
+export type AppMetricsWindow = (typeof APP_METRICS_WINDOWS)[number];
+
+export const APP_METRICS_GROUPS = ["none", "instance", "deployment"] as const;
+export type AppMetricsGroup = (typeof APP_METRICS_GROUPS)[number];
+
+export const APP_RESOURCE_METRICS = ["cpu", "memory", "disk", "egress", "ingress"] as const;
+export type AppResourceMetric = (typeof APP_RESOURCE_METRICS)[number];
+
+type WindowSpec = {
+  windowSeconds: number;
+  bucketSeconds: number;
+  resourceTable: string;
+  requestTable: string;
+};
+
+// Bucket sizes target 60-300 points per chart. Rollups coarser than the
+// bucket are never read; finer rollups are re-bucketed in SQL, which is safe
+// because every column is a min/max/sum over a container's monotone counters.
+export const APP_METRICS_WINDOW_CONFIG: Record<AppMetricsWindow, WindowSpec> = {
+  "1h": {
+    windowSeconds: 60 * 60,
+    bucketSeconds: 60,
+    resourceTable: "instance_resources_per_minute_v1",
+    requestTable: "frontline_requests_per_minute_v1",
+  },
+  "6h": {
+    windowSeconds: 6 * 60 * 60,
+    bucketSeconds: 5 * 60,
+    resourceTable: "instance_resources_per_minute_v1",
+    requestTable: "frontline_requests_per_5m_v1",
+  },
+  "1d": {
+    windowSeconds: 24 * 60 * 60,
+    bucketSeconds: 15 * 60,
+    resourceTable: "instance_resources_per_minute_v1",
+    requestTable: "frontline_requests_per_15m_v1",
+  },
+  "1w": {
+    windowSeconds: 7 * 24 * 60 * 60,
+    bucketSeconds: 60 * 60,
+    resourceTable: "instance_resources_per_hour_v1",
+    requestTable: "frontline_requests_per_hour_v1",
+  },
+  "30d": {
+    windowSeconds: 30 * 24 * 60 * 60,
+    bucketSeconds: 6 * 60 * 60,
+    resourceTable: "instance_resources_per_hour_v1",
+    requestTable: "frontline_requests_per_hour_v1",
+  },
+};
+
+export type AppMetricsRange = {
+  startMs: number;
+  endMs: number;
+  bucketSeconds: number;
+};
+
+export function resolveAppMetricsRange(window: AppMetricsWindow, nowMs: number): AppMetricsRange {
+  const spec = APP_METRICS_WINDOW_CONFIG[window];
+  const bucketMs = spec.bucketSeconds * 1000;
+  const endMs = Math.floor(nowMs / bucketMs) * bucketMs + bucketMs;
+  return { startMs: endMs - spec.windowSeconds * 1000, endMs, bucketSeconds: spec.bucketSeconds };
+}
+
+const scopeParams = z.object({
+  workspaceId: z.string(),
+  projectId: z.string(),
+  appId: z.string(),
+  environmentId: z.string(),
+  window: z.enum(APP_METRICS_WINDOWS),
+  groupBy: z.enum(APP_METRICS_GROUPS),
+  startMs: z.number().int(),
+  endMs: z.number().int(),
+});
+
+const internalParams = scopeParams.extend({
+  tableName: z.string(),
+  bucketSeconds: z.number().int(),
+});
+
+const seriesPointSchema = z.object({
+  x: z.number().int(),
+  series: z.string(),
+  y: z.number(),
+});
+export type AppMetricsSeriesPoint = z.infer<typeof seriesPointSchema>;
+
+const BUCKET =
+  "toInt64(toUnixTimestamp(toStartOfInterval(time, INTERVAL {bucketSeconds: UInt32} SECOND)) * 1000)";
+
+const SCOPE_FILTER = `
+  workspace_id = {workspaceId: String}
+  AND project_id = {projectId: String}
+  AND app_id = {appId: String}
+  AND environment_id = {environmentId: String}
+  AND time >= fromUnixTimestamp64Milli({startMs: Int64})
+  AND time <  fromUnixTimestamp64Milli({endMs: Int64})`;
+
+// Per-container reduction inside a bucket. cpu and network are monotone
+// counters, so the delta of the rollup's max and min is the amount consumed
+// in that bucket. memory and disk are gauges, so the peak is kept.
+const RESOURCE_CONTAINER_AGG: Record<AppResourceMetric, string> = {
+  cpu: "sum(cpu_usage_usec_max - cpu_usage_usec_min)",
+  memory: "max(memory_bytes_max)",
+  disk: "max(disk_used_bytes_max)",
+  egress: "sum(network_egress_public_bytes_max - network_egress_public_bytes_min)",
+  ingress: "sum(network_ingress_public_bytes_max - network_ingress_public_bytes_min)",
+};
+
+const RESOURCE_SERIES: Record<AppMetricsGroup, string> = {
+  none: "''",
+  instance: "instance_id",
+  deployment: "resource_id",
+};
+
+// Resource series per bucket. cpu is in microseconds consumed per bucket,
+// egress/ingress in bytes per bucket, memory/disk in bytes at peak. Rates are
+// derived by the caller from bucketSeconds so one query serves both the
+// "rate" and the "total per bucket" presentations.
+export function getAppResourceTimeseries(ch: Querier) {
+  return async (args: z.infer<typeof scopeParams> & { metric: AppResourceMetric }) => {
+    const spec = APP_METRICS_WINDOW_CONFIG[args.window];
+    const query = ch.query({
+      query: `
+        SELECT x, series, toFloat64(sum(container_value)) AS y
+        FROM (
+          SELECT
+            ${BUCKET} AS x,
+            ${RESOURCE_SERIES[args.groupBy]} AS series,
+            container_uid,
+            ${RESOURCE_CONTAINER_AGG[args.metric]} AS container_value
+          FROM {tableName: Identifier}
+          WHERE ${SCOPE_FILTER}
+            AND resource_type = 'deployment'
+          GROUP BY x, series, container_uid
+        )
+        GROUP BY x, series
+        ORDER BY x ASC, series ASC`,
+      params: internalParams,
+      schema: seriesPointSchema,
+    });
+    const { metric: _metric, ...rest } = args;
+    return query({ ...rest, tableName: spec.resourceTable, bucketSeconds: spec.bucketSeconds });
+  };
+}
+
+const STATUS_CLASS = "concat(toString(intDiv(response_status, 100)), 'xx')";
+
+const REQUEST_SERIES: Record<AppMetricsGroup, string> = {
+  none: STATUS_CLASS,
+  instance: STATUS_CLASS,
+  deployment: `concat(deployment_id, ':', ${STATUS_CLASS})`,
+};
+
+// Request counts per bucket, split by status class (2xx, 3xx, 4xx, 5xx). The
+// deployment group keeps the status class as a suffix ("d_123:5xx") so the
+// caller can show both total and error traffic per deployment from one read.
+// The frontline rollups have no instance dimension, so the instance group
+// falls back to status class.
+export function getAppRequestTimeseries(ch: Querier) {
+  return async (args: z.infer<typeof scopeParams>) => {
+    const spec = APP_METRICS_WINDOW_CONFIG[args.window];
+    const query = ch.query({
+      query: `
+        SELECT
+          ${BUCKET} AS x,
+          ${REQUEST_SERIES[args.groupBy]} AS series,
+          toFloat64(sum(count)) AS y
+        FROM {tableName: Identifier}
+        WHERE ${SCOPE_FILTER}
+        GROUP BY x, series
+        ORDER BY x ASC, series ASC`,
+      params: internalParams,
+      schema: seriesPointSchema,
+    });
+    return query({ ...args, tableName: spec.requestTable, bucketSeconds: spec.bucketSeconds });
+  };
+}
+
+const latencyPointSchema = z.object({
+  x: z.number().int(),
+  series: z.string(),
+  p50: z.number(),
+  p95: z.number(),
+  p99: z.number(),
+});
+export type AppLatencyPoint = z.infer<typeof latencyPointSchema>;
+
+const LATENCY_SERIES: Record<AppMetricsGroup, string> = {
+  none: "''",
+  instance: "''",
+  deployment: "deployment_id",
+};
+
+// Latency percentiles per bucket in milliseconds. Buckets with no traffic
+// come back as NaN from quantile merge and are coerced to zero so the chart
+// can draw a gap-free line.
+export function getAppLatencyTimeseries(ch: Querier) {
+  return async (args: z.infer<typeof scopeParams>) => {
+    const spec = APP_METRICS_WINDOW_CONFIG[args.window];
+    const query = ch.query({
+      query: `
+        SELECT
+          ${BUCKET} AS x,
+          ${LATENCY_SERIES[args.groupBy]} AS series,
+          ifNotFinite(round(quantileTDigestMerge(0.5)(latency_p50), 2), 0) AS p50,
+          ifNotFinite(round(quantileTDigestMerge(0.95)(latency_p95), 2), 0) AS p95,
+          ifNotFinite(round(quantileTDigestMerge(0.99)(latency_p99), 2), 0) AS p99
+        FROM {tableName: Identifier}
+        WHERE ${SCOPE_FILTER}
+        GROUP BY x, series
+        ORDER BY x ASC, series ASC`,
+      params: internalParams,
+      schema: latencyPointSchema,
+    });
+    return query({ ...args, tableName: spec.requestTable, bucketSeconds: spec.bucketSeconds });
+  };
+}

--- a/web/internal/clickhouse/src/index.ts
+++ b/web/internal/clickhouse/src/index.ts
@@ -117,6 +117,24 @@ import {
 } from "./resources";
 export { TIME_WINDOWS, type TimeWindow } from "./resources";
 import {
+  getAppLatencyTimeseries,
+  getAppRequestTimeseries,
+  getAppResourceTimeseries,
+} from "./app-metrics";
+export {
+  APP_METRICS_WINDOWS,
+  APP_METRICS_GROUPS,
+  APP_RESOURCE_METRICS,
+  APP_METRICS_WINDOW_CONFIG,
+  resolveAppMetricsRange,
+  type AppMetricsWindow,
+  type AppMetricsGroup,
+  type AppResourceMetric,
+  type AppMetricsRange,
+  type AppMetricsSeriesPoint,
+  type AppLatencyPoint,
+} from "./app-metrics";
+import {
   getDeploymentLatencyWithTimeseries,
   getDeploymentRpsTimeseries,
   getInstanceRps,
@@ -386,6 +404,13 @@ export class ClickHouse {
         egress: { timeseries: getResourceNetworkEgressTimeseries(this.querier) },
         ingress: { timeseries: getResourceNetworkIngressTimeseries(this.querier) },
       },
+    };
+  }
+  public get appMetrics() {
+    return {
+      resources: getAppResourceTimeseries(this.querier),
+      requests: getAppRequestTimeseries(this.querier),
+      latency: getAppLatencyTimeseries(this.querier),
     };
   }
   public get environment() {


### PR DESCRIPTION
> **DO NOT MERGE.** Prototype for review and discussion only.

## What does this PR do?

Adds an app-level **Metrics** tab behind the `app-metrics` flag (off by default). It charts CPU, memory, disk, public egress/ingress, requests by status class, 5xx rate and latency percentiles for one app in one environment, with a marker on every deploy, so a spike can be traced to the release that caused it. Egress sits next to request volume on purpose: a customer recently got a surprise egress bill from a retry storm that no page in the product could attribute.

The page ships as two picker variants to compare: **Timeline** (equal-chart grid, Sum/Instances toggle, dotted deploy lines) and **Totals** (headline numbers per card, drill-in splits by deployment with a breakdown table). Both share an environment select, a time range, a searchable deployment combobox that splits every chart into one line per picked deployment, and hover synced across charts. Data comes from the existing `instance_resources_*` and `frontline_requests_*` rollups through new app+environment scoped ClickHouse queries.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Screenshots / recordings

_To be added — light, dark, mobile._

## How should this be tested?

- Add `app-metrics` to `FLAGS_LOCAL_OVERRIDES`, restart the dev server, open any app. A **Metrics** tab appears in the app sidebar; without the flag the route redirects to Overview.
- Switch environment and time range; every chart should re-query and share one x-axis.
- Hover any chart: cursor and tooltip should appear on all charts at the same bucket, and the tooltip should name a deploy when one falls in that bucket.
- Pick one or more deployments in the combobox: each chart becomes one line per pick, markers filter to the picks, the URL carries the selection.
- Press `2` or click the bottom pill for the Totals variant; click a card to drill in and check the per-deployment table sums match the card headline.
- Not tested: apps with dozens of deployments in range (the combobox scrolls but the chart palette repeats after seven), and the `1h` window against live heimdall data (only seeded data was available locally).

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [ ] Ran `mise run fmt`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues
- [ ] If I made a visual change: Filled out the "Screenshots / recordings" section, as shown in the [screenshot and recording guide](../docs/engineering/contributing/quality/screenshots-and-recordings.mdx)

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary
