### PR TITLE
fix(db): preserve query errors when rollback fails

### DIFF
--- a/pkg/db/rollback_test.go
+++ b/pkg/db/rollback_test.go
@@ -1,0 +1,34 @@
+package db
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/codes"
+	"github.com/unkeyed/unkey/pkg/fault"
+)
+
+func TestRollbackError(t *testing.T) {
+	cause := &mysql.MySQLError{Number: 3024, Message: "statement timed out"}
+	for _, rollbackErr := range []error{nil, sql.ErrTxDone, fmt.Errorf("rollback: %w", sql.ErrTxDone)} {
+		require.Same(t, cause, rollbackError(cause, rollbackErr))
+	}
+
+	rollbackErr := errors.New("connection lost during rollback")
+	err := rollbackError(cause, rollbackErr)
+	require.ErrorIs(t, err, cause)
+	require.ErrorIs(t, err, rollbackErr)
+	var mysqlErr *mysql.MySQLError
+	require.ErrorAs(t, err, &mysqlErr)
+	require.Equal(t, uint16(3024), mysqlErr.Number)
+	require.Contains(t, err.Error(), cause.Error())
+	require.Contains(t, err.Error(), rollbackErr.Error())
+	require.Equal(t, "Unable to rollback database transaction.", fault.UserFacingMessage(err))
+	code, ok := fault.GetCode(err)
+	require.True(t, ok)
+	require.Equal(t, codes.App.Internal.ServiceUnavailable.URN(), code)
+}

--- a/pkg/db/tx.go
+++ b/pkg/db/tx.go
@@ -10,6 +10,7 @@ package db
 import (
 	"context"
 	"database/sql"
+	"errors"
 
 	"github.com/unkeyed/unkey/pkg/codes"
 	"github.com/unkeyed/unkey/pkg/fault"
@@ -123,16 +124,7 @@ func TxWithResult[T any](ctx context.Context, db *Replica, fn func(context.Conte
 
 	t, err = fn(ctx, tx)
 	if err != nil {
-		rollbackErr := tx.Rollback()
-
-		if rollbackErr != nil && rollbackErr != sql.ErrTxDone {
-			return t, fault.Wrap(rollbackErr,
-				fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
-				fault.Internal("database failed to rollback transaction"), fault.Public("Unable to rollback database transaction."),
-			)
-		}
-
-		return t, err
+		return t, rollbackError(err, tx.Rollback())
 	}
 
 	err = tx.Commit()
@@ -144,6 +136,16 @@ func TxWithResult[T any](ctx context.Context, db *Replica, fn func(context.Conte
 	}
 
 	return t, nil
+}
+
+func rollbackError(cause, rollbackErr error) error {
+	if rollbackErr == nil || errors.Is(rollbackErr, sql.ErrTxDone) {
+		return cause
+	}
+	return fault.Wrap(errors.Join(cause, rollbackErr),
+		fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
+		fault.Internal("database failed to rollback transaction"), fault.Public("Unable to rollback database transaction."),
+	)
 }
 
 // Tx executes fn within a database transaction without returning a result.

--- a/pkg/mysql/rollback_test.go
+++ b/pkg/mysql/rollback_test.go
@@ -1,0 +1,34 @@
+package mysql
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/codes"
+	"github.com/unkeyed/unkey/pkg/fault"
+)
+
+func TestRollbackError(t *testing.T) {
+	cause := &mysql.MySQLError{Number: 3024, Message: "statement timed out"}
+	for _, rollbackErr := range []error{nil, sql.ErrTxDone, fmt.Errorf("rollback: %w", sql.ErrTxDone)} {
+		require.Same(t, cause, rollbackError(cause, rollbackErr))
+	}
+
+	rollbackErr := errors.New("connection lost during rollback")
+	err := rollbackError(cause, rollbackErr)
+	require.ErrorIs(t, err, cause)
+	require.ErrorIs(t, err, rollbackErr)
+	var mysqlErr *mysql.MySQLError
+	require.ErrorAs(t, err, &mysqlErr)
+	require.Equal(t, uint16(3024), mysqlErr.Number)
+	require.Contains(t, err.Error(), cause.Error())
+	require.Contains(t, err.Error(), rollbackErr.Error())
+	require.Equal(t, "Unable to rollback database transaction.", fault.UserFacingMessage(err))
+	code, ok := fault.GetCode(err)
+	require.True(t, ok)
+	require.Equal(t, codes.App.Internal.ServiceUnavailable.URN(), code)
+}

--- a/pkg/mysql/tx.go
+++ b/pkg/mysql/tx.go
@@ -3,6 +3,7 @@ package mysql
 import (
 	"context"
 	"database/sql"
+	"errors"
 
 	"github.com/unkeyed/unkey/pkg/codes"
 	"github.com/unkeyed/unkey/pkg/fault"
@@ -24,16 +25,7 @@ func TxWithResult[T any](ctx context.Context, db *Replica, fn func(context.Conte
 
 	t, err = fn(ctx, tx)
 	if err != nil {
-		rollbackErr := tx.Rollback()
-
-		if rollbackErr != nil && rollbackErr != sql.ErrTxDone {
-			return t, fault.Wrap(rollbackErr,
-				fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
-				fault.Internal("database failed to rollback transaction"), fault.Public("Unable to rollback database transaction."),
-			)
-		}
-
-		return t, err
+		return t, rollbackError(err, tx.Rollback())
 	}
 
 	err = tx.Commit()
@@ -45,6 +37,16 @@ func TxWithResult[T any](ctx context.Context, db *Replica, fn func(context.Conte
 	}
 
 	return t, nil
+}
+
+func rollbackError(cause, rollbackErr error) error {
+	if rollbackErr == nil || errors.Is(rollbackErr, sql.ErrTxDone) {
+		return cause
+	}
+	return fault.Wrap(errors.Join(cause, rollbackErr),
+		fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
+		fault.Internal("database failed to rollback transaction"), fault.Public("Unable to rollback database transaction."),
+	)
 }
 
 // Tx executes fn within a database transaction without returning a result.


### PR DESCRIPTION
## Problem:

When a transaction failed and rollback also failed, the transaction helpers discarded the original error.
Our logs then show the rollback failure instead of the SQL timeout that caused it.

## Solution:

Preserve both failures in the returned error. Keep the original error unchanged when rollback succeeds or the transaction has already ended.

## Impact:

Logs retain both error messages, and callers can recover the original MySQL error number. Existing public responses and the rollback service-unavailable code stay unchanged. This change is independent of the audit export and ClickHouse driver changes.

## Testing:

- mise run build: passed, zero lint issues.
- mise exec -- rask ./pkg/mysql ./pkg/db: 52 tests passed.
- Regression tests cover successful rollback, completed transactions, both error causes, MySQL error numbers, and unchanged public responses.