### PR TITLE
feat(portal): Add usage analytics to the keys page

### DIFF
--- a/web/apps/portal/src/components/analytics/format.ts
+++ b/web/apps/portal/src/components/analytics/format.ts
@@ -1,0 +1,30 @@
+import { HOURLY_MAX_DAYS } from "./schema/analytics.schema";
+
+const countFormat = new Intl.NumberFormat("en-US");
+const hourFormat = new Intl.DateTimeFormat("en-US", {
+  hour: "2-digit",
+  minute: "2-digit",
+  hour12: false,
+});
+const dayFormat = new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric" });
+const dayHourFormat = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+  hour12: false,
+});
+
+export function formatCount(value: number): string {
+  return countFormat.format(value);
+}
+
+export function formatBucketTime(time: number, days: number): string {
+  if (days > HOURLY_MAX_DAYS) {
+    return dayFormat.format(time);
+  }
+  if (days > 1) {
+    return dayHourFormat.format(time);
+  }
+  return hourFormat.format(time);
+}

--- a/web/apps/portal/src/components/analytics/header-stat.tsx
+++ b/web/apps/portal/src/components/analytics/header-stat.tsx
@@ -6,17 +6,19 @@ type Props = {
 
 export function HeaderStat({ label, value, swatch }: Props) {
   return (
-    <div className="flex flex-col gap-1">
-      <span className="flex items-center gap-1.5 text-gray-11 text-xs">
+    <div className="flex flex-col gap-1.5 px-5 py-4 sm:px-6 sm:py-5">
+      <span className="flex items-center gap-2 text-gray-11 text-sm">
         {swatch && (
           <span className="size-2 rounded-xs" style={{ backgroundColor: swatch }} aria-hidden />
         )}
         {label}
       </span>
       {value === null ? (
-        <div className="h-6 w-20 rounded bg-gray-3 motion-safe:animate-pulse" />
+        <div className="h-8 w-28 rounded bg-gray-3 motion-safe:animate-pulse sm:h-9" />
       ) : (
-        <span className="font-semibold text-base text-gray-12 tabular-nums">{value}</span>
+        <span className="font-semibold text-2xl text-gray-12 tabular-nums tracking-tight sm:text-3xl">
+          {value}
+        </span>
       )}
     </div>
   );

--- a/web/apps/portal/src/components/analytics/header-stat.tsx
+++ b/web/apps/portal/src/components/analytics/header-stat.tsx
@@ -1,0 +1,23 @@
+type Props = {
+  label: string;
+  value: string | null;
+  swatch?: string;
+};
+
+export function HeaderStat({ label, value, swatch }: Props) {
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="flex items-center gap-1.5 text-gray-11 text-xs">
+        {swatch && (
+          <span className="size-2 rounded-xs" style={{ backgroundColor: swatch }} aria-hidden />
+        )}
+        {label}
+      </span>
+      {value === null ? (
+        <div className="h-6 w-20 rounded bg-gray-3 motion-safe:animate-pulse" />
+      ) : (
+        <span className="font-semibold text-base text-gray-12 tabular-nums">{value}</span>
+      )}
+    </div>
+  );
+}

--- a/web/apps/portal/src/components/analytics/hooks/queries/use-verifications-query.ts
+++ b/web/apps/portal/src/components/analytics/hooks/queries/use-verifications-query.ts
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { getVerifications } from "~/lib/portal-api";
 import type { VerificationBucket } from "../../schema/analytics.schema";
 
@@ -21,6 +21,7 @@ export function useVerificationsQuery(days: number) {
     queryFn: () => getVerifications({ data: { days } }),
     staleTime: 1000 * 60, // 1 minute
     refetchOnWindowFocus: false,
+    placeholderData: keepPreviousData,
   });
 
   const buckets: VerificationBucket[] = query.data?.buckets ?? [];

--- a/web/apps/portal/src/components/analytics/range-control.tsx
+++ b/web/apps/portal/src/components/analytics/range-control.tsx
@@ -1,0 +1,37 @@
+import type { AnalyticsPeriod } from "./schema/analytics.schema";
+
+type Props = {
+  options: AnalyticsPeriod[];
+  value: number;
+  onChange: (days: number) => void;
+};
+
+function shortLabel(days: number): string {
+  return days === 1 ? "24h" : `${days}d`;
+}
+
+export function RangeControl({ options, value, onChange }: Props) {
+  return (
+    <fieldset
+      className="inline-flex items-center gap-0.5 rounded-md bg-gray-3 p-0.5"
+      aria-label="Time range"
+    >
+      {options.map((option) => {
+        const active = option.days === value;
+        return (
+          <button
+            key={option.days}
+            type="button"
+            aria-pressed={active}
+            onClick={() => onChange(option.days)}
+            className={`min-h-8 rounded-sm px-3 py-1.5 font-medium text-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-12 focus-visible:ring-offset-1 sm:min-h-0 sm:py-1 ${
+              active ? "bg-background text-gray-12 shadow-xs" : "text-gray-11 hover:text-gray-12"
+            }`}
+          >
+            {shortLabel(option.days)}
+          </button>
+        );
+      })}
+    </fieldset>
+  );
+}

--- a/web/apps/portal/src/components/analytics/schema/analytics.schema.ts
+++ b/web/apps/portal/src/components/analytics/schema/analytics.schema.ts
@@ -13,6 +13,9 @@ export type AnalyticsPeriod = { days: number; label: string };
  * 365-day TTL — the widest range for which verification data still exists. */
 export const MAX_PERIOD_DAYS = 365;
 
+/** The API buckets hourly up to this many days and daily beyond. */
+export const HOURLY_MAX_DAYS = 4;
+
 /** Fixed ladder rungs, in ascending days. `1` = 24 hours. */
 const PERIOD_LADDER_DAYS = [1, 7, 30, 90] as const;
 

