### PR TITLE
acme: migrate certificate issuance to Lego v5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/distribution/reference v0.6.0
 	github.com/docker/cli v29.8.0+incompatible
 	github.com/getkin/kin-openapi v0.149.0
-	github.com/go-acme/lego/v4 v4.35.2
+	github.com/go-acme/lego/v5 v5.4.1
 	github.com/go-sql-driver/mysql v1.10.1
 	github.com/google/go-containerregistry v0.22.1
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
@@ -352,4 +352,5 @@ require (
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.2 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
+	software.sslmate.com/src/go-pkcs12 v0.7.3 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -233,14 +233,14 @@ github.com/felixge/httpsnoop v1.1.0/go.mod h1:Zqxgdd+1Rkcz8euOqdr7lqgCRJztwr5hp9
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
-github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
-github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
+github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
+github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/fxamacker/cbor/v2 v2.9.3 h1:oQBnFATpNdY8gJHTndDDv5Xl4QqNaz51G5LLEPhng3Q=
 github.com/fxamacker/cbor/v2 v2.9.3/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/getkin/kin-openapi v0.149.0 h1:ZbhmVJ4yq5RZDUsyP8lcBcGMsjsaTqXEFt6isdtMDfA=
 github.com/getkin/kin-openapi v0.149.0/go.mod h1:1+BHDzstro+P5CKtPy1X4PfofnFgmRe6uvMy9+r9fKY=
-github.com/go-acme/lego/v4 v4.35.2 h1:uVQg+KC/yj9R2g7Q9W5wDqhvQvxV5SMu5eqFVoN5xZU=
-github.com/go-acme/lego/v4 v4.35.2/go.mod h1:pX2jN5n8OphMGY1IaMjYm5DAEzguBaKRt8AvJAgJXpc=
+github.com/go-acme/lego/v5 v5.4.1 h1:Jt6xAP9xQrJ3SLLGgxejfDDd3pzdrmuLCWe4oTqHHQc=
+github.com/go-acme/lego/v5 v5.4.1/go.mod h1:OvMMHc6DVeqycOGhNRuMlNa1V304qEFRljWDHMpEcLc=
 github.com/go-faster/city v1.0.1 h1:4WAxSZ3V2Ws4QRDrscLEDcibJY8uf41H6AhXDrNDcGw=
 github.com/go-faster/city v1.0.1/go.mod h1:jKcUJId49qdW3L1qKHH/3wPeUstCVpVSXTM6vO3VcTw=
 github.com/go-faster/errors v0.8.0 h1:9T9eJrM+72dFk7n4DfhuaDDe6cyuFCSW2oNUkN77Yqc=
@@ -920,3 +920,5 @@ sigs.k8s.io/structured-merge-diff/v6 v6.4.2 h1:qdOxHwrl2Kaag1aQEarlYcOA9vSyGCp3C
 sigs.k8s.io/structured-merge-diff/v6 v6.4.2/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
 sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=
+software.sslmate.com/src/go-pkcs12 v0.7.3 h1:JBQD3FDqYjTeyDAeZQklj2ar88ykBLtALloPJHyAauU=
+software.sslmate.com/src/go-pkcs12 v0.7.3/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=

--- a/svc/ctrl/services/acme/errors.go
+++ b/svc/ctrl/services/acme/errors.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-acme/lego/v4/acme"
+	"github.com/go-acme/lego/v5/acme"
 )
 
 // ACMEErrorType represents the type of ACME error.
