### PR TITLE
test: remove rate-limit and repeat flakes

### DIFF
--- a/internal/services/ratelimit/global_integration_test.go
+++ b/internal/services/ratelimit/global_integration_test.go
@@ -811,11 +811,8 @@ func TestGlobal_BelowUtilizationFloorDoesNotPush(t *testing.T) {
 
 	region.runGlobalPushOnce()
 
-	// Never can return with a query still running, racing database cleanup.
-	for deadline := time.Now().Add(2 * time.Second); time.Now().Before(deadline); time.Sleep(100 * time.Millisecond) {
-		require.False(t, env.hasRow(workspaceID, namespace, identifier, "region-a", duration.Milliseconds()),
-			"sub-floor utilization must not write a global-counters row")
-	}
+	require.False(t, env.hasRow(workspaceID, namespace, identifier, "region-a", duration.Milliseconds()),
+		"sub-floor utilization must not write a global-counters row")
 }
 
 // TestGlobal_PushUsesConvergedLocalCount asserts that push eligibility is
@@ -1321,12 +1318,8 @@ func TestGlobal_DoesNotPropagateColdOversizedRequest(t *testing.T) {
 
 	region.runGlobalPushOnce()
 
-	// The cold-window denial increments nothing (deny path doesn't bump
-	// val), so val stays 0 and the utilization filter skips the flush.
-	for deadline := time.Now().Add(2 * time.Second); time.Now().Before(deadline); time.Sleep(100 * time.Millisecond) {
-		require.False(t, env.hasRow(workspaceID, namespace, identifier, "region-a", duration.Milliseconds()),
-			"cold oversized denial must not write a global-counters row")
-	}
+	require.False(t, env.hasRow(workspaceID, namespace, identifier, "region-a", duration.Milliseconds()),
+		"cold oversized denial must not write a global-counters row")
 }
 
 // TestGlobal_EntriesCreatedOnSync asserts that the pull goroutine

