### PR TITLE
cache: migrate to Otter v2 with write-based expiry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/go-sql-driver/mysql v1.10.1
 	github.com/google/go-containerregistry v0.22.1
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
-	github.com/maypok86/otter v1.2.4
+	github.com/maypok86/otter/v2 v2.3.0
 	github.com/moby/buildkit v0.33.0
 	github.com/oapi-codegen/nullable v1.2.0
 	github.com/oapi-codegen/runtime v1.7.0
@@ -171,14 +171,12 @@ require (
 	github.com/docker/docker-credential-helpers v0.9.9 // indirect
 	github.com/docker/go-connections v0.8.1 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
-	github.com/dolthub/maphash v0.1.0 // indirect
 	github.com/dprotaso/go-yit v0.0.0-20220510233725-9ba8df137936 // indirect
 	github.com/ebitengine/purego v0.11.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
 	github.com/fatih/structtag v1.2.0 // indirect
 	github.com/felixge/httpsnoop v1.1.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.3 // indirect
-	github.com/gammazero/deque v1.2.1 // indirect
 	github.com/go-faster/city v1.0.1 // indirect
 	github.com/go-faster/errors v0.8.0 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -218,8 +218,6 @@ github.com/docker/go-connections v0.8.1 h1:JibmG5hULs5qXSr/cp/w3Pw5fZuStt4MOHMUE
 github.com/docker/go-connections v0.8.1/go.mod h1:no1qkHdjq7kLMGUXYAduOhYPSJxxvgWBh7ogVvptn3Q=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
-github.com/dolthub/maphash v0.1.0 h1:bsQ7JsF4FkkWyrP3oCnFJgrCUAFbFf3kOl4L/QxPDyQ=
-github.com/dolthub/maphash v0.1.0/go.mod h1:gkg4Ch4CdCDu5h6PMriVLawB7koZ+5ijb9puGMV50a4=
 github.com/dprotaso/go-yit v0.0.0-20191028211022-135eb7262960 h1:aRd8M7HJVZOqn/vhOzrGcQH0lNAMkqMn+pXUYkatmcA=
 github.com/dprotaso/go-yit v0.0.0-20191028211022-135eb7262960/go.mod h1:9HQzr9D/0PGwMEbC3d5AB7oi67+h4TsQqItC1GVYG58=
 github.com/ebitengine/purego v0.11.0 h1:jhp/D+Nyv7UUW8HAcmcjt2N2rYrYi9m3SL21k0Ua/NI=
@@ -239,8 +237,6 @@ github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor/v2 v2.9.3 h1:oQBnFATpNdY8gJHTndDDv5Xl4QqNaz51G5LLEPhng3Q=
 github.com/fxamacker/cbor/v2 v2.9.3/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/gammazero/deque v1.2.1 h1:9fnQVFCCZ9/NOc7ccTNqzoKd1tCWOqeI05/lPqFPMGQ=
-github.com/gammazero/deque v1.2.1/go.mod h1:5nSFkzVm+afG9+gy0VIowlqVAW4N8zNcMne+CMQVD2g=
 github.com/getkin/kin-openapi v0.149.0 h1:ZbhmVJ4yq5RZDUsyP8lcBcGMsjsaTqXEFt6isdtMDfA=
 github.com/getkin/kin-openapi v0.149.0/go.mod h1:1+BHDzstro+P5CKtPy1X4PfofnFgmRe6uvMy9+r9fKY=
 github.com/go-acme/lego/v4 v4.35.2 h1:uVQg+KC/yj9R2g7Q9W5wDqhvQvxV5SMu5eqFVoN5xZU=
@@ -388,8 +384,8 @@ github.com/mattn/go-colorable v0.1.15 h1:+u9SLTRGnXv73cEsnsmoZBom+dMU88B2M0aDcWy
 github.com/mattn/go-colorable v0.1.15/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.24 h1:tGZZoVgT/KiqK1c8ocVLeDS8BSWMRd47J3Lbz7vsReI=
 github.com/mattn/go-isatty v0.0.24/go.mod h1:nMCL3Zebbrt45jsMDgnfIwz6ydEQApk5oEI3HqDio6A=
-github.com/maypok86/otter v1.2.4 h1:HhW1Pq6VdJkmWwcZZq19BlEQkHtI8xgsQzBVXJU0nfc=
-github.com/maypok86/otter v1.2.4/go.mod h1:mKLfoI7v1HOmQMwFgX4QkRk23mX6ge3RDvjdHOWG4R4=
+github.com/maypok86/otter/v2 v2.3.0 h1:8H8AVVFUSzJwIegKwv1uF5aGitTY+AIrtktg7OcLs8w=
+github.com/maypok86/otter/v2 v2.3.0/go.mod h1:XgIdlpmL6jYz882/CAx1E4C1ukfgDKSaw4mWq59+7l8=
 github.com/mdlayher/netlink v1.7.2 h1:/UtM3ofJap7Vl4QWCPDGXY8d3GIY2UGSDbK+QWmY8/g=
 github.com/mdlayher/netlink v1.7.2/go.mod h1:xraEF7uJbxLhc5fpHL4cPe221LI2bdttWlU+ZGLfQSw=
 github.com/mdlayher/socket v0.5.1 h1:VZaqt6RkGkt2OE9l3GcC6nZkqD3xKeQLyfleW/uBcos=

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -8,7 +8,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/maypok86/otter"
+	"github.com/maypok86/otter/v2"
+	"github.com/maypok86/otter/v2/stats"
 	"github.com/unkeyed/unkey/pkg/assert"
 	"github.com/unkeyed/unkey/pkg/cache/metrics"
 	"github.com/unkeyed/unkey/pkg/clock"
@@ -20,7 +21,7 @@ import (
 )
 
 type cache[K comparable, V any] struct {
-	otter    otter.Cache[K, swrEntry[V]]
+	otter    *otter.Cache[K, swrEntry[V]]
 	fresh    time.Duration
 	stale    time.Duration
 	resource string
@@ -58,25 +59,39 @@ var _ Cache[any, any] = (*cache[any, any])(nil)
 func New[K comparable, V any](config Config[K, V]) (Cache[K, V], error) {
 	if err := assert.All(
 		assert.NotNil(config.Clock, "clock is required"),
+		assert.Greater(config.MaxSize, 0, "max size must be positive"),
+		assert.Greater(config.Stale, 0, "stale duration must be positive"),
 	); err != nil {
 		return nil, fmt.Errorf("invalid cache config: %w", err)
 	}
 
-	builder, err := otter.NewBuilder[K, swrEntry[V]](config.MaxSize)
-	if err != nil {
-		return nil, err
-	}
-
-	otter, err := builder.
-		CollectStats().
-		Cost(func(key K, value swrEntry[V]) uint32 {
-			return 1
-		}).
-		WithTTL(config.Stale).
-		DeletionListener(func(key K, value swrEntry[V], cause otter.DeletionCause) {
-			metrics.CacheDeleted.WithLabelValues(config.Resource, cause.String()).Inc()
-		}).
-		Build()
+	otter, err := otter.New(&otter.Options[K, swrEntry[V]]{
+		MaximumSize:      config.MaxSize,
+		MaximumWeight:    0,
+		StatsRecorder:    stats.NewCounter(),
+		InitialCapacity:  0,
+		Weigher:          nil,
+		ExpiryCalculator: otter.ExpiryWriting[K, swrEntry[V]](config.Stale),
+		OnDeletion: func(event otter.DeletionEvent[K, swrEntry[V]]) {
+			var cause string
+			switch event.Cause {
+			case otter.CauseInvalidation:
+				cause = "Explicit"
+			case otter.CauseReplacement:
+				cause = "Replaced"
+			case otter.CauseOverflow:
+				cause = "Size"
+			case otter.CauseExpiration:
+				cause = "Expired"
+			}
+			metrics.CacheDeleted.WithLabelValues(config.Resource, cause).Inc()
+		},
+		OnAtomicDeletion:  nil,
+		RefreshCalculator: nil,
+		Executor:          nil,
+		Clock:             nil,
+		Logger:            nil,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -108,8 +123,8 @@ func New[K comparable, V any](config Config[K, V]) (Cache[K, V], error) {
 	}
 
 	c.stopMetrics = repeat.Every(60*time.Second, func() {
-		metrics.CacheSize.WithLabelValues(c.resource).Set(float64(c.otter.Size()))
-		metrics.CacheCapacity.WithLabelValues(c.resource).Set(float64(c.otter.Capacity()))
+		metrics.CacheSize.WithLabelValues(c.resource).Set(float64(c.otter.EstimatedSize()))
+		metrics.CacheCapacity.WithLabelValues(c.resource).Set(float64(c.otter.GetMaximum()))
 	})
 	return c, nil
 }
@@ -164,7 +179,7 @@ func (c *cache[K, V]) Get(ctx context.Context, key K) (value V, hit CacheHit) {
 		return e.Value, e.Hit
 	}
 
-	c.otter.Delete(key)
+	c.otter.Invalidate(key)
 	c.recordTiming(ctx, "cache_get", "miss", start)
 
 	return value, Miss
@@ -188,7 +203,7 @@ func (c *cache[K, V]) GetMany(ctx context.Context, keys []K) (values map[K]V, hi
 			continue
 		}
 
-		c.otter.Delete(key)
+		c.otter.Invalidate(key)
 		hits[key] = Miss
 	}
 
@@ -246,7 +261,7 @@ func (c *cache[K, V]) SetMany(ctx context.Context, values map[K]V) {
 }
 
 func (c *cache[K, V]) get(_ context.Context, key K) (swrEntry[V], bool) {
-	v, ok := c.otter.Get(key)
+	v, ok := c.otter.GetIfPresent(key)
 
 	metrics.CacheReads.WithLabelValues(c.resource, fmt.Sprintf("%t", ok)).Inc()
 
@@ -255,17 +270,16 @@ func (c *cache[K, V]) get(_ context.Context, key K) (swrEntry[V], bool) {
 
 func (c *cache[K, V]) Remove(ctx context.Context, keys ...K) {
 	for _, key := range keys {
-		c.otter.Delete(key)
+		c.otter.Invalidate(key)
 	}
 }
 
 func (c *cache[K, V]) Dump(ctx context.Context) ([]byte, error) {
 	data := make(map[K]swrEntry[V])
 
-	c.otter.Range(func(key K, entry swrEntry[V]) bool {
+	for key, entry := range c.otter.All() {
 		data[key] = entry
-		return true
-	})
+	}
 
 	b, err := json.Marshal(data)
 	if err != nil {
@@ -294,7 +308,7 @@ func (c *cache[K, V]) Restore(ctx context.Context, b []byte) error {
 }
 
 func (c *cache[K, V]) Clear(ctx context.Context) {
-	c.otter.Clear()
+	c.otter.InvalidateAll()
 }
 
 func (c *cache[K, V]) Name() string {
@@ -367,7 +381,7 @@ func (c *cache[K, V]) SWR(
 		}
 
 		// We have old data, that we should not serve anymore
-		c.otter.Delete(key)
+		c.otter.Invalidate(key)
 	}
 
 	// Cache Miss - measure total time including all overhead
@@ -537,7 +551,7 @@ func (c *cache[K, V]) SWRWithFallback(
 		}
 
 		// Expired - delete and continue checking other candidates
-		c.otter.Delete(key)
+		c.otter.Invalidate(key)
 	}
 
 	// Cache miss on all candidates - fetch from origin

--- a/pkg/cache/otter_test.go
+++ b/pkg/cache/otter_test.go
@@ -1,0 +1,62 @@
+package cache
+
+import (
+	"context"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/clock"
+)
+
+func TestCacheConfigurationLimits(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		size  int
+		stale time.Duration
+	}{
+		{"zero size", 0, time.Minute},
+		{"negative size", -1, time.Minute},
+		{"zero TTL", 1, 0},
+		{"negative TTL", 1, -time.Minute},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c, err := New(Config[string, string]{
+				Fresh:    time.Minute,
+				Stale:    tc.stale,
+				MaxSize:  tc.size,
+				Resource: t.Name(),
+				Clock:    clock.New(),
+			})
+			require.Error(t, err)
+			require.Nil(t, c)
+		})
+	}
+}
+
+func TestOverwriteResetsExpiration(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		c, err := New(Config[string, string]{
+			Fresh:    time.Minute,
+			Stale:    2 * time.Minute,
+			MaxSize:  10,
+			Resource: t.Name(),
+			Clock:    clock.New(),
+		})
+		require.NoError(t, err)
+		t.Cleanup(c.Close)
+		t.Cleanup(func() { c.(*cache[string, string]).otter.StopAllGoroutines() })
+		ctx := context.Background()
+		c.Set(ctx, "key", "first")
+		time.Sleep(90 * time.Second)
+		c.Set(ctx, "key", "replacement")
+		time.Sleep(45 * time.Second)
+		value, hit := c.Get(ctx, "key")
+		require.Equal(t, Hit, hit)
+		require.Equal(t, "replacement", value)
+		time.Sleep(80 * time.Second)
+		_, hit = c.Get(ctx, "key")
+		require.Equal(t, Miss, hit)
+	})
+}


### PR DESCRIPTION
## Problem:

Otter v2 changes the cache API and expiry policy. A direct version bump could change overwrite TTL behavior.

## Solution:

Migrate to Otter 2.3.0 with write-based expiry and an overwrite-expiry regression test.

## Impact:

Preserves positive capacity/TTL checks and deletion metric labels. Eviction changes from S3-FIFO to W-TinyLFU.

Draft stack prerequisites: #7330 and #7320 through #7326. `deps/integration-base` is a merge-only review anchor, not implementation work to merge separately. Do not merge this stack into that anchor. After both prerequisites land, rebase the dependency stack onto current `main` and retarget bottom PR #7353 to `main`; keep later PRs based on the preceding layer. Existing prerequisite PRs are unchanged.

## Testing:

Cache package passed 55 tests under the race detector in combined verification.

Final combined compatible stack (not an independent run of every intermediate PR):
- `mise run test --concurrency=4`: 303 suites, 24,506 passed, zero failed, 7,875 ignored; 186 cached.
- `GOFLAGS=-race mise run test --concurrency=4`: 303 suites, 24,506 passed, zero failed, 7,875 ignored; 279 cached.
- `mise run build`: passed; lint reported zero issues.
- Tagged control-plane suite: 25 passed.

Full normal and race runs used separate test-container scopes. The race run resumed after fixing the cancellation fixture. An earlier analytics-count timeout did not recur; its cause remains unconfirmed. These are local verification results, not a claim that draft CI ran or passed.