### PR TITLE
keys: isolate errors in the asynchronous cache loader

### DIFF
--- a/internal/services/keys/get.go
+++ b/internal/services/keys/get.go
@@ -103,8 +103,7 @@ func (s *service) Get(ctx context.Context, sess *zen.Session, sha256Hash string)
 
 	key, hit, err := s.keyCache.SWR(ctx, sha256Hash, func(ctx context.Context) (keysdb.CachedKeyData, error) {
 		// Use database retry with exponential backoff, skipping non-transient errors
-		var row keysdb.FindKeyForVerificationRow
-		row, err = mysql.WithRetryContext(ctx, func() (keysdb.FindKeyForVerificationRow, error) {
+		row, err := mysql.WithRetryContext(ctx, func() (keysdb.FindKeyForVerificationRow, error) {
 			return keysdb.Query.FindKeyForVerification(ctx, s.db.RO(), sha256Hash)
 		})
 		if err != nil {


### PR DESCRIPTION
## Problem:

An asynchronous cache refresh wrote the enclosing function's error variable while the caller returned it. Full race verification reproduced the data race.

## Solution:

Keep the database row and error local to the cache-loader callback.

## Impact:

Removes the shared error write without changing cache concurrency, API defaults, or response contracts. This small fix can be reviewed independently of dependency upgrades.

Draft stack prerequisites: #7330 and #7320 through #7326. `deps/integration-base` is a merge-only review anchor, not implementation work to merge separately. Do not merge this stack into that anchor. After both prerequisites land, rebase the dependency stack onto current `main` and retarget bottom PR #7353 to `main`; keep later PRs based on the preceding layer. Existing prerequisite PRs are unchanged.

## Testing:

The reproducing multi-node case and key service checks passed 38 targeted race tests after the fix.

Final combined compatible stack (not an independent run of every intermediate PR):
- `mise run test --concurrency=4`: 303 suites, 24,506 passed, zero failed, 7,875 ignored; 186 cached.
- `GOFLAGS=-race mise run test --concurrency=4`: 303 suites, 24,506 passed, zero failed, 7,875 ignored; 279 cached.
- `mise run build`: passed; lint reported zero issues.
- Tagged control-plane suite: 25 passed.

Full normal and race runs used separate test-container scopes. The race run resumed after fixing the cancellation fixture. An earlier analytics-count timeout did not recur; its cause remains unconfirmed. These are local verification results, not a claim that draft CI ran or passed.