--- a/web/apps/portal/src/components/analytics/verifications-chart.tsx
+++ b/web/apps/portal/src/components/analytics/verifications-chart.tsx
@@ -9,12 +9,14 @@ import {
 import { formatBucketTime, formatCount } from "./format";
 import type { VerificationBucket } from "./schema/analytics.schema";
 
+// Matches the dashboard's valid bars (`--accent-4`); the portal has no accent scale.
+const VALID_BAR_COLOR = "hsl(240 10% 92%)";
 export const VALID_COLOR = "hsl(var(--gray-8))";
 export const REJECTED_COLOR = "hsl(var(--error-9))";
 const GRID_COLOR = "hsl(var(--gray-6))";
 
 const chartConfig: ChartConfig = {
-  valid: { label: "Valid", color: VALID_COLOR },
+  valid: { label: "Valid", color: VALID_BAR_COLOR },
   rejected: { label: "Invalid", color: REJECTED_COLOR },
 };
 
@@ -50,7 +52,13 @@ export function VerificationsChart({ buckets, days }: Props) {
         margin={{ top: 8, right: 8, bottom: 0, left: 0 }}
         barCategoryGap={2}
       >
-        <CartesianGrid horizontal vertical={false} strokeDasharray="3 3" stroke={GRID_COLOR} />
+        <CartesianGrid
+          horizontal
+          vertical={false}
+          strokeDasharray="3 3"
+          stroke={GRID_COLOR}
+          strokeOpacity={0.5}
+        />
         <XAxis
           dataKey="time"
           tickLine={false}

--- a/web/apps/portal/src/components/analytics/verifications-chart.tsx
+++ b/web/apps/portal/src/components/analytics/verifications-chart.tsx
@@ -9,8 +9,7 @@ import {
 import { formatBucketTime, formatCount } from "./format";
 import type { VerificationBucket } from "./schema/analytics.schema";
 
-// Matches the dashboard's valid bars (`--accent-4`); the portal has no accent scale.
-const VALID_BAR_COLOR = "hsl(240 10% 92%)";
+const VALID_BAR_COLOR = "hsl(var(--accent-4))";
 export const VALID_COLOR = "hsl(var(--gray-8))";
 export const REJECTED_COLOR = "hsl(var(--error-9))";
 const GRID_COLOR = "hsl(var(--gray-6))";

--- a/web/apps/portal/src/components/analytics/verifications-chart.tsx
+++ b/web/apps/portal/src/components/analytics/verifications-chart.tsx
@@ -1,134 +1,95 @@
 import { useMemo } from "react";
-import { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
+import {
+  type ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "~/components/ui/chart";
+import { formatBucketTime, formatCount } from "./format";
 import type { VerificationBucket } from "./schema/analytics.schema";
 
-type ChartRow = VerificationBucket & { label: string };
+export const VALID_COLOR = "hsl(var(--gray-8))";
+export const REJECTED_COLOR = "hsl(var(--error-9))";
+const GRID_COLOR = "hsl(var(--gray-6))";
 
-// The API buckets by hour for windows up to ~4 days and by day beyond, so the
-// axis/tooltip label follows the same threshold.
-const HOURLY_MAX_DAYS = 4;
+const chartConfig: ChartConfig = {
+  valid: { label: "Valid", color: VALID_COLOR },
+  rejected: { label: "Invalid", color: REJECTED_COLOR },
+};
 
-const VALID_COLOR = "hsl(var(--gray-8))";
-const ERROR_COLOR = "hsl(var(--error-9))";
+type Row = {
+  time: number;
+  valid: number;
+  rejected: number;
+  total: number;
+};
 
 type Props = {
   buckets: VerificationBucket[];
-  /** Window length in days; selects hourly vs daily label formatting. */
   days: number;
 };
 
-/**
- * Format a bucket timestamp for the x-axis and tooltip. Short windows use an
- * hourly label; multi-day windows use a date label, matching the bucket
- * granularity the API returns for each range.
- */
-function formatBucketTime(time: number, days: number): string {
-  const date = new Date(time);
-  if (days <= HOURLY_MAX_DAYS) {
-    return date.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" });
-  }
-  return date.toLocaleDateString(undefined, { month: "short", day: "numeric" });
-}
-
-/**
- * Stacked bar chart of verifications over time: valid (gray) stacked with error
- * (red), one bar per API bucket. Self-contained — axes, grid, and a custom
- * tooltip — rather than pulling the dashboard's selection-enabled chart infra,
- * since the portal only needs a read-only view.
- */
 export function VerificationsChart({ buckets, days }: Props) {
-  const data = useMemo(
-    () => buckets.map((b) => ({ ...b, label: formatBucketTime(b.time, days) })),
-    [buckets, days],
+  const rows = useMemo<Row[]>(
+    () =>
+      buckets.map((bucket) => ({
+        time: bucket.time,
+        valid: bucket.valid,
+        rejected: bucket.error,
+        total: bucket.total,
+      })),
+    [buckets],
   );
 
   return (
-    <ResponsiveContainer width="100%" height={280}>
-      <BarChart data={data} margin={{ top: 8, right: 8, bottom: 0, left: 0 }} barCategoryGap={2}>
-        <CartesianGrid
-          horizontal
-          vertical={false}
-          strokeDasharray="3 3"
-          stroke="hsl(var(--gray-6))"
-          strokeOpacity={0.5}
-        />
+    <ChartContainer config={chartConfig} className="aspect-auto h-full w-full">
+      <BarChart
+        accessibilityLayer
+        data={rows}
+        margin={{ top: 8, right: 8, bottom: 0, left: 0 }}
+        barCategoryGap={2}
+      >
+        <CartesianGrid horizontal vertical={false} strokeDasharray="3 3" stroke={GRID_COLOR} />
         <XAxis
-          dataKey="label"
+          dataKey="time"
           tickLine={false}
           axisLine={false}
-          minTickGap={24}
-          tick={{ fill: "hsl(var(--gray-10))", fontSize: 11 }}
+          minTickGap={32}
+          tickFormatter={(time: number) => formatBucketTime(time, days)}
+          tick={{ fontSize: 11 }}
         />
-        <YAxis
-          width={40}
-          tickLine={false}
-          axisLine={false}
-          allowDecimals={false}
-          tick={{ fill: "hsl(var(--gray-10))", fontSize: 11 }}
+        <YAxis hide />
+        <ChartTooltip
+          cursor={{ fill: "hsl(var(--gray-3))" }}
+          content={
+            <ChartTooltipContent
+              labelFormatter={(_, payload) => {
+                const row: Row | undefined = payload[0]?.payload;
+                if (!row) {
+                  return null;
+                }
+                return (
+                  <div className="flex items-center justify-between gap-8 px-4">
+                    <span className="text-gray-12">{formatBucketTime(row.time, days)}</span>
+                    <span className="font-mono text-gray-11 tabular-nums">
+                      {formatCount(row.total)} total
+                    </span>
+                  </div>
+                );
+              }}
+            />
+          }
         />
-        <Tooltip cursor={{ fill: "hsl(var(--gray-3))" }} content={<ChartTooltip />} />
-        <Bar dataKey="valid" stackId="v" fill={VALID_COLOR} radius={[0, 0, 0, 0]} />
-        <Bar dataKey="error" stackId="v" fill={ERROR_COLOR} radius={[2, 2, 0, 0]} />
+        <Bar dataKey="valid" stackId="v" fill="var(--color-valid)" isAnimationActive={false} />
+        <Bar
+          dataKey="rejected"
+          stackId="v"
+          fill="var(--color-rejected)"
+          radius={[2, 2, 0, 0]}
+          isAnimationActive={false}
+        />
       </BarChart>
-    </ResponsiveContainer>
-  );
-}
-
-/**
- * Recharts injects `active` and `payload` into the tooltip content element at
- * runtime; they are typed loosely here (as the dashboard's chart does) and
- * narrowed before use.
- */
-function ChartTooltip({
-  active,
-  payload,
-}: {
-  active?: boolean;
-  payload?: Array<{ payload?: unknown }>;
-}) {
-  if (!active || !payload?.length) {
-    return null;
-  }
-  const bucket = payload[0]?.payload as ChartRow | undefined;
-  if (!bucket) {
-    return null;
-  }
-  return (
-    <div className="rounded-md border border-gray-6 bg-background px-3 py-2 text-xs shadow-md">
-      <div className="mb-1 font-medium text-gray-12">{bucket.label}</div>
-      <div className="flex flex-col gap-1">
-        <TooltipRow label="Total" count={bucket.total} swatch={null} />
-        <TooltipRow label="Valid" count={bucket.valid} swatch={VALID_COLOR} />
-        <TooltipRow label="Errors" count={bucket.error} swatch={ERROR_COLOR} />
-      </div>
-    </div>
-  );
-}
-
-function TooltipRow({
-  label,
-  count,
-  swatch,
-}: {
-  label: string;
-  count: number;
-  swatch: string | null;
-}) {
-  return (
-    <div className="flex items-center justify-between gap-4">
-      <span className="flex items-center gap-2 text-gray-11">
-        {swatch ? (
-          <span
-            className="size-1.5 rounded-[1px]"
-            style={{ backgroundColor: swatch }}
-            aria-hidden
-          />
-        ) : (
-          <span className="size-1.5" aria-hidden />
-        )}
-        {label}
-      </span>
-      <span className="text-gray-12 tabular-nums">{count.toLocaleString()}</span>
-    </div>
+    </ChartContainer>
   );
 }

--- a/web/apps/portal/src/components/keys-table/usage-popover.tsx
+++ b/web/apps/portal/src/components/keys-table/usage-popover.tsx
@@ -24,8 +24,8 @@ export function UsagePopover({ buckets, errors }: Props) {
         <span className="text-gray-11 text-xs">Last 30 days</span>
       </div>
       <div className="flex flex-col gap-1 text-xs">
-        <Row label="Valid" count={validTotal} swatch="bg-gray-7" />
-        {errorTotal > 0 && <Row label="Errors" count={errorTotal} swatch="bg-error-9" />}
+        <Row label="Valid" count={validTotal} swatch="bg-accent-4" />
+        {errorTotal > 0 && <Row label="Errors" count={errorTotal} swatch="bg-orange-9" />}
       </div>
     </div>
   );

--- a/web/apps/portal/src/components/keys-table/usage-sparkline.tsx
+++ b/web/apps/portal/src/components/keys-table/usage-sparkline.tsx
@@ -56,7 +56,7 @@ export function UsageSparkline({ buckets, errors, maxBars = 30, ariaLabel }: Pro
   }, [recent, errors, maxBars]);
 
   const baseClass = cn(
-    "h-[28px] w-[158px] cursor-pointer overflow-hidden rounded-sm bg-gray-2 px-1 py-0",
+    "h-[28px] w-[158px] cursor-pointer overflow-hidden rounded-sm px-1 py-0",
     "transition-colors hover:bg-gray-3",
     "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-12 focus-visible:ring-offset-1",
   );
@@ -86,8 +86,8 @@ export function UsageSparkline({ buckets, errors, maxBars = 30, ariaLabel }: Pro
             ) : (
               bars.map((bar) => (
                 <div key={bar.key} className="flex flex-col">
-                  <div className="w-[3px] bg-error-9" style={{ height: `${bar.top}px` }} />
-                  <div className="w-[3px] bg-gray-7" style={{ height: `${bar.bottom}px` }} />
+                  <div className="w-[3px] bg-orange-9" style={{ height: `${bar.top}px` }} />
+                  <div className="w-[3px] bg-accent-4" style={{ height: `${bar.bottom}px` }} />
                 </div>
               ))
             )}

--- a/web/apps/portal/src/components/not-found.tsx
+++ b/web/apps/portal/src/components/not-found.tsx
@@ -1,0 +1,55 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { PortalFooter } from "~/components/portal-footer";
+import { PortalHeader } from "~/components/portal-header";
+import { Button } from "~/components/ui/button";
+import { deriveVisibleTabs } from "~/lib/scopes";
+import { getSessionWithConfig } from "~/lib/session";
+
+export function NotFound() {
+  const { data, isPending } = useQuery({
+    queryKey: ["portal", "session"],
+    queryFn: () => getSessionWithConfig(),
+    staleTime: 1000 * 60,
+    refetchOnWindowFocus: false,
+  });
+
+  const session = data?.session;
+  const appName = data?.config?.displayName;
+  const home = session ? deriveVisibleTabs(session.scopes)[0] : undefined;
+
+  return (
+    <div className="flex min-h-screen flex-col bg-background">
+      {session && (
+        <PortalHeader
+          scopes={session.scopes}
+          logoUrl={data?.config?.branding?.logoUrl ?? undefined}
+          returnUrl={session.returnUrl ?? undefined}
+          appName={appName}
+        />
+      )}
+      <main className="mx-auto flex w-full max-w-5xl flex-1 flex-col items-center justify-center px-4 py-16 text-center sm:px-8">
+        <p className="font-mono text-gray-9 text-xs tracking-wide" aria-hidden="true">
+          404
+        </p>
+        <h1 className="mt-2 font-semibold text-gray-12 text-xl">Page not found</h1>
+        <p className="mt-1 max-w-sm text-gray-11 text-sm">
+          The page you asked for doesn't exist in this portal. It may have moved, or the link was
+          typed wrong.
+        </p>
+        {!isPending && session && (
+          <div className="mt-6 flex flex-wrap items-center justify-center gap-2">
+            {home && <Button render={<Link to={home.href}>Go to {home.label}</Link>} />}
+            {session.returnUrl && (
+              <Button
+                variant="outline"
+                render={<a href={session.returnUrl}>Return to {appName ?? "application"}</a>}
+              />
+            )}
+          </div>
+        )}
+      </main>
+      {session && <PortalFooter />}
+    </div>
+  );
+}

--- a/web/apps/portal/src/components/not-found.tsx
+++ b/web/apps/portal/src/components/not-found.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
+import { onPrimaryColor } from "@unkey/ui/src/lib/branding";
 import { PortalFooter } from "~/components/portal-footer";
 import { PortalHeader } from "~/components/portal-header";
 import { Button } from "~/components/ui/button";
@@ -17,9 +18,23 @@ export function NotFound() {
   const session = data?.session;
   const appName = data?.config?.displayName;
   const home = session ? deriveVisibleTabs(session.scopes)[0] : undefined;
+  const primaryColor = data?.config?.branding?.primaryColor;
+
+  const brandingStyle: Record<string, string> = {
+    "--portal-primary-foreground": onPrimaryColor(primaryColor),
+  };
+  if (primaryColor) {
+    brandingStyle["--portal-primary"] = primaryColor;
+  }
 
   return (
-    <div className="flex min-h-screen flex-col bg-background">
+    <div style={brandingStyle} className="flex min-h-screen flex-col bg-background">
+      {isPending && (
+        <div
+          className="min-h-14"
+          style={{ backgroundColor: "var(--portal-primary, var(--color-gray-12))" }}
+        />
+      )}
       {session && (
         <PortalHeader
           scopes={session.scopes}
@@ -49,6 +64,7 @@ export function NotFound() {
           </div>
         )}
       </main>
+      {isPending && <div className="min-h-14 bg-gray-3/50" />}
       {session && <PortalFooter />}
     </div>
   );

--- a/web/apps/portal/src/components/portal-footer.tsx
+++ b/web/apps/portal/src/components/portal-footer.tsx
@@ -3,8 +3,8 @@ import { UnkeyLogo } from "~/components/ui/unkey-logo";
 export function PortalFooter() {
   return (
     <footer className="w-full bg-gray-3/50">
-      <div className="flex items-center justify-between px-4 py-5 text-gray-11 text-xs sm:px-8">
-        <span className="inline-flex items-center gap-1.5">
+      <div className="flex flex-col gap-3 px-4 py-5 text-gray-11 text-xs sm:flex-row sm:items-center sm:justify-between sm:px-8">
+        <span className="inline-flex items-center gap-1.5 whitespace-nowrap">
           Powered by
           <a
             href="https://unkey.com"
@@ -13,7 +13,7 @@ export function PortalFooter() {
             <UnkeyLogo className="h-3.5 w-auto" />
           </a>
         </span>
-        <nav className="flex items-center gap-5">
+        <nav className="flex flex-wrap items-center gap-x-5 gap-y-2">
           <a href="https://unkey.com/portal" className="transition-colors hover:text-gray-12">
             Learn about Unkey Portal
           </a>

--- a/web/apps/portal/src/components/portal-header.tsx
+++ b/web/apps/portal/src/components/portal-header.tsx
@@ -1,5 +1,11 @@
 import { Link, useLocation } from "@tanstack/react-router";
-import { deriveVisibleTabs } from "~/lib/scopes";
+import { ChartColumn, KeyRound, type LucideIcon } from "lucide-react";
+import { type PortalTab, deriveVisibleTabs } from "~/lib/scopes";
+
+const TAB_ICONS: Record<PortalTab["id"], LucideIcon> = {
+  keys: KeyRound,
+  analytics: ChartColumn,
+};
 
 type PortalHeaderProps = {
   scopes: ReadonlyArray<string>;
@@ -10,8 +16,8 @@ type PortalHeaderProps = {
 
 /**
  * Branded portal header: a colored bar (customer's primary color, dark
- * fallback) carrying the logo and scope-derived navigation on the left and a
- * return-to-application link on the right.
+ * fallback) with the logo on the left, scope-derived navigation centered and a
+ * return-to-application link on the right. Below `sm` it stacks to two rows.
  */
 export function PortalHeader({ scopes, logoUrl, returnUrl, appName }: PortalHeaderProps) {
   const pathname = useLocation({ select: (location) => location.pathname });
@@ -22,7 +28,7 @@ export function PortalHeader({ scopes, logoUrl, returnUrl, appName }: PortalHead
       className="w-full text-[var(--portal-primary-foreground,#ffffff)]"
       style={{ backgroundColor: "var(--portal-primary, var(--color-gray-12))" }}
     >
-      <div className="flex min-h-14 flex-col gap-2 px-4 py-3 sm:flex-row sm:items-center sm:gap-6 sm:px-8 sm:py-0">
+      <div className="flex min-h-14 flex-col gap-2 px-4 py-3 sm:grid sm:grid-cols-[1fr_auto_1fr] sm:items-center sm:gap-6 sm:px-8 sm:py-0">
         <div className="flex min-w-0 items-center justify-between gap-6 sm:contents">
           {(logoUrl || appName) && (
             <div className="flex min-w-0 items-center gap-2.5 sm:max-w-sm">
@@ -38,7 +44,7 @@ export function PortalHeader({ scopes, logoUrl, returnUrl, appName }: PortalHead
             <a
               href={returnUrl}
               title={`Return to ${appName ?? "application"}`}
-              className="min-w-0 max-w-[50%] truncate rounded-md py-1.5 text-[color-mix(in_srgb,var(--portal-primary-foreground,#ffffff)_85%,transparent)] text-sm transition-colors hover:text-[var(--portal-primary-foreground,#ffffff)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--portal-primary-foreground,#ffffff)] focus-visible:ring-offset-1 focus-visible:ring-offset-[var(--portal-primary,var(--color-gray-12))] sm:order-last sm:max-w-xs"
+              className="min-w-0 max-w-[50%] truncate rounded-md py-1.5 text-[color-mix(in_srgb,var(--portal-primary-foreground,#ffffff)_85%,transparent)] text-sm transition-colors hover:text-[var(--portal-primary-foreground,#ffffff)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--portal-primary-foreground,#ffffff)] focus-visible:ring-offset-1 focus-visible:ring-offset-[var(--portal-primary,var(--color-gray-12))] sm:col-start-3 sm:row-start-1 sm:max-w-xs sm:justify-self-end"
             >
               <span aria-hidden="true">← </span>
               Return to {appName ?? "application"}
@@ -47,22 +53,24 @@ export function PortalHeader({ scopes, logoUrl, returnUrl, appName }: PortalHead
         </div>
         {tabs.length > 1 && (
           <nav
-            className="-mx-3 flex items-center gap-1 sm:mx-0 sm:mr-auto"
+            className="-mx-3 flex items-center gap-1 sm:col-start-2 sm:row-start-1 sm:mx-0 sm:justify-self-center"
             aria-label="Portal navigation"
           >
             {tabs.map((tab) => {
               const isActive = pathname.startsWith(tab.href);
+              const Icon = TAB_ICONS[tab.id];
               return (
                 <Link
                   key={tab.id}
                   to={tab.href}
                   aria-current={isActive ? "page" : undefined}
-                  className={`rounded-md px-3 py-1.5 font-medium text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--portal-primary-foreground,#ffffff)] focus-visible:ring-offset-1 focus-visible:ring-offset-[var(--portal-primary,var(--color-gray-12))] ${
+                  className={`flex items-center gap-2 rounded-md px-3 py-1.5 font-medium text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--portal-primary-foreground,#ffffff)] focus-visible:ring-offset-1 focus-visible:ring-offset-[var(--portal-primary,var(--color-gray-12))] ${
                     isActive
                       ? "bg-[color-mix(in_srgb,var(--portal-primary-foreground,#ffffff)_15%,transparent)]"
                       : "text-[color-mix(in_srgb,var(--portal-primary-foreground,#ffffff)_80%,transparent)] hover:bg-[color-mix(in_srgb,var(--portal-primary-foreground,#ffffff)_10%,transparent)] hover:text-[var(--portal-primary-foreground,#ffffff)]"
                   }`}
                 >
+                  <Icon className="size-4" aria-hidden="true" />
                   {tab.label}
                 </Link>
               );

--- a/web/apps/portal/src/components/portal-header.tsx
+++ b/web/apps/portal/src/components/portal-header.tsx
@@ -17,30 +17,27 @@ export function PortalHeader({ scopes, logoUrl, returnUrl, appName }: PortalHead
   const pathname = useLocation({ select: (location) => location.pathname });
   const tabs = deriveVisibleTabs(scopes);
 
-  const returnLink = (label: string, className: string) =>
-    returnUrl && (
-      <a
-        href={returnUrl}
-        className={`whitespace-nowrap text-[color-mix(in_srgb,var(--portal-primary-foreground,#ffffff)_85%,transparent)] text-sm transition-colors hover:text-[var(--portal-primary-foreground,#ffffff)] ${className}`}
-      >
-        ← {label}
-      </a>
-    );
-
   return (
     <header
       className="w-full text-[var(--portal-primary-foreground,#ffffff)]"
       style={{ backgroundColor: "var(--portal-primary, var(--color-gray-12))" }}
     >
       <div className="flex min-h-14 flex-col gap-2 px-4 py-3 sm:flex-row sm:items-center sm:gap-6 sm:px-8 sm:py-0">
-        <div className="flex items-center justify-between gap-6">
+        <div className="flex min-w-0 items-center justify-between gap-6 sm:contents">
           {(logoUrl || appName) && (
-            <div className="flex items-center gap-2.5">
+            <div className="flex min-w-0 items-center gap-2.5 sm:max-w-sm">
               {logoUrl && <img src={logoUrl} alt="" className="h-6 w-auto" aria-hidden="true" />}
-              {appName && <span className="font-medium text-sm">{appName}</span>}
+              {appName && <span className="truncate font-medium text-sm">{appName}</span>}
             </div>
           )}
-          {returnLink("Go back", "sm:hidden")}
+          {returnUrl && (
+            <a
+              href={returnUrl}
+              className="min-w-0 max-w-[50%] truncate text-[color-mix(in_srgb,var(--portal-primary-foreground,#ffffff)_85%,transparent)] text-sm transition-colors hover:text-[var(--portal-primary-foreground,#ffffff)] sm:order-last sm:max-w-xs"
+            >
+              ← Return to {appName ?? "application"}
+            </a>
+          )}
         </div>
         {tabs.length > 1 && (
           <nav
@@ -66,7 +63,6 @@ export function PortalHeader({ scopes, logoUrl, returnUrl, appName }: PortalHead
             })}
           </nav>
         )}
-        {returnLink(`Return to ${appName ?? "application"}`, "hidden sm:inline")}
       </div>
     </header>
   );

--- a/web/apps/portal/src/components/portal-header.tsx
+++ b/web/apps/portal/src/components/portal-header.tsx
@@ -27,15 +27,21 @@ export function PortalHeader({ scopes, logoUrl, returnUrl, appName }: PortalHead
           {(logoUrl || appName) && (
             <div className="flex min-w-0 items-center gap-2.5 sm:max-w-sm">
               {logoUrl && <img src={logoUrl} alt="" className="h-6 w-auto" aria-hidden="true" />}
-              {appName && <span className="truncate font-medium text-sm">{appName}</span>}
+              {appName && (
+                <span className="truncate font-medium text-sm" title={appName}>
+                  {appName}
+                </span>
+              )}
             </div>
           )}
           {returnUrl && (
             <a
               href={returnUrl}
-              className="min-w-0 max-w-[50%] truncate text-[color-mix(in_srgb,var(--portal-primary-foreground,#ffffff)_85%,transparent)] text-sm transition-colors hover:text-[var(--portal-primary-foreground,#ffffff)] sm:order-last sm:max-w-xs"
+              title={`Return to ${appName ?? "application"}`}
+              className="min-w-0 max-w-[50%] truncate rounded-md py-1.5 text-[color-mix(in_srgb,var(--portal-primary-foreground,#ffffff)_85%,transparent)] text-sm transition-colors hover:text-[var(--portal-primary-foreground,#ffffff)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--portal-primary-foreground,#ffffff)] focus-visible:ring-offset-1 focus-visible:ring-offset-[var(--portal-primary,var(--color-gray-12))] sm:order-last sm:max-w-xs"
             >
-              ← Return to {appName ?? "application"}
+              <span aria-hidden="true">← </span>
+              Return to {appName ?? "application"}
             </a>
           )}
         </div>

--- a/web/apps/portal/src/components/portal-header.tsx
+++ b/web/apps/portal/src/components/portal-header.tsx
@@ -1,4 +1,8 @@
+import { Link, useLocation } from "@tanstack/react-router";
+import { deriveVisibleTabs } from "~/lib/scopes";
+
 type PortalHeaderProps = {
+  scopes: ReadonlyArray<string>;
   logoUrl?: string;
   returnUrl?: string;
   appName?: string;
@@ -6,31 +10,63 @@ type PortalHeaderProps = {
 
 /**
  * Branded portal header: a colored bar (customer's primary color, dark
- * fallback) carrying the logo on the left and a return-to-application link on
- * the right. Tabbed navigation was removed while Analytics and Docs are
- * deferred to v2; the portal currently exposes only the Keys page.
+ * fallback) carrying the logo and scope-derived navigation on the left and a
+ * return-to-application link on the right.
  */
-export function PortalHeader({ logoUrl, returnUrl, appName }: PortalHeaderProps) {
+export function PortalHeader({ scopes, logoUrl, returnUrl, appName }: PortalHeaderProps) {
+  const pathname = useLocation({ select: (location) => location.pathname });
+  const tabs = deriveVisibleTabs(scopes);
+
+  const returnLink = (label: string, className: string) =>
+    returnUrl && (
+      <a
+        href={returnUrl}
+        className={`whitespace-nowrap text-[color-mix(in_srgb,var(--portal-primary-foreground,#ffffff)_85%,transparent)] text-sm transition-colors hover:text-[var(--portal-primary-foreground,#ffffff)] ${className}`}
+      >
+        ← {label}
+      </a>
+    );
+
   return (
     <header
       className="w-full text-[var(--portal-primary-foreground,#ffffff)]"
       style={{ backgroundColor: "var(--portal-primary, var(--color-gray-12))" }}
     >
-      <div className="flex h-14 items-center justify-between gap-6 px-4 sm:px-8">
-        {(logoUrl || appName) && (
-          <div className="flex items-center gap-2.5">
-            {logoUrl && <img src={logoUrl} alt="" className="h-6 w-auto" aria-hidden="true" />}
-            {appName && <span className="font-medium text-sm">{appName}</span>}
-          </div>
-        )}
-        {returnUrl && (
-          <a
-            href={returnUrl}
-            className="whitespace-nowrap text-[color-mix(in_srgb,var(--portal-primary-foreground,#ffffff)_85%,transparent)] text-sm transition-colors hover:text-[var(--portal-primary-foreground,#ffffff)]"
+      <div className="flex min-h-14 flex-col gap-2 px-4 py-3 sm:flex-row sm:items-center sm:gap-6 sm:px-8 sm:py-0">
+        <div className="flex items-center justify-between gap-6">
+          {(logoUrl || appName) && (
+            <div className="flex items-center gap-2.5">
+              {logoUrl && <img src={logoUrl} alt="" className="h-6 w-auto" aria-hidden="true" />}
+              {appName && <span className="font-medium text-sm">{appName}</span>}
+            </div>
+          )}
+          {returnLink("Go back", "sm:hidden")}
+        </div>
+        {tabs.length > 1 && (
+          <nav
+            className="-mx-3 flex items-center gap-1 sm:mx-0 sm:mr-auto"
+            aria-label="Portal navigation"
           >
-            ← Return to {appName ?? "application"}
-          </a>
+            {tabs.map((tab) => {
+              const isActive = pathname.startsWith(tab.href);
+              return (
+                <Link
+                  key={tab.id}
+                  to={tab.href}
+                  aria-current={isActive ? "page" : undefined}
+                  className={`rounded-md px-3 py-1.5 font-medium text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--portal-primary-foreground,#ffffff)] focus-visible:ring-offset-1 focus-visible:ring-offset-[var(--portal-primary,var(--color-gray-12))] ${
+                    isActive
+                      ? "bg-[color-mix(in_srgb,var(--portal-primary-foreground,#ffffff)_15%,transparent)]"
+                      : "text-[color-mix(in_srgb,var(--portal-primary-foreground,#ffffff)_80%,transparent)] hover:bg-[color-mix(in_srgb,var(--portal-primary-foreground,#ffffff)_10%,transparent)] hover:text-[var(--portal-primary-foreground,#ffffff)]"
+                  }`}
+                >
+                  {tab.label}
+                </Link>
+              );
+            })}
+          </nav>
         )}
+        {returnLink(`Return to ${appName ?? "application"}`, "hidden sm:inline")}
       </div>
     </header>
   );

--- a/web/apps/portal/src/components/ui/chart.tsx
+++ b/web/apps/portal/src/components/ui/chart.tsx
@@ -168,12 +168,12 @@ function ChartTooltipContent({
       ref={ref}
       role="tooltip"
       className={cn(
-        "grid select-none items-start gap-2 rounded-lg border border-gray-6 bg-background pt-4 pb-2 text-xs shadow-md sm:w-fit md:w-fit md:max-w-[360px]",
+        "grid select-none items-start gap-1.5 rounded-lg border border-gray-6 bg-background pt-3 pb-2 text-xs shadow-md sm:w-fit md:w-fit md:max-w-[360px]",
         className,
       )}
     >
       {nestLabel ? null : tooltipLabel}
-      <div className="grid gap-1.5">
+      <div className="grid gap-0.5">
         {payload.map((item: Record<string, unknown>, index: number) => {
           const key = `${nameKey || item?.name || item?.dataKey || "value"}`;
           const itemConfig = getPayloadConfigFromPayload(config, item, key);
@@ -218,7 +218,7 @@ function ChartTooltipContent({
                 )}
                 <div
                   className={cn(
-                    "flex w-full justify-between gap-4 py-2 leading-none",
+                    "flex w-full justify-between gap-4 py-1 leading-none",
                     nestLabel ? "items-end" : "items-center",
                   )}
                 >

--- a/web/apps/portal/src/components/ui/chart.tsx
+++ b/web/apps/portal/src/components/ui/chart.tsx
@@ -1,0 +1,283 @@
+import * as React from "react";
+import * as RechartsPrimitive from "recharts";
+
+import { cn } from "~/lib/utils";
+
+const numberFormat = new Intl.NumberFormat("en-US");
+
+function formatNumber(value: number): string {
+  return numberFormat.format(value);
+}
+
+const THEMES = { light: "", dark: ".dark" } as const;
+
+export type ChartConfig = {
+  [k in string]: {
+    label?: React.ReactNode;
+    subLabel?: React.ReactNode;
+    icon?: React.ComponentType;
+  } & (
+    | { color?: string; theme?: never }
+    | { color?: never; theme: Record<keyof typeof THEMES, string> }
+  );
+};
+
+type ChartContextProps = {
+  config: ChartConfig;
+};
+
+const ChartContext = React.createContext<ChartContextProps | null>(null);
+
+function useChart() {
+  const context = React.useContext(ChartContext);
+
+  if (!context) {
+    throw new Error("useChart must be used within a <ChartContainer />");
+  }
+
+  return context;
+}
+
+function ChartContainer({
+  id,
+  className,
+  children,
+  config,
+  ...props
+}: React.ComponentProps<"div"> & {
+  config: ChartConfig;
+  children: React.ComponentProps<typeof RechartsPrimitive.ResponsiveContainer>["children"];
+}) {
+  const uniqueId = React.useId();
+  const chartId = `chart-${id || uniqueId.replace(/:/g, "")}`;
+
+  return (
+    <ChartContext.Provider value={{ config }}>
+      <div
+        data-chart={chartId}
+        className={cn(
+          "flex aspect-video justify-center text-xs [&_*:focus]:outline-none [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-hidden [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-sector]:outline-hidden [&_.recharts-surface]:outline-hidden [&_.recharts-wrapper:focus-visible]:rounded-md [&_.recharts-wrapper:focus-visible]:ring-2 [&_.recharts-wrapper:focus-visible]:ring-gray-12",
+          className,
+        )}
+        {...props}
+      >
+        <ChartStyle id={chartId} config={config} />
+        <RechartsPrimitive.ResponsiveContainer initialDimension={{ width: 1, height: 1 }}>
+          {children}
+        </RechartsPrimitive.ResponsiveContainer>
+      </div>
+    </ChartContext.Provider>
+  );
+}
+
+function ChartStyle({ id, config }: { id: string; config: ChartConfig }) {
+  const colorConfig = Object.entries(config).filter(([_, config]) => config.theme || config.color);
+
+  if (!colorConfig.length) {
+    return null;
+  }
+
+  return (
+    <style
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: Dynamic CSS generation for chart theming
+      dangerouslySetInnerHTML={{
+        __html: Object.entries(THEMES)
+          .map(
+            ([theme, prefix]) => `
+${prefix} [data-chart=${id}] {
+${colorConfig
+  .map(([key, itemConfig]) => {
+    const color = itemConfig.theme?.[theme as keyof typeof itemConfig.theme] || itemConfig.color;
+    return color ? `  --color-${key}: ${color};` : null;
+  })
+  .join("\n")}
+}
+`,
+          )
+          .join("\n"),
+      }}
+    />
+  );
+}
+
+const ChartTooltip = RechartsPrimitive.Tooltip;
+
+function ChartTooltipContent({
+  active,
+  payload: rawPayload,
+  className,
+  indicator = "dot",
+  hideLabel = false,
+  hideIndicator = false,
+  label,
+  labelFormatter,
+  labelClassName,
+  color,
+  nameKey,
+  labelKey,
+  bottomExplainer,
+  ref,
+}: React.ComponentProps<typeof RechartsPrimitive.Tooltip> &
+  React.ComponentProps<"div"> & {
+    hideLabel?: boolean;
+    hideIndicator?: boolean;
+    indicator?: "line" | "dot" | "dashed";
+    nameKey?: string;
+    labelKey?: string;
+    bottomExplainer?: React.ReactNode;
+    payload?: unknown;
+    label?: unknown;
+  }) {
+  const { config } = useChart();
+
+  // Type guard for payload
+  const payload = Array.isArray(rawPayload) ? rawPayload : [];
+
+  const tooltipLabel = React.useMemo(() => {
+    if (hideLabel || !payload.length) {
+      return null;
+    }
+
+    const [item] = payload;
+    const key = `${labelKey || item?.dataKey || item?.name || "value"}`;
+    const itemConfig = getPayloadConfigFromPayload(config, item, key);
+    const value =
+      !labelKey && typeof label === "string" ? config[label]?.label || label : itemConfig?.label;
+
+    if (labelFormatter) {
+      return (
+        <div className={cn("font-medium", labelClassName)}>{labelFormatter(value, payload)}</div>
+      );
+    }
+
+    if (!value) {
+      return null;
+    }
+
+    return <div className={cn("font-medium", labelClassName)}>{value}</div>;
+  }, [label, labelFormatter, payload, hideLabel, labelClassName, config, labelKey]);
+
+  if (!active || !payload.length) {
+    return null;
+  }
+
+  const nestLabel = payload.length === 1 && indicator !== "dot";
+
+  return (
+    <div
+      ref={ref}
+      role="tooltip"
+      className={cn(
+        "grid select-none items-start gap-2 rounded-lg border border-gray-6 bg-background pt-4 pb-2 text-xs shadow-md sm:w-fit md:w-fit md:max-w-[360px]",
+        className,
+      )}
+    >
+      {nestLabel ? null : tooltipLabel}
+      <div className="grid gap-1.5">
+        {payload.map((item: Record<string, unknown>, index: number) => {
+          const key = `${nameKey || item?.name || item?.dataKey || "value"}`;
+          const itemConfig = getPayloadConfigFromPayload(config, item, key);
+          const itemPayload = item?.payload as Record<string, unknown> | undefined;
+          const indicatorColor = color || itemPayload?.fill || item?.color;
+          const dataKey =
+            typeof item?.dataKey === "string" || typeof item?.dataKey === "number"
+              ? item.dataKey
+              : index;
+          const itemName = typeof item?.name === "string" ? item.name : "";
+          const itemValue =
+            typeof item?.value === "number" || typeof item?.value === "string" ? item.value : null;
+
+          return (
+            <div
+              key={dataKey}
+              className={cn(
+                "flex w-full gap-4 px-4 [&>svg]:h-2.5 [&>svg]:w-2.5 [&>svg]:text-muted-foreground",
+                indicator === "dot" && "items-center",
+              )}
+            >
+              <>
+                {itemConfig?.icon ? (
+                  <itemConfig.icon />
+                ) : (
+                  !hideIndicator && (
+                    <div
+                      className={cn("shrink-0 rounded-xs border-border bg-(--color-bg)", {
+                        "size-2": indicator === "dot",
+                        "w-1": indicator === "line",
+                        "w-0 border-[1.5px] border-dashed bg-transparent": indicator === "dashed",
+                        "my-0.5": nestLabel && indicator === "dashed",
+                      })}
+                      style={
+                        {
+                          "--color-bg": indicatorColor,
+                          "--color-border": indicatorColor,
+                        } as React.CSSProperties
+                      }
+                    />
+                  )
+                )}
+                <div
+                  className={cn(
+                    "flex w-full justify-between gap-4 py-2 leading-none",
+                    nestLabel ? "items-end" : "items-center",
+                  )}
+                >
+                  <div className="flex items-center gap-4">
+                    {nestLabel ? tooltipLabel : null}
+                    {itemConfig?.subLabel && (
+                      <span className="text-gray-11 text-xs capitalize">
+                        {itemConfig?.subLabel}
+                      </span>
+                    )}
+
+                    <span className="text-gray-12 text-xs capitalize">
+                      {itemConfig?.label || itemName}
+                    </span>
+                  </div>
+                  <div className="ml-auto">
+                    {itemValue !== null && (
+                      <span className="font-mono text-gray-12 tabular-nums">
+                        {formatNumber(
+                          typeof itemValue === "number" ? itemValue : Number(itemValue),
+                        )}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              </>
+            </div>
+          );
+        })}
+      </div>
+      {bottomExplainer}
+    </div>
+  );
+}
+
+// Helper to extract item config from a payload.
+function getPayloadConfigFromPayload(config: ChartConfig, payload: unknown, key: string) {
+  if (typeof payload !== "object" || payload === null) {
+    return undefined;
+  }
+
+  const payloadPayload =
+    "payload" in payload && typeof payload.payload === "object" && payload.payload !== null
+      ? payload.payload
+      : undefined;
+
+  let configLabelKey: string = key;
+
+  if (key in payload && typeof payload[key as keyof typeof payload] === "string") {
+    configLabelKey = payload[key as keyof typeof payload] as string;
+  } else if (
+    payloadPayload &&
+    key in payloadPayload &&
+    typeof payloadPayload[key as keyof typeof payloadPayload] === "string"
+  ) {
+    configLabelKey = payloadPayload[key as keyof typeof payloadPayload] as string;
+  }
+
+  return configLabelKey in config ? config[configLabelKey] : config[key as keyof typeof config];
+}
+
+export { ChartContainer, ChartTooltip, ChartTooltipContent };

--- a/web/apps/portal/src/lib/fake-data.test.ts
+++ b/web/apps/portal/src/lib/fake-data.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "vitest";
+import { fakeKeyUsage, fakeVerifications } from "./fake-data";
+
+describe("fakeVerifications", () => {
+  test("matches the API's inclusive bucket count", () => {
+    expect(fakeVerifications(1, "populated")).toHaveLength(25);
+    expect(fakeVerifications(7, "populated")).toHaveLength(8);
+    expect(fakeVerifications(30, "empty")).toHaveLength(31);
+  });
+
+  test("valid and error sum to total", () => {
+    for (const bucket of fakeVerifications(7, "populated")) {
+      expect(bucket.valid + bucket.error).toBe(bucket.total);
+      expect(bucket.error).toBeLessThanOrEqual(bucket.total);
+    }
+  });
+
+  test("is deterministic", () => {
+    expect(fakeVerifications(7, "populated")).toEqual(fakeVerifications(7, "populated"));
+  });
+});
+
+describe("fakeKeyUsage", () => {
+  test("returns 30 daily buckets with errors bounded by usage", () => {
+    const { usage, errors } = fakeKeyUsage("key_abc", "populated");
+    expect(usage).toHaveLength(30);
+    expect(errors).toHaveLength(30);
+    errors.forEach((err, i) => expect(err).toBeLessThanOrEqual(usage[i]));
+  });
+
+  test("differs per key and is stable per key", () => {
+    expect(fakeKeyUsage("key_a", "populated")).toEqual(fakeKeyUsage("key_a", "populated"));
+    expect(fakeKeyUsage("key_a", "populated").usage).not.toEqual(
+      fakeKeyUsage("key_b", "populated").usage,
+    );
+  });
+});

--- a/web/apps/portal/src/lib/fake-data.ts
+++ b/web/apps/portal/src/lib/fake-data.ts
@@ -1,0 +1,115 @@
+/**
+ * This is a stand in for `portal.getVerifications`, so the analytics UI can
+ * be reviewed without me wiring up the backend.
+ *
+ * THIS FILE IS TEMPORARY - DELETE IT WHEN YOURE DONE. `FAKE_ANALYTICS` switches both the analytics chart and the keys
+ * table sparklines to generated data. This must not ship on: before merging,
+ * set it to `null` (or delete this file and the two branches in
+ * `portal-api.ts`) and wire the real timeseries.
+ */
+
+import {
+  HOURLY_MAX_DAYS,
+  type VerificationBucket,
+} from "~/components/analytics/schema/analytics.schema";
+
+export type FakeDataVariant = "populated" | "empty";
+
+export const FAKE_ANALYTICS: FakeDataVariant | null = "populated";
+
+const HOUR_MS = 3_600_000;
+const DAY_MS = 86_400_000;
+const KEY_USAGE_DAYS = 30;
+const SEED = 1_337_042;
+
+const HOUR_WEIGHTS = [
+  0.28, 0.21, 0.16, 0.14, 0.15, 0.22, 0.38, 0.6, 0.85, 1.0, 1.06, 1.02, 0.9, 0.99, 1.09, 1.07, 0.96,
+  0.81, 0.67, 0.59, 0.52, 0.46, 0.4, 0.33,
+];
+const DAY_WEIGHTS = [0.41, 1.0, 1.07, 1.05, 1.02, 0.94, 0.48];
+
+function mulberry32(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4_294_967_296;
+  };
+}
+
+function hashString(value: string): number {
+  let hash = 2_166_136_261;
+  for (let i = 0; i < value.length; i++) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 16_777_619);
+  }
+  return hash >>> 0;
+}
+
+// The API fills from the bucket containing `start` through the bucket
+// containing `end` inclusive, so a 24h window has 25 hourly buckets.
+function bucketStarts(days: number): number[] {
+  const hourly = days <= HOURLY_MAX_DAYS;
+  const step = hourly ? HOUR_MS : DAY_MS;
+  const count = (hourly ? 24 * days : days) + 1;
+  const end = Math.floor(Date.now() / step) * step;
+  const starts: number[] = [];
+  for (let i = count - 1; i >= 0; i--) {
+    starts.push(end - i * step);
+  }
+  return starts;
+}
+
+export function fakeVerifications(days: number, variant: FakeDataVariant): VerificationBucket[] {
+  const starts = bucketStarts(days);
+  if (variant === "empty") {
+    return starts.map((time) => ({ time, total: 0, valid: 0, error: 0 }));
+  }
+
+  const random = mulberry32(SEED + days);
+  const hourly = days <= HOURLY_MAX_DAYS;
+  const base = hourly ? 1_450 : 27_500;
+
+  return starts.map((time) => {
+    const date = new Date(time);
+    const rhythm = hourly ? HOUR_WEIGHTS[date.getHours()] : DAY_WEIGHTS[date.getDay()];
+    const jitter = 0.82 + random() * 0.36;
+    const spike = random() > 0.94 ? 1.6 + random() * 0.9 : 1;
+    const total = Math.round(base * rhythm * jitter * spike);
+    const burst = random() > 0.91 ? 2.8 + random() * 1.7 : 1;
+    const rejected = Math.min(Math.round(total * 0.07 * (0.6 + random() * 0.8) * burst), total);
+    return { time, total, valid: total - rejected, error: rejected };
+  });
+}
+
+export function fakeKeyUsage(
+  keyId: string,
+  variant: FakeDataVariant,
+): { usage: number[]; errors: number[] } {
+  if (variant === "empty") {
+    return {
+      usage: new Array(KEY_USAGE_DAYS).fill(0),
+      errors: new Array(KEY_USAGE_DAYS).fill(0),
+    };
+  }
+
+  const hash = hashString(keyId);
+  const random = mulberry32(SEED + hash);
+  const perDay = 40 + (hash % 25_000);
+  const errorRate = 0.02 + (hash % 11) / 100;
+  const now = Math.floor(Date.now() / DAY_MS) * DAY_MS;
+
+  const usage: number[] = [];
+  const errors: number[] = [];
+  for (let i = KEY_USAGE_DAYS - 1; i >= 0; i--) {
+    const day = new Date(now - i * DAY_MS).getDay();
+    const jitter = 0.7 + random() * 0.6;
+    const spike = random() > 0.93 ? 2.1 + random() : 1;
+    const total = Math.round(perDay * DAY_WEIGHTS[day] * jitter * spike);
+    usage.push(total);
+    errors.push(Math.min(Math.round(total * errorRate * (0.4 + random() * 1.6)), total));
+  }
+  return { usage, errors };
+}

--- a/web/apps/portal/src/lib/portal-api.ts
+++ b/web/apps/portal/src/lib/portal-api.ts
@@ -13,6 +13,7 @@ import {
   rerollKeyRequestSchema,
 } from "~/components/keys-table/schema/keys.schema";
 import { env } from "./env";
+import { FAKE_ANALYTICS, fakeKeyUsage, fakeVerifications } from "./fake-data";
 import { SESSION_COOKIE_NAME } from "./session";
 
 /**
@@ -171,7 +172,7 @@ export const listKeys = createServerFn({ method: "GET" })
             createdAt: k.createdAt,
             expires: k.expires ?? null,
             enabled: k.enabled,
-            usage: [],
+            ...(FAKE_ANALYTICS ? fakeKeyUsage(k.keyId, FAKE_ANALYTICS) : { usage: [] }),
           })),
           cursor: pagination.cursor ?? null,
           hasMore: pagination.hasMore,
@@ -193,6 +194,10 @@ export const getVerifications = createServerFn({ method: "GET" })
   .handler(
     ({ data }): Promise<VerificationsTimeseries> =>
       withPortalClient(async (client, token) => {
+        if (FAKE_ANALYTICS) {
+          return { days: data.days, buckets: fakeVerifications(data.days, FAKE_ANALYTICS) };
+        }
+
         const endTime = Date.now();
         const startTime = endTime - data.days * MS_PER_DAY;
         const res = await client.portal.getVerifications(

--- a/web/apps/portal/src/lib/portal.ts
+++ b/web/apps/portal/src/lib/portal.ts
@@ -10,6 +10,7 @@ export type PortalBranding = {
 export type Portal = {
   id: string;
   slug: string;
+  displayName: string;
   enabled: boolean;
   branding: PortalBranding | null;
 };
@@ -29,6 +30,7 @@ export async function loadPortal(portalId: string): Promise<Portal | null> {
     columns: {
       id: true,
       slug: true,
+      displayName: true,
       enabled: true,
       logoUrl: true,
       primaryColor: true,
@@ -44,6 +46,7 @@ export async function loadPortal(portalId: string): Promise<Portal | null> {
   return {
     id: config.id,
     slug: config.slug,
+    displayName: config.displayName,
     enabled: config.enabled,
     branding: hasBranding ? { logoUrl: config.logoUrl, primaryColor: config.primaryColor } : null,
   };

--- a/web/apps/portal/src/lib/scopes.test.ts
+++ b/web/apps/portal/src/lib/scopes.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { canReadKeys, canRerollKeys, getDefaultTabHref } from "./scopes";
+import {
+  canReadAnalytics,
+  canReadKeys,
+  canRerollKeys,
+  deriveVisibleTabs,
+  getDefaultTabHref,
+} from "./scopes";
 
 describe("canReadKeys", () => {
   it("is true when keys:read is present", () => {
@@ -38,18 +44,59 @@ describe("canRerollKeys", () => {
   });
 });
 
+describe("canReadAnalytics", () => {
+  it("is true when analytics:read is present", () => {
+    expect(canReadAnalytics(["keys:read", "analytics:read"])).toBe(true);
+  });
+
+  it("is false for a keys-only session", () => {
+    expect(canReadAnalytics(["keys:read", "keys:reroll"])).toBe(false);
+  });
+
+  it("is false for empty scopes", () => {
+    expect(canReadAnalytics([])).toBe(false);
+  });
+});
+
+describe("deriveVisibleTabs", () => {
+  it("lists both tabs in navigation order", () => {
+    expect(deriveVisibleTabs(["analytics:read", "keys:read"])).toEqual([
+      { id: "keys", label: "API keys", href: "/keys" },
+      { id: "analytics", label: "Analytics", href: "/analytics" },
+    ]);
+  });
+
+  it("omits the analytics tab without analytics:read", () => {
+    expect(deriveVisibleTabs(["keys:read"])).toEqual([
+      { id: "keys", label: "API keys", href: "/keys" },
+    ]);
+  });
+
+  it("omits the keys tab without keys:read", () => {
+    expect(deriveVisibleTabs(["analytics:read"])).toEqual([
+      { id: "analytics", label: "Analytics", href: "/analytics" },
+    ]);
+  });
+
+  it("is empty for empty scopes", () => {
+    expect(deriveVisibleTabs([])).toEqual([]);
+  });
+});
+
 describe("getDefaultTabHref", () => {
   it("lands on the keys page when the session can read keys", () => {
     expect(getDefaultTabHref(["keys:read"])).toBe("/keys");
   });
 
-  it("ignores deferred analytics scope when keys is absent", () => {
-    // Analytics is deferred to v2, so analytics:read no longer grants a landing
-    // destination even though the session carries it.
-    expect(getDefaultTabHref(["analytics:read"])).toBeNull();
+  it("prefers keys over analytics", () => {
+    expect(getDefaultTabHref(["analytics:read", "keys:read"])).toBe("/keys");
   });
 
-  it("is null when the session can't read keys", () => {
+  it("falls back to analytics when keys is absent", () => {
+    expect(getDefaultTabHref(["analytics:read"])).toBe("/analytics");
+  });
+
+  it("is null when the session can reach no page", () => {
     expect(getDefaultTabHref(["keys:reroll"])).toBeNull();
   });
 

--- a/web/apps/portal/src/lib/scopes.ts
+++ b/web/apps/portal/src/lib/scopes.ts
@@ -28,7 +28,7 @@ export function canReadAnalytics(scopes: ReadonlyArray<string>): boolean {
 }
 
 export type PortalTab = {
-  id: string;
+  id: "keys" | "analytics";
   label: string;
   href: string;
 };

--- a/web/apps/portal/src/lib/scopes.ts
+++ b/web/apps/portal/src/lib/scopes.ts
@@ -19,12 +19,41 @@ export function canRerollKeys(scopes: ReadonlyArray<string>): boolean {
 }
 
 /**
- * Landing destination after session exchange.
- *
- * The portal currently exposes only the Keys page; Analytics and Docs are
- * deferred to v2 and blocked at the route layer. Returns null when the session
- * can't read keys so the caller can surface an appropriate state.
+ * Whether a session may read verification analytics. `portal.getVerifications`
+ * authorizes `read_analytics`, so the analytics page and its tab must only
+ * appear for sessions granted `analytics:read`.
+ */
+export function canReadAnalytics(scopes: ReadonlyArray<string>): boolean {
+  return scopes.includes("analytics:read");
+}
+
+export type PortalTab = {
+  id: string;
+  label: string;
+  href: string;
+};
+
+/**
+ * The header tabs a session can reach, in navigation order. Each tab is gated
+ * on the scope its page's API call needs, so navigation never offers a page the
+ * API would refuse to fill.
+ */
+export function deriveVisibleTabs(scopes: ReadonlyArray<string>): PortalTab[] {
+  const tabs: PortalTab[] = [];
+  if (canReadKeys(scopes)) {
+    tabs.push({ id: "keys", label: "API keys", href: "/keys" });
+  }
+  if (canReadAnalytics(scopes)) {
+    tabs.push({ id: "analytics", label: "Analytics", href: "/analytics" });
+  }
+  return tabs;
+}
+
+/**
+ * Landing destination after session exchange: the first tab the session can
+ * reach. Returns null when it can reach none, so the caller can surface an
+ * appropriate state.
  */
 export function getDefaultTabHref(scopes: ReadonlyArray<string>): string | null {
-  return canReadKeys(scopes) ? "/keys" : null;
+  return deriveVisibleTabs(scopes)[0]?.href ?? null;
 }

--- a/web/apps/portal/src/routes/__root.tsx
+++ b/web/apps/portal/src/routes/__root.tsx
@@ -1,6 +1,7 @@
 import { HeadContent, Outlet, Scripts, createRootRoute } from "@tanstack/react-router";
 /// <reference types="vite/client" />
 import type { ReactNode } from "react";
+import { NotFound } from "~/components/not-found";
 import { ReactQueryProvider } from "~/providers/react-query-provider";
 import "~/styles/tailwind.css";
 
@@ -20,6 +21,7 @@ export const Route = createRootRoute({
     ],
   }),
   component: RootComponent,
+  notFoundComponent: NotFound,
 });
 
 function RootComponent() {

--- a/web/apps/portal/src/routes/_portal.tsx
+++ b/web/apps/portal/src/routes/_portal.tsx
@@ -39,6 +39,7 @@ function PortalLayout() {
     <div style={brandingStyle} className="flex min-h-screen flex-col bg-background">
       {session.preview && <PreviewBanner />}
       <PortalHeader
+        scopes={session.scopes}
         logoUrl={portal?.branding?.logoUrl ?? undefined}
         returnUrl={session.returnUrl ?? undefined}
         appName={portal?.displayName ?? undefined}

--- a/web/apps/portal/src/routes/_portal/analytics.tsx
+++ b/web/apps/portal/src/routes/_portal/analytics.tsx
@@ -1,37 +1,34 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
-import { AlertTriangle, BarChart3 } from "lucide-react";
+import { AlertTriangle } from "lucide-react";
 import { useMemo, useState } from "react";
 import { computeMetrics } from "~/components/analytics/analytics-transform";
+import { formatCount } from "~/components/analytics/format";
+import { HeaderStat } from "~/components/analytics/header-stat";
 import { useVerificationsQuery } from "~/components/analytics/hooks/queries/use-verifications-query";
+import { RangeControl } from "~/components/analytics/range-control";
 import {
   availableAnalyticsPeriods,
   defaultAnalyticsPeriodDays,
 } from "~/components/analytics/schema/analytics.schema";
-import { VerificationsChart } from "~/components/analytics/verifications-chart";
+import {
+  REJECTED_COLOR,
+  VALID_COLOR,
+  VerificationsChart,
+} from "~/components/analytics/verifications-chart";
 import { Alert, AlertDescription, AlertTitle } from "~/components/ui/alert";
 import { Button } from "~/components/ui/button";
-import {
-  Empty,
-  EmptyDescription,
-  EmptyHeader,
-  EmptyMedia,
-  EmptyTitle,
-} from "~/components/ui/empty";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "~/components/ui/select";
 import { isRetentionExceededError, isUnauthorizedError } from "~/lib/portal-api";
+import { canReadAnalytics, getDefaultTabHref } from "~/lib/scopes";
+
+const CHART_HEIGHT = 280;
+
+type CardState = "loading" | "error" | "empty" | "populated";
 
 export const Route = createFileRoute("/_portal/analytics")({
-  beforeLoad: () => {
-    // Analytics is deferred to v2. The route is kept for reuse but blocked at
-    // the route layer: it must not render even for a session that carries
-    // analytics:read, and direct navigation is redirected away.
-    throw redirect({ to: "/keys" });
+  beforeLoad: ({ context }) => {
+    if (!canReadAnalytics(context.session.scopes)) {
+      throw redirect({ to: getDefaultTabHref(context.session.scopes) ?? "/" });
+    }
   },
   component: AnalyticsPage,
 });
@@ -39,21 +36,35 @@ export const Route = createFileRoute("/_portal/analytics")({
 function AnalyticsPage() {
   const { session, logsRetentionDays } = Route.useRouteContext();
 
-  // Only offer windows the workspace can actually query; a longer one than its
-  // retention would just error server-side. Retention is fixed for the session,
-  // so compute the options and initial window once.
   const periodOptions = useMemo(
     () => availableAnalyticsPeriods(logsRetentionDays),
     [logsRetentionDays],
   );
   const [days, setDays] = useState<number>(() => defaultAnalyticsPeriodDays(logsRetentionDays));
 
-  const { buckets, isInitialLoading, isError, error, refetch } = useVerificationsQuery(days);
+  const { buckets, isInitialLoading, isFetching, isError, error, refetch } =
+    useVerificationsQuery(days);
   const metrics = useMemo(() => computeMetrics(buckets), [buckets]);
+
+  if (isError && isUnauthorizedError(error)) {
+    return (
+      <main className="mx-auto max-w-5xl px-4 pt-8 pb-12 sm:px-8">
+        <SessionExpired returnUrl={session.returnUrl} />
+      </main>
+    );
+  }
+
+  const state = cardState(isInitialLoading, isError, metrics.totalRequests);
+  const stat = (count: number) => {
+    if (state === "loading") {
+      return null;
+    }
+    return state === "populated" ? formatCount(count) : "--";
+  };
 
   return (
     <main className="mx-auto max-w-5xl px-4 pt-8 pb-12 sm:px-8">
-      <header className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+      <header className="mb-6 flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
         <div className="flex flex-col gap-1">
           <h1 className="font-semibold text-gray-12 text-xl">Analytics</h1>
           <p className="text-gray-11 text-sm">
@@ -61,107 +72,87 @@ function AnalyticsPage() {
           </p>
         </div>
         {periodOptions.length > 1 && (
-          <Select
-            value={String(days)}
-            onValueChange={(value) => setDays(Number(value))}
-            items={periodOptions.map((option) => ({
-              value: String(option.days),
-              label: option.label,
-            }))}
-          >
-            <SelectTrigger className="w-44" aria-label="Time period">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {periodOptions.map((option) => (
-                <SelectItem key={option.days} value={String(option.days)}>
-                  {option.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+          <RangeControl options={periodOptions} value={days} onChange={setDays} />
         )}
       </header>
 
-      {isInitialLoading ? (
-        <AnalyticsLoading />
-      ) : isError && isUnauthorizedError(error) ? (
-        // Expired/invalid session: retrying won't help — send the user back to
-        // the application that launched the portal.
-        <SessionExpired returnUrl={session.returnUrl} />
-      ) : isError && isRetentionExceededError(error) ? (
-        // Window isn't available (e.g. retention lowered mid-session). Options
-        // are gated to what's available, so this is rare; show a neutral,
-        // actionable message rather than the generic error.
-        <AnalyticsError
-          title="Time range unavailable"
-          message="That time range isn't available. Try a shorter range."
-          onRetry={refetch}
-        />
-      ) : isError ? (
-        <AnalyticsError
-          message={error instanceof Error ? error.message : undefined}
-          onRetry={refetch}
-        />
-      ) : metrics.totalRequests === 0 ? (
-        <AnalyticsEmpty />
-      ) : (
-        <div className="flex flex-col gap-6">
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-            <MetricCard label="Total Requests" value={metrics.totalRequests.toLocaleString()} />
-            <MetricCard label="Success Rate" value={formatPercent(metrics.successRate)} />
-            <MetricCard label="Error Rate" value={formatPercent(metrics.errorRate)} />
-          </div>
-          <div className="rounded-lg border border-primary/10 bg-background p-4">
-            <VerificationsChart buckets={buckets} days={days} />
-          </div>
+      <section className="rounded-lg border border-primary/10 bg-background">
+        <div className="flex flex-wrap items-center gap-6 border-gray-6 border-b px-5 py-4 sm:gap-8">
+          <HeaderStat label="Total" value={stat(metrics.totalRequests)} />
+          <HeaderStat label="Valid" value={stat(metrics.validRequests)} swatch={VALID_COLOR} />
+          <HeaderStat label="Invalid" value={stat(metrics.errorRequests)} swatch={REJECTED_COLOR} />
         </div>
-      )}
+
+        <div
+          className={`p-4 transition-opacity ${isFetching && !isInitialLoading ? "opacity-60" : ""}`}
+          style={{ height: CHART_HEIGHT + 32 }}
+        >
+          <ChartSlot
+            state={state}
+            message={
+              isRetentionExceededError(error)
+                ? "That time range isn't available. Try a shorter range."
+                : "Couldn't load your analytics"
+            }
+            onRetry={isRetentionExceededError(error) ? undefined : () => refetch()}
+          >
+            <VerificationsChart buckets={buckets} days={days} />
+          </ChartSlot>
+        </div>
+      </section>
     </main>
   );
 }
 
-/** Render a [0, 1] fraction as a one-decimal percentage. */
-function formatPercent(fraction: number): string {
-  return `${(fraction * 100).toFixed(1)}%`;
+function cardState(loading: boolean, failed: boolean, total: number): CardState {
+  if (loading) {
+    return "loading";
+  }
+  if (failed) {
+    return "error";
+  }
+  return total === 0 ? "empty" : "populated";
 }
 
-function MetricCard({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="rounded-lg border border-primary/10 bg-background p-4">
-      <span className="text-gray-11 text-xs">{label}</span>
-      <div className="mt-1 font-semibold text-2xl text-gray-12 tabular-nums">{value}</div>
-    </div>
-  );
-}
-
-function AnalyticsLoading() {
-  return (
-    <div
-      className="flex min-h-64 items-center justify-center text-gray-11 text-sm"
-      aria-busy="true"
-    >
-      Loading analytics…
-    </div>
-  );
-}
-
-function AnalyticsEmpty() {
-  return (
-    <div className="rounded-lg border border-primary/10 bg-background">
-      <Empty>
-        <EmptyHeader>
-          <EmptyMedia variant="icon">
-            <BarChart3 />
-          </EmptyMedia>
-          <EmptyTitle>No verification data yet</EmptyTitle>
-          <EmptyDescription>
-            Once your keys start being verified, usage metrics and trends will appear here.
-          </EmptyDescription>
-        </EmptyHeader>
-      </Empty>
-    </div>
-  );
+function ChartSlot({
+  state,
+  message,
+  onRetry,
+  children,
+}: {
+  state: CardState;
+  message: string;
+  onRetry?: () => void;
+  children: React.ReactNode;
+}) {
+  switch (state) {
+    case "loading":
+      return (
+        <div
+          className="h-full w-full rounded-md bg-gray-3 motion-safe:animate-pulse"
+          aria-busy="true"
+        />
+      );
+    case "error":
+      return (
+        <div className="flex h-full flex-col items-center justify-center gap-3">
+          <p className="text-gray-12 text-sm">{message}</p>
+          {onRetry && (
+            <Button variant="outline" onClick={onRetry}>
+              Try again
+            </Button>
+          )}
+        </div>
+      );
+    case "empty":
+      return (
+        <div className="flex h-full items-center justify-center text-gray-11 text-sm">
+          No data for this time range
+        </div>
+      );
+    case "populated":
+      return children;
+  }
 }
 
 function SessionExpired({ returnUrl }: { returnUrl: string | null }) {
@@ -175,29 +166,6 @@ function SessionExpired({ returnUrl }: { returnUrl: string | null }) {
       {returnUrl && (
         <Button variant="outline" render={<a href={returnUrl}>Back to application</a>} />
       )}
-    </div>
-  );
-}
-
-function AnalyticsError({
-  title = "Couldn't load your analytics",
-  message,
-  onRetry,
-}: {
-  title?: string;
-  message?: string;
-  onRetry: () => void;
-}) {
-  return (
-    <div className="flex flex-col items-center gap-4">
-      <Alert variant="destructive" className="max-w-md">
-        <AlertTriangle />
-        <AlertTitle>{title}</AlertTitle>
-        <AlertDescription>{message ?? "Something went wrong. Please try again."}</AlertDescription>
-      </Alert>
-      <Button variant="outline" onClick={onRetry}>
-        Try again
-      </Button>
     </div>
   );
 }

--- a/web/apps/portal/src/routes/_portal/analytics.tsx
+++ b/web/apps/portal/src/routes/_portal/analytics.tsx
@@ -77,8 +77,8 @@ function AnalyticsPage() {
       </header>
 
       <section className="rounded-lg border border-primary/10 bg-background">
-        <div className="flex flex-wrap items-center gap-6 border-gray-6 border-b px-5 py-4 sm:gap-8">
-          <HeaderStat label="Total" value={stat(metrics.totalRequests)} />
+        <div className="grid divide-y divide-primary/10 border-primary/10 border-b sm:grid-cols-3 sm:divide-x sm:divide-y-0">
+          <HeaderStat label="Total requests" value={stat(metrics.totalRequests)} />
           <HeaderStat label="Valid" value={stat(metrics.validRequests)} swatch={VALID_COLOR} />
           <HeaderStat label="Invalid" value={stat(metrics.errorRequests)} swatch={REJECTED_COLOR} />
         </div>

--- a/web/apps/portal/src/routes/_portal/keys.tsx
+++ b/web/apps/portal/src/routes/_portal/keys.tsx
@@ -10,14 +10,12 @@ import { Alert, AlertDescription, AlertTitle } from "~/components/ui/alert";
 import { Button } from "~/components/ui/button";
 import { TooltipProvider } from "~/components/ui/tooltip";
 import { isUnauthorizedError } from "~/lib/portal-api";
-import { canReadKeys, canRerollKeys } from "~/lib/scopes";
+import { canReadKeys, canRerollKeys, getDefaultTabHref } from "~/lib/scopes";
 
 export const Route = createFileRoute("/_portal/keys")({
   beforeLoad: ({ context }) => {
-    // The page lists keys via portal.listKeys (authorized with read_key), so it
-    // must only render for sessions that carry that action.
     if (!canReadKeys(context.session.scopes)) {
-      throw redirect({ to: "/" });
+      throw redirect({ to: getDefaultTabHref(context.session.scopes) ?? "/" });
     }
   },
   component: KeysPage,

--- a/web/apps/portal/src/routes/prototypes/-key-breakdown-data.ts
+++ b/web/apps/portal/src/routes/prototypes/-key-breakdown-data.ts
@@ -1,0 +1,106 @@
+import type { VerificationBucket } from "~/components/analytics/schema/analytics.schema";
+import { fakeVerifications } from "~/lib/fake-data";
+
+export type KeyUsage = {
+  id: string;
+  name: string;
+  start: string;
+  enabled: boolean;
+  buckets: VerificationBucket[];
+  total: number;
+  error: number;
+};
+
+const KEYS = [
+  {
+    id: "key_3f9kQmT2",
+    name: "Production",
+    start: "acme_3f9k",
+    enabled: true,
+    share: 0.73,
+    errorBias: 0.8,
+  },
+  {
+    id: "key_8xq2Lp0V",
+    name: "Development",
+    start: "acme_8xq2",
+    enabled: true,
+    share: 0.21,
+    errorBias: 1.6,
+  },
+  {
+    id: "key_v01cZr8N",
+    name: "CI Pipeline",
+    start: "acme_v01c",
+    enabled: true,
+    share: 0.06,
+    errorBias: 1.1,
+  },
+  {
+    id: "key_ld7mWe4H",
+    name: "Legacy",
+    start: "acme_ld7m",
+    enabled: false,
+    share: 0,
+    errorBias: 0,
+  },
+];
+
+function mulberry32(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4_294_967_296;
+  };
+}
+
+// Splits every bucket of the aggregate series across the keys so that the
+// per-key rows always sum back to the chart the end user is looking at.
+export function fakeKeyBreakdown(days: number): { totals: VerificationBucket[]; keys: KeyUsage[] } {
+  const totals = fakeVerifications(days, "populated");
+  const random = mulberry32(9_001 + days);
+  const perKey = KEYS.map(() => [] as VerificationBucket[]);
+
+  for (const bucket of totals) {
+    const weights = KEYS.map((k) => (k.share === 0 ? 0 : k.share * (0.8 + random() * 0.4)));
+    const weightSum = weights.reduce((a, b) => a + b, 0) || 1;
+    const errorWeights = KEYS.map((k, i) => weights[i] * k.errorBias);
+    const errorSum = errorWeights.reduce((a, b) => a + b, 0) || 1;
+
+    const taker = 0;
+    let totalLeft = bucket.total;
+    let errorLeft = bucket.error;
+    const split = KEYS.map((_, i) => {
+      if (i === taker) {
+        return { total: 0, error: 0 };
+      }
+      const total = Math.round((bucket.total * weights[i]) / weightSum);
+      const error = Math.min(Math.round((bucket.error * errorWeights[i]) / errorSum), total);
+      totalLeft -= total;
+      errorLeft -= error;
+      return { total, error };
+    });
+    split[taker] = {
+      total: Math.max(totalLeft, 0),
+      error: Math.max(Math.min(errorLeft, totalLeft), 0),
+    };
+    split.forEach(({ total, error }, i) => {
+      perKey[i].push({ time: bucket.time, total, valid: total - error, error });
+    });
+  }
+
+  const keys = KEYS.map((k, i) => ({
+    id: k.id,
+    name: k.name,
+    start: k.start,
+    enabled: k.enabled,
+    buckets: perKey[i],
+    total: perKey[i].reduce((a, b) => a + b.total, 0),
+    error: perKey[i].reduce((a, b) => a + b.error, 0),
+  })).sort((a, b) => b.total - a.total);
+
+  return { totals, keys };
+}

--- a/web/apps/portal/src/routes/prototypes/-picker.tsx
+++ b/web/apps/portal/src/routes/prototypes/-picker.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+
+const CSS = `
+.proto-picker{position:fixed;left:50%;transform:translateX(-50%);z-index:2147483647;display:flex;align-items:center;gap:2px;padding:4px;border-radius:999px;background:rgba(10,10,10,.82);-webkit-backdrop-filter:blur(12px) saturate(1.4);backdrop-filter:blur(12px) saturate(1.4);box-shadow:0 0 0 1px rgba(255,255,255,.08) inset,0 8px 24px rgba(0,0,0,.24),0 2px 6px rgba(0,0,0,.12);font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;font-size:13px;line-height:1;-webkit-font-smoothing:antialiased;user-select:none;-webkit-user-select:none}
+.proto-picker-highlight{position:absolute;top:4px;left:0;height:28px;border-radius:999px;background:rgba(255,255,255,.12);will-change:transform}
+.proto-picker[data-ready] .proto-picker-highlight{transition:transform 250ms cubic-bezier(.23,1,.32,1),width 250ms cubic-bezier(.23,1,.32,1)}
+@media (prefers-reduced-motion:reduce){.proto-picker[data-ready] .proto-picker-highlight{transition:none}}
+.proto-picker-item{position:relative;display:flex;align-items:center;height:28px;padding:0 12px;border:0;border-radius:999px;background:transparent;color:rgba(255,255,255,.55);font:inherit;cursor:pointer;transition:color 150ms ease-out}
+.proto-picker-item:hover{color:rgba(255,255,255,.85)}
+.proto-picker-item:active{transform:scale(.97)}
+.proto-picker-item:focus-visible{outline:2px solid rgba(255,255,255,.4);outline-offset:2px}
+.proto-picker-item[data-active]{color:#fff}
+.proto-picker-label{color:rgba(255,255,255,.35);font-size:11px;padding:0 6px 0 10px;text-transform:uppercase;letter-spacing:.04em}
+`;
+
+type Props = {
+  label: string;
+  names: string[];
+  index: number;
+  onChange: (index: number) => void;
+  bottom: number;
+  keyboard?: boolean;
+};
+
+export function Picker({ label, names, index, onChange, bottom, keyboard = false }: Props) {
+  const itemRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const [highlight, setHighlight] = useState({ width: 0, x: 0 });
+  const [ready, setReady] = useState(false);
+
+  useLayoutEffect(() => {
+    const el = itemRefs.current[index];
+    if (el) {
+      setHighlight({ width: el.offsetWidth, x: el.offsetLeft });
+    }
+  }, [index]);
+
+  useEffect(() => {
+    const id = requestAnimationFrame(() => requestAnimationFrame(() => setReady(true)));
+    return () => cancelAnimationFrame(id);
+  }, []);
+
+  useEffect(() => {
+    if (!keyboard) {
+      return;
+    }
+    function onKey(e: KeyboardEvent) {
+      const target = e.target as HTMLElement | null;
+      if (
+        target &&
+        (/^(INPUT|TEXTAREA|SELECT)$/.test(target.tagName) || target.isContentEditable)
+      ) {
+        return;
+      }
+      if (e.metaKey || e.ctrlKey || e.altKey) {
+        return;
+      }
+      const num = Number.parseInt(e.key, 10);
+      if (num >= 1 && num <= names.length) {
+        onChange(num - 1);
+      } else if (e.key === "ArrowRight") {
+        onChange((index + 1) % names.length);
+      } else if (e.key === "ArrowLeft") {
+        onChange((index - 1 + names.length) % names.length);
+      }
+    }
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [index, names.length, onChange, keyboard]);
+
+  return (
+    <>
+      <style>{CSS}</style>
+      <nav
+        className="proto-picker"
+        aria-label={`Prototype ${label}`}
+        data-ready={ready ? "" : undefined}
+        style={{ bottom }}
+      >
+        <span className="proto-picker-label">{label}</span>
+        <span
+          className="proto-picker-highlight"
+          aria-hidden="true"
+          style={{ width: highlight.width, transform: `translateX(${highlight.x}px)` }}
+        />
+        {names.map((name, i) => (
+          <button
+            key={name}
+            type="button"
+            ref={(el) => {
+              itemRefs.current[i] = el;
+            }}
+            className="proto-picker-item"
+            data-active={i === index ? "" : undefined}
+            aria-current={i === index ? "true" : undefined}
+            onClick={() => onChange(i)}
+          >
+            {name}
+          </button>
+        ))}
+      </nav>
+    </>
+  );
+}

--- a/web/apps/portal/src/routes/prototypes/key-breakdown.tsx
+++ b/web/apps/portal/src/routes/prototypes/key-breakdown.tsx
@@ -1,0 +1,250 @@
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { useEffect, useMemo, useState } from "react";
+import { z } from "zod";
+import { computeMetrics } from "~/components/analytics/analytics-transform";
+import { formatCount } from "~/components/analytics/format";
+import { HeaderStat } from "~/components/analytics/header-stat";
+import { RangeControl } from "~/components/analytics/range-control";
+import { availableAnalyticsPeriods } from "~/components/analytics/schema/analytics.schema";
+import {
+  REJECTED_COLOR,
+  VALID_COLOR,
+  VerificationsChart,
+} from "~/components/analytics/verifications-chart";
+import { PortalFooter } from "~/components/portal-footer";
+import { PortalHeader } from "~/components/portal-header";
+import { type KeyUsage, fakeKeyBreakdown } from "./-key-breakdown-data";
+import { Picker } from "./-picker";
+
+const LAYOUTS = ["Attached", "Separate", "Side by side"] as const;
+const PERIODS = availableAnalyticsPeriods(30);
+
+const searchSchema = z.object({
+  v: z.number().int().min(1).max(LAYOUTS.length).catch(1),
+  range: z.union([z.literal(1), z.literal(7), z.literal(30)]).catch(7),
+});
+
+export const Route = createFileRoute("/prototypes/key-breakdown")({
+  validateSearch: searchSchema,
+  component: KeyBreakdownPrototype,
+});
+
+function KeyBreakdownPrototype() {
+  const { v, range } = Route.useSearch();
+  const navigate = useNavigate({ from: Route.fullPath });
+  const [chrome, setChrome] = useState(true);
+  const layout = LAYOUTS[v - 1];
+
+  const { totals, keys } = useMemo(() => fakeKeyBreakdown(range), [range]);
+  const metrics = useMemo(() => computeMetrics(totals), [totals]);
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.metaKey && e.key === ".") {
+        e.preventDefault();
+        setChrome((value) => !value);
+      }
+    }
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, []);
+
+  const setRange = (days: number) =>
+    navigate({ search: (prev) => ({ ...prev, range: days as 1 | 7 | 30 }), replace: true });
+  navigate({ search: (prev) => ({ ...prev, key: undefined }), replace: true });
+
+  const stats = (
+    <div className="grid divide-y divide-primary/10 border-primary/10 border-b sm:grid-cols-3 sm:divide-x sm:divide-y-0">
+      <HeaderStat label="Total requests" value={formatCount(metrics.totalRequests)} />
+      <HeaderStat label="Valid" value={formatCount(metrics.validRequests)} swatch={VALID_COLOR} />
+      <HeaderStat
+        label="Invalid"
+        value={formatCount(metrics.errorRequests)}
+        swatch={REJECTED_COLOR}
+      />
+    </div>
+  );
+
+  const chart = (
+    <div className="p-4" style={{ height: 312 }}>
+      <VerificationsChart buckets={totals} days={range} />
+    </div>
+  );
+
+  const grandTotal = totals.reduce((a, b) => a + b.total, 0);
+  const list = <KeyList keys={keys} grandTotal={grandTotal} />;
+
+  return (
+    <div className="flex min-h-screen flex-col bg-background">
+      <PortalHeader
+        scopes={["keys:read", "analytics:read"]}
+        appName="Acme Ltd"
+        returnUrl="#return"
+      />
+      <main
+        className={`mx-auto w-full flex-1 px-4 pt-8 pb-12 sm:px-8 ${layout === "Side by side" ? "max-w-6xl" : "max-w-5xl"}`}
+      >
+        <header className="mb-6 flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+          <div className="flex flex-col gap-1">
+            <h1 className="font-semibold text-gray-12 text-xl">Analytics</h1>
+            <p className="text-gray-11 text-sm">
+              Monitor verification activity and usage trends for your API keys.
+            </p>
+          </div>
+          <RangeControl options={PERIODS} value={range} onChange={setRange} />
+        </header>
+
+        {layout === "Attached" && (
+          <section className="rounded-lg border border-primary/10 bg-background">
+            {stats}
+            {chart}
+            <div className="border-primary/10 border-t">
+              <ListHeading count={keys.length} inset />
+              {list}
+            </div>
+          </section>
+        )}
+
+        {layout === "Separate" && (
+          <div className="flex flex-col gap-6">
+            <section className="rounded-lg border border-primary/10 bg-background">
+              {stats}
+              {chart}
+            </section>
+            <section>
+              <ListHeading count={keys.length} />
+              <div className="rounded-lg border border-primary/10 bg-background">{list}</div>
+            </section>
+          </div>
+        )}
+
+        {layout === "Side by side" && (
+          <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_340px]">
+            <section className="rounded-lg border border-primary/10 bg-background">
+              {stats}
+              {chart}
+            </section>
+            <section className="flex flex-col rounded-lg border border-primary/10 bg-background">
+              <ListHeading count={keys.length} inset compact />
+              <KeyList keys={keys} grandTotal={grandTotal} compact />
+            </section>
+          </div>
+        )}
+      </main>
+      <PortalFooter />
+      {chrome && (
+        <Picker
+          label="layout"
+          names={[...LAYOUTS]}
+          index={v - 1}
+          onChange={(i) => navigate({ search: (prev) => ({ ...prev, v: i + 1 }), replace: true })}
+          bottom={24}
+          keyboard
+        />
+      )}
+    </div>
+  );
+}
+
+function ListHeading({
+  count,
+  inset,
+  compact,
+}: { count: number; inset?: boolean; compact?: boolean }) {
+  return (
+    <div
+      className={`flex items-baseline justify-between ${inset ? "px-5 pt-4 pb-1 sm:px-6" : "mb-3"} ${compact ? "border-primary/10 border-b pb-3" : ""}`}
+    >
+      <h2 className="font-medium text-gray-12 text-sm">By key</h2>
+      <span className="text-gray-10 text-xs">{count} keys</span>
+    </div>
+  );
+}
+
+function KeyList({
+  keys,
+  grandTotal,
+  compact,
+}: {
+  keys: KeyUsage[];
+  grandTotal: number;
+  compact?: boolean;
+}) {
+  return (
+    <ul className="divide-y divide-primary/10">
+      {keys.map((k) => {
+        return (
+          <li key={k.id}>
+            <div
+              className={`grid w-full items-center gap-4 px-5 py-3 text-left sm:px-6 ${
+                compact
+                  ? "grid-cols-[minmax(0,1fr)_auto]"
+                  : "grid-cols-[minmax(0,1.4fr)_minmax(0,1fr)_minmax(0,1.6fr)]"
+              }`}
+            >
+              <div className="min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className="truncate font-medium text-gray-12 text-sm">{k.name}</span>
+                  {!k.enabled && <span className="text-gray-9 text-xs">Disabled</span>}
+                </div>
+                <span className="block truncate font-mono text-gray-10 text-xs">{k.start}••••</span>
+              </div>
+              {!compact && (
+                <div className="flex flex-col">
+                  <span className="font-medium text-gray-12 text-sm tabular-nums">
+                    {formatCount(k.total)}
+                  </span>
+                  <span className="text-gray-10 text-xs tabular-nums">
+                    {grandTotal ? `${((k.total / grandTotal) * 100).toFixed(0)}% · ` : ""}
+                    {formatCount(k.error)} invalid
+                  </span>
+                </div>
+              )}
+              <div className={`flex flex-col items-end gap-1 ${compact ? "" : "sm:items-stretch"}`}>
+                {compact && (
+                  <span className="font-medium text-gray-12 text-sm tabular-nums">
+                    {formatCount(k.total)}
+                  </span>
+                )}
+                <Sparkline buckets={k.buckets} width={compact ? 96 : undefined} />
+              </div>
+            </div>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+function Sparkline({ buckets, width }: { buckets: KeyUsage["buckets"]; width?: number }) {
+  const max = Math.max(...buckets.map((b) => b.total), 1);
+  if (buckets.every((b) => b.total === 0)) {
+    return (
+      <div
+        className="flex h-7 items-center justify-center rounded-sm bg-gray-2 text-[11px] text-gray-10"
+        style={{ width }}
+      >
+        No usage
+      </div>
+    );
+  }
+  return (
+    <div
+      className="flex h-7 items-end gap-px rounded-sm bg-gray-2 px-1"
+      style={{ width }}
+      aria-hidden="true"
+    >
+      {buckets.map((b) => {
+        const h = Math.max(Math.round((b.total / max) * 24), b.total > 0 ? 1 : 0);
+        const e =
+          b.total > 0 ? Math.max(Math.round((b.error / b.total) * h), b.error > 0 ? 1 : 0) : 0;
+        return (
+          <div key={b.time} className="flex min-w-0 flex-1 flex-col justify-end">
+            <div className="w-full bg-error-9" style={{ height: e }} />
+            <div className="w-full bg-gray-7" style={{ height: h - e }} />
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/apps/portal/src/styles/tailwind.css
+++ b/web/apps/portal/src/styles/tailwind.css
@@ -63,6 +63,10 @@
   --color-warningA-3: hsla(var(--warningA-3));
   --color-warningA-11: hsla(var(--warningA-11));
 
+  /* Chart series, mirrored from the dashboard so both products draw usage alike */
+  --color-accent-4: hsl(var(--accent-4));
+  --color-orange-9: hsl(var(--orange-9));
+
   /* Error (Tomato) */
   --color-error-3: hsl(var(--error-3));
   --color-error-9: hsl(var(--error-9));
@@ -135,6 +139,9 @@
     --warning-11: 35, 100%, 34%;
     --warningA-3: 47, 100%, 50%, 0.24;
     --warningA-11: 43, 100%, 30%, 1;
+
+    --accent-4: 240, 10%, 92%;
+    --orange-9: 23, 93%, 53%;
 
     /* Error (Tomato) */
     --error-3: 10, 92%, 95%;


### PR DESCRIPTION
## What does this PR do?

Gives end users usage analytics inside the customer portal, on the keys page they already use. The page gains a filter popover (key, outcome, status, with counts), a time-range picker capped to the workspace's log retention, a Total / Valid / Invalid strip, and an outcome-stacked chart of verifications over the selected range, all above a keys table that now shows each key's valid and invalid counts for that range, sorts on them, pages, and offers key rotation from a row menu. Filters narrow the chart, the strip and the table together and persist in the URL. Sessions without the analytics scope get the same page with the analytics parts hidden.

The separate Analytics tab and route are gone; `/analytics` redirects to `/keys`. The old keys-table components, the fake-data generator and the initial design prototype route are deleted. Charts sit on a shadcn-style `ChartContainer` copied from the dashboard so later portal charts share it.

https://linear.app/unkey/issue/DES-50 · https://linear.app/unkey/issue/ENG-3086

<!-- before-and-after:start -->
| Before (Keys page · desktop) | After (Keys page · desktop) |
|:---:|:---:|
| ![Before](https://github.com/user-attachments/assets/94df1f20-6497-4c2c-a11b-8cf59d482ea2) | ![After](https://github.com/user-attachments/assets/7e8cf112-5305-42ba-9784-1f464c891b93) |

| Before (Keys page · mobile) | After (Keys page · mobile) |
|:---:|:---:|
| ![Before](https://github.com/user-attachments/assets/8cf6cde0-1ef3-402c-8581-71f675a8e906) | ![After](https://github.com/user-attachments/assets/c78e3008-95c6-4dc5-ad32-fa89c101d73a) |

| Before (Filter popover) | After (Filter popover) |
|:---:|:---:|
| ![Before](https://github.com/user-attachments/assets/94df1f20-6497-4c2c-a11b-8cf59d482ea2) | ![After](https://github.com/user-attachments/assets/979a3890-1766-4da2-8d9f-a03ff354cadd) |

| Before (Filter popover · Outcome panel with counts) | After (Filter popover · Outcome panel with counts) |
|:---:|:---:|
| ![Before](https://github.com/user-attachments/assets/94df1f20-6497-4c2c-a11b-8cf59d482ea2) | ![After](https://github.com/user-attachments/assets/36eb45f1-69f6-4522-84c6-c9b762e7e4fb) |

| Before (Filters applied (key + outcomes) narrow chart, strip and table) | After (Filters applied (key + outcomes) narrow chart, strip and table) |
|:---:|:---:|
| ![Before](https://github.com/user-attachments/assets/94df1f20-6497-4c2c-a11b-8cf59d482ea2) | ![After](https://github.com/user-attachments/assets/2404f078-96a4-44cc-9578-12c2b078603e) |

| Before (Time presets (retention-capped)) | After (Time presets (retention-capped)) |
|:---:|:---:|
| ![Before](https://github.com/user-attachments/assets/94df1f20-6497-4c2c-a11b-8cf59d482ea2) | ![After](https://github.com/user-attachments/assets/61c3b140-d459-4f52-a602-5b03d60eaa1e) |

| Before (Empty table · no keys match filters) | After (Empty table · no keys match filters) |
|:---:|:---:|
| ![Before](https://github.com/user-attachments/assets/94df1f20-6497-4c2c-a11b-8cf59d482ea2) | ![After](https://github.com/user-attachments/assets/2ef5b719-e6f6-4f51-92ed-fbb2463d4e28) |

| Before (Empty chart · no data for this time range) | After (Empty chart · no data for this time range) |
|:---:|:---:|
| ![Before](https://github.com/user-attachments/assets/94df1f20-6497-4c2c-a11b-8cf59d482ea2) | ![After](https://github.com/user-attachments/assets/2dec9036-3b1c-4812-9cc3-460d8eedc5cb) |

| Before (Loading skeletons) | After (Loading skeletons) |
|:---:|:---:|
| ![Before](https://github.com/user-attachments/assets/94df1f20-6497-4c2c-a11b-8cf59d482ea2) | ![After](https://github.com/user-attachments/assets/de910bcb-4e31-4789-9da2-0cceed52046f) |

| Before (Error · keys list failed) | After (Error · keys list failed) |
|:---:|:---:|
| ![Before](https://github.com/user-attachments/assets/94df1f20-6497-4c2c-a11b-8cf59d482ea2) | ![After](https://github.com/user-attachments/assets/8f305879-c3b6-4f51-8502-4d90d8385891) |

| Before (Error · analytics failed) | After (Error · analytics failed) |
|:---:|:---:|
| ![Before](https://github.com/user-attachments/assets/94df1f20-6497-4c2c-a11b-8cf59d482ea2) | ![After](https://github.com/user-attachments/assets/604f969e-ff41-413b-83ec-163b83d28fc9) |

| Before (Rotate key from the row menu) | After (Rotate key from the row menu) |
|:---:|:---:|
| ![Before](https://github.com/user-attachments/assets/94df1f20-6497-4c2c-a11b-8cf59d482ea2) | ![After](https://github.com/user-attachments/assets/b78ee05c-3df6-4c53-8cd2-3ae7603b923b) |

| Before (Session without analytics:read) | After (Session without analytics:read) |
|:---:|:---:|
| ![Before](https://github.com/user-attachments/assets/94df1f20-6497-4c2c-a11b-8cf59d482ea2) | ![After](https://github.com/user-attachments/assets/8625f0fe-ca31-421b-9c98-0a61fcc32d9c) |

| Before (Not found page) | After (Not found page) |
|:---:|:---:|
| ![Before](https://github.com/user-attachments/assets/94df1f20-6497-4c2c-a11b-8cf59d482ea2) | ![After](https://github.com/user-attachments/assets/828de879-fff8-47ba-b0a8-07a467fe79d3) |

<!-- before-and-after:end -->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

`mise exec -- pnpm --dir=web/apps/portal test` and `typecheck`.

Manual: mint a session with `keys:read`, `keys:reroll`, `analytics:read` and open the portal. Confirm the strip, chart and Valid/Invalid columns render for the selected range; apply a key, outcome and status filter and confirm the URL, chart, strip and table all narrow together and pills clear them; switch time presets and confirm only presets within retention are offered; open a row's menu and rotate a key. Mint a session with only `keys:read` and confirm the analytics parts are hidden and the table sorts by name. Open `/analytics` and confirm it lands on `/keys`. Resize to a phone width and confirm the header splits to two rows, the popover goes full width and the table hides its Key column.

### Notes for reviewers

- `portal.createSession` does not accept `analytics:read` yet, so in production the analytics parts stay hidden until the scope work in ENG-3086 lands. Everything else on the page is live.
- Per-key usage is one `getVerifications(keyId)` call per key, capped at 50 keys. A grouped endpoint would remove that; `lastUsed` on `listKeys` would let a Last used column return.
- The browser memoises the session lookup so filter clicks do not re-hit the database. It only caches a resolved session and is cleared on exchange, sign-out and any unauthorized response.
- Not tested with more than a page of keys (the local seed has four).

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [x] Ran `pnpm build`
- [x] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary
