### PR TITLE
fix(db): reduce external waits inside transactions

### DIFF
--- a/svc/api/routes/v2_apps_update_app/handler.go
+++ b/svc/api/routes/v2_apps_update_app/handler.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"net/http"
+	"slices"
 	"time"
 
 	"github.com/oapi-codegen/nullable"
@@ -72,7 +73,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	// emits under one correlation id.
 	ctx = auditlog.WithCorrelation(ctx, auditlog.NewCorrelationID())
 
-	data, err := db.TxWithResultRetry(ctx, h.DB.RW(), func(ctx context.Context, tx db.DBTX) (openapi.App, error) {
+	findApp := func(tx db.DBTX) (db.App, error) {
 		app, err := db.Query.FindAppByProjectAndIdOrSlug(ctx, tx, db.FindAppByProjectAndIdOrSlugParams{
 			WorkspaceID: principal.AuthorizedWorkspaceID,
 			Project:     req.Project,
@@ -80,7 +81,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		})
 		if err != nil {
 			if db.IsNotFound(err) {
-				return openapi.App{}, fault.New(
+				return db.App{}, fault.New(
 					"app not found",
 					fault.Code(codes.Data.App.NotFound.URN()),
 					fault.Internal("app not found"),
@@ -88,7 +89,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 				)
 			}
 
-			return openapi.App{}, fault.Wrap(
+			return db.App{}, fault.Wrap(
 				err,
 				fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
 				fault.Internal("database error"),
@@ -109,12 +110,12 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			}),
 		))
 		if err != nil {
-			return openapi.App{}, err
+			return db.App{}, err
 		}
 
 		// connect_repository gates every git change, disconnect included.
 		if gitSpecified && app.SourceType == db.AppsSourceTypeOci {
-			return openapi.App{}, fault.New(
+			return db.App{}, fault.New(
 				"git update is incompatible with app source",
 				fault.Code(codes.App.Validation.InvalidInput.URN()),
 				fault.Internal("cannot update git configuration for an OCI-sourced app"),
@@ -122,7 +123,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			)
 		}
 		if req.Oci != nil && app.SourceType != db.AppsSourceTypeOci {
-			return openapi.App{}, fault.New(
+			return db.App{}, fault.New(
 				"image update is incompatible with app source",
 				fault.Code(codes.App.Validation.InvalidInput.URN()),
 				fault.Internal("cannot update OCI image configuration for a non-OCI app"),
@@ -143,10 +144,39 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 				}),
 			))
 			if err != nil {
-				return openapi.App{}, err
+				return db.App{}, err
 			}
 		}
 
+		return app, nil
+	}
+	var resolved githubapp.Resolved
+	if gitSpecified && !req.Git.IsNull() && req.Git.MustGet().Repository != nil {
+		app, err := findApp(h.DB.RW())
+		if err != nil {
+			return err
+		}
+		if h.GitHubAppName == "" {
+			return fault.New("github not configured",
+				fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
+				fault.Public("GitHub repository connection is not enabled."))
+		}
+		installations, lookupErr := db.Query.FindGithubAppInstallationsByWorkspaceId(ctx, h.DB.RW(), app.WorkspaceID)
+		if lookupErr != nil {
+			return fault.Wrap(lookupErr, fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
+				fault.Public("Failed to connect the GitHub repository."))
+		}
+		resolved, err = githubapp.Resolve(h.GitHubClient, h.GitHubAppName, installations, *req.Git.MustGet().Repository)
+		if err != nil {
+			return err
+		}
+	}
+
+	data, err := db.TxWithResultRetry(ctx, h.DB.RW(), func(ctx context.Context, tx db.DBTX) (openapi.App, error) {
+		app, err := findApp(tx)
+		if err != nil {
+			return openapi.App{}, err
+		}
 		updatedAt := time.Now().UnixMilli()
 		update := db.UpdateAppParams{
 			WorkspaceID:               principal.AuthorizedWorkspaceID,
@@ -183,7 +213,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 		// gitState is the connection echoed in the response: current when git is
 		// unspecified, nil on disconnect, the new repository on connect.
-		gitState, err := h.applyGitChange(ctx, tx, app, req.Git)
+		gitState, err := h.applyGitChange(ctx, tx, app, req.Git, resolved)
 		if err != nil {
 			return openapi.App{}, err
 		}
@@ -349,6 +379,7 @@ func (h *Handler) applyGitChange(
 	tx db.DBTX,
 	app db.App,
 	git nullable.Nullable[openapi.AppGitUpdateInput],
+	resolved githubapp.Resolved,
 ) (*openapi.AppGit, error) {
 
 	if !git.IsSpecified() {
@@ -430,15 +461,6 @@ func (h *Handler) applyGitChange(
 		return githubapp.GitResponse(conn.RepositoryFullName, branch), nil
 	}
 
-	if h.GitHubAppName == "" {
-		return nil, fault.New(
-			"github not configured",
-			fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
-			fault.Internal("github app credentials are not configured for this deployment"),
-			fault.Public("GitHub repository connection is not enabled."),
-		)
-	}
-
 	installations, err := db.Query.FindGithubAppInstallationsByWorkspaceId(ctx, tx, app.WorkspaceID)
 	if err != nil {
 		return nil, fault.Wrap(
@@ -449,9 +471,10 @@ func (h *Handler) applyGitChange(
 		)
 	}
 
-	resolved, err := githubapp.Resolve(h.GitHubClient, h.GitHubAppName, installations, *requested.Repository)
-	if err != nil {
-		return nil, err
+	if !slices.Contains(installations, resolved.InstallationID) {
+		return nil, fault.New("github installation changed during update",
+			fault.Code(codes.App.Precondition.PreconditionFailed.URN()),
+			fault.Public("GitHub installation changed. Please retry the request."))
 	}
 
 	// A fresh connect adopts the repository's GitHub default branch; replacing an

--- a/svc/ctrl/services/customdomain/add_custom_domain_test.go
+++ b/svc/ctrl/services/customdomain/add_custom_domain_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"connectrpc.com/connect"
 	restateingress "github.com/restatedev/sdk-go/ingress"
@@ -29,6 +30,32 @@ import (
 const testBearer = "test-token"
 
 var errInjectedAuditInsert = errors.New("injected audit insert failure")
+
+func TestAddCustomDomainBoundsIngressWait(t *testing.T) {
+	f := newFixture(t, 1)
+	var submits atomic.Int32
+	stop := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		submits.Add(1)
+		select {
+		case <-r.Context().Done():
+		case <-stop:
+		}
+	}))
+	t.Cleanup(server.Close)
+	defer close(stop)
+	svc := f.newServiceWithRestate(t, server.URL)
+	started := time.Now()
+	_, err := svc.AddCustomDomain(context.Background(), f.request(f.domain))
+	require.Error(t, err)
+	require.Equal(t, int32(1), submits.Load())
+	require.Less(t, time.Since(started), 5*time.Second)
+	require.Equal(t, 0, countRows(t, context.Background(), f.database.RW(),
+		"SELECT COUNT(*) FROM custom_domains WHERE workspace_id = ? AND domain = ?", f.workspaceID, f.domain))
+	rows, err := f.database.ListClickhouseOutboxByWorkspace(context.Background(), f.workspaceID)
+	require.NoError(t, err)
+	require.Empty(t, rows)
+}
 
 // A domain in the database always has a matching outbox row, which is only observable
 // once the insert commits.

--- a/svc/ctrl/services/customdomain/service.go
+++ b/svc/ctrl/services/customdomain/service.go
@@ -233,12 +233,6 @@ func (s *Service) AddCustomDomain(
 			return connect.NewError(connect.CodeInternal, fmt.Errorf("insert audit log: %w", txErr))
 		}
 
-		// Submitting inside the transaction makes the RPC all-or-nothing: a failed
-		// submit rolls the row and its audit entry back, so retrying createDomain is
-		// the recovery. The workflow tolerates reading before the commit lands (see
-		// rowVisibilityGrace in the worker), and a TxRetry rerun re-submitting is
-		// safe because the invocation is keyed by domainID, a virtual object Restate
-		// runs one at a time per domain.
 		sendResp, sendErr := s.startVerification(txCtx, domainID)
 		if sendErr != nil {
 			logger.Error(
@@ -482,6 +476,10 @@ func (s *Service) RetryVerification(
 
 // startVerification submits the verification workflow for domainID.
 func (s *Service) startVerification(ctx context.Context, domainID string) (restateingress.SimpleSendResponse, error) {
+	// Keep failed submission recoverable by rolling back the domain and audit
+	// writes, but do not let ingress stalls consume the Vitess transaction limit.
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
 	client := hydrav1.NewCustomDomainServiceIngressClient(s.restate, domainID)
 
 	return client.VerifyDomain().Send(ctx, &hydrav1.VerifyDomainRequest{})

--- a/web/apps/dashboard/lib/trpc/routers/key/create.test.ts
+++ b/web/apps/dashboard/lib/trpc/routers/key/create.test.ts
@@ -1,0 +1,120 @@
+import { initTRPC } from "@trpc/server";
+import { beforeEach, expect, it, vi } from "vitest";
+import { createKey } from "./create";
+import { createRootKey } from "./createRootKey";
+
+const state = vi.hoisted(() => ({
+  inTransaction: false,
+  transactions: 0,
+  encrypt: vi.fn(),
+  insert: vi.fn(),
+  audit: vi.fn(),
+  identity: vi.fn(),
+}));
+vi.mock("@/lib/vault-client", () => ({ createVaultClient: () => ({ encrypt: state.encrypt }) }));
+vi.mock("@/lib/audit", () => ({ insertAuditLogs: state.audit }));
+vi.mock("@/lib/env", () => ({ env: () => ({ UNKEY_WORKSPACE_ID: "unkey", UNKEY_API_ID: "api" }) }));
+vi.mock("@/lib/projects/ensure-default-project-id", () => ({
+  ensureDefaultProjectId: async () => "project",
+}));
+vi.mock("@unkey/keys", () => ({
+  newKey: async () => ({ key: "secret", hash: "hash", prefix: "test", start: "start", end: "end" }),
+}));
+vi.mock("../../trpc", async () => {
+  const { initTRPC } = await import("@trpc/server");
+  const t = initTRPC.create();
+  return {
+    workspaceProcedure: t.procedure,
+    requireWorkspaceAdmin: t.middleware(({ next }) => next()),
+    ratelimit: { create: {} },
+    withRatelimit: () => t.middleware(({ next }) => next()),
+  };
+});
+vi.mock(
+  "@/app/(app)/[workspaceSlug]/apis/[apiId]/_components/create-key/create-key.schema",
+  async () => {
+    const { z } = await import("zod");
+    return {
+      createKeyInputSchema: z.object({ keyAuthId: z.string(), identityId: z.string().optional() }),
+    };
+  },
+);
+vi.mock("@/lib/db", () => {
+  const tx = {
+    insert: (table: string) => ({ values: async (values: unknown) => state.insert(table, values) }),
+    query: { identities: { findFirst: state.identity }, permissions: { findMany: async () => [] } },
+  };
+  return {
+    schema: {
+      keys: "keys",
+      encryptedKeys: "encryptedKeys",
+      permissions: "permissions",
+      keysPermissions: "keysPermissions",
+    },
+    db: {
+      query: {
+        keyAuth: { findFirst: async () => ({ id: "ka", storeEncryptedKeys: true }) },
+        apis: { findFirst: async () => ({ keyAuthId: "ka" }) },
+      },
+      transaction: async (fn: (connection: typeof tx) => Promise<unknown>) => {
+        expect(state.inTransaction).toBe(false);
+        state.transactions++;
+        state.inTransaction = true;
+        try {
+          return await fn(tx);
+        } finally {
+          state.inTransaction = false;
+        }
+      },
+    },
+  };
+});
+const caller = initTRPC
+  .context<{ workspace: { id: string }; user: { id: string }; audit: { location: string } }>()
+  .create()
+  .router({ create: createKey, createRoot: createRootKey })
+  .createCaller({ workspace: { id: "ws" }, user: { id: "user" }, audit: { location: "test" } });
+
+beforeEach(() => {
+  state.transactions = 0;
+  state.insert.mockReset();
+  state.audit.mockReset();
+  state.identity.mockReset().mockResolvedValue({ id: "identity" });
+  state.encrypt.mockReset().mockImplementation(async () => {
+    expect(state.inTransaction).toBe(false);
+    return { encrypted: "ciphertext", keyId: "encryption-key" };
+  });
+});
+
+it("encrypts before opening the transaction and persists the prepared ciphertext", async () => {
+  expect(await caller.create({ keyAuthId: "ka" })).toMatchObject({ key: "secret" });
+  expect(state.transactions).toBe(1);
+  expect(state.insert).toHaveBeenCalledWith(
+    "encryptedKeys",
+    expect.objectContaining({ encrypted: "ciphertext", encryptionKeyId: "encryption-key" }),
+  );
+  expect(state.audit).toHaveBeenCalledOnce();
+});
+
+it("does not open a transaction when Vault fails", async () => {
+  state.encrypt.mockRejectedValue(new Error("vault unavailable"));
+  await expect(caller.create({ keyAuthId: "ka" })).rejects.toThrow();
+  expect(state.transactions).toBe(0);
+  expect(state.insert).not.toHaveBeenCalled();
+});
+
+it("still rejects an identity outside the workspace before writing", async () => {
+  state.identity.mockResolvedValue(undefined);
+  await expect(caller.create({ keyAuthId: "ka", identityId: "foreign" })).rejects.toThrow();
+  expect(state.insert).not.toHaveBeenCalled();
+});
+
+it("creates root-key permissions in the caller's transaction instead of opening a second one", async () => {
+  expect(await caller.createRoot({ permissions: ["api.*.create_api"] })).toMatchObject({
+    key: "secret",
+  });
+  expect(state.transactions).toBe(1);
+  expect(state.insert).toHaveBeenCalledWith("permissions", expect.any(Array));
+  expect(state.insert).toHaveBeenCalledWith("keysPermissions", expect.any(Array));
+  expect(state.audit).toHaveBeenCalledOnce();
+});

--- a/web/apps/dashboard/lib/trpc/routers/key/create.ts
+++ b/web/apps/dashboard/lib/trpc/routers/key/create.ts
@@ -43,15 +43,16 @@ export const createKey = workspaceProcedure
     }
 
     try {
+      const prepared = await prepareKey(input, ctx.workspace.id, keyAuth.storeEncryptedKeys);
       return await db.transaction(async (tx) => {
         return await createKeyCore(
           {
             ...input,
             keyAuthId: keyAuth.id,
-            storeEncryptedKeys: keyAuth.storeEncryptedKeys,
           },
           ctx,
           tx,
+          prepared,
         );
       });
     } catch (_err) {
@@ -73,10 +74,23 @@ type CreateKeyContext = {
 
 type DatabaseTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0];
 
+export async function prepareKey(
+  input: Pick<CreateKeyInput, "prefix" | "bytes">,
+  workspaceId: string,
+  storeEncryptedKeys: boolean,
+) {
+  const generated = await newKey({ prefix: input.prefix, byteLength: input.bytes });
+  const encrypted = storeEncryptedKeys
+    ? await vault.encrypt({ keyring: workspaceId, data: generated.key })
+    : undefined;
+  return { ...generated, encrypted };
+}
+
 export async function createKeyCore(
-  input: CreateKeyInput & { storeEncryptedKeys: boolean },
+  input: CreateKeyInput,
   ctx: CreateKeyContext,
   tx: DatabaseTransaction,
+  prepared: Awaited<ReturnType<typeof prepareKey>>,
 ) {
   // The keys.identity_id column has no FK or workspace predicate. If we
   // accept a client-supplied identityId without verifying it belongs to this
@@ -103,10 +117,7 @@ export async function createKeyCore(
   }
 
   const keyId = newId("key");
-  const { key, hash, prefix, start, end } = await newKey({
-    prefix: input.prefix,
-    byteLength: input.bytes,
-  });
+  const { key, hash, prefix, start, end } = prepared;
 
   await tx.insert(schema.keys).values({
     id: keyId,
@@ -131,11 +142,8 @@ export async function createKeyCore(
     environment: input.environment,
   });
 
-  if (input.storeEncryptedKeys) {
-    const { encrypted, keyId: encryptionKeyId } = await vault.encrypt({
-      keyring: ctx.workspace.id,
-      data: key,
-    });
+  if (prepared.encrypted) {
+    const { encrypted, keyId: encryptionKeyId } = prepared.encrypted;
 
     await tx.insert(schema.encryptedKeys).values({
       encrypted,

--- a/web/apps/dashboard/lib/trpc/routers/key/createRootKey.ts
+++ b/web/apps/dashboard/lib/trpc/routers/key/createRootKey.ts
@@ -100,6 +100,7 @@ export const createRootKey = workspaceProcedure
         });
 
         const { permissions, auditLogs: createPermissionLogs } = await upsertPermissions(
+          tx,
           ctx,
           env().UNKEY_WORKSPACE_ID,
           input.permissions,

--- a/web/apps/dashboard/lib/trpc/routers/key/reroll/index.test.ts
+++ b/web/apps/dashboard/lib/trpc/routers/key/reroll/index.test.ts
@@ -1,0 +1,73 @@
+import { initTRPC } from "@trpc/server";
+import { expect, it, vi } from "vitest";
+import { rerollRootKey } from "./index";
+
+const state = vi.hoisted(() => ({ inTransaction: false, encrypt: vi.fn(), insert: vi.fn() }));
+vi.mock("@/lib/vault-client", () => ({ createVaultClient: () => ({ encrypt: state.encrypt }) }));
+vi.mock("@/lib/audit", () => ({ insertAuditLogs: vi.fn() }));
+vi.mock("@/lib/env", () => ({ env: () => ({ UNKEY_WORKSPACE_ID: "unkey" }) }));
+vi.mock("@unkey/keys", () => ({
+  newKey: async () => ({ key: "secret", hash: "hash", start: "start", end: "end" }),
+}));
+vi.mock("../../../trpc", async () => {
+  const { initTRPC } = await import("@trpc/server");
+  const t = initTRPC.create();
+  const pass = t.middleware(({ next }) => next());
+  return {
+    workspaceProcedure: t.procedure,
+    requireWorkspaceAdmin: pass,
+    ratelimit: { create: {} },
+    withRatelimit: () => pass,
+  };
+});
+vi.mock("@/lib/db", () => {
+  const tx = {
+    select: () => ({ from: () => ({ where: () => ({ for: async () => [{ id: "key" }] }) }) }),
+    query: {
+      keys: {
+        findFirst: async () => ({
+          workspaceId: "unkey",
+          start: "unkey_",
+          prefix: "unkey",
+          expires: null,
+          encrypted: { keyId: "key" },
+          keyAuth: { storeEncryptedKeys: true, defaultBytes: 16 },
+        }),
+      },
+    },
+    insert: state.insert,
+  };
+  return {
+    and: vi.fn(),
+    eq: vi.fn(),
+    isNull: vi.fn(),
+    schema: { keys: {} },
+    db: {
+      transaction: async (fn: (connection: typeof tx) => Promise<unknown>) => {
+        state.inTransaction = true;
+        try {
+          return await fn(tx);
+        } finally {
+          state.inTransaction = false;
+        }
+      },
+    },
+  };
+});
+
+it("bounds encryption of the locked source and rolls back on a Vault failure", async () => {
+  state.encrypt.mockImplementation(async (_request: unknown, options: { timeoutMs: number }) => {
+    expect(state.inTransaction).toBe(true);
+    expect(options.timeoutMs).toBe(2_000);
+    throw new Error("deadline exceeded");
+  });
+  const caller = initTRPC
+    .context<{ workspace: { id: string }; user: { id: string }; audit: { location: string } }>()
+    .create()
+    .router({ reroll: rerollRootKey })
+    .createCaller({ workspace: { id: "ws" }, user: { id: "user" }, audit: { location: "test" } });
+  await expect(caller.reroll({ keyId: "key", expiration: 0 })).rejects.toThrow();
+  expect(state.encrypt).toHaveBeenCalledOnce();
+  expect(state.insert).not.toHaveBeenCalled();
+  expect(state.inTransaction).toBe(false);
+});

--- a/web/apps/dashboard/lib/trpc/routers/key/reroll/index.ts
+++ b/web/apps/dashboard/lib/trpc/routers/key/reroll/index.ts
@@ -204,13 +204,13 @@ async function rerollKeyCore({
 
       const { key: plaintext, hash, start, end } = await newKey({ prefix, byteLength });
 
-      // Encrypt inside the tx so the decision uses the locked source
-      // state. The lock is held for the duration of this RPC, but key
-      // rotation is rare enough that this is acceptable; the alternative
-      // (speculative pre-tx encrypt) reintroduces a TOCTOU on the
-      // `encrypted` flag and the keyring.
+      // Encryption uses the locked key's settings. Bound the RPC so a Vault
+      // outage cannot hold the key lock until the database transaction timeout.
       const encryptedRecord = source.encrypted
-        ? await vault.encrypt({ keyring: source.workspaceId, data: plaintext })
+        ? await vault.encrypt(
+            { keyring: source.workspaceId, data: plaintext },
+            { timeoutMs: 2_000 },
+          )
         : undefined;
 
       // The new key inherits the source's expiry so rotation preserves

--- a/web/apps/dashboard/lib/trpc/routers/key/updateRootKeyPermissions.ts
+++ b/web/apps/dashboard/lib/trpc/routers/key/updateRootKeyPermissions.ts
@@ -74,7 +74,7 @@ export const updateRootKeyPermissions = workspaceProcedure
 
         // Upsert new permissions
         const { permissions: upsertedPermissions, auditLogs: createPermissionLogs } =
-          await upsertPermissions(ctx, env().UNKEY_WORKSPACE_ID, input.permissions);
+          await upsertPermissions(tx, ctx, env().UNKEY_WORKSPACE_ID, input.permissions);
 
         auditLogs.push(...createPermissionLogs);
 

--- a/web/apps/dashboard/lib/trpc/routers/rbac.ts
+++ b/web/apps/dashboard/lib/trpc/routers/rbac.ts
@@ -1,4 +1,4 @@
-import { type InsertPermission, type Permission, db, schema } from "@/lib/db";
+import { type InsertPermission, type Permission, type Transaction, schema } from "@/lib/db";
 
 import type { UnkeyAuditLog } from "@/lib/audit";
 import { ensureDefaultProjectId } from "@/lib/projects/ensure-default-project-id";
@@ -7,6 +7,7 @@ import { newId } from "@unkey/id";
 import type { Context } from "../context";
 
 export async function upsertPermissions(
+  tx: Transaction,
   ctx: Context,
   workspaceId: string,
   slugs: string[],
@@ -14,78 +15,76 @@ export async function upsertPermissions(
   permissions: Omit<Permission, "pk">[];
   auditLogs: UnkeyAuditLog[];
 }> {
-  return await db.transaction(async (tx) => {
-    const projectId = await ensureDefaultProjectId(tx, workspaceId);
-    const existingPermissions = await tx.query.permissions.findMany({
-      where: (table, { inArray, and, eq }) =>
-        and(eq(table.workspaceId, workspaceId), inArray(table.slug, slugs)),
-      columns: {
-        id: true,
-        workspaceId: true,
-        projectId: true,
-        name: true,
-        slug: true,
-        description: true,
-        updatedAtM: true,
-        createdAtM: true,
+  const projectId = await ensureDefaultProjectId(tx, workspaceId);
+  const existingPermissions = await tx.query.permissions.findMany({
+    where: (table, { inArray, and, eq }) =>
+      and(eq(table.workspaceId, workspaceId), inArray(table.slug, slugs)),
+    columns: {
+      id: true,
+      workspaceId: true,
+      projectId: true,
+      name: true,
+      slug: true,
+      description: true,
+      updatedAtM: true,
+      createdAtM: true,
+    },
+  });
+
+  const newPermissions: InsertPermission[] = [];
+  const auditLogs: UnkeyAuditLog[] = [];
+
+  const userId = ctx.user?.id;
+  if (!userId) {
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "UserId not found",
+    });
+  }
+
+  const permissions: Omit<Permission, "pk">[] = slugs.map((slug) => {
+    const existingPermission = existingPermissions.find((p) => p.slug === slug);
+
+    if (existingPermission) {
+      return existingPermission;
+    }
+
+    const permission = {
+      id: newId("permission"),
+      workspaceId,
+      projectId,
+      name: slug,
+      slug: slug,
+      description: null,
+      updatedAtM: null,
+      createdAtM: Date.now(),
+    };
+
+    newPermissions.push(permission);
+    auditLogs.push({
+      workspaceId,
+      actor: { type: "user", id: userId },
+      event: "permission.create",
+      description: `Created ${permission.id}`,
+      resources: [
+        {
+          type: "permission",
+          id: permission.id,
+          name: permission.slug,
+        },
+      ],
+      context: {
+        location: ctx.audit.location,
+        userAgent: ctx.audit.userAgent,
       },
     });
 
-    const newPermissions: InsertPermission[] = [];
-    const auditLogs: UnkeyAuditLog[] = [];
-
-    const userId = ctx.user?.id;
-    if (!userId) {
-      throw new TRPCError({
-        code: "NOT_FOUND",
-        message: "UserId not found",
-      });
-    }
-
-    const permissions: Omit<Permission, "pk">[] = slugs.map((slug) => {
-      const existingPermission = existingPermissions.find((p) => p.slug === slug);
-
-      if (existingPermission) {
-        return existingPermission;
-      }
-
-      const permission = {
-        id: newId("permission"),
-        workspaceId,
-        projectId,
-        name: slug,
-        slug: slug,
-        description: null,
-        updatedAtM: null,
-        createdAtM: Date.now(),
-      };
-
-      newPermissions.push(permission);
-      auditLogs.push({
-        workspaceId,
-        actor: { type: "user", id: userId },
-        event: "permission.create",
-        description: `Created ${permission.id}`,
-        resources: [
-          {
-            type: "permission",
-            id: permission.id,
-            name: permission.slug,
-          },
-        ],
-        context: {
-          location: ctx.audit.location,
-          userAgent: ctx.audit.userAgent,
-        },
-      });
-
-      return permission;
-    });
-
-    if (newPermissions.length) {
-      await tx.insert(schema.permissions).values(newPermissions);
-    }
-
-    return { permissions, auditLogs };
+    return permission;
   });
+
+  if (newPermissions.length) {
+    await tx.insert(schema.permissions).values(newPermissions);
+  }
+
+  return { permissions, auditLogs };
 }

--- a/web/apps/dashboard/lib/trpc/routers/share/reveal.test.ts
+++ b/web/apps/dashboard/lib/trpc/routers/share/reveal.test.ts
@@ -1,0 +1,119 @@
+import { initTRPC } from "@trpc/server";
+import { beforeEach, expect, it, vi } from "vitest";
+import { revealSharedSecret } from "./reveal";
+
+type Row = { workspaceId: string; encrypted: string; expiresAt: number };
+const state = vi.hoisted(() => ({
+  row: undefined as Row | undefined,
+  inTransaction: false,
+  decrypt: vi.fn(),
+  audit: vi.fn(),
+}));
+vi.mock("@/lib/vault-client", () => ({ createVaultClient: () => ({ decrypt: state.decrypt }) }));
+vi.mock("@/lib/audit", () => ({ insertAuditLogs: state.audit }));
+vi.mock("../../trpc", async () => {
+  const { initTRPC } = await import("@trpc/server");
+  return {
+    publicProcedure: initTRPC.context<{ audit: { location: string } }>().create().procedure,
+  };
+});
+vi.mock("@/lib/db", () => {
+  const select = () => ({
+    from: () => ({
+      where: () =>
+        Object.assign(Promise.resolve(state.row ? [{ ...state.row }] : []), {
+          for: async () => (state.row ? [{ ...state.row }] : []),
+        }),
+    }),
+  });
+  const tx = {
+    select,
+    delete: () => ({
+      where: async () => {
+        state.row = undefined;
+      },
+    }),
+  };
+  let previous: Promise<unknown> = Promise.resolve();
+  return {
+    eq: vi.fn(),
+    schema: { sharedSecrets: {} },
+    db: {
+      select,
+      transaction: (fn: (connection: typeof tx) => Promise<unknown>) => {
+        const result = previous
+          .catch(() => {})
+          .then(async () => {
+            const before = state.row;
+            state.inTransaction = true;
+            try {
+              return await fn(tx);
+            } catch (err) {
+              state.row = before;
+              throw err;
+            } finally {
+              state.inTransaction = false;
+            }
+          });
+        previous = result;
+        return result;
+      },
+    },
+  };
+});
+const caller = initTRPC
+  .context<{ audit: { location: string } }>()
+  .create()
+  .router({ reveal: revealSharedSecret })
+  .createCaller({ audit: { location: "test" } });
+
+beforeEach(() => {
+  state.row = { workspaceId: "ws", encrypted: "ciphertext", expiresAt: Date.now() + 60_000 };
+  state.audit.mockReset();
+  state.decrypt.mockReset().mockImplementation(async () => {
+    expect(state.inTransaction).toBe(false);
+    return { plaintext: "secret" };
+  });
+});
+
+it("decrypts without a transaction and returns the secret only once", async () => {
+  const results = await Promise.all([
+    caller.reveal({ id: "share" }),
+    caller.reveal({ id: "share" }),
+  ]);
+  expect(results.filter((r) => r.ok)).toHaveLength(1);
+  expect(results).toContainEqual({ ok: true, secret: "secret" });
+  expect(state.audit).toHaveBeenCalledTimes(1);
+});
+
+it("leaves the share retryable when Vault fails", async () => {
+  state.decrypt.mockRejectedValue(new Error("vault unavailable"));
+  await expect(caller.reveal({ id: "share" })).rejects.toThrow("vault unavailable");
+  expect(state.row).toBeDefined();
+  expect(state.audit).not.toHaveBeenCalled();
+});
+
+it.each(["expired", "replaced", "deleted"])(
+  "does not return a share %s during decryption",
+  async (change) => {
+    state.decrypt.mockImplementation(async () => {
+      if (change === "deleted") {
+        state.row = undefined;
+      } else if (state.row) {
+        state.row = {
+          ...state.row,
+          ...(change === "expired" ? { expiresAt: 0 } : { encrypted: "other" }),
+        };
+      }
+      return { plaintext: "secret" };
+    });
+    expect(await caller.reveal({ id: "share" })).toEqual({ ok: false });
+    expect(state.audit).not.toHaveBeenCalled();
+  },
+);
+
+it("does not consume the share or return plaintext if the audit write fails", async () => {
+  state.audit.mockRejectedValue(new Error("audit unavailable"));
+  await expect(caller.reveal({ id: "share" })).rejects.toThrow("audit unavailable");
+  expect(state.row).toBeDefined();
+});

--- a/web/apps/dashboard/lib/trpc/routers/share/reveal.ts
+++ b/web/apps/dashboard/lib/trpc/routers/share/reveal.ts
@@ -11,14 +11,27 @@ const vault = createVaultClient(VaultService);
 // used). Distinguishing them would leak whether an id ever existed.
 type RevealResult = { ok: true; secret: string } | { ok: false };
 
-// Public: the share id is the bearer credential. The whole read -> decrypt ->
-// delete -> audit sequence runs in one transaction. `SELECT ... FOR UPDATE` locks
-// the row so concurrent reveals of the same id serialize: the loser blocks until
-// we commit, then reads nothing. Decrypt happens before the delete, so a vault
-// outage rolls the transaction back and leaves the row retryable.
+// Decrypt speculatively without holding a database connection. Only the caller
+// that locks and consumes the same, still-valid row may return the plaintext.
 export const revealSharedSecret = publicProcedure
   .input(z.object({ id: z.string().min(1).max(256) }))
   .mutation(async ({ ctx, input }): Promise<RevealResult> => {
+    const [candidate] = await db
+      .select({
+        workspaceId: schema.sharedSecrets.workspaceId,
+        expiresAt: schema.sharedSecrets.expiresAt,
+        encrypted: schema.sharedSecrets.encrypted,
+      })
+      .from(schema.sharedSecrets)
+      .where(eq(schema.sharedSecrets.id, input.id));
+    if (!candidate || candidate.expiresAt <= Date.now()) {
+      return { ok: false };
+    }
+    const { plaintext } = await vault.decrypt({
+      keyring: candidate.workspaceId,
+      encrypted: candidate.encrypted,
+    });
+
     return db.transaction(async (tx): Promise<RevealResult> => {
       const [row] = await tx
         .select({
@@ -30,14 +43,15 @@ export const revealSharedSecret = publicProcedure
         .where(eq(schema.sharedSecrets.id, input.id))
         .for("update");
 
-      if (!row || row.expiresAt <= Date.now()) {
+      if (
+        !row ||
+        row.expiresAt <= Date.now() ||
+        row.workspaceId !== candidate.workspaceId ||
+        row.encrypted !== candidate.encrypted ||
+        row.expiresAt !== candidate.expiresAt
+      ) {
         return { ok: false };
       }
-
-      const { plaintext } = await vault.decrypt({
-        keyring: row.workspaceId,
-        encrypted: row.encrypted,
-      });
 
       await tx.delete(schema.sharedSecrets).where(eq(schema.sharedSecrets.id, input.id));
 

--- a/web/apps/dashboard/lib/trpc/routers/workspace/create.test.ts
+++ b/web/apps/dashboard/lib/trpc/routers/workspace/create.test.ts
@@ -1,0 +1,85 @@
+import { initTRPC } from "@trpc/server";
+import { beforeEach, expect, it, vi } from "vitest";
+import { createWorkspace } from "./create";
+
+const state = vi.hoisted(() => ({
+  inTransaction: false,
+  transactions: 0,
+  createTenant: vi.fn(),
+  findFirst: vi.fn(),
+  insert: vi.fn(),
+  audit: vi.fn(),
+}));
+vi.mock("@/lib/auth/server", () => ({ auth: { createTenant: state.createTenant } }));
+vi.mock("@/lib/audit", () => ({ insertAuditLogs: state.audit }));
+vi.mock("@/lib/env", () => ({ env: () => ({ AUTH_PROVIDER: "workos" }) }));
+vi.mock("../../trpc", async () => {
+  const { initTRPC } = await import("@trpc/server");
+  return { protectedProcedure: initTRPC.create().procedure };
+});
+vi.mock("@/lib/db", () => {
+  const tx = {
+    insert: (table: string) => ({ values: async (values: unknown) => state.insert(table, values) }),
+  };
+  return {
+    schema: { workspaces: "workspaces", limits: "limits", workspaceBilling: "billing" },
+    db: {
+      query: { workspaces: { findFirst: state.findFirst } },
+      transaction: async (fn: (connection: typeof tx) => Promise<unknown>) => {
+        state.transactions++;
+        state.inTransaction = true;
+        try {
+          return await fn(tx);
+        } finally {
+          state.inTransaction = false;
+        }
+      },
+    },
+  };
+});
+const caller = initTRPC
+  .context<{ user: { id: string }; audit: { location: string } }>()
+  .create()
+  .router({ create: createWorkspace })
+  .createCaller({ user: { id: "user" }, audit: { location: "test" } });
+
+beforeEach(() => {
+  state.transactions = 0;
+  state.insert.mockReset();
+  state.audit.mockReset();
+  state.findFirst.mockReset().mockResolvedValue(undefined);
+  state.createTenant.mockReset().mockImplementation(async () => {
+    expect(state.inTransaction).toBe(false);
+    return "org";
+  });
+});
+
+it("creates the WorkOS tenant before opening the MySQL transaction", async () => {
+  expect(await caller.create({ name: "Workspace", slug: "workspace" })).toEqual({
+    orgId: "org",
+    slug: "workspace",
+  });
+  expect(state.transactions).toBe(1);
+  expect(state.insert).toHaveBeenCalledTimes(3);
+  expect(state.audit).toHaveBeenCalledOnce();
+});
+
+it("does not open a transaction if WorkOS fails", async () => {
+  const log = vi.spyOn(console, "error").mockImplementation(() => {});
+  state.createTenant.mockRejectedValue(new Error("WorkOS unavailable"));
+  try {
+    await expect(caller.create({ name: "Workspace", slug: "workspace" })).rejects.toThrow();
+    expect(state.transactions).toBe(0);
+    expect(state.insert).not.toHaveBeenCalled();
+  } finally {
+    log.mockRestore();
+  }
+});
+
+it("rejects an existing slug without creating a WorkOS tenant", async () => {
+  state.findFirst.mockResolvedValue({ id: "existing" });
+  await expect(caller.create({ name: "Workspace", slug: "workspace" })).rejects.toThrow(
+    "already exists",
+  );
+  expect(state.createTenant).not.toHaveBeenCalled();
+});

--- a/web/apps/dashboard/lib/trpc/routers/workspace/create.ts
+++ b/web/apps/dashboard/lib/trpc/routers/workspace/create.ts
@@ -28,55 +28,55 @@ export const createWorkspace = protectedProcedure
       });
     }
 
-    const orgId = await db
-      .transaction(async (tx) => {
-        if (env().AUTH_PROVIDER === "local") {
-          // Check if this user already has a workspace
-          const existingWorkspaces = await tx.query.workspaces.findMany({
-            where: (workspaces, { eq }) => eq(workspaces.orgId, ctx.tenant.id),
-            columns: { id: true },
-          });
-
-          if (existingWorkspaces.length > 0) {
-            throw new TRPCError({
-              code: "METHOD_NOT_SUPPORTED",
-              message:
-                "You cannot create additional workspaces in local development mode. Use workOS auth provider if you need to test multi-workspace functionality.",
-            });
-          }
-        }
-
-        const duplicateSlug = await tx.query.workspaces.findFirst({
-          where: (workspaces, { eq }) => eq(workspaces.slug, input.slug),
+    try {
+      if (env().AUTH_PROVIDER === "local") {
+        // Check if this user already has a workspace
+        const existingWorkspaces = await db.query.workspaces.findMany({
+          where: (workspaces, { eq }) => eq(workspaces.orgId, ctx.tenant.id),
           columns: { id: true },
         });
 
-        if (duplicateSlug) {
+        if (existingWorkspaces.length > 0) {
           throw new TRPCError({
-            code: "CONFLICT",
-            message: "A workspace with this slug already exists.",
+            code: "METHOD_NOT_SUPPORTED",
+            message:
+              "You cannot create additional workspaces in local development mode. Use workOS auth provider if you need to test multi-workspace functionality.",
           });
         }
+      }
 
-        const orgId = await authProvider.createTenant({
-          name: input.name,
-          userId,
+      const duplicateSlug = await db.query.workspaces.findFirst({
+        where: (workspaces, { eq }) => eq(workspaces.slug, input.slug),
+        columns: { id: true },
+      });
+
+      if (duplicateSlug) {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message: "A workspace with this slug already exists.",
         });
+      }
 
-        const workspace: InsertWorkspace = {
-          id: newId("workspace"),
-          orgId: orgId,
-          name: input.name,
-          slug: input.slug,
-          betaFeatures: {},
-          enabled: true,
-          deleteProtection: true,
-          createdAtM: Date.now(),
-          updatedAtM: null,
-          deletedAtM: null,
-          k8sNamespace: dns1035(),
-        };
+      const orgId = await authProvider.createTenant({
+        name: input.name,
+        userId,
+      });
 
+      const workspace: InsertWorkspace = {
+        id: newId("workspace"),
+        orgId: orgId,
+        name: input.name,
+        slug: input.slug,
+        betaFeatures: {},
+        enabled: true,
+        deleteProtection: true,
+        createdAtM: Date.now(),
+        updatedAtM: null,
+        deletedAtM: null,
+        k8sNamespace: dns1035(),
+      };
+
+      await db.transaction(async (tx) => {
         await tx.insert(schema.workspaces).values(workspace);
         await tx.insert(schema.limits).values({
           workspaceId: workspace.id,
@@ -106,23 +106,17 @@ export const createWorkspace = protectedProcedure
             },
           },
         ]);
-
-        return orgId;
-      })
-      .catch((err) => {
-        if (err instanceof TRPCError) {
-          throw err;
-        }
-        console.error(err);
-        throw new TRPCError({
-          code: "INTERNAL_SERVER_ERROR",
-          message:
-            "We are unable to create the workspace. Please try again or contact support@unkey.com",
-        });
       });
-
-    return {
-      orgId,
-      slug: input.slug,
-    };
+      return { orgId, slug: input.slug };
+    } catch (err) {
+      if (err instanceof TRPCError) {
+        throw err;
+      }
+      console.error(err);
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message:
+          "We are unable to create the workspace. Please try again or contact support@unkey.com",
+      });
+    }
   });

--- a/web/apps/dashboard/lib/trpc/routers/workspace/onboarding.ts
+++ b/web/apps/dashboard/lib/trpc/routers/workspace/onboarding.ts
@@ -4,7 +4,7 @@ import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { workspaceProcedure } from "../../trpc";
 import { createApiCore } from "../api/create";
-import { createKeyCore } from "../key/create";
+import { createKeyCore, prepareKey } from "../key/create";
 
 const createWorkspaceWithApiAndKeyInputSchema = z.object({
   apiName: z
@@ -21,6 +21,7 @@ export const onboardingKeyCreation = workspaceProcedure
     const { apiName, ...keyInput } = input;
 
     try {
+      const prepared = await prepareKey(keyInput, ctx.workspace.id, false);
       return await db.transaction(async (tx) => {
         // Create API
         const apiResult = await createApiCore({ name: apiName }, ctx, tx);
@@ -29,10 +30,10 @@ export const onboardingKeyCreation = workspaceProcedure
           {
             ...keyInput,
             keyAuthId: apiResult.keyAuthId,
-            storeEncryptedKeys: false, // Default for new APIs. Can be activated by unkey with a support ticket.
           },
           ctx,
           tx,
+          prepared,
         );
 
         return {


### PR DESCRIPTION
## Problem:

As with the auditlog export some of our APi/Dashboard operations also held cons/open transactions while waiting for external services which is something we dont really want.

could leak to exhausting our transaction limit or prolonging row locks.

Our Root-key permission upserts also opened independent transactions that could commit separately from the key change which isnt that great

## Solution:

Move 

- GitHub lookup
- WorkOS tenant creation
- Key encryption, 
- shared-secret decryption 

outside SQL transactions.

## Impact:

External stalls no longer occupy SQL connections in the four moved paths. One-time secret reveal still checks expiry and permits only one successful consumer. The retained exceptions still hold connections briefly; their deadlines reduce risk rather than remove it. MySQL cannot roll back accepted WorkOS or Restate operations, and this change does not provide distributed atomicity. Pool limits remain unchanged.

This change is independent of the audit exporter and driver fix in #7302 and the rollback error fix in #7303.

## Testing:

- Targeted Rask checks for apps.updateApp and customdomain: 86 tests passed.
- Four focused dashboard Vitest files: 14 tests passed.
- Dashboard typecheck: passed.
- mise run build: passed, zero lint issues.
- Scoped Biome checks: passed.
- Regression checks cover stalled ingress rollback, external call ordering, concurrent secret consumption, expiry and replacement during decryption, audit failure, and shared root-key permission transactions. Dashboard checks use mocked dependencies; Go checks use real MySQL.