### PR TITLE
Restore recent deployments on container app overviews

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/overview/components/recent-deployments.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/overview/components/recent-deployments.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useWorkspaceNavigation } from "@/hooks/use-workspace-navigation";
+import { findRolledBackFrom } from "@/lib/collections/deploy/rollback";
+import { routes } from "@/lib/navigation/routes";
+import { ResourceList, ResourceListBody, ResourceListContent, ResourceListHeader } from "@unkey/ui";
+import Link from "next/link";
+import { useAppId, useProjectData } from "../../data-provider";
+import { DeploymentRow } from "../../deployments/components/deployment-row";
+import { DeploymentsSkeleton } from "../../deployments/components/deployments-skeleton";
+import { useAppCurrentDeployment } from "../../hooks/use-app-current-deployment";
+
+export function RecentDeployments() {
+  const workspace = useWorkspaceNavigation();
+  const appId = useAppId();
+  const { projectId, deployments, environments, isDeploymentsLoading } = useProjectData();
+  const { app, currentDeployment, isRolledBack } = useAppCurrentDeployment();
+  const rolledBackFromId =
+    isRolledBack && currentDeployment
+      ? findRolledBackFrom(deployments, currentDeployment)?.id
+      : undefined;
+
+  return (
+    <ResourceList>
+      <ResourceListHeader className="flex-row items-center justify-between">
+        <h2 className="font-medium text-accent-12 text-sm">Recent Deployments</h2>
+        <Link
+          href={routes.projects.apps.deployments({
+            workspaceSlug: workspace.slug,
+            projectId,
+            appId,
+          })}
+          className="text-[13px] text-gray-11 transition-colors hover:text-gray-12"
+        >
+          View all deployments
+        </Link>
+      </ResourceListHeader>
+      {isDeploymentsLoading ? (
+        <DeploymentsSkeleton rows={5} />
+      ) : (
+        <ResourceListContent>
+          <ResourceListBody>
+            {deployments.slice(0, 5).map((deployment) => (
+              <DeploymentRow
+                key={deployment.id}
+                deployment={deployment}
+                environment={environments.find((env) => env.id === deployment.environmentId)}
+                repoFullName={app?.repositoryFullName ?? null}
+                currentDeployment={currentDeployment}
+                isRolledBack={isRolledBack}
+                isRolledBackFrom={deployment.id === rolledBackFromId}
+                liveSince={app?.updatedAt ?? null}
+                href={routes.projects.apps.deployment({
+                  workspaceSlug: workspace.slug,
+                  projectId,
+                  appId,
+                  deploymentId: deployment.id,
+                })}
+              />
+            ))}
+          </ResourceListBody>
+        </ResourceListContent>
+      )}
+    </ResourceList>
+  );
+}

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/overview/page.test.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/overview/page.test.tsx
@@ -1,0 +1,98 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ComponentProps } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DeploymentRow } from "../deployments/components/deployment-row";
+import Overview from "./page";
+
+vi.mock("@unkey/ui", () => ({
+  PageBody: "div",
+  PageContainer: "div",
+  PageHeader: "header",
+  PageHeaderContent: "div",
+  PageHeaderTitle: "h1",
+  ResourceList: "section",
+  ResourceListBody: "ul",
+  ResourceListContent: "div",
+  ResourceListHeader: "header",
+}));
+
+const state = vi.hoisted(() => ({
+  sourceType: "oci",
+  deployments: Array.from({ length: 6 }, (_, index) => ({
+    id: `d_${6 - index}`,
+    environmentId: "env_preview",
+    status: "stopped",
+  })),
+}));
+
+vi.mock("@/hooks/use-workspace-navigation", () => ({
+  useWorkspaceNavigation: () => ({ slug: "workspace" }),
+}));
+vi.mock("../data-provider", () => ({
+  useAppId: () => "app_container",
+  useProjectData: () => ({
+    projectId: "proj_backend",
+    deployments: state.deployments,
+    environments: [{ id: "env_preview", slug: "preview" }],
+    isDeploymentsLoading: false,
+  }),
+}));
+vi.mock("../hooks/use-app-current-deployment", () => ({
+  useAppCurrentDeployment: () => ({
+    app: { sourceType: state.sourceType },
+    currentDeployment: undefined,
+    isRolledBack: false,
+  }),
+}));
+vi.mock("./components/active-branches", () => ({
+  ActiveBranches: () => <h2>Active Branches</h2>,
+}));
+vi.mock("./components/app-production-card", () => ({
+  AppProductionCard: () => <div>Production</div>,
+}));
+vi.mock("./components/overview-page-title", () => ({
+  OverviewPageTitle: () => "Container app",
+}));
+vi.mock("../navigations/create-deployment-button", () => ({
+  CreateDeploymentButton: () => <button type="button">Create deployment</button>,
+}));
+vi.mock("../deployments/components/deployment-row", () => ({
+  DeploymentRow: ({ deployment, href }: ComponentProps<typeof DeploymentRow>) => (
+    <li>
+      <a href={href}>{deployment.id}</a>
+    </li>
+  ),
+}));
+
+afterEach(cleanup);
+beforeEach(() => {
+  state.sourceType = "oci";
+});
+
+describe("Overview deployment history", () => {
+  it("shows the five most recent container deployments, including stopped deployments", () => {
+    render(<Overview />);
+    expect(screen.getByRole("heading", { name: "Recent Deployments" })).toBeTruthy();
+    expect(screen.queryByRole("heading", { name: "Active Branches" })).toBeNull();
+    expect(screen.getAllByRole("listitem").map((row) => row.textContent)).toEqual([
+      "d_6",
+      "d_5",
+      "d_4",
+      "d_3",
+      "d_2",
+    ]);
+    expect(screen.getByRole("link", { name: "d_6" }).getAttribute("href")).toBe(
+      "/workspace/projects/proj_backend/apps/app_container/deployments/d_6",
+    );
+    expect(screen.getByRole("link", { name: "View all deployments" }).getAttribute("href")).toBe(
+      "/workspace/projects/proj_backend/apps/app_container/deployments",
+    );
+  });
+
+  it.each(["git", "unknown"])("preserves the existing branch view for %s apps", (source) => {
+    state.sourceType = source;
+    render(<Overview />);
+    expect(screen.getByRole("heading", { name: "Active Branches" })).toBeTruthy();
+    expect(screen.queryByRole("heading", { name: "Recent Deployments" })).toBeNull();
+  });
+});

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/overview/page.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/apps/[appId]/(overview)/overview/page.tsx
@@ -3,13 +3,16 @@
 import { PageBody, PageContainer, PageHeader, PageHeaderContent, PageHeaderTitle } from "@unkey/ui";
 import { ActiveDeploymentCardEmpty } from "../../components/active-deployment-card/components/active-deployment-card-empty";
 import { useProjectData } from "../data-provider";
