### PR TITLE
fix(dashboard): Use sentence case in remaining empty state titles

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/authorization/roles/components/table/roles-list.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/authorization/roles/components/table/roles-list.tsx
@@ -72,7 +72,7 @@ export const RolesList = () => {
           <div className="w-full flex justify-center items-center h-full">
             <Empty className="w-[400px] flex items-start">
               <Empty.Icon className="w-auto" />
-              <Empty.Title>No Roles Found</Empty.Title>
+              <Empty.Title>No roles found</Empty.Title>
               <Empty.Description className="text-left">
                 There are no roles configured yet. Create your first role to start managing
                 permissions and access control.

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/identities/_components/table/identities-list.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/identities/_components/table/identities-list.tsx
@@ -162,7 +162,7 @@ function IdentityResults({ search }: { search: string }) {
         <div className="flex w-full items-center justify-center px-4 py-16">
           <Empty className="w-[400px] items-start">
             <Empty.Icon className="w-auto" />
-            <Empty.Title>No Identities Found</Empty.Title>
+            <Empty.Title>No identities found</Empty.Title>
             <Empty.Description className="text-left">
               {search
                 ? "Try adjusting your search query"

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/_components/apps-list/index.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/[projectId]/_components/apps-list/index.tsx
@@ -54,7 +54,7 @@ export const AppsList = () => {
         <div className="flex-1 flex justify-center items-center px-4 py-16 border border-grayA-4 rounded-lg overflow-hidden">
           <Empty className="w-[400px] flex items-start">
             <Empty.Icon className="w-auto" />
-            <Empty.Title>No Apps Found</Empty.Title>
+            <Empty.Title>No apps found</Empty.Title>
             <Empty.Description className="text-left">
               This project has no apps yet. Create an app to start deploying.
             </Empty.Description>

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/_components/list/index.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/projects/_components/list/index.tsx
@@ -35,7 +35,7 @@ export const ProjectsList = () => {
       <div className="w-full flex justify-center items-center h-full">
         <Empty className="w-[400px] flex items-start">
           <Empty.Icon className="w-auto" />
-          <Empty.Title>No Projects Found</Empty.Title>
+          <Empty.Title>No projects found</Empty.Title>
           <Empty.Description className="text-left">
             This workspace has no projects yet.
           </Empty.Description>

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/ratelimits/_components/list/index.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/ratelimits/_components/list/index.tsx
@@ -54,7 +54,7 @@ export const NamespaceList = () => {
         <div className="flex w-full items-center justify-center px-4 py-16">
           <Empty className="w-[600px] items-start p-0">
             <Empty.Icon className="w-auto" />
-            <Empty.Title>No Namespaces found</Empty.Title>
+            <Empty.Title>No namespaces found</Empty.Title>
             <Empty.Description className="text-left">
               You haven't created any Namespaces yet. Create one by performing a limit request as
               shown below.


### PR DESCRIPTION
## What does this PR do?

Five empty states still used title case ("No Apps Found", "No Projects Found", "No Identities Found", "No Roles Found", "No Namespaces found"). The rest of the dashboard uses sentence case. This makes them match.

Copy only. No logic, props or styling change. Follow-up to #7390.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

Open each list with no rows, or filtered to nothing: Projects, a project's Apps, Ratelimit namespaces, Identities, and Authorization > Roles. Each title must read in sentence case.

Not tested: nothing was run locally. Each change is one literal string inside JSX, so there is no behaviour to exercise.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [Internal Workflow Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand areas
- [ ] Ran `pnpm build`
- [ ] Ran `pnpm fmt`
- [ ] Ran `make fmt` on `/go` directory
- [ ] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Unkey Docs if changes were necessary