### PR TITLE
paseto: use strict JSON decoding for payload validation

### DIFF
--- a/pkg/paseto/payload.go
+++ b/pkg/paseto/payload.go
@@ -1,15 +1,12 @@
 package paseto
 
 import (
-	"bytes"
 	"encoding/json"
 	jsonv2 "encoding/json/v2"
 	"fmt"
-	"io"
 	"reflect"
 	"regexp"
 	"time"
-	"unicode/utf8"
 )
 
 var rfc3339DateTimePattern = regexp.MustCompile(
@@ -54,92 +51,18 @@ func decodePayload[T ClaimSet](encoded []byte) (T, error) {
 }
 
 func inspectPayload(encoded []byte) (payloadObject, error) {
-	if !utf8.Valid(encoded) {
-		return payloadObject{}, fmt.Errorf("payload is not valid UTF-8")
-	}
-	object := map[string]json.RawMessage{}
-	if err := json.Unmarshal(encoded, &object); err != nil {
+	var object map[string]json.RawMessage
+	if err := jsonv2.Unmarshal(encoded, &object); err != nil {
 		return payloadObject{}, fmt.Errorf("decode payload object: %w", err)
 	}
-	if err := requireUniqueJSONObject(encoded); err != nil {
-		return payloadObject{}, err
+	if object == nil {
+		return payloadObject{}, fmt.Errorf("payload must be a JSON object")
 	}
 	claims, err := parseRegisteredClaims(object)
 	if err != nil {
 		return payloadObject{}, err
 	}
 	return payloadObject{claims: claims, fields: object}, nil
-}
-
-func requireUniqueJSONObject(encoded []byte) error {
-	decoder := json.NewDecoder(bytes.NewReader(encoded))
-	decoder.UseNumber()
-	first, err := decoder.Token()
-	if err != nil {
-		return fmt.Errorf("decode payload: %w", err)
-	}
-	delimiter, ok := first.(json.Delim)
-	if !ok || delimiter != '{' {
-		return fmt.Errorf("payload must be a JSON object")
-	}
-	if err := inspectJSONObject(decoder); err != nil {
-		return err
-	}
-	if _, err := decoder.Token(); err != io.EOF {
-		if err == nil {
-			return fmt.Errorf("payload contains data after the JSON object")
-		}
-		return fmt.Errorf("decode payload: %w", err)
-	}
-	return nil
-}
-
-func inspectJSONValue(decoder *json.Decoder) error {
-	token, err := decoder.Token()
-	if err != nil {
-		return fmt.Errorf("decode JSON value: %w", err)
-	}
-	delimiter, ok := token.(json.Delim)
-	if !ok {
-		return nil
-	}
-	if delimiter == '{' {
-		return inspectJSONObject(decoder)
-	}
-	// At a value boundary, the decoder can return only an opening object or
-	// array delimiter. The object case returned above, so this is an array.
-	for decoder.More() {
-		if err := inspectJSONValue(decoder); err != nil {
-			return err
-		}
-	}
-	if _, err := decoder.Token(); err != nil {
-		return fmt.Errorf("decode JSON array: %w", err)
-	}
-	return nil
-}
-
-func inspectJSONObject(decoder *json.Decoder) error {
-	seen := map[string]struct{}{}
-	for decoder.More() {
-		token, err := decoder.Token()
-		if err != nil {
-			return fmt.Errorf("decode JSON object key: %w", err)
-		}
-		// A decoder inside an object returns a string token for every key.
-		key := token.(string)
-		if _, duplicate := seen[key]; duplicate {
-			return fmt.Errorf("payload contains duplicate key %q", key)
-		}
-		seen[key] = struct{}{}
-		if err := inspectJSONValue(decoder); err != nil {
-			return err
-		}
-	}
-	if _, err := decoder.Token(); err != nil {
-		return fmt.Errorf("decode JSON object: %w", err)
-	}
-	return nil
 }
 
 func parseRegisteredClaims(object map[string]json.RawMessage) (Claims, error) {

--- a/pkg/paseto/payload_test.go
+++ b/pkg/paseto/payload_test.go
@@ -40,8 +40,11 @@ func TestPayloadDecoding_RejectsInvalidAuthenticatedJSON(t *testing.T) {
 		{name: "string", payload: []byte(`"payload"`)},
 		{name: "trailing value", payload: []byte(`{} {}`)},
 		{name: "invalid UTF-8", payload: []byte{'{', '"', 'x', '"', ':', '"', 0xff, '"', '}'}},
+		{name: "invalid Unicode escape", payload: []byte(`{"x":"\ud800"}`)},
 		{name: "duplicate top-level key", payload: []byte(`{"role":"reader","role":"admin"}`)},
 		{name: "duplicate nested key", payload: []byte(`{"nested":{"key":1,"key":2}}`)},
+		{name: "duplicate key in array", payload: []byte(`{"nested":[{"key":1,"key":2}]}`)},
+		{name: "escaped duplicate key", payload: []byte(`{"role":"reader","\u0072ole":"admin"}`)},
 		{name: "issuer number", payload: []byte(`{"iss":1}`)},
 		{name: "issuer null", payload: []byte(`{"iss":null}`)},
 		{name: "subject object", payload: []byte(`{"sub":{}}`)},
@@ -89,9 +92,7 @@ func TestPayloadDecoding_RejectsMalformedStringClaim(t *testing.T) {
 	require.Error(t, err)
 }
 
-// TestUniqueJSONObject_RejectsEveryTruncationBoundary guarantees malformed
-// objects fail whether truncation occurs in a value, array, or object.
-func TestUniqueJSONObject_RejectsEveryTruncationBoundary(t *testing.T) {
+func TestPayloadInspection_RejectsEveryTruncationBoundary(t *testing.T) {
 	tests := []struct {
 		name    string
 		payload string
@@ -107,7 +108,8 @@ func TestUniqueJSONObject_RejectsEveryTruncationBoundary(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			require.Error(t, requireUniqueJSONObject([]byte(test.payload)))
+			_, err := inspectPayload([]byte(test.payload))
+			require.Error(t, err)
 		})
 	}
 }


### PR DESCRIPTION
## Problem:

PASETO payload validation maintains a recursive JSON walker to reject duplicate names and malformed input. The strict standard-library decoder can perform this validation.

## Solution:

Use JSON v2 validation and remove the custom walker. Retain object-only payloads and registered-claim validation. Add coverage for escaped duplicate names, duplicate names inside arrays, and invalid Unicode escapes.

## Impact:

Layer 7 of 7, based on #7325. Duplicate names, malformed JSON, invalid UTF-8, and non-object payloads remain invalid. Unpaired Unicode surrogates are now rejected rather than replaced. Valid payloads retain the existing claim rules.

## Testing:

- Targeted PASETO checks passed: 1,411 passed, 14 ignored.
- Final combined stack: `mise run build` passed, including lint with 0 issues.
- Final combined stack: `mise run test --concurrency 2` passed 300 suites: 24,281 passed, 0 failed, 7,898 ignored; 83 suites cached.
- BPF generation passed with no generated changes.