+import { useAppCurrentDeployment } from "../hooks/use-app-current-deployment";
 import { CreateDeploymentButton } from "../navigations/create-deployment-button";
 import { ActiveBranches } from "./components/active-branches";
 import { AppProductionCard } from "./components/app-production-card";
 import { OverviewPageTitle } from "./components/overview-page-title";
+import { RecentDeployments } from "./components/recent-deployments";
 
 export default function Overview() {
   const { deployments, isDeploymentsLoading } = useProjectData();
+  const { app } = useAppCurrentDeployment();
   const hasNoDeployments = !isDeploymentsLoading && deployments.length === 0;
 
   return (
@@ -31,7 +34,7 @@ export default function Overview() {
         ) : (
           <div className="flex flex-col gap-5">
             <AppProductionCard />
-            <ActiveBranches />
+            {app?.sourceType === "oci" ? <RecentDeployments /> : <ActiveBranches />}
           </div>
         )}
       </PageBody>


### PR DESCRIPTION
## Problem:


The container app overview was empty and looked very not great 

## Solution:

Show the five newest deployments below the production card for container apps.

## Impact:

Git and unknown-source apps keep their existing Active Branches view. No API or database changes.

Same Container Demo Overview page, app, deployment data, and 1440 × 1000 viewport at 2× in both captures. A real local production deployment is Live with one running instance. The chart shows 1.1K real requests, not mocked data.

**Before:** the live production card and request chart are visible, but no deployment history appears below them.

![Before: Container Demo Overview with live production and request chart, without recent history](https://ampcode.com/user-content/artifacts/169cd4f41f4919bf4455861bbc38228ee778d6ac376d6e0d5d7d48b8f24bb144-file.png)

**↓ After:** the same production card and chart remain unchanged. Recent Deployments now shows the five newest deployments below them, with a link to full history.

![After: same live Container Demo Overview and request chart, with Recent Deployments below](https://ampcode.com/user-content/artifacts/a6acbbc42a5e06c8e9ff1227825e0fc670925957949e77b2f73a1d275d9e37a2-file.png)

## Testing:
