### PR TITLE
feat(ctrl): reconcile three-day Depot layer cache retention

### DIFF
--- a/svc/ctrl/internal/depotcache/policy.go
+++ b/svc/ctrl/internal/depotcache/policy.go
@@ -1,0 +1,4 @@
+// Package depotcache defines the managed Depot project layer-cache policy.
+package depotcache
+
+const RetentionDays = int32(3)

--- a/svc/ctrl/worker/cron/deployment_garbage_collection_test.go
+++ b/svc/ctrl/worker/cron/deployment_garbage_collection_test.go
@@ -313,6 +313,14 @@ func TestDeploymentGarbageCollection_RetainsHistoryAndReconcilesDepot(t *testing
 	require.Equal(t, "depot-transient", updatedTransientProject.DepotProjectID.String)
 	require.Equal(t, []string{testOrphanTag}, depot.deletedImageTags())
 	require.Equal(t, []string{"depot-orphan"}, depot.deletedProjectIDs())
+	cacheProject, exists, err := depot.GetProject(h.Ctx, "depot-referenced")
+	require.NoError(t, err)
+	require.True(t, exists)
+	require.Equal(t, int32(3), cacheProject.CacheRetentionDays)
+	registryProject, exists, err := depot.GetProject(h.Ctx, "registry-project")
+	require.NoError(t, err)
+	require.True(t, exists)
+	require.Zero(t, registryProject.CacheRetentionDays)
 	restoredProject, err = h.DB.FindProjectById(h.Ctx, restoredProject.ID)
 	require.NoError(t, err)
 	require.Equal(t, "depot-restored", restoredProject.DepotProjectID.String)
@@ -442,6 +450,18 @@ func (f *fakeDepot) DeleteProject(_ context.Context, projectID string) error {
 	delete(f.projects, projectID)
 	f.deletedProjects = append(f.deletedProjects, projectID)
 	return nil
+}
+
+func (f *fakeDepot) SetCacheRetention(_ context.Context, projectID, expectedName string, days int32) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	project, exists := f.projects[projectID]
+	if !exists || project.Name != expectedName || project.CacheRetentionDays == days {
+		return false, nil
+	}
+	project.CacheRetentionDays = days
+	f.projects[projectID] = project
+	return true, nil
 }
 
 func (f *fakeDepot) deletedImageTags() []string {

--- a/svc/ctrl/worker/cron/deploymentgc/cache_retention_test.go
+++ b/svc/ctrl/worker/cron/deploymentgc/cache_retention_test.go
@@ -1,0 +1,68 @@
+package deploymentgc
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"buf.build/gen/go/depot/api/connectrpc/go/depot/core/v1/corev1connect"
+	corev1 "buf.build/gen/go/depot/api/protocolbuffers/go/depot/core/v1"
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/svc/ctrl/internal/depotcache"
+	"google.golang.org/protobuf/proto"
+)
+
+type cacheProjectClient struct {
+	corev1connect.ProjectServiceClient
+	project   *corev1.Project
+	update    *corev1.UpdateProjectRequest
+	updateErr error
+}
+
+func (c *cacheProjectClient) GetProject(context.Context, *connect.Request[corev1.GetProjectRequest]) (*connect.Response[corev1.GetProjectResponse], error) {
+	return connect.NewResponse(&corev1.GetProjectResponse{Project: proto.CloneOf(c.project)}), nil
+}
+
+func (c *cacheProjectClient) UpdateProject(_ context.Context, req *connect.Request[corev1.UpdateProjectRequest]) (*connect.Response[corev1.UpdateProjectResponse], error) {
+	c.update = req.Msg
+	return connect.NewResponse(&corev1.UpdateProjectResponse{}), c.updateErr
+}
+
+func TestCacheRetentionPreservesStorageAndProjectSettings(t *testing.T) {
+	projects := &cacheProjectClient{project: &corev1.Project{
+		ProjectId:   "build",
+		Name:        "production-proj_test",
+		RegionId:    "us-east-1",
+		CachePolicy: &corev1.CachePolicy{KeepDays: 7, KeepGb: 25},
+	}}
+	client := &depotClient{projects: projects}
+	changed, err := client.SetCacheRetention(t.Context(), "build", "production-proj_test", depotcache.RetentionDays)
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.Equal(t, int32(3), projects.update.CachePolicy.GetKeepDays())
+	require.Equal(t, int32(25), projects.update.CachePolicy.GetKeepGb())
+	require.Nil(t, projects.update.Name)
+	require.Nil(t, projects.update.RegionId)
+	require.Nil(t, projects.update.Hardware)
+
+	projects.update = nil
+	projects.project.CachePolicy.KeepDays = depotcache.RetentionDays
+	changed, err = client.SetCacheRetention(t.Context(), "build", "production-proj_test", depotcache.RetentionDays)
+	require.NoError(t, err)
+	require.False(t, changed)
+	require.Nil(t, projects.update)
+
+	projects.project.CachePolicy.KeepDays = 7
+	projects.project.Name = "another-owner"
+	changed, err = client.SetCacheRetention(t.Context(), "build", "production-proj_test", depotcache.RetentionDays)
+	require.NoError(t, err)
+	require.False(t, changed)
+	require.Nil(t, projects.update)
+
+	projects.project.Name = "production-proj_test"
+	projects.updateErr = connect.NewError(connect.CodeInvalidArgument, errors.New("unsupported retention"))
+	changed, err = client.SetCacheRetention(t.Context(), "build", "production-proj_test", depotcache.RetentionDays)
+	require.Error(t, err)
+	require.False(t, changed)
+}

