### PR TITLE
fix: Hide skipped deployments from browsing views

### DIFF
--- a/web/apps/dashboard/lib/trpc/routers/deploy/deployment/deployment-query-helpers.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/deployment/deployment-query-helpers.ts
@@ -1,8 +1,16 @@
 import type { InstanceStatus } from "@/lib/collections/deploy/instance-status";
-import type { InferSelectModel } from "@/lib/db";
+import { type InferSelectModel, ne } from "@/lib/db";
 import type { LastExit } from "@/lib/types/deploy";
 import { type ContainerStatus, deployments } from "@unkey/db/src/schema";
 import { mapRegionToFlag } from "../network/utils";
+
+// A skipped row records a push the platform declined to build at all (watch
+// paths didn't match, auto-deploy off). Nothing was ever deployed, so the
+// browsing views leave them out; a lookup by deployment id still returns them
+// so their detail page keeps working.
+export function excludeSkipped() {
+  return ne(deployments.status, "skipped");
+}
 
 export const deploymentSelectFields = {
   id: deployments.id,

--- a/web/apps/dashboard/lib/trpc/routers/deploy/deployment/list-active-branches.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/deployment/list-active-branches.ts
@@ -2,7 +2,7 @@ import { and, db, desc, eq, isNotNull, ne, sql } from "@/lib/db";
 import { ratelimit, withRatelimit, workspaceProcedure } from "@/lib/trpc/trpc";
 import { deployments, environments } from "@unkey/db/src/schema";
 import { z } from "zod";
-import { deploymentListSelect } from "./deployment-query-helpers";
+import { deploymentListSelect, excludeSkipped } from "./deployment-query-helpers";
 import { enrichDeploymentRows } from "./enrich-deployment-rows";
 
 const ACTIVE_BRANCHES_LIMIT = 100;
@@ -26,6 +26,10 @@ export const listActiveBranches = workspaceProcedure
           eq(deployments.appId, input.appId),
           isNotNull(deployments.gitBranch),
           ne(deployments.gitBranch, ""),
+          // Filtered before the row number is assigned, so a branch whose most
+          // recent push was skipped still shows the deployment actually live on
+          // it instead of dropping off the list entirely.
+          excludeSkipped(),
         ),
       )
       .as("ranked");

--- a/web/apps/dashboard/lib/trpc/routers/deploy/deployment/list-branches.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/deployment/list-branches.ts
@@ -2,6 +2,7 @@ import { and, db, desc, eq, isNotNull, ne, sql } from "@/lib/db";
 import { ratelimit, withRatelimit, workspaceProcedure } from "@/lib/trpc/trpc";
 import { deployments } from "@unkey/db/src/schema";
 import { z } from "zod";
+import { excludeSkipped } from "./deployment-query-helpers";
 
 // Branch options for the deployments filter. Derived from the whole history,
 // not from the loaded page, so a branch that last deployed months ago is still
@@ -21,6 +22,7 @@ export const listDeploymentBranches = workspaceProcedure
           eq(deployments.appId, input.appId),
           isNotNull(deployments.gitBranch),
           ne(deployments.gitBranch, ""),
+          excludeSkipped(),
         ),
       )
       .groupBy(deployments.gitBranch)

--- a/web/apps/dashboard/lib/trpc/routers/deploy/deployment/list.ts
+++ b/web/apps/dashboard/lib/trpc/routers/deploy/deployment/list.ts
@@ -4,7 +4,7 @@ import { ratelimit, withRatelimit, workspaceProcedure } from "@/lib/trpc/trpc";
 import { TRPCError } from "@trpc/server";
 import { deployments } from "@unkey/db/src/schema";
 import { z } from "zod";
-import { deploymentListSelect } from "./deployment-query-helpers";
+import { deploymentListSelect, excludeSkipped } from "./deployment-query-helpers";
 import { enrichDeploymentRows } from "./enrich-deployment-rows";
 
 const MAX_LIMIT = 500;
@@ -41,7 +41,7 @@ export const listDeployments = workspaceProcedure
             eq(deployments.workspaceId, ctx.workspace.id),
             eq(deployments.projectId, input.projectId),
             input.appId !== undefined ? eq(deployments.appId, input.appId) : undefined,
-            input.deploymentIds ? inArray(deployments.id, input.deploymentIds) : undefined,
+            input.deploymentIds ? inArray(deployments.id, input.deploymentIds) : excludeSkipped(),
             input.environmentIds
               ? inArray(deployments.environmentId, input.environmentIds)
               : undefined,


### PR DESCRIPTION
Problem: Monorepos show every branch and not just the ones related to that application.

Solution: Hide the ones not related to the current application. 

Testing: Add a monorepo with watch areas and make sure only active deployments land there. 

Security: none 