### PR TITLE
chore(db): add project-scoped permissions and roles index

### DIFF
--- a/pkg/mysql/schema/permissions.sql
+++ b/pkg/mysql/schema/permissions.sql
@@ -10,7 +10,10 @@ CREATE TABLE `permissions` (
 	`updated_at_m` bigint,
 	CONSTRAINT `permissions_pk` PRIMARY KEY(`pk`),
 	CONSTRAINT `permissions_id_unique` UNIQUE(`id`),
-	CONSTRAINT `unique_slug_per_workspace_idx` UNIQUE(`workspace_id`,`slug`)
+	CONSTRAINT `unique_slug_per_workspace_idx` UNIQUE(`workspace_id`,`slug`),
+	CONSTRAINT `unique_slug_per_project_idx` UNIQUE(`project_id`,`slug`)
 );
+
+CREATE INDEX `permissions_workspace_id_idx` ON `permissions` (`workspace_id`);
 
 CREATE INDEX `permissions_project_id_idx` ON `permissions` (`project_id`);

--- a/pkg/mysql/schema/roles.sql
+++ b/pkg/mysql/schema/roles.sql
@@ -9,7 +9,8 @@ CREATE TABLE `roles` (
 	`updated_at_m` bigint,
 	CONSTRAINT `roles_pk` PRIMARY KEY(`pk`),
 	CONSTRAINT `roles_id_unique` UNIQUE(`id`),
-	CONSTRAINT `unique_name_per_workspace_idx` UNIQUE(`name`,`workspace_id`)
+	CONSTRAINT `unique_name_per_workspace_idx` UNIQUE(`name`,`workspace_id`),
+	CONSTRAINT `unique_name_per_project_idx` UNIQUE(`project_id`,`name`)
 );
 
 CREATE INDEX `workspace_id_idx` ON `roles` (`workspace_id`);

--- a/pkg/mysql/schema/roles.sql
+++ b/pkg/mysql/schema/roles.sql
@@ -9,11 +9,9 @@ CREATE TABLE `roles` (
 	`updated_at_m` bigint,
 	CONSTRAINT `roles_pk` PRIMARY KEY(`pk`),
 	CONSTRAINT `roles_id_unique` UNIQUE(`id`),
-	CONSTRAINT `unique_name_per_workspace_idx` UNIQUE(`name`,`workspace_id`),
+	CONSTRAINT `unique_name_per_workspace_idx` UNIQUE(`workspace_id`,`name`),
 	CONSTRAINT `unique_name_per_project_idx` UNIQUE(`project_id`,`name`)
 );
-
-CREATE INDEX `workspace_id_idx` ON `roles` (`workspace_id`);
 
 CREATE INDEX `roles_project_id_idx` ON `roles` (`project_id`);
 

--- a/web/internal/db/src/schema/rbac.ts
+++ b/web/internal/db/src/schema/rbac.ts
@@ -96,6 +96,7 @@ export const roles = mysqlTable(
   (table) => [
     index("workspace_id_idx").on(table.workspaceId),
     unique("unique_name_per_workspace_idx").on(table.name, table.workspaceId),
+    unique("unique_name_per_project_idx").on(table.projectId, table.name),
     index("roles_project_id_idx").on(table.projectId),
   ],
 );

--- a/web/internal/db/src/schema/rbac.ts
+++ b/web/internal/db/src/schema/rbac.ts
@@ -24,6 +24,8 @@ export const permissions = mysqlTable(
   },
   (table) => [
     unique("unique_slug_per_workspace_idx").on(table.workspaceId, table.slug),
+    unique("unique_slug_per_project_idx").on(table.projectId, table.slug),
+    index("permissions_workspace_id_idx").on(table.workspaceId),
     index("permissions_project_id_idx").on(table.projectId),
   ],
 );

--- a/web/internal/db/src/schema/rbac.ts
+++ b/web/internal/db/src/schema/rbac.ts
@@ -94,8 +94,7 @@ export const roles = mysqlTable(
     updatedAtM: bigint("updated_at_m", { mode: "number" }).$onUpdateFn(() => Date.now()),
   },
   (table) => [
-    index("workspace_id_idx").on(table.workspaceId),
-    unique("unique_name_per_workspace_idx").on(table.name, table.workspaceId),
+    unique("unique_name_per_workspace_idx").on(table.workspaceId, table.name),
     unique("unique_name_per_project_idx").on(table.projectId, table.name),
     index("roles_project_id_idx").on(table.projectId),
   ],


### PR DESCRIPTION
When we moved permissions and roles to projects, we forgot to add an appropriate index to ensure uniqueness within a project.

This PR adds that index, but does not remove the old index yet, we'll do that later in this stack, after ensuring all reader/writers are handling the uniqueness correctly.