### PR TITLE
go: use CutLast for suffix and prefix parsing

### DIFF
--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -382,8 +382,8 @@ func (c *Client) GetScopedInstallationToken(installationID int64, repo string, p
 			var repositories []string
 			if repo != "" {
 				repoName := repo
-				if idx := strings.LastIndex(repo, "/"); idx >= 0 {
-					repoName = repo[idx+1:]
+				if _, name, found := strings.CutLast(repo, "/"); found {
+					repoName = name
 				}
 				repositories = []string{repoName}
 			}

--- a/pkg/testutil/containers/compose.go
+++ b/pkg/testutil/containers/compose.go
@@ -216,9 +216,9 @@ func composePort(output string) (int, error) {
 		return strconv.Atoi(port)
 	}
 
-	idx := strings.LastIndex(line, ":")
-	if idx == -1 || idx == len(line)-1 {
+	_, port, found := strings.CutLast(line, ":")
+	if !found || port == "" {
 		return 0, fmt.Errorf("parse docker compose port output %q: %w", output, err)
 	}
-	return strconv.Atoi(line[idx+1:])
+	return strconv.Atoi(port)
 }

--- a/svc/api/internal/githubapp/githubapp.go
+++ b/svc/api/internal/githubapp/githubapp.go
@@ -131,8 +131,7 @@ func DefaultBranch(fallback string, override *string) string {
 func normalizeRepository(repository string) (string, error) {
 	repository = strings.TrimSpace(repository)
 
-	if i := strings.LastIndex(repository, "github.com"); i >= 0 {
-		rest := repository[i+len("github.com"):]
+	if _, rest, found := strings.CutLast(repository, "github.com"); found {
 		if strings.HasPrefix(rest, "/") || strings.HasPrefix(rest, ":") {
 			repository = strings.TrimLeft(rest, "/:")
 		}

--- a/svc/api/routes/v2_keys_reroll_key/handler.go
+++ b/svc/api/routes/v2_keys_reroll_key/handler.go
@@ -131,9 +131,8 @@ func (h *Handler) RerollKey(
 	length := 16
 	prefix := keyData.Key.Prefix
 	if prefix == "" {
-		separator := strings.LastIndex(keyData.Key.Start, "_")
-		if separator >= 0 {
-			prefix = keyData.Key.Start[:separator]
+		if legacyPrefix, _, found := strings.CutLast(keyData.Key.Start, "_"); found {
+			prefix = legacyPrefix
 		}
 	}
 


### PR DESCRIPTION
## Problem:

Four parsing sites manually locate the last separator and slice the string. The standard library now provides this operation.

## Solution:

Use strings.CutLast for GitHub path parsing, test-container port parsing, and rerolled key prefixes.

## Impact:

Layer 6 of 7, based on #7324. Existing results remain unchanged, including inputs without a separator.

## Testing:

- Targeted checks across the four affected packages passed: 89 tests.
- Final combined stack: `mise run build` passed, including lint with 0 issues.
- Final combined stack: `mise run test --concurrency 2` passed 300 suites: 24,281 passed, 0 failed, 7,898 ignored; 83 suites cached.

Refresh on 2026-09-20:
- Integrated [main at f48de30](https://github.com/unkeyed/unkey/commit/f48de30bc100ae79dffe1200bf7e42d09b26d46e) through the parent branches. Published history is preserved.
- Refreshed the parent branch without changing this layer’s intended behavior.
- Local refreshed combined dependency tree: build/lint passed with zero issues; full normal suite passed 310 suites, 25,029 tests, zero failures and 7,875 ignored. Tagged checks passed 386 tests; tagged race checks passed 29 tests. These combined results include the separate OpenAPI and dependency prerequisites; they are not a claim that this individual PR passed CI.
- Full combined race verification is still running. Dependency PR publication remains separate.