### PR TITLE
ctrl: verify two-tick recovery and repair audit fixtures

### DIFF
--- a/svc/ctrl/integration/custom_domain_delete_test.go
+++ b/svc/ctrl/integration/custom_domain_delete_test.go
@@ -13,6 +13,7 @@ import (
 	mysqltype "github.com/unkeyed/unkey/pkg/mysql/types"
 	"github.com/unkeyed/unkey/pkg/uid"
 	"github.com/unkeyed/unkey/svc/ctrl/integration/seed"
+	"github.com/unkeyed/unkey/svc/ctrl/internal/auditlogs"
 	"github.com/unkeyed/unkey/svc/ctrl/internal/db"
 	"github.com/unkeyed/unkey/svc/ctrl/services/customdomain"
 )
@@ -35,9 +36,12 @@ func TestDeleteCustomDomain_DoesNotDeleteOtherWorkspaceFrontlineRoute(t *testing
 
 	const fqdn = "victim.example.com"
 
+	logs, err := auditlogs.New(auditlogs.Config{DB: h.DB})
+	require.NoError(t, err)
 	svc := customdomain.New(customdomain.Config{
-		Database: h.DB,
-		Bearer:   testBearer,
+		Database:  h.DB,
+		Bearer:    testBearer,
+		Auditlogs: logs,
 	})
 
 	// --- Victim workspace B: verified domain + live frontline route ---
@@ -142,7 +146,7 @@ func TestDeleteCustomDomain_DoesNotDeleteOtherWorkspaceFrontlineRoute(t *testing
 	})
 	req.Header().Set("Authorization", "Bearer "+testBearer)
 
-	_, err := svc.DeleteCustomDomain(ctx, req)
+	_, err = svc.DeleteCustomDomain(ctx, req)
 	require.NoError(t, err)
 
 	// The victim's live frontline route must still exist and be unchanged.
@@ -165,9 +169,12 @@ func TestDeleteCustomDomain_DeletesOwnFrontlineRoute(t *testing.T) {
 
 	const fqdn = "owned.example.com"
 
+	logs, err := auditlogs.New(auditlogs.Config{DB: h.DB})
+	require.NoError(t, err)
 	svc := customdomain.New(customdomain.Config{
-		Database: h.DB,
-		Bearer:   testBearer,
+		Database:  h.DB,
+		Bearer:    testBearer,
+		Auditlogs: logs,
 	})
 
 	ws := h.Seed.Resources.UserWorkspace.ID
@@ -228,7 +235,7 @@ func TestDeleteCustomDomain_DeletesOwnFrontlineRoute(t *testing.T) {
 	})
 	req.Header().Set("Authorization", "Bearer "+testBearer)
 
-	_, err := svc.DeleteCustomDomain(ctx, req)
+	_, err = svc.DeleteCustomDomain(ctx, req)
 	require.NoError(t, err)
 
 	_, err = h.DB.FindFrontlineRouteByFQDN(ctx, fqdn)

