### PR TITLE
go: use typed error matching

### DIFF
--- a/cmd/api/util/errors.go
+++ b/cmd/api/util/errors.go
@@ -13,23 +13,19 @@ func FormatError(err error) string {
 		return ""
 	}
 
-	var forbidden *apierrors.ForbiddenErrorResponse
-	if errors.As(err, &forbidden) {
+	if forbidden, ok := errors.AsType[*apierrors.ForbiddenErrorResponse](err); ok {
 		return fmt.Sprintf("Permission denied: %s", forbidden.Error_.GetDetail())
 	}
 
-	var unauthorized *apierrors.UnauthorizedErrorResponse
-	if errors.As(err, &unauthorized) {
+	if unauthorized, ok := errors.AsType[*apierrors.UnauthorizedErrorResponse](err); ok {
 		return fmt.Sprintf("Authentication failed: %s\n\nCheck your root key or run 'unkey auth login'", unauthorized.Error_.GetDetail())
 	}
 
-	var notFound *apierrors.NotFoundErrorResponse
-	if errors.As(err, &notFound) {
+	if notFound, ok := errors.AsType[*apierrors.NotFoundErrorResponse](err); ok {
 		return fmt.Sprintf("Not found: %s", notFound.Error_.GetDetail())
 	}
 
-	var badRequest *apierrors.BadRequestErrorResponse
-	if errors.As(err, &badRequest) {
+	if badRequest, ok := errors.AsType[*apierrors.BadRequestErrorResponse](err); ok {
 		msg := badRequest.Error_.GetDetail()
 		for _, ve := range badRequest.Error_.GetErrors() {
 			msg += fmt.Sprintf("\n  %s: %s", ve.GetLocation(), ve.GetMessage())

--- a/cmd/deploy/internal/errors/errors.go
+++ b/cmd/deploy/internal/errors/errors.go
@@ -116,23 +116,19 @@ func FormatError(err error) string {
 		return ""
 	}
 
-	var forbiddenErr *apierrors.ForbiddenErrorResponse
-	if errors.As(err, &forbiddenErr) {
+	if forbiddenErr, ok := errors.AsType[*apierrors.ForbiddenErrorResponse](err); ok {
 		return formatPermissionError(forbiddenErr)
 	}
 
-	var unauthorizedErr *apierrors.UnauthorizedErrorResponse
-	if errors.As(err, &unauthorizedErr) {
+	if unauthorizedErr, ok := errors.AsType[*apierrors.UnauthorizedErrorResponse](err); ok {
 		return formatAuthenticationError(unauthorizedErr)
 	}
 
-	var notFoundErr *apierrors.NotFoundErrorResponse
-	if errors.As(err, &notFoundErr) {
+	if notFoundErr, ok := errors.AsType[*apierrors.NotFoundErrorResponse](err); ok {
 		return formatNotFoundError(notFoundErr)
 	}
 
-	var badRequestErr *apierrors.BadRequestErrorResponse
-	if errors.As(err, &badRequestErr) {
+	if badRequestErr, ok := errors.AsType[*apierrors.BadRequestErrorResponse](err); ok {
 		return formatValidationError(badRequestErr)
 	}
 

--- a/cmd/dev/stripe/stripe.go
+++ b/cmd/dev/stripe/stripe.go
@@ -18,8 +18,8 @@ import (
 // longer exists. The dev tools treat that as "already done" rather than a
 // failure: deletes and resets must be idempotent to be useful for cleanup.
 func isResourceMissing(err error) bool {
-	var stripeErr *stripesdk.Error
-	return errors.As(err, &stripeErr) && stripeErr.Code == stripesdk.ErrorCodeResourceMissing
+	stripeErr, ok := errors.AsType[*stripesdk.Error](err)
+	return ok && stripeErr.Code == stripesdk.ErrorCodeResourceMissing
 }
 
 // Cmd is the stripe dev-tools namespace.

--- a/internal/services/ratelimit/origin.go
+++ b/internal/services/ratelimit/origin.go
@@ -22,8 +22,10 @@ func errorReason(err error) string {
 	}
 	// go-redis surfaces a blown deadline as a socket timeout that doesn't unwrap
 	// to context.DeadlineExceeded, so check net.Error too.
-	var netErr net.Error
-	if errors.Is(err, context.DeadlineExceeded) || (errors.As(err, &netErr) && netErr.Timeout()) {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "timeout"
+	}
+	if netErr, ok := errors.AsType[net.Error](err); ok && netErr.Timeout() {
 		return "timeout"
 	}
 	return "other"

--- a/pkg/clickhouse/errors.go
+++ b/pkg/clickhouse/errors.go
@@ -90,8 +90,7 @@ func IsUserQueryError(err error) bool {
 	}
 
 	// Check ClickHouse exception codes
-	var chErr *ch.Exception
-	if errors.As(err, &chErr) {
+	if chErr, ok := errors.AsType[*ch.Exception](err); ok {
 		return userErrorCodes[chErr.Code]
 	}
 
@@ -244,8 +243,7 @@ func WrapClickHouseError(err error) error {
 	}
 
 	// Check ClickHouse exception codes for resource errors
-	var chErr *ch.Exception
-	if errors.As(err, &chErr) {
+	if chErr, ok := errors.AsType[*ch.Exception](err); ok {
 		if response, ok := resourceLimitCodes[chErr.Code]; ok {
 			return fault.Wrap(
 				err,

--- a/pkg/db/handle_err_deadlock.go
+++ b/pkg/db/handle_err_deadlock.go
@@ -86,8 +86,7 @@ func IsConnectionError(err error) bool {
 	}
 
 	// Check for network errors
-	var netErr net.Error
-	if errors.As(err, &netErr) {
+	if _, ok := errors.AsType[net.Error](err); ok {
 		return true
 	}
 
@@ -114,10 +113,6 @@ func isMySQLError(err error, number uint16) bool {
 		return false
 	}
 
-	var mysqlErr *mysql.MySQLError
-	if errors.As(err, &mysqlErr) && mysqlErr.Number == number {
-		return true
-	}
-
-	return false
+	mysqlErr, ok := errors.AsType[*mysql.MySQLError](err)
+	return ok && mysqlErr.Number == number
 }

--- a/pkg/db/handle_err_duplicate_key.go
+++ b/pkg/db/handle_err_duplicate_key.go
@@ -7,12 +7,8 @@ import (
 )
 
 // IsDuplicateKeyError reports whether err is a MySQL duplicate-entry error
-// (error number 1062), traversing wrapped errors via errors.As.
+// (error number 1062), including wrapped errors.
 func IsDuplicateKeyError(err error) bool {
-	var mysqlErr *mysql.MySQLError
-	if errors.As(err, &mysqlErr) && mysqlErr.Number == 1062 {
-		return true
-	}
-
-	return false
+	mysqlErr, ok := errors.AsType[*mysql.MySQLError](err)
+	return ok && mysqlErr.Number == 1062
 }

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -59,8 +59,8 @@ func newResolver(server string, timeout time.Duration) *net.Resolver {
 // (NXDOMAIN, no such host, etc.). These are expected when a record hasn't been
 // configured yet, not actual failures.
 func IsNotFoundError(err error) bool {
-	var dnsErr *net.DNSError
-	return err != nil && errors.As(err, &dnsErr) && dnsErr.IsNotFound
+	dnsErr, ok := errors.AsType[*net.DNSError](err)
+	return ok && dnsErr.IsNotFound
 }
 
 // LookupTXT looks up TXT records for the given domain.

--- a/pkg/dns/domainconnect/client.go
+++ b/pkg/dns/domainconnect/client.go
@@ -151,8 +151,7 @@ func lookupDomainConnectRecord(ctx context.Context, domain string) (string, erro
 
 	records, err := net.DefaultResolver.LookupTXT(ctx, name)
 	if err != nil {
-		var dnsErr *net.DNSError
-		if errors.As(err, &dnsErr) && dnsErr.IsNotFound {
+		if dnsErr, ok := errors.AsType[*net.DNSError](err); ok && dnsErr.IsNotFound {
 			return "", ErrNoDomainConnectRecord
 		}
 		return "", err

--- a/pkg/mysql/handle_err_deadlock.go
+++ b/pkg/mysql/handle_err_deadlock.go
@@ -59,8 +59,7 @@ func IsConnectionError(err error) bool {
 		return true
 	}
 
-	var netErr net.Error
-	if errors.As(err, &netErr) {
+	if _, ok := errors.AsType[net.Error](err); ok {
 		return true
 	}
 
@@ -85,10 +84,6 @@ func isMySQLError(err error, number uint16) bool {
 		return false
 	}
 
-	var mysqlErr *mysql.MySQLError
-	if errors.As(err, &mysqlErr) && mysqlErr.Number == number {
-		return true
-	}
-
-	return false
+	mysqlErr, ok := errors.AsType[*mysql.MySQLError](err)
+	return ok && mysqlErr.Number == number
 }

--- a/pkg/webhook/receiver.go
+++ b/pkg/webhook/receiver.go
@@ -107,8 +107,7 @@ func (rec *Receiver) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	event, err := rec.verifier.Verify(r)
 	if err != nil {
-		var tooLarge *http.MaxBytesError
-		if errors.As(err, &tooLarge) {
+		if _, ok := errors.AsType[*http.MaxBytesError](err); ok {
 			rec.count("none", "too_large")
 			logger.Warn("webhook rejected: body too large", "provider", rec.provider)
 			http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)

--- a/pkg/zen/session.go
+++ b/pkg/zen/session.go
@@ -89,8 +89,7 @@ func (s *Session) Init(w http.ResponseWriter, r *http.Request, maxBodySize int64
 		// Handle read errors (including MaxBytesError)
 		if err != nil {
 			// Check if this is a MaxBytesError from http.MaxBytesReader
-			var maxBytesErr *http.MaxBytesError
-			if errors.As(err, &maxBytesErr) {
+			if maxBytesErr, ok := errors.AsType[*http.MaxBytesError](err); ok {
 				return fault.Wrap(err,
 					fault.Code(codes.User.BadRequest.RequestBodyTooLarge.URN()),
 					fault.Internal(fmt.Sprintf("request body exceeds size limit of %d bytes", maxBytesErr.Limit)),

--- a/svc/api/internal/ctrlclient/errors.go
+++ b/svc/api/internal/ctrlclient/errors.go
@@ -16,8 +16,8 @@ import (
 // "generate upload URL") and will be used to generate user-facing error messages.
 func HandleError(err error, context string) error {
 	// Convert Connect errors to fault errors
-	var connectErr *connect.Error
-	if !errors.As(err, &connectErr) {
+	connectErr, ok := errors.AsType[*connect.Error](err)
+	if !ok {
 		// Non-Connect errors
 		return fault.Wrap(err,
 			fault.Code(codes.App.Internal.ServiceUnavailable.URN()),

--- a/svc/api/internal/customdomain/error.go
+++ b/svc/api/internal/customdomain/error.go
@@ -26,8 +26,8 @@ var ctrlCodes = map[connect.Code]codes.URN{
 // between that read and ctrl's re-check. Anything ctrl does not raise through a gate
 // falls through to [ctrlclient.HandleError].
 func MapCtrlError(err error, action string) error {
-	var connectErr *connect.Error
-	if !errors.As(err, &connectErr) {
+	connectErr, ok := errors.AsType[*connect.Error](err)
+	if !ok {
 		return ctrlclient.HandleError(err, action)
 	}
 

--- a/svc/api/internal/testutil/seed/seed.go
+++ b/svc/api/internal/testutil/seed/seed.go
@@ -466,8 +466,7 @@ func (s *Seeder) CreateRootKey(ctx context.Context, workspaceID string, permissi
 				CreatedAtM:   time.Now().UnixMilli(),
 			})
 
-			mysqlErr := &mysql.MySQLError{} // nolint:exhaustruct
-			if errors.As(err, &mysqlErr) {
+			if mysqlErr, ok := errors.AsType[*mysql.MySQLError](err); ok {
 				require.True(s.t, db.IsDuplicateKeyError(err), "Expected duplicate key error, got MySQL error number %d", mysqlErr.Number)
 				existing, findErr := db.Query.FindPermissionByNameAndWorkspaceID(ctx, s.DB.RO(), db.FindPermissionByNameAndWorkspaceIDParams{
 					WorkspaceID: s.Resources.RootWorkspace.ID,

--- a/svc/api/routes/v2_deployments_create_deployment/handler.go
+++ b/svc/api/routes/v2_deployments_create_deployment/handler.go
@@ -190,8 +190,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 	if err != nil {
 		// Map ctrl's precondition failure to a 412 instead of a 500. Keep its
 		// message in the internal error but return a fixed public reason so callers can't probe upstream state.
-		var connectErr *connect.Error
-		if errors.As(err, &connectErr) && connectErr.Code() == connect.CodeFailedPrecondition {
+		if connectErr, ok := errors.AsType[*connect.Error](err); ok && connectErr.Code() == connect.CodeFailedPrecondition {
 			return fault.Wrap(
 				err,
 				fault.Code(codes.App.Precondition.PreconditionFailed.URN()),

--- a/svc/api/routes/v3_deployments_create_deployment/handler.go
+++ b/svc/api/routes/v3_deployments_create_deployment/handler.go
@@ -185,8 +185,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 	ctrlResp, err := h.CtrlClient.CreateDeployment(ctx, ctrlReq)
 	if err != nil {
-		var connectErr *connect.Error
-		if errors.As(err, &connectErr) && connectErr.Code() == connect.CodeFailedPrecondition {
+		if connectErr, ok := errors.AsType[*connect.Error](err); ok && connectErr.Code() == connect.CodeFailedPrecondition {
 			return fault.Wrap(
 				err,
 				fault.Code(codes.App.Precondition.PreconditionFailed.URN()),

--- a/svc/ctrl/integration/seed/seed.go
+++ b/svc/ctrl/integration/seed/seed.go
@@ -498,8 +498,7 @@ func (s *Seeder) CreateRootKey(ctx context.Context, workspaceID string, permissi
 				CreatedAtM:   time.Now().UnixMilli(),
 			})
 
-			mysqlErr := &mysql.MySQLError{} // nolint:exhaustruct
-			if errors.As(err, &mysqlErr) {
+			if mysqlErr, ok := errors.AsType[*mysql.MySQLError](err); ok {
 				require.True(s.t, db.IsDuplicateKeyError(err), "Expected duplicate key error, got MySQL error number %d", mysqlErr.Number)
 				existing, findErr := s.DB.FindPermissionByNameAndWorkspaceID(ctx, db.FindPermissionByNameAndWorkspaceIDParams{
 					WorkspaceID: s.Resources.RootWorkspace.ID,

--- a/svc/ctrl/internal/billingmeter/stripe.go
+++ b/svc/ctrl/internal/billingmeter/stripe.go
@@ -153,8 +153,8 @@ func (p *stripePusher) Push(ctx context.Context, req PushRequest) (int, error) {
 // terminal fails the push invocation immediately instead. Rate limits (429),
 // request timeouts (408), and 5xx/network errors stay retryable.
 func terminalMeterErr(err error) bool {
-	var sErr *stripe.Error
-	return errors.As(err, &sErr) &&
+	sErr, ok := errors.AsType[*stripe.Error](err)
+	return ok &&
 		sErr.HTTPStatusCode >= 400 && sErr.HTTPStatusCode < 500 &&
 		sErr.HTTPStatusCode != 408 && sErr.HTTPStatusCode != 429
 }

--- a/svc/ctrl/internal/gatefault/gatefault_test.go
+++ b/svc/ctrl/internal/gatefault/gatefault_test.go
@@ -16,8 +16,8 @@ func TestConnect(t *testing.T) {
 	f := fault.New("internal detail", fault.Public("The deployment is not ready."))
 	err := gatefault.Connect(f)
 
-	var ce *connect.Error
-	require.True(t, errors.As(err, &ce))
+	ce, ok := errors.AsType[*connect.Error](err)
+	require.True(t, ok)
 	require.Equal(t, connect.CodeFailedPrecondition, ce.Code())
 	require.Equal(t, "The deployment is not ready.", ce.Message())
 	require.NotContains(t, ce.Message(), "internal detail")

--- a/svc/ctrl/internal/invoicecloser/stripe.go
+++ b/svc/ctrl/internal/invoicecloser/stripe.go
@@ -48,8 +48,7 @@ func (c *stripeCloser) ListDraftInvoices(ctx context.Context, stripeSubscription
 func (c *stripeCloser) GetInvoice(ctx context.Context, invoiceID string) (DraftInvoice, error) {
 	invoice, err := c.client.V1Invoices.Retrieve(ctx, invoiceID, nil)
 	if err != nil {
-		var sErr *stripe.Error
-		if errors.As(err, &sErr) && sErr.Code == stripe.ErrorCodeResourceMissing {
+		if sErr, ok := errors.AsType[*stripe.Error](err); ok && sErr.Code == stripe.ErrorCodeResourceMissing {
 			return DraftInvoice{}, ErrNotFound //nolint:exhaustruct // zero value on the not-found path
 		}
 		return DraftInvoice{}, fault.Wrap(err, fault.Internal("failed to read stripe invoice")) //nolint:exhaustruct // zero value on the error path

--- a/svc/ctrl/services/acme/errors.go
+++ b/svc/ctrl/services/acme/errors.go
@@ -58,8 +58,7 @@ func ParseACMEError(err error) *ParsedACMEError {
 	}
 
 	// Check for rate limit error (lego wraps this nicely)
-	var rateLimitErr *acme.RateLimitedError
-	if errors.As(err, &rateLimitErr) {
+	if rateLimitErr, ok := errors.AsType[*acme.RateLimitedError](err); ok {
 		parsed.Type = ACMEErrorRateLimited
 		parsed.IsRetryable = false
 		parsed.Message = fmt.Sprintf("Let's Encrypt rate limit exceeded: %s", rateLimitErr.Detail)
@@ -75,8 +74,7 @@ func ParseACMEError(err error) *ParsedACMEError {
 	}
 
 	// Check for general ACME problem details
-	var problemErr *acme.ProblemDetails
-	if errors.As(err, &problemErr) {
+	if problemErr, ok := errors.AsType[*acme.ProblemDetails](err); ok {
 		parsed.Message = fmt.Sprintf("ACME error [%s]: %s", problemErr.Type, problemErr.Detail)
 
 		// Check problem type
@@ -177,15 +175,6 @@ func NewRateLimitError(parsed *ParsedACMEError) *RateLimitError {
 		Message:    parsed.Message,
 		RetryAfter: parsed.RetryAfter,
 	}
-}
-
-// AsRateLimitError checks if err is a RateLimitError and returns it.
-func AsRateLimitError(err error) (*RateLimitError, bool) {
-	var rle *RateLimitError
-	if errors.As(err, &rle) {
-		return rle, true
-	}
-	return nil, false
 }
 
 // ShouldRetry returns true if the error is transient and the operation should be retried.

--- a/svc/ctrl/worker/certificate/process_challenge_handler.go
+++ b/svc/ctrl/worker/certificate/process_challenge_handler.go
@@ -3,6 +3,7 @@ package certificate
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 
@@ -119,7 +120,7 @@ func (s *Service) ProcessChallenge(
 		}
 
 		// Check if it's a rate limit error
-		if rle, ok := acme.AsRateLimitError(obtainErr); ok {
+		if rle, ok := errors.AsType[*acme.RateLimitError](obtainErr); ok {
 			if rateLimitRetry >= maxRateLimitRetries {
 				logger.Error("max rate limit retries exceeded",
 					"domain", req.GetDomain(),

--- a/svc/frontline/internal/proxy/error.go
+++ b/svc/frontline/internal/proxy/error.go
@@ -25,12 +25,10 @@ func IsDialError(err error) bool {
 	if err == nil {
 		return false
 	}
-	var netErr *net.OpError
-	if errors.As(err, &netErr) && netErr.Op == "dial" {
+	if netErr, ok := errors.AsType[*net.OpError](err); ok && netErr.Op == "dial" {
 		return true
 	}
-	var dnsErr *net.DNSError
-	if errors.As(err, &dnsErr) {
+	if _, ok := errors.AsType[*net.DNSError](err); ok {
 		return true
 	}
 	return false
@@ -57,8 +55,7 @@ func categorizeProxyError(err error, target string) (codes.URN, string) {
 			fmt.Sprintf("The %s did not respond in time. Please try again later.", target)
 	}
 
-	var netErr *net.OpError
-	if errors.As(err, &netErr) {
+	if netErr, ok := errors.AsType[*net.OpError](err); ok {
 		if netErr.Timeout() {
 			return codes.Frontline.Proxy.GatewayTimeout.URN(),
 				fmt.Sprintf("The %s did not respond in time. Please try again later.", target)
@@ -80,8 +77,7 @@ func categorizeProxyError(err error, target string) (codes.URN, string) {
 		}
 	}
 
-	var dnsErr *net.DNSError
-	if errors.As(err, &dnsErr) {
+	if dnsErr, ok := errors.AsType[*net.DNSError](err); ok {
 		if dnsErr.IsNotFound {
 			return codes.Frontline.Proxy.ServiceUnavailable.URN(),
 				fmt.Sprintf("DNS resolution failed for the %s. Please check your configuration or contact support at support@unkey.com.", target)

--- a/svc/vault/internal/storage/s3.go
+++ b/svc/vault/internal/storage/s3.go
@@ -59,8 +59,7 @@ func NewS3(config S3Config) (Storage, error) {
 		Bucket: aws.String(config.S3Bucket),
 	})
 	if err != nil {
-		var alreadyOwned *s3types.BucketAlreadyOwnedByYou
-		if !errors.As(err, &alreadyOwned) {
+		if _, ok := errors.AsType[*s3types.BucketAlreadyOwnedByYou](err); !ok {
 			return nil, fmt.Errorf("failed to create bucket: %w", err)
 		}
 	}
@@ -98,9 +97,10 @@ func (s *s3) GetObject(ctx context.Context, key string) ([]byte, bool, error) {
 	if err != nil {
 		// A missing key is an expected miss, not an error. S3 reports it as
 		// NoSuchKey; some S3-compatible stores only surface the 404 status.
-		var noSuchKey *s3types.NoSuchKey
-		var respErr *awshttp.ResponseError
-		if errors.As(err, &noSuchKey) || (errors.As(err, &respErr) && respErr.HTTPStatusCode() == http.StatusNotFound) {
+		if _, ok := errors.AsType[*s3types.NoSuchKey](err); ok {
+			return nil, false, nil
+		}
+		if respErr, ok := errors.AsType[*awshttp.ResponseError](err); ok && respErr.HTTPStatusCode() == http.StatusNotFound {
 			return nil, false, nil
 		}
 		return nil, false, fmt.Errorf("failed to get object: %w", err)

--- a/web/tools/gha-fetch-digest/cmd/main.go
+++ b/web/tools/gha-fetch-digest/cmd/main.go
@@ -114,8 +114,7 @@ func fetchTag(ctx context.Context, client *github.Client, owner, repo string) (s
 
 	release, _, err := client.Repositories.GetLatestRelease(ctx, owner, repo)
 	if err != nil {
-		var errResp *github.ErrorResponse
-		if errors.As(err, &errResp) {
+		if errResp, ok := errors.AsType[*github.ErrorResponse](err); ok {
 			if errResp.Response != nil && errResp.Response.StatusCode == 404 {
 				return "", fmt.Errorf("no latest release found. Check available releases at: https://github.com/%s/%s/releases", owner, repo)
 			}
@@ -124,8 +123,7 @@ func fetchTag(ctx context.Context, client *github.Client, owner, repo string) (s
 			}
 		}
 
-		var rateLimitErr *github.RateLimitError
-		if errors.As(err, &rateLimitErr) {
+		if rateLimitErr, ok := errors.AsType[*github.RateLimitError](err); ok {
 			return "", fmt.Errorf("GitHub API rate limit exceeded. Resets at %v. Set GITHUB_TOKEN environment variable",
 				rateLimitErr.Rate.Reset.Time)
 		}
@@ -143,8 +141,7 @@ func fetchTag(ctx context.Context, client *github.Client, owner, repo string) (s
 func fetchCommitSHA(ctx context.Context, client *github.Client, owner, repo, tag string) (string, error) {
 	commit, _, err := client.Repositories.GetCommit(ctx, owner, repo, tag, nil)
 	if err != nil {
-		var errResp *github.ErrorResponse
-		if errors.As(err, &errResp) && errResp.Response != nil && errResp.Response.StatusCode == 404 {
+		if errResp, ok := errors.AsType[*github.ErrorResponse](err); ok && errResp.Response != nil && errResp.Response.StatusCode == 404 {
 			return "", fmt.Errorf("tag '%s' not found in repository %s/%s", tag, owner, repo)
 		}
 		return "", fmt.Errorf("error fetching commit for tag %s: %w", tag, err)


### PR DESCRIPTION
## Problem:

Go added a new errors.AsType generic which replaces our usual copy paste of

```
var notFound *apierrors.NotFoundErrorResponse
	if errors.As(err, &notFound) {
             .....
        }
```

with a single

```
if notFound, ok := errors.AsType[*apierrors.NotFoundErrorResponse](err); ok {
    return fmt.Sprintf("Not found: %s", notFound.Error_.GetDetail())
}
```

## Impact:

Cleaner code

## Testing:

- Targeted checks in affected packages passed: 1,532 tests.
- Build and lint passed with 0 issues.
- The nested GitHub Action helper module passed its 3 tests.
- Final combined stack: `mise run test --concurrency 2` passed 300 suites: 24,281 passed, 0 failed, 7,898 ignored; 83 suites cached.

Refresh on 2026-09-20:
- Integrated [main at f48de30](https://github.com/unkeyed/unkey/commit/f48de30bc100ae79dffe1200bf7e42d09b26d46e) through the parent branches. Published history is preserved.
- Preserved the Restate deployment flow and externally managed S3 buckets. Added typed matching for new observations and preserved ClickHouse and S3 short-circuit behavior. ClickHouse/storage race verification passed 1,180 tests; the final S3 check passed 68 tests.
- Local refreshed combined dependency tree: build/lint passed with zero issues; full normal suite passed 310 suites, 25,029 tests, zero failures and 7,875 ignored. Tagged checks passed 386 tests; tagged race checks passed 29 tests. These combined results include the separate OpenAPI and dependency prerequisites; they are not a claim that this individual PR passed CI.
- Full combined race verification is still running. Dependency PR publication remains separate.