### PR TITLE
fix: Pre-filter inactive deployment statuses

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/components/deployments-card-list.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/components/deployments-card-list.tsx
@@ -81,10 +81,10 @@ export function DeploymentsCardList() {
           ) : (
             <Empty className="w-[400px] flex items-start">
               <Empty.Icon className="w-auto" />
-              <Empty.Title>No Deployments Found</Empty.Title>
+              <Empty.Title>No Active Deployments</Empty.Title>
               <Empty.Description className="text-left">
-                There are no deployments yet. Push to your connected repository or trigger a manual
-                deployment to get started.
+                Push to your connected repository or trigger a manual deployment to get started.
+                Cancelled, superseded and stopped deployments are hidden by default.
               </Empty.Description>
               <Empty.Actions className="mt-4 justify-start">
                 <a

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/hooks/use-deployments.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/hooks/use-deployments.ts
@@ -17,7 +17,7 @@ export type DeploymentListRow = {
 export function useDeployments() {
   const { projectId, environments, isEnvironmentsLoading } = useProjectData();
   const appId = useAppId();
-  const { filters } = useFilters();
+  const { filters, isFiltered } = useFilters();
 
   const { input, cannotMatch } = useMemo(
     () => buildDeploymentListInput(filters, environments),
@@ -55,7 +55,7 @@ export function useDeployments() {
     isLoading: isEnvironmentsLoading || query.isInitialLoading,
     isError: query.isError,
     refetch: query.refetch,
-    isFiltered: filters.length > 0,
+    isFiltered,
     hasNextPage: query.hasNextPage ?? false,
     isFetchingNextPage: query.isFetchingNextPage,
     fetchNextPage: query.fetchNextPage,

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/hooks/use-filters.test.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/hooks/use-filters.test.ts
@@ -1,0 +1,109 @@
+import { renderHook } from "@testing-library/react";
+import { useQueryStates } from "nuqs";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DeploymentListQuerySearchParams } from "../filters.schema";
+import { useFilters } from "./use-filters";
+
+vi.mock("nuqs", () => ({
+  useQueryStates: vi.fn(),
+  parseAsInteger: {
+    parse: (str: string | null) => (str ? Number.parseInt(str) : null),
+    serialize: (value: number | null) => value?.toString() ?? "",
+  },
+}));
+
+vi.stubGlobal("crypto", { randomUUID: vi.fn(() => "test-uuid") });
+
+const mockUseQueryStates = vi.mocked(useQueryStates);
+const mockSetSearchParams = vi.fn();
+
+const stubSearchParams = (overrides: Partial<DeploymentListQuerySearchParams> = {}) => {
+  mockUseQueryStates.mockImplementation(() => [
+    {
+      status: null,
+      environment: null,
+      branch: null,
+      startTime: null,
+      endTime: null,
+      since: null,
+      ...overrides,
+    },
+    mockSetSearchParams,
+  ]);
+};
+
+const statusValues = (filters: ReturnType<typeof useFilters>["filters"]) =>
+  filters.flatMap((f) => (f.field === "status" ? [f.value] : []));
+
+describe("useFilters", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stubSearchParams();
+  });
+
+  it("pre-selects the default status groups when the url carries no status", () => {
+    const { result } = renderHook(() => useFilters());
+
+    expect(statusValues(result.current.filters)).toEqual([
+      "ready",
+      "failed",
+      "building",
+      "queued",
+      "blocked",
+    ]);
+    expect(result.current.isFiltered).toBe(false);
+  });
+
+  it("reports an explicit selection matching the default as unfiltered", () => {
+    stubSearchParams({
+      status: ["blocked", "queued", "building", "failed", "ready"].map((value) => ({
+        value,
+        operator: "is",
+      })),
+    });
+
+    const { result } = renderHook(() => useFilters());
+    expect(result.current.isFiltered).toBe(false);
+  });
+
+  it("keeps an explicit selection that widens past the default", () => {
+    stubSearchParams({
+      status: [{ value: "superseded", operator: "is" }],
+    });
+
+    const { result } = renderHook(() => useFilters());
+    expect(statusValues(result.current.filters)).toEqual(["superseded"]);
+    expect(result.current.isFiltered).toBe(true);
+  });
+
+  it("keeps the default statuses while another field is filtered", () => {
+    stubSearchParams({ branch: [{ value: "main", operator: "is" }] });
+
+    const { result } = renderHook(() => useFilters());
+    expect(statusValues(result.current.filters)).toHaveLength(5);
+    expect(result.current.isFiltered).toBe(true);
+  });
+
+  it("writes the default statuses alongside a newly toggled one", () => {
+    const { result } = renderHook(() => useFilters());
+    result.current.toggleArrayFilter("status", "superseded");
+
+    expect(mockSetSearchParams).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: ["ready", "failed", "building", "queued", "blocked", "superseded"].map((value) => ({
+          value,
+          operator: "is",
+        })),
+      }),
+    );
+  });
+
+  it("falls back to the default statuses when the last one is unticked", () => {
+    stubSearchParams({ status: [{ value: "ready", operator: "is" }] });
+
+    const { result } = renderHook(() => useFilters());
+    result.current.toggleArrayFilter("status", "ready");
+
+    expect(mockSetSearchParams).toHaveBeenCalledWith(expect.objectContaining({ status: null }));
+  });
+});

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/hooks/use-filters.ts
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/deployments/hooks/use-filters.ts
@@ -2,6 +2,7 @@ import {
   parseAsFilterValueArray,
   parseAsRelativeTime,
 } from "@/components/logs/validation/utils/nuqs-parsers";