--- a/svc/ctrl/integration/deploy_spend_realert_test.go
+++ b/svc/ctrl/integration/deploy_spend_realert_test.go
@@ -139,11 +139,9 @@ func TestDeploySpendCheck_ReAlertAfterBudgetChange(t *testing.T) {
 	tick(budgetLow, 10_000, true) // 100% of $100 -> stopped email #1, suspend
 	require.True(t, suspended, "spend at budget with stop set should suspend")
 
-	// Raise the budget to $200: spend ($100) is now under it. The first tick
-	// records the resume streak and the second confirms it.
-	tick(budgetHigh, 10_000, true) // 50% of $200 -> first confirmation, no email
+	tick(budgetHigh, 10_000, true)
 	require.True(t, suspended, "one under-budget tick must not resume")
-	tick(budgetHigh, 10_000, true) // second confirmation -> resume, no email
+	tick(budgetHigh, 10_000, true)
 	require.False(t, suspended, "second under-budget tick should resume")
 
 	// Spend climbs into the raised budget's thresholds.

--- a/svc/ctrl/integration/deploy_spend_realert_test.go
+++ b/svc/ctrl/integration/deploy_spend_realert_test.go
@@ -78,12 +78,12 @@ func startSpendCheckCapturing(t *testing.T, database db.Database, sender email.S
 
 // TestDeploySpendCheck_ReAlertAfterBudgetChange walks the user's reported flow:
 // spend hits a $100 budget with stop set (stopped email, suspend), the budget is
-// raised to $200 (compute resumes), then spend climbs into the new budget's
-// thresholds. The warning at 75% of the raised budget and the second stopped
-// email must both fire. On the pre-fix code the raised-budget warning never fires
-// because the high-water mark is pinned at 100% from the first suspension, and
-// even if it did the idempotency key (period+threshold only) would dedup it
-// against the old budget's 75% warning.
+// raised to $200 (compute resumes after confirmation), then spend climbs into
+// the new budget's thresholds. The warning at 75% of the raised budget and the
+// second stopped email must both fire. On the pre-fix code the raised-budget
+// warning never fires because the high-water mark is pinned at 100% from the
+// first suspension, and even if it did the idempotency key (period+threshold
+// only) would dedup it against the old budget's 75% warning.
 func TestDeploySpendCheck_ReAlertAfterBudgetChange(t *testing.T) {
 	h := New(t)
 	ctx := h.Context()
@@ -139,9 +139,12 @@ func TestDeploySpendCheck_ReAlertAfterBudgetChange(t *testing.T) {
 	tick(budgetLow, 10_000, true) // 100% of $100 -> stopped email #1, suspend
 	require.True(t, suspended, "spend at budget with stop set should suspend")
 
-	// Raise the budget to $200: spend ($100) is now under it, so compute resumes.
-	tick(budgetHigh, 10_000, true) // 50% of $200 -> resume, no email
-	require.False(t, suspended, "raising the budget above spend should resume")
+	// Raise the budget to $200: spend ($100) is now under it. The first tick
+	// records the resume streak and the second confirms it.
+	tick(budgetHigh, 10_000, true) // 50% of $200 -> first confirmation, no email
+	require.True(t, suspended, "one under-budget tick must not resume")
+	tick(budgetHigh, 10_000, true) // second confirmation -> resume, no email
+	require.False(t, suspended, "second under-budget tick should resume")
 
 	// Spend climbs into the raised budget's thresholds.
 	tick(budgetHigh, 15_000, true) // 75% of $200 -> 75% warning at the NEW budget

--- a/svc/ctrl/integration/deploy_spend_reenforce_test.go
+++ b/svc/ctrl/integration/deploy_spend_reenforce_test.go
@@ -207,9 +207,9 @@ func TestDeploySpendCheck_ReEnforceMergesSuspensionRecord(t *testing.T) {
 		return e == nil && got.DesiredState == mysqltype.DeploymentsDesiredStateStopped
 	}, 15*time.Second, 200*time.Millisecond, "re-enforcement should stop the leaked app2")
 
-	// 4) Resume with the budget raised above spend. The merged record restores
-	//    BOTH apps; a replace bug would have dropped app1.
-	r, err = client.CheckWorkspaceSpend().Request(ctx, &hydrav1.CheckWorkspaceSpendRequest{
+	// 4) Raise the budget above spend. The first under-budget tick only records
+	//    the resume streak, leaving the workspace and both deployments stopped.
+	raisedBudget := &hydrav1.CheckWorkspaceSpendRequest{
 		Period:             period,
 		BudgetCents:        1_000_000,
 		Stop:               true,
@@ -218,9 +218,33 @@ func TestDeploySpendCheck_ReEnforceMergesSuspensionRecord(t *testing.T) {
 		WorkspaceSlug:      "test",
 		SpendMicroCents:    200 * deploybilling.MicroCentsPerCent,
 		CurrentlySuspended: true,
-	})
+	}
+	r, err = client.CheckWorkspaceSpend().Request(ctx, raisedBudget)
 	require.NoError(t, err)
-	require.False(t, r.GetSuspended(), "budget raised above spend should resume")
+	require.True(t, r.GetSuspended(), "one under-budget tick must not resume")
+
+	billing, err := h.DB.FindWorkspaceBillingByWorkspaceID(ctx, dep1.WorkspaceID)
+	require.NoError(t, err)
+	require.True(t, billing.SpendSuspended, "one under-budget tick must leave spend_suspended set")
+
+	app1, err := h.DB.FindAppById(ctx, dep1.AppID)
+	require.NoError(t, err)
+	require.False(t, app1.CurrentDeploymentID.Valid, "app1 must remain stopped until the second tick")
+	app2, err := h.DB.FindAppById(ctx, dep2.AppID)
+	require.NoError(t, err)
+	require.False(t, app2.CurrentDeploymentID.Valid, "app2 must remain stopped until the second tick")
+	gotDep1, err := h.DB.FindDeploymentById(ctx, dep1.ID)
+	require.NoError(t, err)
+	require.Equal(t, mysqltype.DeploymentsDesiredStateStopped, gotDep1.DesiredState)
+	gotDep2, err := h.DB.FindDeploymentById(ctx, dep2.ID)
+	require.NoError(t, err)
+	require.Equal(t, mysqltype.DeploymentsDesiredStateStopped, gotDep2.DesiredState)
+
+	// 5) The second consecutive under-budget tick resumes. The merged record
+	//    restores BOTH apps; a replace bug would have dropped app1.
+	r, err = client.CheckWorkspaceSpend().Request(ctx, raisedBudget)
+	require.NoError(t, err)
+	require.False(t, r.GetSuspended(), "second under-budget tick should resume")
 	require.Eventually(t, func() bool {
 		a1, e1 := h.DB.FindAppById(ctx, dep1.AppID)
 		a2, e2 := h.DB.FindAppById(ctx, dep2.AppID)

--- a/svc/ctrl/integration/deploy_spend_reenforce_test.go
+++ b/svc/ctrl/integration/deploy_spend_reenforce_test.go
@@ -207,8 +207,6 @@ func TestDeploySpendCheck_ReEnforceMergesSuspensionRecord(t *testing.T) {
 		return e == nil && got.DesiredState == mysqltype.DeploymentsDesiredStateStopped
 	}, 15*time.Second, 200*time.Millisecond, "re-enforcement should stop the leaked app2")
 
-	// 4) Raise the budget above spend. The first under-budget tick only records
-	//    the resume streak, leaving the workspace and both deployments stopped.
 	raisedBudget := &hydrav1.CheckWorkspaceSpendRequest{
 		Period:             period,
 		BudgetCents:        1_000_000,
@@ -240,8 +238,6 @@ func TestDeploySpendCheck_ReEnforceMergesSuspensionRecord(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, mysqltype.DeploymentsDesiredStateStopped, gotDep2.DesiredState)
 
-	// 5) The second consecutive under-budget tick resumes. The merged record
-	//    restores BOTH apps; a replace bug would have dropped app1.
 	r, err = client.CheckWorkspaceSpend().Request(ctx, raisedBudget)
 	require.NoError(t, err)
 	require.False(t, r.GetSuspended(), "second under-budget tick should resume")


### PR DESCRIPTION
## Problem:

Tagged control-plane tests expected recovery after one tick, but production requires two confirmations. Deletion fixtures also lacked required audit-log dependencies.

## Solution:

Assert suspension after the first tick and recovery after the second. Supply the missing fixture dependencies.

## Impact:

Preserves production two-confirmation safety. Production handlers and recovery thresholds are unchanged.

Draft stack prerequisites: #7330 and #7320 through #7326. `deps/integration-base` is a merge-only review anchor, not implementation work to merge separately. Do not merge this stack into that anchor. After both prerequisites land, rebase the dependency stack onto current `main` and retarget bottom PR #7353 to `main`; keep later PRs based on the preceding layer. Existing prerequisite PRs are unchanged.

## Testing:

The committed compatible graph passed all 25 tagged control-plane integration tests.

Final combined compatible stack (not an independent run of every intermediate PR):
- `mise run test --concurrency=4`: 303 suites, 24,506 passed, zero failed, 7,875 ignored; 186 cached.
- `GOFLAGS=-race mise run test --concurrency=4`: 303 suites, 24,506 passed, zero failed, 7,875 ignored; 279 cached.
- `mise run build`: passed; lint reported zero issues.
- Tagged control-plane suite: 25 passed.

Full normal and race runs used separate test-container scopes. The race run resumed after fixing the cancellation fixture. An earlier analytics-count timeout did not recur; its cause remains unconfirmed. These are local verification results, not a claim that draft CI ran or passed.