### PR TITLE
lint: migrate the active exhaustruct analyzer to v5

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -4,7 +4,7 @@ linters:
   enable:
     - errcheck
     - exhaustive
-    - exhaustruct
+    - exhaustruct_v5
     - govet
     - ineffassign
     - reassign
@@ -15,8 +15,8 @@ linters:
     exhaustive:
       check:
         - switch
-    exhaustruct:
-      exclude:
+    exhaustruct_v5:
+      ignore-patterns:
         - ^google\.golang\.org/protobuf/internal/filedesc\..*$
         - ^google\.golang\.org/protobuf/internal/filetype\..*$
         - ^google\.golang\.org/protobuf/reflect/protoreflect\..*$
@@ -94,7 +94,7 @@ linters:
       - std-error-handling
     rules:
       - linters:
-          - exhaustruct
+          - exhaustruct_v5
         path: _test\.go
       - linters:
           - unused

--- a/cmd/dev/github/tunnel.go
+++ b/cmd/dev/github/tunnel.go
@@ -184,7 +184,7 @@ func generateAppJWT(appID int64, privateKeyPEM string) (string, error) {
 	}
 
 	now := time.Now()
-	// nolint:exhaustruct
+	// nolint:exhaustruct_v5
 	claims := jwt.RegisteredClaims{
 		IssuedAt:  now.Add(-60 * time.Second).Unix(),
 		ExpiresAt: now.Add(10 * time.Minute).Unix(),

--- a/cmd/dev/seed/checkpoints/checkpoints.go
+++ b/cmd/dev/seed/checkpoints/checkpoints.go
@@ -162,7 +162,7 @@ func parseFlags(cmd *cli.Command) (generator, error) {
 		return generator{}, fmt.Errorf("invalid --egress-per-day: %w", err)
 	}
 
-	return generator{ //nolint:exhaustruct // target and allocation fields are filled by the caller.
+	return generator{ //nolint:exhaustruct_v5 // target and allocation fields are filled by the caller.
 		vcpu:         vcpu,
 		memoryBytes:  memoryBytes,
 		diskBytes:    diskBytes,

--- a/cmd/dev/seed/checkpoints/checkpoints_test.go
+++ b/cmd/dev/seed/checkpoints/checkpoints_test.go
@@ -71,8 +71,8 @@ func TestGeneratorMatchesBillingMath(t *testing.T) {
 	}{
 		{
 			name: "24/7 single replica",
-			g: generator{ //nolint:exhaustruct
-				target:        target{workspaceID: "ws", projectID: "proj", environmentID: "env", resourceID: "d_1"}, //nolint:exhaustruct
+			g: generator{ //nolint:exhaustruct_v5
+				target:        target{workspaceID: "ws", projectID: "proj", environmentID: "env", resourceID: "d_1"}, //nolint:exhaustruct_v5
 				vcpu:          0.5,
 				memoryBytes:   512 * 1024 * 1024,
 				diskBytes:     1024 * 1024 * 1024,
@@ -87,8 +87,8 @@ func TestGeneratorMatchesBillingMath(t *testing.T) {
 		},
 		{
 			name: "partial uptime, multi replica",
-			g: generator{ //nolint:exhaustruct
-				target:        target{workspaceID: "ws", projectID: "proj", environmentID: "env", resourceID: "d_2"}, //nolint:exhaustruct
+			g: generator{ //nolint:exhaustruct_v5
+				target:        target{workspaceID: "ws", projectID: "proj", environmentID: "env", resourceID: "d_2"}, //nolint:exhaustruct_v5
 				vcpu:          2,
 				memoryBytes:   1024 * 1024 * 1024,
 				diskBytes:     0,
@@ -106,8 +106,8 @@ func TestGeneratorMatchesBillingMath(t *testing.T) {
 			// index-based counters, which must still bill exactly what
 			// expected() predicts (no compounding per-tick truncation).
 			name: "fractional vcpu",
-			g: generator{ //nolint:exhaustruct
-				target:        target{workspaceID: "ws", projectID: "proj", environmentID: "env", resourceID: "d_3"}, //nolint:exhaustruct
+			g: generator{ //nolint:exhaustruct_v5
+				target:        target{workspaceID: "ws", projectID: "proj", environmentID: "env", resourceID: "d_3"}, //nolint:exhaustruct_v5
 				vcpu:          0.333,
 				memoryBytes:   256 * 1024 * 1024,
 				diskBytes:     0,

--- a/cmd/dev/seed/checkpoints/target.go
+++ b/cmd/dev/seed/checkpoints/target.go
@@ -65,7 +65,7 @@ func resolveTarget(ctx context.Context, database db.Database, cmd *cli.Command) 
 		return target{}, err
 	}
 
-	t := target{workspaceID: workspaceID, projectID: projectID, appID: appID, environmentID: envID} //nolint:exhaustruct
+	t := target{workspaceID: workspaceID, projectID: projectID, appID: appID, environmentID: envID} //nolint:exhaustruct_v5
 
 	if deploymentID := cmd.String("deployment"); deploymentID != "" {
 		t.resourceID = deploymentID

--- a/cmd/dev/seed/local.go
+++ b/cmd/dev/seed/local.go
@@ -359,7 +359,7 @@ func seedLocal(ctx context.Context, cmd *cli.Command) error {
 			{
 				WorkspaceID:                           workspaceID,
 				ApiBillableOperationsCountMaxPerMonth: 150_000,
-				ApiRequestsCountMaxPerMinute:          sql.NullInt32{}, //nolint:exhaustruct
+				ApiRequestsCountMaxPerMinute:          sql.NullInt32{}, //nolint:exhaustruct_v5
 				LogsRetentionDaysMax:                  7,
 				LogsAuditRetentionDaysMax:             30,
 				TeamEnabled:                           false,
@@ -376,7 +376,7 @@ func seedLocal(ctx context.Context, cmd *cli.Command) error {
 			{
 				WorkspaceID:                           rootWorkspaceID,
 				ApiBillableOperationsCountMaxPerMonth: 150_000,
-				ApiRequestsCountMaxPerMinute:          sql.NullInt32{}, //nolint:exhaustruct
+				ApiRequestsCountMaxPerMinute:          sql.NullInt32{}, //nolint:exhaustruct_v5
 				LogsRetentionDaysMax:                  7,
 				LogsAuditRetentionDaysMax:             30,
 				TeamEnabled:                           false,

--- a/cmd/dev/stripe/reset.go
+++ b/cmd/dev/stripe/reset.go
@@ -101,7 +101,7 @@ func reset(ctx context.Context, cmd *cli.Command) error {
 	if err := db.Query.UpsertLimit(ctx, database.RW(), db.UpsertLimitParams{
 		WorkspaceID:                           workspaceID,
 		ApiBillableOperationsCountMaxPerMonth: 150_000,
-		ApiRequestsCountMaxPerMinute:          sql.NullInt32{}, //nolint:exhaustruct
+		ApiRequestsCountMaxPerMinute:          sql.NullInt32{}, //nolint:exhaustruct_v5
 		LogsRetentionDaysMax:                  7,
 		LogsAuditRetentionDaysMax:             30,
 		TeamEnabled:                           false,

--- a/cmd/dev/stripe/stripe.go
+++ b/cmd/dev/stripe/stripe.go
@@ -53,7 +53,7 @@ func newClient(cmd *cli.Command) (*stripesdk.Client, error) {
 	}
 
 	return stripesdk.NewClient(key, stripesdk.WithBackends(stripesdk.NewBackendsWithConfig(&stripesdk.BackendConfig{
-		//nolint:exhaustruct // defaults are fine for everything but the logger
+		//nolint:exhaustruct_v5 // defaults are fine for everything but the logger
 		// Every error is returned and rendered by the command itself; the
 		// SDK's default stderr printer would double-report them, raw and ugly.
 		LeveledLogger: &stripesdk.LeveledLogger{Level: stripesdk.LevelNull},

--- a/cmd/version/main.go
+++ b/cmd/version/main.go
@@ -106,7 +106,7 @@ unkey version list --branch main --status active --limit 3  # Combine filters`,
 	},
 }
 
-// nolint: exhaustruct
+// nolint: exhaustruct_v5
 var rollbackCmd = &cli.Command{
 	AcceptsArgs: true,
 	Name:        "rollback",

--- a/internal/services/keys/get.go
+++ b/internal/services/keys/get.go
@@ -169,7 +169,7 @@ func (s *service) Get(ctx context.Context, sess *zen.Session, sha256Hash string)
 	}, caches.DefaultFindFirstOp)
 	if err != nil {
 		if mysql.IsNotFound(err) {
-			// nolint:exhaustruct
+			// nolint:exhaustruct_v5
 			return &KeyVerifier{
 				Status:    StatusNotFound,
 				message:   "key does not exist",
@@ -188,7 +188,7 @@ func (s *service) Get(ctx context.Context, sess *zen.Session, sha256Hash string)
 	}
 
 	if hit == cache.Null {
-		// nolint:exhaustruct
+		// nolint:exhaustruct_v5
 		return &KeyVerifier{
 			Status:    StatusNotFound,
 			message:   "key does not exist",
@@ -201,7 +201,7 @@ func (s *service) Get(ctx context.Context, sess *zen.Session, sha256Hash string)
 
 	// ForWorkspace set but that doesn't exist
 	if key.ForWorkspaceID.Valid && !key.ForWorkspaceEnabled.Valid {
-		// nolint:exhaustruct
+		// nolint:exhaustruct_v5
 		return &KeyVerifier{
 			Status:    StatusWorkspaceNotFound,
 			message:   "workspace not found",
@@ -214,7 +214,7 @@ func (s *service) Get(ctx context.Context, sess *zen.Session, sha256Hash string)
 
 	// Workspace is disabled or the key is not allowed to be used for workspace operations
 	if !key.WorkspaceEnabled || (key.ForWorkspaceEnabled.Valid && !key.ForWorkspaceEnabled.Bool) {
-		// nolint:exhaustruct
+		// nolint:exhaustruct_v5
 		kv = &KeyVerifier{
 			Status:                StatusWorkspaceDisabled,
 			message:               "workspace is disabled",

--- a/internal/services/keys/get_migrated.go
+++ b/internal/services/keys/get_migrated.go
@@ -41,7 +41,7 @@ func (s *service) GetMigrated(ctx context.Context, sess *zen.Session, rawKey str
 	})
 	if err != nil {
 		if mysql.IsNotFound(err) {
-			// nolint:exhaustruct
+			// nolint:exhaustruct_v5
 			return &KeyVerifier{
 				Status:    StatusNotFound,
 				message:   "migration does not exist",
@@ -102,7 +102,7 @@ func (s *service) GetMigrated(ctx context.Context, sess *zen.Session, rawKey str
 	case keysdb.KeyMigrationsAlgorithmSha256:
 		// If we have a sha256 already migrated key and we didn't find it in the first place
 		// then it doesn't exist, and there is nothing to migrate here.
-		// nolint:exhaustruct
+		// nolint:exhaustruct_v5
 		return &KeyVerifier{
 			Status:    StatusNotFound,
 			message:   "key does not exist",

--- a/internal/services/keys/verifier.go
+++ b/internal/services/keys/verifier.go
@@ -79,7 +79,7 @@ func (k *KeyVerifier) Verify(ctx context.Context, opts ...VerifyOption) error {
 		return nil
 	}
 
-	// nolint:exhaustruct
+	// nolint:exhaustruct_v5
 	config := &verifyConfig{}
 	for _, opt := range opts {
 		if err := opt(config); err != nil {

--- a/internal/services/ratelimit/global_integration_test.go
+++ b/internal/services/ratelimit/global_integration_test.go
@@ -288,7 +288,7 @@ func TestGlobalPush_EmitsRowsInUniqueKeyOrder(t *testing.T) {
 
 	for attempt := range 20 {
 		recorder := &recordingGlobalCounterDB{}
-		svc := &service{ //nolint:exhaustruct // test only needs global push dependencies
+		svc := &service{ //nolint:exhaustruct_v5 // test only needs global push dependencies
 			clock:                clock.NewTestClock(),
 			region:               "region-a",
 			db:                   rldb.New(recorder, recorder),
@@ -296,7 +296,7 @@ func TestGlobalPush_EmitsRowsInUniqueKeyOrder(t *testing.T) {
 		}
 
 		for _, key := range keys {
-			entry := &counterEntry{} //nolint:exhaustruct // only push eligibility fields matter here
+			entry := &counterEntry{} //nolint:exhaustruct_v5 // only push eligibility fields matter here
 			entry.val.Store(10)
 			entry.globalPushThreshold.Store(1)
 			svc.counters.Store(key, entry)
@@ -395,7 +395,7 @@ func TestGlobalPush_RetriesDeadlock(t *testing.T) {
 }
 
 func newGlobalPushOnlyService(db rldb.DBTX, region string) *service {
-	return &service{ //nolint:exhaustruct // test only needs global push dependencies
+	return &service{ //nolint:exhaustruct_v5 // test only needs global push dependencies
 		clock:                clock.NewTestClock(),
 		region:               region,
 		db:                   rldb.New(db, db),
@@ -404,7 +404,7 @@ func newGlobalPushOnlyService(db rldb.DBTX, region string) *service {
 }
 
 func newGlobalPullOnlyService(env *integrationTestEnv, clk clock.Clock, region string) *service {
-	return &service{ //nolint:exhaustruct // test only needs global pull dependencies
+	return &service{ //nolint:exhaustruct_v5 // test only needs global pull dependencies
 		clock:  clk,
 		region: region,
 		db:     env.rldb,
@@ -412,7 +412,7 @@ func newGlobalPullOnlyService(env *integrationTestEnv, clk clock.Clock, region s
 }
 
 func storePushableCounter(svc *service, key counterKey) *counterEntry {
-	entry := &counterEntry{} //nolint:exhaustruct // only push eligibility fields matter here
+	entry := &counterEntry{} //nolint:exhaustruct_v5 // only push eligibility fields matter here
 	entry.val.Store(10)
 	entry.globalPushThreshold.Store(1)
 	svc.counters.Store(key, entry)

--- a/internal/services/ratelimit/janitor_test.go
+++ b/internal/services/ratelimit/janitor_test.go
@@ -26,12 +26,12 @@ func TestJanitor_EvictsExpiredCounters(t *testing.T) {
 	// Counter for a window that ended 10 minutes ago (far past 3× duration).
 	oldSeq := calculateSequence(clk.Now().Add(-10*time.Minute), duration)
 	oldKey := counterKey{workspaceID: "ws", namespace: "ns", identifier: "expired", durationMs: durationMs, sequence: oldSeq}
-	svc.counters.Store(oldKey, &counterEntry{}) //nolint:exhaustruct
+	svc.counters.Store(oldKey, &counterEntry{}) //nolint:exhaustruct_v5
 
 	// Counter for the current window — should survive.
 	freshSeq := calculateSequence(clk.Now(), duration)
 	freshKey := counterKey{workspaceID: "ws", namespace: "ns", identifier: "fresh", durationMs: durationMs, sequence: freshSeq}
-	svc.counters.Store(freshKey, &counterEntry{}) //nolint:exhaustruct
+	svc.counters.Store(freshKey, &counterEntry{}) //nolint:exhaustruct_v5
 
 	svc.runJanitorOnce()
 

--- a/internal/services/ratelimit/service.go
+++ b/internal/services/ratelimit/service.go
@@ -378,10 +378,10 @@ func New(config Config) (*service, error) {
 		config.Clock = clock.New()
 	}
 
-	s := &service{ //nolint:exhaustruct // background state zero-initializes before goroutines start
+	s := &service{ //nolint:exhaustruct_v5 // background state zero-initializes before goroutines start
 		clock:        config.Clock,
-		counters:     sync.Map{}, //nolint:exhaustruct // sync.Map zero value is ready to use
-		strictUntils: sync.Map{}, //nolint:exhaustruct // sync.Map zero value is ready to use
+		counters:     sync.Map{}, //nolint:exhaustruct_v5 // sync.Map zero value is ready to use
+		strictUntils: sync.Map{}, //nolint:exhaustruct_v5 // sync.Map zero value is ready to use
 		origin:       config.Counter,
 		region:       config.Region,
 		replayBuffer: buffer.New[RatelimitRequest](buffer.Config{
@@ -469,7 +469,7 @@ func (s *service) findOrCreateCounter(key counterKey) (*counterEntry, bool) {
 	if v, ok := s.counters.Load(key); ok {
 		return v.(*counterEntry), false
 	}
-	fresh := &counterEntry{ //nolint:exhaustruct // other fields zero-initialize correctly
+	fresh := &counterEntry{ //nolint:exhaustruct_v5 // other fields zero-initialize correctly
 		fetch: func(ctx context.Context, op string) (int64, bool) { return s.fetchFromOrigin(ctx, key, op) },
 	}
 	actual, loaded := s.counters.LoadOrStore(key, fresh)

--- a/internal/services/usagelimiter/service.go
+++ b/internal/services/usagelimiter/service.go
@@ -56,7 +56,7 @@ func New(config Config) (*service, error) {
 //   - Service: Counter-based Redis implementation (recommended)
 //   - error: Any initialization errors
 func NewRedisWithCounter(config RedisConfig) (Service, error) {
-	//nolint:exhaustruct // ReplayWorkers defaults to 8 in NewCounter when unset
+	//nolint:exhaustruct_v5 // ReplayWorkers defaults to 8 in NewCounter when unset
 	return NewCounter(CounterConfig{
 		FindKeyCredits:      config.FindKeyCredits,
 		DecrementKeyCredits: config.DecrementKeyCredits,

--- a/pkg/batch/process.go
+++ b/pkg/batch/process.go
@@ -92,7 +92,7 @@ func New[T any](config Config[T]) *BatchProcessor[T] {
 		config.Consumers = 1
 	}
 
-	bp := &BatchProcessor[T]{ //nolint:exhaustruct // consumers WaitGroup zero-value is the intended initial state
+	bp := &BatchProcessor[T]{ //nolint:exhaustruct_v5 // consumers WaitGroup zero-value is the intended initial state
 		name: config.Name,
 		buffer: buffer.New[T](buffer.Config{
 			Name:     config.Name,

--- a/pkg/cli/flag.go
+++ b/pkg/cli/flag.go
@@ -507,9 +507,9 @@ func Default(value any) FlagOption {
 
 // String creates a new string flag with optional configuration
 func String(name, usage string, opts ...FlagOption) *StringFlag {
-	// nolint: exhaustruct
+	// nolint: exhaustruct_v5
 	flag := &StringFlag{
-		// nolint: exhaustruct
+		// nolint: exhaustruct_v5
 		baseFlag: baseFlag{
 			name:     name,
 			usage:    usage,
@@ -544,9 +544,9 @@ func String(name, usage string, opts ...FlagOption) *StringFlag {
 
 // Duration creates a new duration flag with optional configuration
 func Duration(name, usage string, opts ...FlagOption) *DurationFlag {
-	// nolint: exhaustruct
+	// nolint: exhaustruct_v5
 	flag := &DurationFlag{
-		// nolint: exhaustruct
+		// nolint: exhaustruct_v5
 		baseFlag: baseFlag{
 			name:     name,
 			usage:    usage,
@@ -585,9 +585,9 @@ func Duration(name, usage string, opts ...FlagOption) *DurationFlag {
 
 // Bool creates a new boolean flag with optional configuration
 func Bool(name, usage string, opts ...FlagOption) *BoolFlag {
-	// nolint: exhaustruct
+	// nolint: exhaustruct_v5
 	flag := &BoolFlag{
-		// nolint: exhaustruct
+		// nolint: exhaustruct_v5
 		baseFlag: baseFlag{
 			name:     name,
 			usage:    usage,
@@ -626,9 +626,9 @@ func Bool(name, usage string, opts ...FlagOption) *BoolFlag {
 
 // Int creates a new integer flag with optional configuration
 func Int(name, usage string, opts ...FlagOption) *IntFlag {
-	// nolint: exhaustruct
+	// nolint: exhaustruct_v5
 	flag := &IntFlag{
-		// nolint: exhaustruct
+		// nolint: exhaustruct_v5
 		baseFlag: baseFlag{
 			name:     name,
 			usage:    usage,
@@ -668,9 +668,9 @@ func Int(name, usage string, opts ...FlagOption) *IntFlag {
 
 // Float creates a new float flag with optional configuration
 func Float(name, usage string, opts ...FlagOption) *FloatFlag {
-	// nolint: exhaustruct
+	// nolint: exhaustruct_v5
 	flag := &FloatFlag{
-		// nolint: exhaustruct
+		// nolint: exhaustruct_v5
 		baseFlag: baseFlag{
 			name:     name,
 			usage:    usage,
@@ -710,9 +710,9 @@ func Float(name, usage string, opts ...FlagOption) *FloatFlag {
 
 // StringSlice creates a new string slice flag with optional configuration
 func StringSlice(name, usage string, opts ...FlagOption) *StringSliceFlag {
-	// nolint: exhaustruct
+	// nolint: exhaustruct_v5
 	flag := &StringSliceFlag{
-		// nolint: exhaustruct
+		// nolint: exhaustruct_v5
 		baseFlag: baseFlag{
 			name:     name,
 			usage:    usage,
@@ -749,9 +749,9 @@ func StringSlice(name, usage string, opts ...FlagOption) *StringSliceFlag {
 // values are shown in help text and validation errors, so they are declared in
 // a single place.
 func Enum(name, usage string, allowed []string, opts ...FlagOption) *EnumFlag {
-	// nolint: exhaustruct
+	// nolint: exhaustruct_v5
 	flag := &EnumFlag{
-		// nolint: exhaustruct
+		// nolint: exhaustruct_v5
 		baseFlag: baseFlag{
 			name:     name,
 			usage:    usage,
@@ -789,9 +789,9 @@ func Enum(name, usage string, allowed []string, opts ...FlagOption) *EnumFlag {
 
 // Int64 creates a new int64 flag with optional configuration
 func Int64(name, usage string, opts ...FlagOption) *Int64Flag {
-	// nolint: exhaustruct
+	// nolint: exhaustruct_v5
 	flag := &Int64Flag{
-		// nolint: exhaustruct
+		// nolint: exhaustruct_v5
 		baseFlag: baseFlag{
 			name:     name,
 			usage:    usage,

--- a/pkg/clock/cached_clock.go
+++ b/pkg/clock/cached_clock.go
@@ -56,7 +56,7 @@ func NewCachedClock(resolution time.Duration) *CachedClock {
 }
 
 // Ensure CachedClock implements the Clock interface
-// nolint:exhaustruct
+// nolint:exhaustruct_v5
 var _ Clock = &CachedClock{}
 
 // Now returns the current system time.

--- a/pkg/clock/cached_clock_test.go
+++ b/pkg/clock/cached_clock_test.go
@@ -123,6 +123,6 @@ func TestCachedClock(t *testing.T) {
 	})
 
 	t.Run("CachedClock implements Clock interface", func(t *testing.T) {
-		var _ Clock = &CachedClock{} // nolint:exhaustruct
+		var _ Clock = &CachedClock{} // nolint:exhaustruct_v5
 	})
 }

--- a/pkg/clock/test_clock.go
+++ b/pkg/clock/test_clock.go
@@ -31,7 +31,7 @@ func NewTestClock(now ...time.Time) *TestClock {
 	if len(now) == 0 {
 		now = append(now, time.Now())
 	}
-	return &TestClock{mu: sync.RWMutex{}, now: now[0]} //nolint:exhaustruct
+	return &TestClock{mu: sync.RWMutex{}, now: now[0]} //nolint:exhaustruct_v5
 }
 
 // Ensure TestClock implements the Clock interface
@@ -113,7 +113,7 @@ func (c *TestClock) NewTicker(d time.Duration) Ticker {
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	t := &testTicker{ //nolint:exhaustruct // stopMu and stopped take their zero values
+	t := &testTicker{ //nolint:exhaustruct_v5 // stopMu and stopped take their zero values
 		parent:   c,
 		period:   d,
 		nextFire: c.now.Add(d),

--- a/pkg/clock/test_clock_test.go
+++ b/pkg/clock/test_clock_test.go
@@ -91,7 +91,7 @@ func TestTestClockWithNegativeTick(t *testing.T) {
 
 func TestClockInterface(t *testing.T) {
 	var realClock Clock = &RealClock{}
-	var testClock Clock = &TestClock{} // nolint:exhaustruct
+	var testClock Clock = &TestClock{} // nolint:exhaustruct_v5
 
 	require.Implements(t, (*Clock)(nil), realClock)
 	require.Implements(t, (*Clock)(nil), testClock)

--- a/pkg/counter/memory.go
+++ b/pkg/counter/memory.go
@@ -23,7 +23,7 @@ type memoryCounter struct {
 // NewMemory creates a new in-memory counter.
 // Entries with a TTL are lazily expired on access.
 func NewMemory() Counter {
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	return &memoryCounter{
 		entries: make(map[string]memoryEntry),
 	}

--- a/pkg/db/key_data.go
+++ b/pkg/db/key_data.go
@@ -51,7 +51,7 @@ func ToKeyData[T KeyRow](row T) *KeyData {
 }
 
 func buildKeyDataFromID(r *FindLiveKeyByIDRow) *KeyData {
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	kd := &KeyData{
 		Key: Key{
 			ID:                r.KeyID,
@@ -93,7 +93,7 @@ func buildKeyDataFromID(r *FindLiveKeyByIDRow) *KeyData {
 }
 
 func buildKeyDataFromKeySpace(r *ListLiveKeysByKeySpaceIDRow) *KeyData {
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	kd := &KeyData{
 		Key: Key{
 			Pk:                 r.Pk,
@@ -135,7 +135,7 @@ func buildKeyDataFromKeySpace(r *ListLiveKeysByKeySpaceIDRow) *KeyData {
 	}
 
 	if r.IdentityID.Valid {
-		//nolint:exhaustruct
+		//nolint:exhaustruct_v5
 		kd.Identity = &Identity{
 			Pk:          r.Pk,
 			ID:          r.IdentityID.String,
@@ -162,7 +162,7 @@ func buildKeyDataFromKeySpace(r *ListLiveKeysByKeySpaceIDRow) *KeyData {
 }
 
 func buildKeyData(r *FindLiveKeyByHashRow) *KeyData {
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	kd := &KeyData{
 		Key: Key{
 			ID:                r.KeyID,
@@ -206,7 +206,7 @@ func populateFindLiveKeyRelationships(kd *KeyData, workspaceID string, identityI
 	identityMeta []byte, roles, permissions, rolePermissions, ratelimits interface{},
 ) {
 	if identityID.Valid {
-		//nolint:exhaustruct
+		//nolint:exhaustruct_v5
 		kd.Identity = &Identity{
 			ID:          identityID.String,
 			ExternalID:  identityExternalID.String,

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -48,7 +48,7 @@ func newResolver(server string, timeout time.Duration) *net.Resolver {
 		PreferGo:     true,
 		StrictErrors: false,
 		Dial: func(ctx context.Context, network, _ string) (net.Conn, error) {
-			d := net.Dialer{} //nolint:exhaustruct
+			d := net.Dialer{} //nolint:exhaustruct_v5
 			d.Timeout = timeout
 			return d.DialContext(ctx, network, server)
 		},

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -182,7 +182,7 @@ func (c *Client) ghHeaders(installationID int64) (map[string]string, error) {
 // generateJWT creates a short-lived JWT for GitHub App authentication.
 func (c *Client) generateJWT() (string, error) {
 	now := time.Now()
-	// nolint:exhaustruct
+	// nolint:exhaustruct_v5
 	claims := jwt.RegisteredClaims{
 		IssuedAt:  now.Unix(),
 		ExpiresAt: now.Add(10 * time.Minute).Unix(),

--- a/pkg/logger/global.go
+++ b/pkg/logger/global.go
@@ -46,7 +46,7 @@ func newDefaultHandler(out *os.File) slog.Handler {
 	if term.IsTerminal(int(out.Fd())) && os.Getenv("NO_COLOR") == "" {
 		return newPrettyHandler(out, level)
 	}
-	return slog.NewTextHandler(out, &slog.HandlerOptions{ //nolint:exhaustruct // ReplaceAttr default
+	return slog.NewTextHandler(out, &slog.HandlerOptions{ //nolint:exhaustruct_v5 // ReplaceAttr default
 		Level:     level,
 		AddSource: true,
 	})

--- a/pkg/logger/level_test.go
+++ b/pkg/logger/level_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestAtLevel(t *testing.T) {
 	var buf bytes.Buffer
-	//nolint:exhaustruct // only Level matters here
+	//nolint:exhaustruct_v5 // only Level matters here
 	base := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
 	h := AtLevel(base, slog.LevelWarn)
 	log := slog.New(h)

--- a/pkg/logger/loggertest/capture.go
+++ b/pkg/logger/loggertest/capture.go
@@ -129,7 +129,7 @@ func (h *CaptureHandler) Find(t *testing.T, msg string) slog.Record {
 		}
 	}
 	t.Fatalf("no record with message %q (captured %d records)", msg, len(h.records))
-	return slog.Record{} //nolint:exhaustruct // unreachable; t.Fatalf aborts the test
+	return slog.Record{} //nolint:exhaustruct_v5 // unreachable; t.Fatalf aborts the test
 }
 
 // FlatAttrs collapses a record's attributes into key→value, flattening

--- a/pkg/logger/pretty.go
+++ b/pkg/logger/pretty.go
@@ -137,7 +137,7 @@ func levelTag(l slog.Level) string {
 // slog.Handler contract.
 func appendAttr(b *strings.Builder, groupPrefix string, a slog.Attr) {
 	a.Value = a.Value.Resolve()
-	if a.Equal(slog.Attr{}) { //nolint:exhaustruct // zero attr is the sentinel per slog docs
+	if a.Equal(slog.Attr{}) { //nolint:exhaustruct_v5 // zero attr is the sentinel per slog docs
 		return
 	}
 	if a.Value.Kind() == slog.KindGroup {

--- a/pkg/prefixedapikey/prefixedapikey.go
+++ b/pkg/prefixedapikey/prefixedapikey.go
@@ -58,7 +58,7 @@ func padStart(str string, length int, padChar string) string {
 func GenerateAPIKey(opts *GenerateAPIKeyOptions) (*APIKey, error) {
 	// Set default values if not provided
 	if opts == nil {
-		// nolint:exhaustruct
+		// nolint:exhaustruct_v5
 		opts = &GenerateAPIKeyOptions{}
 	}
 	if opts.KeyPrefix == "" {

--- a/pkg/rbac/parser.go
+++ b/pkg/rbac/parser.go
@@ -57,7 +57,7 @@ type parser struct {
 //	}
 //	// Use the resulting PermissionQuery...
 func newParser(input string) *parser {
-	//nolint: exhaustruct
+	//nolint: exhaustruct_v5
 	p := &parser{
 		lexer: newLexer(input),
 	}

--- a/pkg/ssrf/ssrf.go
+++ b/pkg/ssrf/ssrf.go
@@ -145,7 +145,7 @@ func applyOptions(opts []Option) config {
 // guard. It resolves the host itself and dials resolved IPs directly, so the
 // address that passed the check is exactly the address that is dialed.
 func dialContext(cfg config) func(context.Context, string, string) (net.Conn, error) {
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	dialer := &net.Dialer{Timeout: 30 * time.Second, KeepAlive: 30 * time.Second}
 	return func(ctx context.Context, network, address string) (net.Conn, error) {
 		host, port, err := net.SplitHostPort(address)

--- a/pkg/testutil/containers/restate.go
+++ b/pkg/testutil/containers/restate.go
@@ -82,7 +82,7 @@ func Restate(t *testing.T, services ...restate.ServiceDefinition) RestateConfig 
 
 	admin := restateAdminClient{
 		baseURL: cfg.AdminURL,
-		http:    &http.Client{Timeout: 10 * time.Second}, //nolint:exhaustruct // Defaults are sufficient for tests.
+		http:    &http.Client{Timeout: 10 * time.Second}, //nolint:exhaustruct_v5 // Defaults are sufficient for tests.
 	}
 	require.Eventually(t, func() bool {
 		healthCtx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
@@ -102,7 +102,7 @@ func Restate(t *testing.T, services ...restate.ServiceDefinition) RestateConfig 
 	require.NoError(t, err)
 	workerListener, err := net.Listen("tcp", "0.0.0.0:0") //nolint:gosec // Restate in Docker must reach the test worker.
 	require.NoError(t, err)
-	worker = httptest.NewUnstartedServer(h2c.NewHandler(restateHandler, &http2.Server{})) //nolint:exhaustruct // Defaults are sufficient for tests.
+	worker = httptest.NewUnstartedServer(h2c.NewHandler(restateHandler, &http2.Server{})) //nolint:exhaustruct_v5 // Defaults are sufficient for tests.
 	require.NoError(t, worker.Listener.Close())
 	worker.Listener = workerListener
 	worker.Start()

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -70,7 +70,7 @@ func New(certPEMBlock, keyPEMBlock []byte) (*tls.Config, error) {
 		return nil, fault.Wrap(err, fault.Internal("failed to parse TLS certificate"), fault.Public("Invalid certificate or key format"))
 	}
 
-	// nolint:exhaustruct
+	// nolint:exhaustruct_v5
 	return &tls.Config{
 		Certificates: []tls.Certificate{cert},
 		MinVersion:   tls.VersionTLS13,

--- a/pkg/webhook/verifiers/stripe/stripe.go
+++ b/pkg/webhook/verifiers/stripe/stripe.go
@@ -35,7 +35,7 @@ func (v *Verifier) Verify(r *http.Request) (webhook.Event, error) {
 	// drift into a total webhook outage. Verification stays strict on the
 	// signature; handlers are expected to parse the raw payload minimally,
 	// reading only fields that are stable across Stripe API versions.
-	//nolint:exhaustruct // defaults are correct for everything else
+	//nolint:exhaustruct_v5 // defaults are correct for everything else
 	event, err := stripewebhook.ConstructEventWithOptions(
 		body,
 		r.Header.Get("Stripe-Signature"),

--- a/pkg/zen/auth_test.go
+++ b/pkg/zen/auth_test.go
@@ -1,4 +1,4 @@
-// nolint:exhaustruct
+// nolint:exhaustruct_v5
 package zen
 
 import (

--- a/pkg/zen/request_util.go
+++ b/pkg/zen/request_util.go
@@ -8,7 +8,7 @@ import (
 // BindBody binds the request body to the given struct.
 // If it fails, an error is returned, that you can directly return from your handler.
 func BindBody[T any](s *Session) (T, error) {
-	// nolint:exhaustruct
+	// nolint:exhaustruct_v5
 	var req T
 	err := s.BindBody(&req)
 	if err != nil {

--- a/pkg/zen/server.go
+++ b/pkg/zen/server.go
@@ -113,7 +113,7 @@ func New(config Config) (*Server, error) {
 	// Wrap handler with h2c if enabled for HTTP/2 cleartext support
 	var handler http.Handler = mux
 	if config.EnableH2C {
-		//nolint:exhaustruct
+		//nolint:exhaustruct_v5
 		h2s := &http2.Server{}
 		handler = h2c.NewHandler(mux, h2s)
 	}

--- a/pkg/zen/session_bind_body_test.go
+++ b/pkg/zen/session_bind_body_test.go
@@ -1,4 +1,4 @@
-// nolint:exhaustruct
+// nolint:exhaustruct_v5
 package zen
 
 import (

--- a/pkg/zen/session_bind_query_test.go
+++ b/pkg/zen/session_bind_query_test.go
@@ -1,4 +1,4 @@
-// nolint:exhaustruct
+// nolint:exhaustruct_v5
 package zen
 
 import (

--- a/pkg/zen/validation/validator.go
+++ b/pkg/zen/validation/validator.go
@@ -34,7 +34,7 @@ func (v *Validator) Validate(ctx context.Context, r *http.Request) (openapi.BadR
 
 	result := v.core.Validate(r)
 	if result == nil {
-		//nolint:exhaustruct
+		//nolint:exhaustruct_v5
 		return openapi.BadRequestErrorResponse{}, true
 	}
 
@@ -47,7 +47,7 @@ func (v *Validator) Validate(ctx context.Context, r *http.Request) (openapi.BadR
 		}
 	}
 
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	return openapi.BadRequestErrorResponse{
 		Meta: openapi.Meta{
 			RequestId: ctxutil.GetRequestID(r.Context()),

--- a/svc/api/integration/multi_node_usagelimiting/run.go
+++ b/svc/api/integration/multi_node_usagelimiting/run.go
@@ -35,13 +35,13 @@ func RunUsageLimitTest(
 	rootKey := h.Seed.CreateRootKey(ctx, workspace.ID, "api.*.verify_key")
 
 	// Create API using seed
-	// nolint: exhaustruct
+	// nolint: exhaustruct_v5
 	api := h.Seed.CreateAPI(ctx, seed.CreateApiRequest{
 		WorkspaceID: workspace.ID,
 	})
 
 	// Create key with specified credit limit using seed
-	// nolint: exhaustruct
+	// nolint: exhaustruct_v5
 	keyResponse := h.Seed.CreateKey(ctx, seed.CreateKeyRequest{
 		WorkspaceID: workspace.ID,
 		KeySpaceID:  api.KeyAuthID.String,

--- a/svc/api/internal/middleware/authentication.go
+++ b/svc/api/internal/middleware/authentication.go
@@ -145,7 +145,7 @@ func checkWorkspaceRateLimit(ctx context.Context, sess *zen.Session, config Auth
 		Limit:       int64(limit),
 		Duration:    duration,
 		Cost:        1,
-		Time:        time.Time{}, //nolint:exhaustruct // use ratelimiter's clock
+		Time:        time.Time{}, //nolint:exhaustruct_v5 // use ratelimiter's clock
 	})
 	if err != nil {
 		logger.Error("workspace rate limit: ratelimiter error",

--- a/svc/api/internal/middleware/errors_test.go
+++ b/svc/api/internal/middleware/errors_test.go
@@ -1,4 +1,4 @@
-// nolint:exhaustruct
+// nolint:exhaustruct_v5
 package middleware_test
 
 import (

--- a/svc/api/internal/testutil/http.go
+++ b/svc/api/internal/testutil/http.go
@@ -782,7 +782,7 @@ func (h *Harness) SetupAnalytics(workspaceID string, opts ...SetupAnalyticsOptio
 	err = db.Query.UpsertLimit(ctx, h.DB.RW(), db.UpsertLimitParams{
 		WorkspaceID:                           workspaceID,
 		ApiBillableOperationsCountMaxPerMonth: 1_000_000,
-		ApiRequestsCountMaxPerMinute:          sql.NullInt32{}, //nolint:exhaustruct
+		ApiRequestsCountMaxPerMinute:          sql.NullInt32{}, //nolint:exhaustruct_v5
 		LogsRetentionDaysMax:                  uint16(config.RetentionDays),
 		LogsAuditRetentionDaysMax:             uint16(config.RetentionDays),
 		TeamEnabled:                           false,

--- a/svc/api/internal/testutil/seed/seed.go
+++ b/svc/api/internal/testutil/seed/seed.go
@@ -49,7 +49,7 @@ func New(t *testing.T, database db.Database, vault vault.VaultServiceClient) *Se
 		t:         t,
 		DB:        database,
 		Vault:     vault,
-		Resources: Resources{}, //nolint:exhaustruct
+		Resources: Resources{}, //nolint:exhaustruct_v5
 	}
 }
 
@@ -74,7 +74,7 @@ func (s *Seeder) CreateWorkspace(ctx context.Context) db.Workspace {
 	err = db.Query.UpsertLimit(ctx, s.DB.RW(), db.UpsertLimitParams{
 		WorkspaceID:                           params.ID,
 		ApiBillableOperationsCountMaxPerMonth: 1_000_000,
-		ApiRequestsCountMaxPerMinute:          sql.NullInt32{}, //nolint:exhaustruct
+		ApiRequestsCountMaxPerMinute:          sql.NullInt32{}, //nolint:exhaustruct_v5
 		LogsRetentionDaysMax:                  30,
 		LogsAuditRetentionDaysMax:             30,
 		TeamEnabled:                           false,

--- a/svc/api/routes/v2_apps_delete_app/400_test.go
+++ b/svc/api/routes/v2_apps_delete_app/400_test.go
@@ -1,4 +1,4 @@
-//nolint:exhaustruct
+//nolint:exhaustruct_v5
 package handler_test
 
 import (

--- a/svc/api/routes/v2_apps_update_app/400_test.go
+++ b/svc/api/routes/v2_apps_update_app/400_test.go
@@ -1,4 +1,4 @@
-//nolint:exhaustruct
+//nolint:exhaustruct_v5
 package handler_test
 
 import (

--- a/svc/api/routes/v2_deploy_create_deployment/handler.go
+++ b/svc/api/routes/v2_deploy_create_deployment/handler.go
@@ -92,7 +92,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	// nolint: exhaustruct // optional proto fields, only setting whats provided
+	// nolint: exhaustruct_v5 // optional proto fields, only setting whats provided
 	ctrlReq := &ctrlv1.CreateDeploymentRequest{
 		ProjectId:       row.ProjectID,
 		AppId:           row.AppID,
@@ -137,7 +137,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 	// Handle optional git commit info
 	if req.GitCommit != nil {
-		// nolint: exhaustruct // optional proto fields, only setting whats provided
+		// nolint: exhaustruct_v5 // optional proto fields, only setting whats provided
 		gitCommit := &ctrlv1.GitCommitInfo{
 			Branch: req.Branch,
 		}

--- a/svc/api/routes/v2_deployments_create_deployment/handler.go
+++ b/svc/api/routes/v2_deployments_create_deployment/handler.go
@@ -109,7 +109,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	// nolint: exhaustruct // optional proto fields are set per source below
+	// nolint: exhaustruct_v5 // optional proto fields are set per source below
 	ctrlReq := &ctrlv1.CreateDeploymentRequest{
 		ProjectId:       environment.ProjectID,
 		AppId:           environment.AppID,
@@ -150,7 +150,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			}
 			return fault.Wrap(err, fault.Internal("failed to check repo connection"))
 		}
-		// nolint: exhaustruct // ctrl fills the commit metadata it resolves from git
+		// nolint: exhaustruct_v5 // ctrl fills the commit metadata it resolves from git
 		ctrlReq.Source = &ctrlv1.CreateDeploymentRequest_GitCommit{
 			GitCommit: &ctrlv1.GitCommitInfo{
 				Branch:         ptr.SafeDeref(git.Branch),

--- a/svc/api/routes/v2_deployments_get_deployment/handler.go
+++ b/svc/api/routes/v2_deployments_get_deployment/handler.go
@@ -97,7 +97,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			fault.Public("Failed to retrieve deployment."),
 		)
 	}
-	var state db.ListDeploymentEnvAndAppStateRow //nolint:exhaustruct // zero value when the join misses
+	var state db.ListDeploymentEnvAndAppStateRow //nolint:exhaustruct_v5 // zero value when the join misses
 	if len(states) > 0 {
 		state = states[0]
 	}

--- a/svc/api/routes/v2_environments_update_settings/200_test.go
+++ b/svc/api/routes/v2_environments_update_settings/200_test.go
@@ -24,7 +24,7 @@ func TestUpdateSettingsSuccessfully(t *testing.T) {
 	err := db.Query.UpsertLimit(ctx, h.DB.RW(), db.UpsertLimitParams{
 		WorkspaceID:                           workspace.ID,
 		ApiBillableOperationsCountMaxPerMonth: 1_000_000,
-		ApiRequestsCountMaxPerMinute:          sql.NullInt32{}, //nolint:exhaustruct
+		ApiRequestsCountMaxPerMinute:          sql.NullInt32{}, //nolint:exhaustruct_v5
 		LogsRetentionDaysMax:                  30,
 		LogsAuditRetentionDaysMax:             30,
 		TeamEnabled:                           false,

--- a/svc/api/routes/v2_identities_create_identity/400_test.go
+++ b/svc/api/routes/v2_identities_create_identity/400_test.go
@@ -1,4 +1,4 @@
-//nolint:exhaustruct
+//nolint:exhaustruct_v5
 package handler_test
 
 import (

--- a/svc/api/routes/v2_identities_delete_identity/400_test.go
+++ b/svc/api/routes/v2_identities_delete_identity/400_test.go
@@ -1,4 +1,4 @@
-//nolint:exhaustruct
+//nolint:exhaustruct_v5
 package handler_test
 
 import (

--- a/svc/api/routes/v2_identities_delete_identity/handler.go
+++ b/svc/api/routes/v2_identities_delete_identity/handler.go
@@ -52,7 +52,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	// nolint:exhaustruct
+	// nolint:exhaustruct_v5
 	req, err := zen.BindBody[Request](s)
 	if err != nil {
 		return err

--- a/svc/api/routes/v2_identities_list_identities/handler.go
+++ b/svc/api/routes/v2_identities_list_identities/handler.go
@@ -46,7 +46,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	// nolint:exhaustruct
+	// nolint:exhaustruct_v5
 	req, err := zen.BindBody[Request](s)
 	if err != nil {
 		return err

--- a/svc/api/routes/v2_identities_list_identities/scale_test.go
+++ b/svc/api/routes/v2_identities_list_identities/scale_test.go
@@ -179,7 +179,7 @@ func seedScaleLimits(t *testing.T, ctx context.Context, h *testutil.Harness) {
 	err := db.Query.UpsertLimit(ctx, h.DB.RW(), db.UpsertLimitParams{
 		WorkspaceID:                           scaleWorkspaceID,
 		ApiBillableOperationsCountMaxPerMonth: 1_000_000,
-		ApiRequestsCountMaxPerMinute:          sql.NullInt32{}, //nolint:exhaustruct
+		ApiRequestsCountMaxPerMinute:          sql.NullInt32{}, //nolint:exhaustruct_v5
 		LogsRetentionDaysMax:                  30,
 		LogsAuditRetentionDaysMax:             30,
 		TeamEnabled:                           false,

--- a/svc/api/routes/v2_identities_update_identity/handler.go
+++ b/svc/api/routes/v2_identities_update_identity/handler.go
@@ -190,7 +190,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 				Meta: metaBytes,
 			})
 			if err != nil {
-				// nolint:exhaustruct
+				// nolint:exhaustruct_v5
 				return txResult{}, fault.Wrap(err,
 					fault.Internal("unable to update metadata"), fault.Public("We're unable to update the identity's metadata."),
 				)
@@ -261,7 +261,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			if len(rateLimitsToDelete) > 0 {
 				err = db.Query.DeleteManyRatelimitsByIDs(ctx, tx, rateLimitsToDelete)
 				if err != nil {
-					// nolint:exhaustruct
+					// nolint:exhaustruct_v5
 					return txResult{}, fault.Wrap(err,
 						fault.Internal("unable to delete ratelimits"), fault.Public("We're unable to delete ratelimits."),
 					)
@@ -288,7 +288,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 						AutoApply: newRL.AutoApply,
 					})
 					if err != nil {
-						// nolint:exhaustruct
+						// nolint:exhaustruct_v5
 						return txResult{}, fault.Wrap(err,
 							fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
 							fault.Internal("database failed to update ratelimit"),
@@ -382,7 +382,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			if len(rateLimitsToInsert) > 0 {
 				err = db.BulkQuery.InsertIdentityRatelimits(ctx, tx, rateLimitsToInsert)
 				if err != nil {
-					// nolint:exhaustruct
+					// nolint:exhaustruct_v5
 					return txResult{}, fault.Wrap(err,
 						fault.Code(codes.App.Internal.ServiceUnavailable.URN()),
 						fault.Internal("database failed to insert ratelimits"),
@@ -405,7 +405,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 
 		err = h.Auditlogs.Insert(ctx, tx, auditLogs)
 		if err != nil {
-			// nolint:exhaustruct
+			// nolint:exhaustruct_v5
 			return txResult{}, err
 		}
 

--- a/svc/api/routes/v2_keys_migrate_keys/handler.go
+++ b/svc/api/routes/v2_keys_migrate_keys/handler.go
@@ -196,7 +196,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 				RemainingRequests:  sql.NullInt64{Valid: false, Int64: 0},
 				RefillDay:          sql.NullInt16{Valid: false, Int16: 0},
 				RefillAmount:       sql.NullInt64{Valid: false, Int64: 0},
-			} // nolint:exhaustruct
+			} // nolint:exhaustruct_v5
 
 			if key.Meta != nil {
 				metaBytes, marshalErr := json.Marshal(*key.Meta)

--- a/svc/api/routes/v2_keys_reroll_key/200_test.go
+++ b/svc/api/routes/v2_keys_reroll_key/200_test.go
@@ -267,7 +267,7 @@ func TestRerollKeySuccess(t *testing.T) {
 			WorkspaceID: workspace.ID,
 			Disabled:    false,
 			KeySpaceID:  api.KeyAuthID.String,
-		}) // nolint:exhaustruct
+		}) // nolint:exhaustruct_v5
 
 		req := handler.Request{
 			KeyId:      key.KeyID,

--- a/svc/api/routes/v2_keys_reroll_key/handler.go
+++ b/svc/api/routes/v2_keys_reroll_key/handler.go
@@ -321,7 +321,7 @@ func (h *Handler) RerollKey(
 				expiration = time.Now()
 			}
 
-			//nolint: exhaustruct
+			//nolint: exhaustruct_v5
 			err = db.Query.UpdateKey(ctx, tx, db.UpdateKeyParams{
 				ID:               req.KeyId,
 				ExpiresSpecified: 1,

--- a/svc/api/routes/v2_keys_verify_key/audit_log_internal_test.go
+++ b/svc/api/routes/v2_keys_verify_key/audit_log_internal_test.go
@@ -46,7 +46,7 @@ func TestBufferAuditLog_SkipsNonRootPrincipal(t *testing.T) {
 		require.Zero(t, eventCountFlushed.Load())
 	})
 
-	h := &Handler{DirectAuditLogs: directAuditLogs} //nolint:exhaustruct
+	h := &Handler{DirectAuditLogs: directAuditLogs} //nolint:exhaustruct_v5
 	p := &principal.Principal{
 		Version: principal.Version,
 		Subject: principal.Subject{
@@ -63,8 +63,8 @@ func TestBufferAuditLog_SkipsNonRootPrincipal(t *testing.T) {
 		AuthorizedWorkspaceID: "ws_123",
 		Permissions:           nil,
 	}
-	key := &keys.KeyVerifier{ //nolint:exhaustruct
-		Key: keysdb.FindKeyForVerificationRow{ID: "key_123"}, //nolint:exhaustruct
+	key := &keys.KeyVerifier{ //nolint:exhaustruct_v5
+		Key: keysdb.FindKeyForVerificationRow{ID: "key_123"}, //nolint:exhaustruct_v5
 	}
 
 	h.bufferAuditLog(sess, p, key, 0)

--- a/svc/api/routes/v2_keys_verify_key/handler.go
+++ b/svc/api/routes/v2_keys_verify_key/handler.go
@@ -83,7 +83,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			Meta: openapi.Meta{
 				RequestId: s.RequestID(),
 			},
-			// nolint:exhaustruct
+			// nolint:exhaustruct_v5
 			Data: openapi.V2KeysVerifyKeyResponseData{
 				Code:  openapi.NOTFOUND,
 				Valid: false,
@@ -97,7 +97,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			Meta: openapi.Meta{
 				RequestId: s.RequestID(),
 			},
-			// nolint:exhaustruct
+			// nolint:exhaustruct_v5
 			Data: openapi.V2KeysVerifyKeyResponseData{
 				Code:  openapi.NOTFOUND,
 				Valid: false,
@@ -128,7 +128,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			Meta: openapi.Meta{
 				RequestId: s.RequestID(),
 			},
-			// nolint:exhaustruct
+			// nolint:exhaustruct_v5
 			Data: openapi.V2KeysVerifyKeyResponseData{
 				Code:  openapi.NOTFOUND,
 				Valid: false,

--- a/svc/api/routes/v2_projects_create_project/400_test.go
+++ b/svc/api/routes/v2_projects_create_project/400_test.go
@@ -1,4 +1,4 @@
-//nolint:exhaustruct
+//nolint:exhaustruct_v5
 package handler_test
 
 import (

--- a/svc/api/routes/v2_projects_delete_project/400_test.go
+++ b/svc/api/routes/v2_projects_delete_project/400_test.go
@@ -1,4 +1,4 @@
-//nolint:exhaustruct
+//nolint:exhaustruct_v5
 package handler_test
 
 import (

--- a/svc/api/routes/v2_projects_get_project/400_test.go
+++ b/svc/api/routes/v2_projects_get_project/400_test.go
@@ -1,4 +1,4 @@
-//nolint:exhaustruct
+//nolint:exhaustruct_v5
 package handler_test
 
 import (

--- a/svc/api/routes/v2_projects_list_projects/400_test.go
+++ b/svc/api/routes/v2_projects_list_projects/400_test.go
@@ -1,4 +1,4 @@
-//nolint:exhaustruct
+//nolint:exhaustruct_v5
 package handler_test
 
 import (

--- a/svc/api/routes/v2_projects_update_project/400_test.go
+++ b/svc/api/routes/v2_projects_update_project/400_test.go
@@ -1,4 +1,4 @@
-//nolint:exhaustruct
+//nolint:exhaustruct_v5
 package handler_test
 
 import (

--- a/svc/api/routes/v2_ratelimit_delete_override/handler.go
+++ b/svc/api/routes/v2_ratelimit_delete_override/handler.go
@@ -187,20 +187,20 @@ func (h *Handler) getNamespace(ctx context.Context, workspaceID, nameOrID string
 			})
 		})
 		if dbErr != nil {
-			return db.FindRatelimitNamespace{}, dbErr //nolint:exhaustruct
+			return db.FindRatelimitNamespace{}, dbErr //nolint:exhaustruct_v5
 		}
 		return namespace.ParseNamespaceRow(row), nil
 	}, caches.DefaultFindFirstOp)
 
 	if err != nil {
 		if db.IsNotFound(err) {
-			return db.FindRatelimitNamespace{}, false, nil //nolint:exhaustruct
+			return db.FindRatelimitNamespace{}, false, nil //nolint:exhaustruct_v5
 		}
-		return db.FindRatelimitNamespace{}, false, err //nolint:exhaustruct
+		return db.FindRatelimitNamespace{}, false, err //nolint:exhaustruct_v5
 	}
 
 	if hit == cache.Null {
-		return db.FindRatelimitNamespace{}, false, nil //nolint:exhaustruct
+		return db.FindRatelimitNamespace{}, false, nil //nolint:exhaustruct_v5
 	}
 
 	return ns, true, nil

--- a/svc/api/routes/v2_ratelimit_get_override/400_test.go
+++ b/svc/api/routes/v2_ratelimit_get_override/400_test.go
@@ -1,4 +1,4 @@
-//nolint:exhaustruct
+//nolint:exhaustruct_v5
 package handler_test
 
 import (

--- a/svc/api/routes/v2_ratelimit_get_override/handler.go
+++ b/svc/api/routes/v2_ratelimit_get_override/handler.go
@@ -154,19 +154,19 @@ func (h *Handler) getNamespace(ctx context.Context, workspaceID, nameOrID string
 			})
 		})
 		if dbErr != nil {
-			return db.FindRatelimitNamespace{}, dbErr //nolint:exhaustruct
+			return db.FindRatelimitNamespace{}, dbErr //nolint:exhaustruct_v5
 		}
 		return namespace.ParseNamespaceRow(row), nil
 	}, caches.DefaultFindFirstOp)
 	if err != nil {
 		if db.IsNotFound(err) {
-			return db.FindRatelimitNamespace{}, false, nil //nolint:exhaustruct
+			return db.FindRatelimitNamespace{}, false, nil //nolint:exhaustruct_v5
 		}
-		return db.FindRatelimitNamespace{}, false, err //nolint:exhaustruct
+		return db.FindRatelimitNamespace{}, false, err //nolint:exhaustruct_v5
 	}
 
 	if hit == cache.Null {
-		return db.FindRatelimitNamespace{}, false, nil //nolint:exhaustruct
+		return db.FindRatelimitNamespace{}, false, nil //nolint:exhaustruct_v5
 	}
 
 	return ns, true, nil

--- a/svc/api/routes/v2_ratelimit_limit/audit_log_internal_test.go
+++ b/svc/api/routes/v2_ratelimit_limit/audit_log_internal_test.go
@@ -45,7 +45,7 @@ func TestBufferAuditLog_SkipsNonRootPrincipal(t *testing.T) {
 		require.Zero(t, eventCountFlushed.Load())
 	})
 
-	h := &Handler{DirectAuditLogs: directAuditLogs} //nolint:exhaustruct
+	h := &Handler{DirectAuditLogs: directAuditLogs} //nolint:exhaustruct_v5
 	p := &principal.Principal{
 		Version: principal.Version,
 		Subject: principal.Subject{
@@ -62,7 +62,7 @@ func TestBufferAuditLog_SkipsNonRootPrincipal(t *testing.T) {
 		AuthorizedWorkspaceID: "ws_123",
 		Permissions:           nil,
 	}
-	namespace := db.FindRatelimitNamespace{ //nolint:exhaustruct
+	namespace := db.FindRatelimitNamespace{ //nolint:exhaustruct_v5
 		ID:          "rlns_123",
 		WorkspaceID: "ws_123",
 		Name:        "namespace",

--- a/svc/api/routes/v2_ratelimit_limit/handler.go
+++ b/svc/api/routes/v2_ratelimit_limit/handler.go
@@ -282,20 +282,20 @@ func (h *Handler) getNamespace(ctx context.Context, workspaceID, nameOrID string
 			})
 		})
 		if dbErr != nil {
-			return db.FindRatelimitNamespace{}, dbErr //nolint:exhaustruct
+			return db.FindRatelimitNamespace{}, dbErr //nolint:exhaustruct_v5
 		}
 		return namespace.ParseNamespaceRow(row), nil
 	}, caches.DefaultFindFirstOp)
 
 	if err != nil {
 		if db.IsNotFound(err) {
-			return db.FindRatelimitNamespace{}, false, nil //nolint:exhaustruct
+			return db.FindRatelimitNamespace{}, false, nil //nolint:exhaustruct_v5
 		}
-		return db.FindRatelimitNamespace{}, false, err //nolint:exhaustruct
+		return db.FindRatelimitNamespace{}, false, err //nolint:exhaustruct_v5
 	}
 
 	if hit == cache.Null {
-		return db.FindRatelimitNamespace{}, false, nil //nolint:exhaustruct
+		return db.FindRatelimitNamespace{}, false, nil //nolint:exhaustruct_v5
 	}
 
 	return ns, true, nil
@@ -316,7 +316,7 @@ func (h *Handler) createNamespace(ctx context.Context, s *zen.Session, principal
 				CreatedAt:   now,
 			})
 			if insertErr != nil && !db.IsDuplicateKeyError(insertErr) {
-				return db.FindRatelimitNamespace{}, fault.Wrap(insertErr, //nolint:exhaustruct
+				return db.FindRatelimitNamespace{}, fault.Wrap(insertErr, //nolint:exhaustruct_v5
 					fault.Code(codes.App.Internal.UnexpectedError.URN()),
 					fault.Public("An unexpected error occurred while creating the namespace."),
 				)
@@ -325,7 +325,7 @@ func (h *Handler) createNamespace(ctx context.Context, s *zen.Session, principal
 			if db.IsDuplicateKeyError(insertErr) {
 				// Re-fetch after this transaction closes so a snapshot established by
 				// EnsureDefaultProject cannot hide the concurrently committed row.
-				return db.FindRatelimitNamespace{}, nil //nolint:exhaustruct
+				return db.FindRatelimitNamespace{}, nil //nolint:exhaustruct_v5
 			}
 
 			result := db.FindRatelimitNamespace{

--- a/svc/api/routes/v2_ratelimit_list_overrides/400_test.go
+++ b/svc/api/routes/v2_ratelimit_list_overrides/400_test.go
@@ -1,4 +1,4 @@
-//nolint:exhaustruct
+//nolint:exhaustruct_v5
 package handler_test
 
 import (

--- a/svc/api/routes/v3_deployments_create_deployment/handler.go
+++ b/svc/api/routes/v3_deployments_create_deployment/handler.go
@@ -123,7 +123,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 		return err
 	}
 
-	// nolint: exhaustruct // optional proto fields are set per source below
+	// nolint: exhaustruct_v5 // optional proto fields are set per source below
 	ctrlReq := &ctrlv1.CreateDeploymentRequest{
 		ProjectId:       environment.ProjectID,
 		AppId:           environment.AppID,
@@ -158,7 +158,7 @@ func (h *Handler) Handle(ctx context.Context, s *zen.Session) error {
 			}
 			return fault.Wrap(err, fault.Internal("failed to check repo connection"))
 		}
-		// nolint: exhaustruct // ctrl fills the commit metadata it resolves from git
+		// nolint: exhaustruct_v5 // ctrl fills the commit metadata it resolves from git
 		ctrlReq.Source = &ctrlv1.CreateDeploymentRequest_GitCommit{
 			GitCommit: &ctrlv1.GitCommitInfo{
 				Branch:         ptr.SafeDeref(git.Branch),

--- a/svc/api/run.go
+++ b/svc/api/run.go
@@ -105,7 +105,7 @@ func Run(ctx context.Context, cfg Config) error {
 
 	reg := promclient.NewRegistry()
 	reg.MustRegister(collectors.NewGoCollector())
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	reg.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 	reg.MustRegister(prometheus.NewSystemMetricsCollector())
 	lazy.SetRegistry(reg)

--- a/svc/ctrl/api/run.go
+++ b/svc/ctrl/api/run.go
@@ -104,7 +104,7 @@ func Run(ctx context.Context, cfg Config) error {
 
 	reg := promclient.NewRegistry()
 	reg.MustRegister(collectors.NewGoCollector())
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	reg.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 	reg.MustRegister(prometheus.NewSystemMetricsCollector())
 	lazy.SetRegistry(reg)

--- a/svc/ctrl/api/webhooks/stripe/invoice_created_test.go
+++ b/svc/ctrl/api/webhooks/stripe/invoice_created_test.go
@@ -23,14 +23,14 @@ func renewalInvoice(customer, subscription string) stripesdk.Invoice {
 	now := time.Now().UTC()
 	start := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC).AddDate(0, -1, 0)
 	end := start.AddDate(0, 1, 0)
-	//nolint:exhaustruct // the handler reads only these fields off the SDK invoice
+	//nolint:exhaustruct_v5 // the handler reads only these fields off the SDK invoice
 	return stripesdk.Invoice{
 		ID:            "in_test",
 		BillingReason: stripesdk.InvoiceBillingReasonSubscriptionCycle,
-		Customer:      &stripesdk.Customer{ID: customer}, //nolint:exhaustruct // unexpanded id, as delivered
-		Parent: &stripesdk.InvoiceParent{ //nolint:exhaustruct // only the subscription reference is read
-			SubscriptionDetails: &stripesdk.InvoiceParentSubscriptionDetails{ //nolint:exhaustruct // ditto
-				Subscription: &stripesdk.Subscription{ID: subscription}, //nolint:exhaustruct // unexpanded id, as delivered
+		Customer:      &stripesdk.Customer{ID: customer}, //nolint:exhaustruct_v5 // unexpanded id, as delivered
+		Parent: &stripesdk.InvoiceParent{ //nolint:exhaustruct_v5 // only the subscription reference is read
+			SubscriptionDetails: &stripesdk.InvoiceParentSubscriptionDetails{ //nolint:exhaustruct_v5 // ditto
+				Subscription: &stripesdk.Subscription{ID: subscription}, //nolint:exhaustruct_v5 // unexpanded id, as delivered
 			},
 		},
 		PeriodStart: start.Unix(),
@@ -114,7 +114,7 @@ func TestInvoiceCreated_DecodesSubscription(t *testing.T) {
 func TestInvoiceCreated_IgnoresNonRenewal(t *testing.T) {
 	t.Parallel()
 
-	h := &handler{} //nolint:exhaustruct // early-return paths need no deps
+	h := &handler{} //nolint:exhaustruct_v5 // early-return paths need no deps
 	inv := renewalInvoice("cus_test", "sub_test")
 	inv.BillingReason = stripesdk.InvoiceBillingReasonSubscriptionCreate
 	err := h.invoiceCreated(context.Background(), webhook.Event{}, inv)
@@ -129,7 +129,7 @@ func TestInvoiceCreated_IgnoresUnknownCustomer(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, database.Close()) })
 
-	h := &handler{db: database} //nolint:exhaustruct // restate/stripe unused on ignore path
+	h := &handler{db: database} //nolint:exhaustruct_v5 // restate/stripe unused on ignore path
 	err = h.invoiceCreated(context.Background(), webhook.Event{}, renewalInvoice("cus_no_deploy_workspace", "sub_test"))
 	require.ErrorIs(t, err, webhook.ErrIgnore)
 }
@@ -137,7 +137,7 @@ func TestInvoiceCreated_IgnoresUnknownCustomer(t *testing.T) {
 func TestInvoiceCreated_IgnoresMissingCustomerOrPeriod(t *testing.T) {
 	t.Parallel()
 
-	h := &handler{} //nolint:exhaustruct // early-return paths need no deps
+	h := &handler{} //nolint:exhaustruct_v5 // early-return paths need no deps
 	inv := renewalInvoice("cus_test", "sub_test")
 
 	inv.Customer = nil
@@ -167,7 +167,7 @@ func TestInvoiceCreated_RejectsEmptyBillingReason(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, database.Close()) })
 
-	h := &handler{db: database} //nolint:exhaustruct // stripe/restate unused on ignore path
+	h := &handler{db: database} //nolint:exhaustruct_v5 // stripe/restate unused on ignore path
 	inv := renewalInvoice("cus_test", "sub_test")
 	inv.BillingReason = ""
 	err = h.invoiceCreated(context.Background(), webhook.Event{}, inv)
@@ -222,7 +222,7 @@ func TestInvoiceCreated_IgnoresMismatchedSubscription(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	h := &handler{db: database} //nolint:exhaustruct // stripe/restate unused on ignore path
+	h := &handler{db: database} //nolint:exhaustruct_v5 // stripe/restate unused on ignore path
 	err = h.invoiceCreated(context.Background(), webhook.Event{}, renewalInvoice(customerID, "sub_other_product"))
 	require.ErrorIs(t, err, webhook.ErrIgnore)
 }

--- a/svc/ctrl/integration/build_slot_test.go
+++ b/svc/ctrl/integration/build_slot_test.go
@@ -170,7 +170,7 @@ func TestBuildSlot_ReclaimsSlotOfKilledInvocation(t *testing.T) {
 	require.NoError(t, h.DB.UpsertLimit(ctx, db.UpsertLimitParams{
 		WorkspaceID:                           workspaceID,
 		ApiBillableOperationsCountMaxPerMonth: 1_000_000,
-		ApiRequestsCountMaxPerMinute:          sql.NullInt32{}, //nolint:exhaustruct
+		ApiRequestsCountMaxPerMinute:          sql.NullInt32{}, //nolint:exhaustruct_v5
 		LogsRetentionDaysMax:                  7,
 		LogsAuditRetentionDaysMax:             7,
 		TeamEnabled:                           false,
@@ -185,7 +185,7 @@ func TestBuildSlot_ReclaimsSlotOfKilledInvocation(t *testing.T) {
 		AutoscalingReplicasMax:                0,
 	}))
 
-	liveness := &lazyLiveness{} //nolint:exhaustruct
+	liveness := &lazyLiveness{} //nolint:exhaustruct_v5
 	slotService := buildslot.New(buildslot.Config{
 		DB:           h.DB,
 		RestateAdmin: liveness,

--- a/svc/ctrl/integration/seed/seed.go
+++ b/svc/ctrl/integration/seed/seed.go
@@ -45,7 +45,7 @@ func New(t *testing.T, database db.Database, vault vault.VaultServiceClient) *Se
 		t:            t,
 		DB:           database,
 		Vault:        vault,
-		Resources:    Resources{}, //nolint:exhaustruct
+		Resources:    Resources{}, //nolint:exhaustruct_v5
 		workspaceIDs: nil,
 	}
 	t.Cleanup(s.cleanup)
@@ -105,7 +105,7 @@ func (s *Seeder) CreateWorkspace(ctx context.Context) db.Workspace {
 	err = s.DB.UpsertLimit(ctx, db.UpsertLimitParams{
 		WorkspaceID:                           params.ID,
 		ApiBillableOperationsCountMaxPerMonth: 1_000_000,
-		ApiRequestsCountMaxPerMinute:          sql.NullInt32{}, //nolint:exhaustruct
+		ApiRequestsCountMaxPerMinute:          sql.NullInt32{}, //nolint:exhaustruct_v5
 		LogsRetentionDaysMax:                  30,
 		LogsAuditRetentionDaysMax:             30,
 		TeamEnabled:                           false,
@@ -801,7 +801,7 @@ func (s *Seeder) CreateWorkspaceWithLimits(ctx context.Context, req CreateWorksp
 		err := s.DB.UpsertLimit(ctx, db.UpsertLimitParams{
 			WorkspaceID:                           ws.ID,
 			ApiBillableOperationsCountMaxPerMonth: uint64(req.RequestsPerMonth),
-			ApiRequestsCountMaxPerMinute:          sql.NullInt32{}, //nolint:exhaustruct
+			ApiRequestsCountMaxPerMinute:          sql.NullInt32{}, //nolint:exhaustruct_v5
 			LogsRetentionDaysMax:                  uint16(req.LogsRetentionDays),
 			LogsAuditRetentionDaysMax:             uint16(req.AuditLogsRetentionDays),
 			TeamEnabled:                           req.Team,

--- a/svc/ctrl/internal/billingmeter/stripe.go
+++ b/svc/ctrl/internal/billingmeter/stripe.go
@@ -67,7 +67,7 @@ func (sdkLogger) Errorf(format string, v ...any) {
 // NewStripe builds a Stripe-backed Pusher from a secret key.
 func NewStripe(secretKey string) Pusher {
 	return &stripePusher{client: stripe.NewClient(secretKey, stripe.WithBackends(stripe.NewBackendsWithConfig(&stripe.BackendConfig{
-		//nolint:exhaustruct // defaults are fine for everything but the logger
+		//nolint:exhaustruct_v5 // defaults are fine for everything but the logger
 		LeveledLogger: sdkLogger{},
 	})))}
 }

--- a/svc/ctrl/internal/invoicecloser/noop.go
+++ b/svc/ctrl/internal/invoicecloser/noop.go
@@ -15,7 +15,7 @@ func (n *noopCloser) ListDraftInvoices(_ context.Context, _ string) ([]DraftInvo
 }
 
 func (n *noopCloser) GetInvoice(_ context.Context, _ string) (DraftInvoice, error) {
-	return DraftInvoice{}, ErrNotFound //nolint:exhaustruct // nothing exists when Stripe is not configured
+	return DraftInvoice{}, ErrNotFound //nolint:exhaustruct_v5 // nothing exists when Stripe is not configured
 }
 
 func (n *noopCloser) ClaimInvoice(_ context.Context, _ string, _ int64) error {

--- a/svc/ctrl/internal/invoicecloser/stripe.go
+++ b/svc/ctrl/internal/invoicecloser/stripe.go
@@ -49,9 +49,9 @@ func (c *stripeCloser) GetInvoice(ctx context.Context, invoiceID string) (DraftI
 	invoice, err := c.client.V1Invoices.Retrieve(ctx, invoiceID, nil)
 	if err != nil {
 		if sErr, ok := errors.AsType[*stripe.Error](err); ok && sErr.Code == stripe.ErrorCodeResourceMissing {
-			return DraftInvoice{}, ErrNotFound //nolint:exhaustruct // zero value on the not-found path
+			return DraftInvoice{}, ErrNotFound //nolint:exhaustruct_v5 // zero value on the not-found path
 		}
-		return DraftInvoice{}, fault.Wrap(err, fault.Internal("failed to read stripe invoice")) //nolint:exhaustruct // zero value on the error path
+		return DraftInvoice{}, fault.Wrap(err, fault.Internal("failed to read stripe invoice")) //nolint:exhaustruct_v5 // zero value on the error path
 	}
 	return DraftInvoice{
 		ID:            invoice.ID,
@@ -73,7 +73,7 @@ func (c *stripeCloser) GetInvoice(ctx context.Context, invoiceID string) (DraftI
 // the customer never billed, which is worse than the stale-usage case this
 // deadline exists to bound.
 func (c *stripeCloser) ClaimInvoice(ctx context.Context, invoiceID string, finalizeAt int64) error {
-	_, err := c.client.V1Invoices.Update(ctx, invoiceID, &stripe.InvoiceUpdateParams{ //nolint:exhaustruct // only finalization scheduling changes
+	_, err := c.client.V1Invoices.Update(ctx, invoiceID, &stripe.InvoiceUpdateParams{ //nolint:exhaustruct_v5 // only finalization scheduling changes
 		AutoAdvance:              new(true),
 		AutomaticallyFinalizesAt: new(finalizeAt),
 	})

--- a/svc/ctrl/internal/workos/client.go
+++ b/svc/ctrl/internal/workos/client.go
@@ -35,6 +35,6 @@ func New(apiKey string) Resolver {
 	return &client{
 		apiKey:  apiKey,
 		baseURL: baseURL,
-		http:    &http.Client{Timeout: requestTimeout}, //nolint:exhaustruct // default transport, only the timeout matters
+		http:    &http.Client{Timeout: requestTimeout}, //nolint:exhaustruct_v5 // default transport, only the timeout matters
 	}
 }

--- a/svc/ctrl/services/acme/user.go
+++ b/svc/ctrl/services/acme/user.go
@@ -77,7 +77,7 @@ func GetOrCreateUser(ctx context.Context, cfg UserConfig) (*lego.Client, error) 
 
 	// If we have a valid registration URI, use it
 	if foundUser.RegistrationUri.Valid && foundUser.RegistrationUri.String != "" {
-		//nolint:exhaustruct // external library type
+		//nolint:exhaustruct_v5 // external library type
 		user.Registration = &acme.ExtendedAccount{
 			Location: foundUser.RegistrationUri.String,
 		}

--- a/svc/ctrl/services/customdomain/add_custom_domain_test.go
+++ b/svc/ctrl/services/customdomain/add_custom_domain_test.go
@@ -472,7 +472,7 @@ func newFixture(t *testing.T, customDomainsMax uint32) fixture {
 	f := fixture{
 		database: database,
 		seeder:   seeder,
-		chain:    chain{}, //nolint:exhaustruct
+		chain:    chain{}, //nolint:exhaustruct_v5
 		domain:   randomDomain(),
 	}
 	f.chain = f.seedChain(t, seeder.Resources.UserWorkspace.ID, customDomainsMax)
@@ -514,7 +514,7 @@ func (f fixture) seedChain(t *testing.T, workspaceID string, customDomainsMax ui
 	require.NoError(t, f.database.UpsertLimit(ctx, db.UpsertLimitParams{
 		WorkspaceID:                           workspaceID,
 		ApiBillableOperationsCountMaxPerMonth: 150_000,
-		ApiRequestsCountMaxPerMinute:          sql.NullInt32{}, //nolint:exhaustruct
+		ApiRequestsCountMaxPerMinute:          sql.NullInt32{}, //nolint:exhaustruct_v5
 		LogsRetentionDaysMax:                  7,
 		LogsAuditRetentionDaysMax:             30,
 		TeamEnabled:                           false,

--- a/svc/ctrl/services/deployment/create_deployment.go
+++ b/svc/ctrl/services/deployment/create_deployment.go
@@ -453,7 +453,7 @@ func (s *Service) createAndDeploy(ctx context.Context, p createParams) (string, 
 			return "", connect.NewError(connect.CodeFailedPrecondition,
 				fmt.Errorf("OCI source for app %q is invalid: %w", c.app.ID, imageErr))
 		}
-		commit = commitFields{ //nolint:exhaustruct
+		commit = commitFields{ //nolint:exhaustruct_v5
 		}
 		deploymentSource = db.DeploymentsSourceOci
 		requestedImage = imageReference
@@ -473,7 +473,7 @@ func (s *Service) createAndDeploy(ctx context.Context, p createParams) (string, 
 		if ociErr != nil {
 			return "", ociErr
 		}
-		commit = commitFields{ //nolint:exhaustruct
+		commit = commitFields{ //nolint:exhaustruct_v5
 		}
 		deploymentSource = db.DeploymentsSourceOci
 		requestedImage = imageReference

--- a/svc/ctrl/services/openapi/get_diff.go
+++ b/svc/ctrl/services/openapi/get_diff.go
@@ -60,7 +60,7 @@ func (s *Service) GetOpenApiDiff(ctx context.Context, req *connect.Request[ctrlv
 	}
 
 	// Generate diff report
-	// nolint: exhaustruct
+	// nolint: exhaustruct_v5
 	diffReport, err := diff.Get(&diff.Config{}, s1, s2)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fault.Wrap(err,

--- a/svc/ctrl/worker/certificate/process_challenge_handler.go
+++ b/svc/ctrl/worker/certificate/process_challenge_handler.go
@@ -257,7 +257,7 @@ func (s *Service) obtainCertificate(ctx context.Context, _ string, dom db.Custom
 
 	// Request certificate from Let's Encrypt
 	// Restate handles retries - we return TerminalError for non-retryable errors
-	//nolint:exhaustruct // external library type
+	//nolint:exhaustruct_v5 // external library type
 	request := certificate.ObtainRequest{
 		Domains:          []string{domain},
 		Bundle:           true,

--- a/svc/ctrl/worker/clickhouseuser/configure_user_handler.go
+++ b/svc/ctrl/worker/clickhouseuser/configure_user_handler.go
@@ -94,12 +94,12 @@ func (s *Service) configureUser(
 	result, err := restate.Run(ctx, func(rc restate.RunContext) (existingUserResult, error) {
 		row, err := s.db.FindClickhouseWorkspaceSettingsByWorkspaceID(rc, workspaceID)
 		if db.IsNotFound(err) {
-			//nolint:exhaustruct // zero value is intentional for not-found case
+			//nolint:exhaustruct_v5 // zero value is intentional for not-found case
 			return existingUserResult{Found: false}, nil
 		}
 
 		if err != nil {
-			//nolint:exhaustruct // zero value is intentional for error case
+			//nolint:exhaustruct_v5 // zero value is intentional for error case
 			return existingUserResult{Found: false}, err
 		}
 

--- a/svc/ctrl/worker/cron/deploy_billing_close_integration_test.go
+++ b/svc/ctrl/worker/cron/deploy_billing_close_integration_test.go
@@ -232,7 +232,7 @@ func (f *fakeCloser) GetInvoice(_ context.Context, invoiceID string) (invoiceclo
 			}
 		}
 	}
-	return invoicecloser.DraftInvoice{}, invoicecloser.ErrNotFound //nolint:exhaustruct // zero value on the not-found path
+	return invoicecloser.DraftInvoice{}, invoicecloser.ErrNotFound //nolint:exhaustruct_v5 // zero value on the not-found path
 }
 
 func (f *fakeCloser) setDrafts(subscriptionID string, drafts []invoicecloser.DraftInvoice) {
@@ -293,7 +293,7 @@ func seedBillableWorkspace(t *testing.T, h *harness.Harness, customerID, subscri
 }
 
 func TestDeployBillingClose_Integration(t *testing.T) {
-	reader := &fakeUsageReader{} //nolint:exhaustruct // zero value is an empty reader
+	reader := &fakeUsageReader{} //nolint:exhaustruct_v5 // zero value is an empty reader
 	pusher := newFakePusher()
 	closer := newFakeCloser()
 
@@ -465,7 +465,7 @@ func TestDeployBillingClose_Integration(t *testing.T) {
 }
 
 func TestCloseDeployBillingWorkspace_Integration(t *testing.T) {
-	reader := &fakeUsageReader{} //nolint:exhaustruct
+	reader := &fakeUsageReader{} //nolint:exhaustruct_v5
 	pusher := newFakePusher()
 	closer := newFakeCloser()
 	h := harness.New(t, harness.WithDeployBilling(reader, pusher, closer))

--- a/svc/ctrl/worker/cron/deploy_spend_check_orchestrator_integration_test.go
+++ b/svc/ctrl/worker/cron/deploy_spend_check_orchestrator_integration_test.go
@@ -50,7 +50,7 @@ func clearBudgetOnCleanup(t *testing.T, h *harness.Harness, workspaceID string) 
 // TestRunDeploySpendCheck_OrchestratorIntegration exercises the fleet scan and
 // fan-out decision without driving the per-workspace check to completion.
 func TestRunDeploySpendCheck_OrchestratorIntegration(t *testing.T) {
-	reader := &fakeUsageReader{} //nolint:exhaustruct // set per subtest
+	reader := &fakeUsageReader{} //nolint:exhaustruct_v5 // set per subtest
 	h := harness.New(t, harness.WithDeployBilling(reader, newFakePusher(), newFakeCloser()))
 
 	// The harness database is shared across test processes, and other tests

--- a/svc/ctrl/worker/cron/deploybilling/billing.go
+++ b/svc/ctrl/worker/cron/deploybilling/billing.go
@@ -83,7 +83,7 @@ func AggregateUsage(rows []clickhouse.InstanceMeterUsage) map[string]billingmete
 	for _, r := range rows {
 		a := sums[r.WorkspaceID]
 		if a == nil {
-			a = &usageAccumulator{} //nolint:exhaustruct // zero-value accumulator, summed into below
+			a = &usageAccumulator{} //nolint:exhaustruct_v5 // zero-value accumulator, summed into below
 			sums[r.WorkspaceID] = a
 		}
 		a.cpuSeconds += r.CPUSeconds

--- a/svc/ctrl/worker/deploy/build.go
+++ b/svc/ctrl/worker/deploy/build.go
@@ -557,7 +557,7 @@ func (w *Workflow) imageExports(imageName string) []client.ExportEntry {
 	if w.registryConfig.Insecure {
 		attrs["registry.insecure"] = "true"
 	}
-	//nolint: exhaustruct
+	//nolint: exhaustruct_v5
 	return []client.ExportEntry{
 		{
 			Type:  "image",
@@ -569,7 +569,7 @@ func (w *Workflow) imageExports(imageName string) []client.ExportEntry {
 // registryAuthProvider returns a session attachable that authenticates image
 // pushes to the configured container registry.
 func (w *Workflow) registryAuthProvider() session.Attachable {
-	//nolint: exhaustruct
+	//nolint: exhaustruct_v5
 	return authprovider.NewDockerAuthProvider(authprovider.DockerAuthProviderConfig{
 		AuthConfigProvider: authprovider.LoadAuthConfig(&configfile.ConfigFile{
 			AuthConfigs: map[string]types.AuthConfig{
@@ -709,11 +709,11 @@ func (w *Workflow) getOrCreateDepotProject(ctx context.Context, unkeyProjectID s
 	})
 
 	projectClient := corev1connect.NewProjectServiceClient(httpClient, w.buildConfig.Depot.APIUrl, connect.WithInterceptors(authInterceptor))
-	//nolint: exhaustruct // optional fields
+	//nolint: exhaustruct_v5 // optional fields
 	createResp, err := projectClient.CreateProject(ctx, connect.NewRequest(&corev1.CreateProjectRequest{
 		Name:     projectName,
 		RegionId: w.buildConfig.Depot.ProjectRegion,
-		//nolint: exhaustruct // missing fields is deprecated
+		//nolint: exhaustruct_v5 // missing fields is deprecated
 		CachePolicy: &corev1.CachePolicy{
 			KeepGb:   defaultCacheKeepGB,
 			KeepDays: defaultCacheKeepDays,

--- a/svc/ctrl/worker/deploy/build_kubernetes.go
+++ b/svc/ctrl/worker/deploy/build_kubernetes.go
@@ -63,7 +63,7 @@ func (w *Workflow) withKubernetesBuildkit(
 ) (string, error) {
 	jobs := w.k8s.BatchV1().Jobs(w.buildConfig.Kubernetes.Namespace)
 
-	//nolint: exhaustruct
+	//nolint: exhaustruct_v5
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			// GenerateName gives every attempt a fresh Job, so a Restate
@@ -80,18 +80,18 @@ func (w *Workflow) withKubernetesBuildkit(
 			ActiveDeadlineSeconds:   new(int64(buildJobDeadlineSeconds)),
 			TTLSecondsAfterFinished: new(int32(buildJobTTLSeconds)),
 			Template: corev1.PodTemplateSpec{
-				//nolint: exhaustruct
+				//nolint: exhaustruct_v5
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
 						"app":                     "buildkit",
 						"unkey.com/deployment-id": params.DeploymentID,
 					},
 				},
-				//nolint: exhaustruct
+				//nolint: exhaustruct_v5
 				Spec: corev1.PodSpec{
 					RestartPolicy: corev1.RestartPolicyNever,
 					Containers: []corev1.Container{
-						//nolint: exhaustruct
+						//nolint: exhaustruct_v5
 						{
 							Name:  "buildkitd",
 							Image: w.buildConfig.Kubernetes.Image,
@@ -100,20 +100,20 @@ func (w *Workflow) withKubernetesBuildkit(
 								"--addr", fmt.Sprintf("tcp://0.0.0.0:%d", buildkitPort),
 							},
 							Ports: []corev1.ContainerPort{
-								//nolint: exhaustruct
+								//nolint: exhaustruct_v5
 								{ContainerPort: buildkitPort},
 							},
-							//nolint: exhaustruct
+							//nolint: exhaustruct_v5
 							SecurityContext: &corev1.SecurityContext{
 								Privileged: new(true),
 							},
 							// buildctl talks over the unix socket, so ready
 							// means buildkitd accepts RPCs, not merely that
 							// the process started.
-							//nolint: exhaustruct
+							//nolint: exhaustruct_v5
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
-									//nolint: exhaustruct
+									//nolint: exhaustruct_v5
 									Exec: &corev1.ExecAction{
 										Command: []string{"buildctl", "debug", "workers"},
 									},

--- a/svc/ctrl/worker/deploy/build_kubernetes_test.go
+++ b/svc/ctrl/worker/deploy/build_kubernetes_test.go
@@ -24,14 +24,14 @@ func TestSanitizeK8sName(t *testing.T) {
 }
 
 func TestImageExportsInsecure(t *testing.T) {
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	secure := &Workflow{registryConfig: RegistryConfig{Repository: "registry.acme.com/deployments"}}
 	exports := secure.imageExports("registry.acme.com/deployments:p-d")
 	require.Len(t, exports, 1)
 	require.Equal(t, "registry.acme.com/deployments:p-d", exports[0].Attrs["name"])
 	require.NotContains(t, exports[0].Attrs, "registry.insecure")
 
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	insecure := &Workflow{registryConfig: RegistryConfig{Repository: "ctlptl-registry:5000/deployments", Insecure: true}}
 	exports = insecure.imageExports("ctlptl-registry:5000/deployments:p-d")
 	require.Equal(t, "true", exports[0].Attrs["registry.insecure"])

--- a/svc/ctrl/worker/deploy/build_test.go
+++ b/svc/ctrl/worker/deploy/build_test.go
@@ -17,13 +17,13 @@ func TestBuildGitContextURL(t *testing.T) {
 	}{
 		{
 			name: "branch push uses commit sha on base repo",
-			//nolint:exhaustruct
+			//nolint:exhaustruct_v5
 			params: gitBuildParams{Repository: "acme/app", CommitSHA: "deadbeef"},
 			want:   "https://github.com/acme/app.git#deadbeef",
 		},
 		{
 			name: "fork PR fetches refs/pull from BASE repo, not the fork",
-			//nolint:exhaustruct
+			//nolint:exhaustruct_v5
 			params: gitBuildParams{Repository: "acme/app", ForkRepository: "attacker/app", CommitSHA: "deadbeef", PrNumber: 42},
 			// GitHub serves refs/pull/<n>/head only on the base repo. Using the
 			// fork here (the old bug) produced an unresolvable URL.
@@ -31,31 +31,31 @@ func TestBuildGitContextURL(t *testing.T) {
 		},
 		{
 			name: "fork ref deployed by concrete SHA fetches from the fork",
-			//nolint:exhaustruct
+			//nolint:exhaustruct_v5
 			params: gitBuildParams{Repository: "acme/app", ForkRepository: "contributor/app", CommitSHA: "cafebabe"},
 			want:   "https://github.com/contributor/app.git#cafebabe",
 		},
 		{
 			name: "context subdir is appended",
-			//nolint:exhaustruct
+			//nolint:exhaustruct_v5
 			params: gitBuildParams{Repository: "acme/app", CommitSHA: "deadbeef", ContextPath: "services/api"},
 			want:   "https://github.com/acme/app.git#deadbeef:services/api",
 		},
 		{
 			name: "fork PR with subdir still targets base repo",
-			//nolint:exhaustruct
+			//nolint:exhaustruct_v5
 			params: gitBuildParams{Repository: "acme/app", ForkRepository: "attacker/app", CommitSHA: "deadbeef", PrNumber: 7, ContextPath: "svc"},
 			want:   "https://github.com/acme/app.git#refs/pull/7/head:svc",
 		},
 		{
 			name: "dot context means root",
-			//nolint:exhaustruct
+			//nolint:exhaustruct_v5
 			params: gitBuildParams{Repository: "acme/app", CommitSHA: "deadbeef", ContextPath: "."},
 			want:   "https://github.com/acme/app.git#deadbeef",
 		},
 		{
 			name: "leading slash stripped",
-			//nolint:exhaustruct
+			//nolint:exhaustruct_v5
 			params: gitBuildParams{Repository: "acme/app", CommitSHA: "deadbeef", ContextPath: "/services/api"},
 			want:   "https://github.com/acme/app.git#deadbeef:services/api",
 		},

--- a/svc/ctrl/worker/deploy/deploy_handler.go
+++ b/svc/ctrl/worker/deploy/deploy_handler.go
@@ -629,7 +629,7 @@ func (w *Workflow) createTopologies(
 
 		// CreatedAt is filled in below inside the Run so the timestamp stays
 		// stable across Restate replays.
-		//nolint: exhaustruct
+		//nolint: exhaustruct_v5
 		topologies = append(topologies, db.InsertDeploymentTopologyParams{
 			WorkspaceID:                workspace.ID,
 			DeploymentID:               deployment.ID,
@@ -971,9 +971,9 @@ func (w *Workflow) initGitHubStatus(
 			if db.IsNotFound(findErr) {
 				// No connection — return zero value, not an error.
 				// Returning an error here would cause Restate to retry forever.
-				return db.GithubRepoConnection{}, nil //nolint:exhaustruct
+				return db.GithubRepoConnection{}, nil //nolint:exhaustruct_v5
 			}
-			return db.GithubRepoConnection{}, findErr //nolint:exhaustruct
+			return db.GithubRepoConnection{}, findErr //nolint:exhaustruct_v5
 		}
 		return found, nil
 	}, restate.WithName("find github repo connection"), restate.WithMaxRetryAttempts(runMaxAttempts))

--- a/svc/ctrl/worker/deploy/domains.go
+++ b/svc/ctrl/worker/deploy/domains.go
@@ -104,7 +104,7 @@ func buildDomains(
 		domains = append(domains,
 			newDomain{
 				domain: fmt.Sprintf("%s-git-%s-%s.%s", prefix, short, workspaceSlug, apex),
-				//nolint: exhaustruct
+				//nolint: exhaustruct_v5
 				sticky: db.FrontlineRoutesStickyNone,
 			},
 		)
@@ -139,7 +139,7 @@ func buildDomains(
 	// deployment-specific domain for stable public access.
 	domains = append(domains, newDomain{
 		domain: fmt.Sprintf("%s-%s-%s.%s", prefix, sluggify(deploymentID), workspaceSlug, apex),
-		//nolint: exhaustruct
+		//nolint: exhaustruct_v5
 		sticky: db.FrontlineRoutesStickyDeployment,
 	})
 

--- a/svc/ctrl/worker/deploy/railpack.go
+++ b/svc/ctrl/worker/deploy/railpack.go
@@ -267,7 +267,7 @@ func (w *Workflow) buildRailpackPrepareSolverOptions(
 		sessionAttachables = append(sessionAttachables, secretsprovider.FromMap(secrets))
 	}
 
-	//nolint: exhaustruct
+	//nolint: exhaustruct_v5
 	return client.SolveOpt{
 		Frontend: "dockerfile.v0",
 		FrontendAttrs: map[string]string{
@@ -335,7 +335,7 @@ func (w *Workflow) buildRailpackSolverOptions(
 		sessionAttachables = append(sessionAttachables, secretsprovider.FromMap(secrets))
 	}
 
-	//nolint: exhaustruct
+	//nolint: exhaustruct_v5
 	return client.SolveOpt{
 		Frontend:      "gateway.v0",
 		FrontendAttrs: frontendAttrs,

--- a/svc/ctrl/worker/deploy/registry_transport.go
+++ b/svc/ctrl/worker/deploy/registry_transport.go
@@ -25,7 +25,7 @@ type registryDialer struct {
 // newRegistryTransport clones the registry client's defaults and replaces its
 // dialer so DNS resolution and the connection use the same approved address.
 func newRegistryTransport(trustedRegistry string) *http.Transport {
-	dialer := &net.Dialer{ //nolint:exhaustruct // Standard-library dialer defaults are intentional.
+	dialer := &net.Dialer{ //nolint:exhaustruct_v5 // Standard-library dialer defaults are intentional.
 		Timeout:   30 * time.Second,
 		KeepAlive: 30 * time.Second,
 	}

--- a/svc/ctrl/worker/run.go
+++ b/svc/ctrl/worker/run.go
@@ -133,7 +133,7 @@ func Run(ctx context.Context, cfg Config) error {
 
 	reg := promclient.NewRegistry()
 	reg.MustRegister(collectors.NewGoCollector())
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	reg.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 	reg.MustRegister(prometheus.NewSystemMetricsCollector())
 	lazy.SetRegistry(reg)

--- a/svc/frontline/internal/policies/engine_test.go
+++ b/svc/frontline/internal/policies/engine_test.go
@@ -58,7 +58,7 @@ func TestParseMiddleware_WithPolicies(t *testing.T) {
 				Enabled: new(true),
 				Match:   nil,
 				Config: &frontlinev1.Policy_Keyauth{
-					//nolint:exhaustruct
+					//nolint:exhaustruct_v5
 					Keyauth: &frontlinev1.KeyAuth{KeySpaceIds: []string{"ks_123"}},
 				},
 			},

--- a/svc/frontline/internal/policies/firewall/executor_test.go
+++ b/svc/frontline/internal/policies/firewall/executor_test.go
@@ -18,7 +18,7 @@ func TestFirewallExecutor_Deny(t *testing.T) {
 	e := &Executor{}
 	req := httptest.NewRequest("GET", "/xxx", nil)
 
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	cfg := &frontlinev1.Firewall{Action: frontlinev1.Action_ACTION_DENY}
 
 	action, err := e.Execute(context.Background(), nil, req, cfg)
@@ -37,7 +37,7 @@ func TestFirewallExecutor_Unspecified(t *testing.T) {
 	e := &Executor{}
 	req := httptest.NewRequest("GET", "/xxx", nil)
 
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	cfg := &frontlinev1.Firewall{Action: frontlinev1.Action_ACTION_UNSPECIFIED}
 
 	action, err := e.Execute(context.Background(), nil, req, cfg)
@@ -59,7 +59,7 @@ func TestFirewallExecutor_DoesNotTouchRequest(t *testing.T) {
 	e := &Executor{}
 	req := httptest.NewRequest("GET", "/xxx", nil)
 	req.Header.Set("X-Original", "yes")
-	_, _ = e.Execute(context.Background(), nil, req, &frontlinev1.Firewall{ //nolint:exhaustruct
+	_, _ = e.Execute(context.Background(), nil, req, &frontlinev1.Firewall{ //nolint:exhaustruct_v5
 		Action: frontlinev1.Action_ACTION_DENY,
 	})
 	require.Equal(t, "yes", req.Header.Get("X-Original"))

--- a/svc/frontline/internal/policies/integration_test.go
+++ b/svc/frontline/internal/policies/integration_test.go
@@ -354,7 +354,7 @@ func (h *testHarness) seedKeyRatelimit(ctx context.Context, wsID, keyID, name st
 func newSession(t *testing.T, req *http.Request) *zen.Session {
 	t.Helper()
 	w := httptest.NewRecorder()
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	sess := &zen.Session{}
 	err := sess.Init(w, req, 0)
 	require.NoError(t, err)
@@ -364,7 +364,7 @@ func newSession(t *testing.T, req *http.Request) *zen.Session {
 func newSessionWithRecorder(t *testing.T, req *http.Request) (*zen.Session, *httptest.ResponseRecorder) {
 	t.Helper()
 	w := httptest.NewRecorder()
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	sess := &zen.Session{}
 	err := sess.Init(w, req, 0)
 	require.NoError(t, err)
@@ -622,7 +622,7 @@ func TestKeyAuth_InvalidKey_NotFound(t *testing.T) {
 	req.Header.Set("Authorization", "Bearer sk_this_key_does_not_exist")
 	sess := newSession(t, req)
 
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	policies := []*frontlinev1.Policy{
 		{
 			Id:      "auth",

--- a/svc/frontline/internal/policies/keyauth/headers_test.go
+++ b/svc/frontline/internal/policies/keyauth/headers_test.go
@@ -18,7 +18,7 @@ func TestFindMostRestrictive(t *testing.T) {
 		return &ratelimit.RatelimitResponse{Success: false, Remaining: remaining}
 	}
 	entry := func(resp *ratelimit.RatelimitResponse) keys.RatelimitConfigAndResult {
-		//nolint:exhaustruct
+		//nolint:exhaustruct_v5
 		return keys.RatelimitConfigAndResult{Response: resp}
 	}
 

--- a/svc/frontline/internal/policies/keyauth/keyextract_test.go
+++ b/svc/frontline/internal/policies/keyauth/keyextract_test.go
@@ -43,7 +43,7 @@ func TestExtractKey_BearerLocation(t *testing.T) {
 	req := &http.Request{Header: http.Header{}}
 	req.Header.Set("Authorization", "Bearer my_key")
 
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	locations := []*frontlinev1.KeyLocation{
 		{Location: &frontlinev1.KeyLocation_Bearer{Bearer: &frontlinev1.BearerTokenLocation{}}},
 	}
@@ -58,7 +58,7 @@ func TestExtractKey_HeaderLocation(t *testing.T) {
 	req := &http.Request{Header: http.Header{}}
 	req.Header.Set("X-API-Key", "custom_key_123")
 
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	locations := []*frontlinev1.KeyLocation{
 		{Location: &frontlinev1.KeyLocation_Header{
 			Header: &frontlinev1.HeaderKeyLocation{Name: "X-API-Key"},
@@ -75,7 +75,7 @@ func TestExtractKey_HeaderWithStripPrefix(t *testing.T) {
 	req := &http.Request{Header: http.Header{}}
 	req.Header.Set("Authorization", "ApiKey sk_live_abc123")
 
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	locations := []*frontlinev1.KeyLocation{
 		{Location: &frontlinev1.KeyLocation_Header{
 			Header: &frontlinev1.HeaderKeyLocation{
@@ -95,7 +95,7 @@ func TestExtractKey_HeaderStripPrefixMismatch(t *testing.T) {
 	req := &http.Request{Header: http.Header{}}
 	req.Header.Set("Authorization", "Bearer sk_live_abc123")
 
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	locations := []*frontlinev1.KeyLocation{
 		{Location: &frontlinev1.KeyLocation_Header{
 			Header: &frontlinev1.HeaderKeyLocation{
@@ -117,7 +117,7 @@ func TestExtractKey_QueryParam(t *testing.T) {
 		URL:    &url.URL{RawQuery: "api_key=query_key_123"},
 	}
 
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	locations := []*frontlinev1.KeyLocation{
 		{Location: &frontlinev1.KeyLocation_QueryParam{
 			QueryParam: &frontlinev1.QueryParamKeyLocation{Name: "api_key"},
@@ -137,7 +137,7 @@ func TestExtractKey_FallbackOrder(t *testing.T) {
 		URL:    &url.URL{RawQuery: "token=fallback_key"},
 	}
 
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	locations := []*frontlinev1.KeyLocation{
 		{Location: &frontlinev1.KeyLocation_Header{
 			Header: &frontlinev1.HeaderKeyLocation{Name: "X-API-Key"},
@@ -160,7 +160,7 @@ func TestExtractKey_FirstLocationWins(t *testing.T) {
 	}
 	req.Header.Set("X-API-Key", "header_key")
 
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	locations := []*frontlinev1.KeyLocation{
 		{Location: &frontlinev1.KeyLocation_Header{
 			Header: &frontlinev1.HeaderKeyLocation{Name: "X-API-Key"},

--- a/svc/frontline/internal/policies/match_test.go
+++ b/svc/frontline/internal/policies/match_test.go
@@ -22,7 +22,7 @@ func TestMatchesRequest_PathExact(t *testing.T) {
 	rc := newRegexCache()
 	req := &http.Request{Method: "GET", URL: &url.URL{Path: "/api/v1"}, Header: http.Header{}}
 
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	exprs := []*frontlinev1.MatchExpr{
 		{Expr: &frontlinev1.MatchExpr_Path{Path: &frontlinev1.PathMatch{
 			Path: &frontlinev1.StringMatch{Match: &frontlinev1.StringMatch_Exact{Exact: "/api/v1"}},
@@ -39,7 +39,7 @@ func TestMatchesRequest_PathExactMismatch(t *testing.T) {
 	rc := newRegexCache()
 	req := &http.Request{Method: "GET", URL: &url.URL{Path: "/api/v2"}, Header: http.Header{}}
 
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	exprs := []*frontlinev1.MatchExpr{
 		{Expr: &frontlinev1.MatchExpr_Path{Path: &frontlinev1.PathMatch{
 			Path: &frontlinev1.StringMatch{Match: &frontlinev1.StringMatch_Exact{Exact: "/api/v1"}},
@@ -56,7 +56,7 @@ func TestMatchesRequest_PathPrefix(t *testing.T) {
 	rc := newRegexCache()
 	req := &http.Request{Method: "GET", URL: &url.URL{Path: "/api/v1/users"}, Header: http.Header{}}
 
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	exprs := []*frontlinev1.MatchExpr{
 		{Expr: &frontlinev1.MatchExpr_Path{Path: &frontlinev1.PathMatch{
 			Path: &frontlinev1.StringMatch{Match: &frontlinev1.StringMatch_Prefix{Prefix: "/api/v1"}},
@@ -73,7 +73,7 @@ func TestMatchesRequest_PathRegex(t *testing.T) {
 	rc := newRegexCache()
 	req := &http.Request{Method: "GET", URL: &url.URL{Path: "/api/v2/users/123"}, Header: http.Header{}}
 
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	exprs := []*frontlinev1.MatchExpr{
 		{Expr: &frontlinev1.MatchExpr_Path{Path: &frontlinev1.PathMatch{
 			Path: &frontlinev1.StringMatch{Match: &frontlinev1.StringMatch_Regex{Regex: `^/api/v\d+/users/\d+$`}},
@@ -90,7 +90,7 @@ func TestMatchesRequest_PathCaseInsensitive(t *testing.T) {
 	rc := newRegexCache()
 	req := &http.Request{Method: "GET", URL: &url.URL{Path: "/API/V1"}, Header: http.Header{}}
 
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	exprs := []*frontlinev1.MatchExpr{
 		{Expr: &frontlinev1.MatchExpr_Path{Path: &frontlinev1.PathMatch{
 			Path: &frontlinev1.StringMatch{
@@ -127,7 +127,7 @@ func TestMatchesRequest_MethodMatch(t *testing.T) {
 			t.Parallel()
 			req := &http.Request{Method: tt.method, URL: &url.URL{Path: "/"}, Header: http.Header{}}
 
-			//nolint:exhaustruct
+			//nolint:exhaustruct_v5
 			exprs := []*frontlinev1.MatchExpr{
 				{Expr: &frontlinev1.MatchExpr_Method{Method: &frontlinev1.MethodMatch{Methods: tt.methods}}},
 			}
@@ -146,7 +146,7 @@ func TestMatchesRequest_HeaderPresent(t *testing.T) {
 	req := &http.Request{Method: "GET", URL: &url.URL{Path: "/"}, Header: http.Header{}}
 	req.Header.Set("Authorization", "Bearer token")
 
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	exprs := []*frontlinev1.MatchExpr{
 		{Expr: &frontlinev1.MatchExpr_Header{Header: &frontlinev1.HeaderMatch{
 			Name:  "Authorization",
@@ -165,7 +165,7 @@ func TestMatchesRequest_HeaderNotPresent(t *testing.T) {
 
 	req := &http.Request{Method: "GET", URL: &url.URL{Path: "/"}, Header: http.Header{}}
 
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	exprs := []*frontlinev1.MatchExpr{
 		{Expr: &frontlinev1.MatchExpr_Header{Header: &frontlinev1.HeaderMatch{
 			Name:  "Authorization",
@@ -185,7 +185,7 @@ func TestMatchesRequest_HeaderValue(t *testing.T) {
 	req := &http.Request{Method: "GET", URL: &url.URL{Path: "/"}, Header: http.Header{}}
 	req.Header.Set("Content-Type", "application/json")
 
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	exprs := []*frontlinev1.MatchExpr{
 		{Expr: &frontlinev1.MatchExpr_Header{Header: &frontlinev1.HeaderMatch{
 			Name: "Content-Type",
@@ -210,7 +210,7 @@ func TestMatchesRequest_QueryParamPresent(t *testing.T) {
 		Header: http.Header{},
 	}
 
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	exprs := []*frontlinev1.MatchExpr{
 		{Expr: &frontlinev1.MatchExpr_QueryParam{QueryParam: &frontlinev1.QueryParamMatch{
 			Name:  "debug",
@@ -233,7 +233,7 @@ func TestMatchesRequest_QueryParamValue(t *testing.T) {
 		Header: http.Header{},
 	}
 
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	exprs := []*frontlinev1.MatchExpr{
 		{Expr: &frontlinev1.MatchExpr_QueryParam{QueryParam: &frontlinev1.QueryParamMatch{
 			Name: "version",
@@ -255,7 +255,7 @@ func TestMatchesRequest_ANDSemantics(t *testing.T) {
 	// Path matches but method doesn't
 	req := &http.Request{Method: "DELETE", URL: &url.URL{Path: "/api/v1"}, Header: http.Header{}}
 
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	exprs := []*frontlinev1.MatchExpr{
 		{Expr: &frontlinev1.MatchExpr_Path{Path: &frontlinev1.PathMatch{
 			Path: &frontlinev1.StringMatch{Match: &frontlinev1.StringMatch_Prefix{Prefix: "/api"}},
@@ -274,7 +274,7 @@ func TestMatchesRequest_ANDSemanticsAllMatch(t *testing.T) {
 
 	req := &http.Request{Method: "POST", URL: &url.URL{Path: "/api/v1"}, Header: http.Header{}}
 
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	exprs := []*frontlinev1.MatchExpr{
 		{Expr: &frontlinev1.MatchExpr_Path{Path: &frontlinev1.PathMatch{
 			Path: &frontlinev1.StringMatch{Match: &frontlinev1.StringMatch_Prefix{Prefix: "/api"}},

--- a/svc/frontline/internal/policies/openapi/executor_test.go
+++ b/svc/frontline/internal/policies/openapi/executor_test.go
@@ -59,7 +59,7 @@ func TestExecute_EmptySpec(t *testing.T) {
 	e := newTestExecutor(t)
 	req := httptest.NewRequest("GET", "/anything", nil)
 
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	redactor, err := e.Execute(context.Background(), nil, req, &frontlinev1.OpenApiRequestValidation{})
 	require.NoError(t, err)
 	require.Nil(t, redactor)

--- a/svc/frontline/internal/proxy/director_test.go
+++ b/svc/frontline/internal/proxy/director_test.go
@@ -19,7 +19,7 @@ func TestInstanceDirector_RemovesMetadata(t *testing.T) {
 	clk := clock.NewTestClock(now)
 	metadata, err := meta.New(testMetadataSigningKey)
 	require.NoError(t, err)
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	svc := &service{
 		instanceID: "frontline_1",
 		platform:   "aws",
@@ -48,7 +48,7 @@ func TestRegionDirector_SetsMetadata(t *testing.T) {
 	clk := clock.NewTestClock(now)
 	metadata, err := meta.New(testMetadataSigningKey)
 	require.NoError(t, err)
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	svc := &service{
 		instanceID: "frontline_1",
 		platform:   "aws",
@@ -93,7 +93,7 @@ func newDirectorSession(t *testing.T) (*http.Request, *zen.Session) {
 
 	req := httptest.NewRequest(http.MethodGet, "https://example.com", nil)
 	w := httptest.NewRecorder()
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	sess := &zen.Session{}
 	require.NoError(t, sess.Init(w, req, 0))
 	return req, sess

--- a/svc/frontline/internal/proxy/forward.go
+++ b/svc/frontline/internal/proxy/forward.go
@@ -94,7 +94,7 @@ func (s *service) forward(ctx context.Context, sess *zen.Session, cfg forwardCon
 		backendStart = time.Time{}
 	}
 
-	// nolint:exhaustruct
+	// nolint:exhaustruct_v5
 	clientTrace := &httptrace.ClientTrace{
 		ConnectDone: func(network, addr string, err error) {
 			outcome := dialOutcomeSuccess
@@ -107,7 +107,7 @@ func (s *service) forward(ctx context.Context, sess *zen.Session, cfg forwardCon
 
 	tracking, hasTracking := RequestTrackingFromContext(ctx)
 
-	// nolint:exhaustruct
+	// nolint:exhaustruct_v5
 	proxy := &httputil.ReverseProxy{
 		Transport:     cfg.transport,
 		FlushInterval: -1, // flush immediately for streaming

--- a/svc/frontline/internal/proxy/hops_test.go
+++ b/svc/frontline/internal/proxy/hops_test.go
@@ -22,7 +22,7 @@ const testMetadataSigningKey = "000102030405060708090a0b0c0d0e0f1011121314151617
 func TestNew_RequiresMetadata(t *testing.T) {
 	t.Parallel()
 
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	svc, err := New(Config{})
 	require.ErrorContains(t, err, "metadata codec is required")
 	require.Nil(t, svc)
@@ -34,7 +34,7 @@ func TestNew_RejectsNegativeMaxHops(t *testing.T) {
 	metadata, err := meta.New(testMetadataSigningKey)
 	require.NoError(t, err)
 
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	svc, err := New(Config{
 		MaxHops:  -1,
 		Metadata: metadata,
@@ -49,7 +49,7 @@ func TestForwardToRegion_RejectsHopLimit(t *testing.T) {
 	clk := clock.New()
 	metadata, err := meta.New(testMetadataSigningKey)
 	require.NoError(t, err)
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	svc, err := New(Config{
 		InstanceID: "frontline_1",
 		Platform:   "aws",
@@ -63,7 +63,7 @@ func TestForwardToRegion_RejectsHopLimit(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "https://api.example.com", nil)
 	w := httptest.NewRecorder()
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	sess := &zen.Session{}
 	require.NoError(t, sess.Init(w, req, 0))
 
@@ -82,7 +82,7 @@ func TestForwardToRegion_AllowsLastHop(t *testing.T) {
 	metadata, err := meta.New(testMetadataSigningKey)
 	require.NoError(t, err)
 	transport, recorder := newMetadataTransport(t, metadata)
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	svc := &service{
 		instanceID: "frontline_3",
 		platform:   "aws",
@@ -114,7 +114,7 @@ func TestForwardToRegion_AppendsMetadataAtEachHop(t *testing.T) {
 	require.NoError(t, err)
 	transport, recorder := newMetadataTransport(t, metadata)
 
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	first := &service{
 		instanceID: "frontline_1",
 		platform:   "aws",
@@ -143,7 +143,7 @@ func TestForwardToRegion_AppendsMetadataAtEachHop(t *testing.T) {
 
 	incomingHops := recorder.seen[0].Hops
 	secondNow := clk.Tick(250 * time.Millisecond)
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	second := &service{
 		instanceID: "frontline_2",
 		platform:   "aws",
@@ -186,7 +186,7 @@ func TestForwardToRegion_PreservesDuplicateRegions(t *testing.T) {
 	metadata, err := meta.New(testMetadataSigningKey)
 	require.NoError(t, err)
 	transport, recorder := newMetadataTransport(t, metadata)
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	svc := &service{
 		instanceID: "frontline_2",
 		platform:   "aws",
@@ -231,7 +231,7 @@ func (t *metadataTransport) RoundTrip(req *http.Request) (*http.Response, error)
 	}
 	t.seen = append(t.seen, metadata)
 	t.tokens = append(t.tokens, token)
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	return &http.Response{
 		StatusCode: http.StatusOK,
 		Header:     make(http.Header),
@@ -242,7 +242,7 @@ func (t *metadataTransport) RoundTrip(req *http.Request) (*http.Response, error)
 
 func newProxySession(t *testing.T, req *http.Request) *zen.Session {
 	t.Helper()
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	sess := &zen.Session{}
 	require.NoError(t, sess.Init(httptest.NewRecorder(), req, 0))
 	return sess

--- a/svc/frontline/internal/proxy/service.go
+++ b/svc/frontline/internal/proxy/service.go
@@ -58,7 +58,7 @@ func New(cfg Config) (*service, error) {
 	if cfg.Transport != nil {
 		transport = cfg.Transport
 	} else {
-		//nolint:exhaustruct
+		//nolint:exhaustruct_v5
 		transport = &http.Transport{
 			Proxy:             http.ProxyFromEnvironment,
 			ForceAttemptHTTP2: true,
@@ -167,7 +167,7 @@ func (s *service) ForwardToRegion(ctx context.Context, sess *zen.Session, target
 	})
 
 	metadata := &meta.Metadata{
-		//nolint:exhaustruct // Frontline metadata only needs an expiry.
+		//nolint:exhaustruct_v5 // Frontline metadata only needs an expiry.
 		Claims: paseto.Claims{
 			ExpiresAt: now.Add(frontlineMetadataTTL),
 		},

--- a/svc/frontline/internal/proxy/transport.go
+++ b/svc/frontline/internal/proxy/transport.go
@@ -24,7 +24,7 @@ type TransportRegistry struct {
 // NewTransportRegistry creates transports for http1 and h2c. Unknown or
 // unimplemented protocols (h2, h3) fall back to http1.
 func NewTransportRegistry() *TransportRegistry {
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	h1 := &http.Transport{
 		DialContext: (&net.Dialer{
 			Timeout:   10 * time.Second,
@@ -35,7 +35,7 @@ func NewTransportRegistry() *TransportRegistry {
 		IdleConnTimeout:     90 * time.Second,
 	}
 
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	h2c := &http2.Transport{
 		AllowHTTP: true,
 		DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {

--- a/svc/frontline/internal/router/routing.go
+++ b/svc/frontline/internal/router/routing.go
@@ -116,7 +116,7 @@ func (s *service) selectDestination(
 		)
 	}
 
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	return RouteDecision{
 		Destination:         DestinationRemoteRegion,
 		DeploymentID:        route.DeploymentID,

--- a/svc/frontline/middleware/clickhouse_logging.go
+++ b/svc/frontline/middleware/clickhouse_logging.go
@@ -23,7 +23,7 @@ import (
 func WithClickHouseLogging(buf *batch.BatchProcessor[schema.FrontlineRequest], clk clock.Clock, frontlineID, region, platform string) zen.Middleware {
 	return func(next zen.HandleFunc) zen.HandleFunc {
 		return func(ctx context.Context, s *zen.Session) error {
-			//nolint:exhaustruct
+			//nolint:exhaustruct_v5
 			tracking := &proxy.RequestTracking{
 				StartTime: clk.Now(),
 			}

--- a/svc/frontline/middleware/sanitize_headers_test.go
+++ b/svc/frontline/middleware/sanitize_headers_test.go
@@ -102,7 +102,7 @@ func TestWithReservedHeaderStrip_RemovesReservedTrailers(t *testing.T) {
 func newMiddlewareSession(t *testing.T, req *http.Request) *zen.Session {
 	t.Helper()
 	w := httptest.NewRecorder()
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	sess := &zen.Session{}
 	require.NoError(t, sess.Init(w, req, 0))
 	return sess

--- a/svc/frontline/routes/proxy/duplex_test.go
+++ b/svc/frontline/routes/proxy/duplex_test.go
@@ -115,7 +115,7 @@ func startH2CDuplexBackend(t *testing.T) (string, func()) {
 		}
 	})
 
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	srv := &http.Server{Handler: h2c.NewHandler(handler, &http2.Server{})}
 	go func() { _ = srv.Serve(ln) }()
 

--- a/svc/frontline/routes/proxy/handler.go
+++ b/svc/frontline/routes/proxy/handler.go
@@ -63,7 +63,7 @@ func (h *Handler) Handle(ctx context.Context, sess *zen.Session) error {
 		// middleware before this handler, so this branch is unreachable
 		// in production. Allocate one so the engine + proxy don't panic
 		// if someone reorders middleware.
-		//nolint:exhaustruct
+		//nolint:exhaustruct_v5
 		tracking = &proxy.RequestTracking{StartTime: startTime}
 		ctx = proxy.WithRequestTracking(ctx, tracking)
 	}

--- a/svc/frontline/routes/proxy/retry_test.go
+++ b/svc/frontline/routes/proxy/retry_test.go
@@ -163,7 +163,7 @@ func TestMetadata_InvalidHeaderDoesNotBlockRegionalRequest(t *testing.T) {
 	t.Parallel()
 
 	stub := &recordingProxy{regionBody: "served-by-peer-region"}
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	decision := router.RouteDecision{
 		Destination:         router.DestinationRemoteRegion,
 		RemoteRegionAddress: "us-west-2.aws",
@@ -299,7 +299,7 @@ func startBackend(t *testing.T, h http.HandlerFunc) (string, func()) {
 	t.Helper()
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	srv := &http.Server{Handler: h}
 	go func() { _ = srv.Serve(ln) }()
 	return ln.Addr().String(), func() {
@@ -355,7 +355,7 @@ func localDecision(addrs ...string) router.RouteDecision {
 			Address: addr,
 		}
 	}
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	return router.RouteDecision{
 		Destination:      router.DestinationLocalInstance,
 		DeploymentID:     "dep_test",
@@ -384,7 +384,7 @@ func startFrontlineWithH2CIngress(t *testing.T, decision router.RouteDecision, p
 	require.NoError(t, err)
 
 	if proxySvc == nil {
-		//nolint:exhaustruct
+		//nolint:exhaustruct_v5
 		ps, err := proxy.New(proxy.Config{
 			InstanceID:         "test-instance",
 			Platform:           "test",
@@ -407,7 +407,7 @@ func startFrontlineWithH2CIngress(t *testing.T, decision router.RouteDecision, p
 		Metadata:      metadata,
 	}
 
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	zenSrv, err := zen.New(zen.Config{
 		ReadTimeout:        -1,
 		WriteTimeout:       -1,

--- a/svc/frontline/run.go
+++ b/svc/frontline/run.go
@@ -116,7 +116,7 @@ func Run(ctx context.Context, cfg Config) error {
 
 	reg := promclient.NewRegistry()
 	reg.MustRegister(collectors.NewGoCollector())
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	reg.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 	reg.MustRegister(prometheus.NewSystemMetricsCollector())
 	lazy.SetRegistry(reg)
@@ -291,7 +291,7 @@ func Run(ctx context.Context, cfg Config) error {
 		return fmt.Errorf("unable to create Frontline metadata codec: %w", err)
 	}
 
-	// nolint:exhaustruct
+	// nolint:exhaustruct_v5
 	proxySvc, err := proxy.New(proxy.Config{
 		InstanceID:         cfg.InstanceID,
 		Platform:           cfg.Platform,

--- a/svc/frontline/tls.go
+++ b/svc/frontline/tls.go
@@ -46,7 +46,7 @@ func buildTlsConfig(cfg Config, certManager certmanager.Service) (*tls.Config, e
 
 		logger.Info("TLS configured with dynamic certificate manager")
 
-		//nolint:exhaustruct
+		//nolint:exhaustruct_v5
 		return &tls.Config{
 			GetCertificate: func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
 				return certManager.GetCertificate(context.Background(), hello.ServerName)

--- a/svc/heimdall/internal/network/classifier_fuzz_test.go
+++ b/svc/heimdall/internal/network/classifier_fuzz_test.go
@@ -48,7 +48,7 @@ func FuzzClassifier(f *testing.F) {
 	f.Fuzz(func(t *testing.T, frame []byte) {
 		objs := loadFuzzObjects(t)
 		for _, prog := range []*ebpf.Program{objs.CountEgress, objs.CountIngress} {
-			ret, err := prog.Run(&ebpf.RunOptions{Data: frame}) //nolint:exhaustruct
+			ret, err := prog.Run(&ebpf.RunOptions{Data: frame}) //nolint:exhaustruct_v5
 			if err != nil {
 				// EINVAL covers the "skb too small" / "context shape rejected"
 				// cases the kernel emits before our program runs. Those are
@@ -70,9 +70,9 @@ func FuzzClassifier(f *testing.F) {
 // (CI runners without CAP_BPF should skip the fuzz harness, not fail).
 func loadFuzzObjects(t *testing.T) *bpfObjects {
 	t.Helper()
-	objs := &bpfObjects{}            //nolint:exhaustruct
-	opts := &ebpf.CollectionOptions{ //nolint:exhaustruct
-		Maps: ebpf.MapOptions{PinPath: bpffsTempDir(t)}, //nolint:exhaustruct
+	objs := &bpfObjects{}            //nolint:exhaustruct_v5
+	opts := &ebpf.CollectionOptions{ //nolint:exhaustruct_v5
+		Maps: ebpf.MapOptions{PinPath: bpffsTempDir(t)}, //nolint:exhaustruct_v5
 	}
 	if err := loadBpfObjects(objs, opts); err != nil {
 		if isEnvSkipError(err) {

--- a/svc/heimdall/internal/network/classifier_linux_test.go
+++ b/svc/heimdall/internal/network/classifier_linux_test.go
@@ -119,13 +119,13 @@ func loadTestObjects(t *testing.T) *bpfObjects {
 	if err := rlimit.RemoveMemlock(); err != nil {
 		t.Skipf("rlimit.RemoveMemlock unavailable (likely no CAP_SYS_RESOURCE): %v", err)
 	}
-	objs := &bpfObjects{} //nolint:exhaustruct // populated by loadBpfObjects
+	objs := &bpfObjects{} //nolint:exhaustruct_v5 // populated by loadBpfObjects
 	// The BPF program declares `pod_counters` with LIBBPF_PIN_BY_NAME,
 	// which requires a PinPath when loading. The kernel rejects pin paths
 	// not on a bpffs, so t.TempDir() (tmpfs/ext4) is wrong; use a unique
 	// directory under /sys/fs/bpf instead. Skip on hosts without bpffs.
-	opts := &ebpf.CollectionOptions{ //nolint:exhaustruct
-		Maps: ebpf.MapOptions{PinPath: bpffsTempDir(t)}, //nolint:exhaustruct
+	opts := &ebpf.CollectionOptions{ //nolint:exhaustruct_v5
+		Maps: ebpf.MapOptions{PinPath: bpffsTempDir(t)}, //nolint:exhaustruct_v5
 	}
 	if err := loadBpfObjects(objs, opts); err != nil {
 		// Only skip on kernel/privilege errors; let verifier failures and
@@ -146,7 +146,7 @@ func loadTestObjects(t *testing.T) *bpfObjects {
 // is an observer and must be non-terminating in the TCX chain.
 func runProg(t *testing.T, prog *ebpf.Program, frame []byte) {
 	t.Helper()
-	ret, err := prog.Run(&ebpf.RunOptions{Data: frame}) //nolint:exhaustruct
+	ret, err := prog.Run(&ebpf.RunOptions{Data: frame}) //nolint:exhaustruct_v5
 	require.NoError(t, err, "prog.Run")
 	require.Equal(t, int32(-1), int32(ret), "observer must return TC_ACT_UNSPEC")
 }

--- a/svc/heimdall/internal/network/network_linux.go
+++ b/svc/heimdall/internal/network/network_linux.go
@@ -174,12 +174,12 @@ func NewReader(criSocket string) (Reader, error) {
 	// than per-pod (every per-pod load below will just re-open the same
 	// pin). Strip the spec's programs for this load — we only want the
 	// map and its pin semantics now.
-	mapOnlySpec := &ebpf.CollectionSpec{ //nolint:exhaustruct // ByteOrder + Types default
+	mapOnlySpec := &ebpf.CollectionSpec{ //nolint:exhaustruct_v5 // ByteOrder + Types default
 		Maps:      spec.Maps,
 		Variables: spec.Variables,
 	}
-	mapColl, err := ebpf.NewCollectionWithOptions(mapOnlySpec, ebpf.CollectionOptions{ //nolint:exhaustruct // Programs optional
-		Maps: ebpf.MapOptions{ //nolint:exhaustruct // LoadPinOptions optional
+	mapColl, err := ebpf.NewCollectionWithOptions(mapOnlySpec, ebpf.CollectionOptions{ //nolint:exhaustruct_v5 // Programs optional
+		Maps: ebpf.MapOptions{ //nolint:exhaustruct_v5 // LoadPinOptions optional
 			PinPath: bpfPinDir,
 		},
 	})
@@ -194,7 +194,7 @@ func NewReader(criSocket string) (Reader, error) {
 		return nil, fmt.Errorf("pod_counters map missing after load")
 	}
 
-	pinOpts := ebpf.MapOptions{ //nolint:exhaustruct // LoadPinOptions optional
+	pinOpts := ebpf.MapOptions{ //nolint:exhaustruct_v5 // LoadPinOptions optional
 		PinPath: bpfPinDir,
 	}
 	r := &linuxReader{

--- a/svc/heimdall/internal/network/veth_linux.go
+++ b/svc/heimdall/internal/network/veth_linux.go
@@ -111,7 +111,7 @@ func attachPodEth0(
 		return nil, nil, nil, 0, fmt.Errorf("%w: POD_KEY variable missing from spec (bpf2go regen needed?)", ErrTCXAttach)
 	}
 
-	coll, copyErr = ebpf.NewCollectionWithOptions(perPodSpec, ebpf.CollectionOptions{ //nolint:exhaustruct // Programs optional
+	coll, copyErr = ebpf.NewCollectionWithOptions(perPodSpec, ebpf.CollectionOptions{ //nolint:exhaustruct_v5 // Programs optional
 		Maps: pinOpts,
 	})
 	if copyErr != nil {
@@ -133,7 +133,7 @@ func attachPodEth0(
 	// Head anchor so we run ahead of any other TCX program that might
 	// install here later; our handlers return TCX_NEXT so they don't
 	// terminate the chain.
-	egress, attachErr := link.AttachTCX(link.TCXOptions{ //nolint:exhaustruct // Flags/ExpectedRevision optional
+	egress, attachErr := link.AttachTCX(link.TCXOptions{ //nolint:exhaustruct_v5 // Flags/ExpectedRevision optional
 		Interface: int(eth0),
 		Program:   countEgress,
 		Attach:    ebpf.AttachTCXEgress,
@@ -146,7 +146,7 @@ func attachPodEth0(
 		return nil, nil, nil, 0, fmt.Errorf("attach tcx egress on pod eth0 (pod egress): %w: %w", ErrTCXAttach, attachErr)
 	}
 
-	ingress, attachErr = link.AttachTCX(link.TCXOptions{ //nolint:exhaustruct
+	ingress, attachErr = link.AttachTCX(link.TCXOptions{ //nolint:exhaustruct_v5
 		Interface: int(eth0),
 		Program:   countIngress,
 		Attach:    ebpf.AttachTCXIngress,

--- a/svc/heimdall/run.go
+++ b/svc/heimdall/run.go
@@ -57,7 +57,7 @@ func Run(ctx context.Context, cfg Config) error {
 	// explicitly to preserve the scrape output.
 	reg := promclient.NewRegistry()
 	reg.MustRegister(collectors.NewGoCollector())
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	reg.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 	lazy.SetRegistry(reg)
 	buildinfometrics.Register("heimdall")
@@ -206,7 +206,7 @@ func Run(ctx context.Context, cfg Config) error {
 		// started and isn't shutting down, which already captures the
 		// "collector is live and initialized" condition.
 		mux := http.NewServeMux()
-		//nolint:exhaustruct
+		//nolint:exhaustruct_v5
 		mux.Handle("GET /metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
 		r.RegisterHealth(mux, "/health")
 

--- a/svc/krane/internal/deployment/apply.go
+++ b/svc/krane/internal/deployment/apply.go
@@ -375,12 +375,12 @@ func (c *Controller) ensureHPAExists(ctx context.Context, req *ctrlv1.ApplyDeplo
 	}
 	if policy.MemoryThreshold != nil {
 		metrics = append(metrics,
-			//nolint:exhaustruct
+			//nolint:exhaustruct_v5
 			autoscalingv2.MetricSpec{
 				Type: autoscalingv2.ResourceMetricSourceType,
 				Resource: &autoscalingv2.ResourceMetricSource{
 					Name: corev1.ResourceMemory,
-					//nolint:exhaustruct
+					//nolint:exhaustruct_v5
 					Target: autoscalingv2.MetricTarget{
 						Type:               autoscalingv2.UtilizationMetricType,
 						AverageUtilization: policy.MemoryThreshold,
@@ -392,12 +392,12 @@ func (c *Controller) ensureHPAExists(ctx context.Context, req *ctrlv1.ApplyDeplo
 
 	// CPU is always a scaling signal.
 	metrics = append(metrics,
-		//nolint:exhaustruct
+		//nolint:exhaustruct_v5
 		autoscalingv2.MetricSpec{
 			Type: autoscalingv2.ResourceMetricSourceType,
 			Resource: &autoscalingv2.ResourceMetricSource{
 				Name: corev1.ResourceCPU,
-				//nolint:exhaustruct
+				//nolint:exhaustruct_v5
 				Target: autoscalingv2.MetricTarget{
 					Type:               autoscalingv2.UtilizationMetricType,
 					AverageUtilization: cpuThreshold,
@@ -406,7 +406,7 @@ func (c *Controller) ensureHPAExists(ctx context.Context, req *ctrlv1.ApplyDeplo
 		},
 	)
 
-	//nolint:exhaustruct // k8s API types have many optional fields
+	//nolint:exhaustruct_v5 // k8s API types have many optional fields
 	desired := &autoscalingv2.HorizontalPodAutoscaler{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "autoscaling/v2",
@@ -418,7 +418,7 @@ func (c *Controller) ensureHPAExists(ctx context.Context, req *ctrlv1.ApplyDeplo
 			Labels:          deploymentLabels(req),
 			OwnerReferences: []metav1.OwnerReference{replicaSetOwnerRef(rs)},
 		},
-		//nolint:exhaustruct
+		//nolint:exhaustruct_v5
 		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
 			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 				APIVersion: "apps/v1",
@@ -427,9 +427,9 @@ func (c *Controller) ensureHPAExists(ctx context.Context, req *ctrlv1.ApplyDeplo
 			},
 			MinReplicas: new(minReplicas),
 			MaxReplicas: maxReplicas,
-			//nolint:exhaustruct
+			//nolint:exhaustruct_v5
 			Behavior: &autoscalingv2.HorizontalPodAutoscalerBehavior{
-				//nolint:exhaustruct
+				//nolint:exhaustruct_v5
 				ScaleDown: &autoscalingv2.HPAScalingRules{
 					StabilizationWindowSeconds: new(scaleDownStabilizationSeconds),
 				},
@@ -485,7 +485,7 @@ func buildPodDisruptionBudget(req *ctrlv1.ApplyDeployment, rs *appsv1.ReplicaSet
 	maxUnavailable := intstr.FromInt32(1)
 	alwaysAllow := policyv1.AlwaysAllow
 
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	pdb := &policyv1.PodDisruptionBudget{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "policy/v1",
@@ -497,7 +497,7 @@ func buildPodDisruptionBudget(req *ctrlv1.ApplyDeployment, rs *appsv1.ReplicaSet
 			Labels:          deploymentLabels(req),
 			OwnerReferences: []metav1.OwnerReference{replicaSetOwnerRef(rs)},
 		},
-		//nolint:exhaustruct
+		//nolint:exhaustruct_v5
 		Spec: policyv1.PodDisruptionBudgetSpec{
 			MaxUnavailable:             &maxUnavailable,
 			UnhealthyPodEvictionPolicy: &alwaysAllow,

--- a/svc/krane/pkg/controlplane/client.go
+++ b/svc/krane/pkg/controlplane/client.go
@@ -39,7 +39,7 @@ func NewClient(cfg ClientConfig) ctrl.ClusterServiceClient {
 
 	// Use h2c (HTTP/2 cleartext) for non-TLS URLs, regular HTTP/2 for TLS
 	if strings.HasPrefix(cfg.URL, "http://") {
-		//nolint:exhaustruct
+		//nolint:exhaustruct_v5
 		transport = &http2.Transport{
 			AllowHTTP: true,
 			DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
@@ -51,7 +51,7 @@ func NewClient(cfg ClientConfig) ctrl.ClusterServiceClient {
 			PingTimeout:     5 * time.Second,
 		}
 	} else {
-		//nolint:exhaustruct
+		//nolint:exhaustruct_v5
 		transport = &http2.Transport{
 			ReadIdleTimeout: 10 * time.Second,
 			PingTimeout:     5 * time.Second,

--- a/svc/krane/run.go
+++ b/svc/krane/run.go
@@ -89,7 +89,7 @@ func Run(ctx context.Context, cfg Config) error {
 
 	reg := promclient.NewRegistry()
 	reg.MustRegister(collectors.NewGoCollector())
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	reg.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 	reg.MustRegister(prometheus.NewSystemMetricsCollector())
 	lazy.SetRegistry(reg)

--- a/svc/logdrain/run.go
+++ b/svc/logdrain/run.go
@@ -43,7 +43,7 @@ func Run(ctx context.Context, cfg Config) error {
 	leaseID := uid.New("")
 	reg := promclient.NewRegistry()
 	reg.MustRegister(collectors.NewGoCollector())
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	reg.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 	reg.MustRegister(prometheus.NewSystemMetricsCollector())
 	lazy.SetRegistry(reg)
@@ -87,7 +87,7 @@ func Run(ctx context.Context, cfg Config) error {
 	// not restart a pod because a customer endpoint is down.
 	if cfg.Observability.Metrics != nil && cfg.Observability.Metrics.PrometheusPort > 0 {
 		mux := http.NewServeMux()
-		//nolint:exhaustruct
+		//nolint:exhaustruct_v5
 		mux.Handle("GET /metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
 		r.RegisterHealth(mux, "/health")
 

--- a/svc/vault/internal/keyring/decode_and_decrypt_key.go
+++ b/svc/vault/internal/keyring/decode_and_decrypt_key.go
@@ -13,7 +13,7 @@ import (
 func (k *Keyring) DecodeAndDecryptKey(ctx context.Context, b []byte) (*vaultv1.DataEncryptionKey, string, error) {
 	_, span := tracing.Start(ctx, "keyring.DecodeAndDecryptKey")
 	defer span.End()
-	encrypted := &vaultv1.EncryptedDataEncryptionKey{} // nolint:exhaustruct
+	encrypted := &vaultv1.EncryptedDataEncryptionKey{} // nolint:exhaustruct_v5
 	err := proto.Unmarshal(b, encrypted)
 	if err != nil {
 		tracing.RecordError(span, err)
@@ -33,7 +33,7 @@ func (k *Keyring) DecodeAndDecryptKey(ctx context.Context, b []byte) (*vaultv1.D
 		return nil, "", fmt.Errorf("failed to decrypt ciphertext: %w", err)
 	}
 
-	dek := &vaultv1.DataEncryptionKey{} // nolint:exhaustruct
+	dek := &vaultv1.DataEncryptionKey{} // nolint:exhaustruct_v5
 	err = proto.Unmarshal(plaintext, dek)
 	if err != nil {
 		tracing.RecordError(span, err)

--- a/svc/vault/internal/vault/rpc_decrypt.go
+++ b/svc/vault/internal/vault/rpc_decrypt.go
@@ -41,7 +41,7 @@ func (s *Service) decrypt(
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode encrypted data: %w", err)
 	}
-	encrypted := vaultv1.Encrypted{} // nolint:exhaustruct
+	encrypted := vaultv1.Encrypted{} // nolint:exhaustruct_v5
 	err = proto.Unmarshal(b, &encrypted)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal encrypted data: %w", err)

--- a/svc/vault/internal/vault/service.go
+++ b/svc/vault/internal/vault/service.go
@@ -101,7 +101,7 @@ func loadMasterKeys(masterKey string, previousMasterKey *string) (*vaultv1.KeyEn
 }
 
 func parseMasterKey(masterKey string) (*vaultv1.KeyEncryptionKey, error) {
-	kek := &vaultv1.KeyEncryptionKey{} // nolint:exhaustruct
+	kek := &vaultv1.KeyEncryptionKey{} // nolint:exhaustruct_v5
 	b, err := base64.StdEncoding.DecodeString(masterKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode master key: %w", err)

--- a/svc/vault/run.go
+++ b/svc/vault/run.go
@@ -60,7 +60,7 @@ func Run(ctx context.Context, cfg Config) error {
 
 	reg := promclient.NewRegistry()
 	reg.MustRegister(collectors.NewGoCollector())
-	//nolint:exhaustruct
+	//nolint:exhaustruct_v5
 	reg.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 	reg.MustRegister(prometheus.NewSystemMetricsCollector())
 	lazy.SetRegistry(reg)

--- a/tools/amp-orb-services/proxy.go
+++ b/tools/amp-orb-services/proxy.go
@@ -121,7 +121,7 @@ func runFrontlineProxy(args []string) error {
 		routeMu:        sync.Mutex{},
 		// Amp terminates public TLS. Frontline uses a self-signed development
 		// certificate on loopback, so the bridge must not verify that certificate.
-		tlsConfig: &tls.Config{ //nolint:exhaustruct,gosec
+		tlsConfig: &tls.Config{ //nolint:exhaustruct_v5,gosec
 			MinVersion:         tls.VersionTLS12,
 			ServerName:         sourceHostname,
 			InsecureSkipVerify: true,


### PR DESCRIPTION
## Problem:

The declared analyzer dependency was current, but golangci-lint still ran the deprecated analyzer name.

## Solution:

Use exhaustruct_v5, its renamed settings, and the corresponding existing nolint names.

## Impact:

Preserves all existing exclusion patterns and suppression scopes. The 306 directive changes are mechanical; no new suppressions are added.

Draft stack prerequisites: #7330 and #7320 through #7326. `deps/integration-base` is a merge-only review anchor, not implementation work to merge separately. Do not merge this stack into that anchor. After both prerequisites land, rebase the dependency stack onto current `main` and retarget bottom PR #7353 to `main`; keep later PRs based on the preceding layer. Existing prerequisite PRs are unchanged.

## Testing:

Configuration verification and full lint passed with zero issues and no deprecated-analyzer warning. All 136 Go-file changes were checked as exact directive-name changes.

Final combined compatible stack (not an independent run of every intermediate PR):
- `mise run test --concurrency=4`: 303 suites, 24,506 passed, zero failed, 7,875 ignored; 186 cached.
- `GOFLAGS=-race mise run test --concurrency=4`: 303 suites, 24,506 passed, zero failed, 7,875 ignored; 279 cached.
- `mise run build`: passed; lint reported zero issues.
- Tagged control-plane suite: 25 passed.

Full normal and race runs used separate test-container scopes. The race run resumed after fixing the cancellation fixture. An earlier analytics-count timeout did not recur; its cause remains unconfirmed. These are local verification results, not a claim that draft CI ran or passed.