@@ -63,12 +63,10 @@ func ParseACMEError(err error) *ParsedACMEError {
 		parsed.IsRetryable = false
 		parsed.Message = fmt.Sprintf("Let's Encrypt rate limit exceeded: %s", rateLimitErr.Detail)
 
-		if rateLimitErr.RetryAfter != "" {
-			if t, parseErr := time.Parse(time.RFC1123, rateLimitErr.RetryAfter); parseErr == nil {
-				parsed.RetryAfter = t
-				parsed.Message = fmt.Sprintf("Let's Encrypt rate limit exceeded. Retry after %s: %s",
-					t.Format(time.RFC3339), rateLimitErr.Detail)
-			}
+		if rateLimitErr.RetryAfter > 0 {
+			parsed.RetryAfter = time.Now().Add(rateLimitErr.RetryAfter)
+			parsed.Message = fmt.Sprintf("Let's Encrypt rate limit exceeded. Retry after %s: %s",
+				parsed.RetryAfter.Format(time.RFC3339), rateLimitErr.Detail)
 		}
 		return parsed
 	}

--- a/svc/ctrl/services/acme/errors_test.go
+++ b/svc/ctrl/services/acme/errors_test.go
@@ -1,0 +1,34 @@
+package acme
+
+import (
+	"fmt"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	legoacme "github.com/go-acme/lego/v5/acme"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRateLimitRetryAfter(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var problem legoacme.ProblemDetails
+		problem.Type = "urn:ietf:params:acme:error:rateLimited"
+		problem.Detail = "too many certificates"
+		for _, delay := range []time.Duration{0, 5 * time.Minute} {
+			var rateLimitError error = &legoacme.RateLimitedError{
+				ProblemDetails: &problem,
+				RetryAfter:     delay,
+			}
+			err := fmt.Errorf("obtain certificate: %w", rateLimitError)
+			parsed := ParseACMEError(err)
+			require.Equal(t, ACMEErrorRateLimited, parsed.Type)
+			require.False(t, parsed.IsRetryable)
+			if delay == 0 {
+				require.True(t, parsed.RetryAfter.IsZero())
+			} else {
+				require.Equal(t, time.Now().Add(delay), parsed.RetryAfter)
+			}
+		}
+	})
+}

