### PR TITLE
fix(db): scope GitHub installation relation to workspace

### DIFF
--- a/web/internal/db/src/schema/github_app.test.ts
+++ b/web/internal/db/src/schema/github_app.test.ts
@@ -1,0 +1,61 @@
+import { drizzle } from "drizzle-orm/mysql2";
+import { createConnection } from "mysql2/promise";
+import { expect, it } from "vitest";
+import * as schema from "./index";
+
+it.skipIf(!process.env.TEST_DATABASE_URL)(
+  "resolves shared GitHub installations only within the connection workspace",
+  async () => {
+    const connection = await createConnection(process.env.TEST_DATABASE_URL ?? "");
+    try {
+      await connection.query(`CREATE TEMPORARY TABLE github_app_installations (
+        pk BIGINT PRIMARY KEY,
+        workspace_id VARCHAR(256) NOT NULL,
+        installation_id BIGINT NOT NULL,
+        UNIQUE (workspace_id, installation_id)
+      )`);
+      await connection.query(`CREATE TEMPORARY TABLE github_repo_connections (
+        pk BIGINT PRIMARY KEY,
+        workspace_id VARCHAR(256) NOT NULL,
+        app_id VARCHAR(256) NOT NULL UNIQUE,
+        installation_id BIGINT NOT NULL
+      )`);
+      await connection.query(`INSERT INTO github_app_installations VALUES
+        (3, 'ws_other', 4701),
+        (91, 'ws_target', 4701),
+        (12, 'ws_target', 8802)`);
+      await connection.query(`INSERT INTO github_repo_connections VALUES
+        (8, 'ws_target', 'app_target', 4701),
+        (22, 'ws_other', 'app_other', 4701),
+        (45, 'ws_target', 'app_second', 8802)`);
+
+      const db = drizzle(connection, { schema, mode: "planetscale" });
+      const connections = await db.query.githubRepoConnections.findMany({
+        columns: { appId: true },
+        with: {
+          installation: {
+            columns: { pk: true, workspaceId: true, installationId: true },
+          },
+        },
+        orderBy: (table, { asc }) => asc(table.pk),
+      });
+
+      expect(connections).toEqual([
+        {
+          appId: "app_target",
+          installation: { pk: 91, workspaceId: "ws_target", installationId: 4701 },
+        },
+        {
+          appId: "app_other",
+          installation: { pk: 3, workspaceId: "ws_other", installationId: 4701 },
+        },
+        {
+          appId: "app_second",
+          installation: { pk: 12, workspaceId: "ws_target", installationId: 8802 },
+        },
+      ]);
+    } finally {
+      await connection.end();
+    }
+  },
+);

--- a/web/internal/db/src/schema/github_app.ts
+++ b/web/internal/db/src/schema/github_app.ts
@@ -62,7 +62,7 @@ export const githubRepoConnectionsRelations = relations(githubRepoConnections, (
     references: [apps.id],
   }),
   installation: one(githubAppInstallations, {
-    fields: [githubRepoConnections.installationId],
-    references: [githubAppInstallations.installationId],
+    fields: [githubRepoConnections.workspaceId, githubRepoConnections.installationId],
+    references: [githubAppInstallations.workspaceId, githubAppInstallations.installationId],
   }),
 }));


### PR DESCRIPTION
## Problem:

After #7214, one GitHub installation can belong to several workspaces. 
Repository connections still resolve installations by installation ID alone. A connection can therefore select another workspace's installation row.

## Solution:

Resolve each connection's installation within the same workspace, while still matching the installation ID.

## Impact:

This is a standalone follow-up to merged PR #7214, based on `main`. It does not depend on or change #7224. No migration or repository uniqueness change is needed.

## Testing:

