### PR TITLE
chore(db): add project-scoped role index

### DIFF
--- a/pkg/mysql/schema/roles.sql
+++ b/pkg/mysql/schema/roles.sql
@@ -9,7 +9,8 @@ CREATE TABLE `roles` (
 	`updated_at_m` bigint,
 	CONSTRAINT `roles_pk` PRIMARY KEY(`pk`),
 	CONSTRAINT `roles_id_unique` UNIQUE(`id`),
-	CONSTRAINT `unique_name_per_workspace_idx` UNIQUE(`name`,`workspace_id`)
+	CONSTRAINT `unique_name_per_workspace_idx` UNIQUE(`name`,`workspace_id`),
+	CONSTRAINT `unique_name_per_project_idx` UNIQUE(`project_id`,`name`)
 );
 
 CREATE INDEX `workspace_id_idx` ON `roles` (`workspace_id`);

--- a/web/internal/db/src/schema/rbac.ts
+++ b/web/internal/db/src/schema/rbac.ts
@@ -96,6 +96,7 @@ export const roles = mysqlTable(
   (table) => [
     index("workspace_id_idx").on(table.workspaceId),
     unique("unique_name_per_workspace_idx").on(table.name, table.workspaceId),
+    unique("unique_name_per_project_idx").on(table.projectId, table.name),
     index("roles_project_id_idx").on(table.projectId),
   ],
 );


### PR DESCRIPTION
## Notes for description (rewrite before review)

### Goal
- Allow role names to become unique per project without removing the existing workspace constraint yet.

### Approach
- Add `UNIQUE(project_id, name)` to the Drizzle role schema.
- Keep the regular `workspace_id` and `project_id` indexes.
- Regenerate `pkg/mysql/schema/roles.sql`.

### Decisions made in this session
- Keep `UNIQUE(workspace_id, name)` until the project-association checks are deployed and existing data is safe.
- Keep this PR independent from the permission index PR.
- Replace #7281 with a branch based on the current `main`.

### Review focus
- Confirm the new unique index can be created from current production data.

### Verification
- `mise run generate-sql` regenerated the expected role schema. Current `main` also produced unrelated trailing-newline drift in three SQL files, which this PR excludes.
- `git diff --check origin/main...HEAD` passed.