--- a/svc/ctrl/services/acme/providers/http_provider.go
+++ b/svc/ctrl/services/acme/providers/http_provider.go
@@ -1,9 +1,10 @@
 package providers
 
 import (
+	"context"
 	"time"
 
-	"github.com/go-acme/lego/v4/challenge"
+	"github.com/go-acme/lego/v5/challenge"
 	"github.com/unkeyed/unkey/pkg/cache"
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/db"
@@ -21,14 +22,14 @@ type httpDNS struct {
 // Present stores the challenge token in the database for the gateway to serve.
 // The gateway will intercept requests to /.well-known/acme-challenge/{token}
 // and respond with the keyAuth value.
-func (h *httpDNS) Present(domain, token, keyAuth string) error {
+func (h *httpDNS) Present(_ context.Context, domain, token, keyAuth string) error {
 	logger.Info("presenting http-01 challenge", "domain", domain)
 	// The actual DB update is handled by the generic Provider wrapper
 	return nil
 }
 
 // CleanUp is a no-op for HTTP-01 - the token remains in DB until overwritten
-func (h *httpDNS) CleanUp(domain, token, keyAuth string) error {
+func (h *httpDNS) CleanUp(_ context.Context, domain, token, keyAuth string) error {
 	logger.Info("cleaning up http-01 challenge", "domain", domain)
 	return nil
 }

--- a/svc/ctrl/services/acme/providers/provider.go
+++ b/svc/ctrl/services/acme/providers/provider.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/go-acme/lego/v4/challenge"
+	"github.com/go-acme/lego/v5/challenge"
 	"github.com/unkeyed/unkey/internal/services/caches"
 	"github.com/unkeyed/unkey/pkg/assert"
 	"github.com/unkeyed/unkey/pkg/cache"
@@ -24,8 +24,8 @@ var _ challenge.ProviderTimeout = (*Provider)(nil)
 // DNSProvider is the interface for underlying DNS operations.
 // Lego's route53.DNSProvider implements this.
 type DNSProvider interface {
-	Present(domain, token, keyAuth string) error
-	CleanUp(domain, token, keyAuth string) error
+	Present(ctx context.Context, domain, token, keyAuth string) error
+	CleanUp(ctx context.Context, domain, token, keyAuth string) error
 	Timeout() (timeout, interval time.Duration)
 }
 
@@ -88,9 +88,7 @@ func (p *Provider) resolveDomain(ctx context.Context, domain string) (db.CustomD
 }
 
 // Present creates a DNS TXT record for the ACME challenge and tracks it in the database.
-func (p *Provider) Present(domain, token, keyAuth string) error {
-	ctx := context.Background()
-
+func (p *Provider) Present(ctx context.Context, domain, token, keyAuth string) error {
 	// Find domain - tries exact match first, then wildcard (*.domain)
 	dom, err := p.resolveDomain(ctx, domain)
 	if err != nil {
@@ -99,7 +97,7 @@ func (p *Provider) Present(domain, token, keyAuth string) error {
 
 	logger.Info("presenting dns challenge", "domain", domain, "matched", dom.Domain)
 
-	err = p.dns.Present(domain, token, keyAuth)
+	err = p.dns.Present(ctx, domain, token, keyAuth)
 	if err != nil {
 		return fmt.Errorf("failed to present DNS challenge for domain %s: %w", domain, err)
 	}
@@ -120,10 +118,10 @@ func (p *Provider) Present(domain, token, keyAuth string) error {
 }
 
 // CleanUp removes the DNS TXT record.
-func (p *Provider) CleanUp(domain, token, keyAuth string) error {
+func (p *Provider) CleanUp(ctx context.Context, domain, token, keyAuth string) error {
 	logger.Info("cleaning up dns challenge", "domain", domain)
 
-	err := p.dns.CleanUp(domain, token, keyAuth)
+	err := p.dns.CleanUp(context.WithoutCancel(ctx), domain, token, keyAuth)
 	if err != nil {
 		logger.Warn("failed to clean up dns challenge record", "error", err, "domain", domain)
 	}

--- a/svc/ctrl/services/acme/providers/provider_test.go
+++ b/svc/ctrl/services/acme/providers/provider_test.go
@@ -1,0 +1,68 @@
+package providers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unkeyed/unkey/pkg/cache"
+	"github.com/unkeyed/unkey/pkg/clock"
+	"github.com/unkeyed/unkey/svc/ctrl/internal/db"
+)
+
+type canceledLookup struct {
+	db.Database
+}
+
+func (c canceledLookup) FindCustomDomainByDomainOrWildcard(ctx context.Context, _ db.FindCustomDomainByDomainOrWildcardParams) (db.CustomDomain, error) {
+	return db.CustomDomain{}, ctx.Err()
+}
+
+func TestPresentPropagatesCancellation(t *testing.T) {
+	c, err := cache.New(cache.Config[string, db.CustomDomain]{
+		Fresh:    time.Minute,
+		Stale:    2 * time.Minute,
+		MaxSize:  10,
+		Resource: t.Name(),
+		Clock:    clock.New(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(c.Close)
+	p := Provider{db: canceledLookup{Database: nil}, dns: nil, cache: c}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.ErrorIs(t, p.Present(ctx, "example.com", "token", "authorization"), context.Canceled)
+}
+
+type cleanupDNS struct {
+	DNSProvider
+	cleanup func(context.Context, string, string, string) error
+}
+
+func (d cleanupDNS) CleanUp(ctx context.Context, domain, token, keyAuth string) error {
+	return d.cleanup(ctx, domain, token, keyAuth)
+}
+
+func TestCleanupSurvivesCanceledIssuance(t *testing.T) {
+	called := false
+	p := Provider{
+		db:    nil,
+		cache: nil,
+		dns: cleanupDNS{
+			DNSProvider: nil,
+			cleanup: func(ctx context.Context, domain, token, keyAuth string) error {
+				called = true
+				require.NoError(t, ctx.Err())
+				require.Equal(t, "example.com", domain)
+				require.Equal(t, "token", token)
+				require.Equal(t, "authorization", keyAuth)
+				return nil
+			},
+		},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.NoError(t, p.CleanUp(ctx, "example.com", "token", "authorization"))
+	require.True(t, called)
+}

--- a/svc/ctrl/services/acme/providers/route53_provider.go
+++ b/svc/ctrl/services/acme/providers/route53_provider.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/go-acme/lego/v4/providers/dns/route53"
+	"github.com/go-acme/lego/v5/providers/dns/route53"
 	"github.com/unkeyed/unkey/pkg/cache"
 	"github.com/unkeyed/unkey/pkg/logger"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/db"

--- a/svc/ctrl/services/acme/user.go
+++ b/svc/ctrl/services/acme/user.go
@@ -10,8 +10,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/go-acme/lego/v4/lego"
-	"github.com/go-acme/lego/v4/registration"
+	"github.com/go-acme/lego/v5/acme"
+	"github.com/go-acme/lego/v5/lego"
+	"github.com/go-acme/lego/v5/registration"
 	vaultv1 "github.com/unkeyed/unkey/gen/proto/vault/v1"
 	"github.com/unkeyed/unkey/gen/rpc/vault"
 	"github.com/unkeyed/unkey/pkg/logger"
@@ -22,19 +23,19 @@ import (
 type AcmeUser struct {
 	WorkspaceID  string
 	EmailDomain  string
-	Registration *registration.Resource
-	key          crypto.PrivateKey
+	Registration *acme.ExtendedAccount
+	key          crypto.Signer
 }
 
 func (u *AcmeUser) GetEmail() string {
 	return fmt.Sprintf("%s@%s", u.WorkspaceID, u.EmailDomain)
 }
 
-func (u AcmeUser) GetRegistration() *registration.Resource {
+func (u AcmeUser) GetRegistration() *acme.ExtendedAccount {
 	return u.Registration
 }
 
-func (u *AcmeUser) GetPrivateKey() crypto.PrivateKey {
+func (u *AcmeUser) GetPrivateKey() crypto.Signer {
 	return u.key
 }
 
@@ -77,8 +78,8 @@ func GetOrCreateUser(ctx context.Context, cfg UserConfig) (*lego.Client, error) 
 	// If we have a valid registration URI, use it
 	if foundUser.RegistrationUri.Valid && foundUser.RegistrationUri.String != "" {
 		//nolint:exhaustruct // external library type
-		user.Registration = &registration.Resource{
-			URI: foundUser.RegistrationUri.String,
+		user.Registration = &acme.ExtendedAccount{
+			Location: foundUser.RegistrationUri.String,
 		}
 	}
 
@@ -94,7 +95,7 @@ func GetOrCreateUser(ctx context.Context, cfg UserConfig) (*lego.Client, error) 
 			"workspace_id", cfg.WorkspaceID,
 		)
 
-		reg, regErr := client.Registration.Register(registration.RegisterOptions{TermsOfServiceAgreed: true})
+		reg, regErr := client.Registration.Register(ctx, registration.RegisterOptions{TermsOfServiceAgreed: true})
 		if regErr != nil {
 			return nil, fmt.Errorf("failed to complete acme registration: %w", regErr)
 		}
@@ -103,7 +104,7 @@ func GetOrCreateUser(ctx context.Context, cfg UserConfig) (*lego.Client, error) 
 
 		if updateErr := cfg.DB.UpdateAcmeUserRegistrationURI(ctx, db.UpdateAcmeUserRegistrationURIParams{
 			ID:              foundUser.ID,
-			RegistrationUri: sql.NullString{Valid: true, String: reg.URI},
+			RegistrationUri: sql.NullString{Valid: true, String: reg.Location},
 		}); updateErr != nil {
 			logger.Warn("failed to persist registration URI", "error", updateErr)
 		}
@@ -155,7 +156,7 @@ func register(ctx context.Context, cfg UserConfig) (*lego.Client, error) {
 		return nil, fmt.Errorf("failed to create acme client: %w", err)
 	}
 
-	reg, err := client.Registration.Register(registration.RegisterOptions{TermsOfServiceAgreed: true})
+	reg, err := client.Registration.Register(ctx, registration.RegisterOptions{TermsOfServiceAgreed: true})
 	if err != nil {
 		return nil, fmt.Errorf("failed to register acme user: %w", err)
 	}
@@ -164,7 +165,7 @@ func register(ctx context.Context, cfg UserConfig) (*lego.Client, error) {
 
 	err = cfg.DB.UpdateAcmeUserRegistrationURI(ctx, db.UpdateAcmeUserRegistrationURIParams{
 		ID:              id,
-		RegistrationUri: sql.NullString{Valid: true, String: reg.URI},
+		RegistrationUri: sql.NullString{Valid: true, String: reg.Location},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to update acme user registration status: %w", err)

--- a/svc/ctrl/worker/certificate/process_challenge_handler.go
+++ b/svc/ctrl/worker/certificate/process_challenge_handler.go
@@ -7,8 +7,10 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/go-acme/lego/v4/certificate"
-	"github.com/go-acme/lego/v4/lego"
+	"github.com/go-acme/lego/v5/certcrypto"
+	"github.com/go-acme/lego/v5/certificate"
+	"github.com/go-acme/lego/v5/challenge/dns01"
+	"github.com/go-acme/lego/v5/lego"
 	restate "github.com/restatedev/sdk-go"
 	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
 	vaultv1 "github.com/unkeyed/unkey/gen/proto/vault/v1"
@@ -227,7 +229,7 @@ func (s *Service) getOrCreateAcmeClient(ctx context.Context, domain string) (*le
 		if s.dnsProvider == nil {
 			return nil, fmt.Errorf("DNS provider required for wildcard certificate: %s", domain)
 		}
-		if err := client.Challenge.SetDNS01Provider(s.dnsProvider); err != nil {
+		if err := client.Challenge.SetDNS01Provider(s.dnsProvider, dns01.DisableRecursiveNSsPropagationRequirement()); err != nil {
 			return nil, fmt.Errorf("failed to set DNS-01 provider: %w", err)
 		}
 		logger.Info("using DNS-01 challenge for wildcard domain", "domain", domain)
@@ -257,11 +259,13 @@ func (s *Service) obtainCertificate(ctx context.Context, _ string, dom db.Custom
 	// Restate handles retries - we return TerminalError for non-retryable errors
 	//nolint:exhaustruct // external library type
 	request := certificate.ObtainRequest{
-		Domains: []string{domain},
-		Bundle:  true,
+		Domains:          []string{domain},
+		Bundle:           true,
+		KeyType:          certcrypto.RSA2048,
+		EnableCommonName: true,
 	}
 
-	certificates, err := client.Certificate.Obtain(request)
+	certificates, err := client.Certificate.Obtain(ctx, request)
 	if err != nil {
 		parsed := acme.ParseACMEError(err)
 		logger.Error("certificate obtain failed",

--- a/svc/ctrl/worker/certificate/service.go
+++ b/svc/ctrl/worker/certificate/service.go
@@ -1,7 +1,7 @@
 package certificate
 
 import (
-	"github.com/go-acme/lego/v4/challenge"
+	"github.com/go-acme/lego/v5/challenge"
 	hydrav1 "github.com/unkeyed/unkey/gen/proto/hydra/v1"
 	"github.com/unkeyed/unkey/gen/rpc/vault"
 	"github.com/unkeyed/unkey/pkg/healthcheck"

--- a/svc/ctrl/worker/run.go
+++ b/svc/ctrl/worker/run.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
-	"github.com/go-acme/lego/v4/challenge"
+	"github.com/go-acme/lego/v5/challenge"
 	promclient "github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	restate "github.com/restatedev/sdk-go"


### PR DESCRIPTION
## Problem:

Lego v5 changes DNS provider and certificate request APIs.

## Solution:

Migrate certificate issuance and provider adapters to Lego 5.4.1.

## Impact:

Preserves RSA-2048, Common Name, account registration URL, and authoritative DNS propagation. Cleanup remains possible after request cancellation. RetryAfter duration becomes a deadline. No live CA issuance was performed.

Draft stack prerequisites: #7330 and #7320 through #7326. `deps/integration-base` is a merge-only review anchor, not implementation work to merge separately. Do not merge this stack into that anchor. After both prerequisites land, rebase the dependency stack onto current `main` and retarget bottom PR #7353 to `main`; keep later PRs based on the preceding layer. Existing prerequisite PRs are unchanged.

## Testing:

ACME/provider tests passed within the focused 204-test race run during migration verification.

Final combined compatible stack (not an independent run of every intermediate PR):
- `mise run test --concurrency=4`: 303 suites, 24,506 passed, zero failed, 7,875 ignored; 186 cached.
- `GOFLAGS=-race mise run test --concurrency=4`: 303 suites, 24,506 passed, zero failed, 7,875 ignored; 279 cached.
- `mise run build`: passed; lint reported zero issues.
- Tagged control-plane suite: 25 passed.

Full normal and race runs used separate test-container scopes. The race run resumed after fixing the cancellation fixture. An earlier analytics-count timeout did not recur; its cause remains unconfirmed. These are local verification results, not a claim that draft CI ran or passed.