### PR TITLE
fix(heimdall): ignore exec-process exit events

### DIFF
--- a/svc/heimdall/internal/collector/cri_linux.go
+++ b/svc/heimdall/internal/collector/cri_linux.go
@@ -169,6 +169,9 @@ func (w *criWatcher) handle(ctx context.Context, topic string, raw typeurl.Any) 
 		containerID = evt.GetContainerID()
 		metrics.CRIEventsReceived.WithLabelValues("start").Inc()
 	case *eventstypes.TaskExit:
+		if evt.GetID() != evt.GetContainerID() {
+			return
+		}
 		kind = criExit
 		containerID = evt.GetContainerID()
 		metrics.CRIEventsReceived.WithLabelValues("exit").Inc()

--- a/svc/heimdall/internal/collector/cri_linux_test.go
+++ b/svc/heimdall/internal/collector/cri_linux_test.go
@@ -1,0 +1,24 @@
+//go:build linux
+
+package collector
+
+import (
+	"testing"
+
+	eventstypes "github.com/containerd/containerd/api/events"
+	"github.com/containerd/typeurl/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCRIWatcherIgnoresExecExitBeforeContainerLookup(t *testing.T) {
+	event, err := typeurl.MarshalAny(&eventstypes.TaskExit{
+		ContainerID: "container-id",
+		ID:          "exec-id",
+	})
+	require.NoError(t, err)
+
+	watcher := &criWatcher{}
+	require.NotPanics(t, func() {
+		watcher.handle(t.Context(), "/tasks/exit", event)
+	})
+}


### PR DESCRIPTION
## Problem:

Heimdall treated exec-process exits as container exits. POST healthchecks and custom preStop hooks could detach network tracking and reset byte counters, causing underbilling.

## Solution:

Ignore exec-process exits. Keep final checkpoints and network cleanup for main-process exits.

## Impact:

POST probes no longer interrupt network tracking or reset counters. Actual container-exit behavior remains unchanged.

## Testing:

- Added a regression test that confirms exec exits are ignored before container lookup.
- `mise exec -- rask ./svc/heimdall/internal/collector`: 18 tests passed.
- `mise run build`: passed; lint reported 0 issues.
- `mise run test`: 300 suites, 24,331 passed, 0 failed, 7,877 ignored.
- `git diff --check`: clean.