--- a/svc/ctrl/worker/cron/deploymentgc/depot.go
+++ b/svc/ctrl/worker/cron/deploymentgc/depot.go
@@ -24,9 +24,10 @@ type DepotImage struct {
 
 // DepotProject is the build-project identity needed for reconciliation.
 type DepotProject struct {
-	ID        string
-	Name      string
-	CreatedAt time.Time
+	ID                 string
+	Name               string
+	CreatedAt          time.Time
+	CacheRetentionDays int32
 }
 
 // Depot is the narrow subset of the Depot API used by garbage collection.
@@ -41,6 +42,7 @@ type Depot interface {
 	GetProject(ctx context.Context, projectID string) (DepotProject, bool, error)
 	// DeleteProject deletes a project. A missing project must count as success.
 	DeleteProject(ctx context.Context, projectID string) error
+	SetCacheRetention(ctx context.Context, projectID, expectedName string, days int32) (bool, error)
 }
 
 type depotClient struct {
@@ -119,9 +121,10 @@ func (c *depotClient) ListProjects(ctx context.Context, pageToken string) ([]Dep
 	projects := make([]DepotProject, 0, len(response.Msg.GetProjects()))
 	for _, project := range response.Msg.GetProjects() {
 		projects = append(projects, DepotProject{
-			ID:        project.GetProjectId(),
-			Name:      project.GetName(),
-			CreatedAt: validTime(project.GetCreatedAt()),
+			ID:                 project.GetProjectId(),
+			Name:               project.GetName(),
+			CreatedAt:          validTime(project.GetCreatedAt()),
+			CacheRetentionDays: project.GetCachePolicy().GetKeepDays(),
 		})
 	}
 	return projects, response.Msg.GetNextPageToken(), nil
@@ -138,10 +141,42 @@ func (c *depotClient) GetProject(ctx context.Context, projectID string) (DepotPr
 	}
 	project := response.Msg.GetProject()
 	return DepotProject{
-		ID:        project.GetProjectId(),
-		Name:      project.GetName(),
-		CreatedAt: validTime(project.GetCreatedAt()),
+		ID:                 project.GetProjectId(),
+		Name:               project.GetName(),
+		CreatedAt:          validTime(project.GetCreatedAt()),
+		CacheRetentionDays: project.GetCachePolicy().GetKeepDays(),
 	}, true, nil
+}
+
+func (c *depotClient) SetCacheRetention(ctx context.Context, projectID, expectedName string, days int32) (bool, error) {
+	response, err := c.projects.GetProject(ctx, connect.NewRequest(&corev1.GetProjectRequest{ProjectId: projectID}))
+	if connect.CodeOf(err) == connect.CodeNotFound {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	project := response.Msg.GetProject()
+	if project.GetProjectId() != projectID || project.GetName() != expectedName {
+		return false, nil
+	}
+	policy := project.GetCachePolicy()
+	if policy == nil {
+		return false, fmt.Errorf("Depot project %s has no cache policy", projectID)
+	}
+	if policy.GetKeepDays() == days {
+		return false, nil
+	}
+	policy.KeepDays = days
+	request := &corev1.UpdateProjectRequest{
+		ProjectId:   projectID,
+		Name:        nil,
+		RegionId:    nil,
+		CachePolicy: policy,
+		Hardware:    nil,
+	}
+	_, err = c.projects.UpdateProject(ctx, connect.NewRequest(request))
+	return err == nil, err
 }
 
 func (c *depotClient) DeleteProject(ctx context.Context, projectID string) error {

--- a/svc/ctrl/worker/cron/deploymentgc/handler.go
+++ b/svc/ctrl/worker/cron/deploymentgc/handler.go
@@ -18,6 +18,7 @@ import (
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/db"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/deploymentretention"
+	"github.com/unkeyed/unkey/svc/ctrl/internal/depotcache"
 )
 
 const (
@@ -125,6 +126,9 @@ func (h *Handler) Handle(ctx restate.ObjectContext, _ *hydrav1.RunDeploymentGarb
 	if err != nil {
 		return nil, err
 	}
+	if err := h.reconcileCacheRetention(ctx, databaseProjects, depotProjects); err != nil {
+		return nil, err
+	}
 	imagesDeleted, err := h.deleteOrphanImages(ctx, now, databaseImages, depotImages, maxDepotResourceDeletes)
 	if err != nil {
 		return nil, err
@@ -142,6 +146,30 @@ func (h *Handler) Handle(ctx restate.ObjectContext, _ *hydrav1.RunDeploymentGarb
 		"depot_resources_deleted", response.GetDepotResourcesDeleted(),
 	)
 	return response, nil
+}
+
+func (h *Handler) reconcileCacheRetention(ctx restate.ObjectContext, references []projectReference, projects map[string]DepotProject) error {
+	var updated int32
+	for _, reference := range references {
+		project, exists := projects[reference.DepotProjectID]
+		if !exists || project.ID == h.registryProjectID || !h.isManagedBuildProject(project.Name) || project.CacheRetentionDays == depotcache.RetentionDays {
+			continue
+		}
+		changed, err := restate.Run(ctx, func(runCtx restate.RunContext) (bool, error) {
+			return h.depot.SetCacheRetention(runCtx, project.ID, project.Name, depotcache.RetentionDays)
+		}, restate.WithName("reconcile Depot cache retention"), restate.WithMaxRetryAttempts(runMaxAttempts))
+		if err != nil {
+			return fmt.Errorf("update Depot project %s cache retention: %w", project.ID, err)
+		}
+		if changed {
+			updated++
+		}
+		if updated >= maxDepotResourceDeletes {
+			break
+		}
+	}
+	logger.Info("Depot build cache retention reconciled", "projects_updated", updated, "retention_days", depotcache.RetentionDays)
+	return nil
 }
 
 func (h *Handler) dispatchExpiredDeployments(ctx restate.ObjectContext, now time.Time) (int32, error) {

--- a/svc/ctrl/worker/deploy/build.go
+++ b/svc/ctrl/worker/deploy/build.go
@@ -34,16 +34,13 @@ import (
 	"github.com/unkeyed/unkey/pkg/ptr"
 	"github.com/unkeyed/unkey/pkg/validation"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/db"
+	"github.com/unkeyed/unkey/svc/ctrl/internal/depotcache"
 )
 
 const (
 	// defaultCacheKeepGB is the maximum cache size in gigabytes for new Depot
 	// projects. Depot evicts least-recently-used cache entries when exceeded.
 	defaultCacheKeepGB = 25
-
-	// defaultCacheKeepDays is the maximum age in days for cached build layers.
-	// Layers older than this are evicted regardless of cache size.
-	defaultCacheKeepDays = 7
 
 	// gitAuthTokenSecretID is the BuildKit session secret holding the GitHub
 	// installation token for git context fetches. The host suffix scopes the
@@ -716,7 +713,7 @@ func (w *Workflow) getOrCreateDepotProject(ctx context.Context, unkeyProjectID s
 		//nolint: exhaustruct // missing fields is deprecated
 		CachePolicy: &corev1.CachePolicy{
 			KeepGb:   defaultCacheKeepGB,
-			KeepDays: defaultCacheKeepDays,
+			KeepDays: depotcache.RetentionDays,
 		},
 	}))
 	if err != nil {

--- a/svc/ctrl/worker/deploy/build_cache_test.go
+++ b/svc/ctrl/worker/deploy/build_cache_test.go
@@ -1,0 +1,55 @@
+package deploy
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"buf.build/gen/go/depot/api/connectrpc/go/depot/core/v1/corev1connect"
+	corev1 "buf.build/gen/go/depot/api/protocolbuffers/go/depot/core/v1"
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/svc/ctrl/internal/db"
+)
+
+type cacheCreationDB struct {
+	db.Database
+	depotProjectID string
+}
+
+func (d *cacheCreationDB) FindProjectById(context.Context, string) (db.Project, error) {
+	return db.Project{}, nil
+}
+
+func (d *cacheCreationDB) UpdateProjectDepotID(_ context.Context, params db.UpdateProjectDepotIDParams) error {
+	d.depotProjectID = params.DepotProjectID.String
+	return nil
+}
+
+type cacheCreationServer struct {
+	corev1connect.UnimplementedProjectServiceHandler
+	request *corev1.CreateProjectRequest
+}
+
+func (s *cacheCreationServer) CreateProject(_ context.Context, req *connect.Request[corev1.CreateProjectRequest]) (*connect.Response[corev1.CreateProjectResponse], error) {
+	s.request = req.Msg
+	return connect.NewResponse(&corev1.CreateProjectResponse{Project: &corev1.Project{ProjectId: "depot-project"}}), nil
+}
+
+func TestNewDepotProjectUsesThreeDayLayerCache(t *testing.T) {
+	projects := &cacheCreationServer{}
+	_, handler := corev1connect.NewProjectServiceHandler(projects)
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	database := &cacheCreationDB{}
+	w := &Workflow{db: database, buildConfig: BuildConfig{Depot: DepotConfig{
+		APIUrl: server.URL, ProjectPrefix: "production", ProjectRegion: "us-east-1",
+	}}}
+	id, err := w.getOrCreateDepotProject(t.Context(), "proj_test")
+	require.NoError(t, err)
+	require.Equal(t, "depot-project", id)
+	require.Equal(t, id, database.depotProjectID)
+	require.Equal(t, "production-proj_test", projects.request.GetName())
+	require.Equal(t, int32(3), projects.request.GetCachePolicy().GetKeepDays())
+	require.Equal(t, int32(25), projects.request.GetCachePolicy().GetKeepGb())
+}


### PR DESCRIPTION
## Problem:

New Depot build projects retain layer cache for seven days. Existing projects do not receive a changed retention target automatically.

## Solution:

Set a three-day target for new managed build projects and reconcile existing database-referenced managed projects. Preserve the 25 GB default for new projects and all current storage limits and other settings for existing projects. Exclude the registry project and projects outside the configured ownership prefix.

## Impact:

Follow-up to #7307 in stack #7104. **Blocked for rollout until Depot confirms that the server accepts three days.** No production Depot settings were changed.

The [Depot cache documentation](https://depot.dev/docs/cache/overview) separates project Docker layer cache from organization remote build cache. Project `CachePolicy.KeepDays` controls Docker layer cache only. Organization remote build cache is unchanged. Depot documents 7/14/30-day choices; the integer API field and CLI validation do not prove that the server accepts three days. New builds and reconciliation can fail if Depot rejects this value.

After vendor confirmation, deploy the recovery layer before enabling GC. The cron will update existing managed build projects, with at most 1,000 actual policy updates per run. It preserves the registry and unmanaged projects.

## Testing:

- `mise run test` on the full follow-up stack: 21,992 passed, 0 failed, 7,719 ignored across 276 suites.
- `mise run build`: passed, 0 lint issues.
- Local Connect-server tests verify new-project three-day/25 GB requests, existing-project updates, preserved settings, no-op and ownership checks, and surfaced server rejection.
- The real-Restate cron test verifies that the referenced build project receives three days and the registry project remains unchanged.
- These tests use a local fake Depot server. They do not establish production support for three-day retention.
