### PR TITLE
perf(frontline): reuse bounded proxy copy buffers

### DIFF
--- a/svc/frontline/internal/proxy/buffer_pool.go
+++ b/svc/frontline/internal/proxy/buffer_pool.go
@@ -1,0 +1,24 @@
+package proxy
+
+const copyBufferSize = 32 << 10
+
+var responseCopyBuffers = make(copyBufferPool, 64)
+
+type copyBufferPool chan []byte
+
+func (p copyBufferPool) Get() []byte {
+	select {
+	case b := <-p:
+		return b
+	default:
+		return make([]byte, copyBufferSize)
+	}
+}
+
+func (p copyBufferPool) Put(b []byte) {
+	clear(b)
+	select {
+	case p <- b:
+	default:
+	}
+}

--- a/svc/frontline/internal/proxy/buffer_pool_test.go
+++ b/svc/frontline/internal/proxy/buffer_pool_test.go
@@ -1,0 +1,70 @@
+package proxy
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCopyBufferPoolClearsAndBoundsIdleBuffers(t *testing.T) {
+	pool := make(copyBufferPool, 1)
+	first, second := pool.Get(), pool.Get()
+	require.Len(t, first, copyBufferSize)
+	require.Len(t, second, copyBufferSize)
+	copy(first, "first tenant")
+	copy(second, "second tenant")
+	pool.Put(first)
+	pool.Put(second)
+	require.Len(t, pool, 1)
+	require.Equal(t, make([]byte, copyBufferSize), pool.Get())
+	require.Empty(t, pool)
+	require.Equal(t, make([]byte, copyBufferSize), second)
+}
+
+func BenchmarkReverseProxyBufferPool(b *testing.B) {
+	for _, pooled := range []bool{false, true} {
+		name := "unpooled"
+		if pooled {
+			name = "pooled"
+		}
+		b.Run(name, func(b *testing.B) {
+			payload := strings.Repeat("x", 64<<10)
+			proxy := httputil.ReverseProxy{
+				Director:  func(_ *http.Request) {},
+				Transport: bufferBenchmarkTransport{payload: payload},
+			}
+			if pooled {
+				proxy.BufferPool = make(copyBufferPool, 64)
+			}
+			req := httptest.NewRequest(http.MethodGet, "http://upstream.test/", nil)
+			b.ReportAllocs()
+			b.SetBytes(int64(len(payload)))
+			b.ResetTimer()
+			for b.Loop() {
+				proxy.ServeHTTP(&discardResponseWriter{header: make(http.Header)}, req)
+			}
+		})
+	}
+}
+
+type bufferBenchmarkTransport struct{ payload string }
+
+func (t bufferBenchmarkTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode:    http.StatusOK,
+		Header:        make(http.Header),
+		Body:          io.NopCloser(strings.NewReader(t.payload)),
+		ContentLength: int64(len(t.payload)),
+	}, nil
+}
+
+type discardResponseWriter struct{ header http.Header }
+
+func (w *discardResponseWriter) Header() http.Header       { return w.header }
+func (*discardResponseWriter) Write(p []byte) (int, error) { return len(p), nil }
+func (*discardResponseWriter) WriteHeader(_ int)           {}

--- a/svc/frontline/internal/proxy/forward.go
+++ b/svc/frontline/internal/proxy/forward.go
@@ -110,6 +110,7 @@ func (s *service) forward(ctx context.Context, sess *zen.Session, cfg forwardCon
 	// nolint:exhaustruct
 	proxy := &httputil.ReverseProxy{
 		Transport:     cfg.transport,
+		BufferPool:    responseCopyBuffers,
 		FlushInterval: -1, // flush immediately for streaming
 		Director: func(req *http.Request) {
 			proxyStartTime = s.clock.Now()


### PR DESCRIPTION
## Problem:

Each proxied response gets a new 32 KiB temporary buffer to copy bytes from upstream to the customer. We throw that buffer away when the response finishes. At high request rates, repeatedly creating and discarding these buffers adds memory-management work.

## Solution:

Reuse the buffer for another response instead of throwing it away. Clear its contents before reuse.

This buffer does not hold the whole response. A 1 MiB response passes through it in chunks of up to 32 KiB. A larger response uses more chunks, not a larger buffer. The full body still reaches the customer.

## Impact:

Keep at most 64 spare buffers, totaling 2 MiB. This is not a limit on active responses:

- No spare buffer? Allocate one; do not wait for another response to finish.
- Spare storage full? Discard the returned buffer.

This saves repeated allocations but adds buffer-clearing work and access to a shared pool. It does not change body logging.

## Testing:

Local benchmark for a 64 KiB response:

| Per response | Before | After |
| --- | ---: | ---: |
| Bytes allocated | 34,536 B | 1,768 B |
| Allocations | 19 | 18 |

The saving is one 32 KiB buffer per response when reused. Proxy tests and targeted race checks passed; tests check buffer clearing and the spare-buffer limit.

**This does not yet prove better performance at 3k+ RPS.** A separate benchmark is comparing this pool, Go's `sync.Pool`, and no pool, including responses lasting 5 ms to 15 seconds. Keep this PR draft until those results are reviewed.