### PR TITLE
counter: keep concurrent Redis test errors local

### DIFF
--- a/pkg/counter/redis_test.go
+++ b/pkg/counter/redis_test.go
@@ -518,7 +518,7 @@ func TestRedisCounterDecrement(t *testing.T) {
 			go func() {
 				defer wg.Done()
 				for range decrementsPerWorker {
-					_, err = ctr.Decrement(ctx, key, 2)
+					_, err := ctr.Decrement(ctx, key, 2)
 					if err != nil {
 						t.Errorf("decrement error: %v", err)
 						return
@@ -617,9 +617,8 @@ func TestRedisCounterDecrementIfExists(t *testing.T) {
 		for range numWorkers {
 			go func() {
 				defer wg.Done()
-				var existed, success bool
 
-				_, existed, success, err = ctr.DecrementIfExists(ctx, key, 1)
+				_, existed, success, err := ctr.DecrementIfExists(ctx, key, 1)
 				if err != nil {
 					t.Errorf("DecrementIfExists error: %v", err)
 					return
@@ -798,11 +797,7 @@ func TestRedisCounterDecrementLogic(t *testing.T) {
 				// Wait for all goroutines to be ready
 				<-startBarrier
 
-				var remaining int64
-				var existed bool
-				var success bool
-
-				remaining, existed, success, err = ctr.DecrementIfExists(ctx, key, decrementAmount)
+				remaining, existed, success, err := ctr.DecrementIfExists(ctx, key, decrementAmount)
 				require.NoError(t, err)
 				require.True(t, existed)
 				require.GreaterOrEqual(t, remaining, int64(0), "decrement should always return non-negative actual count")
@@ -872,11 +867,7 @@ func TestRedisCounterDecrementLogic(t *testing.T) {
 			wg.Go(func() {
 				<-startBarrier
 
-				var remaining int64
-				var existed bool
-				var success bool
-
-				remaining, existed, success, err = ctr.DecrementIfExists(ctx, key, decrementAmount)
+				remaining, existed, success, err := ctr.DecrementIfExists(ctx, key, decrementAmount)
 				require.NoError(t, err)
 				require.True(t, existed)
 				require.GreaterOrEqual(t, remaining, int64(0), "should always return non-negative actual count")


### PR DESCRIPTION
## Problem:

Four concurrent Redis test callbacks wrote shared setup error variables. Race verification reproduced the failures.

## Solution:

Keep each operation's results inside its callback.

## Impact:

Changes tests only. Worker concurrency and counter assertions are unchanged.

Draft stack prerequisites: #7330 and #7320 through #7326. `deps/integration-base` is a merge-only review anchor, not implementation work to merge separately. Do not merge this stack into that anchor. After both prerequisites land, rebase the dependency stack onto current `main` and retarget bottom PR #7353 to `main`; keep later PRs based on the preceding layer. Existing prerequisite PRs are unchanged.

## Testing:

The counter package passed all 54 tests under the race detector after the fix.

Final combined compatible stack (not an independent run of every intermediate PR):
- `mise run test --concurrency=4`: 303 suites, 24,506 passed, zero failed, 7,875 ignored; 186 cached.
- `GOFLAGS=-race mise run test --concurrency=4`: 303 suites, 24,506 passed, zero failed, 7,875 ignored; 279 cached.
- `mise run build`: passed; lint reported zero issues.
- Tagged control-plane suite: 25 passed.

Full normal and race runs used separate test-container scopes. The race run resumed after fixing the cancellation fixture. An earlier analytics-count timeout did not recur; its cause remains unconfirmed. These are local verification results, not a claim that draft CI ran or passed.