### PR TITLE
fix(dashboard): Paginate the Active Branches card

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/overview/components/active-branches/index.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/overview/components/active-branches/index.tsx
@@ -7,6 +7,7 @@ import {
   ResourceList,
   ResourceListBody,
   ResourceListContent,
+  ResourceListFooter,
   ResourceListHeader,
 } from "@unkey/ui";
 import Link from "next/link";
@@ -20,7 +21,8 @@ export function ActiveBranches() {
   const workspace = useWorkspaceNavigation();
   const { projectId, environments } = useProjectData();
   const appId = useAppId();
-  const { branches, isLoading, isError, refetch } = useActiveBranches();
+  const { branches, isLoading, isError, refetch, hasNextPage, isFetchingNextPage, fetchNextPage } =
+    useActiveBranches();
   const {
     app,
     currentDeployment,
@@ -88,6 +90,19 @@ export function ActiveBranches() {
                 />
               ))}
             </ResourceListBody>
+          )}
+          {hasNextPage && (
+            <ResourceListFooter>
+              <Button
+                size="md"
+                variant="outline"
+                disabled={isFetchingNextPage}
+                loading={isFetchingNextPage}
+                onClick={() => fetchNextPage()}
+              >
+                Load more
+              </Button>
+            </ResourceListFooter>
           )}
         </ResourceListContent>
       )}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/overview/components/active-branches/use-active-branches.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/overview/components/active-branches/use-active-branches.ts
@@ -1,22 +1,35 @@
 import { isDeploymentSettling } from "@/lib/collections/deploy/deployment-status";
 import { trpc } from "@/lib/trpc/client";
+import { useMemo } from "react";
 import { useAppId, useProjectData } from "../../../data-provider";
+
+const PAGE_SIZE = 10;
 
 export function useActiveBranches() {
   const { projectId } = useProjectData();
   const appId = useAppId();
 
-  const query = trpc.deploy.deployment.listActiveBranches.useQuery(
-    { projectId, appId },
+  const query = trpc.deploy.deployment.listActiveBranches.useInfiniteQuery(
+    { projectId, appId, limit: PAGE_SIZE },
     {
-      refetchInterval: (data) => (data?.some(isDeploymentSettling) ? 5_000 : false),
+      getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+      refetchInterval: (data) =>
+        data?.pages[0]?.branches.some(isDeploymentSettling) ? 5_000 : false,
     },
   );
 
+  const branches = useMemo(
+    () => (query.data?.pages ?? []).flatMap((page) => page.branches),
+    [query.data],
+  );
+
   return {
-    branches: query.data ?? [],
-    isLoading: query.isLoading,
+    branches,
+    isLoading: query.isInitialLoading,
     isError: query.isError,
     refetch: query.refetch,
+    hasNextPage: query.hasNextPage ?? false,
+    isFetchingNextPage: query.isFetchingNextPage,
+    fetchNextPage: query.fetchNextPage,
   };
 }

--- a/web/apps/dashboard/lib/trpc/routers/deploy/deployment/list-active-branches.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/deployment/list-active-branches.ts
@@ -1,14 +1,21 @@
-import { and, db, desc, eq, isNotNull, ne, sql } from "@/lib/db";
+import { and, db, desc, eq, isNotNull, lt, ne, or, sql } from "@/lib/db";
 import { ratelimit, withRatelimit, workspaceProcedure } from "@/lib/trpc/trpc";
 import { deployments, environments } from "@unkey/db/src/schema";
 import { z } from "zod";
 import { deploymentListSelect } from "./deployment-query-helpers";
 import { enrichDeploymentRows } from "./enrich-deployment-rows";
 
-const ACTIVE_BRANCHES_LIMIT = 100;
+const MAX_LIMIT = 100;
 
 export const listActiveBranches = workspaceProcedure
-  .input(z.object({ projectId: z.string(), appId: z.string() }))
+  .input(
+    z.object({
+      projectId: z.string(),
+      appId: z.string(),
+      limit: z.number().int().min(1).max(MAX_LIMIT).default(10),
+      cursor: z.object({ createdAt: z.number().int(), id: z.string() }).nullish(),
+    }),
+  )
   .use(withRatelimit(ratelimit.read))
   .query(async ({ ctx, input }) => {
     const ranked = db
@@ -35,9 +42,35 @@ export const listActiveBranches = workspaceProcedure
       .from(deployments)
       .innerJoin(ranked, eq(ranked.id, deployments.id))
       .innerJoin(environments, eq(environments.id, deployments.environmentId))
-      .where(and(eq(ranked.rn, 1), eq(environments.kind, "preview")))
+      .where(
+        and(
+          eq(ranked.rn, 1),
+          eq(environments.kind, "preview"),
+          input.cursor
+            ? or(
+                lt(deployments.createdAt, input.cursor.createdAt),
+                and(
+                  eq(deployments.createdAt, input.cursor.createdAt),
+                  lt(deployments.id, input.cursor.id),
+                ),
+              )
+            : undefined,
+        ),
+      )
       .orderBy(desc(deployments.createdAt), desc(deployments.id))
-      .limit(ACTIVE_BRANCHES_LIMIT);
+      .limit(input.limit + 1);
 
-    return enrichDeploymentRows(ctx.workspace.id, rows);
+    const hasMore = rows.length > input.limit;
+    const branchRows = hasMore ? rows.slice(0, input.limit) : rows;
+    const last = branchRows.at(-1);
+    const nextCursor = hasMore && last ? { createdAt: last.createdAt, id: last.id } : null;
+
+    if (branchRows.length === 0) {
+      return { branches: [], nextCursor: null };
+    }
+
+    return {
+      branches: await enrichDeploymentRows(ctx.workspace.id, branchRows),
+      nextCursor,
+    };
   });


### PR DESCRIPTION
## Why

I forgot to paginate the active branches list which meant that repo's with a large number of branches ended up having a really loong page. This paginates them. 

## Verification

`pnpm --dir=web/apps/dashboard typecheck` passes, and Biome reports no changes on the three touched files. By hand against an app with fifteen preview branches: the card shows ten rows and the button, one click appends the remaining five in date order with no repeat and no gap, and the button then disappears. Not covered: a deployment that arrives while a later page is open.

**Before** — every branch at once

![Before](https://github.com/user-attachments/assets/944b977c-3784-4280-9b7d-e5f0e912d348)

**After** — ten branches and a Load more button

![After](https://github.com/user-attachments/assets/20076311-995d-4700-94a5-e63e81ee7fb2)
