### PR TITLE
protobuf: run the latest Connect generator locally

### DIFF
--- a/gen/proto/ctrl/v1/ctrlv1connect/ops.connect.go
+++ b/gen/proto/ctrl/v1/ctrlv1connect/ops.connect.go
@@ -46,10 +46,10 @@ type OpsServiceClient interface {
 	// settings and env vars — config drift since the source applies.
 	//
 	// Source resolution:
-	//  1. If the source has a git_commit_sha AND the app has a github repo
-	//     connection, rebuild from the pinned SHA.
-	//  2. Otherwise reuse the source deployment's OCI image verbatim.
-	//  3. If neither is available, the RPC fails.
+	//   1. If the source has a git_commit_sha AND the app has a github repo
+	//      connection, rebuild from the pinned SHA.
+	//   2. Otherwise reuse the source deployment's OCI image verbatim.
+	//   3. If neither is available, the RPC fails.
 	//
 	// Guardrail (unless `force` is true): no newer active deployment may exist
 	// on the same (app, environment, branch).
@@ -97,10 +97,10 @@ type OpsServiceHandler interface {
 	// settings and env vars — config drift since the source applies.
 	//
 	// Source resolution:
-	//  1. If the source has a git_commit_sha AND the app has a github repo
-	//     connection, rebuild from the pinned SHA.
-	//  2. Otherwise reuse the source deployment's OCI image verbatim.
-	//  3. If neither is available, the RPC fails.
+	//   1. If the source has a git_commit_sha AND the app has a github repo
+	//      connection, rebuild from the pinned SHA.
+	//   2. Otherwise reuse the source deployment's OCI image verbatim.
+	//   3. If neither is available, the RPC fails.
 	//
 	// Guardrail (unless `force` is true): no newer active deployment may exist
 	// on the same (app, environment, branch).

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,10 @@ module github.com/unkeyed/unkey
 go 1.27.1
 
 // Generating code
-tool github.com/restatedev/sdk-go/x/protoc-gen-go-restate
+tool (
+	connectrpc.com/connect/cmd/protoc-gen-connect-go
+	github.com/restatedev/sdk-go/x/protoc-gen-go-restate
+)
 
 // Linting
 tool (

--- a/svc/ctrl/proto/buf.gen.yaml
+++ b/svc/ctrl/proto/buf.gen.yaml
@@ -8,7 +8,7 @@ plugins:
       - paths=import
       - module=github.com/unkeyed/unkey/gen/proto
 
-  - remote: buf.build/connectrpc/go:v1.20.0
+  - local: ["go", "tool", "protoc-gen-connect-go"]
     out: ../../../gen/proto
     opt:
       - paths=import

--- a/svc/vault/proto/buf.gen.yaml
+++ b/svc/vault/proto/buf.gen.yaml
@@ -8,7 +8,7 @@ plugins:
       - paths=import
       - module=github.com/unkeyed/unkey/gen/proto
 
-  - remote: buf.build/connectrpc/go:v1.20.0
+  - local: ["go", "tool", "protoc-gen-connect-go"]
     out: ../../../gen/proto
     opt:
       - paths=import


### PR DESCRIPTION
## Problem:

Connect 1.21 was released before the corresponding remote Buf plugin was available.

## Solution:

Pin and run the upstream Go tool protoc-gen-connect-go 1.21 locally.

## Impact:

Avoids retaining the older remote generator. Regeneration changes comment indentation, not executable output.

Draft stack prerequisites: #7330 and #7320 through #7326. `deps/integration-base` is a merge-only review anchor, not implementation work to merge separately. Do not merge this stack into that anchor. After both prerequisites land, rebase the dependency stack onto current `main` and retarget bottom PR #7353 to `main`; keep later PRs based on the preceding layer. Existing prerequisite PRs are unchanged.

## Testing:

Actual protobuf generation completed. Output checks found only the expected comment-format change.

Final combined compatible stack (not an independent run of every intermediate PR):
- `mise run test --concurrency=4`: 303 suites, 24,506 passed, zero failed, 7,875 ignored; 186 cached.
- `GOFLAGS=-race mise run test --concurrency=4`: 303 suites, 24,506 passed, zero failed, 7,875 ignored; 279 cached.
- `mise run build`: passed; lint reported zero issues.
- Tagged control-plane suite: 25 passed.

Full normal and race runs used separate test-container scopes. The race run resumed after fixing the cancellation fixture. An earlier analytics-count timeout did not recur; its cause remains unconfirmed. These are local verification results, not a claim that draft CI ran or passed.