### PR TITLE
flo/deployment gc recovery

### DIFF
--- a/gen/proto/hydra/v1/deploy.pb.go
+++ b/gen/proto/hydra/v1/deploy.pb.go
@@ -360,6 +360,94 @@ func (x *GarbageCollectDeploymentResponse) GetDeleted() bool {
 	return false
 }
 
+type RestoreDeploymentRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	DeploymentId  string                 `protobuf:"bytes,1,opt,name=deployment_id,json=deploymentId,proto3" json:"deployment_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RestoreDeploymentRequest) Reset() {
+	*x = RestoreDeploymentRequest{}
+	mi := &file_hydra_v1_deploy_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RestoreDeploymentRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RestoreDeploymentRequest) ProtoMessage() {}
+
+func (x *RestoreDeploymentRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_hydra_v1_deploy_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RestoreDeploymentRequest.ProtoReflect.Descriptor instead.
+func (*RestoreDeploymentRequest) Descriptor() ([]byte, []int) {
+	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *RestoreDeploymentRequest) GetDeploymentId() string {
+	if x != nil {
+		return x.DeploymentId
+	}
+	return ""
+}
+
+type RestoreDeploymentResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Restored      bool                   `protobuf:"varint,1,opt,name=restored,proto3" json:"restored,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RestoreDeploymentResponse) Reset() {
+	*x = RestoreDeploymentResponse{}
+	mi := &file_hydra_v1_deploy_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RestoreDeploymentResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RestoreDeploymentResponse) ProtoMessage() {}
+
+func (x *RestoreDeploymentResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_hydra_v1_deploy_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RestoreDeploymentResponse.ProtoReflect.Descriptor instead.
+func (*RestoreDeploymentResponse) Descriptor() ([]byte, []int) {
+	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *RestoreDeploymentResponse) GetRestored() bool {
+	if x != nil {
+		return x.Restored
+	}
+	return false
+}
+
 type NotifyInstancesReadyRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	DeploymentId  string                 `protobuf:"bytes,1,opt,name=deployment_id,json=deploymentId,proto3" json:"deployment_id,omitempty"`
@@ -369,7 +457,7 @@ type NotifyInstancesReadyRequest struct {
 
 func (x *NotifyInstancesReadyRequest) Reset() {
 	*x = NotifyInstancesReadyRequest{}
-	mi := &file_hydra_v1_deploy_proto_msgTypes[6]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -381,7 +469,7 @@ func (x *NotifyInstancesReadyRequest) String() string {
 func (*NotifyInstancesReadyRequest) ProtoMessage() {}
 
 func (x *NotifyInstancesReadyRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_hydra_v1_deploy_proto_msgTypes[6]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -394,7 +482,7 @@ func (x *NotifyInstancesReadyRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NotifyInstancesReadyRequest.ProtoReflect.Descriptor instead.
 func (*NotifyInstancesReadyRequest) Descriptor() ([]byte, []int) {
-	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{6}
+	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *NotifyInstancesReadyRequest) GetDeploymentId() string {
@@ -413,7 +501,7 @@ type NotifyInstancesReadyResponse struct {
 
 func (x *NotifyInstancesReadyResponse) Reset() {
 	*x = NotifyInstancesReadyResponse{}
-	mi := &file_hydra_v1_deploy_proto_msgTypes[7]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -425,7 +513,7 @@ func (x *NotifyInstancesReadyResponse) String() string {
 func (*NotifyInstancesReadyResponse) ProtoMessage() {}
 
 func (x *NotifyInstancesReadyResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_hydra_v1_deploy_proto_msgTypes[7]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -438,7 +526,7 @@ func (x *NotifyInstancesReadyResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NotifyInstancesReadyResponse.ProtoReflect.Descriptor instead.
 func (*NotifyInstancesReadyResponse) Descriptor() ([]byte, []int) {
-	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{7}
+	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *NotifyInstancesReadyResponse) GetResolved() bool {
@@ -459,7 +547,7 @@ type DockerImage struct {
 
 func (x *DockerImage) Reset() {
 	*x = DockerImage{}
-	mi := &file_hydra_v1_deploy_proto_msgTypes[8]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -471,7 +559,7 @@ func (x *DockerImage) String() string {
 func (*DockerImage) ProtoMessage() {}
 
 func (x *DockerImage) ProtoReflect() protoreflect.Message {
-	mi := &file_hydra_v1_deploy_proto_msgTypes[8]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -484,7 +572,7 @@ func (x *DockerImage) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DockerImage.ProtoReflect.Descriptor instead.
 func (*DockerImage) Descriptor() ([]byte, []int) {
-	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{8}
+	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *DockerImage) GetImage() string {
@@ -527,7 +615,7 @@ type GitSource struct {
 
 func (x *GitSource) Reset() {
 	*x = GitSource{}
-	mi := &file_hydra_v1_deploy_proto_msgTypes[9]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -539,7 +627,7 @@ func (x *GitSource) String() string {
 func (*GitSource) ProtoMessage() {}
 
 func (x *GitSource) ProtoReflect() protoreflect.Message {
-	mi := &file_hydra_v1_deploy_proto_msgTypes[9]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -552,7 +640,7 @@ func (x *GitSource) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GitSource.ProtoReflect.Descriptor instead.
 func (*GitSource) Descriptor() ([]byte, []int) {
-	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{9}
+	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *GitSource) GetInstallationId() int64 {
@@ -634,7 +722,7 @@ type DeployRequest struct {
 
 func (x *DeployRequest) Reset() {
 	*x = DeployRequest{}
-	mi := &file_hydra_v1_deploy_proto_msgTypes[10]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -646,7 +734,7 @@ func (x *DeployRequest) String() string {
 func (*DeployRequest) ProtoMessage() {}
 
 func (x *DeployRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_hydra_v1_deploy_proto_msgTypes[10]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -659,7 +747,7 @@ func (x *DeployRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeployRequest.ProtoReflect.Descriptor instead.
 func (*DeployRequest) Descriptor() ([]byte, []int) {
-	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{10}
+	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *DeployRequest) GetDeploymentId() string {
@@ -725,7 +813,7 @@ type DeployResponse struct {
 
 func (x *DeployResponse) Reset() {
 	*x = DeployResponse{}
-	mi := &file_hydra_v1_deploy_proto_msgTypes[11]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -737,7 +825,7 @@ func (x *DeployResponse) String() string {
 func (*DeployResponse) ProtoMessage() {}
 
 func (x *DeployResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_hydra_v1_deploy_proto_msgTypes[11]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -750,7 +838,7 @@ func (x *DeployResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeployResponse.ProtoReflect.Descriptor instead.
 func (*DeployResponse) Descriptor() ([]byte, []int) {
-	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{11}
+	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{13}
 }
 
 // RollbackRequest identifies the deployment to roll back from and the
@@ -769,7 +857,7 @@ type RollbackRequest struct {
 
 func (x *RollbackRequest) Reset() {
 	*x = RollbackRequest{}
-	mi := &file_hydra_v1_deploy_proto_msgTypes[12]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -781,7 +869,7 @@ func (x *RollbackRequest) String() string {
 func (*RollbackRequest) ProtoMessage() {}
 
 func (x *RollbackRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_hydra_v1_deploy_proto_msgTypes[12]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -794,7 +882,7 @@ func (x *RollbackRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RollbackRequest.ProtoReflect.Descriptor instead.
 func (*RollbackRequest) Descriptor() ([]byte, []int) {
-	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{12}
+	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *RollbackRequest) GetSourceDeploymentId() string {
@@ -833,7 +921,7 @@ type RollbackResponse struct {
 
 func (x *RollbackResponse) Reset() {
 	*x = RollbackResponse{}
-	mi := &file_hydra_v1_deploy_proto_msgTypes[13]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -845,7 +933,7 @@ func (x *RollbackResponse) String() string {
 func (*RollbackResponse) ProtoMessage() {}
 
 func (x *RollbackResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_hydra_v1_deploy_proto_msgTypes[13]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -858,7 +946,7 @@ func (x *RollbackResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RollbackResponse.ProtoReflect.Descriptor instead.
 func (*RollbackResponse) Descriptor() ([]byte, []int) {
-	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{13}
+	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{15}
 }
 
 // PromoteRequest identifies a ready deployment to promote to live.
@@ -873,7 +961,7 @@ type PromoteRequest struct {
 
 func (x *PromoteRequest) Reset() {
 	*x = PromoteRequest{}
-	mi := &file_hydra_v1_deploy_proto_msgTypes[14]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -885,7 +973,7 @@ func (x *PromoteRequest) String() string {
 func (*PromoteRequest) ProtoMessage() {}
 
 func (x *PromoteRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_hydra_v1_deploy_proto_msgTypes[14]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -898,7 +986,7 @@ func (x *PromoteRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PromoteRequest.ProtoReflect.Descriptor instead.
 func (*PromoteRequest) Descriptor() ([]byte, []int) {
-	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{14}
+	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *PromoteRequest) GetTargetDeploymentId() string {
@@ -930,7 +1018,7 @@ type PromoteResponse struct {
 
 func (x *PromoteResponse) Reset() {
 	*x = PromoteResponse{}
-	mi := &file_hydra_v1_deploy_proto_msgTypes[15]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -942,7 +1030,7 @@ func (x *PromoteResponse) String() string {
 func (*PromoteResponse) ProtoMessage() {}
 
 func (x *PromoteResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_hydra_v1_deploy_proto_msgTypes[15]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -955,7 +1043,7 @@ func (x *PromoteResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PromoteResponse.ProtoReflect.Descriptor instead.
 func (*PromoteResponse) Descriptor() ([]byte, []int) {
-	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{15}
+	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{17}
 }
 
 type TeardownRequest struct {
@@ -968,7 +1056,7 @@ type TeardownRequest struct {
 
 func (x *TeardownRequest) Reset() {
 	*x = TeardownRequest{}
-	mi := &file_hydra_v1_deploy_proto_msgTypes[16]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -980,7 +1068,7 @@ func (x *TeardownRequest) String() string {
 func (*TeardownRequest) ProtoMessage() {}
 
 func (x *TeardownRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_hydra_v1_deploy_proto_msgTypes[16]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -993,7 +1081,7 @@ func (x *TeardownRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TeardownRequest.ProtoReflect.Descriptor instead.
 func (*TeardownRequest) Descriptor() ([]byte, []int) {
-	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{16}
+	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *TeardownRequest) GetMode() TeardownMode {
@@ -1018,7 +1106,7 @@ type TeardownResponse struct {
 
 func (x *TeardownResponse) Reset() {
 	*x = TeardownResponse{}
-	mi := &file_hydra_v1_deploy_proto_msgTypes[17]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1030,7 +1118,7 @@ func (x *TeardownResponse) String() string {
 func (*TeardownResponse) ProtoMessage() {}
 
 func (x *TeardownResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_hydra_v1_deploy_proto_msgTypes[17]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1043,7 +1131,7 @@ func (x *TeardownResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TeardownResponse.ProtoReflect.Descriptor instead.
 func (*TeardownResponse) Descriptor() ([]byte, []int) {
-	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{17}
+	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *TeardownResponse) GetDeploymentsStopped() int32 {
@@ -1068,7 +1156,7 @@ type ResumeRequest struct {
 
 func (x *ResumeRequest) Reset() {
 	*x = ResumeRequest{}
-	mi := &file_hydra_v1_deploy_proto_msgTypes[18]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1080,7 +1168,7 @@ func (x *ResumeRequest) String() string {
 func (*ResumeRequest) ProtoMessage() {}
 
 func (x *ResumeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_hydra_v1_deploy_proto_msgTypes[18]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1093,7 +1181,7 @@ func (x *ResumeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResumeRequest.ProtoReflect.Descriptor instead.
 func (*ResumeRequest) Descriptor() ([]byte, []int) {
-	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{18}
+	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{20}
 }
 
 type ResumeResponse struct {
@@ -1106,7 +1194,7 @@ type ResumeResponse struct {
 
 func (x *ResumeResponse) Reset() {
 	*x = ResumeResponse{}
-	mi := &file_hydra_v1_deploy_proto_msgTypes[19]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1118,7 +1206,7 @@ func (x *ResumeResponse) String() string {
 func (*ResumeResponse) ProtoMessage() {}
 
 func (x *ResumeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_hydra_v1_deploy_proto_msgTypes[19]
+	mi := &file_hydra_v1_deploy_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1131,7 +1219,7 @@ func (x *ResumeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResumeResponse.ProtoReflect.Descriptor instead.
 func (*ResumeResponse) Descriptor() ([]byte, []int) {
-	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{19}
+	return file_hydra_v1_deploy_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *ResumeResponse) GetDeploymentsResumed() int32 {
@@ -1159,7 +1247,11 @@ const file_hydra_v1_deploy_proto_rawDesc = "" +
 	"\x1fGarbageCollectDeploymentRequest\x12#\n" +
 	"\rdeployment_id\x18\x01 \x01(\tR\fdeploymentId\"<\n" +
 	" GarbageCollectDeploymentResponse\x12\x18\n" +
-	"\adeleted\x18\x01 \x01(\bR\adeleted\"B\n" +
+	"\adeleted\x18\x01 \x01(\bR\adeleted\"?\n" +
+	"\x18RestoreDeploymentRequest\x12#\n" +
+	"\rdeployment_id\x18\x01 \x01(\tR\fdeploymentId\"7\n" +
+	"\x19RestoreDeploymentResponse\x12\x1a\n" +
+	"\brestored\x18\x01 \x01(\bR\brestored\"B\n" +
 	"\x1bNotifyInstancesReadyRequest\x12#\n" +
 	"\rdeployment_id\x18\x01 \x01(\tR\fdeploymentId\":\n" +
 	"\x1cNotifyInstancesReadyResponse\x12\x1a\n" +
@@ -1208,14 +1300,15 @@ const file_hydra_v1_deploy_proto_rawDesc = "" +
 	"\fTeardownMode\x12\x1d\n" +
 	"\x19TEARDOWN_MODE_UNSPECIFIED\x10\x00\x12\x19\n" +
 	"\x15TEARDOWN_MODE_ARCHIVE\x10\x01\x12\x19\n" +
-	"\x15TEARDOWN_MODE_SUSPEND\x10\x022\xe1\x04\n" +
+	"\x15TEARDOWN_MODE_SUSPEND\x10\x022\xb7\x05\n" +
 	"\rDeployService\x12=\n" +
 	"\x06Deploy\x12\x17.hydra.v1.DeployRequest\x1a\x18.hydra.v1.DeployResponse\"\x00\x12C\n" +
 	"\bRollback\x12\x19.hydra.v1.RollbackRequest\x1a\x1a.hydra.v1.RollbackResponse\"\x00\x12@\n" +
 	"\aPromote\x12\x18.hydra.v1.PromoteRequest\x1a\x19.hydra.v1.PromoteResponse\"\x00\x12U\n" +
 	"\x0eStopDeployment\x12\x1f.hydra.v1.StopDeploymentRequest\x1a .hydra.v1.StopDeploymentResponse\"\x00\x12U\n" +
 	"\x0eWakeDeployment\x12\x1f.hydra.v1.WakeDeploymentRequest\x1a .hydra.v1.WakeDeploymentResponse\"\x00\x12i\n" +
-	"\x0eGarbageCollect\x12).hydra.v1.GarbageCollectDeploymentRequest\x1a*.hydra.v1.GarbageCollectDeploymentResponse\"\x00\x12k\n" +
+	"\x0eGarbageCollect\x12).hydra.v1.GarbageCollectDeploymentRequest\x1a*.hydra.v1.GarbageCollectDeploymentResponse\"\x00\x12T\n" +
+	"\aRestore\x12\".hydra.v1.RestoreDeploymentRequest\x1a#.hydra.v1.RestoreDeploymentResponse\"\x00\x12k\n" +
 	"\x14NotifyInstancesReady\x12%.hydra.v1.NotifyInstancesReadyRequest\x1a&.hydra.v1.NotifyInstancesReadyResponse\"\x04\x98\x80\x01\x02\x1a\x04\x98\x80\x01\x012\xa1\x01\n" +
 	"\x15DeployTeardownService\x12C\n" +
 	"\bTeardown\x12\x19.hydra.v1.TeardownRequest\x1a\x1a.hydra.v1.TeardownResponse\"\x00\x12=\n" +
@@ -1235,7 +1328,7 @@ func file_hydra_v1_deploy_proto_rawDescGZIP() []byte {
 }
 
 var file_hydra_v1_deploy_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_hydra_v1_deploy_proto_msgTypes = make([]protoimpl.MessageInfo, 20)
+var file_hydra_v1_deploy_proto_msgTypes = make([]protoimpl.MessageInfo, 22)
 var file_hydra_v1_deploy_proto_goTypes = []any{
 	(TeardownMode)(0),                        // 0: hydra.v1.TeardownMode
 	(*StopDeploymentRequest)(nil),            // 1: hydra.v1.StopDeploymentRequest
@@ -1244,50 +1337,54 @@ var file_hydra_v1_deploy_proto_goTypes = []any{
 	(*WakeDeploymentResponse)(nil),           // 4: hydra.v1.WakeDeploymentResponse
 	(*GarbageCollectDeploymentRequest)(nil),  // 5: hydra.v1.GarbageCollectDeploymentRequest
 	(*GarbageCollectDeploymentResponse)(nil), // 6: hydra.v1.GarbageCollectDeploymentResponse
-	(*NotifyInstancesReadyRequest)(nil),      // 7: hydra.v1.NotifyInstancesReadyRequest
-	(*NotifyInstancesReadyResponse)(nil),     // 8: hydra.v1.NotifyInstancesReadyResponse
-	(*DockerImage)(nil),                      // 9: hydra.v1.DockerImage
-	(*GitSource)(nil),                        // 10: hydra.v1.GitSource
-	(*DeployRequest)(nil),                    // 11: hydra.v1.DeployRequest
-	(*DeployResponse)(nil),                   // 12: hydra.v1.DeployResponse
-	(*RollbackRequest)(nil),                  // 13: hydra.v1.RollbackRequest
-	(*RollbackResponse)(nil),                 // 14: hydra.v1.RollbackResponse
-	(*PromoteRequest)(nil),                   // 15: hydra.v1.PromoteRequest
-	(*PromoteResponse)(nil),                  // 16: hydra.v1.PromoteResponse
-	(*TeardownRequest)(nil),                  // 17: hydra.v1.TeardownRequest
-	(*TeardownResponse)(nil),                 // 18: hydra.v1.TeardownResponse
-	(*ResumeRequest)(nil),                    // 19: hydra.v1.ResumeRequest
-	(*ResumeResponse)(nil),                   // 20: hydra.v1.ResumeResponse
-	(*v1.ActorInfo)(nil),                     // 21: ctrl.v1.ActorInfo
+	(*RestoreDeploymentRequest)(nil),         // 7: hydra.v1.RestoreDeploymentRequest
+	(*RestoreDeploymentResponse)(nil),        // 8: hydra.v1.RestoreDeploymentResponse
+	(*NotifyInstancesReadyRequest)(nil),      // 9: hydra.v1.NotifyInstancesReadyRequest
+	(*NotifyInstancesReadyResponse)(nil),     // 10: hydra.v1.NotifyInstancesReadyResponse
+	(*DockerImage)(nil),                      // 11: hydra.v1.DockerImage
+	(*GitSource)(nil),                        // 12: hydra.v1.GitSource
+	(*DeployRequest)(nil),                    // 13: hydra.v1.DeployRequest
+	(*DeployResponse)(nil),                   // 14: hydra.v1.DeployResponse
+	(*RollbackRequest)(nil),                  // 15: hydra.v1.RollbackRequest
+	(*RollbackResponse)(nil),                 // 16: hydra.v1.RollbackResponse
+	(*PromoteRequest)(nil),                   // 17: hydra.v1.PromoteRequest
+	(*PromoteResponse)(nil),                  // 18: hydra.v1.PromoteResponse
+	(*TeardownRequest)(nil),                  // 19: hydra.v1.TeardownRequest
+	(*TeardownResponse)(nil),                 // 20: hydra.v1.TeardownResponse
+	(*ResumeRequest)(nil),                    // 21: hydra.v1.ResumeRequest
+	(*ResumeResponse)(nil),                   // 22: hydra.v1.ResumeResponse
+	(*v1.ActorInfo)(nil),                     // 23: ctrl.v1.ActorInfo
 }
 var file_hydra_v1_deploy_proto_depIdxs = []int32{
-	21, // 0: hydra.v1.StopDeploymentRequest.actor:type_name -> ctrl.v1.ActorInfo
-	21, // 1: hydra.v1.WakeDeploymentRequest.actor:type_name -> ctrl.v1.ActorInfo
-	10, // 2: hydra.v1.DeployRequest.git:type_name -> hydra.v1.GitSource
-	9,  // 3: hydra.v1.DeployRequest.docker_image:type_name -> hydra.v1.DockerImage
-	21, // 4: hydra.v1.RollbackRequest.actor:type_name -> ctrl.v1.ActorInfo
-	21, // 5: hydra.v1.PromoteRequest.actor:type_name -> ctrl.v1.ActorInfo
+	23, // 0: hydra.v1.StopDeploymentRequest.actor:type_name -> ctrl.v1.ActorInfo
+	23, // 1: hydra.v1.WakeDeploymentRequest.actor:type_name -> ctrl.v1.ActorInfo
+	12, // 2: hydra.v1.DeployRequest.git:type_name -> hydra.v1.GitSource
+	11, // 3: hydra.v1.DeployRequest.docker_image:type_name -> hydra.v1.DockerImage
+	23, // 4: hydra.v1.RollbackRequest.actor:type_name -> ctrl.v1.ActorInfo
+	23, // 5: hydra.v1.PromoteRequest.actor:type_name -> ctrl.v1.ActorInfo
 	0,  // 6: hydra.v1.TeardownRequest.mode:type_name -> hydra.v1.TeardownMode
-	11, // 7: hydra.v1.DeployService.Deploy:input_type -> hydra.v1.DeployRequest
-	13, // 8: hydra.v1.DeployService.Rollback:input_type -> hydra.v1.RollbackRequest
-	15, // 9: hydra.v1.DeployService.Promote:input_type -> hydra.v1.PromoteRequest
+	13, // 7: hydra.v1.DeployService.Deploy:input_type -> hydra.v1.DeployRequest
+	15, // 8: hydra.v1.DeployService.Rollback:input_type -> hydra.v1.RollbackRequest
+	17, // 9: hydra.v1.DeployService.Promote:input_type -> hydra.v1.PromoteRequest
 	1,  // 10: hydra.v1.DeployService.StopDeployment:input_type -> hydra.v1.StopDeploymentRequest
 	3,  // 11: hydra.v1.DeployService.WakeDeployment:input_type -> hydra.v1.WakeDeploymentRequest
 	5,  // 12: hydra.v1.DeployService.GarbageCollect:input_type -> hydra.v1.GarbageCollectDeploymentRequest
-	7,  // 13: hydra.v1.DeployService.NotifyInstancesReady:input_type -> hydra.v1.NotifyInstancesReadyRequest
-	17, // 14: hydra.v1.DeployTeardownService.Teardown:input_type -> hydra.v1.TeardownRequest
-	19, // 15: hydra.v1.DeployTeardownService.Resume:input_type -> hydra.v1.ResumeRequest
-	12, // 16: hydra.v1.DeployService.Deploy:output_type -> hydra.v1.DeployResponse
-	14, // 17: hydra.v1.DeployService.Rollback:output_type -> hydra.v1.RollbackResponse
-	16, // 18: hydra.v1.DeployService.Promote:output_type -> hydra.v1.PromoteResponse
-	2,  // 19: hydra.v1.DeployService.StopDeployment:output_type -> hydra.v1.StopDeploymentResponse
-	4,  // 20: hydra.v1.DeployService.WakeDeployment:output_type -> hydra.v1.WakeDeploymentResponse
-	6,  // 21: hydra.v1.DeployService.GarbageCollect:output_type -> hydra.v1.GarbageCollectDeploymentResponse
-	8,  // 22: hydra.v1.DeployService.NotifyInstancesReady:output_type -> hydra.v1.NotifyInstancesReadyResponse
-	18, // 23: hydra.v1.DeployTeardownService.Teardown:output_type -> hydra.v1.TeardownResponse
-	20, // 24: hydra.v1.DeployTeardownService.Resume:output_type -> hydra.v1.ResumeResponse
-	16, // [16:25] is the sub-list for method output_type
-	7,  // [7:16] is the sub-list for method input_type
+	7,  // 13: hydra.v1.DeployService.Restore:input_type -> hydra.v1.RestoreDeploymentRequest
+	9,  // 14: hydra.v1.DeployService.NotifyInstancesReady:input_type -> hydra.v1.NotifyInstancesReadyRequest
+	19, // 15: hydra.v1.DeployTeardownService.Teardown:input_type -> hydra.v1.TeardownRequest
+	21, // 16: hydra.v1.DeployTeardownService.Resume:input_type -> hydra.v1.ResumeRequest
+	14, // 17: hydra.v1.DeployService.Deploy:output_type -> hydra.v1.DeployResponse
+	16, // 18: hydra.v1.DeployService.Rollback:output_type -> hydra.v1.RollbackResponse
+	18, // 19: hydra.v1.DeployService.Promote:output_type -> hydra.v1.PromoteResponse
+	2,  // 20: hydra.v1.DeployService.StopDeployment:output_type -> hydra.v1.StopDeploymentResponse
+	4,  // 21: hydra.v1.DeployService.WakeDeployment:output_type -> hydra.v1.WakeDeploymentResponse
+	6,  // 22: hydra.v1.DeployService.GarbageCollect:output_type -> hydra.v1.GarbageCollectDeploymentResponse
+	8,  // 23: hydra.v1.DeployService.Restore:output_type -> hydra.v1.RestoreDeploymentResponse
+	10, // 24: hydra.v1.DeployService.NotifyInstancesReady:output_type -> hydra.v1.NotifyInstancesReadyResponse
+	20, // 25: hydra.v1.DeployTeardownService.Teardown:output_type -> hydra.v1.TeardownResponse
+	22, // 26: hydra.v1.DeployTeardownService.Resume:output_type -> hydra.v1.ResumeResponse
+	17, // [17:27] is the sub-list for method output_type
+	7,  // [7:17] is the sub-list for method input_type
 	7,  // [7:7] is the sub-list for extension type_name
 	7,  // [7:7] is the sub-list for extension extendee
 	0,  // [0:7] is the sub-list for field type_name
@@ -1298,7 +1395,7 @@ func file_hydra_v1_deploy_proto_init() {
 	if File_hydra_v1_deploy_proto != nil {
 		return
 	}
-	file_hydra_v1_deploy_proto_msgTypes[10].OneofWrappers = []any{
+	file_hydra_v1_deploy_proto_msgTypes[12].OneofWrappers = []any{
 		(*DeployRequest_Git)(nil),
 		(*DeployRequest_DockerImage)(nil),
 	}
@@ -1308,7 +1405,7 @@ func file_hydra_v1_deploy_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_hydra_v1_deploy_proto_rawDesc), len(file_hydra_v1_deploy_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   20,
+			NumMessages:   22,
 			NumExtensions: 0,
 			NumServices:   2,
 		},

--- a/gen/proto/hydra/v1/deploy_restate.pb.go
+++ b/gen/proto/hydra/v1/deploy_restate.pb.go
@@ -52,6 +52,8 @@ type DeployServiceClient interface {
 	// GarbageCollect deletes a terminal deployment after rechecking its
 	// retention policy. The request ID must match the deployment-keyed object.
 	GarbageCollect(opts ...sdk_go.ClientOption) sdk_go.Client[*GarbageCollectDeploymentRequest, *GarbageCollectDeploymentResponse]
+	// Restore recovers deployment history without starting compute or changing traffic.
+	Restore(opts ...sdk_go.ClientOption) sdk_go.Client[*RestoreDeploymentRequest, *RestoreDeploymentResponse]
 	// NotifyInstancesReady is called by the control plane when enough instances
 	// have become healthy across the required regions. It resolves the awakeable
 	// stored by a suspended deploy or wake workflow so it can continue.
@@ -120,6 +122,14 @@ func (c *deployServiceClient) GarbageCollect(opts ...sdk_go.ClientOption) sdk_go
 	return sdk_go.WithRequestType[*GarbageCollectDeploymentRequest](sdk_go.Object[*GarbageCollectDeploymentResponse](c.ctx, "hydra.v1.DeployService", c.key, "GarbageCollect", cOpts...))
 }
 
+func (c *deployServiceClient) Restore(opts ...sdk_go.ClientOption) sdk_go.Client[*RestoreDeploymentRequest, *RestoreDeploymentResponse] {
+	cOpts := c.options
+	if len(opts) > 0 {
+		cOpts = append(append([]sdk_go.ClientOption{}, cOpts...), opts...)
+	}
+	return sdk_go.WithRequestType[*RestoreDeploymentRequest](sdk_go.Object[*RestoreDeploymentResponse](c.ctx, "hydra.v1.DeployService", c.key, "Restore", cOpts...))
+}
+
 func (c *deployServiceClient) NotifyInstancesReady(opts ...sdk_go.ClientOption) sdk_go.Client[*NotifyInstancesReadyRequest, *NotifyInstancesReadyResponse] {
 	cOpts := c.options
 	if len(opts) > 0 {
@@ -155,6 +165,8 @@ type DeployServiceIngressClient interface {
 	// GarbageCollect deletes a terminal deployment after rechecking its
 	// retention policy. The request ID must match the deployment-keyed object.
 	GarbageCollect() ingress.Requester[*GarbageCollectDeploymentRequest, *GarbageCollectDeploymentResponse]
+	// Restore recovers deployment history without starting compute or changing traffic.
+	Restore() ingress.Requester[*RestoreDeploymentRequest, *RestoreDeploymentResponse]
 	// NotifyInstancesReady is called by the control plane when enough instances
 	// have become healthy across the required regions. It resolves the awakeable
 	// stored by a suspended deploy or wake workflow so it can continue.
@@ -205,6 +217,11 @@ func (c *deployServiceIngressClient) GarbageCollect() ingress.Requester[*Garbage
 	return ingress.NewRequester[*GarbageCollectDeploymentRequest, *GarbageCollectDeploymentResponse](c.client, c.serviceName, "GarbageCollect", &c.key, &codec)
 }
 
+func (c *deployServiceIngressClient) Restore() ingress.Requester[*RestoreDeploymentRequest, *RestoreDeploymentResponse] {
+	codec := encoding.ProtoJSONCodec
+	return ingress.NewRequester[*RestoreDeploymentRequest, *RestoreDeploymentResponse](c.client, c.serviceName, "Restore", &c.key, &codec)
+}
+
 func (c *deployServiceIngressClient) NotifyInstancesReady() ingress.Requester[*NotifyInstancesReadyRequest, *NotifyInstancesReadyResponse] {
 	codec := encoding.ProtoJSONCodec
 	return ingress.NewRequester[*NotifyInstancesReadyRequest, *NotifyInstancesReadyResponse](c.client, c.serviceName, "NotifyInstancesReady", &c.key, &codec)
@@ -251,6 +268,8 @@ type DeployServiceServer interface {
 	// GarbageCollect deletes a terminal deployment after rechecking its
 	// retention policy. The request ID must match the deployment-keyed object.
 	GarbageCollect(ctx sdk_go.ObjectContext, req *GarbageCollectDeploymentRequest) (*GarbageCollectDeploymentResponse, error)
+	// Restore recovers deployment history without starting compute or changing traffic.
+	Restore(ctx sdk_go.ObjectContext, req *RestoreDeploymentRequest) (*RestoreDeploymentResponse, error)
 	// NotifyInstancesReady is called by the control plane when enough instances
 	// have become healthy across the required regions. It resolves the awakeable
 	// stored by a suspended deploy or wake workflow so it can continue.
@@ -282,6 +301,9 @@ func (UnimplementedDeployServiceServer) WakeDeployment(ctx sdk_go.ObjectContext,
 func (UnimplementedDeployServiceServer) GarbageCollect(ctx sdk_go.ObjectContext, req *GarbageCollectDeploymentRequest) (*GarbageCollectDeploymentResponse, error) {
 	return nil, sdk_go.TerminalError(fmt.Errorf("method GarbageCollect not implemented"), 501)
 }
+func (UnimplementedDeployServiceServer) Restore(ctx sdk_go.ObjectContext, req *RestoreDeploymentRequest) (*RestoreDeploymentResponse, error) {
+	return nil, sdk_go.TerminalError(fmt.Errorf("method Restore not implemented"), 501)
+}
 func (UnimplementedDeployServiceServer) NotifyInstancesReady(ctx sdk_go.ObjectSharedContext, req *NotifyInstancesReadyRequest) (*NotifyInstancesReadyResponse, error) {
 	return nil, sdk_go.TerminalError(fmt.Errorf("method NotifyInstancesReady not implemented"), 501)
 }
@@ -310,6 +332,7 @@ func NewDeployServiceServer(srv DeployServiceServer, opts ...sdk_go.ServiceDefin
 	router = router.Handler("StopDeployment", sdk_go.NewObjectHandler(srv.StopDeployment))
 	router = router.Handler("WakeDeployment", sdk_go.NewObjectHandler(srv.WakeDeployment))
 	router = router.Handler("GarbageCollect", sdk_go.NewObjectHandler(srv.GarbageCollect))
+	router = router.Handler("Restore", sdk_go.NewObjectHandler(srv.Restore))
 	router = router.Handler("NotifyInstancesReady", sdk_go.NewObjectSharedHandler(srv.NotifyInstancesReady))
 	return router
 }

--- a/pkg/db/deployment_domain_list.sql_generated.go
+++ b/pkg/db/deployment_domain_list.sql_generated.go
@@ -15,6 +15,7 @@ SELECT r.fully_qualified_domain_name AS domain
 FROM frontline_routes r
 JOIN deployments d ON r.deployment_id = d.id
 WHERE d.workspace_id = ?
+  AND d.deleted_at IS NULL
   AND r.deployment_id = ?
 ORDER BY r.fully_qualified_domain_name
 `
@@ -30,6 +31,7 @@ type ListDeploymentDomainsParams struct {
 //	FROM frontline_routes r
 //	JOIN deployments d ON r.deployment_id = d.id
 //	WHERE d.workspace_id = ?
+//	  AND d.deleted_at IS NULL
 //	  AND r.deployment_id = ?
 //	ORDER BY r.fully_qualified_domain_name
 func (q *Queries) ListDeploymentDomains(ctx context.Context, db DBTX, arg ListDeploymentDomainsParams) ([]string, error) {
@@ -60,6 +62,7 @@ SELECT r.deployment_id AS deployment_id, r.fully_qualified_domain_name AS domain
 FROM frontline_routes r
 JOIN deployments d ON r.deployment_id = d.id
 WHERE d.workspace_id = ?
+  AND d.deleted_at IS NULL
   AND r.deployment_id IN (/*SLICE:deployment_ids*/?)
 ORDER BY r.deployment_id, r.fully_qualified_domain_name
 `
@@ -80,6 +83,7 @@ type ListDeploymentDomainsByIdsRow struct {
 //	FROM frontline_routes r
 //	JOIN deployments d ON r.deployment_id = d.id
 //	WHERE d.workspace_id = ?
+//	  AND d.deleted_at IS NULL
 //	  AND r.deployment_id IN (/*SLICE:deployment_ids*/?)
 //	ORDER BY r.deployment_id, r.fully_qualified_domain_name
 func (q *Queries) ListDeploymentDomainsByIds(ctx context.Context, db DBTX, arg ListDeploymentDomainsByIdsParams) ([]ListDeploymentDomainsByIdsRow, error) {

--- a/pkg/db/deployment_find_by_id.sql_generated.go
+++ b/pkg/db/deployment_find_by_id.sql_generated.go
@@ -10,12 +10,12 @@ import (
 )
 
 const findDeploymentById = `-- name: FindDeploymentById :one
-SELECT pk, id, k8s_name, workspace_id, project_id, environment_id, app_id, image, build_id, git_commit_sha, git_branch, git_commit_message, git_commit_author_handle, git_commit_author_avatar_url, git_commit_timestamp, sentinel_config, cpu_millicores, memory_mib, storage_mib, desired_state, encrypted_environment_variables, command, port, shutdown_signal, upstream_protocol, healthcheck, pr_number, fork_repository_full_name, github_deployment_id, invocation_id, status, ` + "`" + `trigger` + "`" + `, triggered_by, trigger_reason, created_at, updated_at FROM ` + "`" + `deployments` + "`" + ` WHERE id = ?
+SELECT pk, id, k8s_name, deleted_at, restored_at, workspace_id, project_id, environment_id, app_id, image, build_id, git_commit_sha, git_branch, git_commit_message, git_commit_author_handle, git_commit_author_avatar_url, git_commit_timestamp, sentinel_config, cpu_millicores, memory_mib, storage_mib, desired_state, encrypted_environment_variables, command, port, shutdown_signal, upstream_protocol, healthcheck, pr_number, fork_repository_full_name, github_deployment_id, invocation_id, status, ` + "`" + `trigger` + "`" + `, triggered_by, trigger_reason, created_at, updated_at FROM ` + "`" + `deployments` + "`" + ` WHERE id = ? AND deleted_at IS NULL
 `
 
 // FindDeploymentById
 //
-//	SELECT pk, id, k8s_name, workspace_id, project_id, environment_id, app_id, image, build_id, git_commit_sha, git_branch, git_commit_message, git_commit_author_handle, git_commit_author_avatar_url, git_commit_timestamp, sentinel_config, cpu_millicores, memory_mib, storage_mib, desired_state, encrypted_environment_variables, command, port, shutdown_signal, upstream_protocol, healthcheck, pr_number, fork_repository_full_name, github_deployment_id, invocation_id, status, `trigger`, triggered_by, trigger_reason, created_at, updated_at FROM `deployments` WHERE id = ?
+//	SELECT pk, id, k8s_name, deleted_at, restored_at, workspace_id, project_id, environment_id, app_id, image, build_id, git_commit_sha, git_branch, git_commit_message, git_commit_author_handle, git_commit_author_avatar_url, git_commit_timestamp, sentinel_config, cpu_millicores, memory_mib, storage_mib, desired_state, encrypted_environment_variables, command, port, shutdown_signal, upstream_protocol, healthcheck, pr_number, fork_repository_full_name, github_deployment_id, invocation_id, status, `trigger`, triggered_by, trigger_reason, created_at, updated_at FROM `deployments` WHERE id = ? AND deleted_at IS NULL
 func (q *Queries) FindDeploymentById(ctx context.Context, db DBTX, id string) (Deployment, error) {
 	row := db.QueryRowContext(ctx, findDeploymentById, id)
 	var i Deployment
@@ -23,6 +23,8 @@ func (q *Queries) FindDeploymentById(ctx context.Context, db DBTX, id string) (D
 		&i.Pk,
 		&i.ID,
 		&i.K8sName,
+		&i.DeletedAt,
+		&i.RestoredAt,
 		&i.WorkspaceID,
 		&i.ProjectID,
 		&i.EnvironmentID,

--- a/pkg/db/deployment_find_with_environment.sql_generated.go
+++ b/pkg/db/deployment_find_with_environment.sql_generated.go
@@ -14,16 +14,18 @@ import (
 )
 
 const findDeploymentWithEnvironment = `-- name: FindDeploymentWithEnvironment :one
-SELECT d.pk, d.id, d.k8s_name, d.workspace_id, d.project_id, d.environment_id, d.app_id, d.image, d.build_id, d.git_commit_sha, d.git_branch, d.git_commit_message, d.git_commit_author_handle, d.git_commit_author_avatar_url, d.git_commit_timestamp, d.sentinel_config, d.cpu_millicores, d.memory_mib, d.storage_mib, d.desired_state, d.encrypted_environment_variables, d.command, d.port, d.shutdown_signal, d.upstream_protocol, d.healthcheck, d.pr_number, d.fork_repository_full_name, d.github_deployment_id, d.invocation_id, d.status, d.` + "`" + `trigger` + "`" + `, d.triggered_by, d.trigger_reason, d.created_at, d.updated_at, e.slug AS environment_slug, e.kind AS environment_kind
+SELECT d.pk, d.id, d.k8s_name, d.deleted_at, d.restored_at, d.workspace_id, d.project_id, d.environment_id, d.app_id, d.image, d.build_id, d.git_commit_sha, d.git_branch, d.git_commit_message, d.git_commit_author_handle, d.git_commit_author_avatar_url, d.git_commit_timestamp, d.sentinel_config, d.cpu_millicores, d.memory_mib, d.storage_mib, d.desired_state, d.encrypted_environment_variables, d.command, d.port, d.shutdown_signal, d.upstream_protocol, d.healthcheck, d.pr_number, d.fork_repository_full_name, d.github_deployment_id, d.invocation_id, d.status, d.` + "`" + `trigger` + "`" + `, d.triggered_by, d.trigger_reason, d.created_at, d.updated_at, e.slug AS environment_slug, e.kind AS environment_kind
 FROM deployments d
 JOIN environments e ON d.environment_id = e.id
-WHERE d.id = ?
+WHERE d.id = ? AND d.deleted_at IS NULL
 `
 
 type FindDeploymentWithEnvironmentRow struct {
 	Pk                            uint64                            `db:"pk"`
 	ID                            string                            `db:"id"`
 	K8sName                       string                            `db:"k8s_name"`
+	DeletedAt                     sql.NullInt64                     `db:"deleted_at"`
+	RestoredAt                    sql.NullInt64                     `db:"restored_at"`
 	WorkspaceID                   string                            `db:"workspace_id"`
 	ProjectID                     string                            `db:"project_id"`
 	EnvironmentID                 string                            `db:"environment_id"`
@@ -63,10 +65,10 @@ type FindDeploymentWithEnvironmentRow struct {
 
 // FindDeploymentWithEnvironment
 //
-//	SELECT d.pk, d.id, d.k8s_name, d.workspace_id, d.project_id, d.environment_id, d.app_id, d.image, d.build_id, d.git_commit_sha, d.git_branch, d.git_commit_message, d.git_commit_author_handle, d.git_commit_author_avatar_url, d.git_commit_timestamp, d.sentinel_config, d.cpu_millicores, d.memory_mib, d.storage_mib, d.desired_state, d.encrypted_environment_variables, d.command, d.port, d.shutdown_signal, d.upstream_protocol, d.healthcheck, d.pr_number, d.fork_repository_full_name, d.github_deployment_id, d.invocation_id, d.status, d.`trigger`, d.triggered_by, d.trigger_reason, d.created_at, d.updated_at, e.slug AS environment_slug, e.kind AS environment_kind
+//	SELECT d.pk, d.id, d.k8s_name, d.deleted_at, d.restored_at, d.workspace_id, d.project_id, d.environment_id, d.app_id, d.image, d.build_id, d.git_commit_sha, d.git_branch, d.git_commit_message, d.git_commit_author_handle, d.git_commit_author_avatar_url, d.git_commit_timestamp, d.sentinel_config, d.cpu_millicores, d.memory_mib, d.storage_mib, d.desired_state, d.encrypted_environment_variables, d.command, d.port, d.shutdown_signal, d.upstream_protocol, d.healthcheck, d.pr_number, d.fork_repository_full_name, d.github_deployment_id, d.invocation_id, d.status, d.`trigger`, d.triggered_by, d.trigger_reason, d.created_at, d.updated_at, e.slug AS environment_slug, e.kind AS environment_kind
 //	FROM deployments d
 //	JOIN environments e ON d.environment_id = e.id
-//	WHERE d.id = ?
+//	WHERE d.id = ? AND d.deleted_at IS NULL
 func (q *Queries) FindDeploymentWithEnvironment(ctx context.Context, db DBTX, id string) (FindDeploymentWithEnvironmentRow, error) {
 	row := db.QueryRowContext(ctx, findDeploymentWithEnvironment, id)
 	var i FindDeploymentWithEnvironmentRow
@@ -74,6 +76,8 @@ func (q *Queries) FindDeploymentWithEnvironment(ctx context.Context, db DBTX, id
 		&i.Pk,
 		&i.ID,
 		&i.K8sName,
+		&i.DeletedAt,
+		&i.RestoredAt,
 		&i.WorkspaceID,
 		&i.ProjectID,
 		&i.EnvironmentID,

--- a/pkg/db/deployment_list.sql_generated.go
+++ b/pkg/db/deployment_list.sql_generated.go
@@ -13,8 +13,9 @@ import (
 )
 
 const listDeployments = `-- name: ListDeployments :many
-SELECT d.pk, d.id, d.k8s_name, d.workspace_id, d.project_id, d.environment_id, d.app_id, d.image, d.build_id, d.git_commit_sha, d.git_branch, d.git_commit_message, d.git_commit_author_handle, d.git_commit_author_avatar_url, d.git_commit_timestamp, d.sentinel_config, d.cpu_millicores, d.memory_mib, d.storage_mib, d.desired_state, d.encrypted_environment_variables, d.command, d.port, d.shutdown_signal, d.upstream_protocol, d.healthcheck, d.pr_number, d.fork_repository_full_name, d.github_deployment_id, d.invocation_id, d.status, d.` + "`" + `trigger` + "`" + `, d.triggered_by, d.trigger_reason, d.created_at, d.updated_at FROM ` + "`" + `deployments` + "`" + ` d
+SELECT d.pk, d.id, d.k8s_name, d.deleted_at, d.restored_at, d.workspace_id, d.project_id, d.environment_id, d.app_id, d.image, d.build_id, d.git_commit_sha, d.git_branch, d.git_commit_message, d.git_commit_author_handle, d.git_commit_author_avatar_url, d.git_commit_timestamp, d.sentinel_config, d.cpu_millicores, d.memory_mib, d.storage_mib, d.desired_state, d.encrypted_environment_variables, d.command, d.port, d.shutdown_signal, d.upstream_protocol, d.healthcheck, d.pr_number, d.fork_repository_full_name, d.github_deployment_id, d.invocation_id, d.status, d.` + "`" + `trigger` + "`" + `, d.triggered_by, d.trigger_reason, d.created_at, d.updated_at FROM ` + "`" + `deployments` + "`" + ` d
 WHERE d.workspace_id = ?
+  AND d.deleted_at IS NULL
   AND (? = '' OR d.project_id = ?)
   AND (? = '' OR d.app_id = ?)
   AND (? = '' OR d.environment_id = ?)
@@ -41,8 +42,9 @@ type ListDeploymentsParams struct {
 // has_status_filter gates the status clause; without it sqlc renders an empty
 // status set as IN (NULL), which matches nothing.
 //
-//	SELECT d.pk, d.id, d.k8s_name, d.workspace_id, d.project_id, d.environment_id, d.app_id, d.image, d.build_id, d.git_commit_sha, d.git_branch, d.git_commit_message, d.git_commit_author_handle, d.git_commit_author_avatar_url, d.git_commit_timestamp, d.sentinel_config, d.cpu_millicores, d.memory_mib, d.storage_mib, d.desired_state, d.encrypted_environment_variables, d.command, d.port, d.shutdown_signal, d.upstream_protocol, d.healthcheck, d.pr_number, d.fork_repository_full_name, d.github_deployment_id, d.invocation_id, d.status, d.`trigger`, d.triggered_by, d.trigger_reason, d.created_at, d.updated_at FROM `deployments` d
+//	SELECT d.pk, d.id, d.k8s_name, d.deleted_at, d.restored_at, d.workspace_id, d.project_id, d.environment_id, d.app_id, d.image, d.build_id, d.git_commit_sha, d.git_branch, d.git_commit_message, d.git_commit_author_handle, d.git_commit_author_avatar_url, d.git_commit_timestamp, d.sentinel_config, d.cpu_millicores, d.memory_mib, d.storage_mib, d.desired_state, d.encrypted_environment_variables, d.command, d.port, d.shutdown_signal, d.upstream_protocol, d.healthcheck, d.pr_number, d.fork_repository_full_name, d.github_deployment_id, d.invocation_id, d.status, d.`trigger`, d.triggered_by, d.trigger_reason, d.created_at, d.updated_at FROM `deployments` d
 //	WHERE d.workspace_id = ?
+//	  AND d.deleted_at IS NULL
 //	  AND (? = '' OR d.project_id = ?)
 //	  AND (? = '' OR d.app_id = ?)
 //	  AND (? = '' OR d.environment_id = ?)
@@ -87,6 +89,8 @@ func (q *Queries) ListDeployments(ctx context.Context, db DBTX, arg ListDeployme
 			&i.Pk,
 			&i.ID,
 			&i.K8sName,
+			&i.DeletedAt,
+			&i.RestoredAt,
 			&i.WorkspaceID,
 			&i.ProjectID,
 			&i.EnvironmentID,

--- a/pkg/db/deployment_update_desired_state.sql_generated.go
+++ b/pkg/db/deployment_update_desired_state.sql_generated.go
@@ -15,7 +15,7 @@ import (
 const updateDeploymentDesiredState = `-- name: UpdateDeploymentDesiredState :exec
 UPDATE deployments
 SET desired_state = ?, updated_at = ?
-WHERE id = ?
+WHERE id = ? AND deleted_at IS NULL
 `
 
 type UpdateDeploymentDesiredStateParams struct {
@@ -28,7 +28,7 @@ type UpdateDeploymentDesiredStateParams struct {
 //
 //	UPDATE deployments
 //	SET desired_state = ?, updated_at = ?
-//	WHERE id = ?
+//	WHERE id = ? AND deleted_at IS NULL
 func (q *Queries) UpdateDeploymentDesiredState(ctx context.Context, db DBTX, arg UpdateDeploymentDesiredStateParams) error {
 	_, err := db.ExecContext(ctx, updateDeploymentDesiredState, arg.DesiredState, arg.UpdatedAt, arg.ID)
 	return err

--- a/pkg/db/models_generated.go
+++ b/pkg/db/models_generated.go
@@ -683,6 +683,8 @@ type Deployment struct {
 	Pk                            uint64                            `db:"pk"`
 	ID                            string                            `db:"id"`
 	K8sName                       string                            `db:"k8s_name"`
+	DeletedAt                     sql.NullInt64                     `db:"deleted_at"`
+	RestoredAt                    sql.NullInt64                     `db:"restored_at"`
 	WorkspaceID                   string                            `db:"workspace_id"`
 	ProjectID                     string                            `db:"project_id"`
 	EnvironmentID                 string                            `db:"environment_id"`

--- a/pkg/db/querier_generated.go
+++ b/pkg/db/querier_generated.go
@@ -334,14 +334,14 @@ type Querier interface {
 	FindDefaultProjectByWorkspaceID(ctx context.Context, db DBTX, workspaceID string) (string, error)
 	//FindDeploymentById
 	//
-	//  SELECT pk, id, k8s_name, workspace_id, project_id, environment_id, app_id, image, build_id, git_commit_sha, git_branch, git_commit_message, git_commit_author_handle, git_commit_author_avatar_url, git_commit_timestamp, sentinel_config, cpu_millicores, memory_mib, storage_mib, desired_state, encrypted_environment_variables, command, port, shutdown_signal, upstream_protocol, healthcheck, pr_number, fork_repository_full_name, github_deployment_id, invocation_id, status, `trigger`, triggered_by, trigger_reason, created_at, updated_at FROM `deployments` WHERE id = ?
+	//  SELECT pk, id, k8s_name, deleted_at, restored_at, workspace_id, project_id, environment_id, app_id, image, build_id, git_commit_sha, git_branch, git_commit_message, git_commit_author_handle, git_commit_author_avatar_url, git_commit_timestamp, sentinel_config, cpu_millicores, memory_mib, storage_mib, desired_state, encrypted_environment_variables, command, port, shutdown_signal, upstream_protocol, healthcheck, pr_number, fork_repository_full_name, github_deployment_id, invocation_id, status, `trigger`, triggered_by, trigger_reason, created_at, updated_at FROM `deployments` WHERE id = ? AND deleted_at IS NULL
 	FindDeploymentById(ctx context.Context, db DBTX, id string) (Deployment, error)
 	//FindDeploymentWithEnvironment
 	//
-	//  SELECT d.pk, d.id, d.k8s_name, d.workspace_id, d.project_id, d.environment_id, d.app_id, d.image, d.build_id, d.git_commit_sha, d.git_branch, d.git_commit_message, d.git_commit_author_handle, d.git_commit_author_avatar_url, d.git_commit_timestamp, d.sentinel_config, d.cpu_millicores, d.memory_mib, d.storage_mib, d.desired_state, d.encrypted_environment_variables, d.command, d.port, d.shutdown_signal, d.upstream_protocol, d.healthcheck, d.pr_number, d.fork_repository_full_name, d.github_deployment_id, d.invocation_id, d.status, d.`trigger`, d.triggered_by, d.trigger_reason, d.created_at, d.updated_at, e.slug AS environment_slug, e.kind AS environment_kind
+	//  SELECT d.pk, d.id, d.k8s_name, d.deleted_at, d.restored_at, d.workspace_id, d.project_id, d.environment_id, d.app_id, d.image, d.build_id, d.git_commit_sha, d.git_branch, d.git_commit_message, d.git_commit_author_handle, d.git_commit_author_avatar_url, d.git_commit_timestamp, d.sentinel_config, d.cpu_millicores, d.memory_mib, d.storage_mib, d.desired_state, d.encrypted_environment_variables, d.command, d.port, d.shutdown_signal, d.upstream_protocol, d.healthcheck, d.pr_number, d.fork_repository_full_name, d.github_deployment_id, d.invocation_id, d.status, d.`trigger`, d.triggered_by, d.trigger_reason, d.created_at, d.updated_at, e.slug AS environment_slug, e.kind AS environment_kind
 	//  FROM deployments d
 	//  JOIN environments e ON d.environment_id = e.id
-	//  WHERE d.id = ?
+	//  WHERE d.id = ? AND d.deleted_at IS NULL
 	FindDeploymentWithEnvironment(ctx context.Context, db DBTX, id string) (FindDeploymentWithEnvironmentRow, error)
 	//FindEnvironmentByAppIdAndSlug
 	//
@@ -1857,6 +1857,7 @@ type Querier interface {
 	//  FROM frontline_routes r
 	//  JOIN deployments d ON r.deployment_id = d.id
 	//  WHERE d.workspace_id = ?
+	//    AND d.deleted_at IS NULL
 	//    AND r.deployment_id = ?
 	//  ORDER BY r.fully_qualified_domain_name
 	ListDeploymentDomains(ctx context.Context, db DBTX, arg ListDeploymentDomainsParams) ([]string, error)
@@ -1866,6 +1867,7 @@ type Querier interface {
 	//  FROM frontline_routes r
 	//  JOIN deployments d ON r.deployment_id = d.id
 	//  WHERE d.workspace_id = ?
+	//    AND d.deleted_at IS NULL
 	//    AND r.deployment_id IN (/*SLICE:deployment_ids*/?)
 	//  ORDER BY r.deployment_id, r.fully_qualified_domain_name
 	ListDeploymentDomainsByIds(ctx context.Context, db DBTX, arg ListDeploymentDomainsByIdsParams) ([]ListDeploymentDomainsByIdsRow, error)
@@ -1907,8 +1909,9 @@ type Querier interface {
 	// has_status_filter gates the status clause; without it sqlc renders an empty
 	// status set as IN (NULL), which matches nothing.
 	//
-	//  SELECT d.pk, d.id, d.k8s_name, d.workspace_id, d.project_id, d.environment_id, d.app_id, d.image, d.build_id, d.git_commit_sha, d.git_branch, d.git_commit_message, d.git_commit_author_handle, d.git_commit_author_avatar_url, d.git_commit_timestamp, d.sentinel_config, d.cpu_millicores, d.memory_mib, d.storage_mib, d.desired_state, d.encrypted_environment_variables, d.command, d.port, d.shutdown_signal, d.upstream_protocol, d.healthcheck, d.pr_number, d.fork_repository_full_name, d.github_deployment_id, d.invocation_id, d.status, d.`trigger`, d.triggered_by, d.trigger_reason, d.created_at, d.updated_at FROM `deployments` d
+	//  SELECT d.pk, d.id, d.k8s_name, d.deleted_at, d.restored_at, d.workspace_id, d.project_id, d.environment_id, d.app_id, d.image, d.build_id, d.git_commit_sha, d.git_branch, d.git_commit_message, d.git_commit_author_handle, d.git_commit_author_avatar_url, d.git_commit_timestamp, d.sentinel_config, d.cpu_millicores, d.memory_mib, d.storage_mib, d.desired_state, d.encrypted_environment_variables, d.command, d.port, d.shutdown_signal, d.upstream_protocol, d.healthcheck, d.pr_number, d.fork_repository_full_name, d.github_deployment_id, d.invocation_id, d.status, d.`trigger`, d.triggered_by, d.trigger_reason, d.created_at, d.updated_at FROM `deployments` d
 	//  WHERE d.workspace_id = ?
+	//    AND d.deleted_at IS NULL
 	//    AND (? = '' OR d.project_id = ?)
 	//    AND (? = '' OR d.app_id = ?)
 	//    AND (? = '' OR d.environment_id = ?)
@@ -2573,7 +2576,7 @@ type Querier interface {
 	//
 	//  UPDATE deployments
 	//  SET desired_state = ?, updated_at = ?
-	//  WHERE id = ?
+	//  WHERE id = ? AND deleted_at IS NULL
 	UpdateDeploymentDesiredState(ctx context.Context, db DBTX, arg UpdateDeploymentDesiredStateParams) error
 	//UpdateDeploymentImage
 	//

--- a/pkg/db/queries/deployment_domain_list.sql
+++ b/pkg/db/queries/deployment_domain_list.sql
@@ -3,6 +3,7 @@ SELECT r.fully_qualified_domain_name AS domain
 FROM frontline_routes r
 JOIN deployments d ON r.deployment_id = d.id
 WHERE d.workspace_id = sqlc.arg(workspace_id)
+  AND d.deleted_at IS NULL
   AND r.deployment_id = sqlc.arg(deployment_id)
 ORDER BY r.fully_qualified_domain_name;
 
@@ -11,5 +12,6 @@ SELECT r.deployment_id AS deployment_id, r.fully_qualified_domain_name AS domain
 FROM frontline_routes r
 JOIN deployments d ON r.deployment_id = d.id
 WHERE d.workspace_id = sqlc.arg(workspace_id)
+  AND d.deleted_at IS NULL
   AND r.deployment_id IN (sqlc.slice('deployment_ids'))
 ORDER BY r.deployment_id, r.fully_qualified_domain_name;

--- a/pkg/db/queries/deployment_find_by_id.sql
+++ b/pkg/db/queries/deployment_find_by_id.sql
@@ -1,2 +1,2 @@
 -- name: FindDeploymentById :one
-SELECT * FROM `deployments` WHERE id = sqlc.arg(id);
+SELECT * FROM `deployments` WHERE id = sqlc.arg(id) AND deleted_at IS NULL;

--- a/pkg/db/queries/deployment_find_with_environment.sql
+++ b/pkg/db/queries/deployment_find_with_environment.sql
@@ -2,4 +2,4 @@
 SELECT d.*, e.slug AS environment_slug, e.kind AS environment_kind
 FROM deployments d
 JOIN environments e ON d.environment_id = e.id
-WHERE d.id = sqlc.arg(id);
+WHERE d.id = sqlc.arg(id) AND d.deleted_at IS NULL;

--- a/pkg/db/queries/deployment_list.sql
+++ b/pkg/db/queries/deployment_list.sql
@@ -3,6 +3,7 @@
 -- status set as IN (NULL), which matches nothing.
 SELECT d.* FROM `deployments` d
 WHERE d.workspace_id = sqlc.arg(workspace_id)
+  AND d.deleted_at IS NULL
   AND (sqlc.arg(project_id) = '' OR d.project_id = sqlc.arg(project_id))
   AND (sqlc.arg(app_id) = '' OR d.app_id = sqlc.arg(app_id))
   AND (sqlc.arg(environment_id) = '' OR d.environment_id = sqlc.arg(environment_id))

--- a/pkg/db/queries/deployment_update_desired_state.sql
+++ b/pkg/db/queries/deployment_update_desired_state.sql
@@ -1,4 +1,4 @@
 -- name: UpdateDeploymentDesiredState :exec
 UPDATE deployments
 SET desired_state = ?, updated_at = ?
-WHERE id = ?;
+WHERE id = ? AND deleted_at IS NULL;

--- a/pkg/mysql/schema/deployments.sql
+++ b/pkg/mysql/schema/deployments.sql
@@ -2,6 +2,8 @@ CREATE TABLE `deployments` (
 	`pk` bigint unsigned AUTO_INCREMENT NOT NULL,
 	`id` varchar(48) COLLATE utf8mb4_0900_as_cs NOT NULL,
 	`k8s_name` varchar(255) NOT NULL,
+	`deleted_at` bigint,
+	`restored_at` bigint,
 	`workspace_id` varchar(48) COLLATE utf8mb4_0900_as_cs NOT NULL,
 	`project_id` varchar(48) COLLATE utf8mb4_0900_as_cs NOT NULL,
 	`environment_id` varchar(48) COLLATE utf8mb4_0900_as_cs NOT NULL,
@@ -46,6 +48,8 @@ CREATE INDEX `workspace_idx` ON `deployments` (`workspace_id`);
 CREATE INDEX `project_idx` ON `deployments` (`project_id`);
 
 CREATE INDEX `status_idx` ON `deployments` (`status`);
+
+CREATE INDEX `image_idx` ON `deployments` (`image`);
 
 CREATE INDEX `app_environment_status_created_idx` ON `deployments` (`app_id`,`environment_id`,`status`,`created_at`);
 

--- a/svc/api/routes/v2_deployments_list_deployments/200_test.go
+++ b/svc/api/routes/v2_deployments_list_deployments/200_test.go
@@ -39,6 +39,16 @@ func TestListWorkspaceWide(t *testing.T) {
 		want[dep.ID] = true
 	}
 
+	deleted := h.CreateDeployment(seed.CreateDeploymentRequest{
+		ID:            uid.New(uid.DeploymentPrefix),
+		WorkspaceID:   setup.Workspace.ID,
+		ProjectID:     setup.Project.ID,
+		AppID:         setup.App.ID,
+		EnvironmentID: setup.Environment.ID,
+	})
+	_, err := h.DB.RW().ExecContext(t.Context(), "UPDATE deployments SET deleted_at = 1 WHERE id = ?", deleted.ID)
+	require.NoError(t, err)
+
 	res := testutil.CallRoute[handler.Request, handler.Response](h, route, authHeaders(setup.RootKey), handler.Request{})
 	require.Equal(t, http.StatusOK, res.Status, "expected 200, received: %s", res.RawBody)
 	require.NotNil(t, res.Body)

--- a/svc/ctrl/integration/harness.go
+++ b/svc/ctrl/integration/harness.go
@@ -118,6 +118,7 @@ func (h *Harness) CreateDeployment(ctx context.Context, req CreateDeploymentRequ
 	err := h.DB.InsertDeployment(ctx, db.InsertDeploymentParams{
 		ID:                            deploymentID,
 		K8sName:                       k8sName,
+		Image:                         sql.NullString{},
 		WorkspaceID:                   workspaceID,
 		ProjectID:                     project.ID,
 		AppID:                         app.ID,

--- a/svc/ctrl/integration/seed/seed.go
+++ b/svc/ctrl/integration/seed/seed.go
@@ -416,6 +416,7 @@ func (s *Seeder) CreateDeployment(ctx context.Context, req CreateDeploymentReque
 	err := s.DB.InsertDeployment(ctx, db.InsertDeploymentParams{
 		ID:                            id,
 		K8sName:                       uid.New("k8s"),
+		Image:                         sql.NullString{},
 		WorkspaceID:                   req.WorkspaceID,
 		ProjectID:                     req.ProjectID,
 		AppID:                         req.AppID,

--- a/svc/ctrl/internal/db/bulk_deployment_insert.sql_generated.go
+++ b/svc/ctrl/internal/db/bulk_deployment_insert.sql_generated.go
@@ -9,7 +9,7 @@ import (
 )
 
 // bulkInsertDeployment is the base query for bulk insert
-const bulkInsertDeployment = `INSERT INTO ` + "`" + `deployments` + "`" + ` ( id, k8s_name, workspace_id, project_id, app_id, environment_id, git_commit_sha, git_branch, sentinel_config, git_commit_message, git_commit_author_handle, git_commit_author_avatar_url, git_commit_timestamp, encrypted_environment_variables, command, status, cpu_millicores, memory_mib, storage_mib, port, shutdown_signal, upstream_protocol, healthcheck, pr_number, fork_repository_full_name, ` + "`" + `trigger` + "`" + `, triggered_by, trigger_reason, created_at, updated_at ) VALUES %s`
+const bulkInsertDeployment = `INSERT INTO ` + "`" + `deployments` + "`" + ` ( id, k8s_name, image, workspace_id, project_id, app_id, environment_id, git_commit_sha, git_branch, sentinel_config, git_commit_message, git_commit_author_handle, git_commit_author_avatar_url, git_commit_timestamp, encrypted_environment_variables, command, status, cpu_millicores, memory_mib, storage_mib, port, shutdown_signal, upstream_protocol, healthcheck, pr_number, fork_repository_full_name, ` + "`" + `trigger` + "`" + `, triggered_by, trigger_reason, created_at, updated_at ) VALUES %s`
 
 // InsertDeployments performs bulk insert in a single query
 
@@ -22,7 +22,7 @@ func (q *BulkQueries) InsertDeployments(ctx context.Context, args []InsertDeploy
 	// Build the bulk insert query
 	valueClauses := make([]string, len(args))
 	for i := range args {
-		valueClauses[i] = "( ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? )"
+		valueClauses[i] = "( ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? )"
 	}
 
 	bulkQuery := fmt.Sprintf(bulkInsertDeployment, strings.Join(valueClauses, ", "))
@@ -32,6 +32,7 @@ func (q *BulkQueries) InsertDeployments(ctx context.Context, args []InsertDeploy
 	for _, arg := range args {
 		allArgs = append(allArgs, arg.ID)
 		allArgs = append(allArgs, arg.K8sName)
+		allArgs = append(allArgs, arg.Image)
 		allArgs = append(allArgs, arg.WorkspaceID)
 		allArgs = append(allArgs, arg.ProjectID)
 		allArgs = append(allArgs, arg.AppID)

--- a/svc/ctrl/internal/db/deployment_find_by_id.sql_generated.go
+++ b/svc/ctrl/internal/db/deployment_find_by_id.sql_generated.go
@@ -10,12 +10,12 @@ import (
 )
 
 const findDeploymentById = `-- name: FindDeploymentById :one
-SELECT pk, id, k8s_name, workspace_id, project_id, environment_id, app_id, image, build_id, git_commit_sha, git_branch, git_commit_message, git_commit_author_handle, git_commit_author_avatar_url, git_commit_timestamp, sentinel_config, cpu_millicores, memory_mib, storage_mib, desired_state, encrypted_environment_variables, command, port, shutdown_signal, upstream_protocol, healthcheck, pr_number, fork_repository_full_name, github_deployment_id, invocation_id, status, ` + "`" + `trigger` + "`" + `, triggered_by, trigger_reason, created_at, updated_at FROM ` + "`" + `deployments` + "`" + ` WHERE id = ?
+SELECT pk, id, k8s_name, deleted_at, restored_at, workspace_id, project_id, environment_id, app_id, image, build_id, git_commit_sha, git_branch, git_commit_message, git_commit_author_handle, git_commit_author_avatar_url, git_commit_timestamp, sentinel_config, cpu_millicores, memory_mib, storage_mib, desired_state, encrypted_environment_variables, command, port, shutdown_signal, upstream_protocol, healthcheck, pr_number, fork_repository_full_name, github_deployment_id, invocation_id, status, ` + "`" + `trigger` + "`" + `, triggered_by, trigger_reason, created_at, updated_at FROM ` + "`" + `deployments` + "`" + ` WHERE id = ? AND deleted_at IS NULL
 `
 
 // FindDeploymentById
 //
-//	SELECT pk, id, k8s_name, workspace_id, project_id, environment_id, app_id, image, build_id, git_commit_sha, git_branch, git_commit_message, git_commit_author_handle, git_commit_author_avatar_url, git_commit_timestamp, sentinel_config, cpu_millicores, memory_mib, storage_mib, desired_state, encrypted_environment_variables, command, port, shutdown_signal, upstream_protocol, healthcheck, pr_number, fork_repository_full_name, github_deployment_id, invocation_id, status, `trigger`, triggered_by, trigger_reason, created_at, updated_at FROM `deployments` WHERE id = ?
+//	SELECT pk, id, k8s_name, deleted_at, restored_at, workspace_id, project_id, environment_id, app_id, image, build_id, git_commit_sha, git_branch, git_commit_message, git_commit_author_handle, git_commit_author_avatar_url, git_commit_timestamp, sentinel_config, cpu_millicores, memory_mib, storage_mib, desired_state, encrypted_environment_variables, command, port, shutdown_signal, upstream_protocol, healthcheck, pr_number, fork_repository_full_name, github_deployment_id, invocation_id, status, `trigger`, triggered_by, trigger_reason, created_at, updated_at FROM `deployments` WHERE id = ? AND deleted_at IS NULL
 func (q *Queries) FindDeploymentById(ctx context.Context, id string) (Deployment, error) {
 	row := q.db.QueryRowContext(ctx, findDeploymentById, id)
 	var i Deployment
@@ -23,6 +23,8 @@ func (q *Queries) FindDeploymentById(ctx context.Context, id string) (Deployment
 		&i.Pk,
 		&i.ID,
 		&i.K8sName,
+		&i.DeletedAt,
+		&i.RestoredAt,
 		&i.WorkspaceID,
 		&i.ProjectID,
 		&i.EnvironmentID,

--- a/svc/ctrl/internal/db/deployment_find_by_k8s_name.sql_generated.go
+++ b/svc/ctrl/internal/db/deployment_find_by_k8s_name.sql_generated.go
@@ -10,12 +10,12 @@ import (
 )
 
 const findDeploymentByK8sName = `-- name: FindDeploymentByK8sName :one
-SELECT pk, id, k8s_name, workspace_id, project_id, environment_id, app_id, image, build_id, git_commit_sha, git_branch, git_commit_message, git_commit_author_handle, git_commit_author_avatar_url, git_commit_timestamp, sentinel_config, cpu_millicores, memory_mib, storage_mib, desired_state, encrypted_environment_variables, command, port, shutdown_signal, upstream_protocol, healthcheck, pr_number, fork_repository_full_name, github_deployment_id, invocation_id, status, ` + "`" + `trigger` + "`" + `, triggered_by, trigger_reason, created_at, updated_at FROM ` + "`" + `deployments` + "`" + ` WHERE k8s_name = ?
+SELECT pk, id, k8s_name, deleted_at, restored_at, workspace_id, project_id, environment_id, app_id, image, build_id, git_commit_sha, git_branch, git_commit_message, git_commit_author_handle, git_commit_author_avatar_url, git_commit_timestamp, sentinel_config, cpu_millicores, memory_mib, storage_mib, desired_state, encrypted_environment_variables, command, port, shutdown_signal, upstream_protocol, healthcheck, pr_number, fork_repository_full_name, github_deployment_id, invocation_id, status, ` + "`" + `trigger` + "`" + `, triggered_by, trigger_reason, created_at, updated_at FROM ` + "`" + `deployments` + "`" + ` WHERE k8s_name = ? AND deleted_at IS NULL
 `
 
 // FindDeploymentByK8sName
 //
-//	SELECT pk, id, k8s_name, workspace_id, project_id, environment_id, app_id, image, build_id, git_commit_sha, git_branch, git_commit_message, git_commit_author_handle, git_commit_author_avatar_url, git_commit_timestamp, sentinel_config, cpu_millicores, memory_mib, storage_mib, desired_state, encrypted_environment_variables, command, port, shutdown_signal, upstream_protocol, healthcheck, pr_number, fork_repository_full_name, github_deployment_id, invocation_id, status, `trigger`, triggered_by, trigger_reason, created_at, updated_at FROM `deployments` WHERE k8s_name = ?
+//	SELECT pk, id, k8s_name, deleted_at, restored_at, workspace_id, project_id, environment_id, app_id, image, build_id, git_commit_sha, git_branch, git_commit_message, git_commit_author_handle, git_commit_author_avatar_url, git_commit_timestamp, sentinel_config, cpu_millicores, memory_mib, storage_mib, desired_state, encrypted_environment_variables, command, port, shutdown_signal, upstream_protocol, healthcheck, pr_number, fork_repository_full_name, github_deployment_id, invocation_id, status, `trigger`, triggered_by, trigger_reason, created_at, updated_at FROM `deployments` WHERE k8s_name = ? AND deleted_at IS NULL
 func (q *Queries) FindDeploymentByK8sName(ctx context.Context, k8sName string) (Deployment, error) {
 	row := q.db.QueryRowContext(ctx, findDeploymentByK8sName, k8sName)
 	var i Deployment
@@ -23,6 +23,8 @@ func (q *Queries) FindDeploymentByK8sName(ctx context.Context, k8sName string) (
 		&i.Pk,
 		&i.ID,
 		&i.K8sName,
+		&i.DeletedAt,
+		&i.RestoredAt,
 		&i.WorkspaceID,
 		&i.ProjectID,
 		&i.EnvironmentID,

--- a/svc/ctrl/internal/db/deployment_find_latest_ready_by_app_and_env.sql_generated.go
+++ b/svc/ctrl/internal/db/deployment_find_latest_ready_by_app_and_env.sql_generated.go
@@ -13,6 +13,7 @@ const findLatestReadyDeploymentByAppAndEnv = `-- name: FindLatestReadyDeployment
 SELECT id
 FROM deployments
 WHERE app_id = ?
+  AND deleted_at IS NULL
   AND environment_id = ?
   AND status = 'ready'
   AND id != ?
@@ -31,6 +32,7 @@ type FindLatestReadyDeploymentByAppAndEnvParams struct {
 //	SELECT id
 //	FROM deployments
 //	WHERE app_id = ?
+//	  AND deleted_at IS NULL
 //	  AND environment_id = ?
 //	  AND status = 'ready'
 //	  AND id != ?

--- a/svc/ctrl/internal/db/deployment_find_with_environment_and_app.sql_generated.go
+++ b/svc/ctrl/internal/db/deployment_find_with_environment_and_app.sql_generated.go
@@ -13,17 +13,19 @@ import (
 )
 
 const findDeploymentWithEnvironmentAndApp = `-- name: FindDeploymentWithEnvironmentAndApp :one
-SELECT d.pk, d.id, d.k8s_name, d.workspace_id, d.project_id, d.environment_id, d.app_id, d.image, d.build_id, d.git_commit_sha, d.git_branch, d.git_commit_message, d.git_commit_author_handle, d.git_commit_author_avatar_url, d.git_commit_timestamp, d.sentinel_config, d.cpu_millicores, d.memory_mib, d.storage_mib, d.desired_state, d.encrypted_environment_variables, d.command, d.port, d.shutdown_signal, d.upstream_protocol, d.healthcheck, d.pr_number, d.fork_repository_full_name, d.github_deployment_id, d.invocation_id, d.status, d.` + "`" + `trigger` + "`" + `, d.triggered_by, d.trigger_reason, d.created_at, d.updated_at, e.slug AS environment_slug, e.kind AS environment_kind, a.current_deployment_id, a.is_rolled_back
+SELECT d.pk, d.id, d.k8s_name, d.deleted_at, d.restored_at, d.workspace_id, d.project_id, d.environment_id, d.app_id, d.image, d.build_id, d.git_commit_sha, d.git_branch, d.git_commit_message, d.git_commit_author_handle, d.git_commit_author_avatar_url, d.git_commit_timestamp, d.sentinel_config, d.cpu_millicores, d.memory_mib, d.storage_mib, d.desired_state, d.encrypted_environment_variables, d.command, d.port, d.shutdown_signal, d.upstream_protocol, d.healthcheck, d.pr_number, d.fork_repository_full_name, d.github_deployment_id, d.invocation_id, d.status, d.` + "`" + `trigger` + "`" + `, d.triggered_by, d.trigger_reason, d.created_at, d.updated_at, e.slug AS environment_slug, e.kind AS environment_kind, a.current_deployment_id, a.is_rolled_back
 FROM deployments d
 JOIN environments e ON e.id = d.environment_id
 JOIN apps a ON a.id = d.app_id
-WHERE d.id = ?
+WHERE d.id = ? AND d.deleted_at IS NULL
 `
 
 type FindDeploymentWithEnvironmentAndAppRow struct {
 	Pk                            uint64                            `db:"pk"`
 	ID                            string                            `db:"id"`
 	K8sName                       string                            `db:"k8s_name"`
+	DeletedAt                     sql.NullInt64                     `db:"deleted_at"`
+	RestoredAt                    sql.NullInt64                     `db:"restored_at"`
 	WorkspaceID                   string                            `db:"workspace_id"`
 	ProjectID                     string                            `db:"project_id"`
 	EnvironmentID                 string                            `db:"environment_id"`
@@ -65,11 +67,11 @@ type FindDeploymentWithEnvironmentAndAppRow struct {
 
 // FindDeploymentWithEnvironmentAndApp
 //
-//	SELECT d.pk, d.id, d.k8s_name, d.workspace_id, d.project_id, d.environment_id, d.app_id, d.image, d.build_id, d.git_commit_sha, d.git_branch, d.git_commit_message, d.git_commit_author_handle, d.git_commit_author_avatar_url, d.git_commit_timestamp, d.sentinel_config, d.cpu_millicores, d.memory_mib, d.storage_mib, d.desired_state, d.encrypted_environment_variables, d.command, d.port, d.shutdown_signal, d.upstream_protocol, d.healthcheck, d.pr_number, d.fork_repository_full_name, d.github_deployment_id, d.invocation_id, d.status, d.`trigger`, d.triggered_by, d.trigger_reason, d.created_at, d.updated_at, e.slug AS environment_slug, e.kind AS environment_kind, a.current_deployment_id, a.is_rolled_back
+//	SELECT d.pk, d.id, d.k8s_name, d.deleted_at, d.restored_at, d.workspace_id, d.project_id, d.environment_id, d.app_id, d.image, d.build_id, d.git_commit_sha, d.git_branch, d.git_commit_message, d.git_commit_author_handle, d.git_commit_author_avatar_url, d.git_commit_timestamp, d.sentinel_config, d.cpu_millicores, d.memory_mib, d.storage_mib, d.desired_state, d.encrypted_environment_variables, d.command, d.port, d.shutdown_signal, d.upstream_protocol, d.healthcheck, d.pr_number, d.fork_repository_full_name, d.github_deployment_id, d.invocation_id, d.status, d.`trigger`, d.triggered_by, d.trigger_reason, d.created_at, d.updated_at, e.slug AS environment_slug, e.kind AS environment_kind, a.current_deployment_id, a.is_rolled_back
 //	FROM deployments d
 //	JOIN environments e ON e.id = d.environment_id
 //	JOIN apps a ON a.id = d.app_id
-//	WHERE d.id = ?
+//	WHERE d.id = ? AND d.deleted_at IS NULL
 func (q *Queries) FindDeploymentWithEnvironmentAndApp(ctx context.Context, id string) (FindDeploymentWithEnvironmentAndAppRow, error) {
 	row := q.db.QueryRowContext(ctx, findDeploymentWithEnvironmentAndApp, id)
 	var i FindDeploymentWithEnvironmentAndAppRow
@@ -77,6 +79,8 @@ func (q *Queries) FindDeploymentWithEnvironmentAndApp(ctx context.Context, id st
 		&i.Pk,
 		&i.ID,
 		&i.K8sName,
+		&i.DeletedAt,
+		&i.RestoredAt,
 		&i.WorkspaceID,
 		&i.ProjectID,
 		&i.EnvironmentID,

--- a/svc/ctrl/internal/db/deployment_gc_delete.sql_generated.go
+++ b/svc/ctrl/internal/db/deployment_gc_delete.sql_generated.go
@@ -100,3 +100,78 @@ func (q *Queries) DeleteOpenAPISpecsByDeploymentID(ctx context.Context, deployme
 	_, err := q.db.ExecContext(ctx, deleteOpenAPISpecsByDeploymentID, deploymentID)
 	return err
 }
+
+const deploymentExistsIncludingDeleted = `-- name: DeploymentExistsIncludingDeleted :one
+SELECT EXISTS(SELECT 1 FROM deployments WHERE id = ?)
+`
+
+// DeploymentExistsIncludingDeleted
+//
+//	SELECT EXISTS(SELECT 1 FROM deployments WHERE id = ?)
+func (q *Queries) DeploymentExistsIncludingDeleted(ctx context.Context, deploymentID string) (bool, error) {
+	row := q.db.QueryRowContext(ctx, deploymentExistsIncludingDeleted, deploymentID)
+	var exists bool
+	err := row.Scan(&exists)
+	return exists, err
+}
+
+const deploymentImageExistsIncludingDeleted = `-- name: DeploymentImageExistsIncludingDeleted :one
+SELECT EXISTS(SELECT 1 FROM deployments WHERE image = ?)
+`
+
+// DeploymentImageExistsIncludingDeleted
+//
+//	SELECT EXISTS(SELECT 1 FROM deployments WHERE image = ?)
+func (q *Queries) DeploymentImageExistsIncludingDeleted(ctx context.Context, image sql.NullString) (bool, error) {
+	row := q.db.QueryRowContext(ctx, deploymentImageExistsIncludingDeleted, image)
+	var exists bool
+	err := row.Scan(&exists)
+	return exists, err
+}
+
+const restoreDeployment = `-- name: RestoreDeployment :execrows
+UPDATE deployments SET deleted_at = NULL, restored_at = ?
+WHERE id = ?
+  AND deleted_at > ?
+`
+
+type RestoreDeploymentParams struct {
+	RestoredAt     sql.NullInt64 `db:"restored_at"`
+	DeploymentID   string        `db:"deployment_id"`
+	RecoveryCutoff sql.NullInt64 `db:"recovery_cutoff"`
+}
+
+// RestoreDeployment
+//
+//	UPDATE deployments SET deleted_at = NULL, restored_at = ?
+//	WHERE id = ?
+//	  AND deleted_at > ?
+func (q *Queries) RestoreDeployment(ctx context.Context, arg RestoreDeploymentParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, restoreDeployment, arg.RestoredAt, arg.DeploymentID, arg.RecoveryCutoff)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+const softDeleteDeploymentForGC = `-- name: SoftDeleteDeploymentForGC :execrows
+UPDATE deployments SET deleted_at = ?
+WHERE id = ? AND deleted_at IS NULL
+`
+
+type SoftDeleteDeploymentForGCParams struct {
+	DeletedAt    sql.NullInt64 `db:"deleted_at"`
+	DeploymentID string        `db:"deployment_id"`
+}
+
+// SoftDeleteDeploymentForGC
+//
+//	UPDATE deployments SET deleted_at = ?
+//	WHERE id = ? AND deleted_at IS NULL
+func (q *Queries) SoftDeleteDeploymentForGC(ctx context.Context, arg SoftDeleteDeploymentForGCParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, softDeleteDeploymentForGC, arg.DeletedAt, arg.DeploymentID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}

--- a/svc/ctrl/internal/db/deployment_gc_find_eligible.sql_generated.go
+++ b/svc/ctrl/internal/db/deployment_gc_find_eligible.sql_generated.go
@@ -11,7 +11,7 @@ import (
 )
 
 const findDeploymentGCEligible = `-- name: FindDeploymentGCEligible :one
-SELECT d.id, d.image
+SELECT d.id, d.image, d.deleted_at
 FROM deployments d
 JOIN environments e ON e.id = d.environment_id
 JOIN apps a ON a.id = d.app_id
@@ -29,14 +29,16 @@ WHERE d.id = ?
       AND fr.sticky IN ('branch', 'environment', 'live')
   )
   AND (
+    d.deleted_at <= ?
+    OR (d.deleted_at IS NULL AND (
     (
       e.kind = 'preview'
-      AND COALESCE(d.updated_at, d.created_at) < CAST(? AS SIGNED)
+      AND GREATEST(COALESCE(d.updated_at, d.created_at), COALESCE(d.restored_at, 0)) < CAST(? AS SIGNED)
     )
     OR
     (
       e.kind = 'production'
-      AND d.created_at < ?
+      AND GREATEST(d.created_at, COALESCE(d.restored_at, 0)) < CAST(? AS SIGNED)
       AND (
         d.status != 'stopped'
         OR (
@@ -44,6 +46,7 @@ WHERE d.id = ?
           FROM deployments newer
           WHERE newer.app_id = d.app_id
             AND newer.environment_id = d.environment_id
+            AND newer.deleted_at IS NULL
             AND newer.status IN ('ready', 'stopped')
             AND (
               newer.created_at > d.created_at
@@ -52,25 +55,29 @@ WHERE d.id = ?
         ) >= CAST(? AS UNSIGNED)
       )
     )
+    ))
   )
+FOR UPDATE
 `
 
 type FindDeploymentGCEligibleParams struct {
-	DeploymentID     string `db:"deployment_id"`
-	PreviewCutoff    int64  `db:"preview_cutoff"`
-	ProductionCutoff int64  `db:"production_cutoff"`
-	KeepSuccessful   int64  `db:"keep_successful"`
+	DeploymentID     string        `db:"deployment_id"`
+	RecoveryCutoff   sql.NullInt64 `db:"recovery_cutoff"`
+	PreviewCutoff    int64         `db:"preview_cutoff"`
+	ProductionCutoff int64         `db:"production_cutoff"`
+	KeepSuccessful   int64         `db:"keep_successful"`
 }
 
 type FindDeploymentGCEligibleRow struct {
-	ID    string         `db:"id"`
-	Image sql.NullString `db:"image"`
+	ID        string         `db:"id"`
+	Image     sql.NullString `db:"image"`
+	DeletedAt sql.NullInt64  `db:"deleted_at"`
 }
 
 // Re-evaluates a deployment immediately before destructive cleanup. This must
 // remain equivalent to ListDeploymentGCCandidates except for pagination.
 //
-//	SELECT d.id, d.image
+//	SELECT d.id, d.image, d.deleted_at
 //	FROM deployments d
 //	JOIN environments e ON e.id = d.environment_id
 //	JOIN apps a ON a.id = d.app_id
@@ -88,14 +95,16 @@ type FindDeploymentGCEligibleRow struct {
 //	      AND fr.sticky IN ('branch', 'environment', 'live')
 //	  )
 //	  AND (
+//	    d.deleted_at <= ?
+//	    OR (d.deleted_at IS NULL AND (
 //	    (
 //	      e.kind = 'preview'
-//	      AND COALESCE(d.updated_at, d.created_at) < CAST(? AS SIGNED)
+//	      AND GREATEST(COALESCE(d.updated_at, d.created_at), COALESCE(d.restored_at, 0)) < CAST(? AS SIGNED)
 //	    )
 //	    OR
 //	    (
 //	      e.kind = 'production'
-//	      AND d.created_at < ?
+//	      AND GREATEST(d.created_at, COALESCE(d.restored_at, 0)) < CAST(? AS SIGNED)
 //	      AND (
 //	        d.status != 'stopped'
 //	        OR (
@@ -103,6 +112,7 @@ type FindDeploymentGCEligibleRow struct {
 //	          FROM deployments newer
 //	          WHERE newer.app_id = d.app_id
 //	            AND newer.environment_id = d.environment_id
+//	            AND newer.deleted_at IS NULL
 //	            AND newer.status IN ('ready', 'stopped')
 //	            AND (
 //	              newer.created_at > d.created_at
@@ -111,15 +121,18 @@ type FindDeploymentGCEligibleRow struct {
 //	        ) >= CAST(? AS UNSIGNED)
 //	      )
 //	    )
+//	    ))
 //	  )
+//	FOR UPDATE
 func (q *Queries) FindDeploymentGCEligible(ctx context.Context, arg FindDeploymentGCEligibleParams) (FindDeploymentGCEligibleRow, error) {
 	row := q.db.QueryRowContext(ctx, findDeploymentGCEligible,
 		arg.DeploymentID,
+		arg.RecoveryCutoff,
 		arg.PreviewCutoff,
 		arg.ProductionCutoff,
 		arg.KeepSuccessful,
 	)
 	var i FindDeploymentGCEligibleRow
-	err := row.Scan(&i.ID, &i.Image)
+	err := row.Scan(&i.ID, &i.Image, &i.DeletedAt)
 	return i, err
 }

--- a/svc/ctrl/internal/db/deployment_gc_list_candidates.sql_generated.go
+++ b/svc/ctrl/internal/db/deployment_gc_list_candidates.sql_generated.go
@@ -7,6 +7,7 @@ package db
 
 import (
 	"context"
+	"database/sql"
 )
 
 const listDeploymentGCCandidates = `-- name: ListDeploymentGCCandidates :many
@@ -28,14 +29,16 @@ WHERE d.pk > ?
       AND fr.sticky IN ('branch', 'environment', 'live')
   )
   AND (
+    d.deleted_at <= ?
+    OR (d.deleted_at IS NULL AND (
     (
       e.kind = 'preview'
-      AND COALESCE(d.updated_at, d.created_at) < CAST(? AS SIGNED)
+      AND GREATEST(COALESCE(d.updated_at, d.created_at), COALESCE(d.restored_at, 0)) < CAST(? AS SIGNED)
     )
     OR
     (
       e.kind = 'production'
-      AND d.created_at < ?
+      AND GREATEST(d.created_at, COALESCE(d.restored_at, 0)) < CAST(? AS SIGNED)
       AND (
         d.status != 'stopped'
         OR (
@@ -43,6 +46,7 @@ WHERE d.pk > ?
           FROM deployments newer
           WHERE newer.app_id = d.app_id
             AND newer.environment_id = d.environment_id
+            AND newer.deleted_at IS NULL
             AND newer.status IN ('ready', 'stopped')
             AND (
               newer.created_at > d.created_at
@@ -51,17 +55,19 @@ WHERE d.pk > ?
         ) >= CAST(? AS UNSIGNED)
       )
     )
+    ))
   )
 ORDER BY d.pk
 LIMIT ?
 `
 
 type ListDeploymentGCCandidatesParams struct {
-	PaginationCursor uint64 `db:"pagination_cursor"`
-	PreviewCutoff    int64  `db:"preview_cutoff"`
-	ProductionCutoff int64  `db:"production_cutoff"`
-	KeepSuccessful   int64  `db:"keep_successful"`
-	Limit            int32  `db:"limit"`
+	PaginationCursor uint64        `db:"pagination_cursor"`
+	RecoveryCutoff   sql.NullInt64 `db:"recovery_cutoff"`
+	PreviewCutoff    int64         `db:"preview_cutoff"`
+	ProductionCutoff int64         `db:"production_cutoff"`
+	KeepSuccessful   int64         `db:"keep_successful"`
+	Limit            int32         `db:"limit"`
 }
 
 type ListDeploymentGCCandidatesRow struct {
@@ -91,14 +97,16 @@ type ListDeploymentGCCandidatesRow struct {
 //	      AND fr.sticky IN ('branch', 'environment', 'live')
 //	  )
 //	  AND (
+//	    d.deleted_at <= ?
+//	    OR (d.deleted_at IS NULL AND (
 //	    (
 //	      e.kind = 'preview'
-//	      AND COALESCE(d.updated_at, d.created_at) < CAST(? AS SIGNED)
+//	      AND GREATEST(COALESCE(d.updated_at, d.created_at), COALESCE(d.restored_at, 0)) < CAST(? AS SIGNED)
 //	    )
 //	    OR
 //	    (
 //	      e.kind = 'production'
-//	      AND d.created_at < ?
+//	      AND GREATEST(d.created_at, COALESCE(d.restored_at, 0)) < CAST(? AS SIGNED)
 //	      AND (
 //	        d.status != 'stopped'
 //	        OR (
@@ -106,6 +114,7 @@ type ListDeploymentGCCandidatesRow struct {
 //	          FROM deployments newer
 //	          WHERE newer.app_id = d.app_id
 //	            AND newer.environment_id = d.environment_id
+//	            AND newer.deleted_at IS NULL
 //	            AND newer.status IN ('ready', 'stopped')
 //	            AND (
 //	              newer.created_at > d.created_at
@@ -114,12 +123,14 @@ type ListDeploymentGCCandidatesRow struct {
 //	        ) >= CAST(? AS UNSIGNED)
 //	      )
 //	    )
+//	    ))
 //	  )
 //	ORDER BY d.pk
 //	LIMIT ?
 func (q *Queries) ListDeploymentGCCandidates(ctx context.Context, arg ListDeploymentGCCandidatesParams) ([]ListDeploymentGCCandidatesRow, error) {
 	rows, err := q.db.QueryContext(ctx, listDeploymentGCCandidates,
 		arg.PaginationCursor,
+		arg.RecoveryCutoff,
 		arg.PreviewCutoff,
 		arg.ProductionCutoff,
 		arg.KeepSuccessful,

--- a/svc/ctrl/internal/db/deployment_insert.sql_generated.go
+++ b/svc/ctrl/internal/db/deployment_insert.sql_generated.go
@@ -16,6 +16,7 @@ const insertDeployment = `-- name: InsertDeployment :exec
 INSERT INTO ` + "`" + `deployments` + "`" + ` (
     id,
     k8s_name,
+    image,
     workspace_id,
     project_id,
     app_id,
@@ -75,6 +76,7 @@ VALUES (
     ?,
     ?,
     ?,
+    ?,
     ?
 )
 `
@@ -82,6 +84,7 @@ VALUES (
 type InsertDeploymentParams struct {
 	ID                            string                      `db:"id"`
 	K8sName                       string                      `db:"k8s_name"`
+	Image                         sql.NullString              `db:"image"`
 	WorkspaceID                   string                      `db:"workspace_id"`
 	ProjectID                     string                      `db:"project_id"`
 	AppID                         string                      `db:"app_id"`
@@ -117,6 +120,7 @@ type InsertDeploymentParams struct {
 //	INSERT INTO `deployments` (
 //	    id,
 //	    k8s_name,
+//	    image,
 //	    workspace_id,
 //	    project_id,
 //	    app_id,
@@ -176,12 +180,14 @@ type InsertDeploymentParams struct {
 //	    ?,
 //	    ?,
 //	    ?,
+//	    ?,
 //	    ?
 //	)
 func (q *Queries) InsertDeployment(ctx context.Context, arg InsertDeploymentParams) error {
 	_, err := q.db.ExecContext(ctx, insertDeployment,
 		arg.ID,
 		arg.K8sName,
+		arg.Image,
 		arg.WorkspaceID,
 		arg.ProjectID,
 		arg.AppID,

--- a/svc/ctrl/internal/db/deployment_list_by_environment_id_and_status.sql_generated.go
+++ b/svc/ctrl/internal/db/deployment_list_by_environment_id_and_status.sql_generated.go
@@ -13,8 +13,9 @@ import (
 )
 
 const listDeploymentsByEnvironmentIdAndStatus = `-- name: ListDeploymentsByEnvironmentIdAndStatus :many
-SELECT pk, id, k8s_name, workspace_id, project_id, environment_id, app_id, image, build_id, git_commit_sha, git_branch, git_commit_message, git_commit_author_handle, git_commit_author_avatar_url, git_commit_timestamp, sentinel_config, cpu_millicores, memory_mib, storage_mib, desired_state, encrypted_environment_variables, command, port, shutdown_signal, upstream_protocol, healthcheck, pr_number, fork_repository_full_name, github_deployment_id, invocation_id, status, ` + "`" + `trigger` + "`" + `, triggered_by, trigger_reason, created_at, updated_at FROM ` + "`" + `deployments` + "`" + `
+SELECT pk, id, k8s_name, deleted_at, restored_at, workspace_id, project_id, environment_id, app_id, image, build_id, git_commit_sha, git_branch, git_commit_message, git_commit_author_handle, git_commit_author_avatar_url, git_commit_timestamp, sentinel_config, cpu_millicores, memory_mib, storage_mib, desired_state, encrypted_environment_variables, command, port, shutdown_signal, upstream_protocol, healthcheck, pr_number, fork_repository_full_name, github_deployment_id, invocation_id, status, ` + "`" + `trigger` + "`" + `, triggered_by, trigger_reason, created_at, updated_at FROM ` + "`" + `deployments` + "`" + `
 WHERE environment_id = ?
+  AND deleted_at IS NULL
   AND status = ?
   AND created_at < ?
   AND (updated_at IS null OR updated_at < ? )
@@ -29,8 +30,9 @@ type ListDeploymentsByEnvironmentIdAndStatusParams struct {
 
 // ListDeploymentsByEnvironmentIdAndStatus
 //
-//	SELECT pk, id, k8s_name, workspace_id, project_id, environment_id, app_id, image, build_id, git_commit_sha, git_branch, git_commit_message, git_commit_author_handle, git_commit_author_avatar_url, git_commit_timestamp, sentinel_config, cpu_millicores, memory_mib, storage_mib, desired_state, encrypted_environment_variables, command, port, shutdown_signal, upstream_protocol, healthcheck, pr_number, fork_repository_full_name, github_deployment_id, invocation_id, status, `trigger`, triggered_by, trigger_reason, created_at, updated_at FROM `deployments`
+//	SELECT pk, id, k8s_name, deleted_at, restored_at, workspace_id, project_id, environment_id, app_id, image, build_id, git_commit_sha, git_branch, git_commit_message, git_commit_author_handle, git_commit_author_avatar_url, git_commit_timestamp, sentinel_config, cpu_millicores, memory_mib, storage_mib, desired_state, encrypted_environment_variables, command, port, shutdown_signal, upstream_protocol, healthcheck, pr_number, fork_repository_full_name, github_deployment_id, invocation_id, status, `trigger`, triggered_by, trigger_reason, created_at, updated_at FROM `deployments`
 //	WHERE environment_id = ?
+//	  AND deleted_at IS NULL
 //	  AND status = ?
 //	  AND created_at < ?
 //	  AND (updated_at IS null OR updated_at < ? )
@@ -52,6 +54,8 @@ func (q *Queries) ListDeploymentsByEnvironmentIdAndStatus(ctx context.Context, a
 			&i.Pk,
 			&i.ID,
 			&i.K8sName,
+			&i.DeletedAt,
+			&i.RestoredAt,
 			&i.WorkspaceID,
 			&i.ProjectID,
 			&i.EnvironmentID,

--- a/svc/ctrl/internal/db/deployment_topology_find_by_deployment_and_region.sql_generated.go
+++ b/svc/ctrl/internal/db/deployment_topology_find_by_deployment_and_region.sql_generated.go
@@ -13,7 +13,7 @@ import (
 const findDeploymentTopologyByDeploymentAndRegion = `-- name: FindDeploymentTopologyByDeploymentAndRegion :one
 SELECT
     dt.pk, dt.workspace_id, dt.deployment_id, dt.region_id, dt.autoscaling_replicas_min, dt.autoscaling_replicas_max, dt.autoscaling_threshold_cpu, dt.autoscaling_threshold_memory, dt.desired_status, dt.created_at, dt.updated_at,
-    d.pk, d.id, d.k8s_name, d.workspace_id, d.project_id, d.environment_id, d.app_id, d.image, d.build_id, d.git_commit_sha, d.git_branch, d.git_commit_message, d.git_commit_author_handle, d.git_commit_author_avatar_url, d.git_commit_timestamp, d.sentinel_config, d.cpu_millicores, d.memory_mib, d.storage_mib, d.desired_state, d.encrypted_environment_variables, d.command, d.port, d.shutdown_signal, d.upstream_protocol, d.healthcheck, d.pr_number, d.fork_repository_full_name, d.github_deployment_id, d.invocation_id, d.status, d.` + "`" + `trigger` + "`" + `, d.triggered_by, d.trigger_reason, d.created_at, d.updated_at,
+    d.pk, d.id, d.k8s_name, d.deleted_at, d.restored_at, d.workspace_id, d.project_id, d.environment_id, d.app_id, d.image, d.build_id, d.git_commit_sha, d.git_branch, d.git_commit_message, d.git_commit_author_handle, d.git_commit_author_avatar_url, d.git_commit_timestamp, d.sentinel_config, d.cpu_millicores, d.memory_mib, d.storage_mib, d.desired_state, d.encrypted_environment_variables, d.command, d.port, d.shutdown_signal, d.upstream_protocol, d.healthcheck, d.pr_number, d.fork_repository_full_name, d.github_deployment_id, d.invocation_id, d.status, d.` + "`" + `trigger` + "`" + `, d.triggered_by, d.trigger_reason, d.created_at, d.updated_at,
     w.k8s_namespace,
     e.slug AS environment_slug,
     r.name AS region_name,
@@ -25,6 +25,7 @@ INNER JOIN ` + "`" + `regions` + "`" + ` r ON r.id = dt.region_id
 INNER JOIN ` + "`" + `environments` + "`" + ` e ON e.id = d.environment_id
 LEFT JOIN ` + "`" + `github_repo_connections` + "`" + ` grc ON grc.app_id = d.app_id
 WHERE dt.deployment_id = ? AND dt.region_id = ?
+  AND d.deleted_at IS NULL
 LIMIT 1
 `
 
@@ -47,7 +48,7 @@ type FindDeploymentTopologyByDeploymentAndRegionRow struct {
 //
 //	SELECT
 //	    dt.pk, dt.workspace_id, dt.deployment_id, dt.region_id, dt.autoscaling_replicas_min, dt.autoscaling_replicas_max, dt.autoscaling_threshold_cpu, dt.autoscaling_threshold_memory, dt.desired_status, dt.created_at, dt.updated_at,
-//	    d.pk, d.id, d.k8s_name, d.workspace_id, d.project_id, d.environment_id, d.app_id, d.image, d.build_id, d.git_commit_sha, d.git_branch, d.git_commit_message, d.git_commit_author_handle, d.git_commit_author_avatar_url, d.git_commit_timestamp, d.sentinel_config, d.cpu_millicores, d.memory_mib, d.storage_mib, d.desired_state, d.encrypted_environment_variables, d.command, d.port, d.shutdown_signal, d.upstream_protocol, d.healthcheck, d.pr_number, d.fork_repository_full_name, d.github_deployment_id, d.invocation_id, d.status, d.`trigger`, d.triggered_by, d.trigger_reason, d.created_at, d.updated_at,
+//	    d.pk, d.id, d.k8s_name, d.deleted_at, d.restored_at, d.workspace_id, d.project_id, d.environment_id, d.app_id, d.image, d.build_id, d.git_commit_sha, d.git_branch, d.git_commit_message, d.git_commit_author_handle, d.git_commit_author_avatar_url, d.git_commit_timestamp, d.sentinel_config, d.cpu_millicores, d.memory_mib, d.storage_mib, d.desired_state, d.encrypted_environment_variables, d.command, d.port, d.shutdown_signal, d.upstream_protocol, d.healthcheck, d.pr_number, d.fork_repository_full_name, d.github_deployment_id, d.invocation_id, d.status, d.`trigger`, d.triggered_by, d.trigger_reason, d.created_at, d.updated_at,
 //	    w.k8s_namespace,
 //	    e.slug AS environment_slug,
 //	    r.name AS region_name,
@@ -59,6 +60,7 @@ type FindDeploymentTopologyByDeploymentAndRegionRow struct {
 //	INNER JOIN `environments` e ON e.id = d.environment_id
 //	LEFT JOIN `github_repo_connections` grc ON grc.app_id = d.app_id
 //	WHERE dt.deployment_id = ? AND dt.region_id = ?
+//	  AND d.deleted_at IS NULL
 //	LIMIT 1
 func (q *Queries) FindDeploymentTopologyByDeploymentAndRegion(ctx context.Context, arg FindDeploymentTopologyByDeploymentAndRegionParams) (FindDeploymentTopologyByDeploymentAndRegionRow, error) {
 	row := q.db.QueryRowContext(ctx, findDeploymentTopologyByDeploymentAndRegion, arg.DeploymentID, arg.RegionID)
@@ -78,6 +80,8 @@ func (q *Queries) FindDeploymentTopologyByDeploymentAndRegion(ctx context.Contex
 		&i.Deployment.Pk,
 		&i.Deployment.ID,
 		&i.Deployment.K8sName,
+		&i.Deployment.DeletedAt,
+		&i.Deployment.RestoredAt,
 		&i.Deployment.WorkspaceID,
 		&i.Deployment.ProjectID,
 		&i.Deployment.EnvironmentID,

--- a/svc/ctrl/internal/db/deployment_topology_list_all_by_region.sql_generated.go
+++ b/svc/ctrl/internal/db/deployment_topology_list_all_by_region.sql_generated.go
@@ -13,7 +13,7 @@ import (
 const listAllDeploymentTopologiesByRegion = `-- name: ListAllDeploymentTopologiesByRegion :many
 SELECT
     dt.pk, dt.workspace_id, dt.deployment_id, dt.region_id, dt.autoscaling_replicas_min, dt.autoscaling_replicas_max, dt.autoscaling_threshold_cpu, dt.autoscaling_threshold_memory, dt.desired_status, dt.created_at, dt.updated_at,
-    d.pk, d.id, d.k8s_name, d.workspace_id, d.project_id, d.environment_id, d.app_id, d.image, d.build_id, d.git_commit_sha, d.git_branch, d.git_commit_message, d.git_commit_author_handle, d.git_commit_author_avatar_url, d.git_commit_timestamp, d.sentinel_config, d.cpu_millicores, d.memory_mib, d.storage_mib, d.desired_state, d.encrypted_environment_variables, d.command, d.port, d.shutdown_signal, d.upstream_protocol, d.healthcheck, d.pr_number, d.fork_repository_full_name, d.github_deployment_id, d.invocation_id, d.status, d.` + "`" + `trigger` + "`" + `, d.triggered_by, d.trigger_reason, d.created_at, d.updated_at,
+    d.pk, d.id, d.k8s_name, d.deleted_at, d.restored_at, d.workspace_id, d.project_id, d.environment_id, d.app_id, d.image, d.build_id, d.git_commit_sha, d.git_branch, d.git_commit_message, d.git_commit_author_handle, d.git_commit_author_avatar_url, d.git_commit_timestamp, d.sentinel_config, d.cpu_millicores, d.memory_mib, d.storage_mib, d.desired_state, d.encrypted_environment_variables, d.command, d.port, d.shutdown_signal, d.upstream_protocol, d.healthcheck, d.pr_number, d.fork_repository_full_name, d.github_deployment_id, d.invocation_id, d.status, d.` + "`" + `trigger` + "`" + `, d.triggered_by, d.trigger_reason, d.created_at, d.updated_at,
     w.k8s_namespace,
     e.slug AS environment_slug,
     r.name AS region_name,
@@ -25,6 +25,7 @@ INNER JOIN ` + "`" + `regions` + "`" + ` r ON r.id = dt.region_id
 INNER JOIN ` + "`" + `environments` + "`" + ` e ON e.id = d.environment_id
 LEFT JOIN ` + "`" + `github_repo_connections` + "`" + ` grc ON grc.app_id = d.app_id
 WHERE r.id = ? AND dt.pk > ? AND dt.desired_status = 'running'
+  AND d.deleted_at IS NULL
 ORDER BY dt.pk ASC
 LIMIT ?
 `
@@ -49,7 +50,7 @@ type ListAllDeploymentTopologiesByRegionRow struct {
 //
 //	SELECT
 //	    dt.pk, dt.workspace_id, dt.deployment_id, dt.region_id, dt.autoscaling_replicas_min, dt.autoscaling_replicas_max, dt.autoscaling_threshold_cpu, dt.autoscaling_threshold_memory, dt.desired_status, dt.created_at, dt.updated_at,
-//	    d.pk, d.id, d.k8s_name, d.workspace_id, d.project_id, d.environment_id, d.app_id, d.image, d.build_id, d.git_commit_sha, d.git_branch, d.git_commit_message, d.git_commit_author_handle, d.git_commit_author_avatar_url, d.git_commit_timestamp, d.sentinel_config, d.cpu_millicores, d.memory_mib, d.storage_mib, d.desired_state, d.encrypted_environment_variables, d.command, d.port, d.shutdown_signal, d.upstream_protocol, d.healthcheck, d.pr_number, d.fork_repository_full_name, d.github_deployment_id, d.invocation_id, d.status, d.`trigger`, d.triggered_by, d.trigger_reason, d.created_at, d.updated_at,
+//	    d.pk, d.id, d.k8s_name, d.deleted_at, d.restored_at, d.workspace_id, d.project_id, d.environment_id, d.app_id, d.image, d.build_id, d.git_commit_sha, d.git_branch, d.git_commit_message, d.git_commit_author_handle, d.git_commit_author_avatar_url, d.git_commit_timestamp, d.sentinel_config, d.cpu_millicores, d.memory_mib, d.storage_mib, d.desired_state, d.encrypted_environment_variables, d.command, d.port, d.shutdown_signal, d.upstream_protocol, d.healthcheck, d.pr_number, d.fork_repository_full_name, d.github_deployment_id, d.invocation_id, d.status, d.`trigger`, d.triggered_by, d.trigger_reason, d.created_at, d.updated_at,
 //	    w.k8s_namespace,
 //	    e.slug AS environment_slug,
 //	    r.name AS region_name,
@@ -61,6 +62,7 @@ type ListAllDeploymentTopologiesByRegionRow struct {
 //	INNER JOIN `environments` e ON e.id = d.environment_id
 //	LEFT JOIN `github_repo_connections` grc ON grc.app_id = d.app_id
 //	WHERE r.id = ? AND dt.pk > ? AND dt.desired_status = 'running'
+//	  AND d.deleted_at IS NULL
 //	ORDER BY dt.pk ASC
 //	LIMIT ?
 func (q *Queries) ListAllDeploymentTopologiesByRegion(ctx context.Context, arg ListAllDeploymentTopologiesByRegionParams) ([]ListAllDeploymentTopologiesByRegionRow, error) {
@@ -87,6 +89,8 @@ func (q *Queries) ListAllDeploymentTopologiesByRegion(ctx context.Context, arg L
 			&i.Deployment.Pk,
 			&i.Deployment.ID,
 			&i.Deployment.K8sName,
+			&i.Deployment.DeletedAt,
+			&i.Deployment.RestoredAt,
 			&i.Deployment.WorkspaceID,
 			&i.Deployment.ProjectID,
 			&i.Deployment.EnvironmentID,

--- a/svc/ctrl/internal/db/deployment_update_desired_state.sql_generated.go
+++ b/svc/ctrl/internal/db/deployment_update_desired_state.sql_generated.go
@@ -15,7 +15,7 @@ import (
 const updateDeploymentDesiredState = `-- name: UpdateDeploymentDesiredState :exec
 UPDATE deployments
 SET desired_state = ?, updated_at = ?
-WHERE id = ?
+WHERE id = ? AND deleted_at IS NULL
 `
 
 type UpdateDeploymentDesiredStateParams struct {
@@ -28,7 +28,7 @@ type UpdateDeploymentDesiredStateParams struct {
 //
 //	UPDATE deployments
 //	SET desired_state = ?, updated_at = ?
-//	WHERE id = ?
+//	WHERE id = ? AND deleted_at IS NULL
 func (q *Queries) UpdateDeploymentDesiredState(ctx context.Context, arg UpdateDeploymentDesiredStateParams) error {
 	_, err := q.db.ExecContext(ctx, updateDeploymentDesiredState, arg.DesiredState, arg.UpdatedAt, arg.ID)
 	return err

--- a/svc/ctrl/internal/db/models_generated.go
+++ b/svc/ctrl/internal/db/models_generated.go
@@ -813,6 +813,8 @@ type Deployment struct {
 	Pk                            uint64                            `db:"pk"`
 	ID                            string                            `db:"id"`
 	K8sName                       string                            `db:"k8s_name"`
+	DeletedAt                     sql.NullInt64                     `db:"deleted_at"`
+	RestoredAt                    sql.NullInt64                     `db:"restored_at"`
 	WorkspaceID                   string                            `db:"workspace_id"`
 	ProjectID                     string                            `db:"project_id"`
 	EnvironmentID                 string                            `db:"environment_id"`

--- a/svc/ctrl/internal/db/querier_generated.go
+++ b/svc/ctrl/internal/db/querier_generated.go
@@ -218,6 +218,14 @@ type Querier interface {
 	//  LEFT JOIN deployments d ON d.workspace_id = w.id
 	//  WHERE w.id IN (/*SLICE:ids*/?)
 	DeleteWorkspacesWithChildren(ctx context.Context, ids []string) error
+	//DeploymentExistsIncludingDeleted
+	//
+	//  SELECT EXISTS(SELECT 1 FROM deployments WHERE id = ?)
+	DeploymentExistsIncludingDeleted(ctx context.Context, deploymentID string) (bool, error)
+	//DeploymentImageExistsIncludingDeleted
+	//
+	//  SELECT EXISTS(SELECT 1 FROM deployments WHERE image = ?)
+	DeploymentImageExistsIncludingDeleted(ctx context.Context, image sql.NullString) (bool, error)
 	//EndActiveDeploymentStepsForDeployments
 	//
 	//  UPDATE `deployment_steps`
@@ -433,16 +441,16 @@ type Querier interface {
 	FindDeployWorkspaceByStripeCustomerID(ctx context.Context, stripeCustomerID sql.NullString) (FindDeployWorkspaceByStripeCustomerIDRow, error)
 	//FindDeploymentById
 	//
-	//  SELECT pk, id, k8s_name, workspace_id, project_id, environment_id, app_id, image, build_id, git_commit_sha, git_branch, git_commit_message, git_commit_author_handle, git_commit_author_avatar_url, git_commit_timestamp, sentinel_config, cpu_millicores, memory_mib, storage_mib, desired_state, encrypted_environment_variables, command, port, shutdown_signal, upstream_protocol, healthcheck, pr_number, fork_repository_full_name, github_deployment_id, invocation_id, status, `trigger`, triggered_by, trigger_reason, created_at, updated_at FROM `deployments` WHERE id = ?
+	//  SELECT pk, id, k8s_name, deleted_at, restored_at, workspace_id, project_id, environment_id, app_id, image, build_id, git_commit_sha, git_branch, git_commit_message, git_commit_author_handle, git_commit_author_avatar_url, git_commit_timestamp, sentinel_config, cpu_millicores, memory_mib, storage_mib, desired_state, encrypted_environment_variables, command, port, shutdown_signal, upstream_protocol, healthcheck, pr_number, fork_repository_full_name, github_deployment_id, invocation_id, status, `trigger`, triggered_by, trigger_reason, created_at, updated_at FROM `deployments` WHERE id = ? AND deleted_at IS NULL
 	FindDeploymentById(ctx context.Context, id string) (Deployment, error)
 	//FindDeploymentByK8sName
 	//
-	//  SELECT pk, id, k8s_name, workspace_id, project_id, environment_id, app_id, image, build_id, git_commit_sha, git_branch, git_commit_message, git_commit_author_handle, git_commit_author_avatar_url, git_commit_timestamp, sentinel_config, cpu_millicores, memory_mib, storage_mib, desired_state, encrypted_environment_variables, command, port, shutdown_signal, upstream_protocol, healthcheck, pr_number, fork_repository_full_name, github_deployment_id, invocation_id, status, `trigger`, triggered_by, trigger_reason, created_at, updated_at FROM `deployments` WHERE k8s_name = ?
+	//  SELECT pk, id, k8s_name, deleted_at, restored_at, workspace_id, project_id, environment_id, app_id, image, build_id, git_commit_sha, git_branch, git_commit_message, git_commit_author_handle, git_commit_author_avatar_url, git_commit_timestamp, sentinel_config, cpu_millicores, memory_mib, storage_mib, desired_state, encrypted_environment_variables, command, port, shutdown_signal, upstream_protocol, healthcheck, pr_number, fork_repository_full_name, github_deployment_id, invocation_id, status, `trigger`, triggered_by, trigger_reason, created_at, updated_at FROM `deployments` WHERE k8s_name = ? AND deleted_at IS NULL
 	FindDeploymentByK8sName(ctx context.Context, k8sName string) (Deployment, error)
 	// Re-evaluates a deployment immediately before destructive cleanup. This must
 	// remain equivalent to ListDeploymentGCCandidates except for pagination.
 	//
-	//  SELECT d.id, d.image
+	//  SELECT d.id, d.image, d.deleted_at
 	//  FROM deployments d
 	//  JOIN environments e ON e.id = d.environment_id
 	//  JOIN apps a ON a.id = d.app_id
@@ -460,14 +468,16 @@ type Querier interface {
 	//        AND fr.sticky IN ('branch', 'environment', 'live')
 	//    )
 	//    AND (
+	//      d.deleted_at <= ?
+	//      OR (d.deleted_at IS NULL AND (
 	//      (
 	//        e.kind = 'preview'
-	//        AND COALESCE(d.updated_at, d.created_at) < CAST(? AS SIGNED)
+	//        AND GREATEST(COALESCE(d.updated_at, d.created_at), COALESCE(d.restored_at, 0)) < CAST(? AS SIGNED)
 	//      )
 	//      OR
 	//      (
 	//        e.kind = 'production'
-	//        AND d.created_at < ?
+	//        AND GREATEST(d.created_at, COALESCE(d.restored_at, 0)) < CAST(? AS SIGNED)
 	//        AND (
 	//          d.status != 'stopped'
 	//          OR (
@@ -475,6 +485,7 @@ type Querier interface {
 	//            FROM deployments newer
 	//            WHERE newer.app_id = d.app_id
 	//              AND newer.environment_id = d.environment_id
+	//              AND newer.deleted_at IS NULL
 	//              AND newer.status IN ('ready', 'stopped')
 	//              AND (
 	//                newer.created_at > d.created_at
@@ -483,7 +494,9 @@ type Querier interface {
 	//          ) >= CAST(? AS UNSIGNED)
 	//        )
 	//      )
+	//      ))
 	//    )
+	//  FOR UPDATE
 	FindDeploymentGCEligible(ctx context.Context, arg FindDeploymentGCEligibleParams) (FindDeploymentGCEligibleRow, error)
 	// Returns all regions where a deployment is configured.
 	// Used for fan-out: when a deployment changes, emit state_change to each region.
@@ -498,7 +511,7 @@ type Querier interface {
 	//
 	//  SELECT
 	//      dt.pk, dt.workspace_id, dt.deployment_id, dt.region_id, dt.autoscaling_replicas_min, dt.autoscaling_replicas_max, dt.autoscaling_threshold_cpu, dt.autoscaling_threshold_memory, dt.desired_status, dt.created_at, dt.updated_at,
-	//      d.pk, d.id, d.k8s_name, d.workspace_id, d.project_id, d.environment_id, d.app_id, d.image, d.build_id, d.git_commit_sha, d.git_branch, d.git_commit_message, d.git_commit_author_handle, d.git_commit_author_avatar_url, d.git_commit_timestamp, d.sentinel_config, d.cpu_millicores, d.memory_mib, d.storage_mib, d.desired_state, d.encrypted_environment_variables, d.command, d.port, d.shutdown_signal, d.upstream_protocol, d.healthcheck, d.pr_number, d.fork_repository_full_name, d.github_deployment_id, d.invocation_id, d.status, d.`trigger`, d.triggered_by, d.trigger_reason, d.created_at, d.updated_at,
+	//      d.pk, d.id, d.k8s_name, d.deleted_at, d.restored_at, d.workspace_id, d.project_id, d.environment_id, d.app_id, d.image, d.build_id, d.git_commit_sha, d.git_branch, d.git_commit_message, d.git_commit_author_handle, d.git_commit_author_avatar_url, d.git_commit_timestamp, d.sentinel_config, d.cpu_millicores, d.memory_mib, d.storage_mib, d.desired_state, d.encrypted_environment_variables, d.command, d.port, d.shutdown_signal, d.upstream_protocol, d.healthcheck, d.pr_number, d.fork_repository_full_name, d.github_deployment_id, d.invocation_id, d.status, d.`trigger`, d.triggered_by, d.trigger_reason, d.created_at, d.updated_at,
 	//      w.k8s_namespace,
 	//      e.slug AS environment_slug,
 	//      r.name AS region_name,
@@ -510,6 +523,7 @@ type Querier interface {
 	//  INNER JOIN `environments` e ON e.id = d.environment_id
 	//  LEFT JOIN `github_repo_connections` grc ON grc.app_id = d.app_id
 	//  WHERE dt.deployment_id = ? AND dt.region_id = ?
+	//    AND d.deleted_at IS NULL
 	//  LIMIT 1
 	FindDeploymentTopologyByDeploymentAndRegion(ctx context.Context, arg FindDeploymentTopologyByDeploymentAndRegionParams) (FindDeploymentTopologyByDeploymentAndRegionRow, error)
 	// Returns the per-region minimum replica requirement for a deployment.
@@ -522,11 +536,11 @@ type Querier interface {
 	FindDeploymentTopologyMinReplicas(ctx context.Context, deploymentID string) ([]FindDeploymentTopologyMinReplicasRow, error)
 	//FindDeploymentWithEnvironmentAndApp
 	//
-	//  SELECT d.pk, d.id, d.k8s_name, d.workspace_id, d.project_id, d.environment_id, d.app_id, d.image, d.build_id, d.git_commit_sha, d.git_branch, d.git_commit_message, d.git_commit_author_handle, d.git_commit_author_avatar_url, d.git_commit_timestamp, d.sentinel_config, d.cpu_millicores, d.memory_mib, d.storage_mib, d.desired_state, d.encrypted_environment_variables, d.command, d.port, d.shutdown_signal, d.upstream_protocol, d.healthcheck, d.pr_number, d.fork_repository_full_name, d.github_deployment_id, d.invocation_id, d.status, d.`trigger`, d.triggered_by, d.trigger_reason, d.created_at, d.updated_at, e.slug AS environment_slug, e.kind AS environment_kind, a.current_deployment_id, a.is_rolled_back
+	//  SELECT d.pk, d.id, d.k8s_name, d.deleted_at, d.restored_at, d.workspace_id, d.project_id, d.environment_id, d.app_id, d.image, d.build_id, d.git_commit_sha, d.git_branch, d.git_commit_message, d.git_commit_author_handle, d.git_commit_author_avatar_url, d.git_commit_timestamp, d.sentinel_config, d.cpu_millicores, d.memory_mib, d.storage_mib, d.desired_state, d.encrypted_environment_variables, d.command, d.port, d.shutdown_signal, d.upstream_protocol, d.healthcheck, d.pr_number, d.fork_repository_full_name, d.github_deployment_id, d.invocation_id, d.status, d.`trigger`, d.triggered_by, d.trigger_reason, d.created_at, d.updated_at, e.slug AS environment_slug, e.kind AS environment_kind, a.current_deployment_id, a.is_rolled_back
 	//  FROM deployments d
 	//  JOIN environments e ON e.id = d.environment_id
 	//  JOIN apps a ON a.id = d.app_id
-	//  WHERE d.id = ?
+	//  WHERE d.id = ? AND d.deleted_at IS NULL
 	FindDeploymentWithEnvironmentAndApp(ctx context.Context, id string) (FindDeploymentWithEnvironmentAndAppRow, error)
 	//FindEnvironmentByAppIdAndSlug
 	//
@@ -653,6 +667,7 @@ type Querier interface {
 	//  SELECT id
 	//  FROM deployments
 	//  WHERE app_id = ?
+	//    AND deleted_at IS NULL
 	//    AND environment_id = ?
 	//    AND status = 'ready'
 	//    AND id != ?
@@ -997,6 +1012,7 @@ type Querier interface {
 	//  INSERT INTO `deployments` (
 	//      id,
 	//      k8s_name,
+	//      image,
 	//      workspace_id,
 	//      project_id,
 	//      app_id,
@@ -1027,6 +1043,7 @@ type Querier interface {
 	//      updated_at
 	//  )
 	//  VALUES (
+	//      ?,
 	//      ?,
 	//      ?,
 	//      ?,
@@ -1470,7 +1487,7 @@ type Querier interface {
 	//
 	//  SELECT
 	//      dt.pk, dt.workspace_id, dt.deployment_id, dt.region_id, dt.autoscaling_replicas_min, dt.autoscaling_replicas_max, dt.autoscaling_threshold_cpu, dt.autoscaling_threshold_memory, dt.desired_status, dt.created_at, dt.updated_at,
-	//      d.pk, d.id, d.k8s_name, d.workspace_id, d.project_id, d.environment_id, d.app_id, d.image, d.build_id, d.git_commit_sha, d.git_branch, d.git_commit_message, d.git_commit_author_handle, d.git_commit_author_avatar_url, d.git_commit_timestamp, d.sentinel_config, d.cpu_millicores, d.memory_mib, d.storage_mib, d.desired_state, d.encrypted_environment_variables, d.command, d.port, d.shutdown_signal, d.upstream_protocol, d.healthcheck, d.pr_number, d.fork_repository_full_name, d.github_deployment_id, d.invocation_id, d.status, d.`trigger`, d.triggered_by, d.trigger_reason, d.created_at, d.updated_at,
+	//      d.pk, d.id, d.k8s_name, d.deleted_at, d.restored_at, d.workspace_id, d.project_id, d.environment_id, d.app_id, d.image, d.build_id, d.git_commit_sha, d.git_branch, d.git_commit_message, d.git_commit_author_handle, d.git_commit_author_avatar_url, d.git_commit_timestamp, d.sentinel_config, d.cpu_millicores, d.memory_mib, d.storage_mib, d.desired_state, d.encrypted_environment_variables, d.command, d.port, d.shutdown_signal, d.upstream_protocol, d.healthcheck, d.pr_number, d.fork_repository_full_name, d.github_deployment_id, d.invocation_id, d.status, d.`trigger`, d.triggered_by, d.trigger_reason, d.created_at, d.updated_at,
 	//      w.k8s_namespace,
 	//      e.slug AS environment_slug,
 	//      r.name AS region_name,
@@ -1482,6 +1499,7 @@ type Querier interface {
 	//  INNER JOIN `environments` e ON e.id = d.environment_id
 	//  LEFT JOIN `github_repo_connections` grc ON grc.app_id = d.app_id
 	//  WHERE r.id = ? AND dt.pk > ? AND dt.desired_status = 'running'
+	//    AND d.deleted_at IS NULL
 	//  ORDER BY dt.pk ASC
 	//  LIMIT ?
 	ListAllDeploymentTopologiesByRegion(ctx context.Context, arg ListAllDeploymentTopologiesByRegionParams) ([]ListAllDeploymentTopologiesByRegionRow, error)
@@ -1574,14 +1592,16 @@ type Querier interface {
 	//        AND fr.sticky IN ('branch', 'environment', 'live')
 	//    )
 	//    AND (
+	//      d.deleted_at <= ?
+	//      OR (d.deleted_at IS NULL AND (
 	//      (
 	//        e.kind = 'preview'
-	//        AND COALESCE(d.updated_at, d.created_at) < CAST(? AS SIGNED)
+	//        AND GREATEST(COALESCE(d.updated_at, d.created_at), COALESCE(d.restored_at, 0)) < CAST(? AS SIGNED)
 	//      )
 	//      OR
 	//      (
 	//        e.kind = 'production'
-	//        AND d.created_at < ?
+	//        AND GREATEST(d.created_at, COALESCE(d.restored_at, 0)) < CAST(? AS SIGNED)
 	//        AND (
 	//          d.status != 'stopped'
 	//          OR (
@@ -1589,6 +1609,7 @@ type Querier interface {
 	//            FROM deployments newer
 	//            WHERE newer.app_id = d.app_id
 	//              AND newer.environment_id = d.environment_id
+	//              AND newer.deleted_at IS NULL
 	//              AND newer.status IN ('ready', 'stopped')
 	//              AND (
 	//                newer.created_at > d.created_at
@@ -1597,6 +1618,7 @@ type Querier interface {
 	//          ) >= CAST(? AS UNSIGNED)
 	//        )
 	//      )
+	//      ))
 	//    )
 	//  ORDER BY d.pk
 	//  LIMIT ?
@@ -1612,8 +1634,9 @@ type Querier interface {
 	ListDeploymentImagesForGC(ctx context.Context, arg ListDeploymentImagesForGCParams) ([]ListDeploymentImagesForGCRow, error)
 	//ListDeploymentsByEnvironmentIdAndStatus
 	//
-	//  SELECT pk, id, k8s_name, workspace_id, project_id, environment_id, app_id, image, build_id, git_commit_sha, git_branch, git_commit_message, git_commit_author_handle, git_commit_author_avatar_url, git_commit_timestamp, sentinel_config, cpu_millicores, memory_mib, storage_mib, desired_state, encrypted_environment_variables, command, port, shutdown_signal, upstream_protocol, healthcheck, pr_number, fork_repository_full_name, github_deployment_id, invocation_id, status, `trigger`, triggered_by, trigger_reason, created_at, updated_at FROM `deployments`
+	//  SELECT pk, id, k8s_name, deleted_at, restored_at, workspace_id, project_id, environment_id, app_id, image, build_id, git_commit_sha, git_branch, git_commit_message, git_commit_author_handle, git_commit_author_avatar_url, git_commit_timestamp, sentinel_config, cpu_millicores, memory_mib, storage_mib, desired_state, encrypted_environment_variables, command, port, shutdown_signal, upstream_protocol, healthcheck, pr_number, fork_repository_full_name, github_deployment_id, invocation_id, status, `trigger`, triggered_by, trigger_reason, created_at, updated_at FROM `deployments`
 	//  WHERE environment_id = ?
+	//    AND deleted_at IS NULL
 	//    AND status = ?
 	//    AND created_at < ?
 	//    AND (updated_at IS null OR updated_at < ? )
@@ -1939,6 +1962,12 @@ type Querier interface {
 	//      updated_at = ?
 	//  WHERE id = ?
 	ResetCustomDomainVerification(ctx context.Context, arg ResetCustomDomainVerificationParams) error
+	//RestoreDeployment
+	//
+	//  UPDATE deployments SET deleted_at = NULL, restored_at = ?
+	//  WHERE id = ?
+	//    AND deleted_at > ?
+	RestoreDeployment(ctx context.Context, arg RestoreDeploymentParams) (int64, error)
 	// Restores an app's current deployment on resume (the inverse of
 	// ClearAppCurrentDeployment, which teardown uses on suspend). Sets only
 	// current_deployment_id and updated_at_m; leaves is_rolled_back untouched.
@@ -1968,6 +1997,11 @@ type Querier interface {
 	//  SET k8s_namespace = ?
 	//  WHERE id = ? AND k8s_namespace IS NULL
 	SetWorkspaceK8sNamespace(ctx context.Context, arg SetWorkspaceK8sNamespaceParams) error
+	//SoftDeleteDeploymentForGC
+	//
+	//  UPDATE deployments SET deleted_at = ?
+	//  WHERE id = ? AND deleted_at IS NULL
+	SoftDeleteDeploymentForGC(ctx context.Context, arg SoftDeleteDeploymentForGCParams) (int64, error)
 	//SoftDeleteKeyByID
 	//
 	//  UPDATE `keys` SET deleted_at_m = ? WHERE id = ?
@@ -2090,7 +2124,7 @@ type Querier interface {
 	//
 	//  UPDATE deployments
 	//  SET desired_state = ?, updated_at = ?
-	//  WHERE id = ?
+	//  WHERE id = ? AND deleted_at IS NULL
 	UpdateDeploymentDesiredState(ctx context.Context, arg UpdateDeploymentDesiredStateParams) error
 	//UpdateDeploymentGithubDeploymentId
 	//

--- a/svc/ctrl/internal/db/queries/deployment_find_by_id.sql
+++ b/svc/ctrl/internal/db/queries/deployment_find_by_id.sql
@@ -1,2 +1,2 @@
 -- name: FindDeploymentById :one
-SELECT * FROM `deployments` WHERE id = sqlc.arg(id);
+SELECT * FROM `deployments` WHERE id = sqlc.arg(id) AND deleted_at IS NULL;

--- a/svc/ctrl/internal/db/queries/deployment_find_by_k8s_name.sql
+++ b/svc/ctrl/internal/db/queries/deployment_find_by_k8s_name.sql
@@ -1,2 +1,2 @@
 -- name: FindDeploymentByK8sName :one
-SELECT * FROM `deployments` WHERE k8s_name = sqlc.arg(k8s_name);
+SELECT * FROM `deployments` WHERE k8s_name = sqlc.arg(k8s_name) AND deleted_at IS NULL;

--- a/svc/ctrl/internal/db/queries/deployment_find_latest_ready_by_app_and_env.sql
+++ b/svc/ctrl/internal/db/queries/deployment_find_latest_ready_by_app_and_env.sql
@@ -2,6 +2,7 @@
 SELECT id
 FROM deployments
 WHERE app_id = sqlc.arg(app_id)
+  AND deleted_at IS NULL
   AND environment_id = sqlc.arg(environment_id)
   AND status = 'ready'
   AND id != sqlc.arg(exclude_id)

--- a/svc/ctrl/internal/db/queries/deployment_find_with_environment_and_app.sql
+++ b/svc/ctrl/internal/db/queries/deployment_find_with_environment_and_app.sql
@@ -3,4 +3,4 @@ SELECT d.*, e.slug AS environment_slug, e.kind AS environment_kind, a.current_de
 FROM deployments d
 JOIN environments e ON e.id = d.environment_id
 JOIN apps a ON a.id = d.app_id
-WHERE d.id = sqlc.arg(id);
+WHERE d.id = sqlc.arg(id) AND d.deleted_at IS NULL;

--- a/svc/ctrl/internal/db/queries/deployment_gc_delete.sql
+++ b/svc/ctrl/internal/db/queries/deployment_gc_delete.sql
@@ -1,6 +1,21 @@
 -- name: DeleteDeploymentByIDForGC :execrows
 DELETE FROM deployments WHERE id = sqlc.arg(deployment_id);
 
+-- name: SoftDeleteDeploymentForGC :execrows
+UPDATE deployments SET deleted_at = sqlc.arg(deleted_at)
+WHERE id = sqlc.arg(deployment_id) AND deleted_at IS NULL;
+
+-- name: RestoreDeployment :execrows
+UPDATE deployments SET deleted_at = NULL, restored_at = sqlc.arg(restored_at)
+WHERE id = sqlc.arg(deployment_id)
+  AND deleted_at > sqlc.arg(recovery_cutoff);
+
+-- name: DeploymentExistsIncludingDeleted :one
+SELECT EXISTS(SELECT 1 FROM deployments WHERE id = sqlc.arg(deployment_id));
+
+-- name: DeploymentImageExistsIncludingDeleted :one
+SELECT EXISTS(SELECT 1 FROM deployments WHERE image = sqlc.arg(image));
+
 -- name: DeleteDeploymentStepsByDeploymentID :exec
 DELETE FROM deployment_steps WHERE deployment_id = sqlc.arg(deployment_id);
 

--- a/svc/ctrl/internal/db/queries/deployment_gc_find_eligible.sql
+++ b/svc/ctrl/internal/db/queries/deployment_gc_find_eligible.sql
@@ -1,7 +1,7 @@
 -- name: FindDeploymentGCEligible :one
 -- Re-evaluates a deployment immediately before destructive cleanup. This must
 -- remain equivalent to ListDeploymentGCCandidates except for pagination.
-SELECT d.id, d.image
+SELECT d.id, d.image, d.deleted_at
 FROM deployments d
 JOIN environments e ON e.id = d.environment_id
 JOIN apps a ON a.id = d.app_id
@@ -19,14 +19,16 @@ WHERE d.id = sqlc.arg(deployment_id)
       AND fr.sticky IN ('branch', 'environment', 'live')
   )
   AND (
+    d.deleted_at <= sqlc.arg(recovery_cutoff)
+    OR (d.deleted_at IS NULL AND (
     (
       e.kind = 'preview'
-      AND COALESCE(d.updated_at, d.created_at) < CAST(sqlc.arg(preview_cutoff) AS SIGNED)
+      AND GREATEST(COALESCE(d.updated_at, d.created_at), COALESCE(d.restored_at, 0)) < CAST(sqlc.arg(preview_cutoff) AS SIGNED)
     )
     OR
     (
       e.kind = 'production'
-      AND d.created_at < sqlc.arg(production_cutoff)
+      AND GREATEST(d.created_at, COALESCE(d.restored_at, 0)) < CAST(sqlc.arg(production_cutoff) AS SIGNED)
       AND (
         d.status != 'stopped'
         OR (
@@ -34,6 +36,7 @@ WHERE d.id = sqlc.arg(deployment_id)
           FROM deployments newer
           WHERE newer.app_id = d.app_id
             AND newer.environment_id = d.environment_id
+            AND newer.deleted_at IS NULL
             AND newer.status IN ('ready', 'stopped')
             AND (
               newer.created_at > d.created_at
@@ -42,4 +45,6 @@ WHERE d.id = sqlc.arg(deployment_id)
         ) >= CAST(sqlc.arg(keep_successful) AS UNSIGNED)
       )
     )
-  );
+    ))
+  )
+FOR UPDATE;

--- a/svc/ctrl/internal/db/queries/deployment_gc_list_candidates.sql
+++ b/svc/ctrl/internal/db/queries/deployment_gc_list_candidates.sql
@@ -20,14 +20,16 @@ WHERE d.pk > sqlc.arg(pagination_cursor)
       AND fr.sticky IN ('branch', 'environment', 'live')
   )
   AND (
+    d.deleted_at <= sqlc.arg(recovery_cutoff)
+    OR (d.deleted_at IS NULL AND (
     (
       e.kind = 'preview'
-      AND COALESCE(d.updated_at, d.created_at) < CAST(sqlc.arg(preview_cutoff) AS SIGNED)
+      AND GREATEST(COALESCE(d.updated_at, d.created_at), COALESCE(d.restored_at, 0)) < CAST(sqlc.arg(preview_cutoff) AS SIGNED)
     )
     OR
     (
       e.kind = 'production'
-      AND d.created_at < sqlc.arg(production_cutoff)
+      AND GREATEST(d.created_at, COALESCE(d.restored_at, 0)) < CAST(sqlc.arg(production_cutoff) AS SIGNED)
       AND (
         d.status != 'stopped'
         OR (
@@ -35,6 +37,7 @@ WHERE d.pk > sqlc.arg(pagination_cursor)
           FROM deployments newer
           WHERE newer.app_id = d.app_id
             AND newer.environment_id = d.environment_id
+            AND newer.deleted_at IS NULL
             AND newer.status IN ('ready', 'stopped')
             AND (
               newer.created_at > d.created_at
@@ -43,6 +46,7 @@ WHERE d.pk > sqlc.arg(pagination_cursor)
         ) >= CAST(sqlc.arg(keep_successful) AS UNSIGNED)
       )
     )
+    ))
   )
 ORDER BY d.pk
 LIMIT ?;

--- a/svc/ctrl/internal/db/queries/deployment_insert.sql
+++ b/svc/ctrl/internal/db/queries/deployment_insert.sql
@@ -2,6 +2,7 @@
 INSERT INTO `deployments` (
     id,
     k8s_name,
+    image,
     workspace_id,
     project_id,
     app_id,
@@ -34,6 +35,7 @@ INSERT INTO `deployments` (
 VALUES (
     sqlc.arg(id),
     sqlc.arg(k8s_name),
+    sqlc.arg(image),
     sqlc.arg(workspace_id),
     sqlc.arg(project_id),
     sqlc.arg(app_id),

--- a/svc/ctrl/internal/db/queries/deployment_list_by_environment_id_and_status.sql
+++ b/svc/ctrl/internal/db/queries/deployment_list_by_environment_id_and_status.sql
@@ -1,6 +1,7 @@
 -- name: ListDeploymentsByEnvironmentIdAndStatus :many
 SELECT * FROM `deployments`
 WHERE environment_id = sqlc.arg(environment_id)
+  AND deleted_at IS NULL
   AND status = sqlc.arg(status)
   AND created_at < sqlc.arg(created_before)
   AND (updated_at IS null OR updated_at < sqlc.arg(updated_before) )

--- a/svc/ctrl/internal/db/queries/deployment_topology_find_by_deployment_and_region.sql
+++ b/svc/ctrl/internal/db/queries/deployment_topology_find_by_deployment_and_region.sql
@@ -15,4 +15,5 @@ INNER JOIN `regions` r ON r.id = dt.region_id
 INNER JOIN `environments` e ON e.id = d.environment_id
 LEFT JOIN `github_repo_connections` grc ON grc.app_id = d.app_id
 WHERE dt.deployment_id = sqlc.arg(deployment_id) AND dt.region_id = sqlc.arg(region_id)
+  AND d.deleted_at IS NULL
 LIMIT 1;

--- a/svc/ctrl/internal/db/queries/deployment_topology_list_all_by_region.sql
+++ b/svc/ctrl/internal/db/queries/deployment_topology_list_all_by_region.sql
@@ -15,5 +15,6 @@ INNER JOIN `regions` r ON r.id = dt.region_id
 INNER JOIN `environments` e ON e.id = d.environment_id
 LEFT JOIN `github_repo_connections` grc ON grc.app_id = d.app_id
 WHERE r.id = sqlc.arg(region_id) AND dt.pk > sqlc.arg(after_pk) AND dt.desired_status = 'running'
+  AND d.deleted_at IS NULL
 ORDER BY dt.pk ASC
 LIMIT ?;

--- a/svc/ctrl/internal/db/queries/deployment_update_desired_state.sql
+++ b/svc/ctrl/internal/db/queries/deployment_update_desired_state.sql
@@ -1,4 +1,4 @@
 -- name: UpdateDeploymentDesiredState :exec
 UPDATE deployments
 SET desired_state = ?, updated_at = ?
-WHERE id = ?;
+WHERE id = ? AND deleted_at IS NULL;

--- a/svc/ctrl/internal/deploymentretention/policy.go
+++ b/svc/ctrl/internal/deploymentretention/policy.go
@@ -8,6 +8,7 @@ import "time"
 const (
 	ProductionAge = 14 * 24 * time.Hour
 	PreviewAge    = 30 * 24 * time.Hour
+	RecoveryAge   = 7 * 24 * time.Hour
 	Successful    = int64(10)
 )
 

--- a/svc/ctrl/proto/hydra/v1/deploy.proto
+++ b/svc/ctrl/proto/hydra/v1/deploy.proto
@@ -51,6 +51,9 @@ service DeployService {
   // retention policy. The request ID must match the deployment-keyed object.
   rpc GarbageCollect(GarbageCollectDeploymentRequest) returns (GarbageCollectDeploymentResponse) {}
 
+  // Restore recovers deployment history without starting compute or changing traffic.
+  rpc Restore(RestoreDeploymentRequest) returns (RestoreDeploymentResponse) {}
+
   // NotifyInstancesReady is called by the control plane when enough instances
   // have become healthy across the required regions. It resolves the awakeable
   // stored by a suspended deploy or wake workflow so it can continue.
@@ -81,6 +84,14 @@ message GarbageCollectDeploymentRequest {
 
 message GarbageCollectDeploymentResponse {
   bool deleted = 1;
+}
+
+message RestoreDeploymentRequest {
+  string deployment_id = 1;
+}
+
+message RestoreDeploymentResponse {
+  bool restored = 1;
 }
 
 message NotifyInstancesReadyRequest {

--- a/svc/ctrl/services/deployment/create_deployment.go
+++ b/svc/ctrl/services/deployment/create_deployment.go
@@ -475,9 +475,11 @@ func (s *Service) createAndDeploy(ctx context.Context, p createParams) (string, 
 	// note doesn't bubble up as a 500 from MySQL.
 	triggerReason := trimLength(p.triggerReason, maxTriggerReasonLength)
 
+	image := deployReq.GetDockerImage().GetImage()
 	err := s.db.InsertDeployment(ctx, db.InsertDeploymentParams{
 		ID:                            deploymentID,
 		K8sName:                       uid.DNS1035(12),
+		Image:                         sql.NullString{String: image, Valid: image != ""},
 		WorkspaceID:                   c.workspaceID,
 		ProjectID:                     c.project.ID,
 		AppID:                         c.app.ID,

--- a/svc/ctrl/worker/cron/deployment_garbage_collection_test.go
+++ b/svc/ctrl/worker/cron/deployment_garbage_collection_test.go
@@ -184,7 +184,7 @@ func TestDeploymentGarbageCollection_RetainsHistoryAndReconcilesDepot(t *testing
 	setDeploymentImage(t, h, referencedImageDeployment.ID, testRegistryRepository+":"+testReferencedTag)
 	setDeploymentImage(t, h, missingImageDeployment.ID, testRegistryRepository+":missing")
 	restoredImageDeployment := h.Seed.CreateDeployment(h.Ctx, seed.CreateDeploymentRequest{
-		ID:            "d_restoredx",
+		ID:            "d_reusedxx",
 		WorkspaceID:   workspace.ID,
 		ProjectID:     project.ID,
 		AppID:         app.ID,
@@ -275,6 +275,22 @@ func TestDeploymentGarbageCollection_RetainsHistoryAndReconcilesDepot(t *testing
 		assert.True(c, db.IsNotFound(secondErr))
 		assert.True(c, db.IsNotFound(previewErr))
 	}, 30*time.Second, 100*time.Millisecond)
+
+	for _, deploymentID := range []string{productionDeployments[1].ID, productionDeployments[2].ID, oldPreview.ID} {
+		exists, existsErr := h.DB.DeploymentExistsIncludingDeleted(h.Ctx, deploymentID)
+		require.NoError(t, existsErr)
+		require.True(t, exists)
+	}
+	restored, err := hydrav1.NewDeployServiceIngressClient(h.Restate, oldPreview.ID).
+		Restore().Request(h.Ctx, &hydrav1.RestoreDeploymentRequest{DeploymentId: oldPreview.ID})
+	require.NoError(t, err)
+	require.True(t, restored.GetRestored())
+	recovered, err := h.DB.FindDeploymentById(h.Ctx, oldPreview.ID)
+	require.NoError(t, err)
+	require.False(t, recovered.DeletedAt.Valid)
+	require.True(t, recovered.RestoredAt.Valid)
+	require.Equal(t, oldPreview.Status, recovered.Status)
+	require.Equal(t, mysqltype.DeploymentsDesiredStateStopped, recovered.DesiredState)
 
 	_, err = h.DB.FindDeploymentById(h.Ctx, productionDeployments[0].ID)
 	require.NoError(t, err, "the current deployment must be retained")

--- a/svc/ctrl/worker/cron/deploymentgc/handler.go
+++ b/svc/ctrl/worker/cron/deploymentgc/handler.go
@@ -3,6 +3,7 @@
 package deploymentgc
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"slices"
@@ -156,6 +157,7 @@ func (h *Handler) dispatchExpiredDeployments(ctx restate.ObjectContext, now time
 				ProductionCutoff: productionCutoff,
 				KeepSuccessful:   deploymentretention.Successful,
 				Limit:            limit,
+				RecoveryCutoff:   sql.NullInt64{Int64: now.Add(-deploymentretention.RecoveryAge).UnixMilli(), Valid: true},
 			})
 		}, restate.WithName("list expired deployments"), restate.WithMaxRetryAttempts(runMaxAttempts))
 		if err != nil {
@@ -368,7 +370,7 @@ func (h *Handler) deleteOrphanImages(ctx restate.ObjectContext, now time.Time, d
 		}
 		candidate := candidates[tag]
 		image, exists := recheckedImages[tag]
-		deploymentID, managed := managedImageDeploymentID(image.Tag)
+		_, managed := managedImageDeploymentID(image.Tag)
 		if !exists || !managed || image.Digest != candidate.Digest {
 			continue
 		}
@@ -376,34 +378,36 @@ func (h *Handler) deleteOrphanImages(ctx restate.ObjectContext, now time.Time, d
 			continue
 		}
 
-		// A managed image tag contains its owning deployment ID. Rechecking that
-		// row closes the gap between pushing an image and saving its tag in MySQL.
-		ownerExists, lookupErr := restate.Run(ctx, func(runCtx restate.RunContext) (bool, error) {
-			_, findErr := h.db.FindDeploymentById(runCtx, deploymentID)
-			if findErr == nil {
-				return true, nil
-			}
-			if db.IsNotFound(findErr) {
-				return false, nil
-			}
-			return false, findErr
-		}, restate.WithName("recheck Depot image owner"), restate.WithMaxRetryAttempts(runMaxAttempts))
-		if lookupErr != nil {
-			return deleted, fmt.Errorf("recheck Depot image owner %s: %w", tag, lookupErr)
-		}
-		if ownerExists {
-			continue
-		}
-
-		deleteErr := restate.RunVoid(ctx, func(runCtx restate.RunContext) error {
-			return h.depot.DeleteImage(runCtx, h.registryProjectID, tag)
+		removed, deleteErr := restate.Run(ctx, func(runCtx restate.RunContext) (bool, error) {
+			return h.deleteUnreferencedImage(runCtx, tag)
 		}, restate.WithName("delete unreferenced Depot image"), restate.WithMaxRetryAttempts(runMaxAttempts))
 		if deleteErr != nil {
 			return deleted, fmt.Errorf("delete Depot image %s: %w", tag, deleteErr)
 		}
-		deleted++
+		if removed {
+			deleted++
+		}
 	}
 	return deleted, nil
+}
+
+func (h *Handler) deleteUnreferencedImage(ctx context.Context, tag string) (bool, error) {
+	deploymentID, managed := managedImageDeploymentID(tag)
+	if !managed {
+		return false, nil
+	}
+	ownerExists, err := h.db.DeploymentExistsIncludingDeleted(ctx, deploymentID)
+	if err != nil || ownerExists {
+		return false, err
+	}
+	referenced, err := h.db.DeploymentImageExistsIncludingDeleted(ctx, sql.NullString{String: h.registryRepository + ":" + tag, Valid: true})
+	if err != nil || referenced {
+		return false, err
+	}
+	if err := h.depot.DeleteImage(ctx, h.registryProjectID, tag); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func managedImageDeploymentID(tag string) (string, bool) {

--- a/svc/ctrl/worker/cron/deploymentgc/image_references_test.go
+++ b/svc/ctrl/worker/cron/deploymentgc/image_references_test.go
@@ -1,0 +1,87 @@
+package deploymentgc
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/svc/ctrl/internal/db"
+)
+
+type imageReferenceDB struct {
+	db.Database
+	owner  bool
+	reused bool
+	err    error
+}
+
+func (d *imageReferenceDB) DeploymentExistsIncludingDeleted(context.Context, string) (bool, error) {
+	return d.owner, d.err
+}
+
+func (d *imageReferenceDB) DeploymentImageExistsIncludingDeleted(context.Context, sql.NullString) (bool, error) {
+	return d.reused, d.err
+}
+
+type imageDeleteDepot struct {
+	Depot
+	calls int
+	err   error
+}
+
+func (d *imageDeleteDepot) DeleteImage(context.Context, string, string) error {
+	d.calls++
+	return d.err
+}
+
+func TestImageDeletionRechecksOwnerAndReuseOnEveryAttempt(t *testing.T) {
+	database := &imageReferenceDB{}
+	depot := &imageDeleteDepot{}
+	h := &Handler{db: database, depot: depot, registryRepository: "registry.depot.dev/test", registryProjectID: "test"}
+	const tag = "proj_project-d_owner"
+	for _, tc := range []struct {
+		name   string
+		owner  bool
+		reused bool
+	}{
+		{name: "owner still building", owner: true},
+		{name: "owner in recovery", owner: true},
+		{name: "owner purged but image reused", reused: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			database.owner, database.reused = tc.owner, tc.reused
+			removed, err := h.deleteUnreferencedImage(t.Context(), tag)
+			require.NoError(t, err)
+			require.False(t, removed)
+			require.Zero(t, depot.calls)
+		})
+	}
+	database.owner, database.reused = false, false
+	depot.err = errors.New("temporary Depot failure")
+	removed, err := h.deleteUnreferencedImage(t.Context(), tag)
+	require.Error(t, err)
+	require.False(t, removed)
+	require.Equal(t, 1, depot.calls)
+
+	database.reused = true
+	depot.err = nil
+	removed, err = h.deleteUnreferencedImage(t.Context(), tag)
+	require.NoError(t, err)
+	require.False(t, removed)
+	require.Equal(t, 1, depot.calls, "a retry must not reuse a journaled absence check")
+
+	database.reused = false
+	database.err = errors.New("database unavailable")
+	removed, err = h.deleteUnreferencedImage(t.Context(), tag)
+	require.Error(t, err)
+	require.False(t, removed)
+	require.Equal(t, 1, depot.calls)
+
+	database.err = nil
+	removed, err = h.deleteUnreferencedImage(t.Context(), tag)
+	require.NoError(t, err)
+	require.True(t, removed)
+	require.Equal(t, 2, depot.calls)
+}

--- a/svc/ctrl/worker/deploy/garbage_collect.go
+++ b/svc/ctrl/worker/deploy/garbage_collect.go
@@ -4,17 +4,15 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"time"
 
 	restate "github.com/restatedev/sdk-go"
 	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
-	"github.com/unkeyed/unkey/pkg/restate/restateutil"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/db"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/deploymentretention"
 )
 
-// GarbageCollect deletes an expired terminal deployment. The DeployService is
-// keyed by deployment ID, so this recheck and deletion serialize with its
-// deploy, stop, and wake lifecycle operations.
+// GarbageCollect soft deletes expired deployments, then purges them after recovery expires.
 func (w *Workflow) GarbageCollect(ctx restate.ObjectContext, req *hydrav1.GarbageCollectDeploymentRequest) (*hydrav1.GarbageCollectDeploymentResponse, error) {
 	deploymentID := req.GetDeploymentId()
 	if deploymentID == "" {
@@ -24,43 +22,70 @@ func (w *Workflow) GarbageCollect(ctx restate.ObjectContext, req *hydrav1.Garbag
 		return nil, restate.TerminalErrorf("deployment ID must match the object key")
 	}
 
-	now, err := restateutil.Now(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("get garbage collection time: %w", err)
-	}
-	productionCutoff, previewCutoff := deploymentretention.Cutoffs(now)
-
 	deleted, err := restate.Run(ctx, func(runCtx restate.RunContext) (bool, error) {
-		return db.TxWithResult(runCtx, w.db.RW(), func(txCtx context.Context, tx db.DBTX) (bool, error) {
-			queries := db.NewQueries(tx)
-			_, findErr := queries.FindDeploymentGCEligible(txCtx, db.FindDeploymentGCEligibleParams{
-				DeploymentID:     deploymentID,
-				PreviewCutoff:    previewCutoff,
-				ProductionCutoff: productionCutoff,
-				KeepSuccessful:   deploymentretention.Successful,
-			})
-			if findErr != nil {
-				if db.IsNotFound(findErr) {
-					return false, nil
-				}
-				return false, findErr
-			}
-
-			if deleteErr := deleteDeploymentChildren(txCtx, queries, deploymentID); deleteErr != nil {
-				return false, deleteErr
-			}
-			rows, deleteErr := queries.DeleteDeploymentByIDForGC(txCtx, deploymentID)
-			if deleteErr != nil {
-				return false, deleteErr
-			}
-			return rows == 1, nil
-		})
+		return w.collectDeployment(runCtx, deploymentID, time.Now())
 	}, restate.WithName("recheck and delete expired deployment"), restate.WithMaxRetryAttempts(runMaxAttempts))
 	if err != nil {
 		return nil, fmt.Errorf("garbage collect deployment %s: %w", deploymentID, err)
 	}
 
 	return &hydrav1.GarbageCollectDeploymentResponse{Deleted: deleted}, nil
+}
+
+func (w *Workflow) collectDeployment(ctx context.Context, deploymentID string, now time.Time) (bool, error) {
+	productionCutoff, previewCutoff := deploymentretention.Cutoffs(now)
+	return db.TxWithResult(ctx, w.db.RW(), func(txCtx context.Context, tx db.DBTX) (bool, error) {
+		queries := db.NewQueries(tx)
+		deployment, findErr := queries.FindDeploymentGCEligible(txCtx, db.FindDeploymentGCEligibleParams{
+			DeploymentID:     deploymentID,
+			PreviewCutoff:    previewCutoff,
+			ProductionCutoff: productionCutoff,
+			KeepSuccessful:   deploymentretention.Successful,
+			RecoveryCutoff:   sql.NullInt64{Int64: now.Add(-deploymentretention.RecoveryAge).UnixMilli(), Valid: true},
+		})
+		if findErr != nil {
+			if db.IsNotFound(findErr) {
+				return false, nil
+			}
+			return false, findErr
+		}
+
+		if !deployment.DeletedAt.Valid {
+			_, deleteErr := queries.SoftDeleteDeploymentForGC(txCtx, db.SoftDeleteDeploymentForGCParams{
+				DeploymentID: deploymentID,
+				DeletedAt:    sql.NullInt64{Int64: now.UnixMilli(), Valid: true},
+			})
+			return false, deleteErr
+		}
+
+		if deleteErr := deleteDeploymentChildren(txCtx, queries, deploymentID); deleteErr != nil {
+			return false, deleteErr
+		}
+		rows, deleteErr := queries.DeleteDeploymentByIDForGC(txCtx, deploymentID)
+		if deleteErr != nil {
+			return false, deleteErr
+		}
+		return rows == 1, nil
+	})
+}
+
+// Restore makes a recoverable deployment visible without starting compute or changing routes.
+func (w *Workflow) Restore(ctx restate.ObjectContext, req *hydrav1.RestoreDeploymentRequest) (*hydrav1.RestoreDeploymentResponse, error) {
+	if req.GetDeploymentId() == "" || req.GetDeploymentId() != restate.Key(ctx) {
+		return nil, restate.TerminalErrorf("deployment ID must match the object key")
+	}
+	rows, err := restate.Run(ctx, func(runCtx restate.RunContext) (int64, error) {
+		now := time.Now()
+		return w.db.RestoreDeployment(runCtx, db.RestoreDeploymentParams{
+			DeploymentID:   req.GetDeploymentId(),
+			RestoredAt:     sql.NullInt64{Int64: now.UnixMilli(), Valid: true},
+			RecoveryCutoff: sql.NullInt64{Int64: now.Add(-deploymentretention.RecoveryAge).UnixMilli(), Valid: true},
+		})
+	}, restate.WithName("restore deployment during recovery"), restate.WithMaxRetryAttempts(runMaxAttempts))
+	if err != nil {
+		return nil, fmt.Errorf("restore deployment: %w", err)
+	}
+	return &hydrav1.RestoreDeploymentResponse{Restored: rows == 1}, nil
 }
 
 func deleteDeploymentChildren(ctx context.Context, queries *db.Queries, deploymentID string) error {

--- a/svc/ctrl/worker/deploy/garbage_collect_test.go
+++ b/svc/ctrl/worker/deploy/garbage_collect_test.go
@@ -1,0 +1,182 @@
+package deploy
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/mysql/sqlcomment"
+	"github.com/unkeyed/unkey/pkg/testutil/containers"
+	"github.com/unkeyed/unkey/pkg/uid"
+	"github.com/unkeyed/unkey/svc/ctrl/internal/db"
+	"github.com/unkeyed/unkey/svc/ctrl/internal/deploymentretention"
+)
+
+func TestDeploymentRecovery(t *testing.T) {
+	database, err := db.New(containers.MySQL(t).DSN, sqlcomment.Disabled())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+	w := &Workflow{db: database}
+	now := time.Now().Truncate(time.Millisecond)
+
+	for _, restore := range []bool{false, true} {
+		t.Run(map[bool]string{false: "purge", true: "restore"}[restore], func(t *testing.T) {
+			id := seedGCDeployment(t, database, now, "preview", "stopped")
+			ctx := t.Context()
+			candidatesAt := func(at time.Time) []string {
+				t.Helper()
+				production, preview := deploymentretention.Cutoffs(at)
+				rows, err := database.ListDeploymentGCCandidates(ctx, db.ListDeploymentGCCandidatesParams{
+					ProductionCutoff: production,
+					PreviewCutoff:    preview,
+					RecoveryCutoff:   sql.NullInt64{Int64: at.Add(-deploymentretention.RecoveryAge).UnixMilli(), Valid: true},
+					KeepSuccessful:   deploymentretention.Successful,
+					Limit:            500,
+				})
+				require.NoError(t, err)
+				var ids []string
+				for _, row := range rows {
+					ids = append(ids, row.ID)
+				}
+				return ids
+			}
+			require.Contains(t, candidatesAt(now), id)
+			_, err := database.RW().ExecContext(ctx, `INSERT INTO deployment_steps
+				(workspace_id, project_id, app_id, environment_id, deployment_id, started_at)
+				SELECT workspace_id, project_id, app_id, environment_id, id, created_at FROM deployments WHERE id = ?`, id)
+			require.NoError(t, err)
+			image := sql.NullString{String: "registry.depot.dev/test:proj_gc-" + id, Valid: true}
+			_, err = database.RW().ExecContext(ctx, "UPDATE deployments SET image = ? WHERE id = ?", image.String, id)
+			require.NoError(t, err)
+
+			deleted, err := w.collectDeployment(ctx, id, now)
+			require.NoError(t, err)
+			require.False(t, deleted)
+			_, err = database.FindDeploymentById(ctx, id)
+			require.True(t, db.IsNotFound(err), "normal lookups must hide recoverable deployments")
+			_, err = database.FindDeploymentWithEnvironmentAndApp(ctx, id)
+			require.True(t, db.IsNotFound(err), "rollback lookup must hide recoverable deployments")
+			exists, err := database.DeploymentExistsIncludingDeleted(ctx, id)
+			require.NoError(t, err)
+			require.True(t, exists)
+			referenced, err := database.DeploymentImageExistsIncludingDeleted(ctx, image)
+			require.NoError(t, err)
+			require.True(t, referenced)
+			var steps int
+			require.NoError(t, database.RW().QueryRowContext(ctx, "SELECT COUNT(*) FROM deployment_steps WHERE deployment_id = ?", id).Scan(&steps))
+			require.Equal(t, 1, steps)
+
+			beforeExpiry := now.Add(deploymentretention.RecoveryAge - time.Millisecond)
+			require.NotContains(t, candidatesAt(beforeExpiry), id)
+			deleted, err = w.collectDeployment(ctx, id, beforeExpiry)
+			require.NoError(t, err)
+			require.False(t, deleted)
+			var deletedAt int64
+			require.NoError(t, database.RW().QueryRowContext(ctx, "SELECT deleted_at FROM deployments WHERE id = ?", id).Scan(&deletedAt))
+			require.Equal(t, now.UnixMilli(), deletedAt, "repeated GC must not restart recovery")
+
+			restoreTime := now.Add(deploymentretention.RecoveryAge)
+			require.Contains(t, candidatesAt(restoreTime), id)
+			if restore {
+				restoreTime = beforeExpiry
+			}
+			rows, err := database.RestoreDeployment(ctx, db.RestoreDeploymentParams{
+				DeploymentID:   id,
+				RestoredAt:     sql.NullInt64{Int64: restoreTime.UnixMilli(), Valid: true},
+				RecoveryCutoff: sql.NullInt64{Int64: restoreTime.Add(-deploymentretention.RecoveryAge).UnixMilli(), Valid: true},
+			})
+			require.NoError(t, err)
+			if restore {
+				require.Equal(t, int64(1), rows)
+				deployment, err := database.FindDeploymentById(ctx, id)
+				require.NoError(t, err)
+				require.Equal(t, "stopped", string(deployment.DesiredState))
+				require.Equal(t, "stopped", string(deployment.Status))
+				deleted, err = w.collectDeployment(ctx, id, restoreTime)
+				require.NoError(t, err)
+				require.False(t, deleted)
+				_, err = database.FindDeploymentById(ctx, id)
+				require.NoError(t, err, "restored deployment gets a fresh retention window")
+				return
+			}
+			require.Zero(t, rows, "restoration must fail at the exact recovery boundary")
+			deleted, err = w.collectDeployment(ctx, id, restoreTime)
+			require.NoError(t, err)
+			require.True(t, deleted)
+			exists, err = database.DeploymentExistsIncludingDeleted(ctx, id)
+			require.NoError(t, err)
+			require.False(t, exists)
+			require.NoError(t, database.RW().QueryRowContext(ctx, "SELECT COUNT(*) FROM deployment_steps WHERE deployment_id = ?", id).Scan(&steps))
+			require.Zero(t, steps)
+			referenced, err = database.DeploymentImageExistsIncludingDeleted(ctx, image)
+			require.NoError(t, err)
+			require.False(t, referenced)
+		})
+	}
+}
+
+func TestGCRechecksProtection(t *testing.T) {
+	database, err := db.New(containers.MySQL(t).DSN, sqlcomment.Disabled())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+	w := &Workflow{db: database}
+	now := time.Now().Truncate(time.Millisecond)
+	for _, protection := range []string{"current", "sticky", "waking", "production_success"} {
+		t.Run(protection, func(t *testing.T) {
+			kind := "preview"
+			if protection == "production_success" {
+				kind = "production"
+			}
+			id := seedGCDeployment(t, database, now, kind, "stopped")
+			ctx := t.Context()
+			switch protection {
+			case "current":
+				_, err = database.RW().ExecContext(ctx, "UPDATE apps SET current_deployment_id = ? WHERE id = (SELECT app_id FROM deployments WHERE id = ?)", id, id)
+			case "sticky":
+				_, err = database.RW().ExecContext(ctx, `INSERT INTO frontline_routes
+					(id, project_id, app_id, environment_id, deployment_id, fully_qualified_domain_name, sticky, created_at)
+					SELECT id, project_id, app_id, environment_id, id, CONCAT(id, '.test'), 'branch', created_at FROM deployments WHERE id = ?`, id)
+			case "waking":
+				_, err = database.RW().ExecContext(ctx, "UPDATE deployments SET desired_state = 'running' WHERE id = ?", id)
+			case "production_success":
+			}
+			require.NoError(t, err)
+			deleted, err := w.collectDeployment(ctx, id, now)
+			require.NoError(t, err)
+			require.False(t, deleted)
+			_, err = database.FindDeploymentById(ctx, id)
+			require.NoError(t, err)
+		})
+	}
+}
+
+func seedGCDeployment(t *testing.T, database db.Database, now time.Time, kind, status string) string {
+	t.Helper()
+	id := uid.New(uid.DeploymentPrefix)
+	appID := uid.New(uid.AppPrefix)
+	envID := uid.New(uid.EnvironmentPrefix)
+	projectID := uid.New(uid.ProjectPrefix)
+	workspaceID := uid.New(uid.WorkspacePrefix)
+	ctx := t.Context()
+	_, err := database.RW().ExecContext(ctx, "INSERT INTO apps (id, workspace_id, project_id, name, slug, created_at) VALUES (?, ?, ?, 'gc', 'gc', ?)", appID, workspaceID, projectID, now.UnixMilli())
+	require.NoError(t, err)
+	_, err = database.RW().ExecContext(ctx, "INSERT INTO environments (id, workspace_id, project_id, app_id, slug, kind, created_at) VALUES (?, ?, ?, ?, 'gc', ?, ?)", envID, workspaceID, projectID, appID, kind, now.UnixMilli())
+	require.NoError(t, err)
+	_, err = database.RW().ExecContext(ctx, `INSERT INTO deployments
+		(id, k8s_name, workspace_id, project_id, app_id, environment_id, sentinel_config, encrypted_environment_variables, cpu_millicores, memory_mib, desired_state, status, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, '', '', 100, 128, 'stopped', ?, ?)`, id, id, workspaceID, projectID, appID, envID, status, now.Add(-90*24*time.Hour).UnixMilli())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		ctx := context.Background()
+		require.NoError(t, deleteDeploymentChildren(ctx, db.NewQueries(database.RW()), id))
+		_, err := database.DeleteDeploymentByIDForGC(ctx, id)
+		require.NoError(t, err)
+		_, err = database.RW().ExecContext(ctx, "DELETE FROM environments WHERE id = ?", envID)
+		require.NoError(t, err)
+		_, err = database.RW().ExecContext(ctx, "DELETE FROM apps WHERE id = ?", appID)
+		require.NoError(t, err)
+	})
+	return id
+}

--- a/svc/ctrl/worker/githubwebhook/handle_push.go
+++ b/svc/ctrl/worker/githubwebhook/handle_push.go
@@ -381,6 +381,7 @@ func insertDeploymentRecord(
 		if txErr := db.NewQueries(tx).InsertDeployment(txCtx, db.InsertDeploymentParams{
 			ID:                            deploymentID,
 			K8sName:                       uid.DNS1035(12),
+			Image:                         sql.NullString{},
 			WorkspaceID:                   project.WorkspaceID,
 			ProjectID:                     project.ID,
 			AppID:                         app.ID,

--- a/svc/frontline/internal/db/ingress_route_find_by_fqdn.sql_generated.go
+++ b/svc/frontline/internal/db/ingress_route_find_by_fqdn.sql_generated.go
@@ -21,7 +21,7 @@ SELECT
 FROM frontline_routes fr
 INNER JOIN deployments d ON d.id = fr.deployment_id
 LEFT JOIN workspace_billing wb ON wb.workspace_id = d.workspace_id
-WHERE fr.fully_qualified_domain_name = ?
+WHERE fr.fully_qualified_domain_name = ? AND d.deleted_at IS NULL
 `
 
 type FindFrontlineRouteByFQDNRow struct {
@@ -52,7 +52,7 @@ type FindFrontlineRouteByFQDNRow struct {
 //	FROM frontline_routes fr
 //	INNER JOIN deployments d ON d.id = fr.deployment_id
 //	LEFT JOIN workspace_billing wb ON wb.workspace_id = d.workspace_id
-//	WHERE fr.fully_qualified_domain_name = ?
+//	WHERE fr.fully_qualified_domain_name = ? AND d.deleted_at IS NULL
 func (q *Queries) FindFrontlineRouteByFQDN(ctx context.Context, fqdn string) (FindFrontlineRouteByFQDNRow, error) {
 	row := q.db.QueryRowContext(ctx, findFrontlineRouteByFQDN, fqdn)
 	var i FindFrontlineRouteByFQDNRow

--- a/svc/frontline/internal/db/querier_generated.go
+++ b/svc/frontline/internal/db/querier_generated.go
@@ -61,7 +61,7 @@ type Querier interface {
 	//  FROM frontline_routes fr
 	//  INNER JOIN deployments d ON d.id = fr.deployment_id
 	//  LEFT JOIN workspace_billing wb ON wb.workspace_id = d.workspace_id
-	//  WHERE fr.fully_qualified_domain_name = ?
+	//  WHERE fr.fully_qualified_domain_name = ? AND d.deleted_at IS NULL
 	FindFrontlineRouteByFQDN(ctx context.Context, fqdn string) (FindFrontlineRouteByFQDNRow, error)
 	// FindInstancesByDeploymentID returns all instances for a given deployment
 	// with region metadata for instance-aware routing decisions.

--- a/svc/frontline/internal/db/queries/ingress_route_find_by_fqdn.sql
+++ b/svc/frontline/internal/db/queries/ingress_route_find_by_fqdn.sql
@@ -17,4 +17,4 @@ SELECT
 FROM frontline_routes fr
 INNER JOIN deployments d ON d.id = fr.deployment_id
 LEFT JOIN workspace_billing wb ON wb.workspace_id = d.workspace_id
-WHERE fr.fully_qualified_domain_name = sqlc.arg(fqdn);
+WHERE fr.fully_qualified_domain_name = sqlc.arg(fqdn) AND d.deleted_at IS NULL;

--- a/web/apps/dashboard/lib/trpc/routers/deploy/app/list.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/app/list.ts
@@ -1,5 +1,5 @@
 import type { App } from "@/lib/collections/deploy/apps";
-import { and, db, desc, eq, inArray, sql } from "@/lib/db";
+import { and, db, desc, eq, inArray, isNull, sql } from "@/lib/db";
 import { ratelimit, withRatelimit, workspaceProcedure } from "@/lib/trpc/trpc";
 import { apps, deployments, frontlineRoutes, githubRepoConnections } from "@unkey/db/src/schema";
 import { z } from "zod";
@@ -43,7 +43,13 @@ export const listApps = workspaceProcedure
         ),
       })
       .from(deployments)
-      .where(and(eq(deployments.workspaceId, workspaceId), inArray(deployments.appId, appIds)))
+      .where(
+        and(
+          eq(deployments.workspaceId, workspaceId),
+          inArray(deployments.appId, appIds),
+          isNull(deployments.deletedAt),
+        ),
+      )
       .as("ranked_deployments");
 
     const rankedRoutes = db
@@ -106,6 +112,7 @@ export const listApps = workspaceProcedure
               and(
                 eq(deployments.workspaceId, workspaceId),
                 inArray(deployments.id, currentDeploymentIds),
+                isNull(deployments.deletedAt),
               ),
             )
         : Promise.resolve([]),

--- a/web/apps/dashboard/lib/trpc/routers/deploy/deployment/deployment-query-helpers.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/deployment/deployment-query-helpers.ts
@@ -1,5 +1,5 @@
 import type { InstanceStatus } from "@/lib/collections/deploy/instance-status";
-import { and, db, eq } from "@/lib/db";
+import { and, db, eq, isNull } from "@/lib/db";
 import type { LastExit } from "@/lib/types/deploy";
 import { type ContainerStatus, apps, deployments } from "@unkey/db/src/schema";
 import { mapRegionToFlag } from "../network/utils";
@@ -137,6 +137,7 @@ export async function fetchCurrentDeploymentOutsideWindow(
         eq(deployments.workspaceId, workspaceId),
         eq(deployments.projectId, input.projectId),
         eq(deployments.id, currentId),
+        isNull(deployments.deletedAt),
       ),
     );
   return deployment ?? null;

--- a/web/apps/dashboard/lib/trpc/routers/deploy/deployment/getById.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/deployment/getById.ts
@@ -1,4 +1,4 @@
-import { and, db, eq } from "@/lib/db";
+import { and, db, eq, isNull } from "@/lib/db";
 import { workspaceProcedure } from "@/lib/trpc/trpc";
 import { TRPCError } from "@trpc/server";
 import {
@@ -37,6 +37,7 @@ export const getById = workspaceProcedure
             eq(deployments.id, input.deploymentId),
             eq(deployments.workspaceId, ctx.workspace.id),
             eq(deployments.projectId, input.projectId),
+            isNull(deployments.deletedAt),
           ),
         )
         .limit(1);

--- a/web/apps/dashboard/lib/trpc/routers/deploy/deployment/list.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/deployment/list.ts
@@ -1,4 +1,4 @@
-import { and, db, desc, eq, gte, inArray, lte, sql } from "@/lib/db";
+import { and, db, desc, eq, gte, inArray, isNull, lte, sql } from "@/lib/db";
 import { workspaceProcedure } from "@/lib/trpc/trpc";
 import type { LastExit } from "@/lib/types/deploy";
 import { TRPCError } from "@trpc/server";
@@ -41,6 +41,7 @@ export const listDeployments = workspaceProcedure
           and(
             eq(deployments.workspaceId, ctx.workspace.id),
             eq(deployments.projectId, input.projectId),
+            isNull(deployments.deletedAt),
             input.appId ? eq(deployments.appId, input.appId) : undefined,
             input.startTime ? gte(deployments.createdAt, input.startTime) : undefined,
             input.endTime ? lte(deployments.createdAt, input.endTime) : undefined,

--- a/web/apps/dashboard/lib/trpc/routers/deploy/project/list.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/project/list.ts
@@ -1,5 +1,5 @@
 import type { Project } from "@/lib/collections/deploy/projects";
-import { and, db, desc, eq, inArray, not, sql } from "@/lib/db";
+import { and, db, desc, eq, inArray, isNull, not, sql } from "@/lib/db";
 import { ratelimit, withRatelimit, workspaceProcedure } from "@/lib/trpc/trpc";
 import {
   apps,
@@ -61,7 +61,11 @@ export const listProjects = workspaceProcedure
         })
         .from(deployments)
         .where(
-          and(eq(deployments.workspaceId, workspaceId), inArray(deployments.projectId, projectIds)),
+          and(
+            eq(deployments.workspaceId, workspaceId),
+            inArray(deployments.projectId, projectIds),
+            isNull(deployments.deletedAt),
+          ),
         )
         .orderBy(deployments.projectId, desc(deployments.createdAt), desc(deployments.id)),
       db
@@ -192,6 +196,7 @@ export const listProjects = workspaceProcedure
             and(
               eq(deployments.workspaceId, workspaceId),
               inArray(deployments.id, currentDeploymentIds),
+              isNull(deployments.deletedAt),
             ),
           )
       : [];

--- a/web/internal/db/src/schema/deployments.ts
+++ b/web/internal/db/src/schema/deployments.ts
@@ -28,6 +28,8 @@ export const deployments = mysqlTable(
     pk: primaryKey(),
     id: id("id").notNull().unique(),
     k8sName: caseInsensitiveVarchar("k8s_name", { length: 255 }).notNull().unique(),
+    deletedAt: bigint("deleted_at", { mode: "number" }),
+    restoredAt: bigint("restored_at", { mode: "number" }),
 
     workspaceId: id("workspace_id").notNull(),
     projectId: id("project_id").notNull(),
@@ -141,6 +143,7 @@ export const deployments = mysqlTable(
     index("workspace_idx").on(table.workspaceId),
     index("project_idx").on(table.projectId),
     index("status_idx").on(table.status),
+    index("image_idx").on(table.image),
     index("app_environment_status_created_idx").on(
       table.appId,
       table.environmentId,


### PR DESCRIPTION
## Problem:

Retention expiry currently deletes deployment history immediately. The owner-ID image check also misses images reused by another deployment after the original owner is removed.

## Solution:

Soft-delete expired deployments. Preserve their records, child records, and images for seven more days. Allow restoration during that period. Purge records only after recovery expires, then let registry reconciliation remove unreferenced images. No candidate table is added.

Hide deleted deployments from normal deployment lists, detail reads, routing, wake, and rollback lookups. Restoration preserves deployment state and does not start compute or change traffic. A restored deployment receives a fresh normal retention period.

Before every image-delete attempt, check both the original owner and all recorded image references, including recovery records. Record prebuilt image references before worker dispatch. This also protects reuse when the original owner is absent.

## Impact:

Follow-up to #7101 in stack #7104. Do not enable destructive GC from #7100/#7101 alone. Apply the additive `deleted_at`, `restored_at`, and image-index schema change before deploying this stack. Deploy recovery-aware services before enabling the schedule in unkeyed/infra#1185. No migration, deployment, or production mutation was performed.

Restoration is an internal, deployment-keyed Restate operation: `POST /hydra.v1.DeployService/<deploymentId>/Restore` with `{"deploymentId":"<deploymentId>"}`. It returns `restored: true` only while recovery is available. No public recovery endpoint or UI control is added.

Fresh image checks are not an atomic transaction across MySQL and Depot. Arbitrary raw image imports after the final reference check can still race external deletion.

## Testing:

- `mise run test` on the full follow-up stack: 21,992 passed, 0 failed, 7,719 ignored across 276 suites.
- `mise run build`: passed, 0 lint issues.
- Targeted Go checks: 190 passed across deployment, reconciliation, cluster, deployment service, frontline routing, and API list packages. The expanded real-Restate cron suite passed all 45 tests, including preserved soft-deleted rows, restoration, and reuse with no owner row.
- Real MySQL tests cover exact seven-day restore/purge boundaries, child preservation/deletion, candidate consistency, and current/sticky/waking/history protections.
- Dashboard typecheck and scoped Biome checks passed. Live local dashboard tRPC calls verified list hiding, detail NOT_FOUND, and list visibility after an actual Restate Restore call. Restored status remained failed and desired state remained stopped. Disposable fixtures were removed.
- Browser verification was blocked: protected pages stayed at “Loading workspace…”. No visual layout changed; rendered deployment interaction remains unverified.
- Relevant SQL and Hydra generated artifacts compile. Full `mise run generate` was blocked by Buf rate limits; unrelated generated churn was removed.
