### PR TITLE
fix(dashboard): remove unsupported viewer role

### DIFF
--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/team/invite-form.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/team/invite-form.tsx
@@ -170,7 +170,6 @@ export const InviteForm = ({ organization }: InviteFormProps) => {
                         value={roleField.value}
                         items={[
                           { value: "developer", label: "Developer" },
-                          { value: "viewer", label: "Viewer" },
                           { value: "admin", label: "Admin" },
                         ]}
                       >
@@ -179,7 +178,6 @@ export const InviteForm = ({ organization }: InviteFormProps) => {
                         </SelectTrigger>
                         <SelectContent>
                           <SelectItem value="developer">Developer</SelectItem>
-                          <SelectItem value="viewer">Viewer</SelectItem>
                           <SelectItem value="admin">Admin</SelectItem>
                         </SelectContent>
                       </Select>

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/team/invite.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/team/invite.tsx
@@ -144,7 +144,6 @@ export const InviteButton = ({ user, organization, ...rest }: InviteButtonProps)
                   value={field.value}
                   items={[
                     { value: "developer", label: "Developer" },
-                    { value: "viewer", label: "Viewer" },
                     { value: "admin", label: "Admin" },
                   ]}
                 >
@@ -153,7 +152,6 @@ export const InviteButton = ({ user, organization, ...rest }: InviteButtonProps)
                   </SelectTrigger>
                   <SelectContent className="border-none rounded-md">
                     <SelectItem value="developer">Developer</SelectItem>
-                    <SelectItem value="viewer">Viewer</SelectItem>
                     <SelectItem value="admin">Admin</SelectItem>
                   </SelectContent>
                 </Select>

--- a/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/team/role-switcher.tsx
+++ b/web/apps/dashboard/app/(app)/[workspaceSlug]/settings/team/role-switcher.tsx
@@ -65,7 +65,6 @@ export const RoleSwitcher = memo<RoleSwitcherProps>(
             items={[
               { value: "admin", label: "Admin" },
               { value: "developer", label: "Developer" },
-              { value: "viewer", label: "Viewer" },
             ]}
             disabled={isCurrentUser || updateMember.isLoading}
             onValueChange={(newRole) => {
@@ -81,7 +80,6 @@ export const RoleSwitcher = memo<RoleSwitcherProps>(
               <SelectGroup>
                 <SelectItem value="admin">Admin</SelectItem>
                 <SelectItem value="developer">Developer</SelectItem>
-                <SelectItem value="viewer">Viewer</SelectItem>
               </SelectGroup>
             </SelectContent>
           </Select>

--- a/web/apps/dashboard/lib/auth/roles.test.ts
+++ b/web/apps/dashboard/lib/auth/roles.test.ts
@@ -10,7 +10,7 @@ describe("organization roles", () => {
   it("recognizes roles that the dashboard can assign", () => {
     expect(isOrganizationRole("admin")).toBe(true);
     expect(isOrganizationRole("developer")).toBe(true);
-    expect(isOrganizationRole("viewer")).toBe(true);
+    expect(isOrganizationRole("viewer")).toBe(false);
     expect(isOrganizationRole("basic_member")).toBe(false);
   });
 
@@ -19,12 +19,10 @@ describe("organization roles", () => {
     expect(canMutateWorkspace("basic_member")).toBe(true);
   });
 
-  it("gives viewers read-only workspace access", () => {
-    expect(canAccessWorkspace("viewer")).toBe(true);
-    expect(canMutateWorkspace("viewer")).toBe(false);
-  });
-
   it("rejects unknown roles", () => {
+    expect(canAccessWorkspace("viewer")).toBe(false);
+    expect(canMutateWorkspace("viewer")).toBe(false);
+    expect(organizationRoleLabel("viewer")).toBe("Unknown role");
     expect(canAccessWorkspace("unknown")).toBe(false);
     expect(canMutateWorkspace("unknown")).toBe(false);
     expect(organizationRoleLabel("unknown")).toBe("Unknown role");

--- a/web/apps/dashboard/lib/auth/roles.ts
+++ b/web/apps/dashboard/lib/auth/roles.ts
@@ -1,4 +1,4 @@
-export const ORGANIZATION_ROLES = ["admin", "developer", "viewer"] as const;
+export const ORGANIZATION_ROLES = ["admin", "developer"] as const;
 
 export type OrganizationRole = (typeof ORGANIZATION_ROLES)[number];
 
@@ -13,7 +13,7 @@ export function canAccessWorkspace(role: string | null | undefined): boolean {
 }
 
 export function canMutateWorkspace(role: string | null | undefined): boolean {
-  return canAccessWorkspace(role) && role !== "viewer";
+  return canAccessWorkspace(role);
 }
 
 export function organizationRoleLabel(role: string | null | undefined): string {
@@ -23,8 +23,6 @@ export function organizationRoleLabel(role: string | null | undefined): string {
     case "developer":
     case LEGACY_MEMBER_ROLE:
       return "Developer";
-    case "viewer":
-      return "Viewer";
     default:
       return "Unknown role";
   }


### PR DESCRIPTION
WorkOS has no valid existing memberships with role `viewer`, but our dashboard offered it as option, which then [failed](https://unkey.slack.com/archives/C0821DDAKAA/p1789112475768579) the invite request.


