### PR TITLE
api: wait for readiness before testing cancellation

### DIFF
--- a/svc/api/cancel_test.go
+++ b/svc/api/cancel_test.go
@@ -30,6 +30,7 @@ func TestContextCancellation(t *testing.T) {
 
 	// Create a cancellable context
 	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
 
 	// Configure the API server
 	config := api.Config{
@@ -69,15 +70,11 @@ func TestContextCancellation(t *testing.T) {
 		resultCh <- runErr
 	}()
 
-	// Wait for the server to start up
-	require.Eventually(t, func() bool {
-		res, livenessErr := http.Get(fmt.Sprintf("http://%s/v2/liveness", ln.Addr()))
-		if livenessErr != nil {
-			return false
-		}
-		defer func() { _ = res.Body.Close() }()
-		return res.StatusCode == http.StatusOK
-	}, 10*time.Second, 100*time.Millisecond, "API server failed to start")
+	client := &http.Client{Timeout: time.Minute}
+	res, err := client.Get(fmt.Sprintf("http://%s/v2/liveness", ln.Addr()))
+	require.NoError(t, err, "API server failed to start")
+	require.NoError(t, res.Body.Close())
+	require.Equal(t, http.StatusOK, res.StatusCode)
 
 	// Verify the server is running
 	t.Log("API server started successfully")
@@ -96,6 +93,6 @@ func TestContextCancellation(t *testing.T) {
 	}
 
 	// Verify the server is no longer responding
-	_, err = http.Get(fmt.Sprintf("http://%s/v2/liveness", ln.Addr()))
+	_, err = client.Get(fmt.Sprintf("http://%s/v2/liveness", ln.Addr()))
 	require.Error(t, err, "Server should no longer be responding after shutdown")
 }


### PR DESCRIPTION
## Problem:

Cold schema validation exceeded the cancellation test's 10-second setup polling budget under the race detector, before cancellation was exercised.

## Solution:

Wait on a bounded readiness request to the already-bound listener and cancel the context on setup failure.

## Impact:

The readiness request has a 60-second timeout. The original 90-second shutdown bound and stopped-server assertion remain unchanged. Production startup and shutdown behavior are unchanged.

Draft stack prerequisites: #7330 and #7320 through #7326. `deps/integration-base` is a merge-only review anchor, not implementation work to merge separately. Do not merge this stack into that anchor. After both prerequisites land, rebase the dependency stack onto current `main` and retarget bottom PR #7353 to `main`; keep later PRs based on the preceding layer. Existing prerequisite PRs are unchanged.

## Testing:

The API package passed 36 normal tests and 36 race tests. Final combined verification then passed all 303 suites in both modes.

Final combined compatible stack (not an independent run of every intermediate PR):
- `mise run test --concurrency=4`: 303 suites, 24,506 passed, zero failed, 7,875 ignored; 186 cached.
- `GOFLAGS=-race mise run test --concurrency=4`: 303 suites, 24,506 passed, zero failed, 7,875 ignored; 279 cached.
- `mise run build`: passed; lint reported zero issues.
- Tagged control-plane suite: 25 passed.

Full normal and race runs used separate test-container scopes. The race run resumed after fixing the cancellation fixture. An earlier analytics-count timeout did not recur; its cause remains unconfirmed. These are local verification results, not a claim that draft CI ran or passed.