--- a/internal/services/ratelimit/global_integration_test.go
+++ b/internal/services/ratelimit/global_integration_test.go
@@ -96,11 +96,11 @@ func TestGlobal_PropagatesCountAcrossRegions(t *testing.T) {
 	regionA := env.newRegionAs(clk, "region-a")
 	regionB := env.newRegionAs(clk, "region-b")
 
+	workspaceID := uid.New(uid.WorkspacePrefix)
 	const (
-		workspaceID = "ws_test"
-		namespace   = "ns"
-		identifier  = "user-shared"
-		limit       = int64(10)
+		namespace  = "ns"
+		identifier = "user-shared"
+		limit      = int64(10)
 	)
 	duration := time.Minute
 	ctx := context.Background()
@@ -680,11 +680,11 @@ func TestGlobal_RealWorldTwoRegionsWithTwoNodesEach(t *testing.T) {
 	regionB1 := env.newRegionWithCounter(clk, "region-b", regionBOrigin)
 	regionB2 := env.newRegionWithCounter(clk, "region-b", regionBOrigin)
 
+	workspaceID := uid.New(uid.WorkspacePrefix)
 	const (
-		workspaceID = "ws_test"
-		namespace   = "ns"
-		identifier  = "user-real-world"
-		limit       = int64(10)
+		namespace  = "ns"
+		identifier = "user-real-world"
+		limit      = int64(10)
 	)
 	duration := time.Minute
 	ctx := context.Background()
@@ -792,11 +792,11 @@ func TestGlobal_BelowUtilizationFloorDoesNotPush(t *testing.T) {
 	clk := clock.NewTestClock()
 	region := env.newRegionAs(clk, "region-a")
 
+	workspaceID := uid.New(uid.WorkspacePrefix)
 	const (
-		workspaceID = "ws_test"
-		namespace   = "ns"
-		identifier  = "user-low-util"
-		limit       = int64(10)
+		namespace  = "ns"
+		identifier = "user-low-util"
+		limit      = int64(10)
 	)
 	duration := time.Minute
 	ctx := context.Background()
@@ -811,13 +811,11 @@ func TestGlobal_BelowUtilizationFloorDoesNotPush(t *testing.T) {
 
 	region.runGlobalPushOnce()
 
-	// The flush filter must have skipped this entry. require.Never polls
-	// to guard against a periodic flush from the background goroutine
-	// firing concurrently.
-	require.Never(t, func() bool {
-		return env.hasRow(workspaceID, namespace, identifier, "region-a", duration.Milliseconds())
-	}, 2*time.Second, 100*time.Millisecond,
-		"sub-floor utilization must not write a global-counters row")
+	// Never can return with a query still running, racing database cleanup.
+	for deadline := time.Now().Add(2 * time.Second); time.Now().Before(deadline); time.Sleep(100 * time.Millisecond) {
+		require.False(t, env.hasRow(workspaceID, namespace, identifier, "region-a", duration.Milliseconds()),
+			"sub-floor utilization must not write a global-counters row")
+	}
 }
 
 // TestGlobal_PushUsesConvergedLocalCount asserts that push eligibility is
@@ -848,11 +846,11 @@ func TestGlobal_PushUsesConvergedLocalCount(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = regionA2.Close() })
 
+	workspaceID := uid.New(uid.WorkspacePrefix)
 	const (
-		workspaceID = "ws_test"
-		namespace   = "ns"
-		identifier  = "user-converged"
-		limit       = int64(10)
+		namespace  = "ns"
+		identifier = "user-converged"
+		limit      = int64(10)
 	)
 	duration := time.Minute
 	ctx := context.Background()
@@ -920,11 +918,11 @@ func TestGlobal_PushIgnoresSpeculativeBatchIncrements(t *testing.T) {
 	clk := clock.NewTestClock()
 	region := env.newRegionAs(clk, "region-a")
 
+	workspaceID := uid.New(uid.WorkspacePrefix)
 	const (
-		workspaceID = "ws_test"
-		namespace   = "ns"
-		identifier  = "user-speculative"
-		limit       = int64(10)
+		namespace  = "ns"
+		identifier = "user-speculative"
+		limit      = int64(10)
 	)
 	duration := time.Minute
 
@@ -972,11 +970,11 @@ func TestGlobal_AtFloorPushes(t *testing.T) {
 	clk := clock.NewTestClock()
 	region := env.newRegionAs(clk, "region-a")
 
+	workspaceID := uid.New(uid.WorkspacePrefix)
 	const (
-		workspaceID = "ws_test"
-		namespace   = "ns"
-		identifier  = "user-at-floor"
-		limit       = int64(10)
+		namespace  = "ns"
+		identifier = "user-at-floor"
+		limit      = int64(10)
 	)
 	duration := time.Minute
 	ctx := context.Background()
@@ -1009,11 +1007,11 @@ func TestGlobal_RemoteEmitForcesLocalSubFloorPush(t *testing.T) {
 	regionA := env.newRegionAs(clk, "region-a")
 	regionB := env.newRegionAs(clk, "region-b")
 
+	workspaceID := uid.New(uid.WorkspacePrefix)
 	const (
-		workspaceID = "ws_test"
-		namespace   = "ns"
-		identifier  = "user-skewed"
-		limit       = int64(10)
+		namespace  = "ns"
+		identifier = "user-skewed"
+		limit      = int64(10)
 	)
 	duration := time.Minute
 	ctx := context.Background()
@@ -1066,11 +1064,11 @@ func TestGlobal_SyncKeepsOwnRegionOutOfGlobalCount(t *testing.T) {
 	clk := clock.NewTestClock()
 	region := env.newRegionAs(clk, "region-a")
 
+	workspaceID := uid.New(uid.WorkspacePrefix)
 	const (
-		workspaceID = "ws_test"
-		namespace   = "ns"
-		identifier  = "user-self-only"
-		limit       = int64(10)
+		namespace  = "ns"
+		identifier = "user-self-only"
+		limit      = int64(10)
 	)
 	duration := time.Minute
 	ctx := context.Background()
@@ -1118,11 +1116,11 @@ func TestGlobal_OwnRegionImportIsRegionalSafetyNet(t *testing.T) {
 	regionA1 := env.newRegionAs(clk, "region-a")
 	regionA2 := env.newRegionAs(clk, "region-a")
 
+	workspaceID := uid.New(uid.WorkspacePrefix)
 	const (
-		workspaceID = "ws_test"
-		namespace   = "ns"
-		identifier  = "user-own-region-import"
-		limit       = int64(10)
+		namespace  = "ns"
+		identifier = "user-own-region-import"
+		limit      = int64(10)
 	)
 	duration := time.Minute
 	ctx := context.Background()
@@ -1185,11 +1183,11 @@ func TestGlobal_SumsAcrossMultipleRegions(t *testing.T) {
 	regionB := env.newRegionAs(clk, "region-b")
 	regionC := env.newRegionAs(clk, "region-c")
 
+	workspaceID := uid.New(uid.WorkspacePrefix)
 	const (
-		workspaceID = "ws_test"
-		namespace   = "ns"
-		identifier  = "user-multi"
-		limit       = int64(20)
+		namespace  = "ns"
+		identifier = "user-multi"
+		limit      = int64(20)
 	)
 	duration := time.Minute
 	ctx := context.Background()
@@ -1252,11 +1250,11 @@ func TestGlobal_ChangeFilterAvoidsRedundantWrites(t *testing.T) {
 	clk := clock.NewTestClock()
 	region := env.newRegionAs(clk, "region-a")
 
+	workspaceID := uid.New(uid.WorkspacePrefix)
 	const (
-		workspaceID = "ws_test"
-		namespace   = "ns"
-		identifier  = "user-quiet"
-		limit       = int64(10)
+		namespace  = "ns"
+		identifier = "user-quiet"
+		limit      = int64(10)
 	)
 	duration := time.Minute
 	ctx := context.Background()
@@ -1305,11 +1303,11 @@ func TestGlobal_DoesNotPropagateColdOversizedRequest(t *testing.T) {
 	clk := clock.NewTestClock()
 	region := env.newRegionAs(clk, "region-a")
 
+	workspaceID := uid.New(uid.WorkspacePrefix)
 	const (
-		workspaceID = "ws_test"
-		namespace   = "ns"
-		identifier  = "user-oversized"
-		limit       = int64(10)
+		namespace  = "ns"
+		identifier = "user-oversized"
+		limit      = int64(10)
 	)
 	duration := time.Minute
 	ctx := context.Background()
@@ -1325,10 +1323,10 @@ func TestGlobal_DoesNotPropagateColdOversizedRequest(t *testing.T) {
 
 	// The cold-window denial increments nothing (deny path doesn't bump
 	// val), so val stays 0 and the utilization filter skips the flush.
-	require.Never(t, func() bool {
-		return env.hasRow(workspaceID, namespace, identifier, "region-a", duration.Milliseconds())
-	}, 2*time.Second, 100*time.Millisecond,
-		"cold oversized denial must not write a global-counters row")
+	for deadline := time.Now().Add(2 * time.Second); time.Now().Before(deadline); time.Sleep(100 * time.Millisecond) {
+		require.False(t, env.hasRow(workspaceID, namespace, identifier, "region-a", duration.Milliseconds()),
+			"cold oversized denial must not write a global-counters row")
+	}
 }
 
 // TestGlobal_EntriesCreatedOnSync asserts that the pull goroutine
@@ -1344,11 +1342,11 @@ func TestGlobal_EntriesCreatedOnSync(t *testing.T) {
 	regionA := env.newRegionAs(clk, "region-a")
 	regionB := env.newRegionAs(clk, "region-b")
 
+	workspaceID := uid.New(uid.WorkspacePrefix)
 	const (
-		workspaceID = "ws_test"
-		namespace   = "ns"
-		identifier  = "user-cold-import"
-		limit       = int64(10)
+		namespace  = "ns"
+		identifier = "user-cold-import"
+		limit      = int64(10)
 	)
 	duration := time.Minute
 	ctx := context.Background()

--- a/internal/services/ratelimit/helpers_test.go
+++ b/internal/services/ratelimit/helpers_test.go
@@ -15,7 +15,7 @@ import (
 	rldb "github.com/unkeyed/unkey/internal/services/ratelimit/db"
 )
 
-// newTestDB returns a [mysql.MySQL] handle for a per-test MySQL container.
+// newTestDB returns a [mysql.MySQL] handle for the worktree's shared MySQL container.
 // Connection is closed on t.Cleanup. Used by unit tests that need to satisfy
 // [Config.DB] but don't exercise cross-region count propagation directly.
 func newTestDB(t testing.TB) DB {
@@ -78,14 +78,8 @@ func (c *failingCounter) Increment(_ context.Context, _ string, _ int64, _ ...ti
 	return 0, c.err
 }
 
-// integrationTestEnv bundles a per-test MySQL container plus both a
-// pkg/mysql database (for handing to [ratelimit.New] under the [DB]
-// interface) and a wrapped ratelimit DB (for direct query assertions).
-// Each test gets independent service instances against the same data
-// plane; that's the multi-region scenario the integration tests assert.
-//
-// Uses a per-test MySQL container so tests that assert on row counts and table
-// contents don't race through shared state.
+// integrationTestEnv connects services and query assertions to the worktree's
+// shared MySQL database. Tests must use unique keys, including across reruns.
 type integrationTestEnv struct {
 	t    *testing.T
 	db   DB

--- a/internal/services/ratelimit/ratelimit_test.go
+++ b/internal/services/ratelimit/ratelimit_test.go
@@ -400,12 +400,10 @@ func TestRatelimit_MidWindowBurstWhenLocalCurIsStale(t *testing.T) {
 		passed, cost, wantMaxPasses)
 }
 
-// TestRatelimit_MultiReplicaMidWindowBurstExceedsLimit keeps the production
-// burst shape that originally exposed stale local replicas. The limiter is
-// still best-effort rather than a Redis reservation on every request, but replay
-// freshness plus aggressive stale reads should bound the overshoot well below
-// the unsynchronized case where every replica independently spends a full local
-// window.
+// TestRatelimit_MultiReplicaMidWindowBurstExceedsLimit bounds overshoot when
+// replay catches up between bursts. Simulated request time does not schedule
+// replay workers: without a replay barrier, every replica may spend its entire
+// local allowance before any increment reaches the shared origin.
 func TestRatelimit_MultiReplicaMidWindowBurstExceedsLimit(t *testing.T) {
 	t.Parallel()
 
@@ -436,6 +434,10 @@ func TestRatelimit_MultiReplicaMidWindowBurstExceedsLimit(t *testing.T) {
 	workspaceID := uid.New(uid.WorkspacePrefix)
 	namespace := uid.New(uid.TestPrefix)
 	identifier := uid.New(uid.TestPrefix)
+	key := counterKey{
+		workspaceID: workspaceID, namespace: namespace, identifier: identifier,
+		durationMs: duration.Milliseconds(), sequence: calculateSequence(windowStart, duration),
+	}
 	// Advance request time through the burst so the test exercises replay-updated
 	// freshness and repeated stale refreshes rather than a Redis reservation model.
 	makeReq := func() RatelimitRequest {
@@ -453,26 +455,38 @@ func TestRatelimit_MultiReplicaMidWindowBurstExceedsLimit(t *testing.T) {
 
 	clk.Tick(30 * time.Second)
 
-	var (
-		passedRequests atomic.Int64
-		wg             sync.WaitGroup
-		start          = make(chan struct{})
-	)
-	for _, svc := range services {
-		wg.Add(1)
-		go func(svc *service) {
-			defer wg.Done()
-			<-start
-			for range burstRequestsPerNode {
-				resp, err := svc.Ratelimit(ctx, makeReq())
-				if err == nil && resp.Success {
-					passedRequests.Add(1)
+	var passedRequests atomic.Int64
+	const requestsPerBatch = 10
+	for range burstRequestsPerNode / requestsPerBatch {
+		var wg sync.WaitGroup
+		start := make(chan struct{})
+		errors := make(chan error, replicas*requestsPerBatch)
+		for _, svc := range services {
+			wg.Add(1)
+			go func(svc *service) {
+				defer wg.Done()
+				<-start
+				for range requestsPerBatch {
+					resp, err := svc.Ratelimit(ctx, makeReq())
+					if err != nil {
+						errors <- err
+					} else if resp.Success {
+						passedRequests.Add(1)
+					}
 				}
-			}
-		}(svc)
+			}(svc)
+		}
+		close(start)
+		wg.Wait()
+		close(errors)
+		for err := range errors {
+			require.NoError(t, err)
+		}
+		require.Eventually(t, func() bool {
+			count, err := origin.Get(ctx, key.redisKey())
+			return err == nil && count == (passedRequests.Load()+replicas)*cost
+		}, time.Second, time.Millisecond, "accepted requests must reach the shared origin before the next batch")
 	}
-	close(start)
-	wg.Wait()
 
 	passedTokens := passedRequests.Load() * cost
 	require.LessOrEqual(t, passedTokens, 3*limit,

--- a/pkg/repeat/every_test.go
+++ b/pkg/repeat/every_test.go
@@ -64,23 +64,23 @@ func TestEvery_BasicFunctionality(t *testing.T) {
 
 	t.Run("stops when stop function is called", func(t *testing.T) {
 		var counter atomic.Int32
-
-		stop := Every(10*time.Millisecond, func() {
+		clk := clock.NewTestClock()
+		stopped := make(chan struct{})
+		stop := EveryClock(stopObservedClock{Clock: clk, stopped: stopped}, 10*time.Millisecond, func() {
 			counter.Add(1)
 		})
+		t.Cleanup(stop)
 
-		// Let it run briefly
-		time.Sleep(25 * time.Millisecond)
 		stop()
+		select {
+		case <-stopped:
+		case <-time.After(time.Second):
+			t.Fatal("ticker did not stop")
+		}
 
-		// Get count after stopping
 		countAfterStop := counter.Load()
-
-		// Wait more time to ensure it really stopped
-		time.Sleep(30 * time.Millisecond)
-		finalCount := counter.Load()
-
-		assert.Equal(t, countAfterStop, finalCount, "function should not be called after stop")
+		clk.Tick(time.Second)
+		require.Equal(t, countAfterStop, counter.Load(), "function should not be called after the ticker stops")
 	})
 }
 
@@ -273,40 +273,41 @@ func TestEvery_EdgeCases(t *testing.T) {
 
 func TestEvery_StopBehavior(t *testing.T) {
 	t.Run("stop is idempotent", func(t *testing.T) {
-		var counter atomic.Int32
-
-		stop := Every(10*time.Millisecond, func() {
-			counter.Add(1)
+		started := make(chan struct{})
+		release := make(chan struct{})
+		finished := make(chan struct{})
+		stopped := make(chan struct{})
+		clk := stopObservedClock{Clock: clock.NewTestClock(), stopped: stopped}
+		stop := EveryClock(clk, time.Hour, func() {
+			close(started)
+			<-release
+		})
+		t.Cleanup(func() {
+			close(release)
+			stop()
+			select {
+			case <-stopped:
+			case <-time.After(time.Second):
+				t.Error("ticker did not stop after releasing the callback")
+			}
 		})
 
-		time.Sleep(25 * time.Millisecond)
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatal("callback did not start")
+		}
+		go func() {
+			stop()
+			stop()
+			close(finished)
+		}()
 
-		// First stop
-		stop()
-		countAfterFirstStop := counter.Load()
-
-		time.Sleep(20 * time.Millisecond)
-
-		// Second stop should be safe
-		stop()
-		countAfterSecondStop := counter.Load()
-
-		assert.Equal(t, countAfterFirstStop, countAfterSecondStop,
-			"second stop call should have no effect")
-	})
-
-	t.Run("stop returns immediately", func(t *testing.T) {
-
-		stop := Every(100*time.Millisecond, func() {
-			time.Sleep(50 * time.Millisecond)
-		})
-
-		start := time.Now()
-		stop()
-		elapsed := time.Since(start)
-
-		assert.Less(t, elapsed, 50*time.Millisecond,
-			"stop should return quickly even if function is running")
+		select {
+		case <-finished:
+		case <-time.After(time.Second):
+			t.Fatal("repeated stop calls must return while the callback is blocked")
+		}
 	})
 }
 
@@ -414,6 +415,25 @@ func TestEvery_Jitter(t *testing.T) {
 		// Should still tick at least the base cadence number of times.
 		assert.GreaterOrEqual(t, counter.Load(), int32(2))
 	})
+}
+
+type stopObservedClock struct {
+	clock.Clock
+	stopped chan struct{}
+}
+
+func (c stopObservedClock) NewTicker(d time.Duration) clock.Ticker {
+	return stopObservedTicker{Ticker: c.Clock.NewTicker(d), stopped: c.stopped}
+}
+
+type stopObservedTicker struct {
+	clock.Ticker
+	stopped chan struct{}
+}
+
+func (t stopObservedTicker) Stop() {
+	t.Ticker.Stop()
+	close(t.stopped)
 }
 
 // Benchmark tests to measure performance impact


### PR DESCRIPTION
## Problem:

we have some faulty tests where we assume for example that simulated time lets async replays finish which well no.
Then we re-use the same workspace id and race a database cleanup.

## Solution:

- Require replay completion between concurrent burst batches. Keep the existing token bound.
- Give global-counter scenarios unique workspace IDs. Assert row absence directly after the synchronous push returns; no polling is needed.
- Check repeated stop calls while a callback is blocked. Wait for ticker shutdown before checking that callbacks have stopped.

## Impact:

Tests only. No production behavior, dependency, or Go version changes. This branch is separate from the Go upgrade stack.

## Testing:

- Follow-up removal of polling: `mise exec -- rask --no-cache ./internal/services/ratelimit` passed all 60 tests. The full suite rerun passed with all 300 suites cached.
- `mise run test --concurrency 2`: 300 suites, 24,328 passed, 0 failed, 7,878 ignored; 2 suites cached. Later targeted runs verified the final test edits.
- Go 1.25.10: 200 burst repetitions passed; 20 more passed with the race detector.
- Both reported MySQL tests passed 100 repetitions each against the reused database.
- Ten uncached Rask runs of both packages passed: 86 tests per run. The final repeat cleanup change also passed a fresh package run.
- Both stop checks passed 1,000 repetitions with the race detector.
- Scoped `golangci-lint`: 0 issues. `git diff --check`: passed.