+import { DEFAULT_DEPLOYMENT_STATUS_GROUPS } from "@/lib/collections/deploy/deployment-status";
 import { parseAsInteger, useQueryStates } from "nuqs";
 import { useCallback, useMemo } from "react";
 import {
@@ -27,6 +28,19 @@ export const queryParamsPayload = {
 const arrayFields = ["status", "environment", "branch"] as const;
 const timeFields = ["startTime", "endTime", "since"] as const;
 
+// The status filter starts pre-selected rather than empty, so an absent url
+// param means the default selection, not "every status".
+const defaultStatusParam: DeploymentListFilterUrlValue[] = DEFAULT_DEPLOYMENT_STATUS_GROUPS.map(
+  (value) => ({ value, operator: "is" }),
+);
+
+const isDefaultStatusSelection = (selection: readonly { value: string | number }[] | null) =>
+  selection === null ||
+  (selection.length === DEFAULT_DEPLOYMENT_STATUS_GROUPS.length &&
+    selection.every((item) =>
+      DEFAULT_DEPLOYMENT_STATUS_GROUPS.some((group) => group === item.value),
+    ));
+
 export const useFilters = () => {
   const [searchParams, setSearchParams] = useQueryStates(queryParamsPayload, {
     history: "push",
@@ -37,7 +51,9 @@ export const useFilters = () => {
 
     // Handle array filters
     arrayFields.forEach((field) => {
-      searchParams[field]?.forEach((item) => {
+      const selection =
+        field === "status" ? (searchParams.status ?? defaultStatusParam) : searchParams[field];
+      selection?.forEach((item) => {
         activeFilters.push({
           id: crypto.randomUUID(),
           field,
@@ -128,8 +144,19 @@ export const useFilters = () => {
     [filters, updateFilters],
   );
 
+  // Whether the user narrowed the list themselves, as opposed to only seeing the
+  // default status selection.
+  const isFiltered = useMemo(
+    () =>
+      !isDefaultStatusSelection(searchParams.status) ||
+      arrayFields.some((field) => field !== "status" && (searchParams[field]?.length ?? 0) > 0) ||
+      timeFields.some((field) => searchParams[field] !== null),
+    [searchParams],
+  );
+
   return {
     filters,
+    isFiltered,
     removeFilter,
     updateFilters,
     toggleArrayFilter,

--- a/web/apps/dashboard/lib/collections/deploy/deployment-status.test.ts
+++ b/web/apps/dashboard/lib/collections/deploy/deployment-status.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import {
+  DEFAULT_DEPLOYMENT_STATUS_GROUPS,
   DEPLOYMENT_STATUSES,
   DEPLOYMENT_STATUS_GROUPS,
   DEPLOYMENT_STATUS_GROUP_NAMES,
@@ -36,6 +37,18 @@ describe("DEPLOYMENT_STATUS_GROUPS", () => {
       "cancelled",
       "superseded",
       "stopped",
+    ]);
+  });
+});
+
+describe("DEFAULT_DEPLOYMENT_STATUS_GROUPS", () => {
+  test("holds every group except the ones out of play", () => {
+    expect(DEFAULT_DEPLOYMENT_STATUS_GROUPS).toEqual([
+      "ready",
+      "failed",
+      "building",
+      "queued",
+      "blocked",
     ]);
   });
 });

--- a/web/apps/dashboard/lib/collections/deploy/deployment-status.ts
+++ b/web/apps/dashboard/lib/collections/deploy/deployment-status.ts
@@ -70,6 +70,19 @@ export const DEPLOYMENT_STATUS_GROUP_NAMES = Object.keys(
   DEPLOYMENT_STATUS_GROUPS,
 ) as DeploymentStatusGroup[];
 
+// Groups holding deployments that are out of play. They accumulate on an active
+// app and bury the rows a user came to look at, so the list starts with them
+// filtered out; selecting them in the status filter brings them back.
+const DEPLOYMENT_STATUS_GROUPS_HIDDEN_BY_DEFAULT = new Set<DeploymentStatusGroup>([
+  "cancelled",
+  "superseded",
+  "stopped",
+]);
+
+export const DEFAULT_DEPLOYMENT_STATUS_GROUPS = DEPLOYMENT_STATUS_GROUP_NAMES.filter(
+  (group) => !DEPLOYMENT_STATUS_GROUPS_HIDDEN_BY_DEFAULT.has(group),
+);
+
 export function isDeploymentStatusGroup(value: string): value is DeploymentStatusGroup {
   return Object.hasOwn(DEPLOYMENT_STATUS_GROUPS, value);
 }


### PR DESCRIPTION
problem: When a user is using a monorepo they may have more skipped then active deployments. 

solution: We now prefilter the deployments page so a user can see active, building, queued, or required approvals by default.

Testing: Go to your project and go to deployments and you should see a pre-filtered deployments list

Before:

<img width="2398" height="876" alt="CleanShot 2026-09-08 at 12 52 13@2x" src="https://github.com/user-attachments/assets/34bc5aa9-8358-47e6-a749-1ce1af38f4a7" />

After:
<img width="2318" height="878" alt="CleanShot 2026-09-08 at 12 52 19@2x" src="https://github.com/user-attachments/assets/ba8deadf-56ff-44f1-8e33-ad43741d2c74" />

Security : None