### PR TITLE
fix(batch): release completed row references

### DIFF
--- a/pkg/batch/process.go
+++ b/pkg/batch/process.go
@@ -56,6 +56,7 @@ type Config[T any] struct {
 
 	// Flush is the function called to process each batch.
 	// It must handle all errors internally and must not panic.
+	// The slice is borrowed until Flush returns; copy rows that must outlive it.
 	Flush func(ctx context.Context, batch []T)
 
 	// Consumers specifies how many goroutine workers should process the channel.
@@ -140,6 +141,7 @@ func (bp *BatchProcessor[T]) process() {
 	flushAndReset := func(trigger string) {
 		if len(batch) > 0 {
 			bp.flush(context.Background(), batch, trigger)
+			clear(batch)
 			batch = batch[:0]
 		}
 		t.Reset(bp.config.FlushInterval)

--- a/pkg/batch/process_test.go
+++ b/pkg/batch/process_test.go
@@ -1,0 +1,38 @@
+package batch
+
+import (
+	"context"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessorClearsFlushedRows(t *testing.T) {
+	var previous []string
+	var tail []string
+	var flushed [][]string
+	processor := New(Config[string]{
+		Name:          t.Name(),
+		BatchSize:     4,
+		BufferSize:    5,
+		FlushInterval: time.Hour,
+		Consumers:     1,
+		Flush: func(_ context.Context, rows []string) {
+			flushed = append(flushed, slices.Clone(rows))
+			if previous != nil {
+				tail = slices.Clone(previous[1:])
+			}
+			previous = rows
+		},
+	})
+	t.Cleanup(processor.Close)
+	for _, row := range []string{"first", "second", "third", "fourth", "last"} {
+		processor.Buffer(row)
+	}
+	processor.Close()
+
+	require.Equal(t, [][]string{{"first", "second", "third", "fourth"}, {"last"}}, flushed)
+	require.Equal(t, []string{"", "", ""}, tail)
+}

--- a/svc/api/internal/middleware/authentication_test.go
+++ b/svc/api/internal/middleware/authentication_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"testing"
 	"time"
 
@@ -195,7 +196,7 @@ func TestWithAuthentication_RecordsRootKeyUsage(t *testing.T) {
 				FlushInterval: time.Hour,
 				Consumers:     1,
 				Flush: func(_ context.Context, rows []schema.KeyVerification) {
-					flushed <- rows
+					flushed <- slices.Clone(rows)
 				},
 			})
 			t.Cleanup(verifications.Close)
@@ -259,7 +260,7 @@ func TestWithAuthentication_RejectsRootPrincipalWithoutKeySource(t *testing.T) {
 		FlushInterval: time.Hour,
 		Consumers:     1,
 		Flush: func(_ context.Context, rows []schema.KeyVerification) {
-			flushed <- rows
+			flushed <- slices.Clone(rows)
 		},
 	})
 
@@ -338,7 +339,7 @@ func TestWithAuthentication_EnforcesWorkspaceRateLimit(t *testing.T) {
 		FlushInterval: time.Hour,
 		Consumers:     1,
 		Flush: func(_ context.Context, rows []schema.KeyVerification) {
-			flushed <- rows
+			flushed <- slices.Clone(rows)
 		},
 	})
 	t.Cleanup(verifications.Close)


### PR DESCRIPTION
## Problem:

After sending logs, we kept references to their bodies and headers in the batch's reusable storage. Go could not free that data, even though we had finished using it.

For example, send four rows, then send just one:

```text
Before: [new row, old row, old row, old row]
After:  [new row, empty,   empty,   empty]
```

Those three old rows could keep large bodies alive until more traffic overwrote them.

## Solution:

Erase the old references after sending a batch. Keep the empty storage for the next batch.

`batch[:0]` already made the slice look empty, but did not erase its contents. Adding `clear(batch)` does that. We keep reusing the storage instead of allocating a new array for every batch.

## Impact:

Go can free completed log data sooner, unless something else still uses it. For example, three old rows with separate 1 MiB bodies could unnecessarily retain 3 MiB. That is an illustration, not a measured production saving.

All rows are still sent. Batch order and shutdown behavior stay unchanged. Code that keeps rows after the flush callback returns must copy them.

## Testing:

Ran the same regression with `mise exec -- rask --no-cache ./pkg/batch`:

- **Before: FAIL.** Unused slots still contain `second`, `third`, and `fourth`.
- **After: PASS.** Those slots are empty.
- The test also verifies that all five rows were sent unchanged.

Batch, buffer, middleware, and targeted race checks passed. The combined stack passed the build and full-suite rerun. This test proves old references are removed; it does not measure production memory savings.