### PR TITLE
refactor: move rollback and promote to envVO

### DIFF
--- a/docs/engineering/architecture/services/control-plane/worker/overview.mdx
+++ b/docs/engineering/architecture/services/control-plane/worker/overview.mdx
@@ -34,8 +34,9 @@ The worker groups multiple Restate services into one process. Each service uses 
 
 | Service | Virtual object key | Responsibility |
 | --- | --- | --- |
-| DeployService | `project_id` | Build, deploy, promote, and rollback orchestration for a project. |
+| DeployService | `deployment_id` | Build, deploy, promote, and rollback orchestration for one deployment. |
 | DeploymentService | `deployment_id` | Serializes desired state changes with nonce-based last-writer-wins. |
+| EnvironmentService | `environment_id` | Environment deletion, and promotion and rollback of the environment's live deployment. |
 | RoutingService | `project_id` | Atomic reassignment of frontline routes to a deployment. |
 | CustomDomainService | `domain` | Domain ownership verification and post-verify actions. |
 | CertificateService | `domain` | Certificate issuance and renewal with ACME and Vault. |

--- a/gen/proto/hydra/v1/environment.pb.go
+++ b/gen/proto/hydra/v1/environment.pb.go
@@ -23,6 +23,208 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+type PromoteDeploymentRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	DeploymentId  string                 `protobuf:"bytes,1,opt,name=deployment_id,json=deploymentId,proto3" json:"deployment_id,omitempty"`
+	Actor         *v1.ActorInfo          `protobuf:"bytes,2,opt,name=actor,proto3" json:"actor,omitempty"`
+	CorrelationId string                 `protobuf:"bytes,3,opt,name=correlation_id,json=correlationId,proto3" json:"correlation_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PromoteDeploymentRequest) Reset() {
+	*x = PromoteDeploymentRequest{}
+	mi := &file_hydra_v1_environment_proto_msgTypes[0]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PromoteDeploymentRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PromoteDeploymentRequest) ProtoMessage() {}
+
+func (x *PromoteDeploymentRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_hydra_v1_environment_proto_msgTypes[0]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PromoteDeploymentRequest.ProtoReflect.Descriptor instead.
+func (*PromoteDeploymentRequest) Descriptor() ([]byte, []int) {
+	return file_hydra_v1_environment_proto_rawDescGZIP(), []int{0}
+}
+
+func (x *PromoteDeploymentRequest) GetDeploymentId() string {
+	if x != nil {
+		return x.DeploymentId
+	}
+	return ""
+}
+
+func (x *PromoteDeploymentRequest) GetActor() *v1.ActorInfo {
+	if x != nil {
+		return x.Actor
+	}
+	return nil
+}
+
+func (x *PromoteDeploymentRequest) GetCorrelationId() string {
+	if x != nil {
+		return x.CorrelationId
+	}
+	return ""
+}
+
+type PromoteDeploymentResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PromoteDeploymentResponse) Reset() {
+	*x = PromoteDeploymentResponse{}
+	mi := &file_hydra_v1_environment_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PromoteDeploymentResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PromoteDeploymentResponse) ProtoMessage() {}
+
+func (x *PromoteDeploymentResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_hydra_v1_environment_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PromoteDeploymentResponse.ProtoReflect.Descriptor instead.
+func (*PromoteDeploymentResponse) Descriptor() ([]byte, []int) {
+	return file_hydra_v1_environment_proto_rawDescGZIP(), []int{1}
+}
+
+// from_deployment_id is the live deployment the caller saw. The handler
+// refuses the rollback if it is no longer live.
+type RollbackDeploymentRequest struct {
+	state            protoimpl.MessageState `protogen:"open.v1"`
+	FromDeploymentId string                 `protobuf:"bytes,1,opt,name=from_deployment_id,json=fromDeploymentId,proto3" json:"from_deployment_id,omitempty"`
+	ToDeploymentId   string                 `protobuf:"bytes,2,opt,name=to_deployment_id,json=toDeploymentId,proto3" json:"to_deployment_id,omitempty"`
+	Actor            *v1.ActorInfo          `protobuf:"bytes,3,opt,name=actor,proto3" json:"actor,omitempty"`
+	CorrelationId    string                 `protobuf:"bytes,4,opt,name=correlation_id,json=correlationId,proto3" json:"correlation_id,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *RollbackDeploymentRequest) Reset() {
+	*x = RollbackDeploymentRequest{}
+	mi := &file_hydra_v1_environment_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RollbackDeploymentRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RollbackDeploymentRequest) ProtoMessage() {}
+
+func (x *RollbackDeploymentRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_hydra_v1_environment_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RollbackDeploymentRequest.ProtoReflect.Descriptor instead.
+func (*RollbackDeploymentRequest) Descriptor() ([]byte, []int) {
+	return file_hydra_v1_environment_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *RollbackDeploymentRequest) GetFromDeploymentId() string {
+	if x != nil {
+		return x.FromDeploymentId
+	}
+	return ""
+}
+
+func (x *RollbackDeploymentRequest) GetToDeploymentId() string {
+	if x != nil {
+		return x.ToDeploymentId
+	}
+	return ""
+}
+
+func (x *RollbackDeploymentRequest) GetActor() *v1.ActorInfo {
+	if x != nil {
+		return x.Actor
+	}
+	return nil
+}
+
+func (x *RollbackDeploymentRequest) GetCorrelationId() string {
+	if x != nil {
+		return x.CorrelationId
+	}
+	return ""
+}
+
+type RollbackDeploymentResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RollbackDeploymentResponse) Reset() {
+	*x = RollbackDeploymentResponse{}
+	mi := &file_hydra_v1_environment_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RollbackDeploymentResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RollbackDeploymentResponse) ProtoMessage() {}
+
+func (x *RollbackDeploymentResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_hydra_v1_environment_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RollbackDeploymentResponse.ProtoReflect.Descriptor instead.
+func (*RollbackDeploymentResponse) Descriptor() ([]byte, []int) {
+	return file_hydra_v1_environment_proto_rawDescGZIP(), []int{3}
+}
+
 // DeleteEnvironmentRequest carries the caller identity and correlation ID into
 // the durable workflow so the environment.delete audit log is written as part
 // of the retried deletion unit. Environment deletes are cascade-only (no direct
@@ -39,7 +241,7 @@ type DeleteEnvironmentRequest struct {
 
 func (x *DeleteEnvironmentRequest) Reset() {
 	*x = DeleteEnvironmentRequest{}
-	mi := &file_hydra_v1_environment_proto_msgTypes[0]
+	mi := &file_hydra_v1_environment_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -51,7 +253,7 @@ func (x *DeleteEnvironmentRequest) String() string {
 func (*DeleteEnvironmentRequest) ProtoMessage() {}
 
 func (x *DeleteEnvironmentRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_hydra_v1_environment_proto_msgTypes[0]
+	mi := &file_hydra_v1_environment_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -64,7 +266,7 @@ func (x *DeleteEnvironmentRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteEnvironmentRequest.ProtoReflect.Descriptor instead.
 func (*DeleteEnvironmentRequest) Descriptor() ([]byte, []int) {
-	return file_hydra_v1_environment_proto_rawDescGZIP(), []int{0}
+	return file_hydra_v1_environment_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *DeleteEnvironmentRequest) GetActor() *v1.ActorInfo {
@@ -89,7 +291,7 @@ type DeleteEnvironmentResponse struct {
 
 func (x *DeleteEnvironmentResponse) Reset() {
 	*x = DeleteEnvironmentResponse{}
-	mi := &file_hydra_v1_environment_proto_msgTypes[1]
+	mi := &file_hydra_v1_environment_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -101,7 +303,7 @@ func (x *DeleteEnvironmentResponse) String() string {
 func (*DeleteEnvironmentResponse) ProtoMessage() {}
 
 func (x *DeleteEnvironmentResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_hydra_v1_environment_proto_msgTypes[1]
+	mi := &file_hydra_v1_environment_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -114,20 +316,33 @@ func (x *DeleteEnvironmentResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteEnvironmentResponse.ProtoReflect.Descriptor instead.
 func (*DeleteEnvironmentResponse) Descriptor() ([]byte, []int) {
-	return file_hydra_v1_environment_proto_rawDescGZIP(), []int{1}
+	return file_hydra_v1_environment_proto_rawDescGZIP(), []int{5}
 }
 
 var File_hydra_v1_environment_proto protoreflect.FileDescriptor
 
 const file_hydra_v1_environment_proto_rawDesc = "" +
 	"\n" +
-	"\x1ahydra/v1/environment.proto\x12\bhydra.v1\x1a\x13ctrl/v1/actor.proto\x1a\x18dev/restate/sdk/go.proto\"k\n" +
+	"\x1ahydra/v1/environment.proto\x12\bhydra.v1\x1a\x13ctrl/v1/actor.proto\x1a\x18dev/restate/sdk/go.proto\"\x90\x01\n" +
+	"\x18PromoteDeploymentRequest\x12#\n" +
+	"\rdeployment_id\x18\x01 \x01(\tR\fdeploymentId\x12(\n" +
+	"\x05actor\x18\x02 \x01(\v2\x12.ctrl.v1.ActorInfoR\x05actor\x12%\n" +
+	"\x0ecorrelation_id\x18\x03 \x01(\tR\rcorrelationId\"\x1b\n" +
+	"\x19PromoteDeploymentResponse\"\xc4\x01\n" +
+	"\x19RollbackDeploymentRequest\x12,\n" +
+	"\x12from_deployment_id\x18\x01 \x01(\tR\x10fromDeploymentId\x12(\n" +
+	"\x10to_deployment_id\x18\x02 \x01(\tR\x0etoDeploymentId\x12(\n" +
+	"\x05actor\x18\x03 \x01(\v2\x12.ctrl.v1.ActorInfoR\x05actor\x12%\n" +
+	"\x0ecorrelation_id\x18\x04 \x01(\tR\rcorrelationId\"\x1c\n" +
+	"\x1aRollbackDeploymentResponse\"k\n" +
 	"\x18DeleteEnvironmentRequest\x12(\n" +
 	"\x05actor\x18\x01 \x01(\v2\x12.ctrl.v1.ActorInfoR\x05actor\x12%\n" +
 	"\x0ecorrelation_id\x18\x02 \x01(\tR\rcorrelationId\"\x1b\n" +
-	"\x19DeleteEnvironmentResponse2o\n" +
+	"\x19DeleteEnvironmentResponse2\xb2\x02\n" +
 	"\x12EnvironmentService\x12S\n" +
-	"\x06Delete\x12\".hydra.v1.DeleteEnvironmentRequest\x1a#.hydra.v1.DeleteEnvironmentResponse\"\x00\x1a\x04\x98\x80\x01\x01B\x96\x01\n" +
+	"\x06Delete\x12\".hydra.v1.DeleteEnvironmentRequest\x1a#.hydra.v1.DeleteEnvironmentResponse\"\x00\x12^\n" +
+	"\x11PromoteDeployment\x12\".hydra.v1.PromoteDeploymentRequest\x1a#.hydra.v1.PromoteDeploymentResponse\"\x00\x12a\n" +
+	"\x12RollbackDeployment\x12#.hydra.v1.RollbackDeploymentRequest\x1a$.hydra.v1.RollbackDeploymentResponse\"\x00\x1a\x04\x98\x80\x01\x01B\x96\x01\n" +
 	"\fcom.hydra.v1B\x10EnvironmentProtoP\x01Z3github.com/unkeyed/unkey/gen/proto/hydra/v1;hydrav1\xa2\x02\x03HXX\xaa\x02\bHydra.V1\xca\x02\bHydra\\V1\xe2\x02\x14Hydra\\V1\\GPBMetadata\xea\x02\tHydra::V1b\x06proto3"
 
 var (
@@ -142,21 +357,31 @@ func file_hydra_v1_environment_proto_rawDescGZIP() []byte {
 	return file_hydra_v1_environment_proto_rawDescData
 }
 
-var file_hydra_v1_environment_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
+var file_hydra_v1_environment_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
 var file_hydra_v1_environment_proto_goTypes = []any{
-	(*DeleteEnvironmentRequest)(nil),  // 0: hydra.v1.DeleteEnvironmentRequest
-	(*DeleteEnvironmentResponse)(nil), // 1: hydra.v1.DeleteEnvironmentResponse
-	(*v1.ActorInfo)(nil),              // 2: ctrl.v1.ActorInfo
+	(*PromoteDeploymentRequest)(nil),   // 0: hydra.v1.PromoteDeploymentRequest
+	(*PromoteDeploymentResponse)(nil),  // 1: hydra.v1.PromoteDeploymentResponse
+	(*RollbackDeploymentRequest)(nil),  // 2: hydra.v1.RollbackDeploymentRequest
+	(*RollbackDeploymentResponse)(nil), // 3: hydra.v1.RollbackDeploymentResponse
+	(*DeleteEnvironmentRequest)(nil),   // 4: hydra.v1.DeleteEnvironmentRequest
+	(*DeleteEnvironmentResponse)(nil),  // 5: hydra.v1.DeleteEnvironmentResponse
+	(*v1.ActorInfo)(nil),               // 6: ctrl.v1.ActorInfo
 }
 var file_hydra_v1_environment_proto_depIdxs = []int32{
-	2, // 0: hydra.v1.DeleteEnvironmentRequest.actor:type_name -> ctrl.v1.ActorInfo
-	0, // 1: hydra.v1.EnvironmentService.Delete:input_type -> hydra.v1.DeleteEnvironmentRequest
-	1, // 2: hydra.v1.EnvironmentService.Delete:output_type -> hydra.v1.DeleteEnvironmentResponse
-	2, // [2:3] is the sub-list for method output_type
-	1, // [1:2] is the sub-list for method input_type
-	1, // [1:1] is the sub-list for extension type_name
-	1, // [1:1] is the sub-list for extension extendee
-	0, // [0:1] is the sub-list for field type_name
+	6, // 0: hydra.v1.PromoteDeploymentRequest.actor:type_name -> ctrl.v1.ActorInfo
+	6, // 1: hydra.v1.RollbackDeploymentRequest.actor:type_name -> ctrl.v1.ActorInfo
+	6, // 2: hydra.v1.DeleteEnvironmentRequest.actor:type_name -> ctrl.v1.ActorInfo
+	4, // 3: hydra.v1.EnvironmentService.Delete:input_type -> hydra.v1.DeleteEnvironmentRequest
+	0, // 4: hydra.v1.EnvironmentService.PromoteDeployment:input_type -> hydra.v1.PromoteDeploymentRequest
+	2, // 5: hydra.v1.EnvironmentService.RollbackDeployment:input_type -> hydra.v1.RollbackDeploymentRequest
+	5, // 6: hydra.v1.EnvironmentService.Delete:output_type -> hydra.v1.DeleteEnvironmentResponse
+	1, // 7: hydra.v1.EnvironmentService.PromoteDeployment:output_type -> hydra.v1.PromoteDeploymentResponse
+	3, // 8: hydra.v1.EnvironmentService.RollbackDeployment:output_type -> hydra.v1.RollbackDeploymentResponse
+	6, // [6:9] is the sub-list for method output_type
+	3, // [3:6] is the sub-list for method input_type
+	3, // [3:3] is the sub-list for extension type_name
+	3, // [3:3] is the sub-list for extension extendee
+	0, // [0:3] is the sub-list for field type_name
 }
 
 func init() { file_hydra_v1_environment_proto_init() }
@@ -170,7 +395,7 @@ func file_hydra_v1_environment_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_hydra_v1_environment_proto_rawDesc), len(file_hydra_v1_environment_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   2,
+			NumMessages:   6,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/proto/hydra/v1/environment_restate.pb.go
+++ b/gen/proto/hydra/v1/environment_restate.pb.go
@@ -15,12 +15,22 @@ import (
 
 // EnvironmentServiceClient is the client API for hydra.v1.EnvironmentService service.
 //
-// EnvironmentService manages environment lifecycle.
+// EnvironmentService serializes everything that changes an environment's live
+// deployment, plus its deletion.
 // Key: environment_id
 type EnvironmentServiceClient interface {
 	// Delete removes an environment and cleans up associated resources.
 	// Key: environment_id
 	Delete(opts ...sdk_go.ClientOption) sdk_go.Client[*DeleteEnvironmentRequest, *DeleteEnvironmentResponse]
+	// PromoteDeployment moves the sticky routes and live pointer to the
+	// deployment and clears is_rolled_back. If it is already live on a
+	// rolled-back app, only the flag changes.
+	// Key: the deployment's environment_id
+	PromoteDeployment(opts ...sdk_go.ClientOption) sdk_go.Client[*PromoteDeploymentRequest, *PromoteDeploymentResponse]
+	// RollbackDeployment moves live traffic from one deployment back to another
+	// and sets is_rolled_back so later deploys do not reclaim the routes.
+	// Key: the environment_id both deployments share
+	RollbackDeployment(opts ...sdk_go.ClientOption) sdk_go.Client[*RollbackDeploymentRequest, *RollbackDeploymentResponse]
 }
 
 type environmentServiceClient struct {
@@ -45,6 +55,22 @@ func (c *environmentServiceClient) Delete(opts ...sdk_go.ClientOption) sdk_go.Cl
 	return sdk_go.WithRequestType[*DeleteEnvironmentRequest](sdk_go.Object[*DeleteEnvironmentResponse](c.ctx, "hydra.v1.EnvironmentService", c.key, "Delete", cOpts...))
 }
 
+func (c *environmentServiceClient) PromoteDeployment(opts ...sdk_go.ClientOption) sdk_go.Client[*PromoteDeploymentRequest, *PromoteDeploymentResponse] {
+	cOpts := c.options
+	if len(opts) > 0 {
+		cOpts = append(append([]sdk_go.ClientOption{}, cOpts...), opts...)
+	}
+	return sdk_go.WithRequestType[*PromoteDeploymentRequest](sdk_go.Object[*PromoteDeploymentResponse](c.ctx, "hydra.v1.EnvironmentService", c.key, "PromoteDeployment", cOpts...))
+}
+
+func (c *environmentServiceClient) RollbackDeployment(opts ...sdk_go.ClientOption) sdk_go.Client[*RollbackDeploymentRequest, *RollbackDeploymentResponse] {
+	cOpts := c.options
+	if len(opts) > 0 {
+		cOpts = append(append([]sdk_go.ClientOption{}, cOpts...), opts...)
+	}
+	return sdk_go.WithRequestType[*RollbackDeploymentRequest](sdk_go.Object[*RollbackDeploymentResponse](c.ctx, "hydra.v1.EnvironmentService", c.key, "RollbackDeployment", cOpts...))
+}
+
 // EnvironmentServiceIngressClient is the ingress client API for hydra.v1.EnvironmentService service.
 //
 // This client is used to call the service from outside of a Restate context.
@@ -52,6 +78,15 @@ type EnvironmentServiceIngressClient interface {
 	// Delete removes an environment and cleans up associated resources.
 	// Key: environment_id
 	Delete() ingress.Requester[*DeleteEnvironmentRequest, *DeleteEnvironmentResponse]
+	// PromoteDeployment moves the sticky routes and live pointer to the
+	// deployment and clears is_rolled_back. If it is already live on a
+	// rolled-back app, only the flag changes.
+	// Key: the deployment's environment_id
+	PromoteDeployment() ingress.Requester[*PromoteDeploymentRequest, *PromoteDeploymentResponse]
+	// RollbackDeployment moves live traffic from one deployment back to another
+	// and sets is_rolled_back so later deploys do not reclaim the routes.
+	// Key: the environment_id both deployments share
+	RollbackDeployment() ingress.Requester[*RollbackDeploymentRequest, *RollbackDeploymentResponse]
 }
 
 type environmentServiceIngressClient struct {
@@ -73,16 +108,36 @@ func (c *environmentServiceIngressClient) Delete() ingress.Requester[*DeleteEnvi
 	return ingress.NewRequester[*DeleteEnvironmentRequest, *DeleteEnvironmentResponse](c.client, c.serviceName, "Delete", &c.key, &codec)
 }
 
+func (c *environmentServiceIngressClient) PromoteDeployment() ingress.Requester[*PromoteDeploymentRequest, *PromoteDeploymentResponse] {
+	codec := encoding.ProtoJSONCodec
+	return ingress.NewRequester[*PromoteDeploymentRequest, *PromoteDeploymentResponse](c.client, c.serviceName, "PromoteDeployment", &c.key, &codec)
+}
+
+func (c *environmentServiceIngressClient) RollbackDeployment() ingress.Requester[*RollbackDeploymentRequest, *RollbackDeploymentResponse] {
+	codec := encoding.ProtoJSONCodec
+	return ingress.NewRequester[*RollbackDeploymentRequest, *RollbackDeploymentResponse](c.client, c.serviceName, "RollbackDeployment", &c.key, &codec)
+}
+
 // EnvironmentServiceServer is the server API for hydra.v1.EnvironmentService service.
 // All implementations should embed UnimplementedEnvironmentServiceServer
 // for forward compatibility.
 //
-// EnvironmentService manages environment lifecycle.
+// EnvironmentService serializes everything that changes an environment's live
+// deployment, plus its deletion.
 // Key: environment_id
 type EnvironmentServiceServer interface {
 	// Delete removes an environment and cleans up associated resources.
 	// Key: environment_id
 	Delete(ctx sdk_go.ObjectContext, req *DeleteEnvironmentRequest) (*DeleteEnvironmentResponse, error)
+	// PromoteDeployment moves the sticky routes and live pointer to the
+	// deployment and clears is_rolled_back. If it is already live on a
+	// rolled-back app, only the flag changes.
+	// Key: the deployment's environment_id
+	PromoteDeployment(ctx sdk_go.ObjectContext, req *PromoteDeploymentRequest) (*PromoteDeploymentResponse, error)
+	// RollbackDeployment moves live traffic from one deployment back to another
+	// and sets is_rolled_back so later deploys do not reclaim the routes.
+	// Key: the environment_id both deployments share
+	RollbackDeployment(ctx sdk_go.ObjectContext, req *RollbackDeploymentRequest) (*RollbackDeploymentResponse, error)
 }
 
 // UnimplementedEnvironmentServiceServer should be embedded to have
@@ -94,6 +149,12 @@ type UnimplementedEnvironmentServiceServer struct{}
 
 func (UnimplementedEnvironmentServiceServer) Delete(ctx sdk_go.ObjectContext, req *DeleteEnvironmentRequest) (*DeleteEnvironmentResponse, error) {
 	return nil, sdk_go.TerminalError(fmt.Errorf("method Delete not implemented"), 501)
+}
+func (UnimplementedEnvironmentServiceServer) PromoteDeployment(ctx sdk_go.ObjectContext, req *PromoteDeploymentRequest) (*PromoteDeploymentResponse, error) {
+	return nil, sdk_go.TerminalError(fmt.Errorf("method PromoteDeployment not implemented"), 501)
+}
+func (UnimplementedEnvironmentServiceServer) RollbackDeployment(ctx sdk_go.ObjectContext, req *RollbackDeploymentRequest) (*RollbackDeploymentResponse, error) {
+	return nil, sdk_go.TerminalError(fmt.Errorf("method RollbackDeployment not implemented"), 501)
 }
 func (UnimplementedEnvironmentServiceServer) testEmbeddedByValue() {}
 
@@ -115,5 +176,7 @@ func NewEnvironmentServiceServer(srv EnvironmentServiceServer, opts ...sdk_go.Se
 	sOpts := append([]sdk_go.ServiceDefinitionOption{sdk_go.WithProtoJSON}, opts...)
 	router := sdk_go.NewObject("hydra.v1.EnvironmentService", sOpts...)
 	router = router.Handler("Delete", sdk_go.NewObjectHandler(srv.Delete))
+	router = router.Handler("PromoteDeployment", sdk_go.NewObjectHandler(srv.PromoteDeployment))
+	router = router.Handler("RollbackDeployment", sdk_go.NewObjectHandler(srv.RollbackDeployment))
 	return router
 }

--- a/svc/ctrl/proto/hydra/v1/environment.proto
+++ b/svc/ctrl/proto/hydra/v1/environment.proto
@@ -7,7 +7,8 @@ import "dev/restate/sdk/go.proto";
 
 option go_package = "github.com/unkeyed/unkey/gen/proto/hydra/v1;hydrav1";
 
-// EnvironmentService manages environment lifecycle.
+// EnvironmentService serializes everything that changes an environment's live
+// deployment, plus its deletion.
 // Key: environment_id
 service EnvironmentService {
   option (dev.restate.sdk.go.service_type) = VIRTUAL_OBJECT;
@@ -15,7 +16,37 @@ service EnvironmentService {
   // Delete removes an environment and cleans up associated resources.
   // Key: environment_id
   rpc Delete(DeleteEnvironmentRequest) returns (DeleteEnvironmentResponse) {}
+
+  // PromoteDeployment moves the sticky routes and live pointer to the
+  // deployment and clears is_rolled_back. If it is already live on a
+  // rolled-back app, only the flag changes.
+  // Key: the deployment's environment_id
+  rpc PromoteDeployment(PromoteDeploymentRequest) returns (PromoteDeploymentResponse) {}
+
+  // RollbackDeployment moves live traffic from one deployment back to another
+  // and sets is_rolled_back so later deploys do not reclaim the routes.
+  // Key: the environment_id both deployments share
+  rpc RollbackDeployment(RollbackDeploymentRequest) returns (RollbackDeploymentResponse) {}
 }
+
+message PromoteDeploymentRequest {
+  string deployment_id = 1;
+  ctrl.v1.ActorInfo actor = 2;
+  string correlation_id = 3;
+}
+
+message PromoteDeploymentResponse {}
+
+// from_deployment_id is the live deployment the caller saw. The handler
+// refuses the rollback if it is no longer live.
+message RollbackDeploymentRequest {
+  string from_deployment_id = 1;
+  string to_deployment_id = 2;
+  ctrl.v1.ActorInfo actor = 3;
+  string correlation_id = 4;
+}
+
+message RollbackDeploymentResponse {}
 
 // DeleteEnvironmentRequest carries the caller identity and correlation ID into
 // the durable workflow so the environment.delete audit log is written as part

--- a/svc/ctrl/worker/environment/delete_handler_test.go
+++ b/svc/ctrl/worker/environment/delete_handler_test.go
@@ -137,6 +137,20 @@ func (l *lazyEnvironmentService) Delete(
 	return (*l.svc).Delete(ctx, req)
 }
 
+func (l *lazyEnvironmentService) PromoteDeployment(
+	ctx restate.ObjectContext,
+	req *hydrav1.PromoteDeploymentRequest,
+) (*hydrav1.PromoteDeploymentResponse, error) {
+	return (*l.svc).PromoteDeployment(ctx, req)
+}
+
+func (l *lazyEnvironmentService) RollbackDeployment(
+	ctx restate.ObjectContext,
+	req *hydrav1.RollbackDeploymentRequest,
+) (*hydrav1.RollbackDeploymentResponse, error) {
+	return (*l.svc).RollbackDeployment(ctx, req)
+}
+
 func countAudits(t *testing.T, ctx context.Context, database db.Database, workspaceID string, event auditlog.AuditLogEvent, resourceID, actorID string) int {
 	t.Helper()
 	rows, err := database.ListClickhouseOutboxByWorkspace(ctx, workspaceID)

--- a/svc/ctrl/worker/environment/helpers_test.go
+++ b/svc/ctrl/worker/environment/helpers_test.go
@@ -1,0 +1,278 @@
+package environment_test
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	ctrlv1 "github.com/unkeyed/unkey/gen/proto/ctrl/v1"
+	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
+	"github.com/unkeyed/unkey/pkg/mysql/sqlcomment"
+	mysqltype "github.com/unkeyed/unkey/pkg/mysql/types"
+	restateadmin "github.com/unkeyed/unkey/pkg/restate/admin"
+	"github.com/unkeyed/unkey/pkg/testutil/containers"
+	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/ctrl/integration/seed"
+	"github.com/unkeyed/unkey/svc/ctrl/internal/auditlogs"
+	"github.com/unkeyed/unkey/svc/ctrl/internal/db"
+	"github.com/unkeyed/unkey/svc/ctrl/worker/deployment"
+	"github.com/unkeyed/unkey/svc/ctrl/worker/environment"
+	"github.com/unkeyed/unkey/svc/ctrl/worker/routing"
+)
+
+// stopDelay is how long a test-scheduled stop waits before it applies. Long
+// enough for the handler under test to run first, short enough to wait out.
+const stopDelay = 300 * time.Millisecond
+
+// fixture is one production environment with three ready deployments.
+// live owns the sticky routes and a commit route; the others are candidates.
+// The seeder has no helper for routes or the app's live pointer, so the fixture
+// writes those rows itself.
+type fixture struct {
+	ctx         context.Context
+	db          db.Database
+	seeder      *seed.Seeder
+	restate     containers.RestateConfig
+	workspaceID string
+	project     db.Project
+	app         db.App
+	env         db.Environment
+	live        db.Deployment
+	candidate   db.Deployment
+	other       db.Deployment
+	actorID     string
+}
+
+func newFixture(t *testing.T) *fixture {
+	t.Helper()
+	ctx := context.Background()
+
+	mysqlCfg := containers.MySQL(t)
+	database, err := db.New(mysqlCfg.DSN, sqlcomment.Disabled())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+
+	seeder := seed.New(t, database, nil)
+	seeder.Seed(ctx)
+	workspaceID := seeder.Resources.UserWorkspace.ID
+
+	project := seeder.CreateProject(ctx, seed.CreateProjectRequest{
+		ID:          uid.New(uid.ProjectPrefix),
+		WorkspaceID: workspaceID,
+		Name:        "KEBAP",
+		Slug:        slugFrom(uid.New(uid.ProjectPrefix)),
+	})
+	app := seeder.CreateApp(ctx, seed.CreateAppRequest{
+		ID:            uid.New(uid.AppPrefix),
+		WorkspaceID:   workspaceID,
+		ProjectID:     project.ID,
+		Name:          "KEBAP",
+		Slug:          slugFrom(uid.New(uid.AppPrefix)),
+		DefaultBranch: "main",
+	})
+
+	f := &fixture{
+		ctx:         ctx,
+		db:          database,
+		seeder:      seeder,
+		restate:     containers.RestateConfig{},
+		workspaceID: workspaceID,
+		project:     project,
+		app:         app,
+		env:         db.Environment{},
+		live:        db.Deployment{},
+		candidate:   db.Deployment{},
+		other:       db.Deployment{},
+		actorID:     uid.New("user"),
+	}
+	f.env = f.newProductionEnvironment(t, "production")
+	f.live = f.newReadyDeployment(t)
+	f.candidate = f.newReadyDeployment(t)
+	f.other = f.newReadyDeployment(t)
+
+	f.insertRoute(t, f.live.ID, db.FrontlineRoutesStickyLive)
+	f.insertRoute(t, f.live.ID, db.FrontlineRoutesStickyEnvironment)
+	f.insertRoute(t, f.live.ID, db.FrontlineRoutesStickyNone)
+	f.setLive(t, f.live.ID, false)
+
+	auditlogSvc, err := auditlogs.New(auditlogs.Config{DB: database})
+	require.NoError(t, err)
+
+	var svc *environment.Service
+	f.restate = containers.Restate(t,
+		hydrav1.NewEnvironmentServiceServer(&lazyEnvironmentService{svc: &svc}),
+		hydrav1.NewRoutingServiceServer(routing.New(routing.Config{DB: database, DefaultDomain: "kebap.test"})),
+		hydrav1.NewDeploymentServiceServer(deployment.New(deployment.Config{DB: database})),
+	)
+	svc, err = environment.New(environment.Config{
+		DB:        database,
+		Admin:     restateadmin.New(restateadmin.Config{BaseURL: f.restate.AdminURL, APIKey: ""}),
+		Auditlogs: auditlogSvc,
+	})
+	require.NoError(t, err)
+
+	return f
+}
+
+func (f *fixture) newProductionEnvironment(t *testing.T, slug string) db.Environment {
+	t.Helper()
+	return f.seeder.CreateEnvironment(f.ctx, seed.CreateEnvironmentRequest{
+		ID:          uid.New(uid.EnvironmentPrefix),
+		WorkspaceID: f.workspaceID,
+		ProjectID:   f.project.ID,
+		AppID:       f.app.ID,
+		Slug:        slug,
+		Kind:        mysqltype.EnvironmentKindProduction,
+	})
+}
+
+func (f *fixture) newReadyDeployment(t *testing.T) db.Deployment {
+	t.Helper()
+	return f.seeder.CreateDeployment(f.ctx, seed.CreateDeploymentRequest{
+		ID:            uid.New(uid.DeploymentPrefix),
+		WorkspaceID:   f.workspaceID,
+		ProjectID:     f.project.ID,
+		AppID:         f.app.ID,
+		EnvironmentID: f.env.ID,
+		Status:        mysqltype.DeploymentsStatusReady,
+	})
+}
+
+func (f *fixture) insertRoute(t *testing.T, deploymentID string, sticky db.FrontlineRoutesSticky) {
+	t.Helper()
+	require.NoError(t, f.db.InsertFrontlineRoute(f.ctx, db.InsertFrontlineRouteParams{
+		ID:                       uid.New(uid.FrontlineRoutePrefix),
+		ProjectID:                f.project.ID,
+		AppID:                    f.app.ID,
+		DeploymentID:             deploymentID,
+		EnvironmentID:            f.env.ID,
+		FullyQualifiedDomainName: slugFrom(uid.New(uid.FrontlineRoutePrefix)) + ".kebap.test",
+		Sticky:                   sticky,
+		CreatedAt:                time.Now().UnixMilli(),
+		UpdatedAt:                sql.NullInt64{Valid: false, Int64: 0},
+	}))
+}
+
+// moveStickyRoutes points the live and environment routes at deploymentID.
+func (f *fixture) moveStickyRoutes(t *testing.T, deploymentID string) {
+	t.Helper()
+	routes, err := f.db.FindFrontlineRoutesByEnvironmentAndSticky(f.ctx, db.FindFrontlineRoutesByEnvironmentAndStickyParams{
+		EnvironmentID: f.env.ID,
+		Sticky:        []db.FrontlineRoutesSticky{db.FrontlineRoutesStickyLive, db.FrontlineRoutesStickyEnvironment},
+	})
+	require.NoError(t, err)
+	for _, route := range routes {
+		require.NoError(t, f.db.ReassignFrontlineRoute(f.ctx, db.ReassignFrontlineRouteParams{
+			DeploymentID: deploymentID,
+			UpdatedAt:    sql.NullInt64{Valid: true, Int64: time.Now().UnixMilli()},
+			ID:           route.ID,
+		}))
+	}
+}
+
+func (f *fixture) setLive(t *testing.T, deploymentID string, rolledBack bool) {
+	t.Helper()
+	require.NoError(t, f.db.UpdateAppDeployments(f.ctx, db.UpdateAppDeploymentsParams{
+		CurrentDeploymentID: sql.NullString{Valid: true, String: deploymentID},
+		IsRolledBack:        rolledBack,
+		UpdatedAt:           sql.NullInt64{Valid: true, Int64: time.Now().UnixMilli()},
+		AppID:               f.app.ID,
+	}))
+}
+
+func (f *fixture) actor() *ctrlv1.ActorInfo {
+	return &ctrlv1.ActorInfo{Id: f.actorID, Type: ctrlv1.ActorType_ACTOR_TYPE_USER}
+}
+
+func (f *fixture) promote(key, deploymentID string) error {
+	_, err := hydrav1.NewEnvironmentServiceIngressClient(f.restate.IngressClient, key).
+		PromoteDeployment().
+		Request(f.ctx, &hydrav1.PromoteDeploymentRequest{
+			DeploymentId:  deploymentID,
+			Actor:         f.actor(),
+			CorrelationId: uid.New("corr"),
+		})
+	return err
+}
+
+func (f *fixture) rollback(key, fromID, toID string) error {
+	_, err := hydrav1.NewEnvironmentServiceIngressClient(f.restate.IngressClient, key).
+		RollbackDeployment().
+		Request(f.ctx, &hydrav1.RollbackDeploymentRequest{
+			FromDeploymentId: fromID,
+			ToDeploymentId:   toID,
+			Actor:            f.actor(),
+			CorrelationId:    uid.New("corr"),
+		})
+	return err
+}
+
+// scheduleStop parks a stop on deploymentID that lands after stopDelay. A
+// handler that clears it keeps the deployment running; one that does not lets
+// it flip to stopped.
+func (f *fixture) scheduleStop(t *testing.T, deploymentID string) {
+	t.Helper()
+	_, err := hydrav1.NewDeploymentServiceIngressClient(f.restate.IngressClient, deploymentID).
+		ScheduleDesiredStateChange().
+		Request(f.ctx, &hydrav1.ScheduleDesiredStateChangeRequest{
+			State:       hydrav1.DeploymentDesiredState_DEPLOYMENT_DESIRED_STATE_STOPPED,
+			DelayMillis: stopDelay.Milliseconds(),
+			Overwrite:   true,
+		})
+	require.NoError(t, err)
+}
+
+// requireDesiredStateAfterStopDelay waits out stopDelay so a parked stop had
+// its chance, then asserts.
+func (f *fixture) requireDesiredStateAfterStopDelay(t *testing.T, deploymentID string, want mysqltype.DeploymentsDesiredState) {
+	t.Helper()
+	time.Sleep(3 * stopDelay)
+	dep, err := f.db.FindDeploymentById(f.ctx, deploymentID)
+	require.NoError(t, err)
+	require.Equal(t, want, dep.DesiredState, "deployment %s desired state", deploymentID)
+}
+
+func (f *fixture) requireLive(t *testing.T, deploymentID string, rolledBack bool) {
+	t.Helper()
+	app, err := f.db.FindAppById(f.ctx, f.app.ID)
+	require.NoError(t, err)
+	require.Equal(t, deploymentID, app.CurrentDeploymentID.String, "app current_deployment_id")
+	require.Equal(t, rolledBack, app.IsRolledBack, "app is_rolled_back")
+}
+
+// routeOwners maps each route kind in the environment to the deployment it
+// points at.
+func (f *fixture) routeOwners(t *testing.T) map[db.FrontlineRoutesSticky]string {
+	t.Helper()
+	routes, err := f.db.FindFrontlineRoutesByEnvironmentAndSticky(f.ctx, db.FindFrontlineRoutesByEnvironmentAndStickyParams{
+		EnvironmentID: f.env.ID,
+		Sticky: []db.FrontlineRoutesSticky{
+			db.FrontlineRoutesStickyLive,
+			db.FrontlineRoutesStickyEnvironment,
+			db.FrontlineRoutesStickyNone,
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, routes, 3)
+
+	owners := make(map[db.FrontlineRoutesSticky]string, len(routes))
+	for _, route := range routes {
+		owners[route.Sticky] = route.DeploymentID
+	}
+	return owners
+}
+
+func (f *fixture) requireRoutes(t *testing.T, stickyOwner, commitOwner string) {
+	t.Helper()
+	owners := f.routeOwners(t)
+	require.Equal(t, stickyOwner, owners[db.FrontlineRoutesStickyLive], "live route")
+	require.Equal(t, stickyOwner, owners[db.FrontlineRoutesStickyEnvironment], "environment route")
+	require.Equal(t, commitOwner, owners[db.FrontlineRoutesStickyNone], "commit route")
+}
+
+func slugFrom(id string) string {
+	return strings.ToLower(strings.ReplaceAll(id, "_", "-"))
+}

--- a/svc/ctrl/worker/environment/helpers_test.go
+++ b/svc/ctrl/worker/environment/helpers_test.go
@@ -66,12 +66,11 @@ func newFixture(t *testing.T) *fixture {
 		Slug:        slugFrom(uid.New(uid.ProjectPrefix)),
 	})
 	app := seeder.CreateApp(ctx, seed.CreateAppRequest{
-		ID:            uid.New(uid.AppPrefix),
-		WorkspaceID:   workspaceID,
-		ProjectID:     project.ID,
-		Name:          "KEBAP",
-		Slug:          slugFrom(uid.New(uid.AppPrefix)),
-		DefaultBranch: "main",
+		ID:          uid.New(uid.AppPrefix),
+		WorkspaceID: workspaceID,
+		ProjectID:   project.ID,
+		Name:        "KEBAP",
+		Slug:        slugFrom(uid.New(uid.AppPrefix)),
 	})
 
 	f := &fixture{

--- a/svc/ctrl/worker/environment/promote_handler.go
+++ b/svc/ctrl/worker/environment/promote_handler.go
@@ -1,0 +1,123 @@
+package environment
+
+import (
+	"fmt"
+
+	restate "github.com/restatedev/sdk-go"
+	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
+	"github.com/unkeyed/unkey/pkg/auditlog"
+	"github.com/unkeyed/unkey/pkg/deploy/deploygate"
+	"github.com/unkeyed/unkey/pkg/logger"
+	"github.com/unkeyed/unkey/svc/ctrl/internal/db"
+	"github.com/unkeyed/unkey/svc/ctrl/internal/gatefault"
+)
+
+// PromoteDeployment makes one deployment the environment's live deployment.
+// See the proto for the contract. The gate check and the swap share the key,
+// so nothing moves the live pointer between them.
+func (s *Service) PromoteDeployment(ctx restate.ObjectContext, req *hydrav1.PromoteDeploymentRequest) (*hydrav1.PromoteDeploymentResponse, error) {
+	deployments, err := s.loadDeployments(ctx, req.GetDeploymentId())
+	if err != nil {
+		return nil, err
+	}
+	deployment := deployments[req.GetDeploymentId()]
+
+	if err := deploygate.CheckPromoteTarget(deploygate.PromoteInput{
+		Status:              deployment.Status,
+		DesiredState:        deployment.DesiredState,
+		EnvironmentKind:     deployment.EnvironmentKind,
+		CurrentDeploymentID: deployment.CurrentDeploymentID.String,
+		DeploymentID:        deployment.ID,
+		IsRolledBack:        deployment.IsRolledBack,
+	}); err != nil {
+		return nil, gatefault.Terminal(err)
+	}
+
+	confirmingRollback := deployment.IsRolledBack && deployment.CurrentDeploymentID.String == deployment.ID
+
+	var routeIDs []string
+	if !confirmingRollback {
+		routeIDs, err = s.findStickyRouteIDs(ctx, deployment.EnvironmentID)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// With no routes the swap only clears is_rolled_back.
+	swap, err := hydrav1.NewRoutingServiceClient(ctx, deployment.EnvironmentID).
+		SwapLiveDeployment().
+		Request(&hydrav1.SwapLiveDeploymentRequest{
+			DeploymentId:      deployment.ID,
+			FrontlineRouteIds: routeIDs,
+			SetRollbackFlag:   false,
+		})
+	if err != nil {
+		return nil, fmt.Errorf("swap live deployment: %w", err)
+	}
+
+	// The deployment may still carry the standby from when it was demoted.
+	_, err = hydrav1.NewDeploymentServiceClient(ctx, deployment.ID).
+		ClearScheduledStateChanges().
+		Request(&hydrav1.ClearScheduledStateChangesRequest{})
+	if err != nil {
+		return nil, fmt.Errorf("clear scheduled state changes: %w", err)
+	}
+
+	demotedID, err := s.demotedDeploymentID(ctx, deployment, swap.GetPreviousDeploymentId(), confirmingRollback)
+	if err != nil {
+		return nil, err
+	}
+	if demotedID != "" {
+		hydrav1.NewDeploymentServiceClient(ctx, demotedID).
+			ScheduleDesiredStateChange().
+			Send(&hydrav1.ScheduleDesiredStateChangeRequest{
+				State:       hydrav1.DeploymentDesiredState_DEPLOYMENT_DESIRED_STATE_STOPPED,
+				DelayMillis: standbyDelay.Milliseconds(),
+			})
+	}
+
+	if err := s.insertLifecycleAudit(
+		ctx,
+		req.GetActor(),
+		req.GetCorrelationId(),
+		deployment,
+		auditlog.DeploymentPromoteEvent,
+		fmt.Sprintf("Promoted deployment %s", deployment.ID),
+	); err != nil {
+		return nil, fmt.Errorf("insert promote audit log: %w", err)
+	}
+
+	logger.Info("deployment promoted",
+		"environment_id", deployment.EnvironmentID,
+		"deployment_id", deployment.ID,
+		"demoted_deployment_id", demotedID,
+		"confirm_rollback", confirmingRollback,
+	)
+	return &hydrav1.PromoteDeploymentResponse{}, nil
+}
+
+// demotedDeploymentID is the deployment that lost live traffic. Confirming a
+// rollback swaps nothing, so it is the newest ready deployment other than the
+// promoted one.
+func (s *Service) demotedDeploymentID(
+	ctx restate.ObjectContext,
+	promoted db.FindDeploymentWithEnvironmentAndAppRow,
+	previous string,
+	confirmingRollback bool,
+) (string, error) {
+	if !confirmingRollback {
+		return previous, nil
+	}
+
+	demoted, err := restate.Run(ctx, func(runCtx restate.RunContext) (string, error) {
+		return s.db.FindLatestReadyDeploymentByAppAndEnv(runCtx, db.FindLatestReadyDeploymentByAppAndEnvParams{
+			AppID:         promoted.AppID,
+			EnvironmentID: promoted.EnvironmentID,
+			ExcludeID:     promoted.ID,
+		})
+	}, restate.WithName("find demoted deployment"), restate.WithMaxRetryAttempts(runMaxAttempts))
+	if err != nil {
+		return "", fmt.Errorf("find demoted deployment: %w", err)
+	}
+	return demoted, nil
+}

--- a/svc/ctrl/worker/environment/promote_handler_test.go
+++ b/svc/ctrl/worker/environment/promote_handler_test.go
@@ -1,0 +1,50 @@
+package environment_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/auditlog"
+	mysqltype "github.com/unkeyed/unkey/pkg/mysql/types"
+)
+
+func TestPromoteDeploymentSwapsLiveRoutes(t *testing.T) {
+	f := newFixture(t)
+
+	// The target carries a parked stop from an earlier demotion; the untouched
+	// deployment carries one too and proves the parked stop mechanism works.
+	f.scheduleStop(t, f.candidate.ID)
+	f.scheduleStop(t, f.other.ID)
+
+	require.NoError(t, f.promote(f.env.ID, f.candidate.ID))
+
+	f.requireLive(t, f.candidate.ID, false)
+	f.requireRoutes(t, f.candidate.ID, f.live.ID)
+	f.requireDesiredStateAfterStopDelay(t, f.candidate.ID, mysqltype.DeploymentsDesiredStateRunning)
+	f.requireDesiredStateAfterStopDelay(t, f.other.ID, mysqltype.DeploymentsDesiredStateStopped)
+	require.Equal(t, 1, countAudits(t, f.ctx, f.db, f.workspaceID, auditlog.DeploymentPromoteEvent, f.candidate.ID, f.actorID))
+}
+
+func TestPromoteDeploymentConfirmsRollback(t *testing.T) {
+	f := newFixture(t)
+	f.moveStickyRoutes(t, f.candidate.ID)
+	f.setLive(t, f.candidate.ID, true)
+
+	require.NoError(t, f.promote(f.env.ID, f.candidate.ID))
+
+	f.requireLive(t, f.candidate.ID, false)
+	f.requireRoutes(t, f.candidate.ID, f.live.ID)
+	require.Equal(t, 1, countAudits(t, f.ctx, f.db, f.workspaceID, auditlog.DeploymentPromoteEvent, f.candidate.ID, f.actorID))
+}
+
+func TestPromoteDeploymentRejectsForeignEnvironment(t *testing.T) {
+	f := newFixture(t)
+	foreign := f.newProductionEnvironment(t, "production-kebap")
+
+	err := f.promote(foreign.ID, f.candidate.ID)
+	require.ErrorContains(t, err, "keyed environment")
+
+	f.requireLive(t, f.live.ID, false)
+	f.requireRoutes(t, f.live.ID, f.live.ID)
+	require.Equal(t, 0, countAudits(t, f.ctx, f.db, f.workspaceID, auditlog.DeploymentPromoteEvent, f.candidate.ID, f.actorID))
+}

--- a/svc/ctrl/worker/environment/rollback_handler.go
+++ b/svc/ctrl/worker/environment/rollback_handler.go
@@ -1,0 +1,93 @@
+package environment
+
+import (
+	"errors"
+	"fmt"
+
+	restate "github.com/restatedev/sdk-go"
+	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
+	"github.com/unkeyed/unkey/pkg/assert"
+	"github.com/unkeyed/unkey/pkg/auditlog"
+	"github.com/unkeyed/unkey/pkg/deploy/deploygate"
+	"github.com/unkeyed/unkey/pkg/logger"
+	"github.com/unkeyed/unkey/svc/ctrl/internal/gatefault"
+)
+
+// RollbackDeployment moves live traffic from one deployment back to an earlier
+// one. See the proto for the contract. If from is no longer live, the caller
+// decided on a state that has since changed, so the rollback is refused.
+func (s *Service) RollbackDeployment(ctx restate.ObjectContext, req *hydrav1.RollbackDeploymentRequest) (*hydrav1.RollbackDeploymentResponse, error) {
+	if req.GetFromDeploymentId() == req.GetToDeploymentId() {
+		return nil, restate.TerminalError(errors.New("from and to must be different deployments"), 400)
+	}
+
+	deployments, err := s.loadDeployments(ctx, req.GetFromDeploymentId(), req.GetToDeploymentId())
+	if err != nil {
+		return nil, err
+	}
+	from := deployments[req.GetFromDeploymentId()]
+	to := deployments[req.GetToDeploymentId()]
+
+	if err := assert.Equal(to.AppID, from.AppID, "deployments must be in the same app"); err != nil {
+		return nil, restate.TerminalError(err, 400)
+	}
+
+	if !from.CurrentDeploymentID.Valid || from.CurrentDeploymentID.String != from.ID {
+		return nil, restate.TerminalError(errors.New("the deployment being rolled back from is no longer live"), 400)
+	}
+
+	if err := deploygate.CheckRollbackTarget(deploygate.RollbackInput{
+		Status:              to.Status,
+		DesiredState:        to.DesiredState,
+		EnvironmentKind:     to.EnvironmentKind,
+		CurrentDeploymentID: from.ID,
+		DeploymentID:        to.ID,
+	}); err != nil {
+		return nil, gatefault.Terminal(err)
+	}
+
+	// The deployment traffic returns to may still carry the standby from when
+	// it was demoted.
+	_, err = hydrav1.NewDeploymentServiceClient(ctx, to.ID).
+		ClearScheduledStateChanges().
+		Request(&hydrav1.ClearScheduledStateChangesRequest{})
+	if err != nil {
+		return nil, fmt.Errorf("clear scheduled state changes: %w", err)
+	}
+
+	routeIDs, err := s.findStickyRouteIDs(ctx, to.EnvironmentID)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = hydrav1.NewRoutingServiceClient(ctx, to.EnvironmentID).
+		SwapLiveDeployment().
+		Request(&hydrav1.SwapLiveDeploymentRequest{
+			DeploymentId:      to.ID,
+			FrontlineRouteIds: routeIDs,
+			SetRollbackFlag:   true,
+		})
+	if err != nil {
+		return nil, fmt.Errorf("swap live deployment: %w", err)
+	}
+
+	if err := s.insertLifecycleAudit(
+		ctx,
+		req.GetActor(),
+		req.GetCorrelationId(),
+		to,
+		auditlog.DeploymentRollbackEvent,
+		fmt.Sprintf("Rolled back to deployment %s", to.ID),
+	); err != nil {
+		return nil, fmt.Errorf("insert rollback audit log: %w", err)
+	}
+
+	logger.Info(
+		"deployment rolled back",
+		"environment_id", to.EnvironmentID,
+		"from_deployment_id", from.ID,
+		"to_deployment_id", to.ID,
+		"routes", len(routeIDs),
+	)
+	return &hydrav1.RollbackDeploymentResponse{}, nil
+}

--- a/svc/ctrl/worker/environment/rollback_handler_test.go
+++ b/svc/ctrl/worker/environment/rollback_handler_test.go
@@ -1,0 +1,44 @@
+package environment_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/auditlog"
+	mysqltype "github.com/unkeyed/unkey/pkg/mysql/types"
+)
+
+func TestRollbackDeploymentSwitchesLiveRoutesBack(t *testing.T) {
+	f := newFixture(t)
+	f.scheduleStop(t, f.candidate.ID)
+
+	require.NoError(t, f.rollback(f.env.ID, f.live.ID, f.candidate.ID))
+
+	f.requireLive(t, f.candidate.ID, true)
+	f.requireRoutes(t, f.candidate.ID, f.live.ID)
+	f.requireDesiredStateAfterStopDelay(t, f.candidate.ID, mysqltype.DeploymentsDesiredStateRunning)
+	require.Equal(t, 1, countAudits(t, f.ctx, f.db, f.workspaceID, auditlog.DeploymentRollbackEvent, f.candidate.ID, f.actorID))
+}
+
+func TestRollbackDeploymentRejectsStaleSource(t *testing.T) {
+	f := newFixture(t)
+
+	err := f.rollback(f.env.ID, f.other.ID, f.candidate.ID)
+	require.ErrorContains(t, err, "no longer live")
+
+	f.requireLive(t, f.live.ID, false)
+	f.requireRoutes(t, f.live.ID, f.live.ID)
+	require.Equal(t, 0, countAudits(t, f.ctx, f.db, f.workspaceID, auditlog.DeploymentRollbackEvent, f.candidate.ID, f.actorID))
+}
+
+func TestRollbackDeploymentRejectsForeignEnvironment(t *testing.T) {
+	f := newFixture(t)
+	foreign := f.newProductionEnvironment(t, "production-kebap")
+
+	err := f.rollback(foreign.ID, f.live.ID, f.candidate.ID)
+	require.ErrorContains(t, err, "keyed environment")
+
+	f.requireLive(t, f.live.ID, false)
+	f.requireRoutes(t, f.live.ID, f.live.ID)
+	require.Equal(t, 0, countAudits(t, f.ctx, f.db, f.workspaceID, auditlog.DeploymentRollbackEvent, f.candidate.ID, f.actorID))
+}

--- a/svc/ctrl/worker/environment/service.go
+++ b/svc/ctrl/worker/environment/service.go
@@ -1,15 +1,31 @@
 package environment
 
 import (
+	"fmt"
+	"time"
+
+	restate "github.com/restatedev/sdk-go"
+	ctrlv1 "github.com/unkeyed/unkey/gen/proto/ctrl/v1"
 	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
 	"github.com/unkeyed/unkey/pkg/assert"
+	"github.com/unkeyed/unkey/pkg/auditlog"
 	restateadmin "github.com/unkeyed/unkey/pkg/restate/admin"
+	"github.com/unkeyed/unkey/svc/ctrl/internal/audit"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/auditlogs"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/db"
 )
 
-// Service implements the EnvironmentService Restate virtual object for durable
-// environment deletion. The virtual object key is the environment ID.
+// standbyDelay keeps a demoted deployment running long enough to roll back to
+// it without a cold start.
+const standbyDelay = 30 * time.Minute
+
+// runMaxAttempts bounds per-Run retries so a persistent failure returns a
+// terminal error instead of eating the invocation retry budget.
+const runMaxAttempts uint = 5
+
+// Service implements the EnvironmentService Restate virtual object. The key is
+// the environment ID, so deletion, promotion, and rollback of one environment
+// never overlap.
 type Service struct {
 	hydrav1.UnimplementedEnvironmentServiceServer
 	db        db.Database
@@ -47,4 +63,97 @@ func New(cfg Config) (*Service, error) {
 		admin:                                 cfg.Admin,
 		auditlogs:                             cfg.Auditlogs,
 	}, nil
+}
+
+// loadDeployments reads each deployment with its environment kind and its
+// app's live pointer, keyed by id, in one step. A deployment outside the keyed
+// environment is refused: the key is the lock.
+func (s *Service) loadDeployments(ctx restate.ObjectContext, deploymentIDs ...string) (map[string]db.FindDeploymentWithEnvironmentAndAppRow, error) {
+	environmentID := restate.Key(ctx)
+
+	deployments, err := restate.Run(ctx, func(runCtx restate.RunContext) (map[string]db.FindDeploymentWithEnvironmentAndAppRow, error) {
+		byID := make(map[string]db.FindDeploymentWithEnvironmentAndAppRow, len(deploymentIDs))
+		for _, id := range deploymentIDs {
+			row, err := s.db.FindDeploymentWithEnvironmentAndApp(runCtx, id)
+			if err != nil {
+				if db.IsNotFound(err) {
+					return nil, restate.TerminalError(fmt.Errorf("deployment not found: %s", id), 404)
+				}
+				return nil, fmt.Errorf("load deployment %s: %w", id, err)
+			}
+			if err := assert.Equal(row.EnvironmentID, environmentID, "deployment must belong to the keyed environment"); err != nil {
+				return nil, restate.TerminalError(err, 400)
+			}
+			byID[id] = row
+		}
+		return byID, nil
+	}, restate.WithName("load deployments"), restate.WithMaxRetryAttempts(runMaxAttempts))
+	if err != nil {
+		return nil, err
+	}
+	return deployments, nil
+}
+
+// findStickyRouteIDs returns the environment and live routes. None is a caller
+// error: there is nothing to move.
+func (s *Service) findStickyRouteIDs(ctx restate.ObjectContext, environmentID string) ([]string, error) {
+	routeIDs, err := restate.Run(ctx, func(runCtx restate.RunContext) ([]string, error) {
+		routes, err := s.db.FindFrontlineRoutesByEnvironmentAndSticky(runCtx, db.FindFrontlineRoutesByEnvironmentAndStickyParams{
+			EnvironmentID: environmentID,
+			Sticky: []db.FrontlineRoutesSticky{
+				db.FrontlineRoutesStickyLive,
+				db.FrontlineRoutesStickyEnvironment,
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
+		ids := make([]string, 0, len(routes))
+		for _, route := range routes {
+			ids = append(ids, route.ID)
+		}
+		return ids, nil
+	}, restate.WithName("find sticky routes"), restate.WithMaxRetryAttempts(runMaxAttempts))
+	if err != nil {
+		return nil, fmt.Errorf("find sticky routes: %w", err)
+	}
+
+	if len(routeIDs) == 0 {
+		return nil, restate.TerminalError(fmt.Errorf("environment %s has no sticky routes", environmentID), 400)
+	}
+	return routeIDs, nil
+}
+
+// insertLifecycleAudit writes one lifecycle audit entry as a durable step. A
+// nil actor is a retained ctrl RPC that writes its own entry; skip it.
+func (s *Service) insertLifecycleAudit(
+	ctx restate.ObjectContext,
+	actor *ctrlv1.ActorInfo,
+	correlationID string,
+	deployment db.FindDeploymentWithEnvironmentAndAppRow,
+	event auditlog.AuditLogEvent,
+	display string,
+) error {
+	if actor == nil {
+		return nil
+	}
+
+	return audit.Insert(ctx, s.auditlogs, audit.Event{
+		Actor:         actor,
+		CorrelationID: correlationID,
+		WorkspaceID:   deployment.WorkspaceID,
+		Event:         event,
+		Display:       display,
+		Resource: auditlog.AuditLogResource{
+			Type:        auditlog.DeploymentResourceType,
+			ID:          deployment.ID,
+			Name:        "",
+			DisplayName: deployment.ID,
+			Meta: map[string]any{
+				"projectId":     deployment.ProjectID,
+				"appId":         deployment.AppID,
+				"environmentId": deployment.EnvironmentID,
+			},
+		},
+	})
 }

--- a/svc/ctrl/worker/run.go
+++ b/svc/ctrl/worker/run.go
@@ -309,29 +309,28 @@ func Run(ctx context.Context, cfg Config) error {
 		return fmt.Errorf("failed to create deploy workflow: %w", err)
 	}
 
-	restateSrv.Bind(hydrav1.NewDeployServiceServer(deployWorkflow,
-		// Retry with exponential backoff: 2s → 4s → 8s → 16s → 30s (capped),
-		// 15 attempts (~5 min total). Short backoffs keep the worst-case
-		// cancel latency low — a user-initiated cancel only lands at the
-		// next attempt boundary, so longer intervals make cancels feel
-		// stuck. 5 minutes total is enough for transient blips; persistent
-		// failures should surface fast rather than retry for half an hour.
-		//
-		// PauseOnMaxAttempts (not Kill) so compensations can still run:
-		// on KILL the invocation is torn down without re-entering the
-		// handler, so the Go defer that fires compensation.Execute never
-		// runs. Individual restate.Run calls should each set
-		// WithMaxRetryDuration so they return TerminalError into Go on
-		// exhaustion — that's the normal path. This service-level policy
-		// is a safety net for failures that escape Run-level bounds.
-		restate.WithInvocationRetryPolicy(
-			restate.WithInitialInterval(2*time.Second),
-			restate.WithExponentiationFactor(2.0),
-			restate.WithMaxInterval(30*time.Second),
-			restate.WithMaxAttempts(15),
-			restate.PauseOnMaxAttempts(),
-		),
-	))
+	// Retry with exponential backoff: 2s → 4s → 8s → 16s → 30s (capped),
+	// 15 attempts (~5 min total). Short backoffs keep the worst-case
+	// cancel latency low. A user-initiated cancel only lands at the
+	// next attempt boundary, so longer intervals make cancels feel
+	// stuck. 5 minutes total is enough for transient blips; persistent
+	// failures should surface fast rather than retry for half an hour.
+	//
+	// PauseOnMaxAttempts (not Kill) so compensations can still run:
+	// on KILL the invocation is torn down without re-entering the
+	// handler, so the Go defer that fires compensation.Execute never
+	// runs. Individual restate.Run calls should each set
+	// WithMaxRetryDuration so they return TerminalError into Go on
+	// exhaustion, which is the normal path. This service-level policy
+	// is a safety net for failures that escape Run-level bounds.
+	deployRetryPolicy := restate.WithInvocationRetryPolicy(
+		restate.WithInitialInterval(2*time.Second),
+		restate.WithExponentiationFactor(2.0),
+		restate.WithMaxInterval(30*time.Second),
+		restate.WithMaxAttempts(15),
+		restate.PauseOnMaxAttempts(),
+	)
+	restateSrv.Bind(hydrav1.NewDeployServiceServer(deployWorkflow, deployRetryPolicy))
 	restateSrv.Bind(hydrav1.NewDeploymentServiceServer(deployment.New(deployment.Config{
 		DB: database,
 	}), restate.WithIngressPrivate(true)))
@@ -409,7 +408,13 @@ func Run(ctx context.Context, cfg Config) error {
 	if err != nil {
 		return fmt.Errorf("failed to create environment worker service: %w", err)
 	}
-	restateSrv.Bind(hydrav1.NewEnvironmentServiceServer(envSvc))
+	// Promote and rollback pause after the deploy budget (~5 minutes) instead
+	// of the server default of 70 attempts, so a stuck one frees the
+	// environment key fast. Delete keeps the default: it is cascade-only and
+	// has to finish.
+	restateSrv.Bind(hydrav1.NewEnvironmentServiceServer(envSvc).
+		ConfigureHandler("PromoteDeployment", deployRetryPolicy).
+		ConfigureHandler("RollbackDeployment", deployRetryPolicy))
 
 	// BuildSlotService is short-lived coordination — AcquireOrWait/Release
 	// journals have no debugging value (each invocation just reads state,


### PR DESCRIPTION
This PR adds `PromoteDeployment` and `RollbackDeployment` handlers to the envVO, keyed by environment_id. Promote, rollback, and delete of one environment now serialize on the same key, so route swap cannot race another live pointer change.

before, these ran on deployVO, keyed by `deployment_id`. Promote A and rollback A→B never serialized with each other even though they mutate the same environment live pointer. environment is the thing being changed, so it is the lock.


## Heads up

No production risk. We only moved them